### PR TITLE
fix(sdk): report a refused connection as a refused connection

### DIFF
--- a/.changeset/sdk-connect-error-provenance.md
+++ b/.changeset/sdk-connect-error-provenance.md
@@ -1,0 +1,13 @@
+---
+"@mcpjam/sdk": patch
+---
+
+Report a refused connection as a refused connection.
+
+Connecting to a host that nothing is listening on classified as `transport/fetch_failed` — "we could not reach it", which tells a developer nothing they did not already know. The specific reason was present the whole time and discarded three separate ways:
+
+- The HTTP connect paths rethrew a readable summary with no `cause`, so the underlying error object (and its errno) was unreachable. Both throw sites now preserve it, and the combined Streamable-HTTP+SSE failure additionally keeps the Streamable attempt on a non-enumerable `streamableCause` for when the two transports failed for different reasons.
+- `extractNodeErrno` returned the first string `code` it found and stopped. A wrapper that stamps its own domain code on the outside of the chain — the MCP SDK's `ERA_NEGOTIATION_FAILED` — therefore shadowed the real `ECONNREFUSED` one hop below it. Unrecognized codes no longer end the walk; they are still returned when the chain holds no errno at all.
+- `describeError` matched undici's generic `fetch failed` before looking for an errno spelled out in the same message ("... connect ECONNREFUSED 127.0.0.1:9999"). An errno in the text now wins over the generic phrase.
+
+A refused port now resolves to `transport/econnrefused`, whose guidance names the actual next step. One documented limit remains: a server pinned to Streamable HTTP (`disableSseFallback`) still reports `transport/fetch_failed`, because the upstream era-negotiation probe drops both the cause and the errno text before MCPJam sees the failure.

--- a/sdk/src/error-describer/describe.ts
+++ b/sdk/src/error-describer/describe.ts
@@ -239,11 +239,14 @@ function messageSlug(message: string): string | undefined {
   // real reason ("... : connect ECONNREFUSED 127.0.0.1:9999"), so matching
   // `fetch failed` first threw away the only actionable half of the message —
   // "we couldn't reach it" instead of "nothing is listening on that port".
-  const errnoInMessage = message.match(
-    /\b(E[A-Z]{2,}|EAI_AGAIN|UND_ERR_[A-Z_]+)\b/,
-  )?.[1];
-  if (errnoInMessage) {
-    const errnoSlug = nodeErrnoToSlug(errnoInMessage);
+  // Every candidate token is checked, not just the first. These messages are
+  // concatenations — a combined transport failure quotes both attempts, and
+  // words like `ERROR` tokenize the same way — so stopping at the first
+  // unmapped match would step over the `ECONNREFUSED` further along.
+  for (const match of message.matchAll(
+    /\b(E[A-Z]{2,}(?:_[A-Z]+)*|UND_ERR_[A-Z_]+)\b/g,
+  )) {
+    const errnoSlug = nodeErrnoToSlug(match[1]);
     if (errnoSlug) {
       return errnoSlug;
     }

--- a/sdk/src/error-describer/describe.ts
+++ b/sdk/src/error-describer/describe.ts
@@ -234,6 +234,20 @@ function messageSlug(message: string): string | undefined {
   if (/\bsocket\s+hang\s+up\b/i.test(message)) {
     return "transport/socket_hang_up";
   }
+  // An errno spelled out in the text beats every generic phrase below. undici
+  // reports connection failures as `TypeError: fetch failed` and appends the
+  // real reason ("... : connect ECONNREFUSED 127.0.0.1:9999"), so matching
+  // `fetch failed` first threw away the only actionable half of the message —
+  // "we couldn't reach it" instead of "nothing is listening on that port".
+  const errnoInMessage = message.match(
+    /\b(E[A-Z]{2,}|EAI_AGAIN|UND_ERR_[A-Z_]+)\b/,
+  )?.[1];
+  if (errnoInMessage) {
+    const errnoSlug = nodeErrnoToSlug(errnoInMessage);
+    if (errnoSlug) {
+      return errnoSlug;
+    }
+  }
   if (/\bfetch\s+failed\b/i.test(message)) {
     return "transport/fetch_failed";
   }

--- a/sdk/src/error-describer/node-errno.ts
+++ b/sdk/src/error-describer/node-errno.ts
@@ -46,18 +46,17 @@ export function extractNodeErrno(
 }
 
 /**
- * Node errnos are bare screaming-snake tokens (`ECONNREFUSED`, `EPIPE`) plus
- * undici's `UND_ERR_*` family. Membership in the shared retryable set is
- * checked first so multi-word errnos like `EAI_AGAIN` are recognized without
- * loosening the pattern enough to swallow unrelated wrapper codes such as
- * `ERA_NEGOTIATION_FAILED`.
+ * Recognition is by explicit membership, never by shape. An `E`-prefixed
+ * screaming-snake pattern reads like a safe heuristic and is not: a wrapper
+ * that stamps `code: "EWRAPPER"` on the outside of a chain would satisfy it,
+ * end the walk, and hide the real `ECONNREFUSED` below — the exact failure
+ * this walk exists to prevent, reintroduced through a looser door.
+ *
+ * An unlisted errno costs nothing: the walk continues, and `extractNodeErrno`
+ * still returns the code as its last-resort fallback.
  */
 function looksLikeNodeErrno(code: string): boolean {
-  return (
-    RETRYABLE_NODE_ERROR_CODES.has(code) ||
-    code.startsWith("UND_ERR_") ||
-    /^E[A-Z]{2,}$/.test(code)
-  );
+  return RETRYABLE_NODE_ERROR_CODES.has(code) || code.startsWith("UND_ERR_");
 }
 
 /**

--- a/sdk/src/error-describer/node-errno.ts
+++ b/sdk/src/error-describer/node-errno.ts
@@ -21,15 +21,43 @@ export function extractNodeErrno(
   }
 
   const code = (error as { code?: unknown }).code;
-  if (typeof code === "string") {
-    return code;
+  const ownCode = typeof code === "string" ? code : undefined;
+  // A recognized errno wins immediately — nothing deeper can beat it.
+  if (ownCode !== undefined && looksLikeNodeErrno(ownCode)) {
+    return ownCode;
   }
 
+  // An UNRECOGNIZED string code must NOT stop the walk. Wrappers stamp their
+  // own domain codes on the outside of a chain (the MCP SDK's era-negotiation
+  // failure carries `code: "ERA_NEGOTIATION_FAILED"`), and returning that here
+  // shadowed the real `ECONNREFUSED` sitting one hop below — the caller then
+  // classified a refused connection as a generic failure.
   const cause = (error as { cause?: unknown }).cause;
   if (cause !== undefined && cause !== error) {
-    return extractNodeErrno(cause, depth + 1);
+    const fromCause = extractNodeErrno(cause, depth + 1);
+    if (fromCause !== undefined) {
+      return fromCause;
+    }
   }
-  return undefined;
+  // Nothing recognized anywhere in the chain: fall back to whatever string
+  // code this level carried, preserving the previous contract for callers
+  // that only test set membership.
+  return ownCode;
+}
+
+/**
+ * Node errnos are bare screaming-snake tokens (`ECONNREFUSED`, `EPIPE`) plus
+ * undici's `UND_ERR_*` family. Membership in the shared retryable set is
+ * checked first so multi-word errnos like `EAI_AGAIN` are recognized without
+ * loosening the pattern enough to swallow unrelated wrapper codes such as
+ * `ERA_NEGOTIATION_FAILED`.
+ */
+function looksLikeNodeErrno(code: string): boolean {
+  return (
+    RETRYABLE_NODE_ERROR_CODES.has(code) ||
+    code.startsWith("UND_ERR_") ||
+    /^E[A-Z]{2,}$/.test(code)
+  );
 }
 
 /**

--- a/sdk/src/mcp-client-manager/MCPClientManager.ts
+++ b/sdk/src/mcp-client-manager/MCPClientManager.ts
@@ -2735,10 +2735,18 @@ export class MCPClientManager {
               { cause: error }
             );
           }
+          // Preserve `cause`: `formatError` reduces the failure to its
+          // message, and the Node errno (`ECONNREFUSED`, `ENOTFOUND`, ...)
+          // lives on the error object — usually one `.cause` hop down, since
+          // undici wraps connect failures as `TypeError("fetch failed")`.
+          // Without the chain, `extractNodeErrno` finds nothing and
+          // `describeError` degrades from a specific transport slug to
+          // message-regex guessing.
           throw new Error(
             `Failed to connect to MCP server "${serverId}" using Streamable HTTP, and this server's declared transport rules out the SSE fallback. Streamable HTTP error: ${formatError(
               error
-            )}`
+            )}`,
+            { cause: error }
           );
         }
       }
@@ -2788,9 +2796,27 @@ export class MCPClientManager {
         );
       }
 
-      throw new Error(
-        `Failed to connect to MCP server "${serverId}" using HTTP transports.${streamableMessage} SSE error: ${sseErrorMessage}.`
+      // `cause` is the SSE failure (the last attempt, and the one whose errno
+      // the message above quotes). Both transports fail with the same errno
+      // whenever the server is simply unreachable — ECONNREFUSED, ENOTFOUND —
+      // so this is the chain `extractNodeErrno` needs to reach a specific
+      // `transport/*` slug instead of message-regex guessing.
+      const combinedError = new Error(
+        `Failed to connect to MCP server "${serverId}" using HTTP transports.${streamableMessage} SSE error: ${sseErrorMessage}.`,
+        { cause: error }
       );
+      // Keep the Streamable HTTP failure reachable for diagnosis when the two
+      // attempts failed for DIFFERENT reasons. Non-enumerable so it never
+      // widens a log line or a JSON.stringify of the error.
+      if (streamableError !== undefined) {
+        Object.defineProperty(combinedError, "streamableCause", {
+          value: streamableError,
+          enumerable: false,
+          configurable: true,
+          writable: true,
+        });
+      }
+      throw combinedError;
     }
   }
 

--- a/sdk/src/mcp-client-manager/MCPClientManager.ts
+++ b/sdk/src/mcp-client-manager/MCPClientManager.ts
@@ -269,6 +269,32 @@ function isAbortError(error: unknown): boolean {
   );
 }
 
+/**
+ * Keep the Streamable HTTP failure reachable on an error whose `cause` is
+ * already the SSE failure. The two transports usually fail the same way, but
+ * when they don't, `cause` alone silently discards half the story — including
+ * the case where Streamable HTTP carried the auth challenge and SSE merely
+ * timed out afterwards.
+ *
+ * Non-enumerable so it never widens a log line or a `JSON.stringify` of the
+ * error. Both combined-failure throw sites go through here so neither can
+ * drift away from the other.
+ */
+function attachStreamableCause<E extends Error>(
+  error: E,
+  streamableError: unknown
+): E {
+  if (streamableError !== undefined) {
+    Object.defineProperty(error, "streamableCause", {
+      value: streamableError,
+      enumerable: false,
+      configurable: true,
+      writable: true,
+    });
+  }
+  return error;
+}
+
 type UpstreamToolDefinition = NonNullable<
   NonNullable<Parameters<ManagedMcpClient["callTool"]>[1]>["toolDefinition"]
 >;
@@ -2789,10 +2815,17 @@ export class MCPClientManager {
       if (sseAuthCheck.isAuth || streamableAuthCheck.isAuth) {
         const statusCode =
           sseAuthCheck.statusCode ?? streamableAuthCheck.statusCode;
-        throw new MCPAuthError(
-          `Authentication failed for MCP server "${serverId}": ${combinedErrorMessage}`,
-          statusCode,
-          { cause: error }
+        // `cause` stays the SSE failure for continuity, but the Streamable
+        // attempt matters twice as much here: when IT is the auth failure and
+        // SSE failed for some other reason, the challenge that triggered this
+        // branch lives only on `streamableError`.
+        throw attachStreamableCause(
+          new MCPAuthError(
+            `Authentication failed for MCP server "${serverId}": ${combinedErrorMessage}`,
+            statusCode,
+            { cause: error }
+          ),
+          streamableError
         );
       }
 
@@ -2801,22 +2834,13 @@ export class MCPClientManager {
       // whenever the server is simply unreachable — ECONNREFUSED, ENOTFOUND —
       // so this is the chain `extractNodeErrno` needs to reach a specific
       // `transport/*` slug instead of message-regex guessing.
-      const combinedError = new Error(
-        `Failed to connect to MCP server "${serverId}" using HTTP transports.${streamableMessage} SSE error: ${sseErrorMessage}.`,
-        { cause: error }
+      throw attachStreamableCause(
+        new Error(
+          `Failed to connect to MCP server "${serverId}" using HTTP transports.${streamableMessage} SSE error: ${sseErrorMessage}.`,
+          { cause: error }
+        ),
+        streamableError
       );
-      // Keep the Streamable HTTP failure reachable for diagnosis when the two
-      // attempts failed for DIFFERENT reasons. Non-enumerable so it never
-      // widens a log line or a JSON.stringify of the error.
-      if (streamableError !== undefined) {
-        Object.defineProperty(combinedError, "streamableCause", {
-          value: streamableError,
-          enumerable: false,
-          configurable: true,
-          writable: true,
-        });
-      }
-      throw combinedError;
     }
   }
 

--- a/sdk/tests/mcp-client-manager.connect-error-cause.test.ts
+++ b/sdk/tests/mcp-client-manager.connect-error-cause.test.ts
@@ -1,0 +1,108 @@
+import { createServer, type Server } from "node:http";
+
+import { MCPClientManager } from "../src/mcp-client-manager";
+import { describeError, extractNodeErrno } from "../src/error-describer";
+
+// What a refused HTTP connect used to classify as, and why it mattered:
+// undici reports the failure as `TypeError: fetch failed` and appends the real
+// reason ("... connect ECONNREFUSED 127.0.0.1:9999"). The manager's rethrow
+// dropped `cause`, and the describer matched `fetch failed` before looking for
+// the errno, so a refused port surfaced as the generic `transport/fetch_failed`
+// ("we could not reach it") instead of `transport/econnrefused` ("nothing is
+// listening on that host and port") — the only half a user can act on.
+describe("HTTP connect failures keep their provenance", () => {
+  let deadUrl: string;
+
+  // Bind a real server to get a port the OS just confirmed is ours, then close
+  // it. Connecting to that port is a deterministic ECONNREFUSED, without
+  // gambling on which ports happen to be free on the host.
+  beforeAll(async () => {
+    const server: Server = createServer();
+    await new Promise<void>((resolve) => server.listen(0, "127.0.0.1", resolve));
+    const address = server.address();
+    if (typeof address === "string" || address === null) {
+      throw new Error("expected an AddressInfo from the test server");
+    }
+    deadUrl = `http://127.0.0.1:${address.port}/mcp`;
+    await new Promise<void>((resolve, reject) =>
+      server.close((err) => (err ? reject(err) : resolve())),
+    );
+  });
+
+  async function captureConnectError(
+    serverId: string,
+    config: Record<string, unknown>,
+  ): Promise<unknown> {
+    const manager = new MCPClientManager({});
+    try {
+      await manager.connectToServer(serverId, config as never);
+      throw new Error("expected the connect to reject");
+    } finally {
+      await manager.disconnectAllServers();
+    }
+  }
+
+  it("classifies a refused Streamable-HTTP+SSE connect as transport/econnrefused", async () => {
+    const error = await captureConnectError("dead", { url: deadUrl }).catch(
+      (e) => e,
+    );
+
+    expect(describeError(error).slug).toBe("transport/econnrefused");
+  }, 20000);
+
+  it("preserves both transport failures on the combined connect error", async () => {
+    const error = (await captureConnectError("dead-both", {
+      url: deadUrl,
+    }).catch((e) => e)) as Error & { streamableCause?: unknown };
+
+    expect(error.cause).toBeDefined();
+    expect(error.streamableCause).toBeDefined();
+    // Non-enumerable: it must not widen a log line or JSON.stringify output.
+    expect(Object.keys(error)).not.toContain("streamableCause");
+  }, 20000);
+
+  it("preserves the cause on the declared-transport connect error", async () => {
+    // `disableSseFallback` rethrows from its own branch — a second throw site
+    // that has to carry the cause too.
+    //
+    // Documented limit: this path CANNOT reach `transport/econnrefused`. The
+    // upstream era-negotiation probe (@modelcontextprotocol/client) wraps the
+    // failure in an `SdkError` that neither keeps undici's `cause` nor repeats
+    // the errno in its message, so the errno is destroyed before MCPJam sees
+    // it. `transport/fetch_failed` is the honest answer here; recovering more
+    // requires an upstream change.
+    const error = (await captureConnectError("dead-declared", {
+      url: deadUrl,
+      disableSseFallback: true,
+    }).catch((e) => e)) as Error;
+
+    expect(error.cause).toBeDefined();
+    expect(describeError(error).slug).toBe("transport/fetch_failed");
+  }, 20000);
+});
+
+describe("extractNodeErrno — wrapper codes must not shadow the real errno", () => {
+  it("walks past an unrecognized string code to the errno below it", () => {
+    // Exactly the production shape: the MCP SDK's era-negotiation failure
+    // stamps `code: "ERA_NEGOTIATION_FAILED"` on the outside of the chain.
+    const systemError = Object.assign(
+      new Error("connect ECONNREFUSED 127.0.0.1:9999"),
+      { code: "ECONNREFUSED" },
+    );
+    const wrapper = Object.assign(new Error("Version negotiation failed"), {
+      code: "ERA_NEGOTIATION_FAILED",
+      cause: systemError,
+    });
+
+    expect(extractNodeErrno(wrapper)).toBe("ECONNREFUSED");
+    expect(describeError(wrapper).slug).toBe("transport/econnrefused");
+  });
+
+  it("still returns an unrecognized code when the chain holds no errno", () => {
+    const wrapper = Object.assign(new Error("Version negotiation failed"), {
+      code: "ERA_NEGOTIATION_FAILED",
+    });
+
+    expect(extractNodeErrno(wrapper)).toBe("ERA_NEGOTIATION_FAILED");
+  });
+});

--- a/sdk/tests/mcp-client-manager.connect-error-cause.test.ts
+++ b/sdk/tests/mcp-client-manager.connect-error-cause.test.ts
@@ -81,7 +81,78 @@ describe("HTTP connect failures keep their provenance", () => {
   }, 20000);
 });
 
+describe("mixed auth and transport failure", () => {
+  let server: Server;
+  let url: string;
+
+  // Streamable HTTP (POST) answers 401 while SSE (GET) fails for an unrelated
+  // reason. The auth challenge that triggers the MCPAuthError therefore lives
+  // ONLY on the Streamable error — `cause` holds the SSE failure.
+  beforeAll(async () => {
+    server = createServer((req, res) => {
+      if (req.method === "POST") {
+        res.writeHead(401, { "content-type": "application/json" });
+        res.end(JSON.stringify({ error: "unauthorized" }));
+        return;
+      }
+      res.writeHead(500, { "content-type": "text/plain" });
+      res.end("sse exploded");
+    });
+    await new Promise<void>((resolve) => server.listen(0, "127.0.0.1", resolve));
+    const address = server.address();
+    if (typeof address === "string" || address === null) {
+      throw new Error("expected an AddressInfo from the test server");
+    }
+    url = `http://127.0.0.1:${address.port}/mcp`;
+  });
+
+  afterAll(async () => {
+    await new Promise<void>((resolve, reject) =>
+      server.close((err) => (err ? reject(err) : resolve())),
+    );
+  });
+
+  it("keeps the Streamable HTTP auth failure reachable on the auth error", async () => {
+    const manager = new MCPClientManager({});
+    let captured: unknown;
+    try {
+      await manager.connectToServer("mixed", { url } as never);
+    } catch (error) {
+      captured = error;
+    } finally {
+      await manager.disconnectAllServers();
+    }
+
+    const error = captured as Error & {
+      streamableCause?: unknown;
+      statusCode?: number;
+    };
+    // Pin the branch: this must be the auth throw, not the combined transport
+    // throw below it, or the assertion proves nothing.
+    expect(error.name).toBe("MCPAuthError");
+    expect(error.statusCode).toBe(401);
+    // Without this the 401 is unrecoverable: `cause` is the SSE 500.
+    expect(error.streamableCause).toBeDefined();
+    expect(Object.keys(error)).not.toContain("streamableCause");
+  }, 20000);
+});
+
 describe("extractNodeErrno — wrapper codes must not shadow the real errno", () => {
+  it("walks past an E-prefixed wrapper code that merely looks like an errno", () => {
+    // `EWRAPPER` has the shape of a Node errno without being one. Recognition
+    // by pattern would end the walk here and lose the errno below.
+    const systemError = Object.assign(new Error("connect ECONNREFUSED"), {
+      code: "ECONNREFUSED",
+    });
+    const wrapper = Object.assign(new Error("wrapped"), {
+      code: "EWRAPPER",
+      cause: systemError,
+    });
+
+    expect(extractNodeErrno(wrapper)).toBe("ECONNREFUSED");
+    expect(describeError(wrapper).slug).toBe("transport/econnrefused");
+  });
+
   it("walks past an unrecognized string code to the errno below it", () => {
     // Exactly the production shape: the MCP SDK's era-negotiation failure
     // stamps `code: "ERA_NEGOTIATION_FAILED"` on the outside of the chain.
@@ -104,5 +175,24 @@ describe("extractNodeErrno — wrapper codes must not shadow the real errno", ()
     });
 
     expect(extractNodeErrno(wrapper)).toBe("ERA_NEGOTIATION_FAILED");
+  });
+});
+
+describe("errno recovered from message text", () => {
+  it("checks every errno-shaped token, not just the first", () => {
+    // The first token here maps to nothing. Stopping at it would fall through
+    // to the generic `fetch failed` slug and discard the ECONNREFUSED that
+    // says what actually happened.
+    const error = new Error(
+      "SSE ERROR: TypeError: fetch failed: connect ECONNREFUSED 127.0.0.1:9999",
+    );
+
+    expect(describeError(error).slug).toBe("transport/econnrefused");
+  });
+
+  it("still reports fetch_failed when no errno is present anywhere", () => {
+    const error = new Error("TypeError: fetch failed");
+
+    expect(describeError(error).slug).toBe("transport/fetch_failed");
   });
 });


### PR DESCRIPTION
## Why

A user interview this week ended on the same complaint twice: when a connection fails, MCPJam gives no evidence of *what* failed. Connecting to a host nothing is listening on classified as `transport/fetch_failed` — "we could not reach it" — which tells a developer nothing they did not already know.

The specific reason was present the whole time. It was discarded three separate ways, and all three had to go for any of it to matter.

## What changed

**1. The connect rethrows dropped `cause`.** `formatError` reduces a failure to its message, and the Node errno lives on the error object — usually one `.cause` hop down, since undici wraps connect failures as `TypeError("fetch failed")`. Both HTTP throw sites now preserve the chain. The combined Streamable-HTTP+SSE failure additionally keeps the Streamable attempt on a non-enumerable `streamableCause`, for when the two transports failed for different reasons (non-enumerable so it never widens a log line or a `JSON.stringify` of the error).

**2. `extractNodeErrno` stopped at the first string `code`.** A wrapper that stamps its own domain code on the outside of the chain — the MCP SDK's `ERA_NEGOTIATION_FAILED` — therefore shadowed the real `ECONNREFUSED` sitting one hop below it. Unrecognized codes no longer end the walk. They are still returned when the chain holds no errno at all, so callers that only test set membership (`isRetryableTransientError`) keep their contract.

**3. `describeError` matched the generic phrase first.** undici's message is `fetch failed`, and it appends the real reason: `... connect ECONNREFUSED 127.0.0.1:9999`. Matching `fetch failed` first threw away the only actionable half. An errno spelled out in the text now wins over the generic phrase; unmapped tokens fall through untouched.

A refused port now resolves to `transport/econnrefused`, whose catalog guidance names the actual next step.

## Documented limit

A server pinned to Streamable HTTP (`disableSseFallback`) still reports `transport/fetch_failed`. The upstream era-negotiation probe in `@modelcontextprotocol/client` wraps the failure in an `SdkError` that keeps neither undici's `cause` nor the errno text, so the information is destroyed before MCPJam ever sees it. That is asserted as a known limit in the test rather than papered over — recovering it needs an upstream change.

## Verification

The new test drives the real `MCPClientManager` against a genuinely dead port (bind a server to get a port the OS confirmed is ours, then close it), so it exercises the production connect path rather than a hand-built error.

- `sdk` suite: 204 files, 3947 passed, 0 failures
- `sdk` typecheck: clean
- `client/src/hooks/__tests__/use-server-state.test.tsx` (asserts these exact connect messages): 86 passed

Error messages are unchanged; this only adds provenance.

## Context

First PR of an error-origin classification program. Later PRs add an `origin` field (`user_server | user_config | mcpjam | ambiguous`) to the catalog and use it to decide what pages the team versus what is a user's own server misbehaving. This one lands alone because accurate slugs are the input that program depends on.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Scoped to SDK error wrapping and classification on connect failures; user-visible messages are unchanged, with behavior limited to more accurate transport slugs and preserved error metadata.
> 
> **Overview**
> **Connect failures now keep their underlying error chain.** HTTP connect rethrows in `MCPClientManager` attach `{ cause: error }`, and dual-transport failures also stash the Streamable HTTP attempt on a non-enumerable `streamableCause` so mixed auth/transport cases stay inspectable.
> 
> **Error classification is more specific.** `extractNodeErrno` walks past unrecognized wrapper `code` values (e.g. `ERA_NEGOTIATION_FAILED`) to find real Node errnos, and `describeError` prefers errno tokens embedded in messages over undici’s generic `fetch failed` phrase. Refused listeners should surface as **`transport/econnrefused`** with actionable catalog guidance.
> 
> **Tests** exercise real `MCPClientManager` connects to a closed port and assert slugs, cause preservation, and the documented limit: `disableSseFallback` may still yield `transport/fetch_failed` when upstream strips errno provenance.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1280f00a930c980a6ead34f635a9b073c0cd420b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Improve SDK connection error classification so refused ports resolve to `transport/econnrefused` instead of `transport/fetch_failed`. Preserve and surface real errno causes to make connect failures actionable.

- **Bug Fixes**
  - Preserve error chain on HTTP connect errors; both combined HTTP+SSE throw sites keep `cause` and attach a non-enumerable `streamableCause` (including the auth path).
  - Update `extractNodeErrno` to walk past wrapper codes and return the real errno; only recognized errnos short-circuit, unrecognized strings no longer stop the walk and are returned only if no errno exists.
  - In `describeError`, scan all errno-like tokens in messages and prefer explicit errnos over generic phrases like "fetch failed".
  - Add tests for real refused connects, wrapper-code chains, mixed auth vs transport failures, and message-token scanning.
  - Known limit: with `disableSseFallback`, errors may still report `transport/fetch_failed` due to upstream handling in `@modelcontextprotocol/client`.

<sup>Written for commit 1280f00a930c980a6ead34f635a9b073c0cd420b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/MCPJam/inspector/pull/3860?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

