### PR TITLE
Show toast for client updates

### DIFF
--- a/mcpjam-inspector/client/src/components/hosts/redesigned/HostBuilderViewRedesigned.tsx
+++ b/mcpjam-inspector/client/src/components/hosts/redesigned/HostBuilderViewRedesigned.tsx
@@ -605,9 +605,11 @@ export function HostBuilderViewRedesigned({
                     }
                     focusSubKey={focusState.focusSubKey}
                     hostDisplayName={draftName}
+                    savedHostDisplayName={host?.name ?? draftName}
                     onHostDisplayNameChange={setDraftName}
                     themeMode={themeMode}
                     draft={draftConfig}
+                    savedDraft={savedConfig ?? draftConfig}
                     onDraftChange={(updater) =>
                       setDraftConfig((prev) => (prev ? updater(prev) : prev))
                     }

--- a/mcpjam-inspector/client/src/components/hosts/redesigned/focus/HostFocusPanel.tsx
+++ b/mcpjam-inspector/client/src/components/hosts/redesigned/focus/HostFocusPanel.tsx
@@ -46,9 +46,11 @@ interface HostFocusPanelProps {
    */
   focusSubKey?: SandboxConfigSubKey;
   hostDisplayName: string;
+  savedHostDisplayName?: string;
   onHostDisplayNameChange: (value: string) => void;
   themeMode?: ThemeMode;
   draft: HostConfigInputV2;
+  savedDraft?: HostConfigInputV2;
   onDraftChange: (
     updater: (prev: HostConfigInputV2) => HostConfigInputV2
   ) => void;
@@ -67,9 +69,11 @@ export function HostFocusPanel({
   onTabChange,
   focusSubKey,
   hostDisplayName,
+  savedHostDisplayName,
   onHostDisplayNameChange,
   themeMode = "light",
   draft,
+  savedDraft,
   onDraftChange,
   attention,
   onClose,
@@ -98,7 +102,9 @@ export function HostFocusPanel({
         action={
           <UpdateHostToLatestButton
             draft={draft}
+            savedDraft={savedDraft}
             hostDisplayName={hostDisplayName}
+            savedHostDisplayName={savedHostDisplayName}
             onHostDisplayNameChange={onHostDisplayNameChange}
             themeMode={themeMode}
             onDraftChange={onDraftChange}

--- a/mcpjam-inspector/client/src/components/hosts/redesigned/focus/HostFocusPanel.tsx
+++ b/mcpjam-inspector/client/src/components/hosts/redesigned/focus/HostFocusPanel.tsx
@@ -101,6 +101,7 @@ export function HostFocusPanel({
         logoSrc={logoSrc}
         action={
           <UpdateHostToLatestButton
+            hostId={hostId}
             draft={draft}
             savedDraft={savedDraft}
             hostDisplayName={hostDisplayName}

--- a/mcpjam-inspector/client/src/components/hosts/redesigned/focus/UpdateHostToLatestButton.tsx
+++ b/mcpjam-inspector/client/src/components/hosts/redesigned/focus/UpdateHostToLatestButton.tsx
@@ -1,3 +1,4 @@
+import { useEffect, useRef } from "react";
 import { RefreshCw } from "lucide-react";
 import { Button } from "@mcpjam/design-system/button";
 import {
@@ -12,13 +13,17 @@ import type { ThemeMode } from "@/types/preferences/theme";
 
 interface UpdateHostToLatestButtonProps {
   draft: HostConfigInputV2;
+  savedDraft?: HostConfigInputV2;
   hostDisplayName: string;
+  savedHostDisplayName?: string;
   onHostDisplayNameChange: (value: string) => void;
   themeMode: ThemeMode;
   onDraftChange: (
     updater: (prev: HostConfigInputV2) => HostConfigInputV2
   ) => void;
 }
+
+const UPDATE_TOAST_ID = "client-update-available";
 
 function cloneJson<T>(value: T): T {
   return JSON.parse(JSON.stringify(value)) as T;
@@ -43,7 +48,9 @@ function applyCatalogTemplateToDraft(
 
 export function UpdateHostToLatestButton({
   draft,
+  savedDraft = draft,
   hostDisplayName,
+  savedHostDisplayName = hostDisplayName,
   onHostDisplayNameChange,
   themeMode,
   onDraftChange,
@@ -61,6 +68,10 @@ export function UpdateHostToLatestButton({
     catalogTemplate === undefined
       ? undefined
       : applyCatalogTemplateToDraft(catalogTemplate, draft, themeMode);
+  const latestSavedDraft =
+    catalogTemplate === undefined
+      ? undefined
+      : applyCatalogTemplateToDraft(catalogTemplate, savedDraft, themeMode);
   const latestDisplayName = catalogHost?.label;
 
   const alreadyCurrent =
@@ -68,6 +79,17 @@ export function UpdateHostToLatestButton({
     latestDisplayName !== undefined &&
     hostDisplayName === latestDisplayName &&
     hostConfigInputsEqual(draft, latestDraft);
+  const savedAlreadyCurrent =
+    latestSavedDraft !== undefined &&
+    latestDisplayName !== undefined &&
+    savedHostDisplayName === latestDisplayName &&
+    hostConfigInputsEqual(savedDraft, latestSavedDraft);
+  const updateAvailable =
+    catalogState.status === "live" &&
+    latestSavedDraft !== undefined &&
+    latestDisplayName !== undefined &&
+    !savedAlreadyCurrent &&
+    !alreadyCurrent;
 
   const disabled =
     catalogState.status !== "live" ||
@@ -97,8 +119,36 @@ export function UpdateHostToLatestButton({
       applyCatalogTemplateToDraft(catalogTemplate, prev, themeMode)
     );
     onHostDisplayNameChange(latestDisplayName);
+    toast.dismiss(UPDATE_TOAST_ID);
     toast.success("Updated to latest");
   };
+
+  // Keep the action pointed at the newest draft without re-showing the toast
+  // on every local edit. Update availability is based on the saved client, so
+  // changing a field in the editor does not look like a new catalog release.
+  const handleClickRef = useRef(handleClick);
+  handleClickRef.current = handleClick;
+
+  useEffect(() => {
+    if (!updateAvailable) {
+      toast.dismiss(UPDATE_TOAST_ID);
+      return;
+    }
+
+    toast.info("Client update available", {
+      id: UPDATE_TOAST_ID,
+      description: `${latestDisplayName} has a newer configuration.`,
+      duration: 10_000,
+      action: {
+        label: "Update to latest",
+        onClick: () => handleClickRef.current(),
+      },
+    });
+
+    return () => {
+      toast.dismiss(UPDATE_TOAST_ID);
+    };
+  }, [latestDisplayName, updateAvailable]);
 
   return (
     <Button

--- a/mcpjam-inspector/client/src/components/hosts/redesigned/focus/UpdateHostToLatestButton.tsx
+++ b/mcpjam-inspector/client/src/components/hosts/redesigned/focus/UpdateHostToLatestButton.tsx
@@ -158,11 +158,19 @@ export function UpdateHostToLatestButton({
       clearTimeout(dismissTimerRef.current);
       dismissTimerRef.current = null;
     }
+    const scheduleDismiss = () => {
+      // Defer cleanup so React Strict Mode's setup/cleanup/setup replay can
+      // cancel it instead of immediately hiding the toast in development.
+      dismissTimerRef.current = setTimeout(() => {
+        toast.dismiss(UPDATE_TOAST_ID);
+        dismissTimerRef.current = null;
+      }, 0);
+    };
     if (!updateAvailable || updateKey === undefined) {
       toast.dismiss(UPDATE_TOAST_ID);
       return;
     }
-    if (offeredUpdateKeyRef.current === updateKey) return;
+    if (offeredUpdateKeyRef.current === updateKey) return scheduleDismiss;
     offeredUpdateKeyRef.current = updateKey;
 
     toast.info("Client update available", {
@@ -175,14 +183,7 @@ export function UpdateHostToLatestButton({
       },
     });
 
-    return () => {
-      // Defer cleanup so React Strict Mode's setup/cleanup/setup replay can
-      // cancel it instead of immediately hiding the toast in development.
-      dismissTimerRef.current = setTimeout(() => {
-        toast.dismiss(UPDATE_TOAST_ID);
-        dismissTimerRef.current = null;
-      }, 0);
-    };
+    return scheduleDismiss;
   }, [latestDisplayName, updateAvailable, updateKey]);
 
   return (

--- a/mcpjam-inspector/client/src/components/hosts/redesigned/focus/UpdateHostToLatestButton.tsx
+++ b/mcpjam-inspector/client/src/components/hosts/redesigned/focus/UpdateHostToLatestButton.tsx
@@ -101,6 +101,9 @@ export function UpdateHostToLatestButton({
     hostConfigInputsEqual(savedDraft, latestSavedDraft);
   const updateAvailable =
     catalogState.status === "live" &&
+    draft.hostStyle === savedDraft.hostStyle &&
+    catalogTemplate !== undefined &&
+    latestDisplayName !== undefined &&
     latestSavedDraft !== undefined &&
     latestSavedDisplayName !== undefined &&
     !savedAlreadyCurrent &&
@@ -159,7 +162,7 @@ export function UpdateHostToLatestButton({
 
     toast.info("Client update available", {
       id: UPDATE_TOAST_ID,
-      description: `${latestSavedDisplayName} has a newer configuration.`,
+      description: `${latestDisplayName} has a newer configuration.`,
       duration: 10_000,
       action: {
         label: "Update to latest",
@@ -170,7 +173,7 @@ export function UpdateHostToLatestButton({
     return () => {
       toast.dismiss(UPDATE_TOAST_ID);
     };
-  }, [latestSavedDisplayName, updateAvailable, updateKey]);
+  }, [latestDisplayName, updateAvailable, updateKey]);
 
   return (
     <Button

--- a/mcpjam-inspector/client/src/components/hosts/redesigned/focus/UpdateHostToLatestButton.tsx
+++ b/mcpjam-inspector/client/src/components/hosts/redesigned/focus/UpdateHostToLatestButton.tsx
@@ -12,6 +12,7 @@ import { getCatalogHost, getCatalogTemplate } from "@mcpjam/sdk/host-compat";
 import type { ThemeMode } from "@/types/preferences/theme";
 
 interface UpdateHostToLatestButtonProps {
+  hostId?: string;
   draft: HostConfigInputV2;
   savedDraft?: HostConfigInputV2;
   hostDisplayName: string;
@@ -47,6 +48,7 @@ function applyCatalogTemplateToDraft(
 }
 
 export function UpdateHostToLatestButton({
+  hostId,
   draft,
   savedDraft = draft,
   hostDisplayName,
@@ -64,15 +66,28 @@ export function UpdateHostToLatestButton({
     catalogState.status === "live"
       ? getCatalogTemplate(catalogState.catalog, draft.hostStyle)
       : undefined;
+  const savedCatalogHost =
+    catalogState.status === "live"
+      ? getCatalogHost(catalogState.catalog, savedDraft.hostStyle)
+      : undefined;
+  const savedCatalogTemplate =
+    catalogState.status === "live"
+      ? getCatalogTemplate(catalogState.catalog, savedDraft.hostStyle)
+      : undefined;
   const latestDraft =
     catalogTemplate === undefined
       ? undefined
       : applyCatalogTemplateToDraft(catalogTemplate, draft, themeMode);
   const latestSavedDraft =
-    catalogTemplate === undefined
+    savedCatalogTemplate === undefined
       ? undefined
-      : applyCatalogTemplateToDraft(catalogTemplate, savedDraft, themeMode);
+      : applyCatalogTemplateToDraft(
+          savedCatalogTemplate,
+          savedDraft,
+          themeMode
+        );
   const latestDisplayName = catalogHost?.label;
+  const latestSavedDisplayName = savedCatalogHost?.label;
 
   const alreadyCurrent =
     latestDraft !== undefined &&
@@ -81,15 +96,19 @@ export function UpdateHostToLatestButton({
     hostConfigInputsEqual(draft, latestDraft);
   const savedAlreadyCurrent =
     latestSavedDraft !== undefined &&
-    latestDisplayName !== undefined &&
-    savedHostDisplayName === latestDisplayName &&
+    latestSavedDisplayName !== undefined &&
+    savedHostDisplayName === latestSavedDisplayName &&
     hostConfigInputsEqual(savedDraft, latestSavedDraft);
   const updateAvailable =
     catalogState.status === "live" &&
     latestSavedDraft !== undefined &&
-    latestDisplayName !== undefined &&
+    latestSavedDisplayName !== undefined &&
     !savedAlreadyCurrent &&
     !alreadyCurrent;
+  const updateKey =
+    catalogState.status === "live"
+      ? `${hostId ?? "current-client"}:${savedDraft.hostStyle}:${catalogState.version}`
+      : undefined;
 
   const disabled =
     catalogState.status !== "live" ||
@@ -128,16 +147,19 @@ export function UpdateHostToLatestButton({
   // changing a field in the editor does not look like a new catalog release.
   const handleClickRef = useRef(handleClick);
   handleClickRef.current = handleClick;
+  const offeredUpdateKeyRef = useRef<string | null>(null);
 
   useEffect(() => {
-    if (!updateAvailable) {
+    if (!updateAvailable || updateKey === undefined) {
       toast.dismiss(UPDATE_TOAST_ID);
       return;
     }
+    if (offeredUpdateKeyRef.current === updateKey) return;
+    offeredUpdateKeyRef.current = updateKey;
 
     toast.info("Client update available", {
       id: UPDATE_TOAST_ID,
-      description: `${latestDisplayName} has a newer configuration.`,
+      description: `${latestSavedDisplayName} has a newer configuration.`,
       duration: 10_000,
       action: {
         label: "Update to latest",
@@ -148,7 +170,7 @@ export function UpdateHostToLatestButton({
     return () => {
       toast.dismiss(UPDATE_TOAST_ID);
     };
-  }, [latestDisplayName, updateAvailable]);
+  }, [latestSavedDisplayName, updateAvailable, updateKey]);
 
   return (
     <Button

--- a/mcpjam-inspector/client/src/components/hosts/redesigned/focus/UpdateHostToLatestButton.tsx
+++ b/mcpjam-inspector/client/src/components/hosts/redesigned/focus/UpdateHostToLatestButton.tsx
@@ -151,8 +151,13 @@ export function UpdateHostToLatestButton({
   const handleClickRef = useRef(handleClick);
   handleClickRef.current = handleClick;
   const offeredUpdateKeyRef = useRef<string | null>(null);
+  const dismissTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
   useEffect(() => {
+    if (dismissTimerRef.current !== null) {
+      clearTimeout(dismissTimerRef.current);
+      dismissTimerRef.current = null;
+    }
     if (!updateAvailable || updateKey === undefined) {
       toast.dismiss(UPDATE_TOAST_ID);
       return;
@@ -171,7 +176,12 @@ export function UpdateHostToLatestButton({
     });
 
     return () => {
-      toast.dismiss(UPDATE_TOAST_ID);
+      // Defer cleanup so React Strict Mode's setup/cleanup/setup replay can
+      // cancel it instead of immediately hiding the toast in development.
+      dismissTimerRef.current = setTimeout(() => {
+        toast.dismiss(UPDATE_TOAST_ID);
+        dismissTimerRef.current = null;
+      }, 0);
     };
   }, [latestDisplayName, updateAvailable, updateKey]);
 

--- a/mcpjam-inspector/client/src/components/hosts/redesigned/focus/__tests__/UpdateHostToLatestButton.test.tsx
+++ b/mcpjam-inspector/client/src/components/hosts/redesigned/focus/__tests__/UpdateHostToLatestButton.test.tsx
@@ -1,4 +1,4 @@
-import { act, useState } from "react";
+import { act, StrictMode, useState } from "react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
@@ -59,6 +59,7 @@ function renderButton(args: {
   initialName?: string;
   savedDraft?: HostConfigInputV2;
   savedName?: string;
+  strictMode?: boolean;
 }) {
   const draftRef: { current: HostConfigInputV2 } = {
     current: args.initialDraft,
@@ -99,7 +100,15 @@ function renderButton(args: {
     );
   }
 
-  const utils = render(<Harness />);
+  const utils = render(
+    args.strictMode ? (
+      <StrictMode>
+        <Harness />
+      </StrictMode>
+    ) : (
+      <Harness />
+    )
+  );
   return {
     draftRef,
     nameRef,
@@ -129,6 +138,21 @@ describe("UpdateHostToLatestButton", () => {
     expect(draftRef.current).toEqual(catalogDraftFor("mistral"));
     expect(nameRef.current).toBe(catalogLabelFor("mistral"));
     expect(toast.success).toHaveBeenCalledWith("Updated to latest");
+  });
+
+  it("keeps the update toast visible during Strict Mode effect replay", async () => {
+    renderButton({
+      initialDraft: emptyHostConfigInputV2({
+        hostStyle: "mistral",
+        modelId: "old-model",
+      }),
+      initialName: "Old Mistral",
+      strictMode: true,
+    });
+
+    await waitFor(() => expect(toast.info).toHaveBeenCalledTimes(1));
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    expect(toast.dismiss).not.toHaveBeenCalled();
   });
 
   it("does not treat unsaved local edits as a new client update", () => {

--- a/mcpjam-inspector/client/src/components/hosts/redesigned/focus/__tests__/UpdateHostToLatestButton.test.tsx
+++ b/mcpjam-inspector/client/src/components/hosts/redesigned/focus/__tests__/UpdateHostToLatestButton.test.tsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { act, useState } from "react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
@@ -66,14 +66,19 @@ function renderButton(args: {
   const nameRef: { current: string } = {
     current: args.initialName ?? "Custom Host",
   };
+  const setDraftRef: {
+    current: (next: HostConfigInputV2) => void;
+  } = { current: () => undefined };
 
   function Harness() {
     const [draft, setDraft] = useState(args.initialDraft);
     const [name, setName] = useState(nameRef.current);
+    setDraftRef.current = setDraft;
     draftRef.current = draft;
     nameRef.current = name;
     return (
       <UpdateHostToLatestButton
+        hostId="host-test"
         draft={draft}
         savedDraft={args.savedDraft}
         hostDisplayName={name}
@@ -95,7 +100,12 @@ function renderButton(args: {
   }
 
   const utils = render(<Harness />);
-  return { draftRef, nameRef, ...utils };
+  return {
+    draftRef,
+    nameRef,
+    setDraft: (next: HostConfigInputV2) => setDraftRef.current(next),
+    ...utils,
+  };
 }
 
 describe("UpdateHostToLatestButton", () => {
@@ -114,7 +124,7 @@ describe("UpdateHostToLatestButton", () => {
     expect(options?.action).toMatchObject({ label: "Update to latest" });
 
     const action = options?.action as { onClick: () => void };
-    action.onClick();
+    act(() => action.onClick());
 
     expect(draftRef.current).toEqual(catalogDraftFor("mistral"));
     expect(nameRef.current).toBe(catalogLabelFor("mistral"));
@@ -131,6 +141,39 @@ describe("UpdateHostToLatestButton", () => {
     });
 
     expect(toast.info).not.toHaveBeenCalled();
+  });
+
+  it("checks saved freshness against the saved host style", () => {
+    const savedDraft = catalogDraftFor("claude");
+    renderButton({
+      initialDraft: { ...savedDraft, hostStyle: "mistral" },
+      savedDraft,
+      initialName: catalogLabelFor("claude"),
+      savedName: catalogLabelFor("claude"),
+    });
+
+    expect(toast.info).not.toHaveBeenCalled();
+  });
+
+  it("does not offer the same catalog update again after local edits", async () => {
+    const savedDraft = emptyHostConfigInputV2({
+      hostStyle: "mistral",
+      modelId: "old-model",
+    });
+    const { draftRef, setDraft } = renderButton({
+      initialDraft: savedDraft,
+      savedDraft,
+      initialName: "Old Mistral",
+      savedName: "Old Mistral",
+    });
+
+    await waitFor(() => expect(toast.info).toHaveBeenCalledTimes(1));
+    const [, options] = vi.mocked(toast.info).mock.calls[0];
+    const action = options?.action as { onClick: () => void };
+    act(() => action.onClick());
+    act(() => setDraft({ ...draftRef.current, modelId: "local-edit" }));
+
+    expect(toast.info).toHaveBeenCalledTimes(1);
   });
 
   it("copies the latest catalog template, including image settings", async () => {

--- a/mcpjam-inspector/client/src/components/hosts/redesigned/focus/__tests__/UpdateHostToLatestButton.test.tsx
+++ b/mcpjam-inspector/client/src/components/hosts/redesigned/focus/__tests__/UpdateHostToLatestButton.test.tsx
@@ -155,6 +155,21 @@ describe("UpdateHostToLatestButton", () => {
     expect(toast.info).not.toHaveBeenCalled();
   });
 
+  it("does not offer an update while the host style has an unsaved change", () => {
+    const savedDraft = emptyHostConfigInputV2({
+      hostStyle: "mistral",
+      modelId: "old-model",
+    });
+    renderButton({
+      initialDraft: { ...savedDraft, hostStyle: "claude" },
+      savedDraft,
+      initialName: "Old Mistral",
+      savedName: "Old Mistral",
+    });
+
+    expect(toast.info).not.toHaveBeenCalled();
+  });
+
   it("does not offer the same catalog update again after local edits", async () => {
     const savedDraft = emptyHostConfigInputV2({
       hostStyle: "mistral",

--- a/mcpjam-inspector/client/src/components/hosts/redesigned/focus/__tests__/UpdateHostToLatestButton.test.tsx
+++ b/mcpjam-inspector/client/src/components/hosts/redesigned/focus/__tests__/UpdateHostToLatestButton.test.tsx
@@ -141,7 +141,7 @@ describe("UpdateHostToLatestButton", () => {
   });
 
   it("keeps the update toast visible during Strict Mode effect replay", async () => {
-    renderButton({
+    const { unmount } = renderButton({
       initialDraft: emptyHostConfigInputV2({
         hostStyle: "mistral",
         modelId: "old-model",
@@ -153,6 +153,9 @@ describe("UpdateHostToLatestButton", () => {
     await waitFor(() => expect(toast.info).toHaveBeenCalledTimes(1));
     await new Promise((resolve) => setTimeout(resolve, 0));
     expect(toast.dismiss).not.toHaveBeenCalled();
+
+    unmount();
+    await waitFor(() => expect(toast.dismiss).toHaveBeenCalledTimes(1));
   });
 
   it("does not treat unsaved local edits as a new client update", () => {

--- a/mcpjam-inspector/client/src/components/hosts/redesigned/focus/__tests__/UpdateHostToLatestButton.test.tsx
+++ b/mcpjam-inspector/client/src/components/hosts/redesigned/focus/__tests__/UpdateHostToLatestButton.test.tsx
@@ -1,6 +1,6 @@
 import { useState } from "react";
-import { describe, expect, it, vi } from "vitest";
-import { render, screen } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import {
   bundledHostCompatCatalog,
@@ -13,6 +13,7 @@ import {
   type HostConfigInputV2,
 } from "@/lib/client-config-v2";
 import { UpdateHostToLatestButton } from "../UpdateHostToLatestButton";
+import { toast } from "@/lib/toast";
 
 const liveCatalog = bundledHostCompatCatalog();
 
@@ -31,8 +32,12 @@ vi.mock("@/lib/host-compat/use-host-catalog", async () => {
 });
 
 vi.mock("@/lib/toast", () => ({
-  toast: { success: vi.fn() },
+  toast: { dismiss: vi.fn(), info: vi.fn(), success: vi.fn() },
 }));
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
 
 function catalogDraftFor(
   hostStyle: string,
@@ -52,6 +57,8 @@ function catalogLabelFor(hostStyle: string) {
 function renderButton(args: {
   initialDraft: HostConfigInputV2;
   initialName?: string;
+  savedDraft?: HostConfigInputV2;
+  savedName?: string;
 }) {
   const draftRef: { current: HostConfigInputV2 } = {
     current: args.initialDraft,
@@ -68,7 +75,9 @@ function renderButton(args: {
     return (
       <UpdateHostToLatestButton
         draft={draft}
+        savedDraft={args.savedDraft}
         hostDisplayName={name}
+        savedHostDisplayName={args.savedName}
         onHostDisplayNameChange={(next) => {
           nameRef.current = next;
           setName(next);
@@ -90,6 +99,40 @@ function renderButton(args: {
 }
 
 describe("UpdateHostToLatestButton", () => {
+  it("offers the latest client configuration in a toast", async () => {
+    const initial = emptyHostConfigInputV2({
+      hostStyle: "mistral",
+      modelId: "old-model",
+    });
+    const { draftRef, nameRef } = renderButton({
+      initialDraft: initial,
+      initialName: "Old Mistral",
+    });
+
+    await waitFor(() => expect(toast.info).toHaveBeenCalledTimes(1));
+    const [, options] = vi.mocked(toast.info).mock.calls[0];
+    expect(options?.action).toMatchObject({ label: "Update to latest" });
+
+    const action = options?.action as { onClick: () => void };
+    action.onClick();
+
+    expect(draftRef.current).toEqual(catalogDraftFor("mistral"));
+    expect(nameRef.current).toBe(catalogLabelFor("mistral"));
+    expect(toast.success).toHaveBeenCalledWith("Updated to latest");
+  });
+
+  it("does not treat unsaved local edits as a new client update", () => {
+    const savedDraft = catalogDraftFor("claude");
+    renderButton({
+      initialDraft: { ...savedDraft, modelId: "local-edit" },
+      savedDraft,
+      initialName: catalogLabelFor("claude"),
+      savedName: catalogLabelFor("claude"),
+    });
+
+    expect(toast.info).not.toHaveBeenCalled();
+  });
+
   it("copies the latest catalog template, including image settings", async () => {
     const user = userEvent.setup();
     const serverConnectionOverrides = {


### PR DESCRIPTION

<img width="375" height="148" alt="image" src="https://github.com/user-attachments/assets/bdb8778e-074a-4416-9535-71ad9e794d23" />


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Show a toast when a newer client configuration is available, with a one-click action to update to the latest catalog template. Detection is based on the saved client (per host), so unsaved edits don’t trigger or re-trigger the toast; works reliably in Strict Mode.

- New Features
  - `UpdateHostToLatestButton` shows a `toast.info` when the saved client has a newer catalog; “Update to latest” applies the latest template and name, dismisses, then `toast.success`.
  - Action stays stable as you edit: stable toast ID, ref, and `updateKey` = `hostId:style:catalogVersion`; no re-offer after local edits, unsaved hostStyle changes, or remounts; per-host scoping via `hostId`.
  - New props: `hostId`, `savedDraft`, `savedHostDisplayName` (plumbed from `HostBuilderViewRedesigned` → `HostFocusPanel` → `UpdateHostToLatestButton`). Tests cover Strict Mode, showing/applying, ignoring unsaved edits, not re-offering the same update, and checking freshness by the saved style.

<sup>Written for commit 0f25d4bbc4795375e9730867d948ac1aca7c81a5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/MCPJam/inspector/pull/3861?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

