### PR TITLE
feat(oauth): toast the backend-classified refresh failures too

### DIFF
--- a/mcpjam-inspector/client/src/lib/__tests__/hosted-oauth-failure.test.ts
+++ b/mcpjam-inspector/client/src/lib/__tests__/hosted-oauth-failure.test.ts
@@ -67,3 +67,100 @@ describe("describeHostedOAuthFailure", () => {
     expect(describeHostedOAuthFailure(null, "X")).toBeNull();
   });
 });
+
+// Structured shapes: what actually reaches the client once the backend
+// classifies the failure (backend #922/#927). The WebApiError carries `code`
+// and `details` off the JSON error body; the messages here are the real ones
+// the backend sends, not invented.
+describe("describeHostedOAuthFailure structured backend shapes", () => {
+  const UNREACHABLE_503 = Object.assign(
+    new Error("Could not reach the authorization server (HTTP 502)."),
+    {
+      code: "authorization_server_unreachable",
+      details: {
+        authorizationServerUnreachable: true,
+        serverId: "srv_1",
+        serverName: "Descope",
+        failure: {
+          url: "https://eliya.descope.team/oauth2/v1/apps/token",
+          status: 502,
+          body: '{"title":"Error 502: Bad gateway","retryable":true}',
+        },
+      },
+    }
+  );
+
+  it("names the host from the recorded failure and offers Retry", () => {
+    const copy = describeHostedOAuthFailure(UNREACHABLE_503, "Descope");
+
+    expect(copy).toEqual({
+      kind: "unreachable",
+      title: "Could not reach eliya.descope.team",
+      detail: [
+        "https://eliya.descope.team/oauth2/v1/apps/token",
+        'HTTP 502, {"title":"Error 502: Bad gateway","retryable":true}',
+      ],
+      action: "retry",
+    });
+  });
+
+  it("falls back to the backend message when no failure was recorded", () => {
+    const copy = describeHostedOAuthFailure(
+      Object.assign(new Error("Could not reach the authorization server."), {
+        code: "authorization_server_unreachable",
+        details: { authorizationServerUnreachable: true, failure: null },
+      }),
+      "Descope"
+    );
+
+    expect(copy).toEqual({
+      kind: "unreachable",
+      title: "Could not reach the authorization server",
+      detail: ["Could not reach the authorization server."],
+      action: "retry",
+    });
+  });
+
+  it("classifies the backend's generic 401 as a decline needing Reconnect", () => {
+    // The inspector server remaps refresh_token_invalid to UNAUTHORIZED but
+    // keeps details.refreshTokenInvalid; the message matches no provider
+    // regex, so only the structured branch can catch it.
+    const copy = describeHostedOAuthFailure(
+      Object.assign(
+        new Error("Hosted OAuth refresh token is invalid. Please reconnect."),
+        {
+          code: "UNAUTHORIZED",
+          details: {
+            oauthRequired: true,
+            refreshTokenInvalid: true,
+            serverId: "srv_1",
+            serverName: "Linear",
+          },
+        }
+      ),
+      "Linear"
+    );
+
+    expect(copy?.kind).toBe("declined");
+    expect(copy?.action).toBe("reconnect");
+    expect(copy?.detail).toEqual([
+      "Hosted OAuth refresh token is invalid. Please reconnect.",
+    ]);
+  });
+});
+
+describe("describeHostedOAuthFailure invalid_client messages", () => {
+  // Real CONVEX-PY events: paths that still surface the raw provider message
+  // (older backend, uncaught throws) rather than the structured 401.
+  it.each([
+    "Uncaught InvalidClientError: Unknown client. The authorization flow may have expired — please retry.",
+    "Uncaught InvalidClientError: Invalid client_id",
+    "Uncaught InvalidClientError: Client authentication failed (e.g., unknown client, no client authentication included, or unsupported authentication method).",
+  ])("asks for a reconnect: %s", (message) => {
+    const copy = describeHostedOAuthFailure(message, "Notion");
+
+    expect(copy?.kind).toBe("declined");
+    expect(copy?.title).toBe("Refresh token declined for Notion");
+    expect(copy?.action).toBe("reconnect");
+  });
+});

--- a/mcpjam-inspector/client/src/lib/hosted-oauth-failure.ts
+++ b/mcpjam-inspector/client/src/lib/hosted-oauth-failure.ts
@@ -27,9 +27,61 @@ export interface HostedOAuthFailureCopy {
 const METADATA_FAILURE =
   /HTTP (\d{3}) trying to load (?:OAuth|OpenID provider) metadata from (\S+?)(?:\s+\(([^)]*)\))?\s*$/i;
 
-/** The token endpoint answered, and the answer was "no". */
+/**
+ * The token endpoint answered, and the answer was "no". The invalid_client
+ * family belongs here: a registration the server has disowned can never
+ * refresh, and re-running authorize (which re-registers) is the fix, same as
+ * for a dead refresh token.
+ */
 const DECLINED =
-  /invalid[_\s-]?grant|InvalidGrantError|refresh[_\s-]?token[_\s-]?not[_\s-]?found|token is not active|expired (?:access\/)?refresh token/i;
+  /invalid[_\s-]?grant|InvalidGrantError|refresh[_\s-]?token[_\s-]?not[_\s-]?found|token is not active|expired (?:access\/)?refresh token|invalid[_\s-]?client|InvalidClientError|unknown client|client authentication failed/i;
+
+/**
+ * What the backend recorded off the authorization server's failing response.
+ * Travels as `details.failure` on the 503 the hosted refresh path returns
+ * (`authorization_server_unreachable`); every field is the other server's, so
+ * rendering it verbatim keeps the no-fabrication invariant.
+ */
+interface AuthorizationServerFailure {
+  url: string;
+  status: number;
+  body: string;
+}
+
+function structuredPartsOf(error: unknown): {
+  code: string | null;
+  details: Record<string, unknown> | null;
+} {
+  if (!error || typeof error !== "object") {
+    return { code: null, details: null };
+  }
+  const record = error as { code?: unknown; details?: unknown };
+  return {
+    code: typeof record.code === "string" ? record.code : null,
+    details:
+      record.details && typeof record.details === "object"
+        ? (record.details as Record<string, unknown>)
+        : null,
+  };
+}
+
+function failureOf(
+  details: Record<string, unknown> | null
+): AuthorizationServerFailure | null {
+  const failure = details?.failure;
+  if (!failure || typeof failure !== "object") {
+    return null;
+  }
+  const record = failure as Record<string, unknown>;
+  if (typeof record.url !== "string" || typeof record.status !== "number") {
+    return null;
+  }
+  return {
+    url: record.url,
+    status: record.status,
+    body: typeof record.body === "string" ? record.body : "",
+  };
+}
 
 function toMessage(error: unknown): string {
   const raw =
@@ -77,6 +129,50 @@ export function describeHostedOAuthFailure(
   const message = toMessage(error);
   if (!message) {
     return null;
+  }
+
+  // Structured shapes first: once the backend classifies a refresh failure it
+  // answers with a code and a generic message ("Hosted OAuth refresh token is
+  // invalid. Please reconnect.") that no provider-message regex below can
+  // match — the regexes only ever see errors the backend did NOT classify.
+  const { code, details } = structuredPartsOf(error);
+
+  if (
+    code === "authorization_server_unreachable" ||
+    details?.authorizationServerUnreachable === true
+  ) {
+    const failure = failureOf(details);
+    if (failure) {
+      return {
+        kind: "unreachable",
+        title: `Could not reach ${hostOf(failure.url) ?? failure.url}`,
+        detail: [
+          failure.url,
+          failure.body
+            ? `HTTP ${failure.status}, ${failure.body}`
+            : `HTTP ${failure.status}`,
+        ],
+        action: "retry",
+      };
+    }
+    return {
+      kind: "unreachable",
+      title: "Could not reach the authorization server",
+      detail: [message],
+      action: "retry",
+    };
+  }
+
+  if (
+    code === "refresh_token_invalid" ||
+    details?.refreshTokenInvalid === true
+  ) {
+    return {
+      kind: "declined",
+      title: `Refresh token declined for ${serverName}`,
+      detail: [message],
+      action: "reconnect",
+    };
   }
 
   const metadata = message.match(METADATA_FAILURE);

--- a/mcpjam-inspector/server/utils/__tests__/hosted-oauth-refresh.test.ts
+++ b/mcpjam-inspector/server/utils/__tests__/hosted-oauth-refresh.test.ts
@@ -86,6 +86,82 @@ describe("forceRefreshHostedOAuthAccessToken", () => {
     });
   });
 
+  it("forwards the recorded failure on authorization_server_unreachable", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () =>
+        new Response(
+          JSON.stringify({
+            success: false,
+            code: "authorization_server_unreachable",
+            message: "Could not reach the authorization server (HTTP 502).",
+            detail: {
+              url: "https://eliya.descope.team/oauth2/v1/apps/token",
+              status: 502,
+              body: '{"title":"Error 502: Bad gateway"}',
+            },
+          }),
+          { status: 503, headers: { "Content-Type": "application/json" } }
+        )
+      )
+    );
+
+    await expect(
+      forceRefreshHostedOAuthAccessToken(
+        "bearer-token",
+        "project-1",
+        "server-1",
+        { serverName: "Descope" }
+      )
+    ).rejects.toMatchObject({
+      status: 503,
+      code: "authorization_server_unreachable",
+      message: "Could not reach the authorization server (HTTP 502).",
+      details: {
+        authorizationServerUnreachable: true,
+        serverId: "server-1",
+        serverName: "Descope",
+        failure: {
+          url: "https://eliya.descope.team/oauth2/v1/apps/token",
+          status: 502,
+          body: '{"title":"Error 502: Bad gateway"}',
+        },
+      },
+    });
+  });
+
+  it("keeps failure null when the backend recorded nothing", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () =>
+        new Response(
+          JSON.stringify({
+            success: false,
+            code: "authorization_server_unreachable",
+            message: "Could not reach the authorization server.",
+            detail: null,
+          }),
+          { status: 503, headers: { "Content-Type": "application/json" } }
+        )
+      )
+    );
+
+    await expect(
+      forceRefreshHostedOAuthAccessToken(
+        "bearer-token",
+        "project-1",
+        "server-1"
+      )
+    ).rejects.toMatchObject({
+      status: 503,
+      code: "authorization_server_unreachable",
+      details: {
+        authorizationServerUnreachable: true,
+        failure: null,
+      },
+    });
+  });
+
   it("propagates a non-refresh error code as the WebRouteError code", async () => {
     vi.stubGlobal(
       "fetch",

--- a/mcpjam-inspector/server/utils/hosted-oauth-refresh.ts
+++ b/mcpjam-inspector/server/utils/hosted-oauth-refresh.ts
@@ -85,6 +85,11 @@ export async function forceRefreshHostedOAuthAccessToken(
         ? body.message
         : `OAuth refresh failed (${response.status})`;
     const isReconnectRequired = code === "refresh_token_invalid";
+    // The backend's 503: the credential is fine, the authorization server
+    // never answered usably. Its `detail` is what that server actually
+    // returned ({url, status, body}) — forwarded so the client can name the
+    // host instead of guessing, null when the backend recorded nothing.
+    const isAuthServerUnreachable = code === "authorization_server_unreachable";
     throw new WebRouteError(
       response.status,
       isReconnectRequired ? ErrorCode.UNAUTHORIZED : (code as ErrorCode),
@@ -95,6 +100,13 @@ export async function forceRefreshHostedOAuthAccessToken(
             refreshTokenInvalid: true,
             serverId,
             serverName: options?.serverName ?? null,
+          }
+        : isAuthServerUnreachable
+        ? {
+            authorizationServerUnreachable: true,
+            serverId,
+            serverName: options?.serverName ?? null,
+            failure: body?.detail ?? null,
           }
         : undefined
     );


### PR DESCRIPTION
Client half of backend MCPJam/mcpjam-backend#927 (follow-up to #3843 and backend #922). That PR classifies token-endpoint refresh failures before they reach the client — which quietly broke the toast parser's assumptions:

- A **decline** now arrives as a 401 with the backend's generic message ("Hosted OAuth refresh token is invalid. Please reconnect.") — matched by **none** of #3843's provider-message regexes, so the user got no toast.
- An **unreachable authorization server** (Cloudflare 502 for `eliya.descope.team`, Akamai's HTML wall at `gateway.mcp.rkt.zone/token`) arrives as a 503 whose recorded response (`{url, status, body}`) the inspector server route dropped on the floor.

## What changes

**Server** (`hosted-oauth-refresh.ts`): on `authorization_server_unreachable`, the `WebRouteError` now carries `details.failure` — the response the backend recorded off the authorization server, forwarded verbatim (null when nothing was recorded). `webError` already serializes details, and `webPost` already rebuilds them client-side; only this hop was dropping it.

**Client** (`hosted-oauth-failure.ts`): classify structurally before message parsing —

- `authorization_server_unreachable` → "Could not reach eliya.descope.team" with the URL and `HTTP 502, <body>` the backend recorded, **Retry** action, credential untouched. Falls back to the backend message when no failure was recorded. Every rendered value is read off the error, preserving #3843's no-fabrication invariant.
- `details.refreshTokenInvalid` → "Refresh token declined", **Reconnect** action. This is the shape all backend-classified declines (invalid_grant, invalid_client, non-conformant dialects) now share.
- The message regexes remain for errors the backend did **not** classify (older backend, uncaught paths), widened with the `invalid_client` family ("Unknown client", "Invalid client_id", "Client authentication failed" — real CONVEX-PY messages) → Reconnect, since re-running authorize is what re-registers the client.

No changes to `use-hosted-oauth-gate.ts` — the toast call site and Retry/Reconnect actions from #3843 work as-is.

## Tests

- Server: the 503 forwarding pinned with the real Convex response shape, including the `failure: null` case (22 tests across both files).
- Client: structured 503 with/without recorded failure, the backend's generic 401, and the three real `invalid_client` messages from Sentry.
- `typecheck:client` and `build:inspector` pass.

Works with the deployed backend either way: structured shapes light up when #927 reaches prod; the regex fallbacks cover everything before that.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> User-facing OAuth error copy and error-detail forwarding only; no auth flow or credential storage changes.
> 
> **Overview**
> Restores hosted OAuth failure toasts after the backend started classifying refresh errors with generic messages and structured codes that the client’s regex-only parser no longer matched.
> 
> **Inspector server:** On `authorization_server_unreachable`, `forceRefreshHostedOAuthAccessToken` now attaches `details.failure` (the backend’s recorded `{url, status, body}`) instead of dropping it on this hop.
> 
> **Client `describeHostedOAuthFailure`:** Checks `code` / `details` before message regexes—503 + `authorizationServerUnreachable` → unreachable copy with host from the recorded URL and **Retry**; `refreshTokenInvalid` (including remapped 401) → declined copy with **Reconnect**. Regex fallbacks stay for unclassified errors, with `invalid_client`-style phrases added to the decline pattern.
> 
> Tests cover server forwarding (with and without `failure`), structured client shapes, and real `invalid_client` message strings.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 51a2ec7f66f1e6e581e4f74ae6c08ea9d0fe494a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Show toasts for backend-classified OAuth refresh failures and forward recorded auth-server responses so the UI can display the host, URL, and status. Fixes missing toasts for declines and unreachable authorization servers.

- **Bug Fixes**
  - Server: include `details.failure` `{url, status, body}` on 503 `authorization_server_unreachable` and forward it in `WebRouteError`.
  - Client: handle structured errors before regex parsing.
    - `authorization_server_unreachable` → "Could not reach <host>" with URL and `HTTP <status>[, <body>]`, action: Retry.
    - `details.refreshTokenInvalid` → "Refresh token declined", action: Reconnect.
  - Expand regex fallback to catch the `invalid_client` family and map to Reconnect.
  - Tests cover structured 503 with/without `failure`, generic 401 declines, and real `invalid_client` messages.

<sup>Written for commit 51a2ec7f66f1e6e581e4f74ae6c08ea9d0fe494a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/MCPJam/inspector/pull/3862?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

