### PR TITLE
fix(oauth): stop redacting live tokens in the hosted request executor

### DIFF
--- a/mcpjam-inspector/client/src/lib/oauth/__tests__/executor-token-integrity.test.ts
+++ b/mcpjam-inspector/client/src/lib/oauth/__tests__/executor-token-integrity.test.ts
@@ -1,0 +1,228 @@
+/**
+ * The OAuth request executor feeds LIVE data to the state machine. Redaction
+ * belongs to the trace layer only.
+ *
+ * Regression: in hosted mode the executor used to run the token response
+ * through `traceOAuthValue`, rewriting `access_token` to
+ * `abcd...[redacted]...yz`. That is still a non-empty string, so it passed the
+ * `!state.accessToken` guard and went upstream as
+ * `Authorization: Bearer abcd...[redacted]...yz`, which resource servers reject
+ * with `401 invalid_token`. The trace path must keep redacting; the executor
+ * must not.
+ */
+
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const {
+  mockAuthFetch,
+  mockRunOAuthStateMachine,
+  mockDiscoverOAuthServerInfo,
+  mockDiscoverAuthorizationServerMetadata,
+  mockRegisterClient,
+  mockSelectResourceURL,
+  mockStartAuthorization,
+} = vi.hoisted(() => ({
+  mockAuthFetch: vi.fn(),
+  mockRunOAuthStateMachine: vi.fn(),
+  mockDiscoverOAuthServerInfo: vi.fn(),
+  mockDiscoverAuthorizationServerMetadata: vi.fn(),
+  mockRegisterClient: vi.fn(),
+  mockSelectResourceURL: vi.fn(),
+  mockStartAuthorization: vi.fn(),
+}));
+
+// Hosted mode is the configuration that exhibited the bug: SANITIZE_OAUTH_TRACES
+// is derived from HOSTED_MODE, so locally the redaction is off and this
+// regression is invisible.
+vi.mock("@/lib/config", async () => {
+  const actual = await vi.importActual<typeof import("@/lib/config")>(
+    "@/lib/config"
+  );
+  return { ...actual, HOSTED_MODE: true, SANITIZE_OAUTH_TRACES: true };
+});
+
+vi.mock("@/lib/session-token", () => ({ authFetch: mockAuthFetch }));
+
+vi.mock("@mcpjam/sdk/browser", async () => {
+  const actual = await vi.importActual<typeof import("@mcpjam/sdk/browser")>(
+    "@mcpjam/sdk/browser"
+  );
+  return {
+    ...actual,
+    runOAuthStateMachine: mockRunOAuthStateMachine,
+    discoverOAuthServerInfo: mockDiscoverOAuthServerInfo,
+    discoverAuthorizationServerMetadata:
+      mockDiscoverAuthorizationServerMetadata,
+    registerClient: mockRegisterClient,
+    selectResourceURL: mockSelectResourceURL,
+    startAuthorization: mockStartAuthorization,
+  };
+});
+
+const ACCESS_TOKEN = "ntn_supersecretaccesstokenvalue1234567890";
+const REFRESH_TOKEN = "rt_supersecretrefreshtokenvalue0987654321";
+
+/** Runs initiateOAuth far enough to capture the executor it builds. */
+async function captureRequestExecutor() {
+  mockRegisterClient.mockResolvedValue({ client_id: "test-client-id" });
+  mockSelectResourceURL.mockResolvedValue(
+    new URL("https://mcp.example.com/mcp")
+  );
+  mockStartAuthorization.mockResolvedValue({
+    authorizationUrl: new URL("https://auth.example.com/authorize"),
+    codeVerifier: "code-verifier",
+  });
+
+  const authorizationServerMetadata = {
+    issuer: "https://auth.example.com",
+    authorization_endpoint: "https://auth.example.com/authorize",
+    token_endpoint: "https://auth.example.com/token",
+    registration_endpoint: "https://auth.example.com/register",
+  };
+  mockDiscoverAuthorizationServerMetadata.mockResolvedValue(
+    authorizationServerMetadata
+  );
+  mockDiscoverOAuthServerInfo.mockResolvedValue({
+    authorizationServerUrl: "https://auth.example.com",
+    resourceMetadataUrl:
+      "https://mcp.example.com/.well-known/oauth-protected-resource/mcp",
+    resourceMetadata: {
+      resource: "https://mcp.example.com/mcp",
+      authorization_servers: ["https://auth.example.com"],
+    },
+    authorizationServerMetadata,
+  });
+
+  let requestExecutor: any;
+  mockRunOAuthStateMachine.mockImplementation(async (opts: any) => {
+    requestExecutor = opts.requestExecutor;
+    return { status: "authorization_required", authorizationUrl: "https://x" };
+  });
+
+  const { initiateOAuth } = await import("../mcp-oauth");
+  await initiateOAuth({
+    serverName: "integrity-probe",
+    serverUrl: "https://mcp.example.com/mcp",
+  } as any);
+
+  expect(requestExecutor, "executor was not captured").toBeTypeOf("function");
+  return requestExecutor;
+}
+
+describe("OAuth request executor token integrity", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    localStorage.clear();
+  });
+
+  it("returns the token response verbatim in hosted mode", async () => {
+    const requestExecutor = await captureRequestExecutor();
+
+    mockAuthFetch.mockResolvedValue(
+      new Response(
+        JSON.stringify({
+          status: 200,
+          statusText: "OK",
+          headers: { "content-type": "application/json" },
+          body: {
+            access_token: ACCESS_TOKEN,
+            refresh_token: REFRESH_TOKEN,
+            token_type: "Bearer",
+            expires_in: 3600,
+          },
+        }),
+        { status: 200, headers: { "content-type": "application/json" } }
+      )
+    );
+
+    const result = await requestExecutor({
+      url: "https://auth.example.com/token",
+      method: "POST",
+      headers: { "content-type": "application/x-www-form-urlencoded" },
+      body: { grant_type: "authorization_code", code: "auth-code" },
+    });
+
+    const body = result.body as Record<string, unknown>;
+    expect(body.access_token).toBe(ACCESS_TOKEN);
+    expect(body.refresh_token).toBe(REFRESH_TOKEN);
+    expect(String(body.access_token)).not.toContain("[redacted]");
+  });
+
+  it("returns registration responses verbatim in hosted mode", async () => {
+    const requestExecutor = await captureRequestExecutor();
+
+    mockAuthFetch.mockResolvedValue(
+      new Response(
+        JSON.stringify({
+          status: 201,
+          statusText: "Created",
+          headers: { "content-type": "application/json" },
+          body: {
+            client_id: "generated-client-id",
+            client_secret: "cs_supersecretclientsecretvalue1234567890",
+          },
+        }),
+        { status: 200, headers: { "content-type": "application/json" } }
+      )
+    );
+
+    const result = await requestExecutor({
+      url: "https://auth.example.com/register",
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: { client_name: "MCPJam" },
+    });
+
+    const body = result.body as Record<string, unknown>;
+    expect(body.client_secret).toBe(
+      "cs_supersecretclientsecretvalue1234567890"
+    );
+    expect(String(body.client_secret)).not.toContain("[redacted]");
+  });
+
+  // The counterpart invariant: because the executor no longer redacts, the
+  // trace layer is the ONLY thing standing between a live token and anything
+  // rendered or persisted. Assert it still does its job on a raw body.
+  it("still redacts credentials when the trace is projected", async () => {
+    const { projectOAuthTraceSnapshot, createOAuthTraceProjectionContext } =
+      await vi.importActual<typeof import("@mcpjam/sdk/browser")>(
+        "@mcpjam/sdk/browser"
+      );
+
+    const snapshot = projectOAuthTraceSnapshot({
+      sanitize: true,
+      context: createOAuthTraceProjectionContext(),
+      state: {
+        currentStep: "token_request",
+        httpHistory: [
+          {
+            step: "token_request",
+            timestamp: 0,
+            request: {
+              method: "POST",
+              url: "https://auth.example.com/token",
+              headers: { authorization: `Bearer ${ACCESS_TOKEN}` },
+              body: { grant_type: "authorization_code", code: "auth-code" },
+            },
+            response: {
+              status: 200,
+              statusText: "OK",
+              headers: { "content-type": "application/json" },
+              body: {
+                access_token: ACCESS_TOKEN,
+                refresh_token: REFRESH_TOKEN,
+                token_type: "Bearer",
+              },
+            },
+          },
+        ],
+        infoLogs: [],
+      } as any,
+    });
+
+    const serialized = JSON.stringify(snapshot);
+    expect(serialized).not.toContain(ACCESS_TOKEN);
+    expect(serialized).not.toContain(REFRESH_TOKEN);
+    expect(serialized).toContain("[redacted]");
+  });
+});

--- a/mcpjam-inspector/client/src/lib/oauth/__tests__/executor-token-integrity.test.ts
+++ b/mcpjam-inspector/client/src/lib/oauth/__tests__/executor-token-integrity.test.ts
@@ -62,6 +62,15 @@ vi.mock("@mcpjam/sdk/browser", async () => {
 const ACCESS_TOKEN = "ntn_supersecretaccesstokenvalue1234567890";
 const REFRESH_TOKEN = "rt_supersecretrefreshtokenvalue0987654321";
 
+/**
+ * The direct (non-proxied) leg of the interceptor. mcp-oauth captures
+ * `const originalFetch = window.fetch` at module load, so this has to be
+ * installed before the module's first dynamic import — reassigning
+ * `window.fetch` from inside a test would be too late to be observed.
+ */
+const directFetch = vi.fn();
+window.fetch = directFetch as unknown as typeof fetch;
+
 /** Runs initiateOAuth far enough to capture the executor it builds. */
 async function captureRequestExecutor() {
   mockRegisterClient.mockResolvedValue({ client_id: "test-client-id" });
@@ -178,6 +187,48 @@ describe("OAuth request executor token integrity", () => {
       "cs_supersecretclientsecretvalue1234567890"
     );
     expect(String(body.client_secret)).not.toContain("[redacted]");
+  });
+
+  // The other changed site. When the direct fetch throws and the request
+  // targets the configured server URL, the executor retries through
+  // executeRequestViaProxy — a separate return path that also used to redact.
+  it("returns proxy-fallback responses verbatim in hosted mode", async () => {
+    const requestExecutor = await captureRequestExecutor();
+
+    // Force the direct attempt to fail so the executor takes the catch branch.
+    directFetch.mockRejectedValue(new TypeError("Failed to fetch"));
+
+    mockAuthFetch.mockResolvedValue(
+      new Response(
+        JSON.stringify({
+          status: 200,
+          statusText: "OK",
+          headers: { "content-type": "application/json" },
+          body: {
+            access_token: ACCESS_TOKEN,
+            refresh_token: REFRESH_TOKEN,
+            token_type: "Bearer",
+          },
+        }),
+        { status: 200, headers: { "content-type": "application/json" } }
+      )
+    );
+
+    // Must equal the executor's serverUrl, or shouldRetryMcpRequestViaProxy
+    // declines the retry and the throw propagates instead.
+    const result = await requestExecutor({
+      url: "https://mcp.example.com/mcp",
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: { jsonrpc: "2.0", id: 1, method: "initialize" },
+    });
+
+    const body = result.body as Record<string, unknown>;
+    expect(body.access_token).toBe(ACCESS_TOKEN);
+    expect(body.refresh_token).toBe(REFRESH_TOKEN);
+    expect(String(body.access_token)).not.toContain("[redacted]");
+    expect(directFetch).toHaveBeenCalled();
+    expect(mockAuthFetch).toHaveBeenCalled();
   });
 
   // The counterpart invariant: because the executor no longer redacts, the

--- a/mcpjam-inspector/client/src/lib/oauth/mcp-oauth.ts
+++ b/mcpjam-inspector/client/src/lib/oauth/mcp-oauth.ts
@@ -456,6 +456,21 @@ function normalizeResponseHeaders(headers: Headers): Record<string, string> {
   return normalized;
 }
 
+/**
+ * Parse a response body that the OAuth flow CONSUMES as live data (tokens,
+ * client registrations). Deliberately NOT redacted: `traceOAuthValue` rewrites
+ * `access_token` to `abcd...[redacted]...yz`, and in hosted mode
+ * (`SANITIZE_OAUTH_TRACES = HOSTED_MODE`) that redacted string is still a
+ * non-empty string, so it sails past every truthiness check and gets sent
+ * upstream as `Authorization: Bearer abcd...[redacted]...yz` — which the
+ * resource server rejects as an invalid token.
+ *
+ * Redaction belongs to the trace layer, which applies it independently:
+ * `readResponseBodyForTrace` for trace-only reads, and
+ * `projectOAuthTraceSnapshot({ sanitize })` for anything derived from
+ * `httpHistory`/`lastResponse`. Persisted flow state additionally drops
+ * history wholesale via `stripOAuthTraceDataFromFlowState`.
+ */
 async function parseOAuthResponseBody(response: Response): Promise<unknown> {
   const text = await response.text();
   if (!text) {
@@ -463,7 +478,7 @@ async function parseOAuthResponseBody(response: Response): Promise<unknown> {
   }
 
   const contentType = response.headers.get("content-type")?.toLowerCase() ?? "";
-  return traceOAuthValue(parseOAuthResponseText(text, contentType));
+  return parseOAuthResponseText(text, contentType);
 }
 
 function serializeOAuthRequestBody(
@@ -778,10 +793,13 @@ async function executeRequestViaProxy(
   };
 
   return {
+    // Live data the flow consumes — not redacted. See parseOAuthResponseBody.
+    // The trace copy of this exchange is built separately by
+    // createTraceResponseFromResult, which does redact.
     status: proxied.status,
     statusText: proxied.statusText,
     headers: proxied.headers ?? {},
-    body: traceOAuthValue(proxied.body),
+    body: proxied.body,
     ok: proxied.status >= 200 && proxied.status < 300,
   };
 }

--- a/sdk/src/oauth/state-machines/trace.ts
+++ b/sdk/src/oauth/state-machines/trace.ts
@@ -208,6 +208,29 @@ function sanitizeOAuthUrl(rawUrl: string): string {
   }
 }
 
+/**
+ * Redact credential-shaped substrings from a free-form error message.
+ *
+ * Error strings interpolate upstream response fields — e.g.
+ * `Token request failed: ${body.error} - ${body.error_description}` — so an
+ * authorization server that echoes a credential back in `error_description`
+ * would otherwise land it verbatim in rendered trace output.
+ *
+ * Unlike `sanitizeOAuthTraceString`, this never re-shapes the value into an
+ * object: an error message must stay a human-readable string. The key list is
+ * kept identical to that function's so redaction behaves predictably across
+ * both paths.
+ */
+function sanitizeTraceErrorMessage(message: string): string {
+  return message
+    .replace(
+      /\b(access_token|refresh_token|id_token|client_secret|code_verifier)\b(\s*[:=]\s*)([^\s&,;]+)/gi,
+      (_match, key: string, separator: string) =>
+        `${key}${separator}[redacted]`,
+    )
+    .replace(/\bBearer\s+[A-Za-z0-9._~+/=-]+\b/gi, "Bearer [redacted]");
+}
+
 function sanitizeOAuthTraceString(value: string): unknown {
   const trimmed = value.trim();
   if (!trimmed) {
@@ -308,6 +331,11 @@ function sanitizeHttpHistoryEntry(entry: HttpHistoryEntry): HttpHistoryEntry {
       ? {
           error: {
             ...entry.error,
+            // `message` is free-form and interpolates upstream fields, so it
+            // needs redacting just as much as `details` does.
+            ...(entry.error.message
+              ? { message: sanitizeTraceErrorMessage(entry.error.message) }
+              : {}),
             details: sanitizeOAuthTraceValue(entry.error.details),
           },
         }
@@ -531,7 +559,13 @@ export function projectOAuthTraceSnapshot(input: {
     httpHistory: (state.httpHistory ?? []).map((entry) =>
       sanitizeTraces ? sanitizeHttpHistoryEntry(entry) : cloneHttpHistoryEntry(entry),
     ),
-    ...(state.error ? { error: state.error } : {}),
+    ...(state.error
+      ? {
+          error: sanitizeTraces
+            ? sanitizeTraceErrorMessage(state.error)
+            : state.error,
+        }
+      : {}),
   };
 
   const currentStepIndex = getStepIndex(state.currentStep);
@@ -555,7 +589,9 @@ export function projectOAuthTraceSnapshot(input: {
     }
     const entryError = inferHttpHistoryEntryError(entry);
     if (entryError) {
-      record.error = entryError;
+      record.error = sanitizeTraces
+        ? sanitizeTraceErrorMessage(entryError)
+        : entryError;
     }
   }
 
@@ -574,7 +610,9 @@ export function projectOAuthTraceSnapshot(input: {
       record.details = logData as Record<string, unknown>;
     }
     if (log.error?.message) {
-      record.error = log.error.message;
+      record.error = sanitizeTraces
+        ? sanitizeTraceErrorMessage(log.error.message)
+        : log.error.message;
     }
   }
 
@@ -673,7 +711,9 @@ export function projectOAuthTraceSnapshot(input: {
     inferStepEntry(entries, context, state.currentStep, true, undefined, sanitizeTraces);
     const currentEntry = entries.get(state.currentStep);
     if (currentEntry) {
-      currentEntry.error = state.error;
+      currentEntry.error = sanitizeTraces
+        ? sanitizeTraceErrorMessage(state.error)
+        : state.error;
     }
   }
 

--- a/sdk/tests/oauth/trace-projection.test.ts
+++ b/sdk/tests/oauth/trace-projection.test.ts
@@ -90,4 +90,67 @@ describe("OAuth trace projection", () => {
     });
     expect(codeStep?.details).toMatchObject({ code: "auth-code-abc123" });
   });
+
+  // Regression: error strings interpolate upstream response fields (e.g.
+  // `Token request failed: ${body.error} - ${body.error_description}`). Once
+  // the request executor stopped redacting live response bodies, an AS that
+  // echoes a credential back in error_description would reach rendered trace
+  // output verbatim unless the projection redacts error strings too.
+  it("redacts credentials echoed into error messages when sanitizing", () => {
+    const leaked =
+      "Token request failed: invalid_client - client_secret=cs_supersecretvalue1234567890 was rejected";
+
+    const snapshot = projectOAuthTraceSnapshot({
+      state: {
+        ...EMPTY_OAUTH_FLOW_STATE,
+        currentStep: "token_request",
+        error: leaked,
+        httpHistory: [
+          {
+            step: "token_request",
+            timestamp: 1_000,
+            request: {
+              method: "POST",
+              url: "https://auth.example.com/token",
+              headers: {},
+              body: { grant_type: "authorization_code" },
+            },
+            error: {
+              message:
+                "upstream said Bearer ntn_supersecretaccesstokenvalue1234567890",
+            },
+          },
+        ],
+        infoLogs: [],
+      },
+      sanitize: true,
+    });
+
+    const serialized = JSON.stringify(snapshot);
+    expect(serialized).not.toContain("cs_supersecretvalue1234567890");
+    expect(serialized).not.toContain("ntn_supersecretaccesstokenvalue1234567890");
+    expect(snapshot.error).toContain("client_secret=[redacted]");
+    // The message must stay a readable string, not be reshaped into an object.
+    expect(typeof snapshot.error).toBe("string");
+    expect(snapshot.error).toContain("Token request failed: invalid_client");
+
+    const tokenStep = snapshot.steps.find((step) => step.step === "token_request");
+    expect(tokenStep?.error).toContain("Bearer [redacted]");
+  });
+
+  it("leaves error messages intact when sanitize is false", () => {
+    const raw = "Token request failed: client_secret=cs_localdevsecret123456";
+    const snapshot = projectOAuthTraceSnapshot({
+      state: {
+        ...EMPTY_OAUTH_FLOW_STATE,
+        currentStep: "token_request",
+        error: raw,
+        httpHistory: [],
+        infoLogs: [],
+      },
+      sanitize: false,
+    });
+
+    expect(snapshot.error).toBe(raw);
+  });
 });


### PR DESCRIPTION
## The bug

In hosted mode, OAuth into a server fails with `Error completing OAuth flow: Authenticated request failed: 401`. The token exchange genuinely succeeds — the token is destroyed on our side, immediately after.

`createOAuthRequestExecutor` is the request executor handed to the OAuth state machines. It ran the response body through `traceOAuthValue` before returning it, so the body the state machine consumed as **live data** was the redacted trace copy:

```
mcp-oauth.ts  parseOAuthResponseBody()  → traceOAuthValue(parsed)
              createOAuthRequestExecutor → body: await parseOAuthResponseBody(...)
              initiateOAuth / handleOAuthCallback → requestExecutor
```

`access_token` is in `SENSITIVE_FIELD_NAMES`, so `redactSensitiveValue` rewrote it to `first4 + "...[redacted]..." + last2`. That is still a **non-empty string**, so it passes the `!state.accessToken` guard, gets stored via `accessToken: tokens.access_token`, and goes out as:

```
Authorization: Bearer ntn_...[redacted]...90   →   401 invalid_token
```

`client_secret` is on the same list, so dynamic client registration was corrupted the same way — DCR clients were issued a mangled secret.

**Scope:** hosted only. `SANITIZE_OAUTH_TRACES = HOSTED_MODE`, so the redaction is off in local dev and the bug is invisible there.

## The fix

Return the raw parsed body from the two sites that feed live data to the state machine — `parseOAuthResponseBody` and `executeRequestViaProxy`.

Nothing leaks as a result. Redaction was already applied independently by the trace layer, which is untouched:

- `readResponseBodyForTrace` — trace-only reads, still redacts
- `createTraceResponseFromResult` — the trace copy of a proxied exchange, still redacts
- `projectOAuthTraceSnapshot({ sanitize })` — `sanitizeHttpHistoryEntry` scrubs request *and* response bodies for anything rendered
- `stripOAuthTraceDataFromFlowState` — persisted flow state drops `httpHistory` / `lastResponse` wholesale

## Tests

`executor-token-integrity.test.ts` captures the real executor from `initiateOAuth` (no mocking of the exchange itself) with hosted config, and asserts both directions:

1. token responses come back verbatim
2. registration responses come back verbatim
3. a projected trace over a **raw** body still redacts

Verified they fail without the fix:

```
× returns the token response verbatim in hosted mode
  → expected 'ntn_...[redacted]...90' to be 'ntn_supersecretaccesstokenvalue1234567890'
× returns registration responses verbatim in hosted mode
  → expected 'cs_s...[redacted]...90' to be 'cs_supersecretclientsecretvalue1234567890'
```

`npm run typecheck:client` clean; 409 tests pass across `client/src/lib/oauth`, `client/src/state`, and `use-server-state`.

## Note for reviewers

This does not explain why some hosted connections still work today. `handleOAuthCallback` branches on `if (storedSession)`: flows started by `initiateOAuth` always save a flow session and take the state-machine path (broken); anything reaching the callback without one falls through to the legacy `exchangeAuthorization` path, which never touches this executor. That second path is why the failure looks inconsistent between deployments. Worth a follow-up to decide whether the legacy branch should still exist.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches OAuth token handling and hosted auth flows; the change is narrowly scoped but incorrect redaction boundaries could leak secrets in traces or break token exchange again.
> 
> **Overview**
> **Fixes hosted OAuth 401s** caused by the request executor feeding the state machine **redacted** token/registration bodies (`traceOAuthValue`) while hosted mode enables trace sanitization — mangled `access_token` / `client_secret` values still looked valid and were sent as `Authorization: Bearer …[redacted]…`.
> 
> **`mcp-oauth.ts`** now returns **raw parsed bodies** from `parseOAuthResponseBody` and the proxy fallback in `executeRequestViaProxy`; redaction stays on trace-only paths (`readResponseBodyForTrace`, `createTraceResponseFromResult`, `projectOAuthTraceSnapshot`).
> 
> **SDK trace projection** adds `sanitizeTraceErrorMessage` so free-form `state.error`, step errors, and HTTP history error messages still scrub echoed credentials when sanitizing — covered by **`executor-token-integrity.test.ts`** and **`trace-projection.test.ts`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ad8caf57d9a437a7522cb53495f948759ab2c4b0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes hosted OAuth by returning unredacted token and registration responses from the request executor and sanitizing trace error strings. Prevents 401s from mangled tokens and blocks secret leaks in rendered traces.

- **Bug Fixes**
  - Return raw bodies from `parseOAuthResponseBody` and `executeRequestViaProxy` for live flows; traces still sanitize. Tests cover token/registration integrity and the proxy-fallback path.
  - Redact credentials in trace error strings in `projectOAuthTraceSnapshot` (state/step errors and `httpHistory[].error.message`). Tests assert sanitized errors when `sanitize` is true and unchanged when false.

<sup>Written for commit ad8caf57d9a437a7522cb53495f948759ab2c4b0. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/MCPJam/inspector/pull/3865?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

