### PR TITLE
Surface the debug proxy's error reason in the OAuth debugger

### DIFF
--- a/mcpjam-inspector/client/src/lib/oauth/__tests__/debug-state-machine-adapter.test.ts
+++ b/mcpjam-inspector/client/src/lib/oauth/__tests__/debug-state-machine-adapter.test.ts
@@ -275,6 +275,20 @@ describe("Inspector OAuth debug proxy failures", () => {
     );
   });
 
+  // The cap applies to whichever branch produced the reason, not just the
+  // raw-text fallback — a JSON `error` is just as capable of being huge.
+  it.each([
+    ["json", JSON.stringify({ error: "x".repeat(1000) })],
+    ["raw text", "x".repeat(1000)],
+  ])("caps a long %s reason", async (_label, body) => {
+    authFetchMock.mockResolvedValue(proxyFailure(body));
+
+    const error = await createDebugRequestExecutor()(request).catch((e) => e);
+    expect(error.message).toBe(
+      `Backend debug proxy error: 400 Bad Request: ${"x".repeat(300)}`,
+    );
+  });
+
   it("keeps the bare status line when the body is empty", async () => {
     authFetchMock.mockResolvedValue(proxyFailure(""));
 

--- a/mcpjam-inspector/client/src/lib/oauth/__tests__/debug-state-machine-adapter.test.ts
+++ b/mcpjam-inspector/client/src/lib/oauth/__tests__/debug-state-machine-adapter.test.ts
@@ -4,9 +4,11 @@ import {
   type OAuthFlowState,
 } from "@mcpjam/sdk/browser";
 import {
+  createDebugRequestExecutor,
   createInspectorOAuthStateMachine,
   type InspectorOAuthStateMachineConfig,
 } from "../debug-state-machine-adapter";
+import { authFetch } from "@/lib/session-token";
 
 const createOAuthStateMachineSpy = vi.fn(() => ({
   proceedToNextStep: vi.fn(),
@@ -229,6 +231,56 @@ describe("Inspector OAuth adapter one-step stepping", () => {
     // scheduleAutoAdvance via optional chaining, so leaving it out is precisely
     // what stops the prepare -> send -> receive burst on a single click.
     expect("scheduleAutoAdvance" in config).toBe(false);
+  });
+});
+
+describe("Inspector OAuth debug proxy failures", () => {
+  const authFetchMock = vi.mocked(authFetch);
+  const request = {
+    method: "GET",
+    url: "https://mcp.example.com/mcp",
+    headers: {},
+  };
+
+  function proxyFailure(body: string) {
+    return new Response(body, { status: 400, statusText: "Bad Request" });
+  }
+
+  beforeEach(() => {
+    authFetchMock.mockReset();
+  });
+
+  // Without the body the flow log and Sentry only ever saw "400 Bad Request",
+  // which is the same string for an unresolvable host, a blocked private
+  // address, and a timeout (INSPECTOR-CLIENT-21M).
+  it("includes the proxy's reason for the failure", async () => {
+    authFetchMock.mockResolvedValue(
+      proxyFailure(
+        JSON.stringify({
+          error: "mcp.internal resolves to a private or reserved address",
+        }),
+      ),
+    );
+
+    await expect(createDebugRequestExecutor()(request)).rejects.toThrow(
+      "Backend debug proxy error: 400 Bad Request: mcp.internal resolves to a private or reserved address",
+    );
+  });
+
+  it("falls back to the raw body when the response is not JSON", async () => {
+    authFetchMock.mockResolvedValue(proxyFailure("<html>502 upstream</html>"));
+
+    await expect(createDebugRequestExecutor()(request)).rejects.toThrow(
+      "Backend debug proxy error: 400 Bad Request: <html>502 upstream</html>",
+    );
+  });
+
+  it("keeps the bare status line when the body is empty", async () => {
+    authFetchMock.mockResolvedValue(proxyFailure(""));
+
+    await expect(createDebugRequestExecutor()(request)).rejects.toThrow(
+      "Backend debug proxy error: 400 Bad Request",
+    );
   });
 });
 

--- a/mcpjam-inspector/client/src/lib/oauth/debug-state-machine-adapter.ts
+++ b/mcpjam-inspector/client/src/lib/oauth/debug-state-machine-adapter.ts
@@ -95,27 +95,35 @@ function serializeProxyBody(
   return body;
 }
 
+/** Cap on the reason text, so no failure body can become the error message. */
+const MAX_PROXY_ERROR_CHARS = 300;
+
 /**
  * The proxy route answers a failure with `{ error }` naming the guard that
  * rejected the request — unresolvable host, private/reserved address, timeout,
  * redirect cap. Dropping it leaves the flow log (and Sentry) with a bare status
  * line that says nothing about which one fired.
+ *
+ * Only the proxy hop's own failures land here: whenever the server under test
+ * answers at all, the route wraps that response in a 200, so this never sees a
+ * body from it.
  */
 async function readProxyError(response: Response): Promise<string | undefined> {
   const text = await response.text().catch(() => "");
   if (!text) return undefined;
+
+  let reason = text;
   try {
     const body = JSON.parse(text) as {
       message?: string;
       error?: string;
     } | null;
     const message = body?.message ?? body?.error;
-    if (typeof message === "string" && message) return message;
+    if (typeof message === "string" && message) reason = message;
   } catch {
-    // Not JSON — a reverse proxy or dev-server error page. Fall through to the
-    // raw text, capped so an HTML document cannot become the error message.
+    // Not JSON — a reverse proxy or dev-server error page. Report its text.
   }
-  return text.slice(0, 300);
+  return reason.slice(0, MAX_PROXY_ERROR_CHARS);
 }
 
 export function createDebugRequestExecutor(): OAuthRequestExecutor {

--- a/mcpjam-inspector/client/src/lib/oauth/debug-state-machine-adapter.ts
+++ b/mcpjam-inspector/client/src/lib/oauth/debug-state-machine-adapter.ts
@@ -95,6 +95,29 @@ function serializeProxyBody(
   return body;
 }
 
+/**
+ * The proxy route answers a failure with `{ error }` naming the guard that
+ * rejected the request — unresolvable host, private/reserved address, timeout,
+ * redirect cap. Dropping it leaves the flow log (and Sentry) with a bare status
+ * line that says nothing about which one fired.
+ */
+async function readProxyError(response: Response): Promise<string | undefined> {
+  const text = await response.text().catch(() => "");
+  if (!text) return undefined;
+  try {
+    const body = JSON.parse(text) as {
+      message?: string;
+      error?: string;
+    } | null;
+    const message = body?.message ?? body?.error;
+    if (typeof message === "string" && message) return message;
+  } catch {
+    // Not JSON — a reverse proxy or dev-server error page. Fall through to the
+    // raw text, capped so an HTML document cannot become the error message.
+  }
+  return text.slice(0, 300);
+}
+
 export function createDebugRequestExecutor(): OAuthRequestExecutor {
   return async (request) => {
     const debugProxyPath = HOSTED_MODE
@@ -119,8 +142,11 @@ export function createDebugRequestExecutor(): OAuthRequestExecutor {
     });
 
     if (!proxyResponse.ok) {
+      const reason = await readProxyError(proxyResponse);
       throw new Error(
-        `Backend debug proxy error: ${proxyResponse.status} ${proxyResponse.statusText}`,
+        `Backend debug proxy error: ${proxyResponse.status} ${proxyResponse.statusText}${
+          reason ? `: ${reason}` : ""
+        }`,
       );
     }
 


### PR DESCRIPTION
The OAuth debugger failed on its first real step: the unauthenticated request to the MCP server that should come back with a 401.

Before sending anything, our Node backend checks the target URL — valid URL, DNS resolves, not a private address. If a check fails, no request goes out.

A check failed, so the MCP server was never contacted. The 400 was ours, not theirs.

The backend's response explains which check failed, but the client kept only the status line (400 Bad Request) and dropped that explanation — so the cause was unknowable.

The client now reads it, so the next occurrence names the actual failure.