### PR TITLE
evals: contain the GitHub Checks availability read in a boundary

### DIFF
--- a/mcpjam-inspector/client/src/components/evals/__tests__/suite-iterations-github-checks.test.tsx
+++ b/mcpjam-inspector/client/src/components/evals/__tests__/suite-iterations-github-checks.test.tsx
@@ -1,0 +1,175 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { SuiteIterationsView } from "../suite-iterations-view";
+import type { EvalSuite } from "../types";
+
+/**
+ * The GitHub Checks availability read is allowed to THROW.
+ *
+ * It is a backend-decided gate, and the backend refuses (rather than answers)
+ * for a caller who is not a signed-in member of the org — `useQuery` re-throws
+ * that during render. These tests pin the consequence: the suite settings sheet
+ * loses the GitHub Checks section and nothing else.
+ */
+
+const mocks = vi.hoisted(() => ({
+  useMutation: vi.fn(() => vi.fn()),
+  useQuery: vi.fn(),
+  availability: vi.fn(),
+  reportBoundaryError: vi.fn(),
+}));
+
+vi.mock("convex/react", () => ({
+  useMutation: (name: any) => (mocks.useMutation as any)(name),
+  useQuery: (name: any, args: any) => (mocks.useQuery as any)(name, args),
+  useConvexAuth: () => ({ isAuthenticated: true, isLoading: false }),
+}));
+
+vi.mock("@workos-inc/authkit-react", () => ({
+  useAuth: () => ({ user: null, isLoading: false, signIn: vi.fn() }),
+}));
+
+vi.mock("@/hooks/useGithubChecksSettings", () => ({
+  GITHUB_CHECKS_UNAVAILABLE_MESSAGE:
+    "GitHub Checks settings are not currently available.",
+  useGithubChecksAvailability: (organizationId: unknown) =>
+    mocks.availability(organizationId),
+}));
+
+vi.mock("../suite-github-checks-section", () => ({
+  SuiteGithubChecksSection: () => <div data-testid="github-checks-section" />,
+}));
+
+vi.mock("@/lib/error-reporting", () => ({
+  reportBoundaryError: (...args: unknown[]) =>
+    mocks.reportBoundaryError(...args),
+}));
+
+vi.mock("@/hooks/useProjectComputer", () => ({
+  useEphemeralCloudAvailable: () => true,
+}));
+vi.mock("@/hooks/useProjectEnvironments", () => ({
+  useProjectEnvironments: () => [],
+}));
+
+vi.mock("../use-suite-data", () => ({
+  useSuiteData: () => ({ runTrendData: [], modelStats: [] }),
+  useRunDetailData: () => ({ caseGroupsForSelectedRun: [] }),
+}));
+
+vi.mock("../suite-header", () => ({
+  SuiteHeader: () => <div data-testid="suite-header" />,
+}));
+
+vi.mock("../eval-export-modal", () => ({ EvalExportModal: () => null }));
+
+vi.mock("@/state/app-state-context", () => ({
+  useSharedAppState: () => ({ servers: {} }),
+}));
+
+const noopNav = {
+  toSuiteOverview: vi.fn(),
+  toRunDetail: vi.fn(),
+  toTestDetail: vi.fn(),
+  toTestEdit: vi.fn(),
+  toSuiteEdit: vi.fn(),
+};
+
+const baseSuite: EvalSuite = {
+  _id: "suite-1",
+  createdBy: "u",
+  name: "Test Suite",
+  description: "",
+  configRevision: "r",
+  environment: { servers: [] },
+  createdAt: 1,
+  updatedAt: 1,
+  source: "ui",
+};
+
+function renderSettingsSheet() {
+  return render(
+    <SuiteIterationsView
+      suite={baseSuite}
+      cases={[]}
+      iterations={[]}
+      allIterations={[]}
+      runs={[]}
+      runsLoading={false}
+      aggregate={null}
+      onRerun={vi.fn()}
+      onCancelRun={vi.fn()}
+      onDelete={vi.fn()}
+      onDeleteRun={vi.fn()}
+      onDirectDeleteRun={vi.fn().mockResolvedValue(undefined)}
+      connectedServerNames={new Set()}
+      canDeleteSuite
+      rerunningSuiteId={null}
+      cancellingRunId={null}
+      deletingSuiteId={null}
+      deletingRunId={null}
+      availableModels={[]}
+      organizationId="org-1"
+      projectId="project-1"
+      route={{ type: "suite-edit", suiteId: "suite-1" }}
+      navigation={noopNav}
+    />
+  );
+}
+
+describe("SuiteIterationsView GitHub Checks gate", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.useMutation.mockReturnValue(vi.fn());
+    mocks.useQuery.mockImplementation(() => undefined);
+  });
+
+  it("keeps the settings sheet up when the availability read throws", () => {
+    mocks.availability.mockImplementation(() => {
+      throw new Error(
+        "[CONVEX Q(github/checkRepoConfigs:getGithubChecksSettingsAvailability)] Server Error"
+      );
+    });
+
+    renderSettingsSheet();
+
+    // The sheet survived: a sibling section still rendered.
+    expect(screen.getByText("Minimum iterations")).toBeTruthy();
+    // ...without the section whose gate refused.
+    expect(screen.queryByText("GitHub Checks")).toBeNull();
+    expect(screen.queryByTestId("github-checks-section")).toBeNull();
+  });
+
+  it("still reports the swallowed error to the error sinks", () => {
+    mocks.availability.mockImplementation(() => {
+      throw new Error("Not a member of this organization");
+    });
+
+    renderSettingsSheet();
+
+    // `fallback={null}` is a UI choice, never a telemetry one.
+    expect(mocks.reportBoundaryError).toHaveBeenCalled();
+    expect(mocks.reportBoundaryError.mock.calls[0]?.[2]).toBe(
+      "suite_github_checks"
+    );
+  });
+
+  it("hides the section when the backend answers `disabled`", () => {
+    mocks.availability.mockReturnValue({ state: "disabled" });
+
+    renderSettingsSheet();
+
+    expect(screen.getByText("Minimum iterations")).toBeTruthy();
+    expect(screen.queryByTestId("github-checks-section")).toBeNull();
+    expect(mocks.reportBoundaryError).not.toHaveBeenCalled();
+  });
+
+  it("renders the section when the backend answers `enabled`", () => {
+    mocks.availability.mockReturnValue({ state: "enabled" });
+
+    renderSettingsSheet();
+
+    expect(screen.getByText("GitHub Checks")).toBeTruthy();
+    expect(screen.getByTestId("github-checks-section")).toBeTruthy();
+  });
+});

--- a/mcpjam-inspector/client/src/components/evals/__tests__/suite-iterations-github-checks.test.tsx
+++ b/mcpjam-inspector/client/src/components/evals/__tests__/suite-iterations-github-checks.test.tsx
@@ -1,4 +1,4 @@
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { render, screen } from "@testing-library/react";
 import { SuiteIterationsView } from "../suite-iterations-view";
 import type { EvalSuite } from "../types";
@@ -122,6 +122,14 @@ describe("SuiteIterationsView GitHub Checks gate", () => {
     vi.clearAllMocks();
     mocks.useMutation.mockReturnValue(vi.fn());
     mocks.useQuery.mockImplementation(() => undefined);
+    // The throwing cases run the REAL boundary, whose componentDidCatch (and
+    // React itself) logs the full error + component stack. That noise on a
+    // passing run buries real failures, so it stays out of the output.
+    vi.spyOn(console, "error").mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
   });
 
   it("keeps the settings sheet up when the availability read throws", () => {

--- a/mcpjam-inspector/client/src/components/evals/suite-iterations-view.tsx
+++ b/mcpjam-inspector/client/src/components/evals/suite-iterations-view.tsx
@@ -52,6 +52,7 @@ import { SuiteDashboard } from "./suite-dashboard";
 import { ScheduleEditor } from "./schedule-editor";
 import { SuiteGithubChecksSection } from "./suite-github-checks-section";
 import { useGithubChecksAvailability } from "@/hooks/useGithubChecksSettings";
+import { ErrorBoundary } from "@/components/ui/error-boundary";
 import { EvalExportModal } from "./eval-export-modal";
 import { ExportTracesModal } from "./export-traces-modal";
 // SuiteExecutionConfigEditor was previously rendered on the suite settings
@@ -165,6 +166,52 @@ function SettingsSection({
       </div>
       <div className="space-y-3">{children}</div>
     </section>
+  );
+}
+
+/**
+ * The GitHub Checks section, availability read and chrome included.
+ *
+ * The read lives HERE rather than in `SuiteIterationsView` for one reason: it
+ * can throw, and it must be able to fail inside a boundary. Availability is
+ * backend-decided, and the backend REFUSES rather than answers for a caller who
+ * is not a signed-in member of the org (a guest actor, a stale org id in client
+ * state) — see `useGithubChecksSettings`. `useQuery` re-throws that during
+ * render, so a hook called in `SuiteIterationsView` itself takes the entire
+ * suite page down with it. It did: the two settings call sites have always
+ * wrapped this hook in an `ErrorBoundary`, the call site added here did not.
+ *
+ * A refused beta gate means "no section", never "no page", so the boundary at
+ * the render site below renders nothing. It still reports to Sentry — silence
+ * is the UI choice, not the telemetry one.
+ *
+ * Not a PostHog flag like its neighbours in the settings sheet: a client-side
+ * twin of a server-evaluated gate could disagree with it, offering a section
+ * whose every write the server then refuses. One authority, asked once.
+ */
+function SuiteGithubChecksSettingsSection({
+  suiteId,
+  projectId,
+  organizationId,
+}: {
+  suiteId: string;
+  projectId?: string | null;
+  organizationId?: string | null;
+}) {
+  const availability = useGithubChecksAvailability(organizationId);
+  if (availability?.state !== "enabled") return null;
+
+  return (
+    <SettingsSection
+      label="GitHub Checks"
+      hint="Run this suite on every pull request to a connected repository."
+    >
+      <SuiteGithubChecksSection
+        suiteId={suiteId}
+        projectId={projectId}
+        organizationId={organizationId}
+      />
+    </SettingsSection>
   );
 }
 
@@ -705,12 +752,6 @@ export function SuiteIterationsView({
 
   const syntheticMonitorsEnabled =
     useFeatureFlagEnabled("synthetic-monitors") === true;
-  // Not a PostHog flag like its neighbours: GitHub Checks availability is
-  // decided BY THE BACKEND (org membership + a server-evaluated release gate),
-  // and a client-side twin could disagree with it — offering a section whose
-  // every write the server then refuses. One authority, asked once.
-  const githubChecksEnabled =
-    useGithubChecksAvailability(organizationId)?.state === "enabled";
 
   const handleOpenSuiteExport = useCallback(() => {
     setExportState({
@@ -1609,18 +1650,13 @@ export function SuiteIterationsView({
               ) : null}
 
               {/* ── GitHub Checks (backend-gated) ────────────────────── */}
-              {githubChecksEnabled ? (
-                <SettingsSection
-                  label="GitHub Checks"
-                  hint="Run this suite on every pull request to a connected repository."
-                >
-                  <SuiteGithubChecksSection
-                    suiteId={suite._id}
-                    projectId={projectId}
-                    organizationId={organizationId}
-                  />
-                </SettingsSection>
-              ) : null}
+              <ErrorBoundary name="suite_github_checks" fallback={null}>
+                <SuiteGithubChecksSettingsSection
+                  suiteId={suite._id}
+                  projectId={projectId}
+                  organizationId={organizationId}
+                />
+              </ErrorBoundary>
 
               {/* ── LLM as Judge ─────────────────────────────────────── */}
               <SettingsSection

--- a/mcpjam-inspector/client/src/components/evals/suite-iterations-view.tsx
+++ b/mcpjam-inspector/client/src/components/evals/suite-iterations-view.tsx
@@ -1650,7 +1650,16 @@ export function SuiteIterationsView({
               ) : null}
 
               {/* ── GitHub Checks (backend-gated) ────────────────────── */}
-              <ErrorBoundary name="suite_github_checks" fallback={null}>
+              {/* Keyed by org id: the boundary holds its error state forever
+                  once tripped (fallback={null} exposes no reset), and the org
+                  id here comes from client state — a stale value that later
+                  corrects itself must remount the boundary and re-ask, or the
+                  section stays hidden for the rest of the session. */}
+              <ErrorBoundary
+                key={organizationId ?? "no-organization"}
+                name="suite_github_checks"
+                fallback={null}
+              >
                 <SuiteGithubChecksSettingsSection
                   suiteId={suite._id}
                   projectId={projectId}

--- a/mcpjam-inspector/client/src/hooks/useGithubChecksSettings.ts
+++ b/mcpjam-inspector/client/src/hooks/useGithubChecksSettings.ts
@@ -16,13 +16,20 @@ import { useDbUserReady } from "@/contexts/db-user-ready-context";
  * types below are hand-mirrored from `convex/github/checkRepoConfigs.ts`. Keep
  * them in sync by hand — nothing checks this at build time.
  *
- * **These hooks can throw, and callers must treat a throw as "unavailable".**
- * `useQuery` re-throws query errors during render, and two ordinary cases
- * produce one here: the backend function is not deployed yet (the two repos
- * release independently), and a caller who is not a member of the active
- * organization (the backend throws there deliberately — answering `disabled`
- * would confirm the org exists). Both callers wrap these in an `ErrorBoundary`
- * for exactly that reason; see `SettingsNav` and `GithubChecksSettingsRoute`.
+ * **These hooks can throw, and every call site MUST sit inside an
+ * `ErrorBoundary`.** `useQuery` re-throws query errors during render, and
+ * ordinary cases produce one here: the backend function is not deployed yet
+ * (the two repos release independently), a guest actor (`signedInQuery` rejects
+ * guests at the boundary), and a caller who is not a member of the org the
+ * caller passed — the backend throws there deliberately, because answering
+ * `disabled` would confirm the org exists.
+ *
+ * The boundary is not optional and not defence in depth: a call in a component
+ * that is not itself inside one takes that component's whole page down. That is
+ * not hypothetical — the suite settings sheet shipped an unguarded call and
+ * crashed `/evals` for every user the backend refused. Call sites:
+ * `IntegrationsRoute`, `GithubChecksRoute`, and
+ * `SuiteGithubChecksSettingsSection` in `suite-iterations-view`.
  */
 
 /**


### PR DESCRIPTION
## The bug

Sentry, `prod`, release `2.35.0`, first seen ~3h after that release: 9 events / 4 users, all on `/evals/suite/<id>`, all the same shape.

```
Error: [CONVEX Q(github/checkRepoConfigs:getGithubChecksSettingsAvailability)] Server Error
  Called by client
  at useGithubChecksAvailability (client/src/hooks/useGithubChecksSettings.ts:75)
  at SuiteIterationsView (client/src/components/evals/suite-iterations-view.tsx:713)
```

The users lose the whole evals suite page — the global boundary catches it and swaps the page for an error state.

## Why it throws

`getGithubChecksSettingsAvailability` is a `signedInQuery` that runs `requireOrgRole(..., 'member')` before it answers. It **refuses** rather than answers for a caller it will not serve, and that refusal is deliberate, documented backend behaviour: answering `disabled` to a non-member would confirm the org exists. Three ordinary situations produce a throw:

- a guest actor — `signedInQuery` rejects guests at the boundary
- a caller who is not a member of the org that was passed
- the backend function not being deployed yet, since the two repos release independently

The org id in question comes from `useEvalTabContext` → `scopedProject?.organizationId`, i.e. the project's org as held in **client state**, so a stale or mismatched value lands in the same throw.

The message reads only `Server Error` because Convex scrubs non-`ConvexError` messages in production. The PostHog path is not involved: `isOrganizationFlagEnabled` catches everything and returns `false`.

**The backend is correct here and is unchanged by this PR.**

## Why it crashed the page

`useQuery` re-throws query errors during render, so a hook called in `SuiteIterationsView` itself fails the whole subtree. The hook's own docstring already said callers must treat a throw as "unavailable" and wrap it in an `ErrorBoundary` — and the two settings call sites (`IntegrationsRoute`, `GithubChecksRoute`) do exactly that. The call site added to the suite settings sheet in #3745 did not, which is why Sentry's suspect commit is right even though the crash only started with the 2.35.0 release.

## The fix

Move the availability read out of `SuiteIterationsView` and into a new `SuiteGithubChecksSettingsSection`, which owns the section chrome as well, and wrap that component in `<ErrorBoundary name="suite_github_checks" fallback={null}>`.

A refused beta gate now means "no section", never "no page". The boundary still reports to Sentry (`reportBoundaryError` runs regardless of which fallback renders), so nothing is lost from telemetry — the errors will keep arriving, now tagged `react_boundary:suite_github_checks` and no longer taking a page down. That is also how we will confirm which of the three refusals these four users are hitting; the Convex prod logs for the request ids carry the real message.

Also updates the hook's docstring: the boundary is a requirement of every call site, not defence in depth, and the previously named call sites had been renamed.

## Tests

New `client/src/components/evals/__tests__/suite-iterations-github-checks.test.tsx` — four cases over the suite settings sheet:

- availability read throws → sibling sections still render, GitHub Checks section is gone (the regression)
- availability read throws → still reported to the error sinks, tagged `suite_github_checks`
- backend answers `disabled` → section hidden, nothing reported
- backend answers `enabled` → section renders

Existing `suite-iterations-master-detail`, `suite-github-checks-section` and `components/settings` suites pass unchanged (55 tests). `tsc --noEmit` clean for the touched files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents the evals suite page from crashing by isolating the GitHub Checks availability read inside a section wrapped in an error boundary. The boundary is now keyed by org id so stale org state doesn’t hide the section for the whole session.

- **Bug Fixes**
  - Moved the availability read into `SuiteGithubChecksSettingsSection` and wrapped it with `<ErrorBoundary name="suite_github_checks" fallback={null}>`; returns null when unavailable.
  - Keyed the boundary by organization id to remount on org changes and re-check availability.
  - Errors still report to Sentry with the `suite_github_checks` tag; only the section is suppressed.
  - Updated `useGithubChecksAvailability` docs to require a boundary at every call site; tests cover enabled/disabled/throw and silence boundary logs.

<sup>Written for commit e8af2cad17345a9a8e15808a97cd756948da6e10. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/MCPJam/inspector/pull/3873?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

