### PR TITLE
fix(chatboxes): visitor-facing runtime copy stops calling every link a swarm

### DIFF
--- a/mcpjam-inspector/client/src/components/hosted/ChatboxChatPage.tsx
+++ b/mcpjam-inspector/client/src/components/hosted/ChatboxChatPage.tsx
@@ -81,10 +81,26 @@ interface ChatboxDisplayError {
   message: string;
 }
 
+/**
+ * Visitor-facing copy on the public chatbox runtime, and the reason none of it
+ * names a product.
+ *
+ * Whoever reads these strings followed a link someone sent them. They are not
+ * signed in to MCPJam, have never seen the dashboard, and "swarm" is a word
+ * they have no referent for — it named the internal surface the link happened
+ * to be created from. Worse, one `chatboxes` row backs BOTH a Swarm and a User
+ * Testing scenario (nothing on the row distinguishes them; `isDeliberateScenario`
+ * infers it client-side), so on the User Testing surface the noun was outright
+ * wrong: the author's own preview told them their scenario was a swarm.
+ *
+ * "Link" is what the visitor actually has, and it is true on every surface.
+ * Keep it that way — reintroducing a product noun here means picking one of two
+ * products for a reader who knows neither.
+ */
 const INVALID_CHATBOX_LINK_MESSAGE =
-  "This swarm link is invalid or expired. Ask the owner to share a new link if you still need access.";
+  "This link is invalid or expired. Ask whoever shared it for a new one if you still need access.";
 const UNEXPECTED_CHATBOX_ERROR_MESSAGE =
-  "We couldn't open this swarm right now. Please try again or open MCPJam.";
+  "We couldn't open this link right now. Please try again or open MCPJam.";
 
 type ChatboxBootstrapAuthMode = "workos" | "guest";
 type ChatboxLandingState =
@@ -178,7 +194,7 @@ function getChatboxDisplayError(
   if (!error) {
     return {
       kind: "invalid_link",
-      title: "Swarm Link Unavailable",
+      title: "Link Unavailable",
       message: INVALID_CHATBOX_LINK_MESSAGE,
     };
   }
@@ -236,14 +252,14 @@ function getChatboxDisplayError(
   if (isInvalidLink) {
     return {
       kind: "invalid_link",
-      title: "Swarm Link Unavailable",
+      title: "Link Unavailable",
       message: INVALID_CHATBOX_LINK_MESSAGE,
     };
   }
 
   return {
     kind: "unexpected",
-    title: "Swarm Link Unavailable",
+    title: "Link Unavailable",
     message: UNEXPECTED_CHATBOX_ERROR_MESSAGE,
   };
 }
@@ -310,7 +326,7 @@ async function redeemChatboxToken(
   if (!nextSession) {
     throw createChatboxRouteError(
       502,
-      "Swarm redeem returned an incomplete bootstrap payload."
+      "Chatbox redeem returned an incomplete bootstrap payload."
     );
   }
 
@@ -843,7 +859,7 @@ export function ChatboxChatPage({
     // Copy link work across reloads.
     const token = shareableToken;
     if (!session || !token) {
-      toast.error("Swarm link unavailable");
+      toast.error("Link unavailable");
       return;
     }
 
@@ -856,9 +872,9 @@ export function ChatboxChatPage({
       await navigator.clipboard.writeText(
         buildChatboxLink(token, session.payload.name)
       );
-      toast.success("Swarm link copied");
+      toast.success("Link copied");
     } catch {
-      toast.error("Failed to copy swarm link");
+      toast.error("Failed to copy link");
     }
   }, [session, shareableToken]);
 

--- a/mcpjam-inspector/client/src/components/hosted/__tests__/ChatboxChatPage.test.tsx
+++ b/mcpjam-inspector/client/src/components/hosted/__tests__/ChatboxChatPage.test.tsx
@@ -289,11 +289,11 @@ describe("ChatboxChatPage", () => {
     render(<ChatboxChatPage pathToken="stale-token" />);
 
     expect(
-      await screen.findByRole("heading", { name: "Swarm Link Unavailable" })
+      await screen.findByRole("heading", { name: "Link Unavailable" })
     ).toBeInTheDocument();
     expect(
       screen.getByText(
-        "This swarm link is invalid or expired. Ask the owner to share a new link if you still need access."
+        "This link is invalid or expired. Ask whoever shared it for a new one if you still need access."
       )
     ).toBeInTheDocument();
     expect(screen.queryByText(/Uncaught Error:/)).not.toBeInTheDocument();
@@ -611,11 +611,11 @@ describe("ChatboxChatPage", () => {
     render(<ChatboxChatPage pathToken="broken-token" />);
 
     expect(
-      await screen.findByRole("heading", { name: "Swarm Link Unavailable" })
+      await screen.findByRole("heading", { name: "Link Unavailable" })
     ).toBeInTheDocument();
     expect(
       screen.getByText(
-        "We couldn't open this swarm right now. Please try again or open MCPJam."
+        "We couldn't open this link right now. Please try again or open MCPJam."
       )
     ).toBeInTheDocument();
     expect(


### PR DESCRIPTION
Client-side counterpart to [mcpjam-backend#930](https://github.com/MCPJam/mcpjam-backend/pull/930), which dropped the same noun from the three strings redeem sends up.

## Why

Whoever reads this copy followed a link someone sent them. They are not signed in, have never seen the dashboard, and "swarm" names an internal surface they have no referent for.

On the User Testing surface it was also simply wrong. One `chatboxes` row backs both a Swarm and a scenario — nothing on the row distinguishes them, `isDeliberateScenario` infers it client-side — so an author previewing their own scenario was told it was a swarm. That is exactly what the original report looked like: an Access Denied card in the Edit tab reading *"This swarm is invite-only"* on a scenario the reader had just created.

"Link" is what the visitor actually holds, and it is true on every surface.

## The change

| before | after |
| --- | --- |
| `"Swarm Link Unavailable"` (×3) | `"Link Unavailable"` |
| `"This swarm link is invalid or expired. Ask the owner to share a new link…"` | `"This link is invalid or expired. Ask whoever shared it for a new one…"` |
| `"We couldn't open this swarm right now."` | `"We couldn't open this link right now."` |
| `"Swarm link copied"` | `"Link copied"` |
| `"Swarm link unavailable"` | `"Link unavailable"` |
| `"Failed to copy swarm link"` | `"Failed to copy link"` |

The invalid-link line also stops saying "ask the owner" — the visitor knows who sent them a link, not who owns a resource they cannot see.

One developer-facing string moves too: the 502 thrown on an incomplete bootstrap now says "Chatbox redeem" rather than "Swarm redeem", matching what the module calls itself. It reaches no user (502 classifies as `unexpected`, which renders the curated copy), so that one is naming only.

A comment on the constants records why the noun is absent, so it does not get "helpfully" reinstated.

## Scope

Only the public chatbox runtime. Every other `swarm` in the client is the Swarms product surface itself — sidebar, insights panels, billing entitlements — where the noun is correct and stays. Verified nothing else on the visitor path still says it, including the backend strings that feed straight into this dialog.

## Tests

`ChatboxChatPage.test.tsx` asserted two of these strings verbatim; both updated. 29 tests passing. Client typecheck shows no new errors (the pre-existing ones are in unrelated webmcp/oauth/app-reducer test files).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Copy-only changes on the public chatbox error and toast UI; no auth, redeem, or routing logic changes.
> 
> **Overview**
> **Public chatbox runtime** visitor copy no longer uses **“swarm”**; errors, toasts, and headings say **“link”** instead (e.g. **Link Unavailable**, invalid/expired and unexpected-open messages, copy-link toasts).
> 
> Invalid-link guidance now says **“whoever shared it”** rather than **“the owner.”** A developer-only incomplete-redeem error string says **“Chatbox redeem”** instead of **“Swarm redeem.”** A comment on the constants documents why product nouns stay out of this surface.
> 
> **`ChatboxChatPage.test.tsx`** expectations were updated to match the new strings.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 81fa4826b6bf8382c8bb38bdbfab9f8601d57373. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Replaced “swarm” with “link” in visitor-facing chatbox runtime copy to avoid confusing users and fix incorrect wording on User Testing scenarios. Aligns with `mcpjam-backend` redeem messages and clarifies what visitors actually have: a shared link.

- **Bug Fixes**
  - Updated titles and messages: “Swarm Link Unavailable” → “Link Unavailable”; “This swarm link…” → “This link…”; “We couldn’t open this swarm…” → “We couldn’t open this link…”.
  - Updated toasts: “Swarm link copied/unavailable/failed…” → “Link copied/unavailable/Failed to copy link”.
  - Renamed developer-facing 502 message to “Chatbox redeem…” for consistency.
  - Scope limited to the public chatbox runtime; Swarms product surface unchanged.

<sup>Written for commit 81fa4826b6bf8382c8bb38bdbfab9f8601d57373. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/MCPJam/inspector/pull/3878?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

