### PR TITLE
fix(mcp): accept the resource indicator as a token audience

### DIFF
--- a/mcp/src/auth.ts
+++ b/mcp/src/auth.ts
@@ -93,7 +93,11 @@ type KeyResolver =
   | Uint8Array;
 
 export interface VerifyConfig {
-  /** WorkOS client id; also the expected token `aud`. */
+  /**
+   * WorkOS client id. One of two accepted token audiences — the other is this
+   * server's resource identifier; see the `audience` array in
+   * `verifyBearerToken` for why both are legitimate.
+   */
   clientId: string;
   /** Custom AuthKit domain (`env.AUTHKIT_DOMAIN`), added to the issuer set. */
   authkitDomain: string | undefined;
@@ -132,6 +136,16 @@ function extractBearerToken(header: string | null): string | undefined {
   if (!header) return undefined;
   const match = /^Bearer\s+(\S+)\s*$/i.exec(header);
   return match?.[1];
+}
+
+/**
+ * This resource server's canonical identifier (RFC 8707). It is the `resource`
+ * of our protected-resource metadata AND one of the two audiences a token may
+ * legitimately carry, so both must be derived here — if they ever drift, we
+ * advertise one identifier and accept a different one.
+ */
+export function resourceIdentifier(origin: string): string {
+  return `${origin}/mcp`;
 }
 
 function resourceMetadataUrl(origin: string): string {
@@ -197,9 +211,26 @@ export async function verifyBearerToken(
     typeof key === "function" ? (key as JWTVerifyGetKey) : async () => key;
 
   try {
+    // Two audiences, because AuthKit legitimately mints either one and which
+    // we get is a dashboard setting, not a property of the token or client:
+    //
+    //  - `resourceIdentifier(origin)` — when an MCP Resource Indicator is
+    //    configured for this server (it is, in prod and staging), AuthKit
+    //    stamps `aud` with the `resource` the client requested. Every
+    //    third-party MCP client (Claude Code, Cursor, …) lands here.
+    //  - `config.clientId` — AuthKit's fallback `aud` when no Resource
+    //    Indicator applies, and what first-party browser session tokens carry.
+    //
+    // jose treats an array as "any of", so a token matching either passes.
+    // Accepting only the client id is what broke third-party OAuth entirely:
+    // the flow completed, then every request 401'd on the audience check.
+    //
+    // This is still a pin, not a loosening — the audience must be US. Dropping
+    // it would let any token from the same issuer, minted for any other
+    // resource, be replayed here (token substitution).
     const { payload } = await jwtVerify(token, getKey, {
       issuer,
-      audience: config.clientId,
+      audience: [config.clientId, resourceIdentifier(origin)],
       algorithms: ["RS256"],
       clockTolerance: 5,
     });

--- a/mcp/src/index.ts
+++ b/mcp/src/index.ts
@@ -5,6 +5,7 @@ import {
   GUEST_ISSUER,
   OAUTH_DISCOVERY_HEADERS,
   normalizeIssuer,
+  resourceIdentifier,
   verifyBearerToken,
   type VerifyConfig,
 } from "./auth.js";
@@ -30,7 +31,9 @@ const LANDING_PAGE = `<!doctype html>
 
 function protectedResourceMetadata(origin: string, issuer: string) {
   return {
-    resource: `${origin}/mcp`,
+    // Shared with the audience check in `verifyBearerToken` — we must accept
+    // exactly the identifier we advertise here.
+    resource: resourceIdentifier(origin),
     authorization_servers: [issuer],
     bearer_methods_supported: ["header"],
   };
@@ -78,8 +81,9 @@ function withMcpCors(response: Response): Response {
 /**
  * The verified bearer in the shape the v2 handler passes through to the server
  * factory. Only `token` is read downstream; `clientId` is required by the type
- * and set to the WorkOS client id these tokens are audience-pinned to (a guest
- * token has no client of its own), and the claims ride along in `extra` for
+ * and set to our own WorkOS client id — not the caller's, which for a
+ * third-party OAuth client we never learn (a guest token likewise has no
+ * client of its own) — and the claims ride along in `extra` for
  * future per-principal behavior. `expiresAt` carries the token's own `exp`
  * (seconds since epoch, the same unit `AuthInfo` uses) — `verifyBearerToken`
  * has already enforced it, so this just keeps the pass-through faithful for

--- a/mcp/tests/auth.test.ts
+++ b/mcp/tests/auth.test.ts
@@ -3,6 +3,7 @@ import { SignJWT, generateKeyPair } from "jose";
 import {
   authkitIssuerJwks,
   GUEST_ISSUER,
+  resourceIdentifier,
   verifyBearerToken,
   type VerifyConfig,
 } from "../src/auth.js";
@@ -135,6 +136,61 @@ describe("verifyBearerToken", () => {
     const result = await verifyBearerToken(request(token), config, ORIGIN);
 
     expect(result.ok).toBe(false);
+  });
+
+  it("accepts a token audienced to our resource indicator (third-party OAuth)", async () => {
+    // The regression this test exists for: with an MCP Resource Indicator
+    // configured in WorkOS, AuthKit stamps `aud` with the requested `resource`
+    // rather than the environment client id. Pinning to the client id alone
+    // 401'd every third-party client (Claude Code, Cursor, …) *after* a
+    // fully successful OAuth flow.
+    const { privateKey, publicKey } = await generateKeyPair("RS256");
+    const config: VerifyConfig = {
+      clientId: CLIENT_ID,
+      authkitDomain: AUTHKIT_DOMAIN,
+      resolveKey: (issuer) =>
+        authkitIssuerJwks(CLIENT_ID, AUTHKIT_DOMAIN).has(issuer)
+          ? publicKey
+          : null,
+    };
+    const token = await makeToken(privateKey, {
+      iss: `https://${AUTHKIT_DOMAIN}`,
+      aud: resourceIdentifier(ORIGIN),
+    });
+
+    const result = await verifyBearerToken(request(token), config, ORIGIN);
+
+    expect(result.ok).toBe(true);
+    if (result.ok) expect(result.verified.payload.sub).toBe("user_123");
+  });
+
+  it("rejects a token audienced to a different MCP resource", async () => {
+    // Accepting both audiences must not become "accept any audience": a token
+    // minted for the staging server (same issuer, same signing keys) must not
+    // be replayable against prod.
+    const { privateKey, publicKey } = await generateKeyPair("RS256");
+    const config: VerifyConfig = {
+      clientId: CLIENT_ID,
+      authkitDomain: AUTHKIT_DOMAIN,
+      resolveKey: (issuer) =>
+        authkitIssuerJwks(CLIENT_ID, AUTHKIT_DOMAIN).has(issuer)
+          ? publicKey
+          : null,
+    };
+    const token = await makeToken(privateKey, {
+      iss: `https://${AUTHKIT_DOMAIN}`,
+      aud: "https://mcp-staging.mcpjam.com/mcp",
+    });
+
+    const result = await verifyBearerToken(request(token), config, ORIGIN);
+
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.response.status).toBe(401);
+  });
+
+  it("advertises the resource identifier it accepts as an audience", () => {
+    // The metadata document and the audience check must not drift apart.
+    expect(resourceIdentifier(ORIGIN)).toBe("https://mcp.mcpjam.com/mcp");
   });
 
   it("rejects a token signed by a different key (bad signature)", async () => {


### PR DESCRIPTION
## Problem

Third-party OAuth clients can complete the full authorization flow against the MCP worker and then have **every** subsequent request rejected with `401 invalid_token`. In Claude Code this surfaces as:

> Got new credentials, but mcpjam rejected them on reconnect. Try re-authenticating, or restart Claude Code if it persists.

Re-authenticating never helps — the new token fails the same check. This affects every external MCP client (Claude Code, Cursor, …). First-party browser sessions were unaffected, which is why it went unnoticed.

## Cause

`verifyBearerToken` pinned the token audience to the WorkOS environment client id alone:

```js
audience: config.clientId,
```

When an MCP Resource Indicator is configured for the server, AuthKit stamps `aud` with the `resource` the client requested rather than the environment client id. Both `https://mcp.mcpjam.com/mcp` and `https://mcp-staging.mcpjam.com/mcp` are registered as resource indicators, so tokens issued to third-party clients carry the resource URL and fail the pin.

Per the [WorkOS docs](https://workos.com/docs/authkit/mcp), the client id is only the *fallback* audience, used when no Resource Indicator applies. Which of the two values arrives is a dashboard setting — not a property of the token or the client — so accepting only one meant this could break with no code change on our side.

## Fix

```js
audience: [config.clientId, resourceIdentifier(origin)],
```

`jose` treats an array as "any of", so a token carrying either value passes.

This remains a pin, not a loosening. The audience must still be *this* server, so a token minted for the staging resource cannot be replayed against production. Dropping the check entirely would permit token substitution from any resource sharing the issuer.

The resource identifier now comes from a single `resourceIdentifier()` helper shared with the protected-resource metadata document, so the identifier we advertise and the one we accept cannot drift apart.

The guest-token path is untouched — guest tokens carry no `aud` and are verified in a separate branch.

## Testing

`47/47` tests pass, typecheck clean. Three new cases:

- accepts a token audienced to our resource indicator (the regression)
- rejects a token audienced to a *different* MCP resource (substitution guard)
- the advertised `resource` and the accepted audience agree

I verified the new coverage actually catches the bug: reverting just the audience line makes the first test fail while the substitution guard still passes.

## Deploy note

Merging does not fix production. Per `mcp/wrangler.jsonc`, prod is promoted manually via `deploy-mcp-prod.yml` (`workflow_dispatch` only), so that workflow needs to be run after this lands. Staging is affected by the same bug and fixed by the same change, since the resource is derived from the request origin.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit 9fc779a70492b8438b1288eeab1d1ec76653e156. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes OAuth audience verification in MCP by accepting the resource indicator as a valid token audience, unblocking third-party clients that were getting 401s after login. Verification still pins tokens to this server to prevent cross-environment replay.

- **Bug Fixes**
  - Accept either `config.clientId` or `resourceIdentifier(origin)` as `aud` in `verifyBearerToken` using `jose`’s array audience.
  - Reuse `resourceIdentifier()` in both verification and protected-resource metadata to keep them in sync.
  - Added tests for third-party audience acceptance, cross-resource rejection, and metadata/acceptance agreement.

- **Migration**
  - Promote to production manually via `deploy-mcp-prod.yml` after merge (staging also benefits from this change).

<sup>Written for commit 9fc779a70492b8438b1288eeab1d1ec76653e156. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/MCPJam/inspector/pull/3879?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

