### PR TITLE
fix(oauth): establish trace redaction safety foundation

### DIFF
--- a/.changeset/oauth-client-trace-error-redaction.md
+++ b/.changeset/oauth-client-trace-error-redaction.md
@@ -1,0 +1,11 @@
+---
+"@mcpjam/inspector": patch
+---
+
+Redact credentials echoed into the OAuth trace entries the client builds itself.
+
+`projectOAuthTraceSnapshot({ sanitize })` covers everything derived from a state machine's HTTP history, but not the trace steps the client writes directly — `failOAuthTraceStep` and the OAuth proxy's transport-failure entry. The refresh flow produces *only* those, so it had no error redaction at all: an authorization server that echoes a `refresh_token` back in `error_description` put it verbatim into a persisted, copyable trace.
+
+Both sites now go through `traceOAuthErrorMessage` in the new `lib/oauth/trace-redaction.ts`, gated on `SANITIZE_OAUTH_TRACES` the same way `traceOAuthValue`/`traceOAuthHeaders` already are — local dev still shows the server's raw text, which is the point of the inspector. The redactor itself is the debugger's existing `sanitizeStepError`, moved rather than rewritten: it already handles URL userinfo, named parameters, echoed `Authorization` headers, JSON credential fields, and truncation tails, and it deliberately preserves diagnostic wording like "Bearer token is expired". `debug-state-machine-adapter.ts` re-exports it, so its callers and tests are unchanged.
+
+Also documents `serializeBody` as a live-data path that must never be redacted, matching the note already on `parseOAuthResponseBody`.

--- a/.changeset/oauth-executor-redaction-sentinel.md
+++ b/.changeset/oauth-executor-redaction-sentinel.md
@@ -1,0 +1,11 @@
+---
+"@mcpjam/sdk": minor
+---
+
+Fail loudly when a redaction sentinel reaches the OAuth state machine as a credential.
+
+The factory already wraps every machine's request executor for SSRF, which makes it the one place that sees every executor result across all four protocol eras. It now also inspects `OAuthRequestResult.body` for the sentinel shapes this codebase's redactors emit (`[redacted]`, and the `abcd...[redacted]...yz` truncation form) in `access_token`, `refresh_token`, `id_token`, and `client_secret`, and throws `OAuthRedactedCredentialError` naming the field and a query/fragment-free request target. Clean results are returned unchanged, by identity.
+
+The point is the seam, not the sentinel. A redaction sentinel is a non-empty string, so it passes every truthiness check and is spent as a credential; the first signal is a `401 invalid_token` from the resource server, three layers from the cause. `OAuthRedactedCredentialError` says what actually happened. The check reads `result.body` because that is where the real executor puts response fields — a guard written against `result.access_token` would look correct and never fire.
+
+The match is deliberately narrow: an opaque token is an arbitrary string, so anything looser would break real logins. This is defense in depth for known shapes, not a substitute for keeping trace transformations out of live-data paths.

--- a/.changeset/oauth-trace-state-error-fallback.md
+++ b/.changeset/oauth-trace-state-error-fallback.md
@@ -1,0 +1,9 @@
+---
+"@mcpjam/sdk": patch
+---
+
+Redact the `state.error` fallback in OAuth trace projection.
+
+`projectOAuthTraceSnapshot` read `state.error` in three places and only sanitized two of them. The unsanitized one is the step-level fallback: when the failing step already has an `httpHistory` entry, `inferHttpHistoryEntryError` returns nothing (it only mines responses for `request_client_registration`), the "no entry for the current step" branch is skipped because the entry exists, and the step's `error` fell through to the raw string. An authorization server that echoes a credential back in `error_description` landed it verbatim in rendered, copied, and persisted traces.
+
+The projection of `state.error` is now computed once, next to the snapshot's own `error` field, and every consumer reads that variable. `state.error` is read raw exactly once in the file, so the redaction policy has a single place to keep in sync rather than three branches to remember.

--- a/mcpjam-inspector/client/src/lib/oauth/__tests__/oauth-trace-error-redaction.test.ts
+++ b/mcpjam-inspector/client/src/lib/oauth/__tests__/oauth-trace-error-redaction.test.ts
@@ -1,0 +1,102 @@
+/**
+ * The client collects its own trace entries — it does not always project an
+ * SDK snapshot. The refresh flow in particular produces ONLY the client-side
+ * trace, so `projectOAuthTraceSnapshot`'s error redaction never runs over it.
+ *
+ * These tests pin the redaction the client applies itself, in the hosted
+ * configuration where `SANITIZE_OAUTH_TRACES` is on.
+ */
+
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("@/lib/config", async () => {
+  const actual = await vi.importActual<typeof import("@/lib/config")>(
+    "@/lib/config",
+  );
+  return { ...actual, HOSTED_MODE: true, SANITIZE_OAUTH_TRACES: true };
+});
+
+const REFRESH_TOKEN = "rt_supersecretrefreshtokenvalue0987654321";
+
+describe("client-side OAuth trace error redaction (hosted)", () => {
+  beforeEach(() => {
+    vi.resetModules();
+  });
+
+  it("redacts credentials echoed into a failed step's error message", async () => {
+    const { createOAuthTrace, failOAuthTraceStep } = await import(
+      "../oauth-trace"
+    );
+
+    const trace = createOAuthTrace({
+      source: "refresh",
+      serverName: "notion",
+      serverUrl: "https://mcp.notion.com/mcp",
+    });
+
+    failOAuthTraceStep(
+      trace,
+      "token_request",
+      new Error(
+        `Refresh failed: invalid_grant - refresh_token=${REFRESH_TOKEN} is expired`,
+      ),
+    );
+
+    const serialized = JSON.stringify(trace);
+    expect(serialized).not.toContain(REFRESH_TOKEN);
+    expect(trace.error).toContain("refresh_token=[redacted]");
+    expect(trace.steps[0]?.error).toContain("refresh_token=[redacted]");
+  });
+
+  // The redactor must not destroy the diagnostic vocabulary it exists to
+  // preserve: "Bearer token is expired" is a description, not a credential.
+  it("keeps diagnostic words that merely look credential-adjacent", async () => {
+    const { createOAuthTrace, failOAuthTraceStep } = await import(
+      "../oauth-trace"
+    );
+
+    const trace = createOAuthTrace({ source: "refresh" });
+    failOAuthTraceStep(
+      trace,
+      "token_request",
+      new Error("Bearer token is expired"),
+    );
+
+    expect(trace.error).toBe("Bearer token is expired");
+  });
+
+  it("redacts credentials echoed into a proxy transport failure", async () => {
+    const { traceOAuthErrorMessage } = await import("../trace-redaction");
+
+    expect(
+      traceOAuthErrorMessage(
+        `OAuth proxy failed: upstream rejected access_token=${REFRESH_TOKEN}`,
+      ),
+    ).not.toContain(REFRESH_TOKEN);
+  });
+});
+
+describe("client-side OAuth trace error redaction (local)", () => {
+  beforeEach(() => {
+    vi.resetModules();
+  });
+
+  it("leaves error messages intact when sanitization is off", async () => {
+    vi.doMock("@/lib/config", async () => {
+      const actual = await vi.importActual<typeof import("@/lib/config")>(
+        "@/lib/config",
+      );
+      return { ...actual, HOSTED_MODE: false, SANITIZE_OAUTH_TRACES: false };
+    });
+
+    const { createOAuthTrace, failOAuthTraceStep } = await import(
+      "../oauth-trace"
+    );
+
+    const raw = `Refresh failed: refresh_token=${REFRESH_TOKEN}`;
+    const trace = createOAuthTrace({ source: "refresh" });
+    failOAuthTraceStep(trace, "token_request", new Error(raw));
+
+    expect(trace.error).toBe(raw);
+  });
+});

--- a/mcpjam-inspector/client/src/lib/oauth/debug-state-machine-adapter.ts
+++ b/mcpjam-inspector/client/src/lib/oauth/debug-state-machine-adapter.ts
@@ -15,6 +15,15 @@ import { reportCaught } from "@/lib/error-reporting";
 import { HOSTED_MODE } from "@/lib/config";
 import { tryResolveProjectServer } from "@/lib/apis/web/context";
 import { fetchOAuthClientSecret } from "@/lib/apis/hosted-oauth-client-secret-api";
+import { sanitizeStepError } from "./trace-redaction";
+
+/**
+ * Re-exported so the debugger's existing callers (and its tests) keep importing
+ * `sanitizeStepError` from here. The implementation moved to
+ * `trace-redaction.ts`, which owns error-string redaction for every OAuth trace
+ * surface rather than just the debugger's Sentry reports.
+ */
+export { sanitizeStepError };
 
 type OAuthRegistrationStrategy =
   | RegistrationStrategy2025_03_26
@@ -258,106 +267,6 @@ function createHostedClientSecretResolver({
  * misbehaving, which is exactly what a debugger is for. The value is the
  * aggregate trend, not a page.
  */
-/**
- * Bound the untrusted text before it leaves the browser.
- *
- * These strings come from the server UNDER TEST — an `error_description` is
- * whatever that server chose to return, and the debugger is routinely pointed
- * at half-built servers that echo request context back into error bodies. A
- * diagnostic signal must not become an exfiltration path, so every shape a
- * credential plausibly arrives in gets redacted before capture:
- *
- *   1. URL userinfo, with or without a scheme (`https://u:p@h`, `u:p@h`)
- *   2. credential-ish query/form parameters, by name
- *   3. `Authorization: Bearer|Basic <value>` echoed from a request
- *   4. JSON credential fields (`"client_secret": "..."`)
- *
- * Then a length cap, because an upstream body can be arbitrarily large.
- *
- * Deliberately over-redacts: losing a token's value costs nothing here (the
- * parameter NAME is the diagnostic), while leaking one is unrecoverable.
- */
-const CREDENTIAL_PARAM_NAMES =
-  "client_secret|access_token|refresh_token|id_token|code_verifier|code|assertion|password|api[-_]?key|token|secret";
-
-/** Final length of a reported message. */
-const MAX_REPORTED = 500;
-
-/**
- * How much raw input the redactors are allowed to scan.
- *
- * The cap has to come BEFORE the replace chain — an upstream body can be
- * megabytes, and four global regexes over it would copy the whole thing four
- * times on a render path. It is deliberately wider than `MAX_REPORTED` so the
- * redactors still see the context around anything that survives to the output.
- */
-const MAX_SCANNED = 4_000;
-
-export function sanitizeStepError(message: string): string {
-  const truncated = message.length > MAX_SCANNED;
-  const bounded = truncated ? message.slice(0, MAX_SCANNED) : message;
-
-  const redacted = bounded
-    // 1a. scheme://user:pass@host. Greedy up to the LAST `@` of the
-    // authority: `@` is legal inside a password, so
-    // `https://user:secret@part@host` has userinfo `user:secret@part`, and
-    // stopping at the first `@` would report half the password.
-    .replace(/([a-z][a-z0-9+.-]*:\/\/)[^\s/?#]*@/gi, "$1[redacted]@")
-    // 1b. bare user:pass@host (no scheme), same greediness.
-    .replace(/(^|[\s(<"'])[^\s/@:]+:[^\s/]+@(?=[\w.-]+)/g, "$1[redacted]@")
-    // 2. ?client_secret=… / &token=…
-    .replace(
-      new RegExp(`\\b(${CREDENTIAL_PARAM_NAMES})=[^&\\s"'<>]+`, "gi"),
-      "$1=[redacted]",
-    )
-    // 3a. An echoed `Authorization:` header — redact whatever follows.
-    .replace(
-      /\b((?:proxy-)?authorization\s*[:=]\s*)(bearer|basic)\s+\S+/gi,
-      "$1$2 [redacted]",
-    )
-    // 3b. A bare `Bearer <value>` with no header context. This one must only
-    // fire on a credential-SHAPED value: `\b(bearer|basic)\s+\w+` turns the
-    // very common "Bearer token is expired" into "Bearer [redacted] is
-    // expired", destroying the diagnostic word this function promises to keep.
-    // Real values carry base64url/JWT punctuation or are simply long.
-    .replace(
-      /\b(bearer|basic)\s+(?:[\w-]*[._~+/=][\w\-._~+/=]*|\w{20,})/gi,
-      "$1 [redacted]",
-    )
-    // 4. "client_secret": "…" — `(?:\\.|[^"\\])*` rather than `[^"]*`, or an
-    // escaped quote inside the value ends the match early and leaves the
-    // secret's tail in the report.
-    .replace(
-      new RegExp(
-        `("(?:${CREDENTIAL_PARAM_NAMES})"\\s*:\\s*)"(?:\\\\.|[^"\\\\])*"`,
-        "gi",
-      ),
-      '$1"[redacted]"',
-    );
-
-  // Patterns 1b/2/3 all match to end-of-string, so a value the cap cut in half
-  // is still redacted. The JSON and scheme-userinfo forms need a closing
-  // delimiter, so cutting mid-value would leave a raw prefix — close those two
-  // here, and only when the cap actually fired, so an ordinary message that
-  // merely ends in a URL keeps its hostname.
-  const tailGuarded = truncated
-    ? redacted
-        .replace(
-          // Escape-aware like the terminated form above, or an unterminated
-          // value containing `\\"` stops the match at that quote and leaks its
-          // tail. `[\\s\\S]?` so a trailing backslash at the cut still matches.
-          new RegExp(
-            `("(?:${CREDENTIAL_PARAM_NAMES})"\\s*:\\s*)"(?:\\\\[\\s\\S]?|[^"\\\\])*$`,
-            "gi",
-          ),
-          '$1"[redacted]',
-        )
-        .replace(/([a-z][a-z0-9+.-]*:\/\/)[^\s/?#]*$/gi, "$1[redacted]")
-    : redacted;
-
-  return tailGuarded.slice(0, MAX_REPORTED);
-}
-
 function withStepFailureReporting(
   updateState: InspectorOAuthStateMachineConfig["updateState"],
   context: { protocolVersion: OAuthProtocolVersion; getStep: () => string },

--- a/mcpjam-inspector/client/src/lib/oauth/mcp-oauth.ts
+++ b/mcpjam-inspector/client/src/lib/oauth/mcp-oauth.ts
@@ -78,6 +78,7 @@ import {
   startOAuthTraceStep,
   type OAuthTrace,
 } from "./oauth-trace";
+import { traceOAuthErrorMessage } from "./trace-redaction";
 
 // Store original fetch for restoration
 const originalFetch = window.fetch;
@@ -1621,8 +1622,13 @@ function createOAuthFetchInterceptor(
         upstreamFinalUrl
       );
     } catch (error) {
+      // `entry` is trace-only display data, so the message is redacted here for
+      // the same reason `traceOAuthValue` redacts the body. The thrown error
+      // below is deliberately the ORIGINAL — callers act on it as live data.
       entry.error = {
-        message: error instanceof Error ? error.message : String(error),
+        message: traceOAuthErrorMessage(
+          error instanceof Error ? error.message : String(error)
+        ),
       };
       entry.duration = Date.now() - entry.timestamp;
       console.error("OAuth proxy failed:", error);
@@ -1632,7 +1638,16 @@ function createOAuthFetchInterceptor(
 }
 
 /**
- * Serialize request body for proxying
+ * Serialize a request body that the OAuth proxy SENDS upstream. Deliberately
+ * NOT redacted, for the same reason `parseOAuthResponseBody` is not: this value
+ * is live wire data, and a redactor here would put
+ * `code_verifier: "abcd...[redacted]...yz"` on the token request — still a
+ * non-empty string, so nothing downstream notices until the authorization
+ * server rejects the exchange.
+ *
+ * The trace copy of this body is redacted separately, by `traceOAuthValue` in
+ * `createHttpHistoryEntry`. Redaction belongs to the trace layer; a redactor
+ * applied to a consumed value is the #3865 bug.
  */
 async function serializeBody(body: BodyInit): Promise<any> {
   if (typeof body === "string") {

--- a/mcpjam-inspector/client/src/lib/oauth/oauth-trace.ts
+++ b/mcpjam-inspector/client/src/lib/oauth/oauth-trace.ts
@@ -7,6 +7,7 @@ import {
   type OAuthTraceStepSnapshot,
   type OAuthTraceStepStatus,
 } from "@mcpjam/sdk/browser";
+import { traceOAuthErrorMessage } from "./trace-redaction";
 
 export type OAuthTraceSource =
   | "interactive_connect"
@@ -440,8 +441,17 @@ export function failOAuthTraceStep(
     details?: Record<string, unknown>;
   } = {},
 ): void {
-  const errorMessage =
-    error instanceof Error ? error.message : typeof error === "string" ? error : String(error);
+  // Error strings interpolate whatever the authorization server put in
+  // `error`/`error_description`. This is the only redaction boundary the
+  // refresh flow has — it builds a client-side trace and never projects an SDK
+  // snapshot, so `projectOAuthTraceSnapshot({ sanitize })` never runs over it.
+  const errorMessage = traceOAuthErrorMessage(
+    error instanceof Error
+      ? error.message
+      : typeof error === "string"
+        ? error
+        : String(error),
+  );
   const existing = [...trace.steps]
     .reverse()
     .find((entry) => entry.step === step && entry.status === "pending");

--- a/mcpjam-inspector/client/src/lib/oauth/trace-redaction.ts
+++ b/mcpjam-inspector/client/src/lib/oauth/trace-redaction.ts
@@ -1,0 +1,131 @@
+/**
+ * Redaction for OAuth trace *display* data collected by the client itself.
+ *
+ * The SDK's `projectOAuthTraceSnapshot({ sanitize })` covers everything derived
+ * from a state machine's `httpHistory`/`infoLogs`. It does not cover the trace
+ * entries the client builds directly — `failOAuthTraceStep`, the OAuth proxy's
+ * transport-failure entry — and the refresh flow produces ONLY those. This
+ * module is the client's half of the same boundary.
+ *
+ * Nothing here may be applied to data the OAuth flow CONSUMES. See the comment
+ * on `parseOAuthResponseBody` in `mcp-oauth.ts`: running a live token response
+ * through a redactor produces a non-empty string that passes every truthiness
+ * check and then fails upstream as `Bearer abcd...[redacted]...yz`.
+ */
+
+import { SANITIZE_OAUTH_TRACES } from "@/lib/config";
+
+/**
+ * Bound the untrusted text before it leaves the browser.
+ *
+ * These strings come from the server UNDER TEST — an `error_description` is
+ * whatever that server chose to return, and MCPJam is routinely pointed at
+ * half-built servers that echo request context back into error bodies. A
+ * diagnostic signal must not become an exfiltration path, so every shape a
+ * credential plausibly arrives in gets redacted before capture:
+ *
+ *   1. URL userinfo, with or without a scheme (`https://u:p@h`, `u:p@h`)
+ *   2. credential-ish query/form parameters, by name
+ *   3. `Authorization: Bearer|Basic <value>` echoed from a request
+ *   4. JSON credential fields (`"client_secret": "..."`)
+ *
+ * Then a length cap, because an upstream body can be arbitrarily large.
+ *
+ * Deliberately over-redacts: losing a token's value costs nothing here (the
+ * parameter NAME is the diagnostic), while leaking one is unrecoverable. What
+ * it must NOT do is destroy diagnostic vocabulary — "Bearer token is expired"
+ * has to survive intact, which is why rule 3b matches only credential-shaped
+ * values.
+ */
+const CREDENTIAL_PARAM_NAMES =
+  "client_secret|access_token|refresh_token|id_token|code_verifier|code|assertion|password|api[-_]?key|token|secret";
+
+/** Final length of a reported message. */
+const MAX_REPORTED = 500;
+
+/**
+ * How much raw input the redactors are allowed to scan.
+ *
+ * The cap has to come BEFORE the replace chain — an upstream body can be
+ * megabytes, and four global regexes over it would copy the whole thing four
+ * times on a render path. It is deliberately wider than `MAX_REPORTED` so the
+ * redactors still see the context around anything that survives to the output.
+ */
+const MAX_SCANNED = 4_000;
+
+export function sanitizeStepError(message: string): string {
+  const truncated = message.length > MAX_SCANNED;
+  const bounded = truncated ? message.slice(0, MAX_SCANNED) : message;
+
+  const redacted = bounded
+    // 1a. scheme://user:pass@host. Greedy up to the LAST `@` of the
+    // authority: `@` is legal inside a password, so
+    // `https://user:secret@part@host` has userinfo `user:secret@part`, and
+    // stopping at the first `@` would report half the password.
+    .replace(/([a-z][a-z0-9+.-]*:\/\/)[^\s/?#]*@/gi, "$1[redacted]@")
+    // 1b. bare user:pass@host (no scheme), same greediness.
+    .replace(/(^|[\s(<"'])[^\s/@:]+:[^\s/]+@(?=[\w.-]+)/g, "$1[redacted]@")
+    // 2. ?client_secret=… / &token=…
+    .replace(
+      new RegExp(`\\b(${CREDENTIAL_PARAM_NAMES})=[^&\\s"'<>]+`, "gi"),
+      "$1=[redacted]",
+    )
+    // 3a. An echoed `Authorization:` header — redact whatever follows.
+    .replace(
+      /\b((?:proxy-)?authorization\s*[:=]\s*)(bearer|basic)\s+\S+/gi,
+      "$1$2 [redacted]",
+    )
+    // 3b. A bare `Bearer <value>` with no header context. This one must only
+    // fire on a credential-SHAPED value: `\b(bearer|basic)\s+\w+` turns the
+    // very common "Bearer token is expired" into "Bearer [redacted] is
+    // expired", destroying the diagnostic word this function promises to keep.
+    // Real values carry base64url/JWT punctuation or are simply long.
+    .replace(
+      /\b(bearer|basic)\s+(?:[\w-]*[._~+/=][\w\-._~+/=]*|\w{20,})/gi,
+      "$1 [redacted]",
+    )
+    // 4. "client_secret": "…" — `(?:\\.|[^"\\])*` rather than `[^"]*`, or an
+    // escaped quote inside the value ends the match early and leaves the
+    // secret's tail in the report.
+    .replace(
+      new RegExp(
+        `("(?:${CREDENTIAL_PARAM_NAMES})"\\s*:\\s*)"(?:\\\\.|[^"\\\\])*"`,
+        "gi",
+      ),
+      '$1"[redacted]"',
+    );
+
+  // Patterns 1b/2/3 all match to end-of-string, so a value the cap cut in half
+  // is still redacted. The JSON and scheme-userinfo forms need a closing
+  // delimiter, so cutting mid-value would leave a raw prefix — close those two
+  // here, and only when the cap actually fired, so an ordinary message that
+  // merely ends in a URL keeps its hostname.
+  const tailGuarded = truncated
+    ? redacted
+        .replace(
+          // Escape-aware like the terminated form above, or an unterminated
+          // value containing `\\"` stops the match at that quote and leaks its
+          // tail. `[\\s\\S]?` so a trailing backslash at the cut still matches.
+          new RegExp(
+            `("(?:${CREDENTIAL_PARAM_NAMES})"\\s*:\\s*)"(?:\\\\[\\s\\S]?|[^"\\\\])*$`,
+            "gi",
+          ),
+          '$1"[redacted]',
+        )
+        .replace(/([a-z][a-z0-9+.-]*:\/\/)[^\s/?#]*$/gi, "$1[redacted]")
+    : redacted;
+
+  return tailGuarded.slice(0, MAX_REPORTED);
+}
+
+/**
+ * The gated entry point for trace *collection*. Mirrors `traceOAuthValue` /
+ * `traceOAuthHeaders` in `mcp-oauth.ts`: on locally, redacting when hosted.
+ *
+ * Local dev keeps raw error text because the whole point of the inspector is
+ * to show the user what their own server actually said; hosted traces are
+ * persisted, copied, and shipped, so they get the redactor.
+ */
+export function traceOAuthErrorMessage(message: string): string {
+  return SANITIZE_OAUTH_TRACES ? sanitizeStepError(message) : message;
+}

--- a/sdk/src/browser.ts
+++ b/sdk/src/browser.ts
@@ -162,6 +162,10 @@ export {
   PROTOCOL_VERSION_INFO,
   getDefaultRegistrationStrategy,
   getSupportedRegistrationStrategies,
+  // Exported so a consumer can distinguish "MCPJam redacted its own live data"
+  // from an authorization-server rejection; both otherwise end in a 401.
+  assertOAuthResultCredentialsUnredacted,
+  OAuthRedactedCredentialError,
 } from "./oauth/state-machines/factory.js";
 export type {
   ProbeHttpAttempt,

--- a/sdk/src/oauth/state-machines/factory.ts
+++ b/sdk/src/oauth/state-machines/factory.ts
@@ -9,7 +9,9 @@ import type {
   OAuthStateMachine,
   OAuthProtocolVersion,
   BaseOAuthStateMachineConfig,
+  OAuthHttpRequest,
   OAuthRequestExecutor,
+  OAuthRequestResult,
   RegistrationStrategy2025_03_26,
   RegistrationStrategy2025_06_18,
   RegistrationStrategy2025_11_25,
@@ -38,6 +40,93 @@ import {
   type DebugOAuthStateMachineConfig as Config2026_07_28,
 } from "./debug-oauth-2026-07-28.js";
 import { protocolVersionLabel } from "../../mcp-client-manager/mcp-protocol-version.js";
+
+/**
+ * A redaction sentinel reached the state machine as a live credential.
+ *
+ * Distinct error type so a caller can tell "MCPJam redacted its own live data"
+ * apart from an authorization-server failure — the two look identical from the
+ * outside (both end in `401 invalid_token`) and that is precisely what made
+ * #3865 expensive to diagnose.
+ */
+export class OAuthRedactedCredentialError extends Error {
+  readonly field: string;
+
+  constructor(field: string, target: string) {
+    super(
+      `OAuth response from ${target} carried a redacted \`${field}\`. ` +
+        "Trace redaction was applied to data the OAuth flow consumes; a " +
+        "redaction sentinel is a non-empty string, so it would be sent " +
+        "upstream as a credential and rejected as invalid. Redaction belongs " +
+        "to the trace projection layer only.",
+    );
+    this.name = "OAuthRedactedCredentialError";
+    this.field = field;
+  }
+}
+
+/**
+ * Top-level credential fields the flow consumes verbatim. A sentinel in any of
+ * these is used as a credential rather than merely displayed.
+ */
+const CONSUMED_CREDENTIAL_FIELDS = [
+  "access_token",
+  "refresh_token",
+  "id_token",
+  "client_secret",
+] as const;
+
+/**
+ * The sentinel shapes this codebase's redactors emit: the bare marker, and the
+ * `redactSensitiveValue` truncation form `abcd...[redacted]...yz`.
+ *
+ * Deliberately narrow. An opaque token is an arbitrary string, so a loose match
+ * would fail real logins — the guard must only fire on values that are
+ * unambiguously our own output.
+ */
+const REDACTION_SENTINELS = [/^\[redacted\]$/, /^.{4}\.\.\.\[redacted\]\.\.\..{2}$/];
+
+/** Strip query and fragment: the target is for diagnosis, not for echoing
+ * request parameters (which can themselves carry credentials) into an error. */
+function describeRequestTarget(request: Pick<OAuthHttpRequest, "url">): string {
+  try {
+    const url = new URL(request.url);
+    return `${url.origin}${url.pathname}`;
+  } catch {
+    return "the authorization server";
+  }
+}
+
+/**
+ * Throw if an executor result carries a redaction sentinel where the flow
+ * expects a credential; otherwise return the result unchanged (by identity).
+ *
+ * Inspects `result.body`, which is where the real executor puts response
+ * fields — a check against `result.access_token` would look reasonable and
+ * never fire.
+ */
+export function assertOAuthResultCredentialsUnredacted(
+  result: OAuthRequestResult,
+  request: Pick<OAuthHttpRequest, "url">,
+): OAuthRequestResult {
+  const body: unknown = result?.body;
+  if (!body || typeof body !== "object" || Array.isArray(body)) {
+    return result;
+  }
+
+  const record = body as Record<string, unknown>;
+  for (const field of CONSUMED_CREDENTIAL_FIELDS) {
+    const value = record[field];
+    if (
+      typeof value === "string" &&
+      REDACTION_SENTINELS.some((pattern) => pattern.test(value))
+    ) {
+      throw new OAuthRedactedCredentialError(field, describeRequestTarget(request));
+    }
+  }
+
+  return result;
+}
 
 /**
  * Configuration for creating an OAuth state machine with protocol version selection
@@ -108,7 +197,10 @@ export function createOAuthStateMachine(
     // redirects (see the client executor / DNS-pinning proxy) — a URL-string
     // check here cannot catch a 3xx or DNS-rebind to a private host.
     assertOutboundOAuthUrlAllowed(request.url, { allowLoopback });
-    return rest.requestExecutor(request);
+    const result = await rest.requestExecutor(request);
+    // Second cross-cutting guard at the same seam: catch a trace redactor that
+    // was applied to live data before the sentinel is spent as a credential.
+    return assertOAuthResultCredentialsUnredacted(result, request);
   };
   const baseConfig = {
     ...rest,

--- a/sdk/src/oauth/state-machines/trace.ts
+++ b/sdk/src/oauth/state-machines/trace.ts
@@ -552,6 +552,18 @@ export function projectOAuthTraceSnapshot(input: {
   sanitize?: boolean;
 }): OAuthTraceSnapshot {
   const { state, context, sanitize: sanitizeTraces = true } = input;
+
+  // The single projection of `state.error`. Every consumer below reads this
+  // variable rather than `state.error`, so there is exactly one place where the
+  // raw value crosses into display output and exactly one place to keep in sync
+  // with the redaction policy. (A previous fix patched one of two fallback
+  // branches and the other kept emitting the raw string.)
+  const projectedStateError = state.error
+    ? sanitizeTraces
+      ? sanitizeTraceErrorMessage(state.error)
+      : state.error
+    : undefined;
+
   const trace: OAuthTraceSnapshot = {
     version: 1,
     currentStep: state.currentStep,
@@ -559,13 +571,7 @@ export function projectOAuthTraceSnapshot(input: {
     httpHistory: (state.httpHistory ?? []).map((entry) =>
       sanitizeTraces ? sanitizeHttpHistoryEntry(entry) : cloneHttpHistoryEntry(entry),
     ),
-    ...(state.error
-      ? {
-          error: sanitizeTraces
-            ? sanitizeTraceErrorMessage(state.error)
-            : state.error,
-        }
-      : {}),
+    ...(projectedStateError ? { error: projectedStateError } : {}),
   };
 
   const currentStepIndex = getStepIndex(state.currentStep);
@@ -711,9 +717,7 @@ export function projectOAuthTraceSnapshot(input: {
     inferStepEntry(entries, context, state.currentStep, true, undefined, sanitizeTraces);
     const currentEntry = entries.get(state.currentStep);
     if (currentEntry) {
-      currentEntry.error = sanitizeTraces
-        ? sanitizeTraceErrorMessage(state.error)
-        : state.error;
+      currentEntry.error = projectedStateError;
     }
   }
 
@@ -729,7 +733,8 @@ export function projectOAuthTraceSnapshot(input: {
         entry.step === state.currentStep &&
         Boolean(state.error) &&
         !usesRecoveredDynamicClientRegistrationFallback(state);
-      const error = entry.error ?? (usesStateError ? state.error : undefined);
+      const error =
+        entry.error ?? (usesStateError ? projectedStateError : undefined);
       const status =
         entry.recovered
           ? "success"

--- a/sdk/tests/oauth/executor-redaction-sentinel.test.ts
+++ b/sdk/tests/oauth/executor-redaction-sentinel.test.ts
@@ -1,0 +1,193 @@
+/**
+ * Defense in depth for the #3865 failure shape.
+ *
+ * A trace redactor was applied to data the OAuth flow CONSUMES, so the state
+ * machine received `access_token: "abcd...[redacted]...yz"` — still a non-empty
+ * string, so it passed every truthiness check and went upstream as
+ * `Authorization: Bearer abcd...[redacted]...yz`. The resource server's
+ * `401 invalid_token` was the first and only signal, three layers away from the
+ * cause.
+ *
+ * The factory already wraps every machine's executor for SSRF, so it is the one
+ * place that sees every executor result for all four eras. Inspect the
+ * credential fields there and fail loudly at the seam instead of silently
+ * shipping a redaction sentinel as a credential.
+ *
+ * This recognizes the sentinel shapes the codebase currently produces. It is
+ * not a proof that every future redactor is covered — keeping trace
+ * transformations out of live-data paths is still the actual rule.
+ */
+
+import {
+  assertOAuthResultCredentialsUnredacted,
+  createOAuthStateMachine,
+  OAuthRedactedCredentialError,
+} from "../../src/oauth/state-machines/factory.js";
+import { EMPTY_OAUTH_FLOW_STATE } from "../../src/oauth/state-machines/types.js";
+import type {
+  OAuthFlowState,
+  OAuthRequestResult,
+} from "../../src/oauth/state-machines/types.js";
+
+const REQUEST = {
+  method: "POST",
+  url: "https://auth.example.com/token?client_id=abc#frag",
+  headers: {},
+};
+
+/** The real executor's shape — credentials live under `body`, not on the result. */
+function result(body: unknown): OAuthRequestResult {
+  return {
+    ok: true,
+    status: 200,
+    statusText: "OK",
+    headers: {},
+    body,
+  } as OAuthRequestResult;
+}
+
+describe("executor redaction sentinel", () => {
+  it("throws on the truncated-tail sentinel in access_token", () => {
+    expect(() =>
+      assertOAuthResultCredentialsUnredacted(
+        result({
+          access_token: "abcd...[redacted]...yz",
+          token_type: "Bearer",
+        }),
+        REQUEST,
+      ),
+    ).toThrow(OAuthRedactedCredentialError);
+  });
+
+  it("names the offending field and a query/fragment-free target", () => {
+    let thrown: unknown;
+    try {
+      assertOAuthResultCredentialsUnredacted(
+        result({ access_token: "abcd...[redacted]...yz" }),
+        REQUEST,
+      );
+    } catch (error) {
+      thrown = error;
+    }
+
+    const message = (thrown as Error).message;
+    expect(message).toContain("access_token");
+    expect(message).toContain("https://auth.example.com/token");
+    // The target is for diagnosis, not for echoing back request parameters.
+    expect(message).not.toContain("client_id=abc");
+    expect(message).not.toContain("frag");
+  });
+
+  it.each([
+    ["refresh_token", "wxyz...[redacted]...ab"],
+    ["id_token", "[redacted]"],
+    ["client_secret", "[redacted]"],
+  ])("throws on a redacted %s", (field, value) => {
+    expect(() =>
+      assertOAuthResultCredentialsUnredacted(
+        result({ [field]: value }),
+        REQUEST,
+      ),
+    ).toThrow(OAuthRedactedCredentialError);
+  });
+
+  it("returns a clean result by identity", () => {
+    const clean = result({
+      access_token: "ntn_realaccesstokenvalue1234567890",
+      refresh_token: "rt_realrefreshtokenvalue0987654321",
+      token_type: "Bearer",
+      expires_in: 3600,
+    });
+    expect(assertOAuthResultCredentialsUnredacted(clean, REQUEST)).toBe(clean);
+  });
+
+  it("ignores non-object and non-string bodies", () => {
+    for (const body of [
+      undefined,
+      null,
+      "raw text",
+      42,
+      [{ access_token: "abcd...[redacted]...yz" }],
+    ]) {
+      const value = result(body);
+      expect(assertOAuthResultCredentialsUnredacted(value, REQUEST)).toBe(value);
+    }
+  });
+
+  // A credential that merely mentions the word must not trip the guard —
+  // opaque tokens are arbitrary strings and a false positive breaks a real
+  // login.
+  it("does not fire on a credential that merely contains the word", () => {
+    for (const token of [
+      "this-token-is-not-redacted-but-mentions-redacted",
+      "redacted",
+      "abcd...[REDACTION]...yz",
+    ]) {
+      const value = result({ access_token: token });
+      expect(assertOAuthResultCredentialsUnredacted(value, REQUEST)).toBe(value);
+    }
+  });
+});
+
+describe("factory wraps every machine's executor with the redaction sentinel", () => {
+  const SERVER_URL = "https://mcp.example.com/mcp";
+
+  function buildAtRegistration(registrationBody: unknown) {
+    const inner = vi.fn().mockResolvedValue(result(registrationBody));
+    let state: OAuthFlowState = {
+      ...EMPTY_OAUTH_FLOW_STATE,
+      serverUrl: SERVER_URL,
+      currentStep: "received_authorization_server_metadata",
+      authorizationServerMetadata: {
+        issuer: "https://auth.example.com",
+        authorization_endpoint: "https://auth.example.com/authorize",
+        token_endpoint: "https://auth.example.com/token",
+        registration_endpoint: "https://auth.example.com/register",
+        response_types_supported: ["code"],
+        code_challenge_methods_supported: ["S256"],
+      },
+    };
+    const machine = createOAuthStateMachine({
+      protocolVersion: "2026-07-28",
+      registrationStrategy: "dcr",
+      state,
+      getState: () => state,
+      updateState: (updates) => {
+        state = { ...state, ...updates };
+      },
+      serverUrl: SERVER_URL,
+      serverName: "Test Server",
+      redirectUrl: "http://127.0.0.1:3333/callback",
+      requestExecutor: inner,
+      dynamicRegistration: { client_name: "Test Client" },
+    });
+    return { machine, inner, getState: () => state };
+  }
+
+  const advance = async (machine: { proceedToNextStep: () => Promise<void> }) => {
+    for (let i = 0; i < 3; i++) {
+      await machine.proceedToNextStep().catch(() => {});
+    }
+  };
+
+  it("surfaces a redacted registration secret as a flow error", async () => {
+    const { machine, getState } = buildAtRegistration({
+      client_id: "generated",
+      client_secret: "abcd...[redacted]...yz",
+    });
+    await advance(machine);
+
+    expect(getState().error ?? "").toContain("client_secret");
+  });
+
+  it("leaves a clean registration response alone", async () => {
+    const { machine, getState } = buildAtRegistration({
+      client_id: "generated",
+      client_secret: "cs_realclientsecretvalue1234567890",
+    });
+    await advance(machine);
+
+    expect(getState().clientId).toBe("generated");
+    expect(getState().error ?? "").not.toContain("redact");
+  });
+});

--- a/sdk/tests/oauth/trace-projection.test.ts
+++ b/sdk/tests/oauth/trace-projection.test.ts
@@ -138,6 +138,94 @@ describe("OAuth trace projection", () => {
     expect(tokenStep?.error).toContain("Bearer [redacted]");
   });
 
+  // Regression: when the current step already has an httpHistory entry, the
+  // `state.error` fallback in the step projection is the only place the error
+  // string reaches the snapshot — `inferHttpHistoryEntryError` only mines
+  // responses for `request_client_registration`, and the "no entry for the
+  // current step" branch is skipped because the entry exists. That fallback
+  // used to emit `state.error` raw even when sanitizing.
+  it("redacts the state-error fallback on a step that already has an http entry", () => {
+    const leaked =
+      "Token request failed: invalid_client - client_secret=cs_stateerrorfallback1234567890 was rejected";
+
+    const snapshot = projectOAuthTraceSnapshot({
+      state: {
+        ...EMPTY_OAUTH_FLOW_STATE,
+        currentStep: "token_request",
+        error: leaked,
+        httpHistory: [
+          {
+            step: "token_request",
+            timestamp: 1_000,
+            request: {
+              method: "POST",
+              url: "https://auth.example.com/token",
+              headers: {},
+              body: { grant_type: "authorization_code" },
+            },
+            response: {
+              status: 400,
+              statusText: "Bad Request",
+              headers: { "content-type": "application/json" },
+              body: { error: "invalid_client" },
+            },
+            // Deliberately no `error` — the executor recorded the response but
+            // no transport-level failure.
+          },
+        ],
+        infoLogs: [],
+      },
+      sanitize: true,
+    });
+
+    const tokenStep = snapshot.steps.find(
+      (step) => step.step === "token_request",
+    );
+    expect(tokenStep?.status).toBe("error");
+    expect(tokenStep?.error).toContain("client_secret=[redacted]");
+    expect(JSON.stringify(snapshot)).not.toContain(
+      "cs_stateerrorfallback1234567890",
+    );
+  });
+
+  it("leaves the state-error fallback intact when sanitize is false", () => {
+    const raw =
+      "Token request failed: client_secret=cs_localdevfallback1234567890";
+
+    const snapshot = projectOAuthTraceSnapshot({
+      state: {
+        ...EMPTY_OAUTH_FLOW_STATE,
+        currentStep: "token_request",
+        error: raw,
+        httpHistory: [
+          {
+            step: "token_request",
+            timestamp: 1_000,
+            request: {
+              method: "POST",
+              url: "https://auth.example.com/token",
+              headers: {},
+              body: { grant_type: "authorization_code" },
+            },
+            response: {
+              status: 400,
+              statusText: "Bad Request",
+              headers: {},
+              body: { error: "invalid_client" },
+            },
+          },
+        ],
+        infoLogs: [],
+      },
+      sanitize: false,
+    });
+
+    const tokenStep = snapshot.steps.find(
+      (step) => step.step === "token_request",
+    );
+    expect(tokenStep?.error).toBe(raw);
+  });
+
   it("leaves error messages intact when sanitize is false", () => {
     const raw = "Token request failed: client_secret=cs_localdevsecret123456";
     const snapshot = projectOAuthTraceSnapshot({


### PR DESCRIPTION
Part 1 of the OAuth maintainability stack.

This isolates trace state/error fallback redaction, client trace error redaction, and the executor redaction sentinel. It intentionally excludes MCP metadata policy, entrypoint refactors, differential fixtures, and sequence-diagram snapshots.

Follow-up stack: #3880.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches OAuth credential handling and trace surfaces where mistakes could break logins or leak secrets; changes are narrowly scoped to display vs live-data boundaries with new tests.
> 
> **Overview**
> **Part 1 of the OAuth maintainability stack** — closes gaps where credentials could appear in persisted/copied traces, and adds a guard when redaction markers leak into live OAuth data.
> 
> **Inspector client:** Error text for client-built traces now goes through `traceOAuthErrorMessage` in `trace-redaction.ts` (gated by `SANITIZE_OAUTH_TRACES`), including `failOAuthTraceStep`, refresh flows, and OAuth proxy transport failures. `sanitizeStepError` moved out of the debugger adapter into that module; the adapter re-exports it so existing callers stay unchanged. Proxy failures redact only the trace entry; thrown errors stay raw. `serializeBody` is documented as a live-data path that must not be redacted.
> 
> **SDK:** `projectOAuthTraceSnapshot` computes a single `projectedStateError` so every step-level fallback uses the same sanitized `state.error` (fixes the branch that still emitted raw strings when HTTP history existed). The state-machine factory wraps the request executor with `assertOAuthResultCredentialsUnredacted`, throwing `OAuthRedactedCredentialError` if `result.body` contains known redaction sentinels in token/secret fields — defense in depth against applying trace redaction to consumed responses.
> 
> Tests cover client hosted/local redaction, SDK trace projection, and executor sentinel behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f85759a686d69e4d9d5ba88e475be5ffdab471de. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Strengthens OAuth trace redaction and adds a guard to prevent redacted values from being used as live credentials. Fixes trace leaks and surfaces a clear error when a redaction sentinel reaches the state machine.

- **Bug Fixes**
  - Redacts the `state.error` fallback in `projectOAuthTraceSnapshot`, fixing an unsanitized step fallback.
  - Redacts client-built trace errors (`failOAuthTraceStep`, proxy transport failures) via `traceOAuthErrorMessage`, gated by `SANITIZE_OAUTH_TRACES`.
  - Keeps diagnostic wording (e.g., “Bearer token is expired”); documents that live data paths (e.g., `serializeBody`) are never redacted.

- **New Features**
  - Adds `assertOAuthResultCredentialsUnredacted` and `OAuthRedactedCredentialError` to detect `[redacted]`/`abcd...[redacted]...yz` sentinels in `access_token`, `refresh_token`, `id_token`, `client_secret` within executor `result.body`, and fail early with a clean target URL.
  - Wraps all state-machine executors with this check and exports the helpers from `@mcpjam/sdk` for consumers.
  - Moves the redactor into a shared client module and re-exports `sanitizeStepError`; adds focused tests for both the guard and redaction.

<sup>Written for commit f85759a686d69e4d9d5ba88e475be5ffdab471de. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/MCPJam/inspector/pull/3882?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

