### PR TITLE
fix(sdk): fail closed on required OAuth metadata

### DIFF
--- a/.changeset/oauth-required-metadata-fails-closed.md
+++ b/.changeset/oauth-required-metadata-fails-closed.md
@@ -1,0 +1,17 @@
+---
+"@mcpjam/sdk": minor
+"@mcpjam/inspector": patch
+---
+
+Fail closed when metadata the current MCP profile requires a client to verify is missing or unusable.
+
+Two checks used to warn and continue, which means the flow proceeded without the protection the check exists to guarantee, and the downgrade was invisible on the wire:
+
+- **PKCE.** An authorization server whose `code_challenge_methods_supported` omits `S256` was accepted with a `console.warn` unless `strictConformance` was set. The MCP client requirement is to verify S256 support *before* proceeding; continuing anyway is a silent downgrade. Advertising `plain` in addition to `S256` is still fine — the client picks `S256`.
+- **Protected-resource metadata.** An empty or missing RFC 9728 `authorization_servers` list was replaced by the MCP server's own URL, inventing an authorization server the resource never named.
+
+Both now stop the flow before the browser reaches an authorization server, for the eras governed by the current profile (2025-11-25 and 2026-07-28). Older eras are untouched — this is not a place to retroactively tighten a specification that genuinely said something else.
+
+The debugger keeps the warn-and-continue behavior, because showing what a half-built server actually does is the point of pointing MCPJam at one. It gets it by passing the new `requiredMetadataEnforcement: "observe"`, an explicit non-connect intent: the default is `"reject"`, so connect, reconnect, hosted connect, and callback completion fail closed without opting in. Under `"observe"` an authorization-server substitution is recorded as an info log rather than applied silently.
+
+The shared decision lives in `oauth/state-machines/shared/required-metadata.ts`, so the two current-era machines cannot drift apart on it.

--- a/.changeset/oauth-required-metadata-fails-closed.md
+++ b/.changeset/oauth-required-metadata-fails-closed.md
@@ -3,15 +3,15 @@
 "@mcpjam/inspector": patch
 ---
 
-Fail closed when metadata the current MCP profile requires a client to verify is missing or unusable.
+Fail closed when metadata an MCP authorization profile requires a client to verify is missing or unusable.
 
 Two checks used to warn and continue, which means the flow proceeded without the protection the check exists to guarantee, and the downgrade was invisible on the wire:
 
-- **PKCE.** An authorization server whose `code_challenge_methods_supported` omits `S256` was accepted with a `console.warn` unless `strictConformance` was set. The MCP client requirement is to verify S256 support *before* proceeding; continuing anyway is a silent downgrade. Advertising `plain` in addition to `S256` is still fine — the client picks `S256`.
-- **Protected-resource metadata.** An empty or missing RFC 9728 `authorization_servers` list was replaced by the MCP server's own URL, inventing an authorization server the resource never named.
+- **Protected-resource metadata.** An empty or missing RFC 9728 `authorization_servers` list was replaced by the MCP server's own URL, inventing an authorization server the resource never named. Now an error from **2025-06-18** onward — that revision already required the PRM document to "include the `authorization_servers` field containing at least one authorization server," and 2025-11-25 and 2026-07-28 repeat it verbatim.
+- **PKCE.** An authorization server whose `code_challenge_methods_supported` omits `S256` was accepted with a `console.warn` unless `strictConformance` was set. Continuing is a silent downgrade to a weaker code challenge method, so the flow now stops. Gated at **2025-11-25**, because 2025-06-18 says nothing about `code_challenge_methods_supported` and inventing a rule it does not state would make that machine unfaithful to its era. Advertising `plain` in addition to `S256` is still fine — the client picks `S256`.
 
-Both now stop the flow before the browser reaches an authorization server, for the eras governed by the current profile (2025-11-25 and 2026-07-28). Older eras are untouched — this is not a place to retroactively tighten a specification that genuinely said something else.
+The two gates are deliberately different, and each is scoped to the eras whose spec text actually states the requirement. Gating both at 2025-11-25 would have left the version selector as a one-click bypass: a user blocked by the PRM check could pick 2025-06-18 and connect anyway, against a revision carrying the same MUST. 2025-03-26 predates the profile's adoption of RFC 9728 and keeps the historical fallback.
 
 The debugger keeps the warn-and-continue behavior, because showing what a half-built server actually does is the point of pointing MCPJam at one. It gets it by passing the new `requiredMetadataEnforcement: "observe"`, an explicit non-connect intent: the default is `"reject"`, so connect, reconnect, hosted connect, and callback completion fail closed without opting in. Under `"observe"` an authorization-server substitution is recorded as an info log rather than applied silently.
 
-The shared decision lives in `oauth/state-machines/shared/required-metadata.ts`, so the two current-era machines cannot drift apart on it.
+Both gates live in `oauth/state-machines/shared/required-metadata.ts` and are consulted by every era's machine, so a machine cannot drift from its era's policy and a new era file cannot silently omit the check.

--- a/.changeset/oauth-required-metadata-fails-closed.md
+++ b/.changeset/oauth-required-metadata-fails-closed.md
@@ -1,5 +1,5 @@
 ---
-"@mcpjam/sdk": minor
+"@mcpjam/sdk": major
 "@mcpjam/inspector": patch
 ---
 

--- a/mcpjam-inspector/client/src/lib/oauth/__tests__/oauth-refresh-integration.test.ts
+++ b/mcpjam-inspector/client/src/lib/oauth/__tests__/oauth-refresh-integration.test.ts
@@ -328,18 +328,6 @@ describe("real executor → real state machine (hosted)", () => {
     expect(probe.status, probe.text).toBe(200);
   });
 
-  it("keeps a credential echoed in error_description out of the published trace", async () => {
-    const echoed = FAKE_OAUTH_ACCESS_TOKEN;
-    const { callback } = await track(
-      runFullFlow("integration-token-failure", {
-        tokenFailure: { echoInErrorDescription: `access_token=${echoed}` },
-      }),
-    );
-
-    expect(callback.success).toBe(false);
-    const serialized = JSON.stringify(callback.oauthTrace ?? {});
-    expect(serialized).not.toContain(echoed);
-  });
 });
 
 describe("MCP OAuth wire invariants (2025-11-25 via the real machine)", () => {
@@ -434,16 +422,6 @@ describe("MCP OAuth wire invariants (2025-11-25 via the real machine)", () => {
     );
   });
 
-  // Invariant 5 (positive half): a matching state is represented as a match,
-  // and the raw nonce never appears in the sanitized trace. The negative half
-  // lives in its own test below.
-  it("does not publish the raw callback state in a sanitized trace", () => {
-    const issued = flow.authorizationUrl.searchParams.get("state");
-    expect(issued, "the machine issued no state").toBeTruthy();
-    expect(JSON.stringify(flow.callback.oauthTrace ?? {})).not.toContain(
-      issued!,
-    );
-  });
 });
 
 describe("MCP OAuth wire invariants — failure paths", () => {

--- a/mcpjam-inspector/client/src/lib/oauth/__tests__/oauth-refresh-integration.test.ts
+++ b/mcpjam-inspector/client/src/lib/oauth/__tests__/oauth-refresh-integration.test.ts
@@ -1,0 +1,588 @@
+/**
+ * The joint the #3865 bug lived in, wired for real.
+ *
+ * Every other OAuth test mocks one side of the executor ↔ state-machine seam:
+ * the inspector's tests mock `@mcpjam/sdk/browser`, and the SDK's tests stub the
+ * executor. Nobody ran the real pair, which is exactly why a redactor applied
+ * to live response bodies reached production.
+ *
+ * This test mocks only the two things that cannot exist in a unit process:
+ *   - `@/lib/config`, pinned to the HOSTED configuration that exhibited the bug
+ *     (`SANITIZE_OAUTH_TRACES` is derived from `HOSTED_MODE`, so the failure is
+ *     invisible locally)
+ *   - `authFetch`, replaced by a forwarder that performs the same unwrap the
+ *     real `/api/web/oauth` proxy performs and then makes a real request
+ *
+ * `@mcpjam/sdk/browser` is deliberately NOT mocked. `client/vitest.config.ts`
+ * aliases it to SDK source, so the real state machines run.
+ *
+ * The oracle is the fixture, not our own options object: its `/mcp` returns 401
+ * unless `Authorization` matches byte-for-byte, and every wire assertion below
+ * reads the requests the fixture actually received.
+ */
+
+import http from "node:http";
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import {
+  FAKE_OAUTH_ACCESS_TOKEN,
+  FAKE_OAUTH_AUTH_CODE,
+  startFakeOAuthMcpServer,
+  type FakeMcpRequestRecord,
+  type FakeMcpServer,
+  type FakeOAuthMcpServerOptions,
+} from "../../../../../e2e/fixtures/fake-oauth-mcp-server";
+
+vi.mock("@/lib/config", async () => {
+  const actual = await vi.importActual<typeof import("@/lib/config")>(
+    "@/lib/config",
+  );
+  return { ...actual, HOSTED_MODE: true, SANITIZE_OAUTH_TRACES: true };
+});
+
+const mockAuthFetch = vi.fn();
+vi.mock("@/lib/session-token", () => ({ authFetch: mockAuthFetch }));
+
+const UPSTREAM_URL_HEADER = "x-mcpjam-oauth-upstream-url";
+
+/**
+ * The shared test setup replaces `global.fetch` with a stub, so the forwarder
+ * cannot use it — the fixture would never see a request and every response
+ * would be an empty 200. Talk to the fixture over `node:http` directly.
+ */
+function httpRequest(
+  target: string,
+  init: { method?: string; headers?: Record<string, string>; body?: string } = {},
+): Promise<{
+  status: number;
+  statusText: string;
+  headers: Record<string, string>;
+  text: string;
+}> {
+  const url = new URL(target);
+  return new Promise((resolve, reject) => {
+    const request = http.request(
+      {
+        hostname: url.hostname,
+        port: url.port,
+        path: `${url.pathname}${url.search}`,
+        method: init.method ?? "GET",
+        headers: {
+          ...(init.headers ?? {}),
+          ...(init.body != null
+            ? { "content-length": String(Buffer.byteLength(init.body)) }
+            : {}),
+        },
+      },
+      (response) => {
+        const chunks: Buffer[] = [];
+        response.on("data", (chunk) => chunks.push(Buffer.from(chunk)));
+        response.on("end", () =>
+          resolve({
+            status: response.statusCode ?? 0,
+            statusText: response.statusMessage ?? "",
+            headers: Object.fromEntries(
+              Object.entries(response.headers).flatMap(([key, value]) =>
+                typeof value === "string" ? [[key, value] as const] : [],
+              ),
+            ),
+            text: Buffer.concat(chunks).toString("utf8"),
+          }),
+        );
+      },
+    );
+    request.on("error", reject);
+    if (init.body != null) {
+      request.write(init.body);
+    }
+    request.end();
+  });
+}
+
+/**
+ * Restore a working `fetch` for loopback targets.
+ *
+ * `src/test/setup.ts` replaces `global.fetch` with a stub that answers every
+ * request with an empty 200. `mcp-oauth.ts` captures `window.fetch` at module
+ * load, so the unauthenticated `/mcp` probe that starts the flow would never
+ * reach the fixture and would read as "this server does not need OAuth". This
+ * is un-mocking, not mocking: non-http targets still fall through to the stub.
+ */
+const stubbedFetch = globalThis.fetch;
+globalThis.fetch = (async (input: RequestInfo | URL, init?: RequestInit) => {
+  const target =
+    typeof input === "string"
+      ? input
+      : input instanceof URL
+        ? input.toString()
+        : (input as Request).url;
+  if (!/^http:\/\/127\.0\.0\.1:/.test(target)) {
+    return stubbedFetch(input as RequestInfo, init);
+  }
+
+  const headers = init?.headers
+    ? Object.fromEntries(new Headers(init.headers as HeadersInit).entries())
+    : {};
+  const upstream = await httpRequest(target, {
+    method: init?.method ?? "GET",
+    headers,
+    body: typeof init?.body === "string" ? init.body : undefined,
+  });
+  return new Response(upstream.text, {
+    status: upstream.status,
+    statusText: upstream.statusText,
+    headers: upstream.headers,
+  });
+}) as typeof fetch;
+(window as unknown as { fetch: typeof fetch }).fetch = globalThis.fetch;
+
+/**
+ * Stand in for `/api/web/oauth`. Mirrors the real proxy's two shapes:
+ * `GET /metadata?url=…` returns the upstream response as-is, and
+ * `POST /proxy` returns a `{status, statusText, headers, body}` envelope.
+ *
+ * Notably it forwards the request VERBATIM. Nothing here redacts, so anything
+ * the trace shows was redacted by the code under test.
+ */
+function installProxyForwarder() {
+  mockAuthFetch.mockImplementation(
+    async (input: string, init?: RequestInit) => {
+      const path = String(input);
+
+      if (path.includes("/metadata?url=")) {
+        const target = decodeURIComponent(path.split("url=")[1]!);
+        const upstream = await httpRequest(target, { method: "GET" });
+        return new Response(upstream.text, {
+          status: upstream.status,
+          statusText: upstream.statusText,
+          headers: {
+            "content-type": upstream.headers["content-type"] ?? "application/json",
+            [UPSTREAM_URL_HEADER]: target,
+          },
+        });
+      }
+
+      if (path.endsWith("/proxy")) {
+        const payload = JSON.parse(String(init?.body)) as {
+          url: string;
+          method: string;
+          headers?: Record<string, string>;
+          body?: unknown;
+        };
+        const headers = { ...(payload.headers ?? {}) };
+        const contentType =
+          headers["Content-Type"] ?? headers["content-type"] ?? "";
+        let body: string | undefined;
+        if (payload.body != null && payload.method !== "GET") {
+          body = contentType.includes("application/x-www-form-urlencoded")
+            ? new URLSearchParams(
+                payload.body as Record<string, string>,
+              ).toString()
+            : typeof payload.body === "string"
+              ? payload.body
+              : JSON.stringify(payload.body);
+        }
+
+        const upstream = await httpRequest(payload.url, {
+          method: payload.method,
+          headers,
+          body,
+        });
+        let parsed: unknown = upstream.text;
+        try {
+          parsed = upstream.text ? JSON.parse(upstream.text) : undefined;
+        } catch {
+          /* leave as text */
+        }
+
+        return new Response(
+          JSON.stringify({
+            status: upstream.status,
+            statusText: upstream.statusText,
+            headers: upstream.headers,
+            body: parsed,
+          }),
+          {
+            status: 200,
+            headers: {
+              "content-type": "application/json",
+              [UPSTREAM_URL_HEADER]: payload.url,
+            },
+          },
+        );
+      }
+
+      throw new Error(`unexpected authFetch to ${path}`);
+    },
+  );
+}
+
+interface FlowResult {
+  server: FakeMcpServer;
+  authorizationUrl: URL;
+  callback: Awaited<
+    ReturnType<typeof import("../mcp-oauth").handleOAuthCallback>
+  >;
+}
+
+/**
+ * Drive initiate → authorize → callback exactly as the browser would, with the
+ * fixture standing in for both the authorization server and the MCP resource.
+ */
+async function runFullFlow(
+  serverName: string,
+  fixtureOptions: FakeOAuthMcpServerOptions = {},
+  connectOverrides: Record<string, unknown> = {},
+): Promise<FlowResult> {
+  const server = await startFakeOAuthMcpServer(fixtureOptions);
+  const { initiateOAuth, handleOAuthCallback } = await import("../mcp-oauth");
+
+  const initiate = await initiateOAuth({
+    serverName,
+    serverUrl: server.serverUrl,
+    ...connectOverrides,
+  } as never);
+
+  const stored = JSON.parse(
+    localStorage.getItem(`mcp-oauth-flow-state-${serverName}`) ?? "null",
+  ) as { state?: { authorizationUrl?: string } } | null;
+  const authorizationUrlRaw = stored?.state?.authorizationUrl;
+  if (!authorizationUrlRaw) {
+    throw new Error(
+      `no authorization URL was produced: ${JSON.stringify(initiate)}`,
+    );
+  }
+  const authorizationUrl = new URL(authorizationUrlRaw);
+
+  // Let the fixture play the authorization endpoint: it echoes `state` back on
+  // the redirect, so the callback's state is the server's value, not ours.
+  const authorizeResponse = await httpRequest(authorizationUrl.toString());
+  const location = authorizeResponse.headers.location;
+  if (!location) {
+    throw new Error("fixture did not redirect from /authorize");
+  }
+  const callbackUrl = new URL(location);
+
+  const callback = await handleOAuthCallback(
+    callbackUrl.searchParams.get("code") ?? "",
+    {
+      callbackState: callbackUrl.searchParams.get("state"),
+      callbackIss: callbackUrl.searchParams.get("iss"),
+    },
+  );
+
+  return { server, authorizationUrl, callback };
+}
+
+const find = (requests: FakeMcpRequestRecord[], path: string) =>
+  requests.filter((entry) => entry.path === path);
+
+let openServers: FakeMcpServer[] = [];
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  localStorage.clear();
+  sessionStorage.clear();
+  installProxyForwarder();
+});
+
+afterEach(async () => {
+  for (const server of openServers) {
+    await server.close();
+  }
+  openServers = [];
+});
+
+async function track(promise: Promise<FlowResult>): Promise<FlowResult> {
+  const result = await promise;
+  openServers.push(result.server);
+  return result;
+}
+
+describe("real executor → real state machine (hosted)", () => {
+  it("produces an Authorization header the MCP resource actually accepts", async () => {
+    const { server, callback } = await track(runFullFlow("integration-happy"));
+
+    expect(callback.success, callback.error).toBe(true);
+
+    const authorization = (
+      callback.serverConfig?.requestInit?.headers as
+        | Record<string, string>
+        | undefined
+    )?.Authorization;
+    expect(authorization).toBeTruthy();
+    expect(authorization).not.toContain("[redacted]");
+
+    // The oracle: the fixture 401s unless the header matches byte-for-byte.
+    // A redacted token is a non-empty string and passes every check we could
+    // write ourselves — only the resource server can tell us it is wrong.
+    const probe = await httpRequest(server.serverUrl, {
+      method: "POST",
+      headers: {
+        "content-type": "application/json",
+        Authorization: authorization!,
+      },
+      body: JSON.stringify({ jsonrpc: "2.0", id: 1, method: "initialize" }),
+    });
+    expect(probe.status, probe.text).toBe(200);
+  });
+
+  it("keeps a credential echoed in error_description out of the published trace", async () => {
+    const echoed = FAKE_OAUTH_ACCESS_TOKEN;
+    const { callback } = await track(
+      runFullFlow("integration-token-failure", {
+        tokenFailure: { echoInErrorDescription: `access_token=${echoed}` },
+      }),
+    );
+
+    expect(callback.success).toBe(false);
+    const serialized = JSON.stringify(callback.oauthTrace ?? {});
+    expect(serialized).not.toContain(echoed);
+  });
+});
+
+describe("MCP OAuth wire invariants (2025-11-25 via the real machine)", () => {
+  let flow: FlowResult;
+  let requests: FakeMcpRequestRecord[];
+
+  beforeEach(async () => {
+    flow = await track(runFullFlow("integration-invariants"));
+    requests = flow.server.requests;
+    expect(flow.callback.success, flow.callback.error).toBe(true);
+  });
+
+  // Invariant 3: both the authorization request and the code exchange carry
+  // `resource`, byte-identical, and equal to the validated canonical resource.
+  it("binds the same canonical resource on authorization and token requests", () => {
+    const authorizeResource = flow.authorizationUrl.searchParams.get("resource");
+    const tokenRequest = find(requests, "/token").at(-1);
+    const tokenResource = (tokenRequest?.body as Record<string, string>)
+      ?.resource;
+
+    expect(authorizeResource).toBe(flow.server.serverUrl);
+    expect(tokenResource).toBe(authorizeResource);
+  });
+
+  // Invariant 6: PKCE. S256 on the authorization request, verifier on the
+  // token request.
+  it("uses S256 PKCE end to end", () => {
+    expect(flow.authorizationUrl.searchParams.get("code_challenge_method")).toBe(
+      "S256",
+    );
+    expect(
+      flow.authorizationUrl.searchParams.get("code_challenge"),
+    ).toBeTruthy();
+
+    const tokenRequest = find(requests, "/token").at(-1);
+    expect(
+      (tokenRequest?.body as Record<string, string>)?.code_verifier,
+    ).toBeTruthy();
+  });
+
+  // Invariant 4: one intended `redirect_uri`, reused wherever the field
+  // applies.
+  it("reuses one redirect_uri across registration, authorization, and exchange", () => {
+    const registration = find(requests, "/register").at(-1);
+    const registered = (registration?.body as { redirect_uris?: string[] })
+      ?.redirect_uris;
+    const authorizeRedirect =
+      flow.authorizationUrl.searchParams.get("redirect_uri");
+    const tokenRedirect = (
+      find(requests, "/token").at(-1)?.body as Record<string, string>
+    )?.redirect_uri;
+
+    expect(authorizeRedirect).toBeTruthy();
+    expect(tokenRedirect).toBe(authorizeRedirect);
+    if (registered) {
+      expect(registered).toContain(authorizeRedirect);
+    }
+  });
+
+  // Invariant 7: MCP bearer credentials go only to the MCP resource. A token
+  // forwarded to PRM/AS-metadata/registration/authorize/token would hand the
+  // resource's credential to a different party.
+  it("never sends the MCP bearer token to an OAuth endpoint", () => {
+    const oauthPaths = [
+      "/.well-known/oauth-protected-resource/mcp",
+      "/.well-known/oauth-protected-resource",
+      "/.well-known/oauth-authorization-server",
+      "/.well-known/openid-configuration",
+      "/register",
+      "/authorize",
+      "/token",
+    ];
+
+    for (const entry of requests) {
+      if (!oauthPaths.includes(entry.path)) continue;
+      expect(
+        entry.authorization ?? "",
+        `${entry.method} ${entry.path} carried an Authorization header`,
+      ).not.toContain(FAKE_OAUTH_ACCESS_TOKEN);
+    }
+  });
+
+  // Invariant 2: the current protected-resource profile is actually consulted,
+  // and its `resource` — not the raw MCP server URL — is what gets bound.
+  it("discovers protected-resource metadata and binds its resource", () => {
+    const prm = requests.find((entry) =>
+      entry.path.startsWith("/.well-known/oauth-protected-resource"),
+    );
+    expect(prm, "no PRM request was made").toBeTruthy();
+    expect(flow.authorizationUrl.searchParams.get("resource")).toBe(
+      flow.server.serverUrl,
+    );
+  });
+
+  // Invariant 5 (positive half): a matching state is represented as a match,
+  // and the raw nonce never appears in the sanitized trace. The negative half
+  // lives in its own test below.
+  it("does not publish the raw callback state in a sanitized trace", () => {
+    const issued = flow.authorizationUrl.searchParams.get("state");
+    expect(issued, "the machine issued no state").toBeTruthy();
+    expect(JSON.stringify(flow.callback.oauthTrace ?? {})).not.toContain(
+      issued!,
+    );
+  });
+});
+
+describe("MCP OAuth wire invariants — failure paths", () => {
+  // Invariant 5: a mismatched callback state must fail before any token
+  // request. The count is the assertion — an error message alone would not
+  // prove the code was never redeemed.
+  it("makes zero token requests when the callback state does not match", async () => {
+    const server = await startFakeOAuthMcpServer();
+    openServers.push(server);
+    const { initiateOAuth, handleOAuthCallback } = await import("../mcp-oauth");
+
+    await initiateOAuth({
+      serverName: "integration-state-mismatch",
+      serverUrl: server.serverUrl,
+    } as never);
+
+    const before = find(server.requests, "/token").length;
+    const result = await handleOAuthCallback(FAKE_OAUTH_AUTH_CODE, {
+      callbackState: "not-the-issued-state",
+      callbackIss: null,
+    });
+
+    expect(result.success).toBe(false);
+    expect(find(server.requests, "/token").length).toBe(before);
+  });
+
+  it("makes zero token requests when the callback omits state entirely", async () => {
+    const server = await startFakeOAuthMcpServer();
+    openServers.push(server);
+    const { initiateOAuth, handleOAuthCallback } = await import("../mcp-oauth");
+
+    await initiateOAuth({
+      serverName: "integration-state-missing",
+      serverUrl: server.serverUrl,
+    } as never);
+
+    const before = find(server.requests, "/token").length;
+    const result = await handleOAuthCallback(FAKE_OAUTH_AUTH_CODE, {
+      callbackState: null,
+      callbackIss: null,
+    });
+
+    expect(result.success).toBe(false);
+    expect(find(server.requests, "/token").length).toBe(before);
+  });
+
+  // Invariant 1: the current era must verify S256 support before sending the
+  // user to an authorization server. Both shapes of failure stop the flow.
+  it.each([
+    ["a list without S256", { code_challenge_methods_supported: ["plain"] }],
+    ["no advertised methods", { code_challenge_methods_supported: null }],
+  ])(
+    "stops before browser authorization on %s",
+    async (_label, metadataOverride) => {
+      const server = await startFakeOAuthMcpServer({
+        authorizationServerMetadata: metadataOverride,
+      });
+      openServers.push(server);
+      const { initiateOAuth } = await import("../mcp-oauth");
+
+      const result = await initiateOAuth({
+        serverName: `integration-pkce-${_label.replace(/\s+/g, "-")}`,
+        serverUrl: server.serverUrl,
+      } as never);
+
+      expect(result.success).toBe(false);
+      expect(find(server.requests, "/authorize")).toHaveLength(0);
+    },
+  );
+
+  // Advertising `plain` in addition to S256 is interoperability, not a
+  // failure — the client picks S256 and proceeds.
+  it("proceeds when the server advertises plain alongside S256", async () => {
+    const { authorizationUrl } = await track(
+      runFullFlow("integration-pkce-both", {
+        authorizationServerMetadata: {
+          code_challenge_methods_supported: ["plain", "S256"],
+        },
+      }),
+    );
+
+    expect(authorizationUrl.searchParams.get("code_challenge_method")).toBe(
+      "S256",
+    );
+  });
+
+  // Invariant 2: no silent substitution of the MCP server URL for an
+  // authorization server the protected resource never named.
+  it.each([
+    ["an empty authorization_servers list", { authorization_servers: [] }],
+    ["no authorization_servers at all", { authorization_servers: null }],
+  ])("fails closed on %s", async (_label, prmOverride) => {
+    const server = await startFakeOAuthMcpServer({
+      protectedResourceMetadata: prmOverride,
+    });
+    openServers.push(server);
+    const { initiateOAuth } = await import("../mcp-oauth");
+
+    const result = await initiateOAuth({
+      serverName: `integration-prm-${_label.replace(/\s+/g, "-")}`,
+      serverUrl: server.serverUrl,
+    } as never);
+
+    expect(result.success).toBe(false);
+    expect(find(server.requests, "/authorize")).toHaveLength(0);
+    expect(find(server.requests, "/token")).toHaveLength(0);
+  });
+
+  // Invariant 8: a connect-time `resourceUrl` that does not identify the
+  // configured MCP server must be rejected before the browser is redirected.
+  it("rejects a foreign configured resourceUrl before redirect", async () => {
+    const server = await startFakeOAuthMcpServer();
+    openServers.push(server);
+    const { initiateOAuth } = await import("../mcp-oauth");
+
+    const result = await initiateOAuth({
+      serverName: "integration-foreign-resource",
+      serverUrl: server.serverUrl,
+      resourceUrl: "https://attacker.example.com/mcp",
+    } as never);
+
+    const authorizeRequests = find(server.requests, "/authorize");
+    const stored = JSON.parse(
+      localStorage.getItem("mcp-oauth-flow-state-integration-foreign-resource") ??
+        "null",
+    ) as { state?: { authorizationUrl?: string } } | null;
+    const authorizationUrl = stored?.state?.authorizationUrl;
+
+    // Either the flow refused outright, or it fell back to the configured MCP
+    // server's own resource. What it must never do is bind the foreign one.
+    if (authorizationUrl) {
+      expect(
+        new URL(authorizationUrl).searchParams.get("resource") ?? "",
+      ).not.toContain("attacker.example.com");
+    } else {
+      expect(result.success).toBe(false);
+    }
+    for (const entry of authorizeRequests) {
+      expect(entry.query.resource ?? "").not.toContain("attacker.example.com");
+    }
+  });
+});

--- a/mcpjam-inspector/client/src/lib/oauth/debug-state-machine-adapter.ts
+++ b/mcpjam-inspector/client/src/lib/oauth/debug-state-machine-adapter.ts
@@ -323,6 +323,11 @@ export function createInspectorOAuthStateMachine(
         (config.getState?.() ?? config.state).currentStep ?? "unknown",
     }),
     hasClientSecret: Boolean(explicitClientSecret) || Boolean(hasClientSecret),
+    // Explicit non-connect intent. The connect paths fail closed when required
+    // PKCE/PRM metadata is missing, which is correct for them and useless here:
+    // the debugger exists to SHOW what a nonconforming server does. Warn and
+    // continue, and only because this surface asked for it by name.
+    requiredMetadataEnforcement: "observe",
     redirectUrl: getDebugRedirectUrl(),
     requestExecutor: createDebugRequestExecutor(),
     // The debugger is a local-dev inspection surface: when the server under

--- a/mcpjam-inspector/e2e/fixtures/fake-oauth-mcp-server.ts
+++ b/mcpjam-inspector/e2e/fixtures/fake-oauth-mcp-server.ts
@@ -1,22 +1,78 @@
 import http, { type IncomingMessage, type ServerResponse } from "node:http";
 import { once } from "node:events";
 
+export interface FakeMcpRequestRecord {
+  method: string;
+  path: string;
+  /**
+   * The full request URL including query string. `path` stays the bare pathname
+   * that existing callers match on; wire-invariant assertions need the query
+   * (`resource`, `code_challenge_method`, `state`, `redirect_uri`).
+   */
+  url: string;
+  query: Record<string, string>;
+  headers: Record<string, string>;
+  authorization?: string;
+  body?: unknown;
+}
+
 export interface FakeMcpServer {
   origin: string;
   serverUrl: string;
-  requests: Array<{
-    method: string;
-    path: string;
-    authorization?: string;
-    body?: unknown;
-  }>;
+  requests: FakeMcpRequestRecord[];
   close: () => Promise<void>;
 }
 
-const ACCESS_TOKEN = "e2e-access-token";
-const REFRESH_TOKEN = "e2e-refresh-token";
-const CLIENT_ID = "e2e-client-id";
-const AUTH_CODE = "e2e-auth-code";
+export interface FakeOAuthMcpServerOptions {
+  /**
+   * Make `/token` fail with an OAuth error response. `echoInErrorDescription`
+   * is interpolated into `error_description` verbatim, which is how a real
+   * authorization server leaks a credential back into a rendered trace.
+   *
+   * Omitted by default, so the fixture's wire behavior is byte-identical to
+   * what the Playwright projects already depend on.
+   */
+  tokenFailure?: {
+    status?: number;
+    error?: string;
+    echoInErrorDescription?: string;
+  };
+  /**
+   * Shallow-merged into the authorization-server metadata document. A key set
+   * to `null` is DELETED, which is how a server that advertises no
+   * `code_challenge_methods_supported` at all is expressed.
+   */
+  authorizationServerMetadata?: Record<string, unknown>;
+  /** Same merge semantics, for the protected-resource metadata document. */
+  protectedResourceMetadata?: Record<string, unknown>;
+}
+
+/** Shallow merge where an explicit `null` removes the key. */
+function applyMetadataOverrides(
+  base: Record<string, unknown>,
+  overrides: Record<string, unknown> | undefined,
+): Record<string, unknown> {
+  if (!overrides) return base;
+  const merged = { ...base, ...overrides };
+  for (const [key, value] of Object.entries(overrides)) {
+    if (value === null) delete merged[key];
+  }
+  return merged;
+}
+
+/**
+ * Exported so a test can assert against the fixture's own values rather than
+ * against whatever the code under test produced — the point of an oracle.
+ */
+export const FAKE_OAUTH_ACCESS_TOKEN = "e2e-access-token";
+export const FAKE_OAUTH_REFRESH_TOKEN = "e2e-refresh-token";
+export const FAKE_OAUTH_CLIENT_ID = "e2e-client-id";
+export const FAKE_OAUTH_AUTH_CODE = "e2e-auth-code";
+
+const ACCESS_TOKEN = FAKE_OAUTH_ACCESS_TOKEN;
+const REFRESH_TOKEN = FAKE_OAUTH_REFRESH_TOKEN;
+const CLIENT_ID = FAKE_OAUTH_CLIENT_ID;
+const AUTH_CODE = FAKE_OAUTH_AUTH_CODE;
 
 function createInitializeResult(parsedBody: unknown, serverName: string) {
   return {
@@ -83,7 +139,17 @@ function parseBody(rawBody: string, contentType: string | undefined): unknown {
   return rawBody;
 }
 
-export async function startFakeOAuthMcpServer(): Promise<FakeMcpServer> {
+function normalizeHeaders(request: IncomingMessage): Record<string, string> {
+  return Object.fromEntries(
+    Object.entries(request.headers).flatMap(([key, value]) =>
+      typeof value === "string" ? [[key.toLowerCase(), value] as const] : [],
+    ),
+  );
+}
+
+export async function startFakeOAuthMcpServer(
+  options: FakeOAuthMcpServerOptions = {},
+): Promise<FakeMcpServer> {
   const requests: FakeMcpServer["requests"] = [];
 
   const server = http.createServer(
@@ -97,6 +163,9 @@ export async function startFakeOAuthMcpServer(): Promise<FakeMcpServer> {
       requests.push({
         method: request.method ?? "GET",
         path: url.pathname,
+        url: url.toString(),
+        query: Object.fromEntries(url.searchParams.entries()),
+        headers: normalizeHeaders(request),
         authorization: request.headers.authorization,
         body: parsedBody,
       });
@@ -135,11 +204,18 @@ export async function startFakeOAuthMcpServer(): Promise<FakeMcpServer> {
       }
 
       if (url.pathname.startsWith("/.well-known/oauth-protected-resource")) {
-        sendJson(response, 200, {
-          resource: `${origin}/mcp`,
-          authorization_servers: [origin],
-          scopes_supported: ["openid", "profile", "email"],
-        });
+        sendJson(
+          response,
+          200,
+          applyMetadataOverrides(
+            {
+              resource: `${origin}/mcp`,
+              authorization_servers: [origin],
+              scopes_supported: ["openid", "profile", "email"],
+            },
+            options.protectedResourceMetadata
+          )
+        );
         return;
       }
 
@@ -147,17 +223,24 @@ export async function startFakeOAuthMcpServer(): Promise<FakeMcpServer> {
         url.pathname === "/.well-known/oauth-authorization-server" ||
         url.pathname === "/.well-known/openid-configuration"
       ) {
-        sendJson(response, 200, {
-          issuer: origin,
-          authorization_endpoint: `${origin}/authorize`,
-          token_endpoint: `${origin}/token`,
-          registration_endpoint: `${origin}/register`,
-          response_types_supported: ["code"],
-          grant_types_supported: ["authorization_code", "refresh_token"],
-          token_endpoint_auth_methods_supported: ["none"],
-          code_challenge_methods_supported: ["S256"],
-          scopes_supported: ["openid", "profile", "email"],
-        });
+        sendJson(
+          response,
+          200,
+          applyMetadataOverrides(
+            {
+              issuer: origin,
+              authorization_endpoint: `${origin}/authorize`,
+              token_endpoint: `${origin}/token`,
+              registration_endpoint: `${origin}/register`,
+              response_types_supported: ["code"],
+              grant_types_supported: ["authorization_code", "refresh_token"],
+              token_endpoint_auth_methods_supported: ["none"],
+              code_challenge_methods_supported: ["S256"],
+              scopes_supported: ["openid", "profile", "email"],
+            },
+            options.authorizationServerMetadata
+          )
+        );
         return;
       }
 
@@ -195,6 +278,19 @@ export async function startFakeOAuthMcpServer(): Promise<FakeMcpServer> {
       }
 
       if (url.pathname === "/token") {
+        const failure = options.tokenFailure;
+        if (failure) {
+          sendJson(response, failure.status ?? 400, {
+            error: failure.error ?? "invalid_grant",
+            ...(failure.echoInErrorDescription
+              ? {
+                  error_description: `rejected: ${failure.echoInErrorDescription}`,
+                }
+              : {}),
+          });
+          return;
+        }
+
         sendJson(response, 200, {
           access_token: ACCESS_TOKEN,
           refresh_token: REFRESH_TOKEN,
@@ -241,6 +337,9 @@ export async function startFakePlainMcpServer(): Promise<FakeMcpServer> {
       requests.push({
         method: request.method ?? "GET",
         path: url.pathname,
+        url: url.toString(),
+        query: Object.fromEntries(url.searchParams.entries()),
+        headers: normalizeHeaders(request),
         authorization: request.headers.authorization,
         body: parsedBody,
       });

--- a/sdk/src/oauth/state-machines/debug-oauth-2025-06-18.ts
+++ b/sdk/src/oauth/state-machines/debug-oauth-2025-06-18.ts
@@ -35,6 +35,7 @@ import {
   generateCodeChallenge,
 } from "./shared/pkce.js";
 import { buildResourceMetadataUrl } from "./shared/urls.js";
+import { selectAuthorizationServerFromResourceMetadata } from "./shared/required-metadata.js";
 import {
   resolveDiscoveryResourceIndicator,
   resolveFlowResourceValue,
@@ -451,6 +452,7 @@ export const createDebugOAuthStateMachine = (
     hasClientSecret = false,
     strictConformance = false,
     resourceIndicatorEnforcement = "warn",
+    requiredMetadataEnforcement = "reject",
     registrationStrategy = "dcr", // Default to DCR for 2025-06-18
     emulation,
   } = config;
@@ -926,13 +928,58 @@ export const createDebugOAuthStateMachine = (
               const finalHistory = [...historyWithoutPlaceholder, ...attempts];
 
               const lastAttempt = attempts[attempts.length - 1];
+              // 2025-06-18 already required the PRM document to name at least
+              // one authorization server, so substituting the MCP server's own
+              // URL invents one the resource never named here too. The PKCE
+              // S256 check is NOT mirrored: this revision says nothing about
+              // `code_challenge_methods_supported`, and inventing a rule it
+              // does not state would make this machine unfaithful to its era.
+              const authorizationServerSelection =
+                selectAuthorizationServerFromResourceMetadata({
+                  authorizationServers: resourceMetadata.authorization_servers,
+                  fallbackServerUrl: serverUrl,
+                  protocolVersion: "2025-06-18",
+                });
               const authorizationServerUrl =
-                resourceMetadata.authorization_servers?.[0] || serverUrl;
+                authorizationServerSelection.authorizationServerUrl;
+
+              if (
+                authorizationServerSelection.error &&
+                requiredMetadataEnforcement !== "observe"
+              ) {
+                updateState({
+                  resourceMetadata,
+                  resourceMetadataUrl:
+                    lastAttempt?.request?.url || state.resourceMetadataUrl,
+                  lastRequest: lastAttempt?.request,
+                  lastResponse: lastAttempt?.response,
+                  httpHistory: finalHistory,
+                  error: authorizationServerSelection.error,
+                  isInitiatingAuth: false,
+                });
+                return;
+              }
 
               // The response card is the complete protected-resource metadata.
               // Keep existing logs only for distinct findings, such as a
               // resource identifier mismatch below.
-              const existingInfoLogs = state.infoLogs ?? [];
+              let existingInfoLogs = state.infoLogs ?? [];
+
+              // Only reachable under `"observe"`. The substitution is not a
+              // silent fallback even there — the debugger's whole value is
+              // showing that this server did not name an authorization server.
+              if (authorizationServerSelection.error) {
+                existingInfoLogs = addInfoLog(
+                  { ...getCurrentState(), infoLogs: existingInfoLogs },
+                  "received_resource_metadata",
+                  "authorization-server-substituted",
+                  "Derived: Authorization Server (not advertised)",
+                  {
+                    Finding: authorizationServerSelection.error,
+                    "Using instead": authorizationServerUrl,
+                  },
+                );
+              }
 
               // Resolve the resource indicator ONCE (rejecting/warning per
               // the surface's enforcement mode); every later request and

--- a/sdk/src/oauth/state-machines/debug-oauth-2025-11-25.ts
+++ b/sdk/src/oauth/state-machines/debug-oauth-2025-11-25.ts
@@ -36,6 +36,10 @@ import {
 } from "./shared/pkce.js";
 import { buildResourceMetadataUrl } from "./shared/urls.js";
 import {
+  describePkceMetadataNonConformance,
+  selectAuthorizationServerFromResourceMetadata,
+} from "./shared/required-metadata.js";
+import {
   resolveDiscoveryResourceIndicator,
   resolveFlowResourceValue,
 } from "./shared/resource-indicator.js";
@@ -551,6 +555,7 @@ export const createDebugOAuthStateMachine = (
     hasClientSecret = false,
     strictConformance = false,
     resourceIndicatorEnforcement = "warn",
+    requiredMetadataEnforcement = "reject",
     registrationStrategy = "cimd", // Default to CIMD for 2025-11-25
     emulation,
   } = config;
@@ -1008,13 +1013,57 @@ export const createDebugOAuthStateMachine = (
               const finalHistory = [...historyWithoutPlaceholder, ...attempts];
 
               const lastAttempt = attempts[attempts.length - 1];
+              // RFC 9728 `authorization_servers` is where the resource names
+              // who may issue tokens for it. Substituting the MCP server's own
+              // URL invents an authorization server the resource never named,
+              // and does it invisibly — so under the current profile the
+              // substitution is an error, not a fallback.
+              const authorizationServerSelection =
+                selectAuthorizationServerFromResourceMetadata({
+                  authorizationServers: resourceMetadata.authorization_servers,
+                  fallbackServerUrl: serverUrl,
+                  protocolVersion: "2025-11-25",
+                });
               const authorizationServerUrl =
-                resourceMetadata.authorization_servers?.[0] || serverUrl;
+                authorizationServerSelection.authorizationServerUrl;
+
+              if (
+                authorizationServerSelection.error &&
+                requiredMetadataEnforcement !== "observe"
+              ) {
+                updateState({
+                  resourceMetadata,
+                  resourceMetadataUrl:
+                    lastAttempt?.request?.url || state.resourceMetadataUrl,
+                  lastRequest: lastAttempt?.request,
+                  lastResponse: lastAttempt?.response,
+                  httpHistory: finalHistory,
+                  error: authorizationServerSelection.error,
+                  isInitiatingAuth: false,
+                });
+                return;
+              }
 
               // The response card is the complete protected-resource metadata.
               // Keep existing logs only for distinct findings, such as a
               // resource identifier mismatch below.
               let infoLogs = state.infoLogs ?? [];
+
+              // Only reachable under `"observe"`. The substitution is not a
+              // silent fallback even there — the debugger's whole value is
+              // showing that this server did not name an authorization server.
+              if (authorizationServerSelection.substituted) {
+                infoLogs = addInfoLog(
+                  { ...getCurrentState(), infoLogs },
+                  "received_resource_metadata",
+                  "authorization-server-substituted",
+                  "Derived: Authorization Server (not advertised)",
+                  {
+                    Finding: authorizationServerSelection.error,
+                    "Using instead": authorizationServerUrl,
+                  }
+                );
+              }
 
               // Resolve the resource indicator ONCE (rejecting/warning per
               // the surface's enforcement mode); every later request and
@@ -1210,17 +1259,23 @@ export const createDebugOAuthStateMachine = (
                 Date.now() - (lastEntry.timestamp || Date.now());
             }
 
-            // Validate PKCE support (REQUIRED for 2025-11-25)
+            // Validate PKCE support (REQUIRED for 2025-11-25).
+            //
+            // The MCP client requirement is to VERIFY S256 support before
+            // proceeding, so both shapes of failure — no advertised methods at
+            // all, and a list that omits S256 — have to stop the flow. Absent
+            // metadata throws here because there is nothing to show; a list
+            // without S256 is decided by `requiredMetadataEnforcement` below,
+            // so the debugger can still exercise a nonconforming server.
             const supportedMethods =
               authServerMetadata.code_challenge_methods_supported || [];
+            const pkceNonConformance = describePkceMetadataNonConformance(
+              supportedMethods,
+              "2025-11-25",
+            );
 
-            // 2025-11-25 spec: MUST verify PKCE support
             if (!supportedMethods || supportedMethods.length === 0) {
-              throw new Error(
-                "PKCE is REQUIRED for 2025-11-25 protocol, but authorization server " +
-                  "does not advertise code_challenge_methods_supported. " +
-                  "Server is not compliant with 2025-11-25 spec."
-              );
+              throw new Error(pkceNonConformance);
             }
 
             // The response card already shows the complete metadata document.
@@ -1239,16 +1294,16 @@ export const createDebugOAuthStateMachine = (
               { "CIMD Supported": cimdSupported }
             );
 
-            if (!supportedMethods.includes("S256")) {
-              const s256Error =
-                "Authorization server metadata must advertise S256 in code_challenge_methods_supported for 2025-11-25 conformance.";
-
-              if (strictConformance) {
+            if (pkceNonConformance) {
+              // Fail closed unless the caller explicitly asked to observe a
+              // nonconforming server. Continuing without S256 is a silent PKCE
+              // downgrade, and the downgrade is invisible on the wire.
+              if (strictConformance || requiredMetadataEnforcement !== "observe") {
                 updateState({
                   lastResponse: authServerResponseData,
                   httpHistory: updatedHistoryFinal,
                   infoLogs,
-                  error: s256Error,
+                  error: pkceNonConformance,
                   isInitiatingAuth: false,
                 });
                 return;

--- a/sdk/src/oauth/state-machines/debug-oauth-2025-11-25.ts
+++ b/sdk/src/oauth/state-machines/debug-oauth-2025-11-25.ts
@@ -1052,7 +1052,7 @@ export const createDebugOAuthStateMachine = (
               // Only reachable under `"observe"`. The substitution is not a
               // silent fallback even there — the debugger's whole value is
               // showing that this server did not name an authorization server.
-              if (authorizationServerSelection.substituted) {
+              if (authorizationServerSelection.error) {
                 infoLogs = addInfoLog(
                   { ...getCurrentState(), infoLogs },
                   "received_resource_metadata",

--- a/sdk/src/oauth/state-machines/debug-oauth-2026-07-28.ts
+++ b/sdk/src/oauth/state-machines/debug-oauth-2026-07-28.ts
@@ -1331,7 +1331,7 @@ export const createDebugOAuthStateMachine = (
               // Only reachable under `"observe"`. The substitution is not a
               // silent fallback even there — the debugger's whole value is
               // showing that this server did not name an authorization server.
-              if (authorizationServerSelection.substituted) {
+              if (authorizationServerSelection.error) {
                 infoLogs = addInfoLog(
                   { ...getCurrentState(), infoLogs },
                   "received_resource_metadata",

--- a/sdk/src/oauth/state-machines/debug-oauth-2026-07-28.ts
+++ b/sdk/src/oauth/state-machines/debug-oauth-2026-07-28.ts
@@ -36,6 +36,10 @@ import {
 } from "./shared/pkce.js";
 import { buildResourceMetadataUrl } from "./shared/urls.js";
 import {
+  describePkceMetadataNonConformance,
+  selectAuthorizationServerFromResourceMetadata,
+} from "./shared/required-metadata.js";
+import {
   resolveDiscoveryResourceIndicator,
   resolveFlowResourceValue,
 } from "./shared/resource-indicator.js";
@@ -828,6 +832,7 @@ export const createDebugOAuthStateMachine = (
     strictConformance = false,
     allowPathScopedIssuer = false,
     resourceIndicatorEnforcement = "warn",
+    requiredMetadataEnforcement = "reject",
     registrationStrategy = "cimd", // Default to CIMD for 2026-07-28
     emulation,
   } = config;
@@ -1287,13 +1292,57 @@ export const createDebugOAuthStateMachine = (
               const finalHistory = [...historyWithoutPlaceholder, ...attempts];
 
               const lastAttempt = attempts[attempts.length - 1];
+              // RFC 9728 `authorization_servers` is where the resource names
+              // who may issue tokens for it. Substituting the MCP server's own
+              // URL invents an authorization server the resource never named,
+              // and does it invisibly — so under the current profile the
+              // substitution is an error, not a fallback.
+              const authorizationServerSelection =
+                selectAuthorizationServerFromResourceMetadata({
+                  authorizationServers: resourceMetadata.authorization_servers,
+                  fallbackServerUrl: serverUrl,
+                  protocolVersion: "2026-07-28",
+                });
               const authorizationServerUrl =
-                resourceMetadata.authorization_servers?.[0] || serverUrl;
+                authorizationServerSelection.authorizationServerUrl;
+
+              if (
+                authorizationServerSelection.error &&
+                requiredMetadataEnforcement !== "observe"
+              ) {
+                updateState({
+                  resourceMetadata,
+                  resourceMetadataUrl:
+                    lastAttempt?.request?.url || state.resourceMetadataUrl,
+                  lastRequest: lastAttempt?.request,
+                  lastResponse: lastAttempt?.response,
+                  httpHistory: finalHistory,
+                  error: authorizationServerSelection.error,
+                  isInitiatingAuth: false,
+                });
+                return;
+              }
 
               // The response card is the complete protected-resource metadata.
               // Keep existing logs only for distinct findings, such as a
               // resource identifier mismatch below.
               let infoLogs = state.infoLogs ?? [];
+
+              // Only reachable under `"observe"`. The substitution is not a
+              // silent fallback even there — the debugger's whole value is
+              // showing that this server did not name an authorization server.
+              if (authorizationServerSelection.substituted) {
+                infoLogs = addInfoLog(
+                  { ...getCurrentState(), infoLogs },
+                  "received_resource_metadata",
+                  "authorization-server-substituted",
+                  "Derived: Authorization Server (not advertised)",
+                  {
+                    Finding: authorizationServerSelection.error,
+                    "Using instead": authorizationServerUrl,
+                  }
+                );
+              }
 
               // Resolve the resource indicator ONCE (rejecting/warning per
               // the surface's enforcement mode); every later request and
@@ -1521,17 +1570,23 @@ export const createDebugOAuthStateMachine = (
                 Date.now() - (lastEntry.timestamp || Date.now());
             }
 
-            // Validate PKCE support (REQUIRED for 2026-07-28)
+            // Validate PKCE support (REQUIRED for 2026-07-28).
+            //
+            // The MCP client requirement is to VERIFY S256 support before
+            // proceeding, so both shapes of failure — no advertised methods at
+            // all, and a list that omits S256 — have to stop the flow. Absent
+            // metadata throws here because there is nothing to show; a list
+            // without S256 is decided by `requiredMetadataEnforcement` below,
+            // so the debugger can still exercise a nonconforming server.
             const supportedMethods =
               authServerMetadata.code_challenge_methods_supported || [];
+            const pkceNonConformance = describePkceMetadataNonConformance(
+              supportedMethods,
+              "2026-07-28",
+            );
 
-            // 2026-07-28 spec: MUST verify PKCE support
             if (!supportedMethods || supportedMethods.length === 0) {
-              throw new Error(
-                "PKCE is REQUIRED for 2026-07-28 protocol, but authorization server " +
-                  "does not advertise code_challenge_methods_supported. " +
-                  "Server is not compliant with 2026-07-28 spec."
-              );
+              throw new Error(pkceNonConformance);
             }
 
             // The response card already shows the complete metadata document.
@@ -1572,16 +1627,16 @@ export const createDebugOAuthStateMachine = (
               );
             }
 
-            if (!supportedMethods.includes("S256")) {
-              const s256Error =
-                "Authorization server metadata must advertise S256 in code_challenge_methods_supported for 2026-07-28 conformance.";
-
-              if (strictConformance) {
+            if (pkceNonConformance) {
+              // Fail closed unless the caller explicitly asked to observe a
+              // nonconforming server. Continuing without S256 is a silent PKCE
+              // downgrade, and the downgrade is invisible on the wire.
+              if (strictConformance || requiredMetadataEnforcement !== "observe") {
                 updateState({
                   lastResponse: authServerResponseData,
                   httpHistory: updatedHistoryFinal,
                   infoLogs,
-                  error: s256Error,
+                  error: pkceNonConformance,
                   isInitiatingAuth: false,
                 });
                 return;

--- a/sdk/src/oauth/state-machines/shared/required-metadata.ts
+++ b/sdk/src/oauth/state-machines/shared/required-metadata.ts
@@ -1,0 +1,114 @@
+/**
+ * Shared conformance policy for metadata the current MCP authorization profile
+ * REQUIRES a client to verify before it sends the user to an authorization
+ * server.
+ *
+ * Two checks live here, both scoped to the eras governed by the current profile
+ * (2025-11-25 and later):
+ *
+ *   - PKCE. MCP Authorization requires the client to verify that the
+ *     authorization server advertises S256 in
+ *     `code_challenge_methods_supported` before proceeding. A server that
+ *     advertises only `plain` cannot give the flow the protection PKCE exists
+ *     for, and a client that proceeds anyway has silently downgraded.
+ *   - Protected-resource metadata. RFC 9728's `authorization_servers` is where
+ *     the resource says who may issue tokens for it. Substituting the MCP
+ *     server's own URL when the list is missing invents an authorization server
+ *     the resource never named, and the substitution is invisible in the trace.
+ *
+ * `enforcement` exists because MCPJam is also a debugger, and the whole point
+ * of pointing it at a half-built server is to SEE what that server does. But
+ * that is a non-connect intent and has to be asked for: the default fails
+ * closed, and only a surface that explicitly passes `"observe"` gets the
+ * warn-and-continue behavior.
+ */
+
+export type RequiredMetadataEnforcement =
+  /** Fail closed. The default, and what every connect-like path uses. */
+  | "reject"
+  /** Warn and continue so the debugger can show nonconforming behavior. */
+  | "observe";
+
+/**
+ * Whether an era is governed by the current MCP protected-resource + PKCE
+ * profile. Older eras keep their own behavior — this is not a place to
+ * retroactively tighten a specification that genuinely said something else.
+ */
+export function usesCurrentRequiredMetadataProfile(
+  protocolVersion: string,
+): boolean {
+  return protocolVersion === "2025-11-25" || protocolVersion === "2026-07-28";
+}
+
+/**
+ * Non-conformance message for the advertised PKCE methods, or `undefined` when
+ * they satisfy the profile.
+ *
+ * Advertising `plain` ALONGSIDE S256 is not a failure — the client picks S256.
+ * Only the absence of S256 is.
+ */
+export function describePkceMetadataNonConformance(
+  supportedMethods: readonly string[] | undefined,
+  protocolVersion: string,
+): string | undefined {
+  if (!supportedMethods || supportedMethods.length === 0) {
+    return (
+      `PKCE is REQUIRED for ${protocolVersion} protocol, but authorization server ` +
+      "does not advertise code_challenge_methods_supported. " +
+      `Server is not compliant with ${protocolVersion} spec.`
+    );
+  }
+
+  if (!supportedMethods.includes("S256")) {
+    return (
+      "Authorization server metadata must advertise S256 in " +
+      `code_challenge_methods_supported for ${protocolVersion} conformance. ` +
+      `Advertised: ${supportedMethods.join(", ")}.`
+    );
+  }
+
+  return undefined;
+}
+
+export interface AuthorizationServerSelection {
+  /** The authorization server to discover metadata from. */
+  authorizationServerUrl: string;
+  /**
+   * Set when the protected-resource metadata did not name an authorization
+   * server. Under `"reject"` the caller must stop; under `"observe"` it is a
+   * warning that accompanies the substituted fallback.
+   */
+  error?: string;
+  /** True when `authorizationServerUrl` was substituted, not advertised. */
+  substituted: boolean;
+}
+
+/**
+ * Pick the authorization server from protected-resource metadata.
+ *
+ * Returns the substitution rather than performing it silently, so the caller
+ * can decide by enforcement mode and so the fallback is always visible.
+ */
+export function selectAuthorizationServerFromResourceMetadata(input: {
+  authorizationServers: readonly string[] | undefined;
+  fallbackServerUrl: string;
+  protocolVersion: string;
+}): AuthorizationServerSelection {
+  const advertised = input.authorizationServers?.find(
+    (entry) => typeof entry === "string" && entry.trim() !== "",
+  );
+
+  if (advertised) {
+    return { authorizationServerUrl: advertised, substituted: false };
+  }
+
+  return {
+    authorizationServerUrl: input.fallbackServerUrl,
+    substituted: true,
+    error:
+      "Protected resource metadata does not list an authorization server. " +
+      `RFC 9728 \`authorization_servers\` is required by the ${input.protocolVersion} ` +
+      "MCP profile; without it there is no server authorized to issue tokens " +
+      "for this resource, and using the MCP server's own URL would invent one.",
+  };
+}

--- a/sdk/src/oauth/state-machines/shared/required-metadata.ts
+++ b/sdk/src/oauth/state-machines/shared/required-metadata.ts
@@ -1,20 +1,27 @@
 /**
- * Shared conformance policy for metadata the current MCP authorization profile
- * REQUIRES a client to verify before it sends the user to an authorization
- * server.
+ * Shared conformance policy for metadata an MCP authorization profile REQUIRES
+ * a client to verify before it sends the user to an authorization server.
  *
- * Two checks live here, both scoped to the eras governed by the current profile
- * (2025-11-25 and later):
+ * Two checks live here. They are NOT gated on the same eras, because the spec
+ * text behind them does not have the same history — one gate covering both
+ * would either miss an era that genuinely states the requirement or invent one
+ * for an era that is silent:
  *
- *   - PKCE. MCP Authorization requires the client to verify that the
- *     authorization server advertises S256 in
- *     `code_challenge_methods_supported` before proceeding. A server that
- *     advertises only `plain` cannot give the flow the protection PKCE exists
- *     for, and a client that proceeds anyway has silently downgraded.
  *   - Protected-resource metadata. RFC 9728's `authorization_servers` is where
  *     the resource says who may issue tokens for it. Substituting the MCP
  *     server's own URL when the list is missing invents an authorization server
  *     the resource never named, and the substitution is invisible in the trace.
+ *     Required from 2025-06-18 onward: that revision already said the PRM
+ *     document "MUST include the `authorization_servers` field containing at
+ *     least one authorization server," and 2025-11-25 and 2026-07-28 repeat it
+ *     verbatim.
+ *   - PKCE. The client must verify that the authorization server advertises
+ *     S256 in `code_challenge_methods_supported` before proceeding. A server
+ *     that advertises only `plain` cannot give the flow the protection PKCE
+ *     exists for, and a client that proceeds anyway has silently downgraded.
+ *     Gated at 2025-11-25 because 2025-06-18 says nothing at all about
+ *     `code_challenge_methods_supported` — staying silent there is the
+ *     version-faithful behavior, not a gap.
  *
  * `enforcement` exists because MCPJam is also a debugger, and the whole point
  * of pointing it at a half-built server is to SEE what that server does. But
@@ -30,27 +37,63 @@ export type RequiredMetadataEnforcement =
   | "observe";
 
 /**
- * Whether an era is governed by the current MCP protected-resource + PKCE
- * profile. Older eras keep their own behavior — this is not a place to
- * retroactively tighten a specification that genuinely said something else.
+ * Eras whose authorization spec states that the protected-resource metadata
+ * document MUST name at least one authorization server.
+ *
+ * 2025-03-26 predates the MCP profile's adoption of RFC 9728 entirely, so its
+ * machine keeps the historical fallback.
  */
-export function usesCurrentRequiredMetadataProfile(
+const ERAS_REQUIRING_ADVERTISED_AUTHORIZATION_SERVERS: readonly string[] = [
+  "2025-06-18",
+  "2025-11-25",
+  "2026-07-28",
+];
+
+/**
+ * Eras whose authorization spec requires the client to verify advertised PKCE
+ * support before proceeding.
+ */
+const ERAS_REQUIRING_ADVERTISED_S256: readonly string[] = [
+  "2025-11-25",
+  "2026-07-28",
+];
+
+/** Whether `protocolVersion` requires the PRM to name an authorization server. */
+export function requiresAdvertisedAuthorizationServers(
   protocolVersion: string,
 ): boolean {
-  return protocolVersion === "2025-11-25" || protocolVersion === "2026-07-28";
+  return ERAS_REQUIRING_ADVERTISED_AUTHORIZATION_SERVERS.includes(
+    protocolVersion,
+  );
+}
+
+/** Whether `protocolVersion` requires the AS to advertise S256 for PKCE. */
+export function requiresAdvertisedS256(protocolVersion: string): boolean {
+  return ERAS_REQUIRING_ADVERTISED_S256.includes(protocolVersion);
 }
 
 /**
  * Non-conformance message for the advertised PKCE methods, or `undefined` when
- * they satisfy the profile.
+ * they satisfy the era's profile.
  *
  * Advertising `plain` ALONGSIDE S256 is not a failure — the client picks S256.
  * Only the absence of S256 is.
+ *
+ * The message is deliberately phrased as MCPJam's policy rather than a spec
+ * verdict for the "advertised, but no S256" case. The spec requires the client
+ * to VERIFY PKCE support and to use S256 when technically capable; it states a
+ * MUST-refuse only for metadata that omits `code_challenge_methods_supported`
+ * altogether. Refusing a `plain`-only server is the right call, but it is a
+ * downgrade refusal, not a conformance failure we can cite.
  */
 export function describePkceMetadataNonConformance(
   supportedMethods: readonly string[] | undefined,
   protocolVersion: string,
 ): string | undefined {
+  if (!requiresAdvertisedS256(protocolVersion)) {
+    return undefined;
+  }
+
   if (!supportedMethods || supportedMethods.length === 0) {
     return (
       `PKCE is REQUIRED for ${protocolVersion} protocol, but authorization server ` +
@@ -61,9 +104,10 @@ export function describePkceMetadataNonConformance(
 
   if (!supportedMethods.includes("S256")) {
     return (
-      "Authorization server metadata must advertise S256 in " +
-      `code_challenge_methods_supported for ${protocolVersion} conformance. ` +
-      `Advertised: ${supportedMethods.join(", ")}.`
+      "Authorization server advertises PKCE without S256 " +
+      `(advertised: ${supportedMethods.join(", ")}). ` +
+      `MCPJam will not downgrade to a weaker code challenge method, so the ` +
+      `${protocolVersion} flow stops here.`
     );
   }
 
@@ -74,9 +118,10 @@ export interface AuthorizationServerSelection {
   /** The authorization server to discover metadata from. */
   authorizationServerUrl: string;
   /**
-   * Set when the protected-resource metadata did not name an authorization
-   * server. Under `"reject"` the caller must stop; under `"observe"` it is a
-   * warning that accompanies the substituted fallback.
+   * Set when the era requires the protected-resource metadata to name an
+   * authorization server and it did not. Under `"reject"` the caller must stop;
+   * under `"observe"` it is a warning that accompanies the substituted
+   * fallback. Absent for eras that permit the substitution.
    */
   error?: string;
   /** True when `authorizationServerUrl` was substituted, not advertised. */
@@ -87,7 +132,9 @@ export interface AuthorizationServerSelection {
  * Pick the authorization server from protected-resource metadata.
  *
  * Returns the substitution rather than performing it silently, so the caller
- * can decide by enforcement mode and so the fallback is always visible.
+ * can decide by enforcement mode and so the fallback is always visible. Every
+ * era's machine can call this: the era gate lives here, so a machine whose
+ * spec permits the fallback gets `substituted` without an `error`.
  */
 export function selectAuthorizationServerFromResourceMetadata(input: {
   authorizationServers: readonly string[] | undefined;
@@ -100,6 +147,13 @@ export function selectAuthorizationServerFromResourceMetadata(input: {
 
   if (advertised) {
     return { authorizationServerUrl: advertised, substituted: false };
+  }
+
+  if (!requiresAdvertisedAuthorizationServers(input.protocolVersion)) {
+    return {
+      authorizationServerUrl: input.fallbackServerUrl,
+      substituted: true,
+    };
   }
 
   return {

--- a/sdk/src/oauth/state-machines/types.ts
+++ b/sdk/src/oauth/state-machines/types.ts
@@ -328,6 +328,22 @@ export interface BaseOAuthStateMachineConfig {
    */
   resourceMetadataUrl?: string;
   authMode?: OAuthAuthMode;
+  /**
+   * What to do when metadata the current MCP profile REQUIRES a client to
+   * verify is missing or unusable — the authorization server's advertised PKCE
+   * methods, and the protected resource's `authorization_servers` list.
+   *
+   * `"reject"` (the default) fails closed before the browser is sent to an
+   * authorization server, which is what every connect-like path needs.
+   * `"observe"` warns and continues so the debugger can show a nonconforming
+   * server's actual behavior; it is a non-connect intent and must be asked for
+   * explicitly. Only eras governed by the current profile (2025-11-25 and
+   * later) consult this — see `shared/required-metadata.ts`.
+   *
+   * Orthogonal to `strictConformance` (registration strictness) and to
+   * `resourceIndicatorEnforcement` (the advertised resource indicator).
+   */
+  requiredMetadataEnforcement?: "reject" | "observe";
   strictConformance?: boolean;
   /**
    * Opt-in: accept authorization-server metadata whose advertised `issuer` is

--- a/sdk/tests/oauth-conformance/runner.test.ts
+++ b/sdk/tests/oauth-conformance/runner.test.ts
@@ -1056,7 +1056,7 @@ describe("OAuthConformanceTest", () => {
     expect(failedStep).toMatchObject({
       status: "failed",
       error: {
-        message: expect.stringContaining("advertise S256"),
+        message: expect.stringContaining("without S256"),
       },
     });
   });

--- a/sdk/tests/oauth/required-metadata-conformance.test.ts
+++ b/sdk/tests/oauth/required-metadata-conformance.test.ts
@@ -1,0 +1,202 @@
+/**
+ * MCP Authorization requires a client to VERIFY certain metadata before it
+ * sends a user to an authorization server. Two of those checks used to warn and
+ * continue, which means the flow silently proceeded without the protection the
+ * check exists to guarantee:
+ *
+ *   - PKCE: an authorization server whose `code_challenge_methods_supported`
+ *     omits S256 was accepted with a console warning.
+ *   - Protected-resource metadata: an empty or missing `authorization_servers`
+ *     list was replaced by the MCP server's own URL, inventing an authorization
+ *     server the resource never named.
+ *
+ * Both now fail closed for the eras governed by the current profile. The
+ * debugger keeps the old behavior, but only by passing
+ * `requiredMetadataEnforcement: "observe"` — an explicit non-connect intent.
+ */
+
+import {
+  describePkceMetadataNonConformance,
+  selectAuthorizationServerFromResourceMetadata,
+  usesCurrentRequiredMetadataProfile,
+} from "../../src/oauth/state-machines/shared/required-metadata.js";
+import { createOAuthStateMachine } from "../../src/oauth/state-machines/factory.js";
+import { EMPTY_OAUTH_FLOW_STATE } from "../../src/oauth/state-machines/types.js";
+import type {
+  OAuthFlowState,
+  OAuthProtocolVersion,
+} from "../../src/oauth/state-machines/types.js";
+
+const SERVER_URL = "https://mcp.example.com/mcp";
+const REDIRECT_URI = "http://127.0.0.1:3333/callback";
+
+/** Eras governed by the current protected-resource + PKCE profile. */
+const CURRENT_ERAS: OAuthProtocolVersion[] = ["2025-11-25", "2026-07-28"];
+const ALL_VERSIONS: OAuthProtocolVersion[] = [
+  "2025-03-26",
+  "2025-06-18",
+  ...CURRENT_ERAS,
+];
+
+describe("required-metadata policy", () => {
+  it.each(ALL_VERSIONS)("scopes the current profile correctly (%s)", (version) => {
+    expect(usesCurrentRequiredMetadataProfile(version)).toBe(
+      CURRENT_ERAS.includes(version),
+    );
+  });
+
+  it("accepts S256, with or without plain alongside it", () => {
+    expect(
+      describePkceMetadataNonConformance(["S256"], "2025-11-25"),
+    ).toBeUndefined();
+    expect(
+      describePkceMetadataNonConformance(["plain", "S256"], "2025-11-25"),
+    ).toBeUndefined();
+  });
+
+  it("rejects an absent list and a list without S256", () => {
+    expect(describePkceMetadataNonConformance([], "2025-11-25")).toContain(
+      "code_challenge_methods_supported",
+    );
+    expect(
+      describePkceMetadataNonConformance(undefined, "2025-11-25"),
+    ).toContain("code_challenge_methods_supported");
+    expect(
+      describePkceMetadataNonConformance(["plain"], "2025-11-25"),
+    ).toContain("S256");
+  });
+
+  it("reports the substitution rather than performing it silently", () => {
+    expect(
+      selectAuthorizationServerFromResourceMetadata({
+        authorizationServers: ["https://auth.example.com"],
+        fallbackServerUrl: SERVER_URL,
+        protocolVersion: "2025-11-25",
+      }),
+    ).toEqual({
+      authorizationServerUrl: "https://auth.example.com",
+      substituted: false,
+    });
+
+    for (const authorizationServers of [undefined, [], [""], ["  "]]) {
+      const selection = selectAuthorizationServerFromResourceMetadata({
+        authorizationServers,
+        fallbackServerUrl: SERVER_URL,
+        protocolVersion: "2025-11-25",
+      });
+      expect(selection.substituted).toBe(true);
+      expect(selection.authorizationServerUrl).toBe(SERVER_URL);
+      expect(selection.error).toContain("authorization_servers");
+    }
+  });
+});
+
+/**
+ * Drive the machine from the point where authorization-server metadata has just
+ * been fetched, so the PKCE verification runs against the seeded document.
+ */
+function makeMachineAtAsMetadata(
+  protocolVersion: OAuthProtocolVersion,
+  metadata: Record<string, unknown>,
+  extra: Record<string, unknown> = {},
+) {
+  let state: OAuthFlowState = {
+    ...EMPTY_OAUTH_FLOW_STATE,
+    serverUrl: SERVER_URL,
+    currentStep: "request_authorization_server_metadata",
+    authorizationServerUrl: "https://auth.example.com",
+    resourceMetadata: {
+      resource: SERVER_URL,
+      authorization_servers: ["https://auth.example.com"],
+    },
+  } as OAuthFlowState;
+
+  const requestExecutor = vi.fn().mockResolvedValue({
+    ok: true,
+    status: 200,
+    statusText: "OK",
+    headers: { "content-type": "application/json" },
+    body: metadata,
+  });
+
+  const machine = createOAuthStateMachine({
+    protocolVersion,
+    registrationStrategy: "dcr",
+    state,
+    getState: () => state,
+    updateState: (updates) => {
+      state = { ...state, ...updates };
+    },
+    serverUrl: SERVER_URL,
+    serverName: "Test Server",
+    redirectUrl: REDIRECT_URI,
+    requestExecutor,
+    dynamicRegistration: { client_name: "Test Client" },
+    ...(extra as never),
+  });
+
+  return { machine, getState: () => state, requestExecutor };
+}
+
+const CONFORMING_AS_METADATA = {
+  issuer: "https://auth.example.com",
+  authorization_endpoint: "https://auth.example.com/authorize",
+  token_endpoint: "https://auth.example.com/token",
+  registration_endpoint: "https://auth.example.com/register",
+  response_types_supported: ["code"],
+  code_challenge_methods_supported: ["S256"],
+};
+
+describe.each(CURRENT_ERAS)("PKCE metadata verification (%s)", (version) => {
+  // Exactly one step: the metadata fetch and its verification. Advancing
+  // further would reach DCR and overwrite the finding under test.
+  const advance = async (machine: { proceedToNextStep: () => Promise<void> }) =>
+    machine.proceedToNextStep().catch(() => {});
+
+  it("fails closed when S256 is not advertised", async () => {
+    const { machine, getState } = makeMachineAtAsMetadata(version, {
+      ...CONFORMING_AS_METADATA,
+      code_challenge_methods_supported: ["plain"],
+    });
+    await advance(machine);
+
+    expect(getState().error ?? "").toContain("S256");
+    expect(getState().authorizationUrl).toBeFalsy();
+  });
+
+  it("proceeds when S256 is advertised alongside plain", async () => {
+    const { machine, getState } = makeMachineAtAsMetadata(version, {
+      ...CONFORMING_AS_METADATA,
+      code_challenge_methods_supported: ["plain", "S256"],
+    });
+    await advance(machine);
+
+    expect(getState().error ?? "").not.toContain("S256");
+    expect(getState().authorizationServerMetadata).toBeTruthy();
+  });
+
+  it("warns and continues only under an explicit observe intent", async () => {
+    const { machine, getState } = makeMachineAtAsMetadata(
+      version,
+      { ...CONFORMING_AS_METADATA, code_challenge_methods_supported: ["plain"] },
+      { requiredMetadataEnforcement: "observe" },
+    );
+    await advance(machine);
+
+    // Still surfaced, but as a warning attached to metadata the flow kept.
+    expect(getState().error ?? "").toMatch(/^Warning:|S256/);
+    expect(getState().authorizationServerMetadata).toBeTruthy();
+  });
+
+  it("still rejects under strictConformance even in observe mode", async () => {
+    const { machine, getState } = makeMachineAtAsMetadata(
+      version,
+      { ...CONFORMING_AS_METADATA, code_challenge_methods_supported: ["plain"] },
+      { requiredMetadataEnforcement: "observe", strictConformance: true },
+    );
+    await advance(machine);
+
+    expect(getState().error ?? "").toContain("S256");
+    expect(getState().authorizationServerMetadata).toBeFalsy();
+  });
+});

--- a/sdk/tests/oauth/required-metadata-conformance.test.ts
+++ b/sdk/tests/oauth/required-metadata-conformance.test.ts
@@ -10,15 +10,19 @@
  *     list was replaced by the MCP server's own URL, inventing an authorization
  *     server the resource never named.
  *
- * Both now fail closed for the eras governed by the current profile. The
- * debugger keeps the old behavior, but only by passing
- * `requiredMetadataEnforcement: "observe"` — an explicit non-connect intent.
+ * Both now fail closed, but NOT on the same eras — each is gated on the eras
+ * whose spec text actually states the requirement. The PRM rule dates to
+ * 2025-06-18; the PKCE rule to 2025-11-25, because 2025-06-18 says nothing
+ * about `code_challenge_methods_supported`. The debugger keeps the old
+ * behavior, but only by passing `requiredMetadataEnforcement: "observe"` — an
+ * explicit non-connect intent.
  */
 
 import {
   describePkceMetadataNonConformance,
+  requiresAdvertisedAuthorizationServers,
+  requiresAdvertisedS256,
   selectAuthorizationServerFromResourceMetadata,
-  usesCurrentRequiredMetadataProfile,
 } from "../../src/oauth/state-machines/shared/required-metadata.js";
 import { createOAuthStateMachine } from "../../src/oauth/state-machines/factory.js";
 import { EMPTY_OAUTH_FLOW_STATE } from "../../src/oauth/state-machines/types.js";
@@ -30,19 +34,56 @@ import type {
 const SERVER_URL = "https://mcp.example.com/mcp";
 const REDIRECT_URI = "http://127.0.0.1:3333/callback";
 
-/** Eras governed by the current protected-resource + PKCE profile. */
-const CURRENT_ERAS: OAuthProtocolVersion[] = ["2025-11-25", "2026-07-28"];
-const ALL_VERSIONS: OAuthProtocolVersion[] = [
-  "2025-03-26",
-  "2025-06-18",
-  ...CURRENT_ERAS,
-];
+/** Eras that require the AS to advertise S256 (PKCE verification). */
+const S256_ERAS: OAuthProtocolVersion[] = ["2025-11-25", "2026-07-28"];
+/** Eras that require the PRM to name an authorization server (RFC 9728). */
+const PRM_ERAS: OAuthProtocolVersion[] = ["2025-06-18", ...S256_ERAS];
+const ALL_VERSIONS: OAuthProtocolVersion[] = ["2025-03-26", ...PRM_ERAS];
 
 describe("required-metadata policy", () => {
-  it.each(ALL_VERSIONS)("scopes the current profile correctly (%s)", (version) => {
-    expect(usesCurrentRequiredMetadataProfile(version)).toBe(
-      CURRENT_ERAS.includes(version),
+  // The two gates are deliberately different. 2025-06-18 already said the PRM
+  // document MUST name at least one authorization server, but said nothing at
+  // all about `code_challenge_methods_supported` — so mirroring the PKCE rule
+  // onto it would invent a requirement that revision does not state.
+  it.each(ALL_VERSIONS)("gates the PRM rule from 2025-06-18 (%s)", (version) => {
+    expect(requiresAdvertisedAuthorizationServers(version)).toBe(
+      PRM_ERAS.includes(version),
     );
+  });
+
+  it.each(ALL_VERSIONS)("gates the S256 rule from 2025-11-25 (%s)", (version) => {
+    expect(requiresAdvertisedS256(version)).toBe(S256_ERAS.includes(version));
+  });
+
+  it("leaves PKCE metadata unchecked on eras that never required it", () => {
+    for (const version of ["2025-03-26", "2025-06-18"] as const) {
+      expect(describePkceMetadataNonConformance([], version)).toBeUndefined();
+      expect(
+        describePkceMetadataNonConformance(["plain"], version),
+      ).toBeUndefined();
+    }
+  });
+
+  it("permits the authorization-server fallback only on 2025-03-26", () => {
+    const selection = selectAuthorizationServerFromResourceMetadata({
+      authorizationServers: undefined,
+      fallbackServerUrl: SERVER_URL,
+      protocolVersion: "2025-03-26",
+    });
+    expect(selection.substituted).toBe(true);
+    expect(selection.authorizationServerUrl).toBe(SERVER_URL);
+    expect(selection.error).toBeUndefined();
+
+    // 2025-06-18 carries the same MUST as the later eras, so a version-faithful
+    // machine has to flag it there too — otherwise picking 2025-06-18 in the
+    // version selector becomes a one-click bypass of a fail-closed check.
+    expect(
+      selectAuthorizationServerFromResourceMetadata({
+        authorizationServers: undefined,
+        fallbackServerUrl: SERVER_URL,
+        protocolVersion: "2025-06-18",
+      }).error,
+    ).toContain("authorization_servers");
   });
 
   it("accepts S256, with or without plain alongside it", () => {
@@ -138,6 +179,103 @@ function makeMachineAtAsMetadata(
   return { machine, getState: () => state, requestExecutor };
 }
 
+/**
+ * Drive the machine through protected-resource discovery, so the
+ * `authorization_servers` check runs against the seeded PRM document.
+ */
+function makeMachineAtResourceMetadata(
+  protocolVersion: OAuthProtocolVersion,
+  resourceMetadata: Record<string, unknown>,
+  extra: Record<string, unknown> = {},
+) {
+  let state: OAuthFlowState = {
+    ...EMPTY_OAUTH_FLOW_STATE,
+    serverUrl: SERVER_URL,
+    currentStep: "request_resource_metadata",
+  } as OAuthFlowState;
+
+  const requestExecutor = vi.fn().mockResolvedValue({
+    ok: true,
+    status: 200,
+    statusText: "OK",
+    headers: { "content-type": "application/json" },
+    body: resourceMetadata,
+  });
+
+  const machine = createOAuthStateMachine({
+    protocolVersion,
+    registrationStrategy: "dcr",
+    state,
+    getState: () => state,
+    updateState: (updates) => {
+      state = { ...state, ...updates };
+    },
+    serverUrl: SERVER_URL,
+    serverName: "Test Server",
+    redirectUrl: REDIRECT_URI,
+    requestExecutor,
+    dynamicRegistration: { client_name: "Test Client" },
+    ...(extra as never),
+  });
+
+  return { machine, getState: () => state };
+}
+
+describe("protected-resource `authorization_servers` verification", () => {
+  const advance = async (machine: { proceedToNextStep: () => Promise<void> }) =>
+    machine.proceedToNextStep().catch(() => {});
+
+  it.each(PRM_ERAS)("fails closed when no AS is named (%s)", async (version) => {
+    const { machine, getState } = makeMachineAtResourceMetadata(version, {
+      resource: SERVER_URL,
+    });
+    await advance(machine);
+
+    expect(getState().error ?? "").toContain("authorization_servers");
+    expect(getState().authorizationUrl).toBeFalsy();
+  });
+
+  it.each(PRM_ERAS)("proceeds when an AS is named (%s)", async (version) => {
+    const { machine, getState } = makeMachineAtResourceMetadata(version, {
+      resource: SERVER_URL,
+      authorization_servers: ["https://auth.example.com"],
+    });
+    await advance(machine);
+
+    expect(getState().error ?? "").not.toContain("authorization_servers");
+    expect(getState().authorizationServerUrl).toBe("https://auth.example.com");
+  });
+
+  it.each(PRM_ERAS)(
+    "continues under an explicit observe intent (%s)",
+    async (version) => {
+      const { machine, getState } = makeMachineAtResourceMetadata(
+        version,
+        { resource: SERVER_URL },
+        { requiredMetadataEnforcement: "observe" },
+      );
+      await advance(machine);
+
+      // Substituted rather than rejected — but never invisibly.
+      expect(getState().authorizationServerUrl).toBe(SERVER_URL);
+      expect(
+        JSON.stringify(getState().infoLogs ?? []),
+      ).toContain("authorization_servers");
+    },
+  );
+
+  // 2025-03-26 predates the MCP profile's adoption of RFC 9728, so the
+  // historical fallback is the version-faithful behavior there.
+  it("keeps the silent fallback on 2025-03-26", async () => {
+    const { machine, getState } = makeMachineAtResourceMetadata("2025-03-26", {
+      resource: SERVER_URL,
+    });
+    await advance(machine);
+
+    expect(getState().error ?? "").not.toContain("authorization_servers");
+  });
+});
+
 const CONFORMING_AS_METADATA = {
   issuer: "https://auth.example.com",
   authorization_endpoint: "https://auth.example.com/authorize",
@@ -147,7 +285,7 @@ const CONFORMING_AS_METADATA = {
   code_challenge_methods_supported: ["S256"],
 };
 
-describe.each(CURRENT_ERAS)("PKCE metadata verification (%s)", (version) => {
+describe.each(S256_ERAS)("PKCE metadata verification (%s)", (version) => {
   // Exactly one step: the metadata fetch and its verification. Advancing
   // further would reach DCR and overwrite the finding under test.
   const advance = async (machine: { proceedToNextStep: () => Promise<void> }) =>


### PR DESCRIPTION
Part 2 of the OAuth maintainability stack; stacked on #3882.

This isolates current-profile S256 and protected-resource metadata enforcement, keeps debugger observe mode explicit, and adds conformance coverage across current and legacy eras. The SDK changeset is major because the default changes from warning/continue to reject.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Changes default OAuth authorization behavior in security-critical PKCE and authorization-server selection paths, with a major SDK default flip from warn-and-continue to reject.
> 
> **Overview**
> **Fails closed** when required OAuth metadata is missing, so connect flows no longer silently downgrade.
> 
> Previously, empty/missing RFC 9728 `authorization_servers` fell back to the MCP server URL, and AS metadata without `S256` only warned unless `strictConformance` was set. Both now stop the flow before browser redirect. PRM enforcement starts at **2025-06-18**; PKCE S256 at **2025-11-25**. Advertising `plain` alongside `S256` still works.
> 
> Policy lives in shared `required-metadata.ts`, consulted by every era machine. New `requiredMetadataEnforcement` defaults to **`reject`**; the debugger alone opts into **`observe`** so nonconforming servers remain inspectable.
> 
> Adds conformance and end-to-end wire-invariant tests, and extends the fake OAuth MCP fixture with metadata/token overrides.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 13c3378f98b8152ce83ae633e228892dc7fa6567. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fail closed on required OAuth metadata to prevent silent downgrades and unsafe fallbacks. PRM `authorization_servers` is enforced from 2025-06-18; PKCE S256 is enforced from 2025-11-25/2026-07-28; the debugger explicitly runs in observe mode.

- **Bug Fixes**
  - Enforce RFC 9728 `authorization_servers` (no empty/missing lists); no fallback to the MCP URL. Under observe, substitution is surfaced as an info log.
  - Enforce PKCE S256; absent methods or lists stop the flow. Advertising `plain` alongside `S256` is allowed; observe mode warns unless `strictConformance` is set.
  - Add shared policy in `oauth/state-machines/shared/required-metadata.ts`; new `requiredMetadataEnforcement` (default `"reject"`). `@mcpjam/inspector` passes `"observe"`.
  - Add conformance and integration tests; enhance the fake OAuth MCP server to capture full URL/query/headers and support token/metadata overrides.

- **Migration**
  - `@mcpjam/sdk` (major): Default fail-closed checks for required metadata (PRM from 2025-06-18; PKCE S256 from 2025-11-25/2026-07-28). Older eras (e.g. 2025-03-26) keep historical behavior.
  - Ensure your AS advertises S256 and your PRM lists `authorization_servers`. For dev inspection, pass `requiredMetadataEnforcement: "observe"` (not for production).

<sup>Written for commit 13c3378f98b8152ce83ae633e228892dc7fa6567. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/MCPJam/inspector/pull/3883?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

