### PR TITLE
test(oauth): add differential harness across protocol eras

### DIFF
--- a/.changeset/oauth-era-differential-harness.md
+++ b/.changeset/oauth-era-differential-harness.md
@@ -1,0 +1,13 @@
+---
+"@mcpjam/sdk": patch
+---
+
+Add a differential golden harness across every era, registration strategy, and branch.
+
+`no-emulation-goldens.test.ts` covers one happy ladder per era, `dcr` only, no error branches. That notices an accidental change to the default path and nothing else — a thin basis for trusting four ~50%-duplicated state machines, and far too thin to justify consolidating them.
+
+`era-differential-goldens.test.ts` widens it to 4 eras × each supported registration strategy (`dcr`, `preregistered`, and `cimd` where the era supports it) × a catalog of the branches that actually differ: DCR failure, DCR failure with a pre-registered fallback, `strictConformance` refusing that fallback, present-but-mismatched and absent RFC 9207 `iss`, issuer mismatch, `allowPathScopedIssuer` on and off, each `resourceIndicatorEnforcement` mode, and — for the current-profile eras — missing PKCE metadata, `S256` absent, `plain` alongside `S256`, and empty or absent `authorization_servers`.
+
+Two layers on purpose. The full request-sequence snapshot is a review aid: it shows what changed, and accepting an update is one keystroke. The named assertions are the gate — S256 PKCE end to end, one `redirect_uri` reused, the same validated canonical resource on both the authorization and token requests, a CSRF state always issued, and no MCP bearer credential on any OAuth endpoint. A snapshot update cannot normalize away a violation of those.
+
+Era differences are pinned rather than tolerated. The issuer-mismatch branch asserts that only 2026-07-28 hard-rejects it, so a change to shared code cannot quietly give an older era the strict behavior or take it from the newest one.

--- a/sdk/tests/oauth/__snapshots__/era-differential-goldens.test.ts.snap
+++ b/sdk/tests/oauth/__snapshots__/era-differential-goldens.test.ts.snap
@@ -1,0 +1,1452 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`branch catalog (2025-03-26) > DCR failure falls back to pre-registered credentials when available 1`] = `
+{
+  "authorizationUrl": "https://mcp-server.example.com/authorize?response_type=code&client_id=fallback-client-id&redirect_uri=http%3A%2F%2Flocalhost%3A3000%2Foauth%2Fcallback%2Fdebug&code_challenge=<code-challenge>&code_challenge_method=S256&state=<state>&resource=https%3A%2F%2Fmcp-server.example.com%2Fmcp",
+  "completed": true,
+  "error": null,
+  "wire": [
+    {
+      "body": null,
+      "headers": {
+        "MCP-Protocol-Version": "2025-03-26",
+      },
+      "method": "GET",
+      "redirect": null,
+      "url": "https://mcp-server.example.com/.well-known/oauth-authorization-server/mcp",
+    },
+    {
+      "body": {
+        "client_name": "Differential Client",
+        "grant_types": [
+          "authorization_code",
+          "refresh_token",
+        ],
+        "redirect_uris": [
+          "http://localhost:3000/oauth/callback/debug",
+        ],
+        "response_types": [
+          "code",
+        ],
+        "token_endpoint_auth_method": "none",
+      },
+      "headers": {
+        "Content-Type": "application/json",
+      },
+      "method": "POST",
+      "redirect": null,
+      "url": "https://mcp-server.example.com/register",
+    },
+    {
+      "body": "grant_type=authorization_code&code=mock-auth-code&redirect_uri=http%3A%2F%2Flocalhost%3A3000%2Foauth%2Fcallback%2Fdebug&code_verifier=<code-verifier>&client_id=fallback-client-id&resource=https%3A%2F%2Fmcp-server.example.com%2Fmcp",
+      "headers": {
+        "Content-Type": "application/x-www-form-urlencoded",
+      },
+      "method": "POST",
+      "redirect": null,
+      "url": "https://mcp-server.example.com/token",
+    },
+    {
+      "body": "{"jsonrpc":"2.0","method":"initialize","params":{"protocolVersion":"2024-11-05","capabilities":{},"clientInfo":{"name":"MCP Inspector","version":"1.0.0"}},"id":2}",
+      "headers": {
+        "Accept": "application/json, text/event-stream",
+        "Authorization": "Bearer access-token",
+        "Content-Type": "application/json",
+      },
+      "method": "POST",
+      "redirect": null,
+      "url": "https://mcp-server.example.com/mcp",
+    },
+  ],
+}
+`;
+
+exports[`branch catalog (2025-03-26) > DCR failure without a fallback stops the flow 1`] = `
+{
+  "authorizationUrl": null,
+  "completed": false,
+  "error": "Dynamic Client Registration failed (400). Configure a pre-registered client or enable DCR on the authorization server.",
+  "wire": [
+    {
+      "body": null,
+      "headers": {
+        "MCP-Protocol-Version": "2025-03-26",
+      },
+      "method": "GET",
+      "redirect": null,
+      "url": "https://mcp-server.example.com/.well-known/oauth-authorization-server/mcp",
+    },
+    {
+      "body": {
+        "client_name": "Differential Client",
+        "grant_types": [
+          "authorization_code",
+          "refresh_token",
+        ],
+        "redirect_uris": [
+          "http://localhost:3000/oauth/callback/debug",
+        ],
+        "response_types": [
+          "code",
+        ],
+        "token_endpoint_auth_method": "none",
+      },
+      "headers": {
+        "Content-Type": "application/json",
+      },
+      "method": "POST",
+      "redirect": null,
+      "url": "https://mcp-server.example.com/register",
+    },
+  ],
+}
+`;
+
+exports[`branch catalog (2025-03-26) > an issuer that does not match the discovery origin is handled per era 1`] = `
+{
+  "authorizationUrl": "https://mcp-server.example.com/authorize?response_type=code&client_id=test-client-id&redirect_uri=http%3A%2F%2Flocalhost%3A3000%2Foauth%2Fcallback%2Fdebug&code_challenge=<code-challenge>&code_challenge_method=S256&state=<state>&resource=https%3A%2F%2Fmcp-server.example.com%2Fmcp",
+  "completed": true,
+  "error": null,
+  "wire": [
+    {
+      "body": null,
+      "headers": {
+        "MCP-Protocol-Version": "2025-03-26",
+      },
+      "method": "GET",
+      "redirect": null,
+      "url": "https://mcp-server.example.com/.well-known/oauth-authorization-server/mcp",
+    },
+    {
+      "body": {
+        "client_name": "Differential Client",
+        "grant_types": [
+          "authorization_code",
+          "refresh_token",
+        ],
+        "redirect_uris": [
+          "http://localhost:3000/oauth/callback/debug",
+        ],
+        "response_types": [
+          "code",
+        ],
+        "token_endpoint_auth_method": "none",
+      },
+      "headers": {
+        "Content-Type": "application/json",
+      },
+      "method": "POST",
+      "redirect": null,
+      "url": "https://mcp-server.example.com/register",
+    },
+    {
+      "body": "grant_type=authorization_code&code=mock-auth-code&redirect_uri=http%3A%2F%2Flocalhost%3A3000%2Foauth%2Fcallback%2Fdebug&code_verifier=<code-verifier>&client_id=test-client-id&resource=https%3A%2F%2Fmcp-server.example.com%2Fmcp",
+      "headers": {
+        "Content-Type": "application/x-www-form-urlencoded",
+      },
+      "method": "POST",
+      "redirect": null,
+      "url": "https://mcp-server.example.com/token",
+    },
+    {
+      "body": "{"jsonrpc":"2.0","method":"initialize","params":{"protocolVersion":"2024-11-05","capabilities":{},"clientInfo":{"name":"MCP Inspector","version":"1.0.0"}},"id":2}",
+      "headers": {
+        "Accept": "application/json, text/event-stream",
+        "Authorization": "Bearer access-token",
+        "Content-Type": "application/json",
+      },
+      "method": "POST",
+      "redirect": null,
+      "url": "https://mcp-server.example.com/mcp",
+    },
+  ],
+}
+`;
+
+exports[`branch catalog (2025-06-18) > DCR failure falls back to pre-registered credentials when available 1`] = `
+{
+  "authorizationUrl": "https://auth-server.example.com/authorize?response_type=code&client_id=fallback-client-id&redirect_uri=http%3A%2F%2Flocalhost%3A3000%2Foauth%2Fcallback%2Fdebug&code_challenge=<code-challenge>&code_challenge_method=S256&state=<state>&resource=https%3A%2F%2Fmcp-server.example.com%2Fmcp",
+  "completed": true,
+  "error": null,
+  "wire": [
+    {
+      "body": "{"jsonrpc":"2.0","method":"initialize","params":{"protocolVersion":"2024-11-05","capabilities":{},"clientInfo":{"name":"MCPJam Inspector","version":"1.0.0"}},"id":1}",
+      "headers": {
+        "Accept": "application/json, text/event-stream",
+        "Content-Type": "application/json",
+        "MCP-Protocol-Version": "2025-06-18",
+      },
+      "method": "POST",
+      "redirect": null,
+      "url": "https://mcp-server.example.com/mcp",
+    },
+    {
+      "body": null,
+      "headers": {
+        "Accept": "application/json",
+        "MCP-Protocol-Version": "2025-11-25",
+      },
+      "method": "GET",
+      "redirect": null,
+      "url": "https://mcp-server.example.com/.well-known/oauth-protected-resource/mcp",
+    },
+    {
+      "body": null,
+      "headers": {},
+      "method": "GET",
+      "redirect": null,
+      "url": "https://auth-server.example.com/.well-known/oauth-authorization-server",
+    },
+    {
+      "body": {
+        "client_name": "Differential Client",
+        "grant_types": [
+          "authorization_code",
+          "refresh_token",
+        ],
+        "redirect_uris": [
+          "http://localhost:3000/oauth/callback/debug",
+        ],
+        "response_types": [
+          "code",
+        ],
+        "token_endpoint_auth_method": "none",
+      },
+      "headers": {
+        "Content-Type": "application/json",
+      },
+      "method": "POST",
+      "redirect": null,
+      "url": "https://auth-server.example.com/register",
+    },
+    {
+      "body": "grant_type=authorization_code&code=mock-auth-code&redirect_uri=http%3A%2F%2Flocalhost%3A3000%2Foauth%2Fcallback%2Fdebug&code_verifier=<code-verifier>&client_id=fallback-client-id&resource=https%3A%2F%2Fmcp-server.example.com%2Fmcp",
+      "headers": {
+        "Content-Type": "application/x-www-form-urlencoded",
+      },
+      "method": "POST",
+      "redirect": null,
+      "url": "https://auth-server.example.com/token",
+    },
+    {
+      "body": "{"jsonrpc":"2.0","method":"initialize","params":{"protocolVersion":"2024-11-05","capabilities":{},"clientInfo":{"name":"MCPJam Inspector","version":"1.0.0"}},"id":2}",
+      "headers": {
+        "Accept": "application/json, text/event-stream",
+        "Authorization": "Bearer access-token",
+        "Content-Type": "application/json",
+        "MCP-Protocol-Version": "2025-06-18",
+      },
+      "method": "POST",
+      "redirect": null,
+      "url": "https://mcp-server.example.com/mcp",
+    },
+  ],
+}
+`;
+
+exports[`branch catalog (2025-06-18) > DCR failure without a fallback stops the flow 1`] = `
+{
+  "authorizationUrl": null,
+  "completed": false,
+  "error": "Dynamic Client Registration failed (400). Configure a pre-registered client or enable DCR on the authorization server.",
+  "wire": [
+    {
+      "body": "{"jsonrpc":"2.0","method":"initialize","params":{"protocolVersion":"2024-11-05","capabilities":{},"clientInfo":{"name":"MCPJam Inspector","version":"1.0.0"}},"id":1}",
+      "headers": {
+        "Accept": "application/json, text/event-stream",
+        "Content-Type": "application/json",
+        "MCP-Protocol-Version": "2025-06-18",
+      },
+      "method": "POST",
+      "redirect": null,
+      "url": "https://mcp-server.example.com/mcp",
+    },
+    {
+      "body": null,
+      "headers": {
+        "Accept": "application/json",
+        "MCP-Protocol-Version": "2025-11-25",
+      },
+      "method": "GET",
+      "redirect": null,
+      "url": "https://mcp-server.example.com/.well-known/oauth-protected-resource/mcp",
+    },
+    {
+      "body": null,
+      "headers": {},
+      "method": "GET",
+      "redirect": null,
+      "url": "https://auth-server.example.com/.well-known/oauth-authorization-server",
+    },
+    {
+      "body": {
+        "client_name": "Differential Client",
+        "grant_types": [
+          "authorization_code",
+          "refresh_token",
+        ],
+        "redirect_uris": [
+          "http://localhost:3000/oauth/callback/debug",
+        ],
+        "response_types": [
+          "code",
+        ],
+        "token_endpoint_auth_method": "none",
+      },
+      "headers": {
+        "Content-Type": "application/json",
+      },
+      "method": "POST",
+      "redirect": null,
+      "url": "https://auth-server.example.com/register",
+    },
+  ],
+}
+`;
+
+exports[`branch catalog (2025-06-18) > an issuer that does not match the discovery origin is handled per era 1`] = `
+{
+  "authorizationUrl": "https://auth-server.example.com/authorize?response_type=code&client_id=test-client-id&redirect_uri=http%3A%2F%2Flocalhost%3A3000%2Foauth%2Fcallback%2Fdebug&code_challenge=<code-challenge>&code_challenge_method=S256&state=<state>&resource=https%3A%2F%2Fmcp-server.example.com%2Fmcp",
+  "completed": true,
+  "error": null,
+  "wire": [
+    {
+      "body": "{"jsonrpc":"2.0","method":"initialize","params":{"protocolVersion":"2024-11-05","capabilities":{},"clientInfo":{"name":"MCPJam Inspector","version":"1.0.0"}},"id":1}",
+      "headers": {
+        "Accept": "application/json, text/event-stream",
+        "Content-Type": "application/json",
+        "MCP-Protocol-Version": "2025-06-18",
+      },
+      "method": "POST",
+      "redirect": null,
+      "url": "https://mcp-server.example.com/mcp",
+    },
+    {
+      "body": null,
+      "headers": {
+        "Accept": "application/json",
+        "MCP-Protocol-Version": "2025-11-25",
+      },
+      "method": "GET",
+      "redirect": null,
+      "url": "https://mcp-server.example.com/.well-known/oauth-protected-resource/mcp",
+    },
+    {
+      "body": null,
+      "headers": {},
+      "method": "GET",
+      "redirect": null,
+      "url": "https://auth-server.example.com/.well-known/oauth-authorization-server",
+    },
+    {
+      "body": {
+        "client_name": "Differential Client",
+        "grant_types": [
+          "authorization_code",
+          "refresh_token",
+        ],
+        "redirect_uris": [
+          "http://localhost:3000/oauth/callback/debug",
+        ],
+        "response_types": [
+          "code",
+        ],
+        "token_endpoint_auth_method": "none",
+      },
+      "headers": {
+        "Content-Type": "application/json",
+      },
+      "method": "POST",
+      "redirect": null,
+      "url": "https://auth-server.example.com/register",
+    },
+    {
+      "body": "grant_type=authorization_code&code=mock-auth-code&redirect_uri=http%3A%2F%2Flocalhost%3A3000%2Foauth%2Fcallback%2Fdebug&code_verifier=<code-verifier>&client_id=test-client-id&resource=https%3A%2F%2Fmcp-server.example.com%2Fmcp",
+      "headers": {
+        "Content-Type": "application/x-www-form-urlencoded",
+      },
+      "method": "POST",
+      "redirect": null,
+      "url": "https://auth-server.example.com/token",
+    },
+    {
+      "body": "{"jsonrpc":"2.0","method":"initialize","params":{"protocolVersion":"2024-11-05","capabilities":{},"clientInfo":{"name":"MCPJam Inspector","version":"1.0.0"}},"id":2}",
+      "headers": {
+        "Accept": "application/json, text/event-stream",
+        "Authorization": "Bearer access-token",
+        "Content-Type": "application/json",
+        "MCP-Protocol-Version": "2025-06-18",
+      },
+      "method": "POST",
+      "redirect": null,
+      "url": "https://mcp-server.example.com/mcp",
+    },
+  ],
+}
+`;
+
+exports[`branch catalog (2025-11-25) > DCR failure falls back to pre-registered credentials when available 1`] = `
+{
+  "authorizationUrl": "https://auth-server.example.com/authorize?response_type=code&client_id=fallback-client-id&redirect_uri=http%3A%2F%2Flocalhost%3A3000%2Foauth%2Fcallback%2Fdebug&code_challenge=<code-challenge>&code_challenge_method=S256&state=<state>&resource=https%3A%2F%2Fmcp-server.example.com%2Fmcp",
+  "completed": true,
+  "error": null,
+  "wire": [
+    {
+      "body": "{"jsonrpc":"2.0","method":"initialize","params":{"protocolVersion":"2025-11-25","capabilities":{},"clientInfo":{"name":"MCPJam Inspector","version":"1.0.0"}},"id":1}",
+      "headers": {
+        "Accept": "application/json, text/event-stream",
+        "Content-Type": "application/json",
+        "MCP-Protocol-Version": "2025-11-25",
+      },
+      "method": "POST",
+      "redirect": null,
+      "url": "https://mcp-server.example.com/mcp",
+    },
+    {
+      "body": null,
+      "headers": {
+        "Accept": "application/json",
+        "MCP-Protocol-Version": "2025-11-25",
+      },
+      "method": "GET",
+      "redirect": null,
+      "url": "https://mcp-server.example.com/.well-known/oauth-protected-resource/mcp",
+    },
+    {
+      "body": null,
+      "headers": {},
+      "method": "GET",
+      "redirect": null,
+      "url": "https://auth-server.example.com/.well-known/oauth-authorization-server",
+    },
+    {
+      "body": {
+        "client_name": "Differential Client",
+        "grant_types": [
+          "authorization_code",
+          "refresh_token",
+        ],
+        "redirect_uris": [
+          "http://localhost:3000/oauth/callback/debug",
+        ],
+        "response_types": [
+          "code",
+        ],
+        "token_endpoint_auth_method": "none",
+      },
+      "headers": {
+        "Content-Type": "application/json",
+      },
+      "method": "POST",
+      "redirect": null,
+      "url": "https://auth-server.example.com/register",
+    },
+    {
+      "body": "grant_type=authorization_code&code=mock-auth-code&redirect_uri=http%3A%2F%2Flocalhost%3A3000%2Foauth%2Fcallback%2Fdebug&code_verifier=<code-verifier>&client_id=fallback-client-id&resource=https%3A%2F%2Fmcp-server.example.com%2Fmcp",
+      "headers": {
+        "Content-Type": "application/x-www-form-urlencoded",
+      },
+      "method": "POST",
+      "redirect": null,
+      "url": "https://auth-server.example.com/token",
+    },
+    {
+      "body": "{"jsonrpc":"2.0","method":"initialize","params":{"protocolVersion":"2025-11-25","capabilities":{},"clientInfo":{"name":"MCPJam Inspector","version":"1.0.0"}},"id":2}",
+      "headers": {
+        "Accept": "application/json, text/event-stream",
+        "Authorization": "Bearer access-token",
+        "Content-Type": "application/json",
+        "MCP-Protocol-Version": "2025-11-25",
+      },
+      "method": "POST",
+      "redirect": null,
+      "url": "https://mcp-server.example.com/mcp",
+    },
+  ],
+}
+`;
+
+exports[`branch catalog (2025-11-25) > DCR failure without a fallback stops the flow 1`] = `
+{
+  "authorizationUrl": null,
+  "completed": false,
+  "error": "Dynamic Client Registration failed (400). Configure a pre-registered client or enable DCR on the authorization server.",
+  "wire": [
+    {
+      "body": "{"jsonrpc":"2.0","method":"initialize","params":{"protocolVersion":"2025-11-25","capabilities":{},"clientInfo":{"name":"MCPJam Inspector","version":"1.0.0"}},"id":1}",
+      "headers": {
+        "Accept": "application/json, text/event-stream",
+        "Content-Type": "application/json",
+        "MCP-Protocol-Version": "2025-11-25",
+      },
+      "method": "POST",
+      "redirect": null,
+      "url": "https://mcp-server.example.com/mcp",
+    },
+    {
+      "body": null,
+      "headers": {
+        "Accept": "application/json",
+        "MCP-Protocol-Version": "2025-11-25",
+      },
+      "method": "GET",
+      "redirect": null,
+      "url": "https://mcp-server.example.com/.well-known/oauth-protected-resource/mcp",
+    },
+    {
+      "body": null,
+      "headers": {},
+      "method": "GET",
+      "redirect": null,
+      "url": "https://auth-server.example.com/.well-known/oauth-authorization-server",
+    },
+    {
+      "body": {
+        "client_name": "Differential Client",
+        "grant_types": [
+          "authorization_code",
+          "refresh_token",
+        ],
+        "redirect_uris": [
+          "http://localhost:3000/oauth/callback/debug",
+        ],
+        "response_types": [
+          "code",
+        ],
+        "token_endpoint_auth_method": "none",
+      },
+      "headers": {
+        "Content-Type": "application/json",
+      },
+      "method": "POST",
+      "redirect": null,
+      "url": "https://auth-server.example.com/register",
+    },
+  ],
+}
+`;
+
+exports[`branch catalog (2025-11-25) > an issuer that does not match the discovery origin is handled per era 1`] = `
+{
+  "authorizationUrl": "https://auth-server.example.com/authorize?response_type=code&client_id=test-client-id&redirect_uri=http%3A%2F%2Flocalhost%3A3000%2Foauth%2Fcallback%2Fdebug&code_challenge=<code-challenge>&code_challenge_method=S256&state=<state>&resource=https%3A%2F%2Fmcp-server.example.com%2Fmcp",
+  "completed": true,
+  "error": null,
+  "wire": [
+    {
+      "body": "{"jsonrpc":"2.0","method":"initialize","params":{"protocolVersion":"2025-11-25","capabilities":{},"clientInfo":{"name":"MCPJam Inspector","version":"1.0.0"}},"id":1}",
+      "headers": {
+        "Accept": "application/json, text/event-stream",
+        "Content-Type": "application/json",
+        "MCP-Protocol-Version": "2025-11-25",
+      },
+      "method": "POST",
+      "redirect": null,
+      "url": "https://mcp-server.example.com/mcp",
+    },
+    {
+      "body": null,
+      "headers": {
+        "Accept": "application/json",
+        "MCP-Protocol-Version": "2025-11-25",
+      },
+      "method": "GET",
+      "redirect": null,
+      "url": "https://mcp-server.example.com/.well-known/oauth-protected-resource/mcp",
+    },
+    {
+      "body": null,
+      "headers": {},
+      "method": "GET",
+      "redirect": null,
+      "url": "https://auth-server.example.com/.well-known/oauth-authorization-server",
+    },
+    {
+      "body": {
+        "client_name": "Differential Client",
+        "grant_types": [
+          "authorization_code",
+          "refresh_token",
+        ],
+        "redirect_uris": [
+          "http://localhost:3000/oauth/callback/debug",
+        ],
+        "response_types": [
+          "code",
+        ],
+        "token_endpoint_auth_method": "none",
+      },
+      "headers": {
+        "Content-Type": "application/json",
+      },
+      "method": "POST",
+      "redirect": null,
+      "url": "https://auth-server.example.com/register",
+    },
+    {
+      "body": "grant_type=authorization_code&code=mock-auth-code&redirect_uri=http%3A%2F%2Flocalhost%3A3000%2Foauth%2Fcallback%2Fdebug&code_verifier=<code-verifier>&client_id=test-client-id&resource=https%3A%2F%2Fmcp-server.example.com%2Fmcp",
+      "headers": {
+        "Content-Type": "application/x-www-form-urlencoded",
+      },
+      "method": "POST",
+      "redirect": null,
+      "url": "https://auth-server.example.com/token",
+    },
+    {
+      "body": "{"jsonrpc":"2.0","method":"initialize","params":{"protocolVersion":"2025-11-25","capabilities":{},"clientInfo":{"name":"MCPJam Inspector","version":"1.0.0"}},"id":2}",
+      "headers": {
+        "Accept": "application/json, text/event-stream",
+        "Authorization": "Bearer access-token",
+        "Content-Type": "application/json",
+        "MCP-Protocol-Version": "2025-11-25",
+      },
+      "method": "POST",
+      "redirect": null,
+      "url": "https://mcp-server.example.com/mcp",
+    },
+  ],
+}
+`;
+
+exports[`branch catalog (2026-07-28) > DCR failure falls back to pre-registered credentials when available 1`] = `
+{
+  "authorizationUrl": "https://auth-server.example.com/authorize?response_type=code&client_id=fallback-client-id&redirect_uri=http%3A%2F%2Flocalhost%3A3000%2Foauth%2Fcallback%2Fdebug&code_challenge=<code-challenge>&code_challenge_method=S256&state=<state>&resource=https%3A%2F%2Fmcp-server.example.com%2Fmcp",
+  "completed": true,
+  "error": null,
+  "wire": [
+    {
+      "body": "{"jsonrpc":"2.0","method":"tools/list","params":{"_meta":{"io.modelcontextprotocol/protocolVersion":"2026-07-28","io.modelcontextprotocol/clientCapabilities":{},"io.modelcontextprotocol/clientInfo":{"name":"MCPJam Inspector","version":"1.0.0"}}},"id":1}",
+      "headers": {
+        "Accept": "application/json, text/event-stream",
+        "Content-Type": "application/json",
+        "MCP-Protocol-Version": "2026-07-28",
+        "Mcp-Method": "tools/list",
+      },
+      "method": "POST",
+      "redirect": null,
+      "url": "https://mcp-server.example.com/mcp",
+    },
+    {
+      "body": null,
+      "headers": {
+        "Accept": "application/json",
+        "MCP-Protocol-Version": "2025-11-25",
+      },
+      "method": "GET",
+      "redirect": null,
+      "url": "https://mcp-server.example.com/.well-known/oauth-protected-resource/mcp",
+    },
+    {
+      "body": null,
+      "headers": {},
+      "method": "GET",
+      "redirect": null,
+      "url": "https://auth-server.example.com/.well-known/oauth-authorization-server",
+    },
+    {
+      "body": {
+        "application_type": "native",
+        "client_name": "Differential Client",
+        "grant_types": [
+          "authorization_code",
+          "refresh_token",
+        ],
+        "redirect_uris": [
+          "http://localhost:3000/oauth/callback/debug",
+        ],
+        "response_types": [
+          "code",
+        ],
+        "token_endpoint_auth_method": "none",
+      },
+      "headers": {
+        "Content-Type": "application/json",
+      },
+      "method": "POST",
+      "redirect": null,
+      "url": "https://auth-server.example.com/register",
+    },
+    {
+      "body": "grant_type=authorization_code&code=mock-auth-code&redirect_uri=http%3A%2F%2Flocalhost%3A3000%2Foauth%2Fcallback%2Fdebug&code_verifier=<code-verifier>&client_id=fallback-client-id&resource=https%3A%2F%2Fmcp-server.example.com%2Fmcp",
+      "headers": {
+        "Content-Type": "application/x-www-form-urlencoded",
+      },
+      "method": "POST",
+      "redirect": null,
+      "url": "https://auth-server.example.com/token",
+    },
+    {
+      "body": "{"jsonrpc":"2.0","method":"tools/list","params":{"_meta":{"io.modelcontextprotocol/protocolVersion":"2026-07-28","io.modelcontextprotocol/clientCapabilities":{},"io.modelcontextprotocol/clientInfo":{"name":"MCPJam Inspector","version":"1.0.0"}}},"id":2}",
+      "headers": {
+        "Accept": "application/json, text/event-stream",
+        "Authorization": "Bearer access-token",
+        "Content-Type": "application/json",
+        "MCP-Protocol-Version": "2026-07-28",
+        "Mcp-Method": "tools/list",
+      },
+      "method": "POST",
+      "redirect": null,
+      "url": "https://mcp-server.example.com/mcp",
+    },
+  ],
+}
+`;
+
+exports[`branch catalog (2026-07-28) > DCR failure without a fallback stops the flow 1`] = `
+{
+  "authorizationUrl": null,
+  "completed": false,
+  "error": "Dynamic Client Registration failed (400). Configure a pre-registered client or enable DCR on the authorization server.",
+  "wire": [
+    {
+      "body": "{"jsonrpc":"2.0","method":"tools/list","params":{"_meta":{"io.modelcontextprotocol/protocolVersion":"2026-07-28","io.modelcontextprotocol/clientCapabilities":{},"io.modelcontextprotocol/clientInfo":{"name":"MCPJam Inspector","version":"1.0.0"}}},"id":1}",
+      "headers": {
+        "Accept": "application/json, text/event-stream",
+        "Content-Type": "application/json",
+        "MCP-Protocol-Version": "2026-07-28",
+        "Mcp-Method": "tools/list",
+      },
+      "method": "POST",
+      "redirect": null,
+      "url": "https://mcp-server.example.com/mcp",
+    },
+    {
+      "body": null,
+      "headers": {
+        "Accept": "application/json",
+        "MCP-Protocol-Version": "2025-11-25",
+      },
+      "method": "GET",
+      "redirect": null,
+      "url": "https://mcp-server.example.com/.well-known/oauth-protected-resource/mcp",
+    },
+    {
+      "body": null,
+      "headers": {},
+      "method": "GET",
+      "redirect": null,
+      "url": "https://auth-server.example.com/.well-known/oauth-authorization-server",
+    },
+    {
+      "body": {
+        "application_type": "native",
+        "client_name": "Differential Client",
+        "grant_types": [
+          "authorization_code",
+          "refresh_token",
+        ],
+        "redirect_uris": [
+          "http://localhost:3000/oauth/callback/debug",
+        ],
+        "response_types": [
+          "code",
+        ],
+        "token_endpoint_auth_method": "none",
+      },
+      "headers": {
+        "Content-Type": "application/json",
+      },
+      "method": "POST",
+      "redirect": null,
+      "url": "https://auth-server.example.com/register",
+    },
+  ],
+}
+`;
+
+exports[`branch catalog (2026-07-28) > an issuer that does not match the discovery origin is handled per era 1`] = `
+{
+  "authorizationUrl": null,
+  "completed": false,
+  "error": "Authorization server metadata \`issuer\` does not match the authorization server URL it was discovered from (expected "https://auth-server.example.com", got "https://elsewhere.example.com"). RFC 8414 §3.3 requires an exact match; refusing to continue.",
+  "wire": [
+    {
+      "body": "{"jsonrpc":"2.0","method":"tools/list","params":{"_meta":{"io.modelcontextprotocol/protocolVersion":"2026-07-28","io.modelcontextprotocol/clientCapabilities":{},"io.modelcontextprotocol/clientInfo":{"name":"MCPJam Inspector","version":"1.0.0"}}},"id":1}",
+      "headers": {
+        "Accept": "application/json, text/event-stream",
+        "Content-Type": "application/json",
+        "MCP-Protocol-Version": "2026-07-28",
+        "Mcp-Method": "tools/list",
+      },
+      "method": "POST",
+      "redirect": null,
+      "url": "https://mcp-server.example.com/mcp",
+    },
+    {
+      "body": null,
+      "headers": {
+        "Accept": "application/json",
+        "MCP-Protocol-Version": "2025-11-25",
+      },
+      "method": "GET",
+      "redirect": null,
+      "url": "https://mcp-server.example.com/.well-known/oauth-protected-resource/mcp",
+    },
+    {
+      "body": null,
+      "headers": {},
+      "method": "GET",
+      "redirect": null,
+      "url": "https://auth-server.example.com/.well-known/oauth-authorization-server",
+    },
+  ],
+}
+`;
+
+exports[`era 2025-03-26 × registration dcr > happy ladder: full request sequence 1`] = `
+{
+  "authorizationUrl": "https://mcp-server.example.com/authorize?response_type=code&client_id=test-client-id&redirect_uri=http%3A%2F%2Flocalhost%3A3000%2Foauth%2Fcallback%2Fdebug&code_challenge=<code-challenge>&code_challenge_method=S256&state=<state>&resource=https%3A%2F%2Fmcp-server.example.com%2Fmcp",
+  "completed": true,
+  "error": null,
+  "wire": [
+    {
+      "body": null,
+      "headers": {
+        "MCP-Protocol-Version": "2025-03-26",
+      },
+      "method": "GET",
+      "redirect": null,
+      "url": "https://mcp-server.example.com/.well-known/oauth-authorization-server/mcp",
+    },
+    {
+      "body": {
+        "client_name": "Differential Client",
+        "grant_types": [
+          "authorization_code",
+          "refresh_token",
+        ],
+        "redirect_uris": [
+          "http://localhost:3000/oauth/callback/debug",
+        ],
+        "response_types": [
+          "code",
+        ],
+        "token_endpoint_auth_method": "none",
+      },
+      "headers": {
+        "Content-Type": "application/json",
+      },
+      "method": "POST",
+      "redirect": null,
+      "url": "https://mcp-server.example.com/register",
+    },
+    {
+      "body": "grant_type=authorization_code&code=mock-auth-code&redirect_uri=http%3A%2F%2Flocalhost%3A3000%2Foauth%2Fcallback%2Fdebug&code_verifier=<code-verifier>&client_id=test-client-id&resource=https%3A%2F%2Fmcp-server.example.com%2Fmcp",
+      "headers": {
+        "Content-Type": "application/x-www-form-urlencoded",
+      },
+      "method": "POST",
+      "redirect": null,
+      "url": "https://mcp-server.example.com/token",
+    },
+    {
+      "body": "{"jsonrpc":"2.0","method":"initialize","params":{"protocolVersion":"2024-11-05","capabilities":{},"clientInfo":{"name":"MCP Inspector","version":"1.0.0"}},"id":2}",
+      "headers": {
+        "Accept": "application/json, text/event-stream",
+        "Authorization": "Bearer access-token",
+        "Content-Type": "application/json",
+      },
+      "method": "POST",
+      "redirect": null,
+      "url": "https://mcp-server.example.com/mcp",
+    },
+  ],
+}
+`;
+
+exports[`era 2025-03-26 × registration preregistered > happy ladder: full request sequence 1`] = `
+{
+  "authorizationUrl": "https://mcp-server.example.com/authorize?response_type=code&client_id=preregistered-client-id&redirect_uri=http%3A%2F%2Flocalhost%3A3000%2Foauth%2Fcallback%2Fdebug&code_challenge=<code-challenge>&code_challenge_method=S256&state=<state>&resource=https%3A%2F%2Fmcp-server.example.com%2Fmcp",
+  "completed": true,
+  "error": null,
+  "wire": [
+    {
+      "body": null,
+      "headers": {
+        "MCP-Protocol-Version": "2025-03-26",
+      },
+      "method": "GET",
+      "redirect": null,
+      "url": "https://mcp-server.example.com/.well-known/oauth-authorization-server/mcp",
+    },
+    {
+      "body": "grant_type=authorization_code&code=mock-auth-code&redirect_uri=http%3A%2F%2Flocalhost%3A3000%2Foauth%2Fcallback%2Fdebug&code_verifier=<code-verifier>&client_id=preregistered-client-id&resource=https%3A%2F%2Fmcp-server.example.com%2Fmcp",
+      "headers": {
+        "Content-Type": "application/x-www-form-urlencoded",
+      },
+      "method": "POST",
+      "redirect": null,
+      "url": "https://mcp-server.example.com/token",
+    },
+    {
+      "body": "{"jsonrpc":"2.0","method":"initialize","params":{"protocolVersion":"2024-11-05","capabilities":{},"clientInfo":{"name":"MCP Inspector","version":"1.0.0"}},"id":2}",
+      "headers": {
+        "Accept": "application/json, text/event-stream",
+        "Authorization": "Bearer access-token",
+        "Content-Type": "application/json",
+      },
+      "method": "POST",
+      "redirect": null,
+      "url": "https://mcp-server.example.com/mcp",
+    },
+  ],
+}
+`;
+
+exports[`era 2025-06-18 × registration dcr > happy ladder: full request sequence 1`] = `
+{
+  "authorizationUrl": "https://auth-server.example.com/authorize?response_type=code&client_id=test-client-id&redirect_uri=http%3A%2F%2Flocalhost%3A3000%2Foauth%2Fcallback%2Fdebug&code_challenge=<code-challenge>&code_challenge_method=S256&state=<state>&resource=https%3A%2F%2Fmcp-server.example.com%2Fmcp",
+  "completed": true,
+  "error": null,
+  "wire": [
+    {
+      "body": "{"jsonrpc":"2.0","method":"initialize","params":{"protocolVersion":"2024-11-05","capabilities":{},"clientInfo":{"name":"MCPJam Inspector","version":"1.0.0"}},"id":1}",
+      "headers": {
+        "Accept": "application/json, text/event-stream",
+        "Content-Type": "application/json",
+        "MCP-Protocol-Version": "2025-06-18",
+      },
+      "method": "POST",
+      "redirect": null,
+      "url": "https://mcp-server.example.com/mcp",
+    },
+    {
+      "body": null,
+      "headers": {
+        "Accept": "application/json",
+        "MCP-Protocol-Version": "2025-11-25",
+      },
+      "method": "GET",
+      "redirect": null,
+      "url": "https://mcp-server.example.com/.well-known/oauth-protected-resource/mcp",
+    },
+    {
+      "body": null,
+      "headers": {},
+      "method": "GET",
+      "redirect": null,
+      "url": "https://auth-server.example.com/.well-known/oauth-authorization-server",
+    },
+    {
+      "body": {
+        "client_name": "Differential Client",
+        "grant_types": [
+          "authorization_code",
+          "refresh_token",
+        ],
+        "redirect_uris": [
+          "http://localhost:3000/oauth/callback/debug",
+        ],
+        "response_types": [
+          "code",
+        ],
+        "token_endpoint_auth_method": "none",
+      },
+      "headers": {
+        "Content-Type": "application/json",
+      },
+      "method": "POST",
+      "redirect": null,
+      "url": "https://auth-server.example.com/register",
+    },
+    {
+      "body": "grant_type=authorization_code&code=mock-auth-code&redirect_uri=http%3A%2F%2Flocalhost%3A3000%2Foauth%2Fcallback%2Fdebug&code_verifier=<code-verifier>&client_id=test-client-id&resource=https%3A%2F%2Fmcp-server.example.com%2Fmcp",
+      "headers": {
+        "Content-Type": "application/x-www-form-urlencoded",
+      },
+      "method": "POST",
+      "redirect": null,
+      "url": "https://auth-server.example.com/token",
+    },
+    {
+      "body": "{"jsonrpc":"2.0","method":"initialize","params":{"protocolVersion":"2024-11-05","capabilities":{},"clientInfo":{"name":"MCPJam Inspector","version":"1.0.0"}},"id":2}",
+      "headers": {
+        "Accept": "application/json, text/event-stream",
+        "Authorization": "Bearer access-token",
+        "Content-Type": "application/json",
+        "MCP-Protocol-Version": "2025-06-18",
+      },
+      "method": "POST",
+      "redirect": null,
+      "url": "https://mcp-server.example.com/mcp",
+    },
+  ],
+}
+`;
+
+exports[`era 2025-06-18 × registration preregistered > happy ladder: full request sequence 1`] = `
+{
+  "authorizationUrl": "https://auth-server.example.com/authorize?response_type=code&client_id=preregistered-client-id&redirect_uri=http%3A%2F%2Flocalhost%3A3000%2Foauth%2Fcallback%2Fdebug&code_challenge=<code-challenge>&code_challenge_method=S256&state=<state>&resource=https%3A%2F%2Fmcp-server.example.com%2Fmcp",
+  "completed": true,
+  "error": null,
+  "wire": [
+    {
+      "body": "{"jsonrpc":"2.0","method":"initialize","params":{"protocolVersion":"2024-11-05","capabilities":{},"clientInfo":{"name":"MCPJam Inspector","version":"1.0.0"}},"id":1}",
+      "headers": {
+        "Accept": "application/json, text/event-stream",
+        "Content-Type": "application/json",
+        "MCP-Protocol-Version": "2025-06-18",
+      },
+      "method": "POST",
+      "redirect": null,
+      "url": "https://mcp-server.example.com/mcp",
+    },
+    {
+      "body": null,
+      "headers": {
+        "Accept": "application/json",
+        "MCP-Protocol-Version": "2025-11-25",
+      },
+      "method": "GET",
+      "redirect": null,
+      "url": "https://mcp-server.example.com/.well-known/oauth-protected-resource/mcp",
+    },
+    {
+      "body": null,
+      "headers": {},
+      "method": "GET",
+      "redirect": null,
+      "url": "https://auth-server.example.com/.well-known/oauth-authorization-server",
+    },
+    {
+      "body": "grant_type=authorization_code&code=mock-auth-code&redirect_uri=http%3A%2F%2Flocalhost%3A3000%2Foauth%2Fcallback%2Fdebug&code_verifier=<code-verifier>&client_id=preregistered-client-id&resource=https%3A%2F%2Fmcp-server.example.com%2Fmcp",
+      "headers": {
+        "Content-Type": "application/x-www-form-urlencoded",
+      },
+      "method": "POST",
+      "redirect": null,
+      "url": "https://auth-server.example.com/token",
+    },
+    {
+      "body": "{"jsonrpc":"2.0","method":"initialize","params":{"protocolVersion":"2024-11-05","capabilities":{},"clientInfo":{"name":"MCPJam Inspector","version":"1.0.0"}},"id":2}",
+      "headers": {
+        "Accept": "application/json, text/event-stream",
+        "Authorization": "Bearer access-token",
+        "Content-Type": "application/json",
+        "MCP-Protocol-Version": "2025-06-18",
+      },
+      "method": "POST",
+      "redirect": null,
+      "url": "https://mcp-server.example.com/mcp",
+    },
+  ],
+}
+`;
+
+exports[`era 2025-11-25 × registration cimd > happy ladder: full request sequence 1`] = `
+{
+  "authorizationUrl": "https://auth-server.example.com/authorize?response_type=code&client_id=https%3A%2F%2Fwww.mcpjam.com%2F.well-known%2Foauth%2Fclient-metadata.json&redirect_uri=http%3A%2F%2Flocalhost%3A3000%2Foauth%2Fcallback%2Fdebug&code_challenge=<code-challenge>&code_challenge_method=S256&state=<state>&resource=https%3A%2F%2Fmcp-server.example.com%2Fmcp",
+  "completed": true,
+  "error": null,
+  "wire": [
+    {
+      "body": "{"jsonrpc":"2.0","method":"initialize","params":{"protocolVersion":"2025-11-25","capabilities":{},"clientInfo":{"name":"MCPJam Inspector","version":"1.0.0"}},"id":1}",
+      "headers": {
+        "Accept": "application/json, text/event-stream",
+        "Content-Type": "application/json",
+        "MCP-Protocol-Version": "2025-11-25",
+      },
+      "method": "POST",
+      "redirect": null,
+      "url": "https://mcp-server.example.com/mcp",
+    },
+    {
+      "body": null,
+      "headers": {
+        "Accept": "application/json",
+        "MCP-Protocol-Version": "2025-11-25",
+      },
+      "method": "GET",
+      "redirect": null,
+      "url": "https://mcp-server.example.com/.well-known/oauth-protected-resource/mcp",
+    },
+    {
+      "body": null,
+      "headers": {},
+      "method": "GET",
+      "redirect": null,
+      "url": "https://auth-server.example.com/.well-known/oauth-authorization-server",
+    },
+    {
+      "body": null,
+      "headers": {},
+      "method": "GET",
+      "redirect": null,
+      "url": "https://www.mcpjam.com/.well-known/oauth/client-metadata.json",
+    },
+    {
+      "body": "grant_type=authorization_code&code=mock-auth-code&redirect_uri=http%3A%2F%2Flocalhost%3A3000%2Foauth%2Fcallback%2Fdebug&code_verifier=<code-verifier>&client_id=https%3A%2F%2Fwww.mcpjam.com%2F.well-known%2Foauth%2Fclient-metadata.json&resource=https%3A%2F%2Fmcp-server.example.com%2Fmcp",
+      "headers": {
+        "Content-Type": "application/x-www-form-urlencoded",
+      },
+      "method": "POST",
+      "redirect": null,
+      "url": "https://auth-server.example.com/token",
+    },
+    {
+      "body": "{"jsonrpc":"2.0","method":"initialize","params":{"protocolVersion":"2025-11-25","capabilities":{},"clientInfo":{"name":"MCPJam Inspector","version":"1.0.0"}},"id":2}",
+      "headers": {
+        "Accept": "application/json, text/event-stream",
+        "Authorization": "Bearer access-token",
+        "Content-Type": "application/json",
+        "MCP-Protocol-Version": "2025-11-25",
+      },
+      "method": "POST",
+      "redirect": null,
+      "url": "https://mcp-server.example.com/mcp",
+    },
+  ],
+}
+`;
+
+exports[`era 2025-11-25 × registration dcr > happy ladder: full request sequence 1`] = `
+{
+  "authorizationUrl": "https://auth-server.example.com/authorize?response_type=code&client_id=test-client-id&redirect_uri=http%3A%2F%2Flocalhost%3A3000%2Foauth%2Fcallback%2Fdebug&code_challenge=<code-challenge>&code_challenge_method=S256&state=<state>&resource=https%3A%2F%2Fmcp-server.example.com%2Fmcp",
+  "completed": true,
+  "error": null,
+  "wire": [
+    {
+      "body": "{"jsonrpc":"2.0","method":"initialize","params":{"protocolVersion":"2025-11-25","capabilities":{},"clientInfo":{"name":"MCPJam Inspector","version":"1.0.0"}},"id":1}",
+      "headers": {
+        "Accept": "application/json, text/event-stream",
+        "Content-Type": "application/json",
+        "MCP-Protocol-Version": "2025-11-25",
+      },
+      "method": "POST",
+      "redirect": null,
+      "url": "https://mcp-server.example.com/mcp",
+    },
+    {
+      "body": null,
+      "headers": {
+        "Accept": "application/json",
+        "MCP-Protocol-Version": "2025-11-25",
+      },
+      "method": "GET",
+      "redirect": null,
+      "url": "https://mcp-server.example.com/.well-known/oauth-protected-resource/mcp",
+    },
+    {
+      "body": null,
+      "headers": {},
+      "method": "GET",
+      "redirect": null,
+      "url": "https://auth-server.example.com/.well-known/oauth-authorization-server",
+    },
+    {
+      "body": {
+        "client_name": "Differential Client",
+        "grant_types": [
+          "authorization_code",
+          "refresh_token",
+        ],
+        "redirect_uris": [
+          "http://localhost:3000/oauth/callback/debug",
+        ],
+        "response_types": [
+          "code",
+        ],
+        "token_endpoint_auth_method": "none",
+      },
+      "headers": {
+        "Content-Type": "application/json",
+      },
+      "method": "POST",
+      "redirect": null,
+      "url": "https://auth-server.example.com/register",
+    },
+    {
+      "body": "grant_type=authorization_code&code=mock-auth-code&redirect_uri=http%3A%2F%2Flocalhost%3A3000%2Foauth%2Fcallback%2Fdebug&code_verifier=<code-verifier>&client_id=test-client-id&resource=https%3A%2F%2Fmcp-server.example.com%2Fmcp",
+      "headers": {
+        "Content-Type": "application/x-www-form-urlencoded",
+      },
+      "method": "POST",
+      "redirect": null,
+      "url": "https://auth-server.example.com/token",
+    },
+    {
+      "body": "{"jsonrpc":"2.0","method":"initialize","params":{"protocolVersion":"2025-11-25","capabilities":{},"clientInfo":{"name":"MCPJam Inspector","version":"1.0.0"}},"id":2}",
+      "headers": {
+        "Accept": "application/json, text/event-stream",
+        "Authorization": "Bearer access-token",
+        "Content-Type": "application/json",
+        "MCP-Protocol-Version": "2025-11-25",
+      },
+      "method": "POST",
+      "redirect": null,
+      "url": "https://mcp-server.example.com/mcp",
+    },
+  ],
+}
+`;
+
+exports[`era 2025-11-25 × registration preregistered > happy ladder: full request sequence 1`] = `
+{
+  "authorizationUrl": "https://auth-server.example.com/authorize?response_type=code&client_id=preregistered-client-id&redirect_uri=http%3A%2F%2Flocalhost%3A3000%2Foauth%2Fcallback%2Fdebug&code_challenge=<code-challenge>&code_challenge_method=S256&state=<state>&resource=https%3A%2F%2Fmcp-server.example.com%2Fmcp",
+  "completed": true,
+  "error": null,
+  "wire": [
+    {
+      "body": "{"jsonrpc":"2.0","method":"initialize","params":{"protocolVersion":"2025-11-25","capabilities":{},"clientInfo":{"name":"MCPJam Inspector","version":"1.0.0"}},"id":1}",
+      "headers": {
+        "Accept": "application/json, text/event-stream",
+        "Content-Type": "application/json",
+        "MCP-Protocol-Version": "2025-11-25",
+      },
+      "method": "POST",
+      "redirect": null,
+      "url": "https://mcp-server.example.com/mcp",
+    },
+    {
+      "body": null,
+      "headers": {
+        "Accept": "application/json",
+        "MCP-Protocol-Version": "2025-11-25",
+      },
+      "method": "GET",
+      "redirect": null,
+      "url": "https://mcp-server.example.com/.well-known/oauth-protected-resource/mcp",
+    },
+    {
+      "body": null,
+      "headers": {},
+      "method": "GET",
+      "redirect": null,
+      "url": "https://auth-server.example.com/.well-known/oauth-authorization-server",
+    },
+    {
+      "body": "grant_type=authorization_code&code=mock-auth-code&redirect_uri=http%3A%2F%2Flocalhost%3A3000%2Foauth%2Fcallback%2Fdebug&code_verifier=<code-verifier>&client_id=preregistered-client-id&resource=https%3A%2F%2Fmcp-server.example.com%2Fmcp",
+      "headers": {
+        "Content-Type": "application/x-www-form-urlencoded",
+      },
+      "method": "POST",
+      "redirect": null,
+      "url": "https://auth-server.example.com/token",
+    },
+    {
+      "body": "{"jsonrpc":"2.0","method":"initialize","params":{"protocolVersion":"2025-11-25","capabilities":{},"clientInfo":{"name":"MCPJam Inspector","version":"1.0.0"}},"id":2}",
+      "headers": {
+        "Accept": "application/json, text/event-stream",
+        "Authorization": "Bearer access-token",
+        "Content-Type": "application/json",
+        "MCP-Protocol-Version": "2025-11-25",
+      },
+      "method": "POST",
+      "redirect": null,
+      "url": "https://mcp-server.example.com/mcp",
+    },
+  ],
+}
+`;
+
+exports[`era 2026-07-28 × registration cimd > happy ladder: full request sequence 1`] = `
+{
+  "authorizationUrl": "https://auth-server.example.com/authorize?response_type=code&client_id=https%3A%2F%2Fwww.mcpjam.com%2F.well-known%2Foauth%2Fclient-metadata.json&redirect_uri=http%3A%2F%2Flocalhost%3A3000%2Foauth%2Fcallback%2Fdebug&code_challenge=<code-challenge>&code_challenge_method=S256&state=<state>&resource=https%3A%2F%2Fmcp-server.example.com%2Fmcp",
+  "completed": true,
+  "error": null,
+  "wire": [
+    {
+      "body": "{"jsonrpc":"2.0","method":"tools/list","params":{"_meta":{"io.modelcontextprotocol/protocolVersion":"2026-07-28","io.modelcontextprotocol/clientCapabilities":{},"io.modelcontextprotocol/clientInfo":{"name":"MCPJam Inspector","version":"1.0.0"}}},"id":1}",
+      "headers": {
+        "Accept": "application/json, text/event-stream",
+        "Content-Type": "application/json",
+        "MCP-Protocol-Version": "2026-07-28",
+        "Mcp-Method": "tools/list",
+      },
+      "method": "POST",
+      "redirect": null,
+      "url": "https://mcp-server.example.com/mcp",
+    },
+    {
+      "body": null,
+      "headers": {
+        "Accept": "application/json",
+        "MCP-Protocol-Version": "2025-11-25",
+      },
+      "method": "GET",
+      "redirect": null,
+      "url": "https://mcp-server.example.com/.well-known/oauth-protected-resource/mcp",
+    },
+    {
+      "body": null,
+      "headers": {},
+      "method": "GET",
+      "redirect": null,
+      "url": "https://auth-server.example.com/.well-known/oauth-authorization-server",
+    },
+    {
+      "body": null,
+      "headers": {},
+      "method": "GET",
+      "redirect": null,
+      "url": "https://www.mcpjam.com/.well-known/oauth/client-metadata.json",
+    },
+    {
+      "body": "grant_type=authorization_code&code=mock-auth-code&redirect_uri=http%3A%2F%2Flocalhost%3A3000%2Foauth%2Fcallback%2Fdebug&code_verifier=<code-verifier>&client_id=https%3A%2F%2Fwww.mcpjam.com%2F.well-known%2Foauth%2Fclient-metadata.json&resource=https%3A%2F%2Fmcp-server.example.com%2Fmcp",
+      "headers": {
+        "Content-Type": "application/x-www-form-urlencoded",
+      },
+      "method": "POST",
+      "redirect": null,
+      "url": "https://auth-server.example.com/token",
+    },
+    {
+      "body": "{"jsonrpc":"2.0","method":"tools/list","params":{"_meta":{"io.modelcontextprotocol/protocolVersion":"2026-07-28","io.modelcontextprotocol/clientCapabilities":{},"io.modelcontextprotocol/clientInfo":{"name":"MCPJam Inspector","version":"1.0.0"}}},"id":2}",
+      "headers": {
+        "Accept": "application/json, text/event-stream",
+        "Authorization": "Bearer access-token",
+        "Content-Type": "application/json",
+        "MCP-Protocol-Version": "2026-07-28",
+        "Mcp-Method": "tools/list",
+      },
+      "method": "POST",
+      "redirect": null,
+      "url": "https://mcp-server.example.com/mcp",
+    },
+  ],
+}
+`;
+
+exports[`era 2026-07-28 × registration dcr > happy ladder: full request sequence 1`] = `
+{
+  "authorizationUrl": "https://auth-server.example.com/authorize?response_type=code&client_id=test-client-id&redirect_uri=http%3A%2F%2Flocalhost%3A3000%2Foauth%2Fcallback%2Fdebug&code_challenge=<code-challenge>&code_challenge_method=S256&state=<state>&resource=https%3A%2F%2Fmcp-server.example.com%2Fmcp",
+  "completed": true,
+  "error": null,
+  "wire": [
+    {
+      "body": "{"jsonrpc":"2.0","method":"tools/list","params":{"_meta":{"io.modelcontextprotocol/protocolVersion":"2026-07-28","io.modelcontextprotocol/clientCapabilities":{},"io.modelcontextprotocol/clientInfo":{"name":"MCPJam Inspector","version":"1.0.0"}}},"id":1}",
+      "headers": {
+        "Accept": "application/json, text/event-stream",
+        "Content-Type": "application/json",
+        "MCP-Protocol-Version": "2026-07-28",
+        "Mcp-Method": "tools/list",
+      },
+      "method": "POST",
+      "redirect": null,
+      "url": "https://mcp-server.example.com/mcp",
+    },
+    {
+      "body": null,
+      "headers": {
+        "Accept": "application/json",
+        "MCP-Protocol-Version": "2025-11-25",
+      },
+      "method": "GET",
+      "redirect": null,
+      "url": "https://mcp-server.example.com/.well-known/oauth-protected-resource/mcp",
+    },
+    {
+      "body": null,
+      "headers": {},
+      "method": "GET",
+      "redirect": null,
+      "url": "https://auth-server.example.com/.well-known/oauth-authorization-server",
+    },
+    {
+      "body": {
+        "application_type": "native",
+        "client_name": "Differential Client",
+        "grant_types": [
+          "authorization_code",
+          "refresh_token",
+        ],
+        "redirect_uris": [
+          "http://localhost:3000/oauth/callback/debug",
+        ],
+        "response_types": [
+          "code",
+        ],
+        "token_endpoint_auth_method": "none",
+      },
+      "headers": {
+        "Content-Type": "application/json",
+      },
+      "method": "POST",
+      "redirect": null,
+      "url": "https://auth-server.example.com/register",
+    },
+    {
+      "body": "grant_type=authorization_code&code=mock-auth-code&redirect_uri=http%3A%2F%2Flocalhost%3A3000%2Foauth%2Fcallback%2Fdebug&code_verifier=<code-verifier>&client_id=test-client-id&resource=https%3A%2F%2Fmcp-server.example.com%2Fmcp",
+      "headers": {
+        "Content-Type": "application/x-www-form-urlencoded",
+      },
+      "method": "POST",
+      "redirect": null,
+      "url": "https://auth-server.example.com/token",
+    },
+    {
+      "body": "{"jsonrpc":"2.0","method":"tools/list","params":{"_meta":{"io.modelcontextprotocol/protocolVersion":"2026-07-28","io.modelcontextprotocol/clientCapabilities":{},"io.modelcontextprotocol/clientInfo":{"name":"MCPJam Inspector","version":"1.0.0"}}},"id":2}",
+      "headers": {
+        "Accept": "application/json, text/event-stream",
+        "Authorization": "Bearer access-token",
+        "Content-Type": "application/json",
+        "MCP-Protocol-Version": "2026-07-28",
+        "Mcp-Method": "tools/list",
+      },
+      "method": "POST",
+      "redirect": null,
+      "url": "https://mcp-server.example.com/mcp",
+    },
+  ],
+}
+`;
+
+exports[`era 2026-07-28 × registration preregistered > happy ladder: full request sequence 1`] = `
+{
+  "authorizationUrl": "https://auth-server.example.com/authorize?response_type=code&client_id=preregistered-client-id&redirect_uri=http%3A%2F%2Flocalhost%3A3000%2Foauth%2Fcallback%2Fdebug&code_challenge=<code-challenge>&code_challenge_method=S256&state=<state>&resource=https%3A%2F%2Fmcp-server.example.com%2Fmcp",
+  "completed": true,
+  "error": null,
+  "wire": [
+    {
+      "body": "{"jsonrpc":"2.0","method":"tools/list","params":{"_meta":{"io.modelcontextprotocol/protocolVersion":"2026-07-28","io.modelcontextprotocol/clientCapabilities":{},"io.modelcontextprotocol/clientInfo":{"name":"MCPJam Inspector","version":"1.0.0"}}},"id":1}",
+      "headers": {
+        "Accept": "application/json, text/event-stream",
+        "Content-Type": "application/json",
+        "MCP-Protocol-Version": "2026-07-28",
+        "Mcp-Method": "tools/list",
+      },
+      "method": "POST",
+      "redirect": null,
+      "url": "https://mcp-server.example.com/mcp",
+    },
+    {
+      "body": null,
+      "headers": {
+        "Accept": "application/json",
+        "MCP-Protocol-Version": "2025-11-25",
+      },
+      "method": "GET",
+      "redirect": null,
+      "url": "https://mcp-server.example.com/.well-known/oauth-protected-resource/mcp",
+    },
+    {
+      "body": null,
+      "headers": {},
+      "method": "GET",
+      "redirect": null,
+      "url": "https://auth-server.example.com/.well-known/oauth-authorization-server",
+    },
+    {
+      "body": "grant_type=authorization_code&code=mock-auth-code&redirect_uri=http%3A%2F%2Flocalhost%3A3000%2Foauth%2Fcallback%2Fdebug&code_verifier=<code-verifier>&client_id=preregistered-client-id&resource=https%3A%2F%2Fmcp-server.example.com%2Fmcp",
+      "headers": {
+        "Content-Type": "application/x-www-form-urlencoded",
+      },
+      "method": "POST",
+      "redirect": null,
+      "url": "https://auth-server.example.com/token",
+    },
+    {
+      "body": "{"jsonrpc":"2.0","method":"tools/list","params":{"_meta":{"io.modelcontextprotocol/protocolVersion":"2026-07-28","io.modelcontextprotocol/clientCapabilities":{},"io.modelcontextprotocol/clientInfo":{"name":"MCPJam Inspector","version":"1.0.0"}}},"id":2}",
+      "headers": {
+        "Accept": "application/json, text/event-stream",
+        "Authorization": "Bearer access-token",
+        "Content-Type": "application/json",
+        "MCP-Protocol-Version": "2026-07-28",
+        "Mcp-Method": "tools/list",
+      },
+      "method": "POST",
+      "redirect": null,
+      "url": "https://mcp-server.example.com/mcp",
+    },
+  ],
+}
+`;

--- a/sdk/tests/oauth/era-differential-goldens.test.ts
+++ b/sdk/tests/oauth/era-differential-goldens.test.ts
@@ -31,6 +31,9 @@ import {
 
 const SERVER_URL = "https://mcp-server.example.com/mcp";
 const SERVER_ORIGIN = "https://mcp-server.example.com";
+
+/** Step ceiling for one driven flow. Comfortably above the longest era. */
+const MAX_STEPS = 40;
 const RESOURCE_METADATA_URL = `${SERVER_ORIGIN}/.well-known/oauth-protected-resource/mcp`;
 const AUTH_SERVER_URL = "https://auth-server.example.com";
 const REDIRECT_URL = "http://localhost:3000/oauth/callback/debug";
@@ -303,7 +306,7 @@ async function run(options: RunOptions): Promise<RunResult> {
   });
 
   let deliveredCode = false;
-  for (let index = 0; index < 40; index += 1) {
+  for (let index = 0; index < MAX_STEPS; index += 1) {
     if (state.currentStep === "complete" || state.error) break;
 
     // Cross the human step exactly once.
@@ -330,6 +333,17 @@ async function run(options: RunOptions): Promise<RunResult> {
       };
       break;
     }
+  }
+
+  // Exhausting the budget is a harness failure, not a result. Every negative
+  // case below asserts `completed === false` plus the absence of a token, and a
+  // machine stuck on an intermediate step satisfies both — so a regression that
+  // never reaches the expected rejection would read as the rejection working.
+  // Only "complete" or a recorded error is a terminal state.
+  if (state.currentStep !== "complete" && !state.error) {
+    throw new Error(
+      `step budget (${MAX_STEPS}) exhausted at "${state.currentStep}" without reaching a terminal state`,
+    );
   }
 
   return {
@@ -450,7 +464,11 @@ function assertWireInvariants(result: RunResult, version: OAuthProtocolVersion) 
   const authorizeResource = authorize!.searchParams.get("resource");
   expect(authorizeResource).toBeTruthy();
   expect(tokenBody.resource).toBe(authorizeResource);
-  expect(new URL(authorizeResource!).origin).toBe(SERVER_ORIGIN);
+  // The whole canonical value, not just its origin: a same-origin switch to
+  // another audience (`/other`) is exactly the mis-binding this invariant
+  // exists to catch, and an origin check waves it through — leaving an
+  // accepted snapshot as the only signal.
+  expect(authorizeResource).toBe(SERVER_URL);
 
   // A CSRF state is always issued.
   expect(authorize!.searchParams.get("state")).toBeTruthy();
@@ -598,6 +616,76 @@ describe.each(ALL_VERSIONS)("branch catalog (%s)", (version) => {
     },
   );
 
+  // The conforming case above is where all three modes agree, so on its own it
+  // cannot tell an implementation that honors `resourceIndicatorEnforcement`
+  // from one that ignores it entirely. The two below make each mode's boundary
+  // observable.
+  //
+  // 2025-03-26 has no PRM step to advertise a resource with, so the knob has
+  // nothing to act on. Skipped rather than returned from — a test that returns
+  // before asserting is reported as passing.
+  //
+  // Same-origin but not a path prefix of the server URL: `evaluateCandidate`
+  // calls this `status: "valid"` with `rfc9728Compliant: false`, so it is the
+  // one shape that separates `reject` from `reject-rfc9728`.
+  it.skipIf(version === "2025-03-26").each([
+    ["warn", true],
+    ["reject", true],
+    ["reject-rfc9728", false],
+  ] as const)(
+    "resourceIndicatorEnforcement=%s on a same-origin non-prefix resource",
+    async (enforcement, expectedToComplete) => {
+      const result = await run({
+        version,
+        registrationStrategy: "dcr",
+        machineConfig: { resourceIndicatorEnforcement: enforcement },
+        knobs: {
+          protectedResourceMetadata: { resource: `${SERVER_ORIGIN}/other` },
+        },
+      });
+
+      expect(result.completed, result.error).toBe(expectedToComplete);
+      if (expectedToComplete) {
+        // The advertised value is what gets bound, including when it is not
+        // the server URL. That is the point of the non-strict modes.
+        expect(authorizationUrl(result)!.searchParams.get("resource")).toBe(
+          `${SERVER_ORIGIN}/other`,
+        );
+      } else {
+        expect(tokenRequest(result)).toBeUndefined();
+      }
+    },
+  );
+
+  // A foreign origin is `status: "incompatible"`, which both reject modes
+  // refuse and `warn` deliberately lets through so real server behavior stays
+  // observable in the debugger.
+  it.skipIf(version === "2025-03-26").each([
+    ["warn", true],
+    ["reject", false],
+    ["reject-rfc9728", false],
+  ] as const)(
+    "resourceIndicatorEnforcement=%s on a foreign-origin resource",
+    async (enforcement, expectedToComplete) => {
+      const foreign = "https://elsewhere.example.com/mcp";
+      const result = await run({
+        version,
+        registrationStrategy: "dcr",
+        machineConfig: { resourceIndicatorEnforcement: enforcement },
+        knobs: { protectedResourceMetadata: { resource: foreign } },
+      });
+
+      expect(result.completed, result.error).toBe(expectedToComplete);
+      if (expectedToComplete) {
+        expect(authorizationUrl(result)!.searchParams.get("resource")).toBe(
+          foreign,
+        );
+      } else {
+        expect(tokenRequest(result)).toBeUndefined();
+      }
+    },
+  );
+
   it.each([true, false])(
     "allowPathScopedIssuer=%s against an exact-match issuer",
     async (allowPathScopedIssuer) => {
@@ -654,6 +742,53 @@ describe.each(ALL_VERSIONS)("branch catalog (%s)", (version) => {
       expect(strict.completed, strict.error).toBe(true);
     }
   });
+
+  // …and the case the toggle actually exists for. Without it the rejection
+  // above is the only outcome exercised, so deleting the opt-in's accept path
+  // entirely would still pass the harness.
+  //
+  // Discovery starts from a path-scoped AS URL while the metadata advertises
+  // the origin root as its issuer — the multi-tenant shape RFC 8414 §3.3's
+  // exact match rejects and `allowPathScopedIssuer` is the opt-in for.
+  it.skipIf(version === "2025-03-26")(
+    "allowPathScopedIssuer accepts an origin-root issuer under a path-scoped AS",
+    async () => {
+      const pathScoped = {
+        knobs: {
+          protectedResourceMetadata: {
+            authorization_servers: [`${AUTH_SERVER_URL}/tenant/abc`],
+          },
+        },
+      } as const;
+
+      const optedOut = await run({
+        version,
+        registrationStrategy: "dcr",
+        ...pathScoped,
+      });
+      const optedIn = await run({
+        version,
+        registrationStrategy: "dcr",
+        ...pathScoped,
+        machineConfig: { allowPathScopedIssuer: true },
+      });
+
+      if (version === "2026-07-28") {
+        // The toggle has to CHANGE the outcome, or it is dead configuration.
+        expect(optedOut.completed).toBe(false);
+        expect(optedOut.error).toMatch(/issuer/i);
+        expect(tokenRequest(optedOut)).toBeUndefined();
+
+        expect(optedIn.completed, optedIn.error).toBe(true);
+        assertWireInvariants(optedIn, version);
+      } else {
+        // Earlier eras ignore the knob; pinned so a shared-code change cannot
+        // quietly extend the strict check backwards.
+        expect(optedOut.completed, optedOut.error).toBe(true);
+        expect(optedIn.completed, optedIn.error).toBe(true);
+      }
+    },
+  );
 
   // --- Current-profile branches. Older eras genuinely differ here. ---
 

--- a/sdk/tests/oauth/era-differential-goldens.test.ts
+++ b/sdk/tests/oauth/era-differential-goldens.test.ts
@@ -50,6 +50,23 @@ const ALL_VERSIONS: OAuthProtocolVersion[] = [
 /** Eras governed by the current PRM + PKCE profile. */
 const CURRENT_ERAS: OAuthProtocolVersion[] = ["2025-11-25", "2026-07-28"];
 
+/**
+ * Eras whose spec requires the PRM to name an authorization server. Note this
+ * is NOT `CURRENT_ERAS`: the RFC 9728 requirement dates to 2025-06-18, while
+ * verifying advertised S256 starts at 2025-11-25.
+ *
+ * Deliberately a LITERAL, not an import of the production gate. Importing it
+ * would make this harness tautological — flipping the gate would silently move
+ * an era from the "fails closed" branch to the "substitutes" branch and every
+ * assertion would still pass. The literal IS the specification here, and drift
+ * from production is exactly the failure worth catching.
+ */
+const PRM_REQUIRED_ERAS: OAuthProtocolVersion[] = [
+  "2025-06-18",
+  "2025-11-25",
+  "2026-07-28",
+];
+
 type RegistrationStrategy = "dcr" | "preregistered" | "cimd";
 
 /** CIMD arrived with 2025-11-25; the factory rejects it for older eras. */
@@ -790,7 +807,61 @@ describe.each(ALL_VERSIONS)("branch catalog (%s)", (version) => {
     },
   );
 
-  // --- Current-profile branches. Older eras genuinely differ here. ---
+  // --- Required-metadata branches. Older eras genuinely differ here, but not
+  // on the same boundary: the PRM `authorization_servers` requirement dates to
+  // 2025-06-18, while verifying advertised S256 starts at 2025-11-25. Gating
+  // both on `isCurrentEra` would leave 2025-06-18's PRM enforcement untested,
+  // which is precisely the era-differential this file exists to pin. ---
+
+  if (PRM_REQUIRED_ERAS.includes(version)) {
+    it.each([
+      ["empty", { authorization_servers: [] }],
+      ["absent", { authorization_servers: null }],
+    ])(
+      "fails closed when PRM authorization_servers is %s",
+      async (_label, override) => {
+        const result = await run({
+          version,
+          registrationStrategy: "dcr",
+          knobs: { protectedResourceMetadata: override },
+        });
+
+        expect(result.completed).toBe(false);
+        expect(tokenRequest(result)).toBeUndefined();
+        // Specifically: it did NOT silently substitute the MCP server URL.
+        expect(result.state.authorizationServerMetadata).toBeFalsy();
+      },
+    );
+
+    it("observe mode substitutes the server URL and records the finding", async () => {
+      const result = await run({
+        version,
+        registrationStrategy: "dcr",
+        knobs: { protectedResourceMetadata: { authorization_servers: [] } },
+        machineConfig: { requiredMetadataEnforcement: "observe" },
+      });
+
+      expect(result.state.authorizationServerUrl).toBe(SERVER_URL);
+      expect(JSON.stringify(result.state.infoLogs ?? [])).toContain(
+        "authorization-server-substituted",
+      );
+    });
+  } else {
+    // The other half of the differential: 2025-03-26 predates the profile's
+    // adoption of RFC 9728, so the historical substitution is correct there and
+    // the flow must NOT stop. Without this the "fails closed" assertions above
+    // would pass just as well if the check were global.
+    it("substitutes the server URL rather than failing closed", async () => {
+      const result = await run({
+        version,
+        registrationStrategy: "dcr",
+        knobs: { protectedResourceMetadata: { authorization_servers: [] } },
+      });
+
+      expect(result.state.authorizationServerUrl).toBe(SERVER_URL);
+      expect(result.error ?? "").not.toContain("authorization_servers");
+    });
+  }
 
   if (isCurrentEra) {
     it("stops before authorization when the AS advertises no S256", async () => {
@@ -824,39 +895,6 @@ describe.each(ALL_VERSIONS)("branch catalog (%s)", (version) => {
       expect(result.completed).toBe(false);
       expect(authorizationUrl(result)).toBeUndefined();
       expect(tokenRequest(result)).toBeUndefined();
-    });
-
-    it.each([
-      ["empty", { authorization_servers: [] }],
-      ["absent", { authorization_servers: null }],
-    ])(
-      "fails closed when PRM authorization_servers is %s",
-      async (_label, override) => {
-        const result = await run({
-          version,
-          registrationStrategy: "dcr",
-          knobs: { protectedResourceMetadata: override },
-        });
-
-        expect(result.completed).toBe(false);
-        expect(tokenRequest(result)).toBeUndefined();
-        // Specifically: it did NOT silently substitute the MCP server URL.
-        expect(result.state.authorizationServerMetadata).toBeFalsy();
-      },
-    );
-
-    it("observe mode substitutes the server URL and records the finding", async () => {
-      const result = await run({
-        version,
-        registrationStrategy: "dcr",
-        knobs: { protectedResourceMetadata: { authorization_servers: [] } },
-        machineConfig: { requiredMetadataEnforcement: "observe" },
-      });
-
-      expect(result.state.authorizationServerUrl).toBe(SERVER_URL);
-      expect(JSON.stringify(result.state.infoLogs ?? [])).toContain(
-        "authorization-server-substituted",
-      );
     });
 
     it("accepts plain advertised alongside S256", async () => {

--- a/sdk/tests/oauth/era-differential-goldens.test.ts
+++ b/sdk/tests/oauth/era-differential-goldens.test.ts
@@ -1,0 +1,742 @@
+/**
+ * Differential goldens across every era, registration strategy, and branch.
+ *
+ * `no-emulation-goldens.test.ts` covers one happy ladder per era, `dcr` only,
+ * no error branches. That is enough to notice an accidental change to the
+ * default path and nothing else — which is a thin basis for any consolidation
+ * of the era machines, and a thin basis for trusting them in general.
+ *
+ * This file widens it to 4 eras × each supported registration strategy × a
+ * catalog of the branches that actually differ between eras: PRM shape, PKCE
+ * metadata, DCR failure and its pre-registered fallback, issuer policy,
+ * resource-indicator enforcement.
+ *
+ * Two layers, deliberately:
+ *
+ *   - A snapshot of the full request sequence. Good for review — it shows what
+ *     changed — and useless as a guarantee, because accepting an updated
+ *     snapshot is one keystroke.
+ *   - Named assertions for the MCP OAuth MUSTs. These are the gate. A snapshot
+ *     update must not be able to normalize away a missing `S256`, a broken
+ *     resource binding, or a credential sent to the wrong endpoint.
+ */
+
+import { createOAuthStateMachine } from "../../src/oauth/state-machines/factory.js";
+import {
+  EMPTY_OAUTH_FLOW_STATE,
+  type OAuthFlowState,
+  type OAuthHttpRequest,
+  type OAuthProtocolVersion,
+} from "../../src/oauth/state-machines/types.js";
+
+const SERVER_URL = "https://mcp-server.example.com/mcp";
+const SERVER_ORIGIN = "https://mcp-server.example.com";
+const RESOURCE_METADATA_URL = `${SERVER_ORIGIN}/.well-known/oauth-protected-resource/mcp`;
+const AUTH_SERVER_URL = "https://auth-server.example.com";
+const REDIRECT_URL = "http://localhost:3000/oauth/callback/debug";
+const CLIENT_ID_METADATA_URL = "https://www.mcpjam.com/.well-known/oauth/client-metadata.json";
+const ACCESS_TOKEN = "access-token";
+
+const ALL_VERSIONS: OAuthProtocolVersion[] = [
+  "2025-03-26",
+  "2025-06-18",
+  "2025-11-25",
+  "2026-07-28",
+];
+
+/** Eras governed by the current PRM + PKCE profile. */
+const CURRENT_ERAS: OAuthProtocolVersion[] = ["2025-11-25", "2026-07-28"];
+
+type RegistrationStrategy = "dcr" | "preregistered" | "cimd";
+
+/** CIMD arrived with 2025-11-25; the factory rejects it for older eras. */
+function supportedStrategies(
+  version: OAuthProtocolVersion,
+): RegistrationStrategy[] {
+  return CURRENT_ERAS.includes(version)
+    ? ["dcr", "preregistered", "cimd"]
+    : ["dcr", "preregistered"];
+}
+
+/**
+ * 2025-03-26 has no protected-resource-metadata step: the authorization server
+ * is discovered on the MCP server's own origin.
+ */
+function authServerBaseFor(version: OAuthProtocolVersion): string {
+  return version === "2025-03-26" ? SERVER_ORIGIN : AUTH_SERVER_URL;
+}
+
+interface RouterKnobs {
+  /** Replace the protected-resource metadata document. `null` deletes a key. */
+  protectedResourceMetadata?: Record<string, unknown>;
+  /** Replace the authorization-server metadata document. `null` deletes a key. */
+  authorizationServerMetadata?: Record<string, unknown>;
+  /** Make dynamic client registration fail. */
+  registrationFails?: boolean;
+  /** Advertise an issuer other than the discovery origin. */
+  issuerOverride?: string;
+}
+
+function applyOverrides(
+  base: Record<string, unknown>,
+  overrides: Record<string, unknown> | undefined,
+): Record<string, unknown> {
+  if (!overrides) return base;
+  const merged = { ...base, ...overrides };
+  for (const [key, value] of Object.entries(overrides)) {
+    if (value === null) delete merged[key];
+  }
+  return merged;
+}
+
+function buildRouter(version: OAuthProtocolVersion, knobs: RouterKnobs = {}) {
+  const asBase = authServerBaseFor(version);
+  const challenge =
+    version === "2025-03-26"
+      ? 'Bearer realm="mcp"'
+      : `Bearer resource_metadata="${RESOURCE_METADATA_URL}"`;
+
+  return async (request: OAuthHttpRequest) => {
+    if (
+      request.url === SERVER_URL &&
+      request.headers.Authorization === `Bearer ${ACCESS_TOKEN}`
+    ) {
+      return {
+        status: 200,
+        statusText: "OK",
+        headers: { "content-type": "application/json" },
+        body:
+          version === "2026-07-28"
+            ? { jsonrpc: "2.0", id: 2, result: { tools: [] } }
+            : {
+                jsonrpc: "2.0",
+                id: 2,
+                result: {
+                  protocolVersion: version,
+                  serverInfo: { name: "mock", version: "1.0.0" },
+                  capabilities: {},
+                },
+              },
+        ok: true,
+      };
+    }
+
+    if (request.url === SERVER_URL) {
+      return {
+        status: 401,
+        statusText: "Unauthorized",
+        headers: { "www-authenticate": challenge },
+        body: null,
+        ok: false,
+      };
+    }
+
+    if (request.url === RESOURCE_METADATA_URL) {
+      return {
+        status: 200,
+        statusText: "OK",
+        headers: { "content-type": "application/json" },
+        body: applyOverrides(
+          { resource: SERVER_URL, authorization_servers: [AUTH_SERVER_URL] },
+          knobs.protectedResourceMetadata,
+        ),
+        ok: true,
+      };
+    }
+
+    if (
+      request.url.includes("/.well-known/oauth-authorization-server") ||
+      request.url.includes("/.well-known/openid-configuration")
+    ) {
+      return {
+        status: 200,
+        statusText: "OK",
+        headers: { "content-type": "application/json" },
+        body: applyOverrides(
+          {
+            issuer: knobs.issuerOverride ?? asBase,
+            authorization_endpoint: `${asBase}/authorize`,
+            token_endpoint: `${asBase}/token`,
+            registration_endpoint: `${asBase}/register`,
+            response_types_supported: ["code"],
+            grant_types_supported: ["authorization_code"],
+            code_challenge_methods_supported: ["S256"],
+            client_id_metadata_document_supported: true,
+          },
+          knobs.authorizationServerMetadata,
+        ),
+        ok: true,
+      };
+    }
+
+    // The Client ID Metadata Document the `cimd` strategy fetches instead of
+    // registering. Served here so CIMD is a real branch in the matrix rather
+    // than a 404 every era fails identically on.
+    if (request.url === CLIENT_ID_METADATA_URL) {
+      return {
+        status: 200,
+        statusText: "OK",
+        headers: { "content-type": "application/json" },
+        body: {
+          client_id: CLIENT_ID_METADATA_URL,
+          client_name: "MCPJam Inspector",
+          redirect_uris: [REDIRECT_URL],
+          grant_types: ["authorization_code", "refresh_token"],
+          response_types: ["code"],
+          token_endpoint_auth_method: "none",
+        },
+        ok: true,
+      };
+    }
+
+    if (request.url === `${asBase}/register`) {
+      if (knobs.registrationFails) {
+        return {
+          status: 400,
+          statusText: "Bad Request",
+          headers: { "content-type": "application/json" },
+          body: {
+            error: "invalid_client_metadata",
+            error_description: "Dynamic registration is disabled.",
+          },
+          ok: false,
+        };
+      }
+      return {
+        status: 200,
+        statusText: "OK",
+        headers: { "content-type": "application/json" },
+        body: { client_id: "test-client-id", token_endpoint_auth_method: "none" },
+        ok: true,
+      };
+    }
+
+    if (request.url === `${asBase}/token`) {
+      return {
+        status: 200,
+        statusText: "OK",
+        headers: { "content-type": "application/json" },
+        body: {
+          access_token: ACCESS_TOKEN,
+          token_type: "Bearer",
+          expires_in: 3600,
+        },
+        ok: true,
+      };
+    }
+
+    return {
+      status: 404,
+      statusText: "Not Found",
+      headers: {},
+      body: null,
+      ok: false,
+    };
+  };
+}
+
+interface RunOptions {
+  version: OAuthProtocolVersion;
+  registrationStrategy: RegistrationStrategy;
+  knobs?: RouterKnobs;
+  machineConfig?: Record<string, unknown>;
+  /** RFC 9207 `iss` delivered with the authorization code. */
+  authorizationResponseIss?: string | null;
+  /** Provide pre-registered credentials (required by the `preregistered` strategy). */
+  preregisteredClientId?: string;
+}
+
+interface RunResult {
+  requests: OAuthHttpRequest[];
+  state: OAuthFlowState;
+  /** True when the flow reached `complete` with an access token. */
+  completed: boolean;
+  error?: string;
+}
+
+/**
+ * Drive a machine to completion or to a stop, WITHOUT throwing on error — the
+ * error branches are the point of this file.
+ */
+async function run(options: RunOptions): Promise<RunResult> {
+  const {
+    version,
+    registrationStrategy,
+    knobs,
+    machineConfig,
+    preregisteredClientId,
+  } = options;
+
+  let state: OAuthFlowState = {
+    ...EMPTY_OAUTH_FLOW_STATE,
+    httpHistory: [],
+    infoLogs: [],
+  };
+  const requests: OAuthHttpRequest[] = [];
+  const route = buildRouter(version, knobs);
+
+  const machine = createOAuthStateMachine({
+    protocolVersion: version,
+    registrationStrategy: registrationStrategy as never,
+    state,
+    getState: () => state,
+    updateState: (updates) => {
+      state = { ...state, ...updates };
+    },
+    serverUrl: SERVER_URL,
+    serverName: "differential-server",
+    redirectUrl: REDIRECT_URL,
+    dynamicRegistration: { client_name: "Differential Client" },
+    clientIdMetadataUrl: CLIENT_ID_METADATA_URL,
+    ...(preregisteredClientId
+      ? {
+          loadPreregisteredCredentials: async () => ({
+            clientId: preregisteredClientId,
+          }),
+        }
+      : {}),
+    requestExecutor: async (request) => {
+      requests.push(request);
+      return route(request);
+    },
+    ...(machineConfig as never),
+  });
+
+  let deliveredCode = false;
+  for (let index = 0; index < 40; index += 1) {
+    if (state.currentStep === "complete" || state.error) break;
+
+    // Cross the human step exactly once.
+    if (state.currentStep === "authorization_request" && !deliveredCode) {
+      deliveredCode = true;
+      state = {
+        ...state,
+        currentStep: "received_authorization_code",
+        authorizationCode: "mock-auth-code",
+        authorizationResponseIss:
+          options.authorizationResponseIss === null
+            ? undefined
+            : (options.authorizationResponseIss ?? authServerBaseFor(version)),
+      };
+      continue;
+    }
+
+    try {
+      await machine.proceedToNextStep();
+    } catch (error) {
+      state = {
+        ...state,
+        error: error instanceof Error ? error.message : String(error),
+      };
+      break;
+    }
+  }
+
+  return {
+    requests,
+    state,
+    completed: state.currentStep === "complete" && Boolean(state.accessToken),
+    error: state.error,
+  };
+}
+
+function normalize(text: string, replacements: Array<[string, string]>): string {
+  let result = text;
+  for (const [value, placeholder] of replacements) {
+    if (value) result = result.split(value).join(placeholder);
+  }
+  return result;
+}
+
+/** Same normalization as the existing goldens: per-run randomness → placeholders. */
+function snapshotPayload(result: RunResult) {
+  const replacements: Array<[string, string]> = (
+    [
+      [result.state.codeVerifier, "<code-verifier>"],
+      [result.state.codeChallenge, "<code-challenge>"],
+      [result.state.state, "<state>"],
+    ] as Array<[string | undefined, string]>
+  ).flatMap(([value, placeholder]) => {
+    if (!value) return [];
+    const formEncoded = new URLSearchParams([["v", value]]).toString().slice(2);
+    return [
+      ...new Set([value, encodeURIComponent(value), formEncoded]),
+    ].map((variant) => [variant, placeholder] as [string, string]);
+  });
+
+  return {
+    wire: result.requests.map((request) => ({
+      url: normalize(request.url, replacements),
+      method: request.method,
+      headers: JSON.parse(
+        normalize(JSON.stringify(request.headers), replacements),
+      ),
+      body:
+        request.body == null
+          ? null
+          : JSON.parse(normalize(JSON.stringify(request.body), replacements)),
+      redirect: request.redirect ?? null,
+    })),
+    authorizationUrl: result.state.authorizationUrl
+      ? normalize(result.state.authorizationUrl, replacements)
+      : null,
+    completed: result.completed,
+    error: result.error
+      ? normalize(result.error, replacements)
+      : null,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Semantic assertions — the gate. A snapshot update cannot weaken these.
+// ---------------------------------------------------------------------------
+
+function tokenRequest(result: RunResult) {
+  return result.requests.filter((request) =>
+    request.url.endsWith("/token"),
+  ).at(-1);
+}
+
+/**
+ * Read a token request's parameters regardless of whether the machine handed
+ * the executor a form-encoded string or an object. Asserting against one shape
+ * only would silently pass on the eras that use the other.
+ */
+function tokenParams(request: OAuthHttpRequest | undefined): Record<string, string> {
+  const body = request?.body;
+  if (typeof body === "string") {
+    return Object.fromEntries(new URLSearchParams(body).entries());
+  }
+  if (body && typeof body === "object") {
+    return body as Record<string, string>;
+  }
+  return {};
+}
+
+function authorizationUrl(result: RunResult): URL | undefined {
+  return result.state.authorizationUrl
+    ? new URL(result.state.authorizationUrl)
+    : undefined;
+}
+
+/**
+ * The MCP OAuth MUSTs, checked against what the machine actually sent.
+ *
+ * Applied to every successful run in the matrix, so a change that satisfies one
+ * era/strategy pair and breaks another cannot pass.
+ */
+function assertWireInvariants(result: RunResult, version: OAuthProtocolVersion) {
+  const authorize = authorizationUrl(result);
+  const token = tokenRequest(result);
+  expect(authorize, "no authorization URL").toBeTruthy();
+  expect(token, "no token request").toBeTruthy();
+  const tokenBody = tokenParams(token);
+
+  // PKCE: S256 on the authorization request, verifier on the exchange.
+  expect(authorize!.searchParams.get("code_challenge_method")).toBe("S256");
+  expect(authorize!.searchParams.get("code_challenge")).toBeTruthy();
+  expect(tokenBody.code_verifier).toBeTruthy();
+  expect(tokenBody.code_verifier).toBe(result.state.codeVerifier);
+
+  // One redirect_uri, reused wherever the field applies.
+  expect(authorize!.searchParams.get("redirect_uri")).toBe(REDIRECT_URL);
+  expect(tokenBody.redirect_uri).toBe(REDIRECT_URL);
+
+  // Resource binding (RFC 8707): both requests carry it, byte-identical, and
+  // it is the validated canonical MCP resource — not some other audience the
+  // authorization server could mint a token for. Every era does this, including
+  // 2025-03-26, which has no PRM step and derives the resource from the server
+  // URL instead.
+  const authorizeResource = authorize!.searchParams.get("resource");
+  expect(authorizeResource).toBeTruthy();
+  expect(tokenBody.resource).toBe(authorizeResource);
+  expect(new URL(authorizeResource!).origin).toBe(SERVER_ORIGIN);
+
+  // A CSRF state is always issued.
+  expect(authorize!.searchParams.get("state")).toBeTruthy();
+
+  // Credentials go only to the MCP resource. A bearer token on PRM, AS
+  // metadata, registration, or the token endpoint hands the resource's
+  // credential to a different party.
+  for (const request of result.requests) {
+    if (request.url === SERVER_URL) continue;
+    expect(
+      JSON.stringify(request.headers ?? {}),
+      `${request.method} ${request.url} carried the access token`,
+    ).not.toContain(ACCESS_TOKEN);
+  }
+}
+
+// ---------------------------------------------------------------------------
+// The matrix
+// ---------------------------------------------------------------------------
+
+const ERA_STRATEGY_PAIRS = ALL_VERSIONS.flatMap((version) =>
+  supportedStrategies(version).map(
+    (strategy) => [version, strategy] as [OAuthProtocolVersion, RegistrationStrategy],
+  ),
+);
+
+describe.each(ERA_STRATEGY_PAIRS)(
+  "era %s × registration %s",
+  (version, strategy) => {
+    const preregisteredClientId =
+      strategy === "preregistered" ? "preregistered-client-id" : undefined;
+
+    it("happy ladder: full request sequence", async () => {
+      const result = await run({
+        version,
+        registrationStrategy: strategy,
+        preregisteredClientId,
+      });
+
+      expect(result.completed, result.error).toBe(true);
+      assertWireInvariants(result, version);
+      expect(snapshotPayload(result)).toMatchSnapshot();
+    });
+
+    it("registers exactly once, and only when the strategy calls for it", async () => {
+      const result = await run({
+        version,
+        registrationStrategy: strategy,
+        preregisteredClientId,
+      });
+
+      const registrations = result.requests.filter((request) =>
+        request.url.endsWith("/register"),
+      );
+      expect(registrations.length).toBe(strategy === "dcr" ? 1 : 0);
+    });
+  },
+);
+
+describe.each(ALL_VERSIONS)("branch catalog (%s)", (version) => {
+  const isCurrentEra = CURRENT_ERAS.includes(version);
+
+  it("DCR failure without a fallback stops the flow", async () => {
+    const result = await run({
+      version,
+      registrationStrategy: "dcr",
+      knobs: { registrationFails: true },
+    });
+
+    expect(result.completed).toBe(false);
+    expect(tokenRequest(result)).toBeUndefined();
+    expect(snapshotPayload(result)).toMatchSnapshot();
+  });
+
+  it("DCR failure falls back to pre-registered credentials when available", async () => {
+    const result = await run({
+      version,
+      registrationStrategy: "dcr",
+      knobs: { registrationFails: true },
+      preregisteredClientId: "fallback-client-id",
+    });
+
+    expect(result.completed, result.error).toBe(true);
+    expect(result.state.clientId).toBe("fallback-client-id");
+    assertWireInvariants(result, version);
+    expect(snapshotPayload(result)).toMatchSnapshot();
+  });
+
+  it("strictConformance refuses the DCR fallback", async () => {
+    const result = await run({
+      version,
+      registrationStrategy: "dcr",
+      knobs: { registrationFails: true },
+      preregisteredClientId: "fallback-client-id",
+      machineConfig: { strictConformance: true },
+    });
+
+    expect(result.completed).toBe(false);
+    expect(tokenRequest(result)).toBeUndefined();
+  });
+
+  it("a present-but-mismatched authorization-response iss is handled per era", async () => {
+    const result = await run({
+      version,
+      registrationStrategy: "dcr",
+      authorizationResponseIss: "https://different-issuer.example.com",
+    });
+
+    if (version === "2026-07-28") {
+      // SEP-2468 makes the present-`iss` comparison a MUST.
+      expect(result.completed).toBe(false);
+      expect(tokenRequest(result)).toBeUndefined();
+    } else {
+      // Older eras do not mandate the check; the flow proceeds, and the wire
+      // invariants still hold.
+      expect(result.completed, result.error).toBe(true);
+      assertWireInvariants(result, version);
+    }
+  });
+
+  it("an absent authorization-response iss does not block redemption", async () => {
+    const result = await run({
+      version,
+      registrationStrategy: "dcr",
+      authorizationResponseIss: null,
+    });
+
+    // A genuinely-absent `iss` is indistinguishable from an un-captured one, so
+    // no era hard-fails on it.
+    expect(result.completed, result.error).toBe(true);
+    assertWireInvariants(result, version);
+  });
+
+  it.each(["warn", "reject", "reject-rfc9728"] as const)(
+    "resourceIndicatorEnforcement=%s on a conforming resource",
+    async (enforcement) => {
+      const result = await run({
+        version,
+        registrationStrategy: "dcr",
+        machineConfig: { resourceIndicatorEnforcement: enforcement },
+      });
+
+      expect(result.completed, result.error).toBe(true);
+      assertWireInvariants(result, version);
+    },
+  );
+
+  it.each([true, false])(
+    "allowPathScopedIssuer=%s against an exact-match issuer",
+    async (allowPathScopedIssuer) => {
+      const result = await run({
+        version,
+        registrationStrategy: "dcr",
+        machineConfig: { allowPathScopedIssuer },
+      });
+
+      // The opt-in must not change behavior when the issuer already matches.
+      expect(result.completed, result.error).toBe(true);
+      assertWireInvariants(result, version);
+    },
+  );
+
+  it("an issuer that does not match the discovery origin is handled per era", async () => {
+    const result = await run({
+      version,
+      registrationStrategy: "dcr",
+      knobs: { issuerOverride: "https://elsewhere.example.com" },
+    });
+
+    // Pinned per era rather than "whatever happens": only 2026-07-28 hard-
+    // rejects the RFC 8414 §3.3 mismatch today, and `allowPathScopedIssuer`
+    // exists as the opt-in for exactly that era. Naming the difference here is
+    // what makes it a decision rather than an accident — and stops a shared-code
+    // change from quietly giving an older era the strict behavior or taking it
+    // away from the newest one.
+    if (version === "2026-07-28") {
+      expect(result.completed).toBe(false);
+      expect(result.error).toMatch(/issuer/i);
+      expect(tokenRequest(result)).toBeUndefined();
+    } else {
+      expect(result.completed, result.error).toBe(true);
+      assertWireInvariants(result, version);
+    }
+    expect(snapshotPayload(result)).toMatchSnapshot();
+  });
+
+  it("allowPathScopedIssuer opts into an origin-root issuer only where the era enforces the match", async () => {
+    const strict = await run({
+      version,
+      registrationStrategy: "dcr",
+      knobs: { issuerOverride: "https://elsewhere.example.com" },
+      machineConfig: { allowPathScopedIssuer: true },
+    });
+
+    // The opt-in is for a same-origin path-prefix ancestor, not for an
+    // arbitrary foreign issuer — turning it on must not accept this one.
+    if (version === "2026-07-28") {
+      expect(strict.completed).toBe(false);
+      expect(tokenRequest(strict)).toBeUndefined();
+    } else {
+      expect(strict.completed, strict.error).toBe(true);
+    }
+  });
+
+  // --- Current-profile branches. Older eras genuinely differ here. ---
+
+  if (isCurrentEra) {
+    it("stops before authorization when the AS advertises no S256", async () => {
+      const result = await run({
+        version,
+        registrationStrategy: "dcr",
+        knobs: {
+          authorizationServerMetadata: {
+            code_challenge_methods_supported: ["plain"],
+          },
+        },
+      });
+
+      expect(result.completed).toBe(false);
+      expect(result.error).toContain("S256");
+      expect(authorizationUrl(result)).toBeUndefined();
+      expect(tokenRequest(result)).toBeUndefined();
+    });
+
+    it("stops before authorization when the AS advertises no PKCE metadata", async () => {
+      const result = await run({
+        version,
+        registrationStrategy: "dcr",
+        knobs: {
+          authorizationServerMetadata: {
+            code_challenge_methods_supported: null,
+          },
+        },
+      });
+
+      expect(result.completed).toBe(false);
+      expect(authorizationUrl(result)).toBeUndefined();
+      expect(tokenRequest(result)).toBeUndefined();
+    });
+
+    it.each([
+      ["empty", { authorization_servers: [] }],
+      ["absent", { authorization_servers: null }],
+    ])(
+      "fails closed when PRM authorization_servers is %s",
+      async (_label, override) => {
+        const result = await run({
+          version,
+          registrationStrategy: "dcr",
+          knobs: { protectedResourceMetadata: override },
+        });
+
+        expect(result.completed).toBe(false);
+        expect(tokenRequest(result)).toBeUndefined();
+        // Specifically: it did NOT silently substitute the MCP server URL.
+        expect(result.state.authorizationServerMetadata).toBeFalsy();
+      },
+    );
+
+    it("observe mode substitutes the server URL and records the finding", async () => {
+      const result = await run({
+        version,
+        registrationStrategy: "dcr",
+        knobs: { protectedResourceMetadata: { authorization_servers: [] } },
+        machineConfig: { requiredMetadataEnforcement: "observe" },
+      });
+
+      expect(result.state.authorizationServerUrl).toBe(SERVER_URL);
+      expect(JSON.stringify(result.state.infoLogs ?? [])).toContain(
+        "authorization-server-substituted",
+      );
+    });
+
+    it("accepts plain advertised alongside S256", async () => {
+      const result = await run({
+        version,
+        registrationStrategy: "dcr",
+        knobs: {
+          authorizationServerMetadata: {
+            code_challenge_methods_supported: ["plain", "S256"],
+          },
+        },
+      });
+
+      expect(result.completed, result.error).toBe(true);
+      assertWireInvariants(result, version);
+    });
+  }
+});


### PR DESCRIPTION
Part 5 of the OAuth maintainability stack; stacked on #3885.

Test-only differential coverage across OAuth eras and enforcement branches. No production behavior is introduced here.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only addition with no production code changes; risk is limited to false confidence if assertions are incomplete.
> 
> **Overview**
> Widens OAuth coverage beyond the existing happy-path `dcr`-only goldens with a **differential harness** across all four protocol eras and every supported registration strategy (`dcr`, `preregistered`, `cimd`).
> 
> Adds a branch catalog that pins era-specific behavior for DCR failure and fallback, `strictConformance`, RFC 9207 `iss` handling, issuer mismatch / `allowPathScopedIssuer`, each `resourceIndicatorEnforcement` mode, PRM `authorization_servers` requirements, and current-era PKCE metadata checks.
> 
> Uses a two-layer gate: request-sequence snapshots for review, plus named wire invariants (S256 PKCE, redirect reuse, canonical resource binding, CSRF state, no bearer on OAuth endpoints) that a snapshot update cannot weaken.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 88b3582d94324e7e13285b3ec6d2e27ea1f1f636. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds and hardens a differential golden test harness for `@mcpjam/sdk` OAuth across protocol eras and registration strategies, pinning era-specific behavior and guarding core invariants. Test-only coverage; no runtime changes.

- **New Features**
  - Covers 4 eras × strategies (`dcr`, `preregistered`, `cimd` where supported) with request-sequence snapshots.
  - Branch catalog: DCR failure and prereg fallback, `strictConformance`, RFC 9207 `iss` present/absent/mismatched, issuer mismatch with `allowPathScopedIssuer` on/off (including path-scoped AS vs origin-root issuer), all `resourceIndicatorEnforcement` modes with separating cases (same-origin non-prefix and foreign-origin resources), and current-era PKCE metadata cases.
  - PRM enforcement pinned to spec history: `authorization_servers` fails closed from `2025-06-18` onward; `2025-03-26` substitutes the server URL (with `observe` mode recording the substitution).
  - Guards: named assertions enforce S256 PKCE, redirect reuse, identical full canonical resource on auth/token, CSRF state issuance, and no MCP bearer token on OAuth endpoints; a step-budget requires a terminal state to avoid false positives. Era differences are pinned; strict issuer match is enforced only in `2026-07-28`.

<sup>Written for commit 88b3582d94324e7e13285b3ec6d2e27ea1f1f636. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/MCPJam/inspector/pull/3886?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

