### PR TITLE
fix(toast): give error toasts a real TTL instead of staying open forever

### DIFF
--- a/mcpjam-inspector/client/src/components/__tests__/ChatTabV2.history-sync.test.tsx
+++ b/mcpjam-inspector/client/src/components/__tests__/ChatTabV2.history-sync.test.tsx
@@ -762,7 +762,7 @@ describe("ChatTabV2 history sync", () => {
       errorToastMessage(
         "This chat changed elsewhere. This reply stayed local, and your next send will continue in a new thread."
       ),
-      { duration: Infinity }
+      { duration: 8000 }
     );
   });
 

--- a/mcpjam-inspector/client/src/components/__tests__/OrganizationsTab.billing.test.tsx
+++ b/mcpjam-inspector/client/src/components/__tests__/OrganizationsTab.billing.test.tsx
@@ -906,7 +906,7 @@ describe("OrganizationsTab billing", () => {
       errorToastMessage(
         "This organization has reached its member limit (3). Ask an organization owner to upgrade.",
       ),
-      { duration: Infinity }
+      { duration: 8000 }
     );
   });
 

--- a/mcpjam-inspector/client/src/components/connection/__tests__/ServerConnectionCard.hosted.test.tsx
+++ b/mcpjam-inspector/client/src/components/connection/__tests__/ServerConnectionCard.hosted.test.tsx
@@ -107,7 +107,7 @@ describe("ServerConnectionCard hosted reconnect guard", () => {
 
     expect(toast.error).toHaveBeenCalledWith(
       errorToastMessage("HTTP servers are not supported in hosted mode"),
-      { duration: Infinity }
+      { duration: 8000 }
     );
     expect(onReconnect).not.toHaveBeenCalled();
   });

--- a/mcpjam-inspector/client/src/components/organization/__tests__/CreateOrganizationDialog.test.tsx
+++ b/mcpjam-inspector/client/src/components/organization/__tests__/CreateOrganizationDialog.test.tsx
@@ -59,7 +59,7 @@ describe("CreateOrganizationDialog", () => {
       errorToastMessage(
         "This organization has reached its project limit (1). Upgrade to create more projects.",
       ),
-      { duration: Infinity },
+      { duration: 8000 },
     );
   });
 });

--- a/mcpjam-inspector/client/src/hooks/__tests__/use-project-state.test.tsx
+++ b/mcpjam-inspector/client/src/hooks/__tests__/use-project-state.test.tsx
@@ -543,7 +543,7 @@ describe("useProjectState automatic project creation", () => {
     expect(createProjectMock).not.toHaveBeenCalled();
     expect(toast.error).toHaveBeenCalledWith(
       errorToastMessage("Create or join an organization to create projects."),
-      { duration: Infinity },
+      { duration: 8000 },
     );
   });
 
@@ -582,7 +582,7 @@ describe("useProjectState automatic project creation", () => {
     expect(createProjectMock).not.toHaveBeenCalled();
     expect(toast.error).toHaveBeenCalledWith(
       errorToastMessage("Create or join an organization to create projects."),
-      { duration: Infinity },
+      { duration: 8000 },
     );
   });
 
@@ -612,7 +612,7 @@ describe("useProjectState automatic project creation", () => {
     expect(createProjectMock).not.toHaveBeenCalled();
     expect(toast.error).toHaveBeenCalledWith(
       errorToastMessage("Create or join an organization to create projects."),
-      { duration: Infinity },
+      { duration: 8000 },
     );
   });
 
@@ -1532,7 +1532,7 @@ describe("useProjectState automatic project creation", () => {
       errorToastMessage(
         "This organization has reached its project limit (1). Upgrade to create more projects.",
       ),
-      { duration: Infinity },
+      { duration: 8000 },
     );
   });
 
@@ -1578,7 +1578,7 @@ describe("useProjectState automatic project creation", () => {
       errorToastMessage(
         "This organization has reached its project limit (1). Ask an organization owner to upgrade.",
       ),
-      { duration: Infinity },
+      { duration: 8000 },
     );
   });
 
@@ -1621,7 +1621,7 @@ describe("useProjectState automatic project creation", () => {
       errorToastMessage(
         "This organization has reached its project limit (1). Ask an organization owner to upgrade.",
       ),
-      { duration: Infinity },
+      { duration: 8000 },
     );
     expect(logger.error).toHaveBeenCalledTimes(2);
   });

--- a/mcpjam-inspector/client/src/hooks/__tests__/use-server-state.test.tsx
+++ b/mcpjam-inspector/client/src/hooks/__tests__/use-server-state.test.tsx
@@ -1221,7 +1221,7 @@ describe("useServerState OAuth callback failures", () => {
       errorToastMessage(
         "OAuth authorization failed: access_denied: User denied access",
       ),
-      { duration: Infinity }
+      { duration: 8000 }
     );
     expect(localStorage.getItem("mcp-oauth-pending")).toBeNull();
     expect(window.location.pathname).toBe("/servers");
@@ -1251,7 +1251,7 @@ describe("useServerState OAuth callback failures", () => {
 
     expect(toastError).toHaveBeenCalledWith(
       errorToastMessage("Error completing OAuth flow: Token exchange failed"),
-      { duration: Infinity }
+      { duration: 8000 }
     );
     expect(localStorage.getItem("mcp-oauth-pending")).toBeNull();
   });
@@ -1797,7 +1797,7 @@ describe("useServerState OAuth callback failures", () => {
 
     expect(toastError).toHaveBeenCalledWith(
       errorToastMessage(CLIENT_CONFIG_SYNC_PENDING_ERROR_MESSAGE),
-      { duration: Infinity }
+      { duration: 8000 }
     );
     expect(
       dispatch.mock.calls.some(([action]) => action.type === "CONNECT_REQUEST")
@@ -1821,7 +1821,7 @@ describe("useServerState OAuth callback failures", () => {
 
     expect(toastError).toHaveBeenCalledWith(
       errorToastMessage(PROJECT_NOT_PROVISIONED_ERROR_MESSAGE),
-      { duration: Infinity }
+      { duration: 8000 }
     );
     expect(testConnectionMock).not.toHaveBeenCalled();
     expect(mockCreateServer).not.toHaveBeenCalled();
@@ -1858,7 +1858,7 @@ describe("useServerState OAuth callback failures", () => {
     });
     expect(toastError).toHaveBeenCalledWith(
       errorToastMessage(PROJECT_NOT_PROVISIONED_ERROR_MESSAGE),
-      { duration: Infinity }
+      { duration: 8000 }
     );
   });
 
@@ -2443,7 +2443,7 @@ describe("useServerState OAuth callback failures", () => {
       errorToastMessage(
         "Network error: Failed to resolve registry OAuth config: registry lookup failed",
       ),
-      { duration: Infinity }
+      { duration: 8000 }
     );
   });
 
@@ -3211,7 +3211,7 @@ describe("syncServerToConvex name-collision recovery", () => {
       errorToastMessage(
         'A server named "taken-name" already exists. Choose a different name.'
       ),
-      { duration: Infinity }
+      { duration: 8000 }
     );
     expect(dispatch).not.toHaveBeenCalledWith(
       expect.objectContaining({ type: "REMOVE_SERVER" })

--- a/mcpjam-inspector/client/src/hooks/__tests__/useAutoConnectProjectServers.test.tsx
+++ b/mcpjam-inspector/client/src/hooks/__tests__/useAutoConnectProjectServers.test.tsx
@@ -360,7 +360,7 @@ describe("useAutoConnectProjectServers", () => {
     );
     expect(mocks.toastError).toHaveBeenCalledWith(
       errorToastMessage("Failed to reconnect 1 server."),
-      { duration: Infinity, id: "reconnect-toast" }
+      { duration: 8000, id: "reconnect-toast" }
     );
     expect(mocks.toastSuccess).not.toHaveBeenCalled();
   });

--- a/mcpjam-inspector/client/src/lib/toast.tsx
+++ b/mcpjam-inspector/client/src/lib/toast.tsx
@@ -6,11 +6,12 @@ import { copyToClipboard } from "@/lib/clipboard";
 /**
  * App-wide toast.
  *
- * Identical to Sonner's `toast`, except error toasts persist until the user
- * dismisses them (the global `<Toaster>` enables a close button) instead of
- * auto-dismissing on Sonner's ~4s default. Errors are the one toast type users
- * must read and usually act on, so they shouldn't vanish on a timer the way
- * success/info toasts do.
+ * Identical to Sonner's `toast`, except error toasts stay up longer than
+ * Sonner's ~4s default (the global `<Toaster>` also enables a close button
+ * for anyone who wants to dismiss sooner). Errors are the one toast type
+ * users must read and usually act on, so they get more time than
+ * success/info toasts — but they still time out on their own; nothing should
+ * require a manual close to go away.
  *
  * Error toasts also get a copy button (visible on hover, via the `<Toaster>`'s
  * `group/toast` class) so long/unreadable error text can be grabbed and
@@ -56,10 +57,12 @@ function CopyableErrorMessage({ text }: { text: string }) {
   );
 }
 
+const ERROR_TOAST_DURATION_MS = 8000;
+
 const error: typeof sonnerToast.error = (message, data) =>
   sonnerToast.error(
     typeof message === "string" ? <CopyableErrorMessage text={message} /> : message,
-    { duration: Infinity, ...data },
+    { duration: ERROR_TOAST_DURATION_MS, ...data },
   );
 
 export const toast: typeof sonnerToast = Object.assign(

--- a/mcpjam-inspector/client/src/test/utils.tsx
+++ b/mcpjam-inspector/client/src/test/utils.tsx
@@ -168,7 +168,7 @@ export function generateTestId(prefix: string): string {
  * @example
  * expect(toastError).toHaveBeenCalledWith(
  *   errorToastMessage("Something went wrong."),
- *   { duration: Infinity },
+ *   { duration: 8000 },
  * );
  */
 export function errorToastMessage(text: string) {


### PR DESCRIPTION
Error toasts were pinned to duration: Infinity, so they never
auto-dismissed and always needed a manual close (PUR-34). Give them an
8s TTL — long enough to read, short enough to not require clicking the
close button — while keeping the close button for anyone who wants to
dismiss sooner.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Error toasts now auto-dismiss after 8 seconds instead of staying open indefinitely. Addresses PUR-34 by preventing stuck toasts while keeping the close button for early dismissal.

- **Bug Fixes**
  - Set error toast duration to 8000 ms via `ERROR_TOAST_DURATION_MS` in the `toast` wrapper.
  - Updated tests to expect the new TTL; success/info toasts are unchanged.

<sup>Written for commit 0a170207487cb92369a55768b0940807adb2bc70. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/MCPJam/inspector/pull/3888?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

