### PR TITLE
fix(hosts): stop a deleted client's permalink from hanging the app

### DIFF
--- a/.changeset/hosts-deleted-permalink-loop.md
+++ b/.changeset/hosts-deleted-permalink-loop.md
@@ -10,4 +10,6 @@ The corrective `navigate('/hosts')` never landed. It is a React Router transitio
 
 `HostsRoute` now resolves the URL id against the client list before it syncs or persists anything, and treats an id the list doesn't contain as unopenable. Nothing writes the dead id back, so there is nothing for `HostsTab` to fight, and the route bounces once to the client list at `/hosts` with a toast explaining the client no longer exists. The bounce uses `replace`, so the dead URL leaves the history stack instead of sitting one Back press away.
 
-The check waits for the client list to finish loading before calling any id dead — the list is empty for a beat on every cold start, and bouncing during that window would break working deep links.
+The check waits for the client list to finish loading before calling any id dead — the list is empty for a beat on every cold start, and bouncing during that window would break working deep links. During that same window the id is merely unverified, so it opens the canvas immediately (no flash of the client list on a normal permalink) but is not yet written to the project's saved "previewed client" — that store is on disk, so closing the tab mid-load would otherwise leave a possibly-deleted client filed as the project's preview and reopen it on the next visit.
+
+Returning to the same dead link later in the session bounces again rather than going quiet, so the explanation isn't shown only to whoever hits it first.

--- a/.changeset/hosts-deleted-permalink-loop.md
+++ b/.changeset/hosts-deleted-permalink-loop.md
@@ -1,0 +1,13 @@
+---
+"@mcpjam/inspector": patch
+---
+
+Fix a client permalink for a deleted client hanging the app.
+
+Client URLs are permalinks, so a bookmark or history entry for `/hosts/:hostId` outlives the client itself. Opening one after the client was deleted — or opening a teammate's link while signed into a different project — put `HostsRoute` and `HostsTab` in a fight over the same id. The route synced the id out of the URL into shared state and into the project's persisted "previewed client"; `HostsTab` reconciled both against the loaded client list, found the id missing, and cleared them; the route then synced the id straight back from the URL, and around again.
+
+The corrective `navigate('/hosts')` never landed. It is a React Router transition, so the stream of higher-priority state updates from that ping-pong starved it indefinitely. The usual symptom was silent: the page looked normal while the tab pegged a CPU core (a harness reproduction rendered over 17,000 times in two seconds). When the updates happened to chain synchronously it instead tripped React's nested-update limit and the app fell through to the route error screen with "Maximum update depth exceeded" — the shape reported by a self-hosted user in Sentry.
+
+`HostsRoute` now resolves the URL id against the client list before it syncs or persists anything, and treats an id the list doesn't contain as unopenable. Nothing writes the dead id back, so there is nothing for `HostsTab` to fight, and the route bounces once to the client list at `/hosts` with a toast explaining the client no longer exists. The bounce uses `replace`, so the dead URL leaves the history stack instead of sitting one Back press away.
+
+The check waits for the client list to finish loading before calling any id dead — the list is empty for a beat on every cold start, and bouncing during that window would break working deep links.

--- a/mcpjam-inspector/client/src/App.tsx
+++ b/mcpjam-inspector/client/src/App.tsx
@@ -765,49 +765,72 @@ export function HostsRoute() {
     projectId: convexProjectId,
   });
 
-  // A `/hosts/:hostId` permalink whose id the project's list doesn't contain:
-  // the client was deleted, or the link came from a project this session isn't
-  // in. Client URLs are permalinks, so bookmarks and history outlive the client
-  // itself and this is reachable from ordinary navigation.
+  // Where the URL's id stands against the project's client list. Client URLs
+  // are permalinks, so bookmarks and history outlive the client itself, and
+  // `dead` — deleted, or a link from a project this session isn't in — is
+  // reachable from ordinary navigation.
   //
-  // Only decidable once the list has actually LOADED. `useHostList` reports
-  // loading until its query resolves — and stays loading while signed out or
-  // while `convexProjectId` is still a placeholder, because it skips the query
-  // in both cases — so this is never true on a cold render, and a real host
-  // never reads as dead while its list is still in flight.
-  const isDeadUrlHost =
-    urlHostId !== null &&
-    !isRouteHostListLoading &&
-    !routeHosts.some((h) => h.hostId === urlHostId);
+  // `pending` is a real state, not a rounding of `dead`: the list is empty for
+  // a beat on every cold start (and `useHostList` also reports loading while
+  // signed out, or while `convexProjectId` is still a placeholder, because it
+  // skips the query in both cases). Calling an id dead in that window would
+  // break every working deep link.
+  const urlHostState: "none" | "pending" | "live" | "dead" =
+    urlHostId === null
+      ? "none"
+      : isRouteHostListLoading
+        ? "pending"
+        : routeHosts.some((h) => h.hostId === urlHostId)
+          ? "live"
+          : "dead";
 
-  // The id this route may open, sync into shared state, and persist. A dead id
-  // resolves to null HERE, before any of those, which is what keeps the route
-  // out of a fight with `HostsTab`: that component reconciles selection and the
-  // previewed host against the same list and clears anything missing, so a
-  // route that kept re-syncing the dead id from the URL would have it cleared
-  // and re-set on every pass. The corrective navigation below is a React Router
-  // transition, and the resulting stream of higher-priority state updates
-  // starves it — the canvas never lands on `/hosts`, the loop never ends, and
-  // it surfaces either as a pegged CPU core or, when the updates chain
-  // synchronously, as "Maximum update depth exceeded" (INSPECTOR-CLIENT-224).
-  const openableHostId = isDeadUrlHost ? null : urlHostId;
+  // The id the canvas may open. A dead id resolves to null HERE, before it
+  // reaches shared state, which is what keeps this route out of a fight with
+  // `HostsTab`: that component reconciles selection and the previewed host
+  // against the same list and clears anything missing, so a route that kept
+  // re-syncing the dead id from the URL would have it cleared and re-set on
+  // every pass. The corrective navigation below is a React Router transition,
+  // and the resulting stream of higher-priority state updates starves it — the
+  // canvas never lands on `/hosts`, the loop never ends, and it surfaces either
+  // as a pegged CPU core or, when the updates chain synchronously, as "Maximum
+  // update depth exceeded" (INSPECTOR-CLIENT-224).
+  //
+  // A `pending` id stays openable so a legitimate permalink opens its canvas
+  // immediately rather than flashing the client list for the length of the
+  // query. That optimism is safe because it never leaves memory — see the
+  // persistence rule below.
+  const openableHostId = urlHostState === "dead" ? null : urlHostId;
 
-  // Bounce a dead permalink to the client list — `/hosts` with no id is the
-  // Connect hub, so the user lands somewhere they can act instead of on a
-  // canvas stuck rendering skeletons for a client that isn't there.
+  // Only a CONFIRMED id is written to the project's previewed client, because
+  // that store is on disk and outlives the URL that seeded it. Persisting a
+  // `pending` id would file an unverified — possibly deleted — client as the
+  // project's preview, and closing the tab mid-load would leave it there to be
+  // reopened on the next visit.
+  const persistableHostId = urlHostState === "live" ? urlHostId : null;
+
+  // Bounce a dead permalink to bare `/hosts`, so the user lands on the client
+  // list (or their previously previewed client) instead of on a canvas stuck
+  // rendering skeletons for a client that isn't there.
   //
   // `replace`, so the dead URL leaves the history stack: a plain push would
   // leave Back pointing at it, and the bounce would repeat on every Back.
-  // Keyed by id so it fires once per dead permalink rather than once per
-  // render, and so a later visit to a DIFFERENT dead id still reports itself.
+  // Keyed by id so it fires once per arrival rather than once per render —
+  // and CLEARED whenever the route isn't sitting on a dead id, because this
+  // component stays mounted across `/hosts` ↔ `/hosts/:hostId` (both paths
+  // render it, so React reuses the instance and the ref survives). Without the
+  // reset, returning to a dead id already bounced once this session would skip
+  // both the redirect and the toast, stranding the user on the dead URL.
   const bouncedDeadHostIdRef = useRef<string | null>(null);
   useEffect(() => {
-    if (!isDeadUrlHost || !urlHostId) return;
+    if (urlHostState !== "dead" || !urlHostId) {
+      bouncedDeadHostIdRef.current = null;
+      return;
+    }
     if (bouncedDeadHostIdRef.current === urlHostId) return;
     bouncedDeadHostIdRef.current = urlHostId;
     navigate(routePaths.hosts, { replace: true });
     toast.error("That client no longer exists. It may have been deleted.");
-  }, [isDeadUrlHost, urlHostId, navigate]);
+  }, [urlHostState, urlHostId, navigate]);
 
   // URL is the source of truth for the open host canvas. Sync into shared
   // state so `GlobalHostBar`, `onCanvasReplaceHost`, and other surfaces that
@@ -816,11 +839,12 @@ export function HostsRoute() {
     if (hostsTabSelectedHostId !== openableHostId) {
       setHostsTabSelectedHostId(openableHostId);
     }
-    if (openableHostId && previewedHostId !== openableHostId) {
-      setPreviewedHostId(openableHostId);
+    if (persistableHostId && previewedHostId !== persistableHostId) {
+      setPreviewedHostId(persistableHostId);
     }
   }, [
     openableHostId,
+    persistableHostId,
     hostsTabSelectedHostId,
     previewedHostId,
     setHostsTabSelectedHostId,

--- a/mcpjam-inspector/client/src/App.tsx
+++ b/mcpjam-inspector/client/src/App.tsx
@@ -760,18 +760,67 @@ export function HostsRoute() {
     }
   }, [routeHostId]);
 
+  const { hosts: routeHosts, isLoading: isRouteHostListLoading } = useHostList({
+    isAuthenticated,
+    projectId: convexProjectId,
+  });
+
+  // A `/hosts/:hostId` permalink whose id the project's list doesn't contain:
+  // the client was deleted, or the link came from a project this session isn't
+  // in. Client URLs are permalinks, so bookmarks and history outlive the client
+  // itself and this is reachable from ordinary navigation.
+  //
+  // Only decidable once the list has actually LOADED. `useHostList` reports
+  // loading until its query resolves — and stays loading while signed out or
+  // while `convexProjectId` is still a placeholder, because it skips the query
+  // in both cases — so this is never true on a cold render, and a real host
+  // never reads as dead while its list is still in flight.
+  const isDeadUrlHost =
+    urlHostId !== null &&
+    !isRouteHostListLoading &&
+    !routeHosts.some((h) => h.hostId === urlHostId);
+
+  // The id this route may open, sync into shared state, and persist. A dead id
+  // resolves to null HERE, before any of those, which is what keeps the route
+  // out of a fight with `HostsTab`: that component reconciles selection and the
+  // previewed host against the same list and clears anything missing, so a
+  // route that kept re-syncing the dead id from the URL would have it cleared
+  // and re-set on every pass. The corrective navigation below is a React Router
+  // transition, and the resulting stream of higher-priority state updates
+  // starves it — the canvas never lands on `/hosts`, the loop never ends, and
+  // it surfaces either as a pegged CPU core or, when the updates chain
+  // synchronously, as "Maximum update depth exceeded" (INSPECTOR-CLIENT-224).
+  const openableHostId = isDeadUrlHost ? null : urlHostId;
+
+  // Bounce a dead permalink to the client list — `/hosts` with no id is the
+  // Connect hub, so the user lands somewhere they can act instead of on a
+  // canvas stuck rendering skeletons for a client that isn't there.
+  //
+  // `replace`, so the dead URL leaves the history stack: a plain push would
+  // leave Back pointing at it, and the bounce would repeat on every Back.
+  // Keyed by id so it fires once per dead permalink rather than once per
+  // render, and so a later visit to a DIFFERENT dead id still reports itself.
+  const bouncedDeadHostIdRef = useRef<string | null>(null);
+  useEffect(() => {
+    if (!isDeadUrlHost || !urlHostId) return;
+    if (bouncedDeadHostIdRef.current === urlHostId) return;
+    bouncedDeadHostIdRef.current = urlHostId;
+    navigate(routePaths.hosts, { replace: true });
+    toast.error("That client no longer exists. It may have been deleted.");
+  }, [isDeadUrlHost, urlHostId, navigate]);
+
   // URL is the source of truth for the open host canvas. Sync into shared
   // state so `GlobalHostBar`, `onCanvasReplaceHost`, and other surfaces that
   // still read `hostsTabSelectedHostId` stay aligned.
   useEffect(() => {
-    if (hostsTabSelectedHostId !== urlHostId) {
-      setHostsTabSelectedHostId(urlHostId);
+    if (hostsTabSelectedHostId !== openableHostId) {
+      setHostsTabSelectedHostId(openableHostId);
     }
-    if (urlHostId && previewedHostId !== urlHostId) {
-      setPreviewedHostId(urlHostId);
+    if (openableHostId && previewedHostId !== openableHostId) {
+      setPreviewedHostId(openableHostId);
     }
   }, [
-    urlHostId,
+    openableHostId,
     hostsTabSelectedHostId,
     previewedHostId,
     setHostsTabSelectedHostId,
@@ -799,7 +848,7 @@ export function HostsRoute() {
     <HostsTab
       projectId={convexProjectId}
       isAuthenticated={isAuthenticated}
-      selectedHostId={urlHostId ?? previewedHostId}
+      selectedHostId={openableHostId ?? previewedHostId}
       onSelectHost={handleSelectHost}
       serversTabElement={<ServersTabBody />}
     />

--- a/mcpjam-inspector/client/src/__tests__/App.hosted-oauth.test.tsx
+++ b/mcpjam-inspector/client/src/__tests__/App.hosted-oauth.test.tsx
@@ -2762,6 +2762,27 @@ describe("App hosted OAuth callback handling", () => {
         },
       },
     }));
+    // The route only PERSISTS a host id the project's list confirms, so the
+    // list has to actually contain it — the suite default leaves every query
+    // but `getCurrentUser` unresolved, which reads as "still loading" and is
+    // not the state a real direct-URL visit lands in.
+    mockUseQuery.mockImplementation((ref: string) =>
+      ref === "users:getCurrentUser"
+        ? existingConvexUser
+        : ref === "hosts:listHosts"
+          ? [
+              {
+                hostId: "host-slack",
+                name: "Slack",
+                hostConfigId: "host-config-slack",
+                modelId: "claude-sonnet-4",
+                serverCount: 0,
+                createdAt: 0,
+                updatedAt: 0,
+              },
+            ]
+          : undefined
+    );
     localStorage.setItem(
       "mcp-previewed-host-id",
       JSON.stringify({ project_shared: "host-claude" })

--- a/mcpjam-inspector/client/src/__tests__/HostsRoute.deleted-host-permalink.test.tsx
+++ b/mcpjam-inspector/client/src/__tests__/HostsRoute.deleted-host-permalink.test.tsx
@@ -1,0 +1,221 @@
+import { render, screen, waitFor } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { routePaths } from "../lib/app-navigation";
+
+/**
+ * Client URLs are permalinks, so a bookmark or history entry for
+ * `/hosts/:hostId` outlives the client itself. Opening one after the client is
+ * deleted (or from a project this session isn't in) used to put the route and
+ * `HostsTab` in a fight over the same id: the route synced it out of the URL
+ * into the previewed-host store, `HostsTab` reconciled it against the loaded
+ * host list and cleared it, and the route synced it straight back. The
+ * corrective `navigate('/hosts')` is a React Router transition, so the stream
+ * of higher-priority state updates starved it — a pegged CPU core, or
+ * "Maximum update depth exceeded" when the updates chained synchronously
+ * (Sentry INSPECTOR-CLIENT-224).
+ *
+ * The route now resolves a dead id to null BEFORE syncing or persisting it,
+ * and bounces once to the client list.
+ */
+const LIVE_HOST_ID = "kd7n2m5xq9b3tv6yz1r4s0hc";
+const DEAD_HOST_ID = "w972jy2ak59yymb7s8f12kmgvs8c6xnr";
+
+const {
+  mockRouteContext,
+  mockNavigate,
+  mockParams,
+  mockHostList,
+  mockPreviewed,
+  mockSetPreviewedHostId,
+  mockToastError,
+} = vi.hoisted(() => ({
+  mockRouteContext: {
+    convexProjectId: "project-1" as string | null,
+    hostsTabSelectedHostId: null as string | null,
+    isAuthenticated: true,
+    setHostsTabSelectedHostId: vi.fn(),
+  },
+  mockNavigate: vi.fn(),
+  mockParams: { hostId: undefined as string | undefined },
+  mockHostList: {
+    hosts: [] as Array<{ hostId: string }>,
+    isLoading: false,
+  },
+  mockPreviewed: { value: null as string | null },
+  mockSetPreviewedHostId: vi.fn(),
+  mockToastError: vi.fn(),
+}));
+
+vi.mock("react-router", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("react-router")>();
+  return {
+    ...actual,
+    useOutletContext: () => mockRouteContext,
+    useParams: () => mockParams,
+  };
+});
+
+// Renders what the canvas is actually handed, so a dead id can't reach it
+// unnoticed.
+vi.mock("../components/HostsTab", () => ({
+  HostsTab: ({ selectedHostId }: { selectedHostId: string | null }) => (
+    <div data-testid="hosts-tab" data-selected-host-id={selectedHostId ?? ""} />
+  ),
+}));
+
+vi.mock("../hooks/useClients", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../hooks/useClients")>();
+  return {
+    ...actual,
+    useHostList: () => mockHostList,
+    useHostMutations: () => ({
+      createHost: vi.fn(),
+      updateHostServers: vi.fn(),
+      deleteHost: vi.fn(),
+      duplicateHost: vi.fn(),
+    }),
+  };
+});
+
+vi.mock("../hooks/use-previewed-client-id", () => ({
+  usePreviewedHostId: () => [mockPreviewed.value, mockSetPreviewedHostId],
+}));
+
+vi.mock("../lib/app-navigation", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../lib/app-navigation")>();
+  return { ...actual, useAppNavigate: () => mockNavigate };
+});
+
+vi.mock("../lib/toast", () => ({
+  toast: { error: mockToastError, success: vi.fn(), message: vi.fn() },
+}));
+
+// The template deep-link hook inside the route reads the theme.
+vi.mock("../stores/preferences/preferences-provider", async (importOriginal) => {
+  const actual = await importOriginal<
+    typeof import("../stores/preferences/preferences-provider")
+  >();
+  return { ...actual, usePreferencesStore: () => "dark" };
+});
+
+// App.tsx's import graph pulls in the CodeMirror JSON editor; stub it (and the
+// CodeMirror packages it imports) so the route module loads under jsdom. Mirror
+// of SkillsRoute.flag-hydration.test.tsx.
+vi.mock("../components/ui/json-editor/codemirror-json-editor", () => ({
+  CodemirrorJsonEditor: () => null,
+}));
+vi.mock("@codemirror/lang-json", () => ({ json: () => ({}) }));
+vi.mock("@codemirror/view", () => ({
+  EditorView: class {},
+  lineNumbers: () => ({}),
+  highlightActiveLine: () => ({}),
+  highlightSpecialChars: () => ({}),
+  keymap: () => ({}),
+}));
+vi.mock("@codemirror/state", () => ({ EditorState: { create: vi.fn() } }));
+vi.mock("@codemirror/commands", () => ({
+  defaultKeymap: [],
+  history: () => ({}),
+  historyKeymap: [],
+}));
+vi.mock("@codemirror/language", () => ({
+  bracketMatching: () => ({}),
+  foldGutter: () => ({}),
+  indentOnInput: () => ({}),
+  syntaxHighlighting: () => ({}),
+  defaultHighlightStyle: {},
+}));
+vi.mock("@codemirror/lint", () => ({
+  linter: () => ({}),
+  lintGutter: () => ({}),
+}));
+
+import { HostsRoute } from "../App";
+
+beforeEach(() => {
+  mockRouteContext.convexProjectId = "project-1";
+  mockRouteContext.hostsTabSelectedHostId = null;
+  mockRouteContext.isAuthenticated = true;
+  mockParams.hostId = undefined;
+  mockHostList.hosts = [{ hostId: LIVE_HOST_ID }];
+  mockHostList.isLoading = false;
+  mockPreviewed.value = null;
+  window.history.replaceState({}, "", routePaths.hosts);
+});
+
+afterEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("HostsRoute — deleted-client permalink", () => {
+  it("bounces a deleted client's permalink to the client list, once", async () => {
+    mockParams.hostId = DEAD_HOST_ID;
+    window.history.replaceState({}, "", `${routePaths.hosts}/${DEAD_HOST_ID}`);
+
+    const { rerender } = render(<HostsRoute />);
+
+    await waitFor(() => {
+      expect(mockNavigate).toHaveBeenCalledWith(routePaths.hosts, {
+        replace: true,
+      });
+    });
+    // `replace`, so Back doesn't point at the dead URL and re-trigger this.
+    expect(mockToastError).toHaveBeenCalledTimes(1);
+
+    // Re-renders while the URL still carries the dead id must not re-fire it.
+    rerender(<HostsRoute />);
+    rerender(<HostsRoute />);
+    expect(mockNavigate).toHaveBeenCalledTimes(1);
+    expect(mockToastError).toHaveBeenCalledTimes(1);
+  });
+
+  it("never syncs or persists a deleted client's id", () => {
+    mockParams.hostId = DEAD_HOST_ID;
+    window.history.replaceState({}, "", `${routePaths.hosts}/${DEAD_HOST_ID}`);
+
+    // Effects flush inside render's `act`, so the sync effect has already had
+    // its chance by the time these assert — no waiting, and a failure lands on
+    // the write itself rather than on a timed-out precondition.
+    render(<HostsRoute />);
+
+    // The loop's fuel: writing the dead id back into the previewed-host store
+    // (which outlives the URL) after HostsTab has cleared it.
+    expect(mockSetPreviewedHostId).not.toHaveBeenCalledWith(DEAD_HOST_ID);
+    expect(mockRouteContext.setHostsTabSelectedHostId).not.toHaveBeenCalledWith(
+      DEAD_HOST_ID
+    );
+    expect(
+      screen.getByTestId("hosts-tab").getAttribute("data-selected-host-id")
+    ).toBe("");
+  });
+
+  it("waits for the host list before calling an id dead", () => {
+    // The regression this guards: bouncing during the load window would break
+    // every deep link, since the list is always empty for a beat.
+    mockParams.hostId = LIVE_HOST_ID;
+    mockHostList.hosts = [];
+    mockHostList.isLoading = true;
+    window.history.replaceState({}, "", `${routePaths.hosts}/${LIVE_HOST_ID}`);
+
+    render(<HostsRoute />);
+
+    expect(mockNavigate).not.toHaveBeenCalled();
+    expect(mockToastError).not.toHaveBeenCalled();
+  });
+
+  it("opens a live client's permalink normally", async () => {
+    mockParams.hostId = LIVE_HOST_ID;
+    window.history.replaceState({}, "", `${routePaths.hosts}/${LIVE_HOST_ID}`);
+
+    render(<HostsRoute />);
+
+    await waitFor(() => {
+      expect(mockSetPreviewedHostId).toHaveBeenCalledWith(LIVE_HOST_ID);
+    });
+    expect(mockNavigate).not.toHaveBeenCalled();
+    expect(mockToastError).not.toHaveBeenCalled();
+    expect(
+      screen.getByTestId("hosts-tab").getAttribute("data-selected-host-id")
+    ).toBe(LIVE_HOST_ID);
+  });
+});

--- a/mcpjam-inspector/client/src/__tests__/HostsRoute.deleted-host-permalink.test.tsx
+++ b/mcpjam-inspector/client/src/__tests__/HostsRoute.deleted-host-permalink.test.tsx
@@ -189,6 +189,50 @@ describe("HostsRoute — deleted-client permalink", () => {
     ).toBe("");
   });
 
+  it("bounces again when the same dead id is re-entered later", async () => {
+    // Both `/hosts` and `/hosts/:hostId` render this component, so React reuses
+    // the instance across the bounce — the once-per-id ref survives, and
+    // without a reset a second arrival at the same dead id would silently do
+    // nothing.
+    mockParams.hostId = DEAD_HOST_ID;
+    const { rerender } = render(<HostsRoute />);
+    await waitFor(() => expect(mockNavigate).toHaveBeenCalledTimes(1));
+
+    // Landed on the client list.
+    mockParams.hostId = undefined;
+    rerender(<HostsRoute />);
+
+    // Back to the same dead client (a second stale link, or an in-app link
+    // pointing at it).
+    mockParams.hostId = DEAD_HOST_ID;
+    rerender(<HostsRoute />);
+
+    await waitFor(() => expect(mockNavigate).toHaveBeenCalledTimes(2));
+    expect(mockToastError).toHaveBeenCalledTimes(2);
+  });
+
+  it("does not persist an unconfirmed id while the list is still loading", async () => {
+    // The load window is the gap the guard could be walked around: until the
+    // list resolves the id is merely unverified, and the previewed-client store
+    // is on disk, so a dead id written here would outlive the URL that seeded
+    // it and be reopened on the next visit.
+    mockParams.hostId = DEAD_HOST_ID;
+    mockHostList.hosts = [];
+    mockHostList.isLoading = true;
+
+    const { rerender } = render(<HostsRoute />);
+
+    expect(mockSetPreviewedHostId).not.toHaveBeenCalled();
+
+    // List resolves without the id: now it is confirmed dead.
+    mockHostList.hosts = [{ hostId: LIVE_HOST_ID }];
+    mockHostList.isLoading = false;
+    rerender(<HostsRoute />);
+
+    await waitFor(() => expect(mockNavigate).toHaveBeenCalled());
+    expect(mockSetPreviewedHostId).not.toHaveBeenCalledWith(DEAD_HOST_ID);
+  });
+
   it("waits for the host list before calling an id dead", () => {
     // The regression this guards: bouncing during the load window would break
     // every deep link, since the list is always empty for a beat.

--- a/mcpjam-inspector/client/src/__tests__/HostsRoute.deleted-host-permalink.test.tsx
+++ b/mcpjam-inspector/client/src/__tests__/HostsRoute.deleted-host-permalink.test.tsx
@@ -223,13 +223,18 @@ describe("HostsRoute — deleted-client permalink", () => {
     const { rerender } = render(<HostsRoute />);
 
     expect(mockSetPreviewedHostId).not.toHaveBeenCalled();
+    // Unverified is not the same as dead: nothing may act on it yet.
+    expect(mockNavigate).not.toHaveBeenCalled();
+    expect(mockToastError).not.toHaveBeenCalled();
 
     // List resolves without the id: now it is confirmed dead.
     mockHostList.hosts = [{ hostId: LIVE_HOST_ID }];
     mockHostList.isLoading = false;
     rerender(<HostsRoute />);
 
-    await waitFor(() => expect(mockNavigate).toHaveBeenCalled());
+    await waitFor(() => expect(mockNavigate).toHaveBeenCalledTimes(1));
+    // Exactly once: crossing pending → dead is one arrival, not one per render.
+    expect(mockToastError).toHaveBeenCalledTimes(1);
     expect(mockSetPreviewedHostId).not.toHaveBeenCalledWith(DEAD_HOST_ID);
   });
 


### PR DESCRIPTION
Client URLs are permalinks, so a bookmark or history entry for `/hosts/:hostId` outlives the client itself. Opening one after the client was deleted (or from another project) put `HostsRoute` and `HostsTab` in a fight over the same id: the route synced it from the URL into shared state and the persisted previewed-client store, `HostsTab` reconciled both against the loaded client list and cleared the missing id, and the route synced it straight back.

The corrective `navigate('/hosts')` never landed — it is a React Router transition, and the stream of higher-priority state updates starved it. Usually that was silent (a pegged CPU core; 17k+ renders in 2s in a harness repro); when the updates chained synchronously it tripped React's nested-update limit and hit the route error screen with "Maximum update depth exceeded", the shape a self-hosted user reported in Sentry.

`HostsRoute` now resolves the URL id against the client list first and treats an absent id as unopenable, so nothing writes it back and there is nothing to fight. A dead permalink bounces once to the client list with a toast, via `replace` so the dead URL leaves the history stack. The check waits for the list to load, since it is empty for a beat on every cold start and bouncing then would break working deep links.

Fixes INSPECTOR-CLIENT-224

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stops a deleted client's permalink from hanging the app. `HostsRoute` now validates `/hosts/:hostId` against the loaded client list and safely redirects dead links to `/hosts`.

- **Bug Fixes**
  - Treat missing ids as unopenable: resolve the URL id against the loaded list before syncing or persisting, so no ping‑pong with `HostsTab`.
  - For dead permalinks, `replace`-navigate to `/hosts` once and show a toast; removes the bad URL from history.
  - Wait for the host list to load before calling an id dead, so valid deep links keep working; no redirect while pending.
  - Persist only confirmed ids; open optimistically during load but do not write unverified ids to the previewed-client store.
  - Reset the once-per-id bounce when not on a dead id; returning to the same dead link later still redirects and explains, and the bounce fires exactly once per arrival.
  - Prevents the render loop, pegged CPU, and "Maximum update depth exceeded". Fixes INSPECTOR-CLIENT-224.

<sup>Written for commit 074a5ead6a721d6a294c7f6f4fc09b66543a9311. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/MCPJam/inspector/pull/3891?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

