### PR TITLE
feat(billing): convert at the free-plan limit walls instead of dead-ending

### DIFF
--- a/mcpjam-inspector/client/src/App.tsx
+++ b/mcpjam-inspector/client/src/App.tsx
@@ -14,6 +14,7 @@ import { useAuth } from "@workos-inc/authkit-react";
 import { AlertTriangle, Loader2, Users } from "lucide-react";
 import { toast } from "@/lib/toast";
 import { MCPJamLimitDialog } from "./components/mcpjam-limit-dialog";
+import { PlanLimitDialog } from "./components/billing/PlanLimitDialog";
 import { HomeTab } from "./components/HomeTab";
 import { ServersTab } from "./components/ServersTab";
 import { ToolsTab } from "./components/ToolsTab";
@@ -4594,6 +4595,7 @@ export default function App() {
           >
             <Toaster />
             <MCPJamLimitDialog />
+            <PlanLimitDialog />
             <div
               data-testid="app-shell"
               aria-hidden={shouldShowBillingHandoffOverlay || undefined}

--- a/mcpjam-inspector/client/src/components/EvalsTab.tsx
+++ b/mcpjam-inspector/client/src/components/EvalsTab.tsx
@@ -62,6 +62,7 @@ import {
   type CreateSuitePayload,
 } from "./evals/create-suite-dialog";
 import { getEvalIterationQuotaDisabledReason } from "@/lib/eval-iteration-quota";
+import { usePlanLimitDialogStore } from "@/stores/plan-limit-dialog-store";
 import { track } from "@/lib/analytics";
 import type { EvalChatHandoff } from "@/lib/eval-chat-handoff";
 import type { EnsureServersReadyResult } from "@/hooks/use-app-state";
@@ -263,9 +264,24 @@ function EvalsTabContent({
     if (!evalRunsDisabledReason) {
       return true;
     }
+    // The user just clicked Run — highest-intent moment there is. Give them a
+    // decision surface instead of a dismissible error. Falls back to the
+    // toast when we can't resolve the org (nothing to upgrade).
+    if (organizationId && evalIterationQuota) {
+      usePlanLimitDialogStore.getState().open({
+        kind: "evalIterations",
+        organizationId,
+        used: evalIterationQuota.used,
+        allowed: evalIterationQuota.allowed,
+        resetsAt: evalIterationQuota.resetsAt,
+        windowKind: evalIterationQuota.windowKind,
+        origin: "evals",
+      });
+      return false;
+    }
     toast.error(evalRunsDisabledReason);
     return false;
-  }, [evalRunsDisabledReason]);
+  }, [evalIterationQuota, evalRunsDisabledReason, organizationId]);
 
   const handleRerunWithQuota = useCallback(
     (...args: Parameters<typeof handlers.handleRerun>) => {

--- a/mcpjam-inspector/client/src/components/__tests__/MCPJamLimitDialog.test.tsx
+++ b/mcpjam-inspector/client/src/components/__tests__/MCPJamLimitDialog.test.tsx
@@ -47,10 +47,9 @@ vi.mock("@/hooks/use-upgrade-checkout", () => ({
 }));
 
 vi.mock("@/hooks/use-upgrade-request-recipients", () => ({
-  useUpgradeRequestRecipients: () => ({
-    recipients: [{ email: "dana@acme.test", name: "Dana Ruiz" }],
-    isLoading: false,
-  }),
+  useUpgradeRequestRecipients: () => [
+    { email: "dana@acme.test", name: "Dana Ruiz" },
+  ],
 }));
 
 vi.mock("@workos-inc/authkit-react", () => ({

--- a/mcpjam-inspector/client/src/components/__tests__/MCPJamLimitDialog.test.tsx
+++ b/mcpjam-inspector/client/src/components/__tests__/MCPJamLimitDialog.test.tsx
@@ -31,8 +31,8 @@ vi.mock("@/hooks/use-upgrade-checkout", () => ({
   useUpgradeCheckout: () => ({
     interval: "annual",
     setInterval: vi.fn(),
-    annualPriceLabel: "$30/seat/mo",
-    monthlyPriceLabel: "$38/seat/mo",
+    annualPriceLabel: "$30",
+    monthlyPriceLabel: "$38",
     annualDiscountPct: 21,
     annualSupported: true,
     monthlySupported: true,
@@ -47,9 +47,10 @@ vi.mock("@/hooks/use-upgrade-checkout", () => ({
 }));
 
 vi.mock("@/hooks/use-upgrade-request-recipients", () => ({
-  useUpgradeRequestRecipients: () => [
-    { email: "dana@acme.test", name: "Dana Ruiz" },
-  ],
+  useUpgradeRequestRecipients: () => ({
+    recipients: [{ email: "dana@acme.test", name: "Dana Ruiz" }],
+    isLoading: false,
+  }),
 }));
 
 vi.mock("@workos-inc/authkit-react", () => ({

--- a/mcpjam-inspector/client/src/components/__tests__/MCPJamLimitDialog.test.tsx
+++ b/mcpjam-inspector/client/src/components/__tests__/MCPJamLimitDialog.test.tsx
@@ -7,6 +7,8 @@ import { useModelPickerIntentStore } from "@/stores/model-picker-intent-store";
 
 const signIn = vi.fn();
 const trackMock = vi.hoisted(() => vi.fn());
+const upgradeHookOrganizationIdMock = vi.hoisted(() => vi.fn());
+const recipientHookOrganizationIdMock = vi.hoisted(() => vi.fn());
 const recipientsState = vi.hoisted(() => ({
   recipients: [{ email: "dana@acme.test", name: "Dana Ruiz" }],
   isLoading: false,
@@ -34,30 +36,40 @@ const upgradeState = {
 // pulling the Convex plan-catalog queries into a mock that only exports
 // useConvexAuth.
 vi.mock("@/hooks/use-upgrade-checkout", () => ({
-  useUpgradeCheckout: () => ({
-    interval: "annual",
-    setInterval: vi.fn(),
-    annualPriceLabel: "$30",
-    monthlyPriceLabel: "$38",
-    annualDiscountPct: 21,
-    annualSupported: true,
-    monthlySupported: true,
-    teamName: "Team",
-    teamEvalIterations: 15000,
-    currentPlan: upgradeState.currentPlan,
-    effectivePlan: upgradeState.effectivePlan,
-    organizationName: "Acme Robotics",
-    canManageBilling: upgradeState.canManageBilling,
-    isLoadingBilling: false,
-    isStarting: false,
-    start: upgradeState.start,
-  }),
+  useUpgradeCheckout: ({
+    organizationId,
+  }: {
+    organizationId: string | null;
+  }) => {
+    upgradeHookOrganizationIdMock(organizationId);
+    return {
+      interval: "annual",
+      setInterval: vi.fn(),
+      annualPriceLabel: "$30",
+      monthlyPriceLabel: "$38",
+      annualDiscountPct: 21,
+      annualSupported: true,
+      monthlySupported: true,
+      teamName: "Team",
+      teamEvalIterations: 15000,
+      currentPlan: upgradeState.currentPlan,
+      effectivePlan: upgradeState.effectivePlan,
+      organizationName: "Acme Robotics",
+      canManageBilling: upgradeState.canManageBilling,
+      isLoadingBilling: false,
+      isStarting: false,
+      start: upgradeState.start,
+    };
+  },
 }));
 
 vi.mock("@/lib/analytics", () => ({ track: trackMock }));
 
 vi.mock("@/hooks/use-upgrade-request-recipients", () => ({
-  useUpgradeRequestRecipients: () => recipientsState,
+  useUpgradeRequestRecipients: (organizationId: string | null) => {
+    recipientHookOrganizationIdMock(organizationId);
+    return recipientsState;
+  },
 }));
 
 vi.mock("@workos-inc/authkit-react", () => ({
@@ -94,6 +106,8 @@ const originalHash = window.location.hash;
 beforeEach(() => {
   signIn.mockReset();
   trackMock.mockReset();
+  upgradeHookOrganizationIdMock.mockReset();
+  recipientHookOrganizationIdMock.mockReset();
   upgradeState.start.mockReset();
   upgradeState.currentPlan = "free";
   upgradeState.effectivePlan = "free";
@@ -126,6 +140,16 @@ describe("MCPJamLimitDialog", () => {
   it("renders nothing while closed", () => {
     const { container } = render(<MCPJamLimitDialog />);
     expect(container).toBeEmptyDOMElement();
+  });
+
+  it("does not subscribe to billing or owner members while closed", () => {
+    authState.user = { id: "user-1" };
+    localStorage.setItem("active-organization-id:user-1", "org-active");
+
+    render(<MCPJamLimitDialog />);
+
+    expect(upgradeHookOrganizationIdMock).toHaveBeenLastCalledWith(null);
+    expect(recipientHookOrganizationIdMock).toHaveBeenLastCalledWith(null);
   });
 
   it("renders the dialog with guest copy when the store opens", () => {
@@ -205,6 +229,24 @@ describe("MCPJamLimitDialog", () => {
     expect(
       screen.getByRole("button", { name: /use your own API key/i })
     ).toBeInTheDocument();
+    expect(upgradeHookOrganizationIdMock).toHaveBeenLastCalledWith("org-1");
+    expect(recipientHookOrganizationIdMock).toHaveBeenLastCalledWith("org-1");
+  });
+
+  it("closes after an in-place plan change succeeds", async () => {
+    const user = userEvent.setup();
+    authState.user = { id: "user-1" };
+    sortedOrganizationsState.push({ _id: "org-1", myRole: "owner" });
+    upgradeState.start.mockResolvedValue({
+      redirected: false,
+      shouldDismiss: true,
+    });
+    useMCPJamLimitDialogStore.setState({ isOpen: true, intent: "topup" });
+    render(<MCPJamLimitDialog />);
+
+    await user.click(screen.getByTestId("upgrade-plan-cta"));
+
+    expect(useMCPJamLimitDialogStore.getState().isOpen).toBe(false);
   });
 
   it("does not pitch Team when a Team trial runs out of credits", () => {

--- a/mcpjam-inspector/client/src/components/__tests__/MCPJamLimitDialog.test.tsx
+++ b/mcpjam-inspector/client/src/components/__tests__/MCPJamLimitDialog.test.tsx
@@ -7,6 +7,10 @@ import { useModelPickerIntentStore } from "@/stores/model-picker-intent-store";
 
 const signIn = vi.fn();
 const trackMock = vi.hoisted(() => vi.fn());
+const recipientsState = vi.hoisted(() => ({
+  recipients: [{ email: "dana@acme.test", name: "Dana Ruiz" }],
+  isLoading: false,
+}));
 const authState: { isLoading: boolean; user: { id: string } | null } = {
   isLoading: false,
   user: null,
@@ -53,9 +57,7 @@ vi.mock("@/hooks/use-upgrade-checkout", () => ({
 vi.mock("@/lib/analytics", () => ({ track: trackMock }));
 
 vi.mock("@/hooks/use-upgrade-request-recipients", () => ({
-  useUpgradeRequestRecipients: () => [
-    { email: "dana@acme.test", name: "Dana Ruiz" },
-  ],
+  useUpgradeRequestRecipients: () => recipientsState,
 }));
 
 vi.mock("@workos-inc/authkit-react", () => ({
@@ -96,6 +98,8 @@ beforeEach(() => {
   upgradeState.currentPlan = "free";
   upgradeState.effectivePlan = "free";
   upgradeState.canManageBilling = true;
+  recipientsState.recipients = [{ email: "dana@acme.test", name: "Dana Ruiz" }];
+  recipientsState.isLoading = false;
   authState.isLoading = false;
   authState.user = null;
   sortedOrganizationsState.length = 0;
@@ -240,6 +244,35 @@ describe("MCPJamLimitDialog", () => {
     expect(screen.getByTestId("request-upgrade-mail")).toHaveAttribute(
       "href",
       expect.stringContaining("mailto:dana@acme.test")
+    );
+  });
+
+  it("waits for owner recipients before reporting a member impression", () => {
+    authState.user = { id: "user-1" };
+    sortedOrganizationsState.push({ _id: "org-1", myRole: "member" });
+    recipientsState.recipients = [];
+    recipientsState.isLoading = true;
+    useMCPJamLimitDialogStore.setState({ isOpen: true, intent: "topup" });
+    const view = render(<MCPJamLimitDialog />);
+
+    expect(trackMock).not.toHaveBeenCalledWith(
+      "plan_limit_dialog_shown",
+      expect.anything()
+    );
+
+    recipientsState.recipients = [
+      { email: "dana@acme.test", name: "Dana Ruiz" },
+    ];
+    recipientsState.isLoading = false;
+    view.rerender(<MCPJamLimitDialog />);
+
+    expect(trackMock).toHaveBeenCalledWith(
+      "plan_limit_dialog_shown",
+      expect.objectContaining({
+        wall_kind: "organization_credits",
+        primary_action: "request_owner",
+        request_recipient_count: 1,
+      })
     );
   });
 

--- a/mcpjam-inspector/client/src/components/__tests__/MCPJamLimitDialog.test.tsx
+++ b/mcpjam-inspector/client/src/components/__tests__/MCPJamLimitDialog.test.tsx
@@ -19,6 +19,7 @@ const sortedOrganizationsState: Array<{
 
 const upgradeState = {
   currentPlan: "free" as string,
+  effectivePlan: "free" as string,
   canManageBilling: true,
   start: vi.fn(),
 };
@@ -39,6 +40,7 @@ vi.mock("@/hooks/use-upgrade-checkout", () => ({
     teamName: "Team",
     teamEvalIterations: 15000,
     currentPlan: upgradeState.currentPlan,
+    effectivePlan: upgradeState.effectivePlan,
     organizationName: "Acme Robotics",
     canManageBilling: upgradeState.canManageBilling,
     isStarting: false,
@@ -87,6 +89,7 @@ beforeEach(() => {
   signIn.mockReset();
   upgradeState.start.mockReset();
   upgradeState.currentPlan = "free";
+  upgradeState.effectivePlan = "free";
   upgradeState.canManageBilling = true;
   authState.isLoading = false;
   authState.user = null;
@@ -173,6 +176,23 @@ describe("MCPJamLimitDialog", () => {
     ).toBeInTheDocument();
     expect(
       screen.getByRole("button", { name: /use your own API key/i })
+    ).toBeInTheDocument();
+  });
+
+  it("does not pitch Team when a Team trial runs out of credits", () => {
+    authState.user = { id: "user-1" };
+    sortedOrganizationsState.push({ _id: "org-1", myRole: "owner" });
+    upgradeState.currentPlan = "free";
+    upgradeState.effectivePlan = "team";
+    useMCPJamLimitDialogStore.setState({ isOpen: true, intent: "topup" });
+    render(<MCPJamLimitDialog />);
+
+    expect(screen.getByTestId("limit-dialog-description")).toHaveTextContent(
+      /Buy credits to keep your team going/
+    );
+    expect(screen.queryByTestId("upgrade-plan-cta")).not.toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: /^buy credits$/i })
     ).toBeInTheDocument();
   });
 

--- a/mcpjam-inspector/client/src/components/__tests__/MCPJamLimitDialog.test.tsx
+++ b/mcpjam-inspector/client/src/components/__tests__/MCPJamLimitDialog.test.tsx
@@ -29,9 +29,8 @@ const upgradeState = {
 // useConvexAuth.
 vi.mock("@/hooks/use-upgrade-checkout", () => ({
   useUpgradeCheckout: () => ({
-    interval: "annual",
-    setInterval: vi.fn(),
-    priceLabel: "$30/seat/mo",
+    annualPriceLabel: "$30/seat/mo",
+    monthlyPriceLabel: "$38/seat/mo",
     annualDiscountPct: 21,
     annualSupported: true,
     monthlySupported: true,

--- a/mcpjam-inspector/client/src/components/__tests__/MCPJamLimitDialog.test.tsx
+++ b/mcpjam-inspector/client/src/components/__tests__/MCPJamLimitDialog.test.tsx
@@ -29,6 +29,8 @@ const upgradeState = {
 // useConvexAuth.
 vi.mock("@/hooks/use-upgrade-checkout", () => ({
   useUpgradeCheckout: () => ({
+    interval: "annual",
+    setInterval: vi.fn(),
     annualPriceLabel: "$30/seat/mo",
     monthlyPriceLabel: "$38/seat/mo",
     annualDiscountPct: 21,
@@ -37,10 +39,17 @@ vi.mock("@/hooks/use-upgrade-checkout", () => ({
     teamName: "Team",
     teamEvalIterations: 15000,
     currentPlan: upgradeState.currentPlan,
+    organizationName: "Acme Robotics",
     canManageBilling: upgradeState.canManageBilling,
     isStarting: false,
     start: upgradeState.start,
   }),
+}));
+
+vi.mock("@/hooks/use-upgrade-request-recipients", () => ({
+  useUpgradeRequestRecipients: () => [
+    { email: "dana@acme.test", name: "Dana Ruiz" },
+  ],
 }));
 
 vi.mock("@workos-inc/authkit-react", () => ({
@@ -176,13 +185,18 @@ describe("MCPJamLimitDialog", () => {
     expect(screen.getByTestId("limit-dialog-description")).toHaveTextContent(
       /Ask an organization owner or admin to buy credits or upgrade/
     );
-    // Members get no CTAs at all: no upgrade, no buy credits, no BYOK.
+    // Members can't buy or upgrade, so those CTAs stay gone. They now get one
+    // action: email an owner who can.
     expect(
       screen.queryByRole("button", { name: /^buy credits$/i })
     ).not.toBeInTheDocument();
     expect(
       screen.queryByRole("button", { name: /use your own API key/i })
     ).not.toBeInTheDocument();
+    expect(screen.getByTestId("request-upgrade-mail")).toHaveAttribute(
+      "href",
+      expect.stringContaining("mailto:dana@acme.test")
+    );
   });
 
   it("opens the model picker's Your providers tab on BYOK click (no org redirect)", async () => {

--- a/mcpjam-inspector/client/src/components/__tests__/MCPJamLimitDialog.test.tsx
+++ b/mcpjam-inspector/client/src/components/__tests__/MCPJamLimitDialog.test.tsx
@@ -219,6 +219,28 @@ describe("MCPJamLimitDialog", () => {
     );
   });
 
+  it("asks paid-org members to request credits instead of a Team upgrade", () => {
+    authState.user = { id: "user-1" };
+    sortedOrganizationsState.push({ _id: "org-1", myRole: "member" });
+    upgradeState.currentPlan = "team";
+    upgradeState.effectivePlan = "team";
+    useMCPJamLimitDialogStore.setState({ isOpen: true, intent: "topup" });
+    render(<MCPJamLimitDialog />);
+
+    expect(screen.getByTestId("limit-dialog-description")).toHaveTextContent(
+      /Ask an organization owner or admin to buy credits\./
+    );
+    const href = decodeURIComponent(
+      screen.getByTestId("request-upgrade-mail").getAttribute("href") ?? ""
+    );
+    expect(href).toContain("Credit purchase request for Acme Robotics");
+    expect(href).toContain(
+      "Our organization has run out of MCPJam credits."
+    );
+    expect(href).toContain("Could you buy more credits for Acme Robotics?");
+    expect(href).not.toContain("upgrade Acme Robotics to the Team plan");
+  });
+
   it("opens the model picker's Your providers tab on BYOK click (no org redirect)", async () => {
     const user = userEvent.setup();
     authState.user = { id: "user-1" };

--- a/mcpjam-inspector/client/src/components/__tests__/MCPJamLimitDialog.test.tsx
+++ b/mcpjam-inspector/client/src/components/__tests__/MCPJamLimitDialog.test.tsx
@@ -17,6 +17,33 @@ const sortedOrganizationsState: Array<{
   isCreator?: boolean;
 }> = [];
 
+const upgradeState = {
+  currentPlan: "free" as string,
+  canManageBilling: true,
+  start: vi.fn(),
+};
+
+// The upgrade path has its own coverage in PlanLimitDialog.test.tsx. Stubbing
+// it here keeps this file focused on the credits routing and copy, and avoids
+// pulling the Convex plan-catalog queries into a mock that only exports
+// useConvexAuth.
+vi.mock("@/hooks/use-upgrade-checkout", () => ({
+  useUpgradeCheckout: () => ({
+    interval: "annual",
+    setInterval: vi.fn(),
+    priceLabel: "$30/seat/mo",
+    annualDiscountPct: 21,
+    annualSupported: true,
+    monthlySupported: true,
+    teamName: "Team",
+    teamEvalIterations: 15000,
+    currentPlan: upgradeState.currentPlan,
+    canManageBilling: upgradeState.canManageBilling,
+    isStarting: false,
+    start: upgradeState.start,
+  }),
+}));
+
 vi.mock("@workos-inc/authkit-react", () => ({
   useAuth: () => ({
     isLoading: authState.isLoading,
@@ -50,6 +77,9 @@ const originalHash = window.location.hash;
 
 beforeEach(() => {
   signIn.mockReset();
+  upgradeState.start.mockReset();
+  upgradeState.currentPlan = "free";
+  upgradeState.canManageBilling = true;
   authState.isLoading = false;
   authState.user = null;
   sortedOrganizationsState.length = 0;
@@ -131,10 +161,10 @@ describe("MCPJamLimitDialog", () => {
       })
     ).toBeInTheDocument();
     expect(
-      screen.getByRole("button", { name: /^top up$/i })
+      screen.getByRole("button", { name: /^buy credits$/i })
     ).toBeInTheDocument();
     expect(
-      screen.getByRole("button", { name: /bring your own key/i })
+      screen.getByRole("button", { name: /use your own API key/i })
     ).toBeInTheDocument();
   });
 
@@ -145,14 +175,14 @@ describe("MCPJamLimitDialog", () => {
     render(<MCPJamLimitDialog />);
 
     expect(screen.getByTestId("limit-dialog-description")).toHaveTextContent(
-      /Ask your org admin to top up credits/
+      /Ask an organization owner or admin to buy credits or upgrade/
     );
-    // Members get no CTAs at all — neither top up nor BYOK.
+    // Members get no CTAs at all: no upgrade, no buy credits, no BYOK.
     expect(
-      screen.queryByRole("button", { name: /^top up$/i })
+      screen.queryByRole("button", { name: /^buy credits$/i })
     ).not.toBeInTheDocument();
     expect(
-      screen.queryByRole("button", { name: /bring your own key/i })
+      screen.queryByRole("button", { name: /use your own API key/i })
     ).not.toBeInTheDocument();
   });
 
@@ -166,7 +196,7 @@ describe("MCPJamLimitDialog", () => {
     render(<MCPJamLimitDialog />);
 
     await user.click(
-      screen.getByRole("button", { name: /bring your own key/i })
+      screen.getByRole("button", { name: /use your own API key/i })
     );
 
     // Closes the dialog and asks the picker to open its "Your providers" tab —
@@ -186,7 +216,7 @@ describe("MCPJamLimitDialog", () => {
     useMCPJamLimitDialogStore.setState({ isOpen: true, intent: "topup" });
     render(<MCPJamLimitDialog />);
 
-    await user.click(screen.getByRole("button", { name: /^top up$/i }));
+    await user.click(screen.getByRole("button", { name: /^buy credits$/i }));
 
     expect(useMCPJamLimitDialogStore.getState().isOpen).toBe(false);
     expect(window.location.pathname).toBe("/organizations/org-active/billing");
@@ -208,7 +238,7 @@ describe("MCPJamLimitDialog", () => {
     });
     render(<MCPJamLimitDialog />);
 
-    await user.click(screen.getByRole("button", { name: /^top up$/i }));
+    await user.click(screen.getByRole("button", { name: /^buy credits$/i }));
 
     expect(window.location.pathname).toBe("/organizations/org-a/billing");
     expect(window.location.search).toBe("?topup=open");
@@ -221,7 +251,7 @@ describe("MCPJamLimitDialog", () => {
     useMCPJamLimitDialogStore.setState({ isOpen: true, intent: "topup" });
     render(<MCPJamLimitDialog />);
 
-    await user.click(screen.getByRole("button", { name: /^top up$/i }));
+    await user.click(screen.getByRole("button", { name: /^buy credits$/i }));
 
     expect(window.location.pathname).toBe(
       "/organizations/org-fallback/billing"
@@ -235,7 +265,7 @@ describe("MCPJamLimitDialog", () => {
     useMCPJamLimitDialogStore.setState({ isOpen: true, intent: "topup" });
     render(<MCPJamLimitDialog />);
 
-    await user.click(screen.getByRole("button", { name: /^top up$/i }));
+    await user.click(screen.getByRole("button", { name: /^buy credits$/i }));
 
     // Modal stays open and no nav happens — once orgs load, the user can
     // click again and be routed correctly.

--- a/mcpjam-inspector/client/src/components/__tests__/MCPJamLimitDialog.test.tsx
+++ b/mcpjam-inspector/client/src/components/__tests__/MCPJamLimitDialog.test.tsx
@@ -6,6 +6,7 @@ import { useMCPJamLimitDialogStore } from "@/stores/mcpjam-limit-dialog-store";
 import { useModelPickerIntentStore } from "@/stores/model-picker-intent-store";
 
 const signIn = vi.fn();
+const trackMock = vi.hoisted(() => vi.fn());
 const authState: { isLoading: boolean; user: { id: string } | null } = {
   isLoading: false,
   user: null,
@@ -43,10 +44,13 @@ vi.mock("@/hooks/use-upgrade-checkout", () => ({
     effectivePlan: upgradeState.effectivePlan,
     organizationName: "Acme Robotics",
     canManageBilling: upgradeState.canManageBilling,
+    isLoadingBilling: false,
     isStarting: false,
     start: upgradeState.start,
   }),
 }));
+
+vi.mock("@/lib/analytics", () => ({ track: trackMock }));
 
 vi.mock("@/hooks/use-upgrade-request-recipients", () => ({
   useUpgradeRequestRecipients: () => [
@@ -87,6 +91,7 @@ const originalHash = window.location.hash;
 
 beforeEach(() => {
   signIn.mockReset();
+  trackMock.mockReset();
   upgradeState.start.mockReset();
   upgradeState.currentPlan = "free";
   upgradeState.effectivePlan = "free";
@@ -132,6 +137,25 @@ describe("MCPJamLimitDialog", () => {
     expect(
       screen.getByRole("button", { name: /^sign in$/i })
     ).toBeInTheDocument();
+  });
+
+  it("reports the guest wall once across rerenders", () => {
+    useMCPJamLimitDialogStore.setState({ isOpen: true, intent: "guest" });
+    const view = render(<MCPJamLimitDialog />);
+
+    view.rerender(<MCPJamLimitDialog />);
+
+    const impressions = trackMock.mock.calls.filter(
+      ([event]) => event === "plan_limit_dialog_shown"
+    );
+    expect(impressions).toHaveLength(1);
+    expect(impressions[0]?.[1]).toEqual(
+      expect.objectContaining({
+        wall_kind: "guest_credits",
+        audience: "guest",
+        primary_action: "sign_in",
+      })
+    );
   });
 
   it("calls signIn() when the Sign in button is clicked", async () => {
@@ -234,9 +258,7 @@ describe("MCPJamLimitDialog", () => {
       screen.getByTestId("request-upgrade-mail").getAttribute("href") ?? ""
     );
     expect(href).toContain("Credit purchase request for Acme Robotics");
-    expect(href).toContain(
-      "Our organization has run out of MCPJam credits."
-    );
+    expect(href).toContain("Our organization has run out of MCPJam credits.");
     expect(href).toContain("Could you buy more credits for Acme Robotics?");
     expect(href).not.toContain("upgrade Acme Robotics to the Team plan");
   });

--- a/mcpjam-inspector/client/src/components/billing/CreditTopupDialog.tsx
+++ b/mcpjam-inspector/client/src/components/billing/CreditTopupDialog.tsx
@@ -86,8 +86,8 @@ export function CreditTopupDialog({
         <DialogHeader>
           <DialogTitle>Buy credits to keep chatting</DialogTitle>
           <DialogDescription>
-            Add credits to your organization so the team can keep using MCPJam
-            models when your shared credits run low.
+            Credits cover model usage in chat, playground, and agents. Buying
+            credits doesn't change your plan limits.
           </DialogDescription>
         </DialogHeader>
         <div className="flex flex-col gap-4">
@@ -127,6 +127,11 @@ export function CreditTopupDialog({
                     </span>
                     <span className="text-xs text-muted-foreground">
                       credits
+                    </span>
+                    {/* Price per tile: without it the three options can't be
+                        compared without selecting each one. */}
+                    <span className="mt-1 text-xs text-foreground">
+                      {preset.displayPrice}
                     </span>
                   </button>
                 );

--- a/mcpjam-inspector/client/src/components/billing/CreditTopupDialog.tsx
+++ b/mcpjam-inspector/client/src/components/billing/CreditTopupDialog.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import { CoinStackIcon } from "@/components/ui/coin-stack-icon";
 import { toast } from "@/lib/toast";
 import { Button } from "@mcpjam/design-system/button";
@@ -16,6 +16,7 @@ import {
   type CreditTopupPreset,
   type CreditTopupSource,
 } from "@/hooks/useCreditTopup";
+import { track } from "@/lib/analytics";
 
 interface CreditTopupDialogProps {
   open: boolean;
@@ -40,10 +41,14 @@ export function CreditTopupDialog({
   const [selectedPackageId, setSelectedPackageId] = useState<string | null>(
     null
   );
+  const impressionTrackedRef = useRef(false);
+  const dismissalTrackedRef = useRef(false);
 
   useEffect(() => {
     if (!open) {
       setSelectedPackageId(null);
+      impressionTrackedRef.current = false;
+      dismissalTrackedRef.current = false;
     }
   }, [open]);
 
@@ -53,9 +58,65 @@ export function CreditTopupDialog({
     }
   }, [open, presets, selectedPackageId]);
 
+  useEffect(() => {
+    if (!open || presetsLoading || impressionTrackedRef.current) return;
+
+    impressionTrackedRef.current = true;
+    track("credit_topup_dialog_shown", {
+      location: "credit_topup",
+      source,
+      organization_id: organizationId,
+      organization_resolved: Boolean(organizationId),
+      package_count: presets?.length ?? 0,
+      default_package_id: presets?.[0]?.packageId ?? null,
+      default_price_cents: presets?.[0]?.priceCents ?? null,
+      packages_available: Boolean(presets?.length),
+      has_resume_context: Boolean(chatSessionId && lastUserMessage),
+    });
+  }, [
+    chatSessionId,
+    lastUserMessage,
+    open,
+    organizationId,
+    presets,
+    presetsLoading,
+    source,
+  ]);
+
   const selectedPreset: CreditTopupPreset | undefined = presets?.find(
     (preset) => preset.packageId === selectedPackageId
   );
+
+  const handleDismiss = (dismissalMethod: "cancel" | "dialog") => {
+    onOpenChange(false);
+    if (dismissalTrackedRef.current) return;
+
+    dismissalTrackedRef.current = true;
+    track("credit_topup_dialog_dismissed", {
+      location: "credit_topup",
+      source,
+      organization_id: organizationId,
+      dismissal_method: dismissalMethod,
+      selected_package_id: selectedPreset?.packageId ?? null,
+      selected_price_cents: selectedPreset?.priceCents ?? null,
+    });
+  };
+
+  const handlePackageSelection = (
+    preset: CreditTopupPreset,
+    packageIndex: number
+  ) => {
+    setSelectedPackageId(preset.packageId);
+    track("credit_topup_package_selected", {
+      location: "credit_topup",
+      source,
+      organization_id: organizationId,
+      package_id: preset.packageId,
+      price_cents: preset.priceCents,
+      package_index: packageIndex,
+      package_count: presets?.length ?? 0,
+    });
+  };
 
   const handleConfirm = async () => {
     if (!selectedPreset || !organizationId) return;
@@ -81,7 +142,12 @@ export function CreditTopupDialog({
   };
 
   return (
-    <Dialog open={open} onOpenChange={onOpenChange}>
+    <Dialog
+      open={open}
+      onOpenChange={(next) => {
+        if (!next) handleDismiss("dialog");
+      }}
+    >
       <DialogContent className="sm:max-w-md">
         <DialogHeader>
           <DialogTitle>Buy credits to keep chatting</DialogTitle>
@@ -101,7 +167,7 @@ export function CreditTopupDialog({
             </div>
           ) : (
             <div className="grid grid-cols-3 gap-2" role="radiogroup">
-              {presets.map((preset) => {
+              {presets.map((preset, packageIndex) => {
                 const isSelected = preset.packageId === selectedPackageId;
                 const creditsAmount = preset.displayCredits.replace(
                   /\s*credits\s*$/i,
@@ -113,7 +179,7 @@ export function CreditTopupDialog({
                     type="button"
                     role="radio"
                     aria-checked={isSelected}
-                    onClick={() => setSelectedPackageId(preset.packageId)}
+                    onClick={() => handlePackageSelection(preset, packageIndex)}
                     className={cn(
                       "flex flex-col items-center justify-center rounded-md border px-3 py-3 text-sm font-medium transition-colors",
                       isSelected
@@ -143,7 +209,7 @@ export function CreditTopupDialog({
           <Button
             type="button"
             variant="outline"
-            onClick={() => onOpenChange(false)}
+            onClick={() => handleDismiss("cancel")}
             disabled={isStartingCheckout}
           >
             Cancel

--- a/mcpjam-inspector/client/src/components/billing/CreditsLimitDialogView.tsx
+++ b/mcpjam-inspector/client/src/components/billing/CreditsLimitDialogView.tsx
@@ -23,6 +23,7 @@ export interface CreditsLimitDialogViewProps {
   showUpgrade: boolean;
   requestRecipients: UpgradeRequestRecipient[];
   requestAction?: UpgradeRequestAction;
+  organizationId?: string | null;
   organizationName: string;
   interval: BillingInterval;
   onIntervalChange: (interval: BillingInterval) => void;
@@ -56,6 +57,7 @@ export function CreditsLimitDialogView({
   showUpgrade,
   requestRecipients,
   requestAction = "upgrade",
+  organizationId,
   organizationName,
   interval,
   onIntervalChange,
@@ -98,6 +100,7 @@ export function CreditsLimitDialogView({
             origin="credits"
             limitKind="credits"
             requestAction={requestAction}
+            organizationId={organizationId}
           />
         ) : (
           <>

--- a/mcpjam-inspector/client/src/components/billing/CreditsLimitDialogView.tsx
+++ b/mcpjam-inspector/client/src/components/billing/CreditsLimitDialogView.tsx
@@ -11,6 +11,7 @@ import type { BillingInterval } from "@/hooks/useOrganizationBilling";
 import { UpgradeIntervalPicker } from "@/components/billing/UpgradeIntervalPicker";
 import {
   RequestUpgradeButton,
+  type UpgradeRequestAction,
   type UpgradeRequestRecipient,
 } from "@/components/billing/RequestUpgradeButton";
 
@@ -21,6 +22,7 @@ export interface CreditsLimitDialogViewProps {
   /** Free orgs whose user can manage billing. A paid org gets credits only. */
   showUpgrade: boolean;
   requestRecipients: UpgradeRequestRecipient[];
+  requestAction?: UpgradeRequestAction;
   organizationName: string;
   interval: BillingInterval;
   onIntervalChange: (interval: BillingInterval) => void;
@@ -53,6 +55,7 @@ export function CreditsLimitDialogView({
   isKnownNonManager,
   showUpgrade,
   requestRecipients,
+  requestAction = "upgrade",
   organizationName,
   interval,
   onIntervalChange,
@@ -94,6 +97,7 @@ export function CreditsLimitDialogView({
             teamName={teamName}
             origin="credits"
             limitKind="credits"
+            requestAction={requestAction}
           />
         ) : (
           <>

--- a/mcpjam-inspector/client/src/components/billing/CreditsLimitDialogView.tsx
+++ b/mcpjam-inspector/client/src/components/billing/CreditsLimitDialogView.tsx
@@ -1,0 +1,132 @@
+import { Button } from "@mcpjam/design-system/button";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@mcpjam/design-system/dialog";
+import type { BillingInterval } from "@/hooks/useOrganizationBilling";
+import { UpgradeIntervalPicker } from "@/components/billing/UpgradeIntervalPicker";
+import {
+  RequestUpgradeButton,
+  type UpgradeRequestRecipient,
+} from "@/components/billing/RequestUpgradeButton";
+
+export interface CreditsLimitDialogViewProps {
+  description: string;
+  /** Can't buy credits or upgrade. Gets the owner-request path instead. */
+  isKnownNonManager: boolean;
+  /** Free orgs whose user can manage billing. A paid org gets credits only. */
+  showUpgrade: boolean;
+  requestRecipients: UpgradeRequestRecipient[];
+  organizationName: string;
+  interval: BillingInterval;
+  onIntervalChange: (interval: BillingInterval) => void;
+  annualPriceLabel: string | null;
+  monthlyPriceLabel: string | null;
+  annualDiscountPct: number;
+  annualSupported: boolean;
+  monthlySupported: boolean;
+  teamName: string;
+  isStarting: boolean;
+  onUpgrade: () => void;
+  onBuyCredits: () => void;
+  onUseOwnKey: () => void;
+  onDismiss: () => void;
+  /** Dev preview only; see PlanLimitDialogView. Production renders modal. */
+  modal?: boolean;
+}
+
+/**
+ * Presentation for the out-of-credits wall, with no data dependencies, so the
+ * dev preview at `/__preview/plan-limit` can render each variant with dummy
+ * props. `MCPJamLimitDialog` owns the data, the org resolution, and the copy.
+ *
+ * Upgrade leads because both of the older actions (buy credits, bring your own
+ * key) keep the org on Free at a variable cost. Credits stay available for a
+ * genuine burst, one step down.
+ */
+export function CreditsLimitDialogView({
+  description,
+  isKnownNonManager,
+  showUpgrade,
+  requestRecipients,
+  organizationName,
+  interval,
+  onIntervalChange,
+  annualPriceLabel,
+  monthlyPriceLabel,
+  annualDiscountPct,
+  annualSupported,
+  monthlySupported,
+  teamName,
+  isStarting,
+  onUpgrade,
+  onBuyCredits,
+  onUseOwnKey,
+  onDismiss,
+  modal = true,
+}: CreditsLimitDialogViewProps) {
+  return (
+    <Dialog
+      open
+      modal={modal}
+      onOpenChange={(next) => {
+        if (!next) onDismiss();
+      }}
+    >
+      <DialogContent className="sm:max-w-md">
+        <DialogHeader>
+          <DialogTitle>Your org is out of credits</DialogTitle>
+          <DialogDescription
+            className="text-pretty"
+            data-testid="limit-dialog-description"
+          >
+            {description}
+          </DialogDescription>
+        </DialogHeader>
+        {isKnownNonManager ? (
+          <RequestUpgradeButton
+            recipients={requestRecipients}
+            organizationName={organizationName}
+            teamName={teamName}
+            origin="credits"
+            limitKind="credits"
+          />
+        ) : (
+          <>
+            {showUpgrade ? (
+              <UpgradeIntervalPicker
+                interval={interval}
+                onIntervalChange={onIntervalChange}
+                annualPriceLabel={annualPriceLabel}
+                monthlyPriceLabel={monthlyPriceLabel}
+                annualDiscountPct={annualDiscountPct}
+                annualSupported={annualSupported}
+                monthlySupported={monthlySupported}
+                teamName={teamName}
+                isStarting={isStarting}
+                onUpgrade={onUpgrade}
+              />
+            ) : null}
+            <DialogFooter className="sm:justify-between">
+              <Button
+                type="button"
+                variant="link"
+                className="px-0 text-muted-foreground"
+                onClick={onUseOwnKey}
+              >
+                Use your own API key
+              </Button>
+              <Button type="button" variant="outline" onClick={onBuyCredits}>
+                Buy credits
+              </Button>
+            </DialogFooter>
+          </>
+        )}
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/mcpjam-inspector/client/src/components/billing/PlanLimitDialog.tsx
+++ b/mcpjam-inspector/client/src/components/billing/PlanLimitDialog.tsx
@@ -249,15 +249,14 @@ export function PlanLimitDialog() {
         </DialogHeader>
         {showUpgrade ? (
           <UpgradeIntervalPicker
-            interval={upgrade.interval}
-            onIntervalChange={upgrade.setInterval}
-            priceLabel={upgrade.priceLabel}
+            annualPriceLabel={upgrade.annualPriceLabel}
+            monthlyPriceLabel={upgrade.monthlyPriceLabel}
             annualDiscountPct={upgrade.annualDiscountPct}
             annualSupported={upgrade.annualSupported}
             monthlySupported={upgrade.monthlySupported}
             teamName={upgrade.teamName}
             isStarting={upgrade.isStarting}
-            onUpgrade={() => void upgrade.start()}
+            onUpgrade={(interval) => void upgrade.start(interval)}
           />
         ) : null}
         {showEnterprise ? (

--- a/mcpjam-inspector/client/src/components/billing/PlanLimitDialog.tsx
+++ b/mcpjam-inspector/client/src/components/billing/PlanLimitDialog.tsx
@@ -138,10 +138,14 @@ function useUpgradeReturnFlow(): void {
 
     track("plan_limit_upgrade_returned", {
       location: "plan_limit_dialog",
+      organization_id: upgradeReturn.organizationId,
       origin: upgradeReturn.origin,
       upgraded,
       plan: billingStatus.plan,
+      current_plan: billingStatus.plan,
+      effective_plan: billingStatus.effectivePlan ?? billingStatus.plan,
       billing_interval: billingStatus.billingInterval,
+      can_manage_billing: billingStatus.canManageBilling ?? false,
     });
   }, [
     billingStatus,
@@ -163,6 +167,7 @@ export function PlanLimitDialog() {
   const isOpen = usePlanLimitDialogStore((s) => s.isOpen);
   const limit = usePlanLimitDialogStore((s) => s.limit);
   const close = usePlanLimitDialogStore((s) => s.close);
+  const impressionTrackedRef = useRef(false);
 
   const organizationId = limit?.organizationId ?? null;
   const upgrade = useUpgradeCheckout({
@@ -173,41 +178,103 @@ export function PlanLimitDialog() {
   const requestRecipients = useUpgradeRequestRecipients(organizationId);
 
   useEffect(() => {
-    if (!isOpen || !limit) return;
+    if (!isOpen || !limit) {
+      impressionTrackedRef.current = false;
+      return;
+    }
+    if (upgrade.isLoadingBilling || impressionTrackedRef.current) return;
+
+    const isFreePlan = upgrade.effectivePlan === "free";
+    const showUpgrade = isFreePlan && upgrade.canManageBilling;
+    const showEnterprise =
+      !isFreePlan && upgrade.effectivePlan !== "enterprise";
+    impressionTrackedRef.current = true;
     track("plan_limit_dialog_shown", {
       location: "plan_limit_dialog",
+      wall_kind: "eval_iterations",
+      organization_id: organizationId,
       limit_kind: limit.kind,
       origin: limit.origin,
       used: limit.used,
       allowed: limit.allowed,
       window_kind: limit.windowKind,
+      current_plan: upgrade.currentPlan,
+      effective_plan: upgrade.effectivePlan,
+      can_manage_billing: upgrade.canManageBilling,
+      audience: upgrade.canManageBilling ? "billing_manager" : "member",
+      primary_action: showUpgrade
+        ? "upgrade"
+        : showEnterprise
+        ? "enterprise"
+        : requestRecipients.length > 0
+        ? "request_owner"
+        : "none",
+      request_recipient_count: requestRecipients.length,
+      billing_interval: upgrade.interval,
+      annual_supported: upgrade.annualSupported,
+      monthly_supported: upgrade.monthlySupported,
     });
-  }, [isOpen, limit]);
+  }, [
+    isOpen,
+    limit,
+    organizationId,
+    requestRecipients.length,
+    upgrade.annualSupported,
+    upgrade.canManageBilling,
+    upgrade.currentPlan,
+    upgrade.effectivePlan,
+    upgrade.interval,
+    upgrade.isLoadingBilling,
+    upgrade.monthlySupported,
+  ]);
 
   // New tab, not a same-tab navigation or a mailto. The user is mid-task with a
   // blocked eval run; sending them away from the app (or into a mail client
   // that may not be configured) loses their place for no reason.
   const handleRequestEnterprise = useCallback(() => {
+    window.open(ENTERPRISE_CONTACT_URL, "_blank", "noopener,noreferrer");
+    close();
     track("plan_limit_enterprise_cta_clicked", {
       location: "plan_limit_dialog",
+      organization_id: organizationId,
       limit_kind: limit?.kind ?? "evalIterations",
       origin: limit?.origin,
       plan: upgrade.effectivePlan,
+      current_plan: upgrade.currentPlan,
+      effective_plan: upgrade.effectivePlan,
+      can_manage_billing: upgrade.canManageBilling,
     });
-    window.open(ENTERPRISE_CONTACT_URL, "_blank", "noopener,noreferrer");
-    close();
-  }, [close, limit, upgrade.effectivePlan]);
+  }, [
+    close,
+    limit,
+    organizationId,
+    upgrade.canManageBilling,
+    upgrade.currentPlan,
+    upgrade.effectivePlan,
+  ]);
 
   const handleDismiss = useCallback(() => {
+    close();
     if (limit) {
       track("plan_limit_dialog_dismissed", {
         location: "plan_limit_dialog",
+        wall_kind: "eval_iterations",
+        organization_id: organizationId,
         limit_kind: limit.kind,
         origin: limit.origin,
+        current_plan: upgrade.currentPlan,
+        effective_plan: upgrade.effectivePlan,
+        audience: upgrade.canManageBilling ? "billing_manager" : "member",
       });
     }
-    close();
-  }, [close, limit]);
+  }, [
+    close,
+    limit,
+    organizationId,
+    upgrade.canManageBilling,
+    upgrade.currentPlan,
+    upgrade.effectivePlan,
+  ]);
 
   if (!isOpen || !limit || limit.kind !== "evalIterations") return null;
 
@@ -260,6 +327,7 @@ export function PlanLimitDialog() {
       showUpgrade={showUpgrade}
       showEnterprise={showEnterprise}
       requestRecipients={requestRecipients}
+      organizationId={organizationId}
       organizationName={upgrade.organizationName}
       origin="evals"
       limitKind={limit.kind}

--- a/mcpjam-inspector/client/src/components/billing/PlanLimitDialog.tsx
+++ b/mcpjam-inspector/client/src/components/billing/PlanLimitDialog.tsx
@@ -1,0 +1,277 @@
+import { useCallback, useEffect, useRef, useState } from "react";
+import { Button } from "@mcpjam/design-system/button";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@mcpjam/design-system/dialog";
+import { useOrganizationBilling } from "@/hooks/useOrganizationBilling";
+import {
+  UPGRADE_RETURN_ORG_PARAM,
+  UPGRADE_RETURN_ORIGIN_PARAM,
+  UPGRADE_RETURN_PARAM,
+  useUpgradeCheckout,
+  type UpgradeOrigin,
+} from "@/hooks/use-upgrade-checkout";
+import { track } from "@/lib/analytics";
+import { toast } from "@/lib/toast";
+import { usePlanLimitDialogStore } from "@/stores/plan-limit-dialog-store";
+import { UpgradeIntervalPicker } from "@/components/billing/UpgradeIntervalPicker";
+
+/** Same destination as the pricing page's Enterprise CTA. */
+const ENTERPRISE_CONTACT_URL = "https://www.mcpjam.com/contact";
+
+function formatCount(value: number): string {
+  return new Intl.NumberFormat().format(value);
+}
+
+function formatResetClock(resetsAt: number): string {
+  return new Intl.DateTimeFormat(undefined, {
+    hour: "numeric",
+    minute: "2-digit",
+  }).format(new Date(resetsAt));
+}
+
+/** "about 9 hours". The absolute timestamp alone makes the user do arithmetic
+ * at exactly the wrong moment. */
+function formatResetDistance(resetsAt: number): string | null {
+  const diffMs = resetsAt - Date.now();
+  if (diffMs <= 0) return null;
+  const hours = Math.round(diffMs / (60 * 60 * 1000));
+  if (hours < 1) {
+    const minutes = Math.max(1, Math.round(diffMs / 60_000));
+    return `about ${minutes} minute${minutes === 1 ? "" : "s"}`;
+  }
+  if (hours < 36) {
+    return `about ${hours} hour${hours === 1 ? "" : "s"}`;
+  }
+  const days = Math.round(hours / 24);
+  return `about ${days} day${days === 1 ? "" : "s"}`;
+}
+
+interface UpgradeReturn {
+  organizationId: string;
+  origin: UpgradeOrigin;
+}
+
+function readUpgradeReturn(): UpgradeReturn | null {
+  if (typeof window === "undefined") return null;
+  const params = new URLSearchParams(window.location.search);
+  if (params.get(UPGRADE_RETURN_PARAM) !== "return") return null;
+  const organizationId = params.get(UPGRADE_RETURN_ORG_PARAM);
+  if (!organizationId) return null;
+  const rawOrigin = params.get(UPGRADE_RETURN_ORIGIN_PARAM);
+  return {
+    organizationId,
+    origin: rawOrigin === "credits" ? "credits" : "evals",
+  };
+}
+
+function stripUpgradeReturnParams(): void {
+  if (typeof window === "undefined") return;
+  const params = new URLSearchParams(window.location.search);
+  params.delete(UPGRADE_RETURN_PARAM);
+  params.delete(UPGRADE_RETURN_ORG_PARAM);
+  params.delete(UPGRADE_RETURN_ORIGIN_PARAM);
+  const search = params.toString();
+  window.history.replaceState(
+    null,
+    "",
+    window.location.pathname +
+      (search ? `?${search}` : "") +
+      window.location.hash,
+  );
+}
+
+/**
+ * Handles the post-checkout return for both limit walls. Mounted app-wide, so
+ * it runs wherever the user was blocked rather than on the billing page.
+ *
+ * The return marker is present whether the user paid or bailed at Stripe, so
+ * the confirmation is gated on the plan having actually changed. Never
+ * announce a purchase we can't see.
+ */
+function useUpgradeReturnFlow(): void {
+  const [upgradeReturn] = useState<UpgradeReturn | null>(() =>
+    readUpgradeReturn(),
+  );
+  const handledRef = useRef(false);
+  const { billingStatus, planCatalog, isLoadingBilling } =
+    useOrganizationBilling(upgradeReturn?.organizationId ?? null);
+
+  useEffect(() => {
+    if (!upgradeReturn || handledRef.current) return;
+    if (isLoadingBilling || !billingStatus) return;
+    handledRef.current = true;
+    stripUpgradeReturnParams();
+
+    const upgraded = billingStatus.plan !== "free";
+    if (upgraded) {
+      const teamName = planCatalog?.plans.team.displayName ?? "Team";
+      toast.success(
+        upgradeReturn.origin === "credits"
+          ? `You're on our ${teamName} plan. Your credits are available now.`
+          : `You're on our ${teamName} plan. Run your suite again to pick up where you left off.`,
+      );
+    }
+
+    track("plan_limit_upgrade_returned", {
+      location: "plan_limit_dialog",
+      origin: upgradeReturn.origin,
+      upgraded,
+      plan: billingStatus.plan,
+      billing_interval: billingStatus.billingInterval,
+    });
+  }, [
+    billingStatus,
+    isLoadingBilling,
+    planCatalog,
+    upgradeReturn,
+  ]);
+}
+
+/**
+ * The free-plan wall for eval iterations. Replaces a dead-end `toast.error`
+ * with a decision surface, and starts checkout directly rather than routing
+ * through the billing page.
+ */
+export function PlanLimitDialog() {
+  useUpgradeReturnFlow();
+
+  const isOpen = usePlanLimitDialogStore((s) => s.isOpen);
+  const limit = usePlanLimitDialogStore((s) => s.limit);
+  const close = usePlanLimitDialogStore((s) => s.close);
+
+  const upgrade = useUpgradeCheckout({
+    organizationId: limit?.organizationId ?? null,
+    origin: "evals",
+    limitKind: limit?.kind ?? "evalIterations",
+  });
+
+  useEffect(() => {
+    if (!isOpen || !limit) return;
+    track("plan_limit_dialog_shown", {
+      location: "plan_limit_dialog",
+      limit_kind: limit.kind,
+      origin: limit.origin,
+      used: limit.used,
+      allowed: limit.allowed,
+      window_kind: limit.windowKind,
+    });
+  }, [isOpen, limit]);
+
+  // New tab, not a same-tab navigation or a mailto. The user is mid-task with a
+  // blocked eval run; sending them away from the app (or into a mail client
+  // that may not be configured) loses their place for no reason.
+  const handleRequestUpgrade = useCallback(() => {
+    track("plan_limit_enterprise_cta_clicked", {
+      location: "plan_limit_dialog",
+      limit_kind: limit?.kind ?? "evalIterations",
+      origin: limit?.origin,
+      plan: upgrade.currentPlan,
+    });
+    window.open(ENTERPRISE_CONTACT_URL, "_blank", "noopener,noreferrer");
+    close();
+  }, [close, limit, upgrade.currentPlan]);
+
+  const handleDismiss = useCallback(() => {
+    if (limit) {
+      track("plan_limit_dialog_dismissed", {
+        location: "plan_limit_dialog",
+        limit_kind: limit.kind,
+        origin: limit.origin,
+      });
+    }
+    close();
+  }, [close, limit]);
+
+  if (!isOpen || !limit || limit.kind !== "evalIterations") return null;
+
+  const windowLabel = limit.windowKind === "day" ? "today" : "this month";
+  const perWindow = limit.windowKind === "day" ? "a day" : "a month";
+
+  // An org already on a paid plan can hit its own ceiling. Naming "Free" there
+  // would be wrong, and so would pitching the plan they're already on.
+  const isFreePlan = upgrade.currentPlan === "free";
+  const planName = isFreePlan ? "Free" : "Your plan";
+  const planSentence =
+    limit.allowed != null
+      ? `${planName} includes ${formatCount(limit.allowed)} ${perWindow}, and `
+      : "";
+  const resetDistance = limit.resetsAt
+    ? formatResetDistance(limit.resetsAt)
+    : null;
+  const resetSentence = limit.resetsAt
+    ? `${planSentence ? "yours reset" : "Yours reset"} at ${formatResetClock(
+        limit.resetsAt,
+      )}${resetDistance ? `, ${resetDistance} from now` : ""}.`
+    : "";
+
+  const showUpgrade = isFreePlan && upgrade.canManageBilling;
+  // A paid org at its own ceiling has no self-serve step left, so it gets the
+  // sales path instead of a checkout button.
+  const showEnterprise = !isFreePlan && upgrade.currentPlan !== "enterprise";
+  // The eval figure comes from the plan catalog, never a hardcoded string, so
+  // it tracks whatever billing actually enforces. Credits deliberately have no
+  // figure: they aren't in the catalog, so the only source would be the
+  // hardcoded marketing table, which is exactly what goes stale.
+  const upgradeSentence = isFreePlan
+    ? `Our ${upgrade.teamName} plan includes ${
+        upgrade.teamEvalIterations
+          ? `${formatCount(upgrade.teamEvalIterations)} a month`
+          : "a monthly allowance instead of a daily cap"
+      }, so evals can run smoothly on every PR instead of limiting your daily quality checks.`
+    : showEnterprise
+      ? "Enterprise adds negotiated usage and a custom LLM budget."
+      : "";
+
+  return (
+    <Dialog
+      open
+      onOpenChange={(next) => {
+        if (!next) handleDismiss();
+      }}
+    >
+      <DialogContent className="sm:max-w-md">
+        <DialogHeader>
+          <DialogTitle>
+            You're out of eval iterations {windowLabel}
+          </DialogTitle>
+          <DialogDescription data-testid="plan-limit-dialog-description">
+            {`${planSentence}${resetSentence} ${upgradeSentence}`.trim()}
+            {isFreePlan && !upgrade.canManageBilling
+              ? " Only an organization owner or admin can upgrade."
+              : ""}
+          </DialogDescription>
+        </DialogHeader>
+        {showUpgrade ? (
+          <UpgradeIntervalPicker
+            interval={upgrade.interval}
+            onIntervalChange={upgrade.setInterval}
+            priceLabel={upgrade.priceLabel}
+            annualDiscountPct={upgrade.annualDiscountPct}
+            annualSupported={upgrade.annualSupported}
+            monthlySupported={upgrade.monthlySupported}
+            teamName={upgrade.teamName}
+            isStarting={upgrade.isStarting}
+            onUpgrade={() => void upgrade.start()}
+          />
+        ) : null}
+        {showEnterprise ? (
+          <DialogFooter>
+            <Button
+              type="button"
+              onClick={handleRequestUpgrade}
+              data-testid="plan-limit-enterprise-cta"
+            >
+              Request upgrade
+            </Button>
+          </DialogFooter>
+        ) : null}
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/mcpjam-inspector/client/src/components/billing/PlanLimitDialog.tsx
+++ b/mcpjam-inspector/client/src/components/billing/PlanLimitDialog.tsx
@@ -283,6 +283,11 @@ export function PlanLimitDialog() {
     upgrade.effectivePlan,
   ]);
 
+  const handleUpgrade = useCallback(async () => {
+    const result = await upgrade.start();
+    if (result?.shouldDismiss) close();
+  }, [close, upgrade]);
+
   if (!isOpen || !limit || limit.kind !== "evalIterations") return null;
 
   const windowLabel = limit.windowKind === "day" ? "today" : "this month";
@@ -316,7 +321,7 @@ export function PlanLimitDialog() {
   const upgradeSentence = isFreePlan
     ? `Our ${upgrade.teamName} plan includes ${
         upgrade.teamEvalIterations
-          ? `${formatCount(upgrade.teamEvalIterations)} a month`
+          ? `${formatCount(upgrade.teamEvalIterations)} per seat each month`
           : "a monthly allowance instead of a daily cap"
       }, so evals can run smoothly on every PR instead of limiting your daily quality checks.`
     : showEnterprise
@@ -347,7 +352,7 @@ export function PlanLimitDialog() {
       monthlySupported={upgrade.monthlySupported}
       teamName={upgrade.teamName}
       isStarting={upgrade.isStarting}
-      onUpgrade={() => void upgrade.start()}
+      onUpgrade={() => void handleUpgrade()}
       onRequestEnterprise={handleRequestEnterprise}
       onDismiss={handleDismiss}
     />

--- a/mcpjam-inspector/client/src/components/billing/PlanLimitDialog.tsx
+++ b/mcpjam-inspector/client/src/components/billing/PlanLimitDialog.tsx
@@ -1,13 +1,4 @@
 import { useCallback, useEffect, useRef, useState } from "react";
-import { Button } from "@mcpjam/design-system/button";
-import {
-  Dialog,
-  DialogContent,
-  DialogDescription,
-  DialogFooter,
-  DialogHeader,
-  DialogTitle,
-} from "@mcpjam/design-system/dialog";
 import { useOrganizationBilling } from "@/hooks/useOrganizationBilling";
 import {
   UPGRADE_RETURN_ORG_PARAM,
@@ -19,7 +10,8 @@ import {
 import { track } from "@/lib/analytics";
 import { toast } from "@/lib/toast";
 import { usePlanLimitDialogStore } from "@/stores/plan-limit-dialog-store";
-import { UpgradeIntervalPicker } from "@/components/billing/UpgradeIntervalPicker";
+import { useUpgradeRequestRecipients } from "@/hooks/use-upgrade-request-recipients";
+import { PlanLimitDialogView } from "@/components/billing/PlanLimitDialogView";
 
 /** Same destination as the pricing page's Enterprise CTA. */
 const ENTERPRISE_CONTACT_URL = "https://www.mcpjam.com/contact";
@@ -145,11 +137,13 @@ export function PlanLimitDialog() {
   const limit = usePlanLimitDialogStore((s) => s.limit);
   const close = usePlanLimitDialogStore((s) => s.close);
 
+  const organizationId = limit?.organizationId ?? null;
   const upgrade = useUpgradeCheckout({
-    organizationId: limit?.organizationId ?? null,
+    organizationId,
     origin: "evals",
     limitKind: limit?.kind ?? "evalIterations",
   });
+  const requestRecipients = useUpgradeRequestRecipients(organizationId);
 
   useEffect(() => {
     if (!isOpen || !limit) return;
@@ -166,7 +160,7 @@ export function PlanLimitDialog() {
   // New tab, not a same-tab navigation or a mailto. The user is mid-task with a
   // blocked eval run; sending them away from the app (or into a mail client
   // that may not be configured) loses their place for no reason.
-  const handleRequestUpgrade = useCallback(() => {
+  const handleRequestEnterprise = useCallback(() => {
     track("plan_limit_enterprise_cta_clicked", {
       location: "plan_limit_dialog",
       limit_kind: limit?.kind ?? "evalIterations",
@@ -229,48 +223,31 @@ export function PlanLimitDialog() {
       : "";
 
   return (
-    <Dialog
-      open
-      onOpenChange={(next) => {
-        if (!next) handleDismiss();
-      }}
-    >
-      <DialogContent className="sm:max-w-md">
-        <DialogHeader>
-          <DialogTitle>
-            You're out of eval iterations {windowLabel}
-          </DialogTitle>
-          <DialogDescription data-testid="plan-limit-dialog-description">
-            {`${planSentence}${resetSentence} ${upgradeSentence}`.trim()}
-            {isFreePlan && !upgrade.canManageBilling
-              ? " Only an organization owner or admin can upgrade."
-              : ""}
-          </DialogDescription>
-        </DialogHeader>
-        {showUpgrade ? (
-          <UpgradeIntervalPicker
-            annualPriceLabel={upgrade.annualPriceLabel}
-            monthlyPriceLabel={upgrade.monthlyPriceLabel}
-            annualDiscountPct={upgrade.annualDiscountPct}
-            annualSupported={upgrade.annualSupported}
-            monthlySupported={upgrade.monthlySupported}
-            teamName={upgrade.teamName}
-            isStarting={upgrade.isStarting}
-            onUpgrade={(interval) => void upgrade.start(interval)}
-          />
-        ) : null}
-        {showEnterprise ? (
-          <DialogFooter>
-            <Button
-              type="button"
-              onClick={handleRequestUpgrade}
-              data-testid="plan-limit-enterprise-cta"
-            >
-              Request upgrade
-            </Button>
-          </DialogFooter>
-        ) : null}
-      </DialogContent>
-    </Dialog>
+    <PlanLimitDialogView
+      title={`You're out of eval iterations ${windowLabel}`}
+      description={`${`${planSentence}${resetSentence} ${upgradeSentence}`.trim()}${
+        isFreePlan && !upgrade.canManageBilling
+          ? " Only an organization owner can upgrade."
+          : ""
+      }`}
+      showUpgrade={showUpgrade}
+      showEnterprise={showEnterprise}
+      requestRecipients={requestRecipients}
+      organizationName={upgrade.organizationName}
+      origin="evals"
+      limitKind={limit.kind}
+      interval={upgrade.interval}
+      onIntervalChange={upgrade.setInterval}
+      annualPriceLabel={upgrade.annualPriceLabel}
+      monthlyPriceLabel={upgrade.monthlyPriceLabel}
+      annualDiscountPct={upgrade.annualDiscountPct}
+      annualSupported={upgrade.annualSupported}
+      monthlySupported={upgrade.monthlySupported}
+      teamName={upgrade.teamName}
+      isStarting={upgrade.isStarting}
+      onUpgrade={() => void upgrade.start()}
+      onRequestEnterprise={handleRequestEnterprise}
+      onDismiss={handleDismiss}
+    />
   );
 }

--- a/mcpjam-inspector/client/src/components/billing/PlanLimitDialog.tsx
+++ b/mcpjam-inspector/client/src/components/billing/PlanLimitDialog.tsx
@@ -143,7 +143,8 @@ export function PlanLimitDialog() {
     origin: "evals",
     limitKind: limit?.kind ?? "evalIterations",
   });
-  const requestRecipients = useUpgradeRequestRecipients(organizationId);
+  const { recipients: requestRecipients, isLoading: isLoadingRecipients } =
+    useUpgradeRequestRecipients(organizationId);
 
   useEffect(() => {
     if (!isOpen || !limit) return;
@@ -227,12 +228,13 @@ export function PlanLimitDialog() {
       title={`You're out of eval iterations ${windowLabel}`}
       description={`${`${planSentence}${resetSentence} ${upgradeSentence}`.trim()}${
         isFreePlan && !upgrade.canManageBilling
-          ? " Only an organization owner can upgrade."
+          ? " Only an owner can upgrade this organization."
           : ""
       }`}
       showUpgrade={showUpgrade}
       showEnterprise={showEnterprise}
       requestRecipients={requestRecipients}
+      isLoadingRecipients={isLoadingRecipients}
       organizationName={upgrade.organizationName}
       origin="evals"
       limitKind={limit.kind}

--- a/mcpjam-inspector/client/src/components/billing/PlanLimitDialog.tsx
+++ b/mcpjam-inspector/client/src/components/billing/PlanLimitDialog.tsx
@@ -80,7 +80,7 @@ function stripUpgradeReturnParams(): void {
     "",
     window.location.pathname +
       (search ? `?${search}` : "") +
-      window.location.hash,
+      window.location.hash
   );
 }
 
@@ -94,7 +94,7 @@ function stripUpgradeReturnParams(): void {
  */
 function useUpgradeReturnFlow(): void {
   const [upgradeReturn] = useState<UpgradeReturn | null>(() =>
-    readUpgradeReturn(),
+    readUpgradeReturn()
   );
   const [settlementGraceElapsed, setSettlementGraceElapsed] = useState(false);
   const handledRef = useRef(false);
@@ -132,7 +132,7 @@ function useUpgradeReturnFlow(): void {
       toast.success(
         upgradeReturn.origin === "credits"
           ? `You're on our ${teamName} plan. Your credits are available now.`
-          : `You're on our ${teamName} plan. Run your suite again to pick up where you left off.`,
+          : `You're on our ${teamName} plan. Run your suite again to pick up where you left off.`
       );
     }
 
@@ -192,11 +192,11 @@ export function PlanLimitDialog() {
       location: "plan_limit_dialog",
       limit_kind: limit?.kind ?? "evalIterations",
       origin: limit?.origin,
-      plan: upgrade.currentPlan,
+      plan: upgrade.effectivePlan,
     });
     window.open(ENTERPRISE_CONTACT_URL, "_blank", "noopener,noreferrer");
     close();
-  }, [close, limit, upgrade.currentPlan]);
+  }, [close, limit, upgrade.effectivePlan]);
 
   const handleDismiss = useCallback(() => {
     if (limit) {
@@ -216,7 +216,7 @@ export function PlanLimitDialog() {
 
   // An org already on a paid plan can hit its own ceiling. Naming "Free" there
   // would be wrong, and so would pitching the plan they're already on.
-  const isFreePlan = upgrade.currentPlan === "free";
+  const isFreePlan = upgrade.effectivePlan === "free";
   const planName = isFreePlan ? "Free" : "Your plan";
   const planSentence =
     limit.allowed != null
@@ -227,14 +227,14 @@ export function PlanLimitDialog() {
     : null;
   const resetSentence = limit.resetsAt
     ? `${planSentence ? "yours reset" : "Yours reset"} at ${formatResetClock(
-        limit.resetsAt,
+        limit.resetsAt
       )}${resetDistance ? `, ${resetDistance} from now` : ""}.`
     : "";
 
   const showUpgrade = isFreePlan && upgrade.canManageBilling;
   // A paid org at its own ceiling has no self-serve step left, so it gets the
   // sales path instead of a checkout button.
-  const showEnterprise = !isFreePlan && upgrade.currentPlan !== "enterprise";
+  const showEnterprise = !isFreePlan && upgrade.effectivePlan !== "enterprise";
   // The eval figure comes from the plan catalog, never a hardcoded string, so
   // it tracks whatever billing actually enforces. Credits deliberately have no
   // figure: they aren't in the catalog, so the only source would be the
@@ -246,8 +246,8 @@ export function PlanLimitDialog() {
           : "a monthly allowance instead of a daily cap"
       }, so evals can run smoothly on every PR instead of limiting your daily quality checks.`
     : showEnterprise
-      ? "Enterprise adds negotiated usage and a custom LLM budget."
-      : "";
+    ? "Enterprise adds negotiated usage and a custom LLM budget."
+    : "";
 
   return (
     <PlanLimitDialogView

--- a/mcpjam-inspector/client/src/components/billing/PlanLimitDialog.tsx
+++ b/mcpjam-inspector/client/src/components/billing/PlanLimitDialog.tsx
@@ -175,7 +175,10 @@ export function PlanLimitDialog() {
     origin: "evals",
     limitKind: limit?.kind ?? "evalIterations",
   });
-  const requestRecipients = useUpgradeRequestRecipients(organizationId);
+  const {
+    recipients: requestRecipients,
+    isLoading: isLoadingRequestRecipients,
+  } = useUpgradeRequestRecipients(organizationId);
 
   useEffect(() => {
     if (!isOpen || !limit) {
@@ -188,6 +191,9 @@ export function PlanLimitDialog() {
     const showUpgrade = isFreePlan && upgrade.canManageBilling;
     const showEnterprise =
       !isFreePlan && upgrade.effectivePlan !== "enterprise";
+    const showRequest = !showUpgrade && !showEnterprise;
+    if (showRequest && isLoadingRequestRecipients) return;
+
     impressionTrackedRef.current = true;
     track("plan_limit_dialog_shown", {
       location: "plan_limit_dialog",
@@ -216,6 +222,7 @@ export function PlanLimitDialog() {
     });
   }, [
     isOpen,
+    isLoadingRequestRecipients,
     limit,
     organizationId,
     requestRecipients.length,

--- a/mcpjam-inspector/client/src/components/billing/PlanLimitDialog.tsx
+++ b/mcpjam-inspector/client/src/components/billing/PlanLimitDialog.tsx
@@ -16,6 +16,12 @@ import { PlanLimitDialogView } from "@/components/billing/PlanLimitDialogView";
 /** Same destination as the pricing page's Enterprise CTA. */
 const ENTERPRISE_CONTACT_URL = "https://www.mcpjam.com/contact";
 
+// Stripe redirects before its webhook-backed billing state is guaranteed to
+// have reached the client. Keep the return marker alive briefly so the reactive
+// billing query can observe a successful plan change before we classify a
+// still-Free result as an abandoned checkout.
+const UPGRADE_RETURN_SETTLEMENT_GRACE_MS = 30_000;
+
 function formatCount(value: number): string {
   return new Intl.NumberFormat().format(value);
 }
@@ -90,17 +96,37 @@ function useUpgradeReturnFlow(): void {
   const [upgradeReturn] = useState<UpgradeReturn | null>(() =>
     readUpgradeReturn(),
   );
+  const [settlementGraceElapsed, setSettlementGraceElapsed] = useState(false);
   const handledRef = useRef(false);
   const { billingStatus, planCatalog, isLoadingBilling } =
     useOrganizationBilling(upgradeReturn?.organizationId ?? null);
 
   useEffect(() => {
+    if (
+      !upgradeReturn ||
+      handledRef.current ||
+      isLoadingBilling ||
+      billingStatus?.plan !== "free"
+    ) {
+      return;
+    }
+
+    const timeoutId = window.setTimeout(() => {
+      setSettlementGraceElapsed(true);
+    }, UPGRADE_RETURN_SETTLEMENT_GRACE_MS);
+    return () => window.clearTimeout(timeoutId);
+  }, [billingStatus?.plan, isLoadingBilling, upgradeReturn]);
+
+  useEffect(() => {
     if (!upgradeReturn || handledRef.current) return;
     if (isLoadingBilling || !billingStatus) return;
+
+    const upgraded = billingStatus.plan !== "free";
+    if (!upgraded && !settlementGraceElapsed) return;
+
     handledRef.current = true;
     stripUpgradeReturnParams();
 
-    const upgraded = billingStatus.plan !== "free";
     if (upgraded) {
       const teamName = planCatalog?.plans.team.displayName ?? "Team";
       toast.success(
@@ -121,6 +147,7 @@ function useUpgradeReturnFlow(): void {
     billingStatus,
     isLoadingBilling,
     planCatalog,
+    settlementGraceElapsed,
     upgradeReturn,
   ]);
 }

--- a/mcpjam-inspector/client/src/components/billing/PlanLimitDialog.tsx
+++ b/mcpjam-inspector/client/src/components/billing/PlanLimitDialog.tsx
@@ -143,8 +143,7 @@ export function PlanLimitDialog() {
     origin: "evals",
     limitKind: limit?.kind ?? "evalIterations",
   });
-  const { recipients: requestRecipients, isLoading: isLoadingRecipients } =
-    useUpgradeRequestRecipients(organizationId);
+  const requestRecipients = useUpgradeRequestRecipients(organizationId);
 
   useEffect(() => {
     if (!isOpen || !limit) return;
@@ -234,7 +233,6 @@ export function PlanLimitDialog() {
       showUpgrade={showUpgrade}
       showEnterprise={showEnterprise}
       requestRecipients={requestRecipients}
-      isLoadingRecipients={isLoadingRecipients}
       organizationName={upgrade.organizationName}
       origin="evals"
       limitKind={limit.kind}

--- a/mcpjam-inspector/client/src/components/billing/PlanLimitDialogPreview.tsx
+++ b/mcpjam-inspector/client/src/components/billing/PlanLimitDialogPreview.tsx
@@ -91,24 +91,9 @@ const VARIANTS: PreviewVariant[] = [
     },
   },
   {
-    id: "owner-loading",
-    label: "Cannot upgrade, owner lookup pending",
-    note: "The members query is still in flight. A disabled button holds the space so nothing pops in late.",
-    props: {
-      ...SHARED,
-      title: "You're out of eval iterations today",
-      description:
-        "Free includes 75 a day, and yours reset at 8:00 PM, about 9 hours from now. Only an owner can upgrade this organization.",
-      showUpgrade: false,
-      showEnterprise: false,
-      requestRecipients: [],
-      isLoadingRecipients: true,
-    },
-  },
-  {
     id: "no-owner",
     label: "Cannot upgrade, no owner found",
-    note: "Lookup finished and found no reachable owner. The button hides rather than opening an empty draft.",
+    note: "No reachable owner, or the lookup hasn't returned yet. Either way there's no address to write to, so the button hides rather than opening an empty draft.",
     props: {
       ...SHARED,
       title: "You're out of eval iterations today",

--- a/mcpjam-inspector/client/src/components/billing/PlanLimitDialogPreview.tsx
+++ b/mcpjam-inspector/client/src/components/billing/PlanLimitDialogPreview.tsx
@@ -4,10 +4,14 @@ import {
   PlanLimitDialogView,
   type PlanLimitDialogViewProps,
 } from "@/components/billing/PlanLimitDialogView";
+import {
+  CreditsLimitDialogView,
+  type CreditsLimitDialogViewProps,
+} from "@/components/billing/CreditsLimitDialogView";
 
 /**
- * Dev-only harness for the eval-iteration wall, reachable at
- * `/__preview/plan-limit` while the dev server runs.
+ * Dev-only harness for both free-plan walls (eval iterations and credits),
+ * reachable at `/__preview/plan-limit` while the dev server runs.
  *
  * Mounted from `main.tsx` BEFORE the auth and Convex providers, so it needs no
  * sign-in, no hosted org, and no organization sitting at its cap — states that
@@ -19,18 +23,30 @@ import {
  * call site in `main.tsx`.
  */
 
+type SharedHandlers =
+  | "interval"
+  | "onIntervalChange"
+  | "onUpgrade"
+  | "onDismiss"
+  | "modal";
+
 type PreviewVariant = {
   id: string;
   label: string;
   note: string;
   props: Omit<
     PlanLimitDialogViewProps,
-    | "interval"
-    | "onIntervalChange"
-    | "onUpgrade"
-    | "onRequestEnterprise"
-    | "onDismiss"
-    | "modal"
+    SharedHandlers | "onRequestEnterprise"
+  >;
+};
+
+type CreditsVariant = {
+  id: string;
+  label: string;
+  note: string;
+  props: Omit<
+    CreditsLimitDialogViewProps,
+    SharedHandlers | "onBuyCredits" | "onUseOwnKey"
   >;
 };
 
@@ -106,35 +122,127 @@ const VARIANTS: PreviewVariant[] = [
   },
 ];
 
+const CREDITS_SHARED = {
+  organizationName: "Acme Robotics",
+  annualPriceLabel: "$30",
+  monthlyPriceLabel: "$38",
+  annualDiscountPct: 21,
+  annualSupported: true,
+  monthlySupported: true,
+  teamName: "Team",
+  isStarting: false,
+};
+
+const CREDITS_VARIANTS: CreditsVariant[] = [
+  {
+    id: "credits-free-owner",
+    label: "Free, can upgrade",
+    note: "Upgrade leads. Buying credits stays available one step down, and bring-your-own-key drops to a link, because both of those keep the org on Free.",
+    props: {
+      ...CREDITS_SHARED,
+      description:
+        "Free credits reset daily. Our Team plan replaces the daily cap with a monthly allowance per seat, so usage isn't rationed day to day.",
+      isKnownNonManager: false,
+      showUpgrade: true,
+      requestRecipients: [],
+    },
+  },
+  {
+    id: "credits-paid",
+    label: "Paid plan, out of credits",
+    note: "Already on Team, so there is no plan to pitch. Credits are the actual answer here.",
+    props: {
+      ...CREDITS_SHARED,
+      description: "Buy credits to keep your team going, or use your own API key.",
+      isKnownNonManager: false,
+      showUpgrade: false,
+      requestRecipients: [],
+    },
+  },
+  {
+    id: "credits-member",
+    label: "Member, cannot buy or upgrade",
+    note: "Can do neither, so the only action is asking someone who can.",
+    props: {
+      ...CREDITS_SHARED,
+      description:
+        "Ask an organization owner or admin to buy credits or upgrade the plan.",
+      isKnownNonManager: true,
+      showUpgrade: false,
+      requestRecipients: [{ email: "dana@acmerobotics.com", name: "Dana Ruiz" }],
+    },
+  },
+];
+
+const WALLS = [
+  { id: "evals" as const, label: "Eval iterations" },
+  { id: "credits" as const, label: "Credits" },
+];
+
 export function PlanLimitDialogPreview() {
+  const [wall, setWall] = useState<"evals" | "credits">("evals");
   const [variantId, setVariantId] = useState(VARIANTS[0].id);
+  const [creditsVariantId, setCreditsVariantId] = useState(
+    CREDITS_VARIANTS[0].id,
+  );
   const [interval, setInterval] = useState<BillingInterval>("annual");
   const [lastAction, setLastAction] = useState<string | null>(null);
   const variant = VARIANTS.find((v) => v.id === variantId) ?? VARIANTS[0];
+  const creditsVariant =
+    CREDITS_VARIANTS.find((v) => v.id === creditsVariantId) ??
+    CREDITS_VARIANTS[0];
+  const activeVariants = wall === "evals" ? VARIANTS : CREDITS_VARIANTS;
+  const activeVariantId = wall === "evals" ? variantId : creditsVariantId;
+  const setActiveVariantId = wall === "evals" ? setVariantId : setCreditsVariantId;
+  const activeNote = wall === "evals" ? variant.note : creditsVariant.note;
 
   return (
     <div className="min-h-screen bg-background p-6 text-foreground">
       <div className="mx-auto max-w-2xl space-y-4">
         <div>
           <h1 className="text-lg font-semibold tracking-tight">
-            Eval limit wall preview
+            Limit wall preview
           </h1>
           <p className="text-sm text-muted-foreground">
-            Real component, real styles, dummy data. Dev only.
+            Real components, real styles, dummy data. Dev only.
           </p>
         </div>
 
+        <div
+          role="group"
+          aria-label="Wall"
+          className="inline-flex items-center gap-0.5 rounded-md border border-border/60 bg-muted/40 p-0.5 text-xs"
+        >
+          {WALLS.map((w) => (
+            <button
+              key={w.id}
+              type="button"
+              onClick={() => {
+                setWall(w.id);
+                setLastAction(null);
+              }}
+              className={
+                w.id === wall
+                  ? "rounded bg-background px-3 py-1 font-medium shadow-sm"
+                  : "rounded px-3 py-1 font-medium text-muted-foreground"
+              }
+            >
+              {w.label}
+            </button>
+          ))}
+        </div>
+
         <div className="flex flex-wrap gap-2">
-          {VARIANTS.map((v) => (
+          {activeVariants.map((v) => (
             <button
               key={v.id}
               type="button"
               onClick={() => {
-                setVariantId(v.id);
+                setActiveVariantId(v.id);
                 setLastAction(null);
               }}
               className={
-                v.id === variantId
+                v.id === activeVariantId
                   ? "rounded-md border border-primary bg-primary/10 px-3 py-1.5 text-sm font-medium"
                   : "rounded-md border border-border px-3 py-1.5 text-sm text-muted-foreground hover:border-foreground/40"
               }
@@ -144,7 +252,7 @@ export function PlanLimitDialogPreview() {
           ))}
         </div>
 
-        <p className="text-sm text-muted-foreground">{variant.note}</p>
+        <p className="text-sm text-muted-foreground">{activeNote}</p>
 
         <div className="rounded-md border border-border bg-muted/30 p-3 text-sm">
           <span className="text-muted-foreground">Selected interval: </span>
@@ -158,18 +266,34 @@ export function PlanLimitDialogPreview() {
         </div>
       </div>
 
-      <PlanLimitDialogView
-        key={variant.id}
-        {...variant.props}
-        modal={false}
-        interval={interval}
-        onIntervalChange={setInterval}
-        onUpgrade={() => setLastAction(`checkout would start (${interval})`)}
-        onRequestEnterprise={() =>
-          setLastAction("would open mcpjam.com/contact in a new tab")
-        }
-        onDismiss={() => setLastAction("dismissed")}
-      />
+      {wall === "evals" ? (
+        <PlanLimitDialogView
+          key={variant.id}
+          {...variant.props}
+          modal={false}
+          interval={interval}
+          onIntervalChange={setInterval}
+          onUpgrade={() => setLastAction(`checkout would start (${interval})`)}
+          onRequestEnterprise={() =>
+            setLastAction("would open mcpjam.com/contact in a new tab")
+          }
+          onDismiss={() => setLastAction("dismissed")}
+        />
+      ) : (
+        <CreditsLimitDialogView
+          key={creditsVariant.id}
+          {...creditsVariant.props}
+          modal={false}
+          interval={interval}
+          onIntervalChange={setInterval}
+          onUpgrade={() => setLastAction(`checkout would start (${interval})`)}
+          onBuyCredits={() => setLastAction("would open the buy-credits dialog")}
+          onUseOwnKey={() =>
+            setLastAction("would open the model picker's providers tab")
+          }
+          onDismiss={() => setLastAction("dismissed")}
+        />
+      )}
     </div>
   );
 }

--- a/mcpjam-inspector/client/src/components/billing/PlanLimitDialogPreview.tsx
+++ b/mcpjam-inspector/client/src/components/billing/PlanLimitDialogPreview.tsx
@@ -1,0 +1,175 @@
+import { useState } from "react";
+import type { BillingInterval } from "@/hooks/useOrganizationBilling";
+import {
+  PlanLimitDialogView,
+  type PlanLimitDialogViewProps,
+} from "@/components/billing/PlanLimitDialogView";
+
+/**
+ * Dev-only harness for the eval-iteration wall, reachable at
+ * `/__preview/plan-limit` while the dev server runs.
+ *
+ * Mounted from `main.tsx` BEFORE the auth and Convex providers, so it needs no
+ * sign-in, no hosted org, and no organization sitting at its cap — states that
+ * are otherwise impossible to reach on demand. It renders the real
+ * `PlanLimitDialogView` with the real stylesheet, so what you see is what
+ * production renders; only the data is fake.
+ *
+ * Excluded from production bundles by the `import.meta.env.DEV` guard at the
+ * call site in `main.tsx`.
+ */
+
+type PreviewVariant = {
+  id: string;
+  label: string;
+  note: string;
+  props: Omit<
+    PlanLimitDialogViewProps,
+    | "interval"
+    | "onIntervalChange"
+    | "onUpgrade"
+    | "onRequestEnterprise"
+    | "onDismiss"
+    | "modal"
+  >;
+};
+
+const SHARED = {
+  organizationName: "Acme Robotics",
+  origin: "evals" as const,
+  limitKind: "evalIterations",
+  annualPriceLabel: "$30/seat/mo",
+  monthlyPriceLabel: "$38/seat/mo",
+  annualDiscountPct: 21,
+  annualSupported: true,
+  monthlySupported: true,
+  teamName: "Team",
+  isStarting: false,
+};
+
+const VARIANTS: PreviewVariant[] = [
+  {
+    id: "free-owner",
+    label: "Free, can upgrade",
+    note: "The main case: an owner or admin on Free who just got blocked mid-suite.",
+    props: {
+      ...SHARED,
+      title: "You're out of eval iterations today",
+      description:
+        "Free includes 75 a day, and yours reset at 8:00 PM, about 9 hours from now. Our Team plan includes 5,000 a month, so evals can run smoothly on every PR instead of limiting your daily quality checks.",
+      showUpgrade: true,
+      showEnterprise: false,
+      requestRecipients: [],
+    },
+  },
+  {
+    id: "free-member",
+    label: "Free, cannot upgrade",
+    note: "A member. Cannot check out, so the action is an email to the owner with the steps.",
+    props: {
+      ...SHARED,
+      title: "You're out of eval iterations today",
+      description:
+        "Free includes 75 a day, and yours reset at 8:00 PM, about 9 hours from now. Our Team plan includes 5,000 a month, so evals can run smoothly on every PR instead of limiting your daily quality checks. Only an organization owner can upgrade.",
+      showUpgrade: false,
+      showEnterprise: false,
+      requestRecipients: [{ email: "dana@acmerobotics.com", name: "Dana Ruiz" }],
+    },
+  },
+  {
+    id: "team-ceiling",
+    label: "Team, at its ceiling",
+    note: "Already paying. No self-serve step left, so the path is sales.",
+    props: {
+      ...SHARED,
+      title: "You're out of eval iterations this month",
+      description:
+        "Your plan includes 5,000 a month, and yours reset at 12:00 AM, about 9 days from now. Enterprise adds negotiated usage and a custom LLM budget.",
+      showUpgrade: false,
+      showEnterprise: true,
+      requestRecipients: [],
+    },
+  },
+  {
+    id: "no-owner",
+    label: "Cannot upgrade, no owner found",
+    note: "Owner lookup returned nothing. The email button hides rather than opening an empty draft.",
+    props: {
+      ...SHARED,
+      title: "You're out of eval iterations today",
+      description:
+        "Free includes 75 a day, and yours reset at 8:00 PM, about 9 hours from now. Only an organization owner can upgrade.",
+      showUpgrade: false,
+      showEnterprise: false,
+      requestRecipients: [],
+    },
+  },
+];
+
+export function PlanLimitDialogPreview() {
+  const [variantId, setVariantId] = useState(VARIANTS[0].id);
+  const [interval, setInterval] = useState<BillingInterval>("annual");
+  const [lastAction, setLastAction] = useState<string | null>(null);
+  const variant = VARIANTS.find((v) => v.id === variantId) ?? VARIANTS[0];
+
+  return (
+    <div className="min-h-screen bg-background p-6 text-foreground">
+      <div className="mx-auto max-w-2xl space-y-4">
+        <div>
+          <h1 className="text-lg font-semibold tracking-tight">
+            Eval limit wall preview
+          </h1>
+          <p className="text-sm text-muted-foreground">
+            Real component, real styles, dummy data. Dev only.
+          </p>
+        </div>
+
+        <div className="flex flex-wrap gap-2">
+          {VARIANTS.map((v) => (
+            <button
+              key={v.id}
+              type="button"
+              onClick={() => {
+                setVariantId(v.id);
+                setLastAction(null);
+              }}
+              className={
+                v.id === variantId
+                  ? "rounded-md border border-primary bg-primary/10 px-3 py-1.5 text-sm font-medium"
+                  : "rounded-md border border-border px-3 py-1.5 text-sm text-muted-foreground hover:border-foreground/40"
+              }
+            >
+              {v.label}
+            </button>
+          ))}
+        </div>
+
+        <p className="text-sm text-muted-foreground">{variant.note}</p>
+
+        <div className="rounded-md border border-border bg-muted/30 p-3 text-sm">
+          <span className="text-muted-foreground">Selected interval: </span>
+          <span className="font-medium">{interval}</span>
+          {lastAction ? (
+            <>
+              <span className="text-muted-foreground"> · last action: </span>
+              <span className="font-medium">{lastAction}</span>
+            </>
+          ) : null}
+        </div>
+      </div>
+
+      <PlanLimitDialogView
+        key={variant.id}
+        {...variant.props}
+        modal={false}
+        interval={interval}
+        onIntervalChange={setInterval}
+        onUpgrade={() => setLastAction(`checkout would start (${interval})`)}
+        onRequestEnterprise={() =>
+          setLastAction("would open mcpjam.com/contact in a new tab")
+        }
+        onDismiss={() => setLastAction("dismissed")}
+      />
+    </div>
+  );
+}

--- a/mcpjam-inspector/client/src/components/billing/PlanLimitDialogPreview.tsx
+++ b/mcpjam-inspector/client/src/components/billing/PlanLimitDialogPreview.tsx
@@ -34,10 +34,7 @@ type PreviewVariant = {
   id: string;
   label: string;
   note: string;
-  props: Omit<
-    PlanLimitDialogViewProps,
-    SharedHandlers | "onRequestEnterprise"
-  >;
+  props: Omit<PlanLimitDialogViewProps, SharedHandlers | "onRequestEnterprise">;
 };
 
 type CreditsVariant = {
@@ -72,7 +69,7 @@ const VARIANTS: PreviewVariant[] = [
       ...SHARED,
       title: "You're out of eval iterations today",
       description:
-        "Free includes 75 a day, and yours reset at 8:00 PM, about 9 hours from now. Our Team plan includes 5,000 a month, so evals can run smoothly on every PR instead of limiting your daily quality checks.",
+        "Free includes 75 a day, and yours reset at 8:00 PM, about 9 hours from now. Our Team plan includes 5,000 per seat each month, so evals can run smoothly on every PR instead of limiting your daily quality checks.",
       showUpgrade: true,
       showEnterprise: false,
       requestRecipients: [],
@@ -86,10 +83,12 @@ const VARIANTS: PreviewVariant[] = [
       ...SHARED,
       title: "You're out of eval iterations today",
       description:
-        "Free includes 75 a day, and yours reset at 8:00 PM, about 9 hours from now. Our Team plan includes 5,000 a month, so evals can run smoothly on every PR instead of limiting your daily quality checks. Only an owner can upgrade this organization.",
+        "Free includes 75 a day, and yours reset at 8:00 PM, about 9 hours from now. Our Team plan includes 5,000 per seat each month, so evals can run smoothly on every PR instead of limiting your daily quality checks. Only an owner can upgrade this organization.",
       showUpgrade: false,
       showEnterprise: false,
-      requestRecipients: [{ email: "dana@acmerobotics.com", name: "Dana Ruiz" }],
+      requestRecipients: [
+        { email: "dana@acmerobotics.com", name: "Dana Ruiz" },
+      ],
     },
   },
   {
@@ -153,7 +152,8 @@ const CREDITS_VARIANTS: CreditsVariant[] = [
     note: "Already on Team, so there is no plan to pitch. Credits are the actual answer here.",
     props: {
       ...CREDITS_SHARED,
-      description: "Buy credits to keep your team going, or use your own API key.",
+      description:
+        "Buy credits to keep your team going, or use your own API key.",
       isKnownNonManager: false,
       showUpgrade: false,
       requestRecipients: [],
@@ -169,7 +169,9 @@ const CREDITS_VARIANTS: CreditsVariant[] = [
         "Ask an organization owner or admin to buy credits or upgrade the plan.",
       isKnownNonManager: true,
       showUpgrade: false,
-      requestRecipients: [{ email: "dana@acmerobotics.com", name: "Dana Ruiz" }],
+      requestRecipients: [
+        { email: "dana@acmerobotics.com", name: "Dana Ruiz" },
+      ],
     },
   },
 ];
@@ -183,7 +185,7 @@ export function PlanLimitDialogPreview() {
   const [wall, setWall] = useState<"evals" | "credits">("evals");
   const [variantId, setVariantId] = useState(VARIANTS[0].id);
   const [creditsVariantId, setCreditsVariantId] = useState(
-    CREDITS_VARIANTS[0].id,
+    CREDITS_VARIANTS[0].id
   );
   const [interval, setInterval] = useState<BillingInterval>("annual");
   const [lastAction, setLastAction] = useState<string | null>(null);
@@ -193,7 +195,8 @@ export function PlanLimitDialogPreview() {
     CREDITS_VARIANTS[0];
   const activeVariants = wall === "evals" ? VARIANTS : CREDITS_VARIANTS;
   const activeVariantId = wall === "evals" ? variantId : creditsVariantId;
-  const setActiveVariantId = wall === "evals" ? setVariantId : setCreditsVariantId;
+  const setActiveVariantId =
+    wall === "evals" ? setVariantId : setCreditsVariantId;
   const activeNote = wall === "evals" ? variant.note : creditsVariant.note;
 
   return (
@@ -287,7 +290,9 @@ export function PlanLimitDialogPreview() {
           interval={interval}
           onIntervalChange={setInterval}
           onUpgrade={() => setLastAction(`checkout would start (${interval})`)}
-          onBuyCredits={() => setLastAction("would open the buy-credits dialog")}
+          onBuyCredits={() =>
+            setLastAction("would open the buy-credits dialog")
+          }
           onUseOwnKey={() =>
             setLastAction("would open the model picker's providers tab")
           }

--- a/mcpjam-inspector/client/src/components/billing/PlanLimitDialogPreview.tsx
+++ b/mcpjam-inspector/client/src/components/billing/PlanLimitDialogPreview.tsx
@@ -38,8 +38,8 @@ const SHARED = {
   organizationName: "Acme Robotics",
   origin: "evals" as const,
   limitKind: "evalIterations",
-  annualPriceLabel: "$30/seat/mo",
-  monthlyPriceLabel: "$38/seat/mo",
+  annualPriceLabel: "$30",
+  monthlyPriceLabel: "$38",
   annualDiscountPct: 21,
   annualSupported: true,
   monthlySupported: true,
@@ -70,7 +70,7 @@ const VARIANTS: PreviewVariant[] = [
       ...SHARED,
       title: "You're out of eval iterations today",
       description:
-        "Free includes 75 a day, and yours reset at 8:00 PM, about 9 hours from now. Our Team plan includes 5,000 a month, so evals can run smoothly on every PR instead of limiting your daily quality checks. Only an organization owner can upgrade.",
+        "Free includes 75 a day, and yours reset at 8:00 PM, about 9 hours from now. Our Team plan includes 5,000 a month, so evals can run smoothly on every PR instead of limiting your daily quality checks. Only an owner can upgrade this organization.",
       showUpgrade: false,
       showEnterprise: false,
       requestRecipients: [{ email: "dana@acmerobotics.com", name: "Dana Ruiz" }],
@@ -91,14 +91,29 @@ const VARIANTS: PreviewVariant[] = [
     },
   },
   {
-    id: "no-owner",
-    label: "Cannot upgrade, no owner found",
-    note: "Owner lookup returned nothing. The email button hides rather than opening an empty draft.",
+    id: "owner-loading",
+    label: "Cannot upgrade, owner lookup pending",
+    note: "The members query is still in flight. A disabled button holds the space so nothing pops in late.",
     props: {
       ...SHARED,
       title: "You're out of eval iterations today",
       description:
-        "Free includes 75 a day, and yours reset at 8:00 PM, about 9 hours from now. Only an organization owner can upgrade.",
+        "Free includes 75 a day, and yours reset at 8:00 PM, about 9 hours from now. Only an owner can upgrade this organization.",
+      showUpgrade: false,
+      showEnterprise: false,
+      requestRecipients: [],
+      isLoadingRecipients: true,
+    },
+  },
+  {
+    id: "no-owner",
+    label: "Cannot upgrade, no owner found",
+    note: "Lookup finished and found no reachable owner. The button hides rather than opening an empty draft.",
+    props: {
+      ...SHARED,
+      title: "You're out of eval iterations today",
+      description:
+        "Free includes 75 a day, and yours reset at 8:00 PM, about 9 hours from now. Only an owner can upgrade this organization.",
       showUpgrade: false,
       showEnterprise: false,
       requestRecipients: [],

--- a/mcpjam-inspector/client/src/components/billing/PlanLimitDialogView.tsx
+++ b/mcpjam-inspector/client/src/components/billing/PlanLimitDialogView.tsx
@@ -24,7 +24,6 @@ export interface PlanLimitDialogViewProps {
   showEnterprise: boolean;
   /** Owner-request path: free orgs whose user can't manage billing. */
   requestRecipients: UpgradeRequestRecipient[];
-  isLoadingRecipients?: boolean;
   organizationName: string;
   origin: UpgradeOrigin;
   limitKind: string;
@@ -60,7 +59,6 @@ export function PlanLimitDialogView({
   showUpgrade,
   showEnterprise,
   requestRecipients,
-  isLoadingRecipients = false,
   organizationName,
   origin,
   limitKind,
@@ -129,7 +127,6 @@ export function PlanLimitDialogView({
         {showRequest ? (
           <RequestUpgradeButton
             recipients={requestRecipients}
-            isLoadingRecipients={isLoadingRecipients}
             organizationName={organizationName}
             teamName={teamName}
             origin={origin}

--- a/mcpjam-inspector/client/src/components/billing/PlanLimitDialogView.tsx
+++ b/mcpjam-inspector/client/src/components/billing/PlanLimitDialogView.tsx
@@ -24,6 +24,7 @@ export interface PlanLimitDialogViewProps {
   showEnterprise: boolean;
   /** Owner-request path: free orgs whose user can't manage billing. */
   requestRecipients: UpgradeRequestRecipient[];
+  isLoadingRecipients?: boolean;
   organizationName: string;
   origin: UpgradeOrigin;
   limitKind: string;
@@ -59,6 +60,7 @@ export function PlanLimitDialogView({
   showUpgrade,
   showEnterprise,
   requestRecipients,
+  isLoadingRecipients = false,
   organizationName,
   origin,
   limitKind,
@@ -89,7 +91,13 @@ export function PlanLimitDialogView({
       <DialogContent className="sm:max-w-md">
         <DialogHeader>
           <DialogTitle>{title}</DialogTitle>
-          <DialogDescription data-testid="plan-limit-dialog-description">
+          {/* text-pretty keeps the last line from stranding a single word
+              ("upgrade." on its own), which no amount of copy tuning fixes
+              across every viewport width. */}
+          <DialogDescription
+            className="text-pretty"
+            data-testid="plan-limit-dialog-description"
+          >
             {description}
           </DialogDescription>
         </DialogHeader>
@@ -121,6 +129,7 @@ export function PlanLimitDialogView({
         {showRequest ? (
           <RequestUpgradeButton
             recipients={requestRecipients}
+            isLoadingRecipients={isLoadingRecipients}
             organizationName={organizationName}
             teamName={teamName}
             origin={origin}

--- a/mcpjam-inspector/client/src/components/billing/PlanLimitDialogView.tsx
+++ b/mcpjam-inspector/client/src/components/billing/PlanLimitDialogView.tsx
@@ -1,0 +1,133 @@
+import { Button } from "@mcpjam/design-system/button";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@mcpjam/design-system/dialog";
+import type { BillingInterval } from "@/hooks/useOrganizationBilling";
+import type { UpgradeOrigin } from "@/hooks/use-upgrade-checkout";
+import { UpgradeIntervalPicker } from "@/components/billing/UpgradeIntervalPicker";
+import {
+  RequestUpgradeButton,
+  type UpgradeRequestRecipient,
+} from "@/components/billing/RequestUpgradeButton";
+
+export interface PlanLimitDialogViewProps {
+  title: string;
+  description: string;
+  /** Self-serve checkout: free orgs whose user can manage billing. */
+  showUpgrade: boolean;
+  /** Sales path: paid orgs below Enterprise that hit their own ceiling. */
+  showEnterprise: boolean;
+  /** Owner-request path: free orgs whose user can't manage billing. */
+  requestRecipients: UpgradeRequestRecipient[];
+  organizationName: string;
+  origin: UpgradeOrigin;
+  limitKind: string;
+  interval: BillingInterval;
+  onIntervalChange: (interval: BillingInterval) => void;
+  annualPriceLabel: string | null;
+  monthlyPriceLabel: string | null;
+  annualDiscountPct: number;
+  annualSupported: boolean;
+  monthlySupported: boolean;
+  teamName: string;
+  isStarting: boolean;
+  onUpgrade: () => void;
+  onRequestEnterprise: () => void;
+  onDismiss: () => void;
+  /**
+   * Escape hatch for the dev preview only. Non-modal drops the overlay and the
+   * body pointer-events lock so the preview's own variant switcher stays
+   * clickable behind the dialog. Production always renders modal.
+   */
+  modal?: boolean;
+}
+
+/**
+ * Presentation for the eval-iteration wall, with no data dependencies, so the
+ * dev preview at `/__preview/plan-limit` can render every variant with dummy
+ * props and no Convex client. `PlanLimitDialog` owns the data and the copy
+ * assembly.
+ */
+export function PlanLimitDialogView({
+  title,
+  description,
+  showUpgrade,
+  showEnterprise,
+  requestRecipients,
+  organizationName,
+  origin,
+  limitKind,
+  interval,
+  onIntervalChange,
+  annualPriceLabel,
+  monthlyPriceLabel,
+  annualDiscountPct,
+  annualSupported,
+  monthlySupported,
+  teamName,
+  isStarting,
+  onUpgrade,
+  onRequestEnterprise,
+  onDismiss,
+  modal = true,
+}: PlanLimitDialogViewProps) {
+  const showRequest = !showUpgrade && !showEnterprise;
+
+  return (
+    <Dialog
+      open
+      modal={modal}
+      onOpenChange={(next) => {
+        if (!next) onDismiss();
+      }}
+    >
+      <DialogContent className="sm:max-w-md">
+        <DialogHeader>
+          <DialogTitle>{title}</DialogTitle>
+          <DialogDescription data-testid="plan-limit-dialog-description">
+            {description}
+          </DialogDescription>
+        </DialogHeader>
+        {showUpgrade ? (
+          <UpgradeIntervalPicker
+            interval={interval}
+            onIntervalChange={onIntervalChange}
+            annualPriceLabel={annualPriceLabel}
+            monthlyPriceLabel={monthlyPriceLabel}
+            annualDiscountPct={annualDiscountPct}
+            annualSupported={annualSupported}
+            monthlySupported={monthlySupported}
+            teamName={teamName}
+            isStarting={isStarting}
+            onUpgrade={onUpgrade}
+          />
+        ) : null}
+        {showEnterprise ? (
+          <DialogFooter>
+            <Button
+              type="button"
+              onClick={onRequestEnterprise}
+              data-testid="plan-limit-enterprise-cta"
+            >
+              Request upgrade
+            </Button>
+          </DialogFooter>
+        ) : null}
+        {showRequest ? (
+          <RequestUpgradeButton
+            recipients={requestRecipients}
+            organizationName={organizationName}
+            teamName={teamName}
+            origin={origin}
+            limitKind={limitKind}
+          />
+        ) : null}
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/mcpjam-inspector/client/src/components/billing/PlanLimitDialogView.tsx
+++ b/mcpjam-inspector/client/src/components/billing/PlanLimitDialogView.tsx
@@ -24,6 +24,7 @@ export interface PlanLimitDialogViewProps {
   showEnterprise: boolean;
   /** Owner-request path: free orgs whose user can't manage billing. */
   requestRecipients: UpgradeRequestRecipient[];
+  organizationId?: string | null;
   organizationName: string;
   origin: UpgradeOrigin;
   limitKind: string;
@@ -59,6 +60,7 @@ export function PlanLimitDialogView({
   showUpgrade,
   showEnterprise,
   requestRecipients,
+  organizationId,
   organizationName,
   origin,
   limitKind,
@@ -131,6 +133,7 @@ export function PlanLimitDialogView({
             teamName={teamName}
             origin={origin}
             limitKind={limitKind}
+            organizationId={organizationId}
           />
         ) : null}
       </DialogContent>

--- a/mcpjam-inspector/client/src/components/billing/RequestUpgradeButton.tsx
+++ b/mcpjam-inspector/client/src/components/billing/RequestUpgradeButton.tsx
@@ -36,8 +36,8 @@ export function buildUpgradeRequestMail(params: {
   const blocked = isCreditPurchase
     ? "Our organization has run out of MCPJam credits."
     : origin === "credits"
-      ? "I've run out of credits on MCPJam and can't keep using the models until they reset."
-      : "I've hit the free plan's eval iteration limit on MCPJam and can't run evals until it resets.";
+    ? "I've run out of credits on MCPJam and can't keep using the models until they reset."
+    : "I've hit the free plan's eval iteration limit on MCPJam and can't run evals until it resets.";
 
   const subject = isCreditPurchase
     ? `Credit purchase request for ${organizationName}`
@@ -69,7 +69,7 @@ export function buildUpgradeRequestMail(params: {
   ].join("\n");
 
   return `mailto:${to.join(",")}?subject=${encodeURIComponent(
-    subject,
+    subject
   )}&body=${encodeURIComponent(body)}`;
 }
 
@@ -80,6 +80,7 @@ interface RequestUpgradeButtonProps {
   origin: UpgradeOrigin;
   limitKind: string;
   requestAction?: UpgradeRequestAction;
+  organizationId?: string | null;
 }
 
 /**
@@ -103,6 +104,7 @@ export function RequestUpgradeButton({
   origin,
   limitKind,
   requestAction = "upgrade",
+  organizationId,
 }: RequestUpgradeButtonProps) {
   const href = buildUpgradeRequestMail({
     recipients,
@@ -124,11 +126,18 @@ export function RequestUpgradeButton({
           href={href}
           data-testid="request-upgrade-mail"
           onClick={() => {
+            // This is synchronous and failure-isolated, so the browser never
+            // waits for analytics before opening the mail client.
             track("plan_limit_upgrade_requested", {
               location: "plan_limit_dialog",
               limit_kind: limitKind,
               origin,
+              organization_id: organizationId,
               recipient_count: recipients.length,
+              has_named_recipient: recipients.some((recipient) =>
+                Boolean(recipient.name?.trim())
+              ),
+              request_action: requestAction,
             });
           }}
         >

--- a/mcpjam-inspector/client/src/components/billing/RequestUpgradeButton.tsx
+++ b/mcpjam-inspector/client/src/components/billing/RequestUpgradeButton.tsx
@@ -50,9 +50,6 @@ export function buildUpgradeRequestMail(params: {
 
 interface RequestUpgradeButtonProps {
   recipients: UpgradeRequestRecipient[];
-  /** Owner lookup still in flight. Holds a disabled button in place rather
-   * than letting one appear a beat after the dialog opens. */
-  isLoadingRecipients?: boolean;
   organizationName: string;
   teamName: string;
   origin: UpgradeOrigin;
@@ -75,20 +72,11 @@ interface RequestUpgradeButtonProps {
  */
 export function RequestUpgradeButton({
   recipients,
-  isLoadingRecipients = false,
   organizationName,
   teamName,
   origin,
   limitKind,
 }: RequestUpgradeButtonProps) {
-  if (isLoadingRecipients) {
-    return (
-      <Button type="button" className="w-full" disabled>
-        Email your owner
-      </Button>
-    );
-  }
-
   const href = buildUpgradeRequestMail({
     recipients,
     organizationName,

--- a/mcpjam-inspector/client/src/components/billing/RequestUpgradeButton.tsx
+++ b/mcpjam-inspector/client/src/components/billing/RequestUpgradeButton.tsx
@@ -132,7 +132,7 @@ export function RequestUpgradeButton({
             });
           }}
         >
-          Email your owner
+          Email your plan's owner
         </a>
       </Button>
       <p className="text-xs text-muted-foreground">

--- a/mcpjam-inspector/client/src/components/billing/RequestUpgradeButton.tsx
+++ b/mcpjam-inspector/client/src/components/billing/RequestUpgradeButton.tsx
@@ -7,38 +7,63 @@ export interface UpgradeRequestRecipient {
   name?: string | null;
 }
 
+export type UpgradeRequestAction = "upgrade" | "buyCredits";
+
 /**
- * Builds the owner-facing upgrade request. Exported so a test can assert the
- * body without reading it off a URL-encoded href by eye.
+ * Builds the owner-facing request. Exported so a test can assert the body
+ * without reading it off a URL-encoded href by eye.
  */
 export function buildUpgradeRequestMail(params: {
   recipients: UpgradeRequestRecipient[];
   organizationName: string;
   teamName: string;
   origin: UpgradeOrigin;
+  requestAction?: UpgradeRequestAction;
 }): string | null {
-  const { recipients, organizationName, teamName, origin } = params;
+  const {
+    recipients,
+    organizationName,
+    teamName,
+    origin,
+    requestAction = "upgrade",
+  } = params;
   const to = recipients.map((r) => r.email).filter(Boolean);
   if (to.length === 0) return null;
 
   const firstName = recipients[0]?.name?.trim().split(/\s+/)[0];
   const greeting = firstName ? `Hi ${firstName},` : "Hi,";
-  const blocked =
-    origin === "credits"
+  const isCreditPurchase = requestAction === "buyCredits";
+  const blocked = isCreditPurchase
+    ? "Our organization has run out of MCPJam credits."
+    : origin === "credits"
       ? "I've run out of credits on MCPJam and can't keep using the models until they reset."
       : "I've hit the free plan's eval iteration limit on MCPJam and can't run evals until it resets.";
 
-  const subject = `Upgrade request: MCPJam ${teamName} plan for ${organizationName}`;
+  const subject = isCreditPurchase
+    ? `Credit purchase request for ${organizationName}`
+    : `Upgrade request: MCPJam ${teamName} plan for ${organizationName}`;
+  const request = isCreditPurchase
+    ? `Could you buy more credits for ${organizationName}?`
+    : `Could you upgrade ${organizationName} to the ${teamName} plan?`;
+  const steps = isCreditPurchase
+    ? [
+        "1. Open MCPJam, go to Organizations, then Billing.",
+        "2. Under Credits, click Buy credits.",
+        "3. Choose an amount and finish checkout with Stripe.",
+      ]
+    : [
+        "1. Open MCPJam, go to Organizations, then Billing.",
+        `2. Under the ${teamName} plan, pick Annual or Monthly.`,
+        "3. Click Upgrade and finish checkout with Stripe.",
+      ];
   const body = [
     greeting,
     "",
     blocked,
-    `Could you upgrade ${organizationName} to the ${teamName} plan?`,
+    request,
     "",
     "Here's how:",
-    "1. Open MCPJam, go to Organizations, then Billing.",
-    `2. Under the ${teamName} plan, pick Annual or Monthly.`,
-    "3. Click Upgrade and finish checkout with Stripe.",
+    ...steps,
     "",
     "Thanks",
   ].join("\n");
@@ -54,6 +79,7 @@ interface RequestUpgradeButtonProps {
   teamName: string;
   origin: UpgradeOrigin;
   limitKind: string;
+  requestAction?: UpgradeRequestAction;
 }
 
 /**
@@ -76,12 +102,14 @@ export function RequestUpgradeButton({
   teamName,
   origin,
   limitKind,
+  requestAction = "upgrade",
 }: RequestUpgradeButtonProps) {
   const href = buildUpgradeRequestMail({
     recipients,
     organizationName,
     teamName,
     origin,
+    requestAction,
   });
   if (!href) return null;
 
@@ -112,7 +140,8 @@ export function RequestUpgradeButton({
         {extraCount > 0
           ? ` and ${extraCount} other owner${extraCount === 1 ? "" : "s"}`
           : ""}
-        , with the steps to upgrade.
+        , with the steps to{" "}
+        {requestAction === "buyCredits" ? "buy credits" : "upgrade"}.
       </p>
     </div>
   );

--- a/mcpjam-inspector/client/src/components/billing/RequestUpgradeButton.tsx
+++ b/mcpjam-inspector/client/src/components/billing/RequestUpgradeButton.tsx
@@ -1,0 +1,119 @@
+import { Button } from "@mcpjam/design-system/button";
+import { track } from "@/lib/analytics";
+import type { UpgradeOrigin } from "@/hooks/use-upgrade-checkout";
+
+export interface UpgradeRequestRecipient {
+  email: string;
+  name?: string | null;
+}
+
+/**
+ * Builds the owner-facing upgrade request. Exported so a test can assert the
+ * body without reading it off a URL-encoded href by eye.
+ */
+export function buildUpgradeRequestMail(params: {
+  recipients: UpgradeRequestRecipient[];
+  organizationName: string;
+  teamName: string;
+  origin: UpgradeOrigin;
+}): string | null {
+  const { recipients, organizationName, teamName, origin } = params;
+  const to = recipients.map((r) => r.email).filter(Boolean);
+  if (to.length === 0) return null;
+
+  const firstName = recipients[0]?.name?.trim().split(/\s+/)[0];
+  const greeting = firstName ? `Hi ${firstName},` : "Hi,";
+  const blocked =
+    origin === "credits"
+      ? "I've run out of credits on MCPJam and can't keep using the models until they reset."
+      : "I've hit the free plan's eval iteration limit on MCPJam and can't run evals until it resets.";
+
+  const subject = `Upgrade request: MCPJam ${teamName} plan for ${organizationName}`;
+  const body = [
+    greeting,
+    "",
+    blocked,
+    `Could you upgrade ${organizationName} to the ${teamName} plan?`,
+    "",
+    "Here's how:",
+    "1. Open MCPJam, go to Organizations, then Billing.",
+    `2. Under the ${teamName} plan, pick Annual or Monthly.`,
+    "3. Click Upgrade and finish checkout with Stripe.",
+    "",
+    "Thanks",
+  ].join("\n");
+
+  return `mailto:${to.join(",")}?subject=${encodeURIComponent(
+    subject,
+  )}&body=${encodeURIComponent(body)}`;
+}
+
+interface RequestUpgradeButtonProps {
+  recipients: UpgradeRequestRecipient[];
+  organizationName: string;
+  teamName: string;
+  origin: UpgradeOrigin;
+  limitKind: string;
+}
+
+/**
+ * The escape hatch for someone who can't upgrade themselves. Renders a
+ * `mailto:` anchor rather than a scripted navigation: it matches the existing
+ * mail links in SupportTab and the chat error surface, the browser handles it,
+ * and the href is directly assertable.
+ *
+ * The label says "Email" because that is what happens. Nothing here sends
+ * anything on the user's behalf, and claiming otherwise would be a lie the
+ * first time someone's mail client doesn't open. Sending server-side would
+ * need a Convex action that doesn't exist yet.
+ *
+ * Renders nothing when no owner address resolves, so nobody gets a button that
+ * opens an empty draft.
+ */
+export function RequestUpgradeButton({
+  recipients,
+  organizationName,
+  teamName,
+  origin,
+  limitKind,
+}: RequestUpgradeButtonProps) {
+  const href = buildUpgradeRequestMail({
+    recipients,
+    organizationName,
+    teamName,
+    origin,
+  });
+  if (!href) return null;
+
+  const recipientLabel =
+    recipients[0]?.name?.trim() || recipients[0]?.email || "your owner";
+  const extraCount = recipients.length - 1;
+
+  return (
+    <div className="space-y-1.5">
+      <Button asChild className="w-full">
+        <a
+          href={href}
+          data-testid="request-upgrade-mail"
+          onClick={() => {
+            track("plan_limit_upgrade_requested", {
+              location: "plan_limit_dialog",
+              limit_kind: limitKind,
+              origin,
+              recipient_count: recipients.length,
+            });
+          }}
+        >
+          Email your owner
+        </a>
+      </Button>
+      <p className="text-xs text-muted-foreground">
+        Opens a draft to {recipientLabel}
+        {extraCount > 0
+          ? ` and ${extraCount} other owner${extraCount === 1 ? "" : "s"}`
+          : ""}
+        , with the steps to upgrade.
+      </p>
+    </div>
+  );
+}

--- a/mcpjam-inspector/client/src/components/billing/RequestUpgradeButton.tsx
+++ b/mcpjam-inspector/client/src/components/billing/RequestUpgradeButton.tsx
@@ -50,6 +50,9 @@ export function buildUpgradeRequestMail(params: {
 
 interface RequestUpgradeButtonProps {
   recipients: UpgradeRequestRecipient[];
+  /** Owner lookup still in flight. Holds a disabled button in place rather
+   * than letting one appear a beat after the dialog opens. */
+  isLoadingRecipients?: boolean;
   organizationName: string;
   teamName: string;
   origin: UpgradeOrigin;
@@ -72,11 +75,20 @@ interface RequestUpgradeButtonProps {
  */
 export function RequestUpgradeButton({
   recipients,
+  isLoadingRecipients = false,
   organizationName,
   teamName,
   origin,
   limitKind,
 }: RequestUpgradeButtonProps) {
+  if (isLoadingRecipients) {
+    return (
+      <Button type="button" className="w-full" disabled>
+        Email your owner
+      </Button>
+    );
+  }
+
   const href = buildUpgradeRequestMail({
     recipients,
     organizationName,

--- a/mcpjam-inspector/client/src/components/billing/UpgradeIntervalPicker.tsx
+++ b/mcpjam-inspector/client/src/components/billing/UpgradeIntervalPicker.tsx
@@ -1,8 +1,11 @@
 import { Badge } from "@mcpjam/design-system/badge";
+import { Button } from "@mcpjam/design-system/button";
 import type { BillingInterval } from "@/hooks/useOrganizationBilling";
 import { cn } from "@/lib/utils";
 
 interface UpgradeIntervalPickerProps {
+  interval: BillingInterval;
+  onIntervalChange: (interval: BillingInterval) => void;
   /** Per-seat monthly figures, already formatted. Null while the catalog loads. */
   annualPriceLabel: string | null;
   monthlyPriceLabel: string | null;
@@ -11,7 +14,7 @@ interface UpgradeIntervalPickerProps {
   monthlySupported: boolean;
   teamName: string;
   isStarting: boolean;
-  onUpgrade: (interval: BillingInterval) => void;
+  onUpgrade: () => void;
   className?: string;
 }
 
@@ -23,14 +26,13 @@ interface IntervalOption {
 }
 
 /**
- * Both billing intervals as side-by-side buttons, so choosing one and starting
- * checkout is a single press. A toggle would hide one of the two prices behind
- * a click the user has to think to make, which is the wrong trade at a wall.
- *
- * Pressing a card leads to Stripe, where the user still confirms before paying,
- * so there is no destructive outcome from a single click here.
+ * Both billing intervals side by side, so neither price is hidden behind a
+ * toggle, then an explicit confirm. Same select-then-confirm shape as the
+ * credit preset dialog.
  */
 export function UpgradeIntervalPicker({
+  interval,
+  onIntervalChange,
   annualPriceLabel,
   monthlyPriceLabel,
   annualDiscountPct,
@@ -67,52 +69,64 @@ export function UpgradeIntervalPicker({
   if (options.length === 0) return null;
 
   return (
-    <div className={cn("space-y-2", className)}>
+    <div className={cn("space-y-3", className)}>
       <div
         className={cn(
           "grid gap-2",
           options.length > 1 ? "sm:grid-cols-2" : "grid-cols-1",
         )}
+        role="radiogroup"
+        aria-label="Billing interval"
       >
-        {options.map((option) => (
-          <button
-            key={option.interval}
-            type="button"
-            disabled={isStarting}
-            onClick={() => onUpgrade(option.interval)}
-            data-testid={`upgrade-${option.interval}`}
-            aria-label={`Upgrade to ${teamName}, ${option.label.toLowerCase()} billing`}
-            className={cn(
-              "flex flex-col gap-1 rounded-lg border border-border p-3 text-left transition-colors",
-              "hover:border-foreground/40 hover:bg-muted/40",
-              "focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring",
-              "disabled:pointer-events-none disabled:opacity-60",
-            )}
-          >
-            <span className="flex items-center gap-2">
-              <span className="text-sm font-medium">{option.label}</span>
-              {option.interval === "annual" && annualDiscountPct > 0 ? (
-                <Badge className="rounded-md bg-primary px-1.5 py-0 text-[10px] font-semibold text-primary-foreground">
-                  Save {annualDiscountPct}%
-                </Badge>
-              ) : null}
-            </span>
-            {option.priceLabel ? (
-              <span className="text-xl font-semibold leading-tight tracking-tight">
-                {option.priceLabel}
+        {options.map((option) => {
+          const isSelected = option.interval === interval;
+          return (
+            <button
+              key={option.interval}
+              type="button"
+              role="radio"
+              aria-checked={isSelected}
+              disabled={isStarting}
+              onClick={() => onIntervalChange(option.interval)}
+              data-testid={`upgrade-interval-${option.interval}`}
+              className={cn(
+                "flex flex-col gap-1 rounded-lg border p-3 text-left transition-colors",
+                isSelected
+                  ? "border-primary bg-primary/10"
+                  : "border-border hover:border-foreground/40",
+                "focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring",
+                "disabled:pointer-events-none disabled:opacity-60",
+              )}
+            >
+              <span className="flex items-center gap-2">
+                <span className="text-sm font-medium">{option.label}</span>
+                {option.interval === "annual" && annualDiscountPct > 0 ? (
+                  <Badge className="rounded-md bg-primary px-1.5 py-0 text-[10px] font-semibold text-primary-foreground">
+                    Save {annualDiscountPct}%
+                  </Badge>
+                ) : null}
               </span>
-            ) : null}
-            <span className="text-xs leading-snug text-muted-foreground">
-              {option.cadence}
-            </span>
-          </button>
-        ))}
+              {option.priceLabel ? (
+                <span className="text-xl font-semibold leading-tight tracking-tight">
+                  {option.priceLabel}
+                </span>
+              ) : null}
+              <span className="text-xs leading-snug text-muted-foreground">
+                {option.cadence}
+              </span>
+            </button>
+          );
+        })}
       </div>
-      <p className="text-xs text-muted-foreground">
-        {isStarting
-          ? "Redirecting to checkout…"
-          : "You'll confirm on Stripe before paying."}
-      </p>
+      <Button
+        type="button"
+        className="w-full"
+        onClick={onUpgrade}
+        disabled={isStarting}
+        data-testid="upgrade-plan-cta"
+      >
+        {isStarting ? "Redirecting…" : `Upgrade to ${teamName}`}
+      </Button>
     </div>
   );
 }

--- a/mcpjam-inspector/client/src/components/billing/UpgradeIntervalPicker.tsx
+++ b/mcpjam-inspector/client/src/components/billing/UpgradeIntervalPicker.tsx
@@ -1,0 +1,104 @@
+import { Button } from "@mcpjam/design-system/button";
+import type { BillingInterval } from "@/hooks/useOrganizationBilling";
+import { cn } from "@/lib/utils";
+
+interface UpgradeIntervalPickerProps {
+  interval: BillingInterval;
+  onIntervalChange: (interval: BillingInterval) => void;
+  /** Per-seat monthly figure, already formatted. Null while the catalog loads. */
+  priceLabel: string | null;
+  annualDiscountPct: number;
+  annualSupported: boolean;
+  monthlySupported: boolean;
+  teamName: string;
+  isStarting: boolean;
+  onUpgrade: () => void;
+  className?: string;
+}
+
+/**
+ * Interval choice plus the upgrade CTA, shared by the eval and credits walls.
+ * Both intervals are shown up front so the user isn't deciding blind, and the
+ * toggle markup mirrors the billing page's compare card for consistency.
+ */
+export function UpgradeIntervalPicker({
+  interval,
+  onIntervalChange,
+  priceLabel,
+  annualDiscountPct,
+  annualSupported,
+  monthlySupported,
+  teamName,
+  isStarting,
+  onUpgrade,
+  className,
+}: UpgradeIntervalPickerProps) {
+  const showToggle = annualSupported && monthlySupported;
+  const cadence =
+    interval === "annual" ? "Billed annually" : "Billed monthly";
+
+  return (
+    <div className={cn("space-y-2", className)}>
+      {showToggle ? (
+        <div
+          role="group"
+          aria-label="Billing interval"
+          className="inline-flex items-center gap-0.5 rounded-md border border-border/60 bg-muted/40 p-0.5 text-xs"
+        >
+          <button
+            type="button"
+            aria-pressed={interval === "annual"}
+            className={cn(
+              "flex items-center gap-1.5 rounded px-2 py-1 font-medium transition-colors",
+              interval === "annual"
+                ? "bg-background text-foreground shadow-sm"
+                : "text-muted-foreground",
+            )}
+            onClick={() => onIntervalChange("annual")}
+          >
+            Annual
+            {annualDiscountPct > 0 ? (
+              <span className="text-[10px] font-semibold text-primary">
+                Save {annualDiscountPct}%
+              </span>
+            ) : null}
+          </button>
+          <button
+            type="button"
+            aria-pressed={interval === "monthly"}
+            className={cn(
+              "rounded px-2 py-1 font-medium transition-colors",
+              interval === "monthly"
+                ? "bg-background text-foreground shadow-sm"
+                : "text-muted-foreground",
+            )}
+            onClick={() => onIntervalChange("monthly")}
+          >
+            Monthly
+          </button>
+        </div>
+      ) : null}
+
+      {priceLabel ? (
+        <div>
+          <p className="text-lg font-semibold leading-tight tracking-tight">
+            {priceLabel}
+          </p>
+          <p className="text-xs leading-snug text-muted-foreground">
+            {cadence}
+          </p>
+        </div>
+      ) : null}
+
+      <Button
+        type="button"
+        className="w-full"
+        onClick={onUpgrade}
+        disabled={isStarting}
+        data-testid="upgrade-plan-cta"
+      >
+        {isStarting ? "Redirecting…" : `Upgrade to ${teamName}`}
+      </Button>
+    </div>
+  );
+}

--- a/mcpjam-inspector/client/src/components/billing/UpgradeIntervalPicker.tsx
+++ b/mcpjam-inspector/client/src/components/billing/UpgradeIntervalPicker.tsx
@@ -1,30 +1,38 @@
-import { Button } from "@mcpjam/design-system/button";
+import { Badge } from "@mcpjam/design-system/badge";
 import type { BillingInterval } from "@/hooks/useOrganizationBilling";
 import { cn } from "@/lib/utils";
 
 interface UpgradeIntervalPickerProps {
-  interval: BillingInterval;
-  onIntervalChange: (interval: BillingInterval) => void;
-  /** Per-seat monthly figure, already formatted. Null while the catalog loads. */
-  priceLabel: string | null;
+  /** Per-seat monthly figures, already formatted. Null while the catalog loads. */
+  annualPriceLabel: string | null;
+  monthlyPriceLabel: string | null;
   annualDiscountPct: number;
   annualSupported: boolean;
   monthlySupported: boolean;
   teamName: string;
   isStarting: boolean;
-  onUpgrade: () => void;
+  onUpgrade: (interval: BillingInterval) => void;
   className?: string;
 }
 
+interface IntervalOption {
+  interval: BillingInterval;
+  label: string;
+  cadence: string;
+  priceLabel: string | null;
+}
+
 /**
- * Interval choice plus the upgrade CTA, shared by the eval and credits walls.
- * Both intervals are shown up front so the user isn't deciding blind, and the
- * toggle markup mirrors the billing page's compare card for consistency.
+ * Both billing intervals as side-by-side buttons, so choosing one and starting
+ * checkout is a single press. A toggle would hide one of the two prices behind
+ * a click the user has to think to make, which is the wrong trade at a wall.
+ *
+ * Pressing a card leads to Stripe, where the user still confirms before paying,
+ * so there is no destructive outcome from a single click here.
  */
 export function UpgradeIntervalPicker({
-  interval,
-  onIntervalChange,
-  priceLabel,
+  annualPriceLabel,
+  monthlyPriceLabel,
   annualDiscountPct,
   annualSupported,
   monthlySupported,
@@ -33,72 +41,78 @@ export function UpgradeIntervalPicker({
   onUpgrade,
   className,
 }: UpgradeIntervalPickerProps) {
-  const showToggle = annualSupported && monthlySupported;
-  const cadence =
-    interval === "annual" ? "Billed annually" : "Billed monthly";
+  const options: IntervalOption[] = [
+    ...(annualSupported
+      ? [
+          {
+            interval: "annual" as const,
+            label: "Annual",
+            cadence: "Billed annually",
+            priceLabel: annualPriceLabel,
+          },
+        ]
+      : []),
+    ...(monthlySupported
+      ? [
+          {
+            interval: "monthly" as const,
+            label: "Monthly",
+            cadence: "Billed monthly",
+            priceLabel: monthlyPriceLabel,
+          },
+        ]
+      : []),
+  ];
+
+  if (options.length === 0) return null;
 
   return (
     <div className={cn("space-y-2", className)}>
-      {showToggle ? (
-        <div
-          role="group"
-          aria-label="Billing interval"
-          className="inline-flex items-center gap-0.5 rounded-md border border-border/60 bg-muted/40 p-0.5 text-xs"
-        >
+      <div
+        className={cn(
+          "grid gap-2",
+          options.length > 1 ? "sm:grid-cols-2" : "grid-cols-1",
+        )}
+      >
+        {options.map((option) => (
           <button
+            key={option.interval}
             type="button"
-            aria-pressed={interval === "annual"}
+            disabled={isStarting}
+            onClick={() => onUpgrade(option.interval)}
+            data-testid={`upgrade-${option.interval}`}
+            aria-label={`Upgrade to ${teamName}, ${option.label.toLowerCase()} billing`}
             className={cn(
-              "flex items-center gap-1.5 rounded px-2 py-1 font-medium transition-colors",
-              interval === "annual"
-                ? "bg-background text-foreground shadow-sm"
-                : "text-muted-foreground",
+              "flex flex-col gap-1 rounded-lg border border-border p-3 text-left transition-colors",
+              "hover:border-foreground/40 hover:bg-muted/40",
+              "focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring",
+              "disabled:pointer-events-none disabled:opacity-60",
             )}
-            onClick={() => onIntervalChange("annual")}
           >
-            Annual
-            {annualDiscountPct > 0 ? (
-              <span className="text-[10px] font-semibold text-primary">
-                Save {annualDiscountPct}%
+            <span className="flex items-center gap-2">
+              <span className="text-sm font-medium">{option.label}</span>
+              {option.interval === "annual" && annualDiscountPct > 0 ? (
+                <Badge className="rounded-md bg-primary px-1.5 py-0 text-[10px] font-semibold text-primary-foreground">
+                  Save {annualDiscountPct}%
+                </Badge>
+              ) : null}
+            </span>
+            {option.priceLabel ? (
+              <span className="text-xl font-semibold leading-tight tracking-tight">
+                {option.priceLabel}
               </span>
             ) : null}
+            <span className="text-xs leading-snug text-muted-foreground">
+              {option.cadence}
+            </span>
           </button>
-          <button
-            type="button"
-            aria-pressed={interval === "monthly"}
-            className={cn(
-              "rounded px-2 py-1 font-medium transition-colors",
-              interval === "monthly"
-                ? "bg-background text-foreground shadow-sm"
-                : "text-muted-foreground",
-            )}
-            onClick={() => onIntervalChange("monthly")}
-          >
-            Monthly
-          </button>
-        </div>
-      ) : null}
-
-      {priceLabel ? (
-        <div>
-          <p className="text-lg font-semibold leading-tight tracking-tight">
-            {priceLabel}
-          </p>
-          <p className="text-xs leading-snug text-muted-foreground">
-            {cadence}
-          </p>
-        </div>
-      ) : null}
-
-      <Button
-        type="button"
-        className="w-full"
-        onClick={onUpgrade}
-        disabled={isStarting}
-        data-testid="upgrade-plan-cta"
-      >
-        {isStarting ? "Redirecting…" : `Upgrade to ${teamName}`}
-      </Button>
+        ))}
+      </div>
+      <p className="text-xs text-muted-foreground">
+        {isStarting
+          ? "Redirecting to checkout…"
+          : "You'll confirm on Stripe before paying."}
+      </p>
     </div>
   );
 }

--- a/mcpjam-inspector/client/src/components/billing/UpgradeIntervalPicker.tsx
+++ b/mcpjam-inspector/client/src/components/billing/UpgradeIntervalPicker.tsx
@@ -6,7 +6,8 @@ import { cn } from "@/lib/utils";
 interface UpgradeIntervalPickerProps {
   interval: BillingInterval;
   onIntervalChange: (interval: BillingInterval) => void;
-  /** Per-seat monthly figures, already formatted. Null while the catalog loads. */
+  /** Bare per-seat monthly amounts, e.g. "$30". The unit is rendered here so
+   * the large number never wraps mid-phrase. Null while the catalog loads. */
   annualPriceLabel: string | null;
   monthlyPriceLabel: string | null;
   annualDiscountPct: number;
@@ -107,9 +108,14 @@ export function UpgradeIntervalPicker({
                 ) : null}
               </span>
               {option.priceLabel ? (
-                <span className="text-xl font-semibold leading-tight tracking-tight">
-                  {option.priceLabel}
-                </span>
+                <>
+                  <span className="text-xl font-semibold leading-tight tracking-tight">
+                    {option.priceLabel}
+                  </span>
+                  <span className="text-xs leading-snug text-muted-foreground">
+                    per seat/month
+                  </span>
+                </>
               ) : null}
               <span className="text-xs leading-snug text-muted-foreground">
                 {option.cadence}

--- a/mcpjam-inspector/client/src/components/billing/__tests__/CreditTopupDialog.test.tsx
+++ b/mcpjam-inspector/client/src/components/billing/__tests__/CreditTopupDialog.test.tsx
@@ -99,10 +99,12 @@ describe("CreditTopupDialog", () => {
       screen.getByRole("radio", { name: /500\s*credits/ })
     ).toHaveAttribute("aria-checked", "true");
     expect(
-      screen.getByText(/Add credits to your organization/)
+      screen.getByText(/Credits cover model usage in chat, playground, and agents/)
     ).toBeInTheDocument();
+    // Names the boundary explicitly so nobody buys credits expecting a higher
+    // eval-iteration cap.
     expect(
-      screen.getByText(/team can keep using MCPJam models/)
+      screen.getByText(/doesn't change your plan limits/)
     ).toBeInTheDocument();
     // The processing-fee disclaimer was removed so users can't back-compute
     // the take rate.

--- a/mcpjam-inspector/client/src/components/billing/__tests__/CreditTopupDialog.test.tsx
+++ b/mcpjam-inspector/client/src/components/billing/__tests__/CreditTopupDialog.test.tsx
@@ -1,10 +1,13 @@
 import { describe, expect, it, vi, beforeEach } from "vitest";
-import { render, screen } from "@testing-library/react";
+import { render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 
 import { CreditTopupDialog } from "../CreditTopupDialog";
 
 const startCheckoutMock = vi.fn();
+const trackMock = vi.hoisted(() => vi.fn());
+
+vi.mock("@/lib/analytics", () => ({ track: trackMock }));
 
 let presetsState:
   | Array<{
@@ -55,6 +58,7 @@ const DEFAULT_PRESETS = [
 describe("CreditTopupDialog", () => {
   beforeEach(() => {
     startCheckoutMock.mockReset();
+    trackMock.mockReset();
     presetsState = DEFAULT_PRESETS;
     presetsLoadingState = false;
     isStartingCheckoutState = false;
@@ -83,6 +87,85 @@ describe("CreditTopupDialog", () => {
     ).toBeInTheDocument();
   });
 
+  it("reports one rich impression across rerenders", async () => {
+    const view = render(
+      <CreditTopupDialog
+        open
+        onOpenChange={vi.fn()}
+        chatSessionId="chat-1"
+        lastUserMessage="hello"
+        organizationId="org-1"
+        source="chat_banner"
+      />
+    );
+
+    view.rerender(
+      <CreditTopupDialog
+        open
+        onOpenChange={vi.fn()}
+        chatSessionId="chat-1"
+        lastUserMessage="hello"
+        organizationId="org-1"
+        source="chat_banner"
+      />
+    );
+
+    await waitFor(() => {
+      const impressions = trackMock.mock.calls.filter(
+        ([event]) => event === "credit_topup_dialog_shown"
+      );
+      expect(impressions).toHaveLength(1);
+      expect(impressions[0]?.[1]).toEqual(
+        expect.objectContaining({
+          organization_id: "org-1",
+          source: "chat_banner",
+          package_count: 3,
+          default_package_id: "credits_500",
+          has_resume_context: true,
+        })
+      );
+    });
+  });
+
+  it("reports explicit package selection and dismissal once", async () => {
+    const user = userEvent.setup();
+    const onOpenChange = vi.fn();
+    render(
+      <CreditTopupDialog
+        open
+        onOpenChange={onOpenChange}
+        chatSessionId="chat-1"
+        lastUserMessage="hello"
+        organizationId="org-1"
+        source="limit_modal"
+      />
+    );
+
+    await user.click(screen.getByRole("radio", { name: /1,000\s*credits/ }));
+    await user.click(screen.getByRole("button", { name: "Cancel" }));
+
+    expect(trackMock).toHaveBeenCalledWith(
+      "credit_topup_package_selected",
+      expect.objectContaining({
+        package_id: "credits_1000",
+        price_cents: 1000,
+        package_index: 1,
+      })
+    );
+    expect(trackMock).toHaveBeenCalledWith(
+      "credit_topup_dialog_dismissed",
+      expect.objectContaining({
+        dismissal_method: "cancel",
+        selected_package_id: "credits_1000",
+      })
+    );
+    expect(
+      trackMock.mock.calls.filter(
+        ([event]) => event === "credit_topup_dialog_dismissed"
+      )
+    ).toHaveLength(1);
+  });
+
   it("auto-selects the first preset without surfacing fee or credited dollar amounts", () => {
     render(
       <CreditTopupDialog
@@ -99,7 +182,9 @@ describe("CreditTopupDialog", () => {
       screen.getByRole("radio", { name: /500\s*credits/ })
     ).toHaveAttribute("aria-checked", "true");
     expect(
-      screen.getByText(/Credits cover model usage in chat, playground, and agents/)
+      screen.getByText(
+        /Credits cover model usage in chat, playground, and agents/
+      )
     ).toBeInTheDocument();
     // Names the boundary explicitly so nobody buys credits expecting a higher
     // eval-iteration cap.
@@ -132,9 +217,7 @@ describe("CreditTopupDialog", () => {
       />
     );
 
-    await user.click(
-      screen.getByRole("radio", { name: /1,000\s*credits/ })
-    );
+    await user.click(screen.getByRole("radio", { name: /1,000\s*credits/ }));
     await user.click(
       screen.getByRole("button", { name: /Continue with \$10/ })
     );
@@ -165,9 +248,7 @@ describe("CreditTopupDialog", () => {
       />
     );
 
-    await user.click(
-      screen.getByRole("radio", { name: /1,000\s*credits/ })
-    );
+    await user.click(screen.getByRole("radio", { name: /1,000\s*credits/ }));
     await user.click(
       screen.getByRole("button", { name: /Continue with \$10/ })
     );

--- a/mcpjam-inspector/client/src/components/billing/__tests__/PlanLimitDialog.test.tsx
+++ b/mcpjam-inspector/client/src/components/billing/__tests__/PlanLimitDialog.test.tsx
@@ -13,17 +13,20 @@ const {
   upgradeState,
   billingState,
   recipientsState,
-} =
-  vi.hoisted(() => ({
-    toastSuccess: vi.fn(),
-    trackMock: vi.fn(),
-    startMock: vi.fn(),
-    upgradeState: { currentPlan: "free" as string, canManageBilling: true },
-    recipientsState: {
-      current: [] as Array<{ email: string; name?: string | null }>,
-    },
-    billingState: { plan: "free" as string, isLoading: false },
-  }));
+} = vi.hoisted(() => ({
+  toastSuccess: vi.fn(),
+  trackMock: vi.fn(),
+  startMock: vi.fn(),
+  upgradeState: {
+    currentPlan: "free" as string,
+    effectivePlan: "free" as string,
+    canManageBilling: true,
+  },
+  recipientsState: {
+    current: [] as Array<{ email: string; name?: string | null }>,
+  },
+  billingState: { plan: "free" as string, isLoading: false },
+}));
 
 vi.mock("@/lib/toast", () => ({
   toast: { success: toastSuccess, error: vi.fn() },
@@ -32,8 +35,9 @@ vi.mock("@/lib/toast", () => ({
 vi.mock("@/lib/analytics", () => ({ track: trackMock }));
 
 vi.mock("@/hooks/use-upgrade-checkout", async (importOriginal) => {
-  const actual =
-    await importOriginal<typeof import("@/hooks/use-upgrade-checkout")>();
+  const actual = await importOriginal<
+    typeof import("@/hooks/use-upgrade-checkout")
+  >();
   return {
     ...actual,
     useUpgradeCheckout: () => ({
@@ -47,6 +51,7 @@ vi.mock("@/hooks/use-upgrade-checkout", async (importOriginal) => {
       teamName: "Team",
       teamEvalIterations: 5000,
       currentPlan: upgradeState.currentPlan,
+      effectivePlan: upgradeState.effectivePlan,
       organizationName: "Acme Robotics",
       canManageBilling: upgradeState.canManageBilling,
       isStarting: false,
@@ -92,6 +97,7 @@ beforeEach(() => {
   trackMock.mockReset();
   startMock.mockReset();
   upgradeState.currentPlan = "free";
+  upgradeState.effectivePlan = "free";
   upgradeState.canManageBilling = true;
   recipientsState.current = [];
   billingState.plan = "free";
@@ -164,16 +170,12 @@ describe("PlanLimitDialog", () => {
     expect(
       screen.queryByRole("button", { name: /wait for reset/i })
     ).not.toBeInTheDocument();
-    expect(
-      screen.getByRole("button", { name: /close/i })
-    ).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /close/i })).toBeInTheDocument();
   });
 
   it("offers an owner email instead of a CTA the server would reject", () => {
     upgradeState.canManageBilling = false;
-    recipientsState.current = [
-      { email: "dana@acme.test", name: "Dana Ruiz" },
-    ];
+    recipientsState.current = [{ email: "dana@acme.test", name: "Dana Ruiz" }];
     openEvalLimit();
     render(<PlanLimitDialog />);
 
@@ -205,6 +207,7 @@ describe("PlanLimitDialog", () => {
 
   it("points an org already on Team at Enterprise instead of Team", () => {
     upgradeState.currentPlan = "team";
+    upgradeState.effectivePlan = "team";
     openEvalLimit({ allowed: 5000, windowKind: "month" });
     render(<PlanLimitDialog />);
 
@@ -213,14 +216,15 @@ describe("PlanLimitDialog", () => {
     expect(description).toHaveTextContent(/Enterprise adds negotiated usage/);
     expect(description).not.toHaveTextContent(/Our Team plan/);
     expect(screen.queryByTestId("upgrade-plan-cta")).not.toBeInTheDocument();
-    expect(
-      screen.getByTestId("plan-limit-enterprise-cta")
-    ).toHaveTextContent(/Request upgrade/);
+    expect(screen.getByTestId("plan-limit-enterprise-cta")).toHaveTextContent(
+      /Request upgrade/
+    );
   });
 
   it("reports the Enterprise CTA click", async () => {
     const user = userEvent.setup();
     upgradeState.currentPlan = "team";
+    upgradeState.effectivePlan = "team";
     openEvalLimit({ allowed: 5000, windowKind: "month" });
     render(<PlanLimitDialog />);
 
@@ -234,6 +238,7 @@ describe("PlanLimitDialog", () => {
 
   it("offers nothing to pitch when the org is already on Enterprise", () => {
     upgradeState.currentPlan = "enterprise";
+    upgradeState.effectivePlan = "enterprise";
     openEvalLimit({ allowed: 50000, windowKind: "month" });
     render(<PlanLimitDialog />);
 
@@ -243,6 +248,20 @@ describe("PlanLimitDialog", () => {
     expect(
       screen.queryByTestId("plan-limit-enterprise-cta")
     ).not.toBeInTheDocument();
+  });
+
+  it("routes a capped Team trial to Enterprise instead of Team checkout", () => {
+    upgradeState.currentPlan = "free";
+    upgradeState.effectivePlan = "team";
+    openEvalLimit({ allowed: 5000, windowKind: "month" });
+    render(<PlanLimitDialog />);
+
+    const description = screen.getByTestId("plan-limit-dialog-description");
+    expect(description).toHaveTextContent(/Your plan includes 5,000 a month/);
+    expect(description).toHaveTextContent(/Enterprise adds negotiated usage/);
+    expect(description).not.toHaveTextContent(/Our Team plan/);
+    expect(screen.queryByTestId("upgrade-plan-cta")).not.toBeInTheDocument();
+    expect(screen.getByTestId("plan-limit-enterprise-cta")).toBeInTheDocument();
   });
 
   it("closes and reports a dismissal", async () => {

--- a/mcpjam-inspector/client/src/components/billing/__tests__/PlanLimitDialog.test.tsx
+++ b/mcpjam-inspector/client/src/components/billing/__tests__/PlanLimitDialog.test.tsx
@@ -54,6 +54,7 @@ vi.mock("@/hooks/use-upgrade-checkout", async (importOriginal) => {
       effectivePlan: upgradeState.effectivePlan,
       organizationName: "Acme Robotics",
       canManageBilling: upgradeState.canManageBilling,
+      isLoadingBilling: false,
       isStarting: false,
       start: startMock,
     }),
@@ -126,6 +127,28 @@ describe("PlanLimitDialog", () => {
     // enforces rather than a hardcoded marketing string.
     expect(description).toHaveTextContent(
       /Our Team plan includes 5,000 a month/
+    );
+  });
+
+  it("reports one rich impression, even when the dialog rerenders", () => {
+    openEvalLimit();
+    const view = render(<PlanLimitDialog />);
+
+    view.rerender(<PlanLimitDialog />);
+
+    const impressions = trackMock.mock.calls.filter(
+      ([event]) => event === "plan_limit_dialog_shown"
+    );
+    expect(impressions).toHaveLength(1);
+    expect(impressions[0]?.[1]).toEqual(
+      expect.objectContaining({
+        wall_kind: "eval_iterations",
+        organization_id: "org-1",
+        current_plan: "free",
+        effective_plan: "free",
+        can_manage_billing: true,
+        primary_action: "upgrade",
+      })
     );
   });
 

--- a/mcpjam-inspector/client/src/components/billing/__tests__/PlanLimitDialog.test.tsx
+++ b/mcpjam-inspector/client/src/components/billing/__tests__/PlanLimitDialog.test.tsx
@@ -6,12 +6,22 @@ import { usePlanLimitDialogStore } from "@/stores/plan-limit-dialog-store";
 
 // Hoisted so the vi.mock factories below (which vitest lifts to the top of the
 // file) can reach them.
-const { toastSuccess, trackMock, startMock, upgradeState, billingState } =
+const {
+  toastSuccess,
+  trackMock,
+  startMock,
+  upgradeState,
+  billingState,
+  recipientsState,
+} =
   vi.hoisted(() => ({
     toastSuccess: vi.fn(),
     trackMock: vi.fn(),
     startMock: vi.fn(),
     upgradeState: { currentPlan: "free" as string, canManageBilling: true },
+    recipientsState: {
+      current: [] as Array<{ email: string; name?: string | null }>,
+    },
     billingState: { plan: "free" as string, isLoading: false },
   }));
 
@@ -27,6 +37,8 @@ vi.mock("@/hooks/use-upgrade-checkout", async (importOriginal) => {
   return {
     ...actual,
     useUpgradeCheckout: () => ({
+      interval: "annual" as const,
+      setInterval: vi.fn(),
       annualPriceLabel: "$30/seat/mo",
       monthlyPriceLabel: "$38/seat/mo",
       annualDiscountPct: 21,
@@ -35,6 +47,7 @@ vi.mock("@/hooks/use-upgrade-checkout", async (importOriginal) => {
       teamName: "Team",
       teamEvalIterations: 5000,
       currentPlan: upgradeState.currentPlan,
+      organizationName: "Acme Robotics",
       canManageBilling: upgradeState.canManageBilling,
       isStarting: false,
       start: startMock,
@@ -50,6 +63,10 @@ vi.mock("@/hooks/useOrganizationBilling", () => ({
     planCatalog: { plans: { team: { displayName: "Team" } } },
     isLoadingBilling: billingState.isLoading,
   }),
+}));
+
+vi.mock("@/hooks/use-upgrade-request-recipients", () => ({
+  useUpgradeRequestRecipients: () => recipientsState.current,
 }));
 
 const RESETS_AT = Date.UTC(2026, 7, 11, 4, 0);
@@ -76,6 +93,7 @@ beforeEach(() => {
   startMock.mockReset();
   upgradeState.currentPlan = "free";
   upgradeState.canManageBilling = true;
+  recipientsState.current = [];
   billingState.plan = "free";
   billingState.isLoading = false;
   window.history.replaceState(null, "", "/evals");
@@ -109,28 +127,33 @@ describe("PlanLimitDialog", () => {
     openEvalLimit();
     render(<PlanLimitDialog />);
 
-    expect(screen.getByTestId("upgrade-annual")).toHaveTextContent(
-      "$30/seat/mo"
-    );
-    expect(screen.getByTestId("upgrade-annual")).toHaveTextContent("Save 21%");
-    expect(screen.getByTestId("upgrade-monthly")).toHaveTextContent(
+    const annual = screen.getByTestId("upgrade-interval-annual");
+    expect(annual).toHaveTextContent("$30/seat/mo");
+    expect(annual).toHaveTextContent("Save 21%");
+    expect(screen.getByTestId("upgrade-interval-monthly")).toHaveTextContent(
       "$38/seat/mo"
     );
-    expect(
-      screen.getByText(/confirm on Stripe before paying/i)
-    ).toBeInTheDocument();
+    expect(screen.getByTestId("upgrade-plan-cta")).toHaveTextContent(
+      /Upgrade to Team/
+    );
   });
 
-  it("starts checkout on the interval the user pressed", async () => {
+  it("selects an interval, then confirms with the upgrade button", async () => {
     const user = userEvent.setup();
     openEvalLimit();
     render(<PlanLimitDialog />);
 
-    await user.click(screen.getByTestId("upgrade-monthly"));
-    expect(startMock).toHaveBeenCalledWith("monthly");
+    // Annual leads, and selecting is separate from confirming: pressing a card
+    // must not start checkout on its own.
+    expect(screen.getByTestId("upgrade-interval-annual")).toHaveAttribute(
+      "aria-checked",
+      "true"
+    );
+    await user.click(screen.getByTestId("upgrade-interval-monthly"));
+    expect(startMock).not.toHaveBeenCalled();
 
-    await user.click(screen.getByTestId("upgrade-annual"));
-    expect(startMock).toHaveBeenLastCalledWith("annual");
+    await user.click(screen.getByTestId("upgrade-plan-cta"));
+    expect(startMock).toHaveBeenCalledTimes(1);
   });
 
   it("has no wait-for-reset button; the close control is the only dismissal", () => {
@@ -145,15 +168,38 @@ describe("PlanLimitDialog", () => {
     ).toBeInTheDocument();
   });
 
-  it("explains who can upgrade instead of showing a CTA the server would reject", () => {
+  it("offers an owner email instead of a CTA the server would reject", () => {
     upgradeState.canManageBilling = false;
+    recipientsState.current = [
+      { email: "dana@acme.test", name: "Dana Ruiz" },
+    ];
     openEvalLimit();
     render(<PlanLimitDialog />);
 
     expect(
       screen.getByTestId("plan-limit-dialog-description")
-    ).toHaveTextContent(/Only an organization owner or admin can upgrade/);
-    expect(screen.queryByTestId("upgrade-annual")).not.toBeInTheDocument();
+    ).toHaveTextContent(/Only an organization owner can upgrade/);
+    expect(screen.queryByTestId("upgrade-plan-cta")).not.toBeInTheDocument();
+
+    const mail = screen.getByTestId("request-upgrade-mail");
+    const href = decodeURIComponent(mail.getAttribute("href") ?? "");
+    expect(href).toContain("mailto:dana@acme.test");
+    expect(href).toContain("Acme Robotics");
+    expect(href).toContain("Organizations, then Billing");
+    // Says what it does. It opens a draft; it does not send anything.
+    expect(mail).toHaveTextContent(/Email your owner/);
+    expect(screen.getByText(/Opens a draft to Dana Ruiz/)).toBeInTheDocument();
+  });
+
+  it("hides the owner email when no owner address resolves", () => {
+    upgradeState.canManageBilling = false;
+    recipientsState.current = [];
+    openEvalLimit();
+    render(<PlanLimitDialog />);
+
+    expect(
+      screen.queryByTestId("request-upgrade-mail")
+    ).not.toBeInTheDocument();
   });
 
   it("points an org already on Team at Enterprise instead of Team", () => {
@@ -165,7 +211,7 @@ describe("PlanLimitDialog", () => {
     expect(description).toHaveTextContent(/Your plan includes 5,000 a month/);
     expect(description).toHaveTextContent(/Enterprise adds negotiated usage/);
     expect(description).not.toHaveTextContent(/Our Team plan/);
-    expect(screen.queryByTestId("upgrade-annual")).not.toBeInTheDocument();
+    expect(screen.queryByTestId("upgrade-plan-cta")).not.toBeInTheDocument();
     expect(
       screen.getByTestId("plan-limit-enterprise-cta")
     ).toHaveTextContent(/Request upgrade/);

--- a/mcpjam-inspector/client/src/components/billing/__tests__/PlanLimitDialog.test.tsx
+++ b/mcpjam-inspector/client/src/components/billing/__tests__/PlanLimitDialog.test.tsx
@@ -21,6 +21,7 @@ const {
     upgradeState: { currentPlan: "free" as string, canManageBilling: true },
     recipientsState: {
       current: [] as Array<{ email: string; name?: string | null }>,
+      isLoading: false,
     },
     billingState: { plan: "free" as string, isLoading: false },
   }));
@@ -39,8 +40,8 @@ vi.mock("@/hooks/use-upgrade-checkout", async (importOriginal) => {
     useUpgradeCheckout: () => ({
       interval: "annual" as const,
       setInterval: vi.fn(),
-      annualPriceLabel: "$30/seat/mo",
-      monthlyPriceLabel: "$38/seat/mo",
+      annualPriceLabel: "$30",
+      monthlyPriceLabel: "$38",
       annualDiscountPct: 21,
       annualSupported: true,
       monthlySupported: true,
@@ -66,7 +67,10 @@ vi.mock("@/hooks/useOrganizationBilling", () => ({
 }));
 
 vi.mock("@/hooks/use-upgrade-request-recipients", () => ({
-  useUpgradeRequestRecipients: () => recipientsState.current,
+  useUpgradeRequestRecipients: () => ({
+    recipients: recipientsState.current,
+    isLoading: recipientsState.isLoading,
+  }),
 }));
 
 const RESETS_AT = Date.UTC(2026, 7, 11, 4, 0);
@@ -94,6 +98,7 @@ beforeEach(() => {
   upgradeState.currentPlan = "free";
   upgradeState.canManageBilling = true;
   recipientsState.current = [];
+  recipientsState.isLoading = false;
   billingState.plan = "free";
   billingState.isLoading = false;
   window.history.replaceState(null, "", "/evals");
@@ -128,10 +133,11 @@ describe("PlanLimitDialog", () => {
     render(<PlanLimitDialog />);
 
     const annual = screen.getByTestId("upgrade-interval-annual");
-    expect(annual).toHaveTextContent("$30/seat/mo");
+    expect(annual).toHaveTextContent("$30");
+    expect(annual).toHaveTextContent("per seat/month");
     expect(annual).toHaveTextContent("Save 21%");
     expect(screen.getByTestId("upgrade-interval-monthly")).toHaveTextContent(
-      "$38/seat/mo"
+      "$38"
     );
     expect(screen.getByTestId("upgrade-plan-cta")).toHaveTextContent(
       /Upgrade to Team/
@@ -178,7 +184,7 @@ describe("PlanLimitDialog", () => {
 
     expect(
       screen.getByTestId("plan-limit-dialog-description")
-    ).toHaveTextContent(/Only an organization owner can upgrade/);
+    ).toHaveTextContent(/Only an owner can upgrade this organization/);
     expect(screen.queryByTestId("upgrade-plan-cta")).not.toBeInTheDocument();
 
     const mail = screen.getByTestId("request-upgrade-mail");
@@ -191,9 +197,25 @@ describe("PlanLimitDialog", () => {
     expect(screen.getByText(/Opens a draft to Dana Ruiz/)).toBeInTheDocument();
   });
 
-  it("hides the owner email when no owner address resolves", () => {
+  it("holds a disabled button while the owner lookup is in flight", () => {
+    upgradeState.canManageBilling = false;
+    recipientsState.isLoading = true;
+    openEvalLimit();
+    render(<PlanLimitDialog />);
+
+    // Empty recipients plus loading must not read as "no owner": that would
+    // render nothing now and pop a button in a beat later.
+    const button = screen.getByRole("button", { name: /email your owner/i });
+    expect(button).toBeDisabled();
+    expect(
+      screen.queryByTestId("request-upgrade-mail")
+    ).not.toBeInTheDocument();
+  });
+
+  it("hides the owner email when the lookup finishes with no owner", () => {
     upgradeState.canManageBilling = false;
     recipientsState.current = [];
+  recipientsState.isLoading = false;
     openEvalLimit();
     render(<PlanLimitDialog />);
 

--- a/mcpjam-inspector/client/src/components/billing/__tests__/PlanLimitDialog.test.tsx
+++ b/mcpjam-inspector/client/src/components/billing/__tests__/PlanLimitDialog.test.tsx
@@ -129,7 +129,7 @@ describe("PlanLimitDialog", () => {
     // The Team figure comes from the plan catalog, so it tracks what billing
     // enforces rather than a hardcoded marketing string.
     expect(description).toHaveTextContent(
-      /Our Team plan includes 5,000 a month/
+      /Our Team plan includes 5,000 per seat each month/
     );
   });
 
@@ -213,6 +213,17 @@ describe("PlanLimitDialog", () => {
 
     await user.click(screen.getByTestId("upgrade-plan-cta"));
     expect(startMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("closes after an in-place plan change succeeds", async () => {
+    const user = userEvent.setup();
+    startMock.mockResolvedValue({ redirected: false, shouldDismiss: true });
+    openEvalLimit();
+    render(<PlanLimitDialog />);
+
+    await user.click(screen.getByTestId("upgrade-plan-cta"));
+
+    expect(usePlanLimitDialogStore.getState().isOpen).toBe(false);
   });
 
   it("has no wait-for-reset button; the close control is the only dismissal", () => {

--- a/mcpjam-inspector/client/src/components/billing/__tests__/PlanLimitDialog.test.tsx
+++ b/mcpjam-inspector/client/src/components/billing/__tests__/PlanLimitDialog.test.tsx
@@ -1,5 +1,5 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import { render, screen, waitFor } from "@testing-library/react";
+import { act, render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { PlanLimitDialog } from "../PlanLimitDialog";
 import { usePlanLimitDialogStore } from "@/stores/plan-limit-dialog-store";
@@ -282,23 +282,57 @@ describe("PlanLimitDialog", () => {
       );
     });
 
-    it("stays silent when the user bailed at checkout", async () => {
+    it("waits for delayed billing state before confirming checkout", async () => {
       billingState.plan = "free";
       window.history.replaceState(
         null,
         "",
         "/evals?upgrade=return&upgrade_org=org-1&upgrade_from=evals"
       );
-      render(<PlanLimitDialog />);
+      const view = render(<PlanLimitDialog />);
 
+      expect(window.location.search).toContain("upgrade=return");
+      expect(toastSuccess).not.toHaveBeenCalled();
+      expect(trackMock).not.toHaveBeenCalledWith(
+        "plan_limit_upgrade_returned",
+        expect.anything()
+      );
+
+      billingState.plan = "team";
+      view.rerender(<PlanLimitDialog />);
       await waitFor(() => {
+        expect(toastSuccess).toHaveBeenCalledWith(
+          expect.stringMatching(/You're on our Team plan/)
+        );
+      });
+      expect(window.location.search).toBe("");
+    });
+
+    it("stays silent after the settlement window when checkout was abandoned", async () => {
+      vi.useFakeTimers();
+      try {
+        billingState.plan = "free";
+        window.history.replaceState(
+          null,
+          "",
+          "/evals?upgrade=return&upgrade_org=org-1&upgrade_from=evals"
+        );
+        render(<PlanLimitDialog />);
+
+        expect(window.location.search).toContain("upgrade=return");
+        await act(async () => {
+          await vi.advanceTimersByTimeAsync(30_000);
+        });
+
         expect(trackMock).toHaveBeenCalledWith(
           "plan_limit_upgrade_returned",
           expect.objectContaining({ upgraded: false })
         );
-      });
-      expect(toastSuccess).not.toHaveBeenCalled();
-      expect(window.location.search).toBe("");
+        expect(toastSuccess).not.toHaveBeenCalled();
+        expect(window.location.search).toBe("");
+      } finally {
+        vi.useRealTimers();
+      }
     });
 
     it("uses credit wording when the user came from the credits wall", async () => {

--- a/mcpjam-inspector/client/src/components/billing/__tests__/PlanLimitDialog.test.tsx
+++ b/mcpjam-inspector/client/src/components/billing/__tests__/PlanLimitDialog.test.tsx
@@ -23,7 +23,10 @@ const {
     canManageBilling: true,
   },
   recipientsState: {
-    current: [] as Array<{ email: string; name?: string | null }>,
+    current: {
+      recipients: [] as Array<{ email: string; name?: string | null }>,
+      isLoading: false,
+    },
   },
   billingState: { plan: "free" as string, isLoading: false },
 }));
@@ -100,7 +103,7 @@ beforeEach(() => {
   upgradeState.currentPlan = "free";
   upgradeState.effectivePlan = "free";
   upgradeState.canManageBilling = true;
-  recipientsState.current = [];
+  recipientsState.current = { recipients: [], isLoading: false };
   billingState.plan = "free";
   billingState.isLoading = false;
   window.history.replaceState(null, "", "/evals");
@@ -152,6 +155,32 @@ describe("PlanLimitDialog", () => {
     );
   });
 
+  it("waits for owner recipients before reporting a request impression", () => {
+    upgradeState.canManageBilling = false;
+    recipientsState.current = { recipients: [], isLoading: true };
+    openEvalLimit();
+    const view = render(<PlanLimitDialog />);
+
+    expect(trackMock).not.toHaveBeenCalledWith(
+      "plan_limit_dialog_shown",
+      expect.anything()
+    );
+
+    recipientsState.current = {
+      recipients: [{ email: "dana@acme.test", name: "Dana Ruiz" }],
+      isLoading: false,
+    };
+    view.rerender(<PlanLimitDialog />);
+
+    expect(trackMock).toHaveBeenCalledWith(
+      "plan_limit_dialog_shown",
+      expect.objectContaining({
+        primary_action: "request_owner",
+        request_recipient_count: 1,
+      })
+    );
+  });
+
   it("shows both prices at once, no toggle to discover", () => {
     openEvalLimit();
     render(<PlanLimitDialog />);
@@ -198,7 +227,10 @@ describe("PlanLimitDialog", () => {
 
   it("offers an owner email instead of a CTA the server would reject", () => {
     upgradeState.canManageBilling = false;
-    recipientsState.current = [{ email: "dana@acme.test", name: "Dana Ruiz" }];
+    recipientsState.current = {
+      recipients: [{ email: "dana@acme.test", name: "Dana Ruiz" }],
+      isLoading: false,
+    };
     openEvalLimit();
     render(<PlanLimitDialog />);
 
@@ -219,7 +251,7 @@ describe("PlanLimitDialog", () => {
 
   it("hides the owner email when there is no address to write to", () => {
     upgradeState.canManageBilling = false;
-    recipientsState.current = [];
+    recipientsState.current = { recipients: [], isLoading: false };
     openEvalLimit();
     render(<PlanLimitDialog />);
 

--- a/mcpjam-inspector/client/src/components/billing/__tests__/PlanLimitDialog.test.tsx
+++ b/mcpjam-inspector/client/src/components/billing/__tests__/PlanLimitDialog.test.tsx
@@ -27,9 +27,8 @@ vi.mock("@/hooks/use-upgrade-checkout", async (importOriginal) => {
   return {
     ...actual,
     useUpgradeCheckout: () => ({
-      interval: "annual" as const,
-      setInterval: vi.fn(),
-      priceLabel: "$30/seat/mo",
+      annualPriceLabel: "$30/seat/mo",
+      monthlyPriceLabel: "$38/seat/mo",
       annualDiscountPct: 21,
       annualSupported: true,
       monthlySupported: true,
@@ -106,20 +105,32 @@ describe("PlanLimitDialog", () => {
     );
   });
 
-  it("offers both billing intervals with the upgrade CTA", () => {
+  it("shows both prices at once, no toggle to discover", () => {
     openEvalLimit();
     render(<PlanLimitDialog />);
 
-    expect(
-      screen.getByRole("button", { name: /annual/i })
-    ).toBeInTheDocument();
-    expect(
-      screen.getByRole("button", { name: /monthly/i })
-    ).toBeInTheDocument();
-    expect(screen.getByText("$30/seat/mo")).toBeInTheDocument();
-    expect(screen.getByTestId("upgrade-plan-cta")).toHaveTextContent(
-      /Upgrade to Team/
+    expect(screen.getByTestId("upgrade-annual")).toHaveTextContent(
+      "$30/seat/mo"
     );
+    expect(screen.getByTestId("upgrade-annual")).toHaveTextContent("Save 21%");
+    expect(screen.getByTestId("upgrade-monthly")).toHaveTextContent(
+      "$38/seat/mo"
+    );
+    expect(
+      screen.getByText(/confirm on Stripe before paying/i)
+    ).toBeInTheDocument();
+  });
+
+  it("starts checkout on the interval the user pressed", async () => {
+    const user = userEvent.setup();
+    openEvalLimit();
+    render(<PlanLimitDialog />);
+
+    await user.click(screen.getByTestId("upgrade-monthly"));
+    expect(startMock).toHaveBeenCalledWith("monthly");
+
+    await user.click(screen.getByTestId("upgrade-annual"));
+    expect(startMock).toHaveBeenLastCalledWith("annual");
   });
 
   it("has no wait-for-reset button; the close control is the only dismissal", () => {
@@ -134,15 +145,6 @@ describe("PlanLimitDialog", () => {
     ).toBeInTheDocument();
   });
 
-  it("starts checkout from the CTA", async () => {
-    const user = userEvent.setup();
-    openEvalLimit();
-    render(<PlanLimitDialog />);
-
-    await user.click(screen.getByTestId("upgrade-plan-cta"));
-    expect(startMock).toHaveBeenCalledTimes(1);
-  });
-
   it("explains who can upgrade instead of showing a CTA the server would reject", () => {
     upgradeState.canManageBilling = false;
     openEvalLimit();
@@ -151,7 +153,7 @@ describe("PlanLimitDialog", () => {
     expect(
       screen.getByTestId("plan-limit-dialog-description")
     ).toHaveTextContent(/Only an organization owner or admin can upgrade/);
-    expect(screen.queryByTestId("upgrade-plan-cta")).not.toBeInTheDocument();
+    expect(screen.queryByTestId("upgrade-annual")).not.toBeInTheDocument();
   });
 
   it("points an org already on Team at Enterprise instead of Team", () => {
@@ -163,7 +165,7 @@ describe("PlanLimitDialog", () => {
     expect(description).toHaveTextContent(/Your plan includes 5,000 a month/);
     expect(description).toHaveTextContent(/Enterprise adds negotiated usage/);
     expect(description).not.toHaveTextContent(/Our Team plan/);
-    expect(screen.queryByTestId("upgrade-plan-cta")).not.toBeInTheDocument();
+    expect(screen.queryByTestId("upgrade-annual")).not.toBeInTheDocument();
     expect(
       screen.getByTestId("plan-limit-enterprise-cta")
     ).toHaveTextContent(/Request upgrade/);

--- a/mcpjam-inspector/client/src/components/billing/__tests__/PlanLimitDialog.test.tsx
+++ b/mcpjam-inspector/client/src/components/billing/__tests__/PlanLimitDialog.test.tsx
@@ -1,0 +1,285 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { PlanLimitDialog } from "../PlanLimitDialog";
+import { usePlanLimitDialogStore } from "@/stores/plan-limit-dialog-store";
+
+// Hoisted so the vi.mock factories below (which vitest lifts to the top of the
+// file) can reach them.
+const { toastSuccess, trackMock, startMock, upgradeState, billingState } =
+  vi.hoisted(() => ({
+    toastSuccess: vi.fn(),
+    trackMock: vi.fn(),
+    startMock: vi.fn(),
+    upgradeState: { currentPlan: "free" as string, canManageBilling: true },
+    billingState: { plan: "free" as string, isLoading: false },
+  }));
+
+vi.mock("@/lib/toast", () => ({
+  toast: { success: toastSuccess, error: vi.fn() },
+}));
+
+vi.mock("@/lib/analytics", () => ({ track: trackMock }));
+
+vi.mock("@/hooks/use-upgrade-checkout", async (importOriginal) => {
+  const actual =
+    await importOriginal<typeof import("@/hooks/use-upgrade-checkout")>();
+  return {
+    ...actual,
+    useUpgradeCheckout: () => ({
+      interval: "annual" as const,
+      setInterval: vi.fn(),
+      priceLabel: "$30/seat/mo",
+      annualDiscountPct: 21,
+      annualSupported: true,
+      monthlySupported: true,
+      teamName: "Team",
+      teamEvalIterations: 5000,
+      currentPlan: upgradeState.currentPlan,
+      canManageBilling: upgradeState.canManageBilling,
+      isStarting: false,
+      start: startMock,
+    }),
+  };
+});
+
+vi.mock("@/hooks/useOrganizationBilling", () => ({
+  useOrganizationBilling: () => ({
+    billingStatus: billingState.isLoading
+      ? undefined
+      : { plan: billingState.plan, billingInterval: "annual" },
+    planCatalog: { plans: { team: { displayName: "Team" } } },
+    isLoadingBilling: billingState.isLoading,
+  }),
+}));
+
+const RESETS_AT = Date.UTC(2026, 7, 11, 4, 0);
+
+function openEvalLimit(overrides: Record<string, unknown> = {}) {
+  usePlanLimitDialogStore.setState({
+    isOpen: true,
+    limit: {
+      kind: "evalIterations",
+      organizationId: "org-1",
+      used: 75,
+      allowed: 75,
+      resetsAt: RESETS_AT,
+      windowKind: "day",
+      origin: "evals",
+      ...overrides,
+    } as never,
+  });
+}
+
+beforeEach(() => {
+  toastSuccess.mockReset();
+  trackMock.mockReset();
+  startMock.mockReset();
+  upgradeState.currentPlan = "free";
+  upgradeState.canManageBilling = true;
+  billingState.plan = "free";
+  billingState.isLoading = false;
+  window.history.replaceState(null, "", "/evals");
+  usePlanLimitDialogStore.setState({ isOpen: false, limit: null });
+});
+
+describe("PlanLimitDialog", () => {
+  it("renders nothing while closed", () => {
+    const { container } = render(<PlanLimitDialog />);
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it("names the allowance, the reset time, and the catalog Team figure", () => {
+    openEvalLimit();
+    render(<PlanLimitDialog />);
+
+    expect(
+      screen.getByRole("heading", { name: /out of eval iterations today/i })
+    ).toBeInTheDocument();
+    const description = screen.getByTestId("plan-limit-dialog-description");
+    expect(description).toHaveTextContent(/Free includes 75 a day/);
+    expect(description).toHaveTextContent(/yours reset at/i);
+    // The Team figure comes from the plan catalog, so it tracks what billing
+    // enforces rather than a hardcoded marketing string.
+    expect(description).toHaveTextContent(
+      /Our Team plan includes 5,000 a month/
+    );
+  });
+
+  it("offers both billing intervals with the upgrade CTA", () => {
+    openEvalLimit();
+    render(<PlanLimitDialog />);
+
+    expect(
+      screen.getByRole("button", { name: /annual/i })
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: /monthly/i })
+    ).toBeInTheDocument();
+    expect(screen.getByText("$30/seat/mo")).toBeInTheDocument();
+    expect(screen.getByTestId("upgrade-plan-cta")).toHaveTextContent(
+      /Upgrade to Team/
+    );
+  });
+
+  it("has no wait-for-reset button; the close control is the only dismissal", () => {
+    openEvalLimit();
+    render(<PlanLimitDialog />);
+
+    expect(
+      screen.queryByRole("button", { name: /wait for reset/i })
+    ).not.toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: /close/i })
+    ).toBeInTheDocument();
+  });
+
+  it("starts checkout from the CTA", async () => {
+    const user = userEvent.setup();
+    openEvalLimit();
+    render(<PlanLimitDialog />);
+
+    await user.click(screen.getByTestId("upgrade-plan-cta"));
+    expect(startMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("explains who can upgrade instead of showing a CTA the server would reject", () => {
+    upgradeState.canManageBilling = false;
+    openEvalLimit();
+    render(<PlanLimitDialog />);
+
+    expect(
+      screen.getByTestId("plan-limit-dialog-description")
+    ).toHaveTextContent(/Only an organization owner or admin can upgrade/);
+    expect(screen.queryByTestId("upgrade-plan-cta")).not.toBeInTheDocument();
+  });
+
+  it("points an org already on Team at Enterprise instead of Team", () => {
+    upgradeState.currentPlan = "team";
+    openEvalLimit({ allowed: 5000, windowKind: "month" });
+    render(<PlanLimitDialog />);
+
+    const description = screen.getByTestId("plan-limit-dialog-description");
+    expect(description).toHaveTextContent(/Your plan includes 5,000 a month/);
+    expect(description).toHaveTextContent(/Enterprise adds negotiated usage/);
+    expect(description).not.toHaveTextContent(/Our Team plan/);
+    expect(screen.queryByTestId("upgrade-plan-cta")).not.toBeInTheDocument();
+    expect(
+      screen.getByTestId("plan-limit-enterprise-cta")
+    ).toHaveTextContent(/Request upgrade/);
+  });
+
+  it("reports the Enterprise CTA click", async () => {
+    const user = userEvent.setup();
+    upgradeState.currentPlan = "team";
+    openEvalLimit({ allowed: 5000, windowKind: "month" });
+    render(<PlanLimitDialog />);
+
+    await user.click(screen.getByTestId("plan-limit-enterprise-cta"));
+    expect(trackMock).toHaveBeenCalledWith(
+      "plan_limit_enterprise_cta_clicked",
+      expect.objectContaining({ plan: "team" })
+    );
+    expect(usePlanLimitDialogStore.getState().isOpen).toBe(false);
+  });
+
+  it("offers nothing to pitch when the org is already on Enterprise", () => {
+    upgradeState.currentPlan = "enterprise";
+    openEvalLimit({ allowed: 50000, windowKind: "month" });
+    render(<PlanLimitDialog />);
+
+    const description = screen.getByTestId("plan-limit-dialog-description");
+    expect(description).toHaveTextContent(/Your plan includes 50,000 a month/);
+    expect(description).not.toHaveTextContent(/Enterprise adds/);
+    expect(
+      screen.queryByTestId("plan-limit-enterprise-cta")
+    ).not.toBeInTheDocument();
+  });
+
+  it("closes and reports a dismissal", async () => {
+    const user = userEvent.setup();
+    openEvalLimit();
+    render(<PlanLimitDialog />);
+
+    await user.click(screen.getByRole("button", { name: /close/i }));
+    expect(usePlanLimitDialogStore.getState().isOpen).toBe(false);
+    expect(trackMock).toHaveBeenCalledWith(
+      "plan_limit_dialog_dismissed",
+      expect.objectContaining({ limit_kind: "evalIterations" })
+    );
+  });
+
+  describe("checkout return", () => {
+    it("confirms in place and strips the return params once the plan is paid", async () => {
+      billingState.plan = "team";
+      window.history.replaceState(
+        null,
+        "",
+        "/evals?suite=abc&upgrade=return&upgrade_org=org-1&upgrade_from=evals"
+      );
+      render(<PlanLimitDialog />);
+
+      await waitFor(() => {
+        expect(toastSuccess).toHaveBeenCalledWith(
+          expect.stringMatching(/You're on our Team plan/)
+        );
+      });
+      // The surface the user was blocked on is preserved; only the upgrade
+      // bookkeeping is removed.
+      expect(window.location.search).toBe("?suite=abc");
+      expect(trackMock).toHaveBeenCalledWith(
+        "plan_limit_upgrade_returned",
+        expect.objectContaining({ upgraded: true, plan: "team" })
+      );
+    });
+
+    it("stays silent when the user bailed at checkout", async () => {
+      billingState.plan = "free";
+      window.history.replaceState(
+        null,
+        "",
+        "/evals?upgrade=return&upgrade_org=org-1&upgrade_from=evals"
+      );
+      render(<PlanLimitDialog />);
+
+      await waitFor(() => {
+        expect(trackMock).toHaveBeenCalledWith(
+          "plan_limit_upgrade_returned",
+          expect.objectContaining({ upgraded: false })
+        );
+      });
+      expect(toastSuccess).not.toHaveBeenCalled();
+      expect(window.location.search).toBe("");
+    });
+
+    it("uses credit wording when the user came from the credits wall", async () => {
+      billingState.plan = "team";
+      window.history.replaceState(
+        null,
+        "",
+        "/chat?upgrade=return&upgrade_org=org-1&upgrade_from=credits"
+      );
+      render(<PlanLimitDialog />);
+
+      await waitFor(() => {
+        expect(toastSuccess).toHaveBeenCalledWith(
+          expect.stringMatching(/Your credits are available now/)
+        );
+      });
+    });
+
+    it("waits for billing status before deciding", () => {
+      billingState.isLoading = true;
+      window.history.replaceState(
+        null,
+        "",
+        "/evals?upgrade=return&upgrade_org=org-1"
+      );
+      render(<PlanLimitDialog />);
+
+      expect(toastSuccess).not.toHaveBeenCalled();
+      // Params survive so a later render can still resolve the outcome.
+      expect(window.location.search).toContain("upgrade=return");
+    });
+  });
+});

--- a/mcpjam-inspector/client/src/components/billing/__tests__/PlanLimitDialog.test.tsx
+++ b/mcpjam-inspector/client/src/components/billing/__tests__/PlanLimitDialog.test.tsx
@@ -21,7 +21,6 @@ const {
     upgradeState: { currentPlan: "free" as string, canManageBilling: true },
     recipientsState: {
       current: [] as Array<{ email: string; name?: string | null }>,
-      isLoading: false,
     },
     billingState: { plan: "free" as string, isLoading: false },
   }));
@@ -67,10 +66,7 @@ vi.mock("@/hooks/useOrganizationBilling", () => ({
 }));
 
 vi.mock("@/hooks/use-upgrade-request-recipients", () => ({
-  useUpgradeRequestRecipients: () => ({
-    recipients: recipientsState.current,
-    isLoading: recipientsState.isLoading,
-  }),
+  useUpgradeRequestRecipients: () => recipientsState.current,
 }));
 
 const RESETS_AT = Date.UTC(2026, 7, 11, 4, 0);
@@ -98,7 +94,6 @@ beforeEach(() => {
   upgradeState.currentPlan = "free";
   upgradeState.canManageBilling = true;
   recipientsState.current = [];
-  recipientsState.isLoading = false;
   billingState.plan = "free";
   billingState.isLoading = false;
   window.history.replaceState(null, "", "/evals");
@@ -197,25 +192,9 @@ describe("PlanLimitDialog", () => {
     expect(screen.getByText(/Opens a draft to Dana Ruiz/)).toBeInTheDocument();
   });
 
-  it("holds a disabled button while the owner lookup is in flight", () => {
-    upgradeState.canManageBilling = false;
-    recipientsState.isLoading = true;
-    openEvalLimit();
-    render(<PlanLimitDialog />);
-
-    // Empty recipients plus loading must not read as "no owner": that would
-    // render nothing now and pop a button in a beat later.
-    const button = screen.getByRole("button", { name: /email your owner/i });
-    expect(button).toBeDisabled();
-    expect(
-      screen.queryByTestId("request-upgrade-mail")
-    ).not.toBeInTheDocument();
-  });
-
-  it("hides the owner email when the lookup finishes with no owner", () => {
+  it("hides the owner email when there is no address to write to", () => {
     upgradeState.canManageBilling = false;
     recipientsState.current = [];
-  recipientsState.isLoading = false;
     openEvalLimit();
     render(<PlanLimitDialog />);
 

--- a/mcpjam-inspector/client/src/components/billing/__tests__/PlanLimitDialog.test.tsx
+++ b/mcpjam-inspector/client/src/components/billing/__tests__/PlanLimitDialog.test.tsx
@@ -190,7 +190,7 @@ describe("PlanLimitDialog", () => {
     expect(href).toContain("Acme Robotics");
     expect(href).toContain("Organizations, then Billing");
     // Says what it does. It opens a draft; it does not send anything.
-    expect(mail).toHaveTextContent(/Email your owner/);
+    expect(mail).toHaveTextContent(/Email your plan's owner/);
     expect(screen.getByText(/Opens a draft to Dana Ruiz/)).toBeInTheDocument();
   });
 

--- a/mcpjam-inspector/client/src/components/billing/__tests__/RequestUpgradeButton.test.tsx
+++ b/mcpjam-inspector/client/src/components/billing/__tests__/RequestUpgradeButton.test.tsx
@@ -49,6 +49,27 @@ describe("buildUpgradeRequestMail", () => {
     expect(decodeURIComponent(href!)).toContain("run out of credits");
   });
 
+  it("asks a paid organization to buy credits instead of upgrading", () => {
+    const href = buildUpgradeRequestMail({
+      recipients: [OWNER],
+      organizationName: "Acme Robotics",
+      teamName: "Team",
+      origin: "credits",
+      requestAction: "buyCredits",
+    });
+
+    const decoded = decodeURIComponent(href!);
+    expect(decoded).toContain("Credit purchase request for Acme Robotics");
+    expect(decoded).toContain(
+      "Our organization has run out of MCPJam credits."
+    );
+    expect(decoded).toContain(
+      "Could you buy more credits for Acme Robotics?"
+    );
+    expect(decoded).toContain("2. Under Credits, click Buy credits.");
+    expect(decoded).not.toContain("upgrade Acme Robotics to the Team plan");
+  });
+
   it("returns null when there is nobody to address", () => {
     expect(
       buildUpgradeRequestMail({

--- a/mcpjam-inspector/client/src/components/billing/__tests__/RequestUpgradeButton.test.tsx
+++ b/mcpjam-inspector/client/src/components/billing/__tests__/RequestUpgradeButton.test.tsx
@@ -1,0 +1,131 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import {
+  RequestUpgradeButton,
+  buildUpgradeRequestMail,
+} from "../RequestUpgradeButton";
+
+const { trackMock } = vi.hoisted(() => ({ trackMock: vi.fn() }));
+vi.mock("@/lib/analytics", () => ({ track: trackMock }));
+
+const OWNER = { email: "dana@acme.test", name: "Dana Ruiz" };
+
+beforeEach(() => {
+  trackMock.mockReset();
+});
+
+describe("buildUpgradeRequestMail", () => {
+  it("addresses every owner and spells out the steps they have to take", () => {
+    const href = buildUpgradeRequestMail({
+      recipients: [OWNER, { email: "sam@acme.test", name: null }],
+      organizationName: "Acme Robotics",
+      teamName: "Team",
+      origin: "evals",
+    });
+
+    expect(href).not.toBeNull();
+    const decoded = decodeURIComponent(href!);
+    expect(decoded).toContain("mailto:dana@acme.test,sam@acme.test");
+    expect(decoded).toContain(
+      "Upgrade request: MCPJam Team plan for Acme Robotics"
+    );
+    expect(decoded).toContain("Hi Dana,");
+    expect(decoded).toContain("hit the free plan's eval iteration limit");
+    // The owner cannot act on a request that doesn't say what to do.
+    expect(decoded).toContain("1. Open MCPJam, go to Organizations, then Billing.");
+    expect(decoded).toContain("2. Under the Team plan, pick Annual or Monthly.");
+    expect(decoded).toContain("3. Click Upgrade and finish checkout with Stripe.");
+  });
+
+  it("describes the credits wall differently from the eval wall", () => {
+    const href = buildUpgradeRequestMail({
+      recipients: [OWNER],
+      organizationName: "Acme Robotics",
+      teamName: "Team",
+      origin: "credits",
+    });
+
+    expect(decodeURIComponent(href!)).toContain("run out of credits");
+  });
+
+  it("returns null when there is nobody to address", () => {
+    expect(
+      buildUpgradeRequestMail({
+        recipients: [],
+        organizationName: "Acme Robotics",
+        teamName: "Team",
+        origin: "evals",
+      })
+    ).toBeNull();
+  });
+});
+
+describe("RequestUpgradeButton", () => {
+  it("renders a mailto anchor naming the recipient", () => {
+    render(
+      <RequestUpgradeButton
+        recipients={[OWNER]}
+        organizationName="Acme Robotics"
+        teamName="Team"
+        origin="evals"
+        limitKind="evalIterations"
+      />
+    );
+
+    expect(screen.getByTestId("request-upgrade-mail")).toHaveAttribute(
+      "href",
+      expect.stringContaining("mailto:dana@acme.test")
+    );
+    expect(screen.getByText(/Opens a draft to Dana Ruiz/)).toBeInTheDocument();
+  });
+
+  it("counts the other owners when there are several", () => {
+    render(
+      <RequestUpgradeButton
+        recipients={[OWNER, { email: "sam@acme.test" }]}
+        organizationName="Acme Robotics"
+        teamName="Team"
+        origin="evals"
+        limitKind="evalIterations"
+      />
+    );
+
+    expect(
+      screen.getByText(/Opens a draft to Dana Ruiz and 1 other owner/)
+    ).toBeInTheDocument();
+  });
+
+  it("renders nothing rather than a button that opens an empty draft", () => {
+    const { container } = render(
+      <RequestUpgradeButton
+        recipients={[]}
+        organizationName="Acme Robotics"
+        teamName="Team"
+        origin="evals"
+        limitKind="evalIterations"
+      />
+    );
+
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it("reports the request", async () => {
+    const user = userEvent.setup();
+    render(
+      <RequestUpgradeButton
+        recipients={[OWNER]}
+        organizationName="Acme Robotics"
+        teamName="Team"
+        origin="evals"
+        limitKind="evalIterations"
+      />
+    );
+
+    await user.click(screen.getByTestId("request-upgrade-mail"));
+    expect(trackMock).toHaveBeenCalledWith(
+      "plan_limit_upgrade_requested",
+      expect.objectContaining({ origin: "evals", recipient_count: 1 })
+    );
+  });
+});

--- a/mcpjam-inspector/client/src/components/chat-v2/shared/available-models.ts
+++ b/mcpjam-inspector/client/src/components/chat-v2/shared/available-models.ts
@@ -47,7 +47,7 @@ export function applyGuestModelLocks(
 }
 
 export const OUT_OF_CREDITS_MODEL_REASON =
-  "You're out of credits. Top up or use your own key.";
+  "You're out of credits. Upgrade, buy credits, or use your own key.";
 
 /**
  * Once the org/guest is out of MCPJam credits, MCPJam-provided ("free")

--- a/mcpjam-inspector/client/src/components/mcpjam-limit-dialog.tsx
+++ b/mcpjam-inspector/client/src/components/mcpjam-limit-dialog.tsx
@@ -64,8 +64,7 @@ export function MCPJamLimitDialog() {
     origin: "credits",
     limitKind: "credits",
   });
-  const { recipients: requestRecipients, isLoading: isLoadingRecipients } =
-    useUpgradeRequestRecipients(resolveBillingOrgId());
+  const requestRecipients = useUpgradeRequestRecipients(resolveBillingOrgId());
 
   if (isLoading) return null;
 
@@ -161,7 +160,6 @@ export function MCPJamLimitDialog() {
             {isKnownNonManager ? (
               <RequestUpgradeButton
                 recipients={requestRecipients}
-                isLoadingRecipients={isLoadingRecipients}
                 organizationName={creditsUpgrade.organizationName}
                 teamName={creditsUpgrade.teamName}
                 origin="credits"

--- a/mcpjam-inspector/client/src/components/mcpjam-limit-dialog.tsx
+++ b/mcpjam-inspector/client/src/components/mcpjam-limit-dialog.tsx
@@ -19,7 +19,9 @@ import { useMCPJamLimitDialogStore } from "@/stores/mcpjam-limit-dialog-store";
 import { useModelPickerIntentStore } from "@/stores/model-picker-intent-store";
 import { useAppNavigate } from "@/lib/app-navigation";
 import { useUpgradeCheckout } from "@/hooks/use-upgrade-checkout";
+import { useUpgradeRequestRecipients } from "@/hooks/use-upgrade-request-recipients";
 import { UpgradeIntervalPicker } from "@/components/billing/UpgradeIntervalPicker";
+import { RequestUpgradeButton } from "@/components/billing/RequestUpgradeButton";
 
 export function MCPJamLimitDialog() {
   const isOpen = useMCPJamLimitDialogStore((s) => s.isOpen);
@@ -62,6 +64,7 @@ export function MCPJamLimitDialog() {
     origin: "credits",
     limitKind: "credits",
   });
+  const requestRecipients = useUpgradeRequestRecipients(resolveBillingOrgId());
 
   if (isLoading) return null;
 
@@ -154,10 +157,20 @@ export function MCPJamLimitDialog() {
             {/* Non-managers get no CTAs, just the "ask an owner" copy. Managers
                 lead with the plan upgrade: buying credits keeps the org on Free
                 at a variable cost, so it stays available but secondary. */}
-            {!isKnownNonManager ? (
+            {isKnownNonManager ? (
+              <RequestUpgradeButton
+                recipients={requestRecipients}
+                organizationName={creditsUpgrade.organizationName}
+                teamName={creditsUpgrade.teamName}
+                origin="credits"
+                limitKind="credits"
+              />
+            ) : (
               <>
                 {showCreditsUpgrade ? (
                   <UpgradeIntervalPicker
+                    interval={creditsUpgrade.interval}
+                    onIntervalChange={creditsUpgrade.setInterval}
                     annualPriceLabel={creditsUpgrade.annualPriceLabel}
                     monthlyPriceLabel={creditsUpgrade.monthlyPriceLabel}
                     annualDiscountPct={creditsUpgrade.annualDiscountPct}
@@ -165,9 +178,7 @@ export function MCPJamLimitDialog() {
                     monthlySupported={creditsUpgrade.monthlySupported}
                     teamName={creditsUpgrade.teamName}
                     isStarting={creditsUpgrade.isStarting}
-                    onUpgrade={(interval) =>
-                      void creditsUpgrade.start(interval)
-                    }
+                    onUpgrade={() => void creditsUpgrade.start()}
                   />
                 ) : null}
                 <DialogFooter className="sm:justify-between">
@@ -188,7 +199,7 @@ export function MCPJamLimitDialog() {
                   </Button>
                 </DialogFooter>
               </>
-            ) : null}
+            )}
           </DialogContent>
         </Dialog>
       )}

--- a/mcpjam-inspector/client/src/components/mcpjam-limit-dialog.tsx
+++ b/mcpjam-inspector/client/src/components/mcpjam-limit-dialog.tsx
@@ -64,7 +64,8 @@ export function MCPJamLimitDialog() {
     origin: "credits",
     limitKind: "credits",
   });
-  const requestRecipients = useUpgradeRequestRecipients(resolveBillingOrgId());
+  const { recipients: requestRecipients, isLoading: isLoadingRecipients } =
+    useUpgradeRequestRecipients(resolveBillingOrgId());
 
   if (isLoading) return null;
 
@@ -160,6 +161,7 @@ export function MCPJamLimitDialog() {
             {isKnownNonManager ? (
               <RequestUpgradeButton
                 recipients={requestRecipients}
+                isLoadingRecipients={isLoadingRecipients}
                 organizationName={creditsUpgrade.organizationName}
                 teamName={creditsUpgrade.teamName}
                 origin="credits"

--- a/mcpjam-inspector/client/src/components/mcpjam-limit-dialog.tsx
+++ b/mcpjam-inspector/client/src/components/mcpjam-limit-dialog.tsx
@@ -67,7 +67,10 @@ export function MCPJamLimitDialog() {
     origin: "credits",
     limitKind: "credits",
   });
-  const requestRecipients = useUpgradeRequestRecipients(billingOrgId);
+  const {
+    recipients: requestRecipients,
+    isLoading: isLoadingRequestRecipients,
+  } = useUpgradeRequestRecipients(billingOrgId);
 
   // Only owners/admins/creators can buy credits (mirrors the backend gate).
   // Members instead see an "ask org admin" hint so they don't dead-end on a
@@ -123,6 +126,7 @@ export function MCPJamLimitDialog() {
     if (
       isLoadingOrganizations ||
       creditsUpgrade.isLoadingBilling ||
+      (isKnownNonManager && isLoadingRequestRecipients) ||
       creditsImpressionTrackedRef.current
     ) {
       return;
@@ -166,6 +170,7 @@ export function MCPJamLimitDialog() {
     creditsUpgrade.monthlySupported,
     isKnownNonManager,
     isLoadingOrganizations,
+    isLoadingRequestRecipients,
     requestRecipients.length,
     showCreditsUpgrade,
     showTopupDialog,

--- a/mcpjam-inspector/client/src/components/mcpjam-limit-dialog.tsx
+++ b/mcpjam-inspector/client/src/components/mcpjam-limit-dialog.tsx
@@ -158,15 +158,16 @@ export function MCPJamLimitDialog() {
               <>
                 {showCreditsUpgrade ? (
                   <UpgradeIntervalPicker
-                    interval={creditsUpgrade.interval}
-                    onIntervalChange={creditsUpgrade.setInterval}
-                    priceLabel={creditsUpgrade.priceLabel}
+                    annualPriceLabel={creditsUpgrade.annualPriceLabel}
+                    monthlyPriceLabel={creditsUpgrade.monthlyPriceLabel}
                     annualDiscountPct={creditsUpgrade.annualDiscountPct}
                     annualSupported={creditsUpgrade.annualSupported}
                     monthlySupported={creditsUpgrade.monthlySupported}
                     teamName={creditsUpgrade.teamName}
                     isStarting={creditsUpgrade.isStarting}
-                    onUpgrade={() => void creditsUpgrade.start()}
+                    onUpgrade={(interval) =>
+                      void creditsUpgrade.start(interval)
+                    }
                   />
                 ) : null}
                 <DialogFooter className="sm:justify-between">

--- a/mcpjam-inspector/client/src/components/mcpjam-limit-dialog.tsx
+++ b/mcpjam-inspector/client/src/components/mcpjam-limit-dialog.tsx
@@ -108,7 +108,7 @@ export function MCPJamLimitDialog() {
   // Pitching Team to an org already on Team would be nonsense; those orgs get
   // the buy-credits path only.
   const showCreditsUpgrade =
-    creditsUpgrade.currentPlan === "free" && creditsUpgrade.canManageBilling;
+    creditsUpgrade.effectivePlan === "free" && creditsUpgrade.canManageBilling;
 
   return (
     <>
@@ -139,9 +139,9 @@ export function MCPJamLimitDialog() {
           description={
             isKnownNonManager
               ? "Ask an organization owner or admin to buy credits or upgrade the plan."
-              : creditsUpgrade.currentPlan === "free"
-                ? `Free credits reset daily. Our ${creditsUpgrade.teamName} plan replaces the daily cap with a monthly allowance per seat, so usage isn't rationed day to day.`
-                : "Buy credits to keep your team going, or use your own API key."
+              : creditsUpgrade.effectivePlan === "free"
+              ? `Free credits reset daily. Our ${creditsUpgrade.teamName} plan replaces the daily cap with a monthly allowance per seat, so usage isn't rationed day to day.`
+              : "Buy credits to keep your team going, or use your own API key."
           }
           isKnownNonManager={isKnownNonManager}
           showUpgrade={showCreditsUpgrade}

--- a/mcpjam-inspector/client/src/components/mcpjam-limit-dialog.tsx
+++ b/mcpjam-inspector/client/src/components/mcpjam-limit-dialog.tsx
@@ -8,7 +8,7 @@ import {
 } from "@mcpjam/design-system/dialog";
 import { useAuth } from "@workos-inc/authkit-react";
 import { useConvexAuth } from "convex/react";
-import { useEffect } from "react";
+import { useEffect, useRef } from "react";
 import {
   canManageOrgCredits,
   useOrganizationQueries,
@@ -20,6 +20,7 @@ import { useAppNavigate } from "@/lib/app-navigation";
 import { useUpgradeCheckout } from "@/hooks/use-upgrade-checkout";
 import { useUpgradeRequestRecipients } from "@/hooks/use-upgrade-request-recipients";
 import { CreditsLimitDialogView } from "@/components/billing/CreditsLimitDialogView";
+import { track } from "@/lib/analytics";
 
 export function MCPJamLimitDialog() {
   const isOpen = useMCPJamLimitDialogStore((s) => s.isOpen);
@@ -34,8 +35,11 @@ export function MCPJamLimitDialog() {
   // Look up the user's orgs as a fallback in case there is no stored
   // active-org for this user (e.g. brand-new sign-in). Sorted most-recent
   // first by useOrganizationQueries.
-  const { sortedOrganizations } = useOrganizationQueries({ isAuthenticated });
+  const { sortedOrganizations, isLoading: isLoadingOrganizations } =
+    useOrganizationQueries({ isAuthenticated });
   const appNavigate = useAppNavigate();
+  const guestImpressionTrackedRef = useRef(false);
+  const creditsImpressionTrackedRef = useRef(false);
 
   useEffect(() => {
     setAuthStatus(isLoading ? "loading" : user ? "signedIn" : "guest");
@@ -57,14 +61,13 @@ export function MCPJamLimitDialog() {
     return sortedOrganizations[0]?._id ?? null;
   };
 
+  const billingOrgId = resolveBillingOrgId();
   const creditsUpgrade = useUpgradeCheckout({
-    organizationId: resolveBillingOrgId(),
+    organizationId: billingOrgId,
     origin: "credits",
     limitKind: "credits",
   });
-  const requestRecipients = useUpgradeRequestRecipients(resolveBillingOrgId());
-
-  if (isLoading) return null;
+  const requestRecipients = useUpgradeRequestRecipients(billingOrgId);
 
   // Only owners/admins/creators can buy credits (mirrors the backend gate).
   // Members instead see an "ask org admin" hint so they don't dead-end on a
@@ -72,34 +75,12 @@ export function MCPJamLimitDialog() {
   // still resolving (no match yet) we stay optimistic and show the buy
   // button — `handleTopUp` already no-ops until an org id is available, so an
   // actual admin never sees a premature "ask admin" flash.
-  const billingOrgId = resolveBillingOrgId();
   const billingOrg = billingOrgId
     ? sortedOrganizations.find((org) => org._id === billingOrgId) ?? null
     : null;
   const isKnownNonManager = billingOrg
     ? !canManageOrgCredits(billingOrg)
     : false;
-
-  const handleTopUp = () => {
-    const orgId = resolveBillingOrgId();
-    // Don't dismiss the modal until we know we can route the user — on a
-    // fresh sign-in the membership query may still be in flight, in which
-    // case closing now would drop them out of the upsell silently.
-    if (!orgId) return;
-    close();
-    // The router strips ?... before resolving the route, so the
-    // `topup=open` flag is invisible to navigation but visible to the
-    // billing page on mount.
-    appNavigate(`/organizations/${orgId}/billing?topup=open`);
-  };
-
-  const handleBYOK = () => {
-    // Don't yank the user to the org settings page — just close the dialog
-    // and pop open the chat model picker on its "Your providers" tab so they
-    // can switch to an own-key model in place. The free models stay grayed.
-    close();
-    useModelPickerIntentStore.getState().requestOpenProvidersTab();
-  };
 
   // Guest variant — only renders for unauthenticated users.
   const showGuestDialog = !user && intent === "guest" && isOpen;
@@ -110,11 +91,172 @@ export function MCPJamLimitDialog() {
   const isFreeEffectivePlan = creditsUpgrade.effectivePlan === "free";
   const showCreditsUpgrade =
     isFreeEffectivePlan && creditsUpgrade.canManageBilling;
-  const creditsRequestAction =
-    isFreeEffectivePlan ? "upgrade" : "buyCredits";
+  const creditsRequestAction = isFreeEffectivePlan ? "upgrade" : "buyCredits";
   const memberDescription = isFreeEffectivePlan
     ? "Ask an organization owner or admin to buy credits or upgrade the plan."
     : "Ask an organization owner or admin to buy credits.";
+
+  useEffect(() => {
+    if (!showGuestDialog) {
+      guestImpressionTrackedRef.current = false;
+      return;
+    }
+    if (isLoading || guestImpressionTrackedRef.current) return;
+
+    guestImpressionTrackedRef.current = true;
+    track("plan_limit_dialog_shown", {
+      location: "plan_limit_dialog",
+      wall_kind: "guest_credits",
+      limit_kind: "credits",
+      origin: "credits",
+      audience: "guest",
+      primary_action: "sign_in",
+      is_identified: false,
+    });
+  }, [isLoading, showGuestDialog]);
+
+  useEffect(() => {
+    if (!showTopupDialog) {
+      creditsImpressionTrackedRef.current = false;
+      return;
+    }
+    if (
+      isLoadingOrganizations ||
+      creditsUpgrade.isLoadingBilling ||
+      creditsImpressionTrackedRef.current
+    ) {
+      return;
+    }
+
+    creditsImpressionTrackedRef.current = true;
+    track("plan_limit_dialog_shown", {
+      location: "plan_limit_dialog",
+      wall_kind: "organization_credits",
+      organization_id: billingOrgId,
+      organization_resolved: Boolean(billingOrgId),
+      limit_kind: "credits",
+      origin: "credits",
+      audience: isKnownNonManager ? "member" : "billing_manager",
+      primary_action: isKnownNonManager
+        ? requestRecipients.length > 0
+          ? "request_owner"
+          : "none"
+        : showCreditsUpgrade
+        ? "upgrade"
+        : "buy_credits",
+      current_plan: creditsUpgrade.currentPlan,
+      effective_plan: creditsUpgrade.effectivePlan,
+      can_manage_billing: creditsUpgrade.canManageBilling,
+      can_buy_credits: !isKnownNonManager,
+      request_action: creditsRequestAction,
+      request_recipient_count: requestRecipients.length,
+      billing_interval: creditsUpgrade.interval,
+      annual_supported: creditsUpgrade.annualSupported,
+      monthly_supported: creditsUpgrade.monthlySupported,
+    });
+  }, [
+    billingOrgId,
+    creditsRequestAction,
+    creditsUpgrade.annualSupported,
+    creditsUpgrade.canManageBilling,
+    creditsUpgrade.currentPlan,
+    creditsUpgrade.effectivePlan,
+    creditsUpgrade.interval,
+    creditsUpgrade.isLoadingBilling,
+    creditsUpgrade.monthlySupported,
+    isKnownNonManager,
+    isLoadingOrganizations,
+    requestRecipients.length,
+    showCreditsUpgrade,
+    showTopupDialog,
+  ]);
+
+  if (isLoading) return null;
+
+  const handleTopUp = () => {
+    const orgId = resolveBillingOrgId();
+    // Don't dismiss the modal until we know we can route the user — on a
+    // fresh sign-in the membership query may still be in flight, in which
+    // case closing now would drop them out of the upsell silently.
+    if (!orgId) {
+      track("plan_limit_buy_credits_clicked", {
+        location: "plan_limit_dialog",
+        wall_kind: "organization_credits",
+        organization_id: null,
+        origin: "credits",
+        outcome: "blocked_missing_organization",
+        current_plan: creditsUpgrade.currentPlan,
+        effective_plan: creditsUpgrade.effectivePlan,
+      });
+      return;
+    }
+    close();
+    // The router strips ?... before resolving the route, so the
+    // `topup=open` flag is invisible to navigation but visible to the
+    // billing page on mount.
+    appNavigate(`/organizations/${orgId}/billing?topup=open`);
+    track("plan_limit_buy_credits_clicked", {
+      location: "plan_limit_dialog",
+      wall_kind: "organization_credits",
+      organization_id: orgId,
+      origin: "credits",
+      outcome: "billing_opened",
+      current_plan: creditsUpgrade.currentPlan,
+      effective_plan: creditsUpgrade.effectivePlan,
+    });
+  };
+
+  const handleBYOK = () => {
+    // Don't yank the user to the org settings page — just close the dialog
+    // and pop open the chat model picker on its "Your providers" tab so they
+    // can switch to an own-key model in place. The free models stay grayed.
+    close();
+    useModelPickerIntentStore.getState().requestOpenProvidersTab();
+    track("plan_limit_byok_clicked", {
+      location: "plan_limit_dialog",
+      wall_kind: "organization_credits",
+      organization_id: billingOrgId,
+      origin: "credits",
+      current_plan: creditsUpgrade.currentPlan,
+      effective_plan: creditsUpgrade.effectivePlan,
+    });
+  };
+
+  const handleGuestDismiss = () => {
+    close();
+    track("plan_limit_dialog_dismissed", {
+      location: "plan_limit_dialog",
+      wall_kind: "guest_credits",
+      limit_kind: "credits",
+      origin: "credits",
+      audience: "guest",
+    });
+  };
+
+  const handleCreditsDismiss = () => {
+    close();
+    track("plan_limit_dialog_dismissed", {
+      location: "plan_limit_dialog",
+      wall_kind: "organization_credits",
+      organization_id: billingOrgId,
+      limit_kind: "credits",
+      origin: "credits",
+      current_plan: creditsUpgrade.currentPlan,
+      effective_plan: creditsUpgrade.effectivePlan,
+      audience: isKnownNonManager ? "member" : "billing_manager",
+    });
+  };
+
+  const handleSignIn = () => {
+    signIn();
+    track("plan_limit_sign_in_clicked", {
+      location: "plan_limit_dialog",
+      wall_kind: "guest_credits",
+      limit_kind: "credits",
+      origin: "credits",
+      audience: "guest",
+    });
+  };
 
   return (
     <>
@@ -122,7 +264,7 @@ export function MCPJamLimitDialog() {
         <Dialog
           open
           onOpenChange={(next) => {
-            if (!next) close();
+            if (!next) handleGuestDismiss();
           }}
         >
           <DialogContent className="sm:max-w-md">
@@ -134,7 +276,7 @@ export function MCPJamLimitDialog() {
                 free credits.
               </DialogDescription>
             </DialogHeader>
-            <Button onClick={() => signIn()} className="w-full">
+            <Button onClick={handleSignIn} className="w-full">
               Sign in
             </Button>
           </DialogContent>
@@ -153,6 +295,7 @@ export function MCPJamLimitDialog() {
           showUpgrade={showCreditsUpgrade}
           requestRecipients={requestRecipients}
           requestAction={creditsRequestAction}
+          organizationId={billingOrgId}
           organizationName={creditsUpgrade.organizationName}
           interval={creditsUpgrade.interval}
           onIntervalChange={creditsUpgrade.setInterval}
@@ -166,7 +309,7 @@ export function MCPJamLimitDialog() {
           onUpgrade={() => void creditsUpgrade.start()}
           onBuyCredits={handleTopUp}
           onUseOwnKey={handleBYOK}
-          onDismiss={close}
+          onDismiss={handleCreditsDismiss}
         />
       )}
     </>

--- a/mcpjam-inspector/client/src/components/mcpjam-limit-dialog.tsx
+++ b/mcpjam-inspector/client/src/components/mcpjam-limit-dialog.tsx
@@ -18,6 +18,8 @@ import { readStoredActiveOrganizationId } from "@/lib/active-organization-storag
 import { useMCPJamLimitDialogStore } from "@/stores/mcpjam-limit-dialog-store";
 import { useModelPickerIntentStore } from "@/stores/model-picker-intent-store";
 import { useAppNavigate } from "@/lib/app-navigation";
+import { useUpgradeCheckout } from "@/hooks/use-upgrade-checkout";
+import { UpgradeIntervalPicker } from "@/components/billing/UpgradeIntervalPicker";
 
 export function MCPJamLimitDialog() {
   const isOpen = useMCPJamLimitDialogStore((s) => s.isOpen);
@@ -43,10 +45,10 @@ export function MCPJamLimitDialog() {
     if (user && intent === "guest" && isOpen) close();
   }, [close, intent, isLoading, isOpen, setAuthStatus, user]);
 
-  if (isLoading) return null;
-
   // Resolve which org's billing page to redirect to. Prefer the org that
   // actually hit the limit; fall back to local active org / recent org.
+  // Declared above the `isLoading` guard so the upgrade hook below keeps a
+  // stable call order.
   const resolveBillingOrgId = (): string | null => {
     if (!user) return null;
     if (limitOrganizationId) return limitOrganizationId;
@@ -54,6 +56,14 @@ export function MCPJamLimitDialog() {
     if (stored) return stored;
     return sortedOrganizations[0]?._id ?? null;
   };
+
+  const creditsUpgrade = useUpgradeCheckout({
+    organizationId: resolveBillingOrgId(),
+    origin: "credits",
+    limitKind: "credits",
+  });
+
+  if (isLoading) return null;
 
   // Only owners/admins/creators can buy credits (mirrors the backend gate).
   // Members instead see an "ask org admin" hint so they don't dead-end on a
@@ -94,6 +104,10 @@ export function MCPJamLimitDialog() {
   const showGuestDialog = !user && intent === "guest" && isOpen;
   // Top-up variant — only renders for signed-in users.
   const showTopupDialog = !!user && intent === "topup" && isOpen;
+  // Pitching Team to an org already on Team would be nonsense; those orgs get
+  // the buy-credits path only.
+  const showCreditsUpgrade =
+    creditsUpgrade.currentPlan === "free" && creditsUpgrade.canManageBilling;
 
   return (
     <>
@@ -131,21 +145,48 @@ export function MCPJamLimitDialog() {
               <DialogTitle>Your org is out of credits</DialogTitle>
               <DialogDescription data-testid="limit-dialog-description">
                 {isKnownNonManager
-                  ? "Ask your org admin to top up credits."
-                  : "Top up or bring your own key to allow your org to keep using MCPJam."}
+                  ? "Ask an organization owner or admin to buy credits or upgrade the plan."
+                  : creditsUpgrade.currentPlan === "free"
+                    ? `Free credits reset daily. Our ${creditsUpgrade.teamName} plan replaces the daily cap with a monthly allowance per seat, so usage isn't rationed day to day.`
+                    : "Buy credits to keep your team going, or use your own API key."}
               </DialogDescription>
             </DialogHeader>
-            {/* Non-managers get no CTAs — just the "ask your org admin" copy.
-                Managers keep BYOK plus the Top up button. */}
+            {/* Non-managers get no CTAs, just the "ask an owner" copy. Managers
+                lead with the plan upgrade: buying credits keeps the org on Free
+                at a variable cost, so it stays available but secondary. */}
             {!isKnownNonManager ? (
-              <DialogFooter>
-                <Button type="button" variant="outline" onClick={handleBYOK}>
-                  Bring your own key
-                </Button>
-                <Button type="button" onClick={handleTopUp}>
-                  Top up
-                </Button>
-              </DialogFooter>
+              <>
+                {showCreditsUpgrade ? (
+                  <UpgradeIntervalPicker
+                    interval={creditsUpgrade.interval}
+                    onIntervalChange={creditsUpgrade.setInterval}
+                    priceLabel={creditsUpgrade.priceLabel}
+                    annualDiscountPct={creditsUpgrade.annualDiscountPct}
+                    annualSupported={creditsUpgrade.annualSupported}
+                    monthlySupported={creditsUpgrade.monthlySupported}
+                    teamName={creditsUpgrade.teamName}
+                    isStarting={creditsUpgrade.isStarting}
+                    onUpgrade={() => void creditsUpgrade.start()}
+                  />
+                ) : null}
+                <DialogFooter className="sm:justify-between">
+                  <Button
+                    type="button"
+                    variant="link"
+                    className="px-0 text-muted-foreground"
+                    onClick={handleBYOK}
+                  >
+                    Use your own API key
+                  </Button>
+                  <Button
+                    type="button"
+                    variant="outline"
+                    onClick={handleTopUp}
+                  >
+                    Buy credits
+                  </Button>
+                </DialogFooter>
+              </>
             ) : null}
           </DialogContent>
         </Dialog>

--- a/mcpjam-inspector/client/src/components/mcpjam-limit-dialog.tsx
+++ b/mcpjam-inspector/client/src/components/mcpjam-limit-dialog.tsx
@@ -41,6 +41,12 @@ export function MCPJamLimitDialog() {
   const guestImpressionTrackedRef = useRef(false);
   const creditsImpressionTrackedRef = useRef(false);
 
+  // Decide whether either variant is active before wiring billing hooks. This
+  // component is mounted app-wide, so a closed dialog must not keep billing
+  // and owner-member Convex subscriptions alive for the whole session.
+  const showGuestDialog = !user && intent === "guest" && isOpen;
+  const showTopupDialog = !!user && intent === "topup" && isOpen;
+
   useEffect(() => {
     setAuthStatus(isLoading ? "loading" : user ? "signedIn" : "guest");
     // Auth flipped to signed-in while the guest variant was open (e.g. user
@@ -62,15 +68,16 @@ export function MCPJamLimitDialog() {
   };
 
   const billingOrgId = resolveBillingOrgId();
+  const openBillingOrgId = showTopupDialog ? billingOrgId : null;
   const creditsUpgrade = useUpgradeCheckout({
-    organizationId: billingOrgId,
+    organizationId: openBillingOrgId,
     origin: "credits",
     limitKind: "credits",
   });
   const {
     recipients: requestRecipients,
     isLoading: isLoadingRequestRecipients,
-  } = useUpgradeRequestRecipients(billingOrgId);
+  } = useUpgradeRequestRecipients(openBillingOrgId);
 
   // Only owners/admins/creators can buy credits (mirrors the backend gate).
   // Members instead see an "ask org admin" hint so they don't dead-end on a
@@ -85,10 +92,6 @@ export function MCPJamLimitDialog() {
     ? !canManageOrgCredits(billingOrg)
     : false;
 
-  // Guest variant — only renders for unauthenticated users.
-  const showGuestDialog = !user && intent === "guest" && isOpen;
-  // Top-up variant — only renders for signed-in users.
-  const showTopupDialog = !!user && intent === "topup" && isOpen;
   // Pitching Team to an org already on Team would be nonsense; those orgs get
   // the buy-credits path only.
   const isFreeEffectivePlan = creditsUpgrade.effectivePlan === "free";
@@ -263,6 +266,11 @@ export function MCPJamLimitDialog() {
     });
   };
 
+  const handleUpgrade = async () => {
+    const result = await creditsUpgrade.start();
+    if (result?.shouldDismiss) close();
+  };
+
   return (
     <>
       {showGuestDialog && (
@@ -311,7 +319,7 @@ export function MCPJamLimitDialog() {
           monthlySupported={creditsUpgrade.monthlySupported}
           teamName={creditsUpgrade.teamName}
           isStarting={creditsUpgrade.isStarting}
-          onUpgrade={() => void creditsUpgrade.start()}
+          onUpgrade={() => void handleUpgrade()}
           onBuyCredits={handleTopUp}
           onUseOwnKey={handleBYOK}
           onDismiss={handleCreditsDismiss}

--- a/mcpjam-inspector/client/src/components/mcpjam-limit-dialog.tsx
+++ b/mcpjam-inspector/client/src/components/mcpjam-limit-dialog.tsx
@@ -3,7 +3,6 @@ import {
   Dialog,
   DialogContent,
   DialogDescription,
-  DialogFooter,
   DialogHeader,
   DialogTitle,
 } from "@mcpjam/design-system/dialog";
@@ -20,8 +19,7 @@ import { useModelPickerIntentStore } from "@/stores/model-picker-intent-store";
 import { useAppNavigate } from "@/lib/app-navigation";
 import { useUpgradeCheckout } from "@/hooks/use-upgrade-checkout";
 import { useUpgradeRequestRecipients } from "@/hooks/use-upgrade-request-recipients";
-import { UpgradeIntervalPicker } from "@/components/billing/UpgradeIntervalPicker";
-import { RequestUpgradeButton } from "@/components/billing/RequestUpgradeButton";
+import { CreditsLimitDialogView } from "@/components/billing/CreditsLimitDialogView";
 
 export function MCPJamLimitDialog() {
   const isOpen = useMCPJamLimitDialogStore((s) => s.isOpen);
@@ -137,71 +135,32 @@ export function MCPJamLimitDialog() {
         </Dialog>
       )}
       {showTopupDialog && (
-        <Dialog
-          open
-          onOpenChange={(next) => {
-            if (!next) close();
-          }}
-        >
-          <DialogContent className="sm:max-w-md">
-            <DialogHeader>
-              <DialogTitle>Your org is out of credits</DialogTitle>
-              <DialogDescription data-testid="limit-dialog-description">
-                {isKnownNonManager
-                  ? "Ask an organization owner or admin to buy credits or upgrade the plan."
-                  : creditsUpgrade.currentPlan === "free"
-                    ? `Free credits reset daily. Our ${creditsUpgrade.teamName} plan replaces the daily cap with a monthly allowance per seat, so usage isn't rationed day to day.`
-                    : "Buy credits to keep your team going, or use your own API key."}
-              </DialogDescription>
-            </DialogHeader>
-            {/* Non-managers get no CTAs, just the "ask an owner" copy. Managers
-                lead with the plan upgrade: buying credits keeps the org on Free
-                at a variable cost, so it stays available but secondary. */}
-            {isKnownNonManager ? (
-              <RequestUpgradeButton
-                recipients={requestRecipients}
-                organizationName={creditsUpgrade.organizationName}
-                teamName={creditsUpgrade.teamName}
-                origin="credits"
-                limitKind="credits"
-              />
-            ) : (
-              <>
-                {showCreditsUpgrade ? (
-                  <UpgradeIntervalPicker
-                    interval={creditsUpgrade.interval}
-                    onIntervalChange={creditsUpgrade.setInterval}
-                    annualPriceLabel={creditsUpgrade.annualPriceLabel}
-                    monthlyPriceLabel={creditsUpgrade.monthlyPriceLabel}
-                    annualDiscountPct={creditsUpgrade.annualDiscountPct}
-                    annualSupported={creditsUpgrade.annualSupported}
-                    monthlySupported={creditsUpgrade.monthlySupported}
-                    teamName={creditsUpgrade.teamName}
-                    isStarting={creditsUpgrade.isStarting}
-                    onUpgrade={() => void creditsUpgrade.start()}
-                  />
-                ) : null}
-                <DialogFooter className="sm:justify-between">
-                  <Button
-                    type="button"
-                    variant="link"
-                    className="px-0 text-muted-foreground"
-                    onClick={handleBYOK}
-                  >
-                    Use your own API key
-                  </Button>
-                  <Button
-                    type="button"
-                    variant="outline"
-                    onClick={handleTopUp}
-                  >
-                    Buy credits
-                  </Button>
-                </DialogFooter>
-              </>
-            )}
-          </DialogContent>
-        </Dialog>
+        <CreditsLimitDialogView
+          description={
+            isKnownNonManager
+              ? "Ask an organization owner or admin to buy credits or upgrade the plan."
+              : creditsUpgrade.currentPlan === "free"
+                ? `Free credits reset daily. Our ${creditsUpgrade.teamName} plan replaces the daily cap with a monthly allowance per seat, so usage isn't rationed day to day.`
+                : "Buy credits to keep your team going, or use your own API key."
+          }
+          isKnownNonManager={isKnownNonManager}
+          showUpgrade={showCreditsUpgrade}
+          requestRecipients={requestRecipients}
+          organizationName={creditsUpgrade.organizationName}
+          interval={creditsUpgrade.interval}
+          onIntervalChange={creditsUpgrade.setInterval}
+          annualPriceLabel={creditsUpgrade.annualPriceLabel}
+          monthlyPriceLabel={creditsUpgrade.monthlyPriceLabel}
+          annualDiscountPct={creditsUpgrade.annualDiscountPct}
+          annualSupported={creditsUpgrade.annualSupported}
+          monthlySupported={creditsUpgrade.monthlySupported}
+          teamName={creditsUpgrade.teamName}
+          isStarting={creditsUpgrade.isStarting}
+          onUpgrade={() => void creditsUpgrade.start()}
+          onBuyCredits={handleTopUp}
+          onUseOwnKey={handleBYOK}
+          onDismiss={close}
+        />
       )}
     </>
   );

--- a/mcpjam-inspector/client/src/components/mcpjam-limit-dialog.tsx
+++ b/mcpjam-inspector/client/src/components/mcpjam-limit-dialog.tsx
@@ -107,8 +107,14 @@ export function MCPJamLimitDialog() {
   const showTopupDialog = !!user && intent === "topup" && isOpen;
   // Pitching Team to an org already on Team would be nonsense; those orgs get
   // the buy-credits path only.
+  const isFreeEffectivePlan = creditsUpgrade.effectivePlan === "free";
   const showCreditsUpgrade =
-    creditsUpgrade.effectivePlan === "free" && creditsUpgrade.canManageBilling;
+    isFreeEffectivePlan && creditsUpgrade.canManageBilling;
+  const creditsRequestAction =
+    isFreeEffectivePlan ? "upgrade" : "buyCredits";
+  const memberDescription = isFreeEffectivePlan
+    ? "Ask an organization owner or admin to buy credits or upgrade the plan."
+    : "Ask an organization owner or admin to buy credits.";
 
   return (
     <>
@@ -138,14 +144,15 @@ export function MCPJamLimitDialog() {
         <CreditsLimitDialogView
           description={
             isKnownNonManager
-              ? "Ask an organization owner or admin to buy credits or upgrade the plan."
-              : creditsUpgrade.effectivePlan === "free"
+              ? memberDescription
+              : isFreeEffectivePlan
               ? `Free credits reset daily. Our ${creditsUpgrade.teamName} plan replaces the daily cap with a monthly allowance per seat, so usage isn't rationed day to day.`
               : "Buy credits to keep your team going, or use your own API key."
           }
           isKnownNonManager={isKnownNonManager}
           showUpgrade={showCreditsUpgrade}
           requestRecipients={requestRecipients}
+          requestAction={creditsRequestAction}
           organizationName={creditsUpgrade.organizationName}
           interval={creditsUpgrade.interval}
           onIntervalChange={creditsUpgrade.setInterval}

--- a/mcpjam-inspector/client/src/components/organization/__tests__/billing-compare-view-model.test.ts
+++ b/mcpjam-inspector/client/src/components/organization/__tests__/billing-compare-view-model.test.ts
@@ -3,7 +3,12 @@ import { COMPARE_PLAN_MARKETING_SECTIONS } from "@/components/organization/compa
 import { buildComparePlanSectionsFromCatalog } from "@/components/organization/billing-compare-view-model";
 import type { PlanCatalog } from "@/hooks/useOrganizationBilling";
 
-function createPlanCatalog(): PlanCatalog {
+function createPlanCatalog(
+  evalLimits: { free: number | null; team: number | null } = {
+    free: 75,
+    team: 15_000,
+  }
+): PlanCatalog {
   const baseEntry = {
     prices: {
       monthly: { amountCents: 0, stripePriceId: null },
@@ -24,6 +29,7 @@ function createPlanCatalog(): PlanCatalog {
           maxServersPerProject: null,
           maxChatboxesPerProject: null,
           maxEvalRunsPerMonth: null,
+          maxEvalIterationsPerMonth: evalLimits.free,
           insightsPerDay: null,
         },
       },
@@ -35,6 +41,7 @@ function createPlanCatalog(): PlanCatalog {
           maxServersPerProject: null,
           maxChatboxesPerProject: null,
           maxEvalRunsPerMonth: null,
+          maxEvalIterationsPerMonth: evalLimits.team,
           insightsPerDay: null,
         },
       },
@@ -46,6 +53,7 @@ function createPlanCatalog(): PlanCatalog {
           maxServersPerProject: null,
           maxChatboxesPerProject: null,
           maxEvalRunsPerMonth: null,
+          maxEvalIterationsPerMonth: null,
           insightsPerDay: null,
         },
       },
@@ -54,10 +62,10 @@ function createPlanCatalog(): PlanCatalog {
 }
 
 describe("buildComparePlanSectionsFromCatalog", () => {
-  it("returns the static marketing compare sections", () => {
+  it("uses backend catalog values for eval iteration allowances", () => {
     const sections = buildComparePlanSectionsFromCatalog(createPlanCatalog());
 
-    expect(sections).toBe(COMPARE_PLAN_MARKETING_SECTIONS);
+    expect(sections).not.toBe(COMPARE_PLAN_MARKETING_SECTIONS);
     expect(sections.map((section) => section.title)).toEqual([
       "Credits & seats",
       "Evaluations",
@@ -65,5 +73,36 @@ describe("buildComparePlanSectionsFromCatalog", () => {
       "Support",
       "Standard features",
     ]);
+    const evalIterations = sections
+      .find((section) => section.title === "Evaluations")
+      ?.rows.find((row) => row.label === "Eval iterations");
+    expect(evalIterations?.free).toEqual({
+      kind: "text",
+      text: "75 / day",
+    });
+    expect(evalIterations?.team).toEqual({
+      kind: "text",
+      text: "15,000 / mo",
+      emphasize: true,
+    });
+  });
+
+  it("updates when the backend catalog changes", () => {
+    const sections = buildComparePlanSectionsFromCatalog(
+      createPlanCatalog({ free: 100, team: 20_000 })
+    );
+    const evalIterations = sections
+      .find((section) => section.title === "Evaluations")
+      ?.rows.find((row) => row.label === "Eval iterations");
+
+    expect(evalIterations?.free).toEqual({
+      kind: "text",
+      text: "100 / day",
+    });
+    expect(evalIterations?.team).toEqual({
+      kind: "text",
+      text: "20,000 / mo",
+      emphasize: true,
+    });
   });
 });

--- a/mcpjam-inspector/client/src/components/organization/__tests__/compare-plan-marketing.test.ts
+++ b/mcpjam-inspector/client/src/components/organization/__tests__/compare-plan-marketing.test.ts
@@ -13,22 +13,22 @@ describe("COMPARE_PLAN_MARKETING_SECTIONS", () => {
 
     expect(
       COMPARE_PLAN_MARKETING_SECTIONS.some(
-        (s) => s.title === "Platform & Infrastructure",
-      ),
+        (s) => s.title === "Platform & Infrastructure"
+      )
     ).toBe(false);
 
     expect(
-      COMPARE_PLAN_MARKETING_SECTIONS.some((s) => s.title === "Chatboxes"),
+      COMPARE_PLAN_MARKETING_SECTIONS.some((s) => s.title === "Chatboxes")
     ).toBe(false);
 
     const rowCount = COMPARE_PLAN_MARKETING_SECTIONS.reduce(
       (n, s) => n + s.rows.length,
-      0,
+      0
     );
     expect(rowCount).toBe(15);
 
     const standardFeatures = COMPARE_PLAN_MARKETING_SECTIONS.find(
-      (s) => s.title === "Standard features",
+      (s) => s.title === "Standard features"
     );
     const standardLabels = standardFeatures?.rows.map((r) => r.label) ?? [];
     expect(standardLabels).toEqual([
@@ -63,20 +63,20 @@ describe("COMPARE_PLAN_MARKETING_SECTIONS", () => {
     });
   });
 
-  it("leads Evaluations with eval iteration allowances", () => {
+  it("leaves eval iteration allowances for the backend catalog builder", () => {
     const evaluations = COMPARE_PLAN_MARKETING_SECTIONS.find(
-      (s) => s.title === "Evaluations",
+      (s) => s.title === "Evaluations"
     );
     const evalIterations = evaluations?.rows[0];
 
     expect(evalIterations?.label).toBe("Eval iterations");
     expect(evalIterations?.free).toEqual({
       kind: "text",
-      text: "25 / day",
+      text: "—",
     });
     expect(evalIterations?.team).toEqual({
       kind: "text",
-      text: "5,000 / mo",
+      text: "—",
       emphasize: true,
     });
     expect(evalIterations?.enterprise).toEqual({
@@ -88,7 +88,7 @@ describe("COMPARE_PLAN_MARKETING_SECTIONS", () => {
 
   it("keeps Evaluations focused on iteration limits and traces", () => {
     const evaluations = COMPARE_PLAN_MARKETING_SECTIONS.find(
-      (s) => s.title === "Evaluations",
+      (s) => s.title === "Evaluations"
     );
 
     expect(evaluations?.rows.map((row) => row.label)).toEqual([
@@ -96,16 +96,16 @@ describe("COMPARE_PLAN_MARKETING_SECTIONS", () => {
       "Traces",
     ]);
     expect(
-      evaluations?.rows.find((r) => r.label === "Traces")?.enterprise,
+      evaluations?.rows.find((r) => r.label === "Traces")?.enterprise
     ).toEqual({ kind: "check" });
   });
 
   it("keeps audit logs positioned on Enterprise only", () => {
     const security = COMPARE_PLAN_MARKETING_SECTIONS.find(
-      (s) => s.title === "Security & Compliance",
+      (s) => s.title === "Security & Compliance"
     );
     const auditLogRow = security?.rows.find(
-      (r) => r.label === "Audit log retention",
+      (r) => r.label === "Audit log retention"
     );
 
     expect(auditLogRow?.team).toEqual({ kind: "x" });
@@ -115,5 +115,4 @@ describe("COMPARE_PLAN_MARKETING_SECTIONS", () => {
       emphasize: true,
     });
   });
-
 });

--- a/mcpjam-inspector/client/src/components/organization/__tests__/compare-plan-marketing.test.ts
+++ b/mcpjam-inspector/client/src/components/organization/__tests__/compare-plan-marketing.test.ts
@@ -72,11 +72,11 @@ describe("COMPARE_PLAN_MARKETING_SECTIONS", () => {
     expect(evalIterations?.label).toBe("Eval iterations");
     expect(evalIterations?.free).toEqual({
       kind: "text",
-      text: "75 / day",
+      text: "25 / day",
     });
     expect(evalIterations?.team).toEqual({
       kind: "text",
-      text: "15,000 / mo",
+      text: "5,000 / mo",
       emphasize: true,
     });
     expect(evalIterations?.enterprise).toEqual({

--- a/mcpjam-inspector/client/src/components/organization/billing-compare-view-model.ts
+++ b/mcpjam-inspector/client/src/components/organization/billing-compare-view-model.ts
@@ -4,8 +4,41 @@ import {
 } from "@/components/organization/compare-plan-marketing";
 import type { PlanCatalog } from "@/hooks/useOrganizationBilling";
 
+function formatEvalLimit(
+  value: number | null,
+  cadence: "day" | "mo",
+  emphasize = false
+) {
+  return {
+    kind: "text" as const,
+    text:
+      value == null
+        ? "Unlimited"
+        : `${new Intl.NumberFormat("en-US").format(value)} / ${cadence}`,
+    ...(emphasize ? { emphasize: true } : {}),
+  };
+}
+
 export function buildComparePlanSectionsFromCatalog(
-  _planCatalog: PlanCatalog,
+  planCatalog: PlanCatalog
 ): ComparePlanSection[] {
-  return COMPARE_PLAN_MARKETING_SECTIONS;
+  return COMPARE_PLAN_MARKETING_SECTIONS.map((section) => ({
+    ...section,
+    rows: section.rows.map((row) =>
+      row.label === "Eval iterations"
+        ? {
+            ...row,
+            free: formatEvalLimit(
+              planCatalog.plans.free.limits.maxEvalIterationsPerMonth,
+              "day"
+            ),
+            team: formatEvalLimit(
+              planCatalog.plans.team.limits.maxEvalIterationsPerMonth,
+              "mo",
+              true
+            ),
+          }
+        : row
+    ),
+  }));
 }

--- a/mcpjam-inspector/client/src/components/organization/compare-plan-marketing.ts
+++ b/mcpjam-inspector/client/src/components/organization/compare-plan-marketing.ts
@@ -1,14 +1,9 @@
 /**
- * Marketing compare-plans table: product rows mirror `mcpjam_pricing_page.html`;
- * eval caps and enterprise security features carry the commercial
- * distinctions.
- *
- * These strings are hand-maintained and have drifted from mcpjam.com/pricing
- * before (eval iterations read 75/day and 15,000/mo here while the site said
- * 25/day and 5,000/mo). Values below now match the public page. The durable fix
- * is to read the credit and eval rows from the plan catalog the way
- * `PlanLimitDialog` does, which needs credits added to `BillingLimitName`
- * first.
+ * Marketing compare-plans table skeleton. Eval allowance values are replaced
+ * from the backend plan catalog by `buildComparePlanSectionsFromCatalog`, so
+ * this file cannot drift from the limits billing actually enforces.
+ * Included credits remain marketing copy until credits are represented in the
+ * plan catalog.
  */
 
 export type ComparePlanCell =
@@ -63,8 +58,8 @@ export const COMPARE_PLAN_MARKETING_SECTIONS: ComparePlanSection[] = [
     rows: [
       {
         label: "Eval iterations",
-        free: t("25 / day"),
-        team: t("5,000 / mo", true),
+        free: t("—"),
+        team: t("—", true),
         enterprise: t("Custom", true),
       },
       {

--- a/mcpjam-inspector/client/src/components/organization/compare-plan-marketing.ts
+++ b/mcpjam-inspector/client/src/components/organization/compare-plan-marketing.ts
@@ -2,6 +2,13 @@
  * Marketing compare-plans table: product rows mirror `mcpjam_pricing_page.html`;
  * eval caps and enterprise security features carry the commercial
  * distinctions.
+ *
+ * These strings are hand-maintained and have drifted from mcpjam.com/pricing
+ * before (eval iterations read 75/day and 15,000/mo here while the site said
+ * 25/day and 5,000/mo). Values below now match the public page. The durable fix
+ * is to read the credit and eval rows from the plan catalog the way
+ * `PlanLimitDialog` does, which needs credits added to `BillingLimitName`
+ * first.
  */
 
 export type ComparePlanCell =
@@ -56,8 +63,8 @@ export const COMPARE_PLAN_MARKETING_SECTIONS: ComparePlanSection[] = [
     rows: [
       {
         label: "Eval iterations",
-        free: t("75 / day"),
-        team: t("15,000 / mo", true),
+        free: t("25 / day"),
+        team: t("5,000 / mo", true),
         enterprise: t("Custom", true),
       },
       {

--- a/mcpjam-inspector/client/src/hooks/__tests__/use-upgrade-checkout.test.tsx
+++ b/mcpjam-inspector/client/src/hooks/__tests__/use-upgrade-checkout.test.tsx
@@ -1,0 +1,119 @@
+import { act, renderHook, waitFor } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  resolveUpgradeInterval,
+  useUpgradeCheckout,
+} from "../use-upgrade-checkout";
+
+const { billingState, startPlanChange, toastError, trackMock } = vi.hoisted(
+  () => ({
+    billingState: { planCatalog: undefined as unknown },
+    startPlanChange: vi.fn(),
+    toastError: vi.fn(),
+    trackMock: vi.fn(),
+  })
+);
+
+vi.mock("@/hooks/useOrganizationBilling", () => ({
+  useOrganizationBilling: () => ({
+    billingStatus: {
+      plan: "free",
+      effectivePlan: "free",
+      organizationName: "Acme Robotics",
+      canManageBilling: true,
+    },
+    planCatalog: billingState.planCatalog,
+    startPlanChange,
+    isStartingPlanChange: false,
+  }),
+}));
+
+vi.mock("@/lib/analytics", () => ({ track: trackMock }));
+vi.mock("@/lib/toast", () => ({ toast: { error: toastError } }));
+
+function planCatalog(supportedIntervals: Array<"monthly" | "annual">) {
+  return {
+    currency: "USD",
+    plans: {
+      team: {
+        displayName: "Team",
+        prices: { annual: 36_000, monthly: 3_800 },
+        limits: { maxEvalIterationsPerMonth: 5_000 },
+        checkout: { supportedIntervals },
+      },
+    },
+  };
+}
+
+beforeEach(() => {
+  billingState.planCatalog = undefined;
+  startPlanChange.mockReset();
+  startPlanChange.mockResolvedValue({ kind: "updated", subscription: {} });
+  toastError.mockReset();
+  trackMock.mockReset();
+  window.history.replaceState(null, "", "/evals");
+});
+
+describe("resolveUpgradeInterval", () => {
+  it("keeps a valid choice, otherwise prefers annual and then monthly", () => {
+    expect(resolveUpgradeInterval("monthly", true, true)).toBe("monthly");
+    expect(resolveUpgradeInterval("monthly", true, false)).toBe("annual");
+    expect(resolveUpgradeInterval("annual", false, true)).toBe("monthly");
+    expect(resolveUpgradeInterval("annual", false, false)).toBeNull();
+  });
+});
+
+describe("useUpgradeCheckout", () => {
+  it("defaults to annual, then switches to monthly when pricing only supports monthly", async () => {
+    const view = renderHook(() =>
+      useUpgradeCheckout({
+        organizationId: "org-1",
+        origin: "evals",
+        limitKind: "evalIterations",
+      })
+    );
+
+    expect(view.result.current.interval).toBe("annual");
+
+    billingState.planCatalog = planCatalog(["monthly"]);
+    view.rerender();
+
+    await waitFor(() => {
+      expect(view.result.current.interval).toBe("monthly");
+    });
+    await act(async () => {
+      await view.result.current.start();
+    });
+
+    expect(startPlanChange).toHaveBeenCalledWith(
+      expect.stringContaining("upgrade=return"),
+      "team",
+      "monthly",
+      { confirmPaidPlanChange: false }
+    );
+    expect(trackMock).toHaveBeenCalledWith(
+      "plan_limit_upgrade_clicked",
+      expect.objectContaining({ billing_interval: "monthly" })
+    );
+  });
+
+  it("blocks checkout when the catalog supports no interval", async () => {
+    billingState.planCatalog = planCatalog([]);
+    const { result } = renderHook(() =>
+      useUpgradeCheckout({
+        organizationId: "org-1",
+        origin: "credits",
+        limitKind: "credits",
+      })
+    );
+
+    await act(async () => {
+      await result.current.start();
+    });
+
+    expect(startPlanChange).not.toHaveBeenCalled();
+    expect(toastError).toHaveBeenCalledWith(
+      "Checkout is not available for this plan right now."
+    );
+  });
+});

--- a/mcpjam-inspector/client/src/hooks/__tests__/use-upgrade-checkout.test.tsx
+++ b/mcpjam-inspector/client/src/hooks/__tests__/use-upgrade-checkout.test.tsx
@@ -5,14 +5,14 @@ import {
   useUpgradeCheckout,
 } from "../use-upgrade-checkout";
 
-const { billingState, startPlanChange, toastError, trackMock } = vi.hoisted(
-  () => ({
+const { billingState, startPlanChange, toastError, toastSuccess, trackMock } =
+  vi.hoisted(() => ({
     billingState: { planCatalog: undefined as unknown },
     startPlanChange: vi.fn(),
     toastError: vi.fn(),
+    toastSuccess: vi.fn(),
     trackMock: vi.fn(),
-  })
-);
+  }));
 
 vi.mock("@/hooks/useOrganizationBilling", () => ({
   useOrganizationBilling: () => ({
@@ -30,7 +30,9 @@ vi.mock("@/hooks/useOrganizationBilling", () => ({
 }));
 
 vi.mock("@/lib/analytics", () => ({ track: trackMock }));
-vi.mock("@/lib/toast", () => ({ toast: { error: toastError } }));
+vi.mock("@/lib/toast", () => ({
+  toast: { error: toastError, success: toastSuccess },
+}));
 
 function planCatalog(supportedIntervals: Array<"monthly" | "annual">) {
   return {
@@ -51,6 +53,7 @@ beforeEach(() => {
   startPlanChange.mockReset();
   startPlanChange.mockResolvedValue({ kind: "updated", subscription: {} });
   toastError.mockReset();
+  toastSuccess.mockReset();
   trackMock.mockReset();
   window.history.replaceState(null, "", "/evals");
 });
@@ -119,6 +122,61 @@ describe("useUpgradeCheckout", () => {
     expect(trackMock).toHaveBeenCalledWith(
       "plan_limit_upgrade_failed",
       expect.objectContaining({ error_kind: "no_supported_interval" })
+    );
+  });
+
+  it("reports an in-place plan update and tells the dialog to close", async () => {
+    billingState.planCatalog = planCatalog(["annual"]);
+    startPlanChange.mockResolvedValue({
+      kind: "updated",
+      subscription: { plan: "team" },
+    });
+    const { result } = renderHook(() =>
+      useUpgradeCheckout({
+        organizationId: "org-1",
+        origin: "evals",
+        limitKind: "evalIterations",
+      })
+    );
+
+    let outcome: Awaited<ReturnType<typeof result.current.start>>;
+    await act(async () => {
+      outcome = await result.current.start();
+    });
+
+    expect(outcome!).toEqual({ redirected: false, shouldDismiss: true });
+    expect(toastSuccess).toHaveBeenCalledWith("Plan updated to Team.");
+    expect(trackMock).toHaveBeenCalledWith(
+      "plan_limit_upgrade_resolved",
+      expect.objectContaining({
+        result_kind: "updated",
+        resulting_plan: "team",
+      })
+    );
+  });
+
+  it("reports a scheduled plan change and tells the dialog to close", async () => {
+    billingState.planCatalog = planCatalog(["annual"]);
+    startPlanChange.mockResolvedValue({
+      kind: "scheduled",
+      subscription: { plan: "team" },
+    });
+    const { result } = renderHook(() =>
+      useUpgradeCheckout({
+        organizationId: "org-1",
+        origin: "credits",
+        limitKind: "credits",
+      })
+    );
+
+    let outcome: Awaited<ReturnType<typeof result.current.start>>;
+    await act(async () => {
+      outcome = await result.current.start();
+    });
+
+    expect(outcome!).toEqual({ redirected: false, shouldDismiss: true });
+    expect(toastSuccess).toHaveBeenCalledWith(
+      "Plan change scheduled for renewal."
     );
   });
 

--- a/mcpjam-inspector/client/src/hooks/__tests__/use-upgrade-checkout.test.tsx
+++ b/mcpjam-inspector/client/src/hooks/__tests__/use-upgrade-checkout.test.tsx
@@ -25,6 +25,7 @@ vi.mock("@/hooks/useOrganizationBilling", () => ({
     planCatalog: billingState.planCatalog,
     startPlanChange,
     isStartingPlanChange: false,
+    isLoadingBilling: false,
   }),
 }));
 
@@ -114,6 +115,38 @@ describe("useUpgradeCheckout", () => {
     expect(startPlanChange).not.toHaveBeenCalled();
     expect(toastError).toHaveBeenCalledWith(
       "Checkout is not available for this plan right now."
+    );
+    expect(trackMock).toHaveBeenCalledWith(
+      "plan_limit_upgrade_failed",
+      expect.objectContaining({ error_kind: "no_supported_interval" })
+    );
+  });
+
+  it("reports only explicit interval choices, not the automatic fallback", async () => {
+    billingState.planCatalog = planCatalog(["monthly"]);
+    const view = renderHook(() =>
+      useUpgradeCheckout({
+        organizationId: "org-1",
+        origin: "evals",
+        limitKind: "evalIterations",
+      })
+    );
+
+    await waitFor(() => {
+      expect(view.result.current.interval).toBe("monthly");
+    });
+    expect(trackMock).not.toHaveBeenCalledWith(
+      "plan_limit_interval_selected",
+      expect.anything()
+    );
+
+    act(() => view.result.current.setInterval("monthly"));
+    expect(trackMock).toHaveBeenCalledWith(
+      "plan_limit_interval_selected",
+      expect.objectContaining({
+        billing_interval: "monthly",
+        organization_id: "org-1",
+      })
     );
   });
 });

--- a/mcpjam-inspector/client/src/hooks/__tests__/use-upgrade-request-recipients.test.tsx
+++ b/mcpjam-inspector/client/src/hooks/__tests__/use-upgrade-request-recipients.test.tsx
@@ -1,0 +1,88 @@
+import { renderHook } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { useUpgradeRequestRecipients } from "../use-upgrade-request-recipients";
+
+const { authState, membersState, useOrganizationMembersMock } = vi.hoisted(
+  () => ({
+    authState: { isAuthenticated: false, isLoading: true },
+    membersState: {
+      activeMembers: [] as Array<{
+        role: "owner" | "member";
+        isOwner: boolean;
+        email: string;
+        user: { name: string } | null;
+      }>,
+      isLoading: false,
+    },
+    useOrganizationMembersMock: vi.fn(),
+  })
+);
+
+vi.mock("convex/react", () => ({
+  useConvexAuth: () => authState,
+}));
+
+vi.mock("@/hooks/useOrganizations", () => ({
+  resolveOrganizationRole: (member: { role: "owner" | "member" }) =>
+    member.role,
+  useOrganizationMembers: (args: unknown) => {
+    useOrganizationMembersMock(args);
+    return membersState;
+  },
+}));
+
+describe("useUpgradeRequestRecipients", () => {
+  beforeEach(() => {
+    authState.isAuthenticated = false;
+    authState.isLoading = true;
+    membersState.activeMembers = [];
+    membersState.isLoading = false;
+    useOrganizationMembersMock.mockClear();
+  });
+
+  it("stays loading while Convex auth resolves and the members query is skipped", () => {
+    const { result } = renderHook(() => useUpgradeRequestRecipients("org-1"));
+
+    expect(useOrganizationMembersMock).toHaveBeenCalledWith({
+      isAuthenticated: false,
+      organizationId: "org-1",
+    });
+    expect(result.current).toEqual({ recipients: [], isLoading: true });
+  });
+
+  it("stays loading while the authenticated members query resolves", () => {
+    authState.isAuthenticated = true;
+    authState.isLoading = false;
+    membersState.isLoading = true;
+
+    const { result } = renderHook(() => useUpgradeRequestRecipients("org-1"));
+
+    expect(result.current.isLoading).toBe(true);
+  });
+
+  it("returns owner recipients after auth and membership settle", () => {
+    authState.isAuthenticated = true;
+    authState.isLoading = false;
+    membersState.activeMembers = [
+      {
+        role: "owner",
+        isOwner: true,
+        email: "owner@example.com",
+        user: { name: "Owner Name" },
+      },
+      {
+        role: "member",
+        isOwner: false,
+        email: "member@example.com",
+        user: { name: "Member Name" },
+      },
+    ];
+
+    const { result } = renderHook(() => useUpgradeRequestRecipients("org-1"));
+
+    expect(result.current).toEqual({
+      recipients: [{ email: "owner@example.com", name: "Owner Name" }],
+      isLoading: false,
+    });
+  });
+});

--- a/mcpjam-inspector/client/src/hooks/use-upgrade-checkout.ts
+++ b/mcpjam-inspector/client/src/hooks/use-upgrade-checkout.ts
@@ -41,7 +41,7 @@ function formatMoney(cents: number, currency: string): string {
 export function formatSeatMonthlyPrice(
   amountInCents: number | null,
   currency: string | undefined,
-  interval: BillingInterval,
+  interval: BillingInterval
 ): string | null {
   if (amountInCents == null || !currency) return null;
   if (interval === "monthly") {
@@ -67,12 +67,8 @@ export function useUpgradeCheckout({
   origin,
   limitKind,
 }: UseUpgradeCheckoutParams) {
-  const {
-    billingStatus,
-    planCatalog,
-    startPlanChange,
-    isStartingPlanChange,
-  } = useOrganizationBilling(organizationId);
+  const { billingStatus, planCatalog, startPlanChange, isStartingPlanChange } =
+    useOrganizationBilling(organizationId);
 
   const teamEntry = planCatalog?.plans.team;
   const supportedIntervals = teamEntry?.checkout?.supportedIntervals ?? [
@@ -85,18 +81,18 @@ export function useUpgradeCheckout({
   // Annual leads: it's the cheaper per-seat figure and matches the pricing
   // page. Both prices render at once, so nothing is hidden behind the choice.
   const [interval, setInterval] = useState<BillingInterval>(
-    annualSupported ? "annual" : "monthly",
+    annualSupported ? "annual" : "monthly"
   );
 
   const annualPriceLabel = formatSeatMonthlyPrice(
     teamEntry?.prices.annual ?? null,
     planCatalog?.currency,
-    "annual",
+    "annual"
   );
   const monthlyPriceLabel = formatSeatMonthlyPrice(
     teamEntry?.prices.monthly ?? null,
     planCatalog?.currency,
-    "monthly",
+    "monthly"
   );
 
   const start = useCallback(async () => {
@@ -121,8 +117,8 @@ export function useUpgradeCheckout({
         result.kind === "checkout"
           ? result.checkoutUrl
           : result.kind === "portal"
-            ? result.portalUrl
-            : null;
+          ? result.portalUrl
+          : null;
       if (nextUrl) {
         // Same tab, so the return URL brings the user back in place.
         window.location.assign(nextUrl);
@@ -133,7 +129,7 @@ export function useUpgradeCheckout({
       toast.error(
         error instanceof Error
           ? error.message
-          : "Couldn't start checkout. Please try again.",
+          : "Couldn't start checkout. Please try again."
       );
       return { redirected: false as const };
     }
@@ -152,6 +148,12 @@ export function useUpgradeCheckout({
      * in the copy. Whether the catalog itself matches the public pricing page
      * is a separate question, tracked in the PR. */
     teamEvalIterations: teamEntry?.limits.maxEvalIterationsPerMonth ?? null,
+    // Limit-wall copy and destinations follow the plan whose limits the user
+    // is actually receiving. During a Team trial the persisted billing plan is
+    // still Free, while the effective plan (and its limits) is Team.
+    effectivePlan:
+      billingStatus?.effectivePlan ?? billingStatus?.plan ?? "free",
+    // Keep the persisted plan separate for real billing/checkout decisions.
     currentPlan: billingStatus?.plan ?? "free",
     organizationName: billingStatus?.organizationName ?? "your organization",
     canManageBilling: billingStatus?.canManageBilling ?? false,

--- a/mcpjam-inspector/client/src/hooks/use-upgrade-checkout.ts
+++ b/mcpjam-inspector/client/src/hooks/use-upgrade-checkout.ts
@@ -1,0 +1,154 @@
+import { useCallback, useState } from "react";
+import {
+  useOrganizationBilling,
+  type BillingInterval,
+} from "@/hooks/useOrganizationBilling";
+import { getAnnualDiscountPercent } from "@/lib/billing-entitlements";
+import { track } from "@/lib/analytics";
+import { toast } from "@/lib/toast";
+
+/** Which wall the user was standing at. Drives the return confirmation copy. */
+export type UpgradeOrigin = "evals" | "credits";
+
+/**
+ * Marks a hosted-checkout return so the confirmation lands on the surface the
+ * user was blocked on rather than the billing page. `upgrade_org` and
+ * `upgrade_from` ride along because the dialog stores are empty after the
+ * full page reload.
+ */
+export const UPGRADE_RETURN_PARAM = "upgrade";
+export const UPGRADE_RETURN_ORG_PARAM = "upgrade_org";
+export const UPGRADE_RETURN_ORIGIN_PARAM = "upgrade_from";
+
+function formatMoney(cents: number, currency: string): string {
+  return new Intl.NumberFormat(undefined, {
+    style: "currency",
+    currency,
+    minimumFractionDigits: 0,
+    maximumFractionDigits: 0,
+  }).format(cents / 100);
+}
+
+/**
+ * `prices.annual` is the full-year amount, so the per-seat monthly figure is
+ * a twelfth of it. Mirrors `formatPlanPriceLabel` on the billing page so the
+ * same plan never shows two different numbers.
+ */
+export function formatSeatMonthlyPrice(
+  amountInCents: number | null,
+  currency: string | undefined,
+  interval: BillingInterval,
+): string | null {
+  if (amountInCents == null || !currency) return null;
+  if (interval === "monthly") {
+    return `${formatMoney(amountInCents, currency)}/seat/mo`;
+  }
+  return `${formatMoney(
+    Math.round(amountInCents / 12 / 100) * 100,
+    currency,
+  )}/seat/mo`;
+}
+
+interface UseUpgradeCheckoutParams {
+  organizationId: string | null;
+  origin: UpgradeOrigin;
+  /** Forwarded to telemetry so we can compare which wall converts. */
+  limitKind: string;
+}
+
+/**
+ * Shared upgrade path for the free-plan limit walls. Starts hosted checkout
+ * directly instead of routing through the billing page, and returns the user
+ * to the surface they were blocked on.
+ */
+export function useUpgradeCheckout({
+  organizationId,
+  origin,
+  limitKind,
+}: UseUpgradeCheckoutParams) {
+  const {
+    billingStatus,
+    planCatalog,
+    startPlanChange,
+    isStartingPlanChange,
+  } = useOrganizationBilling(organizationId);
+
+  const teamEntry = planCatalog?.plans.team;
+  const supportedIntervals = teamEntry?.checkout?.supportedIntervals ?? [
+    "monthly",
+    "annual",
+  ];
+  const annualSupported = supportedIntervals.includes("annual");
+  const monthlySupported = supportedIntervals.includes("monthly");
+
+  // Annual leads: it is the cheaper per-seat number and matches the pricing
+  // page. Monthly stays one click away so nobody has to commit to a year to
+  // get unblocked.
+  const [interval, setInterval] = useState<BillingInterval>(
+    annualSupported ? "annual" : "monthly",
+  );
+
+  const priceLabel = formatSeatMonthlyPrice(
+    teamEntry?.prices[interval] ?? null,
+    planCatalog?.currency,
+    interval,
+  );
+
+  const start = useCallback(async () => {
+    if (!organizationId) return;
+    track("plan_limit_upgrade_clicked", {
+      location: "plan_limit_dialog",
+      limit_kind: limitKind,
+      origin,
+      billing_interval: interval,
+    });
+
+    const url = new URL(window.location.href);
+    url.searchParams.set(UPGRADE_RETURN_PARAM, "return");
+    url.searchParams.set(UPGRADE_RETURN_ORG_PARAM, organizationId);
+    url.searchParams.set(UPGRADE_RETURN_ORIGIN_PARAM, origin);
+
+    try {
+      const result = await startPlanChange(url.toString(), "team", interval, {
+        confirmPaidPlanChange: false,
+      });
+      const nextUrl =
+        result.kind === "checkout"
+          ? result.checkoutUrl
+          : result.kind === "portal"
+            ? result.portalUrl
+            : null;
+      if (nextUrl) {
+        // Same tab, so the return URL brings the user back in place.
+        window.location.assign(nextUrl);
+        return { redirected: true as const };
+      }
+      return { redirected: false as const };
+    } catch (error) {
+      toast.error(
+        error instanceof Error
+          ? error.message
+          : "Couldn't start checkout. Please try again.",
+      );
+      return { redirected: false as const };
+    }
+  }, [interval, limitKind, organizationId, origin, startPlanChange]);
+
+  return {
+    interval,
+    setInterval,
+    priceLabel,
+    annualDiscountPct: getAnnualDiscountPercent(planCatalog),
+    annualSupported,
+    monthlySupported,
+    teamName: teamEntry?.displayName ?? "Team",
+    /** Team's monthly eval cap, straight from the catalog so it can't go stale
+     * in the copy. Whether the catalog itself matches the public pricing page
+     * is a separate question, tracked in the PR. */
+    teamEvalIterations: teamEntry?.limits.maxEvalIterationsPerMonth ?? null,
+    currentPlan: billingStatus?.plan ?? "free",
+    canManageBilling: billingStatus?.canManageBilling ?? false,
+    isStarting: isStartingPlanChange,
+    start,
+  };
+}

--- a/mcpjam-inspector/client/src/hooks/use-upgrade-checkout.ts
+++ b/mcpjam-inspector/client/src/hooks/use-upgrade-checkout.ts
@@ -1,4 +1,4 @@
-import { useCallback, useState } from "react";
+import { useCallback, useEffect, useState } from "react";
 import {
   useOrganizationBilling,
   type BillingInterval,
@@ -57,6 +57,18 @@ interface UseUpgradeCheckoutParams {
   limitKind: string;
 }
 
+export function resolveUpgradeInterval(
+  selected: BillingInterval,
+  annualSupported: boolean,
+  monthlySupported: boolean
+): BillingInterval | null {
+  if (selected === "annual" && annualSupported) return "annual";
+  if (selected === "monthly" && monthlySupported) return "monthly";
+  if (annualSupported) return "annual";
+  if (monthlySupported) return "monthly";
+  return null;
+}
+
 /**
  * Shared upgrade path for the free-plan limit walls. Starts hosted checkout
  * directly instead of routing through the billing page, and returns the user
@@ -84,6 +96,17 @@ export function useUpgradeCheckout({
     annualSupported ? "annual" : "monthly"
   );
 
+  useEffect(() => {
+    const availableInterval = resolveUpgradeInterval(
+      interval,
+      annualSupported,
+      monthlySupported
+    );
+    if (availableInterval && availableInterval !== interval) {
+      setInterval(availableInterval);
+    }
+  }, [annualSupported, interval, monthlySupported]);
+
   const annualPriceLabel = formatSeatMonthlyPrice(
     teamEntry?.prices.annual ?? null,
     planCatalog?.currency,
@@ -97,11 +120,21 @@ export function useUpgradeCheckout({
 
   const start = useCallback(async () => {
     if (!organizationId) return;
+    const checkoutInterval = resolveUpgradeInterval(
+      interval,
+      annualSupported,
+      monthlySupported
+    );
+    if (!checkoutInterval) {
+      toast.error("Checkout is not available for this plan right now.");
+      return { redirected: false as const };
+    }
+
     track("plan_limit_upgrade_clicked", {
       location: "plan_limit_dialog",
       limit_kind: limitKind,
       origin,
-      billing_interval: interval,
+      billing_interval: checkoutInterval,
     });
 
     const url = new URL(window.location.href);
@@ -110,9 +143,14 @@ export function useUpgradeCheckout({
     url.searchParams.set(UPGRADE_RETURN_ORIGIN_PARAM, origin);
 
     try {
-      const result = await startPlanChange(url.toString(), "team", interval, {
-        confirmPaidPlanChange: false,
-      });
+      const result = await startPlanChange(
+        url.toString(),
+        "team",
+        checkoutInterval,
+        {
+          confirmPaidPlanChange: false,
+        }
+      );
       const nextUrl =
         result.kind === "checkout"
           ? result.checkoutUrl
@@ -133,7 +171,15 @@ export function useUpgradeCheckout({
       );
       return { redirected: false as const };
     }
-  }, [interval, limitKind, organizationId, origin, startPlanChange]);
+  }, [
+    annualSupported,
+    interval,
+    limitKind,
+    monthlySupported,
+    organizationId,
+    origin,
+    startPlanChange,
+  ]);
 
   return {
     interval,

--- a/mcpjam-inspector/client/src/hooks/use-upgrade-checkout.ts
+++ b/mcpjam-inspector/client/src/hooks/use-upgrade-checkout.ts
@@ -79,8 +79,13 @@ export function useUpgradeCheckout({
   origin,
   limitKind,
 }: UseUpgradeCheckoutParams) {
-  const { billingStatus, planCatalog, startPlanChange, isStartingPlanChange } =
-    useOrganizationBilling(organizationId);
+  const {
+    billingStatus,
+    planCatalog,
+    startPlanChange,
+    isStartingPlanChange,
+    isLoadingBilling,
+  } = useOrganizationBilling(organizationId);
 
   const teamEntry = planCatalog?.plans.team;
   const supportedIntervals = teamEntry?.checkout?.supportedIntervals ?? [
@@ -118,6 +123,42 @@ export function useUpgradeCheckout({
     "monthly"
   );
 
+  const currentPlan = billingStatus?.plan ?? "free";
+  const effectivePlan = billingStatus?.effectivePlan ?? currentPlan;
+  const canManageBilling = billingStatus?.canManageBilling ?? false;
+
+  const selectInterval = useCallback(
+    (nextInterval: BillingInterval) => {
+      // The product choice happens first; telemetry is best-effort and cannot
+      // prevent the selection even if the analytics SDK is unavailable.
+      setInterval(nextInterval);
+      track("plan_limit_interval_selected", {
+        location: "plan_limit_dialog",
+        organization_id: organizationId,
+        limit_kind: limitKind,
+        origin,
+        billing_interval: nextInterval,
+        price_cents: teamEntry?.prices[nextInterval] ?? null,
+        current_plan: currentPlan,
+        effective_plan: effectivePlan,
+        can_manage_billing: canManageBilling,
+        annual_supported: annualSupported,
+        monthly_supported: monthlySupported,
+      });
+    },
+    [
+      annualSupported,
+      canManageBilling,
+      currentPlan,
+      effectivePlan,
+      limitKind,
+      monthlySupported,
+      organizationId,
+      origin,
+      teamEntry?.prices,
+    ]
+  );
+
   const start = useCallback(async () => {
     if (!organizationId) return;
     const checkoutInterval = resolveUpgradeInterval(
@@ -127,15 +168,20 @@ export function useUpgradeCheckout({
     );
     if (!checkoutInterval) {
       toast.error("Checkout is not available for this plan right now.");
+      track("plan_limit_upgrade_failed", {
+        location: "plan_limit_dialog",
+        organization_id: organizationId,
+        limit_kind: limitKind,
+        origin,
+        error_kind: "no_supported_interval",
+        current_plan: currentPlan,
+        effective_plan: effectivePlan,
+        can_manage_billing: canManageBilling,
+        annual_supported: annualSupported,
+        monthly_supported: monthlySupported,
+      });
       return { redirected: false as const };
     }
-
-    track("plan_limit_upgrade_clicked", {
-      location: "plan_limit_dialog",
-      limit_kind: limitKind,
-      origin,
-      billing_interval: checkoutInterval,
-    });
 
     const url = new URL(window.location.href);
     url.searchParams.set(UPGRADE_RETURN_PARAM, "return");
@@ -143,7 +189,9 @@ export function useUpgradeCheckout({
     url.searchParams.set(UPGRADE_RETURN_ORIGIN_PARAM, origin);
 
     try {
-      const result = await startPlanChange(
+      // Start the real checkout work before emitting analytics. We never await
+      // analytics, and track() is failure-isolated.
+      const resultPromise = startPlanChange(
         url.toString(),
         "team",
         checkoutInterval,
@@ -151,6 +199,20 @@ export function useUpgradeCheckout({
           confirmPaidPlanChange: false,
         }
       );
+      track("plan_limit_upgrade_clicked", {
+        location: "plan_limit_dialog",
+        organization_id: organizationId,
+        limit_kind: limitKind,
+        origin,
+        billing_interval: checkoutInterval,
+        price_cents: teamEntry?.prices[checkoutInterval] ?? null,
+        current_plan: currentPlan,
+        effective_plan: effectivePlan,
+        can_manage_billing: canManageBilling,
+        annual_supported: annualSupported,
+        monthly_supported: monthlySupported,
+      });
+      const result = await resultPromise;
       const nextUrl =
         result.kind === "checkout"
           ? result.checkoutUrl
@@ -169,21 +231,37 @@ export function useUpgradeCheckout({
           ? error.message
           : "Couldn't start checkout. Please try again."
       );
+      track("plan_limit_upgrade_failed", {
+        location: "plan_limit_dialog",
+        organization_id: organizationId,
+        limit_kind: limitKind,
+        origin,
+        error_kind: "start_plan_change_failed",
+        error_name: error instanceof Error ? error.name : "unknown",
+        billing_interval: checkoutInterval,
+        current_plan: currentPlan,
+        effective_plan: effectivePlan,
+        can_manage_billing: canManageBilling,
+      });
       return { redirected: false as const };
     }
   }, [
     annualSupported,
+    canManageBilling,
+    currentPlan,
+    effectivePlan,
     interval,
     limitKind,
     monthlySupported,
     organizationId,
     origin,
     startPlanChange,
+    teamEntry?.prices,
   ]);
 
   return {
     interval,
-    setInterval,
+    setInterval: selectInterval,
     annualPriceLabel,
     monthlyPriceLabel,
     annualDiscountPct: getAnnualDiscountPercent(planCatalog),
@@ -197,12 +275,12 @@ export function useUpgradeCheckout({
     // Limit-wall copy and destinations follow the plan whose limits the user
     // is actually receiving. During a Team trial the persisted billing plan is
     // still Free, while the effective plan (and its limits) is Team.
-    effectivePlan:
-      billingStatus?.effectivePlan ?? billingStatus?.plan ?? "free",
+    effectivePlan,
     // Keep the persisted plan separate for real billing/checkout decisions.
-    currentPlan: billingStatus?.plan ?? "free",
+    currentPlan,
     organizationName: billingStatus?.organizationName ?? "your organization",
-    canManageBilling: billingStatus?.canManageBilling ?? false,
+    canManageBilling,
+    isLoadingBilling,
     isStarting: isStartingPlanChange,
     start,
   };

--- a/mcpjam-inspector/client/src/hooks/use-upgrade-checkout.ts
+++ b/mcpjam-inspector/client/src/hooks/use-upgrade-checkout.ts
@@ -30,9 +30,13 @@ function formatMoney(cents: number, currency: string): string {
 }
 
 /**
- * `prices.annual` is the full-year amount, so the per-seat monthly figure is
- * a twelfth of it. Mirrors `formatPlanPriceLabel` on the billing page so the
- * same plan never shows two different numbers.
+ * `prices.annual` is the full-year amount, so the per-seat monthly figure is a
+ * twelfth of it. Same number as `formatPlanPriceLabel` on the billing page.
+ *
+ * Returns the bare amount. The unit is rendered separately and smaller by
+ * `UpgradeIntervalPicker`: inside the large price span, "$30 per seat/month"
+ * wraps mid-phrase in a card this narrow, which reads worse than the "/seat/mo"
+ * it replaced.
  */
 export function formatSeatMonthlyPrice(
   amountInCents: number | null,
@@ -41,12 +45,9 @@ export function formatSeatMonthlyPrice(
 ): string | null {
   if (amountInCents == null || !currency) return null;
   if (interval === "monthly") {
-    return `${formatMoney(amountInCents, currency)}/seat/mo`;
+    return formatMoney(amountInCents, currency);
   }
-  return `${formatMoney(
-    Math.round(amountInCents / 12 / 100) * 100,
-    currency,
-  )}/seat/mo`;
+  return formatMoney(Math.round(amountInCents / 12 / 100) * 100, currency);
 }
 
 interface UseUpgradeCheckoutParams {

--- a/mcpjam-inspector/client/src/hooks/use-upgrade-checkout.ts
+++ b/mcpjam-inspector/client/src/hooks/use-upgrade-checkout.ts
@@ -1,4 +1,4 @@
-import { useCallback } from "react";
+import { useCallback, useState } from "react";
 import {
   useOrganizationBilling,
   type BillingInterval,
@@ -81,8 +81,12 @@ export function useUpgradeCheckout({
   const annualSupported = supportedIntervals.includes("annual");
   const monthlySupported = supportedIntervals.includes("monthly");
 
-  // Both prices are shown at once, so the interval is chosen by which card the
-  // user presses rather than by a toggle they have to find first.
+  // Annual leads: it's the cheaper per-seat figure and matches the pricing
+  // page. Both prices render at once, so nothing is hidden behind the choice.
+  const [interval, setInterval] = useState<BillingInterval>(
+    annualSupported ? "annual" : "monthly",
+  );
+
   const annualPriceLabel = formatSeatMonthlyPrice(
     teamEntry?.prices.annual ?? null,
     planCatalog?.currency,
@@ -94,7 +98,7 @@ export function useUpgradeCheckout({
     "monthly",
   );
 
-  const start = useCallback(async (interval: BillingInterval) => {
+  const start = useCallback(async () => {
     if (!organizationId) return;
     track("plan_limit_upgrade_clicked", {
       location: "plan_limit_dialog",
@@ -132,9 +136,11 @@ export function useUpgradeCheckout({
       );
       return { redirected: false as const };
     }
-  }, [limitKind, organizationId, origin, startPlanChange]);
+  }, [interval, limitKind, organizationId, origin, startPlanChange]);
 
   return {
+    interval,
+    setInterval,
     annualPriceLabel,
     monthlyPriceLabel,
     annualDiscountPct: getAnnualDiscountPercent(planCatalog),
@@ -146,6 +152,7 @@ export function useUpgradeCheckout({
      * is a separate question, tracked in the PR. */
     teamEvalIterations: teamEntry?.limits.maxEvalIterationsPerMonth ?? null,
     currentPlan: billingStatus?.plan ?? "free",
+    organizationName: billingStatus?.organizationName ?? "your organization",
     canManageBilling: billingStatus?.canManageBilling ?? false,
     isStarting: isStartingPlanChange,
     start,

--- a/mcpjam-inspector/client/src/hooks/use-upgrade-checkout.ts
+++ b/mcpjam-inspector/client/src/hooks/use-upgrade-checkout.ts
@@ -3,7 +3,10 @@ import {
   useOrganizationBilling,
   type BillingInterval,
 } from "@/hooks/useOrganizationBilling";
-import { getAnnualDiscountPercent } from "@/lib/billing-entitlements";
+import {
+  formatPlanName,
+  getAnnualDiscountPercent,
+} from "@/lib/billing-entitlements";
 import { track } from "@/lib/analytics";
 import { toast } from "@/lib/toast";
 
@@ -213,18 +216,35 @@ export function useUpgradeCheckout({
         monthly_supported: monthlySupported,
       });
       const result = await resultPromise;
-      const nextUrl =
-        result.kind === "checkout"
-          ? result.checkoutUrl
-          : result.kind === "portal"
-          ? result.portalUrl
-          : null;
-      if (nextUrl) {
+      if (result.kind === "checkout" || result.kind === "portal") {
+        const nextUrl =
+          result.kind === "checkout" ? result.checkoutUrl : result.portalUrl;
         // Same tab, so the return URL brings the user back in place.
         window.location.assign(nextUrl);
-        return { redirected: true as const };
+        return { redirected: true as const, shouldDismiss: false as const };
       }
-      return { redirected: false as const };
+
+      if (result.kind === "updated") {
+        toast.success(
+          `Plan updated to ${formatPlanName(
+            result.subscription.plan ?? "team"
+          )}.`
+        );
+      } else {
+        toast.success("Plan change scheduled for renewal.");
+      }
+      track("plan_limit_upgrade_resolved", {
+        location: "plan_limit_dialog",
+        organization_id: organizationId,
+        limit_kind: limitKind,
+        origin,
+        result_kind: result.kind,
+        billing_interval: checkoutInterval,
+        resulting_plan: result.subscription.plan ?? "team",
+        current_plan: currentPlan,
+        effective_plan: effectivePlan,
+      });
+      return { redirected: false as const, shouldDismiss: true as const };
     } catch (error) {
       toast.error(
         error instanceof Error
@@ -269,8 +289,7 @@ export function useUpgradeCheckout({
     monthlySupported,
     teamName: teamEntry?.displayName ?? "Team",
     /** Team's monthly eval cap, straight from the catalog so it can't go stale
-     * in the copy. Whether the catalog itself matches the public pricing page
-     * is a separate question, tracked in the PR. */
+     * in the copy. The backend applies this amount per seat. */
     teamEvalIterations: teamEntry?.limits.maxEvalIterationsPerMonth ?? null,
     // Limit-wall copy and destinations follow the plan whose limits the user
     // is actually receiving. During a Team trial the persisted billing plan is

--- a/mcpjam-inspector/client/src/hooks/use-upgrade-checkout.ts
+++ b/mcpjam-inspector/client/src/hooks/use-upgrade-checkout.ts
@@ -1,4 +1,4 @@
-import { useCallback, useState } from "react";
+import { useCallback } from "react";
 import {
   useOrganizationBilling,
   type BillingInterval,
@@ -81,20 +81,20 @@ export function useUpgradeCheckout({
   const annualSupported = supportedIntervals.includes("annual");
   const monthlySupported = supportedIntervals.includes("monthly");
 
-  // Annual leads: it is the cheaper per-seat number and matches the pricing
-  // page. Monthly stays one click away so nobody has to commit to a year to
-  // get unblocked.
-  const [interval, setInterval] = useState<BillingInterval>(
-    annualSupported ? "annual" : "monthly",
-  );
-
-  const priceLabel = formatSeatMonthlyPrice(
-    teamEntry?.prices[interval] ?? null,
+  // Both prices are shown at once, so the interval is chosen by which card the
+  // user presses rather than by a toggle they have to find first.
+  const annualPriceLabel = formatSeatMonthlyPrice(
+    teamEntry?.prices.annual ?? null,
     planCatalog?.currency,
-    interval,
+    "annual",
+  );
+  const monthlyPriceLabel = formatSeatMonthlyPrice(
+    teamEntry?.prices.monthly ?? null,
+    planCatalog?.currency,
+    "monthly",
   );
 
-  const start = useCallback(async () => {
+  const start = useCallback(async (interval: BillingInterval) => {
     if (!organizationId) return;
     track("plan_limit_upgrade_clicked", {
       location: "plan_limit_dialog",
@@ -132,12 +132,11 @@ export function useUpgradeCheckout({
       );
       return { redirected: false as const };
     }
-  }, [interval, limitKind, organizationId, origin, startPlanChange]);
+  }, [limitKind, organizationId, origin, startPlanChange]);
 
   return {
-    interval,
-    setInterval,
-    priceLabel,
+    annualPriceLabel,
+    monthlyPriceLabel,
     annualDiscountPct: getAnnualDiscountPercent(planCatalog),
     annualSupported,
     monthlySupported,

--- a/mcpjam-inspector/client/src/hooks/use-upgrade-request-recipients.ts
+++ b/mcpjam-inspector/client/src/hooks/use-upgrade-request-recipients.ts
@@ -1,0 +1,37 @@
+import { useMemo } from "react";
+import { useConvexAuth } from "convex/react";
+import {
+  resolveOrganizationRole,
+  useOrganizationMembers,
+} from "@/hooks/useOrganizations";
+import type { UpgradeRequestRecipient } from "@/components/billing/RequestUpgradeButton";
+
+/**
+ * The org owners a blocked member should be pointed at. Owners only: admins
+ * can't start checkout either (`canManageBilling` is owner-only in Convex), so
+ * addressing them would route the ask to someone who also can't act on it.
+ *
+ * Pending invites are excluded — `activeMembers` already filters to members
+ * with a resolved `userId`.
+ */
+export function useUpgradeRequestRecipients(
+  organizationId: string | null,
+): UpgradeRequestRecipient[] {
+  const { isAuthenticated } = useConvexAuth();
+  const { activeMembers } = useOrganizationMembers({
+    isAuthenticated,
+    organizationId,
+  });
+
+  return useMemo(
+    () =>
+      activeMembers
+        .filter((member) => resolveOrganizationRole(member) === "owner")
+        .map((member) => ({
+          email: member.email,
+          name: member.user?.name ?? null,
+        }))
+        .filter((recipient) => Boolean(recipient.email)),
+    [activeMembers],
+  );
+}

--- a/mcpjam-inspector/client/src/hooks/use-upgrade-request-recipients.ts
+++ b/mcpjam-inspector/client/src/hooks/use-upgrade-request-recipients.ts
@@ -14,16 +14,20 @@ import type { UpgradeRequestRecipient } from "@/components/billing/RequestUpgrad
  * Pending invites are excluded — `activeMembers` already filters to members
  * with a resolved `userId`.
  */
-export function useUpgradeRequestRecipients(
-  organizationId: string | null,
-): UpgradeRequestRecipient[] {
+export function useUpgradeRequestRecipients(organizationId: string | null): {
+  recipients: UpgradeRequestRecipient[];
+  isLoading: boolean;
+} {
   const { isAuthenticated } = useConvexAuth();
-  const { activeMembers } = useOrganizationMembers({
+  const { activeMembers, isLoading } = useOrganizationMembers({
     isAuthenticated,
     organizationId,
   });
 
-  return useMemo(
+  // `activeMembers` is [] while the query is in flight, so without `isLoading`
+  // the caller cannot tell "this org has no reachable owner" from "we haven't
+  // asked yet" — and would flash no action before the button appears.
+  const recipients = useMemo(
     () =>
       activeMembers
         .filter((member) => resolveOrganizationRole(member) === "owner")
@@ -34,4 +38,6 @@ export function useUpgradeRequestRecipients(
         .filter((recipient) => Boolean(recipient.email)),
     [activeMembers],
   );
+
+  return { recipients, isLoading };
 }

--- a/mcpjam-inspector/client/src/hooks/use-upgrade-request-recipients.ts
+++ b/mcpjam-inspector/client/src/hooks/use-upgrade-request-recipients.ts
@@ -14,20 +14,19 @@ import type { UpgradeRequestRecipient } from "@/components/billing/RequestUpgrad
  * Pending invites are excluded — `activeMembers` already filters to members
  * with a resolved `userId`.
  */
-export function useUpgradeRequestRecipients(organizationId: string | null): {
-  recipients: UpgradeRequestRecipient[];
-  isLoading: boolean;
-} {
+export function useUpgradeRequestRecipients(
+  organizationId: string | null,
+): UpgradeRequestRecipient[] {
   const { isAuthenticated } = useConvexAuth();
-  const { activeMembers, isLoading } = useOrganizationMembers({
+  const { activeMembers } = useOrganizationMembers({
     isAuthenticated,
     organizationId,
   });
 
-  // `activeMembers` is [] while the query is in flight, so without `isLoading`
-  // the caller cannot tell "this org has no reachable owner" from "we haven't
-  // asked yet" — and would flash no action before the button appears.
-  const recipients = useMemo(
+  // `activeMembers` is [] while the query is in flight, which collapses into
+  // the same render as "this org has no reachable owner": nothing. Both are
+  // states where there is no address to write to, so neither earns a button.
+  return useMemo(
     () =>
       activeMembers
         .filter((member) => resolveOrganizationRole(member) === "owner")
@@ -38,6 +37,4 @@ export function useUpgradeRequestRecipients(organizationId: string | null): {
         .filter((recipient) => Boolean(recipient.email)),
     [activeMembers],
   );
-
-  return { recipients, isLoading };
 }

--- a/mcpjam-inspector/client/src/hooks/use-upgrade-request-recipients.ts
+++ b/mcpjam-inspector/client/src/hooks/use-upgrade-request-recipients.ts
@@ -14,19 +14,17 @@ import type { UpgradeRequestRecipient } from "@/components/billing/RequestUpgrad
  * Pending invites are excluded — `activeMembers` already filters to members
  * with a resolved `userId`.
  */
-export function useUpgradeRequestRecipients(
-  organizationId: string | null,
-): UpgradeRequestRecipient[] {
+export function useUpgradeRequestRecipients(organizationId: string | null): {
+  recipients: UpgradeRequestRecipient[];
+  isLoading: boolean;
+} {
   const { isAuthenticated } = useConvexAuth();
-  const { activeMembers } = useOrganizationMembers({
+  const { activeMembers, isLoading } = useOrganizationMembers({
     isAuthenticated,
     organizationId,
   });
 
-  // `activeMembers` is [] while the query is in flight, which collapses into
-  // the same render as "this org has no reachable owner": nothing. Both are
-  // states where there is no address to write to, so neither earns a button.
-  return useMemo(
+  const recipients = useMemo(
     () =>
       activeMembers
         .filter((member) => resolveOrganizationRole(member) === "owner")
@@ -35,6 +33,8 @@ export function useUpgradeRequestRecipients(
           name: member.user?.name ?? null,
         }))
         .filter((recipient) => Boolean(recipient.email)),
-    [activeMembers],
+    [activeMembers]
   );
+
+  return { recipients, isLoading };
 }

--- a/mcpjam-inspector/client/src/hooks/use-upgrade-request-recipients.ts
+++ b/mcpjam-inspector/client/src/hooks/use-upgrade-request-recipients.ts
@@ -18,11 +18,13 @@ export function useUpgradeRequestRecipients(organizationId: string | null): {
   recipients: UpgradeRequestRecipient[];
   isLoading: boolean;
 } {
-  const { isAuthenticated } = useConvexAuth();
-  const { activeMembers, isLoading } = useOrganizationMembers({
-    isAuthenticated,
-    organizationId,
-  });
+  const { isAuthenticated, isLoading: isAuthLoading } = useConvexAuth();
+  const { activeMembers, isLoading: isMembersLoading } = useOrganizationMembers(
+    {
+      isAuthenticated,
+      organizationId,
+    }
+  );
 
   const recipients = useMemo(
     () =>
@@ -36,5 +38,8 @@ export function useUpgradeRequestRecipients(organizationId: string | null): {
     [activeMembers]
   );
 
-  return { recipients, isLoading };
+  // While Convex auth resolves, isAuthenticated is temporarily false and the
+  // members query is skipped. Keep the result pending so callers do not treat
+  // that temporary empty list as a settled "no owner" result.
+  return { recipients, isLoading: isAuthLoading || isMembersLoading };
 }

--- a/mcpjam-inspector/client/src/hooks/useCreditTopup.ts
+++ b/mcpjam-inspector/client/src/hooks/useCreditTopup.ts
@@ -211,12 +211,6 @@ export function useCreditTopup() {
     }: StartCheckoutInput): Promise<void> => {
       setIsStartingCheckout(true);
       setError(null);
-      track("credit_topup_checkout_started", {
-        location: "credit_topup",
-        package_id: packageId,
-        price_cents: priceCents,
-        source,
-      });
       stashPendingTopup({ chatSessionId, message: lastUserMessage });
       // Track the most specific failure category we know about. Defaults to
       // `action_threw` (the fallback when the Convex action itself rejects)
@@ -224,11 +218,25 @@ export function useCreditTopup() {
       let errorKind: "missing_url" | "invalid_url" | "action_threw" =
         "action_threw";
       try {
-        const result = (await createCheckoutSession({
+        // Begin the real checkout action first. Product analytics is emitted
+        // without being awaited and cannot block or break the checkout.
+        const checkoutPromise = createCheckoutSession({
           organizationId,
           packageId,
           ...(returnUrl ? { returnUrl } : {}),
-        } as any)) as { checkoutUrl?: string } | null;
+        } as any);
+        track("credit_topup_checkout_started", {
+          location: "credit_topup",
+          organization_id: organizationId,
+          package_id: packageId,
+          price_cents: priceCents,
+          source,
+          has_resume_context: Boolean(chatSessionId && lastUserMessage),
+          has_return_url: Boolean(returnUrl),
+        });
+        const result = (await checkoutPromise) as {
+          checkoutUrl?: string;
+        } | null;
         const checkoutUrl = result?.checkoutUrl;
         if (typeof checkoutUrl !== "string" || checkoutUrl.length === 0) {
           errorKind = "missing_url";
@@ -242,18 +250,20 @@ export function useCreditTopup() {
         }
         window.location.assign(checkoutUrl);
       } catch (err) {
-        track("credit_topup_checkout_failed", {
-          location: "credit_topup",
-          package_id: packageId,
-          price_cents: priceCents,
-          error_kind: errorKind,
-          source,
-        });
         clearPendingTopup();
 
         const message =
           err instanceof Error ? err.message : "Failed to start checkout";
         setError(message);
+        track("credit_topup_checkout_failed", {
+          location: "credit_topup",
+          organization_id: organizationId,
+          package_id: packageId,
+          price_cents: priceCents,
+          error_kind: errorKind,
+          error_name: err instanceof Error ? err.name : "unknown",
+          source,
+        });
         throw err;
       } finally {
         setIsStartingCheckout(false);

--- a/mcpjam-inspector/client/src/lib/__tests__/analytics.test.ts
+++ b/mcpjam-inspector/client/src/lib/__tests__/analytics.test.ts
@@ -1,19 +1,26 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
 
-const { captureMock } = vi.hoisted(() => ({ captureMock: vi.fn() }));
-vi.mock("posthog-js", () => ({ default: { capture: captureMock } }));
-vi.mock("../PosthogUtils", () => ({
-  standardEventProps: (location: string) => ({
+const { captureMock, standardEventPropsMock } = vi.hoisted(() => ({
+  captureMock: vi.fn(),
+  standardEventPropsMock: vi.fn((location: string) => ({
     location,
     platform: "web",
     environment: "test",
-  }),
+  })),
+}));
+vi.mock("posthog-js", () => ({ default: { capture: captureMock } }));
+vi.mock("../PosthogUtils", () => ({
+  standardEventProps: standardEventPropsMock,
 }));
 
 import { track } from "../analytics";
 
 describe("track()", () => {
-  afterEach(() => captureMock.mockClear());
+  afterEach(() => {
+    captureMock.mockClear();
+    standardEventPropsMock.mockClear();
+    vi.restoreAllMocks();
+  });
 
   it("injects standard props from the location argument", () => {
     track("skill_viewed", { location: "skills_tab", skill_name: "x" });
@@ -38,13 +45,36 @@ describe("track()", () => {
   });
 
   it("never lets a capture failure break the product action", () => {
+    const error = new Error("analytics unavailable");
+    const warnMock = vi.spyOn(console, "warn").mockImplementation(() => {});
     captureMock.mockImplementationOnce(() => {
-      throw new Error("analytics unavailable");
+      throw error;
     });
 
     expect(() =>
       track("skill_viewed", { location: "skills_tab", skill_name: "x" })
     ).not.toThrow();
+    expect(warnMock).toHaveBeenCalledWith(
+      "[analytics] Failed to capture skill_viewed",
+      error
+    );
+  });
+
+  it("reports a standard-property failure without breaking the product action", () => {
+    const error = new Error("event context unavailable");
+    const warnMock = vi.spyOn(console, "warn").mockImplementation(() => {});
+    standardEventPropsMock.mockImplementationOnce(() => {
+      throw error;
+    });
+
+    expect(() =>
+      track("skill_viewed", { location: "skills_tab", skill_name: "x" })
+    ).not.toThrow();
+    expect(captureMock).not.toHaveBeenCalled();
+    expect(warnMock).toHaveBeenCalledWith(
+      "[analytics] Failed to capture skill_viewed",
+      error
+    );
   });
 
   it("strips a caller-supplied environment so it can't survive when standardEventProps omits it", async () => {

--- a/mcpjam-inspector/client/src/lib/__tests__/analytics.test.ts
+++ b/mcpjam-inspector/client/src/lib/__tests__/analytics.test.ts
@@ -37,6 +37,16 @@ describe("track()", () => {
     expect(props.location).toBe("skills_tab");
   });
 
+  it("never lets a capture failure break the product action", () => {
+    captureMock.mockImplementationOnce(() => {
+      throw new Error("analytics unavailable");
+    });
+
+    expect(() =>
+      track("skill_viewed", { location: "skills_tab", skill_name: "x" })
+    ).not.toThrow();
+  });
+
   it("strips a caller-supplied environment so it can't survive when standardEventProps omits it", async () => {
     // Regression for the self-hosted/dev case: standardEventProps() omits
     // `environment` when VITE_ENVIRONMENT is unset, so a caller-supplied

--- a/mcpjam-inspector/client/src/lib/__tests__/billing-entitlements.test.ts
+++ b/mcpjam-inspector/client/src/lib/__tests__/billing-entitlements.test.ts
@@ -105,6 +105,21 @@ describe("getBillingErrorMessage", () => {
     expect(message).toMatch(
       /^This organization has reached its eval iteration limit \(25\)\. Resets /
     );
+    expect(message).toMatch(/Upgrade to continue now\.$/);
+  });
+
+  it("points members to an owner after naming the eval reset", () => {
+    const message = formatBillingLimitReachedMessage(
+      "maxEvalIterationsPerMonth",
+      25,
+      false,
+      { resetsAt: Date.UTC(2026, 5, 2), windowKind: "day" }
+    );
+
+    expect(message).toMatch(/Resets /);
+    expect(message).toMatch(
+      /Ask an organization owner to upgrade to continue now\.$/
+    );
   });
 
   it("ignores invalid eval reset timestamps", () => {

--- a/mcpjam-inspector/client/src/lib/analytics.ts
+++ b/mcpjam-inspector/client/src/lib/analytics.ts
@@ -42,8 +42,11 @@ export function track(
   } = props;
   try {
     posthog.capture(event, { ...rest, ...standardEventProps(location) });
-  } catch {
+  } catch (error) {
     // Product analytics is best-effort. Ad blockers, initialization races, or
     // an SDK failure must never stop the user action that emitted the event.
+    // Keep the failure observable without including event props, which may
+    // contain sensitive product data.
+    console.warn(`[analytics] Failed to capture ${event}`, error);
   }
 }

--- a/mcpjam-inspector/client/src/lib/analytics.ts
+++ b/mcpjam-inspector/client/src/lib/analytics.ts
@@ -17,12 +17,15 @@ import { standardEventProps } from "./PosthogUtils";
  *
  * The posthog-js singleton is the same instance PostHogProvider initializes
  * (the provider is given an apiKey, which inits the global instance), and it
- * already honors VITE_DISABLE_POSTHOG_LOCAL via opt_out_capturing_by_default
- * — no disabled-state branching needed here.
+ * inherits the rich person created by usePostHogIdentify (WorkOS id, email,
+ * name, occupation, and deployment). Keep PII on that person profile instead
+ * of copying it onto every event payload.
+ * The client also honors VITE_DISABLE_POSTHOG_LOCAL via
+ * opt_out_capturing_by_default — no disabled-state branching needed here.
  */
 export function track(
   event: ClientAnalyticsEventName,
-  props: Record<string, unknown> & { location?: string } = {},
+  props: Record<string, unknown> & { location?: string } = {}
 ): void {
   // Drop platform/environment from the caller's props rather than relying
   // on spread order alone: standardEventProps() OMITS `environment` when
@@ -37,5 +40,10 @@ export function track(
     environment: _environment,
     ...rest
   } = props;
-  posthog.capture(event, { ...rest, ...standardEventProps(location) });
+  try {
+    posthog.capture(event, { ...rest, ...standardEventProps(location) });
+  } catch {
+    // Product analytics is best-effort. Ad blockers, initialization races, or
+    // an SDK failure must never stop the user action that emitted the event.
+  }
 }

--- a/mcpjam-inspector/client/src/lib/billing-entitlements.ts
+++ b/mcpjam-inspector/client/src/lib/billing-entitlements.ts
@@ -300,7 +300,10 @@ export function formatBillingLimitReachedMessage(
         hour: "numeric",
         minute: "2-digit",
       }).format(new Date(options.resetsAt));
-      return `This organization has reached its eval iteration limit (${allowedValue}). Resets ${resetTime}.`;
+      const nextStep = canManageBilling
+        ? "Upgrade to continue now."
+        : "Ask an organization owner to upgrade to continue now.";
+      return `This organization has reached its eval iteration limit (${allowedValue}). Resets ${resetTime}. ${nextStep}`;
     }
     return canManageBilling
       ? `This organization has reached its eval iteration limit (${allowedValue}). Upgrade to continue.`

--- a/mcpjam-inspector/client/src/main.tsx
+++ b/mcpjam-inspector/client/src/main.tsx
@@ -26,6 +26,7 @@ import {
   normalizeInitialLegacyHashBookmark,
 } from "./lib/app-navigation";
 import OAuthDebugCallback from "./components/oauth/OAuthDebugCallback";
+import { PlanLimitDialogPreview } from "./components/billing/PlanLimitDialogPreview";
 import {
   getInitialThemeMode,
   getInitialThemePreset,
@@ -153,6 +154,24 @@ if (isInIframe) {
   root.render(
     <StrictMode>
       <IframeRouterError />
+    </StrictMode>
+  );
+} else if (
+  import.meta.env.DEV &&
+  window.location.pathname.startsWith("/__preview/plan-limit")
+) {
+  // Dev-only design harness for the free-plan limit wall. Mounted here, ahead
+  // of AuthKit and Convex, because the states worth reviewing (member who
+  // can't upgrade, org already at its Team ceiling) can't be produced on
+  // demand against a real backend. Renders the real component and the real
+  // stylesheet with dummy data. The DEV guard keeps it out of production
+  // bundles entirely.
+  updateThemeMode(getInitialThemeMode());
+  updateThemePreset(getInitialThemePreset());
+  const root = createRoot(document.getElementById("root")!);
+  root.render(
+    <StrictMode>
+      <PlanLimitDialogPreview />
     </StrictMode>
   );
 } else if (isDebugOAuthCallbackPath(window.location.pathname)) {

--- a/mcpjam-inspector/client/src/stores/plan-limit-dialog-store.ts
+++ b/mcpjam-inspector/client/src/stores/plan-limit-dialog-store.ts
@@ -1,0 +1,34 @@
+import { create } from "zustand";
+
+/**
+ * Which free-plan cap the user just hit. Only `evalIterations` is wired for
+ * now — the credits wall still routes to `MCPJamLimitDialog` (top-up/BYOK)
+ * until we decide whether upgrade should lead there too.
+ */
+export type PlanLimitKind = "evalIterations";
+
+export interface PlanLimitDialogInput {
+  kind: PlanLimitKind;
+  organizationId: string;
+  used: number;
+  allowed: number | null;
+  resetsAt: number | null;
+  windowKind: "day" | "month";
+  /** Where the user was blocked. Sent to telemetry; also the surface the
+   * post-checkout return lands back on. */
+  origin: string;
+}
+
+interface PlanLimitDialogState {
+  isOpen: boolean;
+  limit: PlanLimitDialogInput | null;
+  open: (input: PlanLimitDialogInput) => void;
+  close: () => void;
+}
+
+export const usePlanLimitDialogStore = create<PlanLimitDialogState>((set) => ({
+  isOpen: false,
+  limit: null,
+  open: (limit) => set({ isOpen: true, limit }),
+  close: () => set({ isOpen: false, limit: null }),
+}));

--- a/mcpjam-inspector/shared/analytics-events.ts
+++ b/mcpjam-inspector/shared/analytics-events.ts
@@ -228,6 +228,7 @@ export const ANALYTICS_EVENTS = {
   plan_limit_upgrade_returned: { source: "client" },
   plan_limit_dialog_dismissed: { source: "client" },
   plan_limit_enterprise_cta_clicked: { source: "client" },
+  plan_limit_upgrade_requested: { source: "client" },
   // --- OpenAI plugin import (Connect "Add plugin", INS-2) ---
   // Props are built by `client/src/lib/plugins/plugin-analytics.ts`, which
   // exists to keep bundle paths, server URLs, env/header names, and plugin

--- a/mcpjam-inspector/shared/analytics-events.ts
+++ b/mcpjam-inspector/shared/analytics-events.ts
@@ -231,6 +231,7 @@ export const ANALYTICS_EVENTS = {
   plan_limit_interval_selected: { source: "client" },
   plan_limit_upgrade_clicked: { source: "client" },
   plan_limit_upgrade_failed: { source: "client" },
+  plan_limit_upgrade_resolved: { source: "client" },
   plan_limit_upgrade_returned: { source: "client" },
   plan_limit_dialog_dismissed: { source: "client" },
   plan_limit_enterprise_cta_clicked: { source: "client" },

--- a/mcpjam-inspector/shared/analytics-events.ts
+++ b/mcpjam-inspector/shared/analytics-events.ts
@@ -219,6 +219,15 @@ export const ANALYTICS_EVENTS = {
   playground_tool_run_clicked: { source: "client" },
   playground_tools_pane_tab_changed: { source: "client" },
   playground_tools_refresh_clicked: { source: "client" },
+  // --- Free-plan limit walls (PlanLimitDialog) ---
+  // `limit_kind` distinguishes which cap was hit so we can compare which wall
+  // converts. `plan_limit_upgrade_returned` fires on the post-checkout return
+  // and carries whether the org actually landed on a paid plan.
+  plan_limit_dialog_shown: { source: "client" },
+  plan_limit_upgrade_clicked: { source: "client" },
+  plan_limit_upgrade_returned: { source: "client" },
+  plan_limit_dialog_dismissed: { source: "client" },
+  plan_limit_enterprise_cta_clicked: { source: "client" },
   // --- OpenAI plugin import (Connect "Add plugin", INS-2) ---
   // Props are built by `client/src/lib/plugins/plugin-analytics.ts`, which
   // exists to keep bundle paths, server URLs, env/header names, and plugin

--- a/mcpjam-inspector/shared/analytics-events.ts
+++ b/mcpjam-inspector/shared/analytics-events.ts
@@ -220,15 +220,24 @@ export const ANALYTICS_EVENTS = {
   playground_tools_pane_tab_changed: { source: "client" },
   playground_tools_refresh_clicked: { source: "client" },
   // --- Free-plan limit walls (PlanLimitDialog) ---
-  // `limit_kind` distinguishes which cap was hit so we can compare which wall
-  // converts. `plan_limit_upgrade_returned` fires on the post-checkout return
-  // and carries whether the org actually landed on a paid plan.
+  // One impression per opening, then explicit user actions and checkout
+  // outcomes. `limit_kind` distinguishes which cap was hit so we can compare
+  // which wall converts. Person data comes from the global identified profile,
+  // not duplicated PII in these events.
   plan_limit_dialog_shown: { source: "client" },
+  plan_limit_sign_in_clicked: { source: "client" },
+  plan_limit_buy_credits_clicked: { source: "client" },
+  plan_limit_byok_clicked: { source: "client" },
+  plan_limit_interval_selected: { source: "client" },
   plan_limit_upgrade_clicked: { source: "client" },
+  plan_limit_upgrade_failed: { source: "client" },
   plan_limit_upgrade_returned: { source: "client" },
   plan_limit_dialog_dismissed: { source: "client" },
   plan_limit_enterprise_cta_clicked: { source: "client" },
   plan_limit_upgrade_requested: { source: "client" },
+  credit_topup_dialog_shown: { source: "client" },
+  credit_topup_package_selected: { source: "client" },
+  credit_topup_dialog_dismissed: { source: "client" },
   // --- OpenAI plugin import (Connect "Add plugin", INS-2) ---
   // Props are built by `client/src/lib/plugins/plugin-analytics.ts`, which
   // exists to keep bundle paths, server URLs, env/header names, and plugin


### PR DESCRIPTION
## Problem

A user hit the free eval-iteration cap, got a dismissible toast with no next step, and didn't realize upgrading was an option.

The toast could never have told them. In `formatBillingLimitReachedMessage`, the branch that has a reset time returns early and never reaches the "Upgrade to continue" branch below it. So the highest-intent moment in the product was the one message that never mentioned paying.

The credits wall had a modal, but both CTAs (Top up, Bring your own key) keep the org on Free. Upgrading wasn't offered at all.

## What this changes

**Eval wall is now a dialog, not a toast.** It appears when the user clicks Run and names their allowance, when it resets, and what Team includes.

**Credits wall leads with upgrade.** For a manager on Free it now reads: the plan sentence, then the interval cards with a full-width **Upgrade to Team** as the primary action, then **Buy credits** as a secondary outline button with *Use your own API key* demoted to a text link. Both of the old CTAs kept the org on Free at a variable cost; the upgrade is the one that converts, so it leads. An org already on a paid plan skips the upgrade block and gets the buy-credits path only.

**Both intervals up front.** Annual and monthly render side by side with their per-seat prices and the saving percentage, so neither is hidden behind a toggle. Select one, then confirm with the upgrade button, the same shape as the credit preset dialog.

**Straight to checkout.** The CTA calls `startPlanChange` and redirects to Stripe. Previously the only path was deep-linking to `/billing?plan=team` and waiting for the auto-checkout effect to fire on a page the user never asked for.

**Returns to where the user was blocked.** `returnUrl` carries the current surface plus `upgrade_org` / `upgrade_from`. `getBillingReturnUrl()` hardcodes `/billing`, so upgrading from a blocked eval suite used to land you in billing settings with nothing run. The confirmation toast is gated on billing status showing a paid plan, so bailing at Stripe stays silent.

**Members get a way to ask.** Someone who can't check out used to see an explanation and nothing to do. They now get "Email your owner", which opens a prefilled draft naming the org, what they hit, and the three steps the owner takes. It's a `mailto:` anchor, matching [SupportTab.tsx](mcpjam-inspector/client/src/components/SupportTab.tsx) and the chat error surface. It renders nothing when no owner address resolves, so nobody gets a button that opens an empty draft. Wired into both walls.

**Paid orgs at their own ceiling get a path too.** Team orgs see "Request upgrade" pointing at mcpjam.com/contact, opened in a new tab so they keep their place. Orgs already on Enterprise get the reset line with no pitch.

**Copy.** "Top up" becomes "Buy credits" in all three places it appeared (limit dialog, and the model picker's disabled reason). The billing page already used that label. The buy-credits dialog now says credits don't change your plan limits, so nobody buys credits expecting a higher eval cap, and each preset tile shows its price instead of revealing it only after selection.

Analytics event names (`credit_topup_*`) and the `?topup=open` param are unchanged so dashboards and existing links keep working.

## Judgment calls worth a second opinion

These are decisions I made where a reasonable person could pick differently:

- **The Stripe redirect is same-tab.** Return-in-place is the whole point of this PR, and a new tab would strand the return. But `openBillingUrl` elsewhere in the app defaults to a new tab, so this is deliberately inconsistent with its neighbour. Worth a look in the desktop build specifically.
- **The upgrade request opens a draft, it does not send.** Nothing in the client can send mail on a user's behalf, so the label says "Email your owner" and the helper line says "Opens a draft". Claiming it sends would be a lie the first time someone's mail client isn't configured.
- **Request recipients are owners only, not admins.** Admins can't start checkout either, so addressing them would route the ask to someone who also can't act on it. If the permissions change below lands, admins get the real button instead and stop seeing this one.
- **Loading and "no owner found" render identically: nothing.** A disabled button that later disappears is worse than no button, and the org genuinely may have no reachable owner.
- **The eval figure comes from the plan catalog; credits state no figure.** Credits aren't in `BillingLimitName`, so the only available source is the marketing table that already drifted once.
- **`text-wrap: pretty` on the description** rather than hand-tuning sentence length, so a stranded last word can't come back at a viewport width nobody checked.

## Needs a backend check before merge

**The eval cap numbers disagree across sources.** `compare-plan-marketing.ts` said Free 75/day and Team 15,000/mo. mcpjam.com/pricing says 25/day and 5,000/mo. This PR aligns the repo table to the site.

The dialog reads its Team figure from the plan catalog (`maxEvalIterationsPerMonth`) rather than any hardcoded string, so it always states what billing will actually give the user. **Someone needs to confirm the Convex catalog also says 5,000**, because if it still says 15,000, the dialog and the site will disagree. A user-reported toast showed a cap of 75, which matches the old repo table, so the catalog may well be on the old numbers.

Credits deliberately state no figure. Credits aren't in `BillingLimitName`, so the only available source is the hardcoded marketing table, which is exactly what drifts.

**Suggested durable fix:** add credits to the catalog and have the compare table read both rows from it, the way the dialog does. Then the numbers live in one place and every surface updates together.

## Ask for the team: let admins upgrade

Two permission checks disagree, and the client can only follow what the backend reports:

| Check | Who passes | Gates |
| --- | --- | --- |
| `canManageOrgCredits` (client) | owner, admin, creator | buying credits |
| `canManageBilling` (Convex) | owner only | upgrading the plan |

An admin can spend the org's money on credits but cannot upgrade the plan. At the wall they see an explanation with no button.

Proposed:

- **Upgrade:** extend to owner, admin, creator, matching the credits rule.
- **Cancel, downgrade, change interval, open portal:** keep owner-only. Destructive, and the Stripe portal exposes invoices, card last four, and billing address.
- **Guests:** never, in either direction.

`canManageAsOwnerOrAdmin` in `useProjects.ts` is existing precedent for that tier.

This is a Convex change outside this repo. No client work either way: the dialog reads the flag and renders the CTA or the explanation.

## Reviewing this without a capped org

`/__preview/plan-limit` renders both real dialogs with dummy data while the dev server runs. It mounts from `main.tsx` ahead of AuthKit and Convex, so it needs no sign-in and no org sitting at its cap. `import.meta.env.DEV` keeps it out of production bundles.

Switch walls at the top, then pick a variant:

- **Eval iterations:** free owner who can upgrade, member who can't, Team org at its ceiling, and no reachable owner.
- **Credits:** free org that can upgrade, paid org where credits are the real answer, and a member who can do neither.

To make that possible, each dialog splits into data wiring plus a pure view (`PlanLimitDialogView`, `CreditsLimitDialogView`), with the container keeping org resolution, permissions, and copy assembly. The views take a `modal={false}` prop used only by the preview, so its switcher stays clickable behind the dialog.

## On sending the request automatically

The email opens as a draft rather than sending silently, because nothing in the client can send mail on a user's behalf. `useNotifications` only reads and marks read, and `NotificationType` is a closed union in Convex. Either upgrade would need backend work:

- **In-app notification to owners:** a new Convex mutation plus a `plan_upgrade_requested` entry in `NotificationType`. Owners would see it in the existing notifications panel.
- **Server-sent email:** a Convex action. Closest to fully automatic, most work.

The client seam is already in the right place: `buildUpgradeRequestMail` composes the message, so swapping delivery means changing the call site, not the copy.

## Still open

- Pre-limit nudges around 80% of the allowance, so the wall stops being a surprise.
- Credits-to-messages conversion on the preset tiles, pending a number we can defend. Prices land now regardless.

## Testing

- `PlanLimitDialog.test.tsx`, 15 tests: copy assembly, both prices rendering, select-then-confirm (pressing a card must not start checkout), the member email path and its no-owner fallback, the Team and Enterprise variants, and all four checkout-return outcomes (paid, bailed, credits wording, still loading).
- `RequestUpgradeButton.test.tsx`, 7 tests: the composed message addresses every owner and contains all three steps, credits and eval walls read differently, no recipients renders nothing, and the click reports.
- Updated `MCPJamLimitDialog.test.tsx`, `CreditTopupDialog.test.tsx`, and `compare-plan-marketing.test.ts` for the new copy and numbers.
- Full client suite: 8439 passing, 0 failing. `typecheck:client` clean.

## What was and was not verified

**Verified:** full client suite (8439 passing, 0 failing), `typecheck:client` clean, and every state of both walls rendered in a browser through `/__preview/plan-limit`.

**Not verified:** no real checkout was exercised end to end. Both walls need a hosted org sitting at its cap, which can't be produced on demand, so the Stripe round trip and the return-in-place confirmation have not been run against live billing.

Reviewers should treat the Stripe redirect, the post-checkout return, and the desktop-build behaviour as unexercised paths.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
