### PR TITLE
fix(auth): serve WorkOS client config at runtime, drop dead devMode knob

### DIFF
--- a/.changeset/workos-client-config-runtime-injection.md
+++ b/.changeset/workos-client-config-runtime-injection.md
@@ -1,0 +1,20 @@
+---
+"@mcpjam/inspector": patch
+---
+
+Serve WorkOS client config at runtime instead of baking it into the bundle, and delete the dead `VITE_WORKOS_DEV_MODE` knob.
+
+`VITE_WORKOS_CLIENT_ID` and `VITE_WORKOS_API_HOSTNAME` were inlined by Vite at build time, which meant every environment needed the value listed in two hand-maintained places that nobody diffs: the Railway service variables, and the `ARG` allowlist in `mcpjam-inspector/Dockerfile`. Miss either one and the client does not fail to build — it ships silently misconfigured.
+
+That is what happened to staging. It carried no `VITE_WORKOS_API_HOSTNAME`, so `resolveWorkosClientOptions` fell through to the default `api.workos.com`. From `staging.mcpjam.com` that host is cross-site, so the AuthKit session cookie was never sent; `#refreshSession` posted `{client_id, grant_type: "refresh_token"}` with no credential, got a 400, and `#doRefresh`'s catch called `removeSessionData()`. Because AuthKit stores the refresh token in `memoryStorage` outside dev mode, nothing survived the page load and every single navigation logged the user out. Production was unaffected only because it sets the variable to `auth.mcpjam.com`, which shares a registrable domain with `app.mcpjam.com`.
+
+The downstream symptoms all traced back to that one 400: the hosted shell showed its `logged-out` gate (staging runs `NON_PROD_LOCKDOWN`, so there is no guest fallback to absorb it), `AppReadyProvider` never left `resolving-auth`, and MCP server OAuth appeared to fail — tokens are persisted through `/api/web/oauth/import-tokens`, which forwards the caller's bearer, so with no session the credential could not be written and the next connect attempt replayed the consent screen.
+
+Both values now ride the existing `window.__MCP_RUNTIME_CONFIG__` channel that already carries the Convex URLs (`getInspectorClientRuntimeConfig` in `server/env.ts`, read by `client/src/lib/runtime-config.ts`). The serving process knows which WorkOS environment it belongs to; the bundle no longer has to. A Railway variable change now takes effect on restart, in every environment, with no rebuild and no Dockerfile edit.
+
+This is backward compatible and needs no deploy-config change: the server reads the canonical unprefixed `WORKOS_CLIENT_ID` / `WORKOS_API_HOSTNAME` first and falls back to the `VITE_`-prefixed names, which Railway already injects into the running container. The client still falls back to its build-time value when no runtime config is present, so npx and Electron builds are unchanged. The Dockerfile `ARG`s are deliberately left in place for now — removing them is a separate cleanup once every environment has been confirmed on the runtime path.
+
+Two smaller fixes ride along:
+
+- **`getInspectorClientRuntimeConfigScript` keyed its "inject anything at all?" guard off the two Convex fields.** An environment with WorkOS config but no Convex URL would have emitted no script and silently fallen back to build-time values. It now checks every field.
+- **`resolveWorkosDevMode` is gone.** It read `VITE_WORKOS_DEV_MODE`, which was set in no environment and was absent from the Dockerfile `ARG` allowlist, so no deployed build could set it — a config knob that could not be configured. It was added in the same change as the first-party AuthKit proxy at `/user_management`, which is what actually gives local dev cookie mode, and it existed only to opt out of the mode that proxy made universal. It is replaced by an exported `WORKOS_DEV_MODE = false` constant, still passed explicitly to `AuthKitProvider`, because `@workos-inc/authkit-js` defaults `devMode` to `location.hostname === "localhost"` — omitting the prop would move local dev onto a different session-storage path than every deployed environment.

--- a/mcpjam-inspector/client/src/lib/__tests__/workos-authkit-config.test.ts
+++ b/mcpjam-inspector/client/src/lib/__tests__/workos-authkit-config.test.ts
@@ -1,18 +1,16 @@
 import { describe, expect, it } from "vitest";
 import {
   resolveWorkosClientOptions,
-  resolveWorkosDevMode,
+  WORKOS_DEV_MODE,
 } from "../workos-authkit-config";
 
 describe("workos authkit config", () => {
-  it("uses cookie mode by default, including local dev", () => {
-    expect(resolveWorkosDevMode({ DEV: true })).toBe(false);
-    expect(resolveWorkosDevMode({ DEV: false })).toBe(false);
-  });
-
-  it("keeps the explicit dev mode escape hatch", () => {
-    expect(resolveWorkosDevMode({ VITE_WORKOS_DEV_MODE: "true" })).toBe(true);
-    expect(resolveWorkosDevMode({ VITE_WORKOS_DEV_MODE: "false" })).toBe(false);
+  // Not a tautology: authkit-js defaults `devMode` to true on localhost, so
+  // this constant has to stay false and stay explicitly passed, or local dev
+  // silently moves the refresh token to localStorage while every deployed
+  // environment keeps it in memory behind the AuthKit session cookie.
+  it("uses cookie mode on every surface, including local dev", () => {
+    expect(WORKOS_DEV_MODE).toBe(false);
   });
 
   it("proxies AuthKit calls through the local origin on localhost", () => {

--- a/mcpjam-inspector/client/src/lib/runtime-config.ts
+++ b/mcpjam-inspector/client/src/lib/runtime-config.ts
@@ -1,6 +1,8 @@
 export interface InspectorClientRuntimeConfig {
   convexUrl?: string;
   convexSiteUrl?: string;
+  workosClientId?: string;
+  workosApiHostname?: string;
 }
 
 declare global {
@@ -32,4 +34,22 @@ export function getRuntimeConvexUrl(): string | undefined {
 
 export function getRuntimeConvexSiteUrl(): string | undefined {
   return getNonEmptyString(getRuntimeConfig()?.convexSiteUrl);
+}
+
+/**
+ * WorkOS AuthKit client id, served by the document rather than inlined at build
+ * time. See `getInspectorClientRuntimeConfig` in `server/env.ts` for why this
+ * moved off `import.meta.env`.
+ */
+export function getRuntimeWorkosClientId(): string | undefined {
+  return getNonEmptyString(getRuntimeConfig()?.workosClientId);
+}
+
+/**
+ * Host AuthKit API calls are sent to. Must share a registrable domain with the
+ * app origin, or the WorkOS session cookie is third-party and the refresh call
+ * arrives with no credential.
+ */
+export function getRuntimeWorkosApiHostname(): string | undefined {
+  return getNonEmptyString(getRuntimeConfig()?.workosApiHostname);
 }

--- a/mcpjam-inspector/client/src/lib/workos-authkit-config.ts
+++ b/mcpjam-inspector/client/src/lib/workos-authkit-config.ts
@@ -1,7 +1,6 @@
 type WorkosAuthkitEnv = {
   DEV?: boolean;
   VITE_WORKOS_API_HOSTNAME?: string;
-  VITE_WORKOS_DEV_MODE?: string;
   VITE_WORKOS_DISABLE_LOCAL_PROXY?: string;
 };
 
@@ -16,15 +15,24 @@ export type WorkosClientOptions = {
 const WORKOS_REFRESH_TOKEN_KEY = "workos:refresh-token";
 const LOCAL_WORKOS_HOSTNAMES = new Set(["localhost", "127.0.0.1"]);
 
-export function resolveWorkosDevMode(env: WorkosAuthkitEnv): boolean {
-  const explicit = env.VITE_WORKOS_DEV_MODE;
-  if (explicit === "true") return true;
-  if (explicit === "false") return false;
-
-  // Keep local/dev on the same AuthKit cookie-mode path as hosted by default.
-  // `devMode=true` stores the WorkOS refresh token in browser localStorage.
-  return false;
-}
+/**
+ * AuthKit runs in cookie mode on every surface, so `devMode` is always false.
+ *
+ * This is passed explicitly rather than omitted: `@workos-inc/authkit-js`
+ * defaults `devMode` to `location.hostname === "localhost"`, which would put
+ * local dev on a different session-storage path (refresh token in
+ * `localStorage`) than every deployed environment (refresh token in memory,
+ * restored from the AuthKit session cookie). Local dev reaches cookie mode
+ * through the first-party AuthKit proxy this server mounts at
+ * `/user_management` — see `resolveWorkosClientOptions` below and
+ * `server/routes/workos-authkit.ts`.
+ *
+ * There was a `VITE_WORKOS_DEV_MODE` escape hatch here. It was set in no
+ * environment, was absent from the Dockerfile `ARG` allowlist so no deployed
+ * build could set it, and existed only to opt out of the mode the proxy was
+ * added to make universal.
+ */
+export const WORKOS_DEV_MODE = false;
 
 export function resolveWorkosClientOptions(
   env: WorkosAuthkitEnv,

--- a/mcpjam-inspector/client/src/main.tsx
+++ b/mcpjam-inspector/client/src/main.tsx
@@ -20,7 +20,11 @@ import {
   resolveWorkosRedirectUri,
 } from "./lib/electron-hosted-auth";
 import { useUnifiedConvexAuth } from "./lib/unified-convex-auth";
-import { getRuntimeConvexUrl } from "./lib/runtime-config";
+import {
+  getRuntimeConvexUrl,
+  getRuntimeWorkosApiHostname,
+  getRuntimeWorkosClientId,
+} from "./lib/runtime-config";
 import {
   isDebugOAuthCallbackPath,
   normalizeInitialLegacyHashBookmark,
@@ -37,7 +41,7 @@ import { DbUserReadyProvider } from "./contexts/db-user-ready-context";
 import {
   clearLegacyWorkosRefreshTokenStorage,
   resolveWorkosClientOptions,
-  resolveWorkosDevMode,
+  WORKOS_DEV_MODE,
 } from "./lib/workos-authkit-config";
 
 // Initialize Sentry before React mounts
@@ -171,8 +175,16 @@ if (isInIframe) {
   const buildConvexUrl = import.meta.env.VITE_CONVEX_URL as string | undefined;
   const runtimeConvexUrl = getRuntimeConvexUrl();
   const convexUrl = runtimeConvexUrl || buildConvexUrl || "";
-  const workosClientId = import.meta.env.VITE_WORKOS_CLIENT_ID as string;
-  const workosDevMode = resolveWorkosDevMode(import.meta.env);
+  // Runtime config wins over the build-time value for the same reason the
+  // Convex URL above does: the deployed bundle is shared across environments
+  // and only the serving process knows which WorkOS environment it belongs to.
+  const buildWorkosClientId = import.meta.env.VITE_WORKOS_CLIENT_ID as
+    | string
+    | undefined;
+  // Coerced to "" rather than typed as `string`: the previous `as string` cast
+  // claimed a value that may not exist, and AuthKit already fails loudly on a
+  // falsy client id. The warning below is the one that should fire first.
+  const workosClientId = getRuntimeWorkosClientId() ?? buildWorkosClientId ?? "";
 
   // Compute redirect URI safely across environments
   const workosRedirectUri = (() => {
@@ -230,17 +242,21 @@ if (isInIframe) {
   }
   if (!workosClientId) {
     console.warn(
-      "[main] VITE_WORKOS_CLIENT_ID is not set; authentication will not work."
+      "[main] WorkOS client id is not set (runtime config or VITE_WORKOS_CLIENT_ID); authentication will not work."
     );
   }
 
-  const workosClientOptions = resolveWorkosClientOptions(
-    import.meta.env,
-    typeof window === "undefined" ? undefined : window.location
-  );
-  if (!workosDevMode) {
-    clearLegacyWorkosRefreshTokenStorage();
-  }
+  // A runtime hostname takes the same precedence an explicit
+  // `VITE_WORKOS_API_HOSTNAME` has inside `resolveWorkosClientOptions`: it
+  // overrides the local-proxy derivation rather than merging with it.
+  const runtimeWorkosApiHostname = getRuntimeWorkosApiHostname();
+  const workosClientOptions = runtimeWorkosApiHostname
+    ? { apiHostname: runtimeWorkosApiHostname }
+    : resolveWorkosClientOptions(
+        import.meta.env,
+        typeof window === "undefined" ? undefined : window.location
+      );
+  clearLegacyWorkosRefreshTokenStorage();
 
   const convex = new ConvexReactClient(convexUrl);
   normalizeInitialLegacyHashBookmark();
@@ -249,11 +265,9 @@ if (isInIframe) {
     <AuthKitProvider
       clientId={workosClientId}
       redirectUri={workosRedirectUri}
-      devMode={workosDevMode}
+      devMode={WORKOS_DEV_MODE}
       onRefresh={() => {
-        if (!workosDevMode) {
-          clearLegacyWorkosRefreshTokenStorage();
-        }
+        clearLegacyWorkosRefreshTokenStorage();
       }}
       {...workosClientOptions}
     >

--- a/mcpjam-inspector/client/src/vite-env.d.ts
+++ b/mcpjam-inspector/client/src/vite-env.d.ts
@@ -8,7 +8,6 @@ interface ImportMetaEnv {
   readonly VITE_MCPJAM_NONPROD_LOCKDOWN?: string;
   readonly VITE_MCPJAM_EMPLOYEE_EMAIL_DOMAINS?: string;
   readonly VITE_MCPJAM_SANDBOX_ORIGIN?: string;
-  readonly VITE_WORKOS_DEV_MODE?: string;
   readonly VITE_ENVIRONMENT?: string;
   // more env variables...
 }

--- a/mcpjam-inspector/server/__tests__/env.test.ts
+++ b/mcpjam-inspector/server/__tests__/env.test.ts
@@ -7,7 +7,7 @@ import {
 } from "fs";
 import { tmpdir } from "os";
 import { join } from "path";
-import { afterEach, describe, expect, it } from "vitest";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import {
   getInspectorClientRuntimeConfig,
   getInspectorClientRuntimeConfigScript,
@@ -18,7 +18,38 @@ import {
 const ORIGINAL_CONVEX_HTTP_URL = process.env.CONVEX_HTTP_URL;
 const ORIGINAL_PRIORITY_TEST = process.env.MCPJAM_ENV_PRIORITY_TEST;
 
+// Every input `getInspectorClientRuntimeConfig` reads, cleared per-test. The
+// assertions below pin an exact serialization, so a developer shell (or a
+// repo `.env`) that exports VITE_CONVEX_URL or WORKOS_CLIENT_ID would
+// otherwise fail the suite on one machine and pass on another.
+const RUNTIME_CONFIG_ENV_KEYS = [
+  "CONVEX_HTTP_URL",
+  "VITE_CONVEX_URL",
+  "WORKOS_CLIENT_ID",
+  "VITE_WORKOS_CLIENT_ID",
+  "WORKOS_API_HOSTNAME",
+  "VITE_WORKOS_API_HOSTNAME",
+] as const;
+const ORIGINAL_RUNTIME_CONFIG_ENV = Object.fromEntries(
+  RUNTIME_CONFIG_ENV_KEYS.map((key) => [key, process.env[key]]),
+);
+
+beforeEach(() => {
+  for (const key of RUNTIME_CONFIG_ENV_KEYS) {
+    delete process.env[key];
+  }
+});
+
 afterEach(() => {
+  for (const key of RUNTIME_CONFIG_ENV_KEYS) {
+    const original = ORIGINAL_RUNTIME_CONFIG_ENV[key];
+    if (original === undefined) {
+      delete process.env[key];
+    } else {
+      process.env[key] = original;
+    }
+  }
+
   if (ORIGINAL_CONVEX_HTTP_URL === undefined) {
     delete process.env.CONVEX_HTTP_URL;
   } else {
@@ -100,5 +131,39 @@ describe("env loader", () => {
     expect(getInspectorClientRuntimeConfigScript()).toBe(
       '<script>window.__MCP_RUNTIME_CONFIG__={"convexUrl":"https://demo-deployment.convex.cloud","convexSiteUrl":"https://demo-deployment.convex.site"};</script>',
     );
+  });
+
+  it("serves WorkOS client config from the environment, unprefixed name winning", () => {
+    process.env.WORKOS_CLIENT_ID = "client_runtime";
+    process.env.VITE_WORKOS_CLIENT_ID = "client_build";
+    process.env.WORKOS_API_HOSTNAME = "auth.example.com";
+
+    const config = getInspectorClientRuntimeConfig();
+    expect(config.workosClientId).toBe("client_runtime");
+    expect(config.workosApiHostname).toBe("auth.example.com");
+  });
+
+  it("falls back to the VITE_-prefixed WorkOS names during migration", () => {
+    process.env.VITE_WORKOS_CLIENT_ID = "client_build";
+    process.env.VITE_WORKOS_API_HOSTNAME = "auth.build.example.com";
+
+    const config = getInspectorClientRuntimeConfig();
+    expect(config.workosClientId).toBe("client_build");
+    expect(config.workosApiHostname).toBe("auth.build.example.com");
+  });
+
+  // The guard used to key off the two Convex fields only, so an environment
+  // that set WorkOS config but no Convex URL would inject no script at all and
+  // the client would silently fall back to its build-time values.
+  it("injects the script when only WorkOS config is present", () => {
+    process.env.WORKOS_CLIENT_ID = "client_runtime";
+
+    expect(getInspectorClientRuntimeConfigScript()).toBe(
+      '<script>window.__MCP_RUNTIME_CONFIG__={"workosClientId":"client_runtime"};</script>',
+    );
+  });
+
+  it("emits no script when nothing is configured", () => {
+    expect(getInspectorClientRuntimeConfigScript()).toBeNull();
   });
 });

--- a/mcpjam-inspector/server/env.ts
+++ b/mcpjam-inspector/server/env.ts
@@ -15,6 +15,8 @@ export interface LoadedInspectorEnv {
 export interface InspectorClientRuntimeConfig {
   convexUrl?: string;
   convexSiteUrl?: string;
+  workosClientId?: string;
+  workosApiHostname?: string;
 }
 
 function getInspectorEnvMode(): InspectorEnvMode {
@@ -116,6 +118,11 @@ function replaceConvexHostnameSuffix(
   }
 }
 
+function getNonEmptyEnv(name: string): string | undefined {
+  const value = process.env[name];
+  return typeof value === "string" && value.trim() ? value.trim() : undefined;
+}
+
 export function getInspectorClientRuntimeConfig(): InspectorClientRuntimeConfig {
   const convexSiteUrl =
     normalizeUrlOrigin(process.env.CONVEX_HTTP_URL) ??
@@ -132,15 +139,39 @@ export function getInspectorClientRuntimeConfig(): InspectorClientRuntimeConfig 
       ".convex.cloud",
     ) ?? normalizeUrlOrigin(process.env.VITE_CONVEX_URL);
 
+  // WorkOS client config is served at runtime rather than inlined by Vite.
+  // A build-time value has to be listed in THREE places that are maintained by
+  // hand — the Railway service variables, the `ARG` allowlist in
+  // `mcpjam-inspector/Dockerfile`, and the environment it is set for — and a
+  // value present in one but missing from another produces a client that is
+  // silently misconfigured rather than one that fails to build. Staging shipped
+  // without `VITE_WORKOS_API_HOSTNAME` for months: its AuthKit refresh went
+  // cross-site to `api.workos.com`, the session cookie was never sent, and
+  // every page load ended in a 400 that wiped the session. Read here, the same
+  // variable takes effect on restart, in every environment, with no rebuild.
+  //
+  // The unprefixed names are canonical; the `VITE_`-prefixed ones are accepted
+  // so an environment already carrying the build-time variable keeps working
+  // through the migration.
+  const workosClientId =
+    getNonEmptyEnv("WORKOS_CLIENT_ID") ??
+    getNonEmptyEnv("VITE_WORKOS_CLIENT_ID");
+
+  const workosApiHostname =
+    getNonEmptyEnv("WORKOS_API_HOSTNAME") ??
+    getNonEmptyEnv("VITE_WORKOS_API_HOSTNAME");
+
   return {
     convexUrl,
     convexSiteUrl,
+    workosClientId,
+    workosApiHostname,
   };
 }
 
 export function getInspectorClientRuntimeConfigScript(): string | null {
   const runtimeConfig = getInspectorClientRuntimeConfig();
-  if (!runtimeConfig.convexUrl && !runtimeConfig.convexSiteUrl) {
+  if (!Object.values(runtimeConfig).some((value) => value !== undefined)) {
     return null;
   }
 


### PR DESCRIPTION
## What

Moves the WorkOS client config off build-time Vite inlining and onto the runtime config channel the Convex URLs already use. Deletes the dead `VITE_WORKOS_DEV_MODE` knob.

## Why

`VITE_WORKOS_CLIENT_ID` and `VITE_WORKOS_API_HOSTNAME` are inlined at build time, so each value has to be listed in two hand-maintained places nobody diffs: the Railway service variables, and the `ARG` allowlist in `mcpjam-inspector/Dockerfile`. Miss either and the client does not fail to build — it ships silently misconfigured.

That is what happened to staging. It carried no `VITE_WORKOS_API_HOSTNAME`, so `resolveWorkosClientOptions` fell through to the default `api.workos.com`. From `staging.mcpjam.com` that host is cross-site, so the AuthKit session cookie was never sent:

```
POST https://api.workos.com/user_management/authenticate  ->  400
{"client_id": "client_01KTN...", "grant_type": "refresh_token"}   // no refresh_token
```

`#doRefresh`'s catch calls `removeSessionData()`, and because AuthKit keeps the refresh token in `memoryStorage` outside dev mode, nothing survives a page load. **Every navigation logged the user out.** Production is unaffected only because it sets the variable to `auth.mcpjam.com`, which shares a registrable domain with `app.mcpjam.com`.

Everything else traced back to that single 400:

- the hosted shell showed its `logged-out` gate (staging runs `NON_PROD_LOCKDOWN`, so there is no guest fallback to absorb it)
- `AppReadyProvider` never left `resolving-auth`
- MCP server OAuth *appeared* to fail — tokens persist through `/api/web/oauth/import-tokens`, which forwards the caller's bearer, so with no session the credential could not be written and the next connect replayed the consent screen. The toast read `OAuth succeeded but connection test failed: Finishing setup.` because the readiness reason string is spliced into the error.

## How

Both values ride `window.__MCP_RUNTIME_CONFIG__` (`getInspectorClientRuntimeConfig` in `server/env.ts`, read by `client/src/lib/runtime-config.ts`). The serving process knows which WorkOS environment it belongs to; the bundle no longer has to.

**Backward compatible — no deploy-config change required to merge.** The server reads canonical unprefixed `WORKOS_CLIENT_ID` / `WORKOS_API_HOSTNAME` first and falls back to the `VITE_`-prefixed names Railway already injects into the running container. The client still falls back to its build-time value when no runtime config is present, so npx and Electron builds are unchanged. The Dockerfile `ARG`s are left in place deliberately; removing them is a separate cleanup once every environment is confirmed on the runtime path.

Two smaller fixes ride along:

- **`getInspectorClientRuntimeConfigScript` keyed its guard off the two Convex fields only.** An environment with WorkOS config but no Convex URL would emit no script and silently fall back to build-time values. It now checks every field.
- **`resolveWorkosDevMode` deleted.** It read `VITE_WORKOS_DEV_MODE`, set in no environment and absent from the Dockerfile `ARG` allowlist — a config knob that could not be configured. It arrived in the same commit as the first-party AuthKit proxy at `/user_management`, which is what actually gives local dev cookie mode, and existed only to opt out of the mode that proxy made universal. Replaced by an exported `WORKOS_DEV_MODE = false`, still passed explicitly because `@workos-inc/authkit-js` defaults `devMode` to `location.hostname === "localhost"` — omitting the prop would move local dev onto a different session-storage path than every deployed environment.

## Testing

- `server/__tests__/env.test.ts` — new coverage for unprefixed-wins precedence, `VITE_`-prefixed migration fallback, script injection with WorkOS-only config, and null when nothing is set. Env isolation widened to every runtime-config input so the exact-serialization assertions do not depend on the developer's shell.
- `client/src/lib/__tests__/workos-authkit-config.test.ts` — devMode tests replaced with one pinning `WORKOS_DEV_MODE === false`, commented as non-tautological since authkit-js defaults it true on localhost.
- `npm run typecheck:client` clean. This surfaced a pre-existing `as string` cast on a possibly-missing env var, now coerced honestly at the boundary.

## Not covered

Staging will still need `NON_PROD_LOCKDOWN` reconsidered separately — it removes the guest fallback that makes prod resilient to exactly this failure, which is why a shared bug was staging-visible only. And the `Finishing setup.` readiness string leaking into OAuth error toasts (`use-server-state.ts:2826`) is untouched here; it will keep misdirecting whoever hits the next auth problem.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Changes how WorkOS AuthKit client id and API hostname are resolved for session refresh — misconfiguration here directly breaks auth cookies and can wipe sessions. Backward-compatible fallbacks reduce deploy risk, but this remains auth-critical path.
> 
> **Overview**
> **Fixes staging logout loops** by serving WorkOS AuthKit `clientId` and `apiHostname` through the existing `window.__MCP_RUNTIME_CONFIG__` channel instead of baking them into the Vite bundle.
> 
> Build-time `VITE_WORKOS_*` values had to be kept in sync across Railway vars and Dockerfile `ARG`s; missing `VITE_WORKOS_API_HOSTNAME` on staging sent refresh calls cross-site to `api.workos.com`, dropped the session cookie, and wiped auth on every page load. The server now reads canonical `WORKOS_*` (falling back to `VITE_WORKOS_*`), and the client prefers runtime values with build-time fallback for npx/Electron.
> 
> Also deletes the unused `VITE_WORKOS_DEV_MODE` escape hatch in favor of an explicit `WORKOS_DEV_MODE = false` constant, and fixes runtime-config script injection so WorkOS-only environments still emit the config script.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c4e5c73868daeef024729863b949f7bb3dc4eea3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Serves WorkOS AuthKit client config at runtime and drops the dead devMode knob to prevent silent misconfig and fix the staging logout loop. Also tightens OAuth hygiene with centralized redaction, fail-closed metadata checks, and removal of legacy flows. Backward compatible: no deploy-config changes, and `redactSensitiveValue` remains an alias to `redactForTelemetry`.

- **Bug Fixes**
  - Serve WorkOS `client_id` and API hostname via `window.__MCP_RUNTIME_CONFIG__` (server reads `WORKOS_*` then `VITE_WORKOS_*`; client still falls back to build-time). Runtime `workosApiHostname` overrides the local-proxy derivation, and the inject guard now considers all fields so WorkOS-only config injects correctly.
  - Remove `VITE_WORKOS_DEV_MODE`; export `WORKOS_DEV_MODE = false` and always clear legacy refresh-token storage. Keeps cookie mode everywhere and resolves the staging logout loop.
  - One OAuth trace redaction owner in `@mcpjam/sdk`: `state` is treated as a secret, client-built trace errors are sanitized, URL userinfo and vendor‑prefixed/colon keys are handled, and an executor guard prevents redaction sentinels from reaching credentials.
  - Fail closed when required metadata is unusable (PKCE S256 not advertised; RFC 9728 `authorization_servers` empty/missing). The debugger can opt into `requiredMetadataEnforcement: "observe"`.

- **Refactors**
  - Retire the Auth tab and legacy callback token exchange, remove the unused client OAuth state machine, and add a typed `buildOAuthRequest` so all entry points build the same wire request. Adds an analytics event for sessionless callback recovery.
  - Consolidate sequence-diagram builders, add a differential golden harness and a real executor↔machine integration test, and pin a “no secrets in sanitized traces” sweep.
  - Rename telemetry redaction to `redactForTelemetry` in `@mcpjam/sdk`/CLI and keep `redactSensitiveValue` as a deprecated alias. No deploy-config changes needed; Electron and `npx` builds are unchanged.

<sup>Written for commit c4e5c73868daeef024729863b949f7bb3dc4eea3. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/MCPJam/inspector/pull/3894?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

