### PR TITLE
PUR-14: Playground control cleanup

### DIFF
--- a/mcpjam-inspector/client/src/components/chat-v2/chat-input/dialogs/__tests__/confirm-chat-reset-dialog.test.tsx
+++ b/mcpjam-inspector/client/src/components/chat-v2/chat-input/dialogs/__tests__/confirm-chat-reset-dialog.test.tsx
@@ -57,10 +57,10 @@ describe("ConfirmChatResetDialog", () => {
     );
 
     await user.click(screen.getByLabelText("Don't show this again"));
-    await user.click(screen.getByRole("button", { name: "Reset chat" }));
+    await user.click(screen.getByRole("button", { name: "Clear chat" }));
 
     expect(localStorage.getItem(SKIP_CHAT_RESET_CONFIRMATION_KEY)).toBe("true");
     expect(onConfirm).toHaveBeenCalledTimes(1);
-    expect(screen.queryByText("Reset chat?")).not.toBeInTheDocument();
+    expect(screen.queryByText("Clear chat?")).not.toBeInTheDocument();
   });
 });

--- a/mcpjam-inspector/client/src/components/chat-v2/chat-input/dialogs/confirm-chat-reset-dialog.tsx
+++ b/mcpjam-inspector/client/src/components/chat-v2/chat-input/dialogs/confirm-chat-reset-dialog.tsx
@@ -37,7 +37,7 @@ export function ConfirmChatResetDialog({
   open,
   onConfirm,
   onCancel,
-  message = "Resetting the chat will clear your current conversation thread. This action cannot be undone.",
+  message = "Clearing the chat will remove your current conversation thread. This action cannot be undone.",
 }: ConfirmChatResetDialogProps) {
   const [dontShowAgain, setDontShowAgain] = useState(false);
   const [shouldSkip, setShouldSkip] = useState(false);
@@ -83,7 +83,7 @@ export function ConfirmChatResetDialog({
     <AlertDialog open={open} onOpenChange={(open) => !open && onCancel()}>
       <AlertDialogContent>
         <AlertDialogHeader>
-          <AlertDialogTitle>Reset chat?</AlertDialogTitle>
+          <AlertDialogTitle>Clear chat?</AlertDialogTitle>
           <AlertDialogDescription>{message}</AlertDialogDescription>
         </AlertDialogHeader>
         <AlertDialogFooter className="flex-row items-center sm:justify-between">
@@ -103,7 +103,7 @@ export function ConfirmChatResetDialog({
           <div className="flex gap-2">
             <AlertDialogCancel onClick={onCancel}>Cancel</AlertDialogCancel>
             <AlertDialogAction onClick={handleConfirm}>
-              Reset chat
+              Clear chat
             </AlertDialogAction>
           </div>
         </AlertDialogFooter>

--- a/mcpjam-inspector/client/src/components/evals/__tests__/trace-view-mode-tabs.test.tsx
+++ b/mcpjam-inspector/client/src/components/evals/__tests__/trace-view-mode-tabs.test.tsx
@@ -34,6 +34,42 @@ describe("TraceViewModeTabs", () => {
     );
   });
 
+  it("leads with Chat in fullWidth order, then Trace then Raw", () => {
+    render(
+      <TraceViewModeTabs
+        mode="chat"
+        onModeChange={vi.fn()}
+        showToolsTab={false}
+        layout="fullWidth"
+      />,
+    );
+
+    const order = screen
+      .getAllByRole("button")
+      .map((btn) => btn.textContent?.trim());
+    expect(order).toEqual(["Chat", "Trace", "Raw"]);
+  });
+
+  it("keeps Chat leading in fullWidth even when the Tool Calls tab is shown", () => {
+    // Guards the PUR-14 intent: `chatTab` must sit ahead of the optional
+    // `toolsTab`/`browserTab` in the array, not merely appear first because
+    // consumers happen to pass showToolsTab={false} today.
+    render(
+      <TraceViewModeTabs
+        mode="chat"
+        onModeChange={vi.fn()}
+        showToolsTab
+        showBrowserTab
+        layout="fullWidth"
+      />,
+    );
+
+    const order = screen
+      .getAllByRole("button")
+      .map((btn) => btn.textContent?.trim());
+    expect(order).toEqual(["Chat", "Tool Calls", "Trace", "Replay", "Raw"]);
+  });
+
   it("hides the Replay tab by default", () => {
     render(
       <TraceViewModeTabs

--- a/mcpjam-inspector/client/src/components/evals/trace-view-mode-tabs.tsx
+++ b/mcpjam-inspector/client/src/components/evals/trace-view-mode-tabs.tsx
@@ -179,9 +179,11 @@ export function TraceViewModeTabs({
   // the step-aligned replay default for authored-step cases. Chat / playground /
   // compare surfaces (fullWidth) never show Steps and lead with Chat (the
   // default-selected view), then Trace, then Raw (PUR-14) — all three are views
-  // onto the same backend object, so Chat leads and Trace sits second.
+  // onto the same backend object. `chatTab` sits first in the array so Chat
+  // leads even if a fullWidth consumer ever enables the Tool Calls tab; the
+  // remaining tabs mirror the default layout's order minus Steps.
   const tabs = fullWidth
-    ? [toolsTab, chatTab, timelineTab, browserTab, rawTab]
+    ? [chatTab, toolsTab, timelineTab, browserTab, rawTab]
     : [stepsTab, chatTab, toolsTab, timelineTab, browserTab, rawTab];
 
   return (

--- a/mcpjam-inspector/client/src/components/evals/trace-view-mode-tabs.tsx
+++ b/mcpjam-inspector/client/src/components/evals/trace-view-mode-tabs.tsx
@@ -177,9 +177,11 @@ export function TraceViewModeTabs({
 
   // Evals (default layout) lead with Steps (when present) then Chat — Steps is
   // the step-aligned replay default for authored-step cases. Chat / playground /
-  // compare surfaces (fullWidth) never show Steps and keep Trace-first ordering.
+  // compare surfaces (fullWidth) never show Steps and lead with Chat (the
+  // default-selected view), then Trace, then Raw (PUR-14) — all three are views
+  // onto the same backend object, so Chat leads and Trace sits second.
   const tabs = fullWidth
-    ? [toolsTab, timelineTab, chatTab, browserTab, rawTab]
+    ? [toolsTab, chatTab, timelineTab, browserTab, rawTab]
     : [stepsTab, chatTab, toolsTab, timelineTab, browserTab, rawTab];
 
   return (

--- a/mcpjam-inspector/client/src/components/ui-playground/PlaygroundMain.tsx
+++ b/mcpjam-inspector/client/src/components/ui-playground/PlaygroundMain.tsx
@@ -21,7 +21,7 @@ import {
   useRef,
 } from "react";
 import type { CSSProperties, ReactNode } from "react";
-import { Braces, Loader2, Trash2 } from "lucide-react";
+import { Braces, Loader2, RotateCcw } from "lucide-react";
 import {
   ElicitationRequestDialog,
   UrlElicitationRequiredDialog,
@@ -4630,11 +4630,12 @@ export function PlaygroundMain({
                   <TooltipTrigger asChild>
                     <Button
                       variant="ghost"
-                      size="icon"
-                      className="h-7 w-7 text-muted-foreground hover:text-foreground"
+                      size="sm"
+                      className="h-7 gap-1.5 px-2 text-muted-foreground hover:text-foreground"
                       onClick={() => setShowClearConfirm(true)}
                     >
-                      <Trash2 className="h-3.5 w-3.5" />
+                      <RotateCcw className="h-3.5 w-3.5" />
+                      Clear chat
                     </Button>
                   </TooltipTrigger>
                   <TooltipContent
@@ -4642,8 +4643,9 @@ export function PlaygroundMain({
                     sideOffset={6}
                     collisionPadding={12}
                   >
-                    <p className="font-medium">Clear chat</p>
+                    <p className="font-medium">Restart session</p>
                     <p className="text-xs font-light text-muted-foreground">
+                      Clears this conversation and starts fresh ·{" "}
                       {navigator.platform.includes("Mac")
                         ? "⌘⇧K"
                         : "Ctrl+Shift+K"}

--- a/mcpjam-inspector/client/src/components/ui-playground/PlaygroundMain.tsx
+++ b/mcpjam-inspector/client/src/components/ui-playground/PlaygroundMain.tsx
@@ -4643,7 +4643,7 @@ export function PlaygroundMain({
                     sideOffset={6}
                     collisionPadding={12}
                   >
-                    <p className="font-medium">Restart session</p>
+                    <p className="font-medium">Clear chat</p>
                     <p className="text-xs font-light text-muted-foreground">
                       Clears this conversation and starts fresh ·{" "}
                       {navigator.platform.includes("Mac")

--- a/mcpjam-inspector/client/src/components/ui-playground/__tests__/PlaygroundMain.test.tsx
+++ b/mcpjam-inspector/client/src/components/ui-playground/__tests__/PlaygroundMain.test.tsx
@@ -2475,12 +2475,9 @@ describe("PlaygroundMain", () => {
 
       render(<PlaygroundMain {...defaultProps} />);
 
-      // Find trash icon button
-      const buttons = screen.getAllByRole("button");
-      const clearButton = buttons.find(
-        (btn) => btn.querySelector(".lucide-trash2") !== null
-      );
-      expect(clearButton).toBeDefined();
+      // Find the "Clear chat" restart-session button
+      const clearButton = screen.queryByRole("button", { name: "Clear chat" });
+      expect(clearButton).not.toBeNull();
     });
 
     it("does not show clear button when thread is empty", () => {
@@ -2488,12 +2485,9 @@ describe("PlaygroundMain", () => {
 
       render(<PlaygroundMain {...defaultProps} />);
 
-      // Should not have trash button
-      const buttons = screen.getAllByRole("button");
-      const clearButton = buttons.find(
-        (btn) => btn.querySelector(".lucide-trash2") !== null
-      );
-      expect(clearButton).toBeUndefined();
+      // Should not have the "Clear chat" button
+      const clearButton = screen.queryByRole("button", { name: "Clear chat" });
+      expect(clearButton).toBeNull();
     });
 
     /**
@@ -2549,10 +2543,8 @@ describe("PlaygroundMain", () => {
         ).toBe(savedSession._id);
       });
 
-      const clearButton = screen
-        .getAllByRole("button")
-        .find((btn) => btn.querySelector(".lucide-trash2") !== null);
-      fireEvent.click(clearButton!);
+      const clearButton = screen.getByRole("button", { name: "Clear chat" });
+      fireEvent.click(clearButton);
       fireEvent.click(
         within(screen.getByTestId("confirm-dialog")).getByRole("button", {
           name: "Confirm",
@@ -2668,10 +2660,8 @@ describe("PlaygroundMain", () => {
       // Guard against a vacuous pass: the param has to be there to be dropped.
       expect(window.location.search).toContain(savedSession.chatSessionId);
 
-      const clearButton = screen
-        .getAllByRole("button")
-        .find((btn) => btn.querySelector(".lucide-trash2") !== null);
-      fireEvent.click(clearButton!);
+      const clearButton = screen.getByRole("button", { name: "Clear chat" });
+      fireEvent.click(clearButton);
       fireEvent.click(
         within(screen.getByTestId("confirm-dialog")).getByRole("button", {
           name: "Confirm",


### PR DESCRIPTION
## Summary

Cluster of small Playground affordance fixes (PUR-14), raised by Vignesh and agreed with Marcelo.

- **Lead the Trace / Chat / Raw tabs with Chat.** In the `fullWidth` treatment the tabs now render **Chat → Trace → Raw** (Trace moves to second) instead of Trace-first. Chat was already the default-selected view; this makes the default tab also *lead*. All three are views onto the same backend object.
- **Replace the trash icon with a clearer "Clear chat" affordance.** The trash icon read as "delete this pane"; it actually restarts the session. It's now a labeled **"Clear chat"** button using the `rotate-ccw` icon, with a **"Restart session"** tooltip (keyboard shortcut preserved).

## Changes

- `evals/trace-view-mode-tabs.tsx` — swap Chat ahead of Trace in the `fullWidth` tab order.
- `ui-playground/PlaygroundMain.tsx` — trailing control is now an icon+label button (`RotateCcw` + "Clear chat") with an updated tooltip; icon import swapped from `Trash2`.
- `ui-playground/__tests__/PlaygroundMain.test.tsx` — locate the button by its accessible name ("Clear chat") instead of the old trash icon class.

## Testing

- `vitest run` for `PlaygroundMain`, `PlaygroundMain.multi-host`, `trace-view-mode-tabs`, `PlaygroundCenterHeaderBar` — all pass.
- Client `tsc --noEmit` — clean.

## Note

`TraceViewModeTabs` (fullWidth) is shared by the Playground, the legacy Chat tab, and compare cards, so the Chat-first order applies consistently across all of them — matching the ticket's "in all treatments" wording.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Lead with Chat in full-width tabs across Playground, legacy Chat, and compare cards. Trace-first becomes Chat → Trace → Raw, with Chat remaining first even when Tool Calls/Replay are enabled; replace the trash icon with a labeled “Clear chat” (RotateCcw) and standardize copy so the button, tooltip, and confirm dialog all say “Clear chat”.

- TraceViewModeTabs: `chatTab` now sits first in `fullWidth` (ahead of optional Tool Calls/Replay); tests assert order with and without those tabs.
- Playground header: new “Clear chat” button with accessible name; tooltip retitled “Clear chat” with a short explanation and shortcut; confirm dialog title/message/action updated; tests locate the control by “Clear chat”.

<sup>Written for commit ce7f3c72f735828c6f06bdecc6b8b7227583f8cf. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/MCPJam/inspector/pull/3895?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

