### PR TITLE
fix(evals): keep suite header actions visible with long names

### DIFF
--- a/mcpjam-inspector/client/src/components/evals/__tests__/suite-header.test.tsx
+++ b/mcpjam-inspector/client/src/components/evals/__tests__/suite-header.test.tsx
@@ -451,7 +451,7 @@ describe("SuiteHeader", () => {
 
     const header = screen.getByTestId("suite-overview-header");
     expect(header).toHaveClass("flex");
-    expect(header).toHaveClass("justify-between");
+    expect(header).toHaveClass("flex-wrap");
     expect(header).toHaveClass("min-w-0");
 
     const leftCluster = header.children[0] as HTMLElement;
@@ -463,6 +463,7 @@ describe("SuiteHeader", () => {
     ).toBe(true);
 
     const actions = screen.getByTestId("suite-overview-actions");
+    expect(actions).toHaveClass("ml-auto");
     expect(actions).toHaveClass("shrink-0");
     expect(actions).toHaveClass("flex-nowrap");
 

--- a/mcpjam-inspector/client/src/components/evals/__tests__/suite-header.test.tsx
+++ b/mcpjam-inspector/client/src/components/evals/__tests__/suite-header.test.tsx
@@ -426,7 +426,58 @@ describe("SuiteHeader", () => {
     expect(onRerun).not.toHaveBeenCalled();
   });
 
-  it("keeps overview toolbar controls in one horizontal row", () => {
+  it("keeps overview actions shrink-wrapped on the right with Run all last", () => {
+    renderWithProviders(
+      <SuiteHeader
+        {...baseProps}
+        viewMode="overview"
+        selectedRunDetails={null}
+        runsViewMode="runs"
+        hideRunActions
+        unifiedSuiteDashboard
+        onCreateTestCase={vi.fn()}
+        onGenerateTestCases={vi.fn()}
+        onOpenExportSuite={vi.fn()}
+        canGenerateTestCases
+        testCases={[
+          {
+            _id: "c1",
+            models: [{ provider: "openai", model: "gpt-4" }],
+          } as any,
+        ]}
+        connectedServerNames={new Set(["asana"])}
+      />
+    );
+
+    const header = screen.getByTestId("suite-overview-header");
+    expect(header).toHaveClass("flex");
+    expect(header).toHaveClass("justify-between");
+    expect(header).toHaveClass("min-w-0");
+
+    const leftCluster = header.children[0] as HTMLElement;
+    expect(leftCluster).toHaveClass("min-w-0");
+    expect(
+      Array.from(leftCluster.querySelectorAll<HTMLElement>("*")).some((el) =>
+        el.className.includes("max-w-[20rem]")
+      )
+    ).toBe(true);
+
+    const actions = screen.getByTestId("suite-overview-actions");
+    expect(actions).toHaveClass("shrink-0");
+    expect(actions).toHaveClass("flex-nowrap");
+
+    const setupSdk = screen.getByRole("button", { name: /Setup SDK/i });
+    const generate = screen.getByRole("button", { name: /^Generate$/i });
+    const newCase = screen.getByRole("button", { name: /New case/i });
+    const runAll = screen.getByRole("button", {
+      name: /Run all cases in this suite/i,
+    });
+    expect(setupSdk.compareDocumentPosition(generate) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy();
+    expect(generate.compareDocumentPosition(newCase) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy();
+    expect(newCase.compareDocumentPosition(runAll) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy();
+  });
+
+  it("does not show Compare clients in the suite overview header", () => {
     renderWithProviders(
       <SuiteHeader
         {...baseProps}
@@ -438,12 +489,27 @@ describe("SuiteHeader", () => {
         onCreateTestCase={vi.fn()}
         onGenerateTestCases={vi.fn()}
         canGenerateTestCases
+        suite={{
+          ...baseSuite,
+          hostAttachments: [
+            {
+              namedHostId: "cursor",
+              hostName: "Cursor",
+              resolvedServerNames: ["asana"],
+            },
+            {
+              namedHostId: "claude",
+              hostName: "Claude",
+              resolvedServerNames: ["asana"],
+            },
+          ],
+        }}
       />
     );
 
-    const header = screen.getByTestId("suite-overview-header");
-    expect(header).toHaveClass("flex");
-    expect(header.querySelector(".flex-nowrap")).toBeTruthy();
+    expect(
+      screen.queryByRole("button", { name: /Compare attached clients/i })
+    ).toBeNull();
   });
 
   it("forwards iterationOverride on Run all even without a match-options override", async () => {

--- a/mcpjam-inspector/client/src/components/evals/suite-environment-composer-bar.tsx
+++ b/mcpjam-inspector/client/src/components/evals/suite-environment-composer-bar.tsx
@@ -33,7 +33,6 @@ import {
   type EnvironmentComposerState,
 } from "@/components/environment-composer/environment-stack";
 import { useComposerResolver } from "@/components/environment-composer/use-composer-resolver";
-import { CompareClientsButton } from "@/components/evals/compare-clients-button";
 import { ServerGroupPicker } from "@/components/hosts/ServerGroupPicker";
 import { MAX_SUITE_ENVIRONMENTS } from "@/components/project-environments/environment-picker";
 import { useComputersEnabled } from "@/hooks/useComputersEnabled";
@@ -318,7 +317,6 @@ function EnvironmentModeBar({
           }
           testIdPrefix="suite-env"
         />
-        <CompareClientsButton hostIds={state.stack.hostIds} />
       </div>
       {unresolvedCount > 0 ? (
         <p
@@ -501,7 +499,6 @@ function LegacyModeBar({
             );
           })
         )}
-        <CompareClientsButton hostIds={hostIds} />
       </div>
 
       {computersEnabled && editable && suite.projectId ? (

--- a/mcpjam-inspector/client/src/components/evals/suite-header.tsx
+++ b/mcpjam-inspector/client/src/components/evals/suite-header.tsx
@@ -924,7 +924,7 @@ export function SuiteHeader(props: SuiteHeaderProps) {
   return (
     <div
       data-testid="suite-overview-header"
-      className="mb-4 flex min-w-0 items-center justify-between gap-x-3"
+      className="mb-4 flex min-w-0 flex-wrap items-center gap-x-3 gap-y-2"
     >
       <div className="flex min-w-0 items-center gap-2">
         <div className="min-w-0 max-w-[20rem] shrink overflow-hidden sm:max-w-md">
@@ -973,7 +973,7 @@ export function SuiteHeader(props: SuiteHeaderProps) {
       {overviewHasRightActions ? (
         <div
           data-testid="suite-overview-actions"
-          className="flex shrink-0 flex-nowrap items-center gap-2"
+          className="ml-auto flex shrink-0 flex-nowrap items-center gap-2"
         >
           {overviewSetupSdkButton}
           {overviewLegacyRunActions}

--- a/mcpjam-inspector/client/src/components/evals/suite-header.tsx
+++ b/mcpjam-inspector/client/src/components/evals/suite-header.tsx
@@ -675,9 +675,6 @@ export function SuiteHeader(props: SuiteHeaderProps) {
     overviewRunAllCta != null ||
     (showTestCaseCtas && Boolean(onGenerateTestCases)) ||
     (showTestCaseCtas && Boolean(onCreateTestCase));
-  const overviewHasExportOrRun =
-    Boolean(onOpenExportSuite) ||
-    (!hideRunActions && (replayableLatestRun || !readOnlyConfig));
 
   const overviewSuiteNavButtons =
     overviewHasSuiteNav ? (
@@ -742,121 +739,119 @@ export function SuiteHeader(props: SuiteHeaderProps) {
       </Tooltip>
     ) : null;
 
-  const overviewCaseToolsCluster = overviewHasCaseTools ? (
-    <div className="flex shrink-0 flex-nowrap items-center gap-2 border-l border-border/40 pl-3">
-      {overviewRunAllCta}
-      {showTestCaseCtas && onGenerateTestCases ? (
-        <div className="inline-flex items-center">
-          <Tooltip>
-            <TooltipTrigger asChild>
-              <span className="inline-flex">
-                <Button
-                  type="button"
-                  variant="outline"
-                  size="sm"
-                  className="h-8 gap-1.5 rounded-r-none"
-                  onClick={onGenerateTestCases}
-                  disabled={!canGenerateTestCases || isGeneratingTestCases}
-                  aria-busy={isGeneratingTestCases}
-                >
-                  {isGeneratingTestCases ? (
-                    <Loader2
-                      className="h-3.5 w-3.5 shrink-0 animate-spin"
-                      aria-hidden
-                    />
-                  ) : (
-                    <Sparkles className="h-3.5 w-3.5 shrink-0" aria-hidden />
-                  )}
-                  Generate
-                </Button>
-              </span>
-            </TooltipTrigger>
-            <TooltipContent
-              variant="muted"
-              side="bottom"
-              align="start"
-              sideOffset={8}
-              className="max-w-[min(17rem,calc(100vw-1.5rem))] px-3 py-2 text-left font-normal leading-relaxed"
-            >
-              {isGeneratingTestCases
-                ? "Generating test cases…"
-                : !canGenerateTestCases
-                  ? (generateTestCasesDisabledReason ??
-                    "Configure suite servers before generating cases.")
-                  : "Generate suggested cases from your server's tools. Use the arrow to set how many and what kind."}
-            </TooltipContent>
-          </Tooltip>
-          <GenerateCasesConfigPopover
-            suiteId={suite._id}
-            onGenerate={onGenerateTestCases}
-            disabled={!canGenerateTestCases}
-            isGenerating={isGeneratingTestCases}
-            disabledReason={generateTestCasesDisabledReason}
-          />
-        </div>
-      ) : null}
-      {showTestCaseCtas && onCreateTestCase ? (
-        <Button
-          type="button"
-          size="sm"
-          variant="outline"
-          className="h-8 gap-1.5"
-          onClick={onCreateTestCase}
-        >
-          <Plus className="h-3.5 w-3.5 shrink-0" aria-hidden />
-          New case
-        </Button>
-      ) : null}
-    </div>
-  ) : null;
-
-  const overviewExportRunCluster = overviewHasExportOrRun ? (
-    <div className="flex shrink-0 flex-nowrap items-center gap-2">
-      {onOpenExportSuite ? (
-        <Button
-          size="sm"
-          variant="outline"
-          className="h-8 gap-1.5"
-          onClick={onOpenExportSuite}
-        >
-          <Code2 className="h-3.5 w-3.5 shrink-0" aria-hidden />
-          Setup SDK
-        </Button>
-      ) : null}
-
-      {!hideRunActions && !readOnlyConfig && hasServersConfigured ? (
+  const overviewGenerateButton =
+    showTestCaseCtas && onGenerateTestCases ? (
+      <div className="inline-flex items-center">
         <Tooltip>
           <TooltipTrigger asChild>
             <span className="inline-flex">
               <Button
-                variant="ghost"
+                type="button"
+                variant="outline"
                 size="sm"
-                className="h-8 gap-1.5 text-muted-foreground"
-                disabled={Boolean(isRerunning || evalRunsDisabledReason)}
-                onClick={() => onRerun(suite, { refreshSnapshot: true })}
+                className="h-8 gap-1.5 rounded-r-none"
+                onClick={onGenerateTestCases}
+                disabled={!canGenerateTestCases || isGeneratingTestCases}
+                aria-busy={isGeneratingTestCases}
               >
-                <RotateCw
-                  className={`h-3.5 w-3.5 shrink-0 ${
-                    isRerunning ? "animate-spin" : ""
-                  }`}
-                  aria-hidden
-                />
-                Update snapshot
+                {isGeneratingTestCases ? (
+                  <Loader2
+                    className="h-3.5 w-3.5 shrink-0 animate-spin"
+                    aria-hidden
+                  />
+                ) : (
+                  <Sparkles className="h-3.5 w-3.5 shrink-0" aria-hidden />
+                )}
+                Generate
               </Button>
             </span>
           </TooltipTrigger>
           <TooltipContent
             variant="muted"
             side="bottom"
-            className="max-w-[16rem]"
+            align="start"
+            sideOffset={8}
+            className="max-w-[min(17rem,calc(100vw-1.5rem))] px-3 py-2 text-left font-normal leading-relaxed"
           >
-            {evalRunsDisabledReason ??
-              "Re-saves the suite's current server list as the frozen execution snapshot and starts a run."}
+            {isGeneratingTestCases
+              ? "Generating test cases…"
+              : !canGenerateTestCases
+                ? (generateTestCasesDisabledReason ??
+                  "Configure suite servers before generating cases.")
+                : "Generate suggested cases from your server's tools. Use the arrow to set how many and what kind."}
           </TooltipContent>
         </Tooltip>
-      ) : null}
+        <GenerateCasesConfigPopover
+          suiteId={suite._id}
+          onGenerate={onGenerateTestCases}
+          disabled={!canGenerateTestCases}
+          isGenerating={isGeneratingTestCases}
+          disabledReason={generateTestCasesDisabledReason}
+        />
+      </div>
+    ) : null;
 
-      {!hideRunActions && (replayableLatestRun || !readOnlyConfig) ? (
+  const overviewNewCaseButton =
+    showTestCaseCtas && onCreateTestCase ? (
+      <Button
+        type="button"
+        size="sm"
+        variant="outline"
+        className="h-8 gap-1.5"
+        onClick={onCreateTestCase}
+      >
+        <Plus className="h-3.5 w-3.5 shrink-0" aria-hidden />
+        New case
+      </Button>
+    ) : null;
+
+  const overviewSetupSdkButton = onOpenExportSuite ? (
+    <Button
+      size="sm"
+      variant="outline"
+      className="h-8 gap-1.5"
+      onClick={onOpenExportSuite}
+    >
+      <Code2 className="h-3.5 w-3.5 shrink-0" aria-hidden />
+      Setup SDK
+    </Button>
+  ) : null;
+
+  const overviewLegacyRunActions =
+    !hideRunActions && (replayableLatestRun || !readOnlyConfig) ? (
+      <>
+        {!readOnlyConfig && hasServersConfigured ? (
+          <Tooltip>
+            <TooltipTrigger asChild>
+              <span className="inline-flex">
+                <Button
+                  variant="ghost"
+                  size="sm"
+                  className="h-8 gap-1.5 text-muted-foreground"
+                  disabled={Boolean(isRerunning || evalRunsDisabledReason)}
+                  onClick={() => onRerun(suite, { refreshSnapshot: true })}
+                >
+                  <RotateCw
+                    className={`h-3.5 w-3.5 shrink-0 ${
+                      isRerunning ? "animate-spin" : ""
+                    }`}
+                    aria-hidden
+                  />
+                  Update snapshot
+                </Button>
+              </span>
+            </TooltipTrigger>
+            <TooltipContent
+              variant="muted"
+              side="bottom"
+              className="max-w-[16rem]"
+            >
+              {evalRunsDisabledReason ??
+                "Re-saves the suite's current server list as the frozen execution snapshot and starts a run."}
+            </TooltipContent>
+          </Tooltip>
+        ) : null}
+
         <Tooltip>
           <TooltipTrigger asChild>
             <span className="inline-flex">
@@ -918,63 +913,75 @@ export function SuiteHeader(props: SuiteHeaderProps) {
                     : "Run all cases"}
           </TooltipContent>
         </Tooltip>
-      ) : null}
-    </div>
-  ) : null;
+      </>
+    ) : null;
+
+  const overviewHasRightActions =
+    overviewHasCaseTools ||
+    Boolean(overviewSetupSdkButton) ||
+    Boolean(overviewLegacyRunActions);
 
   return (
     <div
       data-testid="suite-overview-header"
-      className="mb-4 flex min-w-0 items-center gap-x-3"
+      className="mb-4 flex min-w-0 items-center justify-between gap-x-3"
     >
-      <div className="min-w-0 max-w-[38%] shrink overflow-hidden sm:max-w-[45%]">
-        <div className="flex min-w-0 items-center gap-3">
-          {isEditingName ? (
-            <input
-              type="text"
-              value={editedName}
-              onChange={(e) => setEditedName(e.target.value)}
-              onBlur={handleNameBlur}
-              onKeyDown={handleNameKeyDown}
-              autoFocus
-              className="min-w-0 w-full max-w-full flex-1 rounded-md border border-input px-3 text-base font-semibold leading-none focus:outline-none focus:ring-2 focus:ring-ring md:text-lg h-8 py-0"
-            />
-          ) : readOnlyConfig ? (
-            <h2
-              className="min-w-0 flex-1 truncate px-2 text-base font-semibold leading-none md:text-lg flex h-8 items-center"
-              title={suite.name}
-            >
-              {suite.name}
-            </h2>
-          ) : (
-            <Button
-              variant="ghost"
-              onClick={handleNameClick}
-              className="h-8 min-w-0 max-w-full flex-1 justify-start gap-0 px-2 text-left text-base font-semibold leading-none hover:bg-accent md:text-lg"
-              title={suite.name}
-            >
-              <span className="min-w-0 truncate text-left">{suite.name}</span>
-            </Button>
-          )}
-          {latestRunForMetadata ? (
-            <span className="shrink-0">
-              <CiMetadataDisplay
-                ciMetadata={latestRunForMetadata.ciMetadata}
-                compact={true}
+      <div className="flex min-w-0 items-center gap-2">
+        <div className="min-w-0 max-w-[20rem] shrink overflow-hidden sm:max-w-md">
+          <div className="flex min-w-0 items-center gap-2">
+            {isEditingName ? (
+              <input
+                type="text"
+                value={editedName}
+                onChange={(e) => setEditedName(e.target.value)}
+                onBlur={handleNameBlur}
+                onKeyDown={handleNameKeyDown}
+                autoFocus
+                className="h-8 min-w-0 w-full max-w-full flex-1 rounded-md border border-input px-3 py-0 text-base font-semibold leading-none focus:outline-none focus:ring-2 focus:ring-ring md:text-lg"
               />
-            </span>
-          ) : null}
+            ) : readOnlyConfig ? (
+              <h2
+                className="flex h-8 min-w-0 flex-1 items-center truncate px-2 text-base font-semibold leading-none md:text-lg"
+                title={suite.name}
+              >
+                {suite.name}
+              </h2>
+            ) : (
+              <Button
+                variant="ghost"
+                onClick={handleNameClick}
+                className="h-8 min-w-0 max-w-full flex-1 justify-start gap-0 px-2 text-left text-base font-semibold leading-none hover:bg-accent md:text-lg"
+                title={suite.name}
+              >
+                <span className="min-w-0 truncate text-left">{suite.name}</span>
+              </Button>
+            )}
+            {latestRunForMetadata ? (
+              <span className="shrink-0">
+                <CiMetadataDisplay
+                  ciMetadata={latestRunForMetadata.ciMetadata}
+                  compact={true}
+                />
+              </span>
+            ) : null}
+          </div>
         </div>
+        <div className="min-w-0 shrink">{suiteOverviewHostBar}</div>
+        {overviewSettingsButton}
+        {overviewSuiteNavButtons}
       </div>
-      <div className="min-w-0 flex-1 overflow-x-auto [scrollbar-width:none] [&::-webkit-scrollbar]:hidden">
-        <div className="flex w-max min-w-full flex-nowrap items-center justify-end gap-x-3">
-          <div className="shrink-0">{suiteOverviewHostBar}</div>
-          {overviewSuiteNavButtons}
-          {overviewSettingsButton}
-          {overviewCaseToolsCluster}
-          {overviewExportRunCluster}
+      {overviewHasRightActions ? (
+        <div
+          data-testid="suite-overview-actions"
+          className="flex shrink-0 flex-nowrap items-center gap-2"
+        >
+          {overviewSetupSdkButton}
+          {overviewLegacyRunActions}
+          {overviewGenerateButton}
+          {overviewNewCaseButton}
+          {overviewRunAllCta}
         </div>
-      </div>
+      ) : null}
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- Cap the suite title and put server/client pills + settings with identity on the left so long names truncate instead of crowding the toolbar
- Keep Setup SDK → Generate → New case → Run all in a shrink-wrapped right action cluster that never scrolls or clips
- Remove Compare clients from the suite environment composer header strip

## Test plan
- [ ] Open a suite with a very long name locally (e.g. `/evals/suite/...`) and confirm the title truncates
- [ ] Confirm Setup SDK, Generate, New case, and Run all stay fully visible with no horizontal scrollbar
- [ ] Confirm server/client pills and settings sit next to the title
- [ ] Confirm Compare clients is gone from this header
- [ ] Smoke-test Run all / Generate / New case / Setup SDK still work
- [ ] `npm run test -- --run client/src/components/evals/__tests__/suite-header.test.tsx`


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Keeps suite header actions visible with long names and on narrow panes by truncating the title, moving identity/config left, and shrink-wrapping a right-aligned actions cluster that wraps to a second row when needed. Also removes Compare clients from the environment composer header.

- **Bug Fixes**
  - Truncated the suite title and placed server/client pills and settings next to it on the left.
  - Right action cluster is shrink-wrapped and right-aligned; it stays ordered (Setup SDK → Generate → New case → Run all) and wraps to a second row instead of clipping on narrow layouts.
  - Removed the Compare clients button from the suite environment composer header.
  - Updated `client/src/components/evals/__tests__/suite-header.test.tsx` to assert truncation, wrapping, action order, and absence of Compare clients.

<sup>Written for commit 69640da60796d5b352bc94ecfabb83cf3408b779. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/MCPJam/inspector/pull/3896?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

