### PR TITLE
ops(axiom): version the alert monitors and add an idempotent apply script

### DIFF
--- a/ops/axiom-monitors/README.md
+++ b/ops/axiom-monitors/README.md
@@ -1,0 +1,88 @@
+# Axiom monitors (versioned)
+
+The JSON in `monitors/` is the source of truth for the Axiom monitors this repo
+owns. `apply.mjs` reconciles Axiom to match it.
+
+Before this existed, all 55 monitors lived only in the Axiom UI: unreviewable,
+undiffable, and impossible to recreate. Definitions here are code-reviewed like
+anything else.
+
+## Usage
+
+```bash
+node ops/axiom-monitors/apply.mjs                 # plan (default, read-only)
+node ops/axiom-monitors/apply.mjs --apply         # write
+node ops/axiom-monitors/apply.mjs --only <key>    # restrict to one definition
+node ops/axiom-monitors/apply.mjs --delete <key>  # delete exactly that managed monitor
+```
+
+Plan mode runs every query read-only against the real API and asserts it
+produces the declared `columnName`. A monitor whose APL does not compile, or
+whose query cannot produce the column the threshold reads, is never written.
+
+## Environment
+
+| Variable | Purpose |
+| --- | --- |
+| `AXIOM_TOKEN` | API token. Never committed; redacted from all output. |
+| `AXIOM_ORG_ID` | Monitors are org-scoped (`mcpjam-b35r`). |
+| `AXIOM_NOTIFIER_<KEY>` | One per logical notifier a definition references. |
+
+Notifier IDs are org-specific, so definitions reference a **logical key**
+(`mcpjam-alerts-page`) and the script resolves it from
+`AXIOM_NOTIFIER_MCPJAM_ALERTS_PAGE` at apply time. An unresolved notifier is a
+hard failure, never a default — a monitor wired to nothing looks healthy
+forever, which is the exact failure this work exists to fix.
+
+## Ownership and safety
+
+Ownership is claimed by a marker appended to the monitor description:
+
+```
+[managed: ops/axiom-monitors/<key>.json — edit the file, not this monitor]
+```
+
+- Monitors without the marker are **never** modified or deleted. If a
+  definition's name collides with an unmanaged monitor, the script refuses and
+  tells you, rather than adopting it.
+- Updates are a full-object `PUT` merged onto the current remote object. The v2
+  API clears fields omitted from the body, so a partial PUT would null
+  everything unlisted.
+- `--delete` requires the exact key and only ever removes a managed monitor.
+- Re-running with no definition change is a no-op.
+
+## Open decision before first apply: PAGE vs WARN notifiers
+
+The plan requires PAGE and WARN to be **mechanically** different — if both land
+in `#mcpjam-alerts` with identical treatment, the tiers are names, not tiers.
+
+Today the org has exactly two notifiers: `#mcpjam-alerts`
+(`jnWZGoVFRcvyTdUjBe`) and `MCPJam LLM Safety` (`ox9MvFUsrwZtx9HfxM`). There is
+no separate WARN destination, so `mcpjam-alerts-warn` currently has nowhere
+correct to point. Resolve one of these before applying:
+
+1. Create a second Slack notifier that posts without an on-call mention, and
+   point `AXIOM_NOTIFIER_MCPJAM_ALERTS_WARN` at it. (Needs Slack admin.)
+2. Point both keys at `#mcpjam-alerts` and accept that the tier distinction is
+   only visible in the message text.
+
+Option 1 is what the plan assumes.
+
+## Verifying delivery
+
+Do **not** test by lowering a production monitor's threshold — it posts
+repeatedly to a real channel and risks being left lowered.
+
+Instead create a disposable definition against a controlled dataset and the
+real notifier, confirm one trigger and one resolution, then
+`--delete` that exact key. While doing it, record whether the Slack payload
+includes grouped/projected columns, because the per-class monitors (M3/M4/M6)
+depend on knowing the answer: all 55 pre-existing monitors collapse to a bare
+scalar in Slack, so their drill-down queries may have to carry the diagnosis.
+
+## Fields this Axiom deployment may ignore
+
+`notifyByGroup`, `alertOnNoData`, and `notifyEveryRun` are sent but do not
+appear in the current API's monitor payload. After `--apply` the script reports
+any field the API did not persist. Treat such a report as real: `resolvable`
+silently dropped would turn a day-long incident into repeated notifications.

--- a/ops/axiom-monitors/apply.mjs
+++ b/ops/axiom-monitors/apply.mjs
@@ -1,0 +1,312 @@
+#!/usr/bin/env node
+/**
+ * Apply the checked-in Axiom monitor definitions.
+ *
+ * The JSON under ./monitors is the source of truth. This script is a thin,
+ * idempotent reconciler: it never invents a monitor, never edits one it does
+ * not own, and never deletes anything unless told exactly what to delete.
+ *
+ * Ownership is claimed by a marker line appended to the monitor description
+ * (MANAGED_MARKER below). A monitor in Axiom that shares a name with a
+ * definition but carries no marker is reported as a conflict and left alone —
+ * adopting it silently would let this script clobber hand-authored monitors.
+ *
+ *   node ops/axiom-monitors/apply.mjs                 # plan (default, read-only)
+ *   node ops/axiom-monitors/apply.mjs --apply         # write
+ *   node ops/axiom-monitors/apply.mjs --only <key>    # restrict to one definition
+ *   node ops/axiom-monitors/apply.mjs --delete <key>  # delete exactly that managed monitor
+ *
+ * Env: AXIOM_TOKEN, AXIOM_ORG_ID, and one AXIOM_NOTIFIER_<KEY> per logical
+ * notifier referenced by a definition. Notifier IDs are org-specific, so they
+ * are resolved at apply time rather than committed.
+ */
+import { readdirSync, readFileSync } from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const HERE = path.dirname(fileURLToPath(import.meta.url));
+const MONITOR_DIR = path.join(HERE, "monitors");
+const API = "https://api.axiom.co";
+const MANAGED_PREFIX = "[managed: ops/axiom-monitors/";
+const managedMarker = (key) =>
+  `${MANAGED_PREFIX}${key}.json — edit the file, not this monitor]`;
+
+// Fields we send. Anything Axiom does not persist is reported after apply
+// rather than assumed — this deployment's GET payload omits several of them,
+// and a silently-dropped `resolvable` changes notification behaviour.
+const MONITOR_FIELDS = [
+  "type",
+  "columnName",
+  "operator",
+  "threshold",
+  "rangeMinutes",
+  "intervalMinutes",
+  "notifyByGroup",
+  "alertOnNoData",
+  "resolvable",
+  "notifyEveryRun",
+];
+
+const REQUIRED_MONITOR_FIELDS = [
+  "type",
+  "columnName",
+  "operator",
+  "threshold",
+  "rangeMinutes",
+  "intervalMinutes",
+  "resolvable",
+];
+
+const args = process.argv.slice(2);
+const flag = (name) => args.includes(name);
+const valueOf = (name) => {
+  const i = args.indexOf(name);
+  return i === -1 ? undefined : args[i + 1];
+};
+
+const shouldApply = flag("--apply");
+const onlyKey = valueOf("--only");
+const deleteKey = valueOf("--delete");
+
+/** Never let a token reach stdout, even inside an error body. */
+function redact(text) {
+  const token = process.env.AXIOM_TOKEN;
+  let out = String(text);
+  if (token && token.length > 6) out = out.split(token).join("<redacted>");
+  return out.replace(/xa(at|pt)-[0-9a-f-]{8,}/gi, "<redacted>");
+}
+
+function fail(message) {
+  console.error(`✖ ${redact(message)}`);
+  process.exit(1);
+}
+
+function requireEnv(name, why) {
+  const v = process.env[name];
+  if (!v) fail(`${name} is not set — ${why}`);
+  return v;
+}
+
+const TOKEN = requireEnv("AXIOM_TOKEN", "needed to read or write monitors");
+const ORG_ID = requireEnv("AXIOM_ORG_ID", "monitors are org-scoped");
+
+async function axiom(method, route, body) {
+  const res = await fetch(`${API}${route}`, {
+    method,
+    headers: {
+      Authorization: `Bearer ${TOKEN}`,
+      "X-Axiom-Org-Id": ORG_ID,
+      "Content-Type": "application/json",
+    },
+    ...(body === undefined ? {} : { body: JSON.stringify(body) }),
+  });
+  const text = await res.text();
+  if (!res.ok) {
+    throw new Error(`${method} ${route} → HTTP ${res.status}: ${redact(text)}`);
+  }
+  return text ? JSON.parse(text) : null;
+}
+
+/** Logical notifier key → org-specific id, from the environment. */
+function resolveNotifier(logicalKey) {
+  const envName = `AXIOM_NOTIFIER_${logicalKey.toUpperCase().replace(/[^A-Z0-9]+/g, "_")}`;
+  const id = process.env[envName];
+  // A missing notifier must fail loudly: a monitor wired to nothing looks
+  // healthy forever, which is the exact failure this whole effort exists to fix.
+  if (!id) {
+    fail(
+      `notifier "${logicalKey}" is unresolved — set ${envName} to its Axiom notifier id`,
+    );
+  }
+  return id;
+}
+
+function asText(value) {
+  return Array.isArray(value) ? value.join("\n") : value;
+}
+
+function loadDefinitions() {
+  let files;
+  try {
+    files = readdirSync(MONITOR_DIR).filter((f) => f.endsWith(".json")).sort();
+  } catch {
+    fail(`no monitor definitions found at ${MONITOR_DIR}`);
+  }
+  const defs = files.map((file) => {
+    const full = path.join(MONITOR_DIR, file);
+    let raw;
+    try {
+      raw = JSON.parse(readFileSync(full, "utf8"));
+    } catch (err) {
+      fail(`${file} is not valid JSON: ${err.message}`);
+    }
+    for (const field of ["key", "name", "dataset", "notifier", "aplQuery", "description"]) {
+      if (!raw[field]) fail(`${file} is missing required field "${field}"`);
+    }
+    if (raw.key !== path.basename(file, ".json")) {
+      fail(`${file} declares key "${raw.key}" — key must equal the filename`);
+    }
+    if (!raw.monitor) fail(`${file} is missing the "monitor" block`);
+    for (const field of REQUIRED_MONITOR_FIELDS) {
+      if (raw.monitor[field] === undefined) {
+        fail(`${file} monitor block is missing "${field}"`);
+      }
+    }
+    const apl = asText(raw.aplQuery);
+    if (!apl.includes(`['${raw.dataset}']`)) {
+      fail(`${file} query does not read its declared dataset ['${raw.dataset}']`);
+    }
+    return { ...raw, aplQuery: apl, description: asText(raw.description), file };
+  });
+  const seen = new Set();
+  for (const d of defs) {
+    if (seen.has(d.name)) fail(`duplicate monitor name "${d.name}"`);
+    seen.add(d.name);
+  }
+  return onlyKey ? defs.filter((d) => d.key === onlyKey) : defs;
+}
+
+/** Run the query read-only. A monitor whose APL does not compile is worthless. */
+async function validateQuery(def) {
+  const result = await axiom("POST", "/v1/datasets/_apl?format=tabular", {
+    apl: def.aplQuery,
+    startTime: new Date(Date.now() - 60 * 60 * 1000).toISOString(),
+    endTime: new Date().toISOString(),
+  });
+  const table = result?.tables?.[0];
+  const columns = (table?.fields ?? []).map((f) => f.name);
+  if (!columns.includes(def.monitor.columnName)) {
+    throw new Error(
+      `query does not produce columnName "${def.monitor.columnName}" (got: ${columns.join(", ") || "no columns"})`,
+    );
+  }
+  const rows = table?.columns?.[0]?.length ?? 0;
+  return { columns, rows };
+}
+
+function desiredBody(def) {
+  const body = {
+    name: def.name,
+    description: `${def.description}\n\n${managedMarker(def.key)}`,
+    aplQuery: def.aplQuery,
+    notifierIds: [resolveNotifier(def.notifier)],
+  };
+  for (const field of MONITOR_FIELDS) {
+    if (def.monitor[field] !== undefined) body[field] = def.monitor[field];
+  }
+  return body;
+}
+
+function diffFields(existing, desired) {
+  const changed = [];
+  for (const [k, v] of Object.entries(desired)) {
+    const before = existing[k];
+    const same =
+      Array.isArray(v) && Array.isArray(before)
+        ? JSON.stringify(v) === JSON.stringify(before)
+        : before === v;
+    if (!same) changed.push(k);
+  }
+  return changed;
+}
+
+async function main() {
+  const defs = loadDefinitions();
+  if (defs.length === 0) fail(onlyKey ? `no definition with key "${onlyKey}"` : "no definitions");
+
+  const remote = await axiom("GET", "/v2/monitors");
+  const managedByKey = new Map();
+  for (const m of remote) {
+    const desc = m.description ?? "";
+    const at = desc.indexOf(MANAGED_PREFIX);
+    if (at === -1) continue;
+    const key = desc.slice(at + MANAGED_PREFIX.length).split(".json")[0];
+    managedByKey.set(key, m);
+  }
+
+  if (deleteKey) {
+    const target = managedByKey.get(deleteKey);
+    if (!target) fail(`no managed monitor with key "${deleteKey}" — refusing to guess`);
+    console.log(`delete  ${target.name} (${target.id})`);
+    if (!shouldApply) {
+      console.log("\nplan only — re-run with --apply to delete");
+      return;
+    }
+    await axiom("DELETE", `/v2/monitors/${target.id}`);
+    console.log("deleted");
+    return;
+  }
+
+  const planned = [];
+  for (const def of defs) {
+    let validation;
+    try {
+      validation = await validateQuery(def);
+    } catch (err) {
+      fail(`${def.file}: ${err.message}`);
+    }
+    const existing = managedByKey.get(def.key);
+    const nameClash = remote.find(
+      (m) => m.name === def.name && m.id !== existing?.id,
+    );
+    if (nameClash) {
+      fail(
+        `"${def.name}" already exists in Axiom (${nameClash.id}) without a managed marker. ` +
+          `Refusing to adopt or overwrite an unmanaged monitor — rename one of them, or add the marker by hand to adopt it.`,
+      );
+    }
+    const desired = desiredBody(def);
+    const action = !existing
+      ? "create"
+      : diffFields(existing, desired).length
+        ? "update"
+        : "no-op";
+    planned.push({ def, existing, desired, action, validation });
+  }
+
+  for (const p of planned) {
+    const { def, existing, desired, action, validation } = p;
+    const where = `${def.monitor.operator} ${def.monitor.threshold} over ${def.monitor.rangeMinutes}m every ${def.monitor.intervalMinutes}m`;
+    console.log(`${action.padEnd(7)} ${def.name}`);
+    console.log(`        tier=${def.tier ?? "?"} ${where} → notifier "${def.notifier}"`);
+    console.log(`        query ok — ${validation.rows} row(s) in the last hour`);
+    if (action === "update") {
+      console.log(`        changes: ${diffFields(existing, desired).join(", ")}`);
+    }
+  }
+
+  if (!shouldApply) {
+    console.log("\nplan only — re-run with --apply to write. Unmanaged monitors are never touched.");
+    return;
+  }
+
+  console.log("");
+  for (const p of planned) {
+    if (p.action === "no-op") continue;
+    // v2 monitors take a FULL-object PUT: fields omitted from the body are
+    // cleared, so updates merge onto the existing object rather than replacing it.
+    const saved = p.existing
+      ? await axiom("PUT", `/v2/monitors/${p.existing.id}`, {
+          ...p.existing,
+          ...p.desired,
+        })
+      : await axiom("POST", "/v2/monitors", p.desired);
+
+    const dropped = Object.keys(p.desired).filter(
+      (k) => saved?.[k] === undefined && p.desired[k] !== undefined,
+    );
+    console.log(`${p.action}d ${saved?.name} (${saved?.id})`);
+    console.log(
+      `        effective: ${saved?.operator} ${saved?.threshold} over ${saved?.rangeMinutes}m every ${saved?.intervalMinutes}m, notifiers=${JSON.stringify(saved?.notifierIds ?? [])}`,
+    );
+    if (dropped.length) {
+      // Not fatal, but the operator must know: a field this deployment ignores
+      // is a behaviour we documented in the plan and are not actually getting.
+      console.log(
+        `        ⚠ not persisted by this Axiom deployment: ${dropped.join(", ")}`,
+      );
+    }
+  }
+}
+
+main().catch((err) => fail(err.stack ?? err.message));

--- a/ops/axiom-monitors/monitors/inspector-4xx-storm.json
+++ b/ops/axiom-monitors/monitors/inspector-4xx-storm.json
@@ -1,0 +1,44 @@
+{
+  "key": "inspector-4xx-storm",
+  "name": "MCPJam Inspector 4xx storm (prod)",
+  "tier": "WARN",
+  "owner": "marcelo",
+  "dataset": "inspector-logs",
+  "notifier": "mcpjam-alerts-warn",
+  "monitor": {
+    "type": "Threshold",
+    "columnName": "Count",
+    "operator": "Above",
+    "threshold": 200,
+    "rangeMinutes": 60,
+    "intervalMinutes": 15,
+    "notifyByGroup": false,
+    "alertOnNoData": false,
+    "resolvable": true,
+    "notifyEveryRun": false
+  },
+  "aplQuery": [
+    "['inspector-logs']",
+    "| where _sysTime >= ago(60m)",
+    "| where event == 'http.request.completed'",
+    "| where toint(statusCode) >= 400 and toint(statusCode) < 500",
+    "| where tostring(environment) in ('prod','production')",
+    "| summarize Count = count()"
+  ],
+  "description": [
+    "WARN — owner: marcelo. More than 200 4xx responses in one hour (prod). Not a page.",
+    "",
+    "WHY THIS EXISTS: the 5xx rate monitor is deliberately 5xx-only, so without this the entire 4xx surface is unwatched. That matters because classifyRuntimeError checks isUnauthorized401 before every other branch, so MCP auth failures carrying a clean 401 land on 'http.request.completed' and never reach 'http.request.failed'. Measured on the incident route: 2,328 401s vs 4,932 500s on /api/web/tools/list.",
+    "",
+    "WHY THIS THRESHOLD: measured hourly 4xx over 30d is p50=12, p95=62, p99=89, max=156. 200/hr is ~2.2x p99 and above the observed maximum. Steady auth churn (8,373 401s across 520 orgs in 30d) cannot reach it; a genuine auth or rate-limit storm can.",
+    "",
+    "WHY WARN, NOT PAGE: a 4xx is a declared client outcome. Only an abnormal RATE of one is evidence of anything, and the classes worth paging on are already covered by the per-class spike monitor. Revisit this tier only if a real incident is found to have announced itself here first.",
+    "",
+    "TRIAGE:",
+    "1. Split by status and route: ['inspector-logs'] | where _time > ago(3h) | where event == 'http.request.completed' | where toint(statusCode) between (400 .. 499) | summarize n=count(), orgs=dcount(orgId) by statusCode, tostring(route) | sort by n desc",
+    "2. Wide (many orgs) 401 = credential/session expiry wave, likely ours or an upstream identity provider. Narrow (few orgs) = one tenant's automation; check for a client loop.",
+    "3. 429 concentrated on one route means we are rate-limiting ourselves; confirm against the self-inflicted-load guard before blaming a customer.",
+    "",
+    "ROLLBACK: node ops/axiom-monitors/apply.mjs --only inspector-4xx-storm after reverting the definition file."
+  ]
+}

--- a/ops/axiom-monitors/monitors/inspector-5xx-rate.json
+++ b/ops/axiom-monitors/monitors/inspector-5xx-rate.json
@@ -1,0 +1,41 @@
+{
+  "key": "inspector-5xx-rate",
+  "name": "MCPJam Inspector 5xx rate (prod)",
+  "tier": "PAGE",
+  "owner": "marcelo",
+  "dataset": "inspector-logs",
+  "notifier": "mcpjam-alerts-page",
+  "monitor": {
+    "type": "Threshold",
+    "columnName": "Count",
+    "operator": "Above",
+    "threshold": 100,
+    "rangeMinutes": 60,
+    "intervalMinutes": 15,
+    "notifyByGroup": false,
+    "alertOnNoData": false,
+    "resolvable": true,
+    "notifyEveryRun": false
+  },
+  "aplQuery": [
+    "['inspector-logs']",
+    "| where _sysTime >= ago(60m)",
+    "| where event == 'http.request.failed'",
+    "| where tostring(environment) in ('prod','production')",
+    "| summarize Count = count()"
+  ],
+  "description": [
+    "PAGE — owner: marcelo. Inspector returned more than 100 5xx in one hour (prod).",
+    "",
+    "WHY THIS THRESHOLD: measured hourly 5xx over 630h is p50=8, p95=37, p99=65. 100/hr is ~1.5x p99, so normal traffic cannot reach it. The 2026-08-06 incident hit 3,705 in a single hour and nothing alerted; this monitor exists for that.",
+    "",
+    "SCOPE: 5xx only, deliberately. Including 4xx moves hourly p99 from 65 to 135 and would make this fire on ordinary traffic. 4xx storms are covered by 'MCPJam Inspector 4xx storm'. There is no route exclusion: pathological total volume is an operational symptom even when a user's server triggered it.",
+    "",
+    "TRIAGE:",
+    "1. Find the class. Run: ['inspector-logs'] | where _time > ago(2h) | where event == 'http.request.failed' | summarize n=count(), orgs=dcount(orgId), sample=any(errorMessage) by tostring(route), tostring(errorCode) | sort by n desc",
+    "2. Check concentration. Few orgs with huge per-org volume = an amplification loop on our side (see the 08-06 precedent). Many orgs, thin each = third-party servers are down and this is the product working; consider whether the threshold or a route needs revisiting rather than treating it as an outage.",
+    "3. Check deploy. Compare `release` on the failing rows against the previous hour. A version change at the boundary is your answer; roll back.",
+    "",
+    "ROLLBACK: node ops/axiom-monitors/apply.mjs --only inspector-5xx-rate after reverting the definition file, or disable in the Axiom UI. Do not raise the threshold to silence a real regression."
+  ]
+}

--- a/ops/axiom-monitors/monitors/inspector-telemetry-deadman.json
+++ b/ops/axiom-monitors/monitors/inspector-telemetry-deadman.json
@@ -1,0 +1,41 @@
+{
+  "key": "inspector-telemetry-deadman",
+  "name": "MCPJam Inspector typed request telemetry silent (prod)",
+  "tier": "PAGE",
+  "owner": "marcelo",
+  "dataset": "inspector-logs",
+  "notifier": "mcpjam-alerts-page",
+  "monitor": {
+    "type": "Threshold",
+    "columnName": "Count",
+    "operator": "Below",
+    "threshold": 1,
+    "rangeMinutes": 15,
+    "intervalMinutes": 5,
+    "notifyByGroup": false,
+    "alertOnNoData": true,
+    "resolvable": true,
+    "notifyEveryRun": false
+  },
+  "aplQuery": [
+    "['inspector-logs']",
+    "| where _sysTime >= ago(15m)",
+    "| where tostring(environment) in ('prod','production')",
+    "| where event in ('http.request.completed','http.request.failed')",
+    "| summarize Count = count()"
+  ],
+  "description": [
+    "PAGE — owner: marcelo. No typed HTTP request events from prod for 15 minutes. Normal is roughly 200+ per 15 minutes.",
+    "",
+    "WHILE THIS IS FIRING, EVERY OTHER MONITOR IN THIS CHANNEL IS UNRELIABLE. Their silence means unknown, not healthy.",
+    "",
+    "WHY TYPED EVENTS ONLY: this deliberately counts only 'http.request.completed' and 'http.request.failed', not any row in the dataset. Counting arbitrary rows lets a background or free-form log keep the deadman green while the HTTP telemetry pipeline is broken.",
+    "",
+    "TRIAGE — three causes, in order of likelihood:",
+    "1. Process down or crash-looping. Hit https://app.mcpjam.com/health directly; health paths are excluded from request logging, so they answer even when logging is dead. Health OK + logs silent means the pipeline, not the app.",
+    "2. Ingest broken. AXIOM_TOKEN / AXIOM_DATASET missing or changed (the logger constructs its client lazily and silently no-ops when they are absent), or DO_NOT_TRACK is set. A config change alone can cause this.",
+    "3. Traffic not reaching us. Check the Prod canary workflow and Cloudflare before touching the app. Note the canary's real cadence is ~50 min, not the 15 min its cron requests, so a green canary can be up to an hour stale.",
+    "",
+    "ROLLBACK: node ops/axiom-monitors/apply.mjs --only inspector-telemetry-deadman after reverting the definition file. If prod legitimately has 15-minute zero-traffic windows, add an explicit system heartbeat event and deadman that instead of widening this query back to arbitrary rows."
+  ]
+}


### PR DESCRIPTION
## Why

The inspector's HTTP error surface has never been monitored. All 55 existing Axiom monitors live only in the UI — unreviewable and undiffable — and **50 of them watch the Convex backend**. Only 5 query `inspector-logs`, and all 5 are LLM/billing/model-catalog.

That gap has a cost. On 2026-08-06 a single user generated **3,705 failures in one hour** on `/api/web/tools/list` against a 0.12/hr baseline. Nothing alerted; nobody noticed. This PR is step 1 of the plan to make `#mcpjam-alerts` carry actionable errors.

## What

Three monitors as code-reviewed JSON, plus an idempotent reconciler.

| Monitor | Tier | Rule | Why this number |
| --- | --- | --- | --- |
| `inspector-5xx-rate` | PAGE | >100 5xx/hr | ~1.5× the measured hourly p99 of 65 (p50=8, p95=37, over 630h). Fires on 08-06's 3,705; silent in normal windows. |
| `inspector-telemetry-deadman` | PAGE | <1 typed event/15m | Normal is ~200+ per 15m. Zero is unambiguous. |
| `inspector-4xx-storm` | WARN | >200 4xx/hr | ~2.2× the 4xx p99 of 89, above the observed max of 156. Steady 401 churn (8,373 across 520 orgs/30d) cannot reach it. |

Two deliberate choices worth reviewing:

**The 5xx monitor is 5xx-only.** Including 4xx moves hourly p99 from 65 to 135, so this threshold would fire on ordinary traffic; retuning to ~200 would instead blind it to genuine 5xx incidents. Hence the separate 4xx monitor.

**The 4xx monitor is not optional coverage.** `classifyRuntimeError` checks `isUnauthorized401` before every other branch, so an `MCPAuthError` carrying a clean 401 becomes `401 UNAUTHORIZED` → `http.request.completed` and never reaches `http.request.failed`. Measured on the incident route: **2,328 401s vs 4,932 500s** on `/api/web/tools/list`. A `failed`-only view can miss half an auth incident.

**The deadman counts only `http.request.{completed,failed}`**, not any row in the dataset — otherwise a free-form background log keeps it green while the typed HTTP pipeline is broken.

## apply.mjs

Plans by default; writes only with `--apply`.

- Runs every query **read-only against the real API** and asserts it produces the declared `columnName`. A query that doesn't compile is never written.
- Resolves org-specific notifier IDs from the environment rather than committing them. An unresolved notifier is a hard failure, never a default — a monitor wired to nothing looks healthy forever.
- Claims ownership via a description marker. Monitors without it are never adopted or modified; a name collision with an unmanaged monitor is refused with an explanation.
- Updates are a full-object `PUT` merged onto the remote object, because the v2 API clears fields omitted from the body.
- `--delete` requires an exact key and only removes a managed monitor.

Guards were tested rather than assumed — unresolved notifier, collision against the real `hosted-model catalog` monitor, a query missing its `columnName`, and unknown `--only`/`--delete` keys all fail loudly.

## Not applied yet — one open decision

The plan requires PAGE and WARN to be *mechanically* different; if both land in `#mcpjam-alerts` identically, the tiers are names rather than tiers. The org currently has two notifiers (`#mcpjam-alerts`, `MCPJam LLM Safety`), so `mcpjam-alerts-warn` has nowhere correct to point. Either create a second Slack notifier that posts without an on-call mention (what the plan assumes), or point both keys at the same channel and accept the distinction living only in message text.

Also flagged in the README: `notifyByGroup`, `alertOnNoData`, and `notifyEveryRun` do not appear in this deployment's monitor payload and may be ignored. The script reports any field that didn't persist after `--apply`. If `resolvable` is among them, a sustained incident becomes repeated notifications and the intervals need rethinking.

## Testing

No runtime code changes — this adds an ops directory only. Verified by running the reconciler in plan mode against the live Axiom API (all three queries compile and produce `Count`), and by exercising each safety guard. Nothing has been written to Axiom.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit a8e7473538e4653b9a3381be47c9812274091152. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Versioned Axiom monitors with an idempotent apply script, plus three Inspector alerts (5xx rate, 4xx storm, and a typed-telemetry deadman) to catch outages that UI-only monitors missed. Moves monitoring into code-reviewed JSON and closes the gap that hid the recent 3,705-failure incident.

- **New Features**
  - Three monitors as JSON: 5xx rate PAGE (>100/hr), 4xx storm WARN (>200/hr), telemetry deadman PAGE (<1 typed event/15m). 5xx is 5xx-only; 4xx exists because many auth 401s never hit `http.request.failed`; deadman counts only typed HTTP events.
  - `ops/axiom-monitors/apply.mjs`: plan by default, `--apply` to write; validates queries compile and produce `columnName`; resolves notifier IDs from env; uses a managed description marker; full-object `PUT`; exact-key `--delete`; reports fields the API drops.

- **Migration**
  - Set env: `AXIOM_TOKEN`, `AXIOM_ORG_ID`, and notifier IDs (`AXIOM_NOTIFIER_MCPJAM_ALERTS_PAGE`, `AXIOM_NOTIFIER_MCPJAM_ALERTS_WARN`).
  - Decide notifier split: create a WARN Slack notifier without on-call mentions, or point WARN to `#mcpjam-alerts` temporarily.
  - Dry run: `node ops/axiom-monitors/apply.mjs`. Apply: add `--apply`. To remove: `--delete <key>`.

<sup>Written for commit a8e7473538e4653b9a3381be47c9812274091152. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/MCPJam/inspector/pull/3898?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

