### PR TITLE
feat(server): count socket-level failures so resets stop being invisible

### DIFF
--- a/mcpjam-inspector/server/index.ts
+++ b/mcpjam-inspector/server/index.ts
@@ -9,6 +9,7 @@ import { webBodyLimit } from "./middleware/web-body-limit.js";
 import { logger } from "hono/logger";
 import { logger as appLogger } from "./utils/logger";
 import { reportRouteFailure } from "./utils/route-error-report.js";
+import { attachSocketDiagnostics } from "./utils/socket-diagnostics.js";
 import { serveStatic } from "@hono/node-server/serve-static";
 import { readFileSync } from "fs";
 import { dirname, join } from "path";
@@ -809,6 +810,11 @@ const server = serve({
   port: SERVER_PORT,
   hostname,
 });
+// Count socket-level failures. These die before Node parses a request line,
+// so they emit no `http.request.*` event and are otherwise invisible — the
+// class the 08-11 Cloudflare 502 fell into. Must be attached before traffic
+// arrives; it also owns the `clientError` response (see the module).
+attachSocketDiagnostics(server);
 // Attach the WebSocket upgrade listener (computer terminal bridge).
 injectWebSocket(server);
 

--- a/mcpjam-inspector/server/utils/__tests__/socket-diagnostics.test.ts
+++ b/mcpjam-inspector/server/utils/__tests__/socket-diagnostics.test.ts
@@ -1,0 +1,149 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import http from "node:http";
+import net from "node:net";
+
+const events: Array<{ name: string; payload: Record<string, number> }> = [];
+
+vi.mock("../request-logger.js", () => ({
+  getSystemLogger: () => ({
+    event: (name: string, payload: Record<string, number>) => {
+      events.push({ name, payload });
+    },
+  }),
+}));
+
+const { attachSocketDiagnostics, flushSocketStats } = await import(
+  "../socket-diagnostics.js"
+);
+
+/** Drive a real socket-level failure and return the server's raw reply. */
+function rawExchange(
+  port: number,
+  write: (socket: net.Socket) => void,
+): Promise<string> {
+  return new Promise((resolve) => {
+    let buf = "";
+    const socket = net.connect(port, "127.0.0.1", () => write(socket));
+    socket.on("data", (d) => {
+      buf += d.toString();
+    });
+    socket.on("close", () => resolve(buf));
+    socket.on("error", () => resolve(buf));
+  });
+}
+
+async function withServer(
+  fn: (port: number) => Promise<void>,
+  options?: http.ServerOptions,
+): Promise<void> {
+  const server = http.createServer(options ?? {}, (_req, res) => res.end("ok"));
+  attachSocketDiagnostics(server);
+  await new Promise<void>((r) => server.listen(0, "127.0.0.1", r));
+  const { port } = server.address() as net.AddressInfo;
+  try {
+    await fn(port);
+  } finally {
+    server.close();
+  }
+}
+
+beforeEach(() => {
+  events.length = 0;
+  flushSocketStats();
+  events.length = 0;
+});
+
+describe("socket diagnostics", () => {
+  it("still answers 400 on a malformed request line", async () => {
+    // Attaching a clientError listener REPLACES Node's default handling, so
+    // the response contract has to be preserved explicitly. If this breaks,
+    // a counter has silently become a behaviour change.
+    await withServer(async (port) => {
+      const reply = await rawExchange(port, (s) =>
+        s.write("NOT-HTTP \r\n\r\n"),
+      );
+      expect(reply).toContain("400 Bad Request");
+    });
+  });
+
+  it("answers 431 when headers overflow", async () => {
+    await withServer(
+      async (port) => {
+        const huge = "x".repeat(2000);
+        const reply = await rawExchange(port, (s) =>
+          s.write(`GET / HTTP/1.1\r\nHost: a\r\nX-Big: ${huge}\r\n\r\n`),
+        );
+        expect(reply).toContain("431");
+      },
+      { maxHeaderSize: 1024 },
+    );
+  });
+
+  it("counts a parse failure and reports it in one aggregated row", async () => {
+    await withServer(async (port) => {
+      await rawExchange(port, (s) => s.write("BAD REQUEST LINE\r\n\r\n"));
+    });
+
+    flushSocketStats();
+    expect(events).toHaveLength(1);
+    expect(events[0].name).toBe("http.socket.client_error");
+    expect(events[0].payload.total).toBeGreaterThan(0);
+    // Bucketed, never the raw code — cardinality must not track peer behaviour.
+    expect(Object.keys(events[0].payload).sort()).toEqual([
+      "econnaborted",
+      "econnreset",
+      "epipe",
+      "etimedout",
+      "headerOverflow",
+      "other",
+      "parseError",
+      "total",
+    ]);
+  });
+
+  it("aggregates a storm into a single row rather than one row per socket", async () => {
+    await withServer(async (port) => {
+      for (let i = 0; i < 12; i++) {
+        await rawExchange(port, (s) => s.write("GARBAGE\r\n\r\n"));
+      }
+    });
+
+    flushSocketStats();
+    expect(events).toHaveLength(1);
+    expect(events[0].payload.total).toBe(12);
+  });
+
+  it("emits nothing when there were no failures", () => {
+    flushSocketStats();
+    expect(events).toHaveLength(0);
+  });
+
+  it("resets counters after a flush so the next interval starts clean", async () => {
+    await withServer(async (port) => {
+      await rawExchange(port, (s) => s.write("GARBAGE\r\n\r\n"));
+    });
+    flushSocketStats();
+    events.length = 0;
+
+    flushSocketStats();
+    expect(events).toHaveLength(0);
+  });
+
+  it("does not throw when the peer is already gone", async () => {
+    // The socket can die between the writable check and the write. Throwing
+    // here would reach uncaughtException and take the process down over a
+    // dead connection.
+    await withServer(async (port) => {
+      await new Promise<void>((resolve) => {
+        const socket = net.connect(port, "127.0.0.1", () => {
+          socket.write("GARBAGE\r\n\r\n");
+          socket.destroy();
+          setTimeout(resolve, 50);
+        });
+        socket.on("error", () => resolve());
+      });
+    });
+    // Reaching here without an unhandled exception is the assertion.
+    expect(true).toBe(true);
+  });
+});

--- a/mcpjam-inspector/server/utils/log-events.ts
+++ b/mcpjam-inspector/server/utils/log-events.ts
@@ -203,6 +203,24 @@ export type SystemEventMap = {
   };
   "process.unhandled_rejection": { errorCode: string };
   "process.uncaught_exception": { errorCode: string };
+  /**
+   * Aggregated socket-level failure counters, one line per flush interval
+   * (see utils/socket-diagnostics.ts). These are connections that died before
+   * Node parsed a request line, so they produce NO `http.request.*` event —
+   * this is the only signal that they happened at all. Buckets are a fixed
+   * set, so cardinality cannot grow with traffic. Never emitted per socket:
+   * a reset storm must cost one row per interval, not one row per connection.
+   */
+  "http.socket.client_error": {
+    total: number;
+    econnreset: number;
+    epipe: number;
+    etimedout: number;
+    econnaborted: number;
+    parseError: number;
+    headerOverflow: number;
+    other: number;
+  };
   // Aggregated PostHog relay proxy counters, one line per flush interval
   // (see routes/relay.ts). Low-cardinality by construction; never emitted
   // per-request.

--- a/mcpjam-inspector/server/utils/socket-diagnostics.ts
+++ b/mcpjam-inspector/server/utils/socket-diagnostics.ts
@@ -1,0 +1,154 @@
+/**
+ * Socket-level failure counters for the HTTP server.
+ *
+ * Nothing in the server observes socket-level failures today. A connection
+ * that dies before Node parses a request line produces no request, no
+ * response, and therefore no `http.request.*` event — the request is simply
+ * absent from `inspector-logs`. That is the shape of the 2026-08-11 22:15:54
+ * incident: the user saw a Cloudflare 502 for `app.mcpjam.com` while this
+ * server was healthy and serving ~250 req/min, and no row described it.
+ *
+ * Without this counter that entire failure class is unfalsifiable in
+ * production — we can neither confirm nor rule it out, only speculate. A
+ * probe against Railway's proxy found no evidence of stale upstream sockets
+ * (48/48 clean, including non-retryable POSTs), which makes one specific
+ * theory unlikely but leaves the class itself unmeasured.
+ *
+ * Aggregated on the `relay.stats` precedent rather than emitted per event:
+ * a reset storm must cost one row per flush interval, not one row per socket.
+ * Error codes are bucketed to a fixed set so cardinality cannot grow with
+ * traffic or with whatever a peer does to us.
+ */
+import type { Socket } from "node:net";
+import { getSystemLogger } from "./request-logger.js";
+
+/**
+ * Only the capability we need. `serve()` returns a union of http/https/http2
+ * server types, and http2 emits `clientError` with a different socket type —
+ * depending on the concrete `node:http` Server would force a cast at the call
+ * site for no benefit.
+ */
+type ClientErrorEmitter = {
+  on(
+    event: "clientError",
+    listener: (err: NodeJS.ErrnoException, socket: Socket) => void,
+  ): unknown;
+};
+
+const FLUSH_INTERVAL_MS = 60_000;
+
+const socketLogger = getSystemLogger("http.socket");
+
+/**
+ * Fixed bucket set. Anything unrecognized becomes `other` — never the raw
+ * code — so a peer cannot inflate cardinality by producing novel errors.
+ */
+type ResetBucket =
+  | "econnreset"
+  | "epipe"
+  | "etimedout"
+  | "econnaborted"
+  | "parse_error"
+  | "header_overflow"
+  | "other";
+
+const stats: Record<ResetBucket, number> & { total: number } = {
+  econnreset: 0,
+  epipe: 0,
+  etimedout: 0,
+  econnaborted: 0,
+  parse_error: 0,
+  header_overflow: 0,
+  other: 0,
+  total: 0,
+};
+
+function bucketFor(err: NodeJS.ErrnoException): ResetBucket {
+  const code = err?.code ?? "";
+  switch (code) {
+    case "ECONNRESET":
+      return "econnreset";
+    case "EPIPE":
+      return "epipe";
+    case "ETIMEDOUT":
+      return "etimedout";
+    case "ECONNABORTED":
+      return "econnaborted";
+    case "HPE_HEADER_OVERFLOW":
+      return "header_overflow";
+    default:
+      // llhttp parse failures all share the HPE_ prefix; collapsing them keeps
+      // a malformed-request flood from becoming a wide column set.
+      return code.startsWith("HPE_") ? "parse_error" : "other";
+  }
+}
+
+export function flushSocketStats(): void {
+  if (stats.total === 0) return;
+  socketLogger.event("http.socket.client_error", {
+    total: stats.total,
+    econnreset: stats.econnreset,
+    epipe: stats.epipe,
+    etimedout: stats.etimedout,
+    econnaborted: stats.econnaborted,
+    parseError: stats.parse_error,
+    headerOverflow: stats.header_overflow,
+    other: stats.other,
+  });
+  stats.econnreset = 0;
+  stats.epipe = 0;
+  stats.etimedout = 0;
+  stats.econnaborted = 0;
+  stats.parse_error = 0;
+  stats.header_overflow = 0;
+  stats.other = 0;
+  stats.total = 0;
+}
+
+/**
+ * Reproduces Node's built-in `clientError` response.
+ *
+ * Attaching any `clientError` listener REPLACES Node's default handling —
+ * `_http_server` only runs its own logic when `emit()` reports no listeners.
+ * So observing this event means owning the response, and getting it wrong
+ * turns a counter into a behaviour change. This mirrors the documented
+ * default: 431 for header overflow, 400 otherwise, and an immediate destroy
+ * when the socket cannot be written to.
+ */
+function respondLikeNodeDefault(
+  err: NodeJS.ErrnoException,
+  socket: Socket,
+): void {
+  if (!socket.writable || socket.destroyed) {
+    socket.destroy();
+    return;
+  }
+  const status =
+    err?.code === "HPE_HEADER_OVERFLOW"
+      ? "431 Request Header Fields Too Large"
+      : "400 Bad Request";
+  try {
+    socket.end(`HTTP/1.1 ${status}\r\nConnection: close\r\n\r\n`);
+  } catch {
+    // The peer can vanish between the writable check and the write. This
+    // handler must never throw: an exception here reaches `uncaughtException`
+    // and takes the process down over a dead socket.
+    socket.destroy();
+  }
+}
+
+/**
+ * Count socket-level failures on the HTTP server.
+ *
+ * Safe to call once at startup. Idempotent per server instance.
+ */
+export function attachSocketDiagnostics(server: ClientErrorEmitter): void {
+  server.on("clientError", (err: NodeJS.ErrnoException, socket: Socket) => {
+    stats[bucketFor(err)]++;
+    stats.total++;
+    respondLikeNodeDefault(err, socket);
+  });
+}
+
+// Unref'd so this timer never holds the process open during shutdown.
+setInterval(flushSocketStats, FLUSH_INTERVAL_MS).unref();


### PR DESCRIPTION
## Why

A connection that dies before Node parses a request line produces no request, no response, and therefore no `http.request.*` event. It is simply **absent** from `inspector-logs`.

That is the shape of the 2026-08-11 22:15:54 incident: a user on a live call saw a Cloudflare 502 for `app.mcpjam.com` while this server was healthy and serving ~250 req/min, and no row anywhere described it.

Nothing in the server observes `clientError`, so this entire failure class is currently **unfalsifiable in production** — we can neither confirm nor rule it out, only speculate. The only reason the recent investigation could probe it at all is that staging happened to be reachable directly via its Railway domain, which is not a control we can depend on.

## What this is not

This does **not** claim to fix the 502s, and it deliberately does not change any timeout.

A keep-alive mismatch was the leading theory (Railway documents a 60s idle policy for HTTP/1.1 connections; Node closes idle keep-alive sockets at ~6s). It was tested directly against Railway's proxy on staging — warm the pool, idle past Node's close, force a request over the pooled socket, sweeping 3–30s — and came back **48/48 clean**, including 24 non-retryable POSTs (Envoy retries idempotent requests, so a GET-only result would have proven nothing). That evidence does not support the theory, so no timeout change is included here.

What survives is the observability gap, which is worth closing on its own merits.

## Design

**Aggregated, not per-event.** Modeled on the existing `relay.stats` precedent: a module-level counter flushed on an `unref()`'d 60s interval, no-op when empty. A reset storm costs one row per minute, not one row per socket.

**Fixed cardinality.** Error codes collapse into a closed bucket set (`econnreset`, `epipe`, `etimedout`, `econnaborted`, `parse_error`, `header_overflow`, `other`). All `HPE_*` parse failures share one bucket, so a peer cannot grow the column set by producing novel malformed requests.

## The one risky part, called out for review

**Attaching a `clientError` listener replaces Node's default handling.** `_http_server` only runs its own logic when `emit()` reports no listeners, so observing this event means owning the response — and getting it wrong turns a counter into a silent behavior change.

`respondLikeNodeDefault` reproduces the documented default: 431 on `HPE_HEADER_OVERFLOW`, 400 otherwise, immediate destroy when the socket is not writable. It also never throws — an exception in this handler would reach `uncaughtException` and take the process down over a dead socket.

Two tests cover that contract specifically, and I verified they **fail** when the handler is broken (both assert an empty reply instead of 400/431), so they are not passing vacuously.

## Testing

7 tests, all passing: response contract (400 and 431), bucketing, single-row aggregation of a 12-socket storm, no-op on empty, counter reset after flush, and no-throw when the peer is already gone.

Two unrelated tests in `server/utils/__tests__/logger.test.ts` fail on this branch. I verified they fail identically with this PR's shared-file edits reverted to `origin/main`, so they are **pre-existing** and not caused by this change.

## After deploy

`http.socket.client_error` becomes queryable in `inspector-logs`. If `econnreset` is materially non-zero in production, the keep-alive theory deserves a second look despite the staging result — and if it stays at zero, that class can finally be ruled out with evidence instead of argument.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Attaching a `clientError` listener replaces Node’s default handling, so a buggy response path could change client-facing 400/431 behavior or crash the process. Mitigated by mirroring Node’s defaults and covering that contract in tests.
> 
> **Overview**
> Adds **aggregated socket-level failure telemetry** so connections that die before Node parses a request line are no longer invisible in `inspector-logs` (the failure class behind the 08-11 Cloudflare 502).
> 
> New `socket-diagnostics` module listens for `clientError`, buckets errors into a fixed low-cardinality set (`econnreset`, `epipe`, `parseError`, etc.), and flushes a single `http.socket.client_error` row every 60s — same aggregation pattern as `relay.stats`. Because attaching a listener replaces Node’s default handling, it also reimplements the default 400/431 response and never throws on a dead peer.
> 
> Wired into the standalone server startup in `index.ts`, with tests covering response contract, storm aggregation, and no-throw behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 972d12defe459d587e57d100004b86d0ac3ee515. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add socket-level failure diagnostics so connection errors that occur before Node parses a request are counted and visible. Improves incident visibility for 502s without changing timeouts or request handling.

- **New Features**
  - Attach a `clientError` listener and preserve Node’s default replies (400; 431 on header overflow).
  - Aggregate counts into fixed buckets and flush every 60s; one row per interval.
  - Emit `http.socket.client_error` to `inspector-logs`.
  - Add tests for response contract, bucketing, aggregation, no-op when empty, counter reset, and peer-gone safety.

<sup>Written for commit 972d12defe459d587e57d100004b86d0ac3ee515. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/MCPJam/inspector/pull/3900?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

