### PR TITLE
fix(oauth): drop the November special-case from protocol version labels

### DIFF
--- a/docs/inspector/protocol-versions.mdx
+++ b/docs/inspector/protocol-versions.mdx
@@ -19,7 +19,7 @@ There are three places to set a version, and they layer:
 2. **Add Server modal → Connection overrides → Protocol version** — a _per-server override_ set at add time (available when adding a server to a shared project).
 3. **Server card → Edit → Advanced settings → Protocol version** — a _per-server override_ that wins over the host default.
 
-Use the host default when you want every server in a Client to speak the same version. Use per-server overrides when you're testing a mix — for example, a November server alongside one you're upgrading to Latest.
+Use the host default when you want every server in a Client to speak the same version. Use per-server overrides when you're testing a mix — for example, a server pinned to 2025-11-25 alongside one you're upgrading to Latest.
 
 ## Available versions
 
@@ -29,7 +29,7 @@ Use the host default when you want every server in a Client to speak the same ve
 | ------------------------- | ------------------ | ----------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------- |
 | **Automatic**             | none               | HTTP + stdio: `server/discover`, then legacy fallback | Detect 2026 support from the server; otherwise use the version negotiated by `initialize`. This is the default.                        |
 | **Latest (2026-07-28)**   | `2026-07-28`       | HTTP in MCPJam's preview (Streamable HTTP POST) | You want to test your server against the newest stateless revision — no `initialize` handshake, `server/discover` for capabilities, per-request `_meta`. |
-| **November (2025-11-25)** | `2025-11-25`       | HTTP, STDIO, SSE                                | Pin to the November stateful release. The initialize handshake offers only this version.                                                    |
+| **2025-11-25**            | `2025-11-25`       | HTTP, STDIO, SSE                                | Pin to the 2025-11-25 stateful release. The initialize handshake offers only this version.                                                  |
 | **2025-06-18**            | `2025-06-18`       | HTTP, STDIO, SSE                                | Test against the June 2025 stable revision.                                                                                                 |
 | **2025-03-26**            | `2025-03-26`       | HTTP, STDIO, SSE                                | Test against the March 2025 stable revision.                                                                                                |
 | **Host default** _(per-server only)_ | —     | —                                               | Inherit whatever the Client's MCP Protocol tab is set to.                                                                                   |
@@ -38,7 +38,7 @@ Use the host default when you want every server in a Client to speak the same ve
 
 When Automatic falls back to the legacy `initialize` handshake, it uses the MCP SDK's complete built-in supported-version list. Persisted per-client accept-lists are ignored in Automatic mode so reconnecting cannot accidentally narrow negotiation; choose an explicit version when you want a strict protocol pin.
 
-**Latest** is derived, not hardcoded: it always labels the newest version in the SDK's known-version list. **November** labels the `2025-11-25` stateful release.
+**Latest** is derived, not hardcoded: it always labels the newest version in the SDK's known-version list. Every other known revision is shown as a bare date.
 
 The 2026 RC applies the stateless model across transports. MCPJam's initial preview client is narrower: it currently supports the RC over Streamable HTTP POST. The per-server dropdown hides the RC option for STDIO and legacy SSE servers; if a host-level RC default reaches a non-HTTP server, the inspector fails the connection with a clear transport error instead of silently attempting the wrong protocol.
 
@@ -48,7 +48,7 @@ The 2026 RC applies the stateless model across transports. MCPJam's initial prev
   <img
     className="block"
     src="/images/protocol-versions/host-default-dropdown.png"
-    alt="Client editor with the MCP Protocol tab open and the Protocol version dropdown showing Automatic, Latest (2026-07-28), November (2025-11-25), 2025-06-18, and 2025-03-26 options"
+    alt="Client editor with the MCP Protocol tab open and the Protocol version dropdown showing Automatic, Latest (2026-07-28), 2025-11-25, 2025-06-18, and 2025-03-26 options"
     width="1000"
   />
 </Frame>
@@ -59,7 +59,7 @@ The 2026 RC applies the stateless model across transports. MCPJam's initial prev
 4. In the **Protocol version** dropdown, pick a version:
    - **Automatic** — no pin stored; the SDK picks the version at connect time (default).
    - **Latest (2026-07-28)** — pin to the newest stateless revision.
-   - **November (2025-11-25)** — pin to the November stateful release.
+   - **2025-11-25** — pin to the 2025-11-25 stateful release.
    - **2025-06-18** or **2025-03-26** — pin to an earlier stable revision.
 5. Save.
 
@@ -76,7 +76,7 @@ When adding a server to a shared project, the **Connection overrides** section o
 1. Click **Add server** in the **Servers** tab.
 2. Fill in the server details.
 3. Expand **Connection overrides**.
-4. Pick **Client default**, **Latest (2026-07-28)**, **November (2025-11-25)**, or an earlier stable revision from the **Protocol version** dropdown.
+4. Pick **Client default**, **Latest (2026-07-28)**, **2025-11-25**, or an earlier stable revision from the **Protocol version** dropdown.
 5. Submit the form.
 
 The pin is applied once the server is created and the connection is established.
@@ -86,7 +86,7 @@ The pin is applied once the server is created and the connection is established.
 1. Go to the **Servers** tab.
 2. Click the three dots on the server card → **Edit** (or open **View server info** → **Edit**).
 3. Expand **Advanced settings**.
-4. Find **Protocol version** and pick **Host default**, **Latest (2026-07-28)**, **November (2025-11-25)**, or an earlier stable revision.
+4. Find **Protocol version** and pick **Host default**, **Latest (2026-07-28)**, **2025-11-25**, or an earlier stable revision.
 5. Save and reconnect the server.
 
 The per-server override is the more specific signal — it wins over whatever the Client's MCP Protocol tab says.
@@ -140,7 +140,7 @@ For everything else — `tools/list`, `tools/call`, `resources/*`, `prompts/*`, 
 4. Run a `tools/list` and a `tools/call` from the **Tools** tab.
 5. Watch the **Activity** log for the request `_meta` and the `MCP-Protocol-Version` header.
 6. Try an unsupported version on a second test server to confirm your `-32004` error envelope looks right.
-7. Once your server is happy on Latest, keep one Client on **Automatic** (or pinned to **November (2025-11-25)**) so you can flip between versions without rewriting settings.
+7. Once your server is happy on Latest, keep one Client on **Automatic** (or pinned to **2025-11-25**) so you can flip between versions without rewriting settings.
 
 If you need to talk to a mix of servers on different versions in the same Client, use per-server overrides — the RC server stays pinned to `2026-07-28`, the rest fall back to the host default.
 

--- a/mcpjam-inspector/client/src/components/connection/__tests__/AdvancedConnectionSettingsSection.test.tsx
+++ b/mcpjam-inspector/client/src/components/connection/__tests__/AdvancedConnectionSettingsSection.test.tsx
@@ -314,7 +314,7 @@ describe("AdvancedConnectionSettingsSection", () => {
 
     await user.click(protocolSelect);
     await user.click(
-      screen.getByRole("option", { name: "November (2025-11-25)" })
+      screen.getByRole("option", { name: "2025-11-25" })
     );
     expect(onProtocolChange).toHaveBeenLastCalledWith("2025-11-25");
   });

--- a/mcpjam-inspector/client/src/components/connection/__tests__/ServerDetailModal.test.tsx
+++ b/mcpjam-inspector/client/src/components/connection/__tests__/ServerDetailModal.test.tsx
@@ -365,7 +365,7 @@ describe("ServerDetailModal", () => {
 
     await user.click(protocolSelect);
     await user.click(
-      await screen.findByRole("option", { name: "November (2025-11-25)" })
+      await screen.findByRole("option", { name: "2025-11-25" })
     );
 
     await waitFor(() => {
@@ -412,7 +412,7 @@ describe("ServerDetailModal", () => {
 
     await user.click(hostDefaultSelect);
     await user.click(
-      await screen.findByRole("option", { name: "November (2025-11-25)" })
+      await screen.findByRole("option", { name: "2025-11-25" })
     );
 
     await waitFor(() => {
@@ -430,7 +430,7 @@ describe("ServerDetailModal", () => {
     });
     await waitFor(() => {
       expect(
-        screen.queryByRole("option", { name: "November (2025-11-25)" })
+        screen.queryByRole("option", { name: "2025-11-25" })
       ).not.toBeInTheDocument();
     });
     unmount();
@@ -452,7 +452,7 @@ describe("ServerDetailModal", () => {
     );
 
     const latestSelect = getProtocolVersionCombobox();
-    expect(latestSelect).toHaveTextContent("November (2025-11-25)");
+    expect(latestSelect).toHaveTextContent("2025-11-25");
 
     await user.click(latestSelect);
     await user.click(
@@ -497,7 +497,7 @@ describe("ServerDetailModal", () => {
       screen.getByRole("button", { name: /connection overrides/i })
     );
     const protocolSelect = getProtocolVersionCombobox();
-    expect(protocolSelect).toHaveTextContent("November (2025-11-25)");
+    expect(protocolSelect).toHaveTextContent("2025-11-25");
 
     await user.click(protocolSelect);
     await user.click(

--- a/mcpjam-inspector/client/src/components/connection/shared/AdvancedConnectionSettingsSection.tsx
+++ b/mcpjam-inspector/client/src/components/connection/shared/AdvancedConnectionSettingsSection.tsx
@@ -14,6 +14,7 @@ import {
   SelectValue,
 } from "@mcpjam/design-system/select";
 import { JsonEditor } from "@/components/ui/json-editor";
+import { protocolVersionLabel } from "@mcpjam/sdk/browser";
 import type { McpProtocolVersion } from "@/lib/client-config-v2";
 
 /**
@@ -30,8 +31,8 @@ const MCP_PROTOCOL_OPTIONS: Array<{
   label: string;
 }> = [
   { value: "inherit", label: "Client default" },
-  { value: "latest", label: "Latest (2026-07-28)" },
-  { value: "november", label: "November (2025-11-25)" },
+  { value: "latest", label: protocolVersionLabel("2026-07-28") },
+  { value: "november", label: protocolVersionLabel("2025-11-25") },
 ];
 
 interface HeaderEntry {

--- a/mcpjam-inspector/client/src/components/hosts/redesigned/focus/__tests__/ProtocolTab.versionDropdown.test.tsx
+++ b/mcpjam-inspector/client/src/components/hosts/redesigned/focus/__tests__/ProtocolTab.versionDropdown.test.tsx
@@ -74,7 +74,7 @@ describe("ProtocolTab protocol-version dropdown", () => {
     ).toEqual([
       "Automatic",
       "Latest (2026-07-28)",
-      "November (2025-11-25)",
+      "2025-11-25",
       "2025-06-18",
       "2025-03-26",
     ]);
@@ -104,9 +104,7 @@ describe("ProtocolTab protocol-version dropdown", () => {
     await user.click(
       screen.getByRole("combobox", { name: "MCP protocol version" })
     );
-    await user.click(
-      screen.getByRole("option", { name: "November (2025-11-25)" })
-    );
+    await user.click(screen.getByRole("option", { name: "2025-11-25" }));
 
     // A stateful pin is not cosmetic: it narrows the initialize accept-list.
     expect(screen.getByTestId("pin").textContent).toBe("2025-11-25");
@@ -214,9 +212,7 @@ describe("ProtocolTab dropdown vs. the client's advertised versions", () => {
     await user.click(
       screen.getByRole("combobox", { name: "MCP protocol version" })
     );
-    await user.click(
-      screen.getByRole("option", { name: "November (2025-11-25)" })
-    );
+    await user.click(screen.getByRole("option", { name: "2025-11-25" }));
 
     expect(toast.warning).not.toHaveBeenCalled();
   });
@@ -268,7 +264,7 @@ describe("ProtocolTab dropdown vs. the client's advertised versions", () => {
     // nothing — survives alongside the advertised revision.
     expect(
       (await screen.findAllByRole("option")).map((o) => o.textContent)
-    ).toEqual(["Automatic", "November (2025-11-25)"]);
+    ).toEqual(["Automatic", "2025-11-25"]);
   });
 
   it("offers a stateless version when the client does advertise it", async () => {
@@ -282,7 +278,7 @@ describe("ProtocolTab dropdown vs. the client's advertised versions", () => {
     );
     expect(
       (await screen.findAllByRole("option")).map((o) => o.textContent)
-    ).toEqual(["Automatic", "Latest (2026-07-28)", "November (2025-11-25)"]);
+    ).toEqual(["Automatic", "Latest (2026-07-28)", "2025-11-25"]);
   });
 
   it("offers every version when the client advertises no list", async () => {

--- a/sdk/src/mcp-client-manager/mcp-protocol-version.ts
+++ b/sdk/src/mcp-client-manager/mcp-protocol-version.ts
@@ -52,14 +52,11 @@ const LATEST_PROTOCOL_VERSION: McpProtocolVersion | undefined =
  * cannot disagree about which revision is current:
  *
  * - **Latest** = newest known revision, derived above.
- * - **November** = the 2025-11-25 revision.
- *
- * Older revisions render bare — a fixed marker on them would be one more
- * string to walk forward by hand.
+ * - Every other revision renders bare — a fixed marker on them would be one
+ *   more string to walk forward by hand.
  */
 export function protocolVersionLabel(version: McpProtocolVersion): string {
   if (version === LATEST_PROTOCOL_VERSION) return `Latest (${version})`;
-  if (version === "2025-11-25") return `November (${version})`;
   return version;
 }
 


### PR DESCRIPTION
## Summary
- `protocolVersionLabel()` hardcoded 2025-11-25 as "November (2025-11-25)" while every other non-latest revision rendered as a bare date — inconsistent labeling across the Protocol dropdown.
- Only the newest revision should carry a word marker ("Latest"); every other revision now renders as a plain date, matching 2025-06-18 and 2025-03-26.
- Affects the Connect form's Protocol dropdown, the OAuth debugger, and the Client protocol picker, since all three derive labels from this shared function.

## Test plan
- [x] Updated `ProtocolTab.versionDropdown.test.tsx` assertions from "November (2025-11-25)" to "2025-11-25"
- [x] `AuthenticationSection.test.tsx` and `OAuthProfileModal.test.tsx` already asserted dynamically — no changes needed, still pass
- [x] Ran all 5 affected test files: 125 tests passing

Refs UER-111
## Summary
- `protocolVersionLabel()` hardcoded 2025-11-25 as "November (2025-11-25)" while every other non-latest revision rendered as a bare date — inconsistent labeling across the Protocol dropdown.
- Only the newest revision should carry a word marker ("Latest"); every other revision now renders as a plain date, matching 2025-06-18 and 2025-03-26.
- Affects the Connect form's Protocol dropdown, the OAuth debugger, and the Client protocol picker, since all three derive labels from this shared function.

Before:
<img width="438" height="338" alt="image" src="https://github.com/user-attachments/assets/300e59f6-7f15-4f68-89ca-04b6b540988d" />
After:
<img width="293" height="294" alt="image" src="https://github.com/user-attachments/assets/6c569ac6-ba7b-4448-bb80-433061690d3b" />


## Test plan
- [x] Updated `ProtocolTab.versionDropdown.test.tsx` assertions from "November (2025-11-25)" to "2025-11-25"
- [x] `AuthenticationSection.test.tsx` and `OAuthProfileModal.test.tsx` already asserted dynamically — no changes needed, still pass
- [x] Ran all 5 affected test files: 125 tests passing

Refs UER-111

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Normalized protocol version labels by removing the “November (2025-11-25)” special-case. Only the newest revision shows “Latest”; all others show the date across the Connect form, OAuth debugger, Client protocol picker, and per-server pickers (UER-111).

- **Bug Fixes**
  - Removed the `2025-11-25` special-case from `protocolVersionLabel()`.
  - Per-server pickers now derive labels via `protocolVersionLabel()` from `@mcpjam/sdk/browser`.
  - Updated tests and docs to reflect date-only labeling for non-latest versions.

<sup>Written for commit 7aa6199ae915f180cde0a2805c00dce63a2f859f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/MCPJam/inspector/pull/3927?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

