### PR TITLE
fix(web): report the effective error origin, not the declared catalog value

### DIFF
--- a/mcpjam-inspector/server/routes/web/__tests__/effective-origin.test.ts
+++ b/mcpjam-inspector/server/routes/web/__tests__/effective-origin.test.ts
@@ -72,8 +72,15 @@ describe("effective origin propagation", () => {
     );
     routeError.origin = origin;
 
+    // Route it back through mapRuntimeError before serializing, which is what
+    // a throw/catch path actually does. That call passes no boundary, so its
+    // own decision can only reproduce the declared `ambiguous`; remapping must
+    // preserve the promotion rather than reset it.
+    const mapped = mapRuntimeError(routeError);
+    expect(mapped.origin).toBe("mcpjam");
+
     const c = fakeContext();
-    webErrorFromRoute(c as never, routeError);
+    webErrorFromRoute(c as never, mapped);
 
     expect((c.vars.webErrorMeta as { origin?: string }).origin).toBe("mcpjam");
   });

--- a/mcpjam-inspector/server/routes/web/__tests__/effective-origin.test.ts
+++ b/mcpjam-inspector/server/routes/web/__tests__/effective-origin.test.ts
@@ -1,0 +1,136 @@
+import { describe, expect, it, vi } from "vitest";
+
+vi.mock("@sentry/node", () => ({
+  captureException: vi.fn(),
+  captureMessage: vi.fn(),
+}));
+
+import { originOf } from "@mcpjam/sdk";
+import { reportRouteFailure } from "../../../utils/route-error-report.js";
+import {
+  ErrorCode,
+  WebRouteError,
+  mapRuntimeError,
+  webErrorFromRoute,
+} from "../errors.js";
+
+/**
+ * The effective origin must survive from the capture decision all the way to
+ * `webErrorMeta`, which is what `http.request.failed` reads.
+ *
+ * Before this, `webError` recomputed `originOf(normalized)` at serialization
+ * time — the DECLARED catalog value. A failure reported through an
+ * `mcpjam_internal` boundary is promoted to `mcpjam` and pages Sentry, but its
+ * catalog slug is usually `ambiguous`, so the Axiom row said `ambiguous` for a
+ * failure we had just paged ourselves for. That drift is why `origin=mcpjam`
+ * never appeared in 30 days of production data, and why the MCPJam-fault
+ * monitor had nothing to gate on.
+ */
+function fakeContext() {
+  const vars: Record<string, unknown> = {};
+  return {
+    set: (k: string, v: unknown) => {
+      vars[k] = v;
+    },
+    json: (body: unknown, status: number, headers?: Record<string, string>) => ({
+      body,
+      status,
+      headers,
+    }),
+    vars,
+  };
+}
+
+describe("effective origin propagation", () => {
+  it("carries the promoted origin from mapRuntimeError onto the error", () => {
+    // A generic internal failure: the catalog cannot classify it, so it
+    // resolves `internal/unknown` -> declared `ambiguous`.
+    const routeError = mapRuntimeError(new TypeError("x is not a function"));
+    expect(originOf(routeError.normalized)).toBe("ambiguous");
+    // Nothing declared an internal boundary here, so effective === declared.
+    expect(routeError.origin).toBe("ambiguous");
+  });
+
+  it("reports the EFFECTIVE origin in webErrorMeta, not the declared one", () => {
+    // Reproduce the drift: a route reports through an internal boundary, which
+    // promotes an ambiguous catalog result to `mcpjam`.
+    const raw = new TypeError("cannot read properties of undefined");
+    const { normalized, origin } = reportRouteFailure("internal blew up", raw, {
+      source: "test.internal",
+      hop: "mcpjam_internal",
+    });
+    expect(origin).toBe("mcpjam");
+    // The declared catalog value disagrees — this is the whole bug.
+    expect(originOf(normalized)).toBe("ambiguous");
+
+    const routeError = new WebRouteError(
+      500,
+      ErrorCode.INTERNAL_ERROR,
+      "internal blew up",
+      undefined,
+      normalized,
+    );
+    routeError.origin = origin;
+
+    const c = fakeContext();
+    webErrorFromRoute(c as never, routeError);
+
+    expect((c.vars.webErrorMeta as { origin?: string }).origin).toBe("mcpjam");
+  });
+
+  it("puts the effective origin on the response body and header too", () => {
+    const raw = new TypeError("boom");
+    const { normalized, origin } = reportRouteFailure("boom", raw, {
+      source: "test.internal",
+      hop: "mcpjam_internal",
+    });
+    const routeError = new WebRouteError(
+      500,
+      ErrorCode.INTERNAL_ERROR,
+      "boom",
+      undefined,
+      normalized,
+    );
+    routeError.origin = origin;
+
+    const c = fakeContext();
+    const res = webErrorFromRoute(c as never, routeError) as unknown as {
+      body: { origin?: string };
+      headers?: Record<string, string>;
+    };
+
+    // The header matters independently: the AI SDK consumes the Response into
+    // `new Error(await response.text())`, so the chat client's reporter sees
+    // only status unless the attribution rides in a header.
+    expect(res.body.origin).toBe("mcpjam");
+    expect(res.headers?.["x-mcpjam-error-origin"]).toBe("mcpjam");
+  });
+
+  it("falls back to the declared origin when nothing made a capture decision", () => {
+    // A hand-built WebRouteError that never went through mapRuntimeError has no
+    // effective origin. The declared value is then the best available answer,
+    // and must still be reported rather than dropped.
+    const routeError = mapRuntimeError(
+      new Error("connect ECONNREFUSED 127.0.0.1:8080"),
+    );
+    const declared = originOf(routeError.normalized);
+    routeError.origin = undefined;
+
+    const c = fakeContext();
+    webErrorFromRoute(c as never, routeError);
+
+    expect((c.vars.webErrorMeta as { origin?: string }).origin).toBe(declared);
+    expect(declared).toBe("user_config");
+  });
+
+  it("does not promote a failure with positive user-server evidence", () => {
+    // The boundary declaration must never overrule real evidence: an
+    // ECONNREFUSED that reached an internal hop is still the user's config.
+    const { origin } = reportRouteFailure(
+      "refused",
+      new Error("connect ECONNREFUSED 127.0.0.1:8080"),
+      { source: "test.internal", hop: "mcpjam_internal" },
+    );
+    expect(origin).toBe("user_config");
+  });
+});

--- a/mcpjam-inspector/server/routes/web/errors.ts
+++ b/mcpjam-inspector/server/routes/web/errors.ts
@@ -314,7 +314,13 @@ export function mapRuntimeError(error: unknown): WebRouteError {
       source: "web.mapRuntimeError",
       extra: { status: error.status, code: error.code },
     });
-    error.origin = decision.origin;
+    // Never downgrade an origin that is already set. This call passes no
+    // `boundary`, so its decision can only ever reproduce the DECLARED catalog
+    // value — remapping an error whose origin was already promoted at an
+    // `mcpjam_internal` hop would otherwise reset `mcpjam` back to `ambiguous`,
+    // undoing the promotion on the way to the serializer. The caller that
+    // declared the boundary knew the hop; this one does not.
+    error.origin = error.origin ?? decision.origin;
     return error;
   }
 

--- a/mcpjam-inspector/server/routes/web/errors.ts
+++ b/mcpjam-inspector/server/routes/web/errors.ts
@@ -3,6 +3,7 @@ import {
   describeError,
   isUnauthorized401,
   originOf,
+  type ErrorOrigin,
   type NormalizedError,
 } from "@mcpjam/sdk";
 import { extractInsufficientScopeChallenge } from "../../utils/mcp-error-serialize.js";
@@ -89,6 +90,21 @@ export class WebRouteError extends Error {
    * rich ErrorCard without re-classifying from the raw message.
    */
   normalized?: NormalizedError;
+  /**
+   * The EFFECTIVE origin — the catalog value after any internal-boundary
+   * promotion, i.e. the same value the Sentry capture decision used.
+   *
+   * Distinct from `originOf(this.normalized)`, which is only the DECLARED
+   * catalog value. A route that reports through an `mcpjam_internal` boundary
+   * gets `mcpjam` back and pages Sentry, but the catalog slug underneath is
+   * usually `ambiguous`; recomputing from `normalized` at serialization time
+   * silently reports `ambiguous` for a failure we just paged ourselves for.
+   * That drift is why `origin=mcpjam` never appeared in Axiom.
+   *
+   * Populated by `mapRuntimeError`. Absent when nothing made a capture
+   * decision, in which case the declared value is the best available answer.
+   */
+  origin?: ErrorOrigin;
 
   constructor(
     status: number,
@@ -116,10 +132,21 @@ export function webError(
   // `extras` is permissive (rpc-log collectors, etc.). If it carries a
   // `normalized` key, hoist it to the top-level response body — clients
   // pluck the rich block off the JSON envelope without re-classifying.
-  const { normalized, ...restExtras } = (extras ?? {}) as Record<
-    string,
-    unknown
-  > & { normalized?: NormalizedError };
+  const {
+    normalized,
+    effectiveOrigin,
+    ...restExtras
+  } = (extras ?? {}) as Record<string, unknown> & {
+    normalized?: NormalizedError;
+    effectiveOrigin?: ErrorOrigin;
+  };
+  // Prefer the effective origin (post internal-boundary promotion) over the
+  // declared catalog value. `originOf(normalized)` alone reports `ambiguous`
+  // for failures Sentry was just paged for as `mcpjam`, which made
+  // `origin=mcpjam` unreachable in Axiom and left M2 with nothing to gate on.
+  const reportedOrigin = normalized
+    ? (effectiveOrigin ?? originOf(normalized))
+    : effectiveOrigin;
   // Stash the real code/message for `requestLogContextMiddleware`. A route that
   // *returns* an error response (rather than throwing) leaves the middleware
   // with nothing but a status code, so every such 5xx used to log as the
@@ -135,9 +162,8 @@ export function webError(
       status,
       code,
       message,
-      ...(normalized
-        ? { origin: originOf(normalized), slug: normalized.slug }
-        : {}),
+      ...(reportedOrigin ? { origin: reportedOrigin } : {}),
+      ...(normalized ? { slug: normalized.slug } : {}),
     });
   }
   return c.json(
@@ -146,7 +172,8 @@ export function webError(
       code,
       message,
       ...(details ? { details } : {}),
-      ...(normalized ? { normalized, origin: originOf(normalized) } : {}),
+      ...(normalized ? { normalized } : {}),
+      ...(reportedOrigin ? { origin: reportedOrigin } : {}),
     },
     status,
     // Also a HEADER, because the body does not always survive to the reader
@@ -156,7 +183,7 @@ export function webError(
     // page us for a user's own MCP server. `/api/web/chat-v2` is the primary
     // hosted chat path, so putting this on `webError` rather than on one
     // route covers every `/api/web/*` envelope at once.
-    normalized ? { "x-mcpjam-error-origin": originOf(normalized) } : undefined
+    reportedOrigin ? { "x-mcpjam-error-origin": reportedOrigin } : undefined
   );
 }
 
@@ -187,6 +214,9 @@ export function webErrorFromRoute(
     {
       ...(extras ?? {}),
       ...(routeError.normalized ? { normalized: routeError.normalized } : {}),
+      // Forward the effective origin. Without this the promotion survives all
+      // the way to the serializer and is then thrown away at the last step.
+      ...(routeError.origin ? { effectiveOrigin: routeError.origin } : {}),
     }
   );
 }
@@ -277,19 +307,24 @@ export function mapRuntimeError(error: unknown): WebRouteError {
     if (!error.normalized) {
       error.normalized = describeError(error);
     }
-    maybeCaptureOriginError(error, error.normalized, {
+    // Keep the EFFECTIVE origin the capture decision produced. Discarding it
+    // here is what forced serialization to fall back to the declared catalog
+    // value, so a promoted `mcpjam` failure logged as `ambiguous`.
+    const decision = maybeCaptureOriginError(error, error.normalized, {
       source: "web.mapRuntimeError",
       extra: { status: error.status, code: error.code },
     });
+    error.origin = decision.origin;
     return error;
   }
 
   const routeError = classifyRuntimeError(error);
   attachCause(routeError, error);
-  maybeCaptureOriginError(routeError, routeError.normalized, {
+  const decision = maybeCaptureOriginError(routeError, routeError.normalized, {
     source: "web.mapRuntimeError",
     extra: { status: routeError.status, code: routeError.code },
   });
+  routeError.origin = decision.origin;
   // Stamp the ORIGINAL as well. The cause link above makes the original
   // reachable from `routeError`, but the walk only goes that direction: a
   // handler that keeps its own reference and later calls `logger.error(error)`


### PR DESCRIPTION
## The symptom

`origin=mcpjam` has **never once appeared** in `inspector-logs` — zero rows in 30 days — despite roughly **38 call sites** declaring `hop: "mcpjam_internal"`.

So the monitor meant to page on MCPJam-fault failures had nothing to gate on. Worse than a missing measurement: the measurement was *reporting the wrong number*.

## The cause

Two places computed the origin and disagreed.

**`app.onError` gets it right** — it stashes the effective origin returned by `reportRouteFailure`, including the internal-boundary promotion. Its own comment names the hazard precisely:

> *"The EFFECTIVE origin, including the internal-boundary promotion — not `originOf(normalized)`, which would report `ambiguous` for a failure Sentry was just paged for as `mcpjam`."*

**`webError` did exactly that thing** — and it covers the whole `/api/web/*` surface. It recomputed `originOf(normalized)` at serialization time, which is only the *declared* catalog value. Meanwhile `mapRuntimeError` had the effective value in hand and discarded `maybeCaptureOriginError`'s return.

The result: a failure reported through an internal boundary is promoted to `mcpjam`, pages Sentry, and then logs `ambiguous` to Axiom. **Sentry and Axiom disagree about the same request**, and any aggregate over `origin` is unsound.

Most promotions apply to `ambiguous` catalog results — which is the largest bucket — so this wasn't an edge case. It was the common path.

## The change

The effective origin now travels as a field on `WebRouteError`, populated in `mapRuntimeError` where it was previously thrown away, and `webError` prefers it for:

- `webErrorMeta` → which is what `http.request.failed` reads
- the response body
- the `x-mcpjam-error-origin` header — which matters independently, because the AI SDK consumes the Response into `new Error(await response.text())`, leaving the chat client's reporter with only a status

It falls back to the declared value when nothing made a capture decision, so routes that never went through `mapRuntimeError` behave exactly as before.

## Tests

Five, covering both directions. The one I'd point a reviewer at is the **inverse** guarantee: an `ECONNREFUSED` that crossed an internal hop must **not** be promoted to `mcpjam` — a boundary declaration must never overrule positive user-server evidence. Getting that wrong would rebuild the noise problem this whole effort exists to remove.

I confirmed the tests catch the regression: reverting to the old recomputation fails with `expected 'ambiguous' to be 'mcpjam'` — literally the production symptom.

## Full-suite comparison

The server suite shows 111 failed files / 4 failed tests on this branch. **That is pre-existing.** I ran the same suite against unmodified `origin/main` in the same worktree:

| | Files failed | Tests failed | Tests passed |
| --- | --- | --- | --- |
| `origin/main` | 111 | 4 | 3,592 |
| this branch | 111 | 4 | **3,597** |

Identical failures, +5 passing (mine). The file-level failures are collection errors from a missing bundled build artifact (`./shim/PluginShim.bundled.js`), not assertions.

## Scope

This is the **first of C4's four contracts**. The other three — 4xx telemetry enrichment, a typed event for RPC-over-200 and SSE failures, and threading `credentialOwner` — are independent and each deserve their own review.

All three of them, and the MCPJam-fault monitor, depend on this one. Until it ships, `origin` in Axiom means two different things depending on which path produced the row.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes fault-attribution on every `/api/web/*` error path used by Axiom and client reporters. Incorrect origin reporting could misclassify MCPJam vs user-server failures in monitoring, though behavior is covered by targeted regression tests.
> 
> **Overview**
> Fixes a silent drift where `/api/web/*` error responses logged the **declared** catalog origin (`originOf(normalized)`) instead of the **effective** origin after `mcpjam_internal` promotion. That made promoted `mcpjam` failures page Sentry while Axiom recorded `ambiguous`, so `origin=mcpjam` never appeared in production logs.
> 
> `WebRouteError` now carries an `origin` field set by `mapRuntimeError`. `webError` / `webErrorFromRoute` prefer that value for `webErrorMeta`, the response body, and the `x-mcpjam-error-origin` header, falling back to the declared catalog value when no capture decision was made. Remapping an already-promoted error no longer downgrades it back to `ambiguous`.
> 
> Adds regression tests covering promotion, remapping preservation, header/body emission, declared fallback, and the inverse guarantee that positive user-server evidence is never overridden by an internal boundary.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 324a8a7c37428ee41bf4d72f5c36731cdef4b36a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->