### PR TITLE
ops(axiom): stop reporting a phantom update on every reconcile

### DIFF
--- a/ops/axiom-monitors/README.md
+++ b/ops/axiom-monitors/README.md
@@ -102,7 +102,18 @@ scalar in Slack, so their drill-down queries may have to carry the diagnosis.
 
 ## Fields this Axiom deployment may ignore
 
-`notifyByGroup`, `alertOnNoData`, and `notifyEveryRun` are sent but do not
-appear in the current API's monitor payload. After `--apply` the script reports
-any field the API did not persist. Treat such a report as real: `resolvable`
-silently dropped would turn a day-long incident into repeated notifications.
+`notifyByGroup`, `alertOnNoData`, and `notifyEveryRun` are sent but the API
+omits them from its response when they equal its defaults. After `--apply` the
+script reports any field the response did not echo.
+
+Measured when the PAGE monitors were first applied: **`resolvable` is
+persisted** on all three (it governs repeat notifications, so this is the one
+that mattered), and **`alertOnNoData: true` is persisted** on the deadman where
+it is non-default. The omissions are therefore default-elision, not unsupported
+fields.
+
+Because a field the API omits is not comparable, `diffFields` skips it. Without
+that, every re-run reported `update` for those three keys and buried real drift
+in permanent noise. The trade-off is that drift in exactly those fields cannot
+be detected — the API declines to report them — while everything it does echo,
+including `resolvable`, diffs normally.

--- a/ops/axiom-monitors/apply.mjs
+++ b/ops/axiom-monitors/apply.mjs
@@ -200,6 +200,18 @@ function desiredBody(def) {
 function diffFields(existing, desired) {
   const changed = [];
   for (const [k, v] of Object.entries(desired)) {
+    // A key the API omits entirely from its response is not comparable: we
+    // cannot know what it stored, so treating "absent" as "differs" reports a
+    // change on every run. This deployment omits notifyByGroup / alertOnNoData
+    // / notifyEveryRun when they equal its defaults, which made every re-run
+    // print `update` and buried real drift in permanent noise — exactly what
+    // the plan/diff step exists to surface.
+    //
+    // The cost is that drift in those specific fields is undetectable. That is
+    // a property of the API, not a choice: it declines to tell us. Fields it
+    // does echo — including `resolvable`, which governs repeat notifications —
+    // still diff normally.
+    if (!(k in existing)) continue;
     const before = existing[k];
     const same =
       Array.isArray(v) && Array.isArray(before)


### PR DESCRIPTION
## Context

The three PAGE monitors are **now live in Axiom** (org went 55 → 58 monitors, unmanaged ones untouched):

| Monitor | Rule | id |
| --- | --- | --- |
| 5xx rate | `Above 100` / 60m, every 15m | `iZF2rktfCxueLccUNU` |
| Error class spiking | `Above 0` / 14d, every 15m | `nK0rz2viqEypdo5Diu` |
| Typed telemetry deadman | `Below 1` / 15m, every 5m | `0BxS8CNStk3cr5ivT7` |

All three carry `resolvable: true` and route to `#mcpjam-alerts`. Pre-flight confirmed none would fire on enable: 121 typed events in the last 15m (deadman needs ≥1) and 5xx running at 5/hour against a threshold of 100.

## The bug this fixes

Applying them surfaced a flaw in the reconciler I shipped earlier. Every subsequent plan reported:

```
update  MCPJam Inspector 5xx rate (prod)
        changes: notifyByGroup, alertOnNoData, notifyEveryRun
```

…with no definition change at all.

The API omits those keys from its response when they equal its defaults, and `diffFields` treated *absent-from-response* as *differs*. So the plan/diff step — the safety mechanism whose entire job is showing what a write would do — reported a phantom change on every run. A real change would have been indistinguishable from the noise, and the README's claim that "re-running with no definition change is a no-op" was false.

## The fix

Skip keys the response does not include at all. A field the API declines to report is not comparable, so inferring a difference from its absence is wrong.

The trade-off, stated plainly in the README: drift in those three specific keys becomes undetectable. That's a property of the API rather than a choice — it won't tell us. Everything it *does* echo, including `resolvable`, diffs normally.

Verified both directions:
- three `no-op`s with no definition change
- a threshold edit still reports `changes: threshold`

## A correction to the earlier README

The previous note implied those fields might be **unsupported**. Measured during apply, that's wrong:

- **`resolvable` is persisted** on all three monitors — this is the one that mattered, since it governs whether a sustained incident posts once or repeatedly
- **`alertOnNoData: true` is persisted** on the deadman, where it is non-default

So the omissions are default-elision, not unsupported fields. The README now says so.

## Still not applied

The two WARN monitors (`inspector-4xx-storm`, `inspector-new-error-class`) remain unapplied — `AXIOM_NOTIFIER_MCPJAM_ALERTS_WARN` is deliberately unset, and the script hard-fails rather than silently pointing WARN at the page channel. That decision is unchanged: either a second Slack notifier without an on-call mention, or an explicit call to collapse the tiers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small reconciler/docs fix that only changes how absent API fields are compared; no auth, data, or write-path behavior changes beyond quieter no-op plans.
> 
> **Overview**
> Fixes the monitor reconciler so plan/diff no longer reports a phantom `update` on every run for `notifyByGroup`, `alertOnNoData`, and `notifyEveryRun`.
> 
> `diffFields` now skips keys the Axiom API omits entirely from its response (default-elision), instead of treating absence as a difference. Real drift in echoed fields — including `resolvable` — still diffs normally. The README corrects the earlier “unsupported fields” note and documents the trade-off that drift in those three omitted keys cannot be detected.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 43f05af80965bf5ee48c3f8fb3fe2ef46f4d5427. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->