### PR TITLE
fix(guest-session): send 5xx through webError so the cause reaches Axiom

### DIFF
--- a/mcpjam-inspector/server/routes/web/__tests__/guest-session-diagnosability.test.ts
+++ b/mcpjam-inspector/server/routes/web/__tests__/guest-session-diagnosability.test.ts
@@ -1,0 +1,86 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { Hono } from "hono";
+import guestSession from "../guest-session.js";
+
+/**
+ * A 5xx from this route must carry its cause into `webErrorMeta`, which is
+ * where `requestLogContextMiddleware` reads the code and message for
+ * `http.request.failed`.
+ *
+ * On 2026-07-22 this path failed 434 times in a single day and every row logged
+ * `errorCode: "internal_error"` with NO message, so the incident could not be
+ * diagnosed afterwards. The route knew exactly why it failed — returning
+ * `c.json` directly discarded that text at the response boundary, because a
+ * direct return never sets `webErrorMeta`.
+ *
+ * Deliberately a separate file from `guest-session.test.ts`: that suite shares
+ * module-level rate-limiter and env state across 28 tests, and appending here
+ * perturbed it.
+ */
+const ORIGINAL_NODE_ENV = process.env.NODE_ENV;
+const ORIGINAL_CONVEX_HTTP_URL = process.env.CONVEX_HTTP_URL;
+const ORIGINAL_SHARED_SECRET = process.env.MCPJAM_GUEST_SESSION_SHARED_SECRET;
+const ORIGINAL_FETCH = global.fetch;
+
+describe("guest-session 5xx diagnosability", () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+    process.env.NODE_ENV = "test";
+    process.env.CONVEX_HTTP_URL = "https://test-deployment.convex.site";
+    process.env.MCPJAM_GUEST_SESSION_SHARED_SECRET =
+      "test-guest-session-secret";
+    delete process.env.MCPJAM_GUEST_SESSION_URL;
+    delete process.env.VITE_MCPJAM_HOSTED_MODE;
+    delete process.env.MCPJAM_NONPROD_LOCKDOWN;
+    // The upstream is down: this is the shape that produced the 07-22 rows.
+    global.fetch = vi
+      .fn()
+      .mockImplementation(async () => new Response("nope", { status: 500 }));
+  });
+
+  afterEach(() => {
+    global.fetch = ORIGINAL_FETCH;
+    process.env.NODE_ENV = ORIGINAL_NODE_ENV;
+    process.env.CONVEX_HTTP_URL = ORIGINAL_CONVEX_HTTP_URL;
+    process.env.MCPJAM_GUEST_SESSION_SHARED_SECRET = ORIGINAL_SHARED_SECRET;
+  });
+
+  it("stashes the failure cause in webErrorMeta", async () => {
+    let meta: Record<string, unknown> | undefined;
+    const app = new Hono();
+    app.use("*", async (c, next) => {
+      await next();
+      meta = c.get("webErrorMeta" as never) as Record<string, unknown>;
+    });
+    app.route("/guest-session", guestSession);
+
+    const res = await app.request("/guest-session", {
+      method: "POST",
+      // Distinct client IP: the route rate-limits per IP, and a 429 would
+      // never reach the 503 path this test exists to cover.
+      headers: { "x-forwarded-for": "203.0.113.201" },
+    });
+
+    expect(res.status).toBe(503);
+    expect(meta).toBeDefined();
+    expect(meta?.status).toBe(503);
+    expect(meta?.code).toBe("INTERNAL_ERROR");
+    // The reason must survive to the log row, not only to the client.
+    expect(String(meta?.message)).toContain("guest session");
+  });
+
+  it("leaves the response body shape unchanged", async () => {
+    const app = new Hono();
+    app.route("/guest-session", guestSession);
+
+    const res = await app.request("/guest-session", {
+      method: "POST",
+      headers: { "x-forwarded-for": "203.0.113.202" },
+    });
+    const body = (await res.json()) as Record<string, unknown>;
+
+    expect(res.status).toBe(503);
+    expect(body.code).toBe("INTERNAL_ERROR");
+    expect(typeof body.message).toBe("string");
+  });
+});

--- a/mcpjam-inspector/server/routes/web/guest-session.ts
+++ b/mcpjam-inspector/server/routes/web/guest-session.ts
@@ -18,7 +18,7 @@ import {
   extractGuestSessionCookie,
   shouldFetchGuestSessionFromConvex,
 } from "./guest-session-shared.js";
-import { ErrorCode } from "./errors.js";
+import { ErrorCode, webError } from "./errors.js";
 
 const guestSession = new Hono();
 
@@ -143,12 +143,16 @@ guestSession.post("/", async (c) => {
     );
   }
 
-  return c.json(
-    {
-      code: ErrorCode.INTERNAL_ERROR,
-      message: "Unable to obtain a guest session right now. Please try again.",
-    },
-    503
+  // Through `webError` so the code and message reach `webErrorMeta`, and from
+  // there `http.request.failed`. Returning `c.json` directly produced a 5xx row
+  // with no message at all: on 2026-07-22 this path failed 434 times in a day
+  // and the reason was unrecoverable, because the route knew why and threw the
+  // text away at the response boundary. Body shape is unchanged.
+  return webError(
+    c,
+    503,
+    ErrorCode.INTERNAL_ERROR,
+    "Unable to obtain a guest session right now. Please try again."
   );
 });
 
@@ -223,12 +227,11 @@ guestSession.post("/revoke", async (c) => {
     return c.json({ revoked: false, upstream: "missing" });
   }
 
-  return c.json(
-    {
-      code: ErrorCode.INTERNAL_ERROR,
-      message: "Unable to revoke guest session right now.",
-    },
-    503
+  return webError(
+    c,
+    503,
+    ErrorCode.INTERNAL_ERROR,
+    "Unable to revoke guest session right now."
   );
 });
 
@@ -309,13 +312,11 @@ guestSession.post("/promotion-proof", async (c) => {
     );
   }
 
-  return c.json(
-    {
-      code: ErrorCode.INTERNAL_ERROR,
-      message:
-        "Unable to obtain a guest promotion proof right now. Please try again.",
-    },
-    503
+  return webError(
+    c,
+    503,
+    ErrorCode.INTERNAL_ERROR,
+    "Unable to obtain a guest promotion proof right now. Please try again."
   );
 });
 


### PR DESCRIPTION
## Why this, and not another threshold

Triaging the actual 5xx backlog instead of tuning alert volume. The single largest error class in the system:

**5,070 of 11,916 5xx in 30 days (43%) carry `errorCode: "internal_error"` and no message at all.** None of them can be diagnosed after the fact.

Broken down by route, the top offenders:

| route | status | events | orgs |
| --- | --- | --- | --- |
| `/api/web/tools/list` | 502 | 1,348 | 53 |
| `/api/web/servers/validate` | 502 | 569 | 115 |
| `/api/web/tools/list` | 500 | 552 | 18 |
| `/api/web/tools/list` | 504 | 493 | 32 |
| **`/api/web/guest-session`** | **503** | **442** | — |

## The incident nobody knew about

`/api/web/guest-session` matters more than 442 suggests — it's the front door. A failure means a new visitor cannot obtain a session at all.

**434 of the 442 landed on a single day: 2026-07-22.** Roughly an hour of guest-session failures, self-resolved, never noticed. It's the same day as the 445-event `internal_error` hour surfaced during the monitor work, so almost certainly one incident.

**And the cause is unrecoverable** — which is what this PR fixes.

## The bug

```ts
return c.json(
  { code: ErrorCode.INTERNAL_ERROR, message: "Unable to obtain a guest session right now." },
  503
);
```

`requestLogContextMiddleware` reads the code and message from `webErrorMeta`, which only `webError` sets. A direct `c.json` return never sets it, so the row logs `internal_error` with no message.

**The route knew exactly why it failed and discarded the explanation at the response boundary.**

## The change

All three 503 sites now go through `webError`. The response body is **byte-identical** — `webError` emits the same `{code, message}` shape — so this is invisible to clients and visible only in telemetry. The 28 existing guest-session tests passing unchanged is the evidence for that claim.

## Tests

In a **separate file** deliberately: appending to `guest-session.test.ts` perturbed its shared module-level rate-limiter and env state and broke an unrelated case ("fails closed in production when no client IP header is available"). They also pin a distinct client IP, because the route rate-limits per IP and a 429 would never reach the 503 path the test exists to cover.

Confirmed they catch the regression — reverting one site to `c.json` fails with `expected undefined to be defined` (no `webErrorMeta`), while the body-shape assertion still passes either way, which is exactly the intended property.

## Scope

**Not swept further.** `computer-upload.ts` has five sites with the identical defect, but **zero 5xx in 30 days**, so fixing it would be unverifiable speculation.

The larger `tools/list` and `servers/validate` buckets are a different shape — those routes do have messages on some rows — and need their own investigation rather than being lumped in here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small observability fix on three error paths; response body shape is unchanged and covered by new tests. No auth or session-mint logic changes.
> 
> **Overview**
> Guest-session **503** responses now go through `webError` instead of raw `c.json`, so the failure code and message land in `webErrorMeta` and show up on `http.request.failed` logs.
> 
> Client response bodies stay the same. Covers mint, revoke, and promotion-proof. Adds a focused diagnosability test that asserts `webErrorMeta` is set when upstream returns 500.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 45ca91764795d0b24b56eb808e0671425b1a5e3d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Ensure 5xx from `/api/web/guest-session` carry their cause to logs by routing them through `webError`, fixing silent `internal_error` rows with no message while keeping responses unchanged.

- **Bug Fixes**
  - Use `webError` instead of `c.json` for 503s in `/`, `/revoke`, and `/promotion-proof` so code/message reach `webErrorMeta` and Axiom.
  - Response body remains `{ code, message }`; no client changes.
  - Added focused tests to assert `webErrorMeta` is set and body shape is unchanged.

<sup>Written for commit 45ca91764795d0b24b56eb808e0671425b1a5e3d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/MCPJam/inspector/pull/3930?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

