### PR TITLE
fix(evals): keep run trash button and overview actions visible on narrow widths (PUR-28)

### DIFF
--- a/mcpjam-inspector/client/src/components/evals/__tests__/run-group-delete-visibility.test.tsx
+++ b/mcpjam-inspector/client/src/components/evals/__tests__/run-group-delete-visibility.test.tsx
@@ -1,0 +1,130 @@
+/**
+ * Regression: the run-group delete (trash) button must stay inside the narrow
+ * ("w-60", 240px) results rail instead of overflowing past its edge, where the
+ * split container's `overflow-hidden` clipped it (PUR-28).
+ *
+ * The fix is `min-w-0` on the `RunGroupItem` row wrapper and its middle "select"
+ * button, so the flex column yields before the fixed-width trash button does.
+ * jsdom has no layout engine, so we can't measure the clip directly; instead we
+ * pin the two things that would regress if `min-w-0` were removed — the guards
+ * themselves — plus that the delete control stays rendered and activatable,
+ * including when the group carries no host/environment context data.
+ */
+import { describe, expect, it, vi } from "vitest";
+import { renderWithProviders, screen, userEvent } from "@/test";
+import { SuiteResultsSplit } from "../suite-results-split";
+import { contextSuite, envRun, hostRun } from "./run-context-fixtures";
+import type { EvalSuiteRun } from "../types";
+
+vi.mock("@/hooks/useProjectEnvironmentsEnabled", () => ({
+  useProjectEnvironmentsEnabled: () => true,
+  useProjectEnvironmentsEnabledState: () => true,
+  PROJECT_ENVIRONMENTS_FEATURE_FLAG: "project-environments-enabled",
+}));
+
+// A two-run group whose environment names are long enough that, without
+// `min-w-0` letting the middle column shrink, the middle content would shove
+// the trash button past the 240px rail edge.
+const LONG_NAME =
+  "Staging environment with an extremely long descriptive name that overflows";
+const longLabelGroup: EvalSuiteRun[] = [
+  envRun("twoenv01", "env-a", LONG_NAME, 2, {
+    runGroupId: "g-two",
+    createdAt: 20_000,
+    completedAt: 21_000,
+  }),
+  envRun("twoenv02", "env-b", `${LONG_NAME} (variant)`, 7, {
+    runGroupId: "g-two",
+    createdAt: 20_100,
+    completedAt: 21_100,
+  }),
+];
+
+function renderRail(
+  runs: EvalSuiteRun[],
+  extra?: Partial<React.ComponentProps<typeof SuiteResultsSplit>>,
+) {
+  return renderWithProviders(
+    <SuiteResultsSplit
+      suite={contextSuite}
+      cases={[]}
+      runs={runs}
+      allIterations={[]}
+      hostNamesById={new Map()}
+      allRunsPane={<div />}
+      onTestCaseClick={vi.fn()}
+      onRunClick={vi.fn()}
+      onDeleteRun={vi.fn(async () => {})}
+      {...extra}
+    />,
+  );
+}
+
+describe("RunGroupItem delete button stays visible in the narrow rail (PUR-28)", () => {
+  it("keeps the min-w-0 guards so a long label can't push the trash button out", () => {
+    renderRail(longLabelGroup);
+
+    const deleteButton = screen.getByRole("button", {
+      name: "Delete run group",
+    });
+
+    // The flex row that holds chevron · middle · trash must allow shrinking.
+    const row = deleteButton.parentElement as HTMLElement;
+    expect(row).toHaveClass("flex");
+    expect(row).toHaveClass("items-stretch");
+    expect(row).toHaveClass("min-w-0");
+
+    // The middle "select" column is the one that must yield first — without
+    // min-w-0 it holds its content width and overflows the fixed-width trash.
+    const middleButton = screen
+      .getByText(/Run group g/i)
+      .closest("button") as HTMLElement;
+    expect(middleButton).toHaveClass("flex-1");
+    expect(middleButton).toHaveClass("min-w-0");
+  });
+
+  it("delete control is activatable — opens the confirm dialog and deletes every run in the group", async () => {
+    const onDeleteRun = vi.fn(async () => {});
+    const user = userEvent.setup();
+    renderRail(longLabelGroup, { onDeleteRun });
+
+    await user.click(screen.getByRole("button", { name: "Delete run group" }));
+
+    // Confirm dialog for the whole group (both runs).
+    expect(
+      screen.getByRole("heading", { name: /Delete run group/i }),
+    ).toBeInTheDocument();
+
+    await user.click(screen.getByRole("button", { name: /^Delete$/ }));
+
+    expect(onDeleteRun).toHaveBeenCalledTimes(2);
+    const deletedIds = onDeleteRun.mock.calls.map((c) => c[0]);
+    expect(deletedIds).toEqual(
+      expect.arrayContaining(["twoenv01", "twoenv02"]),
+    );
+  });
+
+  it("renders the delete button for a group carrying no host/environment context data", () => {
+    // null/empty context: host runs with an empty hostNamesById map — the
+    // context summary falls back rather than naming anything, and the trash
+    // control must still render.
+    const hostlessGroup: EvalSuiteRun[] = [
+      hostRun("hostrun1", undefined, {
+        runGroupId: "g-host",
+        createdAt: 30_000,
+        completedAt: 31_000,
+      }),
+      hostRun("hostrun2", undefined, {
+        runGroupId: "g-host",
+        createdAt: 30_100,
+        completedAt: 31_100,
+      }),
+    ];
+
+    renderRail(hostlessGroup, { hostNamesById: new Map() });
+
+    expect(
+      screen.getByRole("button", { name: "Delete run group" }),
+    ).toBeInTheDocument();
+  });
+});

--- a/mcpjam-inspector/client/src/components/evals/__tests__/run-group-delete-visibility.test.tsx
+++ b/mcpjam-inspector/client/src/components/evals/__tests__/run-group-delete-visibility.test.tsx
@@ -10,8 +10,9 @@
  * themselves — plus that the delete control stays rendered and activatable,
  * including when the group carries no host/environment context data.
  */
-import { describe, expect, it, vi } from "vitest";
-import { renderWithProviders, screen, userEvent } from "@/test";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { renderWithProviders, screen, userEvent, waitFor } from "@/test";
+import { toast } from "sonner";
 import { SuiteResultsSplit } from "../suite-results-split";
 import { contextSuite, envRun, hostRun } from "./run-context-fixtures";
 import type { EvalSuiteRun } from "../types";
@@ -20,6 +21,12 @@ vi.mock("@/hooks/useProjectEnvironmentsEnabled", () => ({
   useProjectEnvironmentsEnabled: () => true,
   useProjectEnvironmentsEnabledState: () => true,
   PROJECT_ENVIRONMENTS_FEATURE_FLAG: "project-environments-enabled",
+}));
+
+// Mirrors the repo convention for asserting toast feedback: mock sonner and
+// assert the toast fn was called, rather than depending on a mounted Toaster.
+vi.mock("sonner", () => ({
+  toast: { success: vi.fn(), error: vi.fn() },
 }));
 
 // A two-run group whose environment names are long enough that, without
@@ -61,6 +68,10 @@ function renderRail(
 }
 
 describe("RunGroupItem delete button stays visible in the narrow rail (PUR-28)", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
   it("keeps the min-w-0 guards so a long label can't push the trash button out", () => {
     renderRail(longLabelGroup);
 
@@ -102,6 +113,28 @@ describe("RunGroupItem delete button stays visible in the narrow rail (PUR-28)",
     expect(deletedIds).toEqual(
       expect.arrayContaining(["twoenv01", "twoenv02"]),
     );
+  });
+
+  it("surfaces failure feedback when a deletion rejects", async () => {
+    const onDeleteRun = vi.fn().mockRejectedValue(new Error("network down"));
+    // confirmDeleteRuns logs the failure via console.error before toasting;
+    // swallow it so the expected rejection doesn't clutter test output.
+    const consoleError = vi.spyOn(console, "error").mockImplementation(() => {});
+    const user = userEvent.setup();
+    renderRail(longLabelGroup, { onDeleteRun });
+
+    await user.click(screen.getByRole("button", { name: "Delete run group" }));
+    await user.click(screen.getByRole("button", { name: /^Delete$/ }));
+
+    // The delete was attempted, and the failure surfaced as error feedback
+    // rather than a silent no-op.
+    await waitFor(() =>
+      expect(toast.error).toHaveBeenCalledWith("Failed to delete run"),
+    );
+    expect(onDeleteRun).toHaveBeenCalled();
+    expect(toast.success).not.toHaveBeenCalled();
+
+    consoleError.mockRestore();
   });
 
   it("renders the delete button for a group carrying no host/environment context data", () => {

--- a/mcpjam-inspector/client/src/components/evals/__tests__/suite-header.test.tsx
+++ b/mcpjam-inspector/client/src/components/evals/__tests__/suite-header.test.tsx
@@ -426,7 +426,7 @@ describe("SuiteHeader", () => {
     expect(onRerun).not.toHaveBeenCalled();
   });
 
-  it("keeps overview actions shrink-wrapped on the right with Run all last", () => {
+  it("wraps overview actions onto a second row, right-aligned, with Run all last", () => {
     renderWithProviders(
       <SuiteHeader
         {...baseProps}
@@ -464,8 +464,8 @@ describe("SuiteHeader", () => {
 
     const actions = screen.getByTestId("suite-overview-actions");
     expect(actions).toHaveClass("ml-auto");
-    expect(actions).toHaveClass("shrink-0");
-    expect(actions).toHaveClass("flex-nowrap");
+    expect(actions).toHaveClass("flex-wrap");
+    expect(actions).toHaveClass("justify-end");
 
     const setupSdk = screen.getByRole("button", { name: /Setup SDK/i });
     const generate = screen.getByRole("button", { name: /^Generate$/i });

--- a/mcpjam-inspector/client/src/components/evals/suite-header.tsx
+++ b/mcpjam-inspector/client/src/components/evals/suite-header.tsx
@@ -973,7 +973,7 @@ export function SuiteHeader(props: SuiteHeaderProps) {
       {overviewHasRightActions ? (
         <div
           data-testid="suite-overview-actions"
-          className="ml-auto flex shrink-0 flex-nowrap items-center gap-2"
+          className="ml-auto flex min-w-0 flex-wrap items-center justify-end gap-2"
         >
           {overviewSetupSdkButton}
           {overviewLegacyRunActions}

--- a/mcpjam-inspector/client/src/components/evals/suite-results-split.tsx
+++ b/mcpjam-inspector/client/src/components/evals/suite-results-split.tsx
@@ -352,7 +352,7 @@ function RunGroupItem({
         active ? "border-primary/40 bg-primary/[0.06]" : "border-transparent hover:bg-muted/60",
       )}
     >
-      <div className="flex items-stretch">
+      <div className="flex min-w-0 items-stretch">
         {!group.isStandalone ? (
           <button
             type="button"
@@ -365,7 +365,7 @@ function RunGroupItem({
         ) : (
           <span className="w-7 shrink-0" />
         )}
-        <button type="button" onClick={onSelect} className="flex-1 py-2.5 pr-3 text-left">
+        <button type="button" onClick={onSelect} className="min-w-0 flex-1 py-2.5 pr-3 text-left">
           <div className="flex items-center justify-between gap-2">
             <span className="truncate font-mono text-xs font-medium text-foreground">{group.label}</span>
             <span className="shrink-0 text-[11px] tabular-nums text-muted-foreground">


### PR DESCRIPTION
## What & why

Two Evals UI polish defects from the review (PUR-28).

### 1. Cropped/floating run trash button
In the "RUNS" rail (`RunGroupItem` in `suite-results-split.tsx`), the row is a flex layout: chevron · middle content · trash. The middle button was missing `min-w-0`, so it never shrank below its content width and pushed the `w-7` trash button past the 240px rail edge, where the split container's `overflow-hidden` clipped it.

**Fix:** add `min-w-0` to the row wrapper and the middle content button so the middle column yields first and the delete button always renders fully inside the rail.

### 2. Cropped horizontal scroll of overview toolbar buttons
The suite overview action group was `shrink-0 flex-nowrap`, so on narrow widths the buttons hid behind an invisible horizontal scroll instead of staying visible.

**Fix:** switch the group to `flex-wrap justify-end min-w-0` so Run all / Generate / New case / Setup SDK wrap onto a second row, right-aligned — all buttons visible by default (the layout answer requested in the task, not a scroll fix).

## Tests
- Updated `suite-header.test.tsx` to assert the wrapping layout (`flex-wrap` / `justify-end`) instead of the old `flex-nowrap` / `shrink-0`.
- `suite-header.test.tsx` (20) and the results-split tests (`run-context-identity`, `run-context-kill-switch`, 32) pass.

## Scope note
The "…ver" chip cut off in the toolbar screenshot comes from a separate element — the client/env chip strip in `suite-environment-composer-bar.tsx`, which intentionally scrolls horizontally to hold many chips. This PR is scoped to the action buttons, as the task specifies.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Keeps Evals run-group delete and suite overview actions visible on narrow widths, per PUR-28. Previously the trash button overflowed and was clipped in the 240px rail, and overview actions hid behind horizontal scroll; now the middle content yields and actions wrap to a second row, right-aligned.

- Runs rail: add `min-w-0` to the `RunGroupItem` row and its middle select button so the trash button stays inside the rail.
- Overview actions: switch the actions container to `min-w-0 flex-wrap justify-end` so Run all / Generate / New case / Setup SDK wrap onto a second row, right-aligned.
- Tests: add `run-group-delete-visibility.test.tsx` to pin the `min-w-0` guards, confirm dialog and group deletion behavior, no-context rendering, and the failure path that surfaces “Failed to delete run”; update `suite-header.test.tsx` to assert the wrapped, right-aligned layout.

<sup>Written for commit ef060f80f85ca974e977ab93c440322f5ece636c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/MCPJam/inspector/pull/3937?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

