### PR TITLE
fix(logger): surface search matches hidden by the source filter (PUR-45)

### DIFF
--- a/mcpjam-inspector/client/src/components/__tests__/logger-view.test.tsx
+++ b/mcpjam-inspector/client/src/components/__tests__/logger-view.test.tsx
@@ -1,6 +1,13 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
+import {
+  Children,
+  cloneElement,
+  isValidElement,
+  type ReactElement,
+  type ReactNode,
+} from "react";
 
 vi.mock("@/state/app-state-context", () => ({
   useSharedAppState: () => ({
@@ -20,6 +27,46 @@ vi.mock("@/stores/traffic-log-store", async () => {
     subscribeToRpcStream: vi.fn(() => () => {}),
   };
 });
+
+// Real dropdown menu is a Radix popover; swap it for plain markup so the
+// source-filter radio items are directly clickable in jsdom.
+vi.mock("@mcpjam/design-system/dropdown-menu", () => ({
+  DropdownMenu: ({ children }: { children: ReactNode }) => <>{children}</>,
+  DropdownMenuTrigger: ({ children }: { children: ReactNode }) => (
+    <>{children}</>
+  ),
+  DropdownMenuContent: ({ children }: { children: ReactNode }) => (
+    <>{children}</>
+  ),
+  DropdownMenuRadioGroup: ({
+    children,
+    onValueChange,
+  }: {
+    children: ReactNode;
+    onValueChange: (value: string) => void;
+  }) => (
+    <div data-testid="source-filter-group">
+      {Children.map(children, (child) =>
+        isValidElement(child)
+          ? cloneElement(child as ReactElement<{ value: string }>, {
+              onClick: () => onValueChange((child.props as { value: string }).value),
+            } as Record<string, unknown>)
+          : child,
+      )}
+    </div>
+  ),
+  DropdownMenuRadioItem: ({
+    children,
+    onClick,
+  }: {
+    children: ReactNode;
+    onClick?: () => void;
+  }) => (
+    <button type="button" role="menuitemradio" onClick={onClick}>
+      {children}
+    </button>
+  ),
+}));
 
 import { LoggerView } from "../logger-view";
 import {
@@ -323,5 +370,70 @@ describe("LoggerView hosted rpc logs", () => {
 
     expect(screen.getByText("initialize")).toBeInTheDocument();
     expect(screen.queryByText("Old OAuth Flow")).not.toBeInTheDocument();
+  });
+
+  it("surfaces a hidden-matches banner when the source filter hides a search match, and clears it on click", async () => {
+    const user = userEvent.setup();
+
+    // Only lives on an `http` exchange row, not a JSON-RPC frame.
+    useTrafficLogStore.getState().addMcpServerLog({
+      serverId: "srv-1",
+      serverName: "Notion",
+      direction: "SEND",
+      method: "POST",
+      timestamp: "2026-04-10T12:00:00.000Z",
+      payload: { headers: { "mcp-session-id": "abc-123" } },
+      kind: "http",
+    });
+
+    render(<LoggerView />);
+
+    await user.click(screen.getByTitle("Filter Source"));
+    await user.click(screen.getByRole("menuitemradio", { name: "Server" }));
+
+    await user.type(
+      screen.getByPlaceholderText("Search logs"),
+      "mcp-session-id",
+    );
+
+    expect(
+      screen.getByText("1 match hidden by the source filter"),
+    ).toBeInTheDocument();
+    expect(screen.getByText("No matches in this view")).toBeInTheDocument();
+
+    await user.click(screen.getByText("Clear filter"));
+
+    expect(
+      screen.queryByText("1 match hidden by the source filter"),
+    ).not.toBeInTheDocument();
+    expect(screen.getByText("POST")).toBeInTheDocument();
+  });
+
+  it("shows 'No matches in this view' (not 'No logs yet') when the source filter hides all logs and search is empty", async () => {
+    const user = userEvent.setup();
+
+    useTrafficLogStore.getState().addMcpServerLog({
+      serverId: "srv-1",
+      serverName: "Notion",
+      direction: "SEND",
+      method: "POST",
+      timestamp: "2026-04-10T12:00:00.000Z",
+      payload: { headers: {} },
+      kind: "http",
+    });
+
+    render(<LoggerView />);
+
+    await user.click(screen.getByTitle("Filter Source"));
+    await user.click(screen.getByRole("menuitemradio", { name: "Server" }));
+
+    expect(screen.getByText("No matches in this view")).toBeInTheDocument();
+    expect(screen.queryByText("No logs yet")).not.toBeInTheDocument();
+  });
+
+  it("still shows 'No logs yet' when there are no logs at all", () => {
+    render(<LoggerView />);
+
+    expect(screen.getByText("No logs yet")).toBeInTheDocument();
   });
 });

--- a/mcpjam-inspector/client/src/components/logger-view.tsx
+++ b/mcpjam-inspector/client/src/components/logger-view.tsx
@@ -499,15 +499,17 @@ export function LoggerView({
 
   // Precomputed, lowercased search text per item — the same four fields the
   // search used to concatenate inline (server label, method, direction, and
-  // the stringified payload). Keyed by item id and memoized over `allItems`,
-  // so JSON.stringify runs once per row when the log set changes, not for
-  // every row on every keystroke. (This is the caniuse "precomputed keywords"
-  // idea: a row's search text is something you BUILD, not its raw contents.)
+  // the stringified payload). Keyed by `source:id` (not bare id) because
+  // mcpServerItems and mcpAppsItems generate ids independently — a hosted
+  // eventId or a `${timestamp}-${random}` id could collide across the two
+  // arrays and silently overwrite an entry. Memoized over `allItems`, so
+  // JSON.stringify runs once per row when the log set changes, not for
+  // every row on every keystroke.
   const searchIndex = useMemo(() => {
     const index = new Map<string, string>();
     for (const item of allItems) {
       index.set(
-        item.id,
+        `${item.source}:${item.id}`,
         [
           getDisplayServerLabel(item),
           item.method,
@@ -553,7 +555,9 @@ export function LoggerView({
     const queryLower = searchQuery.trim().toLowerCase();
     if (queryLower) {
       result = result.filter((item) =>
-        (searchIndex.get(item.id) ?? "").includes(queryLower)
+        (searchIndex.get(`${item.source}:${item.id}`) ?? "").includes(
+          queryLower
+        )
       );
     }
 
@@ -897,7 +901,7 @@ export function LoggerView({
         )}
         {filteredItemCount === 0 ? (
           <div className="text-center py-8">
-            {searchQuery.trim() && totalItemCount > 0 ? (
+            {totalItemCount > 0 ? (
               <>
                 <div className="text-xs text-muted-foreground">
                   {"No matches in this view"}
@@ -905,7 +909,9 @@ export function LoggerView({
                 <div className="text-[10px] text-muted-foreground mt-1">
                   {matchesHiddenBySourceFilter > 0
                     ? "Clear the source filter to see hidden matches"
-                    : "Try a different search term"}
+                    : searchQuery.trim()
+                      ? "Try a different search term"
+                      : "Adjust the active filters"}
                 </div>
               </>
             ) : (

--- a/mcpjam-inspector/client/src/components/logger-view.tsx
+++ b/mcpjam-inspector/client/src/components/logger-view.tsx
@@ -497,13 +497,38 @@ export function LoggerView({
     );
   }, [mcpServerItems, mcpAppsItems]);
 
-  const filteredItems = useMemo(() => {
-    let result = allItems;
-
-    // Filter by source type
-    if (sourceFilter !== "all") {
-      result = result.filter((item) => item.source === sourceFilter);
+  // Precomputed, lowercased search text per item — the same four fields the
+  // search used to concatenate inline (server label, method, direction, and
+  // the stringified payload). Keyed by item id and memoized over `allItems`,
+  // so JSON.stringify runs once per row when the log set changes, not for
+  // every row on every keystroke. (This is the caniuse "precomputed keywords"
+  // idea: a row's search text is something you BUILD, not its raw contents.)
+  const searchIndex = useMemo(() => {
+    const index = new Map<string, string>();
+    for (const item of allItems) {
+      index.set(
+        item.id,
+        [
+          getDisplayServerLabel(item),
+          item.method,
+          item.direction,
+          JSON.stringify(item.payload),
+        ]
+          .join("\n")
+          .toLowerCase()
+      );
     }
+    return index;
+  }, [allItems]);
+
+  // Everything EXCEPT the source filter. Split out so we can tell how many
+  // rows actually match the search before the source funnel removes them —
+  // that count is what powers the "N matches hidden by filter" banner and
+  // stops the "Server" filter from silently returning zero. The source
+  // filter is a plain conjunction like the others, so pulling it out of the
+  // chain does not change the final visible set.
+  const itemsBeforeSourceFilter = useMemo(() => {
+    let result = allItems;
 
     // Filter by serverIds if provided
     if (serverIds && serverIds.length > 0) {
@@ -525,23 +550,30 @@ export function LoggerView({
     }
 
     // Filter by search query
-    if (searchQuery.trim()) {
-      const queryLower = searchQuery.toLowerCase();
-      result = result.filter((item) => {
-        return (
-          getDisplayServerLabel(item).toLowerCase().includes(queryLower) ||
-          item.method.toLowerCase().includes(queryLower) ||
-          item.direction.toLowerCase().includes(queryLower) ||
-          JSON.stringify(item.payload).toLowerCase().includes(queryLower)
-        );
-      });
+    const queryLower = searchQuery.trim().toLowerCase();
+    if (queryLower) {
+      result = result.filter((item) =>
+        (searchIndex.get(item.id) ?? "").includes(queryLower)
+      );
     }
 
     return result;
-  }, [allItems, searchQuery, serverIds, sinceTimestamp, sourceFilter]);
+  }, [allItems, searchQuery, searchIndex, serverIds, sinceTimestamp]);
+
+  const filteredItems = useMemo(() => {
+    if (sourceFilter === "all") return itemsBeforeSourceFilter;
+    return itemsBeforeSourceFilter.filter(
+      (item) => item.source === sourceFilter
+    );
+  }, [itemsBeforeSourceFilter, sourceFilter]);
 
   const totalItemCount = allItems.length;
   const filteredItemCount = filteredItems.length;
+
+  // How many rows match the search + other filters but are being removed
+  // purely by the source filter. Zero when the filter is "all".
+  const matchesHiddenBySourceFilter =
+    itemsBeforeSourceFilter.length - filteredItemCount;
 
   return (
     <div className="flex h-full min-h-0 flex-col overflow-hidden">
@@ -840,12 +872,52 @@ export function LoggerView({
       </div>
 
       <div ref={scrollRef} className="flex-1 min-h-0 overflow-y-auto">
+        {searchQuery.trim() && matchesHiddenBySourceFilter > 0 && (
+          <button
+            type="button"
+            onClick={() => {
+              captureLogger("logger_source_filter_changed", {
+                from: sourceFilter,
+                to: "all",
+              });
+              setSourceFilter("all");
+            }}
+            className="flex w-full items-center justify-between gap-2 border-b border-border bg-muted/40 px-3 py-1.5 text-left text-xs text-muted-foreground hover:bg-muted"
+            title="Clear the source filter to show these matches"
+          >
+            <span>
+              {matchesHiddenBySourceFilter}{" "}
+              {matchesHiddenBySourceFilter === 1 ? "match" : "matches"} hidden by
+              the source filter
+            </span>
+            <span className="whitespace-nowrap font-medium text-primary">
+              Clear filter
+            </span>
+          </button>
+        )}
         {filteredItemCount === 0 ? (
           <div className="text-center py-8">
-            <div className="text-xs text-muted-foreground">{"No logs yet"}</div>
-            <div className="text-[10px] text-muted-foreground mt-1">
-              {"Logs will appear here"}
-            </div>
+            {searchQuery.trim() && totalItemCount > 0 ? (
+              <>
+                <div className="text-xs text-muted-foreground">
+                  {"No matches in this view"}
+                </div>
+                <div className="text-[10px] text-muted-foreground mt-1">
+                  {matchesHiddenBySourceFilter > 0
+                    ? "Clear the source filter to see hidden matches"
+                    : "Try a different search term"}
+                </div>
+              </>
+            ) : (
+              <>
+                <div className="text-xs text-muted-foreground">
+                  {"No logs yet"}
+                </div>
+                <div className="text-[10px] text-muted-foreground mt-1">
+                  {"Logs will appear here"}
+                </div>
+              </>
+            )}
           </div>
         ) : (
           <>


### PR DESCRIPTION
## What & why

Searching the Logs panel for an HTTP header term (e.g. `mcp-session-id`) under the **Server** source filter silently returned **zero results**. Headers only live on `http` exchange rows, and those rows are filtered out *before* the search runs; JSON-RPC frames carry no headers in their payload. So the data was in the log and search said nothing existed — the worst kind of bug because you trust the "no results".

This is the cheap, high-value half of PUR-45.

## Changes

- **Stop the zero-results cliff.** Split the source filter out of the filter chain so we can count how many rows match the search + other filters but are removed *purely* by the source funnel. When that count is > 0 and a search is active, a clickable banner shows **"N matches hidden by the source filter — Clear filter"**; clicking resets the filter to All. The empty state now reads *"No matches in this view"* instead of *"No logs yet"* when logs exist but are filtered out.
  - Reordering the filters is safe: they're all conjunctions, so the final visible set is byte-for-byte unchanged.
- **Perf: memoized search index.** Precompute a per-item lowercase search string (server label, method, direction, stringified payload) keyed by item id, memoized over the log set. `JSON.stringify(payload)` now runs once per row when logs change, instead of for every row on every keystroke. No behavior change.

## Out of scope (follow-up)

Per-frame header indexing — making a `tools/call` frame match the header it rode in — is intentionally deferred. It's O(n²) via `findExchangeForFrame` and risks disagreeing with the correlation logic. See the task for the framing on a cheaper looser index.

## Testing

- `npm run typecheck:client` passes.
- Verified live: with a Streamable HTTP server connected and a tool call made, searching `mcp-session-id` under Filter = Server now shows the hidden-matches banner and clears to reveal the matching `http` row, instead of showing nothing.

Task: PUR-45

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Surfaces search matches hidden by the Logs source filter and eliminates false “zero results.” Previously, filtering to Server hid `http` rows before search, so header queries returned nothing; now we expose the count, show a banner, and let users clear the filter.

- Compute search + other filters before the source filter. Final visible set is unchanged; the banner shows “N matches hidden by the source filter” and “Clear filter” switches the source filter to All.
- Empty state now reads “No matches in this view” whenever logs exist but are filtered out (even with an empty search).
- Memoize a per-item lowercase search index keyed by `${source}:${id}` to avoid cross-source id collisions; perf-only.
- Add regression tests for the banner, clear action, and empty-state branches (tests stub `@mcpjam/design-system/dropdown-menu` for jsdom).
- Addresses PUR-45.

<sup>Written for commit 005a5b32db5ebe4a19b510f3a68a77b9b3126d27. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/MCPJam/inspector/pull/3938?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

