### PR TITLE
test(hosted): settle the OAuth gate before reporting a runtime 401

### DIFF
--- a/mcpjam-inspector/client/src/components/hosted/__tests__/ChatboxChatPage.test.tsx
+++ b/mcpjam-inspector/client/src/components/hosted/__tests__/ChatboxChatPage.test.tsx
@@ -952,6 +952,17 @@ describe("ChatboxChatPage", () => {
 
     expect(await screen.findByTestId("chatbox-chat-tab")).toBeInTheDocument();
 
+    // Settle the gate before reporting the 401. A server joins the authorizable
+    // set only once the requirement probe has answered for it, and it verifies
+    // its stored credential after that — so clicking earlier races both, and
+    // the resulting state depends on which promise won. An unblocked composer
+    // is the observable "everything has settled" signal.
+    await waitFor(() =>
+      expect(mockChatTabV2).toHaveBeenLastCalledWith(
+        expect.objectContaining({ chatboxComposerBlocked: false })
+      )
+    );
+
     await userEvent.click(
       screen.getByRole("button", { name: "Trigger OAuth" })
     );
@@ -1018,6 +1029,13 @@ describe("ChatboxChatPage", () => {
     render(<ChatboxChatPage />);
 
     expect(await screen.findByTestId("chatbox-chat-tab")).toBeInTheDocument();
+
+    // See above: let the probe answer and the credentials verify before the 401.
+    await waitFor(() =>
+      expect(mockChatTabV2).toHaveBeenLastCalledWith(
+        expect.objectContaining({ chatboxComposerBlocked: false })
+      )
+    );
 
     await userEvent.click(
       screen.getByRole("button", { name: "Trigger targeted OAuth" })


### PR DESCRIPTION
## Summary

`ChatboxChatPage.test.tsx` fails roughly a quarter of runs on `main`, which is what took `Inspector Tests 4/4` red on #3931 (a PR that touches none of this code).

Two tests click "chat reports OAuth is required" as soon as the chat tab renders, then assert synchronously that the auth panel is up. That was safe when the gate resolved synchronously from the bootstrap payload. #3925 made it asynchronous — a server joins the authorizable set only once `check-oauth` answers for it, and then verifies its stored credential. Clicking before both settle races them:

- the escalation lands on an empty server set, `markOAuthRequired` matches nothing, and no panel appears; or
- it lands and is then overwritten by the credential verification still in flight.

Which one wins depends on machine load. Fix: wait for an unblocked composer — the observable "gate has settled" signal — before reporting the 401.

**Test-only. No production behavior changes.**

## Verification

| | result |
|---|---|
| `ChatboxChatPage.test.tsx` on `main` (unfixed) | 2 failures in 8 runs |
| same file with this change | 0 failures in 14 runs |
| full `vitest run --shard=4/4` (the red shard) | 305 files, 3406 tests, 0 failures |

## Known gap this does not close

These tests were catching a real defect, but only by accident and only sometimes: **a 401 that arrives before the requirement probe answers is silently dropped.** `markOAuthRequired` matches no server and returns without doing anything, so a recipient of a shared scenario can get a failed tool call with no Authorize action. The probe retries up to 6× at 300ms, so that window can exceed a second.

There is also a second, independent defect in the same area: the `runtimeRequiredServerIds` guard added in #3925 is dead code. Its ids are collected inside a `setOAuthStateByServerId` updater, which React runs lazily during render, so the array is still empty when `setRuntimeRequiredServerIds` reads it — the guard that exists to stop a rebuild retracting a runtime prompt never fires.

Both are reproducible and want their own PR. Fixing them properly needs two precedence decisions specified first: runtime 401 vs. in-flight credential validation, and auth panel vs. the guest first-consent welcome screen.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit 3cc54d1ccf5b4398c9b587f3b579867b03049c5d. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stabilizes ChatboxChatPage tests by waiting for the OAuth gate to settle before simulating a runtime 401. Previously the tests clicked immediately after the chat tab rendered and expected the auth panel; with an asynchronous gate, this raced the requirement probe and credential verification and caused flakes. The tests now wait for an unblocked composer (chatboxComposerBlocked: false) as the “gate settled” signal before clicking.

- Reviewer notes:
  - Test-only change in `ChatboxChatPage.test.tsx`; no production behavior changes.
  - Focus on the added waitFor that asserts `mockChatTabV2` was last called with `{ chatboxComposerBlocked: false }` in two tests.
  - This narrows coverage: a 401 that arrives before the probe answers is still dropped; fix tracked separately.

<sup>Written for commit 3cc54d1ccf5b4398c9b587f3b579867b03049c5d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/MCPJam/inspector/pull/3939?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

