### PR TITLE
fix(hosted): stop dropping a runtime 401 that beats the OAuth probe

### DIFF
--- a/mcpjam-inspector/client/src/components/hosted/__tests__/ChatboxChatPage.test.tsx
+++ b/mcpjam-inspector/client/src/components/hosted/__tests__/ChatboxChatPage.test.tsx
@@ -1637,6 +1637,129 @@ describe("ChatboxChatPage", () => {
       ).toBeInTheDocument();
     });
 
+    it("still prompts when the 401 beats the requirement probe", async () => {
+      // A server joins the authorizable set only once the probe answers for it,
+      // and the probe retries — so a real 401 can arrive while the set is still
+      // empty. That escalation used to be dropped on the floor: it matched no
+      // server and returned silently. For a `discover` row this is the whole
+      // ballgame, because a runtime 401 is its only route to a prompt.
+      let resolveProbe: (value: unknown) => void = () => {};
+      mockCheckHostedServerOAuthRequirement.mockImplementation(
+        () =>
+          new Promise((resolve) => {
+            resolveProbe = resolve;
+          })
+      );
+      writeSharedScenario();
+
+      render(<ChatboxChatPage />);
+      expect(await screen.findByTestId("chatbox-chat-tab")).toBeInTheDocument();
+
+      await userEvent.click(
+        screen.getByRole("button", { name: "Trigger OAuth" })
+      );
+      expect(
+        screen.queryByRole("heading", { name: "Authorization Required" })
+      ).not.toBeInTheDocument();
+
+      await act(async () => {
+        resolveProbe({
+          useOAuth: true,
+          requiresAuthorization: false,
+          effectiveAuthMethod: "discover",
+          serverUrl: "https://rabona.ignaciojimenezrocabado.workers.dev/mcp",
+        });
+      });
+
+      expect(
+        await screen.findByRole("heading", { name: "Authorization Required" })
+      ).toBeInTheDocument();
+      expect(
+        screen.getByRole("button", { name: "Authorize" })
+      ).toBeInTheDocument();
+    });
+
+    it("keeps the runtime prompt when a late probe answer rebuilds the gate", async () => {
+      // The probe answering flips `authorizationRequiredUpfront`, which rebuilds
+      // the status map from the descriptors. That rebuild must not retract a
+      // prompt the wire already proved is needed. It used to: the ids meant to
+      // survive it were collected inside a `setState` updater, which React runs
+      // lazily during render, so the guarding set was still empty when read.
+      let resolveProbe: (value: unknown) => void = () => {};
+      mockCheckHostedServerOAuthRequirement.mockImplementation(
+        () =>
+          new Promise((resolve) => {
+            resolveProbe = resolve;
+          })
+      );
+      writeSharedScenario();
+
+      render(<ChatboxChatPage />);
+      expect(await screen.findByTestId("chatbox-chat-tab")).toBeInTheDocument();
+
+      await userEvent.click(
+        screen.getByRole("button", { name: "Trigger OAuth" })
+      );
+
+      // "No authorization needed" is the weakest possible answer, and still not
+      // enough to overturn a 401 already observed on the wire.
+      await act(async () => {
+        resolveProbe({
+          useOAuth: true,
+          requiresAuthorization: false,
+          effectiveAuthMethod: "discover",
+          serverUrl: "https://rabona.ignaciojimenezrocabado.workers.dev/mcp",
+        });
+      });
+      await act(async () => {
+        await Promise.resolve();
+      });
+
+      expect(
+        await screen.findByRole("heading", { name: "Authorization Required" })
+      ).toBeInTheDocument();
+    });
+
+    it("does not let a verification that started earlier erase a newer 401", async () => {
+      mockCheckHostedServerOAuthRequirement.mockResolvedValue({
+        useOAuth: true,
+        requiresAuthorization: true,
+        effectiveAuthMethod: "oauth",
+        serverUrl: "https://rabona.ignaciojimenezrocabado.workers.dev/mcp",
+      });
+      // Hold the credential check open so the 401 lands while it is in flight.
+      let resolveValidation: (value: unknown) => void = () => {};
+      mockValidateHostedServer.mockImplementation(
+        () =>
+          new Promise((resolve) => {
+            resolveValidation = resolve;
+          })
+      );
+      writeSharedScenario();
+
+      render(<ChatboxChatPage />);
+      expect(await screen.findByTestId("chatbox-chat-tab")).toBeInTheDocument();
+
+      await waitFor(() => expect(mockValidateHostedServer).toHaveBeenCalled());
+
+      await userEvent.click(
+        screen.getByRole("button", { name: "Trigger OAuth" })
+      );
+      expect(
+        await screen.findByRole("heading", { name: "Authorization Required" })
+      ).toBeInTheDocument();
+
+      // The verification now succeeds — but it was asking about a credential the
+      // 401 has since disproved, so its answer is stale and must not stand.
+      await act(async () => {
+        resolveValidation({ success: true, status: "connected", initInfo: null });
+      });
+
+      expect(
+        screen.getByRole("heading", { name: "Authorization Required" })
+      ).toBeInTheDocument();
+    });
+
     it("prompts the recipient when the server does require authorization", async () => {
       mockCheckHostedServerOAuthRequirement.mockResolvedValue({
         useOAuth: true,

--- a/mcpjam-inspector/client/src/hooks/hosted/use-hosted-oauth-gate.ts
+++ b/mcpjam-inspector/client/src/hooks/hosted/use-hosted-oauth-gate.ts
@@ -169,17 +169,27 @@ function buildHostedOAuthStateMap(
     } else if (matchesResume) {
       status = hasToken || isVaultBacked ? "verifying" : "resuming";
       errorMessage = null;
-    } else if (
-      server.authorizationRequiredUpfront === false &&
-      !runtimeRequiredServerIds.has(server.serverId)
-    ) {
+    } else if (runtimeRequiredServerIds.has(server.serverId)) {
+      // A tagged 401 proved on the wire that this server needs authorizing, so
+      // no rebuild may retract the prompt — not a stale stored token (which
+      // would downgrade it to "verifying"), and not an
+      // `authorizationRequiredUpfront: false` descriptor. Only consent already
+      // given outranks it: the launching/resume branches above, or an
+      // authorization that has since completed as ready/verifying.
+      status =
+        existing?.status === "ready" || existing?.status === "verifying"
+          ? existing.status
+          : "needs_auth";
+      if (status !== "needs_auth") {
+        errorMessage = null;
+      }
+    } else if (server.authorizationRequiredUpfront === false) {
       // Satisfied by construction: this row can use OAuth but does not demand
       // it before the session runs, so there is no credential to wait for and
       // nothing to verify — a leftover token or vault record from an earlier
       // connect attempt must not resurrect a prompt the server never needed.
-      // Runtime escalation (a real 401) can still flip it to needs_auth. Only
-      // an in-flight authorization and a returning callback (above) outrank
-      // this, because those are consent the user just gave for THIS server.
+      // Runtime escalation (a real 401) still flips it to needs_auth, through
+      // the runtime-required branch above.
       status = "ready";
       errorMessage = null;
     } else if (hasToken) {
@@ -321,6 +331,12 @@ export function useHostedOAuthGate({
   const [runtimeRequiredServerIds, setRuntimeRequiredServerIds] = useState<
     ReadonlySet<string>
   >(() => new Set());
+  // A runtime 401 that arrived before any server had joined the authorizable
+  // set, held until one does. `undefined` means nothing is held; `null` means a
+  // request that carried no server details (it applies to whatever arrives).
+  const [deferredOAuthRequirement, setDeferredOAuthRequirement] = useState<
+    HostedOAuthRequiredDetails | null | undefined
+  >(undefined);
   const [oauthStateByServerId, setOAuthStateByServerId] = useState<
     Record<string, HostedOAuthState>
   >(() =>
@@ -334,6 +350,11 @@ export function useHostedOAuthGate({
   );
   const oauthStateByServerIdRef = useRef(oauthStateByServerId);
   const processingServerIdsRef = useRef<Set<string>>(new Set());
+  // Bumped per server every time a runtime 401 escalates it. Credential
+  // verification reads it before awaiting and again after: a 401 observed on the
+  // wire is NEWER evidence than a verification that started before it, so a
+  // success arriving late must not overwrite the prompt that 401 raised.
+  const runtimeRequiredEpochRef = useRef<Map<string, number>>(new Map());
   const isUnmountedRef = useRef(false);
 
   useEffect(() => {
@@ -479,6 +500,9 @@ export function useHostedOAuthGate({
           }));
         }
 
+        const epochBeforeValidation =
+          runtimeRequiredEpochRef.current.get(server.serverId) ?? 0;
+
         const validation = await validateWithRetry(
           server.serverId,
           accessToken ?? undefined,
@@ -493,6 +517,15 @@ export function useHostedOAuthGate({
             : undefined
         );
         if (isUnmountedRef.current) return;
+
+        // A 401 landed while this verification was in flight. Its prompt is the
+        // newer truth about the credential; leave it standing.
+        if (
+          (runtimeRequiredEpochRef.current.get(server.serverId) ?? 0) !==
+          epochBeforeValidation
+        ) {
+          return;
+        }
 
         if (validation.ok) {
           clearHostedOAuthResumeMarker();
@@ -740,38 +773,60 @@ export function useHostedOAuthGate({
 
   const markOAuthRequired = useCallback(
     (details?: HostedOAuthRequiredDetails) => {
-      const runtimeRequiredIds: string[] = [];
+      // Resolve targets OUTSIDE the updater. React runs updaters lazily during
+      // the render pass, so ids collected inside one were not yet available to
+      // the `setRuntimeRequiredServerIds` call below — the set stayed empty and
+      // the guard that exists to survive a rebuild never fired. Clearing tokens
+      // is a side effect and does not belong in an updater either.
+      const matchingServers = oauthServers.filter((server) => {
+        if (details?.serverId && server.serverId === details.serverId) {
+          return true;
+        }
+        if (details?.serverName && server.serverName === details.serverName) {
+          return true;
+        }
+        if (details?.serverUrl && server.serverUrl === details.serverUrl) {
+          return true;
+        }
+        return false;
+      });
+
+      const fallbackServer =
+        matchingServers.length > 0
+          ? null
+          : oauthServers.length === 1
+          ? oauthServers[0]
+          : null;
+      const targetServers =
+        matchingServers.length > 0
+          ? matchingServers
+          : fallbackServer
+          ? [fallbackServer]
+          : oauthServers;
+
+      if (targetServers.length === 0) {
+        // Nothing to escalate YET. A server joins this set only once the
+        // requirement probe has answered for it, and that answer is fetched
+        // asynchronously — so a real 401 can arrive while the set is still
+        // empty. Dropping it there is what left the recipient of an `auto`
+        // (discover) server with a failed tool call and no Authorize action,
+        // since a runtime 401 is that server's ONLY route to a prompt. Hold the
+        // request and replay it once servers arrive.
+        setDeferredOAuthRequirement(details ?? null);
+        return;
+      }
+
+      for (const server of targetServers) {
+        runtimeRequiredEpochRef.current.set(
+          server.serverId,
+          (runtimeRequiredEpochRef.current.get(server.serverId) ?? 0) + 1
+        );
+        localStorage.removeItem(`mcp-tokens-${server.serverName}`);
+      }
+
       setOAuthStateByServerId((previous) => {
         const nextState = { ...previous };
-        const matchingServers = oauthServers.filter((server) => {
-          if (details?.serverId && server.serverId === details.serverId) {
-            return true;
-          }
-          if (details?.serverName && server.serverName === details.serverName) {
-            return true;
-          }
-          if (details?.serverUrl && server.serverUrl === details.serverUrl) {
-            return true;
-          }
-          return false;
-        });
-
-        const fallbackServer =
-          matchingServers.length > 0
-            ? null
-            : oauthServers.length === 1
-            ? oauthServers[0]
-            : null;
-        const targetServers =
-          matchingServers.length > 0
-            ? matchingServers
-            : fallbackServer
-            ? [fallbackServer]
-            : oauthServers;
-
         for (const server of targetServers) {
-          runtimeRequiredIds.push(server.serverId);
-          localStorage.removeItem(`mcp-tokens-${server.serverName}`);
           nextState[server.serverId] = {
             status: "needs_auth",
             errorMessage: details?.serverUrl ? null : RUNTIME_OAUTH_ERROR,
@@ -787,14 +842,33 @@ export function useHostedOAuthGate({
       });
       // Remember it outside the status map so a later rebuild keeps the prompt.
       setRuntimeRequiredServerIds((previous) => {
-        if (runtimeRequiredIds.every((id) => previous.has(id))) {
+        if (targetServers.every((server) => previous.has(server.serverId))) {
           return previous;
         }
-        return new Set([...previous, ...runtimeRequiredIds]);
+        return new Set([
+          ...previous,
+          ...targetServers.map((server) => server.serverId),
+        ]);
       });
     },
     [oauthServers]
   );
+
+  const markOAuthRequiredRef = useRef(markOAuthRequired);
+  useEffect(() => {
+    markOAuthRequiredRef.current = markOAuthRequired;
+  }, [markOAuthRequired]);
+
+  // Replay a 401 that beat the servers into the gate. Guarded on a non-empty
+  // set so the replay always finds a target and cannot re-defer itself.
+  useEffect(() => {
+    if (deferredOAuthRequirement === undefined) return;
+    if (oauthServers.length === 0) return;
+
+    const details = deferredOAuthRequirement;
+    setDeferredOAuthRequirement(undefined);
+    markOAuthRequiredRef.current(details ?? undefined);
+  }, [deferredOAuthRequirement, oauthServers]);
 
   const pendingOAuthServers = useMemo(
     () =>


### PR DESCRIPTION
## Summary

Follow-up to #3925 / #3939. A hosted server joins the authorizable set only once `check-oauth` has answered whether it needs authorization. That probe is async and retries up to 6× at 300ms — and a real 401 arriving inside that window matched no server, so `markOAuthRequired` returned having done nothing.

For an `oauth` row that was survivable, since it prompts up front anyway. For an **`auto` (discover) row it was the whole failure**: the row is deliberately started as "no authorization needed", so a runtime 401 is its *only* route to a prompt. Drop it and the recipient gets a failed tool call and no Authorize action — the exact dead end #3925 set out to remove.

Scope note: only the *first* 401, inside the probe window, was lost; a later one escalated fine. So this was a bad first-run experience rather than a permanent dead end.

## What changed

Three defects, one story — a 401 observed on the wire is the newest evidence there is about a credential, and nothing may quietly outrank it.

1. **Hold and replay.** An escalation that lands before any server has joined the gate is held and replayed once one does, instead of discarded.
2. **The dead guard.** `runtimeRequiredServerIds` was populated from ids collected *inside* a `setOAuthStateByServerId` updater. React runs updaters lazily during the render pass, so the array was still empty when the set was written — the set never populated, and the guard that exists to stop a rebuild retracting the prompt never fired once. Now resolved outside the updater (where the `localStorage` side effect also belongs), and honoured ahead of both a stale stored token and an `authorizationRequiredUpfront: false` descriptor.
3. **Epoch guard.** A credential verification that began before the 401 could land its success afterwards and overwrite the prompt. Verification is now epoch-stamped per server; a result whose epoch moved is answering about a credential the 401 has since disproved, and is dropped.

**Deliberately unchanged:** the guest first-consent welcome still precedes the auth panel, and servers still join the gate only once the probe answers. An earlier attempt admitted servers during the probe window instead — that fixed the 401 but let the auth panel preempt the welcome screen, so it was discarded in favour of hold-and-replay.

## Verification

Three regression tests, one per defect. Each **fails on `main` and passes here** — confirmed by stashing the production diff and re-running:

```
× still prompts when the 401 beats the requirement probe
× keeps the runtime prompt when a late probe answer rebuilds the gate
× does not let a verification that started earlier erase a newer 401
Tests  3 failed | 35 passed (38)
```

With the fix: `38 passed (38)`.

Also checked:
- `tsc --noEmit -p client/tsconfig.json` — 485 errors before and after, i.e. this adds none (that baseline is pre-existing on `main`).
- Full inspector suite: the only 2 test failures are `server/routes/v1/__tests__/scenarios.test.ts`, which fail identically on clean `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit d4e6b357626c7757998661a772e4fbb3a68ba728. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stops losing a runtime 401 that arrives before the hosted OAuth requirement probe completes, so recipients reliably see the Authorize prompt. Before: a 401 in the probe window matched no server and `markOAuthRequired` did nothing, leaving `auto` (discover) rows with failed tool calls and no prompt. Now: we hold and replay the 401 once servers are known, treat it as the newest truth, and block stale validations from erasing the prompt.

**Key changes**
- Hold and replay a 401 that beats the `check-oauth` probe instead of discarding it.
- Populate and honor `runtimeRequiredServerIds` outside the state updater; it outranks stored tokens and `authorizationRequiredUpfront: false`.
- Epoch-guard validation per server; results that started before a 401 no longer overwrite its prompt.
- Clear stored tokens for targeted servers and set `needs_auth`; then replay any deferred 401 once servers load.
- Intentional non-change: guest consent still precedes the auth panel; servers still join the gate only after the probe answers.

**Review notes**
- Logic lives in `use-hosted-oauth-gate.ts`; three regression tests added in `ChatboxChatPage.test.tsx` cover the probe-window, rebuild, and stale-validation cases.

<sup>Written for commit d4e6b357626c7757998661a772e4fbb3a68ba728. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/MCPJam/inspector/pull/3940?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

