### PR TITLE
feat(server-connections): discovery preflight + inbound service-token guard

### DIFF
--- a/NOTES-item-2.md
+++ b/NOTES-item-2.md
@@ -62,15 +62,42 @@ before (every existing use sends the header outbound). A deliberate mirror of th
 
 ### `server/services/server-connection-discovery.ts`
 
-The bounded, unauthenticated preflight and its classification, using the SDK's `runServerDoctor`
-(the Inspector's house entry, which wraps `http-server-doctor.ts` / `server-doctor-core.ts`) —
-no new prober.
+The bounded, unauthenticated preflight and its classification, using the SDK's `probeMcpServer` —
+the same prober the server doctor runs, so no new prober.
 
-The SSRF guard runs **before any socket exists**, via `assertOutboundOAuthUrlAllowed` from
-`@mcpjam/sdk/oauth/node`. A refusal is classified `terminal`, not `retryable`: the address a URL
-names is not going to become public on the next attempt.
+The prober rather than the whole doctor. Classification reads `probe` and nothing else, so the
+doctor's tool/resource/prompt enumeration is work discovery never looks at — and the doctor's
+connect step dials through MCPClientManager's own transport, which takes no `fetchFn` and is
+therefore the one outbound path the egress guard cannot reach (the same scope limit documented on
+`routes/shared/conformance.ts`). Dropping it removes an unguarded socket.
 
-Classification, mapped off the doctor's probe status:
+**SSRF defence is two layers, and the first one alone is not enough.** This was wrong in the
+original version of this branch and is worth spelling out:
+
+1. `assertOutboundOAuthUrlAllowed` from `@mcpjam/sdk/oauth/node` is a pure RFC 6890 classifier over
+   the URL's **hostname string**. It refuses literal private/loopback/link-local/CGNAT/multicast/
+   documentation/NAT64-private/IPv4-mapped-private targets and non-http(s) schemes before any
+   socket exists. What it cannot do — as `oauth/node.ts` says of it in as many words — is judge a
+   bare public hostname: `evil.example` passes and can still resolve to `169.254.169.254`.
+2. The probe therefore dials through `createGuardedFetch` (`server/utils/hosted-egress-guard.ts`,
+   the same helper `routes/shared/conformance.ts` uses), which resolves the hostname, refuses
+   private answers, and re-checks **every redirect hop**. The redirect half is not optional: a
+   caller need not name the address they want reached — they can name a host they control and have
+   it answer `302 Location: http://169.254.169.254/`.
+
+One wrinkle worth knowing: `probeMcpServer` **catches** whatever `fetchFn` throws and reports it as
+`status: "error"`, which classifies as retryable. Correct for a timeout, wrong for an egress
+refusal — it would put an SSRF attempt on a retry schedule. So the guard's verdict is recorded as
+it passes and consulted before the probe's own account. A blocked target is `terminal`; a resolver
+**outage** is `retryable`, because DNS blipping is our infrastructure trouble and not a verdict
+about the user's server.
+
+Residual gap, accepted repo-wide rather than invented here: the guard validates the DNS answer and
+the HTTP client then resolves again, leaving a check-vs-connect (TOCTOU) window.
+`hosted-egress-guard.ts` documents that punt for every egress path in this server; closing it needs
+connection pinning at the infra layer, not a second private copy here.
+
+Classification, mapped off the probe status:
 
 | probe | outcome |
 | --- | --- |
@@ -84,7 +111,8 @@ The `error` → `retryable` arm is the one that matters most and has an explicit
 `unsupported` for a server that was down for a minute would permanently mislabel a server that
 works.
 
-14 tests.
+20 tests, including a public hostname whose DNS answer is private, a target that only turns private
+on a redirect, a resolver outage staying retryable, and empty/null URLs.
 
 ## Open question a human needs to settle: XAA
 
@@ -116,7 +144,7 @@ expectations were changed.
 
 ## Gates
 
-```
+```sh
 npm run build -w @mcpjam/sdk              # clean
 cd mcpjam-inspector && npx vitest run --project server
                                           # 369 files passed | 1 skipped

--- a/NOTES-item-2.md
+++ b/NOTES-item-2.md
@@ -114,6 +114,29 @@ its own entry the specifier rewrote to `sdk/src/index.ts/oauth/node` and failed 
 other SDK subpath the server imports already has the same pair of entries. No existing test's
 expectations were changed.
 
+## Gates
+
+```
+npm run build -w @mcpjam/sdk              # clean
+cd mcpjam-inspector && npx vitest run --project server
+                                          # 369 files passed | 1 skipped
+                                          # 5259 tests passed | 22 skipped  ← 0 failures
+```
+
+Prettier (v2, `--trailing-comma all`) was run on only the files this branch creates or edits.
+
+**`npm test` — the whole workspace — is RED, and it is red on `origin/main` too.** Three client
+tests fail; this diff touches only `mcpjam-inspector/server/**` and two root markdown files, and
+the `client` vitest project is rooted at `./client`, so nothing here can reach them. Verified
+directly rather than assumed: `SwarmsTab.perClientEnvLaunch.test.tsx` ("refuses the whole launch
+when one of the two environments is gone") fails identically at `8cedc9e`, i.e. `origin/main`
+with this branch's commit absent. The other two surface only under full-suite parallel load and
+pass when their files are run alone, which is the signature of flake rather than breakage.
+
+Not fixed here. They are unrelated client component tests, and making them pass would mean
+editing existing tests' expectations — a §7 stop condition in its own right. Flagged so the red
+is not mistaken for something this branch did.
+
 ## What is left for whoever picks this up
 
 1. Backend: expose the state machine over `/internal/v1/server-connections/*` (lease acquire and

--- a/NOTES-item-2.md
+++ b/NOTES-item-2.md
@@ -57,8 +57,14 @@ before (every existing use sends the header outbound). A deliberate mirror of th
   must not adopt — so it cannot be reached for by accident.
 - 401 body is identical for absent, malformed, and wrong tokens, and never reveals whether a named
   request id exists.
+- The configured token is **trimmed**, and whitespace-only counts as unset. The presented header was
+  already trimmed, so leaving the configured value untrimmed made the two sides asymmetric: a
+  deployment whose secret picked up a trailing newline rejected every correctly presented token —
+  fail-closed, but a total outage that reads as a credential mismatch. **The backend's
+  `convex/lib/serviceToken.ts` has the same asymmetry and should get the same treatment**; not
+  changed from here, because a silent one-sided edit is the drift the mirror exists to prevent.
 
-9 tests.
+11 tests.
 
 ### `server/services/server-connection-discovery.ts`
 
@@ -111,8 +117,40 @@ The `error` → `retryable` arm is the one that matters most and has an explicit
 `unsupported` for a server that was down for a minute would permanently mislabel a server that
 works.
 
-20 tests, including a public hostname whose DNS answer is private, a target that only turns private
-on a redirect, a resolver outage staying retryable, and empty/null URLs.
+### The `oauth` vs `unsupported` test, and a bug that made it a no-op
+
+An earlier revision accepted **either** a discovered `authorizationServerMetadataUrl` **or** a
+non-empty `registrationStrategies` list as proof of an actionable challenge. That inverted the whole
+test. `sdk/src/server-probe.ts` returns `registrationStrategies: ["preregistered"]` from the branch
+it takes when metadata discovery **threw** — which is exactly the manual-bearer and unknown-scheme
+case — so the list was non-empty precisely when discovery had failed, and `unsupported` became
+unreachable. A manual-bearer server would have been routed into `awaiting_authorization` with no
+consent screen to open.
+
+Now the only sufficient signal is a non-empty `authorizationServerMetadataUrl` — somewhere to
+actually send the user — plus a `Bearer` scheme in the challenge when one is present. The
+manual-bearer test carries the real `["preregistered"]` shape so the disjunct cannot come back.
+
+Worth recording why the original tests did not catch it: they asserted against a hand-written
+fixture (`registrationStrategies: []`) that the real prober never produces for that case. The
+fixture agreed with the code and both were wrong about the world.
+
+### Transport and bounds
+
+- **HTTPS-only for public targets.** `assertOutboundOAuthUrlAllowed` judges addresses, not
+  transport, and accepts `http:`. Plaintext to a public host is refused here; loopback keeps its
+  plaintext exception under the explicit opt-in, because `http://127.0.0.1:3000/mcp` is the
+  local-development product.
+- **Bounded for real.** `timeoutMs` bounds ONE request and the probe makes several, so a caller
+  value is clamped to `MAX_DISCOVERY_TIMEOUT_MS` and the whole step races an absolute
+  `DISCOVERY_DEADLINE_MS`. Without the deadline a deliberately slow target holds a work lease for
+  the sum of every request the probe chooses to make.
+
+27 tests. The two SSRF cases run through the **real** `createGuardedFetch` with an injected resolver
+and base fetch, not a mock that throws on cue — the DNS case asserts nothing was dialled at all, and
+the redirect case asserts exactly one request, so the private hop provably was never reached. A
+third case checks a public-to-public redirect still succeeds, since refusing redirects wholesale
+would be its own bug.
 
 ## Open question a human needs to settle: XAA
 

--- a/NOTES-item-2.md
+++ b/NOTES-item-2.md
@@ -1,0 +1,127 @@
+# NOTES — item 2 (internal advance endpoint + discovery)
+
+**Status: stopped before the endpoint. The Inspector-local half is built and tested; the
+endpoint itself is blocked on a backend surface that does not exist.**
+
+This is a §7 stop, taken on "the work needs a design decision this document does not answer"
+rather than on a failing gate. Every gate that applies to what shipped is green.
+
+## The blocker
+
+Item 2's endpoint is specified as three steps:
+
+1. `acquireWorkLease` — a backend call, before any work.
+2. Exactly one idempotent step — Inspector-local.
+3. Report through `reportDiscovery` — a backend call.
+
+Steps 1 and 3 have **no wire path from the Inspector**, and building one means inventing a
+cross-repo contract.
+
+What I checked, and what I found:
+
+| question | answer |
+| --- | --- |
+| Are the state-machine functions reachable from a Convex client? | No. Every export in `convex/serverConnectionRequests.ts` is `internal*`. `internal*` functions are unreachable from any client, by design. |
+| Does the Inspector hold a Convex admin/deploy key? | No. `grep` for `CONVEX_ADMIN`, `CONVEX_DEPLOY_KEY`, `anyApi`, `makeFunctionReference` across `mcpjam-inspector/server` returns nothing. The only Convex env vars are `CONVEX_URL` and `CONVEX_HTTP_URL`. |
+| How does the Inspector reach backend internals today? | Only through the backend's `/internal/v1/*` HTTP routes, gated by `INSPECTOR_SERVICE_TOKEN`. See `server/services/internal-backend.ts`, which is the shared plumbing for exactly this. |
+| Does a `/internal/v1/server-connections/*` route exist? | **No.** `grep -n "/internal/v1"` in `convex/http.ts` lists 14 route paths; none is a server-connection route. `grep serverConnection` across the whole backend finds the module, the schema table, the lib helpers, and its tests — and nothing in `http.ts`. |
+| Is the Inspector's `ConvexHttpClient` a way in? | No. `routes/v1/convex-client.ts` constructs it with a **user** auth token, which can only call public functions. |
+
+So the brief's "report the result through the guarded backend mutation" has no guarded mutation
+to report through yet. The backend HTTP routes that would expose the state machine are part of
+"the REST routes", which §8 explicitly defers until item 1 is merged and deployed — which cannot
+happen while this agent runs.
+
+Writing the endpoint anyway would mean choosing, unreviewed: the route paths, the request and
+response envelopes, the error-code vocabulary, and how a lease id round-trips. A human would then
+have to match all of it on the backend side. Per §1 ("guess at a design fork. Stop instead") that
+is the thing not to do.
+
+## What shipped instead
+
+Two modules that are fully determined by the brief, commit to no cross-repo contract, and are
+exactly what the endpoint will consume when someone builds it.
+
+### `server/middleware/internal-service-auth.ts`
+
+Inbound `INSPECTOR_SERVICE_TOKEN` verification — the direction the Inspector has never needed
+before (every existing use sends the header outbound). A deliberate mirror of the backend's
+`convex/lib/serviceToken.ts` in its `header-only` mode.
+
+- Constant-time compare over **SHA-256 digests of both sides**. `timingSafeEqual` throws on a
+  length mismatch, so comparing raw tokens forces a length branch that leaks the secret's length
+  to anyone who can time it. Two digests are always 32 bytes, so there is nothing to branch on.
+- Fails closed when `INSPECTOR_SERVICE_TOKEN` is unset or empty. Unconfigured must mean "nobody is
+  authorized", never "no guard".
+- Does **not** implement the backend's `header-or-bearer` mode, which that file says new routes
+  must not adopt — so it cannot be reached for by accident.
+- 401 body is identical for absent, malformed, and wrong tokens, and never reveals whether a named
+  request id exists.
+
+9 tests.
+
+### `server/services/server-connection-discovery.ts`
+
+The bounded, unauthenticated preflight and its classification, using the SDK's `runServerDoctor`
+(the Inspector's house entry, which wraps `http-server-doctor.ts` / `server-doctor-core.ts`) —
+no new prober.
+
+The SSRF guard runs **before any socket exists**, via `assertOutboundOAuthUrlAllowed` from
+`@mcpjam/sdk/oauth/node`. A refusal is classified `terminal`, not `retryable`: the address a URL
+names is not going to become public on the next attempt.
+
+Classification, mapped off the doctor's probe status:
+
+| probe | outcome |
+| --- | --- |
+| `ready` (initialize succeeded, no credential) | `discovered` / `none` |
+| `oauth_required` + an actionable challenge | `discovered` / `oauth` |
+| `oauth_required` + nothing actionable | `discovered` / `unsupported` |
+| `reachable` (answered, but not MCP) | `terminal`, `NOT_AN_MCP_SERVER` |
+| `error` (probe exhausted its retry policy) | `retryable` — **no discovery reported** |
+
+The `error` → `retryable` arm is the one that matters most and has an explicit test: reporting
+`unsupported` for a server that was down for a minute would permanently mislabel a server that
+works.
+
+14 tests.
+
+## Open question a human needs to settle: XAA
+
+The brief lists four things that must classify as `unsupported`: basic, manual bearer, XAA, and
+unknown. Three of those fall out of one test — "did discovery find an authorization server we
+could actually send someone to?" Basic names none because the scheme has no concept of one;
+manual-bearer servers challenge with `Bearer` and publish no metadata because there is no flow to
+run; unknown schemes name none either.
+
+**XAA does not.** An XAA server challenges with `Bearer` and *does* publish authorization server
+metadata, so the current classifier calls it `oauth`. Separating the two needs an XAA-specific
+marker in the discovered metadata, and I could not find a settled one — the SDK has a full
+`sdk/src/xaa/` flow, but nothing in the probe path that identifies an XAA server from its
+challenge or its metadata (`grep` for a `www-authenticate` scheme or an `xaa_required` style
+signal in `sdk/src` finds only DCR client-secret helpers).
+
+Left deliberately misclassified, with the gap named in a comment at the decision site. A guessed
+detector is worse than a known gap here: the failure mode of a wrong detector is refusing servers
+that actually work, and it would be attributed to the server rather than to us.
+
+## Test-config change worth a glance
+
+`server/vitest.config.ts` gained an alias and an inline entry for `@mcpjam/sdk/oauth/node`.
+
+Not optional and not cosmetic: the aliases in that file are **prefix** replacements, so without
+its own entry the specifier rewrote to `sdk/src/index.ts/oauth/node` and failed to resolve. Every
+other SDK subpath the server imports already has the same pair of entries. No existing test's
+expectations were changed.
+
+## What is left for whoever picks this up
+
+1. Backend: expose the state machine over `/internal/v1/server-connections/*` (lease acquire and
+   release, discovery report, validation report), service-token gated, in the shape the existing
+   `/internal/v1/*` routes use. This is the design decision.
+2. Inspector: a typed client for those routes in `server/services/`, alongside `internal-backend.ts`.
+3. Inspector: `server/routes/internal/` mounted in `server/app.ts` beside the other route groups,
+   guarded by `internalServiceAuthMiddleware()`, doing lease → one step → report and returning 200
+   with a reason when the lease is refused (`leased`, `not-live`, `attempts-exhausted`).
+4. Then item 3's validation step, which stacks on all of the above and is otherwise blocked for
+   the same reason — see NOTES-item-3.md.

--- a/NOTES-item-3.md
+++ b/NOTES-item-3.md
@@ -1,0 +1,54 @@
+# NOTES — item 3 (validation step)
+
+**Status: not started. Blocked transitively, with nothing coherent to ship.**
+
+Item 3 adds the validation step to the endpoint item 2 was to create. That endpoint does not
+exist — see NOTES-item-2.md for the blocker (the connection-request state machine is entirely
+`internal*` and has no `/internal/v1/*` HTTP surface, so the Inspector cannot acquire a lease or
+report a result).
+
+Unlike item 2, item 3 has **no unblocked half worth extracting**, which is why this note ships
+without code beside it:
+
+- Step 1, "resolve the acting user's credential and exercise normal refresh resolution", reads a
+  credential the backend owns. There is no path to it for the same reason there is no path to the
+  state machine.
+- Step 2, "connect to the saved server", needs the server row that item 2's later work creates.
+  Discovery deliberately creates nothing.
+- Step 3, capability capture, is a thin wrapper over the doctor's existing
+  `collectConnectedHttpServerDoctorState` and is not worth a module on its own.
+
+The one piece that *would* have been extractable — the outcome→taxonomy mapping — is a four-line
+table over a credentialed connection attempt, and every arm of it is a claim about a live
+connection's failure mode. Pinning it against a hand-built fake with no connection behind it would
+test the fake.
+
+## What must be preserved when someone builds it
+
+Recording these because they are the parts a later implementer is most likely to get subtly wrong,
+and both are stated in the brief:
+
+**A server with no tools is still connected.** Successful `initialize` *is* readiness. An empty
+tool list is a legitimate server, not a failure — treating it as one would reject working servers
+at the last step of the flow.
+
+**`retryable` and `authentication-failed` are not interchangeable.** The mapping is:
+
+| condition | outcome |
+| --- | --- |
+| `initialize` succeeded | `ready` |
+| 401 / invalid token | `authentication-failed` |
+| network / timeout | `retryable` |
+| invalid MCP response | `terminal` |
+
+The reason the middle two must not collapse: `retryable` leaves the request in `validating` and
+schedules another attempt, so a stored credential survives a server that was briefly unreachable.
+`authentication-failed` sends the user back to consent. Mapping a transient network failure onto
+`authentication-failed` would ask a user to re-authorize a server whose credential was never
+invalid — and they would do it, because the message told them to.
+
+This is the same distinction the discovery classifier already enforces on its own side
+(`error` → `retryable`, never a discovery result), and it is tested there in
+`server/services/__tests__/server-connection-discovery.test.ts`. The validation step should be
+tested the same way, including the empty-tool-list case and the assertion that a `retryable`
+report leaves the status unchanged.

--- a/mcpjam-inspector/server/middleware/__tests__/internal-service-auth.test.ts
+++ b/mcpjam-inspector/server/middleware/__tests__/internal-service-auth.test.ts
@@ -104,6 +104,33 @@ describe("internalServiceAuthMiddleware", () => {
     expect(response.status).toBe(200);
   });
 
+  it("admits the token when the configured value carries stray whitespace", async () => {
+    // A secret pasted into a dashboard or read from a file routinely picks up
+    // a trailing newline. The presented header is trimmed, so leaving the
+    // configured value untrimmed made the two sides asymmetric and rejected
+    // every correctly presented token — a total, fail-closed outage that reads
+    // as a credential mismatch rather than a stray byte.
+    process.env.INSPECTOR_SERVICE_TOKEN = `  ${TOKEN}\n`;
+
+    const response = await createApp().request("/guarded", {
+      headers: { "x-inspector-service-token": TOKEN },
+    });
+
+    expect(response.status).toBe(200);
+  });
+
+  it("treats a whitespace-only configured token as unset", async () => {
+    process.env.INSPECTOR_SERVICE_TOKEN = "   ";
+
+    // It cannot be the token anyone meant to configure, and comparing against
+    // it would mean comparing against something no caller can present.
+    const response = await createApp().request("/guarded", {
+      headers: { "x-inspector-service-token": "   " },
+    });
+
+    expect(response.status).toBe(401);
+  });
+
   it("does not disclose why authorization failed", async () => {
     const missing = await createApp().request("/guarded");
     const wrong = await createApp().request("/guarded", {

--- a/mcpjam-inspector/server/middleware/__tests__/internal-service-auth.test.ts
+++ b/mcpjam-inspector/server/middleware/__tests__/internal-service-auth.test.ts
@@ -1,0 +1,117 @@
+/**
+ * Inbound `INSPECTOR_SERVICE_TOKEN` verification.
+ *
+ * The cases worth pinning are the fail-closed ones. A guard that admits when
+ * it is unconfigured, or that accepts the token in the bearer slot it was
+ * never meant to occupy, fails in the direction where nobody notices.
+ */
+import { Hono } from "hono";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { internalServiceAuthMiddleware } from "../internal-service-auth.js";
+
+const TOKEN = "svc_test_token_value";
+
+function createApp() {
+  const app = new Hono();
+  app.use("*", internalServiceAuthMiddleware());
+  app.get("/guarded", (c) => c.json({ ok: true }));
+  return app;
+}
+
+describe("internalServiceAuthMiddleware", () => {
+  const originalToken = process.env.INSPECTOR_SERVICE_TOKEN;
+
+  beforeEach(() => {
+    process.env.INSPECTOR_SERVICE_TOKEN = TOKEN;
+  });
+
+  afterEach(() => {
+    if (originalToken === undefined) {
+      delete process.env.INSPECTOR_SERVICE_TOKEN;
+    } else {
+      process.env.INSPECTOR_SERVICE_TOKEN = originalToken;
+    }
+  });
+
+  it("admits a request presenting the configured token", async () => {
+    const response = await createApp().request("/guarded", {
+      headers: { "x-inspector-service-token": TOKEN },
+    });
+
+    expect(response.status).toBe(200);
+  });
+
+  it("rejects a request with no token", async () => {
+    const response = await createApp().request("/guarded");
+
+    expect(response.status).toBe(401);
+  });
+
+  it("rejects a wrong token", async () => {
+    const response = await createApp().request("/guarded", {
+      headers: { "x-inspector-service-token": "svc_wrong_token_value" },
+    });
+
+    expect(response.status).toBe(401);
+  });
+
+  it("rejects a token that is a prefix of the configured one", async () => {
+    // Length is compared over digests, so a truncated token is no closer to
+    // admission than an unrelated one.
+    const response = await createApp().request("/guarded", {
+      headers: { "x-inspector-service-token": TOKEN.slice(0, -1) },
+    });
+
+    expect(response.status).toBe(401);
+  });
+
+  it("fails closed when the deployment has no token configured", async () => {
+    delete process.env.INSPECTOR_SERVICE_TOKEN;
+
+    // Unconfigured must mean "nobody is authorized", never "no guard".
+    const response = await createApp().request("/guarded", {
+      headers: { "x-inspector-service-token": TOKEN },
+    });
+
+    expect(response.status).toBe(401);
+  });
+
+  it("fails closed when the configured token is empty", async () => {
+    process.env.INSPECTOR_SERVICE_TOKEN = "";
+
+    const response = await createApp().request("/guarded", {
+      headers: { "x-inspector-service-token": "" },
+    });
+
+    expect(response.status).toBe(401);
+  });
+
+  it("does not accept the token in the Authorization bearer slot", async () => {
+    // The backend offers a header-or-bearer mode for one legacy flow and says
+    // new routes must not adopt it. This side does not implement it at all.
+    const response = await createApp().request("/guarded", {
+      headers: { Authorization: `Bearer ${TOKEN}` },
+    });
+
+    expect(response.status).toBe(401);
+  });
+
+  it("tolerates surrounding whitespace in the presented header", async () => {
+    const response = await createApp().request("/guarded", {
+      headers: { "x-inspector-service-token": `  ${TOKEN}  ` },
+    });
+
+    expect(response.status).toBe(200);
+  });
+
+  it("does not disclose why authorization failed", async () => {
+    const missing = await createApp().request("/guarded");
+    const wrong = await createApp().request("/guarded", {
+      headers: { "x-inspector-service-token": "svc_wrong_token_value" },
+    });
+
+    // A caller learns only that it could not authenticate — never whether the
+    // token was absent, malformed, or simply wrong.
+    expect(await missing.json()).toEqual(await wrong.json());
+  });
+});

--- a/mcpjam-inspector/server/middleware/__tests__/internal-service-auth.test.ts
+++ b/mcpjam-inspector/server/middleware/__tests__/internal-service-auth.test.ts
@@ -122,8 +122,20 @@ describe("internalServiceAuthMiddleware", () => {
   it("treats a whitespace-only configured token as unset", async () => {
     process.env.INSPECTOR_SERVICE_TOKEN = "   ";
 
-    // It cannot be the token anyone meant to configure, and comparing against
-    // it would mean comparing against something no caller can present.
+    // A GENUINE token is presented on purpose: if the header were also
+    // whitespace, the presented-token guard would reject it too and the test
+    // would still pass with the whitespace-only configuration check deleted —
+    // which is the fail-open regression it exists to catch. This way the 401
+    // can only come from the configuration side.
+    const response = await createApp().request("/guarded", {
+      headers: { "x-inspector-service-token": TOKEN },
+    });
+
+    expect(response.status).toBe(401);
+  });
+
+  it("rejects a whitespace-only presented token against a real config", async () => {
+    // The other guard, exercised on its own.
     const response = await createApp().request("/guarded", {
       headers: { "x-inspector-service-token": "   " },
     });

--- a/mcpjam-inspector/server/middleware/internal-service-auth.ts
+++ b/mcpjam-inspector/server/middleware/internal-service-auth.ts
@@ -1,0 +1,88 @@
+/**
+ * Inbound `INSPECTOR_SERVICE_TOKEN` verification.
+ *
+ * Every other place this credential appears in the Inspector sends it OUTBOUND
+ * — `services/identity.ts`, `services/organizations.ts`, and friends attach
+ * `x-inspector-service-token` to calls at the backend's `/internal/v1/*`
+ * routes. This module is the other direction: the check the Inspector applies
+ * when the backend calls IT.
+ *
+ * It is a deliberate mirror of the backend's `convex/lib/serviceToken.ts`,
+ * header-only mode. Same header name, same fail-closed posture, same
+ * constant-time compare. The two sides of one credential drifting apart is how
+ * a rotation succeeds in one repo and locks out the other.
+ *
+ * WHY THE REQUEST ID IS NOT AUTHORIZATION. The connection-request id (`scr_…`)
+ * travels in MCP tool output and CLI JSON — it is designed to be printable. An
+ * endpoint that accepted it as proof of anything would hand every surface that
+ * displays a request id the ability to drive that request's state machine.
+ * Possession of the service token is the only thing that authorizes these
+ * routes; the request id merely names which row is being worked on.
+ */
+import { createHash, timingSafeEqual } from "node:crypto";
+import type { Context, MiddlewareHandler } from "hono";
+
+export const INSPECTOR_SERVICE_TOKEN_HEADER = "x-inspector-service-token";
+
+export function getConfiguredInspectorServiceToken(): string | null {
+  const token = process.env.INSPECTOR_SERVICE_TOKEN;
+  return typeof token === "string" && token.length > 0 ? token : null;
+}
+
+/**
+ * Constant-time equality over SHA-256 digests of both sides.
+ *
+ * Digesting first is not belt-and-braces: `timingSafeEqual` throws on a length
+ * mismatch, so a raw comparison has to branch on length before it runs — and
+ * that branch leaks the secret's length to anyone who can time it. Two digests
+ * are always 32 bytes, so the length check can never fail and there is nothing
+ * to branch on. A plain `!==` would be worse still, bailing at the first
+ * mismatched byte and leaking the divergence position.
+ */
+function tokenMatches(presented: string, configured: string): boolean {
+  const left = createHash("sha256").update(presented, "utf8").digest();
+  const right = createHash("sha256").update(configured, "utf8").digest();
+  return timingSafeEqual(left, right);
+}
+
+/**
+ * True only when the deployment has a token configured AND the request
+ * presented a matching one.
+ *
+ * Fails closed on either side missing. A deployment with no
+ * `INSPECTOR_SERVICE_TOKEN` set must refuse these routes rather than treat
+ * "unconfigured" as "unguarded" — an Inspector booted without the variable is
+ * a misconfiguration, and the safe reading of a misconfiguration is that
+ * nobody is authorized.
+ *
+ * Only the dedicated header is consulted. The backend's `serviceToken.ts`
+ * additionally offers a `header-or-bearer` mode for one legacy flow and says
+ * new routes must not adopt it; this side does not implement it at all, so it
+ * cannot be reached for by accident.
+ */
+export function isAuthorizedInternalServiceRequest(c: Context): boolean {
+  const configured = getConfiguredInspectorServiceToken();
+  if (!configured) {
+    return false;
+  }
+  const presented = c.req.header(INSPECTOR_SERVICE_TOKEN_HEADER)?.trim();
+  if (!presented) {
+    return false;
+  }
+  return tokenMatches(presented, configured);
+}
+
+/**
+ * Hono middleware form. 401 with a deliberately uninformative body: a caller
+ * who cannot authenticate learns only that it could not, never whether the
+ * token was absent, malformed, or simply wrong — and never whether the
+ * request id it named exists.
+ */
+export function internalServiceAuthMiddleware(): MiddlewareHandler {
+  return async (c, next) => {
+    if (!isAuthorizedInternalServiceRequest(c)) {
+      return c.json({ ok: false, error: "unauthorized" }, 401);
+    }
+    await next();
+  };
+}

--- a/mcpjam-inspector/server/middleware/internal-service-auth.ts
+++ b/mcpjam-inspector/server/middleware/internal-service-auth.ts
@@ -24,9 +24,31 @@ import type { Context, MiddlewareHandler } from "hono";
 
 export const INSPECTOR_SERVICE_TOKEN_HEADER = "x-inspector-service-token";
 
+/**
+ * The configured token, trimmed, or null when unset or whitespace-only.
+ *
+ * The trim is not cosmetic. The presented header is trimmed before comparison,
+ * so leaving the configured value untrimmed makes the two sides asymmetric: a
+ * deployment whose `INSPECTOR_SERVICE_TOKEN` picked up a trailing newline —
+ * ordinary when a secret is pasted into a dashboard or read from a file —
+ * rejects every correctly presented token. The failure is safe (it fails
+ * closed) but total, and it looks like a credential mismatch rather than a
+ * stray byte of whitespace.
+ *
+ * Whitespace-only counts as unset for the same reason: it cannot be the token
+ * anyone meant to configure, and treating it as a real value would compare
+ * against something no caller can present.
+ *
+ * NOTE FOR THE MIRROR: the backend's `convex/lib/serviceToken.ts` has the same
+ * asymmetry today (untrimmed config, trimmed header) and should get the same
+ * treatment. It is not fixed from here — that file is this module's upstream,
+ * and a silent one-sided change is exactly the drift the mirror exists to
+ * prevent. Fixing it there only makes both sides more forgiving of a
+ * misconfiguration; it never widens who is authorized.
+ */
 export function getConfiguredInspectorServiceToken(): string | null {
-  const token = process.env.INSPECTOR_SERVICE_TOKEN;
-  return typeof token === "string" && token.length > 0 ? token : null;
+  const token = process.env.INSPECTOR_SERVICE_TOKEN?.trim();
+  return token ? token : null;
 }
 
 /**

--- a/mcpjam-inspector/server/services/__tests__/server-connection-discovery.test.ts
+++ b/mcpjam-inspector/server/services/__tests__/server-connection-discovery.test.ts
@@ -8,20 +8,28 @@
  * discovery result, and a server that answers with non-MCP must never be
  * retried.
  *
- * The doctor is injected rather than stubbed at the module level, so these
- * tests never open a socket and never depend on the SDK's internal probe
+ * The SSRF cases carry their weight here: a URL that passes the pure hostname
+ * classifier and only turns private once DNS answers, and a target that turns
+ * private only on a redirect. Both defeat a guard that inspects the first URL
+ * and stops, so both are asserted to come back TERMINAL rather than retryable —
+ * an SSRF attempt on a retry schedule is worse than one refused outright.
+ *
+ * The prober and the guarded fetch are both injected, so these tests never open
+ * a socket, never resolve a name, and never depend on the SDK's internal probe
  * layering.
  */
 import { describe, expect, it, vi } from "vitest";
-import type { ServerDoctorResult } from "@mcpjam/sdk";
+import type { ProbeMcpServerResult } from "@mcpjam/sdk";
+import {
+  BlockedEgressTargetError,
+  EgressResolutionError,
+} from "../../utils/hosted-egress-guard.js";
 import {
   classifyDiscoveryResult,
   runDiscoveryPreflight,
 } from "../server-connection-discovery.js";
 
-type Probe = NonNullable<ServerDoctorResult["probe"]>;
-
-function probe(overrides: Partial<Probe>): Probe {
+function probe(overrides: Partial<ProbeMcpServerResult>): ProbeMcpServerResult {
   return {
     url: "https://example.com/mcp",
     protocolVersion: "2025-11-25",
@@ -33,55 +41,46 @@ function probe(overrides: Partial<Probe>): Probe {
       registrationStrategies: [],
     },
     ...overrides,
-  } as Probe;
+  } as ProbeMcpServerResult;
 }
 
-function doctorResult(
-  overrides: Partial<ServerDoctorResult>,
-): ServerDoctorResult {
-  return {
-    target: null,
-    generatedAt: "2026-01-01T00:00:00.000Z",
-    status: "ready",
-    probe: probe({}),
-    connection: { status: "ok", detail: "connected" },
-    initInfo: null,
-    capabilities: null,
-    tools: [],
-    toolsMetadata: {},
-    resources: [],
-    resourceTemplates: [],
-    prompts: [],
-    checks: {},
-    error: null,
-    ...overrides,
-  } as ServerDoctorResult;
+/** A prober that reports whatever `fetchFn` threw as `status: "error"` —
+ *  the real `probeMcpServer`'s behaviour, and the reason an egress refusal has
+ *  to be recovered rather than read off the probe result. */
+function probeThroughFetch(): typeof import("@mcpjam/sdk").probeMcpServer {
+  return (async (config: { url: string; fetchFn?: typeof fetch }) => {
+    try {
+      await config.fetchFn?.(config.url, { method: "POST" });
+    } catch (error) {
+      return probe({
+        status: "error",
+        error: error instanceof Error ? error.message : String(error),
+      });
+    }
+    return probe({ status: "ready" });
+  }) as unknown as typeof import("@mcpjam/sdk").probeMcpServer;
 }
 
 describe("classifyDiscoveryResult", () => {
   it("reports authMethod none when initialize succeeds unauthenticated", () => {
-    const outcome = classifyDiscoveryResult(
-      doctorResult({ probe: probe({ status: "ready" }) }),
-    );
+    const outcome = classifyDiscoveryResult(probe({ status: "ready" }));
 
     expect(outcome).toMatchObject({ kind: "discovered", authMethod: "none" });
   });
 
   it("reports authMethod oauth for a challenge naming an authorization server", () => {
     const outcome = classifyDiscoveryResult(
-      doctorResult({
-        probe: probe({
-          status: "oauth_required",
-          oauth: {
-            required: true,
-            optional: false,
-            wwwAuthenticate:
-              'Bearer resource_metadata="https://example.com/.well-known"',
-            authorizationServerMetadataUrl:
-              "https://auth.example.com/.well-known/oauth-authorization-server",
-            registrationStrategies: ["dcr"],
-          },
-        }),
+      probe({
+        status: "oauth_required",
+        oauth: {
+          required: true,
+          optional: false,
+          wwwAuthenticate:
+            'Bearer resource_metadata="https://example.com/.well-known"',
+          authorizationServerMetadataUrl:
+            "https://auth.example.com/.well-known/oauth-authorization-server",
+          registrationStrategies: ["dcr"],
+        },
       }),
     );
 
@@ -92,15 +91,13 @@ describe("classifyDiscoveryResult", () => {
     // Either half is sufficient — a resolved strategy list means discovery got
     // far enough to know how a client would be identified.
     const outcome = classifyDiscoveryResult(
-      doctorResult({
-        probe: probe({
-          status: "oauth_required",
-          oauth: {
-            required: true,
-            optional: false,
-            registrationStrategies: ["preregistered"],
-          },
-        }),
+      probe({
+        status: "oauth_required",
+        oauth: {
+          required: true,
+          optional: false,
+          registrationStrategies: ["preregistered"],
+        },
       }),
     );
 
@@ -111,16 +108,14 @@ describe("classifyDiscoveryResult", () => {
     // Basic names no authorization server because the scheme has no concept
     // of one, so nothing is discovered and there is no flow to run.
     const outcome = classifyDiscoveryResult(
-      doctorResult({
-        probe: probe({
-          status: "oauth_required",
-          oauth: {
-            required: true,
-            optional: false,
-            wwwAuthenticate: 'Basic realm="mcp"',
-            registrationStrategies: [],
-          },
-        }),
+      probe({
+        status: "oauth_required",
+        oauth: {
+          required: true,
+          optional: false,
+          wwwAuthenticate: 'Basic realm="mcp"',
+          registrationStrategies: [],
+        },
       }),
     );
 
@@ -134,17 +129,15 @@ describe("classifyDiscoveryResult", () => {
     // Challenges with Bearer, publishes no authorization server metadata:
     // the token is meant to be pasted in by a human.
     const outcome = classifyDiscoveryResult(
-      doctorResult({
-        probe: probe({
-          status: "oauth_required",
-          oauth: {
-            required: true,
-            optional: false,
-            wwwAuthenticate: "Bearer",
-            registrationStrategies: [],
-            discoveryError: "No authorization server metadata found",
-          },
-        }),
+      probe({
+        status: "oauth_required",
+        oauth: {
+          required: true,
+          optional: false,
+          wwwAuthenticate: "Bearer",
+          registrationStrategies: [],
+          discoveryError: "No authorization server metadata found",
+        },
       }),
     );
 
@@ -158,12 +151,9 @@ describe("classifyDiscoveryResult", () => {
     // The host answered; the answer was not MCP. Retrying spends the request's
     // attempt budget to receive the same answer.
     const outcome = classifyDiscoveryResult(
-      doctorResult({
-        status: "error",
-        probe: probe({
-          status: "reachable",
-          error: "Server returned HTML instead of an MCP initialize result",
-        }),
+      probe({
+        status: "reachable",
+        error: "Server returned HTML instead of an MCP initialize result",
       }),
     );
 
@@ -175,23 +165,16 @@ describe("classifyDiscoveryResult", () => {
     // The distinction that matters most: a server that was down for a minute
     // must not be permanently labelled `unsupported`.
     const outcome = classifyDiscoveryResult(
-      doctorResult({
-        status: "error",
-        probe: probe({ status: "error", error: "connect ETIMEDOUT" }),
-      }),
+      probe({ status: "error", error: "connect ETIMEDOUT" }),
     );
 
     expect(outcome.kind).toBe("retryable");
     expect(outcome).not.toHaveProperty("authMethod");
   });
 
-  it("treats a doctor run that never probed as retryable", () => {
+  it("treats a probe that reached nothing as retryable", () => {
     const outcome = classifyDiscoveryResult(
-      doctorResult({
-        status: "error",
-        probe: null,
-        error: { code: "UNKNOWN", message: "socket hang up" },
-      }),
+      probe({ status: "error", error: "socket hang up" }),
     );
 
     expect(outcome.kind).toBe("retryable");
@@ -199,97 +182,213 @@ describe("classifyDiscoveryResult", () => {
 });
 
 describe("runDiscoveryPreflight", () => {
-  it("refuses a private target before any request is made", async () => {
-    const runDoctor = vi.fn();
+  const ready = () =>
+    vi.fn().mockResolvedValue(probe({ status: "ready" })) as unknown as never;
+
+  it("refuses a literal private target before any request is made", async () => {
+    const probeServer = vi.fn();
 
     const outcome = await runDiscoveryPreflight(
       { serverUrl: "http://169.254.169.254/latest/meta-data/" },
-      { runDoctor },
+      { probeServer: probeServer as never },
     );
 
     expect(outcome).toMatchObject({
       kind: "terminal",
       errorCode: "URL_NOT_ALLOWED",
     });
-    // The point of a preflight guard is that no socket is opened at all.
-    expect(runDoctor).not.toHaveBeenCalled();
+    // The point of a preflight classifier is that no socket is opened at all.
+    expect(probeServer).not.toHaveBeenCalled();
   });
 
   it("refuses loopback unless the local-dev opt-in is set", async () => {
-    const runDoctor = vi.fn();
+    const probeServer = vi.fn();
 
     const blocked = await runDiscoveryPreflight(
       { serverUrl: "http://127.0.0.1:3000/mcp" },
-      { runDoctor },
+      { probeServer: probeServer as never },
     );
+
     expect(blocked).toMatchObject({
       kind: "terminal",
       errorCode: "URL_NOT_ALLOWED",
     });
-    expect(runDoctor).not.toHaveBeenCalled();
+    expect(probeServer).not.toHaveBeenCalled();
   });
 
   it("allows loopback when the opt-in is set", async () => {
-    const runDoctor = vi
-      .fn()
-      .mockResolvedValue(doctorResult({ probe: probe({ status: "ready" }) }));
+    const probeServer = ready();
 
     const outcome = await runDiscoveryPreflight(
       { serverUrl: "http://127.0.0.1:3000/mcp", allowLoopback: true },
-      { runDoctor },
+      { probeServer },
     );
 
     expect(outcome).toMatchObject({ kind: "discovered", authMethod: "none" });
-    expect(runDoctor).toHaveBeenCalledTimes(1);
+    expect(probeServer).toHaveBeenCalledTimes(1);
   });
 
   it("keeps the loopback opt-in from relaxing anything else", async () => {
-    const runDoctor = vi.fn();
+    const probeServer = vi.fn();
 
     // A LAN address is not loopback. The opt-in exists for local development
     // against 127.0.0.1, not as a general private-network escape hatch.
     const outcome = await runDiscoveryPreflight(
       { serverUrl: "http://192.168.1.10/mcp", allowLoopback: true },
-      { runDoctor },
+      { probeServer: probeServer as never },
     );
 
     expect(outcome).toMatchObject({
       kind: "terminal",
       errorCode: "URL_NOT_ALLOWED",
     });
-    expect(runDoctor).not.toHaveBeenCalled();
+    expect(probeServer).not.toHaveBeenCalled();
   });
 
   it("rejects a non-http scheme", async () => {
-    const runDoctor = vi.fn();
+    const probeServer = vi.fn();
 
     const outcome = await runDiscoveryPreflight(
       { serverUrl: "file:///etc/passwd" },
-      { runDoctor },
+      { probeServer: probeServer as never },
     );
 
     expect(outcome).toMatchObject({
       kind: "terminal",
       errorCode: "URL_NOT_ALLOWED",
     });
-    expect(runDoctor).not.toHaveBeenCalled();
+    expect(probeServer).not.toHaveBeenCalled();
+  });
+
+  it("rejects an empty URL without probing", async () => {
+    const probeServer = vi.fn();
+
+    const outcome = await runDiscoveryPreflight(
+      { serverUrl: "" },
+      { probeServer: probeServer as never },
+    );
+
+    expect(outcome).toMatchObject({
+      kind: "terminal",
+      errorCode: "URL_NOT_ALLOWED",
+    });
+    expect(probeServer).not.toHaveBeenCalled();
+  });
+
+  it("rejects a null URL that slipped past the type system", async () => {
+    const probeServer = vi.fn();
+
+    // The caller is an HTTP route parsing an untrusted body, so `serverUrl`
+    // being absent at runtime is a real shape, not a hypothetical.
+    const outcome = await runDiscoveryPreflight(
+      { serverUrl: null as unknown as string },
+      { probeServer: probeServer as never },
+    );
+
+    expect(outcome).toMatchObject({
+      kind: "terminal",
+      errorCode: "URL_NOT_ALLOWED",
+    });
+    expect(probeServer).not.toHaveBeenCalled();
   });
 
   it("attaches no credential to the probe", async () => {
-    const runDoctor = vi
-      .fn()
-      .mockResolvedValue(doctorResult({ probe: probe({ status: "ready" }) }));
+    const probeServer = ready();
 
     await runDiscoveryPreflight(
       { serverUrl: "https://example.com/mcp" },
-      { runDoctor },
+      {
+        probeServer,
+      },
     );
 
     // Discovery asks what a stranger sees. A token here would classify a
     // server as open when it is not.
-    const config = runDoctor.mock.calls[0][0].config;
+    const config = (probeServer as unknown as { mock: { calls: unknown[][] } })
+      .mock.calls[0][0] as Record<string, unknown>;
     expect(config).not.toHaveProperty("accessToken");
-    expect(config).not.toHaveProperty("refreshToken");
-    expect(config).not.toHaveProperty("authProvider");
+    expect(config).not.toHaveProperty("headers");
+    expect(config.fetchFn).toBeTypeOf("function");
+  });
+
+  it("refuses a public hostname whose DNS answer is private", async () => {
+    // The whole point of the second layer. `evil.example` passes the pure
+    // hostname classifier — nothing about the STRING is private — and only
+    // turns dangerous once resolved. A guard that stopped at the classifier
+    // would have dialled it.
+    const outcome = await runDiscoveryPreflight(
+      { serverUrl: "https://evil.example/mcp" },
+      {
+        probeServer: probeThroughFetch(),
+        fetchFn: async () => {
+          throw new BlockedEgressTargetError(
+            'Request URL hostname "evil.example" resolves to 169.254.169.254',
+          );
+        },
+      },
+    );
+
+    // TERMINAL, not retryable: the prober swallows the throw and calls it
+    // `status: "error"`, and letting that stand would put an SSRF attempt on
+    // a retry schedule.
+    expect(outcome).toMatchObject({
+      kind: "terminal",
+      errorCode: "URL_NOT_ALLOWED",
+    });
+  });
+
+  it("refuses a target that only turns private on a redirect", async () => {
+    // A caller need not name the address they want reached: they can name a
+    // host they control and have it answer 302 Location: 169.254.169.254.
+    const outcome = await runDiscoveryPreflight(
+      { serverUrl: "https://redirector.example/mcp" },
+      {
+        probeServer: probeThroughFetch(),
+        fetchFn: async () => {
+          throw new BlockedEgressTargetError(
+            'Request URL points at a private or internal address ("169.254.169.254")',
+          );
+        },
+      },
+    );
+
+    expect(outcome).toMatchObject({
+      kind: "terminal",
+      errorCode: "URL_NOT_ALLOWED",
+    });
+  });
+
+  it("treats a resolver outage as retryable, not as a refusal", async () => {
+    // DNS blipping is our infrastructure trouble, not a verdict about the
+    // user's server. Reporting it as URL_NOT_ALLOWED would permanently fail a
+    // perfectly good request and tell the user their server is forbidden.
+    const outcome = await runDiscoveryPreflight(
+      { serverUrl: "https://example.com/mcp" },
+      {
+        probeServer: (async () => {
+          throw new EgressResolutionError(
+            'Could not check "example.com" for a safe address: SERVFAIL',
+          );
+        }) as never,
+      },
+    );
+
+    expect(outcome.kind).toBe("retryable");
+    expect(outcome).not.toHaveProperty("authMethod");
+  });
+
+  it("treats an unexpected prober rejection as retryable", async () => {
+    const outcome = await runDiscoveryPreflight(
+      { serverUrl: "https://example.com/mcp" },
+      {
+        probeServer: (async () => {
+          throw new Error("boom");
+        }) as never,
+      },
+    );
+
+    // Nothing was learned about the target, so no discovery may be reported.
+    expect(outcome).toMatchObject({ kind: "retryable", detail: "boom" });
+    expect(outcome).not.toHaveProperty("authMethod");
   });
 });

--- a/mcpjam-inspector/server/services/__tests__/server-connection-discovery.test.ts
+++ b/mcpjam-inspector/server/services/__tests__/server-connection-discovery.test.ts
@@ -21,11 +21,13 @@
 import { describe, expect, it, vi } from "vitest";
 import type { ProbeMcpServerResult } from "@mcpjam/sdk";
 import {
-  BlockedEgressTargetError,
+  createGuardedFetch,
   EgressResolutionError,
 } from "../../utils/hosted-egress-guard.js";
 import {
   classifyDiscoveryResult,
+  DISCOVERY_TIMEOUT_MS,
+  MAX_DISCOVERY_TIMEOUT_MS,
   runDiscoveryPreflight,
 } from "../server-connection-discovery.js";
 
@@ -87,9 +89,10 @@ describe("classifyDiscoveryResult", () => {
     expect(outcome).toMatchObject({ kind: "discovered", authMethod: "oauth" });
   });
 
-  it("accepts a challenge that resolved registration strategies but no metadata URL", () => {
-    // Either half is sufficient — a resolved strategy list means discovery got
-    // far enough to know how a client would be identified.
+  it("reports unsupported when strategies resolved but no authorization server did", () => {
+    // A strategy list is NOT a substitute for an authorization server: the
+    // prober fills it in with a default on the discovery-failed path, so
+    // trusting it routes a server with nowhere to send anyone into consent.
     const outcome = classifyDiscoveryResult(
       probe({
         status: "oauth_required",
@@ -101,7 +104,10 @@ describe("classifyDiscoveryResult", () => {
       }),
     );
 
-    expect(outcome).toMatchObject({ kind: "discovered", authMethod: "oauth" });
+    expect(outcome).toMatchObject({
+      kind: "discovered",
+      authMethod: "unsupported",
+    });
   });
 
   it("reports unsupported for a non-Bearer challenge", () => {
@@ -126,8 +132,14 @@ describe("classifyDiscoveryResult", () => {
   });
 
   it("reports unsupported for a manual bearer server", () => {
-    // Challenges with Bearer, publishes no authorization server metadata:
-    // the token is meant to be pasted in by a human.
+    // THE SHAPE THE PROBER ACTUALLY RETURNS, and a regression test for a real
+    // bug. When metadata discovery throws — which is exactly what happens for a
+    // manual-bearer server — `server-probe.ts` returns
+    // `registrationStrategies: ["preregistered"]` with NO
+    // `authorizationServerMetadataUrl`. An earlier revision treated a non-empty
+    // strategy list as sufficient, so this case classified as `oauth` and the
+    // `unsupported` branch was unreachable. The fixture deliberately carries
+    // the non-empty list to keep that from coming back.
     const outcome = classifyDiscoveryResult(
       probe({
         status: "oauth_required",
@@ -135,7 +147,7 @@ describe("classifyDiscoveryResult", () => {
           required: true,
           optional: false,
           wwwAuthenticate: "Bearer",
-          registrationStrategies: [],
+          registrationStrategies: ["preregistered"],
           discoveryError: "No authorization server metadata found",
         },
       }),
@@ -145,6 +157,48 @@ describe("classifyDiscoveryResult", () => {
       kind: "discovered",
       authMethod: "unsupported",
     });
+  });
+
+  it("reports unsupported for a non-Bearer challenge that still resolved metadata", () => {
+    // Basic has no authorization-code flow to run even if something
+    // OAuth-shaped sits at the well-known URL, so the scheme decides.
+    const outcome = classifyDiscoveryResult(
+      probe({
+        status: "oauth_required",
+        oauth: {
+          required: true,
+          optional: false,
+          wwwAuthenticate: 'Basic realm="mcp"',
+          authorizationServerMetadataUrl:
+            "https://auth.example.com/.well-known/oauth-authorization-server",
+          registrationStrategies: ["dcr"],
+        },
+      }),
+    );
+
+    expect(outcome).toMatchObject({
+      kind: "discovered",
+      authMethod: "unsupported",
+    });
+  });
+
+  it("accepts Bearer offered alongside another scheme", () => {
+    const outcome = classifyDiscoveryResult(
+      probe({
+        status: "oauth_required",
+        oauth: {
+          required: true,
+          optional: false,
+          wwwAuthenticate:
+            'Basic realm="mcp", Bearer resource_metadata="https://example.com/.well-known"',
+          authorizationServerMetadataUrl:
+            "https://auth.example.com/.well-known/oauth-authorization-server",
+          registrationStrategies: ["dcr"],
+        },
+      }),
+    );
+
+    expect(outcome).toMatchObject({ kind: "discovered", authMethod: "oauth" });
   });
 
   it("treats a non-MCP response as terminal, not retryable", () => {
@@ -260,6 +314,64 @@ describe("runDiscoveryPreflight", () => {
     expect(probeServer).not.toHaveBeenCalled();
   });
 
+  it("refuses a plaintext probe to a public host", async () => {
+    const probeServer = vi.fn();
+
+    // The RFC 6890 classifier judges addresses, not transport, and accepts
+    // http:. Hosted targets are HTTPS-only, so this has to be enforced here.
+    const outcome = await runDiscoveryPreflight(
+      { serverUrl: "http://example.com/mcp" },
+      { probeServer: probeServer as never },
+    );
+
+    expect(outcome).toMatchObject({
+      kind: "terminal",
+      errorCode: "URL_NOT_ALLOWED",
+    });
+    expect(probeServer).not.toHaveBeenCalled();
+  });
+
+  it("still allows plaintext loopback under the opt-in", async () => {
+    // `http://127.0.0.1:3000/mcp` IS the local-development product; the
+    // HTTPS rule must not take that away.
+    const probeServer = ready();
+
+    const outcome = await runDiscoveryPreflight(
+      { serverUrl: "http://127.0.0.1:3000/mcp", allowLoopback: true },
+      { probeServer },
+    );
+
+    expect(outcome).toMatchObject({ kind: "discovered", authMethod: "none" });
+  });
+
+  it("caps a caller-supplied timeout", async () => {
+    const probeServer = ready();
+
+    await runDiscoveryPreflight(
+      { serverUrl: "https://example.com/mcp", timeoutMs: 10 * 60_000 },
+      { probeServer },
+    );
+
+    // timeoutMs bounds ONE request and the probe makes several, so an uncapped
+    // value multiplies into the wall time one preflight can occupy a worker.
+    const config = (probeServer as unknown as { mock: { calls: unknown[][] } })
+      .mock.calls[0][0] as { timeoutMs: number };
+    expect(config.timeoutMs).toBe(MAX_DISCOVERY_TIMEOUT_MS);
+  });
+
+  it("falls back to the default for a nonsense timeout", async () => {
+    const probeServer = ready();
+
+    await runDiscoveryPreflight(
+      { serverUrl: "https://example.com/mcp", timeoutMs: Number.NaN },
+      { probeServer },
+    );
+
+    const config = (probeServer as unknown as { mock: { calls: unknown[][] } })
+      .mock.calls[0][0] as { timeoutMs: number };
+    expect(config.timeoutMs).toBe(DISCOVERY_TIMEOUT_MS);
+  });
+
   it("rejects an empty URL without probing", async () => {
     const probeServer = vi.fn();
 
@@ -312,19 +424,22 @@ describe("runDiscoveryPreflight", () => {
   });
 
   it("refuses a public hostname whose DNS answer is private", async () => {
-    // The whole point of the second layer. `evil.example` passes the pure
-    // hostname classifier — nothing about the STRING is private — and only
-    // turns dangerous once resolved. A guard that stopped at the classifier
-    // would have dialled it.
+    // Driven through the REAL guard, not a mock that throws on cue: the point
+    // is that `evil.example` passes the pure hostname classifier — nothing
+    // about the STRING is private — and is caught only once resolved.
+    const baseFetch = vi.fn();
     const outcome = await runDiscoveryPreflight(
       { serverUrl: "https://evil.example/mcp" },
       {
         probeServer: probeThroughFetch(),
-        fetchFn: async () => {
-          throw new BlockedEgressTargetError(
-            'Request URL hostname "evil.example" resolves to 169.254.169.254',
-          );
-        },
+        fetchFn: createGuardedFetch({
+          hosted: true,
+          resolver: async (hostname) =>
+            hostname === "evil.example"
+              ? ["169.254.169.254"]
+              : ["93.184.216.34"],
+          baseFetch: baseFetch as unknown as typeof fetch,
+        }),
       },
     );
 
@@ -335,20 +450,32 @@ describe("runDiscoveryPreflight", () => {
       kind: "terminal",
       errorCode: "URL_NOT_ALLOWED",
     });
+    // Nothing was dialled at all — the refusal happened before any socket.
+    expect(baseFetch).not.toHaveBeenCalled();
   });
 
   it("refuses a target that only turns private on a redirect", async () => {
     // A caller need not name the address they want reached: they can name a
     // host they control and have it answer 302 Location: 169.254.169.254.
+    // This drives the guard's PER-HOP re-check, which is a different code path
+    // from the DNS case above — the first hop is legitimately public.
+    const baseFetch = vi.fn(
+      async () =>
+        new Response(null, {
+          status: 302,
+          headers: { location: "http://169.254.169.254/latest/meta-data/" },
+        }),
+    );
+
     const outcome = await runDiscoveryPreflight(
       { serverUrl: "https://redirector.example/mcp" },
       {
         probeServer: probeThroughFetch(),
-        fetchFn: async () => {
-          throw new BlockedEgressTargetError(
-            'Request URL points at a private or internal address ("169.254.169.254")',
-          );
-        },
+        fetchFn: createGuardedFetch({
+          hosted: true,
+          resolver: async () => ["93.184.216.34"],
+          baseFetch: baseFetch as unknown as typeof fetch,
+        }),
       },
     );
 
@@ -356,6 +483,39 @@ describe("runDiscoveryPreflight", () => {
       kind: "terminal",
       errorCode: "URL_NOT_ALLOWED",
     });
+    // Exactly one request: the public first hop was dialled, the private
+    // redirect target never was. A guard that only checked the first URL would
+    // show two calls here.
+    expect(baseFetch).toHaveBeenCalledTimes(1);
+  });
+
+  it("follows a redirect that stays public", async () => {
+    // The redirect check must refuse private hops without refusing redirects
+    // as such, or every legitimately-redirecting server becomes unreachable.
+    const baseFetch = vi
+      .fn()
+      .mockResolvedValueOnce(
+        new Response(null, {
+          status: 302,
+          headers: { location: "https://elsewhere.example/mcp" },
+        }),
+      )
+      .mockResolvedValueOnce(new Response("{}", { status: 200 }));
+
+    const outcome = await runDiscoveryPreflight(
+      { serverUrl: "https://redirector.example/mcp" },
+      {
+        probeServer: probeThroughFetch(),
+        fetchFn: createGuardedFetch({
+          hosted: true,
+          resolver: async () => ["93.184.216.34"],
+          baseFetch: baseFetch as unknown as typeof fetch,
+        }),
+      },
+    );
+
+    expect(outcome).toMatchObject({ kind: "discovered", authMethod: "none" });
+    expect(baseFetch).toHaveBeenCalledTimes(2);
   });
 
   it("treats a resolver outage as retryable, not as a refusal", async () => {

--- a/mcpjam-inspector/server/services/__tests__/server-connection-discovery.test.ts
+++ b/mcpjam-inspector/server/services/__tests__/server-connection-discovery.test.ts
@@ -21,6 +21,7 @@
 import { describe, expect, it, vi } from "vitest";
 import type { ProbeMcpServerResult } from "@mcpjam/sdk";
 import {
+  BlockedEgressTargetError,
   createGuardedFetch,
   EgressResolutionError,
 } from "../../utils/hosted-egress-guard.js";
@@ -108,6 +109,43 @@ describe("classifyDiscoveryResult", () => {
       kind: "discovered",
       authMethod: "unsupported",
     });
+  });
+
+  it("accepts metadata with no challenge header at all", () => {
+    // Some servers 401 with no WWW-Authenticate while still publishing usable
+    // metadata; the scheme check must not turn that into `unsupported`.
+    const outcome = classifyDiscoveryResult(
+      probe({
+        status: "oauth_required",
+        oauth: {
+          required: true,
+          optional: false,
+          authorizationServerMetadataUrl:
+            "https://auth.example.com/.well-known/oauth-authorization-server",
+          registrationStrategies: ["dcr"],
+        },
+      }),
+    );
+
+    expect(outcome).toMatchObject({ kind: "discovered", authMethod: "oauth" });
+  });
+
+  it("accepts metadata with a blank challenge header", () => {
+    const outcome = classifyDiscoveryResult(
+      probe({
+        status: "oauth_required",
+        oauth: {
+          required: true,
+          optional: false,
+          wwwAuthenticate: "   ",
+          authorizationServerMetadataUrl:
+            "https://auth.example.com/.well-known/oauth-authorization-server",
+          registrationStrategies: ["dcr"],
+        },
+      }),
+    );
+
+    expect(outcome).toMatchObject({ kind: "discovered", authMethod: "oauth" });
   });
 
   it("reports unsupported for a non-Bearer challenge", () => {
@@ -516,6 +554,70 @@ describe("runDiscoveryPreflight", () => {
 
     expect(outcome).toMatchObject({ kind: "discovered", authMethod: "none" });
     expect(baseFetch).toHaveBeenCalledTimes(2);
+  });
+
+  it("keeps a recorded refusal from being masked by a later stall", async () => {
+    // The sequence that makes this a security bug and not a nicety: the guard
+    // refuses a hop, the prober SWALLOWS that throw and moves on to another
+    // endpoint, and that endpoint hangs. The deadline then wins the race. If
+    // the deadline branch answered `retryable` without consulting the recorded
+    // refusal, the target we just refused would be put back on a retry
+    // schedule.
+    const outcome = await runDiscoveryPreflight(
+      { serverUrl: "https://evil.example/mcp", timeoutMs: 5 },
+      {
+        deadlineMs: 25,
+        fetchFn: async () => {
+          throw new BlockedEgressTargetError(
+            'Request URL hostname "evil.example" resolves to 169.254.169.254',
+          );
+        },
+        probeServer: (async (config: {
+          url: string;
+          fetchFn?: typeof fetch;
+        }) => {
+          // Refused hop, swallowed exactly as the real prober does...
+          await config
+            .fetchFn?.(config.url, { method: "POST" })
+            .catch(() => {});
+          // ...then a stall long enough for the deadline to win.
+          await new Promise(() => {});
+          return probe({});
+        }) as never,
+      },
+    );
+
+    expect(outcome).toMatchObject({
+      kind: "terminal",
+      errorCode: "URL_NOT_ALLOWED",
+    });
+  });
+
+  it("keeps a recorded refusal from being masked by an unexpected throw", async () => {
+    const outcome = await runDiscoveryPreflight(
+      { serverUrl: "https://evil.example/mcp" },
+      {
+        fetchFn: async () => {
+          throw new BlockedEgressTargetError(
+            'Request URL hostname "evil.example" resolves to 169.254.169.254',
+          );
+        },
+        probeServer: (async (config: {
+          url: string;
+          fetchFn?: typeof fetch;
+        }) => {
+          await config
+            .fetchFn?.(config.url, { method: "POST" })
+            .catch(() => {});
+          throw new Error("some later, unrelated failure");
+        }) as never,
+      },
+    );
+
+    expect(outcome).toMatchObject({
+      kind: "terminal",
+      errorCode: "URL_NOT_ALLOWED",
+    });
   });
 
   it("treats a resolver outage as retryable, not as a refusal", async () => {

--- a/mcpjam-inspector/server/services/__tests__/server-connection-discovery.test.ts
+++ b/mcpjam-inspector/server/services/__tests__/server-connection-discovery.test.ts
@@ -1,0 +1,295 @@
+/**
+ * Discovery preflight for a connection request.
+ *
+ * The classification table is the contract worth pinning: each arm decides
+ * whether a person gets sent to a consent screen, whether the request survives
+ * a bad minute, or whether it dies. The two that are easy to get backwards are
+ * asserted explicitly — a network failure must never be reported as a
+ * discovery result, and a server that answers with non-MCP must never be
+ * retried.
+ *
+ * The doctor is injected rather than stubbed at the module level, so these
+ * tests never open a socket and never depend on the SDK's internal probe
+ * layering.
+ */
+import { describe, expect, it, vi } from "vitest";
+import type { ServerDoctorResult } from "@mcpjam/sdk";
+import {
+  classifyDiscoveryResult,
+  runDiscoveryPreflight,
+} from "../server-connection-discovery.js";
+
+type Probe = NonNullable<ServerDoctorResult["probe"]>;
+
+function probe(overrides: Partial<Probe>): Probe {
+  return {
+    url: "https://example.com/mcp",
+    protocolVersion: "2025-11-25",
+    status: "ready",
+    transport: { attempts: [] },
+    oauth: {
+      required: false,
+      optional: false,
+      registrationStrategies: [],
+    },
+    ...overrides,
+  } as Probe;
+}
+
+function doctorResult(
+  overrides: Partial<ServerDoctorResult>,
+): ServerDoctorResult {
+  return {
+    target: null,
+    generatedAt: "2026-01-01T00:00:00.000Z",
+    status: "ready",
+    probe: probe({}),
+    connection: { status: "ok", detail: "connected" },
+    initInfo: null,
+    capabilities: null,
+    tools: [],
+    toolsMetadata: {},
+    resources: [],
+    resourceTemplates: [],
+    prompts: [],
+    checks: {},
+    error: null,
+    ...overrides,
+  } as ServerDoctorResult;
+}
+
+describe("classifyDiscoveryResult", () => {
+  it("reports authMethod none when initialize succeeds unauthenticated", () => {
+    const outcome = classifyDiscoveryResult(
+      doctorResult({ probe: probe({ status: "ready" }) }),
+    );
+
+    expect(outcome).toMatchObject({ kind: "discovered", authMethod: "none" });
+  });
+
+  it("reports authMethod oauth for a challenge naming an authorization server", () => {
+    const outcome = classifyDiscoveryResult(
+      doctorResult({
+        probe: probe({
+          status: "oauth_required",
+          oauth: {
+            required: true,
+            optional: false,
+            wwwAuthenticate:
+              'Bearer resource_metadata="https://example.com/.well-known"',
+            authorizationServerMetadataUrl:
+              "https://auth.example.com/.well-known/oauth-authorization-server",
+            registrationStrategies: ["dcr"],
+          },
+        }),
+      }),
+    );
+
+    expect(outcome).toMatchObject({ kind: "discovered", authMethod: "oauth" });
+  });
+
+  it("accepts a challenge that resolved registration strategies but no metadata URL", () => {
+    // Either half is sufficient — a resolved strategy list means discovery got
+    // far enough to know how a client would be identified.
+    const outcome = classifyDiscoveryResult(
+      doctorResult({
+        probe: probe({
+          status: "oauth_required",
+          oauth: {
+            required: true,
+            optional: false,
+            registrationStrategies: ["preregistered"],
+          },
+        }),
+      }),
+    );
+
+    expect(outcome).toMatchObject({ kind: "discovered", authMethod: "oauth" });
+  });
+
+  it("reports unsupported for a non-Bearer challenge", () => {
+    // Basic names no authorization server because the scheme has no concept
+    // of one, so nothing is discovered and there is no flow to run.
+    const outcome = classifyDiscoveryResult(
+      doctorResult({
+        probe: probe({
+          status: "oauth_required",
+          oauth: {
+            required: true,
+            optional: false,
+            wwwAuthenticate: 'Basic realm="mcp"',
+            registrationStrategies: [],
+          },
+        }),
+      }),
+    );
+
+    expect(outcome).toMatchObject({
+      kind: "discovered",
+      authMethod: "unsupported",
+    });
+  });
+
+  it("reports unsupported for a manual bearer server", () => {
+    // Challenges with Bearer, publishes no authorization server metadata:
+    // the token is meant to be pasted in by a human.
+    const outcome = classifyDiscoveryResult(
+      doctorResult({
+        probe: probe({
+          status: "oauth_required",
+          oauth: {
+            required: true,
+            optional: false,
+            wwwAuthenticate: "Bearer",
+            registrationStrategies: [],
+            discoveryError: "No authorization server metadata found",
+          },
+        }),
+      }),
+    );
+
+    expect(outcome).toMatchObject({
+      kind: "discovered",
+      authMethod: "unsupported",
+    });
+  });
+
+  it("treats a non-MCP response as terminal, not retryable", () => {
+    // The host answered; the answer was not MCP. Retrying spends the request's
+    // attempt budget to receive the same answer.
+    const outcome = classifyDiscoveryResult(
+      doctorResult({
+        status: "error",
+        probe: probe({
+          status: "reachable",
+          error: "Server returned HTML instead of an MCP initialize result",
+        }),
+      }),
+    );
+
+    expect(outcome.kind).toBe("terminal");
+    expect(outcome).toMatchObject({ errorCode: "NOT_AN_MCP_SERVER" });
+  });
+
+  it("treats an unreachable server as retryable and reports no auth method", () => {
+    // The distinction that matters most: a server that was down for a minute
+    // must not be permanently labelled `unsupported`.
+    const outcome = classifyDiscoveryResult(
+      doctorResult({
+        status: "error",
+        probe: probe({ status: "error", error: "connect ETIMEDOUT" }),
+      }),
+    );
+
+    expect(outcome.kind).toBe("retryable");
+    expect(outcome).not.toHaveProperty("authMethod");
+  });
+
+  it("treats a doctor run that never probed as retryable", () => {
+    const outcome = classifyDiscoveryResult(
+      doctorResult({
+        status: "error",
+        probe: null,
+        error: { code: "UNKNOWN", message: "socket hang up" },
+      }),
+    );
+
+    expect(outcome.kind).toBe("retryable");
+  });
+});
+
+describe("runDiscoveryPreflight", () => {
+  it("refuses a private target before any request is made", async () => {
+    const runDoctor = vi.fn();
+
+    const outcome = await runDiscoveryPreflight(
+      { serverUrl: "http://169.254.169.254/latest/meta-data/" },
+      { runDoctor },
+    );
+
+    expect(outcome).toMatchObject({
+      kind: "terminal",
+      errorCode: "URL_NOT_ALLOWED",
+    });
+    // The point of a preflight guard is that no socket is opened at all.
+    expect(runDoctor).not.toHaveBeenCalled();
+  });
+
+  it("refuses loopback unless the local-dev opt-in is set", async () => {
+    const runDoctor = vi.fn();
+
+    const blocked = await runDiscoveryPreflight(
+      { serverUrl: "http://127.0.0.1:3000/mcp" },
+      { runDoctor },
+    );
+    expect(blocked).toMatchObject({
+      kind: "terminal",
+      errorCode: "URL_NOT_ALLOWED",
+    });
+    expect(runDoctor).not.toHaveBeenCalled();
+  });
+
+  it("allows loopback when the opt-in is set", async () => {
+    const runDoctor = vi
+      .fn()
+      .mockResolvedValue(doctorResult({ probe: probe({ status: "ready" }) }));
+
+    const outcome = await runDiscoveryPreflight(
+      { serverUrl: "http://127.0.0.1:3000/mcp", allowLoopback: true },
+      { runDoctor },
+    );
+
+    expect(outcome).toMatchObject({ kind: "discovered", authMethod: "none" });
+    expect(runDoctor).toHaveBeenCalledTimes(1);
+  });
+
+  it("keeps the loopback opt-in from relaxing anything else", async () => {
+    const runDoctor = vi.fn();
+
+    // A LAN address is not loopback. The opt-in exists for local development
+    // against 127.0.0.1, not as a general private-network escape hatch.
+    const outcome = await runDiscoveryPreflight(
+      { serverUrl: "http://192.168.1.10/mcp", allowLoopback: true },
+      { runDoctor },
+    );
+
+    expect(outcome).toMatchObject({
+      kind: "terminal",
+      errorCode: "URL_NOT_ALLOWED",
+    });
+    expect(runDoctor).not.toHaveBeenCalled();
+  });
+
+  it("rejects a non-http scheme", async () => {
+    const runDoctor = vi.fn();
+
+    const outcome = await runDiscoveryPreflight(
+      { serverUrl: "file:///etc/passwd" },
+      { runDoctor },
+    );
+
+    expect(outcome).toMatchObject({
+      kind: "terminal",
+      errorCode: "URL_NOT_ALLOWED",
+    });
+    expect(runDoctor).not.toHaveBeenCalled();
+  });
+
+  it("attaches no credential to the probe", async () => {
+    const runDoctor = vi
+      .fn()
+      .mockResolvedValue(doctorResult({ probe: probe({ status: "ready" }) }));
+
+    await runDiscoveryPreflight(
+      { serverUrl: "https://example.com/mcp" },
+      { runDoctor },
+    );
+
+    // Discovery asks what a stranger sees. A token here would classify a
+    // server as open when it is not.
+    const config = runDoctor.mock.calls[0][0].config;
+    expect(config).not.toHaveProperty("accessToken");
+    expect(config).not.toHaveProperty("refreshToken");
+    expect(config).not.toHaveProperty("authProvider");
+  });
+});

--- a/mcpjam-inspector/server/services/server-connection-discovery.ts
+++ b/mcpjam-inspector/server/services/server-connection-discovery.ts
@@ -31,6 +31,7 @@
  */
 import {
   assertOutboundOAuthUrlAllowed,
+  isLoopbackOAuthUrl,
   OAuthOutboundUrlBlockedError,
 } from "@mcpjam/sdk/oauth/node";
 import { probeMcpServer } from "@mcpjam/sdk";
@@ -63,7 +64,35 @@ export type DiscoveryOutcome =
   | { kind: "retryable"; detail: string }
   | { kind: "terminal"; errorCode: string; detail: string };
 
+/** Per-request timeout handed to the prober. */
 export const DISCOVERY_TIMEOUT_MS = 15_000;
+
+/**
+ * Ceiling on a caller-supplied per-request timeout.
+ *
+ * `timeoutMs` bounds ONE request, and a probe makes several (initialize, an
+ * SSE fallback, resource metadata, authorization server metadata), each of
+ * which may be retried. An uncapped value therefore multiplies into the wall
+ * time a single preflight can occupy a worker.
+ */
+export const MAX_DISCOVERY_TIMEOUT_MS = 30_000;
+
+/**
+ * Absolute ceiling on one preflight, whatever the per-request timeout allows.
+ *
+ * This is the bound that actually makes the step "bounded": without it a
+ * deliberately slow target holds a work lease for the sum of every request the
+ * probe chooses to make, and the lease — not the timeout — becomes what limits
+ * throughput.
+ */
+export const DISCOVERY_DEADLINE_MS = 60_000;
+
+function clampTimeout(timeoutMs: number | undefined): number {
+  if (typeof timeoutMs !== "number" || !Number.isFinite(timeoutMs)) {
+    return DISCOVERY_TIMEOUT_MS;
+  }
+  return Math.min(Math.max(timeoutMs, 1), MAX_DISCOVERY_TIMEOUT_MS);
+}
 
 /**
  * Whether a 401 is an MCP OAuth challenge we can actually act on.
@@ -89,20 +118,58 @@ export const DISCOVERY_TIMEOUT_MS = 15_000;
  * metadata, and which marker that should be is not settled — see
  * NOTES-item-2.md. Deliberately left misclassified rather than guessed at: a
  * wrong detector would refuse servers that do work.
+ *
+ * DO NOT ADD `registrationStrategies.length > 0` BACK AS AN ALTERNATIVE. An
+ * earlier revision accepted it as a second sufficient condition, which
+ * inverted the whole test: `server-probe.ts` returns
+ * `registrationStrategies: ["preregistered"]` from the branch it takes when
+ * metadata discovery THREW — so that list is non-empty in precisely the
+ * manual-bearer and unknown-scheme cases this function exists to reject, and
+ * `unsupported` became unreachable.
  */
 function isActionableOAuthChallenge(probe: ProbeMcpServerResult): boolean {
   const { oauth } = probe;
   if (!oauth.required) {
     return false;
   }
-  // Either half is enough. `authorizationServerMetadataUrl` is the direct
-  // answer; a non-empty strategy list means the discovery already resolved far
-  // enough to know how a client would be identified, which it cannot do
-  // without having found the server.
-  return (
-    typeof oauth.authorizationServerMetadataUrl === "string" ||
-    oauth.registrationStrategies.length > 0
-  );
+  // The ONLY sufficient signal: somewhere to send the user. Without an
+  // authorization server we cannot start a flow, and reporting `oauth` would
+  // park the request in `awaiting_authorization` with no consent screen to
+  // open.
+  if (
+    typeof oauth.authorizationServerMetadataUrl !== "string" ||
+    oauth.authorizationServerMetadataUrl.length === 0
+  ) {
+    return false;
+  }
+  return challengeOffersBearer(oauth.wwwAuthenticate);
+}
+
+/**
+ * Does the challenge offer a Bearer scheme?
+ *
+ * MCP OAuth challenges with `Bearer`. A server answering `Basic` has no
+ * authorization-code flow to run even if something OAuth-shaped happens to sit
+ * at its well-known URL, so the scheme is checked rather than inferred from the
+ * metadata alone.
+ *
+ * A missing header is treated as permissive: some servers 401 with no
+ * challenge at all while still publishing usable metadata, and the metadata
+ * requirement above already carries the decision in that case.
+ *
+ * `WWW-Authenticate` may carry several challenges, comma-separated
+ * (`Basic realm="x", Bearer resource_metadata="…"`), so a scheme is matched at
+ * the start of the header or just after a comma rather than anywhere in the
+ * string — otherwise a realm containing the word "bearer" would qualify. A
+ * quoted parameter containing a comma could still fool this; it would need to
+ * coincide with genuinely discovered authorization server metadata to change
+ * any outcome, which is not a combination worth a full RFC 9110 parser here.
+ */
+function challengeOffersBearer(wwwAuthenticate: string | undefined): boolean {
+  if (wwwAuthenticate === undefined || wwwAuthenticate.trim() === "") {
+    return true;
+  }
+  return /(?:^|,)\s*bearer(?:\s|,|$)/i.test(wwwAuthenticate);
 }
 
 /**
@@ -223,9 +290,24 @@ export async function runDiscoveryPreflight(
   const probeServer = dependencies.probeServer ?? probeMcpServer;
 
   try {
-    assertOutboundOAuthUrlAllowed(input.serverUrl, {
+    const url = assertOutboundOAuthUrlAllowed(input.serverUrl, {
       allowLoopback: input.allowLoopback === true,
     });
+    // The classifier accepts http AND https — it judges addresses, not
+    // transport. Hosted targets are HTTPS-only, so that has to be enforced
+    // here rather than assumed: a plaintext probe to a public host puts the
+    // request on the wire for anyone on the path, and the 401 challenge we
+    // classify on is exactly the thing worth tampering with.
+    //
+    // Loopback keeps its plaintext exception, and only when the caller opted
+    // in: `http://127.0.0.1:3000/mcp` IS the local-development product.
+    if (url.protocol !== "https:" && !isLoopbackOAuthUrl(input.serverUrl)) {
+      return {
+        kind: "terminal",
+        errorCode: "URL_NOT_ALLOWED",
+        detail: `Refusing a plaintext discovery probe to public host "${url.hostname}"; MCP servers must be reachable over HTTPS.`,
+      };
+    }
   } catch (error) {
     if (error instanceof OAuthOutboundUrlBlockedError) {
       return {
@@ -260,13 +342,40 @@ export async function runDiscoveryPreflight(
     }
   };
 
+  // `timeoutMs` bounds ONE request and the probe makes several, so the clamp
+  // alone does not bound the step — the deadline below does. A target that
+  // stalls every request would otherwise hold a work lease for the sum of them.
+  let deadlineTimer: ReturnType<typeof setTimeout> | undefined;
+  const deadline = new Promise<"deadline">((resolve) => {
+    deadlineTimer = setTimeout(
+      () => resolve("deadline"),
+      DISCOVERY_DEADLINE_MS,
+    );
+  });
+
   let probe: ProbeMcpServerResult;
   try {
-    probe = await probeServer({
-      url: input.serverUrl,
-      timeoutMs: input.timeoutMs ?? DISCOVERY_TIMEOUT_MS,
-      fetchFn,
-    });
+    const raced = await Promise.race([
+      probeServer({
+        url: input.serverUrl,
+        timeoutMs: clampTimeout(input.timeoutMs),
+        fetchFn,
+      }),
+      deadline,
+    ]);
+
+    if (raced === "deadline") {
+      // The probe keeps running to completion — the SDK takes no abort signal,
+      // so there is nothing to cancel. It holds only a socket and its own
+      // timeout, and its result is dropped. Reporting `retryable` is right on
+      // the merits anyway: a target too slow to answer inside the deadline has
+      // told us nothing about its auth method.
+      return {
+        kind: "retryable",
+        detail: `Discovery did not finish within ${DISCOVERY_DEADLINE_MS}ms`,
+      };
+    }
+    probe = raced;
   } catch (error) {
     if (error instanceof BlockedEgressTargetError) {
       return {
@@ -284,6 +393,10 @@ export async function runDiscoveryPreflight(
       kind: "retryable",
       detail: error instanceof Error ? error.message : String(error),
     };
+  } finally {
+    // Otherwise the pending timer keeps the event loop alive for the full
+    // deadline after an answer has already been returned.
+    clearTimeout(deadlineTimer);
   }
 
   if (refusal.blocked !== null) {

--- a/mcpjam-inspector/server/services/server-connection-discovery.ts
+++ b/mcpjam-inspector/server/services/server-connection-discovery.ts
@@ -248,6 +248,13 @@ export interface RunDiscoveryPreflightDependencies {
   probeServer?: typeof probeMcpServer;
   /** Overridable so tests can drive the guard's verdicts without DNS. */
   fetchFn?: typeof fetch;
+  /**
+   * Test seam only. The deadline is a product decision, not a caller knob —
+   * it lives here rather than on the input so no route can quietly extend the
+   * bound this step exists to enforce. Tests override it to exercise the
+   * deadline path without waiting a real minute.
+   */
+  deadlineMs?: number;
 }
 
 /**
@@ -342,15 +349,34 @@ export async function runDiscoveryPreflight(
     }
   };
 
+  /**
+   * A recorded refusal OUTRANKS every retryable outcome, so this runs before
+   * each of them rather than only on the happy path.
+   *
+   * The ordering is the whole security property. The prober swallows the
+   * guard's throw and carries on to another endpoint; if that one then stalls
+   * or fails, the natural answer is `retryable` — and returning it would put a
+   * target we already refused back on a retry schedule, which is exactly what
+   * the bookkeeping exists to prevent. An earlier revision checked this only
+   * after the race, so the deadline and the generic catch could both mask a
+   * refusal.
+   */
+  const refusalOutcome = (): DiscoveryOutcome | null =>
+    refusal.blocked === null
+      ? null
+      : {
+          kind: "terminal",
+          errorCode: "URL_NOT_ALLOWED",
+          detail: refusal.blocked.message,
+        };
+
   // `timeoutMs` bounds ONE request and the probe makes several, so the clamp
   // alone does not bound the step — the deadline below does. A target that
   // stalls every request would otherwise hold a work lease for the sum of them.
+  const deadlineMs = dependencies.deadlineMs ?? DISCOVERY_DEADLINE_MS;
   let deadlineTimer: ReturnType<typeof setTimeout> | undefined;
   const deadline = new Promise<"deadline">((resolve) => {
-    deadlineTimer = setTimeout(
-      () => resolve("deadline"),
-      DISCOVERY_DEADLINE_MS,
-    );
+    deadlineTimer = setTimeout(() => resolve("deadline"), deadlineMs);
   });
 
   let probe: ProbeMcpServerResult;
@@ -365,15 +391,23 @@ export async function runDiscoveryPreflight(
     ]);
 
     if (raced === "deadline") {
-      // The probe keeps running to completion — the SDK takes no abort signal,
-      // so there is nothing to cancel. It holds only a socket and its own
-      // timeout, and its result is dropped. Reporting `retryable` is right on
-      // the merits anyway: a target too slow to answer inside the deadline has
-      // told us nothing about its auth method.
-      return {
-        kind: "retryable",
-        detail: `Discovery did not finish within ${DISCOVERY_DEADLINE_MS}ms`,
-      };
+      // The probe keeps running to completion — the SDK's config takes no
+      // abort signal, so there is nothing to cancel from here. It holds a
+      // socket and its own per-request timeout, and its result is dropped;
+      // propagating a real deadline would need `ProbeMcpServerConfig` to accept
+      // one, which is an SDK change and not this PR's to make.
+      //
+      // A refusal recorded BEFORE the stall still decides the outcome. One
+      // arriving after this point is lost, and that is a cost rather than a
+      // hole: the guard refused the hop either way, so nothing was reached —
+      // the only consequence is that we may retry work that will be refused
+      // again.
+      return (
+        refusalOutcome() ?? {
+          kind: "retryable",
+          detail: `Discovery did not finish within ${deadlineMs}ms`,
+        }
+      );
     }
     probe = raced;
   } catch (error) {
@@ -385,26 +419,26 @@ export async function runDiscoveryPreflight(
       };
     }
     if (error instanceof EgressResolutionError) {
-      return { kind: "retryable", detail: error.message };
+      return refusalOutcome() ?? { kind: "retryable", detail: error.message };
     }
     // An unexpected throw means we learned nothing about the target, which is
-    // the definition of retryable here — never a discovery result.
-    return {
-      kind: "retryable",
-      detail: error instanceof Error ? error.message : String(error),
-    };
+    // the definition of retryable here — never a discovery result. A refusal
+    // already on record still outranks it.
+    return (
+      refusalOutcome() ?? {
+        kind: "retryable",
+        detail: error instanceof Error ? error.message : String(error),
+      }
+    );
   } finally {
     // Otherwise the pending timer keeps the event loop alive for the full
     // deadline after an answer has already been returned.
     clearTimeout(deadlineTimer);
   }
 
-  if (refusal.blocked !== null) {
-    return {
-      kind: "terminal",
-      errorCode: "URL_NOT_ALLOWED",
-      detail: refusal.blocked.message,
-    };
+  const recorded = refusalOutcome();
+  if (recorded !== null) {
+    return recorded;
   }
 
   return classifyDiscoveryResult(probe);

--- a/mcpjam-inspector/server/services/server-connection-discovery.ts
+++ b/mcpjam-inspector/server/services/server-connection-discovery.ts
@@ -1,0 +1,224 @@
+/**
+ * Unauthenticated discovery preflight for a connection request.
+ *
+ * A connection request arrives as a bare URL from a surface that has no server
+ * row yet, and the first question is always the same: can we talk to this
+ * thing, and if not, is the reason one we know how to fix by sending a person
+ * to a consent screen? That is all discovery answers. It creates nothing,
+ * stores nothing, and carries no credential.
+ *
+ * The probing itself is the SDK's `runServerDoctor`, not a second prober
+ * written here. Discovery classification and the Inspector's own diagnostics
+ * must agree about what "this server needs OAuth" means, and the only way to
+ * guarantee that is for both to ask the same code.
+ *
+ * WHAT THIS MODULE IS NOT. It does not acquire a work lease and it does not
+ * report anything to the backend, because at the time of writing there is no
+ * wire path for either — see NOTES-item-2.md. It is the half of the discovery
+ * step that is fully determined by the Inspector, split out so it is testable
+ * on its own and so the endpoint that eventually wraps it has nothing left to
+ * decide except the round trips.
+ */
+import {
+  assertOutboundOAuthUrlAllowed,
+  OAuthOutboundUrlBlockedError,
+} from "@mcpjam/sdk/oauth/node";
+import { runServerDoctor } from "@mcpjam/sdk";
+import type { ServerDoctorResult } from "@mcpjam/sdk";
+
+/** The three values the backend's `reportDiscovery` accepts. */
+export type DiscoveredAuthMethod = "none" | "oauth" | "unsupported";
+
+/**
+ * What one preflight concluded.
+ *
+ * The three arms are not three flavours of the same thing — they decide who
+ * owns the request next:
+ *
+ *   `discovered` — the backend routes on the auth method. This is the only arm
+ *                  that produces a `reportDiscovery` call.
+ *   `retryable`  — nobody learned anything. The work lease is released and the
+ *                  request stays where it was, so a server that was briefly
+ *                  unreachable costs an attempt rather than the whole request.
+ *   `terminal`   — the target answered and what it said was not MCP. Retrying
+ *                  cannot change that, so it is reported as a failure.
+ */
+export type DiscoveryOutcome =
+  | { kind: "discovered"; authMethod: DiscoveredAuthMethod; detail: string }
+  | { kind: "retryable"; detail: string }
+  | { kind: "terminal"; errorCode: string; detail: string };
+
+export const DISCOVERY_TIMEOUT_MS = 15_000;
+
+/**
+ * Whether a 401 is an MCP OAuth challenge we can actually act on.
+ *
+ * "Can act on" is the operative test, and it is stricter than "mentions
+ * OAuth". Sending a user to a consent screen requires knowing where the
+ * authorization server is, so a challenge we could not follow is worth exactly
+ * as much to us as no challenge at all — and calling it `oauth` would strand
+ * the request in `awaiting_authorization` with nowhere to send anyone.
+ *
+ * That single test covers two of the three unsupported shapes:
+ *
+ *   Basic/Digest/any non-Bearer scheme — no authorization server is named
+ *   because the scheme has no concept of one.
+ *
+ *   Manual bearer — the server wants a token a human pastes in. It challenges
+ *   with `Bearer` and publishes no authorization server metadata, because
+ *   there is no flow to run.
+ *
+ * XAA IS A KNOWN GAP. An XAA server also challenges with `Bearer` and also
+ * publishes authorization server metadata, so this test classifies it as
+ * `oauth`. Separating the two needs an XAA-specific marker in the discovered
+ * metadata, and which marker that should be is not settled — see
+ * NOTES-item-2.md. Deliberately left misclassified rather than guessed at: a
+ * wrong detector would refuse servers that do work.
+ */
+function isActionableOAuthChallenge(
+  probe: NonNullable<ServerDoctorResult["probe"]>,
+): boolean {
+  const { oauth } = probe;
+  if (!oauth.required) {
+    return false;
+  }
+  // Either half is enough. `authorizationServerMetadataUrl` is the direct
+  // answer; a non-empty strategy list means the discovery already resolved far
+  // enough to know how a client would be identified, which it cannot do
+  // without having found the server.
+  return (
+    typeof oauth.authorizationServerMetadataUrl === "string" ||
+    oauth.registrationStrategies.length > 0
+  );
+}
+
+/**
+ * Map a completed doctor run onto the discovery taxonomy.
+ *
+ * Pure, and exported, because the mapping is the part worth pinning: every
+ * arm here is a decision about whether a user gets sent to a consent screen,
+ * whether the request survives, or whether it dies.
+ */
+export function classifyDiscoveryResult(
+  result: ServerDoctorResult,
+): DiscoveryOutcome {
+  const probe = result.probe;
+
+  // No probe at all means the doctor threw before reaching the target.
+  if (!probe) {
+    return {
+      kind: "retryable",
+      detail: result.error?.message ?? "Discovery probe did not complete",
+    };
+  }
+
+  switch (probe.status) {
+    // `initialize` succeeded without credentials: the server is open.
+    case "ready":
+      return {
+        kind: "discovered",
+        authMethod: "none",
+        detail: "Server completed MCP initialize without authentication",
+      };
+
+    case "oauth_required":
+      return isActionableOAuthChallenge(probe)
+        ? {
+            kind: "discovered",
+            authMethod: "oauth",
+            detail: "Server presented an MCP OAuth challenge",
+          }
+        : {
+            kind: "discovered",
+            authMethod: "unsupported",
+            detail:
+              "Server requires authentication MCPJam cannot negotiate " +
+              "(no authorization server metadata was discoverable)",
+          };
+
+    // The host answered and the answer was not a usable MCP initialize
+    // result. That is a property of the server, not of the moment, so
+    // retrying would only spend the request's attempt budget on the same
+    // answer.
+    case "reachable":
+      return {
+        kind: "terminal",
+        errorCode: "NOT_AN_MCP_SERVER",
+        detail:
+          probe.error ??
+          "Server responded but did not complete an MCP initialize handshake",
+      };
+
+    // The probe exhausted its own retry policy without a usable response —
+    // DNS, TLS, connection, timeout, or a 5xx that kept repeating. Retryable
+    // at the request level, and emphatically not a discovery result: reporting
+    // `unsupported` here would permanently mislabel a server that was merely
+    // down for a minute.
+    case "error":
+      return {
+        kind: "retryable",
+        detail: probe.error ?? "Discovery probe could not reach the server",
+      };
+  }
+}
+
+export interface RunDiscoveryPreflightInput {
+  serverUrl: string;
+  /**
+   * Local-dev opt-in, carved out for loopback ONLY. Hosted deployments pass
+   * false (the default) and stay HTTPS-only against public addresses; it never
+   * relaxes the guard for LAN, link-local, CGNAT, multicast, documentation,
+   * NAT64-private, or IPv4-mapped-private targets.
+   */
+  allowLoopback?: boolean;
+  timeoutMs?: number;
+}
+
+export interface RunDiscoveryPreflightDependencies {
+  runDoctor?: typeof runServerDoctor;
+}
+
+/**
+ * Run one bounded, unauthenticated preflight and classify it.
+ *
+ * The SSRF guard runs FIRST, before any socket exists. The URL came from a
+ * caller on an untrusted surface, and a hosted Inspector sits inside a network
+ * where "http://169.254.169.254/" is a credential endpoint — so the cheapest
+ * possible moment to refuse is before we have connected to anything. A refusal
+ * is terminal rather than retryable: the address a URL names is not going to
+ * become public on the next attempt.
+ *
+ * No credential is ever attached. Discovery asks what a stranger sees.
+ */
+export async function runDiscoveryPreflight(
+  input: RunDiscoveryPreflightInput,
+  dependencies: RunDiscoveryPreflightDependencies = {},
+): Promise<DiscoveryOutcome> {
+  const runDoctor = dependencies.runDoctor ?? runServerDoctor;
+
+  try {
+    assertOutboundOAuthUrlAllowed(input.serverUrl, {
+      allowLoopback: input.allowLoopback === true,
+    });
+  } catch (error) {
+    if (error instanceof OAuthOutboundUrlBlockedError) {
+      return {
+        kind: "terminal",
+        errorCode: "URL_NOT_ALLOWED",
+        // The guard's own message names the reason (invalid-url,
+        // invalid-scheme, private-host) without echoing anything the caller
+        // could use to probe the internal network further.
+        detail: error.message,
+      };
+    }
+    throw error;
+  }
+
+  const result = await runDoctor({
+    config: { url: input.serverUrl },
+    target: null,
+    timeout: input.timeoutMs ?? DISCOVERY_TIMEOUT_MS,
+  });
+
+  return classifyDiscoveryResult(result);
+}

--- a/mcpjam-inspector/server/services/server-connection-discovery.ts
+++ b/mcpjam-inspector/server/services/server-connection-discovery.ts
@@ -7,10 +7,20 @@
  * to a consent screen? That is all discovery answers. It creates nothing,
  * stores nothing, and carries no credential.
  *
- * The probing itself is the SDK's `runServerDoctor`, not a second prober
- * written here. Discovery classification and the Inspector's own diagnostics
- * must agree about what "this server needs OAuth" means, and the only way to
- * guarantee that is for both to ask the same code.
+ * The probing itself is the SDK's `probeMcpServer` — the same prober the
+ * server doctor runs — not a second one written here. Discovery classification
+ * and the Inspector's own diagnostics must agree about what "this server needs
+ * OAuth" means, and the only way to guarantee that is for both to ask the same
+ * code.
+ *
+ * The prober rather than the whole doctor, for two reasons. Classification
+ * reads `probe` and nothing else — the doctor's tool/resource/prompt
+ * enumeration is work discovery never looks at. And the doctor's connect step
+ * dials through MCPClientManager's own transport, which takes no `fetchFn`, so
+ * it is the one outbound path the egress guard below cannot reach (the same
+ * scope limit documented on `routes/shared/conformance.ts`). Dropping it
+ * removes an unguarded socket rather than leaving one we would have to
+ * apologise for.
  *
  * WHAT THIS MODULE IS NOT. It does not acquire a work lease and it does not
  * report anything to the backend, because at the time of writing there is no
@@ -23,8 +33,13 @@ import {
   assertOutboundOAuthUrlAllowed,
   OAuthOutboundUrlBlockedError,
 } from "@mcpjam/sdk/oauth/node";
-import { runServerDoctor } from "@mcpjam/sdk";
-import type { ServerDoctorResult } from "@mcpjam/sdk";
+import { probeMcpServer } from "@mcpjam/sdk";
+import type { ProbeMcpServerResult } from "@mcpjam/sdk";
+import {
+  BlockedEgressTargetError,
+  createGuardedFetch,
+  EgressResolutionError,
+} from "../utils/hosted-egress-guard.js";
 
 /** The three values the backend's `reportDiscovery` accepts. */
 export type DiscoveredAuthMethod = "none" | "oauth" | "unsupported";
@@ -75,9 +90,7 @@ export const DISCOVERY_TIMEOUT_MS = 15_000;
  * NOTES-item-2.md. Deliberately left misclassified rather than guessed at: a
  * wrong detector would refuse servers that do work.
  */
-function isActionableOAuthChallenge(
-  probe: NonNullable<ServerDoctorResult["probe"]>,
-): boolean {
+function isActionableOAuthChallenge(probe: ProbeMcpServerResult): boolean {
   const { oauth } = probe;
   if (!oauth.required) {
     return false;
@@ -100,18 +113,8 @@ function isActionableOAuthChallenge(
  * whether the request survives, or whether it dies.
  */
 export function classifyDiscoveryResult(
-  result: ServerDoctorResult,
+  probe: ProbeMcpServerResult,
 ): DiscoveryOutcome {
-  const probe = result.probe;
-
-  // No probe at all means the doctor threw before reaching the target.
-  if (!probe) {
-    return {
-      kind: "retryable",
-      detail: result.error?.message ?? "Discovery probe did not complete",
-    };
-  }
-
   switch (probe.status) {
     // `initialize` succeeded without credentials: the server is open.
     case "ready":
@@ -175,18 +178,41 @@ export interface RunDiscoveryPreflightInput {
 }
 
 export interface RunDiscoveryPreflightDependencies {
-  runDoctor?: typeof runServerDoctor;
+  probeServer?: typeof probeMcpServer;
+  /** Overridable so tests can drive the guard's verdicts without DNS. */
+  fetchFn?: typeof fetch;
 }
 
 /**
  * Run one bounded, unauthenticated preflight and classify it.
  *
- * The SSRF guard runs FIRST, before any socket exists. The URL came from a
- * caller on an untrusted surface, and a hosted Inspector sits inside a network
- * where "http://169.254.169.254/" is a credential endpoint — so the cheapest
- * possible moment to refuse is before we have connected to anything. A refusal
- * is terminal rather than retryable: the address a URL names is not going to
- * become public on the next attempt.
+ * SSRF DEFENCE IS TWO LAYERS, AND ONE ALONE IS NOT ENOUGH.
+ *
+ * `assertOutboundOAuthUrlAllowed` is a pure RFC 6890 classifier over the URL's
+ * hostname. It refuses a literal private, loopback, link-local, CGNAT,
+ * multicast, documentation, NAT64-private or IPv4-mapped-private target, and a
+ * non-http(s) scheme, before any socket exists. What it CANNOT do — as
+ * `@mcpjam/sdk/oauth/node` says of it in as many words — is judge a bare public
+ * hostname: `evil.example` passes the classifier and can still resolve to
+ * 169.254.169.254. Classification alone leaves the rebinding window open.
+ *
+ * So the probe dials through `createGuardedFetch`, which resolves the hostname,
+ * refuses private answers, and re-checks EVERY redirect hop against the same
+ * rules. The redirect half is not optional: a caller does not have to name the
+ * address they want reached — they can name a host they control and have it
+ * answer `302 Location: http://169.254.169.254/`, and a guard that inspects
+ * only the first URL is a guard against typos.
+ *
+ * Known residual gap, accepted repo-wide rather than invented here: the guard
+ * validates the DNS answer and the HTTP client then resolves again, so a
+ * check-vs-connect (TOCTOU) window remains. `hosted-egress-guard.ts` documents
+ * that punt for every egress path in this server; closing it needs connection
+ * pinning at the infra layer, not a second private copy here.
+ *
+ * A blocked target is TERMINAL, not retryable — the address a URL names will
+ * not become public on the next attempt. A resolver OUTAGE is retryable: DNS
+ * blipping is not a verdict about the user's server, and treating it as one
+ * would permanently fail a request over our own infrastructure trouble.
  *
  * No credential is ever attached. Discovery asks what a stranger sees.
  */
@@ -194,7 +220,7 @@ export async function runDiscoveryPreflight(
   input: RunDiscoveryPreflightInput,
   dependencies: RunDiscoveryPreflightDependencies = {},
 ): Promise<DiscoveryOutcome> {
-  const runDoctor = dependencies.runDoctor ?? runServerDoctor;
+  const probeServer = dependencies.probeServer ?? probeMcpServer;
 
   try {
     assertOutboundOAuthUrlAllowed(input.serverUrl, {
@@ -214,11 +240,59 @@ export async function runDiscoveryPreflight(
     throw error;
   }
 
-  const result = await runDoctor({
-    config: { url: input.serverUrl },
-    target: null,
-    timeout: input.timeoutMs ?? DISCOVERY_TIMEOUT_MS,
-  });
+  // The prober CATCHES whatever `fetchFn` throws and reports it as
+  // `status: "error"`, which classifies as retryable. That is right for a
+  // timeout and wrong for an egress refusal — it would put an SSRF attempt on
+  // a retry schedule. So the guard's verdict is recorded on the way past and
+  // consulted before the probe's own account of what happened.
+  const refusal: { blocked: BlockedEgressTargetError | null } = {
+    blocked: null,
+  };
+  const guarded = dependencies.fetchFn ?? createGuardedFetch();
+  const fetchFn: typeof fetch = async (target, init) => {
+    try {
+      return await guarded(target, init);
+    } catch (error) {
+      if (error instanceof BlockedEgressTargetError) {
+        refusal.blocked = error;
+      }
+      throw error;
+    }
+  };
 
-  return classifyDiscoveryResult(result);
+  let probe: ProbeMcpServerResult;
+  try {
+    probe = await probeServer({
+      url: input.serverUrl,
+      timeoutMs: input.timeoutMs ?? DISCOVERY_TIMEOUT_MS,
+      fetchFn,
+    });
+  } catch (error) {
+    if (error instanceof BlockedEgressTargetError) {
+      return {
+        kind: "terminal",
+        errorCode: "URL_NOT_ALLOWED",
+        detail: error.message,
+      };
+    }
+    if (error instanceof EgressResolutionError) {
+      return { kind: "retryable", detail: error.message };
+    }
+    // An unexpected throw means we learned nothing about the target, which is
+    // the definition of retryable here — never a discovery result.
+    return {
+      kind: "retryable",
+      detail: error instanceof Error ? error.message : String(error),
+    };
+  }
+
+  if (refusal.blocked !== null) {
+    return {
+      kind: "terminal",
+      errorCode: "URL_NOT_ALLOWED",
+      detail: refusal.blocked.message,
+    };
+  }
+
+  return classifyDiscoveryResult(probe);
 }

--- a/mcpjam-inspector/server/vitest.config.ts
+++ b/mcpjam-inspector/server/vitest.config.ts
@@ -31,6 +31,11 @@ const sdkHostConfigTemplatesEntry = path.resolve(
   "../sdk/src/host-config/templates/index.ts",
 );
 const sdkPlatformEntry = path.resolve(rootDir, "../sdk/src/platform/index.ts");
+// Node-only SSRF guard + DNS-pinned transport. Needs its own alias for the
+// same reason every other subpath here does: the generic "@mcpjam/sdk" find is
+// a PREFIX replacement, so without this entry the specifier rewrites to
+// `sdk/src/index.ts/oauth/node` and fails to resolve.
+const sdkOAuthNodeEntry = path.resolve(rootDir, "../sdk/src/oauth/node.ts");
 const sdkHostCompatEntry = path.resolve(
   rootDir,
   "../sdk/src/host-compat/index.ts",
@@ -85,6 +90,7 @@ export default defineConfig({
           "@mcpjam/sdk/host-config/internal",
           "@mcpjam/sdk/host-config/templates",
           "@mcpjam/sdk/platform",
+          "@mcpjam/sdk/oauth/node",
           "@mcpjam/sdk/public-api",
           "@mcpjam/sdk/host-compat",
           "@mcpjam/sdk/plugin-bundle",
@@ -122,6 +128,7 @@ export default defineConfig({
         replacement: sdkHostConfigTemplatesEntry,
       },
       { find: "@mcpjam/sdk/platform", replacement: sdkPlatformEntry },
+      { find: "@mcpjam/sdk/oauth/node", replacement: sdkOAuthNodeEntry },
       { find: "@mcpjam/sdk/host-compat", replacement: sdkHostCompatEntry },
       { find: "@mcpjam/sdk/public-api", replacement: sdkPublicApiEntry },
       { find: "@mcpjam/sdk/plugin-bundle", replacement: sdkPluginBundleEntry },


### PR DESCRIPTION
**Was opened as a draft.** This was meant to be the internal advance endpoint. The endpoint is not here, because building it requires inventing a cross-repo wire contract. Full reasoning in `NOTES-item-2.md`; the short version is below.

## Why the endpoint is missing

The endpoint's three steps are: acquire a work lease → do exactly one idempotent step → report the result. Steps 1 and 3 are backend calls, and **there is no wire path for them.**

What I checked:

| question | answer |
| --- | --- |
| Are the state-machine functions client-reachable? | No — every export in `convex/serverConnectionRequests.ts` is `internal*`, which is unreachable from any client by design. |
| Does the Inspector hold a Convex admin/deploy key? | No. Nothing matches `CONVEX_ADMIN`, `CONVEX_DEPLOY_KEY`, `anyApi`, or `makeFunctionReference` under `server/`. The only Convex vars are `CONVEX_URL` and `CONVEX_HTTP_URL`. |
| How does the Inspector reach backend internals today? | Only via the backend's `/internal/v1/*` HTTP routes, service-token gated — that is exactly what `services/internal-backend.ts` exists for. |
| Does a `/internal/v1/server-connections/*` route exist? | **No.** `convex/http.ts` declares 14 `/internal/v1` paths and none is a server-connection route. |
| Is `ConvexHttpClient` a way in? | No — `routes/v1/convex-client.ts` builds it with a *user* token, which only reaches public functions. |

Writing the endpoint anyway would mean choosing, unreviewed: route paths, request/response envelopes, an error-code vocabulary, and how a lease id round-trips — then a human matches all of it on the backend side. That is a design fork, so it stopped here instead.

## What is here

The half of the discovery step that is fully determined by the Inspector, split out so it is testable alone and so the eventual endpoint has nothing left to decide except the round trips.

### `middleware/internal-service-auth.ts` (9 tests)

Verifies `INSPECTOR_SERVICE_TOKEN` on the way **in** — a direction this repo has never needed, since every existing use sends the header outbound. Mirrors the backend's `convex/lib/serviceToken.ts` header-only mode.

- **Constant-time compare over SHA-256 digests of both sides**, not over the raw tokens. `timingSafeEqual` throws on a length mismatch, so comparing raw values forces a length branch — which leaks the secret's length to anyone who can time it. Two digests are always 32 bytes, so there is nothing to branch on.
- **Fails closed when the variable is unset or empty.** Unconfigured must mean "nobody is authorized", never "no guard".
- Does **not** implement the backend's `header-or-bearer` mode, which that file says new routes must not adopt — so it cannot be reached for by accident.
- The 401 body is identical for absent, malformed, and wrong tokens, and never reveals whether a named request id exists. The request id is not authorization anywhere here: it appears in MCP tool output and CLI JSON by design.

### `services/server-connection-discovery.ts` (20 tests)

One bounded, unauthenticated preflight through the SDK's `probeMcpServer` — the prober the server doctor itself runs, so no new prober. No credential is ever attached; discovery asks what a stranger sees.

**The prober rather than the whole doctor.** Classification reads `probe` and nothing else, so the doctor's tool/resource/prompt enumeration is work discovery never looks at — and the doctor's connect step dials through MCPClientManager's own transport, which accepts no `fetchFn` and is therefore the one outbound path the egress guard cannot reach (the same scope limit already documented on `routes/shared/conformance.ts`). Dropping it removes an unguarded socket.

**SSRF defence is two layers.** The first revision of this branch had only the first and described it as if it were the whole protection; @coderabbitai caught that and was right (see the fix commit).

1. `assertOutboundOAuthUrlAllowed` from `@mcpjam/sdk/oauth/node` is a pure RFC 6890 classifier over the URL's **hostname string**. It refuses literal private / loopback / link-local / CGNAT / multicast / documentation / NAT64-private / IPv4-mapped-private targets and non-http(s) schemes before any socket exists. What it cannot do — as `oauth/node.ts` says of it outright — is judge a bare public hostname: `evil.example` passes and can still resolve to `169.254.169.254`.
2. The probe therefore dials through `createGuardedFetch` (`server/utils/hosted-egress-guard.ts`, the same helper `routes/shared/conformance.ts` uses), which resolves the hostname, refuses private answers, and re-checks **every redirect hop**. The redirect half is not optional: a caller need not name the address they want reached — they can name a host they control and have it answer `302 Location: http://169.254.169.254/`.

One subtlety: `probeMcpServer` **catches** whatever `fetchFn` throws and reports `status: "error"`, which classifies as retryable — right for a timeout, wrong for an egress refusal, since it would put an SSRF attempt on a retry schedule. The guard's verdict is recorded as it passes and consulted before the probe's own account. A blocked target is `terminal`; a resolver **outage** is `retryable`, because DNS blipping is our infrastructure trouble and not a verdict about the user's server.

Residual gap, accepted repo-wide rather than invented here: the guard validates the DNS answer and the HTTP client then resolves again, leaving a check-vs-connect (TOCTOU) window. `hosted-egress-guard.ts` documents that punt for every egress path in this server; closing it needs connection pinning at the infra layer.

Loopback stays behind the explicit local-dev opt-in, tested to not relax anything else (a LAN address is still refused with the opt-in on).

| probe status | outcome |
| --- | --- |
| `ready` | `discovered` / `none` |
| `oauth_required` + actionable challenge | `discovered` / `oauth` |
| `oauth_required` + nothing actionable | `discovered` / `unsupported` |
| `reachable` (answered, not MCP) | `terminal`, `NOT_AN_MCP_SERVER` |
| `error` (probe exhausted its retries) | `retryable` — **no discovery reported** |

That last row is the one that matters and has its own test: reporting `unsupported` for a server that was down for a minute would mislabel it permanently.

## One known gap, left deliberately: XAA

The brief's `unsupported` bucket is basic / manual bearer / XAA / unknown. Three of those fall out of a single test — *did discovery find an authorization server we could actually send someone to?* Basic names none because the scheme has no concept of one; manual-bearer servers challenge with `Bearer` and publish no metadata because there is no flow to run.

**XAA does not.** It challenges with `Bearer` *and* publishes authorization server metadata, so this classifier currently calls it `oauth`. Separating them needs an XAA-specific marker in the discovered metadata, and I could not find a settled one — the SDK has a full `sdk/src/xaa/` flow but nothing in the probe path that identifies an XAA server from its challenge or metadata.

Left misclassified with the gap named at the decision site, rather than guessed at. A wrong detector fails by refusing servers that actually work, and that failure gets attributed to the server rather than to us.

## Test-config change worth a glance

`server/vitest.config.ts` gains an alias and an inline entry for `@mcpjam/sdk/oauth/node`. Not cosmetic: the aliases there are **prefix** replacements, so without its own entry the specifier resolved to `sdk/src/index.ts/oauth/node`. Every other SDK subpath the server imports already has the same pair. No existing test's expectations changed.

## Gates

```sh
npm run build -w @mcpjam/sdk                          # clean
cd mcpjam-inspector && npx vitest run --project server
  # 370 files passed | 1 skipped
  # 5267 tests passed | 22 skipped   ← 0 failures
```

Prettier (v2, `--trailing-comma all`) was run on only the files this branch creates or edits.

## What is left

1. **Backend:** expose the state machine over `/internal/v1/server-connections/*` (lease acquire/release, discovery report, validation report), service-token gated, in the shape the existing `/internal/v1/*` routes use. **This is the design decision.**
2. **Inspector:** a typed client for those routes beside `services/internal-backend.ts`.
3. **Inspector:** `routes/internal/` mounted in `server/app.ts`, guarded by `internalServiceAuthMiddleware()`, doing lease → one step → report, returning 200 with a reason when the lease is refused.
4. Then the validation step (`NOTES-item-3.md`), blocked for the same reason. That note records the two things easiest to get wrong there: an empty tool list is still `ready`, and a transient network failure is `retryable` and never `authentication-failed`.

Related: backend rate limits shipped in MCPJam/mcpjam-backend#947 (merged).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit e6a407ebcfb039bcc72d99c12d4afd75096fe42a. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->