### PR TITLE
feat(observability): identify the actor on every Sentry event

### DIFF
--- a/mcpjam-inspector/Dockerfile
+++ b/mcpjam-inspector/Dockerfile
@@ -41,6 +41,14 @@ ARG VITE_WORKOS_API_HOSTNAME
 ARG VITE_CONVEX_URL
 ARG VITE_WORKOS_CLIENT_ID
 ARG VITE_MCPJAM_SANDBOX_ORIGIN
+# Not a VITE_ var — it is never bundled. `sentryVitePlugin` in
+# client/vite.config.ts reads it at BUILD time to upload source maps for the
+# release, and without it every hosted prod stack trace stays minified
+# (`index-<hash>.js:8:117100`) while Sentry falls back to scraping the asset
+# URL, which the SPA answers with index.html. Absent, the plugin warns and
+# skips the upload, so local and desktop builds are unaffected. Scoped to the
+# build stage: the runtime image below copies artifacts, never this ARG.
+ARG SENTRY_AUTH_TOKEN
 
 COPY sdk/tsconfig.json sdk/tsup.config.ts sdk/package.json ./sdk/
 COPY cli/package.json ./cli/package.json
@@ -92,6 +100,7 @@ RUN if [ -n "$VITE_MCPJAM_HOSTED_MODE" ]; then export VITE_MCPJAM_HOSTED_MODE; f
     if [ -n "$VITE_CONVEX_URL" ]; then export VITE_CONVEX_URL; fi; \
     if [ -n "$VITE_WORKOS_CLIENT_ID" ]; then export VITE_WORKOS_CLIENT_ID; fi; \
     if [ -n "$VITE_MCPJAM_SANDBOX_ORIGIN" ]; then export VITE_MCPJAM_SANDBOX_ORIGIN; fi; \
+    if [ -n "$SENTRY_AUTH_TOKEN" ]; then export SENTRY_AUTH_TOKEN; fi; \
     npm run build:client -w @mcpjam/inspector
 
 ################################################################################

--- a/mcpjam-inspector/Dockerfile
+++ b/mcpjam-inspector/Dockerfile
@@ -46,8 +46,17 @@ ARG VITE_MCPJAM_SANDBOX_ORIGIN
 # release, and without it every hosted prod stack trace stays minified
 # (`index-<hash>.js:8:117100`) while Sentry falls back to scraping the asset
 # URL, which the SPA answers with index.html. Absent, the plugin warns and
-# skips the upload, so local and desktop builds are unaffected. Scoped to the
-# build stage: the runtime image below copies artifacts, never this ARG.
+# skips the upload, so local and desktop builds are unaffected.
+#
+# ARG, and not a BuildKit secret mount, because Railway builds this image and
+# does not support `--mount=type=secret`: declaring an ARG of the same name as
+# a service variable is the only supported way to reach a build-time secret
+# there. The exposure that buys is bounded — the ARG is scoped to this build
+# stage, the token is never written to disk or promoted to ENV, and the runtime
+# image below is a separate stage that copies artifacts rather than layers. It
+# would surface in this stage's build history and in `mode=max` provenance,
+# neither of which Railway publishes. Mark the variable Sealed in Railway so it
+# is not readable back out of the dashboard or API.
 ARG SENTRY_AUTH_TOKEN
 
 COPY sdk/tsconfig.json sdk/tsup.config.ts sdk/package.json ./sdk/

--- a/mcpjam-inspector/client/src/App.tsx
+++ b/mcpjam-inspector/client/src/App.tsx
@@ -107,6 +107,7 @@ import { usePostHog, useFeatureFlagEnabled } from "posthog-js/react";
 import { usePostHogIdentify } from "./hooks/usePostHogIdentify";
 import { useSessionRecordingPathGuard } from "./hooks/useSessionRecordingPathGuard";
 import { usePostHogOrgContext } from "./hooks/usePostHogOrgContext";
+import { useSentryOrgContext } from "./hooks/useSentryOrgContext";
 import { useDbUserBootstrapStatus } from "./contexts/db-user-ready-context";
 import { AppStateProvider } from "./state/app-state-context";
 import { ServerActionsProvider } from "./state/server-actions-context";
@@ -2687,6 +2688,7 @@ export default function App() {
     organizationId: activeOrganizationId,
   });
   usePostHogOrgContext(activeOrganizationId);
+  useSentryOrgContext(activeOrganizationId);
   const oauthDebuggerServersRef = useRef(appState.servers);
   oauthDebuggerServersRef.current = appState.servers;
   const projectServersRef = useRef(projectServers);

--- a/mcpjam-inspector/client/src/hooks/__tests__/useEnsureDbUser.test.tsx
+++ b/mcpjam-inspector/client/src/hooks/__tests__/useEnsureDbUser.test.tsx
@@ -159,6 +159,47 @@ describe("useEnsureDbUser", () => {
     );
   });
 
+  it.each([
+    ["only a first name", { firstName: "Some", lastName: null }, "Some"],
+    ["only a last name", { firstName: null, lastName: "One" }, "One"],
+    ["a whitespace-only half", { firstName: "Some", lastName: "  " }, "Some"],
+  ])("builds the display name from %s", async (_label, names, expected) => {
+    mockState.auth.user = { id: "workos-user-1", ...names };
+    mockState.actorKey = "workos-user-1";
+    renderHook(() => useEnsureDbUser());
+
+    await waitFor(() => {
+      expect(mockState.sentrySetUser).toHaveBeenCalledWith(
+        expect.objectContaining({ name: expected })
+      );
+    });
+  });
+
+  it.each([
+    ["both halves are null", { firstName: null, lastName: null }],
+    ["both halves are empty", { firstName: "", lastName: "" }],
+    ["AuthKit supplies neither", {}],
+  ])("omits the name key entirely when %s", async (_label, names) => {
+    // Omitted rather than empty: Sentry renders a user block from whatever
+    // keys are present, and `name: ""` shows as a blank line where the email
+    // would otherwise be.
+    mockState.auth.user = {
+      id: "workos-user-1",
+      email: "someone@example.com",
+      ...names,
+    };
+    mockState.actorKey = "workos-user-1";
+    renderHook(() => useEnsureDbUser());
+
+    await waitFor(() => {
+      expect(mockState.sentrySetUser).toHaveBeenCalledWith({
+        id: "workos-user-1",
+        email: "someone@example.com",
+        username: "someone@example.com",
+      });
+    });
+  });
+
   it("identifies the actor before ensureUser resolves", async () => {
     // The regression this pins: identity used to be set only after the
     // ensureUser round-trip, so anything that crashed during boot — or on a

--- a/mcpjam-inspector/client/src/hooks/__tests__/useEnsureDbUser.test.tsx
+++ b/mcpjam-inspector/client/src/hooks/__tests__/useEnsureDbUser.test.tsx
@@ -5,7 +5,12 @@ import { useEnsureDbUser } from "../useEnsureDbUser";
 const mockState = vi.hoisted(() => ({
   actorKey: "guest-1" as string | null,
   auth: {
-    user: null as { id: string } | null,
+    user: null as {
+      id: string;
+      email?: string;
+      firstName?: string | null;
+      lastName?: string | null;
+    } | null,
   },
   convexAuth: {
     isAuthenticated: true,
@@ -17,6 +22,7 @@ const mockState = vi.hoisted(() => ({
   getExistingGuestId: vi.fn().mockResolvedValue(null as string | null),
   isGuestActivated: vi.fn().mockReturnValue(false),
   sentrySetUser: vi.fn(),
+  sentrySetTag: vi.fn(),
   posthog: null as {
     get_property?: (key: string) => unknown;
     get_distinct_id?: () => string;
@@ -47,8 +53,12 @@ vi.mock("@/lib/guest-session", () => ({
   isGuestActivated: mockState.isGuestActivated,
 }));
 
+// `@/lib/sentry-identity` is deliberately NOT mocked: it is the module under
+// test as much as the hook is, so these assertions run against the real
+// mapping from actor to Sentry scope rather than a restatement of it.
 vi.mock("@sentry/react", () => ({
   setUser: mockState.sentrySetUser,
+  setTag: mockState.sentrySetTag,
 }));
 
 describe("useEnsureDbUser", () => {
@@ -125,21 +135,90 @@ describe("useEnsureDbUser", () => {
     });
   });
 
-  it("clears Sentry when WorkOS signs out but Convex remains guest-authenticated", async () => {
-    mockState.auth.user = { id: "workos-user-1" };
+  it("identifies a signed-in user by email so Sentry issues name a person", async () => {
+    mockState.auth.user = {
+      id: "workos-user-1",
+      email: "someone@example.com",
+      firstName: "Some",
+      lastName: "One",
+    };
     mockState.actorKey = "workos-user-1";
-    const { rerender } = renderHook(() => useEnsureDbUser());
+    renderHook(() => useEnsureDbUser());
 
     await waitFor(() => {
       expect(mockState.sentrySetUser).toHaveBeenCalledWith({
         id: "workos-user-1",
+        email: "someone@example.com",
+        username: "someone@example.com",
+        name: "Some One",
       });
+    });
+    expect(mockState.sentrySetTag).toHaveBeenCalledWith(
+      "actor_kind",
+      "signedIn"
+    );
+  });
+
+  it("identifies the actor before ensureUser resolves", async () => {
+    // The regression this pins: identity used to be set only after the
+    // ensureUser round-trip, so anything that crashed during boot — or on a
+    // session whose ensureUser never succeeded — reported anonymously.
+    mockState.ensureUser.mockImplementation(() => new Promise<void>(() => {}));
+    mockState.auth.user = { id: "workos-user-1", email: "someone@example.com" };
+    mockState.actorKey = "workos-user-1";
+
+    renderHook(() => useEnsureDbUser());
+
+    await waitFor(() => {
+      expect(mockState.sentrySetUser).toHaveBeenCalledWith(
+        expect.objectContaining({ email: "someone@example.com" })
+      );
+    });
+    expect(mockState.ensureUser).toHaveBeenCalledTimes(1);
+  });
+
+  it("identifies guests on the same key PostHog uses", async () => {
+    mockState.auth.user = null;
+    mockState.actorKey = "guest-1";
+    renderHook(() => useEnsureDbUser());
+
+    await waitFor(() => {
+      expect(mockState.sentrySetUser).toHaveBeenCalledWith({ id: "guest-1" });
+    });
+    expect(mockState.sentrySetTag).toHaveBeenCalledWith("actor_kind", "guest");
+  });
+
+  it("drops the signed-in identity when WorkOS signs out but Convex remains guest-authenticated", async () => {
+    mockState.auth.user = { id: "workos-user-1", email: "someone@example.com" };
+    mockState.actorKey = "workos-user-1";
+    const { rerender } = renderHook(() => useEnsureDbUser());
+
+    await waitFor(() => {
+      expect(mockState.sentrySetUser).toHaveBeenCalledWith(
+        expect.objectContaining({ id: "workos-user-1" })
+      );
     });
 
     mockState.sentrySetUser.mockClear();
     mockState.auth.user = null;
     mockState.actorKey = "guest-1";
     rerender();
+
+    // The guest is identified rather than blanked, but the previous account's
+    // email must not survive the switch — `setUser` replaces wholesale, and
+    // this asserts the replacement rather than trusting it.
+    await waitFor(() => {
+      expect(mockState.sentrySetUser).toHaveBeenCalledWith({ id: "guest-1" });
+    });
+    expect(mockState.sentrySetUser).not.toHaveBeenCalledWith(
+      expect.objectContaining({ email: "someone@example.com" })
+    );
+  });
+
+  it("clears the scope entirely while the actor is still resolving", async () => {
+    mockState.auth.user = null;
+    mockState.actorKey = null;
+    renderHook(() => useEnsureDbUser());
 
     await waitFor(() => {
       expect(mockState.sentrySetUser).toHaveBeenCalledWith(null);

--- a/mcpjam-inspector/client/src/hooks/__tests__/useSentryOrgContext.test.tsx
+++ b/mcpjam-inspector/client/src/hooks/__tests__/useSentryOrgContext.test.tsx
@@ -1,0 +1,61 @@
+import { renderHook } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { useSentryOrgContext } from "../useSentryOrgContext";
+
+const mocks = vi.hoisted(() => ({
+  setTag: vi.fn(),
+}));
+
+// Mocked at the SDK boundary rather than at `@/lib/sentry-identity`, so these
+// assertions exercise the real effect-to-tag path instead of restating it.
+vi.mock("@sentry/react", () => ({
+  setUser: vi.fn(),
+  setTag: mocks.setTag,
+}));
+
+describe("useSentryOrgContext", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("tags the org on mount", () => {
+    renderHook(() => useSentryOrgContext("org_123"));
+
+    expect(mocks.setTag).toHaveBeenCalledWith("organization_id", "org_123");
+  });
+
+  it("replaces the tag when the active org changes", () => {
+    const { rerender } = renderHook(
+      ({ orgId }: { orgId: string | null }) => useSentryOrgContext(orgId),
+      { initialProps: { orgId: "org_123" as string | null } }
+    );
+
+    mocks.setTag.mockClear();
+    rerender({ orgId: "org_456" });
+
+    expect(mocks.setTag).toHaveBeenLastCalledWith("organization_id", "org_456");
+  });
+
+  it.each([
+    ["null", null],
+    ["undefined", undefined],
+    // An org id is either a real id or absent; "" is neither, and tagging it
+    // would produce a searchable-but-empty value that matches nothing.
+    ["the empty string", ""],
+  ])("clears the tag for %s", (_label, orgId) => {
+    renderHook(() => useSentryOrgContext(orgId));
+
+    expect(mocks.setTag).toHaveBeenCalledWith("organization_id", undefined);
+  });
+
+  it("clears the tag when the tree unmounts", () => {
+    // The scope is global, this hook is not. An error boundary that unmounts
+    // App would otherwise leave the org on every event that followed.
+    const { unmount } = renderHook(() => useSentryOrgContext("org_123"));
+
+    mocks.setTag.mockClear();
+    unmount();
+
+    expect(mocks.setTag).toHaveBeenCalledWith("organization_id", undefined);
+  });
+});

--- a/mcpjam-inspector/client/src/hooks/useEnsureDbUser.ts
+++ b/mcpjam-inspector/client/src/hooks/useEnsureDbUser.ts
@@ -2,7 +2,7 @@ import { useEffect, useRef, useState } from "react";
 import { useMutation, useConvexAuth } from "convex/react";
 import { useAuth } from "@workos-inc/authkit-react";
 import { usePostHog } from "posthog-js/react";
-import * as Sentry from "@sentry/react";
+import { setSentryActor } from "@/lib/sentry-identity";
 import {
   getExistingGuestId,
   getGuestPromotionProof,
@@ -36,6 +36,24 @@ type EnsureUserMutation = (args: EnsureUserArgs) => Promise<unknown>;
 
 function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === "object" && value !== null;
+}
+
+/**
+ * "First Last" when AuthKit has both halves, otherwise whichever half it has.
+ * Undefined rather than an empty string when it has neither — a blank `name`
+ * would render as an empty line in Sentry's user block instead of falling back
+ * to the email.
+ */
+function displayName(
+  user: {
+    firstName?: string | null;
+    lastName?: string | null;
+  } | null
+): string | undefined {
+  const parts = [user?.firstName, user?.lastName].filter(
+    (part): part is string => typeof part === "string" && part.trim() !== ""
+  );
+  return parts.length > 0 ? parts.join(" ") : undefined;
 }
 
 function isConvexWriteConflictError(err: unknown): boolean {
@@ -167,13 +185,34 @@ export function useEnsureDbUser() {
     }
   }, [isAuthenticated]);
 
-  // WorkOS signout now falls back to Convex guest auth, so Convex can remain
-  // authenticated while the Sentry user must be cleared.
+  // Identity boundary for Sentry.
+  //
+  // Keyed on the actor, NOT on the ensureUser round-trip below. The previous
+  // placement set the user only after `await ensurePromise` resolved, so a
+  // crash during boot — or any crash on a session whose ensureUser was still
+  // in flight or had failed outright — arrived anonymous. Those are precisely
+  // the events worth attributing.
+  //
+  // WorkOS signout falls back to Convex guest auth, so Convex can stay
+  // authenticated while the actor changes underneath it. `setSentryActor`
+  // replaces the user object wholesale, so the previous account's email cannot
+  // survive that switch.
   useEffect(() => {
-    if (!workosUserId) {
-      Sentry.setUser(null);
+    if (!actorKey) {
+      setSentryActor(null);
+      return;
     }
-  }, [workosUserId]);
+    if (workosUserId) {
+      setSentryActor({
+        kind: "signedIn",
+        id: workosUserId,
+        email: user?.email ?? undefined,
+        name: displayName(user),
+      });
+      return;
+    }
+    setSentryActor({ kind: "guest", id: actorKey });
+  }, [actorKey, workosUserId, user?.email, user?.firstName, user?.lastName]);
 
   useEffect(() => {
     if (isLoading) {
@@ -312,9 +351,6 @@ export function useEnsureDbUser() {
 
       lastEnsuredIdentityRef.current = identityKey;
       setEnsuredIdentityKey(identityKey);
-      if (workosUserId) {
-        Sentry.setUser({ id: workosUserId });
-      }
 
       // If we just authenticated as a WorkOS user and a guest cookie was
       // in play, retire it. Safe to call unconditionally — if no cookie

--- a/mcpjam-inspector/client/src/hooks/useEnsureDbUser.ts
+++ b/mcpjam-inspector/client/src/hooks/useEnsureDbUser.ts
@@ -197,11 +197,13 @@ export function useEnsureDbUser() {
   // authenticated while the actor changes underneath it. `setSentryActor`
   // replaces the user object wholesale, so the previous account's email cannot
   // survive that switch.
+  // Signed-in is checked FIRST, and on `workosUserId` rather than on
+  // `actorKey`. `useActorKey` happens to return the WorkOS id ahead of the
+  // guest id, so the two can never disagree for a signed-in render — but
+  // ordering the branches the other way would silently make this identity
+  // depend on that precedence, and a change over there would go quiet here.
+  // Only the guest branch needs the key.
   useEffect(() => {
-    if (!actorKey) {
-      setSentryActor(null);
-      return;
-    }
     if (workosUserId) {
       setSentryActor({
         kind: "signedIn",
@@ -209,6 +211,10 @@ export function useEnsureDbUser() {
         email: user?.email ?? undefined,
         name: displayName(user),
       });
+      return;
+    }
+    if (!actorKey) {
+      setSentryActor(null);
       return;
     }
     setSentryActor({ kind: "guest", id: actorKey });

--- a/mcpjam-inspector/client/src/hooks/useSentryOrgContext.ts
+++ b/mcpjam-inspector/client/src/hooks/useSentryOrgContext.ts
@@ -15,5 +15,11 @@ export function useSentryOrgContext(
 ): void {
   useEffect(() => {
     setSentryOrganization(organizationId);
+    // Cleared on unmount, not just replaced on the next org. `sentry-identity`
+    // promises a scope that carries the current attribution or none, and the
+    // scope is global while this hook is not: an error boundary that unmounts
+    // the tree would otherwise leave `organization_id` behind on every event
+    // that followed.
+    return () => setSentryOrganization(null);
   }, [organizationId]);
 }

--- a/mcpjam-inspector/client/src/hooks/useSentryOrgContext.ts
+++ b/mcpjam-inspector/client/src/hooks/useSentryOrgContext.ts
@@ -1,0 +1,19 @@
+import { useEffect } from "react";
+import { setSentryOrganization } from "@/lib/sentry-identity";
+
+/**
+ * Keep the Sentry scope's `organization_id` tag pointed at the active org.
+ *
+ * Deliberately a sibling of `usePostHogOrgContext` rather than a branch inside
+ * it: the two sinks have different lifecycles (PostHog registers super
+ * properties, Sentry tags a scope) and folding them together would couple an
+ * analytics concern to an error-reporting one. Mounting them side by side at
+ * the same call site is what keeps them from drifting.
+ */
+export function useSentryOrgContext(
+  organizationId: string | null | undefined
+): void {
+  useEffect(() => {
+    setSentryOrganization(organizationId);
+  }, [organizationId]);
+}

--- a/mcpjam-inspector/client/src/lib/__tests__/sentry-identity.test.ts
+++ b/mcpjam-inspector/client/src/lib/__tests__/sentry-identity.test.ts
@@ -1,0 +1,68 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { setSentryActor, setSentryOrganization } from "../sentry-identity";
+
+const mocks = vi.hoisted(() => ({
+  setUser: vi.fn(),
+  setTag: vi.fn(),
+}));
+
+vi.mock("@sentry/react", () => ({
+  setUser: mocks.setUser,
+  setTag: mocks.setTag,
+}));
+
+describe("setSentryActor", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("omits the email fields entirely for an actor without one", () => {
+    // Not `email: undefined`: Sentry renders a user block from whatever keys
+    // are present, and an explicit undefined is a key.
+    setSentryActor({ kind: "guest", id: "guest-1" });
+
+    expect(mocks.setUser).toHaveBeenCalledWith({ id: "guest-1" });
+    expect(mocks.setTag).toHaveBeenCalledWith("actor_kind", "guest");
+  });
+
+  it("mirrors the email into username so the issue list shows a person", () => {
+    setSentryActor({
+      kind: "signedIn",
+      id: "workos-1",
+      email: "someone@example.com",
+    });
+
+    expect(mocks.setUser).toHaveBeenCalledWith({
+      id: "workos-1",
+      email: "someone@example.com",
+      username: "someone@example.com",
+    });
+  });
+
+  it("clears the actor tag along with the user", () => {
+    // A cleared user with a surviving `actor_kind` would attribute the next
+    // anonymous event to the population the previous actor belonged to.
+    setSentryActor(null);
+
+    expect(mocks.setUser).toHaveBeenCalledWith(null);
+    expect(mocks.setTag).toHaveBeenCalledWith("actor_kind", undefined);
+  });
+});
+
+describe("setSentryOrganization", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("clears the tag when the org goes away", () => {
+    setSentryOrganization(null);
+
+    expect(mocks.setTag).toHaveBeenCalledWith("organization_id", undefined);
+  });
+
+  it("tags the active org", () => {
+    setSentryOrganization("org_123");
+
+    expect(mocks.setTag).toHaveBeenCalledWith("organization_id", "org_123");
+  });
+});

--- a/mcpjam-inspector/client/src/lib/__tests__/sentry-identity.test.ts
+++ b/mcpjam-inspector/client/src/lib/__tests__/sentry-identity.test.ts
@@ -54,8 +54,13 @@ describe("setSentryOrganization", () => {
     vi.clearAllMocks();
   });
 
-  it("clears the tag when the org goes away", () => {
-    setSentryOrganization(null);
+  it.each([
+    ["null", null],
+    ["undefined", undefined],
+    ["the empty string", ""],
+    ["whitespace", "   "],
+  ])("clears the tag for %s", (_label, orgId) => {
+    setSentryOrganization(orgId);
 
     expect(mocks.setTag).toHaveBeenCalledWith("organization_id", undefined);
   });

--- a/mcpjam-inspector/client/src/lib/sentry-identity.ts
+++ b/mcpjam-inspector/client/src/lib/sentry-identity.ts
@@ -1,0 +1,78 @@
+import * as Sentry from "@sentry/react";
+
+/**
+ * The one place the Sentry scope learns who is using the app.
+ *
+ * Everything else in the client *reports* errors; nothing else sets identity.
+ * Keeping it to a single writer is what makes the guarantee checkable: a scope
+ * carries the current actor or none, never a stale one, because every
+ * transition — sign-in, sign-out, guest rotation — runs through
+ * `setSentryActor`, and `Sentry.setUser` replaces the user object wholesale.
+ */
+
+/**
+ * Actor kinds, spelled exactly as the server spells them (`ExecutionActorKind`
+ * in `server/utils/execution-scope.ts`, `authType` in the request logs). A
+ * client Sentry issue and the server log line for the same request should be
+ * filterable by the same word rather than by two dialects of it.
+ */
+export type SentryActorKind = "signedIn" | "guest";
+
+export interface SentryActor {
+  kind: SentryActorKind;
+  /**
+   * The same key PostHog identifies on (`useActorKey`): the WorkOS user id when
+   * signed in, the cookie-backed guest id otherwise. Shared deliberately — it
+   * is what lets a Sentry issue be pivoted into the PostHog funnel for the same
+   * actor without maintaining a lookup table between the two products.
+   */
+  id: string;
+  email?: string;
+  name?: string;
+}
+
+/**
+ * Point the scope at the current actor, or clear it.
+ *
+ * Guests are identified too, not blanked. An anonymous crash is the one you
+ * cannot chase, and a guest id is no more identifying than the cookie the
+ * browser is already carrying — while `actor_kind` keeps the two populations
+ * separable in search.
+ *
+ * The email rides along for signed-in users only, and only because they signed
+ * in: `sendDefaultPii: false` (see `shared/sentry-config.ts`) governs what the
+ * SDK collects *automatically* — IP, headers, cookies — and does not suppress
+ * fields set here. That split is the intended posture: nothing incidental, one
+ * field on purpose.
+ */
+export function setSentryActor(actor: SentryActor | null): void {
+  if (!actor) {
+    Sentry.setUser(null);
+    Sentry.setTag("actor_kind", undefined);
+    return;
+  }
+
+  Sentry.setUser({
+    id: actor.id,
+    // `username` as well as `email`: Sentry's issue list renders whichever it
+    // finds first, and without it a user reads as a bare opaque id in exactly
+    // the view where you are trying to recognize someone.
+    ...(actor.email ? { email: actor.email, username: actor.email } : {}),
+    ...(actor.name ? { name: actor.name } : {}),
+  });
+  Sentry.setTag("actor_kind", actor.kind);
+}
+
+/**
+ * Tag the scope with the active organization.
+ *
+ * A tag rather than a context: for a B2B product the first triage question is
+ * "which account", and only tags are indexed for search, filtering, and alert
+ * conditions. Mirrors `usePostHogOrgContext`'s `organization_id` register so
+ * the two sinks agree on the name.
+ */
+export function setSentryOrganization(
+  organizationId: string | null | undefined
+): void {
+  Sentry.setTag("organization_id", organizationId ?? undefined);
+}

--- a/mcpjam-inspector/client/src/lib/sentry-identity.ts
+++ b/mcpjam-inspector/client/src/lib/sentry-identity.ts
@@ -70,9 +70,14 @@ export function setSentryActor(actor: SentryActor | null): void {
  * "which account", and only tags are indexed for search, filtering, and alert
  * conditions. Mirrors `usePostHogOrgContext`'s `organization_id` register so
  * the two sinks agree on the name.
+ *
+ * An org id is either a real id or absent, so a blank one clears rather than
+ * tags: `organization_id:""` is a searchable value that matches nothing and
+ * reads, in a filter dropdown, as an org whose name failed to load.
  */
 export function setSentryOrganization(
   organizationId: string | null | undefined
 ): void {
-  Sentry.setTag("organization_id", organizationId ?? undefined);
+  const trimmed = organizationId?.trim();
+  Sentry.setTag("organization_id", trimmed ? trimmed : undefined);
 }


### PR DESCRIPTION
## Why

For an issue like [INSPECTOR-CLIENT-22X](https://mcpjam-gh.sentry.io/issues/7668382266/) you cannot tell who hit it. Sentry knows a WorkOS id and nothing else — the issue reads `id:user_01KZBPD6EAPXMN2X71XRV6WPQ7` — while PostHog already has the email, name, and organization for the same actor. The two sinks drifted.

Three gaps, all at one boundary.

## What

**Identity moves to `client/src/lib/sentry-identity.ts`**, the single writer of the scope's actor.

- Signed-in users carry `email` and `username`. `sendDefaultPii: false` governs what the SDK collects *automatically* — IP, headers, cookies — and does not suppress fields set deliberately. That split is the intended posture: nothing incidental, one field on purpose.
- Guests are identified rather than blanked, on the same key `useActorKey` gives PostHog, so a Sentry issue can be pivoted into the funnel for the same actor without a lookup table. Previously `Sentry.setUser(null)`, so every guest crash was anonymous.
- `actor_kind` is tagged with the server's own vocabulary (`signedIn` | `guest`, per `ExecutionActorKind`) so a client issue and the server log line for the same request filter on the same word.

**The scope is set from the actor effect, not after the `ensureUser` round-trip.** Identity used to land only after `await ensurePromise` resolved, so anything that crashed during boot — or on a session whose `ensureUser` was still in flight or had failed outright — reported anonymously. Those are the events most worth attributing.

**`organization_id` becomes a Sentry tag**, mirroring the PostHog register. A tag rather than a context: only tags are indexed for search, filtering, and alert conditions, and "which account" is the first triage question for a B2B product.

## Source maps (separate, and the reason that stack trace is unreadable)

`sentryVitePlugin` has been wired in `client/vite.config.ts` all along, but `SENTRY_AUTH_TOKEN` appears only in the desktop release workflows. The hosted image builds from `mcpjam-inspector/Dockerfile`, which never declared it — so **app.mcpjam.com has never uploaded source maps**. Prod stack traces are minified (`index-FNGzysE2.js:8:117100`, frames named `eDe` / `VP` / `rDe`) and Sentry falls back to scraping the asset URL, which the SPA answers with `index.html` — hence the `<link rel="preconnect" ...>` lines shown as source context.

This PR adds the build-stage `ARG` and exports it into `build:client`. Absent, `sentryVitePlugin` warns and skips the upload, so local and desktop builds are unaffected. The ARG is scoped to the build stage; the runtime image copies artifacts, never the token.

> [!IMPORTANT]
> **Merging this does not fix source maps on its own.** `SENTRY_AUTH_TOKEN` still has to be set as a build variable on the Railway prod and staging services. Until then hosted stacks stay minified.

## Testing

- `client/src/lib/__tests__/sentry-identity.test.ts` — 5 new: email/username mirroring, no `email: undefined` key for guests, `actor_kind` cleared alongside the user, org tag set and cleared.
- `client/src/hooks/__tests__/useEnsureDbUser.test.tsx` — 22 pass. New cases pin identity landing *before* `ensureUser` resolves, guests identified on the PostHog key, and — replacing the old "clears Sentry" test — that the previous account's email cannot survive a sign-out into guest auth.
- `client/src/__tests__/App.hosted-oauth.test.tsx` — 62 pass, unaffected by the new hook.
- Client typecheck clean; prettier clean on changed lines.

Not addressed here: the underlying `Cannot read properties of undefined (reading 'role')` on `/playground`. With source maps uploaded, the next occurrence points at a real line instead of a `useMemo` somewhere in the bundle.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit 9ae092109332401679c0d2a288d12232920ddfd0. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Identifies the current actor on every Sentry event and tags the active organization so issues name a person and account and can be pivoted to the same actor in PostHog. Also enables hosted builds to upload source maps.

- Centralizes identity in `client/src/lib/sentry-identity.ts` and sets it from the actor effect before `ensureUser` so boot-time crashes are attributed; prefers a WorkOS user over the guest key to avoid scope clearing edge cases.
- Signed-in users include `email`, `username`, and `name` when available; guests are identified on the same actor key PostHog uses; adds an `actor_kind` tag (`signedIn` | `guest`). `sendDefaultPii: false` remains; email is set only for signed-in users.
- Adds `useSentryOrgContext` to tag `organization_id`, mirroring PostHog; treats blank as absent and clears on unmount so the org doesn’t leak after tree teardown.
- Adds `SENTRY_AUTH_TOKEN` build ARG in `mcpjam-inspector/Dockerfile` for the Vite Sentry plugin; it is read only at build time and excluded from the runtime image.

**Rollout**
- Set `SENTRY_AUTH_TOKEN` as a build variable for prod and staging on Railway to enable source map uploads (mark it Sealed).

<sup>Written for commit a761ca97ba0b864dcfef22d2c59ccca22f7dc387. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/MCPJam/inspector/pull/3942?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

