### PR TITLE
fix(trace): stop trace timeline crashing on stale span message indices

### DIFF
--- a/chat-ui/src/__tests__/trace-timeline.test.tsx
+++ b/chat-ui/src/__tests__/trace-timeline.test.tsx
@@ -89,6 +89,39 @@ describe("TraceTimeline (recorded waterfall)", () => {
     ).toBe(false);
   });
 
+  // A transcript whose last message is a user message would otherwise be the
+  // one a backward walk lands on, mislabelling the row with an unrelated turn.
+  it("borrows no user label when the transcript ends with a user message", () => {
+    const staleSpans: TraceSpan[] = [
+      {
+        id: "p0-llm",
+        name: "Agent",
+        category: "llm",
+        startMs: 0,
+        endMs: 500,
+        promptIndex: 0,
+        stepIndex: 0,
+        messageStartIndex: 5,
+        messageEndIndex: 6,
+      },
+    ];
+    const { getAllByTestId } = render(
+      <TraceTimeline
+        recordedSpans={staleSpans}
+        transcriptMessages={[
+          { role: "user", content: "what's the weather" },
+          { role: "user", content: "still there?" },
+        ]}
+      />,
+    );
+    const rows = getAllByTestId("trace-row");
+    expect(rows.length).toBeGreaterThan(0);
+    expect(rows.some((row) => row.textContent?.includes("User:"))).toBe(false);
+    expect(
+      rows.some((row) => row.textContent?.includes("still there?")),
+    ).toBe(false);
+  });
+
   it("shows harness metadata (provider/finish) in the detail pane for llm spans", () => {
     const llmSpans: TraceSpan[] = [
       {

--- a/chat-ui/src/__tests__/trace-timeline.test.tsx
+++ b/chat-ui/src/__tests__/trace-timeline.test.tsx
@@ -54,6 +54,34 @@ describe("TraceTimeline (recorded waterfall)", () => {
     getByText(/No timing data recorded/i);
   });
 
+  // Rehydrated sessions rebuild the transcript from the UI, so it can be
+  // shorter than the server transcript the span indices were recorded against.
+  it("renders when span message indices point past the transcript", () => {
+    const staleSpans: TraceSpan[] = [
+      {
+        id: "p0-llm",
+        name: "Agent",
+        category: "llm",
+        startMs: 0,
+        endMs: 500,
+        promptIndex: 0,
+        stepIndex: 0,
+        messageStartIndex: 5,
+        messageEndIndex: 6,
+      },
+    ];
+    const { getAllByTestId } = render(
+      <TraceTimeline
+        recordedSpans={staleSpans}
+        transcriptMessages={[
+          { role: "user", content: "what's the weather" },
+          { role: "assistant", content: "it's sunny" },
+        ]}
+      />,
+    );
+    expect(getAllByTestId("trace-row").length).toBeGreaterThan(0);
+  });
+
   it("shows harness metadata (provider/finish) in the detail pane for llm spans", () => {
     const llmSpans: TraceSpan[] = [
       {

--- a/chat-ui/src/__tests__/trace-timeline.test.tsx
+++ b/chat-ui/src/__tests__/trace-timeline.test.tsx
@@ -79,7 +79,14 @@ describe("TraceTimeline (recorded waterfall)", () => {
         ]}
       />,
     );
-    expect(getAllByTestId("trace-row").length).toBeGreaterThan(0);
+    const rows = getAllByTestId("trace-row");
+    expect(rows.length).toBeGreaterThan(0);
+    // Out-of-range indices must not borrow an unrelated user message as the
+    // row's prompt label.
+    expect(rows.some((row) => row.textContent?.includes("User:"))).toBe(false);
+    expect(
+      rows.some((row) => row.textContent?.includes("what's the weather")),
+    ).toBe(false);
   });
 
   it("shows harness metadata (provider/finish) in the detail pane for llm spans", () => {

--- a/chat-ui/src/internal/trace-timeline/trace-timeline.tsx
+++ b/chat-ui/src/internal/trace-timeline/trace-timeline.tsx
@@ -520,14 +520,16 @@ function findUserMessageIndexForRange(
 
   // Span indices are recorded against the server's transcript, which can be
   // longer than the one the browser holds (rehydrated sessions rebuild it from
-  // the UI, dropping transient messages and incomplete tool calls). Clamp so
-  // the backward walk starts inside this transcript instead of past its end.
-  const backwardStartIndex = Math.min(
-    range.startIndex - 1,
-    messages.length - 1,
-  );
-  if (backwardStartIndex >= 0) {
-    for (let index = backwardStartIndex; index >= 0; index -= 1) {
+  // the UI, dropping transient messages and incomplete tool calls). A range
+  // starting past the end describes messages this transcript doesn't have, so
+  // there is no "preceding" user message to walk back to — anything found
+  // there would belong to an unrelated turn.
+  if (range.startIndex >= messages.length) {
+    return undefined;
+  }
+
+  if (range.startIndex > 0) {
+    for (let index = range.startIndex - 1; index >= 0; index -= 1) {
       const message = messages[index];
       if (!message) continue;
       if (message.role === "user") {

--- a/chat-ui/src/internal/trace-timeline/trace-timeline.tsx
+++ b/chat-ui/src/internal/trace-timeline/trace-timeline.tsx
@@ -518,9 +518,18 @@ function findUserMessageIndexForRange(
     return inRangeIndex;
   }
 
-  if (range && range.startIndex > 0) {
-    for (let index = range.startIndex - 1; index >= 0; index -= 1) {
-      const message = messages[index]!;
+  // Span indices are recorded against the server's transcript, which can be
+  // longer than the one the browser holds (rehydrated sessions rebuild it from
+  // the UI, dropping transient messages and incomplete tool calls). Clamp so
+  // the backward walk starts inside this transcript instead of past its end.
+  const backwardStartIndex = Math.min(
+    range.startIndex - 1,
+    messages.length - 1,
+  );
+  if (backwardStartIndex >= 0) {
+    for (let index = backwardStartIndex; index >= 0; index -= 1) {
+      const message = messages[index];
+      if (!message) continue;
       if (message.role === "user") {
         return index;
       }

--- a/mcpjam-inspector/client/src/components/evals/__tests__/trace-timeline.test.tsx
+++ b/mcpjam-inspector/client/src/components/evals/__tests__/trace-timeline.test.tsx
@@ -135,6 +135,39 @@ describe("harness span metadata", () => {
     ).toBe(false);
   });
 
+  // A transcript whose last message is a user message would otherwise be the
+  // one a backward walk lands on, mislabelling the row with an unrelated turn.
+  it("borrows no user label when the transcript ends with a user message", () => {
+    const staleSpans: EvalTraceSpan[] = [
+      {
+        id: "step-0",
+        name: "Step 1",
+        category: "step",
+        startMs: 0,
+        endMs: 500,
+        stepIndex: 0,
+        promptIndex: 0,
+        messageStartIndex: 5,
+        messageEndIndex: 6,
+      },
+    ];
+    render(
+      <TraceTimeline
+        recordedSpans={staleSpans}
+        transcriptMessages={[
+          { role: "user", content: "what's the weather" },
+          { role: "user", content: "still there?" },
+        ]}
+      />,
+    );
+    const rows = screen.getAllByTestId("trace-row");
+    expect(rows.length).toBeGreaterThan(0);
+    expect(rows.some((row) => row.textContent?.includes("User:"))).toBe(false);
+    expect(
+      rows.some((row) => row.textContent?.includes("still there?")),
+    ).toBe(false);
+  });
+
   it("omits throughput on non-llm rows", () => {
     const spans: EvalTraceSpan[] = [
       { id: "step-0", name: "Step 1", category: "step", startMs: 0, endMs: 500, stepIndex: 0 },

--- a/mcpjam-inspector/client/src/components/evals/__tests__/trace-timeline.test.tsx
+++ b/mcpjam-inspector/client/src/components/evals/__tests__/trace-timeline.test.tsx
@@ -100,6 +100,34 @@ describe("harness span metadata", () => {
     expect(meta.textContent).toContain("200.0 tok/s");
   });
 
+  // Rehydrated sessions rebuild the transcript from the UI, so it can be
+  // shorter than the server transcript the span indices were recorded against.
+  it("renders when span message indices point past the transcript", () => {
+    const staleSpans: EvalTraceSpan[] = [
+      {
+        id: "step-0",
+        name: "Step 1",
+        category: "step",
+        startMs: 0,
+        endMs: 500,
+        stepIndex: 0,
+        promptIndex: 0,
+        messageStartIndex: 5,
+        messageEndIndex: 6,
+      },
+    ];
+    render(
+      <TraceTimeline
+        recordedSpans={staleSpans}
+        transcriptMessages={[
+          { role: "user", content: "what's the weather" },
+          { role: "assistant", content: "it's sunny" },
+        ]}
+      />,
+    );
+    expect(screen.getAllByTestId("trace-row").length).toBeGreaterThan(0);
+  });
+
   it("omits throughput on non-llm rows", () => {
     const spans: EvalTraceSpan[] = [
       { id: "step-0", name: "Step 1", category: "step", startMs: 0, endMs: 500, stepIndex: 0 },

--- a/mcpjam-inspector/client/src/components/evals/__tests__/trace-timeline.test.tsx
+++ b/mcpjam-inspector/client/src/components/evals/__tests__/trace-timeline.test.tsx
@@ -125,7 +125,14 @@ describe("harness span metadata", () => {
         ]}
       />,
     );
-    expect(screen.getAllByTestId("trace-row").length).toBeGreaterThan(0);
+    const rows = screen.getAllByTestId("trace-row");
+    expect(rows.length).toBeGreaterThan(0);
+    // Out-of-range indices must not borrow an unrelated user message as the
+    // row's prompt label.
+    expect(rows.some((row) => row.textContent?.includes("User:"))).toBe(false);
+    expect(
+      rows.some((row) => row.textContent?.includes("what's the weather")),
+    ).toBe(false);
   });
 
   it("omits throughput on non-llm rows", () => {

--- a/mcpjam-inspector/client/src/components/evals/trace-timeline.tsx
+++ b/mcpjam-inspector/client/src/components/evals/trace-timeline.tsx
@@ -543,9 +543,18 @@ function findUserMessageIndexForRange(
     return inRangeIndex;
   }
 
-  if (range && range.startIndex > 0) {
-    for (let index = range.startIndex - 1; index >= 0; index -= 1) {
-      const message = messages[index]!;
+  // Span indices are recorded against the server's transcript, which can be
+  // longer than the one the browser holds (rehydrated sessions rebuild it from
+  // the UI, dropping transient messages and incomplete tool calls). Clamp so
+  // the backward walk starts inside this transcript instead of past its end.
+  const backwardStartIndex = Math.min(
+    range.startIndex - 1,
+    messages.length - 1,
+  );
+  if (backwardStartIndex >= 0) {
+    for (let index = backwardStartIndex; index >= 0; index -= 1) {
+      const message = messages[index];
+      if (!message) continue;
       if (message.role === "user") {
         return index;
       }

--- a/mcpjam-inspector/client/src/components/evals/trace-timeline.tsx
+++ b/mcpjam-inspector/client/src/components/evals/trace-timeline.tsx
@@ -545,14 +545,16 @@ function findUserMessageIndexForRange(
 
   // Span indices are recorded against the server's transcript, which can be
   // longer than the one the browser holds (rehydrated sessions rebuild it from
-  // the UI, dropping transient messages and incomplete tool calls). Clamp so
-  // the backward walk starts inside this transcript instead of past its end.
-  const backwardStartIndex = Math.min(
-    range.startIndex - 1,
-    messages.length - 1,
-  );
-  if (backwardStartIndex >= 0) {
-    for (let index = backwardStartIndex; index >= 0; index -= 1) {
+  // the UI, dropping transient messages and incomplete tool calls). A range
+  // starting past the end describes messages this transcript doesn't have, so
+  // there is no "preceding" user message to walk back to — anything found
+  // there would belong to an unrelated turn.
+  if (range.startIndex >= messages.length) {
+    return undefined;
+  }
+
+  if (range.startIndex > 0) {
+    for (let index = range.startIndex - 1; index >= 0; index -= 1) {
       const message = messages[index];
       if (!message) continue;
       if (message.role === "user") {


### PR DESCRIPTION
- Opening the trace timeline on a reloaded chat could crash the page with `Cannot read properties of undefined (reading 'role')` ([Sentry](https://mcpjam-gh.sentry.io/issues/7668382266/)).
- Each trace span saves which messages it covers, counted against the server's copy of the chat. On reload the browser rebuilds the chat from what's on screen, which drops system messages and unfinished tool calls — so it's shorter, and the saved numbers point past the end.
- The code that finds the user's message for a row walked backwards from those numbers without checking the message exists. Now it stays inside the list it actually has.
- Same function exists twice (chat-ui package and inspector client); both are fixed, with a regression test in each.
- No messages disappear — a row whose numbers land past the end just shows no `User: "..."` label instead of crashing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevent trace timeline crashes and mislabels when span message indices are stale after chat rehydration. Previously the code walked backward from server-recorded indices and could read past the transcript or borrow the last user turn; now it bails out for out-of-range ranges and skips gaps so rows render without an incorrect User label.

- Update `findUserMessageIndexForRange` in `chat-ui` and `mcpjam-inspector`: return undefined when `range.startIndex >= messages.length`, and skip undefined slots during the backward walk.
- Add tests in both packages for out-of-range indices and transcripts ending with a user message to ensure no borrowed “User” label.
- No API changes or migration steps.

<sup>Written for commit ff0fb79235681e7f3c3e6b62648a364807eb36e3. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/MCPJam/inspector/pull/3943?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

