### PR TITLE
fix(observability): stop filing Sentry issues for OS-killed utility p…

### DIFF
--- a/mcpjam-inspector/src/crash-reporting.test.ts
+++ b/mcpjam-inspector/src/crash-reporting.test.ts
@@ -35,11 +35,12 @@ describe("childProcessIntegrationOptions", () => {
     expect(events).toContain("oom");
   });
 
-  it("leaves an OS kill as a breadcrumb", () => {
+  it("never captures an OS kill, leaving it a breadcrumb", () => {
     // macOS kills Electron's own utility processes under memory pressure and
     // Electron respawns them; the user sees nothing. Capturing it filed
     // issues about the reporter's machine, not about the app.
-    expect(CAPTURED_EXIT_REASONS).not.toContain("killed");
+    const { events } = childProcessIntegrationOptions();
+    expect(events).not.toContain("killed");
   });
 
   it("keeps the SDK's own defaults", () => {

--- a/mcpjam-inspector/src/crash-reporting.test.ts
+++ b/mcpjam-inspector/src/crash-reporting.test.ts
@@ -28,12 +28,18 @@ import {
 describe("childProcessIntegrationOptions", () => {
   it("promotes the crash-shaped reasons the SDK leaves as breadcrumbs", () => {
     // @sentry/electron 5.12 defaults `events` to abnormal-exit,
-    // launch-failed and integrity-failure only. crashed/oom/killed are
+    // launch-failed and integrity-failure only. crashed/oom are
     // exactly the ones a desktop user experiences as "the app broke".
     const { events } = childProcessIntegrationOptions();
     expect(events).toContain("crashed");
     expect(events).toContain("oom");
-    expect(events).toContain("killed");
+  });
+
+  it("leaves an OS kill as a breadcrumb", () => {
+    // macOS kills Electron's own utility processes under memory pressure and
+    // Electron respawns them; the user sees nothing. Capturing it filed
+    // issues about the reporter's machine, not about the app.
+    expect(CAPTURED_EXIT_REASONS).not.toContain("killed");
   });
 
   it("keeps the SDK's own defaults", () => {

--- a/mcpjam-inspector/src/crash-reporting.ts
+++ b/mcpjam-inspector/src/crash-reporting.ts
@@ -7,9 +7,15 @@ import * as Sentry from "@sentry/electron/main";
  * `["abnormal-exit", "launch-failed", "integrity-failure"]` as EVENTS — the
  * remaining reasons (`crashed`, `oom`, `killed`) are recorded as breadcrumbs
  * only, which means they surface just as context on some LATER event and
- * produce no issue of their own. Those three are the ones a desktop user
+ * produce no issue of their own. `crashed` and `oom` are ones a desktop user
  * actually experiences as "the app broke", so they are promoted to events
  * here.
+ *
+ * `killed` stays out: the OS kills Electron's own utility processes under
+ * memory pressure on a busy machine, Electron respawns them, and the user
+ * sees nothing. Capturing it produced issues about the reporter's hardware
+ * rather than about the app. It remains a breadcrumb, so it still shows up
+ * as context if a real failure follows.
  *
  * `clean-exit` stays out: that is a normal shutdown.
  */
@@ -19,7 +25,6 @@ export const CAPTURED_EXIT_REASONS = [
   "integrity-failure",
   "crashed",
   "oom",
-  "killed",
 ] as const;
 
 interface CrashLogger {

--- a/mcpjam-inspector/src/main.ts
+++ b/mcpjam-inspector/src/main.ts
@@ -17,7 +17,7 @@ Sentry.init({
     deployment: "self_hosted",
   }),
   ipcMode: Sentry.IPCMode.Both, // Enables communication with renderer process
-  // Promotes crashed/oom/killed from breadcrumbs to captured events — see
+  // Promotes crashed/oom from breadcrumbs to captured events — see
   // crash-reporting.ts. `sentryMinidumpIntegration` (native crash upload) is
   // already on by default in @sentry/electron 5.12 and is left alone.
   integrations: crashReportingIntegrations,


### PR DESCRIPTION
…rocesses

macOS kills Electron's own utility processes under memory pressure and Electron respawns them; the user sees nothing. Capturing `killed` as an event filed issues about the reporter's hardware rather than the app, so it drops back to a breadcrumb and still shows as context on a real failure.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stop filing Sentry issues for OS‑killed Electron utility processes by removing `killed` from captured exit events. This cuts noise from macOS memory‑pressure respawns while keeping `killed` as a breadcrumb for context on later failures.

- Removes `killed` from `CAPTURED_EXIT_REASONS`; still promotes `crashed` and `oom` alongside `@sentry/electron` defaults (`abnormal-exit`, `launch-failed`, `integrity-failure`). Updates the Sentry init comment to drop the stale `killed` reference.
- Updates tests to assert `killed` is excluded from the configured events (not just the constant), confirming it remains a breadcrumb. No configuration or migration required.

<sup>Written for commit 9877a08c2b93cb45377c10eb0b577fca6a02faea. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/MCPJam/inspector/pull/3945?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

