### PR TITLE
fix(chat): cap live trace turn history to bound renderer memory growth

### DIFF
--- a/mcpjam-inspector/client/src/hooks/__tests__/use-chat-session.live-trace.test.tsx
+++ b/mcpjam-inspector/client/src/hooks/__tests__/use-chat-session.live-trace.test.tsx
@@ -727,4 +727,61 @@ describe("useChatSession live trace state", () => {
     );
     expect(seenHeartbeat).not.toBe(true);
   });
+
+  it("evicts the oldest turns once the live trace turn cap is exceeded", async () => {
+    const { result } = renderHook(() =>
+      useChatSession({
+        selectedServers: ["server-1"],
+      }),
+    );
+
+    await waitFor(() => {
+      expect(result.current.isSessionBootstrapComplete).toBe(true);
+      expect(mockState.chatOnData).not.toBeNull();
+    });
+
+    // MAX_LIVE_TRACE_TURNS is 200 — push well past it so turn-0 and turn-1
+    // are guaranteed to be evicted, and confirm the most recent turns and
+    // their request payloads survive.
+    const TOTAL_TURNS = 210;
+    act(() => {
+      for (let i = 0; i < TOTAL_TURNS; i += 1) {
+        const turnId = `turn-${i}`;
+        mockState.chatOnData?.(
+          tracePart({
+            type: "turn_start",
+            turnId,
+            promptIndex: i,
+            startedAtMs: i * 1000,
+          }),
+        );
+        mockState.chatOnData?.(
+          tracePart({
+            type: "request_payload",
+            turnId,
+            promptIndex: i,
+            stepIndex: 0,
+            payload: {
+              system: "System",
+              tools: {},
+              messages: [{ role: "user", content: `Prompt ${i}` }],
+            },
+          }),
+        );
+      }
+    });
+
+    await waitFor(() => {
+      expect(result.current.requestPayloadHistory.length).toBeLessThan(
+        TOTAL_TURNS,
+      );
+    });
+
+    const turnIds = result.current.requestPayloadHistory.map(
+      (entry) => entry.turnId,
+    );
+    expect(turnIds).not.toContain("turn-0");
+    expect(turnIds).not.toContain("turn-1");
+    expect(turnIds).toContain(`turn-${TOTAL_TURNS - 1}`);
+  });
 });

--- a/mcpjam-inspector/client/src/hooks/__tests__/use-chat-session.live-trace.test.tsx
+++ b/mcpjam-inspector/client/src/hooks/__tests__/use-chat-session.live-trace.test.tsx
@@ -740,9 +740,10 @@ describe("useChatSession live trace state", () => {
       expect(mockState.chatOnData).not.toBeNull();
     });
 
-    // MAX_LIVE_TRACE_TURNS is 200 — push well past it so turn-0 and turn-1
-    // are guaranteed to be evicted, and confirm the most recent turns and
-    // their request payloads survive.
+    // MAX_LIVE_TRACE_TURNS is 200 — push 10 turns past it so the boundary is
+    // unambiguous: turn-0..turn-9 must be evicted, turn-10..turn-209 must
+    // survive (exactly 200 turns).
+    const MAX_LIVE_TRACE_TURNS = 200;
     const TOTAL_TURNS = 210;
     act(() => {
       for (let i = 0; i < TOTAL_TURNS; i += 1) {
@@ -772,16 +773,143 @@ describe("useChatSession live trace state", () => {
     });
 
     await waitFor(() => {
-      expect(result.current.requestPayloadHistory.length).toBeLessThan(
-        TOTAL_TURNS,
+      expect(result.current.requestPayloadHistory).toHaveLength(
+        MAX_LIVE_TRACE_TURNS,
       );
     });
 
-    const turnIds = result.current.requestPayloadHistory.map(
+    const payloadTurnIds = result.current.requestPayloadHistory.map(
       (entry) => entry.turnId,
     );
-    expect(turnIds).not.toContain("turn-0");
-    expect(turnIds).not.toContain("turn-1");
-    expect(turnIds).toContain(`turn-${TOTAL_TURNS - 1}`);
+    expect(payloadTurnIds).not.toContain("turn-9");
+    expect(payloadTurnIds[0]).toBe("turn-10");
+    expect(payloadTurnIds).toContain(`turn-${TOTAL_TURNS - 1}`);
+
+    // `turnOrder`/`turns` (surfaced via liveTraceEnvelope.turns) must be
+    // bounded too, not just requestPayloadHistory — a regression that only
+    // trims the payload history would still leak turn state.
+    const envelopeTurnIds = result.current.liveTraceEnvelope?.turns?.map(
+      (turn) => turn.turnId,
+    );
+    expect(envelopeTurnIds).toHaveLength(MAX_LIVE_TRACE_TURNS);
+    expect(envelopeTurnIds).not.toContain("turn-9");
+    expect(envelopeTurnIds?.[0]).toBe("turn-10");
+    expect(envelopeTurnIds).toContain(`turn-${TOTAL_TURNS - 1}`);
+  });
+
+  it("evicts the oldest turn when the 201st turn arrives via trace_snapshot", async () => {
+    const { result } = renderHook(() =>
+      useChatSession({
+        selectedServers: ["server-1"],
+      }),
+    );
+
+    await waitFor(() => {
+      expect(result.current.isSessionBootstrapComplete).toBe(true);
+      expect(mockState.chatOnData).not.toBeNull();
+    });
+
+    const MAX_LIVE_TRACE_TURNS = 200;
+    act(() => {
+      for (let i = 0; i < MAX_LIVE_TRACE_TURNS; i += 1) {
+        mockState.chatOnData?.(
+          tracePart({
+            type: "turn_start",
+            turnId: `turn-${i}`,
+            promptIndex: i,
+            startedAtMs: i * 1000,
+          }),
+        );
+      }
+    });
+
+    await waitFor(() => {
+      expect(result.current.liveTraceEnvelope?.turns).toHaveLength(
+        MAX_LIVE_TRACE_TURNS,
+      );
+    });
+
+    // The 201st turn arrives only as a trace_snapshot (no turn_start) — this
+    // return path must evict turn-0 the same way turn_start/request_payload
+    // do.
+    act(() => {
+      mockState.chatOnData?.(
+        tracePart({
+          type: "trace_snapshot",
+          turnId: "turn-200",
+          promptIndex: 200,
+          snapshot: {
+            traceVersion: 1,
+            promptIndex: 200,
+            messages: [{ role: "user", content: "Prompt 200" }],
+            spans: [],
+          },
+        }),
+      );
+    });
+
+    await waitFor(() => {
+      const turnIds = result.current.liveTraceEnvelope?.turns?.map(
+        (turn) => turn.turnId,
+      );
+      expect(turnIds).toHaveLength(MAX_LIVE_TRACE_TURNS);
+      expect(turnIds).not.toContain("turn-0");
+      expect(turnIds).toContain("turn-200");
+    });
+  });
+
+  it("evicts the oldest turn when the 201st turn arrives via turn_finish", async () => {
+    const { result } = renderHook(() =>
+      useChatSession({
+        selectedServers: ["server-1"],
+      }),
+    );
+
+    await waitFor(() => {
+      expect(result.current.isSessionBootstrapComplete).toBe(true);
+      expect(mockState.chatOnData).not.toBeNull();
+    });
+
+    const MAX_LIVE_TRACE_TURNS = 200;
+    act(() => {
+      for (let i = 0; i < MAX_LIVE_TRACE_TURNS; i += 1) {
+        mockState.chatOnData?.(
+          tracePart({
+            type: "turn_start",
+            turnId: `turn-${i}`,
+            promptIndex: i,
+            startedAtMs: i * 1000,
+          }),
+        );
+      }
+    });
+
+    await waitFor(() => {
+      expect(result.current.liveTraceEnvelope?.turns).toHaveLength(
+        MAX_LIVE_TRACE_TURNS,
+      );
+    });
+
+    // The 201st turn arrives only as a turn_finish (no prior turn_start) —
+    // `ensureTurnState` creates it fresh, and this return path must also
+    // evict turn-0.
+    act(() => {
+      mockState.chatOnData?.(
+        tracePart({
+          type: "turn_finish",
+          turnId: "turn-200",
+          promptIndex: 200,
+        }),
+      );
+    });
+
+    await waitFor(() => {
+      const turnIds = result.current.liveTraceEnvelope?.turns?.map(
+        (turn) => turn.turnId,
+      );
+      expect(turnIds).toHaveLength(MAX_LIVE_TRACE_TURNS);
+      expect(turnIds).not.toContain("turn-0");
+      expect(turnIds).toContain("turn-200");
+    });
   });
 });

--- a/mcpjam-inspector/client/src/hooks/use-chat-session.ts
+++ b/mcpjam-inspector/client/src/hooks/use-chat-session.ts
@@ -715,6 +715,12 @@ interface PendingSessionHydration {
 }
 
 const MAX_LIVE_TRACE_EVENTS = 400;
+// Bounds `turnOrder`/`turns`/`requestPayloadHistory` for long-running agent
+// sessions. Without this, a session left open for many hours accumulates one
+// entry per turn — each carrying a full resolved model request (system
+// prompt + entire message history) — growing roughly quadratically and
+// eventually exhausting the renderer's V8 heap (see INSPECTOR-ELECTRON-VR).
+const MAX_LIVE_TRACE_TURNS = 200;
 
 function createEmptyLiveTraceState(): LiveTraceAccumulatorState {
   return {
@@ -1083,6 +1089,37 @@ function upsertRequestPayloadEntry(
   );
 }
 
+// Drops the oldest turns once `turnOrder` exceeds MAX_LIVE_TRACE_TURNS,
+// keeping `turns` and `requestPayloadHistory` in sync with what's evicted.
+function trimLiveTraceTurns(
+  state: LiveTraceAccumulatorState
+): LiveTraceAccumulatorState {
+  if (state.turnOrder.length <= MAX_LIVE_TRACE_TURNS) {
+    return state;
+  }
+
+  const dropCount = state.turnOrder.length - MAX_LIVE_TRACE_TURNS;
+  const droppedTurnIds = new Set(state.turnOrder.slice(0, dropCount));
+  const turnOrder = state.turnOrder.slice(dropCount);
+
+  const turns: Record<string, LiveTraceTurnState> = {};
+  for (const turnId of turnOrder) {
+    const turn = state.turns[turnId];
+    if (turn) {
+      turns[turnId] = turn;
+    }
+  }
+
+  return {
+    ...state,
+    turnOrder,
+    turns,
+    requestPayloadHistory: state.requestPayloadHistory.filter(
+      (entry) => !droppedTurnIds.has(entry.turnId)
+    ),
+  };
+}
+
 function applyLiveTraceEvent(
   state: LiveTraceAccumulatorState,
   event: LiveChatTraceEvent
@@ -1117,7 +1154,7 @@ function applyLiveTraceEvent(
     case "turn_start": {
       const turnExists = baseState.turnOrder.includes(event.turnId);
       const prev = baseState.turns[event.turnId];
-      return {
+      return trimLiveTraceTurns({
         ...baseState,
         turnOrder: turnExists
           ? baseState.turnOrder
@@ -1135,12 +1172,12 @@ function applyLiveTraceEvent(
         },
         activeTurnId: event.turnId,
         activeTurnHasSnapshot: false,
-      };
+      });
     }
     case "request_payload": {
       const turnState = ensureTurnState(event.turnId, event.promptIndex);
       const turnExists = baseState.turnOrder.includes(event.turnId);
-      return {
+      return trimLiveTraceTurns({
         ...baseState,
         turnOrder: turnExists
           ? baseState.turnOrder
@@ -1161,7 +1198,7 @@ function applyLiveTraceEvent(
             payload: event.payload,
           }
         ),
-      };
+      });
     }
     case "trace_snapshot": {
       const turnState = ensureTurnState(
@@ -1169,7 +1206,7 @@ function applyLiveTraceEvent(
         event.snapshot.promptIndex
       );
       const turnExists = baseState.turnOrder.includes(event.turnId);
-      return {
+      return trimLiveTraceTurns({
         ...baseState,
         turnOrder: turnExists
           ? baseState.turnOrder
@@ -1199,12 +1236,12 @@ function applyLiveTraceEvent(
           baseState.activeTurnId === event.turnId ||
           baseState.activeTurnId === null,
         anySnapshotSeen: true,
-      };
+      });
     }
     case "turn_finish": {
       const turnState = ensureTurnState(event.turnId, event.promptIndex);
       const turnExists = baseState.turnOrder.includes(event.turnId);
-      return {
+      return trimLiveTraceTurns({
         ...baseState,
         turnOrder: turnExists
           ? baseState.turnOrder
@@ -1224,7 +1261,7 @@ function applyLiveTraceEvent(
           baseState.activeTurnId === event.turnId
             ? false
             : baseState.activeTurnHasSnapshot,
-      };
+      });
     }
     default:
       return baseState;

--- a/mcpjam-inspector/client/src/hooks/use-chat-session.ts
+++ b/mcpjam-inspector/client/src/hooks/use-chat-session.ts
@@ -721,6 +721,11 @@ const MAX_LIVE_TRACE_EVENTS = 400;
 // prompt + entire message history) — growing roughly quadratically and
 // eventually exhausting the renderer's V8 heap (see INSPECTOR-ELECTRON-VR).
 const MAX_LIVE_TRACE_TURNS = 200;
+// Backstop for `requestPayloadHistory` independent of the turn cap above: a
+// single turn can carry many steps (agent tool-call loops), each appending
+// its own full request payload keyed by turnId+stepIndex, so bounding by
+// turn count alone doesn't bound this array for a pathologically long turn.
+const MAX_LIVE_TRACE_REQUEST_PAYLOADS = 2 * MAX_LIVE_TRACE_TURNS;
 
 function createEmptyLiveTraceState(): LiveTraceAccumulatorState {
   return {
@@ -784,8 +789,18 @@ async function resolveHydratedTurnTraces(
   if (raw.length === 0) {
     return [];
   }
+  // Rehydrating a session with more persisted turns than the live cap would
+  // otherwise recreate the same unbounded growth this cap prevents
+  // (INSPECTOR-ELECTRON-VR) — keep only the most recent turns, and skip
+  // fetching span blobs for the ones we're about to discard.
+  const boundedRaw =
+    raw.length > MAX_LIVE_TRACE_TURNS
+      ? [...raw]
+          .sort((left, right) => left.promptIndex - right.promptIndex)
+          .slice(-MAX_LIVE_TRACE_TURNS)
+      : raw;
   const results = await Promise.all(
-    raw.map(async (trace) => {
+    boundedRaw.map(async (trace) => {
       let spans: EvalTraceSpan[] = [];
       if (trace.spansBlobUrl) {
         try {
@@ -1091,32 +1106,52 @@ function upsertRequestPayloadEntry(
 
 // Drops the oldest turns once `turnOrder` exceeds MAX_LIVE_TRACE_TURNS,
 // keeping `turns` and `requestPayloadHistory` in sync with what's evicted.
+// Also applies a flat backstop cap to `requestPayloadHistory` in case a
+// single turn (still within the turn cap) accumulates many step entries.
 function trimLiveTraceTurns(
   state: LiveTraceAccumulatorState
 ): LiveTraceAccumulatorState {
-  if (state.turnOrder.length <= MAX_LIVE_TRACE_TURNS) {
-    return state;
+  let turnOrder = state.turnOrder;
+  let turns = state.turns;
+  let requestPayloadHistory = state.requestPayloadHistory;
+
+  if (turnOrder.length > MAX_LIVE_TRACE_TURNS) {
+    const dropCount = turnOrder.length - MAX_LIVE_TRACE_TURNS;
+    const droppedTurnIds = new Set(turnOrder.slice(0, dropCount));
+    turnOrder = turnOrder.slice(dropCount);
+
+    const nextTurns: Record<string, LiveTraceTurnState> = {};
+    for (const turnId of turnOrder) {
+      const turn = turns[turnId];
+      if (turn) {
+        nextTurns[turnId] = turn;
+      }
+    }
+    turns = nextTurns;
+
+    requestPayloadHistory = requestPayloadHistory.filter(
+      (entry) => !droppedTurnIds.has(entry.turnId)
+    );
   }
 
-  const dropCount = state.turnOrder.length - MAX_LIVE_TRACE_TURNS;
-  const droppedTurnIds = new Set(state.turnOrder.slice(0, dropCount));
-  const turnOrder = state.turnOrder.slice(dropCount);
+  if (requestPayloadHistory.length > MAX_LIVE_TRACE_REQUEST_PAYLOADS) {
+    requestPayloadHistory = requestPayloadHistory.slice(
+      -MAX_LIVE_TRACE_REQUEST_PAYLOADS
+    );
+  }
 
-  const turns: Record<string, LiveTraceTurnState> = {};
-  for (const turnId of turnOrder) {
-    const turn = state.turns[turnId];
-    if (turn) {
-      turns[turnId] = turn;
-    }
+  if (
+    turnOrder === state.turnOrder &&
+    requestPayloadHistory === state.requestPayloadHistory
+  ) {
+    return state;
   }
 
   return {
     ...state,
     turnOrder,
     turns,
-    requestPayloadHistory: state.requestPayloadHistory.filter(
-      (entry) => !droppedTurnIds.has(entry.turnId)
-    ),
+    requestPayloadHistory,
   };
 }
 


### PR DESCRIPTION
## Summary
- Fixes Sentry [INSPECTOR-ELECTRON-VR](https://mcpjam-gh.sentry.io/issues/INSPECTOR-ELECTRON-VR) — a fatal `EXC_BREAKPOINT` crash from V8 hitting its heap limit (`Reached heap limit` → `FatalProcessOutOfMemory`) in a renderer process after a ~26h chat/agent session.
- Root cause: `requestPayloadHistory` (full resolved model request per turn) and `turns`/`turnOrder` in `use-chat-session.ts` grew without any cap for the lifetime of a session — unlike `events`, which is already capped at `MAX_LIVE_TRACE_EVENTS = 400`. Over a very long session this grows large enough to exhaust the renderer's V8 heap.
- Adds `MAX_LIVE_TRACE_TURNS = 200` and a `trimLiveTraceTurns` helper that evicts the oldest turns (and their associated `requestPayloadHistory` entries) once the cap is exceeded, applied at every state-transition return in `applyLiveTraceEvent`, mirroring the existing `events` cap pattern.

## Test plan
- [x] Added a test asserting turns/request payloads beyond the cap are evicted and the most recent turn survives (`use-chat-session.live-trace.test.tsx`)
- [x] `npx vitest run client/src/hooks/__tests__/use-chat-session.live-trace.test.tsx` — 8/8 passing
- [x] `npm run typecheck` (full workspace) — passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Caps live trace turn history at 200 and adds a request-payload backstop to prevent renderer OOM in long-running chat sessions. Previously, live and hydrated sessions grew unbounded turn state and payload history; now the oldest turns and excess payload entries are evicted, so older turns may no longer appear after the cap.

**Review notes**
- Adds `MAX_LIVE_TRACE_TURNS = 200` and `MAX_LIVE_TRACE_REQUEST_PAYLOADS = 400`; `MAX_LIVE_TRACE_EVENTS = 400` is unchanged.
- Enforces caps in `trimLiveTraceTurns` and during hydration in `resolveHydratedTurnTraces` (keeps only the most recent turns, skips blob fetches for discarded turns).
- Applies eviction on `turn_start`, `request_payload`, `trace_snapshot`, and `turn_finish`; preserves the latest/active turn and keeps `turnOrder`, `turns`, and `requestPayloadHistory` consistent.
- Expands `use-chat-session.live-trace.test.tsx` with boundary and path coverage (including `trace_snapshot` and `turn_finish`).

<sup>Written for commit bc3aa1091a6d6e1b0ee9244c3aca4c0b90681211. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/MCPJam/inspector/pull/3946?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

