### PR TITLE
fix(errors): stop reporting upstream auth rejections as MCPJam 500s

### DIFF
--- a/mcpjam-inspector/client/src/components/evals/__tests__/use-eval-trace-tool-context.test.tsx
+++ b/mcpjam-inspector/client/src/components/evals/__tests__/use-eval-trace-tool-context.test.tsx
@@ -209,4 +209,75 @@ describe("useEvalTraceToolContext", () => {
     expect(mockState.listTools).toHaveBeenCalledTimes(2);
     expect(result.current.error).toBeNull();
   });
+
+  it("surfaces an upstream auth refusal instead of parking on the spinner", async () => {
+    // The hosted route classifies "the user's MCP server refused our
+    // credentials" as 403 UPSTREAM_AUTH_FAILED. Both halves of the transient
+    // heuristic would otherwise claim it — the status is 403 and the message
+    // reads as an auth failure — and a transient verdict leaves this panel
+    // loading forever with no auto-retry. Nothing retryable can fix it, so the
+    // user has to see the error and go reconnect the server.
+    mockState.hostedMode = true;
+    mockState.convexAuth.isAuthenticated = true;
+    mockState.convexAuth.isLoading = false;
+    mockState.projectServers = {
+      serversByName: new Map([["alpha", "server-alpha"]]),
+      isLoading: false,
+    };
+    mockState.listTools.mockRejectedValue(
+      Object.assign(
+        new Error('Authentication failed for MCP server "alpha": HTTP 403'),
+        {
+          status: 403,
+          code: "UPSTREAM_AUTH_FAILED",
+          details: { upstreamAuthRequired: true },
+        },
+      ),
+    );
+
+    const { result } = renderHook(() =>
+      useEvalTraceToolContext({
+        serverNames: ["alpha"],
+        projectId: "shared-project-1",
+      }),
+    );
+
+    await waitFor(() => {
+      expect(result.current.error).toBe(
+        'Authentication failed for MCP server "alpha": HTTP 403',
+      );
+    });
+
+    expect(result.current.isLoading).toBe(false);
+  });
+
+  it("still treats a bare hosted 403 as transient", () => {
+    // Regression guard for the branch above: only the route's explicit
+    // upstream-auth verdict is exempt. A plain 403 during hosted readiness
+    // (project access still settling) must keep its transient handling.
+    mockState.hostedMode = true;
+    mockState.convexAuth.isAuthenticated = true;
+    mockState.convexAuth.isLoading = false;
+    mockState.projectServers = {
+      serversByName: new Map([["alpha", "server-alpha"]]),
+      isLoading: false,
+    };
+    mockState.listTools.mockRejectedValue(
+      Object.assign(new Error("Forbidden"), { status: 403 }),
+    );
+
+    const { result } = renderHook(() =>
+      useEvalTraceToolContext({
+        serverNames: ["alpha"],
+        projectId: "shared-project-1",
+      }),
+    );
+
+    return waitFor(() => {
+      expect(mockState.listTools).toHaveBeenCalledTimes(1);
+    }).then(() => {
+      expect(result.current.error).toBeNull();
+      expect(result.current.isLoading).toBe(true);
+    });
+  });
 });

--- a/mcpjam-inspector/client/src/components/evals/use-eval-trace-tool-context.ts
+++ b/mcpjam-inspector/client/src/components/evals/use-eval-trace-tool-context.ts
@@ -40,12 +40,45 @@ function buildEmptyState(
   };
 }
 
+/**
+ * The route's verdict that the USER'S MCP server refused the credentials
+ * MCPJam presented (`routes/web/errors.ts` `UPSTREAM_AUTH_FAILED`).
+ *
+ * Checked BEFORE the transient heuristics below, and load-bearing: that
+ * verdict arrives as a 403 — and its message ("Authentication failed for MCP
+ * server …") reads as an auth failure — so both halves of the heuristic would
+ * otherwise call it transient and park the panel on a spinner forever. It is
+ * the opposite of transient: nothing this hook can retry will make the
+ * upstream server accept the token, so the user has to see the error and go
+ * reconnect the server.
+ */
+function isUpstreamAuthRefusal(error: {
+  code?: unknown;
+  details?: unknown;
+}): boolean {
+  if (error.code === "UPSTREAM_AUTH_FAILED") return true;
+  const details = error.details;
+  return (
+    !!details &&
+    typeof details === "object" &&
+    (details as { upstreamAuthRequired?: unknown }).upstreamAuthRequired === true
+  );
+}
+
 function isTransientHostedToolContextError(error: unknown): boolean {
   if (!error || typeof error !== "object") {
     return false;
   }
 
-  const withMessage = error as { message?: unknown; status?: unknown };
+  const withMessage = error as {
+    message?: unknown;
+    status?: unknown;
+    code?: unknown;
+    details?: unknown;
+  };
+  if (isUpstreamAuthRefusal(withMessage)) {
+    return false;
+  }
   if (withMessage.status === 401 || withMessage.status === 403) {
     return true;
   }

--- a/mcpjam-inspector/server/routes/v1/__tests__/envelope.test.ts
+++ b/mcpjam-inspector/server/routes/v1/__tests__/envelope.test.ts
@@ -9,6 +9,7 @@
  */
 import { describe, it, expect } from "vitest";
 import { mapErrorToV1 } from "../envelope.js";
+import { V1_ERROR_STATUS } from "../contract.js";
 import { ErrorCode, WebRouteError } from "../../web/errors.js";
 
 describe("mapErrorToV1 — OAUTH_REQUIRED promotion", () => {
@@ -101,6 +102,54 @@ describe("mapErrorToV1 — FEATURE_NOT_SUPPORTED promotion", () => {
     const result = mapErrorToV1(err);
 
     expect(result.code).toBe("INTERNAL_ERROR");
+  });
+});
+
+describe("mapErrorToV1 — upstream auth refusals", () => {
+  it("maps UPSTREAM_AUTH_FAILED to FORBIDDEN, not the unknown-code 500", () => {
+    // `UPSTREAM_AUTH_FAILED` is Inspector-internal and deliberately absent
+    // from the shared `INTERNAL_TO_V1_CODE` table (the Convex backend keeps a
+    // byte-identical copy and never emits this code), so without the explicit
+    // branch in `mapErrorToV1` it hits `mapInternalCode`'s unknown-code
+    // default and reaches CLI/worker callers as a 500 INTERNAL_ERROR — the
+    // exact misreport the classification exists to remove.
+    const err = new WebRouteError(
+      403,
+      ErrorCode.UPSTREAM_AUTH_FAILED,
+      'Authentication failed for MCP server "acme": HTTP 403',
+      { upstreamAuthRequired: true }
+    );
+
+    const result = mapErrorToV1(err);
+
+    expect(result.code).toBe("FORBIDDEN");
+    expect(result.details).toMatchObject({ upstreamAuthRequired: true });
+  });
+
+  it("classifies a transport 403 end-to-end as FORBIDDEN", () => {
+    // Shape of the MCP SDK's StreamableHTTPError/SseError: an Error carrying
+    // the numeric HTTP status. It is NOT an `MCPAuthError`, so the
+    // OAUTH_REQUIRED promotion at the top of `mapErrorToV1` declines it and it
+    // falls through to the runtime classifier.
+    const err = Object.assign(
+      new Error("Error POSTing to endpoint (HTTP 403): forbidden"),
+      { code: 403 }
+    );
+
+    expect(mapErrorToV1(err).code).toBe("FORBIDDEN");
+  });
+
+  it("still answers 403 for the FORBIDDEN code the v1 status map carries", () => {
+    // Guard on the pairing, not just the code: the whole point is that these
+    // stop being 5xx. `V1_ERROR_STATUS.FORBIDDEN` is the contract's answer.
+    const err = new WebRouteError(
+      403,
+      ErrorCode.UPSTREAM_AUTH_FAILED,
+      "refused",
+      { upstreamAuthRequired: true }
+    );
+
+    expect(V1_ERROR_STATUS[mapErrorToV1(err).code]).toBe(403);
   });
 });
 

--- a/mcpjam-inspector/server/routes/v1/envelope.ts
+++ b/mcpjam-inspector/server/routes/v1/envelope.ts
@@ -93,6 +93,30 @@ export function mapErrorToV1(error: unknown): {
       details: routeError.details,
     };
   }
+  // The upstream server refused the credentials we presented. Mapped HERE
+  // rather than in the shared `INTERNAL_TO_V1_CODE` table on purpose:
+  // `UPSTREAM_AUTH_FAILED` is an Inspector-internal code that the Convex
+  // backend never emits, and that table is a SHARED contract the backend
+  // keeps a byte-identical copy of (see ./contract.ts) — pushing an
+  // Inspector-only concept into it would make the two surfaces drift for a
+  // value one of them can never produce. Without this branch `mapInternalCode`
+  // falls through its unknown-code default and answers 500 INTERNAL_ERROR, the
+  // exact misreport this classification exists to remove, on the surface the
+  // CLI and the MCP worker read.
+  //
+  // FORBIDDEN, not OAUTH_REQUIRED: a genuine `MCPAuthError` was already
+  // promoted to OAUTH_REQUIRED at the top of this function, so what reaches
+  // here did NOT identify as an MCP auth failure (a transport error carrying
+  // 403, or a message-pattern match) and carries no grant for the caller to
+  // drive. 403 also matches the status the hosted `/api/web/*` twin returns
+  // for the same throw.
+  if (routeError.code === ErrorCode.UPSTREAM_AUTH_FAILED) {
+    return {
+      code: "FORBIDDEN",
+      message: routeError.message,
+      details: routeError.details,
+    };
+  }
   return {
     code: mapInternalCode(routeError.code),
     message: routeError.message,

--- a/mcpjam-inspector/server/routes/web/__tests__/errors.test.ts
+++ b/mcpjam-inspector/server/routes/web/__tests__/errors.test.ts
@@ -7,7 +7,7 @@ vi.mock("@sentry/node", () => ({
 }));
 import * as Sentry from "@sentry/node";
 const captureException = vi.mocked(Sentry.captureException);
-import { originOf } from "@mcpjam/sdk";
+import { MCPAuthError, originOf } from "@mcpjam/sdk";
 import { InsufficientScopeError } from "@modelcontextprotocol/client";
 
 import {
@@ -40,6 +40,101 @@ describe("mapRuntimeError", () => {
     // No per-server auth context here — the escalation tag is applied only
     // where the effective auth method is known.
     expect(mapped.details?.oauthRequired).toBeUndefined();
+  });
+
+  describe("upstream auth rejections", () => {
+    // The SDK raises this exact shape from `MCPClientManager`'s connect path
+    // (`new MCPAuthError('Authentication failed for MCP server "…": …',
+    // authCheck.statusCode, { cause })`). 3,706 of them landed on
+    // `/api/web/tools/list` in 30 days, every one reported as a 500
+    // INTERNAL_ERROR — an MCPJam fault code for the user's server refusing our
+    // credentials.
+    function upstreamAuthError(statusCode?: number, detail = "") {
+      return new MCPAuthError(
+        `Authentication failed for MCP server "acme": Streamable HTTP error: ${detail}`,
+        statusCode,
+      );
+    }
+
+    // The spec's authorization error table is identical in 2025-03-26,
+    // 2025-06-18, 2025-11-25, 2026-07-28 and draft: 401 (token invalid), 403
+    // (insufficient permissions), 400 (malformed authorization request). All
+    // three are legitimate upstream auth rejections, so none of them may be
+    // reported as an MCPJam internal error.
+    it.each([401, 403, 400])(
+      "never reports an upstream %i auth rejection as 500 INTERNAL_ERROR",
+      (statusCode) => {
+        const mapped = mapRuntimeError(upstreamAuthError(statusCode));
+
+        expect(mapped.status).not.toBe(500);
+        expect(mapped.code).not.toBe(ErrorCode.INTERNAL_ERROR);
+      },
+    );
+
+    it("never reports a status-less auth rejection as 500 INTERNAL_ERROR", () => {
+      // `isAuthError` returns no statusCode when it recognized the failure by
+      // message alone, so the MCPAuthError the SDK builds carries none.
+      const mapped = mapRuntimeError(upstreamAuthError(undefined));
+
+      expect(mapped.status).not.toBe(500);
+      expect(mapped.code).not.toBe(ErrorCode.INTERNAL_ERROR);
+    });
+
+    it("keeps a clean upstream 401 on the existing 401 UNAUTHORIZED branch", () => {
+      const mapped = mapRuntimeError(upstreamAuthError(401));
+
+      expect(mapped.status).toBe(401);
+      expect(mapped.code).toBe(ErrorCode.UNAUTHORIZED);
+    });
+
+    it.each([403, 400, undefined])(
+      "maps an upstream %s auth rejection to 403 UPSTREAM_AUTH_FAILED",
+      (statusCode) => {
+        const mapped = mapRuntimeError(upstreamAuthError(statusCode));
+
+        expect(mapped.status).toBe(403);
+        expect(mapped.code).toBe(ErrorCode.UPSTREAM_AUTH_FAILED);
+        expect(mapped.details?.upstreamAuthRequired).toBe(true);
+      },
+    );
+
+    it("does NOT widen the guest-retry 401 surface", () => {
+      // `authFetch` retries any 401 from `/api/web/*` for an actor with no
+      // WorkOS session (`shouldRetryApiAuth401`) by force-refreshing the guest
+      // token and replaying — and the hosted `webError` envelope cannot send
+      // the `X-MCP-Auth-Required: oauth` header that suppresses it. Sending
+      // these thousands of upstream rejections back as 401 would put every
+      // guest through a refresh + replay that cannot fix the failure.
+      for (const statusCode of [403, 400, undefined]) {
+        expect(mapRuntimeError(upstreamAuthError(statusCode)).status).not.toBe(
+          401,
+        );
+      }
+    });
+
+    it("still carries the normalized block and the effective origin", () => {
+      // The whole point of moving off INTERNAL_ERROR is attribution, so the
+      // envelope must keep saying whose failure this was: `user_config`, which
+      // is also what keeps the strict Sentry policy from paging us for it.
+      const mapped = mapRuntimeError(upstreamAuthError(403));
+
+      expect(mapped.normalized?.slug).toBeTruthy();
+      expect(originOf(mapped.normalized)).toBe("user_config");
+      expect(mapped.origin).toBe("user_config");
+    });
+
+    it("outranks transport noise quoted inside the auth message", () => {
+      // The connect path quotes BOTH the Streamable HTTP and the SSE failure in
+      // one message, so an auth rejection routinely carries "fetch failed" or
+      // "timed out" text. The SDK already classified it from the status codes;
+      // a substring match must not override that.
+      expect(
+        mapRuntimeError(upstreamAuthError(403, "fetch failed")).code,
+      ).toBe(ErrorCode.UPSTREAM_AUTH_FAILED);
+      expect(
+        mapRuntimeError(upstreamAuthError(403, "the request timed out")).code,
+      ).toBe(ErrorCode.UPSTREAM_AUTH_FAILED);
+    });
   });
 
   it("maps ECONN* errno messages to 502", () => {
@@ -136,6 +231,11 @@ describe("mapRuntimeError", () => {
         "https://rs.example/.well-known/oauth-protected-resource",
       errorDescription: undefined,
     });
+    // Regression guard for the generic upstream-auth branch added below it:
+    // `InsufficientScopeError` is also an auth rejection, so it would be
+    // swallowed as UPSTREAM_AUTH_FAILED (dropping the challenge the client
+    // needs to drive the step-up) if that branch ever moved ahead of this one.
+    expect(mapped.code).not.toBe(ErrorCode.UPSTREAM_AUTH_FAILED);
   });
 
   it("recognizes a wrapped insufficient_scope challenge (cause chain) as 403", () => {

--- a/mcpjam-inspector/server/routes/web/errors.ts
+++ b/mcpjam-inspector/server/routes/web/errors.ts
@@ -1,6 +1,7 @@
 import { z } from "zod";
 import {
   describeError,
+  isAuthError,
   isUnauthorized401,
   originOf,
   type ErrorOrigin,
@@ -76,6 +77,25 @@ export const ErrorCode = {
   // token and replay the turn. Emitted once the backend enforces the
   // version it already advertises.
   CHATBOX_ACCESS_STALE: "CHATBOX_ACCESS_STALE",
+  // The USER'S MCP server refused the credentials MCPJam presented. Their
+  // failure, not ours — it was the single largest error class on
+  // `/api/web/tools/list` (3,706 events in 30 days) and every one of them
+  // logged as INTERNAL_ERROR, spending the 5xx budget and hiding real internal
+  // faults behind them.
+  //
+  // Served at 403, deliberately NOT 401. `authFetch` retries any 401 from an
+  // `/api/web/*` path when the actor has no WorkOS session
+  // (`shouldRetryApiAuth401`: `!isAuthenticated && !hasSession`) by clearing
+  // the bearer cache, force-refreshing the guest session and replaying the
+  // request; the hosted `webError` envelope has no way to set the
+  // `X-MCP-Auth-Required: oauth` header that suppresses it (only the LOCAL
+  // `respondWithLocalRouteError` does). Mapping thousands of upstream auth
+  // rejections onto 401 would therefore make every guest burn a guest-token
+  // refresh and a replay on a failure the replay cannot fix. 403 is also the
+  // honest HTTP answer: the CALLER's credentials are not the problem, so
+  // re-authenticating with MCPJam will not change the outcome — the user has
+  // to reconnect the upstream server.
+  UPSTREAM_AUTH_FAILED: "UPSTREAM_AUTH_FAILED",
 } as const;
 
 export type ErrorCode = (typeof ErrorCode)[keyof typeof ErrorCode];
@@ -383,6 +403,43 @@ function classifyRuntimeError(error: unknown): WebRouteError {
       ErrorCode.UNAUTHORIZED,
       message,
       undefined,
+      normalized
+    );
+  }
+
+  // Every OTHER upstream auth rejection. The branch above only recognizes a
+  // clean numeric 401, but the MCP authorization spec's own error table — byte
+  // identical in every version that defines authorization (2025-03-26,
+  // 2025-06-18, 2025-11-25, 2026-07-28, draft) — lists 401 (authorization
+  // required / token invalid), 403 (invalid scopes or insufficient
+  // permissions) AND 400 (malformed authorization request). So a 403 or 400
+  // rejection, or an `MCPAuthError` carrying no status at all, used to fall all
+  // the way through to the 500 fallback and be reported as an MCPJam internal
+  // error. Because every version's table agrees, one shared branch is correct
+  // and no per-era gating applies. (2024-11-05 defines no authorization at all;
+  // an auth failure there is not spec-governed, which is another reason this
+  // keys off the ERROR rather than the negotiated protocol version.)
+  //
+  // Sits ahead of the timeout/connection branches on purpose: an `MCPAuthError`
+  // raised after the Streamable HTTP + SSE fallback pair quotes BOTH transport
+  // failures in one message, so a message-substring match on "fetch failed" or
+  // "timed out" would otherwise outrank the auth classification the SDK already
+  // made from the status codes.
+  //
+  // `isAuthError` rather than `instanceof MCPAuthError`: it matches by class
+  // NAME (the SDK's own convention for this reason) and sees through the
+  // era-negotiation wrapper, so recognition survives the server resolving
+  // `@mcpjam/sdk` to `dist` while another copy resolves to `src`.
+  if (isAuthError(error).isAuth) {
+    return new WebRouteError(
+      403,
+      ErrorCode.UPSTREAM_AUTH_FAILED,
+      message,
+      // Established flag: "the UPSTREAM server demands auth; refreshing an
+      // MCPJam session or guest token cannot change that." The local envelope
+      // already turns it into `X-MCP-Auth-Required: oauth`, which is exactly
+      // the retry suppression this classification wants.
+      { upstreamAuthRequired: true },
       normalized
     );
   }


### PR DESCRIPTION
## The bug

`classifyRuntimeError` recognized only a clean numeric 401 (`isUnauthorized401`). A **403** or **400** auth rejection — or an `MCPAuthError` carrying no status at all — fell straight through to the `500 INTERNAL_ERROR` fallback.

Measured in Axiom over 30 days: **3,706 events** of `Authentication failed for MCP server "…"` on `/api/web/tools/list`, all logged as `500 INTERNAL_ERROR`. That is the largest single error class on the route. Every one of them is the **user's** server refusing our credentials — so they spend our 5xx budget and bury real internal faults underneath them.

## Spec basis

The MCP authorization spec's error table is **byte-identical in every version that defines authorization** (2025-03-26, 2025-06-18, 2025-11-25, 2026-07-28, draft):

| Status | Usage |
|---|---|
| 401 | Authorization required or token invalid |
| 403 | Invalid scopes or insufficient permissions |
| 400 | Malformed authorization request |

An auth rejection legitimately arrives as any of the three, so the old branch was under-inclusive against the spec's own table. Because every version agrees, **one shared branch is correct and no per-era gating applies**. (2024-11-05 defines no authorization at all; an auth failure there is not spec-governed, which is a second reason this keys off the *error* rather than the negotiated protocol version — noted in a comment.)

## Why 403 and not 401

**401 would have been a bug.** The guest-retry path is live on exactly this route — traced end to end:

1. `client/src/lib/session-token.ts:296` — `HOSTED_AUTH_PATH_PREFIXES` includes `"/api/web/"`, so `/api/web/tools/list` is `hostedAuthEligible`.
2. `session-token.ts:483-521` — on `status === 401` + `hostedAuthEligible` + `shouldRetryApiAuth401()` (`!isAuthenticated && !hasSession`), `authFetch` calls `resetTokenCache()`, `forceRefreshGuestSession()`, and replays the request.
3. The only escape hatch is the `X-MCP-Auth-Required: oauth` header, set **only** by `server/utils/local-server-resolver.ts:1546` (`respondWithLocalRouteError`, the *local* envelope). The hosted `webError` never sets it.
4. `/api/web/tools/list` errors flow `tools.ts:80 → withEphemeralConnection → auth.ts:2210 → mapRuntimeError → webErrorFromRoute → webError` — the hosted envelope, no header.

So mapping these thousands of upstream rejections onto 401 would put every guest through a guest-token force-refresh plus a replay that cannot possibly succeed.

403 is also the honest HTTP answer per RFC 9110: the **caller's** credentials are not the problem, so re-authenticating with MCPJam changes nothing — the user has to reconnect the upstream server. It has in-file precedent too: the insufficient-scope branch already maps an upstream auth rejection to 403.

Checked that a bare 403 can't misfire client-side — `chatbox-access-errors.ts:66-84` gates on specific `code` values (never a bare 403), and the SEP-2350 step-up requires `details.insufficientScope`.

## The change

`server/routes/web/errors.ts`, new `ErrorCode.UPSTREAM_AUTH_FAILED` plus one branch:

```ts
if (isAuthError(error).isAuth) {
  return new WebRouteError(403, ErrorCode.UPSTREAM_AUTH_FAILED, message,
    { upstreamAuthRequired: true }, normalized);
}
```

Three decisions worth review attention:

- **`isAuthError` rather than `instanceof MCPAuthError`.** The SDK deliberately matches auth classes by `.name`; `instanceof` silently returns false when the server resolves `@mcpjam/sdk` to `dist` while another copy resolves to `src`. It also sees through the era-negotiation wrapper, matching `isUnauthorized401`.
- **Placed ahead of the timeout/connection matchers.** The connect path quotes *both* the Streamable HTTP and SSE failures in one message, so a real auth rejection routinely carries "fetch failed" or "timed out" text. Reverting proved it: without the fix, an auth error whose message contained "fetch failed" classified as `SERVER_UNREACHABLE` (502).
- **`upstreamAuthRequired: true`** reuses the flag already documented at `local-server-resolver.ts:1541` as "the UPSTREAM server demands auth; refreshing an MCPJam session/guest token can't fix it". Bonus: local routes mapping through this classifier now get `X-MCP-Auth-Required: oauth` for free.

The insufficient-scope 403 and the existing clean-401 branches are untouched and still ordered ahead. `normalized` and the effective `origin` ride along unchanged — origin resolves to `user_config`, so Sentry still correctly declines to page.

## Verification

- New tests cover upstream 401 / 403 / 400 / no-status, an explicit "does NOT widen the guest-retry 401 surface" guard, the transport-noise ordering, and normalized/origin preservation. Added a regression assertion on the existing insufficient-scope test that it stays `FORBIDDEN` and never becomes `UPSTREAM_AUTH_FAILED`.
- **Proved the tests catch the bug**: reverted the classifier to `main` keeping the new tests — **7 failed** (`expected 500 not to be 500`, `expected 500 to be 403`, `expected 'SERVER_UNREACHABLE' to be undefined`). The upstream-401 cases correctly kept passing, confirming the tests isolate the real defect. Restored, re-ran green.
- The five error-path suites (`errors`, `effective-origin`, `route-error-report`, `error-origin-capture`, `request-log-context.middleware`): **108/108 passed**. Baseline on `main` beforehand was 97/97 — no pre-existing failures.
- Full `--project server` suite: **369 files, 5270 tests, all passed.**
- `tsc --noEmit -p server/tsconfig.json`: 109 errors both before and after, none in either touched file — all pre-existing, verified by stashing and re-running.

## Notes for the reviewer

- `isAuthError` can't actually produce a 400 from the SDK's own connect path (`MCPClientManager` passes `authCheck.statusCode`, which is only ever 401 / 403 / `undefined`). The 400 test is kept because it's the spec's third row and costs nothing, but production traffic is 401 / 403 / absent.
- `describeError` labels all of these `auth/http_401` regardless of the real status. Origin is `user_config` in every case so nothing pages, but the slug is a misnomer for 403/400 — SDK-side, out of scope here, worth a follow-up if we slice Axiom by slug.
- Unrelated: three generated build artifacts are missing in a fresh worktree and break 94 test files at collection. Regenerate with `node scripts/bundle-plugin-shim.mjs`, `node scripts/bundle-browser-harness.mjs`, `node scripts/bundle-sandbox-proxy-html.js`. Symlinking `node_modules` alone is not enough.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit 9a759d0331ae93fa84ea8602eb5b5a398d491805. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stop reporting upstream auth refusals as 500s across web and v1 surfaces. Non‑401 upstream auth errors now return 403 FORBIDDEN and the Inspector UI shows the error instead of spinning.

- Web `/api/web/*`: detect upstream auth via `isAuthError` from `@mcpjam/sdk` and return 403 `UPSTREAM_AUTH_FAILED` with `details.upstreamAuthRequired: true`. Keep clean upstream 401 → 401 UNAUTHORIZED and insufficient‑scope challenges → 403 FORBIDDEN (unchanged, still ordered first). Place the new branch before timeout/connection classifiers.
- v1 envelope: map `UPSTREAM_AUTH_FAILED` to `FORBIDDEN` and pass through `details`, avoiding the unknown‑code fallback to a 500. Kept out of the shared `INTERNAL_TO_V1_CODE` table by design.
- Inspector UI: `use-eval-trace-tool-context` treats `UPSTREAM_AUTH_FAILED` (or `details.upstreamAuthRequired: true`) as non‑transient and surfaces the error; a bare hosted 403 during readiness remains transient.
- Preserves error normalization and `origin: user_config`. No migrations or config changes.

<sup>Written for commit cd4baab3b3207b0dc2aaaa0cb0d1d57e990d1543. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/MCPJam/inspector/pull/3948?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

