### PR TITLE
Stop reporting OAuth debugger advisories to Sentry

### DIFF
--- a/mcpjam-inspector/client/src/lib/oauth/__tests__/debug-state-machine-step-reporting.test.ts
+++ b/mcpjam-inspector/client/src/lib/oauth/__tests__/debug-state-machine-step-reporting.test.ts
@@ -133,6 +133,18 @@ describe("OAuth debugger step-failure reporting", () => {
     );
   });
 
+  it("reports the same failure again when a warning came between", () => {
+    // The warning replaced the message on screen, so the recurrence is a new
+    // failure — not the duplicate update the dedup guard exists to swallow.
+    const { wrapped } = wrappedUpdateState();
+
+    wrapped({ error: "token exchange failed: 401" });
+    wrapped({ error: "Warning: Authorization server may not support S256" });
+    wrapped({ error: "token exchange failed: 401" });
+
+    expect(reportCaught).toHaveBeenCalledTimes(2);
+  });
+
   it("still forwards every update to the caller's updateState", () => {
     const { wrapped, updateState } = wrappedUpdateState();
 

--- a/mcpjam-inspector/client/src/lib/oauth/__tests__/debug-state-machine-step-reporting.test.ts
+++ b/mcpjam-inspector/client/src/lib/oauth/__tests__/debug-state-machine-step-reporting.test.ts
@@ -109,6 +109,30 @@ describe("OAuth debugger step-failure reporting", () => {
     expect(reportCaught).not.toHaveBeenCalled();
   });
 
+  it("ignores advisory warnings the flow recovers from", () => {
+    const { wrapped, updateState } = wrappedUpdateState();
+
+    const advisory = {
+      error: "Warning: Authorization server may not support S256 PKCE method",
+    };
+    wrapped(advisory);
+
+    expect(reportCaught).not.toHaveBeenCalled();
+    expect(updateState).toHaveBeenCalledWith(advisory);
+  });
+
+  it("still reports a real failure that follows a warning", () => {
+    const { wrapped } = wrappedUpdateState();
+
+    wrapped({ error: "Warning: Authorization server may not support S256" });
+    wrapped({ error: "token exchange failed: 401" });
+
+    expect(reportCaught).toHaveBeenCalledTimes(1);
+    expect((reportCaught.mock.calls[0][0] as Error).message).toBe(
+      "token exchange failed: 401",
+    );
+  });
+
   it("still forwards every update to the caller's updateState", () => {
     const { wrapped, updateState } = wrappedUpdateState();
 

--- a/mcpjam-inspector/client/src/lib/oauth/debug-state-machine-adapter.ts
+++ b/mcpjam-inspector/client/src/lib/oauth/debug-state-machine-adapter.ts
@@ -282,6 +282,9 @@ function withStepFailureReporting(
     if (typeof error === "string" && error.startsWith("Warning: ")) {
       // Advisory only: the flow continues and the message is already on screen.
       // Reporting these buries real step failures under server-under-test nits.
+      // Still counts as replacing the previous message, so a failure that
+      // recurs after it is a new failure — same as an explicit clear below.
+      lastReportedError = undefined;
       updateState(updates);
       return;
     }

--- a/mcpjam-inspector/client/src/lib/oauth/debug-state-machine-adapter.ts
+++ b/mcpjam-inspector/client/src/lib/oauth/debug-state-machine-adapter.ts
@@ -266,6 +266,10 @@ function createHostedClientSecretResolver({
  * `warning` level, not `error`: many of these are the server-under-test
  * misbehaving, which is exactly what a debugger is for. The value is the
  * aggregate trend, not a page.
+ *
+ * `Warning: `-prefixed messages are skipped entirely — those are advisories the
+ * flow recovers from (an optional metadata field the server left out), not step
+ * failures.
  */
 function withStepFailureReporting(
   updateState: InspectorOAuthStateMachineConfig["updateState"],
@@ -275,6 +279,12 @@ function withStepFailureReporting(
 
   return (updates) => {
     const error = updates.error;
+    if (typeof error === "string" && error.startsWith("Warning: ")) {
+      // Advisory only: the flow continues and the message is already on screen.
+      // Reporting these buries real step failures under server-under-test nits.
+      updateState(updates);
+      return;
+    }
     if (typeof error === "string" && error !== "" && error !== lastReportedError) {
       lastReportedError = error;
       reportCaught(new Error(sanitizeStepError(error)), {


### PR DESCRIPTION
- The OAuth debugger shows warnings when a server's metadata is missing something optional, like not listing S256 in `code_challenge_methods_supported`. The flow keeps working.
- Those warnings were also being sent to Sentry as errors, so a normal debugging session looked like a bug in our app.
- Now we skip any message starting with `Warning: ` when reporting to Sentry. The user still sees it on screen, and real step failures still get reported.
- Fixes INSPECTOR-CLIENT-22E.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stops sending OAuth debugger advisories to Sentry and resets dedupe after an advisory. Previously, "Warning: " messages in the state error field were reported and could cause a recurring real failure after a warning to be swallowed; now advisories are skipped, still shown in the UI, and subsequent real failures are reported.

- In `mcpjam-inspector/client/src/lib/oauth/debug-state-machine-adapter.ts`, `withStepFailureReporting` skips reporting "Warning: " messages, forwards `updateState`, and clears `lastReportedError` on advisory.
- Tests in `mcpjam-inspector/client/src/lib/oauth/__tests__/debug-state-machine-step-reporting.test.ts` cover ignoring advisories, reporting a real failure after a warning, and reporting the same failure again when a warning intervenes.
- Addresses Linear INSPECTOR-CLIENT-22E.

<sup>Written for commit 5baa1a473dcb4b67cf6340b90bcad30b26c1316a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/MCPJam/inspector/pull/3955?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

