### PR TITLE
Stop reporting missing-issuer metadata failures to Sentry

### DIFF
--- a/mcpjam-inspector/client/src/lib/oauth/__tests__/debug-state-machine-step-reporting.test.ts
+++ b/mcpjam-inspector/client/src/lib/oauth/__tests__/debug-state-machine-step-reporting.test.ts
@@ -121,6 +121,20 @@ describe("OAuth debugger step-failure reporting", () => {
     expect(updateState).toHaveBeenCalledWith(advisory);
   });
 
+  it("ignores a metadata document missing the RFC 8414 issuer", () => {
+    // Stops the flow, but it is the server under test violating RFC 8414 and
+    // nothing we act on — it must stay on screen without reaching Sentry.
+    const { wrapped, updateState } = wrappedUpdateState();
+
+    const serverFault = {
+      error: "Authorization server metadata missing required 'issuer' field",
+    };
+    wrapped(serverFault);
+
+    expect(reportCaught).not.toHaveBeenCalled();
+    expect(updateState).toHaveBeenCalledWith(serverFault);
+  });
+
   it("still reports a real failure that follows a warning", () => {
     const { wrapped } = wrappedUpdateState();
 

--- a/mcpjam-inspector/client/src/lib/oauth/__tests__/debug-state-machine-step-reporting.test.ts
+++ b/mcpjam-inspector/client/src/lib/oauth/__tests__/debug-state-machine-step-reporting.test.ts
@@ -15,6 +15,8 @@ vi.mock("@mcpjam/sdk/browser", async (importOriginal) => {
   return { ...actual, createOAuthStateMachine };
 });
 
+import { AUTHORIZATION_SERVER_METADATA_MISSING_ISSUER } from "@mcpjam/sdk/browser";
+
 import { createInspectorOAuthStateMachine } from "../debug-state-machine-adapter";
 
 /**
@@ -124,10 +126,12 @@ describe("OAuth debugger step-failure reporting", () => {
   it("ignores a metadata document missing the RFC 8414 issuer", () => {
     // Stops the flow, but it is the server under test violating RFC 8414 and
     // nothing we act on — it must stay on screen without reaching Sentry.
+    // The message comes from the SDK export the machines throw, so a rephrasing
+    // there cannot leave the adapter matching on stale text.
     const { wrapped, updateState } = wrappedUpdateState();
 
     const serverFault = {
-      error: "Authorization server metadata missing required 'issuer' field",
+      error: AUTHORIZATION_SERVER_METADATA_MISSING_ISSUER,
     };
     wrapped(serverFault);
 

--- a/mcpjam-inspector/client/src/lib/oauth/debug-state-machine-adapter.ts
+++ b/mcpjam-inspector/client/src/lib/oauth/debug-state-machine-adapter.ts
@@ -269,8 +269,22 @@ function createHostedClientSecretResolver({
  *
  * `Warning: `-prefixed messages are skipped entirely — those are advisories the
  * flow recovers from (an optional metadata field the server left out), not step
- * failures.
+ * failures. So are the messages in `UNREPORTED_STEP_FAILURES`.
  */
+/**
+ * Step failures that stop the flow but carry no signal for us.
+ *
+ * The RFC 8414 `issuer` check rejects a metadata document the server under test
+ * built wrong. Every machine enforces it, yet only 2026-07-28 reads the field
+ * afterwards (it compares the issuer to the authorization-server URL and to the
+ * callback `iss`), so on the older three the report is another project's spec
+ * violation arriving as an MCPJam alert. The check itself stays — RFC 8414
+ * makes `issuer` REQUIRED, and the message stays on screen where it belongs.
+ */
+const UNREPORTED_STEP_FAILURES = new Set([
+  "Authorization server metadata missing required 'issuer' field",
+]);
+
 function withStepFailureReporting(
   updateState: InspectorOAuthStateMachineConfig["updateState"],
   context: { protocolVersion: OAuthProtocolVersion; getStep: () => string },
@@ -279,9 +293,12 @@ function withStepFailureReporting(
 
   return (updates) => {
     const error = updates.error;
-    if (typeof error === "string" && error.startsWith("Warning: ")) {
-      // Advisory only: the flow continues and the message is already on screen.
-      // Reporting these buries real step failures under server-under-test nits.
+    if (
+      typeof error === "string" &&
+      (error.startsWith("Warning: ") || UNREPORTED_STEP_FAILURES.has(error))
+    ) {
+      // Not ours to act on: the message is already on screen, and reporting
+      // these buries real step failures under server-under-test nits.
       // Still counts as replacing the previous message, so a failure that
       // recurs after it is a new failure — same as an explicit clear below.
       lastReportedError = undefined;

--- a/mcpjam-inspector/client/src/lib/oauth/debug-state-machine-adapter.ts
+++ b/mcpjam-inspector/client/src/lib/oauth/debug-state-machine-adapter.ts
@@ -1,4 +1,5 @@
 import {
+  AUTHORIZATION_SERVER_METADATA_MISSING_ISSUER,
   DEFAULT_MCPJAM_CLIENT_ID_METADATA_URL,
   createOAuthStateMachine,
   getBrowserDebugDynamicRegistrationMetadata,
@@ -255,6 +256,23 @@ function createHostedClientSecretResolver({
 }
 
 /**
+ * Step failures that stop the flow but carry no signal for us.
+ *
+ * The RFC 8414 `issuer` check rejects a metadata document the server under test
+ * built wrong. Every machine enforces it, yet only 2026-07-28 reads the field
+ * afterwards (it compares the issuer to the authorization-server URL and to the
+ * callback `iss`), so on the older three the report is another project's spec
+ * violation arriving as an MCPJam alert. The check itself stays — RFC 8414
+ * makes `issuer` REQUIRED, and the message stays on screen where it belongs.
+ *
+ * The SDK owns the message and exports it, so matching here cannot drift out of
+ * sync with what the machines actually throw.
+ */
+const UNREPORTED_STEP_FAILURES = new Set([
+  AUTHORIZATION_SERVER_METADATA_MISSING_ISSUER,
+]);
+
+/**
  * Wrap the caller's `updateState` so every NEW step failure is reported.
  *
  * This is the only reliable hook: the SDK state machine catches its own step
@@ -271,20 +289,6 @@ function createHostedClientSecretResolver({
  * flow recovers from (an optional metadata field the server left out), not step
  * failures. So are the messages in `UNREPORTED_STEP_FAILURES`.
  */
-/**
- * Step failures that stop the flow but carry no signal for us.
- *
- * The RFC 8414 `issuer` check rejects a metadata document the server under test
- * built wrong. Every machine enforces it, yet only 2026-07-28 reads the field
- * afterwards (it compares the issuer to the authorization-server URL and to the
- * callback `iss`), so on the older three the report is another project's spec
- * violation arriving as an MCPJam alert. The check itself stays — RFC 8414
- * makes `issuer` REQUIRED, and the message stays on screen where it belongs.
- */
-const UNREPORTED_STEP_FAILURES = new Set([
-  "Authorization server metadata missing required 'issuer' field",
-]);
-
 function withStepFailureReporting(
   updateState: InspectorOAuthStateMachineConfig["updateState"],
   context: { protocolVersion: OAuthProtocolVersion; getStep: () => string },

--- a/sdk/src/browser.ts
+++ b/sdk/src/browser.ts
@@ -188,6 +188,10 @@ export type {
   ProbeTransportResult,
 } from "./server-probe.js";
 export { runOAuthStateMachine } from "./oauth/state-machines/runner.js";
+// Exported so a consumer can recognize this specific step failure by identity
+// instead of re-typing the message — it is the server under test violating
+// RFC 8414, which a host may want to treat differently from its own errors.
+export { AUTHORIZATION_SERVER_METADATA_MISSING_ISSUER } from "./oauth/state-machines/shared/required-metadata.js";
 // OAuth client emulation (HP-43): profile → generic machine knobs. Pure and
 // client-name-free — per-client profiles live in the private backend.
 export { deriveOAuthEmulation } from "./oauth/emulation/derive.js";

--- a/sdk/src/oauth/state-machines/debug-oauth-2025-03-26.ts
+++ b/sdk/src/oauth/state-machines/debug-oauth-2025-03-26.ts
@@ -35,6 +35,7 @@ import {
   generateRandomString,
   generateCodeChallenge,
 } from "./shared/pkce.js";
+import { AUTHORIZATION_SERVER_METADATA_MISSING_ISSUER } from "./shared/required-metadata.js";
 import {
   buildInitializeRequestBody,
   resolveInitializeProtocolVersion,
@@ -492,7 +493,7 @@ export const createDebugOAuthStateMachine = (
             // Validate required AS metadata fields
             if (!authServerMetadata.issuer) {
               throw new Error(
-                "Authorization server metadata missing required 'issuer' field",
+                AUTHORIZATION_SERVER_METADATA_MISSING_ISSUER,
               );
             }
             if (!authServerMetadata.authorization_endpoint) {

--- a/sdk/src/oauth/state-machines/debug-oauth-2025-06-18.ts
+++ b/sdk/src/oauth/state-machines/debug-oauth-2025-06-18.ts
@@ -36,7 +36,10 @@ import {
   generateCodeChallenge,
 } from "./shared/pkce.js";
 import { buildResourceMetadataUrl } from "./shared/urls.js";
-import { selectAuthorizationServerFromResourceMetadata } from "./shared/required-metadata.js";
+import {
+  AUTHORIZATION_SERVER_METADATA_MISSING_ISSUER,
+  selectAuthorizationServerFromResourceMetadata,
+} from "./shared/required-metadata.js";
 import {
   resolveDiscoveryResourceIndicator,
   resolveFlowResourceValue,
@@ -847,7 +850,7 @@ export const createDebugOAuthStateMachine = (
             // Validate required AS metadata fields per RFC 8414
             if (!authServerMetadata.issuer) {
               throw new Error(
-                "Authorization server metadata missing required 'issuer' field",
+                AUTHORIZATION_SERVER_METADATA_MISSING_ISSUER,
               );
             }
             if (!authServerMetadata.authorization_endpoint) {

--- a/sdk/src/oauth/state-machines/debug-oauth-2025-11-25.ts
+++ b/sdk/src/oauth/state-machines/debug-oauth-2025-11-25.ts
@@ -37,6 +37,7 @@ import {
 } from "./shared/pkce.js";
 import { buildResourceMetadataUrl } from "./shared/urls.js";
 import {
+  AUTHORIZATION_SERVER_METADATA_MISSING_ISSUER,
   describePkceMetadataNonConformance,
   selectAuthorizationServerFromResourceMetadata,
 } from "./shared/required-metadata.js";
@@ -848,7 +849,7 @@ export const createDebugOAuthStateMachine = (
             // Validate required AS metadata fields per RFC 8414
             if (!authServerMetadata.issuer) {
               throw new Error(
-                "Authorization server metadata missing required 'issuer' field"
+                AUTHORIZATION_SERVER_METADATA_MISSING_ISSUER
               );
             }
             if (!authServerMetadata.authorization_endpoint) {

--- a/sdk/src/oauth/state-machines/debug-oauth-2026-07-28.ts
+++ b/sdk/src/oauth/state-machines/debug-oauth-2026-07-28.ts
@@ -37,6 +37,7 @@ import {
 } from "./shared/pkce.js";
 import { buildResourceMetadataUrl } from "./shared/urls.js";
 import {
+  AUTHORIZATION_SERVER_METADATA_MISSING_ISSUER,
   describePkceMetadataNonConformance,
   selectAuthorizationServerFromResourceMetadata,
 } from "./shared/required-metadata.js";
@@ -1129,7 +1130,7 @@ export const createDebugOAuthStateMachine = (
             // Validate required AS metadata fields per RFC 8414
             if (!authServerMetadata.issuer) {
               throw new Error(
-                "Authorization server metadata missing required 'issuer' field"
+                AUTHORIZATION_SERVER_METADATA_MISSING_ISSUER
               );
             }
 

--- a/sdk/src/oauth/state-machines/shared/required-metadata.ts
+++ b/sdk/src/oauth/state-machines/shared/required-metadata.ts
@@ -30,6 +30,18 @@
  * warn-and-continue behavior.
  */
 
+/**
+ * Rejection message for authorization-server metadata without RFC 8414's
+ * REQUIRED `issuer`. Every era's machine throws it verbatim.
+ *
+ * A constant rather than four literals because consumers match on the exact
+ * text: the inspector keeps this failure out of its own error reporting (it is
+ * the server under test that is nonconforming, not MCPJam), and a rephrasing on
+ * one side would silently break that match. One export, no drift.
+ */
+export const AUTHORIZATION_SERVER_METADATA_MISSING_ISSUER =
+  "Authorization server metadata missing required 'issuer' field";
+
 export type RequiredMetadataEnforcement =
   /** Fail closed. The default, and what every connect-like path uses. */
   | "reject"


### PR DESCRIPTION
- A user pointed the OAuth debugger at a server whose authorization-server metadata had no `issuer` field. We stop the flow (correct — RFC 8414 requires it), but we also sent it to Sentry, so another project's broken server shows up as an MCPJam error.
- Now that message is skipped from Sentry, exactly like the `Warning:` advisories in #3955. The check stays, the flow still stops, and the message still shows on screen.
- The message itself moved into the SDK (`shared/required-metadata.ts`) and is exported, so all four machines throw it and the inspector matches on it — no copy of the text that can drift out of sync.
- Nothing about the check changes. It has been in every protocol machine since #780, #801 and #3321, and only 2026-07-28 actually uses `issuer` afterwards — it compares it to the AS URL (#3358) and to the callback `iss`.
- Covered by a new unit test in the step-reporting suite.

🤖 Generated with [Claude Code](https://claude.com/claude-code)