### PR TITLE
Fix eval iteration gating and usage display

### DIFF
--- a/mcpjam-inspector/client/src/components/CiEvalsTab.tsx
+++ b/mcpjam-inspector/client/src/components/CiEvalsTab.tsx
@@ -32,6 +32,11 @@ import {
 import { shouldQueryProjectId } from "@/hooks/useProjects";
 import { useEvalsRunsRouteFromUrl } from "@/lib/eval-route-url";
 import { useEvalTabContext } from "@/hooks/use-eval-tab-context";
+import { useEvalIterationQuota } from "@/hooks/use-eval-iteration-quota";
+import {
+  calculateEvalIterationRequest,
+  getEvalIterationQuotaDisabledReason,
+} from "@/lib/eval-iteration-quota";
 import {
   aggregateSuite,
   formatRunId,
@@ -42,6 +47,7 @@ import { useRunDetailData } from "./evals/use-suite-data";
 import { useEvalMutations } from "./evals/use-eval-mutations";
 import { useEvalQueries } from "./evals/use-eval-queries";
 import { useEvalHandlers } from "./evals/use-eval-handlers";
+import { getRunnableCaseModels } from "./evals/single-test-case-runner";
 import {
   CiSuiteListSidebar,
   type SidebarMode,
@@ -115,6 +121,7 @@ export function CiEvalsTab({
       : null;
 
   const {
+    organizationId,
     connectedServerNames,
     userMap,
     canDeleteSuite,
@@ -124,6 +131,17 @@ export function CiEvalsTab({
     isAuthenticated,
     projectId: convexProjectId,
   });
+  const {
+    quota: evalIterationQuota,
+    isLoading: isEvalIterationQuotaLoading,
+  } = useEvalIterationQuota({
+    organizationId,
+    enabled: Boolean(organizationId),
+  });
+  const evalRunsDisabledReason = useMemo(
+    () => getEvalIterationQuotaDisabledReason(evalIterationQuota),
+    [evalIterationQuota],
+  );
 
   const { servers: ciProjectServers = [] } = useProjectServers({
     isAuthenticated,
@@ -326,6 +344,32 @@ export function CiEvalsTab({
     projectServers: ciProjectServers,
     availableModels,
   });
+
+  const guardEvalIterationQuota = useCallback(
+    (requestedIterations = 1) => {
+      if (!organizationId) return true;
+      if (isEvalIterationQuotaLoading) {
+        toast.error("Checking your eval iteration limit. Try again shortly.");
+        return false;
+      }
+      const disabledReason = getEvalIterationQuotaDisabledReason(
+        evalIterationQuota,
+        requestedIterations,
+      );
+      if (!disabledReason) return true;
+      toast.error(disabledReason);
+      return false;
+    },
+    [evalIterationQuota, isEvalIterationQuotaLoading, organizationId],
+  );
+
+  const handleRerunWithQuota = useCallback(
+    (...args: Parameters<typeof handlers.handleRerun>) => {
+      if (!guardEvalIterationQuota()) return;
+      return handlers.handleRerun(...args);
+    },
+    [guardEvalIterationQuota, handlers],
+  );
 
   const suiteAggregate = useMemo(() => {
     if (!selectedSuite || !queries.suiteDetails) return null;
@@ -809,7 +853,7 @@ export function CiEvalsTab({
                       isRunDetailView ? setRunDetailSidebarSortBy : undefined
                     }
                     omitRunIterationList={isRunDetailView}
-                    onRerun={handlers.handleRerun}
+                    onRerun={handleRerunWithQuota}
                     onReplayRun={handlers.handleReplayRun}
                     onCancelRun={handlers.handleCancelRun}
                     onDelete={handleDeleteSuite}
@@ -829,10 +873,22 @@ export function CiEvalsTab({
                     canDeleteRuns={canDeleteRuns}
                     readOnlyConfig
                     omitSuiteHeader
+                    evalRunsDisabledReason={evalRunsDisabledReason}
+                    guardEvalIterationQuota={guardEvalIterationQuota}
                     onRunTestCase={
                       selectedSuite
-                        ? (tc, opts) => {
+                          ? (tc, opts) => {
                             void (async () => {
+                              const requestedIterations =
+                                calculateEvalIterationRequest(
+                                  getRunnableCaseModels(tc).length,
+                                  opts?.iterationOverride ?? tc.runs ?? 1,
+                                );
+                              if (
+                                !guardEvalIterationQuota(requestedIterations)
+                              ) {
+                                return;
+                              }
                               const data = await handlers.handleRunTestCase(
                                 selectedSuite,
                                 tc,

--- a/mcpjam-inspector/client/src/components/EvalsTab.tsx
+++ b/mcpjam-inspector/client/src/components/EvalsTab.tsx
@@ -50,6 +50,7 @@ import { ConfirmationDialogs } from "./evals/ConfirmationDialogs";
 import { useEvalQueries } from "./evals/use-eval-queries";
 import { useEvalMutations } from "./evals/use-eval-mutations";
 import { useEvalHandlers } from "./evals/use-eval-handlers";
+import { getRunnableCaseModels } from "./evals/single-test-case-runner";
 import { isDraftTestCaseId } from "./evals/draft-test-case";
 import { getBillingErrorMessage } from "@/lib/billing-entitlements";
 import { SuiteSwitcher } from "./evals/suite-switcher";
@@ -61,7 +62,10 @@ import {
   CreateSuiteDialog,
   type CreateSuitePayload,
 } from "./evals/create-suite-dialog";
-import { getEvalIterationQuotaDisabledReason } from "@/lib/eval-iteration-quota";
+import {
+  calculateEvalIterationRequest,
+  getEvalIterationQuotaDisabledReason,
+} from "@/lib/eval-iteration-quota";
 import { track } from "@/lib/analytics";
 import type { EvalChatHandoff } from "@/lib/eval-chat-handoff";
 import type { EnsureServersReadyResult } from "@/hooks/use-app-state";
@@ -167,7 +171,10 @@ function EvalsTabContent({
     projectId: projectId ?? null,
     isDirectGuest,
   });
-  const { quota: evalIterationQuota } = useEvalIterationQuota({
+  const {
+    quota: evalIterationQuota,
+    isLoading: isEvalIterationQuotaLoading,
+  } = useEvalIterationQuota({
     organizationId,
     enabled: Boolean(organizationId),
   });
@@ -259,13 +266,27 @@ function EvalsTabContent({
     directDeleteTestCase,
   } = handlers;
 
-  const guardEvalIterationQuota = useCallback(() => {
-    if (!evalRunsDisabledReason) {
-      return true;
-    }
-    toast.error(evalRunsDisabledReason);
-    return false;
-  }, [evalRunsDisabledReason]);
+  const guardEvalIterationQuota = useCallback(
+    (requestedIterations = 1) => {
+      if (!organizationId) {
+        return true;
+      }
+      if (isEvalIterationQuotaLoading) {
+        toast.error("Checking your eval iteration limit. Try again shortly.");
+        return false;
+      }
+      const disabledReason = getEvalIterationQuotaDisabledReason(
+        evalIterationQuota,
+        requestedIterations
+      );
+      if (!disabledReason) {
+        return true;
+      }
+      toast.error(disabledReason);
+      return false;
+    },
+    [evalIterationQuota, isEvalIterationQuotaLoading, organizationId]
+  );
 
   const handleRerunWithQuota = useCallback(
     (...args: Parameters<typeof handlers.handleRerun>) => {
@@ -279,7 +300,17 @@ function EvalsTabContent({
 
   const handleRunTestCaseWithQuota = useCallback(
     (...args: Parameters<typeof handlers.handleRunTestCase>) => {
-      if (!guardEvalIterationQuota()) {
+      const testCase = args[1];
+      const options = args[2];
+      const modelCount = options?.selectedModel
+        ? 1
+        : getRunnableCaseModels(testCase).length;
+      const iterationCount = options?.iterationOverride ?? testCase.runs ?? 1;
+      if (
+        !guardEvalIterationQuota(
+          calculateEvalIterationRequest(modelCount, iterationCount)
+        )
+      ) {
         return Promise.resolve(null);
       }
       return handlers.handleRunTestCase(...args);
@@ -1166,6 +1197,7 @@ function EvalsTabContent({
           canDeleteRuns={canDeleteRuns}
           hideRunActions
           evalRunsDisabledReason={evalRunsDisabledReason}
+          guardEvalIterationQuota={guardEvalIterationQuota}
           onDeleteTestCasesBatch={handleDeleteTestCasesBatch}
           onRunTestCase={(testCase, opts) => {
             void (async () => {

--- a/mcpjam-inspector/client/src/components/billing/CreditBalanceCard.tsx
+++ b/mcpjam-inspector/client/src/components/billing/CreditBalanceCard.tsx
@@ -241,8 +241,8 @@ export function CreditBalanceCard({
                   )}`
                 : undefined
             }
-            // "remaining / allowed": bar drains as iterations are used —
-            // matches the monthly team credits row.
+            // "used / allowed": both the counter and bar grow as eval
+            // attempts are reserved.
             rightText={
               isEvalIterationQuotaLoading ||
               !evalIterationQuota ||
@@ -250,7 +250,7 @@ export function CreditBalanceCard({
                 ? null
                 : `${Math.max(
                     0,
-                    evalIterationQuota.allowed - evalIterationQuota.used
+                    evalIterationQuota.used
                   ).toLocaleString()} / ${evalIterationQuota.allowed.toLocaleString()}`
             }
             fillPercent={
@@ -260,18 +260,20 @@ export function CreditBalanceCard({
                 ? 0
                 : Math.max(
                     0,
-                    ((evalIterationQuota.allowed - evalIterationQuota.used) /
-                      evalIterationQuota.allowed) *
-                      100
+                    Math.min(
+                      100,
+                      (evalIterationQuota.used / evalIterationQuota.allowed) *
+                        100
+                    )
                   )
             }
-            ariaLabel={`${evalIterationLabel} remaining`}
+            ariaLabel={`${evalIterationLabel} used`}
             ariaValueText={
               evalIterationQuota && evalIterationQuota.allowed !== null
                 ? `${Math.max(
                     0,
-                    evalIterationQuota.allowed - evalIterationQuota.used
-                  ).toLocaleString()} of ${evalIterationQuota.allowed.toLocaleString()} eval iterations remaining`
+                    evalIterationQuota.used
+                  ).toLocaleString()} of ${evalIterationQuota.allowed.toLocaleString()} eval iterations used`
                 : undefined
             }
             isLoading={isEvalIterationQuotaLoading}

--- a/mcpjam-inspector/client/src/components/billing/__tests__/CreditBalanceCard.test.tsx
+++ b/mcpjam-inspector/client/src/components/billing/__tests__/CreditBalanceCard.test.tsx
@@ -203,9 +203,35 @@ describe("CreditBalanceCard", () => {
 
     const evalRow = screen.getByTestId("usage-eval-iterations");
     expect(evalRow).toHaveTextContent(/Monthly eval iterations/);
-    // Remaining / allowed — 10,000 allowed minus 7,580 used.
-    expect(evalRow).toHaveTextContent(/2,420 \/ 10,000/);
+    expect(evalRow).toHaveTextContent(/7,580 \/ 10,000/);
+    expect(
+      within(evalRow).getByRole("progressbar", {
+        name: "Monthly eval iterations used",
+      })
+    ).toHaveAttribute("aria-valuetext", "7,580 of 10,000 eval iterations used");
     expect(evalRow).not.toHaveTextContent(/Resets/);
+  });
+
+  it.each([
+    { used: 0, text: "0 / 75" },
+    { used: 75, text: "75 / 75" },
+  ])("renders $text as used eval iterations", ({ used, text }) => {
+    evalQuotaState = {
+      used,
+      allowed: 75,
+      resetsAt: Date.UTC(2026, 7, 14),
+      windowKind: "day",
+    };
+
+    render(<CreditBalanceCard organizationId="org-1" />);
+
+    const evalRow = screen.getByTestId("usage-eval-iterations");
+    expect(evalRow).toHaveTextContent(text);
+    expect(
+      within(evalRow).getByRole("progressbar", {
+        name: "Daily eval iterations used",
+      })
+    ).toHaveAttribute("aria-valuetext", `${used} of 75 eval iterations used`);
   });
 
   it("shows eval iteration reset time only from the info tooltip", async () => {

--- a/mcpjam-inspector/client/src/components/evals/__tests__/test-template-editor-validation.test.tsx
+++ b/mcpjam-inspector/client/src/components/evals/__tests__/test-template-editor-validation.test.tsx
@@ -1,6 +1,7 @@
 import type { ReactElement } from "react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
 import { PreferencesStoreProvider } from "@/stores/preferences/preferences-provider";
 import {
   getStepsBlockReason,
@@ -45,6 +46,10 @@ vi.mock("@/lib/PosthogUtils", () => ({
 vi.mock("@/lib/apis/evals-api", () => ({
   listEvalTools: vi.fn().mockResolvedValue({ tools: [] }),
   runEvalTestCase: vi.fn(),
+}));
+
+vi.mock("@/components/chat-v2/thread/part-switch", () => ({
+  PartSwitch: () => null,
 }));
 
 vi.mock("convex/react", () => ({
@@ -184,5 +189,46 @@ describe("TestTemplateEditor prompt validation UI", () => {
 
     const runButton = screen.getByRole("button", { name: /Quick Run/ });
     expect(runButton).toBeDisabled();
+  });
+
+  it("checks the shared quota guard before starting a Quick Run", async () => {
+    const user = userEvent.setup();
+    const guardEvalIterationQuota = vi.fn(() => false);
+    useQueryMock.mockImplementation((name: string) => {
+      if (name === "testSuites:listTestCases") {
+        return [{ ...caseDoc, query: "Hello" }];
+      }
+      if (name === "testSuites:getTestSuite") {
+        return {
+          _id: "suite-1",
+          environment: { servers: ["srv"] },
+        };
+      }
+      return undefined;
+    });
+
+    renderWithProviders(
+      <TestTemplateEditor
+        suiteId="suite-1"
+        selectedTestCaseId="case-1"
+        connectedServerNames={new Set(["srv"])}
+        projectId={null}
+        availableModels={[
+          {
+            provider: "openai",
+            model: "gpt-4",
+            label: "GPT-4",
+          } as any,
+        ]}
+        suiteIterations={[]}
+        guardEvalIterationQuota={guardEvalIterationQuota}
+      />
+    );
+
+    const runButton = await screen.findByRole("button", { name: /Quick Run/ });
+    await waitFor(() => expect(runButton).toBeEnabled());
+    await user.click(runButton);
+
+    expect(guardEvalIterationQuota).toHaveBeenCalledWith(1);
   });
 });

--- a/mcpjam-inspector/client/src/components/evals/suite-iterations-view.tsx
+++ b/mcpjam-inspector/client/src/components/evals/suite-iterations-view.tsx
@@ -266,6 +266,7 @@ export function SuiteIterationsView({
   projectServers,
   generateTestCasesDisabledReason,
   evalRunsDisabledReason: evalRunsDisabledReasonProp,
+  guardEvalIterationQuota,
   isDirectGuest = false,
   ensureServersReady,
 }: {
@@ -301,6 +302,7 @@ export function SuiteIterationsView({
   canGenerateTestCases?: boolean;
   generateTestCasesDisabledReason?: string;
   evalRunsDisabledReason?: string | null;
+  guardEvalIterationQuota?: (requestedIterations: number) => boolean;
   isGeneratingTestCases?: boolean;
   /** When true, the case list lives in a parent sidebar; omit the duplicate cases table on suite overview. */
   caseListInSidebar?: boolean;
@@ -1062,6 +1064,7 @@ export function SuiteIterationsView({
                   isDirectGuest={isDirectGuest}
                   ensureServersReady={ensureServersReady}
                   projectServers={projectServers}
+                  guardEvalIterationQuota={guardEvalIterationQuota}
                   onExportDraft={handleOpenDraftExport}
                   openCompareFromRoute={
                     route.type === "test-edit" && Boolean(route.openCompare)

--- a/mcpjam-inspector/client/src/components/evals/test-template-editor.tsx
+++ b/mcpjam-inspector/client/src/components/evals/test-template-editor.tsx
@@ -54,6 +54,7 @@ import {
   type MultiModelCardSummary,
 } from "@/components/chat-v2/model-compare-card-header";
 import { getBillingErrorMessage } from "@/lib/billing-entitlements";
+import { calculateEvalIterationRequest } from "@/lib/eval-iteration-quota";
 import type { ModelDefinition } from "@/shared/types";
 import type { RemoteServer } from "@/hooks/useProjects";
 import {
@@ -246,6 +247,8 @@ interface TestTemplateEditorProps {
     serverNames: string[],
   ) => Promise<EnsureServersReadyResult>;
   projectServers?: RemoteServer[];
+  /** Shared org quota gate; receives models multiplied by attempts. */
+  guardEvalIterationQuota?: (requestedIterations: number) => boolean;
   /**
    * Called after an unsaved draft case is persisted for the first time, with the
    * new Convex id, so the parent can swap the `draft:<kind>` route for the real
@@ -678,6 +681,7 @@ export function TestTemplateEditor({
   isDirectGuest = false,
   ensureServersReady,
   projectServers,
+  guardEvalIterationQuota,
   onDraftSaved,
 }: TestTemplateEditorProps) {
   // Resolves the WorkOS token for signed-in users and the guest bearer for
@@ -1997,6 +2001,17 @@ export function TestTemplateEditor({
     );
     if (runModelValues.length === 0) {
       toast.error("Select at least one model to run.");
+      return;
+    }
+
+    const requestedIterations = calculateEvalIterationRequest(
+      runModelValues.length,
+      iterationOverride
+    );
+    if (
+      guardEvalIterationQuota &&
+      !guardEvalIterationQuota(requestedIterations)
+    ) {
       return;
     }
 

--- a/mcpjam-inspector/client/src/lib/eval-iteration-quota.ts
+++ b/mcpjam-inspector/client/src/lib/eval-iteration-quota.ts
@@ -9,11 +9,33 @@ export function formatEvalIterationResetTime(resetsAt: number): string {
   }).format(new Date(resetsAt));
 }
 
+export function calculateEvalIterationRequest(
+  modelCount: number,
+  iterationCount: number
+): number {
+  return (
+    Math.max(1, Math.floor(modelCount)) *
+    Math.max(1, Math.floor(iterationCount))
+  );
+}
+
 export function getEvalIterationQuotaDisabledReason(
-  quota: EvalIterationQuota | undefined
+  quota: EvalIterationQuota | undefined,
+  requestedIterations = 1
 ): string | null {
-  if (!quota || quota.allowed === null || quota.used < quota.allowed) {
+  const requested = Math.max(1, Math.floor(requestedIterations));
+  if (
+    !quota ||
+    quota.allowed === null ||
+    quota.used + requested <= quota.allowed
+  ) {
     return null;
+  }
+  const remaining = Math.max(0, quota.allowed - quota.used);
+  if (remaining > 0) {
+    return `This run needs ${requested.toLocaleString()} eval iterations, but only ${remaining.toLocaleString()} remain. Resets ${formatEvalIterationResetTime(
+      quota.resetsAt
+    )}.`;
   }
   return `Eval iteration limit reached. Resets ${formatEvalIterationResetTime(
     quota.resetsAt

--- a/mcpjam-inspector/client/src/lib/evals/__tests__/eval-iteration-quota.test.ts
+++ b/mcpjam-inspector/client/src/lib/evals/__tests__/eval-iteration-quota.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it } from "vitest";
+import {
+  calculateEvalIterationRequest,
+  getEvalIterationQuotaDisabledReason,
+} from "@/lib/eval-iteration-quota";
+
+const quota = {
+  used: 73,
+  allowed: 75,
+  resetsAt: Date.UTC(2026, 7, 14),
+  windowKind: "day" as const,
+};
+
+describe("getEvalIterationQuotaDisabledReason", () => {
+  it("charges models multiplied by iterations", () => {
+    expect(calculateEvalIterationRequest(3, 4)).toBe(12);
+  });
+
+  it("allows a run that fits the remaining quota", () => {
+    expect(getEvalIterationQuotaDisabledReason(quota, 2)).toBeNull();
+  });
+
+  it("blocks a multi-model run that exceeds the remaining quota", () => {
+    expect(getEvalIterationQuotaDisabledReason(quota, 3)).toContain(
+      "needs 3 eval iterations, but only 2 remain"
+    );
+  });
+
+  it("blocks every run after the limit is reached", () => {
+    expect(
+      getEvalIterationQuotaDisabledReason({ ...quota, used: 75 }, 1)
+    ).toContain("Eval iteration limit reached");
+  });
+});

--- a/mcpjam-inspector/server/routes/shared/evals.ts
+++ b/mcpjam-inspector/server/routes/shared/evals.ts
@@ -24,6 +24,7 @@ import {
 } from "@mcpjam/sdk/host-config/internal";
 import {
   resolveSteps,
+  reserveQuickRunIterations,
   runEvalSuiteWithAiSdk,
   streamTestCase,
   type EvalPinnedSkillSource,
@@ -2163,19 +2164,24 @@ export async function runEvalTestCaseWithManager(
   const expectedIterationId =
     quickResult?.quickRunIterationOutcomes?.[0]?.iterationId;
 
-  let latestIteration: unknown = null;
-  if (expectedIterationId) {
-    latestIteration = await convexClient.query(
-      "testSuites:getTestIteration" as any,
-      { iterationId: expectedIterationId }
+  if (!expectedIterationId) {
+    throw new WebRouteError(
+      500,
+      ErrorCode.INTERNAL_ERROR,
+      "Quick run completed without creating an iteration."
     );
   }
+
+  const latestIteration: unknown = await convexClient.query(
+    "testSuites:getTestIteration" as any,
+    { iterationId: expectedIterationId }
+  );
   if (!latestIteration) {
-    const recentIterations = await convexClient.query(
-      "testSuites:listTestIterations" as any,
-      { testCaseId }
+    throw new WebRouteError(
+      500,
+      ErrorCode.INTERNAL_ERROR,
+      "Quick run iteration could not be loaded."
     );
-    latestIteration = recentIterations?.[0] || null;
   }
 
   if (
@@ -2562,6 +2568,11 @@ export async function streamEvalTestCaseWithManager(
     // the run's own teardown, which aborts through this signal.
     await: { signal: streamAbortController.signal },
   });
+  const [precreatedIterationIds] = await reserveQuickRunIterations(
+    convexClient,
+    [test],
+    testCaseId
+  );
   const tools = (
     suiteHostPolicy || singleCaseTasksSeam
       ? await clientManager.getToolsForAiSdk(resolvedServerIds, {
@@ -2620,6 +2631,7 @@ export async function streamEvalTestCaseWithManager(
           suiteHostConfig,
           toolSignals: streamToolSignals,
           environment: runtimeEnvironment,
+          precreatedIterationIds,
           emit: (event: EvalStreamEvent) => {
             try {
               controller.enqueue(sseEncode(event));

--- a/mcpjam-inspector/server/services/evals-runner.ts
+++ b/mcpjam-inspector/server/services/evals-runner.ts
@@ -76,6 +76,7 @@ import type { PinnableSkill } from "@/shared/skill-types";
 import type { ConvexHttpClient } from "convex/browser";
 import { ErrorCode, WebRouteError } from "../routes/web/errors";
 import {
+  asBillingRouteError,
   createSuiteRunRecorder,
   type SuiteRunRecorder,
 } from "./evals/recorder";
@@ -954,7 +955,7 @@ async function createIterationDirectly(
     iterationNumber: number;
     startedAt: number;
   }
-): Promise<string | undefined> {
+): Promise<string> {
   try {
     const result = await convexClient.mutation(
       "testSuites:recordIterationStartWithoutRun" as any,
@@ -968,10 +969,72 @@ async function createIterationDirectly(
       }
     );
 
-    return result?.iterationId as string | undefined;
+    const iterationId = result?.iterationId as string | undefined;
+    if (!iterationId) {
+      throw new Error("Convex did not return a quick-run iteration id");
+    }
+    return iterationId;
   } catch (error) {
-    logger.error("[evals] Failed to create iteration:", error);
-    return undefined;
+    const billing = asBillingRouteError(error);
+    throw billing ?? error;
+  }
+}
+
+export async function reserveQuickRunIterations(
+  convexClient: ConvexHttpClient,
+  tests: EvalTestCase[],
+  fallbackTestCaseId?: string
+): Promise<string[][]> {
+  const batches = tests.map((sourceTest) => {
+    const test = normalizeTestForPinnedTurns(sourceTest);
+    const resolved = resolveEvalTestCase(test);
+    const count = Math.max(1, Math.floor(test.runs || 1));
+    return {
+      testCaseSnapshot: sanitizeForConvexTransport(
+        snapshotWithStepsForConvex({
+          title: test.title,
+          query: resolved.query,
+          provider: test.provider,
+          model: test.model,
+          runs: count,
+          expectedToolCalls: resolved.expectedToolCalls,
+          isNegativeTest: test.isNegativeTest,
+          expectedOutput: resolved.expectedOutput,
+          steps: resolveSteps(test),
+          advancedConfig: resolved.advancedConfig,
+          matchOptions: test.matchOptions,
+          hostConfigOverride: test.hostConfigOverride,
+        })
+      ),
+      count,
+    };
+  });
+  const testCaseId = tests[0]?.testCaseId ?? fallbackTestCaseId;
+  try {
+    const result = await convexClient.mutation(
+      "testSuites:recordQuickRunBatchStart" as any,
+      {
+        testCaseId,
+        batches,
+        startedAt: Date.now(),
+      }
+    );
+    const iterationIdGroups = result?.iterationIdGroups as
+      | string[][]
+      | undefined;
+    if (
+      !iterationIdGroups ||
+      iterationIdGroups.length !== batches.length ||
+      iterationIdGroups.some(
+        (group, index) => group.length !== batches[index]?.count
+      )
+    ) {
+      throw new Error("Convex did not return every quick-run iteration id");
+    }
+    return iterationIdGroups;
+  } catch (error) {
+    const billing = asBillingRouteError(error);
+    throw billing ?? error;
   }
 }
 
@@ -1468,6 +1531,8 @@ const executeTestCase = async (params: {
   environment?: RunEvalSuiteOptions["config"]["environment"];
   /** Pinned skill delivery for this run (see RunEvalSuiteOptions.pinnedSkillSource). */
   pinnedSkillSource?: EvalPinnedSkillSource;
+  /** IDs reserved atomically for this case before any tool/model work. */
+  precreatedIterationIds?: string[];
 }) => {
   const {
     test,
@@ -1494,6 +1559,7 @@ const executeTestCase = async (params: {
     suiteHostConfig,
     environment,
     pinnedSkillSource,
+    precreatedIterationIds: reservedIterationIds,
   } = params;
   const testCaseId = test.testCaseId || parentTestCaseId;
   const streaming = emit != null;
@@ -1502,6 +1568,22 @@ const executeTestCase = async (params: {
   // so the unified engine sees one shape. No-op for already-pinned / prompt
   // cases.
   const normalizedTest = normalizeTestForPinnedTurns(test);
+  const iterationCount = Math.max(1, Math.floor(normalizedTest.runs || 1));
+  const shouldPrecreateIterations = recorder == null && runId == null;
+  let precreatedIterationIds = reservedIterationIds ?? [];
+  if (shouldPrecreateIterations && reservedIterationIds === undefined) {
+    [precreatedIterationIds] = await reserveQuickRunIterations(
+      convexClient,
+      [normalizedTest],
+      testCaseId
+    );
+  }
+  if (
+    shouldPrecreateIterations &&
+    precreatedIterationIds.length !== iterationCount
+  ) {
+    throw new Error("Quick run iteration reservation count did not match");
+  }
 
   // Run a single iteration under the per-iteration timeout + run-abort guards.
   // Bails immediately if the run was already stopped; on timeout it aborts the
@@ -1544,8 +1626,7 @@ const executeTestCase = async (params: {
     })
   ) {
     const outcomes: EvalIterationOutcome[] = [];
-    const pinnedRuns = Math.max(1, Math.floor(normalizedTest.runs || 1));
-    for (let runIndex = 0; runIndex < pinnedRuns; runIndex++) {
+    for (let runIndex = 0; runIndex < iterationCount; runIndex++) {
       if (abortSignal?.aborted) break;
       const modelFreeParams = {
         test: normalizedTest,
@@ -1584,7 +1665,7 @@ const executeTestCase = async (params: {
               ...modelFreeParams,
               ...(streaming ? { emit: emit! } : {}),
             }),
-          undefined,
+          precreatedIterationIds[runIndex],
           runIndex,
           normalizedTest
         )
@@ -1620,53 +1701,7 @@ const executeTestCase = async (params: {
 
   const outcomes: EvalIterationOutcome[] = [];
 
-  // Mirrors `streamTestCase`: pre-create all N pending iteration rows for
-  // quick-run paths with runs > 1 so the iteration history shows every row
-  // immediately, not one-at-a-time as the loop progresses.
-  const shouldPrecreateIterations =
-    recorder == null && runId == null && test.runs > 1;
-  const precreatedIterationIds: (string | undefined)[] = [];
-  if (shouldPrecreateIterations) {
-    const resolvedTestForPrecreate = resolveEvalTestCase(test);
-    const resolvedStepsForPrecreate = resolveSteps(test);
-    const precreatedAt = Date.now();
-    for (let runIndex = 0; runIndex < test.runs; runIndex++) {
-      try {
-        const iterationParams = {
-          testCaseId: test.testCaseId ?? testCaseId,
-          testCaseSnapshot: {
-            title: test.title,
-            query: resolvedTestForPrecreate.query,
-            provider: test.provider,
-            model: test.model,
-            runs: test.runs,
-            expectedToolCalls: resolvedTestForPrecreate.expectedToolCalls,
-            isNegativeTest: test.isNegativeTest,
-            expectedOutput: resolvedTestForPrecreate.expectedOutput,
-            steps: resolvedStepsForPrecreate,
-            advancedConfig: resolvedTestForPrecreate.advancedConfig,
-            matchOptions: test.matchOptions,
-            hostConfigOverride: test.hostConfigOverride,
-          },
-          iterationNumber: runIndex + 1,
-          startedAt: precreatedAt,
-        };
-        const id = await createIterationDirectly(convexClient, iterationParams);
-        precreatedIterationIds.push(id);
-      } catch (error) {
-        logger.warn(
-          "[evals] Failed to precreate iteration row; falling back to per-loop create",
-          {
-            runIndex,
-            error: error instanceof Error ? error.message : String(error),
-          }
-        );
-        precreatedIterationIds.push(undefined);
-      }
-    }
-  }
-
-  for (let runIndex = 0; runIndex < test.runs; runIndex++) {
+  for (let runIndex = 0; runIndex < iterationCount; runIndex++) {
     const precreatedIterationId = shouldPrecreateIterations
       ? precreatedIterationIds[runIndex]
       : undefined;
@@ -1856,6 +1891,13 @@ export const runEvalSuiteWithAiSdk = async ({
           runId,
         });
 
+  // One Convex transaction reserves and creates the entire compare request
+  // before tools/list, model construction, or any model/tool request starts.
+  const quickRunIterationIdGroups =
+    runId === null
+      ? await reserveQuickRunIterations(convexClient, tests, testCaseId)
+      : [];
+
   const summary = {
     total: 0,
     passed: 0,
@@ -1951,7 +1993,7 @@ export const runEvalSuiteWithAiSdk = async ({
     const renderCheckLimit = createConcurrencyLimiter(
       MAX_CONCURRENT_RENDER_CHECKS
     );
-    const runOne = (test: (typeof tests)[number]) =>
+    const runOne = (test: (typeof tests)[number], testIndex: number) =>
       runTestCase({
         test,
         tools,
@@ -1976,8 +2018,14 @@ export const runEvalSuiteWithAiSdk = async ({
         suiteHostConfig,
         environment: config.environment,
         ...(pinnedSkillSource ? { pinnedSkillSource } : {}),
+        ...(runId === null
+          ? {
+              precreatedIterationIds:
+                quickRunIterationIdGroups[testIndex] ?? [],
+            }
+          : {}),
       });
-    const testPromises = tests.map((test) =>
+    const testPromises = tests.map((test, testIndex) =>
       // Cap concurrent headless browsers for every model-free render check
       // (legacy widget_probe OR a unified case whose turns are all pinned),
       // not just the legacy discriminator — otherwise a monitoring suite of
@@ -1986,8 +2034,8 @@ export const runEvalSuiteWithAiSdk = async ({
         caseType: test.caseType,
         promptTurns: resolveEvalTestCase(test).promptTurns,
       })
-        ? renderCheckLimit(() => runOne(test))
-        : runOne(test)
+        ? renderCheckLimit(() => runOne(test, testIndex))
+        : runOne(test, testIndex)
     );
 
     // Poll the run status: user cancellation, or a `timed_out` status set
@@ -2122,6 +2170,16 @@ export const runEvalSuiteWithAiSdk = async ({
         clearTimeout(runTimeoutId);
       }
       void heartbeatLoop;
+    }
+
+    if (runId === null) {
+      const rejectedQuickRun = results.find(
+        (result): result is PromiseRejectedResult =>
+          result.status === "rejected"
+      );
+      if (rejectedQuickRun) {
+        throw rejectedQuickRun.reason;
+      }
     }
 
     const quickRunOutcomes: EvalIterationOutcome[] = [];

--- a/mcpjam-inspector/server/services/evals/__tests__/evals-runner.test.ts
+++ b/mcpjam-inspector/server/services/evals/__tests__/evals-runner.test.ts
@@ -1,4 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { ConvexError } from "convex/values";
 
 const generateTextMock = vi.hoisted(() => vi.fn());
 const streamTextMock = vi.hoisted(() => vi.fn());
@@ -137,7 +138,11 @@ describe("runEvalSuiteWithAiSdk compare session metadata", () => {
     // not from the runner's `convexHttpUrl` parameter. Set both so the
     // engine paths and any direct-fetch paths target the same host.
     process.env.CONVEX_HTTP_URL = "https://example.convex.site";
-    convexClient.mutation.mockResolvedValue({ iterationId: "iter-1" });
+    convexClient.mutation.mockResolvedValue({
+      iterationId: "iter-1",
+      iterationIds: ["iter-1"],
+      iterationIdGroups: [["iter-1"]],
+    });
     convexClient.query.mockResolvedValue({ status: "running" });
     convexClient.action.mockResolvedValue(undefined);
     mcpClientManager.getToolsForAiSdk.mockResolvedValue({});
@@ -288,6 +293,57 @@ describe("runEvalSuiteWithAiSdk compare session metadata", () => {
       runEvalSuiteWithAiSdk(buildQuickRunConfig() as any)
     ).rejects.toThrow(
       'Could not start eval because "Asana" failed to list tools. Reconnect the server and try again.'
+    );
+  });
+
+  it("rejects a quick run before model or tool execution when quota reservation fails", async () => {
+    const request = buildQuickRunConfig() as any;
+    request.config.tests = [
+      { ...request.config.tests[0], runs: 2 },
+      {
+        ...request.config.tests[0],
+        runs: 2,
+        model: "claude-sonnet-4",
+        provider: "anthropic",
+      },
+    ];
+    convexClient.mutation.mockRejectedValueOnce(
+      new ConvexError({
+        code: "billing_limit_reached",
+        message: "Eval iteration limit reached",
+        limit: "maxEvalIterationsPerMonth",
+        currentValue: 76,
+        allowed: 75,
+        resetsAt: Date.UTC(2026, 7, 14),
+        windowKind: "day",
+      })
+    );
+
+    await expect(
+      runEvalSuiteWithAiSdk(request)
+    ).rejects.toMatchObject({
+      status: 402,
+      code: "BILLING_LIMIT_REACHED",
+      details: expect.objectContaining({
+        code: "billing_limit_reached",
+        allowed: 75,
+      }),
+    });
+
+    expect(createLlmModelMock).not.toHaveBeenCalled();
+    expect(mcpClientManager.getToolsForAiSdk).not.toHaveBeenCalled();
+    expect(generateTextMock).not.toHaveBeenCalled();
+    expect(streamTextMock).not.toHaveBeenCalled();
+    expect(fetchMock).not.toHaveBeenCalled();
+    expect(mcpClientManager.executeTool).not.toHaveBeenCalled();
+    expect(convexClient.mutation).toHaveBeenCalledWith(
+      "testSuites:recordQuickRunBatchStart",
+      expect.objectContaining({
+        batches: [
+          expect.objectContaining({ count: 2 }),
+          expect.objectContaining({ count: 2 }),
+        ],
+      })
     );
   });
 
@@ -1684,13 +1740,14 @@ describe("runEvalSuiteWithAiSdk compare session metadata", () => {
         )
       );
 
-    // The iteration row is created via `mutation` (default mock returns
-    // { iterationId: "iter-1" }); the finalize call goes through `action`
+    // The iteration rows are created via the atomic batch mutation; the
+    // finalize call goes through `action`
     // (testSuites:updateTestIteration). Convex serializes `passed` into
     // separate `result` ("failed") and `status` ("failed") fields — see
     // `finishIterationDirectly`.
     convexClient.mutation.mockResolvedValueOnce({
-      iterationId: "iter-failed-setup",
+      iterationIds: ["iter-failed-setup"],
+      iterationIdGroups: [["iter-failed-setup"]],
     });
 
     try {
@@ -1763,7 +1820,8 @@ describe("runEvalSuiteWithAiSdk compare session metadata", () => {
       .mockRejectedValueOnce(new Error("simulated prep failure"));
 
     convexClient.mutation.mockResolvedValueOnce({
-      iterationId: "iter-negative-setup-fail",
+      iterationIds: ["iter-negative-setup-fail"],
+      iterationIdGroups: [["iter-negative-setup-fail"]],
     });
 
     try {
@@ -1821,7 +1879,8 @@ describe("runEvalSuiteWithAiSdk compare session metadata", () => {
       .mockRejectedValueOnce(new Error("backend stream prep boom"));
 
     convexClient.mutation.mockResolvedValueOnce({
-      iterationId: "iter-stream-setup-fail",
+      iterationIds: ["iter-stream-setup-fail"],
+      iterationIdGroups: [["iter-stream-setup-fail"]],
     });
 
     const emitted: Array<Record<string, unknown>> = [];

--- a/mcpjam-inspector/server/services/evals/recorder.ts
+++ b/mcpjam-inspector/server/services/evals/recorder.ts
@@ -37,7 +37,7 @@ type RunStopReason = "user_cancelled" | "run_timeout" | "iteration_timeout";
  * lost. Returns null for any non-billing error so callers fall through to
  * their normal handling.
  */
-function asBillingRouteError(error: unknown): WebRouteError | null {
+export function asBillingRouteError(error: unknown): WebRouteError | null {
   if (!(error instanceof ConvexError)) {
     return null;
   }


### PR DESCRIPTION
## Root cause
The usage card showed remaining iterations as the progress value, client guards only checked whether the limit was already reached, and the runner swallowed reservation failures or fell back to an older iteration. Multi-model compare requests were also reserved per model after tools/list began.

## Changes
- Show used / allowed with a filling progress bar.
- Apply one quota guard to Evals, CI Evals, Quick Run, Run Compare, retries, and the test editor.
- Calculate requested usage as models × iterations.
- Reserve the full compare request before tools/list or model/tool execution.
- Preserve Convex billing failures as HTTP 402 and never return an old iteration as success.

## Verification
- npm run typecheck:client
- 148 targeted runner, route, component, API, and client-gate tests passed.
- The quota rejection test asserts no tools/list, model creation, fetch, generation, stream, or tool execution occurs.
- Full server tsc still reports pre-existing main-branch errors; changed server paths add no new errors.

Backend: https://github.com/MCPJam/mcpjam-backend/pull/957

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes eval iteration quota gating and usage display across client and runner. Previously the UI showed remaining iterations, guards only fired after the limit was hit, compare runs reserved per model after tools/list, and the runner hid Convex billing failures or returned an older iteration; now the UI shows used/allowed, one guard gates all entry points, requested usage = models × iterations, the full request is reserved up front, and billing failures surface as HTTP 402 without stale successes.

- Behavior/implementation changes
  - Client: Unified quota guard used by Evals, CI Evals, Quick Run, Run Compare, retries, and the test editor. Uses `calculateEvalIterationRequest` and `getEvalIterationQuotaDisabledReason`; blocks while quota is loading and toasts a clear reason when blocked.
  - UI: Credit card shows “used / allowed” with a filling progress bar and accurate ARIA text. Tests updated to match.
  - Server/runner: New `reserveQuickRunIterations` pre-creates all iteration ids atomically before any tools/list, model construction, model/tool calls, or fetches. `runEvalSuiteWithAiSdk` reserves the entire compare request first and threads `precreatedIterationIds` through execution. Convex billing errors are returned as HTTP 402 via `asBillingRouteError`. No fallback to older iterations.
  - Tests: Added quota calculation/guard unit tests and runner tests asserting that quota rejection prevents any tool/model work and that reservation batches match requested counts.

- Rollout
  - Deploy the backend with `testSuites:recordQuickRunBatchStart` and its `iterationIdGroups` response before this client/runner change: https://github.com/MCPJam/mcpjam-backend/pull/957. No config or data migrations required.

<sup>Written for commit ea80552e2dbfe5a126dccba0eb13264434f7a8e3. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/MCPJam/inspector/pull/3960?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

