### PR TITLE
Show launch health beside the findings, never as one

### DIFF
--- a/mcpjam-inspector/client/src/components/shared/usage-insights/__tests__/run-insights.test.tsx
+++ b/mcpjam-inspector/client/src/components/shared/usage-insights/__tests__/run-insights.test.tsx
@@ -474,6 +474,23 @@ describe("RunInsightsBanner + Recommendations", () => {
     expect(screen.getByTestId("run-insight-detail")).toHaveTextContent(/Fix:/i);
   });
 
+  it("announces disclosure state on BOTH of its triggers", () => {
+    // This row has two buttons opening one panel — the count and the
+    // headline. A keyboard user who lands on either must be told the same
+    // thing, so state cannot live on just one of them.
+    state.dto = completed();
+    state.findings = [finding()];
+    renderBannerAndRecommendations();
+    for (const id of ["run-insight-count", "run-insight-headline"]) {
+      expect(screen.getByTestId(id)).toHaveAttribute("aria-expanded", "false");
+    }
+
+    fireEvent.click(screen.getByTestId("run-insight-headline"));
+    for (const id of ["run-insight-count", "run-insight-headline"]) {
+      expect(screen.getByTestId(id)).toHaveAttribute("aria-expanded", "true");
+    }
+  });
+
   it("closes an OPEN recommendation when its evidence disappears", () => {
     state.dto = completed();
     state.findings = [finding()];

--- a/mcpjam-inspector/client/src/components/shared/usage-insights/__tests__/run-insights.test.tsx
+++ b/mcpjam-inspector/client/src/components/shared/usage-insights/__tests__/run-insights.test.tsx
@@ -60,7 +60,7 @@ vi.mock("convex/react", () => ({
 const FINGERPRINT = "no_tools_used:journey:j-1";
 
 function signal(
-  overrides: Partial<SwarmWaveSignalCandidate> = {},
+  overrides: Partial<SwarmWaveSignalCandidate> = {}
 ): SwarmWaveSignalCandidate {
   return {
     detector: "no_tools_used",
@@ -90,7 +90,7 @@ function signals(overrides: Partial<SwarmWaveSignals> = {}): SwarmWaveSignals {
 }
 
 function insightCandidate(
-  overrides: Partial<SwarmWaveInsightCandidate> = {},
+  overrides: Partial<SwarmWaveInsightCandidate> = {}
 ): SwarmWaveInsightCandidate {
   return {
     fingerprint: FINGERPRINT,
@@ -112,7 +112,7 @@ function insightCandidate(
 }
 
 function insights(
-  overrides: Partial<SwarmWaveInsights> = {},
+  overrides: Partial<SwarmWaveInsights> = {}
 ): SwarmWaveInsights {
   return {
     summary: "Agents answered with advice instead of calling the restore tool.",
@@ -131,7 +131,7 @@ function insights(
 }
 
 function completed(
-  over: Partial<SwarmWaveInsights> = {},
+  over: Partial<SwarmWaveInsights> = {}
 ): SwarmWaveInsightsDto {
   return {
     status: "completed",
@@ -173,7 +173,7 @@ function renderInsights() {
         swarmRunGroupId: "run-1",
       }}
       onOpenSession={onOpenSession}
-    />,
+    />
   );
   return onOpenSession;
 }
@@ -194,13 +194,11 @@ describe("one row per problem", () => {
     renderInsights();
     expect(screen.getAllByTestId("run-insight")).toHaveLength(1);
     expect(screen.getByTestId("run-insight-headline")).toHaveTextContent(
-      /never called a tool/i,
+      /never called a tool/i
     );
     // The model's contribution lives behind the expand, never as a second
     // headline saying the same thing.
-    expect(
-      screen.queryByTestId("run-insight-detail"),
-    ).not.toBeInTheDocument();
+    expect(screen.queryByTestId("run-insight-detail")).not.toBeInTheDocument();
   });
 
   it("shows signals immediately, before any generation exists", () => {
@@ -209,7 +207,7 @@ describe("one row per problem", () => {
     state.dto = null;
     renderInsights();
     expect(screen.getByTestId("run-insight-headline")).toHaveTextContent(
-      /never called a tool/i,
+      /never called a tool/i
     );
   });
 
@@ -231,9 +229,9 @@ describe("one row per problem", () => {
     });
     renderInsights();
     fireEvent.click(screen.getByTestId("run-insight-headline"));
-    expect(
-      screen.getByTestId("run-insight-detail"),
-    ).not.toHaveTextContent(/Why:/);
+    expect(screen.getByTestId("run-insight-detail")).not.toHaveTextContent(
+      /Why:/
+    );
   });
 
   it("collapses to the top three, expandable to all", () => {
@@ -264,12 +262,70 @@ describe("one row per problem", () => {
   });
 });
 
+/**
+ * Evidence integrity — the rail must not lend its authority to a row nobody
+ * can check.
+ *
+ * The backend now refuses to mine or narrate an exemplar-less candidate, but
+ * an older server, a cached payload, or a future detector can still hand this
+ * component one. When that happens the deterministic sentence stays (it is a
+ * true statement about counts) and everything that requires evidence — the
+ * expander, the model's cause and fix, the session chips — does not appear.
+ */
+describe("evidence integrity", () => {
+  const unevidenced = () =>
+    signals({ candidates: [signal({ exemplarSessionIds: [] })] });
+
+  it("will not expand a row with no failing session to open", () => {
+    state.signals = unevidenced();
+    state.dto = completed();
+    renderInsights();
+    fireEvent.click(screen.getByTestId("run-insight-headline"));
+    expect(screen.queryByTestId("run-insight-detail")).not.toBeInTheDocument();
+  });
+
+  it("keeps the deterministic sentence for that row", () => {
+    // Suppressing the row entirely would hide a real count. Only the
+    // unverifiable half is withheld.
+    state.signals = unevidenced();
+    renderInsights();
+    expect(screen.getByTestId("run-insight-headline")).toHaveTextContent(
+      /never called a tool/i
+    );
+  });
+
+  it("never renders a Clean chip without a failing one beside it", () => {
+    state.signals = signals({
+      candidates: [
+        signal({ exemplarSessionIds: [], contrastSessionIds: ["s-9"] }),
+      ],
+    });
+    state.dto = completed();
+    renderInsights();
+    fireEvent.click(screen.getByTestId("run-insight-headline"));
+    expect(
+      screen.queryByTestId("run-insight-session-link")
+    ).not.toBeInTheDocument();
+  });
+
+  it("still expands once a failing exemplar is present", () => {
+    state.signals = signals({
+      candidates: [signal({ contrastSessionIds: ["s-9"] })],
+    });
+    state.dto = completed();
+    renderInsights();
+    fireEvent.click(screen.getByTestId("run-insight-headline"));
+    expect(screen.getByTestId("run-insight-detail")).toHaveTextContent(/Why:/);
+    expect(screen.getAllByTestId("run-insight-session-link")).toHaveLength(2);
+  });
+});
+
 describe("summary and caveats", () => {
   it("leads with the summary and demotes caveats to the footer", () => {
     state.dto = completed();
     renderInsights();
     expect(screen.getByTestId("run-insights-summary")).toHaveTextContent(
-      /answered with advice instead of calling the restore tool/i,
+      /answered with advice instead of calling the restore tool/i
     );
     // Coverage is a footnote, not a preamble — a reader scanning for what to
     // fix should not have to read past a disclaimer to reach it.
@@ -298,9 +354,9 @@ describe("summary and caveats", () => {
   it("waits for the run to finish", () => {
     state.signals = signals({ terminal: false });
     renderInsights();
-    expect(
-      screen.getByTestId("run-insights-pending-run"),
-    ).toHaveTextContent(/when the run finishes/i);
+    expect(screen.getByTestId("run-insights-pending-run")).toHaveTextContent(
+      /when the run finishes/i
+    );
     expect(screen.queryByTestId("run-insight")).not.toBeInTheDocument();
   });
 
@@ -314,7 +370,7 @@ describe("summary and caveats", () => {
     state.signals = signals({ candidates: [] });
     renderInsights();
     expect(screen.getByTestId("run-insights-empty")).toHaveTextContent(
-      /no anomalies detected across 20 sessions/i,
+      /no anomalies detected across 20 sessions/i
     );
   });
 });
@@ -331,7 +387,7 @@ function renderBannerAndRecommendations() {
     >
       <RunInsightsBanner />
       <RunInsightsRecommendations />
-    </RunInsightsProvider>,
+    </RunInsightsProvider>
   );
 }
 
@@ -343,12 +399,14 @@ describe("RunInsightsBanner + Recommendations", () => {
 
     expect(screen.getByTestId("run-insights-banner")).toBeInTheDocument();
     expect(screen.getByTestId("run-insights-summary")).toHaveTextContent(
-      /advice instead of calling the restore tool/i,
+      /advice instead of calling the restore tool/i
     );
-    expect(screen.getByTestId("run-insights-recommendations")).toBeInTheDocument();
+    expect(
+      screen.getByTestId("run-insights-recommendations")
+    ).toBeInTheDocument();
     expect(screen.getByText("Recommendations")).toBeInTheDocument();
     expect(screen.getByTestId("run-insight-headline")).toHaveTextContent(
-      /never called a tool/i,
+      /never called a tool/i
     );
   });
 
@@ -361,6 +419,25 @@ describe("RunInsightsBanner + Recommendations", () => {
     fireEvent.click(screen.getByTestId("run-insight-headline"));
     expect(screen.getByTestId("run-insight-detail")).toHaveTextContent(/Why:/i);
     expect(screen.getByTestId("run-insight-detail")).toHaveTextContent(/Fix:/i);
+  });
+
+  // The rail has TWO row components. The evidence rule is a property of the
+  // surface, not of one layout, so it is pinned on both.
+  it("holds the same evidence rule as the compact rail", () => {
+    state.signals = signals({
+      candidates: [
+        signal({ exemplarSessionIds: [], contrastSessionIds: ["s-9"] }),
+      ],
+    });
+    state.dto = completed();
+    state.findings = [finding()];
+    renderBannerAndRecommendations();
+
+    fireEvent.click(screen.getByTestId("run-insight-headline"));
+    expect(screen.queryByTestId("run-insight-detail")).not.toBeInTheDocument();
+    expect(
+      screen.queryByTestId("run-insight-session-link")
+    ).not.toBeInTheDocument();
   });
 });
 
@@ -392,7 +469,7 @@ describe("generation lifecycle", () => {
     await waitFor(() => expect(state.requestMock).toHaveBeenCalledTimes(1));
 
     expect(await screen.findByTestId("run-insights-error")).toHaveTextContent(
-      /Ask a workspace member/,
+      /Ask a workspace member/
     );
     expect(state.requestMock).toHaveBeenCalledTimes(1);
   });
@@ -408,14 +485,16 @@ describe("generation lifecycle", () => {
           swarmRunGroupId: "run-1",
         }}
         onOpenSession={vi.fn()}
-      />,
+      />
     );
     await waitFor(() => expect(state.requestMock).toHaveBeenCalledTimes(1));
 
     fireEvent.click(screen.getByTestId("run-insights-chip"));
     await screen.findByTestId("run-insights");
     fireEvent.keyDown(document.body, { key: "Escape" });
-    await waitFor(() => expect(screen.queryByTestId("run-insights")).toBeNull());
+    await waitFor(() =>
+      expect(screen.queryByTestId("run-insights")).toBeNull()
+    );
     fireEvent.click(screen.getByTestId("run-insights-chip"));
     await screen.findByTestId("run-insights");
 
@@ -441,13 +520,13 @@ describe("generation lifecycle", () => {
     };
     renderInsights();
     expect(screen.getByTestId("run-insights-error")).toHaveTextContent(
-      /spending cap/i,
+      /spending cap/i
     );
     // The deterministic rows survive a failed generation.
     expect(screen.getByTestId("run-insight")).toBeInTheDocument();
     fireEvent.click(screen.getByTestId("run-insights-retry"));
     expect(state.requestMock).toHaveBeenCalledWith(
-      expect.objectContaining({ force: true }),
+      expect.objectContaining({ force: true })
     );
   });
 
@@ -459,14 +538,14 @@ describe("generation lifecycle", () => {
       .fn()
       .mockRejectedValue(
         new Error(
-          'Server Error: Limit "insightsPerDay" reached on the free plan.',
-        ),
+          'Server Error: Limit "insightsPerDay" reached on the free plan.'
+        )
       );
     renderInsights();
     await waitFor(() =>
       expect(screen.getByTestId("run-insights-error")).toHaveTextContent(
-        /daily insights limit/i,
-      ),
+        /daily insights limit/i
+      )
     );
   });
 });
@@ -477,7 +556,7 @@ describe("registry lifecycle", () => {
     state.findings = [finding()];
     renderInsights();
     expect(screen.getByTestId("run-insight-status")).toHaveTextContent(
-      "Recurring ×3",
+      "Recurring ×3"
     );
   });
 
@@ -490,13 +569,13 @@ describe("registry lifecycle", () => {
     fireEvent.click(screen.getByTestId("run-insight-dismiss"));
     expect(screen.getByTestId("run-insight")).toHaveAttribute(
       "data-dismissed",
-      "true",
+      "true"
     );
     await waitFor(() =>
       expect(screen.getByTestId("run-insight")).toHaveAttribute(
         "data-dismissed",
-        "false",
-      ),
+        "false"
+      )
     );
   });
 });
@@ -512,7 +591,7 @@ describe("Lane B discovery", () => {
   };
 
   const withDiscovery = (
-    findings: SwarmWaveDiscoveryFinding[],
+    findings: SwarmWaveDiscoveryFinding[]
   ): SwarmWaveInsightsDto => ({
     ...completed(),
     discovery: {
@@ -528,15 +607,15 @@ describe("Lane B discovery", () => {
     state.dto = withDiscovery([observation]);
     renderInsights();
     expect(screen.getByTestId("run-discovery-toggle")).toHaveTextContent(
-      /not measured by any check/i,
+      /not measured by any check/i
     );
     expect(
-      screen.queryByTestId("run-discovery-finding"),
+      screen.queryByTestId("run-discovery-finding")
     ).not.toBeInTheDocument();
 
     fireEvent.click(screen.getByTestId("run-discovery-toggle"));
     expect(screen.getByTestId("run-discovery-finding")).toHaveTextContent(
-      /opaque error string/i,
+      /opaque error string/i
     );
   });
 
@@ -554,7 +633,7 @@ describe("Lane B discovery", () => {
     renderInsights();
     fireEvent.click(screen.getByTestId("run-discovery-toggle"));
     expect(screen.getByTestId("run-discovery-check")).toHaveTextContent(
-      "toolCalledAtLeastOnce(search_flights)",
+      "toolCalledAtLeastOnce(search_flights)"
     );
   });
 
@@ -573,8 +652,8 @@ describe("signalSentence", () => {
           detector: "hallucinated_tool",
           subjectLabel: "cancel_booking",
           affectedSessions: 1,
-        }),
-      ),
+        })
+      )
     ).toBe('Agents invented a tool named "cancel_booking" in 1 session');
   });
 
@@ -586,9 +665,26 @@ describe("signalSentence", () => {
           subjectLabel: "Reconcile payouts",
           metric: 10_000,
           waveMetric: 2_000,
-        }),
-      ),
+        })
+      )
     ).toContain("5.0×");
+  });
+
+  it("names SESSIONS as the unit for target failures", () => {
+    // The bare "(1 of 2)" this used to print was ambiguous, and while the
+    // detector still had an attempt-outcome fire path those numbers were
+    // launch attempts being read as sessions.
+    expect(
+      signalSentence(
+        signal({
+          detector: "target_failures",
+          subjectKind: "environment",
+          subjectLabel: "Prod stack",
+          affectedSessions: 3,
+          sliceTotal: 4,
+        })
+      )
+    ).toBe("Tool errors concentrate on Prod stack in 3 of 4 sessions");
   });
 
   it("never divides by a missing comparison", () => {
@@ -599,8 +695,8 @@ describe("signalSentence", () => {
           subjectLabel: "Cursor",
           metric: 30_000,
           waveMetric: undefined,
-        }),
-      ),
+        })
+      )
     ).toContain("well above");
   });
 });
@@ -612,16 +708,16 @@ describe("rail density", () => {
     state.dto = completed({ summary: "x".repeat(200) });
     renderInsights();
     fireEvent.click(screen.getByTestId("run-insights-summary-toggle"));
-    expect(
-      screen.getByTestId("run-insights-summary-toggle"),
-    ).toHaveTextContent("Less");
+    expect(screen.getByTestId("run-insights-summary-toggle")).toHaveTextContent(
+      "Less"
+    );
   });
 
   it("leaves a short summary unclamped", () => {
     state.dto = completed({ summary: "Fix the restore tool description." });
     renderInsights();
     expect(
-      screen.queryByTestId("run-insights-summary-toggle"),
+      screen.queryByTestId("run-insights-summary-toggle")
     ).not.toBeInTheDocument();
   });
 });

--- a/mcpjam-inspector/client/src/components/shared/usage-insights/__tests__/run-insights.test.tsx
+++ b/mcpjam-inspector/client/src/components/shared/usage-insights/__tests__/run-insights.test.tsx
@@ -322,6 +322,26 @@ describe("evidence integrity", () => {
     ).not.toBeInTheDocument();
   });
 
+  it("reports its disclosure state to assistive tech, evidence and all", () => {
+    state.dto = completed();
+    const { refresh } = renderRefreshableInsights();
+    const headline = () => screen.getByTestId("run-insight-headline");
+    expect(headline()).toHaveAttribute("aria-expanded", "false");
+
+    fireEvent.click(headline());
+    expect(headline()).toHaveAttribute("aria-expanded", "true");
+
+    // Evidence pulled out from under an open row: the panel closes, and the
+    // announced state has to close with it.
+    state.signals = unevidenced();
+    refresh();
+    expect(headline()).toHaveAttribute("aria-expanded", "false");
+
+    state.signals = signals();
+    refresh();
+    expect(headline()).toHaveAttribute("aria-expanded", "true");
+  });
+
   it("closes an OPEN row when its evidence disappears under it", () => {
     // Signals are a live subscription. Without this, a refresh that dropped
     // the exemplars left the model's Why/Fix on screen with nothing behind

--- a/mcpjam-inspector/client/src/components/shared/usage-insights/__tests__/run-insights.test.tsx
+++ b/mcpjam-inspector/client/src/components/shared/usage-insights/__tests__/run-insights.test.tsx
@@ -60,7 +60,7 @@ vi.mock("convex/react", () => ({
 const FINGERPRINT = "no_tools_used:journey:j-1";
 
 function signal(
-  overrides: Partial<SwarmWaveSignalCandidate> = {}
+  overrides: Partial<SwarmWaveSignalCandidate> = {},
 ): SwarmWaveSignalCandidate {
   return {
     detector: "no_tools_used",
@@ -90,7 +90,7 @@ function signals(overrides: Partial<SwarmWaveSignals> = {}): SwarmWaveSignals {
 }
 
 function insightCandidate(
-  overrides: Partial<SwarmWaveInsightCandidate> = {}
+  overrides: Partial<SwarmWaveInsightCandidate> = {},
 ): SwarmWaveInsightCandidate {
   return {
     fingerprint: FINGERPRINT,
@@ -112,7 +112,7 @@ function insightCandidate(
 }
 
 function insights(
-  overrides: Partial<SwarmWaveInsights> = {}
+  overrides: Partial<SwarmWaveInsights> = {},
 ): SwarmWaveInsights {
   return {
     summary: "Agents answered with advice instead of calling the restore tool.",
@@ -131,7 +131,7 @@ function insights(
 }
 
 function completed(
-  over: Partial<SwarmWaveInsights> = {}
+  over: Partial<SwarmWaveInsights> = {},
 ): SwarmWaveInsightsDto {
   return {
     status: "completed",
@@ -204,11 +204,13 @@ describe("one row per problem", () => {
     renderInsights();
     expect(screen.getAllByTestId("run-insight")).toHaveLength(1);
     expect(screen.getByTestId("run-insight-headline")).toHaveTextContent(
-      /never called a tool/i
+      /never called a tool/i,
     );
     // The model's contribution lives behind the expand, never as a second
     // headline saying the same thing.
-    expect(screen.queryByTestId("run-insight-detail")).not.toBeInTheDocument();
+    expect(
+      screen.queryByTestId("run-insight-detail"),
+    ).not.toBeInTheDocument();
   });
 
   it("shows signals immediately, before any generation exists", () => {
@@ -217,7 +219,7 @@ describe("one row per problem", () => {
     state.dto = null;
     renderInsights();
     expect(screen.getByTestId("run-insight-headline")).toHaveTextContent(
-      /never called a tool/i
+      /never called a tool/i,
     );
   });
 
@@ -239,9 +241,9 @@ describe("one row per problem", () => {
     });
     renderInsights();
     fireEvent.click(screen.getByTestId("run-insight-headline"));
-    expect(screen.getByTestId("run-insight-detail")).not.toHaveTextContent(
-      /Why:/
-    );
+    expect(
+      screen.getByTestId("run-insight-detail"),
+    ).not.toHaveTextContent(/Why:/);
   });
 
   it("collapses to the top three, expandable to all", () => {
@@ -291,7 +293,9 @@ describe("evidence integrity", () => {
     state.dto = completed();
     renderInsights();
     fireEvent.click(screen.getByTestId("run-insight-headline"));
-    expect(screen.queryByTestId("run-insight-detail")).not.toBeInTheDocument();
+    expect(
+      screen.queryByTestId("run-insight-detail"),
+    ).not.toBeInTheDocument();
   });
 
   it("keeps the deterministic sentence for that row", () => {
@@ -300,7 +304,7 @@ describe("evidence integrity", () => {
     state.signals = unevidenced();
     renderInsights();
     expect(screen.getByTestId("run-insight-headline")).toHaveTextContent(
-      /never called a tool/i
+      /never called a tool/i,
     );
   });
 
@@ -314,7 +318,7 @@ describe("evidence integrity", () => {
     renderInsights();
     fireEvent.click(screen.getByTestId("run-insight-headline"));
     expect(
-      screen.queryByTestId("run-insight-session-link")
+      screen.queryByTestId("run-insight-session-link"),
     ).not.toBeInTheDocument();
   });
 
@@ -329,7 +333,9 @@ describe("evidence integrity", () => {
 
     state.signals = unevidenced();
     refresh();
-    expect(screen.queryByTestId("run-insight-detail")).not.toBeInTheDocument();
+    expect(
+      screen.queryByTestId("run-insight-detail"),
+    ).not.toBeInTheDocument();
   });
 
   it("still expands once a failing exemplar is present", () => {
@@ -349,7 +355,7 @@ describe("summary and caveats", () => {
     state.dto = completed();
     renderInsights();
     expect(screen.getByTestId("run-insights-summary")).toHaveTextContent(
-      /answered with advice instead of calling the restore tool/i
+      /answered with advice instead of calling the restore tool/i,
     );
     // Coverage is a footnote, not a preamble — a reader scanning for what to
     // fix should not have to read past a disclaimer to reach it.
@@ -378,9 +384,9 @@ describe("summary and caveats", () => {
   it("waits for the run to finish", () => {
     state.signals = signals({ terminal: false });
     renderInsights();
-    expect(screen.getByTestId("run-insights-pending-run")).toHaveTextContent(
-      /when the run finishes/i
-    );
+    expect(
+      screen.getByTestId("run-insights-pending-run"),
+    ).toHaveTextContent(/when the run finishes/i);
     expect(screen.queryByTestId("run-insight")).not.toBeInTheDocument();
   });
 
@@ -394,7 +400,7 @@ describe("summary and caveats", () => {
     state.signals = signals({ candidates: [] });
     renderInsights();
     expect(screen.getByTestId("run-insights-empty")).toHaveTextContent(
-      /no anomalies detected across 20 sessions/i
+      /no anomalies detected across 20 sessions/i,
     );
   });
 });
@@ -428,14 +434,12 @@ describe("RunInsightsBanner + Recommendations", () => {
 
     expect(screen.getByTestId("run-insights-banner")).toBeInTheDocument();
     expect(screen.getByTestId("run-insights-summary")).toHaveTextContent(
-      /advice instead of calling the restore tool/i
+      /advice instead of calling the restore tool/i,
     );
-    expect(
-      screen.getByTestId("run-insights-recommendations")
-    ).toBeInTheDocument();
+    expect(screen.getByTestId("run-insights-recommendations")).toBeInTheDocument();
     expect(screen.getByText("Recommendations")).toBeInTheDocument();
     expect(screen.getByTestId("run-insight-headline")).toHaveTextContent(
-      /never called a tool/i
+      /never called a tool/i,
     );
   });
 
@@ -461,7 +465,9 @@ describe("RunInsightsBanner + Recommendations", () => {
       candidates: [signal({ exemplarSessionIds: [] })],
     });
     rerender(bannerAndRecommendations());
-    expect(screen.queryByTestId("run-insight-detail")).not.toBeInTheDocument();
+    expect(
+      screen.queryByTestId("run-insight-detail"),
+    ).not.toBeInTheDocument();
   });
 
   // The rail has TWO row components. The evidence rule is a property of the
@@ -477,9 +483,11 @@ describe("RunInsightsBanner + Recommendations", () => {
     renderBannerAndRecommendations();
 
     fireEvent.click(screen.getByTestId("run-insight-headline"));
-    expect(screen.queryByTestId("run-insight-detail")).not.toBeInTheDocument();
     expect(
-      screen.queryByTestId("run-insight-session-link")
+      screen.queryByTestId("run-insight-detail"),
+    ).not.toBeInTheDocument();
+    expect(
+      screen.queryByTestId("run-insight-session-link"),
     ).not.toBeInTheDocument();
   });
 });
@@ -512,7 +520,7 @@ describe("generation lifecycle", () => {
     await waitFor(() => expect(state.requestMock).toHaveBeenCalledTimes(1));
 
     expect(await screen.findByTestId("run-insights-error")).toHaveTextContent(
-      /Ask a workspace member/
+      /Ask a workspace member/,
     );
     expect(state.requestMock).toHaveBeenCalledTimes(1);
   });
@@ -528,16 +536,14 @@ describe("generation lifecycle", () => {
           swarmRunGroupId: "run-1",
         }}
         onOpenSession={vi.fn()}
-      />
+      />,
     );
     await waitFor(() => expect(state.requestMock).toHaveBeenCalledTimes(1));
 
     fireEvent.click(screen.getByTestId("run-insights-chip"));
     await screen.findByTestId("run-insights");
     fireEvent.keyDown(document.body, { key: "Escape" });
-    await waitFor(() =>
-      expect(screen.queryByTestId("run-insights")).toBeNull()
-    );
+    await waitFor(() => expect(screen.queryByTestId("run-insights")).toBeNull());
     fireEvent.click(screen.getByTestId("run-insights-chip"));
     await screen.findByTestId("run-insights");
 
@@ -563,13 +569,13 @@ describe("generation lifecycle", () => {
     };
     renderInsights();
     expect(screen.getByTestId("run-insights-error")).toHaveTextContent(
-      /spending cap/i
+      /spending cap/i,
     );
     // The deterministic rows survive a failed generation.
     expect(screen.getByTestId("run-insight")).toBeInTheDocument();
     fireEvent.click(screen.getByTestId("run-insights-retry"));
     expect(state.requestMock).toHaveBeenCalledWith(
-      expect.objectContaining({ force: true })
+      expect.objectContaining({ force: true }),
     );
   });
 
@@ -581,14 +587,14 @@ describe("generation lifecycle", () => {
       .fn()
       .mockRejectedValue(
         new Error(
-          'Server Error: Limit "insightsPerDay" reached on the free plan.'
-        )
+          'Server Error: Limit "insightsPerDay" reached on the free plan.',
+        ),
       );
     renderInsights();
     await waitFor(() =>
       expect(screen.getByTestId("run-insights-error")).toHaveTextContent(
-        /daily insights limit/i
-      )
+        /daily insights limit/i,
+      ),
     );
   });
 });
@@ -599,7 +605,7 @@ describe("registry lifecycle", () => {
     state.findings = [finding()];
     renderInsights();
     expect(screen.getByTestId("run-insight-status")).toHaveTextContent(
-      "Recurring ×3"
+      "Recurring ×3",
     );
   });
 
@@ -612,13 +618,13 @@ describe("registry lifecycle", () => {
     fireEvent.click(screen.getByTestId("run-insight-dismiss"));
     expect(screen.getByTestId("run-insight")).toHaveAttribute(
       "data-dismissed",
-      "true"
+      "true",
     );
     await waitFor(() =>
       expect(screen.getByTestId("run-insight")).toHaveAttribute(
         "data-dismissed",
-        "false"
-      )
+        "false",
+      ),
     );
   });
 });
@@ -634,7 +640,7 @@ describe("Lane B discovery", () => {
   };
 
   const withDiscovery = (
-    findings: SwarmWaveDiscoveryFinding[]
+    findings: SwarmWaveDiscoveryFinding[],
   ): SwarmWaveInsightsDto => ({
     ...completed(),
     discovery: {
@@ -650,15 +656,15 @@ describe("Lane B discovery", () => {
     state.dto = withDiscovery([observation]);
     renderInsights();
     expect(screen.getByTestId("run-discovery-toggle")).toHaveTextContent(
-      /not measured by any check/i
+      /not measured by any check/i,
     );
     expect(
-      screen.queryByTestId("run-discovery-finding")
+      screen.queryByTestId("run-discovery-finding"),
     ).not.toBeInTheDocument();
 
     fireEvent.click(screen.getByTestId("run-discovery-toggle"));
     expect(screen.getByTestId("run-discovery-finding")).toHaveTextContent(
-      /opaque error string/i
+      /opaque error string/i,
     );
   });
 
@@ -676,7 +682,7 @@ describe("Lane B discovery", () => {
     renderInsights();
     fireEvent.click(screen.getByTestId("run-discovery-toggle"));
     expect(screen.getByTestId("run-discovery-check")).toHaveTextContent(
-      "toolCalledAtLeastOnce(search_flights)"
+      "toolCalledAtLeastOnce(search_flights)",
     );
   });
 
@@ -695,8 +701,8 @@ describe("signalSentence", () => {
           detector: "hallucinated_tool",
           subjectLabel: "cancel_booking",
           affectedSessions: 1,
-        })
-      )
+        }),
+      ),
     ).toBe('Agents invented a tool named "cancel_booking" in 1 session');
   });
 
@@ -708,8 +714,8 @@ describe("signalSentence", () => {
           subjectLabel: "Reconcile payouts",
           metric: 10_000,
           waveMetric: 2_000,
-        })
-      )
+        }),
+      ),
     ).toContain("5.0×");
   });
 
@@ -725,8 +731,8 @@ describe("signalSentence", () => {
           subjectLabel: "Prod stack",
           affectedSessions: 3,
           sliceTotal: 4,
-        })
-      )
+        }),
+      ),
     ).toBe("Tool errors concentrate on Prod stack in 3 of 4 sessions");
   });
 
@@ -738,8 +744,8 @@ describe("signalSentence", () => {
           subjectLabel: "Cursor",
           metric: 30_000,
           waveMetric: undefined,
-        })
-      )
+        }),
+      ),
     ).toContain("well above");
   });
 });
@@ -751,16 +757,16 @@ describe("rail density", () => {
     state.dto = completed({ summary: "x".repeat(200) });
     renderInsights();
     fireEvent.click(screen.getByTestId("run-insights-summary-toggle"));
-    expect(screen.getByTestId("run-insights-summary-toggle")).toHaveTextContent(
-      "Less"
-    );
+    expect(
+      screen.getByTestId("run-insights-summary-toggle"),
+    ).toHaveTextContent("Less");
   });
 
   it("leaves a short summary unclamped", () => {
     state.dto = completed({ summary: "Fix the restore tool description." });
     renderInsights();
     expect(
-      screen.queryByTestId("run-insights-summary-toggle")
+      screen.queryByTestId("run-insights-summary-toggle"),
     ).not.toBeInTheDocument();
   });
 });

--- a/mcpjam-inspector/client/src/components/shared/usage-insights/__tests__/run-insights.test.tsx
+++ b/mcpjam-inspector/client/src/components/shared/usage-insights/__tests__/run-insights.test.tsx
@@ -331,11 +331,14 @@ describe("evidence integrity", () => {
     fireEvent.click(headline());
     expect(headline()).toHaveAttribute("aria-expanded", "true");
 
-    // Evidence pulled out from under an open row: the panel closes, and the
-    // announced state has to close with it.
+    // Evidence pulled out from under an open row. The attribute goes AWAY
+    // rather than reading "false": with nothing to expand, the click is a
+    // no-op and there is no chevron, so this button is not a disclosure
+    // control at all — and announcing it as a collapsed one describes a
+    // control that does not exist.
     state.signals = unevidenced();
     refresh();
-    expect(headline()).toHaveAttribute("aria-expanded", "false");
+    expect(headline()).not.toHaveAttribute("aria-expanded");
 
     state.signals = signals();
     refresh();

--- a/mcpjam-inspector/client/src/components/shared/usage-insights/__tests__/run-insights.test.tsx
+++ b/mcpjam-inspector/client/src/components/shared/usage-insights/__tests__/run-insights.test.tsx
@@ -163,19 +163,29 @@ function finding(overrides: Partial<SwarmFinding> = {}): SwarmFinding {
   };
 }
 
+const INSIGHTS_ELEMENT = (onOpenSession: () => void) => (
+  <RunInsights
+    surface={{
+      kind: "swarm",
+      projectId: "proj-1",
+      swarmRunGroupId: "run-1",
+    }}
+    onOpenSession={onOpenSession}
+  />
+);
+
 function renderInsights() {
   const onOpenSession = vi.fn();
-  render(
-    <RunInsights
-      surface={{
-        kind: "swarm",
-        projectId: "proj-1",
-        swarmRunGroupId: "run-1",
-      }}
-      onOpenSession={onOpenSession}
-    />
-  );
+  render(INSIGHTS_ELEMENT(onOpenSession));
   return onOpenSession;
+}
+
+/** Render, then hand back a `refresh` that re-renders the SAME tree after the
+ * mocked signals change — how a live subscription update reaches the rows. */
+function renderRefreshableInsights() {
+  const onOpenSession = vi.fn();
+  const { rerender } = render(INSIGHTS_ELEMENT(onOpenSession));
+  return { refresh: () => rerender(INSIGHTS_ELEMENT(onOpenSession)) };
 }
 
 beforeEach(() => {
@@ -308,6 +318,20 @@ describe("evidence integrity", () => {
     ).not.toBeInTheDocument();
   });
 
+  it("closes an OPEN row when its evidence disappears under it", () => {
+    // Signals are a live subscription. Without this, a refresh that dropped
+    // the exemplars left the model's Why/Fix on screen with nothing behind
+    // it — the row was merely un-openable, not closed.
+    state.dto = completed();
+    const { refresh } = renderRefreshableInsights();
+    fireEvent.click(screen.getByTestId("run-insight-headline"));
+    expect(screen.getByTestId("run-insight-detail")).toBeInTheDocument();
+
+    state.signals = unevidenced();
+    refresh();
+    expect(screen.queryByTestId("run-insight-detail")).not.toBeInTheDocument();
+  });
+
   it("still expands once a failing exemplar is present", () => {
     state.signals = signals({
       candidates: [signal({ contrastSessionIds: ["s-9"] })],
@@ -375,20 +399,25 @@ describe("summary and caveats", () => {
   });
 });
 
+/** A FUNCTION, not a constant element: React bails out of re-rendering a
+ * subtree handed the identical element object, so a shared constant would make
+ * `rerender` silently no-op. */
+const bannerAndRecommendations = () => (
+  <RunInsightsProvider
+    surface={{
+      kind: "swarm",
+      projectId: "proj-1",
+      swarmRunGroupId: "run-1",
+    }}
+    onOpenSession={vi.fn()}
+  >
+    <RunInsightsBanner />
+    <RunInsightsRecommendations />
+  </RunInsightsProvider>
+);
+
 function renderBannerAndRecommendations() {
-  return render(
-    <RunInsightsProvider
-      surface={{
-        kind: "swarm",
-        projectId: "proj-1",
-        swarmRunGroupId: "run-1",
-      }}
-      onOpenSession={vi.fn()}
-    >
-      <RunInsightsBanner />
-      <RunInsightsRecommendations />
-    </RunInsightsProvider>
-  );
+  return render(bannerAndRecommendations());
 }
 
 describe("RunInsightsBanner + Recommendations", () => {
@@ -419,6 +448,20 @@ describe("RunInsightsBanner + Recommendations", () => {
     fireEvent.click(screen.getByTestId("run-insight-headline"));
     expect(screen.getByTestId("run-insight-detail")).toHaveTextContent(/Why:/i);
     expect(screen.getByTestId("run-insight-detail")).toHaveTextContent(/Fix:/i);
+  });
+
+  it("closes an OPEN recommendation when its evidence disappears", () => {
+    state.dto = completed();
+    state.findings = [finding()];
+    const { rerender } = renderBannerAndRecommendations();
+    fireEvent.click(screen.getByTestId("run-insight-headline"));
+    expect(screen.getByTestId("run-insight-detail")).toBeInTheDocument();
+
+    state.signals = signals({
+      candidates: [signal({ exemplarSessionIds: [] })],
+    });
+    rerender(bannerAndRecommendations());
+    expect(screen.queryByTestId("run-insight-detail")).not.toBeInTheDocument();
   });
 
   // The rail has TWO row components. The evidence rule is a property of the

--- a/mcpjam-inspector/client/src/components/shared/usage-insights/run-insights.tsx
+++ b/mcpjam-inspector/client/src/components/shared/usage-insights/run-insights.tsx
@@ -141,7 +141,8 @@ const STATUS_CHIP: Record<string, { label: string; className: string }> = {
   },
   regressed: {
     label: "Regressed",
-    className: "border-red-500/30 bg-red-500/10 text-red-700 dark:text-red-400",
+    className:
+      "border-red-500/30 bg-red-500/10 text-red-700 dark:text-red-400",
   },
   resolved: {
     label: "Resolved",
@@ -163,7 +164,7 @@ export function signalFingerprint(candidate: {
 }): string {
   const clean = (value: string) => value.replace(/[:\n]/g, "_");
   return `${clean(candidate.detector)}:${clean(candidate.subjectKind)}:${clean(
-    candidate.subjectId
+    candidate.subjectId,
   )}`.slice(0, 200);
 }
 
@@ -174,7 +175,7 @@ export function signalFingerprint(candidate: {
  */
 export function signalSentence(
   c: RailSignalCandidate,
-  opts?: { cohort?: "run" | "window" }
+  opts?: { cohort?: "run" | "window" },
 ): string {
   // Relative detectors compare a slice against everything else measured. On a
   // swarm that population is "the run"; on a hosted surface it is the window
@@ -183,42 +184,20 @@ export function signalSentence(
   const rest = opts?.cohort === "window" ? "these sessions" : "the run";
   switch (c.detector) {
     case "tool_errors":
-      return `${c.subjectLabel} failed ${
-        c.metric ?? c.affectedSessions
-      }× across ${c.affectedSessions} of ${c.sliceTotal} sessions`;
+      return `${c.subjectLabel} failed ${c.metric ?? c.affectedSessions}× across ${c.affectedSessions} of ${c.sliceTotal} sessions`;
     case "hallucinated_tool":
       // "Agents" is swarm vocabulary; a hosted visitor talked to one
       // assistant, and never called it an agent.
       return opts?.cohort === "window"
-        ? `The assistant called a tool named "${
-            c.subjectLabel
-          }" that does not exist, in ${c.affectedSessions} ${plural(
-            c.affectedSessions,
-            "session"
-          )}`
-        : `Agents invented a tool named "${c.subjectLabel}" in ${
-            c.affectedSessions
-          } ${plural(c.affectedSessions, "session")}`;
+        ? `The assistant called a tool named "${c.subjectLabel}" that does not exist, in ${c.affectedSessions} ${plural(c.affectedSessions, "session")}`
+        : `Agents invented a tool named "${c.subjectLabel}" in ${c.affectedSessions} ${plural(c.affectedSessions, "session")}`;
     // ── User Testing detectors ──
     case "negative_feedback":
-      return `${c.affectedSessions} of ${c.sliceTotal} rated ${plural(
-        c.sliceTotal,
-        "session"
-      )} left negative feedback${
-        c.subjectKind === "route" || c.subjectKind === "path"
-          ? ` on ${c.subjectLabel}`
-          : ""
-      }`;
+      return `${c.affectedSessions} of ${c.sliceTotal} rated ${plural(c.sliceTotal, "session")} left negative feedback${c.subjectKind === "route" || c.subjectKind === "path" ? ` on ${c.subjectLabel}` : ""}`;
     case "cohort_struggles":
       return `${c.subjectLabel} visitors struggled in ${c.affectedSessions} of ${c.sliceTotal} sessions`;
     case "terminal_error_concentration":
-      return `${c.affectedSessions} of ${
-        c.sliceTotal
-      } sessions ended on a tool error${
-        c.subjectKind === "route" || c.subjectKind === "path"
-          ? ` in ${c.subjectLabel}`
-          : ""
-      }`;
+      return `${c.affectedSessions} of ${c.sliceTotal} sessions ended on a tool error${c.subjectKind === "route" || c.subjectKind === "path" ? ` in ${c.subjectLabel}` : ""}`;
     case "criterion_fail":
       return `"${c.subjectLabel}" failed in ${c.affectedSessions} of ${c.sliceTotal} graded sessions`;
     case "target_failures":
@@ -226,47 +205,28 @@ export function signalSentence(
       // launch attempts, where this pair counted attempts and the bare
       // "(1 of 2)" read as sessions. That path is gone (launch outcomes are
       // reported as target health, never mined), so the noun is stated.
-      return `Tool errors concentrate on ${c.subjectLabel} in ${
-        c.affectedSessions
-      } of ${c.sliceTotal} ${plural(c.sliceTotal, "session")}`;
+      return `Tool errors concentrate on ${c.subjectLabel} in ${c.affectedSessions} of ${c.sliceTotal} ${plural(c.sliceTotal, "session")}`;
     case "persona_struggles":
       return `${c.subjectLabel} struggled in ${c.affectedSessions} of ${c.sliceTotal} sessions`;
     case "marginal_pass":
-      return `${c.affectedSessions} ${plural(
-        c.affectedSessions,
-        "pass",
-        "passes"
-      )} in "${c.subjectLabel}" barely cleared the judge threshold`;
+      return `${c.affectedSessions} ${plural(c.affectedSessions, "pass", "passes")} in "${c.subjectLabel}" barely cleared the judge threshold`;
     case "turn_cap_grind":
-      return `${c.affectedSessions} ${plural(
-        c.affectedSessions,
-        "session"
-      )} in "${c.subjectLabel}" ran out the ${c.metric ?? "max"}-turn budget`;
+      return `${c.affectedSessions} ${plural(c.affectedSessions, "session")} in "${c.subjectLabel}" ran out the ${c.metric ?? "max"}-turn budget`;
     case "error_recovered_pass":
-      return `${c.affectedSessions} passing ${plural(
-        c.affectedSessions,
-        "session"
-      )} in "${c.subjectLabel}" recovered from tool errors first`;
+      return `${c.affectedSessions} passing ${plural(c.affectedSessions, "session")} in "${c.subjectLabel}" recovered from tool errors first`;
     case "token_outlier":
-      return `"${c.subjectLabel}" uses ~${ratioLabel(
-        c
-      )} the tokens of the rest of ${rest}`;
+      return `"${c.subjectLabel}" uses ~${ratioLabel(c)} the tokens of the rest of ${rest}`;
     case "latency_outlier":
-      return `${c.subjectLabel} p95 latency is ${ratioLabel(
-        c
-      )} the rest of ${rest}`;
+      return `${c.subjectLabel} p95 latency is ${ratioLabel(c)} the rest of ${rest}`;
     case "no_tools_used":
-      return `${c.affectedSessions} ${plural(
-        c.affectedSessions,
-        "session"
-      )} in "${c.subjectLabel}" never called a tool`;
+      return `${c.affectedSessions} ${plural(c.affectedSessions, "session")} in "${c.subjectLabel}" never called a tool`;
     default:
       return `${c.subjectLabel}: ${c.affectedSessions} of ${c.sliceTotal} sessions`;
   }
 }
 
 function plural(n: number, singular: string, pluralForm?: string): string {
-  return n === 1 ? singular : pluralForm ?? `${singular}s`;
+  return n === 1 ? singular : (pluralForm ?? `${singular}s`);
 }
 
 function ratioLabel(c: RailSignalCandidate): string {
@@ -303,7 +263,7 @@ function isBlockingShaped(detector: string): boolean {
  * offer prose it cannot back.
  */
 function canExpand(
-  signal: Pick<RailSignalCandidate, "exemplarSessionIds">
+  signal: Pick<RailSignalCandidate, "exemplarSessionIds">,
 ): boolean {
   return signal.exemplarSessionIds.length > 0;
 }
@@ -336,20 +296,20 @@ function useRailData(surface: RunInsightsSurface): {
           projectId: surface.projectId,
           swarmRunGroupId: surface.swarmRunGroupId,
         }
-      : "skip") as any
+      : "skip") as any,
   ) as SwarmWaveSignals | null | undefined;
   const swarmFindings = useQuery(
     SWARM_QUERIES.listSwarmFindings as any,
-    (isSwarm ? { projectId: surface.projectId } : "skip") as any
+    (isSwarm ? { projectId: surface.projectId } : "skip") as any,
   ) as SwarmFinding[] | undefined;
 
   const windowSignals = useQuery(
     CHATBOX_INSIGHTS_QUERIES.getWindowSignals as any,
-    (isSwarm ? "skip" : { chatboxId: surface.chatboxId }) as any
+    (isSwarm ? "skip" : { chatboxId: surface.chatboxId }) as any,
   ) as ChatboxWindowSignals | null | undefined;
   const windowFindings = useQuery(
     CHATBOX_INSIGHTS_QUERIES.listChatboxFindings as any,
-    (isSwarm ? "skip" : { chatboxId: surface.chatboxId }) as any
+    (isSwarm ? "skip" : { chatboxId: surface.chatboxId }) as any,
   ) as ChatboxFinding[] | undefined;
 
   if (isSwarm) {
@@ -409,7 +369,7 @@ function useRailData(surface: RunInsightsSurface): {
  */
 function useNarrationScope(
   surface: RunInsightsSurface,
-  latestGroupId: string | null | undefined
+  latestGroupId: string | null | undefined,
 ): RunInsightsScope | null {
   return useMemo<RunInsightsScope | null>(() => {
     if (surface.kind === "swarm") {
@@ -420,11 +380,7 @@ function useNarrationScope(
       };
     }
     return latestGroupId
-      ? {
-          kind: "chatbox",
-          chatboxId: surface.chatboxId,
-          groupId: latestGroupId,
-        }
+      ? { kind: "chatbox", chatboxId: surface.chatboxId, groupId: latestGroupId }
       : null;
   }, [surface, latestGroupId]);
 }
@@ -468,7 +424,7 @@ function RunInsightsBody({
   const rows: Row[] = useMemo(() => {
     if (!signals) return [];
     const insightBy = new Map(
-      (insights?.candidates ?? []).map((c) => [c.fingerprint, c])
+      (insights?.candidates ?? []).map((c) => [c.fingerprint, c]),
     );
     const findingBy = new Map((findings ?? []).map((f) => [f.fingerprint, f]));
     return signals.candidates.map((signal) => {
@@ -643,7 +599,7 @@ function RunInsightsBody({
 function useRail(
   surface: RunInsightsSurface,
   canRequestProp: boolean,
-  canDismissProp: boolean
+  canDismissProp: boolean,
 ): {
   rail: ReturnType<typeof useRailData>;
   lifecycle: UseRunInsightsResult;
@@ -679,7 +635,7 @@ function useRunInsightsRail(): RunInsightsRailContextValue {
   const ctx = useContext(RunInsightsRailContext);
   if (!ctx) {
     throw new Error(
-      "RunInsightsBanner / RunInsightsRecommendations require RunInsightsProvider"
+      "RunInsightsBanner / RunInsightsRecommendations require RunInsightsProvider",
     );
   }
   return ctx;
@@ -704,7 +660,9 @@ export function RunInsightsProvider({
 }) {
   const railState = useRail(surface, canRequest, canDismiss);
   return (
-    <RunInsightsRailContext.Provider value={{ ...railState, onOpenSession }}>
+    <RunInsightsRailContext.Provider
+      value={{ ...railState, onOpenSession }}
+    >
       {children}
     </RunInsightsRailContext.Provider>
   );
@@ -712,13 +670,13 @@ export function RunInsightsProvider({
 
 function buildInsightRows(
   rail: ReturnType<typeof useRailData>,
-  lifecycle: UseRunInsightsResult
+  lifecycle: UseRunInsightsResult,
 ): Row[] {
   const { signals, findings } = rail;
   const { insights } = lifecycle;
   if (!signals) return [];
   const insightBy = new Map(
-    (insights?.candidates ?? []).map((c) => [c.fingerprint, c])
+    (insights?.candidates ?? []).map((c) => [c.fingerprint, c]),
   );
   const findingBy = new Map((findings ?? []).map((f) => [f.fingerprint, f]));
   return signals.candidates.map((signal) => {
@@ -769,11 +727,11 @@ export function RunInsights({
 
 function countActivePatterns(
   signals: RailSignals | null | undefined,
-  findings: RailFinding[] | undefined
+  findings: RailFinding[] | undefined,
 ): number {
   if (!signals || !findings) return 0;
   const findingByFingerprint = new Map(
-    findings.map((finding) => [finding.fingerprint, finding])
+    findings.map((finding) => [finding.fingerprint, finding]),
   );
   return signals.candidates.reduce((count, candidate) => {
     const finding = findingByFingerprint.get(signalFingerprint(candidate));
@@ -787,13 +745,17 @@ function countActivePatterns(
  * {@link RunInsightsRecommendations} beside the scorecard.
  */
 export function RunInsightsBanner() {
-  const { rail, lifecycle, canRequest: mayRequest } = useRunInsightsRail();
+  const {
+    rail,
+    lifecycle,
+    canRequest: mayRequest,
+  } = useRunInsightsRail();
   const { signals, findings, cohort } = rail;
   const { insights, busy, unavailable, error, request } = lifecycle;
 
   const activeCount = useMemo(
     () => countActivePatterns(signals, findings),
-    [signals, findings]
+    [signals, findings],
   );
 
   if (!signals) return null;
@@ -881,7 +843,7 @@ export function RunInsightsRecommendations() {
 
   const rows = useMemo(
     () => buildInsightRows(rail, lifecycle),
-    [rail, lifecycle]
+    [rail, lifecycle],
   );
   const [showAll, setShowAll] = useState(false);
 
@@ -915,9 +877,7 @@ export function RunInsightsRecommendations() {
       data-testid="run-insights-recommendations"
     >
       <div className="mb-2.5 flex flex-wrap items-baseline gap-x-2 gap-y-0.5">
-        <h3 className="text-sm font-semibold tracking-tight">
-          Recommendations
-        </h3>
+        <h3 className="text-sm font-semibold tracking-tight">Recommendations</h3>
         <span className="text-xs text-muted-foreground">
           Patterns to investigate across sessions
         </span>
@@ -1050,7 +1010,7 @@ function RecommendationRow({
             "disabled:cursor-default",
             isBlockingShaped(signal.detector)
               ? "border-destructive/50 bg-destructive/10 text-destructive hover:bg-destructive/20"
-              : "border-amber-500/40 bg-amber-500/10 text-amber-700 dark:text-amber-400 hover:bg-amber-500/20"
+              : "border-amber-500/40 bg-amber-500/10 text-amber-700 dark:text-amber-400 hover:bg-amber-500/20",
           )}
           data-testid="run-insight-count"
         >
@@ -1062,17 +1022,14 @@ function RecommendationRow({
           onClick={() => hasDetail && setExpanded((prev) => !prev)}
           data-testid="run-insight-headline"
         >
-          <span
-            className="min-w-0 flex-1 truncate text-xs font-medium"
-            title={headline}
-          >
+          <span className="min-w-0 flex-1 truncate text-xs font-medium" title={headline}>
             {headline}
           </span>
           {hasDetail ? (
             <ChevronRight
               className={cn(
                 "size-3.5 shrink-0 text-muted-foreground transition-transform",
-                isExpanded && "rotate-90"
+                isExpanded && "rotate-90",
               )}
               aria-hidden="true"
             />
@@ -1083,7 +1040,7 @@ function RecommendationRow({
             <span
               className={cn(
                 "rounded border px-1 py-0 text-[10px] font-medium",
-                chip.className
+                chip.className,
               )}
               data-testid="run-insight-status"
             >
@@ -1178,7 +1135,7 @@ export function RunInsightsChip({
 
   const activeCount = useMemo(
     () => countActivePatterns(signals, findings),
-    [signals, findings]
+    [signals, findings],
   );
 
   if (!signals) return null;
@@ -1188,9 +1145,7 @@ export function RunInsightsChip({
         className="inline-flex items-center rounded-md border border-border/50 bg-muted/25 px-2 py-0.5 text-xs text-muted-foreground"
         data-testid="run-insights-chip"
       >
-        {cohort === "window"
-          ? "Insights appear once sessions settle"
-          : "Analyzing…"}
+        {cohort === "window" ? "Insights appear once sessions settle" : "Analyzing…"}
       </span>
     );
   }
@@ -1208,7 +1163,7 @@ export function RunInsightsChip({
             "inline-flex items-center rounded-md border px-2 py-0.5 text-xs font-medium",
             activeCount > 0
               ? STATUS_CHIP.new.className
-              : "border-border/50 bg-muted/25 text-muted-foreground hover:bg-muted/50"
+              : "border-border/50 bg-muted/25 text-muted-foreground hover:bg-muted/50",
           )}
           data-testid="run-insights-chip"
         >
@@ -1321,7 +1276,7 @@ function InsightRow({
               "mt-[7px] size-1.5 shrink-0 rounded-full",
               isBlockingShaped(signal.detector)
                 ? "bg-red-500/70"
-                : "bg-amber-500/60"
+                : "bg-amber-500/60",
             )}
             aria-hidden="true"
           />
@@ -1332,7 +1287,7 @@ function InsightRow({
             <ChevronRight
               className={cn(
                 "mt-1 size-3 shrink-0 text-muted-foreground transition-transform",
-                isExpanded && "rotate-90"
+                isExpanded && "rotate-90",
               )}
               aria-hidden="true"
             />
@@ -1342,7 +1297,7 @@ function InsightRow({
           <span
             className={cn(
               "mt-0.5 shrink-0 rounded border px-1 py-0 text-[10px] font-medium",
-              chip.className
+              chip.className,
             )}
             data-testid="run-insight-status"
           >
@@ -1365,7 +1320,10 @@ function InsightRow({
       </div>
 
       {isExpanded ? (
-        <div className="mt-1 space-y-1 pl-3.5" data-testid="run-insight-detail">
+        <div
+          className="mt-1 space-y-1 pl-3.5"
+          data-testid="run-insight-detail"
+        >
           {insight?.rootCause ? (
             <p className="text-xs text-muted-foreground">
               <span className="font-medium text-foreground/80">Why: </span>
@@ -1525,7 +1483,7 @@ function SessionChip({
         "rounded border px-1.5 py-0.5 text-[11px] hover:bg-muted",
         subtle
           ? "border-border/50 text-muted-foreground"
-          : "border-border text-foreground/80"
+          : "border-border text-foreground/80",
       )}
       data-testid="run-insight-session-link"
     >

--- a/mcpjam-inspector/client/src/components/shared/usage-insights/run-insights.tsx
+++ b/mcpjam-inspector/client/src/components/shared/usage-insights/run-insights.tsx
@@ -141,8 +141,7 @@ const STATUS_CHIP: Record<string, { label: string; className: string }> = {
   },
   regressed: {
     label: "Regressed",
-    className:
-      "border-red-500/30 bg-red-500/10 text-red-700 dark:text-red-400",
+    className: "border-red-500/30 bg-red-500/10 text-red-700 dark:text-red-400",
   },
   resolved: {
     label: "Resolved",
@@ -164,7 +163,7 @@ export function signalFingerprint(candidate: {
 }): string {
   const clean = (value: string) => value.replace(/[:\n]/g, "_");
   return `${clean(candidate.detector)}:${clean(candidate.subjectKind)}:${clean(
-    candidate.subjectId,
+    candidate.subjectId
   )}`.slice(0, 200);
 }
 
@@ -175,7 +174,7 @@ export function signalFingerprint(candidate: {
  */
 export function signalSentence(
   c: RailSignalCandidate,
-  opts?: { cohort?: "run" | "window" },
+  opts?: { cohort?: "run" | "window" }
 ): string {
   // Relative detectors compare a slice against everything else measured. On a
   // swarm that population is "the run"; on a hosted surface it is the window
@@ -184,45 +183,90 @@ export function signalSentence(
   const rest = opts?.cohort === "window" ? "these sessions" : "the run";
   switch (c.detector) {
     case "tool_errors":
-      return `${c.subjectLabel} failed ${c.metric ?? c.affectedSessions}× across ${c.affectedSessions} of ${c.sliceTotal} sessions`;
+      return `${c.subjectLabel} failed ${
+        c.metric ?? c.affectedSessions
+      }× across ${c.affectedSessions} of ${c.sliceTotal} sessions`;
     case "hallucinated_tool":
       // "Agents" is swarm vocabulary; a hosted visitor talked to one
       // assistant, and never called it an agent.
       return opts?.cohort === "window"
-        ? `The assistant called a tool named "${c.subjectLabel}" that does not exist, in ${c.affectedSessions} ${plural(c.affectedSessions, "session")}`
-        : `Agents invented a tool named "${c.subjectLabel}" in ${c.affectedSessions} ${plural(c.affectedSessions, "session")}`;
+        ? `The assistant called a tool named "${
+            c.subjectLabel
+          }" that does not exist, in ${c.affectedSessions} ${plural(
+            c.affectedSessions,
+            "session"
+          )}`
+        : `Agents invented a tool named "${c.subjectLabel}" in ${
+            c.affectedSessions
+          } ${plural(c.affectedSessions, "session")}`;
     // ── User Testing detectors ──
     case "negative_feedback":
-      return `${c.affectedSessions} of ${c.sliceTotal} rated ${plural(c.sliceTotal, "session")} left negative feedback${c.subjectKind === "route" || c.subjectKind === "path" ? ` on ${c.subjectLabel}` : ""}`;
+      return `${c.affectedSessions} of ${c.sliceTotal} rated ${plural(
+        c.sliceTotal,
+        "session"
+      )} left negative feedback${
+        c.subjectKind === "route" || c.subjectKind === "path"
+          ? ` on ${c.subjectLabel}`
+          : ""
+      }`;
     case "cohort_struggles":
       return `${c.subjectLabel} visitors struggled in ${c.affectedSessions} of ${c.sliceTotal} sessions`;
     case "terminal_error_concentration":
-      return `${c.affectedSessions} of ${c.sliceTotal} sessions ended on a tool error${c.subjectKind === "route" || c.subjectKind === "path" ? ` in ${c.subjectLabel}` : ""}`;
+      return `${c.affectedSessions} of ${
+        c.sliceTotal
+      } sessions ended on a tool error${
+        c.subjectKind === "route" || c.subjectKind === "path"
+          ? ` in ${c.subjectLabel}`
+          : ""
+      }`;
     case "criterion_fail":
       return `"${c.subjectLabel}" failed in ${c.affectedSessions} of ${c.sliceTotal} graded sessions`;
     case "target_failures":
-      return `Failures concentrate on ${c.subjectLabel} (${c.affectedSessions} of ${c.sliceTotal})`;
+      // UNITS ARE SESSIONS. The detector used to have a second fire path off
+      // launch attempts, where this pair counted attempts and the bare
+      // "(1 of 2)" read as sessions. That path is gone (launch outcomes are
+      // reported as target health, never mined), so the noun is stated.
+      return `Tool errors concentrate on ${c.subjectLabel} in ${
+        c.affectedSessions
+      } of ${c.sliceTotal} ${plural(c.sliceTotal, "session")}`;
     case "persona_struggles":
       return `${c.subjectLabel} struggled in ${c.affectedSessions} of ${c.sliceTotal} sessions`;
     case "marginal_pass":
-      return `${c.affectedSessions} ${plural(c.affectedSessions, "pass", "passes")} in "${c.subjectLabel}" barely cleared the judge threshold`;
+      return `${c.affectedSessions} ${plural(
+        c.affectedSessions,
+        "pass",
+        "passes"
+      )} in "${c.subjectLabel}" barely cleared the judge threshold`;
     case "turn_cap_grind":
-      return `${c.affectedSessions} ${plural(c.affectedSessions, "session")} in "${c.subjectLabel}" ran out the ${c.metric ?? "max"}-turn budget`;
+      return `${c.affectedSessions} ${plural(
+        c.affectedSessions,
+        "session"
+      )} in "${c.subjectLabel}" ran out the ${c.metric ?? "max"}-turn budget`;
     case "error_recovered_pass":
-      return `${c.affectedSessions} passing ${plural(c.affectedSessions, "session")} in "${c.subjectLabel}" recovered from tool errors first`;
+      return `${c.affectedSessions} passing ${plural(
+        c.affectedSessions,
+        "session"
+      )} in "${c.subjectLabel}" recovered from tool errors first`;
     case "token_outlier":
-      return `"${c.subjectLabel}" uses ~${ratioLabel(c)} the tokens of the rest of ${rest}`;
+      return `"${c.subjectLabel}" uses ~${ratioLabel(
+        c
+      )} the tokens of the rest of ${rest}`;
     case "latency_outlier":
-      return `${c.subjectLabel} p95 latency is ${ratioLabel(c)} the rest of ${rest}`;
+      return `${c.subjectLabel} p95 latency is ${ratioLabel(
+        c
+      )} the rest of ${rest}`;
     case "no_tools_used":
-      return `${c.affectedSessions} ${plural(c.affectedSessions, "session")} in "${c.subjectLabel}" never called a tool`;
+      return `${c.affectedSessions} ${plural(
+        c.affectedSessions,
+        "session"
+      )} in "${c.subjectLabel}" never called a tool`;
     default:
       return `${c.subjectLabel}: ${c.affectedSessions} of ${c.sliceTotal} sessions`;
   }
 }
 
 function plural(n: number, singular: string, pluralForm?: string): string {
-  return n === 1 ? singular : (pluralForm ?? `${singular}s`);
+  return n === 1 ? singular : pluralForm ?? `${singular}s`;
 }
 
 function ratioLabel(c: RailSignalCandidate): string {
@@ -239,6 +283,29 @@ function ratioLabel(c: RailSignalCandidate): string {
 /** Hallucinated tools and failing criteria are the load-bearing problems. */
 function isBlockingShaped(detector: string): boolean {
   return detector === "hallucinated_tool" || detector === "criterion_fail";
+}
+
+/**
+ * A row may open into Why/Fix ONLY when it names a session that exhibits the
+ * anomaly.
+ *
+ * Cause and recommendation are the model's words. Behind an expander with no
+ * failing session to open, they are an unfalsifiable claim: the reader cannot
+ * check them, and the row's authority comes entirely from the confident prose.
+ * A contrast ("Clean 1") does not count — it proves the anomaly did NOT happen
+ * somewhere, which points at nothing to look at.
+ *
+ * The backend now enforces the same rule at both ends (`isGroundedCandidate`
+ * in the miners, `partitionByLoadedEvidence` before narration). This is the
+ * client's own check, not a mirror of theirs: an older server, a cached
+ * payload, or a future detector can still hand this component a row without
+ * exemplars, and it must degrade to the deterministic sentence rather than
+ * offer prose it cannot back.
+ */
+function canExpand(
+  signal: Pick<RailSignalCandidate, "exemplarSessionIds">
+): boolean {
+  return signal.exemplarSessionIds.length > 0;
 }
 
 type Row = {
@@ -269,20 +336,20 @@ function useRailData(surface: RunInsightsSurface): {
           projectId: surface.projectId,
           swarmRunGroupId: surface.swarmRunGroupId,
         }
-      : "skip") as any,
+      : "skip") as any
   ) as SwarmWaveSignals | null | undefined;
   const swarmFindings = useQuery(
     SWARM_QUERIES.listSwarmFindings as any,
-    (isSwarm ? { projectId: surface.projectId } : "skip") as any,
+    (isSwarm ? { projectId: surface.projectId } : "skip") as any
   ) as SwarmFinding[] | undefined;
 
   const windowSignals = useQuery(
     CHATBOX_INSIGHTS_QUERIES.getWindowSignals as any,
-    (isSwarm ? "skip" : { chatboxId: surface.chatboxId }) as any,
+    (isSwarm ? "skip" : { chatboxId: surface.chatboxId }) as any
   ) as ChatboxWindowSignals | null | undefined;
   const windowFindings = useQuery(
     CHATBOX_INSIGHTS_QUERIES.listChatboxFindings as any,
-    (isSwarm ? "skip" : { chatboxId: surface.chatboxId }) as any,
+    (isSwarm ? "skip" : { chatboxId: surface.chatboxId }) as any
   ) as ChatboxFinding[] | undefined;
 
   if (isSwarm) {
@@ -342,7 +409,7 @@ function useRailData(surface: RunInsightsSurface): {
  */
 function useNarrationScope(
   surface: RunInsightsSurface,
-  latestGroupId: string | null | undefined,
+  latestGroupId: string | null | undefined
 ): RunInsightsScope | null {
   return useMemo<RunInsightsScope | null>(() => {
     if (surface.kind === "swarm") {
@@ -353,7 +420,11 @@ function useNarrationScope(
       };
     }
     return latestGroupId
-      ? { kind: "chatbox", chatboxId: surface.chatboxId, groupId: latestGroupId }
+      ? {
+          kind: "chatbox",
+          chatboxId: surface.chatboxId,
+          groupId: latestGroupId,
+        }
       : null;
   }, [surface, latestGroupId]);
 }
@@ -397,7 +468,7 @@ function RunInsightsBody({
   const rows: Row[] = useMemo(() => {
     if (!signals) return [];
     const insightBy = new Map(
-      (insights?.candidates ?? []).map((c) => [c.fingerprint, c]),
+      (insights?.candidates ?? []).map((c) => [c.fingerprint, c])
     );
     const findingBy = new Map((findings ?? []).map((f) => [f.fingerprint, f]));
     return signals.candidates.map((signal) => {
@@ -572,7 +643,7 @@ function RunInsightsBody({
 function useRail(
   surface: RunInsightsSurface,
   canRequestProp: boolean,
-  canDismissProp: boolean,
+  canDismissProp: boolean
 ): {
   rail: ReturnType<typeof useRailData>;
   lifecycle: UseRunInsightsResult;
@@ -608,7 +679,7 @@ function useRunInsightsRail(): RunInsightsRailContextValue {
   const ctx = useContext(RunInsightsRailContext);
   if (!ctx) {
     throw new Error(
-      "RunInsightsBanner / RunInsightsRecommendations require RunInsightsProvider",
+      "RunInsightsBanner / RunInsightsRecommendations require RunInsightsProvider"
     );
   }
   return ctx;
@@ -633,9 +704,7 @@ export function RunInsightsProvider({
 }) {
   const railState = useRail(surface, canRequest, canDismiss);
   return (
-    <RunInsightsRailContext.Provider
-      value={{ ...railState, onOpenSession }}
-    >
+    <RunInsightsRailContext.Provider value={{ ...railState, onOpenSession }}>
       {children}
     </RunInsightsRailContext.Provider>
   );
@@ -643,13 +712,13 @@ export function RunInsightsProvider({
 
 function buildInsightRows(
   rail: ReturnType<typeof useRailData>,
-  lifecycle: UseRunInsightsResult,
+  lifecycle: UseRunInsightsResult
 ): Row[] {
   const { signals, findings } = rail;
   const { insights } = lifecycle;
   if (!signals) return [];
   const insightBy = new Map(
-    (insights?.candidates ?? []).map((c) => [c.fingerprint, c]),
+    (insights?.candidates ?? []).map((c) => [c.fingerprint, c])
   );
   const findingBy = new Map((findings ?? []).map((f) => [f.fingerprint, f]));
   return signals.candidates.map((signal) => {
@@ -700,11 +769,11 @@ export function RunInsights({
 
 function countActivePatterns(
   signals: RailSignals | null | undefined,
-  findings: RailFinding[] | undefined,
+  findings: RailFinding[] | undefined
 ): number {
   if (!signals || !findings) return 0;
   const findingByFingerprint = new Map(
-    findings.map((finding) => [finding.fingerprint, finding]),
+    findings.map((finding) => [finding.fingerprint, finding])
   );
   return signals.candidates.reduce((count, candidate) => {
     const finding = findingByFingerprint.get(signalFingerprint(candidate));
@@ -718,17 +787,13 @@ function countActivePatterns(
  * {@link RunInsightsRecommendations} beside the scorecard.
  */
 export function RunInsightsBanner() {
-  const {
-    rail,
-    lifecycle,
-    canRequest: mayRequest,
-  } = useRunInsightsRail();
+  const { rail, lifecycle, canRequest: mayRequest } = useRunInsightsRail();
   const { signals, findings, cohort } = rail;
   const { insights, busy, unavailable, error, request } = lifecycle;
 
   const activeCount = useMemo(
     () => countActivePatterns(signals, findings),
-    [signals, findings],
+    [signals, findings]
   );
 
   if (!signals) return null;
@@ -816,7 +881,7 @@ export function RunInsightsRecommendations() {
 
   const rows = useMemo(
     () => buildInsightRows(rail, lifecycle),
-    [rail, lifecycle],
+    [rail, lifecycle]
   );
   const [showAll, setShowAll] = useState(false);
 
@@ -850,7 +915,9 @@ export function RunInsightsRecommendations() {
       data-testid="run-insights-recommendations"
     >
       <div className="mb-2.5 flex flex-wrap items-baseline gap-x-2 gap-y-0.5">
-        <h3 className="text-sm font-semibold tracking-tight">Recommendations</h3>
+        <h3 className="text-sm font-semibold tracking-tight">
+          Recommendations
+        </h3>
         <span className="text-xs text-muted-foreground">
           Patterns to investigate across sessions
         </span>
@@ -944,12 +1011,15 @@ function RecommendationRow({
   const chip = finding ? STATUS_CHIP[finding.status] : undefined;
   const affected = signal.affectedSessions;
   const headline = signalSentence(signal, { cohort });
-  const hasDetail = Boolean(
-    insight?.rootCause ||
-      insight?.recommendation ||
-      signal.exemplarSessionIds.length ||
-      signal.contrastSessionIds.length,
-  );
+  // Gated on a failing exemplar — see `canExpand`. Prose and contrast links
+  // are never enough on their own.
+  const hasDetail =
+    canExpand(signal) &&
+    Boolean(
+      insight?.rootCause ||
+        insight?.recommendation ||
+        signal.exemplarSessionIds.length
+    );
 
   const toggleDismiss = () => {
     if (!finding) return;
@@ -980,7 +1050,7 @@ function RecommendationRow({
             "disabled:cursor-default",
             isBlockingShaped(signal.detector)
               ? "border-destructive/50 bg-destructive/10 text-destructive hover:bg-destructive/20"
-              : "border-amber-500/40 bg-amber-500/10 text-amber-700 dark:text-amber-400 hover:bg-amber-500/20",
+              : "border-amber-500/40 bg-amber-500/10 text-amber-700 dark:text-amber-400 hover:bg-amber-500/20"
           )}
           data-testid="run-insight-count"
         >
@@ -992,14 +1062,17 @@ function RecommendationRow({
           onClick={() => hasDetail && setExpanded((prev) => !prev)}
           data-testid="run-insight-headline"
         >
-          <span className="min-w-0 flex-1 truncate text-xs font-medium" title={headline}>
+          <span
+            className="min-w-0 flex-1 truncate text-xs font-medium"
+            title={headline}
+          >
             {headline}
           </span>
           {hasDetail ? (
             <ChevronRight
               className={cn(
                 "size-3.5 shrink-0 text-muted-foreground transition-transform",
-                expanded && "rotate-90",
+                expanded && "rotate-90"
               )}
               aria-hidden="true"
             />
@@ -1010,7 +1083,7 @@ function RecommendationRow({
             <span
               className={cn(
                 "rounded border px-1 py-0 text-[10px] font-medium",
-                chip.className,
+                chip.className
               )}
               data-testid="run-insight-status"
             >
@@ -1057,14 +1130,19 @@ function RecommendationRow({
                 onClick={() => onOpenSession(sessionId)}
               />
             ))}
-            {signal.contrastSessionIds.map((sessionId, i) => (
-              <SessionChip
-                key={sessionId}
-                label={`Clean ${i + 1}`}
-                onClick={() => onOpenSession(sessionId)}
-                subtle
-              />
-            ))}
+            {/* Contrast chips ride ALONGSIDE failing ones, never alone. A
+                lone "Clean 1" reads as evidence for a claim while pointing at
+                a session where the problem did not happen. */}
+            {signal.exemplarSessionIds.length > 0
+              ? signal.contrastSessionIds.map((sessionId, i) => (
+                  <SessionChip
+                    key={sessionId}
+                    label={`Clean ${i + 1}`}
+                    onClick={() => onOpenSession(sessionId)}
+                    subtle
+                  />
+                ))
+              : null}
           </div>
         </div>
       ) : null}
@@ -1100,7 +1178,7 @@ export function RunInsightsChip({
 
   const activeCount = useMemo(
     () => countActivePatterns(signals, findings),
-    [signals, findings],
+    [signals, findings]
   );
 
   if (!signals) return null;
@@ -1110,7 +1188,9 @@ export function RunInsightsChip({
         className="inline-flex items-center rounded-md border border-border/50 bg-muted/25 px-2 py-0.5 text-xs text-muted-foreground"
         data-testid="run-insights-chip"
       >
-        {cohort === "window" ? "Insights appear once sessions settle" : "Analyzing…"}
+        {cohort === "window"
+          ? "Insights appear once sessions settle"
+          : "Analyzing…"}
       </span>
     );
   }
@@ -1128,7 +1208,7 @@ export function RunInsightsChip({
             "inline-flex items-center rounded-md border px-2 py-0.5 text-xs font-medium",
             activeCount > 0
               ? STATUS_CHIP.new.className
-              : "border-border/50 bg-muted/25 text-muted-foreground hover:bg-muted/50",
+              : "border-border/50 bg-muted/25 text-muted-foreground hover:bg-muted/50"
           )}
           data-testid="run-insights-chip"
         >
@@ -1202,12 +1282,15 @@ function InsightRow({
   const dismissed =
     dismissedOptimistic ?? Boolean(finding && finding.dismissedAt !== null);
   const chip = finding ? STATUS_CHIP[finding.status] : undefined;
-  const hasDetail = Boolean(
-    insight?.rootCause ||
-      insight?.recommendation ||
-      signal.exemplarSessionIds.length ||
-      signal.contrastSessionIds.length,
-  );
+  // Gated on a failing exemplar — see `canExpand`. Prose and contrast links
+  // are never enough on their own.
+  const hasDetail =
+    canExpand(signal) &&
+    Boolean(
+      insight?.rootCause ||
+        insight?.recommendation ||
+        signal.exemplarSessionIds.length
+    );
 
   const toggleDismiss = () => {
     if (!finding) return;
@@ -1238,7 +1321,7 @@ function InsightRow({
               "mt-[7px] size-1.5 shrink-0 rounded-full",
               isBlockingShaped(signal.detector)
                 ? "bg-red-500/70"
-                : "bg-amber-500/60",
+                : "bg-amber-500/60"
             )}
             aria-hidden="true"
           />
@@ -1249,7 +1332,7 @@ function InsightRow({
             <ChevronRight
               className={cn(
                 "mt-1 size-3 shrink-0 text-muted-foreground transition-transform",
-                expanded && "rotate-90",
+                expanded && "rotate-90"
               )}
               aria-hidden="true"
             />
@@ -1259,7 +1342,7 @@ function InsightRow({
           <span
             className={cn(
               "mt-0.5 shrink-0 rounded border px-1 py-0 text-[10px] font-medium",
-              chip.className,
+              chip.className
             )}
             data-testid="run-insight-status"
           >
@@ -1282,10 +1365,7 @@ function InsightRow({
       </div>
 
       {expanded ? (
-        <div
-          className="mt-1 space-y-1 pl-3.5"
-          data-testid="run-insight-detail"
-        >
+        <div className="mt-1 space-y-1 pl-3.5" data-testid="run-insight-detail">
           {insight?.rootCause ? (
             <p className="text-xs text-muted-foreground">
               <span className="font-medium text-foreground/80">Why: </span>
@@ -1306,14 +1386,19 @@ function InsightRow({
                 onClick={() => onOpenSession(sessionId)}
               />
             ))}
-            {signal.contrastSessionIds.map((sessionId, i) => (
-              <SessionChip
-                key={sessionId}
-                label={`Clean ${i + 1}`}
-                onClick={() => onOpenSession(sessionId)}
-                subtle
-              />
-            ))}
+            {/* Contrast chips ride ALONGSIDE failing ones, never alone. A
+                lone "Clean 1" reads as evidence for a claim while pointing at
+                a session where the problem did not happen. */}
+            {signal.exemplarSessionIds.length > 0
+              ? signal.contrastSessionIds.map((sessionId, i) => (
+                  <SessionChip
+                    key={sessionId}
+                    label={`Clean ${i + 1}`}
+                    onClick={() => onOpenSession(sessionId)}
+                    subtle
+                  />
+                ))
+              : null}
           </div>
         </div>
       ) : null}
@@ -1440,7 +1525,7 @@ function SessionChip({
         "rounded border px-1.5 py-0.5 text-[11px] hover:bg-muted",
         subtle
           ? "border-border/50 text-muted-foreground"
-          : "border-border text-foreground/80",
+          : "border-border text-foreground/80"
       )}
       data-testid="run-insight-session-link"
     >

--- a/mcpjam-inspector/client/src/components/shared/usage-insights/run-insights.tsx
+++ b/mcpjam-inspector/client/src/components/shared/usage-insights/run-insights.tsx
@@ -1020,6 +1020,7 @@ function RecommendationRow({
           type="button"
           className="flex min-w-0 flex-1 items-center gap-1.5 text-left"
           onClick={() => hasDetail && setExpanded((prev) => !prev)}
+          aria-expanded={isExpanded}
           data-testid="run-insight-headline"
         >
           <span className="min-w-0 flex-1 truncate text-xs font-medium" title={headline}>

--- a/mcpjam-inspector/client/src/components/shared/usage-insights/run-insights.tsx
+++ b/mcpjam-inspector/client/src/components/shared/usage-insights/run-insights.tsx
@@ -1269,6 +1269,7 @@ function InsightRow({
           type="button"
           className="flex min-w-0 flex-1 items-start gap-1.5 text-left"
           onClick={() => hasDetail && setExpanded((prev) => !prev)}
+          aria-expanded={isExpanded}
           data-testid="run-insight-headline"
         >
           <span

--- a/mcpjam-inspector/client/src/components/shared/usage-insights/run-insights.tsx
+++ b/mcpjam-inspector/client/src/components/shared/usage-insights/run-insights.tsx
@@ -1003,7 +1003,7 @@ function RecommendationRow({
           type="button"
           onClick={() => hasDetail && setExpanded((prev) => !prev)}
           disabled={!hasDetail}
-          aria-expanded={isExpanded}
+          aria-expanded={hasDetail ? isExpanded : undefined}
           aria-label={headline}
           className={cn(
             "flex h-6 min-w-7 shrink-0 items-center justify-center rounded border px-1 font-mono text-xs font-semibold tabular-nums transition-colors",
@@ -1020,7 +1020,7 @@ function RecommendationRow({
           type="button"
           className="flex min-w-0 flex-1 items-center gap-1.5 text-left"
           onClick={() => hasDetail && setExpanded((prev) => !prev)}
-          aria-expanded={isExpanded}
+          aria-expanded={hasDetail ? isExpanded : undefined}
           data-testid="run-insight-headline"
         >
           <span className="min-w-0 flex-1 truncate text-xs font-medium" title={headline}>
@@ -1270,7 +1270,7 @@ function InsightRow({
           type="button"
           className="flex min-w-0 flex-1 items-start gap-1.5 text-left"
           onClick={() => hasDetail && setExpanded((prev) => !prev)}
-          aria-expanded={isExpanded}
+          aria-expanded={hasDetail ? isExpanded : undefined}
           data-testid="run-insight-headline"
         >
           <span

--- a/mcpjam-inspector/client/src/components/shared/usage-insights/run-insights.tsx
+++ b/mcpjam-inspector/client/src/components/shared/usage-insights/run-insights.tsx
@@ -1011,15 +1011,15 @@ function RecommendationRow({
   const chip = finding ? STATUS_CHIP[finding.status] : undefined;
   const affected = signal.affectedSessions;
   const headline = signalSentence(signal, { cohort });
-  // Gated on a failing exemplar — see `canExpand`. Prose and contrast links
-  // are never enough on their own.
-  const hasDetail =
-    canExpand(signal) &&
-    Boolean(
-      insight?.rootCause ||
-        insight?.recommendation ||
-        signal.exemplarSessionIds.length
-    );
+  // Gated on a failing exemplar and nothing else — see `canExpand`. An
+  // exemplar alone is worth opening for (the session chips are the point);
+  // prose without one is not.
+  const hasDetail = canExpand(signal);
+  // Evidence can disappear under an OPEN row: signals are a live subscription,
+  // and a refresh that drops the exemplars would otherwise leave the model's
+  // prose on screen with nothing behind it. Derived, not stored, so the row
+  // closes the moment it stops qualifying.
+  const isExpanded = hasDetail && expanded;
 
   const toggleDismiss = () => {
     if (!finding) return;
@@ -1043,7 +1043,7 @@ function RecommendationRow({
           type="button"
           onClick={() => hasDetail && setExpanded((prev) => !prev)}
           disabled={!hasDetail}
-          aria-expanded={expanded}
+          aria-expanded={isExpanded}
           aria-label={headline}
           className={cn(
             "flex h-6 min-w-7 shrink-0 items-center justify-center rounded border px-1 font-mono text-xs font-semibold tabular-nums transition-colors",
@@ -1072,7 +1072,7 @@ function RecommendationRow({
             <ChevronRight
               className={cn(
                 "size-3.5 shrink-0 text-muted-foreground transition-transform",
-                expanded && "rotate-90"
+                isExpanded && "rotate-90"
               )}
               aria-hidden="true"
             />
@@ -1105,7 +1105,7 @@ function RecommendationRow({
           ) : null}
         </div>
       </div>
-      {expanded ? (
+      {isExpanded ? (
         <div
           className="space-y-1 border-t border-border/40 bg-muted/20 px-3 py-2 pl-12"
           data-testid="run-insight-detail"
@@ -1282,15 +1282,15 @@ function InsightRow({
   const dismissed =
     dismissedOptimistic ?? Boolean(finding && finding.dismissedAt !== null);
   const chip = finding ? STATUS_CHIP[finding.status] : undefined;
-  // Gated on a failing exemplar — see `canExpand`. Prose and contrast links
-  // are never enough on their own.
-  const hasDetail =
-    canExpand(signal) &&
-    Boolean(
-      insight?.rootCause ||
-        insight?.recommendation ||
-        signal.exemplarSessionIds.length
-    );
+  // Gated on a failing exemplar and nothing else — see `canExpand`. An
+  // exemplar alone is worth opening for (the session chips are the point);
+  // prose without one is not.
+  const hasDetail = canExpand(signal);
+  // Evidence can disappear under an OPEN row: signals are a live subscription,
+  // and a refresh that drops the exemplars would otherwise leave the model's
+  // prose on screen with nothing behind it. Derived, not stored, so the row
+  // closes the moment it stops qualifying.
+  const isExpanded = hasDetail && expanded;
 
   const toggleDismiss = () => {
     if (!finding) return;
@@ -1332,7 +1332,7 @@ function InsightRow({
             <ChevronRight
               className={cn(
                 "mt-1 size-3 shrink-0 text-muted-foreground transition-transform",
-                expanded && "rotate-90"
+                isExpanded && "rotate-90"
               )}
               aria-hidden="true"
             />
@@ -1364,7 +1364,7 @@ function InsightRow({
         ) : null}
       </div>
 
-      {expanded ? (
+      {isExpanded ? (
         <div className="mt-1 space-y-1 pl-3.5" data-testid="run-insight-detail">
           {insight?.rootCause ? (
             <p className="text-xs text-muted-foreground">

--- a/mcpjam-inspector/client/src/components/swarms/__tests__/swarm-target-health-strip.test.tsx
+++ b/mcpjam-inspector/client/src/components/swarms/__tests__/swarm-target-health-strip.test.tsx
@@ -47,52 +47,6 @@ describe("SwarmTargetHealthStrip", () => {
     );
   });
 
-  it("humanizes the stored refusal instead of printing it raw", () => {
-    render(
-      <SwarmTargetHealthStrip
-        targetHealth={[
-          health({
-            errorMessage:
-              "swarm-agent https://agent.example failed (429): rate limit exceeded",
-          }),
-        ]}
-        terminal
-      />
-    );
-    const reason = screen.getByTestId("swarm-target-health-reason");
-    expect(reason).not.toHaveTextContent("swarm-agent https://agent.example");
-    expect(reason.textContent ?? "").not.toBe("");
-  });
-
-  it("renders a reason from a RECOGNIZED code with no stored message", () => {
-    render(
-      <SwarmTargetHealthStrip
-        targetHealth={[health({ errorCode: "sandbox_at_capacity" })]}
-        terminal
-      />
-    );
-    expect(screen.getByTestId("swarm-target-health-reason")).toHaveTextContent(
-      /at capacity/i
-    );
-  });
-
-  it("shows no reason rather than a non-answer beside the chips", () => {
-    // An unrecognized code with no message humanizes to "The session failed
-    // for an unknown reason" — printed next to a "1 rate limited" chip that
-    // just said what happened, it reads as a contradiction. The chips carry
-    // the outcome; a sentence that adds nothing is worse than no sentence.
-    render(
-      <SwarmTargetHealthStrip
-        targetHealth={[health({ errorCode: "some_unmapped_code" })]}
-        terminal
-      />
-    );
-    expect(screen.getByTestId("swarm-target-health-row")).toBeInTheDocument();
-    expect(
-      screen.queryByTestId("swarm-target-health-reason")
-    ).not.toBeInTheDocument();
-  });
-
   it("stays silent while the wave is still running", () => {
     // Mid-run counts move: an attempt about to be retried reads as a failure
     // until it isn't, and an outage banner over a healthy run is worse than

--- a/mcpjam-inspector/client/src/components/swarms/__tests__/swarm-target-health-strip.test.tsx
+++ b/mcpjam-inspector/client/src/components/swarms/__tests__/swarm-target-health-strip.test.tsx
@@ -1,0 +1,130 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+
+import type { SwarmWaveTargetHealth } from "@/lib/swarm-api";
+import { SwarmTargetHealthStrip } from "../swarm-target-health-strip";
+
+/**
+ * Launch outcomes are REPORTED, never mined.
+ *
+ * A target that never reached a session used to become a `target_failures`
+ * finding: a confident "your MCP server is broken" row with no session to
+ * open behind it. The miner now emits those outcomes as `targetHealth` and
+ * this strip is where they land — beside the findings, never among them.
+ */
+
+function health(
+  overrides: Partial<SwarmWaveTargetHealth> = {}
+): SwarmWaveTargetHealth {
+  return {
+    subjectKind: "environment",
+    subjectId: "env-1",
+    subjectLabel: "Prod stack",
+    attempted: 4,
+    succeeded: 1,
+    failed: 2,
+    rateLimited: 1,
+    ...overrides,
+  };
+}
+
+describe("SwarmTargetHealthStrip", () => {
+  it("keeps rate limited apart from failed", () => {
+    // Summing them made every throttled wave read as an outage.
+    render(<SwarmTargetHealthStrip targetHealth={[health()]} terminal />);
+    expect(screen.getByTestId("swarm-target-health-failed")).toHaveTextContent(
+      "2 failed"
+    );
+    expect(
+      screen.getByTestId("swarm-target-health-rate-limited")
+    ).toHaveTextContent("1 rate limited");
+  });
+
+  it("says these are launch outcomes, not a finding about the server", () => {
+    render(<SwarmTargetHealthStrip targetHealth={[health()]} terminal />);
+    expect(screen.getByTestId("swarm-target-health")).toHaveTextContent(
+      /not a finding about the server/i
+    );
+  });
+
+  it("humanizes the stored refusal instead of printing it raw", () => {
+    render(
+      <SwarmTargetHealthStrip
+        targetHealth={[
+          health({
+            errorMessage:
+              "swarm-agent https://agent.example failed (429): rate limit exceeded",
+          }),
+        ]}
+        terminal
+      />
+    );
+    const reason = screen.getByTestId("swarm-target-health-reason");
+    expect(reason).not.toHaveTextContent("swarm-agent https://agent.example");
+    expect(reason.textContent ?? "").not.toBe("");
+  });
+
+  it("renders a reason from a structured code with no stored message", () => {
+    render(
+      <SwarmTargetHealthStrip
+        targetHealth={[health({ errorCode: "spend_cap_exceeded" })]}
+        terminal
+      />
+    );
+    expect(
+      screen.getByTestId("swarm-target-health-reason")
+    ).toBeInTheDocument();
+  });
+
+  it("stays silent while the wave is still running", () => {
+    // Mid-run counts move: an attempt about to be retried reads as a failure
+    // until it isn't, and an outage banner over a healthy run is worse than
+    // no banner.
+    const { container } = render(
+      <SwarmTargetHealthStrip targetHealth={[health()]} terminal={false} />
+    );
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it("stays silent when every launch succeeded", () => {
+    const { container } = render(
+      <SwarmTargetHealthStrip
+        targetHealth={[
+          health({ attempted: 3, succeeded: 3, failed: 0, rateLimited: 0 }),
+        ]}
+        terminal
+      />
+    );
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it("tolerates a server deployed before the field existed", () => {
+    const { container } = render(
+      <SwarmTargetHealthStrip targetHealth={undefined} terminal />
+    );
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it("lists one row per troubled target, hiding the healthy ones", () => {
+    render(
+      <SwarmTargetHealthStrip
+        targetHealth={[
+          health(),
+          health({
+            subjectKind: "host",
+            subjectId: "h-2",
+            subjectLabel: "Cursor",
+            attempted: 2,
+            succeeded: 2,
+            failed: 0,
+            rateLimited: 0,
+          }),
+        ]}
+        terminal
+      />
+    );
+    const rows = screen.getAllByTestId("swarm-target-health-row");
+    expect(rows).toHaveLength(1);
+    expect(rows[0]).toHaveAttribute("data-subject-id", "env-1");
+  });
+});

--- a/mcpjam-inspector/client/src/components/swarms/__tests__/swarm-target-health-strip.test.tsx
+++ b/mcpjam-inspector/client/src/components/swarms/__tests__/swarm-target-health-strip.test.tsx
@@ -64,16 +64,33 @@ describe("SwarmTargetHealthStrip", () => {
     expect(reason.textContent ?? "").not.toBe("");
   });
 
-  it("renders a reason from a structured code with no stored message", () => {
+  it("renders a reason from a RECOGNIZED code with no stored message", () => {
     render(
       <SwarmTargetHealthStrip
-        targetHealth={[health({ errorCode: "spend_cap_exceeded" })]}
+        targetHealth={[health({ errorCode: "sandbox_at_capacity" })]}
         terminal
       />
     );
+    expect(screen.getByTestId("swarm-target-health-reason")).toHaveTextContent(
+      /at capacity/i
+    );
+  });
+
+  it("shows no reason rather than a non-answer beside the chips", () => {
+    // An unrecognized code with no message humanizes to "The session failed
+    // for an unknown reason" — printed next to a "1 rate limited" chip that
+    // just said what happened, it reads as a contradiction. The chips carry
+    // the outcome; a sentence that adds nothing is worse than no sentence.
+    render(
+      <SwarmTargetHealthStrip
+        targetHealth={[health({ errorCode: "some_unmapped_code" })]}
+        terminal
+      />
+    );
+    expect(screen.getByTestId("swarm-target-health-row")).toBeInTheDocument();
     expect(
-      screen.getByTestId("swarm-target-health-reason")
-    ).toBeInTheDocument();
+      screen.queryByTestId("swarm-target-health-reason")
+    ).not.toBeInTheDocument();
   });
 
   it("stays silent while the wave is still running", () => {
@@ -101,6 +118,13 @@ describe("SwarmTargetHealthStrip", () => {
   it("tolerates a server deployed before the field existed", () => {
     const { container } = render(
       <SwarmTargetHealthStrip targetHealth={undefined} terminal />
+    );
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it("stays silent when target health is present but empty", () => {
+    const { container } = render(
+      <SwarmTargetHealthStrip targetHealth={[]} terminal />
     );
     expect(container).toBeEmptyDOMElement();
   });

--- a/mcpjam-inspector/client/src/components/swarms/swarm-run-detail.tsx
+++ b/mcpjam-inspector/client/src/components/swarms/swarm-run-detail.tsx
@@ -99,7 +99,7 @@ export function SwarmRunDetail({
       if (sessionParam) search.set("session", sessionParam);
       const query = search.toString();
       return query ? `?${query}` : "";
-    })()
+    })(),
   );
   const urlSelection = useMemo(() => parseSelectionParam(selParam), [selParam]);
   const [sessionsPersonaFilter, setSessionsPersonaFilter] = useState<
@@ -140,10 +140,10 @@ export function SwarmRunDetail({
           tab: next,
           sel: selParam ?? undefined,
         }),
-        { replace: true }
+        { replace: true },
       );
     },
-    [navigate, selParam, swarmId]
+    [navigate, selParam, swarmId],
   );
 
   const handleShare = useCallback(async () => {
@@ -167,10 +167,10 @@ export function SwarmRunDetail({
           tab: "sessions",
           session: sessionId,
           sel: selParam ?? undefined,
-        })
+        }),
       );
     },
-    [navigate, selParam, swarmId]
+    [navigate, selParam, swarmId],
   );
 
   /**
@@ -183,31 +183,31 @@ export function SwarmRunDetail({
       buildSwarmPath(swarmId, {
         tab,
         sel: selParam ?? undefined,
-      })
+      }),
     );
   }, [navigate, selParam, swarmId, tab]);
 
   const handleSelectionChange = useCallback(
-    (
-      themes: ReadonlyArray<Pick<ThemeRef, "dimension" | "clusterId">> | null
-    ) => {
+    (themes: ReadonlyArray<Pick<ThemeRef, "dimension" | "clusterId">> | null) => {
       navigate(
         buildSwarmPath(swarmId, {
           tab,
           session: sessionParam ?? undefined,
           sel: themes ? serializeSelectionParam(themes) : undefined,
         }),
-        { replace: true }
+        { replace: true },
       );
     },
-    [navigate, sessionParam, swarmId, tab]
+    [navigate, sessionParam, swarmId, tab],
   );
 
   const launchableJourneyIds = useMemo(() => {
     if (!wave) return [];
     return [
       ...new Set(
-        wave.runs.filter((r) => !r.journeyArchived).map((r) => r.journeyRefId)
+        wave.runs
+          .filter((r) => !r.journeyArchived)
+          .map((r) => r.journeyRefId)
       ),
     ];
   }, [wave]);
@@ -271,7 +271,9 @@ export function SwarmRunDetail({
       ? Math.min(100, Math.round((live.done / live.total) * 100))
       : 0;
   const runIds = wave.runs.map((r) => r.runId);
-  const runLabels = new Map(wave.runs.map((r) => [r.runId, r.journeyName]));
+  const runLabels = new Map(
+    wave.runs.map((r) => [r.runId, r.journeyName])
+  );
   const goalLabels = new Map(
     wave.runs.map((r) => [r.journeyRefId, r.journeyName])
   );
@@ -511,8 +513,7 @@ function DetailPersonasChip({
     for (const run of wave.runs) {
       const existing = byName.get(run.personaName);
       if (existing) existing.journeyCount += 1;
-      else
-        byName.set(run.personaName, { name: run.personaName, journeyCount: 1 });
+      else byName.set(run.personaName, { name: run.personaName, journeyCount: 1 });
     }
     return [...byName.values()].sort((a, b) => a.name.localeCompare(b.name));
   }, [wave.runs]);
@@ -525,14 +526,15 @@ function DetailPersonasChip({
         <button
           type="button"
           className="inline-flex items-center gap-1 rounded-md border border-border/50 bg-muted/25 px-2 py-0.5 text-xs font-medium text-foreground/90 transition-colors hover:bg-muted/50 hover:text-foreground"
-          aria-label={`${rows.length} ${
-            rows.length === 1 ? "persona" : "personas"
-          }`}
+          aria-label={`${rows.length} ${rows.length === 1 ? "persona" : "personas"}`}
         >
           {rows.length} {rows.length === 1 ? "persona" : "personas"}
         </button>
       </PopoverTrigger>
-      <PopoverContent align="start" className="w-72 max-w-[90vw] p-3">
+      <PopoverContent
+        align="start"
+        className="w-72 max-w-[90vw] p-3"
+      >
         <div
           className="flex flex-wrap items-center gap-1.5"
           data-testid="swarm-run-detail-personas"

--- a/mcpjam-inspector/client/src/components/swarms/swarm-run-detail.tsx
+++ b/mcpjam-inspector/client/src/components/swarms/swarm-run-detail.tsx
@@ -35,7 +35,12 @@ import {
   type ThemeRef,
 } from "@/hooks/chatbox-usage-filters";
 import { getShareableAppOrigin } from "@/lib/chatbox-session";
-import { SWARM_QUERIES, type SwarmOverview } from "@/lib/swarm-api";
+import {
+  SWARM_QUERIES,
+  type SwarmOverview,
+  type SwarmWaveSignals,
+} from "@/lib/swarm-api";
+import { SwarmTargetHealthStrip } from "@/components/swarms/swarm-target-health-strip";
 import { shouldQueryProjectId } from "@/hooks/useProjects";
 import { formatSwarmAbsoluteTime } from "@/components/swarms/journey-run-format";
 import { SwarmsSessionsPanel } from "@/components/swarms/SwarmsSessionsPanel";
@@ -94,7 +99,7 @@ export function SwarmRunDetail({
       if (sessionParam) search.set("session", sessionParam);
       const query = search.toString();
       return query ? `?${query}` : "";
-    })(),
+    })()
   );
   const urlSelection = useMemo(() => parseSelectionParam(selParam), [selParam]);
   const [sessionsPersonaFilter, setSessionsPersonaFilter] = useState<
@@ -117,6 +122,17 @@ export function SwarmRunDetail({
     [overview, waves, swarmId]
   );
 
+  // Same subscription the insights rail mounts — Convex dedupes identical
+  // queries, so this costs nothing extra and keeps launch health on screen
+  // regardless of which tab is open.
+  const waveGroupId = wave?.runs[0]?.swarmRunGroupId;
+  const waveSignals = useQuery(
+    SWARM_QUERIES.getWaveSignals as any,
+    (queryable && waveGroupId
+      ? { projectId, swarmRunGroupId: waveGroupId }
+      : "skip") as any
+  ) as SwarmWaveSignals | null | undefined;
+
   const handleTabChange = useCallback(
     (next: SwarmDetailTab) => {
       navigate(
@@ -124,10 +140,10 @@ export function SwarmRunDetail({
           tab: next,
           sel: selParam ?? undefined,
         }),
-        { replace: true },
+        { replace: true }
       );
     },
-    [navigate, selParam, swarmId],
+    [navigate, selParam, swarmId]
   );
 
   const handleShare = useCallback(async () => {
@@ -151,10 +167,10 @@ export function SwarmRunDetail({
           tab: "sessions",
           session: sessionId,
           sel: selParam ?? undefined,
-        }),
+        })
       );
     },
-    [navigate, selParam, swarmId],
+    [navigate, selParam, swarmId]
   );
 
   /**
@@ -167,31 +183,31 @@ export function SwarmRunDetail({
       buildSwarmPath(swarmId, {
         tab,
         sel: selParam ?? undefined,
-      }),
+      })
     );
   }, [navigate, selParam, swarmId, tab]);
 
   const handleSelectionChange = useCallback(
-    (themes: ReadonlyArray<Pick<ThemeRef, "dimension" | "clusterId">> | null) => {
+    (
+      themes: ReadonlyArray<Pick<ThemeRef, "dimension" | "clusterId">> | null
+    ) => {
       navigate(
         buildSwarmPath(swarmId, {
           tab,
           session: sessionParam ?? undefined,
           sel: themes ? serializeSelectionParam(themes) : undefined,
         }),
-        { replace: true },
+        { replace: true }
       );
     },
-    [navigate, sessionParam, swarmId, tab],
+    [navigate, sessionParam, swarmId, tab]
   );
 
   const launchableJourneyIds = useMemo(() => {
     if (!wave) return [];
     return [
       ...new Set(
-        wave.runs
-          .filter((r) => !r.journeyArchived)
-          .map((r) => r.journeyRefId)
+        wave.runs.filter((r) => !r.journeyArchived).map((r) => r.journeyRefId)
       ),
     ];
   }, [wave]);
@@ -255,9 +271,7 @@ export function SwarmRunDetail({
       ? Math.min(100, Math.round((live.done / live.total) * 100))
       : 0;
   const runIds = wave.runs.map((r) => r.runId);
-  const runLabels = new Map(
-    wave.runs.map((r) => [r.runId, r.journeyName])
-  );
+  const runLabels = new Map(wave.runs.map((r) => [r.runId, r.journeyName]));
   const goalLabels = new Map(
     wave.runs.map((r) => [r.journeyRefId, r.journeyName])
   );
@@ -370,6 +384,14 @@ export function SwarmRunDetail({
           ) : null}
         </div>
       ) : null}
+
+      {/* Launch outcomes, above the tabs and OUTSIDE the findings: a target
+          that never reached a session says nothing about the server's tools,
+          and used to be mined as if it did. */}
+      <SwarmTargetHealthStrip
+        targetHealth={waveSignals?.targetHealth}
+        terminal={waveSignals?.terminal ?? false}
+      />
 
       <div className="flex min-h-0 flex-1 flex-col overflow-hidden">
         {tab === "insights" ? (
@@ -489,7 +511,8 @@ function DetailPersonasChip({
     for (const run of wave.runs) {
       const existing = byName.get(run.personaName);
       if (existing) existing.journeyCount += 1;
-      else byName.set(run.personaName, { name: run.personaName, journeyCount: 1 });
+      else
+        byName.set(run.personaName, { name: run.personaName, journeyCount: 1 });
     }
     return [...byName.values()].sort((a, b) => a.name.localeCompare(b.name));
   }, [wave.runs]);
@@ -502,15 +525,14 @@ function DetailPersonasChip({
         <button
           type="button"
           className="inline-flex items-center gap-1 rounded-md border border-border/50 bg-muted/25 px-2 py-0.5 text-xs font-medium text-foreground/90 transition-colors hover:bg-muted/50 hover:text-foreground"
-          aria-label={`${rows.length} ${rows.length === 1 ? "persona" : "personas"}`}
+          aria-label={`${rows.length} ${
+            rows.length === 1 ? "persona" : "personas"
+          }`}
         >
           {rows.length} {rows.length === 1 ? "persona" : "personas"}
         </button>
       </PopoverTrigger>
-      <PopoverContent
-        align="start"
-        className="w-72 max-w-[90vw] p-3"
-      >
+      <PopoverContent align="start" className="w-72 max-w-[90vw] p-3">
         <div
           className="flex flex-wrap items-center gap-1.5"
           data-testid="swarm-run-detail-personas"

--- a/mcpjam-inspector/client/src/components/swarms/swarm-target-health-strip.tsx
+++ b/mcpjam-inspector/client/src/components/swarms/swarm-target-health-strip.tsx
@@ -1,0 +1,115 @@
+/**
+ * Terminal target-health strip — launch outcomes, kept OUT of the findings.
+ *
+ * A wave's targets can fail before a single session exists: the sandbox never
+ * came up, the provider throttled, the host refused the connection. That used
+ * to be mined as a `target_failures` finding, which produced a confident "your
+ * MCP server is broken" row with no session to open behind it. The miner now
+ * emits those outcomes as `targetHealth` instead, and this strip is where they
+ * are shown — above the tab content, beside the findings, never among them.
+ *
+ * Rate-limited is a SEPARATE column from failed on purpose: throttling is a
+ * retry-later, not a broken target, and merging the two made every throttled
+ * wave read as an outage.
+ */
+import { cn } from "@/lib/utils";
+import { humanizeSwarmAttemptError } from "@/shared/swarm-attempt-error";
+import type { SwarmWaveTargetHealth } from "@/lib/swarm-api";
+
+/** A target is worth a row only once something did not simply succeed. */
+function hasTrouble(row: SwarmWaveTargetHealth): boolean {
+  return row.failed > 0 || row.rateLimited > 0;
+}
+
+/**
+ * The refusal, prettified through the SHARED humanizer — same path the live
+ * Running step takes. Never rendered raw: rows written before the runner
+ * started sanitizing still hold a full `swarm-agent <url> failed (429): {...}`
+ * envelope, and a structured code alone is enough for the humanizer to map a
+ * recognized sandbox failure with no stored message at all.
+ */
+export function targetFailureReason(row: SwarmWaveTargetHealth): string | null {
+  if (!row.errorCode && !row.errorMessage) return null;
+  return humanizeSwarmAttemptError(row.errorMessage, row.errorCode).message;
+}
+
+export function SwarmTargetHealthStrip({
+  targetHealth,
+  terminal,
+}: {
+  /** Optional: a server deployed before the field existed omits it. */
+  targetHealth: SwarmWaveTargetHealth[] | undefined;
+  /** Every run of the wave has left `running`. */
+  terminal: boolean;
+}) {
+  // Mid-run counts are a moving target — an attempt that is about to be
+  // retried reads as a failure until it isn't. Wait for the wave to settle
+  // rather than flashing an outage banner at a healthy run.
+  if (!terminal) return null;
+  const troubled = (targetHealth ?? []).filter(hasTrouble);
+  if (troubled.length === 0) return null;
+
+  return (
+    <div
+      className="flex flex-wrap items-center gap-x-4 gap-y-1.5 border-b border-border/40 bg-amber-500/[0.06] px-8 py-2"
+      data-testid="swarm-target-health"
+      role="status"
+    >
+      <span className="text-xs font-medium text-foreground">
+        Some launches did not reach a session
+      </span>
+      {troubled.map((row) => {
+        const reason = targetFailureReason(row);
+        return (
+          <span
+            key={`${row.subjectKind}:${row.subjectId}`}
+            className="flex items-center gap-1.5 text-xs text-muted-foreground"
+            data-testid="swarm-target-health-row"
+            data-subject-id={row.subjectId}
+            {...(reason ? { title: reason } : {})}
+          >
+            <span className="font-medium text-foreground/80">
+              {row.subjectLabel}
+            </span>
+            <span className="tabular-nums">
+              {row.succeeded} of {row.attempted} started
+            </span>
+            {row.failed > 0 ? (
+              <span
+                className={cn(
+                  "rounded border px-1 py-0 text-[10px] font-medium tabular-nums",
+                  "border-destructive/40 bg-destructive/10 text-destructive"
+                )}
+                data-testid="swarm-target-health-failed"
+              >
+                {row.failed} failed
+              </span>
+            ) : null}
+            {row.rateLimited > 0 ? (
+              <span
+                className={cn(
+                  "rounded border px-1 py-0 text-[10px] font-medium tabular-nums",
+                  "border-amber-500/40 bg-amber-500/10 text-amber-700 dark:text-amber-400"
+                )}
+                data-testid="swarm-target-health-rate-limited"
+              >
+                {row.rateLimited} rate limited
+              </span>
+            ) : null}
+            {reason ? (
+              <span
+                className="max-w-[28rem] truncate"
+                data-testid="swarm-target-health-reason"
+              >
+                {reason}
+              </span>
+            ) : null}
+          </span>
+        );
+      })}
+      <span className="text-[11px] text-muted-foreground">
+        Launch outcomes — not a finding about the server's tools.
+      </span>
+    </div>
+  );
+}

--- a/mcpjam-inspector/client/src/components/swarms/swarm-target-health-strip.tsx
+++ b/mcpjam-inspector/client/src/components/swarms/swarm-target-health-strip.tsx
@@ -13,7 +13,10 @@
  * wave read as an outage.
  */
 import { cn } from "@/lib/utils";
-import { humanizeSwarmAttemptError } from "@/shared/swarm-attempt-error";
+import {
+  humanizeSwarmAttemptError,
+  UNKNOWN_ATTEMPT_ERROR_MESSAGE,
+} from "@/shared/swarm-attempt-error";
 import type { SwarmWaveTargetHealth } from "@/lib/swarm-api";
 
 /** A target is worth a row only once something did not simply succeed. */
@@ -25,12 +28,22 @@ function hasTrouble(row: SwarmWaveTargetHealth): boolean {
  * The refusal, prettified through the SHARED humanizer — same path the live
  * Running step takes. Never rendered raw: rows written before the runner
  * started sanitizing still hold a full `swarm-agent <url> failed (429): {...}`
- * envelope, and a structured code alone is enough for the humanizer to map a
- * recognized sandbox failure with no stored message at all.
+ * envelope, and a recognized code alone is enough for the humanizer to name a
+ * sandbox failure with no stored message at all.
+ *
+ * `null` when the humanizer can only reach its unknown-reason fallback. Unlike
+ * a per-attempt view, this strip has ALREADY said what happened in its chips —
+ * "1 rate limited" followed by "The session failed for an unknown reason"
+ * reads as a contradiction, and an unrecognized `errorCode` with no stored
+ * message lands exactly there.
  */
 export function targetFailureReason(row: SwarmWaveTargetHealth): string | null {
   if (!row.errorCode && !row.errorMessage) return null;
-  return humanizeSwarmAttemptError(row.errorMessage, row.errorCode).message;
+  const { message } = humanizeSwarmAttemptError(
+    row.errorMessage,
+    row.errorCode
+  );
+  return message === UNKNOWN_ATTEMPT_ERROR_MESSAGE ? null : message;
 }
 
 export function SwarmTargetHealthStrip({

--- a/mcpjam-inspector/client/src/components/swarms/swarm-target-health-strip.tsx
+++ b/mcpjam-inspector/client/src/components/swarms/swarm-target-health-strip.tsx
@@ -13,37 +13,11 @@
  * wave read as an outage.
  */
 import { cn } from "@/lib/utils";
-import {
-  humanizeSwarmAttemptError,
-  UNKNOWN_ATTEMPT_ERROR_MESSAGE,
-} from "@/shared/swarm-attempt-error";
 import type { SwarmWaveTargetHealth } from "@/lib/swarm-api";
 
 /** A target is worth a row only once something did not simply succeed. */
 function hasTrouble(row: SwarmWaveTargetHealth): boolean {
   return row.failed > 0 || row.rateLimited > 0;
-}
-
-/**
- * The refusal, prettified through the SHARED humanizer — same path the live
- * Running step takes. Never rendered raw: rows written before the runner
- * started sanitizing still hold a full `swarm-agent <url> failed (429): {...}`
- * envelope, and a recognized code alone is enough for the humanizer to name a
- * sandbox failure with no stored message at all.
- *
- * `null` when the humanizer can only reach its unknown-reason fallback. Unlike
- * a per-attempt view, this strip has ALREADY said what happened in its chips —
- * "1 rate limited" followed by "The session failed for an unknown reason"
- * reads as a contradiction, and an unrecognized `errorCode` with no stored
- * message lands exactly there.
- */
-export function targetFailureReason(row: SwarmWaveTargetHealth): string | null {
-  if (!row.errorCode && !row.errorMessage) return null;
-  const { message } = humanizeSwarmAttemptError(
-    row.errorMessage,
-    row.errorCode
-  );
-  return message === UNKNOWN_ATTEMPT_ERROR_MESSAGE ? null : message;
 }
 
 export function SwarmTargetHealthStrip({
@@ -72,14 +46,12 @@ export function SwarmTargetHealthStrip({
         Some launches did not reach a session
       </span>
       {troubled.map((row) => {
-        const reason = targetFailureReason(row);
         return (
           <span
             key={`${row.subjectKind}:${row.subjectId}`}
             className="flex items-center gap-1.5 text-xs text-muted-foreground"
             data-testid="swarm-target-health-row"
             data-subject-id={row.subjectId}
-            {...(reason ? { title: reason } : {})}
           >
             <span className="font-medium text-foreground/80">
               {row.subjectLabel}
@@ -107,14 +79,6 @@ export function SwarmTargetHealthStrip({
                 data-testid="swarm-target-health-rate-limited"
               >
                 {row.rateLimited} rate limited
-              </span>
-            ) : null}
-            {reason ? (
-              <span
-                className="max-w-[28rem] truncate"
-                data-testid="swarm-target-health-reason"
-              >
-                {reason}
               </span>
             ) : null}
           </span>

--- a/mcpjam-inspector/client/src/lib/swarm-api.ts
+++ b/mcpjam-inspector/client/src/lib/swarm-api.ts
@@ -462,12 +462,6 @@ export interface SwarmWaveTargetHealth {
   succeeded: number;
   failed: number;
   rateLimited: number;
-  /** Representative refusal for this target, verbatim from the attempt row —
-   * every attempt against a refusing target carries the same one. Render
-   * through `humanizeSwarmAttemptError`, never raw: rows written before the
-   * runner started sanitizing still hold a full provider envelope. */
-  errorCode?: string;
-  errorMessage?: string;
 }
 
 /** Result of `swarmWaveInsights:getWaveSignals` (null ⇒ unknown wave id). */

--- a/mcpjam-inspector/client/src/lib/swarm-api.ts
+++ b/mcpjam-inspector/client/src/lib/swarm-api.ts
@@ -445,9 +445,37 @@ export interface SwarmWaveSignalCandidate {
   severityScore: number;
 }
 
+/**
+ * Launch outcomes for one execution target of the wave — REPORTING, not a
+ * finding.
+ *
+ * A target that refused connections or throttled the wave has no session to
+ * open and says nothing about the MCP server's tool contract, so it travels
+ * beside the candidates rather than among them. `failed` and `rateLimited`
+ * stay separate: a throttled wave is not a broken server.
+ */
+export interface SwarmWaveTargetHealth {
+  subjectKind: "environment" | "host";
+  subjectId: string;
+  subjectLabel: string;
+  attempted: number;
+  succeeded: number;
+  failed: number;
+  rateLimited: number;
+  /** Representative refusal for this target, verbatim from the attempt row —
+   * every attempt against a refusing target carries the same one. Render
+   * through `humanizeSwarmAttemptError`, never raw: rows written before the
+   * runner started sanitizing still hold a full provider envelope. */
+  errorCode?: string;
+  errorMessage?: string;
+}
+
 /** Result of `swarmWaveInsights:getWaveSignals` (null ⇒ unknown wave id). */
 export interface SwarmWaveSignals {
   candidates: SwarmWaveSignalCandidate[];
+  /** Per-target launch outcomes, worst-first. Optional: a server deployed
+   * before the field existed omits it. */
+  targetHealth?: SwarmWaveTargetHealth[];
   sessionCount: number;
   /** Sessions with no usable readiness analysis (pending/failed/absent). */
   unanalyzedSessionCount: number;

--- a/mcpjam-inspector/shared/swarm-attempt-error.ts
+++ b/mcpjam-inspector/shared/swarm-attempt-error.ts
@@ -37,20 +37,6 @@ const URL_PATTERN = /https?:\/\/\S+/g;
 
 export const MAX_ATTEMPT_ERROR_CHARS = 500;
 
-/**
- * What comes back when nothing in the row could be turned into a sentence — an
- * unrecognized `errorCode` with no stored message, or a message that scrubbed
- * away to nothing.
- *
- * Exported so callers can DETECT the non-answer rather than print it. A per-
- * attempt view still shows it (something did fail, and saying so is honest),
- * but a surface that already states the outcome another way — a "rate limited"
- * chip, say — only contradicts itself by adding "failed for an unknown reason"
- * beside it.
- */
-export const UNKNOWN_ATTEMPT_ERROR_MESSAGE =
-  "The session failed for an unknown reason.";
-
 export type SwarmAttemptErrorInfo = {
   /** Clean, user-facing sentence. Always non-empty. */
   message: string;
@@ -185,7 +171,7 @@ export function humanizeSwarmAttemptError(
       ...(isRerunnableXaaFailure(errorCode) ? { rerunnable: true } : {}),
     };
   }
-  if (!input) return { message: UNKNOWN_ATTEMPT_ERROR_MESSAGE };
+  if (!input) return { message: "The session failed for an unknown reason." };
 
   let body = input;
   let httpStatus: number | undefined;
@@ -200,7 +186,7 @@ export function humanizeSwarmAttemptError(
   if (!parsed) {
     const cleaned = scrub(body) || scrub(input);
     return {
-      message: (cleaned || UNKNOWN_ATTEMPT_ERROR_MESSAGE).slice(
+      message: (cleaned || "The session failed for an unknown reason.").slice(
         0,
         MAX_ATTEMPT_ERROR_CHARS
       ),

--- a/mcpjam-inspector/shared/swarm-attempt-error.ts
+++ b/mcpjam-inspector/shared/swarm-attempt-error.ts
@@ -37,6 +37,20 @@ const URL_PATTERN = /https?:\/\/\S+/g;
 
 export const MAX_ATTEMPT_ERROR_CHARS = 500;
 
+/**
+ * What comes back when nothing in the row could be turned into a sentence — an
+ * unrecognized `errorCode` with no stored message, or a message that scrubbed
+ * away to nothing.
+ *
+ * Exported so callers can DETECT the non-answer rather than print it. A per-
+ * attempt view still shows it (something did fail, and saying so is honest),
+ * but a surface that already states the outcome another way — a "rate limited"
+ * chip, say — only contradicts itself by adding "failed for an unknown reason"
+ * beside it.
+ */
+export const UNKNOWN_ATTEMPT_ERROR_MESSAGE =
+  "The session failed for an unknown reason.";
+
 export type SwarmAttemptErrorInfo = {
   /** Clean, user-facing sentence. Always non-empty. */
   message: string;
@@ -171,7 +185,7 @@ export function humanizeSwarmAttemptError(
       ...(isRerunnableXaaFailure(errorCode) ? { rerunnable: true } : {}),
     };
   }
-  if (!input) return { message: "The session failed for an unknown reason." };
+  if (!input) return { message: UNKNOWN_ATTEMPT_ERROR_MESSAGE };
 
   let body = input;
   let httpStatus: number | undefined;
@@ -186,7 +200,7 @@ export function humanizeSwarmAttemptError(
   if (!parsed) {
     const cleaned = scrub(body) || scrub(input);
     return {
-      message: (cleaned || "The session failed for an unknown reason.").slice(
+      message: (cleaned || UNKNOWN_ATTEMPT_ERROR_MESSAGE).slice(
         0,
         MAX_ATTEMPT_ERROR_CHARS
       ),


### PR DESCRIPTION
Client half of PR 1 of the actionable-insights program. Pairs with MCPJam/mcpjam-backend#961 — merge that first, though nothing here breaks against an older server (every new field is optional).

## Context

The swarm miner used to turn launch attempt outcomes into a `target_failures` finding: a confident "your MCP server is broken" row with no session to open behind it, and a count of *attempts* that this UI printed as sessions. The backend now reports those outcomes as `targetHealth` instead. This is where they land.

## Changes

**`swarm-target-health-strip.tsx`** (new) — terminal strip above the tab content, one row per troubled target. `failed` and `rate limited` are separate chips because a throttled wave is not a broken server, and the strip says outright that these are launch outcomes, *not* a finding about the server's tools. The refusal is rendered through the existing shared `humanizeSwarmAttemptError` rather than raw — rows written before the runner started sanitizing still hold a full `swarm-agent <url> failed (429): {...}` envelope, and a structured code alone is enough for the humanizer with no stored message.

It stays silent while the wave is still running (mid-run counts move — an attempt about to be retried reads as a failure until it isn't, and an outage banner over a healthy run is worse than no banner) and silent when every launch succeeded.

**`run-insights.tsx`**

- `target_failures` now reads "Tool errors concentrate on X in N of M sessions". The unit is stated because the ambiguous bare `(N of M)` was printing attempts as sessions on the fire path that is now gone.
- New `canExpand`: both row components require a **failing exemplar** before they will open into Why/Fix. Cause and recommendation are the model's words; behind an expander with no failing session to open they are an unfalsifiable claim. The deterministic sentence still renders — it is a true statement about counts, and suppressing the row would hide a real signal.
- Contrast chips ride alongside failing ones, never alone: a lone "Clean 1" reads as evidence while pointing at a session where the problem did *not* happen.

The backend enforces the same rule at both ends now. These are the client's own checks, for older servers, cached payloads, and detectors not yet written.

**`swarm-api.ts`** — `SwarmWaveTargetHealth` and the optional `targetHealth` on the signals DTO, hand-mirrored from the backend (two-repo layout).

## Tests

`typecheck:client` clean. 271 test files / 2570 tests green across the touched areas (usage-insights, swarms, chatboxes, evals, hooks). New coverage:

- strip: rate-limited never merged into failed; the "not a finding" wording; a raw provider envelope is humanized, not printed; a bare structured code still yields a reason; silent mid-run, silent when healthy, silent against a server without the field; healthy targets omitted from the list;
- rail: an unevidenced row will not expand, keeps its deterministic sentence, and shows no session chips — pinned on **both** row components, since the rule is a property of the surface and not of one layout;
- `target_failures` phrasing names sessions as the unit.

---
_Generated by [Claude Code](https://claude.ai/code/session_01D3Xoa8DWtUE5rX8nXoCNYq)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit 72363d9087d93052bf533f972962fe4567dcd298. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Shows per-target launch health beside the findings instead of mining launch attempts as a `target_failures` finding. This removes confident rows with no session behind them and fixes counts that treated attempts as sessions.

- Launch-health strip: terminal-only bar above the tabs, one row per troubled target; keeps failed and rate limited separate; silent mid-run and when all launches succeed; omits healthy targets; appears regardless of the active tab; tolerates servers without the field; shows counts only.
- Insights rail: `target_failures` now reads “Tool errors concentrate on X in N of M sessions.” Rows require a failing exemplar to expand, auto-close if evidence disappears, never show “Clean” chips alone, and announce disclosure state via `aria-expanded` on both triggers across both row components; the attribute is omitted when the row is not a disclosure.
- API: adds `SwarmWaveTargetHealth` and optional `targetHealth` on `SwarmWaveSignals`.

**Rollout**
- Backend first recommended (pairs with `MCPJam/mcpjam-backend#961`), but safe to ship independently; no migrations required.

<sup>Written for commit 72919e398950b8524db712ad4eeac6771afa3dd3. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/MCPJam/inspector/pull/3963?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

