### PR TITLE
fix(caniuse): stop lowercasing the compare search query before matching

### DIFF
--- a/mcpjam-inspector/client/src/components/hosts/comparison/HostConfigCompareView.tsx
+++ b/mcpjam-inspector/client/src/components/hosts/comparison/HostConfigCompareView.tsx
@@ -1105,7 +1105,12 @@ function CompareSearchBar({
     [fields]
   );
   const filteredFieldGroups = useMemo(() => {
-    const loweredQuery = query.trim().toLowerCase();
+    // Not lowercased here: normalizeFieldSearchText splits camelCase by its
+    // lowercase-then-uppercase boundary, so a pre-lowered "toolcancelled"
+    // would never split back into "tool cancelled" and fail to match its own
+    // field — which the autocomplete list hits directly, since selecting a
+    // suggestion inserts the field's own camelCase label as the query.
+    const trimmedQuery = query.trim();
     return fieldGroups
       .map((group) => ({
         ...group,
@@ -1113,7 +1118,7 @@ function CompareSearchBar({
           .map((subsection) => ({
             ...subsection,
             fields: subsection.fields.filter((field) =>
-              fieldMatchesQuery(field, loweredQuery)
+              fieldMatchesQuery(field, trimmedQuery)
             ),
           }))
           .filter((subsection) => subsection.fields.length > 0),

--- a/mcpjam-inspector/client/src/components/hosts/comparison/HostConfigCompareView.tsx
+++ b/mcpjam-inspector/client/src/components/hosts/comparison/HostConfigCompareView.tsx
@@ -1105,11 +1105,9 @@ function CompareSearchBar({
     [fields]
   );
   const filteredFieldGroups = useMemo(() => {
-    // Not lowercased here: normalizeFieldSearchText splits camelCase by its
-    // lowercase-then-uppercase boundary, so a pre-lowered "toolcancelled"
-    // would never split back into "tool cancelled" and fail to match its own
-    // field — which the autocomplete list hits directly, since selecting a
-    // suggestion inserts the field's own camelCase label as the query.
+    // Deliberately not lowercased — see fieldMatchesQuery. Selecting a
+    // suggestion feeds that field's own camelCase label back in as the query,
+    // so this list is the first thing a pre-lowered query breaks.
     const trimmedQuery = query.trim();
     return fieldGroups
       .map((group) => ({

--- a/mcpjam-inspector/client/src/components/hosts/comparison/__tests__/HostConfigCompareView.public.test.tsx
+++ b/mcpjam-inspector/client/src/components/hosts/comparison/__tests__/HostConfigCompareView.public.test.tsx
@@ -262,6 +262,39 @@ describe("HostConfigCompareView public mode", () => {
     expect(filterButton).not.toBeDisabled();
   });
 
+  it("matches a field whose label is itself camelCase (regression: search query must not be lowercased)", async () => {
+    // appsCap.toolCancelled's label is literally "toolCancelled" — some MCP
+    // Apps capability rows use their raw camelCase key as the label. If the
+    // query were lowercased before matching (the original bug), typing this
+    // exact label would produce "No fields match" instead of the row itself.
+    const user = userEvent.setup();
+
+    render(
+      <MemoryRouter
+        initialEntries={[
+          "/embed/host-compare?hosts=preset%3Aclaude%2Cpreset%3Avscode",
+        ]}
+      >
+        <HostConfigCompareView
+          projectId={null}
+          isAuthenticated={false}
+          presetOnly
+        />
+      </MemoryRouter>
+    );
+
+    await user.type(
+      screen.getByLabelText("Search client config fields"),
+      "toolCancelled"
+    );
+
+    await waitFor(() => {
+      expect(
+        screen.queryByText(/No fields match/i)
+      ).not.toBeInTheDocument();
+    });
+  });
+
   it("clears search filtering without changing selected clients when Can I use is clicked", async () => {
     const user = userEvent.setup();
 

--- a/mcpjam-inspector/client/src/components/hosts/comparison/__tests__/HostConfigCompareView.public.test.tsx
+++ b/mcpjam-inspector/client/src/components/hosts/comparison/__tests__/HostConfigCompareView.public.test.tsx
@@ -262,15 +262,14 @@ describe("HostConfigCompareView public mode", () => {
     expect(filterButton).not.toBeDisabled();
   });
 
-  it("matches a field whose label is itself camelCase (regression: search query must not be lowercased)", async () => {
-    // appsCap.toolCancelled's label is literally "toolCancelled" — some MCP
-    // Apps capability rows use their raw camelCase key as the label. If the
-    // query were lowercased before matching (the original bug), typing this
-    // exact label would produce "No fields match" instead of the row itself.
-    // This exercises the matrix's own row-filtering path (computeVisibleFieldIds,
-    // fed the raw `fieldSearchQuery` state directly) — not the search bar's
-    // internal autocomplete-suggestion filtering, which has its own coverage
-    // in support-level.test.ts.
+  it("matches a camelCase field label in both the matrix rows and the autocomplete list", async () => {
+    // appsCap.toolCancelled's label is literally "toolCancelled" — the MCP Apps
+    // capability rows use their raw camelCase key as the label. Lowercasing the
+    // query before matching (the original bug) collapses the camelCase boundary
+    // the tokenizer needs, so typing this exact label showed "No fields match".
+    // Both filtering paths are asserted because each has its own call site: the
+    // matrix rows via computeVisibleFieldIds, the suggestion list via
+    // fieldMatchesQuery directly.
     const user = userEvent.setup();
 
     render(
@@ -292,17 +291,22 @@ describe("HostConfigCompareView public mode", () => {
       "toolCancelled"
     );
 
-    // The matrix renders either the table or "No fields match" (mutually
-    // exclusive early returns) — so finding the row inside a real table
-    // already implies the empty state isn't showing. Scoped to the table
-    // because the search bar's own autocomplete popover can render a
-    // "toolCancelled" suggestion at the same time; an unscoped getByText
-    // would collide with it.
+    // The matrix returns either the table or "No fields match" (mutually
+    // exclusive early returns), so finding the row inside a real table already
+    // implies the empty state isn't showing. Scoped to the table because the
+    // autocomplete popover renders its own "toolCancelled" suggestion.
     await waitFor(() => {
       expect(
         within(screen.getByRole("table")).getByText("toolCancelled")
       ).toBeInTheDocument();
     });
+
+    // The suggestion list filters through its own fieldMatchesQuery call, so it
+    // must survive the same camelCase query — this is what the reported bug hit
+    // first: picking a suggestion feeds the field's own label back as the query.
+    expect(
+      within(screen.getByRole("listbox")).getByText("toolCancelled")
+    ).toBeInTheDocument();
   });
 
   it("clears search filtering without changing selected clients when Can I use is clicked", async () => {

--- a/mcpjam-inspector/client/src/components/hosts/comparison/__tests__/HostConfigCompareView.public.test.tsx
+++ b/mcpjam-inspector/client/src/components/hosts/comparison/__tests__/HostConfigCompareView.public.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen, waitFor } from "@testing-library/react";
+import { render, screen, waitFor, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { MemoryRouter, useLocation } from "react-router";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
@@ -267,6 +267,10 @@ describe("HostConfigCompareView public mode", () => {
     // Apps capability rows use their raw camelCase key as the label. If the
     // query were lowercased before matching (the original bug), typing this
     // exact label would produce "No fields match" instead of the row itself.
+    // This exercises the matrix's own row-filtering path (computeVisibleFieldIds,
+    // fed the raw `fieldSearchQuery` state directly) — not the search bar's
+    // internal autocomplete-suggestion filtering, which has its own coverage
+    // in support-level.test.ts.
     const user = userEvent.setup();
 
     render(
@@ -288,10 +292,16 @@ describe("HostConfigCompareView public mode", () => {
       "toolCancelled"
     );
 
+    // The matrix renders either the table or "No fields match" (mutually
+    // exclusive early returns) — so finding the row inside a real table
+    // already implies the empty state isn't showing. Scoped to the table
+    // because the search bar's own autocomplete popover can render a
+    // "toolCancelled" suggestion at the same time; an unscoped getByText
+    // would collide with it.
     await waitFor(() => {
       expect(
-        screen.queryByText(/No fields match/i)
-      ).not.toBeInTheDocument();
+        within(screen.getByRole("table")).getByText("toolCancelled")
+      ).toBeInTheDocument();
     });
   });
 

--- a/mcpjam-inspector/client/src/components/hosts/comparison/__tests__/support-level.test.ts
+++ b/mcpjam-inspector/client/src/components/hosts/comparison/__tests__/support-level.test.ts
@@ -270,6 +270,20 @@ describe("fieldMatchesQuery / computeVisibleFieldIds", () => {
     expect(narrowed.has("modelId")).toBe(false);
     expect(narrowed.size).toBeLessThan(all.size);
   });
+
+  it("computeVisibleFieldIds matches a camelCase field label without lowercasing", () => {
+    // This is the other call site the fix touched (the search bar's own
+    // matching goes through fieldMatchesQuery directly, above) — it must not
+    // reintroduce the pre-lowercasing that broke the search bar's autocomplete.
+    const field = hostConfigField("appsCap.toolCancelled");
+    const ids = computeVisibleFieldIds({
+      configs: [makeConfig()],
+      divergingOnly: false,
+      supportFilter: "all",
+      searchQuery: field.label,
+    });
+    expect(ids.has(field.id)).toBe(true);
+  });
 });
 
 describe("getCapabilityCaveats", () => {

--- a/mcpjam-inspector/client/src/components/hosts/comparison/__tests__/support-level.test.ts
+++ b/mcpjam-inspector/client/src/components/hosts/comparison/__tests__/support-level.test.ts
@@ -231,26 +231,21 @@ describe("fieldMatchesQuery / computeVisibleFieldIds", () => {
 
   it("matches a field whose label is itself camelCase (MCP Apps capability rows)", () => {
     // Some rows' `label` is the raw camelCase key, not a humanized string —
-    // e.g. appsCap.toolCancelled's label is literally "toolCancelled". The
-    // search bar's autocomplete inserts a selected field's own `label` as the
-    // query verbatim (onQueryChange(field.label)), so this must keep matching
-    // its own field, or picking a suggestion produces zero results.
+    // appsCap.toolCancelled's label is literally "toolCancelled". Selecting a
+    // suggestion feeds that label back as the query verbatim
+    // (onQueryChange(field.label)), so it has to match its own field.
     const field = hostConfigField("appsCap.toolCancelled");
     expect(field.label).toBe("toolCancelled");
     expect(fieldMatchesQuery(field, field.label)).toBe(true);
   });
 
-  it("callers must not lowercase the query before calling fieldMatchesQuery", () => {
-    // normalizeFieldSearchText splits camelCase by its lowercase-then-uppercase
-    // boundary; once a query has been forced to lowercase that boundary is
-    // gone for good and can't be recovered inside fieldMatchesQuery itself —
-    // "toolcancelled" stays one token against the haystack's split
-    // "tool"/"cancelled" tokens. This is why the fix lives at the call sites
-    // (HostConfigCompareView's search bar, computeVisibleFieldIds below), not
-    // in fieldMatchesQuery: it documents the failure mode those call sites
-    // must keep avoiding, not a case this function is expected to handle.
+  it("stays case-insensitive now that callers no longer pre-lowercase", () => {
+    // The tokenizer splits on the case boundary first and lowercases after, so
+    // dropping the callers' `.toLowerCase()` costs nothing in case-insensitivity.
     const field = hostConfigField("appsCap.toolCancelled");
-    expect(fieldMatchesQuery(field, field.label.toLowerCase())).toBe(false);
+    for (const query of ["toolCancelled", "ToolCancelled", "TOOL CANCELLED"]) {
+      expect(fieldMatchesQuery(field, query)).toBe(true);
+    }
   });
 
   it("narrows visible ids by search query", () => {

--- a/mcpjam-inspector/client/src/components/hosts/comparison/__tests__/support-level.test.ts
+++ b/mcpjam-inspector/client/src/components/hosts/comparison/__tests__/support-level.test.ts
@@ -229,6 +229,30 @@ describe("fieldMatchesQuery / computeVisibleFieldIds", () => {
     ).toBe(true);
   });
 
+  it("matches a field whose label is itself camelCase (MCP Apps capability rows)", () => {
+    // Some rows' `label` is the raw camelCase key, not a humanized string —
+    // e.g. appsCap.toolCancelled's label is literally "toolCancelled". The
+    // search bar's autocomplete inserts a selected field's own `label` as the
+    // query verbatim (onQueryChange(field.label)), so this must keep matching
+    // its own field, or picking a suggestion produces zero results.
+    const field = hostConfigField("appsCap.toolCancelled");
+    expect(field.label).toBe("toolCancelled");
+    expect(fieldMatchesQuery(field, field.label)).toBe(true);
+  });
+
+  it("callers must not lowercase the query before calling fieldMatchesQuery", () => {
+    // normalizeFieldSearchText splits camelCase by its lowercase-then-uppercase
+    // boundary; once a query has been forced to lowercase that boundary is
+    // gone for good and can't be recovered inside fieldMatchesQuery itself —
+    // "toolcancelled" stays one token against the haystack's split
+    // "tool"/"cancelled" tokens. This is why the fix lives at the call sites
+    // (HostConfigCompareView's search bar, computeVisibleFieldIds below), not
+    // in fieldMatchesQuery: it documents the failure mode those call sites
+    // must keep avoiding, not a case this function is expected to handle.
+    const field = hostConfigField("appsCap.toolCancelled");
+    expect(fieldMatchesQuery(field, field.label.toLowerCase())).toBe(false);
+  });
+
   it("narrows visible ids by search query", () => {
     const all = computeVisibleFieldIds({
       configs: [makeConfig()],

--- a/mcpjam-inspector/client/src/components/hosts/comparison/support-level.ts
+++ b/mcpjam-inspector/client/src/components/hosts/comparison/support-level.ts
@@ -176,11 +176,12 @@ function normalizeFieldSearchText(value: string): string {
 
 /**
  * Free-text match against a field's label / subsection / description / id /
- * path. `query` must keep its original casing — pass it in pre-lowercased and
- * normalizeFieldSearchText's camelCase splitter has no case boundary left to
- * find, so a query like "toolCancelled" would stay one token and never match
- * the haystack's split "tool"/"cancelled" tokens. `normalizeFieldSearchText`
- * already lowercases internally, so callers don't need to.
+ * path. Callers must NOT lowercase `query` before calling this — pass it in
+ * with its original casing intact. `normalizeFieldSearchText` already
+ * lowercases internally, so pre-lowercasing is redundant at best; at worst it
+ * destroys the case boundary its camelCase splitter relies on, so a query
+ * like "toolCancelled" would stay one token once lowercased and never match
+ * the haystack's split "tool"/"cancelled" tokens.
  */
 export function fieldMatchesQuery(
   field: HostConfigFieldDef,

--- a/mcpjam-inspector/client/src/components/hosts/comparison/support-level.ts
+++ b/mcpjam-inspector/client/src/components/hosts/comparison/support-level.ts
@@ -174,12 +174,19 @@ function normalizeFieldSearchText(value: string): string {
     .trim();
 }
 
-/** Free-text match against a field's label / subsection / description / id / path. */
+/**
+ * Free-text match against a field's label / subsection / description / id /
+ * path. `query` must keep its original casing — pass it in pre-lowercased and
+ * normalizeFieldSearchText's camelCase splitter has no case boundary left to
+ * find, so a query like "toolCancelled" would stay one token and never match
+ * the haystack's split "tool"/"cancelled" tokens. `normalizeFieldSearchText`
+ * already lowercases internally, so callers don't need to.
+ */
 export function fieldMatchesQuery(
   field: HostConfigFieldDef,
-  loweredQuery: string
+  query: string
 ): boolean {
-  const queryTokens = normalizeFieldSearchText(loweredQuery)
+  const queryTokens = normalizeFieldSearchText(query)
     .split(/\s+/)
     .filter(Boolean);
   if (queryTokens.length === 0) return true;
@@ -212,7 +219,9 @@ export function computeVisibleFieldIds(args: {
   supportFilter: SupportFilterMode;
   searchQuery: string;
 }): Set<string> {
-  const q = args.searchQuery.trim().toLowerCase();
+  // Not lowercased: see fieldMatchesQuery's docstring — normalizeFieldSearchText
+  // needs the original casing to split camelCase field ids/labels.
+  const q = args.searchQuery.trim();
   const set = new Set<string>();
   for (const field of args.fields ?? HOST_CONFIG_FIELDS) {
     if (args.divergingOnly && !fieldDiverges(field, args.configs)) continue;

--- a/mcpjam-inspector/client/src/components/hosts/comparison/support-level.ts
+++ b/mcpjam-inspector/client/src/components/hosts/comparison/support-level.ts
@@ -176,12 +176,10 @@ function normalizeFieldSearchText(value: string): string {
 
 /**
  * Free-text match against a field's label / subsection / description / id /
- * path. Callers must NOT lowercase `query` before calling this — pass it in
- * with its original casing intact. `normalizeFieldSearchText` already
- * lowercases internally, so pre-lowercasing is redundant at best; at worst it
- * destroys the case boundary its camelCase splitter relies on, so a query
- * like "toolCancelled" would stay one token once lowercased and never match
- * the haystack's split "tool"/"cancelled" tokens.
+ * path. Pass `query` with its original casing — `normalizeFieldSearchText`
+ * lowercases internally, but only after splitting on camelCase boundaries, so
+ * a caller that pre-lowercases leaves "toolCancelled" as the single token
+ * "toolcancelled" and it never matches the haystack's "tool"/"cancelled".
  */
 export function fieldMatchesQuery(
   field: HostConfigFieldDef,
@@ -220,8 +218,7 @@ export function computeVisibleFieldIds(args: {
   supportFilter: SupportFilterMode;
   searchQuery: string;
 }): Set<string> {
-  // Not lowercased: see fieldMatchesQuery's docstring — normalizeFieldSearchText
-  // needs the original casing to split camelCase field ids/labels.
+  // Deliberately not lowercased — see fieldMatchesQuery.
   const q = args.searchQuery.trim();
   const set = new Set<string>();
   for (const field of args.fields ?? HOST_CONFIG_FIELDS) {


### PR DESCRIPTION
## Summary
- The compare search bar's own autocomplete could break its own suggestions: typing "cancel" and picking the `toolCancelled` suggestion returned "No fields match the current search and filters" instead of the field.
- Root cause: both call sites (`HostConfigCompareView`'s search bar, and `computeVisibleFieldIds`) lowercased the query with `.toLowerCase()` before handing it to `fieldMatchesQuery`. `normalizeFieldSearchText` splits camelCase by matching a lowercase-then-uppercase boundary — once the query arrives already lowercased, that boundary is gone for good, so `"toolcancelled"` stays one token and never matches the haystack's split `"tool"`/`"cancelled"` tokens (the haystack side isn't pre-lowered, so it still splits correctly).
- This hits real rows directly: some fields' `label` is itself the raw camelCase key (the MCP Apps capability dimensions, e.g. `toolCancelled`, `setWidgetState`), and picking an autocomplete suggestion inserts that label verbatim as the query — so selecting almost any suggestion in that section failed.
- Fix: stop lowercasing at the two call sites. `normalizeFieldSearchText` already lowercases internally, so callers didn't need to — the pre-lowering was destroying information the function needed, not adding safety.

## Test plan
- [x] New unit tests in `support-level.test.ts`: one confirms a field whose label is itself camelCase (`appsCap.toolCancelled`) matches on its own label; one documents that a pre-lowered query fails (the failure mode the two call sites must keep avoiding).
- [x] Full `comparison/` vitest suite passes.
- [x] Manually verified in-browser: typed "cancel", selected the `toolCancelled` suggestion, table now shows the row instead of "No fields match".

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stops lowercasing the compare search query before matching so camelCase suggestions (e.g., "toolCancelled") match their rows. Previously both the search bar and `computeVisibleFieldIds` lowercased the query, breaking camelCase tokenization; matching remains case-insensitive.

- Remove `.toLowerCase()` in `HostConfigCompareView` and `computeVisibleFieldIds`; pass the trimmed query to `fieldMatchesQuery`.
- Clarify `fieldMatchesQuery` docstring: callers must pass the original casing; add brief call-site comments.
- Tests: add unit tests for camelCase labels and case-insensitivity; cover `computeVisibleFieldIds`; strengthen the render regression to assert the expected row renders inside the table and the autocomplete list shows the same field.
- No migrations or config changes; autocomplete suggestions now correctly show their rows.

<sup>Written for commit a9d34e0a805ae85821f8d62530b539fa0dba7af9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/MCPJam/inspector/pull/3968?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

