### PR TITLE
fix(user-testing): keep Insights visible when window-insights queries throw

### DIFF
--- a/mcpjam-inspector/client/src/components/chatboxes/UserTestingScenarioDetail.tsx
+++ b/mcpjam-inspector/client/src/components/chatboxes/UserTestingScenarioDetail.tsx
@@ -28,15 +28,6 @@ import {
 } from "@/components/shared/usage-insights/run-insights";
 import { withHideSynthetic } from "@/components/chatboxes/user-testing-traffic";
 import {
-  ChatboxOutcomeCalibration,
-  hasOutcomeFeedbackCalibration,
-} from "@/components/chatboxes/ChatboxOutcomeCalibration";
-import {
-  Popover,
-  PopoverContent,
-  PopoverTrigger,
-} from "@mcpjam/design-system/popover";
-import {
   parseSelectionParam,
   serializeSelectionParam,
 } from "@/hooks/chatbox-usage-filters";
@@ -745,14 +736,48 @@ export function UserTestingScenarioDetail({
         ) : null}
         {tab === "insights" ? (
           <div className="absolute inset-0">
-            {/* Ships dark and guest-tolerant: `useQuery` against an undeployed
-                query throws, and a guest hitting the member-only request
-                mutation would too. Keyed per scenario across route reuse. */}
-            <ErrorBoundary key={chatbox.chatboxId} fallback={null}>
-              <RunInsightsProvider
-                surface={{
-                  kind: "chatbox",
-                  chatboxId: chatbox.chatboxId,
+            {/* The workbench (empty state, Sankey, sessions) must stay up
+                even when the window-insights rail is missing: those queries
+                throw against an undeployed backend, and wrapping THIS whole
+                tree in `fallback={null}` left a blank `absolute inset-0`.
+                Isolate the rail; if the workbench itself blows up, show the
+                share empty panel rather than nothing. */}
+            <ErrorBoundary
+              key={chatbox.chatboxId}
+              name="user-testing-insights"
+              fallback={<ChatboxShareEmptyPanel chatbox={chatbox} />}
+            >
+              <InsightsWorkbench
+                scope={{ kind: "chatbox", chatboxId: chatbox.chatboxId }}
+                cohortKey={chatbox.chatboxId}
+                // Scenarios carry real-user traffic; the retired simulation
+                // flow's rows are still in the database and stay hidden.
+                augmentFilter={withHideSynthetic}
+                urlSelection={urlSelection}
+                onSelectionChange={(themes) => {
+                  navigate(
+                    buildUserTestingScenarioPath(chatbox.chatboxId, {
+                      tab: "insights",
+                      session: sessionParam ?? undefined,
+                      sel: themes
+                        ? serializeSelectionParam(themes)
+                        : undefined,
+                      view,
+                    }),
+                    { replace: true },
+                  );
+                }}
+                initialView={view}
+                onViewChange={(nextView) => {
+                  navigate(
+                    buildUserTestingScenarioPath(chatbox.chatboxId, {
+                      tab: "insights",
+                      session: sessionParam ?? undefined,
+                      sel: selParam ?? undefined,
+                      view: nextView,
+                    }),
+                    { replace: true },
+                  );
                 }}
                 onOpenSession={(threadId) => {
                   navigate(
@@ -765,92 +790,49 @@ export function UserTestingScenarioDetail({
                     { replace: true },
                   );
                 }}
-              >
-                <InsightsWorkbench
-                  scope={{ kind: "chatbox", chatboxId: chatbox.chatboxId }}
-                  cohortKey={chatbox.chatboxId}
-                  // Scenarios carry real-user traffic; the retired simulation
-                  // flow's rows are still in the database and stay hidden.
-                  augmentFilter={withHideSynthetic}
-                  urlSelection={urlSelection}
-                  onSelectionChange={(themes) => {
-                    navigate(
-                      buildUserTestingScenarioPath(chatbox.chatboxId, {
-                        tab: "insights",
-                        session: sessionParam ?? undefined,
-                        sel: themes
-                          ? serializeSelectionParam(themes)
-                          : undefined,
-                        view,
-                      }),
-                      { replace: true },
-                    );
-                  }}
-                  initialView={view}
-                  onViewChange={(nextView) => {
-                    navigate(
-                      buildUserTestingScenarioPath(chatbox.chatboxId, {
-                        tab: "insights",
-                        session: sessionParam ?? undefined,
-                        sel: selParam ?? undefined,
-                        view: nextView,
-                      }),
-                      { replace: true },
-                    );
-                  }}
-                  onOpenSession={(threadId) => {
-                    navigate(
-                      buildUserTestingScenarioPath(chatbox.chatboxId, {
-                        tab: "sessions",
-                        session: threadId,
-                        sel: selParam ?? undefined,
-                        view,
-                      }),
-                      { replace: true },
-                    );
-                  }}
-                  onOpenSessionsTab={() => {
-                    navigate(
-                      buildUserTestingScenarioPath(chatbox.chatboxId, {
-                        tab: "sessions",
-                        session: sessionParam ?? undefined,
-                        sel: selParam ?? undefined,
-                        view,
-                      }),
-                      { replace: true },
-                    );
-                  }}
-                  recommendationsSlot={<RunInsightsRecommendations />}
-                  strugglesSlot={(breakdown) =>
-                    hasOutcomeFeedbackCalibration(breakdown) ? (
-                      <Popover>
-                        <PopoverTrigger asChild>
-                          <button
-                            type="button"
-                            className="inline-flex min-w-0 items-center gap-1 rounded-md border border-border/50 bg-muted/25 px-2 py-0.5 text-xs font-medium tabular-nums transition-colors hover:bg-muted/50"
-                            data-testid="chatbox-insights-feedback-chip"
-                          >
-                            Feedback
-                          </button>
-                        </PopoverTrigger>
-                        <PopoverContent
-                          align="start"
-                          className="w-[28rem] max-w-[90vw] p-0"
-                        >
-                          <div className="flex max-h-[60vh] min-h-0 flex-col overflow-y-auto">
-                            <ChatboxOutcomeCalibration breakdown={breakdown} />
-                          </div>
-                        </PopoverContent>
-                      </Popover>
-                    ) : null
-                  }
-                  autoBackfillTopicMap
-                  emptyState={<ChatboxShareEmptyPanel chatbox={chatbox} />}
-                  onEmptyChange={handleInsightsEmptyChange}
-                  className="px-8 py-4"
-                  testIdPrefix="chatbox-insights"
-                />
-              </RunInsightsProvider>
+                onOpenSessionsTab={() => {
+                  navigate(
+                    buildUserTestingScenarioPath(chatbox.chatboxId, {
+                      tab: "sessions",
+                      session: sessionParam ?? undefined,
+                      sel: selParam ?? undefined,
+                      view,
+                    }),
+                    { replace: true },
+                  );
+                }}
+                recommendationsSlot={
+                  <ErrorBoundary
+                    name="user-testing-insights-rail"
+                    fallback={null}
+                  >
+                    <RunInsightsProvider
+                      surface={{
+                        kind: "chatbox",
+                        chatboxId: chatbox.chatboxId,
+                      }}
+                      onOpenSession={(threadId) => {
+                        navigate(
+                          buildUserTestingScenarioPath(chatbox.chatboxId, {
+                            tab: "sessions",
+                            session: threadId,
+                            sel: selParam ?? undefined,
+                            view,
+                          }),
+                          { replace: true },
+                        );
+                      }}
+                    >
+                      <RunInsightsRecommendations />
+                    </RunInsightsProvider>
+                  </ErrorBoundary>
+                }
+                autoBackfillTopicMap
+                emptyState={<ChatboxShareEmptyPanel chatbox={chatbox} />}
+                onEmptyChange={handleInsightsEmptyChange}
+                className="px-8 py-4"
+                testIdPrefix="chatbox-insights"
+              />
             </ErrorBoundary>
           </div>
         ) : null}

--- a/mcpjam-inspector/client/src/components/chatboxes/__tests__/UserTestingScenarioDetail.test.tsx
+++ b/mcpjam-inspector/client/src/components/chatboxes/__tests__/UserTestingScenarioDetail.test.tsx
@@ -256,6 +256,7 @@ const openSetup = () => {
 
 beforeEach(() => {
   vi.clearAllMocks();
+  workbenchMock.mockReset();
   // `clearAllMocks` clears calls but NOT implementations — reinstate the
   // resolved defaults so a per-test rejection can't leak into later cases.
   deleteChatboxMock.mockResolvedValue(undefined);
@@ -325,6 +326,26 @@ describe("UserTestingScenarioDetail", () => {
         cohortKey: "cb-1",
       }),
     );
+  });
+
+  it("shows the share empty panel when Insights throw, not a blank pane", () => {
+    // The window-insights rail used to wrap the whole tab in
+    // `fallback={null}`. An undeployed `getWindowSignals` then left the
+    // Insights `absolute inset-0` with no children — no empty state, no
+    // retry. The workbench must stay reachable; if it itself blows up, the
+    // share empty panel is the recovery UI.
+    const consoleError = vi.spyOn(console, "error").mockImplementation(() => {});
+    workbenchMock.mockImplementation(() => {
+      throw new Error(
+        "Could not find public function: chatboxWindowInsights:getWindowSignals",
+      );
+    });
+
+    renderDetail();
+
+    expect(screen.getByTestId("stub-share-empty")).toBeInTheDocument();
+    expect(screen.queryByTestId("stub-usage-insights")).not.toBeInTheDocument();
+    consoleError.mockRestore();
   });
 
   it("switches tabs by replacing the URL, not pushing onto history", () => {


### PR DESCRIPTION
## Summary
- Isolate the window-insights rail so an undeployed `getWindowSignals` query no longer blanks the whole User Testing Insights tab.
- If the workbench itself throws, show the share empty panel instead of an empty `absolute inset-0`.

## Test plan
- [ ] Open a User Testing scenario with no sessions → Insights shows the share empty state, not a blank pane
- [ ] Open a scenario with sessions → session-flow workbench still renders
- [ ] If the window-insights rail is missing, the workbench stays up and only recommendations stay hidden

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit 7b09d10b904c59abb801166d27d1d55e07cb0aa7. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents the Insights tab from going blank when window-insights queries are undeployed or throw. Previously the entire tab was wrapped in `fallback={null}` and rendered nothing; now only the recommendations rail hides on failure and the workbench shows the share empty panel if it fails.

- Isolates `RunInsightsRecommendations` + `RunInsightsProvider` behind an `ErrorBoundary` (`user-testing-insights-rail`) with `fallback={null}` so missing window-insights only hides recommendations.
- Wraps the workbench in an `ErrorBoundary` (`user-testing-insights`) that falls back to `ChatboxShareEmptyPanel`, keeping empty state/retry visible instead of a blank pane.
- Removes the Feedback calibration UI from Insights (drops `strugglesSlot`, `ChatboxOutcomeCalibration`, `hasOutcomeFeedbackCalibration`, and `@mcpjam/design-system/popover` imports).
- Adds a test asserting the share empty panel renders on workbench errors and resets `workbenchMock` between tests.

<sup>Written for commit 7b09d10b904c59abb801166d27d1d55e07cb0aa7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/MCPJam/inspector/pull/3973?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

