### PR TITLE
fix(user-testing): stop infinite render loop reporting Insights empty state

### DIFF
--- a/mcpjam-inspector/client/src/components/chatboxes/UserTestingScenarioDetail.tsx
+++ b/mcpjam-inspector/client/src/components/chatboxes/UserTestingScenarioDetail.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useRef, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { useLocation, useNavigate } from "react-router";
 import {
   AlertTriangle,
@@ -356,9 +356,17 @@ export function UserTestingScenarioDetail({
     insightsEmptyReport?.chatboxId === chatbox.chatboxId
       ? insightsEmptyReport.empty
       : true;
-  const handleInsightsEmptyChange = (empty: boolean) => {
-    setInsightsEmptyReport({ chatboxId: chatbox.chatboxId, empty });
-  };
+  // Stable ref: a new one each render loops InsightsWorkbench's report effect.
+  const handleInsightsEmptyChange = useCallback(
+    (empty: boolean) => {
+      setInsightsEmptyReport((prev) =>
+        prev?.chatboxId === chatbox.chatboxId && prev.empty === empty
+          ? prev
+          : { chatboxId: chatbox.chatboxId, empty },
+      );
+    },
+    [chatbox.chatboxId],
+  );
   const searchParams = new URLSearchParams(location.search);
   const sessionParam = searchParams.get("session");
   const sessionDeepLinkThreadId = sessionParam;

--- a/mcpjam-inspector/client/src/components/chatboxes/__tests__/UserTestingScenarioDetail.test.tsx
+++ b/mcpjam-inspector/client/src/components/chatboxes/__tests__/UserTestingScenarioDetail.test.tsx
@@ -310,13 +310,27 @@ describe("UserTestingScenarioDetail", () => {
     // Regression for INSPECTOR-CLIENT-236 (infinite render loop).
     renderDetail();
 
-    const before = workbenchMock.mock.calls.at(-1)?.[0]?.onEmptyChange;
-    await act(async () => {
-      (before as (empty: boolean) => void)?.(false);
-    });
-    const after = workbenchMock.mock.calls.at(-1)?.[0]?.onEmptyChange;
+    const before = workbenchMock.mock.calls.at(-1)?.[0]?.onEmptyChange as
+      | ((empty: boolean) => void)
+      | undefined;
+    expect(before).toBeTypeOf("function");
 
+    const callsAfterMount = workbenchMock.mock.calls.length;
+    await act(async () => {
+      before?.(false);
+    });
+    // A no-op regression (setter or callback stops updating) would leave
+    // `calls` at the same length, making the identity check below vacuous.
+    expect(workbenchMock.mock.calls.length).toBeGreaterThan(callsAfterMount);
+    const after = workbenchMock.mock.calls.at(-1)?.[0]?.onEmptyChange;
     expect(after).toBe(before);
+
+    // Redundant update, same value: the no-op guard must skip the re-render.
+    const callsAfterFirstUpdate = workbenchMock.mock.calls.length;
+    await act(async () => {
+      before?.(false);
+    });
+    expect(workbenchMock.mock.calls.length).toBe(callsAfterFirstUpdate);
   });
 
   it("shows setup and share controls on the Edit route", () => {

--- a/mcpjam-inspector/client/src/components/chatboxes/__tests__/UserTestingScenarioDetail.test.tsx
+++ b/mcpjam-inspector/client/src/components/chatboxes/__tests__/UserTestingScenarioDetail.test.tsx
@@ -306,6 +306,19 @@ describe("UserTestingScenarioDetail", () => {
     expect(screen.getByTestId("stub-share-banner")).toBeInTheDocument();
   });
 
+  it("keeps onEmptyChange stable across the render it triggers", async () => {
+    // Regression for INSPECTOR-CLIENT-236 (infinite render loop).
+    renderDetail();
+
+    const before = workbenchMock.mock.calls.at(-1)?.[0]?.onEmptyChange;
+    await act(async () => {
+      (before as (empty: boolean) => void)?.(false);
+    });
+    const after = workbenchMock.mock.calls.at(-1)?.[0]?.onEmptyChange;
+
+    expect(after).toBe(before);
+  });
+
   it("shows setup and share controls on the Edit route", () => {
     renderEdit();
 


### PR DESCRIPTION
## Summary
- `handleInsightsEmptyChange` in `UserTestingScenarioDetail` was recreated every render; `InsightsWorkbench`'s `useEffect([showingEmpty, onEmptyChange])` therefore refired every render, calling `setState` with a fresh object each time and looping ("Maximum update depth exceeded").
- Memoized the callback with `useCallback` (keyed on `chatbox.chatboxId`) and made the setter a no-op when nothing actually changed.

Fixes Sentry issue **INSPECTOR-CLIENT-236**, first seen on `/user-testing`.

## Test plan
- [x] Added a regression test asserting `onEmptyChange` keeps the same reference across the render it triggers (fails on old code, passes now)
- [x] `UserTestingScenarioDetail.test.tsx` — 36/36 passing
- [x] `usage-insights/__tests__/` — 182/182 passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stops an infinite render loop when the Insights empty state is reported in /user-testing. Previously, handleInsightsEmptyChange was recreated on every render, refiring InsightsWorkbench’s [showingEmpty, onEmptyChange] effect and calling setState repeatedly; now the callback is memoized with useCallback keyed by chatbox.chatboxId and the setter no-ops when nothing changed.

- Functional setState compares previous chatboxId and empty to avoid redundant updates.
- Strengthens the regression test: proves a re-render happens on first change, preserves onEmptyChange identity across that render, and skips redundant same-value updates.
- No user-visible behavior change beyond eliminating the "Maximum update depth exceeded" crash.
- Resolves Sentry INSPECTOR-CLIENT-236.

<sup>Written for commit fa3c461559300ee99a72a0afa4d04f0989fca12b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/MCPJam/inspector/pull/3975?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

