### PR TITLE
fix(playground): seed guests with Cursor, not the gated Claude Code 

### DIFF
--- a/mcpjam-inspector/client/src/components/ui-playground/PlaygroundMain.tsx
+++ b/mcpjam-inspector/client/src/components/ui-playground/PlaygroundMain.tsx
@@ -247,10 +247,14 @@ const PLAYGROUND_SEED_RETRY_DELAYS_MS = [1_000, 4_000, 10_000];
 
 // PUR-11: the 3 catalog templates a first-run guest's Playground compare
 // lineup is seeded from, lead first. See the "Seed backstop" effect below.
+// Keep every id here flag-free: guests never match a rollout gate, and the
+// seed refuses a partial lineup (falling back to one blank host), so a gated
+// template like "claude-code" would both leak the gated client to everyone
+// and have no working way to be filtered out.
 const PLAYGROUND_SEED_TEMPLATE_IDS = [
   "chatgpt",
   "claude",
-  "claude-code",
+  "cursor",
 ] as const;
 
 function buildHistoryContentSignature(
@@ -1296,7 +1300,7 @@ export function PlaygroundMain({
   // default "MCPJam" host for empty projects) is hidden on the playground, so
   // this replicates that one-shot seed — but with the immediate client-
   // comparison value prop (PUR-11): guests land with 3 pre-selected clients
-  // (ChatGPT, Claude, Claude Code) instead of one blank host + a toggle they'd
+  // (ChatGPT, Claude, Cursor) instead of one blank host + a toggle they'd
   // have to find and flip themselves. Guarded by `hostList.length === 0` + a
   // per-project ref so it fires at most once per empty project and never
   // blocks a different empty project from getting its own default hosts.

--- a/mcpjam-inspector/client/src/components/ui-playground/__tests__/PlaygroundMain.multi-host.test.tsx
+++ b/mcpjam-inspector/client/src/components/ui-playground/__tests__/PlaygroundMain.multi-host.test.tsx
@@ -695,8 +695,8 @@ describe("PlaygroundMain — multi-host render path", () => {
     expect(mockCreateHost).not.toHaveBeenCalled();
   });
 
-  // PUR-11: guests land with 3 pre-selected clients (ChatGPT, Claude, Claude
-  // Code) instead of a single blank "MCPJam" host + a toggle to find first.
+  // PUR-11: guests land with 3 pre-selected clients (ChatGPT, Claude, Cursor)
+  // instead of a single blank "MCPJam" host + a toggle to find first.
   it("seeds 3 default clients (ChatGPT, Claude, Cursor) for empty projects", async () => {
     multiHostFixture.multiHostEnabled = false;
     multiHostFixture.hostList = [];

--- a/mcpjam-inspector/client/src/components/ui-playground/__tests__/PlaygroundMain.multi-host.test.tsx
+++ b/mcpjam-inspector/client/src/components/ui-playground/__tests__/PlaygroundMain.multi-host.test.tsx
@@ -512,7 +512,7 @@ vi.mock("@/hooks/useClients", () => ({
 }));
 
 // PUR-11 seed backstop reads live catalog templates (chatgpt/claude/
-// claude-code) to seed a guest's first 3 clients. `getCatalogHost` /
+// cursor) to seed a guest's first 3 clients. `getCatalogHost` /
 // `getCatalogTemplate` are the REAL sdk functions running against this fake
 // "live" catalog — only the network-fetching hook is mocked.
 const seedCatalogFixture = {
@@ -551,18 +551,18 @@ const seedCatalogFixture = {
         clientCapabilities: {},
         hostContext: {},
       },
-      "claude-code": {
-        id: "claude-code",
-        label: "Claude Code",
-        provenance: "vendor-doc",
-        rendersMcpApps: false,
-        modelId: "anthropic/claude-haiku-4.5",
+      cursor: {
+        id: "cursor",
+        label: "Cursor",
+        provenance: "probe",
+        rendersMcpApps: true,
+        modelId: "anthropic/claude-sonnet-4.5",
         systemPrompt: "",
-        temperature: 1,
+        temperature: 0.7,
         requireToolApproval: false,
         serverIds: [],
         optionalServerIds: [],
-        connectionDefaults: { headers: {}, requestTimeout: 10000 },
+        connectionDefaults: { headers: {}, requestTimeout: 30000 },
         clientCapabilities: {},
         hostContext: {},
       },
@@ -697,7 +697,7 @@ describe("PlaygroundMain — multi-host render path", () => {
 
   // PUR-11: guests land with 3 pre-selected clients (ChatGPT, Claude, Claude
   // Code) instead of a single blank "MCPJam" host + a toggle to find first.
-  it("seeds 3 default clients (ChatGPT, Claude, Claude Code) for empty projects", async () => {
+  it("seeds 3 default clients (ChatGPT, Claude, Cursor) for empty projects", async () => {
     multiHostFixture.multiHostEnabled = false;
     multiHostFixture.hostList = [];
     mockCreateHost
@@ -710,8 +710,8 @@ describe("PlaygroundMain — multi-host render path", () => {
         hostConfigId: "h-claude-config",
       })
       .mockResolvedValueOnce({
-        hostId: "h-claude-code",
-        hostConfigId: "h-claude-code-config",
+        hostId: "h-cursor",
+        hostConfigId: "h-cursor-config",
       });
 
     // So the grid-render assertion below is actually wired to what the seed
@@ -736,11 +736,11 @@ describe("PlaygroundMain — multi-host render path", () => {
     expect(mockCreateHost).toHaveBeenCalledWith(
       expect.objectContaining({
         projectId: "default",
-        name: "Claude Code",
+        name: "Cursor",
         // The seed pins each template's default model — a modelless host
         // breaks synthetic/swarm runs (no picker fallback on that path).
         input: expect.objectContaining({
-          modelId: "anthropic/claude-haiku-4.5",
+          modelId: "anthropic/claude-sonnet-4.5",
         }),
       })
     );
@@ -754,7 +754,7 @@ describe("PlaygroundMain — multi-host render path", () => {
     expect(mockSetSelectedHostIds).toHaveBeenCalledWith([
       "h-chatgpt",
       "h-claude",
-      "h-claude-code",
+      "h-cursor",
     ]);
 
     // The acceptance criterion end to end: once the host-list query catches
@@ -770,13 +770,13 @@ describe("PlaygroundMain — multi-host render path", () => {
     multiHostFixture.hostList = [
       { hostId: "h-chatgpt", name: "ChatGPT" },
       { hostId: "h-claude", name: "Claude" },
-      { hostId: "h-claude-code", name: "Claude Code" },
+      { hostId: "h-cursor", name: "Cursor" },
     ];
     multiHostFixture.hosts = {
       "h-chatgpt": makeHost("h-chatgpt", "ChatGPT", { hostStyle: "chatgpt" }),
       "h-claude": makeHost("h-claude", "Claude", { hostStyle: "claude" }),
-      "h-claude-code": makeHost("h-claude-code", "Claude Code", {
-        hostStyle: "claude-code",
+      "h-cursor": makeHost("h-cursor", "Cursor", {
+        hostStyle: "cursor",
       }),
     };
     rerender(<PlaygroundMain {...defaultProps} />);
@@ -807,8 +807,8 @@ describe("PlaygroundMain — multi-host render path", () => {
         hostConfigId: "h-claude-config",
       })
       .mockResolvedValueOnce({
-        hostId: "h-claude-code",
-        hostConfigId: "h-claude-code-config",
+        hostId: "h-cursor",
+        hostConfigId: "h-cursor-config",
       });
 
     render(<PlaygroundMain {...defaultProps} />);
@@ -820,7 +820,7 @@ describe("PlaygroundMain — multi-host render path", () => {
       expect(mockSetSelectedHostIds).toHaveBeenCalledWith([
         "h-chatgpt",
         "h-claude",
-        "h-claude-code",
+        "h-cursor",
       ]);
     });
   });
@@ -968,8 +968,8 @@ describe("PlaygroundMain — multi-host render path", () => {
         hostConfigId: "h-claude-config",
       })
       .mockResolvedValueOnce({
-        hostId: "h-claude-code",
-        hostConfigId: "h-claude-code-config",
+        hostId: "h-cursor",
+        hostConfigId: "h-cursor-config",
       });
 
     render(<PlaygroundMain {...defaultProps} />);
@@ -981,7 +981,7 @@ describe("PlaygroundMain — multi-host render path", () => {
       expect(mockSetSelectedHostIds).toHaveBeenCalledWith([
         "h-chatgpt",
         "h-claude",
-        "h-claude-code",
+        "h-cursor",
       ]);
     });
   });
@@ -1018,7 +1018,7 @@ describe("PlaygroundMain — multi-host render path", () => {
     await act(async () => {
       releaseCreate[0]({ hostId: "h-chatgpt" });
       releaseCreate[1]({ hostId: "h-claude" });
-      releaseCreate[2]({ hostId: "h-claude-code" });
+      releaseCreate[2]({ hostId: "h-cursor" });
     });
 
     await waitFor(() => {
@@ -1029,7 +1029,7 @@ describe("PlaygroundMain — multi-host render path", () => {
     expect(mockSetSelectedHostIds).not.toHaveBeenCalledWith([
       "h-chatgpt",
       "h-claude",
-      "h-claude-code",
+      "h-cursor",
     ]);
   });
 
@@ -1068,7 +1068,7 @@ describe("PlaygroundMain — multi-host render path", () => {
     await act(async () => {
       releaseCreate[0]({ hostId: "h-chatgpt" });
       releaseCreate[1]({ hostId: "h-claude" });
-      releaseCreate[2]({ hostId: "h-claude-code" });
+      releaseCreate[2]({ hostId: "h-cursor" });
     });
 
     // The lineup still lands, and the auto-picked lead is kept rather than
@@ -1077,7 +1077,7 @@ describe("PlaygroundMain — multi-host render path", () => {
       expect(loadSelectedHostIds("default")).toEqual([
         "h-chatgpt",
         "h-claude",
-        "h-claude-code",
+        "h-cursor",
       ]);
     });
     expect(readPreviewedHostId()).toBe("h-chatgpt");
@@ -1096,8 +1096,8 @@ describe("PlaygroundMain — multi-host render path", () => {
         hostConfigId: "h-first-claude-config",
       })
       .mockResolvedValueOnce({
-        hostId: "h-first-claude-code",
-        hostConfigId: "h-first-claude-code-config",
+        hostId: "h-first-cursor",
+        hostConfigId: "h-first-cursor-config",
       })
       .mockResolvedValueOnce({
         hostId: "h-second-chatgpt",
@@ -1108,8 +1108,8 @@ describe("PlaygroundMain — multi-host render path", () => {
         hostConfigId: "h-second-claude-config",
       })
       .mockResolvedValueOnce({
-        hostId: "h-second-claude-code",
-        hostConfigId: "h-second-claude-code-config",
+        hostId: "h-second-cursor",
+        hostConfigId: "h-second-cursor-config",
       });
 
     const { rerender } = render(<PlaygroundMain {...defaultProps} />);
@@ -1121,7 +1121,7 @@ describe("PlaygroundMain — multi-host render path", () => {
     expect(mockSetSelectedHostIds).toHaveBeenCalledWith([
       "h-first-chatgpt",
       "h-first-claude",
-      "h-first-claude-code",
+      "h-first-cursor",
     ]);
 
     rerender(<PlaygroundMain {...defaultProps} activeProjectId="second" />);
@@ -1141,12 +1141,12 @@ describe("PlaygroundMain — multi-host render path", () => {
       expect.objectContaining({ projectId: "second", name: "Claude" })
     );
     expect(mockCreateHost).toHaveBeenCalledWith(
-      expect.objectContaining({ projectId: "second", name: "Claude Code" })
+      expect.objectContaining({ projectId: "second", name: "Cursor" })
     );
     expect(mockSetSelectedHostIds).toHaveBeenCalledWith([
       "h-second-chatgpt",
       "h-second-claude",
-      "h-second-claude-code",
+      "h-second-cursor",
     ]);
   });
 


### PR DESCRIPTION
The PUR-11 guest seed cloned the "claude-code" catalog template directly, bypassing the `claude-code-host-enabled` PostHog gate (@mcpjam.com only) — so every first-run guest landed with a real Claude Code client. Gating the seed instead would leave a 2-template lineup, which the seed refuses, dropping guests to one blank host; swapping in "cursor" keeps the 3-way compare and every seeded template flag-free.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Seeds first‑run guests with Cursor instead of the gated Claude Code template, keeping the 3‑way compare lineup flag‑free and honoring the `claude-code-host-enabled` gate. Previously we seeded ChatGPT, Claude, and Claude Code; now we seed ChatGPT, Claude, and Cursor.

- Ensures `PLAYGROUND_SEED_TEMPLATE_IDS` are ungated so guests never fall back to a single blank host (PUR-11).
- Updates tests/fixtures to expect Cursor IDs, labels, and defaults (model and timeout), and asserts the selected host IDs order.
- Updates inline comments to reference Cursor so code and docs match.
- No migrations; existing projects and non‑guest flows are unaffected. QA: create a new/empty project as a guest and confirm ChatGPT, Claude, and Cursor are pre‑selected; Claude Code remains gated.

<sup>Written for commit a67cdf3581b53082a728fae4408676b50ab0d946. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/MCPJam/inspector/pull/3976?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

