### PR TITLE
docs(v1): correct the org-clamp security narrative from #3970

### DIFF
--- a/mcpjam-inspector/server/routes/v1/__tests__/projects-org-scope.test.ts
+++ b/mcpjam-inspector/server/routes/v1/__tests__/projects-org-scope.test.ts
@@ -4,18 +4,18 @@ import { Hono } from "hono";
 /**
  * The org clamp on the project WRITE routes.
  *
- * The backend does not apply one: `projects:createProject` checks the acting
- * USER's membership in the requested org (`requireOrgRole`), the update/delete
- * mutations resolve project access from the same user, and `userMutation`
- * never reads the delegated-org claim. So an `sk_` key bound to org A, minted
- * by someone who also belongs to org B, could reach B's projects — the key's
- * promised scope is not the scope actually enforced.
+ * The backend enforces the delegated org claim inside membership resolution
+ * (`delegatedScopeAllowsOrganization` → `getOrgMembership`), so these gateway
+ * checks are defense-in-depth plus two things the chokepoint cannot give:
+ * a clean 404/403 in this route's own vocabulary, and — the load-bearing one
+ * — the POST fill-in, without which an org-less `create_project` falls back
+ * to the acting user's DEFAULT org and gets REJECTED by the chokepoint
+ * instead of landing in the key's org.
  *
- * The gateway enforces it instead, mirroring the clamp the Convex
- * `/v1/projects` READ route already applies. These tests are the proof, and
- * the session-JWT cases are here to prove the clamp does NOT overreach: a
- * signed-in person is confined to nothing and must keep full access to every
- * org they belong to.
+ * These tests pin the gateway behavior alone (Convex is mocked, so the
+ * backend chokepoint is deliberately out of frame). The session-JWT cases
+ * prove the clamp does NOT overreach: a signed-in person is confined to
+ * nothing and must keep full access to every org they belong to.
  */
 
 const {

--- a/mcpjam-inspector/server/routes/v1/agent.ts
+++ b/mcpjam-inspector/server/routes/v1/agent.ts
@@ -907,6 +907,15 @@ agent.post("/projects/:projectId/agent", async (c) => {
         "In-process /api/v1 dispatch is not registered."
       );
     }
+    // NOTE: self-dispatched requests re-enter bearer auth carrying the
+    // delegated JWT, not the original `sk_` key, so the middleware labels them
+    // a passthrough JWT with no `mcpjamOrganizationId` — every gateway-level
+    // org clamp (`getDelegatedOrganizationId`) is a no-op on this path. That
+    // is contained, not open: the JWT's own org claim is enforced inside
+    // Convex membership resolution (`delegatedScopeAllowsOrganization`), which
+    // is the canonical barrier. But gateway-only niceties (the `POST
+    // /projects` org fill-in, the membership-enumeration clamps) do not apply
+    // to ops invoked through this client.
     const makeClient = (extraHeaders: Record<string, string> = {}) =>
       new PlatformApiClient({
         baseUrl: "http://self.mcpjam.internal/api/v1",

--- a/mcpjam-inspector/server/routes/v1/projects.ts
+++ b/mcpjam-inspector/server/routes/v1/projects.ts
@@ -78,12 +78,17 @@ async function readProject(token: string, projectId: string) {
 /**
  * Refuse to touch a project outside a delegated caller's organization.
  *
- * The mutations address a project by id, and the backend resolves access from
- * the acting USER (`resolveProjectAccess`), never from the delegated token's
- * org — so an `sk_` key bound to org A, minted by someone who also belongs to
- * org B, can otherwise rename or delete B's projects. `getMyProjects` returns
- * the user's projects across ALL their orgs, which is exactly why the id
- * resolves at all and exactly why this check is needed.
+ * DEFENSE-IN-DEPTH, not the only barrier. The backend enforces the delegated
+ * token's org claim inside membership resolution itself
+ * (`delegatedScopeAllowsOrganization` in mcpjam-backend
+ * `convex/lib/authorization.ts`, applied by `getOrgMembership` and therefore
+ * by `resolveProjectAccess`/`requireProjectRole`), so a cross-org mutation
+ * already fails there. What the chokepoint does NOT cover is
+ * `projects:getMyProjects`, which enumerates the user's memberships directly
+ * — `readProject` resolves ids across ALL the user's orgs, and this guard is
+ * what keeps that resolver from widening the gateway's answer. It also pins
+ * the status: a clean 404 here, instead of whatever the backend's rejection
+ * translates to.
  *
  * 404, not 403: the existing miss for an unknown id is already 404, and
  * answering 403 here would confirm that a project the key may not see exists.
@@ -117,20 +122,18 @@ projects.post("/projects", async (c) => {
   }
   const body = parseWithSchema(createProjectSchema, raw);
 
-  // Org clamp for delegated (`sk_` / service) callers, applied HERE because
-  // the backend mutation does not: `projects:createProject` checks the acting
-  // USER's membership in the requested org (`requireOrgRole`), and
-  // `userMutation` never reads the delegated-org claim. So a key bound to org
-  // A, minted by someone who also belongs to org B, could otherwise create in
-  // B. This mirrors the clamp the Convex `/v1/projects` READ route already
-  // applies (convex/publicApi/routes.ts).
+  // Org clamp for delegated (`sk_` / service) callers.
   //
-  // Two cases, and the SECOND is the common one: an explicit mismatch is
-  // rejected, and an ABSENT organizationId is filled in rather than left to
-  // the backend's "the user's default org" fallback — which for a delegated
-  // key is not necessarily the org the key is bound to. An agent calling
-  // create_project with just a name is the likely path, and it must land in
-  // the key's org.
+  // Two cases, and the SECOND is the load-bearing one. An explicit mismatch
+  // is rejected with a clean 403 — the backend's own org chokepoint
+  // (`delegatedScopeAllowsOrganization` inside membership resolution) would
+  // refuse it anyway, but as a translated backend error rather than this
+  // deliberate copy. An ABSENT organizationId is filled in with the key's
+  // org: left alone, the backend falls back to the acting user's DEFAULT
+  // org, which need not be the key's — and since the chokepoint then rejects
+  // the mismatch, `create_project` with just a name (the likely agent call)
+  // would ERROR instead of landing in the key's org. The fill-in is what
+  // makes the bare call work.
   //
   // Session-JWT callers are untouched: they are confined to nothing and may
   // still create in any org they belong to.

--- a/mcpjam-inspector/server/utils/v1-convex-token.ts
+++ b/mcpjam-inspector/server/utils/v1-convex-token.ts
@@ -160,12 +160,16 @@ function usesDelegatedToken(c: Context): boolean {
  * The organization this request is CONFINED TO, or `undefined` for a caller
  * who is confined to nothing.
  *
- * The backend applies this itself for everything reached through a delegated
- * JWT — the token is minted for one org and Convex re-checks membership in it.
- * What the backend cannot clamp is a query that is not org-scoped at all:
- * `organizations:getMyOrganizations` answers "every org this HUMAN belongs to",
- * which for an `sk_` key bound to one org is strictly more than the key may
- * see. A route serving such a query must intersect the result with this.
+ * The backend applies this itself for anything that resolves MEMBERSHIP: the
+ * token's org claim is enforced by `delegatedScopeAllowsOrganization` inside
+ * `getOrgMembership` (mcpjam-backend `convex/lib/authorization.ts`), which
+ * every `resolveProjectAccess`/`requireOrgRole`/`requireProjectRole` path
+ * runs through. What the backend cannot clamp is a query that ENUMERATES
+ * memberships without naming an org: `organizations:getMyOrganizations` and
+ * `projects:getMyProjects` walk the user's membership rows directly and
+ * answer for the acting HUMAN across every org they belong to — strictly more
+ * than an org-bound `sk_` key may see. A route serving such a query must
+ * intersect the result with this.
  *
  * Read the AUTH METHOD, not the presence of `mcpjamOrganizationId`: a session
  * JWT caller can carry the var too (it is the org their UI is looking at), and
@@ -175,10 +179,10 @@ function usesDelegatedToken(c: Context): boolean {
  * FAILS CLOSED. A delegated caller whose org cannot be resolved throws rather
  * than returning `undefined`, because `undefined` here means "confined to
  * nothing" — the caller would skip the clamp entirely and receive everything.
- * The two states are opposites and must not share a return value. Today this
- * is also unreachable, since `getConvexBearerForRequest` mints first and
- * `delegationContext` rejects the same broken state (with this same code); the
- * throw is here so the clamp does not depend on that ordering holding.
+ * The two states are opposites and must not share a return value. Routes are
+ * free to call this before OR after the token mint (`POST /projects` clamps
+ * before minting), so this throw cannot lean on `delegationContext` having
+ * already rejected the same broken state.
  */
 export function getDelegatedOrganizationId(c: Context): string | undefined {
   if (!usesDelegatedToken(c)) return undefined;


### PR DESCRIPTION
Follow-up 1 from the #3970 audit: sweep every other v1 route for the delegated-org confinement gap. The sweep's answer changed the deliverable — **the gap does not exist**, and this PR corrects the comments that said it did, instead of adding ~40 redundant guards.

## What the sweep found

The backend has enforced the delegated token's org claim **inside membership resolution** since June (`delegatedScopeAllowsOrganization` → `getOrgMembership`, backend `convex/lib/authorization.ts:24,156`, shipped in backend `1193531b` on 2026-06-10). Every access helper the v1 route families rely on runs through it — verified per family against backend main:

| Family | Entry point | Chokepointed via |
| --- | --- | --- |
| evals | `authorizeForSuiteActor` (`testSuites.ts:1851`) | `requireProjectRole` / `requireWorkspaceRole` |
| journeys | `journeys:getJourney:165` | `requireProjectRole` |
| hosts | `hosts:getHost:107` | `resolveProjectAccess` |
| environments | `requireMemberAccess` (`projectEnvironments.ts:178`) | `resolveProjectAccess` |
| images | `requireEnvProjectAccess` (`computerEnvironments.ts:174`) | `resolveProjectAccess` |
| servers | `listProjectServersForUser` (`servers.ts:255`) | `hasProjectRole` |
| plugins | `requireProjectPluginRead` (`lib/pluginAuthorization.ts:64`) | `resolveProjectAccess` |
| scenarios/chatboxes | workspace access | `resolveWorkspaceAccess` |

So a cross-org suiteId/hostId/journeyId through a delegated key already dies in Convex. The only things the chokepoint cannot clamp are queries that **enumerate memberships** without naming an org — `organizations:getMyOrganizations` and `projects:getMyProjects` — which are exactly the two #3970 guarded.

## What this PR changes (comments and test docblocks only, no behavior)

- `projects.ts`: the guard and POST-clamp comments no longer claim "the backend never reads the delegated-org claim." They now say what is true: the PATCH/DELETE guard is defense-in-depth + a clean 404; the **POST org fill-in is the load-bearing piece** (an org-less `create_project` falls back to the user's default org, which the chokepoint then *rejects* — the fill-in is what makes the bare call land in the key's org).
- `v1-convex-token.ts`: `getDelegatedOrganizationId`'s docstring names the real backend boundary (membership resolution clamps; membership *enumeration* does not) and drops the stale "the throw is unreachable today" sentence — `POST /projects` clamps before minting, so it is reachable.
- `projects-org-scope.test.ts`: header restated on the same corrected premise.
- `agent.ts`: documents that self-dispatched platform ops re-enter auth as a passthrough JWT, so gateway clamps are no-ops on that path and the Convex chokepoint is the barrier there.

## Why correct comments instead of adding guards

The false narrative is the actual hazard: it invites a future contributor to bolt per-route org guards onto ~40 routes, duplicating an invariant the backend already enforces at the canonical layer — and a gateway copy that drifts from the canonical one is worse than none.

## Verification

- Affected suites: `projects-org-scope`, `organizations`, agent tests — 116 passed (5 files).
- Backend claims verified by reading mcpjam-backend `main` (paths/lines above), not from the #3970 description.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit dceca694e0737f61f42b8ac3c07c09a7058ce7d2. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Corrects the v1 org-clamp security narrative from #3970: the backend already enforces a delegated token’s org claim inside membership resolution. Updates comments/docstrings to reflect the real boundary, explain why the POST org fill-in is load-bearing, and note that only membership-enumerating queries need gateway clamping; no behavior changes.

- Updates comments in `server/routes/v1/projects.ts`, `server/utils/v1-convex-token.ts`, `server/routes/v1/agent.ts`, and `server/routes/v1/__tests__/projects-org-scope.test.ts` to:
  - State that `delegatedScopeAllowsOrganization` is applied via `getOrgMembership` (and thus via `resolveProjectAccess`/`requireProjectRole`/`requireOrgRole`).
  - Call out the two cases the chokepoint cannot clamp: `organizations:getMyOrganizations` and `projects:getMyProjects`.
  - Mark PATCH/DELETE project checks as defense-in-depth with a clean 404, and the POST org fill-in as load-bearing (prevents fallback to a user default org that the chokepoint would reject).
  - Clarify `getDelegatedOrganizationId` fail-closed behavior is reachable pre-mint; drop the “unreachable today” note.
  - Document that self-dispatched ops re-enter as passthrough JWTs, so gateway clamps are no-ops there and the backend chokepoint is the barrier.
- Review focus: verify only comments/docblocks changed; no new guards or runtime logic. This prevents redundant per-route guards that would duplicate backend enforcement.

<sup>Written for commit dceca694e0737f61f42b8ac3c07c09a7058ce7d2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/MCPJam/inspector/pull/3978?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

