### PR TITLE
refactor(cli): one shared platform-command runner instead of nine copies

### DIFF
--- a/.changeset/cli-platform-command-dedupe.md
+++ b/.changeset/cli-platform-command-dedupe.md
@@ -1,0 +1,5 @@
+---
+"@mcpjam/cli": patch
+---
+
+Internal refactor: the nine per-command copies of `addPlatformOptions` / `runPlatformCommand` / `PlatformOptions` collapse into one shared `cli/src/lib/platform-command.ts`. The shared runner is the superset of the variants that had drifted — the execute context always carries `webOrigin` (previously `eval`-only) and the optional external abort signal (previously `projects`-only) — so no command loses behavior. No user-facing changes.

--- a/cli/src/commands/chat.ts
+++ b/cli/src/commands/chat.ts
@@ -10,69 +10,18 @@
  */
 import type { Command } from "commander";
 import {
+  addPlatformOptions,
+  runPlatformCommand,
+  type PlatformOptions,
+} from "../lib/platform-command.js";
+import {
   getChatboxOperation,
   listChatSessionsOperation,
   listChatboxesOperation,
-  PlatformApiError,
   type PlatformOperation,
 } from "@mcpjam/sdk/platform";
 import { writeResult } from "../lib/output.js";
-import { buildPlatformClient, toCliError } from "../lib/platform-client.js";
 import { getGlobalOptions } from "../lib/server-config.js";
-
-type PlatformOptions = {
-  apiKey?: string;
-  apiUrl?: string;
-};
-
-function addPlatformOptions(command: Command): Command {
-  return command
-    .option("--api-key <key>", "MCPJam sk_ API key (overrides MCPJAM_API_KEY)")
-    .option(
-      "--api-url <url>",
-      "MCPJam API base URL (defaults to https://app.mcpjam.com/api/v1)",
-    );
-}
-
-async function runPlatformCommand<TOutput>(
-  options: PlatformOptions,
-  timeoutMs: number,
-  execute: (context: {
-    client: ReturnType<typeof buildPlatformClient>["client"];
-    signal: AbortSignal;
-  }) => Promise<TOutput>,
-): Promise<TOutput> {
-  const controller = new AbortController();
-  const timeoutHandle = setTimeout(() => {
-    controller.abort(
-      new PlatformApiError(
-        `Request timed out after ${timeoutMs}ms`,
-        "TIMEOUT",
-        {
-          status: 0,
-        },
-      ),
-    );
-  }, timeoutMs);
-  timeoutHandle.unref?.();
-
-  try {
-    const { client } = buildPlatformClient({ ...options, timeoutMs });
-    return await execute({ client, signal: controller.signal });
-  } catch (error) {
-    // When OUR deadline fired, surface the armed TIMEOUT error rather than the
-    // bare AbortError some fetch implementations reject with.
-    if (
-      controller.signal.aborted &&
-      controller.signal.reason instanceof PlatformApiError
-    ) {
-      throw toCliError(controller.signal.reason);
-    }
-    throw toCliError(error);
-  } finally {
-    clearTimeout(timeoutHandle);
-  }
-}
 
 /** Validate against the operation's own schema so bad flags fail before the call. */
 function validateOpInput<TInput>(

--- a/cli/src/commands/environments.ts
+++ b/cli/src/commands/environments.ts
@@ -1,6 +1,11 @@
 import { readFileSync } from "node:fs";
 import type { Command } from "commander";
 import {
+  addPlatformOptions,
+  runPlatformCommand,
+  type PlatformOptions,
+} from "../lib/platform-command.js";
+import {
   archiveEnvironmentOperation,
   createEnvironmentOperation,
   getEnvironmentCapabilitiesOperation,
@@ -9,12 +14,10 @@ import {
   resolveEnvironmentOperation,
   restoreEnvironmentOperation,
   updateEnvironmentOperation,
-  PlatformApiError,
   type PlatformOperation,
 } from "@mcpjam/sdk/platform";
 import { JsonInputContext } from "../lib/json-input.js";
 import { usageError, writeResult } from "../lib/output.js";
-import { buildPlatformClient, toCliError } from "../lib/platform-client.js";
 import { getGlobalOptions } from "../lib/server-config.js";
 
 /**
@@ -30,58 +33,6 @@ import { getGlobalOptions } from "../lib/server-config.js";
  * changed the environment in between, the write is rejected with a conflict
  * rather than silently overwriting their edit.
  */
-
-type PlatformOptions = {
-  apiKey?: string;
-  apiUrl?: string;
-};
-
-function addPlatformOptions(command: Command): Command {
-  return command
-    .option("--api-key <key>", "MCPJam sk_ API key (overrides MCPJAM_API_KEY)")
-    .option(
-      "--api-url <url>",
-      "MCPJam API base URL (defaults to https://app.mcpjam.com/api/v1)"
-    );
-}
-
-async function runPlatformCommand<TOutput>(
-  options: PlatformOptions,
-  timeoutMs: number,
-  execute: (context: {
-    client: ReturnType<typeof buildPlatformClient>["client"];
-    signal: AbortSignal;
-  }) => Promise<TOutput>
-): Promise<TOutput> {
-  const controller = new AbortController();
-  const timeoutHandle = setTimeout(() => {
-    controller.abort(
-      new PlatformApiError(
-        `Request timed out after ${timeoutMs}ms`,
-        "TIMEOUT",
-        {
-          status: 0,
-        }
-      )
-    );
-  }, timeoutMs);
-  timeoutHandle.unref?.();
-
-  try {
-    const { client } = buildPlatformClient({ ...options, timeoutMs });
-    return await execute({ client, signal: controller.signal });
-  } catch (error) {
-    if (
-      controller.signal.aborted &&
-      controller.signal.reason instanceof PlatformApiError
-    ) {
-      throw toCliError(controller.signal.reason);
-    }
-    throw toCliError(error);
-  } finally {
-    clearTimeout(timeoutHandle);
-  }
-}
 
 function validateInput<TInput>(
   op: PlatformOperation<TInput, unknown>,

--- a/cli/src/commands/eval.ts
+++ b/cli/src/commands/eval.ts
@@ -8,6 +8,11 @@ import {
 import { dirname, join } from "node:path";
 import type { Command } from "commander";
 import {
+  addPlatformOptions,
+  runPlatformCommand,
+  type PlatformOptions,
+} from "../lib/platform-command.js";
+import {
   createEvalCaseOperation,
   createEvalSuiteOperation,
   deleteEvalCaseOperation,
@@ -23,7 +28,6 @@ import {
   listEvalRunIterationsOperation,
   listEvalSuiteRunsOperation,
   listEvalSuitesOperation,
-  PlatformApiError,
   runEvalCaseOperation,
   runEvalSuiteOperation,
   setEvalSuiteEnvironmentsOperation,
@@ -42,21 +46,11 @@ import {
 } from "../lib/eval-screenshots.js";
 import { operationalError, usageError, writeResult } from "../lib/output.js";
 import { DEFAULT_PLATFORM_ORIGIN } from "../lib/platform-auth.js";
-import {
-  buildPlatformClient,
-  toCliError,
-  webOriginForApiBaseUrl,
-} from "../lib/platform-client.js";
 import { getGlobalOptions, parsePositiveInteger } from "../lib/server-config.js";
 import {
   detectInlineImageProtocol,
   encodeInlineImage,
 } from "../lib/terminal-image.js";
-
-type PlatformOptions = {
-  apiKey?: string;
-  apiUrl?: string;
-};
 
 type CreateOptions = PlatformOptions & {
   project?: string;
@@ -67,15 +61,6 @@ type CreateOptions = PlatformOptions & {
   provider?: string;
   server?: string[];
 };
-
-function addPlatformOptions(command: Command): Command {
-  return command
-    .option("--api-key <key>", "MCPJam sk_ API key (overrides MCPJAM_API_KEY)")
-    .option(
-      "--api-url <url>",
-      "MCPJam API base URL (defaults to https://app.mcpjam.com/api/v1)"
-    );
-}
 
 /**
  * Print a deep link to a run, after the command's own machine-readable
@@ -107,50 +92,6 @@ function writeRunLink(
       suiteId
     )}/runs/${encodeURIComponent(runId)}${query}\n`
   );
-}
-
-async function runPlatformCommand<TOutput>(
-  options: PlatformOptions,
-  timeoutMs: number,
-  execute: (context: {
-    client: ReturnType<typeof buildPlatformClient>["client"];
-    signal: AbortSignal;
-    /** App origin matching the API base this call went to. */
-    webOrigin: string;
-  }) => Promise<TOutput>
-): Promise<TOutput> {
-  const controller = new AbortController();
-  const timeoutHandle = setTimeout(() => {
-    controller.abort(
-      new PlatformApiError(
-        `Request timed out after ${timeoutMs}ms`,
-        "TIMEOUT",
-        {
-          status: 0,
-        }
-      )
-    );
-  }, timeoutMs);
-  timeoutHandle.unref?.();
-
-  try {
-    const { client, baseUrl } = buildPlatformClient({ ...options, timeoutMs });
-    return await execute({
-      client,
-      signal: controller.signal,
-      webOrigin: webOriginForApiBaseUrl(baseUrl),
-    });
-  } catch (error) {
-    if (
-      controller.signal.aborted &&
-      controller.signal.reason instanceof PlatformApiError
-    ) {
-      throw toCliError(controller.signal.reason);
-    }
-    throw toCliError(error);
-  } finally {
-    clearTimeout(timeoutHandle);
-  }
 }
 
 /**

--- a/cli/src/commands/hosts.ts
+++ b/cli/src/commands/hosts.ts
@@ -1,6 +1,11 @@
 import { readFileSync } from "node:fs";
 import type { Command } from "commander";
 import {
+  addPlatformOptions,
+  runPlatformCommand,
+  type PlatformOptions,
+} from "../lib/platform-command.js";
+import {
   createHostOperation,
   deleteHostOperation,
   getHostOperation,
@@ -8,19 +13,12 @@ import {
   updateHostOperation,
   setHostServersOperation,
   duplicateHostOperation,
-  PlatformApiError,
   type PlatformOperation,
 } from "@mcpjam/sdk/platform";
 import { HOST_TEMPLATES as SDK_HOST_TEMPLATES } from "@mcpjam/sdk/host-config/templates";
 import { JsonInputContext } from "../lib/json-input.js";
 import { usageError, writeResult } from "../lib/output.js";
-import { buildPlatformClient, toCliError } from "../lib/platform-client.js";
 import { getGlobalOptions } from "../lib/server-config.js";
-
-type PlatformOptions = {
-  apiKey?: string;
-  apiUrl?: string;
-};
 
 /**
  * Built-in host templates surfaced by `hosts templates`, derived from the SDK
@@ -29,53 +27,6 @@ type PlatformOptions = {
  */
 const HOST_TEMPLATES: ReadonlyArray<{ id: string; label: string }> =
   SDK_HOST_TEMPLATES.map(({ id, label }) => ({ id, label }));
-
-function addPlatformOptions(command: Command): Command {
-  return command
-    .option("--api-key <key>", "MCPJam sk_ API key (overrides MCPJAM_API_KEY)")
-    .option(
-      "--api-url <url>",
-      "MCPJam API base URL (defaults to https://app.mcpjam.com/api/v1)"
-    );
-}
-
-async function runPlatformCommand<TOutput>(
-  options: PlatformOptions,
-  timeoutMs: number,
-  execute: (context: {
-    client: ReturnType<typeof buildPlatformClient>["client"];
-    signal: AbortSignal;
-  }) => Promise<TOutput>
-): Promise<TOutput> {
-  const controller = new AbortController();
-  const timeoutHandle = setTimeout(() => {
-    controller.abort(
-      new PlatformApiError(
-        `Request timed out after ${timeoutMs}ms`,
-        "TIMEOUT",
-        {
-          status: 0,
-        }
-      )
-    );
-  }, timeoutMs);
-  timeoutHandle.unref?.();
-
-  try {
-    const { client } = buildPlatformClient({ ...options, timeoutMs });
-    return await execute({ client, signal: controller.signal });
-  } catch (error) {
-    if (
-      controller.signal.aborted &&
-      controller.signal.reason instanceof PlatformApiError
-    ) {
-      throw toCliError(controller.signal.reason);
-    }
-    throw toCliError(error);
-  } finally {
-    clearTimeout(timeoutHandle);
-  }
-}
 
 /** Read a JSON object from --file (literal path or `-` for stdin) / --json. */
 function loadConfigObject(options: {

--- a/cli/src/commands/images.ts
+++ b/cli/src/commands/images.ts
@@ -1,6 +1,11 @@
 import { readFileSync } from "node:fs";
 import type { Command } from "commander";
 import {
+  addPlatformOptions,
+  runPlatformCommand,
+  type PlatformOptions,
+} from "../lib/platform-command.js";
+import {
   buildImageOperation,
   createImageOperation,
   validateImageBlueprintOperation,
@@ -12,64 +17,10 @@ import {
   resetComputerOperation,
   updateImageOperation,
   useImageOperation,
-  PlatformApiError,
   type PlatformOperation,
 } from "@mcpjam/sdk/platform";
 import { usageError, writeResult } from "../lib/output.js";
-import { buildPlatformClient, toCliError } from "../lib/platform-client.js";
 import { getGlobalOptions } from "../lib/server-config.js";
-
-type PlatformOptions = {
-  apiKey?: string;
-  apiUrl?: string;
-};
-
-function addPlatformOptions(command: Command): Command {
-  return command
-    .option("--api-key <key>", "MCPJam sk_ API key (overrides MCPJAM_API_KEY)")
-    .option(
-      "--api-url <url>",
-      "MCPJam API base URL (defaults to https://app.mcpjam.com/api/v1)"
-    );
-}
-
-async function runPlatformCommand<TOutput>(
-  options: PlatformOptions,
-  timeoutMs: number,
-  execute: (context: {
-    client: ReturnType<typeof buildPlatformClient>["client"];
-    signal: AbortSignal;
-  }) => Promise<TOutput>
-): Promise<TOutput> {
-  const controller = new AbortController();
-  const timeoutHandle = setTimeout(() => {
-    controller.abort(
-      new PlatformApiError(
-        `Request timed out after ${timeoutMs}ms`,
-        "TIMEOUT",
-        {
-          status: 0,
-        }
-      )
-    );
-  }, timeoutMs);
-  timeoutHandle.unref?.();
-
-  try {
-    const { client } = buildPlatformClient({ ...options, timeoutMs });
-    return await execute({ client, signal: controller.signal });
-  } catch (error) {
-    if (
-      controller.signal.aborted &&
-      controller.signal.reason instanceof PlatformApiError
-    ) {
-      throw toCliError(controller.signal.reason);
-    }
-    throw toCliError(error);
-  } finally {
-    clearTimeout(timeoutHandle);
-  }
-}
 
 /** Read blueprint YAML TEXT (not JSON) from a path, or stdin when `--file -`. */
 function loadBlueprintText(file: string): string {

--- a/cli/src/commands/journeys.ts
+++ b/cli/src/commands/journeys.ts
@@ -1,15 +1,18 @@
 import type { Command } from "commander";
 import {
+  addPlatformOptions,
+  runPlatformCommand,
+  type PlatformOptions,
+} from "../lib/platform-command.js";
+import {
   launchJourneyRunOperation,
   cancelJourneyRunOperation,
   getJourneyRunOperation,
   listJourneyRunSessionsOperation,
   listJourneyRunsOperation,
   listJourneysOperation,
-  PlatformApiError,
 } from "@mcpjam/sdk/platform";
 import { usageError, writeResult } from "../lib/output.js";
-import { buildPlatformClient, toCliError } from "../lib/platform-client.js";
 import { getGlobalOptions } from "../lib/server-config.js";
 
 /**
@@ -27,58 +30,6 @@ import { getGlobalOptions } from "../lib/server-config.js";
  * for yours — the server decides, this CLI does not pre-guess, matching how
  * `environments` and `images` behave for features an org lacks.
  */
-
-type PlatformOptions = {
-  apiKey?: string;
-  apiUrl?: string;
-};
-
-function addPlatformOptions(command: Command): Command {
-  return command
-    .option("--api-key <key>", "MCPJam sk_ API key (overrides MCPJAM_API_KEY)")
-    .option(
-      "--api-url <url>",
-      "MCPJam API base URL (defaults to https://app.mcpjam.com/api/v1)"
-    );
-}
-
-async function runPlatformCommand<TOutput>(
-  options: PlatformOptions,
-  timeoutMs: number,
-  execute: (context: {
-    client: ReturnType<typeof buildPlatformClient>["client"];
-    signal: AbortSignal;
-  }) => Promise<TOutput>
-): Promise<TOutput> {
-  const controller = new AbortController();
-  const timeoutHandle = setTimeout(() => {
-    controller.abort(
-      new PlatformApiError(
-        `Request timed out after ${timeoutMs}ms`,
-        "TIMEOUT",
-        {
-          status: 0,
-        }
-      )
-    );
-  }, timeoutMs);
-  timeoutHandle.unref?.();
-
-  try {
-    const { client } = buildPlatformClient({ ...options, timeoutMs });
-    return await execute({ client, signal: controller.signal });
-  } catch (error) {
-    if (
-      controller.signal.aborted &&
-      controller.signal.reason instanceof PlatformApiError
-    ) {
-      throw toCliError(controller.signal.reason);
-    }
-    throw toCliError(error);
-  } finally {
-    clearTimeout(timeoutHandle);
-  }
-}
 
 /** Commander's collector for a repeatable option (`--environment a --environment b`). */
 function collectRepeatable(value: string, previous: string[]): string[] {

--- a/cli/src/commands/organizations.ts
+++ b/cli/src/commands/organizations.ts
@@ -12,63 +12,14 @@
  */
 import type { Command } from "commander";
 import {
-  listOrganizationsOperation,
-  PlatformApiError,
-} from "@mcpjam/sdk/platform";
+  addPlatformOptions,
+  runPlatformCommand,
+  type PlatformOptions,
+} from "../lib/platform-command.js";
+import { listOrganizationsOperation } from "@mcpjam/sdk/platform";
 import { writeResult } from "../lib/output.js";
 import { formatOrganizationsHuman } from "../lib/projects-render.js";
-import { buildPlatformClient, toCliError } from "../lib/platform-client.js";
 import { getGlobalOptions } from "../lib/server-config.js";
-
-type PlatformOptions = {
-  apiKey?: string;
-  apiUrl?: string;
-};
-
-function addPlatformOptions(command: Command): Command {
-  return command
-    .option("--api-key <key>", "MCPJam sk_ API key (overrides MCPJAM_API_KEY)")
-    .option(
-      "--api-url <url>",
-      "MCPJam API base URL (defaults to https://app.mcpjam.com/api/v1)",
-    );
-}
-
-async function runPlatformCommand<TOutput>(
-  options: PlatformOptions,
-  timeoutMs: number,
-  execute: (context: {
-    client: ReturnType<typeof buildPlatformClient>["client"];
-    signal: AbortSignal;
-  }) => Promise<TOutput>,
-): Promise<TOutput> {
-  const controller = new AbortController();
-  const timeoutHandle = setTimeout(() => {
-    controller.abort(
-      new PlatformApiError(`Request timed out after ${timeoutMs}ms`, "TIMEOUT", {
-        status: 0,
-      }),
-    );
-  }, timeoutMs);
-  timeoutHandle.unref?.();
-
-  try {
-    const { client } = buildPlatformClient({ ...options, timeoutMs });
-    return await execute({ client, signal: controller.signal });
-  } catch (error) {
-    // When OUR deadline fired, surface the armed TIMEOUT error rather than the
-    // bare AbortError some fetch implementations reject with.
-    if (
-      controller.signal.aborted &&
-      controller.signal.reason instanceof PlatformApiError
-    ) {
-      throw toCliError(controller.signal.reason);
-    }
-    throw toCliError(error);
-  } finally {
-    clearTimeout(timeoutHandle);
-  }
-}
 
 export function registerOrganizationsCommands(program: Command): void {
   const organizations = program

--- a/cli/src/commands/projects.ts
+++ b/cli/src/commands/projects.ts
@@ -1,5 +1,9 @@
 import type { Command } from "commander";
 import {
+  addPlatformOptions,
+  runPlatformCommand,
+} from "../lib/platform-command.js";
+import {
   connectProjectServerOperation,
   getProjectServerConnectionStatusOperation,
   createProjectOperation,
@@ -10,7 +14,6 @@ import {
   getProjectServerOperation,
   updateProjectServerOperation,
   deleteProjectServerOperation,
-  PlatformApiError,
   showServersOperation,
   updateProjectOperation,
 } from "@mcpjam/sdk/platform";
@@ -20,7 +23,6 @@ import {
   formatShowServersHuman,
 } from "../lib/projects-render.js";
 import { writeResult } from "../lib/output.js";
-import { buildPlatformClient, toCliError } from "../lib/platform-client.js";
 import { getGlobalOptions } from "../lib/server-config.js";
 import { openUrlInBrowser } from "@mcpjam/sdk";
 
@@ -29,15 +31,6 @@ type PlatformOptions = {
   apiUrl?: string;
   project?: string;
 };
-
-function addPlatformOptions(command: Command): Command {
-  return command
-    .option("--api-key <key>", "MCPJam sk_ API key (overrides MCPJAM_API_KEY)")
-    .option(
-      "--api-url <url>",
-      "MCPJam API base URL (defaults to https://app.mcpjam.com/api/v1)"
-    );
-}
 
 /**
  * The one place `--api-key`, `--api-url` and `--project` are resolved.
@@ -99,59 +92,6 @@ function requireProject(command: Command, options: PlatformOptions): string {
     command.error("error: required option '--project <id-or-name>' not specified");
   }
   return project;
-}
-
-async function runPlatformCommand<TOutput>(
-  options: PlatformOptions,
-  timeoutMs: number,
-  execute: (context: {
-    client: ReturnType<typeof buildPlatformClient>["client"];
-    signal: AbortSignal;
-  }) => Promise<TOutput>,
-  /**
-   * Cancels the request from outside its own deadline — today that is Ctrl-C
-   * during a poll. Without it the only way out of an in-flight request is the
-   * timeout, so a user who interrupted a watch still waits the better part of
-   * `timeoutMs` for the terminal to come back.
-   */
-  externalSignal?: AbortSignal
-): Promise<TOutput> {
-  const controller = new AbortController();
-  const timeoutHandle = setTimeout(() => {
-    controller.abort(
-      new PlatformApiError(
-        `Request timed out after ${timeoutMs}ms`,
-        "TIMEOUT",
-        {
-          status: 0,
-        }
-      )
-    );
-  }, timeoutMs);
-  timeoutHandle.unref?.();
-
-  const onExternalAbort = () => controller.abort(externalSignal?.reason);
-  if (externalSignal?.aborted) onExternalAbort();
-  else externalSignal?.addEventListener("abort", onExternalAbort, { once: true });
-
-  try {
-    const { client } = buildPlatformClient({ ...options, timeoutMs });
-    return await execute({ client, signal: controller.signal });
-  } catch (error) {
-    // When OUR deadline fired, surface the armed TIMEOUT error: depending
-    // on the fetch implementation, the rejection may be a bare AbortError
-    // that would otherwise map to INTERNAL_ERROR.
-    if (
-      controller.signal.aborted &&
-      controller.signal.reason instanceof PlatformApiError
-    ) {
-      throw toCliError(controller.signal.reason);
-    }
-    throw toCliError(error);
-  } finally {
-    clearTimeout(timeoutHandle);
-    externalSignal?.removeEventListener("abort", onExternalAbort);
-  }
 }
 
 export function registerProjectsCommands(program: Command): void {

--- a/cli/src/commands/scenarios.ts
+++ b/cli/src/commands/scenarios.ts
@@ -1,11 +1,14 @@
 import type { Command } from "commander";
 import {
-  PlatformApiError,
+  addPlatformOptions,
+  runPlatformCommand,
+  type PlatformOptions,
+} from "../lib/platform-command.js";
+import {
   publishScenarioOperation,
   unpublishScenarioOperation,
 } from "@mcpjam/sdk/platform";
 import { writeResult } from "../lib/output.js";
-import { buildPlatformClient, toCliError } from "../lib/platform-client.js";
 import { getGlobalOptions } from "../lib/server-config.js";
 
 /**
@@ -19,58 +22,6 @@ import { getGlobalOptions } from "../lib/server-config.js";
  * the server says so plainly. UNPUBLISHING is deliberately not gated — taking
  * a live scenario down has to keep working for an org that just lost the flag.
  */
-
-type PlatformOptions = {
-  apiKey?: string;
-  apiUrl?: string;
-};
-
-function addPlatformOptions(command: Command): Command {
-  return command
-    .option("--api-key <key>", "MCPJam sk_ API key (overrides MCPJAM_API_KEY)")
-    .option(
-      "--api-url <url>",
-      "MCPJam API base URL (defaults to https://app.mcpjam.com/api/v1)"
-    );
-}
-
-async function runPlatformCommand<TOutput>(
-  options: PlatformOptions,
-  timeoutMs: number,
-  execute: (context: {
-    client: ReturnType<typeof buildPlatformClient>["client"];
-    signal: AbortSignal;
-  }) => Promise<TOutput>
-): Promise<TOutput> {
-  const controller = new AbortController();
-  const timeoutHandle = setTimeout(() => {
-    controller.abort(
-      new PlatformApiError(
-        `Request timed out after ${timeoutMs}ms`,
-        "TIMEOUT",
-        {
-          status: 0,
-        }
-      )
-    );
-  }, timeoutMs);
-  timeoutHandle.unref?.();
-
-  try {
-    const { client } = buildPlatformClient({ ...options, timeoutMs });
-    return await execute({ client, signal: controller.signal });
-  } catch (error) {
-    if (
-      controller.signal.aborted &&
-      controller.signal.reason instanceof PlatformApiError
-    ) {
-      throw toCliError(controller.signal.reason);
-    }
-    throw toCliError(error);
-  } finally {
-    clearTimeout(timeoutHandle);
-  }
-}
 
 export function registerScenariosCommands(program: Command): void {
   const scenarios = program

--- a/cli/src/lib/platform-command.ts
+++ b/cli/src/lib/platform-command.ts
@@ -1,0 +1,92 @@
+/**
+ * The shared runner for every `mcpjam <group>` command that talks to the
+ * platform API.
+ *
+ * Extracted from nine per-command copies that had already drifted three ways:
+ * `eval` had grown a `webOrigin` in the execute context, `projects` an
+ * external abort signal, and the other seven were byte-identical modulo
+ * formatting. This is the superset — the context always carries `webOrigin`
+ * (it is a pure string transform of the base URL) and the external signal is
+ * optional — so a command file declares nothing and ignores what it does not
+ * use.
+ */
+import type { Command } from "commander";
+import { PlatformApiError } from "@mcpjam/sdk/platform";
+import {
+  buildPlatformClient,
+  toCliError,
+  webOriginForApiBaseUrl,
+} from "./platform-client.js";
+
+export type PlatformOptions = {
+  apiKey?: string;
+  apiUrl?: string;
+};
+
+export function addPlatformOptions(command: Command): Command {
+  return command
+    .option("--api-key <key>", "MCPJam sk_ API key (overrides MCPJAM_API_KEY)")
+    .option(
+      "--api-url <url>",
+      "MCPJam API base URL (defaults to https://app.mcpjam.com/api/v1)"
+    );
+}
+
+export async function runPlatformCommand<TOutput>(
+  options: PlatformOptions,
+  timeoutMs: number,
+  execute: (context: {
+    client: ReturnType<typeof buildPlatformClient>["client"];
+    signal: AbortSignal;
+    /** App origin matching the API base this call went to. */
+    webOrigin: string;
+  }) => Promise<TOutput>,
+  /**
+   * Cancels the request from outside its own deadline — today that is Ctrl-C
+   * during a poll. Without it the only way out of an in-flight request is the
+   * timeout, so a user who interrupted a watch still waits the better part of
+   * `timeoutMs` for the terminal to come back.
+   */
+  externalSignal?: AbortSignal
+): Promise<TOutput> {
+  const controller = new AbortController();
+  const timeoutHandle = setTimeout(() => {
+    controller.abort(
+      new PlatformApiError(
+        `Request timed out after ${timeoutMs}ms`,
+        "TIMEOUT",
+        {
+          status: 0,
+        }
+      )
+    );
+  }, timeoutMs);
+  timeoutHandle.unref?.();
+
+  const onExternalAbort = () => controller.abort(externalSignal?.reason);
+  if (externalSignal?.aborted) onExternalAbort();
+  else externalSignal?.addEventListener("abort", onExternalAbort, { once: true });
+
+  try {
+    const { client, baseUrl } = buildPlatformClient({ ...options, timeoutMs });
+    return await execute({
+      client,
+      signal: controller.signal,
+      webOrigin: webOriginForApiBaseUrl(baseUrl),
+    });
+  } catch (error) {
+    // When OUR deadline fired, surface the armed TIMEOUT error: depending
+    // on the fetch implementation, the rejection may be a bare AbortError
+    // that would otherwise map to INTERNAL_ERROR.
+    if (
+      controller.signal.aborted &&
+      controller.signal.reason instanceof PlatformApiError
+    ) {
+      throw toCliError(controller.signal.reason);
+    }
+    throw toCliError(error);
+  } finally {
+    clearTimeout(timeoutHandle);
+    externalSignal?.removeEventListener("abort", onExternalAbort);
+  }
+}


### PR DESCRIPTION
Follow-up 2 from the #3970 audit. The audit flagged `organizations.ts` copying `addPlatformOptions`/`runPlatformCommand` from `projects.ts`; it turned out to be the **ninth** copy, and the copies had already drifted three ways:

- `eval` had grown a `webOrigin` in the execute context (for printing web deep links),
- `projects` an optional external abort signal (Ctrl-C during a poll),
- `chat` a formatting variant of the base,
- the other five were byte-identical.

## Change

One shared `cli/src/lib/platform-command.ts` exporting `PlatformOptions`, `addPlatformOptions`, and `runPlatformCommand` — the superset of the variants: the context always carries `webOrigin` (a pure string transform of the base URL; callers that don't need it ignore it) and the external signal stays optional. All nine command files now import it. No command loses behavior.

`projects.ts` keeps what is genuinely its own: the `project?` selector extension of `PlatformOptions`, and its Commander option-precedence helpers (`platformOptionsOf`, `requireProject`).

Net: −506/+44 lines in the command files.

## Verification

- `tsx --test`: **575 pass, 0 fail** (full CLI suite).
- `tsc --noEmit`: clean.
- No user-facing changes; patch changeset included.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit d92215a8c46dde732a96cce7ecbe75fcb3eb953c. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Deduplicates nine per-command platform helpers into one shared runner without changing behavior. Previously each command defined `PlatformOptions`/`addPlatformOptions`/`runPlatformCommand` (with drift); now `cli/src/lib/platform-command.ts` exports the superset so all commands import it. The execute context always includes `webOrigin`, and the external abort signal remains optional.

- Replaces local helpers in chat, environments, eval, hosts, images, journeys, organizations, projects, and scenarios with imports from `cli/src/lib/platform-command.ts`.
- Preserves behavior: `webOrigin` is always provided (callers ignore if unused); `projects` continues to pass an optional external abort signal; `projects` keeps its `project` option and precedence helpers.
- No user-facing changes. Full CLI tests pass and typecheck is clean. Changeset adds a patch for `@mcpjam/cli`.

<sup>Written for commit d92215a8c46dde732a96cce7ecbe75fcb3eb953c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/MCPJam/inspector/pull/3979?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

