### PR TITLE
changesets

### DIFF
--- a/.changeset/inspector-release-2026-08-13.md
+++ b/.changeset/inspector-release-2026-08-13.md
@@ -1,0 +1,8 @@
+---
+"@mcpjam/inspector": minor
+---
+
+Release the latest Inspector updates.
+
+- Group scorecards and recommendations under Findings, and keep Insights visible when queries fail.
+- Default guest multi-host Playground sessions to ChatGPT, Claude, and Cursor.


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Releases a minor update to `@mcpjam/inspector` to improve result visibility and simplify guest setup. Previously, scorecards and recommendations were separate and Insights hid on failed queries; now they are grouped under Findings and Insights stay visible. Guest multi-host Playground sessions now default to ChatGPT, Claude, and Cursor (previously no defaults).

<sup>Written for commit bd02172325ba549cfe24a14fd2b9a96dcf1d4b4c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/MCPJam/inspector/pull/3980?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

