### PR TITLE
fix(observability): give every prod log row a release, falling back to the baked version

### DIFF
--- a/mcpjam-inspector/server/sentry.ts
+++ b/mcpjam-inspector/server/sentry.ts
@@ -1,17 +1,6 @@
 import * as Sentry from "@sentry/node";
 import { buildServerSentryConfig } from "../shared/sentry-config.js";
-import { resolveEnvironment } from "./utils/log-events.js";
-
-/**
- * Baked into the bundle by `server/tsup.config.ts` (`define`). It MUST stay a
- * literal `process.env.X` member expression — esbuild's `define` performs a
- * syntactic substitution and cannot see through a dynamic `process.env[name]`
- * lookup, which would leave the shipped server with no release tag.
- *
- * Under tsx in dev the define is absent and this reads the real environment,
- * where npm provides `npm_package_version` as the fallback below.
- */
-const BAKED_VERSION = process.env.MCPJAM_INSPECTOR_VERSION;
+import { resolveAppVersion, resolveEnvironment } from "./utils/log-events.js";
 
 /**
  * Sentry for the standalone Hono server (hosted, npx, Docker).
@@ -35,7 +24,7 @@ export function initServerSentry(): void {
   Sentry.init({
     ...buildServerSentryConfig({
       environment: resolveEnvironment(),
-      release: blankToUndefined(BAKED_VERSION) ?? readEnv("npm_package_version"),
+      release: resolveAppVersion() ?? undefined,
       deployment:
         process.env.VITE_MCPJAM_HOSTED_MODE === "true"
           ? "hosted"

--- a/mcpjam-inspector/server/utils/__tests__/log-events.test.ts
+++ b/mcpjam-inspector/server/utils/__tests__/log-events.test.ts
@@ -1,0 +1,67 @@
+import { describe, expect, it, vi, beforeEach } from "vitest";
+
+// `BAKED_VERSION` is captured at module load (it must stay a literal
+// `process.env.X` so esbuild's `define` can substitute it), so every case
+// stubs the environment first and then re-imports a fresh module — the same
+// pattern server/__tests__/sentry.test.ts uses for the release tag.
+async function freshLogEvents() {
+  vi.resetModules();
+  return import("../log-events.js");
+}
+
+describe("resolveRelease", () => {
+  beforeEach(() => {
+    vi.unstubAllEnvs();
+    vi.stubEnv("RAILWAY_GIT_COMMIT_SHA", "");
+    vi.stubEnv("GIT_SHA", "");
+    vi.stubEnv("MCPJAM_INSPECTOR_VERSION", "");
+    vi.stubEnv("npm_package_version", "");
+  });
+
+  it("prefers the git sha when a repo-connected build provides one", async () => {
+    vi.stubEnv("RAILWAY_GIT_COMMIT_SHA", "abc123");
+    vi.stubEnv("MCPJAM_INSPECTOR_VERSION", "2.36.0");
+    const { resolveRelease } = await freshLogEvents();
+    expect(resolveRelease()).toBe("abc123");
+  });
+
+  it("falls back to the baked app version when no sha is set", async () => {
+    // Production deploys via `railway up` (directory upload, no git
+    // metadata), so neither sha var exists there. Before this fallback every
+    // prod row carried release: null and the deploy-boundary triage step in
+    // the alert runbooks was impossible.
+    vi.stubEnv("MCPJAM_INSPECTOR_VERSION", "2.36.0");
+    const { resolveRelease } = await freshLogEvents();
+    expect(resolveRelease()).toBe("2.36.0");
+  });
+
+  it("treats a declared-but-empty sha as unset", async () => {
+    // Container platforms materialize declared-but-unset vars as "".
+    vi.stubEnv("GIT_SHA", "  ");
+    vi.stubEnv("MCPJAM_INSPECTOR_VERSION", "2.36.0");
+    const { resolveRelease } = await freshLogEvents();
+    expect(resolveRelease()).toBe("2.36.0");
+  });
+
+  it("resolves npm_package_version under tsx where the define is absent", async () => {
+    vi.stubEnv("npm_package_version", "2.36.0-dev");
+    const { resolveRelease } = await freshLogEvents();
+    expect(resolveRelease()).toBe("2.36.0-dev");
+  });
+
+  it("returns null only when nothing identifies the build", async () => {
+    const { resolveRelease } = await freshLogEvents();
+    expect(resolveRelease()).toBeNull();
+  });
+});
+
+describe("resolveAppVersion", () => {
+  it("matches what /health reports so log rows and the canary correlate", async () => {
+    vi.unstubAllEnvs();
+    vi.stubEnv("MCPJAM_INSPECTOR_VERSION", "2.36.0");
+    vi.resetModules();
+    const { resolveAppVersion } = await import("../log-events.js");
+    const { buildHealthMeta } = await import("../health-payload.js");
+    expect(buildHealthMeta().version).toBe(resolveAppVersion());
+  });
+});

--- a/mcpjam-inspector/server/utils/health-payload.ts
+++ b/mcpjam-inspector/server/utils/health-payload.ts
@@ -1,23 +1,4 @@
-import { resolveEnvironment } from "./log-events.js";
-
-/**
- * Baked into the bundle by `server/tsup.config.ts` (`define`).
- *
- * MUST stay a literal `process.env.X` member expression — esbuild's `define`
- * is a syntactic substitution and cannot see through a dynamic
- * `process.env[name]` lookup, which would leave the shipped server reporting
- * no version at all. Under `tsx` in dev the define is absent and this reads
- * the real environment, where npm provides `npm_package_version`.
- *
- * Same mechanism `server/sentry.ts` uses for the release tag.
- */
-const BAKED_VERSION = process.env.MCPJAM_INSPECTOR_VERSION;
-
-function blankToUndefined(value: string | undefined): string | undefined {
-  // Container platforms materialize a declared-but-unset variable as `""`,
-  // which `??` does not catch.
-  return value === undefined || value.trim() === "" ? undefined : value;
-}
+import { resolveAppVersion, resolveEnvironment } from "./log-events.js";
 
 /**
  * Fields every `/health` response carries.
@@ -38,10 +19,7 @@ export function buildHealthMeta(): {
   environment: string;
 } {
   return {
-    version:
-      blankToUndefined(BAKED_VERSION) ??
-      blankToUndefined(process.env.npm_package_version) ??
-      null,
+    version: resolveAppVersion(),
     environment: resolveEnvironment(),
   };
 }

--- a/mcpjam-inspector/server/utils/log-events.ts
+++ b/mcpjam-inspector/server/utils/log-events.ts
@@ -285,6 +285,42 @@ export function resolveEnvironment(): Environment {
   return "dev";
 }
 
+/**
+ * Baked into the bundle by `server/tsup.config.ts` (`define`). MUST stay a
+ * literal `process.env.X` member expression — esbuild's `define` is a
+ * syntactic substitution and cannot see through a dynamic
+ * `process.env[name]` lookup. Under tsx in dev the define is absent and this
+ * reads the real environment, where npm provides `npm_package_version`.
+ *
+ * This is the canonical copy; `server/sentry.ts` (release tag) and
+ * `server/utils/health-payload.ts` (`/health` version) resolve through it so
+ * the three surfaces can never disagree about what build is running.
+ */
+const BAKED_VERSION = process.env.MCPJAM_INSPECTOR_VERSION;
+
+function blankToNull(value: string | undefined): string | null {
+  // Container platforms materialize a declared-but-unset variable as "",
+  // which ?? does not catch.
+  return value === undefined || value.trim() === "" ? null : value;
+}
+
+export function resolveAppVersion(): string | null {
+  return blankToNull(BAKED_VERSION) ?? blankToNull(process.env.npm_package_version);
+}
+
+/**
+ * The git-sha vars only exist on repo-connected builds. Production deploys
+ * via `railway up` (a directory upload with no git metadata), so neither is
+ * set there and every prod row carried `release: null` — which made the
+ * "did a deploy cause this?" triage step in the alert runbooks impossible.
+ * The baked package version is the fallback: prod deploys are releases, so
+ * version boundaries ARE deploy boundaries, and it matches what `/health`
+ * reports, so log rows and the canary correlate directly.
+ */
 export function resolveRelease(): string | null {
-  return process.env.RAILWAY_GIT_COMMIT_SHA ?? process.env.GIT_SHA ?? null;
+  return (
+    blankToNull(process.env.RAILWAY_GIT_COMMIT_SHA) ??
+    blankToNull(process.env.GIT_SHA) ??
+    resolveAppVersion()
+  );
 }


### PR DESCRIPTION
## Problem

Every prod row in `inspector-logs` carries `release: null` — verified against live data: 0 of 754 `http.request.failed` rows since 08-12 have it. `resolveRelease()` reads only `RAILWAY_GIT_COMMIT_SHA` / `GIT_SHA`, and production deploys via `railway up` (a directory upload with no git metadata), so neither var ever exists there.

Consequence: the *"compare `release` across the deploy boundary and roll back"* triage step in every Axiom alert-monitor runbook (`ops/axiom-monitors/monitors/*.json`) is currently impossible, and the alerts plan's controlled-probe acceptance check (release present on typed rows) can never pass.

## Fix

Fall back to the app version tsup already bakes into the bundle (`MCPJAM_INSPECTOR_VERSION`). Prod deploys are releases, so version boundaries **are** deploy boundaries — and the value matches what `/health` reports, so log rows, Sentry events, and the prod canary now all name the same build.

- `resolveAppVersion()` moves to `log-events.ts` as the canonical copy; `sentry.ts` and `health-payload.ts` previously each kept their own baked-version + blank-guard duplicate and now resolve through it, so the three surfaces cannot drift.
- Blank-string guards now apply to the sha vars too (container platforms materialize declared-but-unset vars as `""`).
- The sha vars keep priority, so a future repo-connected or sha-injecting build automatically upgrades the granularity.

## Tests

`server/utils/__tests__/log-events.test.ts` (new): sha priority, blank-sha-treated-as-unset, baked fallback, tsx dev fallback, null-when-nothing, and a lock that `/health`'s version and the log-row release resolve identically. Existing `sentry.test.ts` release tests still pass (20/20).

Part of the #mcpjam-alerts observability program (follow-up to #3875/#3928).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit 0f49ba96a3ec6ca95eeb8a645c5bfe5819320043. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Ensure every prod log row has a non-null release by falling back to the baked app version when no git SHA is present. Previously, `release` was null in prod (no git metadata with `railway up`), blocking deploy-boundary triage in alert runbooks.

- `resolveRelease()` now prefers `RAILWAY_GIT_COMMIT_SHA` or `GIT_SHA`, then falls back to `MCPJAM_INSPECTOR_VERSION`; treats blank env vars as unset.
- Introduces `resolveAppVersion()` in `server/utils/log-events.ts` as the canonical version resolver; `sentry.ts` and `health-payload.ts` now resolve through it so Sentry releases and `/health` versions match.
- Adds tests for SHA priority, baked fallback, dev `npm_package_version`, blank-var handling, and parity between `/health` and log-row release.

<sup>Written for commit 0f49ba96a3ec6ca95eeb8a645c5bfe5819320043. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/MCPJam/inspector/pull/3982?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

