### PR TITLE
ops(axiom): record the WARN-notifier decision and the delivery-test result

### DIFF
--- a/ops/axiom-monitors/README.md
+++ b/ops/axiom-monitors/README.md
@@ -71,22 +71,23 @@ Ownership is claimed by a marker appended to the monitor description:
 - `--delete` requires the exact key and only ever removes a managed monitor.
 - Re-running with no definition change is a no-op.
 
-## Open decision before first apply: PAGE vs WARN notifiers
+## PAGE vs WARN notifiers (decided 2026-08-13)
 
 The plan requires PAGE and WARN to be **mechanically** different — if both land
 in `#mcpjam-alerts` with identical treatment, the tiers are names, not tiers.
 
-Today the org has exactly two notifiers: `#mcpjam-alerts`
-(`jnWZGoVFRcvyTdUjBe`) and `MCPJam LLM Safety` (`ox9MvFUsrwZtx9HfxM`). There is
-no separate WARN destination, so `mcpjam-alerts-warn` currently has nowhere
-correct to point. Resolve one of these before applying:
+Resolution: a second Slack notifier `#mcpjam-alerts (warn)`
+(`Q3BO52GfVxE82N9tWH`) was created against the same channel webhook, and
+`AXIOM_NOTIFIER_MCPJAM_ALERTS_WARN` points at it. This separates the tier
+*identity* now — every WARN monitor is wired to its own notifier object — so
+upgrading either tier later (a mention-carrying webhook for PAGE, a quieter
+channel for WARN) is a notifier-config/env-var change with zero monitor edits.
 
-1. Create a second Slack notifier that posts without an on-call mention, and
-   point `AXIOM_NOTIFIER_MCPJAM_ALERTS_WARN` at it. (Needs Slack admin.)
-2. Point both keys at `#mcpjam-alerts` and accept that the tier distinction is
-   only visible in the message text.
-
-Option 1 is what the plan assumes.
+Deliberately deferred, not forgotten: the message *treatment* is still
+identical, because the PAGE notifier (`jnWZGoVFRcvyTdUjBe`, plain webhook, no
+mention) never had page semantics either. Giving PAGE an on-call mention needs
+a Slack-side webhook or workflow with the mention baked in; when that exists,
+point `AXIOM_NOTIFIER_MCPJAM_ALERTS_PAGE` at it and re-apply.
 
 ## Verifying delivery
 
@@ -99,6 +100,18 @@ real notifier, confirm one trigger and one resolution, then
 includes grouped/projected columns, because the per-class monitors (M3/M4/M6)
 depend on knowing the answer: all 55 pre-existing monitors collapse to a bare
 scalar in Slack, so their drill-down queries may have to carry the diagnosis.
+
+**Run on 2026-08-14 against `#mcpjam-alerts (warn)`:** disposable grouped
+Threshold monitor (`summarize Count = count() by grp`, `notifyByGroup: true`,
+15m range / 1m interval) over a disposable `monitor-delivery-test` dataset.
+One trigger at 03:07:22Z, one resolution at 03:22:24Z when the rows aged out
+of the window — `resolvable: true` produced exactly one open and one close,
+no repeats. Monitor and dataset were deleted afterward. Whether the Slack
+message body rendered the `grp` group value could not be captured
+programmatically (webhooks are write-only); check the 03:07Z/03:22Z posts in
+the channel before relying on grouped columns in any alert payload — until
+someone records that observation here, assume the pre-existing behavior
+(bare scalar) and keep the drill-down queries in the descriptions.
 
 ## Fields this Axiom deployment may ignore
 


### PR DESCRIPTION
Doc-only. Records two ops actions taken 2026-08-13/14 so the repo's monitor README stops describing them as open:

1. **WARN notifier exists.** `#mcpjam-alerts (warn)` (`Q3BO52GfVxE82N9tWH`) was created in Axiom against the same channel webhook. WARN monitors get their own notifier identity, so giving PAGE a mention-carrying webhook (or moving WARN to a quieter channel) later is a notifier/env-var change with zero monitor edits. This was the blocker that kept `inspector-new-error-class` (M4) and `inspector-4xx-storm` (M7) defined-but-unapplied.

2. **Delivery test done per the README's own procedure.** Disposable grouped Threshold monitor over a disposable dataset, wired to the real warn notifier: one trigger (03:07:22Z), one resolution (03:22:24Z) when rows aged out of the window, no repeat posts — confirming `resolvable: true` behaves as the definitions assume. Disposable monitor and dataset deleted afterward. The one thing not machine-verifiable is whether the Slack body rendered the group column (webhooks are write-only); the README now says to observe the 03:07Z post in the channel and record the answer before relying on grouped columns in alert payloads.

Part of the #mcpjam-alerts observability program.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit 6af22c43cb02511b79f165b1bf723e5ef37bd313. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Records the creation of a dedicated WARN Slack notifier and the result of a delivery test in `ops/axiom-monitors/README.md`. This resolves the previously “open” decision and validates that resolvable monitors post exactly one open and one close.

- WARN notifier: `#mcpjam-alerts (warn)` (`Q3BO52GfVxE82N9tWH`) now exists; `AXIOM_NOTIFIER_MCPJAM_ALERTS_WARN` points to it. WARN monitors have their own notifier identity, so future PAGE/WARN treatment changes require only notifier/env-var updates, not monitor edits. This unblocks applying WARN monitors like M4 and M7.
- Delivery test: Disposable grouped Threshold monitor triggered at 03:07:22Z and resolved at 03:22:24Z; `resolvable: true` produced one open and one close with no repeats. Action required: check the 03:07Z/03:22Z posts in `#mcpjam-alerts` to confirm whether grouped column values render in Slack; until confirmed, assume a bare scalar and keep diagnosis in drill-down queries.
- No code or monitor definition changes.

<sup>Written for commit 6af22c43cb02511b79f165b1bf723e5ef37bd313. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/MCPJam/inspector/pull/3985?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

