### PR TITLE
json-tree: stop unbounded recursion past defaultExpandDepth

### DIFF
--- a/mcpjam-inspector/client/src/components/ui/json-editor/__tests__/json-tree-view.test.tsx
+++ b/mcpjam-inspector/client/src/components/ui/json-editor/__tests__/json-tree-view.test.tsx
@@ -1,16 +1,51 @@
-import { describe, it, expect } from "vitest";
-import { render } from "@testing-library/react";
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, fireEvent } from "@testing-library/react";
 import { JsonTreeView } from "../json-tree-view";
+import { copyToClipboard } from "@/lib/clipboard";
+
+vi.mock("@/lib/clipboard", () => ({
+  copyToClipboard: vi.fn(async () => true),
+}));
+
+function deeplyNested(levels: number): Record<string, unknown> {
+  const root: Record<string, unknown> = {};
+  let cursor = root;
+  for (let i = 0; i < levels; i++) {
+    const next: Record<string, unknown> = {};
+    cursor.a = next;
+    cursor = next;
+  }
+  return root;
+}
+
+// Copy buttons carry no accessible name; the collapse toggles are the only
+// other buttons in the tree.
+function copyButtons(container: HTMLElement) {
+  return Array.from(
+    container.querySelectorAll<HTMLButtonElement>(
+      "button:not(.json-collapse-toggle)",
+    ),
+  );
+}
 
 describe("JsonTreeView", () => {
+  beforeEach(() => {
+    vi.mocked(copyToClipboard).mockClear();
+  });
+
+  it("honors defaultExpandDepth on the first paint (INSPECTOR-CLIENT-232)", () => {
+    const { container } = render(
+      <JsonTreeView value={deeplyNested(50_000)} defaultExpandDepth={2} />,
+    );
+
+    // Root, its child, and the collapsed boundary node — nothing below. Seeding
+    // the collapse state in a post-render effect instead paints all 50k levels
+    // once before collapsing them, which exhausts the renderer's heap.
+    expect(container.querySelectorAll(".json-collapse-toggle")).toHaveLength(3);
+  });
+
   it("renders a collapsed deeply nested node without serializing its subtree (INSPECTOR-CLIENT-232)", () => {
-    const root: Record<string, unknown> = {};
-    let cursor = root;
-    for (let i = 0; i < 50_000; i++) {
-      const next: Record<string, unknown> = {};
-      cursor.a = next;
-      cursor = next;
-    }
+    const root = deeplyNested(50_000);
 
     // A collapsed node still renders a copy button for its subtree. Serializing
     // that subtree eagerly at render throws RangeError: Maximum call stack size
@@ -18,5 +53,48 @@ describe("JsonTreeView", () => {
     expect(() =>
       render(<JsonTreeView value={root} collapsedPaths={new Set(["root"])} />),
     ).not.toThrow();
+  });
+
+  it("serializes the subtree when the copy button is actually clicked", async () => {
+    const onCopy = vi.fn();
+    const value = { a: 1, b: { c: 2 } };
+    const { container } = render(
+      <JsonTreeView value={value} onCopy={onCopy} />,
+    );
+
+    // Deferring serialization must not lose it: the first copy button is the
+    // root object's, and it still yields the whole subtree.
+    fireEvent.click(copyButtons(container)[0]);
+
+    const expected = JSON.stringify(value, null, 2);
+    expect(copyToClipboard).toHaveBeenCalledWith(expected);
+    await vi.waitFor(() => expect(onCopy).toHaveBeenCalledWith(expected));
+  });
+
+  it("skips the copy when the subtree cannot be serialized", () => {
+    const onCopy = vi.fn();
+    // JSON.stringify throws on a BigInt.
+    const { container } = render(
+      <JsonTreeView value={{ n: 1n }} onCopy={onCopy} />,
+    );
+
+    expect(() => fireEvent.click(copyButtons(container)[0])).not.toThrow();
+    expect(copyToClipboard).not.toHaveBeenCalled();
+    expect(onCopy).not.toHaveBeenCalled();
+  });
+
+  it("copies literal text for null and empty containers", () => {
+    const { container } = render(
+      <JsonTreeView value={{ a: null, b: {}, c: [] }} />,
+    );
+
+    copyButtons(container).forEach((button) => fireEvent.click(button));
+
+    const copied = vi.mocked(copyToClipboard).mock.calls.map(([arg]) => arg);
+    expect(copied).toContain("null");
+    expect(copied).toContain("{}");
+    expect(copied).toContain("[]");
+    // Never hands the clipboard a non-string.
+    expect(copied.every((arg) => typeof arg === "string")).toBe(true);
   });
 });

--- a/mcpjam-inspector/client/src/components/ui/json-editor/__tests__/json-tree-view.test.tsx
+++ b/mcpjam-inspector/client/src/components/ui/json-editor/__tests__/json-tree-view.test.tsx
@@ -1,0 +1,22 @@
+import { describe, it, expect } from "vitest";
+import { render } from "@testing-library/react";
+import { JsonTreeView } from "../json-tree-view";
+
+describe("JsonTreeView", () => {
+  it("renders a collapsed deeply nested node without serializing its subtree (INSPECTOR-CLIENT-232)", () => {
+    const root: Record<string, unknown> = {};
+    let cursor = root;
+    for (let i = 0; i < 50_000; i++) {
+      const next: Record<string, unknown> = {};
+      cursor.a = next;
+      cursor = next;
+    }
+
+    // A collapsed node still renders a copy button for its subtree. Serializing
+    // that subtree eagerly at render throws RangeError: Maximum call stack size
+    // exceeded on this value, so the button's value must stay a thunk.
+    expect(() =>
+      render(<JsonTreeView value={root} collapsedPaths={new Set(["root"])} />),
+    ).not.toThrow();
+  });
+});

--- a/mcpjam-inspector/client/src/components/ui/json-editor/__tests__/use-json-tree-state.test.ts
+++ b/mcpjam-inspector/client/src/components/ui/json-editor/__tests__/use-json-tree-state.test.ts
@@ -84,6 +84,22 @@ describe("useJsonTreeState", () => {
     );
   });
 
+  it("walks only the populated indexes of a huge sparse array", () => {
+    // length is a million, but one element exists. Building entries per index
+    // instead of per populated key allocates a million tuples to find it.
+    const sparse: unknown[] = [];
+    sparse.length = 1_000_000;
+    sparse[999_999] = { deep: true };
+
+    const { result } = renderHook(() =>
+      useJsonTreeState({ value: { list: sparse }, defaultExpandDepth: 1 }),
+    );
+
+    expect(result.current.collapsedPaths).toEqual(
+      new Set(["root.list", "root.list.999999"]),
+    );
+  });
+
   it("collapseAll collapses every container through the scan cap", () => {
     const { result } = renderHook(() => useJsonTreeState({}));
 

--- a/mcpjam-inspector/client/src/components/ui/json-editor/__tests__/use-json-tree-state.test.ts
+++ b/mcpjam-inspector/client/src/components/ui/json-editor/__tests__/use-json-tree-state.test.ts
@@ -100,6 +100,22 @@ describe("useJsonTreeState", () => {
     );
   });
 
+  it("still collapses a wide container sitting exactly at the scan cap", () => {
+    const root = deeplyNested(100);
+    let cursor = root;
+    while (cursor.a) cursor = cursor.a as Record<string, unknown>;
+    // The node at the cap is wide, and its entries are never needed.
+    for (let i = 0; i < 1_000; i++) cursor[`k${i}`] = i;
+
+    const { result } = renderHook(() =>
+      useJsonTreeState({ value: root, defaultExpandDepth: 2 }),
+    );
+
+    // Depths 2 through 100, with the wide node at the cap still collapsed.
+    expect(result.current.collapsedPaths.size).toBe(99);
+    expect(result.current.isCollapsed(`root${".a".repeat(100)}`)).toBe(true);
+  });
+
   it("collapseAll collapses every container through the scan cap", () => {
     const { result } = renderHook(() => useJsonTreeState({}));
 

--- a/mcpjam-inspector/client/src/components/ui/json-editor/__tests__/use-json-tree-state.test.ts
+++ b/mcpjam-inspector/client/src/components/ui/json-editor/__tests__/use-json-tree-state.test.ts
@@ -1,0 +1,24 @@
+import { describe, it, expect } from "vitest";
+import { renderHook, act } from "@testing-library/react";
+import { useJsonTreeState } from "../use-json-tree-state";
+
+describe("useJsonTreeState", () => {
+  it("does not blow the call stack on deeply nested JSON (INSPECTOR-CLIENT-232)", () => {
+    let deep: any = {};
+    let cursor = deep;
+    for (let i = 0; i < 50_000; i++) {
+      cursor.a = {};
+      cursor = cursor.a;
+    }
+
+    const { result } = renderHook(() =>
+      useJsonTreeState({ defaultExpandDepth: 2 }),
+    );
+
+    expect(() => {
+      act(() => {
+        result.current.initializeFromValue(deep);
+      });
+    }).not.toThrow();
+  });
+});

--- a/mcpjam-inspector/client/src/components/ui/json-editor/__tests__/use-json-tree-state.test.ts
+++ b/mcpjam-inspector/client/src/components/ui/json-editor/__tests__/use-json-tree-state.test.ts
@@ -2,14 +2,20 @@ import { describe, it, expect } from "vitest";
 import { renderHook, act } from "@testing-library/react";
 import { useJsonTreeState } from "../use-json-tree-state";
 
+function deeplyNested(levels: number): Record<string, unknown> {
+  const root: Record<string, unknown> = {};
+  let cursor = root;
+  for (let i = 0; i < levels; i++) {
+    const next: Record<string, unknown> = {};
+    cursor.a = next;
+    cursor = next;
+  }
+  return root;
+}
+
 describe("useJsonTreeState", () => {
   it("does not blow the call stack on deeply nested JSON (INSPECTOR-CLIENT-232)", () => {
-    let deep: any = {};
-    let cursor = deep;
-    for (let i = 0; i < 50_000; i++) {
-      cursor.a = {};
-      cursor = cursor.a;
-    }
+    const deep = deeplyNested(50_000);
 
     const { result } = renderHook(() =>
       useJsonTreeState({ defaultExpandDepth: 2 }),
@@ -21,10 +27,42 @@ describe("useJsonTreeState", () => {
       });
     }).not.toThrow();
 
-    // Asserts the actual collapse result (not just the absence of a throw):
-    // the defensive try/catch in initializeFromValue would otherwise swallow
-    // a reintroduced stack overflow and leave collapsedPaths empty, letting
-    // this test pass for the wrong reason.
-    expect(result.current.collapsedPaths).toEqual(new Set(["root.a.a"]));
+    // Asserts the actual collapse result, not just the absence of a throw.
+    expect(result.current.collapsedPaths.size).toBeGreaterThan(0);
+  });
+
+  it("collapses every container below the expand depth so drilling in reveals one level at a time", () => {
+    const { result } = renderHook(() =>
+      useJsonTreeState({ defaultExpandDepth: 2 }),
+    );
+
+    act(() => {
+      result.current.initializeFromValue(deeplyNested(6));
+    });
+
+    expect(result.current.isCollapsed("root")).toBe(false);
+    expect(result.current.isCollapsed("root.a")).toBe(false);
+    // The boundary node and every descendant below it start collapsed. Without
+    // the descendants, expanding the boundary dumps the whole subtree at once.
+    expect(result.current.isCollapsed("root.a.a")).toBe(true);
+    expect(result.current.isCollapsed("root.a.a.a")).toBe(true);
+    expect(result.current.isCollapsed("root.a.a.a.a")).toBe(true);
+    // The innermost object is empty, so it is not collapsible.
+    expect(result.current.collapsedPaths.size).toBe(4);
+  });
+
+  it("stops enumerating collapse paths past the scan cap so path memory stays bounded", () => {
+    const { result } = renderHook(() =>
+      useJsonTreeState({ defaultExpandDepth: 2 }),
+    );
+
+    act(() => {
+      result.current.initializeFromValue(deeplyNested(50_000));
+    });
+
+    // Depths 2 through the cap (100), inclusive.
+    expect(result.current.collapsedPaths.size).toBe(99);
+    expect(result.current.isCollapsed(`root${".a".repeat(100)}`)).toBe(true);
+    expect(result.current.isCollapsed(`root${".a".repeat(101)}`)).toBe(false);
   });
 });

--- a/mcpjam-inspector/client/src/components/ui/json-editor/__tests__/use-json-tree-state.test.ts
+++ b/mcpjam-inspector/client/src/components/ui/json-editor/__tests__/use-json-tree-state.test.ts
@@ -20,5 +20,11 @@ describe("useJsonTreeState", () => {
         result.current.initializeFromValue(deep);
       });
     }).not.toThrow();
+
+    // Asserts the actual collapse result (not just the absence of a throw):
+    // the defensive try/catch in initializeFromValue would otherwise swallow
+    // a reintroduced stack overflow and leave collapsedPaths empty, letting
+    // this test pass for the wrong reason.
+    expect(result.current.collapsedPaths).toEqual(new Set(["root.a.a"]));
   });
 });

--- a/mcpjam-inspector/client/src/components/ui/json-editor/__tests__/use-json-tree-state.test.ts
+++ b/mcpjam-inspector/client/src/components/ui/json-editor/__tests__/use-json-tree-state.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect } from "vitest";
+import { describe, it, expect, vi } from "vitest";
 import { renderHook, act } from "@testing-library/react";
 import { useJsonTreeState } from "../use-json-tree-state";
 
@@ -17,28 +17,35 @@ describe("useJsonTreeState", () => {
   it("does not blow the call stack on deeply nested JSON (INSPECTOR-CLIENT-232)", () => {
     const deep = deeplyNested(50_000);
 
+    // A stack overflow while deriving the initial state throws out of the
+    // render, failing this line.
     const { result } = renderHook(() =>
-      useJsonTreeState({ defaultExpandDepth: 2 }),
+      useJsonTreeState({ value: deep, defaultExpandDepth: 2 }),
     );
-
-    expect(() => {
-      act(() => {
-        result.current.initializeFromValue(deep);
-      });
-    }).not.toThrow();
 
     // Asserts the actual collapse result, not just the absence of a throw.
     expect(result.current.collapsedPaths.size).toBeGreaterThan(0);
   });
 
-  it("collapses every container below the expand depth so drilling in reveals one level at a time", () => {
-    const { result } = renderHook(() =>
-      useJsonTreeState({ defaultExpandDepth: 2 }),
+  it("tells the parent about the derived collapse state after commit", () => {
+    const onCollapseChange = vi.fn();
+
+    renderHook(() =>
+      useJsonTreeState({
+        value: deeplyNested(6),
+        defaultExpandDepth: 2,
+        onCollapseChange,
+      }),
     );
 
-    act(() => {
-      result.current.initializeFromValue(deeplyNested(6));
-    });
+    expect(onCollapseChange).toHaveBeenCalledTimes(1);
+    expect(onCollapseChange.mock.calls[0][0].size).toBe(4);
+  });
+
+  it("collapses every container below the expand depth so drilling in reveals one level at a time", () => {
+    const { result } = renderHook(() =>
+      useJsonTreeState({ value: deeplyNested(6), defaultExpandDepth: 2 }),
+    );
 
     expect(result.current.isCollapsed("root")).toBe(false);
     expect(result.current.isCollapsed("root.a")).toBe(false);
@@ -53,15 +60,41 @@ describe("useJsonTreeState", () => {
 
   it("stops enumerating collapse paths past the scan cap so path memory stays bounded", () => {
     const { result } = renderHook(() =>
-      useJsonTreeState({ defaultExpandDepth: 2 }),
+      useJsonTreeState({ value: deeplyNested(50_000), defaultExpandDepth: 2 }),
     );
-
-    act(() => {
-      result.current.initializeFromValue(deeplyNested(50_000));
-    });
 
     // Depths 2 through the cap (100), inclusive.
     expect(result.current.collapsedPaths.size).toBe(99);
+    expect(result.current.isCollapsed(`root${".a".repeat(100)}`)).toBe(true);
+    expect(result.current.isCollapsed(`root${".a".repeat(101)}`)).toBe(false);
+  });
+
+  it("skips holes in a sparse array instead of throwing", () => {
+    // A hole, not an undefined element: the walk must not try to descend it.
+    const sparse: unknown[] = new Array(3);
+    sparse[0] = { a: 1 };
+    sparse[2] = { b: 2 };
+
+    const { result } = renderHook(() =>
+      useJsonTreeState({ value: { list: sparse }, defaultExpandDepth: 1 }),
+    );
+
+    expect(result.current.collapsedPaths).toEqual(
+      new Set(["root.list", "root.list.0", "root.list.2"]),
+    );
+  });
+
+  it("collapseAll collapses every container through the scan cap", () => {
+    const { result } = renderHook(() => useJsonTreeState({}));
+
+    act(() => {
+      result.current.collapseAll(deeplyNested(50_000));
+    });
+
+    expect(result.current.isCollapsed("root")).toBe(true);
+    expect(result.current.isCollapsed("root.a")).toBe(true);
+    // Depths 0 through the cap (100), inclusive.
+    expect(result.current.collapsedPaths.size).toBe(101);
     expect(result.current.isCollapsed(`root${".a".repeat(100)}`)).toBe(true);
     expect(result.current.isCollapsed(`root${".a".repeat(101)}`)).toBe(false);
   });

--- a/mcpjam-inspector/client/src/components/ui/json-editor/__tests__/use-json-tree-state.test.ts
+++ b/mcpjam-inspector/client/src/components/ui/json-editor/__tests__/use-json-tree-state.test.ts
@@ -116,6 +116,17 @@ describe("useJsonTreeState", () => {
     expect(result.current.isCollapsed(`root${".a".repeat(100)}`)).toBe(true);
   });
 
+  it("still collapses at the cap when the requested expand depth exceeds it", () => {
+    const { result } = renderHook(() =>
+      useJsonTreeState({ value: deeplyNested(50_000), defaultExpandDepth: 200 }),
+    );
+
+    // Without clamping, nothing satisfies depth >= 200 before the cap stops the
+    // walk, so the set comes back empty and the whole value renders expanded.
+    expect(result.current.isCollapsed(`root${".a".repeat(100)}`)).toBe(true);
+    expect(result.current.collapsedPaths.size).toBe(1);
+  });
+
   it("collapseAll collapses every container through the scan cap", () => {
     const { result } = renderHook(() => useJsonTreeState({}));
 

--- a/mcpjam-inspector/client/src/components/ui/json-editor/json-tree-node.tsx
+++ b/mcpjam-inspector/client/src/components/ui/json-editor/json-tree-node.tsx
@@ -72,7 +72,12 @@ function useProgressiveChildren<T>(items: T[], isExpanded: boolean): T[] {
 
 interface CopyableValueProps {
   children: React.ReactNode;
-  value: string;
+  /**
+   * A thunk defers serializing until the copy is clicked. Object and array
+   * nodes pass one because serializing a deeply nested subtree on every render
+   * overflows the stack (INSPECTOR-CLIENT-232).
+   */
+  value: string | (() => string);
   onCopy?: (value: string) => void;
   /**
    * Keep the copy button visible even when the value isn't hovered. Used on
@@ -94,10 +99,19 @@ const CopyableValue = memo(function CopyableValue({
   const handleCopy = useCallback(
     async (e: React.MouseEvent) => {
       e.stopPropagation();
-      const success = await copyToClipboard(value);
+      let text: string;
+      try {
+        text = typeof value === "function" ? value() : value;
+      } catch (error) {
+        // Serializing can still fail on a value too deep for JSON.stringify;
+        // skip the copy rather than reject out of the click handler.
+        console.error("Failed to serialize value for copy", error);
+        return;
+      }
+      const success = await copyToClipboard(text);
       if (success) {
         setCopied(true);
-        onCopy?.(value);
+        onCopy?.(text);
         setTimeout(() => setCopied(false), 1500);
       }
     },
@@ -170,6 +184,10 @@ function JsonArrayNode({
 
   // Use progressive rendering for large arrays
   const visibleItems = useProgressiveChildren(value, !collapsed);
+  const getCopyValue = useCallback(
+    () => JSON.stringify(value, null, 2),
+    [value],
+  );
 
   const renderKeyPrefix = () => {
     if (keyName === undefined) return null;
@@ -214,11 +232,7 @@ function JsonArrayNode({
           <ChevronRight className="h-3 w-3" />
         </button>
         {renderKeyPrefix()}
-        <CopyableValue
-          value={JSON.stringify(value, null, 2)}
-          onCopy={onCopy}
-          alwaysVisible
-        >
+        <CopyableValue value={getCopyValue} onCopy={onCopy} alwaysVisible>
           <span className="json-punctuation">[</span>
           <span className="text-muted-foreground text-xs px-1">
             {value.length} {value.length === 1 ? "item" : "items"}
@@ -241,11 +255,7 @@ function JsonArrayNode({
           <ChevronRight className="h-3 w-3" />
         </button>
         {renderKeyPrefix()}
-        <CopyableValue
-          value={JSON.stringify(value, null, 2)}
-          onCopy={onCopy}
-          alwaysVisible
-        >
+        <CopyableValue value={getCopyValue} onCopy={onCopy} alwaysVisible>
           <span className="json-punctuation">[</span>
         </CopyableValue>
       </div>
@@ -300,6 +310,10 @@ function JsonObjectNode({
 
   // Use progressive rendering for large objects
   const visibleEntries = useProgressiveChildren(entries, !collapsed);
+  const getCopyValue = useCallback(
+    () => JSON.stringify(value, null, 2),
+    [value],
+  );
 
   const renderKeyPrefix = () => {
     if (keyName === undefined) return null;
@@ -344,11 +358,7 @@ function JsonObjectNode({
           <ChevronRight className="h-3 w-3" />
         </button>
         {renderKeyPrefix()}
-        <CopyableValue
-          value={JSON.stringify(value, null, 2)}
-          onCopy={onCopy}
-          alwaysVisible
-        >
+        <CopyableValue value={getCopyValue} onCopy={onCopy} alwaysVisible>
           <span className="json-punctuation">{"{"}</span>
           <span className="text-muted-foreground text-xs px-1">
             {entries.length} {entries.length === 1 ? "key" : "keys"}
@@ -371,11 +381,7 @@ function JsonObjectNode({
           <ChevronRight className="h-3 w-3" />
         </button>
         {renderKeyPrefix()}
-        <CopyableValue
-          value={JSON.stringify(value, null, 2)}
-          onCopy={onCopy}
-          alwaysVisible
-        >
+        <CopyableValue value={getCopyValue} onCopy={onCopy} alwaysVisible>
           <span className="json-punctuation">{"{"}</span>
         </CopyableValue>
       </div>

--- a/mcpjam-inspector/client/src/components/ui/json-editor/json-tree-view.tsx
+++ b/mcpjam-inspector/client/src/components/ui/json-editor/json-tree-view.tsx
@@ -1,4 +1,3 @@
-import { useEffect } from "react";
 import { cn } from "@/lib/utils";
 import { useJsonTreeState } from "./use-json-tree-state";
 import { JsonTreeNode } from "./json-tree-node";
@@ -26,18 +25,13 @@ export function JsonTreeView({
   collapseStringsAfterLength,
   onCopy,
 }: JsonTreeViewProps) {
-  const { isCollapsed, toggleCollapse, initializeFromValue } = useJsonTreeState(
-    {
-      defaultExpandDepth,
-      initialCollapsedPaths: controlledCollapsedPaths,
-      onCollapseChange,
-    },
-  );
-
-  // Initialize collapse state based on defaultExpandDepth
-  useEffect(() => {
-    initializeFromValue(value);
-  }, [value, initializeFromValue]);
+  // The hook takes the value so defaultExpandDepth applies on the first render.
+  const { isCollapsed, toggleCollapse } = useJsonTreeState({
+    value,
+    defaultExpandDepth,
+    initialCollapsedPaths: controlledCollapsedPaths,
+    onCollapseChange,
+  });
 
   return (
     <div

--- a/mcpjam-inspector/client/src/components/ui/json-editor/use-json-tree-state.ts
+++ b/mcpjam-inspector/client/src/components/ui/json-editor/use-json-tree-state.ts
@@ -24,6 +24,14 @@ interface UseJsonTreeStateReturn {
 // levels: anything deeper stays hidden behind a collapsed ancestor anyway.
 const MAX_COLLAPSE_SCAN_DEPTH = 100;
 
+// Whether a container holds anything, without materializing its entries.
+function hasEntry(value: object): boolean {
+  for (const key in value) {
+    if (Object.prototype.hasOwnProperty.call(value, key)) return true;
+  }
+  return false;
+}
+
 // Walks iteratively rather than recursively: deeply nested values overflowed
 // the call stack (INSPECTOR-CLIENT-232).
 function getPathsAtDepth(value: unknown, maxDepth: number): string[] {
@@ -36,6 +44,15 @@ function getPathsAtDepth(value: unknown, maxDepth: number): string[] {
     const node = stack.pop()!;
     if (typeof node.value !== "object" || node.value === null) continue;
 
+    // At the cap the children are never visited, so only collapsibility is
+    // still in question — answer it without enumerating a wide container.
+    if (node.depth >= MAX_COLLAPSE_SCAN_DEPTH) {
+      if (node.depth >= maxDepth && hasEntry(node.value)) {
+        paths.push(node.path);
+      }
+      continue;
+    }
+
     // Object.entries covers arrays too, and yields only populated indexes: a
     // sparse array costs nothing per hole, where mapping over one allocates a
     // tuple per hole (and holes cannot be destructured in the loop below).
@@ -45,7 +62,6 @@ function getPathsAtDepth(value: unknown, maxDepth: number): string[] {
     if (node.depth >= maxDepth) {
       paths.push(node.path);
     }
-    if (node.depth >= MAX_COLLAPSE_SCAN_DEPTH) continue;
 
     for (const [key, child] of entries) {
       stack.push({

--- a/mcpjam-inspector/client/src/components/ui/json-editor/use-json-tree-state.ts
+++ b/mcpjam-inspector/client/src/components/ui/json-editor/use-json-tree-state.ts
@@ -1,6 +1,11 @@
-import { useState, useCallback, useMemo, useEffect } from "react";
+import { useState, useCallback, useMemo, useEffect, useRef } from "react";
 
 interface UseJsonTreeStateOptions {
+  /**
+   * The value being rendered. Needed at hook-call time so the initial collapse
+   * state can be derived on the first render rather than after it.
+   */
+  value?: unknown;
   defaultExpandDepth?: number;
   initialCollapsedPaths?: Set<string>;
   onCollapseChange?: (paths: Set<string>) => void;
@@ -12,7 +17,6 @@ interface UseJsonTreeStateReturn {
   toggleCollapse: (path: string) => void;
   expandAll: () => void;
   collapseAll: (value: unknown) => void;
-  initializeFromValue: (value: unknown) => void;
 }
 
 // Each collapsed descendant costs a path string that grows with its depth, so
@@ -32,8 +36,11 @@ function getPathsAtDepth(value: unknown, maxDepth: number): string[] {
     const node = stack.pop()!;
     if (typeof node.value !== "object" || node.value === null) continue;
 
+    // Array.from, not map: map keeps holes, and destructuring a hole in the
+    // loop below throws. Holes materialize as undefined and get skipped by the
+    // object check above, matching the forEach this walk replaced.
     const entries: Array<[string, unknown]> = Array.isArray(node.value)
-      ? node.value.map((item, index) => [String(index), item])
+      ? Array.from(node.value, (item, index) => [String(index), item])
       : Object.entries(node.value);
     if (entries.length === 0) continue;
 
@@ -60,14 +67,26 @@ function getAllPaths(value: unknown): string[] {
 }
 
 export function useJsonTreeState({
+  value,
   defaultExpandDepth,
   initialCollapsedPaths,
   onCollapseChange,
 }: UseJsonTreeStateOptions = {}): UseJsonTreeStateReturn {
+  // Derived during the first render, not in a mount effect: an effect commits
+  // after that render, so the tree would paint fully expanded once before
+  // collapsing. That is wasted work on a large tool result and exhausts the
+  // renderer's heap on a deeply nested one (INSPECTOR-CLIENT-232).
+  // null means nothing was derived, so the effect below knows whether the
+  // parent still has to be told.
+  const [derivedCollapsedPaths] = useState<Set<string> | null>(() => {
+    if (initialCollapsedPaths !== undefined) return null;
+    if (defaultExpandDepth === undefined) return null;
+    return new Set(getPathsAtDepth(value, defaultExpandDepth));
+  });
+
   const [collapsedPaths, setCollapsedPaths] = useState<Set<string>>(
-    () => initialCollapsedPaths ?? new Set(),
+    () => derivedCollapsedPaths ?? initialCollapsedPaths ?? new Set(),
   );
-  const [initialized, setInitialized] = useState(false);
 
   const isCollapsed = useCallback(
     (path: string): boolean => collapsedPaths.has(path),
@@ -105,20 +124,14 @@ export function useJsonTreeState({
     [onCollapseChange],
   );
 
-  const initializeFromValue = useCallback(
-    (value: unknown) => {
-      if (initialized || initialCollapsedPaths !== undefined) return;
-
-      if (defaultExpandDepth !== undefined) {
-        const pathsToCollapse = getPathsAtDepth(value, defaultExpandDepth);
-        const newCollapsed = new Set(pathsToCollapse);
-        setCollapsedPaths(newCollapsed);
-        onCollapseChange?.(newCollapsed);
-      }
-      setInitialized(true);
-    },
-    [initialized, defaultExpandDepth, initialCollapsedPaths, onCollapseChange],
-  );
+  // onCollapseChange is a parent callback, so it cannot fire while the state
+  // above is being derived — announcing the derived set has to wait for commit.
+  const announcedInitial = useRef(false);
+  useEffect(() => {
+    if (announcedInitial.current || derivedCollapsedPaths === null) return;
+    announcedInitial.current = true;
+    onCollapseChange?.(derivedCollapsedPaths);
+  }, [derivedCollapsedPaths, onCollapseChange]);
 
   // Sync with external collapsed paths if controlled
   useEffect(() => {
@@ -134,15 +147,7 @@ export function useJsonTreeState({
       toggleCollapse,
       expandAll,
       collapseAll,
-      initializeFromValue,
     }),
-    [
-      collapsedPaths,
-      isCollapsed,
-      toggleCollapse,
-      expandAll,
-      collapseAll,
-      initializeFromValue,
-    ],
+    [collapsedPaths, isCollapsed, toggleCollapse, expandAll, collapseAll],
   );
 }

--- a/mcpjam-inspector/client/src/components/ui/json-editor/use-json-tree-state.ts
+++ b/mcpjam-inspector/client/src/components/ui/json-editor/use-json-tree-state.ts
@@ -15,51 +15,38 @@ interface UseJsonTreeStateReturn {
   initializeFromValue: (value: unknown) => void;
 }
 
-function getPathsAtDepth(
-  value: unknown,
-  maxDepth: number,
-  currentPath = "root",
-  currentDepth = 0,
-): string[] {
+// Each collapsed descendant costs a path string that grows with its depth, so
+// scanning a deeply nested value is quadratic in memory. Stop past this many
+// levels: anything deeper stays hidden behind a collapsed ancestor anyway.
+const MAX_COLLAPSE_SCAN_DEPTH = 100;
+
+// Walks iteratively rather than recursively: deeply nested values overflowed
+// the call stack (INSPECTOR-CLIENT-232).
+function getPathsAtDepth(value: unknown, maxDepth: number): string[] {
   const paths: string[] = [];
+  const stack: Array<{ value: unknown; path: string; depth: number }> = [
+    { value, path: "root", depth: 0 },
+  ];
 
-  if (currentDepth >= maxDepth) {
-    if (
-      (typeof value === "object" &&
-        value !== null &&
-        Object.keys(value).length > 0) ||
-      (Array.isArray(value) && value.length > 0)
-    ) {
-      paths.push(currentPath);
+  while (stack.length > 0) {
+    const node = stack.pop()!;
+    if (typeof node.value !== "object" || node.value === null) continue;
+
+    const entries: Array<[string, unknown]> = Array.isArray(node.value)
+      ? node.value.map((item, index) => [String(index), item])
+      : Object.entries(node.value);
+    if (entries.length === 0) continue;
+
+    if (node.depth >= maxDepth) {
+      paths.push(node.path);
     }
-    // Nodes at or beyond maxDepth are collapsed from their ancestor above,
-    // so descending further only risks a stack overflow on deeply nested
-    // values without changing which paths get collapsed.
-    return paths;
-  }
+    if (node.depth >= MAX_COLLAPSE_SCAN_DEPTH) continue;
 
-  if (typeof value === "object" && value !== null) {
-    if (Array.isArray(value)) {
-      value.forEach((item, index) => {
-        paths.push(
-          ...getPathsAtDepth(
-            item,
-            maxDepth,
-            `${currentPath}.${index}`,
-            currentDepth + 1,
-          ),
-        );
-      });
-    } else {
-      Object.entries(value).forEach(([key, val]) => {
-        paths.push(
-          ...getPathsAtDepth(
-            val,
-            maxDepth,
-            `${currentPath}.${key}`,
-            currentDepth + 1,
-          ),
-        );
+    for (const [key, child] of entries) {
+      stack.push({
+        value: child,
+        path: `${node.path}.${key}`,
+        depth: node.depth + 1,
       });
     }
   }
@@ -67,29 +54,9 @@ function getPathsAtDepth(
   return paths;
 }
 
-function getAllPaths(value: unknown, currentPath = "root"): string[] {
-  const paths: string[] = [];
-
-  if (typeof value === "object" && value !== null) {
-    if (Array.isArray(value)) {
-      if (value.length > 0) {
-        paths.push(currentPath);
-        value.forEach((item, index) => {
-          paths.push(...getAllPaths(item, `${currentPath}.${index}`));
-        });
-      }
-    } else {
-      const keys = Object.keys(value);
-      if (keys.length > 0) {
-        paths.push(currentPath);
-        Object.entries(value).forEach(([key, val]) => {
-          paths.push(...getAllPaths(val, `${currentPath}.${key}`));
-        });
-      }
-    }
-  }
-
-  return paths;
+// "Collapse everything" is the same walk with an expand depth of zero.
+function getAllPaths(value: unknown): string[] {
+  return getPathsAtDepth(value, 0);
 }
 
 export function useJsonTreeState({
@@ -143,17 +110,7 @@ export function useJsonTreeState({
       if (initialized || initialCollapsedPaths !== undefined) return;
 
       if (defaultExpandDepth !== undefined) {
-        let pathsToCollapse: string[];
-        try {
-          pathsToCollapse = getPathsAtDepth(value, defaultExpandDepth);
-        } catch (error) {
-          // Defensive fallback: if computing collapse paths fails on
-          // pathological input, leave everything expanded instead of
-          // crashing the surrounding view.
-          console.error("Failed to compute default collapsed paths", error);
-          setInitialized(true);
-          return;
-        }
+        const pathsToCollapse = getPathsAtDepth(value, defaultExpandDepth);
         const newCollapsed = new Set(pathsToCollapse);
         setCollapsedPaths(newCollapsed);
         onCollapseChange?.(newCollapsed);

--- a/mcpjam-inspector/client/src/components/ui/json-editor/use-json-tree-state.ts
+++ b/mcpjam-inspector/client/src/components/ui/json-editor/use-json-tree-state.ts
@@ -32,6 +32,10 @@ function getPathsAtDepth(
     ) {
       paths.push(currentPath);
     }
+    // Nodes at or beyond maxDepth are collapsed from their ancestor above,
+    // so descending further only risks a stack overflow on deeply nested
+    // values without changing which paths get collapsed.
+    return paths;
   }
 
   if (typeof value === "object" && value !== null) {
@@ -139,10 +143,16 @@ export function useJsonTreeState({
       if (initialized || initialCollapsedPaths !== undefined) return;
 
       if (defaultExpandDepth !== undefined) {
-        const pathsToCollapse = getPathsAtDepth(value, defaultExpandDepth);
-        const newCollapsed = new Set(pathsToCollapse);
-        setCollapsedPaths(newCollapsed);
-        onCollapseChange?.(newCollapsed);
+        try {
+          const pathsToCollapse = getPathsAtDepth(value, defaultExpandDepth);
+          const newCollapsed = new Set(pathsToCollapse);
+          setCollapsedPaths(newCollapsed);
+          onCollapseChange?.(newCollapsed);
+        } catch {
+          // Defensive fallback: if computing collapse paths fails on
+          // pathological input, leave everything expanded instead of
+          // crashing the surrounding view.
+        }
       }
       setInitialized(true);
     },

--- a/mcpjam-inspector/client/src/components/ui/json-editor/use-json-tree-state.ts
+++ b/mcpjam-inspector/client/src/components/ui/json-editor/use-json-tree-state.ts
@@ -36,12 +36,10 @@ function getPathsAtDepth(value: unknown, maxDepth: number): string[] {
     const node = stack.pop()!;
     if (typeof node.value !== "object" || node.value === null) continue;
 
-    // Array.from, not map: map keeps holes, and destructuring a hole in the
-    // loop below throws. Holes materialize as undefined and get skipped by the
-    // object check above, matching the forEach this walk replaced.
-    const entries: Array<[string, unknown]> = Array.isArray(node.value)
-      ? Array.from(node.value, (item, index) => [String(index), item])
-      : Object.entries(node.value);
+    // Object.entries covers arrays too, and yields only populated indexes: a
+    // sparse array costs nothing per hole, where mapping over one allocates a
+    // tuple per hole (and holes cannot be destructured in the loop below).
+    const entries: Array<[string, unknown]> = Object.entries(node.value);
     if (entries.length === 0) continue;
 
     if (node.depth >= maxDepth) {

--- a/mcpjam-inspector/client/src/components/ui/json-editor/use-json-tree-state.ts
+++ b/mcpjam-inspector/client/src/components/ui/json-editor/use-json-tree-state.ts
@@ -143,16 +143,20 @@ export function useJsonTreeState({
       if (initialized || initialCollapsedPaths !== undefined) return;
 
       if (defaultExpandDepth !== undefined) {
+        let pathsToCollapse: string[];
         try {
-          const pathsToCollapse = getPathsAtDepth(value, defaultExpandDepth);
-          const newCollapsed = new Set(pathsToCollapse);
-          setCollapsedPaths(newCollapsed);
-          onCollapseChange?.(newCollapsed);
-        } catch {
+          pathsToCollapse = getPathsAtDepth(value, defaultExpandDepth);
+        } catch (error) {
           // Defensive fallback: if computing collapse paths fails on
           // pathological input, leave everything expanded instead of
           // crashing the surrounding view.
+          console.error("Failed to compute default collapsed paths", error);
+          setInitialized(true);
+          return;
         }
+        const newCollapsed = new Set(pathsToCollapse);
+        setCollapsedPaths(newCollapsed);
+        onCollapseChange?.(newCollapsed);
       }
       setInitialized(true);
     },

--- a/mcpjam-inspector/client/src/components/ui/json-editor/use-json-tree-state.ts
+++ b/mcpjam-inspector/client/src/components/ui/json-editor/use-json-tree-state.ts
@@ -34,7 +34,11 @@ function hasEntry(value: object): boolean {
 
 // Walks iteratively rather than recursively: deeply nested values overflowed
 // the call stack (INSPECTOR-CLIENT-232).
-function getPathsAtDepth(value: unknown, maxDepth: number): string[] {
+function getPathsAtDepth(value: unknown, requestedDepth: number): string[] {
+  // Clamped so the cap always lands on or past the expand depth: otherwise a
+  // requested depth beyond the cap collapses nothing and the whole deep value
+  // renders expanded, which is the crash this walk exists to avoid.
+  const maxDepth = Math.min(requestedDepth, MAX_COLLAPSE_SCAN_DEPTH);
   const paths: string[] = [];
   const stack: Array<{ value: unknown; path: string; depth: number }> = [
     { value, path: "root", depth: 0 },


### PR DESCRIPTION
getPathsAtDepth() used maxDepth only to decide whether a path should be
collapsed, but kept recursing into every descendant regardless of depth.
On tool call inputs/outputs with deep nesting this walks the full object
graph and blows the call stack (RangeError: Maximum call stack size
exceeded) inside the Playground's tool-invocation JSON viewer.

Stop descending once currentDepth >= maxDepth (deeper paths are already
covered by their collapsed ancestor) and wrap the call in a try/catch as
a defensive fallback.

Fixes INSPECTOR-CLIENT-232

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Bounds the JSON viewer’s collapse scan and defers subtree serialization to prevent stack overflows and first-paint heap blowups (INSPECTOR-CLIENT-232). Previously the viewer walked and serialized past `defaultExpandDepth`; now it scans iteratively with a 100-level cap, clamps the expand depth to that cap, derives collapse on first render, and stringifies only on copy.

- Collapse scan: iterative walk stops once depth >= max depth; cap at 100; clamps `defaultExpandDepth` to the cap; decides collapsibility at the cap without enumerating children; uses `Object.entries` to skip sparse-array holes; `getAllPaths` delegates to the same walker.
- Initialization: `useJsonTreeState` accepts `value`, derives `collapsedPaths` during the first render, and calls `onCollapseChange` after commit; removed `initializeFromValue` and the mount effect in `JsonTreeView`.
- Copy: `CopyableValue` accepts a thunk so object/array nodes defer `JSON.stringify` to click; the handler catches serialization errors and skips the copy.

<sup>Written for commit 7a3a2e66f7e9a6e3fd0c6a90639d829a264e42c1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/MCPJam/inspector/pull/3987?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

