### PR TITLE
Report approved swarm runs to their end on Slack and Discord

### DIFF
--- a/discord-app/app.js
+++ b/discord-app/app.js
@@ -18,7 +18,7 @@ import { createDiscordDelivery } from "./delivery.js";
 import { fetchHistory } from "./history.js";
 import { recordPresence } from "./presence.js";
 import { toDeliverableResult, toReplayContent } from "./turn-result.js";
-import { watchDiscordRun } from "./watcher.js";
+import { watchDiscordJourneyRun, watchDiscordRun } from "./watcher.js";
 
 if (!config.botToken) throw new Error("DISCORD_BOT_TOKEN is required");
 for (const warning of describeConfigGaps(config)) {
@@ -462,7 +462,38 @@ client.on(Events.InteractionCreate, async (interaction) => {
 			interaction.customId,
 			runCtx,
 		);
-		if (result.runId && interaction.channel?.isTextBased?.()) {
+		// A JOURNEY (Swarms) run, recognised by the server-sent resource type —
+		// never by operation name, and never routed into the eval watcher, whose
+		// status vocabulary would report a rate-limited fan-out as a pass.
+		if (
+			result.resource?.type === "journey_run" &&
+			result.resource.id &&
+			interaction.channel?.isTextBased?.()
+		) {
+			const surfaceDelivery = createDiscordDelivery(interaction.channel);
+			const status = await surfaceDelivery.deliver(
+				runCtx,
+				textContent(
+					`Swarm run started${result.runUrl ? ` — ${result.runUrl}` : ""}.`,
+					"info",
+				),
+			);
+			const statusHandle = status.handles.at(-1);
+			if (statusHandle) {
+				detach(
+					watchDiscordJourneyRun({
+						apiClient: api,
+						ctx: runCtx,
+						runId: result.resource.id,
+						handle: statusHandle,
+						surfaceDelivery,
+						url: result.runUrl || "",
+						actorId: interaction.user.id,
+					}),
+					`journey run watcher (${result.resource.id})`,
+				);
+			}
+		} else if (result.runId && interaction.channel?.isTextBased?.()) {
 			const surfaceDelivery = createDiscordDelivery(interaction.channel);
 			const status = await surfaceDelivery.deliver(
 				runCtx,

--- a/discord-app/tests/journey-watcher.test.js
+++ b/discord-app/tests/journey-watcher.test.js
@@ -1,0 +1,122 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+import { watchDiscordJourneyRun } from "../watcher.js";
+
+/**
+ * The Discord journey watcher end to end against a fake API: the status
+ * message must be EDITED to the outcome, and evidence must arrive as a NEW
+ * delivery only when the outcome warrants it. These are the two halves that
+ * silently not happening is the bug this module exists to fix — an approved
+ * swarm run whose thread never says how it went.
+ */
+function makeHandle() {
+	const edits = [];
+	return {
+		edits,
+		handle: {
+			message: {
+				edit: async (payload) => {
+					edits.push(payload);
+					return {};
+				},
+			},
+		},
+	};
+}
+
+test("edits the status to a mixed verdict and posts scorecard evidence", async () => {
+	const { handle, edits } = makeHandle();
+	const delivered = [];
+	const run = {
+		status: "completed",
+		summary: { total: 10, succeeded: 6, failed: 4 },
+	};
+	const result = await watchDiscordJourneyRun({
+		apiClient: {
+			getJourneyRun: async () => run,
+			getJourneyRunScorecard: async () => ({
+				criteria: [{ label: "checkout completed", passCount: 6, failCount: 4 }],
+			}),
+			listJourneyRunSessions: async () => [
+				{ personaLabel: "Impatient admin", status: "failed" },
+			],
+		},
+		ctx: {},
+		runId: "jr_1",
+		handle,
+		surfaceDelivery: {
+			deliver: async (_ctx, content) => {
+				delivered.push(content);
+				return { handles: [] };
+			},
+		},
+		url: "https://app/swarms/jr_1",
+		actorId: "u1",
+		intervalMs: 1,
+		maxMs: 1_000,
+	});
+
+	assert.equal(result, run);
+	assert.equal(edits.length, 1);
+	// A completed run with failures is MIXED — the eval watcher's status-only
+	// reading would have called this a pass.
+	assert.match(edits[0].content, /mixed/);
+	assert.match(edits[0].content, /6\/10 sessions/);
+	assert.equal(delivered.length, 1);
+	const evidence = String(delivered[0].parts?.[0] ?? "");
+	assert.match(evidence, /checkout completed: 6 passed, 4 failed/);
+	assert.match(evidence, /Impatient admin: failed/);
+});
+
+test("posts NO evidence under a green verdict", async () => {
+	const { handle, edits } = makeHandle();
+	const delivered = [];
+	await watchDiscordJourneyRun({
+		apiClient: {
+			getJourneyRun: async () => ({
+				status: "completed",
+				summary: { total: 3, succeeded: 3, failed: 0 },
+			}),
+			// Would throw if consulted — a pass must not even fetch evidence.
+			getJourneyRunScorecard: async () => {
+				throw new Error("evidence fetched for a pass");
+			},
+			listJourneyRunSessions: async () => {
+				throw new Error("evidence fetched for a pass");
+			},
+		},
+		ctx: {},
+		runId: "jr_2",
+		handle,
+		surfaceDelivery: {
+			deliver: async (_ctx, content) => {
+				delivered.push(content);
+				return { handles: [] };
+			},
+		},
+		intervalMs: 1,
+		maxMs: 1_000,
+	});
+	assert.equal(edits.length, 1);
+	assert.match(edits[0].content, /passed/);
+	assert.equal(delivered.length, 0);
+});
+
+test("says the run is still going when the watch window expires", async () => {
+	const { handle, edits } = makeHandle();
+	const result = await watchDiscordJourneyRun({
+		apiClient: { getJourneyRun: async () => ({ status: "running" }) },
+		ctx: {},
+		runId: "jr_3",
+		handle,
+		url: "https://app/swarms/jr_3",
+		intervalMs: 1,
+		maxMs: 10,
+	});
+	// Null means WE stopped watching, not that the run stopped — and the
+	// message must say so rather than staying on "running…" forever.
+	assert.equal(result, null);
+	assert.equal(edits.length, 1);
+	assert.match(edits[0].content, /still going/);
+	assert.match(edits[0].content, /jr_3/);
+});

--- a/discord-app/watcher.js
+++ b/discord-app/watcher.js
@@ -1,9 +1,14 @@
 // @ts-nocheck
 import {
+	collectJourneyRunEvidence,
 	fetchRunEvidence,
+	formatJourneyRunEvidenceLines,
+	formatJourneyRunOutcome,
 	formatRunOutcome,
 	isFailedOutcome,
+	journeyOutcomeWantsEvidence,
 	plainText,
+	watchJourneyRunUntilDone,
 	watchRunUntilDone,
 } from "@mcpjam/surface-core";
 
@@ -61,4 +66,96 @@ export function watchDiscordRun({
 				}),
 		},
 	});
+}
+
+/**
+ * Watch a JOURNEY (Swarms) run — the sibling of `watchDiscordRun`, kept
+ * separate for the same reason the core keeps two watchers: different status
+ * vocabulary, cancellation that is not a status, and a verdict that lives in
+ * the summary. Routing a journey run through the eval watcher reports a
+ * rate-limited fan-out as a pass.
+ *
+ * Evidence is TEXT — the scorecard and the worst sessions — not screenshots:
+ * a journey run has no per-step trace to attach. Posted only for outcomes
+ * whose message says something broke (`journeyOutcomeWantsEvidence`); counts
+ * under a green verdict are noise. Delivered as a NEW message via
+ * `surfaceDelivery.deliver`, never an edit — the outcome line must survive.
+ */
+export function watchDiscordJourneyRun({
+	apiClient,
+	ctx,
+	runId,
+	handle,
+	surfaceDelivery = null,
+	url = "",
+	actorId = "",
+	intervalMs = 15_000,
+	// An hour, not the eval watcher's fifteen minutes: a multi-environment
+	// fan-out ordinarily outlives a short window, and timing out on the
+	// ordinary case makes the status message say the least useful thing.
+	maxMs = 60 * 60_000,
+	logger = console,
+}) {
+	return (async () => {
+		const run = await watchJourneyRunUntilDone({
+			apiClient,
+			ctx,
+			runId,
+			url,
+			actorId,
+			statusHandle: handle,
+			pollIntervalMs: intervalMs,
+			maxMs,
+			logger,
+			formatOutcome: formatJourneyRunOutcome,
+			onTerminal: async (_run, outcome) => {
+				if (!journeyOutcomeWantsEvidence(outcome)) return;
+				if (!surfaceDelivery?.deliver) return;
+				const evidence = await collectJourneyRunEvidence({
+					apiClient,
+					ctx,
+					runId,
+					limit: 5,
+					logger,
+				});
+				const lines = formatJourneyRunEvidenceLines(evidence, {
+					maxSessions: 5,
+				});
+				if (lines.length === 0) return;
+				await surfaceDelivery.deliver(ctx, {
+					severity: "info",
+					code: "journey_run_evidence",
+					parts: [lines.join("\n")],
+				});
+			},
+			delivery: {
+				edit: (messageHandle, content) =>
+					messageHandle.message.edit({
+						content: plainText(content),
+						allowedMentions: { parse: [] },
+					}),
+			},
+		});
+		// Null means the WATCH WINDOW expired, not the run — say so instead of
+		// leaving "running…" to read as a hang or a silent bot.
+		if (run === null) {
+			try {
+				await handle.message.edit({
+					content: plainText({
+						severity: "info",
+						code: "journey_run_still_running",
+						parts: [
+							`Swarm run is still going after an hour${url ? ` — follow the rest at ${url}` : ""}.`,
+						],
+					}),
+					allowedMentions: { parse: [] },
+				});
+			} catch (error) {
+				logger?.warn?.(
+					`Journey run ${runId} still-running edit failed: ${error}`,
+				);
+			}
+		}
+		return run;
+	})();
 }

--- a/slack-app/agent/mcpjam-client.js
+++ b/slack-app/agent/mcpjam-client.js
@@ -149,5 +149,9 @@ export const {
   getEvalRun,
   listEvalRunIterations,
   getEvalRunSteps,
+  // Journey (Swarms) runs — the watcher's status poll and its evidence reads.
+  getJourneyRun,
+  listJourneyRunSessions,
+  getJourneyRunScorecard,
   listProjects,
 } = client;

--- a/slack-app/listeners/actions/journey-run-watcher.js
+++ b/slack-app/listeners/actions/journey-run-watcher.js
@@ -1,0 +1,190 @@
+/**
+ * Watching a JOURNEY (Swarms) run to its end in Slack, and saying what
+ * happened.
+ *
+ * A sibling of `run-watcher.js`, not a mode on it — the core keeps the two
+ * watchers separate (`@mcpjam/surface-core`'s `journey-run-watcher.js` header
+ * has the full argument) and this adapter keeps the same boundary: everything
+ * in here is Slack copy and `chat.*` calls, while "when is it over and what
+ * does over mean" belongs to the core.
+ *
+ * SLACK-APP CONVENTION, same as eval runs: a kicked-off run's message IS its
+ * status surface. The message that says "running…" is the same message that
+ * later says how it went — including after the watch window expires, when it
+ * must say "still running, check the app" rather than staying on "running…"
+ * forever and reading as a hang.
+ */
+import {
+  collectJourneyRunEvidence,
+  formatJourneyRunEvidenceLines,
+  journeyOutcomeWantsEvidence,
+  watchJourneyRunUntilDone,
+} from '@mcpjam/surface-core';
+import {
+  getJourneyRun,
+  getJourneyRunScorecard,
+  listJourneyRunSessions,
+} from '../../agent/mcpjam-client.js';
+
+const POLL_INTERVAL_MS = 15_000;
+// An hour, not the eval watcher's fifteen minutes: a fan-out across four
+// environments at ten sessions each is forty conversations, and fifteen
+// minutes times out on the ordinary case.
+const POLL_MAX_MS = 60 * 60 * 1000;
+const EVIDENCE_SESSION_LIMIT = 5;
+
+/**
+ * The Slack line for a settled journey run.
+ *
+ * Keyed on the OUTCOME KIND the core derived, never on `status`: a stopped
+ * run arrives as `status: "failed"` with `canceled: true`, and telling the
+ * person who pressed Stop that their run failed is the kind of wrong that
+ * sends them hunting for a bug.
+ *
+ * @param {Record<string, any>} run
+ * @param {{kind: string, succeeded: number, failed: number, rateLimited: number, total: number}} outcome
+ * @param {string} url
+ * @param {string} userId
+ */
+export function formatJourneyRunOutcome(run, outcome, url, userId) {
+  const counts =
+    outcome.total > 0
+      ? ` (${outcome.succeeded}/${outcome.total} sessions reached their goal)`
+      : '';
+  const who = ` — approved by <@${userId}>`;
+  switch (outcome.kind) {
+    case 'passed':
+      return `:large_green_circle: Swarm run passed${counts}${who}, <${url}|see the sessions>.`;
+    case 'partial':
+      return `:large_yellow_circle: Swarm run finished mixed${counts}${who}, <${url}|see what happened>.`;
+    case 'failed':
+      return `:red_circle: Swarm run failed${counts}${who}, <${url}|see what broke>.`;
+    case 'rate_limited':
+      return `:red_circle: Swarm run stopped early — model capacity ran out${counts}${who}, <${url}|details>.`;
+    case 'stopped':
+      return `:heavy_minus_sign: Swarm run stopped by request${counts}${who}, <${url}|details>.`;
+    case 'stalled':
+      return `:warning: Swarm runner went silent — results are incomplete${counts}${who}, <${url}|details>.`;
+    default:
+      return `:white_circle: Swarm run settled${counts}${who}, <${url}|details>.`;
+  }
+}
+
+/**
+ * Post the scorecard-and-sessions evidence under the outcome message.
+ *
+ * Text, not screenshots — a journey run has no per-step trace to attach; its
+ * evidence is which rubric criteria failed and which personas did not reach
+ * the goal. Posted ONLY for outcomes whose message says something broke
+ * (`journeyOutcomeWantsEvidence`): counts under a green verdict are noise.
+ *
+ * Strictly additive, mirroring eval evidence: by the time this runs the
+ * outcome message is already correct, so every failure in here is logged and
+ * swallowed rather than allowed to make the run look unreported.
+ *
+ * @param {import('@slack/web-api').WebClient} client
+ * @param {{runId: string, ctx: any, channelId: string, threadTs: string, logger: import('@slack/bolt').Logger}} args
+ */
+export async function postJourneyRunEvidence(client, args) {
+  try {
+    const evidence = await collectJourneyRunEvidence({
+      apiClient: { getJourneyRunScorecard, listJourneyRunSessions },
+      ctx: args.ctx,
+      runId: args.runId,
+      limit: EVIDENCE_SESSION_LIMIT,
+      logger: args.logger,
+    });
+    const lines = formatJourneyRunEvidenceLines(evidence, {
+      maxSessions: EVIDENCE_SESSION_LIMIT,
+    });
+    if (lines.length === 0) return;
+    await client.chat.postMessage({
+      channel: args.channelId,
+      thread_ts: args.threadTs,
+      text: lines.join('\n'),
+    });
+  } catch (error) {
+    args.logger.warn(`Journey run ${args.runId} evidence failed: ${error}`);
+  }
+}
+
+/**
+ * Post the "swarm running…" message and hand it to a detached watcher.
+ *
+ * One operation, like the eval twin: a run announced without a watcher leaves
+ * a message that says "running…" forever, and a watcher without a message has
+ * nothing to edit.
+ *
+ * @param {import('@slack/web-api').WebClient} client
+ * @param {{
+ *   runId: string,
+ *   url: string,
+ *   ctx: import('../../agent/slack-context.js').SlackContext,
+ *   channelId: string,
+ *   threadTs: string,
+ *   userId: string,
+ *   logger: import('@slack/bolt').Logger,
+ *   text?: string,
+ * }} args
+ */
+export async function announceAndWatchJourneyRun(client, args) {
+  const posted = await client.chat.postMessage({
+    channel: args.channelId,
+    thread_ts: args.threadTs,
+    text:
+      args.text ??
+      `:rocket: Approved by <@${args.userId}> — swarm running… <${args.url}|watch it here>.`,
+  });
+  if (!posted.ts) return;
+  const statusTs = /** @type {string} */ (posted.ts);
+  void (async () => {
+    const run = await watchJourneyRunUntilDone({
+      apiClient: { getJourneyRun },
+      ctx: args.ctx,
+      runId: args.runId,
+      url: args.url,
+      actorId: args.userId,
+      pollIntervalMs: POLL_INTERVAL_MS,
+      maxMs: POLL_MAX_MS,
+      statusHandle: { id: statusTs, channelId: args.channelId },
+      formatOutcome: (run, outcome, url, actorId) =>
+        formatJourneyRunOutcome(run, outcome, url, actorId),
+      logger: args.logger,
+      onTerminal: async (_run, outcome) => {
+        if (!journeyOutcomeWantsEvidence(outcome)) return;
+        await postJourneyRunEvidence(client, {
+          runId: args.runId,
+          ctx: args.ctx,
+          channelId: args.channelId,
+          threadTs: args.threadTs,
+          logger: args.logger,
+        });
+      },
+      delivery: {
+        edit: (/** @type {any} */ handle, /** @type {any} */ content) =>
+          client.chat.update({
+            channel: handle.channelId,
+            ts: handle.id,
+            text: content,
+          }),
+      },
+    });
+    // The core returns null when the watch WINDOW expired, not when the run
+    // did — nothing failed, we stopped watching. The message must say so:
+    // left on "running…" it reads as a hang, and edited to a verdict it
+    // would be a lie about a run that is still going.
+    if (run === null) {
+      try {
+        await client.chat.update({
+          channel: args.channelId,
+          ts: statusTs,
+          text: `:hourglass_flowing_sand: Swarm run is still going after an hour — <${args.url}|follow the rest in the app>.`,
+        });
+      } catch (error) {
+        args.logger.warn(
+          `Journey run ${args.runId} still-running edit failed: ${error}`
+        );
+      }
+    }
+  })();
+}

--- a/slack-app/listeners/actions/proposal-button.js
+++ b/slack-app/listeners/actions/proposal-button.js
@@ -24,6 +24,7 @@ import { friendlyMessage as slackFriendlyMessage } from '../../render/slack.js';
 import { escapeSlackText } from '../views/agent-reply-builder.js';
 import { postRunEvidence } from './run-evidence.js';
 import { announceAndWatchRun, isFailedOutcome } from './run-watcher.js';
+import { announceAndWatchJourneyRun } from './journey-run-watcher.js';
 
 /**
  * What to say once the action has actually run.
@@ -219,6 +220,27 @@ export async function handleProposalButton({ ack, body, client, context, logger,
             logger,
           });
         },
+      });
+      return;
+    }
+    // A JOURNEY run gets the same live surface, through its own watcher — the
+    // status vocabulary, verdict location, and evidence shape all differ from
+    // eval runs (see surface-core's journey-run-watcher header), so routing it
+    // into the eval watcher would report a rate-limited fan-out as a pass.
+    // Same recognition rule as above: the server-sent resource TYPE.
+    if (
+      outcome.resource?.type === 'journey_run' &&
+      outcome.resource.id &&
+      outcome.resource.url
+    ) {
+      await announceAndWatchJourneyRun(client, {
+        runId: outcome.resource.id,
+        url: outcome.resource.url,
+        ctx: runCtx,
+        channelId,
+        threadTs: parentTs,
+        userId,
+        logger,
       });
       return;
     }

--- a/slack-app/tests/listeners/actions/journey-run-outcome.test.js
+++ b/slack-app/tests/listeners/actions/journey-run-outcome.test.js
@@ -1,0 +1,61 @@
+import assert from 'node:assert';
+import { describe, it } from 'node:test';
+import { journeyRunOutcome } from '@mcpjam/surface-core';
+import { formatJourneyRunOutcome } from '../../../listeners/actions/journey-run-watcher.js';
+
+/**
+ * The Slack line is derived from the core's OUTCOME, never from `status` — the
+ * cases below are exactly the ones a status-only formatter gets wrong, and
+ * each pins the copy a person acts on.
+ */
+describe('formatJourneyRunOutcome', () => {
+  const url = 'https://x/swarms/run_1?project=p1';
+
+  /** @param {Record<string, any>} run */
+  const format = (run) => formatJourneyRunOutcome(run, journeyRunOutcome(run), url, 'U1');
+
+  it('formats a clean pass with session counts', () => {
+    const text = format({ status: 'completed', summary: { total: 10, succeeded: 10, failed: 0 } });
+    assert.ok(text.includes(':large_green_circle:'));
+    assert.ok(text.includes('(10/10 sessions reached their goal)'));
+    assert.ok(text.includes('<@U1>'));
+    assert.ok(text.includes(url));
+  });
+
+  it('calls a completed run with failures MIXED, not passed', () => {
+    // The verdict lives in the summary. `status: completed` alone would put a
+    // green circle on a fan-out where most sessions missed their goal.
+    const text = format({ status: 'completed', summary: { total: 10, succeeded: 4, failed: 6 } });
+    assert.ok(text.includes(':large_yellow_circle:'));
+    assert.ok(text.includes('mixed'));
+    assert.ok(text.includes('(4/10'));
+  });
+
+  it('reports a canceled run as STOPPED, not failed', () => {
+    // A stopped run arrives as `status: failed, canceled: true`. Telling the
+    // person who pressed Stop that their run failed sends them bug-hunting.
+    const text = format({ status: 'failed', canceled: true, summary: { total: 4, succeeded: 2, failed: 2 } });
+    assert.ok(text.includes('stopped by request'));
+    assert.ok(!text.includes(':red_circle:'));
+  });
+
+  it('reports a stale run as the runner going silent', () => {
+    const text = format({ status: 'running', stale: true, summary: { total: 4, succeeded: 1, failed: 0 } });
+    assert.ok(text.includes('went silent'));
+    assert.ok(text.includes('incomplete'));
+  });
+
+  it('says what rate_limited means instead of naming the enum', () => {
+    const text = format({ status: 'rate_limited', summary: { total: 8, succeeded: 3, failed: 1, rateLimited: 4 } });
+    assert.ok(text.includes('model capacity ran out'));
+    assert.ok(!text.includes('rate_limited'));
+  });
+
+  it('omits the counts clause when the summary is empty', () => {
+    // A run that died before producing sessions has nothing to count;
+    // "(0/0 sessions…)" reads as a bug, not a report.
+    const text = format({ status: 'failed' });
+    assert.ok(!text.includes('(0/0'));
+    assert.ok(text.includes(':red_circle:'));
+  });
+});

--- a/slack-app/tests/listeners/actions/proposal-button.test.js
+++ b/slack-app/tests/listeners/actions/proposal-button.test.js
@@ -408,6 +408,28 @@ describe('handleProposalButton', () => {
     assert.match(posted[0].text, /<@U_CLICKER>/);
   });
 
+  it('starts a LIVE swarm message when the approval produced a journey run', async () => {
+    // Same recognition rule as eval runs — the server-sent resource TYPE —
+    // but a different watcher: journey status vocabulary and verdicts differ,
+    // and routing them into the eval watcher misreports rate-limited fan-outs.
+    stub({
+      executeBody: {
+        status: 'succeeded',
+        operation: 'launch_journey_run',
+        kind: 'start',
+        resource: { type: 'journey_run', id: 'jr_1', url: 'https://app/swarms/jr_1?project=p1' },
+        result: {},
+      },
+    });
+    const { args, posted } = clickArgs();
+    await handleProposalButton(/** @type {any} */ (args));
+    assert.strictEqual(posted.length, 1);
+    assert.match(posted[0].text, /swarm running…/);
+    assert.match(posted[0].text, /watch it here/);
+    assert.match(posted[0].text, /<@U_CLICKER>/);
+    assert.ok(posted[0].text.includes('https://app/swarms/jr_1'));
+  });
+
   it('posts a plain announcement when the approval produced no run', async () => {
     stub({
       executeBody: { status: 'succeeded', operation: 'cancel_eval_run', kind: 'cancel', result: {} },

--- a/surface-core/src/copy.js
+++ b/surface-core/src/copy.js
@@ -129,6 +129,140 @@ export function formatRunOutcome(run, url, actorId) {
 	};
 }
 
+/**
+ * The outcome line for a JOURNEY (Swarms) run, from the discriminated outcome
+ * `journeyRunOutcome` produces — never from `status` alone, which reports a
+ * deliberate stop as a failure and a mostly-failed completion as a pass.
+ *
+ * Session counts are in the line whenever the summary carried any, because
+ * "finished" is not the verdict on a fan-out — 8/10 reaching the goal is. The
+ * severity mapping is the part surfaces render as color, so `partial` is a
+ * warning, not a success with a footnote.
+ *
+ * @param {{status?: string}} run
+ * @param {{kind: string, succeeded: number, failed: number, rateLimited: number, total: number}} outcome
+ * @param {string | {url?: string, actorId?: string} | null | undefined} url
+ * @param {string} [actorId]
+ * @returns {StructuredContent}
+ */
+export function formatJourneyRunOutcome(run, outcome, url, actorId) {
+	if (url && typeof url === "object") {
+		actorId = url.actorId;
+		url = url.url;
+	}
+	const counts =
+		outcome.total > 0
+			? ` (${outcome.succeeded}/${outcome.total} sessions reached their goal)`
+			: "";
+	const link = url ? { link: { url, label: "see the sessions" } } : null;
+	const who = actorId ? [" — approved by ", { mention: actorId }] : [];
+	const tail = [...who, ...(link ? [" — ", link] : [])];
+	switch (outcome.kind) {
+		case "passed":
+			return {
+				severity: "success",
+				code: "journey_run_passed",
+				parts: [`Swarm run passed${counts}`, ...tail],
+			};
+		case "partial":
+			return {
+				severity: "warning",
+				code: "journey_run_partial",
+				parts: [`Swarm run finished mixed${counts}`, ...tail],
+			};
+		case "failed":
+			return {
+				severity: "error",
+				code: "journey_run_failed",
+				parts: [`Swarm run failed${counts}`, ...tail],
+			};
+		case "rate_limited":
+			return {
+				severity: "error",
+				code: "journey_run_rate_limited",
+				parts: [
+					`Swarm run stopped early — model capacity ran out${counts}`,
+					...tail,
+				],
+			};
+		case "stopped":
+			// Someone pressed stop. Nothing failed, and copy that says otherwise
+			// sends the person who stopped it looking for a bug.
+			return {
+				severity: "info",
+				code: "journey_run_stopped",
+				parts: [`Swarm run stopped by request${counts}`, ...tail],
+			};
+		case "stalled":
+			return {
+				severity: "warning",
+				code: "journey_run_stalled",
+				parts: [
+					`Swarm runner went silent — results are incomplete${counts}`,
+					...tail,
+				],
+			};
+		default:
+			return {
+				severity: "info",
+				code: "journey_run_settled",
+				parts: [`Swarm run settled${counts}`, ...tail],
+			};
+	}
+}
+
+/**
+ * Evidence for a journey run as plain text lines, shared by every surface so
+ * Slack and Discord cannot drift into describing the same scorecard
+ * differently.
+ *
+ * The SCORECARD LEADS (it is deterministic and usually the whole answer);
+ * sessions follow, worst first, as `collectJourneyRunEvidence` ranked them.
+ * Returns [] when there is nothing worth posting — the caller should then
+ * post nothing rather than an empty frame.
+ *
+ * @param {{scorecard: {criteria?: Array<{label?: string, criterionId?: string, kind?: string, passCount?: number, failCount?: number, pendingCount?: number}>} | null, sessions: Array<Record<string, any>>}} evidence
+ * @param {{maxSessions?: number}} [opts]
+ * @returns {string[]}
+ */
+export function formatJourneyRunEvidenceLines(evidence, opts = {}) {
+	const lines = [];
+	const criteria = evidence?.scorecard?.criteria ?? [];
+	for (const criterion of criteria) {
+		const name = criterion.label || criterion.criterionId || criterion.kind;
+		const pass = criterion.passCount ?? 0;
+		const fail = criterion.failCount ?? 0;
+		const pending = criterion.pendingCount ?? 0;
+		if (!name) continue;
+		// Failing criteria carry the answer; all-pass criteria are one line of
+		// reassurance each and are kept so a mixed scorecard reads as a whole.
+		lines.push(
+			`• ${name}: ${pass} passed, ${fail} failed${pending > 0 ? `, ${pending} pending` : ""}`,
+		);
+	}
+	const sessions = (evidence?.sessions ?? []).slice(
+		0,
+		opts.maxSessions ?? 5,
+	);
+	for (const session of sessions) {
+		const who = session.personaLabel || session.personaId || "session";
+		const verdict =
+			session?.goalScore?.passed === false
+				? "did not reach the goal"
+				: session?.status === "rate_limited"
+					? "rate-limited"
+					: session?.status === "failed"
+						? "failed"
+						: (session?.status ?? "finished");
+		const preview =
+			typeof session.preview === "string" && session.preview.length > 0
+				? ` — “${session.preview.slice(0, 80)}”`
+				: "";
+		lines.push(`◦ ${who}: ${verdict}${preview}`);
+	}
+	return lines;
+}
+
 /** @param {string} message */
 export function errorCopy(message) {
 	return textContent(message, "error");

--- a/surface-core/tests/journey-run-watcher.test.js
+++ b/surface-core/tests/journey-run-watcher.test.js
@@ -408,3 +408,105 @@ describe("watchJourneyRunUntilDone", () => {
 		assert.deepEqual(edits, ["failed"]);
 	});
 });
+
+// ── Shared copy (copy.js) ───────────────────────────────────────────────────
+// Tested here rather than in a copy test because the contract under test is
+// the PAIRING: these formatters consume exactly what `journeyRunOutcome`
+// produces, and drifting apart shows up as wrong words, not errors.
+
+import {
+	formatJourneyRunEvidenceLines,
+	formatJourneyRunOutcome,
+	plainText,
+} from "../src/copy.js";
+
+describe("formatJourneyRunOutcome", () => {
+	const render = (run) =>
+		plainText(
+			formatJourneyRunOutcome(run, journeyRunOutcome(run), {
+				url: "https://app/swarms/jr_1",
+				actorId: "U1",
+			}),
+		);
+
+	test("counts lead the verdict on every settled kind", () => {
+		const line = render({
+			status: "completed",
+			summary: { total: 10, succeeded: 8, failed: 2 },
+		});
+		// completed-with-failures is MIXED — the formatter must follow the
+		// outcome's reclassification, not the raw status.
+		assert.match(line, /mixed/);
+		assert.match(line, /8\/10 sessions reached their goal/);
+	});
+
+	test("a canceled run reads as stopped, with info severity", () => {
+		const content = formatJourneyRunOutcome(
+			{ status: "failed", canceled: true },
+			journeyRunOutcome({ status: "failed", canceled: true }),
+			{ url: "", actorId: "" },
+		);
+		assert.equal(content.severity, "info");
+		assert.equal(content.code, "journey_run_stopped");
+	});
+
+	test("rate limiting is an error explained in words, not an enum", () => {
+		const line = render({
+			status: "rate_limited",
+			summary: { total: 6, succeeded: 2, rateLimited: 4 },
+		});
+		assert.match(line, /model capacity ran out/);
+		assert.doesNotMatch(line, /rate_limited/);
+	});
+
+	test("no counts clause when the run produced no sessions", () => {
+		assert.doesNotMatch(render({ status: "failed" }), /0\/0/);
+	});
+});
+
+describe("formatJourneyRunEvidenceLines", () => {
+	test("scorecard leads, worst sessions follow", () => {
+		const lines = formatJourneyRunEvidenceLines({
+			scorecard: {
+				criteria: [
+					{ label: "checkout completed", passCount: 1, failCount: 7 },
+					{ criterionId: "c2", passCount: 8, failCount: 0 },
+				],
+			},
+			sessions: [
+				{
+					personaLabel: "Impatient admin",
+					status: "completed",
+					goalScore: { passed: false },
+					preview: "I give up",
+				},
+				{ personaLabel: "Patient tester", status: "rate_limited" },
+			],
+		});
+		assert.equal(lines.length, 4);
+		assert.match(lines[0], /checkout completed: 1 passed, 7 failed/);
+		// A criterion with no label still names itself by id.
+		assert.match(lines[1], /c2: 8 passed, 0 failed/);
+		assert.match(lines[2], /Impatient admin: did not reach the goal/);
+		assert.match(lines[2], /I give up/);
+		assert.match(lines[3], /Patient tester: rate-limited/);
+	});
+
+	test("caps sessions and returns [] when there is nothing to show", () => {
+		assert.deepEqual(
+			formatJourneyRunEvidenceLines({ scorecard: null, sessions: [] }),
+			[],
+		);
+		const many = formatJourneyRunEvidenceLines(
+			{
+				scorecard: null,
+				sessions: Array.from({ length: 9 }, (_, index) => ({
+					personaLabel: `p${index}`,
+					status: "failed",
+				})),
+			},
+			{ maxSessions: 3 },
+		);
+		assert.equal(many.length, 3);
+	});
+});


### PR DESCRIPTION
Closes the loudest gap left by #3969: an approved journey launch started a run, and then the thread went silent — the run-watching path was eval-only, so the person who clicked **Launch it** never learned how the fan-out went.

## What changes

Both surfaces now hand a server-sent `journey_run` resource to the journey watcher `surface-core` already ships (merged in #3969 with tests) — never the eval watcher, whose status-only reading would report a rate-limited fan-out as a pass.

- **Shared copy in surface-core** (`formatJourneyRunOutcome`, `formatJourneyRunEvidenceLines`) so Slack and Discord cannot drift into describing the same scorecard differently. The lines follow the core's discriminated outcome: *canceled* reads as stopped-by-request, *stale* as the runner going silent, *completed-with-failures* as **mixed** — with session counts in every verdict.
- **Slack**: a `journey-run-watcher.js` adapter mirroring the eval one, a `journey_run` branch in the proposal button, and the three journey reads exported from the client. The "swarm running…" message is the message that later says how it went.
- **Discord**: `watchDiscordJourneyRun` plus a resource-typed branch in the approval handler.
- **Evidence is text** — the scorecard and the worst sessions, failed-first — posted only under verdicts that say something broke.
- **Window expiry tells the truth**: after an hour the status edits to "still going — follow it in the app" instead of leaving "running…" to read as a hang. Journey watch window is an hour, not the eval watcher's fifteen minutes.

## Testing

- Slack: 6 outcome-copy cases (stopped ≠ failed, mixed ≠ passed, rate-limit copy in words, no `(0/0)` clause) + a proposal-button routing case. Suite: 177 passing.
- Discord: 3 end-to-end watcher cases (mixed verdict + evidence, no evidence under green, window expiry). Suite: 47 passing.
- surface-core: 4 shared-copy cases. Suite: 80 passing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches approval-button routing and long-lived background polling on Slack and Discord; mistakes could misreport run outcomes or spam threads, but changes are additive with dedicated watchers and broad test coverage rather than altering auth or billing.
> 
> **Overview**
> **Approved swarm launches no longer go silent in the thread.** When a proposal executes and the server returns a `journey_run` resource, Slack and Discord route it to a **journey-specific watcher** (not the eval run watcher), so verdicts use journey semantics—mixed fan-outs, deliberate stops, rate limits, and stale runners are not mislabeled as simple pass/fail.
> 
> **surface-core** adds shared `formatJourneyRunOutcome` and `formatJourneyRunEvidenceLines` so both surfaces describe the same scorecard and session summaries. **Slack** adds `journey-run-watcher.js`, wires `announceAndWatchJourneyRun` from the proposal button, and exports journey API reads on the client. **Discord** adds `watchDiscordJourneyRun` and a matching branch in the approval handler.
> 
> The status message is edited in place until the run settles; **text evidence** (scorecard + worst sessions) is posted as a **new** message only when the outcome warrants it. The journey watch window is **one hour** (vs fifteen minutes for evals); if polling stops while the run is still active, the status updates to **still going** with a link to the app instead of hanging on “running…”.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9a52fcd7e5c99646d5830fb12104f77e02ac26c6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Report approved Swarm journey runs to completion on Slack and Discord so the approver sees the verdict and evidence. Previously, approved runs started and then threads stayed silent or were misreported via the eval watcher.

- Route server-sent `journey_run` resources to the journey watcher in both surfaces, never through the eval watcher (avoids treating rate-limited fan-outs as passes).
- Shared copy in `@mcpjam/surface-core`: `formatJourneyRunOutcome` (structured) and `formatJourneyRunEvidenceLines`. Outcomes map canceled→stopped-by-request, stale→runner went silent, completed-with-failures→mixed, with session counts when present.
- Slack: add `journey-run-watcher.js`; `proposal-button` branches on `journey_run`; export `getJourneyRun`, `listJourneyRunSessions`, `getJourneyRunScorecard`. The initial “running…” message is edited to the verdict; after 1 hour it edits to “still going — follow it in the app.”
- Discord: add `watchDiscordJourneyRun`; approval handler routes by resource type. Edit the status message for the outcome; post text evidence as a new message only when the outcome indicates issues.
- Evidence is text (scorecard + worst sessions), not screenshots, and only posts under mixed/failed/rate-limited outcomes.
- Tests cover outcome wording, routing, no evidence under green, mixed verdict + evidence, and window expiry. No config changes or migrations.

<sup>Written for commit 9a52fcd7e5c99646d5830fb12104f77e02ac26c6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/MCPJam/inspector/pull/3990?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

