### PR TITLE
fix(checks): use isKnownPredicateKind for the facet kind guards

### DIFF
--- a/mcpjam-inspector/client/src/components/shared/usage-insights/CriterionScorecard.tsx
+++ b/mcpjam-inspector/client/src/components/shared/usage-insights/CriterionScorecard.tsx
@@ -8,9 +8,8 @@ import {
 } from "@/hooks/chatbox-usage-filters";
 import type { CriterionFacet } from "@/hooks/useUsageInsights";
 import {
-  PREDICATE_KIND_LABELS,
   formatCriterion,
-  type PredicateKind,
+  isKnownPredicateKind,
 } from "@/shared/predicate-kinds";
 
 /** Keep the scorecard headline and compact statline on one calculation. */
@@ -229,8 +228,8 @@ export function CriterionScorecard({
  * `formatCriterion` has no id to fall back to.
  */
 function criterionDisplayName(facet: CriterionFacet): string {
-  if (facet.kind && facet.kind in PREDICATE_KIND_LABELS) {
-    return formatCriterion({ ...facet, kind: facet.kind as PredicateKind });
+  if (facet.kind !== undefined && isKnownPredicateKind(facet.kind)) {
+    return formatCriterion({ ...facet, kind: facet.kind });
   }
   return facet.label?.trim() || facet.criterionId;
 }

--- a/mcpjam-inspector/client/src/components/swarms/swarm-overview-panel.tsx
+++ b/mcpjam-inspector/client/src/components/swarms/swarm-overview-panel.tsx
@@ -46,9 +46,8 @@ import {
   type SwarmOverviewTarget,
 } from "@/lib/swarm-api";
 import {
-  PREDICATE_KIND_LABELS,
   formatCriterion,
-  type PredicateKind,
+  isKnownPredicateKind,
 } from "@/shared/predicate-kinds";
 import { shouldQueryProjectId } from "@/hooks/useProjects";
 import { useProjectEnvironmentsEnabled } from "@/hooks/useProjectEnvironmentsEnabled";
@@ -78,8 +77,8 @@ export function formatPercent(rate: number): string {
  * to).
  */
 function findingName(finding: SwarmOverviewFinding): string {
-  if (finding.kind && finding.kind in PREDICATE_KIND_LABELS) {
-    return formatCriterion({ ...finding, kind: finding.kind as PredicateKind });
+  if (finding.kind !== undefined && isKnownPredicateKind(finding.kind)) {
+    return formatCriterion({ ...finding, kind: finding.kind });
   }
   return finding.label?.trim() || finding.criterionId;
 }


### PR DESCRIPTION
Follow-up to #3971. `criterionDisplayName` (CriterionScorecard) and `findingName` (swarm-overview-panel) still guarded with `kind in PREDICATE_KIND_LABELS` — the prototype-chain-walking pattern that PR introduced `isKnownPredicateKind` to replace.

Not exploitable (these `kind` values are server-derived from validated rubric predicates, not raw wire data), but it left the old idiom sitting next to its replacement. Swapping to the own-property guard also lets its type narrowing remove both `as PredicateKind` casts and the now-unused `PREDICATE_KIND_LABELS` imports.

No behavior change for any known kind. Covered by `InsightsWorkbench.criteria.test.tsx` (16 passing).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Display-label guard refactor only; no auth, data, or API changes, and behavior for known kinds is unchanged per the PR description.
> 
> **Overview**
> Follow-up to #3971: **CriterionScorecard** (`criterionDisplayName`) and **swarm-overview-panel** (`findingName`) still used `kind in PREDICATE_KIND_LABELS` to decide when to call `formatCriterion`.
> 
> Both now use **`isKnownPredicateKind`** with an explicit `kind !== undefined` check, matching the shared own-property guard introduced in that PR. That removes the unused **`PREDICATE_KIND_LABELS`** imports and the **`as PredicateKind`** casts via proper type narrowing.
> 
> **No intended behavior change** for server-derived known predicate kinds; labels still come from `formatCriterion` or the existing author label / raw id fallbacks.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a6bfcf1b2ab57ba63e5b4f636f4542a3da17b641. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Standardizes predicate kind guards in UI checks to use `isKnownPredicateKind` instead of `kind in PREDICATE_KIND_LABELS`. Old behavior walked the prototype chain; new behavior uses an own-property predicate with type narrowing. No behavior change for valid kinds; removes casts and unused imports.

- Updates `criterionDisplayName` and `findingName` to call `formatCriterion` only when `isKnownPredicateKind(kind)` is true.
- Drops `PREDICATE_KIND_LABELS` imports and `as PredicateKind` casts.
- Inputs are server-validated rubric predicates; this is a consistency and safety cleanup, not a security fix.
- Covered by `InsightsWorkbench.criteria.test.tsx` (no test changes).

<sup>Written for commit a6bfcf1b2ab57ba63e5b4f636f4542a3da17b641. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/MCPJam/inspector/pull/3993?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

