### PR TITLE
chore(server-connections): drop the FEATURE_DISABLED mapping the backend no longer emits

### DIFF
--- a/mcpjam-inspector/server/routes/v1/__tests__/server-connections.test.ts
+++ b/mcpjam-inspector/server/routes/v1/__tests__/server-connections.test.ts
@@ -4,7 +4,7 @@
  * These four routes are thin — they forward the caller's own bearer and return
  * what the backend says — so the part worth pinning is the TRANSLATION. The
  * backend raises a vocabulary the generic v1 mapper does not know
- * (`ACTIVE_REQUEST_LIMIT`, `FEATURE_DISABLED`, `AMBIGUOUS_SERVER`), and the
+ * (`ACTIVE_REQUEST_LIMIT`, `AMBIGUOUS_SERVER`), and the
  * generic fallback flattens all of it into a 400: "fix your input", when the
  * honest answer is "wait", "finish one you already started", or "this is not on
  * yet". `CODE_MAP` is also the piece most likely to drift, because a new backend
@@ -166,7 +166,6 @@ describe("error translation", () => {
     ["ACTIVE_REQUEST_LIMIT", 409],
     ["RATE_LIMITED", 429],
     ["PROJECT_ACCESS_DENIED", 403],
-    ["FEATURE_DISABLED", 403],
     ["URL_NOT_ALLOWED", 400],
     ["UNSUPPORTED_AUTH_METHOD", 400],
   ])("maps %s to %i", async (code, status) => {

--- a/mcpjam-inspector/server/routes/v1/server-connections.ts
+++ b/mcpjam-inspector/server/routes/v1/server-connections.ts
@@ -53,8 +53,8 @@ function convexClient(token: string): ConvexHttpClient {
  * Map the connection flow's own error codes onto v1 codes.
  *
  * The generic `translateConvexWriteError` is not used here because this flow
- * raises a vocabulary it does not know — RATE_LIMITED, ACTIVE_REQUEST_LIMIT,
- * FEATURE_DISABLED — and its fallbacks would flatten all three into a 400,
+ * raises a vocabulary it does not know — RATE_LIMITED, ACTIVE_REQUEST_LIMIT —
+ * and its fallbacks would flatten both into a 400,
  * which tells a caller to fix their input when the honest answer is "wait",
  * "finish one of the ones you already started", or "this is not on yet".
  */
@@ -67,7 +67,6 @@ const CODE_MAP: Record<string, { status: number; code: ErrorCode }> = {
   RATE_LIMITED: { status: 429, code: ErrorCode.RATE_LIMITED },
   PROJECT_ACCESS_DENIED: { status: 403, code: ErrorCode.FORBIDDEN },
   FORBIDDEN: { status: 403, code: ErrorCode.FORBIDDEN },
-  FEATURE_DISABLED: { status: 403, code: ErrorCode.FORBIDDEN },
   URL_NOT_ALLOWED: { status: 400, code: ErrorCode.VALIDATION_ERROR },
   UNSUPPORTED_AUTH_METHOD: {
     status: 400,


### PR DESCRIPTION
Companion to MCPJam/mcpjam-backend#967 (remove the server-connection launch flag): the backend no longer emits `FEATURE_DISABLED`, so the v1 route's mapping entry and its test row come out.

**Merge order: backend #967 first.** During a mixed-version window the fallback would flatten `FEATURE_DISABLED` to a 400 — only reachable while an old backend can still produce the code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small cleanup aligned with backend removal; brief mixed-version window could mis-map FEATURE_DISABLED as 500 instead of 403 if deploy order is wrong.
> 
> **Overview**
> Removes **`FEATURE_DISABLED`** from the v1 server-connections error translation now that the backend no longer emits it (companion to removing the server-connection launch flag).
> 
> The **`CODE_MAP`** entry that mapped it to **403** is gone, along with the matching row in the parameterized error-translation test. Comments that listed `FEATURE_DISABLED` among backend-specific codes are updated so they only mention codes the mapper still handles.
> 
> **Merge order:** backend change first. If an old backend still returns `FEATURE_DISABLED` against this inspector, it will no longer get a dedicated 403 mapping and will fall through to the generic **500** path instead of the previous **403**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9ea02ebd4b025f0c2edc718b5359267119ba21c4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removes the `FEATURE_DISABLED` error mapping from the v1 server-connections route and its test row because the backend no longer emits this code. Previously `FEATURE_DISABLED` returned 403; now it is unmapped, which has no effect once the backend change lands.

- **Rollout**
  - Merge MCPJam/mcpjam-backend#967 first. During a mixed-version window, any `FEATURE_DISABLED` from an old backend will fall back to 400.
  - No client or caller changes required.

- **Review notes**
  - Deleted `FEATURE_DISABLED` from `CODE_MAP` and the test matrix; updated comments to reflect the reduced vocabulary.
  - No other routes or mappings changed.

<sup>Written for commit 9ea02ebd4b025f0c2edc718b5359267119ba21c4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/MCPJam/inspector/pull/3994?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

