### PR TITLE
Join the attempt verdict onto journey-run sessions as outcome

### DIFF
--- a/discord-app/tests/journey-watcher.test.js
+++ b/discord-app/tests/journey-watcher.test.js
@@ -38,7 +38,7 @@ test("edits the status to a mixed verdict and posts scorecard evidence", async (
 				criteria: [{ label: "checkout completed", passCount: 6, failCount: 4 }],
 			}),
 			listJourneyRunSessions: async () => [
-				{ personaLabel: "Impatient admin", status: "failed" },
+				{ personaLabel: "Impatient admin", outcome: "failed" },
 			],
 		},
 		ctx: {},

--- a/mcpjam-inspector/server/routes/v1/__tests__/journeys.test.ts
+++ b/mcpjam-inspector/server/routes/v1/__tests__/journeys.test.ts
@@ -518,6 +518,7 @@ describe("session DTO outcome join", () => {
           attempts: [
             { chatSessionId: "cs_ok", hostId: "h1", status: "succeeded" },
             { chatSessionId: "cs_bad", hostId: "h1", status: "failed" },
+            { chatSessionId: "cs_limited", hostId: "h1", status: "rate_limited" },
           ],
         })
       )
@@ -525,7 +526,8 @@ describe("session DTO outcome join", () => {
         page: [
           { id: "s1", chatSessionId: "cs_ok", projectId: PROJECT, status: "active" },
           { id: "s2", chatSessionId: "cs_bad", projectId: PROJECT, status: "active" },
-          { id: "s3", chatSessionId: "cs_unknown", projectId: PROJECT, status: "active" },
+          { id: "s3", chatSessionId: "cs_limited", projectId: PROJECT, status: "active" },
+          { id: "s4", chatSessionId: "cs_unknown", projectId: PROJECT, status: "active" },
         ],
         isDone: true,
         continueCursor: "",
@@ -539,6 +541,9 @@ describe("session DTO outcome join", () => {
     expect(body.items.map((s) => s.outcome)).toEqual([
       "succeeded",
       "failed",
+      // The watcher ranks rate-limited sessions as evidence — this literal
+      // surviving the join is what that depends on.
+      "rate_limited",
       // No matching attempt (historical run) → null, never a guess.
       null,
     ]);

--- a/mcpjam-inspector/server/routes/v1/__tests__/journeys.test.ts
+++ b/mcpjam-inspector/server/routes/v1/__tests__/journeys.test.ts
@@ -505,3 +505,44 @@ describe("POST .../journeys/:journeyId/runs", () => {
     expect(launchMock).not.toHaveBeenCalled();
   });
 });
+
+describe("session DTO outcome join", () => {
+  it("joins each session's attempt outcome from the run row", async () => {
+    // A session row's own `status` is its ARCHIVAL state (active/archived) —
+    // it never says how the attempt went. The verdict lives on the run's
+    // attempts, keyed by chatSessionId, and the route must join it or every
+    // consumer reads "active" as if it were a result.
+    queryMock
+      .mockResolvedValueOnce(
+        runRow({
+          attempts: [
+            { chatSessionId: "cs_ok", hostId: "h1", status: "succeeded" },
+            { chatSessionId: "cs_bad", hostId: "h1", status: "failed" },
+          ],
+        })
+      )
+      .mockResolvedValueOnce({
+        page: [
+          { id: "s1", chatSessionId: "cs_ok", projectId: PROJECT, status: "active" },
+          { id: "s2", chatSessionId: "cs_bad", projectId: PROJECT, status: "active" },
+          { id: "s3", chatSessionId: "cs_unknown", projectId: PROJECT, status: "active" },
+        ],
+        isDone: true,
+        continueCursor: "",
+      });
+
+    const res = await get(`/projects/${PROJECT}/journey-runs/${RUN}/sessions`);
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as {
+      items: Array<{ id: string; status: string; outcome: string | null }>;
+    };
+    expect(body.items.map((s) => s.outcome)).toEqual([
+      "succeeded",
+      "failed",
+      // No matching attempt (historical run) → null, never a guess.
+      null,
+    ]);
+    // The archival flag survives unchanged alongside the verdict.
+    expect(body.items[0]?.status).toBe("active");
+  });
+});

--- a/mcpjam-inspector/server/routes/v1/journeys.ts
+++ b/mcpjam-inspector/server/routes/v1/journeys.ts
@@ -284,7 +284,7 @@ function toJourneyRunDto(row: JourneyRunRow) {
   };
 }
 
-function toJourneySessionDto(row: JourneySessionRow) {
+function toJourneySessionDto(row: JourneySessionRow, outcome?: string | null) {
   return {
     /**
      * The `chatSessions` DOCUMENT id — the same value `GET /v1/chat-sessions`
@@ -309,7 +309,21 @@ function toJourneySessionDto(row: JourneySessionRow) {
     ...(row.personaLabel !== undefined
       ? { personaLabel: row.personaLabel }
       : {}),
+    /**
+     * ARCHIVAL state (`active` | `archived`), not a completion state — a
+     * run session stays `active` forever unless someone archives it, so this
+     * says nothing about how the conversation went. The per-session verdict
+     * is `outcome` below; the run-level verdict is the run's own status.
+     */
     status: row.status ?? null,
+    /**
+     * How this session's ATTEMPT ended, joined from the run row
+     * (`succeeded` | `failed` | `rate_limited` | `running` | `pending`), or
+     * null when the attempt cannot be matched (historical runs whose attempts
+     * predate `chatSessionId` stamping). This is the field a caller should
+     * read to rank or judge sessions — `status` above cannot answer it.
+     */
+    outcome: outcome ?? null,
     readiness: row.readiness ?? null,
     goalScore: row.goalScore ?? null,
     messageCount: row.messageCount ?? 0,
@@ -772,7 +786,17 @@ journeys.get("/projects/:projectId/journey-runs/:runId/sessions", async (c) => {
   const projectId = c.req.param("projectId");
   const runId = c.req.param("runId");
   const client = createConvexClient(await getConvexBearerForRequest(c));
-  await requireRunInProject(client, projectId, runId);
+  const run = await requireRunInProject(client, projectId, runId);
+  // Per-session verdicts live on the RUN row (`attempts[].status`), keyed by
+  // `chatSessionId` — the session row's own `status` is only active/archived.
+  // Joined here so the sessions a caller ranks or judges carry how their
+  // attempt actually ended.
+  const outcomeByChatSessionId = new Map<string, string>();
+  for (const attempt of run.attempts ?? []) {
+    if (attempt.chatSessionId) {
+      outcomeByChatSessionId.set(attempt.chatSessionId, attempt.status);
+    }
+  }
 
   let result: {
     page: JourneySessionRow[];
@@ -792,7 +816,9 @@ journeys.get("/projects/:projectId/journey-runs/:runId/sessions", async (c) => {
   }
   return v1PageJson(
     c,
-    result.page.map(toJourneySessionDto),
+    result.page.map((row) =>
+      toJourneySessionDto(row, outcomeByChatSessionId.get(row.chatSessionId))
+    ),
     nextCursorFrom(result)
   );
 });

--- a/sdk/src/platform/types.ts
+++ b/sdk/src/platform/types.ts
@@ -948,7 +948,18 @@ export interface PlatformJourneyRunSession {
   journeyId?: string;
   personaId?: string;
   personaLabel?: string;
+  /**
+   * ARCHIVAL state (`active` | `archived`) — a run session stays `active`
+   * forever unless archived, so this says nothing about how it went. Read
+   * `outcome` for the verdict.
+   */
   status: string | null;
+  /**
+   * How this session's run attempt ended: `succeeded` | `failed` |
+   * `rate_limited` | `running` | `pending`, or null when the attempt cannot
+   * be matched (historical runs). Absent on servers that predate the field.
+   */
+  outcome?: string | null;
   readiness: unknown;
   goalScore: unknown;
   messageCount: number;

--- a/surface-core/src/copy.js
+++ b/surface-core/src/copy.js
@@ -246,14 +246,17 @@ export function formatJourneyRunEvidenceLines(evidence, opts = {}) {
 	);
 	for (const session of sessions) {
 		const who = session.personaLabel || session.personaId || "session";
+		// Verdict from `outcome` (the attempt's end state) and the judge's
+		// `goalScore` — never from `status`, which is the session's archival
+		// flag and would print "active" as a verdict.
 		const verdict =
 			session?.goalScore?.passed === false
 				? "did not reach the goal"
-				: session?.status === "rate_limited"
+				: session?.outcome === "rate_limited"
 					? "rate-limited"
-					: session?.status === "failed"
+					: session?.outcome === "failed"
 						? "failed"
-						: (session?.status ?? "finished");
+						: "finished";
 		const preview =
 			typeof session.preview === "string" && session.preview.length > 0
 				? ` — “${session.preview.slice(0, 80)}”`

--- a/surface-core/src/journey-run-watcher.js
+++ b/surface-core/src/journey-run-watcher.js
@@ -180,10 +180,13 @@ export async function collectJourneyRunEvidence(args) {
 
 /** @param {Record<string, any>} session */
 function isFailedSession(session) {
-	// `rate_limited` counts: on a rate-limited run those ARE the sessions worth
-	// reading, and ranking them below ordinary completions would attach the
-	// least relevant evidence to exactly the run that needs it.
-	if (session?.status === "failed" || session?.status === "rate_limited") {
+	// `outcome` is the attempt's verdict (`succeeded`/`failed`/`rate_limited`),
+	// joined onto the session by the sessions route. NOT `status` — that field
+	// is the session's archival state (`active`/`archived`) and never says how
+	// the attempt went, which is why an earlier version of this check matched
+	// nothing. `rate_limited` counts: on a rate-limited run those ARE the
+	// sessions worth reading.
+	if (session?.outcome === "failed" || session?.outcome === "rate_limited") {
 		return true;
 	}
 	// `goalScore` is the judge's verdict; `readiness` is the transport-level

--- a/surface-core/tests/journey-run-watcher.test.js
+++ b/surface-core/tests/journey-run-watcher.test.js
@@ -116,9 +116,9 @@ describe("collectJourneyRunEvidence", () => {
 					return [
 						...Array.from({ length: 20 }, (_, index) => ({
 							id: `ok_${index}`,
-							status: "completed",
+							outcome: "succeeded",
 						})),
-						{ id: "late_failure", status: "failed" },
+						{ id: "late_failure", outcome: "failed" },
 					];
 				},
 			},
@@ -138,8 +138,8 @@ describe("collectJourneyRunEvidence", () => {
 			apiClient: {
 				getJourneyRunScorecard: async () => null,
 				listJourneyRunSessions: async () => [
-					{ id: "ok_1", status: "completed" },
-					{ id: "limited", status: "rate_limited" },
+					{ id: "ok_1", outcome: "succeeded" },
+					{ id: "limited", outcome: "rate_limited" },
 				],
 			},
 			ctx: {},
@@ -156,9 +156,9 @@ describe("collectJourneyRunEvidence", () => {
 			apiClient: {
 				getJourneyRunScorecard: async () => ({ criteria: [] }),
 				listJourneyRunSessions: async () => [
-					{ id: "ok_1", status: "completed" },
-					{ id: "bad_1", status: "failed" },
-					{ id: "ok_2", status: "completed" },
+					{ id: "ok_1", outcome: "succeeded" },
+					{ id: "bad_1", outcome: "failed" },
+					{ id: "ok_2", outcome: "succeeded" },
 					{ id: "bad_2", goalScore: { passed: false } },
 				],
 			},
@@ -476,11 +476,11 @@ describe("formatJourneyRunEvidenceLines", () => {
 			sessions: [
 				{
 					personaLabel: "Impatient admin",
-					status: "completed",
+					outcome: "succeeded",
 					goalScore: { passed: false },
 					preview: "I give up",
 				},
-				{ personaLabel: "Patient tester", status: "rate_limited" },
+				{ personaLabel: "Patient tester", outcome: "rate_limited" },
 			],
 		});
 		assert.equal(lines.length, 4);


### PR DESCRIPTION
Found during the staging smoke test: a completed run's sessions all read `status: "active"`. That field is the session's **archival** state (`active`/`archived`) — it never says how the attempt went — which had two consequences:

- The #3990 watcher's failed-session ranking matched on `session.status === "failed" | "rate_limited"`, literals that cannot appear in that field: a dead branch, so evidence ranking fell back to goal scores alone.
- The evidence formatter could print "active" as a session's verdict.

The sessions route now joins the run row's per-attempt statuses (`succeeded | failed | rate_limited`, keyed by `chatSessionId`) onto each session as **`outcome`** — `null` when no attempt matches (historical runs), never a guess — and documents `status` for what it is. `surface-core` ranks and words verdicts from `outcome` + `goalScore`, with "finished" as the fallback. SDK type extended additively.

## Testing
- New route test pinning the join (matched, failed, and unmatched-→null cases; archival flag untouched alongside).
- surface-core (80) + discord (47) + slack (177) + sdk (4279) + journeys/sdk-coverage route suites all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Additive API field with behavior fixes in Discord/Slack evidence paths; callers must read `outcome` for verdicts and handle `null`/older servers, but archival `status` semantics are unchanged.
> 
> **Overview**
> Fixes journey-run session consumers that treated **`status`** (archival `active`/`archived`) as the attempt verdict—so completed runs looked like every session was still **active**, failed-session ranking never matched, and evidence copy could show **active** as a result.
> 
> **`GET …/journey-runs/:runId/sessions`** now loads the run and joins `attempts[].status` onto each session by `chatSessionId` as **`outcome`** (`succeeded` / `failed` / `rate_limited` / etc., or **`null`** when unmatched). **`status`** is unchanged and documented on the DTO. **`surface-core`** ranks evidence and formats session lines from **`outcome`** (+ `goalScore`); the SDK adds optional **`outcome`** on **`PlatformJourneyRunSession`**. Tests cover the join and updated mocks.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f75cd461b378d23d1943365d5dea9e8658317726. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Joins per-attempt verdicts onto journey-run sessions as `outcome` and updates consumers to read it. Previously, clients treated `status` (archival `active`/`archived`) as a verdict; now verdicts come from `outcome`, with UI copy falling back to "finished".

The server’s `GET /v1/projects/:projectId/journey-runs/:runId/sessions` now joins attempts by `chatSessionId` and returns `outcome` (`succeeded` | `failed` | `rate_limited` | `running` | `pending`), or null when unmatched; `status` remains the archival flag. `surface-core` ranks failed sessions by `outcome` and formats evidence from `outcome` + `goalScore` (fallback "finished"); `discord-app` tests updated. The `sdk` adds `outcome?: string | null` to `PlatformJourneyRunSession` and documents `status`.

**Migration**
- Read verdicts from `session.outcome` instead of `session.status`.
- Treat `outcome` as optional; handle `null` and older servers without the field.
- Use `status` only for archival state.

<sup>Written for commit f75cd461b378d23d1943365d5dea9e8658317726. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/MCPJam/inspector/pull/3996?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

