### PR TITLE
test(agent): derive agent tier from operation.risk, with a named-exceptions map

### DIFF
--- a/mcpjam-inspector/server/routes/v1/__tests__/agent-op-registry.test.ts
+++ b/mcpjam-inspector/server/routes/v1/__tests__/agent-op-registry.test.ts
@@ -614,6 +614,204 @@ describe("agent op registry", () => {
   });
 });
 
+describe("tier derives from operation.risk", () => {
+  // The registry's own policy, made mechanical. The comments used to state
+  // the rule as prose while every `tier:` stayed a hand-placed literal, so a
+  // deviation was silent. Now the rule runs over the real catalog: every
+  // operation that declares `risk` must land on the tier its risk derives —
+  // or be NAMED in TIER_EXCEPTIONS below, with the reason a reviewer should
+  // read. The next silent deviation fails here instead of shipping.
+
+  type Placement = "direct" | "gated" | "excluded";
+  type Risk = NonNullable<(typeof ALL_OPERATIONS)[number]["risk"]>;
+
+  /** What each risk class means on this surface. */
+  const TIER_BY_RISK: Readonly<Record<Risk, Placement>> = {
+    none: "direct", // persists, reversible, costs nothing
+    spend: "gated", // a person approves the money
+    exposure: "gated", // a person approves who can reach it
+    destructive: "excluded", // an approval makes spend deliberate; it does
+    //                          not make a removal recoverable
+  };
+
+  /**
+   * The ONLY lawful deviations from the derivation, each with its reason.
+   *
+   * An entry here is a product decision, not an escape hatch: adding one is
+   * exactly the review the derivation exists to force. Neither entry changes
+   * behavior — both document tiers the registry already shipped.
+   */
+  const TIER_EXCEPTIONS: Readonly<
+    Record<string, { tier: Placement; reason: string }>
+  > = {
+    cancel_journey_run: {
+      tier: "gated",
+      reason:
+        "Destructive would derive excluded, but this is the spend-STOPPER: " +
+        "excluding it would let the agent propose launching a run while " +
+        "having no way to propose stopping one. Stopping spend must be " +
+        "approvable, even though cancellation kills in-flight sessions " +
+        "irreversibly.",
+    },
+    publish_scenario: {
+      tier: "excluded",
+      reason:
+        "Exposure would derive gated, but publishing decides who outside " +
+        "the project may talk to your servers. That is a human decision the " +
+        "agent should not even propose.",
+    },
+  };
+
+  const placementOf = (name: string): Placement | "unregistered" => {
+    const entry = AGENT_OP_REGISTRY.find((e) => e.operation.name === name);
+    if (entry) return entry.tier;
+    return name in EXCLUDED_FROM_AGENT ? "excluded" : "unregistered";
+  };
+
+  const classified = ALL_OPERATIONS.filter((op) => op.risk !== undefined);
+
+  it("classifies enough of the catalog for the derivation to mean anything", () => {
+    // Guards the derivation itself: if `risk` were ever dropped from the SDK
+    // catalog, `classified` would be empty and every assertion below would
+    // pass vacuously.
+    expect(classified.length).toBeGreaterThan(20);
+  });
+
+  it("places every risk-classified operation where its risk derives — or where TIER_EXCEPTIONS says", () => {
+    for (const op of classified) {
+      const exception = TIER_EXCEPTIONS[op.name];
+      const expected = exception?.tier ?? TIER_BY_RISK[op.risk!];
+      expect(
+        placementOf(op.name),
+        exception
+          ? `${op.name} (risk: ${op.risk}) is a named exception and must stay ` +
+              `${expected} — TIER_EXCEPTIONS: ${exception.reason}`
+          : `${op.name} (risk: ${op.risk}) must be ${expected}. If this ` +
+              `deviation is deliberate, add ${op.name} to TIER_EXCEPTIONS in ` +
+              `this file with the reason a reviewer should read.`
+      ).toBe(expected);
+    }
+  });
+
+  it("keeps every exception live: a real op, risk-classified, actually deviating", () => {
+    // A vestigial exception is the map lying about the surface: if the SDK's
+    // risk class or the registry's tier moves so the entry no longer
+    // deviates, it must be deleted, or it pre-excuses a FUTURE deviation.
+    for (const [name, exception] of Object.entries(TIER_EXCEPTIONS)) {
+      const op = ALL_OPERATIONS.find((candidate) => candidate.name === name);
+      expect(
+        op,
+        `${name} is not an SDK operation; remove it from TIER_EXCEPTIONS`
+      ).toBeDefined();
+      expect(
+        op!.risk,
+        `${name} declares no risk, so no derivation applies; remove it from TIER_EXCEPTIONS`
+      ).toBeDefined();
+      expect(
+        TIER_BY_RISK[op!.risk!],
+        `${name} no longer deviates — risk "${op!.risk}" already derives ` +
+          `"${exception.tier}"; remove it from TIER_EXCEPTIONS`
+      ).not.toBe(exception.tier);
+      expect(
+        exception.reason.length,
+        `${name} needs a substantive reason`
+      ).toBeGreaterThan(20);
+    }
+  });
+
+  it("finds risk only on writes — the derivation never governs a read", () => {
+    // The SDK's own contract: risk "is meaningless on a read". Reads are
+    // tiered by other concerns entirely (privacy, turn scope), so if one ever
+    // grew a risk field the derivation would start mis-governing it. Checked
+    // against reality: today no read-only operation declares risk, and many
+    // reads are excluded for reasons no risk class describes
+    // (list_chat_sessions is privacy, list_projects is turn scope).
+    for (const op of ALL_OPERATIONS.filter((candidate) => candidate.readOnly)) {
+      expect(
+        op.risk,
+        `${op.name} is read-only; risk is meaningless on a read and would ` +
+          `put it under a derivation that does not govern reads`
+      ).toBeUndefined();
+    }
+  });
+
+  /**
+   * Writes that predate the `risk` field — the legacy catalog, pinned.
+   *
+   * These are exempt from the derivation because "not yet classified" is a
+   * real state, distinct from `risk: none` (delete_project sits here, and it
+   * is anything but). The pin makes the exemption a ratchet: this list may
+   * only SHRINK. A new write cannot join it — it must declare `risk` in the
+   * SDK catalog, which is what puts it under the derivation above.
+   */
+  const UNCLASSIFIED_WRITES: ReadonlySet<string> = new Set([
+    "archive_project_environment",
+    "build_sandbox_image",
+    "call_server_tool",
+    "cancel_eval_run",
+    "close_tunnel",
+    "connect_project_server",
+    "create_eval_case",
+    "create_eval_suite",
+    "create_host",
+    "create_project",
+    "create_project_environment",
+    "create_project_server",
+    "create_sandbox_image",
+    "create_tunnel",
+    "delete_eval_case",
+    "delete_eval_suite",
+    "delete_host",
+    "delete_project",
+    "delete_project_server",
+    "delete_sandbox_image",
+    "duplicate_host",
+    "generate_eval_cases",
+    "promote_sandbox_image",
+    "reset_computer",
+    "restore_project_environment",
+    "run_eval_case",
+    "run_eval_suite",
+    "set_eval_suite_environments",
+    "set_eval_suite_schedule",
+    "set_host_servers",
+    "update_eval_case",
+    "update_eval_suite",
+    "update_host",
+    "update_project",
+    "update_project_environment",
+    "update_project_server",
+    "update_sandbox_image",
+    "use_sandbox_image",
+  ]);
+
+  it("pins the unclassified legacy writes — the list only shrinks", () => {
+    const unclassified = ALL_OPERATIONS.filter(
+      (op) => !op.readOnly && op.risk === undefined
+    ).map((op) => op.name);
+
+    const newcomers = unclassified
+      .filter((name) => !UNCLASSIFIED_WRITES.has(name))
+      .sort();
+    expect(
+      newcomers,
+      `New write operations must declare \`risk\` in the SDK catalog ` +
+        `(none | spend | exposure | destructive) — that classification is ` +
+        `what derives their agent tier. Do not add names to ` +
+        `UNCLASSIFIED_WRITES; it is a legacy pin and only shrinks.`
+    ).toEqual([]);
+
+    const departed = [...UNCLASSIFIED_WRITES]
+      .filter((name) => !unclassified.includes(name))
+      .sort();
+    expect(
+      departed,
+      `These writes were classified (or removed from the catalog) — delete ` +
+        `them from UNCLASSIFIED_WRITES so the derivation above governs them.`
+    ).toEqual([]);
+  });
+});
+
 /**
  * The prompt as it stood before assembly replaced the literal. Kept verbatim,
  * so the refactor is provably a no-op for the model and any future change to

--- a/mcpjam-inspector/server/routes/v1/__tests__/agent-op-registry.test.ts
+++ b/mcpjam-inspector/server/routes/v1/__tests__/agent-op-registry.test.ts
@@ -803,13 +803,19 @@ describe("tier derives from operation.risk", () => {
       (op) => !op.readOnly && op.risk === undefined
     ).map((op) => op.name);
 
+    // EQUALITY, not <=: a <= ceiling decays as the pin shrinks (classifying
+    // five writes leaves five slots of slack a later addition could use
+    // without touching this line). Exact match means every size change —
+    // shrink or grow — must also edit the ceiling, so the two-diff-line
+    // guarantee stays live for the whole life of the pin.
     expect(
       UNCLASSIFIED_WRITES.size,
-      `The unclassified-writes pin grew. Classifying the new write (one ` +
-        `\`risk\` field in the SDK catalog) is the intended fix; growing the ` +
-        `pin needs a reviewer to accept both this ceiling bump and the new ` +
-        `name above.`
-    ).toBeLessThanOrEqual(UNCLASSIFIED_WRITES_CEILING);
+      `The unclassified-writes pin changed size. Shrinking (classifying a ` +
+        `write): lower UNCLASSIFIED_WRITES_CEILING to match. Growing: don't — ` +
+        `classify the new write (one \`risk\` field in the SDK catalog) ` +
+        `instead; growing needs a reviewer to accept both the ceiling bump ` +
+        `and the new name above.`
+    ).toBe(UNCLASSIFIED_WRITES_CEILING);
 
     const newcomers = unclassified
       .filter((name) => !UNCLASSIFIED_WRITES.has(name))

--- a/mcpjam-inspector/server/routes/v1/__tests__/agent-op-registry.test.ts
+++ b/mcpjam-inspector/server/routes/v1/__tests__/agent-op-registry.test.ts
@@ -740,9 +740,15 @@ describe("tier derives from operation.risk", () => {
    *
    * These are exempt from the derivation because "not yet classified" is a
    * real state, distinct from `risk: none` (delete_project sits here, and it
-   * is anything but). The pin makes the exemption a ratchet: this list may
-   * only SHRINK. A new write cannot join it — it must declare `risk` in the
-   * SDK catalog, which is what puts it under the derivation above.
+   * is anything but).
+   *
+   * HONEST LIMITS OF THE PIN: like every in-repo allowlist (the EXCLUDED_*
+   * maps, KNOWN_UNDOCUMENTED, this file's TIER_EXCEPTIONS), it can be edited
+   * by the same PR that adds an unclassified write — no in-repo test can
+   * stop that. What it guarantees is REVIEWER VISIBILITY: joining the list
+   * means adding a name here AND raising the ceiling below, two diff lines
+   * whose comments say "don't". The convention is shrink-only; the
+   * enforcement is review.
    */
   const UNCLASSIFIED_WRITES: ReadonlySet<string> = new Set([
     "archive_project_environment",
@@ -785,10 +791,25 @@ describe("tier derives from operation.risk", () => {
     "use_sandbox_image",
   ]);
 
+  /**
+   * The 38 writes above predate `risk`. This number may only go DOWN — if
+   * you are raising it to admit a new unclassified write, classify the write
+   * instead; that is one field in the SDK catalog.
+   */
+  const UNCLASSIFIED_WRITES_CEILING = 38;
+
   it("pins the unclassified legacy writes — the list only shrinks", () => {
     const unclassified = ALL_OPERATIONS.filter(
       (op) => !op.readOnly && op.risk === undefined
     ).map((op) => op.name);
+
+    expect(
+      UNCLASSIFIED_WRITES.size,
+      `The unclassified-writes pin grew. Classifying the new write (one ` +
+        `\`risk\` field in the SDK catalog) is the intended fix; growing the ` +
+        `pin needs a reviewer to accept both this ceiling bump and the new ` +
+        `name above.`
+    ).toBeLessThanOrEqual(UNCLASSIFIED_WRITES_CEILING);
 
     const newcomers = unclassified
       .filter((name) => !UNCLASSIFIED_WRITES.has(name))

--- a/mcpjam-inspector/server/routes/v1/agent-op-registry.ts
+++ b/mcpjam-inspector/server/routes/v1/agent-op-registry.ts
@@ -679,14 +679,16 @@ export const AGENT_OP_REGISTRY: readonly AgentOpEntry[] = [
 
   // ── SWARMS ────────────────────────────────────────────────────────────
   //
-  // The tiers below are NOT a fresh per-operation judgement — they are read
-  // off `operation.risk` in the SDK catalog:
-  //
-  //   risk: none        → direct   (persists, reversible, costs nothing)
-  //   risk: spend       → gated    (a person approves the money)
-  //   risk: exposure    → gated    (a person approves who can reach it)
-  //   risk: destructive → excluded (an approval makes spend deliberate; it
-  //                                 does not make a deletion recoverable)
+  // The tiers below are NOT a fresh per-operation judgement — they follow
+  // from `operation.risk` in the SDK catalog (none → direct, spend/exposure
+  // → gated, destructive → excluded), and the rule is ENFORCED, not prose:
+  // the "tier derives from operation.risk" suite in agent-op-registry.test.ts
+  // runs the derivation over every risk-classified operation. The only
+  // lawful deviations are the ones NAMED in that suite's `TIER_EXCEPTIONS`
+  // map, each with a written reason (`cancel_journey_run` stays gated so
+  // stopping spend is approvable; `publish_scenario` stays excluded because
+  // who may talk to your servers is a human call). Re-tiering an entry
+  // against its risk fails CI until the exception is written down there.
   //
   // Deriving from shared metadata rather than re-deciding here is the fix for
   // a real failure: `cancel_journey_run` was once excluded from this surface


### PR DESCRIPTION
## What

Test-only. The headless-agent registry (`server/routes/v1/agent-op-registry.ts`) claimed in comments that agent tiering derives from `operation.risk` — `none → direct`, `spend`/`exposure` → `gated`, `destructive` → excluded — but every `tier:` was a hand-placed literal and nothing enforced the rule. Two entries already deviated silently. This PR makes the rule mechanical without changing any tier.

## How

A new `tier derives from operation.risk` suite in `agent-op-registry.test.ts`:

- **Derivation test** — runs the rule over every risk-classified operation in the SDK catalog and asserts its actual placement (registry tier, or `EXCLUDED_FROM_AGENT`). The next deviation fails CI with a message pointing at the exceptions map.
- **`TIER_EXCEPTIONS`** — the only lawful deviations, each with a written reason. Verified against the real catalog to be exactly the two that exist today:
  - `cancel_journey_run` (`destructive`, stays **gated**): it is the spend-stopper — excluding it would let the agent propose launching a run with no way to propose stopping one.
  - `publish_scenario` (`exposure`, stays **excluded**): publishing decides who outside the project may talk to your servers — a human decision the agent should not even propose.
  A staleness check fails if an exception stops deviating (or names a nonexistent/unclassified op), so the map cannot pre-excuse future drift.
- **Legacy pin** — writes that predate the `risk` field (`delete_project`, `close_tunnel`, `archive_project_environment`, …) are pinned by name as "not yet classified". The pin only shrinks: a new write without `risk` fails with a message telling the author to classify it in the SDK catalog; a write that gains `risk` must be deleted from the pin so the derivation governs it.
- **Reads verified out of scope** — no read-only op declares `risk` (the SDK calls it "meaningless on a read"), and reads are tiered by privacy/turn-scope concerns no risk class describes; the test asserts risk stays write-only rather than pretending `readOnly → direct` (reality: many reads are deliberately excluded).
- A vacuity guard so the suite cannot pass trivially if `risk` ever left the catalog.

The registry's prose comment block now points at the enforcing test + `TIER_EXCEPTIONS` instead of restating the rule.

## Verification

- Derivation was run over the real catalog first; the two exceptions above are confirmed to be the only deviations.
- Mutation-tested: removing `publish_scenario` from `TIER_EXCEPTIONS` fails with `publish_scenario (risk: exposure) must be gated. If this deviation is deliberate, add publish_scenario to TIER_EXCEPTIONS…`.
- `npx vitest run server/routes/v1/__tests__/agent-op-registry.test.ts server/routes/v1/__tests__/agent.test.ts server/routes/v1/__tests__/proposed-actions.test.ts` — 130/130 green.

No behavior change: no tier moved, no new gating or confirmations.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> No runtime tier or gating behavior changes—only tests and registry comments that lock existing agent-surface policy in CI.
> 
> **Overview**
> **Test-only:** agent operation tiers are unchanged at runtime; this PR makes the documented `operation.risk` → tier mapping fail CI when it drifts.
> 
> A new **`tier derives from operation.risk`** suite in `agent-op-registry.test.ts` applies `none → direct`, `spend`/`exposure` → `gated`, and `destructive` → `excluded` to every SDK operation with `risk`, using registry tier or `EXCLUDED_FROM_AGENT` as placement. Deviations must appear in **`TIER_EXCEPTIONS`** with a reason (`cancel_journey_run`, `publish_scenario` today), with staleness checks so exceptions cannot outlive real catalog behavior.
> 
> Legacy writes without `risk` stay on a shrink-only **`UNCLASSIFIED_WRITES`** pin (exact count ceiling) so new writes must get `risk` in the SDK instead of silently joining the legacy list. A separate assertion keeps **`risk` off read-only operations**.
> 
> The Swarms comment block in **`agent-op-registry.ts`** now points reviewers at the enforcing test and exception map instead of restating the rule as prose only.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f53f61f784afdd2131fc1263640ae43630231dd3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Enforces agent tiers derive from `operation.risk` in CI without changing any runtime tiers. Previously tiers were hand-set and could drift silently.

- Adds a “tier derives from operation.risk” test suite that checks every risk-classified SDK operation and fails on deviations (with a vacuity guard).
- Introduces `TIER_EXCEPTIONS` with reasons for the only allowed deviations: `cancel_journey_run` (destructive → stays gated to allow stopping spend) and `publish_scenario` (exposure → stays excluded as a human decision), plus a staleness check.
- Pins legacy unclassified writes in `UNCLASSIFIED_WRITES` with an exact count ceiling; any size change must also edit the ceiling. New writes must declare `risk` in the SDK catalog; classified/removed writes must be deleted from the pin. Clarifies the pin guarantees reviewer visibility, not prevention.
- Verifies reads stay out of scope: no read-only operation may declare `risk`.
- Updates the registry comment to point at the enforcing test and exceptions map.

<sup>Written for commit f53f61f784afdd2131fc1263640ae43630231dd3. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/MCPJam/inspector/pull/3997?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

