### PR TITLE
feat(client): cross-surface Sessions page over the unified backend feed

### DIFF
--- a/mcpjam-inspector/client/src/App.tsx
+++ b/mcpjam-inspector/client/src/App.tsx
@@ -11,7 +11,7 @@ import {
   type ComponentProps,
 } from "react";
 import { useAuth } from "@workos-inc/authkit-react";
-import { AlertTriangle, Loader2, Users } from "lucide-react";
+import { AlertTriangle, Loader2, MessageSquare, Users } from "lucide-react";
 import { toast } from "@/lib/toast";
 import { MCPJamLimitDialog } from "./components/mcpjam-limit-dialog";
 import { HomeTab } from "./components/HomeTab";
@@ -36,6 +36,7 @@ import {
   useViewerProjectRole,
 } from "./hooks/useProjects";
 import { ProjectEnvironmentsRoute } from "./components/project-environments/ProjectEnvironmentsRoute";
+import { SessionsPanel } from "./components/sessions/SessionsPanel";
 import { SettingsTab } from "./components/SettingsTab";
 import { ApiKeysRoute } from "./components/settings/ApiKeysRoute";
 import { GithubChecksRoute } from "./components/settings/GithubChecksRoute";
@@ -249,6 +250,7 @@ import {
   useHostMutations,
 } from "@/hooks/useClients";
 import { useSandboxesEnabledState } from "@/hooks/useSandboxesEnabled";
+import { useUnifiedSessionsEnabledState } from "@/hooks/useUnifiedSessionsEnabled";
 import {
   HOST_TEMPLATES,
   seedFromHostTemplate,
@@ -573,6 +575,8 @@ function NoRouterRouteBody({ activeTab }: { activeTab: string }) {
       return <SwarmsRoute />;
     case "environments":
       return <EnvironmentsRoute />;
+    case "sessions":
+      return <SessionsRoute />;
     case "playground":
       return <PlaygroundRoute />;
     case "support":
@@ -820,10 +824,10 @@ export function HostsRoute() {
     idShapedHostId === null
       ? "none"
       : isRouteHostListLoading
-        ? "pending"
-        : routeHosts.some((h) => h.hostId === idShapedHostId)
-          ? "live"
-          : "dead";
+      ? "pending"
+      : routeHosts.some((h) => h.hostId === idShapedHostId)
+      ? "live"
+      : "dead";
 
   // The id the canvas may open. A dead id resolves to null HERE, before it
   // reaches shared state, which is what keeps this route out of a fight with
@@ -1419,8 +1423,7 @@ export function ChatboxesRoute() {
   // to the pathname there. Deliberately NOT `useLocation`: that throws its
   // router invariant on the no-router path.
   const pathname = getRouteFallbackPathname();
-  const rawScenarioId =
-    params.scenarioId ?? scenarioIdFromPathname(pathname);
+  const rawScenarioId = params.scenarioId ?? scenarioIdFromPathname(pathname);
   // `new` is the create route, never a scenario id. The dedicated
   // `user-testing/new` route already keeps it out of `params.scenarioId`, but
   // reserving the word here means route-ordering can't quietly turn the create
@@ -1636,6 +1639,52 @@ export function EnvironmentsRoute() {
       canManage={canManage}
       isAuthenticated={isAuthenticated}
     />
+  );
+}
+
+export function SessionsRoute() {
+  // The cross-surface Sessions feed. Flag-gated while the backing backend
+  // queries (`sessionsFeed:*`) roll out; row-level visibility (who sees whose
+  // Playground sessions, swarm's member gate) is entirely server-side, so no
+  // role gate here — the backend fail-softs a non-member to an empty page.
+  const { convexProjectId } = useAppRouteContext();
+  const unifiedSessionsEnabled = useUnifiedSessionsEnabledState();
+
+  // Only redirect on an explicit `false`. While PostHog hydrates the flag is
+  // `undefined`; bouncing then would strand a flagged-in user who cold-loads
+  // /sessions directly. (Same tradeoff as SwarmsRoute.)
+  if (unifiedSessionsEnabled === false) {
+    return <Navigate to={routePaths.servers} replace />;
+  }
+  if (unifiedSessionsEnabled === undefined) {
+    return null;
+  }
+
+  if (!convexProjectId) {
+    return (
+      <EmptyState
+        icon={MessageSquare}
+        title="Sessions needs a project"
+        description="Sign in and select a project to browse its sessions across Playground, User Testing, Evals, and Swarms."
+      />
+    );
+  }
+
+  return (
+    // Dark-ship guard: `usePaginatedQuery` against a not-yet-deployed backend
+    // query throws. Degrade to copy instead of white-screening the page.
+    <ErrorBoundary
+      name="sessions-panel"
+      fallback={
+        <EmptyState
+          icon={MessageSquare}
+          title="Sessions isn't available yet"
+          description="This project's deployment doesn't serve the unified sessions feed yet. It becomes available with the next backend release."
+        />
+      }
+    >
+      <SessionsPanel key={convexProjectId} projectId={convexProjectId} />
+    </ErrorBoundary>
   );
 }
 
@@ -2963,7 +3012,7 @@ export default function App() {
   // hook for the full chain.
   const hostedClientCapabilities = useHostedClientCapabilities(
     activeHost?.clientCapabilities,
-    activeProject?.clientConfig,
+    activeProject?.clientConfig
   );
   const convexProjectId = activeProject?.sharedProjectId ?? null;
   const projectServerConfigDto = useQuery(

--- a/mcpjam-inspector/client/src/components/mcp-sidebar.tsx
+++ b/mcpjam-inspector/client/src/components/mcp-sidebar.tsx
@@ -21,6 +21,7 @@ import {
   Loader2,
   Layers,
   Cable,
+  MessagesSquare,
 } from "lucide-react";
 import { useFeatureFlagEnabled } from "posthog-js/react";
 import { track } from "@/lib/analytics";
@@ -223,6 +224,14 @@ export const navigationSections: NavSection[] = [
         url: "/evals",
         icon: FlaskConical,
         billingFeature: "evals",
+      },
+      {
+        // Cross-surface session feed (Playground + User Testing + Evals +
+        // Swarms). Route-guarded on the same flag (`SessionsRoute`).
+        title: "Sessions",
+        url: "/sessions",
+        icon: MessagesSquare,
+        featureFlag: "unified-sessions-enabled",
       },
     ],
   },

--- a/mcpjam-inspector/client/src/components/sessions/SessionsPanel.tsx
+++ b/mcpjam-inspector/client/src/components/sessions/SessionsPanel.tsx
@@ -1,0 +1,399 @@
+/**
+ * The cross-surface Sessions page — every transcript in the project
+ * (Playground, User Testing, Evals, Swarms) in one recency feed, with
+ * server-side sourceType/status filters and relevance-ranked title search.
+ *
+ * Mirrors the Swarms Sessions layout (list + detail split); the data layer is
+ * the unified backend feed (`sessionsFeed:*`, see `@/lib/sessions-feed-api`)
+ * rather than a per-surface query. Unlike the client-side-filter convention in
+ * `project-runs-table.tsx`, the sourceType/status filters here are QUERY ARGS:
+ * the backend built `by_project_sourceType_status`-family indexes for exactly
+ * these, so pushing them down changes which index serves the page instead of
+ * hiding loaded rows.
+ *
+ * Row-level visibility is the backend's job (`canViewSessionInProject`):
+ * other members' private Playground sessions never reach this client, so the
+ * panel renders whatever the page contains without re-deriving policy.
+ */
+import { useEffect, useMemo, useState } from "react";
+import { usePaginatedQuery } from "convex/react";
+import { formatDistanceToNow } from "date-fns";
+import { MessageSquare, Search } from "lucide-react";
+import {
+  ResizableHandle,
+  ResizablePanel,
+  ResizablePanelGroup,
+} from "@/components/ui/resizable";
+import { Button } from "@mcpjam/design-system/button";
+import { Input } from "@mcpjam/design-system/input";
+import { ScrollArea } from "@mcpjam/design-system/scroll-area";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@mcpjam/design-system/select";
+import { ShareUsageThreadDetail } from "@/components/connection/share-usage/ShareUsageThreadDetail";
+import { SessionReadinessBadge } from "@/components/chatboxes/session-readiness";
+import { ErrorBoundary } from "@/components/ui/error-boundary";
+import { cn } from "@/lib/utils";
+import {
+  SESSIONS_FEED_PAGE_SIZE,
+  SESSIONS_FEED_QUERIES,
+  SESSION_SOURCE_TYPE_LABELS,
+  sessionParentChipLabel,
+  type SessionFeedItem,
+  type SessionFeedSourceType,
+} from "@/lib/sessions-feed-api";
+
+const SOURCE_TYPE_PILLS: SessionFeedSourceType[] = [
+  "direct",
+  "chatbox",
+  "eval",
+  "swarm",
+];
+
+type StatusFilter = "all" | "active" | "archived";
+
+/** Keystroke → query settle delay for the search subscription. */
+const SEARCH_DEBOUNCE_MS = 250;
+
+export function SessionsPanel({ projectId }: { projectId: string }) {
+  const [sourceFilter, setSourceFilter] = useState<Set<SessionFeedSourceType>>(
+    new Set()
+  );
+  const [statusFilter, setStatusFilter] = useState<StatusFilter>("all");
+  const [searchInput, setSearchInput] = useState("");
+  const [debouncedQuery, setDebouncedQuery] = useState("");
+  const [selectedThreadId, setSelectedThreadId] = useState<string | null>(null);
+
+  useEffect(() => {
+    const handle = window.setTimeout(
+      () => setDebouncedQuery(searchInput.trim()),
+      SEARCH_DEBOUNCE_MS
+    );
+    return () => window.clearTimeout(handle);
+  }, [searchInput]);
+
+  const searching = debouncedQuery.length > 0;
+
+  // Selecting every pill means the same thing as selecting none; omit the arg
+  // in both cases so the backend serves the plain project index.
+  const sourceTypesArg =
+    sourceFilter.size > 0 && sourceFilter.size < SOURCE_TYPE_PILLS.length
+      ? SOURCE_TYPE_PILLS.filter((s) => sourceFilter.has(s))
+      : undefined;
+  const statusArg = statusFilter === "all" ? undefined : statusFilter;
+
+  const queryName = searching
+    ? SESSIONS_FEED_QUERIES.searchProjectSessions
+    : SESSIONS_FEED_QUERIES.listProjectSessions;
+  const queryArgs = {
+    projectId,
+    ...(sourceTypesArg ? { sourceTypes: sourceTypesArg } : {}),
+    ...(statusArg ? { status: statusArg } : {}),
+    ...(searching ? { q: debouncedQuery } : {}),
+  };
+
+  const { results, status, loadMore } = usePaginatedQuery(
+    queryName as any,
+    queryArgs as any,
+    { initialNumItems: SESSIONS_FEED_PAGE_SIZE }
+  );
+  const rows = results as SessionFeedItem[];
+
+  const isLoadingFirstPage = status === "LoadingFirstPage";
+  const canLoadMore = status === "CanLoadMore";
+  const isFiltering =
+    sourceFilter.size > 0 || statusFilter !== "all" || searching;
+
+  const toggleSource = (value: SessionFeedSourceType) => {
+    setSourceFilter((prev) => {
+      const next = new Set(prev);
+      if (next.has(value)) next.delete(value);
+      else next.add(value);
+      return next;
+    });
+  };
+
+  const selectedRow = useMemo(
+    () => rows.find((r) => r.id === selectedThreadId) ?? null,
+    [rows, selectedThreadId]
+  );
+
+  const emptyListCopy = searching
+    ? "No sessions match this search"
+    : isFiltering
+    ? "No sessions match the current filters"
+    : "No sessions yet";
+
+  return (
+    <div className="flex h-full min-h-0 flex-col" data-testid="sessions-panel">
+      <div className="flex shrink-0 items-center justify-between gap-3 border-b border-border/40 px-8 py-2.5">
+        <div className="flex min-w-0 items-center gap-3">
+          <h1 className="text-xl font-bold tracking-tight">Sessions</h1>
+          <p className="hidden truncate text-xs text-muted-foreground sm:block">
+            Every conversation in this project, across Playground, User Testing,
+            Evals, and Swarms.
+          </p>
+        </div>
+      </div>
+
+      <div className="flex shrink-0 flex-wrap items-center gap-2 border-b border-border/40 px-4 py-2.5">
+        <div className="relative w-[min(100%,16rem)]">
+          <Search className="pointer-events-none absolute left-2.5 top-1/2 h-3.5 w-3.5 -translate-y-1/2 text-muted-foreground" />
+          <Input
+            data-testid="sessions-search"
+            aria-label="Search sessions"
+            placeholder="Search sessions…"
+            className="h-8 pl-8 text-xs"
+            value={searchInput}
+            onChange={(event) => setSearchInput(event.target.value)}
+          />
+        </div>
+        <span className="text-xs font-medium text-muted-foreground">
+          Source
+        </span>
+        {SOURCE_TYPE_PILLS.map((value) => {
+          const active = sourceFilter.has(value);
+          return (
+            <button
+              key={value}
+              type="button"
+              aria-pressed={active}
+              data-testid={`sessions-source-pill-${value}`}
+              onClick={() => toggleSource(value)}
+              className={cn(
+                "rounded-full border px-2.5 py-0.5 text-[11px] font-medium transition-colors",
+                active
+                  ? "border-primary/50 bg-primary/10 text-foreground"
+                  : "border-border/60 bg-transparent text-muted-foreground hover:bg-muted/50"
+              )}
+            >
+              {SESSION_SOURCE_TYPE_LABELS[value]}
+            </button>
+          );
+        })}
+        <Select
+          value={statusFilter}
+          onValueChange={(value) => {
+            if (value === "all" || value === "active" || value === "archived") {
+              setStatusFilter(value);
+            }
+          }}
+        >
+          <SelectTrigger
+            data-testid="sessions-status-filter"
+            className="h-8 w-[min(100%,9rem)] text-xs"
+            aria-label="Filter sessions by status"
+          >
+            <SelectValue placeholder="All statuses" />
+          </SelectTrigger>
+          <SelectContent>
+            <SelectItem value="all">All statuses</SelectItem>
+            <SelectItem value="active">Active</SelectItem>
+            <SelectItem value="archived">Archived</SelectItem>
+          </SelectContent>
+        </Select>
+        <div className="ml-auto flex items-center gap-2">
+          {isLoadingFirstPage ? (
+            <p className="text-xs text-muted-foreground">Loading sessions…</p>
+          ) : (
+            <p className="text-xs text-muted-foreground">
+              {`${rows.length}${canLoadMore ? "+" : ""} session${
+                rows.length === 1 ? "" : "s"
+              }`}
+            </p>
+          )}
+          {canLoadMore ? (
+            <Button
+              type="button"
+              size="sm"
+              variant="ghost"
+              className="rounded-xl"
+              onClick={() => loadMore(SESSIONS_FEED_PAGE_SIZE)}
+            >
+              Load more
+            </Button>
+          ) : null}
+        </div>
+      </div>
+
+      {searching && !isLoadingFirstPage ? (
+        // Search pages are relevance-ordered, not newest-first — say so
+        // rather than letting the reordering read as a bug.
+        <p className="shrink-0 px-4 pt-2 text-[11px] text-muted-foreground">
+          Results ranked by title relevance.
+        </p>
+      ) : null}
+
+      <div className="min-h-0 flex-1 overflow-hidden">
+        <ResizablePanelGroup direction="horizontal" className="h-full">
+          <ResizablePanel defaultSize={32} minSize={22}>
+            <ScrollArea className="h-full">
+              <div className="space-y-1 p-2">
+                {rows.map((row) => (
+                  <SessionFeedRow
+                    key={row.id}
+                    row={row}
+                    selected={row.id === selectedThreadId}
+                    onSelect={() => setSelectedThreadId(row.id)}
+                  />
+                ))}
+              </div>
+            </ScrollArea>
+          </ResizablePanel>
+          <ResizableHandle withHandle />
+          <ResizablePanel defaultSize={68} minSize={40}>
+            <div className="h-full overflow-hidden">
+              {selectedThreadId ? (
+                // The shared detail pane is chatbox/swarm-native; a Playground
+                // or eval transcript that trips one of its branches degrades
+                // to the row's own metadata instead of white-screening.
+                <ErrorBoundary
+                  name="sessions-thread-detail"
+                  fallback={<SessionDetailFallback row={selectedRow} />}
+                >
+                  <ShareUsageThreadDetail threadId={selectedThreadId} />
+                </ErrorBoundary>
+              ) : (
+                <div className="flex h-full items-center justify-center">
+                  <div className="text-center">
+                    <MessageSquare className="mx-auto mb-2 h-8 w-8 text-muted-foreground/50" />
+                    <p className="text-sm text-muted-foreground">
+                      {rows.length === 0 && !isLoadingFirstPage
+                        ? emptyListCopy
+                        : "Select a session to view"}
+                    </p>
+                    {!isFiltering &&
+                    rows.length === 0 &&
+                    !isLoadingFirstPage ? (
+                      <p className="mt-1 text-xs text-muted-foreground/70">
+                        Chat in the Playground, share a scenario, or run an eval
+                        or swarm to generate sessions.
+                      </p>
+                    ) : null}
+                  </div>
+                </div>
+              )}
+            </div>
+          </ResizablePanel>
+        </ResizablePanelGroup>
+      </div>
+    </div>
+  );
+}
+
+function SessionFeedRow({
+  row,
+  selected,
+  onSelect,
+}: {
+  row: SessionFeedItem;
+  selected: boolean;
+  onSelect: () => void;
+}) {
+  const parentChip = sessionParentChipLabel(row.parentRef);
+  const title = row.title?.trim() || row.firstMessagePreview || "Untitled";
+
+  return (
+    <button
+      type="button"
+      data-testid={`session-row-${row.chatSessionId}`}
+      onClick={onSelect}
+      className={cn(
+        "w-full rounded-lg border p-3 text-left transition-colors",
+        selected
+          ? "border-primary/50 bg-primary/5"
+          : "border-transparent hover:border-border/60 hover:bg-muted/40"
+      )}
+    >
+      <div className="flex items-center gap-2">
+        <span className="min-w-0 flex-1 truncate text-sm font-medium text-foreground">
+          {title}
+        </span>
+        {row.readiness ? (
+          <SessionReadinessBadge readiness={row.readiness} />
+        ) : null}
+      </div>
+      <div className="mt-1 flex flex-wrap items-center gap-1.5">
+        <span className="rounded-full border border-border/60 px-1.5 py-0 text-[10px] font-medium uppercase tracking-wide text-muted-foreground">
+          {SESSION_SOURCE_TYPE_LABELS[row.sourceType] ?? row.sourceType}
+        </span>
+        {row.ownedByViewer ? (
+          <span className="rounded-full border border-border/60 px-1.5 py-0 text-[10px] font-medium text-muted-foreground">
+            Yours
+          </span>
+        ) : null}
+        {row.visibility === "project" ? (
+          <span className="rounded-full border border-border/60 px-1.5 py-0 text-[10px] font-medium text-muted-foreground">
+            Shared
+          </span>
+        ) : null}
+        {row.synthetic ? (
+          <span
+            className="h-1.5 w-1.5 rounded-full bg-violet-500/70"
+            title="Synthetic session"
+          />
+        ) : null}
+        {parentChip ? (
+          <span className="min-w-0 truncate text-[11px] text-muted-foreground">
+            {parentChip}
+          </span>
+        ) : null}
+      </div>
+      <p className="mt-1 line-clamp-2 text-xs text-muted-foreground">
+        {row.firstMessagePreview}
+      </p>
+      <div className="mt-1.5 flex items-center justify-between gap-2">
+        <span className="text-[10px] text-muted-foreground/80">
+          {formatDistanceToNow(new Date(row.lastActivityAt), {
+            addSuffix: true,
+          })}
+        </span>
+        <span className="flex items-center gap-2 font-mono text-[10px] text-muted-foreground/80">
+          {row.modelId ? <span>{row.modelId}</span> : null}
+          <span className="flex items-center gap-1">
+            <MessageSquare className="h-3 w-3" />
+            {row.messageCount}
+          </span>
+        </span>
+      </div>
+    </button>
+  );
+}
+
+/**
+ * What the detail pane shows when the shared viewer throws on a sourceType it
+ * doesn't fully model yet — the row's own metadata, which is always safe.
+ */
+function SessionDetailFallback({ row }: { row: SessionFeedItem | null }) {
+  if (!row) {
+    return (
+      <div className="flex h-full items-center justify-center">
+        <p className="text-sm text-muted-foreground">
+          This session can't be displayed.
+        </p>
+      </div>
+    );
+  }
+  return (
+    <div className="flex h-full items-center justify-center p-6">
+      <div className="max-w-md text-center">
+        <MessageSquare className="mx-auto mb-2 h-8 w-8 text-muted-foreground/50" />
+        <p className="text-sm font-medium text-foreground">
+          {row.title ?? row.firstMessagePreview}
+        </p>
+        <p className="mt-1 text-xs text-muted-foreground">
+          {SESSION_SOURCE_TYPE_LABELS[row.sourceType] ?? row.sourceType} session
+          · {row.messageCount} messages
+        </p>
+        <p className="mt-2 text-xs text-muted-foreground/70">
+          The full transcript view for this session type isn't available here
+          yet.
+        </p>
+      </div>
+    </div>
+  );
+}

--- a/mcpjam-inspector/client/src/components/sessions/__tests__/SessionsPanel.test.tsx
+++ b/mcpjam-inspector/client/src/components/sessions/__tests__/SessionsPanel.test.tsx
@@ -1,0 +1,238 @@
+/**
+ * CONTRACT TESTS for the cross-surface Sessions panel.
+ *
+ * The inspector has no Convex codegen, so the (name, args) each subscription
+ * dispatches IS the wire contract — a test that mocked the query away wouldn't
+ * catch a wrong arg name (Convex would throw at runtime). We intercept
+ * `usePaginatedQuery`, record every dispatch, and assert:
+ *
+ *   - the default feed is `sessionsFeed:listProjectSessions` with ONLY
+ *     `{ projectId }` (no sourceTypes/status/q keys — absent, not undefined),
+ *   - a source pill narrows SERVER-side via `sourceTypes`,
+ *   - a typed search switches to `sessionsFeed:searchProjectSessions` with the
+ *     debounced `q`,
+ *   - the row's `id` (not `chatSessionId`) is what the detail pane opens.
+ *
+ * Fixtures are typed against `SessionFeedItem`, so a backend DTO rename forces
+ * a fixture edit here rather than silently rendering blanks.
+ */
+import { fireEvent, render, screen, within, act } from "@testing-library/react";
+import { describe, expect, test, vi, beforeEach } from "vitest";
+import type { SessionFeedItem } from "@/lib/sessions-feed-api";
+
+type PaginatedResult = {
+  results: SessionFeedItem[];
+  status: "LoadingFirstPage" | "CanLoadMore" | "Exhausted";
+  isLoading: boolean;
+  loadMore: (n: number) => void;
+};
+
+const mocks = vi.hoisted(() => ({
+  paginated: {
+    current: {
+      results: [] as unknown[],
+      status: "Exhausted",
+      isLoading: false,
+      loadMore: vi.fn(),
+    },
+  },
+  paginatedCalls: [] as Array<{ name: string; args: unknown }>,
+  detailThreadIds: [] as string[],
+}));
+
+vi.mock("convex/react", () => ({
+  usePaginatedQuery: (name: string, args: unknown) => {
+    mocks.paginatedCalls.push({ name, args });
+    return mocks.paginated.current;
+  },
+  useQuery: () => undefined,
+}));
+
+// The shared detail pane pulls half a dozen session queries of its own; the
+// panel's contract with it is just "opens the row's `id`", so stub it and
+// record the id.
+vi.mock("@/components/connection/share-usage/ShareUsageThreadDetail", () => ({
+  ShareUsageThreadDetail: ({ threadId }: { threadId: string }) => {
+    mocks.detailThreadIds.push(threadId);
+    return <div data-testid="thread-detail-stub">{threadId}</div>;
+  },
+}));
+
+import { SessionsPanel } from "@/components/sessions/SessionsPanel";
+
+function setRows(
+  results: SessionFeedItem[],
+  status: PaginatedResult["status"] = "Exhausted"
+) {
+  mocks.paginated.current = {
+    results,
+    status,
+    isLoading: false,
+    loadMore: vi.fn(),
+  };
+}
+
+let fixtureSeq = 0;
+
+function makeRow(overrides: Partial<SessionFeedItem>): SessionFeedItem {
+  fixtureSeq += 1;
+  return {
+    id: `doc_${fixtureSeq}`,
+    chatSessionId: `cs_${fixtureSeq}`,
+    projectId: "p1",
+    sourceType: "direct",
+    status: "active",
+    title: null,
+    firstMessagePreview: "hello there",
+    visibility: null,
+    ownedByViewer: false,
+    startedAt: 1_000,
+    lastActivityAt: Date.now(),
+    messageCount: 3,
+    parentRef: null,
+    ...overrides,
+  };
+}
+
+function lastCall() {
+  return mocks.paginatedCalls[mocks.paginatedCalls.length - 1];
+}
+
+beforeEach(() => {
+  mocks.paginatedCalls.length = 0;
+  mocks.detailThreadIds.length = 0;
+  setRows([]);
+});
+
+describe("SessionsPanel — query contract", () => {
+  test("dispatches the unified feed with ONLY { projectId } by default", () => {
+    render(<SessionsPanel projectId="p1" />);
+
+    const call = lastCall();
+    expect(call.name).toBe("sessionsFeed:listProjectSessions");
+    // Absent keys, not `undefined` values: the args object must not carry
+    // sourceTypes/status/q at all when no filter is active.
+    expect(call.args).toEqual({ projectId: "p1" });
+  });
+
+  test("a source pill narrows the query server-side via sourceTypes", () => {
+    render(<SessionsPanel projectId="p1" />);
+
+    fireEvent.click(screen.getByTestId("sessions-source-pill-swarm"));
+    expect(lastCall()).toEqual({
+      name: "sessionsFeed:listProjectSessions",
+      args: { projectId: "p1", sourceTypes: ["swarm"] },
+    });
+
+    // Selecting every pill means "no filter" — the arg must drop back out so
+    // the backend serves the plain project index.
+    for (const pill of ["direct", "chatbox", "eval"]) {
+      fireEvent.click(screen.getByTestId(`sessions-source-pill-${pill}`));
+    }
+    expect(lastCall().args).toEqual({ projectId: "p1" });
+  });
+
+  test("typing a search switches to the relevance-ranked search query after the debounce", () => {
+    vi.useFakeTimers();
+    render(<SessionsPanel projectId="p1" />);
+
+    fireEvent.change(screen.getByTestId("sessions-search"), {
+      target: { value: "checkout bug" },
+    });
+    // Before the debounce settles the subscription must NOT have switched —
+    // every keystroke re-subscribing would thrash the reactive query.
+    expect(lastCall().name).toBe("sessionsFeed:listProjectSessions");
+
+    act(() => {
+      vi.advanceTimersByTime(300);
+    });
+    expect(lastCall()).toEqual({
+      name: "sessionsFeed:searchProjectSessions",
+      args: { projectId: "p1", q: "checkout bug" },
+    });
+
+    // Clearing the box returns to the recency feed.
+    fireEvent.change(screen.getByTestId("sessions-search"), {
+      target: { value: "" },
+    });
+    act(() => {
+      vi.advanceTimersByTime(300);
+    });
+    expect(lastCall().name).toBe("sessionsFeed:listProjectSessions");
+  });
+});
+
+describe("SessionsPanel — rows and detail", () => {
+  test("renders source badges, ownership, parent chips, and Quick Run", () => {
+    setRows([
+      makeRow({
+        chatSessionId: "cs_direct",
+        sourceType: "direct",
+        title: "My playground chat",
+        ownedByViewer: true,
+        visibility: "private",
+      }),
+      makeRow({
+        chatSessionId: "cs_swarm",
+        sourceType: "swarm",
+        synthetic: true,
+        parentRef: {
+          kind: "journeyRun",
+          journeyRunId: "jr1",
+          journeyRefId: "j1",
+          label: "Checkout journey",
+        },
+      }),
+      makeRow({
+        chatSessionId: "cs_quick",
+        sourceType: "eval",
+        // Quick Run: an iteration with no suite run, by construction — must
+        // render as "Quick Run", not as an unresolved parent.
+        parentRef: {
+          kind: "evalRun",
+          iterationId: "it1",
+          suiteRunId: null,
+          suiteId: null,
+          label: null,
+        },
+      }),
+    ]);
+    render(<SessionsPanel projectId="p1" />);
+
+    const direct = within(screen.getByTestId("session-row-cs_direct"));
+    expect(direct.getByText("My playground chat")).toBeInTheDocument();
+    expect(direct.getByText("Playground")).toBeInTheDocument();
+    expect(direct.getByText("Yours")).toBeInTheDocument();
+
+    const swarm = within(screen.getByTestId("session-row-cs_swarm"));
+    expect(swarm.getByText("Swarm")).toBeInTheDocument();
+    expect(swarm.getByText("Checkout journey")).toBeInTheDocument();
+
+    const quick = within(screen.getByTestId("session-row-cs_quick"));
+    expect(quick.getByText("Quick Run")).toBeInTheDocument();
+  });
+
+  test("clicking a row opens the detail pane with the row's `id`, not its chatSessionId", () => {
+    setRows([
+      makeRow({ id: "doc_abc", chatSessionId: "cs_abc", title: "Pick me" }),
+    ]);
+    render(<SessionsPanel projectId="p1" />);
+
+    fireEvent.click(screen.getByTestId("session-row-cs_abc"));
+    expect(screen.getByTestId("thread-detail-stub")).toHaveTextContent(
+      "doc_abc"
+    );
+    expect(mocks.detailThreadIds).toContain("doc_abc");
+    expect(mocks.detailThreadIds).not.toContain("cs_abc");
+  });
+
+  test("an empty unfiltered feed shows the getting-started empty state", () => {
+    setRows([]);
+    render(<SessionsPanel projectId="p1" />);
+
+    expect(screen.getByText("No sessions yet")).toBeInTheDocument();
+    expect(
+      screen.getByText(/Chat in the Playground, share a scenario/)
+    ).toBeInTheDocument();
+  });
+});

--- a/mcpjam-inspector/client/src/hooks/useUnifiedSessionsEnabled.ts
+++ b/mcpjam-inspector/client/src/hooks/useUnifiedSessionsEnabled.ts
@@ -1,0 +1,27 @@
+import { useFeatureFlagEnabled } from "posthog-js/react";
+
+export const UNIFIED_SESSIONS_FEATURE_FLAG = "unified-sessions-enabled";
+
+/**
+ * The cross-surface Sessions page (`/sessions`) is gated behind one PostHog
+ * flag while the backing backend queries (`sessionsFeed:*`) roll out — prod
+ * Convex functions only land on a release promotion, so the page must ship
+ * dark and be flipped on per-cohort once the backend is live.
+ *
+ * The sidebar filters the nav item on this flag, but a nav filter is not a
+ * gate: `/sessions` is a plain route, so the route guard resolves the same
+ * flag (mirrors `useSandboxesEnabled` / `useProjectEnvironmentsEnabled`).
+ *
+ * `useFeatureFlagEnabled` returns `undefined` while flags load — treated as
+ * off (fail-closed) here. Route guards that need to tell "loading" from "off"
+ * (so a flagged-in user who cold-loads the URL isn't bounced mid-hydrate)
+ * should use {@link useUnifiedSessionsEnabledState}.
+ */
+export function useUnifiedSessionsEnabled(): boolean {
+  return useFeatureFlagEnabled(UNIFIED_SESSIONS_FEATURE_FLAG) === true;
+}
+
+/** Tri-state variant: `undefined` while PostHog flags are still loading. */
+export function useUnifiedSessionsEnabledState(): boolean | undefined {
+  return useFeatureFlagEnabled(UNIFIED_SESSIONS_FEATURE_FLAG);
+}

--- a/mcpjam-inspector/client/src/lib/app-navigation.ts
+++ b/mcpjam-inspector/client/src/lib/app-navigation.ts
@@ -87,6 +87,7 @@ export const routePaths = {
   userTesting: "/user-testing",
   swarms: "/swarms",
   environments: "/environments",
+  sessions: "/sessions",
   playground: "/playground",
   support: "/support",
   settings: "/settings",
@@ -118,7 +119,6 @@ export function buildHostComparePath(
   const search = new URLSearchParams({ hosts: param.join(",") });
   return `${routePaths.hostCompare}?${search.toString()}`;
 }
-
 
 /** The create route. A static segment, so it outranks `:scenarioId`. */
 export const userTestingCreatePath = `${routePaths.userTesting}/new`;
@@ -215,7 +215,7 @@ export function buildSwarmPath(
     tab?: SwarmDetailTab;
     session?: string;
     sel?: string;
-  } = {},
+  } = {}
 ): string {
   const base = `${routePaths.swarms}/${encodeURIComponent(swarmId)}`;
   const search = new URLSearchParams();
@@ -587,7 +587,8 @@ export function useCurrentSearchParam(name: string): string | null {
   // and leave the component rendering the previous tab.
   useLayoutEffect(() => {
     if (locationContext || typeof window === "undefined") return;
-    const syncFallbackSearch = () => setFallbackSearch(getWindowFallbackSearch());
+    const syncFallbackSearch = () =>
+      setFallbackSearch(getWindowFallbackSearch());
     window.addEventListener("popstate", syncFallbackSearch);
     return () => {
       window.removeEventListener("popstate", syncFallbackSearch);

--- a/mcpjam-inspector/client/src/lib/app-routes.ts
+++ b/mcpjam-inspector/client/src/lib/app-routes.ts
@@ -111,6 +111,7 @@ export const APP_ROUTES: readonly AppRouteEntry[] = [
     kind: "screen",
     surfaceId: "project-environments",
   },
+  { path: "sessions", kind: "screen", surfaceId: "sessions" },
   { path: "playground", kind: "screen", surfaceId: "playground" },
   { path: "support", kind: "screen", surfaceId: "support" },
   { path: "settings", kind: "screen", surfaceId: "settings" },

--- a/mcpjam-inspector/client/src/lib/sessions-feed-api.ts
+++ b/mcpjam-inspector/client/src/lib/sessions-feed-api.ts
@@ -1,0 +1,138 @@
+/**
+ * Unified sessions layer client contract — the ONE place the Sessions surface
+ * reaches the backend.
+ *
+ * Centralizes the project-scoped Convex query NAMES the UI subscribes to
+ * (Convex codegen doesn't run in the inspector, so these are string-keyed
+ * `as any` reads — keeping the names here stops them scattering through the
+ * component) and the response DTOs those reads return. Mirrors the backend
+ * `convex/sessionsFeed.ts` by hand (two-repo layout) — the field list here IS
+ * the contract, and the panel's tests type their fixtures against it so a
+ * backend rename forces an edit rather than silently rendering blanks.
+ */
+// Type-only imports — one declaration of each backend contract, not two.
+import type { SessionCriteria, SessionGoalScore } from "@/lib/swarm-api";
+import type { SessionReadiness } from "@/components/chatboxes/session-readiness";
+
+// ── Convex query names (string-keyed reads) ─────────────────────────────────
+export const SESSIONS_FEED_QUERIES = {
+  /**
+   * The project's cross-surface session feed, newest first. Paginated;
+   * `sourceTypes` / `status` are SERVER-side filters (they select the index),
+   * unlike the client-side-over-loaded-pages convention elsewhere — the
+   * backend built indexes for exactly these.
+   */
+  listProjectSessions: "sessionsFeed:listProjectSessions",
+  /**
+   * Relevance-ordered title search over the same scope + authorization.
+   * A separate query, not a `q` arg on the feed: search results cannot be
+   * re-sorted to recency, so mixing them would change the feed's ordering
+   * contract mid-subscription.
+   */
+  searchProjectSessions: "sessionsFeed:searchProjectSessions",
+} as const;
+
+// ── DTOs ────────────────────────────────────────────────────────────────────
+
+export type SessionFeedSourceType = "direct" | "chatbox" | "eval" | "swarm";
+
+/**
+ * A session's parent run — a DISCRIMINATED UNION on `kind`. The backend may
+ * add kinds; treat an unknown `kind` as "no chip", never as an error.
+ * `label: null` means the parent row is gone (deleted suite / journey /
+ * chatbox) — the ids remain so the reference can still be named.
+ */
+export type SessionFeedParentRef =
+  | {
+      kind: "evalRun";
+      iterationId: string;
+      /** `null` = Quick Run (no suite run exists, by construction). */
+      suiteRunId: string | null;
+      suiteId: string | null;
+      label: string | null;
+    }
+  | {
+      kind: "journeyRun";
+      journeyRunId: string;
+      journeyRefId: string | null;
+      label: string | null;
+    }
+  | {
+      kind: "chatbox";
+      chatboxId: string;
+      label: string | null;
+    };
+
+/**
+ * One feed row — the backend `SessionFeedItemDto`. The row identifier is `id`
+ * (`chatSessions._id` under the hood): it is what `ShareUsageThreadDetail`
+ * opens. Fields the backend may not yet write are optional so an older
+ * deployment still renders.
+ *
+ * Counter absence is meaningful: `cumulativeInputTokens === undefined` means
+ * "no turn ever reported usage", which is a different claim from 0 — never
+ * default it.
+ */
+export interface SessionFeedItem {
+  /** `chatSessions._id` — the detail-pane / deep-link id. */
+  id: string;
+  chatSessionId: string;
+  projectId: string | null;
+  sourceType: SessionFeedSourceType;
+  origin?: string | null;
+  status: "active" | "archived";
+  synthetic?: boolean;
+  lockReason?: string | null;
+  /** Resolved title chain (customTitle → displayLabel → persona/visitor → preview). */
+  title: string | null;
+  firstMessagePreview: string;
+  /** Direct rows only: `"private" | "project"`. `null` for every other bucket. */
+  visibility: "private" | "project" | null;
+  ownedByViewer: boolean;
+  startedAt: number;
+  lastActivityAt: number;
+  modelId?: string | null;
+  messageCount: number;
+  cumulativeUserMessageCount?: number;
+  cumulativeToolCallCount?: number;
+  cumulativeInputTokens?: number;
+  cumulativeOutputTokens?: number;
+  readiness?: SessionReadiness | null;
+  goalScore?: SessionGoalScore;
+  criteria?: SessionCriteria;
+  parentRef: SessionFeedParentRef | null;
+}
+
+/** Product name per persistence bucket, as rendered on the row badge. */
+export const SESSION_SOURCE_TYPE_LABELS: Record<SessionFeedSourceType, string> =
+  {
+    direct: "Playground",
+    chatbox: "User Testing",
+    eval: "Eval",
+    swarm: "Swarm",
+  };
+
+/**
+ * The parent chip for a row. Falls back to naming the run kind when the
+ * parent's own label is gone, and calls out Quick Runs (which genuinely have
+ * no suite run) instead of leaving them unexplained.
+ */
+export function sessionParentChipLabel(
+  ref: SessionFeedParentRef | null
+): string | null {
+  if (!ref) return null;
+  if (ref.label) return ref.label;
+  switch (ref.kind) {
+    case "evalRun":
+      return ref.suiteRunId === null ? "Quick Run" : "Eval run";
+    case "journeyRun":
+      return "Swarm run";
+    case "chatbox":
+      return "Scenario";
+    default:
+      // Future parent kinds render nothing rather than a wrong guess.
+      return null;
+  }
+}
+
+export const SESSIONS_FEED_PAGE_SIZE = 25;

--- a/mcpjam-inspector/client/src/router.tsx
+++ b/mcpjam-inspector/client/src/router.tsx
@@ -28,6 +28,7 @@ import App, {
   ScoreRunnerRoute,
   ServersRedirectRoute,
   ServersRoute,
+  SessionsRoute,
   SettingsRoute,
   SkillsRoute,
   SupportRoute,
@@ -144,6 +145,10 @@ const ROUTE_ELEMENTS: Record<
   // enforces the `project-environments-enabled` flag itself (redirects when
   // off), so registration here does not expose the dark feature.
   environments: { element: <EnvironmentsRoute /> },
+  // `/sessions` — cross-surface project session feed. The route component
+  // enforces the `unified-sessions-enabled` flag itself (redirects when off),
+  // so registration here does not expose the dark feature.
+  sessions: { element: <SessionsRoute /> },
   playground: { element: <PlaygroundRoute /> },
   support: { element: <SupportRoute /> },
   settings: { element: <SettingsRoute /> },

--- a/mcpjam-inspector/shared/app-surfaces.ts
+++ b/mcpjam-inspector/shared/app-surfaces.ts
@@ -301,6 +301,32 @@ export const APP_SURFACES = [
     showInAtlas: false,
   },
   {
+    id: "sessions",
+    canonicalPath: "/sessions",
+    routePatterns: ["sessions"],
+    navSegments: ["sessions"],
+    title: "Sessions",
+    purpose:
+      "Browse every conversation in the project in one feed — Playground chats, User Testing sessions, eval iterations, and swarm runs — filter by source, and search by title.",
+    userActivities: [
+      "Browse the project's sessions across all surfaces, newest first",
+      "Filter sessions by source (Playground, User Testing, Eval, Swarm) or status",
+      "Search sessions by title",
+      "Open a session to review its transcript",
+    ],
+    agentTools: {
+      kind: "none",
+      reason:
+        "Read-only browse surface behind a rollout flag; no agent automation until the unified feed is generally available.",
+    },
+    // The Atlas is intentionally STATIC — it cannot read
+    // `unified-sessions-enabled`, so advertising `/sessions` would send the
+    // agent to a surface that redirects on every flag-off project. Flip to
+    // `true` when the flag is retired at GA. (Same rationale as
+    // project-environments.)
+    showInAtlas: false,
+  },
+  {
     id: "evals",
     canonicalPath: "/evals",
     routePatterns: [


### PR DESCRIPTION
## What

Adds `/sessions` — every transcript in the project (Playground, User Testing, Evals, Swarms) in one recency feed, consuming the unified backend sessions layer that shipped in [mcpjam-backend #962](https://github.com/MCPJam/mcpjam-backend/pull/962).

- **`lib/sessions-feed-api.ts`** — the contract module: string-keyed query names (`sessionsFeed:listProjectSessions` / `searchProjectSessions`) plus hand-written `SessionFeedItem` / `SessionFeedParentRef` mirrors, per the codegen-less convention. Test fixtures type against them so a backend rename forces an edit here.
- **`components/sessions/SessionsPanel.tsx`** — list + detail split mirroring the Swarms Sessions layout. Source-type pills and the status select are **server-side query args** (the backend built `by_project_sourceType_status`-family indexes for them — deliberate departure from the client-side-filter convention, noted in the component doc). Search debounces (250ms) into the relevance-ranked search query with honest "ranked by relevance" copy. Rows show source badge, Yours/Shared chips, parent-run label (incl. "Quick Run" for suite-less eval iterations), readiness badge, preview, and metadata. The shared `ShareUsageThreadDetail` opens the row's `id`; source types it doesn't fully model degrade to a metadata card via ErrorBoundary.
- **Wiring** — route table + router + surface manifest + sidebar item + `SessionsRoute` guard, all passing the coverage suites. `agentTools: none` and `showInAtlas: false` while flag-gated (same rationale as project-environments).

## Ships dark

Gated on a new PostHog flag **`unified-sessions-enabled`** (needs creating in PostHog before rollout): the route redirects when the flag is off, renders nothing while it hydrates, and an ErrorBoundary degrades to "Sessions isn't available yet" copy on deployments where the `sessionsFeed:*` queries haven't landed (prod Convex functions arrive with release promotion). Safe to merge ahead of the backend release.

## Tests

- 6 contract tests asserting the exact (name, args) each subscription dispatches: default feed args, pill narrowing (and all-pills = no filter), debounced search switch + clear, detail opens `id` not `chatSessionId`, Quick Run chip, empty state.
- Full client project: 830 files / 8,753 tests green; typecheck + prettier clean.

## Follow-ups (not in this PR)

- `?session=` deep link on `/sessions` (parity with Swarms/User Testing).
- Richer detail rendering for `direct`/`eval` source types in the shared viewer.
- Content search UI once the backend's transcript-search phase lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Read-only UI behind a feature flag with graceful degradation when the backend isn’t live; no auth or data-mutation paths in this diff.
> 
> **Overview**
> Introduces a **unified Sessions** surface at `/sessions` so reviewers can browse every project conversation (Playground, User Testing, Evals, Swarms) in one recency-ordered feed, backed by the new `sessionsFeed:*` Convex layer.
> 
> **`SessionsPanel`** uses a resizable list + detail layout: source-type pills and status are **server-side query args** (not client-side filtering), search debounces into a separate relevance-ranked query, and row selection opens **`ShareUsageThreadDetail`** via the feed row’s `id` (with an ErrorBoundary fallback for source types the shared viewer doesn’t fully support).
> 
> **Rollout wiring** mirrors other dark-shipped features: PostHog flag `unified-sessions-enabled` on the sidebar and in **`SessionsRoute`** (redirect when off, blank while hydrating, empty state without a project, ErrorBoundary when backend queries aren’t deployed). **`lib/sessions-feed-api.ts`** centralizes query names and DTOs; route tables, router, and **`app-surfaces`** register the screen (Atlas hidden until GA). Contract tests lock the paginated query name/args and detail-pane id behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 73406ac66ea5639e9fd36766be4d08b0516e5959. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a cross-surface Sessions page at /sessions that lists every project transcript (Playground, User Testing, Evals, Swarms) in one recency feed. Previously, sessions were surface-specific; now users get a single, searchable feed with server-side source/status filters and a relevance-ranked title search.

- Implements `SessionsPanel` (list + detail). Source pills and status select are server-side query args; search debounces (250ms) into a relevance-ranked query. Rows show source, Yours/Shared, Quick Run chip, readiness, preview, and metadata. Detail opens the row’s id and falls back to a metadata card when needed.
- Introduces `lib/sessions-feed-api.ts` with the string-keyed contract: `sessionsFeed:listProjectSessions` and `sessionsFeed:searchProjectSessions`, plus `SessionFeedItem` and `SessionFeedParentRef`. Tests assert exact query name/args, debounce behavior, Quick Run chip, and that detail opens `id`.
- Wires route, router entry, surface manifest, and sidebar item. The route guards on a new PostHog flag and degrades with an ErrorBoundary on deployments where the feed queries aren’t live. Hidden from Atlas and agents while dark.

- Rollout
  - Create the PostHog feature flag unified-sessions-enabled.
  - Enable per cohort only after the backend `sessionsFeed:*` queries are deployed. Safe to merge before backend release.

<sup>Written for commit 73406ac66ea5639e9fd36766be4d08b0516e5959. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/MCPJam/inspector/pull/3999?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

