### PR TITLE
fix(user-testing): make the surface's claims match the backend's actual gates

### DIFF
--- a/cli/src/commands/user-testing.ts
+++ b/cli/src/commands/user-testing.ts
@@ -18,9 +18,11 @@
  *     irreversible: everyone holding the old URL loses access.
  *
  * AUTHORIZATION differs from the rest of the CLI. These gate on the WORKSPACE
- * role rather than the project role, the exposure controls need project ADMIN,
- * and a legacy workspace with no organization denies `sk_` keys outright. The
- * server's message says which; this CLI does not pre-guess.
+ * role rather than the project role, and workspace membership is enough for
+ * most of them — mode changes, member edits and link rotation included. Only
+ * guest execution and rebinding need project ADMIN, and a legacy workspace
+ * with no organization denies `sk_` keys outright. The server's message says
+ * which; this CLI does not pre-guess.
  */
 import type { Command } from "commander";
 import {

--- a/mcpjam-inspector/server/routes/v1/__tests__/capabilities.test.ts
+++ b/mcpjam-inspector/server/routes/v1/__tests__/capabilities.test.ts
@@ -96,6 +96,18 @@ describe("capability derivation", () => {
     expect(body.can.publishUserTestingScenario).toBe(false);
   });
 
+  it("gives a member the exposure controls but not guest execution", async () => {
+    // The chatbox mutations behind mode changes, member edits and link
+    // rotation gate at workspace MEMBERSHIP upstream — reporting them as
+    // admin-only denied capabilities the caller actually held, this
+    // endpoint's own failure mode. Guest execution is the one exposure
+    // control that genuinely needs admin, and it is a separate key.
+    queryMock.mockResolvedValue(row());
+    const body = (await (await get()).json()) as Body;
+    expect(body.can.changeUserTestingExposure).toBe(true);
+    expect(body.can.manageUserTestingGuestExecution).toBe(false);
+  });
+
   it("does not let a project GRANT stand in for org membership", async () => {
     // `requireProjectRole` ranks the ORG role and ignores the grant, so a
     // guest holding one cannot author. Claiming otherwise would be this
@@ -117,6 +129,11 @@ describe("capability derivation", () => {
     );
     const body = (await (await get()).json()) as Body;
     expect(body.can.publishUserTestingScenario).toBe(true);
+    // Guest execution follows the same `canManageProjectMembers` bar as
+    // publishing, so the grant satisfies it too…
+    expect(body.can.manageUserTestingGuestExecution).toBe(true);
+    // …while the membership-level keys keep ranking the org role alone.
+    expect(body.can.changeUserTestingExposure).toBe(false);
     expect(body.can.writeSwarms).toBe(false);
   });
 
@@ -128,6 +145,7 @@ describe("capability derivation", () => {
     expect(body.can.publishUserTestingScenario).toBe(true);
     expect(body.can.unpublishUserTestingScenario).toBe(true);
     expect(body.can.changeUserTestingExposure).toBe(true);
+    expect(body.can.manageUserTestingGuestExecution).toBe(true);
     expect(body.can.requestInsights).toBe(true);
   });
 
@@ -156,6 +174,12 @@ describe("capability derivation", () => {
     const body = (await (await get()).json()) as Body;
     expect(body.can.cancelJourneyRun).toBe(true);
     expect(body.can.unpublishUserTestingScenario).toBe(true);
+    // The scenario controls stay true too: none of the chatbox mutations
+    // behind them (mode, members, rotate, guest execution) check the beta
+    // flag — only publish/rebind do. Claiming otherwise would deny writes
+    // the backend accepts.
+    expect(body.can.changeUserTestingExposure).toBe(true);
+    expect(body.can.manageUserTestingGuestExecution).toBe(true);
     // …while the exposure-creating half is refused.
     expect(body.can.writeSwarms).toBe(false);
     expect(body.can.publishUserTestingScenario).toBe(false);

--- a/mcpjam-inspector/server/routes/v1/__tests__/user-testing.test.ts
+++ b/mcpjam-inspector/server/routes/v1/__tests__/user-testing.test.ts
@@ -79,13 +79,16 @@ function call(
   });
 }
 
+// Mirrors the `getChatbox` SETTINGS ENVELOPE, which deliberately carries no
+// `accessVersion` — that field only travels on the publish/rebind projection.
+// A stub that invented one here would let the routes appear to serve a value
+// the real upstream never sends.
 const scenarioRow = (projectId = PROJECT) => ({
   _id: SCENARIO,
   projectId,
   workspaceId: "ws_1",
   name: "Checkout",
   mode: "invited_only",
-  accessVersion: 3,
 });
 
 /**
@@ -335,9 +338,16 @@ describe("scenario update", () => {
 
   it("routes a mode change to setChatboxMode and nothing else", async () => {
     mutationMock.mockResolvedValue(null);
-    await call(userTesting, "PATCH", BASE, { mode: "invited_only" });
+    const res = await call(userTesting, "PATCH", BASE, {
+      mode: "invited_only",
+    });
     expect(mutationMock).toHaveBeenCalledTimes(1);
     expect(mutationMock.mock.calls[0]?.[0]).toBe("chatboxes:setChatboxMode");
+    // No `accessVersion` in the response. The mutation bumps it upstream, but
+    // the settings envelope the route re-reads does not carry the value — an
+    // always-null field would document a revocation signal never delivered.
+    const body = (await res.json()) as Record<string, unknown>;
+    expect(body).not.toHaveProperty("accessVersion");
   });
 
   it("routes a rename to updateChatbox and nothing else", async () => {
@@ -631,16 +641,57 @@ describe("exposure controls", () => {
     expect(mutationMock).not.toHaveBeenCalled();
   });
 
-  it("surfaces the admin gate as 403, not a 404", async () => {
-    // The caller is already a workspace member (Convex confirmed it to serve
-    // the preflight), so "requires admin" is actionable and reveals nothing.
-    mutationMock.mockRejectedValue(
-      Object.assign(new Error("Requires admin"), {
-        data: { code: "FORBIDDEN", message: "Requires admin" },
-      })
-    );
+  it("rotates the link without minting an accessVersion it never had", async () => {
+    // The mutation returns the settings envelope: a `link` object and NO
+    // `accessVersion` (only publish/rebind return one). The old response
+    // reported `accessVersion: null` forever while documenting it as the
+    // revocation signal.
+    mutationMock.mockResolvedValue({
+      link: { token: "tok", path: "/s/tok", url: "https://app.test/s/tok" },
+      members: [],
+    });
     const res = await call(userTesting, "POST", `${BASE}/rotate-link`);
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as Record<string, unknown>;
+    expect(body.rotated).toBe(true);
+    expect(body).not.toHaveProperty("accessVersion");
+  });
+
+  it("404s rotate's REAL insufficient-role refusal — it is not an admin gate", async () => {
+    // `rotateChatboxLink` gates at `requireWorkspaceRole(..., 'guest')` and
+    // throws PLAIN errors ("Not a member of this workspace"), never a
+    // ConvexError with a FORBIDDEN code — a previous version of this test
+    // mocked that fictional shape and asserted a 403 the mutation can never
+    // produce. The real refusal means the caller cannot see the workspace at
+    // all, so the translator's prose fallback collapses it to the same
+    // neutral 404 as a missing scenario. (In production Convex redacts the
+    // plain error to "Server Error" before it reaches us; the preflight
+    // normally answers first with its own 404 either way.)
+    mutationMock.mockRejectedValue(new Error("Not a member of this workspace"));
+    const res = await call(userTesting, "POST", `${BASE}/rotate-link`);
+    expect(res.status).toBe(404);
+  });
+
+  it("surfaces guest-execution's REAL admin refusal as 403, not a 404", async () => {
+    // `setChatboxGuestExecution` is the exposure control that genuinely
+    // requires project admin, and its refusal is a plain error naming the
+    // requirement. The caller is already a workspace member (Convex confirmed
+    // it to serve the preflight), so "only project admins" is actionable and
+    // reveals nothing new.
+    mutationMock.mockRejectedValue(
+      new Error("Only project admins can configure guest execution")
+    );
+    const res = await call(userTesting, "PUT", `${BASE}/guest-execution`, {
+      enabled: true,
+      computerEnabled: false,
+      sharedSkillsEnabled: false,
+      dailyCreditCap: 100,
+      dailyComputerStartCap: 0,
+      maxConcurrentComputers: 0,
+    });
     expect(res.status).toBe(403);
+    const body = (await res.json()) as { message: string };
+    expect(body.message).toMatch(/project admins/i);
   });
 });
 

--- a/mcpjam-inspector/server/routes/v1/capabilities.ts
+++ b/mcpjam-inspector/server/routes/v1/capabilities.ts
@@ -152,6 +152,15 @@ function deriveCapabilities(row: CapabilitiesRow) {
      * can do all of them — and none of them check the beta flag. Guest
      * execution is NOT here: it is the one exposure control that genuinely
      * needs admin, split out below.
+     *
+     * KNOWN IMPRECISION, deliberate: workspace access resolves per WORKSPACE
+     * (`resolveWorkspaceAccess`), and a non-admin org member is refused on a
+     * PRIVATE workspace without an explicit grant. This endpoint answers per
+     * project and cannot see per-scenario workspace grants, so a member may
+     * read `true` here and still 404 on one specific private scenario. That
+     * is the descriptive-not-authoritative contract this file's header
+     * states — the alternative, reporting admin-only, denied the capability
+     * to every member for every scenario, which is the larger lie.
      */
     changeUserTestingExposure: isMember,
     /**

--- a/mcpjam-inspector/server/routes/v1/capabilities.ts
+++ b/mcpjam-inspector/server/routes/v1/capabilities.ts
@@ -78,6 +78,17 @@ const ROLE_RANK: Record<string, number> = {
  * `unpublishScenario` stay true for an org that has just lost the flag. An
  * agent that inferred "no flag ⇒ nothing works" would refuse to stop a run
  * precisely when stopping it matters most.
+ *
+ * User testing splits FINER than "admin publishes, members read". The chatbox
+ * mutations behind the day-to-day controls — `setChatboxMode`,
+ * `updateChatbox`, `rotateChatboxLink`, `upsertChatboxMember`,
+ * `removeChatboxMember` — gate at `requireWorkspaceRole(..., 'guest')`
+ * upstream: an ordinary member CAN do all of them, and none sit behind the
+ * beta flag. Only `publishEnvironmentChatbox`, `rebindEnvironmentChatbox` and
+ * `setChatboxGuestExecution` require project admin, and of those only
+ * publish/rebind are flag-gated. Reporting the member-level controls as
+ * admin-gated would DENY capabilities callers actually hold — this endpoint's
+ * own failure mode, delivered by the endpoint itself.
  */
 /** The gate state, or the permissive default when the projection lacks it. */
 function sandboxesOf(row: CapabilitiesRow) {
@@ -134,8 +145,23 @@ function deriveCapabilities(row: CapabilitiesRow) {
     publishUserTestingScenario: isAdmin && !gated,
     /** Taking a live scenario down. Ungated by design. */
     unpublishUserTestingScenario: isAdmin,
-    /** Widening exposure: mode changes, guest execution, member invites. */
-    changeUserTestingExposure: isAdmin && !gated,
+    /**
+     * Mode changes, member invites/removals, link rotation, renames. These
+     * gate at WORKSPACE membership upstream (`requireWorkspaceRole(...,
+     * 'guest')` on every one of the chatbox mutations) — an ordinary member
+     * can do all of them — and none of them check the beta flag. Guest
+     * execution is NOT here: it is the one exposure control that genuinely
+     * needs admin, split out below.
+     */
+    changeUserTestingExposure: isMember,
+    /**
+     * The guest-execution spend caps (`setChatboxGuestExecution`), which are
+     * genuinely project-ADMIN upstream (`canManageProjectMembers`, same bar
+     * as publishing). Kept separate from `changeUserTestingExposure` so the
+     * membership-level controls above are not misreported as admin-only.
+     * Ungated: the beta flag covers publish/rebind, not this.
+     */
+    manageUserTestingGuestExecution: isAdmin,
     /** Requesting an LLM insight pass over a wave or window. */
     requestInsights: isMember,
   };

--- a/mcpjam-inspector/server/routes/v1/user-testing.ts
+++ b/mcpjam-inspector/server/routes/v1/user-testing.ts
@@ -23,9 +23,12 @@
  *     write to one at all, and no amount of role granting changes that. The
  *     backend's 403 copy is forwarded verbatim rather than reworded, because
  *     it is the only place that knows why.
- *   - Publishing, guest execution, link rotation and rebinding need project
- *     ADMIN. An API key acting as an ordinary member gets a 403, and that is
- *     the intended answer.
+ *   - Only PUBLISHING, GUEST EXECUTION and REBINDING need project ADMIN
+ *     upstream (`canManageProjectMembers`). Everything else here — mode
+ *     changes, renames, member edits, link rotation — gates at
+ *     `requireWorkspaceRole(..., 'guest')`: an ordinary member can do all of
+ *     it. For the admin trio, an API key acting as an ordinary member gets a
+ *     403, and that is the intended answer.
  *
  * CROSS-PROJECT SCOPING is enforced HERE. Every `chatboxes:*` mutation takes a
  * `chatboxId` alone and authorizes against whatever workspace the row turns out
@@ -83,6 +86,14 @@ function translateWriteError(error: unknown): WebRouteError {
 
 // ── Convex row shapes (hand-mirrored) ───────────────────────────────────────
 
+/**
+ * The `chatboxes:getChatbox` settings envelope, hand-mirrored down to the
+ * fields this module reads. NO `accessVersion`: the envelope
+ * (`assembleChatboxSettingsResponse` upstream) does not carry it — the value
+ * lives on the `chatboxes` row and only the publish/rebind projection
+ * (`projectEnvironmentChatbox`) returns it. Reintroducing it on the update or
+ * rotate responses needs the backend envelope to carry it first.
+ */
 type ChatboxRow = {
   _id: string;
   projectId?: string;
@@ -90,7 +101,6 @@ type ChatboxRow = {
   name?: string;
   description?: string;
   mode?: "project_members" | "invited_only" | "anyone_with_link";
-  accessVersion?: number;
   environmentId?: string;
 };
 
@@ -316,13 +326,17 @@ userTesting.patch(BASE, async (c) => {
   }
 
   const updated = await requireScenarioInProject(client, projectId, scenarioId);
+  // No `accessVersion` here, deliberately: a mode change does bump it
+  // upstream, but the settings envelope this re-read returns does not carry
+  // the new value (see `ChatboxRow`), and a field that is null on every
+  // response is worse than no field. The publish response
+  // (`scenarios.ts`) carries the real one.
   return v1Resource(c, {
     id: scenarioId,
     projectId,
     name: updated.name ?? null,
     description: updated.description ?? null,
     mode: updated.mode ?? null,
-    accessVersion: updated.accessVersion ?? null,
   });
 });
 
@@ -888,8 +902,13 @@ for (const action of ["dismiss", "undismiss"] as const) {
 // ── Exposure controls ───────────────────────────────────────────────────────
 //
 // Everything below changes WHO CAN REACH the scenario or WHAT IT MAY SPEND on
-// their behalf. All need project admin upstream; an API key acting as an
-// ordinary member gets a 403, which is the intended answer.
+// their behalf — but the upstream gates differ, and the difference matters:
+// guest execution and rebinding need project admin
+// (`canManageProjectMembers`), while link rotation and member edits gate at
+// workspace membership (`requireWorkspaceRole(..., 'guest')`) like the mode
+// change above — an ordinary member can do them. For the admin-gated pair, an
+// API key acting as an ordinary member gets a 403, which is the intended
+// answer.
 
 const guestExecutionSchema = z.strictObject({
   enabled: z.boolean(),
@@ -932,24 +951,28 @@ userTesting.put(`${BASE}/guest-execution`, async (c) => {
 // link has leaked — but it means a caller cannot undo this by rotating back.
 userTesting.post(`${BASE}/rotate-link`, async (c) => {
   const { client, projectId, scenarioId } = await scopedScenario(c);
-  let result: { link?: string; accessVersion?: number } | null;
+  let result: { link?: unknown } | null;
   try {
     result = (await client.mutation(
       "chatboxes:rotateChatboxLink" as never,
       { chatboxId: scenarioId } as never
-    )) as { link?: string; accessVersion?: number } | null;
+    )) as { link?: unknown } | null;
   } catch (error) {
     throw translateWriteError(error);
   }
   // PROJECTED, not spread. Spreading an unread mutation result makes every
   // field upstream adds part of the public contract without review — and on
   // THIS route the fields in question are share secrets.
+  //
+  // No `accessVersion`: the mutation returns the settings envelope, which
+  // does not carry it (see `ChatboxRow`) — the value only travels on the
+  // publish/rebind projection. Reporting `null` forever documented a
+  // revocation signal this response never actually delivered.
   return v1Resource(c, {
     id: scenarioId,
     projectId,
     rotated: true,
     link: result?.link ?? null,
-    accessVersion: result?.accessVersion ?? null,
   });
 });
 

--- a/sdk/src/platform/client.ts
+++ b/sdk/src/platform/client.ts
@@ -1967,8 +1967,10 @@ export class PlatformApiClient {
   // exist yet); everything here is keyed by the scenario.
   //
   // AUTHORIZATION DIFFERS from the rest of this client: these gate on the
-  // WORKSPACE role rather than the project role, and the exposure controls
-  // (guest execution, link rotation, rebinding) need project ADMIN. A legacy
+  // WORKSPACE role rather than the project role, and workspace MEMBERSHIP is
+  // enough for most of them — mode changes, renames, member edits and link
+  // rotation included. Only guest execution and rebinding need project
+  // ADMIN. A legacy
   // workspace with no organization hard-denies delegated (`sk_`) callers
   // entirely — a documented limitation, not a bug you can grant your way out
   // of.

--- a/sdk/src/platform/operations.ts
+++ b/sdk/src/platform/operations.ts
@@ -6089,7 +6089,7 @@ export const updateUserTestingScenarioOperation: PlatformOperation<
   name: "update_user_testing_scenario",
   title: "Update a user-testing scenario",
   description:
-    "Rename a scenario, or change who may open its share link. SINGLE-CONCERN: send `mode` alone, or name/description together — never both, because they are separate operations upstream and applying them in sequence could leave the scenario live in a mode nobody asked for. Widening to anyone_with_link exposes it to anyone holding the URL. Project admin.",
+    "Rename a scenario, or change who may open its share link. SINGLE-CONCERN: send `mode` alone, or name/description together — never both, because they are separate operations upstream and applying them in sequence could leave the scenario live in a mode nobody asked for. Widening to anyone_with_link exposes it to anyone holding the URL. Workspace membership is enough — no admin needed.",
   readOnly: false,
   risk: "exposure",
   inputSchema: updateUserTestingScenarioInput,
@@ -6633,7 +6633,7 @@ export const rotateUserTestingLinkOperation: PlatformOperation<
   name: "rotate_user_testing_link",
   title: "Rotate a user-testing scenario's share link",
   description:
-    "Mint a new share link and invalidate the old one. IMMEDIATE AND IRREVERSIBLE: everyone holding the old URL loses access and every live session on it dies. This is what you do when a link has leaked, not routine hygiene. Project admin.",
+    "Mint a new share link and invalidate the old one. IMMEDIATE AND IRREVERSIBLE: everyone holding the old URL loses access and every live session on it dies. This is what you do when a link has leaked, not routine hygiene. Workspace membership is enough — no admin needed.",
   readOnly: false,
   risk: "destructive",
   inputSchema: userTestingScenarioSelectorInput,

--- a/sdk/src/platform/types.ts
+++ b/sdk/src/platform/types.ts
@@ -1274,7 +1274,15 @@ export interface PlatformCapabilities {
     cancelJourneyRun: boolean;
     publishUserTestingScenario: boolean;
     unpublishUserTestingScenario: boolean;
+    /**
+     * Mode changes, member invites/removals, link rotation, renames — the
+     * scenario controls an ordinary MEMBER can use. Guest execution is not
+     * covered here; it is the one exposure control that needs admin, and it
+     * has its own key below.
+     */
     changeUserTestingExposure: boolean;
+    /** The guest-execution spend caps. Genuinely project-admin upstream. */
+    manageUserTestingGuestExecution: boolean;
     requestInsights: boolean;
   };
 }
@@ -1362,14 +1370,20 @@ export interface PlatformUserTestingSessionDetail {
   nextCursor?: string;
 }
 
-/** Scenario metadata after an update. */
+/**
+ * Scenario metadata after an update.
+ *
+ * NO `accessVersion`, deliberately: a mode change bumps it upstream, but the
+ * envelope the route re-reads does not carry the new value, so the field was
+ * null on every response while documenting itself as the revocation signal.
+ * The publish response (`PlatformScenario`) carries the real one.
+ */
 export interface PlatformUserTestingScenario {
   id: string;
   projectId: string;
   name: string | null;
   description: string | null;
   mode: string | null;
-  accessVersion: number | null;
 }
 
 /** Guest execution caps — the spend dial for anonymous visitors. */


### PR DESCRIPTION
Three verified honesty defects on the User Testing surface, all checked against the backend ground truth in `mcpjam-backend/convex/chatboxes.ts`. Nothing here tightens behavior — no gate, confirmation, or requirement was added anywhere; enforcement stays exactly where it was. This PR only makes what the surface *says* match what the backend *does*.

## 1. Capabilities endpoint denied capabilities callers actually have

`capabilities.ts` reported `changeUserTestingExposure: isAdmin && !gated`. Backend reality: `setChatboxMode`, `updateChatbox`, `rotateChatboxLink`, `upsertChatboxMember`, `removeChatboxMember` all gate at `requireWorkspaceRole(..., 'guest')` — an ordinary member can do every one of them — and none of them check the `sandboxes-enabled` beta flag (only publish/rebind call `requireSandboxesEnabled`). An agent asking before planning was being told "no" for writes the backend accepts, which is the exact failure the endpoint's own header says it exists to prevent.

- `changeUserTestingExposure` now derives from membership, ungated.
- The one exposure control that genuinely needs project admin — `setChatboxGuestExecution` (`canManageProjectMembers`, same bar as publishing) — gets its own **additive** key: `manageUserTestingGuestExecution`.
- `PlatformCapabilities.can` in the SDK extended additively to match.

## 2. False comments and a test pinning a fictional error shape

`user-testing.ts` claimed (twice) that all exposure controls "need project admin upstream". True only for publish, rebind, and guest execution; corrected to per-op truth in the module header and the Exposure-controls banner.

The test "surfaces the admin gate as 403" mocked `rotateChatboxLink` failing with `ConvexError { code: 'FORBIDDEN' }` — a shape that mutation can never produce: it throws plain `Error('Not a member of this workspace')` / `Insufficient workspace permissions` from `requireWorkspaceRole`. Replaced with tests pinning the real shapes through `translateConvexWriteError`:

- rotate's plain workspace-role refusal collapses to the neutral **404** (the caller cannot see the workspace at all — same answer as a missing scenario; in production Convex redacts it to "Server Error" and the preflight answers first anyway);
- guest execution's real plain `Only project admins can configure guest execution` surfaces as the **403** via the prose fallback.

The publish admin-gate test in `scenarios.test.ts` is untouched — publish really does throw a structured `ConvexError FORBIDDEN` naming the admin requirement.

## 3. `accessVersion` was null on every PATCH and rotate-link response

Both responses documented `accessVersion` as the revocation signal but populated it from the upstream settings envelope (`assembleChatboxSettingsResponse`), which does not carry the field — only the publish/rebind projection (`projectEnvironmentChatbox`) returns it. So the field was `null` forever. Removed from those two responses and from `PlatformUserTestingScenario`, with comments noting where the real value lives and that reintroducing it requires the backend envelope to carry it first. Publish and rebind keep their genuine `accessVersion`. No backend change, no faked value.

Also corrected the same false "Project admin." claims in the SDK operation descriptions (`update_user_testing_scenario`, `rotate_user_testing_link`), the SDK client's user-testing section comment, and the CLI module header.

## Verification

- `npx vitest run server/routes/v1/__tests__/user-testing.test.ts server/routes/v1/__tests__/capabilities.test.ts server/routes/v1/__tests__/scenarios.test.ts` — 61/61 green
- `sdk`: `npm run build` + `npm test` — 215 files, 4279 tests green
- Server tsc: no new errors in touched files vs baseline

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Additive capability key and removal of `accessVersion` on update/rotate are breaking for SDK consumers that relied on those fields; behavior and gates on the server are unchanged.
> 
> **Overview**
> Aligns the User Testing **surface** with backend authorization and response shapes; **enforcement is unchanged**.
> 
> **Capabilities** (`capabilities.ts` / SDK `PlatformCapabilities.can`): `changeUserTestingExposure` now reflects **workspace membership** (ungated), not project admin. Adds **`manageUserTestingGuestExecution`** for guest-execution caps, which still require project admin. Comments note members may see `true` for exposure and still 404 on a private workspace without a grant.
> 
> **API responses**: Removes **`accessVersion`** from scenario **PATCH** and **rotate-link** responses and from **`PlatformUserTestingScenario`**—the settings envelope never carried it (only publish/rebind do). Stops advertising a revocation signal that was always `null`.
> 
> **Docs & tests**: Corrects CLI/SDK/route comments (members can rotate links and change mode; only guest execution and rebind need admin). Replaces a rotate-link test that mocked a fictional `FORBIDDEN` ConvexError with cases for real errors: rotate workspace refusal → **404**, guest execution admin refusal → **403**.
> 
> **Migration**: Gate guest-execution UI on `can.manageUserTestingGuestExecution`; use `can.changeUserTestingExposure` for mode/members/rotate. Read `accessVersion` from publish/rebind only.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 67e212f1dfd0cc007e972409251c04b8c2fd1273. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Aligns the User Testing surface with backend authorization and drops a fictional `accessVersion` on update and rotate responses. Old behavior misreported member-level controls as admin-only and returned `accessVersion: null`; new behavior reports real capabilities, treats guest execution as the only admin-only exposure control, and omits fields the backend never sends.

- Capabilities: `changeUserTestingExposure` now derives from workspace membership (no beta gate). Adds `manageUserTestingGuestExecution` for the admin-only spend caps. Documents a known imprecision: non-admin org members may still 404 on a private workspace without a grant. SDK `PlatformCapabilities.can` extended additively.
- Routes and errors: Removes `accessVersion` from scenario PATCH and `rotate-link` responses; publish/rebind keep it. Maps rotate’s insufficient workspace membership to 404; surfaces guest-execution’s admin refusal as 403. Tests pin real shapes.
- SDK/CLI/docs: Updates operation descriptions to reflect membership vs admin. Removes `accessVersion` from `PlatformUserTestingScenario`. No enforcement changes.

- Migration:
  - Stop reading `PlatformUserTestingScenario.accessVersion`; get it from publish/rebind responses instead.
  - Gate guest-execution UI/calls on `can.manageUserTestingGuestExecution`. Use `can.changeUserTestingExposure` for mode, member edits, rename, and link rotation.

<sup>Written for commit 67e212f1dfd0cc007e972409251c04b8c2fd1273. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/MCPJam/inspector/pull/4000?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

