### PR TITLE
fix(observability): record how every stream ended, not just the ones that finished

### DIFF
--- a/mcpjam-inspector/server/middleware/__tests__/request-log-context.middleware.test.ts
+++ b/mcpjam-inspector/server/middleware/__tests__/request-log-context.middleware.test.ts
@@ -595,6 +595,33 @@ describe("requestLogContextMiddleware", () => {
     );
   });
 
+  it("still emits the closed row when the error value cannot be stringified", async () => {
+    // A rejection reason can be a value whose string coercion throws (a
+    // null-prototype object here). The closed row must survive with a
+    // fallback instead of the telemetry code throwing and eating the row.
+    const app = createTestApp();
+    app.get("/api/web/stream", (c) => {
+      c.header("Content-Type", "text/event-stream");
+      const dying = new ReadableStream<Uint8Array>({
+        start(controller) {
+          controller.error(Object.create(null));
+        },
+      });
+      return c.body(dying);
+    });
+
+    const res = await app.request("/api/web/stream");
+    const reader = res.body!.getReader();
+    await reader.read().catch(() => undefined);
+
+    const closed = vi
+      .mocked(logger.event)
+      .mock.calls.filter(([name]) => name === "http.stream.closed");
+    expect(closed).toHaveLength(1);
+    expect((closed[0][2] as any).outcome).toBe("errored");
+    expect((closed[0][2] as any).errorMessage).toBe("[unreadable error value]");
+  });
+
   it("caps the errored stream message at 500 chars", async () => {
     const app = createTestApp();
     app.get("/api/web/stream", (c) => {

--- a/mcpjam-inspector/server/middleware/__tests__/request-log-context.middleware.test.ts
+++ b/mcpjam-inspector/server/middleware/__tests__/request-log-context.middleware.test.ts
@@ -517,6 +517,105 @@ describe("requestLogContextMiddleware", () => {
       .mock.calls.filter(([name]) => name === "http.stream.closed");
     expect(closed).toHaveLength(1);
     expect((closed[0][2] as any).durationMs).toBeGreaterThanOrEqual(0);
+    expect((closed[0][2] as any).outcome).toBe("completed");
+    expect((closed[0][2] as any).errorMessage).toBeUndefined();
+  });
+
+  it("delivers stream bytes unchanged through the close-tracking wrapper", async () => {
+    const app = createTestApp();
+    app.get("/api/web/stream", (c) => {
+      c.header("Content-Type", "text/event-stream");
+      return c.body("data: hello\n\ndata: world\n\n");
+    });
+
+    const res = await app.request("/api/web/stream");
+    expect(await res.text()).toBe("data: hello\n\ndata: world\n\n");
+  });
+
+  // Regression: the old TransformStream hook only had flush(), which runs on
+  // a NORMAL end-of-stream — a consumer cancel (client disconnect) or a
+  // producer error left no http.stream.closed at all. The most common
+  // streaming failure produced zero telemetry rows.
+  it("emits http.stream.closed with outcome 'aborted' when the consumer cancels", async () => {
+    const app = createTestApp();
+    app.get("/api/web/stream", (c) => {
+      c.header("Content-Type", "text/event-stream");
+      // A stream that never ends on its own, so only cancel can close it.
+      const endless = new ReadableStream<Uint8Array>({
+        pull(controller) {
+          controller.enqueue(new TextEncoder().encode("data: tick\n\n"));
+        },
+      });
+      return c.body(endless);
+    });
+
+    const res = await app.request("/api/web/stream");
+    const reader = res.body!.getReader();
+    await reader.read();
+    await reader.cancel(new Error("client went away"));
+
+    const closed = vi
+      .mocked(logger.event)
+      .mock.calls.filter(([name]) => name === "http.stream.closed");
+    expect(closed).toHaveLength(1);
+    expect((closed[0][2] as any).outcome).toBe("aborted");
+    // An abort is not a failure; no message is recorded for it.
+    expect((closed[0][2] as any).errorMessage).toBeUndefined();
+  });
+
+  it("emits http.stream.closed with outcome 'errored' when the producer errors", async () => {
+    const app = createTestApp();
+    app.get("/api/web/stream", (c) => {
+      c.header("Content-Type", "text/event-stream");
+      const dying = new ReadableStream<Uint8Array>({
+        start(controller) {
+          controller.enqueue(new TextEncoder().encode("data: one\n\n"));
+          controller.error(new Error("upstream connection reset"));
+        },
+      });
+      return c.body(dying);
+    });
+
+    const res = await app.request("/api/web/stream");
+    const reader = res.body!.getReader();
+    await expect(async () => {
+      while (true) {
+        const { done } = await reader.read();
+        if (done) break;
+      }
+    }).rejects.toThrow("upstream connection reset");
+
+    const closed = vi
+      .mocked(logger.event)
+      .mock.calls.filter(([name]) => name === "http.stream.closed");
+    expect(closed).toHaveLength(1);
+    expect((closed[0][2] as any).outcome).toBe("errored");
+    expect((closed[0][2] as any).errorMessage).toBe(
+      "upstream connection reset",
+    );
+  });
+
+  it("caps the errored stream message at 500 chars", async () => {
+    const app = createTestApp();
+    app.get("/api/web/stream", (c) => {
+      c.header("Content-Type", "text/event-stream");
+      const dying = new ReadableStream<Uint8Array>({
+        start(controller) {
+          controller.error(new Error("x".repeat(2000)));
+        },
+      });
+      return c.body(dying);
+    });
+
+    const res = await app.request("/api/web/stream");
+    const reader = res.body!.getReader();
+    await expect(reader.read()).rejects.toThrow();
+
+    const closed = vi
+      .mocked(logger.event)
+      .mock.calls.filter(([name]) => name === "http.stream.closed");
+    expect(closed).toHaveLength(1);
+    expect((closed[0][2] as any).errorMessage).toHaveLength(500);
   });
 
   it("re-throws exceptions after emitting http.request.failed", async () => {

--- a/mcpjam-inspector/server/middleware/request-log-context.ts
+++ b/mcpjam-inspector/server/middleware/request-log-context.ts
@@ -100,17 +100,61 @@ export async function requestLogContextMiddleware(c: Context, next: Next) {
     const body = c.res.body;
     if (body) {
       const closedCtx: RequestLogContext = { ...enriched };
-      const ts = new TransformStream({
-        flush() {
-          const durationMs = Date.now() - startedAt;
-          logger.event(
-            "http.stream.closed",
-            { ...closedCtx, durationMs },
-            { statusCode: closedCtx.statusCode ?? status, durationMs },
-          );
+      // Hand-rolled pull wrapper instead of a TransformStream: flush() only
+      // runs on a NORMAL end-of-stream, so a producer error or a client
+      // disconnect used to leave no `http.stream.closed` at all — the most
+      // common streaming failure produced zero telemetry. read()/cancel()
+      // cover all three exits deterministically, and pull() is demand-driven
+      // so backpressure is preserved.
+      const reader = body.getReader();
+      let closedEmitted = false;
+      const emitClosed = (
+        outcome: "completed" | "aborted" | "errored",
+        error?: unknown,
+      ) => {
+        // Exactly once: cancel and a pending read rejection can race.
+        if (closedEmitted) return;
+        closedEmitted = true;
+        const durationMs = Date.now() - startedAt;
+        const errorMessage =
+          outcome === "errored" && error !== undefined
+            ? (error instanceof Error ? error.message : String(error)).slice(
+                0,
+                500,
+              )
+            : undefined;
+        logger.event(
+          "http.stream.closed",
+          { ...closedCtx, durationMs },
+          {
+            statusCode: closedCtx.statusCode ?? status,
+            durationMs,
+            outcome,
+            ...(errorMessage ? { errorMessage } : {}),
+          },
+        );
+      };
+      const wrapped = new ReadableStream<Uint8Array>({
+        async pull(controller) {
+          try {
+            const { done, value } = await reader.read();
+            if (done) {
+              emitClosed("completed");
+              controller.close();
+              return;
+            }
+            controller.enqueue(value);
+          } catch (err) {
+            emitClosed("errored", err);
+            controller.error(err);
+          }
+        },
+        cancel(reason) {
+          emitClosed("aborted", reason);
+          return reader.cancel(reason);
         },
       });
-      c.res = new Response(body.pipeThrough(ts), {
+      c.res = new Response(wrapped, {
         status: c.res.status,
         statusText: c.res.statusText,
         headers: c.res.headers,

--- a/mcpjam-inspector/server/middleware/request-log-context.ts
+++ b/mcpjam-inspector/server/middleware/request-log-context.ts
@@ -116,13 +116,22 @@ export async function requestLogContextMiddleware(c: Context, next: Next) {
         if (closedEmitted) return;
         closedEmitted = true;
         const durationMs = Date.now() - startedAt;
-        const errorMessage =
-          outcome === "errored" && error !== undefined
-            ? (error instanceof Error ? error.message : String(error)).slice(
-                0,
-                500,
-              )
-            : undefined;
+        // Guarded extraction: a rejection reason can be a value whose
+        // message getter or string coercion throws (Proxy trap, null-proto
+        // object). Letting that escape here would swallow the closed row AND
+        // replace the stream error with a secondary failure from the
+        // telemetry code — same precedent as reportRouteFailure's
+        // "[unreadable error value]" handling.
+        let errorMessage: string | undefined;
+        if (outcome === "errored" && error !== undefined) {
+          try {
+            errorMessage = (
+              error instanceof Error ? error.message : String(error)
+            ).slice(0, 500);
+          } catch {
+            errorMessage = "[unreadable error value]";
+          }
+        }
         logger.event(
           "http.stream.closed",
           { ...closedCtx, durationMs },

--- a/mcpjam-inspector/server/utils/log-events.ts
+++ b/mcpjam-inspector/server/utils/log-events.ts
@@ -110,7 +110,23 @@ export type RequestEventMap = {
     slug?: string;
   };
   "http.stream.opened": { statusCode: number };
-  "http.stream.closed": { statusCode: number; durationMs: number };
+  /**
+   * Lifecycle, not failure: every wrapped stream emits exactly one of these,
+   * whatever ends it. `outcome` is the only record of HOW a streaming
+   * response died — the middleware's streaming branch returns before any
+   * `http.request.failed`/`completed` emission, and a producer error or a
+   * client disconnect used to skip the old flush()-only hook entirely,
+   * leaving zero rows for the most common streaming failure. Aborts are
+   * deliberately an `outcome` here and never a failure event: a user closing
+   * a tab is normal operation, but its rate is a useful denominator.
+   */
+  "http.stream.closed": {
+    statusCode: number;
+    durationMs: number;
+    outcome: "completed" | "aborted" | "errored";
+    /** errored only; capped at 500 chars, scrubbed on emit. */
+    errorMessage?: string;
+  };
   "mcp.oauth.proxy.failed": {
     targetUrlHost: string;
     oauthPhase: "metadata" | "proxy" | "token";


### PR DESCRIPTION
## Problem

`http.stream.closed` was emitted from a `TransformStream` `flush()` hook — and `flush()` only runs on a **normal** end-of-stream. A producer error (`controller.error` upstream) or a client disconnect (consumer cancel) skipped it entirely: the most common streaming failure produced **zero** telemetry rows, not even a close. Same "user saw an error, no row in inspector-logs" shape that started the alerts program.

## Fix

Replace the wrapper with a pull-based `ReadableStream` around `body.getReader()`, which observes all three exits deterministically:

- normal end → `outcome: "completed"`
- producer error → `outcome: "errored"` + capped/scrubbed `errorMessage`
- consumer cancel / client disconnect → `outcome: "aborted"`

Exactly-once emission (cancel and a pending read rejection can race), backpressure preserved (pull is demand-driven), `c.res` replacement keeps today's exact shape so wire bytes are untouched — pinned by a new passthrough test.

Aborts are deliberately an *outcome* on this lifecycle event and never a failure event: a closed tab is normal operation, but its rate is a useful denominator. `outcome: "errored"` becomes the monitors' backstop for stream deaths that never reach a catch site; the typed failure events for catch sites that do exist land separately (`route.operation.failed`, follow-up PRs).

## Tests

Extended stream block in `request-log-context.middleware.test.ts`: completed outcome, aborted-on-cancel (regression — today zero rows), errored with message, 500-char cap, byte passthrough. 31/31 pass.

Part of the #mcpjam-alerts observability program (streaming-failure telemetry, PR 1/3).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches the HTTP middleware path for all streaming responses; behavior is intended to be telemetry-only with preserved response bytes, but any wrapper bug could affect SSE/MCP streams in production.
> 
> **Overview**
> Fixes a gap where **SSE/MCP streaming** often produced **no** `http.stream.closed` row: the old `TransformStream` only ran `flush()` on a normal end, so **producer errors** and **client disconnects** skipped close telemetry entirely.
> 
> **`request-log-context`** now wraps the response body with a **pull-based `ReadableStream`** around `body.getReader()`, emitting **exactly one** `http.stream.closed` with **`outcome`**: `completed`, `aborted`, or `errored`, plus optional **capped `errorMessage`** on errors (with safe handling for unreadable rejection values). Wire bytes and backpressure behavior are unchanged.
> 
> **`log-events`** extends the `http.stream.closed` payload type with `outcome` and optional `errorMessage`. Tests cover all three outcomes, byte passthrough, message cap, and unreadable errors.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a678d984f9e0c436563b0592a2390f1852560084. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Emits `http.stream.closed` for every stream termination and records how it ended. Previously it fired only on normal completion; now it emits exactly once with `outcome: "completed" | "aborted" | "errored"` and an optional 500‑char `errorMessage` with a safe fallback, closing telemetry gaps for producer failures and client disconnects; backpressure and response bytes are unchanged.

**Review/Rollout**
- Replaced `TransformStream.flush()` with a pull-based `ReadableStream` around `body.getReader()` in `server/middleware/request-log-context.ts`; enforces once-per-stream emission and survives unstringifiable error values.
- Updated `http.stream.closed` schema in `server/utils/log-events.ts`; tests cover passthrough and all outcomes.
- Migration: update queries/dashboards consuming `http.stream.closed` to handle `outcome` and optional `errorMessage`. Treat `aborted` as non-failure; use `errored` as the failure backstop.

<sup>Written for commit a678d984f9e0c436563b0592a2390f1852560084. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/MCPJam/inspector/pull/4001?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

