### PR TITLE
feat(observability): typed route.operation.failed for mid-stream chat failures

### DIFF
--- a/mcpjam-inspector/server/routes/mcp/chat-v2.ts
+++ b/mcpjam-inspector/server/routes/mcp/chat-v2.ts
@@ -27,6 +27,7 @@ import {
   handleHostedOrgChatModel,
   handleLocalOrgChatModel,
 } from "../../utils/org-model-stream-handler.js";
+import { createRequestStreamFailureReporter } from "../../utils/stream-failure-reporter.js";
 import {
   deriveOrgProviderKey,
   isLocalRuntimeEligible,
@@ -1395,6 +1396,7 @@ chatV2.post("/", async (c) => {
 
       return handleMCPJamFreeChatModel({
         messages: modelMessages as ModelMessage[],
+        failureReporter: createRequestStreamFailureReporter(c, "chat"),
         modelId: String(modelDefinition.id),
         provider: modelDefinition.provider,
         systemPrompt: effectiveEnhancedSystemPrompt,
@@ -1612,6 +1614,7 @@ chatV2.post("/", async (c) => {
       if (runtime.runtimeLocation === "local") {
         return handleLocalOrgChatModel({
           provider: runtime.provider,
+          failureReporter: createRequestStreamFailureReporter(c, "chat"),
           projectId: body.projectId,
           modelId,
           chatSessionId,
@@ -1650,6 +1653,7 @@ chatV2.post("/", async (c) => {
 
       return handleHostedOrgChatModel({
         projectId: body.projectId,
+        failureReporter: createRequestStreamFailureReporter(c, "chat"),
         providerKey,
         modelId,
         messages: modelMessages,

--- a/mcpjam-inspector/server/utils/__tests__/engine-failure-telemetry.test.ts
+++ b/mcpjam-inspector/server/utils/__tests__/engine-failure-telemetry.test.ts
@@ -199,6 +199,26 @@ describe("engine failure telemetry", () => {
     expect(errorChunks()).toHaveLength(0);
   });
 
+  it("stays silent when a NON-abort error lands after the signal fired", async () => {
+    // Exercises the `abortSignal?.aborted` arm, not the error-shape arm: the
+    // rejection is a plain TypeError, so only the engine actually consulting
+    // the signal keeps this silent. Catches a regression where the engine
+    // stops listening to abortSignal entirely.
+    const controller = new AbortController();
+    global.fetch = vi.fn().mockImplementation(() => {
+      controller.abort();
+      return Promise.reject(new TypeError("socket hang up"));
+    });
+    const { reporter, calls } = makeReporter();
+
+    await runTurn({
+      failureReporter: reporter,
+      abortSignal: controller.signal,
+    });
+
+    expect(calls).toHaveLength(0);
+  });
+
   it("reports an unexpected engine throw via the agentic-loop site", async () => {
     global.fetch = vi
       .fn()

--- a/mcpjam-inspector/server/utils/__tests__/engine-failure-telemetry.test.ts
+++ b/mcpjam-inspector/server/utils/__tests__/engine-failure-telemetry.test.ts
@@ -1,0 +1,215 @@
+/**
+ * Mid-stream failures must produce exactly one typed telemetry call — and
+ * aborts must produce none.
+ *
+ * The chat engine answers over a 200 SSE stream, so the HTTP failure events
+ * never see anything that goes wrong after headers. `failureReporter`
+ * (stream-failure-reporter.ts) is the seam that records those failures as
+ * `route.operation.failed`. This suite drives `handleMCPJamFreeChatModel`
+ * with the same mocked-backend harness as the SSE snapshot test and pins:
+ *   - one reporter call + one `{type:"error"}` wire chunk per failure
+ *   - the backend-stream site's hop split (transport failure vs recognized
+ *     user-owned denial)
+ *   - aborts stay silent in both directions
+ *   - the wire error chunk shape is unchanged (client contract)
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  executeToolCallsFromMessages,
+  hasUnresolvedToolCalls,
+} from "@/shared/http-tool-calls";
+import { handleMCPJamFreeChatModel } from "../mcpjam-stream-handler";
+import type {
+  StreamFailureEvent,
+  StreamFailureReporter,
+} from "../stream-failure-reporter";
+
+let lastExecution: Promise<void> | null = null;
+let writtenChunks: any[] = [];
+
+vi.mock("ai", async () => {
+  const actual = await vi.importActual<typeof import("ai")>("ai");
+  return {
+    ...actual,
+    createUIMessageStream: vi.fn(({ execute, onFinish }) => {
+      const writer = {
+        write: vi.fn((chunk) => {
+          writtenChunks.push(chunk);
+        }),
+      };
+      lastExecution = Promise.resolve(execute({ writer })).then(async () => {
+        await onFinish?.();
+      });
+      return { getReader: vi.fn() };
+    }),
+    createUIMessageStreamResponse: vi.fn().mockReturnValue(
+      new Response("{}", {
+        headers: { "Content-Type": "text/event-stream" },
+      }),
+    ),
+  };
+});
+
+vi.mock("@/shared/http-tool-calls", () => ({
+  hasUnresolvedToolCalls: vi.fn(),
+  executeToolCallsFromMessages: vi.fn(),
+}));
+
+vi.mock("../mcpjam-tool-helpers", () => ({
+  serializeToolsForConvex: vi.fn(() => []),
+}));
+
+vi.mock("../logger", () => ({
+  logger: {
+    error: vi.fn(),
+    warn: vi.fn(),
+    info: vi.fn(),
+    event: vi.fn(),
+    systemEvent: vi.fn(),
+  },
+}));
+
+vi.mock("@sentry/node", () => ({
+  captureException: vi.fn(),
+  captureMessage: vi.fn(),
+}));
+
+function makeReporter(): {
+  reporter: StreamFailureReporter;
+  calls: StreamFailureEvent[];
+} {
+  const calls: StreamFailureEvent[] = [];
+  const reporter: StreamFailureReporter = (e) => {
+    calls.push(e);
+    return {
+      normalized: e.normalized ?? ({ slug: "internal/unknown" } as any),
+      origin: "ambiguous",
+    };
+  };
+  return { reporter, calls };
+}
+
+function errorChunks() {
+  return writtenChunks.filter((c) => c?.type === "error");
+}
+
+async function runTurn(overrides: Record<string, unknown> = {}) {
+  await handleMCPJamFreeChatModel({
+    messages: [{ role: "user", content: "Hi." }] as any,
+    modelId: "openai/gpt-oss-120b",
+    systemPrompt: "You are helpful",
+    tools: {},
+    mcpClientManager: {
+      getAllToolsMetadata: vi.fn().mockReturnValue({}),
+      listServers: vi.fn().mockReturnValue([]),
+    } as any,
+    heartbeatIntervalMs: 0,
+    ...overrides,
+  } as any);
+  await lastExecution;
+}
+
+describe("engine failure telemetry", () => {
+  const originalFetch = global.fetch;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    lastExecution = null;
+    writtenChunks = [];
+    process.env.CONVEX_HTTP_URL = "https://test-convex.example.com";
+    vi.mocked(hasUnresolvedToolCalls).mockReturnValue(false);
+    vi.mocked(executeToolCallsFromMessages).mockResolvedValue([]);
+  });
+
+  afterEach(() => {
+    global.fetch = originalFetch;
+    delete process.env.CONVEX_HTTP_URL;
+  });
+
+  it("reports a backend /stream transport failure once, with the internal hop", async () => {
+    global.fetch = vi
+      .fn()
+      .mockResolvedValue(new Response("Bad Gateway", { status: 502 }));
+    const { reporter, calls } = makeReporter();
+
+    await runTurn({ failureReporter: reporter });
+
+    expect(calls).toHaveLength(1);
+    expect(calls[0]).toMatchObject({
+      source: "mcp.chat-v2.backend-stream",
+      hop: "mcpjam_internal",
+      transport: "http_stream",
+    });
+    // The site classifies from the response itself and passes it through so
+    // the reporter never re-derives.
+    expect(calls[0].normalized).toBeDefined();
+    expect(calls[0].context).toMatchObject({ httpStatus: 502 });
+
+    // Exactly one error chunk on the wire, exact client contract shape.
+    const chunks = errorChunks();
+    expect(chunks).toHaveLength(1);
+    expect(Object.keys(chunks[0]).sort()).toEqual(["errorText", "type"]);
+  });
+
+  it("keeps a recognized user-owned denial on the user hop", async () => {
+    // HTTP 200 + JSON body = the backend working correctly and refusing for
+    // a user-owned reason. It must still be recorded (the turn failed from
+    // the user's seat) but on the user hop, so it can never promote to a
+    // page.
+    global.fetch = vi.fn().mockResolvedValue(
+      new Response(
+        JSON.stringify({
+          ok: false,
+          code: "user_rate_limit",
+          error: "Daily limit reached",
+        }),
+        { status: 200, headers: { "Content-Type": "application/json" } },
+      ),
+    );
+    const { reporter, calls } = makeReporter();
+
+    await runTurn({ failureReporter: reporter });
+
+    expect(calls).toHaveLength(1);
+    expect(calls[0]).toMatchObject({
+      source: "mcp.chat-v2.backend-stream",
+      hop: "user_server_hop",
+      errorCode: "user_rate_limit",
+    });
+  });
+
+  it("stays completely silent on abort — no report, no error chunk", async () => {
+    const controller = new AbortController();
+    global.fetch = vi.fn().mockImplementation(() => {
+      controller.abort();
+      return Promise.reject(
+        Object.assign(new Error("This operation was aborted"), {
+          name: "AbortError",
+        }),
+      );
+    });
+    const { reporter, calls } = makeReporter();
+
+    await runTurn({
+      failureReporter: reporter,
+      abortSignal: controller.signal,
+    });
+
+    expect(calls).toHaveLength(0);
+    expect(errorChunks()).toHaveLength(0);
+  });
+
+  it("reports an unexpected engine throw via the agentic-loop site", async () => {
+    global.fetch = vi
+      .fn()
+      .mockRejectedValue(new TypeError("fetch failed: ECONNRESET"));
+    const { reporter, calls } = makeReporter();
+
+    await runTurn({ failureReporter: reporter });
+
+    expect(calls).toHaveLength(1);
+    expect(calls[0].source).toBe("mcp.chat-v2.agentic-loop");
+    expect(calls[0].transport).toBe("http_stream");
+    expect(errorChunks()).toHaveLength(1);
+  });
+});

--- a/mcpjam-inspector/server/utils/__tests__/mcpjam-stream-handler.test.ts
+++ b/mcpjam-inspector/server/utils/__tests__/mcpjam-stream-handler.test.ts
@@ -84,6 +84,12 @@ vi.mock("../logger", () => ({
     // catch-block-doesn't-propagate test would have validated against
     // a mock-shape side effect instead of the real behavior).
     warn: vi.fn(),
+    // The failure-reporter fallback (`createSystemStreamFailureReporter`)
+    // emits the typed route.operation.failed row through the system logger
+    // on every engine failure path; without `systemEvent` the reporter call
+    // would TypeError inside the catch instead of reaching the assertions.
+    systemEvent: vi.fn(),
+    event: vi.fn(),
   },
   // `error-origin-capture` routes its Sentry capture through the logger
   // module, so this mock has to carry it or the backend-failure paths below

--- a/mcpjam-inspector/server/utils/__tests__/stream-failure-reporter.test.ts
+++ b/mcpjam-inspector/server/utils/__tests__/stream-failure-reporter.test.ts
@@ -1,0 +1,100 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("../route-error-report.js", () => ({
+  reportRouteFailure: vi.fn(() => ({
+    normalized: { slug: "transport/fetch_failed" },
+    origin: "ambiguous",
+  })),
+}));
+
+const requestEvent = vi.fn();
+const systemEvent = vi.fn();
+vi.mock("../request-logger.js", () => ({
+  getRequestLogger: vi.fn(() => ({ event: requestEvent })),
+  getSystemLogger: vi.fn(() => ({ event: systemEvent })),
+}));
+
+import { reportRouteFailure } from "../route-error-report.js";
+import {
+  createRequestStreamFailureReporter,
+  createSystemStreamFailureReporter,
+  oncePerTurn,
+  type StreamFailureEvent,
+} from "../stream-failure-reporter.js";
+
+const failure = (over: Partial<StreamFailureEvent> = {}): StreamFailureEvent => ({
+  message: "[test] turn failed",
+  error: new Error("upstream reset"),
+  source: "mcp.chat-v2.engine-step",
+  hop: "user_server_hop",
+  transport: "http_stream",
+  ...over,
+});
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("stream failure reporter", () => {
+  it("classifies first, then emits the typed event with the EFFECTIVE origin", () => {
+    const report = createRequestStreamFailureReporter({} as never, "chat")(
+      failure(),
+    );
+
+    // Classification went through reportRouteFailure (capture ordering,
+    // Sentry stamp, free-form row all live there).
+    expect(reportRouteFailure).toHaveBeenCalledTimes(1);
+    expect(report.origin).toBe("ambiguous");
+
+    expect(requestEvent).toHaveBeenCalledTimes(1);
+    const [name, payload] = requestEvent.mock.calls[0];
+    expect(name).toBe("route.operation.failed");
+    // origin comes from the capture decision's return, slug from its
+    // normalized — never re-derived here.
+    expect(payload).toMatchObject({
+      transport: "http_stream",
+      source: "mcp.chat-v2.engine-step",
+      hop: "user_server_hop",
+      origin: "ambiguous",
+      slug: "transport/fetch_failed",
+      errorMessage: "upstream reset",
+    });
+  });
+
+  it("caps the errorMessage at 500 chars", () => {
+    createRequestStreamFailureReporter({} as never, "chat")(
+      failure({ error: new Error("x".repeat(2000)) }),
+    );
+    expect(requestEvent.mock.calls[0][1].errorMessage).toHaveLength(500);
+  });
+
+  it("system variant emits through the system logger", () => {
+    createSystemStreamFailureReporter("assistant-turn")(failure());
+    expect(systemEvent).toHaveBeenCalledTimes(1);
+    expect(requestEvent).not.toHaveBeenCalled();
+  });
+
+  it("oncePerTurn emits one typed event but still classifies every failure", () => {
+    const wrapped = oncePerTurn(
+      createRequestStreamFailureReporter({} as never, "chat"),
+    );
+
+    wrapped(failure({ source: "mcp.chat-v2.backend-stream" }));
+    const second = wrapped(failure({ source: "mcp.chat-v2.agentic-loop" }));
+
+    // A single turn must not count twice in the operation-failure rate…
+    expect(requestEvent).toHaveBeenCalledTimes(1);
+    // …but the second failure still gets its capture decision and free-form
+    // row (Sentry dedupe is the stamp's job, not ours), and callers still
+    // get a usable report back.
+    expect(reportRouteFailure).toHaveBeenCalledTimes(2);
+    expect(second.origin).toBe("ambiguous");
+  });
+
+  it("omits absent optional fields rather than fabricating them", () => {
+    createRequestStreamFailureReporter({} as never, "chat")(failure());
+    const payload = requestEvent.mock.calls[0][1];
+    expect("errorCode" in payload).toBe(false);
+    expect("rpcMethod" in payload).toBe(false);
+  });
+});

--- a/mcpjam-inspector/server/utils/__tests__/stream-failure-reporter.test.ts
+++ b/mcpjam-inspector/server/utils/__tests__/stream-failure-reporter.test.ts
@@ -61,6 +61,16 @@ describe("stream failure reporter", () => {
     });
   });
 
+  it("survives an error whose string coercion throws", () => {
+    createRequestStreamFailureReporter({} as never, "chat")(
+      failure({ error: Object.create(null) }),
+    );
+    expect(requestEvent).toHaveBeenCalledTimes(1);
+    expect(requestEvent.mock.calls[0][1].errorMessage).toBe(
+      "[unreadable error value]",
+    );
+  });
+
   it("caps the errorMessage at 500 chars", () => {
     createRequestStreamFailureReporter({} as never, "chat")(
       failure({ error: new Error("x".repeat(2000)) }),

--- a/mcpjam-inspector/server/utils/assistant-turn.ts
+++ b/mcpjam-inspector/server/utils/assistant-turn.ts
@@ -173,6 +173,13 @@ export interface RunAssistantTurnOptions {
   onEngineError?: MCPJamHandlerOptions["onEngineError"];
 
   /**
+   * Typed mid-stream failure telemetry pass-through. Callers with a request
+   * context pass a request-scoped reporter; when omitted, the engine's
+   * system-reporter fallback applies (requestId: null on the emitted rows).
+   */
+  failureReporter?: MCPJamHandlerOptions["failureReporter"];
+
+  /**
    * Browser-rendered MCP App eval PR 2: per-step advertised-tool narrowing
    * pass-through. The eval runner uses this to hide `computer` /
    * `finish_widget` until a widget has rendered. Chat / synthetic omit.
@@ -459,6 +466,7 @@ function buildHandlerOptions(
     ...(opts.onStepFinish ? { onStepFinish: opts.onStepFinish } : {}),
     // PR 5b-followup-2: pass-through structured-error callback.
     ...(opts.onEngineError ? { onEngineError: opts.onEngineError } : {}),
+    ...(opts.failureReporter ? { failureReporter: opts.failureReporter } : {}),
     // Browser-rendered MCP App eval PR 2: advertised-tool narrowing hook.
     ...(opts.prepareAdvertisedTools
       ? { prepareAdvertisedTools: opts.prepareAdvertisedTools }

--- a/mcpjam-inspector/server/utils/harness/run-harness-turn.ts
+++ b/mcpjam-inspector/server/utils/harness/run-harness-turn.ts
@@ -75,6 +75,10 @@ import {
   selectDeliverableServerIds,
 } from "./plugin-delivery.js";
 import { logger } from "../logger.js";
+import {
+  createSystemStreamFailureReporter,
+  oncePerTurn,
+} from "../stream-failure-reporter.js";
 import type {
   ChatEngineLoopResult,
   MCPJamHandlerOptions,
@@ -417,6 +421,7 @@ export async function runHarnessTurn(
     onToolResult,
     onStepFinish,
     onEngineError,
+    failureReporter: failureReporterOption,
     onLiveTextDelta,
     requireToolApproval,
     chatSessionId,
@@ -435,6 +440,11 @@ export async function runHarnessTurn(
     effectiveCapabilities,
     createHarnessScopeStepUpContinuation,
   } = options;
+  // One typed route.operation.failed per turn; the system fallback covers
+  // callers with no request context (evals/swarms).
+  const failureReporter = oncePerTurn(
+    failureReporterOption ?? createSystemStreamFailureReporter("harness-turn"),
+  );
   // Canonicalize the model id up front (bare hosted ids like `gpt-5-nano` →
   // `openai/gpt-5-nano`). Everything downstream — supportsModel, the adapter's
   // toNativeModel (Codex only maps the `openai/gpt-5*` form), credential
@@ -2284,7 +2294,18 @@ export async function runHarnessTurn(
         return;
       }
       const errorText = err instanceof Error ? err.message : String(err);
-      logger.error("[harness] turn failed", err);
+      // Reporter, not a bare logger.error: the old call captured to Sentry
+      // unconditionally and left no typed record (the response is a 200
+      // stream the HTTP failure events never see). Classify first, page only
+      // on origin=mcpjam, emit route.operation.failed.
+      failureReporter({
+        message: "[harness] turn failed",
+        error: err,
+        source: "chat.harness-turn",
+        hop: "user_server_hop",
+        transport: "http_stream",
+        context: { promptIndex },
+      });
       // Close any open text block so the UI stream stays balanced.
       closeReasoning();
       if (textId !== undefined) emitTextEnd(writer, textId);

--- a/mcpjam-inspector/server/utils/log-events.ts
+++ b/mcpjam-inspector/server/utils/log-events.ts
@@ -65,6 +65,47 @@ export interface SystemLogContext extends CommonLogContext {
 
 export type BaseLogContext = RequestLogContext | SystemLogContext;
 
+/**
+ * A failure that HTTP status cannot see: an SSE `{type:"error"}` chunk after
+ * 200 headers, or a JSON-RPC error envelope returned over HTTP 200. The
+ * middleware's streaming branch returns before any `http.request.failed` /
+ * `http.request.completed` emission, so a request gets exactly one of the
+ * HTTP events OR (possibly) this one — never both. Registered in BOTH event
+ * maps: chat requests emit through `getRequestLogger` (full request
+ * envelope), while evals/swarm engine runs emit through `getSystemLogger`
+ * (`requestId: null`, omitted-not-fabricated).
+ *
+ * Emitted only via `server/utils/stream-failure-reporter.ts`, which runs
+ * `reportRouteFailure` first — so `origin` here is always the EFFECTIVE
+ * value the Sentry capture decision was made on (post `mcpjam_internal`
+ * promotion), the same axis as `http.request.failed.origin`.
+ */
+type RouteOperationFailedFields = {
+  /** How the failure was carried to the client. */
+  transport: "http_stream" | "rpc_envelope";
+  /**
+   * Stable catch-site id, e.g. "mcp.chat-v2.backend-stream". The same string
+   * `reportRouteFailure` tags Sentry with (as `route:${source}`).
+   */
+  source: string;
+  /** Whose hop failed, as declared at the call site. */
+  hop: "user_server_hop" | "mcpjam_internal";
+  /** Effective origin from the capture decision — see the doc block above. */
+  origin: ErrorOrigin;
+  /** Catalog slug behind `origin`, e.g. `transport/econnrefused`. */
+  slug?: string;
+  /**
+   * Structured code when one exists: a backend denial code
+   * ("user_rate_limit"), a JSON-RPC error code as a string ("-32000"), or a
+   * route ErrorCode. Omitted otherwise.
+   */
+  errorCode?: string;
+  /** Capped at 500 chars; scrubbed by scrubLogPayload on emit. */
+  errorMessage: string;
+  /** rpc_envelope only: the JSON-RPC method that failed ("tools/call", …). */
+  rpcMethod?: string;
+};
+
 export type RequestEventMap = {
   /**
    * 4xx responses land here, not on `http.request.failed` — a 4xx is a
@@ -158,6 +199,9 @@ export type RequestEventMap = {
     sourceType?: "chatbox" | "direct" | "eval" | "swarm";
     // Product-surface discriminator carried alongside sourceType so PostHog
     // can pivot persist failures by surface without rejoining to chatSessions.
+    // CAUTION: this `origin` is a DIFFERENT axis from the ErrorOrigin field
+    // of the same name on `http.request.failed` / `route.operation.failed` —
+    // never join the two in an APL query.
     origin?: "playground" | "mcpjam_agent" | "chatbox" | "eval" | "swarm";
   };
   "widget.resource.served": {
@@ -202,6 +246,7 @@ export type RequestEventMap = {
     statusCode: number;
     errorCode: string;
   };
+  "route.operation.failed": RouteOperationFailedFields;
 };
 
 export type SystemEventMap = {
@@ -260,6 +305,7 @@ export type SystemEventMap = {
     latencyP50Ms: number;
     latencyP95Ms: number;
   };
+  "route.operation.failed": RouteOperationFailedFields;
 };
 
 export type LogEventName = keyof RequestEventMap | keyof SystemEventMap;

--- a/mcpjam-inspector/server/utils/mcpjam-stream-handler.ts
+++ b/mcpjam-inspector/server/utils/mcpjam-stream-handler.ts
@@ -2408,21 +2408,27 @@ async function processOneStep(
     // status from our own backend, which `describeBackendStreamFailure`
     // leaves `ambiguous` because it classifies the response alone and cannot
     // know whose backend answered.
-    failureReporter({
-      message: "[mcpjam-stream-handler] backend stream failed",
-      error: new Error(parsed.message),
-      source: "mcp.chat-v2.backend-stream",
-      hop: isRecognizedDenial ? "user_server_hop" : "mcpjam_internal",
-      transport: "http_stream",
-      normalized,
-      ...(parsed.code ? { errorCode: parsed.code } : {}),
-      context: {
-        httpStatus: res.status,
-        code: parsed.code,
-        isJsonDenial,
-        isRecognizedDenial,
-      },
-    });
+    // Silent-cancel invariant: a fired abort can race this site (res.text()
+    // rejecting into the generic fallback, or the failure landing while the
+    // client is already gone). An aborted turn must not inflate the
+    // operation-failure rate.
+    if (!abortSignal?.aborted) {
+      failureReporter({
+        message: "[mcpjam-stream-handler] backend stream failed",
+        error: new Error(parsed.message),
+        source: "mcp.chat-v2.backend-stream",
+        hop: isRecognizedDenial ? "user_server_hop" : "mcpjam_internal",
+        transport: "http_stream",
+        normalized,
+        ...(parsed.code ? { errorCode: parsed.code } : {}),
+        context: {
+          httpStatus: res.status,
+          code: parsed.code,
+          isJsonDenial,
+          isRecognizedDenial,
+        },
+      });
+    }
     safelyEmitEngineError(onEngineError, {
       message: parsed.message,
       ...(parsed.code ? { code: parsed.code } : {}),
@@ -2898,18 +2904,24 @@ async function processOneStep(
       // row, and the typed route.operation.failed event (the response is a
       // 200 stream, so the HTTP failure events never see this).
       const stepNormalized = describeError(error);
-      failureReporter({
-        message: "[mcpjam-stream-handler] engine step failed",
-        error,
-        source: "mcp.chat-v2.engine-step",
-        hop: "user_server_hop",
-        transport: "http_stream",
-        normalized: stepNormalized,
-        context: {
-          promptIndex: traceTurn.promptIndex,
-          stepIndex,
-        },
-      });
+      // Same silent-cancel guard as the outer loop's catch (which checks
+      // `isAbortError(error) || abortSignal?.aborted`): a non-AbortError that
+      // lands after the signal fired belongs to a turn the client already
+      // cancelled.
+      if (!abortSignal?.aborted) {
+        failureReporter({
+          message: "[mcpjam-stream-handler] engine step failed",
+          error,
+          source: "mcp.chat-v2.engine-step",
+          hop: "user_server_hop",
+          transport: "http_stream",
+          normalized: stepNormalized,
+          context: {
+            promptIndex: traceTurn.promptIndex,
+            stepIndex,
+          },
+        });
+      }
       // PR 5b-followup-2: surface the error to `streamSink: "none"`
       // consumers (eval backend stream runner). The processStream /
       // tool-execution catch path doesn't have a structured body, so

--- a/mcpjam-inspector/server/utils/mcpjam-stream-handler.ts
+++ b/mcpjam-inspector/server/utils/mcpjam-stream-handler.ts
@@ -30,7 +30,11 @@ import {
   describeError,
   type NormalizedError,
 } from "@mcpjam/sdk";
-import { maybeCaptureOriginError } from "./error-origin-capture.js";
+import {
+  createSystemStreamFailureReporter,
+  oncePerTurn,
+  type StreamFailureReporter,
+} from "./stream-failure-reporter.js";
 import type { ModelVisibleMcpToolResults } from "@mcpjam/sdk/host-config/internal";
 import { runHarnessTurn } from "./harness/run-harness-turn.js";
 import type { TrustedHarnessSandboxBinding } from "./harness/resolve-sandbox.js";
@@ -683,6 +687,14 @@ export interface MCPJamHandlerOptions {
    */
   onEngineError?: (event: MCPJamEngineErrorEvent) => void;
   /**
+   * Typed-telemetry seam for mid-stream failures (route.operation.failed).
+   * Routes with a Hono context pass `createRequestStreamFailureReporter(c)`
+   * so the event carries the full request envelope; when absent the engine
+   * falls back to the system reporter, so no caller can silently lose
+   * events. See stream-failure-reporter.ts.
+   */
+  failureReporter?: StreamFailureReporter;
+  /**
    * Browser-rendered MCP App eval PR 2 — optional per-step hook that narrows
    * the *advertised* tool set the model sees this step. Called inside
    * `processOneStep` after the active tool subset is resolved, with
@@ -804,6 +816,9 @@ interface StepContext {
   // processOneStep, processStream/tool-execution catch, outer
   // agentic-loop catch). Optional.
   onEngineError?: (event: MCPJamEngineErrorEvent) => void;
+  // Typed mid-stream failure telemetry; threaded from runChatEngineLoop
+  // (already oncePerTurn-wrapped and fallback-resolved there).
+  failureReporter: StreamFailureReporter;
   // Browser-rendered MCP App eval PR 2: per-step advertised-tool narrowing.
   prepareAdvertisedTools?: MCPJamHandlerOptions["prepareAdvertisedTools"];
   abortSignal?: AbortSignal;
@@ -2111,6 +2126,7 @@ async function processOneStep(
     onToolResult,
     // PR 5b-followup-2 structured-error callback.
     onEngineError,
+    failureReporter,
     // Browser-rendered MCP App eval PR 2: advertised-tool narrowing hook.
     prepareAdvertisedTools,
   } = ctx;
@@ -2374,24 +2390,33 @@ async function processOneStep(
     // working correctly, so only they skip the boundary.
     const isRecognizedDenial =
       isJsonDenial && USER_OWNED_DENIAL_CODES.has(parsed.code ?? "");
-    maybeCaptureOriginError(new Error(parsed.message), normalized, {
-      source: "route:mcp.chat-v2.backend-stream",
-      // The boundary is declared for a genuine TRANSPORT failure only, and
-      // NOT for `isJsonDenial`. A denial is an HTTP 200 carrying a structured
-      // refusal (`{ok:false, code:"user_rate_limit"}`) — the backend working
-      // correctly, and a routine, user-owned outcome. Promoting it would page
-      // the team on every ordinary spend-limit rejection, which is precisely
-      // the noise class this work removes.
-      //
-      // On a real failure the declaration earns its place twice: it tags the
-      // event with the boundary the rest of the codebase triages on, and it
-      // escalates an unrecognized status from our own backend, which
-      // `describeBackendStreamFailure` leaves `ambiguous` because it
-      // classifies the response alone and cannot know whose backend answered.
-      ...(isRecognizedDenial
-        ? {}
-        : { boundary: "mcpjam_internal" as const }),
-      extra: {
+    // Through the reporter, not a bare capture call: reportRouteFailure runs
+    // the same maybeCaptureOriginError decision (source becomes the identical
+    // `route:mcp.chat-v2.backend-stream` Sentry tag), then a free-form Axiom
+    // row, then the typed route.operation.failed event — the only record of
+    // this failure that monitors can key on, since the response is a 200
+    // stream the HTTP events never see.
+    //
+    // The hop is `mcpjam_internal` for a genuine TRANSPORT failure only, and
+    // NOT for `isRecognizedDenial`. A denial is an HTTP 200 carrying a
+    // structured refusal (`{ok:false, code:"user_rate_limit"}`) — the backend
+    // working correctly, and a routine, user-owned outcome. Promoting it
+    // would page the team on every ordinary spend-limit rejection, which is
+    // precisely the noise class this work removes. On a real failure the
+    // internal hop earns its place twice: it tags the event with the boundary
+    // the rest of the codebase triages on, and it escalates an unrecognized
+    // status from our own backend, which `describeBackendStreamFailure`
+    // leaves `ambiguous` because it classifies the response alone and cannot
+    // know whose backend answered.
+    failureReporter({
+      message: "[mcpjam-stream-handler] backend stream failed",
+      error: new Error(parsed.message),
+      source: "mcp.chat-v2.backend-stream",
+      hop: isRecognizedDenial ? "user_server_hop" : "mcpjam_internal",
+      transport: "http_stream",
+      normalized,
+      ...(parsed.code ? { errorCode: parsed.code } : {}),
+      context: {
         httpStatus: res.status,
         code: parsed.code,
         isJsonDenial,
@@ -2865,6 +2890,26 @@ async function processOneStep(
         errorText,
       });
     emitError(writer, errorText);
+      // Site (2) holds a real error. An earlier comment deferred capture to
+      // "the chat route's stream onError" — but runChatEngineLoop's
+      // createUIMessageStream passes only `execute`, so no such onError
+      // exists on this path and the failure was never classified or
+      // recorded. The reporter closes that hole: capture decision, free-form
+      // row, and the typed route.operation.failed event (the response is a
+      // 200 stream, so the HTTP failure events never see this).
+      const stepNormalized = describeError(error);
+      failureReporter({
+        message: "[mcpjam-stream-handler] engine step failed",
+        error,
+        source: "mcp.chat-v2.engine-step",
+        hop: "user_server_hop",
+        transport: "http_stream",
+        normalized: stepNormalized,
+        context: {
+          promptIndex: traceTurn.promptIndex,
+          stepIndex,
+        },
+      });
       // PR 5b-followup-2: surface the error to `streamSink: "none"`
       // consumers (eval backend stream runner). The processStream /
       // tool-execution catch path doesn't have a structured body, so
@@ -2875,9 +2920,7 @@ async function processOneStep(
         rawText: errorText,
         promptIndex: traceTurn.promptIndex,
         stepIndex,
-        // Site (2) holds a real error — no capture here, the chat route's
-        // stream `onError` owns that decision for this path.
-        normalized: describeError(error),
+        normalized: stepNormalized,
       });
       return { shouldContinue: false, didEmitFinish: false };
     }
@@ -3006,6 +3049,7 @@ export async function runChatEngineLoop(
     onStepFinish,
     // PR 5b-followup-2 callback.
     onEngineError,
+    failureReporter: failureReporterOption,
     // Browser-rendered MCP App eval PR 2: advertised-tool narrowing hook.
     prepareAdvertisedTools,
     abortSignal,
@@ -3014,6 +3058,13 @@ export async function runChatEngineLoop(
     progressivePlan,
     discoveryState,
   } = options;
+  // One typed route.operation.failed per turn, whatever combination of the
+  // three failure sites fires; the system fallback covers eval/swarm runs
+  // that have no request context. Later failures in the same turn still get
+  // classified (capture-deduped) and keep their free-form rows.
+  const failureReporter = oncePerTurn(
+    failureReporterOption ?? createSystemStreamFailureReporter("chat-engine"),
+  );
   const resolvedEndpointPath = endpointPath ?? "/stream";
   const resolvedMaxSteps =
     typeof maxSteps === "number" && Number.isFinite(maxSteps) && maxSteps > 0
@@ -3358,6 +3409,7 @@ export async function runChatEngineLoop(
           // the two `processOneStep` error sites (non-OK Convex
           // response + processStream/tool catch).
           onEngineError,
+          failureReporter,
           // Browser-rendered MCP App eval PR 2: advertised-tool narrowing.
           prepareAdvertisedTools,
           abortSignal,
@@ -3439,10 +3491,24 @@ export async function runChatEngineLoop(
       if (isAbortError(error) || abortSignal?.aborted) {
         aborted = true;
       } else {
-        logger.error("[mcpjam-stream-handler] Error in agentic loop", error);
         const failAbs = Date.now();
         const errorText =
           error instanceof Error ? error.message : String(error);
+        const loopNormalized = describeError(error);
+        // Reporter, not a bare logger.error: the old call captured to Sentry
+        // unconditionally — paging on user-fault failures — and left no typed
+        // record a monitor could read (the response is a 200 stream). The
+        // reporter classifies first, pages only on origin=mcpjam, keeps the
+        // free-form row, and emits route.operation.failed.
+        failureReporter({
+          message: "[mcpjam-stream-handler] Error in agentic loop",
+          error,
+          source: "mcp.chat-v2.agentic-loop",
+          hop: "user_server_hop",
+          transport: "http_stream",
+          normalized: loopNormalized,
+          context: { promptIndex: traceTurn.promptIndex },
+        });
         pushAiSdkTrailingErrorSpan(
           traceTurn.turnSpans,
           traceTurn.turnStartedAt,
@@ -3471,7 +3537,7 @@ export async function runChatEngineLoop(
           message: errorText,
           rawText: errorText,
           promptIndex: traceTurn.promptIndex,
-          normalized: describeError(error),
+          normalized: loopNormalized,
         });
       }
     } finally {

--- a/mcpjam-inspector/server/utils/org-model-stream-handler.ts
+++ b/mcpjam-inspector/server/utils/org-model-stream-handler.ts
@@ -45,6 +45,11 @@ import type { PersistedTurnTrace } from "./chat-ingestion";
 import { handleMCPJamFreeChatModel } from "./mcpjam-stream-handler.js";
 import { logger } from "./logger.js";
 import {
+  createSystemStreamFailureReporter,
+  oncePerTurn,
+  type StreamFailureReporter,
+} from "./stream-failure-reporter.js";
+import {
   runDirectChatTurn,
   withMcpToolOriginChunkMetadata,
   type DirectChatTurnPersistEvent,
@@ -142,6 +147,11 @@ export interface OrgModelHandlerOptions {
    * on collision.
    */
   extraBodyFields?: Record<string, unknown>;
+  /**
+   * Typed-telemetry seam for mid-stream failures; forwarded verbatim into
+   * the wrapped MCPJam handler. See stream-failure-reporter.ts.
+   */
+  failureReporter?: StreamFailureReporter;
 }
 
 // ---------------------------------------------------------------------------
@@ -299,6 +309,12 @@ export interface OrgLocalModelHandlerOptions {
    */
   progressivePlan?: ProgressiveToolPlan;
   discoveryState?: ToolDiscoveryState;
+  /**
+   * Typed-telemetry seam for mid-stream failures (route.operation.failed);
+   * see stream-failure-reporter.ts. Constructed at the route layer where a
+   * Hono context exists.
+   */
+  failureReporter?: StreamFailureReporter;
 }
 
 /**
@@ -354,6 +370,15 @@ export function handleLocalOrgChatModel(
     onLiveTextDelta,
   } = options;
 
+  // One typed route.operation.failed per turn across this handler's failure
+  // sites; system fallback keeps the invariant if a future caller forgets it.
+  const failureReporter = oncePerTurn(
+    options.failureReporter ??
+      createSystemStreamFailureReporter("org-local-stream"),
+  );
+
+  // Deliberately NOT reported as an operation failure: this is a declared
+  // product limitation surfaced to the user, not something that broke.
   if (hasUnsupportedLocalApprovalGate(tools, requireToolApproval)) {
     const stream = createUIMessageStream({
       onError: (error) => formatLocalStreamError(error),
@@ -383,6 +408,17 @@ export function handleLocalOrgChatModel(
     assertOrgModelAllowed(provider, modelId);
     llmModel = buildOrgModelFromResolvedConfig(provider, modelId);
   } catch (configErr) {
+    // The response is still a 200 stream whose first chunk is the error, so
+    // the HTTP failure events never see this — the typed event is the only
+    // machine-readable record.
+    failureReporter({
+      message: "[org/local] model config/allowlist failure",
+      error: configErr,
+      source: "web.chat-v2.org-local-config",
+      hop: "user_server_hop",
+      transport: "http_stream",
+      context: { providerKey: provider.providerKey, modelId },
+    });
     const stream = createUIMessageStream({
       onError: (error) => formatLocalStreamError(error),
       onFinish: async () => {
@@ -420,7 +456,16 @@ export function handleLocalOrgChatModel(
       ) {
         return "";
       }
-      logger.error("[org/local] stream error", error);
+      // Reporter, not a bare logger.error: the old call captured to Sentry
+      // unconditionally and left no typed record (this is a 200 stream).
+      failureReporter({
+        message: "[org/local] stream error",
+        error,
+        source: "web.chat-v2.org-local-stream",
+        hop: "user_server_hop",
+        transport: "http_stream",
+        context: { providerKey: provider.providerKey, modelId },
+      });
       return formatLocalStreamError(error);
     },
     onFinish: async () => {
@@ -509,6 +554,17 @@ export function handleLocalOrgChatModel(
           },
           onError: (error) => {
             if (handle!.isAborted() || isAbortError(error)) return "";
+            // toUIMessageStream CONSUMES the error (no rethrow), so the
+            // top-level onError above never sees it — this is the only
+            // chance to record it. The two sites are exclusive per error.
+            failureReporter({
+              message: "[org/local] direct stream error",
+              error,
+              source: "web.chat-v2.org-local-direct-stream",
+              hop: "user_server_hop",
+              transport: "http_stream",
+              context: { providerKey: provider.providerKey, modelId },
+            });
             return formatLocalStreamError(error);
           },
         })) {
@@ -741,6 +797,7 @@ export async function handleHostedOrgChatModel(
     scopeStepUpResume: options.scopeStepUpResume,
     progressivePlan: options.progressivePlan,
     discoveryState: options.discoveryState,
+    failureReporter: options.failureReporter,
     endpointPath: "/stream/org",
     extraBodyFields: {
       // Caller-provided fields first; sibling fields from this handler

--- a/mcpjam-inspector/server/utils/org-model-stream-handler.ts
+++ b/mcpjam-inspector/server/utils/org-model-stream-handler.ts
@@ -410,15 +410,18 @@ export function handleLocalOrgChatModel(
   } catch (configErr) {
     // The response is still a 200 stream whose first chunk is the error, so
     // the HTTP failure events never see this — the typed event is the only
-    // machine-readable record.
-    failureReporter({
-      message: "[org/local] model config/allowlist failure",
-      error: configErr,
-      source: "web.chat-v2.org-local-config",
-      hop: "user_server_hop",
-      transport: "http_stream",
-      context: { providerKey: provider.providerKey, modelId },
-    });
+    // machine-readable record. Silent-cancel invariant: skip the report when
+    // the request was already aborted before validation failed.
+    if (!options.abortSignal?.aborted) {
+      failureReporter({
+        message: "[org/local] model config/allowlist failure",
+        error: configErr,
+        source: "web.chat-v2.org-local-config",
+        hop: "user_server_hop",
+        transport: "http_stream",
+        context: { providerKey: provider.providerKey, modelId },
+      });
+    }
     const stream = createUIMessageStream({
       onError: (error) => formatLocalStreamError(error),
       onFinish: async () => {

--- a/mcpjam-inspector/server/utils/stream-failure-reporter.ts
+++ b/mcpjam-inspector/server/utils/stream-failure-reporter.ts
@@ -1,0 +1,113 @@
+import type { Context } from "hono";
+import type { NormalizedError } from "@mcpjam/sdk";
+import {
+  reportRouteFailure,
+  type RouteFailureHop,
+  type RouteFailureReport,
+} from "./route-error-report.js";
+import { getRequestLogger, getSystemLogger } from "./request-logger.js";
+
+/**
+ * The classification/emission seam for failures HTTP status cannot see —
+ * SSE `{type:"error"}` chunks after 200 headers and JSON-RPC error envelopes
+ * over HTTP 200.
+ *
+ * Why a reporter and not the Hono context: the chat engines
+ * (`mcpjam-stream-handler.ts`, `run-harness-turn.ts`) and the JSON-RPC
+ * bridge deliberately know nothing about Hono. The route layer, which does
+ * hold `c`, constructs a request-scoped reporter and passes exactly one
+ * function down; evals/swarm runs (no request context) get the system
+ * variant instead, so the engines never grow a transport dependency and no
+ * caller can silently lose events.
+ *
+ * Classification stays entirely inside `reportRouteFailure`: capture
+ * decision first (stamps the error so a later `logger.error` cannot
+ * double-page), then the free-form Axiom row, then — here — the typed
+ * `route.operation.failed` event carrying the EFFECTIVE origin the capture
+ * decision was made on.
+ */
+export type StreamFailureEvent = {
+  /** Log line for the free-form row, e.g. "[harness] turn failed". */
+  message: string;
+  /** The original error. Synthesize `new Error(text)` at status-only sites. */
+  error: unknown;
+  /** Stable catch-site id — becomes the Sentry tag `route:${source}`. */
+  source: string;
+  hop: RouteFailureHop;
+  transport: "http_stream" | "rpc_envelope";
+  /** Pass through when the site already computed it; saves a second pass. */
+  normalized?: NormalizedError;
+  errorCode?: string;
+  rpcMethod?: string;
+  /** Extra structured context for the free-form row and Sentry. */
+  context?: Record<string, unknown>;
+};
+
+export type StreamFailureReporter = (
+  event: StreamFailureEvent,
+) => RouteFailureReport;
+
+function classify(e: StreamFailureEvent): RouteFailureReport {
+  return reportRouteFailure(e.message, e.error, {
+    source: e.source,
+    hop: e.hop,
+    ...(e.normalized ? { normalized: e.normalized } : {}),
+    ...(e.context ? { context: e.context } : {}),
+  });
+}
+
+function toPayload(e: StreamFailureEvent, report: RouteFailureReport) {
+  const rawMessage =
+    e.error instanceof Error ? e.error.message : String(e.error);
+  return {
+    transport: e.transport,
+    source: e.source,
+    hop: e.hop,
+    origin: report.origin,
+    ...(report.normalized.slug ? { slug: report.normalized.slug } : {}),
+    ...(e.errorCode ? { errorCode: e.errorCode } : {}),
+    errorMessage: rawMessage.slice(0, 500),
+    ...(e.rpcMethod ? { rpcMethod: e.rpcMethod } : {}),
+  };
+}
+
+export function createRequestStreamFailureReporter(
+  c: Context,
+  component: string,
+): StreamFailureReporter {
+  const log = getRequestLogger(c, component);
+  return (e) => {
+    const report = classify(e);
+    log.event("route.operation.failed", toPayload(e, report));
+    return report;
+  };
+}
+
+export function createSystemStreamFailureReporter(
+  component: string,
+): StreamFailureReporter {
+  const log = getSystemLogger(component);
+  return (e) => {
+    const report = classify(e);
+    log.event("route.operation.failed", toPayload(e, report));
+    return report;
+  };
+}
+
+/**
+ * At most one typed event per engine invocation. A turn can hit the
+ * backend-stream failure site (which returns rather than throws) and then a
+ * later step can still throw; both failures deserve classification and a
+ * free-form row — capture is deduped by the stamp regardless — but a single
+ * turn must not count twice in the operation-failure rate the monitors read.
+ */
+export function oncePerTurn(
+  reporter: StreamFailureReporter,
+): StreamFailureReporter {
+  let emitted = false;
+  return (e) => {
+    if (emitted) return classify(e);
+    emitted = true;
+    return reporter(e);
+  };
+}

--- a/mcpjam-inspector/server/utils/stream-failure-reporter.ts
+++ b/mcpjam-inspector/server/utils/stream-failure-reporter.ts
@@ -57,8 +57,16 @@ function classify(e: StreamFailureEvent): RouteFailureReport {
 }
 
 function toPayload(e: StreamFailureEvent, report: RouteFailureReport) {
-  const rawMessage =
-    e.error instanceof Error ? e.error.message : String(e.error);
+  // Guarded extraction: a message getter or string coercion that throws
+  // (Proxy trap, null-proto object) must not lose the typed event after
+  // classification already succeeded — same precedent as
+  // reportRouteFailure's "[unreadable error value]" handling.
+  let rawMessage: string;
+  try {
+    rawMessage = e.error instanceof Error ? e.error.message : String(e.error);
+  } catch {
+    rawMessage = "[unreadable error value]";
+  }
   return {
     transport: e.transport,
     source: e.source,

--- a/mcpjam-inspector/server/utils/web-chat-turn.ts
+++ b/mcpjam-inspector/server/utils/web-chat-turn.ts
@@ -26,6 +26,7 @@
 import type { Context } from "hono";
 import { type ToolSet, type UIMessageChunk } from "ai";
 import { logger } from "./logger.js";
+import { createRequestStreamFailureReporter } from "./stream-failure-reporter.js";
 import {
   SANDBOX_NOTICE_DATA_PART_TYPE,
   type SandboxNoticeReason,
@@ -529,6 +530,11 @@ export async function streamWebChatTurn(
 ): Promise<Response> {
   const { manager, prepare, persist, runtime } = args;
   const { c } = runtime;
+  // Mid-stream failures happen after this route has already returned a 200
+  // stream, where the HTTP failure events can't see them. The request-scoped
+  // reporter gives every engine below one typed route.operation.failed path
+  // carrying the full request envelope (orgId/route/requestId/release).
+  const failureReporter = createRequestStreamFailureReporter(c, "chat");
 
   // Guard the env once at the top — both branches POST to Convex.
   if (!process.env.CONVEX_HTTP_URL) {
@@ -920,6 +926,7 @@ export async function streamWebChatTurn(
     if (orgRuntime.runtimeLocation === "local") {
       return handleLocalOrgChatModel({
         provider: orgRuntime.provider,
+        failureReporter,
         projectId: persist.projectId,
         modelId,
         chatSessionId: hostedChatSessionId,
@@ -960,6 +967,7 @@ export async function streamWebChatTurn(
 
     return handleHostedOrgChatModel({
       projectId: persist.projectId,
+      failureReporter,
       providerKey: orgRuntime.providerKey,
       modelId,
       chatSessionId: hostedChatSessionId,
@@ -1033,6 +1041,7 @@ export async function streamWebChatTurn(
 
   return handleMCPJamFreeChatModel({
     messages: modelMessages,
+    failureReporter,
     modelId: mcpjamModelId,
     provider: prepare.modelDefinition.provider,
     chatSessionId: hostedChatSessionId,


### PR DESCRIPTION
## Problem

A chat turn answers over a 200 SSE stream, so everything that fails after headers — backend `/stream` failures, engine step throws, agentic-loop crashes, harness turn failures, org-BYOK stream errors — reaches the user as a `{type:"error"}` chunk and leaves **zero rows any monitor can read**. Worse, three of those catch sites used bare `logger.error`, which captures to Sentry unconditionally (paging on user-fault failures), and one site's comment deferred capture to a stream `onError` that doesn't exist on that path — so it recorded nothing at all.

## Fix

New seam: `server/utils/stream-failure-reporter.ts`.

- Routes construct a **request-scoped** reporter (full `orgId`/`route`/`requestId`/`release` envelope) and pass exactly one function into the engine options; evals/swarm runs fall back to a **system** reporter so no caller can silently lose events. The engines never learn about Hono.
- Classification stays entirely inside `reportRouteFailure`: capture decision first (Sentry stamp), free-form row second, typed `route.operation.failed` event last — carrying the **effective** origin the capture decision was made on, the same axis as `http.request.failed.origin`.
- `oncePerTurn` caps the typed event at one per engine invocation; later failures in the same turn still classify (capture-deduped) and keep their free-form rows.
- Aborts emit nothing, preserved at every site.
- No double-count with the HTTP events is structural: the middleware's streaming branch returns before `http.request.failed`/`completed`, so a request gets one family or the other.

Site changes (replace, never add alongside): backend-stream failure keeps its exact capture semantics (same `route:`-prefixed Sentry tag, same conditional internal boundary, now via `hop`) and gains the typed event; the engine-step catch is newly recorded (the real hole); agentic-loop, harness-turn, and org-local bare `logger.error` calls become classify-first; org-local's inner `toUIMessageStream.onError` (which consumes errors without rethrow) and the config-failure stream gain reports; the tool-approval-unsupported literal deliberately does not (declared limitation).

Wire contract untouched: `{type:"error", errorText}` exactly — pinned by the engine suite's existing snapshot tests plus a key-set assertion in the new suite. `chat.session.persist.failed`'s product-surface `origin` field is now documented as a different axis that must never be joined with this one in APL.

## Tests

- `engine-failure-telemetry.test.ts` (new): one reporter call + one error chunk per failure; backend transport failure → `mcpjam_internal` hop; recognized user-owned denial (`user_rate_limit` over 200 JSON) → `user_server_hop`; abort → zero of both; unexpected throw → agentic-loop site.
- `stream-failure-reporter.test.ts` (new): classify-first ordering, effective-origin passthrough, 500-char cap, system-adapter routing, `oncePerTurn` semantics, omitted-not-fabricated fields.
- Full adjacent sweep green: stream-handler (51), snapshot/MRTR/scope-step-up, harness-turn suites, org-model config, assistant-turn, chat-v2 route suites — 240+ tests.

Part of the #mcpjam-alerts observability program (streaming-failure telemetry, PR 2/3). Unblocks half of the M2 MCPJam-fault monitor's coverage requirement.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches many failure paths in the core chat streaming stack; misclassification or double-counting could affect alerts, though abort guards and HTTP-vs-stream separation are explicitly designed to prevent that.
> 
> **Overview**
> Chat turns that return **200 SSE** used to surface failures only as `{type:"error"}` chunks, with no monitorable log row and several paths calling bare `logger.error` (unconditional Sentry) or skipping capture entirely.
> 
> This PR adds **`stream-failure-reporter.ts`**: routes build a request-scoped reporter (`createRequestStreamFailureReporter`) and pass it into MCPJam free chat, org local/hosted handlers, web chat, harness turns, and the main stream engine. Classification still goes through **`reportRouteFailure`**; the reporter then emits **`route.operation.failed`** with effective **origin**, hop, source, and transport. **`oncePerTurn`** limits one typed event per turn; aborts emit nothing. Backend `/stream` failures now report via the reporter (transport → `mcpjam_internal` hop; recognized user denials like `user_rate_limit` → `user_server_hop`) instead of ad-hoc `maybeCaptureOriginError`. Engine-step, agentic-loop, harness, and org-local stream/config errors are wired the same way.
> 
> **`log-events.ts`** registers the new event on request and system maps. SSE wire shape is unchanged. New unit tests cover the reporter and engine telemetry (including abort silence and hop split).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1ab3c4bd3c258b0a48e644477a15bb68b5d370f0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Emits typed `route.operation.failed` for mid‑stream chat failures and removes bare `logger.error` paging. Previously, errors after 200 SSE headers surfaced only as `{type:"error"}` and sometimes paged Sentry; now we classify once per turn, emit a typed event with effective origin, and keep the SSE wire unchanged.

- Adds `server/utils/stream-failure-reporter.ts` with request‑scoped and system reporters, classification‑first via `reportRouteFailure`, a once‑per‑turn guard, a 500‑char `errorMessage` cap, and a fallback for unstringifiable errors.
- Registers `route.operation.failed` in both request and system event maps; origin comes from the capture decision; hop is `mcpjam_internal` for transport failures and `user_server_hop` for recognized user denials.
- Threads a reporter from routes (`chat-v2`, `web-chat-turn`) through engines and handlers (`assistant-turn`, `mcpjam-stream-handler`, `run-harness-turn`, `org-model-stream-handler`); reports at backend `/stream`, engine‑step, agentic‑loop, org‑local config/stream/direct‑stream; tool‑approval unsupported remains unreported.
- Adds abort guards at reporter sites (backend‑stream, engine‑step, org‑local config) so canceled turns emit no events; avoids double‑count with `http.request.*` because streaming returns before those events.

**Rollout and tests**
- No migration required; system reporter covers non‑route callers.
- Tests: `engine-failure-telemetry` (single report per failure, abort silence, hop split, wire shape), `stream-failure-reporter` (classification‑first, unreadable‑error fallback, 500‑char cap, once‑per‑turn, system routing), updated stream handler tests.

<sup>Written for commit 1ab3c4bd3c258b0a48e644477a15bb68b5d370f0. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/MCPJam/inspector/pull/4002?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

