### PR TITLE
feat(observability): report JSON-RPC-over-200 bridge failures as route.operation.failed

### DIFF
--- a/mcpjam-inspector/server/routes/mcp/chat-v2.ts
+++ b/mcpjam-inspector/server/routes/mcp/chat-v2.ts
@@ -27,6 +27,7 @@ import {
   handleHostedOrgChatModel,
   handleLocalOrgChatModel,
 } from "../../utils/org-model-stream-handler.js";
+import { createRequestStreamFailureReporter } from "../../utils/stream-failure-reporter.js";
 import {
   deriveOrgProviderKey,
   isLocalRuntimeEligible,
@@ -1395,6 +1396,7 @@ chatV2.post("/", async (c) => {
 
       return handleMCPJamFreeChatModel({
         messages: modelMessages as ModelMessage[],
+        failureReporter: createRequestStreamFailureReporter(c, "chat"),
         modelId: String(modelDefinition.id),
         provider: modelDefinition.provider,
         systemPrompt: effectiveEnhancedSystemPrompt,
@@ -1612,6 +1614,7 @@ chatV2.post("/", async (c) => {
       if (runtime.runtimeLocation === "local") {
         return handleLocalOrgChatModel({
           provider: runtime.provider,
+          failureReporter: createRequestStreamFailureReporter(c, "chat"),
           projectId: body.projectId,
           modelId,
           chatSessionId,
@@ -1650,6 +1653,7 @@ chatV2.post("/", async (c) => {
 
       return handleHostedOrgChatModel({
         projectId: body.projectId,
+        failureReporter: createRequestStreamFailureReporter(c, "chat"),
         providerKey,
         modelId,
         messages: modelMessages,

--- a/mcpjam-inspector/server/routes/mcp/http-adapters.ts
+++ b/mcpjam-inspector/server/routes/mcp/http-adapters.ts
@@ -11,6 +11,7 @@ import {
 } from "../../services/tunnel-registry";
 import { recordTunnelRequest } from "../../services/tunnel-request-log";
 import { getRequestLogger } from "../../utils/request-logger";
+import { createRequestStreamFailureReporter } from "../../utils/stream-failure-reporter.js";
 import { verifyHarnessProxyToken } from "../../utils/harness/harness-proxy-token";
 import {
   HARNESS_SCOPE_STEP_UP_CORRELATION_HEADER,
@@ -377,6 +378,10 @@ function createHttpHandler(mode: BridgeMode, routePrefix: string) {
             readScopeStepUpCorrelationId(c),
             context,
           ),
+        // Bridge failures leave here as HTTP 200 JSON-RPC error envelopes,
+        // invisible to http.request.failed — the reporter is their only
+        // typed record.
+        failureReporter: createRequestStreamFailureReporter(c, "mcp-bridge"),
       },
     );
     if (!response) {
@@ -446,6 +451,9 @@ function createHttpHandler(mode: BridgeMode, routePrefix: string) {
               readScopeStepUpCorrelationId(c) ?? sess.scopeStepUpCorrelationId,
               context,
             ),
+          // Doubly invisible on this transport: the JSON-RPC error goes out
+          // over the SSE session while HTTP answers 202 Accepted.
+          failureReporter: createRequestStreamFailureReporter(c, "mcp-bridge"),
         },
       );
       // If there is a JSON-RPC response, emit it over SSE to the client

--- a/mcpjam-inspector/server/routes/web/harness-mcp.ts
+++ b/mcpjam-inspector/server/routes/web/harness-mcp.ts
@@ -47,6 +47,7 @@ import {
   publishHarnessScopeStepUp,
 } from "../../utils/harness/harness-scope-step-up.js";
 import { scopeStepUpInfoFromToolError } from "../../utils/insufficient-scope-step-up.js";
+import { createRequestStreamFailureReporter } from "../../utils/stream-failure-reporter.js";
 
 const harnessMcp = new Hono();
 
@@ -263,6 +264,12 @@ async function handle(c: any) {
       ),
       (manager) =>
         handleJsonRpc(serverId, body, manager, "adapter", {
+          // Bridge failures answer 200 with a JSON-RPC error envelope —
+          // invisible to http.request.failed; this is their typed record.
+          failureReporter: createRequestStreamFailureReporter(
+            c,
+            "harness-mcp",
+          ),
           onToolCallError: async (context) => {
             const info = scopeStepUpInfoFromToolError(context);
             if (!info) return;
@@ -316,11 +323,23 @@ async function handle(c: any) {
     if (!response) return c.body("Accepted", 202);
     return c.json(response);
   } catch (e: any) {
-    // Log the real cause server-side, but NEVER leak internal exception text to
-    // the sandbox — return a generic JSON-RPC error so the client can recover.
-    logger.error(
-      `[harness-mcp] proxy error serverId=${serverId}: ${e?.message ?? e}`
-    );
+    // Report the real cause server-side (classified — the old bare
+    // logger.error paged Sentry unconditionally), but NEVER leak internal
+    // exception text to the sandbox — return a generic JSON-RPC error so the
+    // client can recover. HTTP status stays 200, so this reporter call is
+    // the failure's only typed record.
+    try {
+      createRequestStreamFailureReporter(c, "harness-mcp")({
+        message: `[harness-mcp] proxy error serverId=${serverId}`,
+        error: e,
+        source: "web.harness-mcp.proxy",
+        hop: "user_server_hop",
+        transport: "rpc_envelope",
+        context: { serverId },
+      });
+    } catch {
+      // Telemetry must never change the masked response.
+    }
     return c.json(
       {
         jsonrpc: "2.0",

--- a/mcpjam-inspector/server/routes/web/harness-mcp.ts
+++ b/mcpjam-inspector/server/routes/web/harness-mcp.ts
@@ -335,6 +335,9 @@ async function handle(c: any) {
         source: "web.harness-mcp.proxy",
         hop: "user_server_hop",
         transport: "rpc_envelope",
+        // The masked response below is always a -32000; carry it so these
+        // stay queryable alongside the bridge's own failures.
+        errorCode: "-32000",
         context: { serverId },
       });
     } catch {

--- a/mcpjam-inspector/server/services/__tests__/mcp-http-bridge.test.ts
+++ b/mcpjam-inspector/server/services/__tests__/mcp-http-bridge.test.ts
@@ -130,6 +130,48 @@ describe("handleJsonRpc failure telemetry", () => {
     expect(calls[0].rpcMethod).toBe("resources/subscribe");
   });
 
+  it("attributes a prefixed tools/call to the server that actually ran it", async () => {
+    const { reporter, calls } = makeReporter();
+    await handleJsonRpc(
+      "srv-1",
+      {
+        id: 10,
+        method: "tools/call",
+        params: { name: "other-server:boom", arguments: {} },
+      },
+      failingManager({ hasServer: vi.fn().mockReturnValue(true) }),
+      "adapter",
+      { failureReporter: reporter },
+    );
+    expect(calls).toHaveLength(1);
+    expect(calls[0].context).toMatchObject({
+      serverId: "srv-1",
+      targetServerId: "other-server",
+    });
+  });
+
+  it("an UPSTREAM -32601 through the passthrough is a declared outcome — no report", async () => {
+    const { reporter, calls } = makeReporter();
+    const manager = failingManager({
+      getManagedClient: vi.fn().mockReturnValue({
+        request: vi
+          .fn()
+          .mockRejectedValue(
+            Object.assign(new Error("Method not found"), { code: -32601 }),
+          ),
+      }),
+    });
+    const response = await handleJsonRpc(
+      "srv-1",
+      { id: 11, method: "tasks/list", params: {} },
+      manager,
+      "adapter",
+      { failureReporter: reporter },
+    );
+    expect(response.error.code).toBe(-32000);
+    expect(calls).toHaveLength(0);
+  });
+
   it("-32601 method-not-implemented is a declared client outcome — no report", async () => {
     const { reporter, calls } = makeReporter();
     const response = await handleJsonRpc(

--- a/mcpjam-inspector/server/services/__tests__/mcp-http-bridge.test.ts
+++ b/mcpjam-inspector/server/services/__tests__/mcp-http-bridge.test.ts
@@ -1,0 +1,198 @@
+/**
+ * Bridge failure telemetry: every real `handleJsonRpc` failure leaves the
+ * process as HTTP 200 (a JSON-RPC error envelope, or manager-mode's success
+ * envelope with `isError: true`), so `http.request.failed` never sees it.
+ * The injected `failureReporter` is its only typed record — and it must
+ * NEVER change the JSON-RPC response, which is what most of these pin.
+ */
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  handleJsonRpc,
+  parseAndValidateJsonRpc,
+} from "../mcp-http-bridge";
+import type { StreamFailureEvent } from "../../utils/stream-failure-reporter";
+
+function makeReporter() {
+  const calls: StreamFailureEvent[] = [];
+  const reporter = vi.fn((e: StreamFailureEvent) => {
+    calls.push(e);
+    return {
+      normalized: e.normalized ?? ({ slug: "internal/unknown" } as any),
+      origin: "user_server" as const,
+    };
+  });
+  return { reporter, calls };
+}
+
+function failingManager(over: Record<string, unknown> = {}) {
+  return {
+    getManagedClient: vi.fn().mockReturnValue(undefined),
+    hasServer: vi.fn().mockReturnValue(false),
+    listTools: vi.fn(),
+    executeTool: vi.fn().mockRejectedValue(new Error("tool blew up")),
+    readResource: vi.fn().mockRejectedValue(new Error("resource gone")),
+    getPrompt: vi.fn().mockRejectedValue(new Error("prompt gone")),
+    ...over,
+  } as any;
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("handleJsonRpc failure telemetry", () => {
+  it("manager-mode tools/call: reports once AND keeps the success+isError envelope", async () => {
+    const { reporter, calls } = makeReporter();
+    const response = await handleJsonRpc(
+      "srv-1",
+      { id: 1, method: "tools/call", params: { name: "boom", arguments: {} } },
+      failingManager(),
+      "manager",
+      { failureReporter: reporter },
+    );
+
+    // The envelope the plan calls "a failure invisible to both HTTP status
+    // and JSON-RPC error accounting" — byte-identical to before.
+    expect(response).toEqual({
+      jsonrpc: "2.0",
+      id: 1,
+      result: {
+        content: [{ type: "text", text: "Error: tool blew up" }],
+        isError: true,
+      },
+    });
+
+    expect(calls).toHaveLength(1);
+    expect(calls[0]).toMatchObject({
+      source: "mcp.bridge.rpc",
+      hop: "user_server_hop",
+      transport: "rpc_envelope",
+      rpcMethod: "tools/call",
+      errorCode: "-32000",
+    });
+    expect(calls[0].normalized).toBeDefined();
+  });
+
+  it("adapter-mode tools/call: envelope unchanged, one report", async () => {
+    const { reporter, calls } = makeReporter();
+    const response = await handleJsonRpc(
+      "srv-1",
+      { id: 2, method: "tools/call", params: { name: "boom", arguments: {} } },
+      failingManager(),
+      "adapter",
+      { failureReporter: reporter },
+    );
+
+    expect(response.error.code).toBe(-32000);
+    expect(response.error.message).toBe("tool blew up");
+    expect(response.error.data.normalized).toBeDefined();
+    expect(calls).toHaveLength(1);
+  });
+
+  it("resources/read and prompts/get report with their method names", async () => {
+    const { reporter, calls } = makeReporter();
+    await handleJsonRpc(
+      "srv-1",
+      { id: 3, method: "resources/read", params: { uri: "x://y" } },
+      failingManager(),
+      "adapter",
+      { failureReporter: reporter },
+    );
+    await handleJsonRpc(
+      "srv-1",
+      { id: 4, method: "prompts/get", params: { name: "p" } },
+      failingManager(),
+      "adapter",
+      { failureReporter: reporter },
+    );
+    expect(calls.map((c) => c.rpcMethod)).toEqual([
+      "resources/read",
+      "prompts/get",
+    ]);
+  });
+
+  it("passthrough failures report under the forwarded method", async () => {
+    const { reporter, calls } = makeReporter();
+    const manager = failingManager({
+      getManagedClient: vi.fn().mockReturnValue({
+        request: vi.fn().mockRejectedValue(new Error("upstream refused")),
+      }),
+    });
+    const response = await handleJsonRpc(
+      "srv-1",
+      { id: 5, method: "resources/subscribe", params: {} },
+      manager,
+      "adapter",
+      { failureReporter: reporter },
+    );
+    expect(response.error.code).toBe(-32000);
+    expect(calls).toHaveLength(1);
+    expect(calls[0].rpcMethod).toBe("resources/subscribe");
+  });
+
+  it("-32601 method-not-implemented is a declared client outcome — no report", async () => {
+    const { reporter, calls } = makeReporter();
+    const response = await handleJsonRpc(
+      "srv-1",
+      { id: 6, method: "no/such-method", params: {} },
+      failingManager(),
+      "adapter",
+      { failureReporter: reporter },
+    );
+    expect(response.error.code).toBe(-32601);
+    expect(calls).toHaveLength(0);
+  });
+
+  it("notifications produce no response and no report", async () => {
+    const { reporter, calls } = makeReporter();
+    const response = await handleJsonRpc(
+      "srv-1",
+      { method: "notifications/initialized" },
+      failingManager(),
+      "adapter",
+      { failureReporter: reporter },
+    );
+    expect(response).toBeNull();
+    expect(calls).toHaveLength(0);
+  });
+
+  it("a throwing reporter never alters the JSON-RPC response", async () => {
+    const reporter = vi.fn(() => {
+      throw new Error("telemetry sink down");
+    });
+    const response = await handleJsonRpc(
+      "srv-1",
+      { id: 7, method: "tools/call", params: { name: "boom", arguments: {} } },
+      failingManager(),
+      "adapter",
+      { failureReporter: reporter as any },
+    );
+    expect(response.error.code).toBe(-32000);
+    expect(response.error.message).toBe("tool blew up");
+  });
+
+  it("works identically with no reporter injected", async () => {
+    const response = await handleJsonRpc(
+      "srv-1",
+      { id: 8, method: "tools/call", params: { name: "boom", arguments: {} } },
+      failingManager(),
+      "adapter",
+    );
+    expect(response.error.code).toBe(-32000);
+  });
+});
+
+describe("parse-path stays report-free", () => {
+  it("a parse error is already visible as a 4xx row — never a report", async () => {
+    // The reporter never reaches parseAndValidateJsonRpc at all (it has no
+    // options), which IS the design: this test documents the boundary.
+    const validation = await parseAndValidateJsonRpc(() =>
+      Promise.reject(new SyntaxError("bad json")),
+    );
+    expect(validation.ok).toBe(false);
+    if (!validation.ok) {
+      expect(validation.status).toBe(400);
+      expect(validation.response.error.code).toBe(-32700);
+    }
+  });
+});

--- a/mcpjam-inspector/server/services/mcp-http-bridge.ts
+++ b/mcpjam-inspector/server/services/mcp-http-bridge.ts
@@ -1,5 +1,7 @@
 import { MCPClientManager, describeError } from "@mcpjam/sdk";
+import type { NormalizedError } from "@mcpjam/sdk";
 import { z } from "zod";
+import type { StreamFailureReporter } from "../utils/stream-failure-reporter.js";
 
 // Unify JSON-RPC handling used by adapter-http and manager-http routes
 // while preserving their minor response-shape differences.
@@ -18,6 +20,15 @@ export type JsonRpcBridgeOptions = {
     toolName?: string;
     toolInput?: unknown;
   }) => void | Promise<void>;
+  /**
+   * Typed-telemetry seam: every real bridge failure leaves this process as
+   * an HTTP 200 carrying a JSON-RPC error envelope (or, in manager mode, a
+   * success envelope with `isError: true`), so `http.request.failed` never
+   * sees it. The reporter records it as `route.operation.failed`. Reporter
+   * failures are isolated exactly like `onToolCallError` — telemetry can
+   * never change the JSON-RPC response.
+   */
+  failureReporter?: StreamFailureReporter;
 };
 
 type JsonRpcBody = {
@@ -183,6 +194,34 @@ export async function handleJsonRpc(
 
   const respond = (payload: any) => ({ jsonrpc: "2.0", id, ...payload });
 
+  // One call per failed operation. `hop: "user_server_hop"` at every site:
+  // the bridge is a proxy into the user's own MCP server, so the catalog's
+  // verdict stands and only MCPJam-positive slugs escalate. Parse/Invalid-
+  // Request 400s deliberately do NOT report (already visible as 4xx rows),
+  // nor does -32601 Method-not-implemented (a declared client outcome).
+  const reportOperationFailure = (
+    error: unknown,
+    rpcMethod: string,
+    normalized?: NormalizedError,
+    context?: Record<string, unknown>,
+  ) => {
+    try {
+      options.failureReporter?.({
+        message: `[mcp-bridge] ${rpcMethod} failed`,
+        error,
+        source: "mcp.bridge.rpc",
+        hop: "user_server_hop",
+        transport: "rpc_envelope",
+        ...(normalized ? { normalized } : {}),
+        errorCode: "-32000",
+        rpcMethod,
+        context: { serverId, mode, ...(context ?? {}) },
+      });
+    } catch {
+      // Telemetry must never alter the JSON-RPC response.
+    }
+  };
+
   try {
     switch (method) {
       case "ping":
@@ -275,6 +314,15 @@ export async function handleJsonRpc(
             // Observation-only: never turn a side-channel failure into an MCP
             // tool failure different from the upstream error.
           }
+          const normalized = describeError(e);
+          // In the SHARED catch, before the mode branch, deliberately:
+          // manager mode answers with a SUCCESS envelope carrying
+          // `isError: true` — a failure invisible to HTTP status AND to
+          // JSON-RPC error accounting — and it must count exactly like the
+          // adapter-mode -32000.
+          reportOperationFailure(e, "tools/call", normalized, {
+            ...(observedToolName ? { toolName: observedToolName } : {}),
+          });
           if (mode === "manager") {
             const result = {
               content: [
@@ -288,7 +336,7 @@ export async function handleJsonRpc(
             error: {
               code: -32000,
               message: e?.message || String(e),
-              data: { normalized: describeError(e) },
+              data: { normalized },
             },
           });
         }
@@ -332,11 +380,13 @@ export async function handleJsonRpc(
           // adapter mode returns raw content
           return respond({ result: resource });
         } catch (e: any) {
+          const normalized = describeError(e);
+          reportOperationFailure(e, "resources/read", normalized);
           return respond({
             error: {
               code: -32000,
               message: e?.message || String(e),
-              data: { normalized: describeError(e) },
+              data: { normalized },
             },
           });
         }
@@ -375,11 +425,13 @@ export async function handleJsonRpc(
           // adapter mode returns raw content
           return respond({ result: prompt });
         } catch (e: any) {
+          const normalized = describeError(e);
+          reportOperationFailure(e, "prompts/get", normalized);
           return respond({
             error: {
               code: -32000,
               message: e?.message || String(e),
-              data: { normalized: describeError(e) },
+              data: { normalized },
             },
           });
         }
@@ -401,11 +453,13 @@ export async function handleJsonRpc(
             const result = await managed.request({ method, params } as any);
             return respond({ result: result ?? {} });
           } catch (e: any) {
+            const normalized = describeError(e);
+            reportOperationFailure(e, method, normalized);
             return respond({
               error: {
                 code: -32000,
                 message: e?.message || String(e),
-                data: { normalized: describeError(e) },
+                data: { normalized },
               },
             });
           }
@@ -421,11 +475,13 @@ export async function handleJsonRpc(
       }
     }
   } catch (e: any) {
+    const normalized = describeError(e);
+    reportOperationFailure(e, method, normalized);
     return respond({
       error: {
         code: -32000,
         message: e?.message || String(e),
-        data: { normalized: describeError(e) },
+        data: { normalized },
       },
     });
   }

--- a/mcpjam-inspector/server/services/mcp-http-bridge.ts
+++ b/mcpjam-inspector/server/services/mcp-http-bridge.ts
@@ -206,6 +206,13 @@ export async function handleJsonRpc(
     context?: Record<string, unknown>,
   ) => {
     try {
+      // An UPSTREAM -32601 (the connected server rejecting an unknown
+      // method, surfaced through the passthrough or outer catch) is the same
+      // declared client outcome as our own -32601 short-circuit below —
+      // excluded for the same reason.
+      if ((error as { code?: unknown } | undefined)?.code === -32601) {
+        return;
+      }
       options.failureReporter?.({
         message: `[mcp-bridge] ${rpcMethod} failed`,
         error,
@@ -322,6 +329,10 @@ export async function handleJsonRpc(
           // adapter-mode -32000.
           reportOperationFailure(e, "tools/call", normalized, {
             ...(observedToolName ? { toolName: observedToolName } : {}),
+            // A prefixed name ("otherServer:tool") reroutes the call; the
+            // failure belongs to the server that actually executed it, not
+            // the one in the URL.
+            targetServerId,
           });
           if (mode === "manager") {
             const result = {

--- a/mcpjam-inspector/server/utils/__tests__/engine-failure-telemetry.test.ts
+++ b/mcpjam-inspector/server/utils/__tests__/engine-failure-telemetry.test.ts
@@ -199,6 +199,26 @@ describe("engine failure telemetry", () => {
     expect(errorChunks()).toHaveLength(0);
   });
 
+  it("stays silent when a NON-abort error lands after the signal fired", async () => {
+    // Exercises the `abortSignal?.aborted` arm, not the error-shape arm: the
+    // rejection is a plain TypeError, so only the engine actually consulting
+    // the signal keeps this silent. Catches a regression where the engine
+    // stops listening to abortSignal entirely.
+    const controller = new AbortController();
+    global.fetch = vi.fn().mockImplementation(() => {
+      controller.abort();
+      return Promise.reject(new TypeError("socket hang up"));
+    });
+    const { reporter, calls } = makeReporter();
+
+    await runTurn({
+      failureReporter: reporter,
+      abortSignal: controller.signal,
+    });
+
+    expect(calls).toHaveLength(0);
+  });
+
   it("reports an unexpected engine throw via the agentic-loop site", async () => {
     global.fetch = vi
       .fn()

--- a/mcpjam-inspector/server/utils/__tests__/engine-failure-telemetry.test.ts
+++ b/mcpjam-inspector/server/utils/__tests__/engine-failure-telemetry.test.ts
@@ -1,0 +1,215 @@
+/**
+ * Mid-stream failures must produce exactly one typed telemetry call — and
+ * aborts must produce none.
+ *
+ * The chat engine answers over a 200 SSE stream, so the HTTP failure events
+ * never see anything that goes wrong after headers. `failureReporter`
+ * (stream-failure-reporter.ts) is the seam that records those failures as
+ * `route.operation.failed`. This suite drives `handleMCPJamFreeChatModel`
+ * with the same mocked-backend harness as the SSE snapshot test and pins:
+ *   - one reporter call + one `{type:"error"}` wire chunk per failure
+ *   - the backend-stream site's hop split (transport failure vs recognized
+ *     user-owned denial)
+ *   - aborts stay silent in both directions
+ *   - the wire error chunk shape is unchanged (client contract)
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  executeToolCallsFromMessages,
+  hasUnresolvedToolCalls,
+} from "@/shared/http-tool-calls";
+import { handleMCPJamFreeChatModel } from "../mcpjam-stream-handler";
+import type {
+  StreamFailureEvent,
+  StreamFailureReporter,
+} from "../stream-failure-reporter";
+
+let lastExecution: Promise<void> | null = null;
+let writtenChunks: any[] = [];
+
+vi.mock("ai", async () => {
+  const actual = await vi.importActual<typeof import("ai")>("ai");
+  return {
+    ...actual,
+    createUIMessageStream: vi.fn(({ execute, onFinish }) => {
+      const writer = {
+        write: vi.fn((chunk) => {
+          writtenChunks.push(chunk);
+        }),
+      };
+      lastExecution = Promise.resolve(execute({ writer })).then(async () => {
+        await onFinish?.();
+      });
+      return { getReader: vi.fn() };
+    }),
+    createUIMessageStreamResponse: vi.fn().mockReturnValue(
+      new Response("{}", {
+        headers: { "Content-Type": "text/event-stream" },
+      }),
+    ),
+  };
+});
+
+vi.mock("@/shared/http-tool-calls", () => ({
+  hasUnresolvedToolCalls: vi.fn(),
+  executeToolCallsFromMessages: vi.fn(),
+}));
+
+vi.mock("../mcpjam-tool-helpers", () => ({
+  serializeToolsForConvex: vi.fn(() => []),
+}));
+
+vi.mock("../logger", () => ({
+  logger: {
+    error: vi.fn(),
+    warn: vi.fn(),
+    info: vi.fn(),
+    event: vi.fn(),
+    systemEvent: vi.fn(),
+  },
+}));
+
+vi.mock("@sentry/node", () => ({
+  captureException: vi.fn(),
+  captureMessage: vi.fn(),
+}));
+
+function makeReporter(): {
+  reporter: StreamFailureReporter;
+  calls: StreamFailureEvent[];
+} {
+  const calls: StreamFailureEvent[] = [];
+  const reporter: StreamFailureReporter = (e) => {
+    calls.push(e);
+    return {
+      normalized: e.normalized ?? ({ slug: "internal/unknown" } as any),
+      origin: "ambiguous",
+    };
+  };
+  return { reporter, calls };
+}
+
+function errorChunks() {
+  return writtenChunks.filter((c) => c?.type === "error");
+}
+
+async function runTurn(overrides: Record<string, unknown> = {}) {
+  await handleMCPJamFreeChatModel({
+    messages: [{ role: "user", content: "Hi." }] as any,
+    modelId: "openai/gpt-oss-120b",
+    systemPrompt: "You are helpful",
+    tools: {},
+    mcpClientManager: {
+      getAllToolsMetadata: vi.fn().mockReturnValue({}),
+      listServers: vi.fn().mockReturnValue([]),
+    } as any,
+    heartbeatIntervalMs: 0,
+    ...overrides,
+  } as any);
+  await lastExecution;
+}
+
+describe("engine failure telemetry", () => {
+  const originalFetch = global.fetch;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    lastExecution = null;
+    writtenChunks = [];
+    process.env.CONVEX_HTTP_URL = "https://test-convex.example.com";
+    vi.mocked(hasUnresolvedToolCalls).mockReturnValue(false);
+    vi.mocked(executeToolCallsFromMessages).mockResolvedValue([]);
+  });
+
+  afterEach(() => {
+    global.fetch = originalFetch;
+    delete process.env.CONVEX_HTTP_URL;
+  });
+
+  it("reports a backend /stream transport failure once, with the internal hop", async () => {
+    global.fetch = vi
+      .fn()
+      .mockResolvedValue(new Response("Bad Gateway", { status: 502 }));
+    const { reporter, calls } = makeReporter();
+
+    await runTurn({ failureReporter: reporter });
+
+    expect(calls).toHaveLength(1);
+    expect(calls[0]).toMatchObject({
+      source: "mcp.chat-v2.backend-stream",
+      hop: "mcpjam_internal",
+      transport: "http_stream",
+    });
+    // The site classifies from the response itself and passes it through so
+    // the reporter never re-derives.
+    expect(calls[0].normalized).toBeDefined();
+    expect(calls[0].context).toMatchObject({ httpStatus: 502 });
+
+    // Exactly one error chunk on the wire, exact client contract shape.
+    const chunks = errorChunks();
+    expect(chunks).toHaveLength(1);
+    expect(Object.keys(chunks[0]).sort()).toEqual(["errorText", "type"]);
+  });
+
+  it("keeps a recognized user-owned denial on the user hop", async () => {
+    // HTTP 200 + JSON body = the backend working correctly and refusing for
+    // a user-owned reason. It must still be recorded (the turn failed from
+    // the user's seat) but on the user hop, so it can never promote to a
+    // page.
+    global.fetch = vi.fn().mockResolvedValue(
+      new Response(
+        JSON.stringify({
+          ok: false,
+          code: "user_rate_limit",
+          error: "Daily limit reached",
+        }),
+        { status: 200, headers: { "Content-Type": "application/json" } },
+      ),
+    );
+    const { reporter, calls } = makeReporter();
+
+    await runTurn({ failureReporter: reporter });
+
+    expect(calls).toHaveLength(1);
+    expect(calls[0]).toMatchObject({
+      source: "mcp.chat-v2.backend-stream",
+      hop: "user_server_hop",
+      errorCode: "user_rate_limit",
+    });
+  });
+
+  it("stays completely silent on abort — no report, no error chunk", async () => {
+    const controller = new AbortController();
+    global.fetch = vi.fn().mockImplementation(() => {
+      controller.abort();
+      return Promise.reject(
+        Object.assign(new Error("This operation was aborted"), {
+          name: "AbortError",
+        }),
+      );
+    });
+    const { reporter, calls } = makeReporter();
+
+    await runTurn({
+      failureReporter: reporter,
+      abortSignal: controller.signal,
+    });
+
+    expect(calls).toHaveLength(0);
+    expect(errorChunks()).toHaveLength(0);
+  });
+
+  it("reports an unexpected engine throw via the agentic-loop site", async () => {
+    global.fetch = vi
+      .fn()
+      .mockRejectedValue(new TypeError("fetch failed: ECONNRESET"));
+    const { reporter, calls } = makeReporter();
+
+    await runTurn({ failureReporter: reporter });
+
+    expect(calls).toHaveLength(1);
+    expect(calls[0].source).toBe("mcp.chat-v2.agentic-loop");
+    expect(calls[0].transport).toBe("http_stream");
+    expect(errorChunks()).toHaveLength(1);
+  });
+});

--- a/mcpjam-inspector/server/utils/__tests__/mcpjam-stream-handler.test.ts
+++ b/mcpjam-inspector/server/utils/__tests__/mcpjam-stream-handler.test.ts
@@ -84,6 +84,12 @@ vi.mock("../logger", () => ({
     // catch-block-doesn't-propagate test would have validated against
     // a mock-shape side effect instead of the real behavior).
     warn: vi.fn(),
+    // The failure-reporter fallback (`createSystemStreamFailureReporter`)
+    // emits the typed route.operation.failed row through the system logger
+    // on every engine failure path; without `systemEvent` the reporter call
+    // would TypeError inside the catch instead of reaching the assertions.
+    systemEvent: vi.fn(),
+    event: vi.fn(),
   },
   // `error-origin-capture` routes its Sentry capture through the logger
   // module, so this mock has to carry it or the backend-failure paths below

--- a/mcpjam-inspector/server/utils/__tests__/stream-failure-reporter.test.ts
+++ b/mcpjam-inspector/server/utils/__tests__/stream-failure-reporter.test.ts
@@ -1,0 +1,100 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("../route-error-report.js", () => ({
+  reportRouteFailure: vi.fn(() => ({
+    normalized: { slug: "transport/fetch_failed" },
+    origin: "ambiguous",
+  })),
+}));
+
+const requestEvent = vi.fn();
+const systemEvent = vi.fn();
+vi.mock("../request-logger.js", () => ({
+  getRequestLogger: vi.fn(() => ({ event: requestEvent })),
+  getSystemLogger: vi.fn(() => ({ event: systemEvent })),
+}));
+
+import { reportRouteFailure } from "../route-error-report.js";
+import {
+  createRequestStreamFailureReporter,
+  createSystemStreamFailureReporter,
+  oncePerTurn,
+  type StreamFailureEvent,
+} from "../stream-failure-reporter.js";
+
+const failure = (over: Partial<StreamFailureEvent> = {}): StreamFailureEvent => ({
+  message: "[test] turn failed",
+  error: new Error("upstream reset"),
+  source: "mcp.chat-v2.engine-step",
+  hop: "user_server_hop",
+  transport: "http_stream",
+  ...over,
+});
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("stream failure reporter", () => {
+  it("classifies first, then emits the typed event with the EFFECTIVE origin", () => {
+    const report = createRequestStreamFailureReporter({} as never, "chat")(
+      failure(),
+    );
+
+    // Classification went through reportRouteFailure (capture ordering,
+    // Sentry stamp, free-form row all live there).
+    expect(reportRouteFailure).toHaveBeenCalledTimes(1);
+    expect(report.origin).toBe("ambiguous");
+
+    expect(requestEvent).toHaveBeenCalledTimes(1);
+    const [name, payload] = requestEvent.mock.calls[0];
+    expect(name).toBe("route.operation.failed");
+    // origin comes from the capture decision's return, slug from its
+    // normalized — never re-derived here.
+    expect(payload).toMatchObject({
+      transport: "http_stream",
+      source: "mcp.chat-v2.engine-step",
+      hop: "user_server_hop",
+      origin: "ambiguous",
+      slug: "transport/fetch_failed",
+      errorMessage: "upstream reset",
+    });
+  });
+
+  it("caps the errorMessage at 500 chars", () => {
+    createRequestStreamFailureReporter({} as never, "chat")(
+      failure({ error: new Error("x".repeat(2000)) }),
+    );
+    expect(requestEvent.mock.calls[0][1].errorMessage).toHaveLength(500);
+  });
+
+  it("system variant emits through the system logger", () => {
+    createSystemStreamFailureReporter("assistant-turn")(failure());
+    expect(systemEvent).toHaveBeenCalledTimes(1);
+    expect(requestEvent).not.toHaveBeenCalled();
+  });
+
+  it("oncePerTurn emits one typed event but still classifies every failure", () => {
+    const wrapped = oncePerTurn(
+      createRequestStreamFailureReporter({} as never, "chat"),
+    );
+
+    wrapped(failure({ source: "mcp.chat-v2.backend-stream" }));
+    const second = wrapped(failure({ source: "mcp.chat-v2.agentic-loop" }));
+
+    // A single turn must not count twice in the operation-failure rate…
+    expect(requestEvent).toHaveBeenCalledTimes(1);
+    // …but the second failure still gets its capture decision and free-form
+    // row (Sentry dedupe is the stamp's job, not ours), and callers still
+    // get a usable report back.
+    expect(reportRouteFailure).toHaveBeenCalledTimes(2);
+    expect(second.origin).toBe("ambiguous");
+  });
+
+  it("omits absent optional fields rather than fabricating them", () => {
+    createRequestStreamFailureReporter({} as never, "chat")(failure());
+    const payload = requestEvent.mock.calls[0][1];
+    expect("errorCode" in payload).toBe(false);
+    expect("rpcMethod" in payload).toBe(false);
+  });
+});

--- a/mcpjam-inspector/server/utils/__tests__/stream-failure-reporter.test.ts
+++ b/mcpjam-inspector/server/utils/__tests__/stream-failure-reporter.test.ts
@@ -61,6 +61,16 @@ describe("stream failure reporter", () => {
     });
   });
 
+  it("survives an error whose string coercion throws", () => {
+    createRequestStreamFailureReporter({} as never, "chat")(
+      failure({ error: Object.create(null) }),
+    );
+    expect(requestEvent).toHaveBeenCalledTimes(1);
+    expect(requestEvent.mock.calls[0][1].errorMessage).toBe(
+      "[unreadable error value]",
+    );
+  });
+
   it("caps the errorMessage at 500 chars", () => {
     createRequestStreamFailureReporter({} as never, "chat")(
       failure({ error: new Error("x".repeat(2000)) }),

--- a/mcpjam-inspector/server/utils/assistant-turn.ts
+++ b/mcpjam-inspector/server/utils/assistant-turn.ts
@@ -173,6 +173,13 @@ export interface RunAssistantTurnOptions {
   onEngineError?: MCPJamHandlerOptions["onEngineError"];
 
   /**
+   * Typed mid-stream failure telemetry pass-through. Callers with a request
+   * context pass a request-scoped reporter; when omitted, the engine's
+   * system-reporter fallback applies (requestId: null on the emitted rows).
+   */
+  failureReporter?: MCPJamHandlerOptions["failureReporter"];
+
+  /**
    * Browser-rendered MCP App eval PR 2: per-step advertised-tool narrowing
    * pass-through. The eval runner uses this to hide `computer` /
    * `finish_widget` until a widget has rendered. Chat / synthetic omit.
@@ -459,6 +466,7 @@ function buildHandlerOptions(
     ...(opts.onStepFinish ? { onStepFinish: opts.onStepFinish } : {}),
     // PR 5b-followup-2: pass-through structured-error callback.
     ...(opts.onEngineError ? { onEngineError: opts.onEngineError } : {}),
+    ...(opts.failureReporter ? { failureReporter: opts.failureReporter } : {}),
     // Browser-rendered MCP App eval PR 2: advertised-tool narrowing hook.
     ...(opts.prepareAdvertisedTools
       ? { prepareAdvertisedTools: opts.prepareAdvertisedTools }

--- a/mcpjam-inspector/server/utils/harness/run-harness-turn.ts
+++ b/mcpjam-inspector/server/utils/harness/run-harness-turn.ts
@@ -75,6 +75,10 @@ import {
   selectDeliverableServerIds,
 } from "./plugin-delivery.js";
 import { logger } from "../logger.js";
+import {
+  createSystemStreamFailureReporter,
+  oncePerTurn,
+} from "../stream-failure-reporter.js";
 import type {
   ChatEngineLoopResult,
   MCPJamHandlerOptions,
@@ -417,6 +421,7 @@ export async function runHarnessTurn(
     onToolResult,
     onStepFinish,
     onEngineError,
+    failureReporter: failureReporterOption,
     onLiveTextDelta,
     requireToolApproval,
     chatSessionId,
@@ -435,6 +440,11 @@ export async function runHarnessTurn(
     effectiveCapabilities,
     createHarnessScopeStepUpContinuation,
   } = options;
+  // One typed route.operation.failed per turn; the system fallback covers
+  // callers with no request context (evals/swarms).
+  const failureReporter = oncePerTurn(
+    failureReporterOption ?? createSystemStreamFailureReporter("harness-turn"),
+  );
   // Canonicalize the model id up front (bare hosted ids like `gpt-5-nano` →
   // `openai/gpt-5-nano`). Everything downstream — supportsModel, the adapter's
   // toNativeModel (Codex only maps the `openai/gpt-5*` form), credential
@@ -2284,7 +2294,18 @@ export async function runHarnessTurn(
         return;
       }
       const errorText = err instanceof Error ? err.message : String(err);
-      logger.error("[harness] turn failed", err);
+      // Reporter, not a bare logger.error: the old call captured to Sentry
+      // unconditionally and left no typed record (the response is a 200
+      // stream the HTTP failure events never see). Classify first, page only
+      // on origin=mcpjam, emit route.operation.failed.
+      failureReporter({
+        message: "[harness] turn failed",
+        error: err,
+        source: "chat.harness-turn",
+        hop: "user_server_hop",
+        transport: "http_stream",
+        context: { promptIndex },
+      });
       // Close any open text block so the UI stream stays balanced.
       closeReasoning();
       if (textId !== undefined) emitTextEnd(writer, textId);

--- a/mcpjam-inspector/server/utils/log-events.ts
+++ b/mcpjam-inspector/server/utils/log-events.ts
@@ -65,6 +65,47 @@ export interface SystemLogContext extends CommonLogContext {
 
 export type BaseLogContext = RequestLogContext | SystemLogContext;
 
+/**
+ * A failure that HTTP status cannot see: an SSE `{type:"error"}` chunk after
+ * 200 headers, or a JSON-RPC error envelope returned over HTTP 200. The
+ * middleware's streaming branch returns before any `http.request.failed` /
+ * `http.request.completed` emission, so a request gets exactly one of the
+ * HTTP events OR (possibly) this one — never both. Registered in BOTH event
+ * maps: chat requests emit through `getRequestLogger` (full request
+ * envelope), while evals/swarm engine runs emit through `getSystemLogger`
+ * (`requestId: null`, omitted-not-fabricated).
+ *
+ * Emitted only via `server/utils/stream-failure-reporter.ts`, which runs
+ * `reportRouteFailure` first — so `origin` here is always the EFFECTIVE
+ * value the Sentry capture decision was made on (post `mcpjam_internal`
+ * promotion), the same axis as `http.request.failed.origin`.
+ */
+type RouteOperationFailedFields = {
+  /** How the failure was carried to the client. */
+  transport: "http_stream" | "rpc_envelope";
+  /**
+   * Stable catch-site id, e.g. "mcp.chat-v2.backend-stream". The same string
+   * `reportRouteFailure` tags Sentry with (as `route:${source}`).
+   */
+  source: string;
+  /** Whose hop failed, as declared at the call site. */
+  hop: "user_server_hop" | "mcpjam_internal";
+  /** Effective origin from the capture decision — see the doc block above. */
+  origin: ErrorOrigin;
+  /** Catalog slug behind `origin`, e.g. `transport/econnrefused`. */
+  slug?: string;
+  /**
+   * Structured code when one exists: a backend denial code
+   * ("user_rate_limit"), a JSON-RPC error code as a string ("-32000"), or a
+   * route ErrorCode. Omitted otherwise.
+   */
+  errorCode?: string;
+  /** Capped at 500 chars; scrubbed by scrubLogPayload on emit. */
+  errorMessage: string;
+  /** rpc_envelope only: the JSON-RPC method that failed ("tools/call", …). */
+  rpcMethod?: string;
+};
+
 export type RequestEventMap = {
   /**
    * 4xx responses land here, not on `http.request.failed` — a 4xx is a
@@ -158,6 +199,9 @@ export type RequestEventMap = {
     sourceType?: "chatbox" | "direct" | "eval" | "swarm";
     // Product-surface discriminator carried alongside sourceType so PostHog
     // can pivot persist failures by surface without rejoining to chatSessions.
+    // CAUTION: this `origin` is a DIFFERENT axis from the ErrorOrigin field
+    // of the same name on `http.request.failed` / `route.operation.failed` —
+    // never join the two in an APL query.
     origin?: "playground" | "mcpjam_agent" | "chatbox" | "eval" | "swarm";
   };
   "widget.resource.served": {
@@ -202,6 +246,7 @@ export type RequestEventMap = {
     statusCode: number;
     errorCode: string;
   };
+  "route.operation.failed": RouteOperationFailedFields;
 };
 
 export type SystemEventMap = {
@@ -260,6 +305,7 @@ export type SystemEventMap = {
     latencyP50Ms: number;
     latencyP95Ms: number;
   };
+  "route.operation.failed": RouteOperationFailedFields;
 };
 
 export type LogEventName = keyof RequestEventMap | keyof SystemEventMap;

--- a/mcpjam-inspector/server/utils/mcpjam-stream-handler.ts
+++ b/mcpjam-inspector/server/utils/mcpjam-stream-handler.ts
@@ -2408,21 +2408,27 @@ async function processOneStep(
     // status from our own backend, which `describeBackendStreamFailure`
     // leaves `ambiguous` because it classifies the response alone and cannot
     // know whose backend answered.
-    failureReporter({
-      message: "[mcpjam-stream-handler] backend stream failed",
-      error: new Error(parsed.message),
-      source: "mcp.chat-v2.backend-stream",
-      hop: isRecognizedDenial ? "user_server_hop" : "mcpjam_internal",
-      transport: "http_stream",
-      normalized,
-      ...(parsed.code ? { errorCode: parsed.code } : {}),
-      context: {
-        httpStatus: res.status,
-        code: parsed.code,
-        isJsonDenial,
-        isRecognizedDenial,
-      },
-    });
+    // Silent-cancel invariant: a fired abort can race this site (res.text()
+    // rejecting into the generic fallback, or the failure landing while the
+    // client is already gone). An aborted turn must not inflate the
+    // operation-failure rate.
+    if (!abortSignal?.aborted) {
+      failureReporter({
+        message: "[mcpjam-stream-handler] backend stream failed",
+        error: new Error(parsed.message),
+        source: "mcp.chat-v2.backend-stream",
+        hop: isRecognizedDenial ? "user_server_hop" : "mcpjam_internal",
+        transport: "http_stream",
+        normalized,
+        ...(parsed.code ? { errorCode: parsed.code } : {}),
+        context: {
+          httpStatus: res.status,
+          code: parsed.code,
+          isJsonDenial,
+          isRecognizedDenial,
+        },
+      });
+    }
     safelyEmitEngineError(onEngineError, {
       message: parsed.message,
       ...(parsed.code ? { code: parsed.code } : {}),
@@ -2898,18 +2904,24 @@ async function processOneStep(
       // row, and the typed route.operation.failed event (the response is a
       // 200 stream, so the HTTP failure events never see this).
       const stepNormalized = describeError(error);
-      failureReporter({
-        message: "[mcpjam-stream-handler] engine step failed",
-        error,
-        source: "mcp.chat-v2.engine-step",
-        hop: "user_server_hop",
-        transport: "http_stream",
-        normalized: stepNormalized,
-        context: {
-          promptIndex: traceTurn.promptIndex,
-          stepIndex,
-        },
-      });
+      // Same silent-cancel guard as the outer loop's catch (which checks
+      // `isAbortError(error) || abortSignal?.aborted`): a non-AbortError that
+      // lands after the signal fired belongs to a turn the client already
+      // cancelled.
+      if (!abortSignal?.aborted) {
+        failureReporter({
+          message: "[mcpjam-stream-handler] engine step failed",
+          error,
+          source: "mcp.chat-v2.engine-step",
+          hop: "user_server_hop",
+          transport: "http_stream",
+          normalized: stepNormalized,
+          context: {
+            promptIndex: traceTurn.promptIndex,
+            stepIndex,
+          },
+        });
+      }
       // PR 5b-followup-2: surface the error to `streamSink: "none"`
       // consumers (eval backend stream runner). The processStream /
       // tool-execution catch path doesn't have a structured body, so

--- a/mcpjam-inspector/server/utils/mcpjam-stream-handler.ts
+++ b/mcpjam-inspector/server/utils/mcpjam-stream-handler.ts
@@ -30,7 +30,11 @@ import {
   describeError,
   type NormalizedError,
 } from "@mcpjam/sdk";
-import { maybeCaptureOriginError } from "./error-origin-capture.js";
+import {
+  createSystemStreamFailureReporter,
+  oncePerTurn,
+  type StreamFailureReporter,
+} from "./stream-failure-reporter.js";
 import type { ModelVisibleMcpToolResults } from "@mcpjam/sdk/host-config/internal";
 import { runHarnessTurn } from "./harness/run-harness-turn.js";
 import type { TrustedHarnessSandboxBinding } from "./harness/resolve-sandbox.js";
@@ -683,6 +687,14 @@ export interface MCPJamHandlerOptions {
    */
   onEngineError?: (event: MCPJamEngineErrorEvent) => void;
   /**
+   * Typed-telemetry seam for mid-stream failures (route.operation.failed).
+   * Routes with a Hono context pass `createRequestStreamFailureReporter(c)`
+   * so the event carries the full request envelope; when absent the engine
+   * falls back to the system reporter, so no caller can silently lose
+   * events. See stream-failure-reporter.ts.
+   */
+  failureReporter?: StreamFailureReporter;
+  /**
    * Browser-rendered MCP App eval PR 2 — optional per-step hook that narrows
    * the *advertised* tool set the model sees this step. Called inside
    * `processOneStep` after the active tool subset is resolved, with
@@ -804,6 +816,9 @@ interface StepContext {
   // processOneStep, processStream/tool-execution catch, outer
   // agentic-loop catch). Optional.
   onEngineError?: (event: MCPJamEngineErrorEvent) => void;
+  // Typed mid-stream failure telemetry; threaded from runChatEngineLoop
+  // (already oncePerTurn-wrapped and fallback-resolved there).
+  failureReporter: StreamFailureReporter;
   // Browser-rendered MCP App eval PR 2: per-step advertised-tool narrowing.
   prepareAdvertisedTools?: MCPJamHandlerOptions["prepareAdvertisedTools"];
   abortSignal?: AbortSignal;
@@ -2111,6 +2126,7 @@ async function processOneStep(
     onToolResult,
     // PR 5b-followup-2 structured-error callback.
     onEngineError,
+    failureReporter,
     // Browser-rendered MCP App eval PR 2: advertised-tool narrowing hook.
     prepareAdvertisedTools,
   } = ctx;
@@ -2374,24 +2390,33 @@ async function processOneStep(
     // working correctly, so only they skip the boundary.
     const isRecognizedDenial =
       isJsonDenial && USER_OWNED_DENIAL_CODES.has(parsed.code ?? "");
-    maybeCaptureOriginError(new Error(parsed.message), normalized, {
-      source: "route:mcp.chat-v2.backend-stream",
-      // The boundary is declared for a genuine TRANSPORT failure only, and
-      // NOT for `isJsonDenial`. A denial is an HTTP 200 carrying a structured
-      // refusal (`{ok:false, code:"user_rate_limit"}`) — the backend working
-      // correctly, and a routine, user-owned outcome. Promoting it would page
-      // the team on every ordinary spend-limit rejection, which is precisely
-      // the noise class this work removes.
-      //
-      // On a real failure the declaration earns its place twice: it tags the
-      // event with the boundary the rest of the codebase triages on, and it
-      // escalates an unrecognized status from our own backend, which
-      // `describeBackendStreamFailure` leaves `ambiguous` because it
-      // classifies the response alone and cannot know whose backend answered.
-      ...(isRecognizedDenial
-        ? {}
-        : { boundary: "mcpjam_internal" as const }),
-      extra: {
+    // Through the reporter, not a bare capture call: reportRouteFailure runs
+    // the same maybeCaptureOriginError decision (source becomes the identical
+    // `route:mcp.chat-v2.backend-stream` Sentry tag), then a free-form Axiom
+    // row, then the typed route.operation.failed event — the only record of
+    // this failure that monitors can key on, since the response is a 200
+    // stream the HTTP events never see.
+    //
+    // The hop is `mcpjam_internal` for a genuine TRANSPORT failure only, and
+    // NOT for `isRecognizedDenial`. A denial is an HTTP 200 carrying a
+    // structured refusal (`{ok:false, code:"user_rate_limit"}`) — the backend
+    // working correctly, and a routine, user-owned outcome. Promoting it
+    // would page the team on every ordinary spend-limit rejection, which is
+    // precisely the noise class this work removes. On a real failure the
+    // internal hop earns its place twice: it tags the event with the boundary
+    // the rest of the codebase triages on, and it escalates an unrecognized
+    // status from our own backend, which `describeBackendStreamFailure`
+    // leaves `ambiguous` because it classifies the response alone and cannot
+    // know whose backend answered.
+    failureReporter({
+      message: "[mcpjam-stream-handler] backend stream failed",
+      error: new Error(parsed.message),
+      source: "mcp.chat-v2.backend-stream",
+      hop: isRecognizedDenial ? "user_server_hop" : "mcpjam_internal",
+      transport: "http_stream",
+      normalized,
+      ...(parsed.code ? { errorCode: parsed.code } : {}),
+      context: {
         httpStatus: res.status,
         code: parsed.code,
         isJsonDenial,
@@ -2865,6 +2890,26 @@ async function processOneStep(
         errorText,
       });
     emitError(writer, errorText);
+      // Site (2) holds a real error. An earlier comment deferred capture to
+      // "the chat route's stream onError" — but runChatEngineLoop's
+      // createUIMessageStream passes only `execute`, so no such onError
+      // exists on this path and the failure was never classified or
+      // recorded. The reporter closes that hole: capture decision, free-form
+      // row, and the typed route.operation.failed event (the response is a
+      // 200 stream, so the HTTP failure events never see this).
+      const stepNormalized = describeError(error);
+      failureReporter({
+        message: "[mcpjam-stream-handler] engine step failed",
+        error,
+        source: "mcp.chat-v2.engine-step",
+        hop: "user_server_hop",
+        transport: "http_stream",
+        normalized: stepNormalized,
+        context: {
+          promptIndex: traceTurn.promptIndex,
+          stepIndex,
+        },
+      });
       // PR 5b-followup-2: surface the error to `streamSink: "none"`
       // consumers (eval backend stream runner). The processStream /
       // tool-execution catch path doesn't have a structured body, so
@@ -2875,9 +2920,7 @@ async function processOneStep(
         rawText: errorText,
         promptIndex: traceTurn.promptIndex,
         stepIndex,
-        // Site (2) holds a real error — no capture here, the chat route's
-        // stream `onError` owns that decision for this path.
-        normalized: describeError(error),
+        normalized: stepNormalized,
       });
       return { shouldContinue: false, didEmitFinish: false };
     }
@@ -3006,6 +3049,7 @@ export async function runChatEngineLoop(
     onStepFinish,
     // PR 5b-followup-2 callback.
     onEngineError,
+    failureReporter: failureReporterOption,
     // Browser-rendered MCP App eval PR 2: advertised-tool narrowing hook.
     prepareAdvertisedTools,
     abortSignal,
@@ -3014,6 +3058,13 @@ export async function runChatEngineLoop(
     progressivePlan,
     discoveryState,
   } = options;
+  // One typed route.operation.failed per turn, whatever combination of the
+  // three failure sites fires; the system fallback covers eval/swarm runs
+  // that have no request context. Later failures in the same turn still get
+  // classified (capture-deduped) and keep their free-form rows.
+  const failureReporter = oncePerTurn(
+    failureReporterOption ?? createSystemStreamFailureReporter("chat-engine"),
+  );
   const resolvedEndpointPath = endpointPath ?? "/stream";
   const resolvedMaxSteps =
     typeof maxSteps === "number" && Number.isFinite(maxSteps) && maxSteps > 0
@@ -3358,6 +3409,7 @@ export async function runChatEngineLoop(
           // the two `processOneStep` error sites (non-OK Convex
           // response + processStream/tool catch).
           onEngineError,
+          failureReporter,
           // Browser-rendered MCP App eval PR 2: advertised-tool narrowing.
           prepareAdvertisedTools,
           abortSignal,
@@ -3439,10 +3491,24 @@ export async function runChatEngineLoop(
       if (isAbortError(error) || abortSignal?.aborted) {
         aborted = true;
       } else {
-        logger.error("[mcpjam-stream-handler] Error in agentic loop", error);
         const failAbs = Date.now();
         const errorText =
           error instanceof Error ? error.message : String(error);
+        const loopNormalized = describeError(error);
+        // Reporter, not a bare logger.error: the old call captured to Sentry
+        // unconditionally — paging on user-fault failures — and left no typed
+        // record a monitor could read (the response is a 200 stream). The
+        // reporter classifies first, pages only on origin=mcpjam, keeps the
+        // free-form row, and emits route.operation.failed.
+        failureReporter({
+          message: "[mcpjam-stream-handler] Error in agentic loop",
+          error,
+          source: "mcp.chat-v2.agentic-loop",
+          hop: "user_server_hop",
+          transport: "http_stream",
+          normalized: loopNormalized,
+          context: { promptIndex: traceTurn.promptIndex },
+        });
         pushAiSdkTrailingErrorSpan(
           traceTurn.turnSpans,
           traceTurn.turnStartedAt,
@@ -3471,7 +3537,7 @@ export async function runChatEngineLoop(
           message: errorText,
           rawText: errorText,
           promptIndex: traceTurn.promptIndex,
-          normalized: describeError(error),
+          normalized: loopNormalized,
         });
       }
     } finally {

--- a/mcpjam-inspector/server/utils/org-model-stream-handler.ts
+++ b/mcpjam-inspector/server/utils/org-model-stream-handler.ts
@@ -45,6 +45,11 @@ import type { PersistedTurnTrace } from "./chat-ingestion";
 import { handleMCPJamFreeChatModel } from "./mcpjam-stream-handler.js";
 import { logger } from "./logger.js";
 import {
+  createSystemStreamFailureReporter,
+  oncePerTurn,
+  type StreamFailureReporter,
+} from "./stream-failure-reporter.js";
+import {
   runDirectChatTurn,
   withMcpToolOriginChunkMetadata,
   type DirectChatTurnPersistEvent,
@@ -142,6 +147,11 @@ export interface OrgModelHandlerOptions {
    * on collision.
    */
   extraBodyFields?: Record<string, unknown>;
+  /**
+   * Typed-telemetry seam for mid-stream failures; forwarded verbatim into
+   * the wrapped MCPJam handler. See stream-failure-reporter.ts.
+   */
+  failureReporter?: StreamFailureReporter;
 }
 
 // ---------------------------------------------------------------------------
@@ -299,6 +309,12 @@ export interface OrgLocalModelHandlerOptions {
    */
   progressivePlan?: ProgressiveToolPlan;
   discoveryState?: ToolDiscoveryState;
+  /**
+   * Typed-telemetry seam for mid-stream failures (route.operation.failed);
+   * see stream-failure-reporter.ts. Constructed at the route layer where a
+   * Hono context exists.
+   */
+  failureReporter?: StreamFailureReporter;
 }
 
 /**
@@ -354,6 +370,15 @@ export function handleLocalOrgChatModel(
     onLiveTextDelta,
   } = options;
 
+  // One typed route.operation.failed per turn across this handler's failure
+  // sites; system fallback keeps the invariant if a future caller forgets it.
+  const failureReporter = oncePerTurn(
+    options.failureReporter ??
+      createSystemStreamFailureReporter("org-local-stream"),
+  );
+
+  // Deliberately NOT reported as an operation failure: this is a declared
+  // product limitation surfaced to the user, not something that broke.
   if (hasUnsupportedLocalApprovalGate(tools, requireToolApproval)) {
     const stream = createUIMessageStream({
       onError: (error) => formatLocalStreamError(error),
@@ -383,6 +408,17 @@ export function handleLocalOrgChatModel(
     assertOrgModelAllowed(provider, modelId);
     llmModel = buildOrgModelFromResolvedConfig(provider, modelId);
   } catch (configErr) {
+    // The response is still a 200 stream whose first chunk is the error, so
+    // the HTTP failure events never see this — the typed event is the only
+    // machine-readable record.
+    failureReporter({
+      message: "[org/local] model config/allowlist failure",
+      error: configErr,
+      source: "web.chat-v2.org-local-config",
+      hop: "user_server_hop",
+      transport: "http_stream",
+      context: { providerKey: provider.providerKey, modelId },
+    });
     const stream = createUIMessageStream({
       onError: (error) => formatLocalStreamError(error),
       onFinish: async () => {
@@ -420,7 +456,16 @@ export function handleLocalOrgChatModel(
       ) {
         return "";
       }
-      logger.error("[org/local] stream error", error);
+      // Reporter, not a bare logger.error: the old call captured to Sentry
+      // unconditionally and left no typed record (this is a 200 stream).
+      failureReporter({
+        message: "[org/local] stream error",
+        error,
+        source: "web.chat-v2.org-local-stream",
+        hop: "user_server_hop",
+        transport: "http_stream",
+        context: { providerKey: provider.providerKey, modelId },
+      });
       return formatLocalStreamError(error);
     },
     onFinish: async () => {
@@ -509,6 +554,17 @@ export function handleLocalOrgChatModel(
           },
           onError: (error) => {
             if (handle!.isAborted() || isAbortError(error)) return "";
+            // toUIMessageStream CONSUMES the error (no rethrow), so the
+            // top-level onError above never sees it — this is the only
+            // chance to record it. The two sites are exclusive per error.
+            failureReporter({
+              message: "[org/local] direct stream error",
+              error,
+              source: "web.chat-v2.org-local-direct-stream",
+              hop: "user_server_hop",
+              transport: "http_stream",
+              context: { providerKey: provider.providerKey, modelId },
+            });
             return formatLocalStreamError(error);
           },
         })) {
@@ -741,6 +797,7 @@ export async function handleHostedOrgChatModel(
     scopeStepUpResume: options.scopeStepUpResume,
     progressivePlan: options.progressivePlan,
     discoveryState: options.discoveryState,
+    failureReporter: options.failureReporter,
     endpointPath: "/stream/org",
     extraBodyFields: {
       // Caller-provided fields first; sibling fields from this handler

--- a/mcpjam-inspector/server/utils/org-model-stream-handler.ts
+++ b/mcpjam-inspector/server/utils/org-model-stream-handler.ts
@@ -410,15 +410,18 @@ export function handleLocalOrgChatModel(
   } catch (configErr) {
     // The response is still a 200 stream whose first chunk is the error, so
     // the HTTP failure events never see this — the typed event is the only
-    // machine-readable record.
-    failureReporter({
-      message: "[org/local] model config/allowlist failure",
-      error: configErr,
-      source: "web.chat-v2.org-local-config",
-      hop: "user_server_hop",
-      transport: "http_stream",
-      context: { providerKey: provider.providerKey, modelId },
-    });
+    // machine-readable record. Silent-cancel invariant: skip the report when
+    // the request was already aborted before validation failed.
+    if (!options.abortSignal?.aborted) {
+      failureReporter({
+        message: "[org/local] model config/allowlist failure",
+        error: configErr,
+        source: "web.chat-v2.org-local-config",
+        hop: "user_server_hop",
+        transport: "http_stream",
+        context: { providerKey: provider.providerKey, modelId },
+      });
+    }
     const stream = createUIMessageStream({
       onError: (error) => formatLocalStreamError(error),
       onFinish: async () => {

--- a/mcpjam-inspector/server/utils/stream-failure-reporter.ts
+++ b/mcpjam-inspector/server/utils/stream-failure-reporter.ts
@@ -1,0 +1,113 @@
+import type { Context } from "hono";
+import type { NormalizedError } from "@mcpjam/sdk";
+import {
+  reportRouteFailure,
+  type RouteFailureHop,
+  type RouteFailureReport,
+} from "./route-error-report.js";
+import { getRequestLogger, getSystemLogger } from "./request-logger.js";
+
+/**
+ * The classification/emission seam for failures HTTP status cannot see —
+ * SSE `{type:"error"}` chunks after 200 headers and JSON-RPC error envelopes
+ * over HTTP 200.
+ *
+ * Why a reporter and not the Hono context: the chat engines
+ * (`mcpjam-stream-handler.ts`, `run-harness-turn.ts`) and the JSON-RPC
+ * bridge deliberately know nothing about Hono. The route layer, which does
+ * hold `c`, constructs a request-scoped reporter and passes exactly one
+ * function down; evals/swarm runs (no request context) get the system
+ * variant instead, so the engines never grow a transport dependency and no
+ * caller can silently lose events.
+ *
+ * Classification stays entirely inside `reportRouteFailure`: capture
+ * decision first (stamps the error so a later `logger.error` cannot
+ * double-page), then the free-form Axiom row, then — here — the typed
+ * `route.operation.failed` event carrying the EFFECTIVE origin the capture
+ * decision was made on.
+ */
+export type StreamFailureEvent = {
+  /** Log line for the free-form row, e.g. "[harness] turn failed". */
+  message: string;
+  /** The original error. Synthesize `new Error(text)` at status-only sites. */
+  error: unknown;
+  /** Stable catch-site id — becomes the Sentry tag `route:${source}`. */
+  source: string;
+  hop: RouteFailureHop;
+  transport: "http_stream" | "rpc_envelope";
+  /** Pass through when the site already computed it; saves a second pass. */
+  normalized?: NormalizedError;
+  errorCode?: string;
+  rpcMethod?: string;
+  /** Extra structured context for the free-form row and Sentry. */
+  context?: Record<string, unknown>;
+};
+
+export type StreamFailureReporter = (
+  event: StreamFailureEvent,
+) => RouteFailureReport;
+
+function classify(e: StreamFailureEvent): RouteFailureReport {
+  return reportRouteFailure(e.message, e.error, {
+    source: e.source,
+    hop: e.hop,
+    ...(e.normalized ? { normalized: e.normalized } : {}),
+    ...(e.context ? { context: e.context } : {}),
+  });
+}
+
+function toPayload(e: StreamFailureEvent, report: RouteFailureReport) {
+  const rawMessage =
+    e.error instanceof Error ? e.error.message : String(e.error);
+  return {
+    transport: e.transport,
+    source: e.source,
+    hop: e.hop,
+    origin: report.origin,
+    ...(report.normalized.slug ? { slug: report.normalized.slug } : {}),
+    ...(e.errorCode ? { errorCode: e.errorCode } : {}),
+    errorMessage: rawMessage.slice(0, 500),
+    ...(e.rpcMethod ? { rpcMethod: e.rpcMethod } : {}),
+  };
+}
+
+export function createRequestStreamFailureReporter(
+  c: Context,
+  component: string,
+): StreamFailureReporter {
+  const log = getRequestLogger(c, component);
+  return (e) => {
+    const report = classify(e);
+    log.event("route.operation.failed", toPayload(e, report));
+    return report;
+  };
+}
+
+export function createSystemStreamFailureReporter(
+  component: string,
+): StreamFailureReporter {
+  const log = getSystemLogger(component);
+  return (e) => {
+    const report = classify(e);
+    log.event("route.operation.failed", toPayload(e, report));
+    return report;
+  };
+}
+
+/**
+ * At most one typed event per engine invocation. A turn can hit the
+ * backend-stream failure site (which returns rather than throws) and then a
+ * later step can still throw; both failures deserve classification and a
+ * free-form row — capture is deduped by the stamp regardless — but a single
+ * turn must not count twice in the operation-failure rate the monitors read.
+ */
+export function oncePerTurn(
+  reporter: StreamFailureReporter,
+): StreamFailureReporter {
+  let emitted = false;
+  return (e) => {
+    if (emitted) return classify(e);
+    emitted = true;
+    return reporter(e);
+  };
+}

--- a/mcpjam-inspector/server/utils/stream-failure-reporter.ts
+++ b/mcpjam-inspector/server/utils/stream-failure-reporter.ts
@@ -57,8 +57,16 @@ function classify(e: StreamFailureEvent): RouteFailureReport {
 }
 
 function toPayload(e: StreamFailureEvent, report: RouteFailureReport) {
-  const rawMessage =
-    e.error instanceof Error ? e.error.message : String(e.error);
+  // Guarded extraction: a message getter or string coercion that throws
+  // (Proxy trap, null-proto object) must not lose the typed event after
+  // classification already succeeded — same precedent as
+  // reportRouteFailure's "[unreadable error value]" handling.
+  let rawMessage: string;
+  try {
+    rawMessage = e.error instanceof Error ? e.error.message : String(e.error);
+  } catch {
+    rawMessage = "[unreadable error value]";
+  }
   return {
     transport: e.transport,
     source: e.source,

--- a/mcpjam-inspector/server/utils/web-chat-turn.ts
+++ b/mcpjam-inspector/server/utils/web-chat-turn.ts
@@ -26,6 +26,7 @@
 import type { Context } from "hono";
 import { type ToolSet, type UIMessageChunk } from "ai";
 import { logger } from "./logger.js";
+import { createRequestStreamFailureReporter } from "./stream-failure-reporter.js";
 import {
   SANDBOX_NOTICE_DATA_PART_TYPE,
   type SandboxNoticeReason,
@@ -529,6 +530,11 @@ export async function streamWebChatTurn(
 ): Promise<Response> {
   const { manager, prepare, persist, runtime } = args;
   const { c } = runtime;
+  // Mid-stream failures happen after this route has already returned a 200
+  // stream, where the HTTP failure events can't see them. The request-scoped
+  // reporter gives every engine below one typed route.operation.failed path
+  // carrying the full request envelope (orgId/route/requestId/release).
+  const failureReporter = createRequestStreamFailureReporter(c, "chat");
 
   // Guard the env once at the top — both branches POST to Convex.
   if (!process.env.CONVEX_HTTP_URL) {
@@ -920,6 +926,7 @@ export async function streamWebChatTurn(
     if (orgRuntime.runtimeLocation === "local") {
       return handleLocalOrgChatModel({
         provider: orgRuntime.provider,
+        failureReporter,
         projectId: persist.projectId,
         modelId,
         chatSessionId: hostedChatSessionId,
@@ -960,6 +967,7 @@ export async function streamWebChatTurn(
 
     return handleHostedOrgChatModel({
       projectId: persist.projectId,
+      failureReporter,
       providerKey: orgRuntime.providerKey,
       modelId,
       chatSessionId: hostedChatSessionId,
@@ -1033,6 +1041,7 @@ export async function streamWebChatTurn(
 
   return handleMCPJamFreeChatModel({
     messages: modelMessages,
+    failureReporter,
     modelId: mcpjamModelId,
     provider: prepare.modelDefinition.provider,
     chatSessionId: hostedChatSessionId,


### PR DESCRIPTION
**Stacked on #4002 — merge that first** (this uses its `stream-failure-reporter.ts`).

## Problem

Every real `handleJsonRpc` failure leaves the process as **HTTP 200**: an adapter-mode `-32000` envelope, or manager-mode's *success* envelope with `isError: true`. Six of the nine error sites even computed `normalized: describeError(e)` for the envelope — and then nothing recorded any of it. `http.request.failed` structurally cannot see these.

## Fix

`JsonRpcBridgeOptions.failureReporter?` — injected by the two route callers (`http-adapters` for both transports, `harness-mcp` for the sandbox proxy). Five sites report (`transport: "rpc_envelope"`, `source: "mcp.bridge.rpc"`, `rpcMethod` carried):

- `tools/call` **shared catch, before the mode branch** — so manager-mode's success+`isError` envelope (a failure invisible to both HTTP status and JSON-RPC error accounting) counts exactly like adapter-mode's error
- `resources/read`, `prompts/get`, the managed passthrough (under its forwarded method name), and the outer catch

Two deliberately do not, with reasons in code: parse/Invalid-Request 400s (already visible as 4xx rows — reporting would double-count) and `-32601` (a declared client outcome). `hop: "user_server_hop"` everywhere — the bridge proxies into the user's own server, so only MCPJam-positive catalog slugs escalate.

Every reporter call is isolated exactly like `onToolCallError`: telemetry can never change a JSON-RPC response (pinned by a throwing-reporter test). `harness-mcp`'s outer catch loses its bare `logger.error` (unconditional Sentry) for the classify-first flow; the masked 200 response to the sandbox is unchanged.

## Tests

`mcp-http-bridge.test.ts` (new, 9): envelopes byte-identical with/without reporter in both modes; per-method reporting incl. passthrough; `-32601` and notifications report-free; throwing reporter harmless; parse path documented report-free. Caller suites (`harness-mcp`, `http-adapters`, `rpc-logs`) all green — 65 tests.

Part of the #mcpjam-alerts observability program (streaming-failure telemetry, PR 3/3).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches the core MCP JSON-RPC proxy and harness sandbox path; behavior is observation-only with tests pinning response shapes, but mis-classification or double-reporting could affect alerting noise.
> 
> **Overview**
> **JSON-RPC bridge failures that still return HTTP 200** (adapter `-32000` envelopes, manager-mode success + `isError: true`, harness masked proxy errors) were invisible to `http.request.failed`. This PR wires them into the existing **`route.operation.failed`** stream via an optional **`failureReporter`** on `handleJsonRpc`.
> 
> `mcp-http-bridge` reports at **`tools/call`** (shared catch before the mode split), **`resources/read`**, **`prompts/get`**, managed **passthrough**, and the **outer catch**, with `source: "mcp.bridge.rpc"`, `transport: "rpc_envelope"`, and `hop: "user_server_hop"`. It **skips** parse/4xx validation errors and **`-32601`** (including upstream passthrough). Reporter throws are isolated so **JSON-RPC responses stay byte-identical**.
> 
> **`http-adapters`** (POST and SSE `/messages`) and **`harness-mcp`** inject `createRequestStreamFailureReporter`; the harness **outer catch** swaps unconditional `logger.error` for the same classified path while keeping the generic **200** sandbox response. New **`mcp-http-bridge.test.ts`** pins envelopes, attribution (`targetServerId` for prefixed tools), and no-report boundaries.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cf6bb08e447033a9519ff59d400a5d0733276872. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Records JSON-RPC bridge failures that still return HTTP 200 as `route.operation.failed` so they are no longer invisible to `http.request.failed`. Responses and JSON-RPC envelopes are byte-identical; telemetry never alters behavior.

- Adds optional `JsonRpcBridgeOptions.failureReporter`, injected by `mcp/http-adapters` (POST and SSE `/messages`) and `web/harness-mcp` via `createRequestStreamFailureReporter`.
- Reports at five sites: shared `tools/call` catch (before the mode branch), `resources/read`, `prompts/get`, managed passthrough (under the forwarded method), and the outer catch. Skips parse/Invalid-Request 4xx and any `-32601` (including upstream passthrough).
- Emits with `source: "mcp.bridge.rpc"`, `transport: "rpc_envelope"`, `hop: "user_server_hop"`, carries `rpcMethod`, `errorCode: "-32000"`, and `normalized` when available. Attributes prefixed `tools/call` to the executing server via `context.targetServerId`.
- Replaces `harness-mcp` outer-catch `logger.error` with a classified reporter call and sets `errorCode: "-32000"`; continues to return masked 200 responses to the sandbox.
- Adds `mcp-http-bridge.test.ts` to pin envelope stability, per-method reporting, prefixed `tools/call` attribution, passthrough and `-32601` no-report cases, and reporter isolation.

<sup>Written for commit cf6bb08e447033a9519ff59d400a5d0733276872. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/MCPJam/inspector/pull/4003?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

