### PR TITLE
feat(sdk,cli): expose create-time scenario overrides on publish

### DIFF
--- a/cli/src/commands/scenarios.ts
+++ b/cli/src/commands/scenarios.ts
@@ -79,29 +79,65 @@ export function registerScenariosCommands(program: Command): void {
       "Publish project environments for user testing, and take them down again"
     );
 
+  const SCENARIO_MODES = [
+    "project_members",
+    "invited_only",
+    "anyone_with_link",
+  ] as const;
+
   addPlatformOptions(
     scenarios
       .command("publish")
       .description(
-        "Publish an environment as a scenario and print its share link. Idempotent — re-publishing returns the existing scenario, with created: false."
+        "Publish an environment as a scenario and print its share link. Idempotent — re-publishing returns the existing scenario, with created: false. --name, --description and --mode apply at CREATE TIME, in the same call; on a re-publish they are ignored and the result says overridesIgnored: true (use `mcpjam user-testing update` to change an existing scenario)."
       )
       .requiredOption("--environment <id>", "Project environment ID")
       .option(
         "--project <id-or-name>",
         "Project name or ID (defaults to the most recently updated project)"
       )
+      .option("--name <name>", "Scenario name (create time only)")
+      .option("--description <text>", "Scenario description (create time only)")
+      .option(
+        "--mode <mode>",
+        "Who may open the share link (create time only): project_members | invited_only | anyone_with_link"
+      )
   ).action(
     async (
-      options: PlatformOptions & { project?: string; environment: string },
+      options: PlatformOptions & {
+        project?: string;
+        environment: string;
+        name?: string;
+        description?: string;
+        mode?: string;
+      },
       command
     ) => {
       const globalOptions = getGlobalOptions(command);
+      // A misspelled mode is a usage error, answered here — not a server round
+      // trip that spends a request to learn the flag was typed wrong.
+      const mode = options.mode as (typeof SCENARIO_MODES)[number] | undefined;
+      if (mode !== undefined && !SCENARIO_MODES.includes(mode)) {
+        command.error(
+          `error: option '--mode <mode>' must be one of ${SCENARIO_MODES.join(
+            ", "
+          )}`
+        );
+      }
       const result = await runPlatformCommand(
         options,
         globalOptions.timeout,
         ({ client, signal }) =>
           publishScenarioOperation.execute(
-            { project: options.project, environment: options.environment },
+            {
+              project: options.project,
+              environment: options.environment,
+              ...(options.name !== undefined ? { name: options.name } : {}),
+              ...(options.description !== undefined
+                ? { description: options.description }
+                : {}),
+              ...(mode !== undefined ? { mode } : {}),
+            },
             { client, signal }
           )
       );

--- a/cli/tests/scenarios-cli.test.ts
+++ b/cli/tests/scenarios-cli.test.ts
@@ -1,0 +1,137 @@
+import assert from "node:assert/strict";
+import { afterEach, test } from "node:test";
+import { Command, CommanderError } from "commander";
+import { registerScenariosCommands } from "../src/commands/scenarios.js";
+
+/**
+ * `mcpjam scenarios publish` — the create-time override flags.
+ *
+ * What these pin: `--mode` is validated against the enum LOCALLY, so a typo is
+ * a usage error and not a server round trip; and the accepted flags reach the
+ * PUT body verbatim, in the one call that both creates the scenario and sets
+ * who may open it.
+ */
+
+function buildProgram(): Command {
+  const program = new Command()
+    .name("mcpjam")
+    .exitOverride()
+    .configureOutput({ writeErr: () => {}, writeOut: () => {} });
+  registerScenariosCommands(program);
+  return program;
+}
+
+const realFetch = globalThis.fetch;
+const realWrite = process.stdout.write;
+afterEach(() => {
+  globalThis.fetch = realFetch;
+  process.stdout.write = realWrite;
+});
+
+test("publish rejects a mode outside the enum without any request", async () => {
+  const calls: unknown[] = [];
+  globalThis.fetch = (async (...args: unknown[]) => {
+    calls.push(args);
+    throw new Error("unreachable");
+  }) as typeof fetch;
+
+  await assert.rejects(
+    buildProgram().parseAsync(
+      [
+        "scenarios",
+        "publish",
+        "--environment",
+        "env-1",
+        "--mode",
+        "everyone",
+        "--api-key",
+        "sk_test",
+      ],
+      { from: "user" }
+    ),
+    (error: unknown) => {
+      assert.ok(error instanceof CommanderError);
+      assert.match(
+        error.message,
+        /project_members, invited_only, anyone_with_link/
+      );
+      return true;
+    }
+  );
+  assert.equal(calls.length, 0);
+});
+
+test("publish forwards --name, --description and --mode in the PUT body", async () => {
+  const requests: { url: string; init?: RequestInit }[] = [];
+  globalThis.fetch = (async (target: unknown, init?: RequestInit) => {
+    const url = String(target);
+    requests.push({ url, init });
+    if (/\/projects(\?|$)/.test(url)) {
+      return Response.json({
+        items: [
+          {
+            id: "project-1",
+            name: "New",
+            description: null,
+            icon: null,
+            organizationId: "org-a",
+            visibility: null,
+            createdAt: 1,
+            updatedAt: 2,
+          },
+        ],
+      });
+    }
+    if (url.includes("/scenario")) {
+      return Response.json(
+        {
+          id: "scenario-1",
+          environmentId: "env-1",
+          name: "Beta run",
+          mode: "invited_only",
+          accessVersion: 1,
+          link: "https://app.mcpjam.com/s/beta?t=abc",
+          created: true,
+        },
+        { status: 201 }
+      );
+    }
+    return Response.json(
+      { code: "NOT_FOUND", message: `No route for ${url}` },
+      { status: 404 }
+    );
+  }) as typeof fetch;
+  // The command prints the result; keep the test runner's output clean.
+  process.stdout.write = (() => true) as typeof process.stdout.write;
+
+  await buildProgram().parseAsync(
+    [
+      "scenarios",
+      "publish",
+      "--environment",
+      "env-1",
+      "--name",
+      "Beta run",
+      "--description",
+      "Invited testers only",
+      "--mode",
+      "invited_only",
+      "--api-key",
+      "sk_test",
+    ],
+    { from: "user" }
+  );
+
+  const put = requests.find((request) => request.url.includes("/scenario"));
+  assert.ok(put, "expected a PUT to the scenario route");
+  assert.equal(put.init?.method, "PUT");
+  assert.match(
+    put.url,
+    /\/projects\/project-1\/environments\/env-1\/scenario$/
+  );
+  assert.deepEqual(JSON.parse(String(put.init?.body)), {
+    name: "Beta run",
+    description: "Invited testers only",
+    mode: "invited_only",
+  });
+});

--- a/mcpjam-inspector/server/routes/v1/__tests__/scenarios.test.ts
+++ b/mcpjam-inspector/server/routes/v1/__tests__/scenarios.test.ts
@@ -53,10 +53,18 @@ function makeApp() {
   return app;
 }
 
-function call(method: "PUT" | "DELETE") {
+function call(method: "PUT" | "DELETE", body?: unknown) {
   return makeApp().request(
     `/api/v1/projects/${PROJECT}/environments/${ENV}/scenario`,
-    { method }
+    {
+      method,
+      ...(body !== undefined
+        ? {
+            body: JSON.stringify(body),
+            headers: { "content-type": "application/json" },
+          }
+        : {}),
+    }
   );
 }
 
@@ -162,6 +170,67 @@ describe("PUT .../scenario", () => {
     expect((await res.json()) as Record<string, unknown>).toMatchObject({
       created: false,
     });
+  });
+
+  it("forwards create-time overrides to the mutation IN THE SAME CALL", async () => {
+    // One mutation, overrides included — never publish-then-adjust, which
+    // would leave the scenario briefly live in the default mode.
+    mutationMock.mockResolvedValue(
+      published({ name: "Beta run", mode: "invited_only" })
+    );
+
+    const res = await call("PUT", {
+      name: "Beta run",
+      description: "Invited testers only",
+      mode: "invited_only",
+    });
+    expect(res.status).toBe(201);
+    expect(mutationMock).toHaveBeenCalledWith(
+      "chatboxes:publishEnvironmentChatbox",
+      {
+        environmentId: ENV,
+        name: "Beta run",
+        description: "Invited testers only",
+        mode: "invited_only",
+      }
+    );
+    const body = (await res.json()) as Record<string, unknown>;
+    expect(body.mode).toBe("invited_only");
+    expect(body).not.toHaveProperty("overridesIgnored");
+  });
+
+  it("reports overridesIgnored on a republish that discarded them", async () => {
+    // The overrides are create-time only upstream. The caller asked for
+    // `invited_only`; the response's mode is the real one, and staying silent
+    // about the discarded intent is how someone concludes a link is
+    // restricted when it is not.
+    mutationMock.mockResolvedValue(published({ created: false }));
+
+    const res = await call("PUT", { mode: "invited_only" });
+    expect(res.status).toBe(200);
+    expect((await res.json()) as Record<string, unknown>).toMatchObject({
+      created: false,
+      mode: "anyone_with_link",
+      overridesIgnored: true,
+    });
+  });
+
+  it("omits overridesIgnored on a bodyless republish", async () => {
+    // Nothing was asked for, so nothing was ignored — the flag would be noise
+    // on every routine idempotent publish.
+    mutationMock.mockResolvedValue(published({ created: false }));
+
+    const res = await call("PUT");
+    expect(res.status).toBe(200);
+    expect((await res.json()) as Record<string, unknown>).not.toHaveProperty(
+      "overridesIgnored"
+    );
+  });
+
+  it("400s a mode outside the enum, without calling the mutation", async () => {
+    const res = await call("PUT", { mode: "everyone" });
+    expect(res.status).toBe(400);
+    expect(mutationMock).not.toHaveBeenCalled();
   });
 
   it("404s an environment in ANOTHER project, without calling the mutation", async () => {

--- a/sdk/src/platform/client.ts
+++ b/sdk/src/platform/client.ts
@@ -1932,16 +1932,35 @@ export class PlatformApiClient {
   // `sandboxes-enabled` beta flag; UNPUBLISHING deliberately is not, so an org
   // that loses the flag can still take a live scenario down.
 
+  /**
+   * `name`, `description` and `mode` are CREATE-TIME overrides applied in the
+   * same call, so the scenario is never briefly live in a wider mode than the
+   * caller asked for. They are ignored on a republish (the response says
+   * `overridesIgnored: true`) — changing an existing scenario is
+   * `updateUserTestingScenario`.
+   */
   publishScenario(
-    params: { projectId: string; environmentId: string },
+    params: {
+      projectId: string;
+      environmentId: string;
+      name?: string;
+      description?: string;
+      mode?: "project_members" | "invited_only" | "anyone_with_link";
+    },
     options?: RequestOptions
-  ): Promise<PlatformScenario> {
+  ): Promise<PlatformScenario & { overridesIgnored?: boolean }> {
+    const { projectId, environmentId, ...overrides } = params;
+    const body = Object.fromEntries(
+      Object.entries(overrides).filter(([, value]) => value !== undefined)
+    );
     return this.request(
       "PUT",
       `/projects/${encodeURIComponent(
-        params.projectId
-      )}/environments/${encodeURIComponent(params.environmentId)}/scenario`,
-      {},
+        projectId
+      )}/environments/${encodeURIComponent(environmentId)}/scenario`,
+      // Bodyless when there is nothing to send — the common case, and what
+      // existing callers already put on the wire.
+      Object.keys(body).length > 0 ? { body } : {},
       options
     );
   }

--- a/sdk/src/platform/client.ts
+++ b/sdk/src/platform/client.ts
@@ -1949,9 +1949,16 @@ export class PlatformApiClient {
     },
     options?: RequestOptions
   ): Promise<PlatformScenario & { overridesIgnored?: boolean }> {
-    const { projectId, environmentId, ...overrides } = params;
+    const { projectId, environmentId } = params;
+    // Explicit picks, not a rest spread: TypeScript's structural typing lets a
+    // wider object through, and the route's schema is strict — an unknown key
+    // forwarded here turns a valid publish into a 400.
     const body = Object.fromEntries(
-      Object.entries(overrides).filter(([, value]) => value !== undefined)
+      Object.entries({
+        name: params.name,
+        description: params.description,
+        mode: params.mode,
+      }).filter(([, value]) => value !== undefined)
     );
     return this.request(
       "PUT",

--- a/sdk/src/platform/operations.ts
+++ b/sdk/src/platform/operations.ts
@@ -4820,11 +4820,45 @@ const scenarioSelectorInput = z.object({
       "Project environment id to publish (or unpublish). One scenario per environment."
     ),
 });
-export type PublishScenarioInput = z.infer<typeof scenarioSelectorInput>;
+// Create-time overrides, forwarded to the publish IN THE SAME CALL — without
+// them, "publish this restricted to invited people only" is two operations
+// with a window between them where the scenario is live in the default mode.
+const publishScenarioInput = scenarioSelectorInput.extend({
+  name: z
+    .string()
+    .trim()
+    .min(1)
+    .max(200)
+    .optional()
+    .describe(
+      "Scenario name. CREATE-TIME ONLY — ignored on a republish of an already-published environment (rename with update_user_testing_scenario)."
+    ),
+  description: z
+    .string()
+    .max(2000)
+    .optional()
+    .describe(
+      "Scenario description. CREATE-TIME ONLY — ignored on a republish."
+    ),
+  mode: z
+    .enum(["project_members", "invited_only", "anyone_with_link"])
+    .optional()
+    .describe(
+      "Who may open the share link: project_members (signed-in project members only), invited_only (named members, invited individually), anyone_with_link (anyone holding the URL). CREATE-TIME ONLY — ignored on a republish; change an existing scenario's mode with update_user_testing_scenario."
+    ),
+});
+export type PublishScenarioInput = z.infer<typeof publishScenarioInput>;
 
 export type PublishScenarioResult = {
   project: SelectedProjectInfo;
   scenario: PlatformScenario;
+  /**
+   * True when overrides were sent but the environment was ALREADY published,
+   * so they were ignored upstream. The scenario in the result carries the real
+   * name and mode — a caller who asked for `invited_only` must not conclude
+   * the link is restricted when it is not.
+   */
+  overridesIgnored?: boolean;
 };
 
 export const publishScenarioOperation: PlatformOperation<
@@ -4835,20 +4869,32 @@ export const publishScenarioOperation: PlatformOperation<
   risk: "exposure",
   title: "Publish a project environment as a user-testing scenario",
   description:
-    "Publish a project environment so people outside the project can talk to it through a share link. IDEMPOTENT — publishing an already-published environment returns the existing scenario rather than creating a second one; `created` tells you which happened. Requires project admin.",
+    "Publish a project environment so people outside the project can talk to it through a share link. Optional name, description and mode apply atomically at CREATE TIME, so the scenario is never briefly live in a wider mode than asked for. IDEMPOTENT — publishing an already-published environment returns the existing scenario rather than creating a second one; `created` tells you which happened, and `overridesIgnored: true` means the overrides were discarded because the scenario already existed. Requires project admin.",
   readOnly: false,
-  inputSchema: scenarioSelectorInput,
+  inputSchema: publishScenarioInput,
   async execute(input, { client, signal }) {
     const { project } = await resolveProjectOrThrow(
       client,
       input.project,
       signal
     );
-    const scenario = await client.publishScenario(
-      { projectId: project.id, environmentId: input.environment },
+    const { overridesIgnored, ...scenario } = await client.publishScenario(
+      {
+        projectId: project.id,
+        environmentId: input.environment,
+        ...(input.name !== undefined ? { name: input.name } : {}),
+        ...(input.description !== undefined
+          ? { description: input.description }
+          : {}),
+        ...(input.mode !== undefined ? { mode: input.mode } : {}),
+      },
       { signal }
     );
-    return { project: toSelectedProjectInfo(project), scenario };
+    return {
+      project: toSelectedProjectInfo(project),
+      scenario,
+      ...(overridesIgnored ? { overridesIgnored: true } : {}),
+    };
   },
 };
 

--- a/sdk/tests/platform/operations.test.ts
+++ b/sdk/tests/platform/operations.test.ts
@@ -28,6 +28,7 @@ import {
   PlatformApiClient,
   PlatformApiError,
   ALL_OPERATIONS,
+  publishScenarioOperation,
   readServerResourceOperation,
   runEvalSuiteOperation,
   setEvalSuiteEnvironmentsOperation,
@@ -428,6 +429,36 @@ function makeClient(overrides: FixtureOverrides = {}): {
       expect(init?.method).toBe("POST");
       const serverId = decodeURIComponent(path.split("/")[6] ?? "");
       return Response.json({ serverId, status: "closed" });
+    }
+    if (
+      /^\/api\/v1\/projects\/[^/]+\/environments\/[^/]+\/scenario$/.test(path)
+    ) {
+      expect(init?.method).toBe("PUT");
+      const environmentId = decodeURIComponent(path.split("/")[6] ?? "");
+      const requestBody =
+        init?.body === undefined
+          ? {}
+          : (JSON.parse(String(init.body)) as Record<string, unknown>);
+      // `env-existing` is already published: the route ignores create-time
+      // overrides and says so, exactly as the real API does.
+      const created = environmentId !== "env-existing";
+      const overridesSent = Object.keys(requestBody).length > 0;
+      return Response.json(
+        {
+          id: "scenario-1",
+          environmentId,
+          name: created ? ((requestBody.name as string) ?? "Checkout") : "Kept",
+          mode: created
+            ? ((requestBody.mode as string) ?? "project_members")
+            : "anyone_with_link",
+          accessVersion: 1,
+          link: "https://app.mcpjam.com/s/checkout?t=abc",
+          created,
+          ...(!created && overridesSent ? { overridesIgnored: true } : {}),
+          requestBody,
+        },
+        { status: created ? 201 : 200 }
+      );
     }
     if (/^\/api\/v1\/projects\/[^/]+\/chatboxes$/.test(path)) {
       return Response.json({ items: CHATBOXES });
@@ -1166,6 +1197,83 @@ describe("chatbox operations", () => {
     expect((error as PlatformApiError).message).toContain(
       "Support (id: box-1)"
     );
+  });
+});
+
+describe("publishScenarioOperation", () => {
+  it("forwards the create-time overrides verbatim in the PUT body", async () => {
+    const { client, fetchMock } = makeClient();
+
+    const result = await publishScenarioOperation.execute(
+      publishScenarioOperation.inputSchema.parse({
+        environment: "env-1",
+        name: "Checkout flow",
+        description: "Guided checkout walkthrough",
+        mode: "invited_only",
+      }),
+      { client }
+    );
+
+    const [request] = fetchMock.mock.calls.filter(([target]) =>
+      String(target).includes("/scenario")
+    );
+    expect(new URL(String(request?.[0])).pathname).toBe(
+      "/api/v1/projects/project-new/environments/env-1/scenario"
+    );
+    expect(JSON.parse(String((request?.[1] as RequestInit).body))).toEqual({
+      name: "Checkout flow",
+      description: "Guided checkout walkthrough",
+      mode: "invited_only",
+    });
+    expect(result.scenario.created).toBe(true);
+    expect(result.scenario.mode).toBe("invited_only");
+    expect(result.overridesIgnored).toBeUndefined();
+  });
+
+  it("sends no body at all when there are no overrides", async () => {
+    // The pre-override wire shape, preserved: a bodyless PUT is the common
+    // case and what existing callers already produce.
+    const { client, fetchMock } = makeClient();
+
+    await publishScenarioOperation.execute(
+      publishScenarioOperation.inputSchema.parse({ environment: "env-1" }),
+      { client }
+    );
+
+    const [request] = fetchMock.mock.calls.filter(([target]) =>
+      String(target).includes("/scenario")
+    );
+    expect((request?.[1] as RequestInit).body).toBeUndefined();
+  });
+
+  it("hoists overridesIgnored when a republish discarded the overrides", async () => {
+    const { client } = makeClient();
+
+    const result = await publishScenarioOperation.execute(
+      publishScenarioOperation.inputSchema.parse({
+        environment: "env-existing",
+        mode: "invited_only",
+      }),
+      { client }
+    );
+
+    // The response's mode is the real one — the caller asked for
+    // `invited_only` and must learn the link is NOT restricted.
+    expect(result.scenario.created).toBe(false);
+    expect(result.scenario.mode).toBe("anyone_with_link");
+    expect(result.overridesIgnored).toBe(true);
+  });
+
+  it("rejects a mode outside the enum before any request", async () => {
+    const { fetchMock } = makeClient();
+
+    expect(
+      publishScenarioOperation.inputSchema.safeParse({
+        environment: "env-1",
+        mode: "everyone",
+      }).success
+    ).toBe(false);
+    expect(fetchMock).not.toHaveBeenCalled();
   });
 });
 


### PR DESCRIPTION
## What

The v1 route `PUT /projects/:projectId/environments/:environmentId/scenario` already accepts optional `{name, description, mode}` create-time overrides, forwards them to Convex `chatboxes:publishEnvironmentChatbox` in the same call, and reports `overridesIgnored: true` on a republish that discarded them. But the SDK operation and the CLI never exposed those fields, so an agent could not publish a scenario born `invited_only` — it had to publish in the default mode and narrow it afterwards, exactly the exposure window the atomic route call exists to close.

## Changes

- **`sdk` `PlatformApiClient.publishScenario`** — accepts optional `name`, `description`, `mode` and sends them in the PUT body. Additive only: the existing two-field signature still compiles, and a publish with no overrides stays bodyless on the wire, exactly as before. The result type now carries `overridesIgnored?: boolean`.
- **`sdk` `publish_scenario` operation** — the three optional inputs (zod, described as CREATE-TIME ONLY with a pointer to `update_user_testing_scenario` for existing scenarios), passed through verbatim. `overridesIgnored` is hoisted to the top level of the result so an agent learns its overrides were discarded on a republish, and the operation description says what that flag means.
- **`cli` `mcpjam scenarios publish`** — new `--name`, `--description`, `--mode` options. `--mode` is validated against the enum locally and answers a typo with a usage error rather than a server round trip.

No confirmation prompts or gating added anywhere.

## Tests

- `sdk` (`npm test`): 215 files, 4283 passed / 8 skipped — includes new `publishScenarioOperation` tests: overrides forwarded verbatim in the PUT body, bodyless wire shape preserved when no overrides, `overridesIgnored` hoisted on a republish, out-of-enum mode rejected by the schema.
- `cli` (`npm test` + `tsc --noEmit`): 579 passed — includes new tests that `--mode bogus` is a usage error with zero requests, and that `--name/--description/--mode` reach the PUT body.
- inspector route tests (`npx vitest run server/routes/v1/__tests__/scenarios.test.ts server/routes/v1/__tests__/sdk-coverage.test.ts`): 20 passed — new route tests pin overrides forwarded to the mutation in the same call, `overridesIgnored: true` on a republish that discarded them, no flag on a bodyless republish, and a 400 for a mode outside the enum.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes affect scenario share-link exposure (`mode`) at publish time; behavior is additive and well-tested, but misreading `overridesIgnored` on republish could leave a link more open than intended.
> 
> **Overview**
> **Scenario publish** can now set **name**, **description**, and **access mode** in the same atomic call as the first publish, instead of publishing in the default mode and narrowing afterward.
> 
> The **SDK** extends `publishScenario` / `publish_scenario` with optional create-time fields, sends them in the PUT body (still bodyless when omitted), and surfaces **`overridesIgnored`** when a republish discards those overrides. The **CLI** adds matching `--name`, `--description`, and `--mode` flags; invalid `--mode` values fail locally before any API call.
> 
> **Tests** lock in override forwarding, republish behavior, and enum validation across CLI, SDK operations, and the v1 scenario route.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e7ec0eca6e142c349a69e07170536505b54b5331. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Expose create-time scenario overrides on publish so a scenario can be born with the right access. Previously you had to publish in the default mode then restrict; now SDK and CLI can set name, description, and mode atomically. On republish, overrides are ignored and the result signals this.

- SDK: `PlatformApiClient.publishScenario` accepts optional `name`, `description`, `mode` and returns `overridesIgnored?: boolean` on republish. Explicitly picks only these fields to avoid forwarding unknown keys to the route’s strict schema. Calls with no overrides remain bodyless; existing signatures still compile.
- Operation: `publish_scenario` input adds the three optional create-time fields; `overridesIgnored` is hoisted to the top-level result. Input validates `mode` against the enum and documents create-time-only behavior.
- CLI: `mcpjam scenarios publish` adds `--name`, `--description`, `--mode`. `--mode` is validated locally and fails fast on typos without a request.

No prompts or gating added. No migration required; optionally start passing overrides on first publish and handle `overridesIgnored` on republish.

<sup>Written for commit e7ec0eca6e142c349a69e07170536505b54b5331. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/MCPJam/inspector/pull/4004?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

