### PR TITLE
fix(surface-core): biome-format copy.js to unblock CI on main

### DIFF
--- a/surface-core/src/copy.js
+++ b/surface-core/src/copy.js
@@ -240,10 +240,7 @@ export function formatJourneyRunEvidenceLines(evidence, opts = {}) {
 			`• ${name}: ${pass} passed, ${fail} failed${pending > 0 ? `, ${pending} pending` : ""}`,
 		);
 	}
-	const sessions = (evidence?.sessions ?? []).slice(
-		0,
-		opts.maxSessions ?? 5,
-	);
+	const sessions = (evidence?.sessions ?? []).slice(0, opts.maxSessions ?? 5);
 	for (const session of sessions) {
 		const who = session.personaLabel || session.personaId || "session";
 		const verdict =


### PR DESCRIPTION
## What

Mechanical `biome check --write` on `surface-core/src/copy.js` — one `.slice(` call rejoined onto one line. No behavior change.

## Why

#3990 merged while its `test.yml` run was **cancelled**, so the unformatted file landed on main without a completed check. Since then every `test.yml` run on main is red ([7a687a34](https://github.com/MCPJam/inspector/actions?query=branch%3Amain), [08c4cd1f](https://github.com/MCPJam/inspector/actions?query=branch%3Amain)) and every open PR fails the `Run Tests` job at `npm run verify -w @mcpjam/surface-core` → lint, because PR CI merges against main's tip (first observed triaging #3999, which touches no surface-core files).

Verified locally: `biome check` clean and the surface-core test suite (80 tests) green after the fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Formatting-only change with no logic, security, or data-handling impact.
> 
> **Overview**
> **Unblocks CI on `main`** by applying Biome’s formatter to `surface-core/src/copy.js` after an unformatted merge slipped through when a prior PR’s `test.yml` run was cancelled.
> 
> The only code change is collapsing a multi-line `(evidence?.sessions ?? []).slice(...)` call onto one line. **No runtime or copy behavior changes** — this is lint/format compliance so `npm run verify -w @mcpjam/surface-core` passes again.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c7509f062542d9cf7d416d12f925532f21dc0b18. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Formats `surface-core/src/copy.js` with `biome` to restore passing CI on `main`. Previously, linting failed in `@mcpjam/surface-core` due to a multi-line `.slice(`; now it’s single-line. No runtime behavior change.

**Review notes**
- Mechanical `biome check --write`; only changes line wrapping of the `.slice(...)` call.
- Scope: 1 file; unblocks `test.yml` by fixing lint in `@mcpjam/surface-core`.
- Verified locally: `biome check` clean and `@mcpjam/surface-core` tests pass.

<sup>Written for commit c7509f062542d9cf7d416d12f925532f21dc0b18. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/MCPJam/inspector/pull/4005?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

