### PR TITLE
oauth: report the server's real reason when a token request fails

### DIFF
--- a/sdk/src/oauth-conformance/auth-strategies/client-credentials.ts
+++ b/sdk/src/oauth-conformance/auth-strategies/client-credentials.ts
@@ -1,3 +1,4 @@
+import { describeTokenRequestFailure } from "../../oauth/state-machines/shared/response-error.js";
 import type {
   ClientCredentialsResult,
   TrackedRequestFn,
@@ -56,9 +57,7 @@ export async function performClientCredentialsGrant({
   });
 
   if (!tokenResponse.ok) {
-    throw new Error(
-      `Token request failed: ${tokenResponse.body?.error || tokenResponse.statusText} - ${tokenResponse.body?.error_description || "Unknown error"}`,
-    );
+    throw new Error(describeTokenRequestFailure(tokenResponse));
   }
 
   if (!tokenResponse.body?.access_token) {

--- a/sdk/src/oauth/state-machines/debug-oauth-2025-03-26.ts
+++ b/sdk/src/oauth/state-machines/debug-oauth-2025-03-26.ts
@@ -9,7 +9,10 @@
  * - No Client ID Metadata Documents support
  */
 
-import { describeAuthenticatedRequestFailure } from "./shared/response-error.js";
+import {
+  describeAuthenticatedRequestFailure,
+  describeTokenRequestFailure,
+} from "./shared/response-error.js";
 import { decodeJWT, formatJWTTimestamp } from "./shared/jwt.js";
 import { EMPTY_OAUTH_FLOW_STATE, buildResetFlowState } from "./types.js";
 import type {
@@ -1028,7 +1031,7 @@ export const createDebugOAuthStateMachine = (
                   lastResponse: tokenResponseData,
                   httpHistory: updatedHistoryToken,
                   authorizationCode: undefined,
-                  error: `Token request failed: ${response.body?.error || response.statusText} - ${response.body?.error_description || "Unknown error"}`,
+                  error: describeTokenRequestFailure(response),
                   isInitiatingAuth: false,
                 });
                 return;

--- a/sdk/src/oauth/state-machines/debug-oauth-2025-06-18.ts
+++ b/sdk/src/oauth/state-machines/debug-oauth-2025-06-18.ts
@@ -8,7 +8,10 @@
  * - No Client ID Metadata Documents support
  */
 
-import { describeAuthenticatedRequestFailure } from "./shared/response-error.js";
+import {
+  describeAuthenticatedRequestFailure,
+  describeTokenRequestFailure,
+} from "./shared/response-error.js";
 import { decodeJWT, formatJWTTimestamp } from "./shared/jwt.js";
 import { EMPTY_OAUTH_FLOW_STATE, buildResetFlowState } from "./types.js";
 import type {
@@ -1420,7 +1423,7 @@ export const createDebugOAuthStateMachine = (
                   httpHistory: updatedHistoryToken,
                   // Clear the authorization code so it won't be retried
                   authorizationCode: undefined,
-                  error: `Token request failed: ${response.body?.error || response.statusText} - ${response.body?.error_description || "Unknown error"}`,
+                  error: describeTokenRequestFailure(response),
                   isInitiatingAuth: false,
                 });
                 return;

--- a/sdk/src/oauth/state-machines/debug-oauth-2025-11-25.ts
+++ b/sdk/src/oauth/state-machines/debug-oauth-2025-11-25.ts
@@ -8,7 +8,10 @@
  * - Client ID Metadata Documents (CIMD) support per draft-parecki-oauth-client-id-metadata-document-03
  */
 
-import { describeAuthenticatedRequestFailure } from "./shared/response-error.js";
+import {
+  describeAuthenticatedRequestFailure,
+  describeTokenRequestFailure,
+} from "./shared/response-error.js";
 import { decodeJWT, formatJWTTimestamp } from "./shared/jwt.js";
 import { EMPTY_OAUTH_FLOW_STATE, buildResetFlowState } from "./types.js";
 import type {
@@ -1627,7 +1630,7 @@ export const createDebugOAuthStateMachine = (
                   httpHistory: updatedHistoryToken,
                   // Clear the authorization code so it won't be retried
                   authorizationCode: undefined,
-                  error: `Token request failed: ${response.body?.error || response.statusText} - ${response.body?.error_description || "Unknown error"}`,
+                  error: describeTokenRequestFailure(response),
                   isInitiatingAuth: false,
                 });
                 return;

--- a/sdk/src/oauth/state-machines/debug-oauth-2026-07-28.ts
+++ b/sdk/src/oauth/state-machines/debug-oauth-2026-07-28.ts
@@ -8,7 +8,10 @@
  * - Client ID Metadata Documents (CIMD) support per draft-parecki-oauth-client-id-metadata-document-03
  */
 
-import { describeAuthenticatedRequestFailure } from "./shared/response-error.js";
+import {
+  describeAuthenticatedRequestFailure,
+  describeTokenRequestFailure,
+} from "./shared/response-error.js";
 import { decodeJWT, formatJWTTimestamp } from "./shared/jwt.js";
 import { EMPTY_OAUTH_FLOW_STATE, buildResetFlowState } from "./types.js";
 import type {
@@ -2037,7 +2040,7 @@ export const createDebugOAuthStateMachine = (
                   httpHistory: updatedHistoryToken,
                   // Clear the authorization code so it won't be retried
                   authorizationCode: undefined,
-                  error: `Token request failed: ${response.body?.error || response.statusText} - ${response.body?.error_description || "Unknown error"}`,
+                  error: describeTokenRequestFailure(response),
                   isInitiatingAuth: false,
                 });
                 return;

--- a/sdk/src/oauth/state-machines/shared/response-error.ts
+++ b/sdk/src/oauth/state-machines/shared/response-error.ts
@@ -150,20 +150,38 @@ interface FailedResponse {
  * toast and titles an error-report group, so a stack trace or an HTML page must
  * not carry its newlines in — and collapsing before the cap would scan the
  * whole body to do it.
+ *
+ * `statusText` goes through the same pipeline as the reason, for the same
+ * reason: it is the reason-phrase the server under test wrote, not a value we
+ * derived. RFC 9112 confines it to one short line of visible characters, but a
+ * server that ignores that — or a proxy that synthesizes the field from
+ * something else — would otherwise put unredacted text straight into the
+ * message. The status code beside it is the part that is always trustworthy.
+ *
+ * An empty phrase is dropped rather than printed, so a response with no reason
+ * phrase reads `"...: 502"` instead of trailing a bare space. `statusText` is
+ * typed as required, but the value crosses a proxy boundary before it gets
+ * here, so a missing one degrades to that same code-only form rather than
+ * throwing inside the redactor.
  */
 function describeResponseFailure(
   label: string,
   response: FailedResponse,
 ): string {
+  const safeStatusText = toSingleLine(
+    sanitizeTraceErrorMessage(response.statusText ?? "", {
+      maxLength: MAX_REASON_CHARS,
+    }),
+  );
   const reason = extractResponseErrorReason(response.body);
   const safeReason = reason
     ? toSingleLine(
         sanitizeTraceErrorMessage(reason, { maxLength: MAX_REASON_CHARS }),
       )
     : undefined;
-  return `${label}: ${response.status} ${response.statusText}${
-    safeReason ? `: ${safeReason}` : ""
-  }`;
+  return `${label}: ${response.status}${
+    safeStatusText ? ` ${safeStatusText}` : ""
+  }${safeReason ? `: ${safeReason}` : ""}`;
 }
 
 /**

--- a/sdk/src/oauth/state-machines/shared/response-error.ts
+++ b/sdk/src/oauth/state-machines/shared/response-error.ts
@@ -115,18 +115,28 @@ export function extractResponseErrorReason(body: unknown): string | undefined {
   return errorMessage;
 }
 
+/** A response a step can fail on — the fields every failure message reads. */
+interface FailedResponse {
+  status: number;
+  statusText: string;
+  body?: unknown;
+}
+
 /**
- * The flow error for a rejected authenticated request — the debugger's last
- * step, where the server under test answers the token it just issued.
+ * `"<what failed>: <status line>"`, plus the server's own reason when its body
+ * carries one.
  *
- * Status line first so the shape is unchanged, then the server's own reason
- * when the body carries one. Every protocol era ends on that step (older ones
- * with `initialize`, 2026-07-28 with `tools/list`), so they all report it the
- * same way.
+ * The status line always leads, so a body that explains nothing still names the
+ * code. Never interpolate a body field into the message directly: `error` is a
+ * string only when the server follows RFC 6749, and an MCP server rejecting the
+ * request answers with the JSON-RPC `{ error: { code, message } }` shape
+ * instead — which renders as `[object Object]` and buries every distinct
+ * failure in one error-report group. {@link extractResponseErrorReason} knows
+ * both shapes.
  *
  * The reason is redacted here rather than at each display: it is text the
  * server under test chose, and MCPJam is routinely pointed at half-built
- * servers that echo the bearer token back in an error body. This value becomes
+ * servers that echo the bearer token back in an error body. The result becomes
  * `state.error`, which is toasted, folded into conformance step results, and
  * reported — the full body stays readable in HTTP history either way.
  *
@@ -136,23 +146,48 @@ export function extractResponseErrorReason(body: unknown): string | undefined {
  * credential whose closing delimiter sat just past the cap. Its own scan window
  * (`MAX_SCANNED`) bounds the work, so a megabyte body costs one slice.
  *
- * Whitespace is collapsed last, on that capped output: the flow error renders
- * in a toast and titles an error-report group, so a stack trace or an HTML page
- * must not carry its newlines in — and collapsing before the cap would scan the
+ * Whitespace is collapsed last, on that capped output: the message renders in a
+ * toast and titles an error-report group, so a stack trace or an HTML page must
+ * not carry its newlines in — and collapsing before the cap would scan the
  * whole body to do it.
  */
-export function describeAuthenticatedRequestFailure(response: {
-  status: number;
-  statusText: string;
-  body?: unknown;
-}): string {
+function describeResponseFailure(
+  label: string,
+  response: FailedResponse,
+): string {
   const reason = extractResponseErrorReason(response.body);
   const safeReason = reason
     ? toSingleLine(
         sanitizeTraceErrorMessage(reason, { maxLength: MAX_REASON_CHARS }),
       )
     : undefined;
-  return `Authenticated request failed: ${response.status} ${
-    response.statusText
-  }${safeReason ? `: ${safeReason}` : ""}`;
+  return `${label}: ${response.status} ${response.statusText}${
+    safeReason ? `: ${safeReason}` : ""
+  }`;
+}
+
+/**
+ * The flow error for a rejected authenticated request — the debugger's last
+ * step, where the server under test answers the token it just issued.
+ *
+ * Every protocol era ends on that step (older ones with `initialize`,
+ * 2026-07-28 with `tools/list`), so they all report it the same way.
+ */
+export function describeAuthenticatedRequestFailure(
+  response: FailedResponse,
+): string {
+  return describeResponseFailure("Authenticated request failed", response);
+}
+
+/**
+ * The flow error for a rejected token exchange — the authorization server
+ * refusing to trade the code (or the client credentials) for a token.
+ *
+ * Shared by every debug state machine and by the conformance
+ * client-credentials strategy, which all previously hand-rolled the message
+ * from `body.error` and so reported `[object Object] - Unknown error` whenever
+ * the endpoint answered in a non-RFC-6749 shape.
+ */
+export function describeTokenRequestFailure(response: FailedResponse): string {
+  return describeResponseFailure("Token request failed", response);
 }

--- a/sdk/tests/oauth/response-error.test.ts
+++ b/sdk/tests/oauth/response-error.test.ts
@@ -246,3 +246,63 @@ describe("describeTokenRequestFailure", () => {
     expect(message).toContain("invalid_client");
   });
 });
+
+// The reason phrase is the server's text too, so it gets the reason's
+// treatment. RFC 9112 keeps it to one short line of visible characters, but the
+// endpoint is the server under test and the value crosses a proxy before it
+// reaches us — the status code beside it is the only part we can trust.
+describe("describeResponseFailure status-phrase handling", () => {
+  it("redacts a credential reflected in the reason phrase", () => {
+    const message = describeTokenRequestFailure({
+      status: 401,
+      statusText:
+        "Unauthorized - Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.abc.def",
+      body: undefined,
+    });
+
+    expect(message).not.toContain("eyJhbGciOiJIUzI1NiJ9");
+    expect(message).toContain("401");
+  });
+
+  it("keeps a multiline phrase on one line", () => {
+    const message = describeAuthenticatedRequestFailure({
+      status: 500,
+      statusText: "Internal Error\n  at Server.handle (server.js:12)",
+      body: undefined,
+    });
+
+    expect(message).toBe(
+      "Authenticated request failed: 500 Internal Error at Server.handle (server.js:12)"
+    );
+  });
+
+  it("caps a phrase long enough to swamp the message", () => {
+    const message = describeTokenRequestFailure({
+      status: 400,
+      statusText: "y".repeat(5_000),
+      body: undefined,
+    });
+
+    expect(message).toBe(`Token request failed: 400 ${"y".repeat(300)}`);
+  });
+
+  // A proxied response can carry no phrase at all; printing the space anyway
+  // left a message ending in one.
+  it("drops an absent phrase instead of trailing a bare space", () => {
+    expect(
+      describeTokenRequestFailure({
+        status: 502,
+        statusText: "",
+        body: undefined,
+      })
+    ).toBe("Token request failed: 502");
+
+    expect(
+      describeTokenRequestFailure({
+        status: 502,
+        statusText: undefined as unknown as string,
+        body: { error: "temporarily_unavailable" },
+      })
+    ).toBe("Token request failed: 502: temporarily_unavailable");
+  });
+});

--- a/sdk/tests/oauth/response-error.test.ts
+++ b/sdk/tests/oauth/response-error.test.ts
@@ -1,5 +1,6 @@
 import {
   describeAuthenticatedRequestFailure,
+  describeTokenRequestFailure,
   extractResponseErrorReason,
 } from "../../src/oauth/state-machines/shared/response-error.js";
 
@@ -181,5 +182,67 @@ describe("describeAuthenticatedRequestFailure", () => {
     });
 
     expect(message).not.toContain("PASSWORD");
+  });
+});
+
+describe("describeTokenRequestFailure", () => {
+  // The reported failure (INSPECTOR-CLIENT-239): the endpoint answered in a
+  // shape RFC 6749 does not describe, so the old message interpolated an object
+  // into a template literal and lost the one field that said what went wrong.
+  it("reads a non-RFC-6749 nested error instead of rendering [object Object]", () => {
+    const message = describeTokenRequestFailure({
+      status: 400,
+      statusText: "Bad Request",
+      body: { error: { code: -32600, message: "code_verifier mismatch" } },
+    });
+
+    expect(message).toBe(
+      "Token request failed: 400 Bad Request: code_verifier mismatch"
+    );
+    expect(message).not.toContain("[object Object]");
+    expect(message).not.toContain("Unknown error");
+  });
+
+  it("pairs the OAuth error code with its description", () => {
+    expect(
+      describeTokenRequestFailure({
+        status: 400,
+        statusText: "Bad Request",
+        body: {
+          error: "invalid_grant",
+          error_description: "Authorization code expired",
+        },
+      })
+    ).toBe(
+      "Token request failed: 400 Bad Request: invalid_grant: Authorization code expired"
+    );
+  });
+
+  // The status is what stays actionable when the endpoint says nothing — the
+  // old message dropped it whenever `body.error` was set, and printed a bare
+  // "Unknown error" whenever it was not.
+  it("keeps the status line when the body explains nothing", () => {
+    expect(
+      describeTokenRequestFailure({
+        status: 502,
+        statusText: "Bad Gateway",
+        body: undefined,
+      })
+    ).toBe("Token request failed: 502 Bad Gateway");
+  });
+
+  it("redacts a credential the endpoint echoed back", () => {
+    const message = describeTokenRequestFailure({
+      status: 401,
+      statusText: "Unauthorized",
+      body: {
+        error: "invalid_client",
+        error_description:
+          'rejected {"client_secret": "SECRETvalue0123456789"} for this client',
+      },
+    });
+
+    expect(message).not.toContain("SECRETvalue");
+    expect(message).toContain("invalid_client");
   });
 });

--- a/slack-app/listeners/actions/journey-run-watcher.js
+++ b/slack-app/listeners/actions/journey-run-watcher.js
@@ -20,11 +20,7 @@ import {
   journeyOutcomeWantsEvidence,
   watchJourneyRunUntilDone,
 } from '@mcpjam/surface-core';
-import {
-  getJourneyRun,
-  getJourneyRunScorecard,
-  listJourneyRunSessions,
-} from '../../agent/mcpjam-client.js';
+import { getJourneyRun, getJourneyRunScorecard, listJourneyRunSessions } from '../../agent/mcpjam-client.js';
 
 const POLL_INTERVAL_MS = 15_000;
 // An hour, not the eval watcher's fifteen minutes: a fan-out across four
@@ -47,10 +43,7 @@ const EVIDENCE_SESSION_LIMIT = 5;
  * @param {string} userId
  */
 export function formatJourneyRunOutcome(run, outcome, url, userId) {
-  const counts =
-    outcome.total > 0
-      ? ` (${outcome.succeeded}/${outcome.total} sessions reached their goal)`
-      : '';
+  const counts = outcome.total > 0 ? ` (${outcome.succeeded}/${outcome.total} sessions reached their goal)` : '';
   const who = ` — approved by <@${userId}>`;
   switch (outcome.kind) {
     case 'passed':
@@ -131,9 +124,7 @@ export async function announceAndWatchJourneyRun(client, args) {
   const posted = await client.chat.postMessage({
     channel: args.channelId,
     thread_ts: args.threadTs,
-    text:
-      args.text ??
-      `:rocket: Approved by <@${args.userId}> — swarm running… <${args.url}|watch it here>.`,
+    text: args.text ?? `:rocket: Approved by <@${args.userId}> — swarm running… <${args.url}|watch it here>.`,
   });
   if (!posted.ts) return;
   const statusTs = /** @type {string} */ (posted.ts);
@@ -147,8 +138,7 @@ export async function announceAndWatchJourneyRun(client, args) {
       pollIntervalMs: POLL_INTERVAL_MS,
       maxMs: POLL_MAX_MS,
       statusHandle: { id: statusTs, channelId: args.channelId },
-      formatOutcome: (run, outcome, url, actorId) =>
-        formatJourneyRunOutcome(run, outcome, url, actorId),
+      formatOutcome: (run, outcome, url, actorId) => formatJourneyRunOutcome(run, outcome, url, actorId),
       logger: args.logger,
       onTerminal: async (_run, outcome) => {
         if (!journeyOutcomeWantsEvidence(outcome)) return;
@@ -181,9 +171,7 @@ export async function announceAndWatchJourneyRun(client, args) {
           text: `:hourglass_flowing_sand: Swarm run is still going after an hour — <${args.url}|follow the rest in the app>.`,
         });
       } catch (error) {
-        args.logger.warn(
-          `Journey run ${args.runId} still-running edit failed: ${error}`
-        );
+        args.logger.warn(`Journey run ${args.runId} still-running edit failed: ${error}`);
       }
     }
   })();

--- a/slack-app/listeners/actions/proposal-button.js
+++ b/slack-app/listeners/actions/proposal-button.js
@@ -22,9 +22,9 @@ import { tryslackContextFrom } from '../../agent/slack-context.js';
 import { resolveTurnTarget } from '../../agent/turn-target.js';
 import { friendlyMessage as slackFriendlyMessage } from '../../render/slack.js';
 import { escapeSlackText } from '../views/agent-reply-builder.js';
+import { announceAndWatchJourneyRun } from './journey-run-watcher.js';
 import { postRunEvidence } from './run-evidence.js';
 import { announceAndWatchRun, isFailedOutcome } from './run-watcher.js';
-import { announceAndWatchJourneyRun } from './journey-run-watcher.js';
 
 /**
  * What to say once the action has actually run.
@@ -228,11 +228,7 @@ export async function handleProposalButton({ ack, body, client, context, logger,
     // eval runs (see surface-core's journey-run-watcher header), so routing it
     // into the eval watcher would report a rate-limited fan-out as a pass.
     // Same recognition rule as above: the server-sent resource TYPE.
-    if (
-      outcome.resource?.type === 'journey_run' &&
-      outcome.resource.id &&
-      outcome.resource.url
-    ) {
+    if (outcome.resource?.type === 'journey_run' && outcome.resource.id && outcome.resource.url) {
       await announceAndWatchJourneyRun(client, {
         runId: outcome.resource.id,
         url: outcome.resource.url,

--- a/surface-core/src/copy.js
+++ b/surface-core/src/copy.js
@@ -240,10 +240,7 @@ export function formatJourneyRunEvidenceLines(evidence, opts = {}) {
 			`• ${name}: ${pass} passed, ${fail} failed${pending > 0 ? `, ${pending} pending` : ""}`,
 		);
 	}
-	const sessions = (evidence?.sessions ?? []).slice(
-		0,
-		opts.maxSessions ?? 5,
-	);
+	const sessions = (evidence?.sessions ?? []).slice(0, opts.maxSessions ?? 5);
 	for (const session of sessions) {
 		const who = session.personaLabel || session.personaId || "session";
 		const verdict =


### PR DESCRIPTION
Fixes [INSPECTOR-CLIENT-239](https://mcpjam-gh.sentry.io/issues/INSPECTOR-CLIENT-239) · Kestral [BUGS-44](https://app.kestral.ai/workspace/yhNILB2/task/1IMoc9z7)

## The failure

Production surfaced `Token request failed: [object Object] - Unknown error` on `app.mcpjam.com/oauth-flow` (release 2.36.0, protocol 2025-11-25).

The token-exchange step built its message by interpolating the response body straight into a template literal:

```ts
`Token request failed: ${response.body?.error || response.statusText} - ${response.body?.error_description || "Unknown error"}`
```

RFC 6749 makes `error` a string, but the endpoint here is the server *under test* and does not always comply. An MCP server rejecting the exchange answers with the JSON-RPC shape `{ error: { code, message } }`. An object in a template literal renders as `[object Object]`, and since that shape carries no top-level `error_description`, the rest of the line degraded to `Unknown error`.

Three things went wrong at once: the one field that explained the failure (`error.message`) was discarded, the HTTP status never made it into the message because `body.error` shadowed `statusText`, and in Sentry every distinct server failure collapsed into one group titled with a constant string.

## The fix

`extractResponseErrorReason` in `shared/response-error.ts` already handles this — the OAuth `error`/`error_description` pair, plain-text bodies, *and* explicitly the nested JSON-RPC shape — then redacts credentials, caps at 300 chars, and collapses to one line. It was wired into `describeAuthenticatedRequestFailure` and used by all four state machines, but only for the **final authenticated-request step**. The token-request step was never migrated and kept the old hand-rolled interpolation. This is an unfinished refactor, not a new design.

So: generalize `describeAuthenticatedRequestFailure` over its label into a private `describeResponseFailure`, add `describeTokenRequestFailure` beside it, and apply it at the five sites still hand-rolling the message — the four protocol-era state machines and the conformance client-credentials strategy, which had the identical defect.

Messages now lead with the status line and append the server's own reason when there is one:

```
Token request failed: 400 Bad Request: code_verifier mismatch
Token request failed: 400 Bad Request: invalid_grant: Authorization code expired
Token request failed: 502 Bad Gateway
```

## Review follow-up: the reason phrase (ad441ce8b)

CodeRabbit caught that `statusText` was still interpolated raw while the body-derived reason was redacted. Valid, and the same argument applies: the reason phrase is text the server under test wrote. RFC 9112 confines it to one short line of visible characters, but this code path exists *for* servers that ignore the spec, and the value crosses the proxy before it reaches us — the status code beside it is the only part that is always ours. A token endpoint reflecting a bearer token into its phrase would have put it straight into the flow error, the toast and the error report.

It now goes through the same pipeline. An empty phrase is dropped rather than printed, so a proxied response carrying none reads `Token request failed: 502` instead of trailing a bare space; an absent one degrades to that same form rather than throwing inside the redactor, which reads `message.length`.

This hardens the pre-existing `describeAuthenticatedRequestFailure` path too, since both now share the formatter.

## Also here: unblocking `main`'s lint gate (94e160924, a1e8d4bcc)

`Run Tests` was failing on **`main`**, not because of this branch. `#3990` landed unformatted code in two workspaces that gate on `npx @biomejs/biome check .`:

- `surface-core/src/copy.js` — a `.slice(...)` the formatter wants on one line.
- `slack-app/listeners/actions/{journey-run-watcher,proposal-button}.js` — three errors: collapsing onto slack-app's 120-column limit, plus a new import to sort.

`concurrently --kill-others-on-fail` stopped the job the moment surface-core failed, so the slack-app half only appeared once the first was green — hence two commits. Both are formatter output with no hand edits, kept separate from the OAuth work so they can be cherry-picked to `main` directly. `discord-app`, the third workspace on that gate, is already clean.

Worth flagging for follow-up: these three workspaces are the only ones linting via `npx @biomejs/biome`, and nothing catches an unformatted merge before it reddens every open PR.

One non-blocking `noUnusedFunctionParameters` warning survives in each of `copy.js:148` and `journey-run-watcher.js:49` (an unused `run` param). Warnings don't fail the gate and the fix is marked unsafe, so they're left alone.

## Verification

- `sdk/tests/oauth/response-error.test.ts` — 8 new cases. Four pin the reported bug: the nested JSON-RPC body no longer renders `[object Object]` or `Unknown error`, the OAuth pair composes, a body that explains nothing keeps its status line, and an echoed `client_secret` is redacted. Four more cover the phrase: a reflected bearer token, a multiline phrase, a 5000-char phrase hitting the cap, and the empty/absent cases. **23 pass** in the file.
- SDK OAuth suite: **843 passed**, 7 skipped, 38 files — including all four protocol-era golden snapshots, unchanged, confirming no non-failing path shifted.
- Inspector client OAuth suites: **275 passed** (19 files).
- `npm run typecheck` clean; guard checks `check:mcp-v1-runtime-imports`, `check:platform-runtime-safety`, `check:bundled-runtime-paths` and `sdk` `test:packaging` all pass.
- **CI green**: `Run Tests`, `Build and Test`, `Inspector Tests 1-4/4`, `E2E Smoke (Playwright)`, both Snyk checks and cubic all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
