### PR TITLE
style(slack-app): biome formatting — unbreak Run Tests on main

### DIFF
--- a/slack-app/listeners/actions/journey-run-watcher.js
+++ b/slack-app/listeners/actions/journey-run-watcher.js
@@ -20,11 +20,7 @@ import {
   journeyOutcomeWantsEvidence,
   watchJourneyRunUntilDone,
 } from '@mcpjam/surface-core';
-import {
-  getJourneyRun,
-  getJourneyRunScorecard,
-  listJourneyRunSessions,
-} from '../../agent/mcpjam-client.js';
+import { getJourneyRun, getJourneyRunScorecard, listJourneyRunSessions } from '../../agent/mcpjam-client.js';
 
 const POLL_INTERVAL_MS = 15_000;
 // An hour, not the eval watcher's fifteen minutes: a fan-out across four
@@ -47,10 +43,7 @@ const EVIDENCE_SESSION_LIMIT = 5;
  * @param {string} userId
  */
 export function formatJourneyRunOutcome(run, outcome, url, userId) {
-  const counts =
-    outcome.total > 0
-      ? ` (${outcome.succeeded}/${outcome.total} sessions reached their goal)`
-      : '';
+  const counts = outcome.total > 0 ? ` (${outcome.succeeded}/${outcome.total} sessions reached their goal)` : '';
   const who = ` — approved by <@${userId}>`;
   switch (outcome.kind) {
     case 'passed':
@@ -131,9 +124,7 @@ export async function announceAndWatchJourneyRun(client, args) {
   const posted = await client.chat.postMessage({
     channel: args.channelId,
     thread_ts: args.threadTs,
-    text:
-      args.text ??
-      `:rocket: Approved by <@${args.userId}> — swarm running… <${args.url}|watch it here>.`,
+    text: args.text ?? `:rocket: Approved by <@${args.userId}> — swarm running… <${args.url}|watch it here>.`,
   });
   if (!posted.ts) return;
   const statusTs = /** @type {string} */ (posted.ts);
@@ -147,8 +138,7 @@ export async function announceAndWatchJourneyRun(client, args) {
       pollIntervalMs: POLL_INTERVAL_MS,
       maxMs: POLL_MAX_MS,
       statusHandle: { id: statusTs, channelId: args.channelId },
-      formatOutcome: (run, outcome, url, actorId) =>
-        formatJourneyRunOutcome(run, outcome, url, actorId),
+      formatOutcome: (run, outcome, url, actorId) => formatJourneyRunOutcome(run, outcome, url, actorId),
       logger: args.logger,
       onTerminal: async (_run, outcome) => {
         if (!journeyOutcomeWantsEvidence(outcome)) return;
@@ -181,9 +171,7 @@ export async function announceAndWatchJourneyRun(client, args) {
           text: `:hourglass_flowing_sand: Swarm run is still going after an hour — <${args.url}|follow the rest in the app>.`,
         });
       } catch (error) {
-        args.logger.warn(
-          `Journey run ${args.runId} still-running edit failed: ${error}`
-        );
+        args.logger.warn(`Journey run ${args.runId} still-running edit failed: ${error}`);
       }
     }
   })();

--- a/slack-app/listeners/actions/proposal-button.js
+++ b/slack-app/listeners/actions/proposal-button.js
@@ -22,9 +22,9 @@ import { tryslackContextFrom } from '../../agent/slack-context.js';
 import { resolveTurnTarget } from '../../agent/turn-target.js';
 import { friendlyMessage as slackFriendlyMessage } from '../../render/slack.js';
 import { escapeSlackText } from '../views/agent-reply-builder.js';
+import { announceAndWatchJourneyRun } from './journey-run-watcher.js';
 import { postRunEvidence } from './run-evidence.js';
 import { announceAndWatchRun, isFailedOutcome } from './run-watcher.js';
-import { announceAndWatchJourneyRun } from './journey-run-watcher.js';
 
 /**
  * What to say once the action has actually run.
@@ -228,11 +228,7 @@ export async function handleProposalButton({ ack, body, client, context, logger,
     // eval runs (see surface-core's journey-run-watcher header), so routing it
     // into the eval watcher would report a rate-limited fan-out as a pass.
     // Same recognition rule as above: the server-sent resource TYPE.
-    if (
-      outcome.resource?.type === 'journey_run' &&
-      outcome.resource.id &&
-      outcome.resource.url
-    ) {
+    if (outcome.resource?.type === 'journey_run' && outcome.resource.id && outcome.resource.url) {
       await announceAndWatchJourneyRun(client, {
         runId: outcome.resource.id,
         url: outcome.resource.url,


### PR DESCRIPTION
main's required **Run Tests** check is currently failing on every PR (and on main itself — [example run](https://github.com/MCPJam/inspector/actions/runs/31783263041)) in the slack-app workspace's lint step: biome format drift in `journey-run-watcher.js` / `proposal-button.js`. This is `biome check --write` output only — no behavior change. The workspace's lint is clean after (one pre-existing non-failing warning).

Merging this unblocks the Run Tests check for the other open PRs (#3995, #3998, #4007, #4009, #4010).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Formatting and import order only; no functional code changes.
> 
> **Overview**
> Applies **Biome** formatter output to `journey-run-watcher.js` and `proposal-button.js` so `slack-app`’s `biome check` passes again and the repo **Run Tests** lint step stops failing on format drift.
> 
> Changes are whitespace and line breaks only: collapsed multi-line imports, ternaries, `chat.postMessage` text, `formatOutcome` callbacks, and logger strings onto single lines where Biome expects them. In `proposal-button.js`, the `announceAndWatchJourneyRun` import is reordered with the other local action imports, and the `journey_run` resource guard is formatted to one line—**no logic or runtime behavior changes**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a808dd170c2775d179e87d562d40c17c1c7b8616. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the failing Run Tests check by applying `biome` formatting in the Slack app workspace. Previously, CI failed due to lint format drift on main; after this change, lint passes with no runtime behavior changes.

- Ran `biome check --write` on `listeners/actions/journey-run-watcher.js` and `listeners/actions/proposal-button.js` (formatting only).
- Review focus: verify the `slack-app` lint step passes; confirm the diff is formatting-only.
- Rollout: merge to main; no configuration or migration steps.

<sup>Written for commit a808dd170c2775d179e87d562d40c17c1c7b8616. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/MCPJam/inspector/pull/4011?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

