### PR TITLE
feat(ratings): thumbs up/down widget style for per-turn ratings

### DIFF
--- a/chat-ui/src/__tests__/turn-rating.test.tsx
+++ b/chat-ui/src/__tests__/turn-rating.test.tsx
@@ -188,3 +188,115 @@ describe("TurnRating", () => {
     expect(screen.getByRole("radio", { name: "5 of 5" })).toBeChecked();
   });
 });
+
+describe("TurnRating — thumbs variant", () => {
+  it("renders two thumbs as a radiogroup", () => {
+    render(<TurnRating variant="thumbs" />);
+    expect(screen.getByRole("radiogroup")).toBeInTheDocument();
+    expect(screen.getAllByRole("radio")).toHaveLength(2);
+    expect(
+      screen.getByRole("radio", { name: "Thumbs up" })
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("radio", { name: "Thumbs down" })
+    ).toBeInTheDocument();
+  });
+
+  it("submits 1 for up and 0 for down — the numeric contract is unchanged", () => {
+    const onSubmit = vi.fn();
+    const { unmount } = render(
+      <TurnRating variant="thumbs" onSubmit={onSubmit} />
+    );
+    fireEvent.click(screen.getByRole("radio", { name: "Thumbs up" }));
+    expect(onSubmit).toHaveBeenCalledWith({ value: 1 });
+
+    unmount();
+    onSubmit.mockClear();
+    render(<TurnRating variant="thumbs" onSubmit={onSubmit} />);
+    fireEvent.click(screen.getByRole("radio", { name: "Thumbs down" }));
+    expect(onSubmit).toHaveBeenCalledWith({ value: 0 });
+  });
+
+  it("opens the comment row on the first thumb, like stars", () => {
+    const onSubmit = vi.fn();
+    render(<TurnRating variant="thumbs" onSubmit={onSubmit} />);
+
+    expect(screen.queryByRole("textbox")).toBeNull();
+    fireEvent.click(screen.getByRole("radio", { name: "Thumbs down" }));
+
+    fireEvent.change(screen.getByRole("textbox"), {
+      target: { value: "made something up" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: "Send" }));
+
+    expect(onSubmit).toHaveBeenLastCalledWith({
+      value: 0,
+      comment: "made something up",
+    });
+  });
+
+  it("distinguishes a stored thumbs-down from nothing rated at all", () => {
+    // The `draftValue === undefined` sentinel earning its keep: 0 is a real
+    // judgement, and a falsy check anywhere in here would render it unrated.
+    const { rerender } = render(<TurnRating variant="thumbs" />);
+    expect(
+      screen.getByRole("radio", { name: "Thumbs down" })
+    ).not.toBeChecked();
+
+    rerender(<TurnRating variant="thumbs" value={0} status="submitted" />);
+    expect(screen.getByRole("radio", { name: "Thumbs down" })).toBeChecked();
+    expect(screen.getByRole("radio", { name: "Thumbs up" })).not.toBeChecked();
+  });
+
+  it("re-clicking the other thumb switches the judgement", () => {
+    const onSubmit = vi.fn();
+    render(
+      <TurnRating
+        variant="thumbs"
+        value={0}
+        status="submitted"
+        onSubmit={onSubmit}
+      />
+    );
+
+    fireEvent.click(screen.getByRole("radio", { name: "Thumbs up" }));
+
+    expect(onSubmit).toHaveBeenCalledWith({ value: 1 });
+    expect(screen.getByRole("radio", { name: "Thumbs up" })).toBeChecked();
+  });
+
+  it("blocks input while a submission is pending", () => {
+    const onSubmit = vi.fn();
+    render(
+      <TurnRating
+        variant="thumbs"
+        value={1}
+        status="pending"
+        onSubmit={onSubmit}
+      />
+    );
+
+    fireEvent.click(screen.getByRole("radio", { name: "Thumbs down" }));
+    expect(onSubmit).not.toHaveBeenCalled();
+  });
+
+  it("renders read-only with the comment and no inputs", () => {
+    const onSubmit = vi.fn();
+    render(
+      <TurnRating
+        variant="thumbs"
+        readOnly
+        value={0}
+        comment="wrong order"
+        status="submitted"
+        onSubmit={onSubmit}
+      />
+    );
+
+    expect(screen.getByRole("radio", { name: "Thumbs down" })).toBeChecked();
+    expect(screen.getByText(/wrong order/)).toBeInTheDocument();
+    expect(screen.queryByRole("textbox")).toBeNull();
+    fireEvent.click(screen.getByRole("radio", { name: "Thumbs up" }));
+    expect(onSubmit).not.toHaveBeenCalled();
+  });
+});

--- a/chat-ui/src/index.ts
+++ b/chat-ui/src/index.ts
@@ -19,6 +19,7 @@ export {
   TurnRating,
   type TurnRatingProps,
   type TurnRatingStatus,
+  type TurnRatingVariant,
 } from "./turn-rating";
 
 // --- Part renderers (handy for custom layouts) ---

--- a/chat-ui/src/turn-rating.tsx
+++ b/chat-ui/src/turn-rating.tsx
@@ -1,20 +1,38 @@
 import { useEffect, useState } from "react";
-import { Star } from "lucide-react";
+import { Star, ThumbsDown, ThumbsUp } from "lucide-react";
 
 import { cn } from "./internal/cn";
 
 const STARS = [1, 2, 3, 4, 5] as const;
 
+/** Thumbs, worst-first, so the row reads left-to-right like the star scale. */
+const THUMBS = [
+  { value: 0, label: "Thumbs down", Icon: ThumbsDown },
+  { value: 1, label: "Thumbs up", Icon: ThumbsUp },
+] as const;
+
 export type TurnRatingStatus = "idle" | "pending" | "submitted" | "error";
 
+/**
+ * Which control the tester sees. The host picks it from the scenario's
+ * `perTurnFeedback.style`; both emit the same `onSubmit({value, comment})`
+ * contract, only the value domain differs.
+ */
+export type TurnRatingVariant = "stars" | "thumbs";
+
 export interface TurnRatingProps {
-  /** Current rating, 1–5. Absent ⇒ nothing rated yet. */
+  /**
+   * Current rating: 1–5 for `stars`, or 0|1 for `thumbs`. Absent ⇒ nothing
+   * rated yet.
+   */
   value?: number;
   comment?: string;
   status?: TurnRatingStatus;
   /** Display-only (session detail view): no inputs, no submit. */
   readOnly?: boolean;
-  /** Label above the stars. Falsy ⇒ the default copy. */
+  /** Which control to render. Default `stars`. */
+  variant?: TurnRatingVariant;
+  /** Label above the control. Falsy ⇒ the default copy. */
   title?: string;
   commentPlaceholder?: string;
   submitLabel?: string;
@@ -25,7 +43,7 @@ export interface TurnRatingProps {
 }
 
 /**
- * Per-turn rating widget: five stars plus an optional comment.
+ * Per-turn rating widget: five stars (or 👍/👎) plus an optional comment.
  *
  * PRESENTATIONAL ONLY — no mutation, no store, no network. The host owns
  * submission and passes `status` back in, which is what lets the same
@@ -33,15 +51,23 @@ export interface TurnRatingProps {
  * detail view without a second implementation.
  *
  * `submitted` is a resting state, not a terminal one: a tester can revise a
- * rating, so the stars stay interactive and re-clicking one opens the comment
- * row again. The host's mutation upserts, so a revision replaces rather than
- * accumulates.
+ * rating, so the control stays interactive and re-clicking it opens the
+ * comment row again. The host's mutation upserts, so a revision replaces
+ * rather than accumulates.
+ *
+ * THUMBS IS A VARIANT, NOT A SIBLING COMPONENT. Everything except the row of
+ * buttons is shared — the comment editor and its collapse-on-success rule,
+ * the four status states, the two rehydration effects, the read-only render,
+ * and the `draftValue === undefined` sentinel that distinguishes "unrated"
+ * from "rated 0" (which a thumbs-down actually is, and which a second
+ * implementation would be free to get wrong).
  */
 export function TurnRating({
   value,
   comment,
   status = "idle",
   readOnly = false,
+  variant = "stars",
   title,
   commentPlaceholder,
   submitLabel,
@@ -87,11 +113,11 @@ export function TurnRating({
   const effective = hovered ?? draftValue ?? 0;
   const disabled = readOnly || status === "pending";
 
-  function selectStar(next: number) {
+  function selectValue(next: number) {
     if (disabled) return;
     setDraftValue(next);
     setExpanded(true);
-    // Submit the stars immediately. A rating that only counts once someone
+    // Submit the rating immediately. A rating that only counts once someone
     // also writes a comment is a rating most testers never leave; the comment
     // is a second, optional submit on top.
     //
@@ -101,7 +127,7 @@ export function TurnRating({
     // round-trip, blanking an annotation the server quietly kept.
     //
     // Deliberately not the draft: text someone typed and has not sent is not a
-    // rating they submitted, and changing their mind about the stars is not
+    // rating they submitted, and changing their mind about the rating is not
     // consent to publish it. The draft stays in the editor for `submitComment`.
     const saved = comment?.trim() ?? "";
     onSubmit?.({
@@ -136,33 +162,64 @@ export function TurnRating({
           className="flex items-center gap-0.5"
           onMouseLeave={() => setHovered(null)}
         >
-          {STARS.map((star) => (
-            <button
-              key={star}
-              type="button"
-              role="radio"
-              aria-checked={draftValue === star}
-              aria-label={`${star} of 5`}
-              disabled={disabled}
-              className={cn(
-                "rounded-sm p-0.5 text-muted-foreground transition-colors",
-                !disabled &&
-                  "hover:text-amber-500 focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring",
-                star <= effective && "text-amber-500",
-                disabled && "cursor-default"
-              )}
-              onMouseEnter={() => !disabled && setHovered(star)}
-              onClick={() => selectStar(star)}
-            >
-              <Star
-                className="h-4 w-4"
-                // Fill tracks hover as well as selection, so the row reads as
-                // "clicking here gives 3 stars" before the click.
-                fill={star <= effective ? "currentColor" : "none"}
-                aria-hidden
-              />
-            </button>
-          ))}
+          {variant === "thumbs"
+            ? THUMBS.map(({ value: thumbValue, label, Icon }) => {
+                // Compared against the DRAFT, not `effective`: a thumb is
+                // picked, not accumulated, so there is no "fills up to here"
+                // hover preview to mirror — hovering 👍 must not light 👎.
+                const selected = draftValue === thumbValue;
+                return (
+                  <button
+                    key={thumbValue}
+                    type="button"
+                    role="radio"
+                    aria-checked={selected}
+                    aria-label={label}
+                    disabled={disabled}
+                    className={cn(
+                      "rounded-sm p-0.5 text-muted-foreground transition-colors",
+                      !disabled &&
+                        "hover:text-amber-500 focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring",
+                      selected && "text-amber-500",
+                      disabled && "cursor-default"
+                    )}
+                    onClick={() => selectValue(thumbValue)}
+                  >
+                    <Icon
+                      className="h-4 w-4"
+                      fill={selected ? "currentColor" : "none"}
+                      aria-hidden
+                    />
+                  </button>
+                );
+              })
+            : STARS.map((star) => (
+                <button
+                  key={star}
+                  type="button"
+                  role="radio"
+                  aria-checked={draftValue === star}
+                  aria-label={`${star} of 5`}
+                  disabled={disabled}
+                  className={cn(
+                    "rounded-sm p-0.5 text-muted-foreground transition-colors",
+                    !disabled &&
+                      "hover:text-amber-500 focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring",
+                    star <= effective && "text-amber-500",
+                    disabled && "cursor-default"
+                  )}
+                  onMouseEnter={() => !disabled && setHovered(star)}
+                  onClick={() => selectValue(star)}
+                >
+                  <Star
+                    className="h-4 w-4"
+                    // Fill tracks hover as well as selection, so the row reads
+                    // as "clicking here gives 3 stars" before the click.
+                    fill={star <= effective ? "currentColor" : "none"}
+                    aria-hidden
+                  />
+                </button>
+              ))}
         </div>
         {status === "pending" ? (
           <span className="text-muted-foreground">Saving…</span>

--- a/mcpjam-inspector/client/src/components/chatboxes/ChatboxPerTurnFeedbackToggle.tsx
+++ b/mcpjam-inspector/client/src/components/chatboxes/ChatboxPerTurnFeedbackToggle.tsx
@@ -5,8 +5,18 @@ import {
   type ChatboxSettings,
   useChatboxMutations,
 } from "@/hooks/useChatboxes";
+import type { ChatboxPerTurnFeedbackStyle as PerTurnFeedbackStyle } from "@/types/chatUi";
 import { toast } from "@/lib/toast";
 import { convexErrMessage } from "@/lib/convex-error";
+
+const STYLE_OPTIONS: Array<{
+  value: PerTurnFeedbackStyle;
+  label: string;
+  hint: string;
+}> = [
+  { value: "stars", label: "Stars", hint: "Rate each response 1–5 stars" },
+  { value: "thumbs", label: "Thumbs", hint: "Rate each response 👍 or 👎" },
+];
 
 /**
  * The per-scenario rollout control for per-turn ratings.
@@ -29,19 +39,48 @@ export function ChatboxPerTurnFeedbackToggle({
   chatbox: ChatboxSettings;
 }) {
   const { updateChatbox } = useChatboxMutations();
-  const stored = chatbox.chatUi?.surfaces?.perTurnFeedback?.enabled === true;
+  const storedSurface = chatbox.chatUi?.surfaces?.perTurnFeedback;
+  const stored = storedSurface?.enabled === true;
+  // Absent ⇒ stars, matching the backend normalizer. Every scenario that
+  // predates the style field reads as the widget it already had.
+  const storedStyle: PerTurnFeedbackStyle =
+    storedSurface?.style === "thumbs" ? "thumbs" : "stars";
 
   // Optimistic display value. Held until the SERVER's value catches up, not
   // cleared when the mutation resolves: `chatbox` arrives through a reactive
   // query, so dropping the override on resolve makes the switch snap back to
   // the old setting for the frame or two before the update lands.
-  const [optimistic, setOptimistic] = useState<boolean | null>(null);
+  //
+  // ONE OBJECT, not two slots: a `boolean | null` cannot carry both fields,
+  // and a second independent slot would let a style write clear the toggle's
+  // override (or the reverse) while the other was still in flight. Each field
+  // is `null` when it has no pending override of its own.
+  const [optimistic, setOptimistic] = useState<{
+    enabled: boolean | null;
+    style: PerTurnFeedbackStyle | null;
+  }>({ enabled: null, style: null });
   const [saving, setSaving] = useState(false);
-  const enabled = optimistic ?? stored;
+  const enabled = optimistic.enabled ?? stored;
+  const style = optimistic.style ?? storedStyle;
 
   useEffect(() => {
-    if (optimistic !== null && stored === optimistic) setOptimistic(null);
-  }, [optimistic, stored]);
+    // Each override stands down on its OWN field catching up. Clearing both
+    // together would drop a style override the instant an `enabled` write
+    // landed, snapping the segmented control back for a frame.
+    setOptimistic((prev) => {
+      const next = {
+        enabled:
+          prev.enabled !== null && prev.enabled === stored
+            ? null
+            : prev.enabled,
+        style:
+          prev.style !== null && prev.style === storedStyle ? null : prev.style,
+      };
+      return next.enabled === prev.enabled && next.style === prev.style
+        ? prev
+        : next;
+    });
+  }, [stored, storedStyle]);
 
   // Synchronous in-flight latch. A `saving` STATE check cannot serialize this:
   // two `onCheckedChange` calls in the same tick both read the pre-commit
@@ -60,16 +99,41 @@ export function ChatboxPerTurnFeedbackToggle({
     if (inFlightRef.current) return;
     inFlightRef.current = true;
     setSaving(true);
-    setOptimistic(next);
+    setOptimistic((prev) => ({ ...prev, enabled: next }));
     try {
       await updateChatbox({
         chatboxId: chatbox.chatboxId,
         chatUi: { surfaces: { perTurnFeedback: { enabled: next } } },
       } as any);
     } catch (err) {
-      setOptimistic(null);
+      setOptimistic((prev) => ({ ...prev, enabled: null }));
       toast.error(
         convexErrMessage(err, "Failed to update the per-turn ratings setting")
+      );
+    } finally {
+      inFlightRef.current = false;
+      setSaving(false);
+    }
+  };
+
+  const handleStyleChange = async (next: PerTurnFeedbackStyle) => {
+    if (inFlightRef.current) return;
+    if (next === style) return;
+    inFlightRef.current = true;
+    setSaving(true);
+    setOptimistic((prev) => ({ ...prev, style: next }));
+    try {
+      // `{style}` ALONE. The backend merges the patch over the stored surface,
+      // so restating `enabled` here would be this control asserting a rollout
+      // decision it is not making — and would race a toggle write.
+      await updateChatbox({
+        chatboxId: chatbox.chatboxId,
+        chatUi: { surfaces: { perTurnFeedback: { style: next } } },
+      } as any);
+    } catch (err) {
+      setOptimistic((prev) => ({ ...prev, style: null }));
+      toast.error(
+        convexErrMessage(err, "Failed to update the rating widget style")
       );
     } finally {
       inFlightRef.current = false;
@@ -85,7 +149,9 @@ export function ChatboxPerTurnFeedbackToggle({
             Per-turn ratings
           </p>
           <p className="mt-0.5 text-xs leading-relaxed text-muted-foreground">
-            Let testers rate each response 1–5 stars and leave a comment.
+            {style === "thumbs"
+              ? "Let testers rate each response 👍 or 👎 and leave a comment."
+              : "Let testers rate each response 1–5 stars and leave a comment."}{" "}
             Ratings show up on the Sessions tab, where the list can be filtered
             by them.
           </p>
@@ -98,6 +164,51 @@ export function ChatboxPerTurnFeedbackToggle({
           data-testid="user-testing-per-turn-feedback-toggle"
         />
       </div>
+
+      {/* Only while the surface is on. A widget style is a question about a
+          widget nobody is being shown otherwise. */}
+      {enabled ? (
+        <div
+          role="radiogroup"
+          aria-label="Rating widget style"
+          className="mt-3 inline-flex rounded-md border border-border/60 p-0.5"
+          data-testid="user-testing-per-turn-feedback-style"
+        >
+          {STYLE_OPTIONS.map((option) => {
+            const selected = style === option.value;
+            return (
+              <button
+                key={option.value}
+                type="button"
+                role="radio"
+                aria-checked={selected}
+                title={option.hint}
+                disabled={saving}
+                className={`rounded px-2.5 py-1 text-xs font-medium transition-colors ${
+                  selected
+                    ? "bg-muted text-foreground"
+                    : "text-muted-foreground hover:text-foreground"
+                } ${saving ? "cursor-default opacity-70" : ""}`}
+                onClick={() => void handleStyleChange(option.value)}
+                data-testid={`user-testing-per-turn-feedback-style-${option.value}`}
+              >
+                {option.label}
+              </button>
+            );
+          })}
+        </div>
+      ) : null}
+
+      {/* Switching style does not rewrite history: ratings already left under
+          the old widget keep counting on the Sessions tab. Said here because
+          the tester-facing consequence (those turns read as unrated in the new
+          widget) is invisible from this screen. */}
+      {enabled ? (
+        <p className="mt-2 text-[11px] leading-relaxed text-muted-foreground">
+          Changing the style only affects new ratings. Ratings already left in
+          the other style still count on the Sessions tab.
+        </p>
+      ) : null}
     </div>
   );
 }

--- a/mcpjam-inspector/client/src/components/chatboxes/__tests__/ChatboxPerTurnFeedbackToggle.test.tsx
+++ b/mcpjam-inspector/client/src/components/chatboxes/__tests__/ChatboxPerTurnFeedbackToggle.test.tsx
@@ -168,3 +168,142 @@ describe("ChatboxPerTurnFeedbackToggle", () => {
     expect(toastErrorMock).toHaveBeenCalled();
   });
 });
+
+describe("ChatboxPerTurnFeedbackToggle — widget style", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    updateChatboxMock.mockResolvedValue(undefined);
+  });
+
+  const styled = (perTurnFeedback: Record<string, unknown>): ChatboxSettings =>
+    ({
+      chatboxId: "cbx_1",
+      projectId: "proj_1",
+      name: "Scenario",
+      chatUi: { surfaces: { perTurnFeedback } },
+    } as unknown as ChatboxSettings);
+
+  const stylePicker = () =>
+    screen.queryByTestId("user-testing-per-turn-feedback-style");
+  const styleButton = (style: "stars" | "thumbs") =>
+    screen.getByTestId(`user-testing-per-turn-feedback-style-${style}`);
+
+  it("is hidden while the surface is off", () => {
+    // A widget style is a question about a widget nobody is being shown.
+    render(
+      <ChatboxPerTurnFeedbackToggle chatbox={styled({ enabled: false })} />
+    );
+    expect(stylePicker()).toBeNull();
+  });
+
+  it("defaults to stars for a scenario that predates the style field", () => {
+    render(
+      <ChatboxPerTurnFeedbackToggle chatbox={styled({ enabled: true })} />
+    );
+    expect(styleButton("stars")).toHaveAttribute("aria-checked", "true");
+    expect(styleButton("thumbs")).toHaveAttribute("aria-checked", "false");
+  });
+
+  it("reflects a stored thumbs style", () => {
+    render(
+      <ChatboxPerTurnFeedbackToggle
+        chatbox={styled({ enabled: true, style: "thumbs" })}
+      />
+    );
+    expect(styleButton("thumbs")).toHaveAttribute("aria-checked", "true");
+  });
+
+  it("writes ONLY the style — the backend merge preserves enabled", () => {
+    // Restating `enabled` here would be the style control asserting a rollout
+    // decision it is not making, and would race a toggle write.
+    render(
+      <ChatboxPerTurnFeedbackToggle chatbox={styled({ enabled: true })} />
+    );
+
+    fireEvent.click(styleButton("thumbs"));
+
+    expect(updateChatboxMock).toHaveBeenCalledWith({
+      chatboxId: "cbx_1",
+      chatUi: { surfaces: { perTurnFeedback: { style: "thumbs" } } },
+    });
+  });
+
+  it("does not write when the chosen style is already active", () => {
+    render(
+      <ChatboxPerTurnFeedbackToggle chatbox={styled({ enabled: true })} />
+    );
+    fireEvent.click(styleButton("stars"));
+    expect(updateChatboxMock).not.toHaveBeenCalled();
+  });
+
+  it("reverts to the stored style when the write fails", async () => {
+    updateChatboxMock.mockRejectedValue(new Error("nope"));
+    render(
+      <ChatboxPerTurnFeedbackToggle chatbox={styled({ enabled: true })} />
+    );
+
+    fireEvent.click(styleButton("thumbs"));
+
+    await waitFor(() =>
+      expect(styleButton("stars")).toHaveAttribute("aria-checked", "true")
+    );
+    expect(toastErrorMock).toHaveBeenCalled();
+  });
+
+  it("holds the style override until the SERVER's style catches up", async () => {
+    // The two optimistic values live in one object with a PER-FIELD standdown.
+    // `chatbox` arrives through a reactive query that re-renders for reasons
+    // that have nothing to do with this control; a shared "clear on any
+    // resolve" rule would snap the segmented control back to the old style for
+    // the frames before the write lands.
+    let resolveWrite: (() => void) | undefined;
+    updateChatboxMock.mockImplementation(
+      () =>
+        new Promise<void>((resolve) => {
+          resolveWrite = resolve;
+        })
+    );
+
+    const { rerender } = render(
+      <ChatboxPerTurnFeedbackToggle chatbox={styled({ enabled: true })} />
+    );
+
+    fireEvent.click(styleButton("thumbs"));
+    expect(styleButton("thumbs")).toHaveAttribute("aria-checked", "true");
+
+    // A reactive re-render arrives still carrying the OLD style.
+    rerender(
+      <ChatboxPerTurnFeedbackToggle
+        chatbox={styled({ enabled: true, prompt: "unrelated change" })}
+      />
+    );
+    expect(styleButton("thumbs")).toHaveAttribute("aria-checked", "true");
+
+    if (!resolveWrite) throw new Error("expected a pending write to resolve");
+    await act(async () => {
+      resolveWrite!();
+    });
+
+    // Only the server reporting the new style stands the override down.
+    rerender(
+      <ChatboxPerTurnFeedbackToggle
+        chatbox={styled({ enabled: true, style: "thumbs" })}
+      />
+    );
+    expect(styleButton("thumbs")).toHaveAttribute("aria-checked", "true");
+  });
+
+  it("makes the description copy match the chosen style", () => {
+    const { rerender } = render(
+      <ChatboxPerTurnFeedbackToggle chatbox={styled({ enabled: true })} />
+    );
+    expect(screen.getByText(/1–5 stars/)).toBeInTheDocument();
+
+    rerender(
+      <ChatboxPerTurnFeedbackToggle
+        chatbox={styled({ enabled: true, style: "thumbs" })}
+      />
+    );
+    expect(screen.getByText(/👍 or 👎/)).toBeInTheDocument();
+  });
+});

--- a/mcpjam-inspector/client/src/components/connection/share-usage/ShareUsageThreadDetail.tsx
+++ b/mcpjam-inspector/client/src/components/connection/share-usage/ShareUsageThreadDetail.tsx
@@ -33,6 +33,10 @@ import {
 import { SessionInsightBar } from "@/components/chatboxes/session-readiness";
 import { ErrorBoundary } from "@/components/ui/error-boundary";
 import { SessionScoredTranscript } from "@/components/connection/share-usage/session-scored-transcript";
+import {
+  feedbackHeadline,
+  formatThumbCounts,
+} from "@/components/connection/share-usage/feedback-headline";
 import { ConvertPromotableSessionDialog } from "@/components/chat-v2/history/convert-promotable-session-dialog";
 import { navigateToPromotedTestCase } from "@/components/chat-v2/shared/promote-to-eval-navigation";
 import { useAction } from "convex/react";
@@ -513,6 +517,9 @@ export function ShareUsageThreadDetail({
   const reasoningDisplayMode = isChatboxThread ? "collapsible" : "collapsed";
 
   const feedbackSummary = thread.feedback ?? null;
+  const feedbackHeadlineValue = feedbackSummary
+    ? feedbackHeadline(feedbackSummary)
+    : null;
   const hasFeedback =
     feedbackSummary != null ||
     thread.feedbackRating != null ||
@@ -528,16 +535,31 @@ export function ShareUsageThreadDetail({
             <p className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">
               Feedback
             </p>
-            {feedbackSummary ? (
+            {feedbackSummary && feedbackHeadlineValue ? (
               <p className="mt-1 text-sm font-medium">
-                {feedbackSummary.avg.toFixed(1)}/5
+                {feedbackHeadlineValue.kind === "thumbs"
+                  ? formatThumbCounts(
+                      feedbackHeadlineValue.up,
+                      feedbackHeadlineValue.down
+                    )
+                  : feedbackHeadlineValue.kind === "mixed"
+                  ? `${feedbackHeadlineValue.avg.toFixed(
+                      1
+                    )}/5 · ${formatThumbCounts(
+                      feedbackHeadlineValue.up,
+                      feedbackHeadlineValue.down
+                    )}`
+                  : `${feedbackHeadlineValue.avg.toFixed(1)}/5`}
                 <span className="ml-1 font-normal text-muted-foreground">
                   across {feedbackSummary.count}{" "}
                   {feedbackSummary.count === 1 ? "rating" : "ratings"}
                   {/* The worst turn is what the filters and the list row's
                       amber tint key on, so name it here rather than leaving
-                      the average to imply a uniformly mediocre session. */}
-                  {feedbackSummary.count > 1
+                      the average to imply a uniformly mediocre session.
+                      Suppressed for a thumbs-only session: "worst 1/5" would
+                      restate the 👎 tally on a scale nobody was shown. */}
+                  {feedbackSummary.count > 1 &&
+                  feedbackHeadlineValue.kind !== "thumbs"
                     ? ` · worst ${feedbackSummary.min}/5`
                     : ""}
                 </span>

--- a/mcpjam-inspector/client/src/components/connection/share-usage/ShareUsageThreadList.tsx
+++ b/mcpjam-inspector/client/src/components/connection/share-usage/ShareUsageThreadList.tsx
@@ -195,9 +195,11 @@ export function ThreadCard({
                 fact the color carries.
 
                 A thumbs session has no meaningful average, so it shows its
-                tallies instead; a session holding both shows the stars'
-                average WITH the thumb tallies, because dropping either half
-                would under-report how many turns were judged. */}
+                tallies instead; a session holding both shows the BLENDED
+                average (thumbs projected onto the 1–5 axis, down→1/up→5 —
+                `summary.avg` is not a stars-only number) WITH the thumb
+                tallies, because dropping either half would under-report how
+                many turns were judged. */}
             {headline === null ? (
               `${rating}/5`
             ) : headline.kind === "thumbs" ? (

--- a/mcpjam-inspector/client/src/components/connection/share-usage/ShareUsageThreadList.tsx
+++ b/mcpjam-inspector/client/src/components/connection/share-usage/ShareUsageThreadList.tsx
@@ -15,6 +15,10 @@ import {
 } from "@/hooks/useSharedChatThreads";
 import { SessionReadinessBadge } from "@/components/chatboxes/session-readiness";
 import { SessionGoalScoreBadge } from "@/components/shared/session-quality/session-goal-score-badge";
+import {
+  feedbackHeadline,
+  formatThumbCounts,
+} from "@/components/connection/share-usage/feedback-headline";
 
 interface ShareUsageThreadListProps {
   /** Optional: when `threads` is provided (chatbox Usage panel) these are unused. */
@@ -134,6 +138,9 @@ export function ThreadCard({
   const summary = thread.feedback ?? null;
   const rating = summary?.min ?? thread.feedbackRating ?? null;
   const ratingCount = summary?.count ?? thread.feedbackCount ?? 0;
+  // `null` on rows from a backend old enough to send only the flat fields —
+  // those fall back to the bare `min/5` they always showed.
+  const headline = summary ? feedbackHeadline(summary) : null;
   const hasComment =
     summary?.hasComment ?? (thread.feedbackComment?.trim().length ?? 0) > 0;
   const needsReview =
@@ -185,9 +192,27 @@ export function ThreadCard({
             {/* Average for the headline number, `n×` for how many turns it
                 covers — the worst turn is what the amber tint already says,
                 so repeating it here would spend the row's one number on a
-                fact the color carries. */}
-            {summary ? summary.avg.toFixed(1) : rating}/5
-            {ratingCount > 1 ? ` · ${ratingCount}×` : ""}
+                fact the color carries.
+
+                A thumbs session has no meaningful average, so it shows its
+                tallies instead; a session holding both shows the stars'
+                average WITH the thumb tallies, because dropping either half
+                would under-report how many turns were judged. */}
+            {headline === null ? (
+              `${rating}/5`
+            ) : headline.kind === "thumbs" ? (
+              formatThumbCounts(headline.up, headline.down)
+            ) : headline.kind === "mixed" ? (
+              `${headline.avg.toFixed(1)}/5 · ${formatThumbCounts(
+                headline.up,
+                headline.down
+              )}`
+            ) : (
+              <>
+                {headline.avg.toFixed(1)}/5
+                {ratingCount > 1 ? ` · ${ratingCount}×` : ""}
+              </>
+            )}
           </span>
         ) : (
           <span className="text-xs text-muted-foreground">No feedback</span>

--- a/mcpjam-inspector/client/src/components/connection/share-usage/__tests__/ShareUsageThreadCard.test.tsx
+++ b/mcpjam-inspector/client/src/components/connection/share-usage/__tests__/ShareUsageThreadCard.test.tsx
@@ -1,0 +1,90 @@
+/**
+ * The sessions-list row's feedback line.
+ *
+ * The row has ONE number's worth of space, and which number it spends it on
+ * depends on how the session was rated. The amber treatment is style-agnostic
+ * on purpose — it keys on the worst turn, which thumbs are projected onto
+ * server-side.
+ */
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+
+vi.mock("@/hooks/useSharedChatThreads", () => ({
+  useSharedChatThreadList: () => ({ threads: [] }),
+}));
+
+import { ThreadCard } from "../ShareUsageThreadList";
+import type { SharedChatThread } from "@/hooks/useSharedChatThreads";
+
+function thread(
+  feedback: Partial<NonNullable<SharedChatThread["feedback"]>> | null
+): SharedChatThread {
+  return {
+    _id: "t1",
+    sourceType: "chatbox",
+    chatSessionId: "cs1",
+    messageCount: 4,
+    startedAt: 0,
+    lastActivityAt: Date.now(),
+    visitorDisplayName: "Dana",
+    ...(feedback
+      ? {
+          feedback: {
+            count: 1,
+            avg: 3,
+            min: 3,
+            hasComment: false,
+            latestRating: 3,
+            latestAt: 0,
+            ...feedback,
+          },
+        }
+      : {}),
+  } as SharedChatThread;
+}
+
+function renderCard(t: SharedChatThread) {
+  render(<ThreadCard thread={t} isSelected={false} onSelect={() => {}} />);
+}
+
+describe("ThreadCard feedback line", () => {
+  it("shows the average for a star-rated session", () => {
+    renderCard(thread({ count: 2, avg: 4.5, min: 4, latestRating: 5 }));
+    expect(screen.getByText(/4\.5\/5 · 2×/)).toBeInTheDocument();
+  });
+
+  it("shows thumb tallies instead of an average for a thumbs session", () => {
+    renderCard(
+      thread({
+        count: 3,
+        avg: 3.67,
+        min: 1,
+        thumbUpCount: 2,
+        thumbDownCount: 1,
+      })
+    );
+    expect(screen.getByText(/👍 2 · 👎 1/)).toBeInTheDocument();
+    expect(screen.queryByText(/\/5/)).toBeNull();
+  });
+
+  it("shows both for a session rated under both styles", () => {
+    renderCard(thread({ count: 3, avg: 3, min: 1, thumbDownCount: 1 }));
+    expect(screen.getByText(/3\.0\/5 · 👎 1/)).toBeInTheDocument();
+  });
+
+  it("tints a thumbs-down session amber, same predicate as a 1★", () => {
+    const { container } = render(
+      <ThreadCard
+        thread={thread({ count: 1, avg: 1, min: 1, thumbDownCount: 1 })}
+        isSelected={false}
+        onSelect={() => {}}
+      />
+    );
+    expect(container.querySelector(".text-amber-700")).not.toBeNull();
+  });
+
+  it("leaves the no-feedback branch alone", () => {
+    renderCard(thread(null));
+    expect(screen.getByText("No feedback")).toBeInTheDocument();
+  });
+});

--- a/mcpjam-inspector/client/src/components/connection/share-usage/__tests__/feedback-headline.test.ts
+++ b/mcpjam-inspector/client/src/components/connection/share-usage/__tests__/feedback-headline.test.ts
@@ -1,0 +1,75 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  feedbackHeadline,
+  formatThumbCounts,
+} from "@/components/connection/share-usage/feedback-headline";
+
+/**
+ * How a session announces its feedback, derived from the counts alone.
+ *
+ * The backend stores no `style` on the summary — deliberately, because a
+ * session can hold rows from both widgets after a mid-session style switch and
+ * there is no single style to name. These pin the derivation the list row and
+ * the detail header share.
+ */
+
+const base = { count: 1, avg: 3, min: 3 };
+
+describe("feedbackHeadline", () => {
+  it("a star-only session shows its average", () => {
+    expect(feedbackHeadline({ ...base, count: 3, avg: 4.5, min: 3 })).toEqual({
+      kind: "stars",
+      avg: 4.5,
+      count: 3,
+    });
+  });
+
+  it("a thumbs-only session shows tallies, never an average", () => {
+    // `/5` on a session where nobody was offered a 5 is a number the tester
+    // never gave.
+    expect(
+      feedbackHeadline({
+        count: 3,
+        avg: 3.67,
+        min: 1,
+        thumbUpCount: 2,
+        thumbDownCount: 1,
+      })
+    ).toEqual({ kind: "thumbs", up: 2, down: 1, count: 3 });
+  });
+
+  it("a session with both shows the average AND the tallies", () => {
+    // Dropping either half would under-report how many turns were judged.
+    expect(
+      feedbackHeadline({
+        count: 3,
+        avg: 3,
+        min: 1,
+        thumbDownCount: 1,
+      })
+    ).toEqual({ kind: "mixed", avg: 3, count: 3, up: 0, down: 1 });
+  });
+
+  it("treats a pre-thumbs summary as stars", () => {
+    // Every summary written before thumbs existed lacks both counts.
+    expect(feedbackHeadline({ count: 2, avg: 4, min: 3 }).kind).toBe("stars");
+  });
+
+  it("a single thumbs-up is thumbs, not a 5-star average", () => {
+    expect(
+      feedbackHeadline({ count: 1, avg: 5, min: 5, thumbUpCount: 1 })
+    ).toEqual({ kind: "thumbs", up: 1, down: 0, count: 1 });
+  });
+});
+
+describe("formatThumbCounts", () => {
+  it("shows both sides when both happened", () => {
+    expect(formatThumbCounts(3, 1)).toBe("👍 3 · 👎 1");
+  });
+
+  it("drops a zero side rather than printing 👎 0", () => {
+    expect(formatThumbCounts(3, 0)).toBe("👍 3");
+    expect(formatThumbCounts(0, 2)).toBe("👎 2");
+  });
+});

--- a/mcpjam-inspector/client/src/components/connection/share-usage/__tests__/session-scored-transcript.test.tsx
+++ b/mcpjam-inspector/client/src/components/connection/share-usage/__tests__/session-scored-transcript.test.tsx
@@ -1,0 +1,147 @@
+/**
+ * The read-only transcript's score join.
+ *
+ * What these pin:
+ *   - BOTH per-turn keys render. Dropping `user_thumb` (the pre-thumbs filter)
+ *     would silently show a thumbs-rated session as unrated.
+ *   - The widget MATCHES the row. A stored `0` rendered as stars reads as
+ *     "unrated"; a `4` rendered as thumbs cannot be shown at all.
+ *   - A turn carrying rows under BOTH keys shows the latest revision — what
+ *     the tester currently means.
+ */
+import { render } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const { mockScores, mockTurnRating } = vi.hoisted(() => ({
+  mockScores: { rows: [] as unknown[] },
+  mockTurnRating: vi.fn(),
+}));
+
+vi.mock("@/hooks/useSharedChatThreads", () => ({
+  useSharedChatTurnScores: () => ({ scores: mockScores.rows }),
+}));
+
+vi.mock("@mcpjam/chat-ui", () => ({
+  // Identity: the fixture messages below are already the renderable set.
+  getRenderableConversationMessages: (messages: unknown[]) => messages,
+  // Drive the footer callback for every message, which is what the real
+  // transcript does per rendered turn.
+  ReadOnlyTranscript: ({
+    messages,
+    renderTurnFooter,
+  }: {
+    messages: unknown[];
+    renderTurnFooter?: (message: unknown, index: number) => unknown;
+  }) => (
+    <div>
+      {messages.map((message, index) => (
+        <div key={index}>{renderTurnFooter?.(message, index) as never}</div>
+      ))}
+    </div>
+  ),
+  TurnRating: (props: unknown) => {
+    mockTurnRating(props);
+    return null;
+  },
+}));
+
+import { SessionScoredTranscript } from "../session-scored-transcript";
+
+const MESSAGES = [
+  { role: "user", content: "hi" },
+  { role: "assistant", content: "hello" },
+] as never;
+
+function score(overrides: Record<string, unknown>) {
+  return {
+    key: "user_rating",
+    promptIndex: 0,
+    dataType: "numeric",
+    source: "end_user",
+    createdAt: 1,
+    updatedAt: 1,
+    ...overrides,
+  };
+}
+
+function renderTranscript() {
+  // The remaining `ReadOnlyTranscriptProps` are the real transcript's concern;
+  // the mock above ignores them.
+  const props = { threadId: "t1", messages: MESSAGES } as React.ComponentProps<
+    typeof SessionScoredTranscript
+  >;
+  render(<SessionScoredTranscript {...props} />);
+}
+
+describe("SessionScoredTranscript", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockScores.rows = [];
+  });
+
+  it("renders a star row as stars", () => {
+    mockScores.rows = [score({ value: 4, comment: "good" })];
+    renderTranscript();
+    expect(mockTurnRating).toHaveBeenCalledWith(
+      expect.objectContaining({
+        variant: "stars",
+        value: 4,
+        comment: "good",
+        readOnly: true,
+      })
+    );
+  });
+
+  it("renders a thumb row as thumbs", () => {
+    mockScores.rows = [
+      score({ key: "user_thumb", dataType: "boolean", value: 1 }),
+    ];
+    renderTranscript();
+    expect(mockTurnRating).toHaveBeenCalledWith(
+      expect.objectContaining({ variant: "thumbs", value: 1 })
+    );
+  });
+
+  it("shows a thumbs-down rather than treating 0 as unrated", () => {
+    mockScores.rows = [
+      score({
+        key: "user_thumb",
+        dataType: "boolean",
+        value: 0,
+        comment: "wrong order",
+      }),
+    ];
+    renderTranscript();
+    expect(mockTurnRating).toHaveBeenCalledWith(
+      expect.objectContaining({
+        variant: "thumbs",
+        value: 0,
+        comment: "wrong order",
+      })
+    );
+  });
+
+  it("prefers the latest revision when a turn carries both keys", () => {
+    // The shape a mid-session style switch plus a re-rate produces.
+    mockScores.rows = [
+      score({ value: 4, updatedAt: 10 }),
+      score({
+        key: "user_thumb",
+        dataType: "boolean",
+        value: 0,
+        updatedAt: 20,
+      }),
+    ];
+    renderTranscript();
+    expect(mockTurnRating).toHaveBeenCalledTimes(1);
+    expect(mockTurnRating).toHaveBeenCalledWith(
+      expect.objectContaining({ variant: "thumbs", value: 0 })
+    );
+  });
+
+  it("ignores rows under keys that are not per-turn ratings", () => {
+    mockScores.rows = [score({ key: "eval_grade", value: 1 })];
+    renderTranscript();
+    expect(mockTurnRating).not.toHaveBeenCalled();
+  });
+});

--- a/mcpjam-inspector/client/src/components/connection/share-usage/__tests__/session-scored-transcript.test.tsx
+++ b/mcpjam-inspector/client/src/components/connection/share-usage/__tests__/session-scored-transcript.test.tsx
@@ -144,4 +144,24 @@ describe("SessionScoredTranscript", () => {
     renderTranscript();
     expect(mockTurnRating).not.toHaveBeenCalled();
   });
+
+  it("renders nothing when the session has no score rows", () => {
+    mockScores.rows = [];
+    renderTranscript();
+    expect(mockTurnRating).not.toHaveBeenCalled();
+  });
+
+  it("renders nothing while the scores query is still loading", () => {
+    // `useQuery` returns undefined before the first round-trip, and the
+    // transcript is the point of the page — it must render regardless.
+    mockScores.rows = undefined as never;
+    renderTranscript();
+    expect(mockTurnRating).not.toHaveBeenCalled();
+  });
+
+  it("skips a row with no promptIndex — there is no turn to anchor it to", () => {
+    mockScores.rows = [score({ value: 4, promptIndex: undefined })];
+    renderTranscript();
+    expect(mockTurnRating).not.toHaveBeenCalled();
+  });
 });

--- a/mcpjam-inspector/client/src/components/connection/share-usage/feedback-headline.ts
+++ b/mcpjam-inspector/client/src/components/connection/share-usage/feedback-headline.ts
@@ -1,0 +1,56 @@
+/**
+ * How a session's feedback rollup is announced — stars, thumbs, or both.
+ *
+ * Shared by the sessions list row and the thread detail header so the two can
+ * never disagree about what a session's feedback says. The rule is derived
+ * from the counts alone: the backend deliberately stores NO `style` field on
+ * the summary, because a session can hold rows from both widgets (a scenario
+ * whose style was switched mid-session) and there is no single style to name.
+ *
+ * `count` is every rated turn; `thumbUpCount`/`thumbDownCount` are the thumb
+ * subset and are absent rather than zero when there are none. The remainder is
+ * therefore the star rows, and a session with both is `mixed`.
+ *
+ * The AMBER predicate is deliberately not in here: it keys on `min <= 2`,
+ * which is the same for both styles precisely because thumbs are projected
+ * onto the 1–5 axis server-side.
+ */
+
+export interface FeedbackSummaryLike {
+  count: number;
+  avg: number;
+  min: number;
+  thumbUpCount?: number;
+  thumbDownCount?: number;
+}
+
+export type FeedbackHeadline =
+  | { kind: "stars"; avg: number; count: number }
+  | { kind: "thumbs"; up: number; down: number; count: number }
+  | { kind: "mixed"; avg: number; count: number; up: number; down: number };
+
+export function feedbackHeadline(
+  summary: FeedbackSummaryLike
+): FeedbackHeadline {
+  const up = summary.thumbUpCount ?? 0;
+  const down = summary.thumbDownCount ?? 0;
+  const thumbCount = up + down;
+
+  if (thumbCount === 0) {
+    return { kind: "stars", avg: summary.avg, count: summary.count };
+  }
+  // Every rated turn is a thumb ⇒ there is no average worth showing. `/5` on a
+  // session where nobody was offered a 5 is a number the tester never gave.
+  if (thumbCount >= summary.count) {
+    return { kind: "thumbs", up, down, count: summary.count };
+  }
+  return { kind: "mixed", avg: summary.avg, count: summary.count, up, down };
+}
+
+/** `👍 3 · 👎 1`, with a zero side dropped rather than shown as `👎 0`. */
+export function formatThumbCounts(up: number, down: number): string {
+  const parts: string[] = [];
+  if (up > 0) parts.push(`👍 ${up}`);
+  if (down > 0) parts.push(`👎 ${down}`);
+  return parts.join(" · ");
+}

--- a/mcpjam-inspector/client/src/components/connection/share-usage/session-scored-transcript.tsx
+++ b/mcpjam-inspector/client/src/components/connection/share-usage/session-scored-transcript.tsx
@@ -10,6 +10,16 @@ import {
 import { useSharedChatTurnScores } from "@/hooks/useSharedChatThreads";
 
 const USER_RATING_KEY = "user_rating";
+const USER_THUMB_KEY = "user_thumb";
+/** The per-turn keys a tester writes — one per widget style. */
+const TURN_RATING_KEYS = [USER_RATING_KEY, USER_THUMB_KEY];
+
+type TurnRatingRow = {
+  value?: number;
+  comment?: string;
+  key: string;
+  updatedAt: number;
+};
 
 interface SessionScoredTranscriptProps extends ReadOnlyTranscriptProps {
   threadId: string;
@@ -44,21 +54,26 @@ export function SessionScoredTranscript({
    * prompts and counting them would shift every rating one turn late.
    */
   const ratingByVisibleIndex = useMemo(() => {
-    const map = new Map<number, { value?: number; comment?: string }>();
-    const ratings = (scores ?? []).filter(
-      (score) => score.key === USER_RATING_KEY
+    const map = new Map<number, TurnRatingRow>();
+    const ratings = (scores ?? []).filter((score) =>
+      TURN_RATING_KEYS.includes(score.key)
     );
     if (ratings.length === 0) return map;
 
-    const byPromptIndex = new Map<
-      number,
-      { value?: number; comment?: string }
-    >();
+    const byPromptIndex = new Map<number, TurnRatingRow>();
     for (const score of ratings) {
       if (score.promptIndex === undefined) continue;
+      // A turn can carry a row under BOTH keys — a scenario whose style was
+      // switched, re-rated by the same tester. The latest revision is what
+      // they currently mean, so it wins; `updatedAt` is the freshness axis the
+      // backend maintains for exactly this.
+      const existing = byPromptIndex.get(score.promptIndex);
+      if (existing && existing.updatedAt >= score.updatedAt) continue;
       byPromptIndex.set(score.promptIndex, {
         value: score.value,
         comment: score.comment,
+        key: score.key,
+        updatedAt: score.updatedAt,
       });
     }
 
@@ -92,6 +107,10 @@ export function SessionScoredTranscript({
         return (
           <TurnRating
             readOnly
+            // Render the widget the tester actually used. A 0 shown as stars
+            // would read as "unrated"; a 4 shown as thumbs cannot be shown at
+            // all.
+            variant={rating.key === USER_THUMB_KEY ? "thumbs" : "stars"}
             value={rating.value}
             comment={rating.comment}
             status="submitted"

--- a/mcpjam-inspector/client/src/components/hosted/ChatboxChatPage.tsx
+++ b/mcpjam-inspector/client/src/components/hosted/ChatboxChatPage.tsx
@@ -963,6 +963,11 @@ export function ChatboxChatPage({
     enabled: perTurnFeedbackEnabled,
     chatboxId: session?.chatboxId,
     accessVersion: session?.accessVersion,
+    // The style picks the score key. Derived here rather than inside the hook
+    // so the widget's `variant` and the key its clicks write both come from
+    // one read of the config.
+    scoreKey:
+      perTurnFeedback?.style === "thumbs" ? "user_thumb" : "user_rating",
     onStaleHostedAccess: requestRefreshAccessVersion,
   });
   const introGate = useChatboxHostIntroGate({

--- a/mcpjam-inspector/client/src/components/hosted/hosted-turn-rating.tsx
+++ b/mcpjam-inspector/client/src/components/hosted/hosted-turn-rating.tsx
@@ -45,6 +45,10 @@ export function HostedTurnRating({
 
   return (
     <TurnRating
+      // The single switch point between the two widget styles. The hook is
+      // told the matching score key by the page, so the control the tester
+      // sees and the key their click writes cannot disagree.
+      variant={config.style === "thumbs" ? "thumbs" : "stars"}
       value={state.value}
       comment={state.comment}
       status={state.status}

--- a/mcpjam-inspector/client/src/hooks/__tests__/chatbox-usage-filters-per-turn.test.ts
+++ b/mcpjam-inspector/client/src/hooks/__tests__/chatbox-usage-filters-per-turn.test.ts
@@ -137,3 +137,90 @@ describe("worst-turn policy", () => {
     ).toBe(true);
   });
 });
+
+describe("thumbs ride the same worst-turn axis", () => {
+  // The filters never learn what a thumb is. Thumbs are projected onto the
+  // 1–5 scale server-side (down ⇒ 1, up ⇒ 5), which is exactly what lets ONE
+  // filter UI serve both widget styles — these pin that no client-side branch
+  // is needed for it.
+
+  it("a thumbs-down session matches Low (≤2)", () => {
+    const thumbedDown = thread({
+      _id: "a",
+      feedback: summary({
+        count: 2,
+        avg: 3,
+        min: 1,
+        latestRating: 5,
+        thumbUpCount: 1,
+        thumbDownCount: 1,
+      }),
+    });
+    expect(threadMatchesUsageFilter(thumbedDown, "low_ratings")).toBe(true);
+    expect(
+      threadMatchesChip(thumbedDown, {
+        kind: "dimension",
+        key: "feedbackBucket",
+        value: "negative",
+      })
+    ).toBe(true);
+  });
+
+  it("a thumbs-up-only session does not", () => {
+    const thumbedUp = thread({
+      _id: "a",
+      feedback: summary({
+        count: 2,
+        avg: 5,
+        min: 5,
+        latestRating: 5,
+        thumbUpCount: 2,
+      }),
+    });
+    expect(threadMatchesUsageFilter(thumbedUp, "low_ratings")).toBe(false);
+    expect(
+      threadMatchesChip(thumbedUp, {
+        kind: "dimension",
+        key: "feedbackBucket",
+        value: "positive",
+      })
+    ).toBe(true);
+  });
+
+  it("the neutral bucket is simply unreachable for a thumbs-only session", () => {
+    // A documented dead option, not a bug: a two-state control has no neutral
+    // to express, so no projection can land on 3.
+    const thumbedDown = thread({
+      _id: "a",
+      feedback: summary({
+        count: 1,
+        avg: 1,
+        min: 1,
+        latestRating: 1,
+        thumbDownCount: 1,
+      }),
+    });
+    expect(
+      threadMatchesChip(thumbedDown, {
+        kind: "dimension",
+        key: "feedbackBucket",
+        value: "neutral",
+      })
+    ).toBe(false);
+  });
+
+  it("a mixed-style session is judged by its worst turn, whatever wrote it", () => {
+    // One star row (4) and one thumbs-down (⇒ 1) — the complaint wins.
+    const mixed = thread({
+      _id: "a",
+      feedback: summary({
+        count: 2,
+        avg: 2.5,
+        min: 1,
+        latestRating: 4,
+        thumbDownCount: 1,
+      }),
+    });
+    expect(threadMatchesUsageFilter(mixed, "low_ratings")).toBe(true);
+  });
+});

--- a/mcpjam-inspector/client/src/hooks/__tests__/chatbox-usage-filters-per-turn.test.ts
+++ b/mcpjam-inspector/client/src/hooks/__tests__/chatbox-usage-filters-per-turn.test.ts
@@ -138,13 +138,19 @@ describe("worst-turn policy", () => {
   });
 });
 
-describe("thumbs ride the same worst-turn axis", () => {
-  // The filters never learn what a thumb is. Thumbs are projected onto the
-  // 1–5 scale server-side (down ⇒ 1, up ⇒ 5), which is exactly what lets ONE
-  // filter UI serve both widget styles — these pin that no client-side branch
-  // is needed for it.
+describe("a thumbs-rated session needs no client-side filter branch", () => {
+  // SCOPE, stated plainly: the projection itself (down ⇒ 1, up ⇒ 5) happens
+  // server-side in `SUMMARY_VALUE_MAP` and is pinned in the backend's
+  // `sessionScores.test.ts`. The fixtures below therefore set `min` by hand,
+  // exactly as the backend would have written it, and a broken projection
+  // would be caught there rather than here.
+  //
+  // What these pin is the client half: given a summary carrying thumb
+  // tallies, every matcher still reads `min` and NONE of them grows a special
+  // case. That is the claim that would silently rot if someone "fixed" the
+  // filters to branch on `thumbUpCount`/`thumbDownCount`.
 
-  it("a thumbs-down session matches Low (≤2)", () => {
+  it("a summary carrying a down-thumb matches Low (≤2) through min alone", () => {
     const thumbedDown = thread({
       _id: "a",
       feedback: summary({
@@ -166,7 +172,7 @@ describe("thumbs ride the same worst-turn axis", () => {
     ).toBe(true);
   });
 
-  it("a thumbs-up-only session does not", () => {
+  it("an up-thumbs-only summary does not, and buckets positive", () => {
     const thumbedUp = thread({
       _id: "a",
       feedback: summary({
@@ -187,7 +193,7 @@ describe("thumbs ride the same worst-turn axis", () => {
     ).toBe(true);
   });
 
-  it("the neutral bucket is simply unreachable for a thumbs-only session", () => {
+  it("no projected thumb value can land in the neutral bucket", () => {
     // A documented dead option, not a bug: a two-state control has no neutral
     // to express, so no projection can land on 3.
     const thumbedDown = thread({
@@ -209,7 +215,7 @@ describe("thumbs ride the same worst-turn axis", () => {
     ).toBe(false);
   });
 
-  it("a mixed-style session is judged by its worst turn, whatever wrote it", () => {
+  it("a mixed-style summary is judged by min, whatever wrote that turn", () => {
     // One star row (4) and one thumbs-down (⇒ 1) — the complaint wins.
     const mixed = thread({
       _id: "a",

--- a/mcpjam-inspector/client/src/hooks/__tests__/useChatboxTurnRating.test.tsx
+++ b/mcpjam-inspector/client/src/hooks/__tests__/useChatboxTurnRating.test.tsx
@@ -897,6 +897,110 @@ describe("useChatboxTurnRating", () => {
       ).toMatchObject({ value: 0, status: "submitted" });
     });
 
+    it("a rating submitted under the old style does not leak into the new widget", async () => {
+      // The optimistic map wins over the (key-filtered) persisted read, so it
+      // has to be namespaced by key too — otherwise a 4★ submitted this
+      // page-load rehydrates into the thumbs widget as a "submitted" rating
+      // no thumb can represent.
+      const { result, rerender } = renderHook(
+        (props: { scoreKey: "user_rating" | "user_thumb" }) =>
+          useChatboxTurnRating({
+            enabled: true,
+            chatboxId: "cbx_1",
+            accessVersion: 1,
+            scoreKey: props.scoreKey,
+          }),
+        {
+          initialProps: {
+            scoreKey: "user_rating",
+          } as { scoreKey: "user_rating" | "user_thumb" },
+        }
+      );
+
+      act(() => {
+        result.current.submit({
+          chatSessionId: CHAT_SESSION_ID,
+          turnId: TURN_ID,
+          value: 4,
+          comment: "fine",
+        });
+      });
+      await flushMicrotasks();
+      expect(result.current.getState(CHAT_SESSION_ID, TURN_ID)).toMatchObject({
+        value: 4,
+        status: "submitted",
+      });
+
+      rerender({ scoreKey: "user_thumb" });
+
+      expect(result.current.getState(CHAT_SESSION_ID, TURN_ID)).toEqual({
+        status: "idle",
+      });
+
+      // ...and switching back finds the star rating still there.
+      rerender({ scoreKey: "user_rating" });
+      expect(result.current.getState(CHAT_SESSION_ID, TURN_ID)).toMatchObject({
+        value: 4,
+        status: "submitted",
+      });
+    });
+
+    it("a submission under the new style cannot cancel the old style's retry", async () => {
+      // Generations are per (key, session, turn). Sharing them across styles
+      // would let a stars click supersede a queued thumbs retry on the same
+      // turn — silently dropping a judgement the tester actually made.
+      vi.useFakeTimers();
+      mockSubmitScore.mockResolvedValue({ status: "not_ready" });
+
+      const { result, rerender } = renderHook(
+        (props: { scoreKey: "user_rating" | "user_thumb" }) =>
+          useChatboxTurnRating({
+            enabled: true,
+            chatboxId: "cbx_1",
+            accessVersion: 1,
+            scoreKey: props.scoreKey,
+          }),
+        {
+          initialProps: {
+            scoreKey: "user_thumb",
+          } as { scoreKey: "user_rating" | "user_thumb" },
+        }
+      );
+
+      act(() => {
+        result.current.submit({
+          chatSessionId: CHAT_SESSION_ID,
+          turnId: TURN_ID,
+          value: 0,
+        });
+      });
+      await flushMicrotasks();
+
+      // Style switches and the tester rates the same turn again, as stars.
+      rerender({ scoreKey: "user_rating" });
+      mockSubmitScore.mockResolvedValue({ status: "ok" });
+      act(() => {
+        result.current.submit({
+          chatSessionId: CHAT_SESSION_ID,
+          turnId: TURN_ID,
+          value: 5,
+        });
+      });
+      await flushMicrotasks();
+
+      // The queued thumbs retry still fires rather than being superseded.
+      mockSubmitScore.mockClear();
+      await act(async () => {
+        vi.advanceTimersByTime(400);
+        await Promise.resolve();
+      });
+      await flushMicrotasks();
+
+      expect(mockSubmitScore).toHaveBeenCalledWith(
+        expect.objectContaining({ key: "user_thumb", value: 0 })
+      );
+    });
+
     it("a keyless rehydration row is read as stars", async () => {
       // Rows projected by a backend that predates the key field.
       mockUseQuery.mockReturnValue([{ turnId: TURN_ID, value: 3 }]);

--- a/mcpjam-inspector/client/src/hooks/__tests__/useChatboxTurnRating.test.tsx
+++ b/mcpjam-inspector/client/src/hooks/__tests__/useChatboxTurnRating.test.tsx
@@ -759,4 +759,165 @@ describe("useChatboxTurnRating", () => {
 
     expect(mockSubmitScore).not.toHaveBeenCalled();
   });
+
+  describe("score key follows the scenario's widget style", () => {
+    it("writes user_thumb when the scenario picked thumbs", async () => {
+      const { result } = renderHook(() =>
+        useChatboxTurnRating({
+          enabled: true,
+          chatboxId: "cbx_1",
+          accessVersion: 1,
+          scoreKey: "user_thumb",
+        })
+      );
+
+      act(() => {
+        result.current.submit({
+          chatSessionId: CHAT_SESSION_ID,
+          turnId: TURN_ID,
+          value: 0,
+        });
+      });
+      await flushMicrotasks();
+
+      expect(mockSubmitScore).toHaveBeenCalledWith({
+        chatboxId: "cbx_1",
+        accessVersion: 1,
+        chatSessionId: CHAT_SESSION_ID,
+        turnId: TURN_ID,
+        key: "user_thumb",
+        value: 0,
+      });
+      // A thumbs-down is a rated turn, not an unrated one.
+      expect(result.current.getState(CHAT_SESSION_ID, TURN_ID)).toMatchObject({
+        value: 0,
+        status: "submitted",
+      });
+    });
+
+    it("defaults to user_rating when no style was configured", async () => {
+      const { result } = renderHook(() =>
+        useChatboxTurnRating({
+          enabled: true,
+          chatboxId: "cbx_1",
+          accessVersion: 1,
+        })
+      );
+
+      act(() => {
+        result.current.submit({
+          chatSessionId: CHAT_SESSION_ID,
+          turnId: TURN_ID,
+          value: 4,
+        });
+      });
+      await flushMicrotasks();
+
+      expect(mockSubmitScore).toHaveBeenCalledWith(
+        expect.objectContaining({ key: "user_rating" })
+      );
+    });
+
+    it("a not_ready retry resubmits under the key it was created with", async () => {
+      // The retry fires long after the click. If it read the key live and the
+      // scenario had been switched to stars meanwhile, a thumbs-down's `0`
+      // would be resubmitted as a star value and rejected out of range —
+      // losing the tester's judgement to an error they cannot act on.
+      vi.useFakeTimers();
+      mockSubmitScore.mockResolvedValue({ status: "not_ready" });
+
+      const { result, rerender } = renderHook(
+        (props: { scoreKey: "user_rating" | "user_thumb" }) =>
+          useChatboxTurnRating({
+            enabled: true,
+            chatboxId: "cbx_1",
+            accessVersion: 1,
+            scoreKey: props.scoreKey,
+          }),
+        {
+          initialProps: {
+            scoreKey: "user_thumb",
+          } as { scoreKey: "user_rating" | "user_thumb" },
+        }
+      );
+
+      act(() => {
+        result.current.submit({
+          chatSessionId: CHAT_SESSION_ID,
+          turnId: TURN_ID,
+          value: 0,
+        });
+      });
+      await flushMicrotasks();
+
+      // The scenario's style changes while the retry is armed.
+      rerender({ scoreKey: "user_rating" });
+      mockSubmitScore.mockResolvedValue({ status: "ok" });
+      await act(async () => {
+        vi.advanceTimersByTime(400);
+        await Promise.resolve();
+      });
+      await flushMicrotasks();
+
+      for (const call of mockSubmitScore.mock.calls) {
+        expect(call[0]).toMatchObject({ key: "user_thumb", value: 0 });
+      }
+    });
+
+    it("rehydration ignores rows written under the other style", async () => {
+      // `listMySessionScores` returns every key it holds. Keyed by turn alone,
+      // a leftover star row would land in the thumbs widget's slot and
+      // rehydrate as "value 4", which thumbs cannot render honestly.
+      mockUseQuery.mockReturnValue([
+        { key: "user_rating", turnId: TURN_ID, value: 4, comment: "fine" },
+        { key: "user_thumb", turnId: "turn-other", value: 0 },
+      ]);
+
+      const { result } = renderHook(() =>
+        useChatboxTurnRating({
+          enabled: true,
+          chatboxId: "cbx_1",
+          accessVersion: 1,
+          scoreKey: "user_thumb",
+        })
+      );
+
+      act(() => {
+        result.current.observeChatSession(CHAT_SESSION_ID);
+      });
+
+      // The star-rated turn reads as unrated in the thumbs widget — truthful:
+      // it carries no judgement in the style this scenario now asks for. The
+      // row itself survives and still counts in the PM-facing rollup.
+      expect(result.current.getState(CHAT_SESSION_ID, TURN_ID)).toEqual({
+        status: "idle",
+      });
+      expect(
+        result.current.getState(CHAT_SESSION_ID, "turn-other")
+      ).toMatchObject({ value: 0, status: "submitted" });
+    });
+
+    it("a keyless rehydration row is read as stars", async () => {
+      // Rows projected by a backend that predates the key field.
+      mockUseQuery.mockReturnValue([{ turnId: TURN_ID, value: 3 }]);
+
+      const { result } = renderHook(() =>
+        useChatboxTurnRating({
+          enabled: true,
+          chatboxId: "cbx_1",
+          accessVersion: 1,
+          scoreKey: "user_rating",
+        })
+      );
+
+      act(() => {
+        result.current.observeChatSession(CHAT_SESSION_ID);
+      });
+
+      expect(result.current.getState(CHAT_SESSION_ID, TURN_ID)).toMatchObject({
+        value: 3,
+        status: "submitted",
+      });
+    });
+  });
 });

--- a/mcpjam-inspector/client/src/hooks/useChatboxTurnRating.ts
+++ b/mcpjam-inspector/client/src/hooks/useChatboxTurnRating.ts
@@ -35,11 +35,24 @@ export interface TurnRatingState {
   status: TurnRatingStatus;
 }
 
+/** The two per-turn score keys — one per widget style. */
+export type TurnScoreKey = "user_rating" | "user_thumb";
+
 type PendingSubmission = {
   chatSessionId: string;
   turnId: string;
   value: number;
   comment?: string;
+  /**
+   * The key this submission was CREATED under, carried rather than read live
+   * for the same reason `chatboxId` is: every retry path (the not_ready
+   * backoff, the stale-access replay, the abandon sweep) can wake up after the
+   * scenario's style changed, and a `0` minted by a thumbs click must never be
+   * resubmitted as `user_rating` — the server would take it as a star value
+   * out of range, and the tester's actual judgement would be lost to an error
+   * they cannot act on.
+   */
+  scoreKey: TurnScoreKey;
   /**
    * The chatbox this rating was left in. A retry that fires after the host
    * switched chatboxes would otherwise submit the old session and turn under
@@ -63,6 +76,12 @@ interface UseChatboxTurnRatingOptions {
   enabled: boolean;
   chatboxId?: string;
   accessVersion?: number;
+  /**
+   * Which key to write, derived from the scenario's `perTurnFeedback.style`.
+   * Defaults to stars so a config that predates the style field behaves
+   * exactly as it did.
+   */
+  scoreKey?: TurnScoreKey;
   /**
    * Ask the owner (ChatboxChatPage) to re-run `/web/chatbox/redeem`, exactly
    * as the widget-capture hook does. A fresh `accessVersion` flowing back in
@@ -99,6 +118,7 @@ export function useChatboxTurnRating({
   enabled,
   chatboxId,
   accessVersion,
+  scoreKey = "user_rating",
   onStaleHostedAccess,
 }: UseChatboxTurnRatingOptions): UseChatboxTurnRatingResult {
   const submitScore = useMutation("sessionScores:submitScore" as any);
@@ -159,20 +179,31 @@ export function useChatboxTurnRating({
     enabled && chatboxId && chatSessionId
       ? { chatboxId, accessVersion, chatSessionId }
       : "skip"
-  ) as Array<{ turnId?: string; value?: number; comment?: string }> | undefined;
+  ) as
+    | Array<{ key?: string; turnId?: string; value?: number; comment?: string }>
+    | undefined;
 
   const persistedByTurn = useMemo(() => {
     const map = new Map<string, { value?: number; comment?: string }>();
     if (!chatSessionId) return map;
     for (const row of persisted ?? []) {
       if (!row.turnId) continue;
+      // FILTER BY KEY. The server returns every key it holds for this session,
+      // and the map is keyed by turn alone — so after a mid-session style
+      // switch a leftover `user_rating` row would land in the thumbs widget's
+      // slot and rehydrate as "value 4", which the thumbs control has no way
+      // to render honestly. A turn rated under the other style shows as
+      // unrated here, which is the truthful reading: it carries no judgement
+      // in the style this scenario is now asking for. The score row itself
+      // survives and keeps counting in the PM-facing rollup.
+      if ((row.key ?? "user_rating") !== scoreKey) continue;
       map.set(stateKey(chatSessionId, row.turnId), {
         value: row.value,
         comment: row.comment,
       });
     }
     return map;
-  }, [persisted, chatSessionId]);
+  }, [persisted, chatSessionId, scoreKey]);
 
   // Read inside `setState` without making it a dependency — the merge below
   // needs the persisted comment, but re-creating `setState` on every query
@@ -256,7 +287,7 @@ export function useChatboxTurnRating({
           accessVersion: liveAccessVersion,
           chatSessionId: pending.chatSessionId,
           turnId: pending.turnId,
-          key: "user_rating",
+          key: pending.scoreKey,
           value: pending.value,
           ...(pending.comment !== undefined
             ? { comment: pending.comment }
@@ -421,9 +452,9 @@ export function useChatboxTurnRating({
       // redeem the newer submission may no longer need — and standing the
       // timer down should not depend on effect ordering.
       staleQueueRef.current.delete(key);
-      void runSubmit({ ...args, chatboxId, generation }, 0);
+      void runSubmit({ ...args, chatboxId, generation, scoreKey }, 0);
     },
-    [enabled, runSubmit]
+    [enabled, runSubmit, scoreKey]
   );
 
   const getState = useCallback(

--- a/mcpjam-inspector/client/src/hooks/useChatboxTurnRating.ts
+++ b/mcpjam-inspector/client/src/hooks/useChatboxTurnRating.ts
@@ -506,7 +506,10 @@ export function useChatboxTurnRating({
       }
       return IDLE;
     },
-    [states, persistedByTurn]
+    // `scoreKey` is a real input (it namespaces the lookup key), not merely
+    // reachable through `persistedByTurn`'s identity — listing it keeps this
+    // correct even if that memo is ever stabilized.
+    [states, persistedByTurn, scoreKey]
   );
 
   return { observeChatSession, getState, submit };

--- a/mcpjam-inspector/client/src/hooks/useChatboxTurnRating.ts
+++ b/mcpjam-inspector/client/src/hooks/useChatboxTurnRating.ts
@@ -98,7 +98,10 @@ export interface UseChatboxTurnRatingResult {
    * widget reports it rather than the page passing it down.
    */
   observeChatSession: (chatSessionId: string) => void;
-  /** Rating state for one turn, keyed `${chatSessionId}:${turnId}`. */
+  /**
+   * Rating state for one turn, under the hook's CURRENT `scoreKey`. A turn
+   * rated in the other widget style reads as unrated here — see `stateKey`.
+   */
   getState: (chatSessionId: string, turnId: string) => TurnRatingState;
   submit: (args: {
     chatSessionId: string;
@@ -108,8 +111,31 @@ export interface UseChatboxTurnRatingResult {
   }) => void;
 }
 
-function stateKey(chatSessionId: string, turnId: string): string {
-  return `${chatSessionId}:${turnId}`;
+/**
+ * The identity every piece of transient state hangs off.
+ *
+ * SCORE KEY IS PART OF IT, not just session + turn. A rating is a judgement in
+ * a particular widget's vocabulary, and the two vocabularies do not translate:
+ * the same turn can hold a `4` under stars and a `0` under thumbs, and neither
+ * is a sensible value for the other's control. Sharing one slot between them
+ * costs three distinct bugs when a scenario's style changes mid-session:
+ *
+ *   - the optimistic map wins over the (key-filtered) persisted read in
+ *     `getState`, so a 4★ submitted this page-load would rehydrate into the
+ *     thumbs widget as a "submitted" rating no thumb can represent;
+ *   - a new stars submission would bump the generation of a queued thumbs
+ *     retry and silently cancel it, losing a judgement the tester made;
+ *   - the stale-access queue would replace a queued thumbs rating with a stars
+ *     one on the same turn instead of holding both.
+ *
+ * Namespacing the key makes all three impossible rather than handled.
+ */
+function stateKey(
+  scoreKey: TurnScoreKey,
+  chatSessionId: string,
+  turnId: string
+): string {
+  return `${scoreKey}:${chatSessionId}:${turnId}`;
 }
 
 const IDLE: TurnRatingState = { status: "idle" };
@@ -131,8 +157,9 @@ export function useChatboxTurnRating({
   }, []);
 
   // Queued submissions waiting on a fresh accessVersion. Keyed the same way as
-  // `states` so a second rating on the same turn replaces the first rather
-  // than replaying both.
+  // `states` — including the score key — so a second rating on the same turn
+  // AND style replaces the first rather than replaying both, while a rating
+  // left under the other style keeps its own slot.
   const staleQueueRef = useRef(new Map<string, PendingSubmission>());
   // Latest submission generation per key — see `PendingSubmission.generation`.
   const generationRef = useRef(new Map<string, number>());
@@ -197,7 +224,7 @@ export function useChatboxTurnRating({
       // in the style this scenario is now asking for. The score row itself
       // survives and keeps counting in the PM-facing rollup.
       if ((row.key ?? "user_rating") !== scoreKey) continue;
-      map.set(stateKey(chatSessionId, row.turnId), {
+      map.set(stateKey(scoreKey, chatSessionId, row.turnId), {
         value: row.value,
         comment: row.comment,
       });
@@ -248,7 +275,11 @@ export function useChatboxTurnRating({
 
   const runSubmit = useCallback(
     async (pending: PendingSubmission, attempt: number): Promise<void> => {
-      const key = stateKey(pending.chatSessionId, pending.turnId);
+      const key = stateKey(
+        pending.scoreKey,
+        pending.chatSessionId,
+        pending.turnId
+      );
       // A retry waking up on a dead page, or carrying a superseded
       // generation, must do nothing — not touch state, not hit the server.
       if (unmountedRef.current) return;
@@ -380,7 +411,11 @@ export function useChatboxTurnRating({
         staleQueueRef.current.clear();
         staleAttemptRef.current = 0;
         for (const pending of abandoned) {
-          const key = stateKey(pending.chatSessionId, pending.turnId);
+          const key = stateKey(
+            pending.scoreKey,
+            pending.chatSessionId,
+            pending.turnId
+          );
           // A superseded queue entry no longer owns its key's state —
           // erroring it here would clobber a newer click's outcome.
           if (generationRef.current.get(key) !== pending.generation) continue;
@@ -441,7 +476,7 @@ export function useChatboxTurnRating({
     }) => {
       const chatboxId = accessRef.current.chatboxId;
       if (!enabled || !chatboxId) return;
-      const key = stateKey(args.chatSessionId, args.turnId);
+      const key = stateKey(scoreKey, args.chatSessionId, args.turnId);
       // Claim the key: every retry path spawned by an EARLIER click now
       // carries a stale generation and self-cancels.
       const generation = (generationRef.current.get(key) ?? 0) + 1;
@@ -459,7 +494,7 @@ export function useChatboxTurnRating({
 
   const getState = useCallback(
     (session: string, turnId: string): TurnRatingState => {
-      const key = stateKey(session, turnId);
+      const key = stateKey(scoreKey, session, turnId);
       // The optimistic map wins over the persisted read: it carries the
       // in-flight status, and after a submit it already holds the same value
       // the query will report on its next round-trip.

--- a/mcpjam-inspector/client/src/hooks/useSharedChatThreads.ts
+++ b/mcpjam-inspector/client/src/hooks/useSharedChatThreads.ts
@@ -50,6 +50,15 @@ export interface SharedChatThread {
     worstComment?: string;
     latestRating: number;
     latestAt: number;
+    /**
+     * Thumb tallies, when the session was rated with the thumbs widget. Both
+     * are absent on star-only sessions AND on any summary written before
+     * thumbs existed, and the backend emits each only when non-zero — so
+     * `count - up - down` is how many star rows the session has, and a
+     * non-zero remainder is what makes a session "mixed".
+     */
+    thumbUpCount?: number;
+    thumbDownCount?: number;
   } | null;
   toolCallCount?: number;
   /** OAuth or permission flow interrupted the session. */

--- a/mcpjam-inspector/client/src/lib/__tests__/chatbox-session.test.ts
+++ b/mcpjam-inspector/client/src/lib/__tests__/chatbox-session.test.ts
@@ -389,4 +389,45 @@ describe("chatUi surface normalization", () => {
       normalized?.payload.chatUi?.surfaces?.perTurnFeedback
     ).not.toHaveProperty("prompt");
   });
+
+  it("carries the thumbs style through", () => {
+    const normalized = normalizeChatboxSession(
+      session({
+        surfaces: { perTurnFeedback: { enabled: true, style: "thumbs" } },
+      })
+    );
+    expect(normalized?.payload.chatUi?.surfaces?.perTurnFeedback).toEqual({
+      enabled: true,
+      style: "thumbs",
+    });
+  });
+
+  it("omits the style rather than copying an unrecognised one", () => {
+    // A CLOSED enum, not a pass-through string: the value picks which widget
+    // renders and which score key the tester writes under, so an unknown value
+    // copied through would produce a scenario whose widget renders nothing.
+    // Absence means stars downstream.
+    for (const style of ["hearts", "", 5, null, "THUMBS"]) {
+      const normalized = normalizeChatboxSession(
+        session({
+          surfaces: { perTurnFeedback: { enabled: true, style } },
+        })
+      );
+      expect(
+        normalized?.payload.chatUi?.surfaces?.perTurnFeedback
+      ).not.toHaveProperty("style");
+    }
+  });
+
+  it("keeps stars implicit rather than writing it out", () => {
+    const normalized = normalizeChatboxSession(
+      session({
+        surfaces: { perTurnFeedback: { enabled: true, style: "stars" } },
+      })
+    );
+    // Absence IS stars — one representation, so no reader has to handle two.
+    expect(
+      normalized?.payload.chatUi?.surfaces?.perTurnFeedback
+    ).not.toHaveProperty("style");
+  });
 });

--- a/mcpjam-inspector/client/src/lib/chatbox-session.ts
+++ b/mcpjam-inspector/client/src/lib/chatbox-session.ts
@@ -12,6 +12,7 @@ import {
   extractTesterLinkToken,
   TESTER_LINK_PATH_SEGMENT,
 } from "@/lib/tester-link-path";
+import type { ChatboxPerTurnFeedbackStyle } from "@/types/chatUi";
 
 const MCPJAM_APP_ORIGIN = "https://app.mcpjam.com";
 
@@ -85,8 +86,11 @@ export interface ChatboxPerTurnFeedbackPayload {
   /**
    * Which widget to render, and therefore which score key the tester writes
    * under. Absent ⇒ `stars`, the only style that existed before this field.
+   *
+   * Aliased from the settings type rather than restated, so the bootstrap
+   * payload and the scenario config cannot drift apart on what a style is.
    */
-  style?: "stars" | "thumbs";
+  style?: ChatboxPerTurnFeedbackStyle;
   prompt?: string;
   commentPlaceholder?: string;
   thanksMessage?: string;

--- a/mcpjam-inspector/client/src/lib/chatbox-session.ts
+++ b/mcpjam-inspector/client/src/lib/chatbox-session.ts
@@ -82,6 +82,11 @@ export interface ChatboxWelcomeDialogPayload {
  */
 export interface ChatboxPerTurnFeedbackPayload {
   enabled: boolean;
+  /**
+   * Which widget to render, and therefore which score key the tester writes
+   * under. Absent ⇒ `stars`, the only style that existed before this field.
+   */
+  style?: "stars" | "thumbs";
   prompt?: string;
   commentPlaceholder?: string;
   thanksMessage?: string;
@@ -217,6 +222,14 @@ function normalizeChatUiPayload(input: unknown): ChatUiPayload | undefined {
     typeof (perTurnRaw as { enabled?: unknown }).enabled === "boolean"
       ? {
           enabled: (perTurnRaw as { enabled: boolean }).enabled,
+          // A CLOSED enum check, not `optionalString`: the value picks which
+          // widget renders and which score key the tester writes under, so an
+          // unrecognised string copied through would produce a scenario whose
+          // rating widget renders nothing. Anything but "thumbs" omits the
+          // field, and absence means stars downstream.
+          ...((perTurnRaw as { style?: unknown }).style === "thumbs"
+            ? { style: "thumbs" as const }
+            : {}),
           ...optionalString(perTurnRaw, "prompt"),
           ...optionalString(perTurnRaw, "commentPlaceholder"),
           ...optionalString(perTurnRaw, "thanksMessage"),

--- a/mcpjam-inspector/client/src/types/chatUi.ts
+++ b/mcpjam-inspector/client/src/types/chatUi.ts
@@ -10,8 +10,13 @@ export interface ChatboxWelcomeDialogSettings {
 
 /**
  * @deprecated The session-level feedback dialog. Its backend write path and
- * storage table are gone; per-turn ratings replaced it. Kept because stored
- * chatbox docs still carry the object.
+ * storage table are gone; per-turn ratings replaced it.
+ *
+ * As of the backend's Phase-3 deploy A, redeem and the settings response no
+ * longer return this surface at all, and `chatUi.surfaces.feedback` is no
+ * longer writable. Nothing in the client reads it. It survives only so a build
+ * running against an older backend still typechecks, and goes away with the
+ * backend's deploy B.
  */
 export interface ChatboxFeedbackDialogSettings {
   enabled: boolean;
@@ -21,8 +26,16 @@ export interface ChatboxFeedbackDialogSettings {
 }
 
 /**
- * Per-turn ratings: 1–5 stars plus an optional comment under each assistant
- * response, written to `sessionScores` under the `user_rating` key.
+ * Which per-turn widget a scenario shows. `stars` writes `sessionScores` under
+ * the `user_rating` key (1–5); `thumbs` writes `user_thumb` (0|1). Both fold
+ * into the same session rollup server-side, so the Sessions filters do not
+ * branch on this.
+ */
+export type ChatboxPerTurnFeedbackStyle = "stars" | "thumbs";
+
+/**
+ * Per-turn ratings: a rating plus an optional comment under each assistant
+ * response, written to `sessionScores` under the key the `style` selects.
  *
  * OFF by default and rolled out per scenario. The backend normalizer returns a
  * fully-defaulted envelope through redeem, so a `true` default would enable
@@ -30,7 +43,9 @@ export interface ChatboxFeedbackDialogSettings {
  */
 export interface ChatboxPerTurnFeedbackSettings {
   enabled: boolean;
-  /** Label above the stars. Empty ⇒ the widget's own copy. */
+  /** Absent ⇒ `stars`, which is what every scenario predating thumbs had. */
+  style?: ChatboxPerTurnFeedbackStyle;
+  /** Label above the widget. Empty ⇒ the widget's own copy. */
   prompt?: string;
   commentPlaceholder?: string;
   thanksMessage?: string;


### PR DESCRIPTION
Adds 👍/👎 as a per-scenario alternative to the 1–5 star widget for per-turn ratings.

Pairs with MCPJam/mcpjam-backend#981, which adds the `user_thumb` score key and the `style` config field. **That merges first.**

Ships dark: `style` defaults to stars, so thumbs appear only where a scenario picks them.

## `variant`, not a sibling component

`TurnRating` gains `variant?: 'stars' | 'thumbs'` rather than growing a twin. Everything except the row of buttons is genuinely shared — the comment editor and its collapse-on-success rule, the four status states, the two rehydration effects, the read-only render, and the `draftValue === undefined` sentinel that distinguishes "unrated" from "rated 0".

That last one is the reason a second implementation would be a bad idea: a thumbs-down *is* a stored `0`, and any falsy check anywhere in the widget renders it as unrated. There's a test for exactly that.

The numeric `onSubmit({value, comment})` contract holds — thumbs emit `1|0` — so `index.ts` is untouched. The existing 15 tests pass unchanged.

## The key rides the config

`scoreKey` is derived once in `ChatboxChatPage` from `perTurnFeedback.style` and threaded two ways from there: `variant` to the widget, `scoreKey` to the hook. The control the tester sees and the key their click writes cannot disagree.

Inside the hook it lands on `PendingSubmission` — beside `chatboxId` and `generation`, and for the same reason. Every retry path (the `not_ready` backoff, the stale-access replay, the abandon sweep) wakes up long after the click. One that read the key *live* could resubmit a thumbs `0` as `user_rating` after a mid-session style switch, where the server takes it as a star value out of range — losing the tester's judgement to an error they cannot act on.

**Rehydration fix**: `persistedByTurn` now filters by key. `listMySessionScores` returns every key it holds and the map is keyed by `turnId` alone, so a leftover star row would otherwise land in the thumbs widget's slot and rehydrate as "value 4" — which thumbs has no way to render honestly. A turn rated under the other style reads as unrated in the current widget. That's the truthful reading: it carries no judgement in the style this scenario is now asking for, and the row itself survives and still counts in the PM-facing rollup.

## Config parsing

`style` goes through a **closed enum check**, not the pass-through `optionalString`: the value picks which widget renders *and* which key is written, so an unrecognised string copied through would produce a scenario whose rating widget renders nothing. Anything but `"thumbs"` omits the field, and absence means stars — one representation, so no reader handles two.

## Editor

A stars/thumbs segmented control, shown only while the surface is on (a widget style is a question about a widget nobody is being shown otherwise), sending `{style}` **alone** — the backend merge preserves `enabled`, and restating it here would be this control asserting a rollout decision it isn't making, plus racing a toggle write.

The optimistic slot becomes an object with a **per-field standdown**, since one `boolean | null` can't carry both fields and clearing them together would drop a style override the instant an `enabled` write landed. `inFlightRef` is reused as-is. The description copy is style-aware, and a note explains that switching style doesn't rewrite history — a consequence that's invisible from that screen.

## Display

`feedback-headline.ts` derives **stars / thumbs / mixed** from the summary's counts alone. The backend deliberately stores no `style` on the summary, because a session can hold rows from both widgets and there's no single style to name; `count - up - down` is the star-row count.

- **Thumbs-only** → `👍 3 · 👎 1` instead of an average. `/5` on a session where nobody was offered a 5 is a number the tester never gave. The detail header also drops its `worst n/5` clause for these.
- **Mixed** → the stars' average *with* the thumb tallies; dropping either half would under-report how many turns were judged.
- The amber `min <= 2` predicate and the "No feedback" branch are untouched, because thumbs are projected onto the 1–5 axis server-side.

The list row and detail header share the helper so they can't disagree. `session-scored-transcript.tsx` accepts both keys and renders each in the widget that wrote it, preferring the latest-updated row when a turn carries both.

**`chatbox-usage-filters.ts` and the usage panel filter UI are unchanged** — the mapped `min` makes them work as-is. "Neutral (3)" is a documented dead option for thumbs-only scenarios: a two-state control has no neutral to express.

## Testing

`chat-ui`: 22 passed (7 new thumbs cases; the 15 variant-agnostic ones untouched).

`mcpjam-inspector` client project: **all green**. Full-repo run is `13720 passed | 2 failed`, and both failures — plus 99 collection errors — are pre-existing `|server|`-project failures from three missing build artifacts (`PluginShim.bundled.js`, `SandboxProxyHtml.bundled`, `HarnessPageBundle.generated`) in a fresh checkout. No client file fails.

New/extended coverage:
- **Hook** (24): payload carries `user_thumb`, defaults to `user_rating`, a `not_ready` retry resubmits under its original key after the style changes mid-flight, rehydration ignores other-key rows, keyless rows read as stars.
- **Widget**: thumbs radiogroup, `1`/`0` payloads, comment row, re-click switching, pending/read-only, and a stored `0` rendering as checked rather than unrated.
- **Editor** (15): hidden while off, stars default, stored thumbs, `{style}`-only body, no-op on the active style, revert on failure, per-field optimistic standdown, style-aware copy.
- **Display**: `feedback-headline` derivation and `formatThumbCounts`; `ThreadCard` rendering stars vs thumbs vs mixed, the amber tint on a 👎, and the untouched no-feedback branch.
- **Transcript**: both keys rendering in the right widget, `0` not treated as unrated, latest-revision preference, non-rating keys ignored.
- **Filters**: a 👎 session matching "Low (≤2)" and the negative chip, a 👍-only session not, the neutral bucket unreachable, a mixed session judged by its worst turn.
- **Normalizer**: thumbs carried through, invalid values omitted, `stars` kept implicit.

`tsc -p client` shows no new errors in touched files (the ~487 pre-existing ones are unchanged). Prettier run on everything touched.

---
_Generated by [Claude Code](https://claude.ai/code/session_01FmVMex1zwCdBt3cVo4fBez)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches per-turn score submission, optimistic/retry state, and session feedback display; mistakes could mis-record ratings or show wrong widgets, but behavior is heavily tested and defaults preserve existing star-only scenarios.
> 
> **Overview**
> Adds **👍/👎** as a per-scenario alternative to 1–5 stars for per-turn feedback, wired from scenario config through submission, PM display, and read-only transcripts. Default remains stars (`style` absent ⇒ stars); thumbs only appear when a scenario sets `perTurnFeedback.style: "thumbs"` (pairs with backend `user_thumb`).
> 
> **`TurnRating`** gains `variant: "stars" | "thumbs"` on the same component—shared comment flow, status handling, and `onSubmit({ value, comment })` (thumbs use `1`/`0`, with `0` treated as a real rating, not “unrated”).
> 
> **Hosted path:** `ChatboxChatPage` derives `scoreKey` from style once; `useChatboxTurnRating` namespaces optimistic state, retries, and rehydration by `scoreKey` so mid-session style switches cannot resubmit or display the wrong widget. **Editor:** stars/thumbs picker when ratings are enabled, `{ style }`-only patches, per-field optimistic standdown.
> 
> **Sessions UI:** `feedback-headline` classifies rollups as stars / thumbs / mixed from counts; list and detail show thumb tallies instead of misleading `/5` averages where appropriate. **Transcript:** joins both `user_rating` and `user_thumb`, picks latest row when both exist, and renders the matching variant.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 250862a95e4076af4346e4d15b7b9adbe38f7fc6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a thumbs up/down variant for per-turn ratings and threads the chosen style through the widget, submission, rehydration, Sessions display, and transcripts. Prevents cross-style misreads by keying transient state and retries by score key; `getState` now lists `scoreKey` in its deps to avoid stale reads.

- Ships dark: `style` defaults to stars; thumbs render only when a scenario sets `chatUi.surfaces.perTurnFeedback.style: "thumbs"`. `style` is a closed enum; unrecognized values are dropped; absence means stars.
- Backend dependency: pairs with MCPJam/mcpjam-backend#981 (adds `user_thumb` and tallies). Merge that first.
- Widget: `TurnRating` adds `variant: 'stars' | 'thumbs'` with the same `onSubmit({value, comment})` contract; thumbs emit `1|0`; a stored `0` shows as selected. Exports `TurnRatingVariant`.
- Hook: `useChatboxTurnRating` takes `scoreKey` (`'user_rating' | 'user_thumb'`), carries it on pending submissions, and resubmits `not_ready` retries under the original key. Rehydration filters by key; keyless rows default to stars. Optimistic state, generations, and the stale-access queue are keyed by `scoreKey:session:turn`. `getState` depends on `scoreKey`.
- Editor: adds a stars/thumbs segmented control (shown only when enabled). It writes `{style}` only; optimistic state tracks `enabled` and `style` independently; copy is style-aware.
- Display: derives stars/thumbs/mixed from summary counts. Thumbs-only sessions show `👍/👎` tallies; mixed sessions show blended average plus tallies; amber worst-turn (`min ≤ 2`) and “No feedback” branches are unchanged.
- Transcript: accepts both `user_rating` and `user_thumb`, renders each in the matching variant, and prefers the latest `updatedAt` when both exist on a turn.
- Filters: unchanged; thumbs map to the 1–5 axis server-side, so existing min/worst-turn logic and chips work as-is (neutral is unreachable for thumbs-only).
- Types/config: `ChatboxPerTurnFeedbackStyle` is shared with the bootstrap payload; stars kept implicit when absent.

Required action: merge MCPJam/mcpjam-backend#981 first; for scenarios that want thumbs, set `chatUi.surfaces.perTurnFeedback.style: "thumbs"`.

<sup>Written for commit c42009fdcb4a09d0da6d1794af20da38283843b1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/MCPJam/inspector/pull/4017?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

