### PR TITLE
fix(telemetry): own the backend failures whose body names MCPJam

### DIFF
--- a/mcpjam-inspector/server/utils/__tests__/backend-stream-failure.test.ts
+++ b/mcpjam-inspector/server/utils/__tests__/backend-stream-failure.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect } from "vitest";
 import { originOf } from "@mcpjam/sdk";
 import {
   describeBackendStreamFailure,
+  isMcpjamOwnedFailureCode,
   isUserOwnedDenialCode,
 } from "../mcpjam-stream-handler.js";
 
@@ -21,23 +22,63 @@ describe("describeBackendStreamFailure", () => {
   });
 
   it.each([401, 403])(
-    "reads a %i as a provider credential wall, not an MCPJam outage",
+    "reads a bare %i as a user-owned credential wall",
     (status) => {
       const normalized = describeBackendStreamFailure(status, "invalid api key");
 
       expect(normalized.slug).toBe("provider/auth_error");
-      // Defaults to the BYO reading: the key's owner is not plumbed to this
-      // layer, and staying quiet is the safe direction to be wrong in.
+      // With no MCPJam-owned code on the body, a 401 from `/stream` is its own
+      // auth gate (`auth_required` — sign in), which the user owns.
       expect(originOf(normalized)).toBe("user_config");
     },
   );
 
-  it("reads a 429 as a quota wall", () => {
+  it("reads a bare 429 as a quota wall", () => {
     const normalized = describeBackendStreamFailure(429, "rate limited");
 
     expect(normalized.slug).toBe("provider/quota");
     expect(originOf(normalized)).toBe("user_config");
   });
+
+  // The regression this change exists for. `categorizeError` in the backend
+  // mirrors the UPSTREAM provider's status onto our own response, so MCPJam's
+  // revoked managed key arrives as a 401 and MCPJam's own quota as a 429 —
+  // statuses whose catalog origin is `user_config`, which `mcpjam_internal`
+  // refuses to promote. A total hosted outage was filed as the user's problem.
+  it.each([
+    [401, "mcpjam_api_error"],
+    [403, "mcpjam_api_error"],
+    [429, "mcpjam_rate_limit"],
+    [500, "mcpjam_config_error"],
+    // Also at 200: the spend-precheck shape is a 200 JSON denial, and an
+    // MCPJam-owned code can ride the same envelope.
+    [200, "mcpjam_api_error"],
+  ])("owns a %i whose body names us via %s", (status, code) => {
+    const normalized = describeBackendStreamFailure(status, "boom", code);
+
+    expect(originOf(normalized)).toBe("mcpjam");
+  });
+
+  it("keeps the status-derived slug when the code names us", () => {
+    // The user-facing copy stays accurate — the provider DID reject the key.
+    // Only the ownership verdict changes: it was our key.
+    const normalized = describeBackendStreamFailure(
+      401,
+      "boom",
+      "mcpjam_api_error",
+    );
+
+    expect(normalized.slug).toBe("provider/auth_error");
+  });
+
+  it.each(["user_rate_limit", "auth_required", "invalid_request", undefined])(
+    "leaves a %s body on the status verdict",
+    (code) => {
+      expect(originOf(describeBackendStreamFailure(401, "boom", code))).toBe(
+        "user_config",
+      );
+    },
+  );
 
   it("makes no claim about a 4xx it does not recognize", () => {
     const normalized = describeBackendStreamFailure(400, "bad request");
@@ -85,5 +126,43 @@ describe("isUserOwnedDenialCode", () => {
     // costs the blindness this work exists to remove.
     expect(isUserOwnedDenialCode("something_new")).toBe(false);
     expect(isUserOwnedDenialCode(undefined)).toBe(false);
+  });
+});
+
+describe("isMcpjamOwnedFailureCode", () => {
+  it.each(["mcpjam_rate_limit", "mcpjam_api_error", "mcpjam_config_error"])(
+    "claims %s, which the backend itself marks 'not user's fault'",
+    (code) => {
+      expect(isMcpjamOwnedFailureCode(code)).toBe(true);
+    },
+  );
+
+  it.each([
+    "user_rate_limit",
+    "wallet_locked",
+    "auth_required",
+    "provider_rate_limit",
+    "provider_error",
+    "invalid_model",
+  ])("does not claim the user- or provider-owned code %s", (code) => {
+    expect(isMcpjamOwnedFailureCode(code)).toBe(false);
+  });
+
+  it("does not claim an unrecognized or absent code", () => {
+    // Allowlist, not a `mcpjam_` prefix rule: a new backend code must be read
+    // and classified rather than inheriting a page from its name.
+    expect(isMcpjamOwnedFailureCode("mcpjam_something_new")).toBe(false);
+    expect(isMcpjamOwnedFailureCode(undefined)).toBe(false);
+  });
+
+  it("is disjoint from the user-owned set", () => {
+    const ours = ["mcpjam_rate_limit", "mcpjam_api_error", "mcpjam_config_error"];
+    const theirs = ["user_rate_limit", "wallet_locked", "org_rate_limit"];
+    for (const code of ours) {
+      expect(isUserOwnedDenialCode(code)).toBe(false);
+    }
+    for (const code of theirs) {
+      expect(isMcpjamOwnedFailureCode(code)).toBe(false);
+    }
   });
 });

--- a/mcpjam-inspector/server/utils/__tests__/engine-failure-telemetry.test.ts
+++ b/mcpjam-inspector/server/utils/__tests__/engine-failure-telemetry.test.ts
@@ -14,6 +14,7 @@
  *   - the wire error chunk shape is unchanged (client contract)
  */
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { originOf } from "@mcpjam/sdk";
 import {
   executeToolCallsFromMessages,
   hasUnresolvedToolCalls,
@@ -176,6 +177,35 @@ describe("engine failure telemetry", () => {
       hop: "user_server_hop",
       errorCode: "user_rate_limit",
     });
+  });
+
+  it("owns a 401 whose body names MCPJam's own managed key", async () => {
+    // End-to-end guard for the blind spot: the backend's `categorizeError`
+    // mirrors the UPSTREAM provider's 401 onto its own response when MCPJam's
+    // managed Gateway/OpenRouter key is revoked. Classified by status alone
+    // that is `provider/auth_error` → `user_config`, and `mcpjam_internal`
+    // promotes only `ambiguous` — so a total hosted-chat outage reached the
+    // reporter labelled as the user's expired key and could never page.
+    global.fetch = vi.fn().mockResolvedValue(
+      new Response(
+        JSON.stringify({
+          ok: false,
+          code: "mcpjam_api_error",
+          error: "MCPJam is experiencing a configuration issue.",
+        }),
+        { status: 401, headers: { "Content-Type": "application/json" } },
+      ),
+    );
+    const { reporter, calls } = makeReporter();
+
+    await runTurn({ failureReporter: reporter });
+
+    expect(calls).toHaveLength(1);
+    expect(calls[0].errorCode).toBe("mcpjam_api_error");
+    // Not a recognized user-owned denial, so the internal hop still applies —
+    // but the verdict no longer depends on it.
+    expect(calls[0].hop).toBe("mcpjam_internal");
+    expect(originOf(calls[0].normalized)).toBe("mcpjam");
   });
 
   it("stays completely silent on abort — no report, no error chunk", async () => {

--- a/mcpjam-inspector/server/utils/mcpjam-stream-handler.ts
+++ b/mcpjam-inspector/server/utils/mcpjam-stream-handler.ts
@@ -433,14 +433,21 @@ export interface MCPJamEngineErrorEvent {
  * chat turn produced a raw string and no attribution, which is exactly the
  * failure a user cannot tell apart from their own server dying.
  *
- * Status drives the verdict:
+ * The body's guardrail `code` outranks the status, because it is the only
+ * direct evidence of ownership on the wire. The backend answers a failure of
+ * MCPJam's OWN managed provider credential with the upstream provider's
+ * status — `categorizeError` in `convex/stream/routes.ts` returns
+ * `{code:"mcpjam_api_error", statusCode:401}` for a revoked Gateway/OpenRouter
+ * key and `{code:"mcpjam_rate_limit", statusCode:429}` for MCPJam's quota —
+ * so status alone reads a total hosted outage as the user's expired key. See
+ * {@link isMcpjamOwnedFailureCode}.
  *
- * - 401/403 and 429 are the provider walls. They keep the catalog's default
- *   `user_config` origin because the common case is a BYO key that expired or
- *   ran out of credit. A managed-key failure IS ours, but the key's owner is
- *   not plumbed to this layer yet; defaulting to the non-paging reading is the
- *   safe direction to be wrong in, and the fix is to pass `credentialOwner`
- *   once that context exists.
+ * Otherwise status drives the verdict:
+ *
+ * - 401/403 and 429 are the provider walls. With no MCPJam-owned code on the
+ *   body they keep the catalog's default `user_config` origin: `/stream`
+ *   answers its own auth gate with 401 `auth_required` (sign in) and the spend
+ *   precheck with 429 `user_rate_limit`, both genuinely user-owned.
  * - Any other 5xx is OUR backend answering badly, and the origin is set
  *   explicitly rather than taken from the slug. `internal/unknown` is
  *   `ambiguous` by design — it is where unrecognized failures from arbitrary
@@ -452,11 +459,31 @@ export interface MCPJamEngineErrorEvent {
 export function describeBackendStreamFailure(
   status: number | undefined,
   rawText: string,
+  code?: string,
 ): NormalizedError {
   const detail = new Error(
     status !== undefined ? `HTTP ${status}: ${rawText}` : rawText,
   );
 
+  // Before the status branches: a body that names MCPJam settles ownership no
+  // matter which upstream status was mirrored onto it. The slug still comes
+  // from the status so the user-facing copy stays accurate ("the provider
+  // rejected the key" IS what happened — it was just our key).
+  if (isMcpjamOwnedFailureCode(code)) {
+    return {
+      ...describeBackendStreamFailureSlug(status, detail),
+      origin: "mcpjam",
+    };
+  }
+
+  return describeBackendStreamFailureSlug(status, detail);
+}
+
+/** Status → slug, with the catalog's own origin. Shared by both paths above. */
+function describeBackendStreamFailureSlug(
+  status: number | undefined,
+  detail: Error,
+): NormalizedError {
   if (status === 401 || status === 403) {
     return describeAsSlug("provider/auth_error", detail);
   }
@@ -1252,6 +1279,36 @@ const USER_OWNED_DENIAL_CODES = new Set<string>([
 /** Exported for the capture-policy tests; see {@link USER_OWNED_DENIAL_CODES}. */
 export function isUserOwnedDenialCode(code: string | undefined): boolean {
   return USER_OWNED_DENIAL_CODES.has(code ?? "");
+}
+
+/**
+ * The mirror of {@link USER_OWNED_DENIAL_CODES}: backend denial codes that name
+ * MCPJAM as the responsible party.
+ *
+ * Relevant at every status, not just 200 — and that is the whole point. The
+ * backend's `categorizeError` mirrors the UPSTREAM provider's status onto its
+ * own response, so a revoked MCPJam Gateway/OpenRouter key comes back as HTTP
+ * 401 and MCPJam's own provider quota as HTTP 429. Read by status alone those
+ * are `provider/auth_error` / `provider/quota`, whose catalog origin is
+ * `user_config` — and `mcpjam_internal` deliberately promotes only `ambiguous`,
+ * never evidence-bearing origins. So a total hosted-chat outage was filed as
+ * the user's expired key: no capture, no page, and nothing for M2 to fire on.
+ *
+ * Kept as an explicit allowlist rather than a `startsWith("mcpjam_")` rule so
+ * a new backend code has to be read and classified rather than inheriting a
+ * page from its name. Source of truth is the `MCPJamErrorCode` union in the
+ * backend's `convex/stream/routes.ts`; its own comments mark these three
+ * "(not user's fault)".
+ */
+const MCPJAM_OWNED_FAILURE_CODES = new Set<string>([
+  "mcpjam_rate_limit",
+  "mcpjam_api_error",
+  "mcpjam_config_error",
+]);
+
+/** See {@link MCPJAM_OWNED_FAILURE_CODES}. */
+export function isMcpjamOwnedFailureCode(code: string | undefined): boolean {
+  return MCPJAM_OWNED_FAILURE_CODES.has(code ?? "");
 }
 
 /**
@@ -2378,8 +2435,16 @@ async function processOneStep(
     const parsed = parseEngineErrorBody(res.status, errorText);
     // Site (1): no Error object exists here, so classify from the response
     // itself. A 5xx from our own backend is the hosted-502 class — capture it,
-    // because nothing downstream of this point ever will.
-    const normalized = describeBackendStreamFailure(res.status, errorText);
+    // because nothing downstream of this point ever will. `parsed.code` is
+    // passed because the status can be the UPSTREAM provider's, mirrored onto
+    // our response: only the code distinguishes MCPJam's own revoked key
+    // (401 `mcpjam_api_error`) from the caller's missing session (401
+    // `auth_required`).
+    const normalized = describeBackendStreamFailure(
+      res.status,
+      errorText,
+      parsed.code,
+    );
     // `isJsonDenial` proves only that the body was JSON — NOT that it was the
     // documented `{ok:false, code:"..."}` refusal, and "has any code at all"
     // is not enough either. The backend's error-code union includes


### PR DESCRIPTION
## What

A failure of MCPJam's **own managed provider credential** was filed as the user's problem — no Sentry capture, no page, and nothing for M2 to ever fire on.

## The gap

Two rules, each correct on its own:

1. The backend's `categorizeError` (`convex/stream/routes.ts`) mirrors the **upstream provider's** status onto its own response. A revoked MCPJam Gateway/OpenRouter key returns `{code:"mcpjam_api_error", statusCode:401}`; MCPJam's own quota returns `{code:"mcpjam_rate_limit", statusCode:429}`. The backend's own comments mark both `// not user's fault`.
2. `describeBackendStreamFailure` classifies 401/403 → `provider/auth_error` and 429 → `provider/quota`, whose catalog origin is `user_config`. That default is right for the *other* things `/stream` answers with those statuses — its own auth gate (`401 auth_required`, sign in) and the spend precheck (`429 user_rate_limit`).
3. `maybeCaptureOriginError`'s `mcpjam_internal` boundary promotes **only `ambiguous`**, by design: "a boundary declaration should not overrule evidence."

So `user_config` was never promoted, and a total hosted-chat outage arrived at the reporter labelled as the user's expired key.

Traced end to end:

```
provider key revoked
  → backend: {code:"mcpjam_api_error", statusCode:401}
  → site 1: describeBackendStreamFailure(401) → provider/auth_error → user_config
  → hop mcpjam_internal → not promoted (declared !== "ambiguous")
  → origin "user_config", captured: false
```

Only `mcpjam_config_error` (status 500) escaped, via the existing `>= 500` rule.

## The fix

`describeBackendStreamFailure` now takes the guardrail `code` the call site **already parses**, and checks it ahead of the status branches. The three codes the backend marks as ours settle ownership at any status.

The status still picks the slug, so user-facing copy is unchanged and stays accurate — the provider really did reject the key, it was just our key.

`MCPJAM_OWNED_FAILURE_CODES` is the mirror of the existing `USER_OWNED_DENIAL_CODES` and sits beside it. Kept an explicit allowlist rather than a `mcpjam_`-prefix rule so a new backend code has to be read and classified rather than inheriting a page from its name.

## Not changed

- Wire format, error-chunk shape, and every user-facing string.
- The `user_config` verdict for a bare 401/403/429 with no MCPJam-owned code.
- `USER_OWNED_DENIAL_CODES` and the hop split. A `mcpjam_*` code was already excluded from the user-owned exemption; that rule just had no way to reach the origin.

## Verification

- `server/utils/__tests__/backend-stream-failure.test.ts` — 38 pass. New cases pin the four (status, code) pairs, that the slug survives the ownership override, that a bare/`auth_required`/`user_rate_limit` body still reads `user_config`, and that the two code sets are disjoint.
- `server/utils/__tests__/engine-failure-telemetry.test.ts` — 6 pass. New end-to-end case drives the real engine with a mocked 401 `mcpjam_api_error` backend and asserts the reporter receives `origin: "mcpjam"`.
- Full `server/utils` + `server/middleware` suites: 107 files, 1527 tests, all pass.
- `tsc --noEmit -p server/tsconfig.json` clean for the touched files.

## Follow-ups (not in this PR)

1. **Mid-stream `mcpjam_*` is still invisible.** The backend's other delivery path is `toUIMessageStreamResponse({onError})` — the same categorized JSON, serialized into an SSE error part on an HTTP **200** stream. In `processStream` an `{type:"error"}` chunk falls into `default:` and is forwarded to the writer; the loop then returns normally and the turn is counted **successful**. The user sees an error, telemetry sees a success. Same class as the parser-failure bug fixed inline above it.
2. **`describeError` is direction-blind.** Per the 2026-07-28 spec, `-32020 HeaderMismatch` (`400`, §Server Validation) and `-32600 InvalidRequest` mean *the requester's* message was malformed. On the outbound path MCPJam **is** the requester, so those are ours; on the inbound bridge they are the caller's. All three are `ambiguous` today, so a systematic client bug affecting every user can never page.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit b194a39ee10364e86772fa16e332c26fefb02bbf. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Owns backend failures whose body names MCPJam so outages no longer report as user config problems. Previously 401/403/429 responses were classified by status as `user_config`; now a guardrail `code` like `mcpjam_api_error` or `mcpjam_rate_limit` sets origin to `mcpjam` while keeping the same slug.

- `describeBackendStreamFailure` now accepts `code` and prioritizes MCPJam-owned codes before status; status still determines the slug and user-facing copy.
- Adds `MCPJAM_OWNED_FAILURE_CODES` and `isMcpjamOwnedFailureCode`; allowlist is explicit (not `mcpjam_` prefix).
- Passes the parsed `code` from `processOneStep` when classifying errors.
- No wire format, error chunk shape, or user-facing strings changed; bare 401/403/429 remain `user_config`.
- Tests add end-to-end coverage for 401 `mcpjam_api_error` and unit cases for code/status combinations.

<sup>Written for commit b194a39ee10364e86772fa16e332c26fefb02bbf. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/MCPJam/inspector/pull/4018?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

