### PR TITLE
feat(chatbox): send chatboxId with web search so the owner pays

### DIFF
--- a/mcpjam-inspector/server/routes/web/chat-v2.ts
+++ b/mcpjam-inspector/server/routes/web/chat-v2.ts
@@ -433,8 +433,7 @@ chatV2.post("/", async (c) => {
                 "[chat-v2] chatbox attribution unavailable; running without plugin origin",
                 {
                   chatboxId,
-                  error:
-                    error instanceof Error ? error.message : String(error),
+                  error: error instanceof Error ? error.message : String(error),
                 }
               );
             }
@@ -1309,6 +1308,10 @@ chatV2.post("/", async (c) => {
         ...(body.chatSessionId ? { chatSessionId: body.chatSessionId } : {}),
         isGuest: Boolean(c.get("guestId")),
         isChatboxSession,
+        // Lets a spend inside a shared chatbox bill the chatbox OWNER instead
+        // of the visitor, who has no wallet to charge. Only web search reads
+        // it today; the model turn and voice already send their own.
+        ...(isChatboxSession && chatboxId ? { chatboxId } : {}),
         requireToolApproval,
         // Out-of-band and in-process ONLY. Never on `config.computer`:
         // `narrowHostComputer` runs at the top of `resolveHostTools` and

--- a/mcpjam-inspector/server/utils/built-in-tools/exa-web-search.ts
+++ b/mcpjam-inspector/server/utils/built-in-tools/exa-web-search.ts
@@ -24,6 +24,13 @@ export interface ExaWebSearchToolOptions {
   projectId: string;
   /** Optional chat session, used by Convex for idempotency namespacing. */
   chatSessionId?: string;
+  /**
+   * Set when the search happens inside a shared chatbox. A redeemed link grant
+   * on it makes the chatbox OWNER the payer — without it a visitor on a shared
+   * link cannot search at all: an anonymous one is told to sign in, and a
+   * signed-in one is told they are not a member of the owner's organization.
+   */
+  chatboxId?: string;
 }
 
 interface ExaWebSearchResult {
@@ -64,6 +71,7 @@ export function buildExaWebSearchTool(
           body: JSON.stringify({
             projectId: opts.projectId,
             chatSessionId: opts.chatSessionId,
+            ...(opts.chatboxId ? { chatboxId: opts.chatboxId } : {}),
             toolCallId,
             query,
           }),

--- a/mcpjam-inspector/server/utils/built-in-tools/registry.ts
+++ b/mcpjam-inspector/server/utils/built-in-tools/registry.ts
@@ -121,6 +121,14 @@ export interface BuiltInToolContext {
    */
   isChatboxSession?: boolean;
   /**
+   * The chatbox this turn runs in, when it is a chatbox turn. Unlike
+   * {@link isChatboxSession} — which decides what to ADVERTISE — this is
+   * forwarded to Convex so a spend can be billed to the chatbox OWNER rather
+   * than the visitor, who has no wallet to charge. Web search needs it for the
+   * same reason the model turn and voice transcription already do.
+   */
+  chatboxId?: string;
+  /**
    * True when this turn belongs to a Journey (swarm) simulated session.
    * Computer-backed tools are suppressed for those UNLESS the turn holds a
    * {@link sandboxBinding} — see the `bash` gate below.
@@ -244,6 +252,11 @@ export function resolveHostTools(
         authHeader,
         projectId: ctx.projectId,
         ...(ctx.chatSessionId ? { chatSessionId: ctx.chatSessionId } : {}),
+        // Lets Convex bill the chatbox owner. Unlike `bash` and the
+        // `mcpjam_*` tools below, web search stays ADVERTISED in a chatbox
+        // session — so without this it is offered to the model and then
+        // fails at execution for every link visitor.
+        ...(ctx.chatboxId ? { chatboxId: ctx.chatboxId } : {}),
       });
       continue;
     }


### PR DESCRIPTION
Inspector half of owner-billed web search. **Pairs with backend PR MCPJam/mcpjam-backend#987** — inert without it, and that one is inert without this.

## Why

Web search is the last spend a shared chatbox can incur that doesn't bill its owner, and it fails in the worst possible way.

Unlike `bash` and the `mcpjam_*` workspace tools — both of which are explicitly suppressed for guest/chatbox sessions in `resolveHostTools` — `web_search` has no such gate. So if the chatbox's host config has Web Search enabled, the tool **is advertised to the model** in that session. The model duly calls it, and the call dies at Convex for every link visitor:

- anonymous visitors get `Web search requires a signed-in account.`
- signed-in visitors get `You are not a member of this project's organization.` — the same error #978 fixed for chat, in a different route.

So today it's visible-but-broken rather than simply absent, which is the worse failure: the model burns a turn discovering the tool doesn't work.

## What

Thread `chatboxId` down the one chain that lacked it. The model turn and voice transcription already send theirs.

- `BuiltInToolContext` gains `chatboxId`. It's deliberately **distinct from `isChatboxSession`**: that flag decides what to *advertise*, this one decides who *pays*.
- the `web_search` branch of `resolveHostTools` forwards it to `buildExaWebSearchTool`
- `ExaWebSearchToolOptions` gains it and puts it on the POST body
- `chat-v2.ts` passes the already-in-scope `chatboxId`, on chatbox turns only

It's omitted when absent, so non-chatbox turns send a byte-identical body and nothing changes for them.

## Verification

- full suite: **15203 passed**, 6 skipped
- `tsc -p server/tsconfig.json`: my three files produce **zero** errors; the pre-existing errors elsewhere are byte-identical to `origin/main` (verified by stashing and re-running)

## Merge order

Either order is safe — each half is a no-op without the other. Backend first is marginally tidier, since it starts accepting `chatboxId` before anything sends one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit e3c50eb26c8665a4098f2e6f2da140fbf0ff23ff. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Bills web search from shared chatboxes to the chatbox owner by sending `chatboxId` with `web_search` requests. Previously, `web_search` was advertised in chatbox sessions but failed for visitors at Convex; now the call succeeds and charges the owner. Non-chatbox sessions remain unchanged.

**Review and rollout**
- Thread `chatboxId` through `BuiltInToolContext` → `resolveHostTools` → `buildExaWebSearchTool` → request body; only included for chatbox turns to keep non-chatbox requests byte-identical.
- Keep `isChatboxSession` for tool advertisement; use `chatboxId` only for billing.
- Pairs with backend `MCPJam/mcpjam-backend#987`; either can ship first, backend-first preferred. No migrations.

<sup>Written for commit e3c50eb26c8665a4098f2e6f2da140fbf0ff23ff. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/MCPJam/inspector/pull/4019?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

