### PR TITLE
fix(insights): follow-ups from the post-merge review round

### DIFF
--- a/mcpjam-inspector/server/routes/v1/__tests__/insights-envelope.test.ts
+++ b/mcpjam-inspector/server/routes/v1/__tests__/insights-envelope.test.ts
@@ -197,6 +197,24 @@ describe("eval-run insights retry — body validation (it SPENDS)", () => {
     expect(mutationMock).not.toHaveBeenCalled();
   });
 
+  it.each([
+    ["null", JSON.stringify({ force: null })],
+    ["whitespace-only body", "   "],
+  ])("rejects %s rather than billing for it", async (_label, payload) => {
+    vi.clearAllMocks();
+    answerQueries({ getTestSuiteRun: RUN_ROW });
+    const res = await makeApp(evals).request(
+      `/api/v1/projects/${PROJECT}/eval-runs/${RUN}/insights`,
+      {
+        method: "POST",
+        body: payload,
+        headers: { "content-type": "application/json" },
+      },
+    );
+    expect(res.status).toBe(400);
+    expect(mutationMock).not.toHaveBeenCalled();
+  });
+
   it("accepts force: false without forwarding force", async () => {
     vi.clearAllMocks();
     answerQueries({ getTestSuiteRun: RUN_ROW });

--- a/mcpjam-inspector/server/routes/v1/evals.ts
+++ b/mcpjam-inspector/server/routes/v1/evals.ts
@@ -72,6 +72,7 @@ import { getConvexBearerForRequest } from "../../utils/v1-convex-token.js";
 import { logger } from "../../utils/logger.js";
 import { v1Error, v1PageJson, v1Resource } from "./envelope.js";
 import { translateConvexWriteError as translateConvexError } from "./convex-errors.js";
+import { loadInsightsEnvelope } from "./insights-envelope-load.js";
 import { synthesizeServerBody } from "./adapter.js";
 import {
   getCanonicalModelId,
@@ -2086,21 +2087,11 @@ evals.get("/projects/:projectId/eval-runs/:runId", async (c) => {
   // to load it — including an authorization refusal for a caller who can see
   // the run but not its insights — omits the field rather than failing the
   // read: the run itself is the resource here.
-  let insights: Record<string, unknown> | undefined;
-  try {
-    const envelope = await convex.query(
-      "serverQuality:getEvalRunInsightsEnvelope" as any,
-      { suiteRunId: runId },
-    );
-    if (envelope) insights = envelope as Record<string, unknown>;
-  } catch (error) {
-    // Omission is the documented degradation (an older backend has no such
-    // query), but a genuine failure — schema drift, a rename, a transient
-    // error — looks identical from outside. Log so the two are separable in
-    // production; the run itself is still the resource, so the read stands.
-    console.warn("[v1.evals] insights envelope unavailable", error);
-    insights = undefined;
-  }
+  const insights = await loadInsightsEnvelope("v1.evals", () =>
+    convex.query("serverQuality:getEvalRunInsightsEnvelope" as any, {
+      suiteRunId: runId,
+    }),
+  );
 
   return v1Resource(c, {
     ...toRunDto(run!),
@@ -2135,8 +2126,11 @@ evals.post("/projects/:projectId/eval-runs/:runId/insights", async (c) => {
   // rather than a silently-empty body that bills anyway, and `force` must be
   // a real boolean — `{"force":"false"}` is a truthy string, and treating it
   // as consent would charge for a regeneration nobody asked for.
-  const raw = (await c.req.text()).trim();
-  let body: unknown = undefined;
+  const raw = await c.req.text();
+  // Only an ACTUALLY empty body is bodyless. Whitespace is malformed JSON,
+  // and a literal `null` is a value the schema should reject — treating
+  // either as "no body" would bill for a request nobody wrote.
+  let body: unknown = {};
   if (raw.length > 0) {
     try {
       body = JSON.parse(raw);
@@ -2150,7 +2144,7 @@ evals.post("/projects/:projectId/eval-runs/:runId/insights", async (c) => {
   }
   const force = parseWithSchema(
     z.object({ force: z.boolean().optional() }).strict(),
-    body ?? {},
+    body,
   ).force;
 
   try {

--- a/mcpjam-inspector/server/routes/v1/insights-envelope-load.ts
+++ b/mcpjam-inspector/server/routes/v1/insights-envelope-load.ts
@@ -1,0 +1,61 @@
+/**
+ * Loading the insights envelope as an ENRICHMENT on a detail response.
+ *
+ * All three detail routes want the same thing: attach the envelope when the
+ * caller may have it, and never let its absence fail the resource. What
+ * differs from an ordinary catch-site is which failures deserve attention.
+ *
+ * A REFUSAL here is routine. The envelope is gated more tightly than the
+ * resource around it (workspace membership vs. visibility), so an ordinary
+ * lower-privilege viewer — a share-link guest polling their own page — will
+ * be refused on every request. Reporting those would bury a genuine breakage
+ * under expected noise and, through `reportRouteFailure`, risk paging for it.
+ *
+ * A genuine failure is the opposite: a renamed function, schema drift against
+ * the hand-mirrored contract, an outage. Those are invisible if the field
+ * simply goes missing, since absence is also how an older backend behaves.
+ *
+ * So refusals are silent and everything else is reported through the
+ * centralized path, using the same classifier the read-error translator uses
+ * to tell the two apart.
+ */
+import { classifyConvexReadError } from "./convex-read-errors.js";
+import { reportRouteFailure } from "../../utils/route-error-report.js";
+
+export type InsightsEnvelopeSource =
+  | "v1.evals"
+  | "v1.journeys"
+  | "v1.user-testing";
+
+/**
+ * Run an envelope read, returning `undefined` instead of throwing.
+ *
+ * @param source route slug, for the failure report's `source`
+ * @param read the Convex query call
+ */
+export async function loadInsightsEnvelope(
+  source: InsightsEnvelopeSource,
+  read: () => Promise<unknown>,
+): Promise<Record<string, unknown> | undefined> {
+  try {
+    const envelope = await read();
+    return envelope ? (envelope as Record<string, unknown>) : undefined;
+  } catch (error) {
+    const failure = classifyConvexReadError(error);
+    const expected =
+      failure.kind === "membership" ||
+      failure.kind === "authentication" ||
+      // Production redacts a plain-error refusal to "Server Error". On THIS
+      // read that shape is overwhelmingly a refusal rather than a crash, and
+      // the cost of staying quiet is one missed log on a request whose
+      // resource still returned.
+      failure.kind === "redacted";
+    if (!expected) {
+      reportRouteFailure(`[${source}] insights envelope unavailable`, error, {
+        source: `${source}.insights-envelope`,
+        hop: "mcpjam_internal",
+      });
+    }
+    return undefined;
+  }
+}

--- a/mcpjam-inspector/server/routes/v1/journeys.ts
+++ b/mcpjam-inspector/server/routes/v1/journeys.ts
@@ -52,6 +52,7 @@ import { randomUUID } from "node:crypto";
 import { z } from "zod";
 import type { ConvexHttpClient } from "convex/browser";
 import { createConvexClient } from "./convex-client.js";
+import { loadInsightsEnvelope } from "./insights-envelope-load.js";
 import { ErrorCode, WebRouteError } from "../web/errors.js";
 import { getConvexBearerForRequest } from "../../utils/v1-convex-token.js";
 import { v1PageJson, v1Resource } from "./envelope.js";
@@ -784,19 +785,15 @@ journeys.get("/projects/:projectId/journey-runs/:runId", async (c) => {
   // The common insights envelope, DETAIL only (lists stay compact) —
   // resolved through the run's wave; runHealth rides beside findings, never
   // inside them. Load failure omits the field rather than failing the read.
-  let insights: Record<string, unknown> | undefined;
-  try {
-    const envelope = await client.query(
+  const insights = await loadInsightsEnvelope("v1.journeys", () =>
+    client.query(
       "swarmWaveInsights:getJourneyRunInsightsEnvelope" as never,
-      { projectId, runId } as never,
-    );
-    if (envelope) insights = envelope as Record<string, unknown>;
-  } catch (error) {
-    // See the eval twin: omission is the documented degradation, logging is
-    // what keeps a real breakage from being indistinguishable from it.
-    console.warn("[v1.journeys] insights envelope unavailable", error);
-    insights = undefined;
-  }
+      {
+        projectId,
+        runId,
+      } as never,
+    ),
+  );
 
   return v1Resource(c, {
     ...toJourneyRunDto(run),

--- a/mcpjam-inspector/server/routes/v1/user-testing.ts
+++ b/mcpjam-inspector/server/routes/v1/user-testing.ts
@@ -45,6 +45,7 @@ import { getConvexBearerForRequest } from "../../utils/v1-convex-token.js";
 import { v1PageJson, v1Resource } from "./envelope.js";
 import { translateConvexWriteError } from "./convex-errors.js";
 import { translateConvexReadError } from "./convex-read-errors.js";
+import { loadInsightsEnvelope } from "./insights-envelope-load.js";
 
 const userTesting = new Hono();
 
@@ -316,17 +317,12 @@ userTesting.get(BASE, async (c) => {
   // makes this route behave exactly like the eval and journey-run details:
   // the resource always returns, `insights` is present when the caller may
   // have it, and absence reads as `not_available`.
-  let insights: Record<string, unknown> | undefined;
-  try {
-    const envelope = await client.query(
+  const insights = await loadInsightsEnvelope("v1.user-testing", () =>
+    client.query(
       "chatboxWindowInsights:getScenarioInsightsEnvelope" as never,
       { chatboxId: scenarioId } as never,
-    );
-    if (envelope) insights = envelope as Record<string, unknown>;
-  } catch (error) {
-    console.warn("[v1.user-testing] insights envelope unavailable", error);
-    insights = undefined;
-  }
+    ),
+  );
 
   return v1Resource(c, {
     id: scenarioId,

--- a/sdk/src/platform/client.ts
+++ b/sdk/src/platform/client.ts
@@ -131,7 +131,7 @@ export class PlatformApiClient {
   constructor(options: PlatformApiClientOptions) {
     this.baseUrl = (options.baseUrl ?? DEFAULT_PLATFORM_API_BASE_URL).replace(
       /\/+$/,
-      ""
+      "",
     );
     this.getAuth = options.getAuth;
     // Native fetch must run with `this` bound to the global scope. Storing the
@@ -151,51 +151,51 @@ export class PlatformApiClient {
   }
 
   listOrganizations(
-    options?: RequestOptions
+    options?: RequestOptions,
   ): Promise<PlatformPage<PlatformOrganization>> {
     return this.request("GET", "/organizations", {}, options);
   }
 
   listProjects(
     params: { organizationId?: string } = {},
-    options?: RequestOptions
+    options?: RequestOptions,
   ): Promise<PlatformPage<PlatformProject>> {
     return this.request(
       "GET",
       "/projects",
       { query: { organizationId: params.organizationId } },
-      options
+      options,
     );
   }
 
   createProject(
     params: { body: Record<string, unknown> },
-    options?: RequestOptions
+    options?: RequestOptions,
   ): Promise<PlatformProject> {
     return this.request("POST", "/projects", { body: params.body }, options);
   }
 
   updateProject(
     params: { projectId: string; body: Record<string, unknown> },
-    options?: RequestOptions
+    options?: RequestOptions,
   ): Promise<PlatformProject> {
     return this.request(
       "PATCH",
       `/projects/${encodeURIComponent(params.projectId)}`,
       { body: params.body },
-      options
+      options,
     );
   }
 
   deleteProject(
     params: { projectId: string },
-    options?: RequestOptions
+    options?: RequestOptions,
   ): Promise<{ id: string; deleted: boolean }> {
     return this.request(
       "DELETE",
       `/projects/${encodeURIComponent(params.projectId)}`,
       {},
-      options
+      options,
     );
   }
 
@@ -214,13 +214,13 @@ export class PlatformApiClient {
    */
   createServerConnection(
     params: { body: PlatformServerConnectionCreateBody },
-    options?: RequestOptions
+    options?: RequestOptions,
   ): Promise<PlatformServerConnection> {
     return this.request(
       "POST",
       "/server-connections",
       { body: params.body },
-      options
+      options,
     );
   }
 
@@ -230,25 +230,27 @@ export class PlatformApiClient {
    * means the interval itself is too fast — honour `Retry-After`. */
   getServerConnection(
     params: { connectionRequestId: string },
-    options?: RequestOptions
+    options?: RequestOptions,
   ): Promise<PlatformServerConnection> {
     return this.request(
       "GET",
       `/server-connections/${encodeURIComponent(params.connectionRequestId)}`,
       {},
-      options
+      options,
     );
   }
 
   cancelServerConnection(
     params: { connectionRequestId: string },
-    options?: RequestOptions
+    options?: RequestOptions,
   ): Promise<PlatformServerConnection> {
     return this.request(
       "POST",
-      `/server-connections/${encodeURIComponent(params.connectionRequestId)}/cancel`,
+      `/server-connections/${encodeURIComponent(
+        params.connectionRequestId,
+      )}/cancel`,
       {},
-      options
+      options,
     );
   }
 
@@ -260,51 +262,53 @@ export class PlatformApiClient {
    */
   retryServerConnectionValidation(
     params: { connectionRequestId: string },
-    options?: RequestOptions
+    options?: RequestOptions,
   ): Promise<PlatformServerConnection> {
     return this.request(
       "POST",
-      `/server-connections/${encodeURIComponent(params.connectionRequestId)}/retry-validation`,
+      `/server-connections/${encodeURIComponent(
+        params.connectionRequestId,
+      )}/retry-validation`,
       {},
-      options
+      options,
     );
   }
 
   listProjectServers(
     params: { projectId: string },
-    options?: RequestOptions
+    options?: RequestOptions,
   ): Promise<PlatformPage<PlatformProjectServer>> {
     return this.request(
       "GET",
       `/projects/${encodeURIComponent(params.projectId)}/servers`,
       {},
-      options
+      options,
     );
   }
 
   createProjectServer(
     params: { projectId: string; body: Record<string, unknown> },
-    options?: RequestOptions
+    options?: RequestOptions,
   ): Promise<PlatformProjectServer> {
     return this.request(
       "POST",
       `/projects/${encodeURIComponent(params.projectId)}/servers`,
       { body: params.body },
-      options
+      options,
     );
   }
 
   getProjectServer(
     params: { projectId: string; serverId: string },
-    options?: RequestOptions
+    options?: RequestOptions,
   ): Promise<PlatformProjectServer> {
     return this.request(
       "GET",
       `/projects/${encodeURIComponent(
-        params.projectId
+        params.projectId,
       )}/servers/${encodeURIComponent(params.serverId)}`,
       {},
-      options
+      options,
     );
   }
 
@@ -314,41 +318,41 @@ export class PlatformApiClient {
       serverId: string;
       body: Record<string, unknown>;
     },
-    options?: RequestOptions
+    options?: RequestOptions,
   ): Promise<PlatformProjectServer> {
     return this.request(
       "PATCH",
       `/projects/${encodeURIComponent(
-        params.projectId
+        params.projectId,
       )}/servers/${encodeURIComponent(params.serverId)}`,
       { body: params.body },
-      options
+      options,
     );
   }
 
   deleteProjectServer(
     params: { projectId: string; serverId: string },
-    options?: RequestOptions
+    options?: RequestOptions,
   ): Promise<{ id: string; deleted: boolean }> {
     return this.request(
       "DELETE",
       `/projects/${encodeURIComponent(
-        params.projectId
+        params.projectId,
       )}/servers/${encodeURIComponent(params.serverId)}`,
       { body: {} },
-      options
+      options,
     );
   }
 
   listEvalSuites(
     params: { projectId: string },
-    options?: RequestOptions
+    options?: RequestOptions,
   ): Promise<PlatformPage<PlatformEvalSuite>> {
     return this.request(
       "GET",
       `/projects/${encodeURIComponent(params.projectId)}/eval-suites`,
       {},
-      options
+      options,
     );
   }
 
@@ -359,7 +363,7 @@ export class PlatformApiClient {
       limit?: number;
       before?: string;
     } = {},
-    options?: RequestOptions
+    options?: RequestOptions,
   ): Promise<PlatformPage<PlatformChatSession>> {
     return this.request(
       "GET",
@@ -372,33 +376,33 @@ export class PlatformApiClient {
           before: params.before,
         },
       },
-      options
+      options,
     );
   }
 
   listChatboxes(
     params: { projectId: string },
-    options?: RequestOptions
+    options?: RequestOptions,
   ): Promise<PlatformPage<PlatformChatbox>> {
     return this.request(
       "GET",
       `/projects/${encodeURIComponent(params.projectId)}/chatboxes`,
       {},
-      options
+      options,
     );
   }
 
   getChatbox(
     params: { projectId: string; chatboxId: string },
-    options?: RequestOptions
+    options?: RequestOptions,
   ): Promise<PlatformChatboxDetail> {
     return this.request(
       "GET",
       `/projects/${encodeURIComponent(
-        params.projectId
+        params.projectId,
       )}/chatboxes/${encodeURIComponent(params.chatboxId)}`,
       {},
-      options
+      options,
     );
   }
 
@@ -406,27 +410,27 @@ export class PlatformApiClient {
 
   listHosts(
     params: { projectId: string },
-    options?: RequestOptions
+    options?: RequestOptions,
   ): Promise<PlatformPage<PlatformHost>> {
     return this.request(
       "GET",
       `/projects/${encodeURIComponent(params.projectId)}/hosts`,
       {},
-      options
+      options,
     );
   }
 
   getHost(
     params: { projectId: string; hostId: string },
-    options?: RequestOptions
+    options?: RequestOptions,
   ): Promise<PlatformHostDetail> {
     return this.request(
       "GET",
       `/projects/${encodeURIComponent(
-        params.projectId
+        params.projectId,
       )}/hosts/${encodeURIComponent(params.hostId)}`,
       {},
-      options
+      options,
     );
   }
 
@@ -437,13 +441,13 @@ export class PlatformApiClient {
    */
   createHost(
     params: { projectId: string; body: Record<string, unknown> },
-    options?: RequestOptions
+    options?: RequestOptions,
   ): Promise<PlatformHostDetail> {
     return this.request(
       "POST",
       `/projects/${encodeURIComponent(params.projectId)}/hosts`,
       { body: params.body },
-      options
+      options,
     );
   }
 
@@ -453,15 +457,15 @@ export class PlatformApiClient {
       hostId: string;
       body: Record<string, unknown>;
     },
-    options?: RequestOptions
+    options?: RequestOptions,
   ): Promise<PlatformHostDetail> {
     return this.request(
       "PATCH",
       `/projects/${encodeURIComponent(
-        params.projectId
+        params.projectId,
       )}/hosts/${encodeURIComponent(params.hostId)}`,
       { body: params.body },
-      options
+      options,
     );
   }
 
@@ -472,12 +476,12 @@ export class PlatformApiClient {
       serverIds: string[];
       optionalServerIds?: string[];
     },
-    options?: RequestOptions
+    options?: RequestOptions,
   ): Promise<{ hostId: string; hostConfigId: string }> {
     return this.request(
       "POST",
       `/projects/${encodeURIComponent(
-        params.projectId
+        params.projectId,
       )}/hosts/${encodeURIComponent(params.hostId)}/servers`,
       {
         body: {
@@ -487,21 +491,21 @@ export class PlatformApiClient {
             : {}),
         },
       },
-      options
+      options,
     );
   }
 
   duplicateHost(
     params: { projectId: string; hostId: string; name?: string },
-    options?: RequestOptions
+    options?: RequestOptions,
   ): Promise<PlatformHostDetail> {
     return this.request(
       "POST",
       `/projects/${encodeURIComponent(
-        params.projectId
+        params.projectId,
       )}/hosts/${encodeURIComponent(params.hostId)}/duplicate`,
       { body: params.name === undefined ? {} : { name: params.name } },
-      options
+      options,
     );
   }
 
@@ -511,15 +515,15 @@ export class PlatformApiClient {
       hostId: string;
       body?: Record<string, unknown>;
     },
-    options?: RequestOptions
+    options?: RequestOptions,
   ): Promise<PlatformHostDeleted> {
     return this.request(
       "DELETE",
       `/projects/${encodeURIComponent(
-        params.projectId
+        params.projectId,
       )}/hosts/${encodeURIComponent(params.hostId)}`,
       { body: params.body ?? {} },
-      options
+      options,
     );
   }
 
@@ -535,7 +539,7 @@ export class PlatformApiClient {
 
   listEnvironments(
     params: { projectId: string; includeArchived?: boolean },
-    options?: RequestOptions
+    options?: RequestOptions,
   ): Promise<PlatformPage<PlatformEnvironment>> {
     return this.request(
       "GET",
@@ -543,7 +547,7 @@ export class PlatformApiClient {
       {
         query: params.includeArchived ? { includeArchived: "true" } : undefined,
       },
-      options
+      options,
     );
   }
 
@@ -557,29 +561,29 @@ export class PlatformApiClient {
    */
   getEnvironmentCapabilities(
     params: { projectId: string },
-    options?: RequestOptions
+    options?: RequestOptions,
   ): Promise<PlatformEnvironmentCapabilities> {
     return this.request(
       "GET",
       `/projects/${encodeURIComponent(
-        params.projectId
+        params.projectId,
       )}/environments/capabilities`,
       {},
-      options
+      options,
     );
   }
 
   getEnvironment(
     params: { projectId: string; environmentId: string },
-    options?: RequestOptions
+    options?: RequestOptions,
   ): Promise<PlatformEnvironment> {
     return this.request(
       "GET",
       `/projects/${encodeURIComponent(
-        params.projectId
+        params.projectId,
       )}/environments/${encodeURIComponent(params.environmentId)}`,
       {},
-      options
+      options,
     );
   }
 
@@ -591,27 +595,27 @@ export class PlatformApiClient {
    */
   resolveEnvironment(
     params: { projectId: string; environmentId: string },
-    options?: RequestOptions
+    options?: RequestOptions,
   ): Promise<PlatformEnvironmentResolved> {
     return this.request(
       "GET",
       `/projects/${encodeURIComponent(
-        params.projectId
+        params.projectId,
       )}/environments/${encodeURIComponent(params.environmentId)}/resolve`,
       {},
-      options
+      options,
     );
   }
 
   createEnvironment(
     params: { projectId: string; body: PlatformEnvironmentCreateBody },
-    options?: RequestOptions
+    options?: RequestOptions,
   ): Promise<PlatformEnvironment> {
     return this.request(
       "POST",
       `/projects/${encodeURIComponent(params.projectId)}/environments`,
       { body: params.body },
-      options
+      options,
     );
   }
 
@@ -626,15 +630,15 @@ export class PlatformApiClient {
       environmentId: string;
       body: PlatformEnvironmentUpdateBody;
     },
-    options?: RequestOptions
+    options?: RequestOptions,
   ): Promise<PlatformEnvironment> {
     return this.request(
       "PATCH",
       `/projects/${encodeURIComponent(
-        params.projectId
+        params.projectId,
       )}/environments/${encodeURIComponent(params.environmentId)}`,
       { body: params.body },
-      options
+      options,
     );
   }
 
@@ -648,15 +652,15 @@ export class PlatformApiClient {
       environmentId: string;
       expectedRevision: number;
     },
-    options?: RequestOptions
+    options?: RequestOptions,
   ): Promise<PlatformEnvironment> {
     return this.request(
       "POST",
       `/projects/${encodeURIComponent(
-        params.projectId
+        params.projectId,
       )}/environments/${encodeURIComponent(params.environmentId)}/archive`,
       { body: { expectedRevision: params.expectedRevision } },
-      options
+      options,
     );
   }
 
@@ -672,15 +676,15 @@ export class PlatformApiClient {
       environmentId: string;
       expectedRevision: number;
     },
-    options?: RequestOptions
+    options?: RequestOptions,
   ): Promise<PlatformEnvironment> {
     return this.request(
       "POST",
       `/projects/${encodeURIComponent(
-        params.projectId
+        params.projectId,
       )}/environments/${encodeURIComponent(params.environmentId)}/restore`,
       { body: { expectedRevision: params.expectedRevision } },
-      options
+      options,
     );
   }
 
@@ -691,13 +695,13 @@ export class PlatformApiClient {
 
   listProjectPlugins(
     params: { projectId: string },
-    options?: RequestOptions
+    options?: RequestOptions,
   ): Promise<PlatformPage<PlatformPlugin>> {
     return this.request(
       "GET",
       `/projects/${encodeURIComponent(params.projectId)}/plugins`,
       {},
-      options
+      options,
     );
   }
 
@@ -709,13 +713,13 @@ export class PlatformApiClient {
    */
   getPluginVersion(
     params: { pluginVersionId: string },
-    options?: RequestOptions
+    options?: RequestOptions,
   ): Promise<PlatformPluginVersion> {
     return this.request(
       "GET",
       `/plugin-versions/${encodeURIComponent(params.pluginVersionId)}`,
       {},
-      options
+      options,
     );
   }
 
@@ -726,39 +730,39 @@ export class PlatformApiClient {
 
   listImages(
     params: { projectId: string },
-    options?: RequestOptions
+    options?: RequestOptions,
   ): Promise<PlatformPage<PlatformImage>> {
     return this.request(
       "GET",
       `/projects/${encodeURIComponent(params.projectId)}/images`,
       {},
-      options
+      options,
     );
   }
 
   getImage(
     params: { projectId: string; imageId: string },
-    options?: RequestOptions
+    options?: RequestOptions,
   ): Promise<PlatformImage> {
     return this.request(
       "GET",
       `/projects/${encodeURIComponent(
-        params.projectId
+        params.projectId,
       )}/images/${encodeURIComponent(params.imageId)}`,
       {},
-      options
+      options,
     );
   }
 
   createImage(
     params: { projectId: string; body: { name: string; blueprint: string } },
-    options?: RequestOptions
+    options?: RequestOptions,
   ): Promise<PlatformImage> {
     return this.request(
       "POST",
       `/projects/${encodeURIComponent(params.projectId)}/images`,
       { body: params.body },
-      options
+      options,
     );
   }
 
@@ -768,15 +772,15 @@ export class PlatformApiClient {
       imageId: string;
       body: { name?: string; blueprint?: string };
     },
-    options?: RequestOptions
+    options?: RequestOptions,
   ): Promise<PlatformImage> {
     return this.request(
       "PATCH",
       `/projects/${encodeURIComponent(
-        params.projectId
+        params.projectId,
       )}/images/${encodeURIComponent(params.imageId)}`,
       { body: params.body },
-      options
+      options,
     );
   }
 
@@ -784,70 +788,70 @@ export class PlatformApiClient {
    * invalid blueprint is a successful lint with structured errors. */
   validateImageBlueprint(
     params: { projectId: string; body: { blueprint: string } },
-    options?: RequestOptions
+    options?: RequestOptions,
   ): Promise<PlatformImageBlueprintValidation> {
     return this.request(
       "POST",
       `/projects/${encodeURIComponent(params.projectId)}/images/validate`,
       { body: params.body },
-      options
+      options,
     );
   }
 
   deleteImage(
     params: { projectId: string; imageId: string },
-    options?: RequestOptions
+    options?: RequestOptions,
   ): Promise<PlatformImageDeleted> {
     return this.request(
       "DELETE",
       `/projects/${encodeURIComponent(
-        params.projectId
+        params.projectId,
       )}/images/${encodeURIComponent(params.imageId)}`,
       {},
-      options
+      options,
     );
   }
 
   listImageBuilds(
     params: { projectId: string; imageId: string },
-    options?: RequestOptions
+    options?: RequestOptions,
   ): Promise<PlatformPage<PlatformImageBuild>> {
     return this.request(
       "GET",
       `/projects/${encodeURIComponent(
-        params.projectId
+        params.projectId,
       )}/images/${encodeURIComponent(params.imageId)}/builds`,
       {},
-      options
+      options,
     );
   }
 
   /** `POST …/build` — async (202); poll `listImageBuilds` for status. */
   buildImage(
     params: { projectId: string; imageId: string },
-    options?: RequestOptions
+    options?: RequestOptions,
   ): Promise<PlatformImageBuildStarted> {
     return this.request(
       "POST",
       `/projects/${encodeURIComponent(
-        params.projectId
+        params.projectId,
       )}/images/${encodeURIComponent(params.imageId)}/build`,
       {},
-      options
+      options,
     );
   }
 
   promoteImage(
     params: { projectId: string; imageId: string },
-    options?: RequestOptions
+    options?: RequestOptions,
   ): Promise<PlatformImage> {
     return this.request(
       "POST",
       `/projects/${encodeURIComponent(
-        params.projectId
+        params.projectId,
       )}/images/${encodeURIComponent(params.imageId)}/promote`,
       {},
-      options
+      options,
     );
   }
 
@@ -855,28 +859,28 @@ export class PlatformApiClient {
    * pinned image). */
   useImage(
     params: { projectId: string; imageId: string },
-    options?: RequestOptions
+    options?: RequestOptions,
   ): Promise<PlatformComputerAttached> {
     return this.request(
       "POST",
       `/projects/${encodeURIComponent(
-        params.projectId
+        params.projectId,
       )}/images/${encodeURIComponent(params.imageId)}/use`,
       {},
-      options
+      options,
     );
   }
 
   /** Reset the caller's computer to its image (wipes mutable state). */
   resetComputer(
     params: { projectId: string },
-    options?: RequestOptions
+    options?: RequestOptions,
   ): Promise<PlatformComputerReset> {
     return this.request(
       "POST",
       `/projects/${encodeURIComponent(params.projectId)}/computer/reset`,
       {},
-      options
+      options,
     );
   }
 
@@ -886,13 +890,13 @@ export class PlatformApiClient {
    */
   createEvalRun(
     params: { projectId: string; body: Record<string, unknown> },
-    options?: RequestOptions
+    options?: RequestOptions,
   ): Promise<PlatformEvalRunCreated> {
     return this.request(
       "POST",
       `/projects/${encodeURIComponent(params.projectId)}/eval-runs`,
       { body: params.body },
-      options
+      options,
     );
   }
 
@@ -904,27 +908,27 @@ export class PlatformApiClient {
    */
   createEvalSuite(
     params: { projectId: string; body: Record<string, unknown> },
-    options?: RequestOptions
+    options?: RequestOptions,
   ): Promise<PlatformEvalSuiteCreated> {
     return this.request(
       "POST",
       `/projects/${encodeURIComponent(params.projectId)}/eval-suites`,
       { body: params.body },
-      options
+      options,
     );
   }
 
   getEvalRun(
     params: { projectId: string; runId: string },
-    options?: RequestOptions
+    options?: RequestOptions,
   ): Promise<PlatformEvalRun> {
     return this.request(
       "GET",
       `/projects/${encodeURIComponent(
-        params.projectId
+        params.projectId,
       )}/eval-runs/${encodeURIComponent(params.runId)}`,
       {},
-      options
+      options,
     );
   }
 
@@ -935,15 +939,15 @@ export class PlatformApiClient {
    */
   requestEvalRunInsights(
     params: { projectId: string; runId: string; force?: boolean },
-    options?: RequestOptions
+    options?: RequestOptions,
   ): Promise<PlatformEvalRunInsightsRequested> {
     return this.request(
       "POST",
       `/projects/${encodeURIComponent(
-        params.projectId
+        params.projectId,
       )}/eval-runs/${encodeURIComponent(params.runId)}/insights`,
       { body: params.force ? { force: true } : {} },
-      options
+      options,
     );
   }
 
@@ -954,78 +958,78 @@ export class PlatformApiClient {
       cursor?: string;
       limit?: number;
     },
-    options?: RequestOptions
+    options?: RequestOptions,
   ): Promise<PlatformPage<PlatformEvalIteration>> {
     return this.request(
       "GET",
       `/projects/${encodeURIComponent(
-        params.projectId
+        params.projectId,
       )}/eval-runs/${encodeURIComponent(params.runId)}/iterations`,
       { query: { cursor: params.cursor, limit: params.limit } },
-      options
+      options,
     );
   }
 
   /** Full trace envelope (messages + analysis) for one iteration. */
   getEvalIterationTrace(
     params: { projectId: string; runId: string; iterationId: string },
-    options?: RequestOptions
+    options?: RequestOptions,
   ): Promise<unknown> {
     return this.request(
       "GET",
       `/projects/${encodeURIComponent(
-        params.projectId
+        params.projectId,
       )}/eval-runs/${encodeURIComponent(
-        params.runId
+        params.runId,
       )}/iterations/${encodeURIComponent(params.iterationId)}/trace`,
       {},
-      options
+      options,
     );
   }
 
   /** Cancel an in-flight run; returns the run in its (now cancelled) state. */
   cancelEvalRun(
     params: { projectId: string; runId: string },
-    options?: RequestOptions
+    options?: RequestOptions,
   ): Promise<PlatformEvalRun> {
     return this.request(
       "POST",
       `/projects/${encodeURIComponent(
-        params.projectId
+        params.projectId,
       )}/eval-runs/${encodeURIComponent(params.runId)}/cancel`,
       {},
-      options
+      options,
     );
   }
 
   /** One row per authored step (status + reason + evidence) for one iteration. */
   getEvalRunSteps(
     params: { projectId: string; runId: string; iterationId: string },
-    options?: RequestOptions
+    options?: RequestOptions,
   ): Promise<PlatformPage<PlatformEvalStepResult>> {
     return this.request(
       "GET",
       `/projects/${encodeURIComponent(
-        params.projectId
+        params.projectId,
       )}/eval-runs/${encodeURIComponent(
-        params.runId
+        params.runId,
       )}/iterations/${encodeURIComponent(params.iterationId)}/steps`,
       {},
-      options
+      options,
     );
   }
 
   listEvalSuiteRuns(
     params: { projectId: string; suiteId: string; limit?: number },
-    options?: RequestOptions
+    options?: RequestOptions,
   ): Promise<PlatformPage<PlatformEvalRun>> {
     return this.request(
       "GET",
       `/projects/${encodeURIComponent(
-        params.projectId
+        params.projectId,
       )}/eval-suites/${encodeURIComponent(params.suiteId)}/runs`,
       { query: { limit: params.limit } },
-      options
+      options,
     );
   }
 
@@ -1033,15 +1037,15 @@ export class PlatformApiClient {
 
   getEvalSuite(
     params: { projectId: string; suiteId: string },
-    options?: RequestOptions
+    options?: RequestOptions,
   ): Promise<PlatformEvalSuiteDetail> {
     return this.request(
       "GET",
       `/projects/${encodeURIComponent(
-        params.projectId
+        params.projectId,
       )}/eval-suites/${encodeURIComponent(params.suiteId)}`,
       {},
-      options
+      options,
     );
   }
 
@@ -1051,29 +1055,29 @@ export class PlatformApiClient {
       suiteId: string;
       body: Record<string, unknown>;
     },
-    options?: RequestOptions
+    options?: RequestOptions,
   ): Promise<PlatformEvalSuiteDetail> {
     return this.request(
       "PATCH",
       `/projects/${encodeURIComponent(
-        params.projectId
+        params.projectId,
       )}/eval-suites/${encodeURIComponent(params.suiteId)}`,
       { body: params.body },
-      options
+      options,
     );
   }
 
   deleteEvalSuite(
     params: { projectId: string; suiteId: string },
-    options?: RequestOptions
+    options?: RequestOptions,
   ): Promise<PlatformEvalSuiteDeleted> {
     return this.request(
       "DELETE",
       `/projects/${encodeURIComponent(
-        params.projectId
+        params.projectId,
       )}/eval-suites/${encodeURIComponent(params.suiteId)}`,
       {},
-      options
+      options,
     );
   }
 
@@ -1083,45 +1087,45 @@ export class PlatformApiClient {
       suiteId: string;
       body: Record<string, unknown>;
     },
-    options?: RequestOptions
+    options?: RequestOptions,
   ): Promise<PlatformEvalSuiteDetail> {
     return this.request(
       "PATCH",
       `/projects/${encodeURIComponent(
-        params.projectId
+        params.projectId,
       )}/eval-suites/${encodeURIComponent(params.suiteId)}/schedule`,
       { body: params.body },
-      options
+      options,
     );
   }
 
   listEvalCases(
     params: { projectId: string; suiteId: string },
-    options?: RequestOptions
+    options?: RequestOptions,
   ): Promise<PlatformPage<PlatformEvalCase>> {
     return this.request(
       "GET",
       `/projects/${encodeURIComponent(
-        params.projectId
+        params.projectId,
       )}/eval-suites/${encodeURIComponent(params.suiteId)}/cases`,
       {},
-      options
+      options,
     );
   }
 
   getEvalCase(
     params: { projectId: string; suiteId: string; caseId: string },
-    options?: RequestOptions
+    options?: RequestOptions,
   ): Promise<PlatformEvalCase> {
     return this.request(
       "GET",
       `/projects/${encodeURIComponent(
-        params.projectId
+        params.projectId,
       )}/eval-suites/${encodeURIComponent(
-        params.suiteId
+        params.suiteId,
       )}/cases/${encodeURIComponent(params.caseId)}`,
       {},
-      options
+      options,
     );
   }
 
@@ -1131,15 +1135,15 @@ export class PlatformApiClient {
       suiteId: string;
       body: Record<string, unknown>;
     },
-    options?: RequestOptions
+    options?: RequestOptions,
   ): Promise<PlatformEvalCase> {
     return this.request(
       "POST",
       `/projects/${encodeURIComponent(
-        params.projectId
+        params.projectId,
       )}/eval-suites/${encodeURIComponent(params.suiteId)}/cases`,
       { body: params.body },
-      options
+      options,
     );
   }
 
@@ -1150,33 +1154,33 @@ export class PlatformApiClient {
       caseId: string;
       body: Record<string, unknown>;
     },
-    options?: RequestOptions
+    options?: RequestOptions,
   ): Promise<PlatformEvalCase> {
     return this.request(
       "PATCH",
       `/projects/${encodeURIComponent(
-        params.projectId
+        params.projectId,
       )}/eval-suites/${encodeURIComponent(
-        params.suiteId
+        params.suiteId,
       )}/cases/${encodeURIComponent(params.caseId)}`,
       { body: params.body },
-      options
+      options,
     );
   }
 
   deleteEvalCase(
     params: { projectId: string; suiteId: string; caseId: string },
-    options?: RequestOptions
+    options?: RequestOptions,
   ): Promise<PlatformEvalCaseDeleted> {
     return this.request(
       "DELETE",
       `/projects/${encodeURIComponent(
-        params.projectId
+        params.projectId,
       )}/eval-suites/${encodeURIComponent(
-        params.suiteId
+        params.suiteId,
       )}/cases/${encodeURIComponent(params.caseId)}`,
       {},
-      options
+      options,
     );
   }
 
@@ -1186,56 +1190,56 @@ export class PlatformApiClient {
       suiteId: string;
       body: Record<string, unknown>;
     },
-    options?: RequestOptions
+    options?: RequestOptions,
   ): Promise<PlatformEvalCasesGenerated> {
     return this.request(
       "POST",
       `/projects/${encodeURIComponent(
-        params.projectId
+        params.projectId,
       )}/eval-suites/${encodeURIComponent(params.suiteId)}/cases/generate`,
       { body: params.body },
-      options
+      options,
     );
   }
 
   validateServer(
     params: ServerScope & { body?: Record<string, unknown> },
-    options?: RequestOptions
+    options?: RequestOptions,
   ): Promise<Record<string, unknown>> {
     return this.serverOp(params, "validate", options);
   }
 
   doctorServer(
     params: ServerScope & { body?: Record<string, unknown> },
-    options?: RequestOptions
+    options?: RequestOptions,
   ): Promise<PlatformDoctorReport> {
     return this.serverOp(params, "doctor", options);
   }
 
   exportServer(
     params: ServerScope & { body?: Record<string, unknown> },
-    options?: RequestOptions
+    options?: RequestOptions,
   ): Promise<Record<string, unknown>> {
     return this.serverOp(params, "export", options);
   }
 
   listServerTools(
     params: ServerScope & { body?: Record<string, unknown> },
-    options?: RequestOptions
+    options?: RequestOptions,
   ): Promise<PlatformPage<Record<string, unknown>>> {
     return this.serverOp(params, "tools", options);
   }
 
   listServerResources(
     params: ServerScope & { body?: Record<string, unknown> },
-    options?: RequestOptions
+    options?: RequestOptions,
   ): Promise<PlatformPage<Record<string, unknown>>> {
     return this.serverOp(params, "resources", options);
   }
 
   listServerPrompts(
     params: ServerScope & { body?: Record<string, unknown> },
-    options?: RequestOptions
+    options?: RequestOptions,
   ): Promise<PlatformPage<Record<string, unknown>>> {
     return this.serverOp(params, "prompts", options);
   }
@@ -1249,7 +1253,7 @@ export class PlatformApiClient {
     params: ServerScope & {
       body: { toolName: string; parameters?: Record<string, unknown> };
     },
-    options?: RequestOptions
+    options?: RequestOptions,
   ): Promise<Record<string, unknown>> {
     return this.serverOp(params, "tools/call", options);
   }
@@ -1262,7 +1266,7 @@ export class PlatformApiClient {
         arguments?: Record<string, string | number | boolean>;
       };
     },
-    options?: RequestOptions
+    options?: RequestOptions,
   ): Promise<Record<string, unknown>> {
     return this.serverOp(params, "prompts/get", options);
   }
@@ -1270,7 +1274,7 @@ export class PlatformApiClient {
   /** `POST /projects/{p}/servers/{s}/resources/read` — read one resource. */
   readServerResource(
     params: ServerScope & { body: { uri: string } },
-    options?: RequestOptions
+    options?: RequestOptions,
   ): Promise<Record<string, unknown>> {
     return this.serverOp(params, "resources/read", options);
   }
@@ -1283,13 +1287,13 @@ export class PlatformApiClient {
    */
   createTunnel(
     params: { projectId: string; name: string },
-    options?: RequestOptions
+    options?: RequestOptions,
   ): Promise<PlatformTunnelGrant> {
     return this.request(
       "POST",
       `/projects/${encodeURIComponent(params.projectId)}/tunnels`,
       { body: { name: params.name } },
-      options
+      options,
     );
   }
 
@@ -1300,15 +1304,15 @@ export class PlatformApiClient {
    */
   closeTunnel(
     params: { projectId: string; serverId: string },
-    options?: RequestOptions
+    options?: RequestOptions,
   ): Promise<PlatformTunnelClosed> {
     return this.request(
       "POST",
       `/projects/${encodeURIComponent(
-        params.projectId
+        params.projectId,
       )}/tunnels/${encodeURIComponent(params.serverId)}/close`,
       {},
-      options
+      options,
     );
   }
 
@@ -1330,13 +1334,13 @@ export class PlatformApiClient {
 
   listJourneys(
     params: { projectId: string },
-    options?: RequestOptions
+    options?: RequestOptions,
   ): Promise<PlatformPage<PlatformJourney>> {
     return this.request(
       "GET",
       `/projects/${encodeURIComponent(params.projectId)}/journeys`,
       {},
-      options
+      options,
     );
   }
 
@@ -1347,29 +1351,29 @@ export class PlatformApiClient {
       cursor?: string;
       limit?: number;
     },
-    options?: RequestOptions
+    options?: RequestOptions,
   ): Promise<PlatformPage<PlatformJourneyRun>> {
     return this.request(
       "GET",
       `/projects/${encodeURIComponent(
-        params.projectId
+        params.projectId,
       )}/journeys/${encodeURIComponent(params.journeyId)}/runs`,
       { query: pageQuery(params) },
-      options
+      options,
     );
   }
 
   getJourneyRun(
     params: { projectId: string; runId: string },
-    options?: RequestOptions
+    options?: RequestOptions,
   ): Promise<PlatformJourneyRun> {
     return this.request(
       "GET",
       `/projects/${encodeURIComponent(
-        params.projectId
+        params.projectId,
       )}/journey-runs/${encodeURIComponent(params.runId)}`,
       {},
-      options
+      options,
     );
   }
 
@@ -1380,15 +1384,15 @@ export class PlatformApiClient {
       cursor?: string;
       limit?: number;
     },
-    options?: RequestOptions
+    options?: RequestOptions,
   ): Promise<PlatformPage<PlatformJourneyRunSession>> {
     return this.request(
       "GET",
       `/projects/${encodeURIComponent(
-        params.projectId
+        params.projectId,
       )}/journey-runs/${encodeURIComponent(params.runId)}/sessions`,
       { query: pageQuery(params) },
-      options
+      options,
     );
   }
 
@@ -1413,12 +1417,12 @@ export class PlatformApiClient {
       waveId?: string;
       environmentIds?: string[];
     },
-    options?: RequestOptions
+    options?: RequestOptions,
   ): Promise<PlatformJourneyRunLaunched> {
     return this.request(
       "POST",
       `/projects/${encodeURIComponent(
-        params.projectId
+        params.projectId,
       )}/journeys/${encodeURIComponent(params.journeyId)}/runs`,
       {
         body: {
@@ -1428,7 +1432,7 @@ export class PlatformApiClient {
             : {}),
         },
       },
-      options
+      options,
     );
   }
 
@@ -1445,15 +1449,15 @@ export class PlatformApiClient {
    */
   cancelJourneyRun(
     params: { projectId: string; runId: string },
-    options?: RequestOptions
+    options?: RequestOptions,
   ): Promise<PlatformJourneyRunCanceled> {
     return this.request(
       "POST",
       `/projects/${encodeURIComponent(
-        params.projectId
+        params.projectId,
       )}/journey-runs/${encodeURIComponent(params.runId)}/cancel`,
       {},
-      options
+      options,
     );
   }
 
@@ -1469,27 +1473,27 @@ export class PlatformApiClient {
 
   listPersonas(
     params: { projectId: string },
-    options?: RequestOptions
+    options?: RequestOptions,
   ): Promise<PlatformPage<PlatformPersona>> {
     return this.request(
       "GET",
       `/projects/${encodeURIComponent(params.projectId)}/personas`,
       {},
-      options
+      options,
     );
   }
 
   getPersona(
     params: { projectId: string; personaId: string },
-    options?: RequestOptions
+    options?: RequestOptions,
   ): Promise<PlatformPersona> {
     return this.request(
       "GET",
       `/projects/${encodeURIComponent(
-        params.projectId
+        params.projectId,
       )}/personas/${encodeURIComponent(params.personaId)}`,
       {},
-      options
+      options,
     );
   }
 
@@ -1508,14 +1512,14 @@ export class PlatformApiClient {
       avatarShape?: number;
       avatarPalette?: number;
     },
-    options?: RequestOptions
+    options?: RequestOptions,
   ): Promise<PlatformPersona> {
     const { projectId, ...body } = params;
     return this.request(
       "POST",
       `/projects/${encodeURIComponent(projectId)}/personas`,
       { body },
-      options
+      options,
     );
   }
 
@@ -1529,16 +1533,16 @@ export class PlatformApiClient {
       avatarShape?: number;
       avatarPalette?: number;
     },
-    options?: RequestOptions
+    options?: RequestOptions,
   ): Promise<PlatformPersona> {
     const { projectId, personaId, ...body } = params;
     return this.request(
       "PATCH",
       `/projects/${encodeURIComponent(projectId)}/personas/${encodeURIComponent(
-        personaId
+        personaId,
       )}`,
       { body },
-      options
+      options,
     );
   }
 
@@ -1550,29 +1554,29 @@ export class PlatformApiClient {
    */
   deletePersona(
     params: { projectId: string; personaId: string },
-    options?: RequestOptions
+    options?: RequestOptions,
   ): Promise<PlatformPersonaDeleted> {
     return this.request(
       "DELETE",
       `/projects/${encodeURIComponent(
-        params.projectId
+        params.projectId,
       )}/personas/${encodeURIComponent(params.personaId)}`,
       {},
-      options
+      options,
     );
   }
 
   getJourney(
     params: { projectId: string; journeyId: string },
-    options?: RequestOptions
+    options?: RequestOptions,
   ): Promise<PlatformJourney> {
     return this.request(
       "GET",
       `/projects/${encodeURIComponent(
-        params.projectId
+        params.projectId,
       )}/journeys/${encodeURIComponent(params.journeyId)}`,
       {},
-      options
+      options,
     );
   }
 
@@ -1590,14 +1594,14 @@ export class PlatformApiClient {
       serverAttachmentId?: string;
       hostIds?: string[];
     },
-    options?: RequestOptions
+    options?: RequestOptions,
   ): Promise<PlatformJourney> {
     const { projectId, ...body } = params;
     return this.request(
       "POST",
       `/projects/${encodeURIComponent(projectId)}/journeys`,
       { body },
-      options
+      options,
     );
   }
 
@@ -1621,16 +1625,16 @@ export class PlatformApiClient {
       sessionsPerTarget?: number;
       maxTurns?: number;
     },
-    options?: RequestOptions
+    options?: RequestOptions,
   ): Promise<PlatformJourney> {
     const { projectId, journeyId, ...body } = params;
     return this.request(
       "PATCH",
       `/projects/${encodeURIComponent(projectId)}/journeys/${encodeURIComponent(
-        journeyId
+        journeyId,
       )}`,
       { body },
-      options
+      options,
     );
   }
 
@@ -1641,41 +1645,41 @@ export class PlatformApiClient {
    */
   archiveJourney(
     params: { projectId: string; journeyId: string },
-    options?: RequestOptions
+    options?: RequestOptions,
   ): Promise<PlatformJourneyArchived> {
     return this.request(
       "DELETE",
       `/projects/${encodeURIComponent(
-        params.projectId
+        params.projectId,
       )}/journeys/${encodeURIComponent(params.journeyId)}`,
       {},
-      options
+      options,
     );
   }
 
   listSwarms(
     params: { projectId: string },
-    options?: RequestOptions
+    options?: RequestOptions,
   ): Promise<PlatformPage<PlatformSwarm>> {
     return this.request(
       "GET",
       `/projects/${encodeURIComponent(params.projectId)}/swarms`,
       {},
-      options
+      options,
     );
   }
 
   getSwarm(
     params: { projectId: string; swarmId: string },
-    options?: RequestOptions
+    options?: RequestOptions,
   ): Promise<PlatformSwarm> {
     return this.request(
       "GET",
       `/projects/${encodeURIComponent(
-        params.projectId
+        params.projectId,
       )}/swarms/${encodeURIComponent(params.swarmId)}`,
       {},
-      options
+      options,
     );
   }
 
@@ -1689,14 +1693,14 @@ export class PlatformApiClient {
       description?: string;
       environmentIds?: string[];
     },
-    options?: RequestOptions
+    options?: RequestOptions,
   ): Promise<PlatformSwarm> {
     const { projectId, ...body } = params;
     return this.request(
       "POST",
       `/projects/${encodeURIComponent(projectId)}/swarms`,
       { body },
-      options
+      options,
     );
   }
 
@@ -1710,16 +1714,16 @@ export class PlatformApiClient {
       sessionsPerTarget?: number;
       maxTurns?: number;
     },
-    options?: RequestOptions
+    options?: RequestOptions,
   ): Promise<PlatformSwarm> {
     const { projectId, swarmId, ...body } = params;
     return this.request(
       "PATCH",
       `/projects/${encodeURIComponent(projectId)}/swarms/${encodeURIComponent(
-        swarmId
+        swarmId,
       )}`,
       { body },
-      options
+      options,
     );
   }
 
@@ -1729,15 +1733,15 @@ export class PlatformApiClient {
    */
   archiveSwarm(
     params: { projectId: string; swarmId: string },
-    options?: RequestOptions
+    options?: RequestOptions,
   ): Promise<PlatformSwarmArchived> {
     return this.request(
       "DELETE",
       `/projects/${encodeURIComponent(
-        params.projectId
+        params.projectId,
       )}/swarms/${encodeURIComponent(params.swarmId)}`,
       {},
-      options
+      options,
     );
   }
 
@@ -1759,14 +1763,14 @@ export class PlatformApiClient {
       description?: string;
       existingPersonas?: Array<{ name: string; role: string }>;
     },
-    options?: RequestOptions
+    options?: RequestOptions,
   ): Promise<PlatformGenerationDrafts> {
     const { projectId, ...body } = params;
     return this.request(
       "POST",
       `/projects/${encodeURIComponent(projectId)}/personas/generate`,
       { body },
-      options
+      options,
     );
   }
 
@@ -1785,14 +1789,14 @@ export class PlatformApiClient {
       journeyCount?: number;
       description?: string;
     },
-    options?: RequestOptions
+    options?: RequestOptions,
   ): Promise<PlatformGenerationDrafts> {
     const { projectId, ...body } = params;
     return this.request(
       "POST",
       `/projects/${encodeURIComponent(projectId)}/journeys/generate`,
       { body },
-      options
+      options,
     );
   }
 
@@ -1806,81 +1810,81 @@ export class PlatformApiClient {
 
   getSwarmOverview(
     params: { projectId: string },
-    options?: RequestOptions
+    options?: RequestOptions,
   ): Promise<PlatformSwarmOverview> {
     return this.request(
       "GET",
       `/projects/${encodeURIComponent(params.projectId)}/journeys-overview`,
       {},
-      options
+      options,
     );
   }
 
   getJourneyRunScorecard(
     params: { projectId: string; runId: string },
-    options?: RequestOptions
+    options?: RequestOptions,
   ): Promise<PlatformRunScorecard> {
     return this.request(
       "GET",
       `/projects/${encodeURIComponent(
-        params.projectId
+        params.projectId,
       )}/journey-runs/${encodeURIComponent(params.runId)}/scorecard`,
       {},
-      options
+      options,
     );
   }
 
   listSwarmFindings(
     params: { projectId: string },
-    options?: RequestOptions
+    options?: RequestOptions,
   ): Promise<PlatformPage<PlatformSwarmFinding>> {
     return this.request(
       "GET",
       `/projects/${encodeURIComponent(params.projectId)}/journey-findings`,
       {},
-      options
+      options,
     );
   }
 
   dismissSwarmFinding(
     params: { projectId: string; findingId: string },
-    options?: RequestOptions
+    options?: RequestOptions,
   ): Promise<PlatformFindingDismissed> {
     return this.request(
       "POST",
       `/projects/${encodeURIComponent(
-        params.projectId
+        params.projectId,
       )}/journey-findings/${encodeURIComponent(params.findingId)}/dismiss`,
       {},
-      options
+      options,
     );
   }
 
   undismissSwarmFinding(
     params: { projectId: string; findingId: string },
-    options?: RequestOptions
+    options?: RequestOptions,
   ): Promise<PlatformFindingDismissed> {
     return this.request(
       "POST",
       `/projects/${encodeURIComponent(
-        params.projectId
+        params.projectId,
       )}/journey-findings/${encodeURIComponent(params.findingId)}/undismiss`,
       {},
-      options
+      options,
     );
   }
 
   getWaveInsights(
     params: { projectId: string; waveId: string },
-    options?: RequestOptions
+    options?: RequestOptions,
   ): Promise<PlatformWaveInsights> {
     return this.request(
       "GET",
       `/projects/${encodeURIComponent(
-        params.projectId
+        params.projectId,
       )}/waves/${encodeURIComponent(params.waveId)}/insights`,
       {},
-      options
+      options,
     );
   }
 
@@ -1895,15 +1899,15 @@ export class PlatformApiClient {
    */
   requestWaveInsights(
     params: { projectId: string; waveId: string; force?: boolean },
-    options?: RequestOptions
+    options?: RequestOptions,
   ): Promise<PlatformWaveInsightsRequested> {
     return this.request(
       "POST",
       `/projects/${encodeURIComponent(
-        params.projectId
+        params.projectId,
       )}/waves/${encodeURIComponent(params.waveId)}/insights`,
       { body: params.force ? { force: true } : {} },
-      options
+      options,
     );
   }
 
@@ -1914,15 +1918,15 @@ export class PlatformApiClient {
    */
   cancelWaveInsights(
     params: { projectId: string; waveId: string },
-    options?: RequestOptions
+    options?: RequestOptions,
   ): Promise<PlatformWaveInsightsCanceled> {
     return this.request(
       "DELETE",
       `/projects/${encodeURIComponent(
-        params.projectId
+        params.projectId,
       )}/waves/${encodeURIComponent(params.waveId)}/insights`,
       {},
-      options
+      options,
     );
   }
 
@@ -1937,13 +1941,13 @@ export class PlatformApiClient {
    */
   getCapabilities(
     params: { projectId: string },
-    options?: RequestOptions
+    options?: RequestOptions,
   ): Promise<PlatformCapabilities> {
     return this.request(
       "GET",
       `/projects/${encodeURIComponent(params.projectId)}/capabilities`,
       {},
-      options
+      options,
     );
   }
 
@@ -1968,7 +1972,7 @@ export class PlatformApiClient {
       description?: string;
       mode?: "project_members" | "invited_only" | "anyone_with_link";
     },
-    options?: RequestOptions
+    options?: RequestOptions,
   ): Promise<PlatformScenario & { overridesIgnored?: boolean }> {
     const { projectId, environmentId } = params;
     // Explicit picks, not a rest spread: TypeScript's structural typing lets a
@@ -1979,31 +1983,31 @@ export class PlatformApiClient {
         name: params.name,
         description: params.description,
         mode: params.mode,
-      }).filter(([, value]) => value !== undefined)
+      }).filter(([, value]) => value !== undefined),
     );
     return this.request(
       "PUT",
       `/projects/${encodeURIComponent(
-        projectId
+        projectId,
       )}/environments/${encodeURIComponent(environmentId)}/scenario`,
       // Bodyless when there is nothing to send — the common case, and what
       // existing callers already put on the wire.
       Object.keys(body).length > 0 ? { body } : {},
-      options
+      options,
     );
   }
 
   unpublishScenario(
     params: { projectId: string; environmentId: string },
-    options?: RequestOptions
+    options?: RequestOptions,
   ): Promise<PlatformScenarioDeleted> {
     return this.request(
       "DELETE",
       `/projects/${encodeURIComponent(
-        params.projectId
+        params.projectId,
       )}/environments/${encodeURIComponent(params.environmentId)}/scenario`,
       {},
-      options
+      options,
     );
   }
 
@@ -2039,32 +2043,36 @@ export class PlatformApiClient {
       description?: string;
       mode?: "project_members" | "invited_only" | "anyone_with_link";
     },
-    options?: RequestOptions
+    options?: RequestOptions,
   ): Promise<PlatformScenario & { overridesIgnored?: boolean }> {
     const { projectId, environmentId, ...body } = params;
     return this.request(
       "PUT",
       `/projects/${encodeURIComponent(
-        projectId
+        projectId,
       )}/environments/${encodeURIComponent(environmentId)}/scenario`,
       { body },
-      options
+      options,
     );
   }
 
   /**
-   * Scenario detail with the REQUIRED common insights envelope. Project
-   * members only — share-link guests never reach other visitors' evidence.
+   * Scenario detail, with the common insights envelope when the caller may
+   * have it. `insights` is OPTIONAL: the envelope is gated on workspace
+   * membership while the scenario is visible more widely, so a
+   * lower-privilege viewer — and any server predating the envelope — gets the
+   * scenario without it rather than an error. Treat absence as
+   * `not_available`, never as "no findings".
    */
   getUserTestingScenario(
     params: { projectId: string; scenarioId: string },
-    options?: RequestOptions
+    options?: RequestOptions,
   ): Promise<PlatformUserTestingScenarioDetail> {
     return this.request(
       "GET",
       this.userTestingPath(params.projectId, params.scenarioId),
       {},
-      options
+      options,
     );
   }
 
@@ -2083,14 +2091,14 @@ export class PlatformApiClient {
       description?: string;
       mode?: "project_members" | "invited_only" | "anyone_with_link";
     },
-    options?: RequestOptions
+    options?: RequestOptions,
   ): Promise<PlatformUserTestingScenario> {
     const { projectId, scenarioId, ...body } = params;
     return this.request(
       "PATCH",
       this.userTestingPath(projectId, scenarioId),
       { body },
-      options
+      options,
     );
   }
 
@@ -2102,13 +2110,13 @@ export class PlatformApiClient {
       cursor?: string;
       limit?: number;
     },
-    options?: RequestOptions
+    options?: RequestOptions,
   ): Promise<PlatformPage<PlatformUserTestingSession>> {
     return this.request(
       "GET",
       `${this.userTestingPath(params.projectId, params.scenarioId)}/sessions`,
       { query: pageQuery(params) },
-      options
+      options,
     );
   }
 
@@ -2127,22 +2135,22 @@ export class PlatformApiClient {
       cursor?: string;
       limit?: number;
     },
-    options?: RequestOptions
+    options?: RequestOptions,
   ): Promise<PlatformUserTestingSessionDetail> {
     return this.request(
       "GET",
       `${this.userTestingPath(
         params.projectId,
-        params.scenarioId
+        params.scenarioId,
       )}/sessions/${encodeURIComponent(params.sessionId)}`,
       { query: pageQuery(params) },
-      options
+      options,
     );
   }
 
   getUserTestingMetrics(
     params: { projectId: string; scenarioId: string; population?: string },
-    options?: RequestOptions
+    options?: RequestOptions,
   ): Promise<Record<string, unknown>> {
     return this.request(
       "GET",
@@ -2150,7 +2158,7 @@ export class PlatformApiClient {
       {
         query: params.population ? { population: params.population } : {},
       },
-      options
+      options,
     );
   }
 
@@ -2162,53 +2170,53 @@ export class PlatformApiClient {
    */
   getUserTestingUsage(
     params: { projectId: string; scenarioId: string },
-    options?: RequestOptions
+    options?: RequestOptions,
   ): Promise<Record<string, unknown>> {
     return this.request(
       "GET",
       `${this.userTestingPath(params.projectId, params.scenarioId)}/usage`,
       {},
-      options
+      options,
     );
   }
 
   listUserTestingFindings(
     params: { projectId: string; scenarioId: string },
-    options?: RequestOptions
+    options?: RequestOptions,
   ): Promise<PlatformPage<Record<string, unknown>>> {
     return this.request(
       "GET",
       `${this.userTestingPath(params.projectId, params.scenarioId)}/findings`,
       {},
-      options
+      options,
     );
   }
 
   /** Also how you learn the CURRENT window id, which the insights read takes. */
   getUserTestingSignals(
     params: { projectId: string; scenarioId: string },
-    options?: RequestOptions
+    options?: RequestOptions,
   ): Promise<Record<string, unknown>> {
     return this.request(
       "GET",
       `${this.userTestingPath(params.projectId, params.scenarioId)}/signals`,
       {},
-      options
+      options,
     );
   }
 
   getUserTestingInsights(
     params: { projectId: string; scenarioId: string; windowId: string },
-    options?: RequestOptions
+    options?: RequestOptions,
   ): Promise<Record<string, unknown>> {
     return this.request(
       "GET",
       `${this.userTestingPath(
         params.projectId,
-        params.scenarioId
+        params.scenarioId,
       )}/windows/${encodeURIComponent(params.windowId)}/insights`,
       {},
-      options
+      options,
     );
   }
 
@@ -2219,38 +2227,38 @@ export class PlatformApiClient {
    */
   requestUserTestingInsights(
     params: { projectId: string; scenarioId: string; force?: boolean },
-    options?: RequestOptions
+    options?: RequestOptions,
   ): Promise<PlatformUserTestingInsightsRequested> {
     return this.request(
       "POST",
       `${this.userTestingPath(params.projectId, params.scenarioId)}/insights`,
       { body: params.force ? { force: true } : {} },
-      options
+      options,
     );
   }
 
   cancelUserTestingInsights(
     params: { projectId: string; scenarioId: string; windowId: string },
-    options?: RequestOptions
+    options?: RequestOptions,
   ): Promise<Record<string, unknown>> {
     return this.request(
       "DELETE",
       `${this.userTestingPath(params.projectId, params.scenarioId)}/insights`,
       { body: { windowId: params.windowId } },
-      options
+      options,
     );
   }
 
   dismissUserTestingFinding(
     params: { projectId: string; scenarioId: string; findingId: string },
-    options?: RequestOptions
+    options?: RequestOptions,
   ): Promise<Record<string, unknown>> {
     return this.userTestingFindingAction(params, "dismiss", options);
   }
 
   undismissUserTestingFinding(
     params: { projectId: string; scenarioId: string; findingId: string },
-    options?: RequestOptions
+    options?: RequestOptions,
   ): Promise<Record<string, unknown>> {
     return this.userTestingFindingAction(params, "undismiss", options);
   }
@@ -2268,16 +2276,16 @@ export class PlatformApiClient {
       scenarioId: string;
       guestExecution: PlatformGuestExecution;
     },
-    options?: RequestOptions
+    options?: RequestOptions,
   ): Promise<Record<string, unknown>> {
     return this.request(
       "PUT",
       `${this.userTestingPath(
         params.projectId,
-        params.scenarioId
+        params.scenarioId,
       )}/guest-execution`,
       { body: params.guestExecution },
-      options
+      options,
     );
   }
 
@@ -2287,16 +2295,16 @@ export class PlatformApiClient {
    */
   rotateUserTestingLink(
     params: { projectId: string; scenarioId: string },
-    options?: RequestOptions
+    options?: RequestOptions,
   ): Promise<Record<string, unknown>> {
     return this.request(
       "POST",
       `${this.userTestingPath(
         params.projectId,
-        params.scenarioId
+        params.scenarioId,
       )}/rotate-link`,
       {},
-      options
+      options,
     );
   }
 
@@ -2308,29 +2316,29 @@ export class PlatformApiClient {
       email: string;
       sendInviteEmail?: boolean;
     },
-    options?: RequestOptions
+    options?: RequestOptions,
   ): Promise<Record<string, unknown>> {
     const { projectId, scenarioId, ...body } = params;
     return this.request(
       "PUT",
       `${this.userTestingPath(projectId, scenarioId)}/members`,
       { body },
-      options
+      options,
     );
   }
 
   removeUserTestingMember(
     params: { projectId: string; scenarioId: string; member: string },
-    options?: RequestOptions
+    options?: RequestOptions,
   ): Promise<Record<string, unknown>> {
     return this.request(
       "DELETE",
       `${this.userTestingPath(
         params.projectId,
-        params.scenarioId
+        params.scenarioId,
       )}/members/${encodeURIComponent(params.member)}`,
       {},
-      options
+      options,
     );
   }
 
@@ -2341,45 +2349,45 @@ export class PlatformApiClient {
    */
   rebindUserTestingScenario(
     params: { projectId: string; scenarioId: string; environmentId: string },
-    options?: RequestOptions
+    options?: RequestOptions,
   ): Promise<Record<string, unknown>> {
     return this.request(
       "POST",
       `${this.userTestingPath(params.projectId, params.scenarioId)}/rebind`,
       { body: { environmentId: params.environmentId } },
-      options
+      options,
     );
   }
 
   private userTestingPath(projectId: string, scenarioId: string): string {
     return `/projects/${encodeURIComponent(
-      projectId
+      projectId,
     )}/user-testing/scenarios/${encodeURIComponent(scenarioId)}`;
   }
 
   private userTestingFindingAction(
     params: { projectId: string; scenarioId: string; findingId: string },
     action: "dismiss" | "undismiss",
-    options?: RequestOptions
+    options?: RequestOptions,
   ): Promise<Record<string, unknown>> {
     return this.request(
       "POST",
       `${this.userTestingPath(
         params.projectId,
-        params.scenarioId
+        params.scenarioId,
       )}/findings/${encodeURIComponent(params.findingId)}/${action}`,
       {},
-      options
+      options,
     );
   }
 
   private serverOp<T>(
     params: ServerScope & { body?: Record<string, unknown> },
     op: string,
-    options?: RequestOptions
+    options?: RequestOptions,
   ): Promise<T> {
     const path = `/projects/${encodeURIComponent(
-      params.projectId
+      params.projectId,
     )}/servers/${encodeURIComponent(params.serverId)}/${op}`;
     return this.request("POST", path, { body: params.body ?? {} }, options);
   }
@@ -2392,7 +2400,7 @@ export class PlatformApiClient {
     method: "GET" | "POST" | "PUT" | "PATCH" | "DELETE",
     path: string,
     init: { query?: QueryParams; body?: unknown },
-    options?: RequestOptions
+    options?: RequestOptions,
   ): Promise<T> {
     const url = new URL(`${this.baseUrl}${path}`);
     for (const [name, value] of Object.entries(init.query ?? {})) {
@@ -2429,9 +2437,9 @@ export class PlatformApiClient {
     const timeoutHandle = setTimeout(
       () =>
         controller.abort(
-          new Error(`Request timed out after ${this.timeoutMs}ms`)
+          new Error(`Request timed out after ${this.timeoutMs}ms`),
         ),
-      this.timeoutMs
+      this.timeoutMs,
     );
 
     // BOTH THE FETCH AND THE BODY READ ARE INSIDE THIS `try`, and that is the
@@ -2462,10 +2470,10 @@ export class PlatformApiClient {
           aborted
             ? `Request to ${path} timed out after ${this.timeoutMs}ms`
             : `Failed to reach the MCPJam API at ${url.origin}: ${errorMessage(
-                error
+                error,
               )}`,
           aborted ? "TIMEOUT" : "NETWORK_ERROR",
-          { status: 0, endpoint: path, cause: error }
+          { status: 0, endpoint: path, cause: error },
         );
       }
 
@@ -2481,13 +2489,13 @@ export class PlatformApiClient {
           throw new PlatformApiError(
             `Request to ${path} timed out after ${this.timeoutMs}ms`,
             "TIMEOUT",
-            { status: 0, endpoint: path, cause: error }
+            { status: 0, endpoint: path, cause: error },
           );
         }
         throw new PlatformApiError(
           `Failed to read the MCPJam API response (${response.status}) for ${path}`,
           "INTERNAL_ERROR",
-          { status: response.status, endpoint: path, cause: error }
+          { status: response.status, endpoint: path, cause: error },
         );
       }
     } finally {
@@ -2515,7 +2523,7 @@ export class PlatformApiClient {
       throw new PlatformApiError(
         `The MCPJam API returned a non-JSON response (${response.status}) for ${path}`,
         "INTERNAL_ERROR",
-        { status: response.status, endpoint: path, cause: parseError }
+        { status: response.status, endpoint: path, cause: parseError },
       );
     }
 
@@ -2526,7 +2534,7 @@ export class PlatformApiClient {
   private toApiError(
     response: Response,
     body: unknown,
-    path: string
+    path: string,
   ): PlatformApiError {
     const envelope =
       body && typeof body === "object" && !Array.isArray(body)
@@ -2572,7 +2580,7 @@ function fallbackCodeForStatus(status: number): string {
 
 function parseRetryAfter(
   header: string | null,
-  now: number = Date.now()
+  now: number = Date.now(),
 ): number | undefined {
   if (!header) return undefined;
   const seconds = Number(header);


### PR DESCRIPTION
Five review findings landed on #4014 after its final push, so they merged unaddressed. This clears them.

## Logging (coderabbit, major)

The three envelope catch-sites used `console.warn` — the **only** direct-console logging anywhere in `server/routes/v1`, bypassing the centralized reporter every other route uses.

They now share `loadInsightsEnvelope`, which also settles cubic's separate P3 that a share-link guest polling their own page would log a warning on every request. Those two findings pull in opposite directions until you notice the envelope is gated more tightly than the resource around it (workspace membership vs. visibility), which makes a refusal there **routine**. So refusals are classified with the same helper the read translator uses and stay silent, and everything else — a rename, schema drift, an outage — goes through `reportRouteFailure`, where it can page. Reporting the routine case would have buried the real one and risked paging for an ordinary permission outcome.

## Billing edge (cubic, P2)

`raw.trim()` ran before the empty check, so a whitespace-only body counted as bodyless; and `null` collapsed to `{}` through `body ?? {}`. Both scheduled a billable generation for a request nobody wrote. Only a genuinely empty body is bodyless now — whitespace is malformed JSON (400) and `null` is a value the strict schema rejects (400).

## Docs + tests

The SDK's `getUserTestingScenario` docstring still promised a REQUIRED envelope after the type became optional; it now states that absence means `not_available`, never "no findings". Added coverage for `force: null` and the whitespace body.

## Verification

server 5,742 passed, typecheck clean. One unrelated flake in the local bash-engine suite (temp-dir ENOENT, green in isolation, nothing in this diff touches it).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit 37dcc5729ba0375b105c25f0c2b13b23b0b50953. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Consolidates insights envelope loading and fixes billing edge cases for insights requests. This removes noisy warnings for routine authorization refusals and prevents billing when the request body is whitespace or null.

- Centralizes envelope reads with loadInsightsEnvelope in eval, journey-run, and user-testing detail routes. Authorization/refusal/redacted errors are silent; other failures report via reportRouteFailure; omission degrades the field without failing the resource.
- POST /api/v1/projects/{projectId}/eval-runs/{runId}/insights: only an actually empty body is bodyless; whitespace is malformed JSON (400) and literal null is rejected by the strict schema (400). force must be a boolean.
- Adds tests for whitespace and null bodies; updates `sdk` `getUserTestingScenario` docs to state `insights` is optional and absence means not_available.
- Migration: callers that sent whitespace or null must send either {} or {"force": true|false}.

<sup>Written for commit 37dcc5729ba0375b105c25f0c2b13b23b0b50953. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/MCPJam/inspector/pull/4021?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

