### PR TITLE
fix(user-testing): stop the scenario Edit route resolving as a tester link

### DIFF
--- a/mcpjam-inspector/client/src/lib/__tests__/tester-link-path.test.ts
+++ b/mcpjam-inspector/client/src/lib/__tests__/tester-link-path.test.ts
@@ -35,6 +35,38 @@ describe("tester-link-path", () => {
     }
   });
 
+  it("does not read the scenario Edit screen as a tester link", () => {
+    // `/user-testing/<scenarioId>/edit` has a tester link's three segments.
+    // Matching it handed the whole page to the public runtime, which redeemed
+    // "edit" as a token and rendered "Link Unavailable" — the Edit button in
+    // the scenario header looked like it did nothing.
+    for (const editPath of [
+      "/user-testing/t97b0ae1gqfg5faczettv0zk7n8cem4j/edit",
+      "/user-testing/t97b0ae1gqfg5faczettv0zk7n8cem4j/edit/",
+      "/chatbox/host_123/edit",
+    ]) {
+      expect(extractTesterLinkToken(editPath)).toBeNull();
+      expect(TESTER_LINK_RUNTIME_PATH_PATTERN.test(editPath)).toBe(false);
+    }
+    // The token reader is the looser of the two — it also sees pathnames that
+    // still carry a query or hash, and must refuse those too.
+    expect(extractTesterLinkToken("/user-testing/host_123/edit?tab=share")).toBe(
+      null
+    );
+    expect(extractTesterLinkToken("/user-testing/host_123/edit#top")).toBe(null);
+  });
+
+  it("still reads a token that merely starts with the reserved word", () => {
+    // The exclusion is the whole segment, not a prefix — a real token is a
+    // random id and may legitimately begin with these letters.
+    expect(extractTesterLinkToken("/user-testing/demo/edit_tok_1")).toBe(
+      "edit_tok_1"
+    );
+    expect(
+      TESTER_LINK_RUNTIME_PATH_PATTERN.test("/user-testing/demo/edit_tok_1")
+    ).toBe(true);
+  });
+
   it("reads the token through a preview query or a slug bookmark", () => {
     expect(
       extractTesterLinkToken("/user-testing/demo/tok_1?surface=preview")

--- a/mcpjam-inspector/client/src/lib/tester-link-path.ts
+++ b/mcpjam-inspector/client/src/lib/tester-link-path.ts
@@ -22,23 +22,39 @@
 export const TESTER_LINK_PATH_SEGMENT = "user-testing";
 
 /**
+ * Third segments that belong to the SIGNED-IN app, not to a tester link.
+ *
+ * `/user-testing/<scenarioId>/edit` is the scenario's setup screen, and it has
+ * the same three-segment shape as a tester link — so without this exclusion the
+ * token matcher below reads `edit` as a share token, `App` mounts the public
+ * runtime instead of the app shell, and redeeming fails with "Link
+ * Unavailable". That is what made the header's Edit button look dead.
+ *
+ * Reserving the word costs nothing: tokens are minted random ids, never `edit`.
+ */
+const RESERVED_APP_SUBPATH = "edit";
+
+/**
  * Exactly `<segment>/<slug>/<token>`, trailing slash tolerated and nothing
  * else. Deliberately not a `startsWith` — a generic prefix test would let an
  * unrelated future subpath past the iframe guard.
  *
  * `/user-testing/<scenarioId>` (the in-app scenario screen) has two segments,
- * so it cannot match: the third segment is required and cannot be empty.
+ * so it cannot match: the third segment is required and cannot be empty. Its
+ * `/edit` sibling DOES have three, so it is excluded by name.
  */
-export const TESTER_LINK_RUNTIME_PATH_PATTERN =
-  /^\/(?:user-testing|chatbox)\/[^/]+\/[^/]+\/?$/;
+export const TESTER_LINK_RUNTIME_PATH_PATTERN = new RegExp(
+  `^/(?:user-testing|chatbox)/[^/]+/(?!${RESERVED_APP_SUBPATH}/?$)[^/]+/?$`
+);
 
 /**
  * Same shape, token captured. Looser than the pattern above on purpose: a
  * pathname carrying `?surface=preview` or a `#slug` bookmark still yields its
- * token.
+ * token — while still refusing the reserved app sub-path.
  */
-const TESTER_LINK_TOKEN_PATTERN =
-  /^\/(?:user-testing|chatbox)\/[^/?#]+\/([^/?#]+)/;
+const TESTER_LINK_TOKEN_PATTERN = new RegExp(
+  `^/(?:user-testing|chatbox)/[^/?#]+/(?!${RESERVED_APP_SUBPATH}(?:[/?#]|$))([^/?#]+)`
+);
 
 export function extractTesterLinkToken(pathname: string): string | null {
   const match = pathname.match(TESTER_LINK_TOKEN_PATTERN);


### PR DESCRIPTION
## The bug

Clicking **Edit** on a User Testing scenario lands on `Link Unavailable — This link is invalid or expired`, on production, for a scenario you own and can otherwise open:

## Why

A tester share link is `/user-testing/<slug>/<token>`. The Edit route added in #3931 is `/user-testing/<scenarioId>/edit` — the same three segments. `extractTesterLinkToken` matched it and returned `"edit"` as the token, so `App` took the `isChatboxChatRoute` branch and mounted the public guest runtime (`ChatboxChatPage`) instead of the app shell. Redeeming `"edit"` fails, and the guest surface reports it as a dead share link.

Nothing was wrong with the button, the route table, or `editMode` — the whole page was replaced before any of that ran.

The comment in `tester-link-path.ts` explaining why this was impossible ("`/user-testing/<scenarioId>` has two segments, so it cannot match") was accurate right up until the Edit route gave it a third.

## The fix

Both matchers in `client/src/lib/tester-link-path.ts` now refuse `edit` as a token. The exclusion is the whole segment, not a prefix, so a minted token that happens to start with those letters (`edit_tok_1`) still resolves.

Keeping this in the one module that owns the link shape matters: the same patterns back the misrouted-pushState guard in `main.tsx`, `isEmbeddedPreview()`, and `ChatboxPreviewPane`'s navigated-away check. Fixing it in one matcher and not the others is exactly the drift that file exists to prevent.

## Tests

New cases in `tester-link-path.test.ts`: the Edit path (both link shapes, trailing slash, and with a query/hash for the looser token reader) yields no token and fails the runtime pattern; a token that merely starts with `edit` still resolves.

`tester-link-path`, `chatbox-session`, `app-navigation`, and all 12 `components/chatboxes` suites pass — 131 tests in the chatbox set.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit c0559524a17b6f2e749591fa600cf6a65a626d01. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stops the User Testing Edit route from resolving as a tester share link. Previously, visiting /user-testing/<scenarioId>/edit matched the three-segment tester-link shape, mounted the public runtime, and showed “Link Unavailable”; now both tester-link matchers reserve the exact segment “edit” so the signed-in app shell renders Edit as expected.

- Change is centralized in `client/src/lib/tester-link-path.ts`: both the runtime path pattern and token extraction exclude `edit` as the third segment (segment match, not prefix).
- Applies to both `user-testing` and `chatbox` link shapes; tokens that start with “edit” still resolve.
- Tests added in `tester-link-path.test.ts` cover Edit paths (including trailing slash, query, and hash) and ensure legitimate tokens continue to work.
- No routing table or API changes; no migration required.

<sup>Written for commit c0559524a17b6f2e749591fa600cf6a65a626d01. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/MCPJam/inspector/pull/4022?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

