### PR TITLE
excalidraw not connected in local instances

### DIFF
--- a/.changeset/default-nux-claude-gpt-luna.md
+++ b/.changeset/default-nux-claude-gpt-luna.md
@@ -1,0 +1,5 @@
+---
+"@mcpjam/inspector": patch
+---
+
+Automatically connect Excalidraw after a new Playground finishes setup, with Claude selected by default and ChatGPT using GPT-5.6 Luna.

--- a/mcpjam-inspector/client/src/App.tsx
+++ b/mcpjam-inspector/client/src/App.tsx
@@ -1987,6 +1987,7 @@ export function PlaygroundRoute() {
     handleConnect,
     handleUpdateHostContext,
     isAuthenticated,
+    isClientConfigSyncPending,
     isSelectedServerSyncing,
     isWorkOsLoading,
     playgroundServerSelectorProps,
@@ -2009,6 +2010,7 @@ export function PlaygroundRoute() {
       isWorkOsAuthLoading={isWorkOsLoading}
       isConvexAuthenticated={isAuthenticated}
       isProjectProvisioned={Boolean(activeProject?.sharedProjectId)}
+      isClientConfigSyncPending={isClientConfigSyncPending}
       hasSeenFirstRunOnboarding={remoteFirstRunOnboardingShown}
       isServerSyncing={isSelectedServerSyncing}
       onConnect={handleConnect}
@@ -4486,6 +4488,7 @@ export default function App() {
     hostsTabSelectedHostId,
     isAuthLoading,
     isAuthenticated,
+    isClientConfigSyncPending,
     isGuestProjectActor,
     isBillingContextPending,
     isLoadingRemoteProjects,

--- a/mcpjam-inspector/client/src/components/playground/PlaygroundTab.tsx
+++ b/mcpjam-inspector/client/src/components/playground/PlaygroundTab.tsx
@@ -62,6 +62,7 @@ interface PlaygroundTabProps {
   isWorkOsAuthLoading?: boolean;
   isConvexAuthenticated?: boolean;
   isProjectProvisioned?: boolean;
+  isClientConfigSyncPending?: boolean;
   hasSeenFirstRunOnboarding?: boolean;
   isServerSyncing?: boolean;
   onConnect?: (formData: ServerFormData) => void;
@@ -199,6 +200,7 @@ export function PlaygroundTab(props: PlaygroundTabProps) {
     isWorkOsAuthLoading: props.isWorkOsAuthLoading,
     isConvexAuthenticated: props.isConvexAuthenticated,
     isProjectProvisioned: props.isProjectProvisioned,
+    isClientConfigSyncPending: props.isClientConfigSyncPending,
     hasSeenFirstRunOnboarding: props.hasSeenFirstRunOnboarding,
     isServerSyncing: props.isServerSyncing,
     onConnect: props.onConnect,

--- a/mcpjam-inspector/client/src/components/ui-playground/PlaygroundMain.tsx
+++ b/mcpjam-inspector/client/src/components/ui-playground/PlaygroundMain.tsx
@@ -1309,6 +1309,11 @@ export function PlaygroundMain({
   // per-project ref so it fires at most once per empty project and never
   // blocks a different empty project from getting its own default hosts.
   const playgroundSeededProjectIdsRef = useRef(new Set<string>());
+  // While the three first-run hosts are being created, a subscription can
+  // surface ChatGPT before Claude. Do not let the generic missing-preview
+  // fallback turn that timing artifact into the selected default; the seed
+  // writes Claude as the lead after all three creates succeed.
+  const playgroundSeedingProjectIdsRef = useRef(new Set<string>());
   // Retry plumbing for the two failure paths below (single-host create
   // rejected / 3-host seed rolled back). Both clear the project's "seeded"
   // marker, which permits a retry but cannot cause one — this tick is what
@@ -1455,6 +1460,7 @@ export function PlaygroundMain({
     const preSeedSelectedHostIds = loadSelectedHostIds(seedProjectId);
     const preSeedPreviewedHostId = loadPreviewedHostId(seedProjectId);
     playgroundSeededProjectIdsRef.current.add(seedProjectId);
+    playgroundSeedingProjectIdsRef.current.add(seedProjectId);
     Promise.allSettled(
       seeds.map(({ host, template }) =>
         createPlaygroundHost({
@@ -1558,6 +1564,8 @@ export function PlaygroundMain({
         setPreviewedHostId(leadHostId);
         setSelectedHostIds(hostIds);
       }
+    }).finally(() => {
+      playgroundSeedingProjectIdsRef.current.delete(seedProjectId);
     });
   }, [
     isConvexAuthenticated,
@@ -1582,6 +1590,9 @@ export function PlaygroundMain({
       !multiHostProjectId ||
       hostList.length === 0
     ) {
+      return;
+    }
+    if (playgroundSeedingProjectIdsRef.current.has(multiHostProjectId)) {
       return;
     }
     const previewedHostIsValid =

--- a/mcpjam-inspector/client/src/components/ui-playground/PlaygroundMain.tsx
+++ b/mcpjam-inspector/client/src/components/ui-playground/PlaygroundMain.tsx
@@ -252,10 +252,14 @@ const PLAYGROUND_SEED_RETRY_DELAYS_MS = [1_000, 4_000, 10_000];
 // template like "claude-code" would both leak the gated client to everyone
 // and have no working way to be filtered out.
 const PLAYGROUND_SEED_TEMPLATE_IDS = [
-  "chatgpt",
   "claude",
+  "chatgpt",
   "cursor",
 ] as const;
+
+const PLAYGROUND_SEED_MODEL_OVERRIDES: Partial<Record<string, string>> = {
+  chatgpt: "openai/gpt-5.6-luna",
+};
 
 function buildHistoryContentSignature(
   session: ChatHistoryDetailSession,
@@ -1456,9 +1460,14 @@ export function PlaygroundMain({
         createPlaygroundHost({
           projectId: seedProjectId,
           name: host!.label,
-          input: cloneHostTemplateInput(template, {
-            themeMode: seedThemeMode,
-          }),
+          input: {
+            ...cloneHostTemplateInput(template, {
+              themeMode: seedThemeMode,
+            }),
+            ...(PLAYGROUND_SEED_MODEL_OVERRIDES[host!.id]
+              ? { modelId: PLAYGROUND_SEED_MODEL_OVERRIDES[host!.id] }
+              : {}),
+          },
         })
       )
     ).then(async (results) => {

--- a/mcpjam-inspector/client/src/components/ui-playground/PlaygroundMain.tsx
+++ b/mcpjam-inspector/client/src/components/ui-playground/PlaygroundMain.tsx
@@ -1322,6 +1322,10 @@ export function PlaygroundMain({
   const seedRetryCountsRef = useRef(new Map<string, number>());
   const seedRetryTimersRef = useRef(new Set<ReturnType<typeof setTimeout>>());
   const [seedRetryTick, setSeedRetryTick] = useState(0);
+  // A seed completion only mutates a ref. This tick lets the missing-preview
+  // fallback run again when a user changed the compare lineup mid-seed and
+  // the seed correctly declined to overwrite that choice.
+  const [seedCompletionTick, setSeedCompletionTick] = useState(0);
   useEffect(() => {
     const timers = seedRetryTimersRef.current;
     return () => {
@@ -1566,6 +1570,7 @@ export function PlaygroundMain({
       }
     }).finally(() => {
       playgroundSeedingProjectIdsRef.current.delete(seedProjectId);
+      setSeedCompletionTick((tick) => tick + 1);
     });
   }, [
     isConvexAuthenticated,
@@ -1609,6 +1614,7 @@ export function PlaygroundMain({
     previewedHostId,
     resolveFallbackHostId,
     setPreviewedHostId,
+    seedCompletionTick,
   ]);
   // Fixed 3-slot `useHost` calls (the multi-host cap is 3). Each slot
   // short-circuits on null id so passing fewer ids is free. See

--- a/mcpjam-inspector/client/src/components/ui-playground/__tests__/PlaygroundMain.multi-host.test.tsx
+++ b/mcpjam-inspector/client/src/components/ui-playground/__tests__/PlaygroundMain.multi-host.test.tsx
@@ -695,19 +695,19 @@ describe("PlaygroundMain — multi-host render path", () => {
     expect(mockCreateHost).not.toHaveBeenCalled();
   });
 
-  // PUR-11: guests land with 3 pre-selected clients (ChatGPT, Claude, Cursor)
+  // PUR-11: guests land with 3 pre-selected clients (Claude, ChatGPT, Cursor)
   // instead of a single blank "MCPJam" host + a toggle to find first.
-  it("seeds 3 default clients (ChatGPT, Claude, Cursor) for empty projects", async () => {
+  it("seeds 3 default clients (Claude, ChatGPT, Cursor) for empty projects", async () => {
     multiHostFixture.multiHostEnabled = false;
     multiHostFixture.hostList = [];
     mockCreateHost
       .mockResolvedValueOnce({
-        hostId: "h-chatgpt",
-        hostConfigId: "h-chatgpt-config",
-      })
-      .mockResolvedValueOnce({
         hostId: "h-claude",
         hostConfigId: "h-claude-config",
+      })
+      .mockResolvedValueOnce({
+        hostId: "h-chatgpt",
+        hostConfigId: "h-chatgpt-config",
       })
       .mockResolvedValueOnce({
         hostId: "h-cursor",
@@ -728,10 +728,14 @@ describe("PlaygroundMain — multi-host render path", () => {
       expect(mockCreateHost).toHaveBeenCalledTimes(3);
     });
     expect(mockCreateHost).toHaveBeenCalledWith(
-      expect.objectContaining({ projectId: "default", name: "ChatGPT" })
+      expect.objectContaining({ projectId: "default", name: "Claude" })
     );
     expect(mockCreateHost).toHaveBeenCalledWith(
-      expect.objectContaining({ projectId: "default", name: "Claude" })
+      expect.objectContaining({
+        projectId: "default",
+        name: "ChatGPT",
+        input: expect.objectContaining({ modelId: "openai/gpt-5.6-luna" }),
+      })
     );
     expect(mockCreateHost).toHaveBeenCalledWith(
       expect.objectContaining({
@@ -745,15 +749,15 @@ describe("PlaygroundMain — multi-host render path", () => {
       })
     );
 
-    // Lead is the first seed template (ChatGPT); the compare lineup is
+    // Lead is the first seed template (Claude); the compare lineup is
     // seeded alongside it — no manual toggle needed for a guest to land in
     // a 3-way compare.
     await waitFor(() => {
-      expect(readPreviewedHostId()).toBe("h-chatgpt");
+      expect(readPreviewedHostId()).toBe("h-claude");
     });
     expect(mockSetSelectedHostIds).toHaveBeenCalledWith([
-      "h-chatgpt",
       "h-claude",
+      "h-chatgpt",
       "h-cursor",
     ]);
 

--- a/mcpjam-inspector/client/src/components/ui-playground/__tests__/PlaygroundMain.multi-host.test.tsx
+++ b/mcpjam-inspector/client/src/components/ui-playground/__tests__/PlaygroundMain.multi-host.test.tsx
@@ -1037,14 +1037,7 @@ describe("PlaygroundMain — multi-host render path", () => {
     ]);
   });
 
-  // The mirror image of the test above, and the reason the lead guard can't
-  // simply be "did the previewed id move at all". The host-list query catches
-  // up to the FIRST create while the other two are still in flight, so the
-  // "no valid previewed host" fallback effect auto-picks that host as lead —
-  // our own write, not the user's. A guard that read it as a user selection
-  // would bail before `saveSelectedHostIds` and strand the guest with 3 hosts
-  // and no compare lineup: exactly the half-seeded state the seed prevents.
-  it("still lands the 3-way lineup when the host list catches up mid-seed and a lead is auto-picked", async () => {
+  it("keeps Claude as lead when ChatGPT reaches the host list first", async () => {
     multiHostFixture.multiHostEnabled = false;
     multiHostFixture.hostList = [];
     const releaseCreate: Array<(host: { hostId: string }) => void> = [];
@@ -1061,30 +1054,28 @@ describe("PlaygroundMain — multi-host render path", () => {
       expect(releaseCreate).toHaveLength(3);
     });
 
-    // Convex surfaces the first created host while creates 2 and 3 are still
-    // pending; the fallback effect promotes it because nothing is previewed.
+    // ChatGPT resolves before the first seed (Claude), so a generic fallback
+    // would otherwise make ChatGPT the automatic default.
+    await act(async () => {
+      releaseCreate[1]({ hostId: "h-chatgpt" });
+    });
     multiHostFixture.hostList = [{ hostId: "h-chatgpt", name: "ChatGPT" }];
     rerender(<PlaygroundMain {...defaultProps} />);
-    await waitFor(() => {
-      expect(readPreviewedHostId()).toBe("h-chatgpt");
-    });
+    expect(readPreviewedHostId()).toBeNull();
 
     await act(async () => {
-      releaseCreate[0]({ hostId: "h-chatgpt" });
-      releaseCreate[1]({ hostId: "h-claude" });
+      releaseCreate[0]({ hostId: "h-claude" });
       releaseCreate[2]({ hostId: "h-cursor" });
     });
 
-    // The lineup still lands, and the auto-picked lead is kept rather than
-    // being rewritten to a different slot.
     await waitFor(() => {
       expect(loadSelectedHostIds("default")).toEqual([
-        "h-chatgpt",
         "h-claude",
+        "h-chatgpt",
         "h-cursor",
       ]);
     });
-    expect(readPreviewedHostId()).toBe("h-chatgpt");
+    expect(readPreviewedHostId()).toBe("h-claude");
   });
 
   it("seeds 3 default clients for each empty project", async () => {

--- a/mcpjam-inspector/client/src/components/ui-playground/__tests__/PlaygroundMain.multi-host.test.tsx
+++ b/mcpjam-inspector/client/src/components/ui-playground/__tests__/PlaygroundMain.multi-host.test.tsx
@@ -1037,6 +1037,47 @@ describe("PlaygroundMain — multi-host render path", () => {
     ]);
   });
 
+  it("chooses a fallback lead after a user changes only the compare lineup mid-seed", async () => {
+    multiHostFixture.multiHostEnabled = false;
+    multiHostFixture.hostList = [];
+    const releaseCreate: Array<(host: { hostId: string }) => void> = [];
+    mockCreateHost.mockImplementation(
+      () =>
+        new Promise((resolve) => {
+          releaseCreate.push(resolve as (host: { hostId: string }) => void);
+        })
+    );
+
+    const { rerender } = render(<PlaygroundMain {...defaultProps} />);
+    await waitFor(() => {
+      expect(releaseCreate).toHaveLength(3);
+    });
+
+    // The user changes only the compare lineup. With no previewed host yet,
+    // the fallback is deferred until the seed finishes so this choice is not
+    // overwritten by the seed itself.
+    saveSelectedHostIds("default", ["h-chatgpt"]);
+    multiHostFixture.selectedHostIds = ["h-chatgpt"];
+    multiHostFixture.hostList = [
+      { hostId: "h-claude", name: "Claude" },
+      { hostId: "h-chatgpt", name: "ChatGPT" },
+      { hostId: "h-cursor", name: "Cursor" },
+    ];
+    rerender(<PlaygroundMain {...defaultProps} />);
+    expect(readPreviewedHostId()).toBeNull();
+
+    await act(async () => {
+      releaseCreate[0]({ hostId: "h-claude" });
+      releaseCreate[1]({ hostId: "h-chatgpt" });
+      releaseCreate[2]({ hostId: "h-cursor" });
+    });
+
+    await waitFor(() => {
+      expect(readPreviewedHostId()).toBe("h-chatgpt");
+    });
+    expect(loadSelectedHostIds("default")).toEqual(["h-chatgpt"]);
+  });
+
   it("keeps Claude as lead when ChatGPT reaches the host list first", async () => {
     multiHostFixture.multiHostEnabled = false;
     multiHostFixture.hostList = [];
@@ -1061,7 +1102,16 @@ describe("PlaygroundMain — multi-host render path", () => {
     });
     multiHostFixture.hostList = [{ hostId: "h-chatgpt", name: "ChatGPT" }];
     rerender(<PlaygroundMain {...defaultProps} />);
-    expect(readPreviewedHostId()).toBeNull();
+    await waitFor(() => {
+      expect(readPreviewedHostId()).toBeNull();
+    });
+
+    multiHostFixture.hostList = [
+      { hostId: "h-claude", name: "Claude" },
+      { hostId: "h-chatgpt", name: "ChatGPT" },
+      { hostId: "h-cursor", name: "Cursor" },
+    ];
+    rerender(<PlaygroundMain {...defaultProps} />);
 
     await act(async () => {
       releaseCreate[0]({ hostId: "h-claude" });

--- a/mcpjam-inspector/client/src/components/ui-playground/hooks/use-playground-state.ts
+++ b/mcpjam-inspector/client/src/components/ui-playground/hooks/use-playground-state.ts
@@ -110,6 +110,7 @@ export interface UsePlaygroundStateOptions {
   isWorkOsAuthLoading?: boolean;
   isConvexAuthenticated?: boolean;
   isProjectProvisioned?: boolean;
+  isClientConfigSyncPending?: boolean;
   hasSeenFirstRunOnboarding?: boolean;
   isServerSyncing?: boolean;
   onConnect?: (formData: ServerFormData) => void;
@@ -181,6 +182,7 @@ export function usePlaygroundState(options: UsePlaygroundStateOptions) {
     isWorkOsAuthLoading = false,
     isConvexAuthenticated = false,
     isProjectProvisioned = true,
+    isClientConfigSyncPending = false,
     hasSeenFirstRunOnboarding,
     isServerSyncing = false,
     onConnect,
@@ -210,6 +212,7 @@ export function usePlaygroundState(options: UsePlaygroundStateOptions) {
     hasSeenOnboarding: hasSeenFirstRunOnboarding === true,
     canPersistRemoteOnboarding: isConvexAuthenticated,
     isProjectProvisioned,
+    isClientConfigSyncPending,
   });
 
   const firstRunComposerSeed =

--- a/mcpjam-inspector/client/src/hooks/__tests__/use-onboarding.test.tsx
+++ b/mcpjam-inspector/client/src/hooks/__tests__/use-onboarding.test.tsx
@@ -20,8 +20,6 @@ const mockState = vi.hoisted(() => ({
   markOnboardingShownMutation: vi.fn().mockResolvedValue(undefined),
   detectEnvironment: vi.fn(() => "test"),
   detectPlatform: vi.fn(() => "web"),
-  // Toggled per-test so the provisioning gate can be exercised in both hosted
-  // and local modes. Read live via the getter in the config mock below.
   hostedMode: false,
 }));
 
@@ -100,30 +98,57 @@ describe("useOnboarding", () => {
     });
   });
 
-  it("auto-connects Excalidraw in local mode even without a provisioned project", async () => {
-    // In local/non-hosted mode the active project is a local record and
-    // Excalidraw connects as a runtime server, so onboarding must not block on
-    // a Convex-synced project — otherwise guests on deployments that can't
-    // authenticate them hang on an infinite spinner. See issue #3352.
+  it("waits for a new local guest project before auto-connecting", async () => {
     const onConnect = vi.fn();
-    renderHook(() =>
-      useOnboarding({
-        servers: {},
-        onConnect,
-        isSignedInWithWorkOs: false,
-        isWorkOsAuthLoading: false,
-        isProjectProvisioned: false,
-      })
+    const { rerender } = renderHook(
+      ({ isProjectProvisioned }: { isProjectProvisioned: boolean }) =>
+        useOnboarding({
+          servers: {},
+          onConnect,
+          isSignedInWithWorkOs: false,
+          isWorkOsAuthLoading: false,
+          isProjectProvisioned,
+        }),
+      { initialProps: { isProjectProvisioned: false } }
     );
+
+    expect(onConnect).not.toHaveBeenCalled();
+    rerender({ isProjectProvisioned: true });
 
     await waitFor(() => {
       expect(onConnect).toHaveBeenCalledWith(EXCALIDRAW_SERVER_CONFIG);
     });
   });
 
-  it("waits for project provisioning before auto-connecting Excalidraw in hosted mode", async () => {
-    // Hosted mode stores each server on the Convex project, so the first-run
-    // connect must wait for that project to provision.
+  it("waits for first-run client config sync before auto-connecting", async () => {
+    const onConnect = vi.fn();
+    const { rerender } = renderHook(
+      ({ isClientConfigSyncPending }: { isClientConfigSyncPending: boolean }) =>
+        useOnboarding({
+          servers: {},
+          onConnect,
+          isSignedInWithWorkOs: false,
+          isWorkOsAuthLoading: false,
+          isClientConfigSyncPending,
+        }),
+      {
+        initialProps: {
+          isClientConfigSyncPending: true,
+        },
+      }
+    );
+
+    expect(onConnect).not.toHaveBeenCalled();
+
+    rerender({ isClientConfigSyncPending: false });
+
+    await waitFor(() => {
+      expect(onConnect).toHaveBeenCalledTimes(1);
+      expect(onConnect).toHaveBeenCalledWith(EXCALIDRAW_SERVER_CONFIG);
+    });
+  });
+
+  it("waits for a new guest project before auto-connecting Excalidraw", async () => {
     mockState.hostedMode = true;
     const onConnect = vi.fn();
     const { rerender } = renderHook(

--- a/mcpjam-inspector/client/src/hooks/__tests__/use-onboarding.test.tsx
+++ b/mcpjam-inspector/client/src/hooks/__tests__/use-onboarding.test.tsx
@@ -20,18 +20,7 @@ const mockState = vi.hoisted(() => ({
   markOnboardingShownMutation: vi.fn().mockResolvedValue(undefined),
   detectEnvironment: vi.fn(() => "test"),
   detectPlatform: vi.fn(() => "web"),
-  hostedMode: false,
 }));
-
-vi.mock("@/lib/config", async (importActual) => {
-  const actual = await importActual<typeof import("@/lib/config")>();
-  return {
-    ...actual,
-    get HOSTED_MODE() {
-      return mockState.hostedMode;
-    },
-  };
-});
 
 vi.mock("convex/react", () => ({
   useQuery: () => mockState.convexUser,
@@ -76,7 +65,6 @@ describe("useOnboarding", () => {
     vi.clearAllMocks();
     localStorage.clear();
     mockState.convexUser = undefined;
-    mockState.hostedMode = false;
   });
 
   it("auto-connects Excalidraw for a fresh first run", async () => {
@@ -93,28 +81,6 @@ describe("useOnboarding", () => {
     expect(result.current.phase).toBe("connecting_excalidraw");
 
     expect(result.current.isBootstrappingFirstRunConnection).toBe(true);
-    await waitFor(() => {
-      expect(onConnect).toHaveBeenCalledWith(EXCALIDRAW_SERVER_CONFIG);
-    });
-  });
-
-  it("waits for a new local guest project before auto-connecting", async () => {
-    const onConnect = vi.fn();
-    const { rerender } = renderHook(
-      ({ isProjectProvisioned }: { isProjectProvisioned: boolean }) =>
-        useOnboarding({
-          servers: {},
-          onConnect,
-          isSignedInWithWorkOs: false,
-          isWorkOsAuthLoading: false,
-          isProjectProvisioned,
-        }),
-      { initialProps: { isProjectProvisioned: false } }
-    );
-
-    expect(onConnect).not.toHaveBeenCalled();
-    rerender({ isProjectProvisioned: true });
-
     await waitFor(() => {
       expect(onConnect).toHaveBeenCalledWith(EXCALIDRAW_SERVER_CONFIG);
     });
@@ -149,7 +115,6 @@ describe("useOnboarding", () => {
   });
 
   it("waits for a new guest project before auto-connecting Excalidraw", async () => {
-    mockState.hostedMode = true;
     const onConnect = vi.fn();
     const { rerender } = renderHook(
       ({ isProjectProvisioned }: { isProjectProvisioned: boolean }) =>

--- a/mcpjam-inspector/client/src/hooks/__tests__/use-server-state.test.tsx
+++ b/mcpjam-inspector/client/src/hooks/__tests__/use-server-state.test.tsx
@@ -2402,6 +2402,7 @@ describe("useServerState OAuth callback failures", () => {
 
   it("uses the friendly provisioning message when the resolver mapping is missing", async () => {
     tryResolveProjectServerMock.mockReturnValue(null);
+    mockCreateServerIfMissing.mockResolvedValueOnce(undefined);
     const appState = createAppState();
     appState.projects.default.sharedProjectId = "project_default";
 
@@ -2429,6 +2430,44 @@ describe("useServerState OAuth callback failures", () => {
     expect(toastError).toHaveBeenCalledWith(
       errorToastMessage(PROJECT_NOT_PROVISIONED_ERROR_MESSAGE),
       { duration: 8000 }
+    );
+  });
+
+  it("connects with the server id returned by the first-run sync", async () => {
+    tryResolveProjectServerMock.mockReturnValue(null);
+    mockCreateServerIfMissing.mockResolvedValue("srv_excalidraw");
+    const appState = createCloudCliAppState();
+    const dispatch = vi.fn();
+    const { result } = renderUseServerState(dispatch, appState, {
+      isAuthenticated: true,
+      hasSignedInUser: true,
+      useLocalFallback: false,
+      effectiveProjects: appState.projects,
+      effectiveActiveProjectId: "proj_cloud",
+      activeProjectServersFlat: [],
+    });
+
+    await act(async () => {
+      await result.current.handleConnect({
+        name: "Excalidraw (App)",
+        type: "http",
+        url: "https://mcp.excalidraw.com/mcp",
+      });
+    });
+
+    expect(testConnectionMock).toHaveBeenCalledWith(
+      expect.objectContaining({ url: "https://mcp.excalidraw.com/mcp" }),
+      "srv_excalidraw",
+      expect.objectContaining({
+        projectId: "proj_cloud",
+        serverName: "Excalidraw (App)",
+      })
+    );
+    expect(dispatch).toHaveBeenCalledWith(
+      expect.objectContaining({
+        type: "CONNECT_SUCCESS",
+        name: "Excalidraw (App)",
+      })
     );
   });
 
@@ -2721,6 +2760,96 @@ describe("useServerState OAuth callback failures", () => {
     // Superseded is not a failure: op1 resolves (does not reject), so the
     // caller has nothing to aggregate into a "Failed to reconnect" toast.
     expect(firstOpOutcome).toBe("resolved");
+  });
+
+  it("allows a send to proceed when its reconnect is superseded by a successful newer one", async () => {
+    // The Playground send path gates on `readyServerNames`. When a background
+    // reconnect (e.g. the host-switch recycle) takes the op pin mid-send, the
+    // send's own connect returns "superseded" — which used to land in NO
+    // bucket at all: absent from ready, failed, missing AND reauth, so callers
+    // could neither send nor explain why. `ensureServersReady` now follows the
+    // newer op to its real outcome, so a successful replacement still lets
+    // the original send proceed immediately.
+    const { ensureAuthorizedForReconnect } = await import(
+      "@/state/oauth-orchestrator"
+    );
+    vi.mocked(ensureAuthorizedForReconnect).mockResolvedValue({
+      kind: "ready",
+      serverConfig:
+        createAppState().projects.default.servers["demo-server"].config,
+      tokens: undefined,
+    } as any);
+
+    // `ensureServersReady` only takes the reconnect branch for a server that
+    // is not already connected/connecting/in OAuth.
+    const appState = createAppState();
+    appState.projects.default.servers["demo-server"].connectionStatus =
+      "disconnected";
+    appState.servers["demo-server"].connectionStatus = "disconnected";
+
+    let releaseFirst: (value: unknown) => void = () => {};
+    const firstReconnect = new Promise((resolve) => {
+      releaseFirst = resolve;
+    });
+    reconnectServerMock.mockReturnValueOnce(firstReconnect).mockResolvedValue({
+      success: true,
+      initInfo: { clientCapabilities: {} },
+    } as any);
+
+    const dispatch = vi.fn();
+    const { result, rerender } = renderUseServerState(dispatch, appState);
+
+    let outcome: Awaited<
+      ReturnType<typeof result.current.ensureServersReady>
+    > | null = null;
+    await act(async () => {
+      // op1: the "send" path's connect. Blocks inside guardedReconnectServer.
+      const sendConnect = result.current
+        .ensureServersReady(["demo-server"])
+        .then((value) => {
+          outcome = value;
+        });
+      await flushAsyncWork();
+
+      // op2: the background recycle bumps the op token, staling op1.
+      await result.current.reconnectServerForClientSwitch("demo-server");
+
+      // op2 drove the server to connected — publish that to the hook so the
+      // superseded follow-up observes the newer op's real outcome.
+      appState.projects = {
+        ...appState.projects,
+        default: {
+          ...appState.projects.default,
+          servers: {
+            "demo-server": {
+              ...appState.projects.default.servers["demo-server"],
+              connectionStatus: "connected",
+            },
+          },
+        },
+      } as any;
+      appState.servers = {
+        ...appState.servers,
+        "demo-server": {
+          ...appState.servers["demo-server"],
+          connectionStatus: "connected",
+        },
+      } as any;
+      flushSync(() => rerender());
+      // Let the effect that republishes `effectiveServers` run, so the
+      // superseded follow-up polls against the connected state.
+      await flushAsyncWork();
+
+      releaseFirst({ success: true, initInfo: { clientCapabilities: {} } });
+      await sendConnect;
+    });
+
+    expect(outcome).toEqual({
+      readyServerNames: ["demo-server"],
+      missingServerNames: [],
+      failedServerNames: [],
+      reauthServerNames: [],
+    });
   });
 
   it("strips OAuth bearer headers from reconnect fallback configs", async () => {

--- a/mcpjam-inspector/client/src/hooks/use-onboarding.ts
+++ b/mcpjam-inspector/client/src/hooks/use-onboarding.ts
@@ -13,7 +13,6 @@ import {
   EXCALIDRAW_SERVER_CONFIG,
   EXCALIDRAW_SERVER_NAME,
 } from "@/lib/excalidraw-quick-connect";
-import { HOSTED_MODE } from "@/lib/config";
 import type { ServerFormData } from "@/shared/types.js";
 import type { ServerWithName } from "@/hooks/use-app-state";
 
@@ -26,6 +25,7 @@ interface UseOnboardingOptions {
   hasSeenOnboarding?: boolean;
   canPersistRemoteOnboarding?: boolean;
   isProjectProvisioned?: boolean;
+  isClientConfigSyncPending?: boolean;
 }
 
 interface UseOnboardingReturn {
@@ -102,6 +102,7 @@ export function useOnboarding({
   hasSeenOnboarding = false,
   canPersistRemoteOnboarding = false,
   isProjectProvisioned = true,
+  isClientConfigSyncPending = false,
 }: UseOnboardingOptions): UseOnboardingReturn {
   const markOnboardingAsShownMutation = useMutation(
     "users:markOnboardingShown" as any,
@@ -193,14 +194,14 @@ export function useOnboarding({
   useEffect(() => {
     if (isWorkOsAuthLoading || isSignedInWithWorkOs) return;
     if (didAutoConnectRef.current) return;
-    // Hosted mode stores each server on the Convex project, so the first-run
-    // connect must wait for that project to provision. In local/non-hosted
-    // mode the active project is a local record and Excalidraw connects as a
-    // runtime server, so requiring a Convex-synced project here would strand
-    // first-run guests on an infinite spinner on any deployment that can't
-    // authenticate the guest (e.g. the open-source shared Convex deployment,
-    // where guest auth is never trusted). See issue #3352.
-    if (HOSTED_MODE && !isProjectProvisioned) return;
+    // A fresh Playground creates its starter clients before onboarding runs.
+    // Their config sync uses the same connection preflight as MCP servers, so
+    // wait for that sync to settle before spending the one auto-connect attempt.
+    if (isClientConfigSyncPending) return;
+    // Both hosted and local connections now resolve through a Convex project
+    // and server id. A first-run guest reaches this render before that project
+    // exists, so wait here instead of spending the one auto-connect attempt.
+    if (!isProjectProvisioned) return;
 
     if (hasRemoteOnboardingState) {
       if (hasSeenOnboarding) return;
@@ -245,6 +246,7 @@ export function useOnboarding({
     isWorkOsAuthLoading,
     isSignedInWithWorkOs,
     isProjectProvisioned,
+    isClientConfigSyncPending,
     hasRemoteOnboardingState,
     hasSeenOnboarding,
     onConnect,

--- a/mcpjam-inspector/client/src/hooks/use-server-state.ts
+++ b/mcpjam-inspector/client/src/hooks/use-server-state.ts
@@ -901,7 +901,7 @@ export function buildSecretSyncOptions(formData: ServerFormData): {
  * workspace, no retry will clear it, and the user has to rename.
  */
 type ServerSyncResult =
-  | { ok: true; serverId: string }
+  | { ok: true; projectId: string; serverId: string }
   | { ok: false; reason: "not-saved" }
   | { ok: false; reason: "workspace-name-taken"; takenByProjectId?: string };
 
@@ -1537,15 +1537,15 @@ export function useServerState({
       // The authoritative pending server entry when this probe is part of a
       // form save (handleConnect). Threaded into the resolver so wire-era
       // resolution reads the new config/profile, not the stale stored one.
-      authoritativeServerEntry?: ServerWithName
+      authoritativeServerEntry?: ServerWithName,
+      syncedTarget?: { projectId: string; serverId: string }
     ) => {
       assertClientConfigSynced();
-      // Opt into the resolver path when both projectId and a Convex serverId
-      // are populated in the API context; otherwise fall back to legacy
-      // {serverConfig, serverId} so brand-new servers (not yet synced to
-      // Convex) keep working. The 2-arg call signature is preserved when no
-      // resolver context is available so existing test mocks keep matching.
-      const resolved = tryResolveProjectServer(serverName);
+      // Local and hosted connections both require a Convex project/server id.
+      // A brand-new save passes its just-created target directly so this probe
+      // does not race the reactive API-context mapping; older rows resolve
+      // through the normal name-to-id context.
+      const resolved = syncedTarget ?? tryResolveProjectServer(serverName);
       if (resolved) {
         // Re-resolve WITH the Convex serverId. Callers already applied
         // `withProjectConnectionDefaults`, but they only know the display
@@ -1880,7 +1880,11 @@ export function useServerState({
       const confirmSecretCreateIsOurs = async (
         newServerId: string
       ): Promise<ServerSyncResult> => {
-        const ok: ServerSyncResult = { ok: true, serverId: newServerId };
+        const ok: ServerSyncResult = {
+          ok: true,
+          projectId: latestProjectId,
+          serverId: newServerId,
+        };
         if (!isUserReadyRef.current) return ok;
         let rows: RemoteServer[] | undefined;
         try {
@@ -2030,7 +2034,11 @@ export function useServerState({
           } else {
             await convexUpdateServer(updatePayload);
           }
-          return { ok: true, serverId: serverIdToUpdate };
+          return {
+            ok: true,
+            projectId: latestProjectId,
+            serverId: serverIdToUpdate,
+          };
         }
 
         if (existing.workspaceTwin && hasSecretOperation) {
@@ -2048,7 +2056,11 @@ export function useServerState({
         if (!newId) return SERVER_NOT_SAVED;
         return hasSecretOperation
           ? await confirmSecretCreateIsOurs(newId as string)
-          : { ok: true, serverId: newId as string };
+          : {
+              ok: true,
+              projectId: latestProjectId,
+              serverId: newId as string,
+            };
       } catch (primaryError) {
         const primaryErrorMessage =
           primaryError instanceof Error
@@ -2091,7 +2103,11 @@ export function useServerState({
             } else {
               await convexUpdateServer(updatePayload);
             }
-            return { ok: true, serverId: retryExisting._id };
+            return {
+              ok: true,
+              projectId: latestProjectId,
+              serverId: retryExisting._id,
+            };
           }
           // A twin can surface here even when the first resolve missed it: a
           // sibling project may have won the name concurrently, or — the
@@ -2112,7 +2128,11 @@ export function useServerState({
           if (!newId) return SERVER_NOT_SAVED;
           return hasSecretOperation
             ? await confirmSecretCreateIsOurs(newId as string)
-            : { ok: true, serverId: newId as string };
+            : {
+                ok: true,
+                projectId: latestProjectId,
+                serverId: newId as string,
+              };
         } catch (fallbackError) {
           logger.error("Failed to sync server to Convex", {
             serverName,
@@ -3243,6 +3263,9 @@ export function useServerState({
       });
       const token = nextOpToken(formData.name);
       let hostedServerId: string | undefined;
+      let syncedConnectionTarget:
+        | { projectId: string; serverId: string }
+        | undefined;
       const existingServerForSave = appState.servers[formData.name];
       const formOAuthProfile = buildOAuthProfileFromFormData(
         formData,
@@ -3327,6 +3350,10 @@ export function useServerState({
         );
         if (synced.ok) {
           hostedServerId = synced.serverId;
+          syncedConnectionTarget = {
+            projectId: synced.projectId,
+            serverId: synced.serverId,
+          };
           injectHostedServerMapping(formData.name, synced.serverId);
         } else {
           workspaceNameTaken = synced.reason === "workspace-name-taken";
@@ -3410,7 +3437,8 @@ export function useServerState({
           const storedCredentialResult = await guardedTestConnection(
             withProjectConnectionDefaults(serverConfig),
             formData.name,
-            serverEntryForSave
+            serverEntryForSave,
+            syncedConnectionTarget
           );
           if (isStaleOp(formData.name, token)) return;
           if (storedCredentialResult.success) {
@@ -3611,7 +3639,8 @@ export function useServerState({
               const connectionResult = await guardedTestConnection(
                 withProjectConnectionDefaults(oauthServerConfig),
                 formData.name,
-                serverEntryForSave
+                serverEntryForSave,
+                syncedConnectionTarget
               );
               if (isStaleOp(formData.name, token)) return;
               if (connectionResult.success) {
@@ -3683,7 +3712,8 @@ export function useServerState({
         const result = await guardedTestConnection(
           effectiveConfig,
           formData.name,
-          serverEntryForSave
+          serverEntryForSave,
+          syncedConnectionTarget
         );
         if (isStaleOp(formData.name, token)) return;
         if (result.success) {
@@ -5569,14 +5599,27 @@ export function useServerState({
               ] as const;
             }
 
-            return [
-              resolvedKey,
-              await reconnectServerInternal(resolvedKey, {
-                allowInteractiveOAuthFlow: false,
-                select: false,
-                suppressErrors: true,
-              }),
-            ] as const;
+            const outcome = await reconnectServerInternal(resolvedKey, {
+              allowInteractiveOAuthFlow: false,
+              select: false,
+              suppressErrors: true,
+            });
+
+            // "superseded" means a newer connect op took the pin mid-flight
+            // (e.g. the host-switch recycle racing a send). That op — not this
+            // one — drives the server to its final state, so returning
+            // superseded here would leave the server in NO bucket: not ready,
+            // not failed. Callers that gate on `readyServerNames` (the chat
+            // send path) then refuse to send even though the server is about
+            // to be connected. Follow the newer op to its real outcome.
+            if (outcome.status === "superseded") {
+              return [
+                resolvedKey,
+                await waitForServerReconnectOutcome(resolvedKey),
+              ] as const;
+            }
+
+            return [resolvedKey, outcome] as const;
           }
         )
       );
@@ -5610,10 +5653,10 @@ export function useServerState({
             reauthServerNames.push(serverName);
             break;
           case "superseded":
-            // A newer op is already handling this server; it owns the
-            // outcome. Don't classify it as failed — that would produce a
-            // false "failed to connect" signal for a connection that's just
-            // still in progress.
+            // Resolved above by following the newer op to its real outcome, so
+            // this is unreachable in practice. Kept as a defensive branch: a
+            // superseded connection is still in progress, and classifying it
+            // as failed would raise a false "failed to connect".
             break;
           case "failed":
           default:


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Fixes first-run Excalidraw auto-connect on local and hosted instances by waiting for guest project provisioning and the initial client config sync. Sets Claude as the default lead and pins ChatGPT to `openai/gpt-5.6-luna`.

- Onboarding: `useOnboarding` now gates auto-connect on `isProjectProvisioned` and `isClientConfigSyncPending === false`; removes the hosted/local split. Tests updated.
- Playground seeding: Seeds three defaults in order (Claude, ChatGPT, Cursor). Holds selection while seeding so a mid-seed host list cannot make ChatGPT the default; finalizes with Claude as lead. If a user changes only the compare lineup mid-seed, defers the lead until seed completes and then chooses a fallback without overwriting that selection. Applies the ChatGPT model override to `openai/gpt-5.6-luna`. Tests updated.
- Wiring: Threads optional `isClientConfigSyncPending` from `App` → `PlaygroundRoute` → `PlaygroundTab` → `usePlaygroundState` (defaults to `false`).
- Connection pipeline: First-run server sync returns `{ projectId, serverId }` and passes this target into connection preflight so the initial connect uses the synced id. `ensureServersReady` now follows a superseded reconnect to its real outcome to avoid a no-state bucket. New tests cover both cases.

<sup>Written for commit 5787d0f2e1e7893b00a14e1f6a3679bcb95098c6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/MCPJam/inspector/pull/4023?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

