### PR TITLE
fix(chat): a mid-stream error chunk must fail the turn, not complete it

### DIFF
--- a/mcpjam-inspector/server/utils/__tests__/backend-stream-failure.test.ts
+++ b/mcpjam-inspector/server/utils/__tests__/backend-stream-failure.test.ts
@@ -2,8 +2,10 @@ import { describe, it, expect } from "vitest";
 import { originOf } from "@mcpjam/sdk";
 import {
   describeBackendStreamFailure,
+  describeStreamErrorChunkFailure,
   isMcpjamOwnedFailureCode,
   isUserOwnedDenialCode,
+  parseStreamErrorChunkText,
 } from "../mcpjam-stream-handler.js";
 
 describe("describeBackendStreamFailure", () => {
@@ -126,6 +128,92 @@ describe("isUserOwnedDenialCode", () => {
     // costs the blindness this work exists to remove.
     expect(isUserOwnedDenialCode("something_new")).toBe(false);
     expect(isUserOwnedDenialCode(undefined)).toBe(false);
+  });
+});
+
+describe("describeStreamErrorChunkFailure", () => {
+  it.each(["mcpjam_api_error", "mcpjam_rate_limit", "mcpjam_config_error"])(
+    "owns a mid-stream failure whose code names us (%s)",
+    (code) => {
+      expect(
+        originOf(describeStreamErrorChunkFailure(500, "boom", code)),
+      ).toBe("mcpjam");
+    },
+  );
+
+  // The whole reason this is a SEPARATE classifier. On the non-OK path the
+  // status is our own backend's, so a 5xx is our outage. In an error CHUNK it
+  // is the field the backend copied off the upstream provider's error, so an
+  // Anthropic 503 arrives as `statusCode: 503`. Same number, opposite meaning.
+  it.each([500, 502, 503, 529])(
+    "does NOT claim a %i that came from the upstream provider",
+    (status) => {
+      expect(
+        originOf(describeStreamErrorChunkFailure(status, "overloaded", "provider_error")),
+      ).toBe("ambiguous");
+    },
+  );
+
+  it("keeps the paired non-OK classifier owning the same status", () => {
+    // Guards the split: if these two ever agree on a bare 503, one of them is
+    // reading the status against its own delivery path.
+    expect(originOf(describeBackendStreamFailure(503, "boom"))).toBe("mcpjam");
+    expect(originOf(describeStreamErrorChunkFailure(503, "boom"))).toBe(
+      "ambiguous",
+    );
+  });
+
+  it("still reads a provider credential wall from the status", () => {
+    const normalized = describeStreamErrorChunkFailure(401, "bad key");
+
+    expect(normalized.slug).toBe("provider/auth_error");
+    expect(originOf(normalized)).toBe("user_config");
+  });
+});
+
+describe("parseStreamErrorChunkText", () => {
+  it("reads the mid-stream shape, which uses `message` and an upstream status", () => {
+    // NOT the `{ok, code, error, details}` shape of the non-OK path — this is
+    // what `toUIMessageStreamResponse({onError})` serializes.
+    const parsed = parseStreamErrorChunkText(
+      JSON.stringify({
+        code: "mcpjam_api_error",
+        message: "MCPJam is experiencing a configuration issue.",
+        statusCode: 401,
+        isRetryable: false,
+        details: "invalid api key",
+      }),
+    );
+
+    expect(parsed).toEqual({
+      code: "mcpjam_api_error",
+      message: "MCPJam is experiencing a configuration issue.",
+      statusCode: 401,
+      details: "invalid api key",
+    });
+  });
+
+  it("falls back to the raw text when the chunk is not JSON", () => {
+    // Any other producer's error chunk — the text the client used to be
+    // handed verbatim stays the display message.
+    expect(parseStreamErrorChunkText("something broke")).toEqual({
+      message: "something broke",
+    });
+  });
+
+  it("falls back to the raw text when the JSON carries no usable message", () => {
+    const raw = JSON.stringify({ code: "provider_error" });
+
+    expect(parseStreamErrorChunkText(raw)).toEqual({
+      message: raw,
+      code: "provider_error",
+    });
+  });
+
+  it("ignores non-string / non-number fields rather than trusting them", () => {
+    const raw = JSON.stringify({ code: 7, message: "  ", statusCode: "503" });
+
+    expect(parseStreamErrorChunkText(raw)).toEqual({ message: raw });
   });
 });
 

--- a/mcpjam-inspector/server/utils/__tests__/engine-failure-telemetry.test.ts
+++ b/mcpjam-inspector/server/utils/__tests__/engine-failure-telemetry.test.ts
@@ -94,6 +94,26 @@ function errorChunks() {
   return writtenChunks.filter((c) => c?.type === "error");
 }
 
+/**
+ * A real 200 SSE body, so the failure travels the way it does in production:
+ * through `parseJsonEventStream` and the chunk switch, not around them.
+ */
+function sseResponse(chunks: unknown[]): Response {
+  const encoder = new TextEncoder();
+  const stream = new ReadableStream<Uint8Array>({
+    start(controller) {
+      for (const chunk of chunks) {
+        controller.enqueue(encoder.encode(`data: ${JSON.stringify(chunk)}\n\n`));
+      }
+      controller.close();
+    },
+  });
+  return new Response(stream, {
+    status: 200,
+    headers: { "Content-Type": "text/event-stream" },
+  });
+}
+
 async function runTurn(overrides: Record<string, unknown> = {}) {
   await handleMCPJamFreeChatModel({
     messages: [{ role: "user", content: "Hi." }] as any,
@@ -206,6 +226,99 @@ describe("engine failure telemetry", () => {
     // but the verdict no longer depends on it.
     expect(calls[0].hop).toBe("mcpjam_internal");
     expect(originOf(calls[0].normalized)).toBe("mcpjam");
+  });
+
+  it("fails the turn on a mid-stream error chunk instead of succeeding", async () => {
+    // The second delivery path, and the one HTTP status can never see. The
+    // backend's `toUIMessageStreamResponse({onError})` categorizes the failure
+    // and serializes it into an error PART on a stream whose headers already
+    // said 200. That chunk used to fall into processStream's `default:` and be
+    // forwarded verbatim; the loop then returned normally and the turn was
+    // recorded as COMPLETED. The user saw an error, telemetry saw a success.
+    global.fetch = vi.fn().mockResolvedValue(sseResponse([
+      { type: "start" },
+      {
+        type: "error",
+        errorText: JSON.stringify({
+          code: "mcpjam_api_error",
+          message: "MCPJam is experiencing a configuration issue.",
+          statusCode: 401,
+          isRetryable: false,
+        }),
+      },
+    ]));
+    const { reporter, calls } = makeReporter();
+    const onConversationComplete = vi.fn();
+    const onEngineError = vi.fn();
+
+    await runTurn({
+      failureReporter: reporter,
+      onConversationComplete,
+      onEngineError,
+    });
+
+    expect(calls).toHaveLength(1);
+    expect(calls[0].source).toBe("mcp.chat-v2.agentic-loop");
+    expect(calls[0].errorCode).toBe("mcpjam_api_error");
+    // Classified at the chunk, where the structured body still existed.
+    // `describeError` on the rethrown Error could only see the sentence.
+    expect(originOf(calls[0].normalized)).toBe("mcpjam");
+
+    // The turn took the failure path: engine error fired, and the successful
+    // conversation was never persisted.
+    expect(onEngineError).toHaveBeenCalledTimes(1);
+    expect(onConversationComplete).not.toHaveBeenCalled();
+
+    // Still exactly one error chunk on the wire — site 3's `emitError` writes
+    // it, and the raw chunk is deliberately not also forwarded.
+    const chunks = errorChunks();
+    expect(chunks).toHaveLength(1);
+    expect(Object.keys(chunks[0]).sort()).toEqual(["errorText", "type"]);
+    // The parsed sentence, not the raw JSON envelope.
+    expect(chunks[0].errorText).toBe(
+      "MCPJam is experiencing a configuration issue.",
+    );
+  });
+
+  it("does not claim a mid-stream provider 5xx as MCPJam's", async () => {
+    // `statusCode` in an error chunk is the UPSTREAM provider's, copied off
+    // its error — not our backend's response status. Reading it with the
+    // non-OK path's `>= 500 → mcpjam` rule would page us every time someone
+    // else's model was overloaded.
+    global.fetch = vi.fn().mockResolvedValue(sseResponse([
+      { type: "start" },
+      {
+        type: "error",
+        errorText: JSON.stringify({
+          code: "provider_error",
+          message: "The AI provider is temporarily unavailable.",
+          statusCode: 503,
+        }),
+      },
+    ]));
+    const { reporter, calls } = makeReporter();
+
+    await runTurn({ failureReporter: reporter });
+
+    expect(calls).toHaveLength(1);
+    expect(originOf(calls[0].normalized)).toBe("ambiguous");
+  });
+
+  it("still fails the turn on a non-JSON error chunk", async () => {
+    // Any other producer's error chunk. No code, so no ownership claim — but
+    // the turn must still not be recorded as a success.
+    global.fetch = vi.fn().mockResolvedValue(sseResponse([
+      { type: "start" },
+      { type: "error", errorText: "something broke" },
+    ]));
+    const { reporter, calls } = makeReporter();
+    const onConversationComplete = vi.fn();
+
+    await runTurn({ failureReporter: reporter, onConversationComplete });
+
+    expect(calls).toHaveLength(1);
+    expect(onConversationComplete).not.toHaveBeenCalled();
+    expect(errorChunks()[0].errorText).toBe("something broke");
   });
 
   it("stays completely silent on abort — no report, no error chunk", async () => {

--- a/mcpjam-inspector/server/utils/mcpjam-stream-handler.ts
+++ b/mcpjam-inspector/server/utils/mcpjam-stream-handler.ts
@@ -28,6 +28,7 @@ import type { MCPClientManager, Harness } from "@mcpjam/sdk";
 import {
   describeAsSlug,
   describeError,
+  isNormalizedError,
   type NormalizedError,
 } from "@mcpjam/sdk";
 import {
@@ -470,17 +471,51 @@ export function describeBackendStreamFailure(
   // from the status so the user-facing copy stays accurate ("the provider
   // rejected the key" IS what happened — it was just our key).
   if (isMcpjamOwnedFailureCode(code)) {
-    return {
-      ...describeBackendStreamFailureSlug(status, detail),
-      origin: "mcpjam",
-    };
+    return { ...backendFailureSlug(status, detail), origin: "mcpjam" };
   }
 
-  return describeBackendStreamFailureSlug(status, detail);
+  if (status !== undefined && status >= 500) {
+    return { ...backendFailureSlug(status, detail), origin: "mcpjam" };
+  }
+
+  return backendFailureSlug(status, detail);
 }
 
-/** Status → slug, with the catalog's own origin. Shared by both paths above. */
-function describeBackendStreamFailureSlug(
+/**
+ * Classify a mid-stream `{type:"error"}` chunk from MCPJam's own `/stream`
+ * backend — the failure delivered as a stream PART, after the headers already
+ * said 200.
+ *
+ * Same code rule as {@link describeBackendStreamFailure}, and deliberately
+ * NOT the same status rule. There the status is our own backend's response
+ * status, so a 5xx is our outage. Here it is the field the backend copied off
+ * the UPSTREAM provider's error (`categorizeError`'s `statusCode`), so an
+ * Anthropic 503 arrives as `statusCode: 503` — reading that as "our backend
+ * answered 5xx" would page us for someone else's overloaded model. Identical
+ * number, opposite meaning; only the delivery path distinguishes them.
+ *
+ * So the code is the ONLY thing that can assert MCPJam ownership here. Without
+ * one the catalog's own verdict stands — which for an unrecognized provider
+ * failure is `ambiguous`: visible, measured, never paging.
+ */
+export function describeStreamErrorChunkFailure(
+  status: number | undefined,
+  rawText: string,
+  code?: string,
+): NormalizedError {
+  const detail = new Error(
+    status !== undefined ? `HTTP ${status}: ${rawText}` : rawText,
+  );
+
+  if (isMcpjamOwnedFailureCode(code)) {
+    return { ...backendFailureSlug(status, detail), origin: "mcpjam" };
+  }
+
+  return backendFailureSlug(status, detail);
+}
+
+/** Status → slug, carrying the catalog's own origin. Shared by both paths. */
+function backendFailureSlug(
   status: number | undefined,
   detail: Error,
 ): NormalizedError {
@@ -489,9 +524,6 @@ function describeBackendStreamFailureSlug(
   }
   if (status === 429) {
     return describeAsSlug("provider/quota", detail);
-  }
-  if (status !== undefined && status >= 500) {
-    return { ...describeAsSlug("internal/unknown", detail), origin: "mcpjam" };
   }
   return describeAsSlug("internal/unknown", detail);
 }
@@ -1312,6 +1344,73 @@ export function isMcpjamOwnedFailureCode(code: string | undefined): boolean {
 }
 
 /**
+ * Parse the `errorText` of a mid-stream `{type:"error"}` chunk.
+ *
+ * SEPARATE from {@link parseEngineErrorBody} because the two shapes differ.
+ * The backend's non-OK path returns `{ok, code, error, details}` (parsed
+ * there); its mid-stream path is `toUIMessageStreamResponse({onError})`, which
+ * serializes `{code, message, statusCode, isRetryable, details}` — `message`,
+ * not `error`, and it carries the UPSTREAM `statusCode` that never reaches our
+ * own HTTP response. Feeding this shape to the other parser yields the raw JSON
+ * as the display text and drops the status.
+ *
+ * Non-JSON text (any other producer's error chunk) falls back to the text
+ * itself, which is what the client used to be handed verbatim.
+ */
+export function parseStreamErrorChunkText(errorText: string): {
+  message: string;
+  code?: string;
+  statusCode?: number;
+  details?: string;
+} {
+  try {
+    const body = JSON.parse(errorText) as {
+      code?: unknown;
+      message?: unknown;
+      statusCode?: unknown;
+      details?: unknown;
+    };
+    if (body && typeof body === "object") {
+      const message =
+        typeof body.message === "string" && body.message.trim().length > 0
+          ? body.message
+          : errorText;
+      return {
+        message,
+        ...(typeof body.code === "string" ? { code: body.code } : {}),
+        ...(typeof body.statusCode === "number"
+          ? { statusCode: body.statusCode }
+          : {}),
+        ...(typeof body.details === "string" ? { details: body.details } : {}),
+      };
+    }
+  } catch {
+    // Not JSON — fall through to the raw text.
+  }
+  return { message: errorText };
+}
+
+/**
+ * An error carrying a classification its thrower already made.
+ *
+ * Generalizes the convention `WebRouteError` already uses, so the engine's
+ * outer catch can prefer a verdict reached with the structured body in hand
+ * over `describeError`, which would only see the message string.
+ */
+function attachedNormalized(error: unknown): NormalizedError | undefined {
+  if (!error || typeof error !== "object") return undefined;
+  const candidate = (error as { normalized?: unknown }).normalized;
+  return isNormalizedError(candidate) ? candidate : undefined;
+}
+
+/** Guardrail code a thrower attached alongside {@link attachedNormalized}. */
+function attachedFailureCode(error: unknown): string | undefined {
+  if (!error || typeof error !== "object") return undefined;
+  const code = (error as { failureCode?: unknown }).failureCode;
+  return typeof code === "string" ? code : undefined;
+}
+
+/**
  * PR 5b-followup-2: parse a Convex `/stream` non-OK response body as
  * the standard guardrail JSON shape `{ code?, error, details? }`.
  * Falls back to a generic `<status> <text>` message when the body
@@ -1642,6 +1741,48 @@ async function processStream(
           finishChunk = chunk;
           // Don't write finish yet - wait until we know we're done
           break;
+
+        case "error": {
+          // The backend's OTHER failure delivery path, and the one HTTP status
+          // can never see. `toUIMessageStreamResponse({onError})` categorizes
+          // the failure and serializes it into an error PART on a stream whose
+          // headers already said 200 — including `mcpjam_api_error` /
+          // `mcpjam_rate_limit`, i.e. OUR outage.
+          //
+          // This used to fall into `default:` and be forwarded verbatim.
+          // processStream then returned NORMALLY, processOneStep ran its
+          // success epilogue, and the outer loop set `runSucceeded = true`:
+          // the user saw an error while telemetry recorded a completed turn,
+          // and the turn was persisted as a good conversation. Exactly the
+          // bug already fixed for parser failures a few lines above — same
+          // remedy, same reason.
+          //
+          // Throw so it lands in `runChatEngineLoop`'s outer catch (site 3),
+          // which owns the whole failure ritual: error chunk, trace events,
+          // `onEngineError`, and the reporter. Deliberately NOT forwarded
+          // here — site 3's `emitError` writes the single error chunk, so the
+          // wire still carries exactly one.
+          const errorText =
+            typeof (chunk as { errorText?: unknown }).errorText === "string"
+              ? ((chunk as { errorText: string }).errorText)
+              : String((chunk as { errorText?: unknown }).errorText ?? "");
+          const parsed = parseStreamErrorChunkText(errorText);
+          // Classified HERE, where the structured body still exists. By the
+          // time site 3 sees this it is an Error whose message is a sentence;
+          // `describeError` could not recover the guardrail code, and the
+          // ownership verdict depends on it. NOT the non-OK classifier: this
+          // `statusCode` is the upstream provider's, not our backend's — see
+          // {@link describeStreamErrorChunkFailure}.
+          const normalized = describeStreamErrorChunkFailure(
+            parsed.statusCode,
+            errorText,
+            parsed.code,
+          );
+          throw Object.assign(new Error(parsed.message), {
+            normalized,
+            ...(parsed.code ? { failureCode: parsed.code } : {}),
+          });
+        }
 
         default:
           // Forward other chunks (step-start, etc.)
@@ -3571,7 +3712,12 @@ export async function runChatEngineLoop(
         const failAbs = Date.now();
         const errorText =
           error instanceof Error ? error.message : String(error);
-        const loopNormalized = describeError(error);
+        // A thrower that classified with the structured body in hand wins:
+        // a mid-stream error chunk reaches here as an Error whose message is
+        // a sentence, and re-describing it would throw away the guardrail
+        // code that settles ownership.
+        const loopFailureCode = attachedFailureCode(error);
+        const loopNormalized = attachedNormalized(error) ?? describeError(error);
         // Reporter, not a bare logger.error: the old call captured to Sentry
         // unconditionally — paging on user-fault failures — and left no typed
         // record a monitor could read (the response is a 200 stream). The
@@ -3584,6 +3730,7 @@ export async function runChatEngineLoop(
           hop: "user_server_hop",
           transport: "http_stream",
           normalized: loopNormalized,
+          ...(loopFailureCode ? { errorCode: loopFailureCode } : {}),
           context: { promptIndex: traceTurn.promptIndex },
         });
         pushAiSdkTrailingErrorSpan(
@@ -3612,6 +3759,7 @@ export async function runChatEngineLoop(
         // no stepIndex.
         safelyEmitEngineError(onEngineError, {
           message: errorText,
+          ...(loopFailureCode ? { code: loopFailureCode } : {}),
           rawText: errorText,
           promptIndex: traceTurn.promptIndex,
           normalized: loopNormalized,


### PR DESCRIPTION
Follow-up 1 from #4018.

## What

The backend has **two** failure delivery paths. #4018 fixed the non-OK one. The other was invisible: `toUIMessageStreamResponse({onError})` categorizes the failure and serializes it into an error **part** on a stream whose headers already said `200`.

In `processStream`, a `{type:"error"}` chunk fell into `default:` and was forwarded verbatim. The read loop then returned **normally** — `processOneStep` ran its success epilogue, the outer loop set `runSucceeded = true`, and the turn was persisted as a completed conversation.

**The user saw an error; telemetry recorded a success.** Including for `mcpjam_api_error` / `mcpjam_rate_limit` — our own outage.

This is the same bug already fixed for parser failures a few lines above, whose comment describes it exactly: *"processStream then returned NORMALLY … the outer agentic loop marked the turn successful … `onEngineError` never fired."*

## The fix

Same remedy as that precedent: **throw**, and let `runChatEngineLoop`'s outer catch (site 3) own the failure ritual — error chunk, trace events, `onEngineError`, reporter.

- The raw chunk is deliberately **not** also forwarded. Site 3's `emitError` writes the single error chunk, so the wire still carries exactly one.
- Its text improves from the raw JSON envelope to the parsed sentence (`"MCPJam is experiencing a configuration issue."`).
- Classification happens **at the chunk**, where the structured body still exists. By the time site 3 sees it, it is an `Error` whose message is a sentence and the guardrail code that settles ownership is gone. The verdict rides on the thrown error; site 3 prefers it over `describeError`, generalizing the convention `WebRouteError` already uses.

## Why a separate classifier

`describeStreamErrorChunkFailure` is deliberately **not** `describeBackendStreamFailure`.

| | non-OK response | error chunk |
|---|---|---|
| `status` is | our backend's response status | copied off the **upstream provider's** error |
| `503` means | our outage → `mcpjam` | Anthropic overloaded → **not ours** |

Identical number, opposite meaning; only the delivery path distinguishes them. Reusing the `>= 500 → mcpjam` rule would page us every time someone else's model was overloaded. Here the **code** is the only thing that can assert MCPJam ownership; without one the catalog's `ambiguous` stands — visible, measured, never paging.

A test pins the split directly: a bare `503` must read `mcpjam` through one classifier and `ambiguous` through the other.

## Verification

- **The three new end-to-end tests fail without the fix** — confirmed by disabling the `case "error"` branch and re-running (3 failed / 6 passed). They drive the real engine over a genuine 200 SSE body through `parseJsonEventStream` and the chunk switch, not around them.
- They assert: reporter fired once with `origin: "mcpjam"` and `errorCode`, `onEngineError` fired, **`onConversationComplete` never called** (the turn is no longer recorded as a success), and exactly one error chunk with the unchanged `{type, errorText}` shape.
- Plus: a provider `503` mid-stream stays `ambiguous`; a non-JSON error chunk still fails the turn.
- `backend-stream-failure.test.ts` — 51 pass (new coverage for the chunk classifier and the `{code, message, statusCode}` parser, including its rejection of non-string/non-number fields).
- Full `--project server`: **393 files, 5778 tests**, green on 3 of 4 runs. One run had a single unrelated file fail on a temp-dir `ENOENT` in the local-machine/computer tests (`mkdir .mcpjam/computer/logs`); it is flaky and untouched by this change.
- `tsc --noEmit -p server/tsconfig.json` clean for the touched file.

## Remaining follow-up

**`describeError` is direction-blind.** Per the 2026-07-28 spec, `-32020 HeaderMismatch` (§Server Validation — the spec's own table labels the sender a *"Non-conforming client"*) and `-32600 InvalidRequest` mean *the requester's* message was malformed. On the outbound path MCPJam **is** the requester, so those are ours; on the inbound bridge they are the caller's. Both are `ambiguous` today, so a systematic client bug affecting every user can never page.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit 0778b6c1ba49f3c72f0d7bfeb3e5b4904d658769. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes mid-stream `{type:"error"}` SSE handling so an error part fails the turn instead of completing it. Previously the chunk was forwarded and the loop returned normally; now we throw, classify, and record a failed turn with correct telemetry.

- Handle `"error"` in `processStream`: parse via `parseStreamErrorChunkText`, classify with `describeStreamErrorChunkFailure`, attach `normalized` and `failureCode`, then throw. `runChatEngineLoop` prefers the attached classification, emits a single error chunk with the parsed message, reports the failure (including `errorCode`), fires `onEngineError`, and does not call `onConversationComplete`.
- Add `describeStreamErrorChunkFailure`: uses failure code ownership; does not treat chunk `statusCode >= 500` as MCPJam’s outage (that status is from the upstream provider). Extract shared `backendFailureSlug`; keep `describeBackendStreamFailure` mapping 5xx backend responses to MCPJam.
- Add `parseStreamErrorChunkText` for the mid-stream shape `{code, message, statusCode, details}`; falls back to raw text and ignores invalid types.
- Tests cover the 200 SSE path, ownership split (backend 503 → MCPJam vs chunk 503 → ambiguous), single error chunk on the wire, and turn failure on non-JSON error chunks.

<sup>Written for commit 0778b6c1ba49f3c72f0d7bfeb3e5b4904d658769. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/MCPJam/inspector/pull/4025?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

