### PR TITLE
fix(telemetry): claim a HeaderMismatch as ours when we built the request

### DIFF
--- a/mcpjam-inspector/server/services/__tests__/mcp-http-bridge.test.ts
+++ b/mcpjam-inspector/server/services/__tests__/mcp-http-bridge.test.ts
@@ -150,6 +150,75 @@ describe("handleJsonRpc failure telemetry", () => {
     });
   });
 
+  describe("-32020 HeaderMismatch attribution", () => {
+    /** A manager whose tools/call fails with the modern header-mismatch code. */
+    function headerMismatchManager(config?: Record<string, unknown>) {
+      return failingManager({
+        executeTool: vi.fn().mockRejectedValue(
+          Object.assign(
+            new Error("Header mismatch: Mcp-Name 'a' does not match body 'b'"),
+            { code: -32020 },
+          ),
+        ),
+        ...(config
+          ? { getServerConfig: vi.fn().mockReturnValue(config) }
+          : {}),
+      });
+    }
+
+    async function callTool(manager: any, reporter: any) {
+      return handleJsonRpc(
+        "srv-1",
+        { id: 20, method: "tools/call", params: { name: "t", arguments: {} } },
+        manager,
+        "adapter",
+        { failureReporter: reporter },
+      );
+    }
+
+    it("claims it: the server rejected headers MCPJam built", async () => {
+      const { reporter, calls } = makeReporter();
+      await callTool(headerMismatchManager({}), reporter);
+
+      expect(calls).toHaveLength(1);
+      expect(calls[0].hop).toBe("mcpjam_request_construction");
+      expect(calls[0].context).toMatchObject({ upstreamCode: -32020 });
+    });
+
+    it("does NOT claim it when the user asked for a non-conforming client", async () => {
+      // `toolParamHeaderMirroring: "omit"` exists so a user can check whether
+      // their server answers -32020 instead of silently serving the request.
+      // Claiming this would page the team every time the debugger works.
+      const { reporter, calls } = makeReporter();
+      await callTool(
+        headerMismatchManager({ mirrorToolParamHeaders: false }),
+        reporter,
+      );
+
+      expect(calls).toHaveLength(1);
+      expect(calls[0].hop).toBe("user_server_hop");
+    });
+
+    it("still reports — and keeps the envelope — when the manager has no getServerConfig", async () => {
+      // The refinement runs inside a swallowing try/catch, so a manager
+      // missing the accessor must not take the whole report down with it.
+      const { reporter, calls } = makeReporter();
+      const response = await callTool(headerMismatchManager(), reporter);
+
+      expect(calls).toHaveLength(1);
+      expect(calls[0].hop).toBe("mcpjam_request_construction");
+      expect(response).toMatchObject({ jsonrpc: "2.0", id: 20 });
+    });
+
+    it("leaves every other upstream failure on the user hop", async () => {
+      const { reporter, calls } = makeReporter();
+      await callTool(failingManager({ getServerConfig: vi.fn() }), reporter);
+
+      expect(calls).toHaveLength(1);
+      expect(calls[0].hop).toBe("user_server_hop");
+    });
+  });
+
   it("an UPSTREAM -32601 through the passthrough is a declared outcome — no report", async () => {
     const { reporter, calls } = makeReporter();
     const manager = failingManager({

--- a/mcpjam-inspector/server/services/mcp-http-bridge.ts
+++ b/mcpjam-inspector/server/services/mcp-http-bridge.ts
@@ -194,11 +194,46 @@ export async function handleJsonRpc(
 
   const respond = (payload: any) => ({ jsonrpc: "2.0", id, ...payload });
 
-  // One call per failed operation. `hop: "user_server_hop"` at every site:
-  // the bridge is a proxy into the user's own MCP server, so the catalog's
-  // verdict stands and only MCPJam-positive slugs escalate. Parse/Invalid-
-  // Request 400s deliberately do NOT report (already visible as 4xx rows),
-  // nor does -32601 Method-not-implemented (a declared client outcome).
+  /**
+   * Whether a `-32020 HeaderMismatch` from this connection is MCPJam's bug.
+   *
+   * Per 2026-07-28 §Server Validation the server MUST answer `-32020` when the
+   * mirrored `MCP-Protocol-Version` / `Mcp-Method` / `Mcp-Name` /
+   * `Mcp-Param-*` headers disagree with the body; the spec's own table calls
+   * the sender a "Non-conforming client". MCPJam builds those headers
+   * mechanically from the body, so a rejection means OUR mirroring was wrong —
+   * and upstream's evict-refetch-retry recovery has already failed by the time
+   * one reaches here. This is not hypothetical: #3620 shipped exactly this bug
+   * on the hosted MRTR resume leg, and its only wire signature was a `-32020`
+   * filed as `ambiguous`.
+   *
+   * EXCEPT when the user asked for it. `toolParamHeaderMirroring: "omit"`
+   * (surfaced as `mirrorToolParamHeaders: false`) deliberately simulates a
+   * client that never mirrors, precisely so a user can check whether their
+   * server answers `-32020` instead of silently serving the request. That is
+   * the debugger working, and claiming it would page the team on a feature.
+   */
+  const isOwnRequestConstructionFault = (
+    normalized: NormalizedError | undefined,
+  ): boolean => {
+    if (normalized?.slug !== "jsonrpc/header_mismatch") return false;
+    // Optional call, not `manager.getServerConfig(...)`. This runs inside
+    // `reportOperationFailure`'s swallowing try/catch, so a manager without
+    // the accessor (a partial test double, an older embedder) would throw and
+    // silently drop the ENTIRE report rather than just this refinement.
+    const config = clientManager.getServerConfig?.(serverId);
+    // Absent config reads as conforming, matching the knob's own default:
+    // `mirrorToolParamHeaders` is opt-OUT, so only an explicit `false` is a
+    // simulated non-conforming client.
+    return config?.mirrorToolParamHeaders !== false;
+  };
+
+  // One call per failed operation. `hop: "user_server_hop"` at every site
+  // except the one above: the bridge is a proxy into the user's own MCP
+  // server, so the catalog's verdict stands and only MCPJam-positive slugs
+  // escalate. Parse/Invalid-Request 400s deliberately do NOT report (already
+  // visible as 4xx rows), nor does -32601 Method-not-implemented (a declared
+  // client outcome).
   const reportOperationFailure = (
     error: unknown,
     rpcMethod: string,
@@ -213,16 +248,30 @@ export async function handleJsonRpc(
       if ((error as { code?: unknown } | undefined)?.code === -32601) {
         return;
       }
+      const ownRequestFault = isOwnRequestConstructionFault(normalized);
       options.failureReporter?.({
         message: `[mcp-bridge] ${rpcMethod} failed`,
         error,
         source: "mcp.bridge.rpc",
-        hop: "user_server_hop",
+        hop: ownRequestFault
+          ? "mcpjam_request_construction"
+          : "user_server_hop",
         transport: "rpc_envelope",
         ...(normalized ? { normalized } : {}),
         errorCode: "-32000",
         rpcMethod,
-        context: { serverId, mode, ...(context ?? {}) },
+        context: {
+          serverId,
+          mode,
+          // The envelope code is always -32000; the UPSTREAM code is what
+          // distinguishes a header mismatch, and a triager reading the row
+          // should not have to infer it from the slug.
+          ...(typeof (error as { code?: unknown } | undefined)?.code ===
+          "number"
+            ? { upstreamCode: (error as { code: number }).code }
+            : {}),
+          ...(context ?? {}),
+        },
       });
     } catch {
       // Telemetry must never alter the JSON-RPC response.

--- a/mcpjam-inspector/server/utils/__tests__/error-origin-capture.test.ts
+++ b/mcpjam-inspector/server/utils/__tests__/error-origin-capture.test.ts
@@ -118,6 +118,59 @@ describe("mcpjam_internal boundary", () => {
   });
 });
 
+describe("mcpjam_request_construction boundary", () => {
+  it("promotes a header mismatch, which is a verdict on OUR wire format", () => {
+    // Per 2026-07-28 §Server Validation the server MUST answer -32020 when the
+    // mirrored headers disagree with the body, and MCPJam builds those headers.
+    // The slug stays `ambiguous` in the catalog because the same signal is a
+    // deliberate outcome under the non-conforming-client knob — only the call
+    // site can rule that out, so the promotion is a declaration, not a default.
+    const decision = maybeCaptureOriginError(
+      new Error("Header mismatch: Mcp-Name 'foo' does not match body 'bar'"),
+      normalizedFor("jsonrpc/header_mismatch"),
+      {
+        source: "route:mcp.bridge.rpc",
+        boundary: "mcpjam_request_construction",
+      },
+    );
+
+    expect(decision.origin).toBe("mcpjam");
+    expect(decision.captured).toBe(true);
+  });
+
+  it("tags the capture with its own boundary, not mcpjam_internal", () => {
+    // A triager must be able to tell "our infrastructure broke" from "our wire
+    // format was wrong" — they have different owners and different fixes.
+    maybeCaptureOriginError(
+      new Error("header mismatch"),
+      normalizedFor("jsonrpc/header_mismatch"),
+      {
+        source: "route:mcp.bridge.rpc",
+        boundary: "mcpjam_request_construction",
+      },
+    );
+
+    expect(captureException).toHaveBeenCalledTimes(1);
+    expect(captureException.mock.calls[0][1]).toMatchObject({
+      tags: { error_boundary: "mcpjam_request_construction" },
+    });
+  });
+
+  it("does NOT overrule positive evidence either", () => {
+    const decision = maybeCaptureOriginError(
+      new Error("x"),
+      normalizedFor("transport/econnrefused"),
+      {
+        source: "route:mcp.bridge.rpc",
+        boundary: "mcpjam_request_construction",
+      },
+    );
+
+    expect(decision.captured).toBe(false);
+    expect(captureException).not.toHaveBeenCalled();
+  });
+});
+
 describe("capture dedupe", () => {
   it("captures an MCPJam error only once across repeated calls", () => {
     const error = new Error("ours");

--- a/mcpjam-inspector/server/utils/error-origin-capture.ts
+++ b/mcpjam-inspector/server/utils/error-origin-capture.ts
@@ -79,8 +79,31 @@ export type OriginCaptureSource =
  *
  * Use it only where the failing hop is genuinely ours. On a route that
  * proxies to a user-supplied MCP server, the honest answer is no declaration.
+ *
+ * `"mcpjam_request_construction"` means: the hop was into the user's server,
+ * but what it rejected is a message MCPJam BUILT — a protocol-level "your
+ * request was malformed" verdict, where the requester is us. It promotes
+ * `ambiguous` on the same terms, and stays a separate value so a triager can
+ * tell "our infrastructure broke" from "our wire format was wrong".
+ *
+ * Kept as a caller declaration rather than a catalog origin because the same
+ * wire signal can mean the opposite thing here: MCPJam ships a knob that
+ * deliberately simulates a non-conforming client
+ * (`toolParamHeaderMirroring: "omit"`), and its conformance checks provoke
+ * these rejections on purpose. Only the call site can rule that out.
  */
-export type OriginCaptureBoundary = "mcpjam_internal";
+export type OriginCaptureBoundary =
+  | "mcpjam_internal"
+  | "mcpjam_request_construction";
+
+/**
+ * Boundaries that promote `ambiguous` to a capture. Both members qualify; the
+ * set exists so the promotion rule stays one line as boundaries are added.
+ */
+const PROMOTING_BOUNDARIES: ReadonlySet<OriginCaptureBoundary> = new Set([
+  "mcpjam_internal",
+  "mcpjam_request_construction",
+]);
 
 export type OriginCaptureDecision = {
   origin: ErrorOrigin;
@@ -112,7 +135,9 @@ export function maybeCaptureOriginError(
   const declared = originOf(normalized);
   const slug = normalized?.slug;
   const origin =
-    declared === "ambiguous" && options.boundary === "mcpjam_internal"
+    declared === "ambiguous" &&
+    options.boundary !== undefined &&
+    PROMOTING_BOUNDARIES.has(options.boundary)
       ? "mcpjam"
       : declared;
 

--- a/mcpjam-inspector/server/utils/log-events.ts
+++ b/mcpjam-inspector/server/utils/log-events.ts
@@ -1,4 +1,5 @@
 import type { ErrorOrigin } from "@mcpjam/sdk";
+import type { RouteFailureHop } from "./route-error-report.js";
 
 export type Environment =
   | "prod"
@@ -88,8 +89,16 @@ type RouteOperationFailedFields = {
    * `reportRouteFailure` tags Sentry with (as `route:${source}`).
    */
   source: string;
-  /** Whose hop failed, as declared at the call site. */
-  hop: "user_server_hop" | "mcpjam_internal";
+  /**
+   * Whose hop failed, as declared at the call site.
+   *
+   * Imported from `route-error-report.ts` rather than re-listed. A hand-copied
+   * union here is a literal list `tsc` only checks at the ONE call site that
+   * builds this payload — every other consumer (an APL query, a monitor
+   * predicate) silently disagrees with the source of truth, and a new hop
+   * looks like a compile error in the reporter rather than in this file.
+   */
+  hop: RouteFailureHop;
   /** Effective origin from the capture decision — see the doc block above. */
   origin: ErrorOrigin;
   /** Catalog slug behind `origin`, e.g. `transport/econnrefused`. */

--- a/mcpjam-inspector/server/utils/route-error-report.ts
+++ b/mcpjam-inspector/server/utils/route-error-report.ts
@@ -27,8 +27,22 @@ import {
  *   an ECONNREFUSED classified `user_config` stays quiet, which is the
  *   documented gap: an internal-infrastructure connection refusal is not
  *   captured until the classifier can tell the two apart.
+ * - `"mcpjam_request_construction"` — the hop was still into the user's own
+ *   server, but what it rejected is a message MCPJam BUILT. The user's server
+ *   is the messenger, not the fault. Promotes `ambiguous` for the same reason
+ *   `mcpjam_internal` does, and is separate from it because the hop genuinely
+ *   is not internal — a triager reading `error_boundary` should be able to
+ *   tell "our infrastructure broke" from "our wire format was wrong".
+ *
+ *   Declare it ONLY where the site can rule out having asked for the
+ *   rejection. MCPJam is a debugger: it ships a knob that deliberately
+ *   simulates a non-conforming client, and conformance checks provoke these
+ *   rejections on purpose. Both are the product working.
  */
-export type RouteFailureHop = "user_server_hop" | "mcpjam_internal";
+export type RouteFailureHop =
+  | "user_server_hop"
+  | "mcpjam_internal"
+  | "mcpjam_request_construction";
 
 const BOUNDARY_FOR_HOP: Record<
   RouteFailureHop,
@@ -36,6 +50,7 @@ const BOUNDARY_FOR_HOP: Record<
 > = {
   user_server_hop: undefined,
   mcpjam_internal: "mcpjam_internal",
+  mcpjam_request_construction: "mcpjam_request_construction",
 };
 
 /**


### PR DESCRIPTION
Last finding from the spec audit; follows #4018 and #4025.

## What

Per 2026-07-28 §Server Validation, a server **MUST** answer `-32020 HeaderMismatch` when the mirrored `MCP-Protocol-Version` / `Mcp-Method` / `Mcp-Name` / `Mcp-Param-*` headers disagree with the body — and the spec's own table calls the sender a **"Non-conforming client"**.

MCPJam builds those headers mechanically from the body. A rejection is a verdict on **our** wire format; the user's server is the messenger, not the fault. It was filed `ambiguous`, so it could never page.

**Not hypothetical.** #3620 shipped exactly this bug on the hosted MRTR resume leg — the leg bypassed upstream `callTool`'s private `Mcp-Param-*` mirroring, and a conforming 2026-07-28 server answered `-32020`. Its only wire signature was that code. It was found by hand.

## Why the catalog origin is NOT changed

I started by flipping `jsonrpc/header_mismatch` to `mcpjam` in the SDK catalog. That would have been wrong, and it's worth writing down why.

The same wire signal means the opposite thing elsewhere in this product:

- **`toolParamHeaderMirroring: "omit"`** simulates a client that never mirrors, *precisely so* a user can check whether their server answers `-32020` instead of silently serving the request. When it fires, the debugger is working.
- **Three conformance checks** (`runProtocolVersionHeaderMismatchCheck`, `runMethodHeaderMismatchCheck`, `runNameHeaderMismatchCheck`) provoke one on purpose.

A catalog flip would page the team on a feature, every run. Only a call site can rule that out — the same shape `credentialOwner` uses for a question the wire cannot answer.

So the change is a **caller declaration**: a third `RouteFailureHop`, `"mcpjam_request_construction"`. It promotes `ambiguous` on exactly the terms `mcpjam_internal` does (and, like it, never overrules positive evidence), and stays a separate value because the hop genuinely is not internal — a triager reading `error_boundary` should be able to tell *"our infrastructure broke"* from *"our wire format was wrong"*.

The bridge declares it, reading the knob off the already-public `getServerConfig`. **No SDK change.**

## Two things this turned up

1. **The refinement would have silently killed all bridge telemetry.** It runs inside `reportOperationFailure`'s swallowing try/catch, so a manager without `getServerConfig` (a partial test double, an older embedder) would have thrown and dropped the *entire* report, not just this refinement. Now an optional call, with a test that pins it.
2. **`RouteOperationFailedFields.hop` re-listed the union by hand.** It now imports `RouteFailureHop`. A hand-copied literal list is checked at the one call site that builds the payload and nowhere else — the new hop surfaced as a compile error in `stream-failure-reporter.ts` rather than in the file that was actually stale. (Type-only import; no runtime cycle.)

Also records the upstream JSON-RPC code in the event context — the envelope code is always `-32000`, and a triager shouldn't have to infer a header mismatch from the slug.

## Verification

- **The new bridge tests fail without the fix** — confirmed by short-circuiting the predicate (2 failed / 13 passed).
- Bridge: claims a `-32020`; does **not** claim it under `mirrorToolParamHeaders: false`; still reports (and keeps the envelope) when the manager has no `getServerConfig`; every other upstream failure stays on the user hop.
- Capture policy: the new boundary promotes `ambiguous`, tags Sentry with its own `error_boundary`, and does not overrule positive evidence.
- Full `--project server`: **394 files, 5796 tests**, all pass.
- `tsc --noEmit -p server/tsconfig.json`: **196 errors, identical to the baseline on `main`** — measured by reverting `server/` to `HEAD~1` and diffing per-file counts, which is how the two `stream-failure-reporter.ts` errors above were caught.

## After this

The three classifier gaps found in the audit are closed. Next is operational, not code: enable M2 (`event in ("http.request.failed","route.operation.failed") and origin == "mcpjam"`) and bake it for a week before letting it page.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit 24eb2e4d718ae770796e9344fe8797e99e2d5295. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Attributes `-32020 HeaderMismatch` responses to MCPJam when the bridge constructed the mirrored headers, so wire‑format bugs page us; leaves the catalog unchanged and does not claim errors when `mirrorToolParamHeaders: false`.

- Adds `RouteFailureHop` value `mcpjam_request_construction` and promotes `ambiguous` to MCPJam only for `jsonrpc/header_mismatch` with mirroring enabled; tags captures with `error_boundary: mcpjam_request_construction`.
- Updates the bridge to detect this case, keep other failures on `user_server_hop`, and still skip reporting `-32601`.
- Records `upstreamCode` in event context (the envelope stays `-32000`) to make header mismatches visible without inferring from the slug.
- Makes `getServerConfig` optional in telemetry to avoid dropping reports when it is unavailable; adds tests that fail without the fix.
- Replaces a hand-copied `hop` union with an import of `RouteFailureHop` to keep types in sync.

<sup>Written for commit 24eb2e4d718ae770796e9344fe8797e99e2d5295. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/MCPJam/inspector/pull/4029?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

