### PR TITLE
chore(changeset): create-time scenario overrides on publish

### DIFF
--- a/.changeset/publish-scenario-create-time-overrides.md
+++ b/.changeset/publish-scenario-create-time-overrides.md
@@ -1,0 +1,15 @@
+---
+"@mcpjam/sdk": minor
+"@mcpjam/cli": minor
+"@mcpjam/inspector": minor
+---
+
+Set a scenario's name, description and access mode in the same call that publishes it.
+
+Publishing an environment used to take whatever defaults the scenario was created with, so "publish this, but only for invited people" was two operations — a publish, then an update — with a window between them where the share link was live in the DEFAULT mode. Anyone holding the URL during that window got in.
+
+`publishScenario` on the SDK's platform client, and the `publish_scenario` operation behind it, now accept optional `name`, `description` and `mode` (`project_members` | `invited_only` | `anyone_with_link`) and forward them to the v1 route, which applies them at create time. The CLI exposes the same three as `--name`, `--description` and `--mode` on `mcpjam scenarios publish`; a misspelled `--mode` is answered locally as a usage error rather than spending a round trip to learn the flag was typed wrong.
+
+The overrides are CREATE-TIME ONLY. Publishing is idempotent, and re-publishing an already-published environment keeps returning the existing scenario — it does not quietly re-apply the overrides, because that would make a routine re-publish able to change who can open a live link. When overrides were sent and discarded for that reason, the result says `overridesIgnored: true`, and the scenario in the response carries the scenario's REAL name and mode: a caller who asked for `invited_only` must never conclude the link is restricted when it is not. Changing an existing scenario stays `mcpjam user-testing update` / `update_user_testing_scenario`.
+
+Callers that pass no overrides are unaffected — the request body stays empty, exactly what already went on the wire.


### PR DESCRIPTION
- Adds a changeset for the scenario publish overrides that shipped in #4004 and #3969 with no changeset, so the release goes out.
- Bumps @mcpjam/sdk, @mcpjam/cli and @mcpjam/inspector as minor — each got new API surface (`publishScenario` params, `--name/--description/--mode`, the v1 route applying them at create time).
- No code changes, just the changeset file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Publishes create-time scenario overrides by adding a changeset and bumping `@mcpjam/sdk`, `@mcpjam/cli`, and `@mcpjam/inspector` to minor. This releases the already-merged API/CLI support; no code changes in this PR.

**Release notes**
- SDK `publishScenario` now accepts optional `name`, `description`, and `mode`; CLI exposes `--name`, `--description`, and `--mode`.
- Old: publish used defaults and needed a follow-up update. New: apply overrides at create time, removing the window where default access could leak.
- Re-publishing an existing scenario does not re-apply overrides; the response indicates `overridesIgnored`, and updates must go through the update operations.
- Calls without overrides are unchanged.

<sup>Written for commit 21ead9280288c11920af8abf47a9937f09b6971c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/MCPJam/inspector/pull/4034?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

