### PR TITLE
docs: stop telling users to click "Create ngrok tunnel"

### DIFF
--- a/docs/guides/first-chatgpt-app-react.mdx
+++ b/docs/guides/first-chatgpt-app-react.mdx
@@ -209,11 +209,11 @@ The easiest way to test your app:
 
 To connect your app to ChatGPT:
 
-1. Sign in to MCPJam Inspector (ngrok tunnels require an account)
-2. Click **Create ngrok tunnel** with your server connected
+1. Sign in to MCPJam Inspector (tunnels require an account)
+2. Click **Create Tunnel** on the server card with your server connected
 3. Use the tunnel URL as your connector endpoint in ChatGPT
 
-For more information, see our [ngrok tunneling feature blog](https://www.mcpjam.com/blog/ngrok).
+For more information, see [Tunneling](/inspector/connecting-servers#tunneling).
 
 ## What's next?
 

--- a/examples/chatgpt-apps/CoffeeShop/README.md
+++ b/examples/chatgpt-apps/CoffeeShop/README.md
@@ -21,7 +21,7 @@ This builds the React widget and starts the server at `http://localhost:8787/mcp
 
 ## Connecting to ChatGPT
 
-1. In MCPJam Inspector, click **Create ngrok tunnel** with your server connected
+1. In MCPJam Inspector, click **Create Tunnel** on the server card with your server connected
 2. Use the tunnel URL as your connector endpoint in ChatGPT
 
 ## Learn More

--- a/examples/chatgpt-apps/CoffeeShop/server.ts
+++ b/examples/chatgpt-apps/CoffeeShop/server.ts
@@ -205,7 +205,7 @@ httpServer.listen(PORT, () => {
   console.log(`   2. Enter URL: http://localhost:${PORT}/mcp`);
   console.log("");
   console.log("   To connect to ChatGPT:");
-  console.log("   Click 'Create ngrok tunnel' with a connected server,");
+  console.log("   Click 'Create Tunnel' on the card of a connected server,");
   console.log("   then use the tunnel URL as your connector endpoint.");
   console.log("");
   console.log("☕️ ============================================");


### PR DESCRIPTION
Tunnels moved off ngrok onto our own relay, and the button is now labelled **Create Tunnel** — but three places still walked users through a button that doesn't exist.

## Changed

- **`docs/guides/first-chatgpt-app-react.mdx`** — the published "My First ChatGPT App" guide. Also linked to `mcpjam.com/blog/ngrok`; now points at [Tunneling](https://docs.mcpjam.com/inspector/connecting-servers#tunneling), which is accurate and maintained.
- **`examples/chatgpt-apps/CoffeeShop/README.md`**
- **`examples/chatgpt-apps/CoffeeShop/server.ts`** — printed to stdout on every `npm start`.

The main tunneling page (`docs/inspector/connecting-servers.mdx`) was already clean.

## Deliberately left alone

- `docs/getting-started.mdx`, `README.md`, `learn-more-content.ts` — "No API key, ngrok, or subscription needed." That's positioning against a third-party tool and still true.
- `XAAIdpCard.tsx` and `docs/xaa-hosted-issuer.md` — these suggest ngrok for exposing **MCPJam itself** (its XAA issuer endpoint). Our tunnel only exposes a connected MCP server at `{slug}.tunnels.mcpjam.com/api/mcp/adapter-http/{server}`, not arbitrary inspector paths, so it can't replace ngrok there. The advice is correct as written.

Companion PR in mcpjam-backend fixes the preview-env doc, which listed a dead `NGROK_API_KEY` as powering tunnels.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit f35fe6f37836c3130382943eb3dd994f328f9fc9. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Replaces outdated “Create ngrok tunnel” instructions with “Create Tunnel” and updates links to our maintained Tunneling docs. This prevents users from following a non-existent button and aligns guidance with our relay-backed tunnels.

- docs/guides/first-chatgpt-app-react.mdx: updated step text and replaced ngrok blog link with /inspector/connecting-servers#tunneling.
- examples/chatgpt-apps/CoffeeShop/README.md and server.ts: updated the README and the startup banner instructions.
- Intentional exclusions: kept “no ngrok needed” positioning and ngrok guidance for exposing MCPJam’s XAA issuer endpoint, since our tunnel only exposes connected MCP servers.

<sup>Written for commit f35fe6f37836c3130382943eb3dd994f328f9fc9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/MCPJam/inspector/pull/4037?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

