### PR TITLE
ops(alerts): M2 pages from day one — drop the WARN bake

### DIFF
--- a/ops/axiom-monitors/monitors/inspector-mcpjam-fault.json
+++ b/ops/axiom-monitors/monitors/inspector-mcpjam-fault.json
@@ -1,10 +1,10 @@
 {
   "key": "inspector-mcpjam-fault",
   "name": "MCPJam Inspector MCPJam-fault error (prod)",
-  "tier": "WARN",
+  "tier": "PAGE",
   "owner": "marcelo",
   "dataset": "inspector-logs",
-  "notifier": "mcpjam-alerts-warn",
+  "notifier": "mcpjam-alerts-page",
   "monitor": {
     "type": "Threshold",
     "columnName": "Count",
@@ -26,11 +26,13 @@
     "| summarize Count = count() by tostring(slug), tostring(route), tostring(source)"
   ],
   "description": [
-    "WARN (bake) — owner: marcelo. A failure the classifier attributed to MCPJam ITSELF occurred in prod. Zero tolerance: any single occurrence fires.",
+    "PAGE — owner: marcelo. A failure the classifier attributed to MCPJam ITSELF occurred in prod. Zero tolerance: any single occurrence fires.",
     "",
     "THIS IS THE MONITOR THE WHOLE PROGRAM EXISTS FOR. Every other monitor here measures volume or novelty and cannot tell our outage from a user's server dying. This one fires only on `origin == 'mcpjam'` — the effective origin from the capture decision, after boundary promotion, not the catalog's declared value.",
     "",
-    "WHY WARN AND NOT PAGE: the plan gates M2 on a seven-day bake of the corrected effective-origin path, which starts at the deploy that carries #4018/#4025/#4029. Tier is the only thing held back — the alert still posts to #mcpjam-alerts, and PAGE/WARN treatment is currently identical anyway (see README 'PAGE vs WARN notifiers'). To promote after a clean bake, change `tier` to PAGE and `notifier` to mcpjam-alerts-page, then re-apply. Do NOT promote by raising the threshold above 0 — zero tolerance is the design.",
+    "PAGE FROM DAY ONE, bake skipped deliberately (2026-08-15, Marcelo). The plan gated M2 on a seven-day WARN bake. That gate bought nothing: the PAGE and WARN notifiers are the SAME Slack channel webhook with no mention and no escalation, so the tier was a label and the bake was a label's bake. The calibration the bake existed to provide was obtained by measurement instead — ZERO matching rows in 7d of prod history (below) — and zero-tolerance monitors have no threshold to tune. If this becomes noisy, the answer is to fix the misclassification that produced the row, NOT to raise the threshold above 0.",
+    "",
+    "THE TIER IS STILL NOT A PAGER. `mcpjam-alerts-page` is a plain webhook: no on-call mention, no escalation, no acknowledgement. Until that notifier points at something with page semantics, PAGE and WARN differ in name only and this monitor cannot wake anyone up. See README 'PAGE vs WARN notifiers'.",
     "",
     "MEASURED BEFORE ENABLING (2026-08-15, prod, 7d): ZERO rows match. Origin coverage on `http.request.failed` began 2026-08-11 and now runs ~91% (08-12 443/505, 08-13 212/237, 08-14 152/167); the large unattributed bucket before 08-11 predates the field and is not a coverage hole. So a first-run burst is not expected — but see the KNOWN BLIND SPOT below before reading silence as health.",
     "",


### PR DESCRIPTION
Already applied: `ImfZNQNF2ceIg5nmFI` now points at `jnWZGoVFRcvyTdUjBe` (`#mcpjam-alerts`).

## Why the gate is gone

You were right to push on it. The WARN tier didn't buy anything: **`mcpjam-alerts-page` and `mcpjam-alerts-warn` are the same Slack channel webhook**, with no mention and no escalation on either. The tier was a label, so the seven-day bake was a label's bake.

The calibration the bake existed to provide came from measurement instead — **zero `origin == 'mcpjam'` rows in 7 days of prod history** — and a zero-tolerance monitor has no threshold to tune. If it turns noisy, the fix is the misclassification that produced the row, never a higher threshold.

The description now also records what the tier still is **not**: a pager. Until that notifier points at something with page semantics, this cannot wake anyone up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit eba2f5a397fa36f374c1eff8439ba5d8706a764a. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Promotes the prod monitor `inspector-mcpjam-fault` from WARN to PAGE and switches its notifier to `mcpjam-alerts-page`. The WARN bake is removed because PAGE and WARN used the same Slack webhook, and 7 days of prod showed zero `origin == 'mcpjam'` rows.

**Review notes**
- Changes: `"tier": "PAGE"` and `"notifier": "mcpjam-alerts-page"`; query and zero-tolerance threshold are unchanged.
- `mcpjam-alerts-page` is a plain Slack webhook (no on-call mention, no escalation); this still does not page anyone.
- If the alert becomes noisy, fix misclassification; do not raise the threshold above 0.
- Alias mapping for `mcpjam-alerts-page` to the channel is already applied out-of-band.

<sup>Written for commit eba2f5a397fa36f374c1eff8439ba5d8706a764a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/MCPJam/inspector/pull/4038?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

