### PR TITLE
fix(telemetry): attribute the two routes M2 was blind to

### DIFF
--- a/mcpjam-inspector/server/routes/v1/__tests__/envelope.test.ts
+++ b/mcpjam-inspector/server/routes/v1/__tests__/envelope.test.ts
@@ -8,7 +8,7 @@
  * to UNAUTHORIZED, defeating the v1 closed-union contract.
  */
 import { describe, it, expect } from "vitest";
-import { mapErrorToV1 } from "../envelope.js";
+import { mapErrorToV1, v1Error } from "../envelope.js";
 import { V1_ERROR_STATUS } from "../contract.js";
 import { ErrorCode, WebRouteError } from "../../web/errors.js";
 
@@ -163,5 +163,94 @@ describe("mapErrorToV1 — passthrough", () => {
     const err = new WebRouteError(404, ErrorCode.NOT_FOUND, "no such thing");
     const result = mapErrorToV1(err);
     expect(result.code).toBe("NOT_FOUND");
+  });
+});
+
+/**
+ * The `/api/v1/*` surface returned its errors without ever telling
+ * `requestLogContextMiddleware` what they were, so every v1 failure logged as
+ * a bare `internal_error` with no message, no slug, and no origin — and was
+ * therefore unreachable by the MCPJam-fault monitor no matter how badly it
+ * failed. Measured 2026-08-15: 44 opaque 500s on eval-ingest in 72h.
+ */
+describe("v1Error — telemetry envelope", () => {
+  function fakeContext() {
+    const meta: Record<string, unknown> = {};
+    return {
+      set: (key: string, value: unknown) => {
+        meta[key] = value;
+      },
+      json: (body: unknown, status: number) => ({ body, status }),
+      meta,
+    };
+  }
+
+  it("stashes webErrorMeta so the middleware stops logging a bare internal_error", () => {
+    const c = fakeContext();
+
+    v1Error(c as never, "NOT_FOUND", "no such thing");
+
+    expect(c.meta.webErrorMeta).toMatchObject({
+      status: V1_ERROR_STATUS.NOT_FOUND,
+      code: "NOT_FOUND",
+      message: "no such thing",
+    });
+  });
+
+  it("carries attribution when the caller has it", () => {
+    const c = fakeContext();
+
+    v1Error(c as never, "INTERNAL_ERROR", "boom", undefined, {
+      origin: "mcpjam",
+      slug: "internal/unknown",
+    });
+
+    expect(c.meta.webErrorMeta).toMatchObject({
+      origin: "mcpjam",
+      slug: "internal/unknown",
+    });
+  });
+
+  it("omits origin/slug rather than writing empty ones", () => {
+    // An absent origin must stay absent: `isempty(origin)` is how the coverage
+    // query finds unattributed rows, and an empty string would hide them.
+    const c = fakeContext();
+
+    v1Error(c as never, "VALIDATION_ERROR", "bad input");
+
+    expect(c.meta.webErrorMeta).not.toHaveProperty("origin");
+    expect(c.meta.webErrorMeta).not.toHaveProperty("slug");
+  });
+
+  it("does not throw when the context cannot set (non-Hono callers)", () => {
+    expect(() =>
+      v1Error({ json: () => ({}) } as never, "NOT_FOUND", "x"),
+    ).not.toThrow();
+  });
+});
+
+describe("mapErrorToV1 — attribution", () => {
+  it("returns the effective origin and slug for a mapped runtime error", () => {
+    const result = mapErrorToV1(new Error("connect ECONNREFUSED 127.0.0.1:1"));
+
+    expect(result.origin).toBeDefined();
+    expect(result.slug).toBeDefined();
+  });
+
+  it("does not attribute a user's refused connection to MCPJam", () => {
+    // The whole point of the origin axis: this must never page us.
+    const result = mapErrorToV1(new Error("connect ECONNREFUSED 127.0.0.1:1"));
+
+    expect(result.origin).not.toBe("mcpjam");
+  });
+
+  it("preserves an origin the throwing site already promoted", () => {
+    // A route that declared an internal hop resolved `mcpjam` and Sentry was
+    // paged on it. Recomputing here would report `ambiguous` for a failure we
+    // already own — the drift that kept `origin=mcpjam` out of Axiom.
+    const err = new WebRouteError(502, ErrorCode.SERVER_UNREACHABLE, "boom");
+    err.origin = "mcpjam";
+
+    expect(mapErrorToV1(err).origin).toBe("mcpjam");
   });
 });

--- a/mcpjam-inspector/server/routes/v1/__tests__/eval-ingest.test.ts
+++ b/mcpjam-inspector/server/routes/v1/__tests__/eval-ingest.test.ts
@@ -209,3 +209,130 @@ describe("v1 eval-ingest proxies", () => {
     expect(fetchMock).toHaveBeenCalledTimes(suffixes.length);
   });
 });
+
+/**
+ * The hop this proxy makes is to MCPJam's OWN Convex deployment, so an
+ * unrecognized failure is ours. Before the internal-boundary declaration it
+ * classified `transport/fetch_failed` -> `ambiguous` and could never reach the
+ * MCPJam-fault monitor: measured 2026-08-15 as 44 opaque 500s in 72h with
+ * nothing watching them.
+ */
+describe("v1 eval-ingest — failure attribution", () => {
+  const originalEnv = { CONVEX_HTTP_URL: process.env.CONVEX_HTTP_URL };
+  const originalFetch = global.fetch;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    process.env.CONVEX_HTTP_URL = "https://convex-http.example.com";
+    validateGuestTokenMock.mockResolvedValue({ valid: false });
+  });
+
+  afterEach(() => {
+    global.fetch = originalFetch;
+    process.env.CONVEX_HTTP_URL = originalEnv.CONVEX_HTTP_URL;
+  });
+
+  it("reports a transport failure against our own Convex without moving the status", async () => {
+    global.fetch = vi
+      .fn()
+      .mockRejectedValue(new TypeError("fetch failed")) as never;
+
+    const response = await request(
+      makeApp(),
+      "/api/v1/projects/default/eval-ingest/report",
+      JSON.stringify({ results: [] })
+    );
+    const body = (await response.json()) as { code?: string; message?: string };
+
+    // 500, NOT 502. `SERVER_UNREACHABLE` means the USER's target MCP server
+    // everywhere else here, and #3948 showed that reclassifying a route's
+    // status silently blinds monitors keyed on it.
+    expect(response.status).toBe(500);
+    expect(body.code).toBe("INTERNAL_ERROR");
+    // No longer opaque: these rows carried no errorMessage at all before.
+    expect(body.message).toContain("fetch failed");
+  });
+
+  it("still answers TIMEOUT for an abort rather than claiming a fault", async () => {
+    global.fetch = vi.fn().mockRejectedValue(
+      Object.assign(new Error("The operation was aborted"), {
+        name: "AbortError",
+      })
+    ) as never;
+
+    const response = await request(
+      makeApp(),
+      "/api/v1/projects/default/eval-ingest/report",
+      JSON.stringify({ results: [] })
+    );
+    const body = (await response.json()) as { code?: string };
+
+    expect(body.code).toBe("TIMEOUT");
+  });
+});
+
+describe("v1 eval-ingest — webErrorMeta reaches the middleware", () => {
+  const originalEnv = { CONVEX_HTTP_URL: process.env.CONVEX_HTTP_URL };
+  const originalFetch = global.fetch;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    process.env.CONVEX_HTTP_URL = "https://convex-http.example.com";
+    validateGuestTokenMock.mockResolvedValue({ valid: false });
+  });
+
+  afterEach(() => {
+    global.fetch = originalFetch;
+    process.env.CONVEX_HTTP_URL = originalEnv.CONVEX_HTTP_URL;
+  });
+
+  it("promotes a Convex transport failure all the way to origin=mcpjam", async () => {
+    // The end-to-end assertion, not a composition guess: boundary promotion ->
+    // rethrown WebRouteError -> mapErrorToV1 -> v1Error -> webErrorMeta. Every
+    // link is load-bearing and each one has silently dropped the origin before.
+    let meta: Record<string, unknown> | undefined;
+    const app = new Hono();
+    app.use("*", async (c, next) => {
+      await next();
+      meta = c.get("webErrorMeta" as never) as Record<string, unknown>;
+    });
+    app.route("/api/v1", v1Routes);
+
+    global.fetch = vi
+      .fn()
+      .mockRejectedValue(new TypeError("fetch failed")) as never;
+
+    await request(
+      app,
+      "/api/v1/projects/default/eval-ingest/report",
+      JSON.stringify({ results: [] })
+    );
+
+    expect(meta).toBeDefined();
+    expect(meta).toMatchObject({ origin: "mcpjam" });
+    expect(meta).toHaveProperty("slug");
+    // And a real message, where the row used to carry none at all.
+    expect(String(meta?.message)).toContain("fetch failed");
+  });
+
+  it("does NOT claim a caller's own bad input", async () => {
+    // Same route, same serializer: a validation 400 must stay unattributed to
+    // MCPJam or the monitor pages on someone posting malformed JSON.
+    let meta: Record<string, unknown> | undefined;
+    const app = new Hono();
+    app.use("*", async (c, next) => {
+      await next();
+      meta = c.get("webErrorMeta" as never) as Record<string, unknown>;
+    });
+    app.route("/api/v1", v1Routes);
+
+    await request(
+      app,
+      "/api/v1/projects/default/eval-ingest/report",
+      "not json at all"
+    );
+
+    expect(meta).toMatchObject({ code: "VALIDATION_ERROR" });
+    expect(meta?.origin).not.toBe("mcpjam");
+  });
+});

--- a/mcpjam-inspector/server/routes/v1/envelope.ts
+++ b/mcpjam-inspector/server/routes/v1/envelope.ts
@@ -7,7 +7,7 @@
  * public code union, upgrading MCP auth failures to OAUTH_REQUIRED.
  */
 import type { Context } from "hono";
-import { describeError, isMCPAuthError } from "@mcpjam/sdk";
+import { describeError, isMCPAuthError, type ErrorOrigin } from "@mcpjam/sdk";
 import { ErrorCode, mapRuntimeError } from "../web/errors.js";
 import { maybeCaptureOriginError } from "../../utils/error-origin-capture.js";
 import {
@@ -18,13 +18,43 @@ import {
   type V1ErrorCode,
 } from "./contract.js";
 
+/**
+ * What a classified failure knows about itself, forwarded to the telemetry
+ * envelope. See {@link v1Error}.
+ */
+export type V1ErrorAttribution = {
+  origin?: ErrorOrigin;
+  slug?: string;
+};
+
 /** Canonical error response. */
 export function v1Error(
   c: Context,
   code: V1ErrorCode,
   message: string,
-  details?: Record<string, unknown>
+  details?: Record<string, unknown>,
+  attribution?: V1ErrorAttribution
 ) {
+  // Stash for `requestLogContextMiddleware`, exactly as `webError` does for the
+  // `/api/web/*` surface. Without it the ENTIRE `/api/v1/*` surface returned
+  // its errors without ever telling the middleware what they were, so every
+  // failure logged as a bare `internal_error` with no message, no slug, and no
+  // origin — measured on 2026-08-15 as 44 rows on `eval-ingest/report` and
+  // every other v1 5xx, all of them opaque and none of them reachable by the
+  // MCPJam-fault monitor.
+  //
+  // Set unconditionally, not just for classified throws: a route that calls
+  // `v1Error` directly for a declared 4xx outcome still knows its own code and
+  // message, and those are worth more on the row than `internal_error`.
+  if (typeof c?.set === "function") {
+    c.set("webErrorMeta", {
+      status: V1_ERROR_STATUS[code],
+      code,
+      message,
+      ...(attribution?.origin ? { origin: attribution.origin } : {}),
+      ...(attribution?.slug ? { slug: attribution.slug } : {}),
+    });
+  }
   // Cast the dynamic numeric status to satisfy Hono's literal StatusCode union
   // (the web routes sidestep this by typing `c` as `any` in `webError`).
   return c.json(
@@ -60,7 +90,7 @@ export function mapErrorToV1(error: unknown): {
   code: V1ErrorCode;
   message: string;
   details?: Record<string, unknown>;
-} {
+} & V1ErrorAttribution {
   // The two branches below return BEFORE `mapRuntimeError`, which is where the
   // v1 chain would otherwise make its capture decision. Classify them here so
   // no path out of this function escapes unclassified — both are non-MCPJam in
@@ -68,19 +98,32 @@ export function mapErrorToV1(error: unknown): {
   // primitive), so in practice this records the verdict and pages on nothing.
   if (safeIsMcpAuthError(error)) {
     const message = error instanceof Error ? error.message : String(error);
-    maybeCaptureOriginError(error, describeError(error), {
+    // The decision was already being made here and thrown away. Keeping it is
+    // what lets these two early returns carry attribution like every other
+    // path — otherwise the surface's most common non-500 failures stay blank.
+    const decision = maybeCaptureOriginError(error, describeError(error), {
       source: "v1.mapErrorToV1",
       extra: { code: "OAUTH_REQUIRED" },
     });
-    return { code: "OAUTH_REQUIRED", message };
+    return {
+      code: "OAUTH_REQUIRED",
+      message,
+      origin: decision.origin,
+      ...(decision.slug ? { slug: decision.slug } : {}),
+    };
   }
   if (isMcpMethodNotFound(error)) {
     const message = error instanceof Error ? error.message : String(error);
-    maybeCaptureOriginError(error, describeError(error), {
+    const decision = maybeCaptureOriginError(error, describeError(error), {
       source: "v1.mapErrorToV1",
       extra: { code: "FEATURE_NOT_SUPPORTED" },
     });
-    return { code: "FEATURE_NOT_SUPPORTED", message };
+    return {
+      code: "FEATURE_NOT_SUPPORTED",
+      message,
+      origin: decision.origin,
+      ...(decision.slug ? { slug: decision.slug } : {}),
+    };
   }
   const routeError = mapRuntimeError(error);
   if (
@@ -91,6 +134,7 @@ export function mapErrorToV1(error: unknown): {
       code: "OAUTH_REQUIRED",
       message: routeError.message,
       details: routeError.details,
+      ...routeErrorAttribution(routeError),
     };
   }
   // The upstream server refused the credentials we presented. Mapped HERE
@@ -115,12 +159,32 @@ export function mapErrorToV1(error: unknown): {
       code: "FORBIDDEN",
       message: routeError.message,
       details: routeError.details,
+      ...routeErrorAttribution(routeError),
     };
   }
   return {
     code: mapInternalCode(routeError.code),
     message: routeError.message,
     details: routeError.details,
+    ...routeErrorAttribution(routeError),
+  };
+}
+
+/**
+ * Read attribution off a mapped error.
+ *
+ * `origin` is the EFFECTIVE value `mapRuntimeError` resolved (post
+ * internal-boundary promotion), never `originOf(normalized)` — recomputing the
+ * declared catalog value here would report `ambiguous` for a failure Sentry
+ * was just paged for as `mcpjam`, which is the drift that kept `origin=mcpjam`
+ * out of Axiom in the first place.
+ */
+function routeErrorAttribution(
+  routeError: ReturnType<typeof mapRuntimeError>
+): V1ErrorAttribution {
+  return {
+    ...(routeError.origin ? { origin: routeError.origin } : {}),
+    ...(routeError.normalized?.slug ? { slug: routeError.normalized.slug } : {}),
   };
 }
 
@@ -152,6 +216,6 @@ function isMcpMethodNotFound(error: unknown): boolean {
 
 /** Hono onError handler for the v1 router. */
 export function v1OnError(error: unknown, c: Context) {
-  const { code, message, details } = mapErrorToV1(error);
-  return v1Error(c, code, message, details);
+  const { code, message, details, origin, slug } = mapErrorToV1(error);
+  return v1Error(c, code, message, details, { origin, slug });
 }

--- a/mcpjam-inspector/server/routes/v1/eval-ingest.ts
+++ b/mcpjam-inspector/server/routes/v1/eval-ingest.ts
@@ -19,6 +19,7 @@ import { Hono } from "hono";
 import type { Context } from "hono";
 import { ErrorCode, WebRouteError } from "../web/errors.js";
 import { getConvexBearerForRequest } from "../../utils/v1-convex-token.js";
+import { reportRouteFailure } from "../../utils/route-error-report.js";
 import { v1Error } from "./envelope.js";
 
 const evalIngest = new Hono();
@@ -120,7 +121,45 @@ async function proxyIngest(c: Context, suffix: string): Promise<Response> {
     if (isAbortError(error)) {
       return v1Error(c, "TIMEOUT", "Eval ingestion timed out");
     }
-    throw error;
+    // The hop that just failed was to MCPJam's OWN Convex deployment, not to
+    // anything a caller controls, so an unrecognized failure here is ours by
+    // default — the exact case `mcpjam_internal` documents. Without the
+    // declaration a `fetch` failure classifies `transport/fetch_failed` →
+    // `ambiguous` and never reaches the MCPJam-fault monitor, which is why 44
+    // opaque 500s sat on this route in 72h with nothing watching them.
+    //
+    // Reported here rather than at `v1OnError` because only this frame knows
+    // whose hop it was; the shared handler sees every v1 route at once and
+    // would have to guess. `reportRouteFailure` returns the effective origin,
+    // which rides on the rethrown error so the envelope reports the same
+    // verdict Sentry was paged on — `mapRuntimeError` never downgrades an
+    // origin that is already set.
+    const report = reportRouteFailure(
+      "[v1.eval-ingest] convex ingest proxy failed",
+      error,
+      {
+        source: "v1.eval-ingest",
+        hop: "mcpjam_internal",
+        context: { suffix },
+      },
+    );
+    // Status stays 500/INTERNAL_ERROR, deliberately. 502 SERVER_UNREACHABLE
+    // reads as "the USER's target MCP server is down" everywhere else in this
+    // codebase — it is the basis of the 502 triage doctrine (judge a spike by
+    // server-id concentration) — and borrowing it for OUR Convex would corrupt
+    // that. Reclassifying a route's status also has form here: #3948 moved
+    // upstream auth rejections 500->403 and silently blinded the spike
+    // monitor's `maxStatus >= 500` clause. The bug being fixed is missing
+    // ATTRIBUTION, not a wrong status, so the status does not move.
+    const routeError = new WebRouteError(
+      500,
+      ErrorCode.INTERNAL_ERROR,
+      `Eval ingestion upstream failed: ${report.normalized.rawMessage}`,
+      undefined,
+      report.normalized,
+    );
+    routeError.origin = report.origin;
+    throw routeError;
   } finally {
     clearTimeout(timer);
   }

--- a/mcpjam-inspector/server/routes/web/__tests__/oauth.test.ts
+++ b/mcpjam-inspector/server/routes/web/__tests__/oauth.test.ts
@@ -33,7 +33,27 @@ initGuestTokenSecret();
 interface OAuthErrorResponse {
   code: string;
   message: string;
+  /** Legacy compatibility key — see `webErrorCompat`. */
   error: string;
+  /** Attribution, now that these routes serialize through `webErrorFromRoute`. */
+  origin?: string;
+  normalized?: { slug?: string };
+}
+
+/**
+ * The compat keys these routes have always returned. Asserted alongside the
+ * new attribution fields rather than with a bare `toEqual`, so an accidental
+ * REMOVAL of `error`/`code`/`message` still fails while an additive envelope
+ * change does not.
+ */
+function expectCompatBody(
+  data: OAuthErrorResponse,
+  code: string,
+  message: string,
+) {
+  expect(data.code).toBe(code);
+  expect(data.message).toBe(message);
+  expect(data.error).toBe(message);
 }
 
 describe("web routes — oauth requires bearer token", () => {
@@ -144,11 +164,13 @@ describe("web routes — oauth error contract", () => {
     const { status, data } = await expectJson<OAuthErrorResponse>(response);
 
     expect(status).toBe(400);
-    expect(data).toEqual({
-      code: "VALIDATION_ERROR",
-      message: "Invalid URL format",
-      error: "Invalid URL format",
-    });
+    expectCompatBody(data, "VALIDATION_ERROR", "Invalid URL format");
+    // A 400 from our own validation is not evidence of an MCPJam fault, and
+    // these routes declare no internal boundary — so it must never read
+    // `mcpjam`. It carries attribution regardless: before this, the row had
+    // none at all.
+    expect(data.origin).toBeDefined();
+    expect(data.origin).not.toBe("mcpjam");
   });
 
   it("returns compatibility payload for missing metadata url", async () => {
@@ -156,11 +178,8 @@ describe("web routes — oauth error contract", () => {
     const { status, data } = await expectJson<OAuthErrorResponse>(response);
 
     expect(status).toBe(400);
-    expect(data).toEqual({
-      code: "VALIDATION_ERROR",
-      message: "Missing url parameter",
-      error: "Missing url parameter",
-    });
+    expectCompatBody(data, "VALIDATION_ERROR", "Missing url parameter");
+    expect(data.origin).not.toBe("mcpjam");
   });
 
   it("returns compatibility payload for metadata upstream status errors", async () => {
@@ -177,11 +196,19 @@ describe("web routes — oauth error contract", () => {
     const { status, data } = await expectJson<OAuthErrorResponse>(response);
 
     expect(status).toBe(502);
-    expect(data).toEqual({
-      code: "SERVER_UNREACHABLE",
-      message: "Failed to fetch OAuth metadata: 502 Bad Gateway",
-      error: "Failed to fetch OAuth metadata: 502 Bad Gateway",
-    });
+    expectCompatBody(
+      data,
+      "SERVER_UNREACHABLE",
+      "Failed to fetch OAuth metadata: 502 Bad Gateway",
+    );
+    // THE POINT OF THIS CHANGE. This route reaches the USER's authorization
+    // server, so a 502 from it is theirs — it must be attributed (it used to
+    // log as a bare `internal_error` with no origin at all) and it must not be
+    // attributed to us, or the MCPJam-fault monitor pages on third-party
+    // downtime.
+    expect(data.origin).toBeDefined();
+    expect(data.origin).not.toBe("mcpjam");
+    expect(data.normalized?.slug).toBeDefined();
   });
 
   it("returns compatibility payload for generic runtime errors", async () => {

--- a/mcpjam-inspector/server/routes/web/oauth.ts
+++ b/mcpjam-inspector/server/routes/web/oauth.ts
@@ -1,13 +1,18 @@
 import { Hono } from "hono";
 import type { Context } from "hono";
-import type { ContentfulStatusCode } from "hono/utils/http-status";
+import { describeError } from "@mcpjam/sdk";
 import {
   executeOAuthProxy,
   executeDebugOAuthProxy,
   fetchOAuthMetadata,
   OAuthProxyError,
 } from "../../utils/oauth-proxy.js";
-import { ErrorCode, WebRouteError, mapRuntimeError } from "./errors.js";
+import {
+  ErrorCode,
+  WebRouteError,
+  mapRuntimeError,
+  webErrorFromRoute,
+} from "./errors.js";
 import { bearerAuthMiddleware } from "../../middleware/bearer-auth.js";
 import { guestRateLimitMiddleware } from "../../middleware/guest-rate-limit.js";
 import { getRequestLogger } from "../../utils/request-logger.js";
@@ -43,28 +48,48 @@ function statusToErrorCode(status: number): ErrorCode {
 }
 
 function webErrorCompat(c: Context, routeError: WebRouteError) {
+  // Through `webErrorFromRoute`, NOT a hand-rolled `c.json`. The hand-rolled
+  // version never set `webErrorMeta`, so `requestLogContextMiddleware` had
+  // nothing to read: every failure on these routes logged as a bare
+  // `internal_error` with no message, no slug, and no origin. Measured on
+  // 2026-08-15 as 55 rows in 72h on `/api/web/oauth/metadata` alone — the
+  // single largest unattributed class on the whole surface, and structurally
+  // invisible to the MCPJam-fault monitor.
+  //
   // TODO(hosted-v1.1): Remove `error` once clients migrate to `{ code, message }`.
   // This compatibility key exists for one release to avoid breaking callers that
-  // still parse legacy `{ error }` payloads on oauth routes.
-  return c.json(
-    {
-      code: routeError.code,
-      message: routeError.message,
-      error: routeError.message,
-    },
-    routeError.status as ContentfulStatusCode,
-  );
+  // still parse legacy `{ error }` payloads on oauth routes. It rides as an
+  // `extras` key, which `webError` spreads into the body ahead of the canonical
+  // fields, so the wire shape is unchanged apart from the additions every other
+  // `/api/web/*` envelope already carries.
+  return webErrorFromRoute(c, routeError, { error: routeError.message });
 }
 
 function toRouteError(error: unknown): WebRouteError {
-  if (error instanceof WebRouteError) {
-    return error;
-  }
+  // Everything goes through `mapRuntimeError`, including errors that already
+  // ARE a `WebRouteError`. It backfills `normalized` and resolves the effective
+  // `origin`, and `webError` reports neither field unless `normalized` exists —
+  // so returning a hand-built `WebRouteError` unclassified, as both branches
+  // below used to, produced an envelope and a log row with no attribution at
+  // all. It never overrules an origin that is already set.
+  //
+  // NOTE: no `mcpjam_internal` boundary anywhere on this route, deliberately.
+  // These handlers reach the USER's authorization server — an unreachable
+  // `.well-known`, a refused connection, or a wrong issuer is theirs, and
+  // declaring an internal hop here would page us for exactly the class of
+  // third-party outage this program exists to stop paging on.
   if (error instanceof OAuthProxyError) {
-    return new WebRouteError(
-      error.status,
-      statusToErrorCode(error.status),
-      error.message,
+    return mapRuntimeError(
+      new WebRouteError(
+        error.status,
+        statusToErrorCode(error.status),
+        error.message,
+        undefined,
+        // Classify from the ORIGINAL, which carries `.status`. Describing the
+        // rebuilt `WebRouteError` instead would leave the describer nothing but
+        // a message string to pattern-match.
+        describeError(error),
+      ),
     );
   }
   return mapRuntimeError(error);


### PR DESCRIPTION
Closes the blind spot recorded in #4031's monitor description.

## The measurement

Over 72h of prod, these two routes emitted 5xx with **no origin, no slug, and no `errorMessage` at all** — not even a message. That's **52% of MCPJam's own non-proxy 5xx**, structurally unreachable by the MCPJam-fault monitor no matter how badly they failed.

| route | count | what the row said |
|---|---:|---|
| `/api/web/oauth/metadata` | 55 | `internal_error`, everything else null |
| `/api/v1/.../eval-ingest/report` | 44 | `internal_error`, everything else null |

Same root cause on both: **a serializer that never set `webErrorMeta`**, so the middleware fell back to a bare `internal_error`.

## `/api/v1/*` — the whole surface, not just eval-ingest

`v1Error` now stashes `webErrorMeta` the way `webError` always has for `/api/web/*`. This was missing for **every** v1 route.

`mapErrorToV1` returns the effective origin and slug — its two early-return branches were already making a capture decision and throwing it away — and `v1OnError` forwards them. Set unconditionally, so even a declared 4xx now carries its real code and message instead of `internal_error`.

## `/api/web/oauth/*`

`webErrorCompat` delegates to `webErrorFromRoute` instead of a hand-rolled `c.json`. The legacy `error` compat key rides as an extra, so the wire shape only *gains* the fields every other `/api/web/*` envelope already carries.

`toRouteError` now routes every branch through `mapRuntimeError`. Both hand-built `WebRouteError`s carried no `normalized`, and `webError` reports no origin without one — so even after wiring the serializer they'd have stayed blank.

**No internal boundary here, deliberately.** These handlers reach the *user's* authorization server. An unreachable `.well-known` or a refused connection is theirs, and declaring an internal hop would page us for exactly the third-party downtime this program exists to stop paging on. A test pins that a 502 from that route is attributed **and is not `mcpjam`**.

## eval-ingest is the opposite case

Its hop is to MCPJam's **own** Convex, so an unrecognized failure is ours — it declares `mcpjam_internal`. Without that, a `fetch` failure classifies `transport/fetch_failed` → `ambiguous` and still never reaches the monitor.

**Status deliberately stays 500/`INTERNAL_ERROR`.** I started with 502/`SERVER_UNREACHABLE` and backed it out: that code means "the USER's target MCP server is down" everywhere else here and underpins the 502 triage doctrine (judge a spike by server-id concentration). Reclassifying a route's status also has form — #3948 moved upstream auth rejections 500→403 and silently blinded the spike monitor's `maxStatus >= 500` clause. The bug here is missing attribution, not a wrong status.

## Verification

Verified **end-to-end, not by composition** — every link in the chain (boundary promotion → rethrown `WebRouteError` → `mapErrorToV1` → `v1Error` → `webErrorMeta`) has silently dropped the origin at some point in this program's history:

- A test mounts the real v1 router behind a middleware that reads `webErrorMeta`, and asserts a Convex transport failure arrives as `origin: "mcpjam"` with a slug and a real message.
- The same route with malformed caller JSON must **not** be `mcpjam`.
- Flipping the hop to `user_server_hop` fails that test (confirmed by running it).
- The oauth contract tests keep asserting the compat keys, via a helper, so an accidental *removal* of `error`/`code`/`message` still fails while an additive envelope change does not.
- Full `--project server`: **394 files, 5809 tests**, all pass. `tsc` 196 errors = baseline.

## After deploy

The coverage query in #4031's monitor description should drop these two routes to zero:

```apl
['inspector-logs'] | where _time > ago(24h) | where event == 'http.request.failed'
| where tostring(environment) in ('prod','production')
| summarize total = count(), unattributed = countif(isempty(tostring(origin))) by tostring(route)
| where unattributed > 0 | sort by unattributed desc
```

Expect eval-ingest failures to start appearing as `origin=mcpjam` — i.e. M2 will start firing on something real. That is the intended outcome, not a regression.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit 74817f344696977dc9370d5da6fc85c71eba393c. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Attributes failures on `/api/web/oauth/*` and all `/api/v1/*` so logs include origin, slug, and message. Previously these routes logged as bare `internal_error`; now they set `webErrorMeta` without changing response shapes or statuses.

- **Review notes**
  - `/api/v1/*`: `v1OnError` stashes `webErrorMeta` with origin/slug via `mapErrorToV1`; `v1Error` adds a backstop for returned errors (for example, TIMEOUT) and does not clobber existing meta. The v1 router declares `mcpjam_internal` for unclassified 5xx, so eval‑ingest 500s are owned; connection-class failures stay `SERVER_UNREACHABLE` and are not attributed to `mcpjam`. Applies to 4xx and 5xx.
  - `/api/web/oauth/*`: `webErrorCompat` routes through `webErrorFromRoute` and preserves the legacy `error` key while adding origin and normalized details. `toRouteError` always classifies via `mapRuntimeError` (using `describeError` from `@mcpjam/sdk`). No internal boundary is declared; upstream auth server outages are attributed but not to `mcpjam`.
  - Verification: Tests assert end‑to‑end attribution and OAuth compat keys. After deploy, unattributed failures on these routes should drop to zero; M2 will page on real MCPJam faults. No client migration required.

<sup>Written for commit a1180c6d2a13cc00cac96bacd6d34fadb3867931. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/MCPJam/inspector/pull/4039?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

