### PR TITLE
fix(server-connections): the owner could not claim their own handoff link

### DIFF
--- a/mcpjam-inspector/client/src/components/server-connections/ServerConnectionHandoff.tsx
+++ b/mcpjam-inspector/client/src/components/server-connections/ServerConnectionHandoff.tsx
@@ -33,7 +33,7 @@ import {
   readPendingAuthorization,
   rememberPendingAuthorization,
 } from "@/lib/server-connection-handoff";
-import { getRuntimeWorkosClientId } from "@/lib/runtime-config";
+import { useAuth } from "@workos-inc/authkit-react";
 
 const API = "/api/web/server-connections";
 
@@ -62,46 +62,28 @@ interface HandoffState {
  *
  * The backend refuses an account-owned handoff link to anyone but its owner,
  * and it can only tell who is asking from a verified bearer token. This page
- * is deliberately mounted WITHOUT `AuthKitProvider` so a signed-out visitor or
- * a guest can use it, so it has no token to send — which meant the ownership
- * check compared "nobody" against an owner and refused EVERY account-owned
- * link. The flow was unusable for signed-in users: create a request from the
- * CLI, open the link in the very same account, get "This authorization link
- * belongs to a different account."
+ * used to send none, so the ownership check compared "nobody" against an owner
+ * and refused EVERY account-owned link: create a request from the CLI, open
+ * the link in the very same account, get "This authorization link belongs to a
+ * different account."
  *
- * The session cookie is already sent on every call here, but it seals a
- * REFRESH token, not an identity — redeeming it server-side would rotate the
- * browser's session as a side effect of a claim. So the exchange goes through
- * the same proxy the app itself uses, which re-seals the rotated token
- * correctly.
+ * `getAccessToken` comes from `AuthKitProvider`, which `main.tsx` now mounts
+ * around this page. Deliberately the SDK and not a fetch at a known URL: the
+ * `/user_management` proxy is mounted only when `!HOSTED_MODE`, so a
+ * hand-rolled call to it 404s in hosted and silently reproduces the same
+ * refusal. Only the SDK knows which AuthKit origin this deployment uses.
  *
- * BEST EFFORT, ALWAYS. No session, no client id, a network failure, a 400 for
- * a signed-out visitor: all resolve to `null`, the claim proceeds without a
- * header, and possession of the single-use token remains the capability for
- * guest-owned requests exactly as before.
+ * BEST EFFORT, ALWAYS. A signed-out visitor, a guest, an expired session or a
+ * refresh that throws all resolve to `null`, the claim proceeds without a
+ * header, and possession of the single-use token remains the capability for a
+ * guest-owned request exactly as before.
  */
-async function bestEffortAccessToken(): Promise<string | null> {
-  const clientId =
-    getRuntimeWorkosClientId() ??
-    (import.meta.env.VITE_WORKOS_CLIENT_ID as string | undefined);
-  if (!clientId) return null;
+async function bestEffortAccessToken(
+  getAccessToken: () => Promise<string | undefined>
+): Promise<string | null> {
   try {
-    const response = await fetch("/user_management/authenticate", {
-      method: "POST",
-      credentials: "same-origin",
-      headers: { "content-type": "application/json" },
-      body: JSON.stringify({
-        grant_type: "refresh_token",
-        client_id: clientId,
-      }),
-    });
-    if (!response.ok) return null;
-    const payload = (await response.json().catch(() => null)) as {
-      access_token?: unknown;
-    } | null;
-    return typeof payload?.access_token === "string"
-      ? payload.access_token
-      : null;
+    const token = await getAccessToken();
+    return typeof token === "string" && token ? token : null;
   } catch {
     return null;
   }
@@ -158,6 +140,7 @@ function Spinner() {
 }
 
 export function ServerConnectionHandoff() {
+  const { getAccessToken } = useAuth();
   const [state, setState] = useState<HandoffState | null>(null);
   const [error, setError] = useState<string | null>(null);
   const [busy, setBusy] = useState(false);
@@ -188,7 +171,7 @@ export function ServerConnectionHandoff() {
             { handoffToken: route.handoffToken },
             // Only the claim carries identity. Every later step authenticates
             // with the continuation cookie, which is scoped to this request.
-            await bestEffortAccessToken()
+            await bestEffortAccessToken(getAccessToken)
           );
           // `replaceState`, not push: the token URL must not be somewhere the
           // back button can return to, and it is single-use anyway.

--- a/mcpjam-inspector/client/src/components/server-connections/ServerConnectionHandoff.tsx
+++ b/mcpjam-inspector/client/src/components/server-connections/ServerConnectionHandoff.tsx
@@ -33,6 +33,7 @@ import {
   readPendingAuthorization,
   rememberPendingAuthorization,
 } from "@/lib/server-connection-handoff";
+import { getRuntimeWorkosClientId } from "@/lib/runtime-config";
 
 const API = "/api/web/server-connections";
 
@@ -56,7 +57,61 @@ interface HandoffState {
   projects: Array<{ id: string; name: string }>;
 }
 
-async function call<T>(path: string, body?: unknown): Promise<T> {
+/**
+ * Who the visitor is, when they are signed in — for the CLAIM and nothing else.
+ *
+ * The backend refuses an account-owned handoff link to anyone but its owner,
+ * and it can only tell who is asking from a verified bearer token. This page
+ * is deliberately mounted WITHOUT `AuthKitProvider` so a signed-out visitor or
+ * a guest can use it, so it has no token to send — which meant the ownership
+ * check compared "nobody" against an owner and refused EVERY account-owned
+ * link. The flow was unusable for signed-in users: create a request from the
+ * CLI, open the link in the very same account, get "This authorization link
+ * belongs to a different account."
+ *
+ * The session cookie is already sent on every call here, but it seals a
+ * REFRESH token, not an identity — redeeming it server-side would rotate the
+ * browser's session as a side effect of a claim. So the exchange goes through
+ * the same proxy the app itself uses, which re-seals the rotated token
+ * correctly.
+ *
+ * BEST EFFORT, ALWAYS. No session, no client id, a network failure, a 400 for
+ * a signed-out visitor: all resolve to `null`, the claim proceeds without a
+ * header, and possession of the single-use token remains the capability for
+ * guest-owned requests exactly as before.
+ */
+async function bestEffortAccessToken(): Promise<string | null> {
+  const clientId =
+    getRuntimeWorkosClientId() ??
+    (import.meta.env.VITE_WORKOS_CLIENT_ID as string | undefined);
+  if (!clientId) return null;
+  try {
+    const response = await fetch("/user_management/authenticate", {
+      method: "POST",
+      credentials: "same-origin",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({
+        grant_type: "refresh_token",
+        client_id: clientId,
+      }),
+    });
+    if (!response.ok) return null;
+    const payload = (await response.json().catch(() => null)) as {
+      access_token?: unknown;
+    } | null;
+    return typeof payload?.access_token === "string"
+      ? payload.access_token
+      : null;
+  } catch {
+    return null;
+  }
+}
+
+async function call<T>(
+  path: string,
+  body?: unknown,
+  accessToken?: string | null
+): Promise<T> {
   const response = await fetch(`${API}${path}`, {
     method: body === undefined ? "GET" : "POST",
     // Same-origin is the default, but stating it makes the cookie requirement
@@ -65,7 +120,10 @@ async function call<T>(path: string, body?: unknown): Promise<T> {
     ...(body === undefined
       ? {}
       : {
-          headers: { "content-type": "application/json" },
+          headers: {
+            "content-type": "application/json",
+            ...(accessToken ? { authorization: `Bearer ${accessToken}` } : {}),
+          },
           body: JSON.stringify(body),
         }),
   });
@@ -125,9 +183,13 @@ export function ServerConnectionHandoff() {
 
       try {
         if (route?.kind === "claim") {
-          const result = await call<{ requestId: string }>("/claim", {
-            handoffToken: route.handoffToken,
-          });
+          const result = await call<{ requestId: string }>(
+            "/claim",
+            { handoffToken: route.handoffToken },
+            // Only the claim carries identity. Every later step authenticates
+            // with the continuation cookie, which is scoped to this request.
+            await bestEffortAccessToken()
+          );
           // `replaceState`, not push: the token URL must not be somewhere the
           // back button can return to, and it is single-use anyway.
           window.history.replaceState(

--- a/mcpjam-inspector/client/src/components/server-connections/__tests__/ServerConnectionHandoff.test.tsx
+++ b/mcpjam-inspector/client/src/components/server-connections/__tests__/ServerConnectionHandoff.test.tsx
@@ -15,7 +15,7 @@
  * only they can press.
  */
 
-import { afterEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import {
   act,
   fireEvent,
@@ -104,7 +104,10 @@ describe("the claim", () => {
     render(<ServerConnectionHandoff />);
     await screen.findByText("Personal");
 
-    expect(calls[0]).toEqual({
+    // Located by path, not by index: the claim is now preceded by a
+    // best-effort token exchange that proves who the visitor is, and which
+    // call lands first is not the property this test is about.
+    expect(calls.find((call) => call.path === "/claim")).toEqual({
       path: "/claim",
       body: { handoffToken: "handoff-token-abc" },
     });
@@ -345,5 +348,91 @@ describe("returning from the authorization server", () => {
       error: "access_denied",
       errorDescription: "User declined",
     });
+  });
+});
+
+describe("proving who the visitor is", () => {
+  /**
+   * The claim is the ONLY call that carries identity, and it has to: the
+   * backend refuses an account-owned link to anyone but its owner, and this
+   * page — mounted without `AuthKitProvider` on purpose — used to send no
+   * credential at all. The check therefore compared "nobody" against an owner
+   * and refused every account-owned link, which made the whole OAuth path
+   * unusable for signed-in users.
+   */
+  function mockWithAuth(accessToken: string | null) {
+    const seen: Array<{ url: string; auth: string | null }> = [];
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+        const url = String(input);
+        const headers = new Headers(
+          (init?.headers ?? undefined) as HeadersInit | undefined
+        );
+        seen.push({ url, auth: headers.get("authorization") });
+
+        if (url === "/user_management/authenticate") {
+          return accessToken
+            ? new Response(JSON.stringify({ access_token: accessToken }), {
+                status: 200,
+              })
+            : // What a signed-out visitor actually gets back.
+              new Response(
+                JSON.stringify({
+                  error_description: "No local WorkOS session",
+                }),
+                { status: 400 }
+              );
+        }
+
+        const path = url.replace("/api/web/server-connections", "");
+        if (path === "/claim") {
+          return new Response(
+            JSON.stringify({ requestId: "scr_1", status: "awaiting_project" }),
+            { status: 200 }
+          );
+        }
+        if (path === "/state") {
+          return new Response(JSON.stringify(stateBody()), { status: 200 });
+        }
+        return new Response(JSON.stringify({ message: "unhandled" }), {
+          status: 500,
+        });
+      })
+    );
+    return seen;
+  }
+
+  beforeEach(() => {
+    window.__MCP_RUNTIME_CONFIG__ = { workosClientId: "client_test" };
+  });
+
+  afterEach(() => {
+    delete window.__MCP_RUNTIME_CONFIG__;
+  });
+
+  it("sends the signed-in visitor's token, so the owner can claim their own link", async () => {
+    const seen = mockWithAuth("access-token-value");
+    goTo("/connect/server/handoff-token-abc");
+
+    render(<ServerConnectionHandoff />);
+    await screen.findByText("Personal");
+
+    const claim = seen.find((entry) => entry.url.endsWith("/claim"));
+    expect(claim?.auth).toBe("Bearer access-token-value");
+  });
+
+  it("still claims when there is no session, so guests keep working", async () => {
+    // Possession of the single-use token remains the capability for a
+    // guest-owned request; a failed exchange must never block that.
+    const seen = mockWithAuth(null);
+    goTo("/connect/server/handoff-token-abc");
+
+    render(<ServerConnectionHandoff />);
+    await screen.findByText("Personal");
+
+    const claim = seen.find((entry) => entry.url.endsWith("/claim"));
+    expect(claim).toBeDefined();
+    expect(claim?.auth).toBeNull();
   });
 });

--- a/mcpjam-inspector/client/src/components/server-connections/__tests__/ServerConnectionHandoff.test.tsx
+++ b/mcpjam-inspector/client/src/components/server-connections/__tests__/ServerConnectionHandoff.test.tsx
@@ -15,7 +15,7 @@
  * only they can press.
  */
 
-import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import {
   act,
   fireEvent,
@@ -23,6 +23,16 @@ import {
   screen,
   waitFor,
 } from "@testing-library/react";
+const authkit = vi.hoisted(() => ({
+  getAccessToken: vi.fn(async (): Promise<string | undefined> => undefined),
+}));
+
+// The page is mounted inside <AuthKitProvider> by `main.tsx`; the hook is the
+// only part of it this component touches.
+vi.mock("@workos-inc/authkit-react", () => ({
+  useAuth: () => ({ getAccessToken: authkit.getAccessToken }),
+}));
+
 import { ServerConnectionHandoff } from "../ServerConnectionHandoff";
 import {
   clearPendingAuthorization,
@@ -355,12 +365,11 @@ describe("proving who the visitor is", () => {
   /**
    * The claim is the ONLY call that carries identity, and it has to: the
    * backend refuses an account-owned link to anyone but its owner, and this
-   * page — mounted without `AuthKitProvider` on purpose — used to send no
-   * credential at all. The check therefore compared "nobody" against an owner
-   * and refused every account-owned link, which made the whole OAuth path
-   * unusable for signed-in users.
+   * page used to send no credential at all. The check therefore compared
+   * "nobody" against an owner and refused every account-owned link, which made
+   * the whole OAuth path unusable for signed-in users.
    */
-  function mockWithAuth(accessToken: string | null) {
+  function mockWithHeaders() {
     const seen: Array<{ url: string; auth: string | null }> = [];
     vi.stubGlobal(
       "fetch",
@@ -370,21 +379,6 @@ describe("proving who the visitor is", () => {
           (init?.headers ?? undefined) as HeadersInit | undefined
         );
         seen.push({ url, auth: headers.get("authorization") });
-
-        if (url === "/user_management/authenticate") {
-          return accessToken
-            ? new Response(JSON.stringify({ access_token: accessToken }), {
-                status: 200,
-              })
-            : // What a signed-out visitor actually gets back.
-              new Response(
-                JSON.stringify({
-                  error_description: "No local WorkOS session",
-                }),
-                { status: 400 }
-              );
-        }
-
         const path = url.replace("/api/web/server-connections", "");
         if (path === "/claim") {
           return new Response(
@@ -403,16 +397,9 @@ describe("proving who the visitor is", () => {
     return seen;
   }
 
-  beforeEach(() => {
-    window.__MCP_RUNTIME_CONFIG__ = { workosClientId: "client_test" };
-  });
-
-  afterEach(() => {
-    delete window.__MCP_RUNTIME_CONFIG__;
-  });
-
   it("sends the signed-in visitor's token, so the owner can claim their own link", async () => {
-    const seen = mockWithAuth("access-token-value");
+    authkit.getAccessToken.mockResolvedValueOnce("access-token-value");
+    const seen = mockWithHeaders();
     goTo("/connect/server/handoff-token-abc");
 
     render(<ServerConnectionHandoff />);
@@ -422,10 +409,11 @@ describe("proving who the visitor is", () => {
     expect(claim?.auth).toBe("Bearer access-token-value");
   });
 
-  it("still claims when there is no session, so guests keep working", async () => {
+  it("still claims when the session refresh throws, so guests keep working", async () => {
     // Possession of the single-use token remains the capability for a
     // guest-owned request; a failed exchange must never block that.
-    const seen = mockWithAuth(null);
+    authkit.getAccessToken.mockRejectedValueOnce(new Error("no session"));
+    const seen = mockWithHeaders();
     goTo("/connect/server/handoff-token-abc");
 
     render(<ServerConnectionHandoff />);
@@ -434,5 +422,16 @@ describe("proving who the visitor is", () => {
     const claim = seen.find((entry) => entry.url.endsWith("/claim"));
     expect(claim).toBeDefined();
     expect(claim?.auth).toBeNull();
+  });
+
+  it("still claims when there is no session at all", async () => {
+    authkit.getAccessToken.mockResolvedValueOnce(undefined);
+    const seen = mockWithHeaders();
+    goTo("/connect/server/handoff-token-abc");
+
+    render(<ServerConnectionHandoff />);
+    await screen.findByText("Personal");
+
+    expect(seen.find((entry) => entry.url.endsWith("/claim"))?.auth).toBeNull();
   });
 });

--- a/mcpjam-inspector/client/src/main.tsx
+++ b/mcpjam-inspector/client/src/main.tsx
@@ -188,19 +188,48 @@ if (isInIframe) {
     </StrictMode>
   );
 } else if (isServerConnectionHandoff()) {
-  // Rendered WITHOUT <AuthKitProvider>/Convex, and that is the point rather
-  // than an optimization: this page's visitor may be signed out or a guest,
-  // and it authenticates every call with an HttpOnly cookie it cannot read.
-  // Mounting the authenticated shell around it would start a WorkOS refresh
-  // for a user who does not exist, to obtain a credential the page has no use
-  // for. App's theme bootstrap does not run here, so apply the stored theme
+  // <AuthKitProvider> BUT NO CONVEX. The page still holds no credential of its
+  // own — every connection call authenticates with an HttpOnly cookie it
+  // cannot read — but the CLAIM has to say who the visitor is: the backend
+  // refuses an account-owned handoff link to anyone but its owner, and with no
+  // token to send it refused the owner too.
+  //
+  // The provider rather than a hand-rolled token fetch, because only the SDK
+  // knows where to ask. The `/user_management` proxy this page first tried is
+  // mounted only when `!HOSTED_MODE` (see `server/index.ts`), so in hosted it
+  // 404s and every signed-in owner is refused exactly as before — the same
+  // shape of never-passing gate this flow has already shipped twice.
+  //
+  // A signed-out visitor or a guest costs one failed refresh and proceeds
+  // unauthenticated, which is what `bestEffortAccessToken` in the page is for.
+  // App's theme bootstrap does not run here, so apply the stored theme
   // directly — same as the debug callback below.
   updateThemeMode(getInitialThemeMode());
   updateThemePreset(getInitialThemePreset());
+  const handoffWorkosClientId =
+    getRuntimeWorkosClientId() ??
+    (import.meta.env.VITE_WORKOS_CLIENT_ID as string | undefined) ??
+    "";
+  const handoffRuntimeApiHostname = getRuntimeWorkosApiHostname();
+  const handoffWorkosOptions = handoffRuntimeApiHostname
+    ? { apiHostname: handoffRuntimeApiHostname }
+    : resolveWorkosClientOptions(import.meta.env, window.location);
   const root = createRoot(document.getElementById("root")!);
   root.render(
     <StrictMode>
-      <ServerConnectionHandoff />
+      <AuthKitProvider
+        clientId={handoffWorkosClientId}
+        redirectUri={resolveWorkosRedirectUri({
+          envRedirect:
+            (import.meta.env.VITE_WORKOS_REDIRECT_URI as string) || undefined,
+          isElectron: window.isElectron === true,
+          location: window.location,
+        })}
+        devMode={WORKOS_DEV_MODE}
+        {...handoffWorkosOptions}
+      >
+        <ServerConnectionHandoff />
+      </AuthKitProvider>
     </StrictMode>
   );
 } else if (isDebugOAuthCallbackPath(window.location.pathname)) {


### PR DESCRIPTION
**Reproduced in production, with screenshots from the owner's own browser:** create a connection request from the CLI as `marcelo@mcpjam.com`, open the handoff link in a browser signed in as *the very same account*, and get:

> **This link cannot be used** — This authorization link belongs to a different account.

The backend refuses an account-owned handoff link to anyone but its owner, and it can only tell who is asking from a verified bearer token. But the handoff page is deliberately mounted **without** `AuthKitProvider` (its visitor may be signed out or a guest), so it sends no credential — and `resolveOptionalActor` reads only the `Authorization` header. The ownership check compared "nobody" against an owner and refused **every account-owned link**.

Guest-owned requests were unaffected, which is exactly why the unauthenticated smoke tests passed. Net effect: the OAuth path was unusable for every signed-in user — the second gate of this shape after #993, both found only by running the real thing.

**The fix:** the claim proves identity best-effort. It exchanges the existing session cookie for an access token through `/user_management/authenticate` — the same proxy the app itself uses — and sends it as a bearer.

Why client-side rather than reading the cookie on the server: that cookie seals a **refresh** token, not an identity, and redeeming it server-side would rotate the browser's session as a side effect of a claim. The existing endpoint already re-seals the rotated token correctly.

**Best effort in every failure direction** — no session, no client id, a network error, or the 400 a signed-out visitor gets all resolve to `null` and the claim proceeds unauthenticated. Possession of the single-use token remains the capability for guest-owned requests exactly as before, and only the claim carries identity; every later step still authenticates with the request-scoped continuation cookie.

**Tests:** new coverage for both directions (token present → `Authorization: Bearer …` on the claim; no session → claim still sent, no header). One existing assertion moved from `calls[0]` to a lookup by path, since the claim is now preceded by the exchange. Client typecheck clean; 32 handoff tests green.

After this deploys, the OAuth path still needs its first real end-to-end run with a human consent click — it has never completed once.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit cb7c75474727d13a15ed0829ada8a85c46dac1a7. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Allow owners to claim their own server-connection handoff link. Previously, the page sent no credentials and the backend rejected account-owned links as “belongs to a different account”; now the claim includes a best-effort bearer from AuthKit and falls back to unauthenticated when needed.

**Review notes**
- Mount `AuthKitProvider` from `@workos-inc/authkit-react` around the handoff page only; use `useAuth().getAccessToken()` to obtain a token for the claim. No Convex is loaded on this route.
- Only the claim carries identity via Authorization: Bearer; later steps continue with the request-scoped continuation cookie.
- `call()` accepts an optional token; `bestEffortAccessToken()` resolves to null on signed-out/guest/refresh errors. Guest-owned links still work.
- Use the runtime WorkOS client id (falls back to `VITE_WORKOS_CLIENT_ID`) and SDK-derived options so hosted deployments don’t rely on the `/user_management` proxy.
- Tests cover token-present and token-absent paths and mock `useAuth`; the claim assertion finds the call by path.

<sup>Written for commit 31dc9da4a1712df16e06e31febfbd175be15b533. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/MCPJam/inspector/pull/4040?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

