### PR TITLE
fix(nav): resolve unified-sessions-enabled so the Sessions item can appear

### DIFF
--- a/mcpjam-inspector/client/src/components/__tests__/mcp-sidebar-feature-flags.test.ts
+++ b/mcpjam-inspector/client/src/components/__tests__/mcp-sidebar-feature-flags.test.ts
@@ -4,6 +4,7 @@ import {
   filterByFeatureFlags,
   getHostedNavigationSections,
   navigationSections,
+  SIDEBAR_RESOLVED_FLAG_KEYS,
 } from "../mcp-sidebar";
 
 const FakeIcon = () => null;
@@ -46,7 +47,7 @@ describe("filterByFeatureFlags", () => {
           ],
         },
       ],
-      { "registry-enabled": false },
+      { "registry-enabled": false }
     );
     const titles = result[0].items.map((i) => i.title);
     expect(titles).toEqual(["Always Visible"]);
@@ -68,7 +69,7 @@ describe("filterByFeatureFlags", () => {
           ],
         },
       ],
-      { xaa: false },
+      { xaa: false }
     );
 
     expect(result[0].items.map((i) => i.title)).toEqual(["OAuth Debugger"]);
@@ -149,7 +150,7 @@ describe("filterByFeatureFlags", () => {
           ],
         },
       ],
-      { "mcpjam-conformance": false },
+      { "mcpjam-conformance": false }
     );
 
     expect(result[0].items.map((item) => item.title)).toEqual([
@@ -174,7 +175,7 @@ describe("filterByFeatureFlags", () => {
     ];
 
     expect(
-      filterByFeatureFlags(sections, { "sandboxes-enabled": true })[0].items,
+      filterByFeatureFlags(sections, { "sandboxes-enabled": true })[0].items
     ).toEqual([
       {
         title: "Chatboxes",
@@ -185,7 +186,7 @@ describe("filterByFeatureFlags", () => {
       },
     ]);
     expect(
-      filterByFeatureFlags(sections, { "sandboxes-enabled": false }),
+      filterByFeatureFlags(sections, { "sandboxes-enabled": false })
     ).toHaveLength(0);
   });
 
@@ -208,10 +209,56 @@ describe("filterByFeatureFlags", () => {
         billingUiEnabled: true,
         gateDenied: { chatboxes: true },
         enforcementActive: true,
-      },
+      }
     );
 
     expect(result[0].items[0].disabled).toBe(true);
+  });
+});
+
+describe("declared nav flags are actually resolved", () => {
+  // The bug this guards: a nav item can declare `featureFlag: "x"` while the
+  // sidebar's `featureFlags` map never sets `x`. `filterByFeatureFlags` then
+  // reads `undefined`, hides the item permanently, and — because nothing ever
+  // calls the flag — PostHog reports it as never evaluated, which reads like a
+  // rollout/targeting problem instead of a missing map entry. Sessions shipped
+  // that way and was invisible in production with a correctly-configured flag.
+  it("every featureFlag / hiddenByFlag key in navigationSections is in SIDEBAR_RESOLVED_FLAG_KEYS", () => {
+    const declared = new Set<string>();
+    for (const section of navigationSections) {
+      for (const item of section.items) {
+        if (item.featureFlag) declared.add(item.featureFlag);
+        if (item.hiddenByFlag) declared.add(item.hiddenByFlag);
+      }
+    }
+
+    const resolved = new Set<string>(SIDEBAR_RESOLVED_FLAG_KEYS);
+    const missing = [...declared].filter((key) => !resolved.has(key)).sort();
+
+    expect(missing).toEqual([]);
+  });
+
+  it("Sessions is gated by unified-sessions-enabled and appears when it is on", () => {
+    const sessionsItem = navigationSections
+      .flatMap((section) => section.items)
+      .find((item) => item.url === "/sessions");
+
+    expect(sessionsItem).toMatchObject({
+      title: "Sessions",
+      featureFlag: "unified-sessions-enabled",
+    });
+
+    const off = filterByFeatureFlags(navigationSections, {})
+      .flatMap((s) => s.items)
+      .map((i) => i.title);
+    expect(off).not.toContain("Sessions");
+
+    const on = filterByFeatureFlags(navigationSections, {
+      "unified-sessions-enabled": true,
+    })
+      .flatMap((s) => s.items)
+      .map((i) => i.title);
+    expect(on).toContain("Sessions");
   });
 });
 
@@ -235,7 +282,7 @@ describe("applyBillingGateNavState", () => {
         billingUiEnabled: true,
         gateDenied: { evals: true },
         enforcementActive: false,
-      },
+      }
     );
 
     expect(result[0].items[0].disabled).not.toBe(true);
@@ -265,7 +312,7 @@ describe("applyBillingGateNavState", () => {
         billingUiEnabled: true,
         gateDenied: { evals: true },
         enforcementActive: true,
-      },
+      }
     );
 
     const evalItem = result[0].items.find((i) => i.title === "Testing");

--- a/mcpjam-inspector/client/src/components/mcp-sidebar.tsx
+++ b/mcpjam-inspector/client/src/components/mcp-sidebar.tsx
@@ -96,9 +96,35 @@ interface NavSection {
 }
 
 /**
+ * Every flag key the sidebar actually RESOLVES into the `featureFlags` map
+ * inside `MCPSidebar`. A nav item's `featureFlag` / `hiddenByFlag` must appear
+ * here or the item is invisible forever: `filterByFeatureFlags` reads
+ * `flags[key]` as `undefined`, treats it as off, and nothing ever calls the
+ * flag — so PostHog shows it as never evaluated and the cause looks like a
+ * rollout problem rather than a missing map entry. The Sessions item shipped
+ * exactly that way. `mcp-sidebar-feature-flags.test.ts` fails if the two lists
+ * drift again.
+ */
+export const SIDEBAR_RESOLVED_FLAG_KEYS = [
+  "mcpjam-learning",
+  "sandboxes-enabled",
+  "registry-enabled",
+  "mcpjam-conformance",
+  "mcpjam-compatibility",
+  "hosts-enabled",
+  "home-page-enabled",
+  "xaa",
+  "project-environments-enabled",
+  "unified-sessions-enabled",
+] as const;
+
+/**
  * Filter navigation items based on active feature flags.
  * Items with `featureFlag` are shown only when that flag is enabled.
  * Items with `hiddenByFlag` are hidden when that flag is enabled.
+ *
+ * A key missing from `flags` counts as OFF — see
+ * {@link SIDEBAR_RESOLVED_FLAG_KEYS}.
  */
 export function filterByFeatureFlags(
   sections: NavSection[],
@@ -435,6 +461,9 @@ export function MCPSidebar({
   const projectEnvironmentsEnabled = useFeatureFlagEnabled(
     "project-environments-enabled"
   );
+  const unifiedSessionsEnabled = useFeatureFlagEnabled(
+    "unified-sessions-enabled"
+  );
   const { isAuthenticated, isLoading: isConvexAuthLoading } = useConvexAuth();
   const { user, isLoading: isWorkOsAuthLoading } = useAuth();
   // Until WorkOS + Convex resolve the session we don't yet know guest-vs-authed
@@ -511,6 +540,10 @@ export function MCPSidebar({
       xaa: xaaEnabled === true,
       "project-environments-enabled":
         projectEnvironmentsEnabled === true && isAuthenticated,
+      // Project-scoped like the two above: the feed needs a project, and
+      // `SessionsRoute` renders a "needs a project" empty state without one.
+      "unified-sessions-enabled":
+        unifiedSessionsEnabled === true && isAuthenticated,
     }),
     [
       learningEnabled,
@@ -520,6 +553,7 @@ export function MCPSidebar({
       compatibilityEnabled,
       xaaEnabled,
       projectEnvironmentsEnabled,
+      unifiedSessionsEnabled,
       isAuthenticated,
     ]
   );


### PR DESCRIPTION
## The bug

The Sessions nav item shipped in #3999 declaring `featureFlag: "unified-sessions-enabled"`, but `MCPSidebar` resolves flags from a **hand-assembled `featureFlags` map** and the key was never added to it. `filterByFeatureFlags` reads `flags[key]` as `undefined`, treats that as off, and hides the item — **unconditionally, in production, with the PostHog flag correctly configured at 100% for the team.**

The failure is self-concealing: because no code path ever asked for the flag, PostHog reported it as never evaluated (`last_called_at: null`) while a sibling flag with identical targeting (`mcpjam-conformance`, also `email icontains @mcpjam.com`) showed recent calls. That looks like a targeting/rollout problem, and sent triage at the flag and the deploy before the map.

Confirmed the deploy was **not** at fault: the Sessions commit is an ancestor of the last release head and that run's `promote-production` job succeeded.

## The fix

- Resolve the flag with `useFeatureFlagEnabled` and add it to the map, ANDed with `isAuthenticated` like the other project-scoped surfaces (`sandboxes-enabled`, `project-environments-enabled`) — the feed needs a project, and `SessionsRoute` renders a "needs a project" empty state without one.
- Add `SIDEBAR_RESOLVED_FLAG_KEYS` and a test asserting **every** `featureFlag`/`hiddenByFlag` key declared in `navigationSections` is actually resolved. This is the durable part: the class of bug now fails loudly instead of shipping an invisible nav item.

## Verification

- 21 tests in `mcp-sidebar-feature-flags.test.ts` pass; all 43 component test files (578 tests) pass; `typecheck:client` and prettier clean.
- **Mutation-tested the guard**: removing the key from `SIDEBAR_RESOLVED_FLAG_KEYS` reproduces the original bug and fails the new test with `expected [ 'unified-sessions-enabled' ] to deeply equal []`.

After this deploys, the flag will start evaluating and the item appears for @mcpjam.com users.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit 1ac9ba84c66596fbe2e015144c69b1f3a01acf07. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Restore Sessions nav visibility by resolving the `unified-sessions-enabled` flag in `MCPSidebar`. Before, the sidebar never set this key, so `filterByFeatureFlags` treated it as off and hid Sessions; now it appears when the flag is on and the user is authenticated.

- Resolve `unified-sessions-enabled` via `useFeatureFlagEnabled` and include it in the sidebar `featureFlags` map, ANDed with `isAuthenticated`.
- Add `SIDEBAR_RESOLVED_FLAG_KEYS` and a test that ensures every `featureFlag`/`hiddenByFlag` in `navigationSections` is resolved, preventing silent omissions.

<sup>Written for commit 1ac9ba84c66596fbe2e015144c69b1f3a01acf07. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/MCPJam/inspector/pull/4041?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

