### PR TITLE
chore(production-scoring): drop the worker flag — one switch, not two

### DIFF
--- a/mcpjam-inspector/server/index.ts
+++ b/mcpjam-inspector/server/index.ts
@@ -169,7 +169,6 @@ import {
   type GithubChecksWorkerHandle,
 } from "./services/github-checks-worker";
 import {
-  isProductionChecksWorkerEnabled,
   startProductionChecksWorker,
   type ProductionChecksWorkerHandle,
 } from "./services/production-checks-worker";
@@ -846,12 +845,12 @@ if (isGithubChecksWorkerEnabled()) {
 }
 
 // Production scoring: claim-and-grade polling loop for real User Testing
-// sessions. Env-gated; the backend enqueue/routes/cron have their own
-// PRODUCTION_CHECKS_ENABLED gate and 404 the routes when it is off.
-let productionChecksWorker: ProductionChecksWorkerHandle | undefined;
-if (isProductionChecksWorkerEnabled()) {
-  productionChecksWorker = startProductionChecksWorker();
-}
+// sessions. Started unconditionally and deliberately flagless — it self-gates
+// on the service-token env (a non-peer deployment gets an inert handle), and
+// the feature's single switch is the backend's PRODUCTION_CHECKS_ENABLED,
+// which 404s the claim route and parks this loop on a slow poll when off.
+const productionChecksWorker: ProductionChecksWorkerHandle =
+  startProductionChecksWorker();
 
 const expectedParentPid = Number.parseInt(
   process.env.MCPJAM_INSPECTOR_PARENT_PID ?? "",
@@ -909,7 +908,7 @@ async function shutdown() {
     // shutdown rather than skipping straight to the force-exit deadline.
     await scheduledEvalsWorker?.stop();
     await githubChecksWorker?.stop();
-    await productionChecksWorker?.stop();
+    await productionChecksWorker.stop();
     // Abort active synthetic-session runs and write a terminal "failed"
     // status so the dialog/UI doesn't see a stuck "running" run. Bounded
     // by an internal timeout; the outer `forceExitTimer` still wins.

--- a/mcpjam-inspector/server/services/__tests__/production-checks-worker.test.ts
+++ b/mcpjam-inspector/server/services/__tests__/production-checks-worker.test.ts
@@ -140,6 +140,20 @@ describe("startProductionChecksWorker loop", () => {
     })();
   }
 
+  it("stays inert without the service-token env — the only gate there is", async () => {
+    // No flag guards this worker, so a deployment that is not an
+    // infrastructure peer must self-gate here or every local dev inspector
+    // would start polling.
+    vi.unstubAllEnvs();
+    const claim = vi.fn();
+
+    const handle = startProductionChecksWorker({ claim });
+    await flushLoop();
+    await handle.stop();
+
+    expect(claim).not.toHaveBeenCalled();
+  });
+
   it("claims, executes, and keeps polling", async () => {
     const claim = vi
       .fn()

--- a/mcpjam-inspector/server/services/production-checks-worker.ts
+++ b/mcpjam-inspector/server/services/production-checks-worker.ts
@@ -19,9 +19,17 @@
  *     tool-call walker the swarm checks runner uses, so a verdict cannot
  *     depend on which grader asked.
  *
- * Gated by `PRODUCTION_CHECKS_WORKER_ENABLED === '1'` (the backend enqueue,
- * routes, and cron have their own `PRODUCTION_CHECKS_ENABLED` gate; a 404
- * from the claim route means that gate is off and the loop backs off).
+ * ONE switch, and it is the backend's `PRODUCTION_CHECKS_ENABLED`. This worker
+ * has deliberately no flag of its own, unlike its scheduled-evals and
+ * github-checks siblings — a second gate here bought nothing the two existing
+ * ones don't already provide, and cost the failure mode where the feature
+ * reads as ON while silently doing nothing:
+ *
+ *   - being a worker at all requires `CONVEX_HTTP_URL` +
+ *     `INSPECTOR_SERVICE_TOKEN`; a deployment without them is not an
+ *     infrastructure peer and never starts the loop;
+ *   - the feature being off means the claim route 404s, which this loop reads
+ *     as "disabled" and backs off to one poll a minute until it flips.
  */
 
 import { logger } from "../utils/logger";
@@ -61,10 +69,6 @@ type ClaimOutcome =
   /** A trigger was consumed without producing work — poll again immediately. */
   | { kind: "drained" }
   | { kind: "disabled" };
-
-export function isProductionChecksWorkerEnabled(): boolean {
-  return process.env.PRODUCTION_CHECKS_WORKER_ENABLED === "1";
-}
 
 function requiredEnv(): { convexUrl: string; serviceToken: string } | null {
   const convexUrl = process.env.CONVEX_HTTP_URL;
@@ -300,8 +304,9 @@ export interface ProductionChecksWorkerHandle {
 }
 
 /**
- * Start the polling loop. Call once from server bootstrap when
- * {@link isProductionChecksWorkerEnabled}. One grade in flight per instance;
+ * Start the polling loop. Called unconditionally from server bootstrap — it
+ * self-gates on the service-token env below, so a deployment that is not an
+ * infrastructure peer gets an inert handle. One grade in flight per instance;
  * multiple instances race safely (the claim is an atomic Convex mutation).
  */
 export function startProductionChecksWorker(options?: {
@@ -317,10 +322,10 @@ export function startProductionChecksWorker(options?: {
   const claim = options?.claim ?? claimNext;
   const execute = options?.execute ?? executeClaimedCheck;
 
+  // Not a worker peer — every local dev and self-hosted inspector lands here.
+  // Silent on purpose: with no flag to contradict, absent credentials are the
+  // normal case rather than a misconfiguration worth warning about.
   if (!requiredEnv()) {
-    logger.warn(
-      "[production-checks] worker enabled but CONVEX_HTTP_URL / INSPECTOR_SERVICE_TOKEN missing; not starting",
-    );
     return { stop: async () => {} };
   }
 


### PR DESCRIPTION
Removes `PRODUCTION_CHECKS_WORKER_ENABLED`. It was copied from the scheduled-evals / github-checks workers without asking what it bought *here*, and the answer is nothing the two existing gates don't already provide:

- **Being a worker at all** requires `CONVEX_HTTP_URL` + `INSPECTOR_SERVICE_TOKEN` — a deployment that isn't an infrastructure peer never starts the loop.
- **The feature being off** makes the claim route 404, which the loop already reads as "disabled" and backs off to one poll a minute.

What the flag did cost is the failure mode this codebase guards against everywhere else: set the backend flag, forget this one, and the feature reads as ON while silently doing nothing — no error, no log, nothing to notice. `PRODUCTION_CHECKS_ENABLED` on the backend is now the single switch.

Also drops the env-missing warning. With no flag to contradict it, absent credentials are the normal case for every local dev and self-hosted inspector, not a misconfiguration worth a startup warning.

Deliberate divergence from the two sibling workers, documented in the module header so the next reader doesn't "fix" it back.

Tests: 8 (one new — the worker stays inert without the service-token env, which is now the only gate). Typecheck clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit 25048603f302bdd9003b11a7a4dc122e6f7d6956. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Drops the `PRODUCTION_CHECKS_WORKER_ENABLED` flag and starts the production-scoring worker unconditionally. The single switch is now the backend `PRODUCTION_CHECKS_ENABLED`; when off, the claim route 404s and the loop backs off to a slow poll.

Removes the startup warning for missing `CONVEX_HTTP_URL`/`INSPECTOR_SERVICE_TOKEN` since absent creds are normal outside infra peers. The server always creates a worker handle and stops it on shutdown; non-peers get an inert handle. Adds a test confirming the worker stays inert without the service token.

**Migration**
- Remove `PRODUCTION_CHECKS_WORKER_ENABLED` from all environments. Infra peers must continue to set `CONVEX_HTTP_URL` and `INSPECTOR_SERVICE_TOKEN`.

<sup>Written for commit 25048603f302bdd9003b11a7a4dc122e6f7d6956. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/MCPJam/inspector/pull/4042?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

