### PR TITLE
fix(server-connections): claim before AuthKit settles sent no identity

### DIFF
--- a/mcpjam-inspector/client/src/components/server-connections/ServerConnectionHandoff.tsx
+++ b/mcpjam-inspector/client/src/components/server-connections/ServerConnectionHandoff.tsx
@@ -156,16 +156,24 @@ export function ServerConnectionHandoff() {
 
   // First load: trade the token for the cookie, then take it out of the URL.
   useEffect(() => {
-    // WAIT FOR AUTHKIT TO SETTLE FIRST. The provider restores its session
-    // asynchronously, so claiming on mount asks `getAccessToken` before there
-    // is one to give: it answers with nothing, the claim goes out
+    // THE CLAIM WAITS FOR AUTHKIT, AND ONLY THE CLAIM. The provider restores
+    // its session asynchronously, so claiming on mount asks `getAccessToken`
+    // before there is one to give: it answers with nothing, the claim goes out
     // unidentified, and the backend refuses an account-owned link to its own
     // owner — the very failure this identity plumbing exists to fix, moved
     // from "never sends a token" to "sends it a moment too late".
     //
-    // Only the claim waits. A visitor who is signed out settles just as fast
-    // with no user, and the claim proceeds unauthenticated exactly as before.
-    if (authLoading) return;
+    // Every OTHER path here authenticates with the continuation cookie and
+    // wants nothing from AuthKit, so gating them on it would be strictly
+    // harmful: a slow refresh would stall the `/state` read, and a refresh
+    // that never settles would strand `/authorize/complete` — the code
+    // exchange — after the user had already consented. Route first, gate
+    // second.
+    //
+    // A visitor who is signed out settles just as fast with no user, and the
+    // claim proceeds unauthenticated exactly as before.
+    const claimRoute = matchHandoffRoute(window.location.pathname);
+    if (claimRoute?.kind === "claim" && authLoading) return;
     if (claimed.current) return;
     claimed.current = true;
 

--- a/mcpjam-inspector/client/src/components/server-connections/ServerConnectionHandoff.tsx
+++ b/mcpjam-inspector/client/src/components/server-connections/ServerConnectionHandoff.tsx
@@ -140,7 +140,7 @@ function Spinner() {
 }
 
 export function ServerConnectionHandoff() {
-  const { getAccessToken } = useAuth();
+  const { getAccessToken, isLoading: authLoading } = useAuth();
   const [state, setState] = useState<HandoffState | null>(null);
   const [error, setError] = useState<string | null>(null);
   const [busy, setBusy] = useState(false);
@@ -156,6 +156,16 @@ export function ServerConnectionHandoff() {
 
   // First load: trade the token for the cookie, then take it out of the URL.
   useEffect(() => {
+    // WAIT FOR AUTHKIT TO SETTLE FIRST. The provider restores its session
+    // asynchronously, so claiming on mount asks `getAccessToken` before there
+    // is one to give: it answers with nothing, the claim goes out
+    // unidentified, and the backend refuses an account-owned link to its own
+    // owner — the very failure this identity plumbing exists to fix, moved
+    // from "never sends a token" to "sends it a moment too late".
+    //
+    // Only the claim waits. A visitor who is signed out settles just as fast
+    // with no user, and the claim proceeds unauthenticated exactly as before.
+    if (authLoading) return;
     if (claimed.current) return;
     claimed.current = true;
 
@@ -201,7 +211,7 @@ export function ServerConnectionHandoff() {
       }
       await refresh();
     })();
-  }, [refresh]);
+  }, [refresh, authLoading, getAccessToken]);
 
   // Poll only while the outstanding step is someone else's.
   useEffect(() => {

--- a/mcpjam-inspector/client/src/components/server-connections/__tests__/ServerConnectionHandoff.test.tsx
+++ b/mcpjam-inspector/client/src/components/server-connections/__tests__/ServerConnectionHandoff.test.tsx
@@ -25,12 +25,16 @@ import {
 } from "@testing-library/react";
 const authkit = vi.hoisted(() => ({
   getAccessToken: vi.fn(async (): Promise<string | undefined> => undefined),
+  isLoading: false,
 }));
 
 // The page is mounted inside <AuthKitProvider> by `main.tsx`; the hook is the
 // only part of it this component touches.
 vi.mock("@workos-inc/authkit-react", () => ({
-  useAuth: () => ({ getAccessToken: authkit.getAccessToken }),
+  useAuth: () => ({
+    getAccessToken: authkit.getAccessToken,
+    isLoading: authkit.isLoading,
+  }),
 }));
 
 import { ServerConnectionHandoff } from "../ServerConnectionHandoff";
@@ -97,6 +101,7 @@ function goTo(path: string, search = "") {
 // fetch. Nothing below triggers a navigation, so the real object is fine.
 
 afterEach(() => {
+  authkit.isLoading = false;
   clearPendingAuthorization();
   vi.unstubAllGlobals();
   vi.restoreAllMocks();
@@ -433,5 +438,29 @@ describe("proving who the visitor is", () => {
     await screen.findByText("Personal");
 
     expect(seen.find((entry) => entry.url.endsWith("/claim"))?.auth).toBeNull();
+  });
+
+  it("waits for AuthKit before claiming, so the token is not asked for too early", async () => {
+    // The regression that survived the first fix: `AuthKitProvider` restores
+    // its session asynchronously, so a claim fired on mount asks for a token
+    // that does not exist yet, goes out unidentified, and is refused — the
+    // owner sees "belongs to a different account" for their own link.
+    authkit.isLoading = true;
+    // What the real provider does: no session to hand out until it has
+    // finished restoring one. A mock that answers early cannot see this bug.
+    authkit.getAccessToken.mockImplementation(async () =>
+      authkit.isLoading ? undefined : "access-token-value"
+    );
+    const seen = mockWithHeaders();
+    goTo("/connect/server/handoff-token-abc");
+
+    const { rerender } = render(<ServerConnectionHandoff />);
+
+    authkit.isLoading = false;
+    rerender(<ServerConnectionHandoff />);
+    await screen.findByText("Personal");
+
+    const claim = seen.find((entry) => entry.url.endsWith("/claim"));
+    expect(claim?.auth).toBe("Bearer access-token-value");
   });
 });

--- a/mcpjam-inspector/client/src/components/server-connections/__tests__/ServerConnectionHandoff.test.tsx
+++ b/mcpjam-inspector/client/src/components/server-connections/__tests__/ServerConnectionHandoff.test.tsx
@@ -304,6 +304,31 @@ describe("polling", () => {
 });
 
 describe("returning from the authorization server", () => {
+  it("completes even while AuthKit is still loading", async () => {
+    // The callback authenticates with the continuation cookie and wants
+    // nothing from AuthKit, so gating it on the session would be strictly
+    // harmful: a refresh that never settles would strand the code exchange
+    // AFTER the user had already consented, losing the authorization.
+    authkit.isLoading = true;
+    const calls = mockApi({
+      "/authorize/complete": () => ({
+        requestId: "scr_1",
+        status: "validating",
+      }),
+      "/state": () => stateBody({ status: "validating" }),
+    });
+    rememberPendingAuthorization("scr_1", AUTH_URL);
+    goTo("/oauth/callback", "?code=auth-code&state=st&iss=https://as.example");
+
+    render(<ServerConnectionHandoff />);
+
+    await waitFor(() =>
+      expect(
+        calls.find((call) => call.path === "/authorize/complete")
+      ).toBeDefined()
+    );
+  });
+
   it("posts the callback and clears the marker", async () => {
     const calls = mockApi({
       "/authorize/complete": () => ({


### PR DESCRIPTION
Follow-up to #4040, reproduced on staging after it deployed: the owner still gets "This authorization link belongs to a different account" for their own link.

#4040 gave the page a way to prove who the visitor is, and then asked too early. `AuthKitProvider` restores its session **asynchronously**, so a claim fired on mount calls `getAccessToken` before there is one to give — it answers with nothing, the claim goes out unidentified, and the backend refuses. Same symptom, cause moved from "never sends a token" to "sends it a moment too late".

The claim now waits for `isLoading` to clear. Only the claim waits: a signed-out visitor settles just as fast with no user and proceeds unauthenticated, so guest-owned links are unaffected.

The regression test now models what the real provider does (no token until the session is restored) — the previous mock answered immediately and therefore could not see this. I verified the test fails with the gate removed and passes with it.

Client typecheck clean; 15 handoff tests green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit 958834dde29034097062c5c5a251185b5a266f52. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents unidentified claims during server connection handoff by waiting for AuthKit session restoration. Previously the claim fired on mount and called `getAccessToken` before a session existed, sending no identity and failing with “This authorization link belongs to a different account”; now only the claim waits for `isLoading` to clear while the initial `/state` read and `/authorize/complete` callback proceed immediately to avoid stalling or stranding the code exchange.

- Gates only the claim path in `ServerConnectionHandoff` on `authLoading` from `useAuth` (`@workos-inc/authkit-react`); adds `authLoading` and `getAccessToken` to the effect dependencies.
- Adds tests: the claim waits and includes a Bearer token once loaded; the authorization callback still posts to `/authorize/complete` even if `isLoading` remains true.

<sup>Written for commit a4734676e18cb977c5ac09bda43cbd75dc6923ba. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/MCPJam/inspector/pull/4043?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

