### PR TITLE
Mirror the journeyRunsPerDay gate, and catch the next phantom path parameter

### DIFF
--- a/mcpjam-inspector/client/src/hooks/useOrganizationBilling.ts
+++ b/mcpjam-inspector/client/src/hooks/useOrganizationBilling.ts
@@ -41,7 +41,12 @@ export type PremiumnessGateKey =
   | "maxChatboxesPerProject"
   | "maxEvalRunsPerMonth"
   | "maxEvalIterationsPerMonth"
-  | "insightsPerDay";
+  | "insightsPerDay"
+  // Paired with the backend's gate of the same name. A gate key with no entry
+  // here still ARRIVES — `GateDecision.gateKey` is whatever the backend sent —
+  // and falls through `formatPremiumnessGateKey` to be rendered verbatim, so
+  // the user reads "journeyRunsPerDay is not included in the Free plan".
+  | "journeyRunsPerDay";
 
 export type BillingEnforcementState =
   | "active"

--- a/mcpjam-inspector/client/src/lib/__tests__/billing-entitlements.test.ts
+++ b/mcpjam-inspector/client/src/lib/__tests__/billing-entitlements.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, it } from "vitest";
 import {
   BILLING_FEATURE_BY_TAB,
   formatBillingLimitReachedMessage,
+  formatPremiumnessGateKey,
   getBillingErrorMessage,
   getDisplayPriceCentsForPlan,
   getPremiumnessGateForTab,
@@ -12,6 +13,7 @@ import {
 } from "../billing-entitlements";
 import type {
   PlanCatalogEntry,
+  PremiumnessGateKey,
   PremiumnessState,
 } from "@/hooks/useOrganizationBilling";
 
@@ -495,5 +497,42 @@ describe("isPremiumnessGateDeniedForShell", () => {
       }),
     });
     expect(denied).toBe(true);
+  });
+});
+
+describe("formatPremiumnessGateKey", () => {
+  it("names the daily journey launch gate", () => {
+    // The gate key ARRIVES whether or not this file knows it — the backend
+    // sends `GateDecision.gateKey` verbatim — so a missing case is not a crash,
+    // it is the raw key rendered at a user: "journeyRunsPerDay is not included
+    // in the Free plan". This pairs with the backend gate of the same name.
+    expect(formatPremiumnessGateKey("journeyRunsPerDay")).toBe(
+      "Journey launches per day"
+    );
+  });
+
+  it("names every gate key it declares", () => {
+    // The union is a hand-mirror of the backend's gate list. A key added there
+    // and mirrored here but never given a label falls through to the default
+    // and reads as an identifier — which is the whole failure this map exists
+    // to prevent, so catch it as a set rather than one case at a time.
+    const gateKeys: PremiumnessGateKey[] = [
+      "chatboxes",
+      "evals",
+      "cicd",
+      "auditLog",
+      "maxMembers",
+      "maxProjects",
+      "maxServersPerProject",
+      "maxChatboxesPerProject",
+      "maxEvalRunsPerMonth",
+      "maxEvalIterationsPerMonth",
+      "insightsPerDay",
+      "journeyRunsPerDay",
+    ];
+
+    for (const key of gateKeys) {
+      expect(formatPremiumnessGateKey(key), key).not.toBe(key);
+    }
   });
 });

--- a/mcpjam-inspector/client/src/lib/billing-entitlements.ts
+++ b/mcpjam-inspector/client/src/lib/billing-entitlements.ts
@@ -173,6 +173,8 @@ export function formatPremiumnessGateKey(gateKey: PremiumnessGateKey): string {
       return "Eval iterations per month";
     case "insightsPerDay":
       return "Insights per day";
+    case "journeyRunsPerDay":
+      return "Journey launches per day";
     default:
       return gateKey;
   }

--- a/mcpjam-inspector/server/routes/v1/__tests__/openapi-drift.test.ts
+++ b/mcpjam-inspector/server/routes/v1/__tests__/openapi-drift.test.ts
@@ -18,11 +18,17 @@ const spec = JSON.parse(
   )
 ) as {
   security?: unknown[];
+  components?: { parameters?: Record<string, { name?: string; in?: string }> };
   paths: Record<
     string,
     Record<
       string,
-      { operationId?: string; requestBody?: unknown; security?: unknown[] }
+      {
+        operationId?: string;
+        requestBody?: unknown;
+        security?: unknown[];
+        parameters?: Array<{ $ref?: string; name?: string; in?: string }>;
+      }
     >
   >;
 };
@@ -279,5 +285,56 @@ describe("openapi.json ↔ /api/v1 route parity", () => {
         "\n  "
       )}`
     ).toEqual([]);
+  });
+
+  it("declares a path parameter for every placeholder, and no phantoms", () => {
+    // A path item can name a parameter its URL does not contain, or contain one
+    // it never names, and nothing else notices: the route still serves, the
+    // drift check above still matches on path+method, and the playground just
+    // renders the wrong field. `requestEvalRunInsights` shipped with a phantom
+    // `scenarioId` and no `runId` — a copy-paste from the surrounding
+    // user-testing operations — and was found by a person reading, which is not
+    // a mechanism.
+    //
+    // Both directions, because they are different bugs: a MISSING parameter
+    // makes the operation uncallable from a generated client, and a PHANTOM one
+    // asks the caller for an id the route will never read.
+    const shared = spec.components?.parameters ?? {};
+    const resolve = (p: { $ref?: string; name?: string; in?: string }) =>
+      p.$ref ? shared[p.$ref.split("/").pop() ?? ""] ?? {} : p;
+
+    const problems: string[] = [];
+    for (const [path, item] of Object.entries(spec.paths)) {
+      const placeholders = new Set(
+        [...path.matchAll(/\{([^}]+)\}/g)].map((m) => m[1]!)
+      );
+      const itemLevel = (
+        (item as { parameters?: Array<{ $ref?: string }> }).parameters ?? []
+      ).map(resolve);
+
+      for (const [method, op] of Object.entries(item)) {
+        if (!HTTP_METHODS.has(method.toUpperCase())) continue;
+        const declared = [...itemLevel, ...(op.parameters ?? []).map(resolve)];
+        const named = new Set(
+          declared.filter((p) => p.in === "path").map((p) => p.name)
+        );
+        for (const placeholder of placeholders) {
+          if (!named.has(placeholder)) {
+            problems.push(
+              `${method} ${path}: no parameter for {${placeholder}}`
+            );
+          }
+        }
+        for (const name of named) {
+          if (name && !placeholders.has(name)) {
+            problems.push(
+              `${method} ${path}: declares {${name}}, not in the path`
+            );
+          }
+        }
+      }
+    }
+
+    expect(problems.sort(), problems.sort().join("\n")).toEqual([]);
   });
 });


### PR DESCRIPTION
Two follow-ups to #4045, both closing gaps that shipped with it.

## The gate mirror is one entry short, on main, right now

MCPJam/mcpjam-backend#995 added a `journeyRunsPerDay` **premiumness gate** — deliberately, so the client would have a name for the refusal instead of rendering the raw key. The inspector half of that mirror never landed: `PremiumnessGateKey` still stops at `insightsPerDay`, and its own comment claims it "mirrors backend premiumness gate keys exactly."

The failure mode is not a crash and not a silent skip. `GateDecision.gateKey` is whatever the backend sent, so the key **arrives**, falls through `formatPremiumnessGateKey`'s default, and a person reads:

> journeyRunsPerDay is not included in the Free plan

Both halves needed it — the union and the label map.

The label test covers the **whole union**, not just the new key. A gate added upstream and mirrored here but never labelled is exactly the failure the map exists to prevent, and checking it as a set catches the next one without anybody having to remember.

## A phantom path parameter had nothing watching for it

`requestEvalRunInsights` shipped with a `scenarioId` parameter on a path whose only placeholder is `{runId}` — copy-paste from the surrounding user-testing operations. It was found by a person reading the spec, which is not a mechanism.

Nothing else could have caught it. The route still serves; the drift check matches on path plus method and never opens the parameter list; the playground just renders the wrong field. With the spec now at 140 operations, that is worth a guard.

Checks both directions, because they are different bugs:

- a **missing** parameter makes the operation uncallable from a generated client;
- a **phantom** one asks the caller for an id the route will never read.

Verified against the original defect rather than asserted: reintroducing it into the spec fails the test with both halves named separately.

```
post /projects/{projectId}/eval-runs/{runId}/insights: declares {scenarioId}, not in the path
post /projects/{projectId}/eval-runs/{runId}/insights: no parameter for {runId}
```

The spec passes clean as it stands — all 140 operations.

## Verification

v1 route tests plus the billing mirror: **803 passing**. No production behaviour changes; one user-visible string stops being an identifier.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017ybHEdqRFysaSdU6Rf3p9M

---
_Generated by [Claude Code](https://claude.ai/code/session_017ybHEdqRFysaSdU6Rf3p9M)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit 9d95e7f9d2114823cbe65a22be6772cd567f4984. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Mirrors the backend `journeyRunsPerDay` premiumness gate and adds a test that fails when a path’s placeholders and declared parameters do not match. This prevents raw identifiers from showing to users and catches phantom or missing path parameters.

- No behavior changes beyond copy: users now see “Journey launches per day” instead of the raw key.

**Billing gate mirror**
- Adds `journeyRunsPerDay` to `PremiumnessGateKey` and maps it to “Journey launches per day”.
- Tests that every declared gate key has a non-identifier label to prevent future misses.

**OpenAPI path parameter guard**
- Fails if a path contains a `{placeholder}` without a matching `in: path` parameter, or if a path parameter is declared but not present in the URL.
- Resolves `$ref` parameters from `components` and merges item- and operation-level parameters.

<sup>Written for commit 9d95e7f9d2114823cbe65a22be6772cd567f4984. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/MCPJam/inspector/pull/4047?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

