### PR TITLE
fix(billing): limit-wall upgrade path, rebased on main

### DIFF
--- a/mcpjam-inspector/client/src/App.tsx
+++ b/mcpjam-inspector/client/src/App.tsx
@@ -14,6 +14,7 @@ import { useAuth } from "@workos-inc/authkit-react";
 import { AlertTriangle, Loader2, MessageSquare, Users } from "lucide-react";
 import { toast } from "@/lib/toast";
 import { MCPJamLimitDialog } from "./components/mcpjam-limit-dialog";
+import { PlanLimitDialog } from "./components/billing/PlanLimitDialog";
 import { HomeTab } from "./components/HomeTab";
 import { ServersTab } from "./components/ServersTab";
 import { ToolsTab } from "./components/ToolsTab";
@@ -4696,6 +4697,7 @@ export default function App() {
           >
             <Toaster />
             <MCPJamLimitDialog />
+            <PlanLimitDialog />
             <div
               data-testid="app-shell"
               aria-hidden={shouldShowBillingHandoffOverlay || undefined}

--- a/mcpjam-inspector/client/src/components/CiEvalsTab.tsx
+++ b/mcpjam-inspector/client/src/components/CiEvalsTab.tsx
@@ -115,6 +115,7 @@ export function CiEvalsTab({
       : null;
 
   const {
+    organizationId,
     connectedServerNames,
     userMap,
     canDeleteSuite,
@@ -319,6 +320,9 @@ export function CiEvalsTab({
     selectedSuiteEntry,
     selectedSuiteId,
     selectedTestId,
+    // Without this the Runs lens can't open the upgrade wall on a server-side
+    // cap rejection and falls back to the dead-end toast.
+    organizationId,
     connectedServerNames,
     ensureServersReady,
     latestRunBySuiteId,

--- a/mcpjam-inspector/client/src/components/EvalsTab.tsx
+++ b/mcpjam-inspector/client/src/components/EvalsTab.tsx
@@ -62,6 +62,7 @@ import {
   type CreateSuitePayload,
 } from "./evals/create-suite-dialog";
 import { getEvalIterationQuotaDisabledReason } from "@/lib/eval-iteration-quota";
+import { usePlanLimitDialogStore } from "@/stores/plan-limit-dialog-store";
 import { track } from "@/lib/analytics";
 import type { EvalChatHandoff } from "@/lib/eval-chat-handoff";
 import type { EnsureServersReadyResult } from "@/hooks/use-app-state";
@@ -263,9 +264,24 @@ function EvalsTabContent({
     if (!evalRunsDisabledReason) {
       return true;
     }
+    // The user just clicked Run — highest-intent moment there is. Give them a
+    // decision surface instead of a dismissible error. Falls back to the
+    // toast when we can't resolve the org (nothing to upgrade).
+    if (organizationId && evalIterationQuota) {
+      usePlanLimitDialogStore.getState().open({
+        kind: "evalIterations",
+        organizationId,
+        used: evalIterationQuota.used,
+        allowed: evalIterationQuota.allowed,
+        resetsAt: evalIterationQuota.resetsAt,
+        windowKind: evalIterationQuota.windowKind,
+        origin: "evals",
+      });
+      return false;
+    }
     toast.error(evalRunsDisabledReason);
     return false;
-  }, [evalRunsDisabledReason]);
+  }, [evalIterationQuota, evalRunsDisabledReason, organizationId]);
 
   const handleRerunWithQuota = useCallback(
     (...args: Parameters<typeof handlers.handleRerun>) => {

--- a/mcpjam-inspector/client/src/components/EvalsTab.tsx
+++ b/mcpjam-inspector/client/src/components/EvalsTab.tsx
@@ -245,6 +245,7 @@ function EvalsTabContent({
     selectedSuiteId,
     selectedTestId,
     projectId: projectId ?? null,
+    organizationId,
     connectedServerNames,
     ensureServersReady,
     latestRunBySuiteId,

--- a/mcpjam-inspector/client/src/components/__tests__/CiEvalsTab.test.tsx
+++ b/mcpjam-inspector/client/src/components/__tests__/CiEvalsTab.test.tsx
@@ -12,6 +12,7 @@ const mocks = vi.hoisted(() => ({
     current: { type: "list" as const } as any,
   },
   useEvalQueries: vi.fn(),
+  useEvalHandlers: vi.fn(),
   deleteSuiteMutation: vi.fn(),
   directDeleteRun: vi.fn().mockResolvedValue(undefined),
 }));
@@ -92,18 +93,21 @@ vi.mock("../evals/use-eval-queries", () => ({
 }));
 
 vi.mock("../evals/use-eval-handlers", () => ({
-  useEvalHandlers: () => ({
-    handleRerun: vi.fn(),
-    handleReplayRun: vi.fn(),
-    handleCancelRun: vi.fn(),
-    directDeleteRun: mocks.directDeleteRun,
-    rerunningSuiteId: null,
-    replayingRunId: null,
-    cancellingRunId: null,
-    handleCreateTestCase: vi.fn(),
-    handleDuplicateTestCase: vi.fn(),
-    handleGenerateTests: vi.fn(),
-  }),
+  useEvalHandlers: (props: unknown) => {
+    mocks.useEvalHandlers(props);
+    return {
+      handleRerun: vi.fn(),
+      handleReplayRun: vi.fn(),
+      handleCancelRun: vi.fn(),
+      directDeleteRun: mocks.directDeleteRun,
+      rerunningSuiteId: null,
+      replayingRunId: null,
+      cancellingRunId: null,
+      handleCreateTestCase: vi.fn(),
+      handleDuplicateTestCase: vi.fn(),
+      handleGenerateTests: vi.fn(),
+    };
+  },
 }));
 
 vi.mock("../evals/use-suite-data", () => ({
@@ -165,6 +169,7 @@ vi.mock("../evals/trace-viewer", () => ({
 
 vi.mock("@/hooks/use-eval-tab-context", () => ({
   useEvalTabContext: () => ({
+    organizationId: "org-1",
     connectedServerNames: new Set(),
     userMap: new Map(),
     canDeleteSuite: false,
@@ -350,6 +355,16 @@ describe("CiEvalsTab first-run NUX", () => {
 
     expect(screen.queryByText("Run your first eval")).not.toBeInTheDocument();
     expect(screen.getByTestId("project-runs-table")).toBeInTheDocument();
+  });
+
+  it("passes the project's organizationId to the eval handlers", () => {
+    // Without it, `openEvalIterationWall` bails out and a server-side cap
+    // rejection from this lens falls back to the dead-end toast.
+    render(<CiEvalsTab convexProjectId="ws-1" />);
+
+    expect(mocks.useEvalHandlers).toHaveBeenCalledWith(
+      expect.objectContaining({ organizationId: "org-1" }),
+    );
   });
 
   it("includes ui-created suites that CI has reported into", () => {

--- a/mcpjam-inspector/client/src/components/__tests__/CiEvalsTab.test.tsx
+++ b/mcpjam-inspector/client/src/components/__tests__/CiEvalsTab.test.tsx
@@ -13,6 +13,7 @@ const mocks = vi.hoisted(() => ({
   },
   useEvalQueries: vi.fn(),
   useEvalHandlers: vi.fn(),
+  evalTabContext: { organizationId: "org-1" as string | null },
   deleteSuiteMutation: vi.fn(),
   directDeleteRun: vi.fn().mockResolvedValue(undefined),
 }));
@@ -169,7 +170,7 @@ vi.mock("../evals/trace-viewer", () => ({
 
 vi.mock("@/hooks/use-eval-tab-context", () => ({
   useEvalTabContext: () => ({
-    organizationId: "org-1",
+    organizationId: mocks.evalTabContext.organizationId,
     connectedServerNames: new Set(),
     userMap: new Map(),
     canDeleteSuite: false,
@@ -218,7 +219,7 @@ function makeSuite(overrides: Partial<EvalSuite> = {}): EvalSuite {
 }
 
 function makeEntry(
-  overrides: Partial<EvalSuiteOverviewEntry> = {},
+  overrides: Partial<EvalSuiteOverviewEntry> = {}
 ): EvalSuiteOverviewEntry {
   const latestRun =
     overrides.latestRun === undefined ? null : overrides.latestRun;
@@ -237,7 +238,7 @@ function makeEntry(
 }
 
 function makeQueries(
-  overrides: Partial<ReturnType<typeof baseQueries>> = {},
+  overrides: Partial<ReturnType<typeof baseQueries>> = {}
 ): ReturnType<typeof baseQueries> {
   return {
     ...baseQueries(),
@@ -268,6 +269,7 @@ describe("CiEvalsTab first-run NUX", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     mocks.route.current = { type: "list" };
+    mocks.evalTabContext.organizationId = "org-1";
     mocks.useEvalQueries.mockReturnValue(baseQueries());
   });
 
@@ -275,7 +277,7 @@ describe("CiEvalsTab first-run NUX", () => {
     mocks.useEvalQueries.mockReturnValue(
       makeQueries({
         isOverviewLoading: true,
-      }),
+      })
     );
 
     render(<CiEvalsTab convexProjectId="ws-1" />);
@@ -290,7 +292,7 @@ describe("CiEvalsTab first-run NUX", () => {
     expect(screen.getByText("Run your first eval")).toBeInTheDocument();
     expect(screen.getByTestId("sdk-eval-quickstart")).toBeInTheDocument();
     expect(
-      screen.queryByText("Select a suite or commit"),
+      screen.queryByText("Select a suite or commit")
     ).not.toBeInTheDocument();
   });
 
@@ -299,7 +301,7 @@ describe("CiEvalsTab first-run NUX", () => {
     mocks.useEvalQueries.mockReturnValue(
       makeQueries({
         sortedSuites: [makeEntry()],
-      }),
+      })
     );
 
     render(<CiEvalsTab convexProjectId="ws-1" />);
@@ -314,7 +316,7 @@ describe("CiEvalsTab first-run NUX", () => {
     mocks.useEvalQueries.mockReturnValue(
       makeQueries({
         sortedSuites: [makeEntry({ latestRun: run, recentRuns: [run] })],
-      }),
+      })
     );
 
     render(<CiEvalsTab convexProjectId="ws-1" />);
@@ -327,7 +329,7 @@ describe("CiEvalsTab first-run NUX", () => {
     mocks.useEvalQueries.mockReturnValue(
       makeQueries({
         sortedSuites: [makeEntry({ suite: makeSuite({ source: "ui" }) })],
-      }),
+      })
     );
 
     render(<CiEvalsTab convexProjectId="ws-1" />);
@@ -348,7 +350,7 @@ describe("CiEvalsTab first-run NUX", () => {
             recentRuns: [run],
           }),
         ],
-      }),
+      })
     );
 
     render(<CiEvalsTab convexProjectId="ws-1" />);
@@ -363,7 +365,19 @@ describe("CiEvalsTab first-run NUX", () => {
     render(<CiEvalsTab convexProjectId="ws-1" />);
 
     expect(mocks.useEvalHandlers).toHaveBeenCalledWith(
-      expect.objectContaining({ organizationId: "org-1" }),
+      expect.objectContaining({ organizationId: "org-1" })
+    );
+  });
+
+  it("passes null through when the project has no organization", () => {
+    // A personal/local project has none. The handlers must receive the real
+    // absence rather than a stale id from a previously scoped project.
+    mocks.evalTabContext.organizationId = null;
+
+    render(<CiEvalsTab convexProjectId="ws-1" />);
+
+    expect(mocks.useEvalHandlers).toHaveBeenCalledWith(
+      expect.objectContaining({ organizationId: null })
     );
   });
 
@@ -376,7 +390,7 @@ describe("CiEvalsTab first-run NUX", () => {
             suite: makeSuite({ source: "ui", lastSdkRunAt: 123 }),
           }),
         ],
-      }),
+      })
     );
 
     render(<CiEvalsTab convexProjectId="ws-1" />);

--- a/mcpjam-inspector/client/src/components/__tests__/MCPJamLimitDialog.test.tsx
+++ b/mcpjam-inspector/client/src/components/__tests__/MCPJamLimitDialog.test.tsx
@@ -47,10 +47,9 @@ vi.mock("@/hooks/use-upgrade-checkout", () => ({
 }));
 
 vi.mock("@/hooks/use-upgrade-request-recipients", () => ({
-  useUpgradeRequestRecipients: () => ({
-    recipients: [{ email: "dana@acme.test", name: "Dana Ruiz" }],
-    isLoading: false,
-  }),
+  useUpgradeRequestRecipients: () => [
+    { email: "dana@acme.test", name: "Dana Ruiz" },
+  ],
 }));
 
 vi.mock("@workos-inc/authkit-react", () => ({

--- a/mcpjam-inspector/client/src/components/__tests__/MCPJamLimitDialog.test.tsx
+++ b/mcpjam-inspector/client/src/components/__tests__/MCPJamLimitDialog.test.tsx
@@ -31,8 +31,8 @@ vi.mock("@/hooks/use-upgrade-checkout", () => ({
   useUpgradeCheckout: () => ({
     interval: "annual",
     setInterval: vi.fn(),
-    annualPriceLabel: "$30/seat/mo",
-    monthlyPriceLabel: "$38/seat/mo",
+    annualPriceLabel: "$30",
+    monthlyPriceLabel: "$38",
     annualDiscountPct: 21,
     annualSupported: true,
     monthlySupported: true,
@@ -47,9 +47,10 @@ vi.mock("@/hooks/use-upgrade-checkout", () => ({
 }));
 
 vi.mock("@/hooks/use-upgrade-request-recipients", () => ({
-  useUpgradeRequestRecipients: () => [
-    { email: "dana@acme.test", name: "Dana Ruiz" },
-  ],
+  useUpgradeRequestRecipients: () => ({
+    recipients: [{ email: "dana@acme.test", name: "Dana Ruiz" }],
+    isLoading: false,
+  }),
 }));
 
 vi.mock("@workos-inc/authkit-react", () => ({

--- a/mcpjam-inspector/client/src/components/__tests__/MCPJamLimitDialog.test.tsx
+++ b/mcpjam-inspector/client/src/components/__tests__/MCPJamLimitDialog.test.tsx
@@ -7,6 +7,8 @@ import { useModelPickerIntentStore } from "@/stores/model-picker-intent-store";
 
 const signIn = vi.fn();
 const trackMock = vi.hoisted(() => vi.fn());
+const upgradeHookOrganizationIdMock = vi.hoisted(() => vi.fn());
+const recipientHookOrganizationIdMock = vi.hoisted(() => vi.fn());
 const recipientsState = vi.hoisted(() => ({
   recipients: [{ email: "dana@acme.test", name: "Dana Ruiz" }],
   isLoading: false,
@@ -34,30 +36,40 @@ const upgradeState = {
 // pulling the Convex plan-catalog queries into a mock that only exports
 // useConvexAuth.
 vi.mock("@/hooks/use-upgrade-checkout", () => ({
-  useUpgradeCheckout: () => ({
-    interval: "annual",
-    setInterval: vi.fn(),
-    annualPriceLabel: "$30",
-    monthlyPriceLabel: "$38",
-    annualDiscountPct: 21,
-    annualSupported: true,
-    monthlySupported: true,
-    teamName: "Team",
-    teamEvalIterations: 15000,
-    currentPlan: upgradeState.currentPlan,
-    effectivePlan: upgradeState.effectivePlan,
-    organizationName: "Acme Robotics",
-    canManageBilling: upgradeState.canManageBilling,
-    isLoadingBilling: false,
-    isStarting: false,
-    start: upgradeState.start,
-  }),
+  useUpgradeCheckout: ({
+    organizationId,
+  }: {
+    organizationId: string | null;
+  }) => {
+    upgradeHookOrganizationIdMock(organizationId);
+    return {
+      interval: "annual",
+      setInterval: vi.fn(),
+      annualPriceLabel: "$30",
+      monthlyPriceLabel: "$38",
+      annualDiscountPct: 21,
+      annualSupported: true,
+      monthlySupported: true,
+      teamName: "Team",
+      teamEvalIterations: 15000,
+      currentPlan: upgradeState.currentPlan,
+      effectivePlan: upgradeState.effectivePlan,
+      organizationName: "Acme Robotics",
+      canManageBilling: upgradeState.canManageBilling,
+      isLoadingBilling: false,
+      isStarting: false,
+      start: upgradeState.start,
+    };
+  },
 }));
 
 vi.mock("@/lib/analytics", () => ({ track: trackMock }));
 
 vi.mock("@/hooks/use-upgrade-request-recipients", () => ({
-  useUpgradeRequestRecipients: () => recipientsState,
+  useUpgradeRequestRecipients: (organizationId: string | null) => {
+    recipientHookOrganizationIdMock(organizationId);
+    return recipientsState;
+  },
 }));
 
 vi.mock("@workos-inc/authkit-react", () => ({
@@ -94,6 +106,8 @@ const originalHash = window.location.hash;
 beforeEach(() => {
   signIn.mockReset();
   trackMock.mockReset();
+  upgradeHookOrganizationIdMock.mockReset();
+  recipientHookOrganizationIdMock.mockReset();
   upgradeState.start.mockReset();
   upgradeState.currentPlan = "free";
   upgradeState.effectivePlan = "free";
@@ -126,6 +140,16 @@ describe("MCPJamLimitDialog", () => {
   it("renders nothing while closed", () => {
     const { container } = render(<MCPJamLimitDialog />);
     expect(container).toBeEmptyDOMElement();
+  });
+
+  it("does not subscribe to billing or owner members while closed", () => {
+    authState.user = { id: "user-1" };
+    localStorage.setItem("active-organization-id:user-1", "org-active");
+
+    render(<MCPJamLimitDialog />);
+
+    expect(upgradeHookOrganizationIdMock).toHaveBeenLastCalledWith(null);
+    expect(recipientHookOrganizationIdMock).toHaveBeenLastCalledWith(null);
   });
 
   it("renders the dialog with guest copy when the store opens", () => {
@@ -205,6 +229,24 @@ describe("MCPJamLimitDialog", () => {
     expect(
       screen.getByRole("button", { name: /use your own API key/i })
     ).toBeInTheDocument();
+    expect(upgradeHookOrganizationIdMock).toHaveBeenLastCalledWith("org-1");
+    expect(recipientHookOrganizationIdMock).toHaveBeenLastCalledWith("org-1");
+  });
+
+  it("closes after an in-place plan change succeeds", async () => {
+    const user = userEvent.setup();
+    authState.user = { id: "user-1" };
+    sortedOrganizationsState.push({ _id: "org-1", myRole: "owner" });
+    upgradeState.start.mockResolvedValue({
+      redirected: false,
+      shouldDismiss: true,
+    });
+    useMCPJamLimitDialogStore.setState({ isOpen: true, intent: "topup" });
+    render(<MCPJamLimitDialog />);
+
+    await user.click(screen.getByTestId("upgrade-plan-cta"));
+
+    expect(useMCPJamLimitDialogStore.getState().isOpen).toBe(false);
   });
 
   it("does not pitch Team when a Team trial runs out of credits", () => {

--- a/mcpjam-inspector/client/src/components/__tests__/MCPJamLimitDialog.test.tsx
+++ b/mcpjam-inspector/client/src/components/__tests__/MCPJamLimitDialog.test.tsx
@@ -7,6 +7,10 @@ import { useModelPickerIntentStore } from "@/stores/model-picker-intent-store";
 
 const signIn = vi.fn();
 const trackMock = vi.hoisted(() => vi.fn());
+const recipientsState = vi.hoisted(() => ({
+  recipients: [{ email: "dana@acme.test", name: "Dana Ruiz" }],
+  isLoading: false,
+}));
 const authState: { isLoading: boolean; user: { id: string } | null } = {
   isLoading: false,
   user: null,
@@ -53,9 +57,7 @@ vi.mock("@/hooks/use-upgrade-checkout", () => ({
 vi.mock("@/lib/analytics", () => ({ track: trackMock }));
 
 vi.mock("@/hooks/use-upgrade-request-recipients", () => ({
-  useUpgradeRequestRecipients: () => [
-    { email: "dana@acme.test", name: "Dana Ruiz" },
-  ],
+  useUpgradeRequestRecipients: () => recipientsState,
 }));
 
 vi.mock("@workos-inc/authkit-react", () => ({
@@ -96,6 +98,8 @@ beforeEach(() => {
   upgradeState.currentPlan = "free";
   upgradeState.effectivePlan = "free";
   upgradeState.canManageBilling = true;
+  recipientsState.recipients = [{ email: "dana@acme.test", name: "Dana Ruiz" }];
+  recipientsState.isLoading = false;
   authState.isLoading = false;
   authState.user = null;
   sortedOrganizationsState.length = 0;
@@ -240,6 +244,35 @@ describe("MCPJamLimitDialog", () => {
     expect(screen.getByTestId("request-upgrade-mail")).toHaveAttribute(
       "href",
       expect.stringContaining("mailto:dana@acme.test")
+    );
+  });
+
+  it("waits for owner recipients before reporting a member impression", () => {
+    authState.user = { id: "user-1" };
+    sortedOrganizationsState.push({ _id: "org-1", myRole: "member" });
+    recipientsState.recipients = [];
+    recipientsState.isLoading = true;
+    useMCPJamLimitDialogStore.setState({ isOpen: true, intent: "topup" });
+    const view = render(<MCPJamLimitDialog />);
+
+    expect(trackMock).not.toHaveBeenCalledWith(
+      "plan_limit_dialog_shown",
+      expect.anything()
+    );
+
+    recipientsState.recipients = [
+      { email: "dana@acme.test", name: "Dana Ruiz" },
+    ];
+    recipientsState.isLoading = false;
+    view.rerender(<MCPJamLimitDialog />);
+
+    expect(trackMock).toHaveBeenCalledWith(
+      "plan_limit_dialog_shown",
+      expect.objectContaining({
+        wall_kind: "organization_credits",
+        primary_action: "request_owner",
+        request_recipient_count: 1,
+      })
     );
   });
 

--- a/mcpjam-inspector/client/src/components/__tests__/MCPJamLimitDialog.test.tsx
+++ b/mcpjam-inspector/client/src/components/__tests__/MCPJamLimitDialog.test.tsx
@@ -19,6 +19,7 @@ const sortedOrganizationsState: Array<{
 
 const upgradeState = {
   currentPlan: "free" as string,
+  effectivePlan: "free" as string,
   canManageBilling: true,
   start: vi.fn(),
 };
@@ -39,6 +40,7 @@ vi.mock("@/hooks/use-upgrade-checkout", () => ({
     teamName: "Team",
     teamEvalIterations: 15000,
     currentPlan: upgradeState.currentPlan,
+    effectivePlan: upgradeState.effectivePlan,
     organizationName: "Acme Robotics",
     canManageBilling: upgradeState.canManageBilling,
     isStarting: false,
@@ -87,6 +89,7 @@ beforeEach(() => {
   signIn.mockReset();
   upgradeState.start.mockReset();
   upgradeState.currentPlan = "free";
+  upgradeState.effectivePlan = "free";
   upgradeState.canManageBilling = true;
   authState.isLoading = false;
   authState.user = null;
@@ -173,6 +176,23 @@ describe("MCPJamLimitDialog", () => {
     ).toBeInTheDocument();
     expect(
       screen.getByRole("button", { name: /use your own API key/i })
+    ).toBeInTheDocument();
+  });
+
+  it("does not pitch Team when a Team trial runs out of credits", () => {
+    authState.user = { id: "user-1" };
+    sortedOrganizationsState.push({ _id: "org-1", myRole: "owner" });
+    upgradeState.currentPlan = "free";
+    upgradeState.effectivePlan = "team";
+    useMCPJamLimitDialogStore.setState({ isOpen: true, intent: "topup" });
+    render(<MCPJamLimitDialog />);
+
+    expect(screen.getByTestId("limit-dialog-description")).toHaveTextContent(
+      /Buy credits to keep your team going/
+    );
+    expect(screen.queryByTestId("upgrade-plan-cta")).not.toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: /^buy credits$/i })
     ).toBeInTheDocument();
   });
 

--- a/mcpjam-inspector/client/src/components/__tests__/MCPJamLimitDialog.test.tsx
+++ b/mcpjam-inspector/client/src/components/__tests__/MCPJamLimitDialog.test.tsx
@@ -29,9 +29,8 @@ const upgradeState = {
 // useConvexAuth.
 vi.mock("@/hooks/use-upgrade-checkout", () => ({
   useUpgradeCheckout: () => ({
-    interval: "annual",
-    setInterval: vi.fn(),
-    priceLabel: "$30/seat/mo",
+    annualPriceLabel: "$30/seat/mo",
+    monthlyPriceLabel: "$38/seat/mo",
     annualDiscountPct: 21,
     annualSupported: true,
     monthlySupported: true,

--- a/mcpjam-inspector/client/src/components/__tests__/MCPJamLimitDialog.test.tsx
+++ b/mcpjam-inspector/client/src/components/__tests__/MCPJamLimitDialog.test.tsx
@@ -29,6 +29,8 @@ const upgradeState = {
 // useConvexAuth.
 vi.mock("@/hooks/use-upgrade-checkout", () => ({
   useUpgradeCheckout: () => ({
+    interval: "annual",
+    setInterval: vi.fn(),
     annualPriceLabel: "$30/seat/mo",
     monthlyPriceLabel: "$38/seat/mo",
     annualDiscountPct: 21,
@@ -37,10 +39,17 @@ vi.mock("@/hooks/use-upgrade-checkout", () => ({
     teamName: "Team",
     teamEvalIterations: 15000,
     currentPlan: upgradeState.currentPlan,
+    organizationName: "Acme Robotics",
     canManageBilling: upgradeState.canManageBilling,
     isStarting: false,
     start: upgradeState.start,
   }),
+}));
+
+vi.mock("@/hooks/use-upgrade-request-recipients", () => ({
+  useUpgradeRequestRecipients: () => [
+    { email: "dana@acme.test", name: "Dana Ruiz" },
+  ],
 }));
 
 vi.mock("@workos-inc/authkit-react", () => ({
@@ -176,13 +185,18 @@ describe("MCPJamLimitDialog", () => {
     expect(screen.getByTestId("limit-dialog-description")).toHaveTextContent(
       /Ask an organization owner or admin to buy credits or upgrade/
     );
-    // Members get no CTAs at all: no upgrade, no buy credits, no BYOK.
+    // Members can't buy or upgrade, so those CTAs stay gone. They now get one
+    // action: email an owner who can.
     expect(
       screen.queryByRole("button", { name: /^buy credits$/i })
     ).not.toBeInTheDocument();
     expect(
       screen.queryByRole("button", { name: /use your own API key/i })
     ).not.toBeInTheDocument();
+    expect(screen.getByTestId("request-upgrade-mail")).toHaveAttribute(
+      "href",
+      expect.stringContaining("mailto:dana@acme.test")
+    );
   });
 
   it("opens the model picker's Your providers tab on BYOK click (no org redirect)", async () => {

--- a/mcpjam-inspector/client/src/components/__tests__/MCPJamLimitDialog.test.tsx
+++ b/mcpjam-inspector/client/src/components/__tests__/MCPJamLimitDialog.test.tsx
@@ -266,15 +266,20 @@ describe("MCPJamLimitDialog", () => {
     ).toBeInTheDocument();
   });
 
-  it("shows the ask-admin copy and no CTAs for org members", () => {
+  it("shows the ask-owner copy and no CTAs for org members", () => {
     authState.user = { id: "user-1" };
     sortedOrganizationsState.push({ _id: "org-1", myRole: "member" });
     useMCPJamLimitDialogStore.setState({ isOpen: true, intent: "topup" });
     render(<MCPJamLimitDialog />);
 
+    // Owners, not admins: the only action here emails the resolved owners, and
+    // an admin can't upgrade anyway.
     expect(screen.getByTestId("limit-dialog-description")).toHaveTextContent(
-      /Ask an organization owner or admin to buy credits or upgrade/
+      /Ask an organization owner to buy credits or upgrade/
     );
+    expect(
+      screen.getByTestId("limit-dialog-description")
+    ).not.toHaveTextContent(/admin/i);
     // Members can't buy or upgrade, so those CTAs stay gone. They now get one
     // action: email an owner who can.
     expect(
@@ -283,10 +288,12 @@ describe("MCPJamLimitDialog", () => {
     expect(
       screen.queryByRole("button", { name: /use your own API key/i })
     ).not.toBeInTheDocument();
-    expect(screen.getByTestId("request-upgrade-mail")).toHaveAttribute(
-      "href",
-      expect.stringContaining("mailto:dana@acme.test")
+    // Decoded first: the address is percent-encoded in the href, so asserting
+    // the raw string would be checking the encoding rather than the recipient.
+    const memberHref = decodeURIComponent(
+      screen.getByTestId("request-upgrade-mail").getAttribute("href") ?? ""
     );
+    expect(memberHref).toContain("mailto:dana@acme.test");
   });
 
   it("waits for owner recipients before reporting a member impression", () => {
@@ -318,6 +325,41 @@ describe("MCPJamLimitDialog", () => {
     );
   });
 
+  it("waits for owner recipients before reporting an admin impression", () => {
+    // An admin can buy credits but can't upgrade, so they still get a
+    // request-an-owner button. Reporting before the owners resolve would
+    // record a recipient count of 0 for a button that then renders.
+    authState.user = { id: "user-1" };
+    sortedOrganizationsState.push({ _id: "org-1", myRole: "admin" });
+    upgradeState.canManageBilling = false;
+    recipientsState.recipients = [];
+    recipientsState.isLoading = true;
+    useMCPJamLimitDialogStore.setState({ isOpen: true, intent: "topup" });
+    const view = render(<MCPJamLimitDialog />);
+
+    expect(trackMock).not.toHaveBeenCalledWith(
+      "plan_limit_dialog_shown",
+      expect.anything()
+    );
+
+    recipientsState.recipients = [
+      { email: "dana@acme.test", name: "Dana Ruiz" },
+    ];
+    recipientsState.isLoading = false;
+    view.rerender(<MCPJamLimitDialog />);
+
+    expect(trackMock).toHaveBeenCalledWith(
+      "plan_limit_dialog_shown",
+      expect.objectContaining({
+        wall_kind: "organization_credits",
+        can_buy_credits: true,
+        can_manage_billing: false,
+        request_recipient_count: 1,
+      })
+    );
+    expect(screen.getByTestId("request-upgrade-mail")).toBeInTheDocument();
+  });
+
   it("asks paid-org members to request credits instead of a Team upgrade", () => {
     authState.user = { id: "user-1" };
     sortedOrganizationsState.push({ _id: "org-1", myRole: "member" });
@@ -327,7 +369,7 @@ describe("MCPJamLimitDialog", () => {
     render(<MCPJamLimitDialog />);
 
     expect(screen.getByTestId("limit-dialog-description")).toHaveTextContent(
-      /Ask an organization owner or admin to buy credits\./
+      /Ask an organization owner to buy credits\./
     );
     const href = decodeURIComponent(
       screen.getByTestId("request-upgrade-mail").getAttribute("href") ?? ""

--- a/mcpjam-inspector/client/src/components/__tests__/MCPJamLimitDialog.test.tsx
+++ b/mcpjam-inspector/client/src/components/__tests__/MCPJamLimitDialog.test.tsx
@@ -219,6 +219,28 @@ describe("MCPJamLimitDialog", () => {
     );
   });
 
+  it("asks paid-org members to request credits instead of a Team upgrade", () => {
+    authState.user = { id: "user-1" };
+    sortedOrganizationsState.push({ _id: "org-1", myRole: "member" });
+    upgradeState.currentPlan = "team";
+    upgradeState.effectivePlan = "team";
+    useMCPJamLimitDialogStore.setState({ isOpen: true, intent: "topup" });
+    render(<MCPJamLimitDialog />);
+
+    expect(screen.getByTestId("limit-dialog-description")).toHaveTextContent(
+      /Ask an organization owner or admin to buy credits\./
+    );
+    const href = decodeURIComponent(
+      screen.getByTestId("request-upgrade-mail").getAttribute("href") ?? ""
+    );
+    expect(href).toContain("Credit purchase request for Acme Robotics");
+    expect(href).toContain(
+      "Our organization has run out of MCPJam credits."
+    );
+    expect(href).toContain("Could you buy more credits for Acme Robotics?");
+    expect(href).not.toContain("upgrade Acme Robotics to the Team plan");
+  });
+
   it("opens the model picker's Your providers tab on BYOK click (no org redirect)", async () => {
     const user = userEvent.setup();
     authState.user = { id: "user-1" };

--- a/mcpjam-inspector/client/src/components/__tests__/MCPJamLimitDialog.test.tsx
+++ b/mcpjam-inspector/client/src/components/__tests__/MCPJamLimitDialog.test.tsx
@@ -17,6 +17,33 @@ const sortedOrganizationsState: Array<{
   isCreator?: boolean;
 }> = [];
 
+const upgradeState = {
+  currentPlan: "free" as string,
+  canManageBilling: true,
+  start: vi.fn(),
+};
+
+// The upgrade path has its own coverage in PlanLimitDialog.test.tsx. Stubbing
+// it here keeps this file focused on the credits routing and copy, and avoids
+// pulling the Convex plan-catalog queries into a mock that only exports
+// useConvexAuth.
+vi.mock("@/hooks/use-upgrade-checkout", () => ({
+  useUpgradeCheckout: () => ({
+    interval: "annual",
+    setInterval: vi.fn(),
+    priceLabel: "$30/seat/mo",
+    annualDiscountPct: 21,
+    annualSupported: true,
+    monthlySupported: true,
+    teamName: "Team",
+    teamEvalIterations: 15000,
+    currentPlan: upgradeState.currentPlan,
+    canManageBilling: upgradeState.canManageBilling,
+    isStarting: false,
+    start: upgradeState.start,
+  }),
+}));
+
 vi.mock("@workos-inc/authkit-react", () => ({
   useAuth: () => ({
     isLoading: authState.isLoading,
@@ -50,6 +77,9 @@ const originalHash = window.location.hash;
 
 beforeEach(() => {
   signIn.mockReset();
+  upgradeState.start.mockReset();
+  upgradeState.currentPlan = "free";
+  upgradeState.canManageBilling = true;
   authState.isLoading = false;
   authState.user = null;
   sortedOrganizationsState.length = 0;
@@ -131,10 +161,10 @@ describe("MCPJamLimitDialog", () => {
       })
     ).toBeInTheDocument();
     expect(
-      screen.getByRole("button", { name: /^top up$/i })
+      screen.getByRole("button", { name: /^buy credits$/i })
     ).toBeInTheDocument();
     expect(
-      screen.getByRole("button", { name: /bring your own key/i })
+      screen.getByRole("button", { name: /use your own API key/i })
     ).toBeInTheDocument();
   });
 
@@ -145,14 +175,14 @@ describe("MCPJamLimitDialog", () => {
     render(<MCPJamLimitDialog />);
 
     expect(screen.getByTestId("limit-dialog-description")).toHaveTextContent(
-      /Ask your org admin to top up credits/
+      /Ask an organization owner or admin to buy credits or upgrade/
     );
-    // Members get no CTAs at all — neither top up nor BYOK.
+    // Members get no CTAs at all: no upgrade, no buy credits, no BYOK.
     expect(
-      screen.queryByRole("button", { name: /^top up$/i })
+      screen.queryByRole("button", { name: /^buy credits$/i })
     ).not.toBeInTheDocument();
     expect(
-      screen.queryByRole("button", { name: /bring your own key/i })
+      screen.queryByRole("button", { name: /use your own API key/i })
     ).not.toBeInTheDocument();
   });
 
@@ -166,7 +196,7 @@ describe("MCPJamLimitDialog", () => {
     render(<MCPJamLimitDialog />);
 
     await user.click(
-      screen.getByRole("button", { name: /bring your own key/i })
+      screen.getByRole("button", { name: /use your own API key/i })
     );
 
     // Closes the dialog and asks the picker to open its "Your providers" tab —
@@ -186,7 +216,7 @@ describe("MCPJamLimitDialog", () => {
     useMCPJamLimitDialogStore.setState({ isOpen: true, intent: "topup" });
     render(<MCPJamLimitDialog />);
 
-    await user.click(screen.getByRole("button", { name: /^top up$/i }));
+    await user.click(screen.getByRole("button", { name: /^buy credits$/i }));
 
     expect(useMCPJamLimitDialogStore.getState().isOpen).toBe(false);
     expect(window.location.pathname).toBe("/organizations/org-active/billing");
@@ -208,7 +238,7 @@ describe("MCPJamLimitDialog", () => {
     });
     render(<MCPJamLimitDialog />);
 
-    await user.click(screen.getByRole("button", { name: /^top up$/i }));
+    await user.click(screen.getByRole("button", { name: /^buy credits$/i }));
 
     expect(window.location.pathname).toBe("/organizations/org-a/billing");
     expect(window.location.search).toBe("?topup=open");
@@ -221,7 +251,7 @@ describe("MCPJamLimitDialog", () => {
     useMCPJamLimitDialogStore.setState({ isOpen: true, intent: "topup" });
     render(<MCPJamLimitDialog />);
 
-    await user.click(screen.getByRole("button", { name: /^top up$/i }));
+    await user.click(screen.getByRole("button", { name: /^buy credits$/i }));
 
     expect(window.location.pathname).toBe(
       "/organizations/org-fallback/billing"
@@ -235,7 +265,7 @@ describe("MCPJamLimitDialog", () => {
     useMCPJamLimitDialogStore.setState({ isOpen: true, intent: "topup" });
     render(<MCPJamLimitDialog />);
 
-    await user.click(screen.getByRole("button", { name: /^top up$/i }));
+    await user.click(screen.getByRole("button", { name: /^buy credits$/i }));
 
     // Modal stays open and no nav happens — once orgs load, the user can
     // click again and be routed correctly.

--- a/mcpjam-inspector/client/src/components/__tests__/MCPJamLimitDialog.test.tsx
+++ b/mcpjam-inspector/client/src/components/__tests__/MCPJamLimitDialog.test.tsx
@@ -6,6 +6,7 @@ import { useMCPJamLimitDialogStore } from "@/stores/mcpjam-limit-dialog-store";
 import { useModelPickerIntentStore } from "@/stores/model-picker-intent-store";
 
 const signIn = vi.fn();
+const trackMock = vi.hoisted(() => vi.fn());
 const authState: { isLoading: boolean; user: { id: string } | null } = {
   isLoading: false,
   user: null,
@@ -43,10 +44,13 @@ vi.mock("@/hooks/use-upgrade-checkout", () => ({
     effectivePlan: upgradeState.effectivePlan,
     organizationName: "Acme Robotics",
     canManageBilling: upgradeState.canManageBilling,
+    isLoadingBilling: false,
     isStarting: false,
     start: upgradeState.start,
   }),
 }));
+
+vi.mock("@/lib/analytics", () => ({ track: trackMock }));
 
 vi.mock("@/hooks/use-upgrade-request-recipients", () => ({
   useUpgradeRequestRecipients: () => [
@@ -87,6 +91,7 @@ const originalHash = window.location.hash;
 
 beforeEach(() => {
   signIn.mockReset();
+  trackMock.mockReset();
   upgradeState.start.mockReset();
   upgradeState.currentPlan = "free";
   upgradeState.effectivePlan = "free";
@@ -132,6 +137,25 @@ describe("MCPJamLimitDialog", () => {
     expect(
       screen.getByRole("button", { name: /^sign in$/i })
     ).toBeInTheDocument();
+  });
+
+  it("reports the guest wall once across rerenders", () => {
+    useMCPJamLimitDialogStore.setState({ isOpen: true, intent: "guest" });
+    const view = render(<MCPJamLimitDialog />);
+
+    view.rerender(<MCPJamLimitDialog />);
+
+    const impressions = trackMock.mock.calls.filter(
+      ([event]) => event === "plan_limit_dialog_shown"
+    );
+    expect(impressions).toHaveLength(1);
+    expect(impressions[0]?.[1]).toEqual(
+      expect.objectContaining({
+        wall_kind: "guest_credits",
+        audience: "guest",
+        primary_action: "sign_in",
+      })
+    );
   });
 
   it("calls signIn() when the Sign in button is clicked", async () => {
@@ -234,9 +258,7 @@ describe("MCPJamLimitDialog", () => {
       screen.getByTestId("request-upgrade-mail").getAttribute("href") ?? ""
     );
     expect(href).toContain("Credit purchase request for Acme Robotics");
-    expect(href).toContain(
-      "Our organization has run out of MCPJam credits."
-    );
+    expect(href).toContain("Our organization has run out of MCPJam credits.");
     expect(href).toContain("Could you buy more credits for Acme Robotics?");
     expect(href).not.toContain("upgrade Acme Robotics to the Team plan");
   });

--- a/mcpjam-inspector/client/src/components/billing/CreditTopupDialog.tsx
+++ b/mcpjam-inspector/client/src/components/billing/CreditTopupDialog.tsx
@@ -86,8 +86,8 @@ export function CreditTopupDialog({
         <DialogHeader>
           <DialogTitle>Buy credits to keep chatting</DialogTitle>
           <DialogDescription>
-            Add credits to your organization so the team can keep using MCPJam
-            models when your shared credits run low.
+            Credits cover model usage in chat, playground, and agents. Buying
+            credits doesn't change your plan limits.
           </DialogDescription>
         </DialogHeader>
         <div className="flex flex-col gap-4">
@@ -127,6 +127,11 @@ export function CreditTopupDialog({
                     </span>
                     <span className="text-xs text-muted-foreground">
                       credits
+                    </span>
+                    {/* Price per tile: without it the three options can't be
+                        compared without selecting each one. */}
+                    <span className="mt-1 text-xs text-foreground">
+                      {preset.displayPrice}
                     </span>
                   </button>
                 );

--- a/mcpjam-inspector/client/src/components/billing/CreditTopupDialog.tsx
+++ b/mcpjam-inspector/client/src/components/billing/CreditTopupDialog.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import { CoinStackIcon } from "@/components/ui/coin-stack-icon";
 import { toast } from "@/lib/toast";
 import { Button } from "@mcpjam/design-system/button";
@@ -16,6 +16,7 @@ import {
   type CreditTopupPreset,
   type CreditTopupSource,
 } from "@/hooks/useCreditTopup";
+import { track } from "@/lib/analytics";
 
 interface CreditTopupDialogProps {
   open: boolean;
@@ -40,10 +41,14 @@ export function CreditTopupDialog({
   const [selectedPackageId, setSelectedPackageId] = useState<string | null>(
     null
   );
+  const impressionTrackedRef = useRef(false);
+  const dismissalTrackedRef = useRef(false);
 
   useEffect(() => {
     if (!open) {
       setSelectedPackageId(null);
+      impressionTrackedRef.current = false;
+      dismissalTrackedRef.current = false;
     }
   }, [open]);
 
@@ -53,9 +58,65 @@ export function CreditTopupDialog({
     }
   }, [open, presets, selectedPackageId]);
 
+  useEffect(() => {
+    if (!open || presetsLoading || impressionTrackedRef.current) return;
+
+    impressionTrackedRef.current = true;
+    track("credit_topup_dialog_shown", {
+      location: "credit_topup",
+      source,
+      organization_id: organizationId,
+      organization_resolved: Boolean(organizationId),
+      package_count: presets?.length ?? 0,
+      default_package_id: presets?.[0]?.packageId ?? null,
+      default_price_cents: presets?.[0]?.priceCents ?? null,
+      packages_available: Boolean(presets?.length),
+      has_resume_context: Boolean(chatSessionId && lastUserMessage),
+    });
+  }, [
+    chatSessionId,
+    lastUserMessage,
+    open,
+    organizationId,
+    presets,
+    presetsLoading,
+    source,
+  ]);
+
   const selectedPreset: CreditTopupPreset | undefined = presets?.find(
     (preset) => preset.packageId === selectedPackageId
   );
+
+  const handleDismiss = (dismissalMethod: "cancel" | "dialog") => {
+    onOpenChange(false);
+    if (dismissalTrackedRef.current) return;
+
+    dismissalTrackedRef.current = true;
+    track("credit_topup_dialog_dismissed", {
+      location: "credit_topup",
+      source,
+      organization_id: organizationId,
+      dismissal_method: dismissalMethod,
+      selected_package_id: selectedPreset?.packageId ?? null,
+      selected_price_cents: selectedPreset?.priceCents ?? null,
+    });
+  };
+
+  const handlePackageSelection = (
+    preset: CreditTopupPreset,
+    packageIndex: number
+  ) => {
+    setSelectedPackageId(preset.packageId);
+    track("credit_topup_package_selected", {
+      location: "credit_topup",
+      source,
+      organization_id: organizationId,
+      package_id: preset.packageId,
+      price_cents: preset.priceCents,
+      package_index: packageIndex,
+      package_count: presets?.length ?? 0,
+    });
+  };
 
   const handleConfirm = async () => {
     if (!selectedPreset || !organizationId) return;
@@ -81,7 +142,12 @@ export function CreditTopupDialog({
   };
 
   return (
-    <Dialog open={open} onOpenChange={onOpenChange}>
+    <Dialog
+      open={open}
+      onOpenChange={(next) => {
+        if (!next) handleDismiss("dialog");
+      }}
+    >
       <DialogContent className="sm:max-w-md">
         <DialogHeader>
           <DialogTitle>Buy credits to keep chatting</DialogTitle>
@@ -101,7 +167,7 @@ export function CreditTopupDialog({
             </div>
           ) : (
             <div className="grid grid-cols-3 gap-2" role="radiogroup">
-              {presets.map((preset) => {
+              {presets.map((preset, packageIndex) => {
                 const isSelected = preset.packageId === selectedPackageId;
                 const creditsAmount = preset.displayCredits.replace(
                   /\s*credits\s*$/i,
@@ -113,7 +179,7 @@ export function CreditTopupDialog({
                     type="button"
                     role="radio"
                     aria-checked={isSelected}
-                    onClick={() => setSelectedPackageId(preset.packageId)}
+                    onClick={() => handlePackageSelection(preset, packageIndex)}
                     className={cn(
                       "flex flex-col items-center justify-center rounded-md border px-3 py-3 text-sm font-medium transition-colors",
                       isSelected
@@ -143,7 +209,7 @@ export function CreditTopupDialog({
           <Button
             type="button"
             variant="outline"
-            onClick={() => onOpenChange(false)}
+            onClick={() => handleDismiss("cancel")}
             disabled={isStartingCheckout}
           >
             Cancel

--- a/mcpjam-inspector/client/src/components/billing/CreditsLimitDialogView.tsx
+++ b/mcpjam-inspector/client/src/components/billing/CreditsLimitDialogView.tsx
@@ -21,6 +21,9 @@ export interface CreditsLimitDialogViewProps {
   isKnownNonManager: boolean;
   /** Free orgs whose user can manage billing. A paid org gets credits only. */
   showUpgrade: boolean;
+  /** Can buy credits but can't upgrade (admins). They keep the credits path
+   * and get a way to ask an owner, instead of a pitch with no button. */
+  showRequestUpgrade?: boolean;
   requestRecipients: UpgradeRequestRecipient[];
   requestAction?: UpgradeRequestAction;
   organizationId?: string | null;
@@ -34,6 +37,7 @@ export interface CreditsLimitDialogViewProps {
   monthlySupported: boolean;
   teamName: string;
   isStarting: boolean;
+  isLoadingPrices?: boolean;
   onUpgrade: () => void;
   onBuyCredits: () => void;
   onUseOwnKey: () => void;
@@ -55,6 +59,7 @@ export function CreditsLimitDialogView({
   description,
   isKnownNonManager,
   showUpgrade,
+  showRequestUpgrade = false,
   requestRecipients,
   requestAction = "upgrade",
   organizationId,
@@ -68,6 +73,7 @@ export function CreditsLimitDialogView({
   monthlySupported,
   teamName,
   isStarting,
+  isLoadingPrices = false,
   onUpgrade,
   onBuyCredits,
   onUseOwnKey,
@@ -115,7 +121,19 @@ export function CreditsLimitDialogView({
                 monthlySupported={monthlySupported}
                 teamName={teamName}
                 isStarting={isStarting}
+                isLoadingPrices={isLoadingPrices}
                 onUpgrade={onUpgrade}
+              />
+            ) : null}
+            {showRequestUpgrade ? (
+              <RequestUpgradeButton
+                recipients={requestRecipients}
+                organizationName={organizationName}
+                teamName={teamName}
+                origin="credits"
+                limitKind="credits"
+                requestAction="upgrade"
+                organizationId={organizationId}
               />
             ) : null}
             <DialogFooter className="sm:justify-between">

--- a/mcpjam-inspector/client/src/components/billing/CreditsLimitDialogView.tsx
+++ b/mcpjam-inspector/client/src/components/billing/CreditsLimitDialogView.tsx
@@ -23,6 +23,7 @@ export interface CreditsLimitDialogViewProps {
   showUpgrade: boolean;
   requestRecipients: UpgradeRequestRecipient[];
   requestAction?: UpgradeRequestAction;
+  organizationId?: string | null;
   organizationName: string;
   interval: BillingInterval;
   onIntervalChange: (interval: BillingInterval) => void;
@@ -56,6 +57,7 @@ export function CreditsLimitDialogView({
   showUpgrade,
   requestRecipients,
   requestAction = "upgrade",
+  organizationId,
   organizationName,
   interval,
   onIntervalChange,
@@ -98,6 +100,7 @@ export function CreditsLimitDialogView({
             origin="credits"
             limitKind="credits"
             requestAction={requestAction}
+            organizationId={organizationId}
           />
         ) : (
           <>

--- a/mcpjam-inspector/client/src/components/billing/CreditsLimitDialogView.tsx
+++ b/mcpjam-inspector/client/src/components/billing/CreditsLimitDialogView.tsx
@@ -11,6 +11,7 @@ import type { BillingInterval } from "@/hooks/useOrganizationBilling";
 import { UpgradeIntervalPicker } from "@/components/billing/UpgradeIntervalPicker";
 import {
   RequestUpgradeButton,
+  type UpgradeRequestAction,
   type UpgradeRequestRecipient,
 } from "@/components/billing/RequestUpgradeButton";
 
@@ -21,6 +22,7 @@ export interface CreditsLimitDialogViewProps {
   /** Free orgs whose user can manage billing. A paid org gets credits only. */
   showUpgrade: boolean;
   requestRecipients: UpgradeRequestRecipient[];
+  requestAction?: UpgradeRequestAction;
   organizationName: string;
   interval: BillingInterval;
   onIntervalChange: (interval: BillingInterval) => void;
@@ -53,6 +55,7 @@ export function CreditsLimitDialogView({
   isKnownNonManager,
   showUpgrade,
   requestRecipients,
+  requestAction = "upgrade",
   organizationName,
   interval,
   onIntervalChange,
@@ -94,6 +97,7 @@ export function CreditsLimitDialogView({
             teamName={teamName}
             origin="credits"
             limitKind="credits"
+            requestAction={requestAction}
           />
         ) : (
           <>

--- a/mcpjam-inspector/client/src/components/billing/CreditsLimitDialogView.tsx
+++ b/mcpjam-inspector/client/src/components/billing/CreditsLimitDialogView.tsx
@@ -1,0 +1,132 @@
+import { Button } from "@mcpjam/design-system/button";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@mcpjam/design-system/dialog";
+import type { BillingInterval } from "@/hooks/useOrganizationBilling";
+import { UpgradeIntervalPicker } from "@/components/billing/UpgradeIntervalPicker";
+import {
+  RequestUpgradeButton,
+  type UpgradeRequestRecipient,
+} from "@/components/billing/RequestUpgradeButton";
+
+export interface CreditsLimitDialogViewProps {
+  description: string;
+  /** Can't buy credits or upgrade. Gets the owner-request path instead. */
+  isKnownNonManager: boolean;
+  /** Free orgs whose user can manage billing. A paid org gets credits only. */
+  showUpgrade: boolean;
+  requestRecipients: UpgradeRequestRecipient[];
+  organizationName: string;
+  interval: BillingInterval;
+  onIntervalChange: (interval: BillingInterval) => void;
+  annualPriceLabel: string | null;
+  monthlyPriceLabel: string | null;
+  annualDiscountPct: number;
+  annualSupported: boolean;
+  monthlySupported: boolean;
+  teamName: string;
+  isStarting: boolean;
+  onUpgrade: () => void;
+  onBuyCredits: () => void;
+  onUseOwnKey: () => void;
+  onDismiss: () => void;
+  /** Dev preview only; see PlanLimitDialogView. Production renders modal. */
+  modal?: boolean;
+}
+
+/**
+ * Presentation for the out-of-credits wall, with no data dependencies, so the
+ * dev preview at `/__preview/plan-limit` can render each variant with dummy
+ * props. `MCPJamLimitDialog` owns the data, the org resolution, and the copy.
+ *
+ * Upgrade leads because both of the older actions (buy credits, bring your own
+ * key) keep the org on Free at a variable cost. Credits stay available for a
+ * genuine burst, one step down.
+ */
+export function CreditsLimitDialogView({
+  description,
+  isKnownNonManager,
+  showUpgrade,
+  requestRecipients,
+  organizationName,
+  interval,
+  onIntervalChange,
+  annualPriceLabel,
+  monthlyPriceLabel,
+  annualDiscountPct,
+  annualSupported,
+  monthlySupported,
+  teamName,
+  isStarting,
+  onUpgrade,
+  onBuyCredits,
+  onUseOwnKey,
+  onDismiss,
+  modal = true,
+}: CreditsLimitDialogViewProps) {
+  return (
+    <Dialog
+      open
+      modal={modal}
+      onOpenChange={(next) => {
+        if (!next) onDismiss();
+      }}
+    >
+      <DialogContent className="sm:max-w-md">
+        <DialogHeader>
+          <DialogTitle>Your org is out of credits</DialogTitle>
+          <DialogDescription
+            className="text-pretty"
+            data-testid="limit-dialog-description"
+          >
+            {description}
+          </DialogDescription>
+        </DialogHeader>
+        {isKnownNonManager ? (
+          <RequestUpgradeButton
+            recipients={requestRecipients}
+            organizationName={organizationName}
+            teamName={teamName}
+            origin="credits"
+            limitKind="credits"
+          />
+        ) : (
+          <>
+            {showUpgrade ? (
+              <UpgradeIntervalPicker
+                interval={interval}
+                onIntervalChange={onIntervalChange}
+                annualPriceLabel={annualPriceLabel}
+                monthlyPriceLabel={monthlyPriceLabel}
+                annualDiscountPct={annualDiscountPct}
+                annualSupported={annualSupported}
+                monthlySupported={monthlySupported}
+                teamName={teamName}
+                isStarting={isStarting}
+                onUpgrade={onUpgrade}
+              />
+            ) : null}
+            <DialogFooter className="sm:justify-between">
+              <Button
+                type="button"
+                variant="link"
+                className="px-0 text-muted-foreground"
+                onClick={onUseOwnKey}
+              >
+                Use your own API key
+              </Button>
+              <Button type="button" variant="outline" onClick={onBuyCredits}>
+                Buy credits
+              </Button>
+            </DialogFooter>
+          </>
+        )}
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/mcpjam-inspector/client/src/components/billing/PlanLimitDialog.tsx
+++ b/mcpjam-inspector/client/src/components/billing/PlanLimitDialog.tsx
@@ -249,15 +249,14 @@ export function PlanLimitDialog() {
         </DialogHeader>
         {showUpgrade ? (
           <UpgradeIntervalPicker
-            interval={upgrade.interval}
-            onIntervalChange={upgrade.setInterval}
-            priceLabel={upgrade.priceLabel}
+            annualPriceLabel={upgrade.annualPriceLabel}
+            monthlyPriceLabel={upgrade.monthlyPriceLabel}
             annualDiscountPct={upgrade.annualDiscountPct}
             annualSupported={upgrade.annualSupported}
             monthlySupported={upgrade.monthlySupported}
             teamName={upgrade.teamName}
             isStarting={upgrade.isStarting}
-            onUpgrade={() => void upgrade.start()}
+            onUpgrade={(interval) => void upgrade.start(interval)}
           />
         ) : null}
         {showEnterprise ? (

--- a/mcpjam-inspector/client/src/components/billing/PlanLimitDialog.tsx
+++ b/mcpjam-inspector/client/src/components/billing/PlanLimitDialog.tsx
@@ -138,10 +138,14 @@ function useUpgradeReturnFlow(): void {
 
     track("plan_limit_upgrade_returned", {
       location: "plan_limit_dialog",
+      organization_id: upgradeReturn.organizationId,
       origin: upgradeReturn.origin,
       upgraded,
       plan: billingStatus.plan,
+      current_plan: billingStatus.plan,
+      effective_plan: billingStatus.effectivePlan ?? billingStatus.plan,
       billing_interval: billingStatus.billingInterval,
+      can_manage_billing: billingStatus.canManageBilling ?? false,
     });
   }, [
     billingStatus,
@@ -163,6 +167,7 @@ export function PlanLimitDialog() {
   const isOpen = usePlanLimitDialogStore((s) => s.isOpen);
   const limit = usePlanLimitDialogStore((s) => s.limit);
   const close = usePlanLimitDialogStore((s) => s.close);
+  const impressionTrackedRef = useRef(false);
 
   const organizationId = limit?.organizationId ?? null;
   const upgrade = useUpgradeCheckout({
@@ -173,41 +178,103 @@ export function PlanLimitDialog() {
   const requestRecipients = useUpgradeRequestRecipients(organizationId);
 
   useEffect(() => {
-    if (!isOpen || !limit) return;
+    if (!isOpen || !limit) {
+      impressionTrackedRef.current = false;
+      return;
+    }
+    if (upgrade.isLoadingBilling || impressionTrackedRef.current) return;
+
+    const isFreePlan = upgrade.effectivePlan === "free";
+    const showUpgrade = isFreePlan && upgrade.canManageBilling;
+    const showEnterprise =
+      !isFreePlan && upgrade.effectivePlan !== "enterprise";
+    impressionTrackedRef.current = true;
     track("plan_limit_dialog_shown", {
       location: "plan_limit_dialog",
+      wall_kind: "eval_iterations",
+      organization_id: organizationId,
       limit_kind: limit.kind,
       origin: limit.origin,
       used: limit.used,
       allowed: limit.allowed,
       window_kind: limit.windowKind,
+      current_plan: upgrade.currentPlan,
+      effective_plan: upgrade.effectivePlan,
+      can_manage_billing: upgrade.canManageBilling,
+      audience: upgrade.canManageBilling ? "billing_manager" : "member",
+      primary_action: showUpgrade
+        ? "upgrade"
+        : showEnterprise
+        ? "enterprise"
+        : requestRecipients.length > 0
+        ? "request_owner"
+        : "none",
+      request_recipient_count: requestRecipients.length,
+      billing_interval: upgrade.interval,
+      annual_supported: upgrade.annualSupported,
+      monthly_supported: upgrade.monthlySupported,
     });
-  }, [isOpen, limit]);
+  }, [
+    isOpen,
+    limit,
+    organizationId,
+    requestRecipients.length,
+    upgrade.annualSupported,
+    upgrade.canManageBilling,
+    upgrade.currentPlan,
+    upgrade.effectivePlan,
+    upgrade.interval,
+    upgrade.isLoadingBilling,
+    upgrade.monthlySupported,
+  ]);
 
   // New tab, not a same-tab navigation or a mailto. The user is mid-task with a
   // blocked eval run; sending them away from the app (or into a mail client
   // that may not be configured) loses their place for no reason.
   const handleRequestEnterprise = useCallback(() => {
+    window.open(ENTERPRISE_CONTACT_URL, "_blank", "noopener,noreferrer");
+    close();
     track("plan_limit_enterprise_cta_clicked", {
       location: "plan_limit_dialog",
+      organization_id: organizationId,
       limit_kind: limit?.kind ?? "evalIterations",
       origin: limit?.origin,
       plan: upgrade.effectivePlan,
+      current_plan: upgrade.currentPlan,
+      effective_plan: upgrade.effectivePlan,
+      can_manage_billing: upgrade.canManageBilling,
     });
-    window.open(ENTERPRISE_CONTACT_URL, "_blank", "noopener,noreferrer");
-    close();
-  }, [close, limit, upgrade.effectivePlan]);
+  }, [
+    close,
+    limit,
+    organizationId,
+    upgrade.canManageBilling,
+    upgrade.currentPlan,
+    upgrade.effectivePlan,
+  ]);
 
   const handleDismiss = useCallback(() => {
+    close();
     if (limit) {
       track("plan_limit_dialog_dismissed", {
         location: "plan_limit_dialog",
+        wall_kind: "eval_iterations",
+        organization_id: organizationId,
         limit_kind: limit.kind,
         origin: limit.origin,
+        current_plan: upgrade.currentPlan,
+        effective_plan: upgrade.effectivePlan,
+        audience: upgrade.canManageBilling ? "billing_manager" : "member",
       });
     }
-    close();
-  }, [close, limit]);
+  }, [
+    close,
+    limit,
+    organizationId,
+    upgrade.canManageBilling,
+    upgrade.currentPlan,
+    upgrade.effectivePlan,
+  ]);
 
   if (!isOpen || !limit || limit.kind !== "evalIterations") return null;
 
@@ -260,6 +327,7 @@ export function PlanLimitDialog() {
       showUpgrade={showUpgrade}
       showEnterprise={showEnterprise}
       requestRecipients={requestRecipients}
+      organizationId={organizationId}
       organizationName={upgrade.organizationName}
       origin="evals"
       limitKind={limit.kind}

--- a/mcpjam-inspector/client/src/components/billing/PlanLimitDialog.tsx
+++ b/mcpjam-inspector/client/src/components/billing/PlanLimitDialog.tsx
@@ -1,0 +1,277 @@
+import { useCallback, useEffect, useRef, useState } from "react";
+import { Button } from "@mcpjam/design-system/button";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@mcpjam/design-system/dialog";
+import { useOrganizationBilling } from "@/hooks/useOrganizationBilling";
+import {
+  UPGRADE_RETURN_ORG_PARAM,
+  UPGRADE_RETURN_ORIGIN_PARAM,
+  UPGRADE_RETURN_PARAM,
+  useUpgradeCheckout,
+  type UpgradeOrigin,
+} from "@/hooks/use-upgrade-checkout";
+import { track } from "@/lib/analytics";
+import { toast } from "@/lib/toast";
+import { usePlanLimitDialogStore } from "@/stores/plan-limit-dialog-store";
+import { UpgradeIntervalPicker } from "@/components/billing/UpgradeIntervalPicker";
+
+/** Same destination as the pricing page's Enterprise CTA. */
+const ENTERPRISE_CONTACT_URL = "https://www.mcpjam.com/contact";
+
+function formatCount(value: number): string {
+  return new Intl.NumberFormat().format(value);
+}
+
+function formatResetClock(resetsAt: number): string {
+  return new Intl.DateTimeFormat(undefined, {
+    hour: "numeric",
+    minute: "2-digit",
+  }).format(new Date(resetsAt));
+}
+
+/** "about 9 hours". The absolute timestamp alone makes the user do arithmetic
+ * at exactly the wrong moment. */
+function formatResetDistance(resetsAt: number): string | null {
+  const diffMs = resetsAt - Date.now();
+  if (diffMs <= 0) return null;
+  const hours = Math.round(diffMs / (60 * 60 * 1000));
+  if (hours < 1) {
+    const minutes = Math.max(1, Math.round(diffMs / 60_000));
+    return `about ${minutes} minute${minutes === 1 ? "" : "s"}`;
+  }
+  if (hours < 36) {
+    return `about ${hours} hour${hours === 1 ? "" : "s"}`;
+  }
+  const days = Math.round(hours / 24);
+  return `about ${days} day${days === 1 ? "" : "s"}`;
+}
+
+interface UpgradeReturn {
+  organizationId: string;
+  origin: UpgradeOrigin;
+}
+
+function readUpgradeReturn(): UpgradeReturn | null {
+  if (typeof window === "undefined") return null;
+  const params = new URLSearchParams(window.location.search);
+  if (params.get(UPGRADE_RETURN_PARAM) !== "return") return null;
+  const organizationId = params.get(UPGRADE_RETURN_ORG_PARAM);
+  if (!organizationId) return null;
+  const rawOrigin = params.get(UPGRADE_RETURN_ORIGIN_PARAM);
+  return {
+    organizationId,
+    origin: rawOrigin === "credits" ? "credits" : "evals",
+  };
+}
+
+function stripUpgradeReturnParams(): void {
+  if (typeof window === "undefined") return;
+  const params = new URLSearchParams(window.location.search);
+  params.delete(UPGRADE_RETURN_PARAM);
+  params.delete(UPGRADE_RETURN_ORG_PARAM);
+  params.delete(UPGRADE_RETURN_ORIGIN_PARAM);
+  const search = params.toString();
+  window.history.replaceState(
+    null,
+    "",
+    window.location.pathname +
+      (search ? `?${search}` : "") +
+      window.location.hash,
+  );
+}
+
+/**
+ * Handles the post-checkout return for both limit walls. Mounted app-wide, so
+ * it runs wherever the user was blocked rather than on the billing page.
+ *
+ * The return marker is present whether the user paid or bailed at Stripe, so
+ * the confirmation is gated on the plan having actually changed. Never
+ * announce a purchase we can't see.
+ */
+function useUpgradeReturnFlow(): void {
+  const [upgradeReturn] = useState<UpgradeReturn | null>(() =>
+    readUpgradeReturn(),
+  );
+  const handledRef = useRef(false);
+  const { billingStatus, planCatalog, isLoadingBilling } =
+    useOrganizationBilling(upgradeReturn?.organizationId ?? null);
+
+  useEffect(() => {
+    if (!upgradeReturn || handledRef.current) return;
+    if (isLoadingBilling || !billingStatus) return;
+    handledRef.current = true;
+    stripUpgradeReturnParams();
+
+    const upgraded = billingStatus.plan !== "free";
+    if (upgraded) {
+      const teamName = planCatalog?.plans.team.displayName ?? "Team";
+      toast.success(
+        upgradeReturn.origin === "credits"
+          ? `You're on our ${teamName} plan. Your credits are available now.`
+          : `You're on our ${teamName} plan. Run your suite again to pick up where you left off.`,
+      );
+    }
+
+    track("plan_limit_upgrade_returned", {
+      location: "plan_limit_dialog",
+      origin: upgradeReturn.origin,
+      upgraded,
+      plan: billingStatus.plan,
+      billing_interval: billingStatus.billingInterval,
+    });
+  }, [
+    billingStatus,
+    isLoadingBilling,
+    planCatalog,
+    upgradeReturn,
+  ]);
+}
+
+/**
+ * The free-plan wall for eval iterations. Replaces a dead-end `toast.error`
+ * with a decision surface, and starts checkout directly rather than routing
+ * through the billing page.
+ */
+export function PlanLimitDialog() {
+  useUpgradeReturnFlow();
+
+  const isOpen = usePlanLimitDialogStore((s) => s.isOpen);
+  const limit = usePlanLimitDialogStore((s) => s.limit);
+  const close = usePlanLimitDialogStore((s) => s.close);
+
+  const upgrade = useUpgradeCheckout({
+    organizationId: limit?.organizationId ?? null,
+    origin: "evals",
+    limitKind: limit?.kind ?? "evalIterations",
+  });
+
+  useEffect(() => {
+    if (!isOpen || !limit) return;
+    track("plan_limit_dialog_shown", {
+      location: "plan_limit_dialog",
+      limit_kind: limit.kind,
+      origin: limit.origin,
+      used: limit.used,
+      allowed: limit.allowed,
+      window_kind: limit.windowKind,
+    });
+  }, [isOpen, limit]);
+
+  // New tab, not a same-tab navigation or a mailto. The user is mid-task with a
+  // blocked eval run; sending them away from the app (or into a mail client
+  // that may not be configured) loses their place for no reason.
+  const handleRequestUpgrade = useCallback(() => {
+    track("plan_limit_enterprise_cta_clicked", {
+      location: "plan_limit_dialog",
+      limit_kind: limit?.kind ?? "evalIterations",
+      origin: limit?.origin,
+      plan: upgrade.currentPlan,
+    });
+    window.open(ENTERPRISE_CONTACT_URL, "_blank", "noopener,noreferrer");
+    close();
+  }, [close, limit, upgrade.currentPlan]);
+
+  const handleDismiss = useCallback(() => {
+    if (limit) {
+      track("plan_limit_dialog_dismissed", {
+        location: "plan_limit_dialog",
+        limit_kind: limit.kind,
+        origin: limit.origin,
+      });
+    }
+    close();
+  }, [close, limit]);
+
+  if (!isOpen || !limit || limit.kind !== "evalIterations") return null;
+
+  const windowLabel = limit.windowKind === "day" ? "today" : "this month";
+  const perWindow = limit.windowKind === "day" ? "a day" : "a month";
+
+  // An org already on a paid plan can hit its own ceiling. Naming "Free" there
+  // would be wrong, and so would pitching the plan they're already on.
+  const isFreePlan = upgrade.currentPlan === "free";
+  const planName = isFreePlan ? "Free" : "Your plan";
+  const planSentence =
+    limit.allowed != null
+      ? `${planName} includes ${formatCount(limit.allowed)} ${perWindow}, and `
+      : "";
+  const resetDistance = limit.resetsAt
+    ? formatResetDistance(limit.resetsAt)
+    : null;
+  const resetSentence = limit.resetsAt
+    ? `${planSentence ? "yours reset" : "Yours reset"} at ${formatResetClock(
+        limit.resetsAt,
+      )}${resetDistance ? `, ${resetDistance} from now` : ""}.`
+    : "";
+
+  const showUpgrade = isFreePlan && upgrade.canManageBilling;
+  // A paid org at its own ceiling has no self-serve step left, so it gets the
+  // sales path instead of a checkout button.
+  const showEnterprise = !isFreePlan && upgrade.currentPlan !== "enterprise";
+  // The eval figure comes from the plan catalog, never a hardcoded string, so
+  // it tracks whatever billing actually enforces. Credits deliberately have no
+  // figure: they aren't in the catalog, so the only source would be the
+  // hardcoded marketing table, which is exactly what goes stale.
+  const upgradeSentence = isFreePlan
+    ? `Our ${upgrade.teamName} plan includes ${
+        upgrade.teamEvalIterations
+          ? `${formatCount(upgrade.teamEvalIterations)} a month`
+          : "a monthly allowance instead of a daily cap"
+      }, so evals can run smoothly on every PR instead of limiting your daily quality checks.`
+    : showEnterprise
+      ? "Enterprise adds negotiated usage and a custom LLM budget."
+      : "";
+
+  return (
+    <Dialog
+      open
+      onOpenChange={(next) => {
+        if (!next) handleDismiss();
+      }}
+    >
+      <DialogContent className="sm:max-w-md">
+        <DialogHeader>
+          <DialogTitle>
+            You're out of eval iterations {windowLabel}
+          </DialogTitle>
+          <DialogDescription data-testid="plan-limit-dialog-description">
+            {`${planSentence}${resetSentence} ${upgradeSentence}`.trim()}
+            {isFreePlan && !upgrade.canManageBilling
+              ? " Only an organization owner or admin can upgrade."
+              : ""}
+          </DialogDescription>
+        </DialogHeader>
+        {showUpgrade ? (
+          <UpgradeIntervalPicker
+            interval={upgrade.interval}
+            onIntervalChange={upgrade.setInterval}
+            priceLabel={upgrade.priceLabel}
+            annualDiscountPct={upgrade.annualDiscountPct}
+            annualSupported={upgrade.annualSupported}
+            monthlySupported={upgrade.monthlySupported}
+            teamName={upgrade.teamName}
+            isStarting={upgrade.isStarting}
+            onUpgrade={() => void upgrade.start()}
+          />
+        ) : null}
+        {showEnterprise ? (
+          <DialogFooter>
+            <Button
+              type="button"
+              onClick={handleRequestUpgrade}
+              data-testid="plan-limit-enterprise-cta"
+            >
+              Request upgrade
+            </Button>
+          </DialogFooter>
+        ) : null}
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/mcpjam-inspector/client/src/components/billing/PlanLimitDialog.tsx
+++ b/mcpjam-inspector/client/src/components/billing/PlanLimitDialog.tsx
@@ -1,12 +1,14 @@
 import { useCallback, useEffect, useRef, useState } from "react";
 import { useOrganizationBilling } from "@/hooks/useOrganizationBilling";
 import {
+  consumeUpgradeReturnToken,
   UPGRADE_RETURN_ORG_PARAM,
   UPGRADE_RETURN_ORIGIN_PARAM,
   UPGRADE_RETURN_PARAM,
   useUpgradeCheckout,
   type UpgradeOrigin,
 } from "@/hooks/use-upgrade-checkout";
+import { ErrorBoundary } from "@/components/ui/error-boundary";
 import { track } from "@/lib/analytics";
 import { toast } from "@/lib/toast";
 import { usePlanLimitDialogStore } from "@/stores/plan-limit-dialog-store";
@@ -55,7 +57,9 @@ interface UpgradeReturn {
   origin: UpgradeOrigin;
 }
 
-function readUpgradeReturn(): UpgradeReturn | null {
+/** Pure: reading the URL is safe to repeat. Claiming the return is not, and
+ * happens once in an effect below. */
+function readUpgradeReturnParams(): UpgradeReturn | null {
   if (typeof window === "undefined") return null;
   const params = new URLSearchParams(window.location.search);
   if (params.get(UPGRADE_RETURN_PARAM) !== "return") return null;
@@ -92,19 +96,20 @@ function stripUpgradeReturnParams(): void {
  * the confirmation is gated on the plan having actually changed. Never
  * announce a purchase we can't see.
  */
-function useUpgradeReturnFlow(): void {
-  const [upgradeReturn] = useState<UpgradeReturn | null>(() =>
-    readUpgradeReturn()
-  );
+function UpgradeReturnFlow({
+  upgradeReturn,
+}: {
+  upgradeReturn: UpgradeReturn;
+}) {
   const [settlementGraceElapsed, setSettlementGraceElapsed] = useState(false);
-  const handledRef = useRef(false);
+  const settledRef = useRef(false);
+  const waitReportedRef = useRef(false);
   const { billingStatus, planCatalog, isLoadingBilling } =
-    useOrganizationBilling(upgradeReturn?.organizationId ?? null);
+    useOrganizationBilling(upgradeReturn.organizationId);
 
   useEffect(() => {
     if (
-      !upgradeReturn ||
-      handledRef.current ||
+      settledRef.current ||
       isLoadingBilling ||
       billingStatus?.plan !== "free"
     ) {
@@ -115,17 +120,30 @@ function useUpgradeReturnFlow(): void {
       setSettlementGraceElapsed(true);
     }, UPGRADE_RETURN_SETTLEMENT_GRACE_MS);
     return () => window.clearTimeout(timeoutId);
-  }, [billingStatus?.plan, isLoadingBilling, upgradeReturn]);
+  }, [billingStatus?.plan, isLoadingBilling]);
 
   useEffect(() => {
-    if (!upgradeReturn || handledRef.current) return;
+    if (settledRef.current) return;
     if (isLoadingBilling || !billingStatus) return;
 
     const upgraded = billingStatus.plan !== "free";
     if (!upgraded && !settlementGraceElapsed) return;
+    // A webhook slower than the grace window is still a real purchase. Report
+    // the wait once, then keep watching: the plan flip that lands late still
+    // owes the user a confirmation, and freezing the record at "abandoned"
+    // would misreport a customer who paid.
+    if (!upgraded && waitReportedRef.current) return;
 
-    handledRef.current = true;
-    stripUpgradeReturnParams();
+    const settlement = upgraded
+      ? waitReportedRef.current
+        ? "late"
+        : "immediate"
+      : "pending";
+    if (upgraded) {
+      settledRef.current = true;
+    } else {
+      waitReportedRef.current = true;
+    }
 
     if (upgraded) {
       const teamName = planCatalog?.plans.team.displayName ?? "Team";
@@ -141,6 +159,9 @@ function useUpgradeReturnFlow(): void {
       organization_id: upgradeReturn.organizationId,
       origin: upgradeReturn.origin,
       upgraded,
+      // "pending" is a checkout we couldn't see settle in time, not a bail.
+      // Count conversions on "immediate" + "late".
+      settlement,
       plan: billingStatus.plan,
       current_plan: billingStatus.plan,
       effective_plan: billingStatus.effectivePlan ?? billingStatus.plan,
@@ -154,6 +175,49 @@ function useUpgradeReturnFlow(): void {
     settlementGraceElapsed,
     upgradeReturn,
   ]);
+
+  return null;
+}
+
+function UpgradeReturnFlowBoundary() {
+  const [pendingReturn] = useState<UpgradeReturn | null>(() =>
+    readUpgradeReturnParams()
+  );
+  const [upgradeReturn, setUpgradeReturn] = useState<UpgradeReturn | null>(
+    null
+  );
+  const claimedRef = useRef(false);
+
+  // Claiming is a side effect — it burns the one-shot token and rewrites the
+  // URL — so it runs in an effect, guarded to once. The app mounts under
+  // StrictMode, which double-invokes render-phase work and remounts effects in
+  // dev; a marker claimed twice is a confirmation lost.
+  useEffect(() => {
+    if (!pendingReturn || claimedRef.current) return;
+    claimedRef.current = true;
+    // Strip regardless of the outcome: these params must not survive into a
+    // reload, a bookmark, or a link pasted to someone else.
+    stripUpgradeReturnParams();
+    // Only the tab that started checkout can settle a return. Without this the
+    // marker is just a URL: anyone loading it in an org already on a paid plan
+    // gets a purchase confirmation, and the funnel gets a conversion, for a
+    // checkout that never happened.
+    if (consumeUpgradeReturnToken(pendingReturn.organizationId)) {
+      setUpgradeReturn(pendingReturn);
+    }
+  }, [pendingReturn]);
+
+  if (!upgradeReturn) return null;
+
+  // The org id rides in from a URL, so the billing query can reject it — a
+  // deleted org, or membership revoked between checkout and return. Convex
+  // rethrows that from `useQuery` during render, and this is mounted app-wide,
+  // so without a boundary one bad marker replaces the entire app.
+  return (
+    <ErrorBoundary name="upgrade-return-flow" fallback={null}>
+      <UpgradeReturnFlow upgradeReturn={upgradeReturn} />
+    </ErrorBoundary>
+  );
 }
 
 /**
@@ -162,8 +226,15 @@ function useUpgradeReturnFlow(): void {
  * through the billing page.
  */
 export function PlanLimitDialog() {
-  useUpgradeReturnFlow();
+  return (
+    <>
+      <UpgradeReturnFlowBoundary />
+      <PlanLimitWall />
+    </>
+  );
+}
 
+function PlanLimitWall() {
   const isOpen = usePlanLimitDialogStore((s) => s.isOpen);
   const limit = usePlanLimitDialogStore((s) => s.limit);
   const close = usePlanLimitDialogStore((s) => s.close);
@@ -180,18 +251,31 @@ export function PlanLimitDialog() {
     isLoading: isLoadingRequestRecipients,
   } = useUpgradeRequestRecipients(organizationId);
 
+  // Derived once, for both the impression event and the render. Two copies of
+  // this rule drift, and then the funnel reports a variant nobody saw.
+  //
+  // Nothing plan-specific renders until billing resolves: the hook defaults to
+  // free/can't-manage, which would flash the member wall at an owner (whose
+  // "email your owner" draft is addressed to themself) and the Free pitch at a
+  // paid org.
+  const isBillingReady = !upgrade.isLoadingBilling;
+  const isFreePlan = upgrade.effectivePlan === "free";
+  const isEnterprisePlan = upgrade.effectivePlan === "enterprise";
+  const showUpgrade = isBillingReady && isFreePlan && upgrade.canManageBilling;
+  // A paid org at its own ceiling has no self-serve step left, so it gets the
+  // sales path instead of a checkout button.
+  const showEnterprise = isBillingReady && !isFreePlan && !isEnterprisePlan;
+  // Enterprise is excluded deliberately: asking an owner to "upgrade to Team"
+  // is a downgrade pitch, and there is nothing above Enterprise to ask for.
+  const showRequest =
+    isBillingReady && !showUpgrade && !showEnterprise && !isEnterprisePlan;
+
   useEffect(() => {
     if (!isOpen || !limit) {
       impressionTrackedRef.current = false;
       return;
     }
     if (upgrade.isLoadingBilling || impressionTrackedRef.current) return;
-
-    const isFreePlan = upgrade.effectivePlan === "free";
-    const showUpgrade = isFreePlan && upgrade.canManageBilling;
-    const showEnterprise =
-      !isFreePlan && upgrade.effectivePlan !== "enterprise";
-    const showRequest = !showUpgrade && !showEnterprise;
     if (showRequest && isLoadingRequestRecipients) return;
 
     impressionTrackedRef.current = true;
@@ -226,6 +310,9 @@ export function PlanLimitDialog() {
     limit,
     organizationId,
     requestRecipients.length,
+    showEnterprise,
+    showRequest,
+    showUpgrade,
     upgrade.annualSupported,
     upgrade.canManageBilling,
     upgrade.currentPlan,
@@ -294,9 +381,9 @@ export function PlanLimitDialog() {
   const perWindow = limit.windowKind === "day" ? "a day" : "a month";
 
   // An org already on a paid plan can hit its own ceiling. Naming "Free" there
-  // would be wrong, and so would pitching the plan they're already on.
-  const isFreePlan = upgrade.effectivePlan === "free";
-  const planName = isFreePlan ? "Free" : "Your plan";
+  // would be wrong, and so would pitching the plan they're already on. While
+  // billing loads we don't know which, so the neutral name stands in.
+  const planName = isBillingReady && isFreePlan ? "Free" : "Your plan";
   const planSentence =
     limit.allowed != null
       ? `${planName} includes ${formatCount(limit.allowed)} ${perWindow}, and `
@@ -310,15 +397,13 @@ export function PlanLimitDialog() {
       )}${resetDistance ? `, ${resetDistance} from now` : ""}.`
     : "";
 
-  const showUpgrade = isFreePlan && upgrade.canManageBilling;
-  // A paid org at its own ceiling has no self-serve step left, so it gets the
-  // sales path instead of a checkout button.
-  const showEnterprise = !isFreePlan && upgrade.effectivePlan !== "enterprise";
   // The eval figure comes from the plan catalog, never a hardcoded string, so
   // it tracks whatever billing actually enforces. Credits deliberately have no
   // figure: they aren't in the catalog, so the only source would be the
   // hardcoded marketing table, which is exactly what goes stale.
-  const upgradeSentence = isFreePlan
+  const upgradeSentence = !isBillingReady
+    ? ""
+    : isFreePlan
     ? `Our ${upgrade.teamName} plan includes ${
         upgrade.teamEvalIterations
           ? `${formatCount(upgrade.teamEvalIterations)} per seat each month`
@@ -332,12 +417,13 @@ export function PlanLimitDialog() {
     <PlanLimitDialogView
       title={`You're out of eval iterations ${windowLabel}`}
       description={`${`${planSentence}${resetSentence} ${upgradeSentence}`.trim()}${
-        isFreePlan && !upgrade.canManageBilling
+        isBillingReady && isFreePlan && !upgrade.canManageBilling
           ? " Only an owner can upgrade this organization."
           : ""
       }`}
       showUpgrade={showUpgrade}
       showEnterprise={showEnterprise}
+      showRequest={showRequest}
       requestRecipients={requestRecipients}
       organizationId={organizationId}
       organizationName={upgrade.organizationName}
@@ -352,6 +438,7 @@ export function PlanLimitDialog() {
       monthlySupported={upgrade.monthlySupported}
       teamName={upgrade.teamName}
       isStarting={upgrade.isStarting}
+      isLoadingPrices={upgrade.isLoadingPrices}
       onUpgrade={() => void handleUpgrade()}
       onRequestEnterprise={handleRequestEnterprise}
       onDismiss={handleDismiss}

--- a/mcpjam-inspector/client/src/components/billing/PlanLimitDialog.tsx
+++ b/mcpjam-inspector/client/src/components/billing/PlanLimitDialog.tsx
@@ -384,18 +384,24 @@ function PlanLimitWall() {
   // would be wrong, and so would pitching the plan they're already on. While
   // billing loads we don't know which, so the neutral name stands in.
   const planName = isBillingReady && isFreePlan ? "Free" : "Your plan";
-  const planSentence =
+  const allowanceClause =
     limit.allowed != null
-      ? `${planName} includes ${formatCount(limit.allowed)} ${perWindow}, and `
+      ? `${planName} includes ${formatCount(limit.allowed)} ${perWindow}`
       : "";
   const resetDistance = limit.resetsAt
     ? formatResetDistance(limit.resetsAt)
     : null;
-  const resetSentence = limit.resetsAt
-    ? `${planSentence ? "yours reset" : "Yours reset"} at ${formatResetClock(
+  const resetClause = limit.resetsAt
+    ? `${allowanceClause ? "yours reset" : "Yours reset"} at ${formatResetClock(
         limit.resetsAt
-      )}${resetDistance ? `, ${resetDistance} from now` : ""}.`
+      )}${resetDistance ? `, ${resetDistance} from now` : ""}`
     : "";
+  // The conjunction belongs to the pair, not to the allowance. Baking ", and"
+  // into the allowance clause left the copy dangling on it whenever the limit
+  // carries no `resetsAt`.
+  const planSentence = [allowanceClause, resetClause]
+    .filter(Boolean)
+    .join(", and ");
 
   // The eval figure comes from the plan catalog, never a hardcoded string, so
   // it tracks whatever billing actually enforces. Credits deliberately have no
@@ -416,7 +422,9 @@ function PlanLimitWall() {
   return (
     <PlanLimitDialogView
       title={`You're out of eval iterations ${windowLabel}`}
-      description={`${`${planSentence}${resetSentence} ${upgradeSentence}`.trim()}${
+      description={`${`${
+        planSentence ? `${planSentence}.` : ""
+      } ${upgradeSentence}`.trim()}${
         isBillingReady && isFreePlan && !upgrade.canManageBilling
           ? " Only an owner can upgrade this organization."
           : ""

--- a/mcpjam-inspector/client/src/components/billing/PlanLimitDialog.tsx
+++ b/mcpjam-inspector/client/src/components/billing/PlanLimitDialog.tsx
@@ -283,6 +283,11 @@ export function PlanLimitDialog() {
     upgrade.effectivePlan,
   ]);
 
+  const handleUpgrade = useCallback(async () => {
+    const result = await upgrade.start();
+    if (result?.shouldDismiss) close();
+  }, [close, upgrade]);
+
   if (!isOpen || !limit || limit.kind !== "evalIterations") return null;
 
   const windowLabel = limit.windowKind === "day" ? "today" : "this month";
@@ -316,7 +321,7 @@ export function PlanLimitDialog() {
   const upgradeSentence = isFreePlan
     ? `Our ${upgrade.teamName} plan includes ${
         upgrade.teamEvalIterations
-          ? `${formatCount(upgrade.teamEvalIterations)} a month`
+          ? `${formatCount(upgrade.teamEvalIterations)} per seat each month`
           : "a monthly allowance instead of a daily cap"
       }, so evals can run smoothly on every PR instead of limiting your daily quality checks.`
     : showEnterprise
@@ -347,7 +352,7 @@ export function PlanLimitDialog() {
       monthlySupported={upgrade.monthlySupported}
       teamName={upgrade.teamName}
       isStarting={upgrade.isStarting}
-      onUpgrade={() => void upgrade.start()}
+      onUpgrade={() => void handleUpgrade()}
       onRequestEnterprise={handleRequestEnterprise}
       onDismiss={handleDismiss}
     />

--- a/mcpjam-inspector/client/src/components/billing/PlanLimitDialog.tsx
+++ b/mcpjam-inspector/client/src/components/billing/PlanLimitDialog.tsx
@@ -1,13 +1,4 @@
 import { useCallback, useEffect, useRef, useState } from "react";
-import { Button } from "@mcpjam/design-system/button";
-import {
-  Dialog,
-  DialogContent,
-  DialogDescription,
-  DialogFooter,
-  DialogHeader,
-  DialogTitle,
-} from "@mcpjam/design-system/dialog";
 import { useOrganizationBilling } from "@/hooks/useOrganizationBilling";
 import {
   UPGRADE_RETURN_ORG_PARAM,
@@ -19,7 +10,8 @@ import {
 import { track } from "@/lib/analytics";
 import { toast } from "@/lib/toast";
 import { usePlanLimitDialogStore } from "@/stores/plan-limit-dialog-store";
-import { UpgradeIntervalPicker } from "@/components/billing/UpgradeIntervalPicker";
+import { useUpgradeRequestRecipients } from "@/hooks/use-upgrade-request-recipients";
+import { PlanLimitDialogView } from "@/components/billing/PlanLimitDialogView";
 
 /** Same destination as the pricing page's Enterprise CTA. */
 const ENTERPRISE_CONTACT_URL = "https://www.mcpjam.com/contact";
@@ -145,11 +137,13 @@ export function PlanLimitDialog() {
   const limit = usePlanLimitDialogStore((s) => s.limit);
   const close = usePlanLimitDialogStore((s) => s.close);
 
+  const organizationId = limit?.organizationId ?? null;
   const upgrade = useUpgradeCheckout({
-    organizationId: limit?.organizationId ?? null,
+    organizationId,
     origin: "evals",
     limitKind: limit?.kind ?? "evalIterations",
   });
+  const requestRecipients = useUpgradeRequestRecipients(organizationId);
 
   useEffect(() => {
     if (!isOpen || !limit) return;
@@ -166,7 +160,7 @@ export function PlanLimitDialog() {
   // New tab, not a same-tab navigation or a mailto. The user is mid-task with a
   // blocked eval run; sending them away from the app (or into a mail client
   // that may not be configured) loses their place for no reason.
-  const handleRequestUpgrade = useCallback(() => {
+  const handleRequestEnterprise = useCallback(() => {
     track("plan_limit_enterprise_cta_clicked", {
       location: "plan_limit_dialog",
       limit_kind: limit?.kind ?? "evalIterations",
@@ -229,48 +223,31 @@ export function PlanLimitDialog() {
       : "";
 
   return (
-    <Dialog
-      open
-      onOpenChange={(next) => {
-        if (!next) handleDismiss();
-      }}
-    >
-      <DialogContent className="sm:max-w-md">
-        <DialogHeader>
-          <DialogTitle>
-            You're out of eval iterations {windowLabel}
-          </DialogTitle>
-          <DialogDescription data-testid="plan-limit-dialog-description">
-            {`${planSentence}${resetSentence} ${upgradeSentence}`.trim()}
-            {isFreePlan && !upgrade.canManageBilling
-              ? " Only an organization owner or admin can upgrade."
-              : ""}
-          </DialogDescription>
-        </DialogHeader>
-        {showUpgrade ? (
-          <UpgradeIntervalPicker
-            annualPriceLabel={upgrade.annualPriceLabel}
-            monthlyPriceLabel={upgrade.monthlyPriceLabel}
-            annualDiscountPct={upgrade.annualDiscountPct}
-            annualSupported={upgrade.annualSupported}
-            monthlySupported={upgrade.monthlySupported}
-            teamName={upgrade.teamName}
-            isStarting={upgrade.isStarting}
-            onUpgrade={(interval) => void upgrade.start(interval)}
-          />
-        ) : null}
-        {showEnterprise ? (
-          <DialogFooter>
-            <Button
-              type="button"
-              onClick={handleRequestUpgrade}
-              data-testid="plan-limit-enterprise-cta"
-            >
-              Request upgrade
-            </Button>
-          </DialogFooter>
-        ) : null}
-      </DialogContent>
-    </Dialog>
+    <PlanLimitDialogView
+      title={`You're out of eval iterations ${windowLabel}`}
+      description={`${`${planSentence}${resetSentence} ${upgradeSentence}`.trim()}${
+        isFreePlan && !upgrade.canManageBilling
+          ? " Only an organization owner can upgrade."
+          : ""
+      }`}
+      showUpgrade={showUpgrade}
+      showEnterprise={showEnterprise}
+      requestRecipients={requestRecipients}
+      organizationName={upgrade.organizationName}
+      origin="evals"
+      limitKind={limit.kind}
+      interval={upgrade.interval}
+      onIntervalChange={upgrade.setInterval}
+      annualPriceLabel={upgrade.annualPriceLabel}
+      monthlyPriceLabel={upgrade.monthlyPriceLabel}
+      annualDiscountPct={upgrade.annualDiscountPct}
+      annualSupported={upgrade.annualSupported}
+      monthlySupported={upgrade.monthlySupported}
+      teamName={upgrade.teamName}
+      isStarting={upgrade.isStarting}
+      onUpgrade={() => void upgrade.start()}
+      onRequestEnterprise={handleRequestEnterprise}
+      onDismiss={handleDismiss}
+    />
   );
 }

--- a/mcpjam-inspector/client/src/components/billing/PlanLimitDialog.tsx
+++ b/mcpjam-inspector/client/src/components/billing/PlanLimitDialog.tsx
@@ -143,7 +143,8 @@ export function PlanLimitDialog() {
     origin: "evals",
     limitKind: limit?.kind ?? "evalIterations",
   });
-  const requestRecipients = useUpgradeRequestRecipients(organizationId);
+  const { recipients: requestRecipients, isLoading: isLoadingRecipients } =
+    useUpgradeRequestRecipients(organizationId);
 
   useEffect(() => {
     if (!isOpen || !limit) return;
@@ -227,12 +228,13 @@ export function PlanLimitDialog() {
       title={`You're out of eval iterations ${windowLabel}`}
       description={`${`${planSentence}${resetSentence} ${upgradeSentence}`.trim()}${
         isFreePlan && !upgrade.canManageBilling
-          ? " Only an organization owner can upgrade."
+          ? " Only an owner can upgrade this organization."
           : ""
       }`}
       showUpgrade={showUpgrade}
       showEnterprise={showEnterprise}
       requestRecipients={requestRecipients}
+      isLoadingRecipients={isLoadingRecipients}
       organizationName={upgrade.organizationName}
       origin="evals"
       limitKind={limit.kind}

--- a/mcpjam-inspector/client/src/components/billing/PlanLimitDialog.tsx
+++ b/mcpjam-inspector/client/src/components/billing/PlanLimitDialog.tsx
@@ -80,7 +80,7 @@ function stripUpgradeReturnParams(): void {
     "",
     window.location.pathname +
       (search ? `?${search}` : "") +
-      window.location.hash,
+      window.location.hash
   );
 }
 
@@ -94,7 +94,7 @@ function stripUpgradeReturnParams(): void {
  */
 function useUpgradeReturnFlow(): void {
   const [upgradeReturn] = useState<UpgradeReturn | null>(() =>
-    readUpgradeReturn(),
+    readUpgradeReturn()
   );
   const [settlementGraceElapsed, setSettlementGraceElapsed] = useState(false);
   const handledRef = useRef(false);
@@ -132,7 +132,7 @@ function useUpgradeReturnFlow(): void {
       toast.success(
         upgradeReturn.origin === "credits"
           ? `You're on our ${teamName} plan. Your credits are available now.`
-          : `You're on our ${teamName} plan. Run your suite again to pick up where you left off.`,
+          : `You're on our ${teamName} plan. Run your suite again to pick up where you left off.`
       );
     }
 
@@ -192,11 +192,11 @@ export function PlanLimitDialog() {
       location: "plan_limit_dialog",
       limit_kind: limit?.kind ?? "evalIterations",
       origin: limit?.origin,
-      plan: upgrade.currentPlan,
+      plan: upgrade.effectivePlan,
     });
     window.open(ENTERPRISE_CONTACT_URL, "_blank", "noopener,noreferrer");
     close();
-  }, [close, limit, upgrade.currentPlan]);
+  }, [close, limit, upgrade.effectivePlan]);
 
   const handleDismiss = useCallback(() => {
     if (limit) {
@@ -216,7 +216,7 @@ export function PlanLimitDialog() {
 
   // An org already on a paid plan can hit its own ceiling. Naming "Free" there
   // would be wrong, and so would pitching the plan they're already on.
-  const isFreePlan = upgrade.currentPlan === "free";
+  const isFreePlan = upgrade.effectivePlan === "free";
   const planName = isFreePlan ? "Free" : "Your plan";
   const planSentence =
     limit.allowed != null
@@ -227,14 +227,14 @@ export function PlanLimitDialog() {
     : null;
   const resetSentence = limit.resetsAt
     ? `${planSentence ? "yours reset" : "Yours reset"} at ${formatResetClock(
-        limit.resetsAt,
+        limit.resetsAt
       )}${resetDistance ? `, ${resetDistance} from now` : ""}.`
     : "";
 
   const showUpgrade = isFreePlan && upgrade.canManageBilling;
   // A paid org at its own ceiling has no self-serve step left, so it gets the
   // sales path instead of a checkout button.
-  const showEnterprise = !isFreePlan && upgrade.currentPlan !== "enterprise";
+  const showEnterprise = !isFreePlan && upgrade.effectivePlan !== "enterprise";
   // The eval figure comes from the plan catalog, never a hardcoded string, so
   // it tracks whatever billing actually enforces. Credits deliberately have no
   // figure: they aren't in the catalog, so the only source would be the
@@ -246,8 +246,8 @@ export function PlanLimitDialog() {
           : "a monthly allowance instead of a daily cap"
       }, so evals can run smoothly on every PR instead of limiting your daily quality checks.`
     : showEnterprise
-      ? "Enterprise adds negotiated usage and a custom LLM budget."
-      : "";
+    ? "Enterprise adds negotiated usage and a custom LLM budget."
+    : "";
 
   return (
     <PlanLimitDialogView

--- a/mcpjam-inspector/client/src/components/billing/PlanLimitDialog.tsx
+++ b/mcpjam-inspector/client/src/components/billing/PlanLimitDialog.tsx
@@ -1,7 +1,9 @@
 import { useCallback, useEffect, useRef, useState } from "react";
 import { useOrganizationBilling } from "@/hooks/useOrganizationBilling";
 import {
-  consumeUpgradeReturnToken,
+  clearUpgradeReturnToken,
+  markUpgradeReturnWaited,
+  readUpgradeReturnToken,
   UPGRADE_RETURN_ORG_PARAM,
   UPGRADE_RETURN_ORIGIN_PARAM,
   UPGRADE_RETURN_PARAM,
@@ -103,7 +105,9 @@ function UpgradeReturnFlow({
 }) {
   const [settlementGraceElapsed, setSettlementGraceElapsed] = useState(false);
   const settledRef = useRef(false);
-  const waitReportedRef = useRef(false);
+  // Seeded from the ticket: a wait reported before a reload still counts, so
+  // the confirmation that lands afterwards is recorded as "late".
+  const waitReportedRef = useRef(readUpgradeReturnToken()?.waited === true);
   const { billingStatus, planCatalog, isLoadingBilling } =
     useOrganizationBilling(upgradeReturn.organizationId);
 
@@ -141,8 +145,14 @@ function UpgradeReturnFlow({
       : "pending";
     if (upgraded) {
       settledRef.current = true;
+      // Outcome known — this is the only success path that retires the ticket.
+      clearUpgradeReturnToken();
     } else {
       waitReportedRef.current = true;
+      // Kept, deliberately: a webhook slower than the grace window is still a
+      // real purchase, and the ticket is what lets a later load confirm it.
+      // The TTL retires it if nothing ever settles.
+      markUpgradeReturnWaited();
     }
 
     if (upgraded) {
@@ -180,32 +190,25 @@ function UpgradeReturnFlow({
 }
 
 function UpgradeReturnFlowBoundary() {
-  const [pendingReturn] = useState<UpgradeReturn | null>(() =>
-    readUpgradeReturnParams()
-  );
-  const [upgradeReturn, setUpgradeReturn] = useState<UpgradeReturn | null>(
-    null
-  );
-  const claimedRef = useRef(false);
+  // Armed from the ticket, which outlives a reload, rather than from the URL,
+  // which does not. Stripe's webhook can land after the user has refreshed or
+  // navigated, and the confirmation they paid for must not depend on the tab
+  // sitting still until it does.
+  const [upgradeReturn] = useState<UpgradeReturn | null>(() => {
+    const ticket = readUpgradeReturnToken();
+    return ticket
+      ? { organizationId: ticket.organizationId, origin: ticket.origin }
+      : null;
+  });
+  const strippedRef = useRef(false);
 
-  // Claiming is a side effect — it burns the one-shot token and rewrites the
-  // URL — so it runs in an effect, guarded to once. The app mounts under
-  // StrictMode, which double-invokes render-phase work and remounts effects in
-  // dev; a marker claimed twice is a confirmation lost.
+  // The params are bookkeeping for the round trip, never the authority: strip
+  // them on arrival so a reload, bookmark, or pasted link carries nothing.
   useEffect(() => {
-    if (!pendingReturn || claimedRef.current) return;
-    claimedRef.current = true;
-    // Strip regardless of the outcome: these params must not survive into a
-    // reload, a bookmark, or a link pasted to someone else.
-    stripUpgradeReturnParams();
-    // Only the tab that started checkout can settle a return. Without this the
-    // marker is just a URL: anyone loading it in an org already on a paid plan
-    // gets a purchase confirmation, and the funnel gets a conversion, for a
-    // checkout that never happened.
-    if (consumeUpgradeReturnToken(pendingReturn.organizationId)) {
-      setUpgradeReturn(pendingReturn);
-    }
-  }, [pendingReturn]);
+    if (strippedRef.current) return;
+    strippedRef.current = true;
+    if (readUpgradeReturnParams()) stripUpgradeReturnParams();
+  }, []);
 
   if (!upgradeReturn) return null;
 
@@ -410,7 +413,7 @@ function PlanLimitWall() {
   const upgradeSentence = !isBillingReady
     ? ""
     : isFreePlan
-    ? `Our ${upgrade.teamName} plan includes ${
+    ? `The ${upgrade.teamName} plan includes ${
         upgrade.teamEvalIterations
           ? `${formatCount(upgrade.teamEvalIterations)} per seat each month`
           : "a monthly allowance instead of a daily cap"

--- a/mcpjam-inspector/client/src/components/billing/PlanLimitDialog.tsx
+++ b/mcpjam-inspector/client/src/components/billing/PlanLimitDialog.tsx
@@ -248,7 +248,16 @@ function UpgradeReturnFlowBoundary() {
     if (hasUpgradeReturnParams()) stripUpgradeReturnParams();
   }, []);
 
-  if (!upgradeReturn) return null;
+  // Decided during render, not in the effect above. The effect is passive —
+  // it commits a render late — and React runs child effects before parent
+  // ones, so on the single commit where identity drops and a paid billing
+  // update arrive together, the flow's own settle effect would fire the
+  // confirmation before the disarm landed. Gating here means the child is
+  // simply not rendered on that commit, so it has no effect left to run. The
+  // effect above stays for the storage bookkeeping.
+  const activeReturn =
+    userId && upgradeReturn?.userId === userId ? upgradeReturn : null;
+  if (!activeReturn) return null;
 
   // The org id rides in from a URL, so the billing query can reject it — a
   // deleted org, or membership revoked between checkout and return. Convex
@@ -256,7 +265,7 @@ function UpgradeReturnFlowBoundary() {
   // so without a boundary one bad marker replaces the entire app.
   return (
     <ErrorBoundary name="upgrade-return-flow" fallback={null}>
-      <UpgradeReturnFlow upgradeReturn={upgradeReturn} />
+      <UpgradeReturnFlow upgradeReturn={activeReturn} />
     </ErrorBoundary>
   );
 }

--- a/mcpjam-inspector/client/src/components/billing/PlanLimitDialog.tsx
+++ b/mcpjam-inspector/client/src/components/billing/PlanLimitDialog.tsx
@@ -10,6 +10,7 @@ import {
   useUpgradeCheckout,
   type UpgradeOrigin,
 } from "@/hooks/use-upgrade-checkout";
+import { useAuth } from "@workos-inc/authkit-react";
 import { ErrorBoundary } from "@/components/ui/error-boundary";
 import { track } from "@/lib/analytics";
 import { toast } from "@/lib/toast";
@@ -57,21 +58,21 @@ function formatResetDistance(resetsAt: number): string | null {
 interface UpgradeReturn {
   organizationId: string;
   origin: UpgradeOrigin;
+  /** The buyer, carried so the flow can re-read its own ticket. */
+  userId: string;
 }
 
-/** Pure: reading the URL is safe to repeat. Claiming the return is not, and
- * happens once in an effect below. */
-function readUpgradeReturnParams(): UpgradeReturn | null {
-  if (typeof window === "undefined") return null;
-  const params = new URLSearchParams(window.location.search);
-  if (params.get(UPGRADE_RETURN_PARAM) !== "return") return null;
-  const organizationId = params.get(UPGRADE_RETURN_ORG_PARAM);
-  if (!organizationId) return null;
-  const rawOrigin = params.get(UPGRADE_RETURN_ORIGIN_PARAM);
-  return {
-    organizationId,
-    origin: rawOrigin === "credits" ? "credits" : "evals",
-  };
+/**
+ * Only asks whether there is round-trip bookkeeping to clean off the URL. The
+ * params carry no authority any more — the ticket says which org, which
+ * origin, and whose checkout it was — so nothing is read out of them.
+ */
+function hasUpgradeReturnParams(): boolean {
+  if (typeof window === "undefined") return false;
+  return (
+    new URLSearchParams(window.location.search).get(UPGRADE_RETURN_PARAM) ===
+    "return"
+  );
 }
 
 function stripUpgradeReturnParams(): void {
@@ -107,7 +108,9 @@ function UpgradeReturnFlow({
   const settledRef = useRef(false);
   // Seeded from the ticket: a wait reported before a reload still counts, so
   // the confirmation that lands afterwards is recorded as "late".
-  const waitReportedRef = useRef(readUpgradeReturnToken()?.waited === true);
+  const waitReportedRef = useRef(
+    readUpgradeReturnToken(upgradeReturn.userId)?.waited === true
+  );
   const { billingStatus, planCatalog, isLoadingBilling } =
     useOrganizationBilling(upgradeReturn.organizationId);
 
@@ -194,20 +197,42 @@ function UpgradeReturnFlowBoundary() {
   // which does not. Stripe's webhook can land after the user has refreshed or
   // navigated, and the confirmation they paid for must not depend on the tab
   // sitting still until it does.
-  const [upgradeReturn] = useState<UpgradeReturn | null>(() => {
-    const ticket = readUpgradeReturnToken();
-    return ticket
-      ? { organizationId: ticket.organizationId, origin: ticket.origin }
-      : null;
-  });
+  //
+  // Armed against an identity, not just a tab: sessionStorage outlives a
+  // sign-out, so the next person in this tab would otherwise inherit a pending
+  // confirmation — and its conversion event — from the previous one.
+  const { user } = useAuth();
+  const userId = user?.id ?? null;
+  const [upgradeReturn, setUpgradeReturn] = useState<UpgradeReturn | null>(
+    null
+  );
+  const armedForRef = useRef<string | null>(null);
   const strippedRef = useRef(false);
+
+  useEffect(() => {
+    // Nothing to check against yet; the ticket keeps waiting.
+    if (!userId || armedForRef.current === userId) return;
+    armedForRef.current = userId;
+    // Retires the ticket itself when it belongs to someone else, so an
+    // identity switch inside this tab both disarms and cleans up.
+    const ticket = readUpgradeReturnToken(userId);
+    setUpgradeReturn(
+      ticket
+        ? {
+            organizationId: ticket.organizationId,
+            origin: ticket.origin,
+            userId: ticket.userId,
+          }
+        : null
+    );
+  }, [userId]);
 
   // The params are bookkeeping for the round trip, never the authority: strip
   // them on arrival so a reload, bookmark, or pasted link carries nothing.
   useEffect(() => {
     if (strippedRef.current) return;
     strippedRef.current = true;
-    if (readUpgradeReturnParams()) stripUpgradeReturnParams();
+    if (hasUpgradeReturnParams()) stripUpgradeReturnParams();
   }, []);
 
   if (!upgradeReturn) return null;

--- a/mcpjam-inspector/client/src/components/billing/PlanLimitDialog.tsx
+++ b/mcpjam-inspector/client/src/components/billing/PlanLimitDialog.tsx
@@ -149,13 +149,13 @@ function UpgradeReturnFlow({
     if (upgraded) {
       settledRef.current = true;
       // Outcome known — this is the only success path that retires the ticket.
-      clearUpgradeReturnToken();
+      clearUpgradeReturnToken(upgradeReturn.userId);
     } else {
       waitReportedRef.current = true;
       // Kept, deliberately: a webhook slower than the grace window is still a
       // real purchase, and the ticket is what lets a later load confirm it.
       // The TTL retires it if nothing ever settles.
-      markUpgradeReturnWaited();
+      markUpgradeReturnWaited(upgradeReturn.userId);
     }
 
     if (upgraded) {

--- a/mcpjam-inspector/client/src/components/billing/PlanLimitDialog.tsx
+++ b/mcpjam-inspector/client/src/components/billing/PlanLimitDialog.tsx
@@ -149,8 +149,8 @@ function UpgradeReturnFlow({
       const teamName = planCatalog?.plans.team.displayName ?? "Team";
       toast.success(
         upgradeReturn.origin === "credits"
-          ? `You're on our ${teamName} plan. Your credits are available now.`
-          : `You're on our ${teamName} plan. Run your suite again to pick up where you left off.`
+          ? `You're on the ${teamName} plan. Your credits are available now.`
+          : `You're on the ${teamName} plan. Run your suite again to pick up where you left off.`
       );
     }
 

--- a/mcpjam-inspector/client/src/components/billing/PlanLimitDialog.tsx
+++ b/mcpjam-inspector/client/src/components/billing/PlanLimitDialog.tsx
@@ -175,7 +175,10 @@ export function PlanLimitDialog() {
     origin: "evals",
     limitKind: limit?.kind ?? "evalIterations",
   });
-  const requestRecipients = useUpgradeRequestRecipients(organizationId);
+  const {
+    recipients: requestRecipients,
+    isLoading: isLoadingRequestRecipients,
+  } = useUpgradeRequestRecipients(organizationId);
 
   useEffect(() => {
     if (!isOpen || !limit) {
@@ -188,6 +191,9 @@ export function PlanLimitDialog() {
     const showUpgrade = isFreePlan && upgrade.canManageBilling;
     const showEnterprise =
       !isFreePlan && upgrade.effectivePlan !== "enterprise";
+    const showRequest = !showUpgrade && !showEnterprise;
+    if (showRequest && isLoadingRequestRecipients) return;
+
     impressionTrackedRef.current = true;
     track("plan_limit_dialog_shown", {
       location: "plan_limit_dialog",
@@ -216,6 +222,7 @@ export function PlanLimitDialog() {
     });
   }, [
     isOpen,
+    isLoadingRequestRecipients,
     limit,
     organizationId,
     requestRecipients.length,

--- a/mcpjam-inspector/client/src/components/billing/PlanLimitDialog.tsx
+++ b/mcpjam-inspector/client/src/components/billing/PlanLimitDialog.tsx
@@ -16,6 +16,12 @@ import { PlanLimitDialogView } from "@/components/billing/PlanLimitDialogView";
 /** Same destination as the pricing page's Enterprise CTA. */
 const ENTERPRISE_CONTACT_URL = "https://www.mcpjam.com/contact";
 
+// Stripe redirects before its webhook-backed billing state is guaranteed to
+// have reached the client. Keep the return marker alive briefly so the reactive
+// billing query can observe a successful plan change before we classify a
+// still-Free result as an abandoned checkout.
+const UPGRADE_RETURN_SETTLEMENT_GRACE_MS = 30_000;
+
 function formatCount(value: number): string {
   return new Intl.NumberFormat().format(value);
 }
@@ -90,17 +96,37 @@ function useUpgradeReturnFlow(): void {
   const [upgradeReturn] = useState<UpgradeReturn | null>(() =>
     readUpgradeReturn(),
   );
+  const [settlementGraceElapsed, setSettlementGraceElapsed] = useState(false);
   const handledRef = useRef(false);
   const { billingStatus, planCatalog, isLoadingBilling } =
     useOrganizationBilling(upgradeReturn?.organizationId ?? null);
 
   useEffect(() => {
+    if (
+      !upgradeReturn ||
+      handledRef.current ||
+      isLoadingBilling ||
+      billingStatus?.plan !== "free"
+    ) {
+      return;
+    }
+
+    const timeoutId = window.setTimeout(() => {
+      setSettlementGraceElapsed(true);
+    }, UPGRADE_RETURN_SETTLEMENT_GRACE_MS);
+    return () => window.clearTimeout(timeoutId);
+  }, [billingStatus?.plan, isLoadingBilling, upgradeReturn]);
+
+  useEffect(() => {
     if (!upgradeReturn || handledRef.current) return;
     if (isLoadingBilling || !billingStatus) return;
+
+    const upgraded = billingStatus.plan !== "free";
+    if (!upgraded && !settlementGraceElapsed) return;
+
     handledRef.current = true;
     stripUpgradeReturnParams();
 
-    const upgraded = billingStatus.plan !== "free";
     if (upgraded) {
       const teamName = planCatalog?.plans.team.displayName ?? "Team";
       toast.success(
@@ -121,6 +147,7 @@ function useUpgradeReturnFlow(): void {
     billingStatus,
     isLoadingBilling,
     planCatalog,
+    settlementGraceElapsed,
     upgradeReturn,
   ]);
 }

--- a/mcpjam-inspector/client/src/components/billing/PlanLimitDialog.tsx
+++ b/mcpjam-inspector/client/src/components/billing/PlanLimitDialog.tsx
@@ -210,8 +210,21 @@ function UpgradeReturnFlowBoundary() {
   const strippedRef = useRef(false);
 
   useEffect(() => {
-    // Nothing to check against yet; the ticket keeps waiting.
-    if (!userId || armedForRef.current === userId) return;
+    if (!userId) {
+      // Signed out. Drop the in-memory flow rather than leaving it armed for
+      // whoever signs in next: it would otherwise stay subscribed to the
+      // previous buyer's org, and React runs child effects before parent ones,
+      // so a confirmation could fire on the very commit that swaps identity —
+      // before this effect got the chance to disarm it.
+      //
+      // The ticket in storage is deliberately untouched: a token refresh looks
+      // exactly like this, and the same user coming back re-arms from it. A
+      // different user retires it on the next arm.
+      armedForRef.current = null;
+      setUpgradeReturn(null);
+      return;
+    }
+    if (armedForRef.current === userId) return;
     armedForRef.current = userId;
     // Retires the ticket itself when it belongs to someone else, so an
     // identity switch inside this tab both disarms and cleans up.

--- a/mcpjam-inspector/client/src/components/billing/PlanLimitDialog.tsx
+++ b/mcpjam-inspector/client/src/components/billing/PlanLimitDialog.tsx
@@ -143,8 +143,7 @@ export function PlanLimitDialog() {
     origin: "evals",
     limitKind: limit?.kind ?? "evalIterations",
   });
-  const { recipients: requestRecipients, isLoading: isLoadingRecipients } =
-    useUpgradeRequestRecipients(organizationId);
+  const requestRecipients = useUpgradeRequestRecipients(organizationId);
 
   useEffect(() => {
     if (!isOpen || !limit) return;
@@ -234,7 +233,6 @@ export function PlanLimitDialog() {
       showUpgrade={showUpgrade}
       showEnterprise={showEnterprise}
       requestRecipients={requestRecipients}
-      isLoadingRecipients={isLoadingRecipients}
       organizationName={upgrade.organizationName}
       origin="evals"
       limitKind={limit.kind}

--- a/mcpjam-inspector/client/src/components/billing/PlanLimitDialogPreview.tsx
+++ b/mcpjam-inspector/client/src/components/billing/PlanLimitDialogPreview.tsx
@@ -69,7 +69,7 @@ const VARIANTS: PreviewVariant[] = [
       ...SHARED,
       title: "You're out of eval iterations today",
       description:
-        "Free includes 75 a day, and yours reset at 8:00 PM, about 9 hours from now. Our Team plan includes 5,000 per seat each month, so evals can run smoothly on every PR instead of limiting your daily quality checks.",
+        "Free includes 75 a day, and yours reset at 8:00 PM, about 9 hours from now. The Team plan includes 5,000 per seat each month, so evals can run smoothly on every PR instead of limiting your daily quality checks.",
       showUpgrade: true,
       showEnterprise: false,
       requestRecipients: [],
@@ -83,7 +83,7 @@ const VARIANTS: PreviewVariant[] = [
       ...SHARED,
       title: "You're out of eval iterations today",
       description:
-        "Free includes 75 a day, and yours reset at 8:00 PM, about 9 hours from now. Our Team plan includes 5,000 per seat each month, so evals can run smoothly on every PR instead of limiting your daily quality checks. Only an owner can upgrade this organization.",
+        "Free includes 75 a day, and yours reset at 8:00 PM, about 9 hours from now. The Team plan includes 5,000 per seat each month, so evals can run smoothly on every PR instead of limiting your daily quality checks. Only an owner can upgrade this organization.",
       showUpgrade: false,
       showEnterprise: false,
       requestRecipients: [
@@ -140,7 +140,7 @@ const CREDITS_VARIANTS: CreditsVariant[] = [
     props: {
       ...CREDITS_SHARED,
       description:
-        "Free credits reset daily. Our Team plan replaces the daily cap with a monthly allowance per seat, so usage isn't rationed day to day.",
+        "Free credits reset daily. The Team plan replaces the daily cap with a monthly allowance per seat, so usage isn't rationed day to day.",
       isKnownNonManager: false,
       showUpgrade: true,
       requestRecipients: [],

--- a/mcpjam-inspector/client/src/components/billing/PlanLimitDialogPreview.tsx
+++ b/mcpjam-inspector/client/src/components/billing/PlanLimitDialogPreview.tsx
@@ -91,24 +91,9 @@ const VARIANTS: PreviewVariant[] = [
     },
   },
   {
-    id: "owner-loading",
-    label: "Cannot upgrade, owner lookup pending",
-    note: "The members query is still in flight. A disabled button holds the space so nothing pops in late.",
-    props: {
-      ...SHARED,
-      title: "You're out of eval iterations today",
-      description:
-        "Free includes 75 a day, and yours reset at 8:00 PM, about 9 hours from now. Only an owner can upgrade this organization.",
-      showUpgrade: false,
-      showEnterprise: false,
-      requestRecipients: [],
-      isLoadingRecipients: true,
-    },
-  },
-  {
     id: "no-owner",
     label: "Cannot upgrade, no owner found",
-    note: "Lookup finished and found no reachable owner. The button hides rather than opening an empty draft.",
+    note: "No reachable owner, or the lookup hasn't returned yet. Either way there's no address to write to, so the button hides rather than opening an empty draft.",
     props: {
       ...SHARED,
       title: "You're out of eval iterations today",

--- a/mcpjam-inspector/client/src/components/billing/PlanLimitDialogPreview.tsx
+++ b/mcpjam-inspector/client/src/components/billing/PlanLimitDialogPreview.tsx
@@ -4,10 +4,14 @@ import {
   PlanLimitDialogView,
   type PlanLimitDialogViewProps,
 } from "@/components/billing/PlanLimitDialogView";
+import {
+  CreditsLimitDialogView,
+  type CreditsLimitDialogViewProps,
+} from "@/components/billing/CreditsLimitDialogView";
 
 /**
- * Dev-only harness for the eval-iteration wall, reachable at
- * `/__preview/plan-limit` while the dev server runs.
+ * Dev-only harness for both free-plan walls (eval iterations and credits),
+ * reachable at `/__preview/plan-limit` while the dev server runs.
  *
  * Mounted from `main.tsx` BEFORE the auth and Convex providers, so it needs no
  * sign-in, no hosted org, and no organization sitting at its cap — states that
@@ -19,18 +23,30 @@ import {
  * call site in `main.tsx`.
  */
 
+type SharedHandlers =
+  | "interval"
+  | "onIntervalChange"
+  | "onUpgrade"
+  | "onDismiss"
+  | "modal";
+
 type PreviewVariant = {
   id: string;
   label: string;
   note: string;
   props: Omit<
     PlanLimitDialogViewProps,
-    | "interval"
-    | "onIntervalChange"
-    | "onUpgrade"
-    | "onRequestEnterprise"
-    | "onDismiss"
-    | "modal"
+    SharedHandlers | "onRequestEnterprise"
+  >;
+};
+
+type CreditsVariant = {
+  id: string;
+  label: string;
+  note: string;
+  props: Omit<
+    CreditsLimitDialogViewProps,
+    SharedHandlers | "onBuyCredits" | "onUseOwnKey"
   >;
 };
 
@@ -106,35 +122,127 @@ const VARIANTS: PreviewVariant[] = [
   },
 ];
 
+const CREDITS_SHARED = {
+  organizationName: "Acme Robotics",
+  annualPriceLabel: "$30",
+  monthlyPriceLabel: "$38",
+  annualDiscountPct: 21,
+  annualSupported: true,
+  monthlySupported: true,
+  teamName: "Team",
+  isStarting: false,
+};
+
+const CREDITS_VARIANTS: CreditsVariant[] = [
+  {
+    id: "credits-free-owner",
+    label: "Free, can upgrade",
+    note: "Upgrade leads. Buying credits stays available one step down, and bring-your-own-key drops to a link, because both of those keep the org on Free.",
+    props: {
+      ...CREDITS_SHARED,
+      description:
+        "Free credits reset daily. Our Team plan replaces the daily cap with a monthly allowance per seat, so usage isn't rationed day to day.",
+      isKnownNonManager: false,
+      showUpgrade: true,
+      requestRecipients: [],
+    },
+  },
+  {
+    id: "credits-paid",
+    label: "Paid plan, out of credits",
+    note: "Already on Team, so there is no plan to pitch. Credits are the actual answer here.",
+    props: {
+      ...CREDITS_SHARED,
+      description: "Buy credits to keep your team going, or use your own API key.",
+      isKnownNonManager: false,
+      showUpgrade: false,
+      requestRecipients: [],
+    },
+  },
+  {
+    id: "credits-member",
+    label: "Member, cannot buy or upgrade",
+    note: "Can do neither, so the only action is asking someone who can.",
+    props: {
+      ...CREDITS_SHARED,
+      description:
+        "Ask an organization owner or admin to buy credits or upgrade the plan.",
+      isKnownNonManager: true,
+      showUpgrade: false,
+      requestRecipients: [{ email: "dana@acmerobotics.com", name: "Dana Ruiz" }],
+    },
+  },
+];
+
+const WALLS = [
+  { id: "evals" as const, label: "Eval iterations" },
+  { id: "credits" as const, label: "Credits" },
+];
+
 export function PlanLimitDialogPreview() {
+  const [wall, setWall] = useState<"evals" | "credits">("evals");
   const [variantId, setVariantId] = useState(VARIANTS[0].id);
+  const [creditsVariantId, setCreditsVariantId] = useState(
+    CREDITS_VARIANTS[0].id,
+  );
   const [interval, setInterval] = useState<BillingInterval>("annual");
   const [lastAction, setLastAction] = useState<string | null>(null);
   const variant = VARIANTS.find((v) => v.id === variantId) ?? VARIANTS[0];
+  const creditsVariant =
+    CREDITS_VARIANTS.find((v) => v.id === creditsVariantId) ??
+    CREDITS_VARIANTS[0];
+  const activeVariants = wall === "evals" ? VARIANTS : CREDITS_VARIANTS;
+  const activeVariantId = wall === "evals" ? variantId : creditsVariantId;
+  const setActiveVariantId = wall === "evals" ? setVariantId : setCreditsVariantId;
+  const activeNote = wall === "evals" ? variant.note : creditsVariant.note;
 
   return (
     <div className="min-h-screen bg-background p-6 text-foreground">
       <div className="mx-auto max-w-2xl space-y-4">
         <div>
           <h1 className="text-lg font-semibold tracking-tight">
-            Eval limit wall preview
+            Limit wall preview
           </h1>
           <p className="text-sm text-muted-foreground">
-            Real component, real styles, dummy data. Dev only.
+            Real components, real styles, dummy data. Dev only.
           </p>
         </div>
 
+        <div
+          role="group"
+          aria-label="Wall"
+          className="inline-flex items-center gap-0.5 rounded-md border border-border/60 bg-muted/40 p-0.5 text-xs"
+        >
+          {WALLS.map((w) => (
+            <button
+              key={w.id}
+              type="button"
+              onClick={() => {
+                setWall(w.id);
+                setLastAction(null);
+              }}
+              className={
+                w.id === wall
+                  ? "rounded bg-background px-3 py-1 font-medium shadow-sm"
+                  : "rounded px-3 py-1 font-medium text-muted-foreground"
+              }
+            >
+              {w.label}
+            </button>
+          ))}
+        </div>
+
         <div className="flex flex-wrap gap-2">
-          {VARIANTS.map((v) => (
+          {activeVariants.map((v) => (
             <button
               key={v.id}
               type="button"
               onClick={() => {
-                setVariantId(v.id);
+                setActiveVariantId(v.id);
                 setLastAction(null);
               }}
               className={
-                v.id === variantId
+                v.id === activeVariantId
                   ? "rounded-md border border-primary bg-primary/10 px-3 py-1.5 text-sm font-medium"
                   : "rounded-md border border-border px-3 py-1.5 text-sm text-muted-foreground hover:border-foreground/40"
               }
@@ -144,7 +252,7 @@ export function PlanLimitDialogPreview() {
           ))}
         </div>
 
-        <p className="text-sm text-muted-foreground">{variant.note}</p>
+        <p className="text-sm text-muted-foreground">{activeNote}</p>
 
         <div className="rounded-md border border-border bg-muted/30 p-3 text-sm">
           <span className="text-muted-foreground">Selected interval: </span>
@@ -158,18 +266,34 @@ export function PlanLimitDialogPreview() {
         </div>
       </div>
 
-      <PlanLimitDialogView
-        key={variant.id}
-        {...variant.props}
-        modal={false}
-        interval={interval}
-        onIntervalChange={setInterval}
-        onUpgrade={() => setLastAction(`checkout would start (${interval})`)}
-        onRequestEnterprise={() =>
-          setLastAction("would open mcpjam.com/contact in a new tab")
-        }
-        onDismiss={() => setLastAction("dismissed")}
-      />
+      {wall === "evals" ? (
+        <PlanLimitDialogView
+          key={variant.id}
+          {...variant.props}
+          modal={false}
+          interval={interval}
+          onIntervalChange={setInterval}
+          onUpgrade={() => setLastAction(`checkout would start (${interval})`)}
+          onRequestEnterprise={() =>
+            setLastAction("would open mcpjam.com/contact in a new tab")
+          }
+          onDismiss={() => setLastAction("dismissed")}
+        />
+      ) : (
+        <CreditsLimitDialogView
+          key={creditsVariant.id}
+          {...creditsVariant.props}
+          modal={false}
+          interval={interval}
+          onIntervalChange={setInterval}
+          onUpgrade={() => setLastAction(`checkout would start (${interval})`)}
+          onBuyCredits={() => setLastAction("would open the buy-credits dialog")}
+          onUseOwnKey={() =>
+            setLastAction("would open the model picker's providers tab")
+          }
+          onDismiss={() => setLastAction("dismissed")}
+        />
+      )}
     </div>
   );
 }

--- a/mcpjam-inspector/client/src/components/billing/PlanLimitDialogPreview.tsx
+++ b/mcpjam-inspector/client/src/components/billing/PlanLimitDialogPreview.tsx
@@ -1,0 +1,175 @@
+import { useState } from "react";
+import type { BillingInterval } from "@/hooks/useOrganizationBilling";
+import {
+  PlanLimitDialogView,
+  type PlanLimitDialogViewProps,
+} from "@/components/billing/PlanLimitDialogView";
+
+/**
+ * Dev-only harness for the eval-iteration wall, reachable at
+ * `/__preview/plan-limit` while the dev server runs.
+ *
+ * Mounted from `main.tsx` BEFORE the auth and Convex providers, so it needs no
+ * sign-in, no hosted org, and no organization sitting at its cap — states that
+ * are otherwise impossible to reach on demand. It renders the real
+ * `PlanLimitDialogView` with the real stylesheet, so what you see is what
+ * production renders; only the data is fake.
+ *
+ * Excluded from production bundles by the `import.meta.env.DEV` guard at the
+ * call site in `main.tsx`.
+ */
+
+type PreviewVariant = {
+  id: string;
+  label: string;
+  note: string;
+  props: Omit<
+    PlanLimitDialogViewProps,
+    | "interval"
+    | "onIntervalChange"
+    | "onUpgrade"
+    | "onRequestEnterprise"
+    | "onDismiss"
+    | "modal"
+  >;
+};
+
+const SHARED = {
+  organizationName: "Acme Robotics",
+  origin: "evals" as const,
+  limitKind: "evalIterations",
+  annualPriceLabel: "$30/seat/mo",
+  monthlyPriceLabel: "$38/seat/mo",
+  annualDiscountPct: 21,
+  annualSupported: true,
+  monthlySupported: true,
+  teamName: "Team",
+  isStarting: false,
+};
+
+const VARIANTS: PreviewVariant[] = [
+  {
+    id: "free-owner",
+    label: "Free, can upgrade",
+    note: "The main case: an owner or admin on Free who just got blocked mid-suite.",
+    props: {
+      ...SHARED,
+      title: "You're out of eval iterations today",
+      description:
+        "Free includes 75 a day, and yours reset at 8:00 PM, about 9 hours from now. Our Team plan includes 5,000 a month, so evals can run smoothly on every PR instead of limiting your daily quality checks.",
+      showUpgrade: true,
+      showEnterprise: false,
+      requestRecipients: [],
+    },
+  },
+  {
+    id: "free-member",
+    label: "Free, cannot upgrade",
+    note: "A member. Cannot check out, so the action is an email to the owner with the steps.",
+    props: {
+      ...SHARED,
+      title: "You're out of eval iterations today",
+      description:
+        "Free includes 75 a day, and yours reset at 8:00 PM, about 9 hours from now. Our Team plan includes 5,000 a month, so evals can run smoothly on every PR instead of limiting your daily quality checks. Only an organization owner can upgrade.",
+      showUpgrade: false,
+      showEnterprise: false,
+      requestRecipients: [{ email: "dana@acmerobotics.com", name: "Dana Ruiz" }],
+    },
+  },
+  {
+    id: "team-ceiling",
+    label: "Team, at its ceiling",
+    note: "Already paying. No self-serve step left, so the path is sales.",
+    props: {
+      ...SHARED,
+      title: "You're out of eval iterations this month",
+      description:
+        "Your plan includes 5,000 a month, and yours reset at 12:00 AM, about 9 days from now. Enterprise adds negotiated usage and a custom LLM budget.",
+      showUpgrade: false,
+      showEnterprise: true,
+      requestRecipients: [],
+    },
+  },
+  {
+    id: "no-owner",
+    label: "Cannot upgrade, no owner found",
+    note: "Owner lookup returned nothing. The email button hides rather than opening an empty draft.",
+    props: {
+      ...SHARED,
+      title: "You're out of eval iterations today",
+      description:
+        "Free includes 75 a day, and yours reset at 8:00 PM, about 9 hours from now. Only an organization owner can upgrade.",
+      showUpgrade: false,
+      showEnterprise: false,
+      requestRecipients: [],
+    },
+  },
+];
+
+export function PlanLimitDialogPreview() {
+  const [variantId, setVariantId] = useState(VARIANTS[0].id);
+  const [interval, setInterval] = useState<BillingInterval>("annual");
+  const [lastAction, setLastAction] = useState<string | null>(null);
+  const variant = VARIANTS.find((v) => v.id === variantId) ?? VARIANTS[0];
+
+  return (
+    <div className="min-h-screen bg-background p-6 text-foreground">
+      <div className="mx-auto max-w-2xl space-y-4">
+        <div>
+          <h1 className="text-lg font-semibold tracking-tight">
+            Eval limit wall preview
+          </h1>
+          <p className="text-sm text-muted-foreground">
+            Real component, real styles, dummy data. Dev only.
+          </p>
+        </div>
+
+        <div className="flex flex-wrap gap-2">
+          {VARIANTS.map((v) => (
+            <button
+              key={v.id}
+              type="button"
+              onClick={() => {
+                setVariantId(v.id);
+                setLastAction(null);
+              }}
+              className={
+                v.id === variantId
+                  ? "rounded-md border border-primary bg-primary/10 px-3 py-1.5 text-sm font-medium"
+                  : "rounded-md border border-border px-3 py-1.5 text-sm text-muted-foreground hover:border-foreground/40"
+              }
+            >
+              {v.label}
+            </button>
+          ))}
+        </div>
+
+        <p className="text-sm text-muted-foreground">{variant.note}</p>
+
+        <div className="rounded-md border border-border bg-muted/30 p-3 text-sm">
+          <span className="text-muted-foreground">Selected interval: </span>
+          <span className="font-medium">{interval}</span>
+          {lastAction ? (
+            <>
+              <span className="text-muted-foreground"> · last action: </span>
+              <span className="font-medium">{lastAction}</span>
+            </>
+          ) : null}
+        </div>
+      </div>
+
+      <PlanLimitDialogView
+        key={variant.id}
+        {...variant.props}
+        modal={false}
+        interval={interval}
+        onIntervalChange={setInterval}
+        onUpgrade={() => setLastAction(`checkout would start (${interval})`)}
+        onRequestEnterprise={() =>
+          setLastAction("would open mcpjam.com/contact in a new tab")
+        }
+        onDismiss={() => setLastAction("dismissed")}
+      />
+    </div>
+  );
+}

--- a/mcpjam-inspector/client/src/components/billing/PlanLimitDialogPreview.tsx
+++ b/mcpjam-inspector/client/src/components/billing/PlanLimitDialogPreview.tsx
@@ -34,10 +34,7 @@ type PreviewVariant = {
   id: string;
   label: string;
   note: string;
-  props: Omit<
-    PlanLimitDialogViewProps,
-    SharedHandlers | "onRequestEnterprise"
-  >;
+  props: Omit<PlanLimitDialogViewProps, SharedHandlers | "onRequestEnterprise">;
 };
 
 type CreditsVariant = {
@@ -72,7 +69,7 @@ const VARIANTS: PreviewVariant[] = [
       ...SHARED,
       title: "You're out of eval iterations today",
       description:
-        "Free includes 75 a day, and yours reset at 8:00 PM, about 9 hours from now. Our Team plan includes 5,000 a month, so evals can run smoothly on every PR instead of limiting your daily quality checks.",
+        "Free includes 75 a day, and yours reset at 8:00 PM, about 9 hours from now. Our Team plan includes 5,000 per seat each month, so evals can run smoothly on every PR instead of limiting your daily quality checks.",
       showUpgrade: true,
       showEnterprise: false,
       requestRecipients: [],
@@ -86,10 +83,12 @@ const VARIANTS: PreviewVariant[] = [
       ...SHARED,
       title: "You're out of eval iterations today",
       description:
-        "Free includes 75 a day, and yours reset at 8:00 PM, about 9 hours from now. Our Team plan includes 5,000 a month, so evals can run smoothly on every PR instead of limiting your daily quality checks. Only an owner can upgrade this organization.",
+        "Free includes 75 a day, and yours reset at 8:00 PM, about 9 hours from now. Our Team plan includes 5,000 per seat each month, so evals can run smoothly on every PR instead of limiting your daily quality checks. Only an owner can upgrade this organization.",
       showUpgrade: false,
       showEnterprise: false,
-      requestRecipients: [{ email: "dana@acmerobotics.com", name: "Dana Ruiz" }],
+      requestRecipients: [
+        { email: "dana@acmerobotics.com", name: "Dana Ruiz" },
+      ],
     },
   },
   {
@@ -153,7 +152,8 @@ const CREDITS_VARIANTS: CreditsVariant[] = [
     note: "Already on Team, so there is no plan to pitch. Credits are the actual answer here.",
     props: {
       ...CREDITS_SHARED,
-      description: "Buy credits to keep your team going, or use your own API key.",
+      description:
+        "Buy credits to keep your team going, or use your own API key.",
       isKnownNonManager: false,
       showUpgrade: false,
       requestRecipients: [],
@@ -169,7 +169,9 @@ const CREDITS_VARIANTS: CreditsVariant[] = [
         "Ask an organization owner or admin to buy credits or upgrade the plan.",
       isKnownNonManager: true,
       showUpgrade: false,
-      requestRecipients: [{ email: "dana@acmerobotics.com", name: "Dana Ruiz" }],
+      requestRecipients: [
+        { email: "dana@acmerobotics.com", name: "Dana Ruiz" },
+      ],
     },
   },
 ];
@@ -183,7 +185,7 @@ export function PlanLimitDialogPreview() {
   const [wall, setWall] = useState<"evals" | "credits">("evals");
   const [variantId, setVariantId] = useState(VARIANTS[0].id);
   const [creditsVariantId, setCreditsVariantId] = useState(
-    CREDITS_VARIANTS[0].id,
+    CREDITS_VARIANTS[0].id
   );
   const [interval, setInterval] = useState<BillingInterval>("annual");
   const [lastAction, setLastAction] = useState<string | null>(null);
@@ -193,7 +195,8 @@ export function PlanLimitDialogPreview() {
     CREDITS_VARIANTS[0];
   const activeVariants = wall === "evals" ? VARIANTS : CREDITS_VARIANTS;
   const activeVariantId = wall === "evals" ? variantId : creditsVariantId;
-  const setActiveVariantId = wall === "evals" ? setVariantId : setCreditsVariantId;
+  const setActiveVariantId =
+    wall === "evals" ? setVariantId : setCreditsVariantId;
   const activeNote = wall === "evals" ? variant.note : creditsVariant.note;
 
   return (
@@ -287,7 +290,9 @@ export function PlanLimitDialogPreview() {
           interval={interval}
           onIntervalChange={setInterval}
           onUpgrade={() => setLastAction(`checkout would start (${interval})`)}
-          onBuyCredits={() => setLastAction("would open the buy-credits dialog")}
+          onBuyCredits={() =>
+            setLastAction("would open the buy-credits dialog")
+          }
           onUseOwnKey={() =>
             setLastAction("would open the model picker's providers tab")
           }

--- a/mcpjam-inspector/client/src/components/billing/PlanLimitDialogPreview.tsx
+++ b/mcpjam-inspector/client/src/components/billing/PlanLimitDialogPreview.tsx
@@ -38,8 +38,8 @@ const SHARED = {
   organizationName: "Acme Robotics",
   origin: "evals" as const,
   limitKind: "evalIterations",
-  annualPriceLabel: "$30/seat/mo",
-  monthlyPriceLabel: "$38/seat/mo",
+  annualPriceLabel: "$30",
+  monthlyPriceLabel: "$38",
   annualDiscountPct: 21,
   annualSupported: true,
   monthlySupported: true,
@@ -70,7 +70,7 @@ const VARIANTS: PreviewVariant[] = [
       ...SHARED,
       title: "You're out of eval iterations today",
       description:
-        "Free includes 75 a day, and yours reset at 8:00 PM, about 9 hours from now. Our Team plan includes 5,000 a month, so evals can run smoothly on every PR instead of limiting your daily quality checks. Only an organization owner can upgrade.",
+        "Free includes 75 a day, and yours reset at 8:00 PM, about 9 hours from now. Our Team plan includes 5,000 a month, so evals can run smoothly on every PR instead of limiting your daily quality checks. Only an owner can upgrade this organization.",
       showUpgrade: false,
       showEnterprise: false,
       requestRecipients: [{ email: "dana@acmerobotics.com", name: "Dana Ruiz" }],
@@ -91,14 +91,29 @@ const VARIANTS: PreviewVariant[] = [
     },
   },
   {
-    id: "no-owner",
-    label: "Cannot upgrade, no owner found",
-    note: "Owner lookup returned nothing. The email button hides rather than opening an empty draft.",
+    id: "owner-loading",
+    label: "Cannot upgrade, owner lookup pending",
+    note: "The members query is still in flight. A disabled button holds the space so nothing pops in late.",
     props: {
       ...SHARED,
       title: "You're out of eval iterations today",
       description:
-        "Free includes 75 a day, and yours reset at 8:00 PM, about 9 hours from now. Only an organization owner can upgrade.",
+        "Free includes 75 a day, and yours reset at 8:00 PM, about 9 hours from now. Only an owner can upgrade this organization.",
+      showUpgrade: false,
+      showEnterprise: false,
+      requestRecipients: [],
+      isLoadingRecipients: true,
+    },
+  },
+  {
+    id: "no-owner",
+    label: "Cannot upgrade, no owner found",
+    note: "Lookup finished and found no reachable owner. The button hides rather than opening an empty draft.",
+    props: {
+      ...SHARED,
+      title: "You're out of eval iterations today",
+      description:
+        "Free includes 75 a day, and yours reset at 8:00 PM, about 9 hours from now. Only an owner can upgrade this organization.",
       showUpgrade: false,
       showEnterprise: false,
       requestRecipients: [],

--- a/mcpjam-inspector/client/src/components/billing/PlanLimitDialogView.tsx
+++ b/mcpjam-inspector/client/src/components/billing/PlanLimitDialogView.tsx
@@ -24,7 +24,6 @@ export interface PlanLimitDialogViewProps {
   showEnterprise: boolean;
   /** Owner-request path: free orgs whose user can't manage billing. */
   requestRecipients: UpgradeRequestRecipient[];
-  isLoadingRecipients?: boolean;
   organizationName: string;
   origin: UpgradeOrigin;
   limitKind: string;
@@ -60,7 +59,6 @@ export function PlanLimitDialogView({
   showUpgrade,
   showEnterprise,
   requestRecipients,
-  isLoadingRecipients = false,
   organizationName,
   origin,
   limitKind,
@@ -129,7 +127,6 @@ export function PlanLimitDialogView({
         {showRequest ? (
           <RequestUpgradeButton
             recipients={requestRecipients}
-            isLoadingRecipients={isLoadingRecipients}
             organizationName={organizationName}
             teamName={teamName}
             origin={origin}

--- a/mcpjam-inspector/client/src/components/billing/PlanLimitDialogView.tsx
+++ b/mcpjam-inspector/client/src/components/billing/PlanLimitDialogView.tsx
@@ -24,6 +24,7 @@ export interface PlanLimitDialogViewProps {
   showEnterprise: boolean;
   /** Owner-request path: free orgs whose user can't manage billing. */
   requestRecipients: UpgradeRequestRecipient[];
+  isLoadingRecipients?: boolean;
   organizationName: string;
   origin: UpgradeOrigin;
   limitKind: string;
@@ -59,6 +60,7 @@ export function PlanLimitDialogView({
   showUpgrade,
   showEnterprise,
   requestRecipients,
+  isLoadingRecipients = false,
   organizationName,
   origin,
   limitKind,
@@ -89,7 +91,13 @@ export function PlanLimitDialogView({
       <DialogContent className="sm:max-w-md">
         <DialogHeader>
           <DialogTitle>{title}</DialogTitle>
-          <DialogDescription data-testid="plan-limit-dialog-description">
+          {/* text-pretty keeps the last line from stranding a single word
+              ("upgrade." on its own), which no amount of copy tuning fixes
+              across every viewport width. */}
+          <DialogDescription
+            className="text-pretty"
+            data-testid="plan-limit-dialog-description"
+          >
             {description}
           </DialogDescription>
         </DialogHeader>
@@ -121,6 +129,7 @@ export function PlanLimitDialogView({
         {showRequest ? (
           <RequestUpgradeButton
             recipients={requestRecipients}
+            isLoadingRecipients={isLoadingRecipients}
             organizationName={organizationName}
             teamName={teamName}
             origin={origin}

--- a/mcpjam-inspector/client/src/components/billing/PlanLimitDialogView.tsx
+++ b/mcpjam-inspector/client/src/components/billing/PlanLimitDialogView.tsx
@@ -1,0 +1,133 @@
+import { Button } from "@mcpjam/design-system/button";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@mcpjam/design-system/dialog";
+import type { BillingInterval } from "@/hooks/useOrganizationBilling";
+import type { UpgradeOrigin } from "@/hooks/use-upgrade-checkout";
+import { UpgradeIntervalPicker } from "@/components/billing/UpgradeIntervalPicker";
+import {
+  RequestUpgradeButton,
+  type UpgradeRequestRecipient,
+} from "@/components/billing/RequestUpgradeButton";
+
+export interface PlanLimitDialogViewProps {
+  title: string;
+  description: string;
+  /** Self-serve checkout: free orgs whose user can manage billing. */
+  showUpgrade: boolean;
+  /** Sales path: paid orgs below Enterprise that hit their own ceiling. */
+  showEnterprise: boolean;
+  /** Owner-request path: free orgs whose user can't manage billing. */
+  requestRecipients: UpgradeRequestRecipient[];
+  organizationName: string;
+  origin: UpgradeOrigin;
+  limitKind: string;
+  interval: BillingInterval;
+  onIntervalChange: (interval: BillingInterval) => void;
+  annualPriceLabel: string | null;
+  monthlyPriceLabel: string | null;
+  annualDiscountPct: number;
+  annualSupported: boolean;
+  monthlySupported: boolean;
+  teamName: string;
+  isStarting: boolean;
+  onUpgrade: () => void;
+  onRequestEnterprise: () => void;
+  onDismiss: () => void;
+  /**
+   * Escape hatch for the dev preview only. Non-modal drops the overlay and the
+   * body pointer-events lock so the preview's own variant switcher stays
+   * clickable behind the dialog. Production always renders modal.
+   */
+  modal?: boolean;
+}
+
+/**
+ * Presentation for the eval-iteration wall, with no data dependencies, so the
+ * dev preview at `/__preview/plan-limit` can render every variant with dummy
+ * props and no Convex client. `PlanLimitDialog` owns the data and the copy
+ * assembly.
+ */
+export function PlanLimitDialogView({
+  title,
+  description,
+  showUpgrade,
+  showEnterprise,
+  requestRecipients,
+  organizationName,
+  origin,
+  limitKind,
+  interval,
+  onIntervalChange,
+  annualPriceLabel,
+  monthlyPriceLabel,
+  annualDiscountPct,
+  annualSupported,
+  monthlySupported,
+  teamName,
+  isStarting,
+  onUpgrade,
+  onRequestEnterprise,
+  onDismiss,
+  modal = true,
+}: PlanLimitDialogViewProps) {
+  const showRequest = !showUpgrade && !showEnterprise;
+
+  return (
+    <Dialog
+      open
+      modal={modal}
+      onOpenChange={(next) => {
+        if (!next) onDismiss();
+      }}
+    >
+      <DialogContent className="sm:max-w-md">
+        <DialogHeader>
+          <DialogTitle>{title}</DialogTitle>
+          <DialogDescription data-testid="plan-limit-dialog-description">
+            {description}
+          </DialogDescription>
+        </DialogHeader>
+        {showUpgrade ? (
+          <UpgradeIntervalPicker
+            interval={interval}
+            onIntervalChange={onIntervalChange}
+            annualPriceLabel={annualPriceLabel}
+            monthlyPriceLabel={monthlyPriceLabel}
+            annualDiscountPct={annualDiscountPct}
+            annualSupported={annualSupported}
+            monthlySupported={monthlySupported}
+            teamName={teamName}
+            isStarting={isStarting}
+            onUpgrade={onUpgrade}
+          />
+        ) : null}
+        {showEnterprise ? (
+          <DialogFooter>
+            <Button
+              type="button"
+              onClick={onRequestEnterprise}
+              data-testid="plan-limit-enterprise-cta"
+            >
+              Request upgrade
+            </Button>
+          </DialogFooter>
+        ) : null}
+        {showRequest ? (
+          <RequestUpgradeButton
+            recipients={requestRecipients}
+            organizationName={organizationName}
+            teamName={teamName}
+            origin={origin}
+            limitKind={limitKind}
+          />
+        ) : null}
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/mcpjam-inspector/client/src/components/billing/PlanLimitDialogView.tsx
+++ b/mcpjam-inspector/client/src/components/billing/PlanLimitDialogView.tsx
@@ -24,6 +24,7 @@ export interface PlanLimitDialogViewProps {
   showEnterprise: boolean;
   /** Owner-request path: free orgs whose user can't manage billing. */
   requestRecipients: UpgradeRequestRecipient[];
+  organizationId?: string | null;
   organizationName: string;
   origin: UpgradeOrigin;
   limitKind: string;
@@ -59,6 +60,7 @@ export function PlanLimitDialogView({
   showUpgrade,
   showEnterprise,
   requestRecipients,
+  organizationId,
   organizationName,
   origin,
   limitKind,
@@ -131,6 +133,7 @@ export function PlanLimitDialogView({
             teamName={teamName}
             origin={origin}
             limitKind={limitKind}
+            organizationId={organizationId}
           />
         ) : null}
       </DialogContent>

--- a/mcpjam-inspector/client/src/components/billing/PlanLimitDialogView.tsx
+++ b/mcpjam-inspector/client/src/components/billing/PlanLimitDialogView.tsx
@@ -22,7 +22,11 @@ export interface PlanLimitDialogViewProps {
   showUpgrade: boolean;
   /** Sales path: paid orgs below Enterprise that hit their own ceiling. */
   showEnterprise: boolean;
-  /** Owner-request path: free orgs whose user can't manage billing. */
+  /** Owner-request path: free orgs whose user can't manage billing. Defaults
+   * to "neither of the other two", which is wrong for an Enterprise org at its
+   * own ceiling — there is nothing to ask an owner for. The container decides.
+   */
+  showRequest?: boolean;
   requestRecipients: UpgradeRequestRecipient[];
   organizationId?: string | null;
   organizationName: string;
@@ -37,6 +41,7 @@ export interface PlanLimitDialogViewProps {
   monthlySupported: boolean;
   teamName: string;
   isStarting: boolean;
+  isLoadingPrices?: boolean;
   onUpgrade: () => void;
   onRequestEnterprise: () => void;
   onDismiss: () => void;
@@ -59,6 +64,7 @@ export function PlanLimitDialogView({
   description,
   showUpgrade,
   showEnterprise,
+  showRequest,
   requestRecipients,
   organizationId,
   organizationName,
@@ -73,12 +79,13 @@ export function PlanLimitDialogView({
   monthlySupported,
   teamName,
   isStarting,
+  isLoadingPrices = false,
   onUpgrade,
   onRequestEnterprise,
   onDismiss,
   modal = true,
 }: PlanLimitDialogViewProps) {
-  const showRequest = !showUpgrade && !showEnterprise;
+  const showRequestPath = showRequest ?? (!showUpgrade && !showEnterprise);
 
   return (
     <Dialog
@@ -112,6 +119,7 @@ export function PlanLimitDialogView({
             monthlySupported={monthlySupported}
             teamName={teamName}
             isStarting={isStarting}
+            isLoadingPrices={isLoadingPrices}
             onUpgrade={onUpgrade}
           />
         ) : null}
@@ -126,7 +134,7 @@ export function PlanLimitDialogView({
             </Button>
           </DialogFooter>
         ) : null}
-        {showRequest ? (
+        {showRequestPath ? (
           <RequestUpgradeButton
             recipients={requestRecipients}
             organizationName={organizationName}

--- a/mcpjam-inspector/client/src/components/billing/RequestUpgradeButton.tsx
+++ b/mcpjam-inspector/client/src/components/billing/RequestUpgradeButton.tsx
@@ -27,7 +27,19 @@ export function buildUpgradeRequestMail(params: {
     origin,
     requestAction = "upgrade",
   } = params;
-  const to = recipients.map((r) => r.email).filter(Boolean);
+  // Encoded per address, not over the joined list: a legal local part can
+  // contain `#`, `?` or `%`, and raw those end the mailto path early — the
+  // browser reads the rest as a fragment/query, so the recipient is truncated
+  // and the subject and body are dropped. The `,` separators stay literal.
+  //
+  // `@` is restored: it separates local part from domain in the addr-spec, so
+  // RFC 6068 keeps it literal and encodes only within the parts (its own
+  // example is `mailto:gorby%25kremvax@example.com`). Browsers accept `%40`,
+  // but a literal `@` is what the spec asks for.
+  const to = recipients
+    .map((r) => r.email)
+    .filter(Boolean)
+    .map((email) => encodeURIComponent(email).replace(/%40/g, "@"));
   if (to.length === 0) return null;
 
   const firstName = recipients[0]?.name?.trim().split(/\s+/)[0];

--- a/mcpjam-inspector/client/src/components/billing/RequestUpgradeButton.tsx
+++ b/mcpjam-inspector/client/src/components/billing/RequestUpgradeButton.tsx
@@ -36,8 +36,8 @@ export function buildUpgradeRequestMail(params: {
   const blocked = isCreditPurchase
     ? "Our organization has run out of MCPJam credits."
     : origin === "credits"
-      ? "I've run out of credits on MCPJam and can't keep using the models until they reset."
-      : "I've hit the free plan's eval iteration limit on MCPJam and can't run evals until it resets.";
+    ? "I've run out of credits on MCPJam and can't keep using the models until they reset."
+    : "I've hit the free plan's eval iteration limit on MCPJam and can't run evals until it resets.";
 
   const subject = isCreditPurchase
     ? `Credit purchase request for ${organizationName}`
@@ -69,7 +69,7 @@ export function buildUpgradeRequestMail(params: {
   ].join("\n");
 
   return `mailto:${to.join(",")}?subject=${encodeURIComponent(
-    subject,
+    subject
   )}&body=${encodeURIComponent(body)}`;
 }
 
@@ -80,6 +80,7 @@ interface RequestUpgradeButtonProps {
   origin: UpgradeOrigin;
   limitKind: string;
   requestAction?: UpgradeRequestAction;
+  organizationId?: string | null;
 }
 
 /**
@@ -103,6 +104,7 @@ export function RequestUpgradeButton({
   origin,
   limitKind,
   requestAction = "upgrade",
+  organizationId,
 }: RequestUpgradeButtonProps) {
   const href = buildUpgradeRequestMail({
     recipients,
@@ -124,11 +126,18 @@ export function RequestUpgradeButton({
           href={href}
           data-testid="request-upgrade-mail"
           onClick={() => {
+            // This is synchronous and failure-isolated, so the browser never
+            // waits for analytics before opening the mail client.
             track("plan_limit_upgrade_requested", {
               location: "plan_limit_dialog",
               limit_kind: limitKind,
               origin,
+              organization_id: organizationId,
               recipient_count: recipients.length,
+              has_named_recipient: recipients.some((recipient) =>
+                Boolean(recipient.name?.trim())
+              ),
+              request_action: requestAction,
             });
           }}
         >

--- a/mcpjam-inspector/client/src/components/billing/RequestUpgradeButton.tsx
+++ b/mcpjam-inspector/client/src/components/billing/RequestUpgradeButton.tsx
@@ -50,9 +50,6 @@ export function buildUpgradeRequestMail(params: {
 
 interface RequestUpgradeButtonProps {
   recipients: UpgradeRequestRecipient[];
-  /** Owner lookup still in flight. Holds a disabled button in place rather
-   * than letting one appear a beat after the dialog opens. */
-  isLoadingRecipients?: boolean;
   organizationName: string;
   teamName: string;
   origin: UpgradeOrigin;
@@ -75,20 +72,11 @@ interface RequestUpgradeButtonProps {
  */
 export function RequestUpgradeButton({
   recipients,
-  isLoadingRecipients = false,
   organizationName,
   teamName,
   origin,
   limitKind,
 }: RequestUpgradeButtonProps) {
-  if (isLoadingRecipients) {
-    return (
-      <Button type="button" className="w-full" disabled>
-        Email your owner
-      </Button>
-    );
-  }
-
   const href = buildUpgradeRequestMail({
     recipients,
     organizationName,

--- a/mcpjam-inspector/client/src/components/billing/RequestUpgradeButton.tsx
+++ b/mcpjam-inspector/client/src/components/billing/RequestUpgradeButton.tsx
@@ -132,7 +132,7 @@ export function RequestUpgradeButton({
             });
           }}
         >
-          Email your owner
+          Email your plan's owner
         </a>
       </Button>
       <p className="text-xs text-muted-foreground">

--- a/mcpjam-inspector/client/src/components/billing/RequestUpgradeButton.tsx
+++ b/mcpjam-inspector/client/src/components/billing/RequestUpgradeButton.tsx
@@ -7,38 +7,63 @@ export interface UpgradeRequestRecipient {
   name?: string | null;
 }
 
+export type UpgradeRequestAction = "upgrade" | "buyCredits";
+
 /**
- * Builds the owner-facing upgrade request. Exported so a test can assert the
- * body without reading it off a URL-encoded href by eye.
+ * Builds the owner-facing request. Exported so a test can assert the body
+ * without reading it off a URL-encoded href by eye.
  */
 export function buildUpgradeRequestMail(params: {
   recipients: UpgradeRequestRecipient[];
   organizationName: string;
   teamName: string;
   origin: UpgradeOrigin;
+  requestAction?: UpgradeRequestAction;
 }): string | null {
-  const { recipients, organizationName, teamName, origin } = params;
+  const {
+    recipients,
+    organizationName,
+    teamName,
+    origin,
+    requestAction = "upgrade",
+  } = params;
   const to = recipients.map((r) => r.email).filter(Boolean);
   if (to.length === 0) return null;
 
   const firstName = recipients[0]?.name?.trim().split(/\s+/)[0];
   const greeting = firstName ? `Hi ${firstName},` : "Hi,";
-  const blocked =
-    origin === "credits"
+  const isCreditPurchase = requestAction === "buyCredits";
+  const blocked = isCreditPurchase
+    ? "Our organization has run out of MCPJam credits."
+    : origin === "credits"
       ? "I've run out of credits on MCPJam and can't keep using the models until they reset."
       : "I've hit the free plan's eval iteration limit on MCPJam and can't run evals until it resets.";
 
-  const subject = `Upgrade request: MCPJam ${teamName} plan for ${organizationName}`;
+  const subject = isCreditPurchase
+    ? `Credit purchase request for ${organizationName}`
+    : `Upgrade request: MCPJam ${teamName} plan for ${organizationName}`;
+  const request = isCreditPurchase
+    ? `Could you buy more credits for ${organizationName}?`
+    : `Could you upgrade ${organizationName} to the ${teamName} plan?`;
+  const steps = isCreditPurchase
+    ? [
+        "1. Open MCPJam, go to Organizations, then Billing.",
+        "2. Under Credits, click Buy credits.",
+        "3. Choose an amount and finish checkout with Stripe.",
+      ]
+    : [
+        "1. Open MCPJam, go to Organizations, then Billing.",
+        `2. Under the ${teamName} plan, pick Annual or Monthly.`,
+        "3. Click Upgrade and finish checkout with Stripe.",
+      ];
   const body = [
     greeting,
     "",
     blocked,
-    `Could you upgrade ${organizationName} to the ${teamName} plan?`,
+    request,
     "",
     "Here's how:",
-    "1. Open MCPJam, go to Organizations, then Billing.",
-    `2. Under the ${teamName} plan, pick Annual or Monthly.`,
-    "3. Click Upgrade and finish checkout with Stripe.",
+    ...steps,
     "",
     "Thanks",
   ].join("\n");
@@ -54,6 +79,7 @@ interface RequestUpgradeButtonProps {
   teamName: string;
   origin: UpgradeOrigin;
   limitKind: string;
+  requestAction?: UpgradeRequestAction;
 }
 
 /**
@@ -76,12 +102,14 @@ export function RequestUpgradeButton({
   teamName,
   origin,
   limitKind,
+  requestAction = "upgrade",
 }: RequestUpgradeButtonProps) {
   const href = buildUpgradeRequestMail({
     recipients,
     organizationName,
     teamName,
     origin,
+    requestAction,
   });
   if (!href) return null;
 
@@ -112,7 +140,8 @@ export function RequestUpgradeButton({
         {extraCount > 0
           ? ` and ${extraCount} other owner${extraCount === 1 ? "" : "s"}`
           : ""}
-        , with the steps to upgrade.
+        , with the steps to{" "}
+        {requestAction === "buyCredits" ? "buy credits" : "upgrade"}.
       </p>
     </div>
   );

--- a/mcpjam-inspector/client/src/components/billing/RequestUpgradeButton.tsx
+++ b/mcpjam-inspector/client/src/components/billing/RequestUpgradeButton.tsx
@@ -1,0 +1,119 @@
+import { Button } from "@mcpjam/design-system/button";
+import { track } from "@/lib/analytics";
+import type { UpgradeOrigin } from "@/hooks/use-upgrade-checkout";
+
+export interface UpgradeRequestRecipient {
+  email: string;
+  name?: string | null;
+}
+
+/**
+ * Builds the owner-facing upgrade request. Exported so a test can assert the
+ * body without reading it off a URL-encoded href by eye.
+ */
+export function buildUpgradeRequestMail(params: {
+  recipients: UpgradeRequestRecipient[];
+  organizationName: string;
+  teamName: string;
+  origin: UpgradeOrigin;
+}): string | null {
+  const { recipients, organizationName, teamName, origin } = params;
+  const to = recipients.map((r) => r.email).filter(Boolean);
+  if (to.length === 0) return null;
+
+  const firstName = recipients[0]?.name?.trim().split(/\s+/)[0];
+  const greeting = firstName ? `Hi ${firstName},` : "Hi,";
+  const blocked =
+    origin === "credits"
+      ? "I've run out of credits on MCPJam and can't keep using the models until they reset."
+      : "I've hit the free plan's eval iteration limit on MCPJam and can't run evals until it resets.";
+
+  const subject = `Upgrade request: MCPJam ${teamName} plan for ${organizationName}`;
+  const body = [
+    greeting,
+    "",
+    blocked,
+    `Could you upgrade ${organizationName} to the ${teamName} plan?`,
+    "",
+    "Here's how:",
+    "1. Open MCPJam, go to Organizations, then Billing.",
+    `2. Under the ${teamName} plan, pick Annual or Monthly.`,
+    "3. Click Upgrade and finish checkout with Stripe.",
+    "",
+    "Thanks",
+  ].join("\n");
+
+  return `mailto:${to.join(",")}?subject=${encodeURIComponent(
+    subject,
+  )}&body=${encodeURIComponent(body)}`;
+}
+
+interface RequestUpgradeButtonProps {
+  recipients: UpgradeRequestRecipient[];
+  organizationName: string;
+  teamName: string;
+  origin: UpgradeOrigin;
+  limitKind: string;
+}
+
+/**
+ * The escape hatch for someone who can't upgrade themselves. Renders a
+ * `mailto:` anchor rather than a scripted navigation: it matches the existing
+ * mail links in SupportTab and the chat error surface, the browser handles it,
+ * and the href is directly assertable.
+ *
+ * The label says "Email" because that is what happens. Nothing here sends
+ * anything on the user's behalf, and claiming otherwise would be a lie the
+ * first time someone's mail client doesn't open. Sending server-side would
+ * need a Convex action that doesn't exist yet.
+ *
+ * Renders nothing when no owner address resolves, so nobody gets a button that
+ * opens an empty draft.
+ */
+export function RequestUpgradeButton({
+  recipients,
+  organizationName,
+  teamName,
+  origin,
+  limitKind,
+}: RequestUpgradeButtonProps) {
+  const href = buildUpgradeRequestMail({
+    recipients,
+    organizationName,
+    teamName,
+    origin,
+  });
+  if (!href) return null;
+
+  const recipientLabel =
+    recipients[0]?.name?.trim() || recipients[0]?.email || "your owner";
+  const extraCount = recipients.length - 1;
+
+  return (
+    <div className="space-y-1.5">
+      <Button asChild className="w-full">
+        <a
+          href={href}
+          data-testid="request-upgrade-mail"
+          onClick={() => {
+            track("plan_limit_upgrade_requested", {
+              location: "plan_limit_dialog",
+              limit_kind: limitKind,
+              origin,
+              recipient_count: recipients.length,
+            });
+          }}
+        >
+          Email your owner
+        </a>
+      </Button>
+      <p className="text-xs text-muted-foreground">
+        Opens a draft to {recipientLabel}
+        {extraCount > 0
+          ? ` and ${extraCount} other owner${extraCount === 1 ? "" : "s"}`
+          : ""}
+        , with the steps to upgrade.
+      </p>
+    </div>
+  );
+}

--- a/mcpjam-inspector/client/src/components/billing/RequestUpgradeButton.tsx
+++ b/mcpjam-inspector/client/src/components/billing/RequestUpgradeButton.tsx
@@ -50,6 +50,9 @@ export function buildUpgradeRequestMail(params: {
 
 interface RequestUpgradeButtonProps {
   recipients: UpgradeRequestRecipient[];
+  /** Owner lookup still in flight. Holds a disabled button in place rather
+   * than letting one appear a beat after the dialog opens. */
+  isLoadingRecipients?: boolean;
   organizationName: string;
   teamName: string;
   origin: UpgradeOrigin;
@@ -72,11 +75,20 @@ interface RequestUpgradeButtonProps {
  */
 export function RequestUpgradeButton({
   recipients,
+  isLoadingRecipients = false,
   organizationName,
   teamName,
   origin,
   limitKind,
 }: RequestUpgradeButtonProps) {
+  if (isLoadingRecipients) {
+    return (
+      <Button type="button" className="w-full" disabled>
+        Email your owner
+      </Button>
+    );
+  }
+
   const href = buildUpgradeRequestMail({
     recipients,
     organizationName,

--- a/mcpjam-inspector/client/src/components/billing/UpgradeIntervalPicker.tsx
+++ b/mcpjam-inspector/client/src/components/billing/UpgradeIntervalPicker.tsx
@@ -1,8 +1,11 @@
 import { Badge } from "@mcpjam/design-system/badge";
+import { Button } from "@mcpjam/design-system/button";
 import type { BillingInterval } from "@/hooks/useOrganizationBilling";
 import { cn } from "@/lib/utils";
 
 interface UpgradeIntervalPickerProps {
+  interval: BillingInterval;
+  onIntervalChange: (interval: BillingInterval) => void;
   /** Per-seat monthly figures, already formatted. Null while the catalog loads. */
   annualPriceLabel: string | null;
   monthlyPriceLabel: string | null;
@@ -11,7 +14,7 @@ interface UpgradeIntervalPickerProps {
   monthlySupported: boolean;
   teamName: string;
   isStarting: boolean;
-  onUpgrade: (interval: BillingInterval) => void;
+  onUpgrade: () => void;
   className?: string;
 }
 
@@ -23,14 +26,13 @@ interface IntervalOption {
 }
 
 /**
- * Both billing intervals as side-by-side buttons, so choosing one and starting
- * checkout is a single press. A toggle would hide one of the two prices behind
- * a click the user has to think to make, which is the wrong trade at a wall.
- *
- * Pressing a card leads to Stripe, where the user still confirms before paying,
- * so there is no destructive outcome from a single click here.
+ * Both billing intervals side by side, so neither price is hidden behind a
+ * toggle, then an explicit confirm. Same select-then-confirm shape as the
+ * credit preset dialog.
  */
 export function UpgradeIntervalPicker({
+  interval,
+  onIntervalChange,
   annualPriceLabel,
   monthlyPriceLabel,
   annualDiscountPct,
@@ -67,52 +69,64 @@ export function UpgradeIntervalPicker({
   if (options.length === 0) return null;
 
   return (
-    <div className={cn("space-y-2", className)}>
+    <div className={cn("space-y-3", className)}>
       <div
         className={cn(
           "grid gap-2",
           options.length > 1 ? "sm:grid-cols-2" : "grid-cols-1",
         )}
+        role="radiogroup"
+        aria-label="Billing interval"
       >
-        {options.map((option) => (
-          <button
-            key={option.interval}
-            type="button"
-            disabled={isStarting}
-            onClick={() => onUpgrade(option.interval)}
-            data-testid={`upgrade-${option.interval}`}
-            aria-label={`Upgrade to ${teamName}, ${option.label.toLowerCase()} billing`}
-            className={cn(
-              "flex flex-col gap-1 rounded-lg border border-border p-3 text-left transition-colors",
-              "hover:border-foreground/40 hover:bg-muted/40",
-              "focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring",
-              "disabled:pointer-events-none disabled:opacity-60",
-            )}
-          >
-            <span className="flex items-center gap-2">
-              <span className="text-sm font-medium">{option.label}</span>
-              {option.interval === "annual" && annualDiscountPct > 0 ? (
-                <Badge className="rounded-md bg-primary px-1.5 py-0 text-[10px] font-semibold text-primary-foreground">
-                  Save {annualDiscountPct}%
-                </Badge>
-              ) : null}
-            </span>
-            {option.priceLabel ? (
-              <span className="text-xl font-semibold leading-tight tracking-tight">
-                {option.priceLabel}
+        {options.map((option) => {
+          const isSelected = option.interval === interval;
+          return (
+            <button
+              key={option.interval}
+              type="button"
+              role="radio"
+              aria-checked={isSelected}
+              disabled={isStarting}
+              onClick={() => onIntervalChange(option.interval)}
+              data-testid={`upgrade-interval-${option.interval}`}
+              className={cn(
+                "flex flex-col gap-1 rounded-lg border p-3 text-left transition-colors",
+                isSelected
+                  ? "border-primary bg-primary/10"
+                  : "border-border hover:border-foreground/40",
+                "focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring",
+                "disabled:pointer-events-none disabled:opacity-60",
+              )}
+            >
+              <span className="flex items-center gap-2">
+                <span className="text-sm font-medium">{option.label}</span>
+                {option.interval === "annual" && annualDiscountPct > 0 ? (
+                  <Badge className="rounded-md bg-primary px-1.5 py-0 text-[10px] font-semibold text-primary-foreground">
+                    Save {annualDiscountPct}%
+                  </Badge>
+                ) : null}
               </span>
-            ) : null}
-            <span className="text-xs leading-snug text-muted-foreground">
-              {option.cadence}
-            </span>
-          </button>
-        ))}
+              {option.priceLabel ? (
+                <span className="text-xl font-semibold leading-tight tracking-tight">
+                  {option.priceLabel}
+                </span>
+              ) : null}
+              <span className="text-xs leading-snug text-muted-foreground">
+                {option.cadence}
+              </span>
+            </button>
+          );
+        })}
       </div>
-      <p className="text-xs text-muted-foreground">
-        {isStarting
-          ? "Redirecting to checkout…"
-          : "You'll confirm on Stripe before paying."}
-      </p>
+      <Button
+        type="button"
+        className="w-full"
+        onClick={onUpgrade}
+        disabled={isStarting}
+        data-testid="upgrade-plan-cta"
+      >
+        {isStarting ? "Redirecting…" : `Upgrade to ${teamName}`}
+      </Button>
     </div>
   );
 }

--- a/mcpjam-inspector/client/src/components/billing/UpgradeIntervalPicker.tsx
+++ b/mcpjam-inspector/client/src/components/billing/UpgradeIntervalPicker.tsx
@@ -1,0 +1,104 @@
+import { Button } from "@mcpjam/design-system/button";
+import type { BillingInterval } from "@/hooks/useOrganizationBilling";
+import { cn } from "@/lib/utils";
+
+interface UpgradeIntervalPickerProps {
+  interval: BillingInterval;
+  onIntervalChange: (interval: BillingInterval) => void;
+  /** Per-seat monthly figure, already formatted. Null while the catalog loads. */
+  priceLabel: string | null;
+  annualDiscountPct: number;
+  annualSupported: boolean;
+  monthlySupported: boolean;
+  teamName: string;
+  isStarting: boolean;
+  onUpgrade: () => void;
+  className?: string;
+}
+
+/**
+ * Interval choice plus the upgrade CTA, shared by the eval and credits walls.
+ * Both intervals are shown up front so the user isn't deciding blind, and the
+ * toggle markup mirrors the billing page's compare card for consistency.
+ */
+export function UpgradeIntervalPicker({
+  interval,
+  onIntervalChange,
+  priceLabel,
+  annualDiscountPct,
+  annualSupported,
+  monthlySupported,
+  teamName,
+  isStarting,
+  onUpgrade,
+  className,
+}: UpgradeIntervalPickerProps) {
+  const showToggle = annualSupported && monthlySupported;
+  const cadence =
+    interval === "annual" ? "Billed annually" : "Billed monthly";
+
+  return (
+    <div className={cn("space-y-2", className)}>
+      {showToggle ? (
+        <div
+          role="group"
+          aria-label="Billing interval"
+          className="inline-flex items-center gap-0.5 rounded-md border border-border/60 bg-muted/40 p-0.5 text-xs"
+        >
+          <button
+            type="button"
+            aria-pressed={interval === "annual"}
+            className={cn(
+              "flex items-center gap-1.5 rounded px-2 py-1 font-medium transition-colors",
+              interval === "annual"
+                ? "bg-background text-foreground shadow-sm"
+                : "text-muted-foreground",
+            )}
+            onClick={() => onIntervalChange("annual")}
+          >
+            Annual
+            {annualDiscountPct > 0 ? (
+              <span className="text-[10px] font-semibold text-primary">
+                Save {annualDiscountPct}%
+              </span>
+            ) : null}
+          </button>
+          <button
+            type="button"
+            aria-pressed={interval === "monthly"}
+            className={cn(
+              "rounded px-2 py-1 font-medium transition-colors",
+              interval === "monthly"
+                ? "bg-background text-foreground shadow-sm"
+                : "text-muted-foreground",
+            )}
+            onClick={() => onIntervalChange("monthly")}
+          >
+            Monthly
+          </button>
+        </div>
+      ) : null}
+
+      {priceLabel ? (
+        <div>
+          <p className="text-lg font-semibold leading-tight tracking-tight">
+            {priceLabel}
+          </p>
+          <p className="text-xs leading-snug text-muted-foreground">
+            {cadence}
+          </p>
+        </div>
+      ) : null}
+
+      <Button
+        type="button"
+        className="w-full"
+        onClick={onUpgrade}
+        disabled={isStarting}
+        data-testid="upgrade-plan-cta"
+      >
+        {isStarting ? "Redirecting…" : `Upgrade to ${teamName}`}
+      </Button>
+    </div>
+  );
+}

--- a/mcpjam-inspector/client/src/components/billing/UpgradeIntervalPicker.tsx
+++ b/mcpjam-inspector/client/src/components/billing/UpgradeIntervalPicker.tsx
@@ -15,6 +15,9 @@ interface UpgradeIntervalPickerProps {
   monthlySupported: boolean;
   teamName: string;
   isStarting: boolean;
+  /** Catalog still in flight: the cards have no prices yet, so checkout must
+   * not be reachable. */
+  isLoadingPrices?: boolean;
   onUpgrade: () => void;
   className?: string;
 }
@@ -41,6 +44,7 @@ export function UpgradeIntervalPicker({
   monthlySupported,
   teamName,
   isStarting,
+  isLoadingPrices = false,
   onUpgrade,
   className,
 }: UpgradeIntervalPickerProps) {
@@ -87,7 +91,7 @@ export function UpgradeIntervalPicker({
               type="button"
               role="radio"
               aria-checked={isSelected}
-              disabled={isStarting}
+              disabled={isStarting || isLoadingPrices}
               onClick={() => onIntervalChange(option.interval)}
               data-testid={`upgrade-interval-${option.interval}`}
               className={cn(
@@ -128,10 +132,14 @@ export function UpgradeIntervalPicker({
         type="button"
         className="w-full"
         onClick={onUpgrade}
-        disabled={isStarting}
+        disabled={isStarting || isLoadingPrices}
         data-testid="upgrade-plan-cta"
       >
-        {isStarting ? "Redirecting…" : `Upgrade to ${teamName}`}
+        {isLoadingPrices
+          ? "Loading prices…"
+          : isStarting
+          ? "Redirecting…"
+          : `Upgrade to ${teamName}`}
       </Button>
     </div>
   );

--- a/mcpjam-inspector/client/src/components/billing/UpgradeIntervalPicker.tsx
+++ b/mcpjam-inspector/client/src/components/billing/UpgradeIntervalPicker.tsx
@@ -1,30 +1,38 @@
-import { Button } from "@mcpjam/design-system/button";
+import { Badge } from "@mcpjam/design-system/badge";
 import type { BillingInterval } from "@/hooks/useOrganizationBilling";
 import { cn } from "@/lib/utils";
 
 interface UpgradeIntervalPickerProps {
-  interval: BillingInterval;
-  onIntervalChange: (interval: BillingInterval) => void;
-  /** Per-seat monthly figure, already formatted. Null while the catalog loads. */
-  priceLabel: string | null;
+  /** Per-seat monthly figures, already formatted. Null while the catalog loads. */
+  annualPriceLabel: string | null;
+  monthlyPriceLabel: string | null;
   annualDiscountPct: number;
   annualSupported: boolean;
   monthlySupported: boolean;
   teamName: string;
   isStarting: boolean;
-  onUpgrade: () => void;
+  onUpgrade: (interval: BillingInterval) => void;
   className?: string;
 }
 
+interface IntervalOption {
+  interval: BillingInterval;
+  label: string;
+  cadence: string;
+  priceLabel: string | null;
+}
+
 /**
- * Interval choice plus the upgrade CTA, shared by the eval and credits walls.
- * Both intervals are shown up front so the user isn't deciding blind, and the
- * toggle markup mirrors the billing page's compare card for consistency.
+ * Both billing intervals as side-by-side buttons, so choosing one and starting
+ * checkout is a single press. A toggle would hide one of the two prices behind
+ * a click the user has to think to make, which is the wrong trade at a wall.
+ *
+ * Pressing a card leads to Stripe, where the user still confirms before paying,
+ * so there is no destructive outcome from a single click here.
  */
 export function UpgradeIntervalPicker({
-  interval,
-  onIntervalChange,
-  priceLabel,
+  annualPriceLabel,
+  monthlyPriceLabel,
   annualDiscountPct,
   annualSupported,
   monthlySupported,
@@ -33,72 +41,78 @@ export function UpgradeIntervalPicker({
   onUpgrade,
   className,
 }: UpgradeIntervalPickerProps) {
-  const showToggle = annualSupported && monthlySupported;
-  const cadence =
-    interval === "annual" ? "Billed annually" : "Billed monthly";
+  const options: IntervalOption[] = [
+    ...(annualSupported
+      ? [
+          {
+            interval: "annual" as const,
+            label: "Annual",
+            cadence: "Billed annually",
+            priceLabel: annualPriceLabel,
+          },
+        ]
+      : []),
+    ...(monthlySupported
+      ? [
+          {
+            interval: "monthly" as const,
+            label: "Monthly",
+            cadence: "Billed monthly",
+            priceLabel: monthlyPriceLabel,
+          },
+        ]
+      : []),
+  ];
+
+  if (options.length === 0) return null;
 
   return (
     <div className={cn("space-y-2", className)}>
-      {showToggle ? (
-        <div
-          role="group"
-          aria-label="Billing interval"
-          className="inline-flex items-center gap-0.5 rounded-md border border-border/60 bg-muted/40 p-0.5 text-xs"
-        >
+      <div
+        className={cn(
+          "grid gap-2",
+          options.length > 1 ? "sm:grid-cols-2" : "grid-cols-1",
+        )}
+      >
+        {options.map((option) => (
           <button
+            key={option.interval}
             type="button"
-            aria-pressed={interval === "annual"}
+            disabled={isStarting}
+            onClick={() => onUpgrade(option.interval)}
+            data-testid={`upgrade-${option.interval}`}
+            aria-label={`Upgrade to ${teamName}, ${option.label.toLowerCase()} billing`}
             className={cn(
-              "flex items-center gap-1.5 rounded px-2 py-1 font-medium transition-colors",
-              interval === "annual"
-                ? "bg-background text-foreground shadow-sm"
-                : "text-muted-foreground",
+              "flex flex-col gap-1 rounded-lg border border-border p-3 text-left transition-colors",
+              "hover:border-foreground/40 hover:bg-muted/40",
+              "focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring",
+              "disabled:pointer-events-none disabled:opacity-60",
             )}
-            onClick={() => onIntervalChange("annual")}
           >
-            Annual
-            {annualDiscountPct > 0 ? (
-              <span className="text-[10px] font-semibold text-primary">
-                Save {annualDiscountPct}%
+            <span className="flex items-center gap-2">
+              <span className="text-sm font-medium">{option.label}</span>
+              {option.interval === "annual" && annualDiscountPct > 0 ? (
+                <Badge className="rounded-md bg-primary px-1.5 py-0 text-[10px] font-semibold text-primary-foreground">
+                  Save {annualDiscountPct}%
+                </Badge>
+              ) : null}
+            </span>
+            {option.priceLabel ? (
+              <span className="text-xl font-semibold leading-tight tracking-tight">
+                {option.priceLabel}
               </span>
             ) : null}
+            <span className="text-xs leading-snug text-muted-foreground">
+              {option.cadence}
+            </span>
           </button>
-          <button
-            type="button"
-            aria-pressed={interval === "monthly"}
-            className={cn(
-              "rounded px-2 py-1 font-medium transition-colors",
-              interval === "monthly"
-                ? "bg-background text-foreground shadow-sm"
-                : "text-muted-foreground",
-            )}
-            onClick={() => onIntervalChange("monthly")}
-          >
-            Monthly
-          </button>
-        </div>
-      ) : null}
-
-      {priceLabel ? (
-        <div>
-          <p className="text-lg font-semibold leading-tight tracking-tight">
-            {priceLabel}
-          </p>
-          <p className="text-xs leading-snug text-muted-foreground">
-            {cadence}
-          </p>
-        </div>
-      ) : null}
-
-      <Button
-        type="button"
-        className="w-full"
-        onClick={onUpgrade}
-        disabled={isStarting}
-        data-testid="upgrade-plan-cta"
-      >
-        {isStarting ? "Redirecting…" : `Upgrade to ${teamName}`}
-      </Button>
+        ))}
+      </div>
+      <p className="text-xs text-muted-foreground">
+        {isStarting
+          ? "Redirecting to checkout…"
+          : "You'll confirm on Stripe before paying."}
+      </p>
     </div>
   );
 }

--- a/mcpjam-inspector/client/src/components/billing/UpgradeIntervalPicker.tsx
+++ b/mcpjam-inspector/client/src/components/billing/UpgradeIntervalPicker.tsx
@@ -6,7 +6,8 @@ import { cn } from "@/lib/utils";
 interface UpgradeIntervalPickerProps {
   interval: BillingInterval;
   onIntervalChange: (interval: BillingInterval) => void;
-  /** Per-seat monthly figures, already formatted. Null while the catalog loads. */
+  /** Bare per-seat monthly amounts, e.g. "$30". The unit is rendered here so
+   * the large number never wraps mid-phrase. Null while the catalog loads. */
   annualPriceLabel: string | null;
   monthlyPriceLabel: string | null;
   annualDiscountPct: number;
@@ -107,9 +108,14 @@ export function UpgradeIntervalPicker({
                 ) : null}
               </span>
               {option.priceLabel ? (
-                <span className="text-xl font-semibold leading-tight tracking-tight">
-                  {option.priceLabel}
-                </span>
+                <>
+                  <span className="text-xl font-semibold leading-tight tracking-tight">
+                    {option.priceLabel}
+                  </span>
+                  <span className="text-xs leading-snug text-muted-foreground">
+                    per seat/month
+                  </span>
+                </>
               ) : null}
               <span className="text-xs leading-snug text-muted-foreground">
                 {option.cadence}

--- a/mcpjam-inspector/client/src/components/billing/UpgradeIntervalPicker.tsx
+++ b/mcpjam-inspector/client/src/components/billing/UpgradeIntervalPicker.tsx
@@ -73,6 +73,14 @@ export function UpgradeIntervalPicker({
 
   if (options.length === 0) return null;
 
+  // A card with no price has nothing to confirm, so the CTA waits with it.
+  // In practice that only happens while the catalog is still in flight, which
+  // is what the button says.
+  const hasSelectedPrice = options.some(
+    (option) => option.interval === interval && option.priceLabel,
+  );
+  const isWaitingForPrice = isLoadingPrices || !hasSelectedPrice;
+
   return (
     <div className={cn("space-y-3", className)}>
       <div
@@ -132,10 +140,10 @@ export function UpgradeIntervalPicker({
         type="button"
         className="w-full"
         onClick={onUpgrade}
-        disabled={isStarting || isLoadingPrices}
+        disabled={isStarting || isWaitingForPrice}
         data-testid="upgrade-plan-cta"
       >
-        {isLoadingPrices
+        {isWaitingForPrice
           ? "Loading prices…"
           : isStarting
           ? "Redirecting…"

--- a/mcpjam-inspector/client/src/components/billing/__tests__/CreditTopupDialog.test.tsx
+++ b/mcpjam-inspector/client/src/components/billing/__tests__/CreditTopupDialog.test.tsx
@@ -99,10 +99,12 @@ describe("CreditTopupDialog", () => {
       screen.getByRole("radio", { name: /500\s*credits/ })
     ).toHaveAttribute("aria-checked", "true");
     expect(
-      screen.getByText(/Add credits to your organization/)
+      screen.getByText(/Credits cover model usage in chat, playground, and agents/)
     ).toBeInTheDocument();
+    // Names the boundary explicitly so nobody buys credits expecting a higher
+    // eval-iteration cap.
     expect(
-      screen.getByText(/team can keep using MCPJam models/)
+      screen.getByText(/doesn't change your plan limits/)
     ).toBeInTheDocument();
     // The processing-fee disclaimer was removed so users can't back-compute
     // the take rate.

--- a/mcpjam-inspector/client/src/components/billing/__tests__/CreditTopupDialog.test.tsx
+++ b/mcpjam-inspector/client/src/components/billing/__tests__/CreditTopupDialog.test.tsx
@@ -1,10 +1,13 @@
 import { describe, expect, it, vi, beforeEach } from "vitest";
-import { render, screen } from "@testing-library/react";
+import { render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 
 import { CreditTopupDialog } from "../CreditTopupDialog";
 
 const startCheckoutMock = vi.fn();
+const trackMock = vi.hoisted(() => vi.fn());
+
+vi.mock("@/lib/analytics", () => ({ track: trackMock }));
 
 let presetsState:
   | Array<{
@@ -55,6 +58,7 @@ const DEFAULT_PRESETS = [
 describe("CreditTopupDialog", () => {
   beforeEach(() => {
     startCheckoutMock.mockReset();
+    trackMock.mockReset();
     presetsState = DEFAULT_PRESETS;
     presetsLoadingState = false;
     isStartingCheckoutState = false;
@@ -83,6 +87,85 @@ describe("CreditTopupDialog", () => {
     ).toBeInTheDocument();
   });
 
+  it("reports one rich impression across rerenders", async () => {
+    const view = render(
+      <CreditTopupDialog
+        open
+        onOpenChange={vi.fn()}
+        chatSessionId="chat-1"
+        lastUserMessage="hello"
+        organizationId="org-1"
+        source="chat_banner"
+      />
+    );
+
+    view.rerender(
+      <CreditTopupDialog
+        open
+        onOpenChange={vi.fn()}
+        chatSessionId="chat-1"
+        lastUserMessage="hello"
+        organizationId="org-1"
+        source="chat_banner"
+      />
+    );
+
+    await waitFor(() => {
+      const impressions = trackMock.mock.calls.filter(
+        ([event]) => event === "credit_topup_dialog_shown"
+      );
+      expect(impressions).toHaveLength(1);
+      expect(impressions[0]?.[1]).toEqual(
+        expect.objectContaining({
+          organization_id: "org-1",
+          source: "chat_banner",
+          package_count: 3,
+          default_package_id: "credits_500",
+          has_resume_context: true,
+        })
+      );
+    });
+  });
+
+  it("reports explicit package selection and dismissal once", async () => {
+    const user = userEvent.setup();
+    const onOpenChange = vi.fn();
+    render(
+      <CreditTopupDialog
+        open
+        onOpenChange={onOpenChange}
+        chatSessionId="chat-1"
+        lastUserMessage="hello"
+        organizationId="org-1"
+        source="limit_modal"
+      />
+    );
+
+    await user.click(screen.getByRole("radio", { name: /1,000\s*credits/ }));
+    await user.click(screen.getByRole("button", { name: "Cancel" }));
+
+    expect(trackMock).toHaveBeenCalledWith(
+      "credit_topup_package_selected",
+      expect.objectContaining({
+        package_id: "credits_1000",
+        price_cents: 1000,
+        package_index: 1,
+      })
+    );
+    expect(trackMock).toHaveBeenCalledWith(
+      "credit_topup_dialog_dismissed",
+      expect.objectContaining({
+        dismissal_method: "cancel",
+        selected_package_id: "credits_1000",
+      })
+    );
+    expect(
+      trackMock.mock.calls.filter(
+        ([event]) => event === "credit_topup_dialog_dismissed"
+      )
+    ).toHaveLength(1);
+  });
+
   it("auto-selects the first preset without surfacing fee or credited dollar amounts", () => {
     render(
       <CreditTopupDialog
@@ -99,7 +182,9 @@ describe("CreditTopupDialog", () => {
       screen.getByRole("radio", { name: /500\s*credits/ })
     ).toHaveAttribute("aria-checked", "true");
     expect(
-      screen.getByText(/Credits cover model usage in chat, playground, and agents/)
+      screen.getByText(
+        /Credits cover model usage in chat, playground, and agents/
+      )
     ).toBeInTheDocument();
     // Names the boundary explicitly so nobody buys credits expecting a higher
     // eval-iteration cap.
@@ -132,9 +217,7 @@ describe("CreditTopupDialog", () => {
       />
     );
 
-    await user.click(
-      screen.getByRole("radio", { name: /1,000\s*credits/ })
-    );
+    await user.click(screen.getByRole("radio", { name: /1,000\s*credits/ }));
     await user.click(
       screen.getByRole("button", { name: /Continue with \$10/ })
     );
@@ -165,9 +248,7 @@ describe("CreditTopupDialog", () => {
       />
     );
 
-    await user.click(
-      screen.getByRole("radio", { name: /1,000\s*credits/ })
-    );
+    await user.click(screen.getByRole("radio", { name: /1,000\s*credits/ }));
     await user.click(
       screen.getByRole("button", { name: /Continue with \$10/ })
     );

--- a/mcpjam-inspector/client/src/components/billing/__tests__/CreditTopupDialog.test.tsx
+++ b/mcpjam-inspector/client/src/components/billing/__tests__/CreditTopupDialog.test.tsx
@@ -99,6 +99,9 @@ describe("CreditTopupDialog", () => {
       />
     );
 
+    // Rerender with a *changed* impression dependency. Identical props would
+    // leave the effect's dependency array untouched, so the test would pass
+    // with the ref guard deleted and prove nothing.
     view.rerender(
       <CreditTopupDialog
         open
@@ -106,7 +109,7 @@ describe("CreditTopupDialog", () => {
         chatSessionId="chat-1"
         lastUserMessage="hello"
         organizationId="org-1"
-        source="chat_banner"
+        source="limit_modal"
       />
     );
 

--- a/mcpjam-inspector/client/src/components/billing/__tests__/PlanLimitDialog.test.tsx
+++ b/mcpjam-inspector/client/src/components/billing/__tests__/PlanLimitDialog.test.tsx
@@ -13,17 +13,20 @@ const {
   upgradeState,
   billingState,
   recipientsState,
-} =
-  vi.hoisted(() => ({
-    toastSuccess: vi.fn(),
-    trackMock: vi.fn(),
-    startMock: vi.fn(),
-    upgradeState: { currentPlan: "free" as string, canManageBilling: true },
-    recipientsState: {
-      current: [] as Array<{ email: string; name?: string | null }>,
-    },
-    billingState: { plan: "free" as string, isLoading: false },
-  }));
+} = vi.hoisted(() => ({
+  toastSuccess: vi.fn(),
+  trackMock: vi.fn(),
+  startMock: vi.fn(),
+  upgradeState: {
+    currentPlan: "free" as string,
+    effectivePlan: "free" as string,
+    canManageBilling: true,
+  },
+  recipientsState: {
+    current: [] as Array<{ email: string; name?: string | null }>,
+  },
+  billingState: { plan: "free" as string, isLoading: false },
+}));
 
 vi.mock("@/lib/toast", () => ({
   toast: { success: toastSuccess, error: vi.fn() },
@@ -32,8 +35,9 @@ vi.mock("@/lib/toast", () => ({
 vi.mock("@/lib/analytics", () => ({ track: trackMock }));
 
 vi.mock("@/hooks/use-upgrade-checkout", async (importOriginal) => {
-  const actual =
-    await importOriginal<typeof import("@/hooks/use-upgrade-checkout")>();
+  const actual = await importOriginal<
+    typeof import("@/hooks/use-upgrade-checkout")
+  >();
   return {
     ...actual,
     useUpgradeCheckout: () => ({
@@ -47,6 +51,7 @@ vi.mock("@/hooks/use-upgrade-checkout", async (importOriginal) => {
       teamName: "Team",
       teamEvalIterations: 5000,
       currentPlan: upgradeState.currentPlan,
+      effectivePlan: upgradeState.effectivePlan,
       organizationName: "Acme Robotics",
       canManageBilling: upgradeState.canManageBilling,
       isStarting: false,
@@ -92,6 +97,7 @@ beforeEach(() => {
   trackMock.mockReset();
   startMock.mockReset();
   upgradeState.currentPlan = "free";
+  upgradeState.effectivePlan = "free";
   upgradeState.canManageBilling = true;
   recipientsState.current = [];
   billingState.plan = "free";
@@ -164,16 +170,12 @@ describe("PlanLimitDialog", () => {
     expect(
       screen.queryByRole("button", { name: /wait for reset/i })
     ).not.toBeInTheDocument();
-    expect(
-      screen.getByRole("button", { name: /close/i })
-    ).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /close/i })).toBeInTheDocument();
   });
 
   it("offers an owner email instead of a CTA the server would reject", () => {
     upgradeState.canManageBilling = false;
-    recipientsState.current = [
-      { email: "dana@acme.test", name: "Dana Ruiz" },
-    ];
+    recipientsState.current = [{ email: "dana@acme.test", name: "Dana Ruiz" }];
     openEvalLimit();
     render(<PlanLimitDialog />);
 
@@ -205,6 +207,7 @@ describe("PlanLimitDialog", () => {
 
   it("points an org already on Team at Enterprise instead of Team", () => {
     upgradeState.currentPlan = "team";
+    upgradeState.effectivePlan = "team";
     openEvalLimit({ allowed: 5000, windowKind: "month" });
     render(<PlanLimitDialog />);
 
@@ -213,14 +216,15 @@ describe("PlanLimitDialog", () => {
     expect(description).toHaveTextContent(/Enterprise adds negotiated usage/);
     expect(description).not.toHaveTextContent(/Our Team plan/);
     expect(screen.queryByTestId("upgrade-plan-cta")).not.toBeInTheDocument();
-    expect(
-      screen.getByTestId("plan-limit-enterprise-cta")
-    ).toHaveTextContent(/Request upgrade/);
+    expect(screen.getByTestId("plan-limit-enterprise-cta")).toHaveTextContent(
+      /Request upgrade/
+    );
   });
 
   it("reports the Enterprise CTA click", async () => {
     const user = userEvent.setup();
     upgradeState.currentPlan = "team";
+    upgradeState.effectivePlan = "team";
     openEvalLimit({ allowed: 5000, windowKind: "month" });
     render(<PlanLimitDialog />);
 
@@ -234,6 +238,7 @@ describe("PlanLimitDialog", () => {
 
   it("offers nothing to pitch when the org is already on Enterprise", () => {
     upgradeState.currentPlan = "enterprise";
+    upgradeState.effectivePlan = "enterprise";
     openEvalLimit({ allowed: 50000, windowKind: "month" });
     render(<PlanLimitDialog />);
 
@@ -243,6 +248,20 @@ describe("PlanLimitDialog", () => {
     expect(
       screen.queryByTestId("plan-limit-enterprise-cta")
     ).not.toBeInTheDocument();
+  });
+
+  it("routes a capped Team trial to Enterprise instead of Team checkout", () => {
+    upgradeState.currentPlan = "free";
+    upgradeState.effectivePlan = "team";
+    openEvalLimit({ allowed: 5000, windowKind: "month" });
+    render(<PlanLimitDialog />);
+
+    const description = screen.getByTestId("plan-limit-dialog-description");
+    expect(description).toHaveTextContent(/Your plan includes 5,000 a month/);
+    expect(description).toHaveTextContent(/Enterprise adds negotiated usage/);
+    expect(description).not.toHaveTextContent(/Our Team plan/);
+    expect(screen.queryByTestId("upgrade-plan-cta")).not.toBeInTheDocument();
+    expect(screen.getByTestId("plan-limit-enterprise-cta")).toBeInTheDocument();
   });
 
   it("closes and reports a dismissal", async () => {

--- a/mcpjam-inspector/client/src/components/billing/__tests__/PlanLimitDialog.test.tsx
+++ b/mcpjam-inspector/client/src/components/billing/__tests__/PlanLimitDialog.test.tsx
@@ -15,6 +15,7 @@ const {
   upgradeState,
   billingState,
   recipientsState,
+  authState,
 } = vi.hoisted(() => ({
   toastSuccess: vi.fn(),
   trackMock: vi.fn(),
@@ -32,6 +33,14 @@ const {
     },
   },
   billingState: { plan: "free" as string, isLoading: false },
+  authState: { userId: "user-1" as string | null },
+}));
+
+vi.mock("@workos-inc/authkit-react", () => ({
+  useAuth: () => ({
+    user: authState.userId ? { id: authState.userId } : null,
+    isLoading: false,
+  }),
 }));
 
 vi.mock("@/lib/toast", () => ({
@@ -111,6 +120,7 @@ beforeEach(() => {
   recipientsState.current = { recipients: [], isLoading: false };
   billingState.plan = "free";
   billingState.isLoading = false;
+  authState.userId = "user-1";
   window.history.replaceState(null, "", "/evals");
   window.sessionStorage.clear();
   usePlanLimitDialogStore.setState({ isOpen: false, limit: null });
@@ -123,9 +133,10 @@ beforeEach(() => {
 function arriveFromCheckout(
   url: string,
   organizationId = "org-1",
-  origin: "evals" | "credits" = "evals"
+  origin: "evals" | "credits" = "evals",
+  userId = "user-1"
 ) {
-  stashUpgradeReturnToken(organizationId, origin);
+  stashUpgradeReturnToken(organizationId, origin, userId);
   window.history.replaceState(null, "", url);
 }
 
@@ -555,6 +566,65 @@ describe("PlanLimitDialog", () => {
       } finally {
         vi.useRealTimers();
       }
+    });
+
+    it("does not hand the confirmation to whoever signs in next", async () => {
+      // sessionStorage survives a sign-out. Without an identity on the ticket,
+      // the next person in this tab inherits the toast AND the conversion for
+      // a checkout they never started.
+      billingState.plan = "team";
+      arriveFromCheckout(
+        "/evals?upgrade=return&upgrade_org=org-1&upgrade_from=evals",
+        "org-1",
+        "evals",
+        "user-1"
+      );
+
+      authState.userId = "user-2";
+      render(<PlanLimitDialog />);
+
+      await act(async () => {
+        await Promise.resolve();
+      });
+
+      expect(toastSuccess).not.toHaveBeenCalled();
+      expect(trackMock).not.toHaveBeenCalledWith(
+        "plan_limit_upgrade_returned",
+        expect.anything()
+      );
+      // Retired on sight, so it cannot wait around for a third user either.
+      expect(window.sessionStorage.getItem("mcpjam.upgradeReturnToken")).toBe(
+        null
+      );
+    });
+
+    it("keeps waiting through a sign-out blip and confirms for the same user", async () => {
+      // A token refresh briefly drops the identity. That is not a new user, so
+      // the pending confirmation must survive it.
+      billingState.plan = "team";
+      arriveFromCheckout(
+        "/evals?upgrade=return&upgrade_org=org-1&upgrade_from=evals"
+      );
+
+      authState.userId = null;
+      const view = render(<PlanLimitDialog />);
+      await act(async () => {
+        await Promise.resolve();
+      });
+      expect(toastSuccess).not.toHaveBeenCalled();
+      expect(
+        window.sessionStorage.getItem("mcpjam.upgradeReturnToken")
+      ).not.toBe(null);
+
+      authState.userId = "user-1";
+      view.rerender(<PlanLimitDialog />);
+      await act(async () => {
+        await Promise.resolve();
+      });
+
+      expect(toastSuccess).toHaveBeenCalledWith(
+        expect.stringMatching(/You're on the Team plan/)
+      );
     });
 
     it("ignores a return marker that did not come from this tab's checkout", async () => {

--- a/mcpjam-inspector/client/src/components/billing/__tests__/PlanLimitDialog.test.tsx
+++ b/mcpjam-inspector/client/src/components/billing/__tests__/PlanLimitDialog.test.tsx
@@ -54,6 +54,7 @@ vi.mock("@/hooks/use-upgrade-checkout", async (importOriginal) => {
       effectivePlan: upgradeState.effectivePlan,
       organizationName: "Acme Robotics",
       canManageBilling: upgradeState.canManageBilling,
+      isLoadingBilling: false,
       isStarting: false,
       start: startMock,
     }),
@@ -126,6 +127,28 @@ describe("PlanLimitDialog", () => {
     // enforces rather than a hardcoded marketing string.
     expect(description).toHaveTextContent(
       /Our Team plan includes 5,000 a month/
+    );
+  });
+
+  it("reports one rich impression, even when the dialog rerenders", () => {
+    openEvalLimit();
+    const view = render(<PlanLimitDialog />);
+
+    view.rerender(<PlanLimitDialog />);
+
+    const impressions = trackMock.mock.calls.filter(
+      ([event]) => event === "plan_limit_dialog_shown"
+    );
+    expect(impressions).toHaveLength(1);
+    expect(impressions[0]?.[1]).toEqual(
+      expect.objectContaining({
+        wall_kind: "eval_iterations",
+        organization_id: "org-1",
+        current_plan: "free",
+        effective_plan: "free",
+        can_manage_billing: true,
+        primary_action: "upgrade",
+      })
     );
   });
 

--- a/mcpjam-inspector/client/src/components/billing/__tests__/PlanLimitDialog.test.tsx
+++ b/mcpjam-inspector/client/src/components/billing/__tests__/PlanLimitDialog.test.tsx
@@ -120,8 +120,12 @@ beforeEach(() => {
  * A return is only honored in the tab that started checkout, so the tests have
  * to arrive the way a real user does: with the one-shot token in hand.
  */
-function arriveFromCheckout(url: string, organizationId = "org-1") {
-  stashUpgradeReturnToken(organizationId);
+function arriveFromCheckout(
+  url: string,
+  organizationId = "org-1",
+  origin: "evals" | "credits" = "evals"
+) {
+  stashUpgradeReturnToken(organizationId, origin);
   window.history.replaceState(null, "", url);
 }
 
@@ -144,7 +148,7 @@ describe("PlanLimitDialog", () => {
     // The Team figure comes from the plan catalog, so it tracks what billing
     // enforces rather than a hardcoded marketing string.
     expect(description).toHaveTextContent(
-      /Our Team plan includes 5,000 per seat each month/
+      /The Team plan includes 5,000 per seat each month/
     );
   });
 
@@ -317,7 +321,7 @@ describe("PlanLimitDialog", () => {
     const description = screen.getByTestId("plan-limit-dialog-description");
     expect(description).toHaveTextContent(/Your plan includes 5,000 a month/);
     expect(description).toHaveTextContent(/Enterprise adds negotiated usage/);
-    expect(description).not.toHaveTextContent(/Our Team plan/);
+    expect(description).not.toHaveTextContent(/The Team plan/);
     expect(screen.queryByTestId("upgrade-plan-cta")).not.toBeInTheDocument();
     expect(screen.getByTestId("plan-limit-enterprise-cta")).toHaveTextContent(
       /Request upgrade/
@@ -362,7 +366,7 @@ describe("PlanLimitDialog", () => {
     const description = screen.getByTestId("plan-limit-dialog-description");
     expect(description).toHaveTextContent(/Your plan includes 5,000 a month/);
     expect(description).toHaveTextContent(/Enterprise adds negotiated usage/);
-    expect(description).not.toHaveTextContent(/Our Team plan/);
+    expect(description).not.toHaveTextContent(/The Team plan/);
     expect(screen.queryByTestId("upgrade-plan-cta")).not.toBeInTheDocument();
     expect(screen.getByTestId("plan-limit-enterprise-cta")).toBeInTheDocument();
   });
@@ -510,6 +514,49 @@ describe("PlanLimitDialog", () => {
       });
     });
 
+    it("still confirms after a reload while the webhook is pending", async () => {
+      vi.useFakeTimers();
+      try {
+        billingState.plan = "free";
+        arriveFromCheckout(
+          "/evals?upgrade=return&upgrade_org=org-1&upgrade_from=evals"
+        );
+        const first = render(<PlanLimitDialog />);
+
+        await act(async () => {
+          await vi.advanceTimersByTimeAsync(30_000);
+        });
+        expect(toastSuccess).not.toHaveBeenCalled();
+
+        // The user refreshes (or the app remounts) while Stripe's webhook is
+        // still in flight. The URL bookkeeping is long gone by now; only the
+        // ticket can carry the pending confirmation across.
+        first.unmount();
+        expect(window.location.search).toBe("");
+
+        billingState.plan = "team";
+        render(<PlanLimitDialog />);
+        await act(async () => {
+          await vi.advanceTimersByTimeAsync(0);
+        });
+
+        expect(toastSuccess).toHaveBeenCalledWith(
+          expect.stringMatching(/You're on the Team plan/)
+        );
+        // Reported as late, not immediate: the wait survived the reload.
+        expect(trackMock).toHaveBeenCalledWith(
+          "plan_limit_upgrade_returned",
+          expect.objectContaining({ upgraded: true, settlement: "late" })
+        );
+        // Retired, so a third load says nothing.
+        expect(
+          window.sessionStorage.getItem("mcpjam.upgradeReturnToken")
+        ).toBe(null);
+      } finally {
+        vi.useRealTimers();
+      }
+    });
+
     it("ignores a return marker that did not come from this tab's checkout", async () => {
       // A bookmarked or shared link: no token, so no purchase is announced and
       // no conversion is recorded for a checkout that never happened.
@@ -533,7 +580,10 @@ describe("PlanLimitDialog", () => {
       expect(window.location.search).toBe("");
     });
 
-    it("ignores a return marker naming an organization it was not issued for", async () => {
+    it("resolves the org from the ticket, never from the URL", async () => {
+      // A tampered or stale `upgrade_org` must not redirect the confirmation:
+      // the ticket records the org THIS tab actually started checkout for, and
+      // that is the only one we report on.
       billingState.plan = "team";
       arriveFromCheckout(
         "/evals?upgrade=return&upgrade_org=org-2&upgrade_from=evals",
@@ -545,17 +595,18 @@ describe("PlanLimitDialog", () => {
         await Promise.resolve();
       });
 
-      expect(toastSuccess).not.toHaveBeenCalled();
-      expect(trackMock).not.toHaveBeenCalledWith(
+      expect(trackMock).toHaveBeenCalledWith(
         "plan_limit_upgrade_returned",
-        expect.anything()
+        expect.objectContaining({ organization_id: "org-1" })
       );
     });
 
     it("uses credit wording when the user came from the credits wall", async () => {
       billingState.plan = "team";
       arriveFromCheckout(
-        "/chat?upgrade=return&upgrade_org=org-1&upgrade_from=credits"
+        "/chat?upgrade=return&upgrade_org=org-1&upgrade_from=credits",
+        "org-1",
+        "credits"
       );
       render(<PlanLimitDialog />);
 

--- a/mcpjam-inspector/client/src/components/billing/__tests__/PlanLimitDialog.test.tsx
+++ b/mcpjam-inspector/client/src/components/billing/__tests__/PlanLimitDialog.test.tsx
@@ -6,12 +6,22 @@ import { usePlanLimitDialogStore } from "@/stores/plan-limit-dialog-store";
 
 // Hoisted so the vi.mock factories below (which vitest lifts to the top of the
 // file) can reach them.
-const { toastSuccess, trackMock, startMock, upgradeState, billingState } =
+const {
+  toastSuccess,
+  trackMock,
+  startMock,
+  upgradeState,
+  billingState,
+  recipientsState,
+} =
   vi.hoisted(() => ({
     toastSuccess: vi.fn(),
     trackMock: vi.fn(),
     startMock: vi.fn(),
     upgradeState: { currentPlan: "free" as string, canManageBilling: true },
+    recipientsState: {
+      current: [] as Array<{ email: string; name?: string | null }>,
+    },
     billingState: { plan: "free" as string, isLoading: false },
   }));
 
@@ -27,6 +37,8 @@ vi.mock("@/hooks/use-upgrade-checkout", async (importOriginal) => {
   return {
     ...actual,
     useUpgradeCheckout: () => ({
+      interval: "annual" as const,
+      setInterval: vi.fn(),
       annualPriceLabel: "$30/seat/mo",
       monthlyPriceLabel: "$38/seat/mo",
       annualDiscountPct: 21,
@@ -35,6 +47,7 @@ vi.mock("@/hooks/use-upgrade-checkout", async (importOriginal) => {
       teamName: "Team",
       teamEvalIterations: 5000,
       currentPlan: upgradeState.currentPlan,
+      organizationName: "Acme Robotics",
       canManageBilling: upgradeState.canManageBilling,
       isStarting: false,
       start: startMock,
@@ -50,6 +63,10 @@ vi.mock("@/hooks/useOrganizationBilling", () => ({
     planCatalog: { plans: { team: { displayName: "Team" } } },
     isLoadingBilling: billingState.isLoading,
   }),
+}));
+
+vi.mock("@/hooks/use-upgrade-request-recipients", () => ({
+  useUpgradeRequestRecipients: () => recipientsState.current,
 }));
 
 const RESETS_AT = Date.UTC(2026, 7, 11, 4, 0);
@@ -76,6 +93,7 @@ beforeEach(() => {
   startMock.mockReset();
   upgradeState.currentPlan = "free";
   upgradeState.canManageBilling = true;
+  recipientsState.current = [];
   billingState.plan = "free";
   billingState.isLoading = false;
   window.history.replaceState(null, "", "/evals");
@@ -109,28 +127,33 @@ describe("PlanLimitDialog", () => {
     openEvalLimit();
     render(<PlanLimitDialog />);
 
-    expect(screen.getByTestId("upgrade-annual")).toHaveTextContent(
-      "$30/seat/mo"
-    );
-    expect(screen.getByTestId("upgrade-annual")).toHaveTextContent("Save 21%");
-    expect(screen.getByTestId("upgrade-monthly")).toHaveTextContent(
+    const annual = screen.getByTestId("upgrade-interval-annual");
+    expect(annual).toHaveTextContent("$30/seat/mo");
+    expect(annual).toHaveTextContent("Save 21%");
+    expect(screen.getByTestId("upgrade-interval-monthly")).toHaveTextContent(
       "$38/seat/mo"
     );
-    expect(
-      screen.getByText(/confirm on Stripe before paying/i)
-    ).toBeInTheDocument();
+    expect(screen.getByTestId("upgrade-plan-cta")).toHaveTextContent(
+      /Upgrade to Team/
+    );
   });
 
-  it("starts checkout on the interval the user pressed", async () => {
+  it("selects an interval, then confirms with the upgrade button", async () => {
     const user = userEvent.setup();
     openEvalLimit();
     render(<PlanLimitDialog />);
 
-    await user.click(screen.getByTestId("upgrade-monthly"));
-    expect(startMock).toHaveBeenCalledWith("monthly");
+    // Annual leads, and selecting is separate from confirming: pressing a card
+    // must not start checkout on its own.
+    expect(screen.getByTestId("upgrade-interval-annual")).toHaveAttribute(
+      "aria-checked",
+      "true"
+    );
+    await user.click(screen.getByTestId("upgrade-interval-monthly"));
+    expect(startMock).not.toHaveBeenCalled();
 
-    await user.click(screen.getByTestId("upgrade-annual"));
-    expect(startMock).toHaveBeenLastCalledWith("annual");
+    await user.click(screen.getByTestId("upgrade-plan-cta"));
+    expect(startMock).toHaveBeenCalledTimes(1);
   });
 
   it("has no wait-for-reset button; the close control is the only dismissal", () => {
@@ -145,15 +168,38 @@ describe("PlanLimitDialog", () => {
     ).toBeInTheDocument();
   });
 
-  it("explains who can upgrade instead of showing a CTA the server would reject", () => {
+  it("offers an owner email instead of a CTA the server would reject", () => {
     upgradeState.canManageBilling = false;
+    recipientsState.current = [
+      { email: "dana@acme.test", name: "Dana Ruiz" },
+    ];
     openEvalLimit();
     render(<PlanLimitDialog />);
 
     expect(
       screen.getByTestId("plan-limit-dialog-description")
-    ).toHaveTextContent(/Only an organization owner or admin can upgrade/);
-    expect(screen.queryByTestId("upgrade-annual")).not.toBeInTheDocument();
+    ).toHaveTextContent(/Only an organization owner can upgrade/);
+    expect(screen.queryByTestId("upgrade-plan-cta")).not.toBeInTheDocument();
+
+    const mail = screen.getByTestId("request-upgrade-mail");
+    const href = decodeURIComponent(mail.getAttribute("href") ?? "");
+    expect(href).toContain("mailto:dana@acme.test");
+    expect(href).toContain("Acme Robotics");
+    expect(href).toContain("Organizations, then Billing");
+    // Says what it does. It opens a draft; it does not send anything.
+    expect(mail).toHaveTextContent(/Email your owner/);
+    expect(screen.getByText(/Opens a draft to Dana Ruiz/)).toBeInTheDocument();
+  });
+
+  it("hides the owner email when no owner address resolves", () => {
+    upgradeState.canManageBilling = false;
+    recipientsState.current = [];
+    openEvalLimit();
+    render(<PlanLimitDialog />);
+
+    expect(
+      screen.queryByTestId("request-upgrade-mail")
+    ).not.toBeInTheDocument();
   });
 
   it("points an org already on Team at Enterprise instead of Team", () => {
@@ -165,7 +211,7 @@ describe("PlanLimitDialog", () => {
     expect(description).toHaveTextContent(/Your plan includes 5,000 a month/);
     expect(description).toHaveTextContent(/Enterprise adds negotiated usage/);
     expect(description).not.toHaveTextContent(/Our Team plan/);
-    expect(screen.queryByTestId("upgrade-annual")).not.toBeInTheDocument();
+    expect(screen.queryByTestId("upgrade-plan-cta")).not.toBeInTheDocument();
     expect(
       screen.getByTestId("plan-limit-enterprise-cta")
     ).toHaveTextContent(/Request upgrade/);

--- a/mcpjam-inspector/client/src/components/billing/__tests__/PlanLimitDialog.test.tsx
+++ b/mcpjam-inspector/client/src/components/billing/__tests__/PlanLimitDialog.test.tsx
@@ -23,6 +23,7 @@ const {
     currentPlan: "free" as string,
     effectivePlan: "free" as string,
     canManageBilling: true,
+    isLoadingPrices: false,
   },
   recipientsState: {
     current: {
@@ -60,6 +61,7 @@ vi.mock("@/hooks/use-upgrade-checkout", async (importOriginal) => {
       organizationName: "Acme Robotics",
       canManageBilling: upgradeState.canManageBilling,
       isLoadingBilling: false,
+      isLoadingPrices: upgradeState.isLoadingPrices,
       isStarting: false,
       start: startMock,
     }),
@@ -105,6 +107,7 @@ beforeEach(() => {
   upgradeState.currentPlan = "free";
   upgradeState.effectivePlan = "free";
   upgradeState.canManageBilling = true;
+  upgradeState.isLoadingPrices = false;
   recipientsState.current = { recipients: [], isLoading: false };
   billingState.plan = "free";
   billingState.isLoading = false;
@@ -143,6 +146,16 @@ describe("PlanLimitDialog", () => {
     expect(description).toHaveTextContent(
       /Our Team plan includes 5,000 per seat each month/
     );
+  });
+
+  it("drops the conjunction when the limit carries no reset time", () => {
+    openEvalLimit({ resetsAt: null });
+    render(<PlanLimitDialog />);
+
+    const description = screen.getByTestId("plan-limit-dialog-description");
+    expect(description).toHaveTextContent(/Free includes 75 a day\./);
+    expect(description).not.toHaveTextContent(/, and/);
+    expect(description).not.toHaveTextContent(/reset at/i);
   });
 
   it("reports one rich impression, even when the dialog rerenders", () => {
@@ -207,6 +220,18 @@ describe("PlanLimitDialog", () => {
     expect(screen.getByTestId("upgrade-plan-cta")).toHaveTextContent(
       /Upgrade to Team/
     );
+  });
+
+  it("keeps checkout unreachable while the price catalog is still loading", () => {
+    upgradeState.isLoadingPrices = true;
+    openEvalLimit();
+    render(<PlanLimitDialog />);
+
+    // Dialog-level wiring only: the hook's loading flag has to reach the CTA.
+    // How the picker disables the interval cards is the picker's business.
+    const cta = screen.getByTestId("upgrade-plan-cta");
+    expect(cta).toBeDisabled();
+    expect(cta).toHaveTextContent(/Loading prices/);
   });
 
   it("selects an interval, then confirms with the upgrade button", async () => {

--- a/mcpjam-inspector/client/src/components/billing/__tests__/PlanLimitDialog.test.tsx
+++ b/mcpjam-inspector/client/src/components/billing/__tests__/PlanLimitDialog.test.tsx
@@ -21,6 +21,7 @@ const {
     upgradeState: { currentPlan: "free" as string, canManageBilling: true },
     recipientsState: {
       current: [] as Array<{ email: string; name?: string | null }>,
+      isLoading: false,
     },
     billingState: { plan: "free" as string, isLoading: false },
   }));
@@ -39,8 +40,8 @@ vi.mock("@/hooks/use-upgrade-checkout", async (importOriginal) => {
     useUpgradeCheckout: () => ({
       interval: "annual" as const,
       setInterval: vi.fn(),
-      annualPriceLabel: "$30/seat/mo",
-      monthlyPriceLabel: "$38/seat/mo",
+      annualPriceLabel: "$30",
+      monthlyPriceLabel: "$38",
       annualDiscountPct: 21,
       annualSupported: true,
       monthlySupported: true,
@@ -66,7 +67,10 @@ vi.mock("@/hooks/useOrganizationBilling", () => ({
 }));
 
 vi.mock("@/hooks/use-upgrade-request-recipients", () => ({
-  useUpgradeRequestRecipients: () => recipientsState.current,
+  useUpgradeRequestRecipients: () => ({
+    recipients: recipientsState.current,
+    isLoading: recipientsState.isLoading,
+  }),
 }));
 
 const RESETS_AT = Date.UTC(2026, 7, 11, 4, 0);
@@ -94,6 +98,7 @@ beforeEach(() => {
   upgradeState.currentPlan = "free";
   upgradeState.canManageBilling = true;
   recipientsState.current = [];
+  recipientsState.isLoading = false;
   billingState.plan = "free";
   billingState.isLoading = false;
   window.history.replaceState(null, "", "/evals");
@@ -128,10 +133,11 @@ describe("PlanLimitDialog", () => {
     render(<PlanLimitDialog />);
 
     const annual = screen.getByTestId("upgrade-interval-annual");
-    expect(annual).toHaveTextContent("$30/seat/mo");
+    expect(annual).toHaveTextContent("$30");
+    expect(annual).toHaveTextContent("per seat/month");
     expect(annual).toHaveTextContent("Save 21%");
     expect(screen.getByTestId("upgrade-interval-monthly")).toHaveTextContent(
-      "$38/seat/mo"
+      "$38"
     );
     expect(screen.getByTestId("upgrade-plan-cta")).toHaveTextContent(
       /Upgrade to Team/
@@ -178,7 +184,7 @@ describe("PlanLimitDialog", () => {
 
     expect(
       screen.getByTestId("plan-limit-dialog-description")
-    ).toHaveTextContent(/Only an organization owner can upgrade/);
+    ).toHaveTextContent(/Only an owner can upgrade this organization/);
     expect(screen.queryByTestId("upgrade-plan-cta")).not.toBeInTheDocument();
 
     const mail = screen.getByTestId("request-upgrade-mail");
@@ -191,9 +197,25 @@ describe("PlanLimitDialog", () => {
     expect(screen.getByText(/Opens a draft to Dana Ruiz/)).toBeInTheDocument();
   });
 
-  it("hides the owner email when no owner address resolves", () => {
+  it("holds a disabled button while the owner lookup is in flight", () => {
+    upgradeState.canManageBilling = false;
+    recipientsState.isLoading = true;
+    openEvalLimit();
+    render(<PlanLimitDialog />);
+
+    // Empty recipients plus loading must not read as "no owner": that would
+    // render nothing now and pop a button in a beat later.
+    const button = screen.getByRole("button", { name: /email your owner/i });
+    expect(button).toBeDisabled();
+    expect(
+      screen.queryByTestId("request-upgrade-mail")
+    ).not.toBeInTheDocument();
+  });
+
+  it("hides the owner email when the lookup finishes with no owner", () => {
     upgradeState.canManageBilling = false;
     recipientsState.current = [];
+  recipientsState.isLoading = false;
     openEvalLimit();
     render(<PlanLimitDialog />);
 

--- a/mcpjam-inspector/client/src/components/billing/__tests__/PlanLimitDialog.test.tsx
+++ b/mcpjam-inspector/client/src/components/billing/__tests__/PlanLimitDialog.test.tsx
@@ -598,6 +598,43 @@ describe("PlanLimitDialog", () => {
       );
     });
 
+    it("disarms a pending confirmation when the buyer signs out mid-flight", async () => {
+      // The tab stays mounted across the sign-out, so the flow has to be torn
+      // down here — not left pointing at the previous buyer's org for whoever
+      // signs in next.
+      billingState.plan = "free";
+      arriveFromCheckout(
+        "/evals?upgrade=return&upgrade_org=org-1&upgrade_from=evals"
+      );
+      const view = render(<PlanLimitDialog />);
+      await act(async () => {
+        await Promise.resolve();
+      });
+
+      authState.userId = null;
+      view.rerender(<PlanLimitDialog />);
+      await act(async () => {
+        await Promise.resolve();
+      });
+
+      // Someone else signs in, and the org they share is already paid.
+      authState.userId = "user-2";
+      billingState.plan = "team";
+      view.rerender(<PlanLimitDialog />);
+      await act(async () => {
+        await Promise.resolve();
+      });
+
+      expect(toastSuccess).not.toHaveBeenCalled();
+      expect(trackMock).not.toHaveBeenCalledWith(
+        "plan_limit_upgrade_returned",
+        expect.anything()
+      );
+      expect(window.sessionStorage.getItem("mcpjam.upgradeReturnToken")).toBe(
+        null
+      );
+    });
+
     it("keeps waiting through a sign-out blip and confirms for the same user", async () => {
       // A token refresh briefly drops the identity. That is not a new user, so
       // the pending confirmation must survive it.

--- a/mcpjam-inspector/client/src/components/billing/__tests__/PlanLimitDialog.test.tsx
+++ b/mcpjam-inspector/client/src/components/billing/__tests__/PlanLimitDialog.test.tsx
@@ -390,7 +390,7 @@ describe("PlanLimitDialog", () => {
 
       await waitFor(() => {
         expect(toastSuccess).toHaveBeenCalledWith(
-          expect.stringMatching(/You're on our Team plan/)
+          expect.stringMatching(/You're on the Team plan/)
         );
       });
       // The surface the user was blocked on is preserved; only the upgrade
@@ -422,7 +422,7 @@ describe("PlanLimitDialog", () => {
       view.rerender(<PlanLimitDialog />);
       await waitFor(() => {
         expect(toastSuccess).toHaveBeenCalledWith(
-          expect.stringMatching(/You're on our Team plan/)
+          expect.stringMatching(/You're on the Team plan/)
         );
       });
       expect(window.location.search).toBe("");
@@ -478,7 +478,7 @@ describe("PlanLimitDialog", () => {
         });
 
         expect(toastSuccess).toHaveBeenCalledWith(
-          expect.stringMatching(/You're on our Team plan/)
+          expect.stringMatching(/You're on the Team plan/)
         );
         expect(trackMock).toHaveBeenCalledWith(
           "plan_limit_upgrade_returned",
@@ -505,7 +505,7 @@ describe("PlanLimitDialog", () => {
 
       await waitFor(() => {
         expect(toastSuccess).toHaveBeenCalledWith(
-          expect.stringMatching(/You're on our Team plan/)
+          expect.stringMatching(/You're on the Team plan/)
         );
       });
     });

--- a/mcpjam-inspector/client/src/components/billing/__tests__/PlanLimitDialog.test.tsx
+++ b/mcpjam-inspector/client/src/components/billing/__tests__/PlanLimitDialog.test.tsx
@@ -129,7 +129,7 @@ describe("PlanLimitDialog", () => {
     // The Team figure comes from the plan catalog, so it tracks what billing
     // enforces rather than a hardcoded marketing string.
     expect(description).toHaveTextContent(
-      /Our Team plan includes 5,000 a month/
+      /Our Team plan includes 5,000 per seat each month/
     );
   });
 
@@ -213,6 +213,17 @@ describe("PlanLimitDialog", () => {
 
     await user.click(screen.getByTestId("upgrade-plan-cta"));
     expect(startMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("closes after an in-place plan change succeeds", async () => {
+    const user = userEvent.setup();
+    startMock.mockResolvedValue({ redirected: false, shouldDismiss: true });
+    openEvalLimit();
+    render(<PlanLimitDialog />);
+
+    await user.click(screen.getByTestId("upgrade-plan-cta"));
+
+    expect(usePlanLimitDialogStore.getState().isOpen).toBe(false);
   });
 
   it("has no wait-for-reset button; the close control is the only dismissal", () => {

--- a/mcpjam-inspector/client/src/components/billing/__tests__/PlanLimitDialog.test.tsx
+++ b/mcpjam-inspector/client/src/components/billing/__tests__/PlanLimitDialog.test.tsx
@@ -1,5 +1,5 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import { render, screen, waitFor } from "@testing-library/react";
+import { act, render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { PlanLimitDialog } from "../PlanLimitDialog";
 import { usePlanLimitDialogStore } from "@/stores/plan-limit-dialog-store";
@@ -282,23 +282,57 @@ describe("PlanLimitDialog", () => {
       );
     });
 
-    it("stays silent when the user bailed at checkout", async () => {
+    it("waits for delayed billing state before confirming checkout", async () => {
       billingState.plan = "free";
       window.history.replaceState(
         null,
         "",
         "/evals?upgrade=return&upgrade_org=org-1&upgrade_from=evals"
       );
-      render(<PlanLimitDialog />);
+      const view = render(<PlanLimitDialog />);
 
+      expect(window.location.search).toContain("upgrade=return");
+      expect(toastSuccess).not.toHaveBeenCalled();
+      expect(trackMock).not.toHaveBeenCalledWith(
+        "plan_limit_upgrade_returned",
+        expect.anything()
+      );
+
+      billingState.plan = "team";
+      view.rerender(<PlanLimitDialog />);
       await waitFor(() => {
+        expect(toastSuccess).toHaveBeenCalledWith(
+          expect.stringMatching(/You're on our Team plan/)
+        );
+      });
+      expect(window.location.search).toBe("");
+    });
+
+    it("stays silent after the settlement window when checkout was abandoned", async () => {
+      vi.useFakeTimers();
+      try {
+        billingState.plan = "free";
+        window.history.replaceState(
+          null,
+          "",
+          "/evals?upgrade=return&upgrade_org=org-1&upgrade_from=evals"
+        );
+        render(<PlanLimitDialog />);
+
+        expect(window.location.search).toContain("upgrade=return");
+        await act(async () => {
+          await vi.advanceTimersByTimeAsync(30_000);
+        });
+
         expect(trackMock).toHaveBeenCalledWith(
           "plan_limit_upgrade_returned",
           expect.objectContaining({ upgraded: false })
         );
-      });
-      expect(toastSuccess).not.toHaveBeenCalled();
-      expect(window.location.search).toBe("");
+        expect(toastSuccess).not.toHaveBeenCalled();
+        expect(window.location.search).toBe("");
+      } finally {
+        vi.useRealTimers();
+      }
     });
 
     it("uses credit wording when the user came from the credits wall", async () => {

--- a/mcpjam-inspector/client/src/components/billing/__tests__/PlanLimitDialog.test.tsx
+++ b/mcpjam-inspector/client/src/components/billing/__tests__/PlanLimitDialog.test.tsx
@@ -23,7 +23,10 @@ const {
     canManageBilling: true,
   },
   recipientsState: {
-    current: [] as Array<{ email: string; name?: string | null }>,
+    current: {
+      recipients: [] as Array<{ email: string; name?: string | null }>,
+      isLoading: false,
+    },
   },
   billingState: { plan: "free" as string, isLoading: false },
 }));
@@ -100,7 +103,7 @@ beforeEach(() => {
   upgradeState.currentPlan = "free";
   upgradeState.effectivePlan = "free";
   upgradeState.canManageBilling = true;
-  recipientsState.current = [];
+  recipientsState.current = { recipients: [], isLoading: false };
   billingState.plan = "free";
   billingState.isLoading = false;
   window.history.replaceState(null, "", "/evals");
@@ -152,6 +155,32 @@ describe("PlanLimitDialog", () => {
     );
   });
 
+  it("waits for owner recipients before reporting a request impression", () => {
+    upgradeState.canManageBilling = false;
+    recipientsState.current = { recipients: [], isLoading: true };
+    openEvalLimit();
+    const view = render(<PlanLimitDialog />);
+
+    expect(trackMock).not.toHaveBeenCalledWith(
+      "plan_limit_dialog_shown",
+      expect.anything()
+    );
+
+    recipientsState.current = {
+      recipients: [{ email: "dana@acme.test", name: "Dana Ruiz" }],
+      isLoading: false,
+    };
+    view.rerender(<PlanLimitDialog />);
+
+    expect(trackMock).toHaveBeenCalledWith(
+      "plan_limit_dialog_shown",
+      expect.objectContaining({
+        primary_action: "request_owner",
+        request_recipient_count: 1,
+      })
+    );
+  });
+
   it("shows both prices at once, no toggle to discover", () => {
     openEvalLimit();
     render(<PlanLimitDialog />);
@@ -198,7 +227,10 @@ describe("PlanLimitDialog", () => {
 
   it("offers an owner email instead of a CTA the server would reject", () => {
     upgradeState.canManageBilling = false;
-    recipientsState.current = [{ email: "dana@acme.test", name: "Dana Ruiz" }];
+    recipientsState.current = {
+      recipients: [{ email: "dana@acme.test", name: "Dana Ruiz" }],
+      isLoading: false,
+    };
     openEvalLimit();
     render(<PlanLimitDialog />);
 
@@ -219,7 +251,7 @@ describe("PlanLimitDialog", () => {
 
   it("hides the owner email when there is no address to write to", () => {
     upgradeState.canManageBilling = false;
-    recipientsState.current = [];
+    recipientsState.current = { recipients: [], isLoading: false };
     openEvalLimit();
     render(<PlanLimitDialog />);
 

--- a/mcpjam-inspector/client/src/components/billing/__tests__/PlanLimitDialog.test.tsx
+++ b/mcpjam-inspector/client/src/components/billing/__tests__/PlanLimitDialog.test.tsx
@@ -27,9 +27,8 @@ vi.mock("@/hooks/use-upgrade-checkout", async (importOriginal) => {
   return {
     ...actual,
     useUpgradeCheckout: () => ({
-      interval: "annual" as const,
-      setInterval: vi.fn(),
-      priceLabel: "$30/seat/mo",
+      annualPriceLabel: "$30/seat/mo",
+      monthlyPriceLabel: "$38/seat/mo",
       annualDiscountPct: 21,
       annualSupported: true,
       monthlySupported: true,
@@ -106,20 +105,32 @@ describe("PlanLimitDialog", () => {
     );
   });
 
-  it("offers both billing intervals with the upgrade CTA", () => {
+  it("shows both prices at once, no toggle to discover", () => {
     openEvalLimit();
     render(<PlanLimitDialog />);
 
-    expect(
-      screen.getByRole("button", { name: /annual/i })
-    ).toBeInTheDocument();
-    expect(
-      screen.getByRole("button", { name: /monthly/i })
-    ).toBeInTheDocument();
-    expect(screen.getByText("$30/seat/mo")).toBeInTheDocument();
-    expect(screen.getByTestId("upgrade-plan-cta")).toHaveTextContent(
-      /Upgrade to Team/
+    expect(screen.getByTestId("upgrade-annual")).toHaveTextContent(
+      "$30/seat/mo"
     );
+    expect(screen.getByTestId("upgrade-annual")).toHaveTextContent("Save 21%");
+    expect(screen.getByTestId("upgrade-monthly")).toHaveTextContent(
+      "$38/seat/mo"
+    );
+    expect(
+      screen.getByText(/confirm on Stripe before paying/i)
+    ).toBeInTheDocument();
+  });
+
+  it("starts checkout on the interval the user pressed", async () => {
+    const user = userEvent.setup();
+    openEvalLimit();
+    render(<PlanLimitDialog />);
+
+    await user.click(screen.getByTestId("upgrade-monthly"));
+    expect(startMock).toHaveBeenCalledWith("monthly");
+
+    await user.click(screen.getByTestId("upgrade-annual"));
+    expect(startMock).toHaveBeenLastCalledWith("annual");
   });
 
   it("has no wait-for-reset button; the close control is the only dismissal", () => {
@@ -134,15 +145,6 @@ describe("PlanLimitDialog", () => {
     ).toBeInTheDocument();
   });
 
-  it("starts checkout from the CTA", async () => {
-    const user = userEvent.setup();
-    openEvalLimit();
-    render(<PlanLimitDialog />);
-
-    await user.click(screen.getByTestId("upgrade-plan-cta"));
-    expect(startMock).toHaveBeenCalledTimes(1);
-  });
-
   it("explains who can upgrade instead of showing a CTA the server would reject", () => {
     upgradeState.canManageBilling = false;
     openEvalLimit();
@@ -151,7 +153,7 @@ describe("PlanLimitDialog", () => {
     expect(
       screen.getByTestId("plan-limit-dialog-description")
     ).toHaveTextContent(/Only an organization owner or admin can upgrade/);
-    expect(screen.queryByTestId("upgrade-plan-cta")).not.toBeInTheDocument();
+    expect(screen.queryByTestId("upgrade-annual")).not.toBeInTheDocument();
   });
 
   it("points an org already on Team at Enterprise instead of Team", () => {
@@ -163,7 +165,7 @@ describe("PlanLimitDialog", () => {
     expect(description).toHaveTextContent(/Your plan includes 5,000 a month/);
     expect(description).toHaveTextContent(/Enterprise adds negotiated usage/);
     expect(description).not.toHaveTextContent(/Our Team plan/);
-    expect(screen.queryByTestId("upgrade-plan-cta")).not.toBeInTheDocument();
+    expect(screen.queryByTestId("upgrade-annual")).not.toBeInTheDocument();
     expect(
       screen.getByTestId("plan-limit-enterprise-cta")
     ).toHaveTextContent(/Request upgrade/);

--- a/mcpjam-inspector/client/src/components/billing/__tests__/PlanLimitDialog.test.tsx
+++ b/mcpjam-inspector/client/src/components/billing/__tests__/PlanLimitDialog.test.tsx
@@ -1,7 +1,9 @@
+import { StrictMode } from "react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { act, render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { PlanLimitDialog } from "../PlanLimitDialog";
+import { stashUpgradeReturnToken } from "@/hooks/use-upgrade-checkout";
 import { usePlanLimitDialogStore } from "@/stores/plan-limit-dialog-store";
 
 // Hoisted so the vi.mock factories below (which vitest lifts to the top of the
@@ -107,8 +109,18 @@ beforeEach(() => {
   billingState.plan = "free";
   billingState.isLoading = false;
   window.history.replaceState(null, "", "/evals");
+  window.sessionStorage.clear();
   usePlanLimitDialogStore.setState({ isOpen: false, limit: null });
 });
+
+/**
+ * A return is only honored in the tab that started checkout, so the tests have
+ * to arrive the way a real user does: with the one-shot token in hand.
+ */
+function arriveFromCheckout(url: string, organizationId = "org-1") {
+  stashUpgradeReturnToken(organizationId);
+  window.history.replaceState(null, "", url);
+}
 
 describe("PlanLimitDialog", () => {
   it("renders nothing while closed", () => {
@@ -346,9 +358,7 @@ describe("PlanLimitDialog", () => {
   describe("checkout return", () => {
     it("confirms in place and strips the return params once the plan is paid", async () => {
       billingState.plan = "team";
-      window.history.replaceState(
-        null,
-        "",
+      arriveFromCheckout(
         "/evals?suite=abc&upgrade=return&upgrade_org=org-1&upgrade_from=evals"
       );
       render(<PlanLimitDialog />);
@@ -369,14 +379,14 @@ describe("PlanLimitDialog", () => {
 
     it("waits for delayed billing state before confirming checkout", async () => {
       billingState.plan = "free";
-      window.history.replaceState(
-        null,
-        "",
+      arriveFromCheckout(
         "/evals?upgrade=return&upgrade_org=org-1&upgrade_from=evals"
       );
       const view = render(<PlanLimitDialog />);
 
-      expect(window.location.search).toContain("upgrade=return");
+      // Params are consumed on arrival — the pending outcome lives in state,
+      // so a reload or a shared copy of the link can't replay this.
+      expect(window.location.search).toBe("");
       expect(toastSuccess).not.toHaveBeenCalled();
       expect(trackMock).not.toHaveBeenCalledWith(
         "plan_limit_upgrade_returned",
@@ -397,21 +407,18 @@ describe("PlanLimitDialog", () => {
       vi.useFakeTimers();
       try {
         billingState.plan = "free";
-        window.history.replaceState(
-          null,
-          "",
+        arriveFromCheckout(
           "/evals?upgrade=return&upgrade_org=org-1&upgrade_from=evals"
         );
         render(<PlanLimitDialog />);
 
-        expect(window.location.search).toContain("upgrade=return");
         await act(async () => {
           await vi.advanceTimersByTimeAsync(30_000);
         });
 
         expect(trackMock).toHaveBeenCalledWith(
           "plan_limit_upgrade_returned",
-          expect.objectContaining({ upgraded: false })
+          expect.objectContaining({ upgraded: false, settlement: "pending" })
         );
         expect(toastSuccess).not.toHaveBeenCalled();
         expect(window.location.search).toBe("");
@@ -420,11 +427,109 @@ describe("PlanLimitDialog", () => {
       }
     });
 
-    it("uses credit wording when the user came from the credits wall", async () => {
+    it("still confirms a purchase whose webhook lands after the grace window", async () => {
+      vi.useFakeTimers();
+      try {
+        billingState.plan = "free";
+        arriveFromCheckout(
+          "/evals?upgrade=return&upgrade_org=org-1&upgrade_from=evals"
+        );
+        const view = render(<PlanLimitDialog />);
+
+        await act(async () => {
+          await vi.advanceTimersByTimeAsync(30_000);
+        });
+        expect(trackMock).toHaveBeenCalledWith(
+          "plan_limit_upgrade_returned",
+          expect.objectContaining({ upgraded: false, settlement: "pending" })
+        );
+
+        // A slow webhook is still a real purchase: the user gets the
+        // confirmation they paid for, and the record is corrected.
+        billingState.plan = "team";
+        view.rerender(<PlanLimitDialog />);
+        await act(async () => {
+          await vi.advanceTimersByTimeAsync(0);
+        });
+
+        expect(toastSuccess).toHaveBeenCalledWith(
+          expect.stringMatching(/You're on our Team plan/)
+        );
+        expect(trackMock).toHaveBeenCalledWith(
+          "plan_limit_upgrade_returned",
+          expect.objectContaining({ upgraded: true, settlement: "late" })
+        );
+      } finally {
+        vi.useRealTimers();
+      }
+    });
+
+    it("survives the StrictMode double render the app actually mounts under", async () => {
+      // main.tsx wraps the tree in StrictMode, which double-invokes render-phase
+      // initializers and remounts effects in dev. Claiming the marker twice
+      // would burn the one-shot token and swallow the confirmation.
+      billingState.plan = "team";
+      arriveFromCheckout(
+        "/evals?upgrade=return&upgrade_org=org-1&upgrade_from=evals"
+      );
+      render(
+        <StrictMode>
+          <PlanLimitDialog />
+        </StrictMode>
+      );
+
+      await waitFor(() => {
+        expect(toastSuccess).toHaveBeenCalledWith(
+          expect.stringMatching(/You're on our Team plan/)
+        );
+      });
+    });
+
+    it("ignores a return marker that did not come from this tab's checkout", async () => {
+      // A bookmarked or shared link: no token, so no purchase is announced and
+      // no conversion is recorded for a checkout that never happened.
       billingState.plan = "team";
       window.history.replaceState(
         null,
         "",
+        "/evals?upgrade=return&upgrade_org=org-1&upgrade_from=evals"
+      );
+      render(<PlanLimitDialog />);
+
+      await act(async () => {
+        await Promise.resolve();
+      });
+
+      expect(toastSuccess).not.toHaveBeenCalled();
+      expect(trackMock).not.toHaveBeenCalledWith(
+        "plan_limit_upgrade_returned",
+        expect.anything()
+      );
+      expect(window.location.search).toBe("");
+    });
+
+    it("ignores a return marker naming an organization it was not issued for", async () => {
+      billingState.plan = "team";
+      arriveFromCheckout(
+        "/evals?upgrade=return&upgrade_org=org-2&upgrade_from=evals",
+        "org-1"
+      );
+      render(<PlanLimitDialog />);
+
+      await act(async () => {
+        await Promise.resolve();
+      });
+
+      expect(toastSuccess).not.toHaveBeenCalled();
+      expect(trackMock).not.toHaveBeenCalledWith(
+        "plan_limit_upgrade_returned",
+        expect.anything()
+      );
+    });
+
+    it("uses credit wording when the user came from the credits wall", async () => {
+      billingState.plan = "team";
+      arriveFromCheckout(
         "/chat?upgrade=return&upgrade_org=org-1&upgrade_from=credits"
       );
       render(<PlanLimitDialog />);
@@ -438,16 +543,14 @@ describe("PlanLimitDialog", () => {
 
     it("waits for billing status before deciding", () => {
       billingState.isLoading = true;
-      window.history.replaceState(
-        null,
-        "",
-        "/evals?upgrade=return&upgrade_org=org-1"
-      );
+      arriveFromCheckout("/evals?upgrade=return&upgrade_org=org-1");
       render(<PlanLimitDialog />);
 
       expect(toastSuccess).not.toHaveBeenCalled();
-      // Params survive so a later render can still resolve the outcome.
-      expect(window.location.search).toContain("upgrade=return");
+      expect(trackMock).not.toHaveBeenCalledWith(
+        "plan_limit_upgrade_returned",
+        expect.anything()
+      );
     });
   });
 });

--- a/mcpjam-inspector/client/src/components/billing/__tests__/PlanLimitDialog.test.tsx
+++ b/mcpjam-inspector/client/src/components/billing/__tests__/PlanLimitDialog.test.tsx
@@ -1,0 +1,285 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { PlanLimitDialog } from "../PlanLimitDialog";
+import { usePlanLimitDialogStore } from "@/stores/plan-limit-dialog-store";
+
+// Hoisted so the vi.mock factories below (which vitest lifts to the top of the
+// file) can reach them.
+const { toastSuccess, trackMock, startMock, upgradeState, billingState } =
+  vi.hoisted(() => ({
+    toastSuccess: vi.fn(),
+    trackMock: vi.fn(),
+    startMock: vi.fn(),
+    upgradeState: { currentPlan: "free" as string, canManageBilling: true },
+    billingState: { plan: "free" as string, isLoading: false },
+  }));
+
+vi.mock("@/lib/toast", () => ({
+  toast: { success: toastSuccess, error: vi.fn() },
+}));
+
+vi.mock("@/lib/analytics", () => ({ track: trackMock }));
+
+vi.mock("@/hooks/use-upgrade-checkout", async (importOriginal) => {
+  const actual =
+    await importOriginal<typeof import("@/hooks/use-upgrade-checkout")>();
+  return {
+    ...actual,
+    useUpgradeCheckout: () => ({
+      interval: "annual" as const,
+      setInterval: vi.fn(),
+      priceLabel: "$30/seat/mo",
+      annualDiscountPct: 21,
+      annualSupported: true,
+      monthlySupported: true,
+      teamName: "Team",
+      teamEvalIterations: 5000,
+      currentPlan: upgradeState.currentPlan,
+      canManageBilling: upgradeState.canManageBilling,
+      isStarting: false,
+      start: startMock,
+    }),
+  };
+});
+
+vi.mock("@/hooks/useOrganizationBilling", () => ({
+  useOrganizationBilling: () => ({
+    billingStatus: billingState.isLoading
+      ? undefined
+      : { plan: billingState.plan, billingInterval: "annual" },
+    planCatalog: { plans: { team: { displayName: "Team" } } },
+    isLoadingBilling: billingState.isLoading,
+  }),
+}));
+
+const RESETS_AT = Date.UTC(2026, 7, 11, 4, 0);
+
+function openEvalLimit(overrides: Record<string, unknown> = {}) {
+  usePlanLimitDialogStore.setState({
+    isOpen: true,
+    limit: {
+      kind: "evalIterations",
+      organizationId: "org-1",
+      used: 75,
+      allowed: 75,
+      resetsAt: RESETS_AT,
+      windowKind: "day",
+      origin: "evals",
+      ...overrides,
+    } as never,
+  });
+}
+
+beforeEach(() => {
+  toastSuccess.mockReset();
+  trackMock.mockReset();
+  startMock.mockReset();
+  upgradeState.currentPlan = "free";
+  upgradeState.canManageBilling = true;
+  billingState.plan = "free";
+  billingState.isLoading = false;
+  window.history.replaceState(null, "", "/evals");
+  usePlanLimitDialogStore.setState({ isOpen: false, limit: null });
+});
+
+describe("PlanLimitDialog", () => {
+  it("renders nothing while closed", () => {
+    const { container } = render(<PlanLimitDialog />);
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it("names the allowance, the reset time, and the catalog Team figure", () => {
+    openEvalLimit();
+    render(<PlanLimitDialog />);
+
+    expect(
+      screen.getByRole("heading", { name: /out of eval iterations today/i })
+    ).toBeInTheDocument();
+    const description = screen.getByTestId("plan-limit-dialog-description");
+    expect(description).toHaveTextContent(/Free includes 75 a day/);
+    expect(description).toHaveTextContent(/yours reset at/i);
+    // The Team figure comes from the plan catalog, so it tracks what billing
+    // enforces rather than a hardcoded marketing string.
+    expect(description).toHaveTextContent(
+      /Our Team plan includes 5,000 a month/
+    );
+  });
+
+  it("offers both billing intervals with the upgrade CTA", () => {
+    openEvalLimit();
+    render(<PlanLimitDialog />);
+
+    expect(
+      screen.getByRole("button", { name: /annual/i })
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: /monthly/i })
+    ).toBeInTheDocument();
+    expect(screen.getByText("$30/seat/mo")).toBeInTheDocument();
+    expect(screen.getByTestId("upgrade-plan-cta")).toHaveTextContent(
+      /Upgrade to Team/
+    );
+  });
+
+  it("has no wait-for-reset button; the close control is the only dismissal", () => {
+    openEvalLimit();
+    render(<PlanLimitDialog />);
+
+    expect(
+      screen.queryByRole("button", { name: /wait for reset/i })
+    ).not.toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: /close/i })
+    ).toBeInTheDocument();
+  });
+
+  it("starts checkout from the CTA", async () => {
+    const user = userEvent.setup();
+    openEvalLimit();
+    render(<PlanLimitDialog />);
+
+    await user.click(screen.getByTestId("upgrade-plan-cta"));
+    expect(startMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("explains who can upgrade instead of showing a CTA the server would reject", () => {
+    upgradeState.canManageBilling = false;
+    openEvalLimit();
+    render(<PlanLimitDialog />);
+
+    expect(
+      screen.getByTestId("plan-limit-dialog-description")
+    ).toHaveTextContent(/Only an organization owner or admin can upgrade/);
+    expect(screen.queryByTestId("upgrade-plan-cta")).not.toBeInTheDocument();
+  });
+
+  it("points an org already on Team at Enterprise instead of Team", () => {
+    upgradeState.currentPlan = "team";
+    openEvalLimit({ allowed: 5000, windowKind: "month" });
+    render(<PlanLimitDialog />);
+
+    const description = screen.getByTestId("plan-limit-dialog-description");
+    expect(description).toHaveTextContent(/Your plan includes 5,000 a month/);
+    expect(description).toHaveTextContent(/Enterprise adds negotiated usage/);
+    expect(description).not.toHaveTextContent(/Our Team plan/);
+    expect(screen.queryByTestId("upgrade-plan-cta")).not.toBeInTheDocument();
+    expect(
+      screen.getByTestId("plan-limit-enterprise-cta")
+    ).toHaveTextContent(/Request upgrade/);
+  });
+
+  it("reports the Enterprise CTA click", async () => {
+    const user = userEvent.setup();
+    upgradeState.currentPlan = "team";
+    openEvalLimit({ allowed: 5000, windowKind: "month" });
+    render(<PlanLimitDialog />);
+
+    await user.click(screen.getByTestId("plan-limit-enterprise-cta"));
+    expect(trackMock).toHaveBeenCalledWith(
+      "plan_limit_enterprise_cta_clicked",
+      expect.objectContaining({ plan: "team" })
+    );
+    expect(usePlanLimitDialogStore.getState().isOpen).toBe(false);
+  });
+
+  it("offers nothing to pitch when the org is already on Enterprise", () => {
+    upgradeState.currentPlan = "enterprise";
+    openEvalLimit({ allowed: 50000, windowKind: "month" });
+    render(<PlanLimitDialog />);
+
+    const description = screen.getByTestId("plan-limit-dialog-description");
+    expect(description).toHaveTextContent(/Your plan includes 50,000 a month/);
+    expect(description).not.toHaveTextContent(/Enterprise adds/);
+    expect(
+      screen.queryByTestId("plan-limit-enterprise-cta")
+    ).not.toBeInTheDocument();
+  });
+
+  it("closes and reports a dismissal", async () => {
+    const user = userEvent.setup();
+    openEvalLimit();
+    render(<PlanLimitDialog />);
+
+    await user.click(screen.getByRole("button", { name: /close/i }));
+    expect(usePlanLimitDialogStore.getState().isOpen).toBe(false);
+    expect(trackMock).toHaveBeenCalledWith(
+      "plan_limit_dialog_dismissed",
+      expect.objectContaining({ limit_kind: "evalIterations" })
+    );
+  });
+
+  describe("checkout return", () => {
+    it("confirms in place and strips the return params once the plan is paid", async () => {
+      billingState.plan = "team";
+      window.history.replaceState(
+        null,
+        "",
+        "/evals?suite=abc&upgrade=return&upgrade_org=org-1&upgrade_from=evals"
+      );
+      render(<PlanLimitDialog />);
+
+      await waitFor(() => {
+        expect(toastSuccess).toHaveBeenCalledWith(
+          expect.stringMatching(/You're on our Team plan/)
+        );
+      });
+      // The surface the user was blocked on is preserved; only the upgrade
+      // bookkeeping is removed.
+      expect(window.location.search).toBe("?suite=abc");
+      expect(trackMock).toHaveBeenCalledWith(
+        "plan_limit_upgrade_returned",
+        expect.objectContaining({ upgraded: true, plan: "team" })
+      );
+    });
+
+    it("stays silent when the user bailed at checkout", async () => {
+      billingState.plan = "free";
+      window.history.replaceState(
+        null,
+        "",
+        "/evals?upgrade=return&upgrade_org=org-1&upgrade_from=evals"
+      );
+      render(<PlanLimitDialog />);
+
+      await waitFor(() => {
+        expect(trackMock).toHaveBeenCalledWith(
+          "plan_limit_upgrade_returned",
+          expect.objectContaining({ upgraded: false })
+        );
+      });
+      expect(toastSuccess).not.toHaveBeenCalled();
+      expect(window.location.search).toBe("");
+    });
+
+    it("uses credit wording when the user came from the credits wall", async () => {
+      billingState.plan = "team";
+      window.history.replaceState(
+        null,
+        "",
+        "/chat?upgrade=return&upgrade_org=org-1&upgrade_from=credits"
+      );
+      render(<PlanLimitDialog />);
+
+      await waitFor(() => {
+        expect(toastSuccess).toHaveBeenCalledWith(
+          expect.stringMatching(/Your credits are available now/)
+        );
+      });
+    });
+
+    it("waits for billing status before deciding", () => {
+      billingState.isLoading = true;
+      window.history.replaceState(
+        null,
+        "",
+        "/evals?upgrade=return&upgrade_org=org-1"
+      );
+      render(<PlanLimitDialog />);
+
+      expect(toastSuccess).not.toHaveBeenCalled();
+      // Params survive so a later render can still resolve the outcome.
+      expect(window.location.search).toContain("upgrade=return");
+    });
+  });
+});

--- a/mcpjam-inspector/client/src/components/billing/__tests__/PlanLimitDialog.test.tsx
+++ b/mcpjam-inspector/client/src/components/billing/__tests__/PlanLimitDialog.test.tsx
@@ -21,7 +21,6 @@ const {
     upgradeState: { currentPlan: "free" as string, canManageBilling: true },
     recipientsState: {
       current: [] as Array<{ email: string; name?: string | null }>,
-      isLoading: false,
     },
     billingState: { plan: "free" as string, isLoading: false },
   }));
@@ -67,10 +66,7 @@ vi.mock("@/hooks/useOrganizationBilling", () => ({
 }));
 
 vi.mock("@/hooks/use-upgrade-request-recipients", () => ({
-  useUpgradeRequestRecipients: () => ({
-    recipients: recipientsState.current,
-    isLoading: recipientsState.isLoading,
-  }),
+  useUpgradeRequestRecipients: () => recipientsState.current,
 }));
 
 const RESETS_AT = Date.UTC(2026, 7, 11, 4, 0);
@@ -98,7 +94,6 @@ beforeEach(() => {
   upgradeState.currentPlan = "free";
   upgradeState.canManageBilling = true;
   recipientsState.current = [];
-  recipientsState.isLoading = false;
   billingState.plan = "free";
   billingState.isLoading = false;
   window.history.replaceState(null, "", "/evals");
@@ -197,25 +192,9 @@ describe("PlanLimitDialog", () => {
     expect(screen.getByText(/Opens a draft to Dana Ruiz/)).toBeInTheDocument();
   });
 
-  it("holds a disabled button while the owner lookup is in flight", () => {
-    upgradeState.canManageBilling = false;
-    recipientsState.isLoading = true;
-    openEvalLimit();
-    render(<PlanLimitDialog />);
-
-    // Empty recipients plus loading must not read as "no owner": that would
-    // render nothing now and pop a button in a beat later.
-    const button = screen.getByRole("button", { name: /email your owner/i });
-    expect(button).toBeDisabled();
-    expect(
-      screen.queryByTestId("request-upgrade-mail")
-    ).not.toBeInTheDocument();
-  });
-
-  it("hides the owner email when the lookup finishes with no owner", () => {
+  it("hides the owner email when there is no address to write to", () => {
     upgradeState.canManageBilling = false;
     recipientsState.current = [];
-  recipientsState.isLoading = false;
     openEvalLimit();
     render(<PlanLimitDialog />);
 

--- a/mcpjam-inspector/client/src/components/billing/__tests__/PlanLimitDialog.test.tsx
+++ b/mcpjam-inspector/client/src/components/billing/__tests__/PlanLimitDialog.test.tsx
@@ -635,6 +635,34 @@ describe("PlanLimitDialog", () => {
       );
     });
 
+    it("does not confirm when sign-out and the paid update land together", async () => {
+      // The tightest window: identity drops and billing turns paid on the SAME
+      // commit. A passive disarm loses this race — child effects run before
+      // parent ones — so the gate has to be synchronous.
+      billingState.plan = "free";
+      arriveFromCheckout(
+        "/evals?upgrade=return&upgrade_org=org-1&upgrade_from=evals"
+      );
+      const view = render(<PlanLimitDialog />);
+      await act(async () => {
+        await Promise.resolve();
+      });
+      expect(toastSuccess).not.toHaveBeenCalled();
+
+      authState.userId = null;
+      billingState.plan = "team";
+      view.rerender(<PlanLimitDialog />);
+      await act(async () => {
+        await Promise.resolve();
+      });
+
+      expect(toastSuccess).not.toHaveBeenCalled();
+      expect(trackMock).not.toHaveBeenCalledWith(
+        "plan_limit_upgrade_returned",
+        expect.anything()
+      );
+    });
+
     it("keeps waiting through a sign-out blip and confirms for the same user", async () => {
       // A token refresh briefly drops the identity. That is not a new user, so
       // the pending confirmation must survive it.

--- a/mcpjam-inspector/client/src/components/billing/__tests__/PlanLimitDialog.test.tsx
+++ b/mcpjam-inspector/client/src/components/billing/__tests__/PlanLimitDialog.test.tsx
@@ -190,7 +190,7 @@ describe("PlanLimitDialog", () => {
     expect(href).toContain("Acme Robotics");
     expect(href).toContain("Organizations, then Billing");
     // Says what it does. It opens a draft; it does not send anything.
-    expect(mail).toHaveTextContent(/Email your owner/);
+    expect(mail).toHaveTextContent(/Email your plan's owner/);
     expect(screen.getByText(/Opens a draft to Dana Ruiz/)).toBeInTheDocument();
   });
 

--- a/mcpjam-inspector/client/src/components/billing/__tests__/PlanLimitDialog.test.tsx
+++ b/mcpjam-inspector/client/src/components/billing/__tests__/PlanLimitDialog.test.tsx
@@ -561,7 +561,7 @@ describe("PlanLimitDialog", () => {
         );
         // Retired, so a third load says nothing.
         expect(
-          window.sessionStorage.getItem("mcpjam.upgradeReturnToken")
+          window.sessionStorage.getItem("mcpjam.upgradeReturnToken:user-1")
         ).toBe(null);
       } finally {
         vi.useRealTimers();
@@ -592,10 +592,11 @@ describe("PlanLimitDialog", () => {
         "plan_limit_upgrade_returned",
         expect.anything()
       );
-      // Retired on sight, so it cannot wait around for a third user either.
-      expect(window.sessionStorage.getItem("mcpjam.upgradeReturnToken")).toBe(
-        null
-      );
+      // user-2 has no ticket of their own, and user-1's is namespaced out of
+      // reach rather than something user-2's session has to notice and clean.
+      expect(
+        window.sessionStorage.getItem("mcpjam.upgradeReturnToken:user-2")
+      ).toBe(null);
     });
 
     it("disarms a pending confirmation when the buyer signs out mid-flight", async () => {
@@ -630,9 +631,11 @@ describe("PlanLimitDialog", () => {
         "plan_limit_upgrade_returned",
         expect.anything()
       );
-      expect(window.sessionStorage.getItem("mcpjam.upgradeReturnToken")).toBe(
-        null
-      );
+      // user-1's ticket outlives the sign-out untouched — it is namespaced, so
+      // user-2's session can neither read nor redeem it — and dies with the tab.
+      expect(
+        window.sessionStorage.getItem("mcpjam.upgradeReturnToken:user-2")
+      ).toBe(null);
     });
 
     it("does not confirm when sign-out and the paid update land together", async () => {
@@ -678,7 +681,7 @@ describe("PlanLimitDialog", () => {
       });
       expect(toastSuccess).not.toHaveBeenCalled();
       expect(
-        window.sessionStorage.getItem("mcpjam.upgradeReturnToken")
+        window.sessionStorage.getItem("mcpjam.upgradeReturnToken:user-1")
       ).not.toBe(null);
 
       authState.userId = "user-1";

--- a/mcpjam-inspector/client/src/components/billing/__tests__/RequestUpgradeButton.test.tsx
+++ b/mcpjam-inspector/client/src/components/billing/__tests__/RequestUpgradeButton.test.tsx
@@ -49,6 +49,27 @@ describe("buildUpgradeRequestMail", () => {
     expect(decodeURIComponent(href!)).toContain("run out of credits");
   });
 
+  it("asks a paid organization to buy credits instead of upgrading", () => {
+    const href = buildUpgradeRequestMail({
+      recipients: [OWNER],
+      organizationName: "Acme Robotics",
+      teamName: "Team",
+      origin: "credits",
+      requestAction: "buyCredits",
+    });
+
+    const decoded = decodeURIComponent(href!);
+    expect(decoded).toContain("Credit purchase request for Acme Robotics");
+    expect(decoded).toContain(
+      "Our organization has run out of MCPJam credits."
+    );
+    expect(decoded).toContain(
+      "Could you buy more credits for Acme Robotics?"
+    );
+    expect(decoded).toContain("2. Under Credits, click Buy credits.");
+    expect(decoded).not.toContain("upgrade Acme Robotics to the Team plan");
+  });
+
   it("returns null when there is nobody to address", () => {
     expect(
       buildUpgradeRequestMail({

--- a/mcpjam-inspector/client/src/components/billing/__tests__/RequestUpgradeButton.test.tsx
+++ b/mcpjam-inspector/client/src/components/billing/__tests__/RequestUpgradeButton.test.tsx
@@ -1,0 +1,131 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import {
+  RequestUpgradeButton,
+  buildUpgradeRequestMail,
+} from "../RequestUpgradeButton";
+
+const { trackMock } = vi.hoisted(() => ({ trackMock: vi.fn() }));
+vi.mock("@/lib/analytics", () => ({ track: trackMock }));
+
+const OWNER = { email: "dana@acme.test", name: "Dana Ruiz" };
+
+beforeEach(() => {
+  trackMock.mockReset();
+});
+
+describe("buildUpgradeRequestMail", () => {
+  it("addresses every owner and spells out the steps they have to take", () => {
+    const href = buildUpgradeRequestMail({
+      recipients: [OWNER, { email: "sam@acme.test", name: null }],
+      organizationName: "Acme Robotics",
+      teamName: "Team",
+      origin: "evals",
+    });
+
+    expect(href).not.toBeNull();
+    const decoded = decodeURIComponent(href!);
+    expect(decoded).toContain("mailto:dana@acme.test,sam@acme.test");
+    expect(decoded).toContain(
+      "Upgrade request: MCPJam Team plan for Acme Robotics"
+    );
+    expect(decoded).toContain("Hi Dana,");
+    expect(decoded).toContain("hit the free plan's eval iteration limit");
+    // The owner cannot act on a request that doesn't say what to do.
+    expect(decoded).toContain("1. Open MCPJam, go to Organizations, then Billing.");
+    expect(decoded).toContain("2. Under the Team plan, pick Annual or Monthly.");
+    expect(decoded).toContain("3. Click Upgrade and finish checkout with Stripe.");
+  });
+
+  it("describes the credits wall differently from the eval wall", () => {
+    const href = buildUpgradeRequestMail({
+      recipients: [OWNER],
+      organizationName: "Acme Robotics",
+      teamName: "Team",
+      origin: "credits",
+    });
+
+    expect(decodeURIComponent(href!)).toContain("run out of credits");
+  });
+
+  it("returns null when there is nobody to address", () => {
+    expect(
+      buildUpgradeRequestMail({
+        recipients: [],
+        organizationName: "Acme Robotics",
+        teamName: "Team",
+        origin: "evals",
+      })
+    ).toBeNull();
+  });
+});
+
+describe("RequestUpgradeButton", () => {
+  it("renders a mailto anchor naming the recipient", () => {
+    render(
+      <RequestUpgradeButton
+        recipients={[OWNER]}
+        organizationName="Acme Robotics"
+        teamName="Team"
+        origin="evals"
+        limitKind="evalIterations"
+      />
+    );
+
+    expect(screen.getByTestId("request-upgrade-mail")).toHaveAttribute(
+      "href",
+      expect.stringContaining("mailto:dana@acme.test")
+    );
+    expect(screen.getByText(/Opens a draft to Dana Ruiz/)).toBeInTheDocument();
+  });
+
+  it("counts the other owners when there are several", () => {
+    render(
+      <RequestUpgradeButton
+        recipients={[OWNER, { email: "sam@acme.test" }]}
+        organizationName="Acme Robotics"
+        teamName="Team"
+        origin="evals"
+        limitKind="evalIterations"
+      />
+    );
+
+    expect(
+      screen.getByText(/Opens a draft to Dana Ruiz and 1 other owner/)
+    ).toBeInTheDocument();
+  });
+
+  it("renders nothing rather than a button that opens an empty draft", () => {
+    const { container } = render(
+      <RequestUpgradeButton
+        recipients={[]}
+        organizationName="Acme Robotics"
+        teamName="Team"
+        origin="evals"
+        limitKind="evalIterations"
+      />
+    );
+
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it("reports the request", async () => {
+    const user = userEvent.setup();
+    render(
+      <RequestUpgradeButton
+        recipients={[OWNER]}
+        organizationName="Acme Robotics"
+        teamName="Team"
+        origin="evals"
+        limitKind="evalIterations"
+      />
+    );
+
+    await user.click(screen.getByTestId("request-upgrade-mail"));
+    expect(trackMock).toHaveBeenCalledWith(
+      "plan_limit_upgrade_requested",
+      expect.objectContaining({ origin: "evals", recipient_count: 1 })
+    );
+  });
+});

--- a/mcpjam-inspector/client/src/components/billing/__tests__/RequestUpgradeButton.test.tsx
+++ b/mcpjam-inspector/client/src/components/billing/__tests__/RequestUpgradeButton.test.tsx
@@ -70,6 +70,21 @@ describe("buildUpgradeRequestMail", () => {
     expect(decoded).not.toContain("upgrade Acme Robotics to the Team plan");
   });
 
+  it("percent-encodes an address so a reserved character can't truncate it", () => {
+    const href = buildUpgradeRequestMail({
+      recipients: [{ email: "dana#ops@acme.test", name: "Dana Ruiz" }],
+      organizationName: "Acme Robotics",
+      teamName: "Team",
+      origin: "evals",
+    });
+
+    // Raw, the `#` would start the URL fragment: the recipient becomes
+    // "dana" and the subject and body vanish. `@` stays literal — RFC 6068
+    // encodes within the addr-spec, not the separator between its parts.
+    expect(href).toContain("mailto:dana%23ops@acme.test?subject=");
+    expect(decodeURIComponent(href!)).toContain("mailto:dana#ops@acme.test");
+  });
+
   it("returns null when there is nobody to address", () => {
     expect(
       buildUpgradeRequestMail({
@@ -94,10 +109,10 @@ describe("RequestUpgradeButton", () => {
       />
     );
 
-    expect(screen.getByTestId("request-upgrade-mail")).toHaveAttribute(
-      "href",
-      expect.stringContaining("mailto:dana@acme.test")
-    );
+    const href = screen
+      .getByTestId("request-upgrade-mail")
+      .getAttribute("href");
+    expect(decodeURIComponent(href!)).toContain("mailto:dana@acme.test");
     expect(screen.getByText(/Opens a draft to Dana Ruiz/)).toBeInTheDocument();
   });
 

--- a/mcpjam-inspector/client/src/components/billing/__tests__/UpgradeIntervalPicker.test.tsx
+++ b/mcpjam-inspector/client/src/components/billing/__tests__/UpgradeIntervalPicker.test.tsx
@@ -1,0 +1,65 @@
+import type { ComponentProps } from "react";
+import { describe, expect, it, vi } from "vitest";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+
+import { UpgradeIntervalPicker } from "../UpgradeIntervalPicker";
+
+function renderPicker(
+  overrides: Partial<ComponentProps<typeof UpgradeIntervalPicker>> = {}
+) {
+  const onUpgrade = vi.fn();
+  render(
+    <UpgradeIntervalPicker
+      interval="annual"
+      onIntervalChange={vi.fn()}
+      annualPriceLabel="$30"
+      monthlyPriceLabel="$38"
+      annualDiscountPct={21}
+      annualSupported
+      monthlySupported
+      teamName="Team"
+      isStarting={false}
+      onUpgrade={onUpgrade}
+      {...overrides}
+    />
+  );
+  return { onUpgrade };
+}
+
+describe("UpgradeIntervalPicker", () => {
+  it("confirms the upgrade once the selected interval has a price", async () => {
+    const user = userEvent.setup();
+    const { onUpgrade } = renderPicker();
+
+    const cta = screen.getByTestId("upgrade-plan-cta");
+    expect(cta).toBeEnabled();
+    await user.click(cta);
+
+    expect(onUpgrade).toHaveBeenCalledTimes(1);
+  });
+
+  it("keeps checkout closed when the selected card shows no price", async () => {
+    const user = userEvent.setup();
+    const { onUpgrade } = renderPicker({ annualPriceLabel: null });
+
+    const cta = screen.getByTestId("upgrade-plan-cta");
+    expect(cta).toBeDisabled();
+    expect(cta).toHaveTextContent("Loading prices…");
+    await user.click(cta);
+
+    expect(onUpgrade).not.toHaveBeenCalled();
+  });
+
+  it("stays usable when the unselected card is the one missing a price", () => {
+    renderPicker({ monthlyPriceLabel: null });
+
+    expect(screen.getByTestId("upgrade-plan-cta")).toBeEnabled();
+  });
+
+  it("renders nothing when no interval is supported", () => {
+    renderPicker({ annualSupported: false, monthlySupported: false });
+
+    expect(screen.queryByTestId("upgrade-plan-cta")).toBeNull();
+  });
+});

--- a/mcpjam-inspector/client/src/components/billing/__tests__/UpgradeIntervalPicker.test.tsx
+++ b/mcpjam-inspector/client/src/components/billing/__tests__/UpgradeIntervalPicker.test.tsx
@@ -9,10 +9,11 @@ function renderPicker(
   overrides: Partial<ComponentProps<typeof UpgradeIntervalPicker>> = {}
 ) {
   const onUpgrade = vi.fn();
+  const onIntervalChange = vi.fn();
   render(
     <UpgradeIntervalPicker
       interval="annual"
-      onIntervalChange={vi.fn()}
+      onIntervalChange={onIntervalChange}
       annualPriceLabel="$30"
       monthlyPriceLabel="$38"
       annualDiscountPct={21}
@@ -24,7 +25,7 @@ function renderPicker(
       {...overrides}
     />
   );
-  return { onUpgrade };
+  return { onUpgrade, onIntervalChange };
 }
 
 describe("UpgradeIntervalPicker", () => {
@@ -37,6 +38,38 @@ describe("UpgradeIntervalPicker", () => {
     await user.click(cta);
 
     expect(onUpgrade).toHaveBeenCalledTimes(1);
+  });
+
+  it("reports the choice without starting checkout", async () => {
+    const user = userEvent.setup();
+    const { onIntervalChange, onUpgrade } = renderPicker();
+
+    await user.click(screen.getByTestId("upgrade-interval-monthly"));
+
+    expect(onIntervalChange).toHaveBeenCalledWith("monthly");
+    // Selecting is not confirming — the CTA is the only thing that buys.
+    expect(onUpgrade).not.toHaveBeenCalled();
+  });
+
+  it("freezes the whole picker while prices are explicitly loading", async () => {
+    const user = userEvent.setup();
+    // Both labels are present, so only the loading flag can close checkout
+    // here — this is the flag's own path, not the missing-price one below.
+    const { onIntervalChange, onUpgrade } = renderPicker({
+      isLoadingPrices: true,
+    });
+
+    const cta = screen.getByTestId("upgrade-plan-cta");
+    expect(cta).toBeDisabled();
+    expect(cta).toHaveTextContent("Loading prices…");
+    expect(screen.getByTestId("upgrade-interval-annual")).toBeDisabled();
+    expect(screen.getByTestId("upgrade-interval-monthly")).toBeDisabled();
+
+    await user.click(screen.getByTestId("upgrade-interval-monthly"));
+    await user.click(cta);
+
+    expect(onIntervalChange).not.toHaveBeenCalled();
+    expect(onUpgrade).not.toHaveBeenCalled();
   });
 
   it("keeps checkout closed when the selected card shows no price", async () => {

--- a/mcpjam-inspector/client/src/components/chat-v2/shared/available-models.ts
+++ b/mcpjam-inspector/client/src/components/chat-v2/shared/available-models.ts
@@ -48,7 +48,7 @@ export function applyGuestModelLocks(
 }
 
 export const OUT_OF_CREDITS_MODEL_REASON =
-  "You're out of credits. Top up or use your own key.";
+  "You're out of credits. Upgrade, buy credits, or use your own key.";
 
 /**
  * Once the org/guest is out of MCPJam credits, MCPJam-provided ("free")

--- a/mcpjam-inspector/client/src/components/evals/__tests__/use-eval-handlers.test.ts
+++ b/mcpjam-inspector/client/src/components/evals/__tests__/use-eval-handlers.test.ts
@@ -17,6 +17,28 @@ import {
 import { API_ENDPOINTS } from "../constants";
 import { createFetchResponse, createDeferred } from "@/test";
 import { setApiContext } from "@/lib/apis/web/context";
+import { usePlanLimitDialogStore } from "@/stores/plan-limit-dialog-store";
+
+/**
+ * Server-side eval-iteration cap rejection, in the shape `postEvalRequest`
+ * re-throws as a ConvexError (`details` carries the billing payload).
+ */
+function createEvalIterationCapResponse(): Response {
+  return createFetchResponse(
+    {
+      message: "Eval iteration limit reached",
+      details: {
+        code: "billing_limit_reached",
+        limitName: "maxEvalIterationsPerMonth",
+        allowedValue: 100,
+        currentValue: 100,
+        resetsAt: 1_760_000_000_000,
+        windowKind: "month",
+      },
+    },
+    402,
+  );
+}
 
 const { hostedModeRef } = vi.hoisted(() => ({
   hostedModeRef: { value: false },
@@ -80,9 +102,10 @@ vi.mock("@/lib/analytics", () => ({
 vi.mock("sonner", () => ({
   toast: {
     loading: vi.fn().mockReturnValue("toast-id"),
-    success: vi.fn(),
+    success: vi.fn().mockReturnValue("toast-id"),
     error: vi.fn(),
     info: vi.fn(),
+    dismiss: vi.fn(),
   },
 }));
 
@@ -133,6 +156,9 @@ describe("useEvalHandlers", () => {
     mockIsHostedMode.mockReturnValue(false);
     mockProviderGetToken.mockReturnValue("mock-api-key");
     mockProviderHasToken.mockReturnValue(true);
+    usePlanLimitDialogStore.setState({ isOpen: false, limit: null });
+    // Pinned so the wall tests can assert the exact toast the handler dismisses.
+    vi.mocked(toast.success).mockReturnValue("toast-id");
 
     // Default mock implementations
     mockGetAccessToken.mockResolvedValue("mock-access-token");
@@ -873,6 +899,55 @@ describe("useEvalHandlers", () => {
       expect(errorToasts).toContain("Environment changed — retry the run.");
       expect(errorToasts).not.toContain("Upstream exploded");
     });
+
+    it("opens the upgrade wall and clears the optimistic toast when the server rejects the launch on the eval-iteration cap", async () => {
+      // The "Run started successfully!" toast fires before the request
+      // resolves, so leaving it up alongside the wall would claim the run is
+      // on its way.
+      mockAuthFetch.mockResolvedValue(createEvalIterationCapResponse());
+
+      const { result } = renderHook(() =>
+        useEvalHandlers({ ...defaultProps, organizationId: "org-1" }),
+      );
+
+      await act(async () => {
+        await result.current.handleRerun({
+          _id: "suite-123",
+          name: "Test Suite",
+          description: "A test suite",
+          environment: { servers: ["server-1"] },
+        } as any);
+      });
+
+      expect(usePlanLimitDialogStore.getState().limit).toMatchObject({
+        kind: "evalIterations",
+        organizationId: "org-1",
+        used: 100,
+        allowed: 100,
+        windowKind: "month",
+      });
+      expect(toast.dismiss).toHaveBeenCalledWith("toast-id");
+      expect(toast.error).not.toHaveBeenCalled();
+    });
+
+    it("keeps the fallback toast when there is no organization to upgrade", async () => {
+      mockAuthFetch.mockResolvedValue(createEvalIterationCapResponse());
+
+      const { result } = renderHook(() => useEvalHandlers(defaultProps));
+
+      await act(async () => {
+        await result.current.handleRerun({
+          _id: "suite-123",
+          name: "Test Suite",
+          description: "A test suite",
+          environment: { servers: ["server-1"] },
+        } as any);
+      });
+
+      expect(usePlanLimitDialogStore.getState().isOpen).toBe(false);
+      expect(toast.error).toHaveBeenCalled();
+      expect(toast.dismiss).not.toHaveBeenCalled();
+    });
   });
 
   describe("handleRunTestCase", () => {
@@ -1257,6 +1332,110 @@ describe("useEvalHandlers", () => {
 
       const requestBody = JSON.parse(mockAuthFetch.mock.calls[0][1].body);
       expect(requestBody.testCaseOverrides).toBeUndefined();
+    });
+
+    it("opens the upgrade wall when /run-test-case is rejected on the eval-iteration cap", async () => {
+      // The per-model rejection is caught inside the fan-out, so it never
+      // reaches the outer catch — the collected failures have to open the
+      // wall themselves.
+      mockAuthFetch.mockResolvedValue(createEvalIterationCapResponse());
+
+      const { result } = renderHook(() =>
+        useEvalHandlers({ ...defaultProps, organizationId: "org-1" }),
+      );
+
+      await act(async () => {
+        await result.current.handleRunTestCase(
+          {
+            _id: "suite-123",
+            name: "Test Suite",
+            environment: { servers: ["server-1"] },
+          } as any,
+          {
+            _id: "case-123",
+            title: "Single-model case",
+            query: "Test query",
+            models: [{ provider: "openai", model: "gpt-4o" }],
+            expectedToolCalls: [],
+          } as any,
+        );
+      });
+
+      expect(usePlanLimitDialogStore.getState().limit).toMatchObject({
+        kind: "evalIterations",
+        organizationId: "org-1",
+        used: 100,
+        allowed: 100,
+        windowKind: "month",
+      });
+      expect(toast.error).not.toHaveBeenCalled();
+    });
+
+    it("still toasts the cap rejection when there is no organization to upgrade", async () => {
+      mockAuthFetch.mockResolvedValue(createEvalIterationCapResponse());
+
+      const { result } = renderHook(() => useEvalHandlers(defaultProps));
+
+      await act(async () => {
+        await result.current.handleRunTestCase(
+          {
+            _id: "suite-123",
+            name: "Test Suite",
+            environment: { servers: ["server-1"] },
+          } as any,
+          {
+            _id: "case-123",
+            title: "Single-model case",
+            query: "Test query",
+            models: [{ provider: "openai", model: "gpt-4o" }],
+            expectedToolCalls: [],
+          } as any,
+        );
+      });
+
+      expect(usePlanLimitDialogStore.getState().isOpen).toBe(false);
+      expect(toast.error).toHaveBeenCalled();
+    });
+
+    it("keeps the partial-failure count toast when only some models hit the cap", async () => {
+      mockAuthFetch
+        .mockResolvedValueOnce(
+          createFetchResponse({
+            success: true,
+            iteration: { _id: "iter-openai" },
+          }),
+        )
+        .mockResolvedValueOnce(createEvalIterationCapResponse());
+
+      const { result } = renderHook(() =>
+        useEvalHandlers({ ...defaultProps, organizationId: "org-1" }),
+      );
+
+      await act(async () => {
+        await result.current.handleRunTestCase(
+          {
+            _id: "suite-123",
+            name: "Test Suite",
+            environment: { servers: ["server-1"] },
+          } as any,
+          {
+            _id: "case-123",
+            title: "Multi-model case",
+            query: "Test query",
+            models: [
+              { provider: "openai", model: "gpt-4o" },
+              { provider: "anthropic", model: "claude-3-5-sonnet" },
+            ],
+            expectedToolCalls: [],
+          } as any,
+        );
+      });
+
+      expect(usePlanLimitDialogStore.getState().isOpen).toBe(true);
+      // The wall doesn't say how many models did land; that toast still does.
+      expect(toast.error).toHaveBeenCalledWith(
+        "1/2 models completed successfully.",
+      );
     });
   });
 

--- a/mcpjam-inspector/client/src/components/evals/__tests__/use-eval-handlers.test.ts
+++ b/mcpjam-inspector/client/src/components/evals/__tests__/use-eval-handlers.test.ts
@@ -930,6 +930,161 @@ describe("useEvalHandlers", () => {
       expect(toast.error).not.toHaveBeenCalled();
     });
 
+    it("opens the wall for a cap the replay endpoint nests under details", async () => {
+      // Replay is a hand-rolled fetch, not `postEvalRequest`: it threw the
+      // response body whole, so the parser read the outer envelope and the
+      // cap looked like an ordinary failure.
+      mockIsHostedMode.mockReturnValue(true);
+      mockAuthFetch.mockResolvedValue(createEvalIterationCapResponse());
+
+      const { result } = renderHook(() =>
+        useEvalHandlers({
+          ...defaultProps,
+          organizationId: "org-1",
+          connectedServerNames: new Set(),
+          ensureServersReady: vi.fn().mockResolvedValue({
+            readyServerNames: [],
+            missingServerNames: [],
+            failedServerNames: ["server-1"],
+            reauthServerNames: [],
+          }),
+          latestRunBySuiteId: new Map<string, any>([
+            ["suite-123", { _id: "run-source", hasServerReplayConfig: true }],
+          ]),
+        }),
+      );
+
+      await act(async () => {
+        await result.current.handleRerun({
+          _id: "suite-123",
+          name: "CI Suite",
+          source: "ui",
+          environment: { servers: ["server-1"] },
+        } as any);
+      });
+
+      expect(mockAuthFetch).toHaveBeenCalledWith(
+        "/api/web/evals/replay-run",
+        expect.anything(),
+      );
+      expect(usePlanLimitDialogStore.getState().limit).toMatchObject({
+        kind: "evalIterations",
+        organizationId: "org-1",
+        allowed: 100,
+      });
+      expect(toast.error).not.toHaveBeenCalled();
+    });
+
+    it("opens the wall when a cap rejects one target and the rest launch", async () => {
+      // Partial fan-out failures only toast — they never throw — so this
+      // branch has to reach the wall itself.
+      mockAuthFetch.mockImplementation(
+        async (path: string, init: { body: string }) => {
+          if (path !== "/api/mcp/evals/run") {
+            return createFetchResponse({ success: true });
+          }
+          const body = JSON.parse(init.body);
+          return body.namedHostId === "host-claude"
+            ? createEvalIterationCapResponse()
+            : createFetchResponse({ success: true });
+        },
+      );
+
+      const { result } = renderHook(() =>
+        useEvalHandlers({
+          ...defaultProps,
+          organizationId: "org-1",
+          connectedServerNames: new Set(["server-a", "server-b"]),
+        }),
+      );
+
+      await act(async () => {
+        await result.current.handleRerun({
+          _id: "suite-partial",
+          name: "Multi-host suite",
+          environment: { servers: ["server-a", "server-b"] },
+          hostAttachments: [
+            {
+              namedHostId: "host-mcpjam",
+              hostName: "MCPJam",
+              enabledOptionalServerIds: [],
+              resolvedServerNames: ["server-a"],
+            },
+            {
+              namedHostId: "host-claude",
+              hostName: "Claude",
+              enabledOptionalServerIds: [],
+              resolvedServerNames: ["server-b"],
+            },
+          ],
+        } as any);
+      });
+
+      expect(usePlanLimitDialogStore.getState().limit).toMatchObject({
+        kind: "evalIterations",
+        organizationId: "org-1",
+      });
+      // The count toast survives: it says how many DID launch, which the wall
+      // does not.
+      const errorToasts = vi
+        .mocked(toast.error)
+        .mock.calls.map((call) => String(call[0]))
+        .join(" | ");
+      expect(errorToasts).toContain("1 of 2");
+    });
+
+    it("finds a cap carried by a later plan when every plan fails", async () => {
+      // Ordered so the cap is neither `failures[0]` nor the drift 409 the
+      // all-failed branch used to prefer.
+      mockAuthFetch.mockImplementation(
+        async (path: string, init: { body: string }) => {
+          if (path !== "/api/mcp/evals/run") {
+            return createFetchResponse({ success: true });
+          }
+          const body = JSON.parse(init.body);
+          return body.namedHostId === "host-claude"
+            ? createEvalIterationCapResponse()
+            : createFetchResponse({ message: "Upstream exploded" }, 500);
+        },
+      );
+
+      const { result } = renderHook(() =>
+        useEvalHandlers({
+          ...defaultProps,
+          organizationId: "org-1",
+          connectedServerNames: new Set(["server-a", "server-b"]),
+        }),
+      );
+
+      await act(async () => {
+        await result.current.handleRerun({
+          _id: "suite-all-capped",
+          name: "Multi-host suite",
+          environment: { servers: ["server-a", "server-b"] },
+          hostAttachments: [
+            {
+              namedHostId: "host-mcpjam",
+              hostName: "MCPJam",
+              enabledOptionalServerIds: [],
+              resolvedServerNames: ["server-a"],
+            },
+            {
+              namedHostId: "host-claude",
+              hostName: "Claude",
+              enabledOptionalServerIds: [],
+              resolvedServerNames: ["server-b"],
+            },
+          ],
+        } as any);
+      });
+
+      expect(usePlanLimitDialogStore.getState().limit).toMatchObject({
+        kind: "evalIterations",
+        organizationId: "org-1",
+      });
+      expect(toast.error).not.toHaveBeenCalled();
+    });
+
     it("keeps the fallback toast when there is no organization to upgrade", async () => {
       mockAuthFetch.mockResolvedValue(createEvalIterationCapResponse());
 

--- a/mcpjam-inspector/client/src/components/evals/__tests__/use-eval-handlers.test.ts
+++ b/mcpjam-inspector/client/src/components/evals/__tests__/use-eval-handlers.test.ts
@@ -1031,6 +1031,9 @@ describe("useEvalHandlers", () => {
         .mock.calls.map((call) => String(call[0]))
         .join(" | ");
       expect(errorToasts).toContain("1 of 2");
+      // "Starting 2 runs…" fired before anything was accepted, so it can't
+      // stay up next to a wall saying one was refused.
+      expect(toast.dismiss).toHaveBeenCalledWith("toast-id");
     });
 
     it("finds a cap carried by a later plan when every plan fails", async () => {

--- a/mcpjam-inspector/client/src/components/evals/use-eval-handlers.ts
+++ b/mcpjam-inspector/client/src/components/evals/use-eval-handlers.ts
@@ -740,7 +740,7 @@ export function useEvalHandlers({
       const runGroupId = runPlans.length > 1 ? crypto.randomUUID() : undefined;
 
       // Show toast immediately when user clicks rerun
-      toast.success(
+      const runStartedToastId = toast.success(
         runPlans.length > 1
           ? `Starting ${runPlans.length} runs across ${
               isEnvironmentSuite ? "environments" : "hosts"
@@ -944,7 +944,12 @@ export function useEvalHandlers({
         }
       } catch (error) {
         console.error("Failed to rerun evals:", error);
-        if (!openEvalIterationWall(error)) {
+        if (openEvalIterationWall(error)) {
+          // The optimistic "Run started" toast above fired before the server
+          // rejected the launch; leaving it up next to the wall would claim
+          // the run is on its way.
+          toast.dismiss(runStartedToastId);
+        } else {
           toast.error(
             getEnvironmentConflictMessage(error) ??
               getBillingErrorMessage(error, "Failed to start eval run")
@@ -1198,6 +1203,14 @@ export function useEvalHandlers({
           ...failedRuns,
         ];
 
+        // Each per-model rejection is caught inside the map above, so a
+        // server-side cap rejection lands here instead of the outer catch.
+        // Give it the same wall the suite rerun gets; `some` stops at the
+        // first failure the wall takes.
+        const evalIterationWallOpened = totalFailedRuns.some((failure) =>
+          openEvalIterationWall(failure.error)
+        );
+
         if (!options?.suppressCompletionToasts) {
           if (successfulRuns.length === totalModelsRequested) {
             toast.success(
@@ -1206,12 +1219,14 @@ export function useEvalHandlers({
                 : "Test completed successfully!"
             );
           } else if (successfulRuns.length > 0) {
+            // Kept even when the wall opened: it reports how many models did
+            // land, which the wall doesn't say.
             toast.error(
               `${successfulRuns.length}/${totalModelsRequested} model${
                 totalModelsRequested === 1 ? "" : "s"
               } completed successfully.`
             );
-          } else {
+          } else if (!evalIterationWallOpened) {
             toast.error(
               getBillingErrorMessage(
                 totalFailedRuns[0]?.error,
@@ -1219,7 +1234,7 @@ export function useEvalHandlers({
               )
             );
           }
-        } else if (successfulRuns.length === 0) {
+        } else if (successfulRuns.length === 0 && !evalIterationWallOpened) {
           toast.error(
             getBillingErrorMessage(
               totalFailedRuns[0]?.error,

--- a/mcpjam-inspector/client/src/components/evals/use-eval-handlers.ts
+++ b/mcpjam-inspector/client/src/components/evals/use-eval-handlers.ts
@@ -940,10 +940,18 @@ export function useEvalHandlers({
           // A cap can reject one target while others launch. This branch never
           // throws, so the outer catch — and the wall with it — would never
           // see it. Scan every failure, not just the first.
-          openEvalIterationWall(
-            failures.find((failure) => isEvalIterationCap(failure.reason))
-              ?.reason
-          );
+          if (
+            openEvalIterationWall(
+              failures.find((failure) => isEvalIterationCap(failure.reason))
+                ?.reason
+            )
+          ) {
+            // "Starting N runs…" fired before any of them were accepted, so it
+            // overstates the moment the wall says one was refused. The
+            // failure-count toast below is the accurate version — it names how
+            // many of the N actually launched.
+            toast.dismiss(runStartedToastId);
+          }
           const failedHostNames = failures
             .map(
               (failure) =>

--- a/mcpjam-inspector/client/src/components/evals/use-eval-handlers.ts
+++ b/mcpjam-inspector/client/src/components/evals/use-eval-handlers.ts
@@ -33,7 +33,11 @@ import { draftTestCaseId } from "./draft-test-case";
 import { isModelFree, promptTurnsToSteps } from "@/shared/steps";
 import type { useEvalMutations } from "./use-eval-mutations";
 import { authFetch } from "@/lib/session-token";
-import { getBillingErrorMessage } from "@/lib/billing-entitlements";
+import {
+  getBillingErrorMessage,
+  getEvalIterationLimitFromError,
+} from "@/lib/billing-entitlements";
+import { usePlanLimitDialogStore } from "@/stores/plan-limit-dialog-store";
 import type { ModelDefinition } from "@/shared/types";
 import {
   buildEvalConvexAuthPayload,
@@ -194,6 +198,9 @@ interface UseEvalHandlersProps {
   selectedSuiteId: string | null;
   selectedTestId: string | null;
   projectId?: string | null;
+  /** Owner of the eval-iteration quota. Lets a server-side cap rejection open
+   * the same upgrade wall as the client-side pre-check. */
+  organizationId?: string | null;
   connectedServerNames?: Set<string>;
   ensureServersReady?: (
     serverNames: string[]
@@ -221,6 +228,7 @@ export function useEvalHandlers({
   selectedSuiteId,
   selectedTestId,
   projectId = null,
+  organizationId = null,
   connectedServerNames,
   ensureServersReady,
   latestRunBySuiteId,
@@ -230,6 +238,35 @@ export function useEvalHandlers({
   availableModels,
 }: UseEvalHandlersProps) {
   const convex = useConvex();
+  /**
+   * The client-side quota pre-check in EvalsTab can pass on a stale read — a
+   * teammate spends the last iterations while this user sits on Run — and the
+   * server then rejects the start. That rejection is the same wall, so it gets
+   * the same decision surface instead of the dead-end toast.
+   *
+   * Returns whether the wall took the error; callers keep their own toast for
+   * everything else.
+   */
+  const openEvalIterationWall = useCallback(
+    (error: unknown): boolean => {
+      if (!organizationId) return false;
+      if (getEnvironmentConflictMessage(error)) return false;
+      const limit = getEvalIterationLimitFromError(error);
+      if (!limit) return false;
+
+      usePlanLimitDialogStore.getState().open({
+        kind: "evalIterations",
+        organizationId,
+        used: limit.used,
+        allowed: limit.allowed,
+        resetsAt: limit.resetsAt,
+        windowKind: limit.windowKind,
+        origin: "evals",
+      });
+      return true;
+    },
+    [organizationId]
+  );
   // Resolves the WorkOS token for signed-in users and the guest bearer for
   // guests (project-owning guests included). See use-convex-access-token.
   const getAccessToken = useConvexAccessToken();
@@ -557,12 +594,17 @@ export function useEvalHandlers({
         });
       } catch (error) {
         console.error("Failed to replay evals:", error);
-        toast.error(
-          getBillingErrorMessage(error, "Failed to replay eval run"),
-          {
-            id: replayToastId,
-          }
-        );
+        if (openEvalIterationWall(error)) {
+          // The wall carries the message now; leave no orphaned loading toast.
+          toast.dismiss(replayToastId);
+        } else {
+          toast.error(
+            getBillingErrorMessage(error, "Failed to replay eval run"),
+            {
+              id: replayToastId,
+            }
+          );
+        }
       } finally {
         setReplayingRunId(null);
       }
@@ -573,6 +615,7 @@ export function useEvalHandlers({
       selectedSuiteEntry,
       getSuiteExecutionContext,
       getAccessToken,
+      openEvalIterationWall,
     ]
   );
 
@@ -901,10 +944,12 @@ export function useEvalHandlers({
         }
       } catch (error) {
         console.error("Failed to rerun evals:", error);
-        toast.error(
-          getEnvironmentConflictMessage(error) ??
-            getBillingErrorMessage(error, "Failed to start eval run")
-        );
+        if (!openEvalIterationWall(error)) {
+          toast.error(
+            getEnvironmentConflictMessage(error) ??
+              getBillingErrorMessage(error, "Failed to start eval run")
+          );
+        }
       } finally {
         setRerunningSuiteId(null);
       }
@@ -922,6 +967,7 @@ export function useEvalHandlers({
       getSuiteExecutionContext,
       handleReplayRun,
       evalsNavigationContext,
+      openEvalIterationWall,
     ]
   );
 
@@ -1197,7 +1243,9 @@ export function useEvalHandlers({
         return successfulRuns[0]?.data ?? null;
       } catch (error) {
         console.error("Failed to run test case:", error);
-        toast.error(getBillingErrorMessage(error, "Failed to run test case"));
+        if (!openEvalIterationWall(error)) {
+          toast.error(getBillingErrorMessage(error, "Failed to run test case"));
+        }
         return null;
       } finally {
         setRunningTestCaseId(null);
@@ -1213,6 +1261,7 @@ export function useEvalHandlers({
       ensureServersReady,
       projectServers,
       isDirectGuest,
+      openEvalIterationWall,
     ]
   );
 

--- a/mcpjam-inspector/client/src/components/evals/use-eval-handlers.ts
+++ b/mcpjam-inspector/client/src/components/evals/use-eval-handlers.ts
@@ -42,6 +42,7 @@ import type { ModelDefinition } from "@/shared/types";
 import {
   buildEvalConvexAuthPayload,
   getEvalApiEndpoints,
+  rethrowIfBillingError,
   runEvals,
   runEvalTestCase,
   type GenerationOptions,
@@ -191,6 +192,21 @@ export type HandleGenerateEvalTestsOptions = {
    */
   generationOptions?: GenerationOptions;
 };
+
+/**
+ * Worth opening the limit wall for: an eval-iteration cap, and not a
+ * retry-able environment-drift 409 — that one has its own, better message and
+ * no upgrade to offer.
+ *
+ * A fan-out settles per target, so a cap can be one rejection among several.
+ * Callers scan the whole failure list with this rather than trusting the first.
+ */
+function isEvalIterationCap(error: unknown): boolean {
+  return (
+    getEnvironmentConflictMessage(error) === null &&
+    getEvalIterationLimitFromError(error) !== null
+  );
+}
 
 interface UseEvalHandlersProps {
   mutations: ReturnType<typeof useEvalMutations>;
@@ -561,6 +577,17 @@ export function useEvalHandlers({
 
         if (!response.ok) {
           const errorText = await response.text();
+          // Same unwrapping the buffered eval paths get from
+          // `postEvalRequest`: the cap payload rides under `details`, so
+          // throwing the body whole hides it from the limit-wall parser and
+          // from `getBillingErrorMessage`. No-op for every other failure.
+          let errorBody: unknown = null;
+          try {
+            errorBody = JSON.parse(errorText);
+          } catch {
+            // Not JSON; fall through to the generic error below.
+          }
+          rethrowIfBillingError(errorBody);
           throw new Error(errorText || "Failed to replay eval run");
         }
 
@@ -910,6 +937,13 @@ export function useEvalHandlers({
             );
           }
         } else if (failures.length < runPlans.length) {
+          // A cap can reject one target while others launch. This branch never
+          // throws, so the outer catch — and the wall with it — would never
+          // see it. Scan every failure, not just the first.
+          openEvalIterationWall(
+            failures.find((failure) => isEvalIterationCap(failure.reason))
+              ?.reason
+          );
           const failedHostNames = failures
             .map(
               (failure) =>
@@ -934,10 +968,18 @@ export function useEvalHandlers({
           // partial-failure branch above does: throwing `failures[0]` blind
           // would bury a retry-able ENVIRONMENT_REVISION_CONFLICT carried by a
           // later plan behind whatever generic error happened to come first.
+          // A cap outranks a drift 409: the 409 is retry-able, the cap is not,
+          // and only the cap has a next step (upgrade or wait for the reset).
+          // Without this it could sit at index 2 behind a generic error and
+          // never reach the wall.
+          const capFailure = failures.find((failure) =>
+            isEvalIterationCap(failure.reason)
+          );
           const conflictFailure = failures.find(
             (failure) => getEnvironmentConflictMessage(failure.reason) !== null
           );
-          const firstError = (conflictFailure ?? failures[0])?.reason;
+          const firstError = (capFailure ?? conflictFailure ?? failures[0])
+            ?.reason;
           throw firstError instanceof Error
             ? firstError
             : new Error(String(firstError ?? `All ${targetNoun} runs failed`));

--- a/mcpjam-inspector/client/src/components/mcpjam-limit-dialog.tsx
+++ b/mcpjam-inspector/client/src/components/mcpjam-limit-dialog.tsx
@@ -109,9 +109,13 @@ export function MCPJamLimitDialog() {
     !isKnownNonManager && isFreeEffectivePlan && !creditsUpgrade.canManageBilling;
   const creditsRequestAction =
     isKnownNonManager && !isFreeEffectivePlan ? "buyCredits" : "upgrade";
+  // Names owners only, because the one action this wall offers is an email to
+  // the resolved owners. Admins can buy credits but cannot upgrade, so naming
+  // them here promised a recipient the button never writes to — and, on Free,
+  // implied admins could upgrade at all.
   const memberDescription = isFreeEffectivePlan
-    ? "Ask an organization owner or admin to buy credits or upgrade the plan."
-    : "Ask an organization owner or admin to buy credits.";
+    ? "Ask an organization owner to buy credits or upgrade the plan."
+    : "Ask an organization owner to buy credits.";
   // Audience follows the billing permission, the same rule the eval wall uses.
   // `can_buy_credits` is what separates an admin from a plain member.
   const creditsAudience = creditsUpgrade.canManageBilling
@@ -145,7 +149,11 @@ export function MCPJamLimitDialog() {
     if (
       isLoadingOrganizations ||
       creditsUpgrade.isLoadingBilling ||
-      (isKnownNonManager && isLoadingRequestRecipients) ||
+      // Both request paths render a recipient button, so both have to wait for
+      // the owner list. Reporting early on the admin path recorded
+      // `request_recipient_count: 0` for a button that then appeared.
+      ((isKnownNonManager || showCreditsUpgradeRequest) &&
+        isLoadingRequestRecipients) ||
       creditsImpressionTrackedRef.current
     ) {
       return;
@@ -193,6 +201,7 @@ export function MCPJamLimitDialog() {
     isLoadingRequestRecipients,
     requestRecipients.length,
     showCreditsUpgrade,
+    showCreditsUpgradeRequest,
     showTopupDialog,
   ]);
 

--- a/mcpjam-inspector/client/src/components/mcpjam-limit-dialog.tsx
+++ b/mcpjam-inspector/client/src/components/mcpjam-limit-dialog.tsx
@@ -64,8 +64,7 @@ export function MCPJamLimitDialog() {
     origin: "credits",
     limitKind: "credits",
   });
-  const { recipients: requestRecipients, isLoading: isLoadingRecipients } =
-    useUpgradeRequestRecipients(resolveBillingOrgId());
+  const requestRecipients = useUpgradeRequestRecipients(resolveBillingOrgId());
 
   if (isLoading) return null;
 
@@ -161,7 +160,6 @@ export function MCPJamLimitDialog() {
             {isKnownNonManager ? (
               <RequestUpgradeButton
                 recipients={requestRecipients}
-                isLoadingRecipients={isLoadingRecipients}
                 organizationName={creditsUpgrade.organizationName}
                 teamName={creditsUpgrade.teamName}
                 origin="credits"

--- a/mcpjam-inspector/client/src/components/mcpjam-limit-dialog.tsx
+++ b/mcpjam-inspector/client/src/components/mcpjam-limit-dialog.tsx
@@ -19,7 +19,9 @@ import { useMCPJamLimitDialogStore } from "@/stores/mcpjam-limit-dialog-store";
 import { useModelPickerIntentStore } from "@/stores/model-picker-intent-store";
 import { useAppNavigate } from "@/lib/app-navigation";
 import { useUpgradeCheckout } from "@/hooks/use-upgrade-checkout";
+import { useUpgradeRequestRecipients } from "@/hooks/use-upgrade-request-recipients";
 import { UpgradeIntervalPicker } from "@/components/billing/UpgradeIntervalPicker";
+import { RequestUpgradeButton } from "@/components/billing/RequestUpgradeButton";
 
 export function MCPJamLimitDialog() {
   const isOpen = useMCPJamLimitDialogStore((s) => s.isOpen);
@@ -62,6 +64,7 @@ export function MCPJamLimitDialog() {
     origin: "credits",
     limitKind: "credits",
   });
+  const requestRecipients = useUpgradeRequestRecipients(resolveBillingOrgId());
 
   if (isLoading) return null;
 
@@ -154,10 +157,20 @@ export function MCPJamLimitDialog() {
             {/* Non-managers get no CTAs, just the "ask an owner" copy. Managers
                 lead with the plan upgrade: buying credits keeps the org on Free
                 at a variable cost, so it stays available but secondary. */}
-            {!isKnownNonManager ? (
+            {isKnownNonManager ? (
+              <RequestUpgradeButton
+                recipients={requestRecipients}
+                organizationName={creditsUpgrade.organizationName}
+                teamName={creditsUpgrade.teamName}
+                origin="credits"
+                limitKind="credits"
+              />
+            ) : (
               <>
                 {showCreditsUpgrade ? (
                   <UpgradeIntervalPicker
+                    interval={creditsUpgrade.interval}
+                    onIntervalChange={creditsUpgrade.setInterval}
                     annualPriceLabel={creditsUpgrade.annualPriceLabel}
                     monthlyPriceLabel={creditsUpgrade.monthlyPriceLabel}
                     annualDiscountPct={creditsUpgrade.annualDiscountPct}
@@ -165,9 +178,7 @@ export function MCPJamLimitDialog() {
                     monthlySupported={creditsUpgrade.monthlySupported}
                     teamName={creditsUpgrade.teamName}
                     isStarting={creditsUpgrade.isStarting}
-                    onUpgrade={(interval) =>
-                      void creditsUpgrade.start(interval)
-                    }
+                    onUpgrade={() => void creditsUpgrade.start()}
                   />
                 ) : null}
                 <DialogFooter className="sm:justify-between">
@@ -188,7 +199,7 @@ export function MCPJamLimitDialog() {
                   </Button>
                 </DialogFooter>
               </>
-            ) : null}
+            )}
           </DialogContent>
         </Dialog>
       )}

--- a/mcpjam-inspector/client/src/components/mcpjam-limit-dialog.tsx
+++ b/mcpjam-inspector/client/src/components/mcpjam-limit-dialog.tsx
@@ -64,7 +64,8 @@ export function MCPJamLimitDialog() {
     origin: "credits",
     limitKind: "credits",
   });
-  const requestRecipients = useUpgradeRequestRecipients(resolveBillingOrgId());
+  const { recipients: requestRecipients, isLoading: isLoadingRecipients } =
+    useUpgradeRequestRecipients(resolveBillingOrgId());
 
   if (isLoading) return null;
 
@@ -160,6 +161,7 @@ export function MCPJamLimitDialog() {
             {isKnownNonManager ? (
               <RequestUpgradeButton
                 recipients={requestRecipients}
+                isLoadingRecipients={isLoadingRecipients}
                 organizationName={creditsUpgrade.organizationName}
                 teamName={creditsUpgrade.teamName}
                 origin="credits"

--- a/mcpjam-inspector/client/src/components/mcpjam-limit-dialog.tsx
+++ b/mcpjam-inspector/client/src/components/mcpjam-limit-dialog.tsx
@@ -67,7 +67,10 @@ export function MCPJamLimitDialog() {
     origin: "credits",
     limitKind: "credits",
   });
-  const requestRecipients = useUpgradeRequestRecipients(billingOrgId);
+  const {
+    recipients: requestRecipients,
+    isLoading: isLoadingRequestRecipients,
+  } = useUpgradeRequestRecipients(billingOrgId);
 
   // Only owners/admins/creators can buy credits (mirrors the backend gate).
   // Members instead see an "ask org admin" hint so they don't dead-end on a
@@ -123,6 +126,7 @@ export function MCPJamLimitDialog() {
     if (
       isLoadingOrganizations ||
       creditsUpgrade.isLoadingBilling ||
+      (isKnownNonManager && isLoadingRequestRecipients) ||
       creditsImpressionTrackedRef.current
     ) {
       return;
@@ -166,6 +170,7 @@ export function MCPJamLimitDialog() {
     creditsUpgrade.monthlySupported,
     isKnownNonManager,
     isLoadingOrganizations,
+    isLoadingRequestRecipients,
     requestRecipients.length,
     showCreditsUpgrade,
     showTopupDialog,

--- a/mcpjam-inspector/client/src/components/mcpjam-limit-dialog.tsx
+++ b/mcpjam-inspector/client/src/components/mcpjam-limit-dialog.tsx
@@ -158,15 +158,16 @@ export function MCPJamLimitDialog() {
               <>
                 {showCreditsUpgrade ? (
                   <UpgradeIntervalPicker
-                    interval={creditsUpgrade.interval}
-                    onIntervalChange={creditsUpgrade.setInterval}
-                    priceLabel={creditsUpgrade.priceLabel}
+                    annualPriceLabel={creditsUpgrade.annualPriceLabel}
+                    monthlyPriceLabel={creditsUpgrade.monthlyPriceLabel}
                     annualDiscountPct={creditsUpgrade.annualDiscountPct}
                     annualSupported={creditsUpgrade.annualSupported}
                     monthlySupported={creditsUpgrade.monthlySupported}
                     teamName={creditsUpgrade.teamName}
                     isStarting={creditsUpgrade.isStarting}
-                    onUpgrade={() => void creditsUpgrade.start()}
+                    onUpgrade={(interval) =>
+                      void creditsUpgrade.start(interval)
+                    }
                   />
                 ) : null}
                 <DialogFooter className="sm:justify-between">

--- a/mcpjam-inspector/client/src/components/mcpjam-limit-dialog.tsx
+++ b/mcpjam-inspector/client/src/components/mcpjam-limit-dialog.tsx
@@ -327,7 +327,7 @@ export function MCPJamLimitDialog() {
             isKnownNonManager
               ? memberDescription
               : showCreditsUpgrade
-              ? `Free credits reset daily. Our ${creditsUpgrade.teamName} plan replaces the daily cap with a monthly allowance per seat, so usage isn't rationed day to day.`
+              ? `Free credits reset daily. The ${creditsUpgrade.teamName} plan replaces the daily cap with a monthly allowance per seat, so usage isn't rationed day to day.`
               : "Buy credits to keep your team going, or use your own API key."
           }
           isKnownNonManager={isKnownNonManager}

--- a/mcpjam-inspector/client/src/components/mcpjam-limit-dialog.tsx
+++ b/mcpjam-inspector/client/src/components/mcpjam-limit-dialog.tsx
@@ -108,7 +108,7 @@ export function MCPJamLimitDialog() {
   // Pitching Team to an org already on Team would be nonsense; those orgs get
   // the buy-credits path only.
   const showCreditsUpgrade =
-    creditsUpgrade.currentPlan === "free" && creditsUpgrade.canManageBilling;
+    creditsUpgrade.effectivePlan === "free" && creditsUpgrade.canManageBilling;
 
   return (
     <>
@@ -139,9 +139,9 @@ export function MCPJamLimitDialog() {
           description={
             isKnownNonManager
               ? "Ask an organization owner or admin to buy credits or upgrade the plan."
-              : creditsUpgrade.currentPlan === "free"
-                ? `Free credits reset daily. Our ${creditsUpgrade.teamName} plan replaces the daily cap with a monthly allowance per seat, so usage isn't rationed day to day.`
-                : "Buy credits to keep your team going, or use your own API key."
+              : creditsUpgrade.effectivePlan === "free"
+              ? `Free credits reset daily. Our ${creditsUpgrade.teamName} plan replaces the daily cap with a monthly allowance per seat, so usage isn't rationed day to day.`
+              : "Buy credits to keep your team going, or use your own API key."
           }
           isKnownNonManager={isKnownNonManager}
           showUpgrade={showCreditsUpgrade}

--- a/mcpjam-inspector/client/src/components/mcpjam-limit-dialog.tsx
+++ b/mcpjam-inspector/client/src/components/mcpjam-limit-dialog.tsx
@@ -8,7 +8,7 @@ import {
 } from "@mcpjam/design-system/dialog";
 import { useAuth } from "@workos-inc/authkit-react";
 import { useConvexAuth } from "convex/react";
-import { useEffect } from "react";
+import { useEffect, useRef } from "react";
 import {
   canManageOrgCredits,
   useOrganizationQueries,
@@ -20,6 +20,7 @@ import { useAppNavigate } from "@/lib/app-navigation";
 import { useUpgradeCheckout } from "@/hooks/use-upgrade-checkout";
 import { useUpgradeRequestRecipients } from "@/hooks/use-upgrade-request-recipients";
 import { CreditsLimitDialogView } from "@/components/billing/CreditsLimitDialogView";
+import { track } from "@/lib/analytics";
 
 export function MCPJamLimitDialog() {
   const isOpen = useMCPJamLimitDialogStore((s) => s.isOpen);
@@ -34,8 +35,11 @@ export function MCPJamLimitDialog() {
   // Look up the user's orgs as a fallback in case there is no stored
   // active-org for this user (e.g. brand-new sign-in). Sorted most-recent
   // first by useOrganizationQueries.
-  const { sortedOrganizations } = useOrganizationQueries({ isAuthenticated });
+  const { sortedOrganizations, isLoading: isLoadingOrganizations } =
+    useOrganizationQueries({ isAuthenticated });
   const appNavigate = useAppNavigate();
+  const guestImpressionTrackedRef = useRef(false);
+  const creditsImpressionTrackedRef = useRef(false);
 
   useEffect(() => {
     setAuthStatus(isLoading ? "loading" : user ? "signedIn" : "guest");
@@ -57,14 +61,13 @@ export function MCPJamLimitDialog() {
     return sortedOrganizations[0]?._id ?? null;
   };
 
+  const billingOrgId = resolveBillingOrgId();
   const creditsUpgrade = useUpgradeCheckout({
-    organizationId: resolveBillingOrgId(),
+    organizationId: billingOrgId,
     origin: "credits",
     limitKind: "credits",
   });
-  const requestRecipients = useUpgradeRequestRecipients(resolveBillingOrgId());
-
-  if (isLoading) return null;
+  const requestRecipients = useUpgradeRequestRecipients(billingOrgId);
 
   // Only owners/admins/creators can buy credits (mirrors the backend gate).
   // Members instead see an "ask org admin" hint so they don't dead-end on a
@@ -72,34 +75,12 @@ export function MCPJamLimitDialog() {
   // still resolving (no match yet) we stay optimistic and show the buy
   // button — `handleTopUp` already no-ops until an org id is available, so an
   // actual admin never sees a premature "ask admin" flash.
-  const billingOrgId = resolveBillingOrgId();
   const billingOrg = billingOrgId
     ? sortedOrganizations.find((org) => org._id === billingOrgId) ?? null
     : null;
   const isKnownNonManager = billingOrg
     ? !canManageOrgCredits(billingOrg)
     : false;
-
-  const handleTopUp = () => {
-    const orgId = resolveBillingOrgId();
-    // Don't dismiss the modal until we know we can route the user — on a
-    // fresh sign-in the membership query may still be in flight, in which
-    // case closing now would drop them out of the upsell silently.
-    if (!orgId) return;
-    close();
-    // The router strips ?... before resolving the route, so the
-    // `topup=open` flag is invisible to navigation but visible to the
-    // billing page on mount.
-    appNavigate(`/organizations/${orgId}/billing?topup=open`);
-  };
-
-  const handleBYOK = () => {
-    // Don't yank the user to the org settings page — just close the dialog
-    // and pop open the chat model picker on its "Your providers" tab so they
-    // can switch to an own-key model in place. The free models stay grayed.
-    close();
-    useModelPickerIntentStore.getState().requestOpenProvidersTab();
-  };
 
   // Guest variant — only renders for unauthenticated users.
   const showGuestDialog = !user && intent === "guest" && isOpen;
@@ -110,11 +91,172 @@ export function MCPJamLimitDialog() {
   const isFreeEffectivePlan = creditsUpgrade.effectivePlan === "free";
   const showCreditsUpgrade =
     isFreeEffectivePlan && creditsUpgrade.canManageBilling;
-  const creditsRequestAction =
-    isFreeEffectivePlan ? "upgrade" : "buyCredits";
+  const creditsRequestAction = isFreeEffectivePlan ? "upgrade" : "buyCredits";
   const memberDescription = isFreeEffectivePlan
     ? "Ask an organization owner or admin to buy credits or upgrade the plan."
     : "Ask an organization owner or admin to buy credits.";
+
+  useEffect(() => {
+    if (!showGuestDialog) {
+      guestImpressionTrackedRef.current = false;
+      return;
+    }
+    if (isLoading || guestImpressionTrackedRef.current) return;
+
+    guestImpressionTrackedRef.current = true;
+    track("plan_limit_dialog_shown", {
+      location: "plan_limit_dialog",
+      wall_kind: "guest_credits",
+      limit_kind: "credits",
+      origin: "credits",
+      audience: "guest",
+      primary_action: "sign_in",
+      is_identified: false,
+    });
+  }, [isLoading, showGuestDialog]);
+
+  useEffect(() => {
+    if (!showTopupDialog) {
+      creditsImpressionTrackedRef.current = false;
+      return;
+    }
+    if (
+      isLoadingOrganizations ||
+      creditsUpgrade.isLoadingBilling ||
+      creditsImpressionTrackedRef.current
+    ) {
+      return;
+    }
+
+    creditsImpressionTrackedRef.current = true;
+    track("plan_limit_dialog_shown", {
+      location: "plan_limit_dialog",
+      wall_kind: "organization_credits",
+      organization_id: billingOrgId,
+      organization_resolved: Boolean(billingOrgId),
+      limit_kind: "credits",
+      origin: "credits",
+      audience: isKnownNonManager ? "member" : "billing_manager",
+      primary_action: isKnownNonManager
+        ? requestRecipients.length > 0
+          ? "request_owner"
+          : "none"
+        : showCreditsUpgrade
+        ? "upgrade"
+        : "buy_credits",
+      current_plan: creditsUpgrade.currentPlan,
+      effective_plan: creditsUpgrade.effectivePlan,
+      can_manage_billing: creditsUpgrade.canManageBilling,
+      can_buy_credits: !isKnownNonManager,
+      request_action: creditsRequestAction,
+      request_recipient_count: requestRecipients.length,
+      billing_interval: creditsUpgrade.interval,
+      annual_supported: creditsUpgrade.annualSupported,
+      monthly_supported: creditsUpgrade.monthlySupported,
+    });
+  }, [
+    billingOrgId,
+    creditsRequestAction,
+    creditsUpgrade.annualSupported,
+    creditsUpgrade.canManageBilling,
+    creditsUpgrade.currentPlan,
+    creditsUpgrade.effectivePlan,
+    creditsUpgrade.interval,
+    creditsUpgrade.isLoadingBilling,
+    creditsUpgrade.monthlySupported,
+    isKnownNonManager,
+    isLoadingOrganizations,
+    requestRecipients.length,
+    showCreditsUpgrade,
+    showTopupDialog,
+  ]);
+
+  if (isLoading) return null;
+
+  const handleTopUp = () => {
+    const orgId = resolveBillingOrgId();
+    // Don't dismiss the modal until we know we can route the user — on a
+    // fresh sign-in the membership query may still be in flight, in which
+    // case closing now would drop them out of the upsell silently.
+    if (!orgId) {
+      track("plan_limit_buy_credits_clicked", {
+        location: "plan_limit_dialog",
+        wall_kind: "organization_credits",
+        organization_id: null,
+        origin: "credits",
+        outcome: "blocked_missing_organization",
+        current_plan: creditsUpgrade.currentPlan,
+        effective_plan: creditsUpgrade.effectivePlan,
+      });
+      return;
+    }
+    close();
+    // The router strips ?... before resolving the route, so the
+    // `topup=open` flag is invisible to navigation but visible to the
+    // billing page on mount.
+    appNavigate(`/organizations/${orgId}/billing?topup=open`);
+    track("plan_limit_buy_credits_clicked", {
+      location: "plan_limit_dialog",
+      wall_kind: "organization_credits",
+      organization_id: orgId,
+      origin: "credits",
+      outcome: "billing_opened",
+      current_plan: creditsUpgrade.currentPlan,
+      effective_plan: creditsUpgrade.effectivePlan,
+    });
+  };
+
+  const handleBYOK = () => {
+    // Don't yank the user to the org settings page — just close the dialog
+    // and pop open the chat model picker on its "Your providers" tab so they
+    // can switch to an own-key model in place. The free models stay grayed.
+    close();
+    useModelPickerIntentStore.getState().requestOpenProvidersTab();
+    track("plan_limit_byok_clicked", {
+      location: "plan_limit_dialog",
+      wall_kind: "organization_credits",
+      organization_id: billingOrgId,
+      origin: "credits",
+      current_plan: creditsUpgrade.currentPlan,
+      effective_plan: creditsUpgrade.effectivePlan,
+    });
+  };
+
+  const handleGuestDismiss = () => {
+    close();
+    track("plan_limit_dialog_dismissed", {
+      location: "plan_limit_dialog",
+      wall_kind: "guest_credits",
+      limit_kind: "credits",
+      origin: "credits",
+      audience: "guest",
+    });
+  };
+
+  const handleCreditsDismiss = () => {
+    close();
+    track("plan_limit_dialog_dismissed", {
+      location: "plan_limit_dialog",
+      wall_kind: "organization_credits",
+      organization_id: billingOrgId,
+      limit_kind: "credits",
+      origin: "credits",
+      current_plan: creditsUpgrade.currentPlan,
+      effective_plan: creditsUpgrade.effectivePlan,
+      audience: isKnownNonManager ? "member" : "billing_manager",
+    });
+  };
+
+  const handleSignIn = () => {
+    signIn();
+    track("plan_limit_sign_in_clicked", {
+      location: "plan_limit_dialog",
+      wall_kind: "guest_credits",
+      limit_kind: "credits",
+      origin: "credits",
+      audience: "guest",
+    });
+  };
 
   return (
     <>
@@ -122,7 +264,7 @@ export function MCPJamLimitDialog() {
         <Dialog
           open
           onOpenChange={(next) => {
-            if (!next) close();
+            if (!next) handleGuestDismiss();
           }}
         >
           <DialogContent className="sm:max-w-md">
@@ -134,7 +276,7 @@ export function MCPJamLimitDialog() {
                 free credits.
               </DialogDescription>
             </DialogHeader>
-            <Button onClick={() => signIn()} className="w-full">
+            <Button onClick={handleSignIn} className="w-full">
               Sign in
             </Button>
           </DialogContent>
@@ -153,6 +295,7 @@ export function MCPJamLimitDialog() {
           showUpgrade={showCreditsUpgrade}
           requestRecipients={requestRecipients}
           requestAction={creditsRequestAction}
+          organizationId={billingOrgId}
           organizationName={creditsUpgrade.organizationName}
           interval={creditsUpgrade.interval}
           onIntervalChange={creditsUpgrade.setInterval}
@@ -166,7 +309,7 @@ export function MCPJamLimitDialog() {
           onUpgrade={() => void creditsUpgrade.start()}
           onBuyCredits={handleTopUp}
           onUseOwnKey={handleBYOK}
-          onDismiss={close}
+          onDismiss={handleCreditsDismiss}
         />
       )}
     </>

--- a/mcpjam-inspector/client/src/components/mcpjam-limit-dialog.tsx
+++ b/mcpjam-inspector/client/src/components/mcpjam-limit-dialog.tsx
@@ -93,14 +93,30 @@ export function MCPJamLimitDialog() {
     : false;
 
   // Pitching Team to an org already on Team would be nonsense; those orgs get
-  // the buy-credits path only.
-  const isFreeEffectivePlan = creditsUpgrade.effectivePlan === "free";
+  // the buy-credits path only. Until billing resolves we don't know which this
+  // is, and the hook defaults to Free — so hold the plan-specific copy rather
+  // than flash a Free pitch at a Team org.
+  const isBillingReady = !creditsUpgrade.isLoadingBilling;
+  const isFreeEffectivePlan =
+    isBillingReady && creditsUpgrade.effectivePlan === "free";
   const showCreditsUpgrade =
     isFreeEffectivePlan && creditsUpgrade.canManageBilling;
-  const creditsRequestAction = isFreeEffectivePlan ? "upgrade" : "buyCredits";
+  // Buying credits and upgrading the plan are two different permissions:
+  // admins can do the first, only owners the second. An admin who can't
+  // upgrade must not be pitched the upgrade with no way to act on it — they
+  // get the buy-credits copy plus a way to ask an owner.
+  const showCreditsUpgradeRequest =
+    !isKnownNonManager && isFreeEffectivePlan && !creditsUpgrade.canManageBilling;
+  const creditsRequestAction =
+    isKnownNonManager && !isFreeEffectivePlan ? "buyCredits" : "upgrade";
   const memberDescription = isFreeEffectivePlan
     ? "Ask an organization owner or admin to buy credits or upgrade the plan."
     : "Ask an organization owner or admin to buy credits.";
+  // Audience follows the billing permission, the same rule the eval wall uses.
+  // `can_buy_credits` is what separates an admin from a plain member.
+  const creditsAudience = creditsUpgrade.canManageBilling
+    ? "billing_manager"
+    : "member";
 
   useEffect(() => {
     if (!showGuestDialog) {
@@ -143,7 +159,7 @@ export function MCPJamLimitDialog() {
       organization_resolved: Boolean(billingOrgId),
       limit_kind: "credits",
       origin: "credits",
-      audience: isKnownNonManager ? "member" : "billing_manager",
+      audience: creditsAudience,
       primary_action: isKnownNonManager
         ? requestRecipients.length > 0
           ? "request_owner"
@@ -163,6 +179,7 @@ export function MCPJamLimitDialog() {
     });
   }, [
     billingOrgId,
+    creditsAudience,
     creditsRequestAction,
     creditsUpgrade.annualSupported,
     creditsUpgrade.canManageBilling,
@@ -251,7 +268,7 @@ export function MCPJamLimitDialog() {
       origin: "credits",
       current_plan: creditsUpgrade.currentPlan,
       effective_plan: creditsUpgrade.effectivePlan,
-      audience: isKnownNonManager ? "member" : "billing_manager",
+      audience: creditsAudience,
     });
   };
 
@@ -300,13 +317,17 @@ export function MCPJamLimitDialog() {
           description={
             isKnownNonManager
               ? memberDescription
-              : isFreeEffectivePlan
+              : showCreditsUpgrade
               ? `Free credits reset daily. Our ${creditsUpgrade.teamName} plan replaces the daily cap with a monthly allowance per seat, so usage isn't rationed day to day.`
               : "Buy credits to keep your team going, or use your own API key."
           }
           isKnownNonManager={isKnownNonManager}
           showUpgrade={showCreditsUpgrade}
-          requestRecipients={requestRecipients}
+          showRequestUpgrade={showCreditsUpgradeRequest}
+          // Empty until billing resolves: the draft's wording depends on the
+          // plan, and RequestUpgradeButton already renders nothing without a
+          // recipient.
+          requestRecipients={isBillingReady ? requestRecipients : []}
           requestAction={creditsRequestAction}
           organizationId={billingOrgId}
           organizationName={creditsUpgrade.organizationName}
@@ -319,6 +340,7 @@ export function MCPJamLimitDialog() {
           monthlySupported={creditsUpgrade.monthlySupported}
           teamName={creditsUpgrade.teamName}
           isStarting={creditsUpgrade.isStarting}
+          isLoadingPrices={creditsUpgrade.isLoadingPrices}
           onUpgrade={() => void handleUpgrade()}
           onBuyCredits={handleTopUp}
           onUseOwnKey={handleBYOK}

--- a/mcpjam-inspector/client/src/components/mcpjam-limit-dialog.tsx
+++ b/mcpjam-inspector/client/src/components/mcpjam-limit-dialog.tsx
@@ -18,6 +18,8 @@ import { readStoredActiveOrganizationId } from "@/lib/active-organization-storag
 import { useMCPJamLimitDialogStore } from "@/stores/mcpjam-limit-dialog-store";
 import { useModelPickerIntentStore } from "@/stores/model-picker-intent-store";
 import { useAppNavigate } from "@/lib/app-navigation";
+import { useUpgradeCheckout } from "@/hooks/use-upgrade-checkout";
+import { UpgradeIntervalPicker } from "@/components/billing/UpgradeIntervalPicker";
 
 export function MCPJamLimitDialog() {
   const isOpen = useMCPJamLimitDialogStore((s) => s.isOpen);
@@ -43,10 +45,10 @@ export function MCPJamLimitDialog() {
     if (user && intent === "guest" && isOpen) close();
   }, [close, intent, isLoading, isOpen, setAuthStatus, user]);
 
-  if (isLoading) return null;
-
   // Resolve which org's billing page to redirect to. Prefer the org that
   // actually hit the limit; fall back to local active org / recent org.
+  // Declared above the `isLoading` guard so the upgrade hook below keeps a
+  // stable call order.
   const resolveBillingOrgId = (): string | null => {
     if (!user) return null;
     if (limitOrganizationId) return limitOrganizationId;
@@ -54,6 +56,14 @@ export function MCPJamLimitDialog() {
     if (stored) return stored;
     return sortedOrganizations[0]?._id ?? null;
   };
+
+  const creditsUpgrade = useUpgradeCheckout({
+    organizationId: resolveBillingOrgId(),
+    origin: "credits",
+    limitKind: "credits",
+  });
+
+  if (isLoading) return null;
 
   // Only owners/admins/creators can buy credits (mirrors the backend gate).
   // Members instead see an "ask org admin" hint so they don't dead-end on a
@@ -94,6 +104,10 @@ export function MCPJamLimitDialog() {
   const showGuestDialog = !user && intent === "guest" && isOpen;
   // Top-up variant — only renders for signed-in users.
   const showTopupDialog = !!user && intent === "topup" && isOpen;
+  // Pitching Team to an org already on Team would be nonsense; those orgs get
+  // the buy-credits path only.
+  const showCreditsUpgrade =
+    creditsUpgrade.currentPlan === "free" && creditsUpgrade.canManageBilling;
 
   return (
     <>
@@ -131,21 +145,48 @@ export function MCPJamLimitDialog() {
               <DialogTitle>Your org is out of credits</DialogTitle>
               <DialogDescription data-testid="limit-dialog-description">
                 {isKnownNonManager
-                  ? "Ask your org admin to top up credits."
-                  : "Top up or bring your own key to allow your org to keep using MCPJam."}
+                  ? "Ask an organization owner or admin to buy credits or upgrade the plan."
+                  : creditsUpgrade.currentPlan === "free"
+                    ? `Free credits reset daily. Our ${creditsUpgrade.teamName} plan replaces the daily cap with a monthly allowance per seat, so usage isn't rationed day to day.`
+                    : "Buy credits to keep your team going, or use your own API key."}
               </DialogDescription>
             </DialogHeader>
-            {/* Non-managers get no CTAs — just the "ask your org admin" copy.
-                Managers keep BYOK plus the Top up button. */}
+            {/* Non-managers get no CTAs, just the "ask an owner" copy. Managers
+                lead with the plan upgrade: buying credits keeps the org on Free
+                at a variable cost, so it stays available but secondary. */}
             {!isKnownNonManager ? (
-              <DialogFooter>
-                <Button type="button" variant="outline" onClick={handleBYOK}>
-                  Bring your own key
-                </Button>
-                <Button type="button" onClick={handleTopUp}>
-                  Top up
-                </Button>
-              </DialogFooter>
+              <>
+                {showCreditsUpgrade ? (
+                  <UpgradeIntervalPicker
+                    interval={creditsUpgrade.interval}
+                    onIntervalChange={creditsUpgrade.setInterval}
+                    priceLabel={creditsUpgrade.priceLabel}
+                    annualDiscountPct={creditsUpgrade.annualDiscountPct}
+                    annualSupported={creditsUpgrade.annualSupported}
+                    monthlySupported={creditsUpgrade.monthlySupported}
+                    teamName={creditsUpgrade.teamName}
+                    isStarting={creditsUpgrade.isStarting}
+                    onUpgrade={() => void creditsUpgrade.start()}
+                  />
+                ) : null}
+                <DialogFooter className="sm:justify-between">
+                  <Button
+                    type="button"
+                    variant="link"
+                    className="px-0 text-muted-foreground"
+                    onClick={handleBYOK}
+                  >
+                    Use your own API key
+                  </Button>
+                  <Button
+                    type="button"
+                    variant="outline"
+                    onClick={handleTopUp}
+                  >
+                    Buy credits
+                  </Button>
+                </DialogFooter>
+              </>
             ) : null}
           </DialogContent>
         </Dialog>

--- a/mcpjam-inspector/client/src/components/mcpjam-limit-dialog.tsx
+++ b/mcpjam-inspector/client/src/components/mcpjam-limit-dialog.tsx
@@ -41,6 +41,12 @@ export function MCPJamLimitDialog() {
   const guestImpressionTrackedRef = useRef(false);
   const creditsImpressionTrackedRef = useRef(false);
 
+  // Decide whether either variant is active before wiring billing hooks. This
+  // component is mounted app-wide, so a closed dialog must not keep billing
+  // and owner-member Convex subscriptions alive for the whole session.
+  const showGuestDialog = !user && intent === "guest" && isOpen;
+  const showTopupDialog = !!user && intent === "topup" && isOpen;
+
   useEffect(() => {
     setAuthStatus(isLoading ? "loading" : user ? "signedIn" : "guest");
     // Auth flipped to signed-in while the guest variant was open (e.g. user
@@ -62,15 +68,16 @@ export function MCPJamLimitDialog() {
   };
 
   const billingOrgId = resolveBillingOrgId();
+  const openBillingOrgId = showTopupDialog ? billingOrgId : null;
   const creditsUpgrade = useUpgradeCheckout({
-    organizationId: billingOrgId,
+    organizationId: openBillingOrgId,
     origin: "credits",
     limitKind: "credits",
   });
   const {
     recipients: requestRecipients,
     isLoading: isLoadingRequestRecipients,
-  } = useUpgradeRequestRecipients(billingOrgId);
+  } = useUpgradeRequestRecipients(openBillingOrgId);
 
   // Only owners/admins/creators can buy credits (mirrors the backend gate).
   // Members instead see an "ask org admin" hint so they don't dead-end on a
@@ -85,10 +92,6 @@ export function MCPJamLimitDialog() {
     ? !canManageOrgCredits(billingOrg)
     : false;
 
-  // Guest variant — only renders for unauthenticated users.
-  const showGuestDialog = !user && intent === "guest" && isOpen;
-  // Top-up variant — only renders for signed-in users.
-  const showTopupDialog = !!user && intent === "topup" && isOpen;
   // Pitching Team to an org already on Team would be nonsense; those orgs get
   // the buy-credits path only.
   const isFreeEffectivePlan = creditsUpgrade.effectivePlan === "free";
@@ -263,6 +266,11 @@ export function MCPJamLimitDialog() {
     });
   };
 
+  const handleUpgrade = async () => {
+    const result = await creditsUpgrade.start();
+    if (result?.shouldDismiss) close();
+  };
+
   return (
     <>
       {showGuestDialog && (
@@ -311,7 +319,7 @@ export function MCPJamLimitDialog() {
           monthlySupported={creditsUpgrade.monthlySupported}
           teamName={creditsUpgrade.teamName}
           isStarting={creditsUpgrade.isStarting}
-          onUpgrade={() => void creditsUpgrade.start()}
+          onUpgrade={() => void handleUpgrade()}
           onBuyCredits={handleTopUp}
           onUseOwnKey={handleBYOK}
           onDismiss={handleCreditsDismiss}

--- a/mcpjam-inspector/client/src/components/mcpjam-limit-dialog.tsx
+++ b/mcpjam-inspector/client/src/components/mcpjam-limit-dialog.tsx
@@ -3,7 +3,6 @@ import {
   Dialog,
   DialogContent,
   DialogDescription,
-  DialogFooter,
   DialogHeader,
   DialogTitle,
 } from "@mcpjam/design-system/dialog";
@@ -20,8 +19,7 @@ import { useModelPickerIntentStore } from "@/stores/model-picker-intent-store";
 import { useAppNavigate } from "@/lib/app-navigation";
 import { useUpgradeCheckout } from "@/hooks/use-upgrade-checkout";
 import { useUpgradeRequestRecipients } from "@/hooks/use-upgrade-request-recipients";
-import { UpgradeIntervalPicker } from "@/components/billing/UpgradeIntervalPicker";
-import { RequestUpgradeButton } from "@/components/billing/RequestUpgradeButton";
+import { CreditsLimitDialogView } from "@/components/billing/CreditsLimitDialogView";
 
 export function MCPJamLimitDialog() {
   const isOpen = useMCPJamLimitDialogStore((s) => s.isOpen);
@@ -137,71 +135,32 @@ export function MCPJamLimitDialog() {
         </Dialog>
       )}
       {showTopupDialog && (
-        <Dialog
-          open
-          onOpenChange={(next) => {
-            if (!next) close();
-          }}
-        >
-          <DialogContent className="sm:max-w-md">
-            <DialogHeader>
-              <DialogTitle>Your org is out of credits</DialogTitle>
-              <DialogDescription data-testid="limit-dialog-description">
-                {isKnownNonManager
-                  ? "Ask an organization owner or admin to buy credits or upgrade the plan."
-                  : creditsUpgrade.currentPlan === "free"
-                    ? `Free credits reset daily. Our ${creditsUpgrade.teamName} plan replaces the daily cap with a monthly allowance per seat, so usage isn't rationed day to day.`
-                    : "Buy credits to keep your team going, or use your own API key."}
-              </DialogDescription>
-            </DialogHeader>
-            {/* Non-managers get no CTAs, just the "ask an owner" copy. Managers
-                lead with the plan upgrade: buying credits keeps the org on Free
-                at a variable cost, so it stays available but secondary. */}
-            {isKnownNonManager ? (
-              <RequestUpgradeButton
-                recipients={requestRecipients}
-                organizationName={creditsUpgrade.organizationName}
-                teamName={creditsUpgrade.teamName}
-                origin="credits"
-                limitKind="credits"
-              />
-            ) : (
-              <>
-                {showCreditsUpgrade ? (
-                  <UpgradeIntervalPicker
-                    interval={creditsUpgrade.interval}
-                    onIntervalChange={creditsUpgrade.setInterval}
-                    annualPriceLabel={creditsUpgrade.annualPriceLabel}
-                    monthlyPriceLabel={creditsUpgrade.monthlyPriceLabel}
-                    annualDiscountPct={creditsUpgrade.annualDiscountPct}
-                    annualSupported={creditsUpgrade.annualSupported}
-                    monthlySupported={creditsUpgrade.monthlySupported}
-                    teamName={creditsUpgrade.teamName}
-                    isStarting={creditsUpgrade.isStarting}
-                    onUpgrade={() => void creditsUpgrade.start()}
-                  />
-                ) : null}
-                <DialogFooter className="sm:justify-between">
-                  <Button
-                    type="button"
-                    variant="link"
-                    className="px-0 text-muted-foreground"
-                    onClick={handleBYOK}
-                  >
-                    Use your own API key
-                  </Button>
-                  <Button
-                    type="button"
-                    variant="outline"
-                    onClick={handleTopUp}
-                  >
-                    Buy credits
-                  </Button>
-                </DialogFooter>
-              </>
-            )}
-          </DialogContent>
-        </Dialog>
+        <CreditsLimitDialogView
+          description={
+            isKnownNonManager
+              ? "Ask an organization owner or admin to buy credits or upgrade the plan."
+              : creditsUpgrade.currentPlan === "free"
+                ? `Free credits reset daily. Our ${creditsUpgrade.teamName} plan replaces the daily cap with a monthly allowance per seat, so usage isn't rationed day to day.`
+                : "Buy credits to keep your team going, or use your own API key."
+          }
+          isKnownNonManager={isKnownNonManager}
+          showUpgrade={showCreditsUpgrade}
+          requestRecipients={requestRecipients}
+          organizationName={creditsUpgrade.organizationName}
+          interval={creditsUpgrade.interval}
+          onIntervalChange={creditsUpgrade.setInterval}
+          annualPriceLabel={creditsUpgrade.annualPriceLabel}
+          monthlyPriceLabel={creditsUpgrade.monthlyPriceLabel}
+          annualDiscountPct={creditsUpgrade.annualDiscountPct}
+          annualSupported={creditsUpgrade.annualSupported}
+          monthlySupported={creditsUpgrade.monthlySupported}
+          teamName={creditsUpgrade.teamName}
+          isStarting={creditsUpgrade.isStarting}
+          onUpgrade={() => void creditsUpgrade.start()}
+          onBuyCredits={handleTopUp}
+          onUseOwnKey={handleBYOK}
+          onDismiss={close}
+        />
       )}
     </>
   );

--- a/mcpjam-inspector/client/src/components/mcpjam-limit-dialog.tsx
+++ b/mcpjam-inspector/client/src/components/mcpjam-limit-dialog.tsx
@@ -107,8 +107,14 @@ export function MCPJamLimitDialog() {
   const showTopupDialog = !!user && intent === "topup" && isOpen;
   // Pitching Team to an org already on Team would be nonsense; those orgs get
   // the buy-credits path only.
+  const isFreeEffectivePlan = creditsUpgrade.effectivePlan === "free";
   const showCreditsUpgrade =
-    creditsUpgrade.effectivePlan === "free" && creditsUpgrade.canManageBilling;
+    isFreeEffectivePlan && creditsUpgrade.canManageBilling;
+  const creditsRequestAction =
+    isFreeEffectivePlan ? "upgrade" : "buyCredits";
+  const memberDescription = isFreeEffectivePlan
+    ? "Ask an organization owner or admin to buy credits or upgrade the plan."
+    : "Ask an organization owner or admin to buy credits.";
 
   return (
     <>
@@ -138,14 +144,15 @@ export function MCPJamLimitDialog() {
         <CreditsLimitDialogView
           description={
             isKnownNonManager
-              ? "Ask an organization owner or admin to buy credits or upgrade the plan."
-              : creditsUpgrade.effectivePlan === "free"
+              ? memberDescription
+              : isFreeEffectivePlan
               ? `Free credits reset daily. Our ${creditsUpgrade.teamName} plan replaces the daily cap with a monthly allowance per seat, so usage isn't rationed day to day.`
               : "Buy credits to keep your team going, or use your own API key."
           }
           isKnownNonManager={isKnownNonManager}
           showUpgrade={showCreditsUpgrade}
           requestRecipients={requestRecipients}
+          requestAction={creditsRequestAction}
           organizationName={creditsUpgrade.organizationName}
           interval={creditsUpgrade.interval}
           onIntervalChange={creditsUpgrade.setInterval}

--- a/mcpjam-inspector/client/src/components/organization/__tests__/billing-compare-view-model.test.ts
+++ b/mcpjam-inspector/client/src/components/organization/__tests__/billing-compare-view-model.test.ts
@@ -3,7 +3,12 @@ import { COMPARE_PLAN_MARKETING_SECTIONS } from "@/components/organization/compa
 import { buildComparePlanSectionsFromCatalog } from "@/components/organization/billing-compare-view-model";
 import type { PlanCatalog } from "@/hooks/useOrganizationBilling";
 
-function createPlanCatalog(): PlanCatalog {
+function createPlanCatalog(
+  evalLimits: { free: number | null; team: number | null } = {
+    free: 75,
+    team: 15_000,
+  }
+): PlanCatalog {
   const baseEntry = {
     prices: {
       monthly: { amountCents: 0, stripePriceId: null },
@@ -24,6 +29,7 @@ function createPlanCatalog(): PlanCatalog {
           maxServersPerProject: null,
           maxScenariosPerProject: null,
           maxEvalRunsPerMonth: null,
+          maxEvalIterationsPerMonth: evalLimits.free,
           insightsPerDay: null,
         },
       },
@@ -35,6 +41,7 @@ function createPlanCatalog(): PlanCatalog {
           maxServersPerProject: null,
           maxScenariosPerProject: null,
           maxEvalRunsPerMonth: null,
+          maxEvalIterationsPerMonth: evalLimits.team,
           insightsPerDay: null,
         },
       },
@@ -46,6 +53,7 @@ function createPlanCatalog(): PlanCatalog {
           maxServersPerProject: null,
           maxScenariosPerProject: null,
           maxEvalRunsPerMonth: null,
+          maxEvalIterationsPerMonth: null,
           insightsPerDay: null,
         },
       },
@@ -54,10 +62,10 @@ function createPlanCatalog(): PlanCatalog {
 }
 
 describe("buildComparePlanSectionsFromCatalog", () => {
-  it("returns the static marketing compare sections", () => {
+  it("uses backend catalog values for eval iteration allowances", () => {
     const sections = buildComparePlanSectionsFromCatalog(createPlanCatalog());
 
-    expect(sections).toBe(COMPARE_PLAN_MARKETING_SECTIONS);
+    expect(sections).not.toBe(COMPARE_PLAN_MARKETING_SECTIONS);
     expect(sections.map((section) => section.title)).toEqual([
       "Credits & seats",
       "Evaluations",
@@ -65,5 +73,36 @@ describe("buildComparePlanSectionsFromCatalog", () => {
       "Support",
       "Standard features",
     ]);
+    const evalIterations = sections
+      .find((section) => section.title === "Evaluations")
+      ?.rows.find((row) => row.label === "Eval iterations");
+    expect(evalIterations?.free).toEqual({
+      kind: "text",
+      text: "75 / day",
+    });
+    expect(evalIterations?.team).toEqual({
+      kind: "text",
+      text: "15,000 / mo",
+      emphasize: true,
+    });
+  });
+
+  it("updates when the backend catalog changes", () => {
+    const sections = buildComparePlanSectionsFromCatalog(
+      createPlanCatalog({ free: 100, team: 20_000 })
+    );
+    const evalIterations = sections
+      .find((section) => section.title === "Evaluations")
+      ?.rows.find((row) => row.label === "Eval iterations");
+
+    expect(evalIterations?.free).toEqual({
+      kind: "text",
+      text: "100 / day",
+    });
+    expect(evalIterations?.team).toEqual({
+      kind: "text",
+      text: "20,000 / mo",
+      emphasize: true,
+    });
   });
 });

--- a/mcpjam-inspector/client/src/components/organization/__tests__/billing-compare-view-model.test.ts
+++ b/mcpjam-inspector/client/src/components/organization/__tests__/billing-compare-view-model.test.ts
@@ -82,7 +82,9 @@ describe("buildComparePlanSectionsFromCatalog", () => {
     });
     expect(evalIterations?.team).toEqual({
       kind: "text",
-      text: "15,000 / mo",
+      // PER SEAT, like the credits row above it and like the upgrade wall's
+      // "N per seat each month". `15,000 / mo` read as an org-wide total.
+      text: "15,000 / seat / mo",
       emphasize: true,
     });
   });
@@ -101,7 +103,26 @@ describe("buildComparePlanSectionsFromCatalog", () => {
     });
     expect(evalIterations?.team).toEqual({
       kind: "text",
-      text: "20,000 / mo",
+      text: "20,000 / seat / mo",
+      emphasize: true,
+    });
+  });
+
+  it("renders a null catalog limit as Unlimited on either plan", () => {
+    // `null` is the catalog's "no cap", the same value Enterprise carries. It
+    // must never reach the cadence template — "null / day" would read as a cap
+    // of zero on the plan with no cap at all.
+    const sections = buildComparePlanSectionsFromCatalog(
+      createPlanCatalog({ free: null, team: null })
+    );
+    const evalIterations = sections
+      .find((section) => section.title === "Evaluations")
+      ?.rows.find((row) => row.label === "Eval iterations");
+
+    expect(evalIterations?.free).toEqual({ kind: "text", text: "Unlimited" });
+    expect(evalIterations?.team).toEqual({
+      kind: "text",
+      text: "Unlimited",
       emphasize: true,
     });
   });

--- a/mcpjam-inspector/client/src/components/organization/__tests__/compare-plan-marketing.test.ts
+++ b/mcpjam-inspector/client/src/components/organization/__tests__/compare-plan-marketing.test.ts
@@ -13,8 +13,8 @@ describe("COMPARE_PLAN_MARKETING_SECTIONS", () => {
 
     expect(
       COMPARE_PLAN_MARKETING_SECTIONS.some(
-        (s) => s.title === "Platform & Infrastructure",
-      ),
+        (s) => s.title === "Platform & Infrastructure"
+      )
     ).toBe(false);
 
     expect(
@@ -23,12 +23,12 @@ describe("COMPARE_PLAN_MARKETING_SECTIONS", () => {
 
     const rowCount = COMPARE_PLAN_MARKETING_SECTIONS.reduce(
       (n, s) => n + s.rows.length,
-      0,
+      0
     );
     expect(rowCount).toBe(15);
 
     const standardFeatures = COMPARE_PLAN_MARKETING_SECTIONS.find(
-      (s) => s.title === "Standard features",
+      (s) => s.title === "Standard features"
     );
     const standardLabels = standardFeatures?.rows.map((r) => r.label) ?? [];
     expect(standardLabels).toEqual([
@@ -63,20 +63,20 @@ describe("COMPARE_PLAN_MARKETING_SECTIONS", () => {
     });
   });
 
-  it("leads Evaluations with eval iteration allowances", () => {
+  it("leaves eval iteration allowances for the backend catalog builder", () => {
     const evaluations = COMPARE_PLAN_MARKETING_SECTIONS.find(
-      (s) => s.title === "Evaluations",
+      (s) => s.title === "Evaluations"
     );
     const evalIterations = evaluations?.rows[0];
 
     expect(evalIterations?.label).toBe("Eval iterations");
     expect(evalIterations?.free).toEqual({
       kind: "text",
-      text: "25 / day",
+      text: "—",
     });
     expect(evalIterations?.team).toEqual({
       kind: "text",
-      text: "5,000 / mo",
+      text: "—",
       emphasize: true,
     });
     expect(evalIterations?.enterprise).toEqual({
@@ -88,7 +88,7 @@ describe("COMPARE_PLAN_MARKETING_SECTIONS", () => {
 
   it("keeps Evaluations focused on iteration limits and traces", () => {
     const evaluations = COMPARE_PLAN_MARKETING_SECTIONS.find(
-      (s) => s.title === "Evaluations",
+      (s) => s.title === "Evaluations"
     );
 
     expect(evaluations?.rows.map((row) => row.label)).toEqual([
@@ -96,16 +96,16 @@ describe("COMPARE_PLAN_MARKETING_SECTIONS", () => {
       "Traces",
     ]);
     expect(
-      evaluations?.rows.find((r) => r.label === "Traces")?.enterprise,
+      evaluations?.rows.find((r) => r.label === "Traces")?.enterprise
     ).toEqual({ kind: "check" });
   });
 
   it("keeps audit logs positioned on Enterprise only", () => {
     const security = COMPARE_PLAN_MARKETING_SECTIONS.find(
-      (s) => s.title === "Security & Compliance",
+      (s) => s.title === "Security & Compliance"
     );
     const auditLogRow = security?.rows.find(
-      (r) => r.label === "Audit log retention",
+      (r) => r.label === "Audit log retention"
     );
 
     expect(auditLogRow?.team).toEqual({ kind: "x" });
@@ -115,5 +115,4 @@ describe("COMPARE_PLAN_MARKETING_SECTIONS", () => {
       emphasize: true,
     });
   });
-
 });

--- a/mcpjam-inspector/client/src/components/organization/__tests__/compare-plan-marketing.test.ts
+++ b/mcpjam-inspector/client/src/components/organization/__tests__/compare-plan-marketing.test.ts
@@ -72,11 +72,11 @@ describe("COMPARE_PLAN_MARKETING_SECTIONS", () => {
     expect(evalIterations?.label).toBe("Eval iterations");
     expect(evalIterations?.free).toEqual({
       kind: "text",
-      text: "75 / day",
+      text: "25 / day",
     });
     expect(evalIterations?.team).toEqual({
       kind: "text",
-      text: "15,000 / mo",
+      text: "5,000 / mo",
       emphasize: true,
     });
     expect(evalIterations?.enterprise).toEqual({

--- a/mcpjam-inspector/client/src/components/organization/billing-compare-view-model.ts
+++ b/mcpjam-inspector/client/src/components/organization/billing-compare-view-model.ts
@@ -4,9 +4,18 @@ import {
 } from "@/components/organization/compare-plan-marketing";
 import type { PlanCatalog } from "@/hooks/useOrganizationBilling";
 
+/**
+ * `cadence` is the whole suffix, not just the unit, because the two plans are
+ * not the same shape of allowance: Free is an org-wide DAILY cap, Team is a
+ * MONTHLY allowance enforced PER SEAT. Rendering the Team number as `N / mo`
+ * dropped that qualifier, so a multi-seat org read its own entitlement as an
+ * org-wide total — while the upgrade wall (`PlanLimitDialog`) sells the same
+ * catalog number as "N per seat each month" and the credits row directly above
+ * this one already renders `/ seat / mo`.
+ */
 function formatEvalLimit(
   value: number | null,
-  cadence: "day" | "mo",
+  cadence: "day" | "seat / mo",
   emphasize = false
 ) {
   return {
@@ -34,7 +43,7 @@ export function buildComparePlanSectionsFromCatalog(
             ),
             team: formatEvalLimit(
               planCatalog.plans.team.limits.maxEvalIterationsPerMonth,
-              "mo",
+              "seat / mo",
               true
             ),
           }

--- a/mcpjam-inspector/client/src/components/organization/billing-compare-view-model.ts
+++ b/mcpjam-inspector/client/src/components/organization/billing-compare-view-model.ts
@@ -4,8 +4,41 @@ import {
 } from "@/components/organization/compare-plan-marketing";
 import type { PlanCatalog } from "@/hooks/useOrganizationBilling";
 
+function formatEvalLimit(
+  value: number | null,
+  cadence: "day" | "mo",
+  emphasize = false
+) {
+  return {
+    kind: "text" as const,
+    text:
+      value == null
+        ? "Unlimited"
+        : `${new Intl.NumberFormat("en-US").format(value)} / ${cadence}`,
+    ...(emphasize ? { emphasize: true } : {}),
+  };
+}
+
 export function buildComparePlanSectionsFromCatalog(
-  _planCatalog: PlanCatalog,
+  planCatalog: PlanCatalog
 ): ComparePlanSection[] {
-  return COMPARE_PLAN_MARKETING_SECTIONS;
+  return COMPARE_PLAN_MARKETING_SECTIONS.map((section) => ({
+    ...section,
+    rows: section.rows.map((row) =>
+      row.label === "Eval iterations"
+        ? {
+            ...row,
+            free: formatEvalLimit(
+              planCatalog.plans.free.limits.maxEvalIterationsPerMonth,
+              "day"
+            ),
+            team: formatEvalLimit(
+              planCatalog.plans.team.limits.maxEvalIterationsPerMonth,
+              "mo",
+              true
+            ),
+          }
+        : row
+    ),
+  }));
 }

--- a/mcpjam-inspector/client/src/components/organization/compare-plan-marketing.ts
+++ b/mcpjam-inspector/client/src/components/organization/compare-plan-marketing.ts
@@ -1,14 +1,9 @@
 /**
- * Marketing compare-plans table: product rows mirror `mcpjam_pricing_page.html`;
- * eval caps and enterprise security features carry the commercial
- * distinctions.
- *
- * These strings are hand-maintained and have drifted from mcpjam.com/pricing
- * before (eval iterations read 75/day and 15,000/mo here while the site said
- * 25/day and 5,000/mo). Values below now match the public page. The durable fix
- * is to read the credit and eval rows from the plan catalog the way
- * `PlanLimitDialog` does, which needs credits added to `BillingLimitName`
- * first.
+ * Marketing compare-plans table skeleton. Eval allowance values are replaced
+ * from the backend plan catalog by `buildComparePlanSectionsFromCatalog`, so
+ * this file cannot drift from the limits billing actually enforces.
+ * Included credits remain marketing copy until credits are represented in the
+ * plan catalog.
  */
 
 export type ComparePlanCell =
@@ -63,8 +58,8 @@ export const COMPARE_PLAN_MARKETING_SECTIONS: ComparePlanSection[] = [
     rows: [
       {
         label: "Eval iterations",
-        free: t("25 / day"),
-        team: t("5,000 / mo", true),
+        free: t("—"),
+        team: t("—", true),
         enterprise: t("Custom", true),
       },
       {

--- a/mcpjam-inspector/client/src/components/organization/compare-plan-marketing.ts
+++ b/mcpjam-inspector/client/src/components/organization/compare-plan-marketing.ts
@@ -2,6 +2,13 @@
  * Marketing compare-plans table: product rows mirror `mcpjam_pricing_page.html`;
  * eval caps and enterprise security features carry the commercial
  * distinctions.
+ *
+ * These strings are hand-maintained and have drifted from mcpjam.com/pricing
+ * before (eval iterations read 75/day and 15,000/mo here while the site said
+ * 25/day and 5,000/mo). Values below now match the public page. The durable fix
+ * is to read the credit and eval rows from the plan catalog the way
+ * `PlanLimitDialog` does, which needs credits added to `BillingLimitName`
+ * first.
  */
 
 export type ComparePlanCell =
@@ -56,8 +63,8 @@ export const COMPARE_PLAN_MARKETING_SECTIONS: ComparePlanSection[] = [
     rows: [
       {
         label: "Eval iterations",
-        free: t("75 / day"),
-        team: t("15,000 / mo", true),
+        free: t("25 / day"),
+        team: t("5,000 / mo", true),
         enterprise: t("Custom", true),
       },
       {

--- a/mcpjam-inspector/client/src/hooks/__tests__/use-upgrade-checkout.test.tsx
+++ b/mcpjam-inspector/client/src/hooks/__tests__/use-upgrade-checkout.test.tsx
@@ -1,0 +1,119 @@
+import { act, renderHook, waitFor } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  resolveUpgradeInterval,
+  useUpgradeCheckout,
+} from "../use-upgrade-checkout";
+
+const { billingState, startPlanChange, toastError, trackMock } = vi.hoisted(
+  () => ({
+    billingState: { planCatalog: undefined as unknown },
+    startPlanChange: vi.fn(),
+    toastError: vi.fn(),
+    trackMock: vi.fn(),
+  })
+);
+
+vi.mock("@/hooks/useOrganizationBilling", () => ({
+  useOrganizationBilling: () => ({
+    billingStatus: {
+      plan: "free",
+      effectivePlan: "free",
+      organizationName: "Acme Robotics",
+      canManageBilling: true,
+    },
+    planCatalog: billingState.planCatalog,
+    startPlanChange,
+    isStartingPlanChange: false,
+  }),
+}));
+
+vi.mock("@/lib/analytics", () => ({ track: trackMock }));
+vi.mock("@/lib/toast", () => ({ toast: { error: toastError } }));
+
+function planCatalog(supportedIntervals: Array<"monthly" | "annual">) {
+  return {
+    currency: "USD",
+    plans: {
+      team: {
+        displayName: "Team",
+        prices: { annual: 36_000, monthly: 3_800 },
+        limits: { maxEvalIterationsPerMonth: 5_000 },
+        checkout: { supportedIntervals },
+      },
+    },
+  };
+}
+
+beforeEach(() => {
+  billingState.planCatalog = undefined;
+  startPlanChange.mockReset();
+  startPlanChange.mockResolvedValue({ kind: "updated", subscription: {} });
+  toastError.mockReset();
+  trackMock.mockReset();
+  window.history.replaceState(null, "", "/evals");
+});
+
+describe("resolveUpgradeInterval", () => {
+  it("keeps a valid choice, otherwise prefers annual and then monthly", () => {
+    expect(resolveUpgradeInterval("monthly", true, true)).toBe("monthly");
+    expect(resolveUpgradeInterval("monthly", true, false)).toBe("annual");
+    expect(resolveUpgradeInterval("annual", false, true)).toBe("monthly");
+    expect(resolveUpgradeInterval("annual", false, false)).toBeNull();
+  });
+});
+
+describe("useUpgradeCheckout", () => {
+  it("defaults to annual, then switches to monthly when pricing only supports monthly", async () => {
+    const view = renderHook(() =>
+      useUpgradeCheckout({
+        organizationId: "org-1",
+        origin: "evals",
+        limitKind: "evalIterations",
+      })
+    );
+
+    expect(view.result.current.interval).toBe("annual");
+
+    billingState.planCatalog = planCatalog(["monthly"]);
+    view.rerender();
+
+    await waitFor(() => {
+      expect(view.result.current.interval).toBe("monthly");
+    });
+    await act(async () => {
+      await view.result.current.start();
+    });
+
+    expect(startPlanChange).toHaveBeenCalledWith(
+      expect.stringContaining("upgrade=return"),
+      "team",
+      "monthly",
+      { confirmPaidPlanChange: false }
+    );
+    expect(trackMock).toHaveBeenCalledWith(
+      "plan_limit_upgrade_clicked",
+      expect.objectContaining({ billing_interval: "monthly" })
+    );
+  });
+
+  it("blocks checkout when the catalog supports no interval", async () => {
+    billingState.planCatalog = planCatalog([]);
+    const { result } = renderHook(() =>
+      useUpgradeCheckout({
+        organizationId: "org-1",
+        origin: "credits",
+        limitKind: "credits",
+      })
+    );
+
+    await act(async () => {
+      await result.current.start();
+    });
+
+    expect(startPlanChange).not.toHaveBeenCalled();
+    expect(toastError).toHaveBeenCalledWith(
+      "Checkout is not available for this plan right now."
+    );
+  });
+});

--- a/mcpjam-inspector/client/src/hooks/__tests__/use-upgrade-checkout.test.tsx
+++ b/mcpjam-inspector/client/src/hooks/__tests__/use-upgrade-checkout.test.tsx
@@ -7,7 +7,10 @@ import {
 
 const { billingState, startPlanChange, toastError, toastSuccess, trackMock } =
   vi.hoisted(() => ({
-    billingState: { planCatalog: undefined as unknown },
+    billingState: {
+      planCatalog: undefined as unknown,
+      isLoadingPlanCatalog: false,
+    },
     startPlanChange: vi.fn(),
     toastError: vi.fn(),
     toastSuccess: vi.fn(),
@@ -26,6 +29,7 @@ vi.mock("@/hooks/useOrganizationBilling", () => ({
     startPlanChange,
     isStartingPlanChange: false,
     isLoadingBilling: false,
+    isLoadingPlanCatalog: billingState.isLoadingPlanCatalog,
   }),
 }));
 
@@ -34,15 +38,21 @@ vi.mock("@/lib/toast", () => ({
   toast: { error: toastError, success: toastSuccess },
 }));
 
-function planCatalog(supportedIntervals: Array<"monthly" | "annual">) {
+function planCatalog(
+  supportedIntervals: Array<"monthly" | "annual"> | null,
+  prices: { annual: number | null; monthly: number | null } = {
+    annual: 36_000,
+    monthly: 3_800,
+  }
+) {
   return {
     currency: "USD",
     plans: {
       team: {
         displayName: "Team",
-        prices: { annual: 36_000, monthly: 3_800 },
+        prices,
         limits: { maxEvalIterationsPerMonth: 5_000 },
-        checkout: { supportedIntervals },
+        checkout: supportedIntervals ? { supportedIntervals } : null,
       },
     },
   };
@@ -50,6 +60,7 @@ function planCatalog(supportedIntervals: Array<"monthly" | "annual">) {
 
 beforeEach(() => {
   billingState.planCatalog = undefined;
+  billingState.isLoadingPlanCatalog = false;
   startPlanChange.mockReset();
   startPlanChange.mockResolvedValue({ kind: "updated", subscription: {} });
   toastError.mockReset();
@@ -123,6 +134,85 @@ describe("useUpgradeCheckout", () => {
       "plan_limit_upgrade_failed",
       expect.objectContaining({ error_kind: "no_supported_interval" })
     );
+  });
+
+  it("blocks checkout when the catalog says the plan has no checkout", async () => {
+    billingState.planCatalog = planCatalog(null);
+    const { result } = renderHook(() =>
+      useUpgradeCheckout({
+        organizationId: "org-1",
+        origin: "credits",
+        limitKind: "credits",
+      })
+    );
+
+    // No interval is offered at all, so the picker renders nothing.
+    expect(result.current.annualSupported).toBe(false);
+    expect(result.current.monthlySupported).toBe(false);
+
+    await act(async () => {
+      await result.current.start();
+    });
+
+    expect(startPlanChange).not.toHaveBeenCalled();
+    expect(trackMock).toHaveBeenCalledWith(
+      "plan_limit_upgrade_failed",
+      expect.objectContaining({ error_kind: "no_supported_interval" })
+    );
+  });
+
+  it("drops a supported interval the catalog never priced", async () => {
+    billingState.planCatalog = planCatalog(["monthly", "annual"], {
+      annual: null,
+      monthly: 3_800,
+    });
+    const view = renderHook(() =>
+      useUpgradeCheckout({
+        organizationId: "org-1",
+        origin: "evals",
+        limitKind: "evalIterations",
+      })
+    );
+
+    expect(view.result.current.annualSupported).toBe(false);
+    expect(view.result.current.annualPriceLabel).toBeNull();
+    await waitFor(() => {
+      expect(view.result.current.interval).toBe("monthly");
+    });
+
+    await act(async () => {
+      await view.result.current.start();
+    });
+
+    // Checkout can only ever be started on the priced interval.
+    expect(startPlanChange).toHaveBeenCalledWith(
+      expect.stringContaining("upgrade=return"),
+      "team",
+      "monthly",
+      { confirmPaidPlanChange: false }
+    );
+  });
+
+  it("holds checkout while the catalog is still loading", async () => {
+    billingState.planCatalog = planCatalog(["annual"]);
+    billingState.isLoadingPlanCatalog = true;
+    const { result } = renderHook(() =>
+      useUpgradeCheckout({
+        organizationId: "org-1",
+        origin: "evals",
+        limitKind: "evalIterations",
+      })
+    );
+
+    expect(result.current.isLoadingPrices).toBe(true);
+
+    let outcome: Awaited<ReturnType<typeof result.current.start>>;
+    await act(async () => {
+      outcome = await result.current.start();
+    });
+
+    expect(outcome!).toEqual({ redirected: false, shouldDismiss: false });
+    expect(startPlanChange).not.toHaveBeenCalled();
   });
 
   it("reports an in-place plan update and tells the dialog to close", async () => {

--- a/mcpjam-inspector/client/src/hooks/__tests__/use-upgrade-checkout.test.tsx
+++ b/mcpjam-inspector/client/src/hooks/__tests__/use-upgrade-checkout.test.tsx
@@ -40,6 +40,10 @@ vi.mock("@/hooks/useOrganizationBilling", () => ({
   }),
 }));
 
+vi.mock("@workos-inc/authkit-react", () => ({
+  useAuth: () => ({ user: { id: "user-1" }, isLoading: false }),
+}));
+
 vi.mock("@/lib/analytics", () => ({ track: trackMock }));
 vi.mock("@/lib/toast", () => ({
   toast: { error: toastError, info: toastInfo, success: toastSuccess },

--- a/mcpjam-inspector/client/src/hooks/__tests__/use-upgrade-checkout.test.tsx
+++ b/mcpjam-inspector/client/src/hooks/__tests__/use-upgrade-checkout.test.tsx
@@ -5,17 +5,24 @@ import {
   useUpgradeCheckout,
 } from "../use-upgrade-checkout";
 
-const { billingState, startPlanChange, toastError, toastSuccess, trackMock } =
-  vi.hoisted(() => ({
-    billingState: {
-      planCatalog: undefined as unknown,
-      isLoadingPlanCatalog: false,
-    },
-    startPlanChange: vi.fn(),
-    toastError: vi.fn(),
-    toastSuccess: vi.fn(),
-    trackMock: vi.fn(),
-  }));
+const {
+  billingState,
+  startPlanChange,
+  toastError,
+  toastInfo,
+  toastSuccess,
+  trackMock,
+} = vi.hoisted(() => ({
+  billingState: {
+    planCatalog: undefined as unknown,
+    isLoadingPlanCatalog: false,
+  },
+  startPlanChange: vi.fn(),
+  toastError: vi.fn(),
+  toastInfo: vi.fn(),
+  toastSuccess: vi.fn(),
+  trackMock: vi.fn(),
+}));
 
 vi.mock("@/hooks/useOrganizationBilling", () => ({
   useOrganizationBilling: () => ({
@@ -35,7 +42,7 @@ vi.mock("@/hooks/useOrganizationBilling", () => ({
 
 vi.mock("@/lib/analytics", () => ({ track: trackMock }));
 vi.mock("@/lib/toast", () => ({
-  toast: { error: toastError, success: toastSuccess },
+  toast: { error: toastError, info: toastInfo, success: toastSuccess },
 }));
 
 function planCatalog(
@@ -213,6 +220,74 @@ describe("useUpgradeCheckout", () => {
 
     expect(outcome!).toEqual({ redirected: false, shouldDismiss: false });
     expect(startPlanChange).not.toHaveBeenCalled();
+  });
+
+  it("holds checkout when the catalog resolved without a Team entry", async () => {
+    // Distinct from the loading case above: nothing is in flight, there is
+    // simply no plan to sell. The `!teamEntry` guard is the one that stops it.
+    billingState.planCatalog = undefined;
+    billingState.isLoadingPlanCatalog = false;
+    const { result } = renderHook(() =>
+      useUpgradeCheckout({
+        organizationId: "org-1",
+        origin: "evals",
+        limitKind: "evalIterations",
+      })
+    );
+
+    let outcome: Awaited<ReturnType<typeof result.current.start>>;
+    await act(async () => {
+      outcome = await result.current.start();
+    });
+
+    expect(outcome!).toEqual({ redirected: false, shouldDismiss: false });
+    expect(startPlanChange).not.toHaveBeenCalled();
+  });
+
+  it("hands checkout to the browser on desktop instead of navigating in place", async () => {
+    // The desktop shell cancels in-app navigation to an external origin, so
+    // `location.assign` would leave the dialog stranded behind a page that
+    // never moves. Open a real browser tab and release the dialog instead.
+    billingState.planCatalog = planCatalog(["annual"]);
+    startPlanChange.mockResolvedValue({
+      kind: "checkout",
+      checkoutUrl: "https://checkout.stripe.com/c/pay/cs_test_123",
+      subscription: { plan: "team" },
+    });
+    const openSpy = vi.spyOn(window, "open").mockReturnValue(null);
+    (window as { isElectron?: boolean }).isElectron = true;
+
+    try {
+      const { result } = renderHook(() =>
+        useUpgradeCheckout({
+          organizationId: "org-1",
+          origin: "evals",
+          limitKind: "evalIterations",
+        })
+      );
+
+      let outcome: Awaited<ReturnType<typeof result.current.start>>;
+      await act(async () => {
+        outcome = await result.current.start();
+      });
+
+      expect(openSpy).toHaveBeenCalledWith(
+        "https://checkout.stripe.com/c/pay/cs_test_123",
+        "_blank",
+        "noopener,noreferrer"
+      );
+      // The dialog closes here, unlike the same-tab path where the page is
+      // already on its way out.
+      expect(outcome!).toEqual({ redirected: true, shouldDismiss: true });
+      // The return token is only worth writing for a return that can land in
+      // this session; checkout finishing in another browser can't use it.
+      expect(window.sessionStorage.getItem("mcpjam.upgradeReturnToken")).toBe(
+        null
+      );
+    } finally {
+      delete (window as { isElectron?: boolean }).isElectron;
+      openSpy.mockRestore();
+    }
   });
 
   it("reports an in-place plan update and tells the dialog to close", async () => {

--- a/mcpjam-inspector/client/src/hooks/__tests__/use-upgrade-checkout.test.tsx
+++ b/mcpjam-inspector/client/src/hooks/__tests__/use-upgrade-checkout.test.tsx
@@ -5,14 +5,14 @@ import {
   useUpgradeCheckout,
 } from "../use-upgrade-checkout";
 
-const { billingState, startPlanChange, toastError, trackMock } = vi.hoisted(
-  () => ({
+const { billingState, startPlanChange, toastError, toastSuccess, trackMock } =
+  vi.hoisted(() => ({
     billingState: { planCatalog: undefined as unknown },
     startPlanChange: vi.fn(),
     toastError: vi.fn(),
+    toastSuccess: vi.fn(),
     trackMock: vi.fn(),
-  })
-);
+  }));
 
 vi.mock("@/hooks/useOrganizationBilling", () => ({
   useOrganizationBilling: () => ({
@@ -30,7 +30,9 @@ vi.mock("@/hooks/useOrganizationBilling", () => ({
 }));
 
 vi.mock("@/lib/analytics", () => ({ track: trackMock }));
-vi.mock("@/lib/toast", () => ({ toast: { error: toastError } }));
+vi.mock("@/lib/toast", () => ({
+  toast: { error: toastError, success: toastSuccess },
+}));
 
 function planCatalog(supportedIntervals: Array<"monthly" | "annual">) {
   return {
@@ -51,6 +53,7 @@ beforeEach(() => {
   startPlanChange.mockReset();
   startPlanChange.mockResolvedValue({ kind: "updated", subscription: {} });
   toastError.mockReset();
+  toastSuccess.mockReset();
   trackMock.mockReset();
   window.history.replaceState(null, "", "/evals");
 });
@@ -119,6 +122,61 @@ describe("useUpgradeCheckout", () => {
     expect(trackMock).toHaveBeenCalledWith(
       "plan_limit_upgrade_failed",
       expect.objectContaining({ error_kind: "no_supported_interval" })
+    );
+  });
+
+  it("reports an in-place plan update and tells the dialog to close", async () => {
+    billingState.planCatalog = planCatalog(["annual"]);
+    startPlanChange.mockResolvedValue({
+      kind: "updated",
+      subscription: { plan: "team" },
+    });
+    const { result } = renderHook(() =>
+      useUpgradeCheckout({
+        organizationId: "org-1",
+        origin: "evals",
+        limitKind: "evalIterations",
+      })
+    );
+
+    let outcome: Awaited<ReturnType<typeof result.current.start>>;
+    await act(async () => {
+      outcome = await result.current.start();
+    });
+
+    expect(outcome!).toEqual({ redirected: false, shouldDismiss: true });
+    expect(toastSuccess).toHaveBeenCalledWith("Plan updated to Team.");
+    expect(trackMock).toHaveBeenCalledWith(
+      "plan_limit_upgrade_resolved",
+      expect.objectContaining({
+        result_kind: "updated",
+        resulting_plan: "team",
+      })
+    );
+  });
+
+  it("reports a scheduled plan change and tells the dialog to close", async () => {
+    billingState.planCatalog = planCatalog(["annual"]);
+    startPlanChange.mockResolvedValue({
+      kind: "scheduled",
+      subscription: { plan: "team" },
+    });
+    const { result } = renderHook(() =>
+      useUpgradeCheckout({
+        organizationId: "org-1",
+        origin: "credits",
+        limitKind: "credits",
+      })
+    );
+
+    let outcome: Awaited<ReturnType<typeof result.current.start>>;
+    await act(async () => {
+      outcome = await result.current.start();
+    });
+
+    expect(outcome!).toEqual({ redirected: false, shouldDismiss: true });
+    expect(toastSuccess).toHaveBeenCalledWith(
+      "Plan change scheduled for renewal."
     );
   });
 

--- a/mcpjam-inspector/client/src/hooks/__tests__/use-upgrade-checkout.test.tsx
+++ b/mcpjam-inspector/client/src/hooks/__tests__/use-upgrade-checkout.test.tsx
@@ -25,6 +25,7 @@ vi.mock("@/hooks/useOrganizationBilling", () => ({
     planCatalog: billingState.planCatalog,
     startPlanChange,
     isStartingPlanChange: false,
+    isLoadingBilling: false,
   }),
 }));
 
@@ -114,6 +115,38 @@ describe("useUpgradeCheckout", () => {
     expect(startPlanChange).not.toHaveBeenCalled();
     expect(toastError).toHaveBeenCalledWith(
       "Checkout is not available for this plan right now."
+    );
+    expect(trackMock).toHaveBeenCalledWith(
+      "plan_limit_upgrade_failed",
+      expect.objectContaining({ error_kind: "no_supported_interval" })
+    );
+  });
+
+  it("reports only explicit interval choices, not the automatic fallback", async () => {
+    billingState.planCatalog = planCatalog(["monthly"]);
+    const view = renderHook(() =>
+      useUpgradeCheckout({
+        organizationId: "org-1",
+        origin: "evals",
+        limitKind: "evalIterations",
+      })
+    );
+
+    await waitFor(() => {
+      expect(view.result.current.interval).toBe("monthly");
+    });
+    expect(trackMock).not.toHaveBeenCalledWith(
+      "plan_limit_interval_selected",
+      expect.anything()
+    );
+
+    act(() => view.result.current.setInterval("monthly"));
+    expect(trackMock).toHaveBeenCalledWith(
+      "plan_limit_interval_selected",
+      expect.objectContaining({
+        billing_interval: "monthly",
+        organization_id: "org-1",
+      })
     );
   });
 });

--- a/mcpjam-inspector/client/src/hooks/__tests__/use-upgrade-checkout.test.tsx
+++ b/mcpjam-inspector/client/src/hooks/__tests__/use-upgrade-checkout.test.tsx
@@ -71,6 +71,7 @@ beforeEach(() => {
   startPlanChange.mockReset();
   startPlanChange.mockResolvedValue({ kind: "updated", subscription: {} });
   toastError.mockReset();
+  toastInfo.mockReset();
   toastSuccess.mockReset();
   trackMock.mockReset();
   window.history.replaceState(null, "", "/evals");

--- a/mcpjam-inspector/client/src/hooks/__tests__/use-upgrade-request-recipients.test.tsx
+++ b/mcpjam-inspector/client/src/hooks/__tests__/use-upgrade-request-recipients.test.tsx
@@ -1,0 +1,88 @@
+import { renderHook } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { useUpgradeRequestRecipients } from "../use-upgrade-request-recipients";
+
+const { authState, membersState, useOrganizationMembersMock } = vi.hoisted(
+  () => ({
+    authState: { isAuthenticated: false, isLoading: true },
+    membersState: {
+      activeMembers: [] as Array<{
+        role: "owner" | "member";
+        isOwner: boolean;
+        email: string;
+        user: { name: string } | null;
+      }>,
+      isLoading: false,
+    },
+    useOrganizationMembersMock: vi.fn(),
+  })
+);
+
+vi.mock("convex/react", () => ({
+  useConvexAuth: () => authState,
+}));
+
+vi.mock("@/hooks/useOrganizations", () => ({
+  resolveOrganizationRole: (member: { role: "owner" | "member" }) =>
+    member.role,
+  useOrganizationMembers: (args: unknown) => {
+    useOrganizationMembersMock(args);
+    return membersState;
+  },
+}));
+
+describe("useUpgradeRequestRecipients", () => {
+  beforeEach(() => {
+    authState.isAuthenticated = false;
+    authState.isLoading = true;
+    membersState.activeMembers = [];
+    membersState.isLoading = false;
+    useOrganizationMembersMock.mockClear();
+  });
+
+  it("stays loading while Convex auth resolves and the members query is skipped", () => {
+    const { result } = renderHook(() => useUpgradeRequestRecipients("org-1"));
+
+    expect(useOrganizationMembersMock).toHaveBeenCalledWith({
+      isAuthenticated: false,
+      organizationId: "org-1",
+    });
+    expect(result.current).toEqual({ recipients: [], isLoading: true });
+  });
+
+  it("stays loading while the authenticated members query resolves", () => {
+    authState.isAuthenticated = true;
+    authState.isLoading = false;
+    membersState.isLoading = true;
+
+    const { result } = renderHook(() => useUpgradeRequestRecipients("org-1"));
+
+    expect(result.current.isLoading).toBe(true);
+  });
+
+  it("returns owner recipients after auth and membership settle", () => {
+    authState.isAuthenticated = true;
+    authState.isLoading = false;
+    membersState.activeMembers = [
+      {
+        role: "owner",
+        isOwner: true,
+        email: "owner@example.com",
+        user: { name: "Owner Name" },
+      },
+      {
+        role: "member",
+        isOwner: false,
+        email: "member@example.com",
+        user: { name: "Member Name" },
+      },
+    ];
+
+    const { result } = renderHook(() => useUpgradeRequestRecipients("org-1"));
+
+    expect(result.current).toEqual({
+      recipients: [{ email: "owner@example.com", name: "Owner Name" }],
+      isLoading: false,
+    });
+  });
+});

--- a/mcpjam-inspector/client/src/hooks/__tests__/use-upgrade-request-recipients.test.tsx
+++ b/mcpjam-inspector/client/src/hooks/__tests__/use-upgrade-request-recipients.test.tsx
@@ -2,9 +2,10 @@ import { renderHook } from "@testing-library/react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { useUpgradeRequestRecipients } from "../use-upgrade-request-recipients";
 
-const { authState, membersState, useOrganizationMembersMock } = vi.hoisted(
-  () => ({
+const { authState, dbUserState, membersState, useOrganizationMembersMock } =
+  vi.hoisted(() => ({
     authState: { isAuthenticated: false, isLoading: true },
+    dbUserState: { isUserReady: true },
     membersState: {
       activeMembers: [] as Array<{
         role: "owner" | "member";
@@ -15,11 +16,14 @@ const { authState, membersState, useOrganizationMembersMock } = vi.hoisted(
       isLoading: false,
     },
     useOrganizationMembersMock: vi.fn(),
-  })
-);
+  }));
 
 vi.mock("convex/react", () => ({
   useConvexAuth: () => authState,
+}));
+
+vi.mock("@/contexts/db-user-ready-context", () => ({
+  useDbUserReady: () => dbUserState.isUserReady,
 }));
 
 vi.mock("@/hooks/useOrganizations", () => ({
@@ -35,6 +39,7 @@ describe("useUpgradeRequestRecipients", () => {
   beforeEach(() => {
     authState.isAuthenticated = false;
     authState.isLoading = true;
+    dbUserState.isUserReady = true;
     membersState.activeMembers = [];
     membersState.isLoading = false;
     useOrganizationMembersMock.mockClear();
@@ -48,6 +53,32 @@ describe("useUpgradeRequestRecipients", () => {
       organizationId: "org-1",
     });
     expect(result.current).toEqual({ recipients: [], isLoading: true });
+  });
+
+  it("skips the members query until the db user row exists", () => {
+    // Convex auth authenticates before `users:ensureUser` lands; the org query
+    // throws rather than returning empty in that window.
+    authState.isAuthenticated = true;
+    authState.isLoading = false;
+    dbUserState.isUserReady = false;
+
+    const { result } = renderHook(() => useUpgradeRequestRecipients("org-1"));
+
+    expect(useOrganizationMembersMock).toHaveBeenCalledWith({
+      isAuthenticated: false,
+      organizationId: "org-1",
+    });
+    expect(result.current).toEqual({ recipients: [], isLoading: true });
+  });
+
+  it("settles instead of hanging when there is no authenticated session", () => {
+    authState.isAuthenticated = false;
+    authState.isLoading = false;
+    dbUserState.isUserReady = false;
+
+    const { result } = renderHook(() => useUpgradeRequestRecipients("org-1"));
+
+    expect(result.current).toEqual({ recipients: [], isLoading: false });
   });
 
   it("stays loading while the authenticated members query resolves", () => {
@@ -84,5 +115,41 @@ describe("useUpgradeRequestRecipients", () => {
       recipients: [{ email: "owner@example.com", name: "Owner Name" }],
       isLoading: false,
     });
+  });
+
+  it("keeps an owner whose user row carries no name", () => {
+    authState.isAuthenticated = true;
+    authState.isLoading = false;
+    membersState.activeMembers = [
+      {
+        role: "owner",
+        isOwner: true,
+        email: "owner@example.com",
+        user: null,
+      },
+    ];
+
+    const { result } = renderHook(() => useUpgradeRequestRecipients("org-1"));
+
+    expect(result.current.recipients).toEqual([
+      { email: "owner@example.com", name: null },
+    ]);
+  });
+
+  it("drops an owner with no email rather than addressing an empty draft", () => {
+    authState.isAuthenticated = true;
+    authState.isLoading = false;
+    membersState.activeMembers = [
+      {
+        role: "owner",
+        isOwner: true,
+        email: "",
+        user: { name: "Owner Name" },
+      },
+    ];
+
+    const { result } = renderHook(() => useUpgradeRequestRecipients("org-1"));
+
+    expect(result.current.recipients).toEqual([]);
   });
 });

--- a/mcpjam-inspector/client/src/hooks/use-upgrade-checkout.ts
+++ b/mcpjam-inspector/client/src/hooks/use-upgrade-checkout.ts
@@ -36,12 +36,23 @@ export const UPGRADE_RETURN_ORIGIN_PARAM = "upgrade_from";
 const UPGRADE_RETURN_TOKEN_KEY = "mcpjam.upgradeReturnToken";
 const UPGRADE_RETURN_TOKEN_TTL_MS = 2 * 60 * 60 * 1000;
 
-export function stashUpgradeReturnToken(organizationId: string): void {
+export interface UpgradeReturnTicket {
+  organizationId: string;
+  origin: UpgradeOrigin;
+  /** We already reported one settlement wait for this checkout. Survives a
+   * reload so a slow webhook is still recorded as "late", not "immediate". */
+  waited: boolean;
+}
+
+export function stashUpgradeReturnToken(
+  organizationId: string,
+  origin: UpgradeOrigin
+): void {
   if (typeof window === "undefined") return;
   try {
     window.sessionStorage.setItem(
       UPGRADE_RETURN_TOKEN_KEY,
-      JSON.stringify({ organizationId, issuedAt: Date.now() })
+      JSON.stringify({ organizationId, origin, issuedAt: Date.now() })
     );
   } catch {
     // Storage can be unavailable (private mode, blocked cookies). Checkout
@@ -49,23 +60,68 @@ export function stashUpgradeReturnToken(organizationId: string): void {
   }
 }
 
-export function consumeUpgradeReturnToken(organizationId: string): boolean {
-  if (typeof window === "undefined") return false;
+/**
+ * Reads WITHOUT clearing, so the pending confirmation survives a reload or a
+ * remount while Stripe's webhook is still in flight — the toast used to depend
+ * on the tab staying mounted for the whole round trip, which is not something
+ * the user controls.
+ *
+ * The ticket, not the URL, is what arms the return: params are stripped on
+ * arrival, so a shared or bookmarked link still confirms nothing. Clearing is
+ * `clearUpgradeReturnToken`, once the outcome is known.
+ */
+export function readUpgradeReturnToken(): UpgradeReturnTicket | null {
+  if (typeof window === "undefined") return null;
   try {
     const raw = window.sessionStorage.getItem(UPGRADE_RETURN_TOKEN_KEY);
-    if (!raw) return false;
-    window.sessionStorage.removeItem(UPGRADE_RETURN_TOKEN_KEY);
+    if (!raw) return null;
     const parsed = JSON.parse(raw) as {
       organizationId?: string;
+      origin?: string;
       issuedAt?: number;
+      waited?: boolean;
     };
-    if (parsed?.organizationId !== organizationId) return false;
-    return (
-      typeof parsed.issuedAt === "number" &&
-      Date.now() - parsed.issuedAt < UPGRADE_RETURN_TOKEN_TTL_MS
+    const fresh =
+      typeof parsed?.issuedAt === "number" &&
+      Date.now() - parsed.issuedAt < UPGRADE_RETURN_TOKEN_TTL_MS;
+    // The TTL is the give-up: a checkout abandoned at Stripe leaves a ticket
+    // nothing will ever settle, and it must not wait in this tab forever.
+    if (!fresh || !parsed.organizationId) {
+      clearUpgradeReturnToken();
+      return null;
+    }
+    return {
+      organizationId: parsed.organizationId,
+      origin: parsed.origin === "credits" ? "credits" : "evals",
+      waited: parsed.waited === true,
+    };
+  } catch {
+    return null;
+  }
+}
+
+/** Records that we already announced a settlement wait for this checkout. */
+export function markUpgradeReturnWaited(): void {
+  if (typeof window === "undefined") return;
+  try {
+    const raw = window.sessionStorage.getItem(UPGRADE_RETURN_TOKEN_KEY);
+    if (!raw) return;
+    const parsed = JSON.parse(raw) as Record<string, unknown>;
+    window.sessionStorage.setItem(
+      UPGRADE_RETURN_TOKEN_KEY,
+      JSON.stringify({ ...parsed, waited: true })
     );
   } catch {
-    return false;
+    // Best effort: losing this only downgrades a "late" report to "immediate".
+  }
+}
+
+export function clearUpgradeReturnToken(): void {
+  if (typeof window === "undefined") return;
+  try {
+    window.sessionStorage.removeItem(UPGRADE_RETURN_TOKEN_KEY);
+  } catch {
+    // Nothing to do; a stale ticket expires on its own via the TTL.
   }
 }
 
@@ -309,7 +365,7 @@ export function useUpgradeCheckout({
         }
         // Same tab, so the return URL brings the user back in place. The token
         // is what makes that return trustworthy on the way back.
-        stashUpgradeReturnToken(organizationId);
+        stashUpgradeReturnToken(organizationId, origin);
         window.location.assign(nextUrl);
         return { redirected: true, shouldDismiss: false };
       }

--- a/mcpjam-inspector/client/src/hooks/use-upgrade-checkout.ts
+++ b/mcpjam-inspector/client/src/hooks/use-upgrade-checkout.ts
@@ -41,7 +41,7 @@ function formatMoney(cents: number, currency: string): string {
 export function formatSeatMonthlyPrice(
   amountInCents: number | null,
   currency: string | undefined,
-  interval: BillingInterval,
+  interval: BillingInterval
 ): string | null {
   if (amountInCents == null || !currency) return null;
   if (interval === "monthly") {
@@ -67,12 +67,8 @@ export function useUpgradeCheckout({
   origin,
   limitKind,
 }: UseUpgradeCheckoutParams) {
-  const {
-    billingStatus,
-    planCatalog,
-    startPlanChange,
-    isStartingPlanChange,
-  } = useOrganizationBilling(organizationId);
+  const { billingStatus, planCatalog, startPlanChange, isStartingPlanChange } =
+    useOrganizationBilling(organizationId);
 
   const teamEntry = planCatalog?.plans.team;
   const supportedIntervals = teamEntry?.checkout?.supportedIntervals ?? [
@@ -85,18 +81,18 @@ export function useUpgradeCheckout({
   // Annual leads: it's the cheaper per-seat figure and matches the pricing
   // page. Both prices render at once, so nothing is hidden behind the choice.
   const [interval, setInterval] = useState<BillingInterval>(
-    annualSupported ? "annual" : "monthly",
+    annualSupported ? "annual" : "monthly"
   );
 
   const annualPriceLabel = formatSeatMonthlyPrice(
     teamEntry?.prices.annual ?? null,
     planCatalog?.currency,
-    "annual",
+    "annual"
   );
   const monthlyPriceLabel = formatSeatMonthlyPrice(
     teamEntry?.prices.monthly ?? null,
     planCatalog?.currency,
-    "monthly",
+    "monthly"
   );
 
   const start = useCallback(async () => {
@@ -121,8 +117,8 @@ export function useUpgradeCheckout({
         result.kind === "checkout"
           ? result.checkoutUrl
           : result.kind === "portal"
-            ? result.portalUrl
-            : null;
+          ? result.portalUrl
+          : null;
       if (nextUrl) {
         // Same tab, so the return URL brings the user back in place.
         window.location.assign(nextUrl);
@@ -133,7 +129,7 @@ export function useUpgradeCheckout({
       toast.error(
         error instanceof Error
           ? error.message
-          : "Couldn't start checkout. Please try again.",
+          : "Couldn't start checkout. Please try again."
       );
       return { redirected: false as const };
     }
@@ -152,6 +148,12 @@ export function useUpgradeCheckout({
      * in the copy. Whether the catalog itself matches the public pricing page
      * is a separate question, tracked in the PR. */
     teamEvalIterations: teamEntry?.limits.maxEvalIterationsPerMonth ?? null,
+    // Limit-wall copy and destinations follow the plan whose limits the user
+    // is actually receiving. During a Team trial the persisted billing plan is
+    // still Free, while the effective plan (and its limits) is Team.
+    effectivePlan:
+      billingStatus?.effectivePlan ?? billingStatus?.plan ?? "free",
+    // Keep the persisted plan separate for real billing/checkout decisions.
     currentPlan: billingStatus?.plan ?? "free",
     organizationName: billingStatus?.organizationName ?? "your organization",
     canManageBilling: billingStatus?.canManageBilling ?? false,

--- a/mcpjam-inspector/client/src/hooks/use-upgrade-checkout.ts
+++ b/mcpjam-inspector/client/src/hooks/use-upgrade-checkout.ts
@@ -1,0 +1,154 @@
+import { useCallback, useState } from "react";
+import {
+  useOrganizationBilling,
+  type BillingInterval,
+} from "@/hooks/useOrganizationBilling";
+import { getAnnualDiscountPercent } from "@/lib/billing-entitlements";
+import { track } from "@/lib/analytics";
+import { toast } from "@/lib/toast";
+
+/** Which wall the user was standing at. Drives the return confirmation copy. */
+export type UpgradeOrigin = "evals" | "credits";
+
+/**
+ * Marks a hosted-checkout return so the confirmation lands on the surface the
+ * user was blocked on rather than the billing page. `upgrade_org` and
+ * `upgrade_from` ride along because the dialog stores are empty after the
+ * full page reload.
+ */
+export const UPGRADE_RETURN_PARAM = "upgrade";
+export const UPGRADE_RETURN_ORG_PARAM = "upgrade_org";
+export const UPGRADE_RETURN_ORIGIN_PARAM = "upgrade_from";
+
+function formatMoney(cents: number, currency: string): string {
+  return new Intl.NumberFormat(undefined, {
+    style: "currency",
+    currency,
+    minimumFractionDigits: 0,
+    maximumFractionDigits: 0,
+  }).format(cents / 100);
+}
+
+/**
+ * `prices.annual` is the full-year amount, so the per-seat monthly figure is
+ * a twelfth of it. Mirrors `formatPlanPriceLabel` on the billing page so the
+ * same plan never shows two different numbers.
+ */
+export function formatSeatMonthlyPrice(
+  amountInCents: number | null,
+  currency: string | undefined,
+  interval: BillingInterval,
+): string | null {
+  if (amountInCents == null || !currency) return null;
+  if (interval === "monthly") {
+    return `${formatMoney(amountInCents, currency)}/seat/mo`;
+  }
+  return `${formatMoney(
+    Math.round(amountInCents / 12 / 100) * 100,
+    currency,
+  )}/seat/mo`;
+}
+
+interface UseUpgradeCheckoutParams {
+  organizationId: string | null;
+  origin: UpgradeOrigin;
+  /** Forwarded to telemetry so we can compare which wall converts. */
+  limitKind: string;
+}
+
+/**
+ * Shared upgrade path for the free-plan limit walls. Starts hosted checkout
+ * directly instead of routing through the billing page, and returns the user
+ * to the surface they were blocked on.
+ */
+export function useUpgradeCheckout({
+  organizationId,
+  origin,
+  limitKind,
+}: UseUpgradeCheckoutParams) {
+  const {
+    billingStatus,
+    planCatalog,
+    startPlanChange,
+    isStartingPlanChange,
+  } = useOrganizationBilling(organizationId);
+
+  const teamEntry = planCatalog?.plans.team;
+  const supportedIntervals = teamEntry?.checkout?.supportedIntervals ?? [
+    "monthly",
+    "annual",
+  ];
+  const annualSupported = supportedIntervals.includes("annual");
+  const monthlySupported = supportedIntervals.includes("monthly");
+
+  // Annual leads: it is the cheaper per-seat number and matches the pricing
+  // page. Monthly stays one click away so nobody has to commit to a year to
+  // get unblocked.
+  const [interval, setInterval] = useState<BillingInterval>(
+    annualSupported ? "annual" : "monthly",
+  );
+
+  const priceLabel = formatSeatMonthlyPrice(
+    teamEntry?.prices[interval] ?? null,
+    planCatalog?.currency,
+    interval,
+  );
+
+  const start = useCallback(async () => {
+    if (!organizationId) return;
+    track("plan_limit_upgrade_clicked", {
+      location: "plan_limit_dialog",
+      limit_kind: limitKind,
+      origin,
+      billing_interval: interval,
+    });
+
+    const url = new URL(window.location.href);
+    url.searchParams.set(UPGRADE_RETURN_PARAM, "return");
+    url.searchParams.set(UPGRADE_RETURN_ORG_PARAM, organizationId);
+    url.searchParams.set(UPGRADE_RETURN_ORIGIN_PARAM, origin);
+
+    try {
+      const result = await startPlanChange(url.toString(), "team", interval, {
+        confirmPaidPlanChange: false,
+      });
+      const nextUrl =
+        result.kind === "checkout"
+          ? result.checkoutUrl
+          : result.kind === "portal"
+            ? result.portalUrl
+            : null;
+      if (nextUrl) {
+        // Same tab, so the return URL brings the user back in place.
+        window.location.assign(nextUrl);
+        return { redirected: true as const };
+      }
+      return { redirected: false as const };
+    } catch (error) {
+      toast.error(
+        error instanceof Error
+          ? error.message
+          : "Couldn't start checkout. Please try again.",
+      );
+      return { redirected: false as const };
+    }
+  }, [interval, limitKind, organizationId, origin, startPlanChange]);
+
+  return {
+    interval,
+    setInterval,
+    priceLabel,
+    annualDiscountPct: getAnnualDiscountPercent(planCatalog),
+    annualSupported,
+    monthlySupported,
+    teamName: teamEntry?.displayName ?? "Team",
+    /** Team's monthly eval cap, straight from the catalog so it can't go stale
+     * in the copy. Whether the catalog itself matches the public pricing page
+     * is a separate question, tracked in the PR. */
+    teamEvalIterations: teamEntry?.limits.maxEvalIterationsPerMonth ?? null,
+    currentPlan: billingStatus?.plan ?? "free",
+    canManageBilling: billingStatus?.canManageBilling ?? false,
+    isStarting: isStartingPlanChange,
+    start,
+  };
+}

--- a/mcpjam-inspector/client/src/hooks/use-upgrade-checkout.ts
+++ b/mcpjam-inspector/client/src/hooks/use-upgrade-checkout.ts
@@ -23,6 +23,60 @@ export const UPGRADE_RETURN_PARAM = "upgrade";
 export const UPGRADE_RETURN_ORG_PARAM = "upgrade_org";
 export const UPGRADE_RETURN_ORIGIN_PARAM = "upgrade_from";
 
+/**
+ * The URL params alone can't be trusted: they survive bookmarking, sharing and
+ * signed-out loads, and acting on them would announce a purchase (and record a
+ * conversion) that never happened. This one-shot token is written in the tab
+ * that starts checkout and consumed on the way back, so only a genuine return
+ * from Stripe settles.
+ *
+ * It also keeps a stranger's copy of the link from feeding an org id we have no
+ * access to into a Convex `v.id` query.
+ */
+const UPGRADE_RETURN_TOKEN_KEY = "mcpjam.upgradeReturnToken";
+const UPGRADE_RETURN_TOKEN_TTL_MS = 2 * 60 * 60 * 1000;
+
+export function stashUpgradeReturnToken(organizationId: string): void {
+  if (typeof window === "undefined") return;
+  try {
+    window.sessionStorage.setItem(
+      UPGRADE_RETURN_TOKEN_KEY,
+      JSON.stringify({ organizationId, issuedAt: Date.now() })
+    );
+  } catch {
+    // Storage can be unavailable (private mode, blocked cookies). Checkout
+    // still works; the user just doesn't get the return confirmation.
+  }
+}
+
+export function consumeUpgradeReturnToken(organizationId: string): boolean {
+  if (typeof window === "undefined") return false;
+  try {
+    const raw = window.sessionStorage.getItem(UPGRADE_RETURN_TOKEN_KEY);
+    if (!raw) return false;
+    window.sessionStorage.removeItem(UPGRADE_RETURN_TOKEN_KEY);
+    const parsed = JSON.parse(raw) as {
+      organizationId?: string;
+      issuedAt?: number;
+    };
+    if (parsed?.organizationId !== organizationId) return false;
+    return (
+      typeof parsed.issuedAt === "number" &&
+      Date.now() - parsed.issuedAt < UPGRADE_RETURN_TOKEN_TTL_MS
+    );
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * The desktop shell cancels in-app navigation to an external origin and hands
+ * the URL to the system browser, so checkout can never complete in place.
+ */
+function isDesktopApp(): boolean {
+  return typeof window !== "undefined" && window.isElectron === true;
+}
+
 function formatMoney(cents: number, currency: string): string {
   return new Intl.NumberFormat(undefined, {
     style: "currency",
@@ -88,6 +142,7 @@ export function useUpgradeCheckout({
     startPlanChange,
     isStartingPlanChange,
     isLoadingBilling,
+    isLoadingPlanCatalog,
   } = useOrganizationBilling(organizationId);
 
   const teamEntry = planCatalog?.plans.team;
@@ -164,6 +219,12 @@ export function useUpgradeCheckout({
 
   const start = useCallback(async () => {
     if (!organizationId) return;
+    // The catalog is a separate query from billingStatus, so the CTA can be
+    // live while prices and interval support are still unknown. Never send
+    // anyone to checkout on a price we haven't shown them.
+    if (isLoadingPlanCatalog || !teamEntry) {
+      return { redirected: false as const };
+    }
     const checkoutInterval = resolveUpgradeInterval(
       interval,
       annualSupported,
@@ -219,7 +280,20 @@ export function useUpgradeCheckout({
       if (result.kind === "checkout" || result.kind === "portal") {
         const nextUrl =
           result.kind === "checkout" ? result.checkoutUrl : result.portalUrl;
-        // Same tab, so the return URL brings the user back in place.
+        if (isDesktopApp()) {
+          // Return-in-place is impossible here: the shell opens Stripe in the
+          // system browser, so the return URL lands in a different session.
+          // Say where checkout went and release the dialog, rather than
+          // leaving it open behind a page that will never navigate.
+          window.open(nextUrl, "_blank", "noopener,noreferrer");
+          toast.info(
+            "Finish checkout in your browser. Your new plan unlocks here automatically."
+          );
+          return { redirected: true as const, shouldDismiss: true as const };
+        }
+        // Same tab, so the return URL brings the user back in place. The token
+        // is what makes that return trustworthy on the way back.
+        stashUpgradeReturnToken(organizationId);
         window.location.assign(nextUrl);
         return { redirected: true as const, shouldDismiss: false as const };
       }
@@ -271,12 +345,13 @@ export function useUpgradeCheckout({
     currentPlan,
     effectivePlan,
     interval,
+    isLoadingPlanCatalog,
     limitKind,
     monthlySupported,
     organizationId,
     origin,
     startPlanChange,
-    teamEntry?.prices,
+    teamEntry,
   ]);
 
   return {
@@ -300,6 +375,9 @@ export function useUpgradeCheckout({
     organizationName: billingStatus?.organizationName ?? "your organization",
     canManageBilling,
     isLoadingBilling,
+    /** Prices and interval support come from here, so the CTA stays disabled
+     * until it can name what the user is about to buy. */
+    isLoadingPrices: isLoadingPlanCatalog,
     isStarting: isStartingPlanChange,
     start,
   };

--- a/mcpjam-inspector/client/src/hooks/use-upgrade-checkout.ts
+++ b/mcpjam-inspector/client/src/hooks/use-upgrade-checkout.ts
@@ -34,15 +34,26 @@ export const UPGRADE_RETURN_ORIGIN_PARAM = "upgrade_from";
  * It also keeps a stranger's copy of the link from feeding an org id we have no
  * access to into a Convex `v.id` query.
  */
-const UPGRADE_RETURN_TOKEN_KEY = "mcpjam.upgradeReturnToken";
+/**
+ * Scoped by user in the KEY, never stored in the value — the same shape
+ * `active-organization-storage` uses. It keeps an account identifier out of
+ * storage at rest, and it makes a mismatch structurally impossible rather than
+ * something we have to notice and clean up: another user simply has no ticket.
+ */
+const UPGRADE_RETURN_TOKEN_KEY_PREFIX = "mcpjam.upgradeReturnToken";
+
+function upgradeReturnTokenKey(userId: string): string {
+  return `${UPGRADE_RETURN_TOKEN_KEY_PREFIX}:${userId}`;
+}
 const UPGRADE_RETURN_TOKEN_TTL_MS = 2 * 60 * 60 * 1000;
 
 export interface UpgradeReturnTicket {
   organizationId: string;
   origin: UpgradeOrigin;
-  /** Who started this checkout. sessionStorage is per-tab, not per-identity:
-   * without this, signing out and letting someone else sign in inside the same
-   * tab hands them a confirmation — and a conversion — they never earned. */
+  /** Whose ticket this is. Comes from the storage key, not the stored value,
+   * so it is never written down: sessionStorage is per-tab, not per-identity,
+   * and without scoping, signing out and letting someone else sign in inside
+   * the same tab would hand them a confirmation they never earned. */
   userId: string;
   /** We already reported one settlement wait for this checkout. Survives a
    * reload so a slow webhook is still recorded as "late", not "immediate". */
@@ -57,8 +68,8 @@ export function stashUpgradeReturnToken(
   if (typeof window === "undefined") return;
   try {
     window.sessionStorage.setItem(
-      UPGRADE_RETURN_TOKEN_KEY,
-      JSON.stringify({ organizationId, origin, userId, issuedAt: Date.now() })
+      upgradeReturnTokenKey(userId),
+      JSON.stringify({ organizationId, origin, issuedAt: Date.now() })
     );
   } catch {
     // Storage can be unavailable (private mode, blocked cookies). Checkout
@@ -85,12 +96,13 @@ export function readUpgradeReturnToken(
   // still belongs to whoever comes back — a refresh blip is not a new user.
   if (!currentUserId) return null;
   try {
-    const raw = window.sessionStorage.getItem(UPGRADE_RETURN_TOKEN_KEY);
+    const raw = window.sessionStorage.getItem(
+      upgradeReturnTokenKey(currentUserId)
+    );
     if (!raw) return null;
     const parsed = JSON.parse(raw) as {
       organizationId?: string;
       origin?: string;
-      userId?: string;
       issuedAt?: number;
       waited?: boolean;
     };
@@ -99,16 +111,14 @@ export function readUpgradeReturnToken(
       Date.now() - parsed.issuedAt < UPGRADE_RETURN_TOKEN_TTL_MS;
     // The TTL is the give-up: a checkout abandoned at Stripe leaves a ticket
     // nothing will ever settle, and it must not wait in this tab forever.
-    // A ticket belonging to someone else — a previous session in this tab, or
-    // one written before tickets carried an identity — is retired on sight.
-    if (!fresh || !parsed.organizationId || parsed.userId !== currentUserId) {
-      clearUpgradeReturnToken();
+    if (!fresh || !parsed.organizationId) {
+      clearUpgradeReturnToken(currentUserId);
       return null;
     }
     return {
       organizationId: parsed.organizationId,
       origin: parsed.origin === "credits" ? "credits" : "evals",
-      userId: parsed.userId,
+      userId: currentUserId,
       waited: parsed.waited === true,
     };
   } catch {
@@ -117,14 +127,15 @@ export function readUpgradeReturnToken(
 }
 
 /** Records that we already announced a settlement wait for this checkout. */
-export function markUpgradeReturnWaited(): void {
+export function markUpgradeReturnWaited(userId: string): void {
   if (typeof window === "undefined") return;
   try {
-    const raw = window.sessionStorage.getItem(UPGRADE_RETURN_TOKEN_KEY);
+    const key = upgradeReturnTokenKey(userId);
+    const raw = window.sessionStorage.getItem(key);
     if (!raw) return;
     const parsed = JSON.parse(raw) as Record<string, unknown>;
     window.sessionStorage.setItem(
-      UPGRADE_RETURN_TOKEN_KEY,
+      key,
       JSON.stringify({ ...parsed, waited: true })
     );
   } catch {
@@ -132,10 +143,10 @@ export function markUpgradeReturnWaited(): void {
   }
 }
 
-export function clearUpgradeReturnToken(): void {
+export function clearUpgradeReturnToken(userId: string): void {
   if (typeof window === "undefined") return;
   try {
-    window.sessionStorage.removeItem(UPGRADE_RETURN_TOKEN_KEY);
+    window.sessionStorage.removeItem(upgradeReturnTokenKey(userId));
   } catch {
     // Nothing to do; a stale ticket expires on its own via the TTL.
   }

--- a/mcpjam-inspector/client/src/hooks/use-upgrade-checkout.ts
+++ b/mcpjam-inspector/client/src/hooks/use-upgrade-checkout.ts
@@ -1,4 +1,4 @@
-import { useCallback, useState } from "react";
+import { useCallback, useEffect, useState } from "react";
 import {
   useOrganizationBilling,
   type BillingInterval,
@@ -57,6 +57,18 @@ interface UseUpgradeCheckoutParams {
   limitKind: string;
 }
 
+export function resolveUpgradeInterval(
+  selected: BillingInterval,
+  annualSupported: boolean,
+  monthlySupported: boolean
+): BillingInterval | null {
+  if (selected === "annual" && annualSupported) return "annual";
+  if (selected === "monthly" && monthlySupported) return "monthly";
+  if (annualSupported) return "annual";
+  if (monthlySupported) return "monthly";
+  return null;
+}
+
 /**
  * Shared upgrade path for the free-plan limit walls. Starts hosted checkout
  * directly instead of routing through the billing page, and returns the user
@@ -84,6 +96,17 @@ export function useUpgradeCheckout({
     annualSupported ? "annual" : "monthly"
   );
 
+  useEffect(() => {
+    const availableInterval = resolveUpgradeInterval(
+      interval,
+      annualSupported,
+      monthlySupported
+    );
+    if (availableInterval && availableInterval !== interval) {
+      setInterval(availableInterval);
+    }
+  }, [annualSupported, interval, monthlySupported]);
+
   const annualPriceLabel = formatSeatMonthlyPrice(
     teamEntry?.prices.annual ?? null,
     planCatalog?.currency,
@@ -97,11 +120,21 @@ export function useUpgradeCheckout({
 
   const start = useCallback(async () => {
     if (!organizationId) return;
+    const checkoutInterval = resolveUpgradeInterval(
+      interval,
+      annualSupported,
+      monthlySupported
+    );
+    if (!checkoutInterval) {
+      toast.error("Checkout is not available for this plan right now.");
+      return { redirected: false as const };
+    }
+
     track("plan_limit_upgrade_clicked", {
       location: "plan_limit_dialog",
       limit_kind: limitKind,
       origin,
-      billing_interval: interval,
+      billing_interval: checkoutInterval,
     });
 
     const url = new URL(window.location.href);
@@ -110,9 +143,14 @@ export function useUpgradeCheckout({
     url.searchParams.set(UPGRADE_RETURN_ORIGIN_PARAM, origin);
 
     try {
-      const result = await startPlanChange(url.toString(), "team", interval, {
-        confirmPaidPlanChange: false,
-      });
+      const result = await startPlanChange(
+        url.toString(),
+        "team",
+        checkoutInterval,
+        {
+          confirmPaidPlanChange: false,
+        }
+      );
       const nextUrl =
         result.kind === "checkout"
           ? result.checkoutUrl
@@ -133,7 +171,15 @@ export function useUpgradeCheckout({
       );
       return { redirected: false as const };
     }
-  }, [interval, limitKind, organizationId, origin, startPlanChange]);
+  }, [
+    annualSupported,
+    interval,
+    limitKind,
+    monthlySupported,
+    organizationId,
+    origin,
+    startPlanChange,
+  ]);
 
   return {
     interval,

--- a/mcpjam-inspector/client/src/hooks/use-upgrade-checkout.ts
+++ b/mcpjam-inspector/client/src/hooks/use-upgrade-checkout.ts
@@ -79,8 +79,13 @@ export function useUpgradeCheckout({
   origin,
   limitKind,
 }: UseUpgradeCheckoutParams) {
-  const { billingStatus, planCatalog, startPlanChange, isStartingPlanChange } =
-    useOrganizationBilling(organizationId);
+  const {
+    billingStatus,
+    planCatalog,
+    startPlanChange,
+    isStartingPlanChange,
+    isLoadingBilling,
+  } = useOrganizationBilling(organizationId);
 
   const teamEntry = planCatalog?.plans.team;
   const supportedIntervals = teamEntry?.checkout?.supportedIntervals ?? [
@@ -118,6 +123,42 @@ export function useUpgradeCheckout({
     "monthly"
   );
 
+  const currentPlan = billingStatus?.plan ?? "free";
+  const effectivePlan = billingStatus?.effectivePlan ?? currentPlan;
+  const canManageBilling = billingStatus?.canManageBilling ?? false;
+
+  const selectInterval = useCallback(
+    (nextInterval: BillingInterval) => {
+      // The product choice happens first; telemetry is best-effort and cannot
+      // prevent the selection even if the analytics SDK is unavailable.
+      setInterval(nextInterval);
+      track("plan_limit_interval_selected", {
+        location: "plan_limit_dialog",
+        organization_id: organizationId,
+        limit_kind: limitKind,
+        origin,
+        billing_interval: nextInterval,
+        price_cents: teamEntry?.prices[nextInterval] ?? null,
+        current_plan: currentPlan,
+        effective_plan: effectivePlan,
+        can_manage_billing: canManageBilling,
+        annual_supported: annualSupported,
+        monthly_supported: monthlySupported,
+      });
+    },
+    [
+      annualSupported,
+      canManageBilling,
+      currentPlan,
+      effectivePlan,
+      limitKind,
+      monthlySupported,
+      organizationId,
+      origin,
+      teamEntry?.prices,
+    ]
+  );
+
   const start = useCallback(async () => {
     if (!organizationId) return;
     const checkoutInterval = resolveUpgradeInterval(
@@ -127,15 +168,20 @@ export function useUpgradeCheckout({
     );
     if (!checkoutInterval) {
       toast.error("Checkout is not available for this plan right now.");
+      track("plan_limit_upgrade_failed", {
+        location: "plan_limit_dialog",
+        organization_id: organizationId,
+        limit_kind: limitKind,
+        origin,
+        error_kind: "no_supported_interval",
+        current_plan: currentPlan,
+        effective_plan: effectivePlan,
+        can_manage_billing: canManageBilling,
+        annual_supported: annualSupported,
+        monthly_supported: monthlySupported,
+      });
       return { redirected: false as const };
     }
-
-    track("plan_limit_upgrade_clicked", {
-      location: "plan_limit_dialog",
-      limit_kind: limitKind,
-      origin,
-      billing_interval: checkoutInterval,
-    });
 
     const url = new URL(window.location.href);
     url.searchParams.set(UPGRADE_RETURN_PARAM, "return");
@@ -143,7 +189,9 @@ export function useUpgradeCheckout({
     url.searchParams.set(UPGRADE_RETURN_ORIGIN_PARAM, origin);
 
     try {
-      const result = await startPlanChange(
+      // Start the real checkout work before emitting analytics. We never await
+      // analytics, and track() is failure-isolated.
+      const resultPromise = startPlanChange(
         url.toString(),
         "team",
         checkoutInterval,
@@ -151,6 +199,20 @@ export function useUpgradeCheckout({
           confirmPaidPlanChange: false,
         }
       );
+      track("plan_limit_upgrade_clicked", {
+        location: "plan_limit_dialog",
+        organization_id: organizationId,
+        limit_kind: limitKind,
+        origin,
+        billing_interval: checkoutInterval,
+        price_cents: teamEntry?.prices[checkoutInterval] ?? null,
+        current_plan: currentPlan,
+        effective_plan: effectivePlan,
+        can_manage_billing: canManageBilling,
+        annual_supported: annualSupported,
+        monthly_supported: monthlySupported,
+      });
+      const result = await resultPromise;
       const nextUrl =
         result.kind === "checkout"
           ? result.checkoutUrl
@@ -169,21 +231,37 @@ export function useUpgradeCheckout({
           ? error.message
           : "Couldn't start checkout. Please try again."
       );
+      track("plan_limit_upgrade_failed", {
+        location: "plan_limit_dialog",
+        organization_id: organizationId,
+        limit_kind: limitKind,
+        origin,
+        error_kind: "start_plan_change_failed",
+        error_name: error instanceof Error ? error.name : "unknown",
+        billing_interval: checkoutInterval,
+        current_plan: currentPlan,
+        effective_plan: effectivePlan,
+        can_manage_billing: canManageBilling,
+      });
       return { redirected: false as const };
     }
   }, [
     annualSupported,
+    canManageBilling,
+    currentPlan,
+    effectivePlan,
     interval,
     limitKind,
     monthlySupported,
     organizationId,
     origin,
     startPlanChange,
+    teamEntry?.prices,
   ]);
 
   return {
     interval,
-    setInterval,
+    setInterval: selectInterval,
     annualPriceLabel,
     monthlyPriceLabel,
     annualDiscountPct: getAnnualDiscountPercent(planCatalog),
@@ -197,12 +275,12 @@ export function useUpgradeCheckout({
     // Limit-wall copy and destinations follow the plan whose limits the user
     // is actually receiving. During a Team trial the persisted billing plan is
     // still Free, while the effective plan (and its limits) is Team.
-    effectivePlan:
-      billingStatus?.effectivePlan ?? billingStatus?.plan ?? "free",
+    effectivePlan,
     // Keep the persisted plan separate for real billing/checkout decisions.
-    currentPlan: billingStatus?.plan ?? "free",
+    currentPlan,
     organizationName: billingStatus?.organizationName ?? "your organization",
-    canManageBilling: billingStatus?.canManageBilling ?? false,
+    canManageBilling,
+    isLoadingBilling,
     isStarting: isStartingPlanChange,
     start,
   };

--- a/mcpjam-inspector/client/src/hooks/use-upgrade-checkout.ts
+++ b/mcpjam-inspector/client/src/hooks/use-upgrade-checkout.ts
@@ -30,9 +30,13 @@ function formatMoney(cents: number, currency: string): string {
 }
 
 /**
- * `prices.annual` is the full-year amount, so the per-seat monthly figure is
- * a twelfth of it. Mirrors `formatPlanPriceLabel` on the billing page so the
- * same plan never shows two different numbers.
+ * `prices.annual` is the full-year amount, so the per-seat monthly figure is a
+ * twelfth of it. Same number as `formatPlanPriceLabel` on the billing page.
+ *
+ * Returns the bare amount. The unit is rendered separately and smaller by
+ * `UpgradeIntervalPicker`: inside the large price span, "$30 per seat/month"
+ * wraps mid-phrase in a card this narrow, which reads worse than the "/seat/mo"
+ * it replaced.
  */
 export function formatSeatMonthlyPrice(
   amountInCents: number | null,
@@ -41,12 +45,9 @@ export function formatSeatMonthlyPrice(
 ): string | null {
   if (amountInCents == null || !currency) return null;
   if (interval === "monthly") {
-    return `${formatMoney(amountInCents, currency)}/seat/mo`;
+    return formatMoney(amountInCents, currency);
   }
-  return `${formatMoney(
-    Math.round(amountInCents / 12 / 100) * 100,
-    currency,
-  )}/seat/mo`;
+  return formatMoney(Math.round(amountInCents / 12 / 100) * 100, currency);
 }
 
 interface UseUpgradeCheckoutParams {

--- a/mcpjam-inspector/client/src/hooks/use-upgrade-checkout.ts
+++ b/mcpjam-inspector/client/src/hooks/use-upgrade-checkout.ts
@@ -1,4 +1,5 @@
 import { useCallback, useEffect, useState } from "react";
+import { useAuth } from "@workos-inc/authkit-react";
 import {
   useOrganizationBilling,
   type BillingInterval,
@@ -39,6 +40,10 @@ const UPGRADE_RETURN_TOKEN_TTL_MS = 2 * 60 * 60 * 1000;
 export interface UpgradeReturnTicket {
   organizationId: string;
   origin: UpgradeOrigin;
+  /** Who started this checkout. sessionStorage is per-tab, not per-identity:
+   * without this, signing out and letting someone else sign in inside the same
+   * tab hands them a confirmation — and a conversion — they never earned. */
+  userId: string;
   /** We already reported one settlement wait for this checkout. Survives a
    * reload so a slow webhook is still recorded as "late", not "immediate". */
   waited: boolean;
@@ -46,13 +51,14 @@ export interface UpgradeReturnTicket {
 
 export function stashUpgradeReturnToken(
   organizationId: string,
-  origin: UpgradeOrigin
+  origin: UpgradeOrigin,
+  userId: string
 ): void {
   if (typeof window === "undefined") return;
   try {
     window.sessionStorage.setItem(
       UPGRADE_RETURN_TOKEN_KEY,
-      JSON.stringify({ organizationId, origin, issuedAt: Date.now() })
+      JSON.stringify({ organizationId, origin, userId, issuedAt: Date.now() })
     );
   } catch {
     // Storage can be unavailable (private mode, blocked cookies). Checkout
@@ -70,14 +76,21 @@ export function stashUpgradeReturnToken(
  * arrival, so a shared or bookmarked link still confirms nothing. Clearing is
  * `clearUpgradeReturnToken`, once the outcome is known.
  */
-export function readUpgradeReturnToken(): UpgradeReturnTicket | null {
+export function readUpgradeReturnToken(
+  currentUserId: string | null
+): UpgradeReturnTicket | null {
   if (typeof window === "undefined") return null;
+  // No identity to check against yet (auth still resolving, or signed out).
+  // Leave the ticket alone rather than retiring a pending confirmation that
+  // still belongs to whoever comes back — a refresh blip is not a new user.
+  if (!currentUserId) return null;
   try {
     const raw = window.sessionStorage.getItem(UPGRADE_RETURN_TOKEN_KEY);
     if (!raw) return null;
     const parsed = JSON.parse(raw) as {
       organizationId?: string;
       origin?: string;
+      userId?: string;
       issuedAt?: number;
       waited?: boolean;
     };
@@ -86,13 +99,16 @@ export function readUpgradeReturnToken(): UpgradeReturnTicket | null {
       Date.now() - parsed.issuedAt < UPGRADE_RETURN_TOKEN_TTL_MS;
     // The TTL is the give-up: a checkout abandoned at Stripe leaves a ticket
     // nothing will ever settle, and it must not wait in this tab forever.
-    if (!fresh || !parsed.organizationId) {
+    // A ticket belonging to someone else — a previous session in this tab, or
+    // one written before tickets carried an identity — is retired on sight.
+    if (!fresh || !parsed.organizationId || parsed.userId !== currentUserId) {
       clearUpgradeReturnToken();
       return null;
     }
     return {
       organizationId: parsed.organizationId,
       origin: parsed.origin === "credits" ? "credits" : "evals",
+      userId: parsed.userId,
       waited: parsed.waited === true,
     };
   } catch {
@@ -209,6 +225,9 @@ export function useUpgradeCheckout({
     isLoadingBilling,
     isLoadingPlanCatalog,
   } = useOrganizationBilling(organizationId);
+  // Stamped onto the return ticket so only the buyer can redeem it.
+  const { user } = useAuth();
+  const userId = user?.id ?? null;
 
   const teamEntry = planCatalog?.plans.team;
   // One rule for the whole path: an interval is offered only if the catalog
@@ -365,7 +384,7 @@ export function useUpgradeCheckout({
         }
         // Same tab, so the return URL brings the user back in place. The token
         // is what makes that return trustworthy on the way back.
-        stashUpgradeReturnToken(organizationId, origin);
+        if (userId) stashUpgradeReturnToken(organizationId, origin, userId);
         window.location.assign(nextUrl);
         return { redirected: true, shouldDismiss: false };
       }
@@ -424,6 +443,7 @@ export function useUpgradeCheckout({
     origin,
     startPlanChange,
     teamEntry,
+    userId,
   ]);
 
   return {

--- a/mcpjam-inspector/client/src/hooks/use-upgrade-checkout.ts
+++ b/mcpjam-inspector/client/src/hooks/use-upgrade-checkout.ts
@@ -1,4 +1,4 @@
-import { useCallback } from "react";
+import { useCallback, useState } from "react";
 import {
   useOrganizationBilling,
   type BillingInterval,
@@ -81,8 +81,12 @@ export function useUpgradeCheckout({
   const annualSupported = supportedIntervals.includes("annual");
   const monthlySupported = supportedIntervals.includes("monthly");
 
-  // Both prices are shown at once, so the interval is chosen by which card the
-  // user presses rather than by a toggle they have to find first.
+  // Annual leads: it's the cheaper per-seat figure and matches the pricing
+  // page. Both prices render at once, so nothing is hidden behind the choice.
+  const [interval, setInterval] = useState<BillingInterval>(
+    annualSupported ? "annual" : "monthly",
+  );
+
   const annualPriceLabel = formatSeatMonthlyPrice(
     teamEntry?.prices.annual ?? null,
     planCatalog?.currency,
@@ -94,7 +98,7 @@ export function useUpgradeCheckout({
     "monthly",
   );
 
-  const start = useCallback(async (interval: BillingInterval) => {
+  const start = useCallback(async () => {
     if (!organizationId) return;
     track("plan_limit_upgrade_clicked", {
       location: "plan_limit_dialog",
@@ -132,9 +136,11 @@ export function useUpgradeCheckout({
       );
       return { redirected: false as const };
     }
-  }, [limitKind, organizationId, origin, startPlanChange]);
+  }, [interval, limitKind, organizationId, origin, startPlanChange]);
 
   return {
+    interval,
+    setInterval,
     annualPriceLabel,
     monthlyPriceLabel,
     annualDiscountPct: getAnnualDiscountPercent(planCatalog),
@@ -146,6 +152,7 @@ export function useUpgradeCheckout({
      * is a separate question, tracked in the PR. */
     teamEvalIterations: teamEntry?.limits.maxEvalIterationsPerMonth ?? null,
     currentPlan: billingStatus?.plan ?? "free",
+    organizationName: billingStatus?.organizationName ?? "your organization",
     canManageBilling: billingStatus?.canManageBilling ?? false,
     isStarting: isStartingPlanChange,
     start,

--- a/mcpjam-inspector/client/src/hooks/use-upgrade-checkout.ts
+++ b/mcpjam-inspector/client/src/hooks/use-upgrade-checkout.ts
@@ -3,7 +3,10 @@ import {
   useOrganizationBilling,
   type BillingInterval,
 } from "@/hooks/useOrganizationBilling";
-import { getAnnualDiscountPercent } from "@/lib/billing-entitlements";
+import {
+  formatPlanName,
+  getAnnualDiscountPercent,
+} from "@/lib/billing-entitlements";
 import { track } from "@/lib/analytics";
 import { toast } from "@/lib/toast";
 
@@ -213,18 +216,35 @@ export function useUpgradeCheckout({
         monthly_supported: monthlySupported,
       });
       const result = await resultPromise;
-      const nextUrl =
-        result.kind === "checkout"
-          ? result.checkoutUrl
-          : result.kind === "portal"
-          ? result.portalUrl
-          : null;
-      if (nextUrl) {
+      if (result.kind === "checkout" || result.kind === "portal") {
+        const nextUrl =
+          result.kind === "checkout" ? result.checkoutUrl : result.portalUrl;
         // Same tab, so the return URL brings the user back in place.
         window.location.assign(nextUrl);
-        return { redirected: true as const };
+        return { redirected: true as const, shouldDismiss: false as const };
       }
-      return { redirected: false as const };
+
+      if (result.kind === "updated") {
+        toast.success(
+          `Plan updated to ${formatPlanName(
+            result.subscription.plan ?? "team"
+          )}.`
+        );
+      } else {
+        toast.success("Plan change scheduled for renewal.");
+      }
+      track("plan_limit_upgrade_resolved", {
+        location: "plan_limit_dialog",
+        organization_id: organizationId,
+        limit_kind: limitKind,
+        origin,
+        result_kind: result.kind,
+        billing_interval: checkoutInterval,
+        resulting_plan: result.subscription.plan ?? "team",
+        current_plan: currentPlan,
+        effective_plan: effectivePlan,
+      });
+      return { redirected: false as const, shouldDismiss: true as const };
     } catch (error) {
       toast.error(
         error instanceof Error
@@ -269,8 +289,7 @@ export function useUpgradeCheckout({
     monthlySupported,
     teamName: teamEntry?.displayName ?? "Team",
     /** Team's monthly eval cap, straight from the catalog so it can't go stale
-     * in the copy. Whether the catalog itself matches the public pricing page
-     * is a separate question, tracked in the PR. */
+     * in the copy. The backend applies this amount per seat. */
     teamEvalIterations: teamEntry?.limits.maxEvalIterationsPerMonth ?? null,
     // Limit-wall copy and destinations follow the plan whose limits the user
     // is actually receiving. During a Team trial the persisted billing plan is

--- a/mcpjam-inspector/client/src/hooks/use-upgrade-checkout.ts
+++ b/mcpjam-inspector/client/src/hooks/use-upgrade-checkout.ts
@@ -114,6 +114,15 @@ interface UseUpgradeCheckoutParams {
   limitKind: string;
 }
 
+/**
+ * Every `start()` path reports the same two facts: whether the browser is on
+ * its way to Stripe, and whether the caller should close its dialog.
+ */
+export interface UpgradeStartResult {
+  redirected: boolean;
+  shouldDismiss: boolean;
+}
+
 export function resolveUpgradeInterval(
   selected: BillingInterval,
   annualSupported: boolean,
@@ -146,10 +155,17 @@ export function useUpgradeCheckout({
   } = useOrganizationBilling(organizationId);
 
   const teamEntry = planCatalog?.plans.team;
-  const supportedIntervals = teamEntry?.checkout?.supportedIntervals ?? [
-    "monthly",
-    "annual",
-  ];
+  // One rule for the whole path: an interval is offered only if the catalog
+  // both supports it and has priced it, so checkout can never buy something
+  // the card didn't name. `checkout: null` means no self-serve intervals at
+  // all rather than "assume both". Before the catalog lands there is nothing
+  // to trust yet, so both cards render as placeholders and `isLoadingPrices`
+  // keeps checkout closed.
+  const supportedIntervals: BillingInterval[] = teamEntry
+    ? (teamEntry.checkout?.supportedIntervals ?? []).filter(
+        (candidate) => teamEntry.prices[candidate] != null
+      )
+    : ["monthly", "annual"];
   const annualSupported = supportedIntervals.includes("annual");
   const monthlySupported = supportedIntervals.includes("monthly");
 
@@ -217,13 +233,13 @@ export function useUpgradeCheckout({
     ]
   );
 
-  const start = useCallback(async () => {
-    if (!organizationId) return;
+  const start = useCallback(async (): Promise<UpgradeStartResult> => {
+    if (!organizationId) return { redirected: false, shouldDismiss: false };
     // The catalog is a separate query from billingStatus, so the CTA can be
     // live while prices and interval support are still unknown. Never send
     // anyone to checkout on a price we haven't shown them.
     if (isLoadingPlanCatalog || !teamEntry) {
-      return { redirected: false as const };
+      return { redirected: false, shouldDismiss: false };
     }
     const checkoutInterval = resolveUpgradeInterval(
       interval,
@@ -244,7 +260,7 @@ export function useUpgradeCheckout({
         annual_supported: annualSupported,
         monthly_supported: monthlySupported,
       });
-      return { redirected: false as const };
+      return { redirected: false, shouldDismiss: false };
     }
 
     const url = new URL(window.location.href);
@@ -289,13 +305,13 @@ export function useUpgradeCheckout({
           toast.info(
             "Finish checkout in your browser. Your new plan unlocks here automatically."
           );
-          return { redirected: true as const, shouldDismiss: true as const };
+          return { redirected: true, shouldDismiss: true };
         }
         // Same tab, so the return URL brings the user back in place. The token
         // is what makes that return trustworthy on the way back.
         stashUpgradeReturnToken(organizationId);
         window.location.assign(nextUrl);
-        return { redirected: true as const, shouldDismiss: false as const };
+        return { redirected: true, shouldDismiss: false };
       }
 
       if (result.kind === "updated") {
@@ -318,7 +334,7 @@ export function useUpgradeCheckout({
         current_plan: currentPlan,
         effective_plan: effectivePlan,
       });
-      return { redirected: false as const, shouldDismiss: true as const };
+      return { redirected: false, shouldDismiss: true };
     } catch (error) {
       toast.error(
         error instanceof Error
@@ -337,7 +353,7 @@ export function useUpgradeCheckout({
         effective_plan: effectivePlan,
         can_manage_billing: canManageBilling,
       });
-      return { redirected: false as const };
+      return { redirected: false, shouldDismiss: false };
     }
   }, [
     annualSupported,

--- a/mcpjam-inspector/client/src/hooks/use-upgrade-checkout.ts
+++ b/mcpjam-inspector/client/src/hooks/use-upgrade-checkout.ts
@@ -1,4 +1,4 @@
-import { useCallback, useState } from "react";
+import { useCallback } from "react";
 import {
   useOrganizationBilling,
   type BillingInterval,
@@ -81,20 +81,20 @@ export function useUpgradeCheckout({
   const annualSupported = supportedIntervals.includes("annual");
   const monthlySupported = supportedIntervals.includes("monthly");
 
-  // Annual leads: it is the cheaper per-seat number and matches the pricing
-  // page. Monthly stays one click away so nobody has to commit to a year to
-  // get unblocked.
-  const [interval, setInterval] = useState<BillingInterval>(
-    annualSupported ? "annual" : "monthly",
-  );
-
-  const priceLabel = formatSeatMonthlyPrice(
-    teamEntry?.prices[interval] ?? null,
+  // Both prices are shown at once, so the interval is chosen by which card the
+  // user presses rather than by a toggle they have to find first.
+  const annualPriceLabel = formatSeatMonthlyPrice(
+    teamEntry?.prices.annual ?? null,
     planCatalog?.currency,
-    interval,
+    "annual",
+  );
+  const monthlyPriceLabel = formatSeatMonthlyPrice(
+    teamEntry?.prices.monthly ?? null,
+    planCatalog?.currency,
+    "monthly",
   );
 
-  const start = useCallback(async () => {
+  const start = useCallback(async (interval: BillingInterval) => {
     if (!organizationId) return;
     track("plan_limit_upgrade_clicked", {
       location: "plan_limit_dialog",
@@ -132,12 +132,11 @@ export function useUpgradeCheckout({
       );
       return { redirected: false as const };
     }
-  }, [interval, limitKind, organizationId, origin, startPlanChange]);
+  }, [limitKind, organizationId, origin, startPlanChange]);
 
   return {
-    interval,
-    setInterval,
-    priceLabel,
+    annualPriceLabel,
+    monthlyPriceLabel,
     annualDiscountPct: getAnnualDiscountPercent(planCatalog),
     annualSupported,
     monthlySupported,

--- a/mcpjam-inspector/client/src/hooks/use-upgrade-request-recipients.ts
+++ b/mcpjam-inspector/client/src/hooks/use-upgrade-request-recipients.ts
@@ -1,0 +1,37 @@
+import { useMemo } from "react";
+import { useConvexAuth } from "convex/react";
+import {
+  resolveOrganizationRole,
+  useOrganizationMembers,
+} from "@/hooks/useOrganizations";
+import type { UpgradeRequestRecipient } from "@/components/billing/RequestUpgradeButton";
+
+/**
+ * The org owners a blocked member should be pointed at. Owners only: admins
+ * can't start checkout either (`canManageBilling` is owner-only in Convex), so
+ * addressing them would route the ask to someone who also can't act on it.
+ *
+ * Pending invites are excluded — `activeMembers` already filters to members
+ * with a resolved `userId`.
+ */
+export function useUpgradeRequestRecipients(
+  organizationId: string | null,
+): UpgradeRequestRecipient[] {
+  const { isAuthenticated } = useConvexAuth();
+  const { activeMembers } = useOrganizationMembers({
+    isAuthenticated,
+    organizationId,
+  });
+
+  return useMemo(
+    () =>
+      activeMembers
+        .filter((member) => resolveOrganizationRole(member) === "owner")
+        .map((member) => ({
+          email: member.email,
+          name: member.user?.name ?? null,
+        }))
+        .filter((recipient) => Boolean(recipient.email)),
+    [activeMembers],
+  );
+}

--- a/mcpjam-inspector/client/src/hooks/use-upgrade-request-recipients.ts
+++ b/mcpjam-inspector/client/src/hooks/use-upgrade-request-recipients.ts
@@ -14,16 +14,20 @@ import type { UpgradeRequestRecipient } from "@/components/billing/RequestUpgrad
  * Pending invites are excluded — `activeMembers` already filters to members
  * with a resolved `userId`.
  */
-export function useUpgradeRequestRecipients(
-  organizationId: string | null,
-): UpgradeRequestRecipient[] {
+export function useUpgradeRequestRecipients(organizationId: string | null): {
+  recipients: UpgradeRequestRecipient[];
+  isLoading: boolean;
+} {
   const { isAuthenticated } = useConvexAuth();
-  const { activeMembers } = useOrganizationMembers({
+  const { activeMembers, isLoading } = useOrganizationMembers({
     isAuthenticated,
     organizationId,
   });
 
-  return useMemo(
+  // `activeMembers` is [] while the query is in flight, so without `isLoading`
+  // the caller cannot tell "this org has no reachable owner" from "we haven't
+  // asked yet" — and would flash no action before the button appears.
+  const recipients = useMemo(
     () =>
       activeMembers
         .filter((member) => resolveOrganizationRole(member) === "owner")
@@ -34,4 +38,6 @@ export function useUpgradeRequestRecipients(
         .filter((recipient) => Boolean(recipient.email)),
     [activeMembers],
   );
+
+  return { recipients, isLoading };
 }

--- a/mcpjam-inspector/client/src/hooks/use-upgrade-request-recipients.ts
+++ b/mcpjam-inspector/client/src/hooks/use-upgrade-request-recipients.ts
@@ -4,6 +4,7 @@ import {
   resolveOrganizationRole,
   useOrganizationMembers,
 } from "@/hooks/useOrganizations";
+import { useDbUserReady } from "@/contexts/db-user-ready-context";
 import type { UpgradeRequestRecipient } from "@/components/billing/RequestUpgradeButton";
 
 /**
@@ -19,9 +20,15 @@ export function useUpgradeRequestRecipients(organizationId: string | null): {
   isLoading: boolean;
 } {
   const { isAuthenticated, isLoading: isAuthLoading } = useConvexAuth();
+  // Convex auth flips to authenticated before `users:ensureUser` has created
+  // the row every org query resolves the caller against, so `isAuthenticated`
+  // alone would fire `getOrganizationMembers` during bootstrap, where it
+  // throws instead of returning empty. Same gate every other org-scoped hook
+  // uses (useOrgSlackSettings, useProjectEnvironments, useGithubChecksSettings).
+  const isUserReady = useDbUserReady();
   const { activeMembers, isLoading: isMembersLoading } = useOrganizationMembers(
     {
-      isAuthenticated,
+      isAuthenticated: isAuthenticated && isUserReady,
       organizationId,
     }
   );
@@ -38,8 +45,18 @@ export function useUpgradeRequestRecipients(organizationId: string | null): {
     [activeMembers]
   );
 
-  // While Convex auth resolves, isAuthenticated is temporarily false and the
+  // While Convex auth resolves, isAuthenticated is temporarily false, and
+  // while the db user bootstraps the query is gated off — in both windows the
   // members query is skipped. Keep the result pending so callers do not treat
   // that temporary empty list as a settled "no owner" result.
-  return { recipients, isLoading: isAuthLoading || isMembersLoading };
+  //
+  // Bounded rather than a permanent "loading": the bootstrap term is guarded
+  // on `isAuthenticated`, so signed-out callers settle immediately, and an
+  // authenticated session whose ensureUser never lands is already replaced by
+  // App's `UserSetupError` screen.
+  return {
+    recipients,
+    isLoading:
+      isAuthLoading || (isAuthenticated && !isUserReady) || isMembersLoading,
+  };
 }

--- a/mcpjam-inspector/client/src/hooks/use-upgrade-request-recipients.ts
+++ b/mcpjam-inspector/client/src/hooks/use-upgrade-request-recipients.ts
@@ -14,20 +14,19 @@ import type { UpgradeRequestRecipient } from "@/components/billing/RequestUpgrad
  * Pending invites are excluded — `activeMembers` already filters to members
  * with a resolved `userId`.
  */
-export function useUpgradeRequestRecipients(organizationId: string | null): {
-  recipients: UpgradeRequestRecipient[];
-  isLoading: boolean;
-} {
+export function useUpgradeRequestRecipients(
+  organizationId: string | null,
+): UpgradeRequestRecipient[] {
   const { isAuthenticated } = useConvexAuth();
-  const { activeMembers, isLoading } = useOrganizationMembers({
+  const { activeMembers } = useOrganizationMembers({
     isAuthenticated,
     organizationId,
   });
 
-  // `activeMembers` is [] while the query is in flight, so without `isLoading`
-  // the caller cannot tell "this org has no reachable owner" from "we haven't
-  // asked yet" — and would flash no action before the button appears.
-  const recipients = useMemo(
+  // `activeMembers` is [] while the query is in flight, which collapses into
+  // the same render as "this org has no reachable owner": nothing. Both are
+  // states where there is no address to write to, so neither earns a button.
+  return useMemo(
     () =>
       activeMembers
         .filter((member) => resolveOrganizationRole(member) === "owner")
@@ -38,6 +37,4 @@ export function useUpgradeRequestRecipients(organizationId: string | null): {
         .filter((recipient) => Boolean(recipient.email)),
     [activeMembers],
   );
-
-  return { recipients, isLoading };
 }

--- a/mcpjam-inspector/client/src/hooks/use-upgrade-request-recipients.ts
+++ b/mcpjam-inspector/client/src/hooks/use-upgrade-request-recipients.ts
@@ -14,19 +14,17 @@ import type { UpgradeRequestRecipient } from "@/components/billing/RequestUpgrad
  * Pending invites are excluded — `activeMembers` already filters to members
  * with a resolved `userId`.
  */
-export function useUpgradeRequestRecipients(
-  organizationId: string | null,
-): UpgradeRequestRecipient[] {
+export function useUpgradeRequestRecipients(organizationId: string | null): {
+  recipients: UpgradeRequestRecipient[];
+  isLoading: boolean;
+} {
   const { isAuthenticated } = useConvexAuth();
-  const { activeMembers } = useOrganizationMembers({
+  const { activeMembers, isLoading } = useOrganizationMembers({
     isAuthenticated,
     organizationId,
   });
 
-  // `activeMembers` is [] while the query is in flight, which collapses into
-  // the same render as "this org has no reachable owner": nothing. Both are
-  // states where there is no address to write to, so neither earns a button.
-  return useMemo(
+  const recipients = useMemo(
     () =>
       activeMembers
         .filter((member) => resolveOrganizationRole(member) === "owner")
@@ -35,6 +33,8 @@ export function useUpgradeRequestRecipients(
           name: member.user?.name ?? null,
         }))
         .filter((recipient) => Boolean(recipient.email)),
-    [activeMembers],
+    [activeMembers]
   );
+
+  return { recipients, isLoading };
 }

--- a/mcpjam-inspector/client/src/hooks/use-upgrade-request-recipients.ts
+++ b/mcpjam-inspector/client/src/hooks/use-upgrade-request-recipients.ts
@@ -18,11 +18,13 @@ export function useUpgradeRequestRecipients(organizationId: string | null): {
   recipients: UpgradeRequestRecipient[];
   isLoading: boolean;
 } {
-  const { isAuthenticated } = useConvexAuth();
-  const { activeMembers, isLoading } = useOrganizationMembers({
-    isAuthenticated,
-    organizationId,
-  });
+  const { isAuthenticated, isLoading: isAuthLoading } = useConvexAuth();
+  const { activeMembers, isLoading: isMembersLoading } = useOrganizationMembers(
+    {
+      isAuthenticated,
+      organizationId,
+    }
+  );
 
   const recipients = useMemo(
     () =>
@@ -36,5 +38,8 @@ export function useUpgradeRequestRecipients(organizationId: string | null): {
     [activeMembers]
   );
 
-  return { recipients, isLoading };
+  // While Convex auth resolves, isAuthenticated is temporarily false and the
+  // members query is skipped. Keep the result pending so callers do not treat
+  // that temporary empty list as a settled "no owner" result.
+  return { recipients, isLoading: isAuthLoading || isMembersLoading };
 }

--- a/mcpjam-inspector/client/src/hooks/useCreditTopup.ts
+++ b/mcpjam-inspector/client/src/hooks/useCreditTopup.ts
@@ -211,12 +211,6 @@ export function useCreditTopup() {
     }: StartCheckoutInput): Promise<void> => {
       setIsStartingCheckout(true);
       setError(null);
-      track("credit_topup_checkout_started", {
-        location: "credit_topup",
-        package_id: packageId,
-        price_cents: priceCents,
-        source,
-      });
       stashPendingTopup({ chatSessionId, message: lastUserMessage });
       // Track the most specific failure category we know about. Defaults to
       // `action_threw` (the fallback when the Convex action itself rejects)
@@ -224,11 +218,25 @@ export function useCreditTopup() {
       let errorKind: "missing_url" | "invalid_url" | "action_threw" =
         "action_threw";
       try {
-        const result = (await createCheckoutSession({
+        // Begin the real checkout action first. Product analytics is emitted
+        // without being awaited and cannot block or break the checkout.
+        const checkoutPromise = createCheckoutSession({
           organizationId,
           packageId,
           ...(returnUrl ? { returnUrl } : {}),
-        } as any)) as { checkoutUrl?: string } | null;
+        } as any);
+        track("credit_topup_checkout_started", {
+          location: "credit_topup",
+          organization_id: organizationId,
+          package_id: packageId,
+          price_cents: priceCents,
+          source,
+          has_resume_context: Boolean(chatSessionId && lastUserMessage),
+          has_return_url: Boolean(returnUrl),
+        });
+        const result = (await checkoutPromise) as {
+          checkoutUrl?: string;
+        } | null;
         const checkoutUrl = result?.checkoutUrl;
         if (typeof checkoutUrl !== "string" || checkoutUrl.length === 0) {
           errorKind = "missing_url";
@@ -242,18 +250,20 @@ export function useCreditTopup() {
         }
         window.location.assign(checkoutUrl);
       } catch (err) {
-        track("credit_topup_checkout_failed", {
-          location: "credit_topup",
-          package_id: packageId,
-          price_cents: priceCents,
-          error_kind: errorKind,
-          source,
-        });
         clearPendingTopup();
 
         const message =
           err instanceof Error ? err.message : "Failed to start checkout";
         setError(message);
+        track("credit_topup_checkout_failed", {
+          location: "credit_topup",
+          organization_id: organizationId,
+          package_id: packageId,
+          price_cents: priceCents,
+          error_kind: errorKind,
+          error_name: err instanceof Error ? err.name : "unknown",
+          source,
+        });
         throw err;
       } finally {
         setIsStartingCheckout(false);

--- a/mcpjam-inspector/client/src/lib/__tests__/analytics.test.ts
+++ b/mcpjam-inspector/client/src/lib/__tests__/analytics.test.ts
@@ -1,19 +1,26 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
 
-const { captureMock } = vi.hoisted(() => ({ captureMock: vi.fn() }));
-vi.mock("posthog-js", () => ({ default: { capture: captureMock } }));
-vi.mock("../PosthogUtils", () => ({
-  standardEventProps: (location: string) => ({
+const { captureMock, standardEventPropsMock } = vi.hoisted(() => ({
+  captureMock: vi.fn(),
+  standardEventPropsMock: vi.fn((location: string) => ({
     location,
     platform: "web",
     environment: "test",
-  }),
+  })),
+}));
+vi.mock("posthog-js", () => ({ default: { capture: captureMock } }));
+vi.mock("../PosthogUtils", () => ({
+  standardEventProps: standardEventPropsMock,
 }));
 
 import { track } from "../analytics";
 
 describe("track()", () => {
-  afterEach(() => captureMock.mockClear());
+  afterEach(() => {
+    captureMock.mockClear();
+    standardEventPropsMock.mockClear();
+    vi.restoreAllMocks();
+  });
 
   it("injects standard props from the location argument", () => {
     track("skill_viewed", { location: "skills_tab", skill_name: "x" });
@@ -38,13 +45,36 @@ describe("track()", () => {
   });
 
   it("never lets a capture failure break the product action", () => {
+    const error = new Error("analytics unavailable");
+    const warnMock = vi.spyOn(console, "warn").mockImplementation(() => {});
     captureMock.mockImplementationOnce(() => {
-      throw new Error("analytics unavailable");
+      throw error;
     });
 
     expect(() =>
       track("skill_viewed", { location: "skills_tab", skill_name: "x" })
     ).not.toThrow();
+    expect(warnMock).toHaveBeenCalledWith(
+      "[analytics] Failed to capture skill_viewed",
+      error
+    );
+  });
+
+  it("reports a standard-property failure without breaking the product action", () => {
+    const error = new Error("event context unavailable");
+    const warnMock = vi.spyOn(console, "warn").mockImplementation(() => {});
+    standardEventPropsMock.mockImplementationOnce(() => {
+      throw error;
+    });
+
+    expect(() =>
+      track("skill_viewed", { location: "skills_tab", skill_name: "x" })
+    ).not.toThrow();
+    expect(captureMock).not.toHaveBeenCalled();
+    expect(warnMock).toHaveBeenCalledWith(
+      "[analytics] Failed to capture skill_viewed",
+      error
+    );
   });
 
   it("strips a caller-supplied environment so it can't survive when standardEventProps omits it", async () => {

--- a/mcpjam-inspector/client/src/lib/__tests__/analytics.test.ts
+++ b/mcpjam-inspector/client/src/lib/__tests__/analytics.test.ts
@@ -37,6 +37,16 @@ describe("track()", () => {
     expect(props.location).toBe("skills_tab");
   });
 
+  it("never lets a capture failure break the product action", () => {
+    captureMock.mockImplementationOnce(() => {
+      throw new Error("analytics unavailable");
+    });
+
+    expect(() =>
+      track("skill_viewed", { location: "skills_tab", skill_name: "x" })
+    ).not.toThrow();
+  });
+
   it("strips a caller-supplied environment so it can't survive when standardEventProps omits it", async () => {
     // Regression for the self-hosted/dev case: standardEventProps() omits
     // `environment` when VITE_ENVIRONMENT is unset, so a caller-supplied

--- a/mcpjam-inspector/client/src/lib/__tests__/billing-entitlements.test.ts
+++ b/mcpjam-inspector/client/src/lib/__tests__/billing-entitlements.test.ts
@@ -107,21 +107,27 @@ describe("getBillingErrorMessage", () => {
     expect(message).toMatch(
       /^This organization has reached its eval iteration limit \(25\)\. Resets /
     );
-    expect(message).toMatch(/Upgrade to continue now\.$/);
+    // The 402 payload doesn't say who is reading, and this toast reaches
+    // members too. No next step beats naming one they can't take.
+    expect(message).not.toMatch(/Upgrade to continue now/);
+    expect(message).not.toMatch(/Ask an organization owner/);
   });
 
-  it("points members to an owner after naming the eval reset", () => {
-    const message = formatBillingLimitReachedMessage(
-      "maxEvalIterationsPerMonth",
-      25,
-      false,
-      { resetsAt: Date.UTC(2026, 5, 2), windowKind: "day" }
-    );
+  it("keeps the eval reset message role-neutral for either reader", () => {
+    // A capped-until-reset message names no next step for anyone: the owner
+    // doesn't need one, and the member can't act on the one we'd give them.
+    for (const canManageBilling of [true, false]) {
+      const message = formatBillingLimitReachedMessage(
+        "maxEvalIterationsPerMonth",
+        25,
+        canManageBilling,
+        { resetsAt: Date.UTC(2026, 5, 2), windowKind: "day" }
+      );
 
-    expect(message).toMatch(/Resets /);
-    expect(message).toMatch(
-      /Ask an organization owner to upgrade to continue now\.$/
-    );
+      expect(message).toMatch(/Resets /);
+      expect(message).not.toMatch(/Upgrade to continue now/);
+      expect(message).not.toMatch(/Ask an organization owner/);
+    }
   });
 
   it("ignores invalid eval reset timestamps", () => {

--- a/mcpjam-inspector/client/src/lib/__tests__/billing-entitlements.test.ts
+++ b/mcpjam-inspector/client/src/lib/__tests__/billing-entitlements.test.ts
@@ -107,6 +107,21 @@ describe("getBillingErrorMessage", () => {
     expect(message).toMatch(
       /^This organization has reached its eval iteration limit \(25\)\. Resets /
     );
+    expect(message).toMatch(/Upgrade to continue now\.$/);
+  });
+
+  it("points members to an owner after naming the eval reset", () => {
+    const message = formatBillingLimitReachedMessage(
+      "maxEvalIterationsPerMonth",
+      25,
+      false,
+      { resetsAt: Date.UTC(2026, 5, 2), windowKind: "day" }
+    );
+
+    expect(message).toMatch(/Resets /);
+    expect(message).toMatch(
+      /Ask an organization owner to upgrade to continue now\.$/
+    );
   });
 
   it("ignores invalid eval reset timestamps", () => {

--- a/mcpjam-inspector/client/src/lib/__tests__/billing-entitlements.test.ts
+++ b/mcpjam-inspector/client/src/lib/__tests__/billing-entitlements.test.ts
@@ -6,6 +6,7 @@ import {
   formatPremiumnessGateKey,
   getBillingErrorMessage,
   getDisplayPriceCentsForPlan,
+  getEvalIterationLimitFromError,
   getPremiumnessGateForTab,
   getRequiredBillingFeatureForTab,
   isGateAccessDenied,
@@ -555,5 +556,68 @@ describe("formatPremiumnessGateKey", () => {
     for (const key of gateKeys) {
       expect(formatPremiumnessGateKey(key), key).not.toBe(key);
     }
+  });
+});
+
+describe("getEvalIterationLimitFromError", () => {
+  const evalLimitError = (extra: Record<string, unknown>) =>
+    new ConvexError({
+      code: "billing_limit_reached",
+      limit: "maxEvalIterationsPerMonth",
+      allowedValue: 25,
+      currentValue: 25,
+      ...extra,
+    } as never);
+
+  it("takes the window the backend sent, on either plan", () => {
+    expect(
+      getEvalIterationLimitFromError(
+        evalLimitError({ plan: "free", windowKind: "day" })
+      )?.windowKind
+    ).toBe("day");
+    expect(
+      getEvalIterationLimitFromError(
+        evalLimitError({ plan: "team", windowKind: "month" })
+      )?.windowKind
+    ).toBe("month");
+  });
+
+  it("falls back to the plan when the payload omits the window", () => {
+    // One limit NAME, two windows — daily on Free, monthly per seat on Team —
+    // and the wall prints the word ("out of eval iterations today" vs "this
+    // month"). A constant would be wrong for one of the two plans every time,
+    // and wrong toward "month" is the costlier direction: it sells a wait that
+    // ends at the next UTC roll as a month-long block.
+    expect(
+      getEvalIterationLimitFromError(evalLimitError({ plan: "free" }))
+        ?.windowKind
+    ).toBe("day");
+    expect(
+      getEvalIterationLimitFromError(evalLimitError({ plan: "team" }))
+        ?.windowKind
+    ).toBe("month");
+  });
+
+  it("keeps the narrower claim when neither window nor plan is known", () => {
+    expect(getEvalIterationLimitFromError(evalLimitError({}))?.windowKind).toBe(
+      "day"
+    );
+    expect(
+      getEvalIterationLimitFromError(evalLimitError({ windowKind: "week" }))
+        ?.windowKind
+    ).toBe("day");
+  });
+
+  it("ignores errors that are not this cap", () => {
+    expect(
+      getEvalIterationLimitFromError(
+        new ConvexError({
+          code: "billing_limit_reached",
+          limit: "insightsPerDay",
+          allowedValue: 25,
+        } as never)
+      )
+    ).toBeNull();
+    expect(getEvalIterationLimitFromError(new Error("boom"))).toBeNull();
   });
 });

--- a/mcpjam-inspector/client/src/lib/analytics.ts
+++ b/mcpjam-inspector/client/src/lib/analytics.ts
@@ -42,8 +42,11 @@ export function track(
   } = props;
   try {
     posthog.capture(event, { ...rest, ...standardEventProps(location) });
-  } catch {
+  } catch (error) {
     // Product analytics is best-effort. Ad blockers, initialization races, or
     // an SDK failure must never stop the user action that emitted the event.
+    // Keep the failure observable without including event props, which may
+    // contain sensitive product data.
+    console.warn(`[analytics] Failed to capture ${event}`, error);
   }
 }

--- a/mcpjam-inspector/client/src/lib/analytics.ts
+++ b/mcpjam-inspector/client/src/lib/analytics.ts
@@ -17,12 +17,15 @@ import { standardEventProps } from "./PosthogUtils";
  *
  * The posthog-js singleton is the same instance PostHogProvider initializes
  * (the provider is given an apiKey, which inits the global instance), and it
- * already honors VITE_DISABLE_POSTHOG_LOCAL via opt_out_capturing_by_default
- * — no disabled-state branching needed here.
+ * inherits the rich person created by usePostHogIdentify (WorkOS id, email,
+ * name, occupation, and deployment). Keep PII on that person profile instead
+ * of copying it onto every event payload.
+ * The client also honors VITE_DISABLE_POSTHOG_LOCAL via
+ * opt_out_capturing_by_default — no disabled-state branching needed here.
  */
 export function track(
   event: ClientAnalyticsEventName,
-  props: Record<string, unknown> & { location?: string } = {},
+  props: Record<string, unknown> & { location?: string } = {}
 ): void {
   // Drop platform/environment from the caller's props rather than relying
   // on spread order alone: standardEventProps() OMITS `environment` when
@@ -37,5 +40,10 @@ export function track(
     environment: _environment,
     ...rest
   } = props;
-  posthog.capture(event, { ...rest, ...standardEventProps(location) });
+  try {
+    posthog.capture(event, { ...rest, ...standardEventProps(location) });
+  } catch {
+    // Product analytics is best-effort. Ad blockers, initialization races, or
+    // an SDK failure must never stop the user action that emitted the event.
+  }
 }

--- a/mcpjam-inspector/client/src/lib/apis/evals-api.ts
+++ b/mcpjam-inspector/client/src/lib/apis/evals-api.ts
@@ -282,8 +282,14 @@ function mergeHostedServerBatch<
  * by the buffered (`postEvalRequest`) and streamed (`streamEvalTestCase`) eval
  * paths so single-case compare runs surface the same billing UX. No-op unless
  * the payload is a billing cap.
+ *
+ * Exported because the replay endpoint is called with a hand-rolled fetch
+ * rather than `postEvalRequest`: without this the raw response body is thrown
+ * whole, and the billing parser reads the outer envelope (`BILLING_LIMIT_
+ * REACHED`) instead of the payload nested under `details` — so a cap there
+ * looked like an ordinary failure.
  */
-function rethrowIfBillingError(errorBody: unknown): void {
+export function rethrowIfBillingError(errorBody: unknown): void {
   const billingPayload = (
     errorBody as { details?: { code?: unknown } } | null | undefined
   )?.details;

--- a/mcpjam-inspector/client/src/lib/billing-entitlements.ts
+++ b/mcpjam-inspector/client/src/lib/billing-entitlements.ts
@@ -440,7 +440,23 @@ export function getEvalIterationLimitFromError(
     allowed,
     used,
     resetsAt: typeof payload.resetsAt === "number" ? payload.resetsAt : null,
-    windowKind: payload.windowKind === "month" ? "month" : "day",
+    // One limit NAME, two windows: the backend enforces `maxEvalIterationsPerMonth`
+    // as a DAILY cap on Free and a MONTHLY per-seat allowance on Team, and says
+    // which through `windowKind`. The wall renders that word literally ("out of
+    // eval iterations today" vs "this month"), so a payload that omits the field
+    // must not be answered with a constant: hardcoding "month" would tell a Free
+    // user a cap that lifts at the next UTC roll is a month-long block — a wait
+    // sold as an upgrade — and hardcoding "day" mislabels the Team allowance.
+    // The plan is the field the window is derived FROM, so fall back to it; it
+    // also survives payload paths that drop `windowKind` (the v1 route's
+    // `billingDetails` allowlist keeps `plan` and not `windowKind`). Unknown plan
+    // stays "day", the narrower claim: it never overstates how long the block lasts.
+    windowKind:
+      payload.windowKind === "month" || payload.windowKind === "day"
+        ? payload.windowKind
+        : payload.plan === "team" || payload.plan === "enterprise"
+        ? "month"
+        : "day",
   };
 }
 

--- a/mcpjam-inspector/client/src/lib/billing-entitlements.ts
+++ b/mcpjam-inspector/client/src/lib/billing-entitlements.ts
@@ -402,6 +402,48 @@ export function isComputerStartLimitError(error: unknown): boolean {
   return (payload.limitName ?? payload.limit) === "computerStartsPerDay";
 }
 
+export interface EvalIterationLimitError {
+  allowed: number | null;
+  used: number;
+  resetsAt: number | null;
+  windowKind: "day" | "month";
+}
+
+/**
+ * The server is the authority on the eval-iteration cap. The client's quota
+ * query can be stale — a teammate spending the last iterations while this user
+ * sits on the Run button — so a run can clear the pre-check and still be
+ * rejected. Detected here so that rejection can reach the same upgrade wall as
+ * the pre-check instead of the dead-end toast the wall replaced.
+ */
+export function getEvalIterationLimitFromError(
+  error: unknown
+): EvalIterationLimitError | null {
+  const payload = extractBillingErrorPayload(error);
+  if (!payload || payload.code !== "billing_limit_reached") {
+    return null;
+  }
+  if ((payload.limitName ?? payload.limit) !== "maxEvalIterationsPerMonth") {
+    return null;
+  }
+
+  const allowed =
+    typeof payload.allowedValue === "number" ? payload.allowedValue : null;
+  const used =
+    typeof payload.currentValue === "number"
+      ? payload.currentValue
+      : typeof payload.current === "number"
+      ? payload.current
+      : allowed ?? 0;
+
+  return {
+    allowed,
+    used,
+    resetsAt: typeof payload.resetsAt === "number" ? payload.resetsAt : null,
+    windowKind: payload.windowKind === "month" ? "month" : "day",
+  };
+}
+
 export function getBillingErrorMessage(
   error: unknown,
   fallback: string,

--- a/mcpjam-inspector/client/src/main.tsx
+++ b/mcpjam-inspector/client/src/main.tsx
@@ -38,6 +38,7 @@ import {
   readCallbackParams,
   readPendingAuthorization,
 } from "./lib/server-connection-handoff";
+import { PlanLimitDialogPreview } from "./components/billing/PlanLimitDialogPreview";
 import {
   getInitialThemeMode,
   getInitialThemePreset,
@@ -230,6 +231,24 @@ if (isInIframe) {
       >
         <ServerConnectionHandoff />
       </AuthKitProvider>
+    </StrictMode>
+  );
+} else if (
+  import.meta.env.DEV &&
+  window.location.pathname.startsWith("/__preview/plan-limit")
+) {
+  // Dev-only design harness for the free-plan limit wall. Mounted here, ahead
+  // of AuthKit and Convex, because the states worth reviewing (member who
+  // can't upgrade, org already at its Team ceiling) can't be produced on
+  // demand against a real backend. Renders the real component and the real
+  // stylesheet with dummy data. The DEV guard keeps it out of production
+  // bundles entirely.
+  updateThemeMode(getInitialThemeMode());
+  updateThemePreset(getInitialThemePreset());
+  const root = createRoot(document.getElementById("root")!);
+  root.render(
+    <StrictMode>
+      <PlanLimitDialogPreview />
     </StrictMode>
   );
 } else if (isDebugOAuthCallbackPath(window.location.pathname)) {

--- a/mcpjam-inspector/client/src/stores/plan-limit-dialog-store.ts
+++ b/mcpjam-inspector/client/src/stores/plan-limit-dialog-store.ts
@@ -1,0 +1,34 @@
+import { create } from "zustand";
+
+/**
+ * Which free-plan cap the user just hit. Only `evalIterations` is wired for
+ * now — the credits wall still routes to `MCPJamLimitDialog` (top-up/BYOK)
+ * until we decide whether upgrade should lead there too.
+ */
+export type PlanLimitKind = "evalIterations";
+
+export interface PlanLimitDialogInput {
+  kind: PlanLimitKind;
+  organizationId: string;
+  used: number;
+  allowed: number | null;
+  resetsAt: number | null;
+  windowKind: "day" | "month";
+  /** Where the user was blocked. Sent to telemetry; also the surface the
+   * post-checkout return lands back on. */
+  origin: string;
+}
+
+interface PlanLimitDialogState {
+  isOpen: boolean;
+  limit: PlanLimitDialogInput | null;
+  open: (input: PlanLimitDialogInput) => void;
+  close: () => void;
+}
+
+export const usePlanLimitDialogStore = create<PlanLimitDialogState>((set) => ({
+  isOpen: false,
+  limit: null,
+  open: (limit) => set({ isOpen: true, limit }),
+  close: () => set({ isOpen: false, limit: null }),
+}));

--- a/mcpjam-inspector/shared/analytics-events.ts
+++ b/mcpjam-inspector/shared/analytics-events.ts
@@ -268,6 +268,7 @@ export const ANALYTICS_EVENTS = {
   plan_limit_interval_selected: { source: "client" },
   plan_limit_upgrade_clicked: { source: "client" },
   plan_limit_upgrade_failed: { source: "client" },
+  plan_limit_upgrade_resolved: { source: "client" },
   plan_limit_upgrade_returned: { source: "client" },
   plan_limit_dialog_dismissed: { source: "client" },
   plan_limit_enterprise_cta_clicked: { source: "client" },

--- a/mcpjam-inspector/shared/analytics-events.ts
+++ b/mcpjam-inspector/shared/analytics-events.ts
@@ -257,15 +257,24 @@ export const ANALYTICS_EVENTS = {
   playground_tools_pane_tab_changed: { source: "client" },
   playground_tools_refresh_clicked: { source: "client" },
   // --- Free-plan limit walls (PlanLimitDialog) ---
-  // `limit_kind` distinguishes which cap was hit so we can compare which wall
-  // converts. `plan_limit_upgrade_returned` fires on the post-checkout return
-  // and carries whether the org actually landed on a paid plan.
+  // One impression per opening, then explicit user actions and checkout
+  // outcomes. `limit_kind` distinguishes which cap was hit so we can compare
+  // which wall converts. Person data comes from the global identified profile,
+  // not duplicated PII in these events.
   plan_limit_dialog_shown: { source: "client" },
+  plan_limit_sign_in_clicked: { source: "client" },
+  plan_limit_buy_credits_clicked: { source: "client" },
+  plan_limit_byok_clicked: { source: "client" },
+  plan_limit_interval_selected: { source: "client" },
   plan_limit_upgrade_clicked: { source: "client" },
+  plan_limit_upgrade_failed: { source: "client" },
   plan_limit_upgrade_returned: { source: "client" },
   plan_limit_dialog_dismissed: { source: "client" },
   plan_limit_enterprise_cta_clicked: { source: "client" },
   plan_limit_upgrade_requested: { source: "client" },
+  credit_topup_dialog_shown: { source: "client" },
+  credit_topup_package_selected: { source: "client" },
+  credit_topup_dialog_dismissed: { source: "client" },
   // --- OpenAI plugin import (Connect "Add plugin", INS-2) ---
   // Props are built by `client/src/lib/plugins/plugin-analytics.ts`, which
   // exists to keep bundle paths, server URLs, env/header names, and plugin

--- a/mcpjam-inspector/shared/analytics-events.ts
+++ b/mcpjam-inspector/shared/analytics-events.ts
@@ -256,6 +256,15 @@ export const ANALYTICS_EVENTS = {
   playground_tool_run_clicked: { source: "client" },
   playground_tools_pane_tab_changed: { source: "client" },
   playground_tools_refresh_clicked: { source: "client" },
+  // --- Free-plan limit walls (PlanLimitDialog) ---
+  // `limit_kind` distinguishes which cap was hit so we can compare which wall
+  // converts. `plan_limit_upgrade_returned` fires on the post-checkout return
+  // and carries whether the org actually landed on a paid plan.
+  plan_limit_dialog_shown: { source: "client" },
+  plan_limit_upgrade_clicked: { source: "client" },
+  plan_limit_upgrade_returned: { source: "client" },
+  plan_limit_dialog_dismissed: { source: "client" },
+  plan_limit_enterprise_cta_clicked: { source: "client" },
   // --- OpenAI plugin import (Connect "Add plugin", INS-2) ---
   // Props are built by `client/src/lib/plugins/plugin-analytics.ts`, which
   // exists to keep bundle paths, server URLs, env/header names, and plugin

--- a/mcpjam-inspector/shared/analytics-events.ts
+++ b/mcpjam-inspector/shared/analytics-events.ts
@@ -265,6 +265,7 @@ export const ANALYTICS_EVENTS = {
   plan_limit_upgrade_returned: { source: "client" },
   plan_limit_dialog_dismissed: { source: "client" },
   plan_limit_enterprise_cta_clicked: { source: "client" },
+  plan_limit_upgrade_requested: { source: "client" },
   // --- OpenAI plugin import (Connect "Add plugin", INS-2) ---
   // Props are built by `client/src/lib/plugins/plugin-analytics.ts`, which
   // exists to keep bundle paths, server URLs, env/header names, and plugin


### PR DESCRIPTION
This is #3892 (vignesh's limit-wall conversion, all 16 commits kept as-is) rebased onto latest main, with one commit on top fixing the review findings.

- Post-checkout returns now need a one-shot token from the tab that started checkout, so a shared or bookmarked link can't fake a purchase confirmation, fake a conversion, or crash-loop the app by feeding a URL org id into a Convex query.
- A Stripe webhook slower than 30s no longer records a real purchase as abandoned — the wait reports `settlement: "pending"` and a late plan flip still confirms and corrects to `"late"`. Count conversions on immediate+late, not on `upgraded`.
- The Upgrade button waits for the plan catalog, so nobody reaches Stripe on a price they were never shown.
- On desktop, checkout opens in the browser on purpose and the dialog closes, instead of hanging behind a navigation Electron cancels.
- Server-side quota rejections open the same wall as the client pre-check, instead of the old dead-end toast.
- Enterprise orgs no longer get an "upgrade us to Team" mail draft; free-org admins get the credits path plus a way to ask an owner; neither wall shows plan-specific copy until billing resolves.

The role-neutral limit message finding was already fixed on main by the shared `resetsSentence` helper, so that part is main's version, not mine.

Verified: `typecheck:client` clean, full client suite 9098 passing / 0 failing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Converts free-plan limit walls into upgrade decision surfaces and routes server-side 402s to the same wall. Checkout returns are now safe and deterministic: bound to the buyer with a one‑shot ticket scoped by user, gated during render, and confirmed only after billing shows a paid plan.

- Dialog and routing: mounts PlanLimitDialog at app root; client pre‑checks and server 402s open the same wall via the `plan-limit-dialog` store. Evals/Runs/CI pass `organizationId`; replay and fan‑out scan failures, prefer caps over 409s, and dismiss optimistic “Run started” toasts on cap paths.
- Upgrade checkout: `use-upgrade-checkout` arms a sessionStorage return ticket scoped by user id in the key (no ids in values), strips URL params, and confirms only when the plan flips; late webhooks reconcile to “late.” The ticket retires on identity change, disarms on sign‑out, and is gated during render. Desktop opens Stripe externally. Interval cards show only priced, supported cadences; users select then confirm via `UpgradeIntervalPicker`, and the CTA waits for the catalog.
- Credits wall and copy: upgrade is primary, buy credits secondary, BYOK a link. Copy states credits don’t change plan limits; out‑of‑credits messaging updated. Impression/dismissal telemetry de‑duped.
- Roles and requests: non‑managers get “Email your owner” via `RequestUpgradeButton` (RFC‑6068‑safe mailto); Enterprise routes to Contact. Reset messages stay role‑neutral. Pitch/confirmation copy now says “The Team plan…” / “You’re on the Team plan.”
- Catalog and compare: eval limits read from the plan catalog; the compare table renders evals as “/ seat / mo” to match billing.
- Server API and telemetry: exports `rethrowIfBillingError` for replay; adds `plan_limit_*` events with standard props.
- Preview and tests: dev‑only `/__preview/plan-limit` renders eval and credits walls with dummy data. Tests cover return‑ticket scoping, persistence and buyer binding, sign‑out disarm and render‑time gating, desktop checkout, interval guards, server‑reject wall path (including replay, fan‑out, and toast dismissal), mailto encoding, dialog dismissal, analytics, and compare‑table limits.

<sup>Written for commit 567641b0133b990bcf9fc3e8887fc78e9b49ccdc. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/MCPJam/inspector/pull/4052?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

