### PR TITLE
Keep OAuth failure diagnostics visible

### DIFF
--- a/.changeset/calm-pandas-display.md
+++ b/.changeset/calm-pandas-display.md
@@ -1,0 +1,5 @@
+---
+"@mcpjam/sdk": patch
+---
+
+Keep the OAuth sequence diagram visible when a server advertises an invalid protected-resource metadata URL.

--- a/.changeset/calm-pandas-display.md
+++ b/.changeset/calm-pandas-display.md
@@ -3,4 +3,4 @@
 "@mcpjam/inspector": patch
 ---
 
-Keep OAuth diagnostics visible when a server advertises an invalid protected-resource metadata URL or rejects an authorization code with `invalid_grant`.
+Keep OAuth diagnostics visible when a server advertises a metadata URL that is not absolute — the protected-resource URL or an authorization-server endpoint — and when it rejects an authorization code with `invalid_grant`. The sequence diagram now marks the unparsable value instead of crashing, and the token-exchange error keeps the authorization server's own explanation.

--- a/.changeset/calm-pandas-display.md
+++ b/.changeset/calm-pandas-display.md
@@ -1,5 +1,6 @@
 ---
 "@mcpjam/sdk": patch
+"@mcpjam/inspector": patch
 ---
 
-Keep the OAuth sequence diagram visible when a server advertises an invalid protected-resource metadata URL.
+Keep OAuth diagnostics visible when a server advertises an invalid protected-resource metadata URL or rejects an authorization code with `invalid_grant`.

--- a/mcpjam-inspector/client/src/lib/hosted-oauth-failure.ts
+++ b/mcpjam-inspector/client/src/lib/hosted-oauth-failure.ts
@@ -28,13 +28,27 @@ const METADATA_FAILURE =
   /HTTP (\d{3}) trying to load (?:OAuth|OpenID provider) metadata from (\S+?)(?:\s+\(([^)]*)\))?\s*$/i;
 
 /**
+ * The `invalid_grant` family, in every spelling that reaches a client: the
+ * RFC 6749 code itself, the hyphen/space variants a hand-written server emits,
+ * and the `InvalidGrantError` class name a Convex action throws.
+ *
+ * Exported because {@link import("./oauth/mcp-oauth").formatOAuthCallbackError}
+ * classifies the same family on the callback path. One pattern, so extending
+ * either classifier cannot leave the other behind.
+ */
+export const INVALID_GRANT_PATTERN =
+  /invalid[_\s-]?grant|InvalidGrantError/i;
+
+/**
  * The token endpoint answered, and the answer was "no". The invalid_client
  * family belongs here: a registration the server has disowned can never
  * refresh, and re-running authorize (which re-registers) is the fix, same as
  * for a dead refresh token.
  */
-const DECLINED =
-  /invalid[_\s-]?grant|InvalidGrantError|refresh[_\s-]?token[_\s-]?not[_\s-]?found|token is not active|expired (?:access\/)?refresh token|invalid[_\s-]?client|InvalidClientError|unknown client|client authentication failed/i;
+const DECLINED = new RegExp(
+  `${INVALID_GRANT_PATTERN.source}|refresh[_\\s-]?token[_\\s-]?not[_\\s-]?found|token is not active|expired (?:access\\/)?refresh token|invalid[_\\s-]?client|InvalidClientError|unknown client|client authentication failed`,
+  "i"
+);
 
 /**
  * What the backend recorded off the authorization server's failing response.

--- a/mcpjam-inspector/client/src/lib/oauth/__tests__/mcp-oauth.hosted-session.test.ts
+++ b/mcpjam-inspector/client/src/lib/oauth/__tests__/mcp-oauth.hosted-session.test.ts
@@ -132,6 +132,64 @@ describe("mcp-oauth hosted callback sessions", () => {
     });
   });
 
+  it("records and returns the same formatted hosted callback error", async () => {
+    authFetchMock.mockImplementation((url: string) => {
+      if (url === "https://test.convex.site/web/oauth/session/progress") {
+        return Promise.resolve(
+          new Response(JSON.stringify({ success: false, error: "not found" }), {
+            status: 404,
+            headers: { "Content-Type": "application/json" },
+          })
+        );
+      }
+
+      if (url === "https://test.convex.site/web/oauth/complete") {
+        return Promise.resolve(
+          new Response(
+            JSON.stringify({
+              success: false,
+              error:
+                "Uncaught InvalidGrantError: Token is not active\n    at async exchangeGenericAuthorizationCode",
+            }),
+            {
+              status: 400,
+              headers: { "Content-Type": "application/json" },
+            }
+          )
+        );
+      }
+
+      throw new Error(`Unexpected authFetch URL: ${url}`);
+    });
+
+    const { completeHostedOAuthCallback } = await import("../mcp-oauth");
+    const result = await completeHostedOAuthCallback(
+      {
+        surface: "project",
+        projectId: "ws_1",
+        serverId: "srv_asana",
+        serverName: "asana",
+        serverUrl: "https://mcp.asana.com/sse",
+        sessionId: "hosted-session-1",
+        accessScope: "project_member",
+        scenarioId: null,
+        returnPath: "#servers",
+        startedAt: Date.now(),
+      },
+      "oauth-code",
+      { callbackState: "oauth-state-1" }
+    );
+
+    const expectedError =
+      "OAuth token exchange failed (invalid_grant): the authorization server rejected the authorization code. Check whether the code expired or was reused, and whether the redirect URI, client ID, and PKCE verifier match. Server response: Token is not active";
+    expect(result.success).toBe(false);
+    expect(result.error).toBe(expectedError);
+    expect(result.oauthTrace?.error).toBe(expectedError);
+    expect(
+      result.oauthTrace?.steps.find((step) => step.status === "error")?.error
+    ).toBe(expectedError);
+  });
+
   it("uses the flow session version for sessionless completion and reconnect", async () => {
     storeSessionless2026Flow();
     authFetchMock.mockResolvedValue(

--- a/mcpjam-inspector/client/src/lib/oauth/__tests__/mcp-oauth.test.ts
+++ b/mcpjam-inspector/client/src/lib/oauth/__tests__/mcp-oauth.test.ts
@@ -4,36 +4,7 @@
  * Tests for the OAuth fetch interceptor and persisted discovery state.
  */
 
-import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-
-describe("formatOAuthCallbackError", () => {
-  const invalidGrantMessage =
-    "OAuth token exchange failed (invalid_grant): the authorization server rejected the authorization code. Check whether the code expired or was reused, and whether the redirect URI, client ID, and PKCE verifier match.";
-  const invalidClientMessage =
-    "Invalid client ID during token exchange. Please verify the client ID is correctly registered.";
-
-  it.each<[unknown, string]>([
-    ["invalid_grant", invalidGrantMessage],
-    ["invalid-grant", invalidGrantMessage],
-    ["invalid grant", invalidGrantMessage],
-    ["Uncaught InvalidGrantError", invalidGrantMessage],
-    [
-      "Uncaught InvalidGrantError\n    at async exchangeGenericAuthorizationCode",
-      invalidGrantMessage,
-    ],
-    [new Error("invalid_grant"), invalidGrantMessage],
-    [null, "Unknown callback error"],
-    ["", ""],
-    ["invalid_grant: client_id mismatch", invalidClientMessage],
-  ])(
-    "formats callback error context for %s",
-    async (error, expected) => {
-      const { formatOAuthCallbackError } = await import("../mcp-oauth");
-
-      expect(formatOAuthCallbackError(error)).toBe(expected);
-    }
-  );
-});
+import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 
 const {
   mockDiscoverAuthorizationServerMetadata,
@@ -2810,7 +2781,6 @@ describe("mcp-oauth", () => {
         expect.stringMatching(/\.convex\.site\/registry\/oauth\/token$/),
         expect.anything()
       );
-
     });
 
     it("uses the generic Inspector OAuth proxy for Linear-style registry callback token exchange", async () => {
@@ -2883,6 +2853,7 @@ describe("mcp-oauth", () => {
         expect.anything()
       );
     });
+
   });
 
   describe("MCPOAuthProvider.saveTokens convex binding", () => {
@@ -3449,5 +3420,71 @@ describe("evaluateCallbackSecurity (2R-iss callback gate)", () => {
         issParameterSupported: undefined,
       })
     ).toEqual({ ok: true });
+  });
+});
+
+describe("formatOAuthCallbackError", () => {
+  const invalidGrantMessage =
+    "OAuth token exchange failed (invalid_grant): the authorization server rejected the authorization code. Check whether the code expired or was reused, and whether the redirect URI, client ID, and PKCE verifier match.";
+
+  let formatOAuthCallbackError: typeof import("../mcp-oauth").formatOAuthCallbackError;
+
+  beforeAll(async () => {
+    ({ formatOAuthCallbackError } = await import("../mcp-oauth"));
+  });
+
+  it.each<[unknown, string]>([
+    ["invalid_grant", invalidGrantMessage],
+    ["invalid-grant", invalidGrantMessage],
+    ["invalid grant", invalidGrantMessage],
+    ["Uncaught InvalidGrantError", invalidGrantMessage],
+    [
+      "Uncaught InvalidGrantError\n    at async exchangeGenericAuthorizationCode",
+      invalidGrantMessage,
+    ],
+    [new Error("invalid_grant"), invalidGrantMessage],
+    [null, "Unknown callback error"],
+    ["", ""],
+  ])("formats callback error context for %s", (error, expected) => {
+    expect(formatOAuthCallbackError(error)).toBe(expected);
+  });
+
+  // The server's own words survive the canned copy. `describeTokenRequestFailure`
+  // appends `error_description` to the flow error precisely so the cause is
+  // readable, and it is the only part that names what actually went wrong.
+  it.each<[string, string]>([
+    ["invalid_grant: client_id mismatch", "client_id mismatch"],
+    [
+      "Token request failed: 400: invalid_grant: code was issued to another client_id",
+      "code was issued to another client_id",
+    ],
+    ["Uncaught InvalidGrantError: Token is not active", "Token is not active"],
+  ])("keeps the authorization server's reason for %s", (error, reason) => {
+    expect(formatOAuthCallbackError(error)).toBe(
+      `${invalidGrantMessage} Server response: ${reason}`
+    );
+  });
+
+  // A `client_id` mention inside an invalid_grant description must not
+  // reclassify the failure as a registration problem.
+  it("prefers invalid_grant over the client_id substring check", () => {
+    expect(
+      formatOAuthCallbackError("invalid_grant: client_id mismatch")
+    ).toContain("invalid_grant");
+  });
+
+  it("still reports genuine client errors", () => {
+    expect(formatOAuthCallbackError("invalid_client")).toBe(
+      "Invalid client ID during token exchange. Please verify the client ID is correctly registered."
+    );
+    expect(formatOAuthCallbackError("unauthorized_client")).toBe(
+      "Client not authorized for token exchange. The client ID may not match the one used for authorization."
+    );
+  });
+
+  it("reads a message off a plain error-shaped object", () => {
+    expect(formatOAuthCallbackError({ message: "invalid_grant" })).toBe(
+      invalidGrantMessage
+    );
   });
 });

--- a/mcpjam-inspector/client/src/lib/oauth/__tests__/mcp-oauth.test.ts
+++ b/mcpjam-inspector/client/src/lib/oauth/__tests__/mcp-oauth.test.ts
@@ -7,18 +7,30 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 describe("formatOAuthCallbackError", () => {
-  it.each([
-    "invalid_grant",
-    "Uncaught InvalidGrantError",
-    "Uncaught InvalidGrantError\n    at async exchangeGenericAuthorizationCode",
+  const invalidGrantMessage =
+    "OAuth token exchange failed (invalid_grant): the authorization server rejected the authorization code. Check whether the code expired or was reused, and whether the redirect URI, client ID, and PKCE verifier match.";
+  const invalidClientMessage =
+    "Invalid client ID during token exchange. Please verify the client ID is correctly registered.";
+
+  it.each<[unknown, string]>([
+    ["invalid_grant", invalidGrantMessage],
+    ["invalid-grant", invalidGrantMessage],
+    ["invalid grant", invalidGrantMessage],
+    ["Uncaught InvalidGrantError", invalidGrantMessage],
+    [
+      "Uncaught InvalidGrantError\n    at async exchangeGenericAuthorizationCode",
+      invalidGrantMessage,
+    ],
+    [new Error("invalid_grant"), invalidGrantMessage],
+    [null, "Unknown callback error"],
+    ["", ""],
+    ["invalid_grant: client_id mismatch", invalidClientMessage],
   ])(
-    "keeps the OAuth error code and adds token-exchange context: %s",
-    async (error) => {
+    "formats callback error context for %s",
+    async (error, expected) => {
       const { formatOAuthCallbackError } = await import("../mcp-oauth");
 
-      expect(formatOAuthCallbackError(error)).toBe(
-        "OAuth token exchange failed (invalid_grant): the authorization server rejected the authorization code. Check whether the code expired or was reused, and whether the redirect URI, client ID, and PKCE verifier match."
-      );
+      expect(formatOAuthCallbackError(error)).toBe(expected);
     }
   );
 });

--- a/mcpjam-inspector/client/src/lib/oauth/__tests__/mcp-oauth.test.ts
+++ b/mcpjam-inspector/client/src/lib/oauth/__tests__/mcp-oauth.test.ts
@@ -6,6 +6,23 @@
 
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
+describe("formatOAuthCallbackError", () => {
+  it.each([
+    "invalid_grant",
+    "Uncaught InvalidGrantError",
+    "Uncaught InvalidGrantError\n    at async exchangeGenericAuthorizationCode",
+  ])(
+    "keeps the OAuth error code and adds token-exchange context: %s",
+    async (error) => {
+      const { formatOAuthCallbackError } = await import("../mcp-oauth");
+
+      expect(formatOAuthCallbackError(error)).toBe(
+        "OAuth token exchange failed (invalid_grant): the authorization server rejected the authorization code. Check whether the code expired or was reused, and whether the redirect URI, client ID, and PKCE verifier match."
+      );
+    }
+  );
+});
+
 const {
   mockDiscoverAuthorizationServerMetadata,
   mockDiscoverOAuthServerInfo,
@@ -2781,6 +2798,7 @@ describe("mcp-oauth", () => {
         expect.stringMatching(/\.convex\.site\/registry\/oauth\/token$/),
         expect.anything()
       );
+
     });
 
     it("uses the generic Inspector OAuth proxy for Linear-style registry callback token exchange", async () => {
@@ -2853,7 +2871,6 @@ describe("mcp-oauth", () => {
         expect.anything()
       );
     });
-
   });
 
   describe("MCPOAuthProvider.saveTokens convex binding", () => {

--- a/mcpjam-inspector/client/src/lib/oauth/__tests__/mcp-oauth.test.ts
+++ b/mcpjam-inspector/client/src/lib/oauth/__tests__/mcp-oauth.test.ts
@@ -2852,8 +2852,8 @@ describe("mcp-oauth", () => {
         expect.stringMatching(/\.convex\.site\/registry\/oauth\/token$/),
         expect.anything()
       );
-    });
 
+    });
   });
 
   describe("MCPOAuthProvider.saveTokens convex binding", () => {
@@ -3426,6 +3426,7 @@ describe("evaluateCallbackSecurity (2R-iss callback gate)", () => {
 describe("formatOAuthCallbackError", () => {
   const invalidGrantMessage =
     "OAuth token exchange failed (invalid_grant): the authorization server rejected the authorization code. Check whether the code expired or was reused, and whether the redirect URI, client ID, and PKCE verifier match.";
+  const unknownCallbackMessage = "Unknown callback error";
 
   let formatOAuthCallbackError: typeof import("../mcp-oauth").formatOAuthCallbackError;
 
@@ -3443,8 +3444,14 @@ describe("formatOAuthCallbackError", () => {
       invalidGrantMessage,
     ],
     [new Error("invalid_grant"), invalidGrantMessage],
-    [null, "Unknown callback error"],
-    ["", ""],
+    ["Provider temporarily unavailable", "Provider temporarily unavailable"],
+    [null, unknownCallbackMessage],
+    [undefined, unknownCallbackMessage],
+    ["", unknownCallbackMessage],
+    [new Error(""), unknownCallbackMessage],
+    [{ message: "" }, unknownCallbackMessage],
+    [{ message: null }, unknownCallbackMessage],
+    [{ message: undefined }, unknownCallbackMessage],
   ])("formats callback error context for %s", (error, expected) => {
     expect(formatOAuthCallbackError(error)).toBe(expected);
   });

--- a/mcpjam-inspector/client/src/lib/oauth/mcp-oauth.ts
+++ b/mcpjam-inspector/client/src/lib/oauth/mcp-oauth.ts
@@ -2920,7 +2920,7 @@ export async function initiateOAuth(
   }
 }
 
-function formatOAuthCallbackError(error: unknown): string {
+export function formatOAuthCallbackError(error: unknown): string {
   const errorMessage =
     error instanceof Error
       ? error.message
@@ -2937,8 +2937,8 @@ function formatOAuthCallbackError(error: unknown): string {
   if (errorMessage.includes("unauthorized_client")) {
     return "Client not authorized for token exchange. The client ID may not match the one used for authorization.";
   }
-  if (errorMessage.includes("invalid_grant")) {
-    return "Authorization code invalid or expired. Please try the OAuth flow again.";
+  if (/invalid[_\s-]?grant|InvalidGrantError/i.test(errorMessage)) {
+    return "OAuth token exchange failed (invalid_grant): the authorization server rejected the authorization code. Check whether the code expired or was reused, and whether the redirect URI, client ID, and PKCE verifier match.";
   }
 
   return errorMessage;

--- a/mcpjam-inspector/client/src/lib/oauth/mcp-oauth.ts
+++ b/mcpjam-inspector/client/src/lib/oauth/mcp-oauth.ts
@@ -44,6 +44,7 @@ import {
   writeIssuerKeyed,
 } from "./issuer-keyed-storage";
 import { authFetch } from "@/lib/session-token";
+import { INVALID_GRANT_PATTERN } from "@/lib/hosted-oauth-failure";
 import { track } from "@/lib/analytics";
 import { HOSTED_MODE, SANITIZE_OAUTH_TRACES } from "@/lib/config";
 import {
@@ -2920,14 +2921,47 @@ export async function initiateOAuth(
   }
 }
 
+const INVALID_GRANT_COPY =
+  "OAuth token exchange failed (invalid_grant): the authorization server rejected the authorization code. Check whether the code expired or was reused, and whether the redirect URI, client ID, and PKCE verifier match.";
+
+/**
+ * The authorization server's own explanation, when the message carries one.
+ *
+ * `describeTokenRequestFailure` goes to some trouble to append the server's
+ * `error_description` to the flow error, so dropping it here would throw away
+ * the only part of the message that names the actual cause — "Token is not
+ * active" says something the canned copy cannot. Only the text right after the
+ * matched code is taken, and only from its first line: what follows a Convex
+ * `InvalidGrantError` is a stack, which is the noise this formatter exists to
+ * remove.
+ */
+function invalidGrantReason(message: string): string | undefined {
+  const match = message.match(
+    new RegExp(`(?:${INVALID_GRANT_PATTERN.source})\\s*[:-]\\s*(.+)`, "i")
+  );
+  const reason = match?.[1]?.split("\n")[0]?.trim();
+  return reason && !/^at\s/.test(reason) ? reason : undefined;
+}
+
 export function formatOAuthCallbackError(error: unknown): string {
   const errorMessage =
     error instanceof Error
       ? error.message
       : typeof error === "string"
       ? error
+      : error && typeof error === "object" && "message" in error
+      ? String((error as { message: unknown }).message)
       : "Unknown callback error";
 
+  // `invalid_grant` is tested FIRST because the `client_id` check below is a
+  // bare substring match, and the standard description for a rejected code
+  // ("was issued to another client_id") contains it. Ordered the other way,
+  // the most common token-exchange failure is reported as a registration
+  // problem and sends the user to re-check a client ID that is fine.
+  if (INVALID_GRANT_PATTERN.test(errorMessage)) {
+    const reason = invalidGrantReason(errorMessage);
+    return reason ? `${INVALID_GRANT_COPY} Server response: ${reason}` : INVALID_GRANT_COPY;
+  }
   if (
     errorMessage.includes("invalid_client") ||
     errorMessage.includes("client_id")
@@ -2936,9 +2970,6 @@ export function formatOAuthCallbackError(error: unknown): string {
   }
   if (errorMessage.includes("unauthorized_client")) {
     return "Client not authorized for token exchange. The client ID may not match the one used for authorization.";
-  }
-  if (/invalid[_\s-]?grant|InvalidGrantError/i.test(errorMessage)) {
-    return "OAuth token exchange failed (invalid_grant): the authorization server rejected the authorization code. Check whether the code expired or was reused, and whether the redirect URI, client ID, and PKCE verifier match.";
   }
 
   return errorMessage;
@@ -3690,6 +3721,9 @@ export async function handleOAuthCallback(
       oauthTrace: mergedRecoveryTrace,
     };
   } catch (error) {
+    // Classified once: the trace step and the returned error are the same
+    // failure, and formatting twice lets them drift apart.
+    const callbackError = formatOAuthCallbackError(error);
     const callbackTrace = buildOAuthTraceFromFlowState({
       source: "callback",
       serverName: serverName ?? undefined,
@@ -3701,7 +3735,7 @@ export async function handleOAuthCallback(
       state: {
         ...cloneEmptyFlowState(),
         currentStep: "received_authorization_code",
-        error: formatOAuthCallbackError(error),
+        error: callbackError,
       },
     });
     const mergedTrace = serverName
@@ -3712,7 +3746,7 @@ export async function handleOAuthCallback(
     }
     return {
       success: false,
-      error: formatOAuthCallbackError(error),
+      error: callbackError,
       oauthTrace: mergedTrace,
     };
   } finally {

--- a/mcpjam-inspector/client/src/lib/oauth/mcp-oauth.ts
+++ b/mcpjam-inspector/client/src/lib/oauth/mcp-oauth.ts
@@ -2944,14 +2944,19 @@ function invalidGrantReason(message: string): string | undefined {
 }
 
 export function formatOAuthCallbackError(error: unknown): string {
-  const errorMessage =
+  const rawMessage =
     error instanceof Error
       ? error.message
       : typeof error === "string"
       ? error
       : error && typeof error === "object" && "message" in error
-      ? String((error as { message: unknown }).message)
-      : "Unknown callback error";
+      ? (error as { message: unknown }).message
+      : undefined;
+  const errorMessage =
+    rawMessage == null ||
+    (typeof rawMessage === "string" && rawMessage.trim() === "")
+      ? "Unknown callback error"
+      : String(rawMessage);
 
   // `invalid_grant` is tested FIRST because the `client_id` check below is a
   // bare substring match, and the standard description for a rejected code
@@ -3272,16 +3277,8 @@ export async function completeHostedOAuthCallback(
       oauthResourceUrl,
     };
   } catch (error) {
-    const message =
-      error instanceof Error
-        ? error.message
-        : typeof error === "object" &&
-          error !== null &&
-          "message" in error &&
-          typeof (error as { message?: unknown }).message === "string"
-        ? (error as { message: string }).message
-        : String(error);
-    failOAuthTraceStep(callbackTrace, callbackTrace.currentStep, message, {
+    const callbackError = formatOAuthCallbackError(error);
+    failOAuthTraceStep(callbackTrace, callbackTrace.currentStep, callbackError, {
       message: "OAuth callback failed.",
     });
     const backendTrace =
@@ -3303,7 +3300,7 @@ export async function completeHostedOAuthCallback(
     }
     return {
       success: false,
-      error: formatOAuthCallbackError(message),
+      error: callbackError,
       oauthTrace: mergedTrace,
     };
   } finally {

--- a/sdk/src/oauth/state-machines/shared/sequence-diagram.ts
+++ b/sdk/src/oauth/state-machines/shared/sequence-diagram.ts
@@ -72,12 +72,18 @@ function truncate(value: string, length: number): string {
  * misconfiguration would look like a normal step; the suffix is what makes the
  * two distinguishable on screen.
  */
-function pathnameOrRawValue(value: string): string {
-  try {
-    return new URL(value).pathname;
-  } catch {
-    return `${value} (not an absolute URL)`;
+function pathnameOrRawValue(value: unknown): string {
+  if (typeof value === "string" && value.trim() !== "") {
+    try {
+      return new URL(value).pathname;
+    } catch {
+      return `${value} (not an absolute URL)`;
+    }
   }
+
+  const displayedValue =
+    typeof value === "string" ? JSON.stringify(value) : String(value);
+  return `${displayedValue} (not an absolute URL)`;
 }
 
 function resourceDetailValue(
@@ -115,7 +121,7 @@ function protectedResourceMetadataActions(
       description: "Server returns 401 with WWW-Authenticate header",
       from: "mcpServer",
       to: "client",
-      details: flowState.resourceMetadataUrl
+      details: flowState.resourceMetadataUrl !== undefined
         ? [{ label: "Note", value: "Extract resource_metadata URL" }]
         : undefined,
     },
@@ -125,7 +131,7 @@ function protectedResourceMetadataActions(
       description: "Client requests metadata from well-known URI",
       from: "client",
       to: "mcpServer",
-      details: flowState.resourceMetadataUrl
+      details: flowState.resourceMetadataUrl !== undefined
         ? [
             {
               label: "GET",

--- a/sdk/src/oauth/state-machines/shared/sequence-diagram.ts
+++ b/sdk/src/oauth/state-machines/shared/sequence-diagram.ts
@@ -56,11 +56,27 @@ function truncate(value: string, length: number): string {
   return `${value.substring(0, length)}...`;
 }
 
+/**
+ * Render a server-advertised URL as its path, or say so when it is not a URL.
+ *
+ * Every value this runs on is copied verbatim out of a document the server
+ * under test wrote — the `resource_metadata` challenge parameter, the
+ * authorization-server metadata endpoints — and none of them is validated as
+ * absolute before it lands in flow state. `new URL()` throws on a relative
+ * value, and this builder runs inside the diagram's `useMemo`, so an unguarded
+ * parse takes the whole panel down at exactly the moment its ladder is the
+ * thing worth reading.
+ *
+ * The raw value alone would not be enough. A relative `/.well-known/...`
+ * renders byte-identical to the path of a correct absolute URL, so the
+ * misconfiguration would look like a normal step; the suffix is what makes the
+ * two distinguishable on screen.
+ */
 function pathnameOrRawValue(value: string): string {
   try {
     return new URL(value).pathname;
   } catch {
-    return value;
+    return `${value} (not an absolute URL)`;
   }
 }
 
@@ -295,15 +311,15 @@ export function buildOAuthSequenceDiagramActions(
         ? [
             {
               label: "Token",
-              value: new URL(
+              value: pathnameOrRawValue(
                 flowState.authorizationServerMetadata.token_endpoint,
-              ).pathname,
+              ),
             },
             {
               label: "Auth",
-              value: new URL(
+              value: pathnameOrRawValue(
                 flowState.authorizationServerMetadata.authorization_endpoint,
-              ).pathname,
+              ),
             },
           ]
         : undefined,

--- a/sdk/src/oauth/state-machines/shared/sequence-diagram.ts
+++ b/sdk/src/oauth/state-machines/shared/sequence-diagram.ts
@@ -81,8 +81,16 @@ function pathnameOrRawValue(value: unknown): string {
     }
   }
 
-  const displayedValue =
-    typeof value === "string" ? JSON.stringify(value) : String(value);
+  let displayedValue: string;
+  try {
+    displayedValue =
+      typeof value === "string" ||
+      (typeof value === "object" && value !== null)
+        ? JSON.stringify(value) ?? String(value)
+        : String(value);
+  } catch {
+    displayedValue = "[unserializable value]";
+  }
   return `${displayedValue} (not an absolute URL)`;
 }
 

--- a/sdk/src/oauth/state-machines/shared/sequence-diagram.ts
+++ b/sdk/src/oauth/state-machines/shared/sequence-diagram.ts
@@ -56,6 +56,14 @@ function truncate(value: string, length: number): string {
   return `${value.substring(0, length)}...`;
 }
 
+function pathnameOrRawValue(value: string): string {
+  try {
+    return new URL(value).pathname;
+  } catch {
+    return value;
+  }
+}
+
 function resourceDetailValue(
   flowState: OAuthFlowState,
   era: SequenceDiagramEraSpec,
@@ -105,7 +113,7 @@ function protectedResourceMetadataActions(
         ? [
             {
               label: "GET",
-              value: new URL(flowState.resourceMetadataUrl).pathname,
+              value: pathnameOrRawValue(flowState.resourceMetadataUrl),
             },
           ]
         : undefined,

--- a/sdk/tests/oauth/sequence-actions-goldens.test.ts
+++ b/sdk/tests/oauth/sequence-actions-goldens.test.ts
@@ -121,3 +121,30 @@ describe.each(CASES)(
     });
   },
 );
+
+describe.each([
+  "2025-06-18",
+  "2025-11-25",
+  "2026-07-28",
+] satisfies OAuthProtocolVersion[])(
+  "sequence actions (%s / invalid resource metadata URL)",
+  (protocolVersion) => {
+    it("displays the raw value without crashing", () => {
+      const resourceMetadataUrl = "/.well-known/oauth-protected-resource";
+
+      const actions = buildOAuthSequenceActions({
+        protocolVersion,
+        registrationStrategy: "dcr",
+        flowState: {
+          ...EMPTY_OAUTH_FLOW_STATE,
+          resourceMetadataUrl,
+        },
+      });
+
+      expect(
+        actions.find((action) => action.id === "request_resource_metadata")
+          ?.details
+      ).toEqual([{ label: "GET", value: resourceMetadataUrl }]);
+    });
+  }
+);

--- a/sdk/tests/oauth/sequence-actions-goldens.test.ts
+++ b/sdk/tests/oauth/sequence-actions-goldens.test.ts
@@ -136,6 +136,10 @@ describe.each(ALL_VERSIONS.filter((version) => version !== "2025-03-26"))(
       ],
       ["", '"" (not an absolute URL)'],
       [null, "null (not an absolute URL)"],
+      [
+        { href: "/.well-known/oauth-protected-resource" },
+        '{"href":"/.well-known/oauth-protected-resource"} (not an absolute URL)',
+      ],
     ])("annotates malformed value %j without crashing", (value, displayed) => {
       let actions: ReturnType<typeof buildOAuthSequenceActions> = [];
       expect(() => {
@@ -195,6 +199,12 @@ describe.each(ALL_VERSIONS)(
         null,
         "/token (not an absolute URL)",
         "null (not an absolute URL)",
+      ],
+      [
+        { href: "/token" },
+        ["/authorize"],
+        '{"href":"/token"} (not an absolute URL)',
+        '["/authorize"] (not an absolute URL)',
       ],
     ])(
       "annotates malformed token %j and authorization %j without crashing",

--- a/sdk/tests/oauth/sequence-actions-goldens.test.ts
+++ b/sdk/tests/oauth/sequence-actions-goldens.test.ts
@@ -129,27 +129,30 @@ describe.each(CASES)(
 describe.each(ALL_VERSIONS.filter((version) => version !== "2025-03-26"))(
   "sequence actions (%s / invalid resource metadata URL)",
   (protocolVersion) => {
-    it("displays the raw value without crashing", () => {
-      const resourceMetadataUrl = "/.well-known/oauth-protected-resource";
-
-      const actions = buildOAuthSequenceActions({
-        protocolVersion,
-        registrationStrategy: "dcr",
-        flowState: {
-          ...EMPTY_OAUTH_FLOW_STATE,
-          resourceMetadataUrl,
-        },
-      });
+    it.each<[unknown, string]>([
+      [
+        "/.well-known/oauth-protected-resource",
+        "/.well-known/oauth-protected-resource (not an absolute URL)",
+      ],
+      ["", '"" (not an absolute URL)'],
+      [null, "null (not an absolute URL)"],
+    ])("annotates malformed value %j without crashing", (value, displayed) => {
+      let actions: ReturnType<typeof buildOAuthSequenceActions> = [];
+      expect(() => {
+        actions = buildOAuthSequenceActions({
+          protocolVersion,
+          registrationStrategy: "dcr",
+          flowState: {
+            ...EMPTY_OAUTH_FLOW_STATE,
+            resourceMetadataUrl: value,
+          } as OAuthFlowState,
+        });
+      }).not.toThrow();
 
       expect(
         actions.find((action) => action.id === "request_resource_metadata")
           ?.details
-      ).toEqual([
-        {
-          label: "GET",
-          value: `${resourceMetadataUrl} (not an absolute URL)`,
-        },
-      ]);
+      ).toEqual([{ label: "GET", value: displayed }]);
     });
   }
 );
@@ -162,29 +165,66 @@ describe.each(ALL_VERSIONS.filter((version) => version !== "2025-03-26"))(
 describe.each(ALL_VERSIONS)(
   "sequence actions (%s / relative authorization server endpoints)",
   (protocolVersion) => {
-    it("displays the raw endpoints without crashing", () => {
-      const actions = buildOAuthSequenceActions({
-        protocolVersion,
-        registrationStrategy: "dcr",
-        flowState: {
-          ...EMPTY_OAUTH_FLOW_STATE,
-          authorizationServerMetadata: {
-            issuer: "https://auth-server.example.com",
-            authorization_endpoint: "/authorize",
-            token_endpoint: "/token",
-            response_types_supported: ["code"],
-          },
-        } as OAuthFlowState,
-      });
+    it.each<[unknown, unknown, string, string]>([
+      [
+        "/token",
+        "/authorize",
+        "/token (not an absolute URL)",
+        "/authorize (not an absolute URL)",
+      ],
+      [
+        "",
+        "/authorize",
+        '"" (not an absolute URL)',
+        "/authorize (not an absolute URL)",
+      ],
+      [
+        null,
+        "/authorize",
+        "null (not an absolute URL)",
+        "/authorize (not an absolute URL)",
+      ],
+      [
+        "/token",
+        "",
+        "/token (not an absolute URL)",
+        '"" (not an absolute URL)',
+      ],
+      [
+        "/token",
+        null,
+        "/token (not an absolute URL)",
+        "null (not an absolute URL)",
+      ],
+    ])(
+      "annotates malformed token %j and authorization %j without crashing",
+      (tokenEndpoint, authorizationEndpoint, displayedToken, displayedAuth) => {
+        let actions: ReturnType<typeof buildOAuthSequenceActions> = [];
+        expect(() => {
+          actions = buildOAuthSequenceActions({
+            protocolVersion,
+            registrationStrategy: "dcr",
+            flowState: {
+              ...EMPTY_OAUTH_FLOW_STATE,
+              authorizationServerMetadata: {
+                issuer: "https://auth-server.example.com",
+                authorization_endpoint: authorizationEndpoint,
+                token_endpoint: tokenEndpoint,
+                response_types_supported: ["code"],
+              },
+            } as OAuthFlowState,
+          });
+        }).not.toThrow();
 
-      expect(
-        actions.find(
-          (action) => action.id === "received_authorization_server_metadata"
-        )?.details
-      ).toEqual([
-        { label: "Token", value: "/token (not an absolute URL)" },
-        { label: "Auth", value: "/authorize (not an absolute URL)" },
-      ]);
-    });
+        expect(
+          actions.find(
+            (action) => action.id === "received_authorization_server_metadata"
+          )?.details
+        ).toEqual([
+          { label: "Token", value: displayedToken },
+          { label: "Auth", value: displayedAuth },
+        ]);
+      }
+    );
   }
 );

--- a/sdk/tests/oauth/sequence-actions-goldens.test.ts
+++ b/sdk/tests/oauth/sequence-actions-goldens.test.ts
@@ -122,6 +122,8 @@ describe.each(CASES)(
   },
 );
 
+// 2025-03-26 intentionally has no resource-metadata details in this action,
+// so it never parses the displayed URL and cannot hit this rendering crash.
 describe.each([
   "2025-06-18",
   "2025-11-25",

--- a/sdk/tests/oauth/sequence-actions-goldens.test.ts
+++ b/sdk/tests/oauth/sequence-actions-goldens.test.ts
@@ -124,11 +124,9 @@ describe.each(CASES)(
 
 // 2025-03-26 intentionally has no resource-metadata details in this action,
 // so it never parses the displayed URL and cannot hit this rendering crash.
-describe.each([
-  "2025-06-18",
-  "2025-11-25",
-  "2026-07-28",
-] satisfies OAuthProtocolVersion[])(
+// Derived from ALL_VERSIONS rather than listed, so a new era is covered the
+// moment it is added rather than silently skipping this regression.
+describe.each(ALL_VERSIONS.filter((version) => version !== "2025-03-26"))(
   "sequence actions (%s / invalid resource metadata URL)",
   (protocolVersion) => {
     it("displays the raw value without crashing", () => {
@@ -146,7 +144,47 @@ describe.each([
       expect(
         actions.find((action) => action.id === "request_resource_metadata")
           ?.details
-      ).toEqual([{ label: "GET", value: resourceMetadataUrl }]);
+      ).toEqual([
+        {
+          label: "GET",
+          value: `${resourceMetadataUrl} (not an absolute URL)`,
+        },
+      ]);
+    });
+  }
+);
+
+// The authorization-server metadata step renders on EVERY era, including
+// 2025-03-26 — it is outside the protected-resource preamble — so its
+// endpoints have a wider blast radius than the resource-metadata URL above.
+// RFC 8414 requires absolute endpoints, but the machines validate only that
+// the fields are present, so a relative one reaches the diagram unchecked.
+describe.each(ALL_VERSIONS)(
+  "sequence actions (%s / relative authorization server endpoints)",
+  (protocolVersion) => {
+    it("displays the raw endpoints without crashing", () => {
+      const actions = buildOAuthSequenceActions({
+        protocolVersion,
+        registrationStrategy: "dcr",
+        flowState: {
+          ...EMPTY_OAUTH_FLOW_STATE,
+          authorizationServerMetadata: {
+            issuer: "https://auth-server.example.com",
+            authorization_endpoint: "/authorize",
+            token_endpoint: "/token",
+            response_types_supported: ["code"],
+          },
+        } as OAuthFlowState,
+      });
+
+      expect(
+        actions.find(
+          (action) => action.id === "received_authorization_server_metadata"
+        )?.details
+      ).toEqual([
+        { label: "Token", value: "/token (not an absolute URL)" },
+        { label: "Auth", value: "/authorize (not an absolute URL)" },
+      ]);
     });
   }
 );


### PR DESCRIPTION
## What
- keep the OAuth sequence diagram visible for malformed PRM/AS URLs and show their actual string, object, array, empty, or null values
- replace raw `InvalidGrantError` stacks with actionable token-exchange errors that preserve the authorization server reason
- normalize missing callback errors and keep hosted traces consistent with returned errors

## Validation
- focused SDK sequence tests: 84 passed
- focused Inspector OAuth tests: 125 passed
- SDK and Inspector client typechecks passed