### PR TITLE
Fix Not connected crash when a widget's tool call fails after teardown

### DIFF
--- a/mcpjam-inspector/client/src/components/chat-v2/thread/mcp-apps/__tests__/host-app-bridge.test.ts
+++ b/mcpjam-inspector/client/src/components/chat-v2/thread/mcp-apps/__tests__/host-app-bridge.test.ts
@@ -211,6 +211,35 @@ describe("registerHostBridgeHandlers — sendToolCancelled matrix gating", () =>
     ).rejects.toThrow();
     expect(bridge.sendToolCancelled).not.toHaveBeenCalled();
   });
+
+  // Nobody awaits the side-channel notification, and the app-tool call that
+  // failed is often what tore the widget down in the first place — so the
+  // bridge can already be disconnected by the time we send it. An unguarded
+  // send then rejects with "Not connected" and surfaces as an unhandled
+  // rejection, which the hosted app reports as a client crash.
+  it("swallows a send failure when the bridge is already disconnected", async () => {
+    const bridge = makeStubBridge();
+    // Assert on the very promise the handler receives ("this rejection was
+    // handled") rather than on the runtime staying quiet: an unhandled
+    // rejection is reported by the browser, not by vitest's jsdom worker.
+    const sendResult = Promise.reject(new Error("Not connected"));
+    const handled = vi.spyOn(sendResult, "catch");
+    bridge.sendToolCancelled.mockReturnValue(sendResult);
+    register(bridge, {
+      callbacks: { onCallTool: vi.fn().mockRejectedValue(new Error("boom")) },
+    });
+
+    // The tool error still reaches the app through the response path.
+    await expect(
+      (bridge.oncalltool as (p: unknown, e: unknown) => Promise<unknown>)(
+        { name: "go", arguments: {} },
+        {},
+      ),
+    ).rejects.toThrow("boom");
+
+    expect(bridge.sendToolCancelled).toHaveBeenCalledWith({ reason: "boom" });
+    expect(handled).toHaveBeenCalled();
+  });
 });
 
 describe("registerHostBridgeHandlers — app-tool invocation lifecycle", () => {

--- a/sdk/src/widget-runtime/host-app-bridge.ts
+++ b/sdk/src/widget-runtime/host-app-bridge.ts
@@ -331,7 +331,15 @@ export function registerHostBridgeHandlers(
     const sendToolCancelledIfAllowed = (reason: string) => {
       const matrix = getMatrix?.() ?? null;
       if (matrix !== null && matrix.toolCancelled === false) return;
-      void bridge.sendToolCancelled({ reason });
+      // Best-effort, like `teardownResource` below: the app-tool call that
+      // failed may itself be what tore the widget down (unmount, teardown,
+      // navigation), so by the time we report the cancellation the bridge can
+      // already be disconnected and `notification()` rejects with "Not
+      // connected". Nobody awaits this notification, so an unguarded reject
+      // surfaces as an unhandled rejection and gets captured as a crash.
+      void Promise.resolve(bridge.sendToolCancelled({ reason })).catch(
+        () => {}
+      );
     };
     bridge.oncalltool = async ({ name, arguments: args }, _extra) => {
       // Model-only tools (visibility: ["model"]) are not callable by apps.


### PR DESCRIPTION
- A widget in the playground ran a tool, the tool failed, and we tried to send the widget a "that failed" message — but its iframe was already closed, so the message blew up and got logged as a crash ([PostHog issue](https://us.posthog.com/project/212744/error_tracking/01a00a2a-8696-74d2-8272-26cfc8574488)).
- Now that message is best-effort: if the widget is gone, we drop it quietly. Same as the teardown call right below it.
- The real tool error still reaches the widget the normal way, so nothing the user sees changes.
- Added a test that fails without the fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents "Not connected" crashes when a widget’s tool call fails after teardown by making the `tool-cancelled` notification best-effort. Previously we sent the notice even if the widget iframe had closed, leading to an unhandled rejection and a client crash; now we swallow the rejection if the bridge is disconnected. The tool error still returns via the normal response path, so user-visible behavior is unchanged.

**Review notes**
- Wraps `bridge.sendToolCancelled({ reason })` in a resolved promise with a no-op catch, mirroring the best-effort `teardownResource` behavior.
- Adds a test in the inspector to assert the rejection is handled and that the tool error still propagates through the response path.

<sup>Written for commit c3d5a15cdc04cab1c03a6614647c7aa1d3617dd6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/MCPJam/inspector/pull/4054?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

