### PR TITLE
Prevent translated server dialog teardown crash

### DIFF
--- a/mcpjam-inspector/client/src/components/connection/ServerDetailModal.tsx
+++ b/mcpjam-inspector/client/src/components/connection/ServerDetailModal.tsx
@@ -523,6 +523,9 @@ export function ServerDetailModal({
   return (
     <Dialog open={isOpen} onOpenChange={handleOpenChange}>
       <DialogContent
+        // Browser translators rewrite text nodes in-place. React then cannot
+        // safely remove this portaled dialog after its close animation.
+        translate="no"
         // The `sm:` prefix is load-bearing. DialogContent's base carries
         // `sm:max-w-lg`, and tailwind-merge only collapses classes that
         // share a variant — so an unprefixed `max-w-2xl` never conflicts
@@ -532,7 +535,7 @@ export function ServerDetailModal({
         // spares the base `max-w-[calc(100%-2rem)]`, which tailwind-merge
         // used to drop as a same-variant conflict — that's the guard that
         // keeps the dialog off both screen edges below 640px.
-        className="sm:max-w-2xl max-h-[85vh] flex flex-col outline-none focus:outline-none focus-visible:outline-none focus:ring-0 focus-visible:ring-0"
+        className="notranslate sm:max-w-2xl max-h-[85vh] flex flex-col outline-none focus:outline-none focus-visible:outline-none focus:ring-0 focus-visible:ring-0"
         onOpenAutoFocus={(event) => {
           event.preventDefault();
         }}

--- a/mcpjam-inspector/client/src/components/connection/__tests__/ServerDetailModal.test.tsx
+++ b/mcpjam-inspector/client/src/components/connection/__tests__/ServerDetailModal.test.tsx
@@ -168,6 +168,13 @@ describe("ServerDetailModal", () => {
     });
   });
 
+  it("prevents browser translation from rewriting the portaled dialog", () => {
+    render(<ServerDetailModal {...defaultProps} />);
+
+    expect(screen.getByRole("dialog")).toHaveAttribute("translate", "no");
+    expect(screen.getByRole("dialog")).toHaveClass("notranslate");
+  });
+
   // Regression: local mode used to hand this modal the LOCAL project id (a
   // `crypto.randomUUID()` value). `projectServerConfig:getConfig` validates
   // `projectId` as `v.id("projects")`, so the query rejected during render


### PR DESCRIPTION
## What changed

- Mark the server details dialog as `translate="no"` and `notranslate`.
- Add a regression test that protects both attributes.

## Why

PostHog showed the `removeChild` crash immediately after `server_detail_modal_closed`. The preceding click text was translated from the app's English source into Hebrew, confirming that browser translation had rewritten React-owned nodes inside the Radix portal. React then failed while removing the translated dialog after its close animation.

This keeps browser translation available elsewhere in the app while protecting only the affected dynamic portal.

## Validation

- `npx vitest run client/src/components/connection/__tests__/ServerDetailModal.test.tsx` (27 tests passed)
- `npm run typecheck:client`
- `npm run build:client`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents a crash when closing the server details dialog under browser auto-translate. Before: translators rewrote nodes in the portaled dialog, causing a React removeChild error after close. Now: the dialog is marked non-translatable, and translation remains available elsewhere.

**Review notes**
- Add translate="no" and "notranslate" to the portaled DialogContent for the server details dialog.
- Add a regression test that asserts both attributes on the dialog element.

<sup>Written for commit c1ae6ba4ecc0646b1fdf6cb89a63e3cb3a6d9d01. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/MCPJam/inspector/pull/4056?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

