### PR TITLE
fix(github-checks): skip availability query for guests

### DIFF
--- a/mcpjam-inspector/client/src/hooks/__tests__/useGithubChecksSettings.test.tsx
+++ b/mcpjam-inspector/client/src/hooks/__tests__/useGithubChecksSettings.test.tsx
@@ -33,17 +33,22 @@ vi.mock("@/lib/error-reporting", () => ({
 }));
 
 import { ErrorBoundary } from "@/components/ui/error-boundary";
+import { ConvexError } from "convex/values";
 import { useGithubChecksAvailability } from "../useGithubChecksSettings";
 
-function AvailabilityProbe() {
-  const availability = useGithubChecksAvailability("org-1");
+function AvailabilityProbe({
+  organizationId,
+}: {
+  organizationId: string | null | undefined;
+}) {
+  const availability = useGithubChecksAvailability(organizationId);
   return <div>{availability?.state ?? "unavailable"}</div>;
 }
 
-function renderProbe() {
+function renderProbe(organizationId: string | null | undefined = "org-1") {
   return render(
     <ErrorBoundary name="integrations_github_checks" fallback={null}>
-      <AvailabilityProbe />
+      <AvailabilityProbe organizationId={organizationId} />
     </ErrorBoundary>
   );
 }
@@ -75,6 +80,29 @@ describe("useGithubChecksAvailability", () => {
     expect(mocks.reportBoundaryError).not.toHaveBeenCalled();
   });
 
+  it.each([
+    ["an unauthenticated session", false, true, "org-1"],
+    ["an unready user", true, false, "org-1"],
+    ["a null organization id", true, true, null],
+    ["an empty organization id", true, true, ""],
+  ] as const)(
+    "skips the query and reporting for %s",
+    (_state, isAuthenticated, isUserReady, organizationId) => {
+      mocks.user.value = { id: "user-1" };
+      mocks.isAuthenticated.value = isAuthenticated;
+      mocks.isUserReady.value = isUserReady;
+
+      renderProbe(organizationId);
+
+      expect(screen.getByText("unavailable")).toBeInTheDocument();
+      expect(mocks.useQuery).toHaveBeenCalledWith(
+        "github/checkRepoConfigs:getGithubChecksSettingsAvailability",
+        "skip"
+      );
+      expect(mocks.reportBoundaryError).not.toHaveBeenCalled();
+    }
+  );
+
   it("still asks the backend for a signed-in WorkOS user", () => {
     mocks.user.value = { id: "user-1" };
     mocks.useQuery.mockReturnValue({ state: "enabled" });
@@ -86,5 +114,36 @@ describe("useGithubChecksAvailability", () => {
       "github/checkRepoConfigs:getGithubChecksSettingsAvailability",
       { organizationId: "org-1" }
     );
+  });
+
+  it("contains a signed-in membership refusal in the error boundary", () => {
+    mocks.user.value = { id: "user-1" };
+    const refusal = new ConvexError({
+      kind: "forbidden",
+      message: "Not a member of this organization",
+    });
+    mocks.useQuery.mockImplementation(() => {
+      throw refusal;
+    });
+    const consoleError = vi
+      .spyOn(console, "error")
+      .mockImplementation(() => {});
+
+    try {
+      const { container } = renderProbe();
+
+      expect(container).toBeEmptyDOMElement();
+      expect(mocks.useQuery).toHaveBeenCalledWith(
+        "github/checkRepoConfigs:getGithubChecksSettingsAvailability",
+        { organizationId: "org-1" }
+      );
+      expect(mocks.reportBoundaryError).toHaveBeenCalledTimes(1);
+      expect(mocks.reportBoundaryError.mock.calls[0]?.[0]).toBe(refusal);
+      expect(mocks.reportBoundaryError.mock.calls[0]?.[2]).toBe(
+        "integrations_github_checks"
+      );
+    } finally {
+      consoleError.mockRestore();
+    }
   });
 });

--- a/mcpjam-inspector/client/src/hooks/__tests__/useGithubChecksSettings.test.tsx
+++ b/mcpjam-inspector/client/src/hooks/__tests__/useGithubChecksSettings.test.tsx
@@ -1,0 +1,90 @@
+import { render, screen } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  user: { value: null as { id: string } | null },
+  isAuthenticated: { value: true },
+  isUserReady: { value: true },
+  useQuery: vi.fn(),
+  reportBoundaryError: vi.fn(),
+}));
+
+vi.mock("@workos-inc/authkit-react", () => ({
+  useAuth: () => ({ user: mocks.user.value, isLoading: false }),
+}));
+
+vi.mock("convex/react", () => ({
+  useAction: () => vi.fn(),
+  useMutation: () => vi.fn(),
+  useConvexAuth: () => ({
+    isAuthenticated: mocks.isAuthenticated.value,
+    isLoading: false,
+  }),
+  useQuery: (name: unknown, args: unknown) => mocks.useQuery(name, args),
+}));
+
+vi.mock("@/contexts/db-user-ready-context", () => ({
+  useDbUserReady: () => mocks.isUserReady.value,
+}));
+
+vi.mock("@/lib/error-reporting", () => ({
+  reportBoundaryError: (...args: unknown[]) =>
+    mocks.reportBoundaryError(...args),
+}));
+
+import { ErrorBoundary } from "@/components/ui/error-boundary";
+import { useGithubChecksAvailability } from "../useGithubChecksSettings";
+
+function AvailabilityProbe() {
+  const availability = useGithubChecksAvailability("org-1");
+  return <div>{availability?.state ?? "unavailable"}</div>;
+}
+
+function renderProbe() {
+  return render(
+    <ErrorBoundary name="integrations_github_checks" fallback={null}>
+      <AvailabilityProbe />
+    </ErrorBoundary>
+  );
+}
+
+describe("useGithubChecksAvailability", () => {
+  beforeEach(() => {
+    mocks.user.value = null;
+    mocks.isAuthenticated.value = true;
+    mocks.isUserReady.value = true;
+    vi.clearAllMocks();
+    mocks.useQuery.mockImplementation((_name: unknown, args: unknown) => {
+      if (args !== "skip") {
+        throw new Error(
+          "[CONVEX Q(github/checkRepoConfigs:getGithubChecksSettingsAvailability)] Server Error"
+        );
+      }
+      return undefined;
+    });
+  });
+
+  it("does not query or report when the Convex-authenticated actor is a guest", () => {
+    renderProbe();
+
+    expect(screen.getByText("unavailable")).toBeInTheDocument();
+    expect(mocks.useQuery).toHaveBeenCalledWith(
+      "github/checkRepoConfigs:getGithubChecksSettingsAvailability",
+      "skip"
+    );
+    expect(mocks.reportBoundaryError).not.toHaveBeenCalled();
+  });
+
+  it("still asks the backend for a signed-in WorkOS user", () => {
+    mocks.user.value = { id: "user-1" };
+    mocks.useQuery.mockReturnValue({ state: "enabled" });
+
+    renderProbe();
+
+    expect(screen.getByText("enabled")).toBeInTheDocument();
+    expect(mocks.useQuery).toHaveBeenCalledWith(
+      "github/checkRepoConfigs:getGithubChecksSettingsAvailability",
+      { organizationId: "org-1" }
+    );
+  });
+});

--- a/mcpjam-inspector/client/src/hooks/useGithubChecksSettings.ts
+++ b/mcpjam-inspector/client/src/hooks/useGithubChecksSettings.ts
@@ -1,4 +1,5 @@
 import { useCallback } from "react";
+import { useAuth } from "@workos-inc/authkit-react";
 import { useAction, useConvexAuth, useMutation, useQuery } from "convex/react";
 import { useDbUserReady } from "@/contexts/db-user-ready-context";
 
@@ -19,10 +20,11 @@ import { useDbUserReady } from "@/contexts/db-user-ready-context";
  * **These hooks can throw, and every call site MUST sit inside an
  * `ErrorBoundary`.** `useQuery` re-throws query errors during render, and
  * ordinary cases produce one here: the backend function is not deployed yet
- * (the two repos release independently), a guest actor (`signedInQuery` rejects
- * guests at the boundary), and a caller who is not a member of the org the
- * caller passed — the backend throws there deliberately, because answering
- * `disabled` would confirm the org exists.
+ * (the two repos release independently), or a caller is not a member of the org
+ * they passed — the backend throws there deliberately, because answering
+ * `disabled` would confirm the org exists. Guests never ask: GitHub Checks is
+ * member-only, so the availability read is skipped when there is no WorkOS
+ * user even though the guest session is Convex-authenticated.
  *
  * The boundary is not optional and not defence in depth: a call in a component
  * that is not itself inside one takes that component's whole page down. That is
@@ -31,9 +33,7 @@ import { useDbUserReady } from "@/contexts/db-user-ready-context";
  * `IntegrationsRoute`, `GithubChecksRoute`, and
  * `SuiteGithubChecksSettingsSection` in `suite-iterations-view`.
  *
- * A boundary catching this still reports it, which is right for a defect and
- * wrong for a refusal — and an org guest opening a suite produces one every
- * time. The refusals now arrive as a `ConvexError` tagged `kind: 'forbidden'`,
+ * A membership refusal arrives as a `ConvexError` tagged `kind: 'forbidden'`,
  * which `reportCaught` drops. The not-yet-deployed case stays a plain throw and
  * still reports, which is also right: that one means the two repos drifted.
  */
@@ -81,9 +81,12 @@ export const GITHUB_CHECKS_UNAVAILABLE_MESSAGE =
 export function useGithubChecksAvailability(
   organizationId: string | null | undefined
 ): GithubChecksAvailability {
+  const { user } = useAuth();
   const { isAuthenticated } = useConvexAuth();
   const isUserReady = useDbUserReady();
-  const canQuery = Boolean(isAuthenticated && isUserReady && organizationId);
+  const canQuery = Boolean(
+    isAuthenticated && user && isUserReady && organizationId
+  );
 
   return useQuery(
     AVAILABILITY_QUERY as any,


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Skip GitHub Checks availability reads for guest and non-ready sessions to avoid spurious backend “forbidden” errors. Previously a Convex-authenticated guest queried and hit “forbidden”; now we pass the “skip” sentinel and the hook reports unavailable locally. Signed-in WorkOS users behave the same and still query; membership refusals surface in the error boundary.

- Gate `github/checkRepoConfigs:getGithubChecksSettingsAvailability` on a `@workos-inc/authkit-react` user, `convex/react` authentication, DB user readiness, and a non-empty `organizationId`; otherwise pass `"skip"`.
- Extend tests to cover skip for guest, unauthenticated, unready user, and missing `organizationId`; verify the signed-in path returns backend state and a membership refusal is captured by the `ErrorBoundary`.
- No caller changes required; keep existing `ErrorBoundary` wrappers.

<sup>Written for commit cb321c2bd6db05255713858831dd040bd5aa6dff. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/MCPJam/inspector/pull/4057?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

