### PR TITLE
fix(user-testing): stop branding the tester shell as Claude while it loads

### DIFF
--- a/mcpjam-inspector/client/src/components/hosted/ScenarioChatPage.tsx
+++ b/mcpjam-inspector/client/src/components/hosted/ScenarioChatPage.tsx
@@ -957,8 +957,19 @@ export function ScenarioChatPage({
   // emulates. Seeding "claude" made every tester watch a Claude-branded shell
   // load a Cursor scenario; DEFAULT_HOST_STYLE is MCPJam precisely so
   // unresolved surfaces don't impersonate a vendor.
-  const hostStyle = session?.payload.hostStyle ?? DEFAULT_HOST_STYLE.id;
-  const chatUiOverride = session?.payload.chatUiOverride;
+  //
+  // A stored session is no proof of that either. sessionStorage outlives the
+  // page, so a tester who opens a second link redeems scenario B with scenario
+  // A's session still in hand, and the shell wears A's brand for the whole
+  // redemption — the same impersonation, sourced from the last visit instead of
+  // a seed. The session earns the shell only once its own share token is the
+  // one in the address bar; with no token there (the post-redeem strip removed
+  // it) the stored session is all there is, and it is this link's.
+  const sessionForCurrentLink =
+    tokenFromPath && session?.shareToken !== tokenFromPath ? null : session;
+  const hostStyle =
+    sessionForCurrentLink?.payload.hostStyle ?? DEFAULT_HOST_STYLE.id;
+  const chatUiOverride = sessionForCurrentLink?.payload.chatUiOverride;
   const shellStyle = getScenarioShellStyle(hostStyle, themeMode, chatUiOverride);
   const clientLabel = getScenarioHostLabel(hostStyle, chatUiOverride);
   const clientLogoSrc = getScenarioHostLogo(
@@ -1161,7 +1172,7 @@ export function ScenarioChatPage({
                             the scenario's internal name is the author's
                             label for it and means nothing to them. */}
                         <div className="flex min-w-0 flex-1 items-center gap-2">
-                          {session ? (
+                          {sessionForCurrentLink ? (
                             <>
                               <img
                                 src={clientLogoSrc}

--- a/mcpjam-inspector/client/src/components/hosted/ScenarioChatPage.tsx
+++ b/mcpjam-inspector/client/src/components/hosted/ScenarioChatPage.tsx
@@ -1184,13 +1184,21 @@ export function ScenarioChatPage({
                               </h1>
                             </>
                           ) : (
-                            // Placeholder rather than the default host's mark:
-                            // painting one brand and swapping to another once
-                            // the redeem lands reads as a glitch.
-                            <div
-                              aria-hidden
-                              className="h-5 w-28 animate-pulse rounded bg-muted"
-                            />
+                            <>
+                              {/* The skeleton is decorative, so the header
+                                  would have no heading at all while the
+                                  redeem is in flight. Name the shell for a
+                                  screen reader without naming a vendor. */}
+                              <h1 className="sr-only">Loading scenario</h1>
+                              {/* Placeholder rather than the default host's
+                                  mark: painting one brand and swapping to
+                                  another once the redeem lands reads as a
+                                  glitch. */}
+                              <div
+                                aria-hidden
+                                className="h-5 w-28 animate-pulse rounded bg-muted"
+                              />
+                            </>
                           )}
                         </div>
                         <button

--- a/mcpjam-inspector/client/src/components/hosted/ScenarioChatPage.tsx
+++ b/mcpjam-inspector/client/src/components/hosted/ScenarioChatPage.tsx
@@ -59,6 +59,7 @@ import {
   getScenarioHostLogo,
   getScenarioShellStyle,
 } from "@/lib/scenario-client-style";
+import { DEFAULT_HOST_STYLE } from "@/lib/client-styles";
 
 interface ScenarioChatPageProps {
   pathToken?: string | null;
@@ -952,7 +953,11 @@ export function ScenarioChatPage({
     [markOAuthRequired]
   );
 
-  const hostStyle = session?.payload.hostStyle ?? "claude";
+  // Before the redeem resolves we don't know which host this scenario
+  // emulates. Seeding "claude" made every tester watch a Claude-branded shell
+  // load a Cursor scenario; DEFAULT_HOST_STYLE is MCPJam precisely so
+  // unresolved surfaces don't impersonate a vendor.
+  const hostStyle = session?.payload.hostStyle ?? DEFAULT_HOST_STYLE.id;
   const chatUiOverride = session?.payload.chatUiOverride;
   const shellStyle = getScenarioShellStyle(hostStyle, themeMode, chatUiOverride);
   const clientLabel = getScenarioHostLabel(hostStyle, chatUiOverride);
@@ -1156,14 +1161,26 @@ export function ScenarioChatPage({
                             the scenario's internal name is the author's
                             label for it and means nothing to them. */}
                         <div className="flex min-w-0 flex-1 items-center gap-2">
-                          <img
-                            src={clientLogoSrc}
-                            alt=""
-                            className="size-5 shrink-0 object-contain"
-                          />
-                          <h1 className="min-w-0 truncate text-sm font-semibold text-foreground">
-                            {clientLabel}
-                          </h1>
+                          {session ? (
+                            <>
+                              <img
+                                src={clientLogoSrc}
+                                alt=""
+                                className="size-5 shrink-0 object-contain"
+                              />
+                              <h1 className="min-w-0 truncate text-sm font-semibold text-foreground">
+                                {clientLabel}
+                              </h1>
+                            </>
+                          ) : (
+                            // Placeholder rather than the default host's mark:
+                            // painting one brand and swapping to another once
+                            // the redeem lands reads as a glitch.
+                            <div
+                              aria-hidden
+                              className="h-5 w-28 animate-pulse rounded bg-muted"
+                            />
+                          )}
                         </div>
                         <button
                           onClick={handleOpenMcpJam}

--- a/mcpjam-inspector/client/src/components/hosted/ScenarioChatPage.tsx
+++ b/mcpjam-inspector/client/src/components/hosted/ScenarioChatPage.tsx
@@ -1172,13 +1172,21 @@ export function ScenarioChatPage({
                               </h1>
                             </>
                           ) : (
-                            // Placeholder rather than the default host's mark:
-                            // painting one brand and swapping to another once
-                            // the redeem lands reads as a glitch.
-                            <div
-                              aria-hidden
-                              className="h-5 w-28 animate-pulse rounded bg-muted"
-                            />
+                            <>
+                              {/* The skeleton is decorative, so the header
+                                  would have no heading at all while the
+                                  redeem is in flight. Name the shell for a
+                                  screen reader without naming a vendor. */}
+                              <h1 className="sr-only">Loading scenario</h1>
+                              {/* Placeholder rather than the default host's
+                                  mark: painting one brand and swapping to
+                                  another once the redeem lands reads as a
+                                  glitch. */}
+                              <div
+                                aria-hidden
+                                className="h-5 w-28 animate-pulse rounded bg-muted"
+                              />
+                            </>
                           )}
                         </div>
                         <button

--- a/mcpjam-inspector/client/src/components/hosted/ScenarioChatPage.tsx
+++ b/mcpjam-inspector/client/src/components/hosted/ScenarioChatPage.tsx
@@ -945,8 +945,19 @@ export function ScenarioChatPage({
   // emulates. Seeding "claude" made every tester watch a Claude-branded shell
   // load a Cursor scenario; DEFAULT_HOST_STYLE is MCPJam precisely so
   // unresolved surfaces don't impersonate a vendor.
-  const hostStyle = session?.payload.hostStyle ?? DEFAULT_HOST_STYLE.id;
-  const chatUiOverride = session?.payload.chatUiOverride;
+  //
+  // A stored session is no proof of that either. sessionStorage outlives the
+  // page, so a tester who opens a second link redeems scenario B with scenario
+  // A's session still in hand, and the shell wears A's brand for the whole
+  // redemption — the same impersonation, sourced from the last visit instead of
+  // a seed. The session earns the shell only once its own share token is the
+  // one in the address bar; with no token there (the post-redeem strip removed
+  // it) the stored session is all there is, and it is this link's.
+  const sessionForCurrentLink =
+    tokenFromPath && session?.shareToken !== tokenFromPath ? null : session;
+  const hostStyle =
+    sessionForCurrentLink?.payload.hostStyle ?? DEFAULT_HOST_STYLE.id;
+  const chatUiOverride = sessionForCurrentLink?.payload.chatUiOverride;
   const shellStyle = getScenarioShellStyle(hostStyle, themeMode, chatUiOverride);
   const clientLabel = getScenarioHostLabel(hostStyle, chatUiOverride);
   const clientLogoSrc = getScenarioHostLogo(
@@ -1149,7 +1160,7 @@ export function ScenarioChatPage({
                             the scenario's internal name is the author's
                             label for it and means nothing to them. */}
                         <div className="flex min-w-0 flex-1 items-center gap-2">
-                          {session ? (
+                          {sessionForCurrentLink ? (
                             <>
                               <img
                                 src={clientLogoSrc}

--- a/mcpjam-inspector/client/src/components/hosted/ScenarioChatPage.tsx
+++ b/mcpjam-inspector/client/src/components/hosted/ScenarioChatPage.tsx
@@ -58,6 +58,7 @@ import {
   getScenarioHostLogo,
   getScenarioShellStyle,
 } from "@/lib/scenario-client-style";
+import { DEFAULT_HOST_STYLE } from "@/lib/client-styles";
 
 interface ScenarioChatPageProps {
   pathToken?: string | null;
@@ -940,7 +941,11 @@ export function ScenarioChatPage({
     [markOAuthRequired]
   );
 
-  const hostStyle = session?.payload.hostStyle ?? "claude";
+  // Before the redeem resolves we don't know which host this scenario
+  // emulates. Seeding "claude" made every tester watch a Claude-branded shell
+  // load a Cursor scenario; DEFAULT_HOST_STYLE is MCPJam precisely so
+  // unresolved surfaces don't impersonate a vendor.
+  const hostStyle = session?.payload.hostStyle ?? DEFAULT_HOST_STYLE.id;
   const chatUiOverride = session?.payload.chatUiOverride;
   const shellStyle = getScenarioShellStyle(hostStyle, themeMode, chatUiOverride);
   const clientLabel = getScenarioHostLabel(hostStyle, chatUiOverride);
@@ -1144,14 +1149,26 @@ export function ScenarioChatPage({
                             the scenario's internal name is the author's
                             label for it and means nothing to them. */}
                         <div className="flex min-w-0 flex-1 items-center gap-2">
-                          <img
-                            src={clientLogoSrc}
-                            alt=""
-                            className="size-5 shrink-0 object-contain"
-                          />
-                          <h1 className="min-w-0 truncate text-sm font-semibold text-foreground">
-                            {clientLabel}
-                          </h1>
+                          {session ? (
+                            <>
+                              <img
+                                src={clientLogoSrc}
+                                alt=""
+                                className="size-5 shrink-0 object-contain"
+                              />
+                              <h1 className="min-w-0 truncate text-sm font-semibold text-foreground">
+                                {clientLabel}
+                              </h1>
+                            </>
+                          ) : (
+                            // Placeholder rather than the default host's mark:
+                            // painting one brand and swapping to another once
+                            // the redeem lands reads as a glitch.
+                            <div
+                              aria-hidden
+                              className="h-5 w-28 animate-pulse rounded bg-muted"
+                            />
+                          )}
                         </div>
                         <button
                           onClick={handleOpenMcpJam}

--- a/mcpjam-inspector/client/src/components/hosted/__tests__/ScenarioChatPage.test.tsx
+++ b/mcpjam-inspector/client/src/components/hosted/__tests__/ScenarioChatPage.test.tsx
@@ -289,6 +289,29 @@ describe("ScenarioChatPage", () => {
     );
   });
 
+  it("does not brand the shell as Claude while the link is still redeeming", async () => {
+    // Reported by testers on an org-invited scenario: the header showed the
+    // Claude mark and the word "Claude" for the whole load, on a scenario that
+    // wasn't a Claude host at all. The redeem is held open here so the
+    // bootstrapping frame is the one under assertion.
+    mockAuthFetch.mockImplementation(() => new Promise(() => {}));
+
+    const { container } = render(<ScenarioChatPage pathToken="tok_loading" />);
+
+    await waitFor(() => expect(mockAuthFetch).toHaveBeenCalled());
+
+    expect(
+      container.querySelector('[data-host-style="claude"]')
+    ).not.toBeInTheDocument();
+    expect(
+      container.querySelector('[data-host-style="mcpjam"]')
+    ).toBeInTheDocument();
+    // No host identity is claimed until the redeem says which host this is —
+    // painting one brand and swapping to another reads as a glitch.
+    expect(screen.queryByText("Claude")).not.toBeInTheDocument();
+    expect(screen.getByAltText("MCPJam")).toBeInTheDocument();
+  });
+
   // Removed: "uses the Claude loading indicator variant for Claude-style
   // hosted scenarios". The indicator no longer flows through a
   // `loadingIndicatorVariant` prop on ChatTabV2 — the inner thread reads

--- a/mcpjam-inspector/client/src/components/hosted/__tests__/ScenarioChatPage.test.tsx
+++ b/mcpjam-inspector/client/src/components/hosted/__tests__/ScenarioChatPage.test.tsx
@@ -312,6 +312,47 @@ describe("ScenarioChatPage", () => {
     expect(screen.getByAltText("MCPJam")).toBeInTheDocument();
   });
 
+  it("does not wear the previous scenario's brand while a new link redeems", async () => {
+    // sessionStorage outlives the page, so a tester opening a second link still
+    // holds the first scenario's session. Dressing the redemption in that
+    // scenario's host is the same impersonation as seeding one — the stored
+    // session simply supplies the wrong vendor instead of a hardcoded one.
+    writeScenarioSession({
+      scenarioId: "sbx_previous",
+      accessVersion: 1,
+      shareToken: "tok_previous",
+      payload: {
+        projectId: "ws_1",
+        scenarioId: "sbx_previous",
+        name: "Previous Scenario",
+        description: "Hosted scenario",
+        hostStyle: "claude",
+        mode: "invited_only",
+        allowGuestAccess: false,
+        viewerIsProjectMember: true,
+        systemPrompt: "You are helpful.",
+        modelId: "openai/gpt-5-mini",
+        temperature: 0.4,
+        requireToolApproval: true,
+        servers: [],
+      },
+    });
+    mockAuthFetch.mockImplementation(() => new Promise(() => {}));
+
+    const { container } = render(<ScenarioChatPage pathToken="tok_new" />);
+
+    await waitFor(() => expect(mockAuthFetch).toHaveBeenCalled());
+
+    expect(
+      container.querySelector('[data-host-style="claude"]')
+    ).not.toBeInTheDocument();
+    expect(
+      container.querySelector('[data-host-style="mcpjam"]')
+    ).toBeInTheDocument();
+    expect(screen.queryByText("Claude")).not.toBeInTheDocument();
+    expect(screen.getByAltText("MCPJam")).toBeInTheDocument();
+  });
+
   // Removed: "uses the Claude loading indicator variant for Claude-style
   // hosted scenarios". The indicator no longer flows through a
   // `loadingIndicatorVariant` prop on ChatTabV2 — the inner thread reads

--- a/mcpjam-inspector/client/src/components/hosted/__tests__/ScenarioChatPage.test.tsx
+++ b/mcpjam-inspector/client/src/components/hosted/__tests__/ScenarioChatPage.test.tsx
@@ -310,6 +310,11 @@ describe("ScenarioChatPage", () => {
     // painting one brand and swapping to another reads as a glitch.
     expect(screen.queryByText("Claude")).not.toBeInTheDocument();
     expect(screen.getByAltText("MCPJam")).toBeInTheDocument();
+    // The visible placeholder is decorative, so the heading has to carry the
+    // shell's name for a screen reader in the meantime.
+    expect(
+      screen.getByRole("heading", { name: "Loading scenario" })
+    ).toBeInTheDocument();
   });
 
   it("does not wear the previous scenario's brand while a new link redeems", async () => {

--- a/mcpjam-inspector/client/src/components/hosted/__tests__/ScenarioChatPage.test.tsx
+++ b/mcpjam-inspector/client/src/components/hosted/__tests__/ScenarioChatPage.test.tsx
@@ -308,6 +308,47 @@ describe("ScenarioChatPage", () => {
     expect(screen.getByAltText("MCPJam")).toBeInTheDocument();
   });
 
+  it("does not wear the previous scenario's brand while a new link redeems", async () => {
+    // sessionStorage outlives the page, so a tester opening a second link still
+    // holds the first scenario's session. Dressing the redemption in that
+    // scenario's host is the same impersonation as seeding one — the stored
+    // session simply supplies the wrong vendor instead of a hardcoded one.
+    writeScenarioSession({
+      scenarioId: "sbx_previous",
+      accessVersion: 1,
+      shareToken: "tok_previous",
+      payload: {
+        projectId: "ws_1",
+        scenarioId: "sbx_previous",
+        name: "Previous Scenario",
+        description: "Hosted scenario",
+        hostStyle: "claude",
+        mode: "invited_only",
+        allowGuestAccess: false,
+        viewerIsProjectMember: true,
+        systemPrompt: "You are helpful.",
+        modelId: "openai/gpt-5-mini",
+        temperature: 0.4,
+        requireToolApproval: true,
+        servers: [],
+      },
+    });
+    mockAuthFetch.mockImplementation(() => new Promise(() => {}));
+
+    const { container } = render(<ScenarioChatPage pathToken="tok_new" />);
+
+    await waitFor(() => expect(mockAuthFetch).toHaveBeenCalled());
+
+    expect(
+      container.querySelector('[data-host-style="claude"]')
+    ).not.toBeInTheDocument();
+    expect(
+      container.querySelector('[data-host-style="mcpjam"]')
+    ).toBeInTheDocument();
+    expect(screen.queryByText("Claude")).not.toBeInTheDocument();
+    expect(screen.getByAltText("MCPJam")).toBeInTheDocument();
+  });
+
   // Removed: "uses the Claude loading indicator variant for Claude-style
   // hosted scenarios". The indicator no longer flows through a
   // `loadingIndicatorVariant` prop on ChatTabV2 — the inner thread reads

--- a/mcpjam-inspector/client/src/components/hosted/__tests__/ScenarioChatPage.test.tsx
+++ b/mcpjam-inspector/client/src/components/hosted/__tests__/ScenarioChatPage.test.tsx
@@ -306,6 +306,11 @@ describe("ScenarioChatPage", () => {
     // painting one brand and swapping to another reads as a glitch.
     expect(screen.queryByText("Claude")).not.toBeInTheDocument();
     expect(screen.getByAltText("MCPJam")).toBeInTheDocument();
+    // The visible placeholder is decorative, so the heading has to carry the
+    // shell's name for a screen reader in the meantime.
+    expect(
+      screen.getByRole("heading", { name: "Loading scenario" })
+    ).toBeInTheDocument();
   });
 
   it("does not wear the previous scenario's brand while a new link redeems", async () => {

--- a/mcpjam-inspector/client/src/components/hosted/__tests__/ScenarioChatPage.test.tsx
+++ b/mcpjam-inspector/client/src/components/hosted/__tests__/ScenarioChatPage.test.tsx
@@ -285,6 +285,29 @@ describe("ScenarioChatPage", () => {
     );
   });
 
+  it("does not brand the shell as Claude while the link is still redeeming", async () => {
+    // Reported by testers on an org-invited scenario: the header showed the
+    // Claude mark and the word "Claude" for the whole load, on a scenario that
+    // wasn't a Claude host at all. The redeem is held open here so the
+    // bootstrapping frame is the one under assertion.
+    mockAuthFetch.mockImplementation(() => new Promise(() => {}));
+
+    const { container } = render(<ScenarioChatPage pathToken="tok_loading" />);
+
+    await waitFor(() => expect(mockAuthFetch).toHaveBeenCalled());
+
+    expect(
+      container.querySelector('[data-host-style="claude"]')
+    ).not.toBeInTheDocument();
+    expect(
+      container.querySelector('[data-host-style="mcpjam"]')
+    ).toBeInTheDocument();
+    // No host identity is claimed until the redeem says which host this is —
+    // painting one brand and swapping to another reads as a glitch.
+    expect(screen.queryByText("Claude")).not.toBeInTheDocument();
+    expect(screen.getByAltText("MCPJam")).toBeInTheDocument();
+  });
+
   // Removed: "uses the Claude loading indicator variant for Claude-style
   // hosted scenarios". The indicator no longer flows through a
   // `loadingIndicatorVariant` prop on ChatTabV2 — the inner thread reads

--- a/mcpjam-inspector/client/src/components/hosts/HostCanvas.tsx
+++ b/mcpjam-inspector/client/src/components/hosts/HostCanvas.tsx
@@ -15,6 +15,7 @@ import { Plus, Server } from "lucide-react";
 import "@xyflow/react/dist/style.css";
 import { Badge } from "@mcpjam/design-system/badge";
 import { getScenarioHostLogo } from "@/lib/scenario-client-style";
+import { DEFAULT_HOST_STYLE } from "@/lib/client-styles";
 import { cn } from "@/lib/utils";
 import type {
   HostBuilderAddServerNodeData,
@@ -46,7 +47,7 @@ const HostNodeRenderer = memo(
   (props: NodeProps<Node<HostBuilderNodeData, "hostNode">>) => {
     const { data, selected } = props;
     const isHostCard = data.kind === "host";
-    const hostStyle = data.hostStyle ?? "claude";
+    const hostStyle = data.hostStyle ?? DEFAULT_HOST_STYLE.id;
     const hostLogoSrc = isHostCard ? getScenarioHostLogo(hostStyle) : null;
 
     return (

--- a/mcpjam-inspector/client/src/components/hosts/__tests__/HostCanvas.test.tsx
+++ b/mcpjam-inspector/client/src/components/hosts/__tests__/HostCanvas.test.tsx
@@ -1,0 +1,78 @@
+import { describe, expect, it } from "vitest";
+import { render } from "@testing-library/react";
+import { ReactFlowProvider } from "@xyflow/react";
+import { DEFAULT_HOST_STYLE } from "@/lib/client-styles";
+import { getScenarioHostLogo } from "@/lib/scenario-client-style";
+import { HostCanvas } from "../HostCanvas";
+import {
+  HOST_BUILDER_HOST_NODE_ID,
+  type HostBuilderNodeData,
+  type HostBuilderViewModel,
+} from "../host-builder-types";
+
+function renderCanvas(hostData: Partial<HostBuilderNodeData>) {
+  const viewModel: HostBuilderViewModel = {
+    title: "Test host",
+    nodes: [
+      {
+        id: HOST_BUILDER_HOST_NODE_ID,
+        type: "hostNode",
+        position: { x: 0, y: 0 },
+        data: {
+          kind: "host",
+          title: "Host",
+          subtitle: "Test host",
+          chips: [],
+          state: "ready",
+          ...hostData,
+        },
+      },
+    ],
+    edges: [],
+  };
+  return render(
+    <ReactFlowProvider>
+      <div style={{ width: 900, height: 700 }}>
+        <HostCanvas
+          viewModel={viewModel}
+          selectedNodeId={null}
+          onSelectNode={() => {}}
+          onClearSelection={() => {}}
+          onAddServer={() => {}}
+        />
+      </div>
+    </ReactFlowProvider>
+  );
+}
+
+function hostLogoSrc(container: HTMLElement): string | null {
+  const img = container.querySelector(
+    `.react-flow__node[data-id="${HOST_BUILDER_HOST_NODE_ID}"] img`
+  );
+  expect(img).not.toBeNull();
+  return img!.getAttribute("src");
+}
+
+describe("HostCanvas host style logo", () => {
+  const defaultLogo = getScenarioHostLogo(DEFAULT_HOST_STYLE.id);
+
+  it("falls back to the default host style when hostStyle is omitted", () => {
+    const { container } = renderCanvas({});
+    expect(hostLogoSrc(container)).toBe(defaultLogo);
+  });
+
+  // `hostStyle` is typed `HostStyleId` (a plain string), so an empty string is
+  // reachable without a cast; the registry treats it as an unknown id.
+  it("falls back to the default host style when hostStyle is empty", () => {
+    const { container } = renderCanvas({ hostStyle: "" });
+    expect(hostLogoSrc(container)).toBe(defaultLogo);
+  });
+
+  it("renders the logo of the requested host style", () => {
+    const chatgptLogo = getScenarioHostLogo("chatgpt");
+    expect(chatgptLogo).not.toBe(defaultLogo);
+
+    const { container } = renderCanvas({ hostStyle: "chatgpt" });
+    expect(hostLogoSrc(container)).toBe(chatgptLogo);
+  });
+});

--- a/mcpjam-inspector/client/src/lib/client-styles/registry.ts
+++ b/mcpjam-inspector/client/src/lib/client-styles/registry.ts
@@ -74,7 +74,8 @@ export function findHostStyle(
   return registry.get(id);
 }
 
-/** Lookup with claude fallback. Use at boundaries where missing data is normal. */
+/** Lookup with {@link DEFAULT_HOST_STYLE} fallback. Use at boundaries where
+ * missing data is normal. */
 export function getHostStyleOrDefault(
   id: HostStyleId | null | undefined
 ): HostStyleDefinition {


### PR DESCRIPTION
A tester opening a shared scenario link saw the Claude mark and the word
"Claude" in the header for the whole load, whatever host the scenario actually
emulated. The team hit this on an org-invited scenario that wasn't a Claude host
at all.

`ScenarioChatPage` seeded `hostStyle` with the literal `"claude"` while
`session` was null, and the header renders outside the loading branch — so the
wrong vendor stayed on screen until the redeem landed.

`DEFAULT_HOST_STYLE` (MCPJam) exists precisely so unresolved surfaces don't
impersonate a vendor; `registry.ts` says so in a comment. The page now uses it.
The header holds a placeholder until the redeem names the host, rather than
painting one brand and swapping to another once it resolves — that swap reads as
a glitch.

A stored session is no proof of the host either: `sessionStorage` outlives the
page, so a tester opening a second link redeems scenario B while still holding
scenario A's session, and the shell wore A's brand for the whole redemption.
Branding is now derived from the session only when its own `shareToken` is the
token in the address bar.

The placeholder is decorative (`aria-hidden`), which left the header with no
heading at all during redemption — a screen reader had nothing naming the shell,
where before it at least had a wrong vendor name. An `sr-only` `h1` ("Loading
scenario") sits alongside the skeleton: it names the surface without naming a
vendor.

The same literal is fixed in the host builder canvas, where a node with no host
style also rendered Claude's logo, and a stale comment on
`getHostStyleOrDefault` that still claimed a Claude fallback is corrected.

## Testing

- `ScenarioChatPage.test.tsx`: a case that holds the redeem open and asserts the
  bootstrapping frame carries no Claude asset, no Claude label, and a
  "Loading scenario" heading; a second case seeds a previous scenario's session
  and asserts the new link's redemption doesn't wear its brand.
- `HostCanvas.test.tsx`: omitted, empty, and explicit `data.hostStyle`. The type
  is `HostStyleId | undefined`, so the `??` covers the missing case and an empty
  string falls back through the registry lookup rather than the `??`.
- `ScenarioChatPage.test.tsx` 40/40 and `HostCanvas.test.tsx` 3/3.
- Rebased onto `main` before verifying. `npm run typecheck` and
  `npm run typecheck:client -w @mcpjam/inspector` (with the tier-B import guard)
  both exit 0.
- Full inspector suite locally: 1,326 files passed, 9 failed. All nine are known
  local-environment failures on Windows — symlink `EPERM`, 30s timeouts on
  subprocess- and DNS-bound tests, and one file that passes on its own — and
  none are in this diff's import graph. `test:ci:rest` stops on the
  `@mcpjam/design-system` tokens-parity check, which compares an LF file
  against a CRLF one; `docs:check-tokens` fails the same way. Both are CRLF
  artifacts of a local checkout, and `test.yml` is green on the `main` commit
  this branch is rebased onto.

The `?? "claude"` defaults in `ChatHistoryRail`/`ChatHistoryRow` are left alone
on purpose: they feed `getChatboxHostFamily`, and MCPJam's own family *is*
`"claude"`, so changing them would be churn with no visual effect.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stops branding the tester header as Claude while a shared scenario link redeems or when a stale session is present. Previously the header showed Claude or the last scenario's brand; now it uses MCPJam's `DEFAULT_HOST_STYLE` and a neutral placeholder until the host resolves, with an sr-only heading for accessibility.

- ScenarioChatPage: derive branding only when `session.shareToken` matches the link token; otherwise fall back to `DEFAULT_HOST_STYLE.id`, render a placeholder, and keep `chatUiOverride` null until resolved.
- HostCanvas: default `data.hostStyle` to `DEFAULT_HOST_STYLE.id` instead of `"claude"`; add tests for omitted, empty, and explicit styles.
- Leave `ChatHistoryRail`/`ChatHistoryRow` `?? "claude"` defaults unchanged; MCPJam's host family is `"claude"`.

<sup>Written for commit 0632bdce9d894d11988ddcc02185d68e0ef5239b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/MCPJam/inspector/pull/4061?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

