### PR TITLE
fix(user-testing): warn the author before a broken scenario reaches a tester

### DIFF
--- a/mcpjam-inspector/client/src/components/hosted/ScenarioChatPage.tsx
+++ b/mcpjam-inspector/client/src/components/hosted/ScenarioChatPage.tsx
@@ -945,8 +945,19 @@ export function ScenarioChatPage({
   // emulates. Seeding "claude" made every tester watch a Claude-branded shell
   // load a Cursor scenario; DEFAULT_HOST_STYLE is MCPJam precisely so
   // unresolved surfaces don't impersonate a vendor.
-  const hostStyle = session?.payload.hostStyle ?? DEFAULT_HOST_STYLE.id;
-  const chatUiOverride = session?.payload.chatUiOverride;
+  //
+  // A stored session is no proof of that either. sessionStorage outlives the
+  // page, so a tester who opens a second link redeems scenario B with scenario
+  // A's session still in hand, and the shell wears A's brand for the whole
+  // redemption — the same impersonation, sourced from the last visit instead of
+  // a seed. The session earns the shell only once its own share token is the
+  // one in the address bar; with no token there (the post-redeem strip removed
+  // it) the stored session is all there is, and it is this link's.
+  const sessionForCurrentLink =
+    tokenFromPath && session?.shareToken !== tokenFromPath ? null : session;
+  const hostStyle =
+    sessionForCurrentLink?.payload.hostStyle ?? DEFAULT_HOST_STYLE.id;
+  const chatUiOverride = sessionForCurrentLink?.payload.chatUiOverride;
   const shellStyle = getScenarioShellStyle(hostStyle, themeMode, chatUiOverride);
   const clientLabel = getScenarioHostLabel(hostStyle, chatUiOverride);
   const clientLogoSrc = getScenarioHostLogo(
@@ -1149,7 +1160,7 @@ export function ScenarioChatPage({
                             the scenario's internal name is the author's
                             label for it and means nothing to them. */}
                         <div className="flex min-w-0 flex-1 items-center gap-2">
-                          {session ? (
+                          {sessionForCurrentLink ? (
                             <>
                               <img
                                 src={clientLogoSrc}

--- a/mcpjam-inspector/client/src/components/hosted/ScenarioChatPage.tsx
+++ b/mcpjam-inspector/client/src/components/hosted/ScenarioChatPage.tsx
@@ -581,9 +581,18 @@ export function ScenarioChatPage({
     [sessionServersActive]
   );
 
+  const reachabilityCandidateIds = useMemo(
+    () => new Set(reachabilityCandidates.map((server) => server.serverId)),
+    [reachabilityCandidates]
+  );
+
+  // Scoped to the scenario, not to `accessVersion`: a re-redeem mid-session
+  // bumps the version without changing which servers this tester is exercising,
+  // and re-probing there would shut the composer again on every recovery.
   const reachabilityByServerId = useScenarioServerReachability(
     reachabilityCandidates,
-    !!session
+    !!session,
+    session?.scenarioId ?? null
   );
 
   const scenarioServerConfigs = useMemo(() => {
@@ -593,10 +602,16 @@ export function ScenarioChatPage({
       sessionServersActive.map((server) => {
         // Reported: a scenario whose only server never connected ran a full
         // session with a green dot next to it. This map drives the composer's
-        // server list, so a server that did not answer must not claim it did.
-        // Servers still owned by the OAuth gate have no reachability entry and
-        // keep the optimistic status the gate's own flow depends on.
-        const reachability = reachabilityByServerId[server.serverId];
+        // server list, so a server that did not answer must not claim it did —
+        // including on the renders before its probe has even registered, which
+        // is why a candidate with no entry yet reads as still connecting.
+        // Servers owned by the OAuth gate are never probed and keep the
+        // optimistic status the gate's own flow depends on.
+        const reachability =
+          reachabilityByServerId[server.serverId] ??
+          (reachabilityCandidateIds.has(server.serverId)
+            ? "checking"
+            : undefined);
         const connectionStatus =
           reachability === "unreachable"
             ? "failed"
@@ -619,7 +634,12 @@ export function ScenarioChatPage({
         ];
       })
     );
-  }, [session, sessionServersActive, reachabilityByServerId]);
+  }, [
+    session,
+    sessionServersActive,
+    reachabilityByServerId,
+    reachabilityCandidateIds,
+  ]);
 
   const reachableSessionServerIds = useMemo(
     () =>
@@ -643,13 +663,17 @@ export function ScenarioChatPage({
 
   // Sending before the probes answer is the silent failure in a new outfit: a
   // server still being checked is withheld from the turn, so the model would
-  // answer with none of the tools the tester was sent here to exercise.
+  // answer with none of the tools the tester was sent here to exercise. A
+  // candidate with no entry has not been probed yet either — the hook records
+  // "checking" from an effect, so the first render after a session resolves has
+  // an empty map and would otherwise open the composer on unprobed servers.
   const isCheckingServerReachability = useMemo(
     () =>
-      sessionServersActive.some(
-        (server) => reachabilityByServerId[server.serverId] === "checking"
+      reachabilityCandidates.some(
+        (server) =>
+          (reachabilityByServerId[server.serverId] ?? "checking") === "checking"
       ),
-    [sessionServersActive, reachabilityByServerId]
+    [reachabilityCandidates, reachabilityByServerId]
   );
 
   const hostedServerIdsByName = useMemo(() => {

--- a/mcpjam-inspector/client/src/components/hosted/ScenarioChatPage.tsx
+++ b/mcpjam-inspector/client/src/components/hosted/ScenarioChatPage.tsx
@@ -58,6 +58,7 @@ import {
   getScenarioHostLogo,
   getScenarioShellStyle,
 } from "@/lib/scenario-client-style";
+import { DEFAULT_HOST_STYLE } from "@/lib/client-styles";
 
 interface ScenarioChatPageProps {
   pathToken?: string | null;
@@ -940,7 +941,11 @@ export function ScenarioChatPage({
     [markOAuthRequired]
   );
 
-  const hostStyle = session?.payload.hostStyle ?? "claude";
+  // Before the redeem resolves we don't know which host this scenario
+  // emulates. Seeding "claude" made every tester watch a Claude-branded shell
+  // load a Cursor scenario; DEFAULT_HOST_STYLE is MCPJam precisely so
+  // unresolved surfaces don't impersonate a vendor.
+  const hostStyle = session?.payload.hostStyle ?? DEFAULT_HOST_STYLE.id;
   const chatUiOverride = session?.payload.chatUiOverride;
   const shellStyle = getScenarioShellStyle(hostStyle, themeMode, chatUiOverride);
   const clientLabel = getScenarioHostLabel(hostStyle, chatUiOverride);
@@ -1144,14 +1149,26 @@ export function ScenarioChatPage({
                             the scenario's internal name is the author's
                             label for it and means nothing to them. */}
                         <div className="flex min-w-0 flex-1 items-center gap-2">
-                          <img
-                            src={clientLogoSrc}
-                            alt=""
-                            className="size-5 shrink-0 object-contain"
-                          />
-                          <h1 className="min-w-0 truncate text-sm font-semibold text-foreground">
-                            {clientLabel}
-                          </h1>
+                          {session ? (
+                            <>
+                              <img
+                                src={clientLogoSrc}
+                                alt=""
+                                className="size-5 shrink-0 object-contain"
+                              />
+                              <h1 className="min-w-0 truncate text-sm font-semibold text-foreground">
+                                {clientLabel}
+                              </h1>
+                            </>
+                          ) : (
+                            // Placeholder rather than the default host's mark:
+                            // painting one brand and swapping to another once
+                            // the redeem lands reads as a glitch.
+                            <div
+                              aria-hidden
+                              className="h-5 w-28 animate-pulse rounded bg-muted"
+                            />
+                          )}
                         </div>
                         <button
                           onClick={handleOpenMcpJam}

--- a/mcpjam-inspector/client/src/components/hosted/ScenarioChatPage.tsx
+++ b/mcpjam-inspector/client/src/components/hosted/ScenarioChatPage.tsx
@@ -39,6 +39,7 @@ import { bootstrapServerToHostedOAuthDescriptor } from "@/lib/scenario-server-op
 import { useHostedOAuthRequirements } from "@/hooks/hosted/use-hosted-oauth-requirements";
 import { useScenarioTurnRating } from "@/hooks/useScenarioTurnRating";
 import { HostedTurnRating } from "@/components/hosted/hosted-turn-rating";
+import { useScenarioServerReachability } from "@/hooks/hosted/use-scenario-server-reachability";
 import { isHostedOAuthBusy } from "@/lib/hosted-oauth-resume";
 import type { HostedOAuthRequiredDetails } from "@/lib/hosted-oauth-required";
 import {
@@ -52,6 +53,7 @@ import { ActiveHostCapsResolverScope } from "@/contexts/active-host-client-capab
 import { ScenarioSurfaceProvider } from "@/contexts/scenario-surface-context";
 import { WebManagedServersProvider } from "@/contexts/web-managed-servers-context";
 import { ScenarioHostOnboardingOverlays } from "@/components/hosted/ScenarioHostOnboardingOverlays";
+import { ScenarioUnreachableServersBanner } from "@/components/hosted/ScenarioUnreachableServersBanner";
 import { useScenarioHostIntroGate } from "@/components/hosted/useScenarioHostIntroGate";
 import {
   getScenarioHostLabel,
@@ -568,25 +570,87 @@ export function ScenarioChatPage({
     isAuthenticated,
   });
 
+  // Only servers the OAuth machinery never touches. Every `useOAuth` row —
+  // including a discover-mode one, which the mirror also reports as true — is
+  // the gate's: it verifies them against this same /validate endpoint, and a
+  // row that is merely waiting for consent, or that answers 401 until it gets
+  // it, is not an unreachable server. Probing those here would double-connect
+  // and mislabel them.
+  const reachabilityCandidates = useMemo(
+    () => sessionServersActive.filter((server) => !server.useOAuth),
+    [sessionServersActive]
+  );
+
+  const reachabilityByServerId = useScenarioServerReachability(
+    reachabilityCandidates,
+    !!session
+  );
+
   const scenarioServerConfigs = useMemo(() => {
     if (!session) return {};
 
     return Object.fromEntries(
-      sessionServersActive.map((server) => [
-        server.serverName,
-        {
-          name: server.serverName,
-          config: {
-            url: "https://scenario-chat.invalid",
-          } as any,
-          lastConnectionTime: new Date(),
-          connectionStatus: "connected",
-          retryCount: 0,
-          enabled: true,
-        } satisfies ServerWithName,
-      ])
+      sessionServersActive.map((server) => {
+        // Reported: a scenario whose only server never connected ran a full
+        // session with a green dot next to it. This map drives the composer's
+        // server list, so a server that did not answer must not claim it did.
+        // Servers still owned by the OAuth gate have no reachability entry and
+        // keep the optimistic status the gate's own flow depends on.
+        const reachability = reachabilityByServerId[server.serverId];
+        const connectionStatus =
+          reachability === "unreachable"
+            ? "failed"
+            : reachability === "checking"
+              ? "connecting"
+              : "connected";
+
+        return [
+          server.serverName,
+          {
+            name: server.serverName,
+            config: {
+              url: "https://scenario-chat.invalid",
+            } as any,
+            lastConnectionTime: new Date(),
+            connectionStatus,
+            retryCount: 0,
+            enabled: true,
+          } satisfies ServerWithName,
+        ];
+      })
     );
-  }, [session, sessionServersActive]);
+  }, [session, sessionServersActive, reachabilityByServerId]);
+
+  const reachableSessionServerIds = useMemo(
+    () =>
+      sessionServersActive
+        .filter(
+          (server) => reachabilityByServerId[server.serverId] !== "unreachable"
+        )
+        .map((server) => server.serverId),
+    [sessionServersActive, reachabilityByServerId]
+  );
+
+  const unreachableServerNames = useMemo(
+    () =>
+      sessionServersActive
+        .filter(
+          (server) => reachabilityByServerId[server.serverId] === "unreachable"
+        )
+        .map((server) => server.serverName),
+    [sessionServersActive, reachabilityByServerId]
+  );
+
+  // Sending before the probes answer is the silent failure in a new outfit: a
+  // server still being checked is withheld from the turn, so the model would
+  // answer with none of the tools the tester was sent here to exercise.
+  const isCheckingServerReachability = useMemo(
+    () =>
+      sessionServersActive.some(
+        (server) => reachabilityByServerId[server.serverId] === "checking"
+      ),
+    [sessionServersActive, reachabilityByServerId]
+  );
 
   const hostedServerIdsByName = useMemo(() => {
     if (!session) return {};
@@ -1057,6 +1121,7 @@ export function ScenarioChatPage({
 
     return (
       <div className="relative flex min-h-0 flex-1 flex-col overflow-hidden">
+        <ScenarioUnreachableServersBanner serverNames={unreachableServerNames} />
         <ChatTabV2
           connectedOrConnectingServerConfigs={scenarioServerConfigs}
           selectedServerNames={sessionServersActive.map(
@@ -1070,9 +1135,13 @@ export function ScenarioChatPage({
             accessVersion: session.accessVersion,
             scenarioSurface: session.surface ?? "share_link",
             projectId: session.payload.projectId,
-            selectedServerIds: sessionServersActive.map(
-              (server) => server.serverId
-            ),
+            // `hostedContext.selectedServerIds` wins over the status-filtered
+            // names inside ChatTabV2, so a server proven unreachable has to be
+            // dropped HERE or the turn still ships it. Sending it anyway costs
+            // the whole turn: one server that fails `listTools` rejects the
+            // Promise.all behind the tool set. The tester already has the
+            // banner saying why it's missing.
+            selectedServerIds: reachableSessionServerIds,
             requestRefreshAccessVersion,
             refreshAccessSession,
             onAccessRevoked: handleHostedAccessRevoked,
@@ -1094,8 +1163,14 @@ export function ScenarioChatPage({
               ),
           }}
           onOAuthRequired={handleOAuthRequired}
-          scenarioComposerBlocked={introGate.composerBlocked}
-          scenarioComposerBlockedReason="Get started or authorize to send messages…"
+          scenarioComposerBlocked={
+            introGate.composerBlocked || isCheckingServerReachability
+          }
+          scenarioComposerBlockedReason={
+            introGate.composerBlocked
+              ? "Get started or authorize to send messages…"
+              : "Connecting to this session's tools…"
+          }
           scenarioOptionalInventory={scenarioOptionalInventory}
           onEnableScenarioOptionalServer={handleEnableScenarioOptionalServer}
           renderAssistantTurnActions={

--- a/mcpjam-inspector/client/src/components/hosted/ScenarioUnreachableServersBanner.tsx
+++ b/mcpjam-inspector/client/src/components/hosted/ScenarioUnreachableServersBanner.tsx
@@ -1,0 +1,48 @@
+import { AlertTriangle } from "lucide-react";
+
+/**
+ * Tells a tester that a server this session depends on did not connect.
+ *
+ * The failure it reports used to be silent: the composer's server list showed
+ * a green dot for every server in the bootstrap payload whether or not anything
+ * had ever reached them, so a tester could spend a whole session asking a model
+ * with no tools why it couldn't do the thing they were sent here to try.
+ *
+ * Copy stays in the visitor's frame — they followed a link, they cannot fix the
+ * scenario's setup, and transport detail is noise to them. Naming the server
+ * and pointing at whoever shared the link is the whole actionable content.
+ */
+export function ScenarioUnreachableServersBanner({
+  serverNames,
+}: {
+  serverNames: string[];
+}) {
+  // The live region is mounted even while empty. A `role="status"` element that
+  // appears already populated is not reliably announced — the region has to
+  // exist before the text arrives for the change to be one.
+  return (
+    <div role="status" aria-live="polite">
+      {serverNames.length === 0 ? null : (
+        <div className="border-b border-amber-500/30 bg-amber-500/10 px-4 py-2.5">
+          <div className="mx-auto flex w-full max-w-6xl items-start gap-2.5">
+            <AlertTriangle className="mt-0.5 size-4 shrink-0 text-amber-600 dark:text-amber-500" />
+            <div className="min-w-0 text-xs leading-relaxed">
+              <p className="font-medium text-foreground">
+                {serverNames.length > 1
+                  ? `${serverNames.length} servers couldn't be reached`
+                  : `${serverNames[0]} couldn't be reached`}
+              </p>
+              <p className="mt-0.5 text-muted-foreground">
+                {serverNames.length > 1 ? `${serverNames.join(", ")}. ` : null}
+                Anything that needs{" "}
+                {serverNames.length > 1 ? "these tools" : "this tool"} won&apos;t
+                work in this session. You can still chat — let whoever shared
+                this link know.
+              </p>
+            </div>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/mcpjam-inspector/client/src/components/hosted/__tests__/ScenarioChatPage.test.tsx
+++ b/mcpjam-inspector/client/src/components/hosted/__tests__/ScenarioChatPage.test.tsx
@@ -2030,7 +2030,13 @@ describe("ScenarioChatPage", () => {
       expect(
         screen.queryByText(/couldn't be reached/)
       ).not.toBeInTheDocument();
-      expect(mockValidateHostedServer).toHaveBeenCalledWith("srv_excalidraw");
+      expect(mockValidateHostedServer).toHaveBeenCalledWith(
+        "srv_excalidraw",
+        undefined,
+        undefined,
+        undefined,
+        expect.any(AbortSignal)
+      );
     });
 
     it("retries a blip rather than branding a healthy server unreachable", async () => {
@@ -2086,6 +2092,137 @@ describe("ScenarioChatPage", () => {
           expect.objectContaining({ scenarioComposerBlocked: false })
         )
       );
+    });
+
+    it("holds the composer on the very first frame, before the probe registers", async () => {
+      // The hook records "checking" from an effect, so the render that first
+      // has a session still has an empty verdict map. That frame is painted and
+      // interactive: a tester who sends into it ships a server nothing has
+      // reached yet, which is the failure the probe exists to prevent.
+      mockValidateHostedServer.mockImplementation(() => new Promise(() => {}));
+      writeDrawingScenario();
+
+      render(<ScenarioChatPage />);
+
+      expect(await screen.findByTestId("scenario-chat-tab")).toBeInTheDocument();
+      expect(mockChatTabV2.mock.calls.length).toBeGreaterThan(0);
+      for (const [props] of mockChatTabV2.mock.calls) {
+        expect(props).toMatchObject({
+          scenarioComposerBlocked: true,
+          scenarioComposerBlockedReason: "Connecting to this session's tools…",
+        });
+      }
+      const firstProps = mockChatTabV2.mock.calls[0]?.[0] as {
+        connectedOrConnectingServerConfigs?: Record<
+          string,
+          { connectionStatus?: string }
+        >;
+      };
+      expect(
+        firstProps.connectedOrConnectingServerConfigs?.excalidraw
+          ?.connectionStatus
+      ).toBe("connecting");
+    });
+
+    it("abandons a probe that outlives the page", async () => {
+      // The route holds an MCP connection open for its whole connect timeout.
+      // A tester who closed the tab has no use for the answer, and the
+      // connection should not stay open waiting to give it.
+      let probeSignal: AbortSignal | undefined;
+      mockValidateHostedServer.mockImplementation(
+        (
+          _serverId: string,
+          _oauthAccessToken: unknown,
+          _clientCapabilities: unknown,
+          _hostedContext: unknown,
+          signal?: AbortSignal
+        ) =>
+          new Promise(() => {
+            probeSignal = signal;
+          })
+      );
+      writeDrawingScenario();
+
+      const view = render(<ScenarioChatPage />);
+
+      await waitFor(() => expect(probeSignal).toBeDefined());
+      expect(probeSignal?.aborted).toBe(false);
+
+      view.unmount();
+
+      expect(probeSignal?.aborted).toBe(true);
+    });
+
+    it("re-probes a shared server when the tester opens another scenario", async () => {
+      // Opening a second link does not remount this page — the session is
+      // swapped in place — and two scenarios in one project can list the same
+      // server id. The first session's verdict used to carry over, so the
+      // second scenario reported a failure it had never observed, and the
+      // server was never probed for it at all.
+      vi.spyOn(console, "error").mockImplementation(() => {});
+      let serverIsDown = true;
+      mockValidateHostedServer.mockImplementation(async () => {
+        if (serverIsDown) {
+          throw new Error("SSE error: Non-200 status code (502)");
+        }
+        return { success: true, status: "connected", initInfo: null };
+      });
+      mockAuthFetch.mockImplementation(
+        async (_path: string, init: RequestInit) => {
+          const { scenarioToken } = JSON.parse(String(init.body)) as {
+            scenarioToken: string;
+          };
+          const scenarioId = scenarioToken === "tok_b" ? "sbx_b" : "sbx_a";
+          return createFetchResponse({
+            scenarioId,
+            accessVersion: 1,
+            bootstrap: {
+              projectId: "ws_1",
+              scenarioId,
+              name: "Drawing Scenario",
+              description: "Hosted scenario",
+              hostStyle: "cursor",
+              mode: "anyone_with_link",
+              allowGuestAccess: true,
+              viewerIsProjectMember: false,
+              systemPrompt: "You are helpful.",
+              modelId: "openai/gpt-5-mini",
+              temperature: 0.4,
+              requireToolApproval: false,
+              servers: [
+                {
+                  serverId: "srv_excalidraw",
+                  serverName: "excalidraw",
+                  useOAuth: false,
+                  serverUrl: "https://mcp.excalidraw.example/mcp",
+                  clientId: null,
+                  oauthScopes: null,
+                },
+              ],
+            },
+          });
+        }
+      );
+
+      const view = render(<ScenarioChatPage pathToken="tok_a" />);
+
+      expect(
+        await screen.findByText("excalidraw couldn't be reached")
+      ).toBeInTheDocument();
+
+      serverIsDown = false;
+      window.history.replaceState({}, "", "/user-testing/other/tok_b");
+      view.rerender(<ScenarioChatPage pathToken="tok_b" />);
+
+      await waitFor(() =>
+        expect(latestServerConfigs()?.excalidraw?.connectionStatus).toBe(
+          "connected"
+        )
+      );
+      expect(screen.queryByText(/couldn't be reached/)).not.toBeInTheDocument();
+      expect(latestHostedContext()?.selectedServerIds).toEqual([
+        "srv_excalidraw",
+      ]);
     });
   });
 });

--- a/mcpjam-inspector/client/src/components/hosted/__tests__/ScenarioChatPage.test.tsx
+++ b/mcpjam-inspector/client/src/components/hosted/__tests__/ScenarioChatPage.test.tsx
@@ -308,6 +308,47 @@ describe("ScenarioChatPage", () => {
     expect(screen.getByAltText("MCPJam")).toBeInTheDocument();
   });
 
+  it("does not wear the previous scenario's brand while a new link redeems", async () => {
+    // sessionStorage outlives the page, so a tester opening a second link still
+    // holds the first scenario's session. Dressing the redemption in that
+    // scenario's host is the same impersonation as seeding one — the stored
+    // session simply supplies the wrong vendor instead of a hardcoded one.
+    writeScenarioSession({
+      scenarioId: "sbx_previous",
+      accessVersion: 1,
+      shareToken: "tok_previous",
+      payload: {
+        projectId: "ws_1",
+        scenarioId: "sbx_previous",
+        name: "Previous Scenario",
+        description: "Hosted scenario",
+        hostStyle: "claude",
+        mode: "invited_only",
+        allowGuestAccess: false,
+        viewerIsProjectMember: true,
+        systemPrompt: "You are helpful.",
+        modelId: "openai/gpt-5-mini",
+        temperature: 0.4,
+        requireToolApproval: true,
+        servers: [],
+      },
+    });
+    mockAuthFetch.mockImplementation(() => new Promise(() => {}));
+
+    const { container } = render(<ScenarioChatPage pathToken="tok_new" />);
+
+    await waitFor(() => expect(mockAuthFetch).toHaveBeenCalled());
+
+    expect(
+      container.querySelector('[data-host-style="claude"]')
+    ).not.toBeInTheDocument();
+    expect(
+      container.querySelector('[data-host-style="mcpjam"]')
+    ).toBeInTheDocument();
+    expect(screen.queryByText("Claude")).not.toBeInTheDocument();
+    expect(screen.getByAltText("MCPJam")).toBeInTheDocument();
+  });
+
   // Removed: "uses the Claude loading indicator variant for Claude-style
   // hosted scenarios". The indicator no longer flows through a
   // `loadingIndicatorVariant` prop on ChatTabV2 — the inner thread reads

--- a/mcpjam-inspector/client/src/components/hosted/__tests__/ScenarioChatPage.test.tsx
+++ b/mcpjam-inspector/client/src/components/hosted/__tests__/ScenarioChatPage.test.tsx
@@ -1923,4 +1923,169 @@ describe("ScenarioChatPage", () => {
       );
     });
   });
+
+  describe("a tester is told when a server did not connect", () => {
+    // The reported failure: a scenario built on an Excalidraw server ran a full
+    // session without it. The bootstrap payload lists servers but never touches
+    // them, and the page then hard-coded `connectionStatus: "connected"` for
+    // every row — so the composer showed a green dot for a server nothing had
+    // ever reached, and the first real connection attempt happened inside a
+    // chat turn.
+    function writeDrawingScenario() {
+      writeScenarioSession({
+        scenarioId: "sbx_1",
+        accessVersion: 1,
+        payload: {
+          projectId: "ws_1",
+          scenarioId: "sbx_1",
+          name: "Drawing Scenario",
+          description: "Hosted scenario",
+          hostStyle: "cursor",
+          mode: "anyone_with_link",
+          allowGuestAccess: true,
+          viewerIsProjectMember: false,
+          systemPrompt: "You are helpful.",
+          modelId: "openai/gpt-5-mini",
+          temperature: 0.4,
+          requireToolApproval: false,
+          servers: [
+            {
+              serverId: "srv_excalidraw",
+              serverName: "excalidraw",
+              useOAuth: false,
+              serverUrl: "https://mcp.excalidraw.example/mcp",
+              clientId: null,
+              oauthScopes: null,
+            },
+          ],
+        },
+      });
+    }
+
+    function latestHostedContext() {
+      const calls = mockChatTabV2.mock.calls;
+      const last = calls[calls.length - 1]?.[0] as
+        | { hostedContext?: { selectedServerIds?: string[] } }
+        | undefined;
+      return last?.hostedContext;
+    }
+
+    function latestServerConfigs() {
+      const calls = mockChatTabV2.mock.calls;
+      const last = calls[calls.length - 1]?.[0] as
+        | {
+            connectedOrConnectingServerConfigs?: Record<
+              string,
+              { connectionStatus?: string }
+            >;
+          }
+        | undefined;
+      return last?.connectedOrConnectingServerConfigs;
+    }
+
+    it("names the unreachable server instead of reporting it connected", async () => {
+      const consoleError = vi
+        .spyOn(console, "error")
+        .mockImplementation(() => {});
+      mockValidateHostedServer.mockRejectedValue(
+        new Error("SSE error: Non-200 status code (502)")
+      );
+      writeDrawingScenario();
+
+      render(<ScenarioChatPage />);
+
+      expect(
+        await screen.findByText("excalidraw couldn't be reached")
+      ).toBeInTheDocument();
+      await waitFor(() =>
+        expect(latestServerConfigs()?.excalidraw?.connectionStatus).toBe(
+          "failed"
+        )
+      );
+      // Shipping it to the turn anyway costs the whole turn: one server that
+      // fails `listTools` rejects the Promise.all behind the tool set.
+      expect(latestHostedContext()?.selectedServerIds).toEqual([]);
+      // Transport detail is noise to someone who followed a link, but whoever
+      // debugs the scenario still needs it.
+      expect(consoleError).toHaveBeenCalledWith(
+        "[useScenarioServerReachability] server did not connect",
+        expect.objectContaining({
+          serverId: "srv_excalidraw",
+          serverName: "excalidraw",
+        })
+      );
+    });
+
+    it("says nothing when the server answers", async () => {
+      writeDrawingScenario();
+
+      render(<ScenarioChatPage />);
+
+      expect(await screen.findByTestId("scenario-chat-tab")).toBeInTheDocument();
+      await waitFor(() =>
+        expect(latestServerConfigs()?.excalidraw?.connectionStatus).toBe(
+          "connected"
+        )
+      );
+      expect(
+        screen.queryByText(/couldn't be reached/)
+      ).not.toBeInTheDocument();
+      expect(mockValidateHostedServer).toHaveBeenCalledWith("srv_excalidraw");
+    });
+
+    it("retries a blip rather than branding a healthy server unreachable", async () => {
+      // The verdict is final for the session — nothing re-probes, and it drops
+      // the server from the turn — so a 502 or a dropped connection must not
+      // decide it on the first try.
+      mockValidateHostedServer
+        .mockRejectedValueOnce(new Error("Bad Gateway"))
+        .mockResolvedValue({ success: true, status: "connected" });
+      writeDrawingScenario();
+
+      render(<ScenarioChatPage />);
+
+      await waitFor(() =>
+        expect(latestServerConfigs()?.excalidraw?.connectionStatus).toBe(
+          "connected"
+        )
+      );
+      expect(mockValidateHostedServer).toHaveBeenCalledTimes(2);
+      expect(screen.queryByText(/couldn't be reached/)).not.toBeInTheDocument();
+    });
+
+    it("holds the composer until the probe answers", async () => {
+      // Sending while a server is still being checked withholds it from the
+      // turn, which is the same silent failure wearing a different hat: the
+      // model answers with none of the tools the tester was sent here to try.
+      let resolveValidation: (value: unknown) => void = () => {};
+      mockValidateHostedServer.mockImplementation(
+        () =>
+          new Promise((resolve) => {
+            resolveValidation = resolve;
+          })
+      );
+      writeDrawingScenario();
+
+      render(<ScenarioChatPage />);
+
+      await waitFor(() =>
+        expect(mockChatTabV2).toHaveBeenLastCalledWith(
+          expect.objectContaining({
+            scenarioComposerBlocked: true,
+            scenarioComposerBlockedReason: "Connecting to this session's tools…",
+          })
+        )
+      );
+
+      await act(async () => {
+        resolveValidation({ success: true, status: "connected" });
+      });
+
+      await waitFor(() =>
+        expect(mockChatTabV2).toHaveBeenLastCalledWith(
+          expect.objectContaining({ scenarioComposerBlocked: false })
+        )
+      );
+    });
+  });
 });

--- a/mcpjam-inspector/client/src/components/hosted/__tests__/ScenarioChatPage.test.tsx
+++ b/mcpjam-inspector/client/src/components/hosted/__tests__/ScenarioChatPage.test.tsx
@@ -285,6 +285,29 @@ describe("ScenarioChatPage", () => {
     );
   });
 
+  it("does not brand the shell as Claude while the link is still redeeming", async () => {
+    // Reported by testers on an org-invited scenario: the header showed the
+    // Claude mark and the word "Claude" for the whole load, on a scenario that
+    // wasn't a Claude host at all. The redeem is held open here so the
+    // bootstrapping frame is the one under assertion.
+    mockAuthFetch.mockImplementation(() => new Promise(() => {}));
+
+    const { container } = render(<ScenarioChatPage pathToken="tok_loading" />);
+
+    await waitFor(() => expect(mockAuthFetch).toHaveBeenCalled());
+
+    expect(
+      container.querySelector('[data-host-style="claude"]')
+    ).not.toBeInTheDocument();
+    expect(
+      container.querySelector('[data-host-style="mcpjam"]')
+    ).toBeInTheDocument();
+    // No host identity is claimed until the redeem says which host this is —
+    // painting one brand and swapping to another reads as a glitch.
+    expect(screen.queryByText("Claude")).not.toBeInTheDocument();
+    expect(screen.getByAltText("MCPJam")).toBeInTheDocument();
+  });
+
   // Removed: "uses the Claude loading indicator variant for Claude-style
   // hosted scenarios". The indicator no longer flows through a
   // `loadingIndicatorVariant` prop on ChatTabV2 — the inner thread reads

--- a/mcpjam-inspector/client/src/components/hosts/HostCanvas.tsx
+++ b/mcpjam-inspector/client/src/components/hosts/HostCanvas.tsx
@@ -15,6 +15,7 @@ import { Plus, Server } from "lucide-react";
 import "@xyflow/react/dist/style.css";
 import { Badge } from "@mcpjam/design-system/badge";
 import { getScenarioHostLogo } from "@/lib/scenario-client-style";
+import { DEFAULT_HOST_STYLE } from "@/lib/client-styles";
 import { cn } from "@/lib/utils";
 import type {
   HostBuilderAddServerNodeData,
@@ -46,7 +47,7 @@ const HostNodeRenderer = memo(
   (props: NodeProps<Node<HostBuilderNodeData, "hostNode">>) => {
     const { data, selected } = props;
     const isHostCard = data.kind === "host";
-    const hostStyle = data.hostStyle ?? "claude";
+    const hostStyle = data.hostStyle ?? DEFAULT_HOST_STYLE.id;
     const hostLogoSrc = isHostCard ? getScenarioHostLogo(hostStyle) : null;
 
     return (

--- a/mcpjam-inspector/client/src/components/hosts/__tests__/HostCanvas.test.tsx
+++ b/mcpjam-inspector/client/src/components/hosts/__tests__/HostCanvas.test.tsx
@@ -1,0 +1,78 @@
+import { describe, expect, it } from "vitest";
+import { render } from "@testing-library/react";
+import { ReactFlowProvider } from "@xyflow/react";
+import { DEFAULT_HOST_STYLE } from "@/lib/client-styles";
+import { getScenarioHostLogo } from "@/lib/scenario-client-style";
+import { HostCanvas } from "../HostCanvas";
+import {
+  HOST_BUILDER_HOST_NODE_ID,
+  type HostBuilderNodeData,
+  type HostBuilderViewModel,
+} from "../host-builder-types";
+
+function renderCanvas(hostData: Partial<HostBuilderNodeData>) {
+  const viewModel: HostBuilderViewModel = {
+    title: "Test host",
+    nodes: [
+      {
+        id: HOST_BUILDER_HOST_NODE_ID,
+        type: "hostNode",
+        position: { x: 0, y: 0 },
+        data: {
+          kind: "host",
+          title: "Host",
+          subtitle: "Test host",
+          chips: [],
+          state: "ready",
+          ...hostData,
+        },
+      },
+    ],
+    edges: [],
+  };
+  return render(
+    <ReactFlowProvider>
+      <div style={{ width: 900, height: 700 }}>
+        <HostCanvas
+          viewModel={viewModel}
+          selectedNodeId={null}
+          onSelectNode={() => {}}
+          onClearSelection={() => {}}
+          onAddServer={() => {}}
+        />
+      </div>
+    </ReactFlowProvider>
+  );
+}
+
+function hostLogoSrc(container: HTMLElement): string | null {
+  const img = container.querySelector(
+    `.react-flow__node[data-id="${HOST_BUILDER_HOST_NODE_ID}"] img`
+  );
+  expect(img).not.toBeNull();
+  return img!.getAttribute("src");
+}
+
+describe("HostCanvas host style logo", () => {
+  const defaultLogo = getScenarioHostLogo(DEFAULT_HOST_STYLE.id);
+
+  it("falls back to the default host style when hostStyle is omitted", () => {
+    const { container } = renderCanvas({});
+    expect(hostLogoSrc(container)).toBe(defaultLogo);
+  });
+
+  // `hostStyle` is typed `HostStyleId` (a plain string), so an empty string is
+  // reachable without a cast; the registry treats it as an unknown id.
+  it("falls back to the default host style when hostStyle is empty", () => {
+    const { container } = renderCanvas({ hostStyle: "" });
+    expect(hostLogoSrc(container)).toBe(defaultLogo);
+  });
+
+  it("renders the logo of the requested host style", () => {
+    const chatgptLogo = getScenarioHostLogo("chatgpt");
+    expect(chatgptLogo).not.toBe(defaultLogo);
+
+    const { container } = renderCanvas({ hostStyle: "chatgpt" });
+    expect(hostLogoSrc(container)).toBe(chatgptLogo);
+  });
+});

--- a/mcpjam-inspector/client/src/components/scenarios/ScenarioShareBanner.tsx
+++ b/mcpjam-inspector/client/src/components/scenarios/ScenarioShareBanner.tsx
@@ -53,8 +53,9 @@ function useScenarioShareInvite(scenario: ScenarioSettings) {
   // handing the link out here made the two surfaces disagree — the Edit tab
   // refused to give the link while this strip copied it out anyway. Nothing is
   // rotated or revoked; the token returns when the scenario can run again.
+  const unrunnableReason = scenario.environmentError?.message ?? null;
   const shareLink =
-    scenario.link?.token && !scenario.environmentError
+    scenario.link?.token && !unrunnableReason
       ? buildScenarioLink(scenario.link.token, scenario.name)
       : null;
   const displayLink = shareLink?.replace(/^https?:\/\//, "") ?? null;
@@ -70,7 +71,11 @@ function useScenarioShareInvite(scenario: ScenarioSettings) {
   };
 
   const handleInvite = async () => {
-    if (!normalizedEmail || emailInvalid || isInviting) return;
+    // Inviting mails the same withheld link out, so it stops on the same
+    // condition: an invite to a scenario that can't run is a broken session
+    // with someone else's name on it.
+    if (!normalizedEmail || emailInvalid || isInviting || unrunnableReason)
+      return;
     setIsInviting(true);
     try {
       await upsertScenarioMember({
@@ -90,6 +95,7 @@ function useScenarioShareInvite(scenario: ScenarioSettings) {
 
   return {
     shareLink,
+    unrunnableReason,
     displayLink,
     email,
     setEmail,
@@ -112,6 +118,7 @@ function InviteByEmailControl({
   isInviting,
   normalizedEmail,
   emailInvalid,
+  unrunnableReason,
   handleInvite,
 }: {
   id: string;
@@ -122,6 +129,7 @@ function InviteByEmailControl({
   isInviting: boolean;
   normalizedEmail: string;
   emailInvalid: boolean;
+  unrunnableReason: string | null;
   handleInvite: () => void;
 }) {
   return (
@@ -148,6 +156,7 @@ function InviteByEmailControl({
             type="email"
             placeholder="name@company.com"
             value={email}
+            disabled={Boolean(unrunnableReason)}
             onChange={(event) => setEmail(event.target.value)}
             onKeyDown={(event) => {
               if (event.key === "Enter") {
@@ -162,12 +171,28 @@ function InviteByEmailControl({
           <Button
             type="button"
             size="sm"
-            disabled={!normalizedEmail || emailInvalid || isInviting}
+            disabled={
+              !normalizedEmail ||
+              emailInvalid ||
+              isInviting ||
+              Boolean(unrunnableReason)
+            }
             onClick={() => void handleInvite()}
           >
             {isInviting ? "…" : "Invite"}
           </Button>
         </div>
+        {/* The trigger stays live so the reason is reachable — a popover that
+            refuses to open leaves the author guessing why. */}
+        {unrunnableReason ? (
+          <p
+            className="text-xs text-muted-foreground"
+            data-testid={`${id}-invite-unrunnable`}
+          >
+            {unrunnableReason} Point this scenario at a working environment to
+            invite testers again.
+          </p>
+        ) : null}
         {emailInvalid ? (
           <p
             id={`${id}-email-error`}
@@ -192,6 +217,7 @@ function ShareActions({
   isInviting,
   normalizedEmail,
   emailInvalid,
+  unrunnableReason,
   handleCopyLink,
   handleInvite,
   showInvite,
@@ -206,6 +232,7 @@ function ShareActions({
   isInviting: boolean;
   normalizedEmail: string;
   emailInvalid: boolean;
+  unrunnableReason: string | null;
   handleCopyLink: () => void;
   handleInvite: () => void;
   showInvite: boolean;
@@ -223,6 +250,7 @@ function ShareActions({
           isInviting={isInviting}
           normalizedEmail={normalizedEmail}
           emailInvalid={emailInvalid}
+          unrunnableReason={unrunnableReason}
           handleInvite={handleInvite}
         />
       ) : null}

--- a/mcpjam-inspector/client/src/components/scenarios/ScenarioShareBanner.tsx
+++ b/mcpjam-inspector/client/src/components/scenarios/ScenarioShareBanner.tsx
@@ -30,15 +30,33 @@ import { cn } from "@/lib/utils";
 
 const INVITE_EMAIL_PATTERN = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
 
+/**
+ * What stands in for the URL. "No share link yet" is only true before one has
+ * been minted — saying it while a link exists but is withheld reads as a
+ * missing feature rather than a scenario the author needs to fix.
+ */
+function withheldOrAbsentLinkLabel(scenario: ScenarioSettings): string {
+  if (scenario.link?.token && scenario.environmentError) {
+    return "Withheld — this scenario can't run.";
+  }
+  return "No share link yet.";
+}
+
 function useScenarioShareInvite(scenario: ScenarioSettings) {
   const { upsertScenarioMember } = useScenarioMutations();
   const [email, setEmail] = useState("");
   const [inviteOpen, setInviteOpen] = useState(false);
   const [isInviting, setIsInviting] = useState(false);
 
-  const shareLink = scenario.link?.token
-    ? buildScenarioLink(scenario.link.token, scenario.name)
-    : null;
+  // Withheld on the same condition `ScenarioShareSection` withholds it: a
+  // scenario whose environment doesn't resolve won't open for a tester, so
+  // handing the link out here made the two surfaces disagree — the Edit tab
+  // refused to give the link while this strip copied it out anyway. Nothing is
+  // rotated or revoked; the token returns when the scenario can run again.
+  const shareLink =
+    scenario.link?.token && !scenario.environmentError
+      ? buildScenarioLink(scenario.link.token, scenario.name)
+      : null;
   const displayLink = shareLink?.replace(/^https?:\/\//, "") ?? null;
   const normalizedEmail = email.trim().toLowerCase();
   const emailInvalid =
@@ -265,7 +283,7 @@ export function ScenarioShareBanner({
           )}
           data-testid="user-testing-share-link"
         >
-          {share.displayLink ?? "No share link yet."}
+          {share.displayLink ?? withheldOrAbsentLinkLabel(scenario)}
         </button>
       </div>
       <ShareActions id="user-testing-share" showInvite {...share} />
@@ -292,9 +310,9 @@ export function ScenarioShareEmptyPanel({
 }) {
   const { isAuthenticated } = useConvexAuth();
   const share = useScenarioShareInvite(scenario);
-  // Same gate as the header Open preview: a broken environment won't open
-  // for testers either, so framing it here would only mislead.
-  const canOpenPreview = Boolean(share.shareLink && !scenario.environmentError);
+  // `shareLink` is already withheld while the environment can't resolve, so
+  // this is the same gate the header Open preview uses.
+  const canOpenPreview = Boolean(share.shareLink);
 
   return (
     <div
@@ -356,7 +374,7 @@ export function ScenarioShareEmptyPanel({
             className="mt-6 rounded-xl border border-border/60 bg-muted/30 px-4 py-3 text-sm text-muted-foreground"
             data-testid="user-testing-share-empty-blocked"
           >
-            {share.shareLink
+            {scenario.link?.token && scenario.environmentError
               ? "This scenario can't be opened right now — its environment isn't resolving, so the link won't load for you or a tester."
               : "No share link yet."}
           </p>
@@ -375,7 +393,7 @@ export function ScenarioShareEmptyPanel({
             className="min-w-0 flex-1 basis-full truncate rounded-lg border border-border/60 bg-muted/30 px-3 py-1.5 font-mono text-xs text-muted-foreground sm:basis-0"
             title={share.shareLink ?? undefined}
           >
-            {share.displayLink ?? "No share link yet."}
+            {share.displayLink ?? withheldOrAbsentLinkLabel(scenario)}
           </span>
           <ShareActions
             id="user-testing-share-empty"

--- a/mcpjam-inspector/client/src/components/scenarios/UserTestingScenarioDetail.tsx
+++ b/mcpjam-inspector/client/src/components/scenarios/UserTestingScenarioDetail.tsx
@@ -51,6 +51,7 @@ import {
 } from "@/components/environment-composer/environment-stack";
 import { isAdhocUnavailable } from "@/components/environment-composer/resolve-stacks";
 import { useComposerResolver } from "@/components/environment-composer/use-composer-resolver";
+import { useCloudServerReadiness } from "@/components/environment-composer/use-cloud-server-readiness";
 import { NameEnvironmentDialog } from "@/components/project-environments/NameEnvironmentDialog";
 import { TextareaAutosize } from "@/components/ui/textarea-autosize";
 import {
@@ -379,6 +380,27 @@ export function UserTestingScenarioDetail({
   // this state calls for.
   const environmentError = scenario.environmentError ?? null;
 
+  /**
+   * The other way a scenario ships broken, which nothing on this surface used
+   * to say: the environment resolves fine, but every server behind it is one a
+   * shared session can't reach — a stdio server, or a localhost/private URL.
+   * The author runs it locally, it works, and the failure is discovered by
+   * whoever they sent the link to.
+   *
+   * Warn rather than withhold. Unlike an unresolvable environment this is
+   * measured from the catalog, `assessCloudServerReadiness` deliberately fails
+   * open on anything it can't see, and the author may be mid-setup — so the
+   * cost of being wrong here should be a notice, not a confiscated link.
+   */
+  const serverReadiness = useCloudServerReadiness({
+    // Trimmed, matching `useComposerResolver` — the same id reaches both.
+    projectId: scenario.projectId.trim(),
+    state: composer,
+    environments: liveNamedEnvironments,
+  });
+  const unreachableServerNames =
+    serverReadiness.status === "local_only" ? serverReadiness.serverNames : null;
+
   const publishLink = scenario.link?.token
     ? buildScenarioLink(scenario.link.token, scenario.name)
     : null;
@@ -541,6 +563,28 @@ export function UserTestingScenarioDetail({
                       </p>
                       <p className="mt-0.5 text-xs text-muted-foreground">
                         {environmentError.message} Its sessions are unaffected.
+                      </p>
+                    </div>
+                  </div>
+                ) : null}
+
+                {unreachableServerNames ? (
+                  <div
+                    data-testid="user-testing-detail-unreachable-servers"
+                    className="mb-4 flex items-start gap-2 rounded-md border border-amber-500/30 bg-amber-500/10 px-4 py-3"
+                  >
+                    <AlertTriangle className="mt-0.5 size-4 shrink-0 text-amber-600 dark:text-amber-500" />
+                    <div className="min-w-0 text-sm">
+                      <p className="font-medium text-foreground">
+                        Testers won&apos;t be able to reach{" "}
+                        {unreachableServerNames.join(", ")}.
+                      </p>
+                      <p className="mt-0.5 text-xs text-muted-foreground">
+                        A shared session runs in MCPJam&apos;s cloud, which
+                        can&apos;t reach a stdio server or a localhost or
+                        private-address URL. Expose the server over HTTPS and
+                        point this scenario at that URL — it will work for you
+                        locally either way.
                       </p>
                     </div>
                   </div>

--- a/mcpjam-inspector/client/src/components/scenarios/__tests__/ScenarioShareBanner.test.tsx
+++ b/mcpjam-inspector/client/src/components/scenarios/__tests__/ScenarioShareBanner.test.tsx
@@ -67,6 +67,31 @@ describe("ScenarioShareBanner", () => {
     const { container } = render(<ScenarioShareBanner scenario={scenario} />);
     expect(container).toBeEmptyDOMElement();
   });
+
+  it("withholds the link while the environment can't resolve", () => {
+    // The Edit tab already refused to hand this link out. This strip copied it
+    // to the clipboard anyway, so the same scenario was both unshareable and
+    // one click from being shared.
+    render(
+      <ScenarioShareBanner
+        scenario={
+          {
+            ...scenario,
+            environmentError: {
+              code: "ENV_ARCHIVED",
+              message: "Environment archived.",
+            },
+          } as ScenarioSettings
+        }
+      />,
+    );
+
+    expect(screen.queryByText("mcpjam.link/t/tok")).not.toBeInTheDocument();
+    expect(
+      screen.getByText("Withheld — this scenario can't run."),
+    ).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Copy link" })).toBeDisabled();
+  });
 });
 
 describe("ScenarioShareEmptyPanel", () => {

--- a/mcpjam-inspector/client/src/components/scenarios/__tests__/ScenarioShareBanner.test.tsx
+++ b/mcpjam-inspector/client/src/components/scenarios/__tests__/ScenarioShareBanner.test.tsx
@@ -92,6 +92,61 @@ describe("ScenarioShareBanner", () => {
     ).toBeInTheDocument();
     expect(screen.getByRole("button", { name: "Copy link" })).toBeDisabled();
   });
+
+  it("invites a tester when the scenario can run", async () => {
+    render(<ScenarioShareBanner scenario={scenario} />);
+
+    fireEvent.click(screen.getByTestId("user-testing-share-invite"));
+    fireEvent.change(screen.getByLabelText("Invite with email"), {
+      target: { value: "tester@example.com" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: "Invite" }));
+
+    await waitFor(() =>
+      expect(upsertScenarioMemberMock).toHaveBeenCalledWith({
+        scenarioId: "cb-1",
+        email: "tester@example.com",
+        sendInviteEmail: true,
+      }),
+    );
+  });
+
+  it("does not email a tester while the environment can't resolve", async () => {
+    // Withholding the link but leaving Invite live mailed the same dead link
+    // out under the author's name.
+    const { rerender } = render(<ScenarioShareBanner scenario={scenario} />);
+
+    fireEvent.click(screen.getByTestId("user-testing-share-invite"));
+    fireEvent.change(screen.getByLabelText("Invite with email"), {
+      target: { value: "tester@example.com" },
+    });
+
+    rerender(
+      <ScenarioShareBanner
+        scenario={
+          {
+            ...scenario,
+            environmentError: {
+              code: "ENV_ARCHIVED",
+              message: "Environment archived.",
+            },
+          } as ScenarioSettings
+        }
+      />,
+    );
+
+    const emailInput = screen.getByLabelText("Invite with email");
+    expect(emailInput).toBeDisabled();
+    expect(screen.getByRole("button", { name: "Invite" })).toBeDisabled();
+    expect(
+      screen.getByTestId("user-testing-share-invite-unrunnable"),
+    ).toHaveTextContent("Environment archived.");
+
+    fireEvent.keyDown(emailInput, { key: "Enter" });
+    fireEvent.click(screen.getByRole("button", { name: "Invite" }));
+
+    await waitFor(() => expect(upsertScenarioMemberMock).not.toHaveBeenCalled());
+  });
 });
 
 describe("ScenarioShareEmptyPanel", () => {

--- a/mcpjam-inspector/client/src/components/scenarios/__tests__/UserTestingScenarioDetail.test.tsx
+++ b/mcpjam-inspector/client/src/components/scenarios/__tests__/UserTestingScenarioDetail.test.tsx
@@ -36,6 +36,7 @@ const {
   environmentState,
   namedListState,
   flagState,
+  serverReadinessState,
 } = vi.hoisted(() => ({
   navigateMock: vi.fn(),
   locationState: { search: "" },
@@ -57,6 +58,9 @@ const {
   // loading, an array once settled.
   namedListState: { value: [] as unknown },
   flagState: { environmentsEnabled: true },
+  // What `useCloudServerReadiness` answers with. "ok" for every spec that
+  // isn't about hosted reachability.
+  serverReadinessState: { value: { status: "ok" } as unknown },
 }));
 
 vi.mock("react-router", () => ({
@@ -216,6 +220,12 @@ vi.mock("@/hooks/useClients", () => ({
   useHost: () => hostState,
 }));
 
+// The real hook reads the project's server catalog through four Convex-backed
+// queries; these specs drive its verdict directly.
+vi.mock("@/components/environment-composer/use-cloud-server-readiness", () => ({
+  useCloudServerReadiness: () => serverReadinessState.value,
+}));
+
 import { UserTestingScenarioDetail } from "../UserTestingScenarioDetail";
 import { toast } from "@/lib/toast";
 
@@ -283,6 +293,7 @@ beforeEach(() => {
   environmentState.row = undefined;
   namedListState.value = [];
   flagState.environmentsEnabled = true;
+  serverReadinessState.value = { status: "ok" };
 });
 
 describe("UserTestingScenarioDetail", () => {
@@ -438,6 +449,33 @@ describe("UserTestingScenarioDetail", () => {
     expect(navigateMock).toHaveBeenCalledWith("/user-testing/cb-1?tab=sessions", {
       replace: true,
     });
+  });
+
+  it("warns on Edit when no tester could reach the scenario's servers", () => {
+    // The environment resolves — nothing above catches this — but every server
+    // behind it is stdio or a localhost URL, so it works for the author and
+    // fails for everyone they send the link to.
+    serverReadinessState.value = {
+      status: "local_only",
+      labels: ["Checkout flow"],
+      serverNames: ["excalidraw"],
+    };
+
+    renderEdit({ environmentId: "env-1", environmentName: "Checkout flow" });
+
+    const notice = screen.getByTestId(
+      "user-testing-detail-unreachable-servers",
+    );
+    expect(notice).toHaveTextContent("excalidraw");
+    expect(notice).toHaveTextContent(/can't reach a stdio server/i);
+  });
+
+  it("says nothing about reachability when the servers are reachable", () => {
+    renderEdit({ environmentId: "env-1", environmentName: "Checkout flow" });
+
+    expect(
+      screen.queryByTestId("user-testing-detail-unreachable-servers"),
+    ).not.toBeInTheDocument();
   });
 
   it("hides Edit setup on a host-backed scenario (composer can't run)", () => {

--- a/mcpjam-inspector/client/src/hooks/hosted/use-scenario-server-reachability.ts
+++ b/mcpjam-inspector/client/src/hooks/hosted/use-scenario-server-reachability.ts
@@ -1,0 +1,173 @@
+import { useEffect, useRef, useState } from "react";
+import { validateHostedServer } from "@/lib/apis/web/servers-api";
+import { BootstrapNotReadyError } from "@/lib/app-ready";
+
+/**
+ * Whether this session can actually reach a server, as opposed to whether the
+ * bootstrap payload listed it.
+ *
+ * "checking" is the pre-answer state. It is deliberately not treated as
+ * reachable: the reported failure was a tester spending a whole session on a
+ * scenario whose only server never connected, so an unanswered probe must not
+ * read as a working session.
+ */
+export type ScenarioServerReachability =
+  | "checking"
+  | "reachable"
+  | "unreachable";
+
+/**
+ * Attempts while the request builder is still refusing to build. `/redeem`
+ * resolves before `useApiContext` has published this scenario's project and
+ * server ids, so the first probes lose that race. These cost nothing — the
+ * builder throws synchronously, without a round trip — so they are counted
+ * separately from attempts that actually reached the server.
+ */
+const BOOTSTRAP_ATTEMPTS = 6;
+const BOOTSTRAP_RETRY_DELAY_MS = 300;
+
+/**
+ * Attempts that reach the wire. Calling a healthy server unreachable is not a
+ * cosmetic error: the verdict is final for the session (nothing re-probes), it
+ * drops the server from the turn, and it tells the tester something false. One
+ * retry covers the blips that would otherwise do that — a 502, a dropped
+ * connection, a server slow to wake — without making a genuinely dead server
+ * take a minute to report.
+ */
+const PROBE_ATTEMPTS = 2;
+const PROBE_RETRY_DELAY_MS = 500;
+
+/**
+ * Client-side deadline. The route bounds its own handler, which does not bound
+ * this promise: a dropped connection or a proxy that never answers would leave
+ * the probe pending forever, and "checking" holds the composer shut. Set above
+ * the server's connect timeout so this only fires when the response itself is
+ * lost.
+ */
+const PROBE_TIMEOUT_MS = 15_000;
+
+export interface ScenarioServerReachabilityInput {
+  serverId: string;
+  serverName: string;
+}
+
+function delay(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+function withProbeTimeout<T>(promise: Promise<T>): Promise<T> {
+  return new Promise<T>((resolve, reject) => {
+    const timeoutId = window.setTimeout(() => {
+      reject(new Error(`Probe timed out after ${PROBE_TIMEOUT_MS}ms`));
+    }, PROBE_TIMEOUT_MS);
+    promise.then(
+      (value) => {
+        window.clearTimeout(timeoutId);
+        resolve(value);
+      },
+      (error) => {
+        window.clearTimeout(timeoutId);
+        reject(error);
+      }
+    );
+  });
+}
+
+/**
+ * Connects to each of a tester session's servers up front and reports which
+ * ones answered.
+ *
+ * Nothing else in the guest runtime does this. `/api/web/scenarios/redeem` is a
+ * config fetch that never touches the servers it lists, and the first real
+ * connection attempt happens inside a chat turn — so an unreachable server was
+ * invisible until the tester had already spent the session on it, or produced
+ * a generic failed turn with no attribution.
+ *
+ * `/api/web/servers/validate` is the same connect-and-list-tools hop the chat
+ * turn will make, so a pass here means the turn's connection will work for the
+ * same reasons, and a failure here is the failure the turn would have hit.
+ *
+ * The caller decides which servers to probe: servers whose authorization is
+ * still unresolved belong to the OAuth gate, which verifies them with this same
+ * endpoint. Probing those here would double-connect and report "unreachable"
+ * for a server that is merely waiting for consent.
+ */
+export function useScenarioServerReachability(
+  servers: ScenarioServerReachabilityInput[],
+  enabled: boolean
+): Record<string, ScenarioServerReachability> {
+  const [reachabilityByServerId, setReachabilityByServerId] = useState<
+    Record<string, ScenarioServerReachability>
+  >({});
+  const probedServerIdsRef = useRef<Set<string>>(new Set());
+  const isUnmountedRef = useRef(false);
+
+  useEffect(() => {
+    isUnmountedRef.current = false;
+    return () => {
+      isUnmountedRef.current = true;
+    };
+  }, []);
+
+  useEffect(() => {
+    if (!enabled) return;
+
+    for (const server of servers) {
+      if (probedServerIdsRef.current.has(server.serverId)) continue;
+      probedServerIdsRef.current.add(server.serverId);
+
+      setReachabilityByServerId((previous) =>
+        previous[server.serverId]
+          ? previous
+          : { ...previous, [server.serverId]: "checking" }
+      );
+
+      void (async () => {
+        let reachability: ScenarioServerReachability = "unreachable";
+        let bootstrapAttempts = 0;
+        let probeAttempts = 0;
+
+        for (;;) {
+          try {
+            await withProbeTimeout(validateHostedServer(server.serverId));
+            reachability = "reachable";
+            break;
+          } catch (error) {
+            const isBootstrap = error instanceof BootstrapNotReadyError;
+            const exhausted = isBootstrap
+              ? ++bootstrapAttempts >= BOOTSTRAP_ATTEMPTS
+              : ++probeAttempts >= PROBE_ATTEMPTS;
+
+            if (exhausted) {
+              // Transport details are never shown to a tester — they followed a
+              // link and cannot act on an SSE status code. The banner names the
+              // server; the detail stays here for whoever debugs it.
+              console.error(
+                "[useScenarioServerReachability] server did not connect",
+                {
+                  serverId: server.serverId,
+                  serverName: server.serverName,
+                  error,
+                }
+              );
+              break;
+            }
+
+            await delay(
+              isBootstrap ? BOOTSTRAP_RETRY_DELAY_MS : PROBE_RETRY_DELAY_MS
+            );
+            if (isUnmountedRef.current) return;
+          }
+        }
+
+        if (isUnmountedRef.current) return;
+        setReachabilityByServerId((previous) => ({
+          ...previous,
+          [server.serverId]: reachability,
+        }));
+      })();
+    }
+  }, [enabled, servers]);
+
+  return reachabilityByServerId;
+}

--- a/mcpjam-inspector/client/src/hooks/hosted/use-scenario-server-reachability.ts
+++ b/mcpjam-inspector/client/src/hooks/hosted/use-scenario-server-reachability.ts
@@ -55,9 +55,16 @@ function delay(ms: number): Promise<void> {
   return new Promise((resolve) => setTimeout(resolve, ms));
 }
 
-function withProbeTimeout<T>(promise: Promise<T>): Promise<T> {
+function withProbeTimeout<T>(
+  promise: Promise<T>,
+  controller: AbortController
+): Promise<T> {
   return new Promise<T>((resolve, reject) => {
     const timeoutId = window.setTimeout(() => {
+      // Abort as well as reject. Rejecting only frees this caller: the request
+      // it gave up on keeps its connection open on the server, and the retry
+      // below opens a second one against the same server.
+      controller.abort();
       reject(new Error(`Probe timed out after ${PROBE_TIMEOUT_MS}ms`));
     }, PROBE_TIMEOUT_MS);
     promise.then(
@@ -91,26 +98,56 @@ function withProbeTimeout<T>(promise: Promise<T>): Promise<T> {
  * still unresolved belong to the OAuth gate, which verifies them with this same
  * endpoint. Probing those here would double-connect and report "unreachable"
  * for a server that is merely waiting for consent.
+ *
+ * `sessionKey` identifies the redeemed session these verdicts belong to. Every
+ * verdict is scoped to it, because a verdict says "this session reached this
+ * server", not "this server is up".
  */
 export function useScenarioServerReachability(
   servers: ScenarioServerReachabilityInput[],
-  enabled: boolean
+  enabled: boolean,
+  sessionKey: string | null
 ): Record<string, ScenarioServerReachability> {
   const [reachabilityByServerId, setReachabilityByServerId] = useState<
     Record<string, ScenarioServerReachability>
   >({});
   const probedServerIdsRef = useRef<Set<string>>(new Set());
+  const probedSessionKeyRef = useRef<string | null>(sessionKey);
   const isUnmountedRef = useRef(false);
+  const inFlightProbesRef = useRef<Set<AbortController>>(new Set());
+
+  // A tester opening a different scenario does not remount the page —
+  // `ScenarioChatPage` swaps its session in place — so the previous session's
+  // probe state has to be dropped here. Two scenarios in one project can list
+  // the same server id, and keeping the old verdict would both skip probing it
+  // and show an answer this session never got. Reset during render so no frame
+  // is painted from the previous session's verdicts.
+  if (probedSessionKeyRef.current !== sessionKey) {
+    probedSessionKeyRef.current = sessionKey;
+    probedServerIdsRef.current = new Set();
+    setReachabilityByServerId((previous) =>
+      Object.keys(previous).length === 0 ? previous : {}
+    );
+  }
 
   useEffect(() => {
     isUnmountedRef.current = false;
     return () => {
       isUnmountedRef.current = true;
+      // A probe that outlives the page still holds a connection open on the
+      // server for the rest of its connect timeout, and nobody is left to read
+      // its answer.
+      for (const controller of inFlightProbesRef.current) {
+        controller.abort();
+      }
+      inFlightProbesRef.current.clear();
     };
   }, []);
 
   useEffect(() => {
     if (!enabled) return;
+
+    const probeSessionKey = sessionKey;
 
     for (const server of servers) {
       if (probedServerIdsRef.current.has(server.serverId)) continue;
@@ -128,8 +165,19 @@ export function useScenarioServerReachability(
         let probeAttempts = 0;
 
         for (;;) {
+          const controller = new AbortController();
+          inFlightProbesRef.current.add(controller);
           try {
-            await withProbeTimeout(validateHostedServer(server.serverId));
+            await withProbeTimeout(
+              validateHostedServer(
+                server.serverId,
+                undefined,
+                undefined,
+                undefined,
+                controller.signal
+              ),
+              controller
+            );
             reachability = "reachable";
             break;
           } catch (error) {
@@ -157,17 +205,22 @@ export function useScenarioServerReachability(
               isBootstrap ? BOOTSTRAP_RETRY_DELAY_MS : PROBE_RETRY_DELAY_MS
             );
             if (isUnmountedRef.current) return;
+          } finally {
+            inFlightProbesRef.current.delete(controller);
           }
         }
 
         if (isUnmountedRef.current) return;
+        // The tester moved to another scenario while this ran. The answer is
+        // about a session the page no longer shows, and its map was cleared.
+        if (probedSessionKeyRef.current !== probeSessionKey) return;
         setReachabilityByServerId((previous) => ({
           ...previous,
           [server.serverId]: reachability,
         }));
       })();
     }
-  }, [enabled, servers]);
+  }, [enabled, servers, sessionKey]);
 
   return reachabilityByServerId;
 }

--- a/mcpjam-inspector/client/src/lib/apis/web/base.ts
+++ b/mcpjam-inspector/client/src/lib/apis/web/base.ts
@@ -42,11 +42,13 @@ export class WebApiError extends Error {
 export async function webPost<TRequest, TResponse>(
   path: string,
   payload: TRequest,
+  options?: { signal?: AbortSignal },
 ): Promise<TResponse> {
   const response = await authFetch(path, {
     method: "POST",
     headers: { "Content-Type": "application/json" },
     body: JSON.stringify(payload),
+    signal: options?.signal,
   });
 
   let body: any = null;

--- a/mcpjam-inspector/client/src/lib/apis/web/servers-api.ts
+++ b/mcpjam-inspector/client/src/lib/apis/web/servers-api.ts
@@ -94,7 +94,13 @@ export async function validateHostedServer(
   serverNameOrId: string,
   oauthAccessToken?: string,
   clientCapabilities?: Record<string, unknown>,
-  hostedContext?: HostedServerValidateContext
+  hostedContext?: HostedServerValidateContext,
+  /**
+   * Cancels the connect for a caller running its own deadline. The route keeps
+   * an MCP connection open for as long as its connect timeout allows, so a
+   * caller that gave up and retried would otherwise hold two open at once.
+   */
+  signal?: AbortSignal
 ): Promise<HostedServerValidateResponse> {
   const request: Record<string, unknown> = hostedContext
     ? {
@@ -153,6 +159,7 @@ export async function validateHostedServer(
   }
   return webPost<typeof request, HostedServerValidateResponse>(
     "/api/web/servers/validate",
-    request
+    request,
+    { signal }
   );
 }

--- a/mcpjam-inspector/client/src/lib/client-styles/registry.ts
+++ b/mcpjam-inspector/client/src/lib/client-styles/registry.ts
@@ -74,7 +74,8 @@ export function findHostStyle(
   return registry.get(id);
 }
 
-/** Lookup with claude fallback. Use at boundaries where missing data is normal. */
+/** Lookup with {@link DEFAULT_HOST_STYLE} fallback. Use at boundaries where
+ * missing data is normal. */
 export function getHostStyleOrDefault(
   id: HostStyleId | null | undefined
 ): HostStyleDefinition {


### PR DESCRIPTION
> Stacked on #4062, which is stacked on #4061. Review those first; this PR's diff
> is only the third commit.

Two ways a scenario got shared when it couldn't run.

**The withhold leaked.** The tester link was withheld on the Edit tab while the
environment couldn't resolve, but `useScenarioShareInvite` built the same link
from the token alone — so the header strip and the Insights empty panel copied
out a link the other surface had just refused to give. The same scenario was both
unshareable and one click from being shared. The withhold now lives in the hook
all three surfaces read from, and the placeholder says the link is withheld
instead of claiming none exists.

**Nothing caught the other case at all:** an environment that resolves fine whose
servers are all stdio or localhost URLs. Hosted sessions can't reach either, so
the scenario works for the author and fails for everyone they send it to — which
is exactly how a tester ends up in a session whose only server never connects.
`assessCloudServerReadiness` already encodes that rule for the swarm flow; User
Testing now reads the same verdict.

It warns rather than withholds. That assessment deliberately fails open on
anything it can't measure, and an author mid-setup shouldn't lose their link to a
guess.

The copy is scenario-specific rather than reusing `describeCloudServerBlock` —
that helper's text talks about "a cloud run" and "the client", which is swarm
vocabulary and means nothing on this surface.

## Testing

- New case in `ScenarioShareBanner.test.tsx`: the header strip withholds the link
  and disables Copy when the environment can't resolve.
- Two new cases in `UserTestingScenarioDetail.test.tsx`: the notice names the
  unreachable server, and says nothing when the servers are reachable.
- `ScenarioShareBanner` 8/8, `UserTestingScenarioDetail` 39/39,
  `ScenarioShareSection` 5/5.
- `npm run typecheck` and `npm run typecheck:client` both exit 0.
- Full client suite green (9,075 tests). Repo guards, SDK build and
  `build:inspector` all pass.

## Known limitation

`assessCloudServerReadiness` falls back to the whole project catalog when a
target resolves by host rather than an explicit server group, so the notice can
name servers this scenario doesn't use. That's pre-existing helper behavior and
`describeCloudServerBlock` already ships with the same exposure on the swarm
surface — worth fixing, but in the helper and not here.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents broken User Testing scenarios from being shared and warns when hosted testers can’t reach local-only servers. Previously, Edit withheld the link but the header/empty panel still exposed it and Invite emailed it; now all surfaces withhold and Invite is disabled with a reason.

- Centralizes link withholding in useScenarioShareInvite when environmentError is set; header and empty panel show “Withheld — this scenario can’t run.” and disable Copy/Open Preview.
- Stops emailing invites while the scenario is unrunnable; disables the email field and Invite button, and surfaces the environment error in the popover.
- Adds hosted reachability checks via useCloudServerReadiness; Edit warns when servers are stdio/localhost/private URLs, but keeps the share link to avoid false positives.

<sup>Written for commit c6e5460281a62ddcf9549e563e26357926ef74ba. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/MCPJam/inspector/pull/4063?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

