### PR TITLE
fix(billing): handle the denied-org null from the billing queries

### DIFF
--- a/mcpjam-inspector/client/src/components/organization/OrganizationBillingSection.tsx
+++ b/mcpjam-inspector/client/src/components/organization/OrganizationBillingSection.tsx
@@ -1011,8 +1011,13 @@ export function OrganizationBillingSection({
                       annualDiscountPct={annualDiscountPct}
                     />
                   </div>
+                  {/* The catalog resolves to undefined both in flight and on a
+                      denied org read. Only the first is loading — saying so in
+                      the second left denied orgs on a spinner that never ends. */}
                   <div className="rounded-md border border-dashed border-border/70 p-4 text-sm text-muted-foreground">
-                    Loading plan catalog...
+                    {isLoadingPlanCatalog
+                      ? "Loading plan catalog..."
+                      : "Plan catalog unavailable for this organization."}
                   </div>
                 </div>
               ) : (

--- a/mcpjam-inspector/client/src/components/organization/__tests__/OrganizationBillingSection.test.tsx
+++ b/mcpjam-inspector/client/src/components/organization/__tests__/OrganizationBillingSection.test.tsx
@@ -1,0 +1,50 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import { OrganizationBillingSection } from "@/components/organization/OrganizationBillingSection";
+
+vi.mock("@/hooks/useCreditTopupReturnFlow", () => ({
+  useCreditTopupReturnFlowBilling: () => undefined,
+}));
+
+// `planCatalog` is undefined in two unrelated situations: the read is still in
+// flight, and the org was denied it. The card renders on `!planCatalog` either
+// way, so only the copy can tell them apart.
+function renderCatalogCard(isLoadingPlanCatalog: boolean) {
+  return render(
+    <OrganizationBillingSection
+      organizationId="org_1"
+      organizationName="Acme"
+      showPlanBilling
+      showCredits={false}
+      canManageCredits={false}
+      billingStatus={undefined}
+      planCatalog={undefined}
+      isLoadingBilling={false}
+      isLoadingPlanCatalog={isLoadingPlanCatalog}
+      isStartingPlanChange={false}
+      pendingPlanChangeTarget={null}
+      isOpeningPortal={false}
+      onDowngradePlan={vi.fn()}
+      onStartPlanChange={vi.fn()}
+    />
+  );
+}
+
+describe("OrganizationBillingSection plan catalog placeholder", () => {
+  it("says it is loading while the catalog read is in flight", () => {
+    renderCatalogCard(true);
+
+    expect(screen.getByText("Loading plan catalog...")).toBeInTheDocument();
+  });
+
+  // The denial case: the flag is already false, so claiming to load here is a
+  // spinner that never resolves.
+  it("says the catalog is unavailable once the read has resolved without one", () => {
+    renderCatalogCard(false);
+
+    expect(
+      screen.getByText("Plan catalog unavailable for this organization.")
+    ).toBeInTheDocument();
+    expect(screen.queryByText("Loading plan catalog...")).toBeNull();
+  });
+});

--- a/mcpjam-inspector/client/src/hooks/__tests__/use-eval-iteration-quota.test.tsx
+++ b/mcpjam-inspector/client/src/hooks/__tests__/use-eval-iteration-quota.test.tsx
@@ -1,0 +1,51 @@
+import { renderHook } from "@testing-library/react";
+import { describe, expect, it, vi, beforeEach } from "vitest";
+import { useEvalIterationQuota } from "@/hooks/use-eval-iteration-quota";
+
+const mocks = vi.hoisted(() => ({
+  useQuery: vi.fn(),
+}));
+
+vi.mock("convex/react", () => ({
+  useQuery: (...args: unknown[]) => mocks.useQuery(...args),
+}));
+
+describe("useEvalIterationQuota", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  // A denial must not read as "still loading" — that spins forever.
+  it("folds a denied org read (null) into undefined and stops loading", () => {
+    mocks.useQuery.mockReturnValue(null);
+
+    const { result } = renderHook(() =>
+      useEvalIterationQuota({ organizationId: "org_1" })
+    );
+
+    expect(result.current.quota).toBeUndefined();
+    expect(result.current.isLoading).toBe(false);
+    expect(result.current.isAtLimit).toBe(false);
+  });
+
+  it("reports the backend payload for an allowed org read", () => {
+    mocks.useQuery.mockReturnValue({
+      used: 5,
+      allowed: 10,
+      resetsAt: 0,
+      windowKind: "day",
+    });
+
+    const { result } = renderHook(() =>
+      useEvalIterationQuota({ organizationId: "org_1" })
+    );
+
+    expect(result.current.quota).toEqual({
+      used: 5,
+      allowed: 10,
+      resetsAt: 0,
+      windowKind: "day",
+    });
+    expect(result.current.isLoading).toBe(false);
+  });
+});

--- a/mcpjam-inspector/client/src/hooks/__tests__/use-eval-iteration-quota.test.tsx
+++ b/mcpjam-inspector/client/src/hooks/__tests__/use-eval-iteration-quota.test.tsx
@@ -45,6 +45,7 @@ describe("useEvalIterationQuota", () => {
   // with an in-flight one.
   it.each([
     ["no organizationId", { organizationId: null }],
+    ["empty organizationId", { organizationId: "" }],
     ["enabled: false", { organizationId: "org_1", enabled: false }],
   ])("never loads when the query is skipped (%s)", (_label, args) => {
     mocks.useQuery.mockReturnValue(undefined);

--- a/mcpjam-inspector/client/src/hooks/__tests__/use-eval-iteration-quota.test.tsx
+++ b/mcpjam-inspector/client/src/hooks/__tests__/use-eval-iteration-quota.test.tsx
@@ -28,6 +28,33 @@ describe("useEvalIterationQuota", () => {
     expect(result.current.isAtLimit).toBe(false);
   });
 
+  // The counterpart to the denial case: undefined is the in-flight answer, and
+  // it is the one state that must still read as loading.
+  it("keeps loading while the read is still in flight (undefined)", () => {
+    mocks.useQuery.mockReturnValue(undefined);
+
+    const { result } = renderHook(() =>
+      useEvalIterationQuota({ organizationId: "org_1" })
+    );
+
+    expect(result.current.quota).toBeUndefined();
+    expect(result.current.isLoading).toBe(true);
+  });
+
+  // A skipped query also sits at undefined forever, so it must not be confused
+  // with an in-flight one.
+  it.each([
+    ["no organizationId", { organizationId: null }],
+    ["enabled: false", { organizationId: "org_1", enabled: false }],
+  ])("never loads when the query is skipped (%s)", (_label, args) => {
+    mocks.useQuery.mockReturnValue(undefined);
+
+    const { result } = renderHook(() => useEvalIterationQuota(args));
+
+    expect(result.current.quota).toBeUndefined();
+    expect(result.current.isLoading).toBe(false);
+  });
+
   it("reports the backend payload for an allowed org read", () => {
     mocks.useQuery.mockReturnValue({
       used: 5,

--- a/mcpjam-inspector/client/src/hooks/__tests__/useOrganizationBillingStatus.test.tsx
+++ b/mcpjam-inspector/client/src/hooks/__tests__/useOrganizationBillingStatus.test.tsx
@@ -74,12 +74,57 @@ describe("useOrganizationBilling loading flags", () => {
     expect(result.current.isLoadingPlanCatalog).toBe(false);
   });
 
-  it("reports no loading when the org is absent and queries are skipped", () => {
+  // Both falsy org ids skip. Spelled out separately because the gate is a
+  // truthiness check, and a null-only guard would let "" through to a query.
+  it.each([
+    ["null", null],
+    ["empty string", ""],
+  ])(
+    "reports no loading when the org id is %s and queries are skipped",
+    (_label, organizationId) => {
+      mocks.useQuery.mockReturnValue(undefined);
+
+      const { result } = renderHook(() =>
+        useOrganizationBilling(organizationId)
+      );
+
+      expect(result.current.isLoadingBilling).toBe(false);
+      expect(result.current.isLoadingEntitlements).toBe(false);
+      expect(result.current.isLoadingOrganizationPremiumness).toBe(false);
+      expect(result.current.isLoadingPlanCatalog).toBe(false);
+    }
+  );
+
+  // The project-scoped query has its own gate on top of the org one, so its
+  // flag needs its own in-flight and denied reads to be pinned at all.
+  it("reports loading for project premiumness while its read is in flight", () => {
     mocks.useQuery.mockReturnValue(undefined);
 
-    const { result } = renderHook(() => useOrganizationBilling(null));
+    const { result } = renderHook(() =>
+      useOrganizationBilling("org_1", { projectId: "proj_1" })
+    );
 
-    expect(result.current.isLoadingBilling).toBe(false);
-    expect(result.current.isLoadingPlanCatalog).toBe(false);
+    expect(result.current.isLoadingProjectPremiumness).toBe(true);
+  });
+
+  it("stops reporting project premiumness loading on a denied read", () => {
+    mocks.useQuery.mockReturnValue(null);
+
+    const { result } = renderHook(() =>
+      useOrganizationBilling("org_1", { projectId: "proj_1" })
+    );
+
+    expect(result.current.projectPremiumness).toBeUndefined();
+    expect(result.current.isLoadingProjectPremiumness).toBe(false);
+  });
+
+  // Without a project there is nothing to load, so the flag must stay down
+  // even while the org-scoped reads are still in flight.
+  it("never reports project premiumness loading when no project is given", () => {
+    mocks.useQuery.mockReturnValue(undefined);
+
+    const { result } = renderHook(() => useOrganizationBilling("org_1"));
+
+    expect(result.current.isLoadingProjectPremiumness).toBe(false);
   });
 });

--- a/mcpjam-inspector/client/src/hooks/__tests__/useOrganizationBillingStatus.test.tsx
+++ b/mcpjam-inspector/client/src/hooks/__tests__/useOrganizationBillingStatus.test.tsx
@@ -1,0 +1,85 @@
+import { renderHook } from "@testing-library/react";
+import { describe, expect, it, vi, beforeEach } from "vitest";
+import {
+  useOrganizationBilling,
+  useOrganizationBillingStatus,
+} from "@/hooks/useOrganizationBilling";
+
+const mocks = vi.hoisted(() => ({
+  useQuery: vi.fn(),
+}));
+
+vi.mock("convex/react", () => ({
+  useQuery: (...args: unknown[]) => mocks.useQuery(...args),
+  useAction: () => vi.fn(),
+  useMutation: () => vi.fn(),
+}));
+
+describe("useOrganizationBillingStatus", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("reports undefined, not null, while the query is still loading", () => {
+    mocks.useQuery.mockReturnValue(undefined);
+
+    const { result } = renderHook(() => useOrganizationBillingStatus("org_1"));
+
+    expect(result.current).toBeUndefined();
+  });
+
+  it("returns the backend payload for an allowed org read", () => {
+    mocks.useQuery.mockReturnValue({ plan: "team" });
+
+    const { result } = renderHook(() => useOrganizationBillingStatus("org_1"));
+
+    expect(result.current).toEqual({ plan: "team" });
+  });
+
+  // A consumer that reads `.plan` off this would crash on a raw null.
+  it("folds a denied org read (null) into undefined instead of passing it through", () => {
+    mocks.useQuery.mockReturnValue(null);
+
+    const { result } = renderHook(() => useOrganizationBillingStatus("org_1"));
+
+    expect(result.current).toBeUndefined();
+  });
+});
+
+describe("useOrganizationBilling loading flags", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("reports loading while the queries are in flight", () => {
+    mocks.useQuery.mockReturnValue(undefined);
+
+    const { result } = renderHook(() => useOrganizationBilling("org_1"));
+
+    expect(result.current.isLoadingBilling).toBe(true);
+    expect(result.current.isLoadingPlanCatalog).toBe(true);
+  });
+
+  // The flags gate skeletons in OrganizationBillingSection. Deriving them
+  // from the null-folded value would leave a denied org loading forever.
+  it("stops reporting loading once a denied org read resolves to null", () => {
+    mocks.useQuery.mockReturnValue(null);
+
+    const { result } = renderHook(() => useOrganizationBilling("org_1"));
+
+    expect(result.current.billingStatus).toBeUndefined();
+    expect(result.current.isLoadingBilling).toBe(false);
+    expect(result.current.isLoadingEntitlements).toBe(false);
+    expect(result.current.isLoadingOrganizationPremiumness).toBe(false);
+    expect(result.current.isLoadingPlanCatalog).toBe(false);
+  });
+
+  it("reports no loading when the org is absent and queries are skipped", () => {
+    mocks.useQuery.mockReturnValue(undefined);
+
+    const { result } = renderHook(() => useOrganizationBilling(null));
+
+    expect(result.current.isLoadingBilling).toBe(false);
+    expect(result.current.isLoadingPlanCatalog).toBe(false);
+  });
+});

--- a/mcpjam-inspector/client/src/hooks/use-eval-iteration-quota.ts
+++ b/mcpjam-inspector/client/src/hooks/use-eval-iteration-quota.ts
@@ -14,14 +14,17 @@ export function useEvalIterationQuota({
   organizationId?: string | null;
   enabled?: boolean;
 }) {
-  const quota = useQuery(
+  // The backend returns null for a denied org read. Keep the raw value so
+  // `isLoading` below can tell a denial from a request still in flight.
+  const raw = useQuery(
     "billing:getEvalIterationQuota" as any,
     enabled && organizationId ? ({ organizationId } as any) : "skip"
-  ) as EvalIterationQuota | undefined;
+  ) as EvalIterationQuota | null | undefined;
+  const quota = raw ?? undefined;
 
   return {
     quota,
-    isLoading: Boolean(enabled && organizationId && quota === undefined),
+    isLoading: Boolean(enabled && organizationId && raw === undefined),
     isAtLimit: Boolean(
       quota && quota.allowed !== null && quota.used >= quota.allowed
     ),

--- a/mcpjam-inspector/client/src/hooks/useOrganizationBilling.ts
+++ b/mcpjam-inspector/client/src/hooks/useOrganizationBilling.ts
@@ -217,16 +217,33 @@ export interface StartOrganizationPlanChangeOptions {
   confirmPaidPlanChange?: boolean;
 }
 
+/**
+ * One org-scoped billing query. The backend returns null for a denied org
+ * read, so the value folds to `undefined` (what consumers already render
+ * nothing for) while `isLoading` reads the RAW result — deriving it from the
+ * fold would leave a denied surface stuck on its skeleton forever.
+ */
+function useBillingQuery<T>(
+  name: string,
+  args: Record<string, unknown> | "skip"
+): { value: T | undefined; isLoading: boolean } {
+  const raw = useQuery(name as any, args as any) as T | null | undefined;
+  return {
+    value: raw ?? undefined,
+    isLoading: args !== "skip" && raw === undefined,
+  };
+}
+
 export function useOrganizationBillingStatus(
   organizationId: string | null,
   options?: UseOrganizationBillingStatusOptions
 ): OrganizationBillingStatus | undefined {
   const enabled = options?.enabled ?? true;
 
-  return useQuery(
-    "billing:getOrganizationBillingStatus" as any,
-    enabled && organizationId ? ({ organizationId } as any) : "skip"
-  ) as OrganizationBillingStatus | undefined;
+  return useBillingQuery<OrganizationBillingStatus>(
+    "billing:getOrganizationBillingStatus",
+    enabled && organizationId ? { organizationId } : "skip"
+  ).value;
 }
 
 export function useOrganizationBilling(
@@ -240,30 +257,40 @@ export function useOrganizationBilling(
   const shouldQuerySeatPaymentIntent =
     shouldQueryOrganization && options?.includeSeatPaymentIntent === true;
 
-  const billingStatus = useOrganizationBillingStatus(organizationId, {
-    enabled,
-  });
+  const { value: billingStatus, isLoading: isLoadingBilling } =
+    useBillingQuery<OrganizationBillingStatus>(
+      "billing:getOrganizationBillingStatus",
+      shouldQueryOrganization ? { organizationId } : "skip"
+    );
 
-  const entitlements = useQuery(
-    "billing:getOrganizationEntitlements" as any,
-    shouldQueryOrganization ? ({ organizationId } as any) : "skip"
-  ) as OrganizationEntitlements | undefined;
+  const { value: entitlements, isLoading: isLoadingEntitlements } =
+    useBillingQuery<OrganizationEntitlements>(
+      "billing:getOrganizationEntitlements",
+      shouldQueryOrganization ? { organizationId } : "skip"
+    );
 
-  const organizationPremiumness = useQuery(
-    "billing:getOrganizationPremiumness" as any,
-    shouldQueryOrganization ? ({ organizationId } as any) : "skip"
-  ) as PremiumnessState | undefined;
+  const {
+    value: organizationPremiumness,
+    isLoading: isLoadingOrganizationPremiumness,
+  } = useBillingQuery<PremiumnessState>(
+    "billing:getOrganizationPremiumness",
+    shouldQueryOrganization ? { organizationId } : "skip"
+  );
 
-  const projectPremiumness = useQuery(
-    "billing:getProjectPremiumness" as any,
-    shouldQueryProject ? ({ organizationId, projectId } as any) : "skip"
-  ) as PremiumnessState | undefined;
+  const { value: projectPremiumness, isLoading: isLoadingProjectPremiumness } =
+    useBillingQuery<PremiumnessState>(
+      "billing:getProjectPremiumness",
+      shouldQueryProject ? { organizationId, projectId } : "skip"
+    );
 
-  const planCatalog = useQuery(
-    "billing:getPlanCatalog" as any,
-    shouldQueryOrganization ? ({ organizationId } as any) : "skip"
-  ) as PlanCatalog | undefined;
+  const { value: planCatalog, isLoading: isLoadingPlanCatalog } =
+    useBillingQuery<PlanCatalog>(
+      "billing:getPlanCatalog",
+      shouldQueryOrganization ? { organizationId } : "skip"
+    );
 
+  // Not folded: null is already this query's "no active intent" answer, and a
+  // denial lands on the same null to the same effect.
   const activeSeatPaymentIntent = useQuery(
     "billing:getActiveOrganizationSeatPaymentIntent" as any,
     shouldQuerySeatPaymentIntent ? ({ organizationId } as any) : "skip"
@@ -594,11 +621,6 @@ export function useOrganizationBilling(
     ]
   );
 
-  const isLoadingOrganizationPremiumness =
-    shouldQueryOrganization && organizationPremiumness === undefined;
-  const isLoadingProjectPremiumness =
-    shouldQueryProject && projectPremiumness === undefined;
-
   return {
     billingStatus,
     organizationPremiumness,
@@ -606,12 +628,11 @@ export function useOrganizationBilling(
     entitlements,
     activeSeatPaymentIntent,
     planCatalog,
-    isLoadingBilling: shouldQueryOrganization && billingStatus === undefined,
-    isLoadingEntitlements:
-      shouldQueryOrganization && entitlements === undefined,
+    isLoadingBilling,
+    isLoadingEntitlements,
     isLoadingOrganizationPremiumness,
     isLoadingProjectPremiumness,
-    isLoadingPlanCatalog: shouldQueryOrganization && planCatalog === undefined,
+    isLoadingPlanCatalog,
     isStartingPlanChange,
     pendingPlanChangeTarget,
     isOpeningPortal,


### PR DESCRIPTION
## Summary

Client counterpart to MCPJam/mcpjam-backend#983. **Both must land together** — that PR makes the org-scoped billing queries return `null` instead of throwing when the read is denied (stale `organizationId` from a removed member's old tab, a bookmarked link, a quick nav before an org switch settles).

## What changed

The billing queries now route through `useBillingQuery`, which does two things that pull in opposite directions:

- **The value folds `null` → `undefined`**, which every consumer already renders nothing for. Without this a component would read `null` as loaded data and crash on `billingStatus.plan`.
- **`isLoading` is derived from the RAW result**, not the folded one. `undefined` is also Convex's "in flight" sentinel, so a flag read off the fold would leave a denied org reporting "loading" forever — `OrganizationBillingSection` and the plan-catalog card would sit on their skeletons with nothing ever arriving. Before backend #983 that case threw into an error boundary; a permanent skeleton is not an improvement.

`getActiveOrganizationSeatPaymentIntent` is deliberately **not** folded: `null` is already its "no active intent" answer and a denial lands on the same null to the same effect.

`creditHistory` / `pendingCreditTopups` needed no change — the backend answers a denial there with `{ items: [] }`, matching what their guest branch already returned.

## Test plan

- [x] `npm run typecheck:client`, `npx prettier --check` on changed files
- [x] `vitest run` across the billing/evals/org consumers — 1095 passed
- [x] New tests cover in-flight, denied, and skipped for the loading flags; the denied case fails against the naive fold

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Handle denied-organization billing reads without infinite spinners. Backend now returns null on denied reads; hooks fold null to undefined while loading flags read the raw value. Previously these cases threw; now the UI renders nothing or “unavailable” instead of spinning.

- Adds `useBillingQuery` for org-/project-scoped queries (`billing:getOrganizationBillingStatus`, `billing:getOrganizationEntitlements`, `billing:getOrganizationPremiumness`, `billing:getProjectPremiumness`, `billing:getPlanCatalog`); folds `null` → `undefined` and derives `isLoading` from the raw result. Leaves `billing:getActiveOrganizationSeatPaymentIntent` unchanged.
- Plan catalog: if not loading and the catalog is absent (denied), show “Plan catalog unavailable for this organization.” instead of “Loading plan catalog...”.
- Aligns `useEvalIterationQuota` with the same null-folding and loading rules.
- Tests pin plan-catalog placeholder copy; cover in-flight, denied, and skipped states (including empty-string org ids) and exercise `isLoadingProjectPremiumness`.

**Rollout**
- Ship alongside the backend returning `null` on denied org reads; otherwise behavior is unchanged.

<sup>Written for commit 261223cf01a576eb6cffa1f0768a49b5abb5e34c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/MCPJam/inspector/pull/4064?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

