### PR TITLE
feat(sdk): add OrcaRouter as a built-in LLM provider

### DIFF
--- a/.changeset/orcarouter-provider.md
+++ b/.changeset/orcarouter-provider.md
@@ -1,0 +1,7 @@
+---
+"@mcpjam/sdk": minor
+---
+
+Add OrcaRouter as a built-in LLM provider.
+
+`@mcpjam/sdk` now recognizes the `orcarouter/` model prefix (`orcarouter/anthropic/claude-sonnet-5`, `orcarouter/openai/gpt-4o`, ...) in `createModelFromString` and the org-resolved provider builder. OrcaRouter is an AI gateway that fronts many upstream models behind a single OpenAI-compatible Chat Completions endpoint; models route through the OpenAI adapter with the well-known default base URL `https://api.orcarouter.ai/v1` (overridable via `baseUrls.orcarouter` or an org provider's `baseUrl`), using `.chat()` since the gateway does not implement the newer `/v1/responses` API.

--- a/docs/sdk/reference/llm-providers.mdx
+++ b/docs/sdk/reference/llm-providers.mdx
@@ -4,7 +4,7 @@ description: "API reference for LLM provider configuration"
 icon: "book"
 ---
 
-The SDK supports 10 built-in LLM providers and allows custom provider configuration for any OpenAI or Anthropic-compatible endpoint.
+The SDK supports 11 built-in LLM providers and allows custom provider configuration for any OpenAI or Anthropic-compatible endpoint.
 
 ## Model String Format
 
@@ -293,7 +293,33 @@ const agent = new HostRunner({
 
 ---
 
-### xAI (Grok)
+### OrcaRouter
+
+| Property | Value |
+|----------|-------|
+| Prefix | `orcarouter/` |
+| Environment Variable | `ORCAROUTER_API_KEY` |
+| Default Base URL | `https://api.orcarouter.ai/v1` |
+
+[OrcaRouter](https://www.orcarouter.ai) is an AI gateway that fronts many upstream models (Anthropic, OpenAI, and more) behind a single OpenAI-compatible Chat Completions endpoint. Model ids stay namespaced, e.g. `orcarouter/anthropic/claude-sonnet-5`. Requests route through the OpenAI adapter's Chat Completions API (the gateway does not implement the newer `/v1/responses` API). Override the endpoint with `baseUrls.orcarouter`.
+
+| Model ID | Description |
+|----------|-------------|
+| `anthropic/claude-sonnet-5` | Claude Sonnet 5 via OrcaRouter |
+| `anthropic/claude-haiku-4.5` | Claude Haiku 4.5 via OrcaRouter |
+| `openai/gpt-4o` | GPT-4o via OrcaRouter |
+
+#### Example
+
+```typescript
+const agent = new HostRunner({
+  tools,
+  model: "orcarouter/anthropic/claude-sonnet-5",
+  apiKey: process.env.ORCAROUTER_API_KEY,
+});
+```
+
+---
 
 | Property | Value |
 |----------|-------|
@@ -485,6 +511,7 @@ const provider = createCustomProvider({
 | Mistral | `MISTRAL_API_KEY` |
 | DeepSeek | `DEEPSEEK_API_KEY` |
 | OpenRouter | `OPENROUTER_API_KEY` |
+| OrcaRouter | `ORCAROUTER_API_KEY` |
 | xAI | `XAI_API_KEY` |
 
 ---

--- a/sdk/src/model-factory.ts
+++ b/sdk/src/model-factory.ts
@@ -28,6 +28,11 @@ export interface BaseUrls {
   anthropic?: string;
   openai?: string;
   /**
+   * OrcaRouter OpenAI-compatible gateway endpoint. When omitted, the
+   * well-known default https://api.orcarouter.ai/v1 is used.
+   */
+  orcarouter?: string;
+  /**
    * Amazon Bedrock regional runtime endpoint, e.g.
    * https://bedrock-runtime.us-east-1.amazonaws.com.
    * When omitted, the provider derives it from the AWS_REGION env var.
@@ -58,6 +63,7 @@ const BUILT_IN_PROVIDERS: LLMProvider[] = [
   "ollama",
   "mistral",
   "openrouter",
+  "orcarouter",
   "xai",
 ];
 
@@ -249,6 +255,18 @@ export function createModelFromString(
     case "openrouter": {
       const openrouter = createOpenRouter({ apiKey });
       return openrouter(model) as unknown as ProviderLanguageModel;
+    }
+
+    case "orcarouter": {
+      // OrcaRouter is an OpenAI-compatible gateway. Route through Chat
+      // Completions (.chat()) — like the LiteLLM custom preset — since the
+      // gateway does not implement the newer /v1/responses API. Model ids stay
+      // namespaced ("orcarouter/anthropic/claude-sonnet-5" → "anthropic/claude-sonnet-5").
+      const orcarouter = createOpenAI({
+        apiKey,
+        baseURL: baseUrls?.orcarouter ?? "https://api.orcarouter.ai/v1",
+      });
+      return orcarouter.chat(model) as ProviderLanguageModel;
     }
 
     case "xai": {
@@ -490,6 +508,14 @@ export function buildOrgModelFromResolvedConfig(
         "X-Title": "MCPJam",
       },
     })(m) as unknown as LanguageModel;
+  }
+  if (providerKey === "orcarouter") {
+    const openai = createOpenAI({
+      apiKey: requireOrgSecret(config, "OrcaRouter"),
+      baseURL: config.baseUrl ?? "https://api.orcarouter.ai/v1",
+    });
+    // Chat Completions (.chat()), matching createModelFromString.
+    return openai.chat(m) as unknown as LanguageModel;
   }
   if (providerKey === "bedrock") {
     return createAmazonBedrock({

--- a/sdk/src/types.ts
+++ b/sdk/src/types.ts
@@ -40,6 +40,7 @@ export type LLMProvider =
   | "ollama"
   | "mistral"
   | "openrouter"
+  | "orcarouter"
   | "xai";
 
 /**

--- a/sdk/tests/model-factory.test.ts
+++ b/sdk/tests/model-factory.test.ts
@@ -172,6 +172,7 @@ describe("model-factory", () => {
         "ollama",
         "mistral",
         "openrouter",
+        "orcarouter",
         "xai",
       ];
 
@@ -431,6 +432,50 @@ describe("model-factory", () => {
       });
     });
 
+    describe("orcarouter provider", () => {
+      it("should route via OpenAI adapter to the default endpoint", () => {
+        createModelFromString(
+          "orcarouter/anthropic/claude-sonnet-5",
+          defaultOptions
+        );
+
+        expect(createOpenAI).toHaveBeenCalledWith({
+          apiKey: "test-api-key",
+          baseURL: "https://api.orcarouter.ai/v1",
+        });
+      });
+
+      it("should pass namespaced model id to Chat Completions", () => {
+        const model = createModelFromString(
+          "orcarouter/anthropic/claude-sonnet-5",
+          defaultOptions
+        );
+
+        expect(model).toEqual({
+          provider: "openai-chat",
+          modelId: "anthropic/claude-sonnet-5",
+          type: "mock-model",
+        });
+      });
+
+      it("should use custom base URL when provided", () => {
+        const options: CreateModelOptions = {
+          apiKey: "test-api-key",
+          baseUrls: { orcarouter: "https://orcarouter.example.com/v1" },
+        };
+
+        createModelFromString(
+          "orcarouter/openai/gpt-4o",
+          options
+        );
+
+        expect(createOpenAI).toHaveBeenCalledWith({
+          apiKey: "test-api-key",
+          baseURL: "https://orcarouter.example.com/v1",
+        });
+      });
+    });
+
     describe("xai provider", () => {
       it("should create xai model with api key", () => {
         createModelFromString("xai/grok-1", defaultOptions);
@@ -526,9 +571,10 @@ describe("model-factory", () => {
         azure: "https://azure.openai.com",
         anthropic: "https://anthropic.com",
         openai: "https://openai.com",
+        orcarouter: "https://api.orcarouter.ai/v1",
       };
 
-      expect(Object.keys(baseUrls)).toHaveLength(4);
+      expect(Object.keys(baseUrls)).toHaveLength(5);
     });
   });
 });
@@ -599,6 +645,46 @@ describe("buildOrgModelFromResolvedConfig", () => {
         "X-Title": "MCPJam",
       },
     });
+  });
+
+  it("orcarouter: routes via OpenAI adapter to default endpoint", () => {
+    const config: OrgProviderResolvedConfig = {
+      providerKey: "orcarouter",
+      apiKey: "orca-key",
+    };
+    const model = buildOrgModelFromResolvedConfig(
+      config,
+      "anthropic/claude-sonnet-5"
+    );
+    expect(createOpenAI).toHaveBeenCalledWith({
+      apiKey: "orca-key",
+      baseURL: "https://api.orcarouter.ai/v1",
+    });
+    expect(model).toEqual({
+      provider: "openai-chat",
+      modelId: "anthropic/claude-sonnet-5",
+      type: "mock-model",
+    });
+  });
+
+  it("orcarouter: uses org-provided baseUrl when present", () => {
+    const config: OrgProviderResolvedConfig = {
+      providerKey: "orcarouter",
+      apiKey: "orca-key",
+      baseUrl: "https://orcarouter.example.com/v1",
+    };
+    buildOrgModelFromResolvedConfig(config, "openai/gpt-4o");
+    expect(createOpenAI).toHaveBeenCalledWith({
+      apiKey: "orca-key",
+      baseURL: "https://orcarouter.example.com/v1",
+    });
+  });
+
+  it("orcarouter: throws provider_not_configured without apiKey", () => {
+    const config: OrgProviderResolvedConfig = { providerKey: "orcarouter" };
+    expect(() =>
+      buildOrgModelFromResolvedConfig(config, "anthropic/claude-sonnet-5")
+    ).toThrow(OrgProviderConfigError);
   });
 
   it("bedrock: calls createAmazonBedrock with apiKey and baseURL", () => {
@@ -729,6 +815,15 @@ describe("assertOrgModelAllowed", () => {
     };
     expect(() =>
       assertOrgModelAllowed(config, "anything/model")
+    ).not.toThrow();
+  });
+
+  it("orcarouter: passes through without allowlist check", () => {
+    const config: OrgProviderResolvedConfig = {
+      providerKey: "orcarouter",
+    };
+    expect(() =>
+      assertOrgModelAllowed(config, "anthropic/claude-sonnet-5")
     ).not.toThrow();
   });
 


### PR DESCRIPTION
## Add OrcaRouter as a built-in LLM provider

This PR adds [OrcaRouter](https://www.orcarouter.ai) as a named built-in LLM provider in `@mcpjam/sdk`, mirroring how OpenRouter is wired in the model factory.

OrcaRouter is an AI gateway that fronts many upstream models (`anthropic/claude-*`, `openai/*`, ...) behind a single OpenAI-compatible Chat Completions endpoint (`https://api.orcarouter.ai/v1/chat/completions`), so it slots into the existing OpenAI adapter:

- **`LLMProvider`** union (`sdk/src/types.ts`) and `BUILT_IN_PROVIDERS` extended with `orcarouter`, so `parseLLMString("orcarouter/...")` resolves as a built-in provider
- **`createModelFromString`** (`sdk/src/model-factory.ts`): new `case "orcarouter"` that routes through `createOpenAI` with the well-known default base URL `https://api.orcarouter.ai/v1` (overridable via `baseUrls.orcarouter`), using `.chat()` to force the Chat Completions API since the gateway does not implement the newer `/v1/responses` API. Model ids stay namespaced (`orcarouter/anthropic/claude-sonnet-5` → `anthropic/claude-sonnet-5`)
- **`buildOrgModelFromResolvedConfig`**: `orcarouter` branch for the local BYOK runtime, using the org-provided `baseUrl` or the default endpoint
- **Docs**: `docs/sdk/reference/llm-providers.mdx` provider section, model table, and env-var summary row (`ORCAROUTER_API_KEY`)
- **Changeset**: `@mcpjam/sdk` minor

The wire format was verified live against `https://api.orcarouter.ai/v1/chat/completions`: a POST with Bearer auth and the namespaced model id `anthropic/claude-sonnet-5` returns `choices[0].message.content` as expected, matching what the OpenAI adapter's `.chat()` sends.

It also runs gateway-level, zero-trust security for AI agents on the same endpoint — screening every prompt/response and governing every tool call on a default-deny basis, with no application code changes.

I'm an engineer on the OrcaRouter team.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds OrcaRouter as a built-in LLM provider in `@mcpjam/sdk`, so `orcarouter/...` model strings work out of the box against OrcaRouter’s OpenAI‑compatible Chat Completions endpoint. Previously this required a custom provider; now we default to `https://api.orcarouter.ai/v1` and preserve namespaced model IDs.

- Model factory: `LLMProvider`/`BUILT_IN_PROVIDERS` include `orcarouter`; `createModelFromString("orcarouter/...")` calls `createOpenAI().chat()` with the default base URL or `baseUrls.orcarouter`. The adapter receives the inner model id (e.g., `anthropic/claude-sonnet-5`).
- Org provider: `providerKey: "orcarouter"` supported; uses org `apiKey` (`ORCAROUTER_API_KEY`) and optional `baseUrl`; routes via Chat Completions.
- Behavior: forces Chat Completions (not `/v1/responses`); streaming and tool semantics match the existing OpenAI chat adapter.
- Docs, tests, and a minor changeset included. Migration (optional): replace custom OrcaRouter configs with `orcarouter/...` model strings and set `ORCAROUTER_API_KEY`; override the endpoint with `baseUrls.orcarouter` or org `baseUrl` if needed.

<sup>Written for commit 10ff7758d80eabb9d495ff58386419fb3df9042e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/MCPJam/inspector/pull/4065?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

