### PR TITLE
fix(mcp-apps): report the declared CSP so Apps render in User Testing

### DIFF
--- a/mcpjam-inspector/client/src/components/chat-v2/thread/mcp-apps/__tests__/mcp-apps-renderer.test.tsx
+++ b/mcpjam-inspector/client/src/components/chat-v2/thread/mcp-apps/__tests__/mcp-apps-renderer.test.tsx
@@ -3067,6 +3067,47 @@ describe("MCPAppsRenderer tool input streaming", () => {
     }
   });
 
+  it("does not carry a blocked-App notice onto freshly committed HTML", async () => {
+    // A violation belongs to the bytes that reported it. Once new HTML is
+    // committed the notice must not keep explaining the old ones — it would
+    // misdiagnose the new render outright if that failed for an unrelated
+    // reason. Covers both the resource swap and a refetch under the same
+    // identity, which the identity-keyed reset effect cannot see.
+    vi.useFakeTimers({ shouldAdvanceTime: true });
+    try {
+      const { rerender } = render(<HostedRenderer {...baseProps} />);
+
+      await vi.waitFor(() => {
+        expect(sandboxedIframePropsRef.current?.onMessage).toBeTruthy();
+      });
+
+      postCspViolation({ blockedUri: "https://resource-a.example/app.js" });
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(2000);
+      });
+      expect(screen.getByTestId("mcp-app-csp-blocked-notice")).toBeTruthy();
+
+      // Same renderer, different live resource.
+      rerender(
+        <HostedRenderer
+          {...baseProps}
+          toolCallId="call-2"
+          resourceUri="mcp-app://other"
+        />
+      );
+
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(2000);
+      });
+
+      // Nothing has been reported against the new bytes, so there is nothing
+      // to explain about them.
+      expect(screen.queryByTestId("mcp-app-csp-blocked-notice")).toBeNull();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
   it("explains a block after a TIGHTENED policy breaks a previously-working App", async () => {
     // End-to-end guard on the case the notice most needs to cover: the App
     // boots fine, the policy is then narrowed, and the reloaded App can't

--- a/mcpjam-inspector/client/src/components/chat-v2/thread/mcp-apps/__tests__/mcp-apps-renderer.test.tsx
+++ b/mcpjam-inspector/client/src/components/chat-v2/thread/mcp-apps/__tests__/mcp-apps-renderer.test.tsx
@@ -2877,6 +2877,195 @@ describe("MCPAppsRenderer tool input streaming", () => {
     warnSpy.mockRestore();
     errorSpy.mockRestore();
   });
+
+  // ── Scenario surface × declared host profile ────────────────────────────
+  // The "MCP Apps render blank in User Testing" regression. A scenario
+  // surface forces `cspMode: "permissive"`; the server used to answer that
+  // request by withholding the resource's declared CSP. Every host template
+  // seeds `apps.sandbox.csp.mode: "declared"`, so `resolveSandboxCsp` then
+  // ran with `resourceCsp: undefined`, fell back to the empty secure
+  // default, and forced `permissive: false` — the sandbox proxy emitted
+  // `script-src 'unsafe-inline' data: blob:` and every esm.sh module load
+  // in the App was refused. The tester saw an empty bordered box.
+  const declaredCspProfile = (): HostConfigMcpProfileV1 => ({
+    profileVersion: 1,
+    apps: { sandbox: { csp: { mode: "declared" } } },
+  });
+
+  it("keeps the resource-declared CSP on a scenario surface under a 'declared' host profile", async () => {
+    // Server response as it now stands: a scenario surface asks for
+    // permissive, and the route reports the declaration regardless.
+    vi.mocked(authFetch).mockResolvedValue({
+      ok: true,
+      json: () =>
+        Promise.resolve({
+          html: "<html><body>live-widget</body></html>",
+          csp: {
+            resourceDomains: ["https://esm.sh"],
+            connectDomains: ["https://esm.sh"],
+          },
+          permissive: true,
+          mimeTypeValid: true,
+          prefersBorder: true,
+        }),
+      status: 200,
+      headers: new Headers(),
+    } as Response);
+
+    render(
+      <WidgetSurfaceProvider value="scenario">
+        <ActiveMcpProfileProvider value={declaredCspProfile()}>
+          <HostedRenderer {...baseProps} />
+        </ActiveMcpProfileProvider>
+      </WidgetSurfaceProvider>
+    );
+
+    await vi.waitFor(() => {
+      expect(sandboxedIframePropsRef.current?.csp).toBeTruthy();
+    });
+
+    // Before the fix both lists came back `[]` — the empty secure default.
+    expect(sandboxedIframePropsRef.current.csp.resourceDomains).toEqual([
+      "https://esm.sh",
+    ]);
+    expect(sandboxedIframePropsRef.current.csp.connectDomains).toEqual([
+      "https://esm.sh",
+    ]);
+    // The host policy is in force, so the meta-CSP is injected — with the
+    // declared origins in it, which is the whole point.
+    expect(sandboxedIframePropsRef.current.permissive).toBe(false);
+  });
+
+  it("keeps empty domain lists on a scenario surface when the App declares no CSP", async () => {
+    // The inverse, and a spec MUST: "if `ui.csp` is omitted" the host keeps
+    // the restrictive default, and "Host MAY further restrict but MUST NOT
+    // allow undeclared domains." An undeclared App stays blocked — Change 3
+    // makes that legible rather than blank.
+    vi.mocked(authFetch).mockResolvedValue({
+      ok: true,
+      json: () =>
+        Promise.resolve({
+          html: "<html><body>live-widget</body></html>",
+          csp: undefined,
+          permissive: true,
+          mimeTypeValid: true,
+          prefersBorder: true,
+        }),
+      status: 200,
+      headers: new Headers(),
+    } as Response);
+
+    render(
+      <WidgetSurfaceProvider value="scenario">
+        <ActiveMcpProfileProvider value={declaredCspProfile()}>
+          <HostedRenderer {...baseProps} />
+        </ActiveMcpProfileProvider>
+      </WidgetSurfaceProvider>
+    );
+
+    await vi.waitFor(() => {
+      expect(sandboxedIframePropsRef.current?.csp).toBeTruthy();
+    });
+
+    expect(sandboxedIframePropsRef.current.csp.resourceDomains).toEqual([]);
+    expect(sandboxedIframePropsRef.current.csp.connectDomains).toEqual([]);
+  });
+
+  // ── Blocked-App notice ──────────────────────────────────────────────────
+  // An App whose own resources are refused never signals ready, so the
+  // iframe stays at `opacity: 0`. Without a notice that is indistinguishable
+  // from a hang — the two-hour-investigation failure mode this replaces.
+  const postCspViolation = (overrides: Record<string, unknown> = {}): void => {
+    act(() => {
+      sandboxedIframePropsRef.current.onMessage({
+        data: {
+          type: "mcp-apps:csp-violation",
+          directive: "script-src-elem",
+          effectiveDirective: "script-src-elem",
+          blockedUri: "https://esm.sh/react@19",
+          ...overrides,
+        },
+      } as MessageEvent);
+    });
+  };
+
+  it("explains a CSP-blocked App that never signals ready", async () => {
+    vi.useFakeTimers({ shouldAdvanceTime: true });
+    try {
+      render(<HostedRenderer {...baseProps} />);
+
+      await vi.waitFor(() => {
+        expect(sandboxedIframePropsRef.current?.onMessage).toBeTruthy();
+      });
+
+      postCspViolation();
+      // Grace period: the notice must not race a View that is merely slow.
+      expect(screen.queryByTestId("mcp-app-csp-blocked-notice")).toBeNull();
+
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(2000);
+      });
+
+      const notice = screen.getByTestId("mcp-app-csp-blocked-notice");
+      expect(notice.textContent).toContain("Content Security Policy");
+      // Names the blocked directive and the first blocked origin — the two
+      // facts that turn this into a five-second diagnosis.
+      expect(notice.textContent).toContain("script-src-elem");
+      expect(notice.textContent).toContain("https://esm.sh/react@19");
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("keeps the blocked-App notice plain-language in minimal mode", async () => {
+    vi.useFakeTimers({ shouldAdvanceTime: true });
+    try {
+      render(<HostedRenderer {...baseProps} minimalMode={true} />);
+
+      await vi.waitFor(() => {
+        expect(sandboxedIframePropsRef.current?.onMessage).toBeTruthy();
+      });
+
+      postCspViolation();
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(2000);
+      });
+
+      const notice = screen.getByTestId("mcp-app-csp-blocked-notice");
+      // Testers get a sentence, not a debug dump.
+      expect(notice.textContent).toContain("couldn't load its resources");
+      expect(notice.textContent).not.toContain("Content Security Policy");
+      expect(notice.textContent).not.toContain("script-src-elem");
+      expect(notice.textContent).toContain("https://esm.sh/react@19");
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("does not show the blocked-App notice when the App boots anyway", async () => {
+    // A blocked optional asset (an analytics beacon, a webfont) still
+    // reports a violation. If the View initializes, there is nothing wrong
+    // to report and the notice must never appear.
+    vi.useFakeTimers({ shouldAdvanceTime: true });
+    try {
+      render(<HostedRenderer {...baseProps} />);
+
+      await vi.waitFor(() => {
+        expect(sandboxedIframePropsRef.current?.onMessage).toBeTruthy();
+      });
+
+      postCspViolation({ blockedUri: "https://analytics.example.com/beacon" });
+      act(() => triggerReady());
+
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(2000);
+      });
+
+      expect(screen.queryByTestId("mcp-app-csp-blocked-notice")).toBeNull();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
 });
 
 // ── Host capability gating ─────────────────────────────────────────────────

--- a/mcpjam-inspector/client/src/components/chat-v2/thread/mcp-apps/__tests__/mcp-apps-renderer.test.tsx
+++ b/mcpjam-inspector/client/src/components/chat-v2/thread/mcp-apps/__tests__/mcp-apps-renderer.test.tsx
@@ -3067,6 +3067,56 @@ describe("MCPAppsRenderer tool input streaming", () => {
     }
   });
 
+  it("explains a block after a TIGHTENED policy breaks a previously-working App", async () => {
+    // End-to-end guard on the case the notice most needs to cover: the App
+    // boots fine, the policy is then narrowed, and the reloaded App can't
+    // initialize. This works because `effectiveSandboxKey` is a dependency
+    // of the bridge-connect effect, which resets readiness when it re-runs —
+    // pinning that here so a refactor that decouples the two (leaving
+    // `isReady` true across a policy reload) turns the notice back into a
+    // silent blank surface.
+    vi.useFakeTimers({ shouldAdvanceTime: true });
+    try {
+      const renderTree = (connectDomains: string[]) => (
+        <ActiveMcpProfileProvider
+          value={{
+            profileVersion: 1,
+            apps: {
+              sandbox: {
+                csp: { mode: "declared", restrictTo: { connectDomains } },
+              },
+            },
+          }}
+        >
+          <HostedRenderer {...baseProps} />
+        </ActiveMcpProfileProvider>
+      );
+
+      const { rerender } = render(renderTree(["https://api.example.com"]));
+
+      await vi.waitFor(() => {
+        expect(sandboxedIframePropsRef.current?.onMessage).toBeTruthy();
+      });
+      act(() => triggerReady());
+
+      // Narrow the policy — the iframe reloads and the App is now blocked.
+      rerender(renderTree([]));
+      await vi.waitFor(() => {
+        expect(sandboxedIframePropsRef.current.csp.connectDomains).toEqual([]);
+      });
+
+      postCspViolation({ blockedUri: "https://api.example.com/data" });
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(2000);
+      });
+
+      const notice = screen.getByTestId("mcp-app-csp-blocked-notice");
+      expect(notice.textContent).toContain("https://api.example.com/data");
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
   it("clears a stale blocked-App notice when the sandbox policy changes", async () => {
     // Widening a profile to unblock an App re-posts the resource-ready
     // payload (SandboxedIframe keys it on the resolved csp), so the View

--- a/mcpjam-inspector/client/src/components/chat-v2/thread/mcp-apps/__tests__/mcp-apps-renderer.test.tsx
+++ b/mcpjam-inspector/client/src/components/chat-v2/thread/mcp-apps/__tests__/mcp-apps-renderer.test.tsx
@@ -3066,6 +3066,65 @@ describe("MCPAppsRenderer tool input streaming", () => {
       vi.useRealTimers();
     }
   });
+
+  it("clears a stale blocked-App notice when the sandbox policy changes", async () => {
+    // Widening a profile to unblock an App re-posts the resource-ready
+    // payload (SandboxedIframe keys it on the resolved csp), so the View
+    // boots again. A violation recorded against the PREVIOUS policy must not
+    // keep naming an origin that is now allowed.
+    vi.useFakeTimers({ shouldAdvanceTime: true });
+    try {
+      const renderTree = (connectDomains: string[]) => (
+        <ActiveMcpProfileProvider
+          value={{
+            profileVersion: 1,
+            apps: {
+              sandbox: {
+                csp: { mode: "declared", restrictTo: { connectDomains } },
+              },
+            },
+          }}
+        >
+          <HostedRenderer {...baseProps} />
+        </ActiveMcpProfileProvider>
+      );
+
+      // `restrictTo` INTERSECTS the declared baseline, so the widened value
+      // must be one the baseline actually contains — otherwise the resolved
+      // policy is unchanged and no reload happens.
+      const { rerender } = render(renderTree([]));
+
+      await vi.waitFor(() => {
+        expect(sandboxedIframePropsRef.current?.onMessage).toBeTruthy();
+      });
+      expect(sandboxedIframePropsRef.current.csp.connectDomains).toEqual([]);
+
+      postCspViolation();
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(2000);
+      });
+      expect(screen.getByTestId("mcp-app-csp-blocked-notice")).toBeTruthy();
+
+      // Profile edit → new resolved CSP → iframe reload.
+      rerender(renderTree(["https://api.example.com"]));
+
+      await vi.waitFor(() => {
+        expect(sandboxedIframePropsRef.current.csp.connectDomains).toEqual([
+          "https://api.example.com",
+        ]);
+      });
+
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(2000);
+      });
+
+      // Stale violation dropped: nothing has been reported against the new
+      // policy yet, so there is nothing to explain.
+      expect(screen.queryByTestId("mcp-app-csp-blocked-notice")).toBeNull();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
 });
 
 // ── Host capability gating ─────────────────────────────────────────────────

--- a/mcpjam-inspector/server/routes/apps/__tests__/widget-content-metadata.test.ts
+++ b/mcpjam-inspector/server/routes/apps/__tests__/widget-content-metadata.test.ts
@@ -27,6 +27,7 @@ const RESOURCE_URI = "ui://test/view.html";
 function makeMockManager(opts: {
   contentMeta?: Record<string, unknown>;
   listingMeta?: Record<string, unknown>;
+  listResourcesRejects?: boolean;
 }) {
   return {
     readResource: vi.fn().mockResolvedValue({
@@ -39,14 +40,16 @@ function makeMockManager(opts: {
         },
       ],
     }),
-    listResources: vi.fn().mockResolvedValue({
-      resources: [
-        {
-          uri: RESOURCE_URI,
-          ...(opts.listingMeta ? { _meta: opts.listingMeta } : {}),
-        },
-      ],
-    }),
+    listResources: opts.listResourcesRejects
+      ? vi.fn().mockRejectedValue(new Error("Method not found: resources/list"))
+      : vi.fn().mockResolvedValue({
+          resources: [
+            {
+              uri: RESOURCE_URI,
+              ...(opts.listingMeta ? { _meta: opts.listingMeta } : {}),
+            },
+          ],
+        }),
   };
 }
 
@@ -224,6 +227,37 @@ describe("/widget-content — SEP-1865 metadata precedence", () => {
     const body = await res.json();
     expect(body.csp).toBeUndefined();
     expect(body.permissive).toBe(true);
+  });
+
+  it("still serves content metadata when resources/list fails", async () => {
+    // The listing lookup is a fallback, not a dependency: a server that
+    // doesn't implement `resources/list` (or errors on it) must be no worse
+    // off than before the fallback existed.
+    const manager = makeMockManager({
+      contentMeta: { ui: FULL_UI_META },
+      listResourcesRejects: true,
+    });
+    const res = await postWidgetContent(buildApp(manager));
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.html).toBe(HTML);
+    expect(body.csp).toEqual({ connectDomains: ["https://api.example.com"] });
+    expect(body.metadataSources.csp).toBe("content");
+  });
+
+  it("drops malformed domain fields from a declared csp", async () => {
+    // `_meta` is server-controlled. Downstream consumers assume `string[]`
+    // — the SDK resolver spreads each field and throws on a number — so a
+    // malformed declaration must degrade rather than break the render.
+    const manager = makeMockManager({
+      contentMeta: {
+        ui: { csp: { connectDomains: 42, resourceDomains: ["https://esm.sh"] } },
+      },
+    });
+    const res = await postWidgetContent(buildApp(manager), "permissive");
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.csp).toEqual({ resourceDomains: ["https://esm.sh"] });
   });
 
   it("reports metadataSource='none' when no source has any UI metadata", async () => {

--- a/mcpjam-inspector/server/routes/apps/__tests__/widget-content-metadata.test.ts
+++ b/mcpjam-inspector/server/routes/apps/__tests__/widget-content-metadata.test.ts
@@ -62,7 +62,10 @@ function buildApp(manager: ReturnType<typeof makeMockManager>) {
   return app;
 }
 
-async function postWidgetContent(app: Hono) {
+async function postWidgetContent(
+  app: Hono,
+  cspMode: "permissive" | "widget-declared" = "widget-declared",
+) {
   return app.request("/api/apps/mcp-apps/widget-content", {
     method: "POST",
     headers: { "Content-Type": "application/json" },
@@ -73,7 +76,7 @@ async function postWidgetContent(app: Hono) {
       toolName: "test-tool",
       toolInput: {},
       toolOutput: null,
-      cspMode: "widget-declared",
+      cspMode,
     }),
   });
 }
@@ -160,6 +163,67 @@ describe("/widget-content — SEP-1865 metadata precedence", () => {
       connectDomains: ["https://legacy.example.com"],
     });
     expect(body.prefersBorder).toBe(false);
+  });
+
+  it("still reports the declared csp when the request asks for cspMode='permissive'", async () => {
+    // Regression: the route used to withhold the declaration whenever the
+    // caller asked for permissive. Scenario / minimal surfaces always ask
+    // for permissive, so their client-side `resolveSandboxCsp` ran with
+    // `resourceCsp: undefined` under a `mode: "declared"` host profile and
+    // fell back to the empty secure default — emitting the STRICTEST
+    // possible CSP on exactly the surfaces that requested the loosest.
+    //
+    // `permissive` alone tells the sandbox proxy whether to inject; what
+    // the resource declared is reported either way. Returning it cannot
+    // loosen anything, because `permissive: true` means "no CSP injected".
+    const manager = makeMockManager({
+      contentMeta: {
+        ui: {
+          csp: {
+            resourceDomains: ["https://esm.sh"],
+            connectDomains: ["https://esm.sh"],
+          },
+        },
+      },
+    });
+    const res = await postWidgetContent(buildApp(manager), "permissive");
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.permissive).toBe(true);
+    expect(body.cspMode).toBe("permissive");
+    expect(body.csp).toEqual({
+      resourceDomains: ["https://esm.sh"],
+      connectDomains: ["https://esm.sh"],
+    });
+    expect(body.metadataSources.csp).toBe("content");
+  });
+
+  it("reports the listing-declared csp under cspMode='permissive' too", async () => {
+    // Both halves of the fix at once: the listing-only declaration must be
+    // found (SEP-1865 "hosts MUST check both locations") AND survive a
+    // permissive request.
+    const manager = makeMockManager({
+      contentMeta: undefined,
+      listingMeta: {
+        ui: { csp: { resourceDomains: ["https://esm.sh"] } },
+      },
+    });
+    const res = await postWidgetContent(buildApp(manager), "permissive");
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.csp).toEqual({ resourceDomains: ["https://esm.sh"] });
+    expect(body.metadataSources.csp).toBe("listing");
+  });
+
+  it("leaves csp undefined under cspMode='permissive' when nothing is declared", async () => {
+    // The spec default: no declaration means no baseline to report. The
+    // client keeps the secure default rather than inventing origins.
+    const manager = makeMockManager({});
+    const res = await postWidgetContent(buildApp(manager), "permissive");
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.csp).toBeUndefined();
+    expect(body.permissive).toBe(true);
   });
 
   it("reports metadataSource='none' when no source has any UI metadata", async () => {

--- a/mcpjam-inspector/server/routes/apps/mcp-apps/index.ts
+++ b/mcpjam-inspector/server/routes/apps/mcp-apps/index.ts
@@ -12,13 +12,10 @@ import { logger } from "../../../utils/logger";
 import { getRequestLogger } from "../../../utils/request-logger";
 import { classifyWidgetError } from "../../../utils/error-classify";
 import { RESOURCE_MIME_TYPE } from "@modelcontextprotocol/ext-apps/app-bridge";
-import type {
-  McpUiResourceCsp,
-  McpUiResourceMeta,
-} from "@modelcontextprotocol/ext-apps";
 import { MCP_APPS_SANDBOX_PROXY_HTML } from "../SandboxProxyHtml.bundled";
 import { RECORDER_SHIM_JS } from "./recorder-shim";
 import { injectOpenAICompat } from "../../../utils/widget-helpers";
+import { resolveUiResourceMeta } from "../../../utils/ui-resource-meta";
 
 const apps = new Hono();
 
@@ -60,7 +57,6 @@ const ACCEPTED_WIDGET_MIMETYPES = new Set<string>([
  * CSP mode types - matches client-side CspMode type
  */
 type CspMode = "permissive" | "widget-declared";
-type MetadataSource = "content" | "listing" | "legacy" | "mixed" | "none";
 
 interface WidgetContentRequest {
   serverId: string;
@@ -107,35 +103,6 @@ interface WidgetContentRequest {
   template?: string;
   viewMode?: string;
   viewParams?: Record<string, unknown>;
-}
-
-/**
- * Fallback CSP extraction for legacy Apps SDK widgets that declare CSP
- * via `_meta["openai/widgetCSP"]` (snake_case fields:
- * `connect_domains`, `resource_domains`, `frame_domains`) instead of the
- * SEP-1865 `_meta.ui.csp` shape (camelCase). Returns the camelCase shape
- * the proxy's buildCSP expects, or undefined when no legacy CSP is set
- * or only contains non-array values.
- */
-function extractLegacyOpenAICsp(
-  resourceMeta: Record<string, unknown> | undefined
-): McpUiResourceCsp | undefined {
-  if (!resourceMeta) return undefined;
-  const legacy = resourceMeta["openai/widgetCSP"];
-  if (!legacy || typeof legacy !== "object") return undefined;
-  const src = legacy as Record<string, unknown>;
-  const readArr = (v: unknown): string[] | undefined =>
-    Array.isArray(v)
-      ? v.filter((x): x is string => typeof x === "string" && x.length > 0)
-      : undefined;
-  const out: McpUiResourceCsp = {};
-  const connect = readArr(src.connect_domains);
-  const resource = readArr(src.resource_domains);
-  const frame = readArr(src.frame_domains);
-  if (connect && connect.length > 0) out.connectDomains = connect;
-  if (resource && resource.length > 0) out.resourceDomains = resource;
-  if (frame && frame.length > 0) out.frameDomains = frame;
-  return Object.keys(out).length > 0 ? out : undefined;
 }
 
 // Serve widget content with CSP metadata (SEP-1865)
@@ -257,33 +224,15 @@ apps.post("/widget-content", async (c) => {
       return c.json({ error: "No HTML content in resource" }, 404);
     }
 
-    // SEP-1865 effective UI metadata resolution (PR 2026-01):
-    //   1. content-item `_meta.ui` from the `resources/read` content   (canonical)
-    //   2. listing `_meta.ui` from `resources/list`                    (fallback)
-    //   3. legacy Apps SDK `openai/widget*` keys on either source      (last resort)
-    //
-    // The fallback chain is per-field, not all-or-nothing: a widget
-    // that publishes only `csp` at the content level and only
-    // `prefersBorder` at the listing level should see both honored.
-    // Listing lookup is best-effort — older servers that don't
-    // implement `resources/list` (or that fail to return the URI) just
-    // leave the listing source undefined and the content source wins.
+    // SEP-1865 effective UI metadata resolution — see
+    // utils/ui-resource-meta.ts for the per-field precedence chain
+    // (content `_meta.ui` → listing `_meta.ui` → legacy `openai/widget*`).
+    // Listing lookup is best-effort: older servers that don't implement
+    // `resources/list` (or that fail to return the URI) just leave the
+    // listing source undefined and the content source wins.
     const resourceMeta = content._meta as Record<string, unknown> | undefined;
-    const contentUiMeta = (
-      resourceMeta as { ui?: McpUiResourceMeta } | undefined
-    )?.ui;
 
     let listingMeta: Record<string, unknown> | undefined;
-    let listingUiMeta: McpUiResourceMeta | undefined;
-    const metadataSources: {
-      csp: Exclude<MetadataSource, "mixed">;
-      permissions: Exclude<MetadataSource, "mixed">;
-      prefersBorder: Exclude<MetadataSource, "mixed">;
-    } = {
-      csp: "none",
-      permissions: "none",
-      prefersBorder: "none",
-    };
     try {
       const listing = await mcpClientManager.listResources(serverId);
       const match = listing?.resources?.find(
@@ -291,7 +240,6 @@ apps.post("/widget-content", async (c) => {
       ) as { _meta?: Record<string, unknown> } | undefined;
       if (match?._meta) {
         listingMeta = match._meta;
-        listingUiMeta = (match._meta as { ui?: McpUiResourceMeta }).ui;
       }
     } catch (err) {
       logger.debug("[MCP Apps] resources/list fallback skipped", {
@@ -300,59 +248,8 @@ apps.post("/widget-content", async (c) => {
       });
     }
 
-    const contentLegacyCsp = extractLegacyOpenAICsp(resourceMeta);
-    const listingLegacyCsp = extractLegacyOpenAICsp(listingMeta);
-    let csp: McpUiResourceCsp | undefined;
-    if (contentUiMeta?.csp) {
-      csp = contentUiMeta.csp;
-      metadataSources.csp = "content";
-    } else if (listingUiMeta?.csp) {
-      csp = listingUiMeta.csp;
-      metadataSources.csp = "listing";
-    } else if (contentLegacyCsp) {
-      csp = contentLegacyCsp;
-      metadataSources.csp = "legacy";
-    } else if (listingLegacyCsp) {
-      csp = listingLegacyCsp;
-      metadataSources.csp = "legacy";
-    }
-    const permissions =
-      contentUiMeta?.permissions ?? listingUiMeta?.permissions;
-    if (contentUiMeta?.permissions) {
-      metadataSources.permissions = "content";
-    } else if (listingUiMeta?.permissions) {
-      metadataSources.permissions = "listing";
-    }
-    const prefersBorderLegacy = (m: Record<string, unknown> | undefined) =>
-      typeof m?.["openai/widgetPrefersBorder"] === "boolean"
-        ? (m["openai/widgetPrefersBorder"] as boolean)
-        : undefined;
-    const contentLegacyPrefersBorder = prefersBorderLegacy(resourceMeta);
-    const listingLegacyPrefersBorder = prefersBorderLegacy(listingMeta);
-    let prefersBorder: boolean | undefined;
-    if (contentUiMeta?.prefersBorder !== undefined) {
-      prefersBorder = contentUiMeta.prefersBorder;
-      metadataSources.prefersBorder = "content";
-    } else if (listingUiMeta?.prefersBorder !== undefined) {
-      prefersBorder = listingUiMeta.prefersBorder;
-      metadataSources.prefersBorder = "listing";
-    } else if (contentLegacyPrefersBorder !== undefined) {
-      prefersBorder = contentLegacyPrefersBorder;
-      metadataSources.prefersBorder = "legacy";
-    } else if (listingLegacyPrefersBorder !== undefined) {
-      prefersBorder = listingLegacyPrefersBorder;
-      metadataSources.prefersBorder = "legacy";
-    }
-
-    const usedMetadataSources = new Set(
-      Object.values(metadataSources).filter((source) => source !== "none")
-    );
-    const metadataSource: MetadataSource =
-      usedMetadataSources.size === 0
-        ? "none"
-        : usedMetadataSources.size === 1
-        ? Array.from(usedMetadataSources)[0]
-        : "mixed";
+    const { csp, permissions, prefersBorder, metadataSources, metadataSource } =
+      resolveUiResourceMeta({ contentMeta: resourceMeta, listingMeta });
 
     // Log CSP and permissions configuration for security review (SEP-1865)
     logger.debug("[MCP Apps] Security configuration", {
@@ -378,8 +275,9 @@ apps.post("/widget-content", async (c) => {
         : null,
     });
 
-    // When in permissive mode, skip CSP entirely (for testing/debugging)
-    // When in widget-declared mode, use the widget's CSP metadata (or restrictive defaults)
+    // `permissive` tells the sandbox proxy to skip CSP injection entirely.
+    // It does NOT change what the resource declared, so the response always
+    // reports `csp` verbatim (see the `csp` field below).
     const isPermissive = effectiveCspMode === "permissive";
 
     // Optionally inject the OpenAI Apps SDK `window.openai` shim.
@@ -424,7 +322,15 @@ apps.post("/widget-content", async (c) => {
     c.header("Cache-Control", "no-cache, no-store, must-revalidate");
     return c.json({
       html,
-      csp: isPermissive ? undefined : csp,
+      // Always report what the resource declared. The request's `cspMode`
+      // decides whether a CSP is *injected* (`permissive` below), never what
+      // the resource *declared* — withholding the declaration here made the
+      // client's `resolveSandboxCsp` fall back to the empty secure default
+      // under a `mode: "declared"` host profile, producing the strictest
+      // possible CSP on exactly the surfaces that asked for permissive
+      // (scenario / minimal). Returning it cannot loosen anything:
+      // `permissive: true` already means "no CSP injected at all".
+      csp,
       permissions, // Include permissions metadata
       permissive: isPermissive, // Tell sandbox-proxy to skip CSP injection entirely
       cspMode: effectiveCspMode,

--- a/mcpjam-inspector/server/routes/apps/mcp-apps/index.ts
+++ b/mcpjam-inspector/server/routes/apps/mcp-apps/index.ts
@@ -15,7 +15,10 @@ import { RESOURCE_MIME_TYPE } from "@modelcontextprotocol/ext-apps/app-bridge";
 import { MCP_APPS_SANDBOX_PROXY_HTML } from "../SandboxProxyHtml.bundled";
 import { RECORDER_SHIM_JS } from "./recorder-shim";
 import { injectOpenAICompat } from "../../../utils/widget-helpers";
-import { resolveUiResourceMeta } from "../../../utils/ui-resource-meta";
+import {
+  findListingMetaForUri,
+  resolveUiResourceMeta,
+} from "../../../utils/ui-resource-meta";
 
 const apps = new Hono();
 
@@ -232,21 +235,16 @@ apps.post("/widget-content", async (c) => {
     // listing source undefined and the content source wins.
     const resourceMeta = content._meta as Record<string, unknown> | undefined;
 
-    let listingMeta: Record<string, unknown> | undefined;
-    try {
-      const listing = await mcpClientManager.listResources(serverId);
-      const match = listing?.resources?.find(
-        (r: { uri?: unknown }) => r?.uri === resolvedResourceUri
-      ) as { _meta?: Record<string, unknown> } | undefined;
-      if (match?._meta) {
-        listingMeta = match._meta;
-      }
-    } catch (err) {
-      logger.debug("[MCP Apps] resources/list fallback skipped", {
-        resourceUri: resolvedResourceUri,
-        reason: err instanceof Error ? err.message : String(err),
-      });
-    }
+    const listingMeta = await findListingMetaForUri(
+      mcpClientManager,
+      serverId,
+      resolvedResourceUri,
+      (reason) =>
+        logger.debug("[MCP Apps] resources/list fallback skipped", {
+          resourceUri: resolvedResourceUri,
+          reason,
+        })
+    );
 
     const { csp, permissions, prefersBorder, metadataSources, metadataSource } =
       resolveUiResourceMeta({ contentMeta: resourceMeta, listingMeta });

--- a/mcpjam-inspector/server/routes/apps/mcp-apps/index.ts
+++ b/mcpjam-inspector/server/routes/apps/mcp-apps/index.ts
@@ -16,6 +16,7 @@ import { MCP_APPS_SANDBOX_PROXY_HTML } from "../SandboxProxyHtml.bundled";
 import { RECORDER_SHIM_JS } from "./recorder-shim";
 import { injectOpenAICompat } from "../../../utils/widget-helpers";
 import {
+  canSkipListingLookup,
   findListingMetaForUri,
   resolveUiResourceMeta,
 } from "../../../utils/ui-resource-meta";
@@ -235,16 +236,20 @@ apps.post("/widget-content", async (c) => {
     // listing source undefined and the content source wins.
     const resourceMeta = content._meta as Record<string, unknown> | undefined;
 
-    const listingMeta = await findListingMetaForUri(
-      mcpClientManager,
-      serverId,
-      resolvedResourceUri,
-      (reason) =>
-        logger.debug("[MCP Apps] resources/list fallback skipped", {
-          resourceUri: resolvedResourceUri,
-          reason,
-        })
-    );
+    // A content item that already declares every field can't be improved by
+    // a lower-precedence source, so skip the round-trip entirely.
+    const listingMeta = canSkipListingLookup(resourceMeta)
+      ? undefined
+      : await findListingMetaForUri(
+          mcpClientManager,
+          serverId,
+          resolvedResourceUri,
+          (reason) =>
+            logger.debug("[MCP Apps] resources/list fallback skipped", {
+              resourceUri: resolvedResourceUri,
+              reason,
+            })
+        );
 
     const { csp, permissions, prefersBorder, metadataSources, metadataSource } =
       resolveUiResourceMeta({ contentMeta: resourceMeta, listingMeta });

--- a/mcpjam-inspector/server/routes/web/__tests__/apps-widget-content.test.ts
+++ b/mcpjam-inspector/server/routes/web/__tests__/apps-widget-content.test.ts
@@ -262,6 +262,37 @@ describe("hosted /widget-content — malformed declarations", () => {
     expect(body.metadataSources.csp).toBe("content");
   });
 
+  it("drops malformed permission markers instead of granting them", async () => {
+    // The renderer grants on plain truthiness, so a non-object marker like
+    // `"yes"` would read as a genuine camera request.
+    mockResource({
+      contentMeta: {
+        ui: {
+          permissions: {
+            camera: {},
+            microphone: "yes",
+            geolocation: true,
+            clipboardWrite: null,
+          },
+        },
+      },
+    });
+    const res = await postWidgetContent(makeApp());
+    const body = await res.json();
+    expect(body.permissions).toEqual({ camera: {} });
+  });
+
+  it("keeps unknown permission keys so future spec additions survive", async () => {
+    // Key-agnostic on purpose: enumerating today's four permissions would
+    // silently drop any the spec adds later.
+    mockResource({
+      contentMeta: { ui: { permissions: { somethingNew: {} } } },
+    });
+    const res = await postWidgetContent(makeApp());
+    const body = await res.json();
+    expect(body.permissions).toEqual({ somethingNew: {} });
+  });
+
   it("ignores a non-boolean prefersBorder", async () => {
     mockResource({ contentMeta: { ui: { prefersBorder: "yes" } } });
     const res = await postWidgetContent(makeApp());
@@ -389,6 +420,66 @@ describe("hosted /widget-content — SEP-1865 metadata precedence", () => {
     expect(managerState.listResources).toHaveBeenCalledTimes(1);
   });
 
+  it("skips the listing round-trip when the content item declares everything", async () => {
+    // The listing can only supply fields the content item didn't. When the
+    // canonical block is complete, the request is pure latency in front of
+    // the App's HTML — and this is the common case for a well-formed App.
+    mockResource({
+      contentMeta: {
+        ui: { csp: ESM_CSP, permissions: { camera: {} }, prefersBorder: true },
+      },
+    });
+    const res = await postWidgetContent(makeApp());
+    const body = await res.json();
+    expect(body.csp).toEqual(ESM_CSP);
+    expect(body.metadataSource).toBe("content");
+    expect(managerState.listResources).not.toHaveBeenCalled();
+  });
+
+  it("still consults the listing when the content item declares only some fields", async () => {
+    mockResource({
+      contentMeta: { ui: { csp: ESM_CSP } },
+      listingMeta: { ui: { prefersBorder: false } },
+    });
+    const res = await postWidgetContent(makeApp());
+    const body = await res.json();
+    expect(body.prefersBorder).toBe(false);
+    expect(managerState.listResources).toHaveBeenCalled();
+  });
+
+  it("still consults the listing when the content item has only legacy keys", async () => {
+    // Legacy `openai/widget*` ranks BELOW the listing's `_meta.ui`, so a
+    // content item carrying only legacy metadata must not short-circuit.
+    mockResource({
+      contentMeta: {
+        "openai/widgetCSP": { connect_domains: ["https://legacy.example.com"] },
+        "openai/widgetPrefersBorder": true,
+      },
+      listingMeta: { ui: { csp: ESM_CSP } },
+    });
+    const res = await postWidgetContent(makeApp());
+    const body = await res.json();
+    expect(managerState.listResources).toHaveBeenCalled();
+    // Listing's canonical csp beats the content item's legacy csp.
+    expect(body.csp).toEqual(ESM_CSP);
+    expect(body.metadataSources.csp).toBe("listing");
+  });
+
+  it("stops paginating when the server repeats a cursor", async () => {
+    // A server that keeps reissuing the same cursor would otherwise spin to
+    // the page cap on every single render.
+    mockResource({});
+    managerState.listResources.mockImplementation(async () => ({
+      resources: [{ uri: "ui://other/a.html" }],
+      nextCursor: "same-cursor-forever",
+    }));
+
+    const res = await postWidgetContent(makeApp());
+    expect(res.status).toBe(200);
+    // First page, then one more with the cursor — then the repeat is caught.
+    expect(managerState.listResources).toHaveBeenCalledTimes(2);
+  });
+
   it("caps the pagination walk instead of enumerating a huge catalog", async () => {
     // A server that paginates forever must not hold the App's HTML hostage.
     managerState.readResource.mockResolvedValue({
@@ -396,9 +487,12 @@ describe("hosted /widget-content — SEP-1865 metadata precedence", () => {
         { uri: RESOURCE_URI, mimeType: MCP_APPS_MIMETYPE, text: HTML },
       ],
     });
+    // Distinct cursors each time, so this exercises the page cap rather than
+    // the repeated-cursor guard.
+    let page = 0;
     managerState.listResources.mockImplementation(async () => ({
       resources: [{ uri: "ui://other/a.html" }],
-      nextCursor: "more",
+      nextCursor: `page-${page++}`,
     }));
 
     const res = await postWidgetContent(makeApp());
@@ -406,7 +500,12 @@ describe("hosted /widget-content — SEP-1865 metadata precedence", () => {
     const body = await res.json();
     expect(body.html).toBe(HTML);
     expect(body.metadataSource).toBe("none");
-    expect(managerState.listResources).toHaveBeenCalledTimes(5);
+    // Bounded, and the App still renders rather than hanging behind an
+    // unbounded enumeration. The exact bound is an implementation detail;
+    // what matters is that it terminates and stays modest.
+    const calls = managerState.listResources.mock.calls.length;
+    expect(calls).toBeGreaterThan(1);
+    expect(calls).toBeLessThanOrEqual(20);
   });
 
   it("still serves the App when the server has no resources/list", async () => {

--- a/mcpjam-inspector/server/routes/web/__tests__/apps-widget-content.test.ts
+++ b/mcpjam-inspector/server/routes/web/__tests__/apps-widget-content.test.ts
@@ -293,6 +293,54 @@ describe("hosted /widget-content — malformed declarations", () => {
     expect(body.permissions).toEqual({ somethingNew: {} });
   });
 
+  it("trims declared origins so the hosted clamp sees what the browser will", async () => {
+    // Security, not tidiness. The hosted clamp's `matchesAnyDeny` lower-cases
+    // but does not trim, so a padded `" https://mcpjam.com "` slips past the
+    // MCPJam deny list — and the sandbox proxy's `sanitizeDomain` then trims
+    // it on the way out, so the browser allows the protected origin. Emitting
+    // the canonical form here keeps clamp and browser looking at one string.
+    mockResource({
+      contentMeta: {
+        ui: {
+          csp: {
+            connectDomains: ["  https://mcpjam.com  ", "\thttps://esm.sh\n"],
+          },
+        },
+      },
+    });
+    const res = await postWidgetContent(makeApp(), "permissive");
+    const body = await res.json();
+    expect(body.csp.connectDomains).toEqual([
+      "https://mcpjam.com",
+      "https://esm.sh",
+    ]);
+  });
+
+  it("strips characters the sandbox proxy would remove later", async () => {
+    // Same lockstep requirement for the quote/semicolon class that
+    // `sanitizeDomain` drops — otherwise the clamp inspects a string the
+    // browser never sees.
+    mockResource({
+      contentMeta: {
+        ui: { csp: { connectDomains: ['https://mcpjam.com";', "   ", "<>"] } },
+      },
+    });
+    const res = await postWidgetContent(makeApp(), "permissive");
+    const body = await res.json();
+    expect(body.csp.connectDomains).toEqual(["https://mcpjam.com"]);
+  });
+
+  it("canonicalizes legacy openai/widgetCSP origins the same way", async () => {
+    mockResource({
+      contentMeta: {
+        "openai/widgetCSP": { connect_domains: ["  https://mcpjam.com  "] },
+      },
+    });
+    const res = await postWidgetContent(makeApp(), "permissive");
+    const body = await res.json();
+    expect(body.csp).toEqual({ connectDomains: ["https://mcpjam.com"] });
+  });
+
   it("ignores a non-boolean prefersBorder", async () => {
     mockResource({ contentMeta: { ui: { prefersBorder: "yes" } } });
     const res = await postWidgetContent(makeApp());

--- a/mcpjam-inspector/server/routes/web/__tests__/apps-widget-content.test.ts
+++ b/mcpjam-inspector/server/routes/web/__tests__/apps-widget-content.test.ts
@@ -1,0 +1,264 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { Hono } from "hono";
+
+/**
+ * Hosted-mode `/web/apps/mcp-apps/widget-content` coverage.
+ *
+ * Two properties this route regressed on, both SEP-1865 conformance
+ * defects that rendered a declared App as a blank box on the User Testing
+ * surface:
+ *
+ *   1. It withheld the resource's declared `csp` whenever the request asked
+ *      for `cspMode: "permissive"` — which scenario / minimal surfaces
+ *      always do. With no baseline, the client's `resolveSandboxCsp` fell
+ *      back to the empty secure default under a `mode: "declared"` host
+ *      profile and emitted the strictest possible CSP.
+ *   2. It read `_meta.ui` only from the `resources/read` content item. The
+ *      spec requires hosts to check the `resources/list` entry too,
+ *      "preferring the content item and falling back to the listing entry."
+ *
+ * The local route (routes/apps/mcp-apps) is covered by
+ * routes/apps/__tests__/widget-content-metadata.test.ts; both now share
+ * utils/ui-resource-meta.ts.
+ */
+
+const HTML = "<!doctype html><html><body>hi</body></html>";
+const MCP_APPS_MIMETYPE = "text/html;profile=mcp-app";
+const RESOURCE_URI = "ui://test/view.html";
+
+const managerState = vi.hoisted(() => ({
+  readResource: vi.fn(),
+  listResources: vi.fn(),
+}));
+
+// `withEphemeralConnection` normally authorizes the caller and spins up a
+// real ephemeral MCP connection. Stub it down to "parse the body, hand the
+// route a manager, JSON-encode whatever it returns" — this suite is about
+// the route's metadata resolution, not the hosted auth path.
+vi.mock("../auth.js", async () => {
+  const { z } = await import("zod");
+  class WebRouteError extends Error {
+    status: number;
+    code: string;
+    constructor(status: number, code: string, message: string) {
+      super(message);
+      this.status = status;
+      this.code = code;
+    }
+  }
+  return {
+    WebRouteError,
+    ErrorCode: new Proxy({}, { get: (_t, key) => String(key) }),
+    projectServerSchema: z
+      .object({
+        projectId: z.string().min(1),
+        serverId: z.string().min(1),
+      })
+      .passthrough(),
+    assertBearerToken: () => "token",
+    handleRoute: async (c: any, fn: () => Promise<unknown>) => {
+      try {
+        return c.json(await fn(), 200);
+      } catch (error: any) {
+        return c.json({ error: error?.message }, error?.status ?? 500);
+      }
+    },
+    withEphemeralConnection: async (c: any, schema: any, fn: any) => {
+      const body = schema.parse(await c.req.json());
+      try {
+        return c.json(await fn(managerState, body), 200);
+      } catch (error: any) {
+        return c.json({ error: error?.message }, error?.status ?? 500);
+      }
+    },
+  };
+});
+
+import appsRoutes from "../apps.js";
+
+function makeApp() {
+  const app = new Hono();
+  app.route("/api/web/apps", appsRoutes);
+  return app;
+}
+
+function mockResource(opts: {
+  contentMeta?: Record<string, unknown>;
+  listingMeta?: Record<string, unknown>;
+  listResourcesRejects?: boolean;
+}) {
+  managerState.readResource.mockResolvedValue({
+    contents: [
+      {
+        uri: RESOURCE_URI,
+        mimeType: MCP_APPS_MIMETYPE,
+        text: HTML,
+        ...(opts.contentMeta ? { _meta: opts.contentMeta } : {}),
+      },
+    ],
+  });
+  if (opts.listResourcesRejects) {
+    managerState.listResources.mockRejectedValue(
+      new Error("Method not found: resources/list")
+    );
+  } else {
+    managerState.listResources.mockResolvedValue({
+      resources: [
+        {
+          uri: RESOURCE_URI,
+          ...(opts.listingMeta ? { _meta: opts.listingMeta } : {}),
+        },
+      ],
+    });
+  }
+}
+
+async function postWidgetContent(
+  app: Hono,
+  cspMode: "permissive" | "widget-declared" = "widget-declared"
+) {
+  return app.request("/api/web/apps/mcp-apps/widget-content", {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      authorization: "Bearer test",
+    },
+    body: JSON.stringify({
+      projectId: "p1",
+      serverId: "s1",
+      resourceUri: RESOURCE_URI,
+      toolId: "t1",
+      toolName: "test-tool",
+      toolInput: {},
+      toolOutput: null,
+      cspMode,
+    }),
+  });
+}
+
+const ESM_CSP = {
+  resourceDomains: ["https://esm.sh"],
+  connectDomains: ["https://esm.sh"],
+};
+
+describe("hosted /widget-content — declared CSP", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("reports the declared csp when the request asks for cspMode='permissive'", async () => {
+    // The exact failing configuration from the User Testing surface: an
+    // App declaring esm.sh, fetched by a scenario surface (which always
+    // sends `permissive`). The declaration must survive to the client so
+    // its `mode: "declared"` host profile has a real baseline to resolve.
+    mockResource({ contentMeta: { ui: { csp: ESM_CSP } } });
+    const res = await postWidgetContent(makeApp(), "permissive");
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.csp).toEqual(ESM_CSP);
+    // `permissive` is unchanged — it alone decides whether the sandbox
+    // proxy injects a meta-CSP.
+    expect(body.permissive).toBe(true);
+    expect(body.cspMode).toBe("permissive");
+  });
+
+  it("reports the declared csp under cspMode='widget-declared' too", async () => {
+    mockResource({ contentMeta: { ui: { csp: ESM_CSP } } });
+    const res = await postWidgetContent(makeApp(), "widget-declared");
+    const body = await res.json();
+    expect(body.csp).toEqual(ESM_CSP);
+    expect(body.permissive).toBe(false);
+  });
+
+  it("leaves csp undefined when the resource declares nothing (spec default)", async () => {
+    mockResource({});
+    const res = await postWidgetContent(makeApp(), "permissive");
+    const body = await res.json();
+    expect(body.csp).toBeUndefined();
+    expect(body.metadataSource).toBe("none");
+  });
+});
+
+describe("hosted /widget-content — SEP-1865 metadata precedence", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("falls back to the listing _meta.ui when the content item has none", async () => {
+    mockResource({
+      listingMeta: {
+        ui: { csp: ESM_CSP, permissions: { camera: {} }, prefersBorder: true },
+      },
+    });
+    const res = await postWidgetContent(makeApp());
+    const body = await res.json();
+    expect(body.csp).toEqual(ESM_CSP);
+    expect(body.permissions).toEqual({ camera: {} });
+    expect(body.prefersBorder).toBe(true);
+    expect(body.metadataSource).toBe("listing");
+    expect(body.metadataSources).toEqual({
+      csp: "listing",
+      permissions: "listing",
+      prefersBorder: "listing",
+    });
+  });
+
+  it("prefers the content item over the listing entry", async () => {
+    mockResource({
+      contentMeta: { ui: { csp: { connectDomains: ["https://content"] } } },
+      listingMeta: { ui: { csp: { connectDomains: ["https://listing"] } } },
+    });
+    const res = await postWidgetContent(makeApp());
+    const body = await res.json();
+    expect(body.csp).toEqual({ connectDomains: ["https://content"] });
+    expect(body.metadataSources.csp).toBe("content");
+  });
+
+  it("resolves per field, reporting 'mixed' when sources differ", async () => {
+    mockResource({
+      contentMeta: { ui: { prefersBorder: false } },
+      listingMeta: { ui: { csp: ESM_CSP } },
+    });
+    const res = await postWidgetContent(makeApp());
+    const body = await res.json();
+    expect(body.csp).toEqual(ESM_CSP);
+    expect(body.prefersBorder).toBe(false);
+    expect(body.metadataSource).toBe("mixed");
+    expect(body.metadataSources).toEqual({
+      csp: "listing",
+      permissions: "none",
+      prefersBorder: "content",
+    });
+  });
+
+  it("falls back to legacy openai/widget* keys on either source", async () => {
+    mockResource({
+      contentMeta: {
+        "openai/widgetCSP": { connect_domains: ["https://legacy.example.com"] },
+        "openai/widgetPrefersBorder": false,
+      },
+    });
+    const res = await postWidgetContent(makeApp());
+    const body = await res.json();
+    expect(body.csp).toEqual({
+      connectDomains: ["https://legacy.example.com"],
+    });
+    expect(body.prefersBorder).toBe(false);
+    expect(body.metadataSource).toBe("legacy");
+  });
+
+  it("still serves the App when the server has no resources/list", async () => {
+    // Best-effort lookup: a server that doesn't implement `resources/list`
+    // must be no worse off than before the listing fallback existed.
+    mockResource({
+      contentMeta: { ui: { csp: ESM_CSP } },
+      listResourcesRejects: true,
+    });
+    const res = await postWidgetContent(makeApp());
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.html).toBe(HTML);
+    expect(body.csp).toEqual(ESM_CSP);
+    expect(body.metadataSources.csp).toBe("content");
+  });
+});

--- a/mcpjam-inspector/server/routes/web/__tests__/apps-widget-content.test.ts
+++ b/mcpjam-inspector/server/routes/web/__tests__/apps-widget-content.test.ts
@@ -354,6 +354,68 @@ describe("hosted /widget-content — malformed declarations", () => {
     expect(body.csp.connectDomains).toEqual(["https://legit.example"]);
   });
 
+  it("drops root-dot host spellings that evade the loopback and MCPJam clamps", async () => {
+    // `https://localhost.` is the same host to DNS and to the browser, but
+    // not to the clamp: `isDangerousHostname` tests `=== "localhost"` and
+    // `.endsWith(".localhost")`, and the URL parser preserves the terminal
+    // dot on names (it strips it on IPv4 literals). Same trick evades
+    // `matchesAnyDeny` for the MCPJam origins. Left intact, a hosted App
+    // could reach services on the tester's own machine.
+    mockResource({
+      contentMeta: {
+        ui: {
+          csp: {
+            connectDomains: [
+              "https://localhost.",
+              "https://foo.localhost.",
+              "https://mcpjam.com.",
+              "https://legit.example",
+            ],
+          },
+        },
+      },
+    });
+    const res = await postWidgetContent(makeApp(), "permissive");
+    const body = await res.json();
+    expect(body.csp.connectDomains).toEqual(["https://legit.example"]);
+  });
+
+  it("drops schemeless and wildcard root-dot spellings too", async () => {
+    mockResource({
+      contentMeta: {
+        ui: { csp: { connectDomains: ["*.mcpjam.com.", "localhost."] } },
+      },
+    });
+    const res = await postWidgetContent(makeApp(), "permissive");
+    const body = await res.json();
+    expect(body.csp.connectDomains).toEqual([]);
+  });
+
+  it("leaves ordinary hosts and IPv4 literals alone", async () => {
+    // Guard against over-eager stripping: the fix must not eat legitimate
+    // declarations.
+    mockResource({
+      contentMeta: {
+        ui: {
+          csp: {
+            connectDomains: [
+              "https://esm.sh",
+              "*.example.com",
+              "https://example.com/path",
+            ],
+          },
+        },
+      },
+    });
+    const res = await postWidgetContent(makeApp(), "permissive");
+    const body = await res.json();
+    expect(body.csp.connectDomains).toEqual([
+      "https://esm.sh",
+      "*.example.com",
+      "https://example.com/path",
+    ]);
+  });
+
   it("drops whitespace-bearing entries on the legacy path too", async () => {
     mockResource({
       contentMeta: {

--- a/mcpjam-inspector/server/routes/web/__tests__/apps-widget-content.test.ts
+++ b/mcpjam-inspector/server/routes/web/__tests__/apps-widget-content.test.ts
@@ -330,6 +330,44 @@ describe("hosted /widget-content — malformed declarations", () => {
     expect(body.csp.connectDomains).toEqual(["https://mcpjam.com"]);
   });
 
+  it("drops entries with embedded whitespace that would fan out into extra sources", async () => {
+    // A CSP source list is space-separated. The clamp inspects each array
+    // entry as ONE value, but `buildCSP` joins the list with spaces — so
+    // `"https://safe.example https://mcpjam.com"` matches no deny pattern
+    // and still reaches the browser as two sources, smuggling the protected
+    // origin past a clamp documented as non-bypassable. Same for a `*`.
+    mockResource({
+      contentMeta: {
+        ui: {
+          csp: {
+            connectDomains: [
+              "https://safe.example https://mcpjam.com",
+              "https://safe.example *",
+              "https://legit.example",
+            ],
+          },
+        },
+      },
+    });
+    const res = await postWidgetContent(makeApp(), "permissive");
+    const body = await res.json();
+    expect(body.csp.connectDomains).toEqual(["https://legit.example"]);
+  });
+
+  it("drops whitespace-bearing entries on the legacy path too", async () => {
+    mockResource({
+      contentMeta: {
+        "openai/widgetCSP": {
+          connect_domains: ["https://safe.example https://mcpjam.com"],
+        },
+      },
+    });
+    const res = await postWidgetContent(makeApp(), "permissive");
+    const body = await res.json();
+    // Nothing survived, so there is no legacy csp to report.
+    expect(body.csp).toBeUndefined();
+  });
+
   it("canonicalizes legacy openai/widgetCSP origins the same way", async () => {
     mockResource({
       contentMeta: {

--- a/mcpjam-inspector/server/routes/web/__tests__/apps-widget-content.test.ts
+++ b/mcpjam-inspector/server/routes/web/__tests__/apps-widget-content.test.ts
@@ -179,6 +179,69 @@ describe("hosted /widget-content — declared CSP", () => {
   });
 });
 
+describe("hosted /widget-content — malformed declarations", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("drops non-array domain fields instead of passing them downstream", async () => {
+    // `_meta` is server-controlled and unvalidated. Downstream consumers
+    // assume `string[]`: the SDK resolver spreads each field (throws on a
+    // number) and the sandbox proxy's buildCSP iterates it. A malformed
+    // declaration must degrade, not take down the render — and reporting
+    // the declaration under `permissive` (this PR) newly exposes scenario
+    // surfaces to that path.
+    mockResource({
+      contentMeta: {
+        ui: {
+          csp: {
+            connectDomains: "https://not-an-array.example.com",
+            resourceDomains: ["https://esm.sh", 42, "", "  "],
+            frameDomains: null,
+          },
+        },
+      },
+    });
+    const res = await postWidgetContent(makeApp(), "permissive");
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.csp).toEqual({ resourceDomains: ["https://esm.sh"] });
+  });
+
+  it("treats an entirely malformed csp as absent so lower sources still win", async () => {
+    mockResource({
+      contentMeta: { ui: { csp: "totally-not-a-csp" } },
+      listingMeta: { ui: { csp: ESM_CSP } },
+    });
+    const res = await postWidgetContent(makeApp());
+    const body = await res.json();
+    expect(body.csp).toEqual(ESM_CSP);
+    expect(body.metadataSources.csp).toBe("listing");
+  });
+
+  it("preserves an explicitly empty domain list as a real declaration", async () => {
+    // `{ connectDomains: [] }` means "allow nothing here" — a declaration,
+    // not a missing one. Collapsing it to undefined would hand the decision
+    // to a lower-precedence source the App didn't intend.
+    mockResource({
+      contentMeta: { ui: { csp: { connectDomains: [] } } },
+      listingMeta: { ui: { csp: ESM_CSP } },
+    });
+    const res = await postWidgetContent(makeApp());
+    const body = await res.json();
+    expect(body.csp).toEqual({ connectDomains: [] });
+    expect(body.metadataSources.csp).toBe("content");
+  });
+
+  it("ignores a non-boolean prefersBorder", async () => {
+    mockResource({ contentMeta: { ui: { prefersBorder: "yes" } } });
+    const res = await postWidgetContent(makeApp());
+    const body = await res.json();
+    expect(body.prefersBorder).toBeUndefined();
+    expect(body.metadataSources.prefersBorder).toBe("none");
+  });
+});
+
 describe("hosted /widget-content — SEP-1865 metadata precedence", () => {
   beforeEach(() => {
     vi.clearAllMocks();
@@ -245,6 +308,76 @@ describe("hosted /widget-content — SEP-1865 metadata precedence", () => {
     });
     expect(body.prefersBorder).toBe(false);
     expect(body.metadataSource).toBe("legacy");
+  });
+
+  it("follows resources/list pagination to find a later-page declaration", async () => {
+    // `resources/list` is paginated and the listing declaration can sit on
+    // any page. Searching only page one would report a declared App as
+    // undeclared — the exact blank-render failure this fallback exists to
+    // prevent.
+    managerState.readResource.mockResolvedValue({
+      contents: [
+        { uri: RESOURCE_URI, mimeType: MCP_APPS_MIMETYPE, text: HTML },
+      ],
+    });
+    managerState.listResources.mockImplementation(
+      async (_serverId: string, params?: { cursor?: string }) => {
+        if (!params?.cursor) {
+          return {
+            resources: [{ uri: "ui://other/a.html" }],
+            nextCursor: "page-2",
+          };
+        }
+        return {
+          resources: [{ uri: RESOURCE_URI, _meta: { ui: { csp: ESM_CSP } } }],
+        };
+      }
+    );
+
+    const res = await postWidgetContent(makeApp(), "permissive");
+    const body = await res.json();
+    expect(body.csp).toEqual(ESM_CSP);
+    expect(body.metadataSources.csp).toBe("listing");
+    expect(managerState.listResources).toHaveBeenCalledTimes(2);
+  });
+
+  it("stops paginating as soon as the resource is found", async () => {
+    // Latency guard: the walk must not enumerate the whole catalog once it
+    // has what it came for.
+    managerState.listResources.mockImplementation(async () => ({
+      resources: [{ uri: RESOURCE_URI, _meta: { ui: { csp: ESM_CSP } } }],
+      nextCursor: "page-2",
+    }));
+    managerState.readResource.mockResolvedValue({
+      contents: [
+        { uri: RESOURCE_URI, mimeType: MCP_APPS_MIMETYPE, text: HTML },
+      ],
+    });
+
+    const res = await postWidgetContent(makeApp());
+    const body = await res.json();
+    expect(body.csp).toEqual(ESM_CSP);
+    expect(managerState.listResources).toHaveBeenCalledTimes(1);
+  });
+
+  it("caps the pagination walk instead of enumerating a huge catalog", async () => {
+    // A server that paginates forever must not hold the App's HTML hostage.
+    managerState.readResource.mockResolvedValue({
+      contents: [
+        { uri: RESOURCE_URI, mimeType: MCP_APPS_MIMETYPE, text: HTML },
+      ],
+    });
+    managerState.listResources.mockImplementation(async () => ({
+      resources: [{ uri: "ui://other/a.html" }],
+      nextCursor: "more",
+    }));
+
+    const res = await postWidgetContent(makeApp());
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.html).toBe(HTML);
+    expect(body.metadataSource).toBe("none");
+    expect(managerState.listResources).toHaveBeenCalledTimes(5);
   });
 
   it("still serves the App when the server has no resources/list", async () => {

--- a/mcpjam-inspector/server/routes/web/__tests__/apps-widget-content.test.ts
+++ b/mcpjam-inspector/server/routes/web/__tests__/apps-widget-content.test.ts
@@ -233,6 +233,35 @@ describe("hosted /widget-content — malformed declarations", () => {
     expect(body.metadataSources.csp).toBe("content");
   });
 
+  it("preserves a bare empty csp object as a deny-by-default declaration", async () => {
+    // `_meta.ui.csp: {}` omits every domain field to ask for the secure
+    // default. Treating it as absent would let the listing entry supply a
+    // BROADER policy than the content item asked for — a precedence
+    // inversion in the widening direction, which is the dangerous one.
+    mockResource({
+      contentMeta: { ui: { csp: {} } },
+      listingMeta: { ui: { csp: ESM_CSP } },
+    });
+    const res = await postWidgetContent(makeApp());
+    const body = await res.json();
+    expect(body.csp).toEqual({});
+    expect(body.metadataSources.csp).toBe("content");
+  });
+
+  it("keeps content precedence when its only declared fields are malformed", async () => {
+    // Same principle one step further: the object is a declaration, so a
+    // field that sanitizes away to nothing still means deny-by-default
+    // rather than handing the decision to a broader lower source.
+    mockResource({
+      contentMeta: { ui: { csp: { connectDomains: 42 } } },
+      listingMeta: { ui: { csp: ESM_CSP } },
+    });
+    const res = await postWidgetContent(makeApp());
+    const body = await res.json();
+    expect(body.csp).toEqual({});
+    expect(body.metadataSources.csp).toBe("content");
+  });
+
   it("ignores a non-boolean prefersBorder", async () => {
     mockResource({ contentMeta: { ui: { prefersBorder: "yes" } } });
     const res = await postWidgetContent(makeApp());

--- a/mcpjam-inspector/server/routes/web/apps.ts
+++ b/mcpjam-inspector/server/routes/web/apps.ts
@@ -1,14 +1,12 @@
 import { Hono } from "hono";
 import { z } from "zod";
 import { RESOURCE_MIME_TYPE } from "@modelcontextprotocol/ext-apps/app-bridge";
-import type {
-  McpUiResourceCsp,
-  McpUiResourcePermissions,
-} from "@modelcontextprotocol/ext-apps";
 import { CORS_ORIGINS } from "../../config.js";
 import { MCP_APPS_SANDBOX_PROXY_HTML } from "../apps/SandboxProxyHtml.bundled.js";
 import { RECORDER_SHIM_JS } from "../apps/mcp-apps/recorder-shim.js";
 import { injectOpenAICompat } from "../../utils/widget-helpers.js";
+import { logger } from "../../utils/logger.js";
+import { resolveUiResourceMeta } from "../../utils/ui-resource-meta.js";
 import {
   projectServerSchema,
   withEphemeralConnection,
@@ -25,34 +23,6 @@ const SANDBOX_PROXY_HTML_WITH_RECORDER = MCP_APPS_SANDBOX_PROXY_HTML.replace(
   '"__MCPJAM_RECORDER_SHIM__"',
   () => JSON.stringify(RECORDER_SHIM_JS),
 );
-
-/**
- * Hosted-mode mirror of `extractLegacyOpenAICsp` in
- * routes/apps/mcp-apps/index.ts. Reads the legacy Apps SDK CSP shape
- * (`_meta["openai/widgetCSP"]` with snake_case fields) and returns the
- * camelCase `McpUiResourceCsp` the proxy expects, or undefined when no
- * legacy CSP is present.
- */
-function extractLegacyOpenAICspHosted(
-  resourceMeta: Record<string, unknown> | undefined,
-): McpUiResourceCsp | undefined {
-  if (!resourceMeta) return undefined;
-  const legacy = resourceMeta["openai/widgetCSP"];
-  if (!legacy || typeof legacy !== "object") return undefined;
-  const src = legacy as Record<string, unknown>;
-  const readArr = (v: unknown): string[] | undefined =>
-    Array.isArray(v)
-      ? v.filter((x): x is string => typeof x === "string" && x.length > 0)
-      : undefined;
-  const out: McpUiResourceCsp = {};
-  const connect = readArr(src.connect_domains);
-  const resource = readArr(src.resource_domains);
-  const frame = readArr(src.frame_domains);
-  if (connect && connect.length > 0) out.connectDomains = connect;
-  if (resource && resource.length > 0) out.resourceDomains = resource;
-  if (frame && frame.length > 0) out.frameDomains = frame;
-  return Object.keys(out).length > 0 ? out : undefined;
-}
 
 // Mimetypes accepted by the hosted-mode widget-content route. Mirrors
 // the local route in routes/apps/mcp-apps/index.ts — see the long-form
@@ -190,28 +160,46 @@ apps.post("/mcp-apps/widget-content", async (c) =>
         );
       }
 
+      // SEP-1865 effective UI metadata resolution. Shared with the local
+      // route via utils/ui-resource-meta.ts: per-field precedence of
+      // content `_meta.ui` → listing `_meta.ui` → legacy `openai/widget*`.
+      // The spec requires hosts to check BOTH the `resources/read` content
+      // item and the `resources/list` entry — a server that declares
+      // `_meta.ui` only at listing level used to render blank here while
+      // working fine locally.
       const resourceMeta = content._meta as
         | Record<string, unknown>
         | undefined;
-      const uiMeta = (resourceMeta as { ui?: any } | undefined)?.ui as
-        | {
-            csp?: McpUiResourceCsp;
-            permissions?: McpUiResourcePermissions;
-            prefersBorder?: boolean;
-          }
-        | undefined;
-      // Apps SDK widgets declare CSP under _meta["openai/widgetCSP"]
-      // (snake_case) and border preference under
-      // _meta["openai/widgetPrefersBorder"]. Fall back to those so the
-      // consolidated path renders legacy widgets with their declared
-      // origins and border preference. Mirrors routes/apps/mcp-apps/index.ts.
-      const cspFromMeta: McpUiResourceCsp | undefined =
-        uiMeta?.csp ?? extractLegacyOpenAICspHosted(resourceMeta);
-      const prefersBorderFromMeta: boolean | undefined =
-        uiMeta?.prefersBorder ??
-        (typeof resourceMeta?.["openai/widgetPrefersBorder"] === "boolean"
-          ? (resourceMeta["openai/widgetPrefersBorder"] as boolean)
-          : undefined);
+
+      // Best-effort listing lookup: servers without `resources/list` (or
+      // that don't return this URI) simply fall through to the content
+      // item, exactly as before this lookup existed.
+      let listingMeta: Record<string, unknown> | undefined;
+      try {
+        const listing = await manager.listResources(body.serverId);
+        const match = (listing as any)?.resources?.find(
+          (r: { uri?: unknown }) => r?.uri === resolvedResourceUri,
+        ) as { _meta?: Record<string, unknown> } | undefined;
+        if (match?._meta) {
+          listingMeta = match._meta;
+        }
+      } catch (err) {
+        logger.debug("[MCP Apps] resources/list fallback skipped", {
+          resourceUri: resolvedResourceUri,
+          reason: err instanceof Error ? err.message : String(err),
+        });
+      }
+
+      const {
+        csp: cspFromMeta,
+        permissions: permissionsFromMeta,
+        prefersBorder: prefersBorderFromMeta,
+        metadataSource,
+        metadataSources,
+      } = resolveUiResourceMeta({
+        contentMeta: resourceMeta,
+        listingMeta,
+      });
 
       // Mirror the local CLI route's behavior: only inject the
       // OpenAI Apps SDK shim when the caller has opted in. Hosted
@@ -238,8 +226,12 @@ apps.post("/mcp-apps/widget-content", async (c) =>
 
       return {
         html,
-        csp: effectiveCspMode === "permissive" ? undefined : cspFromMeta,
-        permissions: uiMeta?.permissions,
+        // Always report what the resource declared — see the matching
+        // comment in routes/apps/mcp-apps/index.ts. `cspMode` decides
+        // whether a CSP is injected (`permissive` below), not what the
+        // resource declared.
+        csp: cspFromMeta,
+        permissions: permissionsFromMeta,
         permissive: effectiveCspMode === "permissive",
         cspMode: effectiveCspMode,
         prefersBorder: prefersBorderFromMeta,
@@ -252,6 +244,11 @@ apps.post("/mcp-apps/widget-content", async (c) =>
         mimeType: contentMimeType,
         mimeTypeValid,
         mimeTypeWarning,
+        // SEP-1865 metadata precedence, mirroring the local route.
+        // `metadataSource` is a summary ("mixed" when per-field fallbacks
+        // used different sources); `metadataSources` reports per field.
+        metadataSource,
+        metadataSources,
       };
     },
   ),

--- a/mcpjam-inspector/server/routes/web/apps.ts
+++ b/mcpjam-inspector/server/routes/web/apps.ts
@@ -7,6 +7,7 @@ import { RECORDER_SHIM_JS } from "../apps/mcp-apps/recorder-shim.js";
 import { injectOpenAICompat } from "../../utils/widget-helpers.js";
 import { logger } from "../../utils/logger.js";
 import {
+  canSkipListingLookup,
   findListingMetaForUri,
   resolveUiResourceMeta,
 } from "../../utils/ui-resource-meta.js";
@@ -177,16 +178,20 @@ apps.post("/mcp-apps/widget-content", async (c) =>
       // Best-effort listing lookup: servers without `resources/list` (or
       // that don't return this URI) simply fall through to the content
       // item, exactly as before this lookup existed.
-      const listingMeta = await findListingMetaForUri(
-        manager,
-        body.serverId,
-        resolvedResourceUri,
-        (reason) =>
-          logger.debug("[MCP Apps] resources/list fallback skipped", {
-            resourceUri: resolvedResourceUri,
-            reason,
-          }),
-      );
+      // A content item that already declares every field can't be improved
+      // by a lower-precedence source, so skip the round-trip entirely.
+      const listingMeta = canSkipListingLookup(resourceMeta)
+        ? undefined
+        : await findListingMetaForUri(
+            manager,
+            body.serverId,
+            resolvedResourceUri,
+            (reason) =>
+              logger.debug("[MCP Apps] resources/list fallback skipped", {
+                resourceUri: resolvedResourceUri,
+                reason,
+              }),
+          );
 
       const {
         csp: cspFromMeta,

--- a/mcpjam-inspector/server/routes/web/apps.ts
+++ b/mcpjam-inspector/server/routes/web/apps.ts
@@ -6,7 +6,10 @@ import { MCP_APPS_SANDBOX_PROXY_HTML } from "../apps/SandboxProxyHtml.bundled.js
 import { RECORDER_SHIM_JS } from "../apps/mcp-apps/recorder-shim.js";
 import { injectOpenAICompat } from "../../utils/widget-helpers.js";
 import { logger } from "../../utils/logger.js";
-import { resolveUiResourceMeta } from "../../utils/ui-resource-meta.js";
+import {
+  findListingMetaForUri,
+  resolveUiResourceMeta,
+} from "../../utils/ui-resource-meta.js";
 import {
   projectServerSchema,
   withEphemeralConnection,
@@ -174,21 +177,16 @@ apps.post("/mcp-apps/widget-content", async (c) =>
       // Best-effort listing lookup: servers without `resources/list` (or
       // that don't return this URI) simply fall through to the content
       // item, exactly as before this lookup existed.
-      let listingMeta: Record<string, unknown> | undefined;
-      try {
-        const listing = await manager.listResources(body.serverId);
-        const match = (listing as any)?.resources?.find(
-          (r: { uri?: unknown }) => r?.uri === resolvedResourceUri,
-        ) as { _meta?: Record<string, unknown> } | undefined;
-        if (match?._meta) {
-          listingMeta = match._meta;
-        }
-      } catch (err) {
-        logger.debug("[MCP Apps] resources/list fallback skipped", {
-          resourceUri: resolvedResourceUri,
-          reason: err instanceof Error ? err.message : String(err),
-        });
-      }
+      const listingMeta = await findListingMetaForUri(
+        manager,
+        body.serverId,
+        resolvedResourceUri,
+        (reason) =>
+          logger.debug("[MCP Apps] resources/list fallback skipped", {
+            resourceUri: resolvedResourceUri,
+            reason,
+          }),
+      );
 
       const {
         csp: cspFromMeta,

--- a/mcpjam-inspector/server/utils/ui-resource-meta.ts
+++ b/mcpjam-inspector/server/utils/ui-resource-meta.ts
@@ -152,14 +152,34 @@ function normalizeCsp(value: unknown): McpUiResourceCsp | undefined {
   return out;
 }
 
-/** Permissions must be a plain object — SEP-1865 declares each as `{}`. */
+/**
+ * Normalize `_meta.ui.permissions`. SEP-1865 declares each requested
+ * permission as an empty object (`{}`), and the renderer grants on plain
+ * truthiness (`if (v) resourcePermsMap[k] = true`) — so a malformed
+ * `{ camera: "yes" }` would be read as a genuine camera request. Marker
+ * values are checked individually and anything that isn't a plain object is
+ * dropped rather than granted.
+ *
+ * Deliberately key-agnostic: every surviving marker is rewritten to the
+ * canonical `{}`, but the key set is not enumerated. Hard-coding today's four
+ * permissions would silently discard any the spec adds later, trading a
+ * malformed-input bug for a spec-drift one.
+ */
 function normalizePermissions(
   value: unknown
 ): McpUiResourcePermissions | undefined {
   if (!value || typeof value !== "object" || Array.isArray(value)) {
     return undefined;
   }
-  return value as McpUiResourcePermissions;
+  const out: Record<string, Record<string, never>> = {};
+  for (const [key, marker] of Object.entries(
+    value as Record<string, unknown>
+  )) {
+    if (marker && typeof marker === "object" && !Array.isArray(marker)) {
+      out[key] = {};
+    }
+  }
+  return out as McpUiResourcePermissions;
 }
 
 interface NormalizedUiMeta {
@@ -264,17 +284,20 @@ export function resolveUiResourceMeta(
 /**
  * Page cap for the `resources/list` lookup below.
  *
- * `resources/list` is paginated, and the listing declaration can live on any
- * page — searching only the first would silently treat a listing-only
- * declaration as absent, which is the exact failure this fallback exists to
- * prevent. But this runs on every widget render, so an unbounded walk would
- * put a large catalog's full enumeration in front of the App's HTML.
+ * `resources/list` is paginated and the listing declaration can live on any
+ * page, so the walk has to follow `nextCursor`. It cannot follow it forever:
+ * this runs on every widget render, ahead of the App's HTML, so an unbounded
+ * walk makes each render on a large catalog pay that catalog's full
+ * enumeration in sequential round-trips.
  *
- * The cap splits the difference: follow `nextCursor` until the URI is found,
- * the server stops paginating, or this many pages have been read. Nine out of
- * ten servers answer on page one and never pay for a second round-trip.
+ * The bound is set high enough to cover realistic catalogs rather than to
+ * ration requests — most servers answer on page one, and
+ * `canSkipListingLookup` removes the request entirely for the common
+ * fully-declared resource. Hitting the cap is reported through `onSkipped`
+ * rather than passing silently, so a truncated walk is diagnosable instead of
+ * looking like "no declaration".
  */
-const LISTING_LOOKUP_MAX_PAGES = 5;
+const LISTING_LOOKUP_MAX_PAGES = 20;
 
 interface ResourceListingClient {
   listResources(
@@ -284,14 +307,33 @@ interface ResourceListingClient {
 }
 
 /**
+ * True when the content item's canonical `_meta.ui` already supplies every
+ * field the resolver reads, so no lower-precedence source could change the
+ * outcome and the `resources/list` round-trip is pure cost.
+ *
+ * Only the canonical block counts. Legacy `openai/widget*` keys rank BELOW
+ * the listing's `_meta.ui`, so a content item carrying only legacy metadata
+ * must still consult the listing.
+ */
+export function canSkipListingLookup(
+  contentMeta: Record<string, unknown> | undefined
+): boolean {
+  const ui = readUiMeta(contentMeta);
+  return (
+    ui.csp !== undefined &&
+    ui.permissions !== undefined &&
+    ui.prefersBorder !== undefined
+  );
+}
+
+/**
  * Best-effort lookup of a resource's `resources/list` `_meta`, following
- * pagination up to `LISTING_LOOKUP_MAX_PAGES` and stopping as soon as the URI
- * is found.
+ * pagination and stopping as soon as the URI is found.
  *
  * Returns undefined when the server doesn't implement `resources/list`, the
- * URI isn't listed, or the walk hits the page cap — all of which leave the
- * caller with the content-item metadata it already had. Never throws: the
- * listing is a fallback, so a failure here must not fail the render.
+ * URI isn't listed, or the walk is cut short — all of which leave the caller
+ * with the content-item metadata it already had. Never throws: the listing is
+ * a fallback, so a failure here must not fail the render.
  */
 export async function findListingMetaForUri(
   manager: ResourceListingClient,
@@ -301,6 +343,10 @@ export async function findListingMetaForUri(
 ): Promise<Record<string, unknown> | undefined> {
   try {
     let cursor: string | undefined;
+    // A server that keeps handing back a cursor it already issued would
+    // otherwise spin until the page cap, turning one broken server into
+    // `LISTING_LOOKUP_MAX_PAGES` pointless round-trips on every render.
+    const seenCursors = new Set<string>();
     for (let page = 0; page < LISTING_LOOKUP_MAX_PAGES; page++) {
       const listing = (await manager.listResources(
         serverId,
@@ -323,6 +369,13 @@ export async function findListingMetaForUri(
       if (match || typeof nextCursor !== "string" || nextCursor.length === 0) {
         return undefined;
       }
+      if (seenCursors.has(nextCursor)) {
+        onSkipped?.(
+          `resources/list repeated cursor "${nextCursor}" — stopping pagination`
+        );
+        return undefined;
+      }
+      seenCursors.add(nextCursor);
       cursor = nextCursor;
     }
     onSkipped?.(

--- a/mcpjam-inspector/server/utils/ui-resource-meta.ts
+++ b/mcpjam-inspector/server/utils/ui-resource-meta.ts
@@ -80,9 +80,15 @@ export function extractLegacyOpenAICsp(
   const legacy = resourceMeta["openai/widgetCSP"];
   if (!legacy || typeof legacy !== "object") return undefined;
   const src = legacy as Record<string, unknown>;
+  // Canonicalized on the same terms as the SEP-1865 path — a padded or
+  // quote-bearing origin declared through the legacy keys reaches the same
+  // clamp and the same proxy, so it has the same bypass exposure.
   const readArr = (v: unknown): string[] | undefined =>
     Array.isArray(v)
-      ? v.filter((x): x is string => typeof x === "string" && x.length > 0)
+      ? v
+          .filter((x): x is string => typeof x === "string")
+          .map(canonicalizeCspSource)
+          .filter((x) => x.length > 0)
       : undefined;
   const out: McpUiResourceCsp = {};
   const connect = readArr(src.connect_domains);
@@ -108,6 +114,41 @@ const CSP_DOMAIN_KEYS = [
   "frameDomains",
   "baseUriDomains",
 ] as const;
+
+/**
+ * Canonicalize one declared CSP source into the exact string the sandbox
+ * proxy will emit.
+ *
+ * This must stay in lockstep with `sanitizeDomain` in sandbox-proxy.html
+ * (`domain.replace(/['"<>;]/g, "").trim()`), and the reason is a real
+ * security bug rather than tidiness. Every consumer between here and the
+ * browser compares these strings verbatim: the hosted clamp's
+ * `matchesAnyDeny` lower-cases but does NOT trim, so a padded
+ * `" https://mcpjam.com "` fails to match the MCPJam deny pattern and
+ * survives the clamp — and then the proxy trims it on the way out and the
+ * browser allows the protected origin. Clamp and browser end up disagreeing
+ * about what the value is, which defeats a clamp documented as
+ * non-bypassable.
+ *
+ * Canonicalizing at this choke point means the value the clamp inspects is
+ * byte-identical to the one the browser enforces.
+ */
+function canonicalizeCspSource(value: string): string {
+  return value.replace(/['"<>;]/g, "").trim();
+}
+
+/**
+ * A plain `{}` — not an array, not a `Date`/`Map`/class instance.
+ *
+ * Over MCP, `_meta` arrives as parsed JSON, so exotic objects can't reach
+ * here on the live path; this keeps the predicate honest about what it
+ * claims to check rather than closing a reachable hole.
+ */
+function isPlainObject(value: unknown): value is Record<string, unknown> {
+  if (!value || typeof value !== "object" || Array.isArray(value)) return false;
+  const proto = Object.getPrototypeOf(value);
+  return proto === Object.prototype || proto === null;
+}
 
 /**
  * Coerce a resource-declared `_meta.ui.csp` into a shape the downstream CSP
@@ -145,9 +186,10 @@ function normalizeCsp(value: unknown): McpUiResourceCsp | undefined {
   for (const key of CSP_DOMAIN_KEYS) {
     const list = src[key];
     if (!Array.isArray(list)) continue;
-    out[key] = list.filter(
-      (d): d is string => typeof d === "string" && d.trim().length > 0
-    );
+    out[key] = list
+      .filter((d): d is string => typeof d === "string")
+      .map(canonicalizeCspSource)
+      .filter((d) => d.length > 0);
   }
   return out;
 }
@@ -175,7 +217,7 @@ function normalizePermissions(
   for (const [key, marker] of Object.entries(
     value as Record<string, unknown>
   )) {
-    if (marker && typeof marker === "object" && !Array.isArray(marker)) {
+    if (isPlainObject(marker)) {
       out[key] = {};
     }
   }

--- a/mcpjam-inspector/server/utils/ui-resource-meta.ts
+++ b/mcpjam-inspector/server/utils/ui-resource-meta.ts
@@ -123,11 +123,18 @@ const CSP_DOMAIN_KEYS = [
  * `cspMode: "permissive"` requests — scenario / minimal surfaces used to be
  * shielded from a malformed declaration by the withholding this PR removed.
  *
- * Non-array fields are dropped; non-string entries within a field are
- * dropped. An explicitly empty array is preserved — `{ connectDomains: [] }`
- * is a meaningful "allow nothing here" declaration, not a missing one.
- * Returns undefined when no recognized field survives, so resolution falls
- * through to the next source instead of reporting a phantom declaration.
+ * Any plain object counts as a declaration, and emptiness is meaningful:
+ * `{ connectDomains: [] }` and a bare `{}` both say "allow nothing here",
+ * which is a real deny-by-default choice rather than a missing one. Treating
+ * either as absent would let a lower-precedence source (the listing entry or
+ * legacy keys) supply a BROADER policy than the content item asked for —
+ * inverting the precedence SEP-1865 requires, in the widening direction.
+ *
+ * Only a structurally invalid value — a string, number, array, or null —
+ * is rejected outright, so resolution falls through rather than reporting a
+ * phantom declaration. Within a valid object, non-array fields and
+ * non-string entries are dropped individually; a field that survives as
+ * nothing is deny-by-default, again the safe direction.
  */
 function normalizeCsp(value: unknown): McpUiResourceCsp | undefined {
   if (!value || typeof value !== "object" || Array.isArray(value)) {
@@ -135,16 +142,14 @@ function normalizeCsp(value: unknown): McpUiResourceCsp | undefined {
   }
   const src = value as Record<string, unknown>;
   const out: McpUiResourceCsp = {};
-  let sawRecognizedField = false;
   for (const key of CSP_DOMAIN_KEYS) {
     const list = src[key];
     if (!Array.isArray(list)) continue;
-    sawRecognizedField = true;
     out[key] = list.filter(
       (d): d is string => typeof d === "string" && d.trim().length > 0
     );
   }
-  return sawRecognizedField ? out : undefined;
+  return out;
 }
 
 /** Permissions must be a plain object — SEP-1865 declares each as `{}`. */

--- a/mcpjam-inspector/server/utils/ui-resource-meta.ts
+++ b/mcpjam-inspector/server/utils/ui-resource-meta.ts
@@ -102,10 +102,79 @@ function extractLegacyPrefersBorder(
     : undefined;
 }
 
+const CSP_DOMAIN_KEYS = [
+  "connectDomains",
+  "resourceDomains",
+  "frameDomains",
+  "baseUriDomains",
+] as const;
+
+/**
+ * Coerce a resource-declared `_meta.ui.csp` into a shape the downstream CSP
+ * builders can actually consume.
+ *
+ * `_meta` is server-controlled and unvalidated. The consumers assume every
+ * domain field is a `string[]`: the SDK resolver spreads them
+ * (`[...(value.connectDomains ?? [])]`, which THROWS on a number) and the
+ * sandbox proxy's `buildCSP` iterates them. A truthy-but-malformed
+ * declaration would therefore take down the render rather than degrade.
+ *
+ * That path matters more now that the routes report the declaration even for
+ * `cspMode: "permissive"` requests — scenario / minimal surfaces used to be
+ * shielded from a malformed declaration by the withholding this PR removed.
+ *
+ * Non-array fields are dropped; non-string entries within a field are
+ * dropped. An explicitly empty array is preserved — `{ connectDomains: [] }`
+ * is a meaningful "allow nothing here" declaration, not a missing one.
+ * Returns undefined when no recognized field survives, so resolution falls
+ * through to the next source instead of reporting a phantom declaration.
+ */
+function normalizeCsp(value: unknown): McpUiResourceCsp | undefined {
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    return undefined;
+  }
+  const src = value as Record<string, unknown>;
+  const out: McpUiResourceCsp = {};
+  let sawRecognizedField = false;
+  for (const key of CSP_DOMAIN_KEYS) {
+    const list = src[key];
+    if (!Array.isArray(list)) continue;
+    sawRecognizedField = true;
+    out[key] = list.filter(
+      (d): d is string => typeof d === "string" && d.trim().length > 0
+    );
+  }
+  return sawRecognizedField ? out : undefined;
+}
+
+/** Permissions must be a plain object — SEP-1865 declares each as `{}`. */
+function normalizePermissions(
+  value: unknown
+): McpUiResourcePermissions | undefined {
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    return undefined;
+  }
+  return value as McpUiResourcePermissions;
+}
+
+interface NormalizedUiMeta {
+  csp?: McpUiResourceCsp;
+  permissions?: McpUiResourcePermissions;
+  prefersBorder?: boolean;
+}
+
 function readUiMeta(
   meta: Record<string, unknown> | undefined
-): McpUiResourceMeta | undefined {
-  return (meta as { ui?: McpUiResourceMeta } | undefined)?.ui;
+): NormalizedUiMeta {
+  const ui = (meta as { ui?: McpUiResourceMeta } | undefined)?.ui;
+  if (!ui || typeof ui !== "object" || Array.isArray(ui)) return {};
+  return {
+    csp: normalizeCsp(ui.csp),
+    permissions: normalizePermissions(ui.permissions),
+    // Anything non-boolean is a malformed declaration, not a `false`.
+    prefersBorder:
+      typeof ui.prefersBorder === "boolean" ? ui.prefersBorder : undefined,
+  };
 }
 
 /**
@@ -185,4 +254,78 @@ export function resolveUiResourceMeta(
       : "mixed";
 
   return { csp, permissions, prefersBorder, metadataSources, metadataSource };
+}
+
+/**
+ * Page cap for the `resources/list` lookup below.
+ *
+ * `resources/list` is paginated, and the listing declaration can live on any
+ * page — searching only the first would silently treat a listing-only
+ * declaration as absent, which is the exact failure this fallback exists to
+ * prevent. But this runs on every widget render, so an unbounded walk would
+ * put a large catalog's full enumeration in front of the App's HTML.
+ *
+ * The cap splits the difference: follow `nextCursor` until the URI is found,
+ * the server stops paginating, or this many pages have been read. Nine out of
+ * ten servers answer on page one and never pay for a second round-trip.
+ */
+const LISTING_LOOKUP_MAX_PAGES = 5;
+
+interface ResourceListingClient {
+  listResources(
+    serverId: string,
+    params?: { cursor?: string }
+  ): Promise<unknown>;
+}
+
+/**
+ * Best-effort lookup of a resource's `resources/list` `_meta`, following
+ * pagination up to `LISTING_LOOKUP_MAX_PAGES` and stopping as soon as the URI
+ * is found.
+ *
+ * Returns undefined when the server doesn't implement `resources/list`, the
+ * URI isn't listed, or the walk hits the page cap — all of which leave the
+ * caller with the content-item metadata it already had. Never throws: the
+ * listing is a fallback, so a failure here must not fail the render.
+ */
+export async function findListingMetaForUri(
+  manager: ResourceListingClient,
+  serverId: string,
+  resourceUri: string,
+  onSkipped?: (reason: string) => void
+): Promise<Record<string, unknown> | undefined> {
+  try {
+    let cursor: string | undefined;
+    for (let page = 0; page < LISTING_LOOKUP_MAX_PAGES; page++) {
+      const listing = (await manager.listResources(
+        serverId,
+        cursor ? { cursor } : undefined
+      )) as
+        | {
+            resources?: Array<{ uri?: unknown; _meta?: unknown }>;
+            nextCursor?: unknown;
+          }
+        | undefined;
+
+      const match = listing?.resources?.find((r) => r?.uri === resourceUri);
+      if (match?._meta && typeof match._meta === "object") {
+        return match._meta as Record<string, unknown>;
+      }
+
+      const nextCursor = listing?.nextCursor;
+      // Found the entry but it carries no `_meta`, or the server is done
+      // paginating — either way there is nothing further to read.
+      if (match || typeof nextCursor !== "string" || nextCursor.length === 0) {
+        return undefined;
+      }
+      cursor = nextCursor;
+    }
+    onSkipped?.(
+      `resource not found within the first ${LISTING_LOOKUP_MAX_PAGES} listing pages`
+    );
+    return undefined;
+  } catch (err) {
+    onSkipped?.(err instanceof Error ? err.message : String(err));
+    return undefined;
+  }
 }

--- a/mcpjam-inspector/server/utils/ui-resource-meta.ts
+++ b/mcpjam-inspector/server/utils/ui-resource-meta.ts
@@ -147,7 +147,36 @@ function canonicalizeCspSource(value: string): string {
   const stripped = value.replace(/['"<>;]/g, "").trim();
   // Any interior whitespace means this entry would fan out into multiple
   // CSP sources at emit time, past whatever the clamp inspected.
-  return /\s/.test(stripped) ? "" : stripped;
+  if (/\s/.test(stripped)) return "";
+  if (hasTrailingDotHost(stripped)) return "";
+  return stripped;
+}
+
+/**
+ * True when the source's host ends in the root-zone dot (`https://localhost.`,
+ * `*.mcpjam.com.`).
+ *
+ * A terminal dot spells the same host to DNS and to the browser, but not to
+ * the clamp: `isDangerousHostname` tests `host === "localhost"` and
+ * `host.endsWith(".localhost")`, and `matchesAnyDeny` compares deny patterns
+ * as plain strings — the dotted spelling matches neither, so `https://localhost.`
+ * survives the loopback clamp and `https://mcpjam.com.` survives the MCPJam
+ * clamp, while the browser resolves both to the protected target. (IPv4
+ * literals are safe: the URL parser already strips the dot from `127.0.0.1.`.)
+ *
+ * Dropped rather than rewritten, on the same reasoning as whitespace: a
+ * declaration has no legitimate need for the root-dot spelling, and rewriting
+ * it would mean this helper deciding what the App "meant".
+ */
+function hasTrailingDotHost(source: string): boolean {
+  try {
+    return new URL(source).hostname.endsWith(".");
+  } catch {
+    // Schemeless / wildcard forms (`*.example.com.`, `example.com.`) don't
+    // parse as URLs. Fall back to the host-ish prefix before any path.
+    const hostish = source.split("/")[0];
+    return hostish.endsWith(".") && hostish !== ".";
+  }
 }
 
 /**

--- a/mcpjam-inspector/server/utils/ui-resource-meta.ts
+++ b/mcpjam-inspector/server/utils/ui-resource-meta.ts
@@ -116,25 +116,38 @@ const CSP_DOMAIN_KEYS = [
 ] as const;
 
 /**
- * Canonicalize one declared CSP source into the exact string the sandbox
- * proxy will emit.
+ * Canonicalize one declared CSP source into exactly the string the sandbox
+ * proxy will emit, or `""` when the entry can't be represented as a single
+ * source (callers drop empties).
  *
- * This must stay in lockstep with `sanitizeDomain` in sandbox-proxy.html
- * (`domain.replace(/['"<>;]/g, "").trim()`), and the reason is a real
- * security bug rather than tidiness. Every consumer between here and the
- * browser compares these strings verbatim: the hosted clamp's
- * `matchesAnyDeny` lower-cases but does NOT trim, so a padded
- * `" https://mcpjam.com "` fails to match the MCPJam deny pattern and
- * survives the clamp — and then the proxy trims it on the way out and the
- * browser allows the protected origin. Clamp and browser end up disagreeing
- * about what the value is, which defeats a clamp documented as
- * non-bypassable.
+ * Every consumer between here and the browser compares these strings
+ * verbatim, and two different mismatches have each produced a real bypass of
+ * the hosted clamp:
  *
- * Canonicalizing at this choke point means the value the clamp inspects is
- * byte-identical to the one the browser enforces.
+ *   - Padding. `matchesAnyDeny` lower-cases but does NOT trim, so
+ *     `" https://mcpjam.com "` matched no deny pattern and survived the
+ *     clamp — then the proxy's `sanitizeDomain` trimmed it on the way out and
+ *     the browser allowed the protected origin.
+ *   - Embedded whitespace. A CSP source list is space-separated, so an entry
+ *     like `"https://safe.example https://mcpjam.com"` is ONE value to the
+ *     clamp (matching nothing) but TWO sources to the browser once
+ *     `buildCSP` joins the list with spaces. Same for a smuggled `*`.
+ *
+ * Both reduce to the same rule: one array entry must mean one source, spelled
+ * the same way here as at the point of enforcement. Whitespace-bearing
+ * entries are dropped rather than split — a split would hand the clamp
+ * tokens the declaration never legitimately expressed, and a malformed
+ * declaration should fail closed.
+ *
+ * The character strip must stay in lockstep with `sanitizeDomain` in
+ * sandbox-proxy.html (`domain.replace(/['"<>;]/g, "").trim()`); if that gains
+ * another transform, this has to follow or the gap reopens.
  */
 function canonicalizeCspSource(value: string): string {
-  return value.replace(/['"<>;]/g, "").trim();
+  const stripped = value.replace(/['"<>;]/g, "").trim();
+  // Any interior whitespace means this entry would fan out into multiple
+  // CSP sources at emit time, past whatever the clamp inspected.
+  return /\s/.test(stripped) ? "" : stripped;
 }
 
 /**

--- a/mcpjam-inspector/server/utils/ui-resource-meta.ts
+++ b/mcpjam-inspector/server/utils/ui-resource-meta.ts
@@ -1,0 +1,188 @@
+/**
+ * SEP-1865 effective UI metadata resolution, shared by both widget-content
+ * routes (local `routes/apps/mcp-apps/index.ts` and hosted
+ * `routes/web/apps.ts`).
+ *
+ * The spec allows `_meta.ui` to appear on the `resources/list` entry, on the
+ * `resources/read` content item, or on both, and requires that "Hosts MUST
+ * check both locations, preferring the content item and falling back to the
+ * listing entry." Resolution order per field:
+ *
+ *   1. content-item `_meta.ui` from `resources/read`   (canonical)
+ *   2. listing `_meta.ui` from `resources/list`        (fallback)
+ *   3. legacy Apps SDK `openai/widget*` keys on either  (last resort)
+ *
+ * The fallback chain is per-field, not all-or-nothing: a widget that
+ * publishes only `csp` at the content level and only `prefersBorder` at the
+ * listing level should see both honored.
+ *
+ * This is a plain server module rather than an `@mcpjam/sdk` export on
+ * purpose — the SDK's `dist` vs `src` resolution would couple the server to
+ * an SDK rebuild for a change that only the two routes consume.
+ */
+
+import type {
+  McpUiResourceCsp,
+  McpUiResourceMeta,
+  McpUiResourcePermissions,
+} from "@modelcontextprotocol/ext-apps";
+
+/** Where a single resolved field came from. */
+export type MetadataFieldSource = "content" | "listing" | "legacy" | "none";
+
+/**
+ * Summary across all fields. `"mixed"` when two fields resolved from
+ * different sources — reported alongside the per-field breakdown so the
+ * conformance view can tell "content won everywhere" from "content won for
+ * csp, listing won for prefersBorder".
+ */
+export type MetadataSource = MetadataFieldSource | "mixed";
+
+export interface UiResourceMetaSources {
+  csp: MetadataFieldSource;
+  permissions: MetadataFieldSource;
+  prefersBorder: MetadataFieldSource;
+}
+
+export interface ResolvedUiResourceMeta {
+  csp?: McpUiResourceCsp;
+  permissions?: McpUiResourcePermissions;
+  prefersBorder?: boolean;
+  /** Per-field breakdown of which source won. */
+  metadataSources: UiResourceMetaSources;
+  /** Summary of `metadataSources` — `"mixed"` when they disagree. */
+  metadataSource: MetadataSource;
+}
+
+export interface ResolveUiResourceMetaArgs {
+  /** `_meta` from the `resources/read` content item. */
+  contentMeta?: Record<string, unknown>;
+  /**
+   * `_meta` from the matching `resources/list` entry. Best-effort: servers
+   * that don't implement `resources/list` (or don't return the URI) simply
+   * leave this undefined and the content source wins.
+   */
+  listingMeta?: Record<string, unknown>;
+}
+
+/**
+ * Fallback CSP extraction for legacy Apps SDK widgets that declare CSP via
+ * `_meta["openai/widgetCSP"]` (snake_case fields: `connect_domains`,
+ * `resource_domains`, `frame_domains`) instead of the SEP-1865 `_meta.ui.csp`
+ * shape (camelCase). Returns the camelCase shape the sandbox proxy's buildCSP
+ * expects, or undefined when no legacy CSP is set or it only contains
+ * non-array values.
+ */
+export function extractLegacyOpenAICsp(
+  resourceMeta: Record<string, unknown> | undefined
+): McpUiResourceCsp | undefined {
+  if (!resourceMeta) return undefined;
+  const legacy = resourceMeta["openai/widgetCSP"];
+  if (!legacy || typeof legacy !== "object") return undefined;
+  const src = legacy as Record<string, unknown>;
+  const readArr = (v: unknown): string[] | undefined =>
+    Array.isArray(v)
+      ? v.filter((x): x is string => typeof x === "string" && x.length > 0)
+      : undefined;
+  const out: McpUiResourceCsp = {};
+  const connect = readArr(src.connect_domains);
+  const resource = readArr(src.resource_domains);
+  const frame = readArr(src.frame_domains);
+  if (connect && connect.length > 0) out.connectDomains = connect;
+  if (resource && resource.length > 0) out.resourceDomains = resource;
+  if (frame && frame.length > 0) out.frameDomains = frame;
+  return Object.keys(out).length > 0 ? out : undefined;
+}
+
+function extractLegacyPrefersBorder(
+  resourceMeta: Record<string, unknown> | undefined
+): boolean | undefined {
+  return typeof resourceMeta?.["openai/widgetPrefersBorder"] === "boolean"
+    ? (resourceMeta["openai/widgetPrefersBorder"] as boolean)
+    : undefined;
+}
+
+function readUiMeta(
+  meta: Record<string, unknown> | undefined
+): McpUiResourceMeta | undefined {
+  return (meta as { ui?: McpUiResourceMeta } | undefined)?.ui;
+}
+
+/**
+ * Resolve the effective `csp` / `permissions` / `prefersBorder` for a UI
+ * resource from its content-item and listing `_meta`, per SEP-1865
+ * precedence. See the module docstring for the ordering.
+ */
+export function resolveUiResourceMeta(
+  args: ResolveUiResourceMetaArgs
+): ResolvedUiResourceMeta {
+  const { contentMeta, listingMeta } = args;
+  const contentUiMeta = readUiMeta(contentMeta);
+  const listingUiMeta = readUiMeta(listingMeta);
+
+  const metadataSources: UiResourceMetaSources = {
+    csp: "none",
+    permissions: "none",
+    prefersBorder: "none",
+  };
+
+  // ── csp ──────────────────────────────────────────────────────────────
+  const contentLegacyCsp = extractLegacyOpenAICsp(contentMeta);
+  const listingLegacyCsp = extractLegacyOpenAICsp(listingMeta);
+  let csp: McpUiResourceCsp | undefined;
+  if (contentUiMeta?.csp) {
+    csp = contentUiMeta.csp;
+    metadataSources.csp = "content";
+  } else if (listingUiMeta?.csp) {
+    csp = listingUiMeta.csp;
+    metadataSources.csp = "listing";
+  } else if (contentLegacyCsp) {
+    csp = contentLegacyCsp;
+    metadataSources.csp = "legacy";
+  } else if (listingLegacyCsp) {
+    csp = listingLegacyCsp;
+    metadataSources.csp = "legacy";
+  }
+
+  // ── permissions ──────────────────────────────────────────────────────
+  // No legacy equivalent: the Apps SDK never shipped a `openai/widget*`
+  // permissions key, so this is a two-source chain.
+  let permissions: McpUiResourcePermissions | undefined;
+  if (contentUiMeta?.permissions) {
+    permissions = contentUiMeta.permissions;
+    metadataSources.permissions = "content";
+  } else if (listingUiMeta?.permissions) {
+    permissions = listingUiMeta.permissions;
+    metadataSources.permissions = "listing";
+  }
+
+  // ── prefersBorder ────────────────────────────────────────────────────
+  const contentLegacyPrefersBorder = extractLegacyPrefersBorder(contentMeta);
+  const listingLegacyPrefersBorder = extractLegacyPrefersBorder(listingMeta);
+  let prefersBorder: boolean | undefined;
+  if (contentUiMeta?.prefersBorder !== undefined) {
+    prefersBorder = contentUiMeta.prefersBorder;
+    metadataSources.prefersBorder = "content";
+  } else if (listingUiMeta?.prefersBorder !== undefined) {
+    prefersBorder = listingUiMeta.prefersBorder;
+    metadataSources.prefersBorder = "listing";
+  } else if (contentLegacyPrefersBorder !== undefined) {
+    prefersBorder = contentLegacyPrefersBorder;
+    metadataSources.prefersBorder = "legacy";
+  } else if (listingLegacyPrefersBorder !== undefined) {
+    prefersBorder = listingLegacyPrefersBorder;
+    metadataSources.prefersBorder = "legacy";
+  }
+
+  const usedMetadataSources = new Set(
+    Object.values(metadataSources).filter((source) => source !== "none")
+  );
+  const metadataSource: MetadataSource =
+    usedMetadataSources.size === 0
+      ? "none"
+      : usedMetadataSources.size === 1
+      ? (Array.from(usedMetadataSources)[0] as MetadataFieldSource)
+      : "mixed";
+
+  return { csp, permissions, prefersBorder, metadataSources, metadataSource };
+}

--- a/mcpjam-inspector/server/utils/ui-resource-meta.ts
+++ b/mcpjam-inspector/server/utils/ui-resource-meta.ts
@@ -370,8 +370,15 @@ export async function findListingMetaForUri(
         return undefined;
       }
       if (seenCursors.has(nextCursor)) {
+        // Report the fact, not the value: pagination cursors are opaque
+        // server-generated tokens and implementations encode internal state
+        // in them. "The server repeated a cursor" is the whole diagnostic;
+        // the token itself adds nothing and puts server-side identifiers
+        // into our debug logs.
         onSkipped?.(
-          `resources/list repeated cursor "${nextCursor}" — stopping pagination`
+          `resources/list repeated a pagination cursor after ${
+            page + 1
+          } page(s) — stopping`
         );
         return undefined;
       }

--- a/widget-react/src/mcp-apps-renderer.tsx
+++ b/widget-react/src/mcp-apps-renderer.tsx
@@ -96,6 +96,13 @@ const DEFAULT_INPUT_SCHEMA = { type: "object" } as const;
 
 const SUPPRESSED_UI_LOG_METHODS = new Set(["ui/notifications/size-changed"]);
 const PIP_MAX_HEIGHT = "min(40vh, 600px)";
+/**
+ * Grace period before an App that reported a CSP violation but hasn't
+ * signalled `ui/initialize` is declared blocked. A View that loads a
+ * blocked-but-optional asset (an analytics beacon, a font) still boots, so
+ * the notice must not flash in front of a widget that is merely slow.
+ */
+const CSP_BLOCKED_NOTICE_DELAY_MS = 1500;
 const SAFE_OPEN_IN_APP_PROTOCOLS = new Set(["http:", "https:"]);
 
 function toSafeOpenInAppUrl(value: string): string | null {
@@ -1197,6 +1204,15 @@ export function MCPAppsRendererSurface({
   const [isReady, setIsReady] = useState(false);
   const [reinitCount, setReinitCount] = useState(0);
   const [loadError, setLoadError] = useState<string | null>(null);
+  // First CSP violation reported by the sandbox proxy for the current bytes.
+  // Kept locally (the debug sink is write-only) so a View that never boots
+  // because its own resources were blocked can say so instead of rendering
+  // an empty box. First violation wins — it is the one that explains the
+  // failure; later ones are usually cascade noise from the same block.
+  const [firstCspBlock, setFirstCspBlock] = useState<{
+    directive?: string;
+    blockedUri?: string;
+  } | null>(null);
   const [widgetHtml, setWidgetHtml] = useState<string | null>(null);
   const [openInAppUrlOverride, setOpenInAppUrlOverride] = useState<
     string | null
@@ -1424,6 +1440,9 @@ export function MCPAppsRendererSurface({
     setWidgetPermissions(undefined);
     setWidgetPermissive(isCachedReplay ? true : false);
     setPrefersBorder(cachedReplayPrefersBorder ?? true);
+    // New bytes incoming — violations recorded against the old ones no
+    // longer describe what is on screen.
+    setFirstCspBlock(null);
   }, [
     cachedReplayWidgetHtmlUrl,
     cachedReplayPrefersBorder,
@@ -2122,6 +2141,7 @@ export function MCPAppsRendererSurface({
   useEffect(() => {
     if (loadedCspMode !== null && loadedCspMode !== cspMode) {
       clearCspViolations(toolCallId);
+      setFirstCspBlock(null);
     }
   }, [cspMode, loadedCspMode, toolCallId, clearCspViolations]);
   useEffect(() => {
@@ -2135,6 +2155,7 @@ export function MCPAppsRendererSurface({
         loadedMcpAppsCapabilitiesHash !== widgetMcpAppsCapabilitiesReloadKey);
     if (injectionChanged || capabilitiesChanged) {
       clearCspViolations(toolCallId);
+      setFirstCspBlock(null);
     }
   }, [
     widgetInjectOpenAiCompatReloadKey,
@@ -3663,6 +3684,21 @@ export function MCPAppsRendererSurface({
         timestamp: timestamp || Date.now(),
       });
 
+      // Remember the first block so the render path can explain a View
+      // that never boots. Cleared on every reload alongside the debug
+      // store's violation list.
+      setFirstCspBlock((prev) =>
+        prev ?? {
+          directive:
+            typeof effectiveDirective === "string" && effectiveDirective
+              ? effectiveDirective
+              : typeof directive === "string"
+              ? directive
+              : undefined,
+          blockedUri: typeof blockedUri === "string" ? blockedUri : undefined,
+        }
+      );
+
       if (!minimalMode) {
         console.warn(
           `[MCP Apps CSP Violation] ${directive}: Blocked ${blockedUri}`,
@@ -3868,6 +3904,24 @@ export function MCPAppsRendererSurface({
   };
   const showWidget = isReady && canRenderStreamingInput;
 
+  // An App whose own resources were blocked by CSP never signals ready, so
+  // the iframe sits at `opacity: 0` forever — indistinguishable from a hang.
+  // Surface the block instead, after a grace period so a View that boots
+  // despite a blocked optional asset never flashes the notice.
+  const [cspBlockedNoticeVisible, setCspBlockedNoticeVisible] = useState(false);
+  useEffect(() => {
+    if (!firstCspBlock || isReady) {
+      setCspBlockedNoticeVisible(false);
+      return;
+    }
+    const timer = window.setTimeout(
+      () => setCspBlockedNoticeVisible(true),
+      CSP_BLOCKED_NOTICE_DELAY_MS
+    );
+    return () => window.clearTimeout(timer);
+  }, [firstCspBlock, isReady]);
+  const showCspBlockedNotice = cspBlockedNoticeVisible && !showWidget;
+
   useEffect(() => {
     logWidgetDebug("host-to-ui", "debug/widget-visibility", {
       bridgeTransportReady,
@@ -4008,7 +4062,10 @@ export function MCPAppsRendererSurface({
       ? { position: "absolute" as const, pointerEvents: "none" as const }
       : {}),
   };
-  const showHostChrome = !isFullscreen && matrixGatedPrefersBorder;
+  // Suppress the empty bordered box while the blocked-App notice stands in
+  // for it — otherwise the notice renders *below* the blank box it explains.
+  const showHostChrome =
+    !isFullscreen && matrixGatedPrefersBorder && !showCspBlockedNotice;
   const hostChromeStyle: CSSProperties | undefined = showHostChrome
     ? {
         backgroundColor: mergedStyleVariables["--color-background-primary"],
@@ -4154,6 +4211,32 @@ export function MCPAppsRendererSurface({
       >
         {iframe}
       </div>
+      {/* The App reported a CSP violation and never signalled ready — its
+       * own resources were blocked, so the iframe would otherwise stay an
+       * empty box. Name the blocked directive and the first blocked origin
+       * for developer surfaces; testers get the plain-language line. */}
+      {showCspBlockedNotice && (
+        <div
+          data-testid="mcp-app-csp-blocked-notice"
+          role="status"
+          className="border border-destructive/40 bg-destructive/10 text-destructive text-xs rounded-md px-3 py-2"
+        >
+          <span>
+            {minimalMode
+              ? "This app couldn't load its resources."
+              : `MCP App blocked by Content Security Policy${
+                  firstCspBlock?.directive
+                    ? ` (${firstCspBlock.directive})`
+                    : ""
+                }.`}
+          </span>
+          {firstCspBlock?.blockedUri ? (
+            <span className="mt-0.5 block font-mono break-all opacity-80">
+              {firstCspBlock.blockedUri}
+            </span>
+          ) : null}
+        </div>
+      )}
       {/* SEP-1865 App-Provided Tools: per-iframe busy indicator. Surfaces
        * when the host is dispatching `tools/call` into this iframe (the
        * count comes from `useAppToolsRegistry.pendingControllers`). Sits

--- a/widget-react/src/mcp-apps-renderer.tsx
+++ b/widget-react/src/mcp-apps-renderer.tsx
@@ -2917,6 +2917,11 @@ export function MCPAppsRendererSurface({
     if (previous === null || previous === effectiveSandboxKey) return;
     clearCspViolations(toolCallId);
     setFirstCspBlock(null);
+    // Readiness deliberately NOT reset here. `effectiveSandboxKey` is also a
+    // dependency of the bridge-connect effect below, which already does
+    // `setIsReady(false)` when it re-runs — so a policy change resets
+    // readiness exactly once, on the path that owns it. Duplicating it here
+    // would be dead code that reads like a second source of truth.
   }, [effectiveSandboxKey, toolCallId, clearCspViolations]);
 
   // Publish the resolved sandbox payload into the widget-debug store so the

--- a/widget-react/src/mcp-apps-renderer.tsx
+++ b/widget-react/src/mcp-apps-renderer.tsx
@@ -2904,6 +2904,21 @@ export function MCPAppsRendererSurface({
     [effectiveSandbox]
   );
 
+  // `SandboxedIframe` keys its resource-ready payload on the resolved csp /
+  // permissions / sandbox attrs, so any change here re-posts the HTML and the
+  // View boots again. A violation recorded against the PREVIOUS policy no
+  // longer describes what is on screen — without this, widening a profile to
+  // unblock an App would leave the notice naming the origin that is now
+  // allowed. Skip the first commit: the initial resolution is not a reload.
+  const lastEffectiveSandboxKeyRef = useRef<string | null>(null);
+  useEffect(() => {
+    const previous = lastEffectiveSandboxKeyRef.current;
+    lastEffectiveSandboxKeyRef.current = effectiveSandboxKey;
+    if (previous === null || previous === effectiveSandboxKey) return;
+    clearCspViolations(toolCallId);
+    setFirstCspBlock(null);
+  }, [effectiveSandboxKey, toolCallId, clearCspViolations]);
+
   // Publish the resolved sandbox payload into the widget-debug store so the
   // Sandbox debug panel can render it. `restrictTo` and `cspMode` come from
   // the source profile because the resolver intersects them in but doesn't

--- a/widget-react/src/mcp-apps-renderer.tsx
+++ b/widget-react/src/mcp-apps-renderer.tsx
@@ -1690,6 +1690,9 @@ export function MCPAppsRendererSurface({
       liveRenderIdentityRef.current = null;
       setWidgetHtml(html);
       setWidgetCsp(undefined);
+      // Same reasoning as the live commit below: new bytes, so a violation
+      // held from the previous resource no longer describes the screen.
+      setFirstCspBlock(null);
       setWidgetPermissions(undefined);
       setWidgetPermissive(true);
       setPrefersBorder(initialPrefersBorder ?? true);
@@ -1828,6 +1831,13 @@ export function MCPAppsRendererSurface({
       liveRenderIdentityRef.current = liveRenderIdentityKey;
       setWidgetHtml(html);
       setWidgetCsp(csp);
+      // New bytes are going on screen, so a violation still held here was
+      // reported against the previous ones. The identity-keyed reset effect
+      // above covers a resourceUri/session change; this covers the case it
+      // cannot see — a refetch that commits fresh HTML under the SAME
+      // identity. Stating the invariant at the commit site keeps it local:
+      // new bytes, no stale block.
+      setFirstCspBlock(null);
       setWidgetPermissions(permissions);
       setWidgetPermissive(permissive ?? false);
       setPrefersBorder(prefersBorder ?? true);
@@ -3414,9 +3424,7 @@ export function MCPAppsRendererSurface({
                   // (shared gate with the pre-prompt check above).
                   const safeHref = toSafeDownloadLinkUrl(link.uri);
                   if (safeHref === null) {
-                    throw new Error(
-                      `Unsupported download URI: ${link.uri}`
-                    );
+                    throw new Error(`Unsupported download URI: ${link.uri}`);
                   }
                   window.open(safeHref, "_blank", "noopener,noreferrer");
                 }
@@ -3707,16 +3715,17 @@ export function MCPAppsRendererSurface({
       // Remember the first block so the render path can explain a View
       // that never boots. Cleared on every reload alongside the debug
       // store's violation list.
-      setFirstCspBlock((prev) =>
-        prev ?? {
-          directive:
-            typeof effectiveDirective === "string" && effectiveDirective
-              ? effectiveDirective
-              : typeof directive === "string"
-              ? directive
-              : undefined,
-          blockedUri: typeof blockedUri === "string" ? blockedUri : undefined,
-        }
+      setFirstCspBlock(
+        (prev) =>
+          prev ?? {
+            directive:
+              typeof effectiveDirective === "string" && effectiveDirective
+                ? effectiveDirective
+                : typeof directive === "string"
+                ? directive
+                : undefined,
+            blockedUri: typeof blockedUri === "string" ? blockedUri : undefined,
+          }
       );
 
       if (!minimalMode) {


### PR DESCRIPTION
## Problem

Testers on a published scenario link saw an empty bordered box where the MCP App should be. The trigger was inverted: **the User Testing surface asks for "permissive" CSP, and that request is exactly what produced the strictest possible CSP.**

1. Scenario/minimal surfaces force `cspMode: "permissive"` (`widget-react/src/mcp-apps-renderer.tsx`).
2. Both widget-content routes **withheld the resource's declared CSP** when the request said permissive.
3. The permissive short-circuit in the renderer requires `isPlaygroundActive` and excludes scenario/minimal surfaces, so the host-policy resolver runs anyway.
4. Every host template seeds `apps.sandbox.csp.mode: "declared"`, so `resolveSandboxCsp` ran with `resourceCsp: undefined` → fell back to the empty secure default → all four domain lists came back `[]`.
5. A truthy-but-empty result forces `permissive: false`, and the sandbox proxy emitted `default-src 'none'; script-src 'unsafe-inline' data: blob:; connect-src 'none'; …` into the App's srcdoc.
6. The Excalidraw resource **does** declare `_meta.ui.csp = { resourceDomains: ["https://esm.sh"], connectDomains: ["https://esm.sh"] }` and boots React/Excalidraw from `https://esm.sh` via an importmap. Every module load was blocked → blank iframe.

Per SEP-1865 this is a conformance defect, not just a UX one. The spec says the host "MUST construct CSP headers based on declared domains" and reserves the restrictive default for *"if `ui.csp` is omitted"*. We had a declaration and behaved as though we didn't.

## Change 1 — stop withholding the declared CSP (the fix)

The request's `cspMode` no longer decides *what the server reports*. It reports what the resource declared; the `permissive` flag alone tells the sandbox proxy whether to inject.

- `server/routes/web/apps.ts` → `csp: cspFromMeta`
- `server/routes/apps/mcp-apps/index.ts` → `csp` (dropped the `isPermissive` ternary)

Returning the declaration cannot loosen anything: `permissive: true` already means "no CSP injected at all." No client change was required — with a real baseline, `resolveSandboxCsp` keeps `esm.sh` under `mode: "declared"`, the hosted clamp leaves it alone (it only strips mcpjam.com/dangerous origins), and the proxy emits `script-src 'unsafe-inline' data: blob: https://esm.sh`.

**Behavior change:** scenario surfaces move from *accidentally strictest* to *spec-correct declared enforcement*. Paths that were already correct are unchanged — the playground permissive toggle still returns `csp: undefined` explicitly, and a surface with no host profile still resolves `permissive: true` via `widgetPermissive`.

## Change 2 — hosted route reads `_meta.ui` from both spec locations

SEP-1865: metadata may appear on the `resources/list` entry, the `resources/read` content item, or both, and "Hosts MUST check both locations, preferring the content item and falling back to the listing entry."

The **local** route already did this correctly, per field, with legacy `openai/widget*` fallback and `metadataSources` telemetry. The **hosted** route only read `content._meta` — so a server that declares `_meta.ui` only at listing level was blank in hosted and fine locally.

- Extracted the local route's resolution into `server/utils/ui-resource-meta.ts`: `resolveUiResourceMeta({ contentMeta, listingMeta })` → `{ csp, permissions, prefersBorder, metadataSources, metadataSource }`. Kept as a plain server module — no `@mcpjam/sdk` export, so no SDK rebuild/publish coupling.
- Both routes call it; the hosted route gains the best-effort `manager.listResources(serverId)` lookup in the same try/catch, so servers without `resources/list` are unaffected. It now also echoes `metadataSource` / `metadataSources` like the local route.
- Deleted `extractLegacyOpenAICspHosted` — it was a duplicate of the shared helper.

## Change 3 — a blocked App now says so instead of rendering a white box

**Undeclared Apps stay restricted.** SEP-1865 forbids loosening: the restrictive default is a MUST when the declaration is omitted, and "Host MAY further restrict but MUST NOT allow undeclared domains." So the secure default stays, and the resulting blank box explains itself instead.

`widget-react/src/mcp-apps-renderer.tsx`: when the App reported a CSP violation and never signalled ready, an inline notice replaces the empty bordered box, naming the blocked directive and the first blocked URI. On `minimalMode` (the tester) it reads as a plain "this app couldn't load its resources" line rather than a debug dump. A 1.5s grace period keeps it from flashing in front of a View that boots despite a blocked *optional* asset (an analytics beacon, a webfont).

## Tests

- `server/routes/apps/__tests__/widget-content-metadata.test.ts` — extended: `cspMode: "permissive"` **still returns** the declared `csp`; listing-only declaration under permissive; no-declaration still yields `undefined`.
- `server/routes/web/__tests__/apps-widget-content.test.ts` — **new**, the hosted route had no widget-content coverage. Declared-CSP behavior under both modes, full metadata-precedence matrix (content / listing / mixed / legacy), and a server without `resources/list`.
- `client/.../mcp-apps/__tests__/mcp-apps-renderer.test.tsx` — regression at the exact failing configuration: scenario surface + profile `{ apps: { sandbox: { csp: { mode: "declared" } } } }` + a fetch returning the esm.sh declaration → asserts `SandboxedIframe` receives `csp.resourceDomains === ["https://esm.sh"]` (this yielded `[]` before). Plus the inverse (no declaration → empty lists preserved) and three blocked-App-notice cases.
- `server/__tests__/sandbox-proxy-buildCSP.test.ts` — unchanged; it already documents why the empty baseline was fatal.

**Verification that the tests bite:** with Change 1 temporarily reverted, the three new declared-CSP assertions fail (`expected undefined to deeply equal { … }`) and everything else stays green.

```
npm run test -w @mcpjam/inspector    → 1295 files / 15647 tests passed, 0 failed
npm run test -w @mcpjam/widget-react → 8 passed
```

Both `tsc --noEmit` passes (server tsconfig, widget-react) are clean.

## Risks

- **Widening, not narrowing.** Change 1 only ever adds back origins the resource itself declared, and host `restrictTo`/`deny` plus the non-bypassable hosted clamp still run on top. A host profile configured to narrow keeps narrowing.
- **Snapshots.** Scenario-captured widgets will now persist a non-null `widgetCsp`. That is more accurate, and old snapshots replay from their own stored values — no migration.
- **Extra hosted round-trip.** The hosted route now issues one best-effort `resources/list` per widget-content request, matching what the local route already did.

## Out of scope / follow-ups

- **`server/routes/web/mcpjam-agent.ts:643` carries the same withholding pattern** (`csp: effectiveCspMode === "permissive" ? undefined : uiMeta?.csp`) for MCPJam's own first-party agent widgets, and reads only `content._meta`. It was not in the stated scope of this change, so it is left as-is — worth a follow-up decision, since it is the same defect class.
- **Sessions transcript** renders via `chat-ui`'s `ReadOnlyTranscript` with `widgetPolicy="placeholder"` and no `renderWidget`, so it never mounts an App by design. Unchanged by this fix; replaying Apps there needs its own decision (live re-fetch vs. the captured snapshot `useSharedChatWidgetCapture` already persists).

## Remaining manual verification

The automated wire checks are covered above; these still want a human with a browser:

1. Local `npm run dev`, connect `https://mcp.excalidraw.com/mcp`, run `create_view` from Connect → Chat (guards against regression) and then from a scenario/tester surface (broken before, should render now).
2. Staging `staging.mcpjam.com/user-testing/mcpjam/8R6e6g6rF9RRGRuhnT4eB`, "draw a dog" — note guest execution is off, so this needs a signed-in tester. In DevTools confirm the srcdoc's injected `<meta http-equiv="Content-Security-Policy">` now contains `https://esm.sh` under `script-src`/`connect-src`.
3. Point a scenario at a UI resource with no `_meta.ui.csp` and confirm it still gets the secure default *and* now shows the Change 3 notice.
4. Sandbox origin is still distinct per environment — untouched by this change, but it is the property that keeps the sandbox isolated from app cookies.

---
_Generated by [Claude Code](https://claude.ai/code/session_01DxFfp7zV5yqVBwTGHhqGrs)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit f9b4efd6139cc8e02a1c3902da7f36c35ac24b57. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Always report and normalize each App’s declared CSP so Apps render in User Testing and clamp bypasses are closed. Previously, `permissive` requests hid the declaration and forced the strict default; now `permissive` only controls injection, declarations are canonicalized (including dropping whitespace‑smuggling and trailing‑dot hosts), and undeclared Apps remain restricted.

- Both widget-content routes always include the declared `csp`; `permissive` only skips injection. Legacy `openai/widgetCSP` is treated the same.
- Shared `resolveUiResourceMeta` normalizes `_meta.ui` per field (content → listing → legacy), follows listing pagination with a cap and repeated-cursor guard, skips the lookup when the content item declares all fields, and emits `metadataSource`/`metadataSources`.
- Canonicalization/hardening: trims and strips quotes/semicolons, drops entries with interior whitespace, and removes trailing-dot host spellings (for example `localhost.` or `*.mcpjam.com.`) before clamp; preserves `{}` and empty arrays as deny-by-default; drops malformed domain fields; validates permission markers; ignores non-boolean `prefersBorder`.
- Client clears CSP diagnostics when the effective sandbox policy changes and shows a delayed inline notice if an App reports a violation and never initializes (plain language in minimal mode).

<sup>Written for commit 2dd0992214c0a8b211f974bafa2c051bd472db7e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/MCPJam/inspector/pull/4070?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

