### PR TITLE
Stop silently dropping every message after a failed detach

### DIFF
--- a/.changeset/silent-turn-loss-after-failed-detach.md
+++ b/.changeset/silent-turn-loss-after-failed-detach.md
@@ -1,0 +1,18 @@
+---
+"@mcpjam/inspector": patch
+---
+
+Stop silently dropping every message after a failed detach.
+
+When `detachToLocalFork` cannot confirm its fork went live, the surface stays on
+the old chat session — with `resumedVersion` deliberately preserved — while its
+history selection is cleared. Every later send then carried a stale
+`expectedVersion`, the server returned a 409, and the resulting `conflict`
+receipt reached a post-stream branch that returned without doing anything. The
+turn was lost, no notice was shown, and the state repeated for every message
+until the page was reloaded.
+
+A `conflict` now routes to the detach handler even when the turn has no version
+baseline, so the user either moves to a fresh thread or is told the move failed.
+The rail refresh stays suppressed on that path, and no other receipt outcome
+changes behaviour.

--- a/mcpjam-inspector/client/src/hooks/__tests__/use-resumed-thread-persistence.test.tsx
+++ b/mcpjam-inspector/client/src/hooks/__tests__/use-resumed-thread-persistence.test.tsx
@@ -414,6 +414,52 @@ describe("useResumedThreadPersistence", () => {
     expect(harness.refreshAfterStream).not.toHaveBeenCalled();
   });
 
+  it("detaches on a conflict with no baseline — the failed-detach loop", () => {
+    // The production sequence. `detachToLocalFork` could not confirm its fork
+    // went live, so the surface stayed on the OLD chat session with
+    // `resumedVersion` preserved while `cancelPendingHistorySelection` nulled
+    // `activeHistorySessionId` — which is what makes the baseline null here.
+    // The next send carries the stale `expectedVersion`, the server 409s, and
+    // the receipt names the still-live old session, so it passes
+    // `consumePersistReceipt` and lands in the no-baseline branch. That branch
+    // used to return silently, losing this turn and every turn after it.
+    const harness = setup({
+      receipt: { outcome: "conflict", chatSessionId: "c", currentVersion: 9 },
+    });
+    const detached = { ...harness.props, activeHistorySessionId: null };
+
+    act(() => harness.view.rerender({ ...detached, status: "submitted" }));
+    expect(harness.sendBaselineRef.current).toBeNull();
+    act(() => harness.view.rerender({ ...detached, status: "streaming" }));
+    act(() => harness.view.rerender({ ...detached, status: "ready" }));
+
+    expect(harness.onConflict).toHaveBeenCalledTimes(1);
+    // Still suppressed: the refresh would reattach the thread being left.
+    expect(harness.refreshAfterStream).not.toHaveBeenCalled();
+  });
+
+  it("does not detach a baseline-less turn on any other outcome", () => {
+    // A fresh, non-resumed thread has no baseline by design. Only positive
+    // evidence of a concurrent writer may cost the user their thread.
+    for (const receipt of [
+      { outcome: "saved" as const, chatSessionId: "c", version: 5 },
+      { outcome: "skipped" as const, chatSessionId: "c", version: 4 },
+      { outcome: "failed" as const, chatSessionId: "c" },
+      null,
+    ]) {
+      const harness = setup({ resumedVersion: null, receipt });
+
+      harness.runTurn();
+      act(() => {
+        vi.advanceTimersByTime(11_000);
+      });
+
+      expect(harness.onConflict).not.toHaveBeenCalled();
+      expect(harness.onUnsaved).not.toHaveBeenCalled();
+      expect(harness.refreshAfterStream).toHaveBeenCalled();
+    }
+  });
+
   it("refreshes the rail for a fresh thread — that is how it learns the new row", () => {
     const harness = setup({ resumedVersion: null, receipt: null });
     harness.runTurn();

--- a/mcpjam-inspector/client/src/hooks/use-resumed-thread-persistence.ts
+++ b/mcpjam-inspector/client/src/hooks/use-resumed-thread-persistence.ts
@@ -215,16 +215,42 @@ export function useResumedThreadPersistence(
     // need the rail refresh: this is the turn that created the row, so the
     // refresh is how the surface learns its id.
     //
-    // A null baseline does not guarantee a null conflict, though. The baseline
-    // is also cleared mid-stream by every deliberate session change (new chat,
-    // archive-all, reset, a rewind's `onBeforeBranch`), and a turn invalidated
-    // that way can still come back with a `conflict` receipt. Refreshing then
-    // could reattach the session the surface just left, which is exactly what
-    // clearing the baseline was protecting against.
+    // A null baseline does not guarantee a null conflict, though — and the case
+    // that matters is NOT the deliberate session changes (new chat, archive-all,
+    // reset, a rewind's `onBeforeBranch`) this guard used to cite. Every one of
+    // those also mints a new `chatSessionId`, so `consumePersistReceipt` rejects
+    // the turn's receipt outright and this branch sees `null`; it never observes
+    // a conflict on that path at all.
+    //
+    // The path it does observe is a FAILED DETACH. `detachToLocalFork` could not
+    // confirm its fork went live, so the surface stayed on the OLD
+    // `chatSessionId` with `resumedVersion` deliberately preserved, while
+    // `cancelPendingHistorySelection` nulled `activeHistorySessionId` — which is
+    // what leaves the baseline null here. Every later send then carries the stale
+    // `expectedVersion`, the server 409s, and the `conflict` receipt names the
+    // still-live old session, so it passes validation and lands right here.
+    // Swallowing it lost that turn, and every turn after it, in silence.
+    //
+    // So a conflict is routed to `onConflict()` even with no baseline. The
+    // surfaces implement it as a detach, which re-attempts the fork: on success
+    // the user moves to a fresh thread and the loop is broken, and on failure
+    // they at least get the fork-failed notice again instead of nothing.
+    //
+    // This is NOT the immediate re-mint `detachToLocalFork` deliberately refuses.
+    // That one fires inside the failed detach itself, where the second
+    // `queueSessionHydration` would clear a `loadChatSession` still resolving and
+    // yank the user out of the thread they just clicked. This fires at the next
+    // turn boundary — a whole request and stream later — by which point any
+    // hydration that superseded the fork has long since committed.
+    //
+    // The rail refresh stays suppressed on that path: it resolves asynchronously
+    // and could reattach the very session the detach is leaving.
     if (!baseline) {
-      if (receipt?.outcome !== "conflict") {
-        callbacksRef.current.refreshAfterStream();
+      if (receipt?.outcome === "conflict") {
+        callbacksRef.current.onConflict();
+        return;
       }
+      callbacksRef.current.refreshAfterStream();
       return;
     }
 


### PR DESCRIPTION
## The symptom

After a failed detach, every subsequent message is silently lost — forever, with no toast, no error, and no visible sign anything went wrong. The user keeps typing into a thread that cannot accept writes. Only a page reload breaks out of it.

## The mechanism

1. `detachToLocalFork` (`client/src/hooks/use-chat-session.ts:4057`) mints a new `chatSessionId` and requires an exact match to confirm the fork went live. When the fork is superseded it returns `null` — correctly, and deliberately without retrying (#4069). The surface shows `DETACH_FORK_FAILED_MESSAGE` once.
2. In that state the OLD `chatSessionId` is still live, `resumedVersion` is deliberately preserved (it is the concurrency guard protecting the row from being clobbered), but `activeHistorySessionId` has been nulled by `cancelPendingHistorySelection()`.
3. The next send therefore carries the stale `expectedVersion`, and the server 409s → a `conflict` receipt comes back.
4. The baseline capture in `use-resumed-thread-persistence.ts` requires `activeHistorySessionId`, so `sendBaselineRef` is `null` for that turn.
5. The `!baseline` branch read `if (receipt?.outcome !== "conflict") { refreshAfterStream(); } return;` — so a `conflict` fell straight through and returned. No toast, no detach, no reconcile. And it repeated on every send thereafter.

**The receipt is not filtered out on the way in.** `consumePersistReceipt` (`use-chat-session.ts:2251`) rejects receipts whose `chatSessionId` no longer matches the live session — but in the failed-detach state the live session IS still the old id the receipt names, so the receipt passes validation and reaches this branch intact.

## The fix

In the `!baseline` branch, a `conflict` now routes to `onConflict()`. Both surfaces implement that as `detachHistorySession(RESUMED_THREAD_CONFLICT_MESSAGE)`, which re-attempts `detachToLocalFork` and, either way, tells the user something true: on success they move to a fresh thread and the loop is broken; on failure they get `DETACH_FORK_FAILED_MESSAGE` again rather than silence.

This is **not** the "retry a superseded fork" pattern #4069 deliberately rejected. That one was an immediate re-mint inside `detachToLocalFork`, where the second `queueSessionHydration` would clear a `loadChatSession` still resolving and yank the user out of the thread they had just clicked. This fires at the next turn boundary — a whole request and stream later — by which point any hydration that superseded the fork has long since committed. The distinction is captured in a comment so a future reader does not "fix" it back.

The rail refresh stays suppressed on the conflict path: it resolves asynchronously and would reattach the very thread being left.

## The inert-guard comment

The old comment justified the guard with a different scenario — a mid-stream deliberate session change (new chat, archive-all, reset, a rewind's `onBeforeBranch`). Verified against every one of those call sites: they all also mint a new `chatSessionId` (`handleNewChat`/`handleArchiveAllComplete` → `baseResetChat` → `setChatSessionId(generateId())`, `onBeforeBranch` → the branch mint). So `consumePersistReceipt` returns `null` on exactly that path and the refresh ran anyway. The guard was inert in the case it documented and only fired in the case where it caused harm. The comment now describes reality.

## Tests

`client/src/hooks/__tests__/use-resumed-thread-persistence.test.tsx`:

- **"detaches on a conflict with no baseline — the failed-detach loop"** reproduces the exact prod sequence: `activeHistorySessionId: null` with `resumedVersion` still set (so the baseline is null for the reason it is null in production), a turn ending with a `conflict` receipt. **Verified failing without the fix** (`expected "spy" to be called 1 times, but got 0 times`), passing with it.
- **"does not detach a baseline-less turn on any other outcome"** pins `saved` / `skipped` / `failed` / no-receipt with a null baseline: still no detach, still no unsaved warning, still refreshes the rail. A fresh non-resumed thread has no baseline by design and must not be affected.

Suites run: `use-resumed-thread-persistence` (24), `ChatTabV2.history-sync` (23), `PlaygroundMain` (86) — 133 passing. `npm run typecheck:client` clean.

## Scope

Deliberately limited to the `conflict` case. A `failed`/`skipped` receipt with a null baseline is a different question — a fresh non-resumed thread legitimately has no baseline to reconcile against, so starting a reconcile there would warn about turns that saved fine. Left alone, and pinned by the second test.

Note: a sibling PR in flight also edits this post-stream effect (adding abort-awareness). A trivial rebase may be needed depending on merge order — the two changes touch adjacent lines in the same `useEffect`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes resumed-thread post-stream conflict handling in chat persistence; scope is narrow and covered by tests, but wrong routing could still affect detach vs rail refresh behavior.
> 
> **Overview**
> Fixes a **silent message-loss loop** after **`detachToLocalFork`** fails: the UI can stay on the old chat session with **`resumedVersion`** kept but **`activeHistorySessionId`** cleared, so later sends use a stale **`expectedVersion`**, get **409** responses, and return a **`conflict`** persist receipt with **no send baseline**.
> 
> In **`use-resumed-thread-persistence`**, the **no-baseline** post-stream path now calls **`onConflict()`** when the receipt is **`conflict`** (still **without** refreshing the history rail), instead of returning with no user feedback. Other outcomes on that path still only refresh the rail. Inline comments were updated to describe the failed-detach case rather than mid-stream session switches (which never surface a conflict here).
> 
> Tests cover the production failed-detach sequence and assert baseline-less **`saved` / `skipped` / `failed` / no-receipt** turns still do not detach. A patch **changeset** documents the fix.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 54f0367ef403b92fefbfb411f0bbe050f4ba6f0a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stops the silent turn loss after a failed detach by handling conflict receipts when no version baseline exists. Previously, after a failed `detachToLocalFork`, subsequent sends 409ed and the `conflict` receipt was ignored, dropping every message without feedback.

- On a no-baseline `conflict` in `use-resumed-thread-persistence`, call `onConflict()` (implemented as `detachHistorySession(RESUMED_THREAD_CONFLICT_MESSAGE)`), which re-attempts the fork on the next turn; the user either moves to a fresh thread or sees `DETACH_FORK_FAILED_MESSAGE` again.
- Keep the rail refresh suppressed on this path to avoid reattaching the session being left.
- Scope: only affects `conflict` with no baseline. Other outcomes (`saved`, `skipped`, `failed`, or no receipt) are unchanged, and deliberate session changes remain unaffected (they mint a new `chatSessionId`, so their receipts are rejected earlier).
- Tests added to pin the failed-detach loop and non-conflict behavior; all suites pass and typecheck is clean.

<sup>Written for commit 54f0367ef403b92fefbfb411f0bbe050f4ba6f0a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/MCPJam/inspector/pull/4072?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

