### PR TITLE
fix(chat): Stop no longer claims the reply could not be saved

### DIFF
--- a/.changeset/stop-no-false-unsaved-toast.md
+++ b/.changeset/stop-no-false-unsaved-toast.md
@@ -1,0 +1,11 @@
+---
+"@mcpjam/inspector": patch
+---
+
+Stop pressing Stop from claiming the reply could not be saved.
+
+Pressing Stop during a turn on a resumed chat-history thread produced an error toast about ten seconds later: "This reply couldn't be saved to your chat history. It's still visible here." Nothing had gone wrong — the user had cancelled the turn on purpose — and it fired on every Stop, on both the chat tab and the playground.
+
+Three correct behaviors combined into a wrong one. The AI SDK has no distinct "aborted" status: on abort it sets `status: "ready"` and returns (`ai/dist/index.mjs`, in `makeRequest`'s catch — `if (isAbort || err.name === "AbortError") { this.setStatus({ status: "ready" }); return null; }`). The server deliberately does not persist an aborted turn — `onFinishEngine` in `server/utils/mcpjam-stream-handler.ts` gates the persist and the `data-persist-receipt` write on `runSucceeded && !aborted` — so no receipt is emitted and the session version never moves. And `useResumedThreadPersistence`, seeing a normal end-of-stream with no receipt, falls back to watching the session subscription for a version bump, which is exactly the deploy-skew case it was built for. The bump never came, the 10 s window expired, and the hook reported a dropped write.
+
+`useChatSession` now records whether the turn was aborted and exposes it as `consumeTurnAborted()`, alongside the existing `consumePersistReceipt()` and with the same consume-once semantics. It is sourced from the AI SDK's own `onFinish({ isAbort })` rather than from the Stop button, so an abort from any source counts and every finished turn overwrites a stopped predecessor. `useResumedThreadPersistence` checks it right after the send baseline is consumed and returns: no reconcile, no toast, no rail refresh and no read-marking, because an aborted turn wrote nothing for the rail to learn. Any receipt that raced the abort is consumed and discarded so it cannot be handed to the next turn.

--- a/.changeset/stop-no-false-unsaved-toast.md
+++ b/.changeset/stop-no-false-unsaved-toast.md
@@ -2,7 +2,7 @@
 "@mcpjam/inspector": patch
 ---
 
-Stop pressing Stop from claiming the reply could not be saved.
+Pressing Stop no longer claims the reply could not be saved.
 
 Pressing Stop during a turn on a resumed chat-history thread produced an error toast about ten seconds later: "This reply couldn't be saved to your chat history. It's still visible here." Nothing had gone wrong — the user had cancelled the turn on purpose — and it fired on every Stop, on both the chat tab and the playground.
 

--- a/mcpjam-inspector/client/src/components/ChatTabV2.tsx
+++ b/mcpjam-inspector/client/src/components/ChatTabV2.tsx
@@ -440,6 +440,7 @@ export function ChatTabV2({
     startChatWithMessages,
     detachToLocalFork,
     consumePersistReceipt,
+    consumeTurnAborted,
     loadChatSession,
     rewindToMessage,
     syncResumedVersion,
@@ -1170,6 +1171,7 @@ export function ChatTabV2({
     activeHistorySessionId,
     resumedVersion,
     consumePersistReceipt,
+    consumeTurnAborted,
     reactiveSessionVersion: reactiveHistorySession?.version,
     syncResumedVersion,
     markHistorySessionRead: (sessionId) => {

--- a/mcpjam-inspector/client/src/components/__tests__/ChatTabV2.history-sync.test.tsx
+++ b/mcpjam-inspector/client/src/components/__tests__/ChatTabV2.history-sync.test.tsx
@@ -426,6 +426,7 @@ const mockUseChatSession = {
     chatSessionId: "forked-session",
   })),
   consumePersistReceipt: vi.fn(() => null as any),
+  consumeTurnAborted: vi.fn(() => false),
   loadChatSession: vi.fn(async () => undefined),
   rewindToMessage: vi.fn(),
   syncResumedVersion: vi.fn((version: number | null) => {
@@ -514,6 +515,7 @@ describe("ChatTabV2 history sync", () => {
     mockReactiveHistoryState.session = undefined;
     mockReactiveHistoryState.widgetSnapshots = undefined;
     mockUseChatSession.consumePersistReceipt.mockReset().mockReturnValue(null);
+    mockUseChatSession.consumeTurnAborted.mockReset().mockReturnValue(false);
     Object.assign(mockUseChatSession, {
       messages: [
         {

--- a/mcpjam-inspector/client/src/components/ui-playground/PlaygroundMain.tsx
+++ b/mcpjam-inspector/client/src/components/ui-playground/PlaygroundMain.tsx
@@ -916,6 +916,7 @@ export function PlaygroundMain({
     startChatWithMessages,
     detachToLocalFork,
     consumePersistReceipt,
+    consumeTurnAborted,
     liveTraceEnvelope,
     requestPayloadHistory,
     hasTraceSnapshot,
@@ -2936,6 +2937,7 @@ export function PlaygroundMain({
     activeHistorySessionId,
     resumedVersion,
     consumePersistReceipt,
+    consumeTurnAborted,
     reactiveSessionVersion: reactiveHistorySession?.version,
     syncResumedVersion,
     markHistorySessionRead: (sessionId) => {

--- a/mcpjam-inspector/client/src/components/ui-playground/__tests__/PlaygroundMain.test.tsx
+++ b/mcpjam-inspector/client/src/components/ui-playground/__tests__/PlaygroundMain.test.tsx
@@ -277,6 +277,7 @@ const mockUseChatSession = {
   rewindToMessage: vi.fn(),
   detachToLocalFork: vi.fn(async () => ({ chatSessionId: "forked-session" })),
   consumePersistReceipt: vi.fn(() => null),
+  consumeTurnAborted: vi.fn(() => false),
   syncResumedVersion: vi.fn(),
   resumedVersion: null,
   restoredToolRenderOverrides: {},

--- a/mcpjam-inspector/client/src/hooks/__tests__/use-resumed-thread-persistence.test.tsx
+++ b/mcpjam-inspector/client/src/hooks/__tests__/use-resumed-thread-persistence.test.tsx
@@ -24,6 +24,8 @@ describe("useResumedThreadPersistence", () => {
     receipt?: PersistReceiptData | null;
     resumedVersion?: number | null;
     enabled?: boolean;
+    /** The turn was stopped by the user (the AI SDK reports it as `ready`). */
+    aborted?: boolean;
   }) {
     const sendBaselineRef = createRef<{
       sessionId: string;
@@ -34,9 +36,16 @@ describe("useResumedThreadPersistence", () => {
     } | null>;
     sendBaselineRef.current = null;
 
-    const consumePersistReceipt = vi.fn(
-      () => overrides?.receipt ?? null
-    ) as unknown as () => PersistReceiptData | null;
+    const consumePersistReceipt = vi.fn(() => overrides?.receipt ?? null);
+    // Consuming, exactly like `useChatSession`'s: the answer describes one
+    // turn, so reading it takes it. That is what keeps a stopped turn from
+    // silencing the turn after it.
+    let turnAborted = overrides?.aborted ?? false;
+    const consumeTurnAborted = vi.fn(() => {
+      const value = turnAborted;
+      turnAborted = false;
+      return value;
+    });
     const syncResumedVersion = vi.fn();
     const markHistorySessionRead = vi.fn();
     const refreshAfterStream = vi.fn();
@@ -50,7 +59,9 @@ describe("useResumedThreadPersistence", () => {
       activeHistorySessionId: SESSION_ID as string | null,
       resumedVersion:
         overrides?.resumedVersion === undefined ? 4 : overrides.resumedVersion,
-      consumePersistReceipt,
+      consumePersistReceipt:
+        consumePersistReceipt as unknown as () => PersistReceiptData | null,
+      consumeTurnAborted,
       reactiveSessionVersion: undefined as number | null | undefined,
       syncResumedVersion,
       markHistorySessionRead,
@@ -76,6 +87,8 @@ describe("useResumedThreadPersistence", () => {
       props,
       runTurn,
       sendBaselineRef,
+      consumePersistReceipt,
+      consumeTurnAborted,
       syncResumedVersion,
       markHistorySessionRead,
       refreshAfterStream,
@@ -443,6 +456,104 @@ describe("useResumedThreadPersistence", () => {
 
     // An inactive surface must not warn about a thread it no longer shows.
     expect(harness.onUnsaved).not.toHaveBeenCalled();
+  });
+
+  it("says nothing when the user stops the turn", () => {
+    // Stop is the one end-of-stream that legitimately saves nothing: the server
+    // persists only `runSucceeded && !aborted`, so no receipt arrives and the
+    // session version never moves. That is byte-for-byte the silence a dropped
+    // write produces, so without an explicit abort signal this turn runs the
+    // full no-receipt window and then calls a deliberate cancel a failure.
+    const harness = setup({ aborted: true, receipt: null });
+
+    harness.runTurn();
+    act(() => {
+      vi.advanceTimersByTime(11_000);
+    });
+
+    expect(harness.onUnsaved).not.toHaveBeenCalled();
+    expect(harness.onConflict).not.toHaveBeenCalled();
+    expect(harness.syncResumedVersion).not.toHaveBeenCalled();
+    // Nothing was written, so the rail has nothing new to learn and the row's
+    // unread state is exactly as the server left it.
+    expect(harness.refreshAfterStream).not.toHaveBeenCalled();
+    expect(harness.markHistorySessionRead).not.toHaveBeenCalled();
+  });
+
+  it("still warns on a receipt-less turn the user did NOT stop", () => {
+    // The control for the case above: silence is only forgivable when we know
+    // why it is silent.
+    const harness = setup({ aborted: false, receipt: null });
+
+    harness.runTurn();
+    act(() => {
+      vi.advanceTimersByTime(11_000);
+    });
+
+    expect(harness.consumeTurnAborted).toHaveBeenCalled();
+    expect(harness.onUnsaved).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not carry a stopped turn into the next one", () => {
+    const harness = setup({ aborted: true, receipt: null });
+
+    harness.runTurn();
+    act(() => {
+      vi.advanceTimersByTime(11_000);
+    });
+    expect(harness.onUnsaved).not.toHaveBeenCalled();
+
+    // Nobody stopped this one, so its silence is a real dropped write and must
+    // still be reported.
+    harness.runTurn();
+    act(() => {
+      vi.advanceTimersByTime(11_000);
+    });
+    expect(harness.onUnsaved).toHaveBeenCalledTimes(1);
+  });
+
+  it("discards a straggler receipt from a stopped turn", () => {
+    // An aborted turn is not supposed to produce a receipt. If one raced the
+    // abort anyway, leaving it in place would hand it to the NEXT turn's
+    // post-stream pass as though it described that turn.
+    const harness = setup({
+      aborted: true,
+      receipt: { outcome: "saved", chatSessionId: "c", version: 5 },
+    });
+
+    harness.runTurn();
+
+    expect(harness.consumePersistReceipt).toHaveBeenCalledTimes(1);
+    expect(harness.syncResumedVersion).not.toHaveBeenCalled();
+  });
+
+  it("does not refresh the rail for a stopped turn on a fresh thread", () => {
+    // The fresh-thread refresh exists so the surface learns the id of the row
+    // its turn created. A stopped turn creates no row.
+    const harness = setup({
+      resumedVersion: null,
+      aborted: true,
+      receipt: null,
+    });
+
+    harness.runTurn();
+
+    expect(harness.refreshAfterStream).not.toHaveBeenCalled();
+    expect(harness.onUnsaved).not.toHaveBeenCalled();
+  });
+
+  it("ignores a stop pressed while nothing is streaming", () => {
+    const harness = setup({ aborted: true, receipt: null });
+
+    // No turn ran, so there is no stream transition to react to and nothing
+    // consumes the flag — it simply waits for a turn that never happened.
+    act(() => {
+      vi.advanceTimersByTime(11_000);
+    });
+
+    expect(harness.consumeTurnAborted).not.toHaveBeenCalled();
+    expect(harness.onUnsaved).not.toHaveBeenCalled();
+    expect(harness.onConflict).not.toHaveBeenCalled();
   });
 
   it("stays inert when disabled", () => {

--- a/mcpjam-inspector/client/src/hooks/__tests__/use-resumed-thread-persistence.test.tsx
+++ b/mcpjam-inspector/client/src/hooks/__tests__/use-resumed-thread-persistence.test.tsx
@@ -549,9 +549,12 @@ describe("useResumedThreadPersistence", () => {
     expect(harness.onConflict).not.toHaveBeenCalled();
   });
 
-  it("does not refresh the rail for a stopped turn on a fresh thread", () => {
-    // The fresh-thread refresh exists so the surface learns the id of the row
-    // its turn created. A stopped turn creates no row.
+  it("still refreshes the rail for a stopped turn on a fresh thread", () => {
+    // A stop does not prove nothing was written: the server checks
+    // `runSucceeded && !aborted` once and then awaits the ingest, so a Stop
+    // landing after that check still lets the commit through. On a fresh thread
+    // that means a ROW may now exist which this surface has never seen, and the
+    // refresh is how it learns the id. It reads, so it stays silent either way.
     const harness = setup({
       resumedVersion: null,
       aborted: true,
@@ -560,8 +563,38 @@ describe("useResumedThreadPersistence", () => {
 
     harness.runTurn();
 
-    expect(harness.refreshAfterStream).not.toHaveBeenCalled();
+    expect(harness.refreshAfterStream).toHaveBeenCalled();
     expect(harness.onUnsaved).not.toHaveBeenCalled();
+  });
+
+  it("silently picks up a version a stopped turn committed anyway", () => {
+    // Same race, resumed thread: the commit landed but cancelling the response
+    // kept its receipt from ever arriving. Without reconciliation
+    // `resumedVersion` stays stale and the NEXT send carries a stale
+    // `expectedVersion` into the false conflict this hook exists to remove.
+    const harness = setup({ aborted: true, receipt: null });
+
+    harness.runTurn();
+    act(() => {
+      harness.view.rerender({ ...harness.props, reactiveSessionVersion: 5 });
+    });
+
+    expect(harness.syncResumedVersion).toHaveBeenCalledWith(5);
+    expect(harness.onUnsaved).not.toHaveBeenCalled();
+  });
+
+  it("never reports a stopped turn as unsaved when no version arrives", () => {
+    // The other half of silence: the watch runs its full window and says
+    // nothing, because an unsaved reply is the intended outcome of a stop.
+    const harness = setup({ aborted: true, receipt: null });
+
+    harness.runTurn();
+    act(() => {
+      vi.advanceTimersByTime(11_000);
+    });
+
+    expect(harness.onUnsaved).not.toHaveBeenCalled();
+    expect(harness.syncResumedVersion).not.toHaveBeenCalled();
   });
 
   it("ignores a stop pressed while nothing is streaming", () => {

--- a/mcpjam-inspector/client/src/hooks/__tests__/use-resumed-thread-persistence.test.tsx
+++ b/mcpjam-inspector/client/src/hooks/__tests__/use-resumed-thread-persistence.test.tsx
@@ -512,10 +512,11 @@ describe("useResumedThreadPersistence", () => {
     expect(harness.onUnsaved).toHaveBeenCalledTimes(1);
   });
 
-  it("discards a straggler receipt from a stopped turn", () => {
-    // An aborted turn is not supposed to produce a receipt. If one raced the
-    // abort anyway, leaving it in place would hand it to the NEXT turn's
-    // post-stream pass as though it described that turn.
+  it("honors a saved receipt that wins the race against the stop", () => {
+    // The server writes the receipt once the ingest has committed and before it
+    // closes the stream, so a Stop pressed in that window reports an abort for a
+    // turn that WAS saved. Discarding the receipt would strand `resumedVersion`
+    // on its pre-turn value and send the next turn into a false conflict.
     const harness = setup({
       aborted: true,
       receipt: { outcome: "saved", chatSessionId: "c", version: 5 },
@@ -524,7 +525,28 @@ describe("useResumedThreadPersistence", () => {
     harness.runTurn();
 
     expect(harness.consumePersistReceipt).toHaveBeenCalledTimes(1);
+    expect(harness.syncResumedVersion).toHaveBeenCalledWith(5);
+    expect(harness.onUnsaved).not.toHaveBeenCalled();
+  });
+
+  it("still says nothing when a stopped turn's receipt reports no write", () => {
+    // The complement: only a receipt that PROVES a write outlives the abort.
+    // A withdrawn turn has no reply to warn about, so `failed` stays silent —
+    // and the receipt is still consumed so it cannot leak into the next turn.
+    const harness = setup({
+      aborted: true,
+      receipt: { outcome: "failed", chatSessionId: "c" },
+    });
+
+    harness.runTurn();
+    act(() => {
+      vi.advanceTimersByTime(11_000);
+    });
+
+    expect(harness.consumePersistReceipt).toHaveBeenCalledTimes(1);
     expect(harness.syncResumedVersion).not.toHaveBeenCalled();
+    expect(harness.onUnsaved).not.toHaveBeenCalled();
+    expect(harness.onConflict).not.toHaveBeenCalled();
   });
 
   it("does not refresh the rail for a stopped turn on a fresh thread", () => {

--- a/mcpjam-inspector/client/src/hooks/use-chat-session.ts
+++ b/mcpjam-inspector/client/src/hooks/use-chat-session.ts
@@ -641,6 +641,13 @@ export interface UseChatSessionReturn {
    * describes exactly one turn.
    */
   consumePersistReceipt: () => PersistReceiptData | null;
+  /**
+   * Take whether the turn that just ended was ABORTED (Stop, or any other abort
+   * of the active response). The AI SDK reports an abort as `status: "ready"`
+   * with no receipt, so without this a stopped turn looks exactly like a turn
+   * whose save silently vanished. Consuming: each answer describes one turn.
+   */
+  consumeTurnAborted: () => boolean;
 
   // Resumed thread version (for optimistic concurrency)
   resumedVersion: number | null;
@@ -1715,6 +1722,23 @@ export function useChatSession(
     chatSessionId: string;
     turnId: string;
   } | null>(null);
+  /**
+   * Whether the turn that just ended was ABORTED rather than allowed to finish.
+   *
+   * The AI SDK has no distinct "aborted" status — on abort it sets
+   * `status: "ready"` and returns (ai/dist/index.mjs, in `makeRequest`'s catch:
+   * `if (isAbort || err.name === "AbortError") { this.setStatus({ status:
+   * "ready" }); return null; }`). So a stopped turn is indistinguishable from a
+   * completed one by status alone, and post-stream consumers that expect a
+   * persist receipt would wait out their whole reconciliation window for a
+   * receipt the server never sends: it persists only `runSucceeded && !aborted`.
+   *
+   * Sourced from the SDK's own `onFinish({ isAbort })` rather than from the Stop
+   * button, so an abort from ANY source counts — Stop, an unmounting instance
+   * aborting its controller, a navigation. Set on every turn end (true or
+   * false), so a finished turn always overwrites a stopped predecessor.
+   */
+  const turnAbortedRef = useRef(false);
   const [, setHydrationTick] = useState(0);
   const [resumedVersion, setResumedVersion] = useState<number | null>(null);
   const [restoredToolRenderOverrides, setRestoredToolRenderOverrides] =
@@ -2222,6 +2246,11 @@ export function useChatSession(
           turnId: part.data.turnId,
         };
         persistReceiptRef.current = null;
+        // Same lifetime as the receipt: a new turn invalidates the previous
+        // turn's abort just as it invalidates the previous turn's receipt.
+        // `onFinish` already clears it at every turn end, so this only matters
+        // when nothing consumed the flag (no history rail on this surface).
+        turnAbortedRef.current = false;
       }
 
       setLiveTraceState((current) => applyLiveTraceEvent(current, part.data));
@@ -2259,6 +2288,24 @@ export function useChatSession(
       return null;
     }
     return receipt;
+  }, []);
+
+  /**
+   * Take whether the turn that just ended was aborted.
+   *
+   * Consuming, like {@link consumePersistReceipt}: the answer describes exactly
+   * one turn, and a leftover `true` would tell the next turn's post-stream
+   * reconciliation to stand down when it should be watching.
+   *
+   * Deliberately NOT session-scoped the way the receipt is. The receipt carries
+   * data (a version) that would be actively wrong if applied to another thread;
+   * this is a bare "nothing was written", which is true of the aborted turn no
+   * matter which thread the surface is on when it reads it.
+   */
+  const consumeTurnAborted = useCallback((): boolean => {
+    const aborted = turnAbortedRef.current;
+    turnAbortedRef.current = false;
+    return aborted;
   }, []);
 
   const syncResumedVersion = useCallback((version: number | null) => {
@@ -2994,6 +3041,14 @@ export function useChatSession(
     transport: proxyTransport,
     onData: handleStreamDataPart,
     onError: handleChatError,
+    // Records whether the turn was aborted, for `consumeTurnAborted`. Runs in
+    // the SDK's `finally` — after `setStatus({ status: "ready" })` but before
+    // React renders that status — so a post-stream effect reading it on the
+    // ready transition always sees THIS turn's answer. Same ordering guarantee
+    // the persist receipt already relies on.
+    onFinish: ({ isAbort }) => {
+      turnAbortedRef.current = isAbort;
+    },
     // SEP-1865 App-Provided Tools: AI SDK v6 IGNORES the return value of
     // `onToolCall`. Tool results must be supplied imperatively via
     // `addToolOutput(...)`. Server-tool calls bypass this handler (they
@@ -4692,6 +4747,7 @@ export function useChatSession(
     loadChatSession,
     syncResumedVersion,
     consumePersistReceipt,
+    consumeTurnAborted,
 
     // Resumed thread version
     resumedVersion,

--- a/mcpjam-inspector/client/src/hooks/use-resumed-thread-persistence.ts
+++ b/mcpjam-inspector/client/src/hooks/use-resumed-thread-persistence.ts
@@ -219,25 +219,43 @@ export function useResumedThreadPersistence(
     sendBaselineRef.current = null;
     if (!enabled) return;
 
-    // The user stopped the turn. Nothing below applies, because there is
-    // nothing to reconcile: the server persists only `runSucceeded && !aborted`
-    // (`server/utils/mcpjam-stream-handler.ts`, `onFinishEngine`), so an aborted
+    // Both consumed BEFORE the abort check, because an abort can race a receipt
+    // that already arrived. The server writes the receipt once the ingest has
+    // committed and before it closes the stream, so a Stop pressed inside that
+    // window reports `isAbort: true` for a turn the server has already saved —
+    // and the persist can hold the stream open for seconds, which is exactly
+    // when a user reaches for Stop. Discarding that receipt would strand
+    // `resumedVersion` on its pre-turn value, and the next send would carry a
+    // stale `expectedVersion` into a false conflict: the bug this hook exists
+    // to remove.
+    const aborted = callbacksRef.current.consumeTurnAborted();
+    const receipt = callbacksRef.current.consumePersistReceipt();
+    // Only a receipt that PROVES a write outlives the abort. `saved`/`duplicate`
+    // carry the authoritative new version, so they fall through and are handled
+    // exactly as they would be on a turn nobody stopped.
+    const receiptProvesWrite =
+      receipt?.outcome === "saved" || receipt?.outcome === "duplicate";
+
+    // The user stopped the turn and nothing was committed. There is nothing to
+    // reconcile: the server persists only `runSucceeded && !aborted`
+    // (`server/utils/mcpjam-stream-handler.ts`, `onFinishEngine`), so such a
     // turn produces no receipt AND no version bump — the exact signature this
     // hook otherwise reads as a dropped write. Left to run, the no-receipt
     // branch would watch the subscription for its full 10 s and then tell the
     // user their reply "couldn't be saved", which is a false alarm about a
     // deliberate action: not saving a withdrawn turn IS the intended outcome.
-    if (callbacksRef.current.consumeTurnAborted()) {
-      // Consume and discard. A receipt is not expected here, but a straggler
-      // left in place would be handed to the NEXT turn's post-stream pass as if
-      // it described that turn.
-      callbacksRef.current.consumePersistReceipt();
+    //
+    // A `failed`, `skipped`, or `conflict` receipt is suppressed here too: the
+    // turn was withdrawn, so there is no reply to warn about and none to fork
+    // away from. A real conflict has not been lost — the session is still
+    // ahead, so the next send reports it with a reply actually worth saving.
+    if (aborted && !receiptProvesWrite) {
       // Belt and braces — the stream-start branch above already cleared it for
       // this turn. Keeping it here makes the abort path a complete no-op on its
       // own rather than one that depends on a sibling branch.
       pendingReconcileRef.current = null;
       // No rail refresh and no read-marking either. Both exist to reflect a
-      // write that just landed; an aborted turn wrote nothing, so the rail has
+      // write that just landed; this turn wrote nothing, so the rail has
       // nothing new to learn and the row's unread state is exactly as the
       // server last left it.
       return;
@@ -246,8 +264,6 @@ export function useResumedThreadPersistence(
     if (activeHistorySessionId) {
       callbacksRef.current.markHistorySessionRead(activeHistorySessionId);
     }
-
-    const receipt = callbacksRef.current.consumePersistReceipt();
 
     // A turn on a fresh (non-resumed) thread has no baseline to advance. It DOES
     // need the rail refresh: this is the turn that created the row, so the

--- a/mcpjam-inspector/client/src/hooks/use-resumed-thread-persistence.ts
+++ b/mcpjam-inspector/client/src/hooks/use-resumed-thread-persistence.ts
@@ -70,6 +70,15 @@ type PendingReconcile = {
   deadlineAt: number;
   /** True once the "couldn't save" notice has been shown for this turn. */
   notified: boolean;
+  /**
+   * Watch for a late commit but never tell the user about its absence.
+   *
+   * Set for a withdrawn turn, where a missing write is the intended outcome and
+   * a warning would be nonsense — but the version still has to be picked up if
+   * the server committed anyway, or the next send carries a stale
+   * `expectedVersion` into a false conflict.
+   */
+  silent: boolean;
 };
 
 export interface ResumedThreadPersistenceOptions {
@@ -173,12 +182,18 @@ export function useResumedThreadPersistence(
   );
 
   const startReconcile = useCallback(
-    (sessionId: string, baselineVersion: number, windowMs: number) => {
+    (
+      sessionId: string,
+      baselineVersion: number,
+      windowMs: number,
+      options?: { silent?: boolean }
+    ) => {
       pendingReconcileRef.current = {
         sessionId,
         baselineVersion,
         deadlineAt: Date.now() + windowMs,
         notified: false,
+        silent: options?.silent ?? false,
       };
       wakeReconcileWatcher();
     },
@@ -254,10 +269,31 @@ export function useResumedThreadPersistence(
       // this turn. Keeping it here makes the abort path a complete no-op on its
       // own rather than one that depends on a sibling branch.
       pendingReconcileRef.current = null;
-      // No rail refresh and no read-marking either. Both exist to reflect a
-      // write that just landed; this turn wrote nothing, so the rail has
-      // nothing new to learn and the row's unread state is exactly as the
-      // server last left it.
+
+      // "Aborted" does NOT prove nothing was written. The server checks
+      // `runSucceeded && !aborted` once, then awaits the ingest — so a Stop
+      // landing after that check still lets the commit through, while
+      // cancelling the response prevents its receipt from ever reaching us.
+      // The write is real and this client cannot see it.
+      //
+      // So the version is still reconciled, just silently: a bump gets picked
+      // up (otherwise the next send carries a stale `expectedVersion` into the
+      // false conflict this hook exists to remove), and its absence is never
+      // reported, because not saving a withdrawn turn is the intended outcome.
+      if (baseline) {
+        startReconcile(
+          baseline.sessionId,
+          baseline.version,
+          NO_RECEIPT_RECONCILE_WINDOW_MS,
+          { silent: true }
+        );
+        return;
+      }
+
+      // No baseline: a fresh thread, where there is no version to reconcile but
+      // there may now be a ROW this surface has never seen. The rail refresh is
+      // how it learns that row's id, and it is silent either way — it reads.
+      callbacksRef.current.refreshAfterStream();
       return;
     }
 
@@ -368,11 +404,14 @@ export function useResumedThreadPersistence(
       return () => window.clearTimeout(timerId);
     }
 
-    if (!pending.notified) {
+    if (!pending.notified && !pending.silent) {
       // Deadline passed with no version bump. Now — and only now — say the
       // reply is not in history. The thread stays attached: the user's messages
       // are still on screen, and forcing a new thread would lose more than it
       // fixes.
+      //
+      // A silent watch skips this entirely: it belongs to a turn the user
+      // withdrew, so an unsaved reply is the expected result, not news.
       pending.notified = true;
       callbacksRef.current.onUnsaved();
     }

--- a/mcpjam-inspector/client/src/hooks/use-resumed-thread-persistence.ts
+++ b/mcpjam-inspector/client/src/hooks/use-resumed-thread-persistence.ts
@@ -95,6 +95,17 @@ export interface ResumedThreadPersistenceOptions {
   resumedVersion: number | null;
   consumePersistReceipt: () => PersistReceiptData | null;
   /**
+   * Take whether the turn that just ended was ABORTED — the user pressed Stop,
+   * or the active response was aborted some other way.
+   *
+   * Needed because the AI SDK has no "aborted" status: on abort it sets
+   * `status: "ready"` and returns (ai/dist/index.mjs, `makeRequest`'s catch:
+   * `if (isAbort || err.name === "AbortError") { this.setStatus({ status:
+   * "ready" }); return null; }`). A stopped turn therefore reaches the
+   * end-of-stream path below looking exactly like a completed one.
+   */
+  consumeTurnAborted: () => boolean;
+  /**
    * Live version from the session subscription: `undefined` while loading or
    * torn down (it is disabled mid-stream), `null` when the row is gone.
    */
@@ -119,6 +130,7 @@ export function useResumedThreadPersistence(
     activeHistorySessionId,
     resumedVersion,
     consumePersistReceipt,
+    consumeTurnAborted,
     reactiveSessionVersion,
     syncResumedVersion,
     markHistorySessionRead,
@@ -133,6 +145,7 @@ export function useResumedThreadPersistence(
   // and consume the baseline early.
   const callbacksRef = useRef({
     consumePersistReceipt,
+    consumeTurnAborted,
     syncResumedVersion,
     markHistorySessionRead,
     refreshAfterStream,
@@ -141,6 +154,7 @@ export function useResumedThreadPersistence(
   });
   callbacksRef.current = {
     consumePersistReceipt,
+    consumeTurnAborted,
     syncResumedVersion,
     markHistorySessionRead,
     refreshAfterStream,
@@ -204,6 +218,30 @@ export function useResumedThreadPersistence(
     const baseline = sendBaselineRef.current;
     sendBaselineRef.current = null;
     if (!enabled) return;
+
+    // The user stopped the turn. Nothing below applies, because there is
+    // nothing to reconcile: the server persists only `runSucceeded && !aborted`
+    // (`server/utils/mcpjam-stream-handler.ts`, `onFinishEngine`), so an aborted
+    // turn produces no receipt AND no version bump — the exact signature this
+    // hook otherwise reads as a dropped write. Left to run, the no-receipt
+    // branch would watch the subscription for its full 10 s and then tell the
+    // user their reply "couldn't be saved", which is a false alarm about a
+    // deliberate action: not saving a withdrawn turn IS the intended outcome.
+    if (callbacksRef.current.consumeTurnAborted()) {
+      // Consume and discard. A receipt is not expected here, but a straggler
+      // left in place would be handed to the NEXT turn's post-stream pass as if
+      // it described that turn.
+      callbacksRef.current.consumePersistReceipt();
+      // Belt and braces — the stream-start branch above already cleared it for
+      // this turn. Keeping it here makes the abort path a complete no-op on its
+      // own rather than one that depends on a sibling branch.
+      pendingReconcileRef.current = null;
+      // No rail refresh and no read-marking either. Both exist to reflect a
+      // write that just landed; an aborted turn wrote nothing, so the rail has
+      // nothing new to learn and the row's unread state is exactly as the
+      // server last left it.
+      return;
+    }
 
     if (activeHistorySessionId) {
       callbacksRef.current.markHistorySessionRead(activeHistorySessionId);


### PR DESCRIPTION
## Symptom

Pressing **Stop** during a chat turn on a resumed history thread pops an error toast about ten seconds later:

> This reply couldn't be saved to your chat history. It's still visible here.

Nothing went wrong — the user cancelled the turn on purpose. It fires on every Stop on a resumed thread, on both the chat tab and the playground.

## Mechanism

Three individually correct behaviors compose into a wrong one.

1. **The AI SDK has no "aborted" status.** On abort it sets `ready` and returns — `node_modules/ai/dist/index.mjs:13229-13232`, in `makeRequest`'s catch:
   ```js
   if (isAbort || err.name === "AbortError") {
     isAbort = true;
     this.setStatus({ status: "ready" });
     return null;
   }
   ```
2. So an aborted turn takes the normal end-of-stream path in `use-resumed-thread-persistence.ts` — the `status !== "ready"` guard passes and the send baseline is consumed like any finished turn.
3. **No receipt arrives, by design.** `onFinishEngine` in `server/utils/mcpjam-stream-handler.ts:3806` gates the persist *and* the `data-persist-receipt` write on `if (runSucceeded && !aborted)`. An aborted turn is partial; recording it would corrupt history.
4. With no receipt, the hook starts the no-receipt reconciliation (`NO_RECEIPT_RECONCILE_WINDOW_MS = 10_000`) and watches the session subscription for a version bump. Nothing was persisted, so the version never bumps, the window expires, and `onUnsaved()` fires.

The reconciliation path is right for what it was built for (deploy skew: a new client against a server that predates the receipt part). It just cannot tell "the server never answered" from "the server had nothing to say".

## Fix

`useChatSession` now knows the turn was aborted, and the persistence hook skips reconciliation entirely — an aborted turn has nothing to reconcile.

- **`use-chat-session.ts`**: `turnAbortedRef` is set from the AI SDK's own `onFinish({ isAbort })` rather than from the Stop button. That covers aborts from *any* source (Stop, an unmounting instance aborting its controller, navigation), and because `onFinish` runs on every turn end with `isAbort` either way, a finished turn always overwrites a stopped predecessor. It is also cleared at `turn_start`, the same place `persistReceiptRef` is cleared, so abort state cannot outlive its turn even on a surface that never consumes it. Exposed as `consumeTurnAborted(): boolean`, matching `consumePersistReceipt`'s consume-once convention.

  Ordering is the same guarantee the receipt already relies on: `onFinish` runs in the SDK's `finally`, after `setStatus({ status: "ready" })` but before React renders that status, so a post-stream effect reading it on the ready transition always sees this turn's answer.

- **`use-resumed-thread-persistence.ts`**: a new `consumeTurnAborted` option, checked in the post-stream path right after the baseline is consumed and cleared. On an abort it clears any pending reconcile, starts none, and toasts nothing.

  Two deliberate calls, both commented in the code:
  - **The receipt is still consumed, and discarded.** One is not expected, but a straggler left in place would be handed to the *next* turn's post-stream pass as if it described that turn.
  - **`markHistorySessionRead` and `refreshAfterStream` are skipped.** Both exist to reflect a write that just landed. An aborted turn wrote nothing, so the rail has nothing new to learn (notably, the fresh-thread refresh exists so the surface learns the id of the row its turn created — a stopped turn creates no row), and the row's unread state is exactly as the server last left it.

Both surfaces pass the new option: `ChatTabV2.tsx` and `ui-playground/PlaygroundMain.tsx`.

### Edge cases

- **Stop with no stream running** — the SDK's `stop()` is already a no-op outside `submitted`/`streaming`, so `onFinish` never fires; and the hook only reads the flag on a streaming → ready transition. Covered by a test.
- **Stop between turns** — same: no request in flight means no `onFinish`, and `turn_start` clears the flag when the next turn begins.
- **Stop on a non-resumed thread (no baseline)** — the abort check sits *before* the `!baseline` branch, so the fresh-thread rail refresh is skipped too. Covered by a test.
- **Abort state leaking into the next turn** — three independent guards (consume-on-read, `onFinish` overwriting on every turn end, `turn_start` clearing). Covered by a test.

## Tests

`client/src/hooks/__tests__/use-resumed-thread-persistence.test.tsx`, six new cases (22 → 28):

- `says nothing when the user stops the turn` — **this is the one that fails without the fix**: it asserts `onUnsaved` is not called after advancing 11 s, and on `main` it is called once. Verified by reverting just the abort branch and re-running: 5 of the 6 new cases fail, 23 existing cases still pass.
- `still warns on a receipt-less turn the user did NOT stop` — the control; a normal turn is unaffected.
- `does not carry a stopped turn into the next one` — turn 1 stopped and silent (no toast), turn 2 silent but not stopped (toast).
- `discards a straggler receipt from a stopped turn`.
- `does not refresh the rail for a stopped turn on a fresh thread`.
- `ignores a stop pressed while nothing is streaming`.

The two surface tests that mock `useChatSession` (`ChatTabV2.history-sync.test.tsx`, `PlaygroundMain.test.tsx`) gained `consumeTurnAborted` in their mock objects.

**Results** — `npm run typecheck:client` clean; `vitest run` over `client/src/hooks/__tests__/`, `client/src/components/__tests__/`, `client/src/components/ui-playground/__tests__/`, `client/src/components/chat-v2/__tests__/`, `client/src/components/hosted/__tests__/ScenarioChatPage.test.tsx` and `client/src/lib/__tests__/scope-step-up.test.ts`: 160 files, 2166 tests, all passing. `use-chat-session.fork.test.tsx` and the other `use-chat-session.*` suites are green.

## Note

A sibling PR is in flight that also edits `use-resumed-thread-persistence.ts` — its `!baseline` conflict branch, a different part of the same effect. A trivial rebase may be needed depending on merge order.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit 4c1f917b3c9e6b4cb93794b7f75b6c74d8352a97. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stops showing a false “reply couldn’t be saved” toast after pressing Stop on a resumed thread. Previously, an aborted turn ended as ready with no receipt and triggered the 10s reconcile/toast; now aborts are detected and handled without warnings, while versions and the rail still stay in sync.

- `useChatSession` records aborts via the SDK’s `onFinish({ isAbort })`, exposes `consumeTurnAborted()`, and resets at `turn_start` (consume-once like `consumePersistReceipt()`).
- `useResumedThreadPersistence` consumes abort and receipt first. On abort with no proof of write: no toast and no read-marking; on resumed threads it starts a silent reconcile to pick up any version bump; on fresh threads it refreshes the rail. Saved/duplicate receipts that win the race still update `resumedVersion`; other outcomes are suppressed.
- Receipt-less turns that were not stopped still warn as before.
- `ChatTabV2` and `PlaygroundMain` now pass `consumeTurnAborted`; tests added for stop, receipt race, fresh-thread, and leak cases.
- Migration: if you use `useResumedThreadPersistence` elsewhere, pass `consumeTurnAborted`.

<sup>Written for commit c8039c4ded738d2aeff809d4cf81f1f0e052464a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/MCPJam/inspector/pull/4073?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

