### PR TITLE
fix(evals): redact credentials at the eval reporting sinks

### DIFF
--- a/.changeset/redact-eval-reporting-sinks.md
+++ b/.changeset/redact-eval-reporting-sinks.md
@@ -1,0 +1,32 @@
+---
+"@mcpjam/sdk": patch
+"@mcpjam/cli": patch
+---
+
+Keep eval credentials out of logs, error trackers, and exported report files.
+
+Eval replay configs carry live `accessToken` / `refreshToken` / `clientSecret`
+values, and they legitimately travel in the ingest request body — replay cannot
+authorize an MCP call without them. That is fine while the body is the only
+place they appear. It stops being fine the moment something quotes the request
+back.
+
+Two paths did. The backend's failure message was passed through
+`normalizeReportingErrorMessage` verbatim into `EvalReportingError`, which the
+SDK writes to stderr and sends to Sentry as the exception value — so a validator
+that echoes the rejected argument, which is exactly what Convex's
+`ArgumentValidationError` does, published live credentials to a log line and a
+third-party error tracker. Separately, `--out` and `--reporter` are two exports
+of the same run, and only the reporter half was redacted: `writeJsonArtifact`
+wrote whatever it was handed straight to disk, so the identical report left
+clean through one flag and in the clear through the other.
+
+Both are now redacted at the point the data becomes an artifact rather than at
+each sink, so a new caller inherits the guarantee instead of having to remember
+it. The request body is deliberately unchanged — redacting it would silently
+break replay while looking like hardening — and a canary-secret regression test
+asserts both directions: the planted credential must reach the request body, and
+must reach nothing else.
+
+Adds `redactTelemetryString`, a string-specialized `redactForTelemetry` for
+message-shaped sinks.

--- a/cli/src/lib/reporting.ts
+++ b/cli/src/lib/reporting.ts
@@ -6,6 +6,7 @@ import {
   type StructuredRunReport,
 } from "@mcpjam/sdk";
 import { operationalError, usageError, writeResult } from "./output.js";
+import { redactForTelemetry } from "./redaction.js";
 
 export type ReporterFormat = "json-summary" | "junit-xml";
 
@@ -37,6 +38,15 @@ export function writeReporterResult(
   writeResult(renderStructuredRunJson(report), "json");
 }
 
+/**
+ * `--out` and `--reporter` are two terminals for the same artifact, and only
+ * the reporter half was redacted: `renderStructuredRunJson` scrubs the report,
+ * while this wrote whatever it was handed straight to disk. So the identical
+ * run exported clean through one flag and in the clear through the other.
+ *
+ * Redact here rather than at the two call sites, so a third `--out` cannot
+ * reintroduce the gap by forgetting.
+ */
 export async function writeJsonArtifact(
   outputPath: string,
   payload: unknown,
@@ -47,7 +57,7 @@ export async function writeJsonArtifact(
     await mkdir(path.dirname(resolvedPath), { recursive: true });
     await writeFile(
       resolvedPath,
-      `${JSON.stringify(payload, null, 2)}\n`,
+      `${JSON.stringify(redactForTelemetry(payload), null, 2)}\n`,
       "utf8",
     );
   } catch (error) {

--- a/cli/tests/reporting.test.ts
+++ b/cli/tests/reporting.test.ts
@@ -117,3 +117,41 @@ test("writeJsonArtifact writes json to disk", async () => {
 
   assert.deepEqual(payload, { ok: true });
 });
+
+// `--out` and `--reporter` are two exports of the same run. The reporter half
+// has always been redacted (see the json-summary test above); the file half was
+// not, so the same report left clean through one flag and in the clear through
+// the other.
+test("writeJsonArtifact redacts the artifact it writes to disk", async () => {
+  const directory = await mkdtemp(path.join(os.tmpdir(), "mcpjam-reporting-"));
+  const artifactPath = path.join(directory, "report.json");
+
+  const writtenPath = await writeJsonArtifact(artifactPath, makeReport());
+  const raw = await readFile(writtenPath, "utf8");
+  const payload = JSON.parse(raw);
+
+  assert.equal(
+    payload.metadata.redactedRawResult.content[0].textPreview,
+    "Authorization: [REDACTED]",
+  );
+  assert.equal(raw.includes("top-secret"), false);
+  // Non-sensitive fields must survive — a redactor that eats the report is not
+  // a fix.
+  assert.equal(payload.kind, "tools-call-validation");
+  assert.equal(payload.schemaVersion, 1);
+});
+
+test("writeJsonArtifact keeps planted credentials out of an exported run", async () => {
+  const directory = await mkdtemp(path.join(os.tmpdir(), "mcpjam-reporting-"));
+  const artifactPath = path.join(directory, "report.json");
+
+  const canary = "at_canary_1a2b3c4d5e6f7g8h9i0j";
+  const writtenPath = await writeJsonArtifact(artifactPath, {
+    ok: false,
+    servers: [{ serverId: "asana", accessToken: canary }],
+    error: `connection refused (authorization: Bearer ${canary})`,
+  });
+  const raw = await readFile(writtenPath, "utf8");
+
+  assert.equal(raw.includes(canary), false);
+});

--- a/sdk/src/report-eval-results.ts
+++ b/sdk/src/report-eval-results.ts
@@ -12,6 +12,7 @@ import {
   type SdkEvalsWireHostConfig,
 } from "./sdk-evals-wire-host-config.js";
 import { resolveRunLevelHostSnapshot } from "./sdk-evals-host-config-source.js";
+import { redactTelemetryString } from "./telemetry-redaction.js";
 import type { HostJson } from "./host-config/public-types.js";
 
 const DEFAULT_REQUEST_TIMEOUT_MS = 15_000;
@@ -325,17 +326,35 @@ function normalizeBillingLimitMessage(
   return "Billing limit reached.";
 }
 
+/**
+ * Every ingest failure message the backend hands back funnels through here on
+ * its way into an `EvalReportingError`, and from there into both stderr and
+ * Sentry's exception value. The string is server-controlled, and the ingest
+ * body it describes carries `accessToken`/`refreshToken`/`clientSecret` — a
+ * validator that echoes the rejected argument (Convex's ArgumentValidationError
+ * does exactly that) would otherwise publish live credentials to a log and a
+ * third-party error tracker.
+ *
+ * Redact once, here, rather than at each sink: this is the single point where a
+ * remote string becomes ours, so every downstream consumer inherits the
+ * guarantee instead of having to remember it.
+ */
 function normalizeReportingErrorMessage(
   rawMessage: string
 ): NormalizedReportingError {
   if (!rawMessage.includes("billing_limit_reached")) {
-    return { message: rawMessage, isBillingLimitReached: false };
+    return {
+      message: redactTelemetryString(rawMessage),
+      isBillingLimitReached: false,
+    };
   }
 
   const payload = extractFirstJsonObject(rawMessage);
   const billingMessage = payload ? normalizeBillingLimitMessage(payload) : null;
   return {
-    message: billingMessage ?? "Billing limit reached.",
+    message: billingMessage
+      ? redactTelemetryString(billingMessage)
+      : "Billing limit reached.",
     isBillingLimitReached: true,
   };
 }
@@ -615,9 +634,12 @@ async function uploadBlobToConvex(
         return responseBody.storageId;
       }
 
-      const message =
+      // Same reasoning as `normalizeReportingErrorMessage`: server-controlled
+      // string, and this one reaches a console.warn in the widget-snapshot path.
+      const message = redactTelemetryString(
         responseBody.error ??
-        `Artifact upload failed with status ${response.status}: ${response.statusText}`;
+          `Artifact upload failed with status ${response.status}: ${response.statusText}`
+      );
       if (
         isRetryableStatus(response.status) &&
         attempt < config.retryDelaysMs.length

--- a/sdk/src/telemetry-redaction.ts
+++ b/sdk/src/telemetry-redaction.ts
@@ -4,6 +4,21 @@ export function redactForTelemetry(value: unknown): unknown {
   return redactForTelemetryAtPath(value, []);
 }
 
+/**
+ * String-specialized `redactForTelemetry`, for the sinks that hold a message
+ * rather than a payload — a thrown error, a log line, a Sentry exception value.
+ *
+ * The redactor already scrubs strings, but it is typed `unknown -> unknown`, so
+ * every message-shaped caller otherwise re-narrows the result itself. Three
+ * modules grew a private copy of exactly this (`error-describer/describe.ts`,
+ * `conformance-redaction.ts`, `xaa/state-machines/state-machine.ts`); this is
+ * the one they should collapse onto, so a fourth does not appear.
+ */
+export function redactTelemetryString(value: string): string {
+  const redacted = redactForTelemetry(value);
+  return typeof redacted === "string" ? redacted : value;
+}
+
 function redactForTelemetryAtPath(value: unknown, path: string[]): unknown {
   if (Array.isArray(value)) {
     return value.map((entry) => redactForTelemetryAtPath(entry, path));

--- a/sdk/tests/eval-reporting-canary-secret.test.ts
+++ b/sdk/tests/eval-reporting-canary-secret.test.ts
@@ -1,0 +1,224 @@
+/**
+ * Canary-secret regression test for the eval reporting path (Evals v2, Lane A3).
+ *
+ * The premise Lane A started from — "credentials are persisted as eval data" —
+ * turned out to be false. What is true is narrower and harder to see by reading
+ * code: credentials legitimately transit in the ingest body, so every sink that
+ * quotes something about that request is one echo away from publishing them.
+ *
+ * These tests plant a canary in the place a real credential lives and assert it
+ * never surfaces anywhere else. They deliberately assert BOTH directions:
+ * the canary must reach the request body (replay is authorized by it, and a
+ * "fix" that redacts the body would silently break replay while looking like
+ * hardening), and must reach nothing else.
+ */
+
+const sentryMocks = vi.hoisted(() => ({
+  addBreadcrumb: vi.fn().mockResolvedValue(undefined),
+  captureEvalReportingFailure: vi.fn().mockResolvedValue(undefined),
+}));
+
+vi.mock("../src/sentry", () => ({
+  addBreadcrumb: sentryMocks.addBreadcrumb,
+  captureEvalReportingFailure: sentryMocks.captureEvalReportingFailure,
+}));
+
+import {
+  reportEvalResults,
+  reportEvalResultsSafely,
+} from "../src/report-eval-results";
+import { renderStructuredRunJson } from "../src/structured-reporting";
+
+/**
+ * Distinctive enough that a substring search cannot collide with fixture noise,
+ * and shaped like the real thing so key- and value-based redactors both engage.
+ */
+const CANARY = "at_canary_1a2b3c4d5e6f7g8h9i0j";
+const CANARY_REFRESH = "rt_canary_9z8y7x6w5v4u3t2s1r0q";
+const CANARY_CLIENT_SECRET = "cs_canary_qwertyuiopasdfghjkl";
+
+const replayConfigs = [
+  {
+    serverId: "asana",
+    url: "https://mcp.example.com/mcp",
+    accessToken: CANARY,
+    clientId: "client_public_id",
+    clientSecret: CANARY_CLIENT_SECRET,
+  },
+];
+
+function canaryStrings(): string[] {
+  return [CANARY, CANARY_REFRESH, CANARY_CLIENT_SECRET];
+}
+
+/** Serialize anything a sink was handed, so one search covers nested shapes. */
+function serializeSinkArgs(args: unknown[]): string {
+  return args
+    .map((arg) => {
+      if (arg instanceof Error) {
+        return `${arg.name}: ${arg.message}\n${arg.stack ?? ""}`;
+      }
+      if (typeof arg === "string") return arg;
+      try {
+        return JSON.stringify(arg);
+      } catch {
+        return String(arg);
+      }
+    })
+    .join("\n");
+}
+
+function expectNoCanary(haystack: string, sinkName: string): void {
+  for (const canary of canaryStrings()) {
+    expect(
+      haystack.includes(canary),
+      `${sinkName} leaked a planted credential (${canary})`
+    ).toBe(false);
+  }
+}
+
+/**
+ * The failure being defended against: a server that echoes the rejected request
+ * back in its error string. Convex's ArgumentValidationError does exactly this,
+ * so this is the realistic shape, not a contrived one.
+ */
+function echoingErrorResponse(body: unknown): any {
+  return {
+    ok: false,
+    status: 400,
+    statusText: "Bad Request",
+    json: async () => ({
+      ok: false,
+      error: `ArgumentValidationError: Object contains extra field. Object: ${JSON.stringify(
+        body
+      )}`,
+    }),
+  };
+}
+
+describe("canary secret — eval reporting", () => {
+  const originalFetch = global.fetch;
+
+  afterEach(() => {
+    global.fetch = originalFetch;
+    sentryMocks.addBreadcrumb.mockClear();
+    sentryMocks.captureEvalReportingFailure.mockClear();
+    vi.restoreAllMocks();
+  });
+
+  it("sends the credential in the request body — replay depends on it", async () => {
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      status: 200,
+      statusText: "OK",
+      json: async () => ({
+        ok: true,
+        suiteId: "suite_1",
+        runId: "run_1",
+        status: "completed",
+        result: "passed",
+        summary: { total: 1, passed: 1, failed: 0, passRate: 1 },
+      }),
+    });
+    global.fetch = fetchMock as any;
+
+    await reportEvalResults({
+      apiKey: "sk_test_key",
+      baseUrl: "https://example.com",
+      suiteName: "canary suite",
+      results: [{ caseTitle: "happy-path", passed: true }],
+      serverReplayConfigs: replayConfigs,
+    });
+
+    const sentBody = String(fetchMock.mock.calls[0][1].body);
+    expect(sentBody).toContain(CANARY);
+    expect(sentBody).toContain(CANARY_CLIENT_SECRET);
+  });
+
+  it("keeps an echoing backend error out of the thrown message, stderr and Sentry", async () => {
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    const logSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+
+    const fetchMock = vi
+      .fn()
+      .mockImplementation(async (_url, init) =>
+        echoingErrorResponse(JSON.parse(String(init.body)))
+      );
+    global.fetch = fetchMock as any;
+
+    // Safe mode swallows the throw and routes the message to console.warn +
+    // Sentry, which is precisely the pair under test.
+    await reportEvalResultsSafely({
+      apiKey: "sk_test_key",
+      baseUrl: "https://example.com",
+      suiteName: "canary suite",
+      results: [{ caseTitle: "happy-path", passed: true }],
+      serverReplayConfigs: replayConfigs,
+    });
+
+    expectNoCanary(
+      serializeSinkArgs(warnSpy.mock.calls.flat()),
+      "console.warn"
+    );
+    expectNoCanary(
+      serializeSinkArgs(errorSpy.mock.calls.flat()),
+      "console.error"
+    );
+    expectNoCanary(serializeSinkArgs(logSpy.mock.calls.flat()), "console.log");
+
+    expect(sentryMocks.captureEvalReportingFailure).toHaveBeenCalled();
+    expectNoCanary(
+      serializeSinkArgs(
+        sentryMocks.captureEvalReportingFailure.mock.calls.flat()
+      ),
+      "Sentry captureEvalReportingFailure"
+    );
+    expectNoCanary(
+      serializeSinkArgs(sentryMocks.addBreadcrumb.mock.calls.flat()),
+      "Sentry addBreadcrumb"
+    );
+  });
+
+  it("keeps an echoing backend error out of the error surfaced to the caller", async () => {
+    const fetchMock = vi
+      .fn()
+      .mockImplementation(async (_url, init) =>
+        echoingErrorResponse(JSON.parse(String(init.body)))
+      );
+    global.fetch = fetchMock as any;
+
+    const thrown = await reportEvalResults({
+      apiKey: "sk_test_key",
+      baseUrl: "https://example.com",
+      suiteName: "canary suite",
+      results: [{ caseTitle: "happy-path", passed: true }],
+      serverReplayConfigs: replayConfigs,
+    }).then(
+      () => null,
+      (error: unknown) => error
+    );
+
+    expect(thrown).toBeInstanceOf(Error);
+    expectNoCanary(serializeSinkArgs([thrown]), "thrown EvalReportingError");
+  });
+
+  it("keeps planted credentials out of the rendered structured report", () => {
+    const rendered = renderStructuredRunJson({
+      // The report contract has no credential field; a leak arrives as
+      // incidental payload — an error string, a captured tool result — so
+      // that is what is planted here.
+      summary: { total: 1, passed: 0, failed: 1, passRate: 0 },
+      cases: [
+        {
+          name: "canary case",
+          passed: false,
+          error: `connection refused (authorization: Bearer ${CANARY})`,
+          metadata: { accessToken: CANARY, refreshToken: CANARY_REFRESH },
+        },
+      ],
+    } as never);
+
+    expectNoCanary(JSON.stringify(rendered), "renderStructuredRunJson");
+  });
+});


### PR DESCRIPTION
Evals v2 **Lane A, steps A2 + A3** (inspector half). Follows [mcpjam-backend#1010](https://github.com/MCPJam/mcpjam-backend/pull/1010) (A1, merged). The backend half of A2/A3 is a separate PR in `mcpjam-backend`; the two are independent, not stacked.

## The shape of the problem

Eval replay configs carry live `accessToken` / `refreshToken` / `clientSecret`, and they **legitimately travel in the ingest request body** — replay cannot authorize an MCP call without them. That is fine while the body is the only place they appear. It stops being fine the moment something quotes the request back.

Two paths did.

**1. Backend error strings → stderr and Sentry.** `normalizeReportingErrorMessage` passed the server's failure string verbatim into `EvalReportingError`, which the SDK writes to `console.warn` and hands to Sentry as the exception value. So a validator that echoes the rejected argument — which is exactly what Convex's `ArgumentValidationError` does — published live customer credentials to a log line and a third-party error tracker. Every ingest call funnels through this helper (one-shot and streaming alike, since `startEvalRun` / `appendEvalRunIterations` / `finalizeEvalRun` all use `requestWithRetry`), so redacting where the remote string becomes ours covers all three sinks from one place.

**2. `--out` exported unredacted.** `--out` and `--reporter` are two exports of the same run, and only the reporter half was redacted: `renderStructuredRunJson` scrubs the report, while `writeJsonArtifact` wrote its argument straight to disk. The identical run left clean through one flag and in the clear through the other. Redaction goes in the helper rather than at the two call sites (`eval.ts:1084`, `server.ts:603`) so a third `--out` cannot reopen it by forgetting.

## These leaks are real, not theoretical

Reverting either fix fails the canary test. Verified by doing it:

- with the message fix reverted → `console.warn leaked a planted credential (at_canary_…)` and `thrown EvalReportingError leaked a planted credential (…)`
- with the fix in place → 4/4 pass

## What is deliberately NOT changed

The request body. Redacting it would replace the three token fields with `[REDACTED]` and **silently break replay while looking like hardening**. The canary test therefore asserts **both** directions: the planted credential *must* reach the request body, and *must* reach nothing else. A future "tightening" that breaks replay will fail this test rather than ship.

## Also added

`redactTelemetryString`, a string-specialized `redactForTelemetry` for message-shaped sinks. Three modules had already grown a private copy of exactly this (`error-describer/describe.ts:72`, `conformance-redaction.ts:286`, `xaa/state-machines/state-machine.ts:86`); this is the one they should collapse onto, so a fourth does not appear. Collapsing the existing three is left out of this PR — it would churn XAA and conformance code unrelated to Lane A.

## Verification

- Full SDK suite: **4668 passed**, 8 skipped (225 files).
- Full CLI suite: **642 passed**, 0 failed.
- `typecheck` clean for both workspaces; `prettier --check` clean on every file I touched that was clean on `main`. (`cli/src/lib/reporting.ts` and `cli/tests/reporting.test.ts` were already unformatted on `main`, so I matched their local style rather than reformatting lines I did not write.)
- Note for anyone reproducing locally: a stale `sdk/dist` in a shared checkout makes ~11 CLI test files fail with `does not provide an export named …`. That is the worktree `node_modules` symlink resolving `@mcpjam/sdk` to the main checkout, not a regression — `npm run build -w @mcpjam/sdk` clears it. CI builds the SDK before the CLI suite, so it does not arise there.

## Lane A status after this

A1 merged; A2 + A3 land here and in the backend PR. Remaining: **A1c** (human/ops — confirm WorkOS actually deleted the May-2026 legacy keys; that Slack thread ended unresolved) and **A4** (deferred KMS envelope encryption, scheduled against the first enterprise security review).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit b7354320b19c9b2adf5d48084c720555ca6b4eb8. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Redacts eval credentials from error/logging paths and exported artifacts to prevent leaks to stderr, Sentry, and `--out` files, while keeping the request body intact for replay. Previously, backend error strings and `--out` artifacts could include raw `accessToken`/`refreshToken`/`clientSecret`; now both paths are redacted at the point data becomes our artifact.

**Review focus**
- SDK: `normalizeReportingErrorMessage` and the blob upload error path now call `redactTelemetryString`; this sanitizes thrown `EvalReportingError`, `console.warn`, and Sentry values.
- CLI: `writeJsonArtifact` wraps payloads with `redactForTelemetry` so `--out` matches the already-redacted `--reporter`.
- Utility: adds `redactTelemetryString` in `sdk/src/telemetry-redaction.ts` for message-shaped sinks.
- Tests: adds a canary regression test to ensure credentials appear only in the ingest body and never in logs, thrown errors, Sentry, or exported reports.

<sup>Written for commit b7354320b19c9b2adf5d48084c720555ca6b4eb8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/MCPJam/inspector/pull/4075?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

