### PR TITLE
test(github-checks): pin the sandbox teardown guarantee, and fix a stale claim

### DIFF
--- a/.changeset/github-checks-teardown-pins.md
+++ b/.changeset/github-checks-teardown-pins.md
@@ -1,0 +1,5 @@
+---
+"@mcpjam/inspector": patch
+---
+
+Pin the GitHub PR check sandbox's orphan backstop in tests. A dead worker's box is reaped by E2B's own TTL, so the `timeoutMs` and `lifecycle: { onTimeout: "kill" }` provisioning options are what actually guarantee teardown — and neither was asserted, so dropping `lifecycle`, or switching it to `pause` (which would snapshot a pull request's build rather than destroy it), would have passed CI. Also asserts that no MCPJam credential material reaches the box, that a missing dedicated template fails rather than falling back to the shared computer image, and that a failed kill stays best-effort.

--- a/mcpjam-inspector/server/services/github-checks-worker.ts
+++ b/mcpjam-inspector/server/services/github-checks-worker.ts
@@ -28,8 +28,13 @@
  * fails it ~5 minutes later, which shows up on someone's PR as a check that
  * hung and then went neutral.
  *
- * Gated by `GITHUB_CHECKS_WORKER_ENABLED === '1'`; the backend has its own
- * `GITHUB_CHECKS_ENABLED` gate and 404s this whole surface when it is off.
+ * Gated by `GITHUB_CHECKS_WORKER_ENABLED === '1'`. That gate stops this
+ * process from CLAIMING work; it is not a kill switch for the feature. The
+ * backend's `GITHUB_CHECKS_ENABLED` gate — which this comment used to claim
+ * 404s the whole surface — no longer exists, so with the worker off the
+ * webhook still accepts deliveries and still inserts triggers. They sit
+ * `pending` until the backend's 30-minute sweep retires them as
+ * `worker_unavailable`, concluding each check neutral with an explanation.
  */
 
 import { WEB_CALL_TIMEOUT_MS } from "../config.js";

--- a/mcpjam-inspector/server/services/github-checks/__tests__/sandbox-provision.test.ts
+++ b/mcpjam-inspector/server/services/github-checks/__tests__/sandbox-provision.test.ts
@@ -1,7 +1,9 @@
 import { describe, expect, it, vi } from "vitest";
 import { Sandbox } from "e2b";
 import {
+  CHECK_SANDBOX_TIMEOUT_MS,
   GITHUB_CHECKS_EGRESS_DENY_CIDRS,
+  killCheckSandbox,
   provisionCheckSandbox,
 } from "../sandbox";
 
@@ -10,22 +12,27 @@ vi.mock("e2b", async () => {
   return { ...actual, Sandbox: { ...actual.Sandbox, create: vi.fn() } };
 });
 
+/** The env every test here provisions against. */
+function stubProvisionEnv(): void {
+  vi.stubEnv("E2B_API_KEY", "e2b_test_key");
+  vi.stubEnv("GITHUB_CHECKS_E2B_TEMPLATE_ID", "template-test");
+}
+
+const ARGS = {
+  triggerId: "trigger-1",
+  repoFullName: "acme/example",
+  prNumber: 7,
+} as const;
+
 describe("provisionCheckSandbox", () => {
   it("creates a public box with the backend's non-guest egress baseline", async () => {
     const create = vi.mocked(Sandbox.create);
     const sandbox = { sandboxId: "sb_test" } as never;
-    vi.stubEnv("E2B_API_KEY", "e2b_test_key");
-    vi.stubEnv("GITHUB_CHECKS_E2B_TEMPLATE_ID", "template-test");
+    stubProvisionEnv();
     create.mockResolvedValueOnce(sandbox);
 
     try {
-      await expect(
-        provisionCheckSandbox({
-          triggerId: "trigger-1",
-          repoFullName: "acme/example",
-          prNumber: 7,
-        })
-      ).resolves.toBe(sandbox);
+      await expect(provisionCheckSandbox({ ...ARGS })).resolves.toBe(sandbox);
 
       expect(create).toHaveBeenCalledWith(
         "template-test",
@@ -40,5 +47,115 @@ describe("provisionCheckSandbox", () => {
       create.mockReset();
       vi.unstubAllEnvs();
     }
+  });
+
+  it("pins the orphan backstop: a TTL, and kill (never pause) at it", async () => {
+    // THE teardown guarantee, and the only one that survives this process
+    // dying. `killCheckSandbox` is best-effort by design — a failed kill is a
+    // warning — so what actually bounds an orphaned box is E2B reaping it at
+    // its own TTL. That made these two options load-bearing and untested:
+    // dropping `lifecycle` would leave dead workers' boxes alive on E2B's
+    // default handling, and `onTimeout: "pause"` would SNAPSHOT a pull
+    // request's build instead of destroying it — persisting the workspace this
+    // check promises never to keep.
+    const create = vi.mocked(Sandbox.create);
+    stubProvisionEnv();
+    create.mockResolvedValueOnce({ sandboxId: "sb_ttl" } as never);
+
+    try {
+      await provisionCheckSandbox({ ...ARGS });
+      const options = create.mock.calls[0][1] as {
+        timeoutMs?: number;
+        lifecycle?: { onTimeout?: string };
+      };
+      expect(options.timeoutMs).toBe(CHECK_SANDBOX_TIMEOUT_MS);
+      expect(options.lifecycle).toEqual({ onTimeout: "kill" });
+    } finally {
+      create.mockReset();
+      vi.unstubAllEnvs();
+    }
+  });
+
+  it("hands the box no credential material of ours", async () => {
+    // The sandbox runs untrusted PR code, so the only secret that may reach
+    // E2B is the API key authenticating US to E2B. Nothing about MCPJam's
+    // environment — and no GitHub credential — may ride along in the metadata
+    // or anywhere else in the create options. Asserted over the whole
+    // serialized payload rather than field by field, so a future field cannot
+    // add one without tripping this.
+    const create = vi.mocked(Sandbox.create);
+    stubProvisionEnv();
+    vi.stubEnv("GITHUB_APP_PRIVATE_KEY", "canary-github-app-key");
+    vi.stubEnv("CONVEX_DEPLOY_KEY", "canary-convex-deploy-key");
+    vi.stubEnv("INSPECTOR_SERVICE_TOKEN", "canary-service-token");
+    create.mockResolvedValueOnce({ sandboxId: "sb_creds" } as never);
+
+    try {
+      await provisionCheckSandbox({ ...ARGS });
+      const [, options] = create.mock.calls[0] as [
+        string,
+        Record<string, unknown>
+      ];
+      const { apiKey, ...rest } = options;
+      expect(apiKey).toBe("e2b_test_key");
+      const serialized = JSON.stringify(rest);
+      for (const canary of [
+        "canary-github-app-key",
+        "canary-convex-deploy-key",
+        "canary-service-token",
+      ]) {
+        expect(serialized).not.toContain(canary);
+      }
+      // No env passthrough at all: the recipe's own env is applied per command,
+      // never as a box-wide default the build inherits.
+      expect(rest).not.toHaveProperty("envs");
+    } finally {
+      create.mockReset();
+      vi.unstubAllEnvs();
+    }
+  });
+
+  it("refuses to run without the dedicated template, rather than falling back", async () => {
+    // The shared computer template carries a browser, a desktop, and Project
+    // Computer tooling — none of which a pull request's build should be able
+    // to touch. A missing template id is a deployment error, and the failure
+    // is attributed to US (`infra_error`), never to the PR.
+    const create = vi.mocked(Sandbox.create);
+    vi.stubEnv("E2B_API_KEY", "e2b_test_key");
+    vi.stubEnv("GITHUB_CHECKS_E2B_TEMPLATE_ID", "");
+
+    try {
+      await expect(provisionCheckSandbox({ ...ARGS })).rejects.toMatchObject({
+        outcome: "infra_error",
+      });
+      expect(create).not.toHaveBeenCalled();
+    } finally {
+      create.mockReset();
+      vi.unstubAllEnvs();
+    }
+  });
+});
+
+describe("killCheckSandbox", () => {
+  it("kills the box it is given", async () => {
+    const kill = vi.fn().mockResolvedValue(undefined);
+    await killCheckSandbox({ sandboxId: "sb_1", kill } as never);
+    expect(kill).toHaveBeenCalledTimes(1);
+  });
+
+  it("swallows a failed kill — the TTL is the real backstop", async () => {
+    // Deliberate: teardown runs in a `finally`, and letting it throw would
+    // replace the check's real outcome with a cleanup error. The box still
+    // dies at its TTL (pinned above), which is why this is safe to swallow
+    // rather than merely convenient.
+    const kill = vi.fn().mockRejectedValue(new Error("e2b unreachable"));
+    await expect(
+      killCheckSandbox({ sandboxId: "sb_2", kill } as never)
+    ).resolves.toBeUndefined();
+    expect(kill).toHaveBeenCalledTimes(1);
+  });
+
+  it("is a no-op when there is no box", async () => {
+    await expect(killCheckSandbox(null)).resolves.toBeUndefined();
   });
 });


### PR DESCRIPTION
**Evals v2 · Lane C · step H7.** Tests + one comment fix; no production behaviour change. Independent of the two backend PRs (MCPJam/mcpjam-backend#1012, #1013).

## Why

The Lane C audit found teardown was tested as *"we call `kill`"* — which is the weaker half of the guarantee.

`killCheckSandbox` is best-effort **by design**: a failed kill is a `logger.warn`, because letting it throw inside the worker's `finally` would replace a check's real outcome with a cleanup error. So what actually guarantees an orphaned box dies is E2B reaping it at its own TTL — which makes `timeoutMs` and `lifecycle: { onTimeout: "kill" }` the load-bearing options. Neither was asserted anywhere. Dropping `lifecycle` would leave a dead worker's box alive on E2B's default handling, and `onTimeout: "pause"` would **snapshot a pull request's build** rather than destroy it — persisting the workspace this check promises never to keep. Both would have passed CI.

That's the acceptance row *"Sandbox termination → no persistent workspace, cache write, or credential material"*, which we could not previously claim was tested.

## What's pinned now

- **The orphan backstop:** `timeoutMs === CHECK_SANDBOX_TIMEOUT_MS` and `lifecycle` is exactly `{ onTimeout: "kill" }`.
- **No credential material reaches the box:** canary values stubbed into `GITHUB_APP_PRIVATE_KEY`, `CONVEX_DEPLOY_KEY`, `INSPECTOR_SERVICE_TOKEN`, then asserted absent from the whole serialized create payload (minus the E2B API key, which authenticates *us* to E2B). Asserted over the serialization rather than field-by-field so a future field can't smuggle one in. Also asserts no box-wide `envs` passthrough.
- **No template fallback:** a missing `GITHUB_CHECKS_E2B_TEMPLATE_ID` fails as `infra_error` and never reaches `Sandbox.create` — the shared computer template carries a browser, a desktop, and Project Computer tooling that a PR's build must not touch.
- **Kill semantics:** kills when given a box, swallows a failing kill, no-ops on `null`.

## The comment fix

`github-checks-worker.ts` claimed the backend "has its own `GITHUB_CHECKS_ENABLED` gate and 404s this whole surface when it is off." **That gate no longer exists.** With the worker disabled the webhook still accepts deliveries and still inserts triggers; they sit `pending` until the backend's 30-minute sweep retires them. Leaving the claim invites someone to treat the worker env flag as a kill switch for the feature — it only stops *this process* from claiming. (A real operator kill switch is step H4, blocked on a Schema Request.)

## Verification

- `npx vitest run server/services/github-checks/ server/services/__tests__/github-checks-worker*.test.ts` → **469 passed / 12 files**.
- Probe: removed `lifecycle` from `provisionCheckSandbox` → the backstop test fails, the other six pass. It pins the invariant, not the shape.
- Prettier clean (v2 — the one reformat was my own line; no untouched lines reformatted).
- Note for anyone running these in a fresh worktree: two git-ignored generated bundles (`PluginShim.bundled.ts`, `HarnessPageBundle.generated.ts`) must exist or the worker test file fails to load. Pre-existing, unrelated to this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit 09e017dda64b098c4f6ee5f2c7fda3eada8c4a2b. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Pins the teardown guarantee for GitHub PR check sandboxes in tests and corrects a stale worker gating comment. Old tests only verified we called kill; new tests assert the E2B TTL backstop and best‑effort kill semantics that actually ensure teardown. No production behavior change.

- Asserts the orphan backstop: `timeoutMs === CHECK_SANDBOX_TIMEOUT_MS` and `lifecycle: { onTimeout: "kill" }`; tests fail if `lifecycle` is omitted or set to `pause`.
- Verifies no MCPJam credentials reach the sandbox and no box‑wide env passthrough; only the E2B API key is sent.
- Fails fast with `infra_error` when `GITHUB_CHECKS_E2B_TEMPLATE_ID` is missing, never invoking `Sandbox.create` or falling back to the shared template.
- Tests `killCheckSandbox`: kills when given a box, swallows kill errors, and no‑ops on `null`.
- Updates the comment in `github-checks-worker.ts` to clarify `GITHUB_CHECKS_WORKER_ENABLED` only prevents this process from claiming work; the backend `GITHUB_CHECKS_ENABLED` gate no longer exists.

<sup>Written for commit 09e017dda64b098c4f6ee5f2c7fda3eada8c4a2b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/MCPJam/inspector/pull/4077?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

