### PR TITLE
chore(deps): update Electron 37 → 43

### DIFF
--- a/.changeset/electron-major-bump.md
+++ b/.changeset/electron-major-bump.md
@@ -1,0 +1,5 @@
+---
+"@mcpjam/inspector": patch
+---
+
+Update Electron 37.10.3 -> 43.4.0, clearing all 31 open Electron security advisories (7 high, 18 medium, 6 low). 43 is the current stable line; the minimum fix version (39.8.10) is already outside Electron's support window.

--- a/mcpjam-inspector/package.json
+++ b/mcpjam-inspector/package.json
@@ -241,7 +241,7 @@
     "autoprefixer": "^10.4.21",
     "concurrently": "^9.1.0",
     "cross-env": "^10.1.0",
-    "electron": "^37.2.5",
+    "electron": "^43.4.0",
     "eslint": "^9",
     "jsdom": "^27.4.0",
     "png-to-ico": "^2.1.8",

--- a/package-lock.json
+++ b/package-lock.json
@@ -533,7 +533,7 @@
         "autoprefixer": "^10.4.21",
         "concurrently": "^9.1.0",
         "cross-env": "^10.1.0",
-        "electron": "^37.2.5",
+        "electron": "^43.4.0",
         "eslint": "^9",
         "jsdom": "^27.4.0",
         "png-to-ico": "^2.1.8",
@@ -4439,6 +4439,16 @@
       },
       "engines": {
         "node": ">= 14.17.5"
+      }
+    },
+    "node_modules/@electron-internal/extract-zip": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/@electron-internal/extract-zip/-/extract-zip-1.0.5.tgz",
+      "integrity": "sha512-+bqFCP98pLI0Tt0XQo1TmlXtwjWchISndDOxCkEcIuUgXWpBnLyRI+2DU+mesvnMMX6L1XDqYNA0lXNDHd/yiA==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=22.12.0"
       }
     },
     "node_modules/@electron/asar": {
@@ -20299,22 +20309,22 @@
       "license": "MIT"
     },
     "node_modules/electron": {
-      "version": "37.10.3",
-      "resolved": "https://registry.npmjs.org/electron/-/electron-37.10.3.tgz",
-      "integrity": "sha512-3IjCGSjQmH50IbW2PFveaTzK+KwcFX9PEhE7KXb9v5IT8cLAiryAN7qezm/XzODhDRlLu0xKG1j8xWBtZ/bx/g==",
+      "version": "43.4.0",
+      "resolved": "https://registry.npmjs.org/electron/-/electron-43.4.0.tgz",
+      "integrity": "sha512-3qxGF0CeQbiox5oWV1JlbWGQ1VerbmDhTFqW4sJ8h7uqTHniFYPObXJcDna0DMh32et0fFyKzz0YY8lJv3t5jg==",
       "dev": true,
-      "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
-        "@electron/get": "^2.0.0",
-        "@types/node": "^22.7.7",
-        "extract-zip": "^2.0.1"
+        "@electron-internal/extract-zip": "^1.0.1",
+        "@electron/get": "^5.0.0",
+        "@types/node": "^24.9.0"
       },
       "bin": {
-        "electron": "cli.js"
+        "electron": "cli.js",
+        "install-electron": "install.js"
       },
       "engines": {
-        "node": ">= 12.20.55"
+        "node": ">= 22.12.0"
       }
     },
     "node_modules/electron-installer-common": {
@@ -20854,66 +20864,53 @@
       }
     },
     "node_modules/electron/node_modules/@electron/get": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/@electron/get/-/get-2.0.3.tgz",
-      "integrity": "sha512-Qkzpg2s9GnVV2I2BjRksUi43U5e6+zaQMcjoJy0C+C5oxaKl+fmckGDQFtRpZpZV0NQekuZZ+tGz7EA9TVnQtQ==",
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/@electron/get/-/get-5.1.0.tgz",
+      "integrity": "sha512-3kSBtG8ObcTVfXanm5vVJ6UnBLEVmVsRk1M+vGqCuMBV+XLCbJYuWQful+yIy0GQDsSlK0kHEriEHn7SPk4EnA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "debug": "^4.1.1",
-        "env-paths": "^2.2.0",
-        "fs-extra": "^8.1.0",
-        "got": "^11.8.5",
+        "env-paths": "^3.0.0",
+        "graceful-fs": "^4.2.11",
         "progress": "^2.0.3",
-        "semver": "^6.2.0",
+        "semver": "^7.6.3",
         "sumchecker": "^3.0.1"
       },
       "engines": {
-        "node": ">=12"
+        "node": ">=22.12.0"
       },
       "optionalDependencies": {
-        "global-agent": "^3.0.0"
+        "undici": "^7.24.4"
       }
     },
     "node_modules/electron/node_modules/@types/node": {
-      "version": "22.19.17",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.19.17.tgz",
-      "integrity": "sha512-wGdMcf+vPYM6jikpS/qhg6WiqSV/OhG+jeeHT/KlVqxYfD40iYJf9/AE1uQxVWFvU7MipKRkRv8NSHiCGgPr8Q==",
+      "version": "24.13.3",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.13.3.tgz",
+      "integrity": "sha512-Dh8vAsV36ig5wa9OX4pXvMc9D3Veibfw2wix0CUwYODLD8nkj9UsLjASr49nPg+2eKzxhBV+v7L8pXvT4e639Q==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "undici-types": "~6.21.0"
+        "undici-types": "~7.18.0"
       }
     },
-    "node_modules/electron/node_modules/fs-extra": {
-      "version": "8.1.0",
-      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-8.1.0.tgz",
-      "integrity": "sha512-yhlQgA6mnOJUKOsRUFsgJdQCvkKhcz8tlZG5HBQfReYZy46OwLcY+Zia0mtdHsOo9y/hP+CxMN0TU9QxoOtG4g==",
+    "node_modules/electron/node_modules/env-paths": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/env-paths/-/env-paths-3.0.0.tgz",
+      "integrity": "sha512-dtJUTepzMW3Lm/NPxRf3wP4642UWhjL2sQxc+ym2YMj1m/H2zDNQOlezafzkHwn6sMstjHTwG6iQQsctDW/b1A==",
       "dev": true,
       "license": "MIT",
-      "dependencies": {
-        "graceful-fs": "^4.2.0",
-        "jsonfile": "^4.0.0",
-        "universalify": "^0.1.0"
-      },
       "engines": {
-        "node": ">=6 <7 || >=8"
-      }
-    },
-    "node_modules/electron/node_modules/semver": {
-      "version": "6.3.1",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
-      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
-      "dev": true,
-      "license": "ISC",
-      "bin": {
-        "semver": "bin/semver.js"
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/electron/node_modules/undici-types": {
-      "version": "6.21.0",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
-      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+      "version": "7.18.2",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.18.2.tgz",
+      "integrity": "sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w==",
       "dev": true,
       "license": "MIT"
     },


### PR DESCRIPTION
Clears **all 31 open Electron advisories** on `mcpjam-inspector/package.json` — 7 high, 18 medium, 6 low. That is ~7% of the entire open Dependabot queue from a one-line dependency change.

## Why 43 and not 39

Every one of the 31 advisories is fixed by `>= 39.8.10`, so 39 is the *minimum*. But Electron only patches its latest three majors, and 43 is current stable — landing on 39 would clear the queue today and start refilling it with the next Chromium CVE. 43 buys roughly a year instead of roughly zero.

## Why the blast radius is small

The main process uses a narrow, stable slice of the API:

```
app.getAppPath / getName / getPath / getVersion / isPackaged / isDefaultProtocolClient
app.on / whenReady / quit / relaunch / requestSingleInstanceLock
app.setAppUserModelId / setAsDefaultProtocolClient
BrowserWindow, ipcMain, shell.openExternal, shell.openPath
```

None of these changed across 38→43. The renderer is a normal React app, and the Chromium jump is the usual one any Electron upgrade carries.

## Verified

- `npm install` resolves clean; `node_modules/.bin/electron --version` → `v43.4.0`
- `npm run typecheck:client -w @mcpjam/inspector` ✅
- `npm run build:inspector` ✅
- **electron-forge's own Vite builds** of `src/main.ts`, `src/preload.ts`, and the renderer target all build against 43 ✅ — this is the part most likely to break on a six-major jump

## Not verified — please read before merging

`electron-forge package` does **not** complete in my environment. It stalls at `Finalizing package` (while extracting the Electron release zip) and exits without producing `out/`.

I checked whether that is this PR's fault: **an Electron 37 build from unmodified `main`, in a second worktree, stalls at exactly the same step.** So this is a local sandbox limitation, not a regression from the bump — but it does mean packaging is genuinely unproven for 43.

The release workflows (`mac-release.yml` / `windows-release.yml`) are `workflow_call` targets reached only through `release.yml`, which is `workflow_dispatch` and publishes real artifacts — so no PR check exercises packaging today. Before this ships in a desktop build, one of:

1. Someone runs `npm run electron:package -w @mcpjam/inspector` locally (unsandboxed, `NODE_OPTIONS=--max-old-space-size=8192` — the release workflows already set this, and without it the main-process bundle OOMs at Node's 4GB default) and launches the resulting `.app`; **or**
2. We add a packaging smoke job to PR CI. Arguably worth having permanently, given the desktop build currently has zero pre-release signal.

Worth noting `@electron/fuses` is at 2.1.1 (2.1.3 available) and the fuses plugin flips fuses during exactly the finalization step I could not reach — so if packaging does fail on 43 for real, that is the first place I would look.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit 6736c7b209226dbf74632b4e9db1802a919b8ddf. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Updates `electron` from 37.2.5 to 43.4.0 to clear 31 Electron security advisories and stay on a supported major. No intended behavior changes; the app uses only APIs unchanged across 38–43.

- Why 43: `>=39.8.10` fixes the advisories, but 39 is outside Electron’s support window; 43 is current stable.
- Dev/CI requirement: Installing `electron@43` requires Node >= 22.12.0.
- Verified: clean install; `electron --version` shows 43.4.0; `typecheck:client` and `build:inspector` pass; `electron-forge` Vite builds for main, preload, and renderer succeed.
- Packaging: Before a desktop release, package locally via `NODE_OPTIONS=--max-old-space-size=8192 npm run electron:package -w @mcpjam/inspector` and launch the app, or add a packaging smoke job in CI. If packaging fails, first check the `@electron/fuses` step during finalization.

<sup>Written for commit 6736c7b209226dbf74632b4e9db1802a919b8ddf. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/MCPJam/inspector/pull/4081?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

