### PR TITLE
feat(mcp): resolve and negotiate the dual-era protocol selection

### DIFF
--- a/mcpjam-inspector/client/src/components/connection/ServerDetailModal.tsx
+++ b/mcpjam-inspector/client/src/components/connection/ServerDetailModal.tsx
@@ -92,7 +92,7 @@ interface ServerDetailModalProps {
    * Undefined = no host-level pin = "Legacy · default" attribution on
    * the chip.
    */
-  hostDefaultMcpProtocolVersion?: McpProtocolVersion;
+  hostDefaultMcpProtocolVersion?: McpProtocolVersion | "auto";
   /** Project default XAA test identity — shown as override placeholders. */
   projectXaaDefaultIdentity?: { subject: string; email: string } | null;
 }
@@ -176,8 +176,12 @@ export function ServerDetailModal({
   // without forcing the Servers tab to also wire up the provider just
   // for the chip's source attribution.
   const activeMcpProfile = useActiveMcpProfile();
-  const resolvedHostDefaultMcpProtocolVersion: McpProtocolVersion | undefined =
+  const storedHostDefaultMcpProtocolVersion =
     hostDefaultMcpProtocolVersion ?? activeMcpProfile?.mcpProtocolVersion;
+  const resolvedHostDefaultMcpProtocolVersion: McpProtocolVersion | undefined =
+    storedHostDefaultMcpProtocolVersion === "auto"
+      ? undefined
+      : storedHostDefaultMcpProtocolVersion;
   const canEditMcpProtocolVersionOverride = Boolean(
     canQueryProjectServerConfig &&
       serverId &&

--- a/mcpjam-inspector/client/src/components/hosts/redesigned/focus/ProtocolTab.tsx
+++ b/mcpjam-inspector/client/src/components/hosts/redesigned/focus/ProtocolTab.tsx
@@ -43,10 +43,9 @@ import type { HostAttentionIssue } from "../types";
 import { useJsonDraftBuffer } from "./useJsonDraftBuffer";
 
 /**
- * "auto" is the UI-only sentinel for "no pin stored" — it maps to
- * `mcpProfile.mcpProtocolVersion === undefined`, NOT to a wire literal.
- * Deliberately not labelled with a version number: absence means the SDK
- * picks the version at connect time, so hardcoding a revision into that
+ * "auto" is a stored selection policy, NOT a wire literal. The SDK negotiates
+ * at connect time and never emits the string itself. Deliberately not labelled
+ * with a version number: hardcoding a revision into that
  * label would go stale the moment the SDK's default moves (the sequenced
  * Phase-5 `versionNegotiation: 'auto'` activation) without anything in
  * this file changing.
@@ -112,7 +111,7 @@ const HOST_PROTOCOL_OPTIONS: Array<{
 /**
  * Which versions this client may actually be pinned to.
  *
- * The backend refuses to store a STATEFUL pin the client does not also
+ * The backend refuses to store a concrete pin the client does not also
  * advertise in `initialize.supportedProtocolVersions` — the SDK's
  * `ConflictingProtocolVersionPin` rule in `canonicalizeMcpProfile`. Presets
  * carry that list (VS Code ships `["2025-11-25"]`), so offering every version
@@ -120,15 +119,12 @@ const HOST_PROTOCOL_OPTIONS: Array<{
  * opaque "Server Error". Offer what actually saves instead.
  *
  * The advertised list is the whole answer, INCLUDING for stateless revisions.
- * The backend only validates stateful pins (stateless ones skip the initialize
- * handshake, so `ConflictingProtocolVersionPin` never fires for them), but
- * "the backend would accept it" is not the same as "this client speaks it":
- * offering `2026-07-28` on a client that never advertised it emulates a
+ * Offering `2026-07-28` on a client that never advertised it would emulate a
  * product capability that does not exist. A client supports a revision when it
  * lists that revision — there is no separate stateless-support flag.
  *
  * Exempt from the filter:
- * - `"auto"`, which stores no pin at all and so claims nothing.
+ * - `"auto"`, which is a negotiation policy rather than a concrete pin.
  * - The stored value, so a row already pinned outside its own advertised list
  *   keeps rendering its selection instead of silently reading as "Automatic".
  *   Same don't-strand-the-user rule as the policy controls further down.
@@ -214,7 +210,7 @@ type ProtocolDoc = {
    * persistence; per-server pins live on the server card's Connection
    * overrides section.
    */
-  mcpProtocolVersion?: McpProtocolVersion;
+  mcpProtocolVersion?: HostProtocolDropdownValue;
   /**
    * Whether the simulated client mirrors `x-mcp-header` tool arguments into
    * `Mcp-Param-*` request headers (SEP-2243, 2026-07-28). Absent → `"mirror"`,
@@ -517,14 +513,13 @@ export function applyJsonToDraft(
     if (cleaned.length > 0) supportedProtocolVersions = cleaned;
   }
 
-  // mcpProtocolVersion — membership-gate via `isKnownProtocolVersion`
-  // so typo strings fall back to `undefined` (= "SDK default") rather
-  // than slipping through to the SDK's open-routing predicate. Absent
-  // / wrong type also collapses to undefined for the same canonical-
-  // hash-stability reason documented in the type.
-  let mcpProtocolVersion: McpProtocolVersion | undefined;
+  // `auto` is a stored selection policy; every other accepted value is a
+  // concrete wire revision. Typo strings still collapse to undefined.
+  let mcpProtocolVersion: HostProtocolDropdownValue | undefined;
   const rawProtocolVersion = parsed.mcpProtocolVersion;
-  if (
+  if (rawProtocolVersion === "auto") {
+    mcpProtocolVersion = "auto";
+  } else if (
     typeof rawProtocolVersion === "string" &&
     isKnownProtocolVersion(rawProtocolVersion)
   ) {
@@ -658,8 +653,10 @@ export function ProtocolTab({
   // "Automatic" — matching what the connect path does with them anyway.
   const storedProtocolVersion = draft.mcpProfile?.mcpProtocolVersion;
   const selectedDropdownValue: HostProtocolDropdownValue =
-    storedProtocolVersion !== undefined &&
-    isKnownProtocolVersion(storedProtocolVersion)
+    storedProtocolVersion === "auto"
+      ? "auto"
+      : storedProtocolVersion !== undefined &&
+        isKnownProtocolVersion(storedProtocolVersion)
       ? storedProtocolVersion
       : "auto";
 
@@ -677,23 +674,20 @@ export function ProtocolTab({
   );
   const protocolOptionsRestricted =
     protocolOptions.length < HOST_PROTOCOL_OPTIONS.length;
-  // A stored stateful pin outside the advertised list — a legacy row, or one
+  // A stored concrete pin outside the advertised list — a legacy row, or one
   // hand-edited in the JSON. Its option is force-kept (see the helper), which
   // can pad the list back to full length, so this must be detected directly
   // rather than inferred from the option count. Saving such a draft throws
   // `ConflictingProtocolVersionPin`; warn before Save does.
   const selectedPinUnadvertised =
     selectedDropdownValue !== "auto" &&
-    !isStatelessProtocolVersion(selectedDropdownValue) &&
     advertisedProtocolVersions !== undefined &&
     advertisedProtocolVersions.length > 0 &&
     !advertisedProtocolVersions.includes(selectedDropdownValue);
 
-  // Dropdown handler. Writes through to `draft.mcpProfile.mcpProtocolVersion`
-  // directly (parallel to the JSON editor's applyJsonToDraft path) so the
-  // JSON view round-trips immediately. Maps the UI-only "default" sentinel
-  // to `undefined` — preserves canonical-hash stability so the SDK can
-  // upgrade its default version without churning every stored host config.
+  // Dropdown handler. `undefined` here means the user selected Automatic;
+  // persist the explicit policy so ChatGPT's default can differ from a legacy
+  // row whose field is genuinely absent.
   const setProtocolVersion = (next: McpProtocolVersion | undefined) => {
     const warning = legacyProtocolSupportWarning(
       draft.hostStyle,
@@ -724,7 +718,7 @@ export function ProtocolTab({
       const updated: HostConfigMcpProfileV1 = {
         ...base,
         initialize,
-        mcpProtocolVersion: next,
+        mcpProtocolVersion: next ?? "auto",
       };
       return {
         ...prev,
@@ -858,7 +852,7 @@ export function ProtocolTab({
         <div className="flex items-center gap-3">
           <span
             className="text-[12px] font-medium"
-            title="Automatic: store no pin — MCPJam picks the wire version at connect time. Any other choice pins that exact revision for every server on this client."
+            title="Automatic: negotiate at connect time. Any other choice pins that exact revision for every server on this client."
           >
             {fProtocolVersion.label}
           </span>
@@ -893,7 +887,7 @@ export function ProtocolTab({
             materially, so they get their own copy: a stateless pin has no
             legacy fallback, while a stateful pin narrows the initialize
             handshake to that one version. "Automatic" gets no line — the
-            absence of a pin needs no explanation and keeps the panel quiet in
+            selection policy needs no extra explanation and keeps the panel quiet in
             the default state. */}
         {selectedDropdownValue !== "auto" && (
           <p className="mt-1.5 text-[11px] leading-snug text-muted-foreground">
@@ -905,8 +899,7 @@ export function ProtocolTab({
         {/* Without this line a preset-backed client reads as a broken control:
             the missing revisions look arbitrary, and the list that removed them
             is invisible unless the JSON editor below is open. Name both. The
-            claim is scoped to pre-2026 revisions — stateless versions skip the
-            initialize handshake and stay pinnable regardless of the list. */}
+            list constrains every concrete pin, including 2026. */}
         {protocolOptionsRestricted && (
           <p className="mt-1.5 text-[11px] leading-snug text-muted-foreground">
             This client advertises{" "}

--- a/mcpjam-inspector/client/src/components/hosts/redesigned/focus/__tests__/ProtocolTab.versionDropdown.test.tsx
+++ b/mcpjam-inspector/client/src/components/hosts/redesigned/focus/__tests__/ProtocolTab.versionDropdown.test.tsx
@@ -116,7 +116,7 @@ describe("ProtocolTab protocol-version dropdown", () => {
     expect(screen.getByTestId("pin").textContent).toBe("2025-06-18");
   });
 
-  it("defaults an unpinned host to Automatic and stores no pin", () => {
+  it("renders a legacy unpinned host as Automatic without rewriting it", () => {
     render(<Harness initial={emptyHostConfigInputV2()} />);
 
     expect(
@@ -125,7 +125,7 @@ describe("ProtocolTab protocol-version dropdown", () => {
     expect(screen.getByTestId("pin").textContent).toBe("<undefined>");
   });
 
-  it("selecting Latest pins 2026-07-28; returning to Automatic clears it", async () => {
+  it("selecting Latest pins 2026-07-28; returning to Automatic stores auto", async () => {
     const user = userEvent.setup();
     render(<Harness initial={emptyHostConfigInputV2()} />);
 
@@ -135,14 +135,12 @@ describe("ProtocolTab protocol-version dropdown", () => {
     await user.click(screen.getByRole("option", { name: /Latest/i }));
     expect(screen.getByTestId("pin").textContent).toBe("2026-07-28");
 
-    // Back to Automatic must restore ABSENCE, not a 2025 literal — a stored
-    // literal would churn the canonical config hash against every
-    // pre-feature row.
+    // Automatic is an explicit selection policy, not a wire protocol literal.
     await user.click(
       screen.getByRole("combobox", { name: "MCP protocol version" })
     );
     await user.click(screen.getByRole("option", { name: "Automatic" }));
-    expect(screen.getByTestId("pin").textContent).toBe("<undefined>");
+    expect(screen.getByTestId("pin").textContent).toBe("auto");
   });
 
   it("shows a stored legacy pin as itself instead of collapsing it", () => {
@@ -176,7 +174,7 @@ describe("ProtocolTab protocol-version dropdown", () => {
 });
 
 /**
- * The backend (`canonicalizeMcpProfile`) refuses to store a STATEFUL pin that
+ * The backend (`canonicalizeMcpProfile`) refuses to store a concrete pin that
  * is absent from `initialize.supportedProtocolVersions` —
  * `ConflictingProtocolVersionPin`. Preset-backed clients carry that list, so
  * offering the full set on them produced choices that failed at Save with an
@@ -257,11 +255,9 @@ describe("ProtocolTab dropdown vs. the client's advertised versions", () => {
       screen.getByRole("combobox", { name: "MCP protocol version" })
     );
 
-    // The backend WOULD accept a stateless pin here (it only validates
-    // stateful ones), but accepting it is not the same as the client speaking
-    // it: offering 2026-07-28 to a client that never advertised it emulates a
-    // capability the real product does not have. Only Automatic — which claims
-    // nothing — survives alongside the advertised revision.
+    // Every concrete pin is constrained by the advertised support list,
+    // including the stateless 2026 revision. Automatic remains available as
+    // the negotiation policy.
     expect(
       (await screen.findAllByRole("option")).map((o) => o.textContent)
     ).toEqual(["Automatic", "2025-11-25"]);
@@ -386,7 +382,7 @@ describe("ProtocolTab dropdown vs. the client's advertised versions", () => {
     ).toBeInTheDocument();
   });
 
-  it("does not warn on an advertised or stateless pin", () => {
+  it("does not warn on an advertised pin and warns on any unadvertised pin", () => {
     // Advertised pin: fine.
     const { unmount } = render(
       <Harness initial={withAdvertised(["2025-11-25"], "2025-11-25")} />
@@ -394,11 +390,8 @@ describe("ProtocolTab dropdown vs. the client's advertised versions", () => {
     expect(screen.queryByText(/does not advertise/)).toBeNull();
     unmount();
 
-    // Stateless pin: the dropdown no longer OFFERS an unadvertised stateless
-    // version, but a config that already carries one still saves — the backend
-    // rule never reaches it. The warning speaks only to save failure, so it
-    // must stay silent here rather than crying wolf.
+    // The stateless wire path also has to match the client's advertised list.
     render(<Harness initial={withAdvertised(["2025-11-25"], "2026-07-28")} />);
-    expect(screen.queryByText(/does not advertise/)).toBeNull();
+    expect(screen.getByText(/does not advertise/)).toBeInTheDocument();
   });
 });

--- a/mcpjam-inspector/client/src/lib/__tests__/client-config-v2-mcp-profile.test.ts
+++ b/mcpjam-inspector/client/src/lib/__tests__/client-config-v2-mcp-profile.test.ts
@@ -73,14 +73,12 @@ describe("resolveClientInfo", () => {
   });
 
   test("returns undefined when initialize.clientInfo is unset (even with profile present)", () => {
-    expect(
-      resolveClientInfo({ profileVersion: 1 }),
-    ).toBeUndefined();
+    expect(resolveClientInfo({ profileVersion: 1 })).toBeUndefined();
     expect(
       resolveClientInfo({
         profileVersion: 1,
         initialize: { supportedProtocolVersions: ["2025-11-25"] },
-      }),
+      })
     ).toBeUndefined();
   });
 
@@ -152,14 +150,13 @@ describe("emptyHostConfigInputV2 mcpProfile handling", () => {
     // (Hit this exact bug during initial test writing — shared mutable
     // fixtures + an aliasing assertion is a foot-gun.)
     const source = JSON.parse(
-      JSON.stringify(SAMPLE_PROFILE),
+      JSON.stringify(SAMPLE_PROFILE)
     ) as HostConfigMcpProfileV1;
     const partial: Partial<HostConfigInputV2> = { mcpProfile: source };
     const input = emptyHostConfigInputV2(partial);
     expect(input.mcpProfile).toEqual(SAMPLE_PROFILE);
     // Mutate the source — input must be unaffected.
-    (source.initialize!.clientInfo as Record<string, unknown>).name =
-      "mutated";
+    (source.initialize!.clientInfo as Record<string, unknown>).name = "mutated";
     expect(input.mcpProfile?.initialize?.clientInfo?.name).toBe("chatgpt");
   });
 });
@@ -173,7 +170,7 @@ describe("hostConfigDtoToInput mcpProfile round-trip", () => {
   test("DTO with mcpProfile → input with cloned mcpProfile", () => {
     // Same aliasing-test trap — deep-clone the fixture before mutation.
     const sourceProfile = JSON.parse(
-      JSON.stringify(SAMPLE_PROFILE),
+      JSON.stringify(SAMPLE_PROFILE)
     ) as HostConfigMcpProfileV1;
     const dto = { ...BASE_DTO, mcpProfile: sourceProfile };
     const input = hostConfigDtoToInput(dto);
@@ -282,7 +279,7 @@ describe("hostConfigInputsEqual mcpProfile semantics", () => {
 });
 
 describe("resolveEffectiveCompatRuntime — per-method capability matrix", () => {
-  test('host style with `compatRuntime.openaiApps: false` resolves to `{ injected: false }` regardless of overrides', () => {
+  test("host style with `compatRuntime.openaiApps: false` resolves to `{ injected: false }` regardless of overrides", () => {
     // Claude doesn't inject the shim. Per-method overrides without
     // injection are meaningless — the resolver must short-circuit.
     const result = resolveEffectiveCompatRuntime({
@@ -391,20 +388,20 @@ describe("resolveEffectiveCompatRuntime — per-method capability matrix", () =>
 // but the runtime always uses the host default).
 describe("resolveEffectiveMcpProtocolVersion — per-server override precedence", () => {
   test("server override wins over host default", () => {
-    expect(
-      resolveEffectiveMcpProtocolVersion("2026-07-28", "2025-11-25"),
-    ).toBe("2026-07-28");
+    expect(resolveEffectiveMcpProtocolVersion("2026-07-28", "2025-11-25")).toBe(
+      "2026-07-28"
+    );
   });
 
   test("host default applies when no server override", () => {
     expect(resolveEffectiveMcpProtocolVersion(undefined, "2025-11-25")).toBe(
-      "2025-11-25",
+      "2025-11-25"
     );
   });
 
   test("returns undefined when neither layer has an opinion (SDK default semantics)", () => {
     expect(resolveEffectiveMcpProtocolVersion(undefined, undefined)).toBe(
-      undefined,
+      undefined
     );
   });
 
@@ -413,9 +410,9 @@ describe("resolveEffectiveMcpProtocolVersion — per-server override precedence"
     // migration test, one legacy server overridden back to 2025-11-25.
     // The override must reach the connect path or the legacy server
     // will fail with -32004.
-    expect(
-      resolveEffectiveMcpProtocolVersion("2025-11-25", "2026-07-28"),
-    ).toBe("2025-11-25");
+    expect(resolveEffectiveMcpProtocolVersion("2025-11-25", "2026-07-28")).toBe(
+      "2025-11-25"
+    );
   });
 });
 
@@ -425,7 +422,10 @@ describe("isMcpProfileEmpty (shared by every profile write path)", () => {
     // inlined at four write sites, so a field one of them didn't know about
     // silently collapsed the profile — losing the user's setting on save.
     for (const profile of [
-      { profileVersion: 1 as const, paginationTraversal: "firstPageOnly" as const },
+      {
+        profileVersion: 1 as const,
+        paginationTraversal: "firstPageOnly" as const,
+      },
       { profileVersion: 1 as const, mrtrSupport: "none" as const },
       { profileVersion: 1 as const, toolParamHeaderMirroring: "omit" as const },
     ]) {
@@ -436,20 +436,18 @@ describe("isMcpProfileEmpty (shared by every profile write path)", () => {
   it("treats an EMPTY initialize envelope as empty", () => {
     // The canonicalizer drops an empty `initialize`, so persisting a profile
     // that holds only one would mint a row hashing identically to no profile.
-    expect(
-      isMcpProfileEmpty({ profileVersion: 1, initialize: {} }),
-    ).toBe(true);
+    expect(isMcpProfileEmpty({ profileVersion: 1, initialize: {} })).toBe(true);
     expect(
       isMcpProfileEmpty({
         profileVersion: 1,
         initialize: { supportedProtocolVersions: [] },
-      }),
+      })
     ).toBe(true);
     expect(
       isMcpProfileEmpty({
         profileVersion: 1,
         initialize: { supportedProtocolVersions: ["2026-07-28"] },
-      }),
+      })
     ).toBe(false);
   });
 

--- a/mcpjam-inspector/client/src/lib/host-config-field-schema.ts
+++ b/mcpjam-inspector/client/src/lib/host-config-field-schema.ts
@@ -471,15 +471,16 @@ export const HOST_CONFIG_FIELDS: ReadonlyArray<HostConfigFieldDef> = [
     label: "Protocol version",
     path: "mcpProfile.mcpProtocolVersion",
     description:
-      "Host default pin. Per-server overrides win. Undefined = SDK chooses at request time.",
+      'Host default selection. "auto" negotiates at connect time; concrete versions pin that exact era. Per-server overrides win.',
     kind: {
       kind: "enum",
       options: [
+        "auto",
         "2025-03-26",
         "2025-06-18",
         "2025-11-25",
         "2026-07-28",
-      ] as ReadonlyArray<McpProtocolVersion>,
+      ] as ReadonlyArray<McpProtocolVersion | "auto">,
     },
     read: (cfg) => mcpProfile(cfg)?.mcpProtocolVersion,
   },

--- a/sdk/src/host-config/defaults.ts
+++ b/sdk/src/host-config/defaults.ts
@@ -41,7 +41,8 @@ export const DEFAULT_TEMPERATURE_V2 = 0.7;
  */
 export function resolveEffectiveMcpProtocolVersion(
   serverOverride: McpProtocolVersion | undefined,
-  hostDefault: McpProtocolVersion | undefined,
+  hostDefault: McpProtocolVersion | "auto" | undefined
 ): McpProtocolVersion | undefined {
-  return serverOverride ?? hostDefault;
+  if (serverOverride !== undefined) return serverOverride;
+  return hostDefault === "auto" ? undefined : hostDefault;
 }

--- a/sdk/src/host-config/host-connection.ts
+++ b/sdk/src/host-config/host-connection.ts
@@ -61,7 +61,7 @@ function isRecord(value: unknown): value is Record<string, unknown> {
  * (Not the public `Host.toJSON()` shape, which uses `mcp.protocolVersion` etc.)
  */
 export function hostConnectionProfile(
-  hostConfig: Record<string, unknown>,
+  hostConfig: Record<string, unknown>
 ): HostConnectionProfile {
   const mcpProfile = isRecord(hostConfig.mcpProfile)
     ? hostConfig.mcpProfile
@@ -79,15 +79,16 @@ export function hostConnectionProfile(
     : undefined;
 
   const supportedProtocolVersions = Array.isArray(
-    initialize?.supportedProtocolVersions,
+    initialize?.supportedProtocolVersions
   )
     ? (initialize.supportedProtocolVersions as unknown[]).filter(
-        (v): v is string => typeof v === "string",
+        (v): v is string => typeof v === "string"
       )
     : undefined;
 
   const mcpProtocolVersion =
-    typeof mcpProfile?.mcpProtocolVersion === "string"
+    typeof mcpProfile?.mcpProtocolVersion === "string" &&
+    mcpProfile.mcpProtocolVersion !== "auto"
       ? mcpProfile.mcpProtocolVersion
       : undefined;
 

--- a/sdk/src/mcp-client-manager/MCPClientManager.ts
+++ b/sdk/src/mcp-client-manager/MCPClientManager.ts
@@ -2340,16 +2340,13 @@ export class MCPClientManager {
       const wantsStateless =
         resolvedProtocolVersion !== undefined &&
         isStatelessProtocolVersion(resolvedProtocolVersion);
-      // Resolve negotiation before the legacy initialize accept-list so Auto
-      // has one source of truth. An unpinned connection probes the modern era
-      // first and, on a legacy signal, must fall back with the upstream SDK's
-      // complete built-in supported-version list. Forwarding a persisted
-      // per-server or manager-default list here can make the first connection
-      // succeed but a later reconnect reject the server's valid counter-offer.
+      // Resolve negotiation independently from the client's support list. The
+      // list says which revisions the client can speak; the selection says
+      // whether to auto-negotiate or pin one era. Upstream uses the same list
+      // to constrain modern discovery candidates and legacy fallback.
       const versionNegotiation = resolveVersionNegotiation(
         resolvedProtocolVersion
       );
-      const wantsAutoNegotiation = versionNegotiation?.mode === "auto";
       // Stateful `mcpProtocolVersion` pin (e.g. `"2025-11-25"`) propagates
       // into the legacy `Client`'s `supportedProtocolVersions` accept-list
       // so `initialize.params.protocolVersion` actually goes out as the
@@ -2357,15 +2354,16 @@ export class MCPClientManager {
       // explicit `supportedProtocolVersions` (per-server or default) still
       // wins for an explicit pin — pinning at one layer while overriding the
       // other would be ambiguous and the override is the more specific signal.
-      // Auto deliberately ignores both lists so its legacy fallback negotiates
-      // against every version supported by the upstream SDK.
-      const resolvedSupportedProtocolVersions = wantsAutoNegotiation
-        ? undefined
-        : config.supportedProtocolVersions ??
-          this.defaultSupportedProtocolVersions ??
-          (!wantsStateless && resolvedProtocolVersion !== undefined
-            ? [resolvedProtocolVersion]
-            : undefined);
+      // Automatic mode honors the same declared support list. This is what
+      // lets a host truthfully say "2025-11-25 + 2026-07-28" once, then let
+      // the SDK select between those eras without accidentally falling back
+      // to some other legacy revision.
+      const resolvedSupportedProtocolVersions =
+        config.supportedProtocolVersions ??
+        this.defaultSupportedProtocolVersions ??
+        (!wantsStateless && resolvedProtocolVersion !== undefined
+          ? [resolvedProtocolVersion]
+          : undefined);
       // Send the version that was actually PINNED, not whatever happens to
       // sit at index 0 of the accept-list.
       //
@@ -2384,7 +2382,7 @@ export class MCPClientManager {
       //
       // A pin absent from the list is left alone: it would put a version on
       // the wire the client never claimed to speak. `canonicalizeMcpProfile`
-      // rejects that combination for stateful pins anyway, so this only
+      // rejects that combination for concrete host pins anyway, so this only
       // guards hand-built configs.
       const supportedProtocolVersions =
         !wantsStateless &&

--- a/sdk/tests/MCPClientManager.auto-protocol-reconnect.test.ts
+++ b/sdk/tests/MCPClientManager.auto-protocol-reconnect.test.ts
@@ -5,8 +5,9 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 let sseConstructedCount = 0;
 
 vi.mock("@modelcontextprotocol/client", async (importOriginal) => {
-  const actual =
-    await importOriginal<typeof import("@modelcontextprotocol/client")>();
+  const actual = await importOriginal<
+    typeof import("@modelcontextprotocol/client")
+  >();
   class SpySSEClientTransport extends actual.SSEClientTransport {
     constructor(url: URL, opts?: Record<string, unknown>) {
       super(url, opts as never);
@@ -19,9 +20,7 @@ vi.mock("@modelcontextprotocol/client", async (importOriginal) => {
   };
 });
 
-const { MCPClientManager } = await import(
-  "../src/mcp-client-manager/index.js"
-);
+const { MCPClientManager } = await import("../src/mcp-client-manager/index.js");
 
 const NEGOTIATED_VERSION = "2025-06-18";
 const STALE_ACCEPT_LIST = ["2025-11-25"];
@@ -130,7 +129,7 @@ describe("MCPClientManager Automatic legacy fallback", () => {
     await fixture.close();
   });
 
-  it("accepts 2025-06-18 after disconnect and reconnect despite a stale list", async () => {
+  it("honors a per-server support list after disconnect and reconnect", async () => {
     await manager.connectToServer("bart", {
       url: fixture.url,
       timeout: 5_000,
@@ -140,15 +139,13 @@ describe("MCPClientManager Automatic legacy fallback", () => {
     );
 
     await manager.removeServer("bart");
-    await manager.connectToServer("bart", {
-      url: fixture.url,
-      timeout: 5_000,
-      supportedProtocolVersions: STALE_ACCEPT_LIST,
-    });
-
-    expect(manager.getInitializationInfo("bart")?.protocolVersion).toBe(
-      NEGOTIATED_VERSION
-    );
+    await expect(
+      manager.connectToServer("bart", {
+        url: fixture.url,
+        timeout: 5_000,
+        supportedProtocolVersions: STALE_ACCEPT_LIST,
+      })
+    ).rejects.toThrow(/Server's protocol version is not supported: 2025-06-18/);
     const initializeRequests = fixture.requests.filter(
       (request) => request.rpcMethod === "initialize"
     );
@@ -156,24 +153,22 @@ describe("MCPClientManager Automatic legacy fallback", () => {
     expect(
       initializeRequests.map((request) => request.proposedProtocolVersion)
     ).toEqual(["2025-11-25", "2025-11-25"]);
-    expect(sseConstructedCount).toBe(0);
+    expect(sseConstructedCount).toBe(1);
   });
 
-  it("ignores a stale manager-default accept-list in Automatic mode", async () => {
+  it("honors the manager-default support list in Automatic mode", async () => {
     await manager.disconnectAllServers();
     manager = new MCPClientManager(
       {},
       { defaultSupportedProtocolVersions: STALE_ACCEPT_LIST }
     );
 
-    await manager.connectToServer("bart", {
-      url: fixture.url,
-      timeout: 5_000,
-    });
-
-    expect(manager.getInitializationInfo("bart")?.protocolVersion).toBe(
-      NEGOTIATED_VERSION
-    );
+    await expect(
+      manager.connectToServer("bart", {
+        url: fixture.url,
+        timeout: 5_000,
+      })
+    ).rejects.toThrow(/Server's protocol version is not supported: 2025-06-18/);
   });
 
   it("keeps an explicit legacy protocol pin strict", async () => {
@@ -244,7 +239,7 @@ describe("MCPClientManager Automatic legacy fallback", () => {
   it("leaves a pin that the accept-list does not contain alone", async () => {
     // Hoisting an unlisted pin would put a version on the wire this client
     // never claimed to speak. `canonicalizeMcpProfile` rejects that pairing
-    // for stateful pins, so this only guards hand-built configs.
+    // for concrete host pins, so this only guards hand-built configs.
     await manager.connectToServer("bart", {
       url: fixture.url,
       timeout: 5_000,

--- a/sdk/tests/host-config-defaults.test.ts
+++ b/sdk/tests/host-config-defaults.test.ts
@@ -12,32 +12,44 @@ describe("DEFAULT_TEMPERATURE_V2", () => {
 
 describe("resolveEffectiveMcpProtocolVersion", () => {
   it("returns the per-server override when present (server wins over host default)", () => {
-    expect(
-      resolveEffectiveMcpProtocolVersion("2025-06-18", "2025-11-25"),
-    ).toBe("2025-06-18");
+    expect(resolveEffectiveMcpProtocolVersion("2025-06-18", "2025-11-25")).toBe(
+      "2025-06-18"
+    );
   });
 
   it("returns the host default when the server has no override", () => {
+    expect(resolveEffectiveMcpProtocolVersion(undefined, "2025-11-25")).toBe(
+      "2025-11-25"
+    );
+  });
+
+  it("reduces the host Automatic policy to an unpinned connection", () => {
     expect(
-      resolveEffectiveMcpProtocolVersion(undefined, "2025-11-25"),
-    ).toBe("2025-11-25");
+      resolveEffectiveMcpProtocolVersion(undefined, "auto")
+    ).toBeUndefined();
+  });
+
+  it("lets a concrete per-server pin override the host Automatic policy", () => {
+    expect(resolveEffectiveMcpProtocolVersion("2026-07-28", "auto")).toBe(
+      "2026-07-28"
+    );
   });
 
   it("returns undefined when neither layer has an opinion — load-bearing sentinel: SDK chooses at request time", () => {
     expect(
-      resolveEffectiveMcpProtocolVersion(undefined, undefined),
+      resolveEffectiveMcpProtocolVersion(undefined, undefined)
     ).toBeUndefined();
   });
 
   it("returns the per-server override even when host default is also set (no merge)", () => {
-    expect(
-      resolveEffectiveMcpProtocolVersion("2026-07-28", "2025-03-26"),
-    ).toBe("2026-07-28");
+    expect(resolveEffectiveMcpProtocolVersion("2026-07-28", "2025-03-26")).toBe(
+      "2026-07-28"
+    );
   });
 
   it("returns the per-server override when host default is undefined", () => {
-    expect(
-      resolveEffectiveMcpProtocolVersion("2025-03-26", undefined),
-    ).toBe("2025-03-26");
+    expect(resolveEffectiveMcpProtocolVersion("2025-03-26", undefined)).toBe(
+      "2025-03-26"
+    );
   });
 });

--- a/sdk/tests/host-connection.test.ts
+++ b/sdk/tests/host-connection.test.ts
@@ -7,7 +7,7 @@ import {
 
 const profileFor = (id: HostTemplateId) =>
   hostConnectionProfile(
-    seedHostTemplate(id) as unknown as Record<string, unknown>,
+    seedHostTemplate(id) as unknown as Record<string, unknown>
   );
 
 const extensions = (caps: Record<string, unknown> | undefined) =>
@@ -17,14 +17,16 @@ describe("hostConnectionProfile", () => {
   it("derives Claude's identity + the MCP Apps UI capability", () => {
     const p = profileFor("claude");
     expect(p.clientInfo?.name).toBe("claude-ai");
-    expect(extensions(p.clientCapabilities)["io.modelcontextprotocol/ui"]).toBeDefined();
+    expect(
+      extensions(p.clientCapabilities)["io.modelcontextprotocol/ui"]
+    ).toBeDefined();
     // Claude's model filters app-only tools (default visibility policy).
     expect(p.respectToolVisibility).not.toBe(false);
   });
 
   it("pins Goose's advertised protocol version", () => {
     expect(profileFor("goose").supportedProtocolVersions).toContain(
-      "2025-03-26",
+      "2025-03-26"
     );
   });
 
@@ -54,8 +56,27 @@ describe("hostConnectionProfile", () => {
     expect(
       hostConnectionProfile({
         mcpProfile: { initialize: { mcpProtocolVersion: "2026-07-28" } },
-      }).mcpProtocolVersion,
+      }).mcpProtocolVersion
     ).toBeUndefined();
+  });
+
+  it("reduces auto to no wire pin while preserving the nested connection profile", () => {
+    const p = hostConnectionProfile({
+      mcpProfile: {
+        profileVersion: 1,
+        mcpProtocolVersion: "auto",
+        initialize: {
+          supportedProtocolVersions: ["2025-11-25", "2026-07-28"],
+          clientInfo: { name: "openai-mcp", version: "1.0.0" },
+        },
+      },
+    });
+    expect(p.mcpProtocolVersion).toBeUndefined();
+    expect(p.supportedProtocolVersions).toEqual(["2025-11-25", "2026-07-28"]);
+    expect(p.clientInfo).toMatchObject({
+      name: "openai-mcp",
+      version: "1.0.0",
+    });
   });
 
   describe("toolParamHeaderMirroring → mirrorToolParamHeaders", () => {

--- a/sdk/tests/host.test.ts
+++ b/sdk/tests/host.test.ts
@@ -112,6 +112,25 @@ describe("Host — public surface", () => {
     }
   });
 
+  it("round-trips automatic selection with the existing initialize profile", () => {
+    const host = new Host({ style: "chatgpt", model: "openai/gpt-5" });
+    host.mcp.protocolVersion = "auto";
+    host.mcp.initialize = {
+      supportedProtocolVersions: ["2025-11-25", "2026-07-28"],
+      clientInfo: { name: "openai-mcp", version: "1.0.0" },
+    };
+
+    const json = host.toJSON();
+    expect(json.mcp).toMatchObject({
+      protocolVersion: "auto",
+      initialize: {
+        supportedProtocolVersions: ["2025-11-25", "2026-07-28"],
+        clientInfo: { name: "openai-mcp", version: "1.0.0" },
+      },
+    });
+    expect(new Host(json).toJSON()).toEqual(json);
+  });
+
   it("serializes explicit MCP image policies", () => {
     const json = new Host({
       style: "mcpjam",

--- a/sdk/tests/support/dual-era-fixture.test.ts
+++ b/sdk/tests/support/dual-era-fixture.test.ts
@@ -16,32 +16,37 @@ import {
 
 function byMethod(
   exchanges: RawExchange[],
-  method: string,
+  method: string
 ): RawExchange | undefined {
-  return exchanges.find((e) => getWireField(e.request.json, "method") === method);
+  return exchanges.find(
+    (e) => getWireField(e.request.json, "method") === method
+  );
 }
 
-/**
- * Connect a modern-pinned client to the fixture in-process, capturing every
- * frame. `handler.fetch` serves the request without a socket — the URL is
- * never dialed.
- */
-async function connectModern() {
+async function connectFixture(mode?: "auto" | { pin: "2026-07-28" }) {
   const handler = createFixtureHandler();
   const cap = createCapturingFetch((input, init) =>
-    handler.fetch(new Request(input as string | URL, init)),
+    handler.fetch(new Request(input as string | URL, init))
   );
   const client = new Client(
     { name: "dual-era-fixture-test", version: "1.0.0" },
-    { versionNegotiation: { mode: { pin: "2026-07-28" } } },
+    mode === undefined
+      ? undefined
+      : {
+          supportedProtocolVersions: ["2025-11-25", "2026-07-28"],
+          versionNegotiation: { mode },
+        }
   );
   const transport = new StreamableHTTPClientTransport(
     new URL("http://fixture.local/mcp"),
-    { fetch: cap.fetch },
+    { fetch: cap.fetch }
   );
   await client.connect(transport);
   return { client, cap };
 }
+
+const connectModern = () => connectFixture({ pin: "2026-07-28" });
+const connectAutomatic = () => connectFixture("auto");
 
 /**
  * Connect a default (legacy) client to the SAME handler. `createMcpHandler`
@@ -49,17 +54,7 @@ async function connectModern() {
  * client runs the ordinary `initialize` handshake.
  */
 async function connectLegacy() {
-  const handler = createFixtureHandler();
-  const cap = createCapturingFetch((input, init) =>
-    handler.fetch(new Request(input as string | URL, init)),
-  );
-  const client = new Client({ name: "dual-era-fixture-test", version: "1.0.0" });
-  const transport = new StreamableHTTPClientTransport(
-    new URL("http://fixture.local/mcp"),
-    { fetch: cap.fetch },
-  );
-  await client.connect(transport);
-  return { client, cap };
+  return connectFixture();
 }
 
 describe("dual-era fixture — modern (2026-07-28)", () => {
@@ -71,7 +66,9 @@ describe("dual-era fixture — modern (2026-07-28)", () => {
     expect(tools.tools.map((t) => t.name)).toContain("echo");
 
     const resources = await client.listResources();
-    expect(resources.resources.map((r) => r.uri)).toContain(FIXTURE_GREETING_URI);
+    expect(resources.resources.map((r) => r.uri)).toContain(
+      FIXTURE_GREETING_URI
+    );
 
     const prompts = await client.listPrompts();
     expect(prompts.prompts.map((p) => p.name)).toContain("welcome");
@@ -94,16 +91,21 @@ describe("dual-era fixture — modern (2026-07-28)", () => {
     await client.listTools();
     const readResult = await client.readResource({ uri: FIXTURE_GREETING_URI });
     expect(
-      Array.isArray(readResult.contents) ? readResult.contents[0]?.text : undefined,
+      Array.isArray(readResult.contents)
+        ? readResult.contents[0]?.text
+        : undefined
     ).toBe("hello from the fixture");
 
     // server/discover fired during connect (SEP-2575).
     expect(byMethod(cap.exchanges, "server/discover")).toBeDefined();
+    expect(byMethod(cap.exchanges, "initialize")).toBeUndefined();
 
     // resultType is REQUIRED on every modern result (SEP-2322).
     const list = byMethod(cap.exchanges, "tools/list");
     expect(list, "tools/list exchange captured").toBeDefined();
-    expect(getWireField(list!.response.json, "result.resultType")).toBe("complete");
+    expect(getWireField(list!.response.json, "result.resultType")).toBe(
+      "complete"
+    );
 
     // CacheableResult: ttlMs + cacheScope on list/read results (SEP-2549). The
     // server always emits both on the modern era (defaulting to 0 / 'private').
@@ -121,7 +123,7 @@ describe("dual-era fixture — modern (2026-07-28)", () => {
         "params",
         "_meta",
         "io.modelcontextprotocol/protocolVersion",
-      ]),
+      ])
     ).toBe("2026-07-28");
 
     // No sessions in the modern era (SEP-2567): the server must never mint one.
@@ -133,6 +135,16 @@ describe("dual-era fixture — modern (2026-07-28)", () => {
   });
 });
 
+describe("dual-era fixture — automatic selection", () => {
+  it("selects modern via server/discover without initialize", async () => {
+    const { client, cap } = await connectAutomatic();
+    expect(client.getProtocolEra()).toBe("modern");
+    expect(byMethod(cap.exchanges, "server/discover")).toBeDefined();
+    expect(byMethod(cap.exchanges, "initialize")).toBeUndefined();
+    await client.close();
+  });
+});
+
 describe("dual-era fixture — legacy (2025-era)", () => {
   it("serves the same handler over the legacy era with no modern wire members", async () => {
     const { client, cap } = await connectLegacy();
@@ -140,6 +152,7 @@ describe("dual-era fixture — legacy (2025-era)", () => {
 
     const tools = await client.listTools();
     expect(tools.tools.map((t) => t.name)).toContain("echo");
+    expect(byMethod(cap.exchanges, "initialize")).toBeDefined();
 
     // The legacy era carries no `resultType` on the wire — the modern-only
     // member must not leak onto a 2025-era result.


### PR DESCRIPTION
Stacked on #4085 — merge that first. Replaces #3828, which mixed data and behavior; this is the behavior half.

- Makes the app actually act on the `auto` protocol setting that #4085 publishes.
- On connect, `auto` means "don't pin a version" — the client negotiates the era with the server instead of announcing one up front.
- The host's protocol dropdown gains the matching Automatic option.
- No catalog or host data changes here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Implements automatic MCP protocol negotiation across the 2025/2026 eras and treats "auto" as a stored selection policy. Automatic now negotiates the era on connect (no wire pin) and respects the client’s advertised support list, which can change reconnect behavior.

- Host defaults may now be `"auto"`. At connect time the SDK reduces `"auto"` to no pin and negotiates via discovery; explicit server pins still win. The connection profile never emits `"auto"` on the wire.
- The manager honors `supportedProtocolVersions` in Automatic mode (per-server or manager default). It negotiates only within that list and rejects servers that counter-offer an unlisted version. Explicit pins remain strict.
- The protocol dropdown adds an Automatic option. Selecting it persists `"auto"`; legacy rows with no pin render as Automatic without rewriting. The dropdown only offers advertised versions and warns on any unadvertised pin.

**Review and rollout**
- Config shape: `mcpProfile.mcpProtocolVersion` can be `"auto"` in stored configs and Host JSON; connection profiles still carry `undefined` for the wire pin.
- If you set `supportedProtocolVersions` (per server or manager default), include all eras you want to negotiate; Automatic will fail when the server selects a version outside that list. No data migration is required.

<sup>Written for commit 008b419659a4140ec75f423f224d3b748f4812e9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/MCPJam/inspector/pull/4086?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

