### PR TITLE
fix(chat): prevent headerless local Playground turns

### DIFF
--- a/mcpjam-inspector/client/src/components/ui-playground/__tests__/multi-model-playground-card.broadcast-replay.test.tsx
+++ b/mcpjam-inspector/client/src/components/ui-playground/__tests__/multi-model-playground-card.broadcast-replay.test.tsx
@@ -1,0 +1,280 @@
+import { useState } from "react";
+import { render, screen, waitFor } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { MultiModelPlaygroundCard } from "../multi-model-playground-card";
+import type { MultiModelCardSummary } from "@/components/chat-v2/model-compare-card-header";
+
+vi.mock("use-stick-to-bottom", () => {
+  const StickToBottomComponent = ({
+    children,
+  }: {
+    children: React.ReactNode;
+  }) => <div data-testid="stick-to-bottom">{children}</div>;
+  StickToBottomComponent.Content = ({
+    children,
+  }: {
+    children: React.ReactNode;
+  }) => <div>{children}</div>;
+
+  return {
+    StickToBottom: StickToBottomComponent,
+    useStickToBottomContext: () => ({
+      isAtBottom: true,
+      scrollToBottom: vi.fn(),
+    }),
+  };
+});
+
+const mockUseChatSession = {
+  // Elicitation surface (hosted). These suites never elicit, but the shape
+  // must match the hook's contract or the dialog crashes on undefined.
+  pendingElicitations: [],
+  respondToElicitation: vi.fn(),
+  elicitationResponding: false,
+  urlElicitationRequired: [],
+  dismissUrlElicitationRequired: vi.fn(),
+  messages: [],
+  setMessages: vi.fn(),
+  sendMessage: vi.fn(),
+  stop: vi.fn(),
+  status: "ready",
+  error: undefined,
+  chatSessionId: "chat-session-1",
+  toolsMetadata: {},
+  toolServerMap: {},
+  liveTraceEnvelope: null,
+  requestPayloadHistory: [],
+  hasTraceSnapshot: false,
+  hasLiveTimelineContent: false,
+  traceViewsSupported: true,
+  isStreaming: false,
+  isSessionBootstrapComplete: true,
+  addToolApprovalResponse: vi.fn(),
+  systemPrompt: "",
+  startChatWithMessages: vi.fn(),
+};
+
+vi.mock("@/hooks/use-chat-session", () => ({
+  useChatSession: () => mockUseChatSession,
+}));
+
+vi.mock("@/components/chat-v2/thread", () => ({
+  Thread: () => <div data-testid="thread" />,
+}));
+
+vi.mock("@/components/evals/trace-viewer", () => ({
+  TraceViewer: () => <div data-testid="trace-viewer" />,
+}));
+
+vi.mock("@/components/chat-v2/error", () => ({
+  ErrorBox: () => <div data-testid="error-box" />,
+}));
+
+vi.mock("@/components/chat-v2/shared/chat-helpers", async (importOriginal) => {
+  const actual = await importOriginal<
+    typeof import("@/components/chat-v2/shared/chat-helpers")
+  >();
+  return {
+    ...actual,
+    formatErrorMessage: () => null,
+  };
+});
+
+vi.mock("@/components/chat-v2/model-compare-card-header", () => ({
+  ModelCompareCardHeader: ({
+    model,
+    showComparisonChrome = true,
+    showTraceTabs,
+  }: {
+    model: { name: string };
+    showComparisonChrome?: boolean;
+    showTraceTabs: boolean;
+  }) => {
+    if (!showComparisonChrome && !showTraceTabs) {
+      return null;
+    }
+    return <div data-testid="compare-card-header">{model.name}</div>;
+  },
+}));
+
+vi.mock("@/stores/preferences/preferences-provider", () => ({
+  usePreferencesStore: <T,>(selector: (state: any) => T): T =>
+    selector({ hostCapabilitiesOverride: null }),
+}));
+
+vi.mock("@/contexts/scenario-client-style-context", () => ({
+  ScenarioHostStyleProvider: ({ children }: { children: React.ReactNode }) => (
+    <>{children}</>
+  ),
+  ScenarioHostThemeProvider: ({ children }: { children: React.ReactNode }) => (
+    <>{children}</>
+  ),
+  ScenarioChatUiOverrideProvider: ({
+    children,
+  }: {
+    children: React.ReactNode;
+  }) => <>{children}</>,
+  useScenarioChatUiOverride: () => undefined,
+}));
+
+vi.mock("@/contexts/scenario-client-capabilities-override-context", () => ({
+  ScenarioHostCapabilitiesOverrideProvider: ({
+    children,
+  }: {
+    children: React.ReactNode;
+  }) => <>{children}</>,
+  useScenarioHostCapabilitiesOverride: () => undefined,
+}));
+
+vi.mock("@/contexts/active-mcp-profile-context", () => ({
+  ActiveMcpProfileProvider: ({ children }: { children: React.ReactNode }) => (
+    <>{children}</>
+  ),
+  useActiveMcpProfile: () => undefined,
+}));
+
+vi.mock("@/contexts/active-host-client-capabilities-context", () => ({
+  ActiveHostCapsResolverScope: ({
+    children,
+  }: {
+    children: React.ReactNode;
+  }) => <>{children}</>,
+}));
+
+vi.mock("@/stores/preferences/preferences-provider", () => ({
+  usePreferencesStore: () => null,
+}));
+
+const model = {
+  id: "openai/gpt-5-mini",
+  name: "GPT-5 Mini",
+  provider: "openai" as const,
+};
+
+function Harness() {
+  const [summaries, setSummaries] = useState<
+    Record<string, MultiModelCardSummary>
+  >({});
+  const [messageFlags, setMessageFlags] = useState<Record<string, boolean>>({});
+
+  return (
+    <div>
+      <div data-testid="summary-count">{Object.keys(summaries).length}</div>
+      <div data-testid="message-flag-count">
+        {Object.keys(messageFlags).length}
+      </div>
+      <MultiModelPlaygroundCard
+        compareId={String(model.id)}
+        compareLabel={model.name}
+        compareKind="model"
+        model={model}
+        comparisonSummaries={Object.values(summaries)}
+        selectedServers={[]}
+        broadcastRequest={null}
+        deterministicExecutionRequest={null}
+        stopRequestId={0}
+        executionConfig={{
+          systemPrompt: "",
+          temperature: 0.7,
+          requireToolApproval: false,
+        }}
+        displayMode="inline"
+        onDisplayModeChange={vi.fn()}
+        hostStyle="chatgpt"
+        effectiveThreadTheme="light"
+        deviceType="mobile"
+        onSummaryChange={(summary) =>
+          setSummaries((previous) => ({
+            ...previous,
+            [summary.modelId]: summary,
+          }))
+        }
+        onHasMessagesChange={(modelId, hasMessages) =>
+          setMessageFlags((previous) => ({
+            ...previous,
+            [modelId]: hasMessages,
+          }))
+        }
+      />
+    </div>
+  );
+}
+
+describe("a freshly mounted card defers a queued turn until auth bootstrap", () => {
+  /**
+   * The card owns its OWN `useChatSession`, so it owns its own async auth
+   * bootstrap. A stored `broadcastRequest` can exist on the first render after
+   * a host switch. The card must leave it unconsumed until its own session
+   * bootstrap completes, then replay it exactly once.
+   */
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockUseChatSession.isSessionBootstrapComplete = false;
+  });
+
+  const request = {
+    id: 1,
+    text: "hello",
+    files: undefined,
+    prependMessages: [],
+    widgetModelContext: [],
+  };
+
+  function cardWithBroadcast(broadcastRequest: unknown) {
+    return (
+      <MultiModelPlaygroundCard
+        compareId="host-1"
+        compareLabel="Cursor"
+        compareKind="host"
+        model={model}
+        comparisonSummaries={[]}
+        selectedServers={[]}
+        broadcastRequest={broadcastRequest as never}
+        deterministicExecutionRequest={null}
+        stopRequestId={0}
+        executionConfig={{
+          systemPrompt: "",
+          temperature: 0.7,
+          requireToolApproval: false,
+        }}
+        displayMode="inline"
+        onDisplayModeChange={vi.fn()}
+        hostStyle="chatgpt"
+        effectiveThreadTheme="light"
+        deviceType="mobile"
+        onSummaryChange={vi.fn()}
+        onHasMessagesChange={vi.fn()}
+        showComparisonChrome={false}
+      />
+    );
+  }
+
+  function renderWithBroadcast(broadcastRequest: unknown) {
+    return render(cardWithBroadcast(broadcastRequest));
+  }
+
+  it("defers the queued turn, then sends it once bootstrap completes", async () => {
+    const view = renderWithBroadcast(request);
+    expect(mockUseChatSession.sendMessage).not.toHaveBeenCalled();
+
+    mockUseChatSession.isSessionBootstrapComplete = true;
+    view.rerender(cardWithBroadcast(request));
+
+    await waitFor(() =>
+      expect(mockUseChatSession.sendMessage).toHaveBeenCalledTimes(1)
+    );
+    expect(mockUseChatSession.sendMessage).toHaveBeenCalledWith(
+      expect.objectContaining({ text: "hello" })
+    );
+
+    view.rerender(cardWithBroadcast(request));
+    expect(mockUseChatSession.sendMessage).toHaveBeenCalledTimes(1);
+  });
+
+  it("stays quiet when there is nothing queued (isolates the trigger)", async () => {
+    mockUseChatSession.isSessionBootstrapComplete = true;
+    renderWithBroadcast(null);
+    await waitFor(() => expect(true).toBe(true));
+    expect(mockUseChatSession.sendMessage).not.toHaveBeenCalled();
+  });
+});

--- a/mcpjam-inspector/client/src/components/ui-playground/multi-model-playground-card.tsx
+++ b/mcpjam-inspector/client/src/components/ui-playground/multi-model-playground-card.tsx
@@ -337,6 +337,7 @@ export function MultiModelPlaygroundCard({
     hasLiveTimelineContent,
     traceViewsSupported,
     isStreaming,
+    isSessionBootstrapComplete,
     addToolApprovalResponse,
     startChatWithMessages,
   } = useChatSession({
@@ -528,6 +529,10 @@ export function MultiModelPlaygroundCard({
   }, [modelContextQueue]);
 
   useEffect(() => {
+    if (!isSessionBootstrapComplete) {
+      return;
+    }
+
     if (!broadcastRequest) {
       return;
     }
@@ -558,6 +563,7 @@ export function MultiModelPlaygroundCard({
   }, [
     broadcastRequest,
     drainModelContextQueue,
+    isSessionBootstrapComplete,
     sendMessage,
     setMessages,
     outgoingSenderMetadata,

--- a/mcpjam-inspector/client/src/hooks/__tests__/use-chat-session.auth-bootstrap-window.test.tsx
+++ b/mcpjam-inspector/client/src/hooks/__tests__/use-chat-session.auth-bootstrap-window.test.tsx
@@ -203,4 +203,24 @@ describe("useChatSession — request-time chat Authorization", () => {
       expect(transport.headers?.Authorization).toBeUndefined();
     }
   });
+
+  it("propagates bearer lookup failures without restoring cached Authorization", async () => {
+    const error = new Error("bearer lookup failed");
+    mockState.authFetch.mockRejectedValueOnce(error);
+
+    renderHook(() =>
+      useChatSession({ selectedServers: ["server-1"] } as never)
+    );
+    await waitFor(() =>
+      expect(mockState.transportOptions.length).toBeGreaterThan(0)
+    );
+
+    const transport = mockState.transportOptions.at(-1)!;
+    await expect(
+      transport.fetch?.("/api/mcp/chat-v2", { method: "POST" })
+    ).rejects.toBe(error);
+    for (const option of mockState.transportOptions) {
+      expect(option.headers?.Authorization).toBeUndefined();
+    }
+  });
 });

--- a/mcpjam-inspector/client/src/hooks/__tests__/use-chat-session.auth-bootstrap-window.test.tsx
+++ b/mcpjam-inspector/client/src/hooks/__tests__/use-chat-session.auth-bootstrap-window.test.tsx
@@ -1,0 +1,206 @@
+import { renderHook, waitFor } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { useChatSession } from "../use-chat-session";
+
+/**
+ * Regression coverage for the auth-bootstrap window behind the `Bearer ` 502.
+ *
+ * `useChatSession` resolves its Authorization header ASYNCHRONOUSLY
+ * (`getAccessToken()` → guest fallback). Until that settles, `authHeaders` is
+ * undefined. The transport must not snapshot that state; its fetch resolves
+ * the bearer through authFetch at the moment the request is sent.
+ */
+const mockState = vi.hoisted(() => ({
+  chatOnData: null as ((part: unknown) => void) | null,
+  transportOptions: [] as Array<{
+    body?: () => Record<string, unknown>;
+    headers?: Record<string, string>;
+    fetch?: (input: RequestInfo | URL, init?: RequestInit) => Promise<Response>;
+  }>,
+  chatStatus: "ready" as string,
+  messages: [] as unknown[],
+  convexMutation: vi.fn(async () => ({ ok: true })),
+  setMessages: vi.fn(),
+  sendMessage: vi.fn(async () => {}),
+  stop: vi.fn(),
+  addToolApprovalResponse: vi.fn(),
+  authFetch: vi.fn(),
+  // A member (WorkOS) bearer by default → authIsMemberRef true. Individual
+  // tests flip it to null to model a signed-out guest.
+  getAccessToken: vi.fn(async () => "workos-jwt"),
+  hasToken: vi.fn(() => false),
+  getToken: vi.fn(() => ""),
+  getOpenRouterSelectedModels: vi.fn(() => []),
+  getOllamaBaseUrl: vi.fn(() => "http://127.0.0.1:11434"),
+  getAzureBaseUrl: vi.fn(() => ""),
+  getCustomProviderByName: vi.fn(),
+  setSelectedModelId: vi.fn(),
+  getToolsMetadata: vi.fn(async () => ({
+    metadata: {},
+    toolServerMap: {},
+    tokenCounts: null,
+  })),
+  countTextTokens: vi.fn(async () => null),
+  convexAuth: { isAuthenticated: true, isLoading: false },
+  detectOllamaModels: vi.fn(async () => ({
+    isRunning: false,
+    availableModels: [],
+  })),
+  detectOllamaToolCapableModels: vi.fn(async () => []),
+  idCounter: 0,
+}));
+
+const byokModel = { id: "gpt-4", name: "GPT-4", provider: "openai" as const };
+
+function nextSessionId() {
+  mockState.idCounter += 1;
+  return `chat-session-${mockState.idCounter}`;
+}
+
+vi.mock("@/state/oauth-orchestrator", () => ({
+  applyToolCallStepUp: vi.fn(),
+}));
+vi.mock("@/lib/config", () => ({ HOSTED_MODE: false }));
+vi.mock("@/components/chat-v2/shared/model-helpers", () => ({
+  buildAvailableModels: vi.fn(() => [byokModel]),
+  getDefaultModel: vi.fn(() => byokModel),
+  isMCPJamProvidedModelMenuItem: vi.fn(() => false),
+}));
+vi.mock("@/hooks/use-hosted-model-catalog", () => ({
+  useHostedModelCatalog: () => ({ hostedCatalog: [], status: "fallback" }),
+}));
+vi.mock("@/hooks/use-ai-provider-keys", () => ({
+  useAiProviderKeys: () => ({
+    hasToken: mockState.hasToken,
+    getToken: mockState.getToken,
+    getOpenRouterSelectedModels: mockState.getOpenRouterSelectedModels,
+    getOllamaBaseUrl: mockState.getOllamaBaseUrl,
+    getAzureBaseUrl: mockState.getAzureBaseUrl,
+  }),
+}));
+vi.mock("@/hooks/use-custom-providers", () => ({
+  useCustomProviders: () => ({
+    customProviders: [],
+    getCustomProviderByName: mockState.getCustomProviderByName,
+  }),
+}));
+vi.mock("@/hooks/use-persisted-model", () => ({
+  usePersistedModel: () => ({
+    selectedModelId: "gpt-4",
+    setSelectedModelId: mockState.setSelectedModelId,
+    selectedModelIds: ["gpt-4"],
+    setSelectedModelIds: vi.fn(),
+    multiModelEnabled: false,
+    setMultiModelEnabled: vi.fn(),
+  }),
+}));
+vi.mock("@/hooks/useSharedChatWidgetCapture", () => ({
+  useSharedChatWidgetCapture: vi.fn(),
+}));
+vi.mock("@/lib/ollama-utils", () => ({
+  detectOllamaModels: mockState.detectOllamaModels,
+  detectOllamaToolCapableModels: mockState.detectOllamaToolCapableModels,
+}));
+vi.mock("@/lib/apis/mcp-tools-api", () => ({
+  getToolsMetadata: mockState.getToolsMetadata,
+}));
+vi.mock("@/lib/apis/mcp-tokenizer-api", () => ({
+  countTextTokens: mockState.countTextTokens,
+}));
+vi.mock("@/lib/session-token", () => ({
+  authFetch: mockState.authFetch,
+  getAuthHeaders: vi.fn(() => ({})),
+}));
+vi.mock("@workos-inc/authkit-react", () => ({
+  useAuth: () => ({ getAccessToken: mockState.getAccessToken }),
+}));
+vi.mock("convex/react", () => ({
+  useConvexAuth: () => mockState.convexAuth,
+  useQuery: () => undefined,
+  useConvex: () => ({ mutation: mockState.convexMutation }),
+}));
+vi.mock("@ai-sdk/react", () => ({
+  useChat: vi.fn((options: { onData?: (part: unknown) => void }) => {
+    mockState.chatOnData = options.onData ?? null;
+    return {
+      messages: mockState.messages,
+      sendMessage: mockState.sendMessage,
+      stop: mockState.stop,
+      status: mockState.chatStatus,
+      error: undefined,
+      setMessages: mockState.setMessages,
+      addToolApprovalResponse: mockState.addToolApprovalResponse,
+    };
+  }),
+}));
+vi.mock("ai", () => ({
+  DefaultChatTransport: class MockTransport {
+    constructor(options: {
+      body?: () => Record<string, unknown>;
+      headers?: Record<string, string>;
+      fetch?: (
+        input: RequestInfo | URL,
+        init?: RequestInit
+      ) => Promise<Response>;
+    }) {
+      mockState.transportOptions.push(options);
+    }
+  },
+  generateId: vi.fn(() => nextSessionId()),
+  lastAssistantMessageIsCompleteWithApprovalResponses: vi.fn(),
+  convertToModelMessages: vi.fn(async () => []),
+}));
+
+/** A token fetch that never settles — models the in-flight bootstrap. */
+function pendingAccessToken() {
+  return new Promise<string>(() => {});
+}
+
+function transportAt(index: number) {
+  const t = mockState.transportOptions[index];
+  return (t?.headers ?? {}) as Record<string, string>;
+}
+
+describe("useChatSession — request-time chat Authorization", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    localStorage.clear();
+    mockState.chatOnData = null;
+    mockState.transportOptions = [];
+    mockState.chatStatus = "ready";
+    mockState.idCounter = 0;
+    mockState.messages = [];
+    mockState.getAccessToken.mockResolvedValue("workos-jwt");
+    mockState.authFetch.mockResolvedValue(new Response("", { status: 200 }));
+  });
+
+  it("delegates a pre-bootstrap local chat request to authFetch", async () => {
+    mockState.getAccessToken.mockImplementation(pendingAccessToken);
+
+    renderHook(() =>
+      useChatSession({ selectedServers: ["server-1"] } as never)
+    );
+    await waitFor(() => expect(mockState.chatOnData).not.toBeNull());
+
+    const transport = mockState.transportOptions.at(-1)!;
+    const headers = transportAt(mockState.transportOptions.length - 1);
+    expect(headers.Authorization).toBeUndefined();
+
+    const init = { method: "POST" };
+    await transport.fetch?.("/api/mcp/chat-v2", init);
+
+    expect(mockState.authFetch).toHaveBeenCalledWith("/api/mcp/chat-v2", init);
+  });
+
+  it("never snapshots Authorization into transport headers", async () => {
+    renderHook(() =>
+      useChatSession({ selectedServers: ["server-1"] } as never)
+    );
+    await waitFor(() =>
+      expect(mockState.transportOptions.length).toBeGreaterThan(1)
+    );
+    for (const transport of mockState.transportOptions) {
+      expect(transport.headers?.Authorization).toBeUndefined();
+    }
+  });
+});

--- a/mcpjam-inspector/client/src/hooks/__tests__/use-chat-session.minimal-mode.test.tsx
+++ b/mcpjam-inspector/client/src/hooks/__tests__/use-chat-session.minimal-mode.test.tsx
@@ -311,9 +311,13 @@ describe("useChatSession minimal mode parity", () => {
     mockGetAccessToken.mockResolvedValue(null);
     mockGetGuestBearerToken.mockReset();
     mockGetGuestBearerToken.mockResolvedValue("guest-token");
-    mockAuthFetch.mockResolvedValue(new Response(null, { status: 200 }));
     mockWindowFetch.mockReset();
     mockWindowFetch.mockResolvedValue(new Response(null, { status: 200 }));
+    mockAuthFetch.mockReset();
+    mockAuthFetch.mockImplementation(
+      (input: RequestInfo | URL, init?: RequestInit) =>
+        mockWindowFetch(input, init)
+    );
     vi.stubGlobal("fetch", mockWindowFetch);
     useMCPJamLimitDialogStore.setState({
       authStatus: "guest",
@@ -609,7 +613,7 @@ describe("useChatSession minimal mode parity", () => {
     warnSpy.mockRestore();
   });
 
-  it("keeps non-hosted chat off authFetch while using modal-aware fetch", async () => {
+  it("uses request-time authFetch for non-hosted chat", async () => {
     const selectedServers = ["server-1"];
     const { result } = renderHook(() =>
       useChatSession({
@@ -628,9 +632,9 @@ describe("useChatSession minimal mode parity", () => {
     const latestTransport = mockTransportInstances.at(-1)!;
     expect(latestTransport.options.api).toBe("/api/mcp/chat-v2");
     expect(latestTransport.options.fetch).toEqual(expect.any(Function));
-    expect(await resolveConfig(latestTransport.options.headers)).toEqual({
-      Authorization: "Bearer guest-token",
-    });
+    expect(
+      await resolveConfig(latestTransport.options.headers)
+    ).toBeUndefined();
 
     act(() => {
       result.current.sendMessage({ text: "hello" });
@@ -644,14 +648,14 @@ describe("useChatSession minimal mode parity", () => {
       ).toBe(true);
     });
     expect(getUsedTransport().options.api).toBe("/api/mcp/chat-v2");
-    expect(mockWindowFetch).toHaveBeenCalledWith(
+    expect(mockAuthFetch).toHaveBeenCalledWith(
       "/api/mcp/chat-v2",
       expect.objectContaining({
         method: "POST",
-        headers: { Authorization: "Bearer guest-token" },
       })
     );
-    expect(mockAuthFetch).not.toHaveBeenCalled();
+    const requestInit = mockAuthFetch.mock.calls.at(-1)?.[1] as RequestInit;
+    expect(new Headers(requestInit.headers).has("Authorization")).toBe(false);
   });
 
   it("attaches widget model context to the next request only", async () => {
@@ -743,7 +747,7 @@ describe("useChatSession minimal mode parity", () => {
     await waitFor(() => {
       expect(useMCPJamLimitDialogStore.getState().isOpen).toBe(true);
     });
-    expect(mockAuthFetch).not.toHaveBeenCalled();
+    expect(mockAuthFetch).toHaveBeenCalledTimes(1);
   });
 
   it("opens the mcpjam-limit dialog for chat-v2 stream limit errors", async () => {
@@ -902,9 +906,9 @@ describe("useChatSession minimal mode parity", () => {
 
     const latestTransport = mockTransportInstances.at(-1)!;
     expect(latestTransport.options.api).toBe("/api/mcp/chat-v2");
-    expect(await resolveConfig(latestTransport.options.headers)).toEqual({
-      Authorization: "Bearer guest-token",
-    });
+    expect(
+      await resolveConfig(latestTransport.options.headers)
+    ).toBeUndefined();
     expect(result.current.disableForAuthentication).toBe(false);
     expect(result.current.availableModels.map((model) => model.id)).toEqual([
       "gpt-4",
@@ -972,16 +976,18 @@ describe("useChatSession minimal mode parity", () => {
       accessScope: "chat_v2",
     });
     expect(transport.requests[0]).not.toHaveProperty("apiKey");
-    expect(mockWindowFetch).toHaveBeenCalledWith(
+    expect(mockAuthFetch).toHaveBeenCalledWith(
       "/api/web/chat-v2",
-      expect.objectContaining({
-        headers: { Authorization: "Bearer guest-token" },
-      })
+      expect.objectContaining({ method: "POST" })
     );
-    expect(mockAuthFetch).not.toHaveBeenCalled();
+    const requestInit = mockAuthFetch.mock.calls.at(-1)?.[1] as RequestInit;
+    expect(new Headers(requestInit.headers).has("Authorization")).toBe(false);
   });
 
   it("uses the local MCP route for org BYOK when a selected server is local-only", async () => {
+    const ensureServerIds = vi.fn(async () => [
+      { serverId: "hosted-server-id" },
+    ]);
     mockModelState.selectedModelId = orgAnthropicModel.id;
     mockGetAccessToken.mockResolvedValue(null);
     mockSharedAppState.servers = {
@@ -1005,6 +1011,7 @@ describe("useChatSession minimal mode parity", () => {
         hostedContext: {
           projectId: "project-1",
           selectedServerIds: [],
+          ensureServerIds,
         },
       })
     );
@@ -1029,13 +1036,11 @@ describe("useChatSession minimal mode parity", () => {
     });
     expect(transport.requests[0]).not.toHaveProperty("apiKey");
     expect(transport.requests[0]).not.toHaveProperty("selectedServerIds");
-    expect(mockWindowFetch).toHaveBeenCalledWith(
+    expect(mockAuthFetch).toHaveBeenCalledWith(
       "/api/mcp/chat-v2",
-      expect.objectContaining({
-        headers: { Authorization: "Bearer guest-token" },
-      })
+      expect.objectContaining({ method: "POST" })
     );
-    expect(mockAuthFetch).not.toHaveBeenCalled();
+    expect(ensureServerIds).not.toHaveBeenCalled();
   });
 
   it("fails closed to the local MCP route when a selected server's config is unresolved", async () => {

--- a/mcpjam-inspector/client/src/hooks/use-chat-session.ts
+++ b/mcpjam-inspector/client/src/hooks/use-chat-session.ts
@@ -79,7 +79,6 @@ import type { SerializedModelRequestTool } from "@/shared/model-request-payload"
 import { countTextTokens } from "@/lib/apis/mcp-tokenizer-api";
 import {
   authFetch,
-  getAuthHeaders as getSessionAuthHeaders,
 } from "@/lib/session-token";
 import {
   classifyScenarioAccessResponse,
@@ -2688,10 +2687,16 @@ export function useChatSession(
       apiKey = getToken(selectedModel.provider as keyof ProviderTokens);
     }
 
-    // Authorization is resolved by authFetch at request time. Keep only the
-    // local session header and any local-computer consent capability here.
-    const sessionHeaders = getSessionAuthHeaders();
-    const mergedHeaders = { ...sessionHeaders } as Record<string, string>;
+    // NEITHER credential is snapshotted here. authFetch calls the very same
+    // `getAuthHeaders()` at request time, and `buildAuthFetchInit` merges
+    // `init.headers` LAST — so a copy taken when this memo ran would override
+    // the fresh one. That is not theoretical: the local dev server mints a new
+    // session token on every restart, and this memo (which no longer depends
+    // on `authHeaders`) can outlive several of them, so the stale copy won the
+    // merge and the route answered 401 "Invalid session token". authFetch's
+    // own 401 session-recovery could not rescue it either — its retry rebuilds
+    // from the same `init`, re-applying the same stale header.
+    const mergedHeaders = {} as Record<string, string>;
     // Consent capability for the local computer engine — a header, never the
     // body, so it can't land in a persisted transcript. Only on a direct
     // (non-scenario) turn whose resolved engine is local; the server re-checks
@@ -2713,9 +2718,8 @@ export function useChatSession(
     if (sendLocalEngine && localConsentToken) {
       mergedHeaders[LOCAL_CONSENT_HEADER] = localConsentToken;
     }
-    // authFetch owns Authorization for every chat route. A transport-level
-    // bearer would override its freshly resolved value because init headers
-    // are merged last.
+    // Only the local-computer consent capability rides the transport, because
+    // it is not a credential authFetch knows how to resolve.
     const transportHeaders =
       Object.keys(mergedHeaders).length > 0 ? mergedHeaders : undefined;
 

--- a/mcpjam-inspector/client/src/hooks/use-chat-session.ts
+++ b/mcpjam-inspector/client/src/hooks/use-chat-session.ts
@@ -2520,6 +2520,10 @@ export function useChatSession(
     !hostedRequiresWebChatApi &&
     selectedModelUsesOrgRuntime &&
     hasLocalOnlySelectedServer;
+  const isHostedTransport = HOSTED_MODE || hostedRequiresWebChatApi;
+  const shouldUseOrgAwareChatApi =
+    isHostedTransport ||
+    (selectedModelUsesOrgRuntime && !localMcpRuntimeRequired);
   const traceViewsSupported = HOSTED_MODE
     ? isMcpJamModel || selectedModelUsesOrgRuntime
     : true;
@@ -2540,13 +2544,10 @@ export function useChatSession(
       // belonging to a different request.
       lastChatResponseRef.current = null;
 
-      // authFetch owns auth resolution (WorkOS bearer / guest bearer via
-      // the scenario-installed apiContext) wherever the web engine is in
-      // play — hosted builds, and scenario runtime sessions on any platform.
-      const useAuthedFetch = HOSTED_MODE || hostedRequiresWebChatApi;
-      let response = useAuthedFetch
-        ? await authFetch(input, init)
-        : await fetch(input, init);
+      // Resolve the WorkOS / guest bearer at request time for every chat
+      // route. authFetch attaches it only to allowlisted Convex-backed paths,
+      // including both /api/web/chat-v2 and local /api/mcp/chat-v2.
+      let response = await authFetch(input, init);
 
       // Scenario access recovery. A scenario turn re-resolves its authoritative
       // config server-side on every send, so an open tab can lose access
@@ -2562,7 +2563,7 @@ export function useChatSession(
       // send — the replay's own verdict is final.
       if (
         !response.ok &&
-        useAuthedFetch &&
+        isHostedTransport &&
         hostedScenarioId &&
         typeof init?.body === "string" &&
         hostedRefreshAccessSession
@@ -2609,7 +2610,7 @@ export function useChatSession(
 
       if (!response.ok) {
         await notifyMCPJamLimitErrorFromResponse(response);
-        if (useAuthedFetch) {
+        if (isHostedTransport) {
           await ingestHostedRpcLogsFromResponse(response);
         }
       }
@@ -2617,6 +2618,7 @@ export function useChatSession(
     },
     [
       hostedRequiresWebChatApi,
+      isHostedTransport,
       hostedScenarioId,
       hostedRefreshAccessSession,
       hostedOnAccessRevoked,
@@ -2672,10 +2674,6 @@ export function useChatSession(
   const turnTaskScopeRef = useRef<string | undefined>(undefined);
 
   const transport = useMemo(() => {
-    const shouldUseOrgAwareChatApi =
-      HOSTED_MODE ||
-      hostedRequiresWebChatApi ||
-      (selectedModelUsesOrgRuntime && !localMcpRuntimeRequired);
     const shouldSendClientApiKey =
       !shouldUseOrgAwareChatApi && !selectedModelUsesOrgRuntime;
     let apiKey: string;
@@ -2690,12 +2688,10 @@ export function useChatSession(
       apiKey = getToken(selectedModel.provider as keyof ProviderTokens);
     }
 
-    // Merge session auth headers with workos auth headers
+    // Authorization is resolved by authFetch at request time. Keep only the
+    // local session header and any local-computer consent capability here.
     const sessionHeaders = getSessionAuthHeaders();
-    const mergedHeaders = { ...sessionHeaders, ...authHeaders } as Record<
-      string,
-      string
-    >;
+    const mergedHeaders = { ...sessionHeaders } as Record<string, string>;
     // Consent capability for the local computer engine — a header, never the
     // body, so it can't land in a persisted transcript. Only on a direct
     // (non-scenario) turn whose resolved engine is local; the server re-checks
@@ -2717,14 +2713,11 @@ export function useChatSession(
     if (sendLocalEngine && localConsentToken) {
       mergedHeaders[LOCAL_CONSENT_HEADER] = localConsentToken;
     }
-    // When authFetch carries the request (hosted builds, scenario runtime
-    // sessions), it owns the Authorization header — don't double-attach.
+    // authFetch owns Authorization for every chat route. A transport-level
+    // bearer would override its freshly resolved value because init headers
+    // are merged last.
     const transportHeaders =
-      HOSTED_MODE || hostedRequiresWebChatApi
-        ? undefined
-        : Object.keys(mergedHeaders).length > 0
-        ? mergedHeaders
-        : undefined;
+      Object.keys(mergedHeaders).length > 0 ? mergedHeaders : undefined;
 
     const chatApi = shouldUseOrgAwareChatApi
       ? "/api/web/chat-v2"
@@ -2975,10 +2968,10 @@ export function useChatSession(
     getToken,
     getCustomProviderByName,
     customProviders,
-    authHeaders,
     selectedModelUsesOrgRuntime,
     localMcpRuntimeRequired,
     hostedRequiresWebChatApi,
+    shouldUseOrgAwareChatApi,
     temperature,
     systemPrompt,
     selectedServers,

--- a/mcpjam-inspector/client/src/hooks/use-chat-session.ts
+++ b/mcpjam-inspector/client/src/hooks/use-chat-session.ts
@@ -3732,10 +3732,7 @@ export function useChatSession(
         // name. Only on the web-engine path, and only when the surface provided
         // a resolver (Playground). On failure, fail the send CLOSED with a
         // visible toast (callers fire-and-forget, so don't reject).
-        const usesWebEngine =
-          HOSTED_MODE ||
-          selectedModelUsesOrgRuntime ||
-          hostedRequiresWebChatApi;
+        const usesWebEngine = shouldUseOrgAwareChatApi;
         // Snapshot the selection ONCE: the resolved ids must ride with the
         // names they were resolved from, even if the user edits the selection
         // while the preflight is in flight.
@@ -3824,8 +3821,7 @@ export function useChatSession(
       hostedEnsureServerIds,
       hostedEnvironmentId,
       selectedServers,
-      selectedModelUsesOrgRuntime,
-      hostedRequiresWebChatApi,
+      shouldUseOrgAwareChatApi,
     ]
   );
 

--- a/mcpjam-inspector/client/src/lib/__tests__/session-token.local-chat-auth.test.ts
+++ b/mcpjam-inspector/client/src/lib/__tests__/session-token.local-chat-auth.test.ts
@@ -1,7 +1,9 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 const { getApiAuthorizationHeader } = vi.hoisted(() => ({
-  getApiAuthorizationHeader: vi.fn(async () => "Bearer workos-jwt"),
+  getApiAuthorizationHeader: vi.fn(
+    async (): Promise<string | null> => "Bearer workos-jwt"
+  ),
 }));
 
 vi.mock("@/lib/config", () => ({ HOSTED_MODE: false }));
@@ -41,5 +43,28 @@ describe("authFetch local chat bearer", () => {
         Authorization: "Bearer workos-jwt",
       },
     });
+  });
+
+  it("omits Authorization when bearer resolution returns empty", async () => {
+    getApiAuthorizationHeader.mockResolvedValueOnce(null);
+
+    await authFetch("/api/mcp/chat-v2", { method: "POST" });
+
+    expect(global.fetch).toHaveBeenCalledWith("/api/mcp/chat-v2", {
+      method: "POST",
+      headers: {
+        "X-MCP-Session-Auth": "Bearer local-session",
+      },
+    });
+  });
+
+  it("does not send when bearer resolution rejects", async () => {
+    const error = new Error("bearer lookup failed");
+    getApiAuthorizationHeader.mockRejectedValueOnce(error);
+
+    await expect(
+      authFetch("/api/mcp/chat-v2", { method: "POST" })
+    ).rejects.toBe(error);
+    expect(global.fetch).not.toHaveBeenCalled();
   });
 });

--- a/mcpjam-inspector/client/src/lib/__tests__/session-token.local-chat-auth.test.ts
+++ b/mcpjam-inspector/client/src/lib/__tests__/session-token.local-chat-auth.test.ts
@@ -1,0 +1,45 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const { getApiAuthorizationHeader } = vi.hoisted(() => ({
+  getApiAuthorizationHeader: vi.fn(async () => "Bearer workos-jwt"),
+}));
+
+vi.mock("@/lib/config", () => ({ HOSTED_MODE: false }));
+vi.mock("@/lib/apis/web/context", () => ({
+  getApiAuthorizationHeader,
+  resetTokenCache: vi.fn(),
+  shouldRetryApiAuth401: vi.fn(() => false),
+}));
+vi.mock("@/lib/guest-session", () => ({
+  forceRefreshGuestSession: vi.fn(),
+}));
+vi.mock("@/lib/convex-site-url", () => ({
+  getConvexSiteUrl: vi.fn(() => null),
+}));
+vi.mock("@/lib/analytics", () => ({ track: vi.fn() }));
+
+import { authFetch } from "../session-token";
+
+describe("authFetch local chat bearer", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    window.__MCP_SESSION_TOKEN__ = "local-session";
+    vi.mocked(global.fetch).mockReset();
+    vi.mocked(global.fetch).mockResolvedValue(
+      new Response("", { status: 200 })
+    );
+  });
+
+  it("resolves and attaches the Convex bearer to /api/mcp/chat-v2", async () => {
+    await authFetch("/api/mcp/chat-v2", { method: "POST" });
+
+    expect(getApiAuthorizationHeader).toHaveBeenCalledTimes(1);
+    expect(global.fetch).toHaveBeenCalledWith("/api/mcp/chat-v2", {
+      method: "POST",
+      headers: {
+        "X-MCP-Session-Auth": "Bearer local-session",
+        Authorization: "Bearer workos-jwt",
+      },
+    });
+  });
+});

--- a/mcpjam-inspector/client/src/lib/session-token.ts
+++ b/mcpjam-inspector/client/src/lib/session-token.ts
@@ -308,6 +308,9 @@ const HOSTED_AUTH_PATH_PREFIXES = [
   // Local resolver path that calls Convex /web/authorize-batch-local.
   "/api/mcp/connect",
   "/api/mcp/servers/reconnect",
+  // Local chat re-calls Convex for host/scenario runtime config and
+  // persistence, so resolve its bearer at request time as well.
+  "/api/mcp/chat-v2",
   // Local XAA proxy paths whose server-target / registration runs resolve a
   // Convex-stored secret on the user's behalf (the hosted `/api/web/xaa/*`
   // equivalents are already covered by the `/api/web/` prefix above).

--- a/mcpjam-inspector/server/utils/__tests__/host-runtime-config.test.ts
+++ b/mcpjam-inspector/server/utils/__tests__/host-runtime-config.test.ts
@@ -69,6 +69,31 @@ describe("fetchHostRuntimeConfig", () => {
     expect(fetchSpy).not.toHaveBeenCalled();
   });
 
+  it("forwards a token that merely STARTS with the letters Bearer", async () => {
+    // Regression: a `^Bearer\s*` strip (zero-or-more) mangled an opaque token
+    // like `Bearerabc123` into `abc123` — a different credential.
+    let auth = "";
+    mockFetch((_url, init) => {
+      auth = (init.headers as Record<string, string>).authorization;
+      return Response.json({ ok: true, config: { hostId: "h1" } });
+    });
+    await fetchHostRuntimeConfig({ hostId: "h1", bearer: "Bearerabc123" });
+    expect(auth).toBe("Bearer Bearerabc123");
+  });
+
+  it("answers a blank bearer as 401 even when the endpoint is unconfigured", async () => {
+    // The caller being unauthenticated is a 401, and must not inherit the 500
+    // that missing CONVEX_HTTP_URL returns.
+    delete process.env.CONVEX_HTTP_URL;
+    const fetchSpy = vi.fn();
+    globalThis.fetch = fetchSpy as unknown as typeof fetch;
+
+    const result = await fetchHostRuntimeConfig({ hostId: "h1", bearer: "" });
+
+    expect(result).toMatchObject({ ok: false, status: 401 });
+    expect(fetchSpy).not.toHaveBeenCalled();
+  });
+
   it("does not double-prefix an already-Bearer token", async () => {
     let auth = "";
     mockFetch((_url, init) => {

--- a/mcpjam-inspector/server/utils/__tests__/host-runtime-config.test.ts
+++ b/mcpjam-inspector/server/utils/__tests__/host-runtime-config.test.ts
@@ -53,6 +53,22 @@ describe("fetchHostRuntimeConfig", () => {
     });
   });
 
+  it("rejects a blank bearer as 401 without hitting the network", async () => {
+    // Regression: an unauthenticated local Playground turn on a host-bound
+    // conversation sent `Bearer ` (empty), Convex threw "Invalid
+    // authentication header", the backend answered 500 and the route
+    // collapsed it to a 502 the client reported as MCPJam's fault.
+    const fetchSpy = vi.fn();
+    globalThis.fetch = fetchSpy as unknown as typeof fetch;
+
+    for (const bearer of ["", "   ", "Bearer "]) {
+      const result = await fetchHostRuntimeConfig({ hostId: "h1", bearer });
+      expect(result.ok).toBe(false);
+      expect(result).toMatchObject({ status: 401 });
+    }
+    expect(fetchSpy).not.toHaveBeenCalled();
+  });
+
   it("does not double-prefix an already-Bearer token", async () => {
     let auth = "";
     mockFetch((_url, init) => {

--- a/mcpjam-inspector/server/utils/host-runtime-config.ts
+++ b/mcpjam-inspector/server/utils/host-runtime-config.ts
@@ -103,10 +103,27 @@ export async function fetchHostRuntimeConfig(args: {
       error: "Host runtime-config endpoint is not configured",
     };
   }
-  const trimmedBearer = args.bearer.trim();
-  const authorization = /^Bearer\s/i.test(trimmedBearer)
-    ? trimmedBearer
-    : `Bearer ${trimmedBearer}`;
+  // Normalize to the TOKEN, then re-prefix, so `Bearer ` (header present,
+  // token empty) is recognized as blank rather than sent on as the
+  // double-prefixed `Bearer Bearer`.
+  const bearerToken = args.bearer.trim().replace(/^Bearer\s*/i, "").trim();
+  // A BLANK bearer never reaches the network. `Bearer ` with nothing after it
+  // is a MALFORMED header, and Convex's `getUserIdentity()` throws on it
+  // instead of returning null — so the backend route's catch-all answers 500,
+  // both chat-v2 routes collapse a >=500 to 502, and the client attributes any
+  // 5xx from our own route to MCPJam. An unauthenticated local Playground turn
+  // on a host-bound conversation (`/api/mcp/chat-v2` reads the header as `""`)
+  // therefore paged us with "Invalid authentication header" instead of telling
+  // the user to sign in. Fail closed as 401, the way the scenario branch of
+  // `mcp/chat-v2.ts` already does before it fetches.
+  if (!bearerToken) {
+    return {
+      ok: false,
+      status: 401,
+      error: "Not signed in — sign in (or retry) to run this host.",
+    };
+  }
+  const authorization = `Bearer ${bearerToken}`;
 
   let response: Response;
   try {

--- a/mcpjam-inspector/server/utils/host-runtime-config.ts
+++ b/mcpjam-inspector/server/utils/host-runtime-config.ts
@@ -89,6 +89,43 @@ export async function fetchHostRuntimeConfig(args: {
   bearer: string;
   signal?: AbortSignal;
 }): Promise<HostRuntimeConfigResult> {
+  // Normalize to the TOKEN, then re-prefix, so `Bearer ` (header present,
+  // token empty) is recognized as blank rather than sent on as the
+  // double-prefixed `Bearer Bearer`.
+  //
+  // The prefix test REQUIRES whitespace (`/^Bearer\s/i`, the same shape the
+  // original code used): an opaque token that merely starts with the letters
+  // "Bearer" (`Bearerabc…`) must be forwarded untouched, not silently turned
+  // into a different token. And the left-trim happens BEFORE the test, never a
+  // full `trim()` first — trimming `"Bearer "` down to `"Bearer"` destroys the
+  // very space that distinguishes an empty-token header from a token that is
+  // itself the word "Bearer".
+  const leftTrimmed = args.bearer.replace(/^\s+/, "");
+  const bearerToken = (
+    /^Bearer\s/i.test(leftTrimmed) ? leftTrimmed.slice("Bearer".length) : leftTrimmed
+  ).trim();
+  // A BLANK bearer never reaches the network, and is answered BEFORE the
+  // endpoint config is resolved: an unauthenticated turn is the caller's
+  // problem and must read as 401, not inherit the 500 that missing
+  // `CONVEX_HTTP_URL` returns below.
+  //
+  // `Bearer ` with nothing after it is a MALFORMED header, and Convex's
+  // `getUserIdentity()` throws on it instead of returning null — so the
+  // backend route's catch-all answers 500, both chat-v2 routes collapse a
+  // >=500 to 502, and the client attributes any 5xx from our own route to
+  // MCPJam. A local Playground turn on a host-bound conversation whose
+  // guest/member token hadn't resolved (`/api/mcp/chat-v2` reads the header as
+  // `""`) therefore paged us with "Invalid authentication header" instead of
+  // asking the user to retry. Fail closed as 401, the way the scenario branch
+  // of `mcp/chat-v2.ts` already does before it fetches.
+  if (!bearerToken) {
+    return {
+      ok: false,
+      status: 401,
+      error:
+        "Couldn't authenticate this turn — retry, or sign in if you're not a guest.",
+    };
+  }
   let url: string;
   try {
     url = new URL("/web/host/runtime-config", getConvexHttpUrl()).toString();
@@ -101,26 +138,6 @@ export async function fetchHostRuntimeConfig(args: {
       ok: false,
       status: 500,
       error: "Host runtime-config endpoint is not configured",
-    };
-  }
-  // Normalize to the TOKEN, then re-prefix, so `Bearer ` (header present,
-  // token empty) is recognized as blank rather than sent on as the
-  // double-prefixed `Bearer Bearer`.
-  const bearerToken = args.bearer.trim().replace(/^Bearer\s*/i, "").trim();
-  // A BLANK bearer never reaches the network. `Bearer ` with nothing after it
-  // is a MALFORMED header, and Convex's `getUserIdentity()` throws on it
-  // instead of returning null — so the backend route's catch-all answers 500,
-  // both chat-v2 routes collapse a >=500 to 502, and the client attributes any
-  // 5xx from our own route to MCPJam. A local Playground turn on a host-bound
-  // conversation whose guest/member token hadn't resolved (`/api/mcp/chat-v2`
-  // reads the header as `""`) therefore paged us with "Invalid authentication
-  // header" instead of asking the user to retry. Fail closed as 401, the way
-  // the scenario branch of `mcp/chat-v2.ts` already does before it fetches.
-  if (!bearerToken) {
-    return {
-      ok: false,
-      status: 401,
-      error: "Couldn't authenticate this turn — retry, or sign in if you're not a guest.",
     };
   }
   const authorization = `Bearer ${bearerToken}`;

--- a/mcpjam-inspector/server/utils/host-runtime-config.ts
+++ b/mcpjam-inspector/server/utils/host-runtime-config.ts
@@ -111,16 +111,16 @@ export async function fetchHostRuntimeConfig(args: {
   // is a MALFORMED header, and Convex's `getUserIdentity()` throws on it
   // instead of returning null — so the backend route's catch-all answers 500,
   // both chat-v2 routes collapse a >=500 to 502, and the client attributes any
-  // 5xx from our own route to MCPJam. An unauthenticated local Playground turn
-  // on a host-bound conversation (`/api/mcp/chat-v2` reads the header as `""`)
-  // therefore paged us with "Invalid authentication header" instead of telling
-  // the user to sign in. Fail closed as 401, the way the scenario branch of
-  // `mcp/chat-v2.ts` already does before it fetches.
+  // 5xx from our own route to MCPJam. A local Playground turn on a host-bound
+  // conversation whose guest/member token hadn't resolved (`/api/mcp/chat-v2`
+  // reads the header as `""`) therefore paged us with "Invalid authentication
+  // header" instead of asking the user to retry. Fail closed as 401, the way
+  // the scenario branch of `mcp/chat-v2.ts` already does before it fetches.
   if (!bearerToken) {
     return {
       ok: false,
       status: 401,
-      error: "Not signed in — sign in (or retry) to run this host.",
+      error: "Couldn't authenticate this turn — retry, or sign in if you're not a guest.",
     };
   }
   const authorization = `Bearer ${bearerToken}`;


### PR DESCRIPTION
## Summary

A newly mounted Playground/App Builder panel could replay a queued turn before its async auth state resolved. The local chat request then had no Authorization header, which previously became a malformed `Bearer ` upstream and surfaced as a misleading 502.

- Resolve the WorkOS/guest bearer at request time through `authFetch` for both chat routes.
- Allowlist `/api/mcp/chat-v2`, since the local route calls Convex for runtime config and persistence.
- Stop snapshotting Authorization into transport headers, so fresh request auth cannot be overridden.
- Defer compare-card broadcast replay until that card finishes session bootstrap.
- Keep the server-side blank-bearer guard, returning a clean 401 before any Convex fetch.

## Verification

- Focused auth/bootstrap/replay tests: 5 passed.
- `npm run typecheck:client` passed.