### PR TITLE
fix(swarms): drop the chat composer from the Describe step (BB-78)

### DIFF
--- a/mcpjam-inspector/client/src/components/swarms/__tests__/SwarmsTab.createFlow.test.tsx
+++ b/mcpjam-inspector/client/src/components/swarms/__tests__/SwarmsTab.createFlow.test.tsx
@@ -275,25 +275,6 @@ vi.mock("@/components/swarms/journey-rubric-editor", () => ({
   ),
 }));
 
-vi.mock("@/components/mcpjam-agent/McpjamAgentComposer", () => ({
-  McpjamAgentComposer: ({
-    value,
-    onChange,
-    placeholder,
-  }: {
-    value: string;
-    onChange: (next: string) => void;
-    placeholder?: string;
-  }) => (
-    <textarea
-      aria-label="Describe swarm"
-      placeholder={placeholder}
-      value={value}
-      onChange={(event) => onChange(event.target.value)}
-    />
-  ),
-}));
-
 vi.mock("@/components/project-environments/environment-picker", () => ({
   EnvironmentPicker: ({
     value,
@@ -341,7 +322,7 @@ function submitLaunchEnabled() {
 }
 
 function fillDescribe(text = "Support agents answering refunds") {
-  fireEvent.change(screen.getByLabelText("Describe swarm"), {
+  fireEvent.change(screen.getByLabelText(/describe/i), {
     target: { value: text },
   });
   // Auto-seed usually already picked the first named environment; only click
@@ -479,12 +460,37 @@ describe("SwarmsTab — New swarm create flow", () => {
     expect(screen.getByText(/describe your users to continue/i)).toBeVisible();
 
     // Targets are auto-seeded; a description is the remaining gate for generate.
-    fireEvent.change(screen.getByLabelText("Describe swarm"), {
+    fireEvent.change(screen.getByLabelText(/describe/i), {
       target: { value: "Support agents answering refunds" },
     });
     expect(submit).not.toBeDisabled();
     expect(submit).toHaveTextContent("Continue");
     expect(screen.getByText(/3 new personas on next step/i)).toBeVisible();
+  });
+
+  /**
+   * Describe is a form field, not a chat. It used to mount the Agent chat
+   * composer, which brought a Send button wired to Continue but gated on its
+   * own `canSubmit` — so it rendered enabled while Continue was blocked and did
+   * nothing when clicked. Worse, the composer bound Enter to submit, so Enter
+   * could not open a new line and instead jumped the step mid-sentence.
+   */
+  it("offers no send affordance on Describe, and leaves Enter to the text", async () => {
+    const user = userEvent.setup();
+    openDescribe();
+    const field = screen.getByLabelText(/describe/i);
+
+    expect(screen.queryByRole("button", { name: /send/i })).toBeNull();
+    expect(screen.queryByText(/enter to send/i)).toBeNull();
+
+    // Typed rather than `fireEvent`ed: only a real key sequence tells a newline
+    // apart from a swallowed Enter. The first word already enables Continue, so
+    // a submit-on-Enter binding fires here instead of opening a line.
+    await user.type(field, "Refund agents{enter}and billing devs");
+
+    expect(screen.getByTestId("new-swarm-continue")).not.toBeDisabled();
+    expect(field).toHaveValue("Refund agents\nand billing devs");
+    expect(generateSwarmPersonaBatchMock).not.toHaveBeenCalled();
   });
 
   it("auto-seeds the first named environment on open", () => {
@@ -1645,7 +1651,7 @@ describe("SwarmsTab — New swarm create flow", () => {
     environments = environmentsRef.current;
     openDescribe();
 
-    fireEvent.change(screen.getByLabelText("Describe swarm"), {
+    fireEvent.change(screen.getByLabelText(/describe/i), {
       target: { value: "Support agents answering refunds" },
     });
     // No named envs → auto-seed picks Claude; add Cursor for a two-client fan-out.
@@ -1687,7 +1693,7 @@ describe("SwarmsTab — New swarm create flow", () => {
     environments = environmentsRef.current;
     openDescribe();
 
-    fireEvent.change(screen.getByLabelText("Describe swarm"), {
+    fireEvent.change(screen.getByLabelText(/describe/i), {
       target: { value: "Support agents answering refunds" },
     });
     // Auto-seed already has Claude; add Cursor.
@@ -1867,7 +1873,7 @@ describe("SwarmsTab create flow — survives a remount", () => {
     expect(
       await screen.findByText(/persona generation was interrupted/i)
     ).toBeVisible();
-    expect(screen.getByLabelText("Describe swarm")).toHaveValue(
+    expect(screen.getByLabelText(/describe/i)).toHaveValue(
       "Support agents answering refunds"
     );
   });
@@ -1887,7 +1893,7 @@ describe("SwarmsTab create flow — survives a remount", () => {
     expect(
       screen.queryByTestId("new-swarm-proposed-personas")
     ).not.toBeInTheDocument();
-    expect(screen.getByLabelText("Describe swarm")).toHaveValue("");
+    expect(screen.getByLabelText(/describe/i)).toHaveValue("");
   });
 
   it("says what stage it is in while generation runs", async () => {

--- a/mcpjam-inspector/client/src/components/swarms/__tests__/SwarmsTab.perClientEnvLaunch.test.tsx
+++ b/mcpjam-inspector/client/src/components/swarms/__tests__/SwarmsTab.perClientEnvLaunch.test.tsx
@@ -222,22 +222,6 @@ vi.mock("@/components/swarms/journey-rubric-editor", () => ({
   ),
 }));
 
-vi.mock("@/components/mcpjam-agent/McpjamAgentComposer", () => ({
-  McpjamAgentComposer: ({
-    value,
-    onChange,
-  }: {
-    value: string;
-    onChange: (next: string) => void;
-  }) => (
-    <textarea
-      aria-label="Describe swarm"
-      value={value}
-      onChange={(event) => onChange(event.target.value)}
-    />
-  ),
-}));
-
 vi.mock("@/components/project-environments/environment-picker", () => ({
   EnvironmentPicker: ({
     value,
@@ -293,7 +277,7 @@ function perClientEnvironments() {
 /** Describe with a paragraph and BOTH per-client environments selected. */
 function describeAcrossBothClients() {
   render(<SwarmsTab projectId="proj-1" isAuthenticated createFlow />);
-  fireEvent.change(screen.getByLabelText("Describe swarm"), {
+  fireEvent.change(screen.getByLabelText(/describe/i), {
     target: { value: "Finance ops reconciling payouts" },
   });
   const picker = screen.getByTestId("new-swarm-environments-picker");

--- a/mcpjam-inspector/client/src/components/swarms/new-swarm-create-flow.tsx
+++ b/mcpjam-inspector/client/src/components/swarms/new-swarm-create-flow.tsx
@@ -30,7 +30,7 @@ import {
 import { Label } from "@mcpjam/design-system/label";
 import { Loader2 } from "lucide-react";
 import { ErrorBoundary } from "@/components/ui/error-boundary";
-import { McpjamAgentComposer } from "@/components/mcpjam-agent/McpjamAgentComposer";
+import { TextareaAutosize } from "@/components/ui/textarea-autosize";
 import { SwarmTargetComposer } from "@/components/swarms/swarm-target-composer";
 import {
   resolveSwarmJourneyPayload,
@@ -125,6 +125,10 @@ const CREATE_STEPS = [
 // content, so users hit a disabled button with no idea the box was empty.
 const DESCRIBE_PLACEHOLDER =
   "e.g. Finance ops reconciling payouts, and devs wiring up subscription billing.";
+
+/** Ties the Describe label to its field; the label's wording changes with the
+ *  persona count, so the association has to be by id rather than by text. */
+const DESCRIBE_FIELD_ID = "new-swarm-describe";
 
 /** Concurrent launches. Bounded so a 60-journey launch doesn't open 60
  * simultaneous requests, while still finishing in seconds. */
@@ -1782,7 +1786,7 @@ export function NewSwarmCreateFlow({
 
               <section className="flex min-h-0 min-w-0 flex-col gap-3">
                 <div className="shrink-0 space-y-1">
-                  <Label>
+                  <Label htmlFor={DESCRIBE_FIELD_ID}>
                     {personaList.length > 0
                       ? "Or describe new ones"
                       : "Describe your users"}
@@ -1791,19 +1795,32 @@ export function NewSwarmCreateFlow({
                     We’ll propose personas and goals for you to confirm.
                   </p>
                 </div>
-                <McpjamAgentComposer
-                  value={draft}
-                  onChange={setDraft}
-                  onSubmit={handleContinue}
-                  placeholder={DESCRIBE_PLACEHOLDER}
-                  minRows={personaList.length > 0 ? 8 : 3}
-                  maxRows={personaList.length > 0 ? 16 : 8}
+                {/* A plain field, NOT the Agent chat composer. That composer
+                    ships a Send button and swallows Enter to submit — on a step
+                    that advances through Continue, Enter belongs to the text. */}
+                <div
                   className={
                     personaList.length > 0
-                      ? "flex h-72 min-h-0 flex-col [&_textarea]:min-h-0 [&_textarea]:flex-1"
+                      ? "flex h-72 min-h-0 flex-col"
                       : undefined
                   }
-                />
+                >
+                  <TextareaAutosize
+                    id={DESCRIBE_FIELD_ID}
+                    value={draft}
+                    onChange={(event) => setDraft(event.target.value)}
+                    placeholder={DESCRIBE_PLACEHOLDER}
+                    minRows={personaList.length > 0 ? 8 : 3}
+                    maxRows={personaList.length > 0 ? 16 : 8}
+                    // `resize-none`: the grip fights the autosize, which rewrites
+                    // the height on the next keystroke. Every other textarea in
+                    // the app drops it for the same reason.
+                    className={cn(
+                      "resize-none",
+                      personaList.length > 0 && "min-h-0 flex-1",
+                    )}
+                  />
+                </div>
               </section>
             </div>
 


### PR DESCRIPTION
Closes BB-78.

The Describe step of the new-swarm flow mounted `McpjamAgentComposer` — the Agent **chat** composer — for its "describe your users" field. Four chat affordances leaked in with it.

## What was actually broken

**The Send button lied about its state.** It and Continue run on different gates:

| | Enabled when |
|---|---|
| Arrow (composer `canSubmit`) | the textarea has text |
| Continue (`canContinue`) | text **+** a reachable server **+** nothing in flight |

`onSubmit` was wired to `handleContinue`, which starts with `if (!canContinue) return;`. So whenever the step was blocked for any reason other than empty text, the arrow rendered enabled and orange while Continue was correctly greyed out — and clicking it did nothing. That is the state in the bug report.

**Enter was worse.** The composer `preventDefault`s Enter and submits. In a field that grows to 8 rows, Enter could not open a new line; and once the flow could continue, Enter fired the generation and jumped the step mid-sentence.

## What changed

`TextareaAutosize` instead. It already carries the app's standard field styling — border, radius, focus ring — so no shell CSS is duplicated, and it drops all four leaked affordances at once:

- the Send button
- Enter-to-submit
- the `"Enter to send · Shift+Enter for newline"` hint
- the orange invite ring, which exists to prompt a first *chat* message

Plus `resize-none`, for the same reason every other textarea in the app sets it (including the composer this replaces, and the next step of this same flow): the grip fights the autosize, which rewrites the height on the next keystroke.

The label is now tied to the field by id. It had no accessible name before — the composer supplied none either — and the wording changes with the persona count, so the association can't be by text.

Continue stays the single confirmation for the page.

## Before / After



**Before**

<img width="1041" height="511" alt="image" src="https://github.com/user-attachments/assets/a91baee2-3d01-4b73-b514-760be9e47491" />


**After**

<img width="995" height="496" alt="image" src="https://github.com/user-attachments/assets/a6179c76-3f59-4168-ac3f-a8ad00a2acd1" />


## Verified

- `swarms/__tests__` — 304 tests across 31 files, green
- Client typecheck clean
- New regression test pins both halves: no control named /send/i, no "Enter to send" text, and `Enter` typed mid-value lands a newline instead of advancing

The test was mutation-checked, and the first version of it **did not hold up** — `handleGenerate` is async, so asserting the mock right after the event ran too early, and `fireEvent.keyDown` cannot tell a newline from a swallowed Enter in jsdom. The version here uses `userEvent.type(..., "{enter}")` and asserts the `\n` reached the value. Both mutations now fail it:

| Mutation | Result |
|---|---|
| Put a Send button back | fails |
| Re-bind Enter to submit | fails |

The two suites that stubbed the composer render the real field now, so their mocks are gone — 7 queries repointed to match the label rather than the stub's `aria-label`.

## Notes

This matches the direction Vig gave in #engineering: a regular text box a little taller than one row, with *"Continue at the bottom acts as the confirmation for the inputs on the entire page"*. That also settles the open question in the task — remove the control rather than wire it.

A WIP redesign of this page is in flight and reworks more than this field (a swarm name input, "Where it runs" moved up, the persona picker merged in). This change is a subset of it and doesn't conflict: the redesign keeps a plain multi-line box, and dropping the composer is a prerequisite either way.

Left alone deliberately: the mockup's Describe box looks fixed-height, while this keeps the current `minRows`/`maxRows` autosize. Pinning the height is the redesign's call, not this fix's.
