### PR TITLE
Evals W0.1c: the SDK sends the declared `caseId` on upload

### DIFF
--- a/.changeset/sdk-sends-declared-case-id.md
+++ b/.changeset/sdk-sends-declared-case-id.md
@@ -59,11 +59,14 @@ strict/non-strict behavior.
 `SuiteRunToEvalResultsOptions` gain an optional `caseId` (and `caseIdByTest` for
 the suite variant, mirroring `expectedToolCallsByTest`). These converters
 receive a `casePrefix` rather than an `EvalTest`, so they cannot know the
-declared identity — it is offered and never defaulted. Note that
-`runToEvalResults` synthesizes `caseTitle` per iteration, so supplying one id
-across a run groups its iterations as a single hosted case instead of one case
-per iteration; that is the caller's choice to make. Passing nothing produces the
-same payload as before, byte for byte.
+declared identity — it is offered and never defaulted. Supplying one id across a
+run groups its iterations as a single hosted case instead of one case per
+iteration; that is the caller's choice to make. `runToEvalResults` also drops
+its per-iteration `-iter-N` `caseTitle` suffix when an id is given, since that
+suffix is what made each iteration a separate case and a grouped case would
+otherwise be titled after its first iteration. The iteration number still rides
+`metadata.iterationNumber`. Passing nothing produces the same payload as before,
+byte for byte.
 
 The low-level mappers stay permissive: `promptsToEvalResult` and
 `PromptResult.toEvalResult` forward whatever `caseId` the caller passes and do

--- a/.changeset/sdk-sends-declared-case-id.md
+++ b/.changeset/sdk-sends-declared-case-id.md
@@ -55,6 +55,16 @@ compatibility error naming the required upgrade — flagged as
 reported as an eval verdict. `reportEvalResultsSafely` keeps its existing
 strict/non-strict behavior.
 
+`RunToEvalResultsOptions`, `IterationToEvalResultOptions` and
+`SuiteRunToEvalResultsOptions` gain an optional `caseId` (and `caseIdByTest` for
+the suite variant, mirroring `expectedToolCallsByTest`). These converters
+receive a `casePrefix` rather than an `EvalTest`, so they cannot know the
+declared identity — it is offered and never defaulted. Note that
+`runToEvalResults` synthesizes `caseTitle` per iteration, so supplying one id
+across a run groups its iterations as a single hosted case instead of one case
+per iteration; that is the caller's choice to make. Passing nothing produces the
+same payload as before, byte for byte.
+
 The low-level mappers stay permissive: `promptsToEvalResult` and
 `PromptResult.toEvalResult` forward whatever `caseId` the caller passes and do
 not enforce the equality rule themselves. The construction-time check covers the

--- a/.changeset/sdk-sends-declared-case-id.md
+++ b/.changeset/sdk-sends-declared-case-id.md
@@ -1,0 +1,64 @@
+---
+"@mcpjam/sdk": major
+---
+
+The SDK sends the declared `caseId` on upload.
+
+`EvalResultInput` gains an optional `caseId` — the case's DECLARED identity
+(`EvalTestConfig.id`) — and it now rides the wire on every result an
+`EvalSuite` reports. 5.0.0 made `id` required but changed no payload byte; the
+field was declared and inert. This connects it.
+
+The backend resolves by `caseId` first, falls back to the content-hash key, and
+ADOPTS: an id-bearing upload that resolves by hash to a case with no declared id
+patches the id on without touching the immutable `caseKey`. That is what lets a
+renamed test keep its hosted history instead of forking it — the whole reason
+the field exists.
+
+**Breaking: `id` and `externalCaseId` must agree.** A test that declares both,
+with different values, now throws at construction:
+
+```ts
+new EvalTest({
+  id: "c_minted",
+  externalCaseId: "legacy_case_7", // ← throws
+  name: "refund flow",
+  test: async (executor) => { ... },
+});
+```
+
+They are two claims about which case this is, and picking a winner silently is
+how one case's history gets cross-joined onto another's. The migration is always
+`id := externalCaseId`: the hosted case is keyed under `external:<externalCaseId>`,
+so declaring that same value as `id` lands the declared id in the join the case
+already lives under and its history simply continues. A differing pair is
+rejected at ingest too, so shipping it would fail the upload rather than pick a
+winner. An empty `externalCaseId` is absent, not a second claim, and is
+unaffected.
+
+The one case the migration cannot fix is an `externalCaseId` outside the opaque-id
+charset (`^[A-Za-z0-9_-]{1,128}$`) — that field was never charset-bound, so
+values exist that no `id` can equal. 5.0.0's missing-`id` error suggested a
+freshly minted id for exactly those configs, and that pair now throws. Rename the
+external id itself to a conforming value and declare it in both fields; an
+external id that was never charset-valid has no hosted history for the rename to
+strand. The error message says so at the line that is wrong.
+
+**Minimum reporting-backend contract.** Argument validation on the ingest
+surface is strict: a backend that predates declared case ids rejects the WHOLE
+report rather than dropping the unknown field. `@mcpjam/sdk` 6 therefore
+requires a reporting backend that accepts `caseId`. MCPJam-hosted
+`app.mcpjam.com` does; a caller-supplied `baseUrl` pointing at an older or
+custom deployment may not, and such a rejection is now surfaced as an actionable
+compatibility error naming the required upgrade — flagged as
+`EvalReportingError.isReportingBackendIncompatible`, never retried, and never
+reported as an eval verdict. `reportEvalResultsSafely` keeps its existing
+strict/non-strict behavior.
+
+The low-level mappers stay permissive: `promptsToEvalResult` and
+`PromptResult.toEvalResult` forward whatever `caseId` the caller passes and do
+not enforce the equality rule themselves. The construction-time check covers the
+`EvalTest` path and the backend's ingest preflight covers everyone else.
+
+Nothing else about the payload changes. A config with no `externalCaseId` emits
+exactly what it emitted before, plus `caseId`.

--- a/docs/sdk/reference/eval-reporting.mdx
+++ b/docs/sdk/reference/eval-reporting.mdx
@@ -449,6 +449,7 @@ Advanced replay override. Most users should not construct this manually.
 | `trace` | `EvalTraceInput` | No | Conversation trace |
 | `externalIterationId` | `string` | No | Custom iteration ID |
 | `externalCaseId` | `string` | No | Custom case ID |
+| `caseId` | `string` | No | The case's declared identity ([`EvalTestConfig.id`](/sdk/reference/eval-test)). An `EvalSuite` puts this on every result automatically. The backend resolves by it first and adopts it onto a case that resolved by content hash, which is what lets a renamed test keep its history. Must equal `externalCaseId` when both are present. |
 | `metadata` | `Record<string, string \| number \| boolean>` | No | Custom metadata; values must be scalars. When the runner evaluates a case's predicates, it persists `{ predicate, passed, reason, scope? }[]` under `metadata.predicates` automatically. |
 | `isNegativeTest` | `boolean` | No | Whether this is a negative test |
 | `advancedConfig` | `Record<string, unknown>` | No | Advanced case configuration recorded with the iteration (e.g. `steps`, `system`, `temperature`) |

--- a/docs/sdk/reference/eval-test.mdx
+++ b/docs/sdk/reference/eval-test.mdx
@@ -59,7 +59,12 @@ new EvalTest(options: EvalTestConfig)
   `externalCaseId`, reuse that value verbatim as `id` — do not mint a new one.
   The hosted history for that case is keyed on `externalCaseId`, so setting
   `id` to the same value keeps the history intact. Setting `id` to a different
-  value is a hard error at ingest.
+  value is a hard error — at construction from 6.0, and at ingest.
+
+  If your `externalCaseId` is not a valid id (it was never charset-bound, so it
+  may contain spaces, slashes or punctuation), no `id` can agree with it.
+  Rename the external id itself to a conforming value and declare that same
+  value in both fields.
 
   ```typescript
   // Before

--- a/sdk/src/EvalSuite.ts
+++ b/sdk/src/EvalSuite.ts
@@ -283,6 +283,12 @@ export class EvalSuite {
       matchOptionsByTest[name] = test.getConfig().matchOptions;
       const config = test.getConfig();
       const identity = {
+        // Unconditional, unlike its three siblings: `id` is required, so
+        // there is no absent case to spread around. `identity` is therefore
+        // always non-empty and `caseIdentityByTest` goes from sparse to dense
+        // — safe because every reader looks the record up by test NAME and
+        // none of them branches on how many entries it holds.
+        caseId: config.id,
         ...(config.externalCaseId !== undefined
           ? { externalCaseId: config.externalCaseId }
           : {}),

--- a/sdk/src/EvalTest.ts
+++ b/sdk/src/EvalTest.ts
@@ -157,8 +157,6 @@ function missingCaseIdFix(
 
 /**
  * A case's identity must be DECLARED, and it must be usable in a URL, a file
- * path and a CLI argument./**
- * A case's identity must be DECLARED, and it must be usable in a URL, a file
  * path and a CLI argument.
  *
  * Deliberately NOT derived from `name` when absent: deriving it would recreate

--- a/sdk/src/EvalTest.ts
+++ b/sdk/src/EvalTest.ts
@@ -115,6 +115,49 @@ function suggestedCaseId(config: EvalTestConfig): string {
 }
 
 /**
+ * The fix sentence for a config with no `id`. Three situations, three fixes —
+ * and getting this wrong is not cosmetic.
+ *
+ * A pre-6 config carrying an `externalCaseId` that CANNOT be an id used to be
+ * told "mint one and commit it", which is a complete instruction only until
+ * `assertSingleCaseIdentity` exists. Followed verbatim it produces a minted id
+ * beside an unchanged external id — a differing pair — so the very next run
+ * throws again, and the whole migration is only revealed one error at a time.
+ * An error that prescribes a change which cannot construct is worse than one
+ * that says nothing, so that case states BOTH halves at once.
+ */
+function missingCaseIdFix(
+  external: string | undefined,
+  suggestion: string
+): string {
+  if (external === undefined) {
+    return `Mint one once and commit it: id: "${suggestion}"`;
+  }
+  if (external === suggestion) {
+    return (
+      `This test already declares \`externalCaseId\`, which is the key its ` +
+      `hosted history is joined on, so reuse it verbatim: id: "${suggestion}"`
+    );
+  }
+  // `suggestedCaseId` only reuses an `externalCaseId` that can BE an id, so
+  // reaching here means it cannot — and `id := externalCaseId`, the migration
+  // every other external-id user gets, is simply unavailable.
+  return (
+    `Its \`externalCaseId\` (${JSON.stringify(
+      external
+    )}) cannot itself be an ` +
+    `id — ids are 1-128 characters of letters, digits, '-' and '_' — so no id ` +
+    `can agree with it, and a differing pair is refused here and at ingest. ` +
+    `Rename the external id to a conforming value and declare that same value ` +
+    `in BOTH fields: id: "${suggestion}", externalCaseId: "${suggestion}". An ` +
+    `external id that was never charset-valid has no hosted history for the ` +
+    `rename to strand.`
+  );
+}
+
+/**
+ * A case's identity must be DECLARED, and it must be usable in a URL, a file
+ * path and a CLI argument./**
  * A case's identity must be DECLARED, and it must be usable in a URL, a file
  * path and a CLI argument.
  *
@@ -127,16 +170,14 @@ function assertDeclaredCaseId(config: EvalTestConfig): void {
   const label = config.name ? `"${config.name}"` : "(unnamed)";
   if (config.id === undefined || config.id === null || config.id === "") {
     const suggestion = suggestedCaseId(config);
-    const reusesExternal = suggestion === config.externalCaseId;
+    // `""` is absent here for the same reason it is in `assertSingleCaseIdentity`.
+    const external =
+      config.externalCaseId === "" ? undefined : config.externalCaseId;
     throw new Error(
       `EvalTest ${label} has no \`id\`. A case's identity is declared, not ` +
         `derived from its name — otherwise renaming the test forks its hosted ` +
         `history. ` +
-        (reusesExternal
-          ? `This test already declares \`externalCaseId\`, which is the key its ` +
-            `hosted history is joined on, so reuse it verbatim: `
-          : `Mint one once and commit it: `) +
-        `id: "${suggestion}"`
+        missingCaseIdFix(external, suggestion)
     );
   }
   const parsed = opaqueIdSchema.safeParse(config.id);

--- a/sdk/src/EvalTest.ts
+++ b/sdk/src/EvalTest.ts
@@ -1104,6 +1104,12 @@ export class EvalTest {
       this.config.matchOptions,
       this.lastEvaluationConfig ?? undefined,
       {
+        // The standalone-run twin of `EvalSuite`'s identity object. A test run
+        // directly with reporting enabled uploads through HERE, not through the
+        // suite, so leaving `caseId` off this one would mean a renamed
+        // standalone test still forks its hosted history — the exact bug the
+        // declared id exists to retire, surviving on the path nobody looked at.
+        caseId: this.config.id,
         ...(this.config.externalCaseId !== undefined
           ? { externalCaseId: this.config.externalCaseId }
           : {}),

--- a/sdk/src/EvalTest.ts
+++ b/sdk/src/EvalTest.ts
@@ -152,6 +152,53 @@ function assertDeclaredCaseId(config: EvalTestConfig): void {
 }
 
 /**
+ * One case, one identity.
+ *
+ * `id` and `externalCaseId` are two claims about WHICH case this is, and from
+ * this step on both ride the wire. Picking a winner between them silently is
+ * how one case's history gets cross-joined onto another's, so a differing pair
+ * is a hard error — here at construction, and again in the backend's ingest
+ * preflight for callers that never build an `EvalTest`. Failing here is the
+ * kinder half of the same rule: it costs a stack trace instead of a rejected
+ * upload at the end of a run.
+ *
+ * The migration is always `id := externalCaseId`, because `externalCaseId` is
+ * the key the hosted case already lives under (`external:<id>`). The one case
+ * where that is impossible is an `externalCaseId` outside the opaque-id charset
+ * — never charset-bound, so values exist that no `id` can equal — and the
+ * message says so rather than suggesting a fix that the next line rejects.
+ */
+function assertSingleCaseIdentity(config: EvalTestConfig): void {
+  const external = config.externalCaseId;
+  // `""` is absent, not present-and-conflicting. The constructor's
+  // normalization above drops a whitespace-only value but leaves a literal
+  // empty string, and `getCaseKey` reads both as "no external id" — so does
+  // the backend's equality rule (`external.length > 0 && external !== declared`).
+  // Throwing here would refuse a config the wire accepts.
+  if (external === undefined || external === "" || config.id === external) {
+    return;
+  }
+  const label = config.name ? `"${config.name}"` : "(unnamed)";
+  const externalCanBeAnId = opaqueIdSchema.safeParse(external).success;
+  throw new Error(
+    `EvalTest ${label} declares two different identities: id ` +
+      `${JSON.stringify(config.id)} and externalCaseId ` +
+      `${JSON.stringify(external)}. ` +
+      (externalCanBeAnId
+        ? `The hosted case is keyed as external:${external}, so the migration ` +
+          `is id: ${JSON.stringify(external)} — the declared id lands in the ` +
+          `join the case already lives under and its history continues.`
+        : `externalCaseId ${JSON.stringify(external)} cannot itself be an id ` +
+          `(1-128 characters of letters, digits, '-' and '_'), so no id can ` +
+          `agree with it. Rename the external id to a conforming value and ` +
+          `declare that same value as \`id\`: an external id that was never ` +
+          `charset-valid has no hosted history for the rename to strand.`) +
+      ` A differing pair is rejected at ingest too, so shipping it would fail ` +
+      `the upload rather than pick a winner.`
+  );
+}
+
+/**
  * Configuration for an EvalTest
  *
  * All tests use the multi-turn pattern with a test function that receives a
@@ -170,8 +217,10 @@ export interface EvalTestConfig {
    * `opaqueIdSchema`) — our `c_` prefix is a grep convenience, not a rule.
    *
    * Distinct from {@link EvalTestConfig.externalCaseId}, which is the hosted
-   * JOIN key with live wire semantics. Nothing on the wire changes because of
-   * this field yet; the upload payload is byte-identical to before.
+   * JOIN key that predates the charset rule. Both ride the upload now, as
+   * `caseId` and `externalCaseId`, and they must AGREE when both are set — a
+   * differing pair throws at construction and is refused at ingest. The
+   * migration for an existing `externalCaseId` user is `id := externalCaseId`.
    */
   id: string;
   name: string;
@@ -198,10 +247,12 @@ export interface EvalTestConfig {
    * case's history on the run page. Identity rides HERE, never on `name`:
    * display names collide and get renamed.
    *
-   * Kept alongside the new required {@link EvalTestConfig.id}: this one has
-   * live wire semantics that a deployed backend depends on, while `id` is the
-   * declared identity the contract now requires. Converging the two is a
-   * backend change that happens after the mirroring backend work ships.
+   * Kept alongside the required {@link EvalTestConfig.id}: this one is the
+   * `external:` join key a deployed backend depends on, while `id` is the
+   * declared identity the contract requires. Both are uploaded, so a config
+   * that sets both must set them to the SAME value — see
+   * {@link EvalTestConfig.id}. Retiring this field is a later step; it has
+   * live wire semantics until one is written to converge them.
    *
    * **NORMALIZED at construction**: surrounding whitespace is trimmed, and a
    * whitespace-only value is dropped as though it were absent. The value you
@@ -484,6 +535,10 @@ export class EvalTest {
       }
     }
     assertDeclaredCaseId(config);
+    // After `assertDeclaredCaseId`, so a config with an `externalCaseId` and
+    // no `id` gets the missing-id error that already names `id := externalCaseId`
+    // as the fix, rather than a conflict error about a field it never set.
+    assertSingleCaseIdentity(config);
     assertValidMatchOptions(config.matchOptions ?? {});
     assertLocallyEvaluablePredicates(config.predicates);
     // A negative case asserts "no tool was called", so `evaluateToolCalls`

--- a/sdk/src/PromptResult.ts
+++ b/sdk/src/PromptResult.ts
@@ -401,6 +401,7 @@ export class PromptResult {
       errorDetails: options?.errorDetails,
       trace,
       externalIterationId: options?.externalIterationId,
+      caseId: options?.caseId,
       externalCaseId: options?.externalCaseId,
       metadata: options?.metadata,
       isNegativeTest: options?.isNegativeTest,

--- a/sdk/src/errors.ts
+++ b/sdk/src/errors.ts
@@ -19,6 +19,7 @@ export type EvalReportingErrorOptions = SdkErrorOptions & {
   endpoint?: string;
   attemptCount?: number;
   isBillingLimitReached?: boolean;
+  isReportingBackendIncompatible?: boolean;
 };
 
 export class EvalReportingError extends SdkError {
@@ -26,6 +27,16 @@ export class EvalReportingError extends SdkError {
   public readonly endpoint?: string;
   public readonly attemptCount?: number;
   public readonly isBillingLimitReached: boolean;
+  /**
+   * The destination refused the report because it does not understand a field
+   * this SDK sends — a reporting backend older than the SDK's minimum contract.
+   *
+   * Flagged separately from every other rejection because the fix is different
+   * in kind: nothing about the run or the payload is wrong, so retrying, editing
+   * the suite, or reading it as a failed eval are all the wrong move. The only
+   * fix is upgrading the destination (or pointing `baseUrl` at one that is).
+   */
+  public readonly isReportingBackendIncompatible: boolean;
 
   constructor(message: string, options: EvalReportingErrorOptions = {}) {
     super(message, "EVAL_REPORTING_ERROR", options);
@@ -34,5 +45,7 @@ export class EvalReportingError extends SdkError {
     this.endpoint = options.endpoint;
     this.attemptCount = options.attemptCount;
     this.isBillingLimitReached = options.isBillingLimitReached ?? false;
+    this.isReportingBackendIncompatible =
+      options.isReportingBackendIncompatible ?? false;
   }
 }

--- a/sdk/src/eval-reporting-types.ts
+++ b/sdk/src/eval-reporting-types.ts
@@ -104,6 +104,20 @@ export type EvalResultInput = {
   trace?: EvalTraceInput;
   externalIterationId?: string;
   externalCaseId?: string;
+  /**
+   * The case's DECLARED identity (`EvalTestConfig.id`) — the id an author
+   * committed beside the test.
+   *
+   * The backend resolves by this first (`by_testSuite_declaredCaseId`), falling
+   * back to the content-hash key, and ADOPTS: an id-bearing upload that resolves
+   * by hash to a case with no declared id patches the id on without touching the
+   * immutable `caseKey`. That is what lets a renamed test keep its history.
+   *
+   * Must equal `externalCaseId` when both are present — the SDK enforces that at
+   * construction and the backend rejects a mismatch at ingest. Never a silent
+   * precedence between two identity claims.
+   */
+  caseId?: string;
   /** Extensible per-iteration metadata; predicate verdicts are nested here. */
   metadata?: Record<string, unknown>;
   isNegativeTest?: boolean;

--- a/sdk/src/eval-result-mapping.ts
+++ b/sdk/src/eval-result-mapping.ts
@@ -497,6 +497,18 @@ export interface IterationToEvalResultOptions {
   promptSelector?: "first" | "last";
   /** @see MCPJamReportingConfig.failOnToolError */
   failOnToolError?: boolean;
+  /**
+   * The case's DECLARED identity (`EvalTestConfig.id`), forwarded when given.
+   *
+   * Optional and never defaulted, because this converter cannot know it: it
+   * receives a `casePrefix`, not an `EvalTest`. Passing it is what lets a
+   * reporter built on these helpers join a renamed test to its hosted history
+   * — but note that `caseTitle` here is synthesized PER ITERATION, so one id
+   * across a run's iterations groups them as one case rather than one case per
+   * iteration. That is a deliberate choice for the caller to make, which is why
+   * nothing here supplies it on their behalf.
+   */
+  caseId?: string;
 }
 
 /**
@@ -555,6 +567,7 @@ export function iterationToEvalResult(
 
   return {
     caseTitle: options.caseTitle,
+    ...(options.caseId !== undefined ? { caseId: options.caseId } : {}),
     query: selectedPrompt?.getPrompt(),
     passed,
     durationMs: durationMs > 0 ? durationMs : undefined,
@@ -587,6 +600,8 @@ export interface RunToEvalResultsOptions {
   expectedToolCalls?: EvalExpectedToolCall[];
   promptSelector?: "first" | "last";
   failOnToolError?: boolean;
+  /** @see IterationToEvalResultOptions.caseId */
+  caseId?: string;
 }
 
 /**
@@ -604,6 +619,7 @@ export function runToEvalResults(
       expectedToolCalls: options.expectedToolCalls,
       promptSelector: options.promptSelector,
       failOnToolError: options.failOnToolError,
+      caseId: options.caseId,
     })
   );
 }
@@ -618,6 +634,13 @@ export interface SuiteRunToEvalResultsOptions {
   expectedToolCallsByTest?: Record<string, EvalExpectedToolCall[]>;
   promptSelector?: "first" | "last";
   failOnToolError?: boolean;
+  /**
+   * Declared case ids, keyed by test name — the same shape as
+   * `expectedToolCallsByTest`, because one id cannot describe a whole suite.
+   *
+   * @see IterationToEvalResultOptions.caseId
+   */
+  caseIdByTest?: Record<string, string>;
 }
 
 /**
@@ -639,6 +662,7 @@ export function suiteRunToEvalResults(
       expectedToolCalls,
       promptSelector: options.promptSelector,
       failOnToolError: options.failOnToolError,
+      caseId: options.caseIdByTest?.[testName],
     });
     results.push(...testResults);
   }

--- a/sdk/src/eval-result-mapping.ts
+++ b/sdk/src/eval-result-mapping.ts
@@ -502,11 +502,12 @@ export interface IterationToEvalResultOptions {
    *
    * Optional and never defaulted, because this converter cannot know it: it
    * receives a `casePrefix`, not an `EvalTest`. Passing it is what lets a
-   * reporter built on these helpers join a renamed test to its hosted history
-   * — but note that `caseTitle` here is synthesized PER ITERATION, so one id
-   * across a run's iterations groups them as one case rather than one case per
-   * iteration. That is a deliberate choice for the caller to make, which is why
-   * nothing here supplies it on their behalf.
+   * reporter built on these helpers join a renamed test to its hosted history.
+   *
+   * Supplying one across a run's iterations declares them ONE case rather than
+   * one case per iteration — a change to how they land hosted, which is why
+   * nothing supplies it on the caller's behalf. See {@link runToEvalResults}
+   * for the `caseTitle` consequence.
    */
   caseId?: string;
 }
@@ -606,6 +607,15 @@ export interface RunToEvalResultsOptions {
 
 /**
  * Convert all iterations from an EvalRunResult to EvalResultInput payloads.
+ *
+ * The per-iteration `-iter-N` title suffix is what makes each iteration land as
+ * its OWN hosted case, so it is dropped when a declared `caseId` is supplied:
+ * that id says these iterations are one case, and the backend then titles that
+ * case from the first result it accepts (`sdkEvals.ts`, the grouped-stats
+ * `title` is set once and never revised) — leaving a case that holds N
+ * iterations named after iteration 1, or after iteration 2 when the first is
+ * skipped. Nothing is lost by dropping it: the iteration number already rides
+ * every result as `metadata.iterationNumber`.
  */
 export function runToEvalResults(
   run: EvalRunResult,
@@ -613,7 +623,10 @@ export function runToEvalResults(
 ): EvalResultInput[] {
   return run.iterationDetails.map((iteration, index) =>
     iterationToEvalResult(iteration, index, {
-      caseTitle: `${options.casePrefix}-iter-${index + 1}`,
+      caseTitle:
+        options.caseId !== undefined
+          ? options.casePrefix
+          : `${options.casePrefix}-iter-${index + 1}`,
       provider: options.provider,
       model: options.model,
       expectedToolCalls: options.expectedToolCalls,

--- a/sdk/src/eval-result-mapping.ts
+++ b/sdk/src/eval-result-mapping.ts
@@ -380,6 +380,7 @@ export function promptsToEvalResult(
     errorDetails: overrides.errorDetails,
     trace,
     externalIterationId: overrides.externalIterationId,
+    caseId: overrides.caseId,
     externalCaseId: overrides.externalCaseId,
     metadata: overrides.metadata,
     isNegativeTest: overrides.isNegativeTest,
@@ -742,6 +743,8 @@ function syntheticStepsForCase(
  * backend reads them to join a local run to a hosted case's history.
  */
 export type EvalCaseIdentity = {
+  /** The case's DECLARED identity — `EvalTestConfig.id`. */
+  caseId?: string;
   externalCaseId?: string;
   isNegativeTest?: boolean;
   expectedOutput?: string;
@@ -787,10 +790,14 @@ export function iterationsToEvalResultInputs(
       durationMs: durationMs > 0 ? durationMs : undefined,
       expectedToolCalls,
       actualToolCalls,
-      // Hosted↔local identity and semantics. These are the SAME wire fields
-      // the backend already hashes into caseKey and renders on the run page,
-      // so a materialized hosted case joins its own history instead of
-      // appearing as a new scenario.
+      // Hosted↔local identity and semantics, on the wire. `caseId` is the
+      // DECLARED identity the backend resolves by first (and adopts onto a
+      // case that resolved by content hash); `externalCaseId` is the older
+      // join key it hashes into caseKey. Either way a materialized hosted case
+      // joins its own history instead of appearing as a new scenario.
+      ...(caseIdentity?.caseId !== undefined
+        ? { caseId: caseIdentity.caseId }
+        : {}),
       ...(caseIdentity?.externalCaseId !== undefined
         ? { externalCaseId: caseIdentity.externalCaseId }
         : {}),
@@ -880,6 +887,7 @@ export function suiteTestResultsToEvalResultInputs(
         durationMs: durationMs > 0 ? durationMs : undefined,
         expectedToolCalls,
         actualToolCalls,
+        ...(identity?.caseId !== undefined ? { caseId: identity.caseId } : {}),
         ...(identity?.externalCaseId !== undefined
           ? { externalCaseId: identity.externalCaseId }
           : {}),

--- a/sdk/src/report-eval-results.ts
+++ b/sdk/src/report-eval-results.ts
@@ -67,6 +67,7 @@ type BackendEnvelope<T> = {
 type NormalizedReportingError = {
   message: string;
   isBillingLimitReached: boolean;
+  isReportingBackendIncompatible: boolean;
 };
 
 type EvalArtifactUploadUrlResponse = {
@@ -210,13 +211,14 @@ function toEvalReportingError(
   }
 
   const rawMessage = error instanceof Error ? error.message : String(error);
-  const { message, isBillingLimitReached } =
+  const { message, isBillingLimitReached, isReportingBackendIncompatible } =
     normalizeReportingErrorMessage(rawMessage);
   return new EvalReportingError(message, {
     attemptCount,
     cause: error,
     endpoint,
     isBillingLimitReached,
+    isReportingBackendIncompatible,
     statusCode,
   });
 }
@@ -327,6 +329,77 @@ function normalizeBillingLimitMessage(
 }
 
 /**
+ * Fields this SDK sends that a reporting backend older than the minimum
+ * contract will not recognize. `caseId` (declared case identity) is the first
+ * and, for now, only one.
+ */
+const REQUIRED_BACKEND_FIELDS = ["caseId"] as const;
+
+/**
+ * Prefix that marks a message as ALREADY rewritten by
+ * {@link describeIncompatibleReportingBackend}. The rewrite quotes the backend
+ * verbatim at the end, so without a sentinel a second normalization pass would
+ * match its own output and nest the explanation inside itself.
+ */
+const INCOMPATIBLE_BACKEND_PREFIX =
+  "This reporting backend is older than this SDK requires";
+
+/**
+ * An "I do not know this field" rejection, as opposed to "this field's value is
+ * wrong".
+ *
+ * The distinction is the whole point. A backend that understands `caseId` also
+ * rejects bad ones — an unusable charset, an id that disagrees with
+ * `externalCaseId` — and those messages are written for the author and must
+ * reach them as written. What is matched here is the other thing: a strict
+ * argument validator refusing a field it has never heard of, which says nothing
+ * about the payload and everything about the destination.
+ *
+ * Phrasings are matched loosely because they are not ours to pin down. Convex
+ * says "Object contains extra field `caseId` that is not in the validator";
+ * a caller-supplied `baseUrl` reimplementing the ingest contract will say
+ * something else. Requiring the field name AND an unknown-field phrasing keeps
+ * the loose half from swallowing value errors.
+ */
+const UNKNOWN_FIELD_PHRASING =
+  /(?:extra|unknown|unexpected|unrecognized|additional)\s+(?:field|argument|propert|key)|not in the validator|is not allowed|no such (?:field|argument)/i;
+
+function isUnknownFieldRejection(rawMessage: string): boolean {
+  if (rawMessage.startsWith(INCOMPATIBLE_BACKEND_PREFIX)) return false;
+  if (!REQUIRED_BACKEND_FIELDS.some((field) => rawMessage.includes(field))) {
+    return false;
+  }
+  return UNKNOWN_FIELD_PHRASING.test(rawMessage);
+}
+
+/**
+ * Turn a strict-validator refusal into the sentence the author can act on.
+ *
+ * The public SDK reports to a caller-supplied `baseUrl`, so we cannot prove
+ * every destination is current — what we can do is not make somebody read a
+ * validator dump to learn that their deployment needs an upgrade. Three facts
+ * the raw message never carries: NOTHING was filed (argument validation is
+ * strict, so the whole upload is refused rather than the field stripped), the
+ * run itself is fine, and the fix is on the destination rather than in the
+ * suite.
+ *
+ * The backend's own words are kept at the end. They name which field and which
+ * endpoint, and a rewrite that discarded them would be harder to debug than the
+ * dump it replaced.
+ */
+function describeIncompatibleReportingBackend(rawMessage: string): string {
+  return (
+    `${INCOMPATIBLE_BACKEND_PREFIX}: it rejected \`caseId\`, the declared case ` +
+    `identity @mcpjam/sdk sends on every result. Argument validation is strict, ` +
+    `so the WHOLE report was refused rather than the field ignored — no results ` +
+    `were filed, and this is a reporting failure, not an eval verdict. Upgrade ` +
+    `the reporting backend to one that accepts declared case ids (MCPJam-hosted ` +
+    `app.mcpjam.com does), or point \`baseUrl\` at one that is. Backend said: ` +
+    rawMessage
+  );
+}
+
+/**
  * Every ingest failure message the backend hands back funnels through here on
  * its way into an `EvalReportingError`, and from there into both stderr and
  * Sentry's exception value. The string is server-controlled, and the ingest
@@ -343,9 +416,17 @@ function normalizeReportingErrorMessage(
   rawMessage: string
 ): NormalizedReportingError {
   if (!rawMessage.includes("billing_limit_reached")) {
+    // Redact FIRST, then explain: the compatibility rewrite quotes the backend
+    // verbatim, and the dump a Convex validator echoes is the ingest body —
+    // the one that carries `accessToken`/`refreshToken`/`clientSecret`.
+    const redacted = redactTelemetryString(rawMessage);
+    const incompatible = isUnknownFieldRejection(redacted);
     return {
-      message: redactTelemetryString(rawMessage),
+      message: incompatible
+        ? describeIncompatibleReportingBackend(redacted)
+        : redacted,
       isBillingLimitReached: false,
+      isReportingBackendIncompatible: incompatible,
     };
   }
 
@@ -356,6 +437,7 @@ function normalizeReportingErrorMessage(
       ? redactTelemetryString(billingMessage)
       : "Billing limit reached.",
     isBillingLimitReached: true,
+    isReportingBackendIncompatible: false,
   };
 }
 
@@ -370,6 +452,25 @@ function isBillingLimitReachedError(error: unknown): boolean {
     error.message.startsWith("Eval iteration limit reached.") ||
     normalizeReportingErrorMessage(error.message).isBillingLimitReached
   );
+}
+
+/**
+ * A rejection no retry can fix. Mirrors {@link isBillingLimitReachedError}: the
+ * destination's validator will refuse the identical payload every time, so the
+ * three backoff attempts only delay the message the author needs to read.
+ */
+function isReportingBackendIncompatibleError(error: unknown): boolean {
+  if (!(error instanceof Error)) {
+    return false;
+  }
+  if (
+    error instanceof EvalReportingError &&
+    error.isReportingBackendIncompatible
+  ) {
+    return true;
+  }
+  return normalizeReportingErrorMessage(error.message)
+    .isReportingBackendIncompatible;
 }
 
 function generateExternalRunId(): string {
@@ -478,12 +579,16 @@ async function requestWithRetry<T>(
             responseBody.error ??
             responseBody.message ??
             "Unknown SDK evals error";
-          const { message, isBillingLimitReached } =
-            normalizeReportingErrorMessage(rawMessage);
+          const {
+            message,
+            isBillingLimitReached,
+            isReportingBackendIncompatible,
+          } = normalizeReportingErrorMessage(rawMessage);
           throw new EvalReportingError(message, {
             attemptCount: attempt + 1,
             endpoint: path,
             isBillingLimitReached,
+            isReportingBackendIncompatible,
             statusCode: response.status,
           });
         }
@@ -494,10 +599,11 @@ async function requestWithRetry<T>(
         responseBody?.error ??
         responseBody?.message ??
         `Request failed with status ${response.status}: ${response.statusText}`;
-      const { message, isBillingLimitReached } =
+      const { message, isBillingLimitReached, isReportingBackendIncompatible } =
         normalizeReportingErrorMessage(rawMessage);
       if (
         !isBillingLimitReached &&
+        !isReportingBackendIncompatible &&
         isRetryableStatus(response.status) &&
         attempt < config.retryDelaysMs.length
       ) {
@@ -509,6 +615,7 @@ async function requestWithRetry<T>(
         attemptCount: attempt + 1,
         endpoint: path,
         isBillingLimitReached,
+        isReportingBackendIncompatible,
         statusCode: response.status,
       });
     } catch (error) {
@@ -521,6 +628,7 @@ async function requestWithRetry<T>(
         error instanceof EvalReportingError ? error.statusCode : undefined;
       const shouldRetry =
         !isBillingLimitReachedError(error) &&
+        !isReportingBackendIncompatibleError(error) &&
         (isAbortError ||
           error instanceof TypeError ||
           (typeof errorStatusCode === "number" &&

--- a/sdk/src/report-eval-results.ts
+++ b/sdk/src/report-eval-results.ts
@@ -344,6 +344,13 @@ const REQUIRED_BACKEND_FIELDS = ["caseId"] as const;
 const INCOMPATIBLE_BACKEND_PREFIX =
   "This reporting backend is older than this SDK requires";
 
+/** Phrasings that come BEFORE the field: "extra field `caseId`". */
+const UNKNOWN_FIELD_BEFORE =
+  "(?:extra|unknown|unexpected|unrecognized|additional)\\s+(?:field|argument|propert\\w*|key)|no such (?:field|argument)";
+/** Phrasings that come AFTER it: "`caseId` is not allowed". */
+const UNKNOWN_FIELD_AFTER =
+  "(?:is\\s+)?not\\s+(?:in the validator|allowed|permitted|a\\s+(?:valid|known|recognized)\\s+(?:field|argument|propert\\w*))";
+
 /**
  * An "I do not know this field" rejection, as opposed to "this field's value is
  * wrong".
@@ -356,20 +363,38 @@ const INCOMPATIBLE_BACKEND_PREFIX =
  * about the payload and everything about the destination.
  *
  * Phrasings are matched loosely because they are not ours to pin down. Convex
- * says "Object contains extra field `caseId` that is not in the validator";
- * a caller-supplied `baseUrl` reimplementing the ingest contract will say
- * something else. Requiring the field name AND an unknown-field phrasing keeps
- * the loose half from swallowing value errors.
+ * says "Object contains extra field `caseId` that is not in the validator"; a
+ * caller-supplied `baseUrl` reimplementing the ingest contract will say
+ * something else.
+ *
+ * The field name must be ADJACENT to the phrasing, not merely present in the
+ * message. A validator that refuses some other unknown field echoes the whole
+ * rejected object back, and that echo contains `caseId` — so "mentions caseId
+ * somewhere AND complains about an unknown field" matches a rejection that has
+ * nothing to do with declared ids, and would answer it with upgrade advice for
+ * the wrong field while suppressing the retry it might deserve. Adjacency is
+ * what separates the sentence from the payload dump that follows it.
  */
-const UNKNOWN_FIELD_PHRASING =
-  /(?:extra|unknown|unexpected|unrecognized|additional)\s+(?:field|argument|propert|key)|not in the validator|is not allowed|no such (?:field|argument)/i;
+function rejectsFieldAsUnknown(message: string, field: string): boolean {
+  // Only quoting and punctuation may sit between the phrase and the name —
+  // "extra field `caseId`", never "extra field `metadata` … {caseId: …}".
+  const phraseThenField = new RegExp(
+    `(?:${UNKNOWN_FIELD_BEFORE})[\\s:='"\`]{0,4}${field}\\b`,
+    "i"
+  );
+  // The mirror image, bounded to one line so it cannot reach into the dump.
+  const fieldThenPhrase = new RegExp(
+    `\\b${field}["'\`]?[^\\n]{0,24}?(?:${UNKNOWN_FIELD_AFTER})`,
+    "i"
+  );
+  return phraseThenField.test(message) || fieldThenPhrase.test(message);
+}
 
 function isUnknownFieldRejection(rawMessage: string): boolean {
   if (rawMessage.startsWith(INCOMPATIBLE_BACKEND_PREFIX)) return false;
-  if (!REQUIRED_BACKEND_FIELDS.some((field) => rawMessage.includes(field))) {
-    return false;
-  }
-  return UNKNOWN_FIELD_PHRASING.test(rawMessage);
+  return REQUIRED_BACKEND_FIELDS.some((field) =>
+    rejectsFieldAsUnknown(rawMessage, field)
+  );
 }
 
 /**

--- a/sdk/tests/EvalTest.test.ts
+++ b/sdk/tests/EvalTest.test.ts
@@ -125,6 +125,40 @@ describe("EvalTest", () => {
         ).toThrow(/invalid `id`/);
       });
 
+      it("gives a non-conforming externalCaseId the WHOLE migration at once", () => {
+        // A pre-6 config with an `externalCaseId` that cannot be an id and no
+        // `id` at all. Suggesting a bare mint here would prescribe a change
+        // that fails on the very next construction — the minted id beside the
+        // unchanged external id is exactly the pair `assertSingleCaseIdentity`
+        // rejects — so this error has to state both halves.
+        let message = "";
+        try {
+          new EvalTest({
+            externalCaseId: "refund flow/1",
+            name: "pre-6 config",
+            test: async () => true,
+          } as unknown as ConstructorParameters<typeof EvalTest>[0]);
+        } catch (error) {
+          message = error instanceof Error ? error.message : String(error);
+        }
+        expect(message).toContain("has no `id`");
+        expect(message).toContain("cannot itself be an id");
+        expect(message).toContain("BOTH fields");
+
+        // And the fix it prescribes must actually construct.
+        const suggested = message.match(/id: "([^"]+)"/)?.[1];
+        expect(suggested).toMatch(/^c_[A-Za-z0-9_-]+$/);
+        expect(
+          () =>
+            new EvalTest({
+              id: suggested!,
+              externalCaseId: suggested!,
+              name: "pre-6 config",
+              test: async () => true,
+            })
+        ).not.toThrow();
+      });
+
       it("refuses two disagreeing identity claims, naming the migration", () => {
         // `id` and `externalCaseId` both ride the wire now, so a differing
         // pair is a hard error rather than a silent precedence — the same

--- a/sdk/tests/EvalTest.test.ts
+++ b/sdk/tests/EvalTest.test.ts
@@ -125,6 +125,78 @@ describe("EvalTest", () => {
         ).toThrow(/invalid `id`/);
       });
 
+      it("refuses two disagreeing identity claims, naming the migration", () => {
+        // `id` and `externalCaseId` both ride the wire now, so a differing
+        // pair is a hard error rather than a silent precedence — the same
+        // rule the backend applies at ingest, applied a run earlier.
+        let message = "";
+        try {
+          new EvalTest({
+            id: "c_minted",
+            externalCaseId: "legacy_case_7",
+            name: "two-identities",
+            test: async () => true,
+          });
+        } catch (error) {
+          message = error instanceof Error ? error.message : String(error);
+        }
+        expect(message).toContain("declares two different identities");
+        expect(message).toContain('id "c_minted"');
+        expect(message).toContain('externalCaseId "legacy_case_7"');
+        // The migration rule, stated as the fix: id := externalCaseId.
+        expect(message).toContain("external:legacy_case_7");
+        expect(message).toContain('id: "legacy_case_7"');
+        // And why shipping it anyway is not an option.
+        expect(message).toContain("rejected at ingest");
+      });
+
+      it("accepts the migrated pair, and an empty externalCaseId", () => {
+        expect(
+          () =>
+            new EvalTest({
+              id: "legacy_case_7",
+              externalCaseId: "legacy_case_7",
+              name: "migrated",
+              test: async () => true,
+            })
+        ).not.toThrow();
+        // `""` is absent, not a second claim — `getCaseKey` and the backend's
+        // equality rule both read it as "no external id".
+        expect(
+          () =>
+            new EvalTest({
+              id: "c_minted",
+              externalCaseId: "",
+              name: "empty-external",
+              test: async () => true,
+            })
+        ).not.toThrow();
+      });
+
+      it("tells a non-conforming externalCaseId to rename, not to migrate", () => {
+        // The one behavior break in this step. W0.1a suggested a freshly
+        // MINTED id for these configs (`suggestedCaseId` only reuses an
+        // `externalCaseId` that can BE an id), so the pair it produced now
+        // throws — and no `id` can equal a value outside the charset, so the
+        // fix cannot be `id := externalCaseId`.
+        let message = "";
+        try {
+          new EvalTest({
+            id: "c_minted",
+            externalCaseId: "refund flow/1",
+            name: "unmintable-external",
+            test: async () => true,
+          });
+        } catch (error) {
+          message = error instanceof Error ? error.message : String(error);
+        }
+        expect(message).toContain("declares two different identities");
+        expect(message).toContain("cannot itself be an id");
+        expect(message).toContain("Rename the external id");
+        // Never the migration that the very next construction would reject.
+        expect(message).not.toContain('id: "refund flow/1"');
+      });
+
       it("accepts ids the platform already issues", () => {
         for (const id of [
           "jd7fk3m2q9x5p1v8s4t6w0y2z",

--- a/sdk/tests/declared-case-id-wire.test.ts
+++ b/sdk/tests/declared-case-id-wire.test.ts
@@ -336,12 +336,22 @@ describe("declared case id on the upload", () => {
       caseId: "c_run",
     });
     expect(declared.map((result) => result.caseId)).toEqual(["c_run", "c_run"]);
-    // `caseTitle` is still synthesized per iteration — supplying an id groups
-    // them, it does not rename them.
-    expect(declared.map((result) => result.caseTitle)).toEqual([
-      "run-iter-1",
-      "run-iter-2",
+    // The `-iter-N` suffix is what makes each iteration its own hosted case, so
+    // declaring one id drops it: the backend titles a grouped case from the
+    // first result it accepts, and keeping the suffix would leave a case that
+    // holds both iterations named "run-iter-1".
+    expect(declared.map((result) => result.caseTitle)).toEqual(["run", "run"]);
+    // The iteration number is not lost — it rides the metadata, as it did
+    // before this option existed.
+    expect(declared.map((result) => result.metadata?.iterationNumber)).toEqual([
+      1, 2,
     ]);
+    // And without an id, the per-iteration titles are exactly as they were.
+    expect(
+      runToEvalResults(run, { casePrefix: "run" }).map(
+        (result) => result.caseTitle
+      )
+    ).toEqual(["run-iter-1", "run-iter-2"]);
 
     const suite = suiteRunToEvalResults(
       new Map([
@@ -381,8 +391,19 @@ describe("declared case id on the upload", () => {
 
     expect(bare[0].caseId).toBeUndefined();
     expect("caseId" in bare[0]).toBe(false);
-    const { caseId: _dropped, ...withoutCaseId } = declared[0];
-    expect(withoutCaseId).toEqual(bare[0]);
+
+    // Declaring an id changes exactly two keys and no others: `caseId` is
+    // added, and `caseTitle` loses the `-iter-N` suffix because the id says
+    // these iterations are one case rather than one case each.
+    const {
+      caseId: _dropped,
+      caseTitle: declaredTitle,
+      ...declaredRest
+    } = declared[0];
+    const { caseTitle: bareTitle, ...bareRest } = bare[0];
+    expect(declaredRest).toEqual(bareRest);
+    expect(bareTitle).toBe("run-iter-1");
+    expect(declaredTitle).toBe("run");
   });
 
   it("forwards caseId through the low-level prompt mappers", () => {

--- a/sdk/tests/declared-case-id-wire.test.ts
+++ b/sdk/tests/declared-case-id-wire.test.ts
@@ -142,6 +142,31 @@ describe("declared case id on the upload", () => {
     expect(results[0].caseTitle).toBe("refund flow");
   });
 
+  it("serializes `caseId` from a standalone EvalTest run too", async () => {
+    // `EvalTest.run()` with reporting enabled uploads through its OWN identity
+    // object, not the suite's. A renamed standalone test would keep forking its
+    // history if only the suite path carried the id.
+    const fetchMock = vi.fn().mockResolvedValue(okResponse());
+    global.fetch = fetchMock as any;
+
+    const test = new EvalTest({
+      id: "c_standalone",
+      name: "standalone case",
+      test: async (executor) => {
+        await executor.run("go");
+        return true;
+      },
+    });
+    await test.run(mockAgent(), {
+      iterations: 1,
+      mcpjam: { apiKey: "sk_test_key", baseUrl: BASE_URL },
+    });
+
+    const [result] = uploadedResults(fetchMock);
+    expect(result.caseId).toBe("c_standalone");
+    expect(result.caseTitle).toBe("standalone case");
+  });
+
   it("emits caseId === externalCaseId for a hosted corpus case", () => {
     // `loadCorpus` satisfies the equality rule by construction — it declares
     // the hosted case's own id in BOTH fields. Verified rather than assumed,
@@ -414,6 +439,37 @@ describe("a reporting backend that does not understand caseId", () => {
     await expect(
       reportEvalResultsSafely({ ...input, strict: true })
     ).rejects.toThrow(/older than this SDK requires/);
+  });
+
+  it("does not claim incompatibility when a DIFFERENT field was rejected", async () => {
+    // The validator refuses `metadata` and echoes the rejected object back —
+    // and that echo contains `caseId`. Answering this with "upgrade your
+    // backend, it does not know caseId" would send the author to fix a field
+    // the backend accepted, and would suppress a retry this may deserve.
+    const otherField =
+      "ArgumentValidationError: Object contains extra field `metadata` that " +
+      'is not in the validator.\n\nObject: {caseTitle: "refund flow", ' +
+      'caseId: "c_refund", metadata: {run: 1}}\n' +
+      "Validator: v.object({caseTitle: v.string(), caseId: v.optional(v.string())})";
+    global.fetch = vi.fn().mockResolvedValue({
+      ok: false,
+      status: 400,
+      statusText: "Bad Request",
+      json: async () => ({ ok: false, error: otherField }),
+    }) as any;
+
+    const error = await reportEvalResults(input).then(
+      () => null,
+      (thrown) => thrown
+    );
+
+    expect((error as EvalReportingError).isReportingBackendIncompatible).toBe(
+      false
+    );
+    expect((error as Error).message).toBe(otherField);
+    expect((error as Error).message).not.toContain(
+      "older than this SDK requires"
+    );
   });
 
   it("leaves a backend that DOES understand caseId to speak for itself", async () => {

--- a/sdk/tests/declared-case-id-wire.test.ts
+++ b/sdk/tests/declared-case-id-wire.test.ts
@@ -25,6 +25,8 @@ import { evalTestFromPlatformCase } from "../src/corpus";
 import {
   iterationsToEvalResultInputs,
   promptsToEvalResult,
+  runToEvalResults,
+  suiteRunToEvalResults,
 } from "../src/eval-result-mapping";
 import {
   reportEvalResults,
@@ -312,6 +314,75 @@ describe("declared case id on the upload", () => {
     for (const result of results) {
       expect(result.externalCaseId).toBeUndefined();
     }
+  });
+
+  it("forwards caseId through the run-conversion helpers when asked", () => {
+    // These helpers carry no identity of their own — they receive a
+    // `casePrefix`, not an `EvalTest` — so `caseId` is offered and never
+    // defaulted. A caller who wants a run's iterations joined to one declared
+    // case can now say so; one who says nothing gets exactly what they got
+    // before.
+    const iteration = {
+      passed: true,
+      prompts: [mockPromptResult("hello")],
+      latencies: [{ e2eMs: 10, llmMs: 8, mcpMs: 2 }],
+      tokens: { input: 5, output: 5, total: 10 },
+      retryCount: 0,
+    } as never;
+    const run = { iterationDetails: [iteration, iteration] } as never;
+
+    const declared = runToEvalResults(run, {
+      casePrefix: "run",
+      caseId: "c_run",
+    });
+    expect(declared.map((result) => result.caseId)).toEqual(["c_run", "c_run"]);
+    // `caseTitle` is still synthesized per iteration — supplying an id groups
+    // them, it does not rename them.
+    expect(declared.map((result) => result.caseTitle)).toEqual([
+      "run-iter-1",
+      "run-iter-2",
+    ]);
+
+    const suite = suiteRunToEvalResults(
+      new Map([
+        ["first", run],
+        ["second", run],
+      ]),
+      { casePrefix: "s", caseIdByTest: { first: "c_first" } }
+    );
+    expect(suite.map((result) => result.caseId)).toEqual([
+      "c_first",
+      "c_first",
+      undefined,
+      undefined,
+    ]);
+  });
+
+  it("leaves the run-conversion payload byte-identical when no caseId is given", () => {
+    // The additive guarantee, diffed rather than asserted by eye: a caller who
+    // passes nothing must get the pre-change payload back, key for key.
+    const iteration = {
+      passed: true,
+      prompts: [mockPromptResult("hello")],
+      latencies: [{ e2eMs: 10, llmMs: 8, mcpMs: 2 }],
+      tokens: { input: 5, output: 5, total: 10 },
+      retryCount: 0,
+    } as never;
+    const run = { iterationDetails: [iteration] } as never;
+
+    const bare = JSON.parse(
+      JSON.stringify(runToEvalResults(run, { casePrefix: "run" }))
+    );
+    const declared = JSON.parse(
+      JSON.stringify(
+        runToEvalResults(run, { casePrefix: "run", caseId: "c_run" })
+      )
+    );
+
+    expect(bare[0].caseId).toBeUndefined();
+    expect("caseId" in bare[0]).toBe(false);
+    const { caseId: _dropped, ...withoutCaseId } = declared[0];
+    expect(withoutCaseId).toEqual(bare[0]);
   });
 
   it("forwards caseId through the low-level prompt mappers", () => {

--- a/sdk/tests/declared-case-id-wire.test.ts
+++ b/sdk/tests/declared-case-id-wire.test.ts
@@ -1,0 +1,443 @@
+/**
+ * The declared case id ON THE WIRE.
+ *
+ * W0.1a made `EvalTestConfig.id` required but changed no payload byte; this is
+ * the step that puts it in the upload. The load-bearing assertions here are
+ * therefore made against the SERIALIZED request body, not against the in-memory
+ * result objects — "the field reaches the backend" is the claim, and a mapper
+ * that builds it correctly into an object nobody sends proves nothing.
+ */
+const sentryMocks = vi.hoisted(() => ({
+  addBreadcrumb: vi.fn().mockResolvedValue(undefined),
+  captureEvalReportingFailure: vi.fn().mockResolvedValue(undefined),
+}));
+
+vi.mock("../src/sentry", () => ({
+  addBreadcrumb: sentryMocks.addBreadcrumb,
+  captureEvalReportingFailure: sentryMocks.captureEvalReportingFailure,
+}));
+
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { EvalSuite } from "../src/EvalSuite";
+import { EvalTest } from "../src/EvalTest";
+import { PromptResult } from "../src/PromptResult";
+import { evalTestFromPlatformCase } from "../src/corpus";
+import {
+  iterationsToEvalResultInputs,
+  promptsToEvalResult,
+} from "../src/eval-result-mapping";
+import {
+  reportEvalResults,
+  reportEvalResultsSafely,
+} from "../src/report-eval-results";
+import { EvalReportingError } from "../src/errors";
+import type { EvalResultInput } from "../src/eval-reporting-types";
+import type { HostRunner } from "../src/HostRunner";
+import type { PlatformEvalCase } from "../src/platform/types";
+
+const BASE_URL = "https://backend.test";
+
+function mockPromptResult(prompt: string): PromptResult {
+  return PromptResult.from({
+    prompt,
+    messages: [
+      { role: "user", content: prompt },
+      { role: "assistant", content: "ok" },
+    ],
+    text: "ok",
+    toolCalls: [],
+    usage: { inputTokens: 5, outputTokens: 5, totalTokens: 10 },
+    latency: { e2eMs: 10, llmMs: 8, mcpMs: 2 },
+  });
+}
+
+/** Minimal executor: no `getHostSnapshot`, so no capability probe fires. */
+function mockAgent(): HostRunner {
+  const create = (): HostRunner => {
+    let history: PromptResult[] = [];
+    return {
+      run: async (message: string) => {
+        const result = mockPromptResult(message);
+        history.push(result);
+        return result;
+      },
+      resetPromptHistory: () => {
+        history = [];
+      },
+      getPromptHistory: () => [...history],
+      withOptions: () => create(),
+    } as unknown as HostRunner;
+  };
+  return create();
+}
+
+function okResponse(): any {
+  return {
+    ok: true,
+    status: 200,
+    statusText: "OK",
+    json: async () => ({
+      ok: true,
+      suiteId: "suite_1",
+      runId: "run_1",
+      status: "completed",
+      result: "passed",
+      summary: { total: 1, passed: 1, failed: 0, passRate: 1 },
+    }),
+  };
+}
+
+/** The results array exactly as it was serialized onto the request body. */
+function uploadedResults(fetchMock: ReturnType<typeof vi.fn>): any[] {
+  const body = JSON.parse(fetchMock.mock.calls[0][1].body as string);
+  return body.results;
+}
+
+async function runSuiteAndCapture(suite: EvalSuite): Promise<any[]> {
+  const fetchMock = vi.fn().mockResolvedValue(okResponse());
+  global.fetch = fetchMock as any;
+  await suite.run(mockAgent(), {
+    iterations: 1,
+    mcpjam: { apiKey: "sk_test_key", baseUrl: BASE_URL },
+  });
+  expect(fetchMock).toHaveBeenCalled();
+  return uploadedResults(fetchMock);
+}
+
+describe("declared case id on the upload", () => {
+  const originalFetch = global.fetch;
+  const originalBaseUrl = process.env.MCPJAM_BASE_URL;
+  const originalApiKey = process.env.MCPJAM_API_KEY;
+
+  afterEach(() => {
+    global.fetch = originalFetch;
+    if (originalBaseUrl === undefined) delete process.env.MCPJAM_BASE_URL;
+    else process.env.MCPJAM_BASE_URL = originalBaseUrl;
+    if (originalApiKey === undefined) delete process.env.MCPJAM_API_KEY;
+    else process.env.MCPJAM_API_KEY = originalApiKey;
+    sentryMocks.addBreadcrumb.mockClear();
+    sentryMocks.captureEvalReportingFailure.mockClear();
+    vi.restoreAllMocks();
+  });
+
+  it("serializes `caseId` from the config onto every result", async () => {
+    const suite = new EvalSuite({ name: "wire" });
+    suite.add(
+      new EvalTest({
+        id: "c_refund_flow",
+        name: "refund flow",
+        test: async (executor) => {
+          await executor.run("ask for a refund");
+          return true;
+        },
+      })
+    );
+
+    const results = await runSuiteAndCapture(suite);
+
+    expect(results).toHaveLength(1);
+    expect(results[0].caseId).toBe("c_refund_flow");
+    // The whole point of the field: the id survives a rename of the display
+    // name, which the title does not.
+    expect(results[0].caseTitle).toBe("refund flow");
+  });
+
+  it("emits caseId === externalCaseId for a hosted corpus case", () => {
+    // `loadCorpus` satisfies the equality rule by construction — it declares
+    // the hosted case's own id in BOTH fields. Verified rather than assumed,
+    // because a drift here throws at construction for every corpus user.
+    const platformCase: PlatformEvalCase = {
+      id: "case_hosted_1",
+      title: "Refund flow",
+      steps: [{ id: "s1", kind: "prompt", prompt: "Ask for a refund" }],
+      iterations: 1,
+      isNegative: false,
+      models: [{ provider: "openai", model: "gpt-4o" } as never],
+      createdAt: 1,
+      updatedAt: 2,
+    };
+    const test = evalTestFromPlatformCase(platformCase);
+    const config = test.getConfig();
+
+    expect(config.id).toBe("case_hosted_1");
+    expect(config.externalCaseId).toBe("case_hosted_1");
+
+    const [result] = iterationsToEvalResultInputs(
+      config.name ?? "",
+      [
+        {
+          passed: true,
+          prompts: [mockPromptResult("Ask for a refund")],
+          latencies: [{ e2eMs: 10, llmMs: 8, mcpMs: 2 }],
+          tokens: { input: 5, output: 5, total: 10 },
+        } as never,
+      ],
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      { caseId: config.id, externalCaseId: config.externalCaseId }
+    );
+    expect(result.caseId).toBe("case_hosted_1");
+    expect(result.externalCaseId).toBe("case_hosted_1");
+  });
+
+  it("adds caseId and changes nothing else about a legacy payload", async () => {
+    // Diffed, not eyeballed: the same iteration is mapped twice, once with a
+    // declared identity and once with none, and the two payloads must differ
+    // in exactly one key.
+    const iterations = [
+      {
+        passed: true,
+        prompts: [mockPromptResult("hello")],
+        latencies: [{ e2eMs: 10, llmMs: 8, mcpMs: 2 }],
+        tokens: { input: 5, output: 5, total: 10 },
+        retryCount: 0,
+      } as never,
+    ];
+    const mapArgs = [
+      "legacy case",
+      iterations,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+    ] as const;
+
+    const legacy = JSON.parse(
+      JSON.stringify(iterationsToEvalResultInputs(...mapArgs))
+    );
+    const declared = JSON.parse(
+      JSON.stringify(
+        iterationsToEvalResultInputs(...mapArgs, { caseId: "c_legacy" })
+      )
+    );
+
+    expect(declared).toHaveLength(1);
+    expect(declared[0].caseId).toBe("c_legacy");
+    const { caseId: _dropped, ...withoutCaseId } = declared[0];
+    expect(withoutCaseId).toEqual(legacy[0]);
+
+    // And on the wire, a config with no `externalCaseId` gains `caseId` and
+    // no other key.
+    const suite = new EvalSuite({ name: "legacy" });
+    suite.add(
+      new EvalTest({
+        id: "c_legacy",
+        name: "legacy case",
+        test: async (executor) => {
+          await executor.run("hello");
+          return true;
+        },
+      })
+    );
+    const [uploaded] = await runSuiteAndCapture(suite);
+    expect(uploaded.caseId).toBe("c_legacy");
+    // `externalIterationId` is stamped on by the reporter, not the mapper.
+    const {
+      caseId: _uploadedId,
+      externalIterationId,
+      ...uploadedMapped
+    } = uploaded;
+    expect(typeof externalIterationId).toBe("string");
+    expect(Object.keys(uploadedMapped).sort()).toEqual(
+      Object.keys(legacy[0]).sort()
+    );
+  });
+
+  it("keeps per-test identity when no test declares an externalCaseId", async () => {
+    // `caseIdentityByTest` used to be sparse — populated only for tests that
+    // set one of the three optional identity fields — and a required `id`
+    // makes it dense. Every reader keys it by test NAME, so the change is
+    // safe; this is the guard that says so.
+    const suite = new EvalSuite({ name: "dense" });
+    suite.add(
+      new EvalTest({
+        id: "c_first",
+        name: "first",
+        test: async (executor) => {
+          await executor.run("one");
+          return true;
+        },
+      })
+    );
+    suite.add(
+      new EvalTest({
+        id: "c_second",
+        name: "second",
+        test: async (executor) => {
+          await executor.run("two");
+          return false;
+        },
+      })
+    );
+
+    const results = await runSuiteAndCapture(suite);
+
+    expect(
+      results.map((result) => [result.caseTitle, result.caseId, result.passed])
+    ).toEqual([
+      ["first", "c_first", true],
+      ["second", "c_second", false],
+    ]);
+    for (const result of results) {
+      expect(result.externalCaseId).toBeUndefined();
+    }
+  });
+
+  it("forwards caseId through the low-level prompt mappers", () => {
+    const prompt = mockPromptResult("hello");
+
+    const withId = promptsToEvalResult([prompt], {
+      caseTitle: "case",
+      passed: true,
+      caseId: "c_prompts",
+    });
+    expect(withId.caseId).toBe("c_prompts");
+
+    const withoutId = promptsToEvalResult([prompt], {
+      caseTitle: "case",
+      passed: true,
+    });
+    expect(withoutId.caseId).toBeUndefined();
+    expect(JSON.stringify(withoutId)).not.toContain("caseId");
+
+    const single = prompt.toEvalResult({
+      caseTitle: "case",
+      caseId: "c_single",
+    });
+    expect(single.caseId).toBe("c_single");
+    expect(prompt.toEvalResult({ caseTitle: "case" }).caseId).toBeUndefined();
+    expect(
+      JSON.stringify(prompt.toEvalResult({ caseTitle: "case" }))
+    ).not.toContain("caseId");
+  });
+});
+
+describe("a reporting backend that does not understand caseId", () => {
+  const originalFetch = global.fetch;
+  const originalBaseUrl = process.env.MCPJAM_BASE_URL;
+
+  // What a Convex validator predating W0.1b hands back. Strict argument
+  // validation refuses the WHOLE upload rather than stripping the field, so
+  // this is a rejection with nothing filed — not a partial write.
+  const ARGUMENT_VALIDATION_ERROR =
+    "ArgumentValidationError: Object contains extra field `caseId` that is " +
+    'not in the validator.\n\nObject: {caseTitle: "refund flow"}\n' +
+    "Validator: v.object({caseTitle: v.string()})";
+
+  function rejectingFetch(status: number) {
+    return vi.fn().mockResolvedValue({
+      ok: false,
+      status,
+      statusText: "Internal Server Error",
+      json: async () => ({ ok: false, error: ARGUMENT_VALIDATION_ERROR }),
+    });
+  }
+
+  const input = {
+    apiKey: "sk_test_key",
+    baseUrl: BASE_URL,
+    suiteName: "compat",
+    results: [
+      { caseTitle: "refund flow", passed: true, caseId: "c_refund" },
+    ] as EvalResultInput[],
+  };
+
+  afterEach(() => {
+    global.fetch = originalFetch;
+    if (originalBaseUrl === undefined) delete process.env.MCPJAM_BASE_URL;
+    else process.env.MCPJAM_BASE_URL = originalBaseUrl;
+    sentryMocks.addBreadcrumb.mockClear();
+    sentryMocks.captureEvalReportingFailure.mockClear();
+    vi.restoreAllMocks();
+  });
+
+  it("surfaces an actionable upgrade error, not a validator dump", async () => {
+    global.fetch = rejectingFetch(500) as any;
+
+    const error = await reportEvalResults(input).then(
+      () => null,
+      (thrown) => thrown
+    );
+
+    expect(error).toBeInstanceOf(EvalReportingError);
+    expect((error as EvalReportingError).isReportingBackendIncompatible).toBe(
+      true
+    );
+    const message = (error as Error).message;
+    expect(message).toContain("older than this SDK requires");
+    // Names the field, what was lost, and where the fix lives.
+    expect(message).toContain("caseId");
+    expect(message).toContain("no results were filed");
+    expect(message).toContain("baseUrl");
+    // A reporting failure, said in those words — never a verdict on the run.
+    expect(message).toContain("not an eval verdict");
+    // The backend's own words survive: they name the endpoint and the field.
+    expect(message).toContain("ArgumentValidationError");
+  });
+
+  it("does not retry a rejection no retry can fix", async () => {
+    // 500 is normally retried three times with backoff. A strict validator
+    // will refuse the identical payload every time, so the retries only delay
+    // the message the author needs to read.
+    const fetchMock = rejectingFetch(500);
+    global.fetch = fetchMock as any;
+
+    await expect(reportEvalResults(input)).rejects.toThrow(
+      /older than this SDK requires/
+    );
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("stays a warning and a null result through the safe entry point", async () => {
+    global.fetch = rejectingFetch(500) as any;
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+
+    await expect(reportEvalResultsSafely(input)).resolves.toBeNull();
+
+    expect(warn).toHaveBeenCalledTimes(1);
+    const warning = warn.mock.calls[0][0] as string;
+    expect(warning).toContain("eval reporting failed");
+    expect(warning).toContain("older than this SDK requires");
+    // The run's own verdicts are untouched — nothing here reports a failure.
+    expect(input.results[0].passed).toBe(true);
+  });
+
+  it("still throws from the safe entry point under strict", async () => {
+    global.fetch = rejectingFetch(500) as any;
+
+    await expect(
+      reportEvalResultsSafely({ ...input, strict: true })
+    ).rejects.toThrow(/older than this SDK requires/);
+  });
+
+  it("leaves a backend that DOES understand caseId to speak for itself", async () => {
+    // An invalid-id or conflicting-identity rejection is a content error the
+    // author must read as written; rewriting it as "upgrade your backend"
+    // would send them to fix the wrong thing.
+    const conflict =
+      'Conflicting case identity for "refund flow": caseId "c_a" and ' +
+      'externalCaseId "c_b" are two different claims about which case this is.';
+    global.fetch = vi.fn().mockResolvedValue({
+      ok: false,
+      status: 400,
+      statusText: "Bad Request",
+      json: async () => ({ ok: false, error: conflict }),
+    }) as any;
+
+    const error = await reportEvalResults(input).then(
+      () => null,
+      (thrown) => thrown
+    );
+
+    expect((error as EvalReportingError).isReportingBackendIncompatible).toBe(
+      false
+    );
+    expect((error as Error).message).toBe(conflict);
+  });
+});

--- a/vitest/tests/packaging.e2e.mjs
+++ b/vitest/tests/packaging.e2e.mjs
@@ -152,7 +152,11 @@ export function suiteOf(EvalSuite, EvalTest, cases) {
     suite.add(new EvalTest({
       // \`id\` is the case's declared identity and is required by @mcpjam/sdk.
       // Passed through from the scenario so the packaged tarball is exercised
-      // against the same shape a consumer writes.
+      // against the same shape a consumer writes. Where a scenario also sets
+      // \`externalCaseId\`, the two carry the SAME value: they are two claims
+      // about one case, and @mcpjam/sdk rejects a differing pair. The scenarios
+      // keep the external id because the \`[id]\` title suffix is derived from
+      // it, and the output assertions below match on that suffix.
       id: entry.id,
       name: entry.name,
       ...(entry.externalCaseId ? { externalCaseId: entry.externalCaseId } : {}),
@@ -181,7 +185,7 @@ import { describeEvalSuite } from "@mcpjam/vitest";
 import { StubExecutor, suiteOf } from "./support.mjs";
 
 describeEvalSuite("packaged suite", suiteOf(EvalSuite, EvalTest, [
-  { id: "c_green", name: "a case that passes", externalCaseId: "case_green", passes: true },
+  { id: "case_green", name: "a case that passes", externalCaseId: "case_green", passes: true },
 ]), {
   executor: new StubExecutor(),
   run: { iterations: 1, mcpjam: { enabled: false } },
@@ -200,7 +204,7 @@ import { describeEvalSuite } from "@mcpjam/vitest";
 import { StubExecutor, suiteOf } from "./support.mjs";
 
 describeEvalSuite("packaged suite", suiteOf(EvalSuite, EvalTest, [
-  { id: "c_red", name: "a case that fails", externalCaseId: "case_red", passes: false },
+  { id: "case_red", name: "a case that fails", externalCaseId: "case_red", passes: false },
 ]), {
   executor: new StubExecutor(),
   run: { iterations: 1, mcpjam: { enabled: false } },
@@ -225,7 +229,7 @@ import { describeEvalSuite } from "@mcpjam/vitest";
 import { StubExecutor, suiteOf } from "./support.mjs";
 
 describeEvalSuite("packaged suite", suiteOf(EvalSuite, EvalTest, [
-  { id: "c_green", name: "a case that passes", externalCaseId: "case_green", passes: true },
+  { id: "case_green", name: "a case that passes", externalCaseId: "case_green", passes: true },
 ]), {
   executor: new StubExecutor(),
   run: { iterations: 1, mcpjam: { enabled: false } },

--- a/vitest/tests/plan.test.ts
+++ b/vitest/tests/plan.test.ts
@@ -25,8 +25,11 @@ let mintedCaseIds = 0;
 
 function evalTest(name: string, externalCaseId?: string): EvalTest {
   mintedCaseIds += 1;
+  // A corpus case declares its hosted id in BOTH fields — `id` and
+  // `externalCaseId` are two claims about the same case, and `EvalTest`
+  // rejects a differing pair. Only a local test mints an id of its own.
   return new EvalTest({
-    id: `c_plan_${mintedCaseIds}`,
+    id: externalCaseId ?? `c_plan_${mintedCaseIds}`,
     name,
     ...(externalCaseId ? { externalCaseId } : {}),
     test: async () => true,
@@ -51,7 +54,7 @@ describe("planEvalSuite", () => {
       title: "Refund flow [case_123]",
       testName: "Refund flow",
       scenarioId: "case_123",
-      caseId: expect.stringMatching(/^c_plan_\d+$/),
+      caseId: "case_123",
     });
   });
 

--- a/vitest/tests/register.test.ts
+++ b/vitest/tests/register.test.ts
@@ -27,7 +27,9 @@ function passingSuite(): EvalSuite {
   const suite = new EvalSuite({ name: "registered suite" });
   suite.add(
     new EvalTest({
-      id: "c_register_first",
+      // A corpus-backed case declares its hosted id in both fields; `EvalTest`
+      // rejects a differing pair.
+      id: "case_first",
       name: "answers the first prompt",
       externalCaseId: "case_first",
       test: async (executor) => {


### PR DESCRIPTION
W0.1a made `EvalTestConfig.id` required but changed **no payload byte** — the field was declared and inert. W0.1b taught the backend to accept, validate, resolve and adopt a declared `caseId`, and it is deployed. This PR connects the two: `caseId` now rides the wire on every result the SDK reports, and the SDK refuses at construction to ship two disagreeing identity claims.

After this step a renamed test keeps its hosted history on the SDK path. W0.2 is the acceptance test that proves it end-to-end.

## What changed

All in `sdk/src/`, plus `@mcpjam/vitest` fixtures and two doc pages.

- **`eval-reporting-types.ts`** — `EvalResultInput` gains an optional `caseId`, beside `externalCaseId`.
- **`eval-result-mapping.ts`** — `EvalCaseIdentity` carries it; both identity spreads (`iterationsToEvalResultInputs` and its twin in `suiteTestResultsToEvalResultInputs`) emit it **first**, so the declared identity reads as the primary one. `promptsToEvalResult` forwards `overrides.caseId`.
- **`PromptResult.ts`** — `toEvalResult` forwards `options.caseId`. Without it, `toEvalResult` would be a reporting entry point that never adopts — the exact bug class this step closes.
- **`EvalSuite.ts` and `EvalTest.ts`** — **both** identity-construction sites populate `caseId` from the config's `id`. `EvalSuite.buildEvalResultInputs` covers a suite run; `EvalTest.buildEvalResultInputs` covers a test run directly with reporting enabled.
- **`EvalTest.ts`** — new `assertSingleCaseIdentity`: an `id` that differs from `externalCaseId` throws at construction. The missing-`id` error is now three-way rather than two-way, so a pre-6 config with a non-conforming external id gets the complete migration in one error instead of two.
- **`eval-result-mapping.ts` (new public options)** — `IterationToEvalResultOptions` and `RunToEvalResultsOptions` gain an optional `caseId`; `SuiteRunToEvalResultsOptions` gains `caseIdByTest`, keyed by test name like `expectedToolCallsByTest`. Additive only — see below.
- **`report-eval-results.ts` / `errors.ts`** — a rejection from a reporting backend that predates W0.1b is classified and rewritten as an actionable compatibility error.

`PromptsToEvalResultOverrides` and `PromptResult.toEvalResult`'s options both derive from `EvalResultInput` via `Partial<Omit<…>>` lists that do not name `caseId`, so they picked the field up automatically — only the value forwarding was needed. Likewise `addFromRun` / `recordFromRun` / `addFromSuiteRun` already spread caller options straight through, so the reporter needed no edits.

## The one behavior break, and why it is deliberate

A test that declares both `id` and `externalCaseId` with **different values** now throws at construction. They are two claims about which case this is, and picking a winner silently is how one case's history gets cross-joined onto another's. The backend already rejects a differing pair at ingest, so shipping it would fail the upload rather than pick a winner — failing at construction just costs a stack trace instead of a lost run.

The migration is always `id := externalCaseId`: the hosted case is keyed under `external:` + the external id, so declaring that same value as `id` lands the declared id in the join the case already lives under and its history continues.

**The case the migration cannot fix.** `externalCaseId` was never charset-bound, so values exist that no `id` can equal. For those, both the missing-`id` error and the conflict error say to rename the external id itself to a conforming value and declare it in **both** fields. The prod charset audit says nobody is in this position on the hosted side (18,290 cases, zero `external:`-keyed), but the SDK is client-side and a local-only test could be, so the guidance ships and is tested — including a test that constructs the exact config the error prescribes, so the advice cannot rot into something that no longer works.

One judgment call worth flagging: an **empty** `externalCaseId` is treated as absent, not as a second claim. The constructor's existing normalization drops a whitespace-only value but leaves a literal `""`, and both `getCaseKey` and the backend's own equality rule (`external.length > 0 && external !== declared`) read `""` as "no external id". Throwing on it would have been a second, unintended break refusing a config the wire accepts.

## Deliberate consequences

- **`caseIdentityByTest` goes from sparse to dense.** `id` is required, so `identity` is now always non-empty and the `Object.keys(identity).length > 0` guard is always true. Safe as-is: `suiteTestResultsToEvalResultInputs` reads the record per-test by name (`caseIdentityByTest?.[testName]`) and has no branch on its size. Guarded by a test anyway.
- **The low-level mappers stay permissive.** `promptsToEvalResult` and `toEvalResult` forward whatever the caller passes and do NOT enforce the equality rule. The construction-time check covers the `EvalTest` path; the backend's `assertDeclaredCaseIdentities` preflight rejects mismatches from low-level callers at ingest. No throws were added to the mappers.
- **The run-conversion helpers offer the id, never default it.** `iterationToEvalResult` / `runToEvalResults` / `suiteRunToEvalResults` carry *no* identity today — not `caseId`, and not `externalCaseId`, `isNegativeTest` or `expectedOutput` either — so this is a long-standing gap rather than a regression here. Closing it automatically would mean more than putting a field on the wire: `runToEvalResults` synthesizes `caseTitle` **per iteration**, so every iteration already lands as its own hosted case, and attaching one id across a run would collapse N cases into one. That is a change to hosted grouping for existing callers and is not this step's to make. A caller who wants that can now ask for it; a caller who says nothing gets a byte-identical payload, which is diffed in a test.
- **`loadCorpus` needed no change.** It already sets `id` and `externalCaseId` to the same hosted id, satisfying the equality rule by construction. Verified with a test rather than "fixed".
- **`@mcpjam/vitest` needed no code change** — it re-exports nothing from `EvalResultInput`, and its `config.id` read is already defensive. Its *fixtures* are another matter: `plan.test.ts`, `register.test.ts` and the three generated scenarios in `packaging.e2e.mjs` all constructed the now-rejected pair and were migrated to the shape real users must adopt. In `packaging.e2e.mjs` the `id` moves to the external value rather than the reverse, because the `[id]` title suffix is derived from `externalCaseId` and the output assertions match on that suffix.

## Custom `baseUrl` compatibility

Convex argument validation is strict: a backend that predates W0.1b rejects the **whole** upload rather than stripping the unknown field. The public SDK can report to a caller-supplied `baseUrl`, so MCPJam cannot prove every destination is upgraded. SDK 6 therefore documents a minimum reporting-backend contract of W0.1b, and such a rejection is now surfaced as an actionable compatibility error that names the required upgrade instead of a raw validator dump.

- Flagged as `EvalReportingError.isReportingBackendIncompatible` for programmatic branching.
- **Not retried** — a strict validator refuses the identical payload every time, so the three backoff attempts would only delay the message.
- Detection requires the field name **adjacent to** an unknown-field phrasing, bounded to a single line. Mere co-occurrence is not enough: a validator rejecting some *other* unknown field echoes the whole payload back, and that echo contains `caseId` — matching on presence alone would answer an unrelated rejection with upgrade advice for the wrong field and suppress a retry it may deserve. A backend that *does* understand `caseId` (invalid-id, conflicting-identity) still speaks for itself. Both cases tested.
- The backend's own words are preserved at the end of the rewritten message, after redaction (the echoed object is the ingest body, which carries `accessToken`/`refreshToken`/`clientSecret`).
- `reportEvalResultsSafely` retains its existing strict/non-strict behavior; the non-strict warning says "eval reporting failed", never anything that reads as an eval verdict.

## Tests

New `sdk/tests/declared-case-id-wire.test.ts` (14 tests) plus four added to `sdk/tests/EvalTest.test.ts`:

1. **On the wire** — a suite run through the same path `reportEvalResults` uses; assertions are made against the **serialized JSON request body**, not the in-memory objects. A companion test covers the standalone `EvalTest.run()` upload path.
2. **Corpus parity** — a `loadCorpus` case emits `caseId === externalCaseId ===` the hosted id.
3. **Equality violation throws** at construction, message naming `id := externalCaseId`.
4. **Non-conforming `externalCaseId`** throws with rename guidance from both errors, and the missing-`id` error's prescription is then constructed to prove it works.
5. **Legacy shape unchanged otherwise** — the same iteration is mapped twice, with and without a declared identity, and the two JSON payloads are **diffed**: they differ in exactly one key. The wire payload's key set and the run-conversion payload are compared the same way.
6. **Dense `caseIdentityByTest`** — a suite where no test sets `externalCaseId` still produces correct per-test identity and per-test verdicts.
7. `promptsToEvalResult`, `PromptResult.toEvalResult` and the run-conversion helpers forward `caseId` when given one and omit it from the serialized payload when not.
8. Backend-compatibility classification, non-retry, strict/non-strict behavior, the "different field rejected" echo case, and the "backend understands caseId" case.

Every regression test added during review was confirmed to fail with its fix reverted.

### Verification

```
npm run typecheck -w @mcpjam/sdk           ✅
npm test -w @mcpjam/sdk                    ✅ 230 files, 4810 passed, 8 skipped
npm run test:packaging -w @mcpjam/sdk      ✅
npm test -w @mcpjam/vitest                 ✅ 2 files, 23 passed
npm run test:packaging -w @mcpjam/vitest   ✅ all packaging checks passed
```

The last command was missing from my first round — the step brief's verification list did not name it — and it is what CI's "Run Tests" job caught. All five run before every push now.

**Pre-existing failure, not mine:** `sdk/tests/browser-entry-guard.test.ts` fails when run standalone on current `main` (from #4078's dependency bumps) — confirmed by stashing this branch's changes and re-running at the merge-base. It passes inside `npm test -w @mcpjam/sdk`, which builds first. Untouched here.

**`Mintlify Deployment` is red on the base branch, not because of this PR.** It failed identically on #4093 — main's current head, a docs-only commit where every other check passed — with "Failed to fetch OpenAPI file for anchor or tab". `docs/reference/openapi.json` is tracked and untouched by this diff.

**`Cursor Bugbot` has not run on any commit here** — the Cursor account hit a usage/spend limit — so this PR has no Bugbot coverage.

## Release

Changeset: **`@mcpjam/sdk` major** (→ 6.0.0). No `@mcpjam/vitest` bump (no code change), no `@mcpjam/inspector` bump.

## Rollout — operator-owned, not done in this PR

**Merging is reversible; publishing is not.** Merging this changes nothing in the world: no `caseId` reaches any backend until an SDK carrying it is published and a user upgrades. No feature flag — pre-publish the full-revert window is real, and post-publish a flag that disabled sending would just reintroduce the fork.

**Publish gate for MCPJam-managed environments:** the release that first *transmits* `caseId` must not publish until W0.1b is deployed to every MCPJam-managed reporting backend. Prod and staging are confirmed (08-18); the remaining check is preview/branch deployments. An SDK sending `caseId` to a backend predating W0.1b gets the whole upload **rejected**, not a stripped field. This gate does not cover custom `baseUrl` destinations — those are handled by the compatibility error above, not by the gate.

After publish, resolution is the permanent compatibility floor: defects are fixed forward; a revert may touch behavior layered on later — never the arg, never the resolution order.

### Post-merge live wire test (needs a staging `sk_` key)

1. Legacy no-`caseId` upload → case created, `caseKey` = `hash:X`, no `declaredCaseId`.
2. Same content with `caseId` → same case, id adopted, key unchanged.
3. Rename + same `caseId` → still one case, one group on run page / insights / diff.
4. Unrelated legacy upload → byte-identical behavior.

## Out of scope

Batch create + authoring-path minting (W0.3) · the automated rename-continuity acceptance test (W0.2) · YAML loader / `eval validate` (B1) · retiring `externalCaseId` (not scheduled — it has live wire semantics and stays until a step is written to converge them) · fixing `browser-entry-guard.test.ts`.

**Surfaced during review, deliberately left for a follow-up:** making the run-conversion helpers carry the declared id *automatically*. That requires first deciding whether a run's iterations should stay one hosted case per iteration (today's behavior, via the synthesized per-iteration `caseTitle`) or collapse into one — a hosted-grouping question this step should not answer unilaterally.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit cbf481a4909c6bf0b8e291a296ee23ee56d70e08. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->