### PR TITLE
github checks: clone private repositories with a token that never touches disk

### DIFF
--- a/.changeset/private-repo-clone-token.md
+++ b/.changeset/private-repo-clone-token.md
@@ -1,0 +1,41 @@
+---
+"@mcpjam/inspector": patch
+---
+
+Clone private repositories for GitHub PR checks, using a short-lived
+installation token that never touches disk.
+
+A claim now carries `repoPrivate`. When it is true — and only then — the worker
+asks the backend's `/internal/v1/github-checks/clone-token` route for a
+repository-scoped `contents: read` installation token and threads it to the
+clone. Public repositories are cloned anonymously, byte-for-byte as before, and
+never call the route at all: minting a credential nothing needs is blast radius
+bought for nothing.
+
+The ordering is load-bearing in both directions. The token is minted **after**
+`/plan/begin` and **before** the first sandbox is provisioned, so a mint failure
+is reported as an ordinary ladder-level `clone` / `clone_failed` attempt on a
+plan that already exists — attributable, countable, and `infra_error` rather than
+the pull request's fault — instead of needing the planless completion path. A
+`409` means this worker no longer holds the claim: the check is abandoned with no
+competing completion and no box provisioned, and a `502` or a null token for a
+private repository are the same `clone_failed` result, because an anonymous
+retry would 404 and read as the repository having vanished.
+
+Where the credential goes is deliberately narrow. It rides on a command-line
+`git -c 'http.extraheader=AUTHORIZATION: basic <base64>'` for the clone and the
+fetch, and nothing else — not the checkout, not `rev-parse`, not the build. The
+URL stays the ordinary `https://github.com/owner/repo.git`, because a credential
+in the URL is written verbatim into `.git/config`, which is a file the pull
+request's own build would then be able to read. No credential helper, no
+environment variable, no file, and nothing persisted: `-c` is process-scoped, and
+clone and fetch both finish before any PR-controlled process runs.
+
+A new `redactCloneCredential` boundary removes the raw token, the
+`base64(x-access-token:<token>)` it is sent as, and any whole
+`AUTHORIZATION: basic …` header from every observable failure — a non-zero git
+exit, a deadline overrun, and in particular a thrown transport error, since an
+SDK error quotes the command it was running and that command carries the header.
+Redaction runs _before_ clamping, because clamping is a length and markdown
+boundary rather than a secret one. Token-derived values are removed by literal
+replacement, never by a pattern built from the token.

--- a/mcpjam-inspector/server/services/__tests__/github-checks-worker-source.test.ts
+++ b/mcpjam-inspector/server/services/__tests__/github-checks-worker-source.test.ts
@@ -63,6 +63,7 @@ describe("defaultRunEvalSuite provenance", () => {
         projectId: "proj-1",
         createdByExternalId: "user_x",
         suiteId: "suite-1",
+        repoPrivate: false,
       },
       bearer: "bearer-token",
       serverId: "srv-1",
@@ -91,7 +92,9 @@ describe("defaultRunEvalSuite provenance", () => {
     prepareEvalRun.mockResolvedValue({ runId: "run-9", recorder, execute });
     const mutation = vi.fn().mockResolvedValue(undefined);
     createConvexClient.mockReturnValue({
-      query: vi.fn().mockResolvedValue({ configSnapshot: { environment: null } }),
+      query: vi
+        .fn()
+        .mockResolvedValue({ configSnapshot: { environment: null } }),
       mutation,
     });
 
@@ -107,6 +110,7 @@ describe("defaultRunEvalSuite provenance", () => {
           projectId: "proj-1",
           createdByExternalId: "user_x",
           suiteId: "suite-1",
+          repoPrivate: false,
         },
         bearer: "bearer-token",
         serverId: "srv-1",

--- a/mcpjam-inspector/server/services/__tests__/github-checks-worker.test.ts
+++ b/mcpjam-inspector/server/services/__tests__/github-checks-worker.test.ts
@@ -13,16 +13,16 @@ import {
   executeClaimedCheck,
   runReachedAVerdict,
   verifyRunSnapshot,
+  claimNextForTests,
+  CloneTokenUnavailableError,
   LeaseLostError,
+  mintCloneTokenForTests,
   startGithubChecksWorker,
   type CheckExecutionDeps,
   type PlanlessCheckReport,
   type ClaimedGithubCheck,
 } from "../github-checks-worker";
-import {
-  CheckStepError,
-  type CheckSandbox,
-} from "../github-checks/sandbox";
+import { CheckStepError, type CheckSandbox } from "../github-checks/sandbox";
 import {
   CheckStoppedByPlan,
   PlanProtocolError,
@@ -54,7 +54,14 @@ const CLAIM: ClaimedGithubCheck = {
   projectId: "proj-1",
   createdByExternalId: "user_workos_1",
   suiteId: "suite-1",
+  repoPrivate: false,
 };
+
+/** The same check, on a repository that needs a credential to clone. */
+const PRIVATE_CLAIM: ClaimedGithubCheck = { ...CLAIM, repoPrivate: true };
+
+/** A stand-in installation token. Never real, always asserted absent. */
+const CLONE_TOKEN = "ghs_privateRepoToken1234567890";
 
 const RECIPE = {
   build: "npm ci && npm run build",
@@ -75,6 +82,8 @@ type Completion = {
 
 type Harness = {
   deps: Partial<CheckExecutionDeps>;
+  /** Every `resolveAndStart` args object, so the threaded token is assertable. */
+  resolveArgs: Array<{ cloneToken?: string }>;
   /** Planless reports — reachable ONLY when `/plan/begin` produced no plan. */
   reports: PlanlessCheckReport[];
   /** Every `/attempt` the worker itself posted (the resolver's are its own). */
@@ -109,6 +118,7 @@ function harness(
   const completions: Completion[] = [];
   const events: string[] = [];
   const heartbeats: string[] = [];
+  const resolveArgs: Array<{ cloneToken?: string }> = [];
 
   const session: CheckPlanSession = {
     planId: "plan-1",
@@ -159,7 +169,12 @@ function harness(
     // collaborator (`resolve-and-start.ts`, tested in its own suite). What the
     // WORKER owes is exactly one completion per claim, the eval attempt posted
     // at launch, and teardown of whatever box it was handed.
+    mintCloneToken: async () => {
+      events.push("mintCloneToken");
+      return CLONE_TOKEN;
+    },
     resolveAndStart: async (_args, overrides) => {
+      resolveArgs.push(_args);
       events.push("resolveAndStart");
       overrides?.onSandbox?.(sandbox);
       return {
@@ -216,6 +231,7 @@ function harness(
 
   return {
     deps,
+    resolveArgs,
     reports,
     attempts,
     completions,
@@ -339,7 +355,6 @@ describe("executeClaimedCheck — happy path", () => {
       serverName: "gh-check-trig-1",
     });
   });
-
 });
 
 describe("executeClaimedCheck — the plan owns the verdict", () => {
@@ -487,7 +502,9 @@ describe("executeClaimedCheck — the plan owns the verdict", () => {
   });
 
   const evalDies = {
-    runEvalSuite: async (args: { onRunStarted?: (id: string) => Promise<void> }) => {
+    runEvalSuite: async (args: {
+      onRunStarted?: (id: string) => Promise<void>;
+    }) => {
       await args.onRunStarted?.("run-1");
       throw new Error("fetch failed: ECONNREFUSED");
     },
@@ -1192,5 +1209,270 @@ describe("runReachedAVerdict", () => {
     ]) {
       expect(runReachedAVerdict(status)).toBe(false);
     }
+  });
+});
+
+// ═══════════════════════════════════════════════════════════════════════════
+// PRIVATE REPOSITORIES
+// ═══════════════════════════════════════════════════════════════════════════
+//
+// The ordering is the load-bearing part and the reason these live here rather
+// than in the resolver's suite: the credential is minted AFTER the plan exists
+// and BEFORE a box is provisioned, so a mint failure is an ordinary attempt on
+// an existing plan instead of a second planless completion, and costs no E2B
+// box. Everything else below is about the credential not escaping.
+
+describe("executeClaimedCheck — the private-repository clone credential", () => {
+  /** Computed independently of the module under test. */
+  const basic = Buffer.from(`x-access-token:${CLONE_TOKEN}`, "utf8").toString(
+    "base64"
+  );
+  const credentialForms = [CLONE_TOKEN, basic, `AUTHORIZATION: basic ${basic}`];
+
+  it("mints AFTER the plan and BEFORE the first sandbox, then threads it to the clone", async () => {
+    const h = harness();
+    await executeClaimedCheck(PRIVATE_CLAIM, "worker-1", h.deps);
+
+    // `beginPlan` → `mintCloneToken` → `resolveAndStart`, in that order and no
+    // other. `resolveAndStart` owns provisioning, so its position IS the
+    // "before any box" guarantee.
+    expect(h.events.slice(0, 3)).toEqual([
+      "beginPlan",
+      "mintCloneToken",
+      "resolveAndStart",
+    ]);
+    expect(h.resolveArgs[0].cloneToken).toBe(CLONE_TOKEN);
+    // The ordinary check still happened, end to end.
+    expect(h.completions).toHaveLength(1);
+    expect(h.reports).toHaveLength(0);
+  });
+
+  it("never asks for a credential for a public repository", async () => {
+    // Not an optimization: minting a `contents: read` token nothing needs is
+    // blast radius bought for nothing.
+    const h = harness();
+    await executeClaimedCheck(CLAIM, "worker-1", h.deps);
+
+    expect(h.events).not.toContain("mintCloneToken");
+    expect(h.resolveArgs[0]).not.toHaveProperty("cloneToken");
+  });
+
+  it("completes with a ladder `clone_failed` when the mint fails, and provisions nothing", async () => {
+    // A 502 from the mint route. There is a plan, so this is reported THROUGH
+    // it — the planless completion is only for a check that never got one.
+    const h = harness({
+      mintCloneToken: async () => {
+        throw new CloneTokenUnavailableError(
+          "the backend could not mint a clone token (502)"
+        );
+      },
+    });
+    await executeClaimedCheck(PRIVATE_CLAIM, "worker-1", h.deps);
+
+    expect(h.events).not.toContain("resolveAndStart");
+    expect(h.completions).toHaveLength(1);
+    expect(h.completions[0].terminalAttempt).toMatchObject({
+      // LADDER-scoped: no candidate exists, because nothing was detected yet.
+      phase: "clone",
+      ok: false,
+      failureKind: "clone_failed",
+    });
+    expect(h.completions[0].terminalAttempt).not.toHaveProperty("candidateId");
+    // No outcome named here either — a ladder `clone_failed` is `infra_error`
+    // backend-side, and it is never the pull request's fault.
+    expect(h.completions[0]).not.toHaveProperty("outcome");
+    expect(h.reports).toHaveLength(0);
+  });
+
+  it("treats a null token for a private repository exactly like a failed mint", async () => {
+    // `cloneToken: null` is the PUBLIC answer. Arriving for a private claim it
+    // means the same thing a 502 does — we cannot clone — so an anonymous
+    // attempt that would 404 and read as "the repository vanished" is refused.
+    const h = harness({ mintCloneToken: async () => null });
+    await executeClaimedCheck(PRIVATE_CLAIM, "worker-1", h.deps);
+
+    expect(h.events).not.toContain("resolveAndStart");
+    expect(h.completions).toHaveLength(1);
+    expect(h.completions[0].terminalAttempt).toMatchObject({
+      phase: "clone",
+      ok: false,
+      failureKind: "clone_failed",
+    });
+  });
+
+  it("abandons the check on a 409 from the mint, with no competing completion", async () => {
+    // 409 means somebody else holds the claim, which means the backend has
+    // already concluded this check. A completion posted over the top would be
+    // rejected at best and a competing verdict at worst.
+    const h = harness({
+      mintCloneToken: async () => {
+        throw new LeaseLostError("trigger_completed");
+      },
+    });
+    await executeClaimedCheck(PRIVATE_CLAIM, "worker-1", h.deps);
+
+    expect(h.completions).toHaveLength(0);
+    expect(h.reports).toHaveLength(0);
+    expect(h.events).not.toContain("resolveAndStart");
+    // The box that was never provisioned is still "killed" (a null handle), so
+    // the cleanup path is uniform.
+    expect(h.events).toContain("killSandbox");
+  });
+
+  /** Capture every `logger.error` call, argument objects included. */
+  async function captureErrorLogs(): Promise<unknown[]> {
+    const logger = await import("../../utils/logger");
+    const logged: unknown[] = [];
+    const spy = vi
+      .spyOn(logger.logger, "error")
+      .mockImplementation((message, error, context) => {
+        logged.push([
+          message,
+          error instanceof Error ? `${error.message}\n${error.stack}` : error,
+          context,
+        ]);
+      });
+    onTestFinished(() => spy.mockRestore());
+    return logged;
+  }
+
+  it("leaks no credential form through the failure, the log, the attempt or the completion", async () => {
+    // THE LEAK TEST. `sandbox.commands.run` throwing an error that quotes the
+    // WHOLE command is exactly what an E2B transport failure looks like, and the
+    // command it quotes is the one carrying the auth header. `sandbox.ts`
+    // redacts it at the boundary it owns; this asserts the worker's own
+    // observables — the log (Sentry's only capture path), the terminal attempt
+    // and the completion — are clean even if that first boundary ever fails.
+    const logged = await captureErrorLogs();
+    const echoedCommand = `bash -lc 'git -c 'http.extraheader=AUTHORIZATION: basic ${basic}' clone --depth 50' (raw ${CLONE_TOKEN})`;
+    const h = harness({
+      resolveAndStart: async () => {
+        throw new CheckStepError(
+          "infra_error",
+          `sandbox command failed: ${echoedCommand}`,
+          `\`\`\`text\n${echoedCommand}\n\`\`\``
+        );
+      },
+    });
+    await executeClaimedCheck(PRIVATE_CLAIM, "worker-1", h.deps);
+
+    const observable = JSON.stringify({
+      logged,
+      completions: h.completions,
+      attempts: h.attempts,
+      reports: h.reports,
+    });
+    for (const form of credentialForms) {
+      expect(observable).not.toContain(form);
+    }
+    // The check still got its one completion, and the failure is still legible.
+    expect(h.completions).toHaveLength(1);
+    expect(h.completions[0].detailsMarkdown).toContain("[redacted]");
+    expect(JSON.stringify(logged)).toContain("sandbox command failed");
+  });
+
+  it("leaks no credential form when the MINT itself fails", async () => {
+    // The worker holds no token on this path — the mint is what failed — so the
+    // constant `AUTHORIZATION:` sweep is the whole defence, and it has to be
+    // enough on its own.
+    const logged = await captureErrorLogs();
+    const h = harness({
+      mintCloneToken: async () => {
+        throw new CloneTokenUnavailableError(
+          `mint failed while sending AUTHORIZATION: basic ${basic}`
+        );
+      },
+    });
+    await executeClaimedCheck(PRIVATE_CLAIM, "worker-1", h.deps);
+
+    const observable = JSON.stringify({ logged, completions: h.completions });
+    expect(observable).not.toContain(basic);
+    expect(observable).not.toContain(`AUTHORIZATION: basic ${basic}`);
+    // Redacted, not swallowed: the operator still gets a legible failure.
+    expect(h.completions[0].terminalAttempt?.detailsClamped).toContain(
+      "mint failed"
+    );
+    expect(h.completions[0].terminalAttempt?.detailsClamped).toContain(
+      "[redacted]"
+    );
+    expect(h.completions[0].detailsMarkdown).toContain(
+      "not a problem with the pull request"
+    );
+  });
+});
+
+describe("the clone-token wire contract", () => {
+  // Hand-mirrored from the backend across two repos, so the status mapping is
+  // pinned at the wire rather than only at the dep seam.
+  function stubFetch(status: number, body: unknown) {
+    vi.stubEnv("CONVEX_HTTP_URL", "https://convex.test");
+    vi.stubEnv("INSPECTOR_SERVICE_TOKEN", "service-token");
+    const fetchMock = vi.fn(
+      async () =>
+        new Response(JSON.stringify(body), {
+          status,
+          headers: { "content-type": "application/json" },
+        })
+    );
+    vi.stubGlobal("fetch", fetchMock);
+    onTestFinished(() => {
+      vi.unstubAllEnvs();
+      vi.unstubAllGlobals();
+    });
+    return fetchMock;
+  }
+
+  it("posts { triggerId, claimedBy } and returns the token", async () => {
+    const fetchMock = stubFetch(200, {
+      ok: true,
+      cloneToken: CLONE_TOKEN,
+      expiresAt: 1_700_000_000,
+    });
+    await expect(mintCloneTokenForTests("trig-1", "worker-1")).resolves.toBe(
+      CLONE_TOKEN
+    );
+    const [url, init] = fetchMock.mock.calls[0] as unknown as [
+      string,
+      RequestInit
+    ];
+    expect(url).toContain("/internal/v1/github-checks/clone-token");
+    expect(JSON.parse(String(init.body))).toEqual({
+      triggerId: "trig-1",
+      claimedBy: "worker-1",
+    });
+  });
+
+  it("answers null when the backend says no token was needed", async () => {
+    stubFetch(200, { ok: true, cloneToken: null });
+    await expect(
+      mintCloneTokenForTests("trig-1", "worker-1")
+    ).resolves.toBeNull();
+  });
+
+  it("maps 409 to lease loss, not to a mint failure", async () => {
+    stubFetch(409, { ok: false, error: "trigger_completed" });
+    await expect(
+      mintCloneTokenForTests("trig-1", "worker-1")
+    ).rejects.toBeInstanceOf(LeaseLostError);
+  });
+
+  it("maps 502 to a mint failure, without echoing the backend's body", async () => {
+    stubFetch(502, { ok: false, error: "Could not mint a clone token" });
+    const error = await mintCloneTokenForTests("trig-1", "worker-1").catch(
+      (e) => e
+    );
+    expect(error).toBeInstanceOf(CloneTokenUnavailableError);
+    expect(String(error)).toContain("502");
+  });
+
+  it("mirrors repoPrivate off the claim body", async () => {
+    // The field is hand-mirrored across two repos, and dropping it here would
+    // silently degrade every private repository to an anonymous clone.
+    stubFetch(200, {
+      ok: true,
+      claimed: { ...PRIVATE_CLAIM, triggerId: "trig-9" },
+    });
+    const claimed = await claimNextForTests("worker-1");
+    expect(claimed).toMatchObject({ triggerId: "trig-9", repoPrivate: true });
   });
 });

--- a/mcpjam-inspector/server/services/__tests__/github-checks-worker.test.ts
+++ b/mcpjam-inspector/server/services/__tests__/github-checks-worker.test.ts
@@ -1284,6 +1284,27 @@ describe("executeClaimedCheck — the private-repository clone credential", () =
     expect(h.reports).toHaveLength(0);
   });
 
+  it("never completes the fresh plan with an empty attempt log", async () => {
+    // The consequence the typed transport failure exists to prevent. An untyped
+    // throw from the mint reaches the generic catch, which has no degraded
+    // marker for it either — so `/complete` would carry no `terminalAttempt`
+    // and the backend would derive an outcome from nothing at all.
+    const h = harness({
+      mintCloneToken: async () => {
+        throw new Error("service route /clone-token timed out after 15000ms");
+      },
+    });
+    await executeClaimedCheck(PRIVATE_CLAIM, "worker-1", h.deps);
+
+    expect(h.events).not.toContain("resolveAndStart");
+    expect(h.completions).toHaveLength(1);
+    expect(h.completions[0].terminalAttempt).toMatchObject({
+      phase: "clone",
+      ok: false,
+      failureKind: "clone_failed",
+    });
+  });
+
   it("treats a null token for a private repository exactly like a failed mint", async () => {
     // `cloneToken: null` is the PUBLIC answer. Arriving for a private claim it
     // means the same thing a 502 does — we cannot clone — so an anonymous
@@ -1454,6 +1475,30 @@ describe("the clone-token wire contract", () => {
     await expect(
       mintCloneTokenForTests("trig-1", "worker-1")
     ).rejects.toBeInstanceOf(LeaseLostError);
+  });
+
+  it("maps a transport failure to a mint failure, not an untyped throw", async () => {
+    // The route rejecting BEFORE it answers — a network failure, or the
+    // service-route's own deadline. Untyped, this would skip the mint-failure
+    // branch entirely and complete the plan with no attempt on it at all.
+    vi.stubEnv("CONVEX_HTTP_URL", "https://convex.test");
+    vi.stubEnv("INSPECTOR_SERVICE_TOKEN", "service-token");
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => {
+        throw new Error("ECONNREFUSED 10.0.0.1:443");
+      })
+    );
+    onTestFinished(() => {
+      vi.unstubAllEnvs();
+      vi.unstubAllGlobals();
+    });
+
+    const error = await mintCloneTokenForTests("trig-1", "worker-1").catch(
+      (e) => e
+    );
+    expect(error).toBeInstanceOf(CloneTokenUnavailableError);
+    expect(String(error)).toContain("ECONNREFUSED");
   });
 
   it("maps 502 to a mint failure, without echoing the backend's body", async () => {

--- a/mcpjam-inspector/server/services/github-checks-worker.ts
+++ b/mcpjam-inspector/server/services/github-checks-worker.ts
@@ -49,6 +49,7 @@ import {
   clampOutput,
   isGithubChecksSandboxConfigured,
   killCheckSandbox,
+  redactCloneCredential,
   type CheckSandbox,
 } from "./github-checks/sandbox.js";
 import { resolveAndStart } from "./github-checks/resolve-and-start.js";
@@ -92,6 +93,16 @@ export type ClaimedGithubCheck = {
   projectId: string;
   createdByExternalId: string;
   suiteId: string;
+  /**
+   * Whether the checkout needs an installation token to clone.
+   *
+   * A REQUIRED boolean, matching the backend, which always sends one (`false`
+   * for a row that never recorded a visibility). Optional-with-a-default would
+   * mean a wire regression silently degrades to "public" — and "public" is the
+   * value that clones without a credential, so the failure mode of guessing
+   * would be a private repository's check failing rather than the reverse.
+   */
+  repoPrivate: boolean;
 };
 
 export type CheckSummary = {
@@ -214,8 +225,77 @@ export class LeaseLostError extends Error {
   }
 }
 
+/**
+ * The backend could not give us a credential for a private repository.
+ *
+ * A DISTINCT type, because the response it demands is distinct from every other
+ * failure in this file: it happens after `/plan/begin` and before anything is
+ * provisioned, so it is reported as a ladder-level `clone` attempt on the plan
+ * that already exists — never through the planless path, and never as the pull
+ * request's fault. Nothing about a PR can cause it.
+ */
+export class CloneTokenUnavailableError extends Error {
+  constructor(readonly detail: string) {
+    super(`clone token unavailable: ${detail}`);
+    this.name = "CloneTokenUnavailableError";
+  }
+}
+
+/**
+ * Mint the clone credential for THIS claim, or find out we no longer hold it.
+ *
+ * Three answers, and the difference between them is the whole contract:
+ *
+ *   200 + `cloneToken: null`   nothing was needed. Only legal for a public
+ *                              repository; for a private one the caller treats
+ *                              it as a mint failure, because a null token and a
+ *                              502 leave us equally unable to clone.
+ *   200 + `cloneToken: string` use it for clone/fetch and nothing else.
+ *   409                        this worker is not the claim holder any more.
+ *                              LEASE LOSS — the check has already been
+ *                              concluded by somebody else, so we must not
+ *                              manufacture a competing completion.
+ *   502 (or anything else)     the mint failed backend-side. The message is
+ *                              deliberately flat there and stays flat here.
+ *
+ * The token is NEVER logged, and no branch of this function puts the response
+ * body into an error — a 502's body is a constant string, and a 200's body is
+ * the secret itself.
+ */
+async function mintCloneToken(
+  triggerId: string,
+  claimedBy: string
+): Promise<string | null> {
+  const { status, body } = await postServiceRoute(
+    `${SERVICE_BASE}/clone-token`,
+    { triggerId, claimedBy }
+  );
+  if (status === 409) {
+    throw new LeaseLostError(String(body?.error ?? "not_the_claim_holder"));
+  }
+  if (status !== 200 || !body?.ok) {
+    throw new CloneTokenUnavailableError(
+      `the backend could not mint a clone token (${status})`
+    );
+  }
+  const token = body.cloneToken;
+  return typeof token === "string" && token.length > 0 ? token : null;
+}
+
 /** Test seam: the heartbeat's response validation is the whole point of it. */
 export const sendHeartbeatForTests = sendHeartbeat;
+
+/**
+ * Test seam: the clone-token contract is a two-repo hand-mirror, so the status
+ * mapping (409 ⇒ lease loss, 502 ⇒ mint failure) is worth pinning at the wire.
+ */
+export const mintCloneTokenForTests = mintCloneToken;
+
+/**
+ * Test seam: `repoPrivate` arriving intact is the difference between cloning a
+ * private repository and not, and the claim body is where it can get dropped.
+ */
+export const claimNextForTests = claimNext;
 
 /**
  * Test seam for the real eval integration. The worker tests replace
@@ -308,6 +388,38 @@ export function describeCheckFailure(error: unknown): {
 }
 
 /**
+ * The error, with any clone credential removed from its message AND its stack.
+ *
+ * A COPY rather than a mutation: the original is what the `finally` and the
+ * caller still hold, and rewriting a thrown object's message under them is the
+ * kind of action at a distance that is impossible to reason about later.
+ *
+ * This is the second line of defence, not the first. `sandbox.ts` redacts at the
+ * boundary where the credential-bearing text first becomes ours, so the error
+ * arriving here is already clean; this exists because `logger.error` is the
+ * server's single Sentry capture path, and a secret that reaches Sentry cannot
+ * be recalled from it. The constant `AUTHORIZATION:` sweep runs whether or not
+ * a token is held; the token-derived forms are removed only when one is.
+ */
+function redactErrorForLog(error: unknown, cloneToken: string | null): unknown {
+  if (!(error instanceof Error)) return error;
+  const message = redactCloneCredential(error.message, cloneToken);
+  const stack = error.stack
+    ? redactCloneCredential(error.stack, cloneToken)
+    : error.stack;
+  // UNCHANGED ⇒ the ORIGINAL, class and all. Only a genuinely
+  // credential-bearing error is replaced, so the overwhelming majority of
+  // failures still reach the logger as the typed error they were thrown as —
+  // and the constant `AUTHORIZATION:` sweep still runs on every one of them,
+  // whether or not a token is currently held.
+  if (message === error.message && stack === error.stack) return error;
+  const copy = new Error(message);
+  copy.name = error.name;
+  if (stack) copy.stack = stack;
+  return copy;
+}
+
+/**
  * Cap on the resolver's own failure copy. Bounded by construction already
  * (constant strings plus one clamped parser message), so this is a backstop
  * against a future message growing without anyone noticing, not a sanitizer.
@@ -379,6 +491,15 @@ export type CheckExecutionDeps = {
    * planless completion contract forever.
    */
   beginPlan: (claimed: ClaimedGithubCheck) => Promise<CheckPlanSession>;
+  /**
+   * Mint the private-repository clone credential. Called ONLY when the claim
+   * says `repoPrivate`, and only between `beginPlan` and the first provision —
+   * see the ordering note in `executeClaimedCheck`.
+   */
+  mintCloneToken: (
+    triggerId: string,
+    claimedBy: string
+  ) => Promise<string | null>;
   /**
    * The deterministic ladder plus the sandboxes it needs — provisioning,
    * cloning, building, the runtime verification, and a FRESH BOX PER CANDIDATE
@@ -988,6 +1109,7 @@ function defaultDeps(): CheckExecutionDeps {
         repoFullName: claimed.repoFullName,
         headSha: claimed.headSha,
       }),
+    mintCloneToken,
     resolveAndStart,
     killSandbox: killCheckSandbox,
     getBearer: getConvexBearerForDelegation,
@@ -1157,7 +1279,44 @@ export async function executeClaimedCheck(
   /** The in-box diagnostic for an eval that died. DISPLAY text, no authority. */
   let evalFailureDetails: string | undefined;
 
+  /**
+   * The clone credential, for a private repository only. Held in a local, never
+   * written to a field of any long-lived object, and passed exactly one place:
+   * the clone.
+   */
+  let cloneToken: string | null = null;
+
   try {
+    // ═══════════════════════════════════════════════════════════════════════
+    // STEP 3 — MINT THE CLONE CREDENTIAL, AFTER THE PLAN AND BEFORE THE BOX.
+    // ═══════════════════════════════════════════════════════════════════════
+    //
+    // The ordering is load-bearing in BOTH directions:
+    //
+    //   after `beginPlan`   so a mint failure has a plan to be reported
+    //                       against, and lands as an ordinary `clone` attempt
+    //                       rather than a second planless completion;
+    //   before `provision`  so a check we already know cannot clone never costs
+    //                       an E2B box, and the failure cannot be confused with
+    //                       one the sandbox caused.
+    //
+    // A PUBLIC claim never calls the route at all. That is not an optimization:
+    // it is what keeps the blast radius of a `contents: read` mint proportional
+    // to the number of checks that genuinely need one.
+    if (claimed.repoPrivate) {
+      cloneToken = await deps.mintCloneToken(claimed.triggerId, claimedBy);
+      if (!cloneToken) {
+        // A null token is only ever legal for a public repository. Here it means
+        // the same thing a 502 does — we cannot clone — so it gets the same
+        // answer rather than a silent anonymous attempt that would 404 and read
+        // as the repository having vanished.
+        throw new CloneTokenUnavailableError(
+          "the backend returned no clone token for a private repository"
+        );
+      }
+      assertLeaseHeld();
+    }
+
     // Runs the deterministic ladder against the checkout, then executes the
     // BACKEND'S candidates in the BACKEND'S order, reporting every phase, and
     // leaves the accepted box running a verified server. Provisioning, cloning,
@@ -1170,6 +1329,7 @@ export async function executeClaimedCheck(
         repoFullName: claimed.repoFullName,
         prNumber: claimed.prNumber,
         headSha: claimed.headSha,
+        ...(cloneToken ? { cloneToken } : {}),
       },
       {
         plan: session,
@@ -1311,18 +1471,61 @@ export async function executeClaimedCheck(
       });
       return;
     }
+    if (error instanceof CloneTokenUnavailableError) {
+      // Reported ON THE PLAN, as a LADDER-scoped `clone` attempt: no candidate
+      // exists yet (nothing has been provisioned, let alone detected), and the
+      // backend attributes a ladder `clone_failed` as `infra_error`. It is ours
+      // — an app installation, a GitHub outage, a minting bug — and there is no
+      // reading of it that is the pull request's fault.
+      const detail = redactCloneCredential(error.detail, cloneToken).slice(
+        0,
+        500
+      );
+      logger.error(
+        "[github-checks] could not mint a clone token",
+        redactErrorForLog(error, cloneToken),
+        { ...logContext, planId: session.planId, detail }
+      );
+      await safeComplete({
+        detailsMarkdown:
+          "MCPJam could not obtain a credential to clone this private repository, so nothing was built or evaluated. This is an MCPJam-side failure, not a problem with the pull request — check that the MCPJam GitHub App is still installed on this repository and retry the check.",
+        terminalAttempt: {
+          phase: "clone",
+          ok: false,
+          failureKind: "clone_failed",
+          durationMs: 0,
+          detailsClamped: detail,
+        },
+      });
+      return;
+    }
     const described = describeCheckFailure(error);
-    logger.error("[github-checks] check failed", error, {
-      ...logContext,
-      planId: session.planId,
-      reason: described.failureReason,
-      candidate: acceptedCandidateId,
-    });
+    // Redacted BEFORE any of it is logged, completed or clamped. A clone that
+    // failed inside the box is the one failure whose text can have touched the
+    // credential, and `describeCheckFailure` is a formatter — it has no idea a
+    // secret is in play.
+    const failureReason = redactCloneCredential(
+      described.failureReason,
+      cloneToken
+    );
+    logger.error(
+      "[github-checks] check failed",
+      redactErrorForLog(error, cloneToken),
+      {
+        ...logContext,
+        planId: session.planId,
+        reason: failureReason,
+        candidate: acceptedCandidateId,
+      }
+    );
     // NO OUTCOME. Every failure that got this far was reported as an attempt at
     // the phase it happened at; the backend derives what it adds up to. The only
     // things travelling here are display text and — when the backend went away
     // mid-flight — the degraded marker.
-    const details = described.detailsMarkdown ?? evalFailureDetails;
+    const rawDetails = described.detailsMarkdown ?? evalFailureDetails;
+    const details = rawDetails
+      ? redactCloneCredential(rawDetails, cloneToken)
+      : undefined;
     const marker = degradedMarker(error);
     await safeComplete({
       ...(details
@@ -1332,7 +1535,21 @@ export async function executeClaimedCheck(
               : clampOutput(rawOf(details)),
           }
         : {}),
-      ...(marker ? { terminalAttempt: marker } : {}),
+      ...(marker
+        ? {
+            terminalAttempt: {
+              ...marker,
+              ...(marker.detailsClamped
+                ? {
+                    detailsClamped: redactCloneCredential(
+                      marker.detailsClamped,
+                      cloneToken
+                    ),
+                  }
+                : {}),
+            },
+          }
+        : {}),
     });
   } finally {
     clearInterval(heartbeat);

--- a/mcpjam-inspector/server/services/github-checks-worker.ts
+++ b/mcpjam-inspector/server/services/github-checks-worker.ts
@@ -257,6 +257,10 @@ export class CloneTokenUnavailableError extends Error {
  *                              manufacture a competing completion.
  *   502 (or anything else)     the mint failed backend-side. The message is
  *                              deliberately flat there and stays flat here.
+ *   no answer at all           a transport failure or the route's deadline.
+ *                              Typed as the 502 case, so it reaches the same
+ *                              ladder-level `clone_failed` rather than falling
+ *                              through as an untyped throw.
  *
  * The token is NEVER logged, and no branch of this function puts the response
  * body into an error — a 502's body is a constant string, and a 200's body is
@@ -266,10 +270,28 @@ async function mintCloneToken(
   triggerId: string,
   claimedBy: string
 ): Promise<string | null> {
-  const { status, body } = await postServiceRoute(
-    `${SERVICE_BASE}/clone-token`,
-    { triggerId, claimedBy }
-  );
+  let status: number;
+  let body: any;
+  try {
+    ({ status, body } = await postServiceRoute(`${SERVICE_BASE}/clone-token`, {
+      triggerId,
+      claimedBy,
+    }));
+  } catch (error) {
+    // THE ROUTE NEVER ANSWERED — a network failure, a missing service-token
+    // env, or the service-route's own 15s deadline. Materially identical to a
+    // 502: we hold no credential and cannot clone. It is typed as the same
+    // failure so it takes the same branch, because an untyped throw here would
+    // fall through to the generic catch, which has no degraded marker for it
+    // either — and would complete the freshly opened plan with an EMPTY attempt
+    // log. A check that ran nothing and reported nothing is the one shape the
+    // plan shell exists to prevent.
+    throw new CloneTokenUnavailableError(
+      `the clone-token route could not be reached: ${
+        error instanceof Error ? error.message : String(error)
+      }`
+    );
+  }
   if (status === 409) {
     throw new LeaseLostError(String(body?.error ?? "not_the_claim_holder"));
   }
@@ -1304,7 +1326,24 @@ export async function executeClaimedCheck(
     // it is what keeps the blast radius of a `contents: read` mint proportional
     // to the number of checks that genuinely need one.
     if (claimed.repoPrivate) {
-      cloneToken = await deps.mintCloneToken(claimed.triggerId, claimedBy);
+      try {
+        cloneToken = await deps.mintCloneToken(claimed.triggerId, claimedBy);
+      } catch (error) {
+        // THE PHASE DECIDES THE ATTRIBUTION, NOT THE ERROR'S TYPE. `mintCloneToken`
+        // already types its own failures, but this step must hold whatever the
+        // dep throws: anything that is not a lease loss means we reached the
+        // clone with no credential, and it has to land as `clone_failed` on the
+        // plan we just opened. Letting an untyped throw through would take the
+        // generic path, which has no degraded marker for it either — and would
+        // complete a fresh plan with an EMPTY attempt log, a check that ran
+        // nothing and reported nothing.
+        if (error instanceof LeaseLostError) throw error;
+        throw error instanceof CloneTokenUnavailableError
+          ? error
+          : new CloneTokenUnavailableError(
+              error instanceof Error ? error.message : String(error)
+            );
+      }
       if (!cloneToken) {
         // A null token is only ever legal for a public repository. Here it means
         // the same thing a 502 does — we cannot clone — so it gets the same

--- a/mcpjam-inspector/server/services/github-checks/__tests__/resolve-and-start.test.ts
+++ b/mcpjam-inspector/server/services/github-checks/__tests__/resolve-and-start.test.ts
@@ -1016,4 +1016,33 @@ describe("resolveAndStart — the private-repository clone credential", () => {
     // And nothing leaked through the whole recorded attempt log either.
     expect(JSON.stringify(f.attempts)).not.toContain(TOKEN);
   });
+
+  it("redacts before the 500-character bound, so no slice can halve the token", async () => {
+    // Clamping after redacting is safe; redacting after clamping is not. A
+    // token straddling the boundary would be cut in half, and half a token no
+    // longer matches the literal the replacement looks for — so it would survive
+    // into the corpus as a fragment nobody can search for later.
+    const session = fakeSession();
+    const f = fakes({
+      session,
+      clone: () => {
+        // A plain Error, which is the branch `errorDetail` bounds at 500. The
+        // padding puts the token at offsets 488-518, straddling the cut: redact
+        // first and the whole literal goes, clamp first and its first 12
+        // characters survive into the corpus as an unsearchable fragment.
+        throw new Error(`${"padding ".repeat(61)}${TOKEN} trailing`);
+      },
+    });
+
+    await stopOf(resolveAndStart({ ...ARGS, cloneToken: TOKEN }, f.deps));
+
+    const detail =
+      f.attempts.find((attempt) => attempt.phase === "clone" && !attempt.ok)
+        ?.detailsClamped ?? "";
+    expect(detail.length).toBeLessThanOrEqual(500);
+    expect(detail).not.toContain(TOKEN);
+    // No FRAGMENT of it either — the whole literal was replaced before the cut.
+    expect(detail).not.toContain(TOKEN.slice(0, 12));
+    expect(detail).toContain("[redacted]");
+  });
 });

--- a/mcpjam-inspector/server/services/github-checks/__tests__/resolve-and-start.test.ts
+++ b/mcpjam-inspector/server/services/github-checks/__tests__/resolve-and-start.test.ts
@@ -166,11 +166,15 @@ function fakeSession(options?: {
   return { session, attempts, completions };
 }
 
+type CloneCall = Parameters<ResolveAndStartDeps["cloneAndCheckout"]>[1];
+
 type Fakes = {
   deps: Partial<ResolveAndStartDeps> & { plan: CheckPlanSession };
   events: string[];
   boxes: CheckSandbox[];
   attempts: RecordedAttempt[];
+  /** What `cloneAndCheckout` was asked for, per box. */
+  clones: CloneCall[];
 };
 
 /**
@@ -190,6 +194,7 @@ function fakes(options: {
 }): Fakes {
   const events: string[] = [];
   const boxes: CheckSandbox[] = [];
+  const clones: CloneCall[] = [];
   let provisioned = 0;
   const scripted = options.session ?? fakeSession();
 
@@ -208,7 +213,8 @@ function fakes(options: {
       events.push(`provision:${box.sandboxId}`);
       return box;
     },
-    cloneAndCheckout: async (sandbox) => {
+    cloneAndCheckout: async (sandbox, cloneArgs) => {
+      clones.push(cloneArgs);
       options.clone?.(boxes.length);
       events.push(`clone:${sandbox.sandboxId}`);
     },
@@ -237,7 +243,7 @@ function fakes(options: {
     now: () => 0,
   };
 
-  return { deps, events, boxes, attempts: scripted.attempts };
+  return { deps, events, boxes, attempts: scripted.attempts, clones };
 }
 
 async function stopOf(promise: Promise<unknown>): Promise<CheckStoppedByPlan> {
@@ -927,5 +933,87 @@ describe("judgeListeners", () => {
   it("says 'unknown' — never ok — when no process could be attributed", () => {
     const verdict = judgeListeners({ processes: [] }, spawn);
     expect(verdict.status).toBe("unknown");
+  });
+});
+
+describe("resolveAndStart — the private-repository clone credential", () => {
+  const TOKEN = "ghs_privateRepoToken1234567890";
+
+  it("threads the token to EVERY clone, and to nothing else", async () => {
+    // A fresh box per candidate means a fresh clone per candidate, so the
+    // credential is needed on each one — a token threaded only to the first
+    // would work right up until the second candidate, where it would look like
+    // the repository disappeared.
+    const session = fakeSession({
+      candidates: [planned("c1", { start: "node a.js" }), planned("c2")],
+      actions: { "build:fail": { action: "try_next_candidate" } },
+    });
+    const f = fakes({
+      ladder: { kind: "candidates", candidates: [recipe()] },
+      session,
+      attempt: (built) => {
+        if (built.start === "node a.js") failing("build_failed")();
+      },
+    });
+
+    await resolveAndStart({ ...ARGS, cloneToken: TOKEN }, f.deps);
+
+    expect(f.clones.length).toBeGreaterThan(1);
+    for (const clone of f.clones) {
+      expect(clone.cloneToken).toBe(TOKEN);
+      expect(clone.headSha).toBe(ARGS.headSha);
+    }
+    // It travels on the CHECKOUT args and nowhere else. Recipes and planned
+    // candidates are logged, digested and sent to the backend; a secret on one
+    // of those types is a secret in the corpus.
+    const localCandidates = JSON.stringify(f.attempts);
+    expect(localCandidates).not.toContain(TOKEN);
+  });
+
+  it("asks for no credential at all when the repository is public", async () => {
+    const f = fakes({
+      ladder: { kind: "candidates", candidates: [recipe()] },
+    });
+    await resolveAndStart(ARGS, f.deps);
+    expect(f.clones).toHaveLength(1);
+    expect(f.clones[0].cloneToken).toBeUndefined();
+    expect(f.clones[0]).not.toHaveProperty("cloneToken");
+  });
+
+  it("redacts the credential out of a clone failure before it reaches the backend", async () => {
+    // `detailsClamped` is stored in the corpus. A secret that reaches it is a
+    // secret nobody can un-store, so this is the second redaction boundary —
+    // `sandbox.ts` owns the first, and neither is allowed to be the only one.
+    const basic = Buffer.from(`x-access-token:${TOKEN}`, "utf8").toString(
+      "base64"
+    );
+    const session = fakeSession();
+    const f = fakes({
+      session,
+      clone: () => {
+        throw new CheckStepError(
+          "infra_error",
+          `sandbox command failed: git -c 'http.extraheader=AUTHORIZATION: basic ${basic}' clone --depth 50 (token ${TOKEN})`
+        );
+      },
+    });
+
+    const stop = await stopOf(
+      resolveAndStart({ ...ARGS, cloneToken: TOKEN }, f.deps)
+    );
+    expect(stop.reason).toBe("clone_failed");
+
+    const cloneAttempt = f.attempts.find(
+      (attempt) => attempt.phase === "clone" && !attempt.ok
+    );
+    expect(cloneAttempt?.failureKind).toBe("clone_failed");
+    for (const form of [TOKEN, basic, `AUTHORIZATION: basic ${basic}`]) {
+      expect(cloneAttempt?.detailsClamped ?? "").not.toContain(form);
+    }
+    // Redacted, not dropped: the failure is still legible.
+    expect(cloneAttempt?.detailsClamped).toContain("sandbox command failed");
+    expect(cloneAttempt?.detailsClamped).toContain("[redacted]");
+    // And nothing leaked through the whole recorded attempt log either.
+    expect(JSON.stringify(f.attempts)).not.toContain(TOKEN);
   });
 });

--- a/mcpjam-inspector/server/services/github-checks/__tests__/sandbox.test.ts
+++ b/mcpjam-inspector/server/services/github-checks/__tests__/sandbox.test.ts
@@ -6,6 +6,7 @@ import {
   clampOutput,
   cloneAndCheckout,
   OUTPUT_CLAMP_CHARS,
+  redactCloneCredential,
   PROBE_MAX_RESPONSE_BYTES,
   waitForMcpInitialize,
   type CheckSandbox,
@@ -623,6 +624,261 @@ describe("cloneAndCheckout", () => {
     // injected text stays inside nested quotes.
     expect(box.calls[0].command.startsWith("bash -lc '")).toBe(true);
     expect(box.calls[0].command).not.toMatch(/;\s*rm -rf \/\s*'?\s*&&/);
+  });
+
+  // ═════════════════════════════════════════════════════════════════════════
+  // PRIVATE REPOSITORIES
+  // ═════════════════════════════════════════════════════════════════════════
+  //
+  // The credential is a short-lived `contents: read` installation token, and
+  // every test below is about one of two things: that it reaches git at all,
+  // and that it reaches NOTHING ELSE. The second is the interesting half —
+  // a token that leaks into a check's output is readable by anyone who can see
+  // the pull request.
+
+  /** Computed INDEPENDENTLY of the module, so the test is not a mirror of it. */
+  const basicValue = (token: string) =>
+    Buffer.from(`x-access-token:${token}`, "utf8").toString("base64");
+
+  /** The three shapes a credential can escape in. */
+  const credentialForms = (token: string) => [
+    token,
+    basicValue(token),
+    `AUTHORIZATION: basic ${basicValue(token)}`,
+  ];
+
+  const TOKEN = "ghs_privateRepoToken1234567890";
+
+  it("carries the credential on the clone AND the fetch, in a header, never in the URL", async () => {
+    const headSha = "c".repeat(40);
+    const box = fakeSandbox({ stdout: { "rev-parse HEAD": `${headSha}\n` } });
+
+    await cloneAndCheckout(box.sandbox, {
+      repoFullName: "mcpjam/private-fixture",
+      prNumber: 7,
+      headSha,
+      cloneToken: TOKEN,
+    });
+
+    const script = scriptOf(box.calls[0].command);
+    const header = `http.extraheader=AUTHORIZATION: basic ${basicValue(TOKEN)}`;
+    // BOTH authenticated requests: the PR ref is a second fetch against the same
+    // private repository, and a clone that works followed by a fetch that 404s
+    // is the shape of forgetting it.
+    expect(script).toContain(`git -c '${header}' clone --depth 50`);
+    expect(script).toContain(`git -c '${header}' fetch --depth 50 origin`);
+    // The URL stays the ORDINARY public-looking HTTPS one. A credential in the
+    // URL is written verbatim into `.git/config`, where the PR's own build runs.
+    expect(script).toContain("'https://github.com/mcpjam/private-fixture.git'");
+    expect(script).not.toContain("x-access-token:");
+    expect(script).not.toMatch(/https:\/\/[^'\s]*@github\.com/);
+    // The RAW token never appears anywhere in the command stream — only the
+    // base64 of `x-access-token:<token>` does.
+    expect(script).not.toContain(TOKEN);
+    // Not an env var, not a file, not a credential helper.
+    expect(box.calls[0].opts?.envs).toBeUndefined();
+    expect(script).not.toContain("credential.helper");
+    expect(script).not.toContain("git config");
+  });
+
+  it("keeps the credential off the checkout and everything after it", async () => {
+    // `-c` is process-scoped, so it is gone the moment git exits. What must not
+    // happen is it being added to commands that do not need it: a detached
+    // checkout is purely local, and `rev-parse` reads the clone we already have.
+    const headSha = "c".repeat(40);
+    const box = fakeSandbox({ stdout: { "rev-parse HEAD": `${headSha}\n` } });
+
+    await cloneAndCheckout(box.sandbox, {
+      repoFullName: "mcpjam/private-fixture",
+      prNumber: 7,
+      headSha,
+      cloneToken: TOKEN,
+    });
+
+    const script = scriptOf(box.calls[0].command);
+    const [checkoutSegment] = script.split("git checkout").slice(1);
+    expect(checkoutSegment).toBeDefined();
+    expect(checkoutSegment).not.toContain("extraheader");
+    // The sha assertion is its own command, and carries nothing.
+    const revParse = box.calls[1].command;
+    expect(revParse).toContain("rev-parse HEAD");
+    expect(revParse).not.toContain("extraheader");
+    for (const form of credentialForms(TOKEN)) {
+      expect(revParse).not.toContain(form);
+    }
+    // Exactly two `-c` occurrences in the whole script: the clone and the fetch.
+    expect(script.match(/-c 'http\.extraheader=/g)).toHaveLength(2);
+  });
+
+  it("leaves the anonymous clone byte-for-byte unchanged", async () => {
+    // The public path is the overwhelming majority of checks, and it must not
+    // acquire so much as a stray space from the private one existing.
+    const headSha = "a".repeat(40);
+    const box = fakeSandbox({ stdout: { "rev-parse HEAD": `${headSha}\n` } });
+
+    await cloneAndCheckout(box.sandbox, {
+      repoFullName: "mcpjam/mcp-check-fixture",
+      prNumber: 7,
+      headSha,
+    });
+
+    expect(scriptOf(box.calls[0].command)).toBe(
+      [
+        "set -e",
+        "rm -rf /home/user/repo",
+        "git clone --depth 50 'https://github.com/mcpjam/mcp-check-fixture.git' /home/user/repo",
+        "cd /home/user/repo",
+        "git fetch --depth 50 origin 'pull/7/head'",
+        `git checkout --detach '${headSha}'`,
+      ].join(" && ")
+    );
+  });
+
+  it("redacts every credential form out of a failing clone's output", async () => {
+    // git prints the failing request on some errors, and the output travels to
+    // the check's details on somebody's pull request.
+    const box = fakeSandbox({
+      exitCodes: { "clone --depth 50": 128 },
+      stderr: {
+        "clone --depth 50": [
+          `fatal: unable to access 'https://github.com/mcpjam/private-fixture.git/'`,
+          `> AUTHORIZATION: basic ${basicValue(TOKEN)}`,
+          `token was ${TOKEN}`,
+        ].join("\n"),
+      },
+    });
+
+    const error = (await cloneAndCheckout(box.sandbox, {
+      repoFullName: "mcpjam/private-fixture",
+      prNumber: 7,
+      headSha: "c".repeat(40),
+      cloneToken: TOKEN,
+    }).catch((e) => e)) as CheckStepError;
+
+    expect(error.outcome).toBe("infra_error");
+    const observable = `${error.message}\n${error.detailsMarkdown ?? ""}`;
+    for (const form of credentialForms(TOKEN)) {
+      expect(observable).not.toContain(form);
+    }
+    // Redacted, not merely truncated: the surrounding diagnostic survives, so
+    // the author still learns the clone failed and against which repository.
+    expect(error.detailsMarkdown).toContain("fatal: unable to access");
+    expect(error.detailsMarkdown).toContain("[redacted]");
+  });
+
+  it("redacts a thrown transport error that echoes the whole command", async () => {
+    // THE IMPORTANT ONE. `runForeground`'s transport branch folds
+    // `errorMessage(error)` into a `CheckStepError`, and the E2B SDK's errors
+    // quote the command they were running — which, for a private clone, is the
+    // command carrying the auth header. Nothing about that is redacted by
+    // clamping, and this path does not even go through the clamp.
+    const box = fakeSandbox({
+      throwOn: (command) =>
+        command.includes("clone --depth 50")
+          ? new Error(`sandbox unavailable while running: ${command}`)
+          : undefined,
+    });
+
+    const error = (await cloneAndCheckout(box.sandbox, {
+      repoFullName: "mcpjam/private-fixture",
+      prNumber: 7,
+      headSha: "c".repeat(40),
+      cloneToken: TOKEN,
+    }).catch((e) => e)) as CheckStepError;
+
+    expect(error).toBeInstanceOf(CheckStepError);
+    // Ours, not the PR's — E2B being unreachable says nothing about the code.
+    expect(error.outcome).toBe("infra_error");
+    const observable = `${error.message}\n${error.detailsMarkdown ?? ""}\n${
+      error.stack ?? ""
+    }`;
+    for (const form of credentialForms(TOKEN)) {
+      expect(observable).not.toContain(form);
+    }
+    expect(error.message).toContain("sandbox command failed");
+  });
+
+  it("redacts a clone that overran its own deadline", async () => {
+    // The deadline branch clamps, and clamping is a LENGTH boundary: a clamped
+    // header is still a header. Redaction has to happen first.
+    vi.useFakeTimers();
+    try {
+      const box = fakeSandbox({
+        throwOn: (command) => {
+          if (!command.includes("clone --depth 50")) return undefined;
+          vi.setSystemTime(Date.now() + 6 * 60_000);
+          return Object.assign(new Error("timeout"), {
+            stderr: `giving up on AUTHORIZATION: basic ${basicValue(TOKEN)}`,
+          });
+        },
+      });
+
+      const error = (await cloneAndCheckout(box.sandbox, {
+        repoFullName: "mcpjam/private-fixture",
+        prNumber: 7,
+        headSha: "c".repeat(40),
+        cloneToken: TOKEN,
+      }).catch((e) => e)) as CheckStepError;
+
+      const observable = `${error.message}\n${error.detailsMarkdown ?? ""}`;
+      for (const form of credentialForms(TOKEN)) {
+        expect(observable).not.toContain(form);
+      }
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+});
+
+describe("redactCloneCredential", () => {
+  const TOKEN = "ghs_aB3.+/=xyz";
+  const basic = Buffer.from(`x-access-token:${TOKEN}`, "utf8").toString(
+    "base64"
+  );
+
+  it("removes the raw token, the base64, and the header", async () => {
+    const text = [
+      `raw ${TOKEN} here`,
+      `encoded ${basic} here`,
+      `git -c 'http.extraheader=AUTHORIZATION: basic ${basic}' clone --depth 50`,
+    ].join("\n");
+
+    const out = redactCloneCredential(text, TOKEN);
+    expect(out).not.toContain(TOKEN);
+    expect(out).not.toContain(basic);
+    expect(out).toContain("[redacted]");
+    // The shell quoting around the header survives, so the surrounding command
+    // is still readable as a command.
+    expect(out).toContain("' clone --depth 50");
+  });
+
+  it("removes an AUTHORIZATION header even with no token to compare against", async () => {
+    // The defence that does not depend on us having guessed the encoding: any
+    // basic header goes, token or not. That is what covers a future command
+    // that grows one before anybody remembers to thread the secret through.
+    const out = redactCloneCredential(
+      "> AUTHORIZATION: Basic c29tZXRoaW5nRWxzZQ==",
+      undefined
+    );
+    expect(out).not.toContain("c29tZXRoaW5nRWxzZQ==");
+    expect(out).toContain("[redacted]");
+  });
+
+  it("is a literal replacement, so regex metacharacters in a token still match", async () => {
+    // `.` and `+` in a token would widen or break a pattern built by
+    // interpolation. This token has both.
+    expect(redactCloneCredential(`prefix ${TOKEN} suffix`, TOKEN)).toBe(
+      "prefix [redacted] suffix"
+    );
+    // And a token-shaped string that is NOT the token is left alone.
+    expect(redactCloneCredential("ghs_aB3X+/=xyz", TOKEN)).toBe(
+      "ghs_aB3X+/=xyz"
+    );
+  });
+
+  it("is idempotent, so a doubly-redacted string stays readable", async () => {
+    const once = redactCloneCredential(`AUTHORIZATION: basic ${basic}`, TOKEN);
+    expect(redactCloneCredential(once, TOKEN)).toBe(once);
   });
 });
 

--- a/mcpjam-inspector/server/services/github-checks/resolve-and-start.ts
+++ b/mcpjam-inspector/server/services/github-checks/resolve-and-start.ts
@@ -584,7 +584,14 @@ function recipeOf(planned: PlannedCandidate): ResolvedRecipe {
 }
 
 /**
- * `errorDetail`, with any clone credential removed first.
+ * `errorDetail`, with any clone credential removed BEFORE the 500-character
+ * bound is applied.
+ *
+ * The ordering is the same one `sandbox.ts` makes for `errorMessage`, for the
+ * same reason: a slice that lands mid-token leaves half a token in the corpus,
+ * and a halved token no longer matches the literal the replacement is looking
+ * for. So this redacts the UNCLAMPED text and clamps last — which is why it
+ * cannot simply wrap `errorDetail`.
  *
  * Separate from `errorDetail` rather than folded into it so the redaction is
  * visible at the call site that needs it: the clone is the only phase whose
@@ -594,9 +601,21 @@ function redactedErrorDetail(
   error: unknown,
   cloneToken?: string
 ): string | undefined {
-  const detail = errorDetail(error);
-  if (detail === undefined) return undefined;
-  return redactCloneCredential(detail, cloneToken) || undefined;
+  // Mirrors `errorDetail`'s branches and its BOUNDS exactly — `detailsMarkdown`
+  // arrives already clamped and fenced from `sandbox.ts` and is not re-bounded,
+  // while a bare message is. What differs is only the ORDER: redact, then clamp.
+  if (error instanceof CheckStepError && error.detailsMarkdown !== undefined) {
+    return (
+      redactCloneCredential(error.detailsMarkdown, cloneToken) || undefined
+    );
+  }
+  if (error instanceof Error) {
+    return (
+      redactCloneCredential(error.message, cloneToken).slice(0, 500) ||
+      undefined
+    );
+  }
+  return undefined;
 }
 
 function errorDetail(error: unknown): string | undefined {

--- a/mcpjam-inspector/server/services/github-checks/resolve-and-start.ts
+++ b/mcpjam-inspector/server/services/github-checks/resolve-and-start.ts
@@ -75,6 +75,7 @@ import {
   cloneAndCheckout,
   killCheckSandbox,
   provisionCheckSandbox,
+  redactCloneCredential,
   type CheckSandbox,
   type SpawnIdentity,
   type StartedServer,
@@ -170,6 +171,17 @@ export type ResolveAndStartArgs = {
   repoFullName: string;
   prNumber: number;
   headSha: string;
+  /**
+   * The clone credential for a PRIVATE repository, minted by the worker between
+   * `/plan/begin` and the first provision. Absent for a public one, which is
+   * cloned anonymously exactly as before.
+   *
+   * It lives on the ARGS and not on the recipe or the plan types on purpose:
+   * every candidate re-clones into a fresh box, so this is a property of the
+   * CHECKOUT, and widening a recipe or a plan candidate to carry a secret would
+   * put it on types that are logged, digested and sent to the backend.
+   */
+  cloneToken?: string;
 };
 
 function provenanceOf(recipe: ResolvedRecipe): RecipeProvenance {
@@ -297,6 +309,7 @@ export async function resolveAndStart(
         repoFullName: args.repoFullName,
         prNumber: args.prNumber,
         headSha: args.headSha,
+        ...(args.cloneToken ? { cloneToken: args.cloneToken } : {}),
       });
     } catch (error) {
       await plan.attempt({
@@ -305,7 +318,11 @@ export async function resolveAndStart(
         ok: false,
         failureKind: "clone_failed",
         durationMs: deps.now() - cloneStartedAt,
-        detailsClamped: errorDetail(error),
+        // The one attempt detail that can carry a credential. `sandbox.ts`
+        // already redacts at the boundary it owns; this is the second, at the
+        // boundary where the text leaves the process for the corpus, because a
+        // detail that reaches the backend is a detail nobody can un-store.
+        detailsClamped: redactedErrorDetail(error, args.cloneToken),
       });
       throw new CheckStoppedByPlan("clone_failed");
     }
@@ -564,6 +581,22 @@ function recipeOf(planned: PlannedCandidate): ResolvedRecipe {
     ownershipProof: planned.ownershipProof,
     evidence: planned.evidence ?? [],
   };
+}
+
+/**
+ * `errorDetail`, with any clone credential removed first.
+ *
+ * Separate from `errorDetail` rather than folded into it so the redaction is
+ * visible at the call site that needs it: the clone is the only phase whose
+ * failure text can have touched a secret.
+ */
+function redactedErrorDetail(
+  error: unknown,
+  cloneToken?: string
+): string | undefined {
+  const detail = errorDetail(error);
+  if (detail === undefined) return undefined;
+  return redactCloneCredential(detail, cloneToken) || undefined;
 }
 
 function errorDetail(error: unknown): string | undefined {

--- a/mcpjam-inspector/server/services/github-checks/sandbox.ts
+++ b/mcpjam-inspector/server/services/github-checks/sandbox.ts
@@ -273,6 +273,72 @@ function stripControlCharacters(text: string): string {
   return out;
 }
 
+/** What every redacted credential form collapses to. */
+const REDACTED_CREDENTIAL = "[redacted]";
+
+/**
+ * Every `AUTHORIZATION: basic …` header, wherever it turns up.
+ *
+ * CONSTANT on purpose, and deliberately NOT built from the token: a secret
+ * interpolated into a pattern is a secret that can carry regex metacharacters,
+ * and the one time that matters is the time the redaction silently stops
+ * matching. The token-derived forms are removed by literal replacement instead
+ * (below); this pattern exists to catch the header AS A WHOLE — including the
+ * copy an SDK echoes back inside a failing command line — so nothing survives
+ * on the strength of an encoding we did not anticipate.
+ *
+ * The value class requires at least one character, which also makes the
+ * function idempotent: `AUTHORIZATION: basic [redacted]` no longer matches.
+ */
+const CLONE_AUTH_HEADER_PATTERN =
+  /AUTHORIZATION:\s*basic\s+[A-Za-z0-9+/=_-]+/gi;
+
+/**
+ * The base64 an installation token is sent as: `x-access-token:<token>`.
+ *
+ * Computed HOST-SIDE, so the token itself never appears in the command stream
+ * in plaintext — only this encoding of it does, and only inside the
+ * `http.extraheader` config value.
+ */
+function cloneAuthHeaderValue(token: string): string {
+  return Buffer.from(`x-access-token:${token}`, "utf8").toString("base64");
+}
+
+/**
+ * Strip a clone credential out of text that is about to be OBSERVED — thrown,
+ * logged, reported as an attempt detail, or rendered on somebody's pull request.
+ *
+ * Three forms, because the credential reaches observable text three ways:
+ *
+ *   1. the RAW installation token — anything that echoes what we were handed;
+ *   2. `base64(x-access-token:<token>)` — what the header actually carries;
+ *   3. the whole `AUTHORIZATION: basic …` header — which is how it arrives in
+ *      practice, since the E2B SDK's errors quote the command they were running
+ *      and the command contains the `-c http.extraheader=…` argument verbatim.
+ *
+ * Applied BEFORE `clampOutput`, never after. Clamping is a length and markdown
+ * boundary — it truncates, strips control characters and fences — and none of
+ * that removes a secret; a clamped log tail is exactly as leaked as an unclamped
+ * one.
+ */
+export function redactCloneCredential(
+  text: string,
+  token?: string | null
+): string {
+  if (typeof text !== "string" || text.length === 0) return "";
+  let out = text.replace(
+    CLONE_AUTH_HEADER_PATTERN,
+    `AUTHORIZATION: basic ${REDACTED_CREDENTIAL}`
+  );
+  if (token) {
+    // Literal, not regex: `split`/`join` treats the needle as bytes, so a token
+    // containing `.` or `+` cannot quietly widen or narrow the match.
+    out = out.split(cloneAuthHeaderValue(token)).join(REDACTED_CREDENTIAL);
+    out = out.split(token).join(REDACTED_CREDENTIAL);
+  }
+  return out;
+}
+
 export function isGithubChecksSandboxConfigured(): boolean {
   return Boolean(
     process.env.E2B_API_KEY?.trim() &&
@@ -372,6 +438,13 @@ async function runForeground(
      * `infra_error` (neutral) rather than a red X on a good PR.
      */
     timeoutOutcome: CheckStepOutcome;
+    /**
+     * The clone credential, when THIS command carries one. Every observable
+     * form of a failure is redacted with it before anything else happens to the
+     * text — in particular before `clampOutput`, which is a length boundary and
+     * not a secret one.
+     */
+    secret?: string;
   }
 ): Promise<RunResult> {
   const startedAt = Date.now();
@@ -401,13 +474,24 @@ async function runForeground(
       throw new CheckStepError(
         opts.timeoutOutcome,
         `command exceeded its ${Math.round(opts.timeoutMs / 1000)}s deadline`,
-        clampOutput(`${exit.stdout ?? ""}\n${exit.stderr ?? ""}`) || undefined
+        clampOutput(
+          redactCloneCredential(
+            `${exit.stdout ?? ""}\n${exit.stderr ?? ""}`,
+            opts.secret
+          )
+        ) || undefined
       );
     }
     // Not a command failure — the sandbox itself is unreachable.
+    //
+    // THE LEAKIEST PATH IN THIS MODULE. `errorMessage` is fed the SDK's own
+    // error, and an E2B transport error quotes the command it was running —
+    // which, for a private clone, is the command carrying the auth header. It is
+    // redacted here rather than at the caller because this is where the SDK's
+    // text first becomes ours.
     throw new CheckStepError(
       "infra_error",
-      `sandbox command failed: ${errorMessage(error)}`
+      `sandbox command failed: ${errorMessage(error, opts.secret)}`
     );
   }
 }
@@ -427,7 +511,9 @@ function looksLikeSandboxTransportFailure(error: unknown): boolean {
 }
 
 /**
- * Clone the PR head, anonymously.
+ * Clone the PR head — anonymously for a public repository, and with a
+ * short-lived, repository-scoped `contents: read` installation token for a
+ * private one.
  *
  * `refs/pull/<n>/head` rather than the branch name: the branch may have been
  * renamed or deleted since the webhook fired, and the PR ref is stable. The
@@ -436,21 +522,74 @@ function looksLikeSandboxTransportFailure(error: unknown): boolean {
  * have us build a different tree and report the verdict against the sha in the
  * check, i.e. quietly lie about what was tested.
  *
- * No credentials: the repo is public, so the clone is anonymous. This is what
- * lets the box hold nothing worth stealing.
+ * ═══════════════════════════════════════════════════════════════════════════
+ * WHERE THE CREDENTIAL GOES, AND WHERE IT DELIBERATELY DOES NOT
+ * ═══════════════════════════════════════════════════════════════════════════
+ *
+ * On a command-line `-c http.extraheader=…`, on the CLONE and the FETCH, and
+ * nowhere else. Every alternative was rejected for a specific reason:
+ *
+ *   - IN THE URL (`https://x-access-token:<t>@github.com/…`) — git writes the
+ *     remote verbatim into `.git/config`, so the checkout the PR's own build
+ *     then runs inside would contain the credential as a file. It also lands in
+ *     `git remote -v`, in submodule resolution, and in any log that echoes the
+ *     remote.
+ *   - `git config --add` INSIDE the checkout — same problem by a different
+ *     route: a `-c` on the command line is process-scoped and never persisted,
+ *     which is the entire reason it is the mechanism here.
+ *   - A CREDENTIAL HELPER, an env var, or a file — each one leaves the secret
+ *     readable by whatever runs next in the box, and what runs next is the pull
+ *     request's build.
+ *
+ * The `fetch` needs it as much as the clone does: the PR ref is a second
+ * authenticated request against the same private repository, and a clone that
+ * succeeds followed by a fetch that 404s is the confusing shape of forgetting
+ * it. `checkout`, `rev-parse` and everything downstream are purely local and
+ * get nothing.
+ *
+ * THE RESIDUAL, NAMED: E2B is the sandbox provider and therefore sees the
+ * command stream, including this header. That is accepted rather than solved —
+ * we already trust E2B with the checkout itself. What is NOT accepted is the
+ * PR's own code seeing it, which is why nothing is persisted: clone and fetch
+ * both finish before any PR-controlled process runs.
  */
 export async function cloneAndCheckout(
   sandbox: CheckSandbox,
-  args: { repoFullName: string; prNumber: number; headSha: string }
+  args: {
+    repoFullName: string;
+    prNumber: number;
+    headSha: string;
+    /**
+     * Installation token for a PRIVATE repository. Absent ⇒ the clone is
+     * anonymous, byte-for-byte as it has always been.
+     */
+    cloneToken?: string;
+  }
 ): Promise<void> {
+  // Unchanged, and unchanged ON PURPOSE even when a token is in play: the
+  // credential travels in a header, so the URL stays the ordinary public-looking
+  // HTTPS one and nothing that echoes it can leak anything.
   const cloneUrl = `https://github.com/${args.repoFullName}.git`;
+  // A trailing space when present and the empty string when not, so the
+  // anonymous command bytes are identical to what they were before tokens
+  // existed.
+  const authConfig = args.cloneToken
+    ? `-c ${shellQuote(
+        `http.extraheader=AUTHORIZATION: basic ${cloneAuthHeaderValue(
+          args.cloneToken
+        )}`
+      )} `
+    : "";
   const script = [
     `set -e`,
     `rm -rf ${CHECKOUT_DIR}`,
     // Shallow, but deep enough that a PR ref's own history resolves.
-    `git clone --depth 50 ${shellQuote(cloneUrl)} ${CHECKOUT_DIR}`,
+    `git ${authConfig}clone --depth 50 ${shellQuote(cloneUrl)} ${CHECKOUT_DIR}`,
     `cd ${CHECKOUT_DIR}`,
-    `git fetch --depth 50 origin ${shellQuote(`pull/${args.prNumber}/head`)}`,
+    `git ${authConfig}fetch --depth 50 origin ${shellQuote(
+      `pull/${args.prNumber}/head`
+    )}`,
+    // No credential: a detached checkout is a purely local operation.
     `git checkout --detach ${shellQuote(args.headSha)}`,
   ].join(" && ");
 
@@ -459,18 +598,29 @@ export async function cloneAndCheckout(
     `bash -lc ${shellQuote(script)}`,
     {
       timeoutMs: CLONE_TIMEOUT_MS,
-      // A public repo we were just told about should clone promptly; a stall is
-      // ours or GitHub's, matching how a non-zero clone exit is attributed.
+      // A repo we were just told about, and now hold a credential for, should
+      // clone promptly; a stall is ours or GitHub's, matching how a non-zero
+      // clone exit is attributed.
       timeoutOutcome: "infra_error",
+      secret: args.cloneToken,
     }
   );
   if (result.exitCode !== 0) {
-    // A public repo we were just told about should always clone. If it doesn't,
-    // that is our problem (or GitHub's), not the PR author's.
+    // A repo we were just told about — and, for a private one, just minted a
+    // token for — should always clone. If it doesn't, that is our problem (or
+    // GitHub's), not the PR author's.
+    //
+    // REDACTED BEFORE CLAMPED. git prints the failing request on some errors,
+    // and clamping would merely shorten the header rather than remove it.
     throw new CheckStepError(
       "infra_error",
       `clone/checkout failed (exit ${result.exitCode})`,
-      clampOutput(`${result.stdout}\n${result.stderr}`)
+      clampOutput(
+        redactCloneCredential(
+          `${result.stdout}\n${result.stderr}`,
+          args.cloneToken
+        )
+      )
     );
   }
 
@@ -706,14 +856,17 @@ async function readProcessGroup(
     `}catch(e){}`;
   let stdout = "";
   try {
-    const result = (await sandbox.commands.run(`node -e ${JSON.stringify(script)}`, {
-      timeoutMs: 30_000,
-    })) as { stdout?: unknown } | null;
+    const result = (await sandbox.commands.run(
+      `node -e ${JSON.stringify(script)}`,
+      {
+        timeoutMs: 30_000,
+      }
+    )) as { stdout?: unknown } | null;
     stdout = typeof result?.stdout === "string" ? result.stdout : "";
   } catch (error) {
     stdout =
       typeof (error as { stdout?: unknown })?.stdout === "string"
-        ? ((error as { stdout: string }).stdout)
+        ? (error as { stdout: string }).stdout
         : "";
   }
   for (const line of stdout.split("\n")) {
@@ -1227,7 +1380,9 @@ function isJsonRpcMessageShaped(value: unknown): boolean {
 
   if (message.result !== undefined) {
     return (
-      within(RESULT_RESPONSE_KEYS) && idIsValid && isResultShaped(message.result)
+      within(RESULT_RESPONSE_KEYS) &&
+      idIsValid &&
+      isResultShaped(message.result)
     );
   }
   if (message.error !== undefined) {
@@ -1685,6 +1840,20 @@ export function shellQuote(value: string): string {
   return `'${value.replace(/'/g, `'\\''`)}'`;
 }
 
-function errorMessage(error: unknown): string {
-  return error instanceof Error ? error.message.slice(0, 300) : String(error);
+/**
+ * An error's text, with any clone credential already removed.
+ *
+ * Redaction happens BEFORE the slice, deliberately: slicing first can cut a
+ * token in half, and half a token in a log is still half a token in a log —
+ * and no longer matches the literal the redaction is looking for.
+ *
+ * The `secret` is optional because most callers run commands that never carry
+ * one. They still get the constant header sweep, which costs nothing and means
+ * a future command that grows an `AUTHORIZATION:` header is covered the day it
+ * is written rather than the day somebody remembers.
+ */
+function errorMessage(error: unknown, secret?: string | null): string {
+  const raw = error instanceof Error ? error.message : String(error);
+  const redacted = redactCloneCredential(raw, secret);
+  return error instanceof Error ? redacted.slice(0, 300) : redacted;
 }


### PR DESCRIPTION
Finishes the Inspector half of private-repository support for GitHub PR checks. The backend half is already deployed (backend PR #1020): claims carry `repoPrivate: boolean`, and `POST /internal/v1/github-checks/clone-token` mints a repository-scoped, `contents: read` installation token for the current claim holder.

**This PR does not change the backend.** It mirrors the deployed contract exactly.

> Placeholders below are written as `TOKEN` / `BASE64` rather than in angle brackets — an earlier revision of this description used angle brackets and GitHub stripped them as HTML, silently deleting the credential mechanism from the three places that matter most.

## `begin -> mint -> provision`

The executor order is load-bearing in both directions:

1. claim (already exists)
2. `beginPlan` — the plan shell
3. **if and only if `repoPrivate`** — mint the clone token
4. provision the first sandbox
5. clone and continue resolution

- **After `beginPlan`**, so a mint failure has a plan to be reported against. It lands as an ordinary ladder-level `clone` / `clone_failed` terminal attempt (no `candidateId` — nothing has been detected yet), which the backend attributes as `infra_error`. It never takes the planless completion path, and it is never the pull request's fault.
- **Before the first provision**, so a check we already know cannot clone never costs an E2B box, and the failure cannot be confused with one the sandbox caused.

Status mapping, mirrored from the deployed route:

| response | behavior |
| --- | --- |
| `200 { cloneToken: null }` | no token needed. Only legal for a public repo. |
| `200 { cloneToken, expiresAt }` | used for clone/fetch and nothing else. |
| `409` | lease loss. The check is abandoned — no competing completion, no sandbox. |
| `502` | mint failed. Plan completion with a ladder `clone` / `clone_failed`. |
| no answer at all (transport / deadline) | same as `502` — see the review-round fix below. |
| null token on a `repoPrivate` claim | the same `clone_failed` result — an anonymous retry would 404 and read as the repository having vanished. |

A public claim never calls the route at all. That is not an optimization: it keeps the blast radius of a `contents: read` mint proportional to the number of checks that genuinely need one. Heartbeat and lease-loss behavior are unchanged.

## The credential boundary, and the E2B residual

The token rides on a command-line `git -c 'http.extraheader=AUTHORIZATION: basic BASE64'` for the **clone** and the **fetch**, and nothing else — not `checkout`, not `rev-parse`, not the build or start commands. `BASE64` is `base64("x-access-token:TOKEN")`, computed host-side, so the raw token never appears in the command stream at all.

Everything else was rejected for a specific reason:

- **In the URL** (`https://x-access-token:TOKEN@github.com/owner/repo.git`) — git writes the remote verbatim into `.git/config`, so the checkout the PR's own build then runs inside would contain the credential as a file. It also lands in `git remote -v` and in any log that echoes the remote. The URL stays exactly `https://github.com/owner/repo.git`.
- **`git config --add` inside the checkout** — same problem by another route. A command-line `-c` is process-scoped and never persisted, which is the whole reason it is the mechanism.
- **A credential helper, an env var, or a file** — each leaves the secret readable by whatever runs next in the box, and what runs next is the pull request's build.

The existing `shellQuote` is used throughout; no second shell escape was hand-rolled. The anonymous path is byte-for-byte identical to what it was — there is a test asserting the exact command string.

**The acknowledged residual, named in the code:** E2B, as the sandbox provider, sees the command stream and therefore sees the header. That is accepted rather than solved — we already trust E2B with the checkout itself. What is *not* accepted is the PR's own code seeing it, and nothing is persisted: clone and fetch both finish before any PR-controlled process runs.

## Redaction coverage

A small, deterministic `redactCloneCredential(text, token)` boundary in `sandbox.ts` removes three forms:

1. the raw installation token, `TOKEN`;
2. `BASE64`, i.e. `base64("x-access-token:TOKEN")`;
3. any whole `AUTHORIZATION: basic ...` header — including forms echoed back inside a shell command.

Token-derived values are removed by **literal** `split`/`join` replacement, never by a pattern built from the token (a token can carry regex metacharacters, and the one time that matters is the time the redaction silently stops matching). The header sweep is a *constant* pattern, so it runs whether or not a token is currently held.

**Redaction happens before clamping and before slicing, everywhere.** Clamping is a length and markdown boundary — it truncates, strips control characters and fences — and none of that removes a secret. A clamped log tail is exactly as leaked as an unclamped one, and a cut landing mid-token leaves a fragment that no longer matches the literal the replacement looks for.

Applied to every observable clone failure path:

- non-zero git exit stdout/stderr;
- deadline-overrun output;
- **thrown E2B/transport errors** — `runForeground`'s transport branch folds `errorMessage(error)` into a `CheckStepError`, and an SDK error quotes the whole command it was running, which for a private clone is the command carrying the header;
- the eventual `CheckStepError` (message and `detailsMarkdown`);
- the `clone_failed` attempt's `detailsClamped` in `resolve-and-start.ts` — a second boundary, because a detail that reaches the backend's corpus is a detail nobody can un-store;
- worker log metadata, the error object handed to `logger.error` (the server's single Sentry capture path — a secret that reaches Sentry cannot be recalled), the terminal attempt detail, and the completion payload.

`redactErrorForLog` hands back the *original* error when the redaction changed nothing, so the overwhelming majority of failures still reach the logger as the typed error they were thrown as.

## Review round (`1575403`)

Two real bugs, found by Codex and CodeRabbit independently, both fixed:

**A transport failure lost the plan attribution.** `postServiceRoute` does not only return a status — it throws on missing env, on a `fetch` rejection, and when the response-body read hits its 15s abort deadline. `mintCloneToken` rejected with a plain `Error` in those cases, so the executor skipped the `CloneTokenUnavailableError` branch and fell into the generic path, where `degradedMarker` only fires on `PlanUnreachableError`. Net result: a freshly opened plan completed with **no `terminalAttempt` at all** — a check that ran nothing and reported nothing, precisely the shape the plan shell exists to prevent.

Fixed at two levels. `mintCloneToken` types its own transport failures, making its documented answer table true standalone; and `executeClaimedCheck` additionally converts whatever `deps.mintCloneToken` throws, so the **phase** decides the attribution rather than the error's type. The second level earned its place empirically — fixing only the inner function left the executor-level test red, because an injected dep throwing untyped bypassed it. `LeaseLostError` is rethrown unchanged at both.

**`redactedErrorDetail` redacted after the 500-character slice.** The opposite of the ordering `sandbox.ts` argues for. It now redacts the unclamped text and clamps last, mirroring `errorDetail`'s branches and its per-branch bounds exactly — `detailsMarkdown` arrives already clamped and fenced from `sandbox.ts` and is still not re-bounded, so the other call site's build-log details are not truncated.

## Tests

**211 passing** across the four affected suites. Every new behavioral test was **probed red** before being accepted — the implementation was deliberately broken, the specific test confirmed failing, and the break reverted without removing the test:

| probe | test that went red |
| --- | --- |
| drop redaction from the transport branch | thrown transport error leaks |
| forget the header on the `fetch` | clone-and-fetch header |
| put the credential in the URL | no credential in the URL |
| clamp before redacting | failing clone's output leaks |
| extraheader on `checkout` too | credential off later commands |
| don't thread the token to the clone | token threaded to every clone |
| report the raw error detail | attempt detail leaks |
| always pass a `cloneToken` key | public claim asks for nothing |
| mint *before* `beginPlan` | ordering |
| mint for public claims too | public claim asks for nothing |
| null token falls back to anonymous | null == mint failure |
| report the mint failure planlessly | ladder `clone_failed` completion |
| don't redact the worker's derived text | the leak test |
| treat 409 as an ordinary mint failure | 409 maps to lease loss |
| revert the executor's mint-step attribution | empty attempt log |
| revert the wire-level transport typing | transport maps to mint failure |
| redact after the slice again | token straddling the 500-char cut |

Covering: claim mirroring of `repoPrivate` (at the wire, through `claimNext`); public claim makes no token call and its clone/fetch bytes are unchanged; private happy path event order `beginPlan -> mintCloneToken -> resolveAndStart` with the token threaded to the clone; null/502/transport producing exactly one plan completion with a ladder `clone_failed` and no `resolveAndStart`; clone and fetch both carrying `http.extraheader` with an ordinary HTTPS URL; the extraheader absent from checkout and `rev-parse`; a non-zero clone whose output contains the token exposing none of the three forms; **the leak test** — `sandbox.commands.run` throwing an error containing the complete command string, asserted against the thrown error, the described failure, the logged metadata, the terminal attempt and the completion; a token positioned at offsets 488–518 so it straddles the 500-character cut, asserting no 12-character fragment survives; 409 following lease-loss behavior; and the pre-existing SHA-assertion and anonymous-clone tests still green.

## Verification

From `mcpjam-inspector/`:

- `npx vitest run` on the three named suites plus `github-checks-worker-source.test.ts` — **211 passed**
- `npx vitest run server/services` — **1655 passed / 98 files**
- `npx tsc --noEmit -p server/tsconfig.json` — no new errors (two pre-existing baseline `TS6133`s in `resolve-and-start.ts` and `sandbox.test.ts` remain, confirmed present on `main` by stashing)
- `npx prettier --check` on every touched file — clean
- root `npm run test:checks` (the repo-guard suite: mcp-v1 runtime imports, bundled runtime paths, platform runtime safety, incl. `:dist`) — passed
- CI green on `1575403`: Build and Test, all four Inspector Tests shards, Run Tests, E2E Smoke, and both CodeQL analyses

Prettier brought three files that were already drifting on `main` into conformance; that accounts for three small unrelated hunks. No generated bundle was hand-edited — `scripts/bundle-*.mjs` were run as the `pretest` hook does.

A patch changeset is included.

## Still requires an operator

**Private-repository drill.** Not runnable from CI, and not yet done: install the MCPJam GitHub App on a private fixture repository, connect it, open a pull request against it, and verify that the check clones, builds and runs its evals. Then inspect the check output, the worker logs and the stored attempt details for absence of all three credential forms — the raw `ghs_` token, the `base64("x-access-token:TOKEN")` value, and any `AUTHORIZATION: basic` header. The redaction is covered by unit tests at every boundary in this diff, but a live run is what confirms the mint route, the App's installation scope and the end-to-end clone actually agree.