### PR TITLE
fix(chat): stop retrying a widget snapshot the scenario can never accept (CONVEX-19N)

### DIFF
--- a/mcpjam-inspector/client/src/hooks/__tests__/useSharedChatWidgetCapture.test.tsx
+++ b/mcpjam-inspector/client/src/hooks/__tests__/useSharedChatWidgetCapture.test.tsx
@@ -598,6 +598,89 @@ describe("useSharedChatWidgetCapture", () => {
     unmount();
   });
 
+  it("abandons a snapshot whose server left the scenario allowlist instead of retrying it", async () => {
+    // Sentry CONVEX-19N. A transcript outlives the allowlist, so this
+    // toolCallId is re-offered on every sweep and the backend refuses it every
+    // time. `shouldRetryPendingSnapshot` used to arm the ladder anyway (its
+    // `result == null` early return makes the catch path retry on any error),
+    // turning one dead snapshot into six backend calls.
+    const onStaleHostedAccess = vi.fn();
+    class OutsideAllowlistError extends Error {
+      data: { code: string; message: string };
+      constructor() {
+        super("Server is not in the scenario allowlist");
+        this.data = {
+          code: "server_not_in_scenario_allowlist",
+          message: "Server is not in the scenario allowlist",
+        };
+      }
+    }
+    mockCreateWidgetSnapshot.mockReset();
+    mockCreateWidgetSnapshot.mockRejectedValue(new OutsideAllowlistError());
+
+    const { unmount } = renderHook(() =>
+      useSharedChatWidgetCapture({
+        enabled: true,
+        chatSessionId: "chat-session-outside",
+        hostedScenarioId: "cbx_1",
+        hostedAccessVersion: 1,
+        onStaleHostedAccess,
+        messages: [
+          {
+            id: "assistant-1",
+            role: "assistant",
+            parts: [
+              {
+                type: "tool-search",
+                toolCallId: "call-outside",
+                input: { q: "hello" },
+                output: { result: "world", _serverId: "server-gone" },
+              },
+            ],
+          } as any,
+        ],
+      }),
+    );
+
+    act(() => {
+      useWidgetDebugStore.setState({
+        widgets: new Map([
+          [
+            "call-outside",
+            {
+              toolCallId: "call-outside",
+              toolName: "search",
+              protocol: "mcp-apps",
+              widgetState: null,
+              globals: { theme: "dark", displayMode: "inline" },
+              widgetHtml: "<div>Widget</div>",
+              updatedAt: Date.now(),
+            },
+          ],
+        ]),
+      });
+    });
+
+    act(() => {
+      vi.advanceTimersByTime(500);
+    });
+    await flushMicrotasks();
+
+    expect(mockCreateWidgetSnapshot).toHaveBeenCalledTimes(1);
+
+    // The retry ladder tops out around 10s a step; a minute covers all five.
+    act(() => {
+      vi.advanceTimersByTime(60_000);
+    });
+    await flushMicrotasks();
+
+    expect(mockCreateWidgetSnapshot).toHaveBeenCalledTimes(1);
+    // Nor is it a stale-access case: re-redeeming buys nothing here.
+    expect(onStaleHostedAccess).not.toHaveBeenCalled();
+
+    unmount();
+  });
+
   it("retries stale snapshots even after the first refresh callback fails to advance accessVersion", async () => {
     // P2 from review: if the parent's /redeem fetch fails, hostedAccessVersion
     // never bumps, so the reset effect never runs. The hook must still fire

--- a/mcpjam-inspector/client/src/hooks/__tests__/useSharedChatWidgetCapture.test.tsx
+++ b/mcpjam-inspector/client/src/hooks/__tests__/useSharedChatWidgetCapture.test.tsx
@@ -681,6 +681,190 @@ describe("useSharedChatWidgetCapture", () => {
     unmount();
   });
 
+  it("stops asking for a re-redeem once a queued snapshot turns out to be terminal", async () => {
+    // stale THEN terminal, without an accessVersion bump in between: the
+    // toolCallId is still sitting in the stale-replay queue, so the bounded
+    // backoff would keep asking the parent to redeem on behalf of work that is
+    // never going to run again.
+    const onStaleHostedAccess = vi.fn();
+    class StaleError extends Error {
+      data: { code: string; currentAccessVersion: number };
+      constructor() {
+        super("Scenario access version is stale; client must re-redeem.");
+        this.data = { code: "scenario_access_stale", currentAccessVersion: 7 };
+      }
+    }
+    class OutsideAllowlistError extends Error {
+      data: { code: string };
+      constructor() {
+        super("Server is not in the scenario allowlist");
+        this.data = { code: "server_not_in_scenario_allowlist" };
+      }
+    }
+    mockCreateWidgetSnapshot.mockReset();
+    mockCreateWidgetSnapshot
+      .mockRejectedValueOnce(new StaleError())
+      .mockRejectedValue(new OutsideAllowlistError());
+
+    const { unmount } = renderHook(() =>
+      useSharedChatWidgetCapture({
+        enabled: true,
+        chatSessionId: "chat-session-stale-then-terminal",
+        hostedScenarioId: "cbx_1",
+        hostedAccessVersion: 1,
+        onStaleHostedAccess,
+        messages: [
+          {
+            id: "assistant-1",
+            role: "assistant",
+            parts: [
+              {
+                type: "tool-search",
+                toolCallId: "call-mixed",
+                input: { q: "hello" },
+                output: { result: "world", _serverId: "server-gone" },
+              },
+            ],
+          } as any,
+        ],
+      }),
+    );
+
+    const setWidget = (html: string) => {
+      act(() => {
+        useWidgetDebugStore.setState({
+          widgets: new Map([
+            [
+              "call-mixed",
+              {
+                toolCallId: "call-mixed",
+                toolName: "search",
+                protocol: "mcp-apps",
+                widgetState: null,
+                globals: { theme: "dark", displayMode: "inline" },
+                widgetHtml: html,
+                updatedAt: Date.now(),
+              },
+            ],
+          ]),
+        });
+      });
+    };
+
+    setWidget("<div>Widget</div>");
+    act(() => {
+      vi.advanceTimersByTime(500);
+    });
+    await flushMicrotasks();
+    expect(onStaleHostedAccess).toHaveBeenCalled();
+
+    // A new html hash re-arms the sweep, so a second attempt runs without the
+    // accessVersion having moved. That one comes back terminal.
+    setWidget("<div>Widget v2</div>");
+    act(() => {
+      vi.advanceTimersByTime(500);
+    });
+    await flushMicrotasks();
+
+    const refreshCallsAfterTerminal = onStaleHostedAccess.mock.calls.length;
+    const snapshotCallsAfterTerminal =
+      mockCreateWidgetSnapshot.mock.calls.length;
+
+    act(() => {
+      vi.advanceTimersByTime(120_000);
+    });
+    await flushMicrotasks();
+
+    expect(onStaleHostedAccess.mock.calls.length).toBe(refreshCallsAfterTerminal);
+    expect(mockCreateWidgetSnapshot.mock.calls.length).toBe(
+      snapshotCallsAfterTerminal,
+    );
+
+    unmount();
+  });
+
+  it("forgets an abandoned snapshot when the chat identity changes", async () => {
+    // Abandonment is per-scope. A different chat (or scenario) can legitimately
+    // include the same toolCallId against a server that IS in its allowlist.
+    class OutsideAllowlistError extends Error {
+      data: { code: string };
+      constructor() {
+        super("Server is not in the scenario allowlist");
+        this.data = { code: "server_not_in_scenario_allowlist" };
+      }
+    }
+    mockCreateWidgetSnapshot.mockReset();
+    mockCreateWidgetSnapshot.mockRejectedValue(new OutsideAllowlistError());
+
+    const messages = [
+      {
+        id: "assistant-1",
+        role: "assistant",
+        parts: [
+          {
+            type: "tool-search",
+            toolCallId: "call-rescoped",
+            input: { q: "hello" },
+            output: { result: "world", _serverId: "server-gone" },
+          },
+        ],
+      } as any,
+    ];
+
+    const { rerender, unmount } = renderHook(
+      (props: { chatSessionId: string }) =>
+        useSharedChatWidgetCapture({
+          enabled: true,
+          chatSessionId: props.chatSessionId,
+          hostedScenarioId: "cbx_1",
+          hostedAccessVersion: 1,
+          onStaleHostedAccess: vi.fn(),
+          messages,
+        }),
+      { initialProps: { chatSessionId: "chat-a" } },
+    );
+
+    act(() => {
+      useWidgetDebugStore.setState({
+        widgets: new Map([
+          [
+            "call-rescoped",
+            {
+              toolCallId: "call-rescoped",
+              toolName: "search",
+              protocol: "mcp-apps",
+              widgetState: null,
+              globals: { theme: "dark", displayMode: "inline" },
+              widgetHtml: "<div>Widget</div>",
+              updatedAt: Date.now(),
+            },
+          ],
+        ]),
+      });
+    });
+    act(() => {
+      vi.advanceTimersByTime(500);
+    });
+    await flushMicrotasks();
+
+    const callsUnderChatA = mockCreateWidgetSnapshot.mock.calls.length;
+    expect(callsUnderChatA).toBeGreaterThanOrEqual(1);
+
+    // Same toolCallId, different chat: the abandonment must not carry over.
+    mockCreateWidgetSnapshot.mockReset();
+    mockCreateWidgetSnapshot.mockResolvedValue("snapshot-rescoped");
+    rerender({ chatSessionId: "chat-b" });
+
+    act(() => {
+      vi.advanceTimersByTime(500);
+    });
+    await flushMicrotasks();
+
+    expect(mockCreateWidgetSnapshot).toHaveBeenCalled();
+
+    unmount();
+  });
+
   it("retries stale snapshots even after the first refresh callback fails to advance accessVersion", async () => {
     // P2 from review: if the parent's /redeem fetch fails, hostedAccessVersion
     // never bumps, so the reset effect never runs. The hook must still fire

--- a/mcpjam-inspector/client/src/hooks/useSharedChatWidgetCapture.ts
+++ b/mcpjam-inspector/client/src/hooks/useSharedChatWidgetCapture.ts
@@ -15,7 +15,10 @@ import {
   sanitizeWidgetForBackend,
   type SharedChatWidgetSnapshotPayload,
 } from "@/shared/widget-snapshot";
-import { isStaleHostedAccessError } from "@/lib/hosted-access-errors";
+import {
+  isServerOutsideScenarioError,
+  isStaleHostedAccessError,
+} from "@/lib/hosted-access-errors";
 
 interface UseSharedChatWidgetCaptureOptions {
   enabled: boolean;
@@ -233,6 +236,11 @@ export function useSharedChatWidgetCapture({
   // until an unrelated widget/message change happens to retrigger the
   // debounced sweep.
   const pendingStaleRetryRef = useRef(new Set<string>());
+  // ToolCallIds whose snapshot the backend refused for good — their server is
+  // not in the scenario allowlist and the transcript naming it won't change.
+  // Hook-owned rather than folded into `persistedSnapshotToolCallIdsRef`,
+  // which is rebuilt from props on every change and would drop the entry.
+  const abandonedToolCallIdsRef = useRef(new Set<string>());
   // Bounded backoff state for re-asking the parent to redeem. Tracks how
   // many times the timer has refired (without an accessVersion bump in
   // between) and the currently-scheduled timer. Reset to zero whenever
@@ -339,6 +347,7 @@ export function useSharedChatWidgetCapture({
       cachedBlobsRef.current.clear();
       retryCountRef.current.clear();
       pendingStaleRetryRef.current.clear();
+      abandonedToolCallIdsRef.current.clear();
       clearPendingStaleRefresh();
       for (const timer of pendingTimersRef.current.values()) {
         clearTimeout(timer);
@@ -398,6 +407,9 @@ export function useSharedChatWidgetCapture({
       return;
     }
     if (persistedSnapshotToolCallIdsRef.current.has(toolCallId)) {
+      return;
+    }
+    if (abandonedToolCallIdsRef.current.has(toolCallId)) {
       return;
     }
     if (!toolSource.serverId) {
@@ -552,7 +564,30 @@ export function useSharedChatWidgetCapture({
         // belong to a different scope now.
         return;
       }
-      if (isStaleHostedAccessError(error)) {
+      if (isServerOutsideScenarioError(error)) {
+        // TERMINAL. This widget's server left the scenario allowlist, and the
+        // transcript that names it is not going to change, so every sweep
+        // re-offers the same doomed toolCallId. Checked BEFORE the retry
+        // ladder below, which `shouldRetryPendingSnapshot` would otherwise
+        // arm: its `result == null` early return makes the catch path retry
+        // on any error, so one dead snapshot burned six backend calls (the
+        // shape visible in Sentry CONVEX-19N — bursts of exactly six).
+        //
+        // Abandoned so the debounced sweep stops re-picking it. Not a
+        // stale-access case: there is no fresher accessVersion to redeem for.
+        abandonedToolCallIdsRef.current.add(toolCallId);
+        cachedBlobsRef.current.delete(toolCallId);
+        retryCountRef.current.delete(toolCallId);
+        const staleTimer = pendingTimersRef.current.get(toolCallId);
+        if (staleTimer) {
+          clearTimeout(staleTimer);
+          pendingTimersRef.current.delete(toolCallId);
+        }
+        console.warn(
+          "[useSharedChatWidgetCapture] Server is no longer in the scenario allowlist; dropping snapshot for",
+          toolCallId,
+        );
+      } else if (isStaleHostedAccessError(error)) {
         // Drop cached blobs uploaded under the stale accessVersion, queue
         // this toolCallId for replay once the fresh accessVersion arrives,
         // and ask the owner to re-redeem. The reset effect drains the

--- a/mcpjam-inspector/client/src/hooks/useSharedChatWidgetCapture.ts
+++ b/mcpjam-inspector/client/src/hooks/useSharedChatWidgetCapture.ts
@@ -578,10 +578,19 @@ export function useSharedChatWidgetCapture({
         abandonedToolCallIdsRef.current.add(toolCallId);
         cachedBlobsRef.current.delete(toolCallId);
         retryCountRef.current.delete(toolCallId);
-        const staleTimer = pendingTimersRef.current.get(toolCallId);
-        if (staleTimer) {
-          clearTimeout(staleTimer);
+        const abandonedTimer = pendingTimersRef.current.get(toolCallId);
+        if (abandonedTimer) {
+          clearTimeout(abandonedTimer);
           pendingTimersRef.current.delete(toolCallId);
+        }
+        // It can already be queued for stale replay: an earlier attempt hit
+        // `scenario_access_stale`, and this one came back terminal before the
+        // parent's re-redeem landed. Leaving it queued keeps the backoff timer
+        // asking for a fresh accessVersion on behalf of work that will never
+        // run again.
+        pendingStaleRetryRef.current.delete(toolCallId);
+        if (pendingStaleRetryRef.current.size === 0) {
+          clearPendingStaleRefresh();
         }
         console.warn(
           "[useSharedChatWidgetCapture] Server is no longer in the scenario allowlist; dropping snapshot for",
@@ -663,7 +672,12 @@ export function useSharedChatWidgetCapture({
 
     for (const [toolCallId, widget] of widgets) {
       const existingTimer = pendingTimersRef.current.get(toolCallId);
-      if (persistedSnapshotToolCallIdsRef.current.has(toolCallId)) {
+      // Already stored, or refused for good — either way there is nothing left
+      // to capture, so don't keep re-arming a timer whose attempt bails.
+      if (
+        persistedSnapshotToolCallIdsRef.current.has(toolCallId) ||
+        abandonedToolCallIdsRef.current.has(toolCallId)
+      ) {
         if (existingTimer) {
           clearTimeout(existingTimer);
           pendingTimersRef.current.delete(toolCallId);

--- a/mcpjam-inspector/client/src/lib/hosted-access-errors.ts
+++ b/mcpjam-inspector/client/src/lib/hosted-access-errors.ts
@@ -12,8 +12,29 @@
  * that needed it (`useSharedChatWidgetCapture`).
  */
 export function isStaleHostedAccessError(error: unknown): boolean {
-  if (!error || typeof error !== "object") return false;
+  return hostedErrorCode(error) === "scenario_access_stale";
+}
+
+/**
+ * The opposite of a stale-access rejection: nothing recovers this one.
+ *
+ * A transcript outlives the allowlist. Drop a server from a scenario and the
+ * tool calls it already produced stay in the messages the capture hook sweeps,
+ * so it re-offers that `serverId` forever. `accessVersion` does not catch it —
+ * the client re-redeems, the version matches, and the write is still refused.
+ *
+ * So this must NOT feed the re-redeem path (there is no fresher version to
+ * get) and must not feed the local retry ladder (every attempt lands on the
+ * same rejection). Drop the work instead.
+ */
+export function isServerOutsideScenarioError(error: unknown): boolean {
+  return hostedErrorCode(error) === "server_not_in_scenario_allowlist";
+}
+
+function hostedErrorCode(error: unknown): string | null {
+  if (!error || typeof error !== "object") return null;
   const data = (error as { data?: unknown }).data;
-  if (!data || typeof data !== "object") return false;
-  return (data as { code?: unknown }).code === "scenario_access_stale";
+  if (!data || typeof data !== "object") return null;
+  const code = (data as { code?: unknown }).code;
+  return typeof code === "string" ? code : null;
 }


### PR DESCRIPTION
The client half of Sentry **CONVEX-19N**. Pairs with **MCPJam/mcpjam-backend#1025** — land that one first; this branch is inert without it (the code never matches, and the old retry behaviour stands).

## What was happening

The capture hook retried every failed snapshot five times over, including the one failure no retry can fix: the widget's server is not in the scenario's allowlist. Each attempt is an uncaught exception on the backend, so **one dead `toolCallId` paged six times**. The issue's timing shows it plainly — three bursts of exactly six, gaps growing ×1.5, matching this hook's `1000 * 1.5^retries` ladder.

## The retry was not deliberate

```ts
function shouldRetryPendingSnapshot(result: unknown, error: unknown): boolean {
  if (result == null) return true;
  const message = error instanceof Error ? error.message : String(error);
  return message.includes("Session not found");
}
```

It reads as *"retry only Session not found"*. But the catch path calls it as `shouldRetryPendingSnapshot(undefined, error)`, and `undefined == null` is true — so it returns before the message check. **That check is unreachable from the catch**, and every error retried.

I did not narrow the predicate to its written intent. That would also drop the retries that genuinely recover transient upload failures, which is a regression this bug doesn't ask for. Instead the one terminal case is classified and handled before the ladder is armed.

## Why this case is terminal

A transcript outlives the allowlist. Drop a server from a scenario and the tool calls it already produced stay in the messages the hook sweeps, so it re-offers that `serverId` forever.

It is not a stale-access case either, so it must not feed the re-redeem path: the client re-redeems, `accessVersion` matches, and the write is still refused. Confirmed from `normalizeScenarioSession`, which rejects any session whose `accessVersion` is not a finite number — so the version is always sent and the backend's concurrency gate always runs. Reaching this error means the version matched.

## Notes on the implementation

Abandoned `toolCallId`s live in their own ref rather than in `persistedSnapshotToolCallIdsRef`. That one is rebuilt from props whenever they change ([the effect at ~L318](https://github.com/MCPJam/inspector/blob/main/mcpjam-inspector/client/src/hooks/useSharedChatWidgetCapture.ts)), so an entry added there would be dropped on the next sweep and the retry would come straight back. Cleared on identity change alongside the other per-scope refs.

`isServerOutsideScenarioError` sits next to `isStaleHostedAccessError` in `lib/hosted-access-errors.ts`, sharing a small `hostedErrorCode` reader. Same reasoning the module already gives for living there: every hosted writer needs the same classification.

## Verified

- `useSharedChatWidgetCapture.test.tsx` — 12 tests green, including the new one
- `useScenarioTurnRating.test.tsx` — green (other consumer of the same module)
- Client typecheck clean

Mutation-checked: disabling the terminal branch so it falls through to the ladder fails the new test (`expected "spy" to be called 1 times, but got 2 times`).

One honest limit on that test: it demonstrates *no retry vs. at least one retry*, not the full 6× amplification. Draining all five rungs needs a microtask flush per rung, and the assertion doesn't need it to hold.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stops retrying widget snapshots when the widget’s server is not in the scenario allowlist (CONVEX-19N). Previously all failures retried five times (six calls total) and spammed the backend; now the terminal allowlist case is detected, the snapshot is dropped, and any queued re-redeem is cleared.

- Adds `isServerOutsideScenarioError` and uses it in `useSharedChatWidgetCapture` to abandon the `toolCallId` before any retry.
- Removes abandoned IDs from the stale-replay queue and cancels the re-deem timer when the queue empties; prevents the sweep from re-arming timers for abandoned IDs.
- Tracks abandoned IDs in a ref scoped to chat identity; clears on identity change and logs a console warning.
- Keeps existing behavior for stale access (re-redeem and retry) and transient failures.

**Rollout**
- Requires `MCPJam/mcpjam-backend#1025` to emit `server_not_in_scenario_allowlist`; land backend first. Until then, behavior is unchanged.

<sup>Written for commit d36a451517dc6d24df0a252c3cd071a85b5f367e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/MCPJam/inspector/pull/4098?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

