### PR TITLE
ops(alerts): stop counting credential-less 4xx in the storm monitor

### DIFF
--- a/mcpjam-inspector/server/middleware/__tests__/bearer-auth.test.ts
+++ b/mcpjam-inspector/server/middleware/__tests__/bearer-auth.test.ts
@@ -328,4 +328,65 @@ describe("bearerAuthMiddleware — request-local memoization", () => {
     expect(validateApiKeyMock).toHaveBeenCalledTimes(1);
     expect(lookupWorkosKeyBindingMock).toHaveBeenCalledTimes(1);
   });
+  /**
+   * `credentialPresented` is what lets the 4xx storm monitor tell a customer
+   * outage apart from background noise. A scan walks the public API with no
+   * `Authorization` header and produces hundreds of correct 401s; without this
+   * label those are indistinguishable from 401s where somebody's key failed.
+   */
+  const seedLogContext = (app: Hono, sink: { ctx: unknown }) => {
+    app.use("*", async (c, next) => {
+      c.set("requestLogContext", {
+        event: "http.request.completed",
+        timestamp: new Date().toISOString(),
+        environment: "test",
+        release: null,
+        component: "http",
+        requestId: "req_cred",
+        route: "pending",
+        method: "GET",
+        authType: "unknown",
+      } as never);
+      await next();
+      // Runs AFTER the middleware short-circuits, which is the only way to
+      // observe the context on a request that never reached a handler.
+      sink.ctx = c.get("requestLogContext");
+    });
+  };
+
+  it("labels a 401 with credentialPresented false when no bearer was sent", async () => {
+    const sink: { ctx: unknown } = { ctx: null };
+    const app = new Hono();
+    seedLogContext(app, sink);
+    app.use("*", bearerAuthMiddleware);
+    app.get("/test", (c) => c.json({ ok: true }));
+
+    const res = await app.request("/test");
+
+    expect(res.status).toBe(401);
+    expect((sink.ctx as { credentialPresented?: boolean }).credentialPresented).toBe(
+      false
+    );
+  });
+
+  it("labels a rejected credential with credentialPresented true", async () => {
+    // An invalid key is a caller whose credential FAILED — the class the
+    // monitor must keep counting, unlike the no-header case above.
+    validateApiKeyMock.mockResolvedValueOnce({ apiKey: null });
+
+    const sink: { ctx: unknown } = { ctx: null };
+    const app = new Hono();
+    seedLogContext(app, sink);
+    app.use("*", bearerAuthMiddleware);
+    app.get("/test", (c) => c.json({ ok: true }));
+
+    const res = await app.request("/test", {
+      headers: { authorization: "Bearer sk_bad" },
+    });
+
+    expect(res.status).toBe(401);
+    expect((sink.ctx as { credentialPresented?: boolean }).credentialPresented).toBe(
+      true
+    );
+  });
 });

--- a/mcpjam-inspector/server/middleware/bearer-auth.ts
+++ b/mcpjam-inspector/server/middleware/bearer-auth.ts
@@ -119,11 +119,23 @@ export async function bearerAuthMiddleware(
 ): Promise<Response | void> {
   const authHeader = c.req.header("authorization");
   if (!authHeader || !authHeader.startsWith("Bearer ")) {
+    // Label the 401 before returning it. Every branch below rejects a caller
+    // who at least presented something; this one rejects a caller who
+    // presented nothing, and that is the only 4xx class that carries no
+    // signal about our own health. Scanners and crawlers generate it in
+    // bulk against the public API, so the storm monitor has to be able to
+    // exclude it — see `credentialPresented` in `log-events.ts`.
+    setRequestLogContext(c, { credentialPresented: false });
     return c.json(
       { code: ErrorCode.UNAUTHORIZED, message: "Bearer token required" },
       401
     );
   }
+
+  // Set once, here, rather than per-branch: everything past this point had a
+  // bearer, so every 401 it produces is somebody's credential failing —
+  // invalid key, unknown user, orphaned key alike.
+  setRequestLogContext(c, { credentialPresented: true });
 
   const token = authHeader.slice("Bearer ".length);
 

--- a/mcpjam-inspector/server/utils/log-events.ts
+++ b/mcpjam-inspector/server/utils/log-events.ts
@@ -32,6 +32,26 @@ interface CommonLogContext {
   durationMs?: number;
 
   authType: AuthType;
+  /**
+   * Whether the caller presented a bearer credential AT ALL, set by
+   * `bearerAuthMiddleware` on every route it fronts. This is not "was the
+   * caller authorized" — an invalid key, an unknown user and an orphaned key
+   * are all `true`. It answers the one question a 401 count cannot: did
+   * somebody's credential fail, or did nobody send one?
+   *
+   * The distinction is the difference between a customer outage and
+   * background noise. A contracted pentest sweep (or any scanner) walks the
+   * public API with no `Authorization` header and produces hundreds of
+   * perfectly correct 401s; a real auth incident produces 401s from callers
+   * who DID present something. Without this field both fingerprint as
+   * "route 401" and the 4xx storm monitor cannot tell them apart — which is
+   * exactly what happened on 2026-08-18, where a scan tripped the WARN and
+   * triage had no query that could name the caller.
+   *
+   * Absent on routes that do not run `bearerAuthMiddleware`; monitors must
+   * treat null as "unknown", never as "no credential".
+   */
+  credentialPresented?: boolean | null;
   userId?: string | null;
   userExternalId?: string | null;
   guestExternalId?: string | null;

--- a/ops/axiom-monitors/monitors/inspector-4xx-storm.json
+++ b/ops/axiom-monitors/monitors/inspector-4xx-storm.json
@@ -23,6 +23,7 @@
     "| where event == 'http.request.completed'",
     "| where toint(statusCode) >= 400 and toint(statusCode) < 500",
     "| where tostring(environment) in ('prod','production')",
+    "| where isnull(credentialPresented) or credentialPresented == true",
     "| summarize Count = count()"
   ],
   "description": [
@@ -30,7 +31,11 @@
     "",
     "WHY THIS EXISTS: the 5xx rate monitor is deliberately 5xx-only, so without this the entire 4xx surface is unwatched. That matters because classifyRuntimeError checks isUnauthorized401 before every other branch, so MCP auth failures carrying a clean 401 land on 'http.request.completed' and never reach 'http.request.failed'. Measured on the incident route: 2,328 401s vs 4,932 500s on /api/web/tools/list.",
     "",
-    "WHY THIS THRESHOLD: measured hourly 4xx over 30d is p50=12, p95=62, p99=89, max=156. 200/hr is ~2.2x p99 and above the observed maximum. Steady auth churn (8,373 401s across 520 orgs in 30d) cannot reach it; a genuine auth or rate-limit storm can.",
+    "WHY NO-CREDENTIAL 4xx ARE EXCLUDED: `bearerAuthMiddleware` sets `credentialPresented` on every route it fronts. False means the caller sent no `Authorization` header at all — the one 4xx class that says nothing about our health, because anything that walks the public API generates it in bulk. On 2026-08-18 a contracted Oneleet sweep (54,105 requests across every mcpjam subdomain, self-identified via `x-oneleet-scan`) put ~600 of these on /api/v1/* and tripped this monitor at 231. Nothing was broken. A 401 from a caller who DID present something is a different animal and still counts.",
+    "",
+    "NULL IS NOT FALSE: routes outside `bearerAuthMiddleware` never set the field, so the filter keeps nulls. Reading a missing field as \"no credential\" would silently drop every 4xx on the unauthenticated routes — the same populated-field trap `orgId` already fell into for the whole public API.",
+    "",
+    "WHY THIS THRESHOLD: measured hourly 4xx over 30d is p50=12, p95=62, p99=89, max=156. 200/hr is ~2.2x p99 and above the observed maximum. Steady auth churn (8,373 401s across 520 orgs in 30d) cannot reach it; a genuine auth or rate-limit storm can. NOTE: those percentiles were measured BEFORE the no-credential exclusion below, on a population that included scan traffic. 200/hr is therefore a more conservative bar now than when it was set; re-measure before lowering it.",
     "",
     "WHY WARN, NOT PAGE: a 4xx is a declared client outcome. Only an abnormal RATE of one is evidence of anything, and the classes worth paging on are already covered by the per-class spike monitor. Revisit this tier only if a real incident is found to have announced itself here first.",
     "",


### PR DESCRIPTION
The 4xx storm monitor counted every 4xx equally, so anything that walks the public API without an `Authorization` header could trip it. On 2026-08-18 a contracted Oneleet sweep — 54,105 requests across every mcpjam subdomain, self-identified via `x-oneleet-scan` — put ~600 bare 401s on `/api/v1/*` and fired the WARN at 231. Nothing was broken, and no query in the runbook could show that: the rows carry no orgId, no path, no errorCode, so a scan and a customer outage fingerprint identically.

`bearerAuthMiddleware` now labels the request log with `credentialPresented` — false when no bearer arrived at all, true for every branch past that point (invalid key, unknown user, orphaned key). The monitor keeps counting 401s from callers whose credential FAILED and drops the ones from callers who never presented one.

The filter keeps nulls. Routes outside `bearerAuthMiddleware` never set the field, and reading a missing field as "no credential" would silently drop every 4xx on the unauthenticated routes — the same populated-field trap `orgId` already fell into for the whole public API.

Threshold left at 200/hr: its percentiles were measured on a population that included scan traffic, so it is now a more conservative bar than when it was set, not a looser one.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Exclude credential‑less 4xx from the inspector storm monitor to prevent scanner traffic from triggering alerts. Previously all 4xx were counted; now only 4xx with a presented credential (or unknown) are counted, while requests with no Authorization header are dropped.

- `bearerAuthMiddleware` sets `credentialPresented: false` for missing Authorization and `true` once a Bearer token is present; log context type now includes optional `credentialPresented` and preserves nulls for routes outside the middleware.
- Monitor query (`ops/axiom-monitors/monitors/inspector-4xx-storm.json`) filters with `isnull(credentialPresented) or credentialPresented == true`, excluding only explicit `false`.
- Tests add coverage for both no-header and invalid-key 401 labeling.
- Threshold stays at 200/hr; it is now more conservative since scan traffic is excluded. No migrations required.

<sup>Written for commit 53c5be9a4f3b07c36cf063408934b10ca39f0d85. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/MCPJam/inspector/pull/4099?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

