### PR TITLE
changesets

### DIFF
--- a/.changeset/releases-2026-08-18.md
+++ b/.changeset/releases-2026-08-18.md
@@ -1,0 +1,12 @@
+---
+"@mcpjam/inspector": minor
+"@mcpjam/cli": minor
+"@mcpjam/sdk": minor
+---
+
+Release the latest Inspector, CLI, and SDK updates.
+
+- Offer the current Anthropic models — Fable 5, Opus 5, Opus 4.8/4.7/4.6, Sonnet 5/4.6 — to BYOK Anthropic keys, and stop sending a `temperature` to the ids that reject it.
+- Run GitHub PR checks against private repositories, cloning with a short-lived installation token that never touches disk.
+- Ship the closed eval step union and the declared `caseId` on upload, so a renamed test keeps its hosted history instead of forking it.
+- Clear the open critical dependency advisories.


### PR DESCRIPTION
Release changeset for Inspector, CLI, and SDK ahead of a deploy — same shape as #4051.

Resulting versions (verified with a local `changeset version` dry run, then reset):

| package | now | after |
| --- | --- | --- |
| `@mcpjam/sdk` | 5.0.0 | 6.0.0 (major, from the two pending eval-contract changesets) |
| `@mcpjam/cli` | 3.24.0 | 3.25.0, dep → `^6.0.0` |
| `@mcpjam/inspector` | 2.40.0 | 2.41.0 |

`@mcpjam/vitest` and `@mcpjam/widget-react` take dependent patches.

`@mcpjam/cli` has no source changes since 3.24.0; the minor is so it republishes against SDK 6.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit c5410efdada570a3765cc14f14c75262fbc5418f. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Publish a release changeset to ship the latest `@mcpjam/inspector`, `@mcpjam/cli`, and `@mcpjam/sdk`, aligning CLI with SDK v6 and unblocking deploys. This adds Anthropic model support without temperature errors, runs PR checks on private repos, preserves eval history on test rename, and clears critical advisories.

- BYOK Anthropic keys: previously sent `temperature` to all models; now offers Fable 5, Opus 5/4.x, Sonnet 5/4.6 and omits `temperature` for model IDs that reject it.
- GitHub PR checks: previously unavailable for private repos; now run using a short‑lived installation token that never touches disk.
- Eval uploads: previously renaming a test forked hosted history; now use a closed step union and a declared `caseId` to keep history.

**Versions and migration**
- `@mcpjam/sdk` → 6.0.0 (via existing changesets): update to the closed eval step union and include `caseId` on upload.
- `@mcpjam/cli` → 3.25.0, depends on `@mcpjam/sdk@^6`; no CLI source changes.
- `@mcpjam/inspector` → 2.41.0; `@mcpjam/vitest` and `@mcpjam/widget-react` take dependent patches.

<sup>Written for commit c5410efdada570a3765cc14f14c75262fbc5418f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/MCPJam/inspector/pull/4101?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

