### PR TITLE
github checks: declare a build/start environment in mcpjam.yaml

### DIFF
--- a/.changeset/mcpjam-yaml-declared-env.md
+++ b/.changeset/mcpjam-yaml-declared-env.md
@@ -1,0 +1,52 @@
+---
+"@mcpjam/inspector": patch
+---
+
+Let a repository declare a build/start environment in `mcpjam.yaml`, and inject
+it into GitHub PR checks through E2B's `envs` command option.
+
+`checks.env` is a bounded map of `NAME: value` pairs — at most 20 entries, keys
+of at most 64 characters matching `^[A-Z][A-Z0-9_]*$`, values of at most 1,024
+characters. The bounds mirror the backend's, which already accepts and persists
+the field. Anything outside them is **rejected, never truncated or coerced**: a
+shortened value, or an unquoted `8080` silently read as `"8080"`, is a different
+configuration from the one the author committed, and a check that started a
+server with it would report a verdict about something nobody wrote. A value that
+is not a string, a map that is a list or a scalar, and an unknown sibling key
+under `checks:` all fail the file — which, at an authoritative rung, means the
+check fails honestly rather than falling through to a heuristic guess. An empty
+`env: {}` normalizes to no environment at all, so it has the same runtime
+behaviour and the same wire shape as omitting the field.
+
+**These are non-secret configuration literals. Do not put credentials in
+`mcpjam.yaml`.** The map comes out of a file committed to the repository —
+readable by anyone who can read the repo — and it is persisted verbatim in
+durable backend plan rows. Nothing redacts it and nothing expires it. It is for
+the flags a server needs in order to boot, and for nothing that would matter if
+it were printed in public. The GitHub-checks clone token is the counter-example
+of how a secret is handled here: minted per check, carried on a single
+command-line git header, redacted out of every observable failure, and never an
+environment variable.
+
+Only an authoritative rung produces one. `mcpjam.yaml` is the only real producer
+(the operator override table is empty on purpose), detection never invents an
+environment, and the backend refuses `env` on a cacheable `detected` or
+`agentic` recipe — so a cached recipe stays env-free. The Inspector reports the
+declared map to the plan, and executes back whatever the plan issues: the
+backend still owns candidate ordering and selection.
+
+Injection happens at exactly two commands, the build and the background start,
+as E2B's `commands.run(..., { envs })` option. Nothing is ever written into a
+command string — no `export`, no assignment, no shell interpolation — so the
+build and start scripts stay byte-identical with and without an environment, and
+author-controlled values never enter a `bash -lc` quoting boundary or the
+command text that failure diagnostics quote into a check summary. Provisioning,
+clone and fetch, checkout and sha verification, `/proc` listener inspection,
+health probes, and the log tail all receive nothing. On a recipe with no
+environment the `envs` key is omitted entirely rather than passed as `undefined`
+or `{}`.
+
+Error messages name `checks.env` or `checks.env.<key>` and the limit that was
+violated. Keys are echoed, because the author needs to see which one is wrong,
+and are length-clamped through the same formatter every other echoed key uses.
+Values are never echoed.

--- a/mcpjam-inspector/server/services/github-checks/__tests__/resolve-and-start.test.ts
+++ b/mcpjam-inspector/server/services/github-checks/__tests__/resolve-and-start.test.ts
@@ -1161,3 +1161,32 @@ describe("resolveAndStart — the declared environment travels with the recipe",
     expect("env" in built[0]).toBe(false);
   });
 });
+
+describe("resolveAndStart — an empty environment is an absent one, everywhere", () => {
+  // `{}` is truthy, so "copy it when it is there" and "copy it when there is
+  // something in it" are different rules, and only the second one holds the
+  // contract. The backend cannot issue an empty map today — its candidates come
+  // from the env-free cache or from the local candidates we already normalize —
+  // so this is the boundary staying honest ahead of the case rather than after
+  // it.
+  it("drops a backend-planned `env: {}` instead of carrying it forward", async () => {
+    const built: Array<Record<string, unknown>> = [];
+    const session = fakeSession({
+      candidates: [planned("c1", { env: {} })],
+    });
+    const f = fakes({
+      ladder: { kind: "candidates", candidates: [recipe()] },
+      session,
+    });
+    const inner = f.deps.buildAndStart!;
+    f.deps.buildAndStart = async (sandbox, recipeToRun) => {
+      built.push(recipeToRun as unknown as Record<string, unknown>);
+      return inner(sandbox, recipeToRun);
+    };
+
+    const result = await resolveAndStart(ARGS, f.deps);
+    expect(built).toHaveLength(1);
+    expect("env" in built[0]).toBe(false);
+    expect("env" in result.recipe).toBe(false);
+  });
+});

--- a/mcpjam-inspector/server/services/github-checks/__tests__/resolve-and-start.test.ts
+++ b/mcpjam-inspector/server/services/github-checks/__tests__/resolve-and-start.test.ts
@@ -84,6 +84,9 @@ function planned(
       start: full.start,
       port: full.port,
       mcpPath: full.mcpPath,
+      // Only when the caller asked for one: an env-free plan candidate is the
+      // ordinary case, and it must arrive with no `env` key at all.
+      ...(full.env ? { env: full.env } : {}),
     },
     rung: full.rung,
     evidence: full.evidence,
@@ -1044,5 +1047,117 @@ describe("resolveAndStart — the private-repository clone credential", () => {
     // No FRAGMENT of it either — the whole literal was replaced before the cut.
     expect(detail).not.toContain(TOKEN.slice(0, 12));
     expect(detail).toContain("[redacted]");
+  });
+});
+
+describe("resolveAndStart — the declared environment travels with the recipe", () => {
+  // The channel runs repo -> parser -> plan -> backend -> plan -> execution, and
+  // this file owns the two hops in the middle. What must not happen at either
+  // is the environment being dropped: a server started without the
+  // configuration its author declared fails its probe and reports
+  // `server_unhealthy` against a pull request that did nothing wrong.
+  const ENV = { LOG_LEVEL: "debug", FIXTURE_MODE: "strict" };
+
+  it("reports a declared candidate's env to the backend", async () => {
+    let seen: any = null;
+    const session = fakeSession({ onCandidates: (input) => (seen = input) });
+    const f = fakes({
+      ladder: {
+        kind: "authoritative",
+        recipe: recipe({
+          rung: "declared",
+          ownershipProof: "verified",
+          evidence: ["mcpjam.yaml at repo root (version 1)"],
+          env: ENV,
+        }),
+      },
+      session,
+    });
+
+    await resolveAndStart(ARGS, f.deps);
+    expect(seen.localCandidates).toEqual([
+      {
+        recipe: {
+          build: "npm ci",
+          start: "npm start",
+          port: 3001,
+          mcpPath: "/mcp",
+          env: ENV,
+        },
+        rung: "declared",
+        evidence: ["mcpjam.yaml at repo root (version 1)"],
+        ownershipProof: "verified",
+      },
+    ]);
+  });
+
+  it("sends NO env key for a detected candidate, or an empty one", async () => {
+    // Detection never proposes an environment, and the backend REJECTS `env` on
+    // a cacheable rung — so an `env: undefined` or an `env: {}` riding along on
+    // a detected candidate is not a harmless extra key, it is a 400 on a
+    // candidate that would otherwise have run.
+    let seen: any = null;
+    const session = fakeSession({ onCandidates: (input) => (seen = input) });
+    const f = fakes({
+      ladder: {
+        kind: "candidates",
+        candidates: [
+          recipe({ start: "node detected.js" }),
+          // Defensive: even if something upstream hands over an empty map, it is
+          // absence and must be reported as absence.
+          recipe({ start: "node empty-env.js", env: {} }),
+        ],
+      },
+      session,
+    });
+
+    await resolveAndStart(ARGS, f.deps);
+    for (const candidate of seen.localCandidates) {
+      expect("env" in candidate.recipe).toBe(false);
+    }
+  });
+
+  it("hands the plan's env to buildAndStart, unchanged", async () => {
+    // The backend owns the plan: whatever env it issues is the one that runs,
+    // including one the Inspector never proposed.
+    const built: Array<Record<string, string> | undefined> = [];
+    const session = fakeSession({
+      candidates: [
+        planned("c1", {
+          start: "node planned.js",
+          rung: "declared",
+          env: { FROM_PLAN: "yes" },
+        }),
+      ],
+    });
+    const f = fakes({
+      // The local candidate carries NO environment, so what runs can only have
+      // come from the plan.
+      ladder: { kind: "candidates", candidates: [recipe()] },
+      session,
+    });
+    const inner = f.deps.buildAndStart!;
+    f.deps.buildAndStart = async (sandbox, recipeToRun) => {
+      built.push(recipeToRun.env);
+      return inner(sandbox, recipeToRun);
+    };
+
+    const result = await resolveAndStart(ARGS, f.deps);
+    expect(built).toEqual([{ FROM_PLAN: "yes" }]);
+    expect(result.recipe.env).toEqual({ FROM_PLAN: "yes" });
+  });
+
+  it("leaves no env key on an env-free planned candidate", async () => {
+    const built: Array<Record<string, unknown>> = [];
+    const f = fakes({ ladder: { kind: "candidates", candidates: [recipe()] } });
+    const inner = f.deps.buildAndStart!;
+    f.deps.buildAndStart = async (sandbox, recipeToRun) => {
+      built.push(recipeToRun as unknown as Record<string, unknown>);
+      return inner(sandbox, recipeToRun);
+    };
+
+    await resolveAndStart(ARGS, f.deps);
+    expect(built).toHaveLength(1);
+    expect("env" in built[0]).toBe(false);
   });
 });

--- a/mcpjam-inspector/server/services/github-checks/__tests__/resolver.test.ts
+++ b/mcpjam-inspector/server/services/github-checks/__tests__/resolver.test.ts
@@ -288,3 +288,212 @@ describe("review hardening (cyclic values, fence escape, byte cap)", () => {
     }
   });
 });
+
+// ═══════════════════════════════════════════════════════════════════════════
+// `checks.env` — the declared environment channel
+// ═══════════════════════════════════════════════════════════════════════════
+//
+// The bounds below are the BACKEND's, mirrored here on purpose: the plan route
+// rejects an out-of-bounds `env` with a message about a file the author cannot
+// see from a 400, so the parser has to fail first, at the field, in the file's
+// own vocabulary. If the two ever disagree, this is the side that finds out.
+//
+// The other property under test is that VALUES never surface in an error.
+// Keys do (the author needs to see their typo, and they are length-clamped);
+// values are the one part of the file this module refuses to echo.
+
+describe("parseMcpjamYaml — checks.env", () => {
+  const withEnv = (envBlock: string) =>
+    `${VALID_YAML.trimEnd()}\n  env:\n${envBlock}\n`;
+
+  it("round-trips a valid map onto the declared recipe", () => {
+    const resolved = parseMcpjamYaml(
+      withEnv("    LOG_LEVEL: debug\n    FIXTURE_MODE: strict"),
+    );
+    expect(resolved?.env).toEqual({
+      LOG_LEVEL: "debug",
+      FIXTURE_MODE: "strict",
+    });
+    expect(resolved?.rung).toBe("declared");
+    // The rest of the recipe is untouched by the new field.
+    expect(resolved?.build).toBe("npm ci && npm run build");
+    expect(resolved?.port).toBe(3001);
+  });
+
+  it("keeps shell-significant characters as literal values", () => {
+    // These reach E2B's `envs` option, never a shell script, so nothing here is
+    // expanded, substituted, or split. The parser's job is to hand them over
+    // byte-for-byte.
+    const resolved = parseMcpjamYaml(
+      withEnv(
+        [
+          `    SHELLY: "$(whoami) \`id\` $HOME"`,
+          `    QUOTED: "a 'b' \\"c\\" d"`,
+          `    SEMIS: "x; rm -rf /; y && z | w"`,
+          `    NEWLINEY: "first\\nsecond"`,
+        ].join("\n"),
+      ),
+    );
+    expect(resolved?.env).toEqual({
+      SHELLY: "$(whoami) `id` $HOME",
+      QUOTED: `a 'b' "c" d`,
+      SEMIS: "x; rm -rf /; y && z | w",
+      NEWLINEY: "first\nsecond",
+    });
+  });
+
+  it("treats an absent map and an empty map identically — no env at all", () => {
+    // Same runtime behaviour AND the same wire shape: `env: {}` must not travel
+    // to the backend as an empty object, because an empty object is a value and
+    // "no environment" is the absence of one.
+    expect(parseMcpjamYaml(VALID_YAML)?.env).toBeUndefined();
+    expect("env" in (parseMcpjamYaml(VALID_YAML) ?? {})).toBe(false);
+    const empty = parseMcpjamYaml(`${VALID_YAML.trimEnd()}\n  env: {}\n`);
+    expect(empty?.env).toBeUndefined();
+    expect("env" in (empty ?? {})).toBe(false);
+  });
+
+  it("accepts exactly 20 keys and rejects 21", () => {
+    const lines = (count: number) =>
+      Array.from({ length: count }, (_, i) => `    K${i}: v`).join("\n");
+    expect(Object.keys(parseMcpjamYaml(withEnv(lines(20)))?.env ?? {})).toHaveLength(
+      20,
+    );
+    const err = expectResolutionError(() => parseMcpjamYaml(withEnv(lines(21))));
+    expect(err.reason).toBe("invalid_mcpjam_yaml");
+    expect(err.message).toContain("checks.env");
+    expect(err.message).toContain("20");
+  });
+
+  it("accepts a 64-character key and rejects a 65-character one", () => {
+    const key = (length: number) => `K${"A".repeat(length - 1)}`;
+    expect(parseMcpjamYaml(withEnv(`    ${key(64)}: v`))?.env).toEqual({
+      [key(64)]: "v",
+    });
+    const err = expectResolutionError(() =>
+      parseMcpjamYaml(withEnv(`    ${key(65)}: v`)),
+    );
+    expect(err.message).toContain("64");
+  });
+
+  it("accepts a 1024-character value and rejects a 1025-character one", () => {
+    const value = (length: number) => "v".repeat(length);
+    expect(parseMcpjamYaml(withEnv(`    BIG: ${value(1024)}`))?.env).toEqual({
+      BIG: value(1024),
+    });
+    const err = expectResolutionError(() =>
+      parseMcpjamYaml(withEnv(`    BIG: ${value(1025)}`)),
+    );
+    expect(err.message).toContain("checks.env.BIG");
+    expect(err.message).toContain("1024");
+    // REJECTED, never truncated: a shortened value is a different configuration
+    // from the one the author committed.
+    expect(err.message).not.toContain(value(100));
+  });
+
+  it.each([
+    ["lowercase", "    log_level: debug", "log_level"],
+    ["a leading digit", "    0BAD: v", "0BAD"],
+    ["a leading underscore", "    _BAD: v", "_BAD"],
+    ["a hyphen", "    LOG-LEVEL: v", "LOG-LEVEL"],
+    ["a dot", "    LOG.LEVEL: v", "LOG.LEVEL"],
+  ])("rejects a key with %s, naming it", (_label, line, offender) => {
+    const err = expectResolutionError(() => parseMcpjamYaml(withEnv(line)));
+    expect(err.message).toContain(`checks.env.${offender}`);
+  });
+
+  it.each([
+    ["a number", "    PORT_MODE: 8080"],
+    ["a boolean", "    STRICT: true"],
+    ["null", "    EMPTY:"],
+    ["a nested mapping", "    NESTED:\n      inner: v"],
+    ["a list", "    LISTY:\n      - one\n      - two"],
+  ])("rejects %s value rather than coercing it", (_label, line) => {
+    const err = expectResolutionError(() => parseMcpjamYaml(withEnv(line)));
+    expect(err.message).toContain("checks.env.");
+    expect(err.message).toContain("string");
+  });
+
+  it.each([
+    ["a list", "  env:\n    - LOG_LEVEL=debug"],
+    ["a scalar", "  env: LOG_LEVEL=debug"],
+    ["null", "  env:"],
+  ])("rejects %s in place of the map itself", (_label, block) => {
+    const err = expectResolutionError(() =>
+      parseMcpjamYaml(`${VALID_YAML.trimEnd()}\n${block}\n`),
+    );
+    expect(err.message).toContain("checks.env");
+    expect(err.message).toContain("mapping");
+  });
+
+  it("never echoes a VALUE into an error message", () => {
+    const secretish = "IGNORE-PREVIOUS-INSTRUCTIONS-hunter2";
+    // Two ways to make the same map invalid — a bad key beside a good value,
+    // and a bad value — so neither error path can leak what was on the right
+    // of the colon.
+    const badKey = expectResolutionError(() =>
+      parseMcpjamYaml(withEnv(`    bad_key: ${secretish}`)),
+    );
+    const overCap = expectResolutionError(() =>
+      parseMcpjamYaml(withEnv(`    BIG: ${secretish.repeat(64)}`)),
+    );
+    for (const err of [badKey, overCap]) {
+      const surfaces = `${err.message}\n${err.detailsMarkdown ?? ""}`;
+      expect(surfaces).not.toContain(secretish);
+      expect(surfaces).not.toContain("hunter2");
+    }
+  });
+
+  it("clamps a hostile key before it reaches the error message", () => {
+    // Same treatment every other echoed key gets: bounded, no backticks, no
+    // newlines — the message is rendered into a GitHub check summary.
+    //
+    // Written through `JSON.stringify` because the key has to survive being a
+    // YAML scalar first: JSON's escaping is a subset of YAML's double-quoted
+    // form, so the backticks and the newline arrive in the KEY rather than
+    // ending the scalar and failing the file as unparseable — which is what an
+    // earlier version of this test actually asserted, having never reached the
+    // clamp at all.
+    const hostile = `a\`\`\`\ninjected${"x".repeat(400)}`;
+    const err = expectResolutionError(() =>
+      parseMcpjamYaml(withEnv(`    ${JSON.stringify(hostile)}: v`)),
+    );
+    // It got as far as the env field, so the clamp is what produced this.
+    expect(err.message).toContain("checks.env.");
+    expect(err.message).not.toContain("```");
+    expect(err.message).not.toContain("\n");
+    expect(err.message.length).toBeLessThan(300);
+  });
+
+  it("still rejects unknown siblings of env under checks:", () => {
+    const err = expectResolutionError(() =>
+      parseMcpjamYaml(
+        `${withEnv("    LOG_LEVEL: debug").trimEnd()}\n  envs: nope\n`,
+      ),
+    );
+    expect(err.message).toContain("envs");
+  });
+
+  it("an invalid env FAILS the ladder — it does not fall through", () => {
+    // The authoritative-rung contract, applied to the new field: a broken env
+    // map is the author's, and running a heuristic guess instead would start a
+    // server without the configuration they declared.
+    const err = expectResolutionError(() =>
+      resolveRecipe({
+        repoFullName: "someone/some-server",
+        mcpjamYaml: withEnv("    log_level: debug"),
+      }),
+    );
+    expect(err.reason).toBe("invalid_mcpjam_yaml");
+    expect(err.reason).not.toBe("no_recipe");
+  });
+
+  it("carries env through the ladder onto the declared recipe", () => {
+    const resolved = resolveRecipe({
+      repoFullName: "someone/some-server",
+      mcpjamYaml: withEnv("    LOG_LEVEL: debug"),
+    });
+    expect(resolved.rung).toBe("declared");
+    expect(resolved.env).toEqual({ LOG_LEVEL: "debug" });
+  });
+});

--- a/mcpjam-inspector/server/services/github-checks/__tests__/sandbox.test.ts
+++ b/mcpjam-inspector/server/services/github-checks/__tests__/sandbox.test.ts
@@ -2453,3 +2453,172 @@ describe("recipes", () => {
     expect(resolveCheckRecipe("mcpjam/mcp-check-fixture")).toBeNull();
   });
 });
+
+describe("buildAndStart — the recipe's declared environment", () => {
+  // WHERE THE ENVIRONMENT GOES, AND WHERE IT MUST NOT.
+  //
+  // It goes into E2B's `envs` COMMAND OPTION on exactly two commands: the build
+  // and the start. It never becomes shell text. An `export FOO=…` prepended to
+  // a command string would put author-controlled bytes inside a script that is
+  // already carrying a `bash -lc` quoting boundary, and every diagnostic this
+  // module produces quotes commands — so a value in a command string is a value
+  // in a check summary, a log line, and an SDK transport error.
+  //
+  // Everything else the box runs — clone, fetch, sha verification, `/proc`
+  // inspection, the log tail — is OUR plumbing, not the PR's server, and gets
+  // nothing.
+  const ENV = { LOG_LEVEL: "debug", FIXTURE_MODE: "strict" };
+  const ENV_RECIPE = { ...RECIPE, env: ENV };
+
+  const isBuild = (call: Call) => call.command.includes("npm run build");
+  const isStart = (call: Call) => Boolean(call.opts?.background);
+
+  it("passes the SAME map to the build and the start, in `envs`", async () => {
+    const box = fakeSandbox();
+    await buildAndStart(box.sandbox, ENV_RECIPE, {
+      fetchImpl: vi.fn(async () => okInitialize()) as unknown as typeof fetch,
+    });
+
+    const build = box.calls.find(isBuild);
+    const start = box.calls.find(isStart);
+    expect(build?.opts?.envs).toEqual(ENV);
+    expect(start?.opts?.envs).toEqual(ENV);
+  });
+
+  it("keeps every value OUT of the command strings", async () => {
+    // Values chosen to be visible if they were ever interpolated, and to break
+    // the script if they were interpolated unquoted.
+    const hostile = {
+      LOG_LEVEL: "SENTINEL-$(touch /tmp/pwned)",
+      QUOTED: `it's "quoted"; rm -rf /`,
+    };
+    const box = fakeSandbox();
+    await buildAndStart(
+      box.sandbox,
+      { ...RECIPE, env: hostile },
+      {
+        fetchImpl: vi.fn(async () => okInitialize()) as unknown as typeof fetch,
+      }
+    );
+
+    for (const call of box.calls) {
+      expect(call.command).not.toContain("SENTINEL");
+      expect(call.command).not.toContain("pwned");
+      expect(call.command).not.toContain("LOG_LEVEL");
+      expect(call.command).not.toContain("export ");
+    }
+  });
+
+  it("leaves the build and start command strings byte-identical to the no-env run", async () => {
+    // The no-env path is the overwhelming majority of checks. The environment
+    // channel must be invisible to it — and to the commands themselves even when
+    // an environment IS present, since the whole point is that it travels beside
+    // the command rather than inside it.
+    const fetchImpl = () =>
+      vi.fn(async () => okInitialize()) as unknown as typeof fetch;
+    const plain = fakeSandbox();
+    await buildAndStart(plain.sandbox, RECIPE, { fetchImpl: fetchImpl() });
+    const withEnv = fakeSandbox();
+    await buildAndStart(withEnv.sandbox, ENV_RECIPE, {
+      fetchImpl: fetchImpl(),
+    });
+
+    expect(withEnv.calls.map((call) => call.command)).toEqual(
+      plain.calls.map((call) => call.command)
+    );
+  });
+
+  it("omits `envs` ENTIRELY when the recipe has none", async () => {
+    // Not `envs: undefined` and not `envs: {}` — the key is absent, so the
+    // options object is the one this module has always sent.
+    const box = fakeSandbox();
+    await buildAndStart(box.sandbox, RECIPE, {
+      fetchImpl: vi.fn(async () => okInitialize()) as unknown as typeof fetch,
+    });
+
+    for (const call of box.calls) {
+      expect(Object.keys(call.opts ?? {})).not.toContain("envs");
+    }
+    expect(box.calls.find(isBuild)?.opts).toEqual({
+      cwd: "/home/user/repo",
+      timeoutMs: 10 * 60_000,
+    });
+  });
+
+  it("omits `envs` for an empty map, which is the same as no map", async () => {
+    const box = fakeSandbox();
+    await buildAndStart(
+      box.sandbox,
+      { ...RECIPE, env: {} },
+      {
+        fetchImpl: vi.fn(async () => okInitialize()) as unknown as typeof fetch,
+      }
+    );
+
+    for (const call of box.calls) {
+      expect(Object.keys(call.opts ?? {})).not.toContain("envs");
+    }
+  });
+
+  it("gives the environment to NOTHING except the build and the start", async () => {
+    // The `/proc` read for the spawn's process group, and the log tail fetched
+    // for a health failure, both run through this module. Neither is the PR's
+    // server, and handing them the recipe's environment would put it into
+    // commands whose output is quoted into a check summary.
+    const box = fakeSandbox({
+      // Force the unhealthy path so the log tail is fetched too.
+      stdout: { "tail -c": "server said nothing useful" },
+    });
+    await buildAndStart(box.sandbox, ENV_RECIPE, {
+      fetchImpl: vi.fn(
+        async () => new Response("nope", { status: 500 })
+      ) as unknown as typeof fetch,
+      healthTimeoutMs: 1,
+      healthIntervalMs: 1,
+    }).catch(() => {});
+
+    const others = box.calls.filter((call) => !isBuild(call) && !isStart(call));
+    // The `/proc` read and the log tail, at least — if this ever drops to zero
+    // the assertion below has stopped testing anything.
+    expect(others.length).toBeGreaterThan(0);
+    for (const call of others) {
+      expect(call.opts?.envs).toBeUndefined();
+    }
+  });
+
+  it("gives the clone NOTHING, with or without a credential", async () => {
+    // `cloneAndCheckout` runs before any recipe is executed and takes no recipe
+    // at all — asserted here so a future signature change that threads one in
+    // has to come past this test. The clone credential goes the other way: it
+    // rides a command-line `-c` header and is never an environment variable.
+    const headSha = "d".repeat(40);
+    for (const cloneToken of [undefined, "ghs_privateRepoToken1234567890"]) {
+      const box = fakeSandbox({ stdout: { "rev-parse HEAD": `${headSha}\n` } });
+      await cloneAndCheckout(box.sandbox, {
+        repoFullName: "mcpjam/private-fixture",
+        prNumber: 7,
+        headSha,
+        cloneToken,
+      });
+      for (const call of box.calls) {
+        expect(call.opts?.envs).toBeUndefined();
+      }
+    }
+  });
+
+  it("still attributes a failing build to the PR when an environment is present", async () => {
+    // The environment must not change what a failure MEANS: a non-zero build is
+    // still the pull request's, with its log tail attached.
+    const box = fakeSandbox({
+      exitCodes: { "npm run build": 1 },
+      stdout: { "tail -c": "boom" },
+    });
+
+    const error = await buildAndStart(box.sandbox, ENV_RECIPE, {
+      fetchImpl: vi.fn(async () => okInitialize()) as unknown as typeof fetch,
+    }).catch((e) => e as CheckStepError);
+
+    expect((error as CheckStepError).outcome).toBe("build_failed");
+    expect((error as CheckStepError).detailsMarkdown).toContain("boom");
+  });
+});

--- a/mcpjam-inspector/server/services/github-checks/recipes.ts
+++ b/mcpjam-inspector/server/services/github-checks/recipes.ts
@@ -48,6 +48,27 @@ export type CheckRecipe = {
   port: number;
   /** Path the streamable-HTTP MCP endpoint is served on. */
   mcpPath: string;
+  /**
+   * Non-secret configuration literals, injected into the BUILD and the START
+   * commands and nowhere else (`sandbox.ts` passes them as E2B's `envs` command
+   * option, never as shell text).
+   *
+   * ONLY AN AUTHORITATIVE RUNG PRODUCES THIS. Today that means a repository's
+   * committed `mcpjam.yaml` (`resolver/mcpjamYaml.ts`), which is the only real
+   * producer, plus the operator override table above; the backend REJECTS an
+   * `env` on a cacheable `detected` or `agentic` recipe, so detection must never
+   * invent one and a cached recipe is always env-free.
+   *
+   * NEVER PUT A CREDENTIAL HERE. The values are committed to a repository and
+   * persisted verbatim in the backend's durable plan rows — nothing redacts
+   * them and nothing expires them. The clone token is the counter-example of how
+   * a secret IS handled: minted per check, carried on one command, redacted out
+   * of every observable failure, and never an environment variable.
+   *
+   * Absent means absent: an empty map is normalized away at the parser, so
+   * `undefined` is the only shape "no environment" ever takes.
+   */
+  env?: Record<string, string>;
 };
 
 /**

--- a/mcpjam-inspector/server/services/github-checks/resolve-and-start.ts
+++ b/mcpjam-inspector/server/services/github-checks/resolve-and-start.ts
@@ -402,6 +402,14 @@ export async function resolveAndStart(
           start: candidate.start,
           port: candidate.port,
           mcpPath: candidate.mcpPath,
+          // Only a DECLARED (or operator-override) recipe carries one, and only
+          // when it is non-empty. The key is omitted rather than sent as
+          // `undefined` or `{}`: the backend refuses `env` on a cacheable rung,
+          // so an empty map riding along on a detected candidate would be a 400
+          // on a candidate that was otherwise fine.
+          ...(candidate.env && Object.keys(candidate.env).length > 0
+            ? { env: candidate.env }
+            : {}),
         },
         rung: candidate.rung,
         evidence: candidate.evidence,
@@ -577,6 +585,12 @@ function recipeOf(planned: PlannedCandidate): ResolvedRecipe {
     start: planned.recipe.start,
     port: planned.recipe.port,
     mcpPath: planned.recipe.mcpPath,
+    // The PLAN's environment, not the one we proposed — the backend owns the
+    // plan, and a candidate it issued must execute exactly as issued. Copied
+    // conditionally so an env-free plan candidate stays env-free rather than
+    // acquiring an `env: undefined` that later code would have to know to
+    // ignore.
+    ...(planned.recipe.env ? { env: planned.recipe.env } : {}),
     rung: planned.rung,
     ownershipProof: planned.ownershipProof,
     evidence: planned.evidence ?? [],

--- a/mcpjam-inspector/server/services/github-checks/resolve-and-start.ts
+++ b/mcpjam-inspector/server/services/github-checks/resolve-and-start.ts
@@ -407,9 +407,7 @@ export async function resolveAndStart(
           // `undefined` or `{}`: the backend refuses `env` on a cacheable rung,
           // so an empty map riding along on a detected candidate would be a 400
           // on a candidate that was otherwise fine.
-          ...(candidate.env && Object.keys(candidate.env).length > 0
-            ? { env: candidate.env }
-            : {}),
+          ...envField(candidate.env),
         },
         rung: candidate.rung,
         evidence: candidate.evidence,
@@ -579,6 +577,27 @@ export async function resolveAndStart(
   }
 }
 
+/**
+ * `{ env }` when there is an environment, and NOTHING otherwise.
+ *
+ * ONE rule for both directions this module carries an environment across — the
+ * candidates we report to the plan, and the candidate the plan hands back. They
+ * had the rule written out twice and it drifted immediately: `{}` is truthy, so
+ * "copy it when it is there" quietly admits the empty map that "copy it when
+ * there is something in it" rejects.
+ *
+ * The distinction is not cosmetic on the outbound side. An empty map is still a
+ * VALUE, and the backend refuses `env` on a cacheable rung — so an empty one
+ * riding along on a detected candidate is a 400 on a candidate that was
+ * otherwise fine. Inbound it is a shape the rest of the pipeline should never
+ * have to recognise as a second spelling of absence.
+ */
+function envField(env: Record<string, string> | undefined): {
+  env?: Record<string, string>;
+} {
+  return env && Object.keys(env).length > 0 ? { env } : {};
+}
+
 function recipeOf(planned: PlannedCandidate): ResolvedRecipe {
   return {
     build: planned.recipe.build,
@@ -586,11 +605,10 @@ function recipeOf(planned: PlannedCandidate): ResolvedRecipe {
     port: planned.recipe.port,
     mcpPath: planned.recipe.mcpPath,
     // The PLAN's environment, not the one we proposed — the backend owns the
-    // plan, and a candidate it issued must execute exactly as issued. Copied
-    // conditionally so an env-free plan candidate stays env-free rather than
-    // acquiring an `env: undefined` that later code would have to know to
-    // ignore.
-    ...(planned.recipe.env ? { env: planned.recipe.env } : {}),
+    // plan, and a candidate it issued must execute exactly as issued. Through
+    // `envField` so an env-free plan candidate stays env-free rather than
+    // acquiring a key later code would have to know to ignore.
+    ...envField(planned.recipe.env),
     rung: planned.rung,
     ownershipProof: planned.ownershipProof,
     evidence: planned.evidence ?? [],

--- a/mcpjam-inspector/server/services/github-checks/resolver/mcpjamYaml.ts
+++ b/mcpjam-inspector/server/services/github-checks/resolver/mcpjamYaml.ts
@@ -28,7 +28,33 @@ import { RecipeResolutionError, type ResolvedRecipe } from "./types";
 export const MCPJAM_YAML_MAX_BYTES = 32 * 1024;
 
 /** Keys the v1 `checks:` section understands. Anything else is a typo. */
-const CHECKS_KEYS = new Set(["transport", "build", "start", "port", "path"]);
+const CHECKS_KEYS = new Set([
+  "transport",
+  "build",
+  "start",
+  "port",
+  "path",
+  "env",
+]);
+
+/**
+ * Bounds on `checks.env`, MIRRORED FROM THE BACKEND (`github/recipeCache.ts`).
+ *
+ * They are duplicated rather than imported because the two live in different
+ * deployments, and the duplication is deliberate in one direction: the backend
+ * rejects an out-of-bounds `env` at the plan route, but it does so with a 400
+ * about a `recipe.env` the author never wrote — pointing at a plan payload
+ * rather than at the file. So the parser fails FIRST, at the field, in the
+ * file's own vocabulary. If the two ever drift, the resolver tests are where
+ * that surfaces.
+ *
+ * The key shape is the shape POSIX environment variables actually take; a key
+ * that cannot be exported has no business travelling as far as a plan row.
+ */
+export const MCPJAM_ENV_MAX_KEYS = 20;
+export const MCPJAM_ENV_KEY_MAX_CHARS = 64;
+export const MCPJAM_ENV_VALUE_MAX_CHARS = 1_024;
+const MCPJAM_ENV_KEY_PATTERN = /^[A-Z][A-Z0-9_]*$/;
 
 // Messages name the requirement only — the formatter below prepends the
 // `checks.<field>:` path, so embedding it here too would double it.
@@ -72,6 +98,85 @@ function clampForError(value: unknown): string {
     text = "[unserializable value]";
   }
   return text.replace(/`/g, "'").replace(/[\r\n]+/g, " ").slice(0, 80);
+}
+
+/**
+ * Parse `checks.env` — the DECLARED ENVIRONMENT CHANNEL.
+ *
+ * ═══════════════════════════════════════════════════════════════════════════
+ * THESE ARE NON-SECRET CONFIGURATION LITERALS. NEVER PUT A CREDENTIAL HERE.
+ *
+ * The map comes out of a file COMMITTED to the repository — readable by anyone
+ * who can read the repo, including every fork and every pull request author —
+ * and it is persisted VERBATIM in the backend's durable plan rows. Nothing
+ * redacts it, nothing expires it, and nothing scopes it to one check. It is for
+ * the flags a server needs in order to boot (`LOG_LEVEL`, `FIXTURE_MODE`), and
+ * for nothing that would matter if it were printed in public.
+ * ═══════════════════════════════════════════════════════════════════════════
+ *
+ * Returns `undefined` for both an absent map and an EMPTY one. `env: {}` and no
+ * `env:` at all describe the same server, so they get the same wire shape —
+ * otherwise an empty object would travel to the backend, join the plan row, and
+ * become part of a candidate's identity there, making two identical recipes
+ * look like two different ones.
+ *
+ * Everything out of bounds is REJECTED, never truncated or coerced: a shortened
+ * value, or a `8080` quietly read as `"8080"`, is a different configuration from
+ * the one the author committed, and starting a server with it would report a
+ * verdict about something nobody wrote.
+ */
+function parseChecksEnv(raw: unknown): Record<string, string> | undefined {
+  if (raw === undefined) return undefined;
+  if (typeof raw !== "object" || raw === null || Array.isArray(raw)) {
+    invalid("checks.env: must be a mapping of NAME: value pairs");
+  }
+
+  const source = raw as Record<string, unknown>;
+  const keys = Object.keys(source);
+  if (keys.length === 0) return undefined;
+  if (keys.length > MCPJAM_ENV_MAX_KEYS) {
+    // The COUNT, not the keys: naming twenty-one of them would be a wall of
+    // author-controlled text in a check summary to say one number.
+    invalid(
+      `checks.env: has ${keys.length} entries; at most ${MCPJAM_ENV_MAX_KEYS} are allowed`,
+    );
+  }
+
+  // Built fresh, own validated keys only, so nothing the YAML node carries —
+  // prototype included — travels on with the recipe.
+  const env: Record<string, string> = {};
+  for (const key of keys) {
+    // Keys are echoed (the author needs to see which one is wrong) and clamped
+    // for exactly the reasons `clampForError` exists. VALUES ARE NEVER ECHOED:
+    // they are the payload, and a check summary is a public page.
+    const named = clampForError(key);
+    if (key.length > MCPJAM_ENV_KEY_MAX_CHARS) {
+      invalid(
+        `checks.env.${named}: name exceeds ${MCPJAM_ENV_KEY_MAX_CHARS} characters (${key.length})`,
+      );
+    }
+    if (!MCPJAM_ENV_KEY_PATTERN.test(key)) {
+      invalid(
+        `checks.env.${named}: name must match ${String(MCPJAM_ENV_KEY_PATTERN)} ` +
+          "(an uppercase environment variable name)",
+      );
+    }
+    const value = source[key];
+    if (typeof value !== "string") {
+      invalid(
+        `checks.env.${named}: must be a string — quote it if it is a number, ` +
+          "a boolean, or empty",
+      );
+    }
+    if (value.length > MCPJAM_ENV_VALUE_MAX_CHARS) {
+      invalid(
+        `checks.env.${named}: exceeds ${MCPJAM_ENV_VALUE_MAX_CHARS} characters (${value.length})`,
+      );
+    }
+    env[key] = value;
+  }
+
+  return env;
 }
 
 /**
@@ -162,11 +267,21 @@ export function parseMcpjamYaml(raw: string | null): ResolvedRecipe | null {
     );
   }
 
+  // Parsed from the RAW section, not from `parsed.data`: the zod schema above
+  // describes the executable fields, and adding a record to it would express the
+  // shape without any of the bounds. Validated after it, so a file missing
+  // `build` is told about `build` rather than about an environment typo.
+  const env = parseChecksEnv(checksRecord.env);
+
   const recipe: CheckRecipe = {
     build: parsed.data.build,
     start: parsed.data.start,
     port: parsed.data.port,
     mcpPath: parsed.data.path,
+    // Spread so an absent environment leaves NO `env` key at all — `env:
+    // undefined` is a property, and it would survive into the plan payload as
+    // one. See `parseChecksEnv` for why empty and absent are the same thing.
+    ...(env ? { env } : {}),
   };
 
   return {

--- a/mcpjam-inspector/server/services/github-checks/sandbox.ts
+++ b/mcpjam-inspector/server/services/github-checks/sandbox.ts
@@ -409,6 +409,28 @@ export async function provisionCheckSandbox(args: {
 type RunResult = { exitCode: number; stdout: string; stderr: string };
 
 /**
+ * `{ envs }` when there is an environment to pass, and NOTHING otherwise.
+ *
+ * The empty case is the interesting one. Spreading the result of this into a
+ * command's options leaves an env-free command byte-identical to what this
+ * module has always sent — no `envs: undefined`, no `envs: {}` — so the
+ * overwhelmingly common no-environment path cannot be changed by the existence
+ * of the environment channel, and a diff of the option objects stays a diff
+ * about something real.
+ *
+ * This is the ONLY way a recipe's environment reaches a command. It is never
+ * written into a command STRING: the values come from a PR checkout, every
+ * diagnostic in this module quotes commands into check output, and an `export
+ * FOO=…` would additionally put author bytes inside a `bash -lc` quoting
+ * boundary that is already nested two deep.
+ */
+function envsOption(env: Record<string, string> | undefined): {
+  envs?: Record<string, string>;
+} {
+  return env && Object.keys(env).length > 0 ? { envs: env } : {};
+}
+
+/**
  * Foreground command, normalized. E2B throws on a non-zero exit; every caller
  * here wants the exit code and the streams, so translate the throw back into a
  * result and let the caller decide what a failure MEANS.
@@ -445,6 +467,15 @@ async function runForeground(
      * not a secret one.
      */
     secret?: string;
+    /**
+     * The recipe's declared environment, for the one command that runs the PR's
+     * own code (the build). SEPARATE CONCERN FROM `secret`, in both directions:
+     * these are non-secret literals from a committed file and are never
+     * redacted, and the clone credential is never one of them — it rides a
+     * command-line git header precisely so it does not become an environment
+     * variable in a box where PR code runs.
+     */
+    envs?: Record<string, string>;
   }
 ): Promise<RunResult> {
   const startedAt = Date.now();
@@ -452,6 +483,7 @@ async function runForeground(
     const result = (await sandbox.commands.run(command, {
       cwd: opts.cwd,
       timeoutMs: opts.timeoutMs,
+      ...envsOption(opts.envs),
     })) as Partial<RunResult> | undefined;
     return {
       exitCode: result?.exitCode ?? 0,
@@ -723,6 +755,11 @@ export async function buildAndStart(
         cwd: CHECKOUT_DIR,
         timeoutMs: options?.buildTimeoutMs ?? BUILD_TIMEOUT_MS,
         timeoutOutcome: "build_failed",
+        // The build gets the declared environment too, not just the start: a
+        // build step that reads its configuration (a codegen flag, a fixture
+        // mode) would otherwise produce a tree the start command's environment
+        // no longer matches.
+        ...envsOption(recipe.env),
       }
     );
   } catch (error) {
@@ -768,6 +805,12 @@ export async function buildAndStart(
         // forwards the value to connect-rpc, which treats <= 0 as an
         // already-expired deadline and would abort the spawn instantly.)
         timeoutMs: CHECK_SANDBOX_TIMEOUT_MS,
+        // The server's own configuration, handed to E2B beside the command
+        // rather than written into it. `startCommandScript` is unchanged and
+        // stays unchanged: the recipe's `start` runs in a nested `bash -lc`
+        // under a watchdog, and an environment assignment threaded through that
+        // would have to survive two quoting boundaries to arrive intact.
+        ...envsOption(recipe.env),
       }
     );
   } catch (error) {


### PR DESCRIPTION
Completes the Inspector half of the declared-recipe environment channel: a repository declares `checks.env` in `mcpjam.yaml`, it survives the backend-owned plan intact, and it reaches the PR's server through E2B's `envs` command option.

## The bounds

`checks.env` is a map of `NAME: value` pairs, bounded exactly as the backend bounds it:

| limit | value |
| --- | --- |
| entries | at most **20** |
| key length | at most **64** characters |
| key shape | `^[A-Z][A-Z0-9_]*$` |
| value length | at most **1,024** characters |

Lengths are JavaScript string lengths, matching the backend's semantics.

**Anything outside the bounds is rejected, never truncated.** A shortened value — or an unquoted `8080` silently coerced to `"8080"` — is a *different configuration* from the one the author committed, and a check that started a server with it would report a verdict about something nobody wrote. Non-string values, a map that is a list/scalar/null, and unknown siblings under `checks:` all fail the file; at an authoritative rung that means the check fails honestly instead of falling through to a heuristic guess. `env: {}` normalizes to no environment, so an empty map has the same runtime behaviour and the same wire shape as omitting the field — enforced at every boundary that carries the field, through a single `envField` helper.

Errors name `checks.env` or `checks.env.<key>` and the violated limit. Keys are echoed (the author needs to see their typo) through the file's existing clamp; **values are never echoed**.

## These values are not secrets

Env values are committed, non-secret configuration literals. They come from a file in the repository — readable by anyone who can read it — and the backend persists them **verbatim in durable plan rows**. Nothing redacts them and nothing expires them. The parser docblock, the `CheckRecipe` field comment, and the changeset all say so plainly: put credentials nowhere near `mcpjam.yaml`.

The clone token remains the counter-example of how a secret is handled: minted per check, carried on a single command-line git header for clone and fetch, redacted out of every observable failure, and never an environment variable.

## Where it is injected

Exactly two commands, via E2B's command option:

```ts
sandbox.commands.run(command, { ..., envs: recipe.env })
```

1. the foreground **build** command;
2. the background **start** command.

**Never inline shell.** No `export`, no assignment, no interpolation, no JSON — `buildCommandScript` and `startCommandScript` are untouched, and the command strings are byte-identical with and without an environment (asserted). On a no-env recipe the `envs` key is omitted entirely rather than passed as `undefined` or `{}`.

Nothing else receives it: provisioning, clone/fetch (public or token-authenticated), checkout and SHA verification, resolver file reads, `/proc` listener inspection, health probes, teardown, and log-tail commands all run exactly as before.

## Rungs and the plan

`env` rides the shared `CheckRecipe` shape, so `ResolvedRecipe`, override recipes, plan input, and planned candidates inherit it without a second environment type. Only authoritative rungs produce one — `mcpjam.yaml` is the only real producer, since the production override table is empty. Detection never invents an environment, and the backend rejects `env` on cacheable `detected`/`agentic` recipes, so **cached recipes stay env-free**.

`resolveAndStart` preserves the field in both directions: local candidates carry `env` only when present and non-empty (never `env: undefined` or `{}`), and `recipeOf` copies the plan's `env` so the exact plan-issued recipe executes. No local ordering, verdict, or policy logic was added — the backend still owns the plan.

## PR #4097's invariants are preserved

The private-repo clone tests are unchanged and green: anonymous clone byte-stability, `http.extraheader` confinement to clone and fetch, absence of the credential from checkout/`rev-parse`, and redaction of a thrown transport error that quotes the complete clone command. `redactCloneCredential` and `runForeground.secret` were not touched — `secret` and `envs` are separate concerns on the same call. A new test additionally pins that the clone receives no `envs` at all, with or without a token.

## Backend dependency

Backend **PR #1020 is already merged and deployed**. Plan candidates accept and persist the bounded `env` field, and the heuristic recipe cache remains deliberately env-free. No backend or client-settings code is changed here.

## Tests

Every new behavioral test was demonstrated **red** against a deliberately broken implementation before being accepted, with the test kept in place during the probe:

| break | tests that went red |
| --- | --- |
| `envsOption` always emits the key | 5 (incl. two of #4097's clone tests) |
| environment inlined as shell `export`s | 3 |
| log tail given the recipe env | 1 |
| local candidates lose `env` | 1 |
| `recipeOf` emits `env: undefined` | 1 |
| `recipeOf` drops the plan's `env` | 1 |
| detected candidates carry an `env` key | 2 |
| `env: {}` kept instead of normalized | 1 |
| non-string values coerced | 5 |
| values echoed / keys unclamped | 2 |
| key not clamped | 1 |
| `recipeOf` carries a backend-planned `env: {}` (2nd commit) | 1 |

One probe found a **vacuous test of my own**: the hostile-key clamp case failed at YAML parse rather than reaching the clamp. It now serializes the key through `JSON.stringify` (valid YAML double-quoted escaping) and asserts the message reached `checks.env.`, and it goes red when the clamp is removed.

Results, from `mcpjam-inspector/`:

```
npx vitest run resolver.test.ts resolve-and-start.test.ts sandbox.test.ts github-checks-worker.test.ts check-plan.test.ts
  → 291 passed (54 / 43 / 109 / 70 / 15)
npx vitest run server/services
  → 98 files, 1694 passed
npx tsc --noEmit -p server/tsconfig.json
  → no new errors (diffed against main: only a line-number shift on a pre-existing TS6133)
npx prettier --check <touched files>
  → clean, except resolver.test.ts and mcpjamYaml.ts
```

Those two files already failed `--check` on `main` with the repo's pinned prettier 2.8.8 (they are written in a trailing-comma style prettier 2 rewrites). I deliberately did not reformat them — doing so would add ~170 lines of unrelated churn — and my additions follow each file's existing style. `sandbox.ts` and `resolve-and-start.ts` did pass before and pass now. CI's `prettier-fix` is a `--write`, so nothing is gated. Generated bundles were regenerated with the repo's `pretest` scripts, never hand-edited, and are gitignored.

## Second commit

CodeRabbit caught that `{}` is truthy, so `recipeOf`'s `...(planned.recipe.env ? … )` would have carried a backend-planned empty map through as `env: {}`. Unreachable today — the backend's candidates come from the env-free recipe cache or from the local candidates this module already normalizes, and `envsOption` keys on the map having contents, so execution was identical either way — but the shape invariant was uneven at one of four boundaries. Both directions now share one `envField` helper, with a regression test proven red against the old spread.

## Operator follow-up drill (not done here)

Open a PR in `MCPJam/mcp-check-fixture` whose server requires a declared env value to boot, then verify build, start, probe, and eval pass end to end — and that the value appears in **no** command diagnostic (check summary, build/server log tail, or a transport error quoting the command).