### PR TITLE
github checks: require an outage policy at connect, through the verified action

### DIFF
--- a/.changeset/github-checks-outage-policy-ui.md
+++ b/.changeset/github-checks-outage-policy-ui.md
@@ -1,0 +1,42 @@
+---
+"@mcpjam/inspector": patch
+---
+
+Ask for a GitHub check's outage policy when a repository is connected, and
+connect through the server-verified action.
+
+Connecting now goes to `github/checkRepoConfigsNode:connectVerifiedRepo`, which
+proves the pinned installation can actually reach the repository before any
+config row is written and stamps the installation id server-side. Both connect
+surfaces — Settings → Integrations → GitHub and the suite's own "run this on
+every pull request" section — use it, so nothing in Inspector calls the
+unverified `github/checkRepoConfigs:connectRepo` mutation any more and it can be
+removed in the follow-up backend deploy. The client never names an installation
+id: which installation can reach a repository is a server-side fact, and a
+client that could name one is a client that could name the wrong one.
+
+The outage policy is now an explicit onboarding choice rather than an assumed
+default. Neither value is preselected and Connect stays disabled until
+repository, suite and policy are all chosen, because a preselected policy
+records a decision nobody made. Both options are described before the choice:
+fail open reports the check as neutral during an MCPJam outage or pause, fail
+closed reports it as failed. Neither description promises a merge outcome —
+MCPJam decides the check's conclusion, and whether a failed or neutral check
+blocks merging is the repository's branch-protection setting, which MCPJam can
+neither read nor set.
+
+Connected rows gain a policy control and keep the distinction visible. A row
+connected before the policy existed shows "Policy not chosen" and says that it
+effectively fails open, rather than rendering `fail_open` as though it had been
+selected — those two rows behave identically today and are not the same thing.
+Choosing a value on such a row records it. The control is disabled while its
+write is in flight and a duplicate change is dropped until it settles, tracked
+separately from the enable toggle so one control never freezes the other.
+
+Rows also show live repository visibility, joined case-insensitively to the
+installation listing. Only an explicit `private` boolean produces a badge:
+a repository GitHub returned without the flag, one absent from the current
+listing, a listing still loading and a listing that failed all render no badge
+at all, because none of them is evidence that a repository is public.
+Visibility is never persisted — it can change under a connected repository at
+any time — and a connected repository missing from the listing keeps its row.

--- a/mcpjam-inspector/client/src/components/evals/__tests__/suite-github-checks-section.test.tsx
+++ b/mcpjam-inspector/client/src/components/evals/__tests__/suite-github-checks-section.test.tsx
@@ -1,10 +1,12 @@
 import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
 import { describe, expect, it, vi } from "vitest";
 
 const {
   mockAvailability,
   mockRepos,
   mockConnectRepo,
+  mockConnectVerifiedRepo,
   mockListInstallationRepos,
   mockNavigate,
   mockToast,
@@ -13,7 +15,11 @@ const {
     value: undefined as { state: "enabled" | "disabled" } | undefined,
   },
   mockRepos: { value: undefined as any[] | undefined },
-  mockConnectRepo: vi.fn(async () => ({ configId: "cfg-new" })),
+  // The unverified connect the backend still exposes for the two-deploy
+  // window. Handed to the component so that reaching for it is a recorded
+  // call rather than a crash — "never called" is the assertion.
+  mockConnectRepo: vi.fn(async () => ({ configId: "cfg-legacy" })),
+  mockConnectVerifiedRepo: vi.fn(async () => ({ configId: "cfg-new" })),
   mockListInstallationRepos: vi.fn(async () => [
     { fullName: "mcpjam/inspector" },
     { fullName: "mcpjam/backend" },
@@ -29,6 +35,7 @@ vi.mock("@/hooks/useGithubChecksSettings", () => ({
     availability: mockAvailability.value,
     repos: mockRepos.value,
     connectRepo: mockConnectRepo,
+    connectVerifiedRepo: mockConnectVerifiedRepo,
     listInstallationRepos: mockListInstallationRepos,
   }),
 }));
@@ -67,6 +74,7 @@ function renderSection(
     "availability" in opts ? opts.availability : { state: "enabled" };
   mockRepos.value = "repos" in opts ? opts.repos : [];
   mockConnectRepo.mockClear();
+  mockConnectVerifiedRepo.mockClear();
   mockNavigate.mockClear();
   return render(
     <SuiteGithubChecksSection
@@ -75,6 +83,16 @@ function renderSection(
       organizationId="org-1"
     />
   );
+}
+
+/** Radix renders options in a portal that exists only while the trigger is open. */
+async function chooseOption(
+  user: ReturnType<typeof userEvent.setup>,
+  triggerLabel: string,
+  optionName: string
+) {
+  await user.click(screen.getByLabelText(triggerLabel));
+  await user.click(await screen.findByRole("option", { name: optionName }));
 }
 
 describe("SuiteGithubChecksSection", () => {
@@ -132,5 +150,62 @@ describe("SuiteGithubChecksSection", () => {
     renderSection({ repos: [CONNECTED_HERE] });
     screen.getByText("Manage in Settings → Integrations").click();
     expect(mockNavigate).toHaveBeenCalledWith("/settings/integrations/github");
+  });
+
+  it("will not connect until an outage policy is chosen", async () => {
+    const user = userEvent.setup();
+    renderSection({ repos: [] });
+    await waitFor(() => expect(mockListInstallationRepos).toHaveBeenCalled());
+
+    const connect = screen.getByRole("button", { name: /Connect/ });
+    expect(connect).toBeDisabled();
+    await chooseOption(user, "Repository", "mcpjam/inspector");
+    // A repository alone is not an answer: this surface sets the policy once,
+    // at connect time, and never offers to change it afterwards.
+    expect(connect).toBeDisabled();
+
+    await chooseOption(user, "Outage policy", "Fail closed");
+    expect(connect).toBeEnabled();
+  });
+
+  it("connects through the verified action, never the unverified mutation", async () => {
+    const user = userEvent.setup();
+    renderSection({ repos: [] });
+    await waitFor(() => expect(mockListInstallationRepos).toHaveBeenCalled());
+
+    await chooseOption(user, "Repository", "mcpjam/inspector");
+    await chooseOption(user, "Outage policy", "Fail open");
+    await user.click(screen.getByRole("button", { name: /Connect/ }));
+
+    await waitFor(() =>
+      expect(mockConnectVerifiedRepo).toHaveBeenCalledTimes(1)
+    );
+    expect(mockConnectVerifiedRepo).toHaveBeenCalledWith({
+      repoFullName: "mcpjam/inspector",
+      projectId: "proj-1",
+      suiteId: "suite-1",
+      outagePolicy: "fail_open",
+    });
+    expect(mockConnectRepo).not.toHaveBeenCalled();
+    expect(mockToast.success).toHaveBeenCalledWith("Repository connected.");
+  });
+
+  it("states the conclusion each policy produces without promising a merge", () => {
+    renderSection({ repos: [] });
+
+    expect(
+      screen.getByText(
+        /During an MCPJam outage or pause, the check reports neutral\./
+      )
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText(
+        /Whether a failed or neutral check blocks merging depends on this repository's branch-protection settings\./
+      )
+    ).toBeInTheDocument();
+    const page = document.body.textContent ?? "";
+    for (const forbidden of [/merges proceed/i, /merges are blocked/i]) {
+      expect(page).not.toMatch(forbidden);
+    }
   });
 });

--- a/mcpjam-inspector/client/src/components/evals/__tests__/suite-github-checks-section.test.tsx
+++ b/mcpjam-inspector/client/src/components/evals/__tests__/suite-github-checks-section.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen, waitFor } from "@testing-library/react";
+import { act, render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { describe, expect, it, vi } from "vitest";
 
@@ -188,6 +188,63 @@ describe("SuiteGithubChecksSection", () => {
     });
     expect(mockConnectRepo).not.toHaveBeenCalled();
     expect(mockToast.success).toHaveBeenCalledWith("Repository connected.");
+  });
+
+  it.each([
+    [
+      "an availability refusal",
+      "GitHub Checks settings are not currently available for this org.",
+      "GitHub Checks settings are not currently available.",
+    ],
+    [
+      "any other refusal",
+      "Repository is not accessible to the MCPJam GitHub App.",
+      "Repository is not accessible to the MCPJam GitHub App.",
+    ],
+  ])("surfaces %s from the verified connect", async (_case, thrown, shown) => {
+    mockConnectVerifiedRepo.mockRejectedValueOnce(new Error(thrown));
+    const user = userEvent.setup();
+    renderSection({ repos: [] });
+    await waitFor(() => expect(mockListInstallationRepos).toHaveBeenCalled());
+
+    await chooseOption(user, "Repository", "mcpjam/inspector");
+    await chooseOption(user, "Outage policy", "Fail closed");
+    await user.click(screen.getByRole("button", { name: /Connect/ }));
+
+    await waitFor(() => expect(mockToast.error).toHaveBeenCalledWith(shown));
+    expect(mockToast.success).not.toHaveBeenCalled();
+  });
+
+  it("says nothing when a connect lands after the section is gone", async () => {
+    // The boundary around this section in `suite-iterations-view` is keyed by
+    // organizationId, so switching orgs unmounts this instance mid-connect.
+    // `toast` is global: without a mount guard, the previous organization's
+    // completion announces itself over the new organization's page.
+    let resolveConnect: ((result: unknown) => void) | undefined;
+    mockConnectVerifiedRepo.mockImplementationOnce(
+      () =>
+        new Promise((resolve) => {
+          resolveConnect = resolve as (result: unknown) => void;
+        })
+    );
+    const user = userEvent.setup();
+    const { unmount } = renderSection({ repos: [] });
+    await waitFor(() => expect(mockListInstallationRepos).toHaveBeenCalled());
+
+    await chooseOption(user, "Repository", "mcpjam/inspector");
+    await chooseOption(user, "Outage policy", "Fail open");
+    await user.click(screen.getByRole("button", { name: /Connect/ }));
+    await waitFor(() =>
+      expect(mockConnectVerifiedRepo).toHaveBeenCalledTimes(1)
+    );
+
+    unmount();
+    await act(async () => {
+      resolveConnect?.({ configId: "cfg-new" });
+    });
+
+    expect(mockToast.success).not.toHaveBeenCalled();
+    expect(mockToast.error).not.toHaveBeenCalled();
   });
 
   it("states the conclusion each policy produces without promising a merge", () => {

--- a/mcpjam-inspector/client/src/components/evals/suite-github-checks-section.tsx
+++ b/mcpjam-inspector/client/src/components/evals/suite-github-checks-section.tsx
@@ -13,8 +13,13 @@ import { useAppNavigate } from "@/lib/app-navigation";
 import {
   GITHUB_CHECKS_UNAVAILABLE_MESSAGE,
   useGithubChecksSettings,
+  type GithubCheckOutagePolicy,
   type InstallationRepo,
 } from "@/hooks/useGithubChecksSettings";
+import {
+  OutagePolicyExplainer,
+  OutagePolicySelectItems,
+} from "@/components/settings/github-checks-outage-policy";
 
 /**
  * "Run this suite on every pull request", on the suite itself.
@@ -30,6 +35,11 @@ import {
  * visible at once — offering them here would let you retarget a repo away from
  * the suite you are standing on, which reads as a mistake even when it is not.
  *
+ * The outage policy is the ONE thing this narrow surface still has to ask for.
+ * It is set at connect time and it is not editable here, so skipping it would
+ * make this the path that quietly produces rows nobody chose a policy for —
+ * exactly the legacy state the settings page has to warn about.
+ *
  * Renders nothing at all when GitHub Checks is unavailable for the org.
  */
 export function SuiteGithubChecksSection({
@@ -42,13 +52,17 @@ export function SuiteGithubChecksSection({
   organizationId?: string | null;
 }) {
   const appNavigate = useAppNavigate();
-  const { availability, repos, connectRepo, listInstallationRepos } =
+  const { availability, repos, connectVerifiedRepo, listInstallationRepos } =
     useGithubChecksSettings(organizationId);
 
   const [installationRepos, setInstallationRepos] = useState<
     InstallationRepo[] | null
   >(null);
   const [pickerRepo, setPickerRepo] = useState("");
+  // Unset until chosen. A default here would be a decision made for someone.
+  const [pickerPolicy, setPickerPolicy] = useState<
+    GithubCheckOutagePolicy | ""
+  >("");
   const [connecting, setConnecting] = useState(false);
 
   const isEnabled = availability?.state === "enabled";
@@ -57,6 +71,7 @@ export function SuiteGithubChecksSection({
     let cancelled = false;
     setInstallationRepos(null);
     setPickerRepo("");
+    setPickerPolicy("");
     if (!isEnabled) {
       return () => {
         cancelled = true;
@@ -98,15 +113,20 @@ export function SuiteGithubChecksSection({
         );
 
   const handleConnect = async () => {
-    if (!pickerRepo || !projectId) return;
+    if (!pickerRepo || !projectId || !pickerPolicy) return;
     setConnecting(true);
     try {
-      await connectRepo({
+      // The server-VERIFIED connect: it proves the pinned installation can
+      // actually reach this repository before any row is written. The
+      // unverified mutation is still deployed and must not be called.
+      await connectVerifiedRepo({
         repoFullName: pickerRepo,
         projectId,
         suiteId,
+        outagePolicy: pickerPolicy,
       });
       setPickerRepo("");
+      setPickerPolicy("");
       toast.success("Repository connected.");
     } catch (error) {
       const message = error instanceof Error ? error.message : String(error);
@@ -157,14 +177,29 @@ export function SuiteGithubChecksSection({
             ))}
           </SelectContent>
         </Select>
+        <Select
+          value={pickerPolicy}
+          onValueChange={(value) =>
+            setPickerPolicy(value as GithubCheckOutagePolicy)
+          }
+        >
+          <SelectTrigger className="w-52" aria-label="Outage policy">
+            <SelectValue placeholder="Select an outage policy" />
+          </SelectTrigger>
+          <SelectContent>
+            <OutagePolicySelectItems />
+          </SelectContent>
+        </Select>
         <Button
           size="sm"
           onClick={() => void handleConnect()}
-          disabled={connecting || !pickerRepo || !projectId}
+          disabled={connecting || !pickerRepo || !projectId || !pickerPolicy}
         >
           <Plus className="mr-2 size-3.5" aria-hidden /> Connect
         </Button>
       </div>
+
+      <OutagePolicyExplainer className="space-y-1 text-xs text-muted-foreground" />
 
       {installationRepos !== null && connectableRepos.length === 0 ? (
         <p className="text-xs text-muted-foreground">

--- a/mcpjam-inspector/client/src/components/evals/suite-github-checks-section.tsx
+++ b/mcpjam-inspector/client/src/components/evals/suite-github-checks-section.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import { Github, Plus } from "lucide-react";
 import { toast } from "@/lib/toast";
 import { Button } from "@mcpjam/design-system/button";
@@ -65,6 +65,21 @@ export function SuiteGithubChecksSection({
   >("");
   const [connecting, setConnecting] = useState(false);
 
+  // Whether this instance is still on screen. The `ErrorBoundary` wrapping this
+  // section in `suite-iterations-view` is KEYED BY organizationId, so switching
+  // organizations remounts the component with a connect still in flight. That
+  // completion belongs to the organization that is gone — and while React drops
+  // the state writes for an unmounted tree, `toast` is global and would happily
+  // announce a repository connected to an organization the user has left. An
+  // org-id ref cannot see this: the remounted instance starts with a fresh one.
+  const mountedRef = useRef(true);
+  useEffect(() => {
+    mountedRef.current = true;
+    return () => {
+      mountedRef.current = false;
+    };
+  }, []);
+
   const isEnabled = availability?.state === "enabled";
 
   useEffect(() => {
@@ -125,10 +140,14 @@ export function SuiteGithubChecksSection({
         suiteId,
         outagePolicy: pickerPolicy,
       });
+      if (!mountedRef.current) return;
       setPickerRepo("");
       setPickerPolicy("");
       toast.success("Repository connected.");
     } catch (error) {
+      // Same rule for the failure: an error about an organization the user has
+      // already left is noise they cannot act on.
+      if (!mountedRef.current) return;
       const message = error instanceof Error ? error.message : String(error);
       toast.error(
         message.includes("not currently available")

--- a/mcpjam-inspector/client/src/components/settings/GithubChecksRoute.tsx
+++ b/mcpjam-inspector/client/src/components/settings/GithubChecksRoute.tsx
@@ -1,9 +1,10 @@
-import { useCallback, useEffect, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 import { Navigate } from "react-router";
 import { useConvexAuth } from "convex/react";
 import { ChevronLeft, Github, Plus, Trash2 } from "lucide-react";
 import { toast } from "@/lib/toast";
 import { useAppNavigate } from "@/lib/app-navigation";
+import { Badge } from "@mcpjam/design-system/badge";
 import { Button } from "@mcpjam/design-system/button";
 import { Switch } from "@mcpjam/design-system/switch";
 import {
@@ -14,11 +15,16 @@ import {
   SelectValue,
 } from "@mcpjam/design-system/select";
 import { useOrganizationQueries } from "@/hooks/useOrganizations";
+import {
+  OutagePolicyExplainer,
+  OutagePolicySelectItems,
+} from "./github-checks-outage-policy";
 import { SettingsSection } from "../setting/SettingsSection";
 import { SettingsPageShell } from "./SettingsPageShell";
 import {
   GITHUB_CHECKS_UNAVAILABLE_MESSAGE,
   useGithubChecksSettings,
+  type GithubCheckOutagePolicy,
   type GithubCheckRepoConfigRow,
   type InstallationRepo,
   type SuiteOption,
@@ -62,6 +68,24 @@ function RepoCheckState({ enabled }: { enabled: boolean }) {
   );
 }
 
+/**
+ * Live GitHub visibility, or nothing.
+ *
+ * `undefined` is UNKNOWN, and it arrives four ways: GitHub omitted the flag,
+ * the repository is not in the current installation listing, the listing has
+ * not loaded yet, or the listing failed. None of those is evidence that a
+ * repository is public, so none of them renders a badge. Guessing wrong here
+ * labels somebody's private repository as public on their own settings page.
+ */
+function RepoVisibilityBadge({ isPrivate }: { isPrivate?: boolean }) {
+  if (isPrivate === undefined) return null;
+  return (
+    <Badge variant="outline" className="shrink-0">
+      {isPrivate ? "Private" : "Public"}
+    </Badge>
+  );
+}
+
 export function GithubChecksRoute({
   activeOrganizationId,
 }: GithubChecksRouteProps = {}) {
@@ -70,9 +94,10 @@ export function GithubChecksRoute({
     availability,
     repos,
     suites,
-    connectRepo,
+    connectVerifiedRepo,
     setRepoEnabled,
     setRepoSuite,
+    setRepoOutagePolicy,
     disconnectRepo,
     listInstallationRepos,
   } = useGithubChecksSettings(activeOrganizationId);
@@ -106,8 +131,29 @@ export function GithubChecksRoute({
   const [pendingToggles, setPendingToggles] = useState<ReadonlySet<string>>(
     () => new Set()
   );
+  // Policy writes are tracked SEPARATELY from `pendingToggles`: they are
+  // different writes on the same row, and one set would have a policy change
+  // disable the enable switch (and vice versa) for no reason the user can see.
+  const [pendingPolicies, setPendingPolicies] = useState<ReadonlySet<string>>(
+    () => new Set()
+  );
   const [pickerRepo, setPickerRepo] = useState<string>("");
   const [pickerSuite, setPickerSuite] = useState<string>("");
+  // `""` is "not chosen", and it is the only initial value this may have. A
+  // preselected policy would record a decision the administrator never made —
+  // the exact thing the unstamped legacy rows below exist to warn about.
+  const [pickerPolicy, setPickerPolicy] = useState<
+    GithubCheckOutagePolicy | ""
+  >("");
+
+  // The organization a completion belongs to. `activeOrganizationId` is a prop
+  // and this component stays mounted across a switch, so an in-flight connect
+  // resolves against whatever org is active WHEN IT LANDS — which is not
+  // necessarily the one it was submitted for.
+  const organizationIdRef = useRef(activeOrganizationId);
+  useEffect(() => {
+    organizationIdRef.current = activeOrganizationId;
+  }, [activeOrganizationId]);
 
   /**
    * A write refused as unavailable means the surface flipped off underneath
@@ -125,14 +171,15 @@ export function GithubChecksRoute({
 
   useEffect(() => {
     // Switching orgs must not let the previous org's in-flight result land on
-    // the new one: `connectRepo` sends the CURRENT org id, so a stale selection
-    // would be submitted against an org that repo does not belong to. Reset the
-    // picker and ignore any completion after cleanup.
+    // the new one: `connectVerifiedRepo` sends the CURRENT org id, so a stale
+    // selection would be submitted against an org that repo does not belong to.
+    // Reset the picker and ignore any completion after cleanup.
     let cancelled = false;
     setInstallationRepos(null);
     setInstallationReposFailed(false);
     setPickerRepo("");
     setPickerSuite("");
+    setPickerPolicy("");
 
     if (availability?.state !== "enabled") {
       return () => {
@@ -153,7 +200,16 @@ export function GithubChecksRoute({
     return () => {
       cancelled = true;
     };
-  }, [availability?.state, listInstallationRepos, handleWriteError]);
+    // `activeOrganizationId` is listed even though nothing in the body reads it
+    // directly: the org IS what this effect resets for, and depending only on
+    // the callback's identity would tie the reset to a memoization detail of
+    // the hook rather than to the switch itself.
+  }, [
+    activeOrganizationId,
+    availability?.state,
+    listInstallationRepos,
+    handleWriteError,
+  ]);
 
   // Without an active organization the availability query never runs, so
   // treating that as "still loading" would leave the page blank forever. But
@@ -180,24 +236,41 @@ export function GithubChecksRoute({
 
   const handleConnect = async () => {
     const suite = suiteById(pickerSuite);
-    if (!pickerRepo || !suite?.projectId) {
-      toast.error("Pick a repository and a suite first.");
+    // The same three-way rule the button enforces, enforced again here. The
+    // disabled attribute is a hint to a person; this is the invariant, and the
+    // policy half of it is why: a connect that quietly omitted `outagePolicy`
+    // would store a row nobody chose a policy for — the legacy state this whole
+    // screen exists to stop creating.
+    if (!pickerRepo || !suite?.projectId || !pickerPolicy) {
+      toast.error("Pick a repository, a suite, and an outage policy first.");
       return;
     }
+    // Which org this submission belongs to. Compared against the ref after the
+    // await, because the user can switch orgs while GitHub is being asked.
+    const submittedForOrganization = activeOrganizationId;
     setConnecting(true);
     try {
       // The project is DERIVED from the suite, never picked separately: the
       // backend requires them to agree, so offering two controls would only
       // create a way to get it wrong.
-      await connectRepo({
+      await connectVerifiedRepo({
         repoFullName: pickerRepo,
         projectId: suite.projectId,
         suiteId: suite._id,
+        outagePolicy: pickerPolicy,
       });
+      // A completion for the PREVIOUS org lands on a page that is now showing a
+      // different one. Clearing selections there would wipe a fresh choice, and
+      // the success toast would credit the wrong organization.
+      if (organizationIdRef.current !== submittedForOrganization) return;
       setPickerRepo("");
       setPickerSuite("");
+      setPickerPolicy("");
       toast.success("Repository connected.");
     } catch (error) {
+      // Same rule for the failure: an error about an org the user has already
+      // left is noise they cannot act on.
+      if (organizationIdRef.current !== submittedForOrganization) return;
       handleWriteError(error);
     } finally {
       setConnecting(false);
@@ -241,6 +314,30 @@ export function GithubChecksRoute({
     }
   };
 
+  const handlePolicyChange = async (
+    row: GithubCheckRepoConfigRow,
+    outagePolicy: GithubCheckOutagePolicy
+  ) => {
+    // Same reason as the enable toggle: the select stays bound to the server
+    // snapshot until the list refreshes, so a second change made before the
+    // first settles would be sent against a row state that is already moving.
+    if (pendingPolicies.has(row._id)) return;
+    setPendingPolicies((current) => new Set(current).add(row._id));
+    try {
+      // `{ changed: false }` is a successful no-op — the stored policy already
+      // said this. Nothing to announce; only a throw is worth a toast.
+      await setRepoOutagePolicy({ configId: row._id, outagePolicy });
+    } catch (error) {
+      handleWriteError(error);
+    } finally {
+      setPendingPolicies((current) => {
+        const next = new Set(current);
+        next.delete(row._id);
+        return next;
+      });
+    }
+  };
+
   const handleDisconnect = async (row: GithubCheckRepoConfigRow) => {
     try {
       await disconnectRepo({ configId: row._id });
@@ -248,6 +345,18 @@ export function GithubChecksRoute({
       handleWriteError(error);
     }
   };
+
+  // Live visibility, keyed by the same normalization the connected-repo join
+  // uses. Only an explicit boolean is recorded: a repository GitHub returned
+  // without `private`, one that is not in this listing at all, and a listing
+  // that has not loaded or has failed all fall through to `undefined`, which
+  // renders no badge.
+  const visibilityByRepo = new Map<string, boolean>();
+  for (const repo of installationRepos ?? []) {
+    if (typeof repo.private === "boolean") {
+      visibilityByRepo.set(repo.fullName.trim().toLowerCase(), repo.private);
+    }
+  }
 
   // Both sides lowercased. The backend stores the canonical lowercase form, so
   // today only the candidate strictly needs it — but relying on that means a
@@ -334,10 +443,27 @@ export function GithubChecksRoute({
                   <Github className="size-4 text-primary" aria-hidden />
                 </div>
                 <div className="flex flex-col min-w-0">
-                  <span className="text-sm font-medium truncate">
-                    {row.repoFullName}
-                  </span>
+                  <div className="flex items-center gap-2 min-w-0">
+                    <span className="text-sm font-medium truncate">
+                      {row.repoFullName}
+                    </span>
+                    <RepoVisibilityBadge
+                      isPrivate={visibilityByRepo.get(
+                        row.repoFullName.trim().toLowerCase()
+                      )}
+                    />
+                  </div>
                   <RepoCheckState enabled={row.enabled} />
+                  {row.outagePolicy === undefined ? (
+                    /* Not the same statement as "fail open": the backend does
+                       behave that way for an unstamped row, but nobody chose
+                       it, and saying so is what lets an administrator tell the
+                       two apart. */
+                    <span className="text-xs text-muted-foreground">
+                      No outage policy chosen — effectively fails open, so the
+                      check reports neutral during an MCPJam outage or pause.
+                    </span>
+                  ) : null}
                 </div>
               </div>
 
@@ -358,6 +484,31 @@ export function GithubChecksRoute({
                         {suite.name}
                       </SelectItem>
                     ))}
+                  </SelectContent>
+                </Select>
+
+                {/* `?? ""` shows the placeholder rather than a value. Binding
+                    this to `fail_open` for an unstamped row would render the
+                    administrator's screen as though they had already chosen
+                    the default — a claim the stored row does not make. */}
+                <Select
+                  value={row.outagePolicy ?? ""}
+                  disabled={pendingPolicies.has(row._id)}
+                  onValueChange={(value) =>
+                    void handlePolicyChange(
+                      row,
+                      value as GithubCheckOutagePolicy
+                    )
+                  }
+                >
+                  <SelectTrigger
+                    className="w-44"
+                    aria-label={`Outage policy for ${row.repoFullName}`}
+                  >
+                    <SelectValue placeholder="Policy not chosen" />
+                  </SelectTrigger>
+                  <SelectContent>
+                    <OutagePolicySelectItems />
                   </SelectContent>
                 </Select>
 
@@ -410,13 +561,31 @@ export function GithubChecksRoute({
             </SelectContent>
           </Select>
 
+          <Select
+            value={pickerPolicy}
+            onValueChange={(value) =>
+              setPickerPolicy(value as GithubCheckOutagePolicy)
+            }
+          >
+            <SelectTrigger className="w-52" aria-label="Outage policy">
+              <SelectValue placeholder="Select an outage policy" />
+            </SelectTrigger>
+            <SelectContent>
+              <OutagePolicySelectItems />
+            </SelectContent>
+          </Select>
+
           <Button
             onClick={() => void handleConnect()}
-            disabled={connecting || !pickerRepo || !pickerSuite}
+            disabled={
+              connecting || !pickerRepo || !pickerSuite || !pickerPolicy
+            }
           >
             <Plus className="mr-2 size-4" aria-hidden /> Connect
           </Button>
         </div>
+
+        <OutagePolicyExplainer className="space-y-1 px-4 pb-3 text-xs text-muted-foreground" />
 
         {installationReposFailed ? (
           <div className="px-4 pb-4 text-sm text-muted-foreground">

--- a/mcpjam-inspector/client/src/components/settings/GithubChecksRoute.tsx
+++ b/mcpjam-inspector/client/src/components/settings/GithubChecksRoute.tsx
@@ -346,24 +346,27 @@ export function GithubChecksRoute({
     }
   };
 
-  // Live visibility, keyed by the same normalization the connected-repo join
-  // uses. Only an explicit boolean is recorded: a repository GitHub returned
-  // without `private`, one that is not in this listing at all, and a listing
-  // that has not loaded or has failed all fall through to `undefined`, which
-  // renders no badge.
+  // ONE normalization for every repository-name comparison on this page, on
+  // both sides of every join. The backend stores the canonical lowercase form,
+  // so today only the candidate strictly needs it — but two spellings of "the
+  // same repository" is exactly how a padded listing entry earns a visibility
+  // badge from one comparison while slipping past the already-connected filter
+  // beside it, landing in the picker as an offer the submit then refuses.
+  const normalizeRepoName = (fullName: string) => fullName.trim().toLowerCase();
+
+  // Live visibility. Only an explicit boolean is recorded: a repository GitHub
+  // returned without `private`, one that is not in this listing at all, and a
+  // listing that has not loaded or has failed all fall through to `undefined`,
+  // which renders no badge.
   const visibilityByRepo = new Map<string, boolean>();
   for (const repo of installationRepos ?? []) {
     if (typeof repo.private === "boolean") {
-      visibilityByRepo.set(repo.fullName.trim().toLowerCase(), repo.private);
+      visibilityByRepo.set(normalizeRepoName(repo.fullName), repo.private);
     }
   }
 
-  // Both sides lowercased. The backend stores the canonical lowercase form, so
-  // today only the candidate strictly needs it — but relying on that means a
-  // contract change silently reintroduces duplicate offers, and normalizing
-  // both is free.
   const alreadyConnected = new Set(
-    rows.map((row) => row.repoFullName.toLowerCase())
+    rows.map((row) => normalizeRepoName(row.repoFullName))
   );
   // Offer nothing until the connected list has actually loaded. `rows` is `[]`
   // while `repos` is undefined, so filtering then would advertise repositories
@@ -372,7 +375,7 @@ export function GithubChecksRoute({
     repos === undefined
       ? []
       : (installationRepos ?? []).filter(
-          (repo) => !alreadyConnected.has(repo.fullName.toLowerCase())
+          (repo) => !alreadyConnected.has(normalizeRepoName(repo.fullName))
         );
 
   return (
@@ -449,7 +452,7 @@ export function GithubChecksRoute({
                     </span>
                     <RepoVisibilityBadge
                       isPrivate={visibilityByRepo.get(
-                        row.repoFullName.trim().toLowerCase()
+                        normalizeRepoName(row.repoFullName)
                       )}
                     />
                   </div>

--- a/mcpjam-inspector/client/src/components/settings/__tests__/github-checks-route.test.tsx
+++ b/mcpjam-inspector/client/src/components/settings/__tests__/github-checks-route.test.tsx
@@ -355,6 +355,29 @@ describe("GithubChecksRoute connect flow", () => {
     expect(connectButton()).toBeEnabled();
   });
 
+  it("does not offer a connected repository whose listing name is padded", async () => {
+    mockRepos.value = [ROW];
+    // One normalization on both sides, or none: a padded entry that earns a
+    // visibility badge from one comparison and slips past the already-connected
+    // filter beside it becomes an offer the submit is refused for.
+    mockListInstallationRepos.mockResolvedValue([
+      { fullName: " MCPJam/MCP-Check-Fixture ", private: true },
+      { fullName: "mcpjam/other-repo", private: false },
+    ]);
+    const user = userEvent.setup();
+    renderRoute();
+    await waitFor(() => expect(mockListInstallationRepos).toHaveBeenCalled());
+
+    await user.click(screen.getByLabelText("Repository"));
+
+    expect(
+      await screen.findByRole("option", { name: "mcpjam/other-repo" })
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByRole("option", { name: /MCP-Check-Fixture/i })
+    ).not.toBeInTheDocument();
+  });
+
   it("preselects neither policy", () => {
     renderRoute();
 

--- a/mcpjam-inspector/client/src/components/settings/__tests__/github-checks-route.test.tsx
+++ b/mcpjam-inspector/client/src/components/settings/__tests__/github-checks-route.test.tsx
@@ -1,4 +1,11 @@
-import { fireEvent, render, screen } from "@testing-library/react";
+import {
+  act,
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+} from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
 import { MemoryRouter, Route, Routes } from "react-router";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
@@ -8,8 +15,10 @@ const {
   mockSuites,
   mockSetRepoEnabled,
   mockSetRepoSuite,
+  mockSetRepoOutagePolicy,
   mockDisconnectRepo,
   mockConnectRepo,
+  mockConnectVerifiedRepo,
   mockListInstallationRepos,
   mockOrgsLoading,
   mockAuthLoading,
@@ -21,8 +30,13 @@ const {
   mockSuites: { value: [] as unknown[] },
   mockSetRepoEnabled: vi.fn(async () => ({ changed: true })),
   mockSetRepoSuite: vi.fn(async () => ({ changed: true })),
+  mockSetRepoOutagePolicy: vi.fn(async () => ({ changed: true })),
   mockDisconnectRepo: vi.fn(async () => ({ removed: true })),
-  mockConnectRepo: vi.fn(async () => ({ configId: "cfg-new" })),
+  // The unverified connect the backend still exposes for the two-deploy
+  // window. It is handed to the component so that reaching for it is a
+  // recorded call rather than a crash — "never called" is the assertion.
+  mockConnectRepo: vi.fn(async () => ({ configId: "cfg-legacy" })),
+  mockConnectVerifiedRepo: vi.fn(async () => ({ configId: "cfg-new" })),
   mockListInstallationRepos: vi.fn(async () => [
     { fullName: "mcpjam/other-repo" },
   ]),
@@ -40,8 +54,10 @@ vi.mock("@/hooks/useGithubChecksSettings", () => ({
     repos: mockRepos.value,
     suites: mockSuites.value,
     connectRepo: mockConnectRepo,
+    connectVerifiedRepo: mockConnectVerifiedRepo,
     setRepoEnabled: mockSetRepoEnabled,
     setRepoSuite: mockSetRepoSuite,
+    setRepoOutagePolicy: mockSetRepoOutagePolicy,
     disconnectRepo: mockDisconnectRepo,
     listInstallationRepos: mockListInstallationRepos,
   }),
@@ -67,6 +83,7 @@ vi.mock("../SettingsNav", () => ({
   SettingsNav: () => <nav data-testid="settings-nav" />,
 }));
 
+import { toast } from "@/lib/toast";
 import { GithubChecksRoute } from "../GithubChecksRoute";
 
 const ROW = {
@@ -80,8 +97,12 @@ const ROW = {
   updatedAt: 1,
 };
 
-function renderRoute(activeOrganizationId: string | null = "org-1") {
-  return render(
+/** A row connected before the outage policy existed: nothing was stored. */
+const UNSET_POLICY_ROW = ROW;
+const FAIL_OPEN_ROW = { ...ROW, outagePolicy: "fail_open" as const };
+
+function routeTree(activeOrganizationId: string | null) {
+  return (
     <MemoryRouter initialEntries={["/settings/integrations/github"]}>
       <Routes>
         <Route
@@ -95,6 +116,38 @@ function renderRoute(activeOrganizationId: string | null = "org-1") {
     </MemoryRouter>
   );
 }
+
+function renderRoute(activeOrganizationId: string | null = "org-1") {
+  return render(routeTree(activeOrganizationId));
+}
+
+/**
+ * Pick a value from one of the page's Radix selects.
+ *
+ * Radix renders its options in a portal that only exists while the trigger is
+ * open, so both halves have to happen through the real controls — which is also
+ * the only way a test sees a disabled trigger the way a user would.
+ */
+async function chooseOption(
+  user: ReturnType<typeof userEvent.setup>,
+  triggerLabel: string,
+  optionName: string | RegExp
+) {
+  await user.click(screen.getByLabelText(triggerLabel));
+  await user.click(await screen.findByRole("option", { name: optionName }));
+}
+
+/** Repository + suite + policy, in the order the page presents them. */
+async function fillConnectForm(
+  user: ReturnType<typeof userEvent.setup>,
+  policyLabel: "Fail open" | "Fail closed" = "Fail closed"
+) {
+  await chooseOption(user, "Repository", "mcpjam/other-repo");
+  await chooseOption(user, "Suite", "Fixture suite");
+  await chooseOption(user, "Outage policy", policyLabel);
+}
+
+const connectButton = () => screen.getByRole("button", { name: /Connect/ });
 
 describe("GithubChecksRoute availability gate", () => {
   beforeEach(() => {
@@ -253,5 +306,503 @@ describe("GithubChecksRoute availability gate", () => {
     expect(
       screen.queryByText(/No repositories connected yet/)
     ).not.toBeInTheDocument();
+  });
+});
+
+/**
+ * Connecting a repository is where the outage policy is DECIDED, and the
+ * decision is the point: an administrator who is never asked leaves a row the
+ * backend treats as fail-open without anyone having chosen that. So the policy
+ * is required, unselected until picked, and described before it is picked.
+ *
+ * The connect itself goes to the server-VERIFIED action, which proves the
+ * pinned installation can reach the repository before writing anything. The
+ * unverified mutation is still deployed; nothing here may call it.
+ */
+describe("GithubChecksRoute connect flow", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockAvailability.value = { state: "enabled" };
+    mockRepos.value = [];
+    mockSuites.value = [
+      { _id: "suite-1", name: "Fixture suite", projectId: "proj-1" },
+      { _id: "suite-2", name: "Second suite", projectId: "proj-1" },
+    ];
+    mockOrgsLoading.value = false;
+    mockAuthLoading.value = false;
+    mockListInstallationRepos.mockReset();
+    mockListInstallationRepos.mockResolvedValue([
+      { fullName: "mcpjam/other-repo", private: false },
+    ]);
+    mockConnectVerifiedRepo.mockReset();
+    mockConnectVerifiedRepo.mockResolvedValue({ configId: "cfg-new" });
+  });
+
+  it("keeps Connect disabled until repository, suite AND policy are chosen", async () => {
+    const user = userEvent.setup();
+    renderRoute();
+    await waitFor(() => expect(mockListInstallationRepos).toHaveBeenCalled());
+
+    expect(connectButton()).toBeDisabled();
+    await chooseOption(user, "Repository", "mcpjam/other-repo");
+    expect(connectButton()).toBeDisabled();
+    await chooseOption(user, "Suite", "Fixture suite");
+    // Repository + suite used to BE the whole form. They are not a policy, and
+    // treating them as a complete answer is what produced unstamped rows.
+    expect(connectButton()).toBeDisabled();
+
+    await chooseOption(user, "Outage policy", "Fail closed");
+    expect(connectButton()).toBeEnabled();
+  });
+
+  it("preselects neither policy", () => {
+    renderRoute();
+
+    const policy = screen.getByLabelText("Outage policy");
+    expect(policy).toHaveTextContent("Select an outage policy");
+    // A placeholder is not a choice. Showing either value here would mean the
+    // form submits a policy the administrator never read.
+    expect(policy).not.toHaveTextContent("Fail open");
+    expect(policy).not.toHaveTextContent("Fail closed");
+  });
+
+  it("sends the verified action the derived project and the explicit policy", async () => {
+    const user = userEvent.setup();
+    renderRoute();
+    await waitFor(() => expect(mockListInstallationRepos).toHaveBeenCalled());
+
+    await fillConnectForm(user, "Fail closed");
+    await user.click(connectButton());
+
+    await waitFor(() =>
+      expect(mockConnectVerifiedRepo).toHaveBeenCalledTimes(1)
+    );
+    expect(mockConnectVerifiedRepo).toHaveBeenCalledWith({
+      repoFullName: "mcpjam/other-repo",
+      // Derived from the suite, never picked separately.
+      projectId: "proj-1",
+      suiteId: "suite-1",
+      outagePolicy: "fail_closed",
+    });
+    // The unverified mutation still exists on the backend. Calling it would
+    // write a config row for a repository nobody proved the App can reach.
+    expect(mockConnectRepo).not.toHaveBeenCalled();
+  });
+
+  it("clears all three selections after a successful connect", async () => {
+    const user = userEvent.setup();
+    renderRoute();
+    await waitFor(() => expect(mockListInstallationRepos).toHaveBeenCalled());
+
+    await fillConnectForm(user, "Fail open");
+    await user.click(connectButton());
+    await waitFor(() => expect(toast.success).toHaveBeenCalled());
+
+    expect(screen.getByLabelText("Repository")).toHaveTextContent(
+      "Select a repository"
+    );
+    expect(screen.getByLabelText("Suite")).toHaveTextContent("Select a suite");
+    // Especially the policy: leaving it set would carry one repository's
+    // decision silently onto the next one connected.
+    expect(screen.getByLabelText("Outage policy")).toHaveTextContent(
+      "Select an outage policy"
+    );
+  });
+
+  it("clears the policy choice when the organization changes", async () => {
+    const user = userEvent.setup();
+    const { rerender } = render(routeTree("org-1"));
+    await waitFor(() => expect(mockListInstallationRepos).toHaveBeenCalled());
+    await fillConnectForm(user, "Fail closed");
+    expect(screen.getByLabelText("Outage policy")).toHaveTextContent(
+      "Fail closed"
+    );
+
+    rerender(routeTree("org-2"));
+
+    await waitFor(() =>
+      expect(mockListInstallationRepos).toHaveBeenCalledTimes(2)
+    );
+    expect(screen.getByLabelText("Outage policy")).toHaveTextContent(
+      "Select an outage policy"
+    );
+    expect(screen.getByLabelText("Repository")).toHaveTextContent(
+      "Select a repository"
+    );
+  });
+
+  it("shows the verified action's flat refusal and keeps the selections", async () => {
+    // The action answers refusals with one sentence on purpose — which repo the
+    // App can see is not something a caller gets to enumerate. The page repeats
+    // it verbatim rather than parsing GitHub detail out of it.
+    mockConnectVerifiedRepo.mockRejectedValueOnce(
+      new Error("Repository is not accessible to the MCPJam GitHub App.")
+    );
+    const user = userEvent.setup();
+    renderRoute();
+    await waitFor(() => expect(mockListInstallationRepos).toHaveBeenCalled());
+
+    await fillConnectForm(user, "Fail closed");
+    await user.click(connectButton());
+
+    await waitFor(() =>
+      expect(toast.error).toHaveBeenCalledWith(
+        "Repository is not accessible to the MCPJam GitHub App."
+      )
+    );
+    // Nothing was connected, so nothing is cleared: the administrator can fix
+    // the App installation and press Connect again.
+    expect(screen.getByLabelText("Repository")).toHaveTextContent(
+      "mcpjam/other-repo"
+    );
+    expect(screen.getByLabelText("Outage policy")).toHaveTextContent(
+      "Fail closed"
+    );
+  });
+
+  it("states what each policy CONCLUDES and leaves merging to branch protection", () => {
+    renderRoute();
+
+    expect(
+      screen.getByText(
+        /During an MCPJam outage or pause, the check reports neutral\./
+      )
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText(
+        /During an MCPJam outage or pause, the check reports failed\./
+      )
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText(
+        /Whether a failed or neutral check blocks merging depends on this repository's branch-protection settings\./
+      )
+    ).toBeInTheDocument();
+
+    // MCPJam sets a conclusion. Whether a conclusion stops a merge is branch
+    // protection's answer, in a repository setting this app cannot read — so
+    // any categorical merge promise here is a promise made for someone else.
+    const page = document.body.textContent ?? "";
+    for (const forbidden of [
+      /merges proceed/i,
+      /merges are blocked/i,
+      /merge will be blocked/i,
+      /cannot be merged/i,
+      /can still be merged/i,
+    ]) {
+      expect(page).not.toMatch(forbidden);
+    }
+  });
+});
+
+/**
+ * The per-row policy control, and the distinction it has to keep visible:
+ * a row with `fail_open` STORED and a row with nothing stored behave the same
+ * way at conclusion time, and are not the same thing. One is a decision; the
+ * other is a decision nobody has made yet.
+ */
+describe("GithubChecksRoute row outage policy", () => {
+  const POLICY_LABEL = "Outage policy for mcpjam/mcp-check-fixture";
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockAvailability.value = { state: "enabled" };
+    mockSuites.value = [
+      { _id: "suite-1", name: "Fixture suite", projectId: "proj-1" },
+    ];
+    mockOrgsLoading.value = false;
+    mockAuthLoading.value = false;
+    mockListInstallationRepos.mockReset();
+    mockListInstallationRepos.mockResolvedValue([]);
+    mockSetRepoOutagePolicy.mockReset();
+    mockSetRepoOutagePolicy.mockResolvedValue({ changed: true });
+  });
+
+  it("shows a stored policy as the selected value and writes a change", async () => {
+    mockRepos.value = [FAIL_OPEN_ROW];
+    const user = userEvent.setup();
+    renderRoute();
+
+    expect(screen.getByLabelText(POLICY_LABEL)).toHaveTextContent("Fail open");
+
+    await chooseOption(user, POLICY_LABEL, "Fail closed");
+
+    expect(mockSetRepoOutagePolicy).toHaveBeenCalledWith({
+      configId: "cfg-1",
+      outagePolicy: "fail_closed",
+    });
+  });
+
+  it("says a legacy row has no policy instead of showing fail open", () => {
+    mockRepos.value = [UNSET_POLICY_ROW];
+    renderRoute();
+
+    const policy = screen.getByLabelText(POLICY_LABEL);
+    expect(policy).toHaveTextContent("Policy not chosen");
+    // Binding the control to `fail_open` would render somebody else's default
+    // as this administrator's choice.
+    expect(policy).not.toHaveTextContent("Fail open");
+    expect(screen.getByText(/No outage policy chosen/)).toBeInTheDocument();
+    // …and the behaviour it actually has today is still stated.
+    expect(screen.getByText(/effectively fails open/)).toBeInTheDocument();
+  });
+
+  it("persists an explicit choice made on a row that had none", async () => {
+    mockRepos.value = [UNSET_POLICY_ROW];
+    const user = userEvent.setup();
+    renderRoute();
+
+    await chooseOption(user, POLICY_LABEL, "Fail open");
+
+    // Same value the backend would have assumed, now actually recorded.
+    expect(mockSetRepoOutagePolicy).toHaveBeenCalledWith({
+      configId: "cfg-1",
+      outagePolicy: "fail_open",
+    });
+  });
+
+  it("treats a silent no-op as success", async () => {
+    mockRepos.value = [FAIL_OPEN_ROW];
+    mockSetRepoOutagePolicy.mockResolvedValue({ changed: false });
+    const user = userEvent.setup();
+    renderRoute();
+
+    await chooseOption(user, POLICY_LABEL, "Fail closed");
+
+    await waitFor(() => expect(mockSetRepoOutagePolicy).toHaveBeenCalled());
+    expect(toast.error).not.toHaveBeenCalled();
+  });
+
+  it("reports a failed policy write through the existing write-error toast", async () => {
+    mockRepos.value = [FAIL_OPEN_ROW];
+    mockSetRepoOutagePolicy.mockRejectedValueOnce(new Error("network"));
+    const user = userEvent.setup();
+    renderRoute();
+
+    await chooseOption(user, POLICY_LABEL, "Fail closed");
+
+    await waitFor(() => expect(toast.error).toHaveBeenCalledWith("network"));
+  });
+
+  it("disables the policy control while its write is in flight and drops a duplicate", async () => {
+    mockRepos.value = [FAIL_OPEN_ROW];
+    let release: (() => void) | undefined;
+    mockSetRepoOutagePolicy.mockImplementationOnce(
+      () =>
+        new Promise((resolve) => {
+          release = () => resolve({ changed: true });
+        })
+    );
+    const user = userEvent.setup();
+    renderRoute();
+
+    await chooseOption(user, POLICY_LABEL, "Fail closed");
+
+    // The select stays bound to the SERVER snapshot until the list refreshes,
+    // so a second change made before the first settles would be decided against
+    // a row state that is already moving. Both halves of the guard hang off the
+    // same pending set: the control goes disabled, and the handler drops a
+    // change for a row it is already writing.
+    const policy = screen.getByLabelText(POLICY_LABEL);
+    expect(policy).toBeDisabled();
+    await user.click(policy);
+    expect(screen.queryByRole("option")).not.toBeInTheDocument();
+    expect(mockSetRepoOutagePolicy).toHaveBeenCalledTimes(1);
+
+    release?.();
+    await waitFor(() =>
+      expect(screen.getByLabelText(POLICY_LABEL)).toBeEnabled()
+    );
+  });
+
+  it("leaves the enable toggle usable while a policy write is pending", async () => {
+    mockRepos.value = [FAIL_OPEN_ROW];
+    mockSetRepoOutagePolicy.mockImplementationOnce(() => new Promise(() => {}));
+    const user = userEvent.setup();
+    renderRoute();
+
+    await chooseOption(user, POLICY_LABEL, "Fail closed");
+
+    // Two different writes on one row. Sharing a pending set would freeze a
+    // control the user has no reason to think is busy.
+    expect(
+      screen.getByLabelText("Enable checks for mcpjam/mcp-check-fixture")
+    ).toBeEnabled();
+  });
+});
+
+/**
+ * Visibility is a LIVE GitHub fact, joined from the installation listing and
+ * persisted nowhere. Everything that is not an explicit boolean is unknown, and
+ * unknown renders nothing — labelling a private repository "Public" on the
+ * owner's own settings page is the one mistake this join must never make.
+ */
+describe("GithubChecksRoute repository visibility", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockAvailability.value = { state: "enabled" };
+    mockSuites.value = [
+      { _id: "suite-1", name: "Fixture suite", projectId: "proj-1" },
+    ];
+    mockOrgsLoading.value = false;
+    mockAuthLoading.value = false;
+    mockRepos.value = [ROW];
+    mockListInstallationRepos.mockReset();
+  });
+
+  it("badges private and public from the live listing, joined case-insensitively", async () => {
+    mockRepos.value = [
+      ROW,
+      { ...ROW, _id: "cfg-2", repoFullName: "mcpjam/public-fixture" },
+    ];
+    // GitHub answers with its own casing, and the row stores the canonical
+    // lowercase form. Both sides are normalized so the join survives that.
+    mockListInstallationRepos.mockResolvedValue([
+      { fullName: "MCPJam/MCP-Check-Fixture", private: true },
+      { fullName: " mcpjam/Public-Fixture ", private: false },
+    ]);
+    renderRoute();
+
+    expect(await screen.findByText("Private")).toBeInTheDocument();
+    expect(screen.getByText("Public")).toBeInTheDocument();
+  });
+
+  it.each([
+    [
+      "GitHub omitted the flag",
+      [{ fullName: "mcpjam/mcp-check-fixture" }] as unknown[],
+    ],
+    [
+      "the row is not in the installation listing",
+      [{ fullName: "mcpjam/other-repo", private: false }] as unknown[],
+    ],
+    ["the listing is empty", [] as unknown[]],
+  ])("asserts no visibility when %s", async (_case, listing) => {
+    mockListInstallationRepos.mockResolvedValue(listing);
+    renderRoute();
+
+    await waitFor(() => expect(mockListInstallationRepos).toHaveBeenCalled());
+    // A connected repository can legitimately be missing from the current
+    // listing; the row stays, only the claim goes.
+    expect(screen.getByText("mcpjam/mcp-check-fixture")).toBeInTheDocument();
+    expect(screen.queryByText("Public")).not.toBeInTheDocument();
+    expect(screen.queryByText("Private")).not.toBeInTheDocument();
+  });
+
+  it("asserts no visibility when the listing fails", async () => {
+    mockListInstallationRepos.mockRejectedValue(new Error("network"));
+    renderRoute();
+
+    expect(
+      await screen.findByText(/Could not load repositories from GitHub/)
+    ).toBeInTheDocument();
+    // An outage is not evidence that anything is public.
+    expect(screen.queryByText("Public")).not.toBeInTheDocument();
+    expect(screen.queryByText("Private")).not.toBeInTheDocument();
+  });
+
+  it("shows no visibility while the listing is still loading", () => {
+    mockListInstallationRepos.mockImplementation(() => new Promise(() => {}));
+    renderRoute();
+
+    expect(screen.getByText("mcpjam/mcp-check-fixture")).toBeInTheDocument();
+    expect(screen.queryByText("Public")).not.toBeInTheDocument();
+  });
+});
+
+/**
+ * Switching organizations while requests are in flight.
+ *
+ * The component stays mounted across the switch, so every pending promise
+ * resolves onto a page that is now showing a DIFFERENT organization. None of
+ * them may land there: not the repository listing (it would badge the new org's
+ * rows with the old org's visibility), and not a connect (it would clear a
+ * fresh selection and announce a repository connected to an org it was not).
+ */
+describe("GithubChecksRoute organization switching", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockAvailability.value = { state: "enabled" };
+    mockSuites.value = [
+      { _id: "suite-1", name: "Fixture suite", projectId: "proj-1" },
+    ];
+    mockOrgsLoading.value = false;
+    mockAuthLoading.value = false;
+    mockListInstallationRepos.mockReset();
+    mockConnectVerifiedRepo.mockReset();
+    mockConnectVerifiedRepo.mockResolvedValue({ configId: "cfg-new" });
+  });
+
+  it("drops a listing that arrives after the organization changed", async () => {
+    mockRepos.value = [ROW];
+    let resolveStale: ((repos: unknown[]) => void) | undefined;
+    mockListInstallationRepos
+      .mockImplementationOnce(
+        () =>
+          new Promise((resolve) => {
+            resolveStale = resolve as (repos: unknown[]) => void;
+          })
+      )
+      .mockResolvedValue([
+        { fullName: "mcpjam/mcp-check-fixture", private: false },
+      ]);
+
+    const { rerender } = render(routeTree("org-1"));
+    rerender(routeTree("org-2"));
+    await waitFor(() =>
+      expect(mockListInstallationRepos).toHaveBeenCalledTimes(2)
+    );
+    expect(await screen.findByText("Public")).toBeInTheDocument();
+
+    // org-1's answer, arriving late and disagreeing.
+    await act(async () => {
+      resolveStale?.([{ fullName: "mcpjam/mcp-check-fixture", private: true }]);
+    });
+
+    expect(screen.getByText("Public")).toBeInTheDocument();
+    expect(screen.queryByText("Private")).not.toBeInTheDocument();
+  });
+
+  it("drops a connect that completes after the organization changed", async () => {
+    mockRepos.value = [];
+    mockListInstallationRepos.mockResolvedValue([
+      { fullName: "mcpjam/other-repo", private: false },
+    ]);
+    let resolveStaleConnect: ((result: unknown) => void) | undefined;
+    mockConnectVerifiedRepo.mockImplementationOnce(
+      () =>
+        new Promise((resolve) => {
+          resolveStaleConnect = resolve as (result: unknown) => void;
+        })
+    );
+
+    const user = userEvent.setup();
+    const { rerender } = render(routeTree("org-1"));
+    await waitFor(() => expect(mockListInstallationRepos).toHaveBeenCalled());
+    await fillConnectForm(user, "Fail closed");
+    await user.click(connectButton());
+    await waitFor(() =>
+      expect(mockConnectVerifiedRepo).toHaveBeenCalledTimes(1)
+    );
+
+    rerender(routeTree("org-2"));
+    await waitFor(() =>
+      expect(mockListInstallationRepos).toHaveBeenCalledTimes(2)
+    );
+    await fillConnectForm(user, "Fail open");
+
+    await act(async () => {
+      resolveStaleConnect?.({ configId: "cfg-new" });
+    });
+
+    // No success for an organization the user has left…
+    expect(toast.success).not.toHaveBeenCalled();
+    // …and the selections just made for THIS organization survive.
+    expect(screen.getByLabelText("Repository")).toHaveTextContent(
+      "mcpjam/other-repo"
+    );
+    expect(screen.getByLabelText("Outage policy")).toHaveTextContent(
+      "Fail open"
+    );
   });
 });

--- a/mcpjam-inspector/client/src/components/settings/github-checks-outage-policy.tsx
+++ b/mcpjam-inspector/client/src/components/settings/github-checks-outage-policy.tsx
@@ -1,0 +1,63 @@
+import { SelectItem } from "@mcpjam/design-system/select";
+import type { GithubCheckOutagePolicy } from "@/hooks/useGithubChecksSettings";
+
+/**
+ * The outage-policy vocabulary, in ONE place because two surfaces connect a
+ * repository — Settings → Integrations → GitHub, and the suite's own "run this
+ * on every pull request" section — and the two must not describe the same
+ * stored value differently.
+ *
+ * The wording is the careful part. MCPJam decides what the check CONCLUDES
+ * (`neutral` for fail open, `failure` for fail closed) and nothing beyond that.
+ * Whether either conclusion stops a merge is branch protection's answer, which
+ * lives in the repository's GitHub settings — MCPJam can neither read it nor
+ * set it. So "merges proceed" and "merges are blocked" are promises made on
+ * someone else's behalf, and copy here never makes them: it states the
+ * conclusion, then names branch protection as the thing that acts on it.
+ */
+export const OUTAGE_POLICY_LABELS: Record<GithubCheckOutagePolicy, string> = {
+  fail_open: "Fail open",
+  fail_closed: "Fail closed",
+};
+
+/** The two options, for any `SelectContent` that offers the policy. */
+export function OutagePolicySelectItems() {
+  return (
+    <>
+      <SelectItem value="fail_open">
+        {OUTAGE_POLICY_LABELS.fail_open}
+      </SelectItem>
+      <SelectItem value="fail_closed">
+        {OUTAGE_POLICY_LABELS.fail_closed}
+      </SelectItem>
+    </>
+  );
+}
+
+/**
+ * What each policy means, shown BEFORE the choice rather than inside the
+ * dropdown: an option label cannot say what the check will conclude, and this
+ * is the decision an administrator is least likely to revisit later.
+ */
+export function OutagePolicyExplainer({ className }: { className?: string }) {
+  return (
+    <div className={className}>
+      <p>
+        <span className="font-medium text-foreground">
+          {OUTAGE_POLICY_LABELS.fail_open}:
+        </span>{" "}
+        During an MCPJam outage or pause, the check reports neutral.
+      </p>
+      <p>
+        <span className="font-medium text-foreground">
+          {OUTAGE_POLICY_LABELS.fail_closed}:
+        </span>{" "}
+        During an MCPJam outage or pause, the check reports failed.
+      </p>
+      <p>
+        Whether a failed or neutral check blocks merging depends on this
+        repository&apos;s branch-protection settings.
+      </p>
+    </div>
+  );
+}

--- a/mcpjam-inspector/client/src/hooks/__tests__/useGithubChecksSettings.test.tsx
+++ b/mcpjam-inspector/client/src/hooks/__tests__/useGithubChecksSettings.test.tsx
@@ -1,21 +1,56 @@
 import { render, screen } from "@testing-library/react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
-const mocks = vi.hoisted(() => ({
-  user: { value: null as { id: string } | null },
-  isAuthenticated: { value: true },
-  isUserReady: { value: true },
-  useQuery: vi.fn(),
-  reportBoundaryError: vi.fn(),
-}));
+const mocks = vi.hoisted(() => {
+  /**
+   * One stable handle per bound backend function, keyed `kind:name`.
+   *
+   * The map is the point. `useAction`/`useMutation` are where this hook DECLARES
+   * which backend functions the settings surface may call, and that declaration
+   * is a contract in its own right — the unverified `connectRepo` mutation is
+   * still deployed, still callable, and the only thing keeping it out of the
+   * product is that nothing here binds it. A test that only watched call
+   * arguments could not see it come back.
+   *
+   * Stable identity also matters mechanically: the hook memoizes its callbacks
+   * on these handles, so a fresh `vi.fn()` per render would churn every
+   * `useCallback` and quietly defeat the memoization the component depends on.
+   */
+  const handles = new Map<string, ReturnType<typeof vi.fn>>();
+  const requests: Array<{ kind: string; name: string; args: unknown }> = [];
+  return {
+    user: { value: null as { id: string } | null },
+    isAuthenticated: { value: true },
+    isUserReady: { value: true },
+    useQuery: vi.fn(),
+    reportBoundaryError: vi.fn(),
+    handles,
+    requests,
+    handleFor(kind: "action" | "mutation", name: string) {
+      const key = `${kind}:${name}`;
+      const existing = handles.get(key);
+      if (existing) return existing;
+      const handle = vi.fn(async (args: unknown) => {
+        requests.push({ kind, name, args });
+        return { ok: true };
+      });
+      handles.set(key, handle);
+      return handle;
+    },
+    resetConvexBindings() {
+      handles.clear();
+      requests.length = 0;
+    },
+  };
+});
 
 vi.mock("@workos-inc/authkit-react", () => ({
   useAuth: () => ({ user: mocks.user.value, isLoading: false }),
 }));
 
 vi.mock("convex/react", () => ({
-  useAction: () => vi.fn(),
-  useMutation: () => vi.fn(),
+  useAction: (name: string) => mocks.handleFor("action", name),
+  useMutation: (name: string) => mocks.handleFor("mutation", name),
   useConvexAuth: () => ({
     isAuthenticated: mocks.isAuthenticated.value,
     isLoading: false,
@@ -34,7 +69,10 @@ vi.mock("@/lib/error-reporting", () => ({
 
 import { ErrorBoundary } from "@/components/ui/error-boundary";
 import { ConvexError } from "convex/values";
-import { useGithubChecksAvailability } from "../useGithubChecksSettings";
+import {
+  useGithubChecksAvailability,
+  useGithubChecksSettings,
+} from "../useGithubChecksSettings";
 
 function AvailabilityProbe({
   organizationId,
@@ -145,5 +183,140 @@ describe("useGithubChecksAvailability", () => {
     } finally {
       consoleError.mockRestore();
     }
+  });
+});
+
+/**
+ * The write surface: WHICH backend functions this hook binds, and exactly what
+ * it sends them.
+ *
+ * Both halves are load-bearing. Connecting a repository moved to a Node action
+ * that proves the pinned installation can actually reach the repository before
+ * it writes anything; the unverified `checkRepoConfigs:connectRepo` mutation is
+ * still deployed for the two-deploy window and would work if it were bound
+ * again, silently giving back a config row nobody verified. And the arguments
+ * are the contract — `organizationId` is added here so no call site can forget
+ * it, and `installationId` is a server-side fact the client never names.
+ */
+describe("useGithubChecksSettings writes", () => {
+  function SettingsProbe() {
+    const settings = useGithubChecksSettings("org-1");
+    return (
+      <div>
+        <button
+          type="button"
+          onClick={() =>
+            void settings.connectVerifiedRepo({
+              repoFullName: "mcpjam/mcp-check-fixture",
+              projectId: "proj-1",
+              suiteId: "suite-1",
+              outagePolicy: "fail_closed",
+            })
+          }
+        >
+          connect
+        </button>
+        <button
+          type="button"
+          onClick={() =>
+            void settings.setRepoOutagePolicy({
+              configId: "cfg-1",
+              outagePolicy: "fail_open",
+            })
+          }
+        >
+          set policy
+        </button>
+        <div data-testid="exposed">
+          {Object.keys(settings).sort().join(",")}
+        </div>
+      </div>
+    );
+  }
+
+  beforeEach(() => {
+    mocks.user.value = { id: "user-1" };
+    mocks.isAuthenticated.value = true;
+    mocks.isUserReady.value = true;
+    mocks.resetConvexBindings();
+    vi.clearAllMocks();
+    mocks.useQuery.mockImplementation((name: unknown, args: unknown) => {
+      if (args === "skip") return undefined;
+      if (String(name).endsWith("getGithubChecksSettingsAvailability")) {
+        return { state: "enabled" };
+      }
+      return [];
+    });
+  });
+
+  it("binds exactly the backend functions this surface is allowed to call", () => {
+    render(<SettingsProbe />);
+
+    // An exact set, not a subset: adding a binding is a deliberate act, and
+    // RE-adding `github/checkRepoConfigs:connectRepo` — the unverified connect
+    // this UI exists to stop using — has to fail here rather than ship.
+    expect([...mocks.handles.keys()].sort()).toEqual(
+      [
+        "action:github/checkRepoConfigsNode:connectVerifiedRepo",
+        "action:github/checkRepoConfigsNode:listInstallationRepos",
+        "mutation:github/checkRepoConfigs:disconnectRepo",
+        "mutation:github/checkRepoConfigs:setRepoEnabled",
+        "mutation:github/checkRepoConfigs:setRepoOutagePolicy",
+        "mutation:github/checkRepoConfigs:setRepoSuite",
+      ].sort()
+    );
+    expect(
+      mocks.handles.has("mutation:github/checkRepoConfigs:connectRepo")
+    ).toBe(false);
+  });
+
+  it("does not expose a legacy connect callback to call sites", () => {
+    render(<SettingsProbe />);
+
+    const exposed = screen.getByTestId("exposed").textContent?.split(",") ?? [];
+    expect(exposed).toContain("connectVerifiedRepo");
+    expect(exposed).toContain("setRepoOutagePolicy");
+    expect(exposed).not.toContain("connectRepo");
+  });
+
+  it("connects through the verified Node action with the org and the explicit policy", () => {
+    render(<SettingsProbe />);
+
+    screen.getByText("connect").click();
+
+    expect(mocks.requests).toEqual([
+      {
+        kind: "action",
+        name: "github/checkRepoConfigsNode:connectVerifiedRepo",
+        // Exactly these five. No `installationId`: which installation can reach
+        // the repository is resolved and proved server-side, and a client that
+        // could name one would be a client that could pick the wrong one.
+        args: {
+          organizationId: "org-1",
+          repoFullName: "mcpjam/mcp-check-fixture",
+          projectId: "proj-1",
+          suiteId: "suite-1",
+          outagePolicy: "fail_closed",
+        },
+      },
+    ]);
+  });
+
+  it("sets a repository's outage policy through the org-scoped mutation", () => {
+    render(<SettingsProbe />);
+
+    screen.getByText("set policy").click();
+
+    expect(mocks.requests).toEqual([
+      {
+        kind: "mutation",
+        name: "github/checkRepoConfigs:setRepoOutagePolicy",
+        args: {
+          organizationId: "org-1",
+          configId: "cfg-1",
+          outagePolicy: "fail_open",
+        },
+      },
+    ]);
   });
 });

--- a/mcpjam-inspector/client/src/hooks/useGithubChecksSettings.ts
+++ b/mcpjam-inspector/client/src/hooks/useGithubChecksSettings.ts
@@ -50,6 +50,17 @@ export type GithubChecksAvailability =
   | { state: "enabled" | "disabled" }
   | undefined;
 
+/**
+ * What the check concludes when MCPJam cannot run the suite — an outage, or a
+ * paused row.
+ *
+ * `fail_open` concludes `neutral`, `fail_closed` concludes `failure`. MCPJam
+ * decides the CONCLUSION and nothing else: whether either one stops a merge is
+ * branch protection's answer, which lives in GitHub and which this app can
+ * neither read nor set. Copy on this surface must never promise a merge result.
+ */
+export type GithubCheckOutagePolicy = "fail_open" | "fail_closed";
+
 export type GithubCheckRepoConfigRow = {
   _id: string;
   repoFullName: string;
@@ -57,11 +68,27 @@ export type GithubCheckRepoConfigRow = {
   organizationId: string;
   projectId: string;
   suiteId: string;
+  /**
+   * Absent on rows connected before the policy existed. Absent is NOT
+   * `fail_open`: the backend treats it as fail-open at conclusion time, but
+   * nobody chose it, and the settings page says exactly that rather than
+   * rendering a choice that was never stored.
+   */
+  outagePolicy?: GithubCheckOutagePolicy;
   createdAt: number;
   updatedAt: number;
 };
 
-export type InstallationRepo = { fullName: string };
+export type InstallationRepo = {
+  fullName: string;
+  /**
+   * GitHub's live `private` flag. Optional because GitHub can omit it, and
+   * never persisted anywhere — visibility can change under a connected
+   * repository at any time. Absent means UNKNOWN, and the UI shows no badge
+   * rather than asserting "public".
+   */
+  private?: boolean;
+};
 
 export type SuiteOption = {
   _id: string;
@@ -128,14 +155,23 @@ export function useGithubChecksSettings(
     ?.map((entry) => entry.suite)
     .filter((suite): suite is SuiteOption => Boolean(suite?._id));
 
-  const connectRepoMutation = useMutation(
-    "github/checkRepoConfigs:connectRepo" as any
+  // The SERVER-VERIFIED connect, and the only connect path this app uses. It is
+  // an action rather than a mutation because proving the pinned installation can
+  // actually reach the repository takes a GitHub round trip, which a mutation
+  // cannot make — and it is the action that stamps the row's installation id.
+  // The unverified `checkRepoConfigs:connectRepo` mutation survives only for the
+  // two-deploy compatibility window and must not be called from here.
+  const connectVerifiedRepoAction = useAction(
+    "github/checkRepoConfigsNode:connectVerifiedRepo" as any
   );
   const setRepoEnabledMutation = useMutation(
     "github/checkRepoConfigs:setRepoEnabled" as any
   );
   const setRepoSuiteMutation = useMutation(
     "github/checkRepoConfigs:setRepoSuite" as any
+  );
+  const setRepoOutagePolicyMutation = useMutation(
+    "github/checkRepoConfigs:setRepoOutagePolicy" as any
   );
   const disconnectRepoMutation = useMutation(
     "github/checkRepoConfigs:disconnectRepo" as any
@@ -144,10 +180,23 @@ export function useGithubChecksSettings(
     "github/checkRepoConfigsNode:listInstallationRepos" as any
   );
 
-  const connectRepo = useCallback(
-    (args: { repoFullName: string; projectId: string; suiteId: string }) =>
-      connectRepoMutation({ organizationId, ...args } as any),
-    [connectRepoMutation, organizationId]
+  /**
+   * `outagePolicy` is REQUIRED here even though the backend accepts it as
+   * optional. Omitting it there means "no policy stored"; omitting it at
+   * onboarding would mean the administrator was never asked, which is the state
+   * this surface exists to stop producing.
+   */
+  const connectVerifiedRepo = useCallback(
+    (args: {
+      repoFullName: string;
+      projectId: string;
+      suiteId: string;
+      outagePolicy: GithubCheckOutagePolicy;
+    }) =>
+      connectVerifiedRepoAction({ organizationId, ...args } as any) as Promise<{
+        configId: string;
+      }>,
+    [connectVerifiedRepoAction, organizationId]
   );
 
   const setRepoEnabled = useCallback(
@@ -160,6 +209,17 @@ export function useGithubChecksSettings(
     (args: { configId: string; projectId: string; suiteId: string }) =>
       setRepoSuiteMutation({ organizationId, ...args } as any),
     [setRepoSuiteMutation, organizationId]
+  );
+
+  const setRepoOutagePolicy = useCallback(
+    (args: { configId: string; outagePolicy: GithubCheckOutagePolicy }) =>
+      setRepoOutagePolicyMutation({
+        organizationId,
+        ...args,
+      } as any) as Promise<{
+        changed: boolean;
+      }>,
+    [setRepoOutagePolicyMutation, organizationId]
   );
 
   const disconnectRepo = useCallback(
@@ -181,9 +241,10 @@ export function useGithubChecksSettings(
     isEnabled,
     repos,
     suites,
-    connectRepo,
+    connectVerifiedRepo,
     setRepoEnabled,
     setRepoSuite,
+    setRepoOutagePolicy,
     disconnectRepo,
     listInstallationRepos,
   };


### PR DESCRIPTION
Finishes the Inspector settings experience for GitHub Checks: the outage policy becomes a required, explicit choice when a repository is connected, administrators can change it per row, connected rows show live repository visibility, and connecting goes through the backend's server-verified action.

## The verified connect

Connecting now calls `github/checkRepoConfigsNode:connectVerifiedRepo` — the action added in backend PR #1024. It proves the pinned installation can actually reach the repository before any row is written, and stamps the installation id server-side. The client sends exactly five fields (`organizationId`, `projectId`, `suiteId`, `repoFullName`, `outagePolicy`) and never names an installation id: which installation can reach a repository is a server-side fact, and a client that could name one is a client that could name the wrong one.

**The legacy unverified `github/checkRepoConfigs:connectRepo` mutation is no longer used by Inspector and can be removed in the follow-up backend cleanup deploy.** That required migrating the second connect surface too — the suite's own "run this on every pull request" section (`suite-github-checks-section.tsx`) also called it, so leaving it alone would have kept the mutation load-bearing and kept producing rows nobody verified or chose a policy for. A hook test asserts the exact set of backend functions this surface binds, so re-adding the legacy mutation fails rather than ships.

The action's refusals are deliberately flat (`Repository is not accessible to the MCPJam GitHub App.`, `GitHub could not be reached right now. Please try again.`); the page repeats them verbatim through the existing write-error toast rather than parsing GitHub detail out of them.

## Policy is an explicit onboarding choice

Neither value is preselected and Connect stays disabled until repository, suite and policy are all chosen; the submit guard enforces the same rule independently of the button's disabled state. Both options are described before the choice is made, as check **conclusions**:

- Fail open — during an MCPJam outage or pause, the check reports neutral.
- Fail closed — during an MCPJam outage or pause, the check reports failed.
- Whether a failed or neutral check blocks merging depends on this repository's branch-protection settings.

**Branch protection, not MCPJam, decides whether any conclusion blocks merging.** MCPJam sets the check's conclusion and can neither read nor set branch protection, so no copy on this surface promises a merge result; a test asserts the qualification is present and that categorical merge promises are absent. The three sentences live in one small shared module so the two connect surfaces cannot drift apart on them.

**Old unstamped rows stay visibly distinguishable and effectively fail-open.** A row connected before the policy existed shows "Policy not chosen" and states that it effectively fails open — the control is *not* bound to `fail_open`, because that would render a decision nobody made. Choosing either value on such a row records it explicitly (the backend counts that as a change, which is the point). A row's policy control is disabled while its write is in flight and drops a duplicate change until it settles, tracked separately from the enable/disable pending set so neither control freezes the other. `{ changed: false }` is silent success.

## Visibility

**Visibility is joined from live GitHub data and never guessed or persisted.** Connected rows are matched to `listInstallationRepos` on trimmed/lowercased `fullName` on both sides. Only an explicit `private` boolean produces a badge: a repository GitHub returned without the flag, one absent from the current listing, a listing still loading, and a listing that failed all render no badge, because none of them is evidence that a repository is public. A connected repository legitimately missing from the listing keeps its row and loses only the claim. The badge is informational — **Inspector PR #4097 already supplies private-repository clone support**, so nothing here gates a capability.

Switching organizations mid-flight cannot leak either way: a listing or a connect that completes after the switch is dropped, so it cannot badge the new organization's rows with the previous organization's visibility, clear a fresh selection, or announce a repository connected to an organization it was not.

## Tests

Run from `mcpjam-inspector/`:

- `npx vitest run client/src/components/settings/__tests__/github-checks-route.test.tsx client/src/hooks/__tests__/useGithubChecksSettings.test.tsx` — 46 passed (35 route, 11 hook).
- `npx vitest run --root client src/components/evals/__tests__/suite-github-checks-section.test.tsx` — 10 passed.
- Every other test file touching this surface (`settings-nav`, `integrations-route`, `SettingsTab`, both `OrganizationsTab` files, `suite-iterations-github-checks`) — passed.
- `npm run typecheck:client` — clean.
- `npx prettier --check` on every touched file — clean.

Each new behavioural test was probed against a deliberately broken implementation and confirmed red before being accepted: the legacy mutation rebound, the policy dropped from the request, a preselected policy, a policy-less Connect button, an unset row bound to `fail_open`, the row pending-write tracking removed, unknown visibility rendered as Public, a case-sensitive join, the per-organization reset removed, a stale connect allowed to land, and merge-promise copy.

**Staging verification still needs an operator.** Nothing here can prove the end-to-end path: that the pinned installation actually verifies a real repository, that a refusal renders as the flat sentence rather than a stack, and that a connected row comes back from the backend carrying the policy it was connected with, are all deployment-shaped facts that need a staging org with the GitHub App installed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016yZQq51cQv5dJgnvZVPyim

---
_Generated by [Claude Code](https://claude.ai/code/session_016yZQq51cQv5dJgnvZVPyim)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes affect PR check configuration and backend connect contracts; behavior is heavily tested but still depends on coordinated backend deploy and staging verification.
> 
> **Overview**
> **GitHub Checks onboarding** now requires an explicit **outage policy** (fail open / fail closed) before Connect is enabled, with shared copy that describes check conclusions and avoids promising merge outcomes. Both **Settings → Integrations → GitHub** and the suite **“run on every PR”** section use the same controls and explainer module.
> 
> **Connecting** no longer calls the unverified `connectRepo` mutation; it uses **`connectVerifiedRepo`**, sending org, repo, suite/project, and policy only (no client `installationId`). The hook drops the legacy callback and tests lock the allowed Convex bindings.
> 
> On **connected rows**, admins can change outage policy (separate in-flight state from the enable toggle). Rows **without a stored policy** show “Policy not chosen” and explain effective fail-open behavior instead of displaying `fail_open` as if it were chosen. **Private/Public** badges come from a live, case-insensitive join to `listInstallationRepos` only when GitHub returns an explicit `private` boolean.
> 
> **Org switches** reset pickers and ignore stale listing/connect completions so visibility, toasts, and form state do not leak across organizations.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 85331f3b8408ca34cf9141b5c2e45c3632affa35. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Requires an explicit outage policy when connecting GitHub Checks and routes all connects through the server-verified action. This removes unverified connects, makes policy intent explicit, and fixes repo-name joins and stale-org toasts.

- Both connect surfaces now call `github/checkRepoConfigsNode:connectVerifiedRepo`. The client sends only `organizationId`, `projectId`, `suiteId`, `repoFullName`, and `outagePolicy` and never names an installation id. The legacy `github/checkRepoConfigs:connectRepo` mutation is unused.
- Connect UI and the suite “run on every PR” section: no default policy; Connect stays disabled until repository, suite, and policy are chosen. Copy names conclusions only (fail-open → neutral, fail-closed → failure) and defers merge behavior to branch protection.
- Existing rows without `outagePolicy` show “Policy not chosen” and explain they effectively fail open; choosing a value records it. Policy writes are tracked separately from enable toggles; controls disable during in-flight writes and drop duplicates; `{ changed: false }` is silent.
- Visibility badges use a single normalization (trim + lowercase) for all comparisons. A case-insensitive join to `listInstallationRepos` supplies visibility; only an explicit `private` boolean renders a badge; unknown renders nothing; visibility is never persisted.
- Org switches: pickers (including policy) reset, and connects/listings that resolve after a switch are ignored to avoid cross-org leaks and toasts. The suite section guards against toasts after unmount.

**Rollout**
- Deploy the backend action `github/checkRepoConfigsNode:connectVerifiedRepo`. After this ships, remove `github/checkRepoConfigs:connectRepo`.
- Verify on staging: refused connects show flat messages; successful connects return rows stamped with the chosen policy.
- No data migration required; administrators should choose a policy for any “Policy not chosen” rows as needed.

<sup>Written for commit 6a3e6c04dd7dfca5a19b8b373fe5490511fe48dc. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/MCPJam/inspector/pull/4104?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

