### PR TITLE
feat(mcp): Automatic negotiates within the client's declared support list

### DIFF
--- a/sdk/src/mcp-client-manager/MCPClientManager.ts
+++ b/sdk/src/mcp-client-manager/MCPClientManager.ts
@@ -2340,16 +2340,13 @@ export class MCPClientManager {
       const wantsStateless =
         resolvedProtocolVersion !== undefined &&
         isStatelessProtocolVersion(resolvedProtocolVersion);
-      // Resolve negotiation before the legacy initialize accept-list so Auto
-      // has one source of truth. An unpinned connection probes the modern era
-      // first and, on a legacy signal, must fall back with the upstream SDK's
-      // complete built-in supported-version list. Forwarding a persisted
-      // per-server or manager-default list here can make the first connection
-      // succeed but a later reconnect reject the server's valid counter-offer.
+      // Resolve negotiation independently from the client's support list. The
+      // list says which revisions the client can speak; the selection says
+      // whether to auto-negotiate or pin one era. Upstream uses the same list
+      // to constrain modern discovery candidates and legacy fallback.
       const versionNegotiation = resolveVersionNegotiation(
         resolvedProtocolVersion
       );
-      const wantsAutoNegotiation = versionNegotiation?.mode === "auto";
       // Stateful `mcpProtocolVersion` pin (e.g. `"2025-11-25"`) propagates
       // into the legacy `Client`'s `supportedProtocolVersions` accept-list
       // so `initialize.params.protocolVersion` actually goes out as the
@@ -2357,15 +2354,16 @@ export class MCPClientManager {
       // explicit `supportedProtocolVersions` (per-server or default) still
       // wins for an explicit pin — pinning at one layer while overriding the
       // other would be ambiguous and the override is the more specific signal.
-      // Auto deliberately ignores both lists so its legacy fallback negotiates
-      // against every version supported by the upstream SDK.
-      const resolvedSupportedProtocolVersions = wantsAutoNegotiation
-        ? undefined
-        : config.supportedProtocolVersions ??
-          this.defaultSupportedProtocolVersions ??
-          (!wantsStateless && resolvedProtocolVersion !== undefined
-            ? [resolvedProtocolVersion]
-            : undefined);
+      // Automatic mode honors the same declared support list. This is what
+      // lets a host truthfully say "2025-11-25 + 2026-07-28" once, then let
+      // the SDK select between those eras without accidentally falling back
+      // to some other legacy revision.
+      const resolvedSupportedProtocolVersions =
+        config.supportedProtocolVersions ??
+        this.defaultSupportedProtocolVersions ??
+        (!wantsStateless && resolvedProtocolVersion !== undefined
+          ? [resolvedProtocolVersion]
+          : undefined);
       // Send the version that was actually PINNED, not whatever happens to
       // sit at index 0 of the accept-list.
       //

--- a/sdk/tests/MCPClientManager.auto-protocol-reconnect.test.ts
+++ b/sdk/tests/MCPClientManager.auto-protocol-reconnect.test.ts
@@ -130,7 +130,7 @@ describe("MCPClientManager Automatic legacy fallback", () => {
     await fixture.close();
   });
 
-  it("accepts 2025-06-18 after disconnect and reconnect despite a stale list", async () => {
+  it("honors a per-server support list after disconnect and reconnect", async () => {
     await manager.connectToServer("bart", {
       url: fixture.url,
       timeout: 5_000,
@@ -140,15 +140,13 @@ describe("MCPClientManager Automatic legacy fallback", () => {
     );
 
     await manager.removeServer("bart");
-    await manager.connectToServer("bart", {
-      url: fixture.url,
-      timeout: 5_000,
-      supportedProtocolVersions: STALE_ACCEPT_LIST,
-    });
-
-    expect(manager.getInitializationInfo("bart")?.protocolVersion).toBe(
-      NEGOTIATED_VERSION
-    );
+    await expect(
+      manager.connectToServer("bart", {
+        url: fixture.url,
+        timeout: 5_000,
+        supportedProtocolVersions: STALE_ACCEPT_LIST,
+      })
+    ).rejects.toThrow(/Server's protocol version is not supported: 2025-06-18/);
     const initializeRequests = fixture.requests.filter(
       (request) => request.rpcMethod === "initialize"
     );
@@ -156,24 +154,22 @@ describe("MCPClientManager Automatic legacy fallback", () => {
     expect(
       initializeRequests.map((request) => request.proposedProtocolVersion)
     ).toEqual(["2025-11-25", "2025-11-25"]);
-    expect(sseConstructedCount).toBe(0);
+    expect(sseConstructedCount).toBe(1);
   });
 
-  it("ignores a stale manager-default accept-list in Automatic mode", async () => {
+  it("honors the manager-default support list in Automatic mode", async () => {
     await manager.disconnectAllServers();
     manager = new MCPClientManager(
       {},
       { defaultSupportedProtocolVersions: STALE_ACCEPT_LIST }
     );
 
-    await manager.connectToServer("bart", {
-      url: fixture.url,
-      timeout: 5_000,
-    });
-
-    expect(manager.getInitializationInfo("bart")?.protocolVersion).toBe(
-      NEGOTIATED_VERSION
-    );
+    await expect(
+      manager.connectToServer("bart", {
+        url: fixture.url,
+        timeout: 5_000,
+      })
+    ).rejects.toThrow(/Server's protocol version is not supported: 2025-06-18/);
   });
 
   it("keeps an explicit legacy protocol pin strict", async () => {


### PR DESCRIPTION
Split out of #4085 so the behaviour change lands on its own.

- Today, "Automatic" ignores the client's stored list of protocol versions and will negotiate down to any revision the underlying SDK knows — even one the client never said it speaks.
- After this, Automatic sticks to the list the client declares, so a client can say "I speak 2025-11-25 and 2026-07-28" once and only those two get used.
- Heads up, this can break existing connections: if a server only offers an older version that isn't in the stored list, the connection now fails instead of quietly downgrading.
- #4085 no longer contains this change, so the ChatGPT client data can ship without it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Automatic negotiation now honors the client’s declared `supportedProtocolVersions` list in `MCPClientManager`. Previously, Automatic ignored the list and could downgrade to any SDK-supported revision; now it negotiates only within the declared list. Connections to servers that only offer a version outside the list will fail instead of silently downgrading.

- Automatic forwards the declared support list to both modern discovery and legacy fallback; explicit `mcpProtocolVersion` pins remain strict.

**Migration**
- Update per-server or default `supportedProtocolVersions` to include all versions you accept from your servers, or pin `mcpProtocolVersion` if you require a specific revision.
- Clear or refresh any persisted support lists that omit a server’s offered version to avoid new connection failures.

<sup>Written for commit 67fdcebca124a7f04cf5a86f3e281daa1dc19706. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/MCPJam/inspector/pull/4105?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

