### PR TITLE
github checks: read a refused write's payload, not its masked message

### DIFF
--- a/.changeset/github-checks-refusal-copy.md
+++ b/.changeset/github-checks-refusal-copy.md
@@ -1,0 +1,21 @@
+---
+"@mcpjam/inspector": patch
+---
+
+Show the GitHub Checks settings refusal the backend actually wrote, instead of
+`Server Error`.
+
+Convex masks a plain thrown error as `Server Error` plus a request id before it
+reaches a browser; only a `ConvexError` arrives intact, carrying its message as
+a payload on `data`. Both connect surfaces read `error.message`, so every
+carefully-worded refusal on this page — the repository is not reachable by the
+App, GitHub is down right now, that repository is already connected, this
+organization is at its limit — reached administrators as `Server Error`.
+
+Less visibly, the availability branch matched on the message text, so with a
+masked message it never fired and the page could not substitute its own copy.
+
+Both surfaces now shape write errors through one helper that reads `data` first
+and falls back to a de-prefixed `message`, which keeps plain throws from a dev
+deployment readable. Requires the backend change that throws these refusals as
+`ConvexError`s (mcpjam-backend #1028).

--- a/mcpjam-inspector/client/src/components/evals/__tests__/suite-github-checks-section.test.tsx
+++ b/mcpjam-inspector/client/src/components/evals/__tests__/suite-github-checks-section.test.tsx
@@ -29,8 +29,6 @@ const {
 }));
 
 vi.mock("@/hooks/useGithubChecksSettings", () => ({
-  GITHUB_CHECKS_UNAVAILABLE_MESSAGE:
-    "GitHub Checks settings are not currently available.",
   useGithubChecksSettings: () => ({
     availability: mockAvailability.value,
     repos: mockRepos.value,

--- a/mcpjam-inspector/client/src/components/evals/__tests__/suite-iterations-github-checks.test.tsx
+++ b/mcpjam-inspector/client/src/components/evals/__tests__/suite-iterations-github-checks.test.tsx
@@ -30,8 +30,6 @@ vi.mock("@workos-inc/authkit-react", () => ({
 }));
 
 vi.mock("@/hooks/useGithubChecksSettings", () => ({
-  GITHUB_CHECKS_UNAVAILABLE_MESSAGE:
-    "GitHub Checks settings are not currently available.",
   useGithubChecksAvailability: (organizationId: unknown) =>
     mocks.availability(organizationId),
 }));

--- a/mcpjam-inspector/client/src/components/evals/suite-github-checks-section.tsx
+++ b/mcpjam-inspector/client/src/components/evals/suite-github-checks-section.tsx
@@ -10,8 +10,8 @@ import {
   SelectValue,
 } from "@mcpjam/design-system/select";
 import { useAppNavigate } from "@/lib/app-navigation";
+import { githubChecksWriteErrorMessage } from "@/lib/github-checks-errors";
 import {
-  GITHUB_CHECKS_UNAVAILABLE_MESSAGE,
   useGithubChecksSettings,
   type GithubCheckOutagePolicy,
   type InstallationRepo,
@@ -148,12 +148,7 @@ export function SuiteGithubChecksSection({
       // Same rule for the failure: an error about an organization the user has
       // already left is noise they cannot act on.
       if (!mountedRef.current) return;
-      const message = error instanceof Error ? error.message : String(error);
-      toast.error(
-        message.includes("not currently available")
-          ? GITHUB_CHECKS_UNAVAILABLE_MESSAGE
-          : message
-      );
+      toast.error(githubChecksWriteErrorMessage(error));
     } finally {
       setConnecting(false);
     }

--- a/mcpjam-inspector/client/src/components/settings/GithubChecksRoute.tsx
+++ b/mcpjam-inspector/client/src/components/settings/GithubChecksRoute.tsx
@@ -21,8 +21,8 @@ import {
 } from "./github-checks-outage-policy";
 import { SettingsSection } from "../setting/SettingsSection";
 import { SettingsPageShell } from "./SettingsPageShell";
+import { githubChecksWriteErrorMessage } from "@/lib/github-checks-errors";
 import {
-  GITHUB_CHECKS_UNAVAILABLE_MESSAGE,
   useGithubChecksSettings,
   type GithubCheckOutagePolicy,
   type GithubCheckRepoConfigRow,
@@ -161,12 +161,7 @@ export function GithubChecksRoute({
    * response — the next render redirects if it is genuinely off now.
    */
   const handleWriteError = useCallback((error: unknown) => {
-    const message = error instanceof Error ? error.message : String(error);
-    if (message.includes("not currently available")) {
-      toast.error(GITHUB_CHECKS_UNAVAILABLE_MESSAGE);
-      return;
-    }
-    toast.error(message);
+    toast.error(githubChecksWriteErrorMessage(error));
   }, []);
 
   useEffect(() => {

--- a/mcpjam-inspector/client/src/components/settings/__tests__/github-checks-route.test.tsx
+++ b/mcpjam-inspector/client/src/components/settings/__tests__/github-checks-route.test.tsx
@@ -46,8 +46,6 @@ const {
 
 // The availability gate is the unit under test; the data layer is stubbed.
 vi.mock("@/hooks/useGithubChecksSettings", () => ({
-  GITHUB_CHECKS_UNAVAILABLE_MESSAGE:
-    "GitHub Checks settings are not currently available.",
   useGithubChecksSettings: () => ({
     availability: mockAvailability.value,
     isEnabled: mockAvailability.value?.state === "enabled",

--- a/mcpjam-inspector/client/src/hooks/useGithubChecksSettings.ts
+++ b/mcpjam-inspector/client/src/hooks/useGithubChecksSettings.ts
@@ -101,9 +101,11 @@ const AVAILABILITY_QUERY =
 const LIST_QUERY = "github/checkRepoConfigs:listForOrganization";
 const SUITES_QUERY = "testSuites:getTestSuitesOverview";
 
-/** The one message the UI shows when the backend refuses on availability. */
-export const GITHUB_CHECKS_UNAVAILABLE_MESSAGE =
-  "GitHub Checks settings are not currently available.";
+// The availability message and the rest of this surface's error copy live in
+// `@/lib/github-checks-errors`, which has no React and no Convex client in it.
+// Both components that show these messages stub THIS module wholesale in their
+// tests, so a message defined here would be stubbed out in exactly the tests
+// that ought to be checking it.
 
 export function useGithubChecksAvailability(
   organizationId: string | null | undefined

--- a/mcpjam-inspector/client/src/lib/__tests__/github-checks-errors.test.ts
+++ b/mcpjam-inspector/client/src/lib/__tests__/github-checks-errors.test.ts
@@ -1,0 +1,99 @@
+import { ConvexError } from "convex/values";
+import { describe, expect, it } from "vitest";
+
+import {
+  GITHUB_CHECKS_UNAVAILABLE_MESSAGE,
+  githubChecksWriteErrorMessage,
+} from "../github-checks-errors";
+
+/**
+ * The rule under test is WHICH FIELD is read, and it only matters in
+ * production.
+ *
+ * Convex masks a plain throw as `Server Error` plus a request id before it
+ * reaches a browser; only a `ConvexError` arrives intact, with its payload on
+ * `data`. So a client that reads `error.message` shows `Server Error` for every
+ * refusal the backend worded carefully — and, less obviously, any branch that
+ * matches on the message text stops matching, because the text it looks for was
+ * replaced.
+ *
+ * Neither dev deployments nor the component tests reproduce the mask, so these
+ * cases construct the masked shape by hand: that is the only place the
+ * distinction is visible.
+ */
+
+/** A refusal as it arrives in a real browser: payload intact, message redacted. */
+function asProductionRejection(payload: string): ConvexError<string> {
+  const error = new ConvexError(payload);
+  error.message = "[Request ID: 6f1c2a] Server Error";
+  return error;
+}
+
+describe("githubChecksWriteErrorMessage", () => {
+  it("shows the refusal the backend wrote, not the masked message", () => {
+    const message = githubChecksWriteErrorMessage(
+      asProductionRejection(
+        "Repository is not accessible to the MCPJam GitHub App."
+      )
+    );
+
+    expect(message).toBe(
+      "Repository is not accessible to the MCPJam GitHub App."
+    );
+    expect(message).not.toContain("Server Error");
+    expect(message).not.toContain("Request ID");
+  });
+
+  it("keeps the two connect refusals distinguishable", () => {
+    // Different advice: one says go and install the App, the other says wait.
+    // Collapsing them sends someone to reconfigure a working installation.
+    expect(
+      githubChecksWriteErrorMessage(
+        asProductionRejection(
+          "GitHub could not be reached right now. Please try again."
+        )
+      )
+    ).toBe("GitHub could not be reached right now. Please try again.");
+  });
+
+  it("still recognises the availability refusal through the mask", () => {
+    // The regression that is invisible from the outside: this branch reads the
+    // message text, so with a masked message it silently never fires and the
+    // user gets a raw backend sentence — or `Server Error` — instead of this
+    // surface's own copy.
+    expect(
+      githubChecksWriteErrorMessage(
+        asProductionRejection(
+          "GitHub Checks settings are not currently available."
+        )
+      )
+    ).toBe(GITHUB_CHECKS_UNAVAILABLE_MESSAGE);
+  });
+
+  it("reads a structured payload's message field", () => {
+    // Not the shape these refusals use, but the shape the shared helper
+    // supports and the one `kind: 'forbidden'` refusals arrive in.
+    expect(
+      githubChecksWriteErrorMessage(
+        new ConvexError({ kind: "forbidden", message: "You are not an admin." })
+      )
+    ).toBe("You are not an admin.");
+  });
+
+  it("falls back to a plain throw's message, de-prefixed", () => {
+    // A dev deployment does not mask, and an invariant violation is deliberately
+    // still a plain throw. Both must stay readable.
+    expect(
+      githubChecksWriteErrorMessage(new Error("[CONVEX M(x)] Suite not found"))
+    ).toBe("Suite not found");
+  });
+
+  it("says something rather than nothing when there is no message at all", () => {
+    for (const nothing of [undefined, null, {}, new Error("")]) {
+      const message = githubChecksWriteErrorMessage(nothing);
+      expect(message.length).toBeGreaterThan(0);
+      expect(message).not.toContain("undefined");
+      expect(message).not.toContain("[object Object]");
+    }
+  });
+});

--- a/mcpjam-inspector/client/src/lib/github-checks-errors.ts
+++ b/mcpjam-inspector/client/src/lib/github-checks-errors.ts
@@ -1,0 +1,48 @@
+import { convexErrMessage } from "@/lib/convex-error";
+
+/**
+ * What a refused GitHub Checks write says to the person who made it.
+ *
+ * Its own module, with no React and no Convex client in it, so the surfaces
+ * that show these messages can be tested against the REAL mapping: both connect
+ * surfaces stub `useGithubChecksSettings` wholesale, and a helper living there
+ * would be replaced by a stub in exactly the tests that should be exercising it.
+ */
+
+/** The one message the UI shows when the backend refuses on availability. */
+export const GITHUB_CHECKS_UNAVAILABLE_MESSAGE =
+  "GitHub Checks settings are not currently available.";
+
+/** Shown when a write fails in a way that carries no message of its own. */
+const GENERIC_WRITE_ERROR = "Something went wrong. Please try again.";
+
+/**
+ * READ `error.data`, NOT `error.message`.
+ *
+ * The backend words these refusals deliberately — "install the App on that
+ * repository" is different advice from "try again", and telling someone the
+ * wrong one sends them to reconfigure a working installation. But Convex only
+ * carries a message across to a PRODUCTION client when it was thrown as a
+ * `ConvexError`, whose payload lands on `data`; `error.message` there is the
+ * redacted `Server Error` / request-id string. Reading `message` therefore
+ * showed the user nothing useful and — worse — made the availability check
+ * below silently never match, because the string it looks for had already been
+ * replaced. (Backend PR #1028 is the other half: it throws these as
+ * `ConvexError`s so there is a payload to read.)
+ *
+ * `convexErrMessage` prefers `data` and falls back to a de-prefixed `message`,
+ * which is what keeps a plain throw from a dev deployment readable too.
+ *
+ * ONE helper because both connect surfaces refuse the same way — the settings
+ * page and the suite's own section — and a second copy of this rule is a second
+ * chance to read the wrong field.
+ */
+export function githubChecksWriteErrorMessage(error: unknown): string {
+  const message = convexErrMessage(error, GENERIC_WRITE_ERROR);
+  // The availability refusal gets this surface's own phrasing; every other
+  // refusal is shown exactly as the backend worded it, because the backend is
+  // the only side that knows which one happened.
+  return message.includes("not currently available")
+    ? GITHUB_CHECKS_UNAVAILABLE_MESSAGE
+    : message;
+}


### PR DESCRIPTION
The Inspector half of the fix started in mcpjam-backend #1028 (merged). Without this, that PR's messages still do not reach anyone.

## What was wrong

Convex masks a plain thrown error as `Server Error` plus a request id before it reaches a browser. Only a `ConvexError` arrives intact, and its message travels as a payload on `data` — `error.message` is the redacted string.

Both connect surfaces read `error.message`. So every refusal on this page arrived as `Server Error`:

- `Repository is not accessible to the MCPJam GitHub App.` — the one whose entire job is to send someone to install the App
- `GitHub could not be reached right now. Please try again.` — deliberately distinct advice from the above
- `That repository is already connected.` and the per-organization limit
- `GitHub Checks settings are not currently available.`

The last one was more than cosmetic. `handleWriteError` branches on `message.includes("not currently available")` to substitute this surface's own copy — matching on text that the mask had already replaced, so the branch never fired in production.

## The change

One helper, `githubChecksWriteErrorMessage`, used by both connect surfaces: the settings page and the suite's own "run this on every pull request" section. It reads `data` first through the existing shared `convexErrMessage`, falls back to a de-prefixed `message` so a plain throw from a dev deployment stays readable, and keeps the availability substitution — which now actually matches.

**Why it lives in `client/src/lib/github-checks-errors.ts` rather than in the settings hook.** Both components `vi.mock("@/hooks/useGithubChecksSettings")` wholesale, so a helper defined there would be replaced by a stub in exactly the tests that ought to exercise it. The new module has no React and no Convex client in it, so component tests get the real mapping and it can be unit-tested directly. `GITHUB_CHECKS_UNAVAILABLE_MESSAGE` moved with it — nothing imported it from the hook any more, so the three test mocks that still declared it were dropped rather than left describing an export that no longer exists.

## Tests

Six unit tests, each red against the old `error.message` behaviour with the tests kept in place. They construct the masked shape by hand — a `ConvexError` whose `message` is `[Request ID: …] Server Error` — because that shape is the only place the bug is visible: dev deployments do not mask, and neither do the component tests. That is the same blind spot that let this ship.

They cover: the flat refusal surviving the mask; the two connect refusals staying distinguishable from each other; the availability branch matching through a masked message; a structured `{kind, message}` payload; a plain throw falling back de-prefixed; and no-message inputs producing something rather than `undefined` or `[object Object]`.

- `npx vitest run` across the six affected files (helper, both connect surfaces, the hook, integrations route, suite-iterations) — 89 passed
- `npm run typecheck:client` — clean
- `npx prettier --check` on all nine touched files — clean

## After this deploys

The connect-refusal staging drill becomes meaningful: a repository the App cannot see should toast the flat sentence, not `Server Error`. Worth running that before the production promote, since this and #1028 only work as a pair.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit 7880fef094a4bb33ab9c02628b2788d1ed599438. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Show the actual GitHub Checks refusal text by reading Convex’s payload instead of the masked `error.message`. Previously both connect surfaces showed “Server Error” and availability copy never appeared; now users see accurate messages in production with a readable dev fallback.

**Review notes**
- Add `githubChecksWriteErrorMessage` in `@/lib/github-checks-errors`: prefers `error.data` via `convexErrMessage`, falls back to de‑prefixed `message`, and applies the availability substitution.
- Update `GithubChecksRoute` and `SuiteGithubChecksSection` to use the helper; move `GITHUB_CHECKS_UNAVAILABLE_MESSAGE` into the lib and remove related test mocks.
- Add unit tests for masked production shape and fallback cases; include a patch changeset for `@mcpjam/inspector`.

**Rollout**
- Deploy with the backend change that throws refusals as `ConvexError` (`mcpjam-backend` #1028).
- Smoke test in staging: connect a repo the App cannot access and verify the specific refusal appears instead of “Server Error”.

<sup>Written for commit 7880fef094a4bb33ab9c02628b2788d1ed599438. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/MCPJam/inspector/pull/4107?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

