### PR TITLE
Evals v2 G1d (inspector): name the user revoking an API key

### DIFF
--- a/.changeset/api-key-revoke-names-its-actor.md
+++ b/.changeset/api-key-revoke-names-its-actor.md
@@ -1,0 +1,24 @@
+---
+"@mcpjam/inspector": patch
+---
+
+Name the revoking user when an API key's org binding is removed.
+
+The binding delete used to arrive at the backend carrying nothing but the key
+id, so the audit row it writes had to infer an actor — and the only identity
+the row carries is the user who minted the key, which is not necessarily the
+one revoking it. The revoke handler now resolves the caller's MCPJam user and
+sends it as `actorUserId`. That is the Convex document id, not the WorkOS
+`sub`; the backend validates it as such.
+
+An unresolvable caller sends nothing rather than failing: by that point the
+WorkOS key is already destroyed, and the backend records the revocation as
+explicitly unattributed instead of naming someone who may not have done it.
+The session's existing ownership check remains the authorization — this is
+attribution, and defense in depth on a route reachable with the service token
+alone.
+
+Minting also stops flattening one backend answer into a bad one: a key id
+already bound to a different organization now surfaces as `409 CONFLICT`
+instead of `502`. The backend refuses to re-point a live key into another org,
+and that refusal is a conflict, not an unreachable service.

--- a/mcpjam-inspector/server/routes/web/__tests__/api-keys.test.ts
+++ b/mcpjam-inspector/server/routes/web/__tests__/api-keys.test.ts
@@ -1,5 +1,11 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { createWebTestApp, expectJson } from "./helpers/test-app.js";
+import { resolveUserByExternalId } from "../../../services/identity.js";
+import {
+  createWorkosKeyBinding,
+  removeWorkosKeyBinding,
+  WorkosKeyBindingError,
+} from "../../../services/workos-key-bindings.js";
 
 // The session bearer is verified in-route (resolveSessionContext); stub it to
 // a fixed WorkOS user so tests exercise the WorkOS REST flow, not JWT crypto.
@@ -106,6 +112,11 @@ describe("web routes — API key revoke ownership", () => {
 
   beforeEach(() => {
     vi.stubEnv("WORKOS_API_KEY", "sk_test_admin");
+    vi.mocked(removeWorkosKeyBinding).mockClear();
+    vi.mocked(removeWorkosKeyBinding).mockResolvedValue(undefined);
+    vi.mocked(resolveUserByExternalId).mockResolvedValue({
+      _id: "mcpjam_user_1",
+    } as Awaited<ReturnType<typeof resolveUserByExternalId>>);
   });
 
   afterEach(() => {
@@ -174,6 +185,55 @@ describe("web routes — API key revoke ownership", () => {
       message: "Could not verify API key ownership",
     });
     expect(deleted).toEqual([]);
+  });
+
+  it("names the revoking user on the binding delete", async () => {
+    stubWorkOS([{ data: [keyRecord(OWNED_KEY_ID)] }]);
+
+    const { status } = await expectJson(await deleteKey(app, OWNED_KEY_ID));
+
+    expect(status).toBe(200);
+    // The MCPJam user id, not the WorkOS `sub` — the backend validates it as a
+    // Convex document id and 400s the other one.
+    expect(removeWorkosKeyBinding).toHaveBeenCalledWith(
+      OWNED_KEY_ID,
+      "mcpjam_user_1",
+    );
+  });
+
+  it("still revokes, unattributed, when the caller has no MCPJam user row", async () => {
+    vi.mocked(resolveUserByExternalId).mockResolvedValue(
+      null as Awaited<ReturnType<typeof resolveUserByExternalId>>,
+    );
+    const { deleted } = stubWorkOS([{ data: [keyRecord(OWNED_KEY_ID)] }]);
+
+    const { status } = await expectJson(await deleteKey(app, OWNED_KEY_ID));
+
+    // The key is gone either way; an unresolvable actor costs attribution, not
+    // the revoke.
+    expect(status).toBe(200);
+    expect(deleted).toEqual([OWNED_KEY_ID]);
+    expect(removeWorkosKeyBinding).toHaveBeenCalledWith(
+      OWNED_KEY_ID,
+      undefined,
+    );
+  });
+
+  it("keeps the revoke successful when the binding delete is refused", async () => {
+    vi.mocked(removeWorkosKeyBinding).mockRejectedValue(
+      new WorkosKeyBindingError(403, "Binding remove failed (403)"),
+    );
+    const { deleted } = stubWorkOS([{ data: [keyRecord(OWNED_KEY_ID)] }]);
+
+    const { status, data } = await expectJson(
+      await deleteKey(app, OWNED_KEY_ID),
+    );
+
+    // The WorkOS key is already destroyed by this point. Failing the response
+    // would tell the user a revoke did not happen when it did.
+    expect(status).toBe(200);
+    expect(data).toEqual({ ok: true });
+    expect(deleted).toEqual([OWNED_KEY_ID]);
   });
 });
 
@@ -289,6 +349,42 @@ describe("web routes — API key mint readiness", () => {
 
     expect(status).toBe(404);
     expect(data).toMatchObject({ code: "NOT_FOUND" });
+  });
+
+  it("409s when the key id is already bound to a different organization", async () => {
+    mockResolveApiKeyReadiness.mockResolvedValue({
+      ready: true,
+      workosOrganizationId: "org_workos_1",
+    });
+    vi.mocked(createWorkosKeyBinding).mockRejectedValueOnce(
+      new WorkosKeyBindingError(
+        409,
+        "This API key is already bound to a different organization",
+      ),
+    );
+    const deleted: string[] = [];
+    const fetchMock = vi.fn(async (input: string | URL, init?: RequestInit) => {
+      const url = new URL(String(input));
+      if (init?.method === "POST" && url.pathname === USER_KEYS_PATH) {
+        return workosJson(keyRecord("api_key_new"));
+      }
+      if (init?.method === "DELETE" && url.pathname.startsWith("/api_keys/")) {
+        deleted.push(
+          decodeURIComponent(url.pathname.slice("/api_keys/".length)),
+        );
+        return new Response(null, { status: 204 });
+      }
+      return workosJson({ message: "unexpected WorkOS call" }, 500);
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    const { status, data } = await expectJson(await mintKey(app));
+
+    // A conflict, not a 502: the backend was reachable and answered clearly.
+    expect(status).toBe(409);
+    expect(data).toMatchObject({ code: "CONFLICT" });
+    // And the just-minted WorkOS key is destroyed, so no unbindable key lives on.
+    expect(deleted).toEqual(["api_key_new"]);
   });
 
   it("400s when the readiness check reports malformed ids", async () => {

--- a/mcpjam-inspector/server/routes/web/api-keys.ts
+++ b/mcpjam-inspector/server/routes/web/api-keys.ts
@@ -412,6 +412,17 @@ apiKeys.post("/", async (c) =>
             `${message} (API key not created)`,
           );
         }
+        // The key id is already bound to a different org. The backend refuses
+        // to re-point a live key, and it is right to: the request is
+        // well-formed and the caller is permitted, so this is a conflict, not
+        // a validation error or a backend fault.
+        if (bindingError.status === 409) {
+          throw new WebRouteError(
+            409,
+            ErrorCode.CONFLICT,
+            `${message} (API key not created)`,
+          );
+        }
       }
       throw new WebRouteError(
         502,
@@ -514,10 +525,25 @@ apiKeys.delete("/:id", async (c) =>
     // and the WorkOS key is already gone, so a cleanup failure (including a
     // binding that was never written) must not fail the user-facing revoke.
     try {
-      await removeWorkosKeyBinding(id);
+      // Name the actor on the binding delete so the backend's audit row says
+      // who revoked instead of inferring the minter. The check above already
+      // proved this session owns the key, so this is not the authorization —
+      // it is attribution, plus defense in depth on a route the service token
+      // alone can reach. Resolving can fail (a WorkOS user with no MCPJam row
+      // yet); the revoke is already done, so send it unattributed rather than
+      // turning a bookkeeping gap into a failed revoke.
+      const actor = await resolveUserByExternalId(session.userId);
+      await removeWorkosKeyBinding(id, actor?._id);
     } catch (error) {
+      const status =
+        error instanceof WorkosKeyBindingError ? error.status : undefined;
       logger.warn("Failed to remove API key org binding during revoke", {
         workos_key_id: id,
+        // A 403 is the minter-only rule firing, which should be unreachable
+        // behind the ownership check above — worth separating from an
+        // unreachable backend when reading logs.
+        ...(status === 403 ? { reason: "not_key_minter" } : {}),
+        ...(status !== undefined ? { binding_status: status } : {}),
         error: error instanceof Error ? error.message : String(error),
       });
     }

--- a/mcpjam-inspector/server/services/workos-key-bindings.ts
+++ b/mcpjam-inspector/server/services/workos-key-bindings.ts
@@ -108,19 +108,33 @@ export async function createWorkosKeyBinding(args: {
  * Remove the org binding for a revoked WorkOS key. The backend delete is
  * idempotent (200 whether or not a row existed); the caller treats a thrown
  * error as best-effort and does not fail the user-facing revoke.
+ *
+ * `actorUserId` names who is revoking, and is an MCPJam `Id<'users'>` — NOT
+ * the WorkOS `sub`. The backend rejects the wrong one with a 400 rather than
+ * recording a meaningless actor, so resolve the user first
+ * (`resolveUserByExternalId`) and omit the argument if that lookup comes back
+ * empty. Omitting it is a supported state, not a failure: the backend then
+ * records the revocation as unattributed instead of inventing an actor.
  */
 export async function removeWorkosKeyBinding(
-  workosApiKeyId: string
+  workosApiKeyId: string,
+  actorUserId?: string
 ): Promise<void> {
   const { convexUrl, serviceToken } = getInternalBackendConfig();
-  const url = `${convexUrl}${BINDINGS_PATH}?workosApiKeyId=${encodeURIComponent(
-    workosApiKeyId
-  )}`;
+  const params = new URLSearchParams({ workosApiKeyId });
+  if (actorUserId) params.set("actorUserId", actorUserId);
+  const url = `${convexUrl}${BINDINGS_PATH}?${params.toString()}`;
   const response = await fetch(url, {
     method: "DELETE",
     headers: { "x-inspector-service-token": serviceToken },
   });
   if (!response.ok) {
-    throw new Error(`Binding remove failed (${response.status})`);
+    // Carry the status: a 403 here means the backend refused the revoke
+    // because the actor did not mint the key, which is a different event from
+    // an unreachable backend and the caller logs it as one.
+    throw new WorkosKeyBindingError(
+      response.status,
+      `Binding remove failed (${response.status})`
+    );
   }
 }


### PR DESCRIPTION
Second half of the API-key lifecycle work merged in mcpjam-backend [#1027](https://github.com/MCPJam/mcpjam-backend/pull/1027). Evals v2 Lane G, step **G1d-inspector**.

## What this fixes

The binding delete reached the backend carrying only the key id. The audit row it writes needs an actor, and the only identity the binding row holds is the **minter** — who is not necessarily the person revoking. So the row named someone who may not have done it.

Now the revoke handler resolves the caller's MCPJam user and sends it as `actorUserId`. That is the Convex document id, not the WorkOS `sub`; the backend validates it as one and 400s the other, so this goes through `resolveUserByExternalId`.

An unresolvable caller sends **nothing** rather than failing. By that point the WorkOS key is already destroyed, and the backend records the revocation as explicitly unattributed (`actorAttributed: false`) instead of inventing an actor. The session's existing `userOwnsApiKey` enumeration check stays first and remains the authorization — this is attribution, plus defense in depth on a route the service token alone can reach.

Minting also stops flattening a clear backend answer into a wrong one: a key id already bound to a different organization now surfaces as **409 CONFLICT** instead of 502. The backend refuses to re-point a live key into another org; that refusal is a conflict, not an unreachable service.

## Merge gate

The backend half is merged but **Deploy Production has not run for it** — that workflow is `repository_dispatch`/manual and last ran on the pre-merge sha. Staging is deployed. Until production is, `actorUserId` would be rejected by the prod validator; the call sits inside a try/catch so the user-facing revoke still succeeds, but the binding row would be orphaned. **Promote the backend to production before merging this.**

## Verification

- `api-keys.test.ts`: 16 passing (4 new).
- All four new tests mutation-tested: dropping the actor argument fails 2, removing the 409 mapping fails 1, rethrowing the binding failure fails 1.
- Full web + v1 route suites: 100 files / 1,551 tests passing.
- No new type errors (the two `tsc` complaints in this test file are pre-existing, at the same lines shifted by the insertion).
- Formatting: both touched files are already prettier-dirty on `main` under the installed prettier v2, so `--write` was not run; the added lines were checked individually against each file's own convention.

Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit 4489d7ebd3001681dda46d99067e69a4bc541f22. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Names the user who revokes an API key and correctly returns 409 when minting a key already bound to another org. Previously, revokes sent only the key id (audits misattributed to the minter) and minting flattened a backend 409 into a 502.

- Revoke now resolves the caller’s MCPJam user and sends it as `actorUserId` (Convex document id, not the WorkOS `sub`). If unresolved, it omits the actor and the backend records the event as unattributed. The user-facing revoke still succeeds if the binding delete fails; logs include `binding_status` and `reason: not_key_minter` on 403.
- Minting maps a backend “already bound to different org” to 409 CONFLICT and deletes the just-minted WorkOS key to avoid an unbindable key.

**Rollout**
- Deploy the backend to production before merging. Otherwise `actorUserId` will be rejected by the prod validator and the binding row will be orphaned (the revoke itself still succeeds).

<sup>Written for commit 4489d7ebd3001681dda46d99067e69a4bc541f22. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/MCPJam/inspector/pull/4108?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

