### PR TITLE
Lane C: connect GitHub accounts to a workspace, and say when a repository is not ready

### DIFF
--- a/.changeset/github-checks-installation-binding.md
+++ b/.changeset/github-checks-installation-binding.md
@@ -1,0 +1,38 @@
+---
+"@mcpjam/inspector": patch
+---
+
+Connect GitHub accounts to a workspace, and say when a connected repository is
+not actually ready.
+
+GitHub Checks used to assume one GitHub App installation for the whole
+deployment, so the settings page had nothing to say about WHICH account a
+repository came from — there was only ever one. That is changing on the backend,
+and this is the surface for it.
+
+Settings → Integrations → GitHub now has a **GitHub accounts** section. Install
+the app on an account from here, or _claim_ an installation somebody already
+added from GitHub's side. Claiming asks you to sign in to GitHub, and the copy
+says why: installing the app is not on its own proof that an installation is
+yours to connect to this workspace, so the backend requires a GitHub user
+authorization that names you as someone who administers that account.
+Disconnecting asks for confirmation, and the confirmation says what is KEPT as
+well as what stops — your suite and policy choices survive, so reconnecting is
+not a rebuild.
+
+Connected repositories now carry a state when something is wrong: **Reconnect
+required**, **App inactive**, or **No access**. Each one names what happened and
+rules out the reading that would send you to fix the wrong thing — three of the
+four states have nothing to do with your code, and the natural assumption when a
+check stops is that it does. A healthy row gets no badge at all. The state is
+decided by the backend; it is never inferred from a missing visibility badge,
+which means "GitHub did not tell us", not "something is wrong".
+
+The repository picker now aggregates every connected account and selects by
+GitHub's numeric repository id rather than by name — two accounts can each have
+a `widgets`, and a name is not an identity. The account is shown beside a
+repository only when it disambiguates.
+
+A repository conflict, an installation already connected to another workspace,
+or a failed proof all read exactly as the backend worded them, and none of them
+names another workspace.

--- a/.changeset/github-checks-installation-binding.md
+++ b/.changeset/github-checks-installation-binding.md
@@ -1,9 +1,12 @@
 ---
-"@mcpjam/inspector": patch
+"@mcpjam/inspector": minor
 ---
 
 Connect GitHub accounts to a workspace, and say when a connected repository is
 not actually ready.
+
+Needs the matching backend deployment: until it lands, the account and
+binding functions this surface calls do not resolve.
 
 GitHub Checks used to assume one GitHub App installation for the whole
 deployment, so the settings page had nothing to say about WHICH account a

--- a/mcpjam-inspector/client/src/App.tsx
+++ b/mcpjam-inspector/client/src/App.tsx
@@ -41,6 +41,7 @@ import { SessionsPanel } from "./components/sessions/SessionsPanel";
 import { SettingsTab } from "./components/SettingsTab";
 import { ApiKeysRoute } from "./components/settings/ApiKeysRoute";
 import { GithubChecksRoute } from "./components/settings/GithubChecksRoute";
+import { GithubInstallCallbackRoute } from "./components/settings/GithubInstallCallbackRoute";
 import { IntegrationsRoute } from "./components/settings/IntegrationsRoute";
 import { ProjectSettingsTab } from "./components/ProjectSettingsTab";
 import { ProjectClientConfigSync } from "./components/client-config/ProjectClientConfigSync";
@@ -2101,6 +2102,37 @@ export function GithubChecksSettingsRoute() {
       fallback={<Navigate to="/settings" replace />}
     >
       <GithubChecksRoute activeOrganizationId={activeOrganizationId} />
+    </ErrorBoundary>
+  );
+}
+
+/**
+ * `/settings/integrations/github/callback` — GitHub's return path, both legs.
+ *
+ * Same `ErrorBoundary` doctrine as the settings page: this page's actions THROW
+ * when the backend cannot answer (not deployed yet, or the caller is not a
+ * member), and without a boundary that unmounts the whole app. It redirects to
+ * `/settings` for the same reason too — a gated surface that cannot confirm it
+ * is available is not available.
+ *
+ * No `activeOrganizationId` is passed, and none is needed: the browser arrives
+ * back from GitHub carrying only query parameters, and which organization the
+ * binding belongs to is recovered server-side from the link session. A page
+ * that read it from app state could disagree with the session and would then be
+ * asserting an organization nobody proved anything about.
+ */
+export function GithubInstallCallbackSettingsRoute() {
+  return (
+    <ErrorBoundary
+      onError={(error) =>
+        console.error(
+          "[settings/integrations/github/callback] unavailable:",
+          error
+        )
+      }
+      fallback={<Navigate to="/settings" replace />}
+    >
+      <GithubInstallCallbackRoute />
     </ErrorBoundary>
   );
 }

--- a/mcpjam-inspector/client/src/components/evals/__tests__/suite-github-checks-section.test.tsx
+++ b/mcpjam-inspector/client/src/components/evals/__tests__/suite-github-checks-section.test.tsx
@@ -306,16 +306,20 @@ describe("SuiteGithubChecksSection repository identity", () => {
   });
 
   it("distinguishes same-named repositories from different accounts", async () => {
+    // IDENTICAL `fullName` on both, which is what makes this test mean
+    // anything: with different names, an implementation that resolved the pick
+    // by name would satisfy every assertion below. The account suffix is the
+    // only thing telling the two options apart.
     mockListInstallationRepos.mockResolvedValue([
       {
         repositoryId: 201,
-        fullName: "acme/widgets",
+        fullName: "widgets",
         installationRef: "bind-acme",
         accountLogin: "acme",
       },
       {
         repositoryId: 202,
-        fullName: "globex/widgets",
+        fullName: "widgets",
         installationRef: "bind-globex",
         accountLogin: "globex",
       },
@@ -325,7 +329,7 @@ describe("SuiteGithubChecksSection repository identity", () => {
     await waitFor(() => expect(mockListInstallationRepos).toHaveBeenCalled());
 
     // With more than one account in play the label earns its place.
-    await chooseOption(user, "Repository", "globex/widgets · globex");
+    await chooseOption(user, "Repository", "widgets · globex");
     await chooseOption(user, "Outage policy", "Fail closed");
     await user.click(screen.getByRole("button", { name: /Connect/ }));
 
@@ -334,7 +338,7 @@ describe("SuiteGithubChecksSection repository identity", () => {
     );
     expect(mockConnectVerifiedRepo).toHaveBeenCalledWith(
       expect.objectContaining({
-        repoFullName: "globex/widgets",
+        repoFullName: "widgets",
         installationRef: "bind-globex",
         repositoryId: 202,
       })

--- a/mcpjam-inspector/client/src/components/evals/__tests__/suite-github-checks-section.test.tsx
+++ b/mcpjam-inspector/client/src/components/evals/__tests__/suite-github-checks-section.test.tsx
@@ -19,11 +19,31 @@ const {
   // window. Handed to the component so that reaching for it is a recorded
   // call rather than a crash — "never called" is the assertion.
   mockConnectRepo: vi.fn(async () => ({ configId: "cfg-legacy" })),
-  mockConnectVerifiedRepo: vi.fn(async () => ({ configId: "cfg-new" })),
-  mockListInstallationRepos: vi.fn(async () => [
-    { fullName: "mcpjam/inspector" },
-    { fullName: "mcpjam/backend" },
-  ]),
+  // Loosely typed for the same reason as the settings-route suite: these stand
+  // in for Convex actions whose arguments are hand-mirrored, and a narrow
+  // inferred shape would fight every fixture variation below.
+  mockConnectVerifiedRepo: vi.fn(async (_args?: Record<string, unknown>) => ({
+    configId: "cfg-new",
+  })),
+  // `repositoryId` is REQUIRED by the contract and is what the picker is keyed
+  // on: two connected accounts can each have a `widgets`, so a name is not a
+  // selector. `installationRef` says which installation the entry came from.
+  mockListInstallationRepos: vi.fn(
+    async (): Promise<unknown[]> => [
+      {
+        repositoryId: 101,
+        fullName: "mcpjam/inspector",
+        installationRef: "bind-1",
+        accountLogin: "mcpjam",
+      },
+      {
+        repositoryId: 102,
+        fullName: "mcpjam/backend",
+        installationRef: "bind-1",
+        accountLogin: "mcpjam",
+      },
+    ]
+  ),
   mockNavigate: vi.fn(),
   mockToast: { error: vi.fn(), success: vi.fn() },
 }));
@@ -183,6 +203,11 @@ describe("SuiteGithubChecksSection", () => {
       projectId: "proj-1",
       suiteId: "suite-1",
       outagePolicy: "fail_open",
+      // Straight off the picked listing entry, both of them. The server
+      // re-verifies which installation this was listed through and which
+      // repository it actually is; neither is reassembled here from a name.
+      installationRef: "bind-1",
+      repositoryId: 101,
     });
     expect(mockConnectRepo).not.toHaveBeenCalled();
     expect(mockToast.success).toHaveBeenCalledWith("Repository connected.");
@@ -262,5 +287,83 @@ describe("SuiteGithubChecksSection", () => {
     for (const forbidden of [/merges proceed/i, /merges are blocked/i]) {
       expect(page).not.toMatch(forbidden);
     }
+  });
+});
+
+// ═══════════════════════════════════════════════════════════════════════════
+// THE PICKER SELECTS BY REPOSITORY ID
+// ═══════════════════════════════════════════════════════════════════════════
+//
+// Two accounts can each have a repository with the same short name, and the
+// connect is keyed on GitHub's numeric id. Selecting by name would make the
+// account label decorative and let one pick resolve to the other repository.
+
+describe("SuiteGithubChecksSection repository identity", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockAvailability.value = { state: "enabled" };
+    mockConnectVerifiedRepo.mockResolvedValue({ configId: "cfg-new" });
+  });
+
+  it("distinguishes same-named repositories from different accounts", async () => {
+    mockListInstallationRepos.mockResolvedValue([
+      {
+        repositoryId: 201,
+        fullName: "acme/widgets",
+        installationRef: "bind-acme",
+        accountLogin: "acme",
+      },
+      {
+        repositoryId: 202,
+        fullName: "globex/widgets",
+        installationRef: "bind-globex",
+        accountLogin: "globex",
+      },
+    ]);
+    const user = userEvent.setup();
+    renderSection({ repos: [] });
+    await waitFor(() => expect(mockListInstallationRepos).toHaveBeenCalled());
+
+    // With more than one account in play the label earns its place.
+    await chooseOption(user, "Repository", "globex/widgets · globex");
+    await chooseOption(user, "Outage policy", "Fail closed");
+    await user.click(screen.getByRole("button", { name: /Connect/ }));
+
+    await waitFor(() =>
+      expect(mockConnectVerifiedRepo).toHaveBeenCalledTimes(1)
+    );
+    expect(mockConnectVerifiedRepo).toHaveBeenCalledWith(
+      expect.objectContaining({
+        repoFullName: "globex/widgets",
+        installationRef: "bind-globex",
+        repositoryId: 202,
+      })
+    );
+  });
+
+  it("omits installationRef when the listing carried none", async () => {
+    // The compatibility window: an organization with no binding is still listed
+    // through the backend's pinned installation, and omitting the reference is
+    // what keeps that connect path reachable.
+    mockListInstallationRepos.mockResolvedValue([
+      { repositoryId: 301, fullName: "mcpjam/pinned" },
+    ]);
+    const user = userEvent.setup();
+    renderSection({ repos: [] });
+    await waitFor(() => expect(mockListInstallationRepos).toHaveBeenCalled());
+
+    await chooseOption(user, "Repository", "mcpjam/pinned");
+    await chooseOption(user, "Outage policy", "Fail open");
+    await user.click(screen.getByRole("button", { name: /Connect/ }));
+
+    await waitFor(() =>
+      expect(mockConnectVerifiedRepo).toHaveBeenCalledTimes(1)
+    );
+    const sent = mockConnectVerifiedRepo.mock.calls[0]?.[0] as Record<
+      string,
+      unknown
+    >;
+    expect(sent).not.toHaveProperty("installationRef");
+    expect(sent.repositoryId).toBe(301);
   });
 });

--- a/mcpjam-inspector/client/src/components/evals/suite-github-checks-section.tsx
+++ b/mcpjam-inspector/client/src/components/evals/suite-github-checks-section.tsx
@@ -12,6 +12,13 @@ import {
 import { useAppNavigate } from "@/lib/app-navigation";
 import { githubChecksWriteErrorMessage } from "@/lib/github-checks-errors";
 import {
+  findRepoByPickerValue,
+  pickerLabelFor,
+  pickerValueFor,
+  shouldShowAccountLabels,
+  verifiedConnectArgs,
+} from "@/lib/github-repo-picker";
+import {
   useGithubChecksSettings,
   type GithubCheckOutagePolicy,
   type InstallationRepo,
@@ -127,19 +134,10 @@ export function SuiteGithubChecksSection({
           (repo) => !alreadyConnected.has(repo.fullName.toLowerCase())
         );
 
-  /** The listing entry the picker's value refers to. See the Select below. */
-  const pickedRepo = connectableRepos.find(
-    (repo) => String(repo.repositoryId) === pickerRepo
-  );
-
-  // Same rule as the settings page: the account label earns its place only when
-  // it disambiguates. One connected account means one repeated label.
-  const showAccountLabels =
-    new Set(
-      connectableRepos
-        .map((repo) => repo.accountLogin)
-        .filter((login): login is string => Boolean(login))
-    ).size > 1;
+  // Selection, labelling and the connect payload are shared with the settings
+  // page through `@/lib/github-repo-picker` — the same contract, stated once.
+  const pickedRepo = findRepoByPickerValue(connectableRepos, pickerRepo);
+  const showAccountLabels = shouldShowAccountLabels(connectableRepos);
 
   const handleConnect = async () => {
     if (!pickedRepo || !projectId || !pickerPolicy) return;
@@ -148,18 +146,14 @@ export function SuiteGithubChecksSection({
       // The server-VERIFIED connect: it proves the selected installation can
       // actually reach this repository before any row is written, and the
       // reference and repository id say WHICH installation and WHICH repository
-      // — both re-verified server-side. The reference is absent only while the
-      // backend is still falling back to its pinned installation.
-      await connectVerifiedRepo({
-        repoFullName: pickedRepo.fullName,
-        projectId,
-        suiteId,
-        outagePolicy: pickerPolicy,
-        ...(pickedRepo.installationRef
-          ? { installationRef: pickedRepo.installationRef }
-          : {}),
-        repositoryId: pickedRepo.repositoryId,
-      });
+      // — both re-verified server-side.
+      await connectVerifiedRepo(
+        verifiedConnectArgs(pickedRepo, {
+          projectId,
+          suiteId,
+          outagePolicy: pickerPolicy,
+        })
+      );
       if (!mountedRef.current) return;
       setPickerRepo("");
       setPickerPolicy("");
@@ -207,13 +201,8 @@ export function SuiteGithubChecksSection({
           </SelectTrigger>
           <SelectContent>
             {connectableRepos.map((repo) => (
-              <SelectItem
-                key={repo.repositoryId}
-                value={String(repo.repositoryId)}
-              >
-                {showAccountLabels && repo.accountLogin
-                  ? `${repo.fullName} · ${repo.accountLogin}`
-                  : repo.fullName}
+              <SelectItem key={repo.repositoryId} value={pickerValueFor(repo)}>
+                {pickerLabelFor(repo, showAccountLabels)}
               </SelectItem>
             ))}
           </SelectContent>

--- a/mcpjam-inspector/client/src/components/evals/suite-github-checks-section.tsx
+++ b/mcpjam-inspector/client/src/components/evals/suite-github-checks-section.tsx
@@ -127,18 +127,38 @@ export function SuiteGithubChecksSection({
           (repo) => !alreadyConnected.has(repo.fullName.toLowerCase())
         );
 
+  /** The listing entry the picker's value refers to. See the Select below. */
+  const pickedRepo = connectableRepos.find(
+    (repo) => String(repo.repositoryId) === pickerRepo
+  );
+
+  // Same rule as the settings page: the account label earns its place only when
+  // it disambiguates. One connected account means one repeated label.
+  const showAccountLabels =
+    new Set(
+      connectableRepos
+        .map((repo) => repo.accountLogin)
+        .filter((login): login is string => Boolean(login))
+    ).size > 1;
+
   const handleConnect = async () => {
-    if (!pickerRepo || !projectId || !pickerPolicy) return;
+    if (!pickedRepo || !projectId || !pickerPolicy) return;
     setConnecting(true);
     try {
-      // The server-VERIFIED connect: it proves the pinned installation can
-      // actually reach this repository before any row is written. The
-      // unverified mutation is still deployed and must not be called.
+      // The server-VERIFIED connect: it proves the selected installation can
+      // actually reach this repository before any row is written, and the
+      // reference and repository id say WHICH installation and WHICH repository
+      // — both re-verified server-side. The reference is absent only while the
+      // backend is still falling back to its pinned installation.
       await connectVerifiedRepo({
-        repoFullName: pickerRepo,
+        repoFullName: pickedRepo.fullName,
         projectId,
         suiteId,
         outagePolicy: pickerPolicy,
+        ...(pickedRepo.installationRef
+          ? { installationRef: pickedRepo.installationRef }
+          : {}),
+        repositoryId: pickedRepo.repositoryId,
       });
       if (!mountedRef.current) return;
       setPickerRepo("");
@@ -179,14 +199,21 @@ export function SuiteGithubChecksSection({
       )}
 
       <div className="flex flex-wrap items-center gap-2">
+        {/* Valued by REPOSITORY ID, not name: two connected accounts can each
+            have a `widgets`, and the id is what the connect is keyed on. */}
         <Select value={pickerRepo} onValueChange={setPickerRepo}>
-          <SelectTrigger className="w-64" aria-label="Repository">
+          <SelectTrigger className="w-72" aria-label="Repository">
             <SelectValue placeholder="Select a repository" />
           </SelectTrigger>
           <SelectContent>
             {connectableRepos.map((repo) => (
-              <SelectItem key={repo.fullName} value={repo.fullName}>
-                {repo.fullName}
+              <SelectItem
+                key={repo.repositoryId}
+                value={String(repo.repositoryId)}
+              >
+                {showAccountLabels && repo.accountLogin
+                  ? `${repo.fullName} · ${repo.accountLogin}`
+                  : repo.fullName}
               </SelectItem>
             ))}
           </SelectContent>
@@ -207,7 +234,7 @@ export function SuiteGithubChecksSection({
         <Button
           size="sm"
           onClick={() => void handleConnect()}
-          disabled={connecting || !pickerRepo || !projectId || !pickerPolicy}
+          disabled={connecting || !pickedRepo || !projectId || !pickerPolicy}
         >
           <Plus className="mr-2 size-3.5" aria-hidden /> Connect
         </Button>

--- a/mcpjam-inspector/client/src/components/settings/GithubChecksRoute.tsx
+++ b/mcpjam-inspector/client/src/components/settings/GithubChecksRoute.tsx
@@ -8,6 +8,16 @@ import { Badge } from "@mcpjam/design-system/badge";
 import { Button } from "@mcpjam/design-system/button";
 import { Switch } from "@mcpjam/design-system/switch";
 import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from "@mcpjam/design-system/alert-dialog";
+import {
   Select,
   SelectContent,
   SelectItem,
@@ -21,11 +31,19 @@ import {
 } from "./github-checks-outage-policy";
 import { SettingsSection } from "../setting/SettingsSection";
 import { SettingsPageShell } from "./SettingsPageShell";
-import { githubChecksWriteErrorMessage } from "@/lib/github-checks-errors";
+import {
+  githubChecksWriteErrorMessage,
+  GITHUB_BINDING_STATUS_COPY,
+  GITHUB_CONNECTION_STATUS_COPY,
+  GITHUB_CONNECTION_STATUS_LABEL,
+  GITHUB_UNBIND_CONFIRMATION,
+} from "@/lib/github-checks-errors";
+import { redirectToGithub } from "@/lib/github-external-redirect";
 import {
   useGithubChecksSettings,
   type GithubCheckOutagePolicy,
   type GithubCheckRepoConfigRow,
+  type GithubInstallationBinding,
   type InstallationRepo,
   type SuiteOption,
 } from "@/hooks/useGithubChecksSettings";
@@ -86,6 +104,98 @@ function RepoVisibilityBadge({ isPrivate }: { isPrivate?: boolean }) {
   );
 }
 
+/**
+ * Whether this connection is actually ready, and what to do if it is not.
+ *
+ * The status is DERIVED BY THE BACKEND from three facts this app never sees —
+ * a verified repository identity, an active org ↔ installation binding, and
+ * per-repository access. It is deliberately NOT inferred from the visibility
+ * badge above: absence there means "GitHub did not tell us", which is a
+ * different thing from "something is wrong", and conflating them would put a
+ * scary warning on a perfectly healthy repository whose `private` flag GitHub
+ * happened to omit.
+ *
+ * `verified` renders nothing at all. A badge saying "fine" on every healthy row
+ * is noise that makes the three rows that need attention harder to find.
+ */
+function RepoConnectionState({
+  status,
+}: {
+  status: GithubCheckRepoConfigRow["connectionStatus"];
+}) {
+  const label = GITHUB_CONNECTION_STATUS_LABEL[status];
+  if (!label) return null;
+  return (
+    <Badge variant="outline" className="shrink-0">
+      {label}
+    </Badge>
+  );
+}
+
+function RepoConnectionExplainer({
+  status,
+}: {
+  status: GithubCheckRepoConfigRow["connectionStatus"];
+}) {
+  const copy = GITHUB_CONNECTION_STATUS_COPY[status];
+  if (!copy) return null;
+  return <span className="text-xs text-muted-foreground">{copy}</span>;
+}
+
+/**
+ * One GitHub account this workspace has connected.
+ *
+ * `accountLogin` is DISPLAY ONLY — GitHub allows renames, and nothing on either
+ * side of this decides anything from it. The raw GitHub installation id is
+ * never rendered and never received: `installationRef` is an opaque row id.
+ */
+function InstallationRow({
+  binding,
+  onUnbind,
+  disabled,
+}: {
+  binding: GithubInstallationBinding;
+  onUnbind: () => void;
+  disabled: boolean;
+}) {
+  return (
+    <div
+      className="flex items-center justify-between gap-4 px-4 py-3"
+      data-testid={`installation-row-${binding.accountLogin}`}
+    >
+      <div className="flex items-center gap-3 min-w-0">
+        <div className="size-8 rounded-md bg-primary/10 flex items-center justify-center shrink-0">
+          <Github className="size-4 text-primary" aria-hidden />
+        </div>
+        <div className="flex flex-col min-w-0">
+          <div className="flex items-center gap-2 min-w-0">
+            <span className="text-sm font-medium truncate">
+              {binding.accountLogin}
+            </span>
+            <Badge variant="outline" className="shrink-0">
+              {binding.accountType === "Organization"
+                ? "Organization"
+                : "Personal"}
+            </Badge>
+          </div>
+          <span className="text-xs text-muted-foreground">
+            {GITHUB_BINDING_STATUS_COPY[binding.status]}
+          </span>
+        </div>
+      </div>
+      <Button
+        variant="outline"
+        size="sm"
+        disabled={disabled}
+        onClick={onUnbind}
+        aria-label={`Disconnect ${binding.accountLogin}`}
+      >
+        Disconnect
+      </Button>
+    </div>
+  );
+}
+
 export function GithubChecksRoute({
   activeOrganizationId,
 }: GithubChecksRouteProps = {}) {
@@ -94,12 +204,16 @@ export function GithubChecksRoute({
     availability,
     repos,
     suites,
+    bindings,
     connectVerifiedRepo,
     setRepoEnabled,
     setRepoSuite,
     setRepoOutagePolicy,
     disconnectRepo,
     listInstallationRepos,
+    startInstallation,
+    startDirectClaim,
+    unbindInstallation,
   } = useGithubChecksSettings(activeOrganizationId);
 
   // `activeOrganizationId` arrives asynchronously during app bootstrap, and the
@@ -137,7 +251,17 @@ export function GithubChecksRoute({
   const [pendingPolicies, setPendingPolicies] = useState<ReadonlySet<string>>(
     () => new Set()
   );
+  // The picker's value is the repository's NUMERIC ID as a string, not its
+  // name. Two accounts can both have a `widgets`, and the id is what the connect
+  // is actually keyed on — selecting by name would make the disambiguation the
+  // account label provides purely cosmetic.
   const [pickerRepo, setPickerRepo] = useState<string>("");
+  // Which binding action is in flight, so the buttons can be disabled without
+  // one spinner standing in for all three.
+  const [bindingBusy, setBindingBusy] = useState(false);
+  // The binding an admin has asked to disconnect, held until they confirm.
+  const [pendingUnbind, setPendingUnbind] =
+    useState<GithubInstallationBinding | null>(null);
   const [pickerSuite, setPickerSuite] = useState<string>("");
   // `""` is "not chosen", and it is the only initial value this may have. A
   // preselected policy would record a decision the administrator never made —
@@ -229,14 +353,54 @@ export function GithubChecksRoute({
   const suiteById = (suiteId: string) =>
     suiteOptions.find((s) => s._id === suiteId);
 
+  /**
+   * Send the admin to GitHub to install, or to authorize a claim.
+   *
+   * Both start server-side — the URL carries a one-time state whose hash the
+   * backend stored — so this only follows what it is handed, through a helper
+   * that refuses anything not on github.com.
+   */
+  const beginBindingFlow = async (kind: "install" | "claim") => {
+    setBindingBusy(true);
+    try {
+      const { url } =
+        kind === "install"
+          ? await startInstallation().then((r) => ({ url: r.installUrl }))
+          : await startDirectClaim().then((r) => ({ url: r.authorizeUrl }));
+      redirectToGithub(url);
+    } catch (error) {
+      handleWriteError(error);
+      // Only cleared on failure: on success the browser is already leaving, and
+      // re-enabling the button would invite a second click that burns a second
+      // link session.
+      setBindingBusy(false);
+    }
+  };
+
+  const handleUnbindConfirmed = async () => {
+    const binding = pendingUnbind;
+    if (!binding) return;
+    setPendingUnbind(null);
+    setBindingBusy(true);
+    try {
+      await unbindInstallation({ installationRef: binding.installationRef });
+      toast.success(`Disconnected ${binding.accountLogin}.`);
+    } catch (error) {
+      handleWriteError(error);
+    } finally {
+      setBindingBusy(false);
+    }
+  };
+
   const handleConnect = async () => {
     const suite = suiteById(pickerSuite);
+    const repo = repoByPickerValue(pickerRepo);
     // The same three-way rule the button enforces, enforced again here. The
     // disabled attribute is a hint to a person; this is the invariant, and the
     // policy half of it is why: a connect that quietly omitted `outagePolicy`
     // would store a row nobody chose a policy for — the legacy state this whole
     // screen exists to stop creating.
-    if (!pickerRepo || !suite?.projectId || !pickerPolicy) {
+    if (!repo || !suite?.projectId || !pickerPolicy) {
       toast.error("Pick a repository, a suite, and an outage policy first.");
       return;
     }
@@ -248,11 +412,22 @@ export function GithubChecksRoute({
       // The project is DERIVED from the suite, never picked separately: the
       // backend requires them to agree, so offering two controls would only
       // create a way to get it wrong.
+      //
+      // `installationRef` and `repositoryId` are taken STRAIGHT OFF the picked
+      // listing entry rather than reassembled: they say which installation this
+      // repository was enumerated through and which repository it actually is,
+      // and the server re-verifies both. The ref is absent only while the
+      // backend is still falling back to its pinned installation, and omitting
+      // it is what keeps that compatibility path reachable.
       await connectVerifiedRepo({
-        repoFullName: pickerRepo,
+        repoFullName: repo.fullName,
         projectId: suite.projectId,
         suiteId: suite._id,
         outagePolicy: pickerPolicy,
+        ...(repo.installationRef
+          ? { installationRef: repo.installationRef }
+          : {}),
+        repositoryId: repo.repositoryId,
       });
       // A completion for the PREVIOUS org lands on a page that is now showing a
       // different one. Clearing selections there would wipe a fresh choice, and
@@ -373,6 +548,23 @@ export function GithubChecksRoute({
           (repo) => !alreadyConnected.has(normalizeRepoName(repo.fullName))
         );
 
+  /** The listing entry the picker's value refers to. */
+  const repoByPickerValue = (value: string): InstallationRepo | undefined =>
+    connectableRepos.find((repo) => String(repo.repositoryId) === value);
+
+  // Show the account beside a repository ONLY when it disambiguates. With one
+  // connected account every row would carry the same label, which is a column
+  // of noise; with several, `widgets` and `widgets` are genuinely two different
+  // repositories and the name alone cannot say which.
+  const accountLogins = new Set(
+    connectableRepos
+      .map((repo) => repo.accountLogin)
+      .filter((login): login is string => Boolean(login))
+  );
+  const showAccountLabels = accountLogins.size > 1;
+
+  const bindingRows: GithubInstallationBinding[] = bindings ?? [];
+
   return (
     <SettingsPageShell
       active="integrations"
@@ -399,6 +591,82 @@ export function GithubChecksRoute({
         head commit and reports back as a status check.
       </p>
 
+      <SettingsSection title="GitHub accounts">
+        {bindings === undefined ? (
+          <div className="flex items-center justify-center px-4 py-8 text-sm text-muted-foreground">
+            Loading…
+          </div>
+        ) : bindingRows.length === 0 ? (
+          <div className="space-y-3 px-4 py-8 text-sm text-muted-foreground">
+            <p>
+              No GitHub accounts connected yet. Install the MCPJam app on the
+              account whose repositories you want checked — or, if somebody has
+              already installed it from GitHub, claim that installation for this
+              workspace.
+            </p>
+          </div>
+        ) : (
+          bindingRows.map((binding) => (
+            <InstallationRow
+              key={binding.installationRef}
+              binding={binding}
+              disabled={bindingBusy}
+              onUnbind={() => setPendingUnbind(binding)}
+            />
+          ))
+        )}
+
+        <div className="flex flex-wrap items-center gap-3 px-4 py-3">
+          <Button
+            disabled={bindingBusy}
+            onClick={() => void beginBindingFlow("install")}
+          >
+            <Github className="mr-2 size-4" aria-hidden /> Install on a GitHub
+            account
+          </Button>
+          <Button
+            variant="outline"
+            disabled={bindingBusy}
+            onClick={() => void beginBindingFlow("claim")}
+          >
+            Claim an existing installation
+          </Button>
+        </div>
+        <p className="px-4 pb-3 text-xs text-muted-foreground">
+          Claiming is for an installation somebody already added from GitHub's
+          side. You will be asked to sign in to GitHub so we can confirm you
+          administer that account — installing the app is not on its own proof
+          that it is yours to connect here.
+        </p>
+      </SettingsSection>
+
+      {/* Explicit confirmation, and the copy says the LIMIT of the consequence
+          as well as the consequence: disconnecting stops checks now, and keeps
+          every suite and policy choice, so reconnecting is not a rebuild. */}
+      <AlertDialog
+        open={pendingUnbind !== null}
+        onOpenChange={(open) => {
+          if (!open) setPendingUnbind(null);
+        }}
+      >
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle>
+              Disconnect {pendingUnbind?.accountLogin}?
+            </AlertDialogTitle>
+            <AlertDialogDescription>
+              {GITHUB_UNBIND_CONFIRMATION}
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogCancel>Keep it connected</AlertDialogCancel>
+            <AlertDialogAction onClick={() => void handleUnbindConfirmed()}>
+              Disconnect
+            </AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
+
       <SettingsSection title="Connected repositories">
         {repos === undefined ? (
           <div className="flex items-center justify-center px-4 py-8 text-sm text-muted-foreground">
@@ -407,9 +675,9 @@ export function GithubChecksRoute({
         ) : rows.length === 0 ? (
           <div className="space-y-3 px-4 py-8 text-sm text-muted-foreground">
             <p>
-              No repositories connected yet. Install the MCPJam GitHub App on a
-              repository, then connect it below to start running checks on its
-              pull requests.
+              No repositories connected yet. Connect a GitHub account above,
+              then connect one of its repositories below to start running checks
+              on its pull requests.
             </p>
             <p>
               A repository can declare its check recipe in a{" "}
@@ -450,8 +718,10 @@ export function GithubChecksRoute({
                         normalizeRepoName(row.repoFullName)
                       )}
                     />
+                    <RepoConnectionState status={row.connectionStatus} />
                   </div>
                   <RepoCheckState enabled={row.enabled} />
+                  <RepoConnectionExplainer status={row.connectionStatus} />
                   {row.outagePolicy === undefined ? (
                     /* Not the same statement as "fail open": the backend does
                        behave that way for an unstamped row, but nobody chose
@@ -533,14 +803,23 @@ export function GithubChecksRoute({
 
       <SettingsSection title="Connect a repository">
         <div className="flex flex-wrap items-center gap-3 px-4 py-3">
+          {/* Keyed and valued by REPOSITORY ID. Two connected accounts can
+              each have a `widgets`, and the id is what the connect is actually
+              keyed on — selecting by name would make the account label below
+              purely decorative and let one pick resolve to the other repo. */}
           <Select value={pickerRepo} onValueChange={setPickerRepo}>
-            <SelectTrigger className="w-64" aria-label="Repository">
+            <SelectTrigger className="w-72" aria-label="Repository">
               <SelectValue placeholder="Select a repository" />
             </SelectTrigger>
             <SelectContent>
               {connectableRepos.map((repo) => (
-                <SelectItem key={repo.fullName} value={repo.fullName}>
-                  {repo.fullName}
+                <SelectItem
+                  key={repo.repositoryId}
+                  value={String(repo.repositoryId)}
+                >
+                  {showAccountLabels && repo.accountLogin
+                    ? `${repo.fullName} · ${repo.accountLogin}`
+                    : repo.fullName}
                 </SelectItem>
               ))}
             </SelectContent>
@@ -592,8 +871,9 @@ export function GithubChecksRoute({
           </div>
         ) : installationRepos !== null && installationRepos.length === 0 ? (
           <div className="px-4 pb-4 text-sm text-muted-foreground">
-            No repositories available. Install the MCPJam GitHub App on the
-            repositories you want checked, then reload this page.
+            {bindingRows.length === 0
+              ? "No repositories available. Connect a GitHub account above first."
+              : "No repositories available. Give the MCPJam app access to the repositories you want checked on GitHub, then reload this page."}
           </div>
         ) : null}
       </SettingsSection>

--- a/mcpjam-inspector/client/src/components/settings/GithubChecksRoute.tsx
+++ b/mcpjam-inspector/client/src/components/settings/GithubChecksRoute.tsx
@@ -40,6 +40,13 @@ import {
 } from "@/lib/github-checks-errors";
 import { redirectToGithub } from "@/lib/github-external-redirect";
 import {
+  findRepoByPickerValue,
+  pickerLabelFor,
+  pickerValueFor,
+  shouldShowAccountLabels,
+  verifiedConnectArgs,
+} from "@/lib/github-repo-picker";
+import {
   useGithubChecksSettings,
   type GithubCheckOutagePolicy,
   type GithubCheckRepoConfigRow,
@@ -394,7 +401,7 @@ export function GithubChecksRoute({
 
   const handleConnect = async () => {
     const suite = suiteById(pickerSuite);
-    const repo = repoByPickerValue(pickerRepo);
+    const repo = findRepoByPickerValue(connectableRepos, pickerRepo);
     // The same three-way rule the button enforces, enforced again here. The
     // disabled attribute is a hint to a person; this is the invariant, and the
     // policy half of it is why: a connect that quietly omitted `outagePolicy`
@@ -412,23 +419,13 @@ export function GithubChecksRoute({
       // The project is DERIVED from the suite, never picked separately: the
       // backend requires them to agree, so offering two controls would only
       // create a way to get it wrong.
-      //
-      // `installationRef` and `repositoryId` are taken STRAIGHT OFF the picked
-      // listing entry rather than reassembled: they say which installation this
-      // repository was enumerated through and which repository it actually is,
-      // and the server re-verifies both. The ref is absent only while the
-      // backend is still falling back to its pinned installation, and omitting
-      // it is what keeps that compatibility path reachable.
-      await connectVerifiedRepo({
-        repoFullName: repo.fullName,
-        projectId: suite.projectId,
-        suiteId: suite._id,
-        outagePolicy: pickerPolicy,
-        ...(repo.installationRef
-          ? { installationRef: repo.installationRef }
-          : {}),
-        repositoryId: repo.repositoryId,
-      });
+      await connectVerifiedRepo(
+        verifiedConnectArgs(repo, {
+          projectId: suite.projectId,
+          suiteId: suite._id,
+          outagePolicy: pickerPolicy,
+        })
+      );
       // A completion for the PREVIOUS org lands on a page that is now showing a
       // different one. Clearing selections there would wipe a fresh choice, and
       // the success toast would credit the wrong organization.
@@ -548,20 +545,12 @@ export function GithubChecksRoute({
           (repo) => !alreadyConnected.has(normalizeRepoName(repo.fullName))
         );
 
-  /** The listing entry the picker's value refers to. */
-  const repoByPickerValue = (value: string): InstallationRepo | undefined =>
-    connectableRepos.find((repo) => String(repo.repositoryId) === value);
-
-  // Show the account beside a repository ONLY when it disambiguates. With one
-  // connected account every row would carry the same label, which is a column
-  // of noise; with several, `widgets` and `widgets` are genuinely two different
-  // repositories and the name alone cannot say which.
-  const accountLogins = new Set(
-    connectableRepos
-      .map((repo) => repo.accountLogin)
-      .filter((login): login is string => Boolean(login))
-  );
-  const showAccountLabels = accountLogins.size > 1;
+  // Selection and labelling live in `@/lib/github-repo-picker`, shared with the
+  // suite's own picker: which value selects a repository, and what the verified
+  // connect is told about it, are a contract with the backend rather than a
+  // presentation detail, and two copies drift the first time either side gains
+  // a field.
+  const showAccountLabels = shouldShowAccountLabels(connectableRepos);
 
   const bindingRows: GithubInstallationBinding[] = bindings ?? [];
 
@@ -815,11 +804,9 @@ export function GithubChecksRoute({
               {connectableRepos.map((repo) => (
                 <SelectItem
                   key={repo.repositoryId}
-                  value={String(repo.repositoryId)}
+                  value={pickerValueFor(repo)}
                 >
-                  {showAccountLabels && repo.accountLogin
-                    ? `${repo.fullName} · ${repo.accountLogin}`
-                    : repo.fullName}
+                  {pickerLabelFor(repo, showAccountLabels)}
                 </SelectItem>
               ))}
             </SelectContent>

--- a/mcpjam-inspector/client/src/components/settings/GithubInstallCallbackRoute.tsx
+++ b/mcpjam-inspector/client/src/components/settings/GithubInstallCallbackRoute.tsx
@@ -167,8 +167,12 @@ export function GithubInstallCallbackRoute() {
         <h2 className="text-lg font-medium">Connect a GitHub account</h2>
       </div>
 
+      {/* This page replaces its whole content asynchronously — "Finishing up"
+          becomes a refusal or an account picker with no interaction — so a
+          screen reader would otherwise sit on a message that has already gone.
+          `role="status"` announces the replacement politely. */}
       {phase.kind === "working" ? (
-        <p className="text-sm text-muted-foreground">
+        <p role="status" className="text-sm text-muted-foreground">
           Finishing up with GitHub…
         </p>
       ) : null}
@@ -176,7 +180,9 @@ export function GithubInstallCallbackRoute() {
       {phase.kind === "failed" ? (
         <SettingsSection title="Could not connect">
           <div className="space-y-3 px-4 py-4">
-            <p className="text-sm text-muted-foreground">{phase.message}</p>
+            <p role="status" className="text-sm text-muted-foreground">
+              {phase.message}
+            </p>
             <Button
               variant="outline"
               onClick={() => appNavigate(SETTINGS_PATH)}

--- a/mcpjam-inspector/client/src/components/settings/GithubInstallCallbackRoute.tsx
+++ b/mcpjam-inspector/client/src/components/settings/GithubInstallCallbackRoute.tsx
@@ -1,0 +1,254 @@
+import { useCallback, useEffect, useRef, useState } from "react";
+import { useSearchParams } from "react-router";
+import { Github } from "lucide-react";
+import { Button } from "@mcpjam/design-system/button";
+import { useAppNavigate } from "@/lib/app-navigation";
+import { toast } from "@/lib/toast";
+import { redirectToGithub } from "@/lib/github-external-redirect";
+import {
+  githubChecksWriteErrorMessage,
+  GITHUB_BINDING_FAILED_MESSAGE,
+  GITHUB_CALLBACK_INCOMPLETE_MESSAGE,
+} from "@/lib/github-checks-errors";
+import {
+  useGithubInstallCallbacks,
+  type ClaimableInstallation,
+} from "@/hooks/useGithubChecksSettings";
+import { SettingsPageShell } from "./SettingsPageShell";
+import { SettingsSection } from "../setting/SettingsSection";
+
+/**
+ * `/settings/integrations/github/callback` — where GitHub sends the browser
+ * back, twice.
+ *
+ * ONE page for both legs, because the browser cannot tell them apart until it
+ * looks at the query string and neither can we:
+ *
+ *   `installation_id` + `state`  → the App's SETUP redirect. The backend
+ *     consumes the install state, records the installation id as an unproven
+ *     CANDIDATE, and hands back GitHub's user-authorization URL. We follow it.
+ *
+ *   `code` + `state`             → the OAuth redirect. The backend exchanges
+ *     the code, proves the candidate against `GET /user/installations`, and
+ *     either finishes the bind or — for a direct-install claim, which had no
+ *     candidate — returns the proven list for a pick.
+ *
+ * EVERYTHING IS PASSED THROUGH VERBATIM. Nothing here parses, normalizes, or
+ * pre-validates a parameter. The backend matches states by hash and treats the
+ * installation id as a claim GitHub itself says can be spoofed, so any
+ * cleverness in the browser could only turn one refusal into a different one —
+ * while a well-meaning "clean this up first" is how a legitimate state stops
+ * matching.
+ *
+ * Every failure renders the SAME copy. The backend refuses flatly on purpose:
+ * telling "already connected to another workspace" apart from "that
+ * installation does not exist" apart from "your proof failed" would answer
+ * questions about other people's GitHub accounts.
+ */
+
+type Phase =
+  | { kind: "working" }
+  | { kind: "failed"; message: string }
+  | {
+      kind: "pick";
+      linkSessionId: string;
+      installations: ClaimableInstallation[];
+    };
+
+const SETTINGS_PATH = "/settings/integrations/github";
+
+export function GithubInstallCallbackRoute() {
+  const [searchParams] = useSearchParams();
+  const appNavigate = useAppNavigate();
+  const {
+    completeInstallSetup,
+    completeUserAuthorization,
+    claimProvenInstallation,
+  } = useGithubInstallCallbacks();
+
+  const [phase, setPhase] = useState<Phase>({ kind: "working" });
+  const [claiming, setClaiming] = useState<number | null>(null);
+
+  // GitHub's redirect is a full page load, but React 18 StrictMode runs effects
+  // twice in development — and both legs CONSUME a one-time state, so a second
+  // run would burn it and land the user on "we could not finish connecting"
+  // having done nothing wrong. Ref rather than state: it must be set
+  // synchronously, before the second invocation can read it.
+  const startedRef = useRef(false);
+
+  const installationId = searchParams.get("installation_id");
+  const state = searchParams.get("state");
+  const code = searchParams.get("code");
+
+  const fail = useCallback((error: unknown) => {
+    setPhase({
+      kind: "failed",
+      // The backend words these; `githubChecksWriteErrorMessage` reads the
+      // `ConvexError` payload rather than the masked `message`. The constant is
+      // only the fallback for a failure that carried no message of its own.
+      message:
+        githubChecksWriteErrorMessage(error) || GITHUB_BINDING_FAILED_MESSAGE,
+    });
+  }, []);
+
+  useEffect(() => {
+    if (startedRef.current) return;
+    startedRef.current = true;
+
+    // The SETUP leg. `installation_id` is a claim; we forward it and let the
+    // backend quarantine it.
+    if (installationId && state) {
+      const parsed = Number(installationId);
+      if (!Number.isInteger(parsed) || parsed <= 0) {
+        // The one thing worth checking here, and only because there is nothing
+        // to send otherwise — GitHub's own parameter must at least be a number.
+        setPhase({ kind: "failed", message: GITHUB_BINDING_FAILED_MESSAGE });
+        return;
+      }
+      void completeInstallSetup({ installationId: parsed, state })
+        .then(({ authorizeUrl }) => redirectToGithub(authorizeUrl))
+        .catch(fail);
+      return;
+    }
+
+    // The OAuth leg.
+    if (code && state) {
+      void completeUserAuthorization({ code, state })
+        .then((result) => {
+          if (result.status === "bound") {
+            toast.success(`Connected ${result.accountLogin}.`);
+            appNavigate(SETTINGS_PATH);
+            return;
+          }
+          setPhase({
+            kind: "pick",
+            linkSessionId: result.linkSessionId,
+            installations: result.installations,
+          });
+        })
+        .catch(fail);
+      return;
+    }
+
+    // Neither. Somebody opened or reloaded this URL directly.
+    setPhase({ kind: "failed", message: GITHUB_CALLBACK_INCOMPLETE_MESSAGE });
+  }, [
+    appNavigate,
+    code,
+    completeInstallSetup,
+    completeUserAuthorization,
+    fail,
+    installationId,
+    state,
+  ]);
+
+  const handleClaim = async (
+    linkSessionId: string,
+    installation: ClaimableInstallation
+  ) => {
+    setClaiming(installation.installationId);
+    try {
+      await claimProvenInstallation({
+        linkSessionId,
+        installationId: installation.installationId,
+      });
+      toast.success(`Connected ${installation.accountLogin}.`);
+      appNavigate(SETTINGS_PATH);
+    } catch (error) {
+      fail(error);
+    } finally {
+      setClaiming(null);
+    }
+  };
+
+  return (
+    <SettingsPageShell active="integrations">
+      <div className="space-y-2">
+        <h2 className="text-lg font-medium">Connect a GitHub account</h2>
+      </div>
+
+      {phase.kind === "working" ? (
+        <p className="text-sm text-muted-foreground">
+          Finishing up with GitHub…
+        </p>
+      ) : null}
+
+      {phase.kind === "failed" ? (
+        <SettingsSection title="Could not connect">
+          <div className="space-y-3 px-4 py-4">
+            <p className="text-sm text-muted-foreground">{phase.message}</p>
+            <Button
+              variant="outline"
+              onClick={() => appNavigate(SETTINGS_PATH)}
+            >
+              Back to GitHub Checks
+            </Button>
+          </div>
+        </SettingsSection>
+      ) : null}
+
+      {phase.kind === "pick" ? (
+        <SettingsSection title="Choose an account">
+          {phase.installations.length === 0 ? (
+            <div className="space-y-3 px-4 py-4 text-sm text-muted-foreground">
+              {/* An EMPTY proven list is a real answer, not a failure: this
+                  GitHub user has the app installed nowhere. Saying so is more
+                  useful than the generic refusal. */}
+              <p>
+                You are signed in to GitHub, but the MCPJam app is not installed
+                on any account you administer. Install it first, then come back.
+              </p>
+              <Button
+                variant="outline"
+                onClick={() => appNavigate(SETTINGS_PATH)}
+              >
+                Back to GitHub Checks
+              </Button>
+            </div>
+          ) : (
+            <>
+              <p className="px-4 pt-3 text-sm text-muted-foreground">
+                These are the accounts you administer that already have the
+                MCPJam app installed. Connecting one lets this workspace run
+                checks on its repositories.
+              </p>
+              {phase.installations.map((installation) => (
+                <div
+                  key={installation.installationId}
+                  className="flex items-center justify-between gap-4 px-4 py-3"
+                  data-testid={`claimable-${installation.accountLogin}`}
+                >
+                  <div className="flex items-center gap-3 min-w-0">
+                    <Github
+                      className="size-4 text-muted-foreground shrink-0"
+                      aria-hidden
+                    />
+                    <div className="flex flex-col min-w-0">
+                      <span className="text-sm font-medium truncate">
+                        {installation.accountLogin}
+                      </span>
+                      <span className="text-xs text-muted-foreground">
+                        {installation.accountType === "Organization"
+                          ? "Organization"
+                          : "Personal account"}
+                      </span>
+                    </div>
+                  </div>
+                  <Button
+                    size="sm"
+                    disabled={claiming !== null}
+                    onClick={() =>
+                      void handleClaim(phase.linkSessionId, installation)
+                    }
+                  >
+                    Connect
+                  </Button>
+                </div>
+              ))}
+            </>
+          )}
+        </SettingsSection>
+      ) : null}
+    </SettingsPageShell>
+  );
+}

--- a/mcpjam-inspector/client/src/components/settings/GithubInstallCallbackRoute.tsx
+++ b/mcpjam-inspector/client/src/components/settings/GithubInstallCallbackRoute.tsx
@@ -106,7 +106,22 @@ export function GithubInstallCallbackRoute() {
         return;
       }
       void completeInstallSetup({ installationId: parsed, state })
-        .then(({ authorizeUrl }) => redirectToGithub(authorizeUrl))
+        .then(({ authorizeUrl }) => {
+          try {
+            redirectToGithub(authorizeUrl);
+          } catch {
+            // A redirect the guard refused is NOT a backend refusal, and must
+            // not be reported as one: `UnsafeRedirectError`'s message is
+            // developer text ("Refused to redirect outside GitHub"), and
+            // `fail` would put it on screen verbatim. The user gets the flat
+            // binding copy; there is nothing for them to do differently.
+            console.error("[github-checks] refused an unsafe authorize URL");
+            setPhase({
+              kind: "failed",
+              message: GITHUB_BINDING_FAILED_MESSAGE,
+            });
+          }
+        })
         .catch(fail);
       return;
     }

--- a/mcpjam-inspector/client/src/components/settings/__tests__/github-checks-route.test.tsx
+++ b/mcpjam-inspector/client/src/components/settings/__tests__/github-checks-route.test.tsx
@@ -20,6 +20,11 @@ const {
   mockConnectRepo,
   mockConnectVerifiedRepo,
   mockListInstallationRepos,
+  mockBindings,
+  mockStartInstallation,
+  mockStartDirectClaim,
+  mockUnbindInstallation,
+  mockRedirectToGithub,
   mockOrgsLoading,
   mockAuthLoading,
 } = vi.hoisted(() => ({
@@ -36,10 +41,35 @@ const {
   // window. It is handed to the component so that reaching for it is a
   // recorded call rather than a crash — "never called" is the assertion.
   mockConnectRepo: vi.fn(async () => ({ configId: "cfg-legacy" })),
-  mockConnectVerifiedRepo: vi.fn(async () => ({ configId: "cfg-new" })),
-  mockListInstallationRepos: vi.fn(async () => [
-    { fullName: "mcpjam/other-repo" },
-  ]),
+  // Typed loosely on purpose. These stand in for Convex actions whose real
+  // arguments are hand-mirrored strings, and pinning a narrow inferred shape
+  // here would make every fixture that adds one optional field a type error in
+  // a file whose job is to vary those fixtures.
+  mockConnectVerifiedRepo: vi.fn(async (_args?: Record<string, unknown>) => ({
+    configId: "cfg-new",
+  })),
+  mockListInstallationRepos: vi.fn(
+    async (): Promise<unknown[]> => [
+      {
+        repositoryId: 2,
+        fullName: "mcpjam/other-repo",
+        installationRef: "bind-1",
+        accountLogin: "mcpjam",
+      },
+    ]
+  ),
+  mockBindings: { value: undefined as unknown[] | undefined },
+  mockStartInstallation: vi.fn(async () => ({
+    installUrl: "https://github.com/apps/mcpjam/installations/new?state=abc",
+  })),
+  mockStartDirectClaim: vi.fn(async () => ({
+    authorizeUrl: "https://github.com/login/oauth/authorize?client_id=x",
+  })),
+  mockUnbindInstallation: vi.fn(async () => ({ changed: true })),
+  // `window.location.assign` is the one thing jsdom will not let a test observe
+  // cleanly, so the redirect lives behind a named export and this stands in for
+  // it. "Where did we send them" is the assertion.
+  mockRedirectToGithub: vi.fn(),
   mockOrgsLoading: { value: false },
   mockAuthLoading: { value: false },
 }));
@@ -51,6 +81,7 @@ vi.mock("@/hooks/useGithubChecksSettings", () => ({
     isEnabled: mockAvailability.value?.state === "enabled",
     repos: mockRepos.value,
     suites: mockSuites.value,
+    bindings: mockBindings.value,
     connectRepo: mockConnectRepo,
     connectVerifiedRepo: mockConnectVerifiedRepo,
     setRepoEnabled: mockSetRepoEnabled,
@@ -58,7 +89,14 @@ vi.mock("@/hooks/useGithubChecksSettings", () => ({
     setRepoOutagePolicy: mockSetRepoOutagePolicy,
     disconnectRepo: mockDisconnectRepo,
     listInstallationRepos: mockListInstallationRepos,
+    startInstallation: mockStartInstallation,
+    startDirectClaim: mockStartDirectClaim,
+    unbindInstallation: mockUnbindInstallation,
   }),
+}));
+
+vi.mock("@/lib/github-external-redirect", () => ({
+  redirectToGithub: mockRedirectToGithub,
 }));
 
 vi.mock("@/lib/toast", () => ({
@@ -91,9 +129,63 @@ const ROW = {
   organizationId: "org-1",
   projectId: "proj-1",
   suiteId: "suite-1",
+  // Backend-DERIVED. The page never computes this, and in particular never
+  // infers it from a missing visibility badge.
+  connectionStatus: "verified" as const,
   createdAt: 1,
   updatedAt: 1,
 };
+
+/**
+ * One entry from the installation listing.
+ *
+ * `repositoryId` is required and is what the picker is keyed on — two accounts
+ * can each have a `widgets`, so a name is not a selector. Ids are derived from
+ * the name so a fixture never has to invent one, and stay stable across a test.
+ */
+let nextRepositoryId = 1000;
+const repositoryIds = new Map<string, number>();
+function repo(
+  fullName: string,
+  overrides: {
+    private?: boolean;
+    installationRef?: string | null;
+    accountLogin?: string;
+  } = {}
+) {
+  const key = fullName.trim().toLowerCase();
+  if (!repositoryIds.has(key)) repositoryIds.set(key, (nextRepositoryId += 1));
+  return {
+    repositoryId: repositoryIds.get(key) as number,
+    fullName,
+    ...(overrides.installationRef === null
+      ? {}
+      : { installationRef: overrides.installationRef ?? "bind-1" }),
+    ...(overrides.accountLogin !== undefined
+      ? { accountLogin: overrides.accountLogin }
+      : { accountLogin: "mcpjam" }),
+    ...(overrides.private !== undefined ? { private: overrides.private } : {}),
+  };
+}
+
+/** One connected GitHub account. */
+function binding(
+  accountLogin: string,
+  overrides: {
+    installationRef?: string;
+    status?: "active" | "suspended" | "removed" | "unbound";
+    accountType?: "Organization" | "User";
+  } = {}
+) {
+  return {
+    installationRef: overrides.installationRef ?? `bind-${accountLogin}`,
+    accountLogin,
+    accountType: overrides.accountType ?? ("Organization" as const),
+    status: overrides.status ?? ("active" as const),
+    boundAt: 1,
+    statusChangedAt: 1,
+  };
+}
 
 /** A row connected before the outage policy existed: nothing was stored. */
 const UNSET_POLICY_ROW = ROW;
@@ -157,6 +249,7 @@ describe("GithubChecksRoute availability gate", () => {
     ];
     mockOrgsLoading.value = false;
     mockAuthLoading.value = false;
+    mockBindings.value = [binding("mcpjam")];
     vi.clearAllMocks();
   });
 
@@ -328,9 +421,10 @@ describe("GithubChecksRoute connect flow", () => {
     ];
     mockOrgsLoading.value = false;
     mockAuthLoading.value = false;
+    mockBindings.value = [binding("mcpjam")];
     mockListInstallationRepos.mockReset();
     mockListInstallationRepos.mockResolvedValue([
-      { fullName: "mcpjam/other-repo", private: false },
+      repo("mcpjam/other-repo", { private: false }),
     ]);
     mockConnectVerifiedRepo.mockReset();
     mockConnectVerifiedRepo.mockResolvedValue({ configId: "cfg-new" });
@@ -359,8 +453,8 @@ describe("GithubChecksRoute connect flow", () => {
     // visibility badge from one comparison and slips past the already-connected
     // filter beside it becomes an offer the submit is refused for.
     mockListInstallationRepos.mockResolvedValue([
-      { fullName: " MCPJam/MCP-Check-Fixture ", private: true },
-      { fullName: "mcpjam/other-repo", private: false },
+      repo(" MCPJam/MCP-Check-Fixture ", { private: true }),
+      repo("mcpjam/other-repo", { private: false }),
     ]);
     const user = userEvent.setup();
     renderRoute();
@@ -404,9 +498,16 @@ describe("GithubChecksRoute connect flow", () => {
       projectId: "proj-1",
       suiteId: "suite-1",
       outagePolicy: "fail_closed",
+      // Taken STRAIGHT OFF the picked listing entry. The reference says which
+      // installation the repository was enumerated through and the id says
+      // which repository it is; the server re-verifies both, and neither is
+      // reassembled here from a name.
+      installationRef: "bind-1",
+      repositoryId: repositoryIds.get("mcpjam/other-repo"),
     });
-    // The unverified mutation still exists on the backend. Calling it would
-    // write a config row for a repository nobody proved the App can reach.
+    // The unverified mutation is GONE from the backend. Calling it would now
+    // fail outright, and before it was removed it wrote config rows for
+    // repositories nobody proved the App could reach.
     expect(mockConnectRepo).not.toHaveBeenCalled();
   });
 
@@ -533,6 +634,7 @@ describe("GithubChecksRoute row outage policy", () => {
     ];
     mockOrgsLoading.value = false;
     mockAuthLoading.value = false;
+    mockBindings.value = [binding("mcpjam")];
     mockListInstallationRepos.mockReset();
     mockListInstallationRepos.mockResolvedValue([]);
     mockSetRepoOutagePolicy.mockReset();
@@ -667,6 +769,7 @@ describe("GithubChecksRoute repository visibility", () => {
     ];
     mockOrgsLoading.value = false;
     mockAuthLoading.value = false;
+    mockBindings.value = [binding("mcpjam")];
     mockRepos.value = [ROW];
     mockListInstallationRepos.mockReset();
   });
@@ -679,8 +782,8 @@ describe("GithubChecksRoute repository visibility", () => {
     // GitHub answers with its own casing, and the row stores the canonical
     // lowercase form. Both sides are normalized so the join survives that.
     mockListInstallationRepos.mockResolvedValue([
-      { fullName: "MCPJam/MCP-Check-Fixture", private: true },
-      { fullName: " mcpjam/Public-Fixture ", private: false },
+      repo("MCPJam/MCP-Check-Fixture", { private: true }),
+      repo(" mcpjam/Public-Fixture ", { private: false }),
     ]);
     renderRoute();
 
@@ -691,11 +794,11 @@ describe("GithubChecksRoute repository visibility", () => {
   it.each([
     [
       "GitHub omitted the flag",
-      [{ fullName: "mcpjam/mcp-check-fixture" }] as unknown[],
+      [repo("mcpjam/mcp-check-fixture")] as unknown[],
     ],
     [
       "the row is not in the installation listing",
-      [{ fullName: "mcpjam/other-repo", private: false }] as unknown[],
+      [repo("mcpjam/other-repo", { private: false })] as unknown[],
     ],
     ["the listing is empty", [] as unknown[]],
   ])("asserts no visibility when %s", async (_case, listing) => {
@@ -749,6 +852,7 @@ describe("GithubChecksRoute organization switching", () => {
     ];
     mockOrgsLoading.value = false;
     mockAuthLoading.value = false;
+    mockBindings.value = [binding("mcpjam")];
     mockListInstallationRepos.mockReset();
     mockConnectVerifiedRepo.mockReset();
     mockConnectVerifiedRepo.mockResolvedValue({ configId: "cfg-new" });
@@ -765,7 +869,7 @@ describe("GithubChecksRoute organization switching", () => {
           })
       )
       .mockResolvedValue([
-        { fullName: "mcpjam/mcp-check-fixture", private: false },
+        repo("mcpjam/mcp-check-fixture", { private: false }),
       ]);
 
     const { rerender } = render(routeTree("org-1"));
@@ -777,7 +881,7 @@ describe("GithubChecksRoute organization switching", () => {
 
     // org-1's answer, arriving late and disagreeing.
     await act(async () => {
-      resolveStale?.([{ fullName: "mcpjam/mcp-check-fixture", private: true }]);
+      resolveStale?.([repo("mcpjam/mcp-check-fixture", { private: true })]);
     });
 
     expect(screen.getByText("Public")).toBeInTheDocument();
@@ -787,7 +891,7 @@ describe("GithubChecksRoute organization switching", () => {
   it("drops a connect that completes after the organization changed", async () => {
     mockRepos.value = [];
     mockListInstallationRepos.mockResolvedValue([
-      { fullName: "mcpjam/other-repo", private: false },
+      repo("mcpjam/other-repo", { private: false }),
     ]);
     let resolveStaleConnect: ((result: unknown) => void) | undefined;
     mockConnectVerifiedRepo.mockImplementationOnce(
@@ -825,5 +929,314 @@ describe("GithubChecksRoute organization switching", () => {
     expect(screen.getByLabelText("Outage policy")).toHaveTextContent(
       "Fail open"
     );
+  });
+});
+
+// ═══════════════════════════════════════════════════════════════════════════
+// GITHUB ACCOUNTS — the org ↔ installation binding surface
+// ═══════════════════════════════════════════════════════════════════════════
+//
+// Three properties this section has to hold, all of which are about NOT saying
+// something:
+//
+//   1. No raw GitHub installation id is ever rendered. `installationRef` is an
+//      opaque row id and is the only handle the page has.
+//   2. A refusal is shown exactly as the backend worded it. The backend refuses
+//      flatly on purpose — telling "already connected to another workspace"
+//      apart from "that installation does not exist" would answer questions
+//      about other people's accounts — so the page must not embellish.
+//   3. Disconnecting asks first, and the confirmation says the LIMIT of the
+//      consequence as well as the consequence.
+
+describe("GithubChecksRoute installations", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockAvailability.value = { state: "enabled" };
+    mockRepos.value = [];
+    mockSuites.value = [];
+    mockOrgsLoading.value = false;
+    mockAuthLoading.value = false;
+    mockBindings.value = [];
+    mockListInstallationRepos.mockReset();
+    mockListInstallationRepos.mockResolvedValue([]);
+    mockStartInstallation.mockReset();
+    mockStartInstallation.mockResolvedValue({
+      installUrl: "https://github.com/apps/mcpjam/installations/new?state=abc",
+    });
+    mockStartDirectClaim.mockReset();
+    mockStartDirectClaim.mockResolvedValue({
+      authorizeUrl: "https://github.com/login/oauth/authorize?client_id=x",
+    });
+    mockUnbindInstallation.mockReset();
+    mockUnbindInstallation.mockResolvedValue({ changed: true });
+    mockRedirectToGithub.mockReset();
+  });
+
+  it("offers both an install and a claim, and explains why claiming needs GitHub", async () => {
+    renderRoute();
+    expect(
+      await screen.findByRole("button", { name: /Install on a GitHub account/ })
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: /Claim an existing installation/ })
+    ).toBeInTheDocument();
+    // The whole reason the claim path needs an OAuth leg, in one sentence: the
+    // App JWT can read every installation it has, so installing is not proof
+    // that an installation is yours to connect here.
+    expect(
+      screen.getByText(/is not on its own proof that it is yours to connect/i)
+    ).toBeInTheDocument();
+  });
+
+  it("sends the admin to the server-built install URL", async () => {
+    const user = userEvent.setup();
+    renderRoute();
+    await user.click(
+      await screen.findByRole("button", { name: /Install on a GitHub account/ })
+    );
+
+    await waitFor(() => expect(mockStartInstallation).toHaveBeenCalledTimes(1));
+    // The URL carries a one-time state the BACKEND minted and hashed. The page
+    // only follows it.
+    expect(mockRedirectToGithub).toHaveBeenCalledWith(
+      "https://github.com/apps/mcpjam/installations/new?state=abc"
+    );
+  });
+
+  it("sends the admin to the OAuth URL for a claim", async () => {
+    const user = userEvent.setup();
+    renderRoute();
+    await user.click(
+      await screen.findByRole("button", {
+        name: /Claim an existing installation/,
+      })
+    );
+
+    await waitFor(() => expect(mockStartDirectClaim).toHaveBeenCalledTimes(1));
+    expect(mockRedirectToGithub).toHaveBeenCalledWith(
+      "https://github.com/login/oauth/authorize?client_id=x"
+    );
+  });
+
+  it("shows the backend's conflict wording verbatim, naming no other workspace", async () => {
+    const conflict = Object.assign(new Error("Server Error"), {
+      data: "That GitHub installation is already connected to a workspace. This is not a problem with your repositories — ask whoever set it up to disconnect it first, or install the app on a different account.",
+    });
+    mockStartInstallation.mockRejectedValue(conflict);
+    const user = userEvent.setup();
+    renderRoute();
+
+    await user.click(
+      await screen.findByRole("button", { name: /Install on a GitHub account/ })
+    );
+    await waitFor(() => expect(toast.error).toHaveBeenCalled());
+
+    const shown = String(
+      (toast.error as ReturnType<typeof vi.fn>).mock.calls[0][0]
+    );
+    expect(shown).toMatch(/already connected to a workspace/i);
+    // Non-disclosure survives the trip through the UI.
+    expect(shown).not.toMatch(/organization|workspace named|org-/i);
+  });
+
+  it.each([
+    ["active", /Repositories on this account can run checks/i],
+    ["suspended", /Suspended on GitHub/i],
+    ["removed", /uninstalled from this account/i],
+  ] as const)("renders the %s binding state", async (status, copy) => {
+    mockBindings.value = [binding("acme", { status })];
+    renderRoute();
+    expect(await screen.findByText("acme")).toBeInTheDocument();
+    expect(screen.getByText(copy)).toBeInTheDocument();
+  });
+
+  it("never renders a raw GitHub installation id", async () => {
+    mockBindings.value = [binding("acme")];
+    const { container } = renderRoute();
+    await screen.findByText("acme");
+    // The opaque ref is all the page has, and even that is not user-facing.
+    expect(container.textContent).not.toMatch(/\b\d{6,}\b/);
+  });
+
+  it("asks before disconnecting, and says what is KEPT as well as what stops", async () => {
+    mockBindings.value = [binding("acme")];
+    const user = userEvent.setup();
+    renderRoute();
+
+    await user.click(
+      await screen.findByRole("button", { name: "Disconnect acme" })
+    );
+    expect(
+      await screen.findByText(/Checks on its repositories stop immediately/i)
+    ).toBeInTheDocument();
+    // The limit matters as much as the consequence: reconnecting is not a
+    // rebuild, and copy that implied otherwise would stop admins acting.
+    expect(
+      screen.getByText(/suite and policy settings are kept/i)
+    ).toBeInTheDocument();
+    // Nothing has happened yet.
+    expect(mockUnbindInstallation).not.toHaveBeenCalled();
+  });
+
+  it("disconnects with the opaque ref once confirmed", async () => {
+    mockBindings.value = [binding("acme", { installationRef: "bind-xyz" })];
+    const user = userEvent.setup();
+    renderRoute();
+
+    await user.click(
+      await screen.findByRole("button", { name: "Disconnect acme" })
+    );
+    await user.click(await screen.findByRole("button", { name: "Disconnect" }));
+
+    await waitFor(() =>
+      expect(mockUnbindInstallation).toHaveBeenCalledWith({
+        installationRef: "bind-xyz",
+      })
+    );
+  });
+
+  it("does not disconnect when the confirmation is dismissed", async () => {
+    mockBindings.value = [binding("acme")];
+    const user = userEvent.setup();
+    renderRoute();
+
+    await user.click(
+      await screen.findByRole("button", { name: "Disconnect acme" })
+    );
+    await user.click(
+      await screen.findByRole("button", { name: "Keep it connected" })
+    );
+
+    expect(mockUnbindInstallation).not.toHaveBeenCalled();
+  });
+});
+
+// ═══════════════════════════════════════════════════════════════════════════
+// CONNECTION STATUS, AND THE PICKER'S IDENTITY
+// ═══════════════════════════════════════════════════════════════════════════
+
+describe("GithubChecksRoute connection status", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockAvailability.value = { state: "enabled" };
+    mockSuites.value = [
+      { _id: "suite-1", name: "Fixture suite", projectId: "proj-1" },
+    ];
+    mockOrgsLoading.value = false;
+    mockAuthLoading.value = false;
+    mockBindings.value = [binding("mcpjam")];
+    mockListInstallationRepos.mockReset();
+    mockListInstallationRepos.mockResolvedValue([]);
+  });
+
+  it("renders no badge at all for a verified row", async () => {
+    mockRepos.value = [ROW];
+    renderRoute();
+    await screen.findByText("mcpjam/mcp-check-fixture");
+    // A badge saying "fine" on every healthy row makes the rows that need
+    // attention harder to find.
+    expect(screen.queryByText("Reconnect required")).not.toBeInTheDocument();
+    expect(screen.queryByText("App inactive")).not.toBeInTheDocument();
+    expect(screen.queryByText("No access")).not.toBeInTheDocument();
+  });
+
+  it.each([
+    ["legacy_unverified", "Reconnect required", /Reconnect it to keep checks/i],
+    ["installation_inactive", "App inactive", /not active on this account/i],
+    ["repository_access_removed", "No access", /no longer has access/i],
+  ] as const)("renders %s", async (status, label, explainer) => {
+    mockRepos.value = [{ ...ROW, connectionStatus: status }];
+    renderRoute();
+    expect(await screen.findByText(label)).toBeInTheDocument();
+    expect(screen.getByText(explainer)).toBeInTheDocument();
+    // Every one of these says what it is NOT, because the natural reading of a
+    // stopped check is "my code did something" and none of these is that.
+    expect(
+      screen.getByText(
+        /not a problem with your pull requests|nothing is wrong/i
+      )
+    ).toBeInTheDocument();
+  });
+
+  it("does NOT infer a status from a missing visibility badge", async () => {
+    // GitHub omitting `private` means "we do not know", not "something is
+    // wrong". Conflating them would put a warning on a healthy repository.
+    mockRepos.value = [ROW];
+    mockListInstallationRepos.mockResolvedValue([
+      repo("mcpjam/mcp-check-fixture"),
+    ]);
+    renderRoute();
+    await screen.findByText("mcpjam/mcp-check-fixture");
+    await waitFor(() => expect(mockListInstallationRepos).toHaveBeenCalled());
+
+    expect(screen.queryByText("Private")).not.toBeInTheDocument();
+    expect(screen.queryByText("Public")).not.toBeInTheDocument();
+    expect(screen.queryByText("Reconnect required")).not.toBeInTheDocument();
+  });
+
+  it("labels the account only when it disambiguates", async () => {
+    mockRepos.value = [];
+    mockListInstallationRepos.mockResolvedValue([
+      repo("acme/widgets", { accountLogin: "acme", installationRef: "b1" }),
+      repo("globex/widgets", { accountLogin: "globex", installationRef: "b2" }),
+    ]);
+    const user = userEvent.setup();
+    renderRoute();
+    await waitFor(() => expect(mockListInstallationRepos).toHaveBeenCalled());
+
+    await user.click(screen.getByLabelText("Repository"));
+    expect(
+      await screen.findByRole("option", { name: "acme/widgets · acme" })
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("option", { name: "globex/widgets · globex" })
+    ).toBeInTheDocument();
+  });
+
+  it("omits the account label when there is only one", async () => {
+    mockRepos.value = [];
+    mockListInstallationRepos.mockResolvedValue([
+      repo("acme/widgets", { accountLogin: "acme" }),
+      repo("acme/gadgets", { accountLogin: "acme" }),
+    ]);
+    const user = userEvent.setup();
+    renderRoute();
+    await waitFor(() => expect(mockListInstallationRepos).toHaveBeenCalled());
+
+    await user.click(screen.getByLabelText("Repository"));
+    // One repeated label on every row is a column of noise.
+    expect(
+      await screen.findByRole("option", { name: "acme/widgets" })
+    ).toBeInTheDocument();
+  });
+
+  it("sends no installationRef when the listing carried none", async () => {
+    // The compatibility window: the backend is still falling back to its pinned
+    // installation for an org with no binding, and omitting the reference is
+    // what keeps that connect path reachable.
+    mockRepos.value = [];
+    mockConnectVerifiedRepo.mockReset();
+    mockConnectVerifiedRepo.mockResolvedValue({ configId: "cfg-pinned" });
+    mockListInstallationRepos.mockResolvedValue([
+      repo("mcpjam/pinned-repo", { installationRef: null, accountLogin: "" }),
+    ]);
+    const user = userEvent.setup();
+    renderRoute();
+    await waitFor(() => expect(mockListInstallationRepos).toHaveBeenCalled());
+
+    await chooseOption(user, "Repository", "mcpjam/pinned-repo");
+    await chooseOption(user, "Suite", "Fixture suite");
+    await chooseOption(user, "Outage policy", "Fail closed");
+    await user.click(connectButton());
+
+    await waitFor(() =>
+      expect(mockConnectVerifiedRepo).toHaveBeenCalledTimes(1)
+    );
+    const sent = mockConnectVerifiedRepo.mock.calls[0]?.[0] as Record<
+      string,
+      unknown
+    >;
+    expect(sent).not.toHaveProperty("installationRef");
+    expect(sent.repositoryId).toBe(repositoryIds.get("mcpjam/pinned-repo"));
   });
 });

--- a/mcpjam-inspector/client/src/components/settings/__tests__/github-checks-route.test.tsx
+++ b/mcpjam-inspector/client/src/components/settings/__tests__/github-checks-route.test.tsx
@@ -1051,11 +1051,38 @@ describe("GithubChecksRoute installations", () => {
   });
 
   it("never renders a raw GitHub installation id", async () => {
-    mockBindings.value = [binding("acme")];
+    // The fixture CARRIES one, and this is the only assertion that mentions it.
+    // Without it the test passes for any rendering — including one that echoes
+    // an id it was never given — because no other fixture here has digits in.
+    const RAW_INSTALLATION_ID = "48213907";
+    mockBindings.value = [
+      { ...binding("acme"), installationId: Number(RAW_INSTALLATION_ID) },
+    ];
     const { container } = renderRoute();
     await screen.findByText("acme");
-    // The opaque ref is all the page has, and even that is not user-facing.
+
+    // The opaque ref is all the page should use, and even that is not
+    // user-facing.
+    expect(container.textContent).not.toContain(RAW_INSTALLATION_ID);
     expect(container.textContent).not.toMatch(/\b\d{6,}\b/);
+  });
+
+  it("has copy for `unbound`, which the backend does not send", async () => {
+    // The fourth state in `GITHUB_BINDING_STATUS_COPY`. The BACKEND filters
+    // `unbound` rows out of `listBindingsForOrganization` — an admin severed
+    // that relationship deliberately, and a fifth state to interpret adds
+    // nothing — so this is unreachable in practice.
+    //
+    // The page deliberately does NOT re-implement that filter. A second
+    // authority on which bindings are visible is exactly the kind of thing
+    // that disagrees with the first one later. The map stays total over the
+    // status union instead, so a backend that ever did send one renders
+    // something true rather than `undefined`, and this pins that.
+    mockBindings.value = [binding("acme", { status: "unbound" })];
+    renderRoute();
+    expect(
+      await screen.findByText(/Disconnected from this workspace/i)
+    ).toBeInTheDocument();
   });
 
   it("asks before disconnecting, and says what is KEPT as well as what stops", async () => {

--- a/mcpjam-inspector/client/src/components/settings/__tests__/github-install-callback-route.test.tsx
+++ b/mcpjam-inspector/client/src/components/settings/__tests__/github-install-callback-route.test.tsx
@@ -1,3 +1,4 @@
+import { StrictMode } from "react";
 import { render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { MemoryRouter, Route, Routes } from "react-router";
@@ -64,13 +65,24 @@ import { GithubInstallCallbackRoute } from "../GithubInstallCallbackRoute";
 
 const PATH = "/settings/integrations/github/callback";
 
+/**
+ * Rendered inside `StrictMode` deliberately.
+ *
+ * StrictMode mounts, unmounts and remounts in development, running the effect
+ * twice — and BOTH legs consume a single-use state, so a second run would burn
+ * it and land the user on a refusal having done nothing wrong. A `rerender`
+ * would not exercise that: it keeps the same instance, so the guard's ref
+ * survives for a reason unrelated to the double mount.
+ */
 function renderCallback(query: string) {
   return render(
-    <MemoryRouter initialEntries={[`${PATH}${query}`]}>
-      <Routes>
-        <Route path={PATH} element={<GithubInstallCallbackRoute />} />
-      </Routes>
-    </MemoryRouter>
+    <StrictMode>
+      <MemoryRouter initialEntries={[`${PATH}${query}`]}>
+        <Routes>
+          <Route path={PATH} element={<GithubInstallCallbackRoute />} />
+        </Routes>
+      </MemoryRouter>
+    </StrictMode>
   );
 }
 
@@ -124,26 +136,39 @@ describe("the setup leg", () => {
     expect(mockCompleteInstallSetup).not.toHaveBeenCalled();
   });
 
-  it("runs the one-time state exchange exactly once", async () => {
-    // Both legs CONSUME a single-use state. A second run — StrictMode's double
-    // effect, say — would burn it and land the user on a refusal having done
-    // nothing wrong.
+  it("runs the one-time state exchange exactly once under StrictMode", async () => {
+    // The real hazard, and the reason `renderCallback` wraps in StrictMode:
+    // the development double-mount would otherwise burn the single-use state
+    // on its second run.
     mockCompleteInstallSetup.mockResolvedValue({
       authorizeUrl: "https://github.com/login/oauth/authorize",
     });
-    const { rerender } = renderCallback("?installation_id=1&state=s");
+    renderCallback("?installation_id=1&state=s");
+
     await waitFor(() =>
       expect(mockCompleteInstallSetup).toHaveBeenCalledTimes(1)
     );
-
-    rerender(
-      <MemoryRouter initialEntries={[`${PATH}?installation_id=1&state=s`]}>
-        <Routes>
-          <Route path={PATH} element={<GithubInstallCallbackRoute />} />
-        </Routes>
-      </MemoryRouter>
-    );
+    // Let anything the second mount queued settle before asserting, so this
+    // cannot pass merely by looking too early.
+    await new Promise((resolve) => setTimeout(resolve, 0));
     expect(mockCompleteInstallSetup).toHaveBeenCalledTimes(1);
+  });
+
+  it("shows the refusal when the returned URL is not a GitHub URL", async () => {
+    // `redirectToGithub` throws on anything outside github.com, and that throw
+    // lands in the same `.catch` as a backend refusal. The seam between the
+    // redirect guard and this page is exactly where a regression would hide.
+    mockCompleteInstallSetup.mockResolvedValue({
+      authorizeUrl: "https://github.com.evil.test/login/oauth/authorize",
+    });
+    mockRedirectToGithub.mockImplementation(() => {
+      throw new Error("Refused to redirect outside GitHub");
+    });
+    renderCallback("?installation_id=4242&state=s");
+
+    expect(
+      await screen.findByText(/could not finish connecting/i)
+    ).toBeInTheDocument();
   });
 });
 

--- a/mcpjam-inspector/client/src/components/settings/__tests__/github-install-callback-route.test.tsx
+++ b/mcpjam-inspector/client/src/components/settings/__tests__/github-install-callback-route.test.tsx
@@ -1,0 +1,292 @@
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { MemoryRouter, Route, Routes } from "react-router";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+// ═══════════════════════════════════════════════════════════════════════════
+// GITHUB'S RETURN PATH, BOTH LEGS
+// ═══════════════════════════════════════════════════════════════════════════
+//
+// The App's setup URL and its OAuth callback point at the SAME path, and the
+// page tells them apart by which query parameters arrived. What these pin:
+//
+//   1. Parameters are forwarded VERBATIM. The backend matches states by hash
+//      and treats the installation id as a claim GitHub itself says can be
+//      spoofed, so any normalization here could only turn a legitimate state
+//      into a non-matching one.
+//   2. The setup leg follows the server-built authorize URL and nothing else.
+//   3. A direct-install claim comes back as a PICK, and the pick sends the
+//      session id the server issued — which is not authority on its own; the
+//      backend re-checks the actor, the session, and the proven list.
+//   4. Every failure renders the copy the backend worded, and a URL with
+//      neither leg's parameters says so plainly instead of looking broken.
+
+const {
+  mockCompleteInstallSetup,
+  mockCompleteUserAuthorization,
+  mockClaimProvenInstallation,
+  mockRedirectToGithub,
+  mockNavigate,
+} = vi.hoisted(() => ({
+  mockCompleteInstallSetup: vi.fn(),
+  mockCompleteUserAuthorization: vi.fn(),
+  mockClaimProvenInstallation: vi.fn(),
+  mockRedirectToGithub: vi.fn(),
+  mockNavigate: vi.fn(),
+}));
+
+vi.mock("@/hooks/useGithubChecksSettings", () => ({
+  useGithubInstallCallbacks: () => ({
+    completeInstallSetup: mockCompleteInstallSetup,
+    completeUserAuthorization: mockCompleteUserAuthorization,
+    claimProvenInstallation: mockClaimProvenInstallation,
+  }),
+}));
+
+vi.mock("@/lib/github-external-redirect", () => ({
+  redirectToGithub: mockRedirectToGithub,
+}));
+
+vi.mock("@/lib/app-navigation", () => ({
+  useAppNavigate: () => mockNavigate,
+}));
+
+vi.mock("@/lib/toast", () => ({
+  toast: { error: vi.fn(), success: vi.fn() },
+}));
+
+vi.mock("../SettingsNav", () => ({
+  SettingsNav: () => <nav data-testid="settings-nav" />,
+}));
+
+import { toast } from "@/lib/toast";
+import { GithubInstallCallbackRoute } from "../GithubInstallCallbackRoute";
+
+const PATH = "/settings/integrations/github/callback";
+
+function renderCallback(query: string) {
+  return render(
+    <MemoryRouter initialEntries={[`${PATH}${query}`]}>
+      <Routes>
+        <Route path={PATH} element={<GithubInstallCallbackRoute />} />
+      </Routes>
+    </MemoryRouter>
+  );
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("the setup leg", () => {
+  it("forwards installation_id and state verbatim, then follows the authorize URL", async () => {
+    mockCompleteInstallSetup.mockResolvedValue({
+      authorizeUrl: "https://github.com/login/oauth/authorize?client_id=x",
+    });
+    renderCallback("?installation_id=4242&state=raw-install-state");
+
+    await waitFor(() =>
+      expect(mockCompleteInstallSetup).toHaveBeenCalledTimes(1)
+    );
+    // The state is passed EXACTLY as GitHub sent it. The backend matches by
+    // hash, so trimming or lower-casing here would simply stop it matching.
+    expect(mockCompleteInstallSetup).toHaveBeenCalledWith({
+      installationId: 4242,
+      state: "raw-install-state",
+    });
+    await waitFor(() =>
+      expect(mockRedirectToGithub).toHaveBeenCalledWith(
+        "https://github.com/login/oauth/authorize?client_id=x"
+      )
+    );
+  });
+
+  it("shows the backend's refusal rather than redirecting", async () => {
+    mockCompleteInstallSetup.mockRejectedValue(
+      Object.assign(new Error("Server Error"), {
+        data: "We could not verify that installation with GitHub. This is not a problem with your repositories — start the connection again from Settings.",
+      })
+    );
+    renderCallback("?installation_id=4242&state=s");
+
+    expect(
+      await screen.findByText(/could not verify that installation/i)
+    ).toBeInTheDocument();
+    expect(mockRedirectToGithub).not.toHaveBeenCalled();
+  });
+
+  it("refuses an installation_id that is not a positive integer", async () => {
+    renderCallback("?installation_id=not-a-number&state=s");
+    expect(
+      await screen.findByText(/could not finish connecting/i)
+    ).toBeInTheDocument();
+    // Nothing was sent: there was nothing to send.
+    expect(mockCompleteInstallSetup).not.toHaveBeenCalled();
+  });
+
+  it("runs the one-time state exchange exactly once", async () => {
+    // Both legs CONSUME a single-use state. A second run — StrictMode's double
+    // effect, say — would burn it and land the user on a refusal having done
+    // nothing wrong.
+    mockCompleteInstallSetup.mockResolvedValue({
+      authorizeUrl: "https://github.com/login/oauth/authorize",
+    });
+    const { rerender } = renderCallback("?installation_id=1&state=s");
+    await waitFor(() =>
+      expect(mockCompleteInstallSetup).toHaveBeenCalledTimes(1)
+    );
+
+    rerender(
+      <MemoryRouter initialEntries={[`${PATH}?installation_id=1&state=s`]}>
+        <Routes>
+          <Route path={PATH} element={<GithubInstallCallbackRoute />} />
+        </Routes>
+      </MemoryRouter>
+    );
+    expect(mockCompleteInstallSetup).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe("the OAuth leg", () => {
+  it("forwards code and state verbatim and returns to settings when bound", async () => {
+    mockCompleteUserAuthorization.mockResolvedValue({
+      status: "bound",
+      accountLogin: "acme",
+    });
+    renderCallback("?code=raw-code&state=raw-oauth-state");
+
+    await waitFor(() =>
+      expect(mockCompleteUserAuthorization).toHaveBeenCalledWith({
+        code: "raw-code",
+        state: "raw-oauth-state",
+      })
+    );
+    await waitFor(() =>
+      expect(mockNavigate).toHaveBeenCalledWith("/settings/integrations/github")
+    );
+    expect(toast.success).toHaveBeenCalledWith("Connected acme.");
+  });
+
+  it("renders the proven list for a direct-install claim", async () => {
+    mockCompleteUserAuthorization.mockResolvedValue({
+      status: "pick_required",
+      linkSessionId: "sess-1",
+      installations: [
+        {
+          installationId: 11,
+          accountLogin: "acme",
+          accountType: "Organization",
+        },
+        { installationId: 12, accountLogin: "dana", accountType: "User" },
+      ],
+    });
+    renderCallback("?code=c&state=s");
+
+    expect(await screen.findByText("acme")).toBeInTheDocument();
+    expect(screen.getByText("dana")).toBeInTheDocument();
+    expect(screen.getByText("Organization")).toBeInTheDocument();
+    expect(screen.getByText("Personal account")).toBeInTheDocument();
+  });
+
+  it("offers ONLY what the backend proved", async () => {
+    // The list is held server-side and re-read at the pick, so an installation
+    // that is not in it cannot be selected — and must not be offered either.
+    mockCompleteUserAuthorization.mockResolvedValue({
+      status: "pick_required",
+      linkSessionId: "sess-1",
+      installations: [
+        {
+          installationId: 11,
+          accountLogin: "acme",
+          accountType: "Organization",
+        },
+      ],
+    });
+    renderCallback("?code=c&state=s");
+
+    await screen.findByText("acme");
+    expect(screen.queryByText("globex")).not.toBeInTheDocument();
+    expect(screen.getAllByRole("button", { name: "Connect" })).toHaveLength(1);
+  });
+
+  it("claims with the session id the server issued", async () => {
+    mockCompleteUserAuthorization.mockResolvedValue({
+      status: "pick_required",
+      linkSessionId: "sess-1",
+      installations: [
+        {
+          installationId: 11,
+          accountLogin: "acme",
+          accountType: "Organization",
+        },
+      ],
+    });
+    mockClaimProvenInstallation.mockResolvedValue({
+      status: "bound",
+      accountLogin: "acme",
+    });
+    const user = userEvent.setup();
+    renderCallback("?code=c&state=s");
+    await screen.findByText("acme");
+
+    await user.click(screen.getByRole("button", { name: "Connect" }));
+
+    // Possessing the session id is not authority — the backend re-checks that
+    // the actor started the flow and that this installation is in the proven
+    // list — so passing it through is safe and is the whole handshake.
+    await waitFor(() =>
+      expect(mockClaimProvenInstallation).toHaveBeenCalledWith({
+        linkSessionId: "sess-1",
+        installationId: 11,
+      })
+    );
+  });
+
+  it("says so plainly when the user has the app installed nowhere", async () => {
+    // An EMPTY proven list is a real answer, not a failure.
+    mockCompleteUserAuthorization.mockResolvedValue({
+      status: "pick_required",
+      linkSessionId: "sess-1",
+      installations: [],
+    });
+    renderCallback("?code=c&state=s");
+
+    expect(
+      await screen.findByText(/not installed on any account you administer/i)
+    ).toBeInTheDocument();
+  });
+
+  it("shows a non-disclosing conflict exactly as the backend worded it", async () => {
+    mockCompleteUserAuthorization.mockRejectedValue(
+      Object.assign(new Error("Server Error"), {
+        data: "That GitHub installation is already connected to a workspace. This is not a problem with your repositories — ask whoever set it up to disconnect it first, or install the app on a different account.",
+      })
+    );
+    renderCallback("?code=c&state=s");
+
+    const shown = await screen.findByText(/already connected to a workspace/i);
+    expect(shown).toBeInTheDocument();
+    // It says a workspace, never which one, and never whether one exists.
+    expect(shown.textContent).not.toMatch(/org-|organization named/i);
+  });
+});
+
+describe("neither leg", () => {
+  it("explains a directly-opened callback instead of looking broken", async () => {
+    renderCallback("");
+    expect(
+      await screen.findByText(/opened without the details GitHub sends/i)
+    ).toBeInTheDocument();
+    expect(mockCompleteInstallSetup).not.toHaveBeenCalled();
+    expect(mockCompleteUserAuthorization).not.toHaveBeenCalled();
+  });
+
+  it("offers a way back", async () => {
+    const user = userEvent.setup();
+    renderCallback("");
+    await user.click(
+      await screen.findByRole("button", { name: /Back to GitHub Checks/ })
+    );
+    expect(mockNavigate).toHaveBeenCalledWith("/settings/integrations/github");
+  });
+});

--- a/mcpjam-inspector/client/src/hooks/__tests__/useGithubChecksSettings.test.tsx
+++ b/mcpjam-inspector/client/src/hooks/__tests__/useGithubChecksSettings.test.tsx
@@ -72,6 +72,7 @@ import { ConvexError } from "convex/values";
 import {
   useGithubChecksAvailability,
   useGithubChecksSettings,
+  useGithubInstallCallbacks,
 } from "../useGithubChecksSettings";
 
 function AvailabilityProbe({
@@ -190,13 +191,14 @@ describe("useGithubChecksAvailability", () => {
  * The write surface: WHICH backend functions this hook binds, and exactly what
  * it sends them.
  *
- * Both halves are load-bearing. Connecting a repository moved to a Node action
- * that proves the pinned installation can actually reach the repository before
- * it writes anything; the unverified `checkRepoConfigs:connectRepo` mutation is
- * still deployed for the two-deploy window and would work if it were bound
- * again, silently giving back a config row nobody verified. And the arguments
- * are the contract — `organizationId` is added here so no call site can forget
- * it, and `installationId` is a server-side fact the client never names.
+ * Both halves are load-bearing. Connecting a repository goes through a Node
+ * action that proves the selected installation can actually reach the
+ * repository before it writes anything; the unverified
+ * `checkRepoConfigs:connectRepo` mutation is now REMOVED from the backend, and
+ * binding it again would be binding a dead id. And the arguments are the
+ * contract — `organizationId` is added here so no call site can forget it, and
+ * the GitHub installation id is a server-side fact the client never names: it
+ * selects with an opaque `installationRef` instead.
  */
 describe("useGithubChecksSettings writes", () => {
   function SettingsProbe() {
@@ -211,6 +213,8 @@ describe("useGithubChecksSettings writes", () => {
               projectId: "proj-1",
               suiteId: "suite-1",
               outagePolicy: "fail_closed",
+              installationRef: "bind-1",
+              repositoryId: 4242,
             })
           }
         >
@@ -226,6 +230,17 @@ describe("useGithubChecksSettings writes", () => {
           }
         >
           set policy
+        </button>
+        <button
+          type="button"
+          onClick={() =>
+            void settings.unbindInstallation({ installationRef: "bind-1" })
+          }
+        >
+          unbind
+        </button>
+        <button type="button" onClick={() => void settings.startInstallation()}>
+          install
         </button>
         <div data-testid="exposed">
           {Object.keys(settings).sort().join(",")}
@@ -259,6 +274,13 @@ describe("useGithubChecksSettings writes", () => {
       [
         "action:github/checkRepoConfigsNode:connectVerifiedRepo",
         "action:github/checkRepoConfigsNode:listInstallationRepos",
+        // The org ↔ installation binding surface. Note what is NOT here: the
+        // two GitHub CALLBACK actions live in `useGithubInstallCallbacks`,
+        // because the callback page has no organization to hand them — it
+        // arrives back from GitHub with query parameters and nothing else.
+        "action:github/appInstallLinkNode:startInstallation",
+        "action:github/appInstallLinkNode:startDirectClaim",
+        "mutation:github/appInstallLink:unbindInstallation",
         "mutation:github/checkRepoConfigs:disconnectRepo",
         "mutation:github/checkRepoConfigs:setRepoEnabled",
         "mutation:github/checkRepoConfigs:setRepoOutagePolicy",
@@ -288,16 +310,50 @@ describe("useGithubChecksSettings writes", () => {
       {
         kind: "action",
         name: "github/checkRepoConfigsNode:connectVerifiedRepo",
-        // Exactly these five. No `installationId`: which installation can reach
-        // the repository is resolved and proved server-side, and a client that
-        // could name one would be a client that could pick the wrong one.
+        // No GitHub `installationId`, ever. Which installation can reach the
+        // repository is resolved and proved server-side, and a client that
+        // could name one would be a client that could name the wrong one —
+        // `installationRef` is an opaque row id the backend resolves and
+        // re-checks, not an assertion about GitHub.
         args: {
           organizationId: "org-1",
           repoFullName: "mcpjam/mcp-check-fixture",
           projectId: "proj-1",
           suiteId: "suite-1",
           outagePolicy: "fail_closed",
+          installationRef: "bind-1",
+          repositoryId: 4242,
         },
+      },
+    ]);
+  });
+
+  it("unbinds with the OPAQUE ref, scoped to the org", () => {
+    render(<SettingsProbe />);
+
+    screen.getByText("unbind").click();
+
+    expect(mocks.requests).toEqual([
+      {
+        kind: "mutation",
+        name: "github/appInstallLink:unbindInstallation",
+        args: { organizationId: "org-1", installationRef: "bind-1" },
+      },
+    ]);
+  });
+
+  it("starts an installation with nothing but the org", () => {
+    render(<SettingsProbe />);
+
+    screen.getByText("install").click();
+
+    // The one-time state is minted and hashed SERVER-side; there is nothing for
+    // the client to contribute and nothing for it to get wrong.
+    expect(mocks.requests).toEqual([
+      {
+        kind: "action",
+        name: "github/appInstallLinkNode:startInstallation",
+        args: { organizationId: "org-1" },
       },
     ]);
   });
@@ -316,6 +372,94 @@ describe("useGithubChecksSettings writes", () => {
           configId: "cfg-1",
           outagePolicy: "fail_open",
         },
+      },
+    ]);
+  });
+});
+
+/**
+ * The CALLBACK surface, and why it is a second hook rather than three more
+ * fields on the first.
+ *
+ * The callback page arrives back from GitHub with query parameters and nothing
+ * else — no organization, no app state worth trusting. Which organization a
+ * binding belongs to is recovered from the link session SERVER-side, so a hook
+ * that required an org id here would have to invent one, and a page that read
+ * it from app state could disagree with the session and then be asserting an
+ * organization nobody proved anything about.
+ */
+describe("useGithubInstallCallbacks", () => {
+  function CallbackProbe() {
+    const callbacks = useGithubInstallCallbacks();
+    return (
+      <div>
+        <button
+          type="button"
+          onClick={() =>
+            void callbacks.completeInstallSetup({
+              installationId: 4242,
+              state: "raw-install-state",
+            })
+          }
+        >
+          setup
+        </button>
+        <button
+          type="button"
+          onClick={() =>
+            void callbacks.completeUserAuthorization({
+              code: "raw-code",
+              state: "raw-oauth-state",
+            })
+          }
+        >
+          oauth
+        </button>
+      </div>
+    );
+  }
+
+  beforeEach(() => {
+    mocks.user.value = { id: "user-1" };
+    mocks.isAuthenticated.value = true;
+    mocks.isUserReady.value = true;
+    mocks.resetConvexBindings();
+    vi.clearAllMocks();
+  });
+
+  it("binds exactly the two callback actions and the claim", () => {
+    render(<CallbackProbe />);
+
+    // An exact set. Anything org-scoped appearing here would mean the callback
+    // page had acquired an organization it has no way to have proved.
+    expect([...mocks.handles.keys()].sort()).toEqual(
+      [
+        "action:github/appInstallLinkNode:claimProvenInstallation",
+        "action:github/appInstallLinkNode:completeInstallSetup",
+        "action:github/appInstallLinkNode:completeUserAuthorization",
+      ].sort()
+    );
+  });
+
+  it("forwards GitHub's parameters verbatim, adding nothing", () => {
+    render(<CallbackProbe />);
+
+    screen.getByText("setup").click();
+    screen.getByText("oauth").click();
+
+    // No `organizationId`, and no normalization of the states: the backend
+    // matches them by hash, so anything done to them here could only stop a
+    // legitimate one from matching.
+    expect(mocks.requests).toEqual([
+      {
+        kind: "action",
+        name: "github/appInstallLinkNode:completeInstallSetup",
+        args: { installationId: 4242, state: "raw-install-state" },
+      },
+      {
+        kind: "action",
+        name: "github/appInstallLinkNode:completeUserAuthorization",
+        args: { code: "raw-code", state: "raw-oauth-state" },
       },
     ]);
   });

--- a/mcpjam-inspector/client/src/hooks/useGithubChecksSettings.ts
+++ b/mcpjam-inspector/client/src/hooks/useGithubChecksSettings.ts
@@ -61,6 +61,75 @@ export type GithubChecksAvailability =
  */
 export type GithubCheckOutagePolicy = "fail_open" | "fail_closed";
 
+/**
+ * How ready a connected repository actually is, DERIVED BY THE BACKEND.
+ *
+ * Never inferred here, and in particular never inferred from a missing
+ * visibility badge: visibility is a live GitHub fact and absence there means
+ * "we do not know", not "something is wrong". The three facts this summarizes —
+ * a server-verified repository identity, an active org ↔ installation binding,
+ * and per-repository access — are deliberately not shipped to the browser, so
+ * this literal is the only thing there is to render.
+ *
+ *   verified                  — connected, proved, installation live.
+ *   legacy_unverified         — no verified repository identity. Reconnect
+ *                               required before enforcement.
+ *   installation_inactive     — the binding is suspended, removed, unbound, or
+ *                               absent. Nothing about the repository is wrong.
+ *   repository_access_removed — the App no longer has THIS repository.
+ */
+export type GithubCheckConnectionStatus =
+  | "verified"
+  | "legacy_unverified"
+  | "installation_inactive"
+  | "repository_access_removed";
+
+export type GithubInstallationAccountType = "Organization" | "User";
+export type GithubInstallationBindingStatus =
+  | "active"
+  | "suspended"
+  | "removed"
+  | "unbound";
+
+/**
+ * One GitHub App installation this organization holds.
+ *
+ * `installationRef` is an OPAQUE Convex row id, never GitHub's installation id.
+ * It is what selects an installation for a connect or an unbind, and it is
+ * deliberately meaningless outside this backend.
+ */
+export type GithubInstallationBinding = {
+  installationRef: string;
+  accountLogin: string;
+  accountType: GithubInstallationAccountType;
+  status: GithubInstallationBindingStatus;
+  boundAt: number;
+  statusChangedAt: number;
+};
+
+/** One installation a direct-install claim may adopt, from the proven list. */
+export type ClaimableInstallation = {
+  installationId: number;
+  accountLogin: string;
+  accountType: GithubInstallationAccountType;
+};
+
+/**
+ * What the OAuth callback resolved to: a completed bind, or a pick.
+ *
+ * The pick arm carries `linkSessionId` back to the browser, which is safe by
+ * design rather than by obscurity — the claim re-checks that the actor is the
+ * one who started the flow, that the session is unexpired, and that the chosen
+ * installation is in the server-held proven list.
+ */
+export type GithubInstallCallbackResult =
+  | { status: "bound"; accountLogin: string }
+  | {
+      status: "pick_required";
+      linkSessionId: string;
+      installations: ClaimableInstallation[];
+    };
+
 export type GithubCheckRepoConfigRow = {
   _id: string;
   repoFullName: string;
@@ -75,11 +144,35 @@ export type GithubCheckRepoConfigRow = {
    * rendering a choice that was never stored.
    */
   outagePolicy?: GithubCheckOutagePolicy;
+  /** Backend-derived. See {@link GithubCheckConnectionStatus}. */
+  connectionStatus: GithubCheckConnectionStatus;
   createdAt: number;
   updatedAt: number;
 };
 
 export type InstallationRepo = {
+  /**
+   * GitHub's numeric repository id — the identity connect is keyed on.
+   *
+   * A repository can be renamed and the freed name re-taken, so `fullName` is
+   * display and routing data. This is sent back at connect and the server
+   * re-verifies it against GitHub's own response.
+   */
+  repositoryId: number;
+  /**
+   * WHICH binding this repository was listed through, opaque.
+   *
+   * ABSENT only while the backend is still falling back to its pinned
+   * installation for an organization with no binding yet. Absent means "send no
+   * reference", which is what keeps the compatibility connect reachable during
+   * that window.
+   */
+  installationRef?: string;
+  /**
+   * The GitHub account, for disambiguating two same-named repositories from
+   * different accounts in one picker. Display only.
+   */
+  accountLogin?: string;
   fullName: string;
   /**
    * GitHub's live `private` flag. Optional because GitHub can omit it, and
@@ -100,6 +193,7 @@ const AVAILABILITY_QUERY =
   "github/checkRepoConfigs:getGithubChecksSettingsAvailability";
 const LIST_QUERY = "github/checkRepoConfigs:listForOrganization";
 const SUITES_QUERY = "testSuites:getTestSuitesOverview";
+const BINDINGS_QUERY = "github/appInstallLink:listBindingsForOrganization";
 
 // The availability message and the rest of this surface's error copy live in
 // `@/lib/github-checks-errors`, which has no React and no Convex client in it.
@@ -182,11 +276,83 @@ export function useGithubChecksSettings(
     "github/checkRepoConfigsNode:listInstallationRepos" as any
   );
 
+  // ── The org ↔ installation binding surface ───────────────────────────────
+  //
+  // EVERY ARGUMENT BELOW IS HAND-MIRRORED from `convex/github/appInstallLink.ts`
+  // and `appInstallLinkNode.ts`. There is no generated client here, so a name
+  // that drifts or a required argument that is forgotten fails at RUNTIME, on
+  // the click, in production — not at build time. Treat these call shapes as
+  // part of the backend's signature and change them together.
+  const startInstallationAction = useAction(
+    "github/appInstallLinkNode:startInstallation" as any
+  );
+  const startDirectClaimAction = useAction(
+    "github/appInstallLinkNode:startDirectClaim" as any
+  );
+  const unbindInstallationMutation = useMutation(
+    "github/appInstallLink:unbindInstallation" as any
+  );
+
+  // Bindings are read for MEMBERS, like the repository list — the write path is
+  // where admin is required — so this rides the same `canQuery` gate.
+  const bindings = useQuery(
+    BINDINGS_QUERY as any,
+    canQuery ? ({ organizationId } as any) : "skip"
+  ) as GithubInstallationBinding[] | undefined;
+
+  /**
+   * Begin installing the App for this organization. Returns GitHub's install
+   * URL; the caller navigates to it.
+   *
+   * The URL carries a one-time state whose HASH is what the backend stored, so
+   * it is not a credential the browser has to protect beyond the session's
+   * ten-minute life.
+   */
+  const startInstallation = useCallback(
+    () =>
+      startInstallationAction({ organizationId } as any) as Promise<{
+        installUrl: string;
+      }>,
+    [startInstallationAction, organizationId]
+  );
+
+  /**
+   * Begin CLAIMING an installation somebody created from GitHub's side, where
+   * there was never a setup redirect for us to catch. Goes straight to the
+   * OAuth leg; the pick comes back from the callback.
+   */
+  const startDirectClaim = useCallback(
+    () =>
+      startDirectClaimAction({ organizationId } as any) as Promise<{
+        authorizeUrl: string;
+      }>,
+    [startDirectClaimAction, organizationId]
+  );
+
+  const unbindInstallation = useCallback(
+    (args: { installationRef: string }) =>
+      unbindInstallationMutation({
+        organizationId,
+        ...args,
+      } as any) as Promise<{
+        changed: boolean;
+      }>,
+    [unbindInstallationMutation, organizationId]
+  );
+
   /**
    * `outagePolicy` is REQUIRED here even though the backend accepts it as
    * optional. Omitting it there means "no policy stored"; omitting it at
    * onboarding would mean the administrator was never asked, which is the state
    * this surface exists to stop producing.
+   *
+   * `installationRef` and `repositoryId` come STRAIGHT OFF the picked
+   * `InstallationRepo` and are never assembled by hand — they say which
+   * installation the repository was listed through and which repository it
+   * actually is, and the server re-verifies both. They are optional here for
+   * exactly one reason: an organization with no binding yet is still listed
+   * through the backend's pinned installation, and those entries carry no ref,
+   * so the connect has to be reachable without one until the pin retires.
    */
   const connectVerifiedRepo = useCallback(
     (args: {
@@ -194,6 +360,8 @@ export function useGithubChecksSettings(
       projectId: string;
       suiteId: string;
       outagePolicy: GithubCheckOutagePolicy;
+      installationRef?: string;
+      repositoryId?: number;
     }) =>
       connectVerifiedRepoAction({ organizationId, ...args } as any) as Promise<{
         configId: string;
@@ -243,11 +411,73 @@ export function useGithubChecksSettings(
     isEnabled,
     repos,
     suites,
+    bindings,
     connectVerifiedRepo,
     setRepoEnabled,
     setRepoSuite,
     setRepoOutagePolicy,
     disconnectRepo,
     listInstallationRepos,
+    startInstallation,
+    startDirectClaim,
+    unbindInstallation,
+  };
+}
+
+/**
+ * The two GitHub callbacks, as their own hook.
+ *
+ * SEPARATE from `useGithubChecksSettings` because the callback page has no
+ * organization to hand it: the browser arrives back from GitHub with nothing but
+ * query parameters, and the organization is recovered from the link session
+ * server-side. A hook that required an org id would have to invent one.
+ *
+ * Both actions take the parameters GitHub sent, VERBATIM. Nothing is parsed,
+ * normalized, or validated here — the backend matches the state by hash and
+ * treats the installation id as an unproven claim, and any cleverness in the
+ * browser could only ever turn a refusal into a different refusal.
+ */
+export function useGithubInstallCallbacks() {
+  const completeInstallSetupAction = useAction(
+    "github/appInstallLinkNode:completeInstallSetup" as any
+  );
+  const completeUserAuthorizationAction = useAction(
+    "github/appInstallLinkNode:completeUserAuthorization" as any
+  );
+  const claimProvenInstallationAction = useAction(
+    "github/appInstallLinkNode:claimProvenInstallation" as any
+  );
+
+  /** GitHub's setup redirect. Returns where to send the browser next. */
+  const completeInstallSetup = useCallback(
+    (args: { installationId: number; state: string }) =>
+      completeInstallSetupAction(args as any) as Promise<{
+        authorizeUrl: string;
+      }>,
+    [completeInstallSetupAction]
+  );
+
+  /** GitHub's OAuth redirect. Either the bind is done, or a pick is needed. */
+  const completeUserAuthorization = useCallback(
+    (args: { code: string; state: string }) =>
+      completeUserAuthorizationAction(
+        args as any
+      ) as Promise<GithubInstallCallbackResult>,
+    [completeUserAuthorizationAction]
+  );
+
+  /** Adopt one installation out of a direct claim's proven list. */
+  const claimProvenInstallation = useCallback(
+    (args: { linkSessionId: string; installationId: number }) =>
+      claimProvenInstallationAction(
+        args as any
+      ) as Promise<GithubInstallCallbackResult>,
+    [claimProvenInstallationAction]
+  );
+
+  return {
+    completeInstallSetup,
+    completeUserAuthorization,
+    claimProvenInstallation,
   };
 }

--- a/mcpjam-inspector/client/src/lib/__tests__/github-external-redirect.test.ts
+++ b/mcpjam-inspector/client/src/lib/__tests__/github-external-redirect.test.ts
@@ -1,0 +1,54 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  redirectToGithub,
+  UnsafeRedirectError,
+} from "../github-external-redirect";
+
+// The binding flow's redirects are URLs the BACKEND built — it is the only side
+// that knows the App slug, the OAuth client id, and the one-time state. So the
+// allowlist here is not defending against the backend; it is making sure this
+// function never becomes a general-purpose `window.location.assign(userInput)`
+// the day something less trustworthy calls it.
+
+const assign = vi.fn();
+
+beforeEach(() => {
+  assign.mockClear();
+  // jsdom's `window.location` is not writable, and `assign` throws
+  // "not implemented" if left alone. Replacing the property is the only way to
+  // observe where a redirect would have gone.
+  Object.defineProperty(window, "location", {
+    configurable: true,
+    value: { assign },
+  });
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe("redirectToGithub", () => {
+  it.each([
+    "https://github.com/apps/mcpjam/installations/new?state=abc",
+    "https://github.com/login/oauth/authorize?client_id=Iv1.x&state=def",
+  ])("follows %s", (url) => {
+    redirectToGithub(url);
+    expect(assign).toHaveBeenCalledWith(url);
+  });
+
+  it.each([
+    // The one a `startsWith` check would wave through, which is exactly how
+    // that gets shipped.
+    "https://github.com.evil.test/apps/mcpjam",
+    "https://evil.test/apps/mcpjam",
+    // Same host, wrong scheme — an http redirect would strip TLS from a flow
+    // whose whole point is proving an identity.
+    "http://github.com/apps/mcpjam",
+    "javascript:alert(1)",
+    "not a url at all",
+    "",
+  ])("refuses %s", (url) => {
+    expect(() => redirectToGithub(url)).toThrow(UnsafeRedirectError);
+    expect(assign).not.toHaveBeenCalled();
+  });
+});

--- a/mcpjam-inspector/client/src/lib/__tests__/route-elements-coverage.test.ts
+++ b/mcpjam-inspector/client/src/lib/__tests__/route-elements-coverage.test.ts
@@ -1,0 +1,63 @@
+import { describe, expect, it } from "vitest";
+import { APP_ROUTES } from "../app-routes";
+import { createAppRouter } from "@/router";
+
+/**
+ * Every registered route element is actually MOUNTED.
+ *
+ * One direction of that invariant has always failed loudly: `buildRouteChildren`
+ * throws when an `APP_ROUTES` entry has no element. The other direction used to
+ * fail SILENTLY, and that is why this file exists — `buildRouteChildren`
+ * iterates `APP_ROUTES`, so a path registered only in `ROUTE_ELEMENTS` is never
+ * mounted at all. The URL falls through to the `"*"` catch-all and renders a
+ * different screen, with nothing in the console, no failing unit test (a
+ * component test mounts the component directly, so it never notices), and
+ * nothing to see until somebody follows the link.
+ *
+ * Not hypothetical: the GitHub install callback reached review registered in
+ * `ROUTE_ELEMENTS` alone, which would have landed every return trip from GitHub
+ * on the servers screen.
+ *
+ * `buildRouteChildren` now throws on both directions, so BUILDING the router is
+ * the assertion — no source parsing, nothing to keep in step with a regex, and
+ * the same check the real app runs at startup.
+ */
+/**
+ * Paths of the app shell's child routes.
+ *
+ * Found by "the route that HAS children" rather than by index: the router also
+ * mounts a standalone `__e2e/oauth-debugger` entry, and an index-based lookup
+ * would silently start reading that one the day another top-level route is
+ * added ahead of the shell.
+ */
+function mountedPaths(): string[] {
+  const router = createAppRouter();
+  const shell = router.routes.find(
+    (route) => (route.children ?? []).length > 0
+  );
+  return (shell?.children ?? []).map((child) =>
+    child.index ? "/" : child.path ?? ""
+  );
+}
+
+describe("the router mounts every route it registers", () => {
+  it("builds without a stranded or unrendered route", () => {
+    // Both guards live inside `buildRouteChildren`, so constructing the router
+    // is what exercises them. A throw here names the offending path.
+    expect(() => createAppRouter()).not.toThrow();
+  });
+
+  it("mounts a child route for every path in the table", () => {
+    const mounted = new Set(mountedPaths());
+    const missing = APP_ROUTES.map((route) => route.path).filter(
+      (routePath) => !mounted.has(routePath)
+    );
+    expect(missing).toEqual([]);
+  });
+
+  it("mounts the GitHub install callback", () => {
+    // Named explicitly rather than left to the sweep above: this is the route
+    // the regression was, and the whole binding flow is unreachable without it.
+    expect(mountedPaths()).toContain("settings/integrations/github/callback");
+  });
+});

--- a/mcpjam-inspector/client/src/lib/app-routes.ts
+++ b/mcpjam-inspector/client/src/lib/app-routes.ts
@@ -123,6 +123,13 @@ export const APP_ROUTES: readonly AppRouteEntry[] = [
     surfaceId: "settings",
   },
   {
+    // Where GitHub sends the browser back — the App's setup URL and its OAuth
+    // callback both point here, told apart by which query parameters arrived.
+    path: "settings/integrations/github/callback",
+    kind: "screen",
+    surfaceId: "settings",
+  },
+  {
     path: "settings/github-checks",
     kind: "redirect",
     note: "Legacy: the page moved under Integrations; redirects to /settings/integrations/github.",

--- a/mcpjam-inspector/client/src/lib/github-checks-errors.ts
+++ b/mcpjam-inspector/client/src/lib/github-checks-errors.ts
@@ -1,4 +1,8 @@
 import { convexErrMessage } from "@/lib/convex-error";
+import type {
+  GithubCheckConnectionStatus,
+  GithubInstallationBindingStatus,
+} from "@/hooks/useGithubChecksSettings";
 
 /**
  * What a refused GitHub Checks write says to the person who made it.
@@ -71,7 +75,10 @@ export const GITHUB_CONNECTION_STATUS_COPY = {
     "The MCPJam GitHub App is not active on this account right now, so checks are paused. This is not a problem with your pull requests — reconnect the app from the section above.",
   repository_access_removed:
     "The MCPJam GitHub App no longer has access to this repository, so checks are paused. This is not a problem with your pull requests — grant it access on GitHub, then reconnect.",
-} as const;
+  // `satisfies`, not a plain annotation: the map keeps its literal types for
+  // callers AND the compiler refuses it if the union gains or loses a member.
+  // Without it, a new status is only noticed when something indexes the map.
+} as const satisfies Record<GithubCheckConnectionStatus, string | null>;
 
 /** The short badge label beside a row. Same states, fewer words. */
 export const GITHUB_CONNECTION_STATUS_LABEL = {
@@ -79,7 +86,7 @@ export const GITHUB_CONNECTION_STATUS_LABEL = {
   legacy_unverified: "Reconnect required",
   installation_inactive: "App inactive",
   repository_access_removed: "No access",
-} as const;
+} as const satisfies Record<GithubCheckConnectionStatus, string | null>;
 
 /**
  * What an installation binding's state means to an administrator.
@@ -94,8 +101,14 @@ export const GITHUB_BINDING_STATUS_COPY = {
     "Suspended on GitHub. Checks are paused for this account until somebody unsuspends the app there.",
   removed:
     "The app was uninstalled from this account. Reconnect it to start running checks again.",
+  // UNREACHABLE IN PRACTICE, and kept anyway. The backend's
+  // `listBindingsForOrganization` filters `unbound` rows out: an admin severed
+  // that relationship deliberately, and keeping it on the page as a fifth state
+  // to interpret adds nothing. The entry stays because the map is total over
+  // the status union — a partial map would mean this file stopped failing to
+  // compile the day the backend changed its mind.
   unbound: "Disconnected from this workspace.",
-} as const;
+} as const satisfies Record<GithubInstallationBindingStatus, string>;
 
 /**
  * The confirmation before an admin severs a binding.

--- a/mcpjam-inspector/client/src/lib/github-checks-errors.ts
+++ b/mcpjam-inspector/client/src/lib/github-checks-errors.ts
@@ -46,3 +46,88 @@ export function githubChecksWriteErrorMessage(error: unknown): string {
     ? GITHUB_CHECKS_UNAVAILABLE_MESSAGE
     : message;
 }
+
+// ── Installation binding ────────────────────────────────────────────────────
+
+/**
+ * What a connected repository's state means, and what it is NOT.
+ *
+ * Each line names what happened and then rules out the reading that would send
+ * somebody to fix the wrong thing. "This is not a problem with your pull
+ * request" is doing real work in a product whose whole output is a red or green
+ * mark on somebody's PR: the natural assumption when a check stops is that the
+ * code did something, and three of these four states have nothing to do with
+ * the code at all.
+ *
+ * The status is DERIVED BY THE BACKEND from facts this app never sees. It is
+ * never inferred here — least of all from a missing visibility badge, which
+ * means "GitHub did not tell us", not "something is wrong".
+ */
+export const GITHUB_CONNECTION_STATUS_COPY = {
+  verified: null,
+  legacy_unverified:
+    "Connected before MCPJam verified repositories. Reconnect it to keep checks running — nothing is wrong with the repository or its pull requests.",
+  installation_inactive:
+    "The MCPJam GitHub App is not active on this account right now, so checks are paused. This is not a problem with your pull requests — reconnect the app from the section above.",
+  repository_access_removed:
+    "The MCPJam GitHub App no longer has access to this repository, so checks are paused. This is not a problem with your pull requests — grant it access on GitHub, then reconnect.",
+} as const;
+
+/** The short badge label beside a row. Same states, fewer words. */
+export const GITHUB_CONNECTION_STATUS_LABEL = {
+  verified: null,
+  legacy_unverified: "Reconnect required",
+  installation_inactive: "App inactive",
+  repository_access_removed: "No access",
+} as const;
+
+/**
+ * What an installation binding's state means to an administrator.
+ *
+ * `accountLogin` is DISPLAY ONLY and is interpolated by the caller — GitHub
+ * lets an account be renamed, so nothing here or anywhere else decides anything
+ * from it.
+ */
+export const GITHUB_BINDING_STATUS_COPY = {
+  active: "Connected. Repositories on this account can run checks.",
+  suspended:
+    "Suspended on GitHub. Checks are paused for this account until somebody unsuspends the app there.",
+  removed:
+    "The app was uninstalled from this account. Reconnect it to start running checks again.",
+  unbound: "Disconnected from this workspace.",
+} as const;
+
+/**
+ * The confirmation before an admin severs a binding.
+ *
+ * Says the consequence and its LIMIT in the same breath. Disconnecting stops
+ * checks immediately, and it is genuinely reversible — nothing about which
+ * suite runs on which repository is thrown away — so the copy must not imply
+ * that reconnecting means rebuilding.
+ */
+export const GITHUB_UNBIND_CONFIRMATION =
+  "Disconnect this GitHub account? Checks on its repositories stop immediately. Your suite and policy settings are kept, so reconnecting restores them.";
+
+/**
+ * The one message the binding flow shows when it could not be completed.
+ *
+ * DELIBERATELY THE SAME for every reason the backend can refuse: the
+ * installation is already connected somewhere else, it does not exist, the
+ * proof did not check out, the state expired. Distinguishing them would answer
+ * questions about other people's GitHub accounts and other workspaces, so the
+ * backend refuses flatly and this is simply what it says.
+ *
+ * The one exception the backend DOES word specifically is a conflict, which
+ * still names no workspace. Both arrive as `ConvexError` payloads and are shown
+ * exactly as the backend worded them; this is only the fallback for a failure
+ * that carried no message of its own.
+ */
+export const GITHUB_BINDING_FAILED_MESSAGE =
+  "We could not finish connecting that GitHub account. This is not a problem with your repositories — start again from Settings.";
+
+/**
+ * A callback URL that carries neither GitHub's setup parameters nor its OAuth
+ * parameters. Somebody opened or reloaded the page directly.
+ */
+export const GITHUB_CALLBACK_INCOMPLETE_MESSAGE =
+  "This page finishes connecting a GitHub account, and it was opened without the details GitHub sends. Start again from Settings.";

--- a/mcpjam-inspector/client/src/lib/github-external-redirect.ts
+++ b/mcpjam-inspector/client/src/lib/github-external-redirect.ts
@@ -1,0 +1,49 @@
+/**
+ * Send the browser to GitHub, and nowhere else.
+ *
+ * The installation-binding flow is three redirects: we hand GitHub a state, it
+ * hands us one back, and each leg is a URL the BACKEND built. That backend is
+ * the only thing that knows the App slug, the OAuth client id, and the one-time
+ * state — so the browser never assembles one of these, it only follows one.
+ *
+ * The allowlist below is therefore not defending against the backend. It is
+ * defending against this function ever acquiring a second caller that passes
+ * something less trustworthy: a `window.location.assign` with a string argument
+ * is an open-redirect primitive, and the cheapest time to make it not be one is
+ * before anybody needs it to be.
+ *
+ * Its own module for a duller reason too: `window.location` is famously
+ * awkward to stub, and a component that calls it directly is a component whose
+ * "did it send them to GitHub" test has to fight jsdom. Mocking one named
+ * export is the whole job instead.
+ */
+
+/** The only origin a binding redirect may target. */
+const GITHUB_ORIGIN = "https://github.com";
+
+export class UnsafeRedirectError extends Error {
+  constructor() {
+    super("Refused to redirect outside GitHub");
+    this.name = "UnsafeRedirectError";
+  }
+}
+
+/**
+ * Navigate to a github.com URL.
+ *
+ * Parsed rather than prefix-matched: `https://github.com.evil.test/` starts with
+ * the right characters and is not GitHub, and a startsWith check is exactly how
+ * that gets shipped. `URL.origin` is the comparison that means what it says.
+ */
+export function redirectToGithub(url: string): void {
+  let parsed: URL;
+  try {
+    parsed = new URL(url);
+  } catch {
+    throw new UnsafeRedirectError();
+  }
+  if (parsed.origin !== GITHUB_ORIGIN) {
+    throw new UnsafeRedirectError();
+  }
+  window.location.assign(parsed.toString());
+}

--- a/mcpjam-inspector/client/src/lib/github-repo-picker.ts
+++ b/mcpjam-inspector/client/src/lib/github-repo-picker.ts
@@ -1,0 +1,100 @@
+import type {
+  GithubCheckOutagePolicy,
+  InstallationRepo,
+} from "@/hooks/useGithubChecksSettings";
+
+/**
+ * The repository-picker rules, in one place.
+ *
+ * Two surfaces offer the same picker — the settings page and the suite's own
+ * section — and all three rules below are a CONTRACT WITH THE BACKEND rather
+ * than a presentation detail: which value selects a repository, and what the
+ * verified connect is told about it. Written twice, they drift the first time
+ * either side gains a field, and the failure mode is not a broken build but a
+ * connect that names the wrong installation.
+ */
+
+/**
+ * Find the entry a picker value refers to.
+ *
+ * The value is the NUMERIC REPOSITORY ID as a string, not the name. Two
+ * connected accounts can each have a `widgets`, and the id is what the connect
+ * is actually keyed on — selecting by name would make the account label merely
+ * decorative and let one pick resolve to the other account's repository.
+ */
+export function findRepoByPickerValue(
+  repos: readonly InstallationRepo[],
+  value: string
+): InstallationRepo | undefined {
+  return repos.find((repo) => String(repo.repositoryId) === value);
+}
+
+/** The value a picker option carries for one entry. */
+export function pickerValueFor(repo: InstallationRepo): string {
+  return String(repo.repositoryId);
+}
+
+/**
+ * Should options carry their GitHub account?
+ *
+ * Only when it DISAMBIGUATES. With one connected account every option would
+ * carry the same suffix, which is a column of noise; with several, `widgets`
+ * and `widgets` are genuinely two repositories and the name alone cannot say
+ * which is which.
+ */
+export function shouldShowAccountLabels(
+  repos: readonly InstallationRepo[]
+): boolean {
+  const logins = new Set(
+    repos
+      .map((repo) => repo.accountLogin)
+      .filter((login): login is string => Boolean(login))
+  );
+  return logins.size > 1;
+}
+
+/** What one option reads as. */
+export function pickerLabelFor(
+  repo: InstallationRepo,
+  showAccountLabels: boolean
+): string {
+  return showAccountLabels && repo.accountLogin
+    ? `${repo.fullName} · ${repo.accountLogin}`
+    : repo.fullName;
+}
+
+/**
+ * The arguments the verified connect is given for one picked repository.
+ *
+ * `installationRef` and `repositoryId` come STRAIGHT OFF the listing entry and
+ * are never reassembled: the reference says which installation the repository
+ * was enumerated through, the id says which repository it is, and the server
+ * re-verifies both. The reference is omitted — not sent as `undefined` — when
+ * the entry carries none, which is how an organization still being listed
+ * through the backend's pinned installation keeps the compatibility connect
+ * reachable.
+ */
+export function verifiedConnectArgs(
+  repo: InstallationRepo,
+  target: {
+    projectId: string;
+    suiteId: string;
+    outagePolicy: GithubCheckOutagePolicy;
+  }
+): {
+  repoFullName: string;
+  projectId: string;
+  suiteId: string;
+  outagePolicy: GithubCheckOutagePolicy;
+  installationRef?: string;
+  repositoryId: number;
+} {
+  return {
+    repoFullName: repo.fullName,
+    projectId: target.projectId,
+    suiteId: target.suiteId,
+    outagePolicy: target.outagePolicy,
+    ...(repo.installationRef ? { installationRef: repo.installationRef } : {}),
+    repositoryId: repo.repositoryId,
+  };
+}

--- a/mcpjam-inspector/client/src/router.tsx
+++ b/mcpjam-inspector/client/src/router.tsx
@@ -66,6 +66,15 @@ function ciEvalsRedirect({ request }: { request: Request }) {
  *
  * Loaders (redirects) live here for the same reason.
  */
+/**
+ * EVERY key here must also be a path in `APP_ROUTES`.
+ *
+ * `buildRouteChildren` iterates `APP_ROUTES`, not this map, so a route
+ * registered ONLY here is never mounted — the URL falls through to the `"*"`
+ * catch-all and renders something else entirely, with no error anywhere.
+ * The reverse direction throws loudly; this one fails silently, which is why
+ * `router.test.tsx` asserts it.
+ */
 const ROUTE_ELEMENTS: Record<
   string,
   { element?: React.ReactElement; loader?: (args: any) => unknown }
@@ -220,6 +229,24 @@ const ROUTE_ELEMENTS: Record<
 
 /** Route table → react-router children, preserving declaration order. */
 function buildRouteChildren() {
+  // THE OTHER DIRECTION, and the one that used to fail silently. This function
+  // iterates `APP_ROUTES`, so a path registered only in `ROUTE_ELEMENTS` is
+  // never mounted: the URL falls through to the `"*"` catch-all and renders a
+  // different screen, with nothing in the console and no failing test — a
+  // component test mounts the component directly, so it never notices.
+  //
+  // Checked here rather than only in a test because this is where the asymmetry
+  // lives, and because a route that cannot be reached should stop the app at
+  // startup rather than reach a user as a wrong page.
+  const tablePaths = new Set(APP_ROUTES.map((route) => route.path));
+  for (const path of Object.keys(ROUTE_ELEMENTS)) {
+    if (!tablePaths.has(path)) {
+      throw new Error(
+        `[router] element registered for "${path}", which is not in APP_ROUTES — it would never be mounted`
+      );
+    }
+  }
+
   return APP_ROUTES.map((route) => {
     const rendered = ROUTE_ELEMENTS[route.path];
     if (!rendered) {

--- a/mcpjam-inspector/client/src/router.tsx
+++ b/mcpjam-inspector/client/src/router.tsx
@@ -3,6 +3,7 @@ import { RouteErrorScreen } from "./components/RouteErrorScreen";
 import App, {
   ApiKeysSettingsRoute,
   GithubChecksSettingsRoute,
+  GithubInstallCallbackSettingsRoute,
   IntegrationsSettingsRoute,
   ChatAliasRoute,
   ScenariosRoute,
@@ -155,6 +156,14 @@ const ROUTE_ELEMENTS: Record<
   "settings/api-keys": { element: <ApiKeysSettingsRoute /> },
   "settings/integrations": { element: <IntegrationsSettingsRoute /> },
   "settings/integrations/github": { element: <GithubChecksSettingsRoute /> },
+  // Where GitHub sends the browser back — BOTH the App's setup URL and its
+  // OAuth callback point here, and the page tells them apart by which query
+  // parameters arrived. One path because GitHub App settings take one of
+  // each, and because a second route would be a second place to keep the
+  // "pass everything through verbatim" rule.
+  "settings/integrations/github/callback": {
+    element: <GithubInstallCallbackSettingsRoute />,
+  },
   // Legacy: the page moved under Integrations. Kept as a redirect because the
   // path shipped in docs and in the backend runbook, so links to it exist
   // outside this app. A loader redirect (not an element) so it resolves before

--- a/mcpjam-inspector/shared/app-surfaces.ts
+++ b/mcpjam-inspector/shared/app-surfaces.ts
@@ -563,6 +563,7 @@ export const APP_SURFACES = [
       "settings/api-keys",
       "settings/integrations",
       "settings/integrations/github",
+      "settings/integrations/github/callback",
     ],
     navSegments: ["settings"],
     title: "Settings",


### PR DESCRIPTION
The Inspector half of Lane C (package 7). Pairs with [MCPJam/mcpjam-backend#1037](https://github.com/MCPJam/mcpjam-backend/pull/1037), which must be on staging before this is useful — the new function ids do not exist until it deploys.

## What changes

GitHub Checks assumed **one** GitHub App installation for the whole deployment, so the settings page had nothing to say about *which* account a repository came from. The backend now binds installations to organizations; this is the surface for it.

**A "GitHub accounts" section.** Install the app on an account from here, or *claim* an installation somebody already added from GitHub's side. Claiming sends you through GitHub sign-in, and the copy says why:

> …installing the app is not on its own proof that it is yours to connect here.

That sentence is the product-facing version of the security argument in the backend PR — the App can mint a token for every installation it has, so a user-authorization leg is what proves *this person* administers *that account*.

**Explicit unbind with confirmation**, whose copy states the limit of the consequence as well as the consequence: checks stop immediately, suite and policy choices are kept, so reconnecting is not a rebuild. Copy that implied otherwise would stop admins acting on a state they need to act on.

**Connected repositories carry a state when something is wrong** — `Reconnect required`, `App inactive`, `No access` — each naming what happened and ruling out the reading that would send someone to fix the wrong thing. Three of the four states have nothing to do with the code, and the natural assumption when a check stops is that they do, so each line says "this is not a problem with your pull requests". A healthy row gets **no badge at all**: a badge saying "fine" on every row makes the ones that need attention harder to find.

**The picker aggregates every connected account and selects by GitHub's numeric repository id**, not by name — two accounts can each have a `widgets`, and a name is not an identity. The account label appears beside a repository only when it disambiguates.

**`/settings/integrations/github/callback`** handles both of GitHub's returns. The App's setup URL and its OAuth callback point at one path and are told apart by which parameters arrived.

## Three decisions worth reviewing

**Nothing is inferred client-side.** `connectionStatus` is derived by the backend from three facts the browser never sees, and in particular it is *not* inferred from a missing visibility badge — absence there means "GitHub did not tell us", not "something is wrong", and conflating them would put a warning on a healthy repository whose `private` flag GitHub happened to omit. There is a test for exactly that.

**Callback parameters are forwarded verbatim.** No parsing, no normalization, no pre-validation. The backend matches states by hash and treats `installation_id` as a claim GitHub itself documents as spoofable, so cleverness here could only turn a legitimate state into a non-matching one — while a well-meaning "clean this up first" is how a working flow breaks. The one exception is checking that `installation_id` is a positive integer, and only because there is otherwise nothing to send.

**Redirects go through one guarded helper.** `lib/github-external-redirect.ts` parses the URL and refuses anything whose origin is not `https://github.com` — not because the backend is untrusted (it builds every one of these URLs), but so this never quietly becomes a general-purpose `location.assign(userInput)` the day something else calls it. It is parsed rather than prefix-matched, because `https://github.com.evil.test/` passes a `startsWith` check and that is exactly how that ships.

## Review round 1 — and a correction

CodeRabbit caught a **real and total bug**, fixed in `191a3ef`: the callback route was registered in `ROUTE_ELEMENTS` but not in `APP_ROUTES`. `buildRouteChildren` iterates `APP_ROUTES`, so it was never mounted — every return trip from GitHub would have fallen through to the `"*"` catch-all and rendered the servers screen, making the whole binding flow unreachable.

The reason it got that far is worth more than the fix: the component tests mount the page directly in a `MemoryRouter`, so none of them exercises the route table. `buildRouteChildren` now throws on **both** directions of the invariant — it already refused a route with no element; it now also refuses an element with no route, naming the stranded path — and `route-elements-coverage.test.ts` builds the real router, so the assertion is the same check the app runs at startup. Red-probed: removing the entry again fails all three tests with the named error.

**Correction.** `191a3ef` claimed five review fixes and landed two. A failed assertion aborted the script meant to write the other three before it reached its write, and I did not re-verify the files afterwards — the suite stayed green because the tests I thought I had changed were still the old ones, passing for the old reasons. `8aeea41` actually applies them, and red-probes the two that make a behavioural claim:

- **StrictMode.** The single-use-state test used `rerender`, which keeps one component instance and so never exercised the double mount the ref exists for. Now wrapped in `StrictMode`. Probe: removing the `startedRef` guard fails it with `expected "spy" to be called 1 times, but got 2 times`; under the old version it passed.
- **Same-named repositories.** The picker-identity test used two *different* full names, so a name-keyed implementation satisfied it. Both fixtures now share one name. Probe: keying the picker on `fullName` resolves the `widgets · globex` option to `bind-acme` / `201` — the other account's repository — and fails; under the old fixture it passed.
- **Redirect-throw coverage**, which found a real defect: `UnsafeRedirectError`'s message is developer text ("Refused to redirect outside GitHub") and the setup leg's `.catch(fail)` put it on screen verbatim. A guard refusing a URL is not a backend refusal, so it now renders the flat binding copy and logs the reason for an operator.

The two that *did* land in `191a3ef`: the raw-installation-id fixture (the assertion previously could not fail, because no fixture contained an id) and the `unbound` state.

Also from that round:

- The picker's three rules were written twice, once per surface. They are a contract with the backend, so they moved to `lib/github-repo-picker.ts` — two copies drift the first time either side gains a field, and the failure mode is a connect naming the wrong installation.
- `role="status"` on the callback page's phase output — it replaces its whole content asynchronously, leaving a screen reader on a message that had already gone.
- `satisfies` on the copy maps, so a drifting status union fails to compile rather than waiting for something to index the map.
- Changeset raised to `minor`, matching how this repo versions added functionality, and it now names the backend dependency.

**Not taken:** a test pinning what the binding actions send when the organization is null. The buttons only render once availability resolves, which requires an organization, so it would pin an accident rather than a decision.

## Contract changes

`InstallationRepo` gains required `repositoryId` and optional `installationRef` / `accountLogin`; `GithubCheckRepoConfigRow` gains required `connectionStatus`. `connectVerifiedRepo` takes optional `installationRef` and `repositoryId`, both lifted straight off the picked listing entry rather than reassembled.

`installationRef` is **optional on purpose**: an organization with no binding yet is still listed through the backend's pinned installation, and those entries carry no ref. Omitting it is what keeps the compatibility connect reachable until the pin retires. Two tests cover that window.

Every one of these argument shapes is hand-mirrored — there is no generated Convex client, so a drift fails at runtime on the click. The new call shapes are commented as part of the backend's signature, and the hook's exact-set binding test is the guard that a removed id cannot be wired back in.

## Verification

- `npx vitest run --project client` — **865 files / 9325 tests passing**, 6 skipped, 0 failures, on the pushed head `8aeea41`.
- `npx tsc --noEmit -p client/tsconfig.json` — no errors in any file this PR touches.
- `npx prettier --check` on the changed files only — clean. Prettier is v2 with no config here, so no file was reformatted beyond the lines this PR changed.
- Changeset included.

Note for anyone running the suite locally: `client/src/components/evals/__tests__/suite-iterations-github-checks.test.tsx` fails to collect on a fresh checkout until `npm run sdk:build` has run (`@mcpjam/sdk/predicates` is unresolvable otherwise). Pre-existing on `main`, not introduced here.

## New tests

| | |
|---|---|
| `route-elements-coverage.test.ts` | the router mounts every route it registers — the regression above |
| `github-install-callback-route.test.tsx` | both legs, verbatim forwarding, the single-use state running once under `StrictMode`, the redirect guard throwing, the pick list, and a directly-opened callback explaining itself |
| `github-external-redirect.test.ts` | the origin allowlist, including the `github.com.evil.test` case |
| `github-checks-route.test.tsx` | the accounts section, every binding state, unbind confirm/dismiss, every connection-status badge, account-label disambiguation, and that a raw installation id present in the fixture never reaches the DOM |
| `suite-github-checks-section.test.tsx` | two identically-named repositories from different accounts resolving distinctly |
| `useGithubChecksSettings.test.tsx` | the exact binding sets for both hooks, and that the callback hook takes no organization |

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FWPD216otYy9YVi1rXTGJy