### PR TITLE
changesets: release Inspector, CLI, and SDK

### DIFF
--- a/.changeset/chatgpt-dual-era-protocol.md
+++ b/.changeset/chatgpt-dual-era-protocol.md
@@ -1,0 +1,55 @@
+---
+"@mcpjam/sdk": minor
+"@mcpjam/inspector": minor
+---
+
+Claude and ChatGPT speak two protocol eras, and a host's protocol selection can
+say "negotiate" instead of naming a revision.
+
+Both catalog rows now list `["2025-11-25", "2026-07-28"]` as supported and are
+marked `provenance: "probe"` — captured from the real clients rather than
+assumed or read off a vendor page. The same capture corrected details that were
+guessed before: ChatGPT and Claude do not honour `requestTeardown`, Claude's
+available display modes are inline and fullscreen (no PiP), Cursor's are inline
+only, and every MCP Apps row now carries explicit `cspConnectDomains` and
+`cspResourceDomains` sets instead of leaving them unstated.
+
+## `mcpProtocolVersion: "auto"`
+
+`mcpProfile.mcpProtocolVersion` accepts `"auto"` alongside the concrete
+revisions. It is a **stored selection policy, never a wire literal**: nothing
+puts the string on a request. `resolveEffectiveMcpProtocolVersion` and
+`hostConnectionProfile` both collapse it to `undefined`, which is exactly what
+an unpinned host resolved to before, so connect behaviour is unchanged for
+every existing row.
+
+The distinction it buys is between "this client negotiates, deliberately" and
+"this field was never set". Legacy rows keep the absent field and keep saving;
+the dual-era presets ship `"auto"` explicitly, so a client whose default is
+negotiation says so in its own config instead of being inferred from a hole.
+Absent still canonicalizes to absent, so pre-feature rows continue to hash
+identically.
+
+`ConflictingProtocolVersionPin` is now stated the way it actually behaves: a
+stateful pin must appear in `initialize.supportedProtocolVersions` (and derives
+that list when the caller sent none), while a stateless pin skips the
+handshake entirely and is exempt from the accept-list check. Hosts saved with a
+stateless pin outside their list predate this work and must keep saving.
+
+## Inspector
+
+The Protocol tab's dropdown offers the union of the client's `initialize`
+accept-list and the eras its catalog row advertises. The handshake list only
+ever carries legacy revisions, so reading it alone made `2026-07-28`
+unselectable on the very clients that speak it. A row with no accept-list is a
+legacy row and stays fully editable — the catalog only widens an existing list,
+never creates one. Selecting Automatic now writes `"auto"` rather than deleting
+the field, and the JSON editor round-trips it.
+
+The unadvertised-pin warning fires for stateful pins only, matching the rule
+above: warning on a stateless pin promised a Save failure that never came.
+
+Can-I-use gains a Protocol versions row. It reads the catalog's supported list
+rather than the preset's handshake list, so the matrix reports what each client
+speaks instead of what it happens to advertise during `initialize`. It renders
+as a plain value, not a support chip — "which eras" is not a yes/no question.

--- a/.changeset/releases-2026-08-19.md
+++ b/.changeset/releases-2026-08-19.md
@@ -1,0 +1,13 @@
+---
+"@mcpjam/inspector": minor
+"@mcpjam/cli": minor
+"@mcpjam/sdk": minor
+---
+
+Release the latest Inspector, CLI, and SDK updates.
+
+- Model Claude and ChatGPT as dual-era clients — 2025-11-25 and 2026-07-28, probed rather than assumed — and let a host's protocol selection say "negotiate" instead of naming a revision.
+- Author eval cases in batches with declared ids, so an agent converting a repo's test files writes them as one validated call instead of one round trip each.
+- Publish the eval role-permission matrix as project capabilities, and gate suite and run deletion on it per row rather than pinning it for everyone.
+- Make GitHub PR checks answerable: an explicit outage policy chosen at connect, a build/start environment declared in `mcpjam.yaml`, and the backend's actual refusal instead of `Server Error`.
+- Name the user revoking an API key on the audit row, rather than inferring the one who minted it.

--- a/.changeset/toast-theme-from-document.md
+++ b/.changeset/toast-theme-from-document.md
@@ -1,0 +1,24 @@
+---
+"@mcpjam/inspector": patch
+---
+
+Keep toast text readable for anyone running the app in light mode on a
+dark-mode machine.
+
+The Toaster read its theme from `next-themes`, which nothing in the app
+provides. With no provider `useTheme()` fell back to `"system"`, so Sonner
+resolved the operating system's setting instead of the app's: on a dark-mode
+machine viewing the light app it stamped `data-sonner-theme="dark"` and
+coloured the toast description near-white on the white background our own
+tokens supplied. The message was there and unreadable.
+
+The theme now comes from the `.dark` class the design system already scopes its
+dark tokens under, read through `useSyncExternalStore` with a `MutationObserver`
+on the document element so a theme switch updates a visible toast. Server-side
+and observer-less environments fall back to light rather than throwing.
+
+The toast description is also pinned to `var(--foreground)` in CSS. Sonner
+colours that one element from its own theme rather than from the variables it
+is handed, which is what made it the single part of a toast that could come out
+light-on-light — pinning it keeps the text readable even if the two themes drift
+again.


### PR DESCRIPTION
Prepares the release changesets for the next deploy.

`npx changeset status` on this branch:

```
@mcpjam/inspector: 2.41.0 -> 2.42.0 (minor)
@mcpjam/sdk:        6.0.0 -> 6.1.0  (minor)
@mcpjam/cli:        3.25.0 -> 3.26.0 (minor)
```

## What's in it

- **`releases-2026-08-19.md`** — the umbrella inspector/cli/sdk minor with the release summary, same shape as `releases-2026-08-16` and `releases-2026-08-18`.

Nine commits have landed since the last `chore(release): version packages` (`ae3a1fd674`). Six carried their own changeset. Two that did not are added here:

- **`chatgpt-dual-era-protocol.md`** (sdk minor, inspector minor) — #4085. Probed dual-era catalog rows for Claude and ChatGPT (`2025-11-25` + `2026-07-28`), the corrected MCP Apps facts that came with the capture (`requestTeardown: false`, display modes, explicit CSP domain sets), `mcpProtocolVersion: "auto"` as a stored selection policy that resolves to `undefined` on the wire, the restated `ConflictingProtocolVersionPin` rule, and the Protocol tab / can-i-use changes.
- **`toast-theme-from-document.md`** (inspector patch) — #4090. The fix lives in `@mcpjam/design-system`, which is private and in the changeset `ignore` list, so it reaches users only through the inspector bundle and is recorded against the inspector.

The third uncovered commit, #4115, is docs-only and gets no changeset.

## Note on the CLI

The only `cli/` change since the last release is the `op-bindings.ts` entry in #4112 — a test-only drift registry whose sole consumer is `sdk-coverage.test.ts`. No user-visible command behaviour changed, so there is no dedicated CLI changeset; the CLI bumps through the umbrella.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit fa67b9f584a5186f29a90027e85a1e45e3cfe85b. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Release changesets for `@mcpjam/inspector`, `@mcpjam/sdk`, and `@mcpjam/cli` to ship minor updates. Models Claude and ChatGPT as dual-era clients and adds an explicit negotiation policy; fixes an inspector toast theme regression. No CLI behavior changes.

- Versions: `@mcpjam/inspector` 2.42.0, `@mcpjam/sdk` 6.1.0, `@mcpjam/cli` 3.26.0.
- Protocols: Catalog marks Claude/ChatGPT as supporting 2025-11-25 and 2026-07-28 (probed). `mcpProtocolVersion: "auto"` is a stored selection policy that resolves to undefined on the wire; legacy rows remain unchanged. Warning on unadvertised pins now applies to stateful pins only.
- Inspector: Protocol dropdown shows the union of handshake accept-list and catalog eras; Automatic writes `"auto"` and round-trips in JSON. Can‑I‑use adds a Protocol versions row.
- UI fix: Toasts now derive theme from the document’s `.dark` class and pin the description color to `var(--foreground)` to avoid light-on-light text when system and app themes differ.
- Umbrella notes included in the release summary: eval case batching, role-permission matrix gating, actionable GitHub PR checks, and audit logs naming the API key revoker.

No migration required. The SDK’s `"auto"` policy preserves prior connection behavior; CLI only bumps via the umbrella.

<sup>Written for commit fa67b9f584a5186f29a90027e85a1e45e3cfe85b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/MCPJam/inspector/pull/4117?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

