### PR TITLE
Claude directory readiness: pinned transport, result model, and the check lanes

### DIFF
--- a/.github/workflows/claude-policy-drift.yml
+++ b/.github/workflows/claude-policy-drift.yml
@@ -1,0 +1,42 @@
+name: Claude policy drift
+
+# Claude's connector-directory pages are the source the readiness checks grade
+# against, and they live on claude.com — they can move on a day nobody touched
+# this repository. That makes drift a "the world changed" event rather than a
+# "this pull request broke something" one, which is why this runs on a schedule
+# instead of in the PR build: gating every unrelated PR on an external site
+# being reachable buys nothing and fails work that is fine.
+#
+# A red run here means the pinned corpus no longer matches the live pages.
+# Re-read the pages that moved, adjust any check whose wording they changed,
+# then `npm run claude-policy:sync` to re-pin. Do NOT re-pin first — the point
+# of the manifest is that a grade can name the revision it was made against.
+on:
+  schedule:
+    # Mondays, 13:00 UTC. Weekly is the right cadence for documentation drift:
+    # often enough to catch a change in the week it lands, rare enough that the
+    # failure means something when it appears.
+    - cron: "0 13 * * 1"
+  workflow_dispatch:
+
+env:
+  NODE_VERSION: "24.14.0"
+
+jobs:
+  check:
+    runs-on: ubuntu-latest
+    name: Compare pinned policy revisions against the live pages
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+
+      # The script imports node builtins only, so it needs no install step and
+      # cannot be broken by a dependency resolution unrelated to policy text.
+      - name: Check pinned policy revisions
+        run: npm run claude-policy:check

--- a/.github/workflows/claude-policy-drift.yml
+++ b/.github/workflows/claude-policy-drift.yml
@@ -19,6 +19,13 @@ on:
     - cron: "0 13 * * 1"
   workflow_dispatch:
 
+# The job reads a checkout and fetches public documentation. It writes nothing
+# back — re-pinning is a deliberate human step — so the token needs no more
+# than `contents: read`, and an unscoped default token on a scheduled workflow
+# is a standing grant nobody is watching.
+permissions:
+  contents: read
+
 env:
   NODE_VERSION: "24.14.0"
 

--- a/mcpjam-inspector/server/routes/shared/conformance.ts
+++ b/mcpjam-inspector/server/routes/shared/conformance.ts
@@ -38,10 +38,26 @@ import {
 } from "../../services/conformance-oauth-sessions.js";
 import { createStreamingPinnedFetch } from "../../utils/pinned-fetch.js";
 
-/** DNS + connect + response headers, across every hop of one request. */
-const CONFORMANCE_CHAIN_TIMEOUT_MS = 30_000;
-/** No bytes for this long on an open stream ⇒ the stream is dead, not slow. */
-const CONFORMANCE_BODY_IDLE_TIMEOUT_MS = 120_000;
+/**
+ * DNS + connect + response headers, across every hop of one request.
+ *
+ * Matched to undici's `headersTimeout`, which is what these runs got from the
+ * global `fetch` before the transport swap. Closing an SSRF hole is not a
+ * reason to start failing servers that were graded fine yesterday, and a cold
+ * container answering its first `initialize` in forty seconds is slow, not
+ * unreachable — the suite's own per-check timeout is what bounds a slow run.
+ */
+const CONFORMANCE_CHAIN_TIMEOUT_MS = 300_000;
+/**
+ * No bytes for this long on an OPEN stream ⇒ the stream is dead, not slow.
+ *
+ * Matched to undici's `bodyTimeout` for the same reason. It cannot be tight:
+ * MCP requires no SSE keepalives, so a conforming notification stream is
+ * allowed to say nothing at all while a long check or an interactive OAuth
+ * wait runs, and killing it would fail the server for our impatience — and
+ * without resumability, drop the notifications the suite is there to observe.
+ */
+const CONFORMANCE_BODY_IDLE_TIMEOUT_MS = 300_000;
 /** Cumulative decompressed body cap for a single conformance request. */
 const CONFORMANCE_MAX_RESPONSE_BYTES = 32 * 1024 * 1024;
 

--- a/mcpjam-inspector/server/routes/shared/conformance.ts
+++ b/mcpjam-inspector/server/routes/shared/conformance.ts
@@ -36,7 +36,47 @@ import {
   submitAuthorizationCode,
   type OAuthConformanceSession,
 } from "../../services/conformance-oauth-sessions.js";
-import { createGuardedFetch } from "../../utils/hosted-egress-guard.js";
+import { createStreamingPinnedFetch } from "../../utils/pinned-fetch.js";
+
+/** DNS + connect + response headers, across every hop of one request. */
+const CONFORMANCE_CHAIN_TIMEOUT_MS = 30_000;
+/** No bytes for this long on an open stream ⇒ the stream is dead, not slow. */
+const CONFORMANCE_BODY_IDLE_TIMEOUT_MS = 120_000;
+/** Cumulative decompressed body cap for a single conformance request. */
+const CONFORMANCE_MAX_RESPONSE_BYTES = 32 * 1024 * 1024;
+
+/**
+ * The one outbound transport every hosted conformance run dials through.
+ *
+ * `createGuardedFetch` — what this used to be — resolves the hostname to
+ * classify it and then hands the URL to a client that resolves it a SECOND
+ * time, which is the DNS-rebinding window itself: pass the check with a public
+ * answer, serve `169.254.169.254` to the connection that actually happens. The
+ * pinned transport resolves once, refuses the disallowed answers, and pins the
+ * surviving addresses into the socket, re-running all of it on every redirect
+ * hop.
+ *
+ * It is handed to the suites as `fetchFn`, which each runner now also threads
+ * into the MCP transport as `baseFetch` — so the one real MCP connection a run
+ * opens is under the same guard as the raw probes beside it, rather than
+ * following its redirects unchecked as it did while this comment's predecessor
+ * documented the gap.
+ *
+ * A no-op outside hosted mode, where reaching localhost is the point.
+ */
+function createConformanceFetch(targetLabel: string): typeof fetch {
+  return createStreamingPinnedFetch({
+    targetLabel,
+    // DNS + connect + headers, summed across the redirect chain. Deliberately
+    // NOT a bound on an established body: an SSE stream is long-lived by
+    // design, and killing one at 30s would fail conforming servers.
+    chainTimeoutMs: CONFORMANCE_CHAIN_TIMEOUT_MS,
+    // A stalled stream still has to die. This is the bound that can apply to
+    // SSE without punishing a healthy stream for staying open.
+    bodyIdleTimeoutMs: CONFORMANCE_BODY_IDLE_TIMEOUT_MS,
+    maxResponseBytes: CONFORMANCE_MAX_RESPONSE_BYTES,
+  });
+}
 
 // ── Result shapes shared with clients ───────────────────────────────────
 
@@ -107,7 +147,7 @@ export async function runProtocolConformance(
     // threading a base fetch through the client manager, which is a shared
     // connection path for every protocol version and every surface, and does not
     // belong in this change.
-    fetchFn: createGuardedFetch(),
+    fetchFn: createConformanceFetch("MCP server"),
   };
   const test = new MCPConformanceTest(config);
   const result = await test.run();
@@ -119,7 +159,13 @@ export async function runProtocolConformance(
 export async function runAppsConformance(
   serverConfig: MCPAppsConformanceConfig,
 ): Promise<{ result: MCPAppsConformanceResult }> {
-  const test = new MCPAppsConformanceTest(serverConfig);
+  // The apps suite is entirely client-driven — it has no raw probes — so
+  // before `baseFetch` existed there was no seam at all to guard it through,
+  // and a hosted apps run dialled the target with nothing in front of it.
+  const test = new MCPAppsConformanceTest({
+    ...serverConfig,
+    baseFetch: serverConfig.baseFetch ?? createConformanceFetch("MCP server"),
+  });
   const result = await test.run();
   return { result };
 }
@@ -129,7 +175,10 @@ export async function runAppsConformance(
 export async function runTasksConformance(
   serverConfig: MCPTasksConformanceConfig,
 ): Promise<{ result: MCPTasksConformanceResult }> {
-  const test = new MCPTasksConformanceTest(serverConfig);
+  const test = new MCPTasksConformanceTest({
+    ...serverConfig,
+    baseFetch: serverConfig.baseFetch ?? createConformanceFetch("MCP server"),
+  });
   const result = await test.run();
   return { result };
 }
@@ -195,7 +244,7 @@ export async function startOAuthConformance(
     // was ever checkable up front. Every request goes through the hop-checking
     // fetch instead. Requests that ask for `redirect: "manual"` keep their 3xx:
     // this suite grades redirects, and following one would erase the evidence.
-    fetchFn: createGuardedFetch(),
+    fetchFn: createConformanceFetch("OAuth endpoint"),
   };
 
   const test = new OAuthConformanceTest(oauthConfig, {

--- a/mcpjam-inspector/server/utils/__tests__/streaming-pinned-fetch.test.ts
+++ b/mcpjam-inspector/server/utils/__tests__/streaming-pinned-fetch.test.ts
@@ -1,0 +1,60 @@
+/**
+ * The streaming transport's INSPECTOR-side contract: hosted gating, and the
+ * error taxonomy that decides `terminal` vs `retryable`.
+ *
+ * The transport's own behavior (pin the address, re-check every hop, cap the
+ * body) is proven against real sockets in the SDK. What can only be proven
+ * here is the wrapping: a refusal must arrive as `BlockedEgressTargetError`,
+ * because `server-connection-discovery` classifies on `instanceof` and a
+ * flattened class puts a refused target back on a retry schedule — the exact
+ * outcome its bookkeeping exists to prevent.
+ */
+
+import { describe, expect, it } from "vitest";
+
+import { createStreamingPinnedFetch } from "../pinned-fetch.js";
+import {
+  BlockedEgressTargetError,
+  EgressResolutionError,
+} from "../hosted-egress-guard.js";
+
+describe("createStreamingPinnedFetch", () => {
+  it("is the untouched global fetch outside hosted mode", async () => {
+    // Locally, reaching localhost is the entire product; the guard is an
+    // egress decision that only exists on our nodes.
+    const local = createStreamingPinnedFetch({ hosted: false });
+    await expect(local("http://127.0.0.1:1/nothing")).rejects.not.toBeInstanceOf(
+      BlockedEgressTargetError,
+    );
+  });
+
+  it("refuses a literal link-local target as a blocked egress target", async () => {
+    const guarded = createStreamingPinnedFetch({ hosted: true });
+    await expect(
+      guarded("https://169.254.169.254/latest/meta-data/"),
+    ).rejects.toBeInstanceOf(BlockedEgressTargetError);
+  });
+
+  it("refuses loopback in hosted mode without the opt-in", async () => {
+    const guarded = createStreamingPinnedFetch({ hosted: true });
+    await expect(guarded("http://127.0.0.1:9/mcp")).rejects.toBeInstanceOf(
+      BlockedEgressTargetError,
+    );
+  });
+
+  it("never repeats the address a hostname resolved to", async () => {
+    const guarded = createStreamingPinnedFetch({ hosted: true });
+    // Naming the resolved answer would turn a refusal into a resolution
+    // oracle: submit a name, read back what our resolver saw, repeat.
+    await expect(guarded("https://169.254.169.254/")).rejects.toThrow(
+      /not a publicly routable address/,
+    );
+  });
+
+  it("classifies an unresolvable host as a resolution failure, not a refusal", async () => {
+    const guarded = createStreamingPinnedFetch({ hosted: true });
+    await expect(
+      guarded("https://this-host-does-not-exist.invalid/mcp"),
+    ).rejects.toBeInstanceOf(EgressResolutionError);
+  });
+});

--- a/mcpjam-inspector/server/utils/__tests__/streaming-pinned-fetch.test.ts
+++ b/mcpjam-inspector/server/utils/__tests__/streaming-pinned-fetch.test.ts
@@ -10,13 +10,43 @@
  * outcome its bookkeeping exists to prevent.
  */
 
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 
-import { createStreamingPinnedFetch } from "../pinned-fetch.js";
-import {
-  BlockedEgressTargetError,
-  EgressResolutionError,
-} from "../hosted-egress-guard.js";
+/**
+ * DNS is stubbed for the whole file, and that is safe: every other case here
+ * dials a NUMERIC address, which the pinned transport classifies without a
+ * lookup. Only the unresolvable-host case reaches the resolver.
+ *
+ * It is stubbed at all because a `.invalid` name is reserved but not
+ * guaranteed: a wildcard or captive resolver in CI answers with a routable
+ * address, the transport dials it, and the rejection arrives as a plain
+ * `Error` — so the case would pass or fail on the network rather than on the
+ * classification it exists to prove.
+ */
+vi.mock("node:dns", async () => {
+  const actual = await vi.importActual<typeof import("node:dns")>("node:dns");
+  return {
+    ...actual,
+    default: actual,
+    lookup: (
+      _hostname: string,
+      options: unknown,
+      callback?: (error: NodeJS.ErrnoException | null) => void,
+    ) => {
+      const done = (typeof options === "function" ? options : callback) as (
+        error: NodeJS.ErrnoException | null,
+      ) => void;
+      const error: NodeJS.ErrnoException = new Error("getaddrinfo ENOTFOUND");
+      error.code = "ENOTFOUND";
+      done(error);
+    },
+  };
+});
+
+const { createStreamingPinnedFetch } = await import("../pinned-fetch.js");
+const { BlockedEgressTargetError, EgressResolutionError } = await import(
+  "../hosted-egress-guard.js"
+);
 
 describe("createStreamingPinnedFetch", () => {
   it("is the untouched global fetch outside hosted mode", async () => {
@@ -52,9 +82,12 @@ describe("createStreamingPinnedFetch", () => {
   });
 
   it("classifies an unresolvable host as a resolution failure, not a refusal", async () => {
+    // `retryable`, not `terminal`: DNS failing is ours to retry, and reporting
+    // it as an egress REFUSAL would put a perfectly legitimate target on the
+    // permanently-blocked list.
     const guarded = createStreamingPinnedFetch({ hosted: true });
     await expect(
-      guarded("https://this-host-does-not-exist.invalid/mcp"),
+      guarded("https://this-host-does-not-exist.example/mcp"),
     ).rejects.toBeInstanceOf(EgressResolutionError);
   });
 });

--- a/mcpjam-inspector/server/utils/__tests__/streaming-pinned-fetch.test.ts
+++ b/mcpjam-inspector/server/utils/__tests__/streaming-pinned-fetch.test.ts
@@ -81,6 +81,21 @@ describe("createStreamingPinnedFetch", () => {
     );
   });
 
+  it("says a plaintext target is plaintext, not unroutable", async () => {
+    // The address message is right for an address problem and wrong for this
+    // one: an `http://` connector on a perfectly public host was being told it
+    // "is not a publicly routable address", sending its owner to look at DNS
+    // and firewalls for something one character in the URL fixes.
+    const guarded = createStreamingPinnedFetch({ hosted: true });
+    const refusal = await guarded("http://example.com/mcp").catch(
+      (error: unknown) => error,
+    );
+    expect(refusal).toBeInstanceOf(BlockedEgressTargetError);
+    expect((refusal as Error).message).toMatch(/plaintext/i);
+    expect((refusal as Error).message).toMatch(/https/i);
+    expect((refusal as Error).message).not.toMatch(/publicly routable/i);
+  });
+
   it("classifies an unresolvable host as a resolution failure, not a refusal", async () => {
     // `retryable`, not `terminal`: DNS failing is ours to retry, and reporting
     // it as an egress REFUSAL would put a perfectly legitimate target on the

--- a/mcpjam-inspector/server/utils/pinned-fetch.ts
+++ b/mcpjam-inspector/server/utils/pinned-fetch.ts
@@ -28,10 +28,12 @@
  */
 
 import {
+  createPinnedStreamingFetch,
   executeOAuthProxy,
   isLoopbackOAuthUrl,
   OAuthProxyError,
 } from "@mcpjam/sdk/oauth/node";
+import { HOSTED_MODE } from "../config.js";
 import {
   BlockedEgressTargetError,
   EgressResolutionError,
@@ -74,6 +76,13 @@ const REFUSAL_PATTERNS: readonly RegExp[] = [
   /invalid url format/i,
   /must not contain credentials/i,
   /only https targets are allowed/i,
+  // The streaming transport's own two refusals. It reaches these BEFORE any
+  // socket exists, and they arrive here as `OAuthProxyError` rather than being
+  // thrown directly the way `createPinnedFetch` throws its loopback refusal —
+  // so without them a refused target was classified `retryable` and went back
+  // on a retry schedule, which is the exact outcome this taxonomy prevents.
+  /refusing a connection to loopback/i,
+  /refusing a plaintext connection/i,
 ];
 
 /** DNS could not answer. Ours to retry, not the caller's to fix. */
@@ -383,31 +392,104 @@ export function createPinnedFetch(
       // so flattening the class made an SSRF refusal indistinguishable from a
       // timeout — the refused target went back on a retry schedule, which is the
       // exact outcome that module's bookkeeping exists to prevent.
-      if (error instanceof OAuthProxyError) {
-        if (REFUSAL_PATTERNS.some((pattern) => pattern.test(error.message))) {
-          // NOT the transport's message. It names the address the hostname
-          // RESOLVED to — "example.com resolves to a private/reserved IP
-          // address (169.254.169.254)" — and this error's message is reported
-          // back to whoever submitted the hostname. That would make a refusal
-          // into a resolution oracle: submit a name, read back what our
-          // resolver saw, and map the internal network one answer at a time.
-          // The requested host is fine to repeat (they typed it); what it
-          // resolved to is not. The original stays on `cause` for logs.
-          throw new BlockedEgressTargetError(
-            `Refusing to connect to "${safeHost(url)}": it is not a publicly routable address.`,
-            { cause: error }
-          );
-        }
-        if (RESOLUTION_FAILURE_PATTERN.test(error.message)) {
-          throw new EgressResolutionError(error.message);
-        }
-        // A genuine transport failure — timeout, byte cap, redirect ceiling.
-        // Still worth retrying, so it stays a plain error.
-        throw new Error(error.message);
-      }
-      throw error;
+      // `classifyPinnedTransportError` is shared with the streaming transport
+      // below so the two cannot disagree about what a refusal is. It never
+      // repeats the address a hostname RESOLVED to — that would make a refusal
+      // into a resolution oracle — and it leaves a genuine transport failure
+      // (timeout, byte cap, redirect ceiling) a plain retryable `Error`.
+      throw classifyPinnedTransportError(error, url);
     }
   };
 
   return pinnedFetch as typeof fetch;
+}
+
+/**
+ * The streaming sibling of {@link createPinnedFetch}.
+ *
+ * `createPinnedFetch` is built on `executeOAuthProxy`, which BUFFERS the whole
+ * response — fine for an OAuth metadata document, impossible for
+ * `text/event-stream`. So it could never be the fetch an MCP transport dials
+ * through, and the conformance suites were left guarding their raw probes with
+ * `createGuardedFetch` (which resolves twice, leaving a TOCTOU window) while
+ * the one real MCP connection each run opens followed redirects with no guard
+ * at all.
+ *
+ * `createPinnedStreamingFetch` closes both halves: same resolve-once,
+ * classify, pin-into-the-socket walk, re-run on every redirect hop, with the
+ * body handed back as a live stream. This wrapper adds the one thing the SDK
+ * cannot know about — the inspector's error taxonomy, which decides `terminal`
+ * vs `retryable` and must not let an SSRF refusal be mistaken for a timeout.
+ *
+ * OUTSIDE HOSTED MODE THIS IS A NO-OP by default. Locally, reaching
+ * `http://127.0.0.1:3000/mcp` is the entire product; the guard is an egress
+ * decision that only exists on our nodes.
+ */
+export function createStreamingPinnedFetch(
+  options: PinnedFetchOptions & {
+    /** Defaults to `HOSTED_MODE`; pass explicitly in tests. */
+    hosted?: boolean;
+    /** Bounds DNS, connect and headers across the whole redirect chain. */
+    chainTimeoutMs?: number;
+    /** Kills a body stream that has stalled. SSE-safe; a total deadline is not. */
+    bodyIdleTimeoutMs?: number;
+    /** Cumulative decompressed body cap for one request. */
+    maxResponseBytes?: number;
+    /** Names the target in refusal messages, e.g. `"MCP server"`. */
+    targetLabel?: string;
+  } = {}
+): typeof fetch {
+  const hosted = options.hosted ?? HOSTED_MODE;
+  if (!hosted) {
+    return ((...args: Parameters<typeof fetch>) =>
+      fetch(...args)) as typeof fetch;
+  }
+
+  const streamingFetch = createPinnedStreamingFetch({
+    allowLoopback: options.allowLoopback,
+    chainTimeoutMs: options.chainTimeoutMs ?? options.timeoutMs,
+    bodyIdleTimeoutMs: options.bodyIdleTimeoutMs,
+    maxResponseBytes: options.maxResponseBytes,
+    targetLabel: options.targetLabel,
+  });
+
+  return (async (input: RequestInfo | URL, init?: RequestInit) => {
+    const url =
+      typeof input === "string"
+        ? input
+        : input instanceof URL
+          ? input.toString()
+          : input.url;
+    try {
+      return await streamingFetch(input as never, init as never);
+    } catch (error) {
+      throw classifyPinnedTransportError(error, url);
+    }
+  }) as typeof fetch;
+}
+
+/**
+ * Map a transport rejection onto the inspector's taxonomy.
+ *
+ * Shared with {@link createPinnedFetch} so the two transports cannot disagree
+ * about what a refusal is — the discrimination is by message because
+ * `OAuthProxyError` carries only a `status`, and that status is 400 for both
+ * "resolves to a private or reserved IP address" (a verdict about the target)
+ * and "request timeout" (an outage on our side).
+ */
+function classifyPinnedTransportError(error: unknown, url: string): unknown {
+  if (!(error instanceof OAuthProxyError)) return error;
+  if (REFUSAL_PATTERNS.some((pattern) => pattern.test(error.message))) {
+    // The address it RESOLVED to never appears in the message: that would make
+    // a refusal into a resolution oracle. The host they typed is theirs
+    // already; the answer our resolver saw is not.
+    return new BlockedEgressTargetError(
+      `Refusing to connect to "${safeHost(url)}": it is not a publicly routable address.`,
+      { cause: error }
+    );
+  }
+  if (RESOLUTION_FAILURE_PATTERN.test(error.message)) {
+    return new EgressResolutionError(error.message);
+  }
+  return new Error(error.message);
 }

--- a/mcpjam-inspector/server/utils/pinned-fetch.ts
+++ b/mcpjam-inspector/server/utils/pinned-fetch.ts
@@ -76,13 +76,32 @@ const REFUSAL_PATTERNS: readonly RegExp[] = [
   /invalid url format/i,
   /must not contain credentials/i,
   /only https targets are allowed/i,
-  // The streaming transport's own two refusals. It reaches these BEFORE any
-  // socket exists, and they arrive here as `OAuthProxyError` rather than being
-  // thrown directly the way `createPinnedFetch` throws its loopback refusal —
-  // so without them a refused target was classified `retryable` and went back
-  // on a retry schedule, which is the exact outcome this taxonomy prevents.
+  // The streaming transport reaches this one BEFORE any socket exists, and it
+  // arrives here as `OAuthProxyError` rather than being thrown directly the way
+  // `createPinnedFetch` throws its loopback refusal — so without it a refused
+  // target was classified `retryable` and went back on a retry schedule, which
+  // is the exact outcome this taxonomy prevents. Loopback belongs in THIS list
+  // because in hosted mode "loopback" and "not publicly routable" are the same
+  // statement; the refusals below are not.
   /refusing a connection to loopback/i,
+];
+
+/**
+ * Refusals that are just as terminal, and just as much the caller's to fix, but
+ * are NOT about where the host resolves.
+ *
+ * These keep the transport's own wording instead of the canned address message.
+ * A connector served over plaintext `http://` is refused for its SCHEME, and
+ * telling its owner that their perfectly public host "is not a publicly
+ * routable address" sends them to look at DNS and firewalls for a problem that
+ * one character in the URL would fix. A redirect chain that runs past the
+ * ceiling is the same kind of mismatch. Both are still 400s — the request
+ * cannot be retried into success — they simply have to say what is actually
+ * wrong.
+ */
+const TERMINAL_REQUEST_PATTERNS: readonly RegExp[] = [
   /refusing a plaintext connection/i,
+  /too many redirects/i,
 ];
 
 /** DNS could not answer. Ours to retry, not the caller's to fix. */
@@ -435,6 +454,8 @@ export function createStreamingPinnedFetch(
     bodyIdleTimeoutMs?: number;
     /** Cumulative decompressed body cap for one request. */
     maxResponseBytes?: number;
+    /** Redirect hops allowed before the chain is refused. Defaults to fetch parity. */
+    maxRedirects?: number;
     /** Names the target in refusal messages, e.g. `"MCP server"`. */
     targetLabel?: string;
   } = {}
@@ -450,6 +471,7 @@ export function createStreamingPinnedFetch(
     chainTimeoutMs: options.chainTimeoutMs ?? options.timeoutMs,
     bodyIdleTimeoutMs: options.bodyIdleTimeoutMs,
     maxResponseBytes: options.maxResponseBytes,
+    maxRedirects: options.maxRedirects,
     targetLabel: options.targetLabel,
   });
 
@@ -487,6 +509,11 @@ function classifyPinnedTransportError(error: unknown, url: string): unknown {
       `Refusing to connect to "${safeHost(url)}": it is not a publicly routable address.`,
       { cause: error }
     );
+  }
+  if (TERMINAL_REQUEST_PATTERNS.some((pattern) => pattern.test(error.message))) {
+    // Terminal like the refusals above, but the transport already said what is
+    // wrong and it is not the address, so its message is the honest one.
+    return new BlockedEgressTargetError(error.message, { cause: error });
   }
   if (RESOLUTION_FAILURE_PATTERN.test(error.message)) {
     return new EgressResolutionError(error.message);

--- a/package.json
+++ b/package.json
@@ -33,6 +33,8 @@
     "verify": "npm run typecheck && npm run test && npm run build:inspector",
     "docs:sync-tokens": "node scripts/sync-docs-tokens.mjs",
     "docs:check-tokens": "node scripts/sync-docs-tokens.mjs --check",
+    "claude-policy:sync": "node scripts/sync-claude-policy-manifest.mjs",
+    "claude-policy:check": "node scripts/sync-claude-policy-manifest.mjs --check",
     "release:status": "changeset status",
     "release:version": "changeset version",
     "release:publish": "changeset publish"

--- a/scripts/sync-claude-policy-manifest.mjs
+++ b/scripts/sync-claude-policy-manifest.mjs
@@ -87,6 +87,16 @@ export function extractText(html) {
       continue;
     }
 
+    // `<!doctype html>` is not a tag `readTag` recognises, so without this it
+    // would survive as literal text and a markup-only doctype change would
+    // move the policy revision.
+    if (/^<!doctype(?:\s|>)/i.test(html.slice(lt, lt + 10))) {
+      const end = html.indexOf(">", lt + 2);
+      out.push(" ");
+      index = end === -1 ? html.length : end + 1;
+      continue;
+    }
+
     const tag = readTag(html, lt);
     if (!tag) {
       // A `<` that does not begin a tag — "a < b" — is content, not markup.
@@ -225,15 +235,24 @@ async function main() {
     ].map((match) => [match[1], match[2]]),
   );
 
+  // A MISSING recorded revision counts as drift. Requiring `previous[page]`
+  // meant `--check` exited 0 whenever the corpus had never been snapshotted at
+  // all — CI would accept an unsnapshotted policy corpus as "no drift", which
+  // is the one state where a grade's provenance is least trustworthy.
   const drifted = results.filter(
     (entry) =>
-      entry.revision &&
-      previous[entry.page] &&
-      previous[entry.page] !== entry.revision,
+      entry.revision && previous[entry.page] !== entry.revision,
   );
+  const unsnapshotted = drifted.filter((entry) => !previous[entry.page]);
 
   if (checkOnly) {
-    if (drifted.length > 0) {
+    if (unsnapshotted.length === drifted.length && drifted.length > 0) {
+      console.error(
+        `\nNOT SNAPSHOTTED: ${unsnapshotted.length} page(s) have no recorded ` +
+          `revision. Run \`npm run claude-policy:sync\` to pin the corpus ` +
+          `before relying on a readiness grade's provenance.`,
+      );
+    } else if (drifted.length > 0) {
       console.error(
         `\nDRIFT: ${drifted
           .map((entry) => entry.page)
@@ -242,6 +261,17 @@ async function main() {
       );
     }
     process.exit(drifted.length > 0 || failures > 0 ? 1 : 0);
+  }
+
+  // NOTHING IS WRITTEN AFTER A PARTIAL FAILURE. `entries` excludes the pages
+  // that failed, so writing here would DELETE their previously recorded
+  // revisions — a transient network blip would silently un-verify part of the
+  // corpus on its way to exiting non-zero.
+  if (failures > 0) {
+    console.error(
+      `\n${failures} page(s) could not be fetched; the manifest was left unchanged.`,
+    );
+    process.exit(1);
   }
 
   const entries = results
@@ -256,12 +286,6 @@ async function main() {
     source.slice(0, beginIndex) + block + source.slice(endIndex),
   );
   console.log(`\nwrote ${MANIFEST}`);
-  if (failures > 0) {
-    console.error(
-      `${failures} page(s) could not be fetched; their revisions stay null.`,
-    );
-    process.exit(1);
-  }
 }
 
 if (

--- a/scripts/sync-claude-policy-manifest.mjs
+++ b/scripts/sync-claude-policy-manifest.mjs
@@ -28,7 +28,7 @@
 import { createHash } from "node:crypto";
 import { readFileSync, writeFileSync } from "node:fs";
 import { dirname, resolve } from "node:path";
-import { fileURLToPath } from "node:url";
+import { fileURLToPath, pathToFileURL } from "node:url";
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const ROOT = resolve(__dirname, "..");
@@ -55,19 +55,122 @@ function readManifestSource() {
 }
 
 /**
- * Visible text only.
+ * Visible text only, by scanning rather than by pattern-matching.
  *
  * Hashing raw HTML would make every unrelated site rebuild look like a policy
- * change, and a manifest that cries wolf is a manifest nobody re-runs.
+ * change, and a manifest that cries wolf is a manifest nobody re-runs. So the
+ * markup has to come out — and the obvious `replace(/<[^>]+>/g, " ")` is wrong
+ * in three ways that all corrupt the hash: it ends a tag at a `>` inside a
+ * quoted attribute value, it does not match `</script >` with a space (so the
+ * script body leaks into the text), and it turns comment bodies into content.
+ * Each of those makes the digest depend on markup trivia, which is exactly
+ * what this function exists to remove.
+ *
+ * A scanner has none of those problems, and it is short.
  */
-function extractText(html) {
-  return html
-    .replace(/<script[\s\S]*?<\/script>/gi, " ")
-    .replace(/<style[\s\S]*?<\/style>/gi, " ")
-    .replace(/<[^>]+>/g, " ")
-    .replace(/&nbsp;/g, " ")
+export function extractText(html) {
+  const out = [];
+  let index = 0;
+
+  while (index < html.length) {
+    const lt = html.indexOf("<", index);
+    if (lt === -1) {
+      out.push(html.slice(index));
+      break;
+    }
+    out.push(html.slice(index, lt));
+
+    if (html.startsWith("<!--", lt)) {
+      const end = html.indexOf("-->", lt + 4);
+      out.push(" ");
+      index = end === -1 ? html.length : end + 3;
+      continue;
+    }
+
+    const tag = readTag(html, lt);
+    if (!tag) {
+      // A `<` that does not begin a tag — "a < b" — is content, not markup.
+      out.push("<");
+      index = lt + 1;
+      continue;
+    }
+
+    out.push(" ");
+    index =
+      !tag.closing && !tag.selfClosing && RAW_TEXT_ELEMENTS.has(tag.name)
+        ? skipRawText(html, tag.end, tag.name)
+        : tag.end;
+  }
+
+  return out
+    .join("")
+    .replace(/&nbsp;/gi, " ")
     .replace(/\s+/g, " ")
     .trim();
+}
+
+/** Elements whose content is not markup and must be dropped whole. */
+const RAW_TEXT_ELEMENTS = new Set(["script", "style"]);
+
+/**
+ * Read one tag starting at `start` (which must point at `<`).
+ *
+ * Returns `undefined` when what follows is not a tag name, so `a < b` stays
+ * text. Quoted attribute values are skipped, so `<a title="a>b">` ends where
+ * the tag actually ends.
+ */
+function readTag(html, start) {
+  let index = start + 1;
+  const closing = html[index] === "/";
+  if (closing) index += 1;
+
+  const nameStart = index;
+  while (index < html.length && /[A-Za-z0-9:-]/.test(html[index])) index += 1;
+  if (index === nameStart) return undefined;
+  const name = html.slice(nameStart, index).toLowerCase();
+
+  let quote;
+  while (index < html.length) {
+    const char = html[index];
+    if (quote) {
+      if (char === quote) quote = undefined;
+    } else if (char === '"' || char === "'") {
+      quote = char;
+    } else if (char === ">") {
+      return {
+        name,
+        closing,
+        selfClosing: html[index - 1] === "/",
+        end: index + 1,
+      };
+    }
+    index += 1;
+  }
+  // Unterminated tag: everything after it is markup we cannot parse, so drop it.
+  return { name, closing, selfClosing: false, end: html.length };
+}
+
+/**
+ * Skip to just past `</name …>`, tolerating whitespace and attributes in the
+ * end tag. `</script >` is valid HTML and a naive `"</script>"` search walks
+ * straight past it, taking the entire rest of the document as script body.
+ */
+function skipRawText(html, from, name) {
+  const lower = html.toLowerCase();
+  const needle = `</${name}`;
+  let index = from;
+  for (;;) {
+    const at = lower.indexOf(needle, index);
+    if (at === -1) return html.length;
+    const after = html[at + needle.length];
+    // A name boundary: `</script>`, `</script >`, `</script\n>` — but not
+    // `</scriptfoo>`, which is a different element.
+    if (after === undefined || after === ">" || /\s/.test(after)) {
+      const tag = readTag(html, at);
+      return tag ? tag.end : html.length;
+    }
+    index = at + needle.length;
+  }
 }
 
 async function fetchPage(url) {
@@ -84,72 +187,86 @@ async function fetchPage(url) {
   return extractText(await response.text());
 }
 
-const { baseUrl, pages } = readManifestSource();
-const results = [];
-let failures = 0;
+/**
+ * The side-effecting half, behind a direct-invocation guard so a test can
+ * import {@link extractText} without the module fetching twelve pages as an
+ * import side effect.
+ */
+async function main() {
+  const { baseUrl, pages } = readManifestSource();
+  const results = [];
+  let failures = 0;
 
-for (const page of pages) {
-  const url = `${baseUrl}/${page}`;
-  try {
-    const text = await fetchPage(url);
-    const revision = createHash("sha256").update(text).digest("hex").slice(0, 32);
-    results.push({ page, url, revision, bytes: text.length });
-    console.log(`ok    ${page}  ${revision}  (${text.length} chars)`);
-  } catch (error) {
-    failures += 1;
-    results.push({ page, url, revision: null, error: String(error) });
-    console.error(`FAIL  ${page}  ${url}  ${error}`);
+  for (const page of pages) {
+    const url = `${baseUrl}/${page}`;
+    try {
+      const text = await fetchPage(url);
+      const revision = createHash("sha256").update(text).digest("hex").slice(0, 32);
+      results.push({ page, url, revision, bytes: text.length });
+      console.log(`ok    ${page}  ${revision}  (${text.length} chars)`);
+    } catch (error) {
+      failures += 1;
+      results.push({ page, url, revision: null, error: String(error) });
+      console.error(`FAIL  ${page}  ${url}  ${error}`);
+    }
   }
-}
 
-const source = readFileSync(MANIFEST, "utf8");
-const beginIndex = source.indexOf(BEGIN);
-const endIndex = source.indexOf(END);
-if (beginIndex === -1 || endIndex === -1) {
-  throw new Error("Could not find the GENERATED block in the manifest.");
-}
-const previous = Object.fromEntries(
-  [
-    ...source
-      .slice(beginIndex, endIndex)
-      .matchAll(/"([^"]+)":\s*"([0-9a-f]+)"/g),
-  ].map((match) => [match[1], match[2]]),
-);
-
-const drifted = results.filter(
-  (entry) =>
-    entry.revision &&
-    previous[entry.page] &&
-    previous[entry.page] !== entry.revision,
-);
-
-if (checkOnly) {
-  if (drifted.length > 0) {
-    console.error(
-      `\nDRIFT: ${drifted
-        .map((entry) => entry.page)
-        .join(", ")} changed since the recorded snapshot. Re-audit the checks ` +
-        `that cite these pages, then re-run without --check.`,
-    );
+  const source = readFileSync(MANIFEST, "utf8");
+  const beginIndex = source.indexOf(BEGIN);
+  const endIndex = source.indexOf(END);
+  if (beginIndex === -1 || endIndex === -1) {
+    throw new Error("Could not find the GENERATED block in the manifest.");
   }
-  process.exit(drifted.length > 0 || failures > 0 ? 1 : 0);
-}
-
-const entries = results
-  .filter((entry) => entry.revision)
-  .map((entry) => `  "${entry.page}": "${entry.revision}",`)
-  .join("\n");
-const block = `${BEGIN}\nconst PAGE_REVISIONS: Partial<Record<ClaudePolicyPage, string>> = {${
-  entries ? `\n${entries}\n` : ""
-}};\n`;
-writeFileSync(
-  MANIFEST,
-  source.slice(0, beginIndex) + block + source.slice(endIndex),
-);
-console.log(`\nwrote ${MANIFEST}`);
-if (failures > 0) {
-  console.error(
-    `${failures} page(s) could not be fetched; their revisions stay null.`,
+  const previous = Object.fromEntries(
+    [
+      ...source
+        .slice(beginIndex, endIndex)
+        .matchAll(/"([^"]+)":\s*"([0-9a-f]+)"/g),
+    ].map((match) => [match[1], match[2]]),
   );
-  process.exit(1);
+
+  const drifted = results.filter(
+    (entry) =>
+      entry.revision &&
+      previous[entry.page] &&
+      previous[entry.page] !== entry.revision,
+  );
+
+  if (checkOnly) {
+    if (drifted.length > 0) {
+      console.error(
+        `\nDRIFT: ${drifted
+          .map((entry) => entry.page)
+          .join(", ")} changed since the recorded snapshot. Re-audit the checks ` +
+          `that cite these pages, then re-run without --check.`,
+      );
+    }
+    process.exit(drifted.length > 0 || failures > 0 ? 1 : 0);
+  }
+
+  const entries = results
+    .filter((entry) => entry.revision)
+    .map((entry) => `  "${entry.page}": "${entry.revision}",`)
+    .join("\n");
+  const block = `${BEGIN}\nconst PAGE_REVISIONS: Partial<Record<ClaudePolicyPage, string>> = {${
+    entries ? `\n${entries}\n` : ""
+  }};\n`;
+  writeFileSync(
+    MANIFEST,
+    source.slice(0, beginIndex) + block + source.slice(endIndex),
+  );
+  console.log(`\nwrote ${MANIFEST}`);
+  if (failures > 0) {
+    console.error(
+      `${failures} page(s) could not be fetched; their revisions stay null.`,
+    );
+    process.exit(1);
+  }
+}
+
+if (
+  process.argv[1] &&
+  import.meta.url === pathToFileURL(process.argv[1]).href
+) {
+  await main();
 }

--- a/scripts/sync-claude-policy-manifest.mjs
+++ b/scripts/sync-claude-policy-manifest.mjs
@@ -1,0 +1,155 @@
+#!/usr/bin/env node
+/**
+ * Snapshot Anthropic's connector-directory documentation into the readiness
+ * policy manifest.
+ *
+ * WHY THIS EXISTS. Every Claude readiness finding cites a page, a section, and
+ * the revision it was graded against. Without a real revision, a grade cannot
+ * tell anyone that the policy moved underneath it — it just stays confidently
+ * wrong. `sdk/src/claude-readiness/manifest.ts` therefore ships with
+ * `revision: null` on every entry (a fabricated hash would make an unaudited
+ * corpus look audited) and this script is what fills them in.
+ *
+ * WHAT IT DOES. Fetches every page in the manifest, reduces the HTML to its
+ * visible text so a rebuilt bundle hash or a rotated asset URL does not read as
+ * a policy change, hashes that, and rewrites the GENERATED block in
+ * `manifest.ts` in place — so the manifest stays static data the browser entry
+ * can import, with no JSON loader and no second file to drift against.
+ *
+ * Usage:
+ *   node scripts/sync-claude-policy-manifest.mjs            # write revisions
+ *   node scripts/sync-claude-policy-manifest.mjs --check    # exit 1 on drift
+ *
+ * `--check` is the one that matters in CI: a changed hash against an unchanged
+ * `snapshotDate` means the docs moved and the check inventory needs
+ * re-auditing before any grade made against it can be trusted.
+ */
+
+import { createHash } from "node:crypto";
+import { readFileSync, writeFileSync } from "node:fs";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const ROOT = resolve(__dirname, "..");
+const MANIFEST = resolve(ROOT, "sdk/src/claude-readiness/manifest.ts");
+const BEGIN = "// BEGIN GENERATED — sync via `npm run claude-policy:sync`";
+const END = "// END GENERATED";
+
+const checkOnly = process.argv.includes("--check");
+
+/** Read the page list and base URL out of the TS module without importing it. */
+function readManifestSource() {
+  const source = readFileSync(MANIFEST, "utf8");
+  const baseMatch = source.match(/CLAUDE_DOCS_BASE_URL = "([^"]+)"/);
+  const pagesBlock = source.match(
+    /CLAUDE_POLICY_PAGES = \[([\s\S]*?)\] as const;/,
+  );
+  if (!baseMatch || !pagesBlock) {
+    throw new Error(
+      "Could not read CLAUDE_DOCS_BASE_URL / CLAUDE_POLICY_PAGES from the manifest.",
+    );
+  }
+  const pages = [...pagesBlock[1].matchAll(/"([^"]+)"/g)].map((m) => m[1]);
+  return { baseUrl: baseMatch[1], pages };
+}
+
+/**
+ * Visible text only.
+ *
+ * Hashing raw HTML would make every unrelated site rebuild look like a policy
+ * change, and a manifest that cries wolf is a manifest nobody re-runs.
+ */
+function extractText(html) {
+  return html
+    .replace(/<script[\s\S]*?<\/script>/gi, " ")
+    .replace(/<style[\s\S]*?<\/style>/gi, " ")
+    .replace(/<[^>]+>/g, " ")
+    .replace(/&nbsp;/g, " ")
+    .replace(/\s+/g, " ")
+    .trim();
+}
+
+async function fetchPage(url) {
+  const response = await fetch(url, {
+    redirect: "follow",
+    headers: { accept: "text/html" },
+    signal: AbortSignal.timeout(30_000),
+  });
+  if (!response.ok) {
+    // Loudly, not silently: hashing a 404 page would pin the manifest to
+    // "page not found" and then report no drift forever after.
+    throw new Error(`${response.status} ${response.statusText}`);
+  }
+  return extractText(await response.text());
+}
+
+const { baseUrl, pages } = readManifestSource();
+const results = [];
+let failures = 0;
+
+for (const page of pages) {
+  const url = `${baseUrl}/${page}`;
+  try {
+    const text = await fetchPage(url);
+    const revision = createHash("sha256").update(text).digest("hex").slice(0, 32);
+    results.push({ page, url, revision, bytes: text.length });
+    console.log(`ok    ${page}  ${revision}  (${text.length} chars)`);
+  } catch (error) {
+    failures += 1;
+    results.push({ page, url, revision: null, error: String(error) });
+    console.error(`FAIL  ${page}  ${url}  ${error}`);
+  }
+}
+
+const source = readFileSync(MANIFEST, "utf8");
+const beginIndex = source.indexOf(BEGIN);
+const endIndex = source.indexOf(END);
+if (beginIndex === -1 || endIndex === -1) {
+  throw new Error("Could not find the GENERATED block in the manifest.");
+}
+const previous = Object.fromEntries(
+  [
+    ...source
+      .slice(beginIndex, endIndex)
+      .matchAll(/"([^"]+)":\s*"([0-9a-f]+)"/g),
+  ].map((match) => [match[1], match[2]]),
+);
+
+const drifted = results.filter(
+  (entry) =>
+    entry.revision &&
+    previous[entry.page] &&
+    previous[entry.page] !== entry.revision,
+);
+
+if (checkOnly) {
+  if (drifted.length > 0) {
+    console.error(
+      `\nDRIFT: ${drifted
+        .map((entry) => entry.page)
+        .join(", ")} changed since the recorded snapshot. Re-audit the checks ` +
+        `that cite these pages, then re-run without --check.`,
+    );
+  }
+  process.exit(drifted.length > 0 || failures > 0 ? 1 : 0);
+}
+
+const entries = results
+  .filter((entry) => entry.revision)
+  .map((entry) => `  "${entry.page}": "${entry.revision}",`)
+  .join("\n");
+const block = `${BEGIN}\nconst PAGE_REVISIONS: Partial<Record<ClaudePolicyPage, string>> = {${
+  entries ? `\n${entries}\n` : ""
+}};\n`;
+writeFileSync(
+  MANIFEST,
+  source.slice(0, beginIndex) + block + source.slice(endIndex),
+);
+console.log(`\nwrote ${MANIFEST}`);
+if (failures > 0) {
+  console.error(
+    `${failures} page(s) could not be fetched; their revisions stay null.`,
+  );
+  process.exit(1);
+}

--- a/scripts/sync-claude-policy-manifest.mjs
+++ b/scripts/sync-claude-policy-manifest.mjs
@@ -244,17 +244,22 @@ async function main() {
       entry.revision && previous[entry.page] !== entry.revision,
   );
   const unsnapshotted = drifted.filter((entry) => !previous[entry.page]);
+  // A page that was never recorded did not CHANGE. Folding both into one
+  // "changed since the recorded snapshot" line sends a maintainer to re-audit
+  // a check against a diff that does not exist.
+  const changed = drifted.filter((entry) => previous[entry.page]);
 
   if (checkOnly) {
-    if (unsnapshotted.length === drifted.length && drifted.length > 0) {
+    if (unsnapshotted.length > 0) {
       console.error(
         `\nNOT SNAPSHOTTED: ${unsnapshotted.length} page(s) have no recorded ` +
           `revision. Run \`npm run claude-policy:sync\` to pin the corpus ` +
           `before relying on a readiness grade's provenance.`,
       );
-    } else if (drifted.length > 0) {
+    }
+    if (changed.length > 0) {
       console.error(
-        `\nDRIFT: ${drifted
+        `\nDRIFT: ${changed
           .map((entry) => entry.page)
           .join(", ")} changed since the recorded snapshot. Re-audit the checks ` +
           `that cite these pages, then re-run without --check.`,

--- a/sdk/src/browser.ts
+++ b/sdk/src/browser.ts
@@ -26,10 +26,88 @@ export {
   type McpModelVisibleToolResultPolicy,
   type McpLinkedResourceReader,
 } from "./mcp-client-manager/model-output.js";
-// Claude directory readiness: the result model, the policy manifest, and the
-// host profile. All pure data — a client rendering lanes, coverage and badges
-// needs exactly this and must not reach the root entry for it.
-export * from "./claude-readiness/index.js";
+/**
+ * Claude directory readiness — the RENDERING surface only.
+ *
+ * Named rather than `export *`, and narrower than the readiness barrel, for
+ * two reasons. A wildcard would make any symbol added to
+ * `claude-readiness/index.ts` public browser API with no change to this file
+ * and no reviewer looking at it. And a client renders lanes, coverage and
+ * badges; it does not RUN checks, so the check runners and their evidence
+ * types have no business in a browser bundle even though they are pure enough
+ * to survive one.
+ */
+export {
+  CLAUDE_EVIDENCE_PROVENANCE,
+  CLAUDE_FINDING_CLASSES,
+  CLAUDE_INTRUSIVENESS_LEVELS,
+  CLAUDE_READINESS_ENGINE_VERSION,
+  CLAUDE_READINESS_LANES,
+  CLAUDE_REQUIRED_LANES,
+  CLAUDE_RUNNER_CAPABILITIES,
+  decideLaneStatus,
+  isDispositiveClaudeFinding,
+  rollUpLaneStatus,
+  summarizeLaneCoverage,
+} from "./claude-readiness/types.js";
+export type {
+  ClaudeCapabilityBadge,
+  ClaudeEvidenceProvenance,
+  ClaudeFindingClass,
+  ClaudeFindingStatus,
+  ClaudeIntrusiveness,
+  ClaudeLaneCoverage,
+  ClaudeLaneStatus,
+  ClaudeReadinessAuthMode,
+  ClaudeReadinessFinding,
+  ClaudeReadinessLane,
+  ClaudeReadinessLaneResult,
+  ClaudeReadinessResult,
+  ClaudeReadinessRunContext,
+  ClaudeRunnerCapability,
+} from "./claude-readiness/types.js";
+
+// The policy corpus, so a surface can say WHICH revision a grade was made
+// against — and whether the corpus was ever snapshotted at all.
+export {
+  CLAUDE_DOCS_BASE_URL,
+  CLAUDE_POLICY_MANIFEST,
+  CLAUDE_POLICY_PAGES,
+  CLAUDE_POLICY_SNAPSHOT_DATE,
+  claudePolicySource,
+  isPolicyCorpusVerified,
+} from "./claude-readiness/manifest.js";
+export type {
+  ClaudePolicyPage,
+  ClaudePolicySourceEntry,
+  ClaudePolicySourceRef,
+} from "./claude-readiness/manifest.js";
+
+// Claude's own constants, and the submission form's shape — a client
+// validating that form before it is submitted needs both.
+export {
+  CLAUDE_APP_CONTENT_DOMAIN_SUFFIX,
+  CLAUDE_APP_DESIGN_BUDGETS,
+  CLAUDE_APP_HTML_MIME,
+  CLAUDE_CALLBACK_URLS,
+  CLAUDE_HOST_PROFILE,
+  CLAUDE_LATENCY_BUDGETS,
+  CLAUDE_SUBMISSION_LIMITS,
+} from "./claude-readiness/profile.js";
+export {
+  CLAUDE_ATTESTATIONS,
+  CLAUDE_DATA_HANDLING_MODES,
+  CLAUDE_DECLARED_AUTH_MODES,
+  claudeSubmissionProfileSchema,
+  parseClaudeSubmissionProfile,
+} from "./claude-readiness/submission-profile.js";
+export type {
+  ClaudeAttestation,
+  ClaudeDataHandlingMode,
+  ClaudeDeclaredAuthMode,
+  ClaudeSubmissionProfile,
+  ClaudeSubmissionProfileParse,
+} from "./claude-readiness/submission-profile.js";
 
 export { redactForTelemetry } from "./telemetry-redaction.js";
 /**

--- a/sdk/src/browser.ts
+++ b/sdk/src/browser.ts
@@ -26,6 +26,11 @@ export {
   type McpModelVisibleToolResultPolicy,
   type McpLinkedResourceReader,
 } from "./mcp-client-manager/model-output.js";
+// Claude directory readiness: the result model, the policy manifest, and the
+// host profile. All pure data — a client rendering lanes, coverage and badges
+// needs exactly this and must not reach the root entry for it.
+export * from "./claude-readiness/index.js";
+
 export { redactForTelemetry } from "./telemetry-redaction.js";
 /**
  * @deprecated Renamed to `redactForTelemetry`. Kept as an alias so external

--- a/sdk/src/claude-readiness/checks/apps.ts
+++ b/sdk/src/claude-readiness/checks/apps.ts
@@ -17,6 +17,12 @@
  */
 
 import { sha256Hex } from "../../contract/canonical.js";
+import {
+  hasAccessibilityAffordance,
+  hasInteractiveElement,
+  scanHtml,
+  type ScannedHtml,
+} from "../html-scan.js";
 import { getToolVisibility } from "../../widget-runtime/tool-visibility.js";
 import { claudePolicySource } from "../manifest.js";
 import {
@@ -182,7 +188,8 @@ const INSTANCE_SUPERSESSION: ClaudeCheckDefinition = {
  */
 const DESIGN_LINTS: Array<{
   definition: ClaudeCheckDefinition;
-  detect: (html: string) => boolean;
+  /** True when the widget looks like it MISSES the guideline. */
+  detect: (scanned: ScannedHtml) => boolean;
   remediation: string;
 }> = [
   {
@@ -191,10 +198,10 @@ const DESIGN_LINTS: Array<{
       "Widget appears to have no narrow-viewport handling",
       "§Responsiveness",
     ),
-    detect: (html) =>
-      !/@media[^{]*\(\s*max-width/i.test(html) &&
-      !/@container/i.test(html) &&
-      !/\bminmax\(|\bclamp\(|\bflex-wrap\b/i.test(html),
+    detect: (scanned) =>
+      !/@media[^{]*\(\s*max-width/i.test(scanned.styleText) &&
+      !/@container/i.test(scanned.styleText) &&
+      !/\bminmax\(|\bclamp\(|\bflex-wrap\b/i.test(scanned.styleText),
     remediation:
       "Claude renders widgets as narrow as 320px. No media query, container query, or intrinsic sizing was found.",
   },
@@ -204,10 +211,10 @@ const DESIGN_LINTS: Array<{
       "Interactive elements may be below the 44×44px touch target",
       "§Touch targets",
     ),
-    detect: (html) =>
-      /<(button|a)\b/i.test(html) &&
-      !/min-height\s*:\s*(4[4-9]|[5-9]\d|\d{3,})px/i.test(html) &&
-      !/min-block-size/i.test(html),
+    detect: (scanned) =>
+      hasInteractiveElement(scanned) &&
+      !/min-height\s*:\s*(4[4-9]|[5-9]\d|\d{3,})px/i.test(scanned.styleText) &&
+      !/min-block-size/i.test(scanned.styleText),
     remediation:
       "Interactive controls were found with no minimum height reaching 44px.",
   },
@@ -217,7 +224,7 @@ const DESIGN_LINTS: Array<{
       "Widget does not account for the device safe area",
       "§Safe areas",
     ),
-    detect: (html) => !/safe-area-inset/i.test(html),
+    detect: (scanned) => !/safe-area-inset/i.test(scanned.styleText),
     remediation:
       "No `env(safe-area-inset-*)` usage was found; content can sit under a notch or home indicator.",
   },
@@ -227,10 +234,10 @@ const DESIGN_LINTS: Array<{
       "Widget appears not to follow the host's light/dark theme",
       "§Theming",
     ),
-    detect: (html) =>
-      !/prefers-color-scheme/i.test(html) &&
-      !/color-scheme/i.test(html) &&
-      !/data-theme/i.test(html),
+    detect: (scanned) =>
+      !/prefers-color-scheme/i.test(scanned.styleText) &&
+      !/color-scheme/i.test(scanned.styleText) &&
+      !scanned.attributes.has("data-theme"),
     remediation:
       "No `prefers-color-scheme`, `color-scheme`, or theme attribute was found; the widget will not follow Claude's theme.",
   },
@@ -240,8 +247,10 @@ const DESIGN_LINTS: Array<{
       "Widget paints an opaque background over the host surface",
       "§Backgrounds",
     ),
-    detect: (html) =>
-      /body\s*{[^}]*background(-color)?\s*:\s*(#|rgb|hsl|white|black)/i.test(html),
+    detect: (scanned) =>
+      /body\s*{[^}]*background(-color)?\s*:\s*(#|rgb|hsl|white|black)/i.test(
+        scanned.styleText,
+      ),
     remediation:
       "The widget paints its own body background; Claude's surface shows through a transparent one.",
   },
@@ -251,7 +260,8 @@ const DESIGN_LINTS: Array<{
       "Widget introduces its own scroll container",
       "§Scrolling",
     ),
-    detect: (html) => /overflow(-y)?\s*:\s*(auto|scroll)/i.test(html),
+    detect: (scanned) =>
+      /overflow(-y)?\s*:\s*(auto|scroll)/i.test(scanned.styleText),
     remediation:
       "A nested scroll region was found. Claude scrolls the conversation, and a scroll-within-a-scroll is hard to use on touch.",
   },
@@ -261,12 +271,9 @@ const DESIGN_LINTS: Array<{
       "Widget shows few accessibility affordances",
       "§Accessibility",
     ),
-    detect: (html) =>
-      /<(button|a|input)\b/i.test(html) &&
-      !/aria-[a-z]+=/i.test(html) &&
-      !/\brole=/i.test(html),
-    remediation:
-      "Interactive elements carry no ARIA attributes or roles.",
+    detect: (scanned) =>
+      hasInteractiveElement(scanned) && !hasAccessibilityAffordance(scanned),
+    remediation: "Interactive elements carry no ARIA attributes or roles.",
   },
   {
     definition: designLint(
@@ -274,7 +281,10 @@ const DESIGN_LINTS: Array<{
       "Widget does not react to the host's display mode",
       "§Display modes",
     ),
-    detect: (html) => !/displayMode|display-mode/i.test(html),
+    detect: (scanned) =>
+      !/displayMode/i.test(scanned.scriptText) &&
+      !/display-mode/i.test(scanned.styleText) &&
+      !scanned.attributes.has("data-display-mode"),
     remediation:
       "No reference to the host display mode was found; the widget will render identically inline and fullscreen.",
   },
@@ -568,8 +578,17 @@ function runDesignLints(
     );
   }
 
+  // Scanned ONCE per resource, not once per lint: eight regex passes over the
+  // same markup would be eight chances to disagree about what is in it.
+  const scanned = withHtml.map((resource) => ({
+    resource,
+    html: scanHtml(resource.html),
+  }));
+
   return DESIGN_LINTS.map((lint) => {
-    const flagged = withHtml.filter((resource) => lint.detect(resource.html));
+    const flagged = scanned
+      .filter((entry) => lint.detect(entry.html))
+      .map((entry) => entry.resource);
     // PROVENANCE IS HONEST HERE. These are `static` reads of markup even when
     // the run also had a browser: a rendering engine was not what produced
     // this signal, and labelling it `browser` would overstate the evidence.

--- a/sdk/src/claude-readiness/checks/apps.ts
+++ b/sdk/src/claude-readiness/checks/apps.ts
@@ -1,0 +1,693 @@
+/**
+ * Claude-specific MCP Apps checks.
+ *
+ * COMPOSITION IS THE POINT. `apps-conformance` already grades whether a widget
+ * is a valid MCP App, and `host-compat` already grades which hosts can render
+ * it. Neither is re-run here. This module consumes their results as evidence
+ * and adds only what is CLAUDE'S — the content-domain derivation, the MIME
+ * profile Claude requires, what Claude does with an OpenAI-only widget — plus
+ * the design-guideline lints, which are advisories because a static read of
+ * HTML cannot establish how something renders.
+ *
+ * Re-running an equivalent check would let readiness and the apps suite
+ * disagree about the same server, and the first question anyone asks about a
+ * disagreement is which one to believe.
+ *
+ * Pure data. No transport, no browser.
+ */
+
+import { sha256Hex } from "../../contract/canonical.js";
+import { getToolVisibility } from "../../widget-runtime/tool-visibility.js";
+import { claudePolicySource } from "../manifest.js";
+import {
+  CLAUDE_APP_CONTENT_DOMAIN_HASH_LENGTH,
+  CLAUDE_APP_CONTENT_DOMAIN_SUFFIX,
+  CLAUDE_APP_HTML_MIME,
+} from "../profile.js";
+import type { ClaudeReadinessFinding } from "../types.js";
+import {
+  derivedFrom,
+  notApplicable,
+  notEvaluated,
+  satisfied,
+  violated,
+  type ClaudeCheckDefinition,
+  type ClaudeCheckStamp,
+} from "./helpers.js";
+
+// ── Evidence ────────────────────────────────────────────────────────────
+
+/** One widget-bearing tool, as the apps suite already resolved it. */
+export interface ClaudeAppToolEvidence {
+  name: string;
+  resourceUri: string;
+  /** The tool declared `_meta.ui.resourceUri` — the modern field. */
+  hasNestedField: boolean;
+  /** The tool declared the deprecated `_meta["ui/resourceUri"]`. */
+  hasLegacyField: boolean;
+  /** Raw `_meta` so the shared visibility helper reads it, not a copy. */
+  toolMeta?: Record<string, unknown>;
+  /** The tool also carries an OpenAI-only widget template. */
+  hasOpenAiWidget?: boolean;
+  /** The tool returns usable text when no widget renders. */
+  hasTextualFallback?: boolean;
+}
+
+/** One widget resource, as read. */
+export interface ClaudeAppResourceEvidence {
+  uri: string;
+  mimeType?: string;
+  /** `_meta.ui.domain`, when the resource set one. */
+  domain?: string;
+  /** `_meta.ui.csp`, when present. */
+  csp?: Record<string, unknown>;
+  /** The HTML text, for the static design lints. Absent ⇒ they cannot run. */
+  html?: string;
+  /** The widget declares it supports only one active instance. */
+  claimsSingleActiveInstance?: boolean;
+}
+
+export interface ClaudeAppsEvidence {
+  /** The connector URL exactly as entered — the content domain derives from it. */
+  enteredUrl: string;
+  /**
+   * Whether an apps-conformance result was consumed. `false` means the run had
+   * no apps evidence at all, which is different from a server with no apps.
+   */
+  appsSuiteRan: boolean;
+  tools?: ClaudeAppToolEvidence[];
+  resources?: ClaudeAppResourceEvidence[];
+  /** The widget's OAuth is owned by the app rather than the connector. */
+  appOwnedOAuth?: boolean;
+  /**
+   * How a rendering observation was obtained, when there was one. Node's
+   * `Origin` probe APPROXIMATES WebKit; it is not WebKit, and a finding built
+   * on it must say so rather than claim a browser observation it did not make.
+   */
+  renderEngine?: "webkit" | "chromium" | "node-approximation";
+}
+
+// ── Definitions ─────────────────────────────────────────────────────────
+
+const RESOURCE_URI_MODERNITY: ClaudeCheckDefinition = {
+  id: "claude.apps.resource-uri-modern",
+  title: "Widget tools declare `_meta.ui.resourceUri`",
+  lane: "runtime-compatibility",
+  class: "required",
+  source: claudePolicySource("mcp-apps/cross-compatibility", "§Tool metadata"),
+  provenance: "static",
+  intrusiveness: "passive",
+};
+
+const HTML_MIME_PROFILE: ClaudeCheckDefinition = {
+  id: "claude.apps.html-mime-profile",
+  title: `Widget resources are served as \`${CLAUDE_APP_HTML_MIME}\``,
+  lane: "runtime-compatibility",
+  class: "required",
+  source: claudePolicySource("mcp-apps/cross-compatibility", "§Resource mime type"),
+  provenance: "wire",
+};
+
+const OPENAI_ONLY_WIDGET: ClaudeCheckDefinition = {
+  id: "claude.apps.openai-only-widget",
+  title: "No tool renders only through an OpenAI-specific widget",
+  lane: "runtime-compatibility",
+  class: "runtime-blocker",
+  source: claudePolicySource("mcp-apps/cross-compatibility", "§Other hosts"),
+  provenance: "static",
+  intrusiveness: "passive",
+};
+
+const UI_DOMAIN_DERIVATION: ClaudeCheckDefinition = {
+  id: "claude.apps.ui-domain-derivation",
+  title: "`ui.domain`, when set, is the domain Claude will serve",
+  lane: "runtime-compatibility",
+  class: "required",
+  source: claudePolicySource("mcp-apps/external-links", "§Content domain"),
+  provenance: "static",
+  intrusiveness: "passive",
+};
+
+const UI_DOMAIN_ADVISED: ClaudeCheckDefinition = {
+  id: "claude.apps.ui-domain-recommended-for-app-oauth",
+  title: "An app-owned OAuth widget benefits from a stable content domain",
+  lane: "experience-insights",
+  class: "recommended",
+  source: claudePolicySource("mcp-apps/external-links", "§Content domain"),
+  provenance: "static",
+  intrusiveness: "passive",
+};
+
+const CSP_SHAPE: ClaudeCheckDefinition = {
+  id: "claude.apps.csp-shape",
+  title: "A declared CSP names only hosts the widget actually needs",
+  lane: "experience-insights",
+  class: "recommended",
+  source: claudePolicySource("mcp-apps/external-links", "§Content security policy"),
+  provenance: "static",
+  intrusiveness: "passive",
+};
+
+const RESULT_SIZE: ClaudeCheckDefinition = {
+  id: "claude.apps.result-size-budget",
+  title: "Tool results stay inside Claude's per-call size budget",
+  lane: "experience-insights",
+  // NOT a static check. The threshold is per CALL, so it depends on the
+  // arguments a caller passes — a tool that is fine on one query and enormous
+  // on another has no static verdict. It belongs to a functional run.
+  class: "manual-review",
+  source: claudePolicySource("mcp-apps/troubleshooting", "§Result size"),
+  provenance: "wire",
+};
+
+const INSTANCE_SUPERSESSION: ClaudeCheckDefinition = {
+  id: "claude.apps.instance-supersession",
+  title: "A single-instance widget yields correctly when superseded",
+  lane: "experience-insights",
+  class: "heuristic",
+  source: claudePolicySource("mcp-apps/design-guidelines", "§Instances"),
+  provenance: "browser",
+  requiresCapabilities: ["browser"],
+};
+
+/**
+ * The design guidelines, as static lints.
+ *
+ * Every one of these is a HEURISTIC and none can fail a lane, because a static
+ * read of HTML cannot establish how something renders. "No `@media` query" is
+ * evidence a widget may not be responsive; a widget laid out entirely in
+ * container queries or intrinsic sizing has none either and is perfectly
+ * responsive. The value is in pointing a reviewer at the likely places, not in
+ * pronouncing a verdict.
+ */
+const DESIGN_LINTS: Array<{
+  definition: ClaudeCheckDefinition;
+  detect: (html: string) => boolean;
+  remediation: string;
+}> = [
+  {
+    definition: designLint(
+      "responsive-320",
+      "Widget appears to have no narrow-viewport handling",
+      "§Responsiveness",
+    ),
+    detect: (html) =>
+      !/@media[^{]*\(\s*max-width/i.test(html) &&
+      !/@container/i.test(html) &&
+      !/\bminmax\(|\bclamp\(|\bflex-wrap\b/i.test(html),
+    remediation:
+      "Claude renders widgets as narrow as 320px. No media query, container query, or intrinsic sizing was found.",
+  },
+  {
+    definition: designLint(
+      "touch-targets",
+      "Interactive elements may be below the 44×44px touch target",
+      "§Touch targets",
+    ),
+    detect: (html) =>
+      /<(button|a)\b/i.test(html) &&
+      !/min-height\s*:\s*(4[4-9]|[5-9]\d|\d{3,})px/i.test(html) &&
+      !/min-block-size/i.test(html),
+    remediation:
+      "Interactive controls were found with no minimum height reaching 44px.",
+  },
+  {
+    definition: designLint(
+      "safe-area",
+      "Widget does not account for the device safe area",
+      "§Safe areas",
+    ),
+    detect: (html) => !/safe-area-inset/i.test(html),
+    remediation:
+      "No `env(safe-area-inset-*)` usage was found; content can sit under a notch or home indicator.",
+  },
+  {
+    definition: designLint(
+      "theming",
+      "Widget appears not to follow the host's light/dark theme",
+      "§Theming",
+    ),
+    detect: (html) =>
+      !/prefers-color-scheme/i.test(html) &&
+      !/color-scheme/i.test(html) &&
+      !/data-theme/i.test(html),
+    remediation:
+      "No `prefers-color-scheme`, `color-scheme`, or theme attribute was found; the widget will not follow Claude's theme.",
+  },
+  {
+    definition: designLint(
+      "transparent-background",
+      "Widget paints an opaque background over the host surface",
+      "§Backgrounds",
+    ),
+    detect: (html) =>
+      /body\s*{[^}]*background(-color)?\s*:\s*(#|rgb|hsl|white|black)/i.test(html),
+    remediation:
+      "The widget paints its own body background; Claude's surface shows through a transparent one.",
+  },
+  {
+    definition: designLint(
+      "nested-scrolling",
+      "Widget introduces its own scroll container",
+      "§Scrolling",
+    ),
+    detect: (html) => /overflow(-y)?\s*:\s*(auto|scroll)/i.test(html),
+    remediation:
+      "A nested scroll region was found. Claude scrolls the conversation, and a scroll-within-a-scroll is hard to use on touch.",
+  },
+  {
+    definition: designLint(
+      "accessibility",
+      "Widget shows few accessibility affordances",
+      "§Accessibility",
+    ),
+    detect: (html) =>
+      /<(button|a|input)\b/i.test(html) &&
+      !/aria-[a-z]+=/i.test(html) &&
+      !/\brole=/i.test(html),
+    remediation:
+      "Interactive elements carry no ARIA attributes or roles.",
+  },
+  {
+    definition: designLint(
+      "display-mode",
+      "Widget does not react to the host's display mode",
+      "§Display modes",
+    ),
+    detect: (html) => !/displayMode|display-mode/i.test(html),
+    remediation:
+      "No reference to the host display mode was found; the widget will render identically inline and fullscreen.",
+  },
+];
+
+function designLint(
+  slug: string,
+  title: string,
+  section: string,
+): ClaudeCheckDefinition {
+  return {
+    id: `claude.apps.design.${slug}`,
+    title,
+    lane: "experience-insights",
+    class: "heuristic",
+    source: claudePolicySource("mcp-apps/design-guidelines", section),
+    provenance: "static",
+    intrusiveness: "passive",
+  };
+}
+
+// ── Derivation ──────────────────────────────────────────────────────────
+
+/**
+ * The content domain Claude serves a widget from.
+ *
+ * `sha256(<exact connector URL>)`, first 32 hex characters, plus the suffix.
+ * "Exact" is load-bearing: a trailing slash, a different scheme, or a
+ * normalised port produces a different digest and therefore a domain Claude
+ * will not serve. So this hashes the URL AS ENTERED and never canonicalizes —
+ * canonicalizing here would make the check pass for a value that fails in
+ * production, which is worse than not checking at all.
+ */
+export function claudeAppContentDomain(enteredUrl: string): string {
+  const digest = sha256Hex(enteredUrl).slice(
+    0,
+    CLAUDE_APP_CONTENT_DOMAIN_HASH_LENGTH,
+  );
+  return `${digest}${CLAUDE_APP_CONTENT_DOMAIN_SUFFIX}`;
+}
+
+// ── The run ─────────────────────────────────────────────────────────────
+
+export function runClaudeAppsChecks(
+  evidence: ClaudeAppsEvidence,
+  stamp: ClaudeCheckStamp,
+): ClaudeReadinessFinding[] {
+  const findings: ClaudeReadinessFinding[] = [];
+  const tools = evidence.tools ?? [];
+  const resources = evidence.resources ?? [];
+
+  const staticDefinitions = [
+    RESOURCE_URI_MODERNITY,
+    HTML_MIME_PROFILE,
+    OPENAI_ONLY_WIDGET,
+    UI_DOMAIN_DERIVATION,
+    UI_DOMAIN_ADVISED,
+    CSP_SHAPE,
+  ];
+
+  if (!evidence.appsSuiteRan) {
+    // No apps evidence at all is NOT "this server has no apps". Saying
+    // `not-applicable` would claim we established something we never looked at.
+    const reason =
+      "no MCP Apps conformance result was available, so nothing app-specific was evaluated";
+    for (const definition of [
+      ...staticDefinitions,
+      RESULT_SIZE,
+      INSTANCE_SUPERSESSION,
+    ]) {
+      findings.push(notEvaluated(definition, stamp, reason));
+    }
+    return findings;
+  }
+
+  if (tools.length === 0) {
+    const reason = "this server advertises no MCP Apps widgets";
+    for (const definition of [
+      ...staticDefinitions,
+      RESULT_SIZE,
+      INSTANCE_SUPERSESSION,
+    ]) {
+      findings.push(notApplicable(definition, stamp, reason));
+    }
+    return findings;
+  }
+
+  // ── resourceUri modernity ────────────────────────────────────────────
+  // The modern field ALONE is correct and complete. Only a tool that declares
+  // the deprecated field and nothing else is a problem — an earlier reading
+  // that warned whenever the legacy field was absent had it exactly backwards.
+  const legacyOnly = tools.filter(
+    (tool) => tool.hasLegacyField && !tool.hasNestedField,
+  );
+  findings.push(
+    derivedFrom(
+      legacyOnly.length === 0
+        ? satisfied(RESOURCE_URI_MODERNITY, stamp, {
+            tools: tools.length,
+            modernOnly: tools.filter((t) => t.hasNestedField && !t.hasLegacyField)
+              .length,
+          })
+        : violated(
+            RESOURCE_URI_MODERNITY,
+            stamp,
+            "Declare `_meta.ui.resourceUri`. These tools use only the deprecated `ui/resourceUri` field, which Claude does not read.",
+            { tools: legacyOnly.map((tool) => tool.name) },
+          ),
+      "apps-conformance:ui-tool-metadata-valid",
+    ),
+  );
+
+  // ── MIME profile ─────────────────────────────────────────────────────
+  const wrongMime = resources.filter(
+    (resource) =>
+      resource.mimeType !== undefined &&
+      normalizeMime(resource.mimeType) !== CLAUDE_APP_HTML_MIME,
+  );
+  const unknownMime = resources.filter(
+    (resource) => resource.mimeType === undefined,
+  );
+  findings.push(
+    resources.length === 0
+      ? notEvaluated(
+          HTML_MIME_PROFILE,
+          stamp,
+          "no widget resources were read, so their mime types are unknown",
+        )
+      : wrongMime.length === 0 && unknownMime.length === 0
+        ? satisfied(HTML_MIME_PROFILE, stamp, { resources: resources.length })
+        : violated(
+            HTML_MIME_PROFILE,
+            stamp,
+            `Serve widget resources as \`${CLAUDE_APP_HTML_MIME}\`. Plain \`text/html\` does not tell the host the payload is an app.`,
+            {
+              wrong: wrongMime.map((r) => ({ uri: r.uri, mimeType: r.mimeType })),
+              missing: unknownMime.map((r) => r.uri),
+            },
+          ),
+  );
+
+  // ── OpenAI-only widgets ──────────────────────────────────────────────
+  // A blocker ONLY when the tool is app-only. A model-visible tool with a
+  // textual fallback still works in Claude — degraded, not broken — and
+  // failing it would tell a submitter their working connector is unusable.
+  const openAiTools = tools.filter(
+    (tool) => tool.hasOpenAiWidget && !tool.hasNestedField && !tool.hasLegacyField,
+  );
+  const blocking = openAiTools.filter((tool) => isAppOnly(tool));
+  const degraded = openAiTools.filter((tool) => !isAppOnly(tool));
+  findings.push(
+    openAiTools.length === 0
+      ? satisfied(OPENAI_ONLY_WIDGET, stamp)
+      : blocking.length > 0
+        ? violated(
+            OPENAI_ONLY_WIDGET,
+            stamp,
+            "These tools render only through an OpenAI-specific widget and are app-only, so in Claude they produce nothing at all. Add an MCP Apps resource or make the tool model-visible with a textual result.",
+            {
+              blocking: blocking.map((tool) => tool.name),
+              degraded: degraded.map((tool) => tool.name),
+            },
+          )
+        : satisfied(OPENAI_ONLY_WIDGET, stamp, {
+            // Named rather than silent: the connector works, and the reviewer
+            // should still know these tools lose their UI in Claude.
+            degraded: degraded.map((tool) => ({
+              name: tool.name,
+              hasTextualFallback: tool.hasTextualFallback ?? false,
+            })),
+          }),
+  );
+
+  // ── ui.domain ────────────────────────────────────────────────────────
+  const expectedDomain = claudeAppContentDomain(evidence.enteredUrl);
+  const withDomain = resources.filter((resource) => resource.domain !== undefined);
+  const mismatched = withDomain.filter(
+    (resource) => resource.domain !== expectedDomain,
+  );
+  findings.push(
+    withDomain.length === 0
+      ? notApplicable(
+          UI_DOMAIN_DERIVATION,
+          stamp,
+          "`ui.domain` is optional and no resource set one",
+        )
+      : mismatched.length === 0
+        ? satisfied(UI_DOMAIN_DERIVATION, stamp, { domain: expectedDomain })
+        : violated(
+            UI_DOMAIN_DERIVATION,
+            stamp,
+            `\`ui.domain\` must be exactly \`${expectedDomain}\` — sha256 of the connector URL as entered, first ${CLAUDE_APP_CONTENT_DOMAIN_HASH_LENGTH} hex characters, plus \`${CLAUDE_APP_CONTENT_DOMAIN_SUFFIX}\`. A trailing slash or a different scheme in the URL changes the digest.`,
+            {
+              expected: expectedDomain,
+              found: mismatched.map((r) => ({ uri: r.uri, domain: r.domain })),
+              hashedInput: evidence.enteredUrl,
+            },
+          ),
+  );
+
+  findings.push(
+    withDomain.length > 0
+      ? notApplicable(
+          UI_DOMAIN_ADVISED,
+          stamp,
+          "the widget already declares a content domain",
+        )
+      : evidence.appOwnedOAuth
+        ? violated(
+            UI_DOMAIN_ADVISED,
+            stamp,
+            "This widget owns its own OAuth but declares no `ui.domain`, so its origin changes with the connector URL and stored credentials will not survive.",
+            { suggested: expectedDomain },
+          )
+        : satisfied(UI_DOMAIN_ADVISED, stamp),
+  );
+
+  // ── CSP ──────────────────────────────────────────────────────────────
+  const wildcardCsp = resources.filter((resource) =>
+    Object.values(resource.csp ?? {}).some(
+      (value) =>
+        Array.isArray(value) &&
+        value.some((entry) => typeof entry === "string" && entry.includes("*")),
+    ),
+  );
+  findings.push(
+    resources.every((resource) => resource.csp === undefined)
+      ? notApplicable(CSP_SHAPE, stamp, "no widget declares a content security policy")
+      : wildcardCsp.length === 0
+        ? satisfied(CSP_SHAPE, stamp)
+        : violated(
+            CSP_SHAPE,
+            stamp,
+            "A wildcard in `_meta.ui.csp` grants the widget more reach than it needs; name the hosts it actually calls.",
+            { resources: wildcardCsp.map((r) => r.uri) },
+          ),
+  );
+
+  // ── Call-specific and browser-only observations ──────────────────────
+  findings.push(
+    notEvaluated(
+      RESULT_SIZE,
+      stamp,
+      "the result-size budget is per CALL, so it depends on the arguments a caller passes and has no static verdict; it is observed by a functional run",
+    ),
+  );
+
+  const singleInstance = resources.filter(
+    (resource) => resource.claimsSingleActiveInstance,
+  );
+  findings.push(
+    singleInstance.length === 0
+      ? notApplicable(
+          INSTANCE_SUPERSESSION,
+          stamp,
+          "no widget claims a single active instance, so there is no supersession contract to test",
+        )
+      : notEvaluated(
+          INSTANCE_SUPERSESSION,
+          stamp,
+          "verifying supersession requires rendering two instances in a browser harness",
+          { resources: singleInstance.map((r) => r.uri) },
+        ),
+  );
+
+  // ── Design guideline lints ───────────────────────────────────────────
+  findings.push(...runDesignLints(evidence, resources, stamp));
+
+  return findings;
+}
+
+function runDesignLints(
+  evidence: ClaudeAppsEvidence,
+  resources: ClaudeAppResourceEvidence[],
+  stamp: ClaudeCheckStamp,
+): ClaudeReadinessFinding[] {
+  const withHtml = resources.filter(
+    (resource): resource is ClaudeAppResourceEvidence & { html: string } =>
+      typeof resource.html === "string" && resource.html.length > 0,
+  );
+
+  if (withHtml.length === 0) {
+    return DESIGN_LINTS.map((lint) =>
+      notEvaluated(
+        lint.definition,
+        stamp,
+        "no widget HTML was captured, so the static design lints could not run",
+      ),
+    );
+  }
+
+  return DESIGN_LINTS.map((lint) => {
+    const flagged = withHtml.filter((resource) => lint.detect(resource.html));
+    // PROVENANCE IS HONEST HERE. These are `static` reads of markup even when
+    // the run also had a browser: a rendering engine was not what produced
+    // this signal, and labelling it `browser` would overstate the evidence.
+    // Where a WebKit harness IS available its observations arrive as separate
+    // findings, because Node's `Origin` probe only approximates WebKit.
+    return flagged.length === 0
+      ? satisfied(lint.definition, stamp, {
+          resources: withHtml.length,
+          renderEngine: evidence.renderEngine ?? "none",
+        })
+      : violated(lint.definition, stamp, lint.remediation, {
+          resources: flagged.map((resource) => resource.uri),
+          renderEngine: evidence.renderEngine ?? "none",
+          // Said out loud on every lint: this is a reading of markup, not an
+          // observation of a rendered widget.
+          basis: "static markup analysis, not a rendered observation",
+        });
+  });
+}
+
+function normalizeMime(mimeType: string): string {
+  return mimeType
+    .split(";")
+    .map((part) => part.trim())
+    .filter(Boolean)
+    .join(";")
+    .toLowerCase();
+}
+
+function isAppOnly(tool: ClaudeAppToolEvidence): boolean {
+  const visibility = getToolVisibility(tool.toolMeta);
+  return visibility.length === 1 && visibility[0] === "app";
+}
+
+// ── Composition from what the run already has ───────────────────────────
+
+/**
+ * Build tool evidence from a listed tool's `_meta`.
+ *
+ * The apps suite's own result reports tool NAMES and resource URIs, not the
+ * per-tool metadata these checks need (modern vs legacy field, visibility, an
+ * OpenAI template). So the raw tool is the input and the suite result is
+ * consumed for its VERDICT — cited via `derivedFrom` — rather than mined for
+ * data it does not carry.
+ *
+ * Returns `undefined` for a tool with no widget at all, which is most tools.
+ */
+export function claudeAppToolEvidenceFrom(tool: {
+  name: string;
+  _meta?: unknown;
+}): ClaudeAppToolEvidence | undefined {
+  const meta =
+    typeof tool._meta === "object" && tool._meta !== null && !Array.isArray(tool._meta)
+      ? (tool._meta as Record<string, unknown>)
+      : undefined;
+  const ui =
+    typeof meta?.ui === "object" && meta.ui !== null && !Array.isArray(meta.ui)
+      ? (meta.ui as Record<string, unknown>)
+      : undefined;
+
+  const nested = typeof ui?.resourceUri === "string" ? ui.resourceUri : undefined;
+  const legacy =
+    typeof meta?.["ui/resourceUri"] === "string"
+      ? (meta["ui/resourceUri"] as string)
+      : undefined;
+  // The OpenAI Apps SDK's template key. A tool carrying only this renders in
+  // ChatGPT and, depending on its visibility, may render nothing in Claude.
+  const openAiTemplate =
+    typeof meta?.["openai/outputTemplate"] === "string"
+      ? (meta["openai/outputTemplate"] as string)
+      : undefined;
+
+  if (!nested && !legacy && !openAiTemplate) return undefined;
+
+  return {
+    name: tool.name,
+    resourceUri: nested ?? legacy ?? openAiTemplate ?? "",
+    hasNestedField: nested !== undefined,
+    hasLegacyField: legacy !== undefined,
+    toolMeta: meta,
+    hasOpenAiWidget: openAiTemplate !== undefined,
+  };
+}
+
+/**
+ * Build resource evidence from one `resources/read` content entry.
+ *
+ * `html` is only populated for a text content whose mime type says HTML —
+ * running the design lints over a blob of JSON would produce confident
+ * nonsense.
+ */
+export function claudeAppResourceEvidenceFrom(content: {
+  uri?: string;
+  mimeType?: string;
+  text?: string;
+  _meta?: unknown;
+}): ClaudeAppResourceEvidence {
+  const meta =
+    typeof content._meta === "object" &&
+    content._meta !== null &&
+    !Array.isArray(content._meta)
+      ? (content._meta as Record<string, unknown>)
+      : undefined;
+  const ui =
+    typeof meta?.ui === "object" && meta.ui !== null && !Array.isArray(meta.ui)
+      ? (meta.ui as Record<string, unknown>)
+      : undefined;
+
+  const isHtml = (content.mimeType ?? "").toLowerCase().includes("text/html");
+
+  return {
+    uri: content.uri ?? "",
+    mimeType: content.mimeType,
+    domain: typeof ui?.domain === "string" ? ui.domain : undefined,
+    csp:
+      typeof ui?.csp === "object" && ui.csp !== null && !Array.isArray(ui.csp)
+        ? (ui.csp as Record<string, unknown>)
+        : undefined,
+    html: isHtml && typeof content.text === "string" ? content.text : undefined,
+    claimsSingleActiveInstance:
+      ui?.singleActiveInstance === true || ui?.instances === "single",
+  };
+}

--- a/sdk/src/claude-readiness/checks/apps.ts
+++ b/sdk/src/claude-readiness/checks/apps.ts
@@ -28,6 +28,7 @@ import { claudePolicySource } from "../manifest.js";
 import {
   CLAUDE_APP_CONTENT_DOMAIN_HASH_LENGTH,
   CLAUDE_APP_CONTENT_DOMAIN_SUFFIX,
+  CLAUDE_APP_DESIGN_BUDGETS,
   CLAUDE_APP_HTML_MIME,
 } from "../profile.js";
 import type { ClaudeReadinessFinding } from "../types.js";
@@ -186,6 +187,28 @@ const INSTANCE_SUPERSESSION: ClaudeCheckDefinition = {
  * responsive. The value is in pointing a reviewer at the likely places, not in
  * pronouncing a verdict.
  */
+/**
+ * Whether the stylesheet declares a block-axis minimum that reaches Claude's
+ * touch-target budget.
+ *
+ * Both spellings count — `min-height` and its logical equivalent
+ * `min-block-size` — and both are read as NUMBERS, so the lint tracks
+ * {@link CLAUDE_APP_DESIGN_BUDGETS} instead of restating it. Only `px` is
+ * considered: a relative unit cannot be resolved without a layout, and
+ * guessing at one would be a rendered observation this static pass never made.
+ */
+function declaresMinimumTouchTarget(styleText: string): boolean {
+  const declarations = styleText.matchAll(
+    /min-(?:height|block-size)\s*:\s*([\d.]+)px/gi,
+  );
+  for (const [, value] of declarations) {
+    if (Number.parseFloat(value) >= CLAUDE_APP_DESIGN_BUDGETS.minTouchTargetPx) {
+      return true;
+    }
+  }
+  return false;
+}
+
 const DESIGN_LINTS: Array<{
   definition: ClaudeCheckDefinition;
   /** True when the widget looks like it MISSES the guideline. */
@@ -202,21 +225,23 @@ const DESIGN_LINTS: Array<{
       !/@media[^{]*\(\s*max-width/i.test(scanned.styleText) &&
       !/@container/i.test(scanned.styleText) &&
       !/\bminmax\(|\bclamp\(|\bflex-wrap\b/i.test(scanned.styleText),
-    remediation:
-      "Claude renders widgets as narrow as 320px. No media query, container query, or intrinsic sizing was found.",
+    remediation: `Claude renders widgets as narrow as ${CLAUDE_APP_DESIGN_BUDGETS.minViewportWidthPx}px. No media query, container query, or intrinsic sizing was found.`,
   },
   {
     definition: designLint(
       "touch-targets",
-      "Interactive elements may be below the 44×44px touch target",
+      `Interactive elements may be below the ${CLAUDE_APP_DESIGN_BUDGETS.minTouchTargetPx}×${CLAUDE_APP_DESIGN_BUDGETS.minTouchTargetPx}px touch target`,
       "§Touch targets",
     ),
+    // Read the declared minimums and COMPARE them, rather than pattern-matching
+    // the digits of one particular number: a regex spelling out `4[4-9]|[5-9]\d`
+    // silently stops agreeing with the budget the moment the budget changes,
+    // and it could only ever check `min-height` while treating any
+    // `min-block-size` at all — including `min-block-size: 8px` — as passing.
     detect: (scanned) =>
       hasInteractiveElement(scanned) &&
-      !/min-height\s*:\s*(4[4-9]|[5-9]\d|\d{3,})px/i.test(scanned.styleText) &&
-      !/min-block-size/i.test(scanned.styleText),
-    remediation:
-      "Interactive controls were found with no minimum height reaching 44px.",
+      !declaresMinimumTouchTarget(scanned.styleText),
+    remediation: `Interactive controls were found with no minimum height reaching ${CLAUDE_APP_DESIGN_BUDGETS.minTouchTargetPx}px.`,
   },
   {
     definition: designLint(
@@ -345,16 +370,28 @@ export function runClaudeAppsChecks(
     CSP_SHAPE,
   ];
 
+  /**
+   * EVERY definition this module can emit, which is what an early return owes
+   * the report.
+   *
+   * The design lints were missing here, so a run with no apps evidence — or a
+   * server with no widgets — silently produced eight fewer findings than the
+   * catalog advertises. Absent is not the same as `not-evaluated`: one is a
+   * check the report can explain, the other is a hole a reader has to notice.
+   */
+  const everyDefinition = [
+    ...staticDefinitions,
+    RESULT_SIZE,
+    INSTANCE_SUPERSESSION,
+    ...DESIGN_LINTS.map((lint) => lint.definition),
+  ];
+
   if (!evidence.appsSuiteRan) {
     // No apps evidence at all is NOT "this server has no apps". Saying
     // `not-applicable` would claim we established something we never looked at.
     const reason =
       "no MCP Apps conformance result was available, so nothing app-specific was evaluated";
-    for (const definition of [
-      ...staticDefinitions,
-      RESULT_SIZE,
-      INSTANCE_SUPERSESSION,
-    ]) {
+    for (const definition of everyDefinition) {
       findings.push(notEvaluated(definition, stamp, reason));
     }
     return findings;
@@ -362,11 +399,7 @@ export function runClaudeAppsChecks(
 
   if (tools.length === 0) {
     const reason = "this server advertises no MCP Apps widgets";
-    for (const definition of [
-      ...staticDefinitions,
-      RESULT_SIZE,
-      INSTANCE_SUPERSESSION,
-    ]) {
+    for (const definition of everyDefinition) {
       findings.push(notApplicable(definition, stamp, reason));
     }
     return findings;

--- a/sdk/src/claude-readiness/checks/apps.ts
+++ b/sdk/src/claude-readiness/checks/apps.ts
@@ -390,8 +390,7 @@ export function runClaudeAppsChecks(
   // ── MIME profile ─────────────────────────────────────────────────────
   const wrongMime = resources.filter(
     (resource) =>
-      resource.mimeType !== undefined &&
-      normalizeMime(resource.mimeType) !== CLAUDE_APP_HTML_MIME,
+      resource.mimeType !== undefined && !isClaudeAppMime(resource.mimeType),
   );
   const unknownMime = resources.filter(
     (resource) => resource.mimeType === undefined,
@@ -494,11 +493,14 @@ export function runClaudeAppsChecks(
 
   // ── CSP ──────────────────────────────────────────────────────────────
   const wildcardCsp = resources.filter((resource) =>
-    Object.values(resource.csp ?? {}).some(
-      (value) =>
-        Array.isArray(value) &&
-        value.some((entry) => typeof entry === "string" && entry.includes("*")),
-    ),
+    Object.values(resource.csp ?? {}).some((value) => {
+      // A directive may be written as a single string rather than a list; a
+      // wildcard hidden in that form is the same wildcard.
+      const entries = Array.isArray(value) ? value : [value];
+      return entries.some(
+        (entry) => typeof entry === "string" && entry.includes("*"),
+      );
+    }),
   );
   findings.push(
     resources.every((resource) => resource.csp === undefined)
@@ -588,14 +590,47 @@ function runDesignLints(
   });
 }
 
-function normalizeMime(mimeType: string): string {
-  return mimeType
-    .split(";")
-    .map((part) => part.trim())
-    .filter(Boolean)
-    .join(";")
-    .toLowerCase();
+/**
+ * Whether a served mime type is the MCP App profile Claude requires.
+ *
+ * The comparison cannot be a string equality against
+ * `"text/html;profile=mcp-app"`. A `charset` parameter is legal on any `text/*`
+ * type and says nothing about the media type, so `text/html;profile=mcp-app;
+ * charset=utf-8` is a CONFORMING resource that a literal comparison would fail
+ * — and this is a `required` runtime check, so that false violation would tell
+ * a submitter to break a widget that works.
+ *
+ * It also cannot compare the essence alone: `profile=mcp-app` is the entire
+ * signal that the payload is an app rather than a document, and dropping it
+ * would make the check pass for plain `text/html`.
+ *
+ * So: essence must be `text/html`, the `profile` parameter must be `mcp-app`,
+ * and every other parameter is ignored.
+ */
+function isClaudeAppMime(mimeType: string): boolean {
+  const [rawEssence, ...rawParameters] = mimeType.split(";");
+  if (rawEssence.trim().toLowerCase() !== CLAUDE_APP_HTML_ESSENCE) return false;
+  for (const parameter of rawParameters) {
+    const separator = parameter.indexOf("=");
+    if (separator === -1) continue;
+    const name = parameter.slice(0, separator).trim().toLowerCase();
+    if (name !== "profile") continue;
+    // Quoted parameter values are legal: `profile="mcp-app"`.
+    const value = parameter
+      .slice(separator + 1)
+      .trim()
+      .replace(/^"(.*)"$/, "$1")
+      .toLowerCase();
+    return value === CLAUDE_APP_PROFILE_VALUE;
+  }
+  return false;
 }
+
+/** The two halves of {@link CLAUDE_APP_HTML_MIME}, split once. */
+const CLAUDE_APP_HTML_ESSENCE = CLAUDE_APP_HTML_MIME.split(";")[0]
+  .trim()
+  .toLowerCase();
+const CLAUDE_APP_PROFILE_VALUE = "mcp-app";
 
 function isAppOnly(tool: ClaudeAppToolEvidence): boolean {
   const visibility = getToolVisibility(tool.toolMeta);

--- a/sdk/src/claude-readiness/checks/auth.ts
+++ b/sdk/src/claude-readiness/checks/auth.ts
@@ -1,0 +1,672 @@
+/**
+ * Non-invasive authentication checks.
+ *
+ * Everything here reasons over metadata the runner already fetched: an
+ * unauthenticated probe, a Protected Resource Metadata document, one
+ * authorization-server metadata document. Zero side effects — nothing here
+ * registers a client, spends a grant, or consumes a rate limit. The probes
+ * that do live behind the intrusive opt-in and are not in this module.
+ *
+ * THE CLASSIFY-DON'T-FAIL RULE. Static-header credentials, authless servers,
+ * custom connection flows and preregistered clients are all valid ways to ship
+ * a connector, and a wire-only runner frequently cannot tell them apart from
+ * each other or from a broken OAuth setup. Failing on that ambiguity would
+ * reject working connectors for being unusual. So the auth MODE is reported as
+ * a badge, and only the things that are unambiguously broken — an
+ * unreachable first authorization server, a challenge that names no metadata —
+ * become findings.
+ *
+ * Pure: takes evidence, returns findings and badges. It dials nothing.
+ */
+
+import { parseBearerAuthenticateParameters } from "../../oauth/state-machines/shared/challenges.js";
+import { claudePolicySource } from "../manifest.js";
+import type {
+  ClaudeCapabilityBadge,
+  ClaudeReadinessFinding,
+} from "../types.js";
+import {
+  informational,
+  notApplicable,
+  notEvaluated,
+  satisfied,
+  violated,
+  type ClaudeCheckDefinition,
+  type ClaudeCheckStamp,
+} from "./helpers.js";
+
+// ── Evidence ────────────────────────────────────────────────────────────
+
+/** The order RFC 9728 discovery is attempted in, and which step answered. */
+export type ClaudePrmDiscoveryStep =
+  | "www-authenticate"
+  | "well-known-path-suffixed"
+  | "well-known-root"
+  | "not-found";
+
+export interface ClaudeAuthEvidence {
+  /** The connector URL exactly as entered — not canonicalized. */
+  enteredUrl: string;
+  /** An unauthenticated request to the MCP endpoint. */
+  unauthenticated?: {
+    status: number;
+    wwwAuthenticate?: string;
+    /**
+     * Whether this response was an attempted PROTECTED operation. A
+     * `WWW-Authenticate` header on a 200 means nothing on, say, a health
+     * endpoint or a discovery response; it is only wrong when the response
+     * represents an auth denial that nonetheless succeeded.
+     */
+    representsProtectedOperation: boolean;
+    /** The server served the request without credentials. */
+    servedWithoutCredentials: boolean;
+  };
+  prm?: {
+    discoveredVia: ClaudePrmDiscoveryStep;
+    url?: string;
+    document?: Record<string, unknown>;
+    fetchError?: string;
+  };
+  /**
+   * Metadata for `authorization_servers[0]` ONLY. Claude does not fall back to
+   * later entries, so the health of the first one is the whole question and a
+   * runner that probed all of them would be grading a different client.
+   */
+  firstAuthorizationServer?: {
+    issuer: string;
+    metadataUrl?: string;
+    reachable: boolean;
+    document?: Record<string, unknown>;
+    fetchError?: string;
+  };
+  /** A `403` step-up challenge, if the run happened to see one. */
+  insufficientScopeChallenge?: { header: string };
+  /**
+   * The `aud` claim of an access token the caller supplied, when it was a JWT.
+   * EVIDENCE ONLY — see the check.
+   */
+  accessTokenAudience?: string[];
+  /** What the submitter declared, when a submission profile was supplied. */
+  declaredAuthMode?: string;
+}
+
+// ── Check definitions ───────────────────────────────────────────────────
+
+const CHALLENGE_PRESENT: ClaudeCheckDefinition = {
+  id: "claude.auth.unauthenticated-challenge",
+  title: "An unauthenticated request is answered with a usable 401 challenge",
+  lane: "runtime-compatibility",
+  class: "runtime-blocker",
+  source: claudePolicySource("authentication", "§Discovery → 401 challenge"),
+  provenance: "wire",
+};
+
+const CHALLENGE_NAMES_METADATA: ClaudeCheckDefinition = {
+  id: "claude.auth.challenge-names-resource-metadata",
+  title: "The 401 challenge points at the Protected Resource Metadata",
+  lane: "runtime-compatibility",
+  class: "runtime-blocker",
+  source: claudePolicySource("authentication", "§Discovery → resource_metadata"),
+  provenance: "wire",
+};
+
+const WWW_AUTH_ON_SUCCESS: ClaudeCheckDefinition = {
+  id: "claude.auth.no-challenge-on-successful-operation",
+  title: "A successful protected operation does not also send a challenge",
+  lane: "runtime-compatibility",
+  class: "recommended",
+  source: claudePolicySource("troubleshooting", "§Auth → Mixed signals"),
+  provenance: "wire",
+};
+
+const PRM_DISCOVERABLE: ClaudeCheckDefinition = {
+  id: "claude.auth.prm-discoverable",
+  title: "Protected Resource Metadata is discoverable in the documented order",
+  lane: "runtime-compatibility",
+  class: "runtime-blocker",
+  source: claudePolicySource("authentication", "§Discovery order"),
+  provenance: "wire",
+};
+
+const PRM_RESOURCE_MATCHES_ENTERED: ClaudeCheckDefinition = {
+  id: "claude.auth.prm-resource-matches-entered-url",
+  title: "PRM `resource` is exactly the URL the user entered",
+  lane: "runtime-compatibility",
+  class: "runtime-blocker",
+  source: claudePolicySource("authentication", "§Protected Resource Metadata"),
+  provenance: "wire",
+};
+
+const RFC8707_RESOURCE_CANONICAL: ClaudeCheckDefinition = {
+  id: "claude.auth.rfc8707-resource-canonical",
+  title: "The RFC 8707 `resource` sent to /authorize and /token is canonical",
+  lane: "runtime-compatibility",
+  class: "required",
+  source: claudePolicySource("authentication", "§Resource indicators"),
+  provenance: "wire",
+  requiresCapabilities: ["interactive-oauth"],
+};
+
+const FIRST_AS_USABLE: ClaudeCheckDefinition = {
+  id: "claude.auth.first-authorization-server-usable",
+  title: "The first `authorization_servers` entry serves valid metadata",
+  lane: "runtime-compatibility",
+  // A BLOCKER, not a warning. Claude takes entry zero and never falls back, so
+  // a broken first entry is a connector that cannot be used — regardless of how
+  // healthy entries one and two are.
+  class: "runtime-blocker",
+  source: claudePolicySource("authentication", "§Authorization servers"),
+  provenance: "wire",
+};
+
+const PKCE_S256: ClaudeCheckDefinition = {
+  id: "claude.auth.pkce-s256-advertised",
+  title: "The authorization server advertises S256 PKCE",
+  lane: "runtime-compatibility",
+  class: "required",
+  source: claudePolicySource("authentication", "§Authorization code flow"),
+  provenance: "wire",
+};
+
+const CIMD_FLAG_CONSISTENT: ClaudeCheckDefinition = {
+  id: "claude.auth.cimd-flag-consistent",
+  title: "A CIMD advertisement is consistent with the rest of the metadata",
+  lane: "runtime-compatibility",
+  class: "required",
+  source: claudePolicySource("authentication", "§Client identity"),
+  provenance: "wire",
+};
+
+const CLIENT_ACQUISITION_PATH: ClaudeCheckDefinition = {
+  id: "claude.auth.client-acquisition-path",
+  title: "Claude has a way to obtain a client identity",
+  lane: "runtime-compatibility",
+  class: "required",
+  source: claudePolicySource("authentication", "§Client registration"),
+  provenance: "wire",
+};
+
+const SCOPE_CHALLENGE_SHAPE: ClaudeCheckDefinition = {
+  id: "claude.auth.insufficient-scope-challenge-shape",
+  title: "An insufficient_scope challenge is well-formed",
+  lane: "runtime-compatibility",
+  class: "required",
+  source: claudePolicySource("authentication", "§Step-up authorization"),
+  provenance: "wire",
+};
+
+const TOKEN_AUDIENCE: ClaudeCheckDefinition = {
+  id: "claude.auth.access-token-audience",
+  title: "Access-token audience, recorded",
+  lane: "experience-insights",
+  // EVIDENCE ONLY, and the class says so. See the check for why an `aud` that
+  // does not name the resource proves nothing.
+  class: "manual-review",
+  source: claudePolicySource("authentication", "§Token audience"),
+  provenance: "wire",
+};
+
+// ── Helpers ─────────────────────────────────────────────────────────────
+
+function stringArray(value: unknown): string[] {
+  return Array.isArray(value)
+    ? value.filter((entry): entry is string => typeof entry === "string")
+    : [];
+}
+
+/**
+ * The canonical form of a resource indicator (RFC 8707 §2): scheme and host
+ * lowercased, default port removed, no fragment, and no query. The path is
+ * KEPT — an MCP server at `/mcp` is a different resource from the origin.
+ */
+export function canonicalResourceIndicator(url: string): string | undefined {
+  let parsed: URL;
+  try {
+    parsed = new URL(url);
+  } catch {
+    return undefined;
+  }
+  parsed.hash = "";
+  parsed.search = "";
+  const isDefaultPort =
+    (parsed.protocol === "https:" && parsed.port === "443") ||
+    (parsed.protocol === "http:" && parsed.port === "80");
+  if (isDefaultPort) parsed.port = "";
+  // `new URL("https://x.example")` renders a trailing slash that the entered
+  // string may not have had; an empty path is the one place the two forms are
+  // genuinely the same resource.
+  const rendered = parsed.toString();
+  return parsed.pathname === "/" && !url.endsWith("/")
+    ? rendered.replace(/\/$/, "")
+    : rendered;
+}
+
+// ── The run ─────────────────────────────────────────────────────────────
+
+export interface ClaudeAuthCheckOutput {
+  findings: ClaudeReadinessFinding[];
+  badges: ClaudeCapabilityBadge[];
+}
+
+export function runClaudeAuthChecks(
+  evidence: ClaudeAuthEvidence,
+  stamp: ClaudeCheckStamp,
+): ClaudeAuthCheckOutput {
+  const findings: ClaudeReadinessFinding[] = [];
+  const badges: ClaudeCapabilityBadge[] = [];
+
+  const probe = evidence.unauthenticated;
+  const challengeParams = parseBearerAuthenticateParameters(
+    probe?.wwwAuthenticate,
+  );
+  const requiresAuth = probe?.status === 401;
+  const servedWithoutAuth = probe?.servedWithoutCredentials === true;
+
+  // ── Auth mode: a badge, never a verdict ──────────────────────────────
+  const mode = classifyAuthMode(evidence, requiresAuth, servedWithoutAuth);
+  badges.push({
+    id: "claude.auth.mode",
+    title: "Authentication mode",
+    state: mode.confident ? "supported" : "claimed",
+    detail: mode.detail,
+    provenance: mode.confident ? "wire" : "declared",
+  });
+
+  // ── The 401 contract ─────────────────────────────────────────────────
+  if (!probe) {
+    const reason = "the run never made an unauthenticated request";
+    findings.push(notEvaluated(CHALLENGE_PRESENT, stamp, reason));
+    findings.push(notEvaluated(CHALLENGE_NAMES_METADATA, stamp, reason));
+    findings.push(notEvaluated(WWW_AUTH_ON_SUCCESS, stamp, reason));
+  } else if (servedWithoutAuth) {
+    // An authless server is a valid submission mode. Nothing about the 401
+    // contract can apply to a server that never issues one.
+    const reason =
+      "the server served the request without credentials, so it does not use the 401 challenge flow";
+    findings.push(notApplicable(CHALLENGE_PRESENT, stamp, reason));
+    findings.push(notApplicable(CHALLENGE_NAMES_METADATA, stamp, reason));
+    findings.push(
+      probe.wwwAuthenticate && probe.representsProtectedOperation
+        ? violated(
+            WWW_AUTH_ON_SUCCESS,
+            stamp,
+            "This response both succeeded and carried a `WWW-Authenticate` challenge. Claude reads the challenge and starts an authorization it did not need.",
+            { status: probe.status, wwwAuthenticate: probe.wwwAuthenticate },
+          )
+        : satisfied(WWW_AUTH_ON_SUCCESS, stamp, { status: probe.status }),
+    );
+  } else {
+    findings.push(
+      requiresAuth
+        ? satisfied(CHALLENGE_PRESENT, stamp, { status: probe.status })
+        : violated(
+            CHALLENGE_PRESENT,
+            stamp,
+            `An unauthenticated request answered ${probe.status}. Claude needs a 401 with a \`WWW-Authenticate: Bearer\` challenge to begin authorization.`,
+            { status: probe.status },
+          ),
+    );
+    findings.push(
+      challengeParams.resource_metadata
+        ? satisfied(CHALLENGE_NAMES_METADATA, stamp, {
+            resourceMetadata: challengeParams.resource_metadata,
+          })
+        : violated(
+            CHALLENGE_NAMES_METADATA,
+            stamp,
+            "Add `resource_metadata=\"…\"` to the `WWW-Authenticate` challenge so Claude can find the Protected Resource Metadata without guessing a well-known path.",
+            { wwwAuthenticate: probe.wwwAuthenticate },
+          ),
+    );
+    // A challenge on a 401 IS the point; this check is only about a challenge
+    // riding on a response that succeeded.
+    findings.push(
+      notApplicable(
+        WWW_AUTH_ON_SUCCESS,
+        stamp,
+        "the probed response was an auth denial, which is where a challenge belongs",
+      ),
+    );
+  }
+
+  // ── PRM ──────────────────────────────────────────────────────────────
+  const prm = evidence.prm;
+  if (!prm) {
+    const reason = "the run did not attempt Protected Resource Metadata discovery";
+    findings.push(notEvaluated(PRM_DISCOVERABLE, stamp, reason));
+    findings.push(notEvaluated(PRM_RESOURCE_MATCHES_ENTERED, stamp, reason));
+  } else if (servedWithoutAuth && prm.discoveredVia === "not-found") {
+    const reason =
+      "the server is authless, so it publishes no Protected Resource Metadata";
+    findings.push(notApplicable(PRM_DISCOVERABLE, stamp, reason));
+    findings.push(notApplicable(PRM_RESOURCE_MATCHES_ENTERED, stamp, reason));
+  } else {
+    findings.push(
+      prm.discoveredVia === "not-found"
+        ? violated(
+            PRM_DISCOVERABLE,
+            stamp,
+            "Publish Protected Resource Metadata — via the challenge's `resource_metadata` pointer, or at `/.well-known/oauth-protected-resource` with the resource path appended.",
+            { fetchError: prm.fetchError },
+          )
+        : satisfied(PRM_DISCOVERABLE, stamp, {
+            discoveredVia: prm.discoveredVia,
+            url: prm.url,
+          }),
+    );
+
+    // TWO DIFFERENT REQUIREMENTS, deliberately not one check. This one is
+    // about the document: PRM `resource` must equal the URL the user typed,
+    // because that is the string Claude matched the connector on. The
+    // canonical-form requirement below is about what the CLIENT sends, and a
+    // server can satisfy either one while failing the other.
+    const declared = prm.document?.resource;
+    findings.push(
+      typeof declared !== "string"
+        ? prm.discoveredVia === "not-found"
+          ? notEvaluated(
+              PRM_RESOURCE_MATCHES_ENTERED,
+              stamp,
+              "no Protected Resource Metadata document was retrieved",
+            )
+          : violated(
+              PRM_RESOURCE_MATCHES_ENTERED,
+              stamp,
+              "The Protected Resource Metadata document has no `resource` field.",
+              { document: prm.document },
+            )
+        : declared === evidence.enteredUrl
+          ? satisfied(PRM_RESOURCE_MATCHES_ENTERED, stamp, { resource: declared })
+          : violated(
+              PRM_RESOURCE_MATCHES_ENTERED,
+              stamp,
+              `PRM declares \`resource: "${declared}"\` but the connector URL is "${evidence.enteredUrl}". Claude compares these exactly — a trailing slash or a different host is a mismatch.`,
+              { declared, entered: evidence.enteredUrl },
+            ),
+    );
+  }
+
+  const canonical = canonicalResourceIndicator(evidence.enteredUrl);
+  findings.push(
+    notEvaluated(
+      RFC8707_RESOURCE_CANONICAL,
+      stamp,
+      "checking the `resource` parameter on /authorize and /token requires completing an authorization, which this run did not do",
+      { expectedCanonicalForm: canonical },
+    ),
+  );
+
+  // ── Authorization server ─────────────────────────────────────────────
+  const authServers = stringArray(prm?.document?.authorization_servers);
+  const first = evidence.firstAuthorizationServer;
+  if (!prm || prm.discoveredVia === "not-found") {
+    const reason = "no Protected Resource Metadata document named an authorization server";
+    for (const definition of [
+      FIRST_AS_USABLE,
+      PKCE_S256,
+      CIMD_FLAG_CONSISTENT,
+      CLIENT_ACQUISITION_PATH,
+    ]) {
+      findings.push(
+        servedWithoutAuth
+          ? notApplicable(definition, stamp, "the server is authless")
+          : notEvaluated(definition, stamp, reason),
+      );
+    }
+  } else if (authServers.length === 0) {
+    findings.push(
+      violated(
+        FIRST_AS_USABLE,
+        stamp,
+        "Protected Resource Metadata lists no `authorization_servers`, so Claude has nowhere to send the user.",
+        { document: prm.document },
+      ),
+    );
+    for (const definition of [PKCE_S256, CIMD_FLAG_CONSISTENT, CLIENT_ACQUISITION_PATH]) {
+      findings.push(
+        notEvaluated(
+          definition,
+          stamp,
+          "no authorization server was named, so its metadata could not be read",
+        ),
+      );
+    }
+  } else if (!first || !first.reachable || !first.document) {
+    findings.push(
+      violated(
+        FIRST_AS_USABLE,
+        stamp,
+        `Claude uses \`authorization_servers[0]\` and does not fall back to later entries. Fix "${authServers[0]}" or list a working server first.`,
+        {
+          issuer: authServers[0],
+          metadataUrl: first?.metadataUrl,
+          fetchError: first?.fetchError,
+          // Naming the alternatives makes the "no fallback" rule concrete for
+          // a submitter whose second entry is perfectly healthy.
+          otherEntries: authServers.slice(1),
+        },
+      ),
+    );
+    for (const definition of [PKCE_S256, CIMD_FLAG_CONSISTENT, CLIENT_ACQUISITION_PATH]) {
+      findings.push(
+        notEvaluated(
+          definition,
+          stamp,
+          "the first authorization server's metadata could not be read",
+        ),
+      );
+    }
+  } else {
+    const document = first.document;
+    findings.push(
+      satisfied(FIRST_AS_USABLE, stamp, {
+        issuer: first.issuer,
+        metadataUrl: first.metadataUrl,
+      }),
+    );
+
+    const pkceMethods = stringArray(document.code_challenge_methods_supported);
+    findings.push(
+      pkceMethods.includes("S256")
+        ? satisfied(PKCE_S256, stamp, { methods: pkceMethods })
+        : violated(
+            PKCE_S256,
+            stamp,
+            "Advertise `S256` in `code_challenge_methods_supported`. Claude always sends a PKCE challenge, and a server that does not advertise S256 support cannot be assumed to verify it.",
+            { methods: pkceMethods },
+          ),
+    );
+
+    // THE CIMD READING, stated so a reviewer can correct it: an advertisement
+    // is two claims, not one — that the server accepts a URL client_id, AND
+    // that it runs the code flow such a client would use. A `true` flag on a
+    // server advertising no `code` response type is an advertisement for a
+    // flow that cannot happen, and Claude would select it and then fail.
+    const cimdFlag = document.client_id_metadata_document_supported;
+    const responseTypes = stringArray(document.response_types_supported);
+    const registrationEndpoint =
+      typeof document.registration_endpoint === "string"
+        ? document.registration_endpoint
+        : undefined;
+    if (cimdFlag === undefined) {
+      findings.push(
+        notApplicable(
+          CIMD_FLAG_CONSISTENT,
+          stamp,
+          "the authorization server does not advertise client-ID-metadata-document support",
+        ),
+      );
+    } else if (typeof cimdFlag !== "boolean") {
+      findings.push(
+        violated(
+          CIMD_FLAG_CONSISTENT,
+          stamp,
+          "`client_id_metadata_document_supported` must be a JSON boolean; a string is not read as a claim of support.",
+          { value: cimdFlag },
+        ),
+      );
+    } else if (cimdFlag && !responseTypes.includes("code")) {
+      findings.push(
+        violated(
+          CIMD_FLAG_CONSISTENT,
+          stamp,
+          "The server advertises client-ID-metadata-document support but no `code` response type, so the flow a CIMD client would run is not offered.",
+          { responseTypes },
+        ),
+      );
+    } else {
+      findings.push(
+        satisfied(CIMD_FLAG_CONSISTENT, stamp, {
+          clientIdMetadataDocumentSupported: cimdFlag,
+          responseTypes,
+        }),
+      );
+    }
+
+    const hasDcr = registrationEndpoint !== undefined;
+    const hasCimd = cimdFlag === true;
+    if (hasDcr || hasCimd) {
+      findings.push(
+        satisfied(CLIENT_ACQUISITION_PATH, stamp, {
+          dynamicClientRegistration: hasDcr,
+          clientIdMetadataDocument: hasCimd,
+        }),
+      );
+      badges.push({
+        id: "claude.auth.client-acquisition",
+        title: "Client acquisition",
+        state: "supported",
+        detail: [hasDcr && "dynamic registration", hasCimd && "client ID metadata document"]
+          .filter(Boolean)
+          .join(" + "),
+        provenance: "wire",
+      });
+    } else {
+      // A preregistered client is a legitimate submission mode; Anthropic
+      // issues the credentials out of band. So this is only a failure when
+      // nothing was declared — otherwise it is a classification.
+      const preregistered = evidence.declaredAuthMode === "oauth-preregistered";
+      findings.push(
+        preregistered
+          ? satisfied(CLIENT_ACQUISITION_PATH, stamp, {
+              mode: "preregistered",
+              declared: evidence.declaredAuthMode,
+            })
+          : violated(
+              CLIENT_ACQUISITION_PATH,
+              stamp,
+              "The authorization server offers neither dynamic registration nor client-ID-metadata-document support. If clients are preregistered out of band, declare `oauth-preregistered` in the submission profile so this is classified rather than flagged.",
+              { registrationEndpoint, clientIdMetadataDocumentSupported: cimdFlag },
+            ),
+      );
+      badges.push({
+        id: "claude.auth.client-acquisition",
+        title: "Client acquisition",
+        state: preregistered ? "claimed" : "unsupported",
+        detail: preregistered
+          ? "preregistered client, declared by the submitter"
+          : "no dynamic registration and no client ID metadata document",
+        provenance: preregistered ? "declared" : "wire",
+      });
+    }
+  }
+
+  // ── Step-up challenge shape ──────────────────────────────────────────
+  const stepUp = evidence.insufficientScopeChallenge;
+  if (!stepUp) {
+    findings.push(
+      notApplicable(
+        SCOPE_CHALLENGE_SHAPE,
+        stamp,
+        "this run observed no insufficient_scope challenge",
+      ),
+    );
+  } else {
+    const params = parseBearerAuthenticateParameters(stepUp.header);
+    // `scope` IS OPTIONAL. Claude performs scope selection when it is omitted,
+    // so requiring it would fail a conforming server for not sending something
+    // the client does not need.
+    findings.push(
+      params.error === "insufficient_scope"
+        ? satisfied(SCOPE_CHALLENGE_SHAPE, stamp, {
+            scope: params.scope,
+            scopeOmitted: params.scope === undefined,
+          })
+        : violated(
+            SCOPE_CHALLENGE_SHAPE,
+            stamp,
+            'A step-up challenge must carry `error="insufficient_scope"` so Claude re-authorizes instead of treating it as a permanent denial.',
+            { header: stepUp.header, error: params.error },
+          ),
+    );
+  }
+
+  // ── Token audience: evidence, not a verdict ──────────────────────────
+  findings.push(
+    evidence.accessTokenAudience === undefined
+      ? notApplicable(
+          TOKEN_AUDIENCE,
+          stamp,
+          "no JWT access token was available to inspect",
+        )
+      : informational(
+          TOKEN_AUDIENCE,
+          stamp,
+          {
+            audience: evidence.accessTokenAudience,
+            resource: evidence.enteredUrl,
+          },
+          // An `aud` that does not name the resource does NOT prove a
+          // mismatch: the server may bind the audience by an equivalent
+          // identifier, and an opaque token has no `aud` to read at all. This
+          // is recorded so a reviewer can weigh it, never graded.
+          "An audience that does not name the connector URL is not by itself a defect — audience binding can be equivalent rather than literal, and opaque tokens carry no `aud` at all.",
+        ),
+  );
+
+  return { findings, badges };
+}
+
+/**
+ * What kind of authentication this connector uses.
+ *
+ * `confident` is false whenever the observation is consistent with more than
+ * one legitimate mode — which is most of the time from outside. The badge
+ * carries the uncertainty rather than resolving it, because resolving it is
+ * how a static-header connector gets reported as broken OAuth.
+ */
+function classifyAuthMode(
+  evidence: ClaudeAuthEvidence,
+  requiresAuth: boolean,
+  servedWithoutAuth: boolean,
+): { detail: string; confident: boolean } {
+  const document = evidence.firstAuthorizationServer?.document;
+  if (document?.registration_endpoint) {
+    return { detail: "OAuth with dynamic client registration", confident: true };
+  }
+  if (document?.client_id_metadata_document_supported === true) {
+    return { detail: "OAuth with a client ID metadata document", confident: true };
+  }
+  if (requiresAuth && evidence.prm?.discoveredVia !== "not-found") {
+    return {
+      detail: "OAuth with a preregistered client",
+      // Indistinguishable from an AS whose metadata we failed to read fully.
+      confident: false,
+    };
+  }
+  if (servedWithoutAuth) {
+    return {
+      detail: evidence.declaredAuthMode
+        ? `served without credentials; submitter declares ${evidence.declaredAuthMode}`
+        : "served without credentials — authless, or credentials carried in a static header",
+      // A static-header connector looks exactly like an authless one here.
+      confident: false,
+    };
+  }
+  return {
+    detail: evidence.declaredAuthMode
+      ? `not determined from the wire; submitter declares ${evidence.declaredAuthMode}`
+      : "not determined from the wire",
+    confident: false,
+  };
+}

--- a/sdk/src/claude-readiness/checks/auth.ts
+++ b/sdk/src/claude-readiness/checks/auth.ts
@@ -235,6 +235,15 @@ function stringArray(value: unknown): string[] {
  * The canonical form of a resource indicator (RFC 8707 §2): scheme and host
  * lowercased, default port removed, no fragment, and no query. The path is
  * KEPT — an MCP server at `/mcp` is a different resource from the origin.
+ *
+ * DELIBERATELY NOT `canonicalizeResourceUrl` from `oauth/resource-policy.ts`,
+ * and the difference is the point rather than an oversight. That function is
+ * the client's own canonicalizer: it keeps the query and keeps a default port,
+ * because its job is to build a value MCPJam will send and then match. This one
+ * grades what CLAUDE sends, and Claude's documented form drops both. Unifying
+ * them would make the check pass values Claude would never produce, so if the
+ * two ever need to converge it has to be because the documentation moved —
+ * check the manifest revision, not this comment.
  */
 export function canonicalResourceIndicator(url: string): string | undefined {
   let parsed: URL;

--- a/sdk/src/claude-readiness/checks/auth.ts
+++ b/sdk/src/claude-readiness/checks/auth.ts
@@ -66,6 +66,13 @@ export interface ClaudeAuthEvidence {
     url?: string;
     document?: Record<string, unknown>;
     fetchError?: string;
+    /**
+     * A `resource_metadata` pointer discovery refused to dial — off-origin, or
+     * not http(s). Recorded rather than dropped: the server published a
+     * pointer no conforming client can follow, and silence would look like the
+     * server never published one.
+     */
+    rejectedPointer?: string;
   };
   /**
    * Metadata for `authorization_servers[0]` ONLY. Claude does not fall back to

--- a/sdk/src/claude-readiness/checks/auth.ts
+++ b/sdk/src/claude-readiness/checks/auth.ts
@@ -366,10 +366,25 @@ export function runClaudeAuthChecks(
             "Publish Protected Resource Metadata — via the challenge's `resource_metadata` pointer, or at `/.well-known/oauth-protected-resource` with the resource path appended.",
             { fetchError: prm.fetchError },
           )
-        : satisfied(PRM_DISCOVERABLE, stamp, {
-            discoveredVia: prm.discoveredVia,
-            url: prm.url,
-          }),
+        : prm.rejectedPointer
+          ? // Discovery SUCCEEDED, via a fallback — and the server still
+            // published a pointer no conforming client can follow. Reporting
+            // only the success would hide a defect that breaks any client
+            // which trusts the challenge, which is most of them.
+            violated(
+              PRM_DISCOVERABLE,
+              stamp,
+              "The 401 challenge points at a Protected Resource Metadata URL on another origin (or a non-http scheme). Point it at this connector's own origin — a conforming client refuses to follow it, and only found your metadata by falling back to the well-known path.",
+              {
+                discoveredVia: prm.discoveredVia,
+                url: prm.url,
+                rejectedPointer: prm.rejectedPointer,
+              },
+            )
+          : satisfied(PRM_DISCOVERABLE, stamp, {
+              discoveredVia: prm.discoveredVia,
+              url: prm.url,
+            }),
     );
 
     // TWO DIFFERENT REQUIREMENTS, deliberately not one check. This one is

--- a/sdk/src/claude-readiness/checks/auth.ts
+++ b/sdk/src/claude-readiness/checks/auth.ts
@@ -82,6 +82,16 @@ export interface ClaudeAuthEvidence {
   /** A `403` step-up challenge, if the run happened to see one. */
   insufficientScopeChallenge?: { header: string };
   /**
+   * The RFC 8707 `resource` parameter the CLIENT actually sent, per endpoint.
+   * Present only when the run completed an authorization — which is why the
+   * check that reads it declares `interactive-oauth` as a prerequisite rather
+   * than guessing from the metadata.
+   */
+  resourceIndicatorsSent?: {
+    authorize?: string;
+    token?: string;
+  };
+  /**
    * The `aud` claim of an access token the caller supplied, when it was a JWT.
    * EVIDENCE ONLY — see the check.
    */
@@ -386,15 +396,45 @@ export function runClaudeAuthChecks(
     );
   }
 
+  // THE SECOND HALF OF THE RESOURCE STORY. The PRM check above is about the
+  // document; this one is about what the CLIENT sends, and a server can
+  // satisfy either while failing the other. It needs an authorization to have
+  // happened, so a headless run reports it unevaluated rather than inferring
+  // it from metadata that says nothing about the parameter.
   const canonical = canonicalResourceIndicator(evidence.enteredUrl);
-  findings.push(
-    notEvaluated(
-      RFC8707_RESOURCE_CANONICAL,
-      stamp,
-      "checking the `resource` parameter on /authorize and /token requires completing an authorization, which this run did not do",
-      { expectedCanonicalForm: canonical },
-    ),
-  );
+  const sent = evidence.resourceIndicatorsSent;
+  if (!sent || (sent.authorize === undefined && sent.token === undefined)) {
+    findings.push(
+      notEvaluated(
+        RFC8707_RESOURCE_CANONICAL,
+        stamp,
+        "checking the `resource` parameter on /authorize and /token requires completing an authorization, which this run did not do",
+        { expectedCanonicalForm: canonical },
+      ),
+    );
+  } else {
+    const wrong = (["authorize", "token"] as const).filter(
+      (endpoint) =>
+        sent[endpoint] !== undefined && sent[endpoint] !== canonical,
+    );
+    findings.push(
+      wrong.length === 0
+        ? satisfied(RFC8707_RESOURCE_CANONICAL, stamp, {
+            canonical,
+            sent,
+          })
+        : violated(
+            RFC8707_RESOURCE_CANONICAL,
+            stamp,
+            `The \`resource\` parameter must be the canonical form \`${canonical}\` — lowercased scheme and host, no default port, no query, no fragment — on every endpoint that carries it.`,
+            {
+              canonical,
+              sent,
+              endpoints: wrong,
+            },
+          ),
+    );
+  }
 
   // ── Authorization server ─────────────────────────────────────────────
   const authServers = stringArray(prm?.document?.authorization_servers);

--- a/sdk/src/claude-readiness/checks/endpoint.ts
+++ b/sdk/src/claude-readiness/checks/endpoint.ts
@@ -102,7 +102,13 @@ export function runClaudeEndpointChecks(
   );
 
   const chain = evidence.redirectChain;
-  if (!chain) {
+  // AN EMPTY CHAIN IS NOT A CLEAN ONE. `traceConnectorRedirects` returns
+  // `redirectChain: []` when the very first request throws, so treating only
+  // the absent field as "never reached" reported two satisfied findings with
+  // `hops: 0` for an endpoint the run never actually touched — the exact
+  // "unobserved obligation reads as a pass" failure every other check module
+  // in this directory is written to avoid.
+  if (!chain || chain.length === 0) {
     const reason = "the run never reached the connector endpoint";
     findings.push(notEvaluated(REDIRECT_STAYS_SECURE, stamp, reason));
     findings.push(notEvaluated(REDIRECT_TERMINATES, stamp, reason));

--- a/sdk/src/claude-readiness/checks/endpoint.ts
+++ b/sdk/src/claude-readiness/checks/endpoint.ts
@@ -1,0 +1,151 @@
+/**
+ * Endpoint checks: the connector URL itself, before anything about MCP.
+ *
+ * These are runtime blockers rather than policy items. A plaintext endpoint is
+ * not a paperwork problem — Claude will not dial it at all, so nothing further
+ * about the server can be graded. Keeping them in the runtime-compatibility
+ * lane is what lets a report say "we never got far enough to check the rest"
+ * instead of listing thirty unevaluated policy items with no explanation.
+ *
+ * Pure: reasons over a redirect trace the runner captured. It dials nothing.
+ */
+
+import { claudePolicySource } from "../manifest.js";
+import type { ClaudeReadinessFinding } from "../types.js";
+import {
+  notEvaluated,
+  satisfied,
+  violated,
+  type ClaudeCheckDefinition,
+  type ClaudeCheckStamp,
+} from "./helpers.js";
+
+const HTTPS_REQUIRED: ClaudeCheckDefinition = {
+  id: "claude.endpoint.https",
+  title: "The connector URL is served over HTTPS",
+  lane: "runtime-compatibility",
+  class: "runtime-blocker",
+  source: claudePolicySource("submission", "§Requirements → Transport"),
+  provenance: "static",
+  intrusiveness: "passive",
+};
+
+const REDIRECT_STAYS_SECURE: ClaudeCheckDefinition = {
+  id: "claude.endpoint.redirects-stay-https",
+  title: "No redirect on the connector URL downgrades to plaintext",
+  lane: "runtime-compatibility",
+  class: "runtime-blocker",
+  source: claudePolicySource("troubleshooting", "§Connection → Redirects"),
+  provenance: "wire",
+};
+
+const REDIRECT_TERMINATES: ClaudeCheckDefinition = {
+  id: "claude.endpoint.redirects-terminate",
+  title: "The connector URL resolves without an unbounded redirect chain",
+  lane: "runtime-compatibility",
+  class: "runtime-blocker",
+  source: claudePolicySource("troubleshooting", "§Connection → Redirects"),
+  provenance: "wire",
+};
+
+/**
+ * One hop of the chain the runner actually walked.
+ *
+ * The trace is an INPUT rather than something this module produces, because
+ * the only transport allowed to walk it in a hosted run is the pinned one, and
+ * a check module that could dial on its own would be a way around that.
+ */
+export interface ClaudeRedirectHop {
+  url: string;
+  status: number;
+  location?: string;
+}
+
+export interface ClaudeEndpointEvidence {
+  /** The URL exactly as entered — not canonicalized. */
+  enteredUrl: string;
+  /** Absent when the run never reached the endpoint. */
+  redirectChain?: ClaudeRedirectHop[];
+  /** True when the chain was cut short by the runner's own ceiling. */
+  redirectLimitHit?: boolean;
+}
+
+export function runClaudeEndpointChecks(
+  evidence: ClaudeEndpointEvidence,
+  stamp: ClaudeCheckStamp,
+): ClaudeReadinessFinding[] {
+  const findings: ClaudeReadinessFinding[] = [];
+
+  let parsed: URL | undefined;
+  try {
+    parsed = new URL(evidence.enteredUrl);
+  } catch {
+    parsed = undefined;
+  }
+
+  findings.push(
+    parsed === undefined
+      ? violated(
+          HTTPS_REQUIRED,
+          stamp,
+          "The connector URL is not a valid absolute URL.",
+          { enteredUrl: evidence.enteredUrl },
+        )
+      : parsed.protocol === "https:"
+        ? satisfied(HTTPS_REQUIRED, stamp)
+        : violated(
+            HTTPS_REQUIRED,
+            stamp,
+            "Serve the connector over HTTPS. Claude will not connect to a plaintext endpoint.",
+            { scheme: parsed.protocol },
+          ),
+  );
+
+  const chain = evidence.redirectChain;
+  if (!chain) {
+    const reason = "the run never reached the connector endpoint";
+    findings.push(notEvaluated(REDIRECT_STAYS_SECURE, stamp, reason));
+    findings.push(notEvaluated(REDIRECT_TERMINATES, stamp, reason));
+    return findings;
+  }
+
+  // A downgrade anywhere in the chain matters even when the chain ENDS on
+  // https: the plaintext hop is rewritable by anyone on the path, and what
+  // they get to choose is where the connector ends up.
+  const downgrades = chain.filter((hop) => {
+    if (!hop.location) return false;
+    try {
+      return new URL(hop.location, hop.url).protocol !== "https:";
+    } catch {
+      return false;
+    }
+  });
+  findings.push(
+    downgrades.length === 0
+      ? satisfied(REDIRECT_STAYS_SECURE, stamp, { hops: chain.length })
+      : violated(
+          REDIRECT_STAYS_SECURE,
+          stamp,
+          "Remove the plaintext hop from the redirect chain — a hop anyone on the path can rewrite decides where the connection ends up, even when the chain finishes on HTTPS.",
+          {
+            hops: downgrades.map((hop) => ({
+              from: hop.url,
+              to: hop.location,
+            })),
+          },
+        ),
+  );
+
+  findings.push(
+    evidence.redirectLimitHit
+      ? violated(
+          REDIRECT_TERMINATES,
+          stamp,
+          "The connector URL redirected past the client's limit. Point the listing at the final URL.",
+          { hops: chain.length },
+        )
+      : satisfied(REDIRECT_TERMINATES, stamp, { hops: chain.length }),
+  );
+
+  return findings;
+}

--- a/sdk/src/claude-readiness/checks/helpers.ts
+++ b/sdk/src/claude-readiness/checks/helpers.ts
@@ -1,0 +1,150 @@
+/**
+ * Finding constructors.
+ *
+ * Checks never build a {@link ClaudeReadinessFinding} literal. Going through
+ * these is what guarantees the fields that make a grade auditable — source
+ * citation, provenance, intrusiveness, engine version, timestamp — are present
+ * on every finding rather than on the ones whose author remembered. A check
+ * that could construct a finding by hand is a check that can quietly ship one
+ * with no provenance.
+ *
+ * Pure data. No transport.
+ */
+
+import type { ClaudePolicySourceRef } from "../manifest.js";
+import {
+  CLAUDE_READINESS_ENGINE_VERSION,
+  type ClaudeEvidenceProvenance,
+  type ClaudeFindingClass,
+  type ClaudeIntrusiveness,
+  type ClaudeReadinessFinding,
+  type ClaudeReadinessLane,
+  type ClaudeRunnerCapability,
+} from "../types.js";
+
+/** Everything about a check that does not depend on what it observed. */
+export interface ClaudeCheckDefinition {
+  id: string;
+  title: string;
+  lane: ClaudeReadinessLane;
+  class: ClaudeFindingClass;
+  source: ClaudePolicySourceRef;
+  provenance: ClaudeEvidenceProvenance;
+  /** Defaults to `read-only`; a purely static lint should say `passive`. */
+  intrusiveness?: ClaudeIntrusiveness;
+  requiresCapabilities?: ClaudeRunnerCapability[];
+}
+
+/** What every check is handed, so none of them reads a clock of its own. */
+export interface ClaudeCheckStamp {
+  /** One timestamp for the whole run: findings from one run are one moment. */
+  evaluatedAt: string;
+}
+
+function base(
+  definition: ClaudeCheckDefinition,
+  stamp: ClaudeCheckStamp,
+): Omit<ClaudeReadinessFinding, "status"> {
+  return {
+    id: definition.id,
+    title: definition.title,
+    lane: definition.lane,
+    class: definition.class,
+    source: definition.source,
+    provenance: definition.provenance,
+    intrusiveness: definition.intrusiveness ?? "read-only",
+    requiresCapabilities: definition.requiresCapabilities,
+    evaluatedAt: stamp.evaluatedAt,
+    engineVersion: CLAUDE_READINESS_ENGINE_VERSION,
+  };
+}
+
+export function satisfied(
+  definition: ClaudeCheckDefinition,
+  stamp: ClaudeCheckStamp,
+  details?: Record<string, unknown>,
+): ClaudeReadinessFinding {
+  return { ...base(definition, stamp), status: "satisfied", details };
+}
+
+export function violated(
+  definition: ClaudeCheckDefinition,
+  stamp: ClaudeCheckStamp,
+  remediation: string,
+  details?: Record<string, unknown>,
+): ClaudeReadinessFinding {
+  return { ...base(definition, stamp), status: "violated", remediation, details };
+}
+
+/**
+ * The requirement applies here but this run never exercised it.
+ *
+ * `reason` is not optional, and that is the point: an unevaluated requirement
+ * with no stated reason is indistinguishable from a bug, and it is what makes
+ * the lane's `incomplete` status actionable rather than mysterious.
+ */
+export function notEvaluated(
+  definition: ClaudeCheckDefinition,
+  stamp: ClaudeCheckStamp,
+  reason: string,
+  details?: Record<string, unknown>,
+): ClaudeReadinessFinding {
+  return {
+    ...base(definition, stamp),
+    status: "not-evaluated",
+    notEvaluatedReason: reason,
+    details,
+  };
+}
+
+/**
+ * The requirement cannot apply to THIS target — an app-only rule against a
+ * server with no apps, an OAuth rule against an authless server.
+ *
+ * Distinct from {@link notEvaluated} in exactly the way `not-applicable` is
+ * distinct from `could-not-run` in the suites: nothing was left unverified.
+ */
+export function notApplicable(
+  definition: ClaudeCheckDefinition,
+  stamp: ClaudeCheckStamp,
+  reason: string,
+): ClaudeReadinessFinding {
+  return {
+    ...base(definition, stamp),
+    status: "not-applicable",
+    notEvaluatedReason: reason,
+  };
+}
+
+/** A statement that carries no pass/fail meaning — badges, observations. */
+export function informational(
+  definition: ClaudeCheckDefinition,
+  stamp: ClaudeCheckStamp,
+  details?: Record<string, unknown>,
+  note?: string,
+): ClaudeReadinessFinding {
+  return {
+    ...base(definition, stamp),
+    status: "informational",
+    remediation: note,
+    details,
+  };
+}
+
+/**
+ * Mark a finding as derived from an existing suite result rather than
+ * re-observed.
+ *
+ * Readiness COMPOSES: re-running an equivalent check would let readiness and
+ * the suite disagree about the same server, and the first question anyone asks
+ * about a disagreement is which one to believe.
+ */
+export function derivedFrom(
+  finding: ClaudeReadinessFinding,
+  ...sources: string[]
+): ClaudeReadinessFinding {
+  return {
+    ...finding,
+    derivedFrom: [...(finding.derivedFrom ?? []), ...sources],
+  };
+}

--- a/sdk/src/claude-readiness/checks/optional-features.ts
+++ b/sdk/src/claude-readiness/checks/optional-features.ts
@@ -1,0 +1,188 @@
+/**
+ * The optional-features lane: capability BADGES, not requirements.
+ *
+ * The distinction is the whole module. Lazy authentication and
+ * enterprise-managed auth are features a connector may offer; a connector that
+ * offers neither is not defective, and grading their absence would tell
+ * submitters to build things Anthropic never asked them for. So nothing here
+ * can move a lane's status — the findings are `experimental-feature`, which
+ * `decideLaneStatus` ignores by construction, and the badges carry the actual
+ * signal.
+ *
+ * DEPTH ONLY WHEN CLAIMED OR SELECTED. Establishing that lazy auth genuinely
+ * works means driving a protected call and watching the challenge arrive
+ * mid-session, and establishing enterprise-managed auth means having an
+ * enterprise tenant. Doing either speculatively against every server would
+ * spend real requests to answer a question nobody asked. So an unclaimed,
+ * undetected feature reports `not-evaluated` and says so, rather than
+ * reporting `unsupported` — which would be a claim this run did not earn.
+ *
+ * Pure data. No transport.
+ */
+
+import { claudePolicySource } from "../manifest.js";
+import type {
+  ClaudeCapabilityBadge,
+  ClaudeReadinessFinding,
+} from "../types.js";
+import type { ClaudeAuthEvidence } from "./auth.js";
+import {
+  informational,
+  notEvaluated,
+  type ClaudeCheckDefinition,
+  type ClaudeCheckStamp,
+} from "./helpers.js";
+
+const LAZY_AUTH: ClaudeCheckDefinition = {
+  id: "claude.features.lazy-authentication",
+  title: "Lazy authentication",
+  lane: "optional-features",
+  class: "experimental-feature",
+  source: claudePolicySource("lazy-authentication", "§Overview"),
+  provenance: "wire",
+};
+
+const ENTERPRISE_MANAGED_AUTH: ClaudeCheckDefinition = {
+  id: "claude.features.enterprise-managed-auth",
+  title: "Enterprise-managed authentication",
+  lane: "optional-features",
+  class: "experimental-feature",
+  source: claudePolicySource("enterprise-managed-auth", "§Overview"),
+  provenance: "declared",
+  intrusiveness: "passive",
+};
+
+export interface ClaudeOptionalFeatureEvidence {
+  auth: ClaudeAuthEvidence;
+  /**
+   * Features the submitter claimed. A claim is what unlocks depth evaluation;
+   * it is never itself the evidence.
+   */
+  claimedFeatures?: {
+    lazyAuthentication?: boolean;
+    enterpriseManagedAuth?: boolean;
+  };
+  /**
+   * Set when the run actually drove a protected call after an unauthenticated
+   * one succeeded — the only observation that establishes lazy auth rather
+   * than inferring it.
+   */
+  lazyAuthProbe?: {
+    unauthenticatedCallSucceeded: boolean;
+    protectedCallChallenged: boolean;
+  };
+}
+
+export interface ClaudeOptionalFeatureOutput {
+  findings: ClaudeReadinessFinding[];
+  badges: ClaudeCapabilityBadge[];
+}
+
+export function runClaudeOptionalFeatureChecks(
+  evidence: ClaudeOptionalFeatureEvidence,
+  stamp: ClaudeCheckStamp,
+): ClaudeOptionalFeatureOutput {
+  const findings: ClaudeReadinessFinding[] = [];
+  const badges: ClaudeCapabilityBadge[] = [];
+
+  // ── Lazy authentication ──────────────────────────────────────────────
+  const probe = evidence.lazyAuthProbe;
+  const claimed = evidence.claimedFeatures?.lazyAuthentication === true;
+  const servedWithoutCredentials =
+    evidence.auth.unauthenticated?.servedWithoutCredentials === true;
+  const publishesChallenge =
+    evidence.auth.prm?.discoveredVia !== undefined &&
+    evidence.auth.prm.discoveredVia !== "not-found";
+
+  if (probe) {
+    const works =
+      probe.unauthenticatedCallSucceeded && probe.protectedCallChallenged;
+    badges.push({
+      id: LAZY_AUTH.id,
+      title: LAZY_AUTH.title,
+      state: works ? "supported" : "unsupported",
+      detail: works
+        ? "an unauthenticated call succeeded and a protected one was challenged"
+        : probe.unauthenticatedCallSucceeded
+          ? "unauthenticated calls succeed, but no protected call produced a challenge"
+          : "the server challenges before any call succeeds",
+      provenance: "wire",
+    });
+    findings.push(informational(LAZY_AUTH, stamp, { probe }));
+  } else if (servedWithoutCredentials && publishesChallenge) {
+    // Consistent with lazy auth and not proof of it: a server that serves
+    // everything and publishes metadata it never enforces looks identical from
+    // here. `claimed` is the honest state for a signal that has not been driven.
+    badges.push({
+      id: LAZY_AUTH.id,
+      title: LAZY_AUTH.title,
+      state: "claimed",
+      detail:
+        "the server answered unauthenticated and still publishes resource metadata, which is consistent with lazy auth but was not driven",
+      provenance: "wire",
+    });
+    findings.push(
+      notEvaluated(
+        LAZY_AUTH,
+        stamp,
+        "lazy authentication is consistent with what this run saw, but establishing it means driving a protected call, which this run did not do",
+      ),
+    );
+  } else if (claimed) {
+    badges.push({
+      id: LAZY_AUTH.id,
+      title: LAZY_AUTH.title,
+      state: "claimed",
+      detail: "declared by the submitter; not verified by this run",
+      provenance: "declared",
+    });
+    findings.push(
+      notEvaluated(
+        LAZY_AUTH,
+        stamp,
+        "the submitter claims lazy authentication; verifying it requires driving a protected call",
+      ),
+    );
+  } else {
+    // NOT `unsupported`. Never looking is not the same as looking and finding
+    // nothing, and a badge that says "unsupported" on the strength of not
+    // having checked is a false statement about someone's product.
+    badges.push({
+      id: LAZY_AUTH.id,
+      title: LAZY_AUTH.title,
+      state: "not-evaluated",
+      detail: "neither claimed nor detected, so it was not evaluated in depth",
+      provenance: "wire",
+    });
+    findings.push(
+      notEvaluated(
+        LAZY_AUTH,
+        stamp,
+        "lazy authentication was neither claimed nor detected, so no depth evaluation was attempted",
+      ),
+    );
+  }
+
+  // ── Enterprise-managed authentication ────────────────────────────────
+  const emaClaimed = evidence.claimedFeatures?.enterpriseManagedAuth === true;
+  badges.push({
+    id: ENTERPRISE_MANAGED_AUTH.id,
+    title: ENTERPRISE_MANAGED_AUTH.title,
+    state: emaClaimed ? "claimed" : "not-evaluated",
+    detail: emaClaimed
+      ? "declared by the submitter; verifying it requires an enterprise tenant this run does not have"
+      : "not claimed, and it cannot be detected from an unauthenticated probe",
+    provenance: "declared",
+  });
+  findings.push(
+    notEvaluated(
+      ENTERPRISE_MANAGED_AUTH,
+      stamp,
+      emaClaimed
+        ? "enterprise-managed auth is claimed; verifying it requires an enterprise tenant and managed credentials"
+        : "enterprise-managed auth leaves no trace on an unauthenticated probe and was not claimed",
+    ),
+  );
+
+  return { findings, badges };
+}

--- a/sdk/src/claude-readiness/checks/submission.ts
+++ b/sdk/src/claude-readiness/checks/submission.ts
@@ -160,31 +160,77 @@ export function runClaudeSubmissionChecks(
 
   const findings: ClaudeReadinessFinding[] = [];
 
-  // The zod schema already enforces these bounds, so a parsed profile cannot
-  // violate them. The check still runs and still reports, because a REPORT
-  // that silently omits a requirement it verified is indistinguishable from
-  // one that never checked it.
+  // RE-CHECKED, not assumed. A profile that came through
+  // `parseClaudeSubmissionProfile` cannot violate these bounds, but
+  // `ClaudeSubmissionEvidence.profile` is a typed field a caller can populate
+  // directly, and a check that reported `satisfied` without looking would be
+  // asserting something it never verified.
+  const overLongFields = [
+    ["name", profile.name.length, CLAUDE_SUBMISSION_LIMITS.nameMaxLength],
+    ["tagline", profile.tagline.length, CLAUDE_SUBMISSION_LIMITS.taglineMaxLength],
+    [
+      "description",
+      profile.description.length,
+      CLAUDE_SUBMISSION_LIMITS.descriptionMaxLength,
+    ],
+  ].filter(([, length, limit]) => (length as number) > (limit as number));
+  const categoryCount = profile.categories.length;
+  const categoriesOutOfRange =
+    categoryCount < CLAUDE_SUBMISSION_LIMITS.categoriesMin ||
+    categoryCount > CLAUDE_SUBMISSION_LIMITS.categoriesMax;
+
   findings.push(
-    satisfied(LISTING_FIELDS, stamp, {
+    overLongFields.length > 0 || categoriesOutOfRange
+      ? violated(
+          LISTING_FIELDS,
+          stamp,
+          `Listing fields must fit their limits: name ≤ ${CLAUDE_SUBMISSION_LIMITS.nameMaxLength}, tagline ≤ ${CLAUDE_SUBMISSION_LIMITS.taglineMaxLength}, description ≤ ${CLAUDE_SUBMISSION_LIMITS.descriptionMaxLength}, and ${CLAUDE_SUBMISSION_LIMITS.categoriesMin}–${CLAUDE_SUBMISSION_LIMITS.categoriesMax} categories.`,
+          {
+            overLong: overLongFields.map(([field, length, limit]) => ({
+              field,
+              length,
+              limit,
+            })),
+            categories: categoryCount,
+          },
+        )
+      : satisfied(LISTING_FIELDS, stamp, {
       nameLength: profile.name.length,
       taglineLength: profile.tagline.length,
       descriptionLength: profile.description.length,
       categories: profile.categories.length,
-      limits: {
-        name: CLAUDE_SUBMISSION_LIMITS.nameMaxLength,
-        tagline: CLAUDE_SUBMISSION_LIMITS.taglineMaxLength,
-        description: CLAUDE_SUBMISSION_LIMITS.descriptionMaxLength,
-      },
-    }),
-  );
-  findings.push(
-    satisfied(LISTING_URLS, stamp, {
-      documentationUrl: profile.documentationUrl,
-      privacyPolicyUrl: profile.privacyPolicyUrl,
-      supportUrl: profile.supportUrl,
-    }),
+          limits: {
+            name: CLAUDE_SUBMISSION_LIMITS.nameMaxLength,
+            tagline: CLAUDE_SUBMISSION_LIMITS.taglineMaxLength,
+            description: CLAUDE_SUBMISSION_LIMITS.descriptionMaxLength,
+          },
+        }),
   );
 
+  const listingUrls = {
+    documentationUrl: profile.documentationUrl,
+    privacyPolicyUrl: profile.privacyPolicyUrl,
+    supportUrl: profile.supportUrl,
+    iconUrl: profile.iconUrl,
+  };
+  const insecureUrls = Object.entries(listingUrls).filter(
+    ([, url]) => !isHttpsUrl(url),
+  );
+  findings.push(
+    insecureUrls.length === 0
+      ? satisfied(LISTING_URLS, stamp, listingUrls)
+      : violated(
+          LISTING_URLS,
+          stamp,
+          "Every listing link must be an https:// URL.",
+          { insecure: insecureUrls.map(([field, url]) => ({ field, url })) },
+        ),
+  );
+
+  const screenshotCount = profile.screenshots.length;
+  const countOutOfRange =
+    screenshotCount < CLAUDE_SUBMISSION_LIMITS.screenshotsMin ||
+    screenshotCount > CLAUDE_SUBMISSION_LIMITS.screenshotsMax;
   const badFormat = profile.screenshots.filter(
     (shot) =>
       !ACCEPTED_SCREENSHOT_MIME.includes(shot.mimeType.split(";")[0].trim().toLowerCase()),
@@ -192,9 +238,12 @@ export function runClaudeSubmissionChecks(
   const tooNarrow = profile.screenshots.filter(
     (shot) => shot.widthPx < CLAUDE_SUBMISSION_LIMITS.screenshotMinWidthPx,
   );
+  // The COUNT is evaluated here too, because the remediation names it. A
+  // message that quotes a range the check never looked at tells a submitter
+  // with too few screenshots that their screenshots are fine.
   findings.push(
-    badFormat.length === 0 && tooNarrow.length === 0
-      ? satisfied(SCREENSHOTS, stamp, { count: profile.screenshots.length })
+    badFormat.length === 0 && tooNarrow.length === 0 && !countOutOfRange
+      ? satisfied(SCREENSHOTS, stamp, { count: screenshotCount })
       : violated(
           SCREENSHOTS,
           stamp,
@@ -208,6 +257,7 @@ export function runClaudeSubmissionChecks(
               url: shot.url,
               widthPx: shot.widthPx,
             })),
+            count: screenshotCount,
           },
         ),
   );
@@ -290,6 +340,14 @@ export function runClaudeSubmissionChecks(
   );
 
   return findings;
+}
+
+function isHttpsUrl(value: string): boolean {
+  try {
+    return new URL(value).protocol === "https:";
+  } catch {
+    return false;
+  }
 }
 
 /**

--- a/sdk/src/claude-readiness/checks/submission.ts
+++ b/sdk/src/claude-readiness/checks/submission.ts
@@ -1,0 +1,311 @@
+/**
+ * Submission-artifact checks.
+ *
+ * The lane's whole shape follows from one fact: without a
+ * {@link ClaudeSubmissionProfile}, none of this can be evaluated. Not
+ * approximated, not inferred from `serverInfo.name` — a listing name is a
+ * field on a form, and a server's advertised name is a different thing that
+ * frequently differs. So with no profile every finding here is
+ * `not-evaluated`, the lane is `incomplete`, and the coverage names
+ * `submissionProfile` as the input that would close it.
+ *
+ * With a profile, the split is sharp:
+ *
+ *   - DETERMINISTIC — presence, lengths, URL shapes, image type and pixel
+ *     dimensions, attestation completeness. These are `required` and they pass
+ *     or fail on the bytes.
+ *   - MANUAL — whether a screenshot shows the product, whether the submitter
+ *     owns the domain, whether an attestation is TRUE. These are
+ *     `manual-review` with `declared` provenance, so no reader can mistake
+ *     "the submitter said so" for "we checked".
+ *
+ * Pure data. No transport.
+ */
+
+import { claudePolicySource } from "../manifest.js";
+import { CLAUDE_SUBMISSION_LIMITS } from "../profile.js";
+import {
+  CLAUDE_ATTESTATIONS,
+  type ClaudeSubmissionProfile,
+} from "../submission-profile.js";
+import type { ClaudeReadinessFinding } from "../types.js";
+import {
+  informational,
+  notEvaluated,
+  satisfied,
+  violated,
+  type ClaudeCheckDefinition,
+  type ClaudeCheckStamp,
+} from "./helpers.js";
+
+const LISTING_FIELDS: ClaudeCheckDefinition = {
+  id: "claude.submission.listing-fields",
+  title: "Listing name, tagline, description and categories are within limits",
+  lane: "submission-artifacts",
+  class: "required",
+  source: claudePolicySource("submission", "§Listing details"),
+  provenance: "declared",
+  intrusiveness: "passive",
+};
+
+const LISTING_URLS: ClaudeCheckDefinition = {
+  id: "claude.submission.urls",
+  title: "Documentation, privacy and support URLs are HTTPS",
+  lane: "submission-artifacts",
+  class: "required",
+  source: claudePolicySource("submission", "§Listing details → Links"),
+  provenance: "declared",
+  intrusiveness: "passive",
+};
+
+const SCREENSHOTS: ClaudeCheckDefinition = {
+  id: "claude.submission.screenshots",
+  title: "Screenshots meet count, format and resolution requirements",
+  lane: "submission-artifacts",
+  class: "required",
+  source: claudePolicySource("submission", "§Screenshots"),
+  provenance: "declared",
+  intrusiveness: "passive",
+};
+
+const SCREENSHOT_PROMPTS: ClaudeCheckDefinition = {
+  id: "claude.submission.screenshot-prompts",
+  title: "Every screenshot is paired with the prompt it illustrates",
+  lane: "submission-artifacts",
+  class: "required",
+  source: claudePolicySource("submission", "§Screenshots"),
+  provenance: "declared",
+  intrusiveness: "passive",
+};
+
+const ATTESTATIONS: ClaudeCheckDefinition = {
+  id: "claude.submission.attestations",
+  title: "All seven submission attestations are affirmed",
+  lane: "submission-artifacts",
+  class: "required",
+  source: claudePolicySource("submission", "§Attestations"),
+  provenance: "declared",
+  intrusiveness: "passive",
+};
+
+const ARTIFACT_QUALITY: ClaudeCheckDefinition = {
+  id: "claude.submission.artifact-quality",
+  title: "Listing copy, screenshots and ownership need a human reviewer",
+  lane: "submission-artifacts",
+  class: "manual-review",
+  source: claudePolicySource("review-criteria", "§Listing quality"),
+  provenance: "declared",
+  intrusiveness: "passive",
+};
+
+const DECLARED_AUTH_MATCHES: ClaudeCheckDefinition = {
+  id: "claude.submission.declared-auth-mode",
+  title: "The declared authentication mode matches what the server does",
+  lane: "submission-artifacts",
+  class: "required",
+  source: claudePolicySource("submission", "§Authentication"),
+  provenance: "declared",
+  intrusiveness: "passive",
+};
+
+const DEFINITIONS = [
+  LISTING_FIELDS,
+  LISTING_URLS,
+  SCREENSHOTS,
+  SCREENSHOT_PROMPTS,
+  ATTESTATIONS,
+  DECLARED_AUTH_MATCHES,
+  ARTIFACT_QUALITY,
+];
+
+/** The named input a caller supplies to make this lane evaluable. */
+export const CLAUDE_SUBMISSION_PROFILE_INPUT = "submissionProfile";
+
+/** PNG only: the listing gallery renders these, and a JPEG is rejected. */
+const ACCEPTED_SCREENSHOT_MIME = ["image/png"];
+
+export interface ClaudeSubmissionEvidence {
+  profile?: ClaudeSubmissionProfile;
+  /** Issues from parsing a profile that was supplied but malformed. */
+  profileIssues?: string[];
+  /**
+   * How the run OBSERVED the server authenticating, when it could tell. Used
+   * only to contradict a declaration — never to supply one, because several
+   * legitimate modes (static header, custom connection, preregistered client)
+   * are indistinguishable from outside.
+   */
+  observedAuthMode?: string;
+}
+
+export function runClaudeSubmissionChecks(
+  evidence: ClaudeSubmissionEvidence,
+  stamp: ClaudeCheckStamp,
+): ClaudeReadinessFinding[] {
+  const { profile } = evidence;
+
+  if (!profile) {
+    // A malformed profile is NOT the same as no profile: the caller did the
+    // work and got it wrong, and saying "no input" would hide their mistake
+    // behind a status that reads like our limitation.
+    const reason = evidence.profileIssues?.length
+      ? `the supplied submission profile did not validate: ${evidence.profileIssues.join("; ")}`
+      : `no submission profile was supplied, and none of these fields can be inferred from the wire (\`serverInfo.name\` is not the listing name)`;
+    return DEFINITIONS.map((definition) =>
+      notEvaluated(definition, stamp, reason, {
+        missingInput: CLAUDE_SUBMISSION_PROFILE_INPUT,
+        issues: evidence.profileIssues,
+      }),
+    );
+  }
+
+  const findings: ClaudeReadinessFinding[] = [];
+
+  // The zod schema already enforces these bounds, so a parsed profile cannot
+  // violate them. The check still runs and still reports, because a REPORT
+  // that silently omits a requirement it verified is indistinguishable from
+  // one that never checked it.
+  findings.push(
+    satisfied(LISTING_FIELDS, stamp, {
+      nameLength: profile.name.length,
+      taglineLength: profile.tagline.length,
+      descriptionLength: profile.description.length,
+      categories: profile.categories.length,
+      limits: {
+        name: CLAUDE_SUBMISSION_LIMITS.nameMaxLength,
+        tagline: CLAUDE_SUBMISSION_LIMITS.taglineMaxLength,
+        description: CLAUDE_SUBMISSION_LIMITS.descriptionMaxLength,
+      },
+    }),
+  );
+  findings.push(
+    satisfied(LISTING_URLS, stamp, {
+      documentationUrl: profile.documentationUrl,
+      privacyPolicyUrl: profile.privacyPolicyUrl,
+      supportUrl: profile.supportUrl,
+    }),
+  );
+
+  const badFormat = profile.screenshots.filter(
+    (shot) =>
+      !ACCEPTED_SCREENSHOT_MIME.includes(shot.mimeType.split(";")[0].trim().toLowerCase()),
+  );
+  const tooNarrow = profile.screenshots.filter(
+    (shot) => shot.widthPx < CLAUDE_SUBMISSION_LIMITS.screenshotMinWidthPx,
+  );
+  findings.push(
+    badFormat.length === 0 && tooNarrow.length === 0
+      ? satisfied(SCREENSHOTS, stamp, { count: profile.screenshots.length })
+      : violated(
+          SCREENSHOTS,
+          stamp,
+          `Supply ${CLAUDE_SUBMISSION_LIMITS.screenshotsMin}–${CLAUDE_SUBMISSION_LIMITS.screenshotsMax} PNG screenshots at least ${CLAUDE_SUBMISSION_LIMITS.screenshotMinWidthPx}px wide.`,
+          {
+            wrongFormat: badFormat.map((shot) => ({
+              url: shot.url,
+              mimeType: shot.mimeType,
+            })),
+            tooNarrow: tooNarrow.map((shot) => ({
+              url: shot.url,
+              widthPx: shot.widthPx,
+            })),
+          },
+        ),
+  );
+
+  const unpaired = profile.screenshots.filter((shot) => !shot.prompt.trim());
+  findings.push(
+    unpaired.length === 0
+      ? satisfied(SCREENSHOT_PROMPTS, stamp)
+      : violated(
+          SCREENSHOT_PROMPTS,
+          stamp,
+          "Pair every screenshot with the prompt it illustrates — a gallery with no prompts does not show a reviewer what the connector does.",
+          { unpaired: unpaired.map((shot) => shot.url) },
+        ),
+  );
+
+  // A missing key and an explicit `false` are different failures: an
+  // incomplete form versus a refusal to affirm. Naming both tells the
+  // submitter which one they are looking at.
+  const missing = CLAUDE_ATTESTATIONS.filter(
+    (attestation) => profile.attestations[attestation] === undefined,
+  );
+  const denied = CLAUDE_ATTESTATIONS.filter(
+    (attestation) => profile.attestations[attestation] === false,
+  );
+  findings.push(
+    missing.length === 0 && denied.length === 0
+      ? satisfied(ATTESTATIONS, stamp, { affirmed: CLAUDE_ATTESTATIONS.length })
+      : violated(
+          ATTESTATIONS,
+          stamp,
+          missing.length > 0 && denied.length > 0
+            ? "Some attestations are unanswered and some are declined; all seven must be affirmed."
+            : missing.length > 0
+              ? "Some attestations are unanswered; all seven must be affirmed."
+              : "Some attestations are declined; all seven must be affirmed.",
+          { unanswered: missing, declined: denied },
+        ),
+  );
+
+  findings.push(
+    evidence.observedAuthMode === undefined
+      ? notEvaluated(
+          DECLARED_AUTH_MATCHES,
+          stamp,
+          "this run could not determine the server's authentication mode from the wire, so the declaration stands unchallenged",
+          { declared: profile.declaredAuthMode },
+        )
+      : contradicts(profile.declaredAuthMode, evidence.observedAuthMode)
+        ? violated(
+            DECLARED_AUTH_MATCHES,
+            stamp,
+            `The submission declares \`${profile.declaredAuthMode}\` but this run observed \`${evidence.observedAuthMode}\`. Correct whichever is wrong before submitting.`,
+            {
+              declared: profile.declaredAuthMode,
+              observed: evidence.observedAuthMode,
+            },
+          )
+        : satisfied(DECLARED_AUTH_MATCHES, stamp, {
+            declared: profile.declaredAuthMode,
+            observed: evidence.observedAuthMode,
+          }),
+  );
+
+  findings.push(
+    informational(
+      ARTIFACT_QUALITY,
+      stamp,
+      {
+        reviewItems: [
+          "the screenshots show this connector rather than a generic UI",
+          "the description matches what the tools actually do",
+          "the submitter owns or is authorized for the service",
+          "the privacy policy covers the declared data handling",
+        ],
+        declaredDataHandling: profile.dataHandling,
+      },
+      "These cannot be settled from the wire; a reviewer has to look.",
+    ),
+  );
+
+  return findings;
+}
+
+/**
+ * Whether a declaration and an observation genuinely conflict.
+ *
+ * Only a positive contradiction counts. `authless` declared against observed
+ * OAuth is a conflict; a declared `static-header` against an observation that
+ * saw no OAuth is not — that is exactly what a static-header server looks
+ * like from outside, and failing it would punish a truthful declaration.
+ */
+function contradicts(declared: string, observed: string): boolean {
+  if (declared === observed) return false;
+  const declaredIsOAuth = declared.startsWith("oauth-");
+  const observedIsOAuth = observed.startsWith("oauth-");
+  if (declaredIsOAuth !== observedIsOAuth) return true;
+  // Two OAuth flavours that disagree — e.g. declared `oauth-dcr` while the
+  // server offers only CIMD — is a real mismatch a reviewer will hit.
+  return declaredIsOAuth && observedIsOAuth;
+}

--- a/sdk/src/claude-readiness/checks/tools.ts
+++ b/sdk/src/claude-readiness/checks/tools.ts
@@ -1,0 +1,369 @@
+/**
+ * Tool-definition checks for the directory-policy lane.
+ *
+ * These are DETERMINISTIC reads of the tool list: a name is over 64 characters
+ * or it is not, an annotation contradicts itself or it does not. Anything that
+ * needs judgement about what a tool DOES — whether it moves money, whether its
+ * description is honest — belongs to experience-insights, not here.
+ *
+ * The catch-all rule is the one that needed the most care, and it is
+ * documented at {@link CATCH_ALL_TOOL} rather than in a summary line.
+ *
+ * Pure: takes a tool snapshot, returns findings. No transport, no client.
+ */
+
+import type { Tool } from "@modelcontextprotocol/client";
+
+import { claudePolicySource } from "../manifest.js";
+import { CLAUDE_SUBMISSION_LIMITS } from "../profile.js";
+import type { ClaudeReadinessFinding } from "../types.js";
+import {
+  notApplicable,
+  satisfied,
+  violated,
+  type ClaudeCheckDefinition,
+  type ClaudeCheckStamp,
+} from "./helpers.js";
+
+const TOOL_NAME_LENGTH: ClaudeCheckDefinition = {
+  id: "claude.tools.name-length",
+  title: "Tool names fit Claude's 64-character limit",
+  lane: "directory-policy",
+  class: "required",
+  source: claudePolicySource("review-criteria", "§Tools → Naming"),
+  provenance: "static",
+  intrusiveness: "passive",
+};
+
+const TOOL_TITLE_PRESENT: ClaudeCheckDefinition = {
+  id: "claude.tools.title-present",
+  title: "Every tool carries a human-readable title",
+  lane: "directory-policy",
+  class: "required",
+  source: claudePolicySource("review-criteria", "§Tools → Titles"),
+  provenance: "static",
+  intrusiveness: "passive",
+};
+
+const TOOL_HINTS_PRESENT: ClaudeCheckDefinition = {
+  id: "claude.tools.behavior-hints-present",
+  title: "Every tool declares its read/write behavior",
+  lane: "directory-policy",
+  class: "required",
+  source: claudePolicySource("review-criteria", "§Tools → Annotations"),
+  provenance: "static",
+  intrusiveness: "passive",
+};
+
+const TOOL_HINTS_CONSISTENT: ClaudeCheckDefinition = {
+  id: "claude.tools.behavior-hints-consistent",
+  title: "No tool declares itself both read-only and destructive",
+  lane: "directory-policy",
+  class: "required",
+  source: claudePolicySource("review-criteria", "§Tools → Annotations"),
+  provenance: "static",
+  intrusiveness: "passive",
+};
+
+const CATCH_ALL_TOOL: ClaudeCheckDefinition = {
+  id: "claude.tools.no-catch-all-read-write",
+  title: "No single tool exposes both safe and unsafe operations",
+  lane: "directory-policy",
+  class: "required",
+  source: claudePolicySource("review-criteria", "§Tools → Scope"),
+  provenance: "static",
+  intrusiveness: "passive",
+};
+
+const CATCH_ALL_FREE_STRING: ClaudeCheckDefinition = {
+  id: "claude.tools.free-string-operation-parameter",
+  title: "No tool dispatches on an unconstrained operation string",
+  lane: "experience-insights",
+  // An ADVISORY, not a requirement. See the note on the check below: an
+  // unconstrained string is a strong smell and not a demonstrated violation.
+  class: "recommended",
+  source: claudePolicySource("review-criteria", "§Tools → Scope"),
+  provenance: "static",
+  intrusiveness: "passive",
+};
+
+/**
+ * Verbs that read, and verbs that change things.
+ *
+ * Deliberately short and unambiguous. A longer list catches more real cases
+ * and also more false ones, and a false "this tool does both" accuses a
+ * submitter of a disqualifying design flaw they do not have.
+ */
+const SAFE_VERBS = ["get", "list", "read", "search", "query", "fetch", "find"];
+const UNSAFE_VERBS = [
+  "create",
+  "update",
+  "delete",
+  "write",
+  "remove",
+  "insert",
+  "upsert",
+  "send",
+  "post",
+  "put",
+  "patch",
+  "execute",
+  "drop",
+];
+
+/** Parameter names that conventionally select an operation. */
+const DISPATCH_PARAMETER_NAMES = [
+  "method",
+  "action",
+  "operation",
+  "op",
+  "command",
+  "verb",
+];
+
+interface SchemaLike {
+  type?: unknown;
+  enum?: unknown;
+  properties?: Record<string, unknown>;
+  [key: string]: unknown;
+}
+
+function asSchema(value: unknown): SchemaLike | undefined {
+  return typeof value === "object" && value !== null
+    ? (value as SchemaLike)
+    : undefined;
+}
+
+function matchesVerb(value: string, verbs: string[]): boolean {
+  const normalized = value.toLowerCase();
+  return verbs.some(
+    (verb) =>
+      normalized === verb ||
+      normalized.startsWith(`${verb}_`) ||
+      normalized.startsWith(`${verb}-`) ||
+      // `getUser`, `createOrder` — camelCase, but only at the START, so
+      // `budget` does not match `get` and `deleted_at` does not match `delete`.
+      new RegExp(`^${verb}[A-Z]`).test(value),
+  );
+}
+
+/**
+ * A tool whose schema DEMONSTRABLY accepts both a safe and an unsafe verb.
+ *
+ * "Demonstrably" is the whole rule, and it is narrow on purpose. The only
+ * evidence that settles this from a schema alone is an ENUMERATED set of
+ * operations containing verbs from both sides: the server has itself written
+ * down that this one tool does `list` and `delete`. Anything looser — a
+ * free-string `method`, a name like `manage_records`, a description that
+ * mentions deleting — is a guess, and a hard failure built on a guess tells a
+ * submitter to redesign their API on our hunch.
+ *
+ * The free-string case is not dropped; it becomes an advisory (see
+ * {@link CATCH_ALL_FREE_STRING}), which is where a strong smell belongs.
+ */
+function demonstrableVerbs(
+  tool: Tool,
+): { parameter: string; safe: string[]; unsafe: string[] } | undefined {
+  const properties = asSchema(tool.inputSchema)?.properties;
+  if (!properties) return undefined;
+
+  for (const [parameter, rawSchema] of Object.entries(properties)) {
+    const schema = asSchema(rawSchema);
+    const values = schema?.enum;
+    if (!Array.isArray(values)) continue;
+    const strings = values.filter(
+      (value): value is string => typeof value === "string",
+    );
+    const safe = strings.filter((value) => matchesVerb(value, SAFE_VERBS));
+    const unsafe = strings.filter((value) => matchesVerb(value, UNSAFE_VERBS));
+    if (safe.length > 0 && unsafe.length > 0) {
+      return { parameter, safe, unsafe };
+    }
+  }
+  return undefined;
+}
+
+/** An unconstrained string parameter whose NAME says it selects an operation. */
+function freeStringDispatch(tool: Tool): string | undefined {
+  const properties = asSchema(tool.inputSchema)?.properties;
+  if (!properties) return undefined;
+  for (const [parameter, rawSchema] of Object.entries(properties)) {
+    const schema = asSchema(rawSchema);
+    if (
+      DISPATCH_PARAMETER_NAMES.includes(parameter.toLowerCase()) &&
+      schema?.type === "string" &&
+      !Array.isArray(schema.enum)
+    ) {
+      return parameter;
+    }
+  }
+  return undefined;
+}
+
+function toolTitle(tool: Tool): string | undefined {
+  const annotations = tool.annotations as { title?: unknown } | undefined;
+  const fromAnnotations =
+    typeof annotations?.title === "string" ? annotations.title : undefined;
+  const fromTool = (tool as { title?: unknown }).title;
+  return (
+    fromAnnotations ?? (typeof fromTool === "string" ? fromTool : undefined)
+  );
+}
+
+function behaviorHints(tool: Tool): {
+  readOnly?: boolean;
+  destructive?: boolean;
+} {
+  const annotations = tool.annotations as
+    | { readOnlyHint?: unknown; destructiveHint?: unknown }
+    | undefined;
+  return {
+    readOnly:
+      typeof annotations?.readOnlyHint === "boolean"
+        ? annotations.readOnlyHint
+        : undefined,
+    destructive:
+      typeof annotations?.destructiveHint === "boolean"
+        ? annotations.destructiveHint
+        : undefined,
+  };
+}
+
+/**
+ * Run every tool check.
+ *
+ * A server with no tools gets `not-applicable` rather than a clean pass: there
+ * is nothing to grade, and reporting five satisfied requirements over an empty
+ * list would be five statements about nothing.
+ */
+export function runClaudeToolChecks(
+  tools: Tool[] | undefined,
+  stamp: ClaudeCheckStamp,
+): ClaudeReadinessFinding[] {
+  const definitions = [
+    TOOL_NAME_LENGTH,
+    TOOL_TITLE_PRESENT,
+    TOOL_HINTS_PRESENT,
+    TOOL_HINTS_CONSISTENT,
+    CATCH_ALL_TOOL,
+    CATCH_ALL_FREE_STRING,
+  ];
+
+  if (!tools || tools.length === 0) {
+    const reason = tools
+      ? "the server advertises no tools, so there is nothing to grade"
+      : "no tool listing was captured for this run";
+    return definitions.map((definition) =>
+      notApplicable(definition, stamp, reason),
+    );
+  }
+
+  const findings: ClaudeReadinessFinding[] = [];
+
+  const overlong = tools.filter(
+    (tool) => tool.name.length > CLAUDE_SUBMISSION_LIMITS.toolNameMaxLength,
+  );
+  findings.push(
+    overlong.length === 0
+      ? satisfied(TOOL_NAME_LENGTH, stamp, { toolCount: tools.length })
+      : violated(
+          TOOL_NAME_LENGTH,
+          stamp,
+          `Shorten these tool names to ${CLAUDE_SUBMISSION_LIMITS.toolNameMaxLength} characters or fewer.`,
+          { tools: overlong.map((tool) => tool.name) },
+        ),
+  );
+
+  const untitled = tools.filter((tool) => !toolTitle(tool)?.trim());
+  findings.push(
+    untitled.length === 0
+      ? satisfied(TOOL_TITLE_PRESENT, stamp)
+      : violated(
+          TOOL_TITLE_PRESENT,
+          stamp,
+          "Give each tool a `title` (or `annotations.title`) — Claude shows it to users in place of the raw tool name.",
+          { tools: untitled.map((tool) => tool.name) },
+        ),
+  );
+
+  const unhinted = tools.filter((tool) => {
+    const hints = behaviorHints(tool);
+    return hints.readOnly === undefined && hints.destructive === undefined;
+  });
+  findings.push(
+    unhinted.length === 0
+      ? satisfied(TOOL_HINTS_PRESENT, stamp)
+      : violated(
+          TOOL_HINTS_PRESENT,
+          stamp,
+          "Set `annotations.readOnlyHint` or `annotations.destructiveHint` on each tool so Claude can tell which calls need confirmation.",
+          { tools: unhinted.map((tool) => tool.name) },
+        ),
+  );
+
+  // Presence and CONSISTENCY are separate checks. A tool can carry both hints
+  // and still be self-contradictory, and collapsing the two would let a
+  // contradiction pass as "annotated".
+  const contradictory = tools.filter((tool) => {
+    const hints = behaviorHints(tool);
+    return hints.readOnly === true && hints.destructive === true;
+  });
+  findings.push(
+    contradictory.length === 0
+      ? satisfied(TOOL_HINTS_CONSISTENT, stamp)
+      : violated(
+          TOOL_HINTS_CONSISTENT,
+          stamp,
+          "A tool cannot be both read-only and destructive; clear whichever hint is wrong.",
+          { tools: contradictory.map((tool) => tool.name) },
+        ),
+  );
+
+  const catchAll = tools
+    .map((tool) => ({ tool, evidence: demonstrableVerbs(tool) }))
+    .filter(
+      (entry): entry is { tool: Tool; evidence: NonNullable<typeof entry.evidence> } =>
+        entry.evidence !== undefined,
+    );
+  findings.push(
+    catchAll.length === 0
+      ? satisfied(CATCH_ALL_TOOL, stamp)
+      : violated(
+          CATCH_ALL_TOOL,
+          stamp,
+          "Split these tools so a single call cannot be either a read or a write — Claude's confirmation model annotates whole tools, not individual arguments.",
+          {
+            tools: catchAll.map((entry) => ({
+              name: entry.tool.name,
+              parameter: entry.evidence.parameter,
+              safeValues: entry.evidence.safe,
+              unsafeValues: entry.evidence.unsafe,
+            })),
+          },
+        ),
+  );
+
+  const freeString = tools
+    .map((tool) => ({ tool, parameter: freeStringDispatch(tool) }))
+    .filter(
+      (entry): entry is { tool: Tool; parameter: string } =>
+        entry.parameter !== undefined,
+    );
+  findings.push(
+    freeString.length === 0
+      ? satisfied(CATCH_ALL_FREE_STRING, stamp)
+      : violated(
+          CATCH_ALL_FREE_STRING,
+          stamp,
+          "Constrain these operation parameters to an enum. As an open string, neither Claude nor this check can tell whether the tool performs a safe or an unsafe action.",
+          {
+            tools: freeString.map((entry) => ({
+              name: entry.tool.name,
+              parameter: entry.parameter,
+            })),
+          },
+        ),
+  );
+
+  return findings;
+}

--- a/sdk/src/claude-readiness/checks/tools.ts
+++ b/sdk/src/claude-readiness/checks/tools.ts
@@ -143,8 +143,11 @@ function matchesVerb(value: string, verbs: string[]): boolean {
       normalized.startsWith(`${verb}_`) ||
       normalized.startsWith(`${verb}-`) ||
       // `getUser`, `createOrder` — camelCase, but only at the START, so
-      // `budget` does not match `get` and `deleted_at` does not match `delete`.
-      new RegExp(`^${verb}[A-Z]`).test(value),
+      // `budget` does not match `get` and `deleted_at` does not match
+      // `delete`. A direct character test rather than a `new RegExp` built on
+      // every comparison.
+      (normalized.startsWith(verb) &&
+        /[A-Z]/.test(value.charAt(verb.length))),
   );
 }
 
@@ -201,14 +204,15 @@ function freeStringDispatch(tool: Tool): string | undefined {
   return undefined;
 }
 
+/**
+ * The tool's display name, in the precedence MCP defines: top-level `title`,
+ * then `annotations.title`, then the raw `name` (which the caller handles).
+ */
 function toolTitle(tool: Tool): string | undefined {
-  const annotations = tool.annotations as { title?: unknown } | undefined;
-  const fromAnnotations =
-    typeof annotations?.title === "string" ? annotations.title : undefined;
   const fromTool = (tool as { title?: unknown }).title;
-  return (
-    fromAnnotations ?? (typeof fromTool === "string" ? fromTool : undefined)
-  );
+  if (typeof fromTool === "string") return fromTool;
+  const annotations = tool.annotations as { title?: unknown } | undefined;
+  return typeof annotations?.title === "string" ? annotations.title : undefined;
 }
 
 function behaviorHints(tool: Tool): {

--- a/sdk/src/claude-readiness/checks/tools.ts
+++ b/sdk/src/claude-readiness/checks/tools.ts
@@ -19,6 +19,7 @@ import { CLAUDE_SUBMISSION_LIMITS } from "../profile.js";
 import type { ClaudeReadinessFinding } from "../types.js";
 import {
   notApplicable,
+  notEvaluated,
   satisfied,
   violated,
   type ClaudeCheckDefinition,
@@ -249,12 +250,24 @@ export function runClaudeToolChecks(
     CATCH_ALL_FREE_STRING,
   ];
 
-  if (!tools || tools.length === 0) {
-    const reason = tools
-      ? "the server advertises no tools, so there is nothing to grade"
-      : "no tool listing was captured for this run";
+  // THESE TWO ARE NOT THE SAME THING, and collapsing them is how a coverage
+  // gap gets reported as a clean lane. A server that advertises no tools has
+  // nothing that could violate a tool requirement — genuinely inapplicable. A
+  // run that never captured the listing has an untested obligation, and saying
+  // "not applicable" there would claim we established something we never
+  // looked at.
+  if (!tools) {
     return definitions.map((definition) =>
-      notApplicable(definition, stamp, reason),
+      notEvaluated(definition, stamp, "no tool listing was captured for this run"),
+    );
+  }
+  if (tools.length === 0) {
+    return definitions.map((definition) =>
+      notApplicable(
+        definition,
+        stamp,
+        "the server advertises no tools, so there is nothing to grade",
+      ),
     );
   }
 

--- a/sdk/src/claude-readiness/discovery.ts
+++ b/sdk/src/claude-readiness/discovery.ts
@@ -326,12 +326,19 @@ async function discoverProtectedResourceMetadata(
     };
   }
 
-  let lastError: string | undefined = rejectedPointer
-    ? `the challenge's resource_metadata pointer was refused: it must be an http(s) URL on the connector's own origin`
+  // The refusal is a SEPARATE fact from whatever the fallback attempts
+  // report, and it must not be overwritten by them: a server that published an
+  // off-origin pointer AND has no well-known document has two problems, and a
+  // report that mentions only the second sends the submitter to the wrong one.
+  const rejectionNote = rejectedPointer
+    ? `the challenge's resource_metadata pointer was refused (it must be an http(s) URL on the connector's own origin)`
     : undefined;
+  let lastError: string | undefined;
   for (const attempt of attempts) {
     const result = await fetchJson(attempt.url, options);
     if (result.status >= 200 && result.status < 300 && result.document) {
+      // `rejectedPointer` rides along on SUCCESS too: the fallback worked, and
+      // the server still published a pointer no conforming client can follow.
       return {
         discoveredVia: attempt.step,
         url: attempt.url,
@@ -341,7 +348,11 @@ async function discoverProtectedResourceMetadata(
     }
     lastError = result.error ?? `${attempt.url} answered ${result.status}`;
   }
-  return { discoveredVia: "not-found", fetchError: lastError, rejectedPointer };
+  return {
+    discoveredVia: "not-found",
+    fetchError: [rejectionNote, lastError].filter(Boolean).join("; ") || undefined,
+    rejectedPointer,
+  };
 }
 
 /**

--- a/sdk/src/claude-readiness/discovery.ts
+++ b/sdk/src/claude-readiness/discovery.ts
@@ -106,6 +106,73 @@ interface FetchedJson {
   error?: string;
 }
 
+/**
+ * The JSON-RPC message carried by one SSE event, if it carries one.
+ *
+ * `data:` may be repeated within an event, and the payload is the lines joined
+ * with newlines — which is exactly how a pretty-printed JSON body arrives.
+ */
+function parseSseEventData(event: string): Record<string, unknown> | undefined {
+  const data = event
+    .split(/\r?\n/)
+    .filter((line) => line.startsWith("data:"))
+    .map((line) => line.slice("data:".length).trimStart())
+    .join("\n");
+  if (!data) return undefined;
+  try {
+    const parsed: unknown = JSON.parse(data);
+    return typeof parsed === "object" && parsed !== null && !Array.isArray(parsed)
+      ? (parsed as Record<string, unknown>)
+      : undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+/**
+ * Read an SSE response only as far as its first JSON-RPC message, then stop.
+ *
+ * Stopping is the point: the server is entitled to hold the stream open after
+ * answering, so reading to `done` would hang until the probe's timeout and
+ * report a healthy connector as unreachable. The byte cap still applies, so a
+ * stream that never produces a parseable event cannot run away either.
+ */
+async function readSseJsonRpc(
+  response: Response,
+): Promise<Record<string, unknown> | undefined> {
+  const body = response.body;
+  if (!body || typeof body.getReader !== "function") return undefined;
+
+  const reader = body.getReader();
+  const decoder = new TextDecoder();
+  let buffered = "";
+  let received = 0;
+  try {
+    for (;;) {
+      const { done, value } = await reader.read();
+      if (done) break;
+      if (!value) continue;
+      received += value.byteLength;
+      if (received > MAX_METADATA_BYTES) return undefined;
+      buffered += decoder.decode(value, { stream: true });
+
+      // Events are separated by a blank line; CRLF is as legal as LF.
+      const events = buffered.split(/\r?\n\r?\n/);
+      // The trailing segment is whatever has not been terminated yet.
+      buffered = events.pop() ?? "";
+      for (const event of events) {
+        const document = parseSseEventData(event);
+        if (document) return document;
+      }
+    }
+    // A stream that closed without a final blank line still left one event.
+    return parseSseEventData(buffered);
+  } finally {
+    await reader.cancel().catch(() => undefined);
+    reader.releaseLock?.();
+  }
+}
+
 async function fetchJson(
   url: string,
   options: ClaudeDiscoveryOptions,
@@ -135,6 +202,21 @@ async function fetchJson(
         status: response.status,
         headers: response.headers,
         error: `metadata document declared ${declaredLength} bytes, over the ${MAX_METADATA_BYTES}-byte cap`,
+      };
+    }
+    // AN SSE ANSWER IS A CONFORMING ANSWER. MCP's Streamable HTTP transport
+    // lets a server reply to a POST with either `application/json` or
+    // `text/event-stream`, and the unauthenticated probe advertises both — so
+    // reading an SSE reply as JSON would fail twice: the frames do not parse,
+    // making a working connector look like one that never answered, and the
+    // stream is allowed to stay open, so the read would block until the
+    // probe's own timeout fired rather than returning what already arrived.
+    const contentType = (response.headers.get("content-type") ?? "").toLowerCase();
+    if (contentType.includes("text/event-stream")) {
+      return {
+        status: response.status,
+        headers: response.headers,
+        document: await readSseJsonRpc(response),
       };
     }
     const text = await readBounded(response);

--- a/sdk/src/claude-readiness/discovery.ts
+++ b/sdk/src/claude-readiness/discovery.ts
@@ -1,0 +1,341 @@
+/**
+ * Evidence gathering: the only part of readiness that touches the network.
+ *
+ * WHY IT IS SEPARATE. Every check module in `checks/` is a pure function over
+ * evidence, which makes each one testable against a fixture and — more
+ * importantly — makes it structurally impossible for a check to dial a target
+ * on its own. In a hosted run the ONLY transport allowed out is the pinned one,
+ * and "the checks cannot reach the network" is a much stronger guarantee than
+ * "the checks are careful about it".
+ *
+ * WHAT IT DOES. Metadata only: an unauthenticated probe, RFC 9728 Protected
+ * Resource Metadata discovery in the documented order, and one authorization
+ * server metadata document. Nothing here registers a client, spends a grant,
+ * or writes anything. Side-effecting probes live behind the intrusive opt-in
+ * and are not in this module.
+ *
+ * `fetchFn` is required rather than defaulted to the global fetch. A default
+ * would make "forgot to pass the guard" the silent case, and the silent case
+ * is the one that reaches `169.254.169.254`.
+ */
+
+import { parseBearerAuthenticateParameters } from "../oauth/state-machines/shared/challenges.js";
+import type {
+  ClaudeAuthEvidence,
+  ClaudePrmDiscoveryStep,
+} from "./checks/auth.js";
+import type {
+  ClaudeEndpointEvidence,
+  ClaudeRedirectHop,
+} from "./checks/endpoint.js";
+
+export interface ClaudeDiscoveryOptions {
+  /** The connector URL exactly as the user entered it. Never canonicalized. */
+  enteredUrl: string;
+  /**
+   * The transport. REQUIRED — in a hosted run this must be the DNS-pinned one,
+   * and a default would make the unguarded case the easy one to reach.
+   */
+  fetchFn: typeof fetch;
+  /** Per-request budget. The caller owns the run-level deadline. */
+  timeoutMs?: number;
+  /** Redirect hops to walk while tracing the endpoint. */
+  maxRedirects?: number;
+  /** Headers the connector needs, e.g. a static credential under test. */
+  headers?: Record<string, string>;
+}
+
+const DEFAULT_TIMEOUT_MS = 15_000;
+const DEFAULT_MAX_REDIRECTS = 5;
+
+/** Body caps for documents we only ever parse as small JSON. */
+const MAX_METADATA_BYTES = 512 * 1024;
+
+interface FetchedJson {
+  status: number;
+  headers: Headers;
+  document?: Record<string, unknown>;
+  error?: string;
+}
+
+async function fetchJson(
+  url: string,
+  options: ClaudeDiscoveryOptions,
+  init?: RequestInit,
+): Promise<FetchedJson> {
+  const controller = new AbortController();
+  const timer = setTimeout(
+    () => controller.abort(new Error("readiness discovery timed out")),
+    options.timeoutMs ?? DEFAULT_TIMEOUT_MS,
+  );
+  try {
+    const response = await options.fetchFn(url, {
+      ...init,
+      headers: { accept: "application/json", ...options.headers, ...init?.headers },
+      signal: controller.signal,
+    });
+    const text = await response.text();
+    if (text.length > MAX_METADATA_BYTES) {
+      return {
+        status: response.status,
+        headers: response.headers,
+        error: `metadata document exceeded ${MAX_METADATA_BYTES} bytes`,
+      };
+    }
+    let document: Record<string, unknown> | undefined;
+    try {
+      const parsed: unknown = text ? JSON.parse(text) : undefined;
+      document =
+        typeof parsed === "object" && parsed !== null && !Array.isArray(parsed)
+          ? (parsed as Record<string, unknown>)
+          : undefined;
+    } catch {
+      document = undefined;
+    }
+    return { status: response.status, headers: response.headers, document };
+  } catch (error) {
+    return {
+      status: 0,
+      headers: new Headers(),
+      error: error instanceof Error ? error.message : String(error),
+    };
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
+/**
+ * Walk the connector URL's redirect chain by hand.
+ *
+ * The transport follows redirects internally and reports only where it landed;
+ * the endpoint checks need each HOP, because a chain that downgrades in the
+ * middle and recovers is invisible from the destination alone.
+ */
+export async function traceConnectorRedirects(
+  options: ClaudeDiscoveryOptions,
+): Promise<ClaudeEndpointEvidence> {
+  const maxRedirects = options.maxRedirects ?? DEFAULT_MAX_REDIRECTS;
+  const chain: ClaudeRedirectHop[] = [];
+  let current = options.enteredUrl;
+
+  for (let hop = 0; hop <= maxRedirects; hop += 1) {
+    const controller = new AbortController();
+    const timer = setTimeout(
+      () => controller.abort(new Error("readiness redirect trace timed out")),
+      options.timeoutMs ?? DEFAULT_TIMEOUT_MS,
+    );
+    let response: Response;
+    try {
+      response = await options.fetchFn(current, {
+        method: "HEAD",
+        redirect: "manual",
+        headers: options.headers,
+        signal: controller.signal,
+      });
+    } catch {
+      // A refused or unreachable hop ends the trace. It is not itself a
+      // redirect finding — the connectivity failure surfaces elsewhere — and
+      // reporting a partial chain is better than reporting none.
+      return { enteredUrl: options.enteredUrl, redirectChain: chain };
+    } finally {
+      clearTimeout(timer);
+    }
+
+    const location = response.headers.get("location") ?? undefined;
+    chain.push({ url: current, status: response.status, location });
+    if (!location || response.status < 300 || response.status >= 400) {
+      return { enteredUrl: options.enteredUrl, redirectChain: chain };
+    }
+    try {
+      current = new URL(location, current).toString();
+    } catch {
+      return { enteredUrl: options.enteredUrl, redirectChain: chain };
+    }
+  }
+
+  return {
+    enteredUrl: options.enteredUrl,
+    redirectChain: chain,
+    redirectLimitHit: true,
+  };
+}
+
+/**
+ * The unauthenticated probe: a JSON-RPC `initialize` with no credentials.
+ *
+ * `initialize` rather than a bare GET because it is the request Claude
+ * actually makes first, so the response is the one Claude actually sees. It
+ * creates no resources and consumes nothing beyond a session the server is
+ * free to discard.
+ */
+async function probeUnauthenticated(
+  options: ClaudeDiscoveryOptions,
+): Promise<ClaudeAuthEvidence["unauthenticated"]> {
+  const result = await fetchJson(options.enteredUrl, options, {
+    method: "POST",
+    headers: {
+      "content-type": "application/json",
+      accept: "application/json, text/event-stream",
+    },
+    body: JSON.stringify({
+      jsonrpc: "2.0",
+      id: 1,
+      method: "initialize",
+      params: {
+        protocolVersion: "2025-06-18",
+        capabilities: {},
+        clientInfo: { name: "mcpjam-claude-readiness", version: "1" },
+      },
+    }),
+  });
+
+  if (result.status === 0) return undefined;
+
+  // "Served without credentials" means the server answered the MCP request,
+  // not merely that it answered with a 200 — an HTML error page is a 200 too.
+  const servedWithoutCredentials =
+    result.status >= 200 &&
+    result.status < 300 &&
+    (result.document?.result !== undefined || result.document?.error !== undefined);
+
+  return {
+    status: result.status,
+    wwwAuthenticate: result.headers.get("www-authenticate") ?? undefined,
+    // The probe IS an attempted protected operation: `initialize` is the call
+    // Claude makes to use the connector, so a challenge riding on a successful
+    // one is the mixed signal the check is about.
+    representsProtectedOperation: true,
+    servedWithoutCredentials,
+  };
+}
+
+/**
+ * RFC 9728 discovery, in the order a client is required to try.
+ *
+ * The order is the requirement, not an optimisation: a server that publishes
+ * PRM only at the ROOT well-known path, while serving the connector at a
+ * sub-path, is discoverable by a client that tries the root and invisible to
+ * one that stops at the path-suffixed form. Recording WHICH step answered is
+ * what lets the report tell a submitter their metadata is reachable only by
+ * luck.
+ */
+async function discoverProtectedResourceMetadata(
+  options: ClaudeDiscoveryOptions,
+  challengePointer: string | undefined,
+): Promise<ClaudeAuthEvidence["prm"]> {
+  const attempts: Array<{ step: ClaudePrmDiscoveryStep; url: string }> = [];
+  if (challengePointer) {
+    try {
+      attempts.push({
+        step: "www-authenticate",
+        url: new URL(challengePointer, options.enteredUrl).toString(),
+      });
+    } catch {
+      // A malformed pointer is itself a finding, raised by the challenge
+      // check; here it simply does not produce an attempt.
+    }
+  }
+  try {
+    const base = new URL(options.enteredUrl);
+    const path = base.pathname.replace(/\/$/, "");
+    attempts.push({
+      step: "well-known-path-suffixed",
+      url: `${base.origin}/.well-known/oauth-protected-resource${path}`,
+    });
+    attempts.push({
+      step: "well-known-root",
+      url: `${base.origin}/.well-known/oauth-protected-resource`,
+    });
+  } catch {
+    return { discoveredVia: "not-found", fetchError: "connector URL is not parseable" };
+  }
+
+  let lastError: string | undefined;
+  for (const attempt of attempts) {
+    const result = await fetchJson(attempt.url, options);
+    if (result.status >= 200 && result.status < 300 && result.document) {
+      return {
+        discoveredVia: attempt.step,
+        url: attempt.url,
+        document: result.document,
+      };
+    }
+    lastError = result.error ?? `${attempt.url} answered ${result.status}`;
+  }
+  return { discoveredVia: "not-found", fetchError: lastError };
+}
+
+/**
+ * Metadata for `authorization_servers[0]` and nothing else.
+ *
+ * Probing every entry would grade a client that falls back. Claude does not,
+ * so a runner that looked past entry zero would report a connector as healthy
+ * that Claude cannot use.
+ */
+async function fetchFirstAuthorizationServer(
+  options: ClaudeDiscoveryOptions,
+  issuer: string | undefined,
+): Promise<ClaudeAuthEvidence["firstAuthorizationServer"]> {
+  if (!issuer) return undefined;
+
+  let base: URL;
+  try {
+    base = new URL(issuer);
+  } catch {
+    return { issuer, reachable: false, fetchError: "issuer is not a valid URL" };
+  }
+
+  const path = base.pathname.replace(/\/$/, "");
+  const candidates = [
+    `${base.origin}/.well-known/oauth-authorization-server${path}`,
+    `${base.origin}/.well-known/openid-configuration${path}`,
+    `${base.origin}${path}/.well-known/openid-configuration`,
+  ];
+
+  let lastError: string | undefined;
+  for (const url of candidates) {
+    const result = await fetchJson(url, options);
+    if (result.status >= 200 && result.status < 300 && result.document) {
+      return { issuer, metadataUrl: url, reachable: true, document: result.document };
+    }
+    lastError = result.error ?? `${url} answered ${result.status}`;
+  }
+  return { issuer, reachable: false, fetchError: lastError };
+}
+
+/**
+ * Gather everything the non-invasive auth checks need, in one pass.
+ *
+ * Ordering is causal rather than parallel: the challenge names the metadata
+ * document, and the metadata document names the authorization server. Firing
+ * these concurrently would mean guessing the well-known paths even when the
+ * server told us where to look.
+ */
+export async function discoverClaudeAuthEvidence(
+  options: ClaudeDiscoveryOptions,
+  extras: Pick<ClaudeAuthEvidence, "declaredAuthMode" | "accessTokenAudience"> = {},
+): Promise<ClaudeAuthEvidence> {
+  const unauthenticated = await probeUnauthenticated(options);
+  const challengePointer = parseBearerAuthenticateParameters(
+    unauthenticated?.wwwAuthenticate,
+  ).resource_metadata;
+
+  const prm = await discoverProtectedResourceMetadata(options, challengePointer);
+  const authorizationServers = Array.isArray(prm?.document?.authorization_servers)
+    ? (prm.document.authorization_servers as unknown[]).filter(
+        (entry): entry is string => typeof entry === "string",
+      )
+    : [];
+  const firstAuthorizationServer = await fetchFirstAuthorizationServer(
+    options,
+    authorizationServers[0],
+  );
+
+  return {
+    enteredUrl: options.enteredUrl,
+    unauthenticated,
+    prm,
+    firstAuthorizationServer,
+    ...extras,
+  };
+}

--- a/sdk/src/claude-readiness/discovery.ts
+++ b/sdk/src/claude-readiness/discovery.ts
@@ -51,6 +51,54 @@ const DEFAULT_MAX_REDIRECTS = 5;
 /** Body caps for documents we only ever parse as small JSON. */
 const MAX_METADATA_BYTES = 512 * 1024;
 
+/**
+ * Read a response body, stopping at the cap.
+ *
+ * Returns `undefined` rather than a truncated string: a half-read JSON
+ * document is not a smaller document, it is a parse error dressed as data.
+ * Counts BYTES, because `String.length` counts UTF-16 code units and a
+ * document of multi-byte characters would sail past a cap named in bytes.
+ *
+ * Falls back to `text()` when the body is not a stream (a mocked `fetchFn`
+ * frequently returns a plain `Response`), and re-measures there.
+ */
+async function readBounded(response: Response): Promise<string | undefined> {
+  const body = response.body;
+  if (!body || typeof body.getReader !== "function") {
+    const text = await response.text();
+    return new TextEncoder().encode(text).length > MAX_METADATA_BYTES
+      ? undefined
+      : text;
+  }
+
+  const reader = body.getReader();
+  const chunks: Uint8Array[] = [];
+  let received = 0;
+  try {
+    for (;;) {
+      const { done, value } = await reader.read();
+      if (done) break;
+      if (!value) continue;
+      received += value.byteLength;
+      if (received > MAX_METADATA_BYTES) {
+        await reader.cancel().catch(() => undefined);
+        return undefined;
+      }
+      chunks.push(value);
+    }
+  } finally {
+    reader.releaseLock?.();
+  }
+
+  const joined = new Uint8Array(received);
+  let offset = 0;
+  for (const chunk of chunks) {
+    joined.set(chunk, offset);
+    offset += chunk.byteLength;
+  }
+  return new TextDecoder().decode(joined);
+}
+
 interface FetchedJson {
   status: number;
   headers: Headers;
@@ -74,8 +122,23 @@ async function fetchJson(
       headers: { accept: "application/json", ...options.headers, ...init?.headers },
       signal: controller.signal,
     });
-    const text = await response.text();
-    if (text.length > MAX_METADATA_BYTES) {
+    // REFUSE BEFORE READING when the server tells us the size. `await
+    // response.text()` materializes the whole body first, so a cap applied
+    // afterwards limits what is PARSED and not what is read — a hostile or
+    // misconfigured endpoint could exhaust memory before the guard ran. In a
+    // hosted run the pinned transport enforces its own decompressed-byte
+    // ceiling, but this function accepts any `fetchFn`, so the guarantee has
+    // to hold here too.
+    const declaredLength = Number(response.headers.get("content-length"));
+    if (Number.isFinite(declaredLength) && declaredLength > MAX_METADATA_BYTES) {
+      return {
+        status: response.status,
+        headers: response.headers,
+        error: `metadata document declared ${declaredLength} bytes, over the ${MAX_METADATA_BYTES}-byte cap`,
+      };
+    }
+    const text = await readBounded(response);
+    if (text === undefined) {
       return {
         status: response.status,
         headers: response.headers,
@@ -224,15 +287,24 @@ async function discoverProtectedResourceMetadata(
   challengePointer: string | undefined,
 ): Promise<ClaudeAuthEvidence["prm"]> {
   const attempts: Array<{ step: ClaudePrmDiscoveryStep; url: string }> = [];
+  let rejectedPointer: string | undefined;
   if (challengePointer) {
-    try {
-      attempts.push({
-        step: "www-authenticate",
-        url: new URL(challengePointer, options.enteredUrl).toString(),
-      });
-    } catch {
-      // A malformed pointer is itself a finding, raised by the challenge
-      // check; here it simply does not produce an attempt.
+    // THE POINTER IS ATTACKER-CONTROLLED. It arrives in a `WWW-Authenticate`
+    // header from the server under test, and `new URL()` will happily accept
+    // `http://169.254.169.254/…` or a `file:` URL. In a hosted run the pinned
+    // transport would refuse it, but this module accepts any `fetchFn`, so the
+    // pointer is validated here rather than trusted to the caller's transport.
+    //
+    // Same origin is not an arbitrary narrowing: RFC 9728 constructs the
+    // metadata URL from the resource identifier itself, and requires the
+    // document's `resource` to equal the request URL. A pointer to another
+    // origin cannot satisfy that, so following it could only ever produce a
+    // document we would then reject.
+    const resolved = resolvePointer(challengePointer, options.enteredUrl);
+    if (resolved) {
+      attempts.push({ step: "www-authenticate", url: resolved });
+    } else {
+      rejectedPointer = challengePointer;
     }
   }
   try {
@@ -247,10 +319,16 @@ async function discoverProtectedResourceMetadata(
       url: `${base.origin}/.well-known/oauth-protected-resource`,
     });
   } catch {
-    return { discoveredVia: "not-found", fetchError: "connector URL is not parseable" };
+    return {
+      discoveredVia: "not-found",
+      fetchError: "connector URL is not parseable",
+      rejectedPointer,
+    };
   }
 
-  let lastError: string | undefined;
+  let lastError: string | undefined = rejectedPointer
+    ? `the challenge's resource_metadata pointer was refused: it must be an http(s) URL on the connector's own origin`
+    : undefined;
   for (const attempt of attempts) {
     const result = await fetchJson(attempt.url, options);
     if (result.status >= 200 && result.status < 300 && result.document) {
@@ -258,11 +336,35 @@ async function discoverProtectedResourceMetadata(
         discoveredVia: attempt.step,
         url: attempt.url,
         document: result.document,
+        rejectedPointer,
       };
     }
     lastError = result.error ?? `${attempt.url} answered ${result.status}`;
   }
-  return { discoveredVia: "not-found", fetchError: lastError };
+  return { discoveredVia: "not-found", fetchError: lastError, rejectedPointer };
+}
+
+/**
+ * Resolve a `resource_metadata` pointer, or refuse it.
+ *
+ * Refuses anything that is not http(s), and anything off the connector's own
+ * origin. Returns `undefined` for a refusal so the caller can report it rather
+ * than silently continuing to the well-known paths as if no pointer existed.
+ */
+function resolvePointer(pointer: string, enteredUrl: string): string | undefined {
+  let resolved: URL;
+  let base: URL;
+  try {
+    base = new URL(enteredUrl);
+    resolved = new URL(pointer, enteredUrl);
+  } catch {
+    return undefined;
+  }
+  if (resolved.protocol !== "https:" && resolved.protocol !== "http:") {
+    return undefined;
+  }
+  if (resolved.origin !== base.origin) return undefined;
+  return resolved.toString();
 }
 
 /**

--- a/sdk/src/claude-readiness/html-scan.ts
+++ b/sdk/src/claude-readiness/html-scan.ts
@@ -1,0 +1,182 @@
+/**
+ * A minimal HTML scanner for the design-guideline lints.
+ *
+ * WHY NOT REGEXES. The lints ask structural questions — "does this widget have
+ * interactive elements", "does anything set a minimum touch target" — and
+ * answering them with `/<(button|a)\b/i` over raw markup is wrong twice over.
+ * It matches a `<button>` written inside an HTML comment or a JavaScript
+ * string, which produces confident nonsense about a widget that has no button
+ * at all; and it is exactly the shape static analysis flags as an incomplete
+ * tag filter, because that is what it is.
+ *
+ * A scanner answers the same questions correctly and cheaply. It is not an
+ * HTML parser: no tree, no error recovery, no entity handling beyond the
+ * obvious. It knows which tags appear, which attributes are used, and what the
+ * `<style>` blocks contain — which is the whole of what the lints need.
+ *
+ * Pure data. Safe from the browser entry.
+ */
+
+/** What one pass over a widget's markup establishes. */
+export interface ScannedHtml {
+  /** Lowercased tag names that appear as real elements. */
+  tags: Set<string>;
+  /** Lowercased attribute names that appear on any element. */
+  attributes: Set<string>;
+  /** Concatenated contents of every `<style>` element. */
+  styleText: string;
+  /** Concatenated contents of every `<script>` element. */
+  scriptText: string;
+}
+
+const RAW_TEXT_ELEMENTS = new Set(["script", "style"]);
+
+/** Is this the start of a doctype declaration? A prefix test, not a pattern. */
+function isDoctypeAt(html: string, at: number): boolean {
+  return html.slice(at, at + 9).toLowerCase() === "<!doctype";
+}
+
+function isNameChar(char: string): boolean {
+  return (
+    (char >= "a" && char <= "z") ||
+    (char >= "A" && char <= "Z") ||
+    (char >= "0" && char <= "9") ||
+    char === "-" ||
+    char === "_" ||
+    char === ":"
+  );
+}
+
+function isSpace(char: string): boolean {
+  return char === " " || char === "\t" || char === "\n" || char === "\r" || char === "\f";
+}
+
+/**
+ * Scan a widget's markup once.
+ *
+ * Comments and raw-text element bodies are skipped rather than searched, so a
+ * `<button>` mentioned in a comment or built inside a script string never
+ * appears in `tags` — which is the false positive the regexes it replaces
+ * produced.
+ */
+export function scanHtml(html: string): ScannedHtml {
+  const tags = new Set<string>();
+  const attributes = new Set<string>();
+  const styleParts: string[] = [];
+  const scriptParts: string[] = [];
+
+  let index = 0;
+  while (index < html.length) {
+    const lt = html.indexOf("<", index);
+    if (lt === -1) break;
+
+    if (html.startsWith("<!--", lt)) {
+      const end = html.indexOf("-->", lt + 4);
+      index = end === -1 ? html.length : end + 3;
+      continue;
+    }
+    if (isDoctypeAt(html, lt)) {
+      const end = html.indexOf(">", lt + 2);
+      index = end === -1 ? html.length : end + 1;
+      continue;
+    }
+
+    let cursor = lt + 1;
+    const closing = html[cursor] === "/";
+    if (closing) cursor += 1;
+
+    const nameStart = cursor;
+    while (cursor < html.length && isNameChar(html[cursor])) cursor += 1;
+    if (cursor === nameStart) {
+      // A `<` that opens nothing — "a < b" in prose.
+      index = lt + 1;
+      continue;
+    }
+    const name = html.slice(nameStart, cursor).toLowerCase();
+    if (!closing) tags.add(name);
+
+    // Walk the attributes, quote-aware, to the tag's real end.
+    let quote: string | undefined;
+    let attributeStart = -1;
+    let selfClosing = false;
+    while (cursor < html.length) {
+      const char = html[cursor];
+      if (quote) {
+        if (char === quote) quote = undefined;
+      } else if (char === '"' || char === "'") {
+        quote = char;
+      } else if (char === ">") {
+        selfClosing = html[cursor - 1] === "/";
+        cursor += 1;
+        break;
+      } else if (!closing) {
+        if (attributeStart === -1 && isNameChar(char) && isSpace(html[cursor - 1])) {
+          attributeStart = cursor;
+        } else if (attributeStart !== -1 && !isNameChar(char)) {
+          attributes.add(html.slice(attributeStart, cursor).toLowerCase());
+          attributeStart = -1;
+        }
+      }
+      cursor += 1;
+    }
+    if (attributeStart !== -1) {
+      attributes.add(html.slice(attributeStart, cursor).toLowerCase());
+    }
+
+    if (closing || selfClosing || !RAW_TEXT_ELEMENTS.has(name)) {
+      index = cursor;
+      continue;
+    }
+
+    // Raw-text element: capture its body and skip past the end tag, tolerating
+    // `</style >` and refusing to stop at `</styles>`.
+    const lower = html.toLowerCase();
+    const needle = `</${name}`;
+    let search = cursor;
+    let bodyEnd = html.length;
+    let resumeAt = html.length;
+    for (;;) {
+      const at = lower.indexOf(needle, search);
+      if (at === -1) break;
+      const after = html[at + needle.length];
+      if (after === undefined || after === ">" || isSpace(after)) {
+        bodyEnd = at;
+        const close = html.indexOf(">", at);
+        resumeAt = close === -1 ? html.length : close + 1;
+        break;
+      }
+      search = at + needle.length;
+    }
+    const body = html.slice(cursor, bodyEnd);
+    if (name === "style") styleParts.push(body);
+    else scriptParts.push(body);
+    index = resumeAt;
+  }
+
+  return {
+    tags,
+    attributes,
+    styleText: styleParts.join("\n"),
+    scriptText: scriptParts.join("\n"),
+  };
+}
+
+/** Whether the markup contains any element a user can interact with. */
+export function hasInteractiveElement(scanned: ScannedHtml): boolean {
+  return (
+    scanned.tags.has("button") ||
+    scanned.tags.has("a") ||
+    scanned.tags.has("input") ||
+    scanned.tags.has("select") ||
+    scanned.tags.has("textarea")
+  );
+}
+
+/** Whether any element carries an ARIA attribute or an explicit role. */
+export function hasAccessibilityAffordance(scanned: ScannedHtml): boolean {
+  if (scanned.attributes.has("role")) return true;
+  for (const attribute of scanned.attributes) {
+    if (attribute.startsWith("aria-")) return true;
+  }
+  return false;
+}

--- a/sdk/src/claude-readiness/html-scan.ts
+++ b/sdk/src/claude-readiness/html-scan.ts
@@ -23,7 +23,15 @@ export interface ScannedHtml {
   tags: Set<string>;
   /** Lowercased attribute names that appear on any element. */
   attributes: Set<string>;
-  /** Concatenated contents of every `<style>` element. */
+  /**
+   * Every declaration the document carries: `<style>` bodies AND the value of
+   * every inline `style` attribute.
+   *
+   * Both, because a widget written as `<button style="min-height: 44px">`
+   * satisfies the touch-target guideline exactly as well as one with a
+   * stylesheet — and a lint that only read `<style>` blocks would report a
+   * violation the author already fixed.
+   */
   styleText: string;
   /** Concatenated contents of every `<script>` element. */
   scriptText: string;
@@ -113,7 +121,12 @@ export function scanHtml(html: string): ScannedHtml {
         if (attributeStart === -1 && isNameChar(char) && isSpace(html[cursor - 1])) {
           attributeStart = cursor;
         } else if (attributeStart !== -1 && !isNameChar(char)) {
-          attributes.add(html.slice(attributeStart, cursor).toLowerCase());
+          const attributeName = html.slice(attributeStart, cursor).toLowerCase();
+          attributes.add(attributeName);
+          if (attributeName === "style") {
+            const value = readAttributeValue(html, cursor);
+            if (value) styleParts.push(value);
+          }
           attributeStart = -1;
         }
       }
@@ -159,6 +172,31 @@ export function scanHtml(html: string): ScannedHtml {
     styleText: styleParts.join("\n"),
     scriptText: scriptParts.join("\n"),
   };
+}
+
+/**
+ * Read an attribute's value, starting at the character after its name.
+ *
+ * Returns `undefined` for a valueless attribute (`disabled`, `hidden`), and
+ * handles both quote styles plus the unquoted form.
+ */
+function readAttributeValue(html: string, from: number): string | undefined {
+  let index = from;
+  while (index < html.length && isSpace(html[index])) index += 1;
+  if (html[index] !== "=") return undefined;
+  index += 1;
+  while (index < html.length && isSpace(html[index])) index += 1;
+
+  const quote = html[index];
+  if (quote === '"' || quote === "'") {
+    const end = html.indexOf(quote, index + 1);
+    return end === -1 ? undefined : html.slice(index + 1, end);
+  }
+  const start = index;
+  while (index < html.length && !isSpace(html[index]) && html[index] !== ">") {
+    index += 1;
+  }
+  return index > start ? html.slice(start, index) : undefined;
 }
 
 /** Whether the markup contains any element a user can interact with. */

--- a/sdk/src/claude-readiness/index.ts
+++ b/sdk/src/claude-readiness/index.ts
@@ -52,6 +52,17 @@ export type {
 } from "./manifest.js";
 
 export {
+  claudeAppContentDomain,
+  claudeAppResourceEvidenceFrom,
+  claudeAppToolEvidenceFrom,
+  runClaudeAppsChecks,
+} from "./checks/apps.js";
+export type {
+  ClaudeAppResourceEvidence,
+  ClaudeAppToolEvidence,
+  ClaudeAppsEvidence,
+} from "./checks/apps.js";
+export {
   canonicalResourceIndicator,
   runClaudeAuthChecks,
 } from "./checks/auth.js";

--- a/sdk/src/claude-readiness/index.ts
+++ b/sdk/src/claude-readiness/index.ts
@@ -52,6 +52,20 @@ export type {
 } from "./manifest.js";
 
 export {
+  canonicalResourceIndicator,
+  runClaudeAuthChecks,
+} from "./checks/auth.js";
+export type {
+  ClaudeAuthEvidence,
+  ClaudeAuthCheckOutput,
+  ClaudePrmDiscoveryStep,
+} from "./checks/auth.js";
+export { runClaudeOptionalFeatureChecks } from "./checks/optional-features.js";
+export type {
+  ClaudeOptionalFeatureEvidence,
+  ClaudeOptionalFeatureOutput,
+} from "./checks/optional-features.js";
+export {
   CLAUDE_SUBMISSION_PROFILE_INPUT,
   runClaudeSubmissionChecks,
 } from "./checks/submission.js";

--- a/sdk/src/claude-readiness/index.ts
+++ b/sdk/src/claude-readiness/index.ts
@@ -52,6 +52,45 @@ export type {
 } from "./manifest.js";
 
 export {
+  CLAUDE_SUBMISSION_PROFILE_INPUT,
+  runClaudeSubmissionChecks,
+} from "./checks/submission.js";
+export type { ClaudeSubmissionEvidence } from "./checks/submission.js";
+export { runClaudeToolChecks } from "./checks/tools.js";
+export { runClaudeEndpointChecks } from "./checks/endpoint.js";
+export type {
+  ClaudeEndpointEvidence,
+  ClaudeRedirectHop,
+} from "./checks/endpoint.js";
+export {
+  derivedFrom,
+  informational,
+  notApplicable,
+  notEvaluated,
+  satisfied,
+  violated,
+} from "./checks/helpers.js";
+export type {
+  ClaudeCheckDefinition,
+  ClaudeCheckStamp,
+} from "./checks/helpers.js";
+
+export {
+  CLAUDE_ATTESTATIONS,
+  CLAUDE_DATA_HANDLING_MODES,
+  CLAUDE_DECLARED_AUTH_MODES,
+  claudeSubmissionProfileSchema,
+  parseClaudeSubmissionProfile,
+} from "./submission-profile.js";
+export type {
+  ClaudeAttestation,
+  ClaudeDataHandlingMode,
+  ClaudeDeclaredAuthMode,
+  ClaudeSubmissionProfile,
+  ClaudeSubmissionProfileParse,
+} from "./submission-profile.js";
+
+export {
   CLAUDE_APP_CONTENT_DOMAIN_HASH_LENGTH,
   CLAUDE_APP_CONTENT_DOMAIN_SUFFIX,
   CLAUDE_APP_DESIGN_BUDGETS,

--- a/sdk/src/claude-readiness/index.ts
+++ b/sdk/src/claude-readiness/index.ts
@@ -52,6 +52,26 @@ export type {
 } from "./manifest.js";
 
 export {
+  CLAUDE_READINESS_INPUTS,
+  gradeClaudeReadiness,
+} from "./runner.js";
+export type { ClaudeReadinessInput } from "./runner.js";
+
+export {
+  gradeClaudeIntrusiveObservations,
+  probeDynamicRegistration,
+  probeRefreshRotation,
+  resolveClaudeIntrusiveMode,
+} from "./intrusive.js";
+export type {
+  ClaudeGrantOrigin,
+  ClaudeIntrusiveConfig,
+  ClaudeIntrusiveMode,
+  ClaudeIntrusiveObservations,
+  ClaudeIntrusiveProbeOptions,
+} from "./intrusive.js";
+
+export {
   claudeAppContentDomain,
   claudeAppResourceEvidenceFrom,
   claudeAppToolEvidenceFrom,

--- a/sdk/src/claude-readiness/index.ts
+++ b/sdk/src/claude-readiness/index.ts
@@ -1,0 +1,64 @@
+/**
+ * Claude directory readiness — a composite readiness product, not a fifth
+ * scored MCP conformance suite.
+ *
+ * Everything exported here is pure data or pure data reasoning: no MCP client,
+ * no transport, no Node built-ins, so the whole module is safe from the
+ * browser entry. The runner and the checks that dial a target live in sibling
+ * modules that are NOT re-exported from here.
+ */
+
+export {
+  CLAUDE_READINESS_LANES,
+  CLAUDE_FINDING_CLASSES,
+  CLAUDE_EVIDENCE_PROVENANCE,
+  CLAUDE_INTRUSIVENESS_LEVELS,
+  CLAUDE_RUNNER_CAPABILITIES,
+  CLAUDE_REQUIRED_LANES,
+  decideLaneStatus,
+  rollUpLaneStatus,
+  summarizeLaneCoverage,
+  CLAUDE_READINESS_ENGINE_VERSION,
+} from "./types.js";
+export type {
+  ClaudeCapabilityBadge,
+  ClaudeEvidenceProvenance,
+  ClaudeFindingClass,
+  ClaudeFindingStatus,
+  ClaudeIntrusiveness,
+  ClaudeLaneCoverage,
+  ClaudeLaneStatus,
+  ClaudeReadinessAuthMode,
+  ClaudeReadinessFinding,
+  ClaudeReadinessLane,
+  ClaudeReadinessLaneResult,
+  ClaudeReadinessResult,
+  ClaudeReadinessRunContext,
+  ClaudeRunnerCapability,
+} from "./types.js";
+
+export {
+  CLAUDE_DOCS_BASE_URL,
+  CLAUDE_POLICY_MANIFEST,
+  CLAUDE_POLICY_PAGES,
+  CLAUDE_POLICY_SNAPSHOT_DATE,
+  claudePolicySource,
+  isPolicyCorpusVerified,
+} from "./manifest.js";
+export type {
+  ClaudePolicyPage,
+  ClaudePolicySourceEntry,
+  ClaudePolicySourceRef,
+} from "./manifest.js";
+
+export {
+  CLAUDE_APP_CONTENT_DOMAIN_HASH_LENGTH,
+  CLAUDE_APP_CONTENT_DOMAIN_SUFFIX,
+  CLAUDE_APP_DESIGN_BUDGETS,
+  CLAUDE_APP_HTML_MIME,
+  CLAUDE_CALLBACK_URLS,
+  CLAUDE_HOST_PROFILE,
+  CLAUDE_LATENCY_BUDGETS,
+  CLAUDE_LOOPBACK_REDIRECT_IGNORES_PORT,
+  CLAUDE_SUBMISSION_LIMITS,
+} from "./profile.js";

--- a/sdk/src/claude-readiness/index.ts
+++ b/sdk/src/claude-readiness/index.ts
@@ -16,6 +16,7 @@ export {
   CLAUDE_RUNNER_CAPABILITIES,
   CLAUDE_REQUIRED_LANES,
   decideLaneStatus,
+  isDispositiveClaudeFinding,
   rollUpLaneStatus,
   summarizeLaneCoverage,
   CLAUDE_READINESS_ENGINE_VERSION,
@@ -57,10 +58,13 @@ export {
 } from "./runner.js";
 export type { ClaudeReadinessInput } from "./runner.js";
 
+// The intrusive GATE and its GRADING are pure — a resolver over a config
+// object and a function over observations — so they belong here. The PROBES
+// are not: they open sockets and register clients. They live in
+// `intrusive-probes.js`, reachable only from the Node entry, so a browser
+// bundle cannot import a function that registers an OAuth client.
 export {
   gradeClaudeIntrusiveObservations,
-  probeDynamicRegistration,
-  probeRefreshRotation,
   resolveClaudeIntrusiveMode,
 } from "./intrusive.js";
 export type {
@@ -68,7 +72,6 @@ export type {
   ClaudeIntrusiveConfig,
   ClaudeIntrusiveMode,
   ClaudeIntrusiveObservations,
-  ClaudeIntrusiveProbeOptions,
 } from "./intrusive.js";
 
 export {

--- a/sdk/src/claude-readiness/intrusive-probes.ts
+++ b/sdk/src/claude-readiness/intrusive-probes.ts
@@ -1,0 +1,15 @@
+/**
+ * The side-effecting probes, kept out of the browser-safe barrel.
+ *
+ * `claude-readiness/index.ts` is re-exported from `@mcpjam/sdk/browser`, and
+ * its header promises pure data and data reasoning. A function that registers
+ * an OAuth client at a stranger's authorization server is neither, and a
+ * browser bundle should not be able to import one at all. The gate and the
+ * grading stay in the pure barrel; only the sockets live here.
+ */
+
+export {
+  probeDynamicRegistration,
+  probeRefreshRotation,
+} from "./intrusive.js";
+export type { ClaudeIntrusiveProbeOptions } from "./intrusive.js";

--- a/sdk/src/claude-readiness/intrusive.ts
+++ b/sdk/src/claude-readiness/intrusive.ts
@@ -265,6 +265,17 @@ export interface ClaudeIntrusiveObservations {
     attempted: boolean;
     /** The server issued a NEW refresh token on the refresh. */
     rotated: boolean;
+    /**
+     * What the FIRST refresh request returned.
+     *
+     * Load-bearing for grading: a refresh that was rejected outright — a
+     * confidential client probed without its secret answers `401
+     * invalid_client` — issues no new token either, and is indistinguishable
+     * from a non-rotating server unless the status is kept. One is the
+     * server's defect; the other is the probe's own request being wrong.
+     */
+    refreshStatus?: number;
+    refreshError?: string;
     /** Replaying the old refresh token: what came back. */
     replayStatus?: number;
     replayError?: string;
@@ -279,6 +290,21 @@ export interface ClaudeIntrusiveObservations {
     wwwAuthenticate?: string;
     error?: string;
   };
+}
+
+/**
+ * Whether the refresh request itself was answered successfully.
+ *
+ * An older observation carries no `refreshStatus` — it predates the field —
+ * and the honest reading of "no status recorded" is that the request is not
+ * known to have failed, which keeps grading of previously captured evidence
+ * exactly as it was.
+ */
+function refreshRequestSucceeded(
+  refresh: NonNullable<ClaudeIntrusiveObservations["refresh"]>,
+): boolean {
+  if (refresh.refreshStatus === undefined) return true;
+  return refresh.refreshStatus >= 200 && refresh.refreshStatus < 300;
 }
 
 /**
@@ -363,13 +389,28 @@ export function gradeClaudeIntrusiveObservations(
           "no refresh token was available from a grant this run owns, and a borrowed one must never be spent here",
       ),
     );
+  } else if (!refresh.rotated && !refreshRequestSucceeded(refresh)) {
+    // THE PROBE'S OWN REQUEST FAILED, so the server was never asked the
+    // question this check grades. Calling that a rotation defect accuses a
+    // submitter of a bug we manufactured — a confidential client probed
+    // without its secret answers `401 invalid_client` and issues no token, and
+    // so does a server with nothing wrong with it.
+    findings.push(
+      notEvaluated(
+        REFRESH_ROTATION,
+        stamp,
+        `the refresh request was rejected (HTTP ${refresh.refreshStatus ?? "unknown"}${
+          refresh.refreshError ? `, ${refresh.refreshError}` : ""
+        }), so rotation was never exercised; check the credentials handed to the probe`,
+      ),
+    );
   } else if (!refresh.rotated) {
     findings.push(
       violated(
         REFRESH_ROTATION,
         stamp,
         "The refresh did not issue a new refresh token. Claude expects rotation; a static refresh token stays valid after a leak.",
-        { replayStatus: refresh.replayStatus },
+        { refreshStatus: refresh.refreshStatus, replayStatus: refresh.replayStatus },
       ),
     );
   } else {
@@ -609,13 +650,19 @@ export async function probeRefreshRotation(
     };
   }
 
+  const refreshStatus = first.response.status;
+  const refreshError =
+    typeof first.json.error === "string" ? first.json.error : undefined;
   const issued =
     typeof first.json.refresh_token === "string"
       ? first.json.refresh_token
       : undefined;
   const rotated = issued !== undefined && issued !== refreshToken;
   if (!rotated) {
-    return { attempted: true, rotated: false };
+    // Carry the status out. Grading cannot tell "this server does not rotate"
+    // from "the server refused OUR request" without it, and the difference
+    // decides whether the finding is the submitter's to fix.
+    return { attempted: true, rotated: false, refreshStatus, refreshError };
   }
 
   try {

--- a/sdk/src/claude-readiness/intrusive.ts
+++ b/sdk/src/claude-readiness/intrusive.ts
@@ -30,6 +30,7 @@
  *      registration that cannot be cleaned up is reported rather than hidden.
  */
 
+import { parseBearerAuthenticateParameters } from "../oauth/state-machines/shared/challenges.js";
 import { claudePolicySource } from "./manifest.js";
 import type { ClaudeReadinessFinding } from "./types.js";
 import {
@@ -293,6 +294,37 @@ export interface ClaudeIntrusiveObservations {
 }
 
 /**
+ * The scopes a step-up challenge asked for, beside the ones the run expected.
+ *
+ * Reported, never graded. A challenge that names no `scope` is conforming, and
+ * a server is free to ask for scopes the operator did not list — so the useful
+ * output is the comparison itself, which tells whoever reads the report
+ * whether their declared expectation matched reality.
+ */
+function summarizeStepUpScopes(
+  wwwAuthenticate: string | undefined,
+  expectedScopes: string[] | undefined,
+): Record<string, unknown> {
+  const expected = expectedScopes ?? [];
+  const challengedScopes = wwwAuthenticate
+    ? (parseBearerAuthenticateParameters(wwwAuthenticate).scope ?? "")
+        .split(/\s+/)
+        .filter(Boolean)
+    : [];
+  return {
+    expectedScopes: expected,
+    challengedScopes,
+    // `undefined` rather than a boolean when the challenge named nothing:
+    // there is no overlap to report, and `false` would read as a mismatch the
+    // server never committed.
+    scopesOverlapExpectation:
+      challengedScopes.length === 0
+        ? undefined
+        : challengedScopes.some((scope) => expected.includes(scope)),
+  };
+}
+
+/**
  * Whether the refresh request itself was answered successfully.
  *
  * An older observation carries no `refreshStatus` — it predates the field —
@@ -461,11 +493,23 @@ export function gradeClaudeIntrusiveObservations(
     const challenged =
       stepUp.status === 403 &&
       /insufficient_scope/.test(stepUp.wwwAuthenticate ?? "");
+    // WHAT THE CONFIG PROMISED, MEASURED. `expectedScopes` is required
+    // alongside `protectedToolName` so the run states what it is asserting,
+    // but nothing compared it, so the requirement bought a config error and no
+    // evidence. Recorded rather than graded: the `scope` parameter is OPTIONAL
+    // on an `insufficient_scope` challenge — Claude selects scopes from
+    // discovery when it is absent — so a server that omits it, or names its
+    // own, is not thereby wrong.
+    const scopeEvidence = summarizeStepUpScopes(
+      stepUp.wwwAuthenticate,
+      mode.expectedScopes,
+    );
     findings.push(
       challenged
         ? satisfied(STEP_UP, stamp, {
             toolName: stepUp.toolName,
             wwwAuthenticate: stepUp.wwwAuthenticate,
+            ...scopeEvidence,
           })
         : violated(
             STEP_UP,
@@ -474,7 +518,7 @@ export function gradeClaudeIntrusiveObservations(
             {
               status: stepUp.status,
               wwwAuthenticate: stepUp.wwwAuthenticate,
-              expectedScopes: mode.expectedScopes,
+              ...scopeEvidence,
             },
           ),
     );

--- a/sdk/src/claude-readiness/intrusive.ts
+++ b/sdk/src/claude-readiness/intrusive.ts
@@ -89,12 +89,39 @@ export type ClaudeIntrusiveMode =
       readonly authorization: IntrusiveAuthorization;
     };
 
-/** The unforgeable capability. Its shape is deliberately private. */
+/**
+ * The unforgeable capability.
+ *
+ * The BRAND is compile-time only, and a type-level guarantee evaporates at the
+ * first `as` cast or the first JavaScript caller. What makes the gate real is
+ * {@link assertArmed} below, which compares against this exact object — so a
+ * hand-built `{enabled: true, …}` reaches a throw rather than a client
+ * registration at somebody else's authorization server.
+ */
 declare const INTRUSIVE_BRAND: unique symbol;
 export interface IntrusiveAuthorization {
   readonly [INTRUSIVE_BRAND]: true;
 }
 const AUTHORIZATION = Object.freeze({}) as IntrusiveAuthorization;
+
+/**
+ * Refuse any mode that did not come out of {@link resolveClaudeIntrusiveMode}.
+ *
+ * Every probe calls this BEFORE its first request. Without it the module's
+ * claim that the capability "cannot be constructed outside this module" is
+ * true of the type and false of the runtime, which is the worse of the two
+ * places for it to be true.
+ */
+function assertArmed(mode: ClaudeIntrusiveMode): asserts mode is Extract<
+  ClaudeIntrusiveMode,
+  { enabled: true }
+> {
+  if (mode.enabled !== true || mode.authorization !== AUTHORIZATION) {
+    throw new Error(
+      "Intrusive probes require a mode returned by resolveClaudeIntrusiveMode.",
+    );
+  }
+}
 
 /**
  * The one door in.
@@ -147,9 +174,13 @@ export function resolveClaudeIntrusiveMode(
     };
   }
   if (context.hasBorrowedAccessToken && config.grantOrigin === "self-acquired") {
-    // The combination is the dangerous one: a run holding a user's token and
-    // claiming its grant is self-acquired is exactly how a borrowed session
-    // gets burned by a refresh-rotation probe.
+    // ONLY `self-acquired` is refused here, and the asymmetry is the point. A
+    // `dedicated-test-account` run spends `testCredentials.refreshToken` —
+    // credentials the caller owns — and never touches the borrowed grant, so
+    // holding one alongside it is harmless. A `self-acquired` run has no such
+    // separate credential, so "the grant this run acquired" and "the token
+    // somebody handed us" are the same thing, and the rotation probe would
+    // burn a live user's session.
     return {
       enabled: false,
       reason:
@@ -433,6 +464,7 @@ export async function probeDynamicRegistration(
   mode: Extract<ClaudeIntrusiveMode, { enabled: true }>,
   options: ClaudeIntrusiveProbeOptions,
 ): Promise<NonNullable<ClaudeIntrusiveObservations["registration"]>> {
+  assertArmed(mode);
   if (!options.registrationEndpoint) {
     return {
       attempted: false,
@@ -535,6 +567,7 @@ export async function probeRefreshRotation(
   mode: Extract<ClaudeIntrusiveMode, { enabled: true }>,
   options: ClaudeIntrusiveProbeOptions,
 ): Promise<NonNullable<ClaudeIntrusiveObservations["refresh"]>> {
+  assertArmed(mode);
   const refreshToken = mode.credentials.refreshToken;
   if (!options.tokenEndpoint || !refreshToken) {
     return {

--- a/sdk/src/claude-readiness/intrusive.ts
+++ b/sdk/src/claude-readiness/intrusive.ts
@@ -1,0 +1,605 @@
+/**
+ * Side-effecting OAuth probes, and the gate that is the actual product here.
+ *
+ * WHAT MAKES THESE DIFFERENT. Everything else in readiness reads metadata. These
+ * three register a client at someone's authorization server, spend a refresh
+ * token and deliberately burn it, and drive a real tool call to force a
+ * step-up. Each one leaves a trace in a stranger's system. Run by accident —
+ * on a schedule, across a directory feed, against a production tenant — they
+ * are indistinguishable from an attack.
+ *
+ * SO THE GATE IS SDK-ENFORCED, NOT CALL-SITE-ENFORCED. {@link
+ * resolveClaudeIntrusiveMode} is the only way to obtain the token these probes
+ * require, and it refuses unless every condition below is met. A call site
+ * cannot opt in by passing a flag it invented, and a future surface that
+ * forgets to check gets a refusal rather than a silent registration.
+ *
+ * The conditions, and why each one:
+ *
+ *   1. `enabled: true` as a literal boolean. A truthy string from a query
+ *      parameter or a YAML file must not be able to arm this.
+ *   2. A stated `grantOrigin`. The probes may only ever use a grant this run
+ *      acquired or a dedicated test account the caller owns. BORROWED
+ *      CREDENTIALS ARE REFUSED OUTRIGHT: burning a refresh token that belongs
+ *      to a real user's live session logs them out of a product they were
+ *      using, and no readiness grade is worth that.
+ *   3. A declared tool and expected scopes before a step-up probe runs. Calling
+ *      an arbitrary tool to see what happens is how a readiness run deletes
+ *      someone's data.
+ *   4. Cleanup is on unless the caller explicitly turns it off, and a
+ *      registration that cannot be cleaned up is reported rather than hidden.
+ */
+
+import { claudePolicySource } from "./manifest.js";
+import type { ClaudeReadinessFinding } from "./types.js";
+import {
+  notEvaluated,
+  satisfied,
+  violated,
+  type ClaudeCheckDefinition,
+  type ClaudeCheckStamp,
+} from "./checks/helpers.js";
+
+/**
+ * Where the grant these probes spend came from.
+ *
+ * There is deliberately no `"caller-supplied"` member. A token handed in for
+ * ordinary operation belongs to whoever authorized it, and spending it here
+ * would be using someone's session to run a test they did not agree to.
+ */
+export type ClaudeGrantOrigin = "self-acquired" | "dedicated-test-account";
+
+export interface ClaudeIntrusiveConfig {
+  /** Literal `true`. A truthy value of any other type is refused. */
+  enabled: boolean;
+  /** Required. See {@link ClaudeGrantOrigin}. */
+  grantOrigin?: ClaudeGrantOrigin;
+  /** Credentials for a dedicated test account, when that is the origin. */
+  testCredentials?: {
+    clientId?: string;
+    clientSecret?: string;
+    refreshToken?: string;
+  };
+  /** The tool the step-up probe is allowed to call. Nothing else may be called. */
+  protectedToolName?: string;
+  /** Scopes that tool is expected to require. */
+  expectedScopes?: string[];
+  /** Delete registered clients afterwards. Defaults to true. */
+  cleanup?: boolean;
+}
+
+export type ClaudeIntrusiveMode =
+  | {
+      enabled: false;
+      /** Why, in words a caller can act on or show a user. */
+      reason: string;
+    }
+  | {
+      enabled: true;
+      grantOrigin: ClaudeGrantOrigin;
+      credentials: NonNullable<ClaudeIntrusiveConfig["testCredentials"]>;
+      protectedToolName?: string;
+      expectedScopes?: string[];
+      cleanup: boolean;
+      /**
+       * Present only on an armed mode, and required by every probe below. It
+       * cannot be constructed outside this module, which is what makes the
+       * gate structural rather than a convention.
+       */
+      readonly authorization: IntrusiveAuthorization;
+    };
+
+/** The unforgeable capability. Its shape is deliberately private. */
+declare const INTRUSIVE_BRAND: unique symbol;
+export interface IntrusiveAuthorization {
+  readonly [INTRUSIVE_BRAND]: true;
+}
+const AUTHORIZATION = Object.freeze({}) as IntrusiveAuthorization;
+
+/**
+ * The one door in.
+ *
+ * Returns a disabled mode with a reason for every path that is not a complete,
+ * explicit opt-in. `undefined` config is the overwhelmingly common case and is
+ * not an error — it is the default, and the default is off.
+ */
+export function resolveClaudeIntrusiveMode(
+  config: ClaudeIntrusiveConfig | undefined,
+  context: {
+    /**
+     * True when the run holds an access token supplied for ORDINARY operation.
+     * Its presence does not enable anything; it is passed so the resolver can
+     * refuse to let a borrowed token become the grant these probes spend.
+     */
+    hasBorrowedAccessToken: boolean;
+  },
+): ClaudeIntrusiveMode {
+  if (!config) {
+    return { enabled: false, reason: "intrusive probes were not requested" };
+  }
+  // A literal boolean, not a truthy value. `enabled: "false"` from a config
+  // file must not arm client registration against a stranger's server.
+  if (config.enabled !== true) {
+    return {
+      enabled: false,
+      reason:
+        "intrusive probes require `enabled: true` as a boolean; any other value is treated as off",
+    };
+  }
+  if (
+    config.grantOrigin !== "self-acquired" &&
+    config.grantOrigin !== "dedicated-test-account"
+  ) {
+    return {
+      enabled: false,
+      reason:
+        "intrusive probes require an explicit `grantOrigin` of `self-acquired` or `dedicated-test-account`",
+    };
+  }
+  if (
+    config.grantOrigin === "dedicated-test-account" &&
+    !config.testCredentials?.clientId
+  ) {
+    return {
+      enabled: false,
+      reason:
+        "`grantOrigin: \"dedicated-test-account\"` requires `testCredentials.clientId`",
+    };
+  }
+  if (context.hasBorrowedAccessToken && config.grantOrigin === "self-acquired") {
+    // The combination is the dangerous one: a run holding a user's token and
+    // claiming its grant is self-acquired is exactly how a borrowed session
+    // gets burned by a refresh-rotation probe.
+    return {
+      enabled: false,
+      reason:
+        "this run holds an access token supplied for ordinary operation; intrusive probes must not spend a borrowed grant. Supply a dedicated test account instead.",
+    };
+  }
+  if (config.protectedToolName !== undefined && !config.expectedScopes?.length) {
+    return {
+      enabled: false,
+      reason:
+        "a step-up probe requires `expectedScopes` alongside `protectedToolName`, so the run knows what it is asserting",
+    };
+  }
+
+  return {
+    enabled: true,
+    grantOrigin: config.grantOrigin,
+    credentials: config.testCredentials ?? {},
+    protectedToolName: config.protectedToolName,
+    expectedScopes: config.expectedScopes,
+    cleanup: config.cleanup ?? true,
+    authorization: AUTHORIZATION,
+  };
+}
+
+// ── Check definitions ───────────────────────────────────────────────────
+
+const DCR_REGISTER: ClaudeCheckDefinition = {
+  id: "claude.intrusive.dynamic-registration",
+  title: "Dynamic client registration succeeds and is cleanable",
+  lane: "runtime-compatibility",
+  class: "required",
+  source: claudePolicySource("authentication", "§Dynamic client registration"),
+  provenance: "wire",
+  intrusiveness: "side-effecting",
+  requiresCapabilities: ["intrusive-probes"],
+};
+
+const REFRESH_ROTATION: ClaudeCheckDefinition = {
+  id: "claude.intrusive.refresh-rotation",
+  title: "A refresh token rotates and the old one is rejected",
+  lane: "runtime-compatibility",
+  class: "required",
+  source: claudePolicySource("authentication", "§Refresh tokens"),
+  provenance: "wire",
+  intrusiveness: "side-effecting",
+  requiresCapabilities: ["intrusive-probes"],
+};
+
+const STEP_UP: ClaudeCheckDefinition = {
+  id: "claude.intrusive.step-up-challenge",
+  title: "A protected tool challenges for the scopes it needs",
+  lane: "runtime-compatibility",
+  class: "required",
+  source: claudePolicySource("authentication", "§Step-up authorization"),
+  provenance: "wire",
+  intrusiveness: "side-effecting",
+  requiresCapabilities: ["intrusive-probes"],
+};
+
+const INTRUSIVE_DEFINITIONS = [DCR_REGISTER, REFRESH_ROTATION, STEP_UP];
+
+// ── Observations ────────────────────────────────────────────────────────
+
+/**
+ * What a probe SAW. The probes below produce these; the grading is separate,
+ * so a caller who ran the probes elsewhere (the oauth-conformance session, for
+ * instance) can hand its evidence straight in rather than re-registering.
+ */
+export interface ClaudeIntrusiveObservations {
+  registration?: {
+    attempted: boolean;
+    status: number;
+    /** RFC 7592 management URI, when the server issued one. */
+    registrationClientUri?: string;
+    /** Whether cleanup ran, and whether it worked. */
+    cleanedUp?: boolean;
+    cleanupError?: string;
+    error?: string;
+  };
+  refresh?: {
+    attempted: boolean;
+    /** The server issued a NEW refresh token on the refresh. */
+    rotated: boolean;
+    /** Replaying the old refresh token: what came back. */
+    replayStatus?: number;
+    replayError?: string;
+    /** Extra fields alongside `error` are valid and must not fail the check. */
+    replayBody?: Record<string, unknown>;
+    error?: string;
+  };
+  stepUp?: {
+    attempted: boolean;
+    toolName: string;
+    status: number;
+    wwwAuthenticate?: string;
+    error?: string;
+  };
+}
+
+/**
+ * Grade what the probes saw.
+ *
+ * Kept apart from the probing so evidence from an existing oauth-conformance
+ * session can be graded WITHOUT re-registering a client — the plan's
+ * "reuse existing session evidence instead of auto re-registering" is a
+ * property of this split, not a promise in a comment.
+ */
+export function gradeClaudeIntrusiveObservations(
+  mode: ClaudeIntrusiveMode,
+  observations: ClaudeIntrusiveObservations,
+  stamp: ClaudeCheckStamp,
+): ClaudeReadinessFinding[] {
+  if (!mode.enabled) {
+    return INTRUSIVE_DEFINITIONS.map((definition) =>
+      notEvaluated(definition, stamp, mode.reason, {
+        missingInput: "intrusive",
+      }),
+    );
+  }
+
+  const findings: ClaudeReadinessFinding[] = [];
+
+  // ── Dynamic client registration ──────────────────────────────────────
+  const registration = observations.registration;
+  if (!registration?.attempted) {
+    findings.push(
+      notEvaluated(
+        DCR_REGISTER,
+        stamp,
+        registration?.error ??
+          "no registration was attempted; the authorization server advertised no registration endpoint",
+      ),
+    );
+  } else if (registration.status < 200 || registration.status >= 300) {
+    findings.push(
+      violated(
+        DCR_REGISTER,
+        stamp,
+        "Dynamic client registration failed. Claude registers a client the first time a user connects, so this blocks every new connection.",
+        { status: registration.status, error: registration.error },
+      ),
+    );
+  } else if (registration.cleanedUp === false) {
+    // A registration we could not remove is a client left behind on someone
+    // else's server. Reporting it is the minimum; hiding it would make this
+    // tool a slow leak.
+    findings.push(
+      violated(
+        DCR_REGISTER,
+        stamp,
+        `Registration succeeded but the test client could not be removed${
+          registration.registrationClientUri
+            ? ` via ${registration.registrationClientUri}`
+            : " (the server issued no `registration_client_uri`)"
+        }. Delete it manually.`,
+        {
+          registrationClientUri: registration.registrationClientUri,
+          cleanupError: registration.cleanupError,
+        },
+      ),
+    );
+  } else {
+    findings.push(
+      satisfied(DCR_REGISTER, stamp, {
+        status: registration.status,
+        cleanedUp: registration.cleanedUp ?? true,
+      }),
+    );
+  }
+
+  // ── Refresh rotation and replay ──────────────────────────────────────
+  const refresh = observations.refresh;
+  if (!refresh?.attempted) {
+    findings.push(
+      notEvaluated(
+        REFRESH_ROTATION,
+        stamp,
+        refresh?.error ??
+          "no refresh token was available from a grant this run owns, and a borrowed one must never be spent here",
+      ),
+    );
+  } else if (!refresh.rotated) {
+    findings.push(
+      violated(
+        REFRESH_ROTATION,
+        stamp,
+        "The refresh did not issue a new refresh token. Claude expects rotation; a static refresh token stays valid after a leak.",
+        { replayStatus: refresh.replayStatus },
+      ),
+    );
+  } else {
+    // THE EXACT CONTRACT: HTTP 400 with `error: "invalid_grant"`. Extra fields
+    // beside it are valid — `error_description`, `error_uri`, anything the
+    // server wants — and a check that required an exact body would fail
+    // conforming servers for being informative.
+    const correctStatus = refresh.replayStatus === 400;
+    const correctError = refresh.replayError === "invalid_grant";
+    findings.push(
+      correctStatus && correctError
+        ? satisfied(REFRESH_ROTATION, stamp, {
+            rotated: true,
+            replayStatus: refresh.replayStatus,
+            replayError: refresh.replayError,
+            extraFields: Object.keys(refresh.replayBody ?? {}).filter(
+              (key) => key !== "error",
+            ),
+          })
+        : violated(
+            REFRESH_ROTATION,
+            stamp,
+            `Replaying the rotated-out refresh token must answer HTTP 400 with \`error: "invalid_grant"\`; this answered ${refresh.replayStatus} with \`${refresh.replayError ?? "no error code"}\`.`,
+            {
+              replayStatus: refresh.replayStatus,
+              replayError: refresh.replayError,
+            },
+          ),
+    );
+  }
+
+  // ── Step-up ──────────────────────────────────────────────────────────
+  const stepUp = observations.stepUp;
+  if (!mode.protectedToolName) {
+    findings.push(
+      notEvaluated(
+        STEP_UP,
+        stamp,
+        "no `protectedToolName` was declared; calling an arbitrary tool to see what happens is not something this runner does",
+        { missingInput: "intrusive.protectedToolName" },
+      ),
+    );
+  } else if (!stepUp?.attempted) {
+    findings.push(
+      notEvaluated(STEP_UP, stamp, stepUp?.error ?? "the step-up probe did not run"),
+    );
+  } else {
+    const challenged =
+      stepUp.status === 403 &&
+      /insufficient_scope/.test(stepUp.wwwAuthenticate ?? "");
+    findings.push(
+      challenged
+        ? satisfied(STEP_UP, stamp, {
+            toolName: stepUp.toolName,
+            wwwAuthenticate: stepUp.wwwAuthenticate,
+          })
+        : violated(
+            STEP_UP,
+            stamp,
+            `Calling \`${stepUp.toolName}\` without its scopes answered ${stepUp.status}. Claude needs a 403 with \`error="insufficient_scope"\` to know it should re-authorize rather than give up.`,
+            {
+              status: stepUp.status,
+              wwwAuthenticate: stepUp.wwwAuthenticate,
+              expectedScopes: mode.expectedScopes,
+            },
+          ),
+    );
+  }
+
+  return findings;
+}
+
+// ── The probes ──────────────────────────────────────────────────────────
+
+export interface ClaudeIntrusiveProbeOptions {
+  fetchFn: typeof fetch;
+  registrationEndpoint?: string;
+  tokenEndpoint?: string;
+  /** Redirect URIs to register. Claude's own, so the registration is realistic. */
+  redirectUris: string[];
+  timeoutMs?: number;
+}
+
+/**
+ * Register a throwaway client and delete it again.
+ *
+ * The `authorization` parameter is the armed mode itself: the probe cannot be
+ * called without one, and one cannot be built outside
+ * {@link resolveClaudeIntrusiveMode}.
+ */
+export async function probeDynamicRegistration(
+  mode: Extract<ClaudeIntrusiveMode, { enabled: true }>,
+  options: ClaudeIntrusiveProbeOptions,
+): Promise<NonNullable<ClaudeIntrusiveObservations["registration"]>> {
+  if (!options.registrationEndpoint) {
+    return {
+      attempted: false,
+      status: 0,
+      error: "the authorization server advertises no registration endpoint",
+    };
+  }
+
+  const signal = AbortSignal.timeout(options.timeoutMs ?? 20_000);
+  let response: Response;
+  try {
+    response = await options.fetchFn(options.registrationEndpoint, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      signal,
+      body: JSON.stringify({
+        client_name: "MCPJam Claude readiness probe",
+        redirect_uris: options.redirectUris,
+        grant_types: ["authorization_code", "refresh_token"],
+        response_types: ["code"],
+        token_endpoint_auth_method: "none",
+      }),
+    });
+  } catch (error) {
+    return {
+      attempted: true,
+      status: 0,
+      error: error instanceof Error ? error.message : String(error),
+    };
+  }
+
+  const body = (await response.json().catch(() => ({}))) as Record<string, unknown>;
+  const registrationClientUri =
+    typeof body.registration_client_uri === "string"
+      ? body.registration_client_uri
+      : undefined;
+  const registrationAccessToken =
+    typeof body.registration_access_token === "string"
+      ? body.registration_access_token
+      : undefined;
+
+  if (!response.ok) {
+    return {
+      attempted: true,
+      status: response.status,
+      error: typeof body.error === "string" ? body.error : response.statusText,
+    };
+  }
+
+  if (!mode.cleanup) {
+    return { attempted: true, status: response.status, registrationClientUri };
+  }
+
+  // RFC 7592 delete. A server that issued no management URI gives us no way to
+  // clean up, and that is reported as a failure of THIS check rather than
+  // quietly leaving a client behind.
+  if (!registrationClientUri) {
+    return {
+      attempted: true,
+      status: response.status,
+      cleanedUp: false,
+      cleanupError: "the server issued no `registration_client_uri`",
+    };
+  }
+
+  try {
+    const deleted = await options.fetchFn(registrationClientUri, {
+      method: "DELETE",
+      headers: registrationAccessToken
+        ? { authorization: `Bearer ${registrationAccessToken}` }
+        : undefined,
+      signal: AbortSignal.timeout(options.timeoutMs ?? 20_000),
+    });
+    return {
+      attempted: true,
+      status: response.status,
+      registrationClientUri,
+      cleanedUp: deleted.ok || deleted.status === 204,
+      cleanupError: deleted.ok ? undefined : `DELETE answered ${deleted.status}`,
+    };
+  } catch (error) {
+    return {
+      attempted: true,
+      status: response.status,
+      registrationClientUri,
+      cleanedUp: false,
+      cleanupError: error instanceof Error ? error.message : String(error),
+    };
+  }
+}
+
+/**
+ * Spend a refresh token, then deliberately replay the spent one.
+ *
+ * ONLY ever reached with a grant the caller owns — the resolver refuses a
+ * borrowed one, so by the time this runs, burning the token cannot log a real
+ * user out of anything.
+ */
+export async function probeRefreshRotation(
+  mode: Extract<ClaudeIntrusiveMode, { enabled: true }>,
+  options: ClaudeIntrusiveProbeOptions,
+): Promise<NonNullable<ClaudeIntrusiveObservations["refresh"]>> {
+  const refreshToken = mode.credentials.refreshToken;
+  if (!options.tokenEndpoint || !refreshToken) {
+    return {
+      attempted: false,
+      rotated: false,
+      error: !options.tokenEndpoint
+        ? "the authorization server advertises no token endpoint"
+        : "no refresh token from a grant this run owns was supplied",
+    };
+  }
+
+  const post = async (token: string) => {
+    const body = new URLSearchParams({
+      grant_type: "refresh_token",
+      refresh_token: token,
+    });
+    if (mode.credentials.clientId) body.set("client_id", mode.credentials.clientId);
+    if (mode.credentials.clientSecret) {
+      body.set("client_secret", mode.credentials.clientSecret);
+    }
+    const response = await options.fetchFn(options.tokenEndpoint!, {
+      method: "POST",
+      headers: { "content-type": "application/x-www-form-urlencoded" },
+      body: body.toString(),
+      signal: AbortSignal.timeout(options.timeoutMs ?? 20_000),
+    });
+    const json = (await response.json().catch(() => ({}))) as Record<string, unknown>;
+    return { response, json };
+  };
+
+  let first: Awaited<ReturnType<typeof post>>;
+  try {
+    first = await post(refreshToken);
+  } catch (error) {
+    return {
+      attempted: true,
+      rotated: false,
+      error: error instanceof Error ? error.message : String(error),
+    };
+  }
+
+  const issued =
+    typeof first.json.refresh_token === "string"
+      ? first.json.refresh_token
+      : undefined;
+  const rotated = issued !== undefined && issued !== refreshToken;
+  if (!rotated) {
+    return { attempted: true, rotated: false };
+  }
+
+  try {
+    const replay = await post(refreshToken);
+    return {
+      attempted: true,
+      rotated: true,
+      replayStatus: replay.response.status,
+      replayError:
+        typeof replay.json.error === "string" ? replay.json.error : undefined,
+      replayBody: replay.json,
+    };
+  } catch (error) {
+    return {
+      attempted: true,
+      rotated: true,
+      error: error instanceof Error ? error.message : String(error),
+    };
+  }
+}

--- a/sdk/src/claude-readiness/manifest.ts
+++ b/sdk/src/claude-readiness/manifest.ts
@@ -1,0 +1,147 @@
+/**
+ * The policy corpus this product grades against, pinned.
+ *
+ * WHY A MANIFEST AT ALL. Anthropic's directory requirements are documentation,
+ * and documentation moves. A readiness grade with no record of WHICH revision
+ * it was made against does not become obviously wrong when the policy changes —
+ * it becomes quietly wrong, which is worse, because a submitter keeps trusting
+ * it. Every finding therefore carries a {@link ClaudePolicySourceRef} naming
+ * the page, the section, and the snapshot it was graded against, so a stale
+ * grade says so about itself.
+ *
+ * ON `revision`. Every entry ships `null` until the sync script
+ * (`npm run claude-policy:sync`) has actually fetched the page, and that is
+ * deliberate rather than unfinished: a hash is a claim that someone read those
+ * exact bytes, and inventing one would make an unverified corpus look audited.
+ * The script rewrites the GENERATED block below in place — rather than writing
+ * a JSON file this module would then have to read — so the manifest stays pure
+ * static data with no loader, no `fs`, and nothing to go stale between two
+ * files. `npm run claude-policy:check` re-fetches and fails on drift: a changed
+ * hash against an unchanged `snapshotDate` is the signal that the checks citing
+ * that page need re-auditing before any grade made against them is trusted.
+ *
+ * ON THE URLs. They are reconstructed from the doc snapshot the check
+ * inventory was written against (2026-08-19). {@link CLAUDE_DOCS_BASE_URL} is
+ * a single constant precisely so a base that has since moved is one edit and
+ * not fourteen, and the sync script reports any entry that no longer resolves
+ * instead of silently hashing a 404 page.
+ *
+ * Pure data. Safe from the browser entry.
+ */
+
+/** The date the check inventory was written against this corpus. ISO date. */
+export const CLAUDE_POLICY_SNAPSHOT_DATE = "2026-08-19";
+
+/**
+ * Base for every documentation page below. Not inlined into the entries so
+ * that a moved docs root is a one-line change; the sync script verifies it.
+ */
+export const CLAUDE_DOCS_BASE_URL = "https://docs.claude.com/en/docs/mcp";
+
+/**
+ * The pages, by stable key. The key — not the URL — is what findings cite, so
+ * a URL that moves does not invalidate every finding id that referenced it.
+ */
+export const CLAUDE_POLICY_PAGES = [
+  "directory",
+  "verification",
+  "submission",
+  "review-criteria",
+  "authentication",
+  "lazy-authentication",
+  "enterprise-managed-auth",
+  "troubleshooting",
+  "mcp-apps/cross-compatibility",
+  "mcp-apps/external-links",
+  "mcp-apps/troubleshooting",
+  "mcp-apps/design-guidelines",
+] as const;
+
+export type ClaudePolicyPage = (typeof CLAUDE_POLICY_PAGES)[number];
+
+export interface ClaudePolicySourceEntry {
+  page: ClaudePolicyPage;
+  url: string;
+  /**
+   * Content hash of the page text at {@link snapshotDate}, or `null` when the
+   * sync script has not run. Never fabricated — see the module docblock.
+   */
+  revision: string | null;
+  snapshotDate: string;
+}
+
+/**
+ * A finding's citation: which page, and where on it.
+ *
+ * `section` is free text on purpose. Anchors churn faster than prose, and a
+ * reader who is handed "the §Authentication → Lazy authentication heading"
+ * can find it in a reorganised page; a dead `#anchor` helps nobody.
+ */
+export interface ClaudePolicySourceRef {
+  page: ClaudePolicyPage;
+  section: string;
+  url: string;
+  revision: string | null;
+  snapshotDate: string;
+}
+
+/**
+ * Content hashes of each page's visible text, keyed by page.
+ *
+ * GENERATED — do not edit by hand; run `npm run claude-policy:sync`. A page
+ * absent from this map has never been fetched and reports `revision: null`.
+ */
+// BEGIN GENERATED — sync via `npm run claude-policy:sync`
+const PAGE_REVISIONS: Partial<Record<ClaudePolicyPage, string>> = {};
+// END GENERATED
+
+const ENTRIES: ClaudePolicySourceEntry[] = CLAUDE_POLICY_PAGES.map((page) => ({
+  page,
+  url: `${CLAUDE_DOCS_BASE_URL}/${page}`,
+  revision: PAGE_REVISIONS[page] ?? null,
+  snapshotDate: CLAUDE_POLICY_SNAPSHOT_DATE,
+}));
+
+/** The manifest, keyed by page. Total over {@link CLAUDE_POLICY_PAGES}. */
+export const CLAUDE_POLICY_MANIFEST: Readonly<
+  Record<ClaudePolicyPage, ClaudePolicySourceEntry>
+> = Object.freeze(
+  Object.fromEntries(ENTRIES.map((entry) => [entry.page, entry])) as Record<
+    ClaudePolicyPage,
+    ClaudePolicySourceEntry
+  >,
+);
+
+/**
+ * Build a finding's citation.
+ *
+ * Findings call this rather than composing a ref by hand, so a page's URL,
+ * revision and snapshot date can only ever come from the manifest — the whole
+ * point being that no finding can cite a source the manifest does not track.
+ */
+export function claudePolicySource(
+  page: ClaudePolicyPage,
+  section: string,
+): ClaudePolicySourceRef {
+  const entry = CLAUDE_POLICY_MANIFEST[page];
+  return {
+    page: entry.page,
+    section,
+    url: entry.url,
+    revision: entry.revision,
+    snapshotDate: entry.snapshotDate,
+  };
+}
+
+/**
+ * Whether this corpus has actually been snapshotted.
+ *
+ * Surfaces show it next to a grade: "graded against an unverified policy
+ * snapshot" is a materially weaker claim than "graded against the corpus as of
+ * 2026-08-19", and collapsing the two would misrepresent the product.
+ */
+export function isPolicyCorpusVerified(): boolean {
+  return Object.values(CLAUDE_POLICY_MANIFEST).every(
+    (entry) => entry.revision !== null,
+  );
+}

--- a/sdk/src/claude-readiness/profile.ts
+++ b/sdk/src/claude-readiness/profile.ts
@@ -1,0 +1,119 @@
+/**
+ * The Claude host's own constants — the values a server has to match, as
+ * opposed to the requirements it has to satisfy.
+ *
+ * Kept apart from the checks so that a Claude-side change (a new callback URL,
+ * a different content host) is one edit to a named constant rather than a
+ * grep through check bodies for a string literal.
+ *
+ * Pure data. Safe from the browser entry.
+ */
+
+import { claudePolicySource } from "./manifest.js";
+
+/**
+ * The redirect URIs Claude sends users back to.
+ *
+ * A server that allowlists redirect URIs must accept these EXACTLY, and the
+ * list is versioned rather than pattern-matched: "any claude.ai URL" is not
+ * what a conforming allowlist should contain, and a check that accepted a
+ * pattern would pass a server that is about to fail in production.
+ */
+export const CLAUDE_CALLBACK_URLS = [
+  "https://claude.ai/api/mcp/auth_callback",
+  "https://claude.com/api/mcp/auth_callback",
+] as const;
+
+/**
+ * Loopback redirect URIs compare with the PORT IGNORED.
+ *
+ * RFC 8252 §7.3: a native client's loopback redirect gets an ephemeral port,
+ * so an authorization server that compares `http://127.0.0.1:49152/callback`
+ * byte-for-byte against a registered `http://127.0.0.1/callback` rejects every
+ * real attempt. This flag exists so the check states the rule it is applying
+ * instead of hard-coding a port nobody can predict.
+ */
+export const CLAUDE_LOOPBACK_REDIRECT_IGNORES_PORT = true;
+
+/**
+ * The content host an MCP App's `ui.domain` must name when it sets one.
+ *
+ * The domain is derived, not chosen: `sha256(<exact connector URL>)`, first 32
+ * hex characters, then this suffix. "Exact" is doing real work — a trailing
+ * slash, a different scheme, or a normalised port produces a different digest
+ * and therefore a domain Claude will not serve, which is why the check
+ * compares against the URL as entered rather than a canonicalised one.
+ */
+export const CLAUDE_APP_CONTENT_DOMAIN_SUFFIX = ".claudemcpcontent.com";
+
+/** Hex characters of the digest that go into the label. */
+export const CLAUDE_APP_CONTENT_DOMAIN_HASH_LENGTH = 32;
+
+/**
+ * The MIME profile a modern MCP App resource must declare.
+ *
+ * `text/html` alone is not it: the profile parameter is what tells the host
+ * the payload is an app rather than a document, and a mismatch is a failure in
+ * the modern-apps lane rather than a style note.
+ */
+export const CLAUDE_APP_HTML_MIME = "text/html;profile=mcp-app";
+
+/**
+ * Latency budgets, in milliseconds.
+ *
+ * These are grading thresholds, not hard timeouts. Every check that uses them
+ * samples and reports raw timings in its details: a shared CI node is a noisy
+ * place to measure, and a single slow sample must never be the whole verdict.
+ */
+export const CLAUDE_LATENCY_BUDGETS = {
+  /** Time to a usable `tools/list` after connect. */
+  toolListingMs: 5_000,
+  /** Time to first byte on the MCP endpoint. */
+  handshakeMs: 3_000,
+  /** How long a widget may take to reach first paint. */
+  widgetFirstPaintMs: 3_000,
+} as const;
+
+/**
+ * Minimum viewport width an MCP App must remain usable at, and the minimum
+ * touch-target edge, from the design guidelines.
+ */
+export const CLAUDE_APP_DESIGN_BUDGETS = {
+  minViewportWidthPx: 320,
+  minTouchTargetPx: 44,
+} as const;
+
+/**
+ * Listing-field bounds from the submission form. Deterministic to check, which
+ * is exactly why they belong to the directory-policy lane and not to a
+ * heuristic one.
+ */
+export const CLAUDE_SUBMISSION_LIMITS = {
+  nameMaxLength: 100,
+  taglineMaxLength: 55,
+  descriptionMaxLength: 2_000,
+  categoriesMin: 1,
+  categoriesMax: 5,
+  screenshotsMin: 3,
+  screenshotsMax: 5,
+  screenshotMinWidthPx: 1_000,
+  /** MCP tool names Claude will accept. */
+  toolNameMaxLength: 64,
+} as const;
+
+/**
+ * The whole profile as one object, with its provenance attached, so a surface
+ * can render "graded against Claude's published host profile, snapshot
+ * 2026-08-19" without reassembling it from loose constants.
+ */
+export const CLAUDE_HOST_PROFILE = {
+  callbackUrls: CLAUDE_CALLBACK_URLS,
+  loopbackRedirectIgnoresPort: CLAUDE_LOOPBACK_REDIRECT_IGNORES_PORT,
+  appContentDomainSuffix: CLAUDE_APP_CONTENT_DOMAIN_SUFFIX,
+  appContentDomainHashLength: CLAUDE_APP_CONTENT_DOMAIN_HASH_LENGTH,
+  appHtmlMime: CLAUDE_APP_HTML_MIME,
+  latencyBudgets: CLAUDE_LATENCY_BUDGETS,
+  appDesignBudgets: CLAUDE_APP_DESIGN_BUDGETS,
+  submissionLimits: CLAUDE_SUBMISSION_LIMITS,
+  source: claudePolicySource("directory", "Host profile constants"),
+} as const;

--- a/sdk/src/claude-readiness/runner.ts
+++ b/sdk/src/claude-readiness/runner.ts
@@ -1,0 +1,275 @@
+/**
+ * The composite readiness run.
+ *
+ * It gathers evidence once, hands it to the pure check modules, and assembles
+ * five lanes plus coverage. It deliberately does NOT re-implement anything the
+ * conformance suites already grade: an apps result and a protocol result are
+ * INPUTS, cited by the findings that rest on them.
+ *
+ * WHAT `status` MEANS HERE. Only the required lanes roll up
+ * (runtime-compatibility and directory-policy). Optional features can never
+ * make a connector "not ready" — a missing badge is not a defect — and
+ * experience insights can never do so either, because an LLM's opinion and a
+ * markup heuristic are not things a submitter should be held to.
+ *
+ * WHY `capabilities` IS ON THE RESULT. A CLI on a laptop can open a browser
+ * and complete an interactive authorization; a hosted node may refuse a raw
+ * origin; a Slack bot has neither. Two surfaces grading the same target agree
+ * only on their SHARED capability subset, and recording what this run could
+ * actually do is what makes a coverage gap legible instead of looking like a
+ * disagreement.
+ */
+
+import { runClaudeAppsChecks, type ClaudeAppsEvidence } from "./checks/apps.js";
+import {
+  runClaudeAuthChecks,
+  type ClaudeAuthEvidence,
+} from "./checks/auth.js";
+import {
+  runClaudeEndpointChecks,
+  type ClaudeEndpointEvidence,
+} from "./checks/endpoint.js";
+import { runClaudeOptionalFeatureChecks } from "./checks/optional-features.js";
+import {
+  CLAUDE_SUBMISSION_PROFILE_INPUT,
+  runClaudeSubmissionChecks,
+} from "./checks/submission.js";
+import { runClaudeToolChecks } from "./checks/tools.js";
+import {
+  gradeClaudeIntrusiveObservations,
+  resolveClaudeIntrusiveMode,
+  type ClaudeIntrusiveConfig,
+  type ClaudeIntrusiveObservations,
+} from "./intrusive.js";
+import { CLAUDE_POLICY_SNAPSHOT_DATE } from "./manifest.js";
+import {
+  parseClaudeSubmissionProfile,
+  type ClaudeSubmissionProfile,
+} from "./submission-profile.js";
+import {
+  CLAUDE_READINESS_ENGINE_VERSION,
+  CLAUDE_READINESS_LANES,
+  decideLaneStatus,
+  rollUpLaneStatus,
+  summarizeLaneCoverage,
+  type ClaudeCapabilityBadge,
+  type ClaudeReadinessAuthMode,
+  type ClaudeReadinessFinding,
+  type ClaudeReadinessLane,
+  type ClaudeReadinessLaneResult,
+  type ClaudeReadinessResult,
+  type ClaudeRunnerCapability,
+} from "./types.js";
+
+import type { Tool } from "@modelcontextprotocol/client";
+
+/**
+ * Everything a run needs, already gathered.
+ *
+ * The runner takes evidence rather than a URL because the two halves have
+ * different trust requirements: gathering evidence needs the pinned transport
+ * and a live connection, and grading it needs neither. Splitting them means
+ * the grading half is a pure function that a test can drive with a fixture and
+ * a hosted surface cannot accidentally point at `169.254.169.254`.
+ */
+export interface ClaudeReadinessInput {
+  /** The connector URL exactly as the user entered it. */
+  enteredUrl: string;
+  authMode: ClaudeReadinessAuthMode;
+  capabilities: ClaudeRunnerCapability[];
+  startedAt: string;
+  evaluatedAt: string;
+  durationMs: number;
+
+  endpoint: ClaudeEndpointEvidence;
+  auth: ClaudeAuthEvidence;
+  apps: ClaudeAppsEvidence;
+  tools?: Tool[];
+
+  /** Raw submission profile, validated here so its issues become findings. */
+  submissionProfile?: unknown;
+  /** Features the submitter claimed, if any. */
+  claimedFeatures?: {
+    lazyAuthentication?: boolean;
+    enterpriseManagedAuth?: boolean;
+  };
+  /** Observed auth mode, for contradicting a declaration. Never for supplying one. */
+  observedAuthMode?: string;
+
+  intrusive?: ClaudeIntrusiveConfig;
+  intrusiveObservations?: ClaudeIntrusiveObservations;
+
+  /** Suite results consumed as evidence, named for the report. */
+  evidenceSources?: string[];
+}
+
+/** Inputs a caller could supply to close a lane's gaps, by lane. */
+function missingInputsFor(
+  lane: ClaudeReadinessLane,
+  findings: ClaudeReadinessFinding[],
+): string[] {
+  return findings
+    .filter((finding) => finding.lane === lane)
+    .flatMap((finding) => {
+      const named = (finding.details as { missingInput?: unknown } | undefined)
+        ?.missingInput;
+      return typeof named === "string" ? [named] : [];
+    });
+}
+
+const LANE_SUMMARIES: Record<ClaudeReadinessLane, string> = {
+  "runtime-compatibility": "whether Claude can connect, authenticate and render",
+  "directory-policy": "the deterministic submission and review requirements",
+  "optional-features": "capability badges; nothing here can make a connector unready",
+  "submission-artifacts": "listing fields, screenshots and attestations",
+  "experience-insights": "heuristics and observations for a human to weigh",
+};
+
+function summarizeLane(
+  lane: ClaudeReadinessLane,
+  status: ClaudeReadinessLaneResult["status"],
+  findings: ClaudeReadinessFinding[],
+): string {
+  const violations = findings.filter(
+    (finding) =>
+      finding.status === "violated" &&
+      (finding.class === "required" || finding.class === "runtime-blocker"),
+  );
+  if (status === "not-ready") {
+    return `${violations.length} requirement(s) unmet — ${LANE_SUMMARIES[lane]}.`;
+  }
+  if (status === "incomplete") {
+    const unevaluated = findings.filter(
+      (finding) => finding.status === "not-evaluated",
+    ).length;
+    return unevaluated > 0
+      ? `${unevaluated} requirement(s) not evaluated — ${LANE_SUMMARIES[lane]}.`
+      : `Nothing dispositive was evaluated — ${LANE_SUMMARIES[lane]}.`;
+  }
+  return `All applicable requirements satisfied — ${LANE_SUMMARIES[lane]}.`;
+}
+
+/**
+ * Grade gathered evidence. Pure — no network, no clock, no randomness.
+ */
+export function gradeClaudeReadiness(
+  input: ClaudeReadinessInput,
+): ClaudeReadinessResult {
+  const stamp = { evaluatedAt: input.evaluatedAt };
+
+  // A malformed profile is kept and reported, not discarded: the caller did
+  // the work and got it wrong, and "no input" would hide their mistake.
+  const parsedProfile = input.submissionProfile
+    ? parseClaudeSubmissionProfile(input.submissionProfile)
+    : { profile: undefined as ClaudeSubmissionProfile | undefined, issues: [] };
+
+  const auth = runClaudeAuthChecks(
+    { ...input.auth, declaredAuthMode: parsedProfile.profile?.declaredAuthMode },
+    stamp,
+  );
+  const optional = runClaudeOptionalFeatureChecks(
+    {
+      auth: input.auth,
+      claimedFeatures: input.claimedFeatures,
+    },
+    stamp,
+  );
+
+  const intrusiveMode = resolveClaudeIntrusiveMode(input.intrusive, {
+    // A run whose auth mode is `provided-token` is holding somebody's
+    // credentials. The resolver is told so it can refuse to spend them.
+    hasBorrowedAccessToken: input.authMode === "provided-token",
+  });
+
+  const findings: ClaudeReadinessFinding[] = [
+    ...runClaudeEndpointChecks(input.endpoint, stamp),
+    ...auth.findings,
+    ...runClaudeToolChecks(input.tools, stamp),
+    ...runClaudeAppsChecks(input.apps, stamp),
+    ...runClaudeSubmissionChecks(
+      {
+        profile: parsedProfile.profile,
+        profileIssues: parsedProfile.issues,
+        observedAuthMode: input.observedAuthMode,
+      },
+      stamp,
+    ),
+    ...optional.findings,
+    ...gradeClaudeIntrusiveObservations(
+      intrusiveMode,
+      input.intrusiveObservations ?? {},
+      stamp,
+    ),
+  ];
+
+  const badges: ClaudeCapabilityBadge[] = [...auth.badges, ...optional.badges];
+
+  const lanes: ClaudeReadinessLaneResult[] = CLAUDE_READINESS_LANES.map((lane) => {
+    const laneFindings = findings.filter((finding) => finding.lane === lane);
+    const status = decideLaneStatus(laneFindings);
+    return {
+      lane,
+      status,
+      summary: summarizeLane(lane, status, laneFindings),
+      coverage: summarizeLaneCoverage(
+        lane,
+        laneFindings,
+        missingInputsFor(lane, findings),
+      ),
+    };
+  });
+
+  const status = rollUpLaneStatus(lanes);
+
+  return {
+    status,
+    summary: buildRunSummary(status, lanes),
+    context: {
+      target: input.enteredUrl,
+      authMode: input.authMode,
+      capabilities: [...input.capabilities].sort(),
+      evidenceSources: [...(input.evidenceSources ?? [])].sort(),
+    },
+    lanes,
+    findings,
+    badges,
+    policySnapshotDate: CLAUDE_POLICY_SNAPSHOT_DATE,
+    engineVersion: CLAUDE_READINESS_ENGINE_VERSION,
+    startedAt: input.startedAt,
+    durationMs: input.durationMs,
+  };
+}
+
+function buildRunSummary(
+  status: ClaudeReadinessResult["status"],
+  lanes: ClaudeReadinessLaneResult[],
+): string {
+  const required = lanes.filter(
+    (lane) =>
+      lane.lane === "runtime-compatibility" || lane.lane === "directory-policy",
+  );
+  if (status === "not-ready") {
+    const failing = required
+      .filter((lane) => lane.status === "not-ready")
+      .map((lane) => lane.lane);
+    return `Not ready for the Claude directory: ${failing.join(" and ")} ${
+      failing.length === 1 ? "has" : "have"
+    } unmet requirements.`;
+  }
+  if (status === "incomplete") {
+    const gaps = required
+      .filter((lane) => lane.status === "incomplete")
+      .flatMap((lane) => lane.coverage.missingInputs);
+    const unique = [...new Set(gaps)];
+    return unique.length > 0
+      ? `Readiness is undetermined: some requirements were not evaluated. Supply ${unique.join(", ")} to close the gap.`
+      : "Readiness is undetermined: some requirements could not be evaluated by this run.";
+  }
+  return "Every requirement this run could evaluate is satisfied.";
+}
+
+/** Named inputs a surface can offer to make a run more complete. */
+export const CLAUDE_READINESS_INPUTS = {
+  submissionProfile: CLAUDE_SUBMISSION_PROFILE_INPUT,
+  intrusive: "intrusive",
+} as const;

--- a/sdk/src/claude-readiness/runner.ts
+++ b/sdk/src/claude-readiness/runner.ts
@@ -49,6 +49,7 @@ import {
 import {
   CLAUDE_READINESS_ENGINE_VERSION,
   CLAUDE_READINESS_LANES,
+  CLAUDE_REQUIRED_LANES,
   decideLaneStatus,
   rollUpLaneStatus,
   summarizeLaneCoverage,
@@ -159,17 +160,33 @@ export function gradeClaudeReadiness(
 
   // A malformed profile is kept and reported, not discarded: the caller did
   // the work and got it wrong, and "no input" would hide their mistake.
-  const parsedProfile = input.submissionProfile
-    ? parseClaudeSubmissionProfile(input.submissionProfile)
-    : { profile: undefined as ClaudeSubmissionProfile | undefined, issues: [] };
+  // PRESENCE, not truthiness. `submissionProfile` is `unknown`, so `null`, `0`
+  // and `""` are malformed INPUT rather than absent input, and routing them
+  // down the "no input" branch would hide a caller's mistake behind a status
+  // that reads like our limitation — the very thing the parse result exists to
+  // prevent.
+  const parsedProfile =
+    input.submissionProfile === undefined
+      ? { profile: undefined as ClaudeSubmissionProfile | undefined, issues: [] }
+      : parseClaudeSubmissionProfile(input.submissionProfile);
 
-  const auth = runClaudeAuthChecks(
-    { ...input.auth, declaredAuthMode: parsedProfile.profile?.declaredAuthMode },
-    stamp,
-  );
+  // ONE merged view, shared by both check modules.
+  //
+  // The profile is authoritative when it declares a mode, but a caller may
+  // also declare one directly on the evidence — and an unconditional overwrite
+  // with `parsedProfile.profile?.declaredAuthMode` erased that declaration
+  // whenever no profile was supplied, which graded a preregistered-client
+  // connector as a runtime failure it does not have. Handing the two modules
+  // different views of the same field was the second half of the same bug.
+  const authEvidence = {
+    ...input.auth,
+    declaredAuthMode:
+      parsedProfile.profile?.declaredAuthMode ?? input.auth.declaredAuthMode,
+  };
+  const auth = runClaudeAuthChecks(authEvidence, stamp);
   const optional = runClaudeOptionalFeatureChecks(
     {
-      auth: input.auth,
+      auth: authEvidence,
       claimedFeatures: input.claimedFeatures,
     },
     stamp,
@@ -244,9 +261,11 @@ function buildRunSummary(
   status: ClaudeReadinessResult["status"],
   lanes: ClaudeReadinessLaneResult[],
 ): string {
-  const required = lanes.filter(
-    (lane) =>
-      lane.lane === "runtime-compatibility" || lane.lane === "directory-policy",
+  // From the shared constant, not a restated literal: `rollUpLaneStatus`
+  // decides the verdict from `CLAUDE_REQUIRED_LANES`, and a second copy here
+  // would let the summary name the wrong lanes after a change to that set.
+  const required = lanes.filter((lane) =>
+    CLAUDE_REQUIRED_LANES.includes(lane.lane),
   );
   if (status === "not-ready") {
     const failing = required

--- a/sdk/src/claude-readiness/runner.ts
+++ b/sdk/src/claude-readiness/runner.ts
@@ -153,6 +153,41 @@ function summarizeLane(
 /**
  * Grade gathered evidence. Pure — no network, no clock, no randomness.
  */
+/**
+ * Hold every finding to the capabilities its own definition declares.
+ *
+ * `requiresCapabilities` was documented as an invariant and enforced nowhere:
+ * each check module was trusted to remember that it had asked for a browser,
+ * an interactive authorization, or the intrusive opt-in, and to report
+ * `not-evaluated` when the run had none. A check that forgets does not fail
+ * loudly — it publishes a verdict it had no evidence for, which is the one
+ * outcome this product cannot afford. Enforcing it centrally makes the
+ * declaration the thing that decides, rather than a comment each author has to
+ * honour.
+ *
+ * It only ever downgrades. A missing capability turns a verdict into
+ * `not-evaluated`; nothing here can turn a `not-evaluated` into a pass.
+ */
+function enforceCapabilityGate(
+  findings: ClaudeReadinessFinding[],
+  capabilities: ClaudeRunnerCapability[],
+): ClaudeReadinessFinding[] {
+  const available = new Set(capabilities);
+  return findings.map((finding) => {
+    const missing = (finding.requiresCapabilities ?? []).filter(
+      (capability) => !available.has(capability),
+    );
+    if (missing.length === 0 || finding.status === "not-evaluated") {
+      return finding;
+    }
+    return {
+      ...finding,
+      status: "not-evaluated",
+      notEvaluatedReason: `this run had no ${missing.join(", ")} capability, so the check could not observe what it grades`,
+    };
+  });
+}
+
 export function gradeClaudeReadiness(
   input: ClaudeReadinessInput,
 ): ClaudeReadinessResult {
@@ -198,7 +233,8 @@ export function gradeClaudeReadiness(
     hasBorrowedAccessToken: input.authMode === "provided-token",
   });
 
-  const findings: ClaudeReadinessFinding[] = [
+  const findings: ClaudeReadinessFinding[] = enforceCapabilityGate(
+    [
     ...runClaudeEndpointChecks(input.endpoint, stamp),
     ...auth.findings,
     ...runClaudeToolChecks(input.tools, stamp),
@@ -217,7 +253,9 @@ export function gradeClaudeReadiness(
       input.intrusiveObservations ?? {},
       stamp,
     ),
-  ];
+    ],
+    input.capabilities,
+  );
 
   const badges: ClaudeCapabilityBadge[] = [...auth.badges, ...optional.badges];
 

--- a/sdk/src/claude-readiness/submission-profile.ts
+++ b/sdk/src/claude-readiness/submission-profile.ts
@@ -1,0 +1,155 @@
+/**
+ * The submission profile: what a submitter DECLARES, as opposed to what the
+ * wire shows.
+ *
+ * WHY AN INPUT AT ALL. Half of Anthropic's directory requirements are about
+ * artifacts a wire probe cannot see — a listing name, a tagline, screenshots,
+ * a privacy policy URL, seven attestations. A runner with no access to those
+ * has exactly two honest options: report the lane `incomplete` and name the
+ * input it lacks, or say nothing. What it must never do is infer them.
+ * `serverInfo.name` is NOT the listing name, and treating it as a proxy would
+ * grade a field the submitter never filled in.
+ *
+ * WHAT THIS BUYS. With the profile supplied, presence, lengths, URL shapes and
+ * image type/dimensions become DETERMINISTIC — pass or fail, no judgement. What
+ * stays `manual-review` is everything the bytes cannot settle: whether a
+ * screenshot shows the product, whether the submitter owns the domain, whether
+ * an attestation is true. Provenance on those findings is `declared`, so no
+ * reader can mistake "the submitter said so" for "we verified it".
+ *
+ * Pure schema. Safe from the browser entry.
+ */
+
+import { z } from "zod";
+
+import { CLAUDE_SUBMISSION_LIMITS } from "./profile.js";
+
+/**
+ * How the connector authenticates, as DECLARED. A wire probe can often infer
+ * this, but not always — a static-header credential and a custom connection
+ * flow both look like "no OAuth" from outside — so the declaration is what
+ * makes those cases classifiable instead of failures.
+ */
+export const CLAUDE_DECLARED_AUTH_MODES = [
+  "oauth-dcr",
+  "oauth-cimd",
+  "oauth-preregistered",
+  "static-header",
+  "authless",
+  "custom-connection",
+] as const;
+
+/** What the connector does with user data, as declared on the submission form. */
+export const CLAUDE_DATA_HANDLING_MODES = [
+  "no-user-data",
+  "processes-user-data",
+  "stores-user-data",
+  "shares-with-third-parties",
+] as const;
+
+/**
+ * The attestations the submission form requires.
+ *
+ * All seven are represented explicitly rather than as a count, so a profile
+ * that is missing one names WHICH one. Every one of them is a claim about the
+ * world that no probe can verify, which is why the checks over them are
+ * presence checks and the truth of them stays `manual-review`.
+ */
+export const CLAUDE_ATTESTATIONS = [
+  "ownsOrIsAuthorizedForService",
+  "accurateDataHandlingDisclosure",
+  "compliesWithUsagePolicies",
+  "noProhibitedContent",
+  "maintainsSecurityPractices",
+  "respondsToSecurityReports",
+  "keepsListingAccurate",
+] as const;
+
+const httpsUrl = z
+  .string()
+  .url()
+  .refine((value) => value.startsWith("https://"), {
+    message: "must be an https:// URL",
+  });
+
+const screenshotSchema = z.object({
+  /** Absolute URL or a data URI the caller has already resolved. */
+  url: z.string().min(1),
+  /** MIME type as served. Anthropic accepts PNG for listing screenshots. */
+  mimeType: z.string().min(1),
+  widthPx: z.number().int().positive(),
+  heightPx: z.number().int().positive(),
+  /**
+   * The prompt this screenshot illustrates. Paired, not optional: a gallery of
+   * screenshots with no prompts does not show a reviewer what the connector
+   * does, which is the thing the requirement is for.
+   */
+  prompt: z.string().min(1),
+});
+
+export const claudeSubmissionProfileSchema = z.object({
+  name: z.string().min(1).max(CLAUDE_SUBMISSION_LIMITS.nameMaxLength),
+  tagline: z.string().min(1).max(CLAUDE_SUBMISSION_LIMITS.taglineMaxLength),
+  description: z
+    .string()
+    .min(1)
+    .max(CLAUDE_SUBMISSION_LIMITS.descriptionMaxLength),
+  categories: z
+    .array(z.string().min(1))
+    .min(CLAUDE_SUBMISSION_LIMITS.categoriesMin)
+    .max(CLAUDE_SUBMISSION_LIMITS.categoriesMax),
+  /** URL-safe listing slug. */
+  slug: z
+    .string()
+    .min(1)
+    .regex(/^[a-z0-9]+(?:-[a-z0-9]+)*$/, "must be a lowercase kebab-case slug"),
+  documentationUrl: httpsUrl,
+  privacyPolicyUrl: httpsUrl,
+  supportUrl: httpsUrl,
+  iconUrl: httpsUrl,
+  declaredAuthMode: z.enum(CLAUDE_DECLARED_AUTH_MODES),
+  dataHandling: z.array(z.enum(CLAUDE_DATA_HANDLING_MODES)).min(1),
+  screenshots: z
+    .array(screenshotSchema)
+    .min(CLAUDE_SUBMISSION_LIMITS.screenshotsMin)
+    .max(CLAUDE_SUBMISSION_LIMITS.screenshotsMax),
+  /**
+   * Attestation → whether the submitter affirmed it. A missing key is not the
+   * same as `false`: one is an incomplete form, the other is a refusal, and
+   * the checks report them differently.
+   */
+  attestations: z.record(z.enum(CLAUDE_ATTESTATIONS), z.boolean()),
+});
+
+export type ClaudeSubmissionProfile = z.infer<
+  typeof claudeSubmissionProfileSchema
+>;
+export type ClaudeDeclaredAuthMode =
+  (typeof CLAUDE_DECLARED_AUTH_MODES)[number];
+export type ClaudeDataHandlingMode = (typeof CLAUDE_DATA_HANDLING_MODES)[number];
+export type ClaudeAttestation = (typeof CLAUDE_ATTESTATIONS)[number];
+
+/**
+ * A profile that failed validation, kept rather than discarded.
+ *
+ * A caller who supplied a malformed profile has NOT supplied no profile, and
+ * reporting the lane as "no input" would hide their mistake behind a status
+ * that reads like our limitation. The issues are surfaced as findings instead.
+ */
+export interface ClaudeSubmissionProfileParse {
+  profile?: ClaudeSubmissionProfile;
+  issues: string[];
+}
+
+export function parseClaudeSubmissionProfile(
+  input: unknown,
+): ClaudeSubmissionProfileParse {
+  const parsed = claudeSubmissionProfileSchema.safeParse(input);
+  if (parsed.success) return { profile: parsed.data, issues: [] };
+  return {
+    issues: parsed.error.issues.map(
+      (issue) =>
+        `${issue.path.join(".") || "(root)"}: ${issue.message}`,
+    ),
+  };
+}

--- a/sdk/src/claude-readiness/types.ts
+++ b/sdk/src/claude-readiness/types.ts
@@ -336,13 +336,24 @@ export function rollUpLaneStatus(
  * reads — that separation is what keeps an LLM's opinion out of a verdict a
  * submitter is held to.
  */
+/**
+ * Whether a finding can DECIDE a lane.
+ *
+ * Exported because the report adapter needs the same answer: a finding that
+ * decides a lane must render as a testcase, and one that does not must render
+ * as an advisory. Two copies of this predicate could disagree, and then a
+ * report would contradict the verdict it is reporting.
+ */
+export function isDispositiveClaudeFinding(
+  finding: Pick<ClaudeReadinessFinding, "class">,
+): boolean {
+  return finding.class === "required" || finding.class === "runtime-blocker";
+}
+
 export function decideLaneStatus(
   findings: ClaudeReadinessFinding[],
 ): ClaudeLaneStatus {
-  const dispositive = findings.filter(
-    (finding) =>
-      finding.class === "required" || finding.class === "runtime-blocker",
-  );
+  const dispositive = findings.filter(isDispositiveClaudeFinding);
   if (dispositive.some((finding) => finding.status === "violated")) {
     return "not-ready";
   }

--- a/sdk/src/claude-readiness/types.ts
+++ b/sdk/src/claude-readiness/types.ts
@@ -1,0 +1,374 @@
+/**
+ * The Claude directory-readiness result model.
+ *
+ * WHAT THIS IS NOT: a fifth scored MCP conformance suite. Anthropic's
+ * connector-directory requirements are a PUBLISHER'S POLICY, not the MCP
+ * specification, and the two answer different questions — "does this server
+ * speak MCP correctly" versus "would Anthropic list it". Mixing them corrupts
+ * both: a server can be flawless MCP and unlistable, or listed and sloppy. So
+ * readiness reuses none of the suites' MUST/SHOULD vocabulary, carries no
+ * conformance score, and is excluded from `pooledConformanceScore`. It
+ * CONSUMES the protocol/oauth/apps/host-compat results as evidence rather than
+ * re-running equivalent checks.
+ *
+ * WHAT IT IS: five independent lanes, each with its own semantics, plus
+ * coverage reported separately from findings so an unevaluated requirement is
+ * never mistaken for a satisfied one. `decideConformanceOutcome`'s rule —
+ * "did not run" must never read as "conformed" — is the ancestor of the
+ * `incomplete` status here.
+ *
+ * Pure data: no MCP client, no transport, no Node built-ins. Safe from the
+ * browser entry.
+ */
+
+import type { ClaudePolicySourceRef } from "./manifest.js";
+
+/**
+ * The engine that produced a finding, stamped onto every one of them.
+ *
+ * Bumped when a check's SEMANTICS change, not when the SDK version does: two
+ * grades of the same target under the same policy snapshot should be
+ * comparable, and tying this to the package version would make every unrelated
+ * release look like a re-audit.
+ */
+export const CLAUDE_READINESS_ENGINE_VERSION = "1";
+
+/**
+ * The five lanes. Each answers a different question and fails for different
+ * reasons, so they are never collapsed into one verdict.
+ */
+export const CLAUDE_READINESS_LANES = [
+  /** Will Claude be able to connect, authenticate, and render at all? */
+  "runtime-compatibility",
+  /** Deterministic submission/review requirements Anthropic states outright. */
+  "directory-policy",
+  /** Capability badges: lazy auth, enterprise-managed auth, auth strategy. */
+  "optional-features",
+  /** Listing fields, screenshots, attestations. Needs declared input. */
+  "submission-artifacts",
+  /** Heuristics, browser observations, LLM/manual review. Never a blocker. */
+  "experience-insights",
+] as const;
+
+export type ClaudeReadinessLane = (typeof CLAUDE_READINESS_LANES)[number];
+
+/**
+ * What KIND of statement a finding is making. Deliberately not `MUST`/`SHOULD`
+ * — those belong to the MCP spec, and reusing them here would let a policy
+ * preference read as a protocol violation.
+ *
+ *   - `required` — Anthropic states it as a submission/review requirement.
+ *     A violation means the connector will be rejected or delisted.
+ *   - `runtime-blocker` — Claude cannot complete the flow at all. Distinct
+ *     from `required` because it fails before policy is even reached: a broken
+ *     first `authorization_servers` entry is not a paperwork problem.
+ *   - `recommended` — stated guidance whose violation is not disqualifying.
+ *   - `experimental-feature` — a capability badge, not a grade. Absence is
+ *     never a defect.
+ *   - `manual-review` — a human has to look. Quality, ownership, and
+ *     credential validity cannot be decided from the wire.
+ *   - `heuristic` — a signal, not a verdict. Belongs to experience-insights
+ *     and may be confirmed by an LLM or a person; never fails a lane.
+ */
+export const CLAUDE_FINDING_CLASSES = [
+  "required",
+  "runtime-blocker",
+  "recommended",
+  "experimental-feature",
+  "manual-review",
+  "heuristic",
+] as const;
+
+export type ClaudeFindingClass = (typeof CLAUDE_FINDING_CLASSES)[number];
+
+/**
+ * The status of a lane whose findings are dispositive.
+ *
+ *   - `ready` — every applicable requirement was evaluated and satisfied.
+ *   - `not-ready` — at least one applicable requirement was violated.
+ *   - `incomplete` — nothing was violated, but something the lane needs was
+ *     never evaluated. `missingInputs` says what the caller must supply.
+ *
+ * `incomplete` is load-bearing and self-describing: a wire-only run cannot see
+ * a screenshot, and reporting `ready` for a lane it could not evaluate would
+ * be the single most damaging thing this product could do.
+ */
+export type ClaudeLaneStatus = "ready" | "not-ready" | "incomplete";
+
+/**
+ * How a finding was established. A grade that cannot say where its evidence
+ * came from is not auditable, and provenance is what stops a static lint from
+ * being read as an observed runtime fact.
+ *
+ *   - `wire` — observed in an HTTP/MCP exchange this run performed.
+ *   - `browser` — observed in a rendered widget/browser harness.
+ *   - `static` — read out of a document, manifest, or schema without dialing.
+ *   - `declared` — asserted by the submitter in a submission profile. Never
+ *     independently verified by this run.
+ *   - `manual` — recorded by a person.
+ */
+export const CLAUDE_EVIDENCE_PROVENANCE = [
+  "wire",
+  "browser",
+  "static",
+  "declared",
+  "manual",
+] as const;
+
+export type ClaudeEvidenceProvenance =
+  (typeof CLAUDE_EVIDENCE_PROVENANCE)[number];
+
+/**
+ * How much a check DOES to the target.
+ *
+ *   - `passive` — no request attributable to this check.
+ *   - `read-only` — requests with no persistent effect on the target.
+ *   - `side-effecting` — registers a client, spends a grant, mutates state.
+ *     Only ever reached through the explicit intrusive opt-in.
+ */
+export const CLAUDE_INTRUSIVENESS_LEVELS = [
+  "passive",
+  "read-only",
+  "side-effecting",
+] as const;
+
+export type ClaudeIntrusiveness = (typeof CLAUDE_INTRUSIVENESS_LEVELS)[number];
+
+/**
+ * How the run authenticated. Recorded on the run so `incomplete` explains
+ * itself: a headless run genuinely cannot complete an interactive consent
+ * screen, and that is a property of the run, not a defect in the server.
+ */
+export type ClaudeReadinessAuthMode =
+  | "headless"
+  | "interactive"
+  | "provided-token";
+
+/**
+ * A capability the RUNNER may or may not have. Surfaces differ — a CLI on a
+ * laptop can resolve DNS and open a browser; a hosted node may refuse raw
+ * origins; a Slack bot has neither — so two surfaces grading the same target
+ * agree only on their SHARED capability subset. Asserting check-for-check
+ * equality across surfaces would be asserting something false.
+ */
+export const CLAUDE_RUNNER_CAPABILITIES = [
+  /** Can resolve arbitrary hostnames. */
+  "dns",
+  /** Can send requests with an arbitrary `Origin`, including a raw one. */
+  "raw-origin",
+  /** Can complete an interactive OAuth authorization. */
+  "interactive-oauth",
+  /** Can render a widget in a real browser engine. */
+  "browser",
+  /** Can render in WebKit specifically, which is what Claude's apps use. */
+  "webkit-browser",
+  /** Explicit opt-in to side-effecting probes is present AND configured. */
+  "intrusive-probes",
+] as const;
+
+export type ClaudeRunnerCapability = (typeof CLAUDE_RUNNER_CAPABILITIES)[number];
+
+/** A finding's verdict. `informational` carries no pass/fail meaning at all. */
+export type ClaudeFindingStatus =
+  | "satisfied"
+  | "violated"
+  | "not-evaluated"
+  | "not-applicable"
+  | "informational";
+
+/**
+ * One graded statement about the target.
+ *
+ * Every field below the verdict exists so the finding survives contact with
+ * time: Anthropic's docs change, and a grade that cannot say WHICH revision it
+ * was made against becomes silently wrong rather than visibly stale.
+ */
+export interface ClaudeReadinessFinding {
+  /**
+   * Stable identifier, shipped WITH its check. There is deliberately no frozen
+   * union of ids for checks that do not exist yet: publishing one would make
+   * the inventory look complete while the coverage was not, which is the same
+   * lie `incomplete` exists to prevent.
+   */
+  id: string;
+  title: string;
+  lane: ClaudeReadinessLane;
+  class: ClaudeFindingClass;
+  status: ClaudeFindingStatus;
+  /** One sentence a submitter can act on. Absent for `satisfied`. */
+  remediation?: string;
+  /** Where in Anthropic's documentation this requirement comes from. */
+  source: ClaudePolicySourceRef;
+  provenance: ClaudeEvidenceProvenance;
+  intrusiveness: ClaudeIntrusiveness;
+  /**
+   * Capabilities the runner needed. When the run lacks one, the finding is
+   * `not-evaluated` and this is why — which is what makes a coverage gap
+   * legible instead of silent.
+   */
+  requiresCapabilities?: ClaudeRunnerCapability[];
+  /** Why a `not-evaluated` finding was not evaluated, in plain words. */
+  notEvaluatedReason?: string;
+  /** ISO-8601. The moment the verdict was reached, not when it was rendered. */
+  evaluatedAt: string;
+  /** Version of the readiness engine that produced this finding. */
+  engineVersion: string;
+  /** Raw observation behind the verdict. Redacted before telemetry. */
+  details?: Record<string, unknown>;
+  /**
+   * Suite results this finding was DERIVED from rather than re-observed, e.g.
+   * `"oauth-conformance:oauth-prm-resource-match"`. Readiness composes; a
+   * finding that quietly re-ran an existing check would let the two disagree.
+   */
+  derivedFrom?: string[];
+}
+
+/**
+ * What a lane managed to look at, reported SEPARATELY from what it found.
+ *
+ * A lane with zero violations and zero evaluated checks is not a pass, and the
+ * only way to keep those apart is to publish the denominator.
+ */
+export interface ClaudeLaneCoverage {
+  lane: ClaudeReadinessLane;
+  /** Findings that reached a `satisfied`/`violated` verdict. */
+  evaluated: number;
+  /** Applicable but never exercised. Each one is an unanswered question. */
+  notEvaluated: number;
+  /** Could not apply to this target; not a gap. */
+  notApplicable: number;
+  /**
+   * Named inputs the caller could supply to close the gap, e.g.
+   * `"submissionProfile"`, `"intrusive.testCredentials"`. Empty when the gap
+   * is not the caller's to close.
+   */
+  missingInputs: string[];
+}
+
+export interface ClaudeReadinessLaneResult {
+  lane: ClaudeReadinessLane;
+  status: ClaudeLaneStatus;
+  /** One line a human can read without opening the findings. */
+  summary: string;
+  coverage: ClaudeLaneCoverage;
+}
+
+/**
+ * A capability badge. Present in the optional-features lane only, and never a
+ * defect when absent — that is the whole difference between a badge and a
+ * requirement.
+ */
+export interface ClaudeCapabilityBadge {
+  id: string;
+  title: string;
+  /**
+   * `supported` — observed working. `unsupported` — observed absent.
+   * `claimed` — the submitter declared it and this run did not verify it.
+   * `not-evaluated` — never looked, which is the default for a badge whose
+   * depth-evaluation was neither claimed nor selected.
+   */
+  state: "supported" | "unsupported" | "claimed" | "not-evaluated";
+  detail?: string;
+  provenance: ClaudeEvidenceProvenance;
+}
+
+/** How the target was reached and what the runner could do while it was there. */
+export interface ClaudeReadinessRunContext {
+  target: string;
+  authMode: ClaudeReadinessAuthMode;
+  capabilities: ClaudeRunnerCapability[];
+  /** Suite results consumed as evidence, by kind. */
+  evidenceSources: string[];
+}
+
+export interface ClaudeReadinessResult {
+  /**
+   * The one dispositive status: the REQUIRED lanes' rollup
+   * (runtime-compatibility + directory-policy). Optional features and
+   * experience insights can never move it, by construction.
+   */
+  status: ClaudeLaneStatus;
+  /** Human-readable rollup of `status`, naming what is missing when incomplete. */
+  summary: string;
+  context: ClaudeReadinessRunContext;
+  lanes: ClaudeReadinessLaneResult[];
+  findings: ClaudeReadinessFinding[];
+  badges: ClaudeCapabilityBadge[];
+  /** Snapshot date of the policy corpus this run graded against (ISO date). */
+  policySnapshotDate: string;
+  engineVersion: string;
+  startedAt: string;
+  durationMs: number;
+}
+
+/** Lanes whose status rolls up into {@link ClaudeReadinessResult.status}. */
+export const CLAUDE_REQUIRED_LANES: readonly ClaudeReadinessLane[] = [
+  "runtime-compatibility",
+  "directory-policy",
+];
+
+/**
+ * Roll the required lanes up.
+ *
+ * `not-ready` dominates `incomplete` dominates `ready`. The ordering is the
+ * point: a run that found a violation AND could not evaluate something else is
+ * `not-ready` — the violation is established, and softening it to `incomplete`
+ * would let an unrelated coverage gap launder a real failure.
+ */
+export function rollUpLaneStatus(
+  lanes: ClaudeReadinessLaneResult[],
+): ClaudeLaneStatus {
+  const required = lanes.filter((lane) =>
+    CLAUDE_REQUIRED_LANES.includes(lane.lane),
+  );
+  if (required.some((lane) => lane.status === "not-ready")) return "not-ready";
+  if (required.some((lane) => lane.status === "incomplete")) return "incomplete";
+  // No required lane present at all is not a pass; it is a run that graded
+  // nothing dispositive.
+  return required.length === 0 ? "incomplete" : "ready";
+}
+
+/**
+ * Decide one lane's status from its findings.
+ *
+ * Only `required` and `runtime-blocker` findings can make a lane `not-ready`.
+ * A `heuristic` or `manual-review` finding never does, however alarming it
+ * reads — that separation is what keeps an LLM's opinion out of a verdict a
+ * submitter is held to.
+ */
+export function decideLaneStatus(
+  findings: ClaudeReadinessFinding[],
+): ClaudeLaneStatus {
+  const dispositive = findings.filter(
+    (finding) =>
+      finding.class === "required" || finding.class === "runtime-blocker",
+  );
+  if (dispositive.some((finding) => finding.status === "violated")) {
+    return "not-ready";
+  }
+  if (dispositive.some((finding) => finding.status === "not-evaluated")) {
+    return "incomplete";
+  }
+  return dispositive.length === 0 ? "incomplete" : "ready";
+}
+
+/** Tally a lane's coverage from its findings. */
+export function summarizeLaneCoverage(
+  lane: ClaudeReadinessLane,
+  findings: ClaudeReadinessFinding[],
+  missingInputs: string[] = [],
+): ClaudeLaneCoverage {
+  return {
+    lane,
+    evaluated: findings.filter(
+      (finding) =>
+        finding.status === "satisfied" || finding.status === "violated",
+    ).length,
+    notEvaluated: findings.filter((finding) => finding.status === "not-evaluated")
+      .length,
+    notApplicable: findings.filter(
+      (finding) => finding.status === "not-applicable",
+    ).length,
+    missingInputs: [...new Set(missingInputs)].sort(),
+  };
+}

--- a/sdk/src/conformance-reporting.ts
+++ b/sdk/src/conformance-reporting.ts
@@ -31,14 +31,48 @@ import type {
   MCPTasksConformanceResult,
   MCPTasksCheckResult,
 } from "./tasks-conformance/index.js";
+import type {
+  ClaudeReadinessFinding,
+  ClaudeReadinessResult,
+} from "./claude-readiness/types.js";
 
 export type ConformanceReportKind =
   | "protocol-conformance"
   | "oauth-conformance"
   | "apps-conformance"
-  | "tasks-conformance";
+  | "tasks-conformance"
+  // NOT a fifth conformance suite. Claude directory readiness grades a
+  // PUBLISHER'S POLICY, not the MCP specification, so it carries no
+  // `score` and is excluded from `pooledConformanceScore` by construction —
+  // the adapter below simply never sets the field. Consumers that switch on
+  // this union must treat it as an advisory-bearing report rather than a
+  // conformance verdict they can pool.
+  | "claude-directory-readiness";
 
 export type ConformanceReportCaseStatus = "passed" | "failed" | "skipped";
+
+/**
+ * A statement that is REPORTED but never graded.
+ *
+ * Heuristics, recommendations, capability badges and things a human has to
+ * look at all belong here. They exist because suppressing them would lose real
+ * signal, and they are kept out of `cases` because a CI job that fails on an
+ * LLM's opinion — or on a capability the server was never required to have —
+ * teaches its owners to ignore the job. JUnit renders these as `<properties>`,
+ * never as failed testcases.
+ */
+export interface ConformanceReportAdvisory {
+  id: string;
+  title: string;
+  /** Id of the {@link ConformanceReportGroup} this advisory was raised in. */
+  group: string;
+  /** What kind of statement it is, e.g. a finding class. */
+  kind: string;
+  /** The verdict, in the vocabulary of whatever produced it. */
+  status: string;
+  message?: string;
+  details?: unknown;
+}
 
 export interface ConformanceReportCase {
   id: string;
@@ -88,13 +122,22 @@ export interface ConformanceReport {
   score?: ConformanceScore;
   durationMs: number;
   groups: ConformanceReportGroup[];
+  /**
+   * Ungraded statements. Absent for the conformance suites, which have none;
+   * present for readiness, whose experience-insights lane is entirely
+   * advisory. Adding an OPTIONAL field keeps `schemaVersion` at 1 — an older
+   * consumer reading a readiness report ignores it and still gets a valid
+   * report, which is the property a version bump would otherwise be asserting.
+   */
+  advisories?: ConformanceReportAdvisory[];
 }
 
 type SupportedSingleConformanceResult =
   | MCPConformanceResult
   | OAuthConformanceResult
   | MCPAppsConformanceResult
-  | MCPTasksConformanceResult;
+  | MCPTasksConformanceResult
+  | ClaudeReadinessResult;
 
 type SupportedSuiteConformanceResult =
   | MCPConformanceSuiteResult
@@ -513,6 +556,127 @@ function createOAuthReport(
   };
 }
 
+/**
+ * Readiness is structurally unlike the suites: `lanes` and `findings` instead
+ * of `checks`, and a `status` that is a three-value readiness verdict rather
+ * than a pass/fail. Discriminating on `lanes` is enough — no suite has one.
+ */
+function isClaudeReadinessResult(
+  result: SupportedConformanceResult,
+): result is ClaudeReadinessResult {
+  return "lanes" in result && "findings" in result && "badges" in result;
+}
+
+/**
+ * Only findings that can DECIDE a lane become testcases.
+ *
+ * Everything else is an advisory. A CI job that fails on a heuristic teaches
+ * its owners to ignore the job, and a capability badge is not a defect at all,
+ * so rendering either as a failed testcase would be actively harmful.
+ */
+function isDispositiveFinding(finding: ClaudeReadinessFinding): boolean {
+  return finding.class === "required" || finding.class === "runtime-blocker";
+}
+
+function readinessCaseStatus(
+  finding: ClaudeReadinessFinding,
+): ConformanceReportCaseStatus {
+  if (finding.status === "violated") return "failed";
+  if (finding.status === "satisfied") return "passed";
+  return "skipped";
+}
+
+function createClaudeReadinessReport(
+  result: ClaudeReadinessResult,
+): ConformanceReport {
+  const advisories: ConformanceReportAdvisory[] = [];
+  const groups: ConformanceReportGroup[] = result.lanes.map((lane) => {
+    const laneFindings = result.findings.filter(
+      (finding) => finding.lane === lane.lane,
+    );
+    for (const finding of laneFindings) {
+      if (isDispositiveFinding(finding)) continue;
+      advisories.push({
+        id: finding.id,
+        title: finding.title,
+        group: lane.lane,
+        kind: finding.class,
+        status: finding.status,
+        message: finding.remediation ?? finding.notEvaluatedReason,
+        details: buildDetailPayload({
+          provenance: finding.provenance,
+          source: finding.source,
+          derivedFrom: finding.derivedFrom,
+          observed: finding.details,
+        }),
+      });
+    }
+    return {
+      id: lane.lane,
+      title: lane.lane,
+      target: result.context.target,
+      // A lane that could not be evaluated is not a passing lane; only
+      // `ready` is. This is the same rule `decideConformanceOutcome` applies
+      // to a suite that skipped half its checks.
+      passed: lane.status === "ready",
+      durationMs: 0,
+      summary: lane.summary,
+      cases: laneFindings.filter(isDispositiveFinding).map((finding) => ({
+        id: finding.id,
+        title: finding.title,
+        category: finding.class,
+        status: readinessCaseStatus(finding),
+        // A finding that was never evaluated left an obligation untested; a
+        // finding that could not apply left nothing unverified. The suites
+        // draw exactly this line and CI reads it.
+        skipReason:
+          finding.status === "not-evaluated"
+            ? ("could-not-run" as const)
+            : finding.status === "not-applicable"
+              ? ("not-applicable" as const)
+              : undefined,
+        durationMs: 0,
+        description: finding.remediation,
+        error:
+          finding.status === "violated"
+            ? (finding.remediation ?? "Requirement not satisfied")
+            : finding.status === "not-evaluated"
+              ? finding.notEvaluatedReason
+              : undefined,
+        details: buildDetailPayload({
+          provenance: finding.provenance,
+          intrusiveness: finding.intrusiveness,
+          source: finding.source,
+          requiresCapabilities: finding.requiresCapabilities,
+          derivedFrom: finding.derivedFrom,
+          observed: finding.details,
+        }),
+      })),
+    };
+  });
+
+  return {
+    schemaVersion: 1,
+    kind: "claude-directory-readiness",
+    name: "Claude Directory Readiness",
+    passed: result.status === "ready",
+    outcome:
+      result.status === "ready"
+        ? "passed"
+        : result.status === "not-ready"
+          ? "failed"
+          : "incomplete",
+    incompleteReason:
+      result.status === "incomplete" ? result.summary : undefined,
+    // DELIBERATELY NO `score`. Readiness grades Anthropic's policy, not the
+    // MCP spec, and pooling it with the four conformance suites would put a
+    // publisher's listing requirements into a protocol-conformance number.
+    durationMs: result.durationMs,
+    groups,
+    advisories,
+  };
+}
+
 export function toConformanceReport(
   result: MCPConformanceResult,
 ): ConformanceReport;
@@ -535,11 +699,20 @@ export function toConformanceReport(
   result: MCPTasksConformanceResult,
 ): ConformanceReport;
 export function toConformanceReport(
+  result: ClaudeReadinessResult,
+): ConformanceReport;
+export function toConformanceReport(
   result: SupportedConformanceResult,
 ): ConformanceReport;
 export function toConformanceReport(
   result: SupportedConformanceResult,
 ): ConformanceReport {
+  // First: readiness is not a suite, and every discriminator below is written
+  // for suite shapes.
+  if (isClaudeReadinessResult(result)) {
+    return createClaudeReadinessReport(result);
+  }
+
   if (isMcpSingleResult(result) || isMcpSuiteResult(result)) {
     return createProtocolReport(result);
   }
@@ -600,9 +773,34 @@ function renderConformanceTestCase(
   return `    <testcase name="${name}" classname="${escapedClassname}" time="${time}"/>`;
 }
 
+/**
+ * Advisories as `<properties>`, which is the only JUnit element that can carry
+ * "here is something you should know" without asserting a verdict.
+ *
+ * The alternative — a `<testcase>` with `<failure>` — would make every CI job
+ * that runs readiness go red on a heuristic, and the alternative after that is
+ * that everyone adds `|| true`. Property names are namespaced by advisory id
+ * so two lanes cannot collide.
+ */
+function renderAdvisoryProperties(
+  advisories: ConformanceReportAdvisory[],
+): string {
+  return advisories
+    .map((advisory) => {
+      const value = advisory.message
+        ? `${advisory.kind}/${advisory.status}: ${advisory.title} — ${advisory.message}`
+        : `${advisory.kind}/${advisory.status}: ${advisory.title}`;
+      return `      <property name="mcpjam.advisory.${escapeXml(
+        sanitizeToken(advisory.id),
+      )}" value="${escapeXml(value)}"/>`;
+    })
+    .join("\n");
+}
+
 function renderConformanceTestSuite(
   group: ConformanceReportGroup,
   score: ConformanceScore | undefined,
+  advisories: ConformanceReportAdvisory[] = [],
 ): string {
   const name = escapeXml(group.title);
   const tests = group.cases.length;
@@ -615,13 +813,22 @@ function renderConformanceTestSuite(
   // <testsuites> root — a root-level block is schema-invalid to Jenkins and
   // friends. The score is REPORT-level (pooled for suites), so every
   // testsuite carries the same values; the property names say so.
-  const properties = score
-    ? `    <properties>\n      <property name="mcpjam.conformance.score" value="${
+  const scoreProperties = score
+    ? `      <property name="mcpjam.conformance.score" value="${
         score.score === null ? "not-scored" : String(score.score)
       }"/>\n      <property name="mcpjam.conformance.summary" value="${escapeXml(
         describeConformanceScore(score),
-      )}"/>\n    </properties>\n`
+      )}"/>`
     : "";
+  const groupAdvisories = advisories.filter(
+    (advisory) => advisory.group === group.id,
+  );
+  const advisoryProperties = renderAdvisoryProperties(groupAdvisories);
+  const propertyLines = [scoreProperties, advisoryProperties].filter(Boolean);
+  const properties =
+    propertyLines.length > 0
+      ? `    <properties>\n${propertyLines.join("\n")}\n    </properties>\n`
+      : "";
 
   const cases = group.cases
     .map((entry) => renderConformanceTestCase(entry, classname))
@@ -652,7 +859,13 @@ export function renderConformanceReportJUnitXml(
   const name = escapeXml(redactedReport.name);
 
   const suites = redactedReport.groups
-    .map((group) => renderConformanceTestSuite(group, redactedReport.score))
+    .map((group) =>
+      renderConformanceTestSuite(
+        group,
+        redactedReport.score,
+        redactedReport.advisories ?? [],
+      ),
+    )
     .join("\n");
 
   return `<?xml version="1.0" encoding="UTF-8"?>\n<testsuites name="${name}" tests="${tests}" failures="${failures}" skipped="${skipped}" time="${time}">\n${suites}\n</testsuites>\n`;

--- a/sdk/src/conformance-reporting.ts
+++ b/sdk/src/conformance-reporting.ts
@@ -31,9 +31,10 @@ import type {
   MCPTasksConformanceResult,
   MCPTasksCheckResult,
 } from "./tasks-conformance/index.js";
-import type {
-  ClaudeReadinessFinding,
-  ClaudeReadinessResult,
+import {
+  isDispositiveClaudeFinding,
+  type ClaudeReadinessFinding,
+  type ClaudeReadinessResult,
 } from "./claude-readiness/types.js";
 
 export type ConformanceReportKind =
@@ -568,15 +569,14 @@ function isClaudeReadinessResult(
 }
 
 /**
- * Only findings that can DECIDE a lane become testcases.
+ * Only findings that can DECIDE a lane become testcases; everything else is an
+ * advisory. A CI job that fails on a heuristic teaches its owners to ignore the
+ * job, and a capability badge is not a defect at all.
  *
- * Everything else is an advisory. A CI job that fails on a heuristic teaches
- * its owners to ignore the job, and a capability badge is not a defect at all,
- * so rendering either as a failed testcase would be actively harmful.
+ * The predicate itself is imported rather than restated, so the renderer and
+ * `decideLaneStatus` cannot drift into disagreeing about the same finding.
  */
-function isDispositiveFinding(finding: ClaudeReadinessFinding): boolean {
-  return finding.class === "required" || finding.class === "runtime-blocker";
-}
+const isDispositiveFinding = isDispositiveClaudeFinding;
 
 function readinessCaseStatus(
   finding: ClaudeReadinessFinding,
@@ -590,11 +590,18 @@ function createClaudeReadinessReport(
   result: ClaudeReadinessResult,
 ): ConformanceReport {
   const advisories: ConformanceReportAdvisory[] = [];
+  // `lanes` and `findings` are independent arrays on the result, so nothing in
+  // the type says every finding's lane appears in `lanes`. When it does not,
+  // an unconsumed finding — a VIOLATED requirement included — would vanish
+  // from the report with no counter and no error. Tracking what was consumed
+  // and sweeping the remainder into advisories keeps the report total.
+  const consumed = new Set<ClaudeReadinessFinding>();
   const groups: ConformanceReportGroup[] = result.lanes.map((lane) => {
     const laneFindings = result.findings.filter(
       (finding) => finding.lane === lane.lane,
     );
     for (const finding of laneFindings) {
+      consumed.add(finding);
       if (isDispositiveFinding(finding)) continue;
       advisories.push({
         id: finding.id,
@@ -654,6 +661,29 @@ function createClaudeReadinessReport(
       })),
     };
   });
+
+  for (const finding of result.findings) {
+    if (consumed.has(finding)) continue;
+    // Orphaned: its lane was not reported. Rendered as an advisory rather than
+    // dropped, and tagged with the lane it CLAIMED, so the gap is visible in
+    // the output instead of being invisible in it.
+    advisories.push({
+      id: finding.id,
+      title: finding.title,
+      group: finding.lane,
+      kind: finding.class,
+      status: finding.status,
+      message:
+        finding.remediation ??
+        finding.notEvaluatedReason ??
+        `reported outside any lane in this result`,
+      details: buildDetailPayload({
+        provenance: finding.provenance,
+        source: finding.source,
+        orphanedLane: finding.lane,
+      }),
+    });
+  }
 
   return {
     schemaVersion: 1,
@@ -858,15 +888,26 @@ export function renderConformanceReportJUnitXml(
   const time = (redactedReport.durationMs / 1000).toFixed(3);
   const name = escapeXml(redactedReport.name);
 
+  const advisories = redactedReport.advisories ?? [];
   const suites = redactedReport.groups
     .map((group) =>
-      renderConformanceTestSuite(
-        group,
-        redactedReport.score,
-        redactedReport.advisories ?? [],
-      ),
+      renderConformanceTestSuite(group, redactedReport.score, advisories),
     )
     .join("\n");
 
-  return `<?xml version="1.0" encoding="UTF-8"?>\n<testsuites name="${name}" tests="${tests}" failures="${failures}" skipped="${skipped}" time="${time}">\n${suites}\n</testsuites>\n`;
+  // An advisory whose `group` names no rendered testsuite would otherwise be
+  // filtered away in silence — present in the JSON report, absent from the
+  // JUnit output, with nothing saying so. It gets its own suite instead.
+  const renderedGroups = new Set(redactedReport.groups.map((group) => group.id));
+  const orphanedAdvisories = advisories.filter(
+    (advisory) => !renderedGroups.has(advisory.group),
+  );
+  const orphanSuite =
+    orphanedAdvisories.length > 0
+      ? `\n  <testsuite name="mcpjam.advisories" tests="0" failures="0" skipped="0" time="0.000">\n    <properties>\n${renderAdvisoryProperties(
+          orphanedAdvisories,
+        )}\n    </properties>\n  </testsuite>`
+      : "";
+
+  return `<?xml version="1.0" encoding="UTF-8"?>\n<testsuites name="${name}" tests="${tests}" failures="${failures}" skipped="${skipped}" time="${time}">\n${suites}${orphanSuite}\n</testsuites>\n`;
 }

--- a/sdk/src/index.ts
+++ b/sdk/src/index.ts
@@ -411,6 +411,14 @@ export type {
 // and the dialing checks are deliberately not re-exported here, so importing
 // the result model never pulls a transport in with it.
 export * from "./claude-readiness/index.js";
+// The one readiness module that touches the network, exported only from the
+// Node entry. It is deliberately absent from `claude-readiness/index.ts` so
+// that importing the result model can never pull a transport in with it.
+export {
+  discoverClaudeAuthEvidence,
+  traceConnectorRedirects,
+} from "./claude-readiness/discovery.js";
+export type { ClaudeDiscoveryOptions } from "./claude-readiness/discovery.js";
 export {
   buildOutcomeSummary,
   decideConformanceOutcome,

--- a/sdk/src/index.ts
+++ b/sdk/src/index.ts
@@ -399,12 +399,18 @@ export {
 } from "./conformance-reporting.js";
 export type {
   ConformanceReport,
+  ConformanceReportAdvisory,
   ConformanceReportCase,
   ConformanceReportCaseStatus,
   ConformanceReportGroup,
   ConformanceReportKind,
   SupportedConformanceResult,
 } from "./conformance-reporting.js";
+
+// Claude directory readiness. Pure data and data reasoning only — the runner
+// and the dialing checks are deliberately not re-exported here, so importing
+// the result model never pulls a transport in with it.
+export * from "./claude-readiness/index.js";
 export {
   buildOutcomeSummary,
   decideConformanceOutcome,

--- a/sdk/src/index.ts
+++ b/sdk/src/index.ts
@@ -419,6 +419,12 @@ export {
   traceConnectorRedirects,
 } from "./claude-readiness/discovery.js";
 export type { ClaudeDiscoveryOptions } from "./claude-readiness/discovery.js";
+// The side-effecting intrusive probes, likewise Node-only. The gate that arms
+// them and the grading that reads them are pure and come from the barrel above.
+export {
+  probeDynamicRegistration,
+  probeRefreshRotation,
+} from "./claude-readiness/intrusive-probes.js";
 export {
   buildOutcomeSummary,
   decideConformanceOutcome,

--- a/sdk/src/mcp-client-manager/MCPClientManager.ts
+++ b/sdk/src/mcp-client-manager/MCPClientManager.ts
@@ -401,6 +401,8 @@ export class MCPClientManager {
   private readonly defaultLogJsonRpc: boolean;
   private readonly defaultRpcLogger?: RpcLogger;
   private readonly defaultHttpLogger?: HttpExchangeLogger;
+  /** See `baseFetch` on `MCPClientManagerOptions`. */
+  private readonly defaultBaseFetch?: typeof fetch;
   private readonly defaultProgressHandler?: ProgressHandler;
   private readonly cacheEventLogger?: CacheEventLogger;
   /**
@@ -441,6 +443,7 @@ export class MCPClientManager {
     this.defaultLogJsonRpc = options.defaultLogJsonRpc ?? false;
     this.defaultRpcLogger = options.rpcLogger;
     this.defaultHttpLogger = options.httpLogger;
+    this.defaultBaseFetch = options.baseFetch;
     this.defaultProgressHandler = options.progressHandler;
     this.cacheEventLogger = options.cacheEventLogger;
     this.traceContextProvider = options.traceContextProvider;
@@ -3641,10 +3644,15 @@ export class MCPClientManager {
     config: MCPServerConfig
   ): typeof fetch {
     const httpLogger = this.resolveHttpLogger(config);
+    // `baseFetch` is the INNERMOST layer, under the logger: the guard has to
+    // see the request that actually leaves, including the routing headers
+    // added above it, and the logger has to record the bytes that guard sent.
+    // Absent ⇒ both wrappers fall back to `globalThis.fetch` exactly as before.
+    const baseFetch = config.baseFetch ?? this.defaultBaseFetch;
     return wrapFetchForTaskRouting(
       httpLogger
-        ? wrapFetchForHttpLogging(serverId, httpLogger)
-        : undefined
+        ? wrapFetchForHttpLogging(serverId, httpLogger, baseFetch)
+        : baseFetch
     );
   }
 

--- a/sdk/src/mcp-client-manager/types.ts
+++ b/sdk/src/mcp-client-manager/types.ts
@@ -336,6 +336,24 @@ export type BaseServerConfig = {
    * reaches a fetch, so it emits nothing.
    */
   httpLogger?: HttpExchangeLogger;
+  /**
+   * The `fetch` the HTTP transport dials through, replacing the global one.
+   *
+   * WHY THIS EXISTS: hosted runs must not reach a private address, and
+   * checking the URL the caller NAMED is not the same as checking the address
+   * we end up dialling — a target can answer `302 Location:
+   * http://169.254.169.254/`. Handing a DNS-pinned fetch
+   * (`@mcpjam/sdk/oauth/node`'s `createPinnedStreamingFetch`) in here is what
+   * puts the one real MCP connection under the same guard as the raw probes
+   * beside it; before this existed, that connection followed redirects
+   * unchecked and the conformance suite documented the hole in a comment.
+   *
+   * It is the INNERMOST fetch: the task-routing and HTTP-logging wrappers are
+   * layered on top, so the bytes this sees are the bytes that leave. Ignored
+   * by stdio, which never reaches a fetch. Absent ⇒ `globalThis.fetch`,
+   * byte-identical to the behavior before this field.
+   */
+  baseFetch?: typeof fetch;
 };
 
 /**
@@ -598,6 +616,9 @@ export interface MCPClientManagerOptions {
   /** Global HTTP-exchange (headers-only) logger. See `httpLogger` on the
    *  server config for why this is a separate channel from `rpcLogger`. */
   httpLogger?: HttpExchangeLogger;
+  /** Default transport `fetch` for every HTTP server. Per-server `baseFetch`
+   *  overrides it. See `baseFetch` on the server config. */
+  baseFetch?: typeof fetch;
   /** Global progress handler */
   progressHandler?: ProgressHandler;
   /**

--- a/sdk/src/mcp-conformance/runner.ts
+++ b/sdk/src/mcp-conformance/runner.ts
@@ -139,6 +139,13 @@ function createServerConfig(
     // connect at all. Absent ⇒ `auto` (automatic negotiation is always on), so
     // an unconfigured conformance run detects the era the server negotiates.
     mcpProtocolVersion: config.protocolVersion,
+    // THE SAME GUARD THE RAW PROBES GET. `fetchFn` used to reach only the raw
+    // HTTP/SSE probes, so the one real MCP connection this suite opens dialled
+    // through the global fetch and followed its redirects unchecked — a
+    // hosted-mode SSRF hole this file's own comment used to document. Threading
+    // it in as the transport's base fetch closes it: one guard, one target, no
+    // second resolution.
+    baseFetch: config.fetchFn,
   };
 }
 

--- a/sdk/src/oauth-proxy-error.ts
+++ b/sdk/src/oauth-proxy-error.ts
@@ -1,0 +1,17 @@
+/**
+ * The pinned transport's error class, in its own module.
+ *
+ * It lives apart from `oauth-proxy.ts` only so that `oauth/pinned-dns.ts` — the
+ * shared DNS half that `oauth-proxy.ts` itself imports — can throw it without
+ * an import cycle. `oauth-proxy.ts` re-exports the symbol, so every existing
+ * `import { OAuthProxyError } from "./oauth-proxy.js"` keeps working and
+ * `instanceof` keeps meaning one class.
+ */
+export class OAuthProxyError extends Error {
+  status: number;
+
+  constructor(status: number, message: string) {
+    super(message);
+    this.status = status;
+  }
+}

--- a/sdk/src/oauth-proxy.ts
+++ b/sdk/src/oauth-proxy.ts
@@ -4,14 +4,11 @@ import https from "node:https";
 import type { LookupFunction } from "node:net";
 import type { IncomingMessage } from "node:http";
 
-export class OAuthProxyError extends Error {
-  status: number;
-
-  constructor(status: number, message: string) {
-    super(message);
-    this.status = status;
-  }
-}
+// Defined in its own module so `oauth/pinned-dns.ts` can throw it without an
+// import cycle; re-exported here so the public symbol and every existing
+// `instanceof` check are unchanged.
+export { OAuthProxyError } from "./oauth-proxy-error.js";
+import { OAuthProxyError } from "./oauth-proxy-error.js";
 
 export interface OAuthProxyRequest {
   url: string;
@@ -46,6 +43,13 @@ import {
   isLoopbackOAuthUrl,
   isPrivateHost,
 } from "./oauth/ssrf-guard.js";
+// The DNS half — resolve once, classify, pin — lives in its own node-only
+// module so the streaming transport in `oauth/pinned-stream-fetch.ts` shares
+// this exact implementation rather than forking a second one.
+import {
+  createPinnedLookup,
+  resolvePinnedAddresses,
+} from "./oauth/pinned-dns.js";
 export { isDisallowedIpAddress };
 
 interface ValidatedUrl {
@@ -817,121 +821,11 @@ export async function executeDebugOAuthProxy(
 const MAX_OAUTH_METADATA_REDIRECTS = 5;
 const MAX_OAUTH_METADATA_BYTES = 1024 * 1024;
 
-interface PinnedAddress {
-  address: string;
-  family: number;
-}
-
 interface RawOAuthMetadataResponse {
   status: number;
   statusText: string;
   headers: Record<string, string>;
   body: string;
-}
-
-function isLoopbackAddress(address: string): boolean {
-  const host = address.includes(":") ? `[${address}]` : address;
-  return isLoopbackOAuthUrl(`http://${host}`);
-}
-
-async function resolvePinnedAddresses(
-  targetUrl: URL,
-  allowLoopbackFlow: boolean,
-  signal: AbortSignal | undefined,
-  targetLabel = "OAuth metadata target"
-): Promise<PinnedAddress[] | null> {
-  const targetIsLoopback = isLoopbackOAuthUrl(targetUrl.toString());
-
-  if (isPrivateHost(targetUrl.hostname)) {
-    if (!(allowLoopbackFlow && targetIsLoopback)) {
-      throw new OAuthProxyError(
-        400,
-        `${targetLabel} is a private/reserved host (${targetUrl.hostname})`
-      );
-    }
-  }
-
-  // Numeric IPs are already the exact socket destination, so there is no DNS
-  // lookup to pin. The literal-host check above has classified them.
-  if (
-    /^\d+\.\d+\.\d+\.\d+$/.test(targetUrl.hostname) ||
-    targetUrl.hostname.includes(":")
-  ) {
-    return null;
-  }
-
-  const addresses = await new Promise<PinnedAddress[]>((resolve, reject) => {
-    const cleanup = () => signal?.removeEventListener("abort", onAbort);
-    const onAbort = () => {
-      cleanup();
-      reject(signal?.reason ?? new Error(`${targetLabel} request aborted`));
-    };
-
-    if (signal?.aborted) {
-      onAbort();
-      return;
-    }
-    signal?.addEventListener("abort", onAbort, { once: true });
-
-    dnsLookupCb(
-      targetUrl.hostname,
-      { all: true, verbatim: true },
-      (error, resolved) => {
-        cleanup();
-        if (error) {
-          reject(
-            new OAuthProxyError(
-              400,
-              `Could not resolve ${targetLabel.toLowerCase()} ${
-                targetUrl.hostname
-              }`
-            )
-          );
-          return;
-        }
-        resolve(Array.isArray(resolved) ? resolved : [resolved]);
-      }
-    );
-  });
-
-  if (addresses.length === 0) {
-    throw new OAuthProxyError(
-      400,
-      `Could not resolve ${targetLabel.toLowerCase()} ${targetUrl.hostname}`
-    );
-  }
-
-  for (const { address } of addresses) {
-    if (targetIsLoopback) {
-      if (!isLoopbackAddress(address)) {
-        throw new OAuthProxyError(
-          400,
-          `Loopback ${targetLabel.toLowerCase()} resolved outside loopback (${address})`
-        );
-      }
-    } else if (isDisallowedIpAddress(address)) {
-      throw new OAuthProxyError(
-        400,
-        `${targetLabel} resolves to a private/reserved IP address (${address})`
-      );
-    }
-  }
-
-  return addresses;
-}
-
-function createPinnedLookup(addresses: PinnedAddress[]): LookupFunction {
-  return (_hostname, options, callback) => {
-    if (typeof options === "object" && options?.all) {
-      return (
-        callback as unknown as (
-          err: NodeJS.ErrnoException | null,
-          resolved: PinnedAddress[]
-        ) => void
-      )(null, addresses);
-    }
-    callback(null, addresses[0].address, addresses[0].family);
-  };
 }
 
 async function requestPinnedOAuthMetadata(

--- a/sdk/src/oauth/node.ts
+++ b/sdk/src/oauth/node.ts
@@ -50,3 +50,11 @@ export {
   validateUrl,
 } from "../oauth-proxy.js";
 export type { OAuthProxyRequest, OAuthProxyResponse } from "../oauth-proxy.js";
+
+// The STREAMING half of the same guarantee. `executeOAuthProxy` buffers, so it
+// can carry OAuth metadata but never `text/event-stream`; this one hands the
+// body back as a live `ReadableStream`, which is what lets the real MCP
+// connection — SSE included — ride the pinned path instead of an unguarded
+// `globalThis.fetch`.
+export { createPinnedStreamingFetch } from "./pinned-stream-fetch.js";
+export type { PinnedStreamingFetchOptions } from "./pinned-stream-fetch.js";

--- a/sdk/src/oauth/pinned-dns.ts
+++ b/sdk/src/oauth/pinned-dns.ts
@@ -1,0 +1,158 @@
+/**
+ * The DNS half of the pinned transport, extracted so more than one transport
+ * can share it.
+ *
+ * `oauth-proxy.ts` grew this logic for its own buffering request path. A
+ * streaming transport (`pinned-stream-fetch.ts`, which the MCP connection
+ * itself rides on) needs exactly the same two steps and must never grow a
+ * second copy: a divergence between "the addresses OAuth discovery validated"
+ * and "the addresses the MCP socket dialled" is precisely the hole this
+ * machinery exists to close.
+ *
+ * The two steps, and why they are two:
+ *
+ *   1. {@link resolvePinnedAddresses} resolves the hostname ONCE and classifies
+ *      every answer under RFC 6890. It returns `null` for a numeric host —
+ *      there is no lookup to pin, and the literal has already been classified.
+ *   2. {@link createPinnedLookup} feeds those exact addresses back to the
+ *      socket as its `lookup`, so the connection cannot re-resolve and land
+ *      somewhere the classifier never saw.
+ *
+ * Node-only: `node:dns` is the whole point. Browser callers get the classifier
+ * alone from `oauth/ssrf-guard.js`, which is deliberately not enough on its own.
+ */
+
+import { lookup as dnsLookupCb } from "node:dns";
+import type { LookupFunction } from "node:net";
+
+import { OAuthProxyError } from "../oauth-proxy-error.js";
+import { isDisallowedIpAddress, isLoopbackOAuthUrl, isPrivateHost } from "./ssrf-guard.js";
+
+export interface PinnedAddress {
+  address: string;
+  family: number;
+}
+
+function isLoopbackAddress(address: string): boolean {
+  const host = address.includes(":") ? `[${address}]` : address;
+  return isLoopbackOAuthUrl(`http://${host}`);
+}
+
+/**
+ * Resolve `targetUrl`'s host once and refuse every disallowed answer.
+ *
+ * Returns the surviving addresses for {@link createPinnedLookup} to pin, or
+ * `null` when the host is a numeric literal: there is no name to re-resolve,
+ * so there is nothing a rebind could change.
+ *
+ * `allowLoopbackFlow` is narrow on purpose — it permits a loopback TARGET, and
+ * then still requires every resolved address to be loopback, so a name that
+ * looks local but answers publicly is refused rather than dialled.
+ */
+export async function resolvePinnedAddresses(
+  targetUrl: URL,
+  allowLoopbackFlow: boolean,
+  signal: AbortSignal | undefined,
+  targetLabel = "OAuth metadata target",
+): Promise<PinnedAddress[] | null> {
+  const targetIsLoopback = isLoopbackOAuthUrl(targetUrl.toString());
+
+  if (isPrivateHost(targetUrl.hostname)) {
+    if (!(allowLoopbackFlow && targetIsLoopback)) {
+      throw new OAuthProxyError(
+        400,
+        `${targetLabel} is a private/reserved host (${targetUrl.hostname})`,
+      );
+    }
+  }
+
+  // Numeric IPs are already the exact socket destination, so there is no DNS
+  // lookup to pin. The literal-host check above has classified them.
+  if (
+    /^\d+\.\d+\.\d+\.\d+$/.test(targetUrl.hostname) ||
+    targetUrl.hostname.includes(":")
+  ) {
+    return null;
+  }
+
+  const addresses = await new Promise<PinnedAddress[]>((resolve, reject) => {
+    const cleanup = () => signal?.removeEventListener("abort", onAbort);
+    const onAbort = () => {
+      cleanup();
+      reject(signal?.reason ?? new Error(`${targetLabel} request aborted`));
+    };
+
+    if (signal?.aborted) {
+      onAbort();
+      return;
+    }
+    signal?.addEventListener("abort", onAbort, { once: true });
+
+    dnsLookupCb(
+      targetUrl.hostname,
+      { all: true, verbatim: true },
+      (error, resolved) => {
+        cleanup();
+        if (error) {
+          reject(
+            new OAuthProxyError(
+              400,
+              `Could not resolve ${targetLabel.toLowerCase()} ${
+                targetUrl.hostname
+              }`,
+            ),
+          );
+          return;
+        }
+        resolve(Array.isArray(resolved) ? resolved : [resolved]);
+      },
+    );
+  });
+
+  if (addresses.length === 0) {
+    throw new OAuthProxyError(
+      400,
+      `Could not resolve ${targetLabel.toLowerCase()} ${targetUrl.hostname}`,
+    );
+  }
+
+  for (const { address } of addresses) {
+    if (targetIsLoopback) {
+      if (!isLoopbackAddress(address)) {
+        throw new OAuthProxyError(
+          400,
+          `Loopback ${targetLabel.toLowerCase()} resolved outside loopback (${address})`,
+        );
+      }
+    } else if (isDisallowedIpAddress(address)) {
+      throw new OAuthProxyError(
+        400,
+        `${targetLabel} resolves to a private/reserved IP address (${address})`,
+      );
+    }
+  }
+
+  return addresses;
+}
+
+/**
+ * The `lookup` that makes the validation binding.
+ *
+ * The callback shape must follow `options.all`: with autoSelectFamily (the
+ * Node ≥20 default) the socket passes `all: true` and expects an ARRAY of
+ * `{address, family}` entries; answering with a bare string there makes Node
+ * throw `ERR_INVALID_IP_ADDRESS`.
+ */
+export function createPinnedLookup(addresses: PinnedAddress[]): LookupFunction {
+  return (_hostname, options, callback) => {
+    if (typeof options === "object" && options?.all) {
+      return (
+        callback as unknown as (
+          err: NodeJS.ErrnoException | null,
+          resolved: PinnedAddress[],
+        ) => void
+      )(null, addresses);
+    }
+    callback(null, addresses[0].address, addresses[0].family);
+  };
+}

--- a/sdk/src/oauth/pinned-stream-fetch.ts
+++ b/sdk/src/oauth/pinned-stream-fetch.ts
@@ -80,7 +80,15 @@ export interface PinnedStreamingFetchOptions {
 
 const DEFAULT_CHAIN_TIMEOUT_MS = 30_000;
 const DEFAULT_MAX_RESPONSE_BYTES = 32 * 1024 * 1024;
-const DEFAULT_MAX_REDIRECTS = 5;
+/**
+ * Matches `fetch` itself, and therefore `createGuardedFetch`'s
+ * `MAX_GUARDED_REDIRECTS`, which is what hosted conformance dialled through
+ * before this transport existed. A lower ceiling here would not have been a
+ * security improvement — every hop is validated either way — it would only
+ * have failed chains that legitimately worked, and enterprise OAuth chains
+ * (apex → www → CDN → tenant routing) do reach six and seven hops.
+ */
+const DEFAULT_MAX_REDIRECTS = 20;
 
 /** Credentials, in the sense Fetch means: dropped when the origin changes. */
 const CREDENTIAL_HEADERS = [
@@ -296,21 +304,38 @@ function toGuardedWebStream(
   destroyUpstream: () => void,
   maxResponseBytes: number,
   bodyIdleTimeoutMs: number,
+  onSettled: () => void,
 ): ReadableStream<Uint8Array> {
   let received = 0;
   let idleTimer: NodeJS.Timeout | undefined;
+  let settled = false;
+
+  const clearIdle = () => {
+    if (idleTimer) clearTimeout(idleTimer);
+    idleTimer = undefined;
+  };
+
+  /**
+   * The body stream outlives the function that returned the `Response`, and it
+   * is the last thing holding the caller's abort listener. Releasing it here —
+   * once, on whichever of end/error/cancel arrives first — is what stops a
+   * transport-lifetime signal accumulating one listener per request.
+   */
+  const settle = () => {
+    if (settled) return;
+    settled = true;
+    clearIdle();
+    onSettled();
+  };
 
   return new ReadableStream<Uint8Array>({
     start(controller) {
-      const clearIdle = () => {
-        if (idleTimer) clearTimeout(idleTimer);
-        idleTimer = undefined;
-      };
       const armIdle = () => {
         if (bodyIdleTimeoutMs <= 0) return;
         clearIdle();
         idleTimer = setTimeout(() => {
           destroyUpstream();
+          settle();
           controller.error(
             new OAuthProxyError(
               504,
@@ -324,11 +349,17 @@ function toGuardedWebStream(
       };
 
       source.on("data", (chunk: Buffer | string) => {
+        // Destroying a socket is asynchronous, so a chunk already in flight
+        // can arrive after the stream settled — after a reader cancelled, or
+        // after the cap errored it. Enqueuing onto a closed controller throws
+        // `ERR_INVALID_STATE` out of an event handler, where nothing can catch
+        // it, so the verdict that already stands wins and the chunk is dropped.
+        if (settled) return;
         const buffer = Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk);
         received += buffer.byteLength;
         if (maxResponseBytes > 0 && received > maxResponseBytes) {
-          clearIdle();
           destroyUpstream();
+          settle();
           controller.error(
             new OAuthProxyError(
               400,
@@ -338,10 +369,20 @@ function toGuardedWebStream(
           return;
         }
         controller.enqueue(new Uint8Array(buffer));
+        // BACKPRESSURE. `source.on("data")` puts the socket in flowing mode,
+        // so without this the bridge enqueues as fast as the network delivers
+        // and the queue — not the consumer — decides how much is held. A
+        // reader that is slow, or that checks `status` and never reads the
+        // body at all, would buffer the entire response in memory: up to the
+        // byte cap, and without limit when the cap is disabled. Pausing when
+        // the reader has no capacity and resuming from `pull` hands that
+        // decision back to the consumer, which is what makes the cap a
+        // ceiling rather than a target.
+        if ((controller.desiredSize ?? 1) <= 0) source.pause();
         armIdle();
       });
       source.on("end", () => {
-        clearIdle();
+        settle();
         try {
           controller.close();
         } catch {
@@ -349,12 +390,14 @@ function toGuardedWebStream(
         }
       });
       source.on("error", (error: Error) => {
-        clearIdle();
         // The SOCKET first. A decoder failure — a truncated gzip member, a
         // corrupt brotli frame — errors the decompressor but leaves the
         // response, and therefore the pinned connection, open. Erroring only
         // the reader would leak it for the lifetime of the process.
         destroyUpstream();
+        // `settle` clears the idle timer and releases the caller's abort
+        // listener; both have to happen on this path too.
+        settle();
         try {
           controller.error(error);
         } catch {
@@ -363,8 +406,12 @@ function toGuardedWebStream(
       });
       armIdle();
     },
+    pull() {
+      // The reader drained the queue and wants more.
+      source.resume();
+    },
     cancel() {
-      if (idleTimer) clearTimeout(idleTimer);
+      settle();
       destroyUpstream();
     },
   });
@@ -473,6 +520,22 @@ export function createPinnedStreamingFetch(
       if (chainDeadline) clearTimeout(chainDeadline);
       chainController.signal.removeEventListener("abort", onChainAbort);
     };
+    /**
+     * The caller's listener has to come off on EVERY terminal path, not only
+     * the error ones. An MCP transport hands the same connection-lifetime
+     * signal to every request it makes, so a listener left behind per request
+     * is a listener leak on a long-lived connection: Node warns at eleven and
+     * the retained closures grow for as long as the connection lives.
+     *
+     * It cannot be released when this function returns, though — the returned
+     * `Response` still has a live body, and the caller's abort must keep
+     * reaching the socket for as long as that body can be read. So a streaming
+     * response hands this to the body stream to call when it settles, and only
+     * the paths with no body left to read call it directly.
+     */
+    const releaseCallerAbort = () => {
+      callerSignal?.removeEventListener("abort", onCallerAbort);
+    };
 
     let currentUrl = startUrl;
     let currentMethod = (init?.method ?? (input as Request)?.method ?? "GET")
@@ -483,7 +546,7 @@ export function createPinnedStreamingFetch(
       currentBody = encodeBody(init?.body as BodyInit | null | undefined);
     } catch (error) {
       releaseChainDeadline();
-      callerSignal?.removeEventListener("abort", onCallerAbort);
+      releaseCallerAbort();
       throw error;
     }
 
@@ -512,7 +575,10 @@ export function createPinnedStreamingFetch(
         if (parsed.protocol !== "https:" && !(chainAllowsLoopback && hopIsLoopback)) {
           throw new OAuthProxyError(
             400,
-            `Refusing a plaintext connection to "${safeHost(currentUrl)}".`,
+            // Name the fix. This refusal is about the SCHEME, and a message
+            // that only says "refused" gets read as an address problem by
+            // whoever has to act on it.
+            `Refusing a plaintext connection to "${safeHost(currentUrl)}": the target must be served over https.`,
           );
         }
 
@@ -585,6 +651,9 @@ export function createPinnedStreamingFetch(
         const responseHeaders = normalizeResponseHeaders(response);
         if (NULL_BODY_STATUSES.has(status)) {
           response.resume();
+          // No body means nothing will settle later, so this path owns the
+          // release itself.
+          releaseCallerAbort();
           return finalizeResponse(
             new Response(null, {
               status,
@@ -603,6 +672,7 @@ export function createPinnedStreamingFetch(
           () => response.destroy(),
           maxResponseBytes,
           bodyIdleTimeoutMs,
+          releaseCallerAbort,
         );
         // `content-encoding`/`content-length` described bytes that no longer
         // exist once `decodeStream` has undone them; leaving them would make
@@ -623,7 +693,7 @@ export function createPinnedStreamingFetch(
       }
     } catch (error) {
       releaseChainDeadline();
-      callerSignal?.removeEventListener("abort", onCallerAbort);
+      releaseCallerAbort();
       // An abort raised by our own deadline reaches here as whatever `undici`
       // or `node:http` chose to throw; the reason we set is the honest one.
       const reason = socketController.signal.reason;
@@ -634,7 +704,8 @@ export function createPinnedStreamingFetch(
     }
     // NOTE: no `finally` that unhooks `onCallerAbort`. The caller's abort must
     // keep reaching the socket for as long as the body stream lives, which is
-    // after this function has already returned its `Response`.
+    // after this function has already returned its `Response` — which is why
+    // `releaseCallerAbort` is handed to that stream rather than called here.
   };
 
   return pinnedStreamingFetch as typeof fetch;

--- a/sdk/src/oauth/pinned-stream-fetch.ts
+++ b/sdk/src/oauth/pinned-stream-fetch.ts
@@ -129,15 +129,30 @@ function stripCredentials(
   );
 }
 
+/**
+ * Fetch's "request-body-header name" list, which is what a method rewrite has
+ * to drop along with the body.
+ *
+ * All five, not the obvious three: `content-language` and `content-location`
+ * describe a body that no longer exists once 301/302/303 rewrote the request
+ * to GET, and leaving them on sends a GET that still claims to carry one.
+ * `oauth-proxy.ts`'s `updateRequestForRedirect` strips the same five — the two
+ * transports must not disagree about what a redirect does to a request.
+ */
+const BODY_HEADERS = [
+  "content-encoding",
+  "content-language",
+  "content-length",
+  "content-location",
+  "content-type",
+];
+
 function stripBodyHeaders(
   headers: Record<string, string>,
 ): Record<string, string> {
   return Object.fromEntries(
     Object.entries(headers).filter(
-      ([name]) =>
-        !["content-type", "content-length", "content-encoding"].includes(
-          name.toLowerCase(),
-        ),
+      ([name]) => !BODY_HEADERS.includes(name.toLowerCase()),
     ),
   );
 }

--- a/sdk/src/oauth/pinned-stream-fetch.ts
+++ b/sdk/src/oauth/pinned-stream-fetch.ts
@@ -204,17 +204,30 @@ function decodeStream(response: IncomingMessage): NodeJS.ReadableStream {
     .toString()
     .trim()
     .toLowerCase();
-  switch (encoding) {
-    case "gzip":
-    case "x-gzip":
-      return response.pipe(createGunzip());
-    case "deflate":
-      return response.pipe(createInflate());
-    case "br":
-      return response.pipe(createBrotliDecompress());
-    default:
-      return response;
-  }
+  const decompressor =
+    encoding === "gzip" || encoding === "x-gzip"
+      ? createGunzip()
+      : encoding === "deflate"
+        ? createInflate()
+        : encoding === "br"
+          ? createBrotliDecompress()
+          : undefined;
+  if (!decompressor) return response;
+
+  // `pipe` DOES NOT FORWARD ERRORS. Node's own documentation says so, and the
+  // consequence here is specific and bad: `toGuardedWebStream` listens to the
+  // decompressor alone, so a socket failure or a caller abort after the
+  // headers were in would error the source, reach nothing, and leave
+  // `Response.body` pending forever — a hang rather than a rejection.
+  //
+  // Destroying the decompressor WITH the reason is what turns that into an
+  // error event the guarded stream can surface.
+  const fail = (error: Error) => decompressor.destroy(error);
+  response.on("error", fail);
+  response.on("aborted", () =>
+    fail(new OAuthProxyError(499, "The connection was aborted.")),
+  );
+  return response.pipe(decompressor);
 }
 
 interface HopResult {

--- a/sdk/src/oauth/pinned-stream-fetch.ts
+++ b/sdk/src/oauth/pinned-stream-fetch.ts
@@ -350,6 +350,11 @@ function toGuardedWebStream(
       });
       source.on("error", (error: Error) => {
         clearIdle();
+        // The SOCKET first. A decoder failure — a truncated gzip member, a
+        // corrupt brotli frame — errors the decompressor but leaves the
+        // response, and therefore the pinned connection, open. Erroring only
+        // the reader would leak it for the lifetime of the process.
+        destroyUpstream();
         try {
           controller.error(error);
         } catch {

--- a/sdk/src/oauth/pinned-stream-fetch.ts
+++ b/sdk/src/oauth/pinned-stream-fetch.ts
@@ -1,0 +1,636 @@
+/**
+ * A DNS-pinned `fetch` that can STREAM — the transport the real MCP connection
+ * rides on.
+ *
+ * WHY A SECOND ONE. `executeOAuthProxy` already resolves once, refuses private
+ * answers, and pins the address into the socket, and the inspector's
+ * `createPinnedFetch` wraps it in a `fetch` shape. But that path BUFFERS: it
+ * reads the whole body into memory before answering, so it can never carry
+ * `text/event-stream`. That is why the guarded fetch threaded into the
+ * conformance suites reached only the raw probes, and why the one real MCP
+ * connection each suite opens still followed redirects unchecked — the gap the
+ * suite's own comment documented and could not close.
+ *
+ * This module closes it. Same two-step guarantee as the buffering path, taken
+ * from the same {@link resolvePinnedAddresses}/{@link createPinnedLookup}
+ * implementation, but the response body is handed back as a live
+ * `ReadableStream`, so an SSE stream stays open and an MCP client cannot tell
+ * it is not talking to `globalThis.fetch`.
+ *
+ * WHAT IT ENFORCES, all of it per hop:
+ *
+ *  - **Scheme.** https, unless the CHAIN started at loopback and this hop is
+ *    loopback too. A public target may not steer a hop at the user's own
+ *    machine.
+ *  - **Address.** Resolve once, classify under RFC 6890, pin. Every redirect
+ *    hop repeats this in full — a `302` to `169.254.169.254` is refused at the
+ *    hop that names it, not after it has been dialled.
+ *  - **Redirect ceiling.** Bounded; the chain fails rather than looping.
+ *  - **Credentials.** Dropped when the origin changes, exactly as Fetch does,
+ *    so a redirect off-origin cannot carry an access token with it.
+ *  - **Time.** A chain deadline covers DNS, connect and headers across every
+ *    hop. It deliberately does NOT cover an established body stream — an SSE
+ *    stream is long-lived by design — which is what {@link
+ *    PinnedStreamingFetchOptions.bodyIdleTimeoutMs} is for: a stalled stream
+ *    dies, a healthy one does not.
+ *  - **Size.** A cumulative cap on body bytes AFTER decompression, so a
+ *    compressed bomb is measured at its real size.
+ *
+ * Node-only. Do not import from browser or worker entry points.
+ */
+
+import http from "node:http";
+import https from "node:https";
+import type { IncomingMessage } from "node:http";
+import { createBrotliDecompress, createGunzip, createInflate } from "node:zlib";
+
+import { OAuthProxyError } from "../oauth-proxy-error.js";
+import { isLoopbackOAuthUrl } from "./ssrf-guard.js";
+import { createPinnedLookup, resolvePinnedAddresses } from "./pinned-dns.js";
+
+export interface PinnedStreamingFetchOptions {
+  /**
+   * Local-dev opt-in for a loopback TARGET. It never relaxes anything else,
+   * and it belongs to the chain: a chain that started public can never arrive
+   * at loopback, however many redirects it takes to try.
+   */
+  allowLoopback?: boolean;
+  /**
+   * Budget for DNS + connect + response headers, summed across every hop of
+   * the redirect chain. An established body stream is outside it — see the
+   * module docblock. Default 30s.
+   */
+  chainTimeoutMs?: number;
+  /**
+   * Kill a body stream that has produced no bytes for this long. This is the
+   * bound that applies to a long-lived SSE stream; a total deadline would
+   * close healthy ones. Default 0 (no idle bound).
+   */
+  bodyIdleTimeoutMs?: number;
+  /**
+   * Cumulative cap on decompressed body bytes for one fetch. Exceeding it
+   * destroys the socket and errors the stream. Default 32 MiB; 0 disables.
+   */
+  maxResponseBytes?: number;
+  /** Redirect hops allowed before the chain is refused. Default 5. */
+  maxRedirects?: number;
+  /** Used in refusal messages, e.g. `"MCP server"`. */
+  targetLabel?: string;
+}
+
+const DEFAULT_CHAIN_TIMEOUT_MS = 30_000;
+const DEFAULT_MAX_RESPONSE_BYTES = 32 * 1024 * 1024;
+const DEFAULT_MAX_REDIRECTS = 5;
+
+/** Credentials, in the sense Fetch means: dropped when the origin changes. */
+const CREDENTIAL_HEADERS = [
+  "authorization",
+  "cookie",
+  "cookie2",
+  "proxy-authorization",
+];
+
+/** Statuses whose `Response` must be constructed with a null body. */
+const NULL_BODY_STATUSES = new Set([101, 204, 205, 304]);
+
+function isRedirectStatus(status: number): boolean {
+  return (
+    status === 301 ||
+    status === 302 ||
+    status === 303 ||
+    status === 307 ||
+    status === 308
+  );
+}
+
+function sameOrigin(a: string, b: string): boolean {
+  try {
+    return new URL(a).origin === new URL(b).origin;
+  } catch {
+    return false;
+  }
+}
+
+function stripCredentials(
+  headers: Record<string, string>,
+): Record<string, string> {
+  return Object.fromEntries(
+    Object.entries(headers).filter(
+      ([name]) => !CREDENTIAL_HEADERS.includes(name.toLowerCase()),
+    ),
+  );
+}
+
+function stripBodyHeaders(
+  headers: Record<string, string>,
+): Record<string, string> {
+  return Object.fromEntries(
+    Object.entries(headers).filter(
+      ([name]) =>
+        !["content-type", "content-length", "content-encoding"].includes(
+          name.toLowerCase(),
+        ),
+    ),
+  );
+}
+
+/** The host alone — never the path or query, which can carry a token. */
+function safeHost(url: string): string {
+  try {
+    return new URL(url).host;
+  } catch {
+    return "an unparseable URL";
+  }
+}
+
+function headersToRecord(
+  input: RequestInfo | URL,
+  init: RequestInit | undefined,
+): Record<string, string> {
+  const record: Record<string, string> = {};
+  const raw = init?.headers ?? (input as Request)?.headers;
+  if (raw) {
+    new Headers(raw as HeadersInit).forEach((value, key) => {
+      record[key] = value;
+    });
+  }
+  return record;
+}
+
+/**
+ * The request body, as bytes.
+ *
+ * MCP posts JSON strings, so string and byte forms are all that is supported.
+ * A streaming request body would need a duplex socket write and is refused
+ * loudly rather than silently sent empty.
+ */
+function encodeBody(body: BodyInit | null | undefined): Buffer | undefined {
+  if (body === null || body === undefined) return undefined;
+  if (typeof body === "string") return Buffer.from(body, "utf8");
+  if (Buffer.isBuffer(body)) return body;
+  if (body instanceof Uint8Array) return Buffer.from(body);
+  if (body instanceof ArrayBuffer) return Buffer.from(new Uint8Array(body));
+  if (ArrayBuffer.isView(body)) {
+    return Buffer.from(body.buffer, body.byteOffset, body.byteLength);
+  }
+  if (body instanceof URLSearchParams) return Buffer.from(body.toString(), "utf8");
+  throw new OAuthProxyError(
+    400,
+    "The pinned streaming transport supports only string or byte request bodies.",
+  );
+}
+
+function normalizeResponseHeaders(response: IncomingMessage): Headers {
+  const headers = new Headers();
+  for (const [key, value] of Object.entries(response.headers)) {
+    if (value === undefined) continue;
+    if (Array.isArray(value)) {
+      // `set-cookie` is the only header Node hands back as an array, and
+      // `Headers.append` is what preserves each one as its own field.
+      for (const entry of value) headers.append(key, entry);
+    } else {
+      headers.set(key, value);
+    }
+  }
+  return headers;
+}
+
+/**
+ * Undo the transfer encoding the server applied, so the byte cap below counts
+ * what the caller will actually receive rather than its compressed shadow.
+ */
+function decodeStream(response: IncomingMessage): NodeJS.ReadableStream {
+  const encoding = (response.headers["content-encoding"] ?? "")
+    .toString()
+    .trim()
+    .toLowerCase();
+  switch (encoding) {
+    case "gzip":
+    case "x-gzip":
+      return response.pipe(createGunzip());
+    case "deflate":
+      return response.pipe(createInflate());
+    case "br":
+      return response.pipe(createBrotliDecompress());
+    default:
+      return response;
+  }
+}
+
+interface HopResult {
+  response: IncomingMessage;
+  url: string;
+}
+
+/**
+ * One hop: validate the scheme, resolve-and-pin the address, and open the
+ * socket. Resolves as soon as the response HEADERS are in — the body is left
+ * streaming, which is the whole point of this module.
+ */
+async function openPinnedHop(
+  targetUrl: URL,
+  method: string,
+  headers: Record<string, string>,
+  body: Buffer | undefined,
+  hopAllowsLoopback: boolean,
+  signal: AbortSignal,
+  targetLabel: string,
+): Promise<HopResult> {
+  const pinnedAddresses = await resolvePinnedAddresses(
+    targetUrl,
+    hopAllowsLoopback,
+    signal,
+    targetLabel,
+  );
+  const transport = targetUrl.protocol === "https:" ? https : http;
+
+  return await new Promise<HopResult>((resolve, reject) => {
+    const request = transport.request(
+      targetUrl,
+      {
+        method,
+        headers,
+        ...(pinnedAddresses
+          ? { lookup: createPinnedLookup(pinnedAddresses) }
+          : {}),
+        // SNI must still name the host, not the pinned literal, or TLS fails
+        // against every virtual host on a shared address.
+        ...(targetUrl.protocol === "https:" &&
+        !/^\d+\.\d+\.\d+\.\d+$/.test(targetUrl.hostname) &&
+        !targetUrl.hostname.includes(":")
+          ? { servername: targetUrl.hostname }
+          : {}),
+        signal,
+      },
+      (response) => resolve({ response, url: targetUrl.toString() }),
+    );
+    request.on("error", reject);
+    if (body) request.write(body);
+    request.end();
+  });
+}
+
+/**
+ * Wrap the decoded body in a `ReadableStream`, enforcing the byte cap and the
+ * idle bound as the bytes flow.
+ *
+ * `destroyUpstream` exists because the cap has to kill the SOCKET, not just
+ * the reader: leaving the connection draining a hostile response defeats the
+ * point of capping it.
+ */
+function toGuardedWebStream(
+  source: NodeJS.ReadableStream,
+  destroyUpstream: () => void,
+  maxResponseBytes: number,
+  bodyIdleTimeoutMs: number,
+): ReadableStream<Uint8Array> {
+  let received = 0;
+  let idleTimer: NodeJS.Timeout | undefined;
+
+  return new ReadableStream<Uint8Array>({
+    start(controller) {
+      const clearIdle = () => {
+        if (idleTimer) clearTimeout(idleTimer);
+        idleTimer = undefined;
+      };
+      const armIdle = () => {
+        if (bodyIdleTimeoutMs <= 0) return;
+        clearIdle();
+        idleTimer = setTimeout(() => {
+          destroyUpstream();
+          controller.error(
+            new OAuthProxyError(
+              504,
+              `The response stream produced no data for ${bodyIdleTimeoutMs}ms.`,
+            ),
+          );
+        }, bodyIdleTimeoutMs);
+        // A pending idle timer must never be the reason the process stays
+        // alive; the stream's own lifetime decides that.
+        idleTimer.unref?.();
+      };
+
+      source.on("data", (chunk: Buffer | string) => {
+        const buffer = Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk);
+        received += buffer.byteLength;
+        if (maxResponseBytes > 0 && received > maxResponseBytes) {
+          clearIdle();
+          destroyUpstream();
+          controller.error(
+            new OAuthProxyError(
+              400,
+              `The response exceeds the ${maxResponseBytes}-byte cap.`,
+            ),
+          );
+          return;
+        }
+        controller.enqueue(new Uint8Array(buffer));
+        armIdle();
+      });
+      source.on("end", () => {
+        clearIdle();
+        try {
+          controller.close();
+        } catch {
+          // Already errored by the cap or the idle bound; nothing to close.
+        }
+      });
+      source.on("error", (error: Error) => {
+        clearIdle();
+        try {
+          controller.error(error);
+        } catch {
+          // Already errored; the first verdict is the one that stands.
+        }
+      });
+      armIdle();
+    },
+    cancel() {
+      if (idleTimer) clearTimeout(idleTimer);
+      destroyUpstream();
+    },
+  });
+}
+
+/**
+ * Build a streaming, DNS-pinned `fetch`.
+ *
+ * The result is drop-in for the subset of `fetch` an MCP transport uses: a URL,
+ * a method, headers, a byte/string body, an `AbortSignal`, and a streaming
+ * response. It does not implement `credentials`, `cache`, or a streaming
+ * request body, and a caller who needs those should not be using it.
+ */
+export function createPinnedStreamingFetch(
+  options: PinnedStreamingFetchOptions = {},
+): typeof fetch {
+  const chainTimeoutMs = options.chainTimeoutMs ?? DEFAULT_CHAIN_TIMEOUT_MS;
+  const maxResponseBytes =
+    options.maxResponseBytes ?? DEFAULT_MAX_RESPONSE_BYTES;
+  const maxRedirects = options.maxRedirects ?? DEFAULT_MAX_REDIRECTS;
+  const bodyIdleTimeoutMs = options.bodyIdleTimeoutMs ?? 0;
+  const targetLabel = options.targetLabel ?? "Target";
+
+  const pinnedStreamingFetch = async (
+    input: RequestInfo | URL,
+    init?: RequestInit,
+  ): Promise<Response> => {
+    const startUrl =
+      typeof input === "string"
+        ? input
+        : input instanceof URL
+          ? input.toString()
+          : input.url;
+
+    const callerSignal =
+      init?.signal ?? (input as Request)?.signal ?? undefined;
+    callerSignal?.throwIfAborted();
+
+    // A `Request` body is a one-shot stream, and a redirect chain may have to
+    // replay it. Copying every other field and leaving the body behind would
+    // send an empty POST and report whatever the server made of THAT as the
+    // target's behavior — a wrong answer dressed as a real one.
+    const fromRequest =
+      typeof input !== "string" && !(input instanceof URL)
+        ? (input as Request)
+        : undefined;
+    if (fromRequest?.body && init?.body === undefined) {
+      throw new OAuthProxyError(
+        400,
+        "A Request with a body cannot be dialled through the pinned transport; pass the body via the init argument so it can be replayed across a redirect.",
+      );
+    }
+
+    // REDIRECT MODE IS THE CALLER'S. The OAuth suite inspects 3xx responses as
+    // evidence, so following one on its behalf would destroy the very thing it
+    // is grading; `"error"` means a redirect IS the failure, and silently
+    // treating it as `"follow"` would do the one thing the caller ruled out.
+    const redirectMode: RequestRedirect =
+      init?.redirect ?? fromRequest?.redirect ?? "follow";
+
+    // LOOPBACK IS A PROPERTY OF THE CHAIN, decided by where it started. With
+    // the opt-in set but derived per hop, a PUBLIC target could answer
+    // `302 Location: http://127.0.0.1:11434/…` and have that hop dialled:
+    // attacker-chosen path, plaintext, on the user's own machine.
+    if (options.allowLoopback !== true && isLoopbackOAuthUrl(startUrl)) {
+      throw new OAuthProxyError(
+        400,
+        `Refusing a connection to loopback address "${safeHost(startUrl)}".`,
+      );
+    }
+    const chainAllowsLoopback =
+      options.allowLoopback === true && isLoopbackOAuthUrl(startUrl);
+
+    // ONE deadline for the whole chain's DNS/connect/header phases. Handing
+    // each hop the full budget would let a five-hop chain outlive five of them.
+    // It is cleared once headers are in, so an SSE body is not on the clock.
+    const chainController = new AbortController();
+    const chainDeadline =
+      chainTimeoutMs > 0
+        ? setTimeout(
+            () =>
+              chainController.abort(
+                new OAuthProxyError(
+                  504,
+                  `${targetLabel} did not answer within ${chainTimeoutMs}ms.`,
+                ),
+              ),
+            chainTimeoutMs,
+          )
+        : undefined;
+    chainDeadline?.unref?.();
+
+    // The socket must die on EITHER the caller's abort or the chain deadline,
+    // and must keep dying on the caller's abort after the deadline is cleared —
+    // so this signal outlives the header phase and owns the body stream too.
+    const socketController = new AbortController();
+    const abortSocket = (reason: unknown) => socketController.abort(reason);
+    const onChainAbort = () => abortSocket(chainController.signal.reason);
+    const onCallerAbort = () => abortSocket(callerSignal?.reason);
+    chainController.signal.addEventListener("abort", onChainAbort, {
+      once: true,
+    });
+    callerSignal?.addEventListener("abort", onCallerAbort, { once: true });
+
+    const releaseChainDeadline = () => {
+      if (chainDeadline) clearTimeout(chainDeadline);
+      chainController.signal.removeEventListener("abort", onChainAbort);
+    };
+
+    let currentUrl = startUrl;
+    let currentMethod = (init?.method ?? (input as Request)?.method ?? "GET")
+      .toUpperCase();
+    let currentHeaders = headersToRecord(input, init);
+    let currentBody: Buffer | undefined;
+    try {
+      currentBody = encodeBody(init?.body as BodyInit | null | undefined);
+    } catch (error) {
+      releaseChainDeadline();
+      callerSignal?.removeEventListener("abort", onCallerAbort);
+      throw error;
+    }
+
+    // Ask for bytes we can measure. `fetch` decompresses transparently and so
+    // do we (`decodeStream`), but announcing identity keeps the common case a
+    // straight copy instead of a zlib pipe.
+    if (
+      !Object.keys(currentHeaders).some(
+        (name) => name.toLowerCase() === "accept-encoding",
+      )
+    ) {
+      currentHeaders["accept-encoding"] = "identity";
+    }
+
+    try {
+      for (let hop = 0; ; hop += 1) {
+        if (hop > maxRedirects) {
+          throw new OAuthProxyError(
+            400,
+            `Too many redirects (more than ${maxRedirects}).`,
+          );
+        }
+
+        const parsed = new URL(currentUrl);
+        const hopIsLoopback = isLoopbackOAuthUrl(currentUrl);
+        if (parsed.protocol !== "https:" && !(chainAllowsLoopback && hopIsLoopback)) {
+          throw new OAuthProxyError(
+            400,
+            `Refusing a plaintext connection to "${safeHost(currentUrl)}".`,
+          );
+        }
+
+        const { response } = await openPinnedHop(
+          parsed,
+          currentMethod,
+          currentHeaders,
+          currentBody,
+          chainAllowsLoopback && hopIsLoopback,
+          socketController.signal,
+          targetLabel,
+        );
+
+        const status = response.statusCode ?? 0;
+        const location = response.headers["location"];
+        if (
+          redirectMode === "error" &&
+          isRedirectStatus(status) &&
+          typeof location === "string"
+        ) {
+          response.resume();
+          throw new OAuthProxyError(
+            400,
+            "The server returned a redirect and the caller asked for none.",
+          );
+        }
+        if (
+          redirectMode === "follow" &&
+          isRedirectStatus(status) &&
+          typeof location === "string"
+        ) {
+          // Nothing downstream will read this hop's body; free the socket
+          // rather than leaving it draining a response we discarded.
+          response.resume();
+
+          let nextUrl: URL;
+          try {
+            nextUrl = new URL(location, currentUrl);
+          } catch {
+            throw new OAuthProxyError(
+              400,
+              "The server returned an invalid redirect location.",
+            );
+          }
+
+          // Fetch's method rewrite, exactly: 301/302 rewrite POST alone, 303
+          // rewrites everything except GET and HEAD, 307/308 rewrite nothing.
+          if (
+            ((status === 301 || status === 302) && currentMethod === "POST") ||
+            (status === 303 &&
+              currentMethod !== "GET" &&
+              currentMethod !== "HEAD")
+          ) {
+            currentMethod = "GET";
+            currentBody = undefined;
+            currentHeaders = stripBodyHeaders(currentHeaders);
+          }
+
+          currentHeaders = sameOrigin(currentUrl, nextUrl.toString())
+            ? currentHeaders
+            : stripCredentials(currentHeaders);
+          currentUrl = nextUrl.toString();
+          continue;
+        }
+
+        // Headers are in and this hop is terminal: the chain deadline has done
+        // its job, and an SSE body must not be on its clock.
+        releaseChainDeadline();
+
+        const responseHeaders = normalizeResponseHeaders(response);
+        if (NULL_BODY_STATUSES.has(status)) {
+          response.resume();
+          return finalizeResponse(
+            new Response(null, {
+              status,
+              statusText: response.statusMessage ?? "",
+              headers: responseHeaders,
+            }),
+            currentUrl,
+          );
+        }
+
+        const decoded = decodeStream(response);
+        // The decoded view is downstream of the socket; destroying the socket
+        // is what actually stops the transfer.
+        const body = toGuardedWebStream(
+          decoded,
+          () => response.destroy(),
+          maxResponseBytes,
+          bodyIdleTimeoutMs,
+        );
+        // `content-encoding`/`content-length` described bytes that no longer
+        // exist once `decodeStream` has undone them; leaving them would make
+        // a consumer that trusts the header mis-read the body.
+        if (responseHeaders.has("content-encoding")) {
+          responseHeaders.delete("content-encoding");
+          responseHeaders.delete("content-length");
+        }
+
+        return finalizeResponse(
+          new Response(body, {
+            status,
+            statusText: response.statusMessage ?? "",
+            headers: responseHeaders,
+          }),
+          currentUrl,
+        );
+      }
+    } catch (error) {
+      releaseChainDeadline();
+      callerSignal?.removeEventListener("abort", onCallerAbort);
+      // An abort raised by our own deadline reaches here as whatever `undici`
+      // or `node:http` chose to throw; the reason we set is the honest one.
+      const reason = socketController.signal.reason;
+      if (socketController.signal.aborted && reason instanceof OAuthProxyError) {
+        throw reason;
+      }
+      throw error;
+    }
+    // NOTE: no `finally` that unhooks `onCallerAbort`. The caller's abort must
+    // keep reaching the socket for as long as the body stream lives, which is
+    // after this function has already returned its `Response`.
+  };
+
+  return pinnedStreamingFetch as typeof fetch;
+}
+
+/**
+ * `Response.url` is read-only and the constructor will not set it, but callers
+ * (and error messages) legitimately want the URL the chain ENDED at rather than
+ * the one it started from — that is the whole difference a redirect makes.
+ */
+function finalizeResponse(response: Response, finalUrl: string): Response {
+  Object.defineProperty(response, "url", {
+    value: finalUrl,
+    configurable: true,
+  });
+  return response;
+}

--- a/sdk/tests/MCPClientManager.base-fetch.test.ts
+++ b/sdk/tests/MCPClientManager.base-fetch.test.ts
@@ -1,0 +1,160 @@
+/**
+ * `baseFetch`: the seam that puts the REAL MCP connection under the same guard
+ * as the raw probes beside it.
+ *
+ * Before it existed, a hosted conformance run guarded its raw HTTP probes with
+ * a hop-checking fetch and then opened its one actual MCP connection through
+ * the global `fetch`, following whatever redirects the target returned. The
+ * suite's own comment said so. These tests pin the two properties that make
+ * the closure real:
+ *
+ *   1. the transport dials through the injected fetch — every request, not
+ *      just the first;
+ *   2. it is the INNERMOST layer, so the guard sees the request that actually
+ *      leaves, headers and all.
+ *
+ * The third test is the regression guard: absent `baseFetch`, nothing changes.
+ */
+
+import http from "http";
+import type { AddressInfo } from "net";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { StreamableHTTPServerTransport } from "@modelcontextprotocol/sdk/server/streamableHttp.js";
+
+import { MCPClientManager } from "../src/mcp-client-manager";
+import { createMockServer } from "./mock-servers";
+
+const stops: Array<() => Promise<void>> = [];
+
+async function startStreamableServer(): Promise<string> {
+  const mcpServer = createMockServer();
+  const transport = new StreamableHTTPServerTransport({
+    sessionIdGenerator: () => `session-${Math.random()}`,
+  });
+  await mcpServer.connect(transport);
+
+  const httpServer = http.createServer(async (req, res) => {
+    if (req.url === "/mcp") {
+      await transport.handleRequest(req, res);
+      return;
+    }
+    res.writeHead(404);
+    res.end("Not found");
+  });
+
+  return await new Promise((resolve) => {
+    httpServer.listen(0, "127.0.0.1", () => {
+      const address = httpServer.address() as AddressInfo;
+      stops.push(
+        () =>
+          new Promise<void>((done) => {
+            httpServer.closeAllConnections?.();
+            httpServer.close(() => done());
+          }),
+      );
+      resolve(`http://127.0.0.1:${address.port}/mcp`);
+    });
+  });
+}
+
+afterEach(async () => {
+  await Promise.all(stops.splice(0).map((stop) => stop()));
+});
+
+describe("baseFetch on the server config", () => {
+  it("carries every transport request, not just the handshake", async () => {
+    const url = await startStreamableServer();
+    const spy = vi.fn<typeof fetch>((input, init) => fetch(input as never, init));
+
+    const manager = new MCPClientManager();
+    try {
+      await manager.connectToServer("s", { url, baseFetch: spy });
+      // A second round trip, after the handshake, must also be on the seam.
+      await manager.listTools("s");
+    } finally {
+      await manager.disconnectAllServers();
+    }
+
+    expect(spy.mock.calls.length).toBeGreaterThan(1);
+    for (const [input] of spy.mock.calls) {
+      const dialled =
+        typeof input === "string"
+          ? input
+          : input instanceof URL
+            ? input.toString()
+            : (input as Request).url;
+      expect(dialled).toContain(new URL(url).host);
+    }
+  });
+
+  it("is the innermost layer, so it observes the headers that actually leave", async () => {
+    const url = await startStreamableServer();
+    const seen: Array<Record<string, string>> = [];
+    const spy: typeof fetch = (input, init) => {
+      seen.push(Object.fromEntries(new Headers(init?.headers).entries()));
+      return fetch(input as never, init);
+    };
+
+    const manager = new MCPClientManager();
+    try {
+      await manager.connectToServer("s", {
+        url,
+        baseFetch: spy,
+        requestInit: { headers: { "x-canary": "present" } },
+      });
+    } finally {
+      await manager.disconnectAllServers();
+    }
+
+    expect(seen.some((headers) => headers["x-canary"] === "present")).toBe(true);
+  });
+
+  it("falls back to the manager default, and to the global fetch when neither is set", async () => {
+    const url = await startStreamableServer();
+    const managerDefault = vi.fn<typeof fetch>((input, init) =>
+      fetch(input as never, init),
+    );
+
+    const withDefault = new MCPClientManager({}, { baseFetch: managerDefault });
+    try {
+      await withDefault.connectToServer("s", { url });
+    } finally {
+      await withDefault.disconnectAllServers();
+    }
+    expect(managerDefault).toHaveBeenCalled();
+
+    // No `baseFetch` anywhere: the connection still works, on the global
+    // fetch. A FRESH server, because the mock's transport accepts exactly one
+    // initialize and a second handshake against it fails for reasons that have
+    // nothing to do with what this asserts.
+    const plainUrl = await startStreamableServer();
+    const plain = new MCPClientManager();
+    try {
+      await expect(
+        plain.connectToServer("s", { url: plainUrl }),
+      ).resolves.not.toThrow();
+    } finally {
+      await plain.disconnectAllServers();
+    }
+  });
+
+  it("lets the per-server value win over the manager default", async () => {
+    const url = await startStreamableServer();
+    const managerDefault = vi.fn<typeof fetch>((input, init) =>
+      fetch(input as never, init),
+    );
+    const perServer = vi.fn<typeof fetch>((input, init) =>
+      fetch(input as never, init),
+    );
+
+    const manager = new MCPClientManager({}, { baseFetch: managerDefault });
+    try {
+      await manager.connectToServer("s", { url, baseFetch: perServer });
+    } finally {
+      await manager.disconnectAllServers();
+    }
+
+    expect(perServer).toHaveBeenCalled();
+    expect(managerDefault).not.toHaveBeenCalled();
+  });
+});

--- a/sdk/tests/claude-readiness/apps-checks.test.ts
+++ b/sdk/tests/claude-readiness/apps-checks.test.ts
@@ -13,6 +13,7 @@
  *     changes the answer.
  */
 
+import { createHash } from "node:crypto";
 import { describe, expect, it } from "vitest";
 
 import {
@@ -122,6 +123,51 @@ describe("the html mime profile", () => {
     expect(finding.class).toBe("required");
   });
 
+  it("tolerates a charset parameter alongside the profile", () => {
+    // `charset` is legal on any `text/*` type and says nothing about the media
+    // type. Rejecting it would fail a conforming widget on a `required` check.
+    expect(
+      byId(
+        run({
+          tools: [MODERN_TOOL],
+          resources: [
+            {
+              uri: "ui://order",
+              mimeType: "text/html;profile=mcp-app; charset=utf-8",
+            },
+          ],
+        }),
+        "claude.apps.html-mime-profile",
+      ).status,
+    ).toBe("satisfied");
+  });
+
+  it("accepts a quoted profile value", () => {
+    expect(
+      byId(
+        run({
+          tools: [MODERN_TOOL],
+          resources: [
+            { uri: "ui://order", mimeType: 'text/html;profile="mcp-app"' },
+          ],
+        }),
+        "claude.apps.html-mime-profile",
+      ).status,
+    ).toBe("satisfied");
+  });
+
+  it("still rejects the essence alone, which carries no app signal", () => {
+    expect(
+      byId(
+        run({
+          tools: [MODERN_TOOL],
+          resources: [{ uri: "ui://order", mimeType: "text/html; charset=utf-8" }],
+        }),
+        "claude.apps.html-mime-profile",
+      ).status,
+    ).toBe("violated");
+  });
+
   it("tolerates spacing and case in the parameter", () => {
     expect(
       byId(
@@ -186,6 +232,18 @@ describe("ui.domain", () => {
     expect(claudeAppContentDomain(URL_UNDER_TEST)).toMatch(
       /^[0-9a-f]{32}\.claudemcpcontent\.com$/,
     );
+  });
+
+  it("pins the exact derivation, so a digest change cannot pass unnoticed", () => {
+    // Neither of the assertions above would catch a switch to a different
+    // digest, a different slice offset, or a lower-cased input — each of which
+    // satisfies "differs on differing input" and "looks like 32 hex" while
+    // breaking every deployed widget.
+    const expected = `${createHash("sha256")
+      .update(URL_UNDER_TEST)
+      .digest("hex")
+      .slice(0, 32)}.claudemcpcontent.com`;
+    expect(claudeAppContentDomain(URL_UNDER_TEST)).toBe(expected);
   });
 
   it("is not applicable when no resource sets one", () => {
@@ -408,6 +466,20 @@ describe("CSP shape", () => {
         run({
           tools: [MODERN_TOOL],
           resources: [{ ...GOOD_RESOURCE, csp: { "connect-src": ["https://*"] } }],
+        }),
+        "claude.apps.csp-shape",
+      ).status,
+    ).toBe("violated");
+  });
+
+  it("catches a wildcard written as a bare string rather than a list", () => {
+    expect(
+      byId(
+        run({
+          tools: [MODERN_TOOL],
+          resources: [
+            { ...GOOD_RESOURCE, csp: { "connect-src": "https://*.example.com" } },
+          ],
         }),
         "claude.apps.csp-shape",
       ).status,

--- a/sdk/tests/claude-readiness/apps-checks.test.ts
+++ b/sdk/tests/claude-readiness/apps-checks.test.ts
@@ -24,6 +24,7 @@ import {
   type ClaudeAppsEvidence,
 } from "../../src/claude-readiness/checks/apps.js";
 import { decideLaneStatus } from "../../src/claude-readiness/index.js";
+import { CLAUDE_APP_DESIGN_BUDGETS } from "../../src/claude-readiness/profile.js";
 
 const STAMP = { evaluatedAt: "2026-08-19T00:00:00.000Z" };
 const URL_UNDER_TEST = "https://mcp.example.com/mcp";
@@ -65,6 +66,34 @@ describe("no apps evidence versus no apps", () => {
   it("reports not-applicable when the suite ran and found no widgets", () => {
     const findings = run({ tools: [] });
     expect(findings.every((f) => f.status === "not-applicable")).toBe(true);
+  });
+
+  it("accounts for every check on both early returns, design lints included", () => {
+    // The early returns used to enumerate the checks by hand and omit the
+    // eight design lints, so a run with no apps evidence quietly produced
+    // fewer findings than the catalog advertises. A missing finding is worse
+    // than a `not-evaluated` one: the reader has to notice the absence.
+    const everyId = new Set(
+      runClaudeAppsChecks(
+        {
+          enteredUrl: URL_UNDER_TEST,
+          appsSuiteRan: true,
+          tools: [MODERN_TOOL],
+          resources: [GOOD_RESOURCE],
+        },
+        STAMP,
+      ).map((finding) => finding.id),
+    );
+
+    for (const evidence of [
+      { enteredUrl: URL_UNDER_TEST, appsSuiteRan: false },
+      { enteredUrl: URL_UNDER_TEST, appsSuiteRan: true, tools: [] },
+    ]) {
+      const reported = new Set(
+        runClaudeAppsChecks(evidence, STAMP).map((finding) => finding.id),
+      );
+      expect(reported).toEqual(everyId);
+    }
   });
 });
 
@@ -365,6 +394,38 @@ describe("design-guideline lints", () => {
         finding.status === "violated",
     );
     expect(flagged).toEqual([]);
+  });
+
+  it("reads the touch-target minimum as a number, not as digits in a regex", () => {
+    const touchTarget = (html: string) =>
+      run({
+        tools: [MODERN_TOOL],
+        resources: [{ ...GOOD_RESOURCE, html }],
+      }).find((f) => f.id === "claude.apps.design.touch-targets")!.status;
+
+    // Exactly the budget passes, and so does the logical property — which the
+    // old regex accepted at ANY value, including ones far below the minimum.
+    expect(
+      touchTarget(
+        `<html><body><button style="min-height: ${CLAUDE_APP_DESIGN_BUDGETS.minTouchTargetPx}px" aria-label="Go">Go</button></body></html>`,
+      ),
+    ).toBe("satisfied");
+    expect(
+      touchTarget(
+        '<html><body><button style="min-block-size: 48px" aria-label="Go">Go</button></body></html>',
+      ),
+    ).toBe("satisfied");
+    expect(
+      touchTarget(
+        '<html><body><button style="min-block-size: 8px" aria-label="Go">Go</button></body></html>',
+      ),
+    ).toBe("violated");
+    // A fractional value below the budget is still below it.
+    expect(
+      touchTarget(
+        '<html><body><button style="min-height: 43.5px" aria-label="Go">Go</button></body></html>',
+      ),
+    ).toBe("violated");
   });
 
   it("does not see a button that exists only inside a comment", () => {

--- a/sdk/tests/claude-readiness/apps-checks.test.ts
+++ b/sdk/tests/claude-readiness/apps-checks.test.ts
@@ -350,6 +350,41 @@ describe("design-guideline lints", () => {
     );
   });
 
+  it("counts inline style declarations, not only <style> blocks", () => {
+    // `<button style="min-height: 44px">` satisfies the guideline exactly as
+    // well as a stylesheet does. Reading only `<style>` bodies would report a
+    // violation the author already fixed.
+    const inlineHtml =
+      '<html><body><button style="min-height: 48px" aria-label="Go">Go</button></body></html>';
+    const flagged = run({
+      tools: [MODERN_TOOL],
+      resources: [{ ...GOOD_RESOURCE, html: inlineHtml }],
+    }).filter(
+      (finding) =>
+        finding.id === "claude.apps.design.touch-targets" &&
+        finding.status === "violated",
+    );
+    expect(flagged).toEqual([]);
+  });
+
+  it("does not see a button that exists only inside a comment", () => {
+    // The regexes this scanner replaced matched markup anywhere in the file,
+    // including commented-out code, and then demanded ARIA on an element the
+    // widget does not have.
+    const commented =
+      "<html><body><!-- <button>old</button> --><p>text</p></body></html>";
+    const flagged = run({
+      tools: [MODERN_TOOL],
+      resources: [{ ...GOOD_RESOURCE, html: commented }],
+    }).filter(
+      (finding) =>
+        (finding.id === "claude.apps.design.accessibility" ||
+          finding.id === "claude.apps.design.touch-targets") &&
+        finding.status === "violated",
+    );
+    expect(flagged).toEqual([]);
+  });
+
   it("clears a careful widget", () => {
     const flagged = run({
       tools: [MODERN_TOOL],

--- a/sdk/tests/claude-readiness/apps-checks.test.ts
+++ b/sdk/tests/claude-readiness/apps-checks.test.ts
@@ -1,0 +1,430 @@
+/**
+ * Claude-specific MCP Apps checks.
+ *
+ * Four rev-2 corrections are pinned here, each one a place a reasonable
+ * implementation gets it backwards:
+ *
+ *   - the MODERN `_meta.ui.resourceUri` alone is correct; only legacy-ONLY is
+ *     a problem (an earlier reading warned whenever the legacy field was
+ *     absent, which is exactly inverted);
+ *   - a `text/html;profile=mcp-app` mismatch is a FAILURE, not a warning;
+ *   - an OpenAI-only widget blocks only when the tool is app-only;
+ *   - `ui.domain` is derived from the EXACT entered URL, so a trailing slash
+ *     changes the answer.
+ */
+
+import { describe, expect, it } from "vitest";
+
+import {
+  claudeAppContentDomain,
+  claudeAppResourceEvidenceFrom,
+  claudeAppToolEvidenceFrom,
+  runClaudeAppsChecks,
+  type ClaudeAppsEvidence,
+} from "../../src/claude-readiness/checks/apps.js";
+import { decideLaneStatus } from "../../src/claude-readiness/index.js";
+
+const STAMP = { evaluatedAt: "2026-08-19T00:00:00.000Z" };
+const URL_UNDER_TEST = "https://mcp.example.com/mcp";
+
+function run(evidence: Partial<ClaudeAppsEvidence>) {
+  return runClaudeAppsChecks(
+    { enteredUrl: URL_UNDER_TEST, appsSuiteRan: true, ...evidence },
+    STAMP,
+  );
+}
+
+function byId(findings: ReturnType<typeof run>, id: string) {
+  return findings.find((finding) => finding.id === id)!;
+}
+
+const MODERN_TOOL = {
+  name: "show_order",
+  resourceUri: "ui://order",
+  hasNestedField: true,
+  hasLegacyField: false,
+  toolMeta: { ui: { resourceUri: "ui://order" } },
+};
+
+const GOOD_RESOURCE = {
+  uri: "ui://order",
+  mimeType: "text/html;profile=mcp-app",
+};
+
+describe("no apps evidence versus no apps", () => {
+  it("reports not-evaluated when the apps suite never ran", () => {
+    // "We have no result" is not "this server has no widgets".
+    const findings = runClaudeAppsChecks(
+      { enteredUrl: URL_UNDER_TEST, appsSuiteRan: false },
+      STAMP,
+    );
+    expect(findings.every((f) => f.status === "not-evaluated")).toBe(true);
+  });
+
+  it("reports not-applicable when the suite ran and found no widgets", () => {
+    const findings = run({ tools: [] });
+    expect(findings.every((f) => f.status === "not-applicable")).toBe(true);
+  });
+});
+
+describe("resourceUri modernity", () => {
+  it("passes a tool that declares only the modern field", () => {
+    expect(
+      byId(run({ tools: [MODERN_TOOL], resources: [GOOD_RESOURCE] }), "claude.apps.resource-uri-modern")
+        .status,
+    ).toBe("satisfied");
+  });
+
+  it("passes a tool that declares both", () => {
+    expect(
+      byId(
+        run({
+          tools: [{ ...MODERN_TOOL, hasLegacyField: true }],
+          resources: [GOOD_RESOURCE],
+        }),
+        "claude.apps.resource-uri-modern",
+      ).status,
+    ).toBe("satisfied");
+  });
+
+  it("fails only a tool that declares the legacy field alone", () => {
+    const finding = byId(
+      run({
+        tools: [{ ...MODERN_TOOL, hasNestedField: false, hasLegacyField: true }],
+        resources: [GOOD_RESOURCE],
+      }),
+      "claude.apps.resource-uri-modern",
+    );
+    expect(finding.status).toBe("violated");
+    expect(finding.details).toMatchObject({ tools: ["show_order"] });
+  });
+
+  it("cites the apps-suite check it composes rather than re-running it", () => {
+    expect(
+      byId(run({ tools: [MODERN_TOOL], resources: [GOOD_RESOURCE] }), "claude.apps.resource-uri-modern")
+        .derivedFrom,
+    ).toContain("apps-conformance:ui-tool-metadata-valid");
+  });
+});
+
+describe("the html mime profile", () => {
+  it("fails plain text/html", () => {
+    const finding = byId(
+      run({
+        tools: [MODERN_TOOL],
+        resources: [{ uri: "ui://order", mimeType: "text/html" }],
+      }),
+      "claude.apps.html-mime-profile",
+    );
+    // A failure, not a warning: without the profile the host does not know the
+    // payload is an app.
+    expect(finding.status).toBe("violated");
+    expect(finding.class).toBe("required");
+  });
+
+  it("tolerates spacing and case in the parameter", () => {
+    expect(
+      byId(
+        run({
+          tools: [MODERN_TOOL],
+          resources: [{ uri: "ui://order", mimeType: "Text/HTML; profile=mcp-app" }],
+        }),
+        "claude.apps.html-mime-profile",
+      ).status,
+    ).toBe("satisfied");
+  });
+});
+
+describe("OpenAI-only widgets", () => {
+  const openAiTool = {
+    name: "chart",
+    resourceUri: "ui://chart",
+    hasNestedField: false,
+    hasLegacyField: false,
+    hasOpenAiWidget: true,
+  };
+
+  it("blocks when the tool is app-only, because Claude renders nothing", () => {
+    const finding = byId(
+      run({
+        tools: [{ ...openAiTool, toolMeta: { ui: { visibility: ["app"] } } }],
+        resources: [],
+      }),
+      "claude.apps.openai-only-widget",
+    );
+    expect(finding.status).toBe("violated");
+    expect(finding.class).toBe("runtime-blocker");
+  });
+
+  it("does not block a model-visible tool — degraded is not broken", () => {
+    const finding = byId(
+      run({
+        tools: [{ ...openAiTool, hasTextualFallback: true }],
+        resources: [],
+      }),
+      "claude.apps.openai-only-widget",
+    );
+    expect(finding.status).toBe("satisfied");
+    // …and still names it, so a reviewer knows the UI is lost in Claude.
+    expect(finding.details).toMatchObject({
+      degraded: [{ name: "chart", hasTextualFallback: true }],
+    });
+  });
+});
+
+describe("ui.domain", () => {
+  it("derives from the EXACT entered URL", () => {
+    // A trailing slash changes the digest, so it must change the domain — a
+    // check that canonicalized first would pass a value that fails in
+    // production.
+    expect(claudeAppContentDomain(URL_UNDER_TEST)).not.toBe(
+      claudeAppContentDomain(`${URL_UNDER_TEST}/`),
+    );
+  });
+
+  it("produces a 32-hex label under the Claude content host", () => {
+    expect(claudeAppContentDomain(URL_UNDER_TEST)).toMatch(
+      /^[0-9a-f]{32}\.claudemcpcontent\.com$/,
+    );
+  });
+
+  it("is not applicable when no resource sets one", () => {
+    expect(
+      byId(
+        run({ tools: [MODERN_TOOL], resources: [GOOD_RESOURCE] }),
+        "claude.apps.ui-domain-derivation",
+      ).status,
+    ).toBe("not-applicable");
+  });
+
+  it("passes an exactly-derived domain", () => {
+    expect(
+      byId(
+        run({
+          tools: [MODERN_TOOL],
+          resources: [
+            { ...GOOD_RESOURCE, domain: claudeAppContentDomain(URL_UNDER_TEST) },
+          ],
+        }),
+        "claude.apps.ui-domain-derivation",
+      ).status,
+    ).toBe("satisfied");
+  });
+
+  it("fails a domain derived from the trailing-slash form and says why", () => {
+    const finding = byId(
+      run({
+        tools: [MODERN_TOOL],
+        resources: [
+          { ...GOOD_RESOURCE, domain: claudeAppContentDomain(`${URL_UNDER_TEST}/`) },
+        ],
+      }),
+      "claude.apps.ui-domain-derivation",
+    );
+    expect(finding.status).toBe("violated");
+    expect(finding.remediation).toMatch(/trailing slash/);
+    expect(finding.details).toMatchObject({ hashedInput: URL_UNDER_TEST });
+  });
+
+  it("only advises about an absent domain when the app owns its OAuth", () => {
+    expect(
+      byId(
+        run({ tools: [MODERN_TOOL], resources: [GOOD_RESOURCE] }),
+        "claude.apps.ui-domain-recommended-for-app-oauth",
+      ).status,
+    ).toBe("satisfied");
+    const advised = byId(
+      run({ tools: [MODERN_TOOL], resources: [GOOD_RESOURCE], appOwnedOAuth: true }),
+      "claude.apps.ui-domain-recommended-for-app-oauth",
+    );
+    expect(advised.status).toBe("violated");
+    // An advisory, so it can never fail the lane.
+    expect(advised.class).toBe("recommended");
+  });
+});
+
+describe("the result-size budget is not a static check", () => {
+  it("is reported as an unevaluated functional observation", () => {
+    const finding = byId(
+      run({ tools: [MODERN_TOOL], resources: [GOOD_RESOURCE] }),
+      "claude.apps.result-size-budget",
+    );
+    expect(finding.status).toBe("not-evaluated");
+    expect(finding.notEvaluatedReason).toMatch(/per CALL/);
+  });
+});
+
+describe("design-guideline lints", () => {
+  const bareHtml = "<html><body><button>Go</button></body></html>";
+  const carefulHtml = `<html><head><style>
+    @media (max-width: 320px) { body { padding: 0 } }
+    button { min-height: 44px }
+    body { padding: env(safe-area-inset-bottom) }
+    @media (prefers-color-scheme: dark) { body { color: #fff } }
+  </style></head><body><button role="button" aria-label="Go" data-display-mode="inline">Go</button></body></html>`;
+
+  it("never fails a lane, whatever it finds", () => {
+    const findings = run({
+      tools: [MODERN_TOOL],
+      resources: [{ ...GOOD_RESOURCE, html: bareHtml }],
+    }).filter((finding) => finding.id.startsWith("claude.apps.design."));
+    expect(findings.length).toBeGreaterThan(0);
+    expect(findings.every((finding) => finding.class === "heuristic")).toBe(true);
+    expect(decideLaneStatus(findings)).toBe("incomplete");
+  });
+
+  it("flags a bare widget across the guideline set", () => {
+    const flagged = run({
+      tools: [MODERN_TOOL],
+      resources: [{ ...GOOD_RESOURCE, html: bareHtml }],
+    }).filter(
+      (finding) =>
+        finding.id.startsWith("claude.apps.design.") && finding.status === "violated",
+    );
+    expect(flagged.map((f) => f.id)).toEqual(
+      expect.arrayContaining([
+        "claude.apps.design.responsive-320",
+        "claude.apps.design.touch-targets",
+        "claude.apps.design.safe-area",
+        "claude.apps.design.theming",
+        "claude.apps.design.accessibility",
+      ]),
+    );
+  });
+
+  it("clears a careful widget", () => {
+    const flagged = run({
+      tools: [MODERN_TOOL],
+      resources: [{ ...GOOD_RESOURCE, html: carefulHtml }],
+    }).filter(
+      (finding) =>
+        finding.id.startsWith("claude.apps.design.") && finding.status === "violated",
+    );
+    expect(flagged).toEqual([]);
+  });
+
+  it("labels its provenance honestly as a static read", () => {
+    // Even with a browser in the run, these lints read markup. Calling them a
+    // `browser` observation would overstate what produced the signal.
+    const finding = run({
+      tools: [MODERN_TOOL],
+      resources: [{ ...GOOD_RESOURCE, html: bareHtml }],
+      renderEngine: "node-approximation",
+    }).find((f) => f.id === "claude.apps.design.theming")!;
+    expect(finding.provenance).toBe("static");
+    expect(finding.details).toMatchObject({
+      renderEngine: "node-approximation",
+      basis: "static markup analysis, not a rendered observation",
+    });
+  });
+
+  it("cannot run at all without widget HTML", () => {
+    const findings = run({
+      tools: [MODERN_TOOL],
+      resources: [GOOD_RESOURCE],
+    }).filter((finding) => finding.id.startsWith("claude.apps.design."));
+    expect(findings.every((f) => f.status === "not-evaluated")).toBe(true);
+  });
+});
+
+describe("instance supersession", () => {
+  it("is only tested for a widget that claims a single active instance", () => {
+    expect(
+      byId(
+        run({ tools: [MODERN_TOOL], resources: [GOOD_RESOURCE] }),
+        "claude.apps.instance-supersession",
+      ).status,
+    ).toBe("not-applicable");
+    expect(
+      byId(
+        run({
+          tools: [MODERN_TOOL],
+          resources: [{ ...GOOD_RESOURCE, claimsSingleActiveInstance: true }],
+        }),
+        "claude.apps.instance-supersession",
+      ).status,
+    ).toBe("not-evaluated");
+  });
+});
+
+describe("composition helpers", () => {
+  it("reads the modern, legacy and OpenAI fields apart", () => {
+    expect(
+      claudeAppToolEvidenceFrom({
+        name: "a",
+        _meta: { ui: { resourceUri: "ui://a" } },
+      }),
+    ).toMatchObject({ hasNestedField: true, hasLegacyField: false });
+    expect(
+      claudeAppToolEvidenceFrom({ name: "b", _meta: { "ui/resourceUri": "ui://b" } }),
+    ).toMatchObject({ hasNestedField: false, hasLegacyField: true });
+    expect(
+      claudeAppToolEvidenceFrom({
+        name: "c",
+        _meta: { "openai/outputTemplate": "ui://c" },
+      }),
+    ).toMatchObject({ hasOpenAiWidget: true, hasNestedField: false });
+  });
+
+  it("returns nothing for an ordinary tool", () => {
+    expect(claudeAppToolEvidenceFrom({ name: "plain" })).toBeUndefined();
+  });
+
+  it("keeps HTML only when the mime type says HTML", () => {
+    expect(
+      claudeAppResourceEvidenceFrom({
+        uri: "ui://a",
+        mimeType: "application/json",
+        text: '{"not":"html"}',
+      }).html,
+    ).toBeUndefined();
+    expect(
+      claudeAppResourceEvidenceFrom({
+        uri: "ui://a",
+        mimeType: "text/html;profile=mcp-app",
+        text: "<html></html>",
+      }).html,
+    ).toBe("<html></html>");
+  });
+
+  it("lifts ui.domain and ui.csp out of the resource meta", () => {
+    expect(
+      claudeAppResourceEvidenceFrom({
+        uri: "ui://a",
+        mimeType: "text/html;profile=mcp-app",
+        _meta: { ui: { domain: "abc.claudemcpcontent.com", csp: { "connect-src": ["*"] } } },
+      }),
+    ).toMatchObject({
+      domain: "abc.claudemcpcontent.com",
+      csp: { "connect-src": ["*"] },
+    });
+  });
+});
+
+describe("CSP shape", () => {
+  it("advises against a wildcard", () => {
+    expect(
+      byId(
+        run({
+          tools: [MODERN_TOOL],
+          resources: [{ ...GOOD_RESOURCE, csp: { "connect-src": ["https://*"] } }],
+        }),
+        "claude.apps.csp-shape",
+      ).status,
+    ).toBe("violated");
+  });
+
+  it("accepts named hosts", () => {
+    expect(
+      byId(
+        run({
+          tools: [MODERN_TOOL],
+          resources: [
+            { ...GOOD_RESOURCE, csp: { "connect-src": ["https://api.example.com"] } },
+          ],
+        }),
+        "claude.apps.csp-shape",
+      ).status,
+    ).toBe("satisfied");
+  });
+});

--- a/sdk/tests/claude-readiness/auth-checks.test.ts
+++ b/sdk/tests/claude-readiness/auth-checks.test.ts
@@ -221,6 +221,39 @@ describe("the RFC 8707 resource parameter, once an authorization happened", () =
   });
 });
 
+describe("a refused resource_metadata pointer is reported, not swallowed", () => {
+  it("fails discovery even when the well-known fallback worked", () => {
+    // The fallback found the document, and the server still published a
+    // pointer no conforming client can follow. Reporting only the success
+    // would hide a defect that breaks every client which trusts the challenge.
+    const finding = byId(
+      runClaudeAuthChecks(
+        {
+          ...HEALTHY,
+          prm: {
+            ...HEALTHY.prm!,
+            discoveredVia: "well-known-path-suffixed",
+            rejectedPointer: "https://elsewhere.example/prm.json",
+          },
+        },
+        STAMP,
+      ),
+      "claude.auth.prm-discoverable",
+    );
+    expect(finding.status).toBe("violated");
+    expect(finding.details).toMatchObject({
+      rejectedPointer: "https://elsewhere.example/prm.json",
+    });
+  });
+
+  it("passes when the pointer was followed normally", () => {
+    expect(
+      byId(runClaudeAuthChecks(HEALTHY, STAMP), "claude.auth.prm-discoverable")
+        .status,
+    ).toBe("satisfied");
+  });
+});
+
 describe("canonicalResourceIndicator", () => {
   it("drops the query, fragment and default port but keeps the path", () => {
     expect(

--- a/sdk/tests/claude-readiness/auth-checks.test.ts
+++ b/sdk/tests/claude-readiness/auth-checks.test.ts
@@ -171,6 +171,56 @@ describe("the PRM resource check is about the ENTERED url", () => {
   });
 });
 
+describe("the RFC 8707 resource parameter, once an authorization happened", () => {
+  it("passes the canonical form on both endpoints", () => {
+    expect(
+      byId(
+        runClaudeAuthChecks(
+          {
+            ...HEALTHY,
+            resourceIndicatorsSent: {
+              authorize: URL_UNDER_TEST,
+              token: URL_UNDER_TEST,
+            },
+          },
+          STAMP,
+        ),
+        "claude.auth.rfc8707-resource-canonical",
+      ).status,
+    ).toBe("satisfied");
+  });
+
+  it("fails a non-canonical value and names the endpoint that sent it", () => {
+    const finding = byId(
+      runClaudeAuthChecks(
+        {
+          ...HEALTHY,
+          resourceIndicatorsSent: {
+            authorize: URL_UNDER_TEST,
+            token: `${URL_UNDER_TEST}?tenant=acme`,
+          },
+        },
+        STAMP,
+      ),
+      "claude.auth.rfc8707-resource-canonical",
+    );
+    expect(finding.status).toBe("violated");
+    expect(finding.details).toMatchObject({ endpoints: ["token"] });
+  });
+
+  it("grades an endpoint that carried the parameter and ignores one that did not", () => {
+    expect(
+      byId(
+        runClaudeAuthChecks(
+          { ...HEALTHY, resourceIndicatorsSent: { authorize: URL_UNDER_TEST } },
+          STAMP,
+        ),
+        "claude.auth.rfc8707-resource-canonical",
+      ).status,
+    ).toBe("satisfied");
+  });
+});
+
 describe("canonicalResourceIndicator", () => {
   it("drops the query, fragment and default port but keeps the path", () => {
     expect(

--- a/sdk/tests/claude-readiness/auth-checks.test.ts
+++ b/sdk/tests/claude-readiness/auth-checks.test.ts
@@ -1,0 +1,443 @@
+/**
+ * The non-invasive auth checks.
+ *
+ * Three corrections from the rev-2 audit are pinned here as named tests,
+ * because each one is a place a reasonable implementation gets it wrong in a
+ * way that looks right:
+ *
+ *   - a broken `authorization_servers[0]` is a BLOCKER, not a warning, because
+ *     Claude never falls back to entry one;
+ *   - `scope` is OPTIONAL on an `insufficient_scope` challenge;
+ *   - a JWT `aud` that does not name the resource proves nothing.
+ *
+ * Plus the classify-don't-fail rule, which is what keeps a static-header or
+ * preregistered-client connector from being reported as broken.
+ */
+
+import { describe, expect, it } from "vitest";
+
+import {
+  canonicalResourceIndicator,
+  runClaudeAuthChecks,
+  type ClaudeAuthEvidence,
+} from "../../src/claude-readiness/checks/auth.js";
+
+const STAMP = { evaluatedAt: "2026-08-19T00:00:00.000Z" };
+const URL_UNDER_TEST = "https://mcp.example.com/mcp";
+
+function byId(
+  output: ReturnType<typeof runClaudeAuthChecks>,
+  id: string,
+) {
+  return output.findings.find((finding) => finding.id === id)!;
+}
+
+function badge(output: ReturnType<typeof runClaudeAuthChecks>, id: string) {
+  return output.badges.find((entry) => entry.id === id)!;
+}
+
+const HEALTHY: ClaudeAuthEvidence = {
+  enteredUrl: URL_UNDER_TEST,
+  unauthenticated: {
+    status: 401,
+    wwwAuthenticate:
+      'Bearer resource_metadata="https://mcp.example.com/.well-known/oauth-protected-resource/mcp"',
+    representsProtectedOperation: true,
+    servedWithoutCredentials: false,
+  },
+  prm: {
+    discoveredVia: "www-authenticate",
+    url: "https://mcp.example.com/.well-known/oauth-protected-resource/mcp",
+    document: {
+      resource: URL_UNDER_TEST,
+      authorization_servers: ["https://auth.example.com"],
+    },
+  },
+  firstAuthorizationServer: {
+    issuer: "https://auth.example.com",
+    metadataUrl: "https://auth.example.com/.well-known/oauth-authorization-server",
+    reachable: true,
+    document: {
+      issuer: "https://auth.example.com",
+      registration_endpoint: "https://auth.example.com/register",
+      code_challenge_methods_supported: ["S256"],
+      response_types_supported: ["code"],
+    },
+  },
+};
+
+describe("a healthy OAuth connector", () => {
+  it("satisfies every applicable runtime requirement", () => {
+    const output = runClaudeAuthChecks(HEALTHY, STAMP);
+    const violations = output.findings.filter((f) => f.status === "violated");
+    expect(violations).toEqual([]);
+  });
+
+  it("badges the auth mode it could actually determine", () => {
+    expect(badge(runClaudeAuthChecks(HEALTHY, STAMP), "claude.auth.mode")).toMatchObject(
+      { state: "supported", provenance: "wire" },
+    );
+  });
+});
+
+describe("authorization_servers[0] is a blocker", () => {
+  const broken: ClaudeAuthEvidence = {
+    ...HEALTHY,
+    prm: {
+      ...HEALTHY.prm!,
+      document: {
+        resource: URL_UNDER_TEST,
+        authorization_servers: [
+          "https://broken.example.com",
+          "https://auth.example.com",
+        ],
+      },
+    },
+    firstAuthorizationServer: {
+      issuer: "https://broken.example.com",
+      reachable: false,
+      fetchError: "ENOTFOUND",
+    },
+  };
+
+  it("fails even though a healthy server is listed second", () => {
+    const finding = byId(
+      runClaudeAuthChecks(broken, STAMP),
+      "claude.auth.first-authorization-server-usable",
+    );
+    expect(finding.status).toBe("violated");
+    // A runtime blocker, not a recommendation: Claude cannot use the connector.
+    expect(finding.class).toBe("runtime-blocker");
+    expect(finding.remediation).toMatch(/does not fall back/);
+  });
+
+  it("names the entries it did not try, so the rule is concrete", () => {
+    expect(
+      byId(runClaudeAuthChecks(broken, STAMP), "claude.auth.first-authorization-server-usable")
+        .details,
+    ).toMatchObject({ otherEntries: ["https://auth.example.com"] });
+  });
+
+  it("leaves the downstream metadata checks unevaluated rather than failed", () => {
+    // The metadata was never read; calling those requirements violated would
+    // invent findings about a document nobody saw.
+    for (const id of [
+      "claude.auth.pkce-s256-advertised",
+      "claude.auth.cimd-flag-consistent",
+      "claude.auth.client-acquisition-path",
+    ]) {
+      expect(byId(runClaudeAuthChecks(broken, STAMP), id).status).toBe(
+        "not-evaluated",
+      );
+    }
+  });
+});
+
+describe("the PRM resource check is about the ENTERED url", () => {
+  it("fails a trailing-slash mismatch", () => {
+    const finding = byId(
+      runClaudeAuthChecks(
+        {
+          ...HEALTHY,
+          prm: {
+            ...HEALTHY.prm!,
+            document: {
+              resource: `${URL_UNDER_TEST}/`,
+              authorization_servers: ["https://auth.example.com"],
+            },
+          },
+        },
+        STAMP,
+      ),
+      "claude.auth.prm-resource-matches-entered-url",
+    );
+    expect(finding.status).toBe("violated");
+    expect(finding.remediation).toMatch(/trailing slash/);
+  });
+
+  it("is separate from the canonical-form requirement", () => {
+    // A server can declare the entered URL correctly and still have a client
+    // send a non-canonical `resource`; one check cannot cover both.
+    const output = runClaudeAuthChecks(HEALTHY, STAMP);
+    expect(byId(output, "claude.auth.prm-resource-matches-entered-url").status).toBe(
+      "satisfied",
+    );
+    expect(byId(output, "claude.auth.rfc8707-resource-canonical").status).toBe(
+      "not-evaluated",
+    );
+    expect(
+      byId(output, "claude.auth.rfc8707-resource-canonical").requiresCapabilities,
+    ).toContain("interactive-oauth");
+  });
+});
+
+describe("canonicalResourceIndicator", () => {
+  it("drops the query, fragment and default port but keeps the path", () => {
+    expect(
+      canonicalResourceIndicator("https://MCP.Example.com:443/mcp?x=1#frag"),
+    ).toBe("https://mcp.example.com/mcp");
+  });
+
+  it("keeps a non-default port", () => {
+    expect(canonicalResourceIndicator("https://mcp.example.com:8443/mcp")).toBe(
+      "https://mcp.example.com:8443/mcp",
+    );
+  });
+
+  it("does not invent a trailing slash on an origin-only URL", () => {
+    expect(canonicalResourceIndicator("https://mcp.example.com")).toBe(
+      "https://mcp.example.com",
+    );
+  });
+});
+
+describe("insufficient_scope challenges", () => {
+  it("passes when `scope` is omitted — Claude selects scopes itself", () => {
+    const finding = byId(
+      runClaudeAuthChecks(
+        {
+          ...HEALTHY,
+          insufficientScopeChallenge: {
+            header: 'Bearer error="insufficient_scope"',
+          },
+        },
+        STAMP,
+      ),
+      "claude.auth.insufficient-scope-challenge-shape",
+    );
+    expect(finding.status).toBe("satisfied");
+    expect(finding.details).toMatchObject({ scopeOmitted: true });
+  });
+
+  it("fails when the error code is something else entirely", () => {
+    expect(
+      byId(
+        runClaudeAuthChecks(
+          {
+            ...HEALTHY,
+            insufficientScopeChallenge: { header: 'Bearer error="invalid_token"' },
+          },
+          STAMP,
+        ),
+        "claude.auth.insufficient-scope-challenge-shape",
+      ).status,
+    ).toBe("violated");
+  });
+});
+
+describe("WWW-Authenticate on a successful response", () => {
+  it("is not applicable when the probed response was the 401 itself", () => {
+    expect(
+      byId(
+        runClaudeAuthChecks(HEALTHY, STAMP),
+        "claude.auth.no-challenge-on-successful-operation",
+      ).status,
+    ).toBe("not-applicable");
+  });
+
+  it("fails only when a protected operation both succeeded and challenged", () => {
+    const output = runClaudeAuthChecks(
+      {
+        ...HEALTHY,
+        unauthenticated: {
+          status: 200,
+          wwwAuthenticate: 'Bearer realm="api"',
+          representsProtectedOperation: true,
+          servedWithoutCredentials: true,
+        },
+      },
+      STAMP,
+    );
+    expect(
+      byId(output, "claude.auth.no-challenge-on-successful-operation").status,
+    ).toBe("violated");
+  });
+
+  it("passes a success with no challenge attached", () => {
+    expect(
+      byId(
+        runClaudeAuthChecks(
+          {
+            ...HEALTHY,
+            unauthenticated: {
+              status: 200,
+              representsProtectedOperation: true,
+              servedWithoutCredentials: true,
+            },
+          },
+          STAMP,
+        ),
+        "claude.auth.no-challenge-on-successful-operation",
+      ).status,
+    ).toBe("satisfied");
+  });
+});
+
+describe("classify, don't fail", () => {
+  it("treats an authless server as inapplicable rather than broken", () => {
+    const output = runClaudeAuthChecks(
+      {
+        enteredUrl: URL_UNDER_TEST,
+        unauthenticated: {
+          status: 200,
+          representsProtectedOperation: true,
+          servedWithoutCredentials: true,
+        },
+        prm: { discoveredVia: "not-found" },
+      },
+      STAMP,
+    );
+    expect(output.findings.filter((f) => f.status === "violated")).toEqual([]);
+    expect(
+      byId(output, "claude.auth.unauthenticated-challenge").status,
+    ).toBe("not-applicable");
+  });
+
+  it("says a static-header connector is indistinguishable rather than guessing", () => {
+    const output = runClaudeAuthChecks(
+      {
+        enteredUrl: URL_UNDER_TEST,
+        unauthenticated: {
+          status: 200,
+          representsProtectedOperation: true,
+          servedWithoutCredentials: true,
+        },
+        prm: { discoveredVia: "not-found" },
+        declaredAuthMode: "static-header",
+      },
+      STAMP,
+    );
+    const mode = badge(output, "claude.auth.mode");
+    expect(mode.state).toBe("claimed");
+    expect(mode.detail).toMatch(/static-header/);
+  });
+
+  it("accepts a preregistered client when the submitter declared one", () => {
+    const noRegistration: ClaudeAuthEvidence = {
+      ...HEALTHY,
+      declaredAuthMode: "oauth-preregistered",
+      firstAuthorizationServer: {
+        ...HEALTHY.firstAuthorizationServer!,
+        document: {
+          issuer: "https://auth.example.com",
+          code_challenge_methods_supported: ["S256"],
+          response_types_supported: ["code"],
+        },
+      },
+    };
+    expect(
+      byId(runClaudeAuthChecks(noRegistration, STAMP), "claude.auth.client-acquisition-path")
+        .status,
+    ).toBe("satisfied");
+  });
+
+  it("flags an undeclared server with no client-acquisition path at all", () => {
+    const finding = byId(
+      runClaudeAuthChecks(
+        {
+          ...HEALTHY,
+          firstAuthorizationServer: {
+            ...HEALTHY.firstAuthorizationServer!,
+            document: {
+              issuer: "https://auth.example.com",
+              code_challenge_methods_supported: ["S256"],
+              response_types_supported: ["code"],
+            },
+          },
+        },
+        STAMP,
+      ),
+      "claude.auth.client-acquisition-path",
+    );
+    expect(finding.status).toBe("violated");
+    // …and the remediation names the declaration that would reclassify it.
+    expect(finding.remediation).toMatch(/oauth-preregistered/);
+  });
+});
+
+describe("PKCE and CIMD metadata", () => {
+  function withAsDocument(document: Record<string, unknown>) {
+    return runClaudeAuthChecks(
+      {
+        ...HEALTHY,
+        firstAuthorizationServer: { ...HEALTHY.firstAuthorizationServer!, document },
+      },
+      STAMP,
+    );
+  }
+
+  it("requires S256 to be advertised", () => {
+    expect(
+      byId(
+        withAsDocument({
+          registration_endpoint: "https://auth.example.com/register",
+          code_challenge_methods_supported: ["plain"],
+          response_types_supported: ["code"],
+        }),
+        "claude.auth.pkce-s256-advertised",
+      ).status,
+    ).toBe("violated");
+  });
+
+  it("does not grade CIMD when the server never advertises it", () => {
+    expect(
+      byId(
+        withAsDocument({
+          registration_endpoint: "https://auth.example.com/register",
+          code_challenge_methods_supported: ["S256"],
+          response_types_supported: ["code"],
+        }),
+        "claude.auth.cimd-flag-consistent",
+      ).status,
+    ).toBe("not-applicable");
+  });
+
+  it("rejects a stringly-typed CIMD flag", () => {
+    expect(
+      byId(
+        withAsDocument({
+          client_id_metadata_document_supported: "true",
+          code_challenge_methods_supported: ["S256"],
+          response_types_supported: ["code"],
+        }),
+        "claude.auth.cimd-flag-consistent",
+      ).status,
+    ).toBe("violated");
+  });
+
+  it("rejects CIMD advertised without the code flow it would use", () => {
+    expect(
+      byId(
+        withAsDocument({
+          client_id_metadata_document_supported: true,
+          code_challenge_methods_supported: ["S256"],
+          response_types_supported: ["token"],
+        }),
+        "claude.auth.cimd-flag-consistent",
+      ).status,
+    ).toBe("violated");
+  });
+});
+
+describe("the JWT audience is evidence, never a verdict", () => {
+  it("records a non-matching audience without failing anything", () => {
+    const finding = byId(
+      runClaudeAuthChecks(
+        { ...HEALTHY, accessTokenAudience: ["https://api.internal/graph"] },
+        STAMP,
+      ),
+      "claude.auth.access-token-audience",
+    );
+    expect(finding.status).toBe("informational");
+    expect(finding.class).toBe("manual-review");
+    expect(finding.lane).toBe("experience-insights");
+    expect(finding.remediation).toMatch(/opaque tokens/);
+  });
+
+  it("is not applicable when there was no JWT to read", () => {
+    expect(
+      byId(runClaudeAuthChecks(HEALTHY, STAMP), "claude.auth.access-token-audience")
+        .status,
+    ).toBe("not-applicable");
+  });
+});

--- a/sdk/tests/claude-readiness/discovery.test.ts
+++ b/sdk/tests/claude-readiness/discovery.test.ts
@@ -110,6 +110,68 @@ describe("the unauthenticated probe", () => {
     });
     expect(evidence.unauthenticated?.servedWithoutCredentials).toBe(true);
   });
+
+  it("reads an SSE answer, which Streamable HTTP lets a server choose", async () => {
+    // The probe advertises `text/event-stream`, so answering with one is
+    // conforming. Parsing it as JSON would fail and record a working authless
+    // connector as one that never answered — a required runtime-blocker
+    // violation manufactured entirely by the probe.
+    const { origin } = await start((_req, res) => {
+      res.writeHead(200, { "content-type": "text/event-stream" });
+      res.write("event: message\n");
+      res.write(
+        `data: ${JSON.stringify({
+          jsonrpc: "2.0",
+          id: 1,
+          result: { protocolVersion: "2025-06-18" },
+        })}\n\n`,
+      );
+      // Deliberately left OPEN: a server may keep the stream up after
+      // answering, and the probe must not wait for it to close.
+    });
+
+    const evidence = await discoverClaudeAuthEvidence({
+      enteredUrl: `${origin}/mcp`,
+      fetchFn: fetch,
+      timeoutMs: 5_000,
+    });
+    expect(evidence.unauthenticated?.servedWithoutCredentials).toBe(true);
+  });
+
+  it("reads an SSE error frame as an answer too", async () => {
+    const { origin } = await start((_req, res) => {
+      res.writeHead(200, { "content-type": "text/event-stream" });
+      res.write(
+        `data: ${JSON.stringify({
+          jsonrpc: "2.0",
+          id: 1,
+          error: { code: -32600, message: "no" },
+        })}\n\n`,
+      );
+    });
+
+    const evidence = await discoverClaudeAuthEvidence({
+      enteredUrl: `${origin}/mcp`,
+      fetchFn: fetch,
+      timeoutMs: 5_000,
+    });
+    expect(evidence.unauthenticated?.servedWithoutCredentials).toBe(true);
+  });
+
+  it("does not call an SSE stream carrying no JSON-RPC message an answer", async () => {
+    const { origin } = await start((_req, res) => {
+      res.writeHead(200, { "content-type": "text/event-stream" });
+      res.write(": keepalive\n\n");
+      res.end();
+    });
+
+    const evidence = await discoverClaudeAuthEvidence({
+      enteredUrl: `${origin}/mcp`,
+      fetchFn: fetch,
+      timeoutMs: 5_000,
+    });
+    expect(evidence.unauthenticated?.servedWithoutCredentials).toBe(false);
+  });
 });
 
 describe("PRM discovery order", () => {

--- a/sdk/tests/claude-readiness/discovery.test.ts
+++ b/sdk/tests/claude-readiness/discovery.test.ts
@@ -36,6 +36,15 @@ async function start(
   return { origin: `http://127.0.0.1:${port}`, hits };
 }
 
+/** An origin nothing listens on: opened to claim a port, then closed. */
+async function closedLoopbackOrigin(): Promise<string> {
+  const server = http.createServer(() => {});
+  await new Promise<void>((resolve) => server.listen(0, "127.0.0.1", resolve));
+  const { port } = server.address() as AddressInfo;
+  await new Promise<void>((resolve) => server.close(() => resolve()));
+  return `http://127.0.0.1:${port}`;
+}
+
 afterEach(async () => {
   await Promise.all(
     servers.splice(0).map(
@@ -260,8 +269,13 @@ describe("the redirect trace", () => {
   });
 
   it("returns the partial chain when a hop is unreachable", async () => {
+    // A port we listened on and then closed refuses immediately. Relying on a
+    // reserved `.invalid` name instead makes the case depend on the resolver:
+    // a wildcard or captive one answers with a routable address, and the test
+    // then waits out a timeout to reach the same assertion.
+    const deadOrigin = await closedLoopbackOrigin();
     const { origin } = await start((_req, res) => {
-      res.writeHead(302, { location: "https://unreachable.invalid/mcp" });
+      res.writeHead(302, { location: `${deadOrigin}/mcp` });
       res.end();
     });
 
@@ -270,6 +284,116 @@ describe("the redirect trace", () => {
       fetchFn: fetch,
     });
     expect(evidence.redirectChain).toHaveLength(1);
+  });
+});
+
+describe("the resource_metadata pointer is not trusted", () => {
+  it("refuses an off-origin pointer and never dials it", async () => {
+    const attacker = await start((_req, res) => {
+      res.writeHead(200, { "content-type": "application/json" });
+      res.end(JSON.stringify({ resource: "x", authorization_servers: [] }));
+    });
+    const { origin } = await start((req, res) => {
+      if (req.url === "/mcp") {
+        res.writeHead(401, {
+          "www-authenticate": `Bearer resource_metadata="${attacker.origin}/prm.json"`,
+        });
+        res.end();
+        return;
+      }
+      res.writeHead(404);
+      res.end();
+    });
+
+    const evidence = await discoverClaudeAuthEvidence({
+      enteredUrl: `${origin}/mcp`,
+      fetchFn: fetch,
+    });
+
+    // The pointer arrives in a header from the server under test; `new URL()`
+    // would happily accept `http://169.254.169.254/…` here.
+    expect(attacker.hits).toEqual([]);
+    expect(evidence.prm?.rejectedPointer).toBe(`${attacker.origin}/prm.json`);
+  });
+
+  it("refuses a non-http scheme", async () => {
+    const { origin } = await start((_req, res) => {
+      res.writeHead(401, {
+        "www-authenticate": `Bearer resource_metadata="file:///etc/passwd"`,
+      });
+      res.end();
+    });
+
+    const evidence = await discoverClaudeAuthEvidence({
+      enteredUrl: `${origin}/mcp`,
+      fetchFn: fetch,
+    });
+    expect(evidence.prm?.rejectedPointer).toBe("file:///etc/passwd");
+  });
+
+  it("still follows a same-origin pointer", async () => {
+    const { origin } = await start((req, res) => {
+      if (req.url === "/custom/prm.json") {
+        json(res, 200, { resource: "x", authorization_servers: [] });
+        return;
+      }
+      res.writeHead(401, {
+        "www-authenticate": `Bearer resource_metadata="/custom/prm.json"`,
+      });
+      res.end();
+    });
+
+    const evidence = await discoverClaudeAuthEvidence({
+      enteredUrl: `${origin}/mcp`,
+      fetchFn: fetch,
+    });
+    expect(evidence.prm?.discoveredVia).toBe("www-authenticate");
+    expect(evidence.prm?.rejectedPointer).toBeUndefined();
+  });
+});
+
+describe("metadata documents are bounded", () => {
+  it("refuses a body that declares a size over the cap, before reading it", async () => {
+    const { origin } = await start((req, res) => {
+      if (req.url?.startsWith("/.well-known/")) {
+        res.writeHead(200, {
+          "content-type": "application/json",
+          "content-length": String(64 * 1024 * 1024),
+        });
+        res.end("{}");
+        return;
+      }
+      res.writeHead(401);
+      res.end();
+    });
+
+    const evidence = await discoverClaudeAuthEvidence({
+      enteredUrl: `${origin}/mcp`,
+      fetchFn: fetch,
+    });
+    expect(evidence.prm?.discoveredVia).toBe("not-found");
+    expect(evidence.prm?.fetchError).toMatch(/over the .* cap/);
+  });
+
+  it("stops reading an oversized body that declared no length", async () => {
+    const { origin } = await start((req, res) => {
+      if (req.url?.startsWith("/.well-known/")) {
+        res.writeHead(200, { "content-type": "application/json" });
+        // Chunked, so there is no content-length to pre-empt on.
+        for (let i = 0; i < 12; i += 1) res.write("x".repeat(64 * 1024));
+        res.end();
+        return;
+      }
+      res.writeHead(401);
+      res.end();
+    });
+
+    const evidence = await discoverClaudeAuthEvidence({
+      enteredUrl: `${origin}/mcp`,
+      fetchFn: fetch,
+    });
+    expect(evidence.prm?.discoveredVia).toBe("not-found");
+    expect(evidence.prm?.fetchError).toMatch(/exceeded/);
   });
 });
 

--- a/sdk/tests/claude-readiness/discovery.test.ts
+++ b/sdk/tests/claude-readiness/discovery.test.ts
@@ -1,0 +1,290 @@
+/**
+ * Discovery, against a real server.
+ *
+ * Two properties are worth a socket rather than a stub:
+ *
+ *   1. the RFC 9728 discovery ORDER — which step answers is itself reported,
+ *      because a server discoverable only at the root well-known path is
+ *      reachable by luck rather than by the documented walk;
+ *   2. the redirect TRACE — the transport follows redirects internally and
+ *      reports only where it landed, so a chain that downgrades mid-way and
+ *      recovers is invisible unless discovery walks it by hand.
+ */
+
+import http from "node:http";
+import type { AddressInfo } from "node:net";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import {
+  discoverClaudeAuthEvidence,
+  traceConnectorRedirects,
+} from "../../src/claude-readiness/discovery.js";
+
+const servers: http.Server[] = [];
+
+async function start(
+  handler: http.RequestListener,
+): Promise<{ origin: string; hits: string[] }> {
+  const hits: string[] = [];
+  const server = http.createServer((req, res) => {
+    hits.push(`${req.method} ${req.url}`);
+    handler(req, res);
+  });
+  servers.push(server);
+  await new Promise<void>((resolve) => server.listen(0, "127.0.0.1", resolve));
+  const { port } = server.address() as AddressInfo;
+  return { origin: `http://127.0.0.1:${port}`, hits };
+}
+
+afterEach(async () => {
+  await Promise.all(
+    servers.splice(0).map(
+      (server) =>
+        new Promise<void>((resolve) => {
+          server.closeAllConnections?.();
+          server.close(() => resolve());
+        }),
+    ),
+  );
+});
+
+function json(res: http.ServerResponse, status: number, body: unknown) {
+  res.writeHead(status, { "content-type": "application/json" });
+  res.end(JSON.stringify(body));
+}
+
+describe("the unauthenticated probe", () => {
+  it("captures the status and the challenge from an initialize", async () => {
+    const { origin, hits } = await start((_req, res) => {
+      res.writeHead(401, {
+        "www-authenticate": `Bearer resource_metadata="/.well-known/oauth-protected-resource/mcp"`,
+      });
+      res.end();
+    });
+
+    const evidence = await discoverClaudeAuthEvidence({
+      enteredUrl: `${origin}/mcp`,
+      fetchFn: fetch,
+    });
+
+    expect(evidence.unauthenticated).toMatchObject({
+      status: 401,
+      servedWithoutCredentials: false,
+      representsProtectedOperation: true,
+    });
+    expect(hits[0]).toBe("POST /mcp");
+  });
+
+  it("only calls a 200 'served without credentials' when MCP actually answered", async () => {
+    // An HTML error page is a 200 too. Treating that as a served MCP request
+    // would classify a broken server as authless.
+    const { origin } = await start((_req, res) => {
+      res.writeHead(200, { "content-type": "text/html" });
+      res.end("<html>gateway</html>");
+    });
+
+    const evidence = await discoverClaudeAuthEvidence({
+      enteredUrl: `${origin}/mcp`,
+      fetchFn: fetch,
+    });
+    expect(evidence.unauthenticated?.servedWithoutCredentials).toBe(false);
+  });
+
+  it("records a genuine MCP result as served without credentials", async () => {
+    const { origin } = await start((_req, res) => {
+      json(res, 200, { jsonrpc: "2.0", id: 1, result: { protocolVersion: "2025-06-18" } });
+    });
+
+    const evidence = await discoverClaudeAuthEvidence({
+      enteredUrl: `${origin}/mcp`,
+      fetchFn: fetch,
+    });
+    expect(evidence.unauthenticated?.servedWithoutCredentials).toBe(true);
+  });
+});
+
+describe("PRM discovery order", () => {
+  it("follows the challenge pointer first and does not guess a well-known path", async () => {
+    const { origin, hits } = await start((req, res) => {
+      if (req.url === "/mcp") {
+        res.writeHead(401, {
+          "www-authenticate": `Bearer resource_metadata="/custom/prm.json"`,
+        });
+        res.end();
+        return;
+      }
+      if (req.url === "/custom/prm.json") {
+        json(res, 200, { resource: `${origin}/mcp`, authorization_servers: [] });
+        return;
+      }
+      res.writeHead(404);
+      res.end();
+    });
+
+    const evidence = await discoverClaudeAuthEvidence({
+      enteredUrl: `${origin}/mcp`,
+      fetchFn: fetch,
+    });
+
+    expect(evidence.prm?.discoveredVia).toBe("www-authenticate");
+    expect(hits).not.toContain("GET /.well-known/oauth-protected-resource/mcp");
+  });
+
+  it("falls back to the path-suffixed well-known form", async () => {
+    const { origin } = await start((req, res) => {
+      if (req.url === "/mcp") {
+        res.writeHead(401);
+        res.end();
+        return;
+      }
+      if (req.url === "/.well-known/oauth-protected-resource/mcp") {
+        json(res, 200, { resource: `${origin}/mcp`, authorization_servers: [] });
+        return;
+      }
+      res.writeHead(404);
+      res.end();
+    });
+
+    const evidence = await discoverClaudeAuthEvidence({
+      enteredUrl: `${origin}/mcp`,
+      fetchFn: fetch,
+    });
+    expect(evidence.prm?.discoveredVia).toBe("well-known-path-suffixed");
+  });
+
+  it("reports the root well-known form as such, so 'reachable by luck' is visible", async () => {
+    const { origin } = await start((req, res) => {
+      if (req.url === "/.well-known/oauth-protected-resource") {
+        json(res, 200, { resource: `${origin}/mcp`, authorization_servers: [] });
+        return;
+      }
+      res.writeHead(401);
+      res.end();
+    });
+
+    const evidence = await discoverClaudeAuthEvidence({
+      enteredUrl: `${origin}/mcp`,
+      fetchFn: fetch,
+    });
+    expect(evidence.prm?.discoveredVia).toBe("well-known-root");
+  });
+
+  it("reports not-found with the last error rather than throwing", async () => {
+    const { origin } = await start((_req, res) => {
+      res.writeHead(404);
+      res.end();
+    });
+
+    const evidence = await discoverClaudeAuthEvidence({
+      enteredUrl: `${origin}/mcp`,
+      fetchFn: fetch,
+    });
+    expect(evidence.prm?.discoveredVia).toBe("not-found");
+    expect(evidence.prm?.fetchError).toContain("404");
+  });
+});
+
+describe("authorization server metadata", () => {
+  it("reads entry zero only, never a later entry", async () => {
+    const auth = await start((req, res) => {
+      if (req.url?.startsWith("/.well-known/")) {
+        json(res, 200, { issuer: "second", code_challenge_methods_supported: ["S256"] });
+        return;
+      }
+      res.writeHead(404);
+      res.end();
+    });
+    const { origin } = await start((req, res) => {
+      if (req.url === "/.well-known/oauth-protected-resource/mcp") {
+        json(res, 200, {
+          resource: "x",
+          authorization_servers: ["https://broken.invalid", auth.origin],
+        });
+        return;
+      }
+      res.writeHead(401);
+      res.end();
+    });
+
+    const evidence = await discoverClaudeAuthEvidence({
+      enteredUrl: `${origin}/mcp`,
+      fetchFn: fetch,
+    });
+
+    expect(evidence.firstAuthorizationServer?.issuer).toBe("https://broken.invalid");
+    expect(evidence.firstAuthorizationServer?.reachable).toBe(false);
+    // The healthy second entry was never dialled — probing it would grade a
+    // client that falls back, which Claude is not.
+    expect(auth.hits).toEqual([]);
+  });
+});
+
+describe("the redirect trace", () => {
+  it("records every hop, including one that downgrades and recovers", async () => {
+    const final = await start((_req, res) => {
+      res.writeHead(200);
+      res.end();
+    });
+    const middle = await start((_req, res) => {
+      res.writeHead(302, { location: `${final.origin}/mcp` });
+      res.end();
+    });
+    const { origin } = await start((_req, res) => {
+      res.writeHead(302, { location: `${middle.origin}/mcp` });
+      res.end();
+    });
+
+    const evidence = await traceConnectorRedirects({
+      enteredUrl: `${origin}/mcp`,
+      fetchFn: fetch,
+    });
+
+    expect(evidence.redirectChain).toHaveLength(3);
+    expect(evidence.redirectChain?.[0].location).toBe(`${middle.origin}/mcp`);
+    expect(evidence.redirectLimitHit).toBeUndefined();
+  });
+
+  it("stops at the ceiling and says so", async () => {
+    const { origin } = await start((_req, res) => {
+      res.writeHead(302, { location: "/again" });
+      res.end();
+    });
+
+    const evidence = await traceConnectorRedirects({
+      enteredUrl: `${origin}/mcp`,
+      fetchFn: fetch,
+      maxRedirects: 2,
+    });
+    expect(evidence.redirectLimitHit).toBe(true);
+    expect(evidence.redirectChain).toHaveLength(3);
+  });
+
+  it("returns the partial chain when a hop is unreachable", async () => {
+    const { origin } = await start((_req, res) => {
+      res.writeHead(302, { location: "https://unreachable.invalid/mcp" });
+      res.end();
+    });
+
+    const evidence = await traceConnectorRedirects({
+      enteredUrl: `${origin}/mcp`,
+      fetchFn: fetch,
+    });
+    expect(evidence.redirectChain).toHaveLength(1);
+  });
+});
+
+describe("the transport is the caller's", () => {
+  it("never reaches the global fetch on its own", async () => {
+    // A default `fetchFn` would make "forgot to pass the guard" the silent
+    // case, and the silent case is the one that reaches 169.254.169.254.
+    const spy = vi.fn<typeof fetch>(async () => new Response("{}", { status: 404 }));
+    await discoverClaudeAuthEvidence({
+      enteredUrl: "https://mcp.example.com/mcp",
+      fetchFn: spy,
+    });
+    expect(spy).toHaveBeenCalled();
+    for (const [input] of spy.mock.calls) {
+      expect(String(input)).toContain("mcp.example.com");
+    }
+  });
+});

--- a/sdk/tests/claude-readiness/endpoint-checks.test.ts
+++ b/sdk/tests/claude-readiness/endpoint-checks.test.ts
@@ -1,0 +1,162 @@
+/**
+ * Endpoint checks. Small surface, one subtle rule.
+ *
+ * The subtle one: a redirect chain that DOWNGRADES in the middle and ends on
+ * https still fails. Nothing leaks on that hop, but anyone on the path can
+ * rewrite its `Location`, and what they get to choose is where the connector
+ * ends up — which decides the auth server a user is later sent to.
+ */
+
+import { describe, expect, it } from "vitest";
+
+import { runClaudeEndpointChecks } from "../../src/claude-readiness/checks/endpoint.js";
+
+const STAMP = { evaluatedAt: "2026-08-19T00:00:00.000Z" };
+
+function byId(
+  findings: ReturnType<typeof runClaudeEndpointChecks>,
+  id: string,
+) {
+  return findings.find((finding) => finding.id === id)!;
+}
+
+describe("the connector scheme", () => {
+  it("passes an https URL", () => {
+    expect(
+      byId(
+        runClaudeEndpointChecks(
+          { enteredUrl: "https://mcp.example.com/mcp", redirectChain: [] },
+          STAMP,
+        ),
+        "claude.endpoint.https",
+      ).status,
+    ).toBe("satisfied");
+  });
+
+  it("fails plaintext as a runtime blocker, not a policy item", () => {
+    const finding = byId(
+      runClaudeEndpointChecks({ enteredUrl: "http://mcp.example.com/mcp" }, STAMP),
+      "claude.endpoint.https",
+    );
+    expect(finding.status).toBe("violated");
+    // The distinction matters: Claude never connects, so nothing downstream
+    // could have been graded either.
+    expect(finding.class).toBe("runtime-blocker");
+    expect(finding.lane).toBe("runtime-compatibility");
+  });
+
+  it("fails an unparseable URL rather than throwing", () => {
+    expect(
+      byId(
+        runClaudeEndpointChecks({ enteredUrl: "not a url" }, STAMP),
+        "claude.endpoint.https",
+      ).status,
+    ).toBe("violated");
+  });
+});
+
+describe("the redirect chain", () => {
+  it("is not-evaluated when the run never reached the endpoint", () => {
+    const findings = runClaudeEndpointChecks(
+      { enteredUrl: "https://mcp.example.com/mcp" },
+      STAMP,
+    );
+    expect(byId(findings, "claude.endpoint.redirects-stay-https").status).toBe(
+      "not-evaluated",
+    );
+    expect(byId(findings, "claude.endpoint.redirects-terminate").status).toBe(
+      "not-evaluated",
+    );
+  });
+
+  it("passes a chain that stays on https", () => {
+    expect(
+      byId(
+        runClaudeEndpointChecks(
+          {
+            enteredUrl: "https://mcp.example.com/mcp",
+            redirectChain: [
+              {
+                url: "https://mcp.example.com/mcp",
+                status: 308,
+                location: "https://api.example.com/mcp",
+              },
+              { url: "https://api.example.com/mcp", status: 200 },
+            ],
+          },
+          STAMP,
+        ),
+        "claude.endpoint.redirects-stay-https",
+      ).status,
+    ).toBe("satisfied");
+  });
+
+  it("fails a mid-chain downgrade even when the chain ends on https", () => {
+    const finding = byId(
+      runClaudeEndpointChecks(
+        {
+          enteredUrl: "https://mcp.example.com/mcp",
+          redirectChain: [
+            {
+              url: "https://mcp.example.com/mcp",
+              status: 302,
+              location: "http://redirect.example.com/mcp",
+            },
+            {
+              url: "http://redirect.example.com/mcp",
+              status: 302,
+              location: "https://api.example.com/mcp",
+            },
+            { url: "https://api.example.com/mcp", status: 200 },
+          ],
+        },
+        STAMP,
+      ),
+      "claude.endpoint.redirects-stay-https",
+    );
+    expect(finding.status).toBe("violated");
+    expect(finding.details).toMatchObject({
+      hops: [{ to: "http://redirect.example.com/mcp" }],
+    });
+  });
+
+  it("resolves a relative Location against the hop it came from", () => {
+    expect(
+      byId(
+        runClaudeEndpointChecks(
+          {
+            enteredUrl: "https://mcp.example.com/mcp",
+            redirectChain: [
+              {
+                url: "https://mcp.example.com/mcp",
+                status: 308,
+                location: "/v2/mcp",
+              },
+              { url: "https://mcp.example.com/v2/mcp", status: 200 },
+            ],
+          },
+          STAMP,
+        ),
+        "claude.endpoint.redirects-stay-https",
+      ).status,
+    ).toBe("satisfied");
+  });
+
+  it("fails a chain that ran past the client's limit", () => {
+    expect(
+      byId(
+        runClaudeEndpointChecks(
+          {
+            enteredUrl: "https://mcp.example.com/mcp",
+            redirectChain: [
+              { url: "https://mcp.example.com/mcp", status: 302, location: "/a" },
+            ],
+            redirectLimitHit: true,
+          },
+          STAMP,
+        ),
+        "claude.endpoint.redirects-terminate",
+      ).status,
+    ).toBe("violated");
+  });
+});

--- a/sdk/tests/claude-readiness/intrusive.test.ts
+++ b/sdk/tests/claude-readiness/intrusive.test.ts
@@ -355,11 +355,45 @@ describe("refresh rotation and replay", () => {
   it("fails a server that never rotates", async () => {
     const finding = gradeClaudeIntrusiveObservations(
       withRefresh(),
-      { refresh: { attempted: true, rotated: false } },
+      { refresh: { attempted: true, rotated: false, refreshStatus: 200 } },
       STAMP,
     ).find((f) => f.id === "claude.intrusive.refresh-rotation")!;
     expect(finding.status).toBe("violated");
     expect(finding.remediation).toMatch(/rotation/);
+  });
+
+  it("does not blame the server when the probe's own request was rejected", async () => {
+    // A confidential client probed without its secret gets `401
+    // invalid_client` and no new token — identical on the wire to a server
+    // that does not rotate. Grading that as a rotation defect reports a
+    // required violation the submitter cannot act on, because it is ours.
+    const finding = gradeClaudeIntrusiveObservations(
+      withRefresh(),
+      {
+        refresh: {
+          attempted: true,
+          rotated: false,
+          refreshStatus: 401,
+          refreshError: "invalid_client",
+        },
+      },
+      STAMP,
+    ).find((f) => f.id === "claude.intrusive.refresh-rotation")!;
+    expect(finding.status).toBe("not-evaluated");
+    expect(finding.notEvaluatedReason).toMatch(/401/);
+    expect(finding.notEvaluatedReason).toMatch(/invalid_client/);
+  });
+
+  it("still grades evidence captured before the status was recorded", async () => {
+    // An observation with no `refreshStatus` predates the field; treating
+    // "not known to have failed" as a failure would silently reclassify old
+    // evidence.
+    const finding = gradeClaudeIntrusiveObservations(
+      withRefresh(),
+      { refresh: { attempted: true, rotated: false } },
+      STAMP,
+    ).find((f) => f.id === "claude.intrusive.refresh-rotation")!;
+    expect(finding.status).toBe("violated");
   });
 
   it("replays the OLD token, which is what proves it was invalidated", async () => {

--- a/sdk/tests/claude-readiness/intrusive.test.ts
+++ b/sdk/tests/claude-readiness/intrusive.test.ts
@@ -138,6 +138,59 @@ describe("a disabled mode grades everything as unevaluated", () => {
   });
 });
 
+describe("the gate is enforced at RUNTIME, not only in the type system", () => {
+  // The brand is compile-time only, so it evaporates at the first `as` cast or
+  // the first JavaScript caller. Without a runtime comparison, a hand-built
+  // object would register an OAuth client at a stranger's server.
+  const forged = {
+    enabled: true,
+    grantOrigin: "dedicated-test-account",
+    credentials: { clientId: "c", refreshToken: "rt" },
+    cleanup: true,
+    authorization: {},
+  } as unknown as Extract<ClaudeIntrusiveMode, { enabled: true }>;
+
+  it("refuses a forged mode before registering anything", async () => {
+    const fetchFn = vi.fn<typeof fetch>();
+    await expect(
+      probeDynamicRegistration(forged, {
+        fetchFn,
+        registrationEndpoint: "https://auth.example.com/register",
+        redirectUris: [],
+      }),
+    ).rejects.toThrow(/resolveClaudeIntrusiveMode/);
+    expect(fetchFn).not.toHaveBeenCalled();
+  });
+
+  it("refuses a forged mode before spending a refresh token", async () => {
+    const fetchFn = vi.fn<typeof fetch>();
+    await expect(
+      probeRefreshRotation(forged, {
+        fetchFn,
+        tokenEndpoint: "https://auth.example.com/token",
+        redirectUris: [],
+      }),
+    ).rejects.toThrow(/resolveClaudeIntrusiveMode/);
+    expect(fetchFn).not.toHaveBeenCalled();
+  });
+
+  it("refuses a disabled mode cast into the armed shape", async () => {
+    const disabled = resolveClaudeIntrusiveMode(undefined, NO_BORROWED);
+    const fetchFn = vi.fn<typeof fetch>();
+    await expect(
+      probeDynamicRegistration(
+        disabled as Extract<ClaudeIntrusiveMode, { enabled: true }>,
+        {
+          fetchFn,
+          registrationEndpoint: "https://auth.example.com/register",
+          redirectUris: [],
+        },
+      ),
+    ).rejects.toThrow(/resolveClaudeIntrusiveMode/);
+    expect(fetchFn).not.toHaveBeenCalled();
+  });
+});
+
 describe("registration cleanup", () => {
   it("deletes the client through the management URI", async () => {
     const calls: Array<{ url: string; method?: string }> = [];

--- a/sdk/tests/claude-readiness/intrusive.test.ts
+++ b/sdk/tests/claude-readiness/intrusive.test.ts
@@ -1,0 +1,394 @@
+/**
+ * The intrusive gate.
+ *
+ * These probes register a client at someone's authorization server, spend a
+ * refresh token and deliberately burn it, and drive a real tool call. Run by
+ * accident — on a schedule, across a directory feed, against a production
+ * tenant — they are indistinguishable from an attack. So the gate is the
+ * product, and every one of these tests is about a way in that must be closed.
+ *
+ * The defence is structural rather than conventional: the probes require an
+ * armed mode, and an armed mode can only be produced by
+ * `resolveClaudeIntrusiveMode`. A call site cannot opt in by passing a flag it
+ * invented, and a future surface that forgets to check gets a refusal instead
+ * of a silent registration.
+ */
+
+import { describe, expect, it, vi } from "vitest";
+
+import {
+  gradeClaudeIntrusiveObservations,
+  probeDynamicRegistration,
+  probeRefreshRotation,
+  resolveClaudeIntrusiveMode,
+  type ClaudeIntrusiveMode,
+} from "../../src/claude-readiness/intrusive.js";
+
+const STAMP = { evaluatedAt: "2026-08-19T00:00:00.000Z" };
+const NO_BORROWED = { hasBorrowedAccessToken: false };
+
+function armed(
+  overrides: Parameters<typeof resolveClaudeIntrusiveMode>[0] = {
+    enabled: true,
+    grantOrigin: "dedicated-test-account",
+    testCredentials: { clientId: "test-client" },
+  },
+): Extract<ClaudeIntrusiveMode, { enabled: true }> {
+  const mode = resolveClaudeIntrusiveMode(overrides, NO_BORROWED);
+  if (!mode.enabled) throw new Error(`expected an armed mode: ${mode.reason}`);
+  return mode;
+}
+
+describe("the gate is closed by default", () => {
+  it("refuses when no config is supplied at all", () => {
+    const mode = resolveClaudeIntrusiveMode(undefined, NO_BORROWED);
+    expect(mode.enabled).toBe(false);
+  });
+
+  it("refuses a truthy non-boolean `enabled`", () => {
+    // `enabled: "false"` out of a YAML file or a query string must not arm
+    // client registration against a stranger's server.
+    for (const value of ["true", "false", 1, {}] as unknown[]) {
+      const mode = resolveClaudeIntrusiveMode(
+        { enabled: value as boolean, grantOrigin: "self-acquired" },
+        NO_BORROWED,
+      );
+      expect(mode.enabled).toBe(false);
+      if (!mode.enabled) expect(mode.reason).toMatch(/as a boolean/);
+    }
+  });
+
+  it("refuses without an explicit grant origin", () => {
+    const mode = resolveClaudeIntrusiveMode({ enabled: true }, NO_BORROWED);
+    expect(mode.enabled).toBe(false);
+    if (!mode.enabled) expect(mode.reason).toMatch(/grantOrigin/);
+  });
+
+  it("refuses a dedicated-account origin with no client id", () => {
+    const mode = resolveClaudeIntrusiveMode(
+      { enabled: true, grantOrigin: "dedicated-test-account" },
+      NO_BORROWED,
+    );
+    expect(mode.enabled).toBe(false);
+  });
+});
+
+describe("borrowed credentials are refused outright", () => {
+  it("will not treat a token supplied for ordinary operation as self-acquired", () => {
+    // Burning a refresh token that belongs to a live user session logs them out
+    // of a product they were using. No readiness grade is worth that.
+    const mode = resolveClaudeIntrusiveMode(
+      { enabled: true, grantOrigin: "self-acquired" },
+      { hasBorrowedAccessToken: true },
+    );
+    expect(mode.enabled).toBe(false);
+    if (!mode.enabled) expect(mode.reason).toMatch(/borrowed grant/);
+  });
+
+  it("still allows a dedicated test account alongside a borrowed token", () => {
+    // The caller owns those credentials; the borrowed one is simply not used.
+    const mode = resolveClaudeIntrusiveMode(
+      {
+        enabled: true,
+        grantOrigin: "dedicated-test-account",
+        testCredentials: { clientId: "test-client" },
+      },
+      { hasBorrowedAccessToken: true },
+    );
+    expect(mode.enabled).toBe(true);
+  });
+});
+
+describe("the step-up probe needs a declared target", () => {
+  it("refuses a tool name with no expected scopes", () => {
+    const mode = resolveClaudeIntrusiveMode(
+      {
+        enabled: true,
+        grantOrigin: "dedicated-test-account",
+        testCredentials: { clientId: "c" },
+        protectedToolName: "delete_everything",
+      },
+      NO_BORROWED,
+    );
+    expect(mode.enabled).toBe(false);
+    if (!mode.enabled) expect(mode.reason).toMatch(/expectedScopes/);
+  });
+
+  it("never calls a tool that was not declared", () => {
+    const findings = gradeClaudeIntrusiveObservations(armed(), {}, STAMP);
+    const stepUp = findings.find(
+      (f) => f.id === "claude.intrusive.step-up-challenge",
+    )!;
+    expect(stepUp.status).toBe("not-evaluated");
+    expect(stepUp.notEvaluatedReason).toMatch(/arbitrary tool/);
+  });
+});
+
+describe("a disabled mode grades everything as unevaluated", () => {
+  it("reports the refusal reason on every intrusive finding", () => {
+    const mode = resolveClaudeIntrusiveMode(undefined, NO_BORROWED);
+    const findings = gradeClaudeIntrusiveObservations(mode, {}, STAMP);
+    expect(findings).toHaveLength(3);
+    for (const finding of findings) {
+      expect(finding.status).toBe("not-evaluated");
+      expect(finding.notEvaluatedReason).toMatch(/not requested/);
+      expect(finding.intrusiveness).toBe("side-effecting");
+      expect(finding.requiresCapabilities).toContain("intrusive-probes");
+    }
+  });
+});
+
+describe("registration cleanup", () => {
+  it("deletes the client through the management URI", async () => {
+    const calls: Array<{ url: string; method?: string }> = [];
+    const fetchFn = vi.fn<typeof fetch>(async (input, init) => {
+      calls.push({ url: String(input), method: init?.method });
+      if (init?.method === "DELETE") return new Response(null, { status: 204 });
+      return new Response(
+        JSON.stringify({
+          client_id: "generated",
+          registration_client_uri: "https://auth.example.com/register/generated",
+          registration_access_token: "rat",
+        }),
+        { status: 201, headers: { "content-type": "application/json" } },
+      );
+    });
+
+    const observation = await probeDynamicRegistration(armed(), {
+      fetchFn,
+      registrationEndpoint: "https://auth.example.com/register",
+      redirectUris: ["https://claude.ai/api/mcp/auth_callback"],
+    });
+
+    expect(observation.cleanedUp).toBe(true);
+    expect(calls[1]).toMatchObject({
+      url: "https://auth.example.com/register/generated",
+      method: "DELETE",
+    });
+  });
+
+  it("reports a client it could not remove rather than hiding it", async () => {
+    // A registration we cannot delete is a client left behind on someone
+    // else's server. Silence there would make this tool a slow leak.
+    const fetchFn = vi.fn<typeof fetch>(
+      async () =>
+        new Response(JSON.stringify({ client_id: "generated" }), {
+          status: 201,
+          headers: { "content-type": "application/json" },
+        }),
+    );
+
+    const observation = await probeDynamicRegistration(armed(), {
+      fetchFn,
+      registrationEndpoint: "https://auth.example.com/register",
+      redirectUris: ["https://claude.ai/api/mcp/auth_callback"],
+    });
+
+    expect(observation.cleanedUp).toBe(false);
+    expect(observation.cleanupError).toMatch(/registration_client_uri/);
+
+    const finding = gradeClaudeIntrusiveObservations(
+      armed(),
+      { registration: observation },
+      STAMP,
+    ).find((f) => f.id === "claude.intrusive.dynamic-registration")!;
+    expect(finding.status).toBe("violated");
+    expect(finding.remediation).toMatch(/Delete it manually/);
+  });
+
+  it("skips cleanup only when the caller turned it off", async () => {
+    const fetchFn = vi.fn<typeof fetch>(
+      async () =>
+        new Response(
+          JSON.stringify({
+            client_id: "generated",
+            registration_client_uri: "https://auth.example.com/register/generated",
+          }),
+          { status: 201, headers: { "content-type": "application/json" } },
+        ),
+    );
+
+    await probeDynamicRegistration(
+      armed({
+        enabled: true,
+        grantOrigin: "dedicated-test-account",
+        testCredentials: { clientId: "c" },
+        cleanup: false,
+      }),
+      {
+        fetchFn,
+        registrationEndpoint: "https://auth.example.com/register",
+        redirectUris: ["https://claude.ai/api/mcp/auth_callback"],
+      },
+    );
+    expect(fetchFn).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not attempt registration when there is no endpoint", async () => {
+    const fetchFn = vi.fn<typeof fetch>();
+    const observation = await probeDynamicRegistration(armed(), {
+      fetchFn,
+      redirectUris: [],
+    });
+    expect(observation.attempted).toBe(false);
+    expect(fetchFn).not.toHaveBeenCalled();
+  });
+});
+
+describe("refresh rotation and replay", () => {
+  const withRefresh = () =>
+    armed({
+      enabled: true,
+      grantOrigin: "dedicated-test-account",
+      testCredentials: { clientId: "c", refreshToken: "old-token" },
+    });
+
+  it("never runs without a refresh token the run owns", async () => {
+    const fetchFn = vi.fn<typeof fetch>();
+    const observation = await probeRefreshRotation(armed(), {
+      fetchFn,
+      tokenEndpoint: "https://auth.example.com/token",
+      redirectUris: [],
+    });
+    expect(observation.attempted).toBe(false);
+    expect(fetchFn).not.toHaveBeenCalled();
+  });
+
+  it("accepts extra fields alongside error=invalid_grant", async () => {
+    // A server that returns `error_description` and `error_uri` beside the
+    // code is being informative, not non-conforming.
+    const findings = gradeClaudeIntrusiveObservations(
+      withRefresh(),
+      {
+        refresh: {
+          attempted: true,
+          rotated: true,
+          replayStatus: 400,
+          replayError: "invalid_grant",
+          replayBody: {
+            error: "invalid_grant",
+            error_description: "token already used",
+            error_uri: "https://auth.example.com/errors/invalid_grant",
+          },
+        },
+      },
+      STAMP,
+    );
+    const finding = findings.find(
+      (f) => f.id === "claude.intrusive.refresh-rotation",
+    )!;
+    expect(finding.status).toBe("satisfied");
+    expect(finding.details).toMatchObject({
+      extraFields: ["error_description", "error_uri"],
+    });
+  });
+
+  it("requires HTTP 400, not merely an error body", async () => {
+    const finding = gradeClaudeIntrusiveObservations(
+      withRefresh(),
+      {
+        refresh: {
+          attempted: true,
+          rotated: true,
+          replayStatus: 200,
+          replayError: "invalid_grant",
+        },
+      },
+      STAMP,
+    ).find((f) => f.id === "claude.intrusive.refresh-rotation")!;
+    expect(finding.status).toBe("violated");
+  });
+
+  it("fails a server that never rotates", async () => {
+    const finding = gradeClaudeIntrusiveObservations(
+      withRefresh(),
+      { refresh: { attempted: true, rotated: false } },
+      STAMP,
+    ).find((f) => f.id === "claude.intrusive.refresh-rotation")!;
+    expect(finding.status).toBe("violated");
+    expect(finding.remediation).toMatch(/rotation/);
+  });
+
+  it("replays the OLD token, which is what proves it was invalidated", async () => {
+    const bodies: string[] = [];
+    const fetchFn = vi.fn<typeof fetch>(async (_input, init) => {
+      bodies.push(String(init?.body));
+      if (bodies.length === 1) {
+        return new Response(
+          JSON.stringify({ access_token: "a", refresh_token: "new-token" }),
+          { status: 200, headers: { "content-type": "application/json" } },
+        );
+      }
+      return new Response(JSON.stringify({ error: "invalid_grant" }), {
+        status: 400,
+        headers: { "content-type": "application/json" },
+      });
+    });
+
+    const observation = await probeRefreshRotation(withRefresh(), {
+      fetchFn,
+      tokenEndpoint: "https://auth.example.com/token",
+      redirectUris: [],
+    });
+
+    expect(observation.rotated).toBe(true);
+    expect(observation.replayStatus).toBe(400);
+    expect(bodies[0]).toContain("refresh_token=old-token");
+    expect(bodies[1]).toContain("refresh_token=old-token");
+  });
+
+  it("does not replay when the server did not rotate", async () => {
+    const fetchFn = vi.fn<typeof fetch>(
+      async () =>
+        new Response(
+          JSON.stringify({ access_token: "a", refresh_token: "old-token" }),
+          { status: 200, headers: { "content-type": "application/json" } },
+        ),
+    );
+    await probeRefreshRotation(withRefresh(), {
+      fetchFn,
+      tokenEndpoint: "https://auth.example.com/token",
+      redirectUris: [],
+    });
+    // Replaying a token the server still considers live would burn a working
+    // grant to learn nothing.
+    expect(fetchFn).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe("step-up grading", () => {
+  const withTool = () =>
+    armed({
+      enabled: true,
+      grantOrigin: "dedicated-test-account",
+      testCredentials: { clientId: "c" },
+      protectedToolName: "read_private",
+      expectedScopes: ["private:read"],
+    });
+
+  it("passes a 403 insufficient_scope challenge", () => {
+    const finding = gradeClaudeIntrusiveObservations(
+      withTool(),
+      {
+        stepUp: {
+          attempted: true,
+          toolName: "read_private",
+          status: 403,
+          wwwAuthenticate: 'Bearer error="insufficient_scope"',
+        },
+      },
+      STAMP,
+    ).find((f) => f.id === "claude.intrusive.step-up-challenge")!;
+    expect(finding.status).toBe("satisfied");
+  });
+
+  it("fails a bare 403 with no challenge", () => {
+    const finding = gradeClaudeIntrusiveObservations(
+      withTool(),
+      { stepUp: { attempted: true, toolName: "read_private", status: 403 } },
+      STAMP,
+    ).find((f) => f.id === "claude.intrusive.step-up-challenge")!;
+    expect(finding.status).toBe("violated");
+    expect(finding.remediation).toMatch(/insufficient_scope/);
+  });
+});

--- a/sdk/tests/claude-readiness/intrusive.test.ts
+++ b/sdk/tests/claude-readiness/intrusive.test.ts
@@ -469,6 +469,53 @@ describe("step-up grading", () => {
     expect(finding.status).toBe("satisfied");
   });
 
+  it("records the challenged scopes against the ones the run expected", () => {
+    // `expectedScopes` is required alongside `protectedToolName` so the run
+    // states what it asserts — but nothing compared it, so the requirement
+    // produced a config error and no evidence.
+    const finding = gradeClaudeIntrusiveObservations(
+      withTool(),
+      {
+        stepUp: {
+          attempted: true,
+          toolName: "read_private",
+          status: 403,
+          wwwAuthenticate:
+            'Bearer error="insufficient_scope", scope="private:read other:write"',
+        },
+      },
+      STAMP,
+    ).find((f) => f.id === "claude.intrusive.step-up-challenge")!;
+    expect(finding.details).toMatchObject({
+      expectedScopes: ["private:read"],
+      challengedScopes: ["private:read", "other:write"],
+      scopesOverlapExpectation: true,
+    });
+  });
+
+  it("does not call an omitted scope a mismatch", () => {
+    // `scope` is OPTIONAL on an insufficient_scope challenge; Claude selects
+    // from discovery when it is absent. Reporting `false` would read as the
+    // server contradicting the run, which it never did.
+    const finding = gradeClaudeIntrusiveObservations(
+      withTool(),
+      {
+        stepUp: {
+          attempted: true,
+          toolName: "read_private",
+          status: 403,
+          wwwAuthenticate: 'Bearer error="insufficient_scope"',
+        },
+      },
+      STAMP,
+    ).find((f) => f.id === "claude.intrusive.step-up-challenge")!;
+    expect(finding.status).toBe("satisfied");
+    expect(finding.details).toMatchObject({ challengedScopes: [] });
+    expect(
+      (finding.details as Record<string, unknown>).scopesOverlapExpectation,
+    ).toBeUndefined();
+  });
+
   it("fails a bare 403 with no challenge", () => {
     const finding = gradeClaudeIntrusiveObservations(
       withTool(),

--- a/sdk/tests/claude-readiness/model.test.ts
+++ b/sdk/tests/claude-readiness/model.test.ts
@@ -1,0 +1,246 @@
+/**
+ * The readiness result model's load-bearing rules.
+ *
+ * Each of these encodes a decision that is easy to regress into something that
+ * reads fine and is wrong: a heuristic quietly failing a lane, an unevaluated
+ * requirement rolling up as a pass, a readiness grade acquiring a conformance
+ * score and leaking into the pooled number.
+ */
+
+import { readFileSync } from "node:fs";
+
+import { describe, expect, it } from "vitest";
+
+import {
+  CLAUDE_POLICY_MANIFEST,
+  CLAUDE_POLICY_PAGES,
+  CLAUDE_POLICY_SNAPSHOT_DATE,
+  CLAUDE_READINESS_ENGINE_VERSION,
+  claudePolicySource,
+  decideLaneStatus,
+  isPolicyCorpusVerified,
+  rollUpLaneStatus,
+  summarizeLaneCoverage,
+  type ClaudeFindingClass,
+  type ClaudeFindingStatus,
+  type ClaudeReadinessFinding,
+  type ClaudeReadinessLane,
+  type ClaudeReadinessLaneResult,
+  type ClaudeLaneStatus,
+} from "../../src/claude-readiness/index.js";
+
+function finding(
+  overrides: Partial<ClaudeReadinessFinding> & {
+    class: ClaudeFindingClass;
+    status: ClaudeFindingStatus;
+  },
+): ClaudeReadinessFinding {
+  return {
+    id: overrides.id ?? "check-id",
+    title: overrides.title ?? "A check",
+    lane: overrides.lane ?? "directory-policy",
+    provenance: overrides.provenance ?? "wire",
+    intrusiveness: overrides.intrusiveness ?? "read-only",
+    source: overrides.source ?? claudePolicySource("directory", "§Overview"),
+    evaluatedAt: overrides.evaluatedAt ?? "2026-08-19T00:00:00.000Z",
+    engineVersion: overrides.engineVersion ?? CLAUDE_READINESS_ENGINE_VERSION,
+    ...overrides,
+  };
+}
+
+function lane(
+  name: ClaudeReadinessLane,
+  status: ClaudeLaneStatus,
+): ClaudeReadinessLaneResult {
+  return {
+    lane: name,
+    status,
+    summary: "",
+    coverage: summarizeLaneCoverage(name, []),
+  };
+}
+
+describe("decideLaneStatus", () => {
+  it("lets only required and runtime-blocker findings fail a lane", () => {
+    for (const cls of ["recommended", "heuristic", "manual-review", "experimental-feature"] as const) {
+      expect(
+        decideLaneStatus([
+          finding({ class: "required", status: "satisfied" }),
+          finding({ class: cls, status: "violated" }),
+        ]),
+      ).toBe("ready");
+    }
+  });
+
+  it("is not-ready on a violated requirement", () => {
+    expect(
+      decideLaneStatus([finding({ class: "required", status: "violated" })]),
+    ).toBe("not-ready");
+  });
+
+  it("treats a runtime blocker as dispositive too", () => {
+    expect(
+      decideLaneStatus([
+        finding({ class: "runtime-blocker", status: "violated" }),
+      ]),
+    ).toBe("not-ready");
+  });
+
+  it("is incomplete when an applicable requirement was never evaluated", () => {
+    expect(
+      decideLaneStatus([
+        finding({ class: "required", status: "satisfied" }),
+        finding({ class: "required", status: "not-evaluated" }),
+      ]),
+    ).toBe("incomplete");
+  });
+
+  it("lets a violation dominate an unrelated coverage gap", () => {
+    // Softening this to `incomplete` would let a gap launder a real failure.
+    expect(
+      decideLaneStatus([
+        finding({ class: "required", status: "violated" }),
+        finding({ class: "required", status: "not-evaluated" }),
+      ]),
+    ).toBe("not-ready");
+  });
+
+  it("does not call a lane with nothing dispositive a pass", () => {
+    expect(decideLaneStatus([])).toBe("incomplete");
+    expect(
+      decideLaneStatus([finding({ class: "heuristic", status: "satisfied" })]),
+    ).toBe("incomplete");
+  });
+
+  it("ignores not-applicable findings entirely", () => {
+    expect(
+      decideLaneStatus([
+        finding({ class: "required", status: "satisfied" }),
+        finding({ class: "required", status: "not-applicable" }),
+      ]),
+    ).toBe("ready");
+  });
+});
+
+describe("rollUpLaneStatus", () => {
+  it("cannot be moved by the optional lanes", () => {
+    expect(
+      rollUpLaneStatus([
+        lane("runtime-compatibility", "ready"),
+        lane("directory-policy", "ready"),
+        lane("optional-features", "not-ready"),
+        lane("experience-insights", "not-ready"),
+        lane("submission-artifacts", "incomplete"),
+      ]),
+    ).toBe("ready");
+  });
+
+  it("lets not-ready dominate incomplete", () => {
+    expect(
+      rollUpLaneStatus([
+        lane("runtime-compatibility", "not-ready"),
+        lane("directory-policy", "incomplete"),
+      ]),
+    ).toBe("not-ready");
+  });
+
+  it("is incomplete when no required lane ran at all", () => {
+    expect(rollUpLaneStatus([lane("experience-insights", "ready")])).toBe(
+      "incomplete",
+    );
+  });
+});
+
+describe("coverage is reported separately from findings", () => {
+  it("counts evaluated, unevaluated and inapplicable apart", () => {
+    const coverage = summarizeLaneCoverage(
+      "directory-policy",
+      [
+        finding({ class: "required", status: "satisfied" }),
+        finding({ class: "required", status: "violated" }),
+        finding({ class: "required", status: "not-evaluated" }),
+        finding({ class: "required", status: "not-applicable" }),
+      ],
+      ["submissionProfile", "submissionProfile"],
+    );
+
+    expect(coverage).toEqual({
+      lane: "directory-policy",
+      evaluated: 2,
+      notEvaluated: 1,
+      notApplicable: 1,
+      missingInputs: ["submissionProfile"],
+    });
+  });
+
+  it("makes a lane that looked at nothing distinguishable from one that passed", () => {
+    const empty = summarizeLaneCoverage("directory-policy", []);
+    expect(empty.evaluated).toBe(0);
+    expect(decideLaneStatus([])).toBe("incomplete");
+  });
+});
+
+describe("the policy manifest", () => {
+  it("is total over the pages the check inventory was written against", () => {
+    for (const page of CLAUDE_POLICY_PAGES) {
+      expect(CLAUDE_POLICY_MANIFEST[page]).toBeDefined();
+      expect(CLAUDE_POLICY_MANIFEST[page].snapshotDate).toBe(
+        CLAUDE_POLICY_SNAPSHOT_DATE,
+      );
+    }
+  });
+
+  it("includes the design-guidelines page the first inventory omitted", () => {
+    expect(CLAUDE_POLICY_PAGES).toContain("mcp-apps/design-guidelines");
+  });
+
+  it("reports an unpopulated corpus as unverified rather than pretending", () => {
+    // A fabricated hash would make an unaudited corpus look audited. Until the
+    // sync script runs, surfaces must be able to say so.
+    expect(isPolicyCorpusVerified()).toBe(false);
+  });
+
+  it("builds every citation from the manifest, never by hand", () => {
+    const ref = claudePolicySource("authentication", "§Lazy authentication");
+    expect(ref).toEqual({
+      page: "authentication",
+      section: "§Lazy authentication",
+      url: CLAUDE_POLICY_MANIFEST.authentication.url,
+      revision: CLAUDE_POLICY_MANIFEST.authentication.revision,
+      snapshotDate: CLAUDE_POLICY_SNAPSHOT_DATE,
+    });
+  });
+});
+
+describe("the manifest stays machine-editable", () => {
+  // `scripts/sync-claude-policy-manifest.mjs` parses this file with regexes and
+  // rewrites a fenced block in it. Those are the two ways the drift-detection
+  // story silently stops working, and neither shows up as a type error.
+  const source = readFileSync(
+    new URL("../../src/claude-readiness/manifest.ts", import.meta.url),
+    "utf8",
+  );
+
+  it("exposes the base URL in the literal form the sync script reads", () => {
+    expect(source).toMatch(/CLAUDE_DOCS_BASE_URL = "https?:\/\/[^"]+"/);
+  });
+
+  it("keeps the page list as a flat `as const` array of string literals", () => {
+    const block = source.match(
+      /CLAUDE_POLICY_PAGES = \[([\s\S]*?)\] as const;/,
+    );
+    expect(block).not.toBeNull();
+    expect([...block![1].matchAll(/"([^"]+)"/g)].map((m) => m[1])).toEqual([
+      ...CLAUDE_POLICY_PAGES,
+    ]);
+  });
+
+  it("keeps the generated fence the script rewrites between", () => {
+    const begin = source.indexOf(
+      "// BEGIN GENERATED — sync via `npm run claude-policy:sync`",
+    );
+    const end = source.indexOf("// END GENERATED");
+    expect(begin).toBeGreaterThan(-1);
+    expect(end).toBeGreaterThan(begin);
+  });
+});

--- a/sdk/tests/claude-readiness/model.test.ts
+++ b/sdk/tests/claude-readiness/model.test.ts
@@ -19,6 +19,7 @@ import {
   CLAUDE_READINESS_ENGINE_VERSION,
   claudePolicySource,
   decideLaneStatus,
+  isDispositiveClaudeFinding,
   isPolicyCorpusVerified,
   rollUpLaneStatus,
   summarizeLaneCoverage,
@@ -63,10 +64,12 @@ function lane(
 
 describe("decideLaneStatus", () => {
   it("lets only required and runtime-blocker findings fail a lane", () => {
-    // Derived from the constant so a class added to the model is covered here
-    // automatically, rather than quietly escaping the central rule.
+    // Derived from the constant AND filtered by the model's own predicate.
+    // Restating the rule as a second literal list would let a newly
+    // dispositive class be picked up here and then asserted non-dispositive —
+    // the suite would stay green while contradicting the model.
     const nonDispositive = CLAUDE_FINDING_CLASSES.filter(
-      (cls) => cls !== "required" && cls !== "runtime-blocker",
+      (cls) => !isDispositiveClaudeFinding({ class: cls }),
     );
     for (const cls of nonDispositive) {
       expect(

--- a/sdk/tests/claude-readiness/model.test.ts
+++ b/sdk/tests/claude-readiness/model.test.ts
@@ -12,6 +12,7 @@ import { readFileSync } from "node:fs";
 import { describe, expect, it } from "vitest";
 
 import {
+  CLAUDE_FINDING_CLASSES,
   CLAUDE_POLICY_MANIFEST,
   CLAUDE_POLICY_PAGES,
   CLAUDE_POLICY_SNAPSHOT_DATE,
@@ -62,7 +63,12 @@ function lane(
 
 describe("decideLaneStatus", () => {
   it("lets only required and runtime-blocker findings fail a lane", () => {
-    for (const cls of ["recommended", "heuristic", "manual-review", "experimental-feature"] as const) {
+    // Derived from the constant so a class added to the model is covered here
+    // automatically, rather than quietly escaping the central rule.
+    const nonDispositive = CLAUDE_FINDING_CLASSES.filter(
+      (cls) => cls !== "required" && cls !== "runtime-blocker",
+    );
+    for (const cls of nonDispositive) {
       expect(
         decideLaneStatus([
           finding({ class: "required", status: "satisfied" }),
@@ -194,9 +200,20 @@ describe("the policy manifest", () => {
     expect(CLAUDE_POLICY_PAGES).toContain("mcp-apps/design-guidelines");
   });
 
-  it("reports an unpopulated corpus as unverified rather than pretending", () => {
-    // A fabricated hash would make an unaudited corpus look audited. Until the
-    // sync script runs, surfaces must be able to say so.
+  it("reports verification from the corpus, never by fabricating a hash", () => {
+    // Asserting `false` here would have gone red the first time a maintainer
+    // ran `claude-policy:sync` as designed, and the failure would have read as
+    // a policy problem rather than a stale assertion. The RULE is what must
+    // hold: verified exactly when every page carries a revision.
+    const everyPageHasRevision = CLAUDE_POLICY_PAGES.every((page) =>
+      Boolean(CLAUDE_POLICY_MANIFEST[page].revision),
+    );
+    expect(isPolicyCorpusVerified()).toBe(everyPageHasRevision);
+  });
+
+  it("is unverified while the shipped corpus is unpopulated", () => {
+    // The state this change actually ships in, asserted separately so the rule
+    // above stays true after a sync while this one is deliberately updated.
     expect(isPolicyCorpusVerified()).toBe(false);
   });
 

--- a/sdk/tests/claude-readiness/optional-features.test.ts
+++ b/sdk/tests/claude-readiness/optional-features.test.ts
@@ -1,0 +1,147 @@
+/**
+ * Capability badges.
+ *
+ * The single rule everything here protects: "we did not look" must never
+ * render as "unsupported". A badge that reports a connector as lacking a
+ * feature it in fact has is a false statement about someone's product, made on
+ * the strength of not having checked.
+ */
+
+import { describe, expect, it } from "vitest";
+
+import { runClaudeOptionalFeatureChecks } from "../../src/claude-readiness/checks/optional-features.js";
+import { decideLaneStatus } from "../../src/claude-readiness/index.js";
+import type { ClaudeAuthEvidence } from "../../src/claude-readiness/checks/auth.js";
+
+const STAMP = { evaluatedAt: "2026-08-19T00:00:00.000Z" };
+
+const CHALLENGED: ClaudeAuthEvidence = {
+  enteredUrl: "https://mcp.example.com/mcp",
+  unauthenticated: {
+    status: 401,
+    representsProtectedOperation: true,
+    servedWithoutCredentials: false,
+  },
+  prm: { discoveredVia: "www-authenticate", document: {} },
+};
+
+const SERVED_AND_PUBLISHES: ClaudeAuthEvidence = {
+  ...CHALLENGED,
+  unauthenticated: {
+    status: 200,
+    representsProtectedOperation: true,
+    servedWithoutCredentials: true,
+  },
+};
+
+function badge(
+  output: ReturnType<typeof runClaudeOptionalFeatureChecks>,
+  id: string,
+) {
+  return output.badges.find((entry) => entry.id === id)!;
+}
+
+describe("badges never decide a lane", () => {
+  it("leaves the optional-features lane incomplete no matter what it found", () => {
+    // `experimental-feature` is not dispositive, so `decideLaneStatus` cannot
+    // be moved by any of it — absence of an optional feature is not a defect.
+    for (const evidence of [CHALLENGED, SERVED_AND_PUBLISHES]) {
+      const output = runClaudeOptionalFeatureChecks({ auth: evidence }, STAMP);
+      expect(decideLaneStatus(output.findings)).toBe("incomplete");
+      expect(
+        output.findings.every((f) => f.class === "experimental-feature"),
+      ).toBe(true);
+    }
+  });
+});
+
+describe("lazy authentication", () => {
+  it("is not-evaluated — not unsupported — when neither claimed nor detected", () => {
+    expect(
+      badge(
+        runClaudeOptionalFeatureChecks({ auth: CHALLENGED }, STAMP),
+        "claude.features.lazy-authentication",
+      ),
+    ).toMatchObject({ state: "not-evaluated" });
+  });
+
+  it("is claimed, not supported, on a consistent-but-undriven observation", () => {
+    const entry = badge(
+      runClaudeOptionalFeatureChecks({ auth: SERVED_AND_PUBLISHES }, STAMP),
+      "claude.features.lazy-authentication",
+    );
+    expect(entry.state).toBe("claimed");
+    expect(entry.detail).toMatch(/not driven/);
+  });
+
+  it("is supported only when a probe actually drove it", () => {
+    const entry = badge(
+      runClaudeOptionalFeatureChecks(
+        {
+          auth: SERVED_AND_PUBLISHES,
+          lazyAuthProbe: {
+            unauthenticatedCallSucceeded: true,
+            protectedCallChallenged: true,
+          },
+        },
+        STAMP,
+      ),
+      "claude.features.lazy-authentication",
+    );
+    expect(entry).toMatchObject({ state: "supported", provenance: "wire" });
+  });
+
+  it("is unsupported when a probe drove it and it did not work", () => {
+    expect(
+      badge(
+        runClaudeOptionalFeatureChecks(
+          {
+            auth: SERVED_AND_PUBLISHES,
+            lazyAuthProbe: {
+              unauthenticatedCallSucceeded: true,
+              protectedCallChallenged: false,
+            },
+          },
+          STAMP,
+        ),
+        "claude.features.lazy-authentication",
+      ).state,
+    ).toBe("unsupported");
+  });
+
+  it("unlocks depth on a submitter claim without treating the claim as evidence", () => {
+    const output = runClaudeOptionalFeatureChecks(
+      { auth: CHALLENGED, claimedFeatures: { lazyAuthentication: true } },
+      STAMP,
+    );
+    const entry = badge(output, "claude.features.lazy-authentication");
+    expect(entry).toMatchObject({ state: "claimed", provenance: "declared" });
+    expect(
+      output.findings.find((f) => f.id === "claude.features.lazy-authentication")
+        ?.notEvaluatedReason,
+    ).toMatch(/driving a protected call/);
+  });
+});
+
+describe("enterprise-managed auth", () => {
+  it("is not-evaluated when unclaimed, because a probe cannot see it", () => {
+    const entry = badge(
+      runClaudeOptionalFeatureChecks({ auth: CHALLENGED }, STAMP),
+      "claude.features.enterprise-managed-auth",
+    );
+    expect(entry.state).toBe("not-evaluated");
+    expect(entry.detail).toMatch(/cannot be detected/);
+  });
+
+  it("is claimed when declared, and says what verifying it would take", () => {
+    const entry = badge(
+      runClaudeOptionalFeatureChecks(
+        { auth: CHALLENGED, claimedFeatures: { enterpriseManagedAuth: true } },
+        STAMP,
+      ),
+      "claude.features.enterprise-managed-auth",
+    );
+    expect(entry.state).toBe("claimed");
+    expect(entry.detail).toMatch(/enterprise tenant/);
+  });
+});

--- a/sdk/tests/claude-readiness/policy-text.test.ts
+++ b/sdk/tests/claude-readiness/policy-text.test.ts
@@ -1,0 +1,86 @@
+/**
+ * The policy-page text extractor, which decides what the drift hash is over.
+ *
+ * The regex version this replaced was flagged by CodeQL as a bad HTML filter,
+ * and the finding was right in a way that mattered here: each of its blind
+ * spots makes the DIGEST depend on markup trivia, so an unchanged policy would
+ * read as drift (or a changed one would not). The hash's whole job is to be
+ * stable under rebuilds and unstable under edits, and these cases are where a
+ * pattern-matched version gets that backwards.
+ */
+
+import { describe, expect, it } from "vitest";
+
+// @ts-expect-error — a maintenance script, deliberately plain JS with no types.
+import { extractText } from "../../../scripts/sync-claude-policy-manifest.mjs";
+
+const text = (html: string): string => extractText(html) as string;
+
+describe("extractText", () => {
+  it("keeps visible text and drops the tags around it", () => {
+    expect(text("<h1>Directory</h1><p>Submit your connector.</p>")).toBe(
+      "Directory Submit your connector.",
+    );
+  });
+
+  it("drops a script body even when the end tag carries whitespace", () => {
+    // `</script >` is valid HTML. A `"</script>"` search walks straight past
+    // it and swallows the rest of the document as script body — so the hash
+    // would then be over an empty string for every page.
+    expect(text("<p>keep</p><script>var x = 1;</script >tail")).toBe("keep tail");
+  });
+
+  it("drops a script body with attributes on the open tag", () => {
+    expect(
+      text('<script type="module" defer>const a = 1;</script><p>keep</p>'),
+    ).toBe("keep");
+  });
+
+  it("does not stop at a </scriptfoo> that is a different element", () => {
+    expect(text("<script>a</scriptfoo>b</script><p>keep</p>")).toBe("keep");
+  });
+
+  it("drops style bodies too", () => {
+    expect(text("<style>body{color:red}</style><p>keep</p>")).toBe("keep");
+  });
+
+  it("drops comments rather than treating them as content", () => {
+    // A build id in a comment would otherwise make every rebuild look like a
+    // policy change.
+    expect(text("<p>keep</p><!-- build 4f21a --><p>also</p>")).toBe(
+      "keep also",
+    );
+  });
+
+  it("does not end a tag at a > inside a quoted attribute", () => {
+    expect(text('<a title="a > b" href="/x">link</a>')).toBe("link");
+    expect(text("<a title='a > b'>link</a>")).toBe("link");
+  });
+
+  it("treats a bare < in prose as content", () => {
+    expect(text("<p>use a < b for comparison</p>")).toBe(
+      "use a < b for comparison",
+    );
+  });
+
+  it("collapses whitespace and decodes non-breaking spaces", () => {
+    expect(text("<p>a&nbsp;b</p>\n\n   <p>c</p>")).toBe("a b c");
+  });
+
+  it("survives an unterminated tag without hanging or throwing", () => {
+    expect(text("<p>keep</p><div class=\"x")).toBe("keep");
+  });
+
+  it("is stable across markup that changes but text that does not", () => {
+    // This is the property the whole manifest rests on.
+    const a = text('<main><p class="prose-a">Connectors must use HTTPS.</p></main>');
+    const b = text('<main id="r2"><p class="prose-b" data-v="9">Connectors must use HTTPS.</p></main>');
+    expect(a).toBe(b);
+  });
+
+  it("changes when the text changes", () => {
+    expect(text("<p>Connectors must use HTTPS.</p>")).not.toBe(
+      text("<p>Connectors may use HTTPS.</p>"),
+    );
+  });
+});

--- a/sdk/tests/claude-readiness/policy-text.test.ts
+++ b/sdk/tests/claude-readiness/policy-text.test.ts
@@ -44,6 +44,14 @@ describe("extractText", () => {
     expect(text("<style>body{color:red}</style><p>keep</p>")).toBe("keep");
   });
 
+  it("drops a doctype declaration", () => {
+    // `readTag` does not recognise `<!doctype html>` as a tag, so without an
+    // explicit branch it survived as literal text — and a markup-only doctype
+    // change would have moved the policy revision.
+    expect(text("<!doctype html><p>Directory</p>")).toBe("Directory");
+    expect(text("<!DOCTYPE HTML><p>Directory</p>")).toBe("Directory");
+  });
+
   it("drops comments rather than treating them as content", () => {
     // A build id in a comment would otherwise make every rebuild look like a
     // policy change.

--- a/sdk/tests/claude-readiness/report.test.ts
+++ b/sdk/tests/claude-readiness/report.test.ts
@@ -1,0 +1,260 @@
+/**
+ * How a readiness result renders — and what it must never become.
+ *
+ * Two properties are the whole point of the adapter:
+ *
+ *   1. It carries NO conformance score, so it cannot be pooled into
+ *      `pooledConformanceScore` or the public score. Anthropic's listing
+ *      policy is not the MCP specification and a number that mixed them would
+ *      be meaningless in both directions.
+ *   2. Advisories render as JUnit `<properties>`, never as failed testcases. A
+ *      CI job that goes red on a heuristic gets `|| true` appended to it, and
+ *      then the real findings stop being read too.
+ */
+
+import { describe, expect, it } from "vitest";
+
+import {
+  renderConformanceReportJUnitXml,
+  toConformanceReport,
+} from "../../src/conformance-reporting.js";
+import { pooledConformanceScore } from "../../src/conformance-score.js";
+import {
+  CLAUDE_POLICY_SNAPSHOT_DATE,
+  CLAUDE_READINESS_ENGINE_VERSION,
+  claudePolicySource,
+  summarizeLaneCoverage,
+  type ClaudeReadinessFinding,
+  type ClaudeReadinessResult,
+} from "../../src/claude-readiness/index.js";
+
+function makeFinding(
+  overrides: Partial<ClaudeReadinessFinding> &
+    Pick<ClaudeReadinessFinding, "id" | "class" | "status" | "lane">,
+): ClaudeReadinessFinding {
+  return {
+    title: overrides.title ?? overrides.id,
+    provenance: "wire",
+    intrusiveness: "read-only",
+    source: claudePolicySource("directory", "§Overview"),
+    evaluatedAt: "2026-08-19T00:00:00.000Z",
+    engineVersion: CLAUDE_READINESS_ENGINE_VERSION,
+    ...overrides,
+  };
+}
+
+function makeResult(
+  findings: ClaudeReadinessFinding[],
+  status: ClaudeReadinessResult["status"] = "not-ready",
+): ClaudeReadinessResult {
+  const lanes: ClaudeReadinessResult["lanes"] = [
+    {
+      lane: "runtime-compatibility",
+      status: "ready",
+      summary: "Claude can connect and authenticate.",
+      coverage: summarizeLaneCoverage(
+        "runtime-compatibility",
+        findings.filter((f) => f.lane === "runtime-compatibility"),
+      ),
+    },
+    {
+      lane: "directory-policy",
+      status: status === "ready" ? "ready" : "not-ready",
+      summary: "One submission requirement is unmet.",
+      coverage: summarizeLaneCoverage(
+        "directory-policy",
+        findings.filter((f) => f.lane === "directory-policy"),
+      ),
+    },
+    {
+      lane: "experience-insights",
+      status: "incomplete",
+      summary: "Heuristics only.",
+      coverage: summarizeLaneCoverage(
+        "experience-insights",
+        findings.filter((f) => f.lane === "experience-insights"),
+        ["llmInsights"],
+      ),
+    },
+  ];
+  return {
+    status,
+    summary: "One directory-policy requirement is unmet.",
+    context: {
+      target: "https://mcp.example.com/mcp",
+      authMode: "headless",
+      capabilities: ["dns"],
+      evidenceSources: ["protocol-conformance"],
+    },
+    lanes,
+    findings,
+    badges: [],
+    policySnapshotDate: CLAUDE_POLICY_SNAPSHOT_DATE,
+    engineVersion: CLAUDE_READINESS_ENGINE_VERSION,
+    startedAt: "2026-08-19T00:00:00.000Z",
+    durationMs: 1234,
+  };
+}
+
+const FINDINGS = [
+  makeFinding({
+    id: "tool-annotations-present",
+    lane: "directory-policy",
+    class: "required",
+    status: "violated",
+    remediation: "Annotate every tool with readOnlyHint or destructiveHint.",
+  }),
+  makeFinding({
+    id: "prm-resource-exact-match",
+    lane: "runtime-compatibility",
+    class: "required",
+    status: "satisfied",
+  }),
+  makeFinding({
+    id: "financial-transfer-tool",
+    lane: "experience-insights",
+    class: "heuristic",
+    status: "violated",
+    remediation: "A tool appears to move money; review the confirmation flow.",
+  }),
+  makeFinding({
+    id: "lazy-auth-supported",
+    lane: "experience-insights",
+    class: "experimental-feature",
+    status: "informational",
+  }),
+];
+
+describe("toConformanceReport for readiness", () => {
+  it("uses its own kind and never carries a conformance score", () => {
+    const report = toConformanceReport(makeResult(FINDINGS));
+
+    expect(report.kind).toBe("claude-directory-readiness");
+    expect(report.score).toBeUndefined();
+    // And so it contributes nothing when a caller pools scores.
+    expect(pooledConformanceScore([]).score).toBeNull();
+  });
+
+  it("maps the readiness verdict onto the shared outcome vocabulary", () => {
+    expect(toConformanceReport(makeResult(FINDINGS)).outcome).toBe("failed");
+    expect(toConformanceReport(makeResult([], "ready")).outcome).toBe("passed");
+
+    const incomplete = toConformanceReport(makeResult([], "incomplete"));
+    expect(incomplete.outcome).toBe("incomplete");
+    expect(incomplete.incompleteReason).toBeTruthy();
+  });
+
+  it("makes only dispositive findings testcases", () => {
+    const report = toConformanceReport(makeResult(FINDINGS));
+    const caseIds = report.groups.flatMap((group) =>
+      group.cases.map((entry) => entry.id),
+    );
+
+    expect(caseIds).toEqual([
+      "prm-resource-exact-match",
+      "tool-annotations-present",
+    ]);
+    expect(caseIds).not.toContain("financial-transfer-tool");
+  });
+
+  it("routes the rest to advisories, tagged with the lane that raised them", () => {
+    const report = toConformanceReport(makeResult(FINDINGS));
+
+    expect(report.advisories?.map((entry) => entry.id)).toEqual([
+      "financial-transfer-tool",
+      "lazy-auth-supported",
+    ]);
+    expect(report.advisories?.[0]).toMatchObject({
+      group: "experience-insights",
+      kind: "heuristic",
+      status: "violated",
+    });
+  });
+
+  it("keeps a lane that could not be evaluated out of the passed column", () => {
+    const report = toConformanceReport(makeResult(FINDINGS));
+    const insights = report.groups.find(
+      (group) => group.id === "experience-insights",
+    );
+    expect(insights?.passed).toBe(false);
+  });
+
+  it("distinguishes an untested obligation from an inapplicable one", () => {
+    const report = toConformanceReport(
+      makeResult([
+        makeFinding({
+          id: "screenshots-present",
+          lane: "directory-policy",
+          class: "required",
+          status: "not-evaluated",
+          notEvaluatedReason: "no submission profile was supplied",
+        }),
+        makeFinding({
+          id: "app-mime-profile",
+          lane: "directory-policy",
+          class: "required",
+          status: "not-applicable",
+        }),
+      ]),
+    );
+    const cases = report.groups.flatMap((group) => group.cases);
+
+    expect(cases.find((c) => c.id === "screenshots-present")?.skipReason).toBe(
+      "could-not-run",
+    );
+    expect(cases.find((c) => c.id === "app-mime-profile")?.skipReason).toBe(
+      "not-applicable",
+    );
+  });
+});
+
+describe("JUnit rendering", () => {
+  it("renders advisories as properties, not as failures", () => {
+    const xml = renderConformanceReportJUnitXml(
+      toConformanceReport(makeResult(FINDINGS)),
+    );
+
+    expect(xml).toContain(
+      '<property name="mcpjam.advisory.financial-transfer-tool"',
+    );
+    // Exactly one failure: the violated REQUIREMENT. The violated heuristic
+    // beside it must not have produced a second one.
+    expect(xml.match(/<failure /g) ?? []).toHaveLength(1);
+    expect(xml).toContain('failures="1"');
+  });
+
+  it("puts each advisory under the testsuite that raised it", () => {
+    const xml = renderConformanceReportJUnitXml(
+      toConformanceReport(makeResult(FINDINGS)),
+    );
+    const insightsSuite = xml.slice(
+      xml.indexOf('<testsuite name="experience-insights"'),
+    );
+
+    expect(insightsSuite).toContain("mcpjam.advisory.financial-transfer-tool");
+    // The policy lane raised no advisories, so it gets no properties block.
+    const policySuite = xml.slice(
+      xml.indexOf('<testsuite name="directory-policy"'),
+      xml.indexOf('<testsuite name="experience-insights"'),
+    );
+    expect(policySuite).not.toContain("<properties>");
+  });
+
+  it("stays valid XML when an advisory message contains markup", () => {
+    const xml = renderConformanceReportJUnitXml(
+      toConformanceReport(
+        makeResult([
+          makeFinding({
+            id: "quote-and-angle",
+            lane: "experience-insights",
+            class: "heuristic",
+            status: "violated",
+            remediation: 'Use <b>"safe"</b> & escape it',
+          }),
+        ]),
+      ),
+    );
+
+    expect(xml).toContain("&lt;b&gt;&quot;safe&quot;&lt;/b&gt; &amp; escape it");
+  });
+});

--- a/sdk/tests/claude-readiness/report.test.ts
+++ b/sdk/tests/claude-readiness/report.test.ts
@@ -131,8 +131,15 @@ describe("toConformanceReport for readiness", () => {
 
     expect(report.kind).toBe("claude-directory-readiness");
     expect(report.score).toBeUndefined();
-    // And so it contributes nothing when a caller pools scores.
-    expect(pooledConformanceScore([]).score).toBeNull();
+    // And so it contributes nothing when a caller pools scores. Pooling the
+    // report's OWN (absent) score is what makes this assertion about the
+    // readiness adapter rather than about `pooledConformanceScore([])`, which
+    // returns null by definition and would pass either way.
+    const contributed = [report.score].filter(
+      (score): score is NonNullable<typeof score> => score !== undefined,
+    );
+    expect(contributed).toEqual([]);
+    expect(pooledConformanceScore(contributed).score).toBeNull();
   });
 
   it("maps the readiness verdict onto the shared outcome vocabulary", () => {
@@ -227,17 +234,21 @@ describe("JUnit rendering", () => {
     const xml = renderConformanceReportJUnitXml(
       toConformanceReport(makeResult(FINDINGS)),
     );
-    const insightsSuite = xml.slice(
-      xml.indexOf('<testsuite name="experience-insights"'),
-    );
+    // Pinned BEFORE slicing. A renamed or reordered suite makes `indexOf`
+    // return -1, and `slice(-1, n)` yields a near-empty string that satisfies
+    // `not.toContain` on nothing at all — the assertion survives while the
+    // coverage quietly does not.
+    const insightsAt = xml.indexOf('<testsuite name="experience-insights"');
+    const policyAt = xml.indexOf('<testsuite name="directory-policy"');
+    expect(insightsAt).toBeGreaterThan(-1);
+    expect(policyAt).toBeGreaterThan(-1);
+    expect(policyAt).toBeLessThan(insightsAt);
 
-    expect(insightsSuite).toContain("mcpjam.advisory.financial-transfer-tool");
-    // The policy lane raised no advisories, so it gets no properties block.
-    const policySuite = xml.slice(
-      xml.indexOf('<testsuite name="directory-policy"'),
-      xml.indexOf('<testsuite name="experience-insights"'),
+    expect(xml.slice(insightsAt)).toContain(
+      "mcpjam.advisory.financial-transfer-tool",
     );
-    expect(policySuite).not.toContain("<properties>");
+    // The policy lane raised no advisories, so it gets no properties block.
+    expect(xml.slice(policyAt, insightsAt)).not.toContain("<properties>");
   });
 
   it("stays valid XML when an advisory message contains markup", () => {

--- a/sdk/tests/claude-readiness/runner.test.ts
+++ b/sdk/tests/claude-readiness/runner.test.ts
@@ -1,0 +1,366 @@
+/**
+ * The composite run: five lanes, one rollup, and the rules that stop the soft
+ * lanes from deciding anything.
+ */
+
+import { describe, expect, it } from "vitest";
+
+import {
+  gradeClaudeReadiness,
+  type ClaudeReadinessInput,
+} from "../../src/claude-readiness/runner.js";
+import { toConformanceReport } from "../../src/conformance-reporting.js";
+
+const URL_UNDER_TEST = "https://mcp.example.com/mcp";
+
+function input(overrides: Partial<ClaudeReadinessInput> = {}): ClaudeReadinessInput {
+  return {
+    enteredUrl: URL_UNDER_TEST,
+    authMode: "headless",
+    capabilities: ["dns"],
+    startedAt: "2026-08-19T00:00:00.000Z",
+    evaluatedAt: "2026-08-19T00:00:01.000Z",
+    durationMs: 1000,
+    endpoint: { enteredUrl: URL_UNDER_TEST, redirectChain: [] },
+    auth: {
+      enteredUrl: URL_UNDER_TEST,
+      unauthenticated: {
+        status: 401,
+        wwwAuthenticate: 'Bearer resource_metadata="https://mcp.example.com/prm"',
+        representsProtectedOperation: true,
+        servedWithoutCredentials: false,
+      },
+      prm: {
+        discoveredVia: "www-authenticate",
+        document: {
+          resource: URL_UNDER_TEST,
+          authorization_servers: ["https://auth.example.com"],
+        },
+      },
+      firstAuthorizationServer: {
+        issuer: "https://auth.example.com",
+        reachable: true,
+        document: {
+          registration_endpoint: "https://auth.example.com/register",
+          code_challenge_methods_supported: ["S256"],
+          response_types_supported: ["code"],
+        },
+      },
+    },
+    apps: { enteredUrl: URL_UNDER_TEST, appsSuiteRan: true, tools: [] },
+    tools: [
+      {
+        name: "list_orders",
+        title: "List orders",
+        annotations: { readOnlyHint: true },
+        inputSchema: { type: "object", properties: {} },
+      } as never,
+    ],
+    evidenceSources: ["protocol-conformance", "apps-conformance"],
+    ...overrides,
+  };
+}
+
+/**
+ * A run with everything: an authorization was completed, so the resource
+ * parameter is observable, and the intrusive probes were armed and ran.
+ *
+ * This is what `ready` actually costs. A headless run cannot reach it, and the
+ * tests below insist on that rather than papering over it — reporting `ready`
+ * for requirements a run could not evaluate is the single most damaging thing
+ * this product could do.
+ */
+function fullyCapable(): ClaudeReadinessInput {
+  const base = input();
+  return {
+    ...base,
+    authMode: "interactive",
+    capabilities: ["dns", "interactive-oauth", "intrusive-probes"],
+    auth: {
+      ...base.auth,
+      resourceIndicatorsSent: {
+        authorize: URL_UNDER_TEST,
+        token: URL_UNDER_TEST,
+      },
+    },
+    intrusive: {
+      enabled: true,
+      grantOrigin: "dedicated-test-account",
+      testCredentials: { clientId: "test", refreshToken: "rt" },
+      protectedToolName: "list_orders",
+      expectedScopes: ["orders:read"],
+    },
+    intrusiveObservations: {
+      registration: { attempted: true, status: 201, cleanedUp: true },
+      refresh: {
+        attempted: true,
+        rotated: true,
+        replayStatus: 400,
+        replayError: "invalid_grant",
+      },
+      stepUp: {
+        attempted: true,
+        toolName: "list_orders",
+        status: 403,
+        wwwAuthenticate: 'Bearer error="insufficient_scope"',
+      },
+    },
+  };
+}
+
+describe("the rollup", () => {
+  it("reports ready only when everything applicable was actually evaluated", () => {
+    const result = gradeClaudeReadiness(fullyCapable());
+    expect(result.status).toBe("ready");
+    expect(result.summary).toMatch(/satisfied/);
+  });
+
+  it("is incomplete for a healthy server graded headlessly, and says why", () => {
+    // Nothing is wrong with this connector. The run simply could not complete
+    // an authorization or run a side-effecting probe, and `incomplete` is the
+    // honest word for that.
+    const result = gradeClaudeReadiness(input());
+    expect(result.status).toBe("incomplete");
+    expect(
+      result.findings.filter(
+        (finding) =>
+          finding.status === "violated" &&
+          (finding.class === "required" || finding.class === "runtime-blocker"),
+      ),
+    ).toEqual([]);
+    const unevaluated = result.findings.filter(
+      (finding) =>
+        finding.lane === "runtime-compatibility" &&
+        finding.status === "not-evaluated",
+    );
+    expect(unevaluated.map((finding) => finding.id)).toEqual(
+      expect.arrayContaining([
+        "claude.auth.rfc8707-resource-canonical",
+        "claude.intrusive.dynamic-registration",
+      ]),
+    );
+  });
+
+  it("cannot be moved by the optional or insight lanes", () => {
+    // A heuristic that fires and a badge that is missing are both present in
+    // this run; neither may change the verdict.
+    const result = gradeClaudeReadiness({
+      ...fullyCapable(),
+      apps: {
+        enteredUrl: URL_UNDER_TEST,
+        appsSuiteRan: true,
+        tools: [
+          {
+            name: "widget",
+            resourceUri: "ui://w",
+            hasNestedField: true,
+            hasLegacyField: false,
+          },
+        ],
+        resources: [
+          {
+            uri: "ui://w",
+            mimeType: "text/html;profile=mcp-app",
+            html: "<html><body><button>x</button></body></html>",
+          },
+        ],
+      },
+    });
+    expect(
+      result.findings.some(
+        (finding) => finding.class === "heuristic" && finding.status === "violated",
+      ),
+    ).toBe(true);
+    expect(result.status).toBe("ready");
+  });
+
+  it("is not-ready on a runtime blocker", () => {
+    const result = gradeClaudeReadiness(
+      input({ endpoint: { enteredUrl: "http://mcp.example.com/mcp" } }),
+    );
+    expect(result.status).toBe("not-ready");
+    expect(result.summary).toMatch(/runtime-compatibility/);
+  });
+
+  it("is incomplete when the policy lane never saw the tool listing", () => {
+    const result = gradeClaudeReadiness({ ...fullyCapable(), tools: undefined });
+    const policy = result.lanes.find((lane) => lane.lane === "directory-policy")!;
+    expect(policy.status).toBe("incomplete");
+    expect(result.status).toBe("incomplete");
+  });
+
+  it("stays ready when the server genuinely has no tools to grade", () => {
+    // Inapplicable is not a gap: there is nothing here that could violate a
+    // tool requirement.
+    const result = gradeClaudeReadiness({ ...fullyCapable(), tools: [] });
+    expect(
+      result.lanes.find((lane) => lane.lane === "directory-policy")!.status,
+    ).toBe("ready");
+  });
+});
+
+describe("coverage and context", () => {
+  it("names submissionProfile as the input the artifacts lane is missing", () => {
+    const artifacts = gradeClaudeReadiness(input()).lanes.find(
+      (lane) => lane.lane === "submission-artifacts",
+    )!;
+    expect(artifacts.status).toBe("incomplete");
+    expect(artifacts.coverage.missingInputs).toContain("submissionProfile");
+  });
+
+  it("records what the runner could actually do", () => {
+    // Two surfaces grading the same target agree only on their shared
+    // capability subset; recording this is what makes a gap legible instead of
+    // looking like a disagreement.
+    const result = gradeClaudeReadiness(
+      input({ capabilities: ["browser", "dns", "interactive-oauth"] }),
+    );
+    expect(result.context.capabilities).toEqual([
+      "browser",
+      "dns",
+      "interactive-oauth",
+    ]);
+    expect(result.context.authMode).toBe("headless");
+    expect(result.context.evidenceSources).toEqual([
+      "apps-conformance",
+      "protocol-conformance",
+    ]);
+  });
+
+  it("stamps one evaluatedAt across every finding", () => {
+    const result = gradeClaudeReadiness(input());
+    const moments = new Set(result.findings.map((finding) => finding.evaluatedAt));
+    expect([...moments]).toEqual(["2026-08-19T00:00:01.000Z"]);
+  });
+
+  it("carries the policy snapshot date the corpus was pinned at", () => {
+    expect(gradeClaudeReadiness(input()).policySnapshotDate).toBe("2026-08-19");
+  });
+});
+
+describe("the submission profile flows into the auth findings", () => {
+  it("lets a declared preregistered client reclassify the acquisition path", () => {
+    const withoutRegistration = input({
+      auth: {
+        ...input().auth,
+        firstAuthorizationServer: {
+          issuer: "https://auth.example.com",
+          reachable: true,
+          document: {
+            code_challenge_methods_supported: ["S256"],
+            response_types_supported: ["code"],
+          },
+        },
+      },
+    });
+
+    const undeclared = gradeClaudeReadiness(withoutRegistration);
+    expect(
+      undeclared.findings.find(
+        (f) => f.id === "claude.auth.client-acquisition-path",
+      )?.status,
+    ).toBe("violated");
+
+    const declared = gradeClaudeReadiness({
+      ...withoutRegistration,
+      submissionProfile: {
+        name: "Acme",
+        tagline: "Acme orders",
+        description: "d",
+        categories: ["Productivity"],
+        slug: "acme",
+        documentationUrl: "https://acme.example/docs",
+        privacyPolicyUrl: "https://acme.example/privacy",
+        supportUrl: "https://acme.example/support",
+        iconUrl: "https://acme.example/icon.png",
+        declaredAuthMode: "oauth-preregistered",
+        dataHandling: ["no-user-data"],
+        screenshots: [1, 2, 3].map((n) => ({
+          url: `https://acme.example/${n}.png`,
+          mimeType: "image/png",
+          widthPx: 1200,
+          heightPx: 800,
+          prompt: `p${n}`,
+        })),
+        attestations: {
+          ownsOrIsAuthorizedForService: true,
+          accurateDataHandlingDisclosure: true,
+          compliesWithUsagePolicies: true,
+          noProhibitedContent: true,
+          maintainsSecurityPractices: true,
+          respondsToSecurityReports: true,
+          keepsListingAccurate: true,
+        },
+      },
+    });
+    expect(
+      declared.findings.find((f) => f.id === "claude.auth.client-acquisition-path")
+        ?.status,
+    ).toBe("satisfied");
+  });
+
+  it("turns a malformed profile into findings rather than silence", () => {
+    const result = gradeClaudeReadiness(
+      input({ submissionProfile: { name: "only a name" } }),
+    );
+    const artifacts = result.findings.filter(
+      (finding) => finding.lane === "submission-artifacts",
+    );
+    expect(artifacts.every((f) => f.status === "not-evaluated")).toBe(true);
+    expect(artifacts[0].notEvaluatedReason).toMatch(/did not validate/);
+  });
+});
+
+describe("intrusive mode inside a run", () => {
+  it("stays off by default and says so on every intrusive finding", () => {
+    const result = gradeClaudeReadiness(input());
+    const intrusive = result.findings.filter(
+      (finding) => finding.intrusiveness === "side-effecting",
+    );
+    expect(intrusive).toHaveLength(3);
+    expect(intrusive.every((f) => f.status === "not-evaluated")).toBe(true);
+  });
+
+  it("refuses to arm when the run is holding somebody else's token", () => {
+    // `provided-token` means the run holds credentials supplied for ordinary
+    // operation. Spending them here would burn a session its owner did not
+    // volunteer.
+    const result = gradeClaudeReadiness(
+      input({
+        authMode: "provided-token",
+        intrusive: { enabled: true, grantOrigin: "self-acquired" },
+      }),
+    );
+    const finding = result.findings.find(
+      (f) => f.id === "claude.intrusive.refresh-rotation",
+    )!;
+    expect(finding.status).toBe("not-evaluated");
+    expect(finding.notEvaluatedReason).toMatch(/borrowed grant/);
+  });
+});
+
+describe("it renders through the shared report adapter", () => {
+  it("produces a readiness report with no conformance score", () => {
+    const report = toConformanceReport(gradeClaudeReadiness(input()));
+    expect(report.kind).toBe("claude-directory-readiness");
+    expect(report.score).toBeUndefined();
+    expect(report.groups.map((group) => group.id)).toEqual([
+      "runtime-compatibility",
+      "directory-policy",
+      "optional-features",
+      "submission-artifacts",
+      "experience-insights",
+    ]);
+  });
+
+  it("routes every non-dispositive finding to advisories", () => {
+    const report = toConformanceReport(gradeClaudeReadiness(input()));
+    const caseIds = new Set(
+      report.groups.flatMap((group) => group.cases.map((entry) => entry.id)),
+    );
+    for (const advisory of report.advisories ?? []) {
+      expect(caseIds.has(advisory.id)).toBe(false);
+    }
+    expect((report.advisories ?? []).length).toBeGreaterThan(0);
+  });
+});

--- a/sdk/tests/claude-readiness/runner.test.ts
+++ b/sdk/tests/claude-readiness/runner.test.ts
@@ -3,6 +3,7 @@
  * lanes from deciding anything.
  */
 
+import type { Tool } from "@modelcontextprotocol/client";
 import { describe, expect, it } from "vitest";
 
 import {
@@ -21,7 +22,12 @@ function input(overrides: Partial<ClaudeReadinessInput> = {}): ClaudeReadinessIn
     startedAt: "2026-08-19T00:00:00.000Z",
     evaluatedAt: "2026-08-19T00:00:01.000Z",
     durationMs: 1000,
-    endpoint: { enteredUrl: URL_UNDER_TEST, redirectChain: [] },
+    endpoint: {
+      enteredUrl: URL_UNDER_TEST,
+      // A REAL one-hop chain. An empty array means the run never reached the
+      // endpoint at all, which is a coverage gap rather than a clean result.
+      redirectChain: [{ url: URL_UNDER_TEST, status: 200 }],
+    },
     auth: {
       enteredUrl: URL_UNDER_TEST,
       unauthenticated: {
@@ -54,7 +60,10 @@ function input(overrides: Partial<ClaudeReadinessInput> = {}): ClaudeReadinessIn
         title: "List orders",
         annotations: { readOnlyHint: true },
         inputSchema: { type: "object", properties: {} },
-      } as never,
+        // `as Tool`, not `as never`: the bottom type is assignable to
+        // everything, so `as never` would stop the compiler checking this
+        // fixture against `Tool` at all.
+      } as Tool,
     ],
     evidenceSources: ["protocol-conformance", "apps-conformance"],
     ...overrides,
@@ -353,14 +362,45 @@ describe("it renders through the shared report adapter", () => {
     ]);
   });
 
-  it("routes every non-dispositive finding to advisories", () => {
-    const report = toConformanceReport(gradeClaudeReadiness(input()));
+  it("routes every finding to exactly one of cases or advisories", () => {
+    // Both directions. Asserting only that advisory ids are absent from cases
+    // would stay green if half the non-dispositive findings were dropped
+    // entirely — which is the failure mode that matters.
+    const result = gradeClaudeReadiness(input());
+    const report = toConformanceReport(result);
     const caseIds = new Set(
       report.groups.flatMap((group) => group.cases.map((entry) => entry.id)),
     );
-    for (const advisory of report.advisories ?? []) {
-      expect(caseIds.has(advisory.id)).toBe(false);
+    const advisoryIds = new Set((report.advisories ?? []).map((a) => a.id));
+
+    for (const finding of result.findings) {
+      const dispositive =
+        finding.class === "required" || finding.class === "runtime-blocker";
+      expect(
+        dispositive ? caseIds.has(finding.id) : advisoryIds.has(finding.id),
+      ).toBe(true);
+      expect(
+        dispositive ? advisoryIds.has(finding.id) : caseIds.has(finding.id),
+      ).toBe(false);
     }
-    expect((report.advisories ?? []).length).toBeGreaterThan(0);
+    expect(advisoryIds.size).toBeGreaterThan(0);
+  });
+
+  it("keeps a finding whose lane was not reported, rather than dropping it", () => {
+    // `lanes` and `findings` are independent arrays, so nothing in the type
+    // says every finding's lane is reported. A dropped VIOLATED requirement
+    // would understate the run with no counter and no error.
+    const result = gradeClaudeReadiness(input());
+    const orphaned = {
+      ...result.findings[0],
+      id: "claude.test.orphan",
+      lane: "experience-insights" as const,
+    };
+    const report = toConformanceReport({
+      ...result,
+      lanes: [],
+      findings: [orphaned],
+    });
+    expect(report.advisories?.map((a) => a.id)).toContain("claude.test.orphan");
   });
 });

--- a/sdk/tests/claude-readiness/runner.test.ts
+++ b/sdk/tests/claude-readiness/runner.test.ts
@@ -236,6 +236,48 @@ describe("coverage and context", () => {
     ]);
   });
 
+  it("will not let a check outrun the capabilities it declared", () => {
+    // `requiresCapabilities` was documented as an invariant and enforced
+    // nowhere, so it held only for as long as every check author remembered
+    // it. A check that forgets does not fail loudly — it publishes a verdict
+    // it had no evidence for. Asserted over EVERY declaring finding rather
+    // than one known id, so a check added later is covered by this test
+    // without anyone remembering to extend it.
+    const result = gradeClaudeReadiness(input({ capabilities: ["dns"] }));
+    const held = new Set(result.context.capabilities);
+    const overreaching = result.findings.filter(
+      (finding) =>
+        (finding.requiresCapabilities ?? []).some(
+          (capability) => !held.has(capability),
+        ) && finding.status !== "not-evaluated",
+    );
+    expect(overreaching).toEqual([]);
+    // And the gate is reached at all — a run where nothing declares a missing
+    // capability would pass the assertion above vacuously.
+    expect(
+      result.findings.some((finding) =>
+        (finding.requiresCapabilities ?? []).some(
+          (capability) => !held.has(capability),
+        ),
+      ),
+    ).toBe(true);
+  });
+
+  it("never upgrades a finding on the strength of a capability", () => {
+    // The gate is one-directional. Holding a capability cannot turn an
+    // unevaluated check into a pass.
+    const result = gradeClaudeReadiness(
+      input({ capabilities: ["browser", "dns", "interactive-oauth"] }),
+    );
+    const gated = result.findings.filter((f) =>
+      (f.requiresCapabilities ?? []).length > 0,
+    );
+    expect(gated.length).toBeGreaterThan(0);
+    for (const finding of gated) {
+      expect(finding.status).not.toBe("satisfied");
+    }
+  });
+
   it("stamps one evaluatedAt across every finding", () => {
     const result = gradeClaudeReadiness(input());
     const moments = new Set(result.findings.map((finding) => finding.evaluatedAt));

--- a/sdk/tests/claude-readiness/submission-checks.test.ts
+++ b/sdk/tests/claude-readiness/submission-checks.test.ts
@@ -1,0 +1,249 @@
+/**
+ * The submission-artifacts lane, whose defining property is what it does
+ * WITHOUT its input.
+ *
+ * Reporting `ready` for a lane a wire-only run cannot evaluate would be the
+ * single most damaging thing this product could do — a submitter would take it
+ * to Anthropic and be rejected on the fields we implied we had checked. So the
+ * no-profile case is tested first and hardest.
+ */
+
+import { describe, expect, it } from "vitest";
+
+import {
+  runClaudeSubmissionChecks,
+  CLAUDE_SUBMISSION_PROFILE_INPUT,
+} from "../../src/claude-readiness/checks/submission.js";
+import {
+  CLAUDE_ATTESTATIONS,
+  parseClaudeSubmissionProfile,
+  type ClaudeSubmissionProfile,
+} from "../../src/claude-readiness/submission-profile.js";
+import { decideLaneStatus } from "../../src/claude-readiness/index.js";
+
+const STAMP = { evaluatedAt: "2026-08-19T00:00:00.000Z" };
+
+function validProfile(
+  overrides: Partial<ClaudeSubmissionProfile> = {},
+): ClaudeSubmissionProfile {
+  return {
+    name: "Acme Orders",
+    tagline: "Look up and track Acme orders",
+    description: "Connects Claude to the Acme order system.",
+    categories: ["Productivity"],
+    slug: "acme-orders",
+    documentationUrl: "https://acme.example/docs",
+    privacyPolicyUrl: "https://acme.example/privacy",
+    supportUrl: "https://acme.example/support",
+    iconUrl: "https://acme.example/icon.png",
+    declaredAuthMode: "oauth-dcr",
+    dataHandling: ["processes-user-data"],
+    screenshots: [1, 2, 3].map((n) => ({
+      url: `https://acme.example/shot-${n}.png`,
+      mimeType: "image/png",
+      widthPx: 1440,
+      heightPx: 900,
+      prompt: `Show me order ${n}`,
+    })),
+    attestations: Object.fromEntries(
+      CLAUDE_ATTESTATIONS.map((attestation) => [attestation, true]),
+    ) as ClaudeSubmissionProfile["attestations"],
+    ...overrides,
+  };
+}
+
+function byId(findings: ReturnType<typeof runClaudeSubmissionChecks>, id: string) {
+  return findings.find((finding) => finding.id === id)!;
+}
+
+describe("with no submission profile", () => {
+  const findings = runClaudeSubmissionChecks({}, STAMP);
+
+  it("evaluates nothing rather than inferring", () => {
+    expect(
+      findings.every((finding) => finding.status === "not-evaluated"),
+    ).toBe(true);
+  });
+
+  it("leaves the lane incomplete, never ready", () => {
+    expect(decideLaneStatus(findings)).toBe("incomplete");
+  });
+
+  it("names the input that would close the gap", () => {
+    for (const finding of findings) {
+      expect(finding.details).toMatchObject({
+        missingInput: CLAUDE_SUBMISSION_PROFILE_INPUT,
+      });
+    }
+  });
+
+  it("says explicitly that serverInfo.name is not the listing name", () => {
+    expect(findings[0].notEvaluatedReason).toMatch(/serverInfo\.name/);
+  });
+
+  it("distinguishes a malformed profile from an absent one", () => {
+    const malformed = runClaudeSubmissionChecks(
+      { profileIssues: ["tagline: String must contain at most 55 character(s)"] },
+      STAMP,
+    );
+    expect(malformed[0].notEvaluatedReason).toMatch(/did not validate/);
+    expect(malformed[0].notEvaluatedReason).toMatch(/tagline/);
+  });
+});
+
+describe("with a valid profile", () => {
+  it("marks the deterministic requirements satisfied", () => {
+    const findings = runClaudeSubmissionChecks(
+      { profile: validProfile(), observedAuthMode: "oauth-dcr" },
+      STAMP,
+    );
+    expect(decideLaneStatus(findings)).toBe("ready");
+  });
+
+  it("keeps quality and ownership as manual review with declared provenance", () => {
+    const finding = byId(
+      runClaudeSubmissionChecks({ profile: validProfile() }, STAMP),
+      "claude.submission.artifact-quality",
+    );
+    // `declared` is what stops a reader taking "the submitter said so" for
+    // "we verified it".
+    expect(finding.class).toBe("manual-review");
+    expect(finding.provenance).toBe("declared");
+    expect(finding.status).toBe("informational");
+  });
+});
+
+describe("screenshots", () => {
+  it("rejects a non-PNG", () => {
+    const profile = validProfile();
+    profile.screenshots[0].mimeType = "image/jpeg";
+    expect(
+      byId(runClaudeSubmissionChecks({ profile }, STAMP), "claude.submission.screenshots")
+        .status,
+    ).toBe("violated");
+  });
+
+  it("rejects one narrower than the minimum", () => {
+    const profile = validProfile();
+    profile.screenshots[1].widthPx = 800;
+    const finding = byId(
+      runClaudeSubmissionChecks({ profile }, STAMP),
+      "claude.submission.screenshots",
+    );
+    expect(finding.status).toBe("violated");
+    expect(finding.details).toMatchObject({ tooNarrow: [{ widthPx: 800 }] });
+  });
+
+  it("tolerates a charset parameter on the mime type", () => {
+    const profile = validProfile();
+    profile.screenshots[0].mimeType = "image/png; charset=binary";
+    expect(
+      byId(runClaudeSubmissionChecks({ profile }, STAMP), "claude.submission.screenshots")
+        .status,
+    ).toBe("satisfied");
+  });
+});
+
+describe("attestations", () => {
+  it("tells an unanswered attestation apart from a declined one", () => {
+    const profile = validProfile();
+    delete (profile.attestations as Record<string, boolean>)
+      .respondsToSecurityReports;
+    profile.attestations.noProhibitedContent = false;
+
+    const finding = byId(
+      runClaudeSubmissionChecks({ profile }, STAMP),
+      "claude.submission.attestations",
+    );
+    expect(finding.status).toBe("violated");
+    expect(finding.details).toMatchObject({
+      unanswered: ["respondsToSecurityReports"],
+      declined: ["noProhibitedContent"],
+    });
+    expect(finding.remediation).toMatch(/unanswered and some are declined/);
+  });
+});
+
+describe("the declared auth mode", () => {
+  it("is left unchallenged when the run could not observe one", () => {
+    const finding = byId(
+      runClaudeSubmissionChecks({ profile: validProfile() }, STAMP),
+      "claude.submission.declared-auth-mode",
+    );
+    expect(finding.status).toBe("not-evaluated");
+  });
+
+  it("fails on a positive contradiction", () => {
+    const finding = byId(
+      runClaudeSubmissionChecks(
+        { profile: validProfile({ declaredAuthMode: "authless" }), observedAuthMode: "oauth-dcr" },
+        STAMP,
+      ),
+      "claude.submission.declared-auth-mode",
+    );
+    expect(finding.status).toBe("violated");
+  });
+
+  it("does not punish a truthful static-header declaration", () => {
+    // A static-header server is indistinguishable from an authless one on the
+    // wire; failing this would penalise an honest submitter for our blind spot.
+    const finding = byId(
+      runClaudeSubmissionChecks(
+        {
+          profile: validProfile({ declaredAuthMode: "static-header" }),
+          observedAuthMode: "authless",
+        },
+        STAMP,
+      ),
+      "claude.submission.declared-auth-mode",
+    );
+    expect(finding.status).toBe("satisfied");
+  });
+});
+
+describe("the profile schema", () => {
+  it("accepts a valid profile", () => {
+    expect(parseClaudeSubmissionProfile(validProfile()).profile).toBeDefined();
+  });
+
+  it("reports each issue with its field path", () => {
+    const { profile, issues } = parseClaudeSubmissionProfile({
+      ...validProfile(),
+      tagline: "x".repeat(56),
+      documentationUrl: "http://acme.example/docs",
+      categories: [],
+    });
+    expect(profile).toBeUndefined();
+    expect(issues.join("\n")).toMatch(/tagline/);
+    expect(issues.join("\n")).toMatch(/documentationUrl.*https/s);
+    expect(issues.join("\n")).toMatch(/categories/);
+  });
+
+  it("requires https on every listing link", () => {
+    expect(
+      parseClaudeSubmissionProfile(
+        validProfile({ privacyPolicyUrl: "http://acme.example/privacy" }),
+      ).profile,
+    ).toBeUndefined();
+  });
+
+  it("bounds the screenshot count on both sides", () => {
+    const profile = validProfile();
+    expect(
+      parseClaudeSubmissionProfile({ ...profile, screenshots: profile.screenshots.slice(0, 2) })
+        .profile,
+    ).toBeUndefined();
+    expect(
+      parseClaudeSubmissionProfile({
+        ...profile,
+        screenshots: [...profile.screenshots, ...profile.screenshots],
+      }).profile,
+    ).toBeUndefined();
+  });
+
+  it("rejects a slug that is not kebab-case", () => {
+    expect(
+      parseClaudeSubmissionProfile(validProfile({ slug: "Acme Orders" })).profile,
+    ).toBeUndefined();
+  });
+});

--- a/sdk/tests/claude-readiness/tool-checks.test.ts
+++ b/sdk/tests/claude-readiness/tool-checks.test.ts
@@ -96,6 +96,24 @@ describe("titles", () => {
     }
   });
 
+  it("prefers the top-level title over the annotation, per MCP precedence", () => {
+    expect(
+      statusOf(
+        runClaudeToolChecks(
+          [
+            tool({
+              name: "t",
+              title: "Top level",
+              annotations: { title: "   ", readOnlyHint: true },
+            }),
+          ],
+          STAMP,
+        ),
+        "claude.tools.title-present",
+      ),
+    ).toBe("satisfied");
+  });
+
   it("treats a whitespace-only title as absent", () => {
     expect(
       statusOf(
@@ -297,6 +315,32 @@ describe("the catch-all rule fails only on demonstrable verbs", () => {
     expect(statusOf(findings, "claude.tools.no-catch-all-read-write")).toBe(
       "violated",
     );
+  });
+
+  it("ignores a verb that is not at the start of the token", () => {
+    // The paired half of the rule above: `getUser` matches because the verb
+    // opens the token, so `userGet` must not.
+    expect(
+      statusOf(
+        runClaudeToolChecks(
+          [
+            tool({
+              name: "records",
+              title: "Records",
+              annotations: { readOnlyHint: true },
+              inputSchema: {
+                type: "object",
+                properties: {
+                  op: { type: "string", enum: ["userGet", "softDelete"] },
+                },
+              },
+            }),
+          ],
+          STAMP,
+        ),
+        "claude.tools.no-catch-all-read-write",
+      ),
+    ).toBe("satisfied");
   });
 
   it("ignores a schema with no properties at all", () => {

--- a/sdk/tests/claude-readiness/tool-checks.test.ts
+++ b/sdk/tests/claude-readiness/tool-checks.test.ts
@@ -39,27 +39,21 @@ describe("a well-formed tool list", () => {
   });
 });
 
-describe("an absent or empty tool list", () => {
-  it("is not-applicable rather than a clean pass", () => {
-    // Five satisfied requirements over an empty list would be five statements
-    // about nothing.
-    for (const findings of [
-      runClaudeToolChecks([], STAMP),
-      runClaudeToolChecks(undefined, STAMP),
-    ]) {
-      expect(
-        findings.every((finding) => finding.status === "not-applicable"),
-      ).toBe(true);
-    }
+describe("an absent tool list is not an empty one", () => {
+  it("treats a server with no tools as inapplicable", () => {
+    // Nothing here can violate a tool requirement, and five satisfied
+    // requirements over an empty list would be five statements about nothing.
+    const findings = runClaudeToolChecks([], STAMP);
+    expect(findings.every((f) => f.status === "not-applicable")).toBe(true);
+    expect(findings[0].notEvaluatedReason).toMatch(/advertises no tools/);
   });
 
-  it("says which of the two situations it was in", () => {
-    expect(runClaudeToolChecks([], STAMP)[0].notEvaluatedReason).toMatch(
-      /advertises no tools/,
-    );
-    expect(runClaudeToolChecks(undefined, STAMP)[0].notEvaluatedReason).toMatch(
-      /no tool listing was captured/,
-    );
+  it("treats an uncaptured listing as an untested obligation", () => {
+    // Collapsing this into "not applicable" would claim we established
+    // something we never looked at, and a lane would read clean on a gap.
+    const findings = runClaudeToolChecks(undefined, STAMP);
+    expect(findings.every((f) => f.status === "not-evaluated")).toBe(true);
+    expect(findings[0].notEvaluatedReason).toMatch(/no tool listing was captured/);
   });
 });
 

--- a/sdk/tests/claude-readiness/tool-checks.test.ts
+++ b/sdk/tests/claude-readiness/tool-checks.test.ts
@@ -1,0 +1,363 @@
+/**
+ * Tool checks, with the false-positive guards weighted as heavily as the
+ * detections.
+ *
+ * The catch-all rule is the one that can do real damage: a hard failure says
+ * "redesign your API", and saying that on a hunch is worse than missing a
+ * case. So the demonstrable-verbs tests come in pairs — the enum that proves
+ * it, and the near-miss that must NOT.
+ */
+
+import type { Tool } from "@modelcontextprotocol/client";
+import { describe, expect, it } from "vitest";
+
+import { runClaudeToolChecks } from "../../src/claude-readiness/checks/tools.js";
+
+const STAMP = { evaluatedAt: "2026-08-19T00:00:00.000Z" };
+
+function tool(overrides: Partial<Tool> & { name: string }): Tool {
+  return {
+    inputSchema: { type: "object", properties: {} },
+    ...overrides,
+  } as Tool;
+}
+
+function statusOf(findings: ReturnType<typeof runClaudeToolChecks>, id: string) {
+  return findings.find((finding) => finding.id === id)?.status;
+}
+
+const WELL_FORMED = tool({
+  name: "list_orders",
+  title: "List orders",
+  annotations: { readOnlyHint: true },
+});
+
+describe("a well-formed tool list", () => {
+  it("satisfies every deterministic tool requirement", () => {
+    const findings = runClaudeToolChecks([WELL_FORMED], STAMP);
+    expect(findings.every((finding) => finding.status === "satisfied")).toBe(true);
+  });
+});
+
+describe("an absent or empty tool list", () => {
+  it("is not-applicable rather than a clean pass", () => {
+    // Five satisfied requirements over an empty list would be five statements
+    // about nothing.
+    for (const findings of [
+      runClaudeToolChecks([], STAMP),
+      runClaudeToolChecks(undefined, STAMP),
+    ]) {
+      expect(
+        findings.every((finding) => finding.status === "not-applicable"),
+      ).toBe(true);
+    }
+  });
+
+  it("says which of the two situations it was in", () => {
+    expect(runClaudeToolChecks([], STAMP)[0].notEvaluatedReason).toMatch(
+      /advertises no tools/,
+    );
+    expect(runClaudeToolChecks(undefined, STAMP)[0].notEvaluatedReason).toMatch(
+      /no tool listing was captured/,
+    );
+  });
+});
+
+describe("name length", () => {
+  it("fails a name past 64 characters and names it", () => {
+    const findings = runClaudeToolChecks(
+      [tool({ ...WELL_FORMED, name: "a".repeat(65) })],
+      STAMP,
+    );
+    const finding = findings.find((f) => f.id === "claude.tools.name-length")!;
+    expect(finding.status).toBe("violated");
+    expect((finding.details as { tools: string[] }).tools[0]).toHaveLength(65);
+  });
+
+  it("accepts exactly 64", () => {
+    expect(
+      statusOf(
+        runClaudeToolChecks(
+          [tool({ ...WELL_FORMED, name: "a".repeat(64) })],
+          STAMP,
+        ),
+        "claude.tools.name-length",
+      ),
+    ).toBe("satisfied");
+  });
+});
+
+describe("titles", () => {
+  it("accepts a title on the tool or on its annotations", () => {
+    for (const candidate of [
+      tool({ name: "t", title: "T", annotations: { readOnlyHint: true } }),
+      tool({ name: "t", annotations: { title: "T", readOnlyHint: true } }),
+    ]) {
+      expect(
+        statusOf(
+          runClaudeToolChecks([candidate], STAMP),
+          "claude.tools.title-present",
+        ),
+      ).toBe("satisfied");
+    }
+  });
+
+  it("treats a whitespace-only title as absent", () => {
+    expect(
+      statusOf(
+        runClaudeToolChecks(
+          [tool({ name: "t", title: "   ", annotations: { readOnlyHint: true } })],
+          STAMP,
+        ),
+        "claude.tools.title-present",
+      ),
+    ).toBe("violated");
+  });
+});
+
+describe("behavior hints", () => {
+  it("requires at least one hint", () => {
+    expect(
+      statusOf(
+        runClaudeToolChecks([tool({ name: "t", title: "T" })], STAMP),
+        "claude.tools.behavior-hints-present",
+      ),
+    ).toBe("violated");
+  });
+
+  it("accepts destructiveHint alone", () => {
+    expect(
+      statusOf(
+        runClaudeToolChecks(
+          [tool({ name: "t", title: "T", annotations: { destructiveHint: true } })],
+          STAMP,
+        ),
+        "claude.tools.behavior-hints-present",
+      ),
+    ).toBe("satisfied");
+  });
+
+  it("flags a tool that claims to be both read-only and destructive", () => {
+    const findings = runClaudeToolChecks(
+      [
+        tool({
+          name: "t",
+          title: "T",
+          annotations: { readOnlyHint: true, destructiveHint: true },
+        }),
+      ],
+      STAMP,
+    );
+    // Presence is satisfied — the hints ARE there — and consistency is not.
+    // Collapsing the two would let a contradiction pass as "annotated".
+    expect(statusOf(findings, "claude.tools.behavior-hints-present")).toBe(
+      "satisfied",
+    );
+    expect(statusOf(findings, "claude.tools.behavior-hints-consistent")).toBe(
+      "violated",
+    );
+  });
+
+  it("does not flag readOnlyHint:true with destructiveHint:false", () => {
+    expect(
+      statusOf(
+        runClaudeToolChecks(
+          [
+            tool({
+              name: "t",
+              title: "T",
+              annotations: { readOnlyHint: true, destructiveHint: false },
+            }),
+          ],
+          STAMP,
+        ),
+        "claude.tools.behavior-hints-consistent",
+      ),
+    ).toBe("satisfied");
+  });
+});
+
+describe("the catch-all rule fails only on demonstrable verbs", () => {
+  it("fails an enum that contains both a safe and an unsafe verb", () => {
+    const findings = runClaudeToolChecks(
+      [
+        tool({
+          name: "records",
+          title: "Records",
+          annotations: { readOnlyHint: false },
+          inputSchema: {
+            type: "object",
+            properties: {
+              action: { type: "string", enum: ["list", "get", "delete"] },
+            },
+          },
+        }),
+      ],
+      STAMP,
+    );
+    const finding = findings.find(
+      (f) => f.id === "claude.tools.no-catch-all-read-write",
+    )!;
+    expect(finding.status).toBe("violated");
+    expect(finding.details).toMatchObject({
+      tools: [{ name: "records", parameter: "action" }],
+    });
+  });
+
+  it("does NOT fail an enum of safe verbs only", () => {
+    expect(
+      statusOf(
+        runClaudeToolChecks(
+          [
+            tool({
+              name: "search",
+              title: "Search",
+              annotations: { readOnlyHint: true },
+              inputSchema: {
+                type: "object",
+                properties: {
+                  mode: { type: "string", enum: ["list", "get", "search"] },
+                },
+              },
+            }),
+          ],
+          STAMP,
+        ),
+        "claude.tools.no-catch-all-read-write",
+      ),
+    ).toBe("satisfied");
+  });
+
+  it("does NOT fail a free-string operation parameter — that is an advisory", () => {
+    const findings = runClaudeToolChecks(
+      [
+        tool({
+          name: "call",
+          title: "Call",
+          annotations: { readOnlyHint: false },
+          inputSchema: {
+            type: "object",
+            properties: { method: { type: "string" } },
+          },
+        }),
+      ],
+      STAMP,
+    );
+    // The hard rule stays clean: nothing DEMONSTRATED that this does both.
+    expect(statusOf(findings, "claude.tools.no-catch-all-read-write")).toBe(
+      "satisfied",
+    );
+    const advisory = findings.find(
+      (f) => f.id === "claude.tools.free-string-operation-parameter",
+    )!;
+    expect(advisory.status).toBe("violated");
+    // …and the advisory can never fail a lane, because it is not dispositive.
+    expect(advisory.class).toBe("recommended");
+    expect(advisory.lane).toBe("experience-insights");
+  });
+
+  it("does not mistake ordinary field names for verbs", () => {
+    // `budget` starts with none of the verbs; `deleted_at` and `getaway` are
+    // the shapes a sloppy substring match would flag.
+    const findings = runClaudeToolChecks(
+      [
+        tool({
+          name: "report",
+          title: "Report",
+          annotations: { readOnlyHint: true },
+          inputSchema: {
+            type: "object",
+            properties: {
+              scope: {
+                type: "string",
+                enum: ["budget", "deleted_at", "getaway", "posts"],
+              },
+            },
+          },
+        }),
+      ],
+      STAMP,
+    );
+    expect(statusOf(findings, "claude.tools.no-catch-all-read-write")).toBe(
+      "satisfied",
+    );
+  });
+
+  it("matches camelCase verbs at the start only", () => {
+    const findings = runClaudeToolChecks(
+      [
+        tool({
+          name: "records",
+          title: "Records",
+          annotations: { readOnlyHint: false },
+          inputSchema: {
+            type: "object",
+            properties: {
+              op: { type: "string", enum: ["getUser", "deleteUser"] },
+            },
+          },
+        }),
+      ],
+      STAMP,
+    );
+    expect(statusOf(findings, "claude.tools.no-catch-all-read-write")).toBe(
+      "violated",
+    );
+  });
+
+  it("ignores a schema with no properties at all", () => {
+    expect(
+      statusOf(
+        runClaudeToolChecks(
+          [
+            tool({
+              name: "ping",
+              title: "Ping",
+              annotations: { readOnlyHint: true },
+              inputSchema: { type: "object" },
+            }),
+          ],
+          STAMP,
+        ),
+        "claude.tools.no-catch-all-read-write",
+      ),
+    ).toBe("satisfied");
+  });
+
+  it("does not flag a constrained enum operation parameter as free-string", () => {
+    expect(
+      statusOf(
+        runClaudeToolChecks(
+          [
+            tool({
+              name: "search",
+              title: "Search",
+              annotations: { readOnlyHint: true },
+              inputSchema: {
+                type: "object",
+                properties: {
+                  method: { type: "string", enum: ["list", "search"] },
+                },
+              },
+            }),
+          ],
+          STAMP,
+        ),
+        "claude.tools.free-string-operation-parameter",
+      ),
+    ).toBe("satisfied");
+  });
+});
+
+describe("every finding is auditable", () => {
+  it("carries a source citation, provenance and an engine version", () => {
+    for (const finding of runClaudeToolChecks([WELL_FORMED], STAMP)) {
+      expect(finding.source.page).toBeTruthy();
+      expect(finding.source.section).toBeTruthy();
+      expect(finding.provenance).toBe("static");
+      expect(finding.intrusiveness).toBe("passive");
+      expect(finding.engineVersion).toBeTruthy();
+      expect(finding.evaluatedAt).toBe(STAMP.evaluatedAt);
+    }
+  });
+});

--- a/sdk/tests/oauth-node-entry.test.ts
+++ b/sdk/tests/oauth-node-entry.test.ts
@@ -38,11 +38,19 @@ describe("@mcpjam/sdk/oauth/node entry", () => {
     );
   });
 
+  it("re-exports the streaming transport from its own module, not a copy", async () => {
+    const streaming = await import("../src/oauth/pinned-stream-fetch.js");
+    expect(oauthNode.createPinnedStreamingFetch).toBe(
+      streaming.createPinnedStreamingFetch
+    );
+  });
+
   it("exposes nothing beyond the documented surface", () => {
     expect(Object.keys(oauthNode).sort()).toEqual([
       "OAuthOutboundUrlBlockedError",
       "OAuthProxyError",
       "assertOutboundOAuthUrlAllowed",
+      "createPinnedStreamingFetch",
       "executeDebugOAuthProxy",
       "executeOAuthProxy",
       "fetchOAuthMetadata",
@@ -83,6 +91,10 @@ describe("@mcpjam/sdk/oauth/node entry", () => {
       "node:http",
       "node:https",
       "node:net",
+      // `node:zlib` is the streaming transport undoing `content-encoding`, so
+      // its byte cap counts DECOMPRESSED bytes and a compressed bomb is
+      // measured at the size it will actually occupy.
+      "node:zlib",
     ]);
   });
 });

--- a/sdk/tests/pinned-stream-fetch.test.ts
+++ b/sdk/tests/pinned-stream-fetch.test.ts
@@ -1,0 +1,390 @@
+/**
+ * The streaming pinned transport, driven against REAL sockets.
+ *
+ * These are not mock tests on purpose. The property under test is what the
+ * socket actually connects to, and the failure this transport exists to
+ * prevent — a target answering `302 Location: http://169.254.169.254/` and
+ * having that hop dialled — is invisible to a test that stubs the dial. So a
+ * real `http.Server` on loopback plays the target, and the assertions are
+ * about which requests it did and did not receive.
+ *
+ * Loopback is reachable here only because `allowLoopback: true` is passed;
+ * every test that matters re-proves that the allowance belongs to the CHAIN
+ * and does not extend to any other private range.
+ */
+
+import http from "node:http";
+import type { AddressInfo } from "node:net";
+import { afterEach, describe, expect, it } from "vitest";
+
+import { createPinnedStreamingFetch } from "../src/oauth/pinned-stream-fetch.js";
+import { OAuthProxyError } from "../src/oauth-proxy-error.js";
+
+interface Recorded {
+  url: string;
+  method: string;
+  headers: http.IncomingHttpHeaders;
+}
+
+const servers: http.Server[] = [];
+
+async function startServer(
+  handler: (req: http.IncomingMessage, res: http.ServerResponse) => void,
+): Promise<{ origin: string; received: Recorded[] }> {
+  const received: Recorded[] = [];
+  const server = http.createServer((req, res) => {
+    received.push({
+      url: req.url ?? "",
+      method: req.method ?? "",
+      headers: req.headers,
+    });
+    handler(req, res);
+  });
+  servers.push(server);
+  await new Promise<void>((resolve) => server.listen(0, "127.0.0.1", resolve));
+  const { port } = server.address() as AddressInfo;
+  return { origin: `http://127.0.0.1:${port}`, received };
+}
+
+afterEach(async () => {
+  await Promise.all(
+    servers.splice(0).map(
+      (server) =>
+        new Promise<void>((resolve) => {
+          server.closeAllConnections?.();
+          server.close(() => resolve());
+        }),
+    ),
+  );
+});
+
+function loopbackFetch(
+  options: Parameters<typeof createPinnedStreamingFetch>[0] = {},
+) {
+  return createPinnedStreamingFetch({ allowLoopback: true, ...options });
+}
+
+describe("the happy path still behaves like fetch", () => {
+  it("returns status, headers and a readable body", async () => {
+    const { origin } = await startServer((_req, res) => {
+      res.writeHead(200, { "content-type": "application/json" });
+      res.end(JSON.stringify({ ok: true }));
+    });
+
+    const response = await loopbackFetch()(`${origin}/mcp`);
+
+    expect(response.status).toBe(200);
+    expect(response.headers.get("content-type")).toBe("application/json");
+    await expect(response.json()).resolves.toEqual({ ok: true });
+  });
+
+  it("sends the method, headers and body it was given", async () => {
+    const { origin, received } = await startServer((_req, res) => {
+      res.writeHead(202);
+      res.end();
+    });
+
+    await loopbackFetch()(`${origin}/mcp`, {
+      method: "POST",
+      headers: { authorization: "Bearer t", "content-type": "application/json" },
+      body: '{"jsonrpc":"2.0"}',
+    });
+
+    expect(received[0].method).toBe("POST");
+    expect(received[0].headers.authorization).toBe("Bearer t");
+  });
+
+  it("reports the URL the chain ENDED at, not the one it started from", async () => {
+    const target = await startServer((_req, res) => {
+      res.writeHead(200);
+      res.end("done");
+    });
+    const { origin } = await startServer((_req, res) => {
+      res.writeHead(302, { location: `${target.origin}/final` });
+      res.end();
+    });
+
+    const response = await loopbackFetch()(`${origin}/start`);
+
+    expect(response.url).toBe(`${target.origin}/final`);
+  });
+});
+
+describe("streaming — the reason this transport exists", () => {
+  it("delivers SSE events as they are written, without waiting for the end", async () => {
+    let close: (() => void) | undefined;
+    const { origin } = await startServer((_req, res) => {
+      res.writeHead(200, {
+        "content-type": "text/event-stream",
+        "cache-control": "no-cache",
+      });
+      res.write("data: first\n\n");
+      // The second event is written only after the reader has consumed the
+      // first — a buffering transport can never satisfy this ordering.
+      close = () => {
+        res.write("data: second\n\n");
+        res.end();
+      };
+    });
+
+    const response = await loopbackFetch()(`${origin}/sse`, {
+      headers: { accept: "text/event-stream" },
+    });
+    const reader = response.body!.getReader();
+    const decoder = new TextDecoder();
+
+    const first = await reader.read();
+    expect(decoder.decode(first.value)).toContain("data: first");
+
+    close!();
+
+    let rest = "";
+    for (;;) {
+      const chunk = await reader.read();
+      if (chunk.done) break;
+      rest += decoder.decode(chunk.value);
+    }
+    expect(rest).toContain("data: second");
+  });
+});
+
+describe("a redirect is re-validated at the hop that names it", () => {
+  it("refuses a redirect to a link-local address and never dials it", async () => {
+    const { origin, received } = await startServer((_req, res) => {
+      res.writeHead(302, { location: "https://169.254.169.254/latest/meta-data/" });
+      res.end();
+    });
+
+    await expect(loopbackFetch()(`${origin}/start`)).rejects.toThrow(
+      /private\/reserved/i,
+    );
+    // The target answered once; the metadata hop was refused before a socket
+    // to it existed.
+    expect(received).toHaveLength(1);
+  });
+
+  it("refuses a plaintext hop that is not loopback, even on a loopback chain", async () => {
+    const { origin } = await startServer((_req, res) => {
+      res.writeHead(302, { location: "http://169.254.169.254/" });
+      res.end();
+    });
+
+    await expect(loopbackFetch()(`${origin}/start`)).rejects.toThrow(
+      /plaintext connection/i,
+    );
+  });
+
+  it("refuses a loopback TARGET outright without the opt-in", async () => {
+    const { origin } = await startServer((_req, res) => {
+      res.writeHead(200);
+      res.end();
+    });
+
+    await expect(
+      createPinnedStreamingFetch()(`${origin}/mcp`),
+    ).rejects.toThrow(/loopback/i);
+  });
+});
+
+describe("credentials do not cross an origin boundary", () => {
+  it("drops Authorization when the redirect changes origin", async () => {
+    const target = await startServer((_req, res) => {
+      res.writeHead(200);
+      res.end("ok");
+    });
+    const { origin } = await startServer((_req, res) => {
+      res.writeHead(302, { location: `${target.origin}/final` });
+      res.end();
+    });
+
+    await loopbackFetch()(`${origin}/start`, {
+      headers: { authorization: "Bearer secret", cookie: "s=1" },
+    });
+
+    expect(target.received[0].headers.authorization).toBeUndefined();
+    expect(target.received[0].headers.cookie).toBeUndefined();
+  });
+
+  it("keeps Authorization on a same-origin redirect", async () => {
+    const { origin, received } = await startServer((req, res) => {
+      if (req.url === "/start") {
+        res.writeHead(302, { location: "/final" });
+        res.end();
+        return;
+      }
+      res.writeHead(200);
+      res.end("ok");
+    });
+
+    await loopbackFetch()(`${origin}/start`, {
+      headers: { authorization: "Bearer secret" },
+    });
+
+    expect(received[1].headers.authorization).toBe("Bearer secret");
+  });
+});
+
+describe("Fetch's method rewrite is reproduced exactly", () => {
+  it("turns a POST into a GET on 303 and drops the body", async () => {
+    const { origin, received } = await startServer((req, res) => {
+      if (req.url === "/start") {
+        res.writeHead(303, { location: "/final" });
+        res.end();
+        return;
+      }
+      res.writeHead(200);
+      res.end("ok");
+    });
+
+    await loopbackFetch()(`${origin}/start`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: "{}",
+    });
+
+    expect(received[1].method).toBe("GET");
+    expect(received[1].headers["content-type"]).toBeUndefined();
+  });
+
+  it("preserves the method on 307", async () => {
+    const { origin, received } = await startServer((req, res) => {
+      if (req.url === "/start") {
+        res.writeHead(307, { location: "/final" });
+        res.end();
+        return;
+      }
+      res.writeHead(200);
+      res.end("ok");
+    });
+
+    await loopbackFetch()(`${origin}/start`, { method: "POST", body: "{}" });
+
+    expect(received[1].method).toBe("POST");
+  });
+});
+
+describe("the caller's redirect mode is honored", () => {
+  it("hands back the 3xx itself under redirect: manual", async () => {
+    const { origin, received } = await startServer((_req, res) => {
+      res.writeHead(302, { location: "/final" });
+      res.end();
+    });
+
+    const response = await loopbackFetch()(`${origin}/start`, {
+      redirect: "manual",
+    });
+
+    expect(response.status).toBe(302);
+    expect(response.headers.get("location")).toBe("/final");
+    expect(received).toHaveLength(1);
+  });
+
+  it("fails the request under redirect: error", async () => {
+    const { origin } = await startServer((_req, res) => {
+      res.writeHead(302, { location: "/final" });
+      res.end();
+    });
+
+    await expect(
+      loopbackFetch()(`${origin}/start`, { redirect: "error" }),
+    ).rejects.toThrow(/redirect/i);
+  });
+});
+
+describe("the bounds", () => {
+  it("refuses a chain longer than the redirect ceiling", async () => {
+    const { origin } = await startServer((_req, res) => {
+      res.writeHead(302, { location: "/again" });
+      res.end();
+    });
+
+    await expect(
+      loopbackFetch({ maxRedirects: 2 })(`${origin}/start`),
+    ).rejects.toThrow(/Too many redirects/i);
+  });
+
+  it("errors the body stream once the byte cap is passed", async () => {
+    const { origin } = await startServer((_req, res) => {
+      res.writeHead(200, { "content-type": "application/octet-stream" });
+      res.write(Buffer.alloc(64 * 1024, 1));
+      res.write(Buffer.alloc(64 * 1024, 1));
+      res.end();
+    });
+
+    const response = await loopbackFetch({ maxResponseBytes: 1024 })(
+      `${origin}/big`,
+    );
+    await expect(response.text()).rejects.toThrow(/byte cap/i);
+  });
+
+  it("counts the cap AFTER decompression, so a compressed bomb is measured honestly", async () => {
+    const { gzipSync } = await import("node:zlib");
+    // ~1 MiB of zeroes compresses to a couple of KiB; a cap applied to the
+    // wire bytes would let it straight through.
+    const payload = gzipSync(Buffer.alloc(1024 * 1024, 0));
+    const { origin } = await startServer((_req, res) => {
+      res.writeHead(200, { "content-encoding": "gzip" });
+      res.end(payload);
+    });
+
+    const response = await loopbackFetch({ maxResponseBytes: 64 * 1024 })(
+      `${origin}/bomb`,
+      { headers: { "accept-encoding": "gzip" } },
+    );
+    await expect(response.text()).rejects.toThrow(/byte cap/i);
+  });
+
+  it("gives up on a target that never sends headers", async () => {
+    const { origin } = await startServer(() => {
+      // Accept the connection and answer nothing, ever.
+    });
+
+    await expect(
+      loopbackFetch({ chainTimeoutMs: 150 })(`${origin}/hang`),
+    ).rejects.toBeInstanceOf(OAuthProxyError);
+  });
+
+  it("does NOT put an established stream on the chain deadline", async () => {
+    const { origin } = await startServer((_req, res) => {
+      res.writeHead(200, { "content-type": "text/event-stream" });
+      res.write("data: hello\n\n");
+      setTimeout(() => {
+        res.write("data: still here\n\n");
+        res.end();
+      }, 250);
+    });
+
+    // The chain deadline is shorter than the stream's lifetime. A transport
+    // that bounded the body with it would drop a conforming SSE server.
+    const response = await loopbackFetch({ chainTimeoutMs: 100 })(`${origin}/sse`);
+    await expect(response.text()).resolves.toContain("still here");
+  });
+
+  it("kills a stream that has stalled past the idle bound", async () => {
+    const { origin } = await startServer((_req, res) => {
+      res.writeHead(200, { "content-type": "text/event-stream" });
+      res.write("data: hello\n\n");
+      // …and then nothing, forever.
+    });
+
+    const response = await loopbackFetch({ bodyIdleTimeoutMs: 150 })(
+      `${origin}/sse`,
+    );
+    await expect(response.text()).rejects.toThrow(/no data/i);
+  });
+});
+
+describe("request shapes it refuses rather than misrepresents", () => {
+  it("refuses a Request carrying a body it could not replay across a redirect", async () => {
+    const { origin } = await startServer((_req, res) => {
+      res.writeHead(200);
+      res.end();
+    });
+
+    const request = new Request(`${origin}/mcp`, {
+      method: "POST",
+      body: "payload",
+    });
+    await expect(loopbackFetch()(request)).rejects.toThrow(/cannot be dialled/i);
+  });
+});

--- a/sdk/tests/pinned-stream-fetch.test.ts
+++ b/sdk/tests/pinned-stream-fetch.test.ts
@@ -292,6 +292,39 @@ describe("the caller's redirect mode is honored", () => {
   });
 });
 
+describe("a method rewrite drops every body header", () => {
+  it("strips content-language and content-location too", async () => {
+    // Fetch's request-body-header list is all five, and `oauth-proxy.ts`'s
+    // `updateRequestForRedirect` strips all five. Leaving two behind sends a
+    // rewritten GET still claiming to describe a body it no longer carries.
+    const { origin, received } = await startServer((req, res) => {
+      if (req.url === "/start") {
+        res.writeHead(303, { location: "/done" });
+        res.end();
+        return;
+      }
+      res.writeHead(200, { "content-type": "application/json" });
+      res.end("{}");
+    });
+
+    await loopbackFetch()(`${origin}/start`, {
+      method: "POST",
+      body: "{}",
+      headers: {
+        "content-type": "application/json",
+        "content-language": "en",
+        "content-location": "/local",
+      },
+    });
+
+    const rewritten = received.at(-1)!;
+    expect(rewritten.method).toBe("GET");
+    expect(rewritten.headers["content-language"]).toBeUndefined();
+    expect(rewritten.headers["content-location"]).toBeUndefined();
+    expect(rewritten.headers["content-type"]).toBeUndefined();
+  });
+});
+
 describe("resources it must not leak", () => {
   it("releases the caller's abort listener when the body is finished", async () => {
     // An MCP transport hands ONE connection-lifetime signal to every request

--- a/sdk/tests/pinned-stream-fetch.test.ts
+++ b/sdk/tests/pinned-stream-fetch.test.ts
@@ -13,6 +13,7 @@
  * and does not extend to any other private range.
  */
 
+import { getEventListeners } from "node:events";
 import http from "node:http";
 import type { AddressInfo } from "node:net";
 import { afterEach, describe, expect, it } from "vitest";
@@ -291,7 +292,115 @@ describe("the caller's redirect mode is honored", () => {
   });
 });
 
+describe("resources it must not leak", () => {
+  it("releases the caller's abort listener when the body is finished", async () => {
+    // An MCP transport hands ONE connection-lifetime signal to every request
+    // it makes. A listener left behind per request is a leak that warns at
+    // eleven and grows for as long as the connection lives.
+    const { origin } = await startServer((_req, res) => {
+      res.writeHead(200, { "content-type": "application/json" });
+      res.end(JSON.stringify({ ok: true }));
+    });
+
+    const controller = new AbortController();
+    const fetchFn = loopbackFetch();
+    for (let i = 0; i < 12; i += 1) {
+      const response = await fetchFn(`${origin}/rpc`, {
+        signal: controller.signal,
+      });
+      await response.text();
+    }
+
+    // One listener would be ordinary; twelve is the leak.
+    expect(getEventListeners(controller.signal, "abort").length).toBe(0);
+  });
+
+  it("releases it for a null-body status too", async () => {
+    const { origin } = await startServer((_req, res) => {
+      res.writeHead(204);
+      res.end();
+    });
+
+    const controller = new AbortController();
+    await loopbackFetch()(`${origin}/nothing`, { signal: controller.signal });
+
+    expect(getEventListeners(controller.signal, "abort").length).toBe(0);
+  });
+
+  it("releases it when the reader cancels a stream it never finished", async () => {
+    const { origin } = await startServer((_req, res) => {
+      res.writeHead(200, { "content-type": "text/event-stream" });
+      res.write("data: one\n\n");
+      // Left open: the caller walks away instead.
+    });
+
+    const controller = new AbortController();
+    const response = await loopbackFetch()(`${origin}/sse`, {
+      signal: controller.signal,
+    });
+    await response.body!.cancel();
+
+    expect(getEventListeners(controller.signal, "abort").length).toBe(0);
+  });
+
+  it("does not buffer a body the consumer has not read", async () => {
+    // Without backpressure the data handler enqueues as fast as the socket
+    // delivers, so the QUEUE decides how much is held rather than the reader.
+    // A consumer that reads one chunk and pauses should leave the rest on the
+    // socket.
+    const chunk = Buffer.alloc(64 * 1024, 7);
+    let written = 0;
+    const { origin } = await startServer((_req, res) => {
+      res.writeHead(200, { "content-type": "application/octet-stream" });
+      const pump = () => {
+        // Write far more than any sane queue would hold.
+        while (written < 200) {
+          written += 1;
+          if (!res.write(chunk)) {
+            res.once("drain", pump);
+            return;
+          }
+        }
+        res.end();
+      };
+      pump();
+    });
+
+    const response = await loopbackFetch()(`${origin}/firehose`);
+    const reader = response.body!.getReader();
+    await reader.read();
+    // Give the socket room to run away if nothing is holding it back.
+    await new Promise((resolve) => setTimeout(resolve, 150));
+    const seen = written;
+    await reader.cancel();
+
+    // The exact number depends on socket buffers; the point is that it is
+    // bounded rather than "all 200 chunks".
+    expect(seen).toBeLessThan(200);
+  });
+});
+
 describe("the bounds", () => {
+  it("allows a chain as long as fetch itself does by default", async () => {
+    // The ceiling exists to stop a loop, not to fail real infrastructure:
+    // apex → www → CDN → tenant routing genuinely reaches six and seven hops,
+    // and every hop is validated either way.
+    let hop = 0;
+    const { origin } = await startServer((_req, res) => {
+      hop += 1;
+      if (hop <= 7) {
+        res.writeHead(302, { location: `/hop-${hop}` });
+        res.end();
+        return;
+      }
+      res.writeHead(200, { "content-type": "application/json" });
+      res.end(JSON.stringify({ arrived: true }));
+    });
+
+    const response = await loopbackFetch()(`${origin}/start`);
+    expect(response.status).toBe(200);
+  });
+
   it("refuses a chain longer than the redirect ceiling", async () => {
     const { origin } = await startServer((_req, res) => {
       res.writeHead(302, { location: "/again" });


### PR DESCRIPTION
Implements the SDK half of the Claude directory-readiness plan (rev 2), plus the SSRF closure that blocks every hosted piece of it.

Readiness is a **composite readiness product, not a fifth scored MCP conformance suite**. Anthropic's directory requirements are a publisher's policy, not the MCP specification, and a server can be flawless MCP and unlistable — or the reverse. Nothing here carries a conformance score or enters `pooledConformanceScore`, and the existing protocol/oauth/apps/host-compat results are **consumed as evidence** rather than re-derived.

## Commits

### `security(conformance)` — dial the real MCP connection through a pinned transport

Hosted conformance runs guarded their raw HTTP probes and then opened their one actual MCP connection through the global `fetch`, following whatever redirects the target returned. The suite documented the hole in a comment rather than closing it, because the existing pinned transport buffers and so can never carry `text/event-stream`.

- `oauth/pinned-dns.ts` extracts resolve-once/classify/pin out of `oauth-proxy.ts` so both transports share one implementation.
- `oauth/pinned-stream-fetch.ts` hands the body back as a live `ReadableStream`. Per hop: scheme check, resolve and pin, redirect ceiling, credentials dropped across origins, Fetch's exact method rewrite, and the caller's `redirect` mode honored so the OAuth suite still sees the 3xx it grades. The chain deadline covers DNS/connect/headers only — an SSE stream is long-lived by design — and a separate idle bound kills a stalled one. The byte cap counts **decompressed** bytes.
- `baseFetch` on the server config and manager options makes that transport the innermost layer of the client manager's fetch chain.
- The protocol suite threads its `fetchFn` in as `baseFetch`; the apps and tasks suites are client-driven and had no seam at all before this.

Also fixes a classification gap the new tests surfaced: the transport's loopback and plaintext refusals were falling through to a plain retryable `Error`, putting a refused target back on a retry schedule.

### `feat` — result model, provenance, and a pinned policy corpus

Five lanes with independent semantics and a finding-class vocabulary that deliberately avoids MUST/SHOULD. Only `required` and `runtime-blocker` findings can decide a lane. Coverage is reported separately from findings, `not-ready` dominates `incomplete` so a gap cannot launder a violation, and the optional lanes cannot move the rollup.

Every finding cites a page, section, and revision. The manifest ships `revision: null` — a fabricated hash would make an unaudited corpus look audited — and `npm run claude-policy:sync` rewrites a generated block from the live pages, with `--check` failing CI on drift.

`kind: "claude-directory-readiness"` and an optional `advisories` field keep `schemaVersion` at 1. JUnit renders advisories as `<properties>` under the lane that raised them: a job that goes red on a heuristic gets `|| true` appended, and then the real findings stop being read too.

### `feat` — submission profile, tool and endpoint checks

`ClaudeSubmissionProfile` is an explicit input. `serverInfo.name` is not the listing name, so without the profile every submission finding is `not-evaluated` and the coverage names the input that closes it. A profile supplied but malformed is reported as that, not as "no input".

The catch-all tool rule fails only on **demonstrable** verbs — an enumerated operation parameter carrying both a safe and an unsafe verb. A free-string `method` is an advisory instead: a hard failure says "redesign your API", and saying that on a hunch is worse than missing a case.

Endpoint checks are runtime blockers. A redirect chain that downgrades mid-way fails even when it ends on HTTPS — anyone on the path can rewrite that hop and choose where the connector ends up.

### `feat` — non-invasive auth discovery checks and badges

Discovery is separate from the checks so every check is a pure function over evidence and structurally cannot dial a target; `fetchFn` is required rather than defaulted.

Rev-2 corrections, each pinned by a named test: a broken `authorization_servers[0]` is a blocker (Claude never falls back, and the report names the healthy later entries it did not try); the PRM resource check is split from the RFC 8707 canonical-form check; `scope` is optional on `insufficient_scope`; a `WWW-Authenticate` on 200 fails only on a succeeded protected operation; a JWT `aud` is evidence, never a verdict.

Classify, don't fail: static-header, authless, custom-connection and preregistered are valid modes a wire-only runner often cannot tell apart, so the auth mode is a badge carrying its own uncertainty. Lazy auth and EMA are badges evaluated in depth only when claimed or detected — an unclaimed, undetected feature reports `not-evaluated`, never `unsupported`.

### `feat` — apps composition and Claude host checks

Modern `_meta.ui.resourceUri` alone is correct; only legacy-only fails. A `text/html;profile=mcp-app` mismatch is a failure. An OpenAI-only widget blocks only when the tool is app-only. `ui.domain` derives from the **exact** entered URL — canonicalizing first would pass a value that fails in production. The 150k threshold is per call, so it has no static verdict. Design-guideline lints are heuristics that label their basis as static markup analysis rather than a rendered observation.

### `feat` — intrusive opt-in gate and the composite run

The gate is SDK-enforced: `resolveClaudeIntrusiveMode` is the only thing that can produce the armed mode the probes require. It refuses unless `enabled` is a literal boolean, a `grantOrigin` is stated, and a step-up probe names both its tool and its scopes. There is no `caller-supplied` grant origin — burning a refresh token from a live user session logs them out of a product they were using.

Two defects the runner tests surfaced, both fixed: the tool checks reported an uncaptured listing as `not-applicable` (identical to a server with genuinely no tools), and the RFC 8707 check was hard-coded unevaluated, making `ready` unreachable.

A healthy connector graded headlessly is `incomplete`, not `ready`, and says which requirements it could not reach.

## Testing

- `npx vitest run --root sdk` — 242 of 243 files pass. `tests/browser-entry-guard.test.ts` fails on `main` as well (it asserts `src/xaa/constants.ts` is in the browser graph and it is not); untouched here.
- New: 188 readiness tests, 20 streaming-transport tests driven against real sockets, 4 `baseFetch` wiring tests, 5 inspector guard tests.
- Inspector: `pinned-fetch`, `hosted-egress-guard`, and the conformance route suites pass.

## Not in this PR

The plan's backend pieces (durable run storage, insights billing) and the hosted routes, CLI and UI surfaces that depend on them. The SDK layer here is what they build on.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019GxvPf8ZDJiBiSnCEHBNbo

---
_Generated by [Claude Code](https://claude.ai/code/session_019GxvPf8ZDJiBiSnCEHBNbo)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit aa9075209b2a9d0367bc6c59605c709e6a0a4f5f. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Pins all MCP and conformance traffic to a streaming, DNS‑pinned transport and lands the Claude directory‑readiness SDK with a pinned policy corpus. Restores undici/fetch parity (redirects/timeouts, header rewrites) and enforces declared check capabilities to prevent silent coverage gaps.

- Transport and inspector
  - Streaming pinned fetch (`createPinnedStreamingFetch` in `@mcpjam/sdk/oauth/node`) with shared DNS/pinning; `MCPClientManager` now accepts `baseFetch` so the one MCP connection is guarded end‑to‑end. The protocol suite threads its `fetchFn` as `baseFetch`.
  - Behavior change: the MCP connection no longer dials via global `fetch` or follows unchecked redirects; per‑hop https/loopback scheme checks, credentials dropped across origins, redirect ceiling restored to fetch parity, and undici‑default chain/idle timeouts. 303 rewrites now drop body headers per spec.
  - Resource handling: real backpressure on the stream bridge; abort listeners released on end/error/cancel; decompressor destroyed on errors; empty redirect traces mean “never reached.” Inspector classifies loopback/plaintext refusals as terminal.
  - Node entry re‑exports the streaming transport; buffering OAuth proxy remains for metadata and counts decompressed bytes toward caps.

- Readiness SDK and policy
  - Result model with lanes, coverage, provenance; no `score`. Only `required`/`runtime-blocker` findings decide a lane; optional lanes cannot move the rollup. Unconsumed findings render as advisories; JUnit nests advisories under `kind: "claude-directory-readiness"`.
  - Evidence and checks: non‑invasive discovery split from pure checks; endpoint, tools, apps, optional‑features, and submission‑artifact checks added. Browser entry exports only rendering‑safe symbols; intrusive probes moved behind `resolveClaudeIntrusiveMode`.
  - Policy/drift: pinned manifest with visible‑text hashing; `claude-policy:sync|check` scripts and a scheduled drift workflow (token scoped to contents: read). Design lints include inline `style` attributes and use a scanner, not regex.
  - New guardrails and fixes: the runner enforces each check’s `requiresCapabilities` (downgrades to `not-evaluated` when missing), apps early‑return coverage includes all lints, step‑up `expectedScopes` are parsed and reported, shared design budgets remove duplicated literals, and `canonicalResourceIndicator` vs `canonicalizeResourceUrl` differences are documented and intentional.

Rollout
- Hosted conformance must pass a guarded `baseFetch` to close the MCP connection hole.
- Add `npm run claude-policy:check` to CI or rely on the scheduled drift workflow.
- Run intrusive probes only via `resolveClaudeIntrusiveMode({ enabled: true, grantOrigin, ... })`; never default‑opt‑in.

<sup>Written for commit 4c391411e0386a84bf85818ea3e2f4ecc9087f1f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/MCPJam/inspector/pull/4120?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

