### PR TITLE
ci: run staging e2e in the pinned Playwright image

### DIFF
--- a/.github/workflows/post-deploy-staging.yml
+++ b/.github/workflows/post-deploy-staging.yml
@@ -78,6 +78,12 @@ jobs:
     # and release.yml polls deploy-staging.yml success as the release gate, so a
     # hard failure here would gate releases. Remove once the suite is promoted.
     continue-on-error: true
+    # Pinned to the same Playwright version as the `@playwright/test` dependency,
+    # matching the `Tests` workflow. The image ships Chromium plus every system
+    # library, so we skip `playwright install --with-deps` — that apt-driven step
+    # was costing 15+ min of variable, sometimes-stalling wall-clock time.
+    # When bumping @playwright/test, bump this tag in lockstep.
+    container: mcr.microsoft.com/playwright:v1.59.1-noble
     # Drives a deployed URL; never launches Electron, so skip its binary download.
     env:
       ELECTRON_SKIP_BINARY_DOWNLOAD: "1"
@@ -93,9 +99,6 @@ jobs:
 
       - name: Install workspace dependencies
         run: npm ci --legacy-peer-deps
-
-      - name: Install Playwright Chromium
-        run: npx playwright install --with-deps chromium
 
       - name: Run Playwright smoke against staging
         # PLAYWRIGHT_BASE_URL makes the config skip the local webServer and drive


### PR DESCRIPTION
## What

The staging post-deploy `e2e` job installed its browser with `npx playwright install --with-deps chromium`. Swap it for the pinned Playwright container image and delete the install step.

## Why

The Chromium download itself takes seconds. `--with-deps` is the expensive half — it switches to root and drives `apt-get` to install Chromium's system libraries. On the Deploy Staging run for #4081 that step sat at **17 minutes**, stalled on the runner's apt mirrorlist, and it is variable run to run.

`test.yml` already solved exactly this. Every job there — including its own `E2E Smoke (Playwright)` job — runs inside `mcr.microsoft.com/playwright:v1.59.1-noble`, with the comment:

> The image ships Chromium + every system library preinstalled, so we skip the `playwright install --with-deps` step entirely — that apt-driven step was costing up to ~7 min of variable, sometimes-stalling wall-clock time.

The staging lane never got the same treatment. This applies it.

## Checks

- Image tag matches the `@playwright/test` version pinned in `package-lock.json` (`1.59.1`), same lockstep rule as `test.yml`.
- `playwright.config.ts` defines only a `chromium` project, so no other browser is needed.
- `PLAYWRIGHT_BASE_URL` makes the config skip the local `webServer` and drive the deployed staging URL, so nothing in the job needs the host runner.
- Workflow YAML parses; `prettier --check` clean.

Expected effect: the job drops from ~18 min to roughly `npm ci` + test time.

## Note for a follow-up

This job is `continue-on-error: true` "during the initial soak", so it has been burning ~18 min of runner time on every push to `main` without being able to fail anything. Worth deciding separately whether to promote it to gating now that it is fast.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit 025f6b4cfa02c79edc8a2791d716238ae75e0e20. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Runs the staging post-deploy e2e job in the pinned Playwright container instead of installing Chromium with `--with-deps`. This removes the apt-driven dependency install that added ~15–17 minutes and introduced variability/stalls.

- Adds `container: mcr.microsoft.com/playwright:v1.59.1-noble`, pinned to `@playwright/test` 1.59.1; bump this tag in lockstep when upgrading.
- Removes the `npx playwright install --with-deps chromium` step; the image includes Chromium and required system libraries.
- No test behavior change: `playwright.config.ts` targets Chromium only and `PLAYWRIGHT_BASE_URL` drives the deployed staging URL.
- Expected runtime: roughly `npm ci` + test time; job remains `continue-on-error: true`.

<sup>Written for commit 025f6b4cfa02c79edc8a2791d716238ae75e0e20. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/MCPJam/inspector/pull/4121?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

