### PR TITLE
docs: Okta SSO & SCIM configuration guide

### DIFF
--- a/docs/docs.json
+++ b/docs/docs.json
@@ -46,6 +46,7 @@
           "installation",
           "hosted/overview",
           "hosted/slack",
+          "hosted/sso",
           "troubleshooting/common-errors",
           "troubleshooting/error-codes",
           "changelog/overview"

--- a/docs/hosted/sso.mdx
+++ b/docs/hosted/sso.mdx
@@ -1,0 +1,150 @@
+---
+title: "Okta SSO & SCIM"
+description: "Sign in to MCPJam with Okta via SAML 2.0, and automate user provisioning and deprovisioning with SCIM"
+icon: "key-round"
+---
+
+<Note>
+Single sign-on and SCIM provisioning are enterprise features, configured per
+organization. Ask us to enable them for yours and we'll send you a setup link —
+or, where it's enabled, use **Settings → Organization → Configure SSO**.
+</Note>
+
+MCPJam supports **SAML 2.0** single sign-on and **SCIM 2.0** user provisioning
+with Okta. Your Okta admin does the setup once, in a guided flow, and after
+that your directory is the source of truth: assigning someone to MCPJam in Okta
+gives them access, and unassigning them takes it away.
+
+Setup takes about 10–15 minutes.
+
+## Before you start
+
+- **An MCPJam organization** on a plan that includes SSO, and a setup link for
+  it. Your MCPJam contact provides one; each link is specific to your
+  organization.
+- **Okta admin access**, enough to add an app integration and configure
+  provisioning.
+- Your email domain **verified** on your MCPJam organization. We do this for
+  you when you're onboarded — it's what lets us route your users to Okta and
+  manage their accounts.
+
+## Part 1 — Single sign-on
+
+<Steps>
+<Step title="Open the setup link and choose Okta">
+The setup portal shows two values for your organization: an **ACS URL** and an
+**SP Entity ID**. Keep this tab open — you'll come back to it in step 4.
+</Step>
+
+<Step title="Add MCPJam in Okta">
+In the Okta Admin Console, go to **Applications → Browse App Catalog**, search
+for **MCPJam**, and add it.
+
+In the app's SAML setup, paste the values from step 1:
+
+| MCPJam setup portal | Okta field |
+| --- | --- |
+| ACS URL | Single Sign-On URL |
+| SP Entity ID | Audience URI (SP Entity ID) |
+</Step>
+
+<Step title="Check the attribute mappings">
+The catalog integration preconfigures the attributes MCPJam needs. Confirm they
+are present:
+
+| Name | Value |
+| --- | --- |
+| `email` | `user.email` |
+| `firstName` | `user.firstName` |
+| `lastName` | `user.lastName` |
+
+Optionally add a `groups` attribute if you want Okta groups to drive MCPJam
+roles.
+</Step>
+
+<Step title="Send Okta's metadata back to MCPJam">
+On the app's **Sign On** tab, copy the **Metadata URL**. Paste it into the
+MCPJam setup portal from step 1 and finish. The connection goes active
+immediately.
+</Step>
+
+<Step title="Assign users and test">
+Assign users or groups to the MCPJam app in Okta. Assigned users can now sign
+in — from the Okta dashboard, or by entering their work email on the MCPJam
+sign-in page, which redirects them to Okta.
+
+Accounts are created automatically on first sign-in, with membership in your
+MCPJam organization. Nobody needs to be invited by hand.
+</Step>
+</Steps>
+
+## Part 2 — Provisioning (SCIM)
+
+SCIM is optional but recommended: it keeps MCPJam in sync with your directory
+and, importantly, **removes access immediately** when someone is offboarded
+rather than when their session happens to expire.
+
+<Steps>
+<Step title="Open the provisioning setup link">
+Choose Okta. The portal shows a **SCIM endpoint** and a **bearer token**.
+</Step>
+
+<Step title="Enable provisioning in Okta">
+In the MCPJam app, open **Provisioning → Configure API Integration**. Paste the
+endpoint and token, then enable:
+
+- **Create Users**
+- **Update User Attributes**
+- **Deactivate Users**
+</Step>
+
+<Step title="Assign users or groups">
+Okta now manages the lifecycle:
+
+- assigning someone provisions their MCPJam account and organization
+  membership;
+- profile changes sync automatically;
+- unassigning or deactivating someone deactivates their MCPJam membership and
+  **revokes their active sessions immediately**.
+</Step>
+</Steps>
+
+## Roles
+
+MCPJam organizations separate **owner**, **admin**, and **member** access.
+Admins manage members and organization settings; members work in the product
+without administrative access. Owners additionally control ownership and
+billing.
+
+Users signing in through Okta are members by default. Map an Okta group to the
+admin role if you want your Okta groups to decide who administers MCPJam.
+
+## Troubleshooting
+
+<AccordionGroup>
+<Accordion title="Sign-in fails with an audience or recipient mismatch">
+The **Single Sign-On URL** or **Audience URI** in Okta doesn't match the values
+from the MCPJam setup portal. Re-copy both from the portal — they are unique to
+your organization.
+</Accordion>
+
+<Accordion title="Users sign in but land somewhere unexpected">
+Their email domain may not be verified on your MCPJam organization, so we can't
+tell which organization they belong to. Contact us and we'll verify it.
+</Accordion>
+
+<Accordion title="Provisioning shows errors in Okta">
+Re-check the SCIM endpoint and bearer token — tokens are specific to one
+directory connection. If you removed and re-created the connection, the old
+token stops working.
+</Accordion>
+
+<Accordion title="A deprovisioned user still appears in MCPJam">
+Deactivated members are retained for audit purposes, without access — their
+sessions are revoked and they cannot sign in.
+</Accordion>
+</AccordionGroup>
+
+## Support
+
+Email [support@mcpjam.com](mailto:support@mcpjam.com) or your MCPJam contact.


### PR DESCRIPTION
## Why

We're submitting MCPJam to the **Okta Integration Network** (a customer's vendor security review requires our SAML/SCIM integration to be listed there). The OIN submission form has a required **"Configuration guide URL"** field that must point at a public page, and Okta's review analyst reads that page to verify the documented setup flow matches what the integration actually does.

This adds that page.

## What

`docs/hosted/sso.mdx` — customer-facing setup guide for SAML 2.0 SSO and SCIM 2.0 provisioning with Okta, published at `docs.mcpjam.com/hosted/sso`:

- Part 1: SAML setup (ACS URL / SP Entity ID exchange, attribute mappings, metadata URL back to us, assignment + JIT first sign-in).
- Part 2: SCIM provisioning, including that deprovisioning revokes active sessions immediately rather than waiting for expiry.
- Roles (owner/admin/member) and Okta group → role mapping.
- Troubleshooting for the four failure modes a first-time configurer actually hits.

Navigation entry added under Get Started, after `hosted/slack`.

Docs-only change — no product code touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit cb6acd1e2f7f102c73ed61dbf750fb933a2c8420. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Publishes a customer-facing Okta SAML SSO and SCIM 2.0 configuration guide at docs.mcpjam.com/hosted/sso and adds it to the docs navigation. This satisfies the Okta Integration Network requirement for a public “Configuration guide URL” and reflects the current product behavior; no runtime changes.

- Adds `docs/hosted/sso.mdx`; links it in `docs/docs.json` under Get Started after `hosted/slack`.
- Documents: ACS URL and SP Entity ID mapping, required SAML attributes (`email`, `firstName`, `lastName`), optional `groups`; Metadata URL handoff; JIT account creation on first sign-in; SCIM endpoint + bearer token with Create/Update/Deactivate; immediate session revocation on deprovision; default roles and optional Okta group → admin mapping; common troubleshooting.

**Review focus**
- Verify SAML field names and attribute keys match our UI and SAML implementation.
- Confirm SCIM endpoint format, token usage, and supported operations are accurate.
- Double-check the “immediate session revocation” behavior is correct.
- Ensure enterprise gating and “setup link” flow aligns with current org settings.
- Confirm navigation placement and final public URL for OIN submission.

<sup>Written for commit cb6acd1e2f7f102c73ed61dbf750fb933a2c8420. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/MCPJam/inspector/pull/4122?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

