### PR TITLE
Claude readiness: name the gap-closing input, stop recommending intrusive probes

### DIFF
--- a/.changeset/claude-readiness-actionable-gaps.md
+++ b/.changeset/claude-readiness-actionable-gaps.md
@@ -1,0 +1,36 @@
+---
+"@mcpjam/sdk": patch
+---
+
+Claude readiness: name the input that closes each gap, and stop recommending intrusive probes.
+
+Running the grader against two live connectors turned up two reporting bugs that
+only appear on a target the run cannot fully reach.
+
+The tool, apps and RFC 8707 checks reported `not-evaluated` without naming an
+input that would close the gap, so the run-level summary could only offer inputs
+some other check had declared. On an OAuth connector the run could not
+authenticate to, the single remaining candidate was `intrusive` — and the report
+told the reader to "supply intrusive to close the gap" on a server whose only
+actual problem was a missing token. Those checks now name `toolListing`,
+`appsResult` and `authorizationRequests`.
+
+`intrusive` is now a GATED input: it registers OAuth clients and spends refresh
+grants, so it is only legitimate against a server the submitter controls with a
+dedicated test account. It never appears in the summary's `Supply …` clause. A
+run whose only remaining gap is intrusive now says nothing failed and that the
+gap needs explicit opt-in, instead of reading as advice to go run it.
+
+`claude.auth.rfc8707-resource-canonical` was unreachable in practice: it grades
+the `resource` parameter sent to `/authorize` and `/token`, but
+`discoverClaudeAuthEvidence` excluded `resourceIndicatorsSent` from the extras a
+caller may pass, and an access token carries no record of the requests that
+produced it. The extras now accept it (alongside `insufficientScopeChallenge`),
+and a new pure `resourceIndicatorsFrom({ authorizationUrl, tokenRequestBody })`
+reads the parameter out of the two requests that carry it — returning
+`undefined` rather than an empty object when neither did, so an absent parameter
+stays `not-evaluated` instead of being graded as a bad one.
+
+New exports: `CLAUDE_GATED_INPUTS`, `CLAUDE_TOOL_LISTING_INPUT`,
+`CLAUDE_APPS_RESULT_INPUT`, `CLAUDE_AUTHORIZATION_REQUESTS_INPUT`,
+`resourceIndicatorsFrom`.

--- a/sdk/src/claude-readiness/checks/apps.ts
+++ b/sdk/src/claude-readiness/checks/apps.ts
@@ -96,6 +96,15 @@ export interface ClaudeAppsEvidence {
 
 // ── Definitions ─────────────────────────────────────────────────────────
 
+/**
+ * The input that closes this module's coverage gap.
+ *
+ * Distinct from the tool-listing input: a run can hold a tool listing and
+ * still have no apps evidence, because reading widget resources is a separate
+ * round trip the caller may not have made.
+ */
+export const CLAUDE_APPS_RESULT_INPUT = "appsResult";
+
 const RESOURCE_URI_MODERNITY: ClaudeCheckDefinition = {
   id: "claude.apps.resource-uri-modern",
   title: "Widget tools declare `_meta.ui.resourceUri`",
@@ -392,7 +401,9 @@ export function runClaudeAppsChecks(
     const reason =
       "no MCP Apps conformance result was available, so nothing app-specific was evaluated";
     for (const definition of everyDefinition) {
-      findings.push(notEvaluated(definition, stamp, reason));
+      findings.push(notEvaluated(definition, stamp, reason, {
+        missingInput: CLAUDE_APPS_RESULT_INPUT,
+      }));
     }
     return findings;
   }

--- a/sdk/src/claude-readiness/checks/auth.ts
+++ b/sdk/src/claude-readiness/checks/auth.ts
@@ -109,6 +109,16 @@ export interface ClaudeAuthEvidence {
 
 // ── Check definitions ───────────────────────────────────────────────────
 
+/**
+ * The input that lets {@link RFC8707_RESOURCE_CANONICAL} run.
+ *
+ * A completed authorization is not enough on its own: an access token is the
+ * OUTPUT of the flow and carries no record of the `resource` parameter that
+ * was sent to reach it. The caller that drove `/authorize` and `/token` is the
+ * only party that saw those requests, so it has to hand them back.
+ */
+export const CLAUDE_AUTHORIZATION_REQUESTS_INPUT = "authorizationRequests";
+
 const CHALLENGE_PRESENT: ClaudeCheckDefinition = {
   id: "claude.auth.unauthenticated-challenge",
   title: "An unauthenticated request is answered with a usable 401 challenge",
@@ -265,6 +275,51 @@ export function canonicalResourceIndicator(url: string): string | undefined {
   return parsed.pathname === "/" && !url.endsWith("/")
     ? rendered.replace(/\/$/, "")
     : rendered;
+}
+
+/**
+ * Read the RFC 8707 `resource` parameter out of the two requests that carry
+ * it, so a caller that drove an authorization can report what it sent.
+ *
+ * Exists because every surface that completes a flow would otherwise write
+ * this parsing itself, and each copy would be a chance to read the wrong
+ * parameter and hand the check a value the client never sent — worse than the
+ * `not-evaluated` it replaces, because a wrong verdict does not announce
+ * itself.
+ *
+ * Returns `undefined` when neither request carried a `resource`. That is NOT a
+ * violation: absence means we still have nothing to grade, and the check must
+ * go on saying so rather than reading a missing parameter as a bad one.
+ */
+export function resourceIndicatorsFrom(requests: {
+  /** The full `/authorize` URL, `resource` included, as it was sent. */
+  authorizationUrl?: string;
+  /** The `/token` request body — form-encoded string, params, or a record. */
+  tokenRequestBody?: string | URLSearchParams | Record<string, string>;
+}): ClaudeAuthEvidence["resourceIndicatorsSent"] | undefined {
+  let authorize: string | undefined;
+  if (requests.authorizationUrl) {
+    try {
+      authorize =
+        new URL(requests.authorizationUrl).searchParams.get("resource") ??
+        undefined;
+    } catch {
+      authorize = undefined;
+    }
+  }
+
+  let token: string | undefined;
+  const body = requests.tokenRequestBody;
+  if (typeof body === "string") {
+    token = new URLSearchParams(body).get("resource") ?? undefined;
+  } else if (body instanceof URLSearchParams) {
+    token = body.get("resource") ?? undefined;
+  } else if (body) {
+    token = typeof body.resource === "string" ? body.resource : undefined;
+  }
+
+  if (authorize === undefined && token === undefined) return undefined;
+  return { authorize, token };
 }
 
 // ── The run ─────────────────────────────────────────────────────────────
@@ -440,7 +495,10 @@ export function runClaudeAuthChecks(
         RFC8707_RESOURCE_CANONICAL,
         stamp,
         "checking the `resource` parameter on /authorize and /token requires completing an authorization, which this run did not do",
-        { expectedCanonicalForm: canonical },
+        {
+          expectedCanonicalForm: canonical,
+          missingInput: CLAUDE_AUTHORIZATION_REQUESTS_INPUT,
+        },
       ),
     );
   } else {

--- a/sdk/src/claude-readiness/checks/tools.ts
+++ b/sdk/src/claude-readiness/checks/tools.ts
@@ -26,6 +26,16 @@ import {
   type ClaudeCheckStamp,
 } from "./helpers.js";
 
+/**
+ * The input that closes this module's coverage gap.
+ *
+ * A tool listing is not something a caller "has" — on an OAuth connector it
+ * costs a completed authorization to get one. Naming it lets a surface tell
+ * the submitter to authenticate rather than leaving the run-level summary to
+ * offer whatever unrelated input happened to be declared elsewhere.
+ */
+export const CLAUDE_TOOL_LISTING_INPUT = "toolListing";
+
 const TOOL_NAME_LENGTH: ClaudeCheckDefinition = {
   id: "claude.tools.name-length",
   title: "Tool names fit Claude's 64-character limit",
@@ -262,7 +272,18 @@ export function runClaudeToolChecks(
   // looked at.
   if (!tools) {
     return definitions.map((definition) =>
-      notEvaluated(definition, stamp, "no tool listing was captured for this run"),
+      notEvaluated(
+        definition,
+        stamp,
+        "no tool listing was captured for this run",
+        // NAMING THE INPUT IS WHAT MAKES THE GAP ACTIONABLE. Without it the
+        // run-level summary can only offer inputs some OTHER check declared,
+        // and on an OAuth connector the only one left is `intrusive` — so a
+        // server whose sole problem is "we could not authenticate" got told to
+        // run the one probe that must never be aimed at someone else's
+        // production server.
+        { missingInput: CLAUDE_TOOL_LISTING_INPUT },
+      ),
     );
   }
   if (tools.length === 0) {

--- a/sdk/src/claude-readiness/discovery.ts
+++ b/sdk/src/claude-readiness/discovery.ts
@@ -508,7 +508,16 @@ async function fetchFirstAuthorizationServer(
  */
 export async function discoverClaudeAuthEvidence(
   options: ClaudeDiscoveryOptions,
-  extras: Pick<ClaudeAuthEvidence, "declaredAuthMode" | "accessTokenAudience"> = {},
+  // `resourceIndicatorsSent` rides in as an EXTRA rather than being discovered:
+  // discovery never drives an authorization, so the only party that can have
+  // seen those requests is the caller that made them.
+  extras: Pick<
+    ClaudeAuthEvidence,
+    | "declaredAuthMode"
+    | "accessTokenAudience"
+    | "resourceIndicatorsSent"
+    | "insufficientScopeChallenge"
+  > = {},
 ): Promise<ClaudeAuthEvidence> {
   const unauthenticated = await probeUnauthenticated(options);
   const challengePointer = parseBearerAuthenticateParameters(

--- a/sdk/src/claude-readiness/index.ts
+++ b/sdk/src/claude-readiness/index.ts
@@ -53,6 +53,7 @@ export type {
 } from "./manifest.js";
 
 export {
+  CLAUDE_GATED_INPUTS,
   CLAUDE_READINESS_INPUTS,
   gradeClaudeReadiness,
 } from "./runner.js";
@@ -75,6 +76,7 @@ export type {
 } from "./intrusive.js";
 
 export {
+  CLAUDE_APPS_RESULT_INPUT,
   claudeAppContentDomain,
   claudeAppResourceEvidenceFrom,
   claudeAppToolEvidenceFrom,
@@ -86,7 +88,9 @@ export type {
   ClaudeAppsEvidence,
 } from "./checks/apps.js";
 export {
+  CLAUDE_AUTHORIZATION_REQUESTS_INPUT,
   canonicalResourceIndicator,
+  resourceIndicatorsFrom,
   runClaudeAuthChecks,
 } from "./checks/auth.js";
 export type {
@@ -104,7 +108,10 @@ export {
   runClaudeSubmissionChecks,
 } from "./checks/submission.js";
 export type { ClaudeSubmissionEvidence } from "./checks/submission.js";
-export { runClaudeToolChecks } from "./checks/tools.js";
+export {
+  CLAUDE_TOOL_LISTING_INPUT,
+  runClaudeToolChecks,
+} from "./checks/tools.js";
 export { runClaudeEndpointChecks } from "./checks/endpoint.js";
 export type {
   ClaudeEndpointEvidence,

--- a/sdk/src/claude-readiness/runner.ts
+++ b/sdk/src/claude-readiness/runner.ts
@@ -20,8 +20,13 @@
  * disagreement.
  */
 
-import { runClaudeAppsChecks, type ClaudeAppsEvidence } from "./checks/apps.js";
 import {
+  CLAUDE_APPS_RESULT_INPUT,
+  runClaudeAppsChecks,
+  type ClaudeAppsEvidence,
+} from "./checks/apps.js";
+import {
+  CLAUDE_AUTHORIZATION_REQUESTS_INPUT,
   runClaudeAuthChecks,
   type ClaudeAuthEvidence,
 } from "./checks/auth.js";
@@ -34,7 +39,10 @@ import {
   CLAUDE_SUBMISSION_PROFILE_INPUT,
   runClaudeSubmissionChecks,
 } from "./checks/submission.js";
-import { runClaudeToolChecks } from "./checks/tools.js";
+import {
+  CLAUDE_TOOL_LISTING_INPUT,
+  runClaudeToolChecks,
+} from "./checks/tools.js";
 import {
   gradeClaudeIntrusiveObservations,
   resolveClaudeIntrusiveMode,
@@ -318,8 +326,31 @@ function buildRunSummary(
       .filter((lane) => lane.status === "incomplete")
       .flatMap((lane) => lane.coverage.missingInputs);
     const unique = [...new Set(gaps)];
-    return unique.length > 0
-      ? `Readiness is undetermined: some requirements were not evaluated. Supply ${unique.join(", ")} to close the gap.`
+
+    // GATED INPUTS ARE NOT RECOMMENDATIONS. `intrusive` registers OAuth
+    // clients and spends refresh grants; it is only ever legitimate against a
+    // server the submitter controls, with a dedicated test account. Listing it
+    // in the same breath as "give us a tool listing" reads as advice to run
+    // it — and on a connector whose ONLY gap was intrusive, that is exactly
+    // what a clean report told the reader to do.
+    const suggestable = unique.filter(
+      (input) => !CLAUDE_GATED_INPUTS.includes(input),
+    );
+    const gated = unique.filter((input) =>
+      CLAUDE_GATED_INPUTS.includes(input),
+    );
+    const gatedNote =
+      gated.length > 0
+        ? gated.length === 1
+          ? ` The remaining gap (${gated[0]}) needs explicit opt-in on a server you control.`
+          : ` The remaining gaps (${gated.join(", ")}) need explicit opt-in on a server you control.`
+        : "";
+
+    if (suggestable.length > 0) {
+      return `Readiness is undetermined: some requirements were not evaluated. Supply ${suggestable.join(", ")} to close the gap.${gatedNote}`;
+    }
+    return gated.length > 0
+      ? `Readiness is undetermined: nothing failed, and every remaining requirement needs a probe this run is not allowed to make on its own.${gatedNote}`
       : "Readiness is undetermined: some requirements could not be evaluated by this run.";
   }
   return "Every requirement this run could evaluate is satisfied.";
@@ -328,5 +359,20 @@ function buildRunSummary(
 /** Named inputs a surface can offer to make a run more complete. */
 export const CLAUDE_READINESS_INPUTS = {
   submissionProfile: CLAUDE_SUBMISSION_PROFILE_INPUT,
+  toolListing: CLAUDE_TOOL_LISTING_INPUT,
+  appsResult: CLAUDE_APPS_RESULT_INPUT,
+  authorizationRequests: CLAUDE_AUTHORIZATION_REQUESTS_INPUT,
   intrusive: "intrusive",
 } as const;
+
+/**
+ * Inputs a report must never simply ask for.
+ *
+ * Everything else on {@link CLAUDE_READINESS_INPUTS} is something a submitter
+ * can hand over at no cost to anyone. These are not: supplying them means
+ * running probes that mutate state on the target, so the decision belongs to
+ * whoever owns that server and a summary line is the wrong place to nudge it.
+ */
+export const CLAUDE_GATED_INPUTS: readonly string[] = [
+  CLAUDE_READINESS_INPUTS.intrusive,
+];

--- a/sdk/tests/claude-readiness/auth-checks.test.ts
+++ b/sdk/tests/claude-readiness/auth-checks.test.ts
@@ -18,6 +18,7 @@ import { describe, expect, it } from "vitest";
 
 import {
   canonicalResourceIndicator,
+  resourceIndicatorsFrom,
   runClaudeAuthChecks,
   type ClaudeAuthEvidence,
 } from "../../src/claude-readiness/checks/auth.js";
@@ -522,5 +523,71 @@ describe("the JWT audience is evidence, never a verdict", () => {
       byId(runClaudeAuthChecks(HEALTHY, STAMP), "claude.auth.access-token-audience")
         .status,
     ).toBe("not-applicable");
+  });
+});
+
+describe("capturing the resource indicators a flow actually sent", () => {
+  const TARGET = "https://mcp.example.com/mcp";
+
+  it("reads `resource` out of the authorize URL and the token body", () => {
+    expect(
+      resourceIndicatorsFrom({
+        authorizationUrl: `https://auth.example.com/authorize?client_id=abc&resource=${encodeURIComponent(TARGET)}&state=xyz`,
+        tokenRequestBody: `grant_type=authorization_code&code=c&resource=${encodeURIComponent(TARGET)}`,
+      }),
+    ).toEqual({ authorize: TARGET, token: TARGET });
+  });
+
+  it("accepts the token body as params or a record, not only a string", () => {
+    // Three shapes because three callers already exist: a raw body string, the
+    // `URLSearchParams` a fetch was built from, and a plain record. A helper
+    // that took only one would be reimplemented by the other two.
+    const expected = { authorize: undefined, token: TARGET };
+    expect(
+      resourceIndicatorsFrom({
+        tokenRequestBody: new URLSearchParams({ resource: TARGET }),
+      }),
+    ).toEqual(expected);
+    expect(
+      resourceIndicatorsFrom({ tokenRequestBody: { resource: TARGET } }),
+    ).toEqual(expected);
+  });
+
+  it("returns undefined when neither request carried one", () => {
+    // NOT an empty object. `{}` would satisfy the check's "did the caller
+    // supply this?" test and turn a gap into a silent pass; `undefined` keeps
+    // the finding at `not-evaluated`, which is the truth.
+    expect(
+      resourceIndicatorsFrom({
+        authorizationUrl: "https://auth.example.com/authorize?client_id=abc",
+        tokenRequestBody: "grant_type=authorization_code&code=c",
+      }),
+    ).toBeUndefined();
+    expect(resourceIndicatorsFrom({})).toBeUndefined();
+  });
+
+  it("does not throw on an unparseable authorization URL", () => {
+    expect(
+      resourceIndicatorsFrom({
+        authorizationUrl: "not a url",
+        tokenRequestBody: { resource: TARGET },
+      }),
+    ).toEqual({ authorize: undefined, token: TARGET });
+  });
+
+  it("feeds the RFC 8707 check, which then grades instead of skipping", () => {
+    const captured = resourceIndicatorsFrom({
+      authorizationUrl: `https://auth.example.com/authorize?resource=${encodeURIComponent("https://MCP.example.com:443/mcp")}`,
+    });
+    const finding = byId(
+      runClaudeAuthChecks(
+        { ...HEALTHY, enteredUrl: TARGET, resourceIndicatorsSent: captured },
+        STAMP,
+      ),
+      "claude.auth.rfc8707-resource-canonical",
+    );
+    // Uppercased host and an explicit default port: a real value a real client
+    // can send, and exactly what the canonical form exists to reject.
+    expect(finding.status).toBe("violated");
   });
 });

--- a/sdk/tests/claude-readiness/runner.test.ts
+++ b/sdk/tests/claude-readiness/runner.test.ts
@@ -7,6 +7,7 @@ import type { Tool } from "@modelcontextprotocol/client";
 import { describe, expect, it } from "vitest";
 
 import {
+  CLAUDE_GATED_INPUTS,
   gradeClaudeReadiness,
   type ClaudeReadinessInput,
 } from "../../src/claude-readiness/runner.js";
@@ -444,5 +445,54 @@ describe("it renders through the shared report adapter", () => {
       findings: [orphaned],
     });
     expect(report.advisories?.map((a) => a.id)).toContain("claude.test.orphan");
+  });
+});
+
+describe("what an incomplete run tells the reader to do", () => {
+  it("names the tool listing, not `intrusive`, when the run never connected", () => {
+    // The reported failure: an OAuth connector the run could not authenticate
+    // to came back `incomplete` with "Supply intrusive to close the gap",
+    // because the tool checks named no input of their own and `intrusive` was
+    // the only candidate left standing.
+    const result = gradeClaudeReadiness(
+      input({ tools: undefined, apps: { enteredUrl: URL_UNDER_TEST, appsSuiteRan: false } }),
+    );
+
+    expect(result.status).toBe("incomplete");
+    expect(result.summary).toContain("toolListing");
+    expect(result.summary).not.toMatch(/Supply[^.]*intrusive/);
+  });
+
+  it("never puts a gated input in the `Supply …` clause", () => {
+    // The invariant, over every input the runner can name, rather than the one
+    // string this bug happened to produce.
+    for (const probe of [
+      input(),
+      input({ tools: undefined }),
+      input({ apps: { enteredUrl: URL_UNDER_TEST, appsSuiteRan: false } }),
+      input({ submissionProfile: undefined }),
+    ]) {
+      const summary = gradeClaudeReadiness(probe).summary;
+      const supplyClause = /Supply ([^.]*)\./.exec(summary)?.[1] ?? "";
+      for (const gated of CLAUDE_GATED_INPUTS) {
+        expect(supplyClause).not.toContain(gated);
+      }
+    }
+  });
+
+  it("says a clean run's only gap needs opt-in, and asks for nothing", () => {
+    // Notion's authenticated run: nothing failed, every lane the run could
+    // reach was satisfied, and the only remaining gap was the intrusive trio.
+    const base = fullyCapable();
+    const result = gradeClaudeReadiness({
+      ...base,
+      capabilities: ["dns", "interactive-oauth"],
+      intrusive: undefined,
+      intrusiveObservations: undefined,
+    });
+
+    expect(result.status).toBe("incomplete");
+    expect(result.summary).not.toContain("Supply");
+    expect(result.summary).toContain("opt-in on a server you control");
   });
 });


### PR DESCRIPTION
Follow-up to #4120. Both bugs were found by running the grader against two live connectors (`mcp.excalidraw.com` and `mcp.notion.com`, the latter through a real OAuth flow) — neither is visible from a fixture, because both only appear on a target the run cannot fully reach.

## 1. The report recommended the one probe you must not run

The tools, apps and RFC 8707 checks reported `not-evaluated` without naming an input that would close the gap. `buildRunSummary` can only offer inputs some check declared, so on an OAuth connector the run could not authenticate to, the only candidate left standing was `intrusive`:

> Readiness is undetermined: some requirements were not evaluated. **Supply intrusive to close the gap.**

That server's only actual problem was a missing token. `intrusive` registers OAuth clients via DCR and spends refresh grants — it is legitimate only against a server the submitter controls, with a dedicated test account, which is why it is opt-in in the first place. Recommending it here is the report pointing at the single most damaging thing a reader could do next.

Worse on a clean target: Notion passes every check we can run unauthenticated, and **zero violations** still produced that same sentence.

Two changes:

- The three check modules now name `toolListing`, `appsResult` and `authorizationRequests`.
- `intrusive` becomes a **gated** input (`CLAUDE_GATED_INPUTS`) and never appears in the `Supply …` clause. A run whose only remaining gap is intrusive now says nothing failed and that the gap needs explicit opt-in.

## 2. `rfc8707-resource-canonical` could not run at all

The check reads `evidence.resourceIndicatorsSent` — but `discoverClaudeAuthEvidence`'s `extras` parameter excluded that field, so no caller could supply it. Completing an authorization does not help on its own: an access token is the *output* of the flow and carries no record of the `resource` parameter sent to reach it. The check was unreachable outside hand-built fixtures, which is why it stayed `not-evaluated` on Notion even after a full successful login.

- `extras` now accepts `resourceIndicatorsSent` (and `insufficientScopeChallenge`).
- New pure `resourceIndicatorsFrom({ authorizationUrl, tokenRequestBody })` reads the parameter out of the two requests that carry it, accepting the token body as a string, `URLSearchParams`, or a record — three shapes because three callers already exist and each would otherwise reimplement the parsing.
- It returns `undefined`, not `{}`, when neither request carried a `resource`. `{}` would satisfy the check's "did the caller supply this?" test and turn a gap into a silent pass.

## Not changed

An earlier draft of this PR was going to exempt app-only tools (`_meta.ui.visibility: ["app"]`) from `claude.tools.title-present`. **That was wrong and is not here.** SEP-1865 says the host must not put app-only tools in *the agent's tool list* — the list handed to the model — but they are still returned by the server's `tools/list` and still surface to humans in approval prompts, audit UI and inspectors. `title` is human display text and was never for the model, so the exemption had no basis. Both tool checks stand as written.

## Verification

- 241 readiness tests pass, 8 new. Each new test was confirmed to fail with the fix reverted — the summary test fails with a single line removed.
- Full SDK suite: 5154 passed. One failure, `browser-entry-guard.test.ts`, verified pre-existing on clean `main` via `git stash`.
- `tsc --noEmit` clean.
- End-to-end against the real servers:
  - Excalidraw: `not-ready`, unchanged.
  - Notion unauthenticated: *"Supply appsResult, authorizationRequests, toolListing to close the gap. The remaining gap (intrusive) needs explicit opt-in on a server you control."*
  - Notion authenticated (28 tools, `directory-policy = ready`): *"Supply authorizationRequests to close the gap. The remaining gap (intrusive) needs explicit opt-in on a server you control."*

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit 57022054193ac533e20221cba57f388ff4208047. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Makes readiness gaps actionable and safe. Previously the report suggested `intrusive` when checks were unevaluated and the RFC 8707 check couldn’t run; now the report names the input that closes each gap and never recommends `intrusive`.

- Names the exact missing inputs per lane: tools → `toolListing`, apps → `appsResult`, auth → `authorizationRequests`. The run-level summary only suggests these and omits gated inputs.
- Gates `intrusive` via `CLAUDE_GATED_INPUTS`. When only gated inputs remain, the summary states nothing failed and that the gap needs explicit opt-in.
- Enables `claude.auth.rfc8707-resource-canonical` by accepting caller-provided evidence: discovery extras now allow `resourceIndicatorsSent` and `insufficientScopeChallenge`. New `resourceIndicatorsFrom({ authorizationUrl, tokenRequestBody })` extracts `resource` and returns `undefined` when absent to keep findings at `not-evaluated`.
- Exposes new exports from `@mcpjam/sdk`: `CLAUDE_GATED_INPUTS`, `CLAUDE_TOOL_LISTING_INPUT`, `CLAUDE_APPS_RESULT_INPUT`, `CLAUDE_AUTHORIZATION_REQUESTS_INPUT`, `resourceIndicatorsFrom`. No migration required; surfaces may optionally pass `authorizationRequests` to grade RFC 8707.

<sup>Written for commit 57022054193ac533e20221cba57f388ff4208047. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/MCPJam/inspector/pull/4131?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

