### PR TITLE
Evals v2 G2d: report who reads an eval iteration's trace

### DIFF
--- a/.changeset/eval-iteration-read-audit.md
+++ b/.changeset/eval-iteration-read-audit.md
@@ -1,0 +1,54 @@
+---
+"@mcpjam/inspector": patch
+---
+
+Record who reads an eval iteration's trace through the public API.
+
+The two per-iteration read routes — `GET …/eval-runs/:runId/iterations/:iterationId/trace`
+and its `/steps` sibling — served a run's stored transcripts with no trace of
+who pulled them. The bulk half of that question was already answerable:
+`eval` is a first-class session source type and the OTLP export defaults to
+`direct+scenario+eval`, so eval transcripts already flow through the audited
+export path. What was missing was the caller walking a run's iterations one at
+a time, which bulk-export auditing never sees.
+
+Both routes now report the read to the platform after it resolves, and the row
+records the actor, the iteration, the run, and how much came back — never any
+part of the transcript.
+
+## Two credentials, two jobs
+
+The report carries both `INSPECTOR_SERVICE_TOKEN` and the caller's Convex
+bearer, and neither substitutes for the other. The service token authorizes the
+call: writing an audit row on someone else's behalf is privileged, and
+possession of it is what says the caller is our deployed server rather than the
+public. The bearer names the human, and the platform resolves the actor from
+it.
+
+The identity is deliberately not derived here. This server's own view of its
+caller is uneven — `mcpjamUserId` is set only on the API-key branch of the
+bearer middleware, and the eval v1 routes do not mount `optional-actor` — so
+deriving the actor at this layer would have attributed API-key reads and
+silently dropped session ones. A trail that is blank for exactly the callers
+someone is most likely asking about is worse than an empty one, because it
+looks like an answer. `getConvexBearerForRequest` already returns a bearer for
+both kinds of caller, and both carry the person's external id as `sub`, so
+forwarding it lets one platform path resolve either.
+
+## It cannot fail your read
+
+The report is best-effort and awaited: it runs after the response body is
+already resolved, and a platform outage, a slow network, or an
+older-than-expected deployment logs once and is swallowed. A `/trace` read that
+404s because no trace exists reports nothing at all — a row here means a
+transcript actually left the product.
+
+`/steps` behaves differently on purpose, matching the route: a missing envelope
+is not a 404 there, so its row carries a trace size only when evidence was
+really resolved, and the absence of that field is how the row says "verdicts
+only".
+
+**Deploy ordering:** the platform route this calls must be deployed first.
+Until it is, the request meets a routing 404, which logs and is discarded —
+a soft landing, not a reason the ordering does not matter, since an undeployed
+platform means no audit rows at all.

--- a/.changeset/eval-iteration-read-audit.md
+++ b/.changeset/eval-iteration-read-audit.md
@@ -35,13 +35,18 @@ looks like an answer. `getConvexBearerForRequest` already returns a bearer for
 both kinds of caller, and both carry the person's external id as `sub`, so
 forwarding it lets one platform path resolve either.
 
-## It cannot fail your read
+## It cannot fail — or delay — your read
 
-The report is best-effort and awaited: it runs after the response body is
-already resolved, and a platform outage, a slow network, or an
-older-than-expected deployment logs once and is swallowed. A `/trace` read that
-404s because no trace exists reports nothing at all — a row here means a
-transcript actually left the product.
+The report is best-effort and detached. It is started after the response body
+is already resolved and is deliberately not awaited, so a platform outage, a
+slow network, or an older-than-expected deployment can neither fail the read
+nor hold it open behind our own bookkeeping; failures log once and are
+swallowed. The request also carries its own 5-second deadline, so a backend
+that accepts the connection and then stalls cannot retain the work and its
+socket indefinitely.
+
+A `/trace` read that 404s because no trace exists reports nothing at all — a
+row here means a transcript actually left the product.
 
 `/steps` behaves differently on purpose, matching the route: a missing envelope
 is not a 404 there, so its row carries a trace size only when evidence was

--- a/mcpjam-inspector/server/routes/v1/__tests__/eval-iteration-read-audit.test.ts
+++ b/mcpjam-inspector/server/routes/v1/__tests__/eval-iteration-read-audit.test.ts
@@ -180,7 +180,12 @@ describe("GET …/iterations/:iterationId/trace — read audit", () => {
     // The whole trace, unchanged — `v1Resource` serves the resource itself,
     // so this is the caller's actual response body, not an envelope field.
     expect(await res.json()).toEqual(TRACE);
-    expect(reportRouteFailureMock).toHaveBeenCalledTimes(1);
+    // `waitFor`, not a bare assertion: the audit is DETACHED, so the response
+    // is allowed to land before the failure is reported. Asserting
+    // synchronously here would be asserting on that race.
+    await vi.waitFor(() =>
+      expect(reportRouteFailureMock).toHaveBeenCalledTimes(1)
+    );
   });
 
   it("still serves the trace when the platform route is not deployed yet", async () => {
@@ -191,7 +196,46 @@ describe("GET …/iterations/:iterationId/trace — read audit", () => {
     const res = await read("trace");
 
     expect(res.status).toBe(200);
-    expect(reportRouteFailureMock).toHaveBeenCalledTimes(1);
+    await vi.waitFor(() =>
+      expect(reportRouteFailureMock).toHaveBeenCalledTimes(1)
+    );
+  });
+
+  it("serves the trace without waiting for the audit to answer", async () => {
+    // A backend that accepts the POST and never replies. Awaiting the audit
+    // would hold this response open behind it; detaching means the caller is
+    // unaffected by our bookkeeping being stuck.
+    fetchMock.mockReturnValue(new Promise(() => {}));
+
+    const res = await read("trace");
+
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual(TRACE);
+    // …and the request really was in flight, so this is not passing by never
+    // having attempted it.
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("bounds the audit request so a stalled backend cannot hold it forever", async () => {
+    await read("trace");
+
+    // `fetch` has no default timeout, so without a signal a half-open
+    // connection would retain the request and its socket indefinitely.
+    const signal = (auditCall().init as { signal?: AbortSignal }).signal;
+    expect(signal).toBeInstanceOf(AbortSignal);
+    expect(signal!.aborted).toBe(false);
+  });
+
+  it("releases the deadline timer once the audit settles", async () => {
+    const clearTimeoutSpy = vi.spyOn(globalThis, "clearTimeout");
+
+    await read("trace");
+
+    // Without the `finally`, every read would leave a 5s timer pending —
+    // harmless once, a per-request leak that keeps the event loop busy at
+    // volume, and the reason the deadline is cleared rather than just set.
+    await vi.waitFor(() => expect(clearTimeoutSpy).toHaveBeenCalled());
+    clearTimeoutSpy.mockRestore();
   });
 
   it("reports nothing when there is no trace to read", async () => {
@@ -256,6 +300,17 @@ describe("GET …/iterations/:iterationId/steps — read audit", () => {
     const res = await read("steps");
 
     expect(res.status).toBe(200);
-    expect(reportRouteFailureMock).toHaveBeenCalledTimes(1);
+    await vi.waitFor(() =>
+      expect(reportRouteFailureMock).toHaveBeenCalledTimes(1)
+    );
+  });
+
+  it("serves the verdicts without waiting for the audit to answer", async () => {
+    fetchMock.mockReturnValue(new Promise(() => {}));
+
+    const res = await read("steps");
+
+    expect(res.status).toBe(200);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
   });
 });

--- a/mcpjam-inspector/server/routes/v1/__tests__/eval-iteration-read-audit.test.ts
+++ b/mcpjam-inspector/server/routes/v1/__tests__/eval-iteration-read-audit.test.ts
@@ -1,0 +1,261 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { Hono } from "hono";
+
+/**
+ * G2d — the two per-iteration read routes report the read to the platform.
+ *
+ * What these tests pin is mostly about the SHAPE of the report rather than
+ * that one is sent, because the ways this can be subtly wrong are all silent:
+ *
+ *  * The caller's Convex bearer must be forwarded ALONGSIDE the service token,
+ *    not instead of it, and must be the bearer the read itself used. The
+ *    platform resolves the acting human from it, so a report that carried only
+ *    the service token would file every read under nobody.
+ *  * A failure must never reach the caller. The report runs after the response
+ *    body already resolved; turning a served trace into a 500 because an audit
+ *    row could not be written is strictly worse than not writing it.
+ *  * A 404 must report nothing. A row is a claim that a transcript left the
+ *    product, and no transcript left on a `TRACE_NOT_AVAILABLE`.
+ */
+
+const {
+  validateGuestTokenMock,
+  convexQueryMock,
+  convexActionMock,
+  fetchMock,
+  reportRouteFailureMock,
+} = vi.hoisted(() => ({
+  validateGuestTokenMock: vi.fn(),
+  convexQueryMock: vi.fn(),
+  convexActionMock: vi.fn(),
+  fetchMock: vi.fn(),
+  reportRouteFailureMock: vi.fn(),
+}));
+
+vi.mock("../../../services/guest-token.js", () => ({
+  validateGuestTokenDetailedAsync: validateGuestTokenMock,
+}));
+
+vi.mock("convex/browser", () => ({
+  ConvexHttpClient: vi.fn().mockImplementation(() => ({
+    setAuth: vi.fn(),
+    query: convexQueryMock,
+    mutation: vi.fn(),
+    action: convexActionMock,
+  })),
+}));
+
+vi.mock("../../../utils/route-error-report.js", async () => {
+  const actual = await vi.importActual<
+    typeof import("../../../utils/route-error-report.js")
+  >("../../../utils/route-error-report.js");
+  return { ...actual, reportRouteFailure: reportRouteFailureMock };
+});
+
+import v1Routes from "../index.js";
+
+const PROJECT_ID = "p1";
+const RUN_ID = "run_1";
+const ITERATION_ID = "iter_1";
+const BEARER = "caller-bearer-token";
+const SERVICE_TOKEN = "inspector-service-token";
+const CONVEX_HTTP_URL = "https://example.convex.site";
+const AUDIT_URL = `${CONVEX_HTTP_URL}/internal/v1/evals/iteration-read`;
+
+const RUN_DOC = {
+  _id: RUN_ID,
+  projectId: PROJECT_ID,
+  suiteId: "suite_1",
+  runNumber: 1,
+  status: "completed",
+  result: "passed",
+  createdAt: 1,
+};
+
+const ITERATION_DOC = {
+  _id: ITERATION_ID,
+  suiteRunId: RUN_ID,
+  testCaseSnapshot: {
+    title: "a case",
+    query: "do the thing",
+    steps: [{ id: "s1", kind: "prompt", prompt: "do the thing" }],
+  },
+  metadata: { stepResults: [{ id: "s1", status: "passed" }] },
+  status: "completed",
+  result: "passed",
+};
+
+const TRACE = { messages: [{ role: "user", content: "do the thing" }] };
+
+function makeApp(): Hono {
+  const app = new Hono();
+  app.route("/api/v1", v1Routes);
+  return app;
+}
+
+function read(kind: "trace" | "steps"): Promise<Response> {
+  return makeApp().request(
+    `/api/v1/projects/${PROJECT_ID}/eval-runs/${RUN_ID}/iterations/${ITERATION_ID}/${kind}`,
+    { method: "GET", headers: { Authorization: `Bearer ${BEARER}` } }
+  );
+}
+
+/** The single audit POST, failing loudly when there is not exactly one. */
+function auditCall(): { url: string; init: RequestInit } {
+  const calls = fetchMock.mock.calls.filter(
+    (call) => String(call[0]) === AUDIT_URL
+  );
+  expect(calls).toHaveLength(1);
+  return { url: String(calls[0][0]), init: calls[0][1] as RequestInit };
+}
+
+function auditBody(): Record<string, unknown> {
+  return JSON.parse(String(auditCall().init.body));
+}
+
+function auditHeaders(): Record<string, string> {
+  return auditCall().init.headers as Record<string, string>;
+}
+
+beforeEach(() => {
+  vi.stubEnv("CONVEX_URL", "https://example.convex.cloud");
+  vi.stubEnv("CONVEX_HTTP_URL", CONVEX_HTTP_URL);
+  vi.stubEnv("INSPECTOR_SERVICE_TOKEN", SERVICE_TOKEN);
+  validateGuestTokenMock.mockResolvedValue({ valid: false });
+  vi.stubGlobal("fetch", fetchMock);
+  fetchMock.mockResolvedValue(
+    new Response(JSON.stringify({ ok: true, recorded: true }), { status: 200 })
+  );
+  convexQueryMock.mockImplementation((name: string) => {
+    if (name === "testSuites:getTestSuiteRun") return Promise.resolve(RUN_DOC);
+    if (name === "testSuites:getTestIteration")
+      return Promise.resolve(ITERATION_DOC);
+    return Promise.resolve(null);
+  });
+  convexActionMock.mockResolvedValue(TRACE);
+});
+
+afterEach(() => {
+  vi.unstubAllEnvs();
+  vi.unstubAllGlobals();
+  vi.clearAllMocks();
+});
+
+describe("GET …/iterations/:iterationId/trace — read audit", () => {
+  it("forwards the caller's bearer ALONGSIDE the service token", async () => {
+    const res = await read("trace");
+    expect(res.status).toBe(200);
+
+    const headers = auditHeaders();
+    // The service token AUTHORIZES the report…
+    expect(headers["x-inspector-service-token"]).toBe(SERVICE_TOKEN);
+    // …and the caller's bearer NAMES THE HUMAN. Sending only the first would
+    // leave the platform with no actor to resolve; sending the service token
+    // in this slot would be worse still.
+    expect(headers.authorization).toBe(`Bearer ${BEARER}`);
+    expect(headers.authorization).not.toContain(SERVICE_TOKEN);
+  });
+
+  it("names the iteration and the size that was served, not the trace", async () => {
+    await read("trace");
+
+    const body = auditBody();
+    expect(body.iterationId).toBe(ITERATION_ID);
+    expect(body.mode).toBe("trace");
+    expect(body.traceBytes).toBe(
+      Buffer.byteLength(JSON.stringify(TRACE), "utf8")
+    );
+    // How much left the product, never what was in it.
+    expect(JSON.stringify(body)).not.toContain("do the thing");
+  });
+
+  it("still serves the trace when the audit report fails", async () => {
+    fetchMock.mockRejectedValue(new Error("platform unreachable"));
+
+    const res = await read("trace");
+
+    // The read already resolved before the report was attempted. Failing it
+    // here would trade a served response for a missing audit row.
+    expect(res.status).toBe(200);
+    // The whole trace, unchanged — `v1Resource` serves the resource itself,
+    // so this is the caller's actual response body, not an envelope field.
+    expect(await res.json()).toEqual(TRACE);
+    expect(reportRouteFailureMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("still serves the trace when the platform route is not deployed yet", async () => {
+    // Convex's own routing 404 — what this looks like before the backend half
+    // ships. Deliberately a soft landing, not a claim the ordering is optional.
+    fetchMock.mockResolvedValue(new Response("Not Found", { status: 404 }));
+
+    const res = await read("trace");
+
+    expect(res.status).toBe(200);
+    expect(reportRouteFailureMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("reports nothing when there is no trace to read", async () => {
+    convexActionMock.mockResolvedValue(null);
+
+    const res = await read("trace");
+
+    expect(res.status).toBe(404);
+    // A row asserts that a transcript left the product. Nothing left here.
+    expect(
+      fetchMock.mock.calls.filter((call) => String(call[0]) === AUDIT_URL)
+    ).toHaveLength(0);
+  });
+
+  it("reports nothing when the iteration does not belong to the run", async () => {
+    convexQueryMock.mockImplementation((name: string) => {
+      if (name === "testSuites:getTestSuiteRun")
+        return Promise.resolve(RUN_DOC);
+      if (name === "testSuites:getTestIteration")
+        return Promise.resolve({ ...ITERATION_DOC, suiteRunId: "other_run" });
+      return Promise.resolve(null);
+    });
+
+    const res = await read("trace");
+
+    expect(res.status).toBe(404);
+    expect(
+      fetchMock.mock.calls.filter((call) => String(call[0]) === AUDIT_URL)
+    ).toHaveLength(0);
+  });
+});
+
+describe("GET …/iterations/:iterationId/steps — read audit", () => {
+  it("files under its own mode and counts the steps it returned", async () => {
+    const res = await read("steps");
+    expect(res.status).toBe(200);
+
+    const body = auditBody();
+    expect(body.mode).toBe("steps");
+    expect(body.stepCount).toBe(1);
+    expect(body.iterationId).toBe(ITERATION_ID);
+    expect(auditHeaders().authorization).toBe(`Bearer ${BEARER}`);
+  });
+
+  it("omits the trace size when no evidence resolved", async () => {
+    // Unlike `/trace`, a missing envelope is NOT a 404 here — verdicts still
+    // return — so the field's absence is how the row says "verdicts only",
+    // rather than claiming a zero-byte trace was served.
+    convexActionMock.mockResolvedValue(null);
+
+    const res = await read("steps");
+    expect(res.status).toBe(200);
+
+    const body = auditBody();
+    expect(body).not.toHaveProperty("traceBytes");
+    expect(body.stepCount).toBe(1);
+  });
+
+  it("still serves the verdicts when the audit report fails", async () => {
+    fetchMock.mockRejectedValue(new Error("platform unreachable"));
+
+    const res = await read("steps");
+
+    expect(res.status).toBe(200);
+    expect(reportRouteFailureMock).toHaveBeenCalledTimes(1);
+  });
+});

--- a/mcpjam-inspector/server/routes/v1/evals.ts
+++ b/mcpjam-inspector/server/routes/v1/evals.ts
@@ -2827,9 +2827,14 @@ evals.get(
       );
     }
     // AFTER the read resolves and after the 404s, so a row means a transcript
-    // actually left the product. Best-effort: `recordEvalIterationRead` never
-    // throws, so a backend outage cannot turn a served trace into a 500.
-    await recordEvalIterationRead({
+    // actually left the product.
+    //
+    // DETACHED, not awaited: bookkeeping must not sit on the critical path of
+    // a read that already succeeded, or a stalled audit backend shows up as a
+    // slow `/trace`. Safe to float because `recordEvalIterationRead` swallows
+    // its own failures — there is no rejection to go unhandled — and it bounds
+    // its own request.
+    void recordEvalIterationRead({
       convexAuthToken,
       iterationId,
       mode: "trace",
@@ -2911,7 +2916,8 @@ evals.get(
     // Unlike `/trace`, a missing envelope is not a 404 here — verdicts still
     // return — so `traceBytes` is present only when evidence was actually
     // resolved, and its absence is how the row says "verdicts only".
-    await recordEvalIterationRead({
+    // Detached for the same reason as the `/trace` site above.
+    void recordEvalIterationRead({
       convexAuthToken,
       iterationId,
       mode: "steps",

--- a/mcpjam-inspector/server/routes/v1/evals.ts
+++ b/mcpjam-inspector/server/routes/v1/evals.ts
@@ -87,6 +87,10 @@ import {
   type EvalStepReplay,
 } from "@/shared/eval-step-replay";
 import { getConvexBearerForRequest } from "../../utils/v1-convex-token.js";
+import {
+  measureTraceBytes,
+  recordEvalIterationRead,
+} from "../../services/eval-trace-access-audit.js";
 import { logger } from "../../utils/logger.js";
 import { v1Error, v1PageJson, v1Resource } from "./envelope.js";
 import { translateConvexWriteError as translateConvexError } from "./convex-errors.js";
@@ -2779,7 +2783,10 @@ evals.get(
     const projectId = c.req.param("projectId");
     const runId = c.req.param("runId");
     const iterationId = c.req.param("iterationId");
-    const convex = createConvexReadClient(await getConvexBearerForRequest(c));
+    // Held rather than inlined: the same bearer authorizes the read AND names
+    // the human in the audit row below (see services/eval-trace-access-audit).
+    const convexAuthToken = await getConvexBearerForRequest(c);
+    const convex = createConvexReadClient(convexAuthToken);
 
     let trace: unknown;
     try {
@@ -2819,6 +2826,15 @@ evals.get(
         { reason: "TRACE_NOT_AVAILABLE" },
       );
     }
+    // AFTER the read resolves and after the 404s, so a row means a transcript
+    // actually left the product. Best-effort: `recordEvalIterationRead` never
+    // throws, so a backend outage cannot turn a served trace into a 500.
+    await recordEvalIterationRead({
+      convexAuthToken,
+      iterationId,
+      mode: "trace",
+      traceBytes: measureTraceBytes(trace),
+    });
     return v1Resource(c, trace);
   },
 );
@@ -2835,7 +2851,8 @@ evals.get(
     const projectId = c.req.param("projectId");
     const runId = c.req.param("runId");
     const iterationId = c.req.param("iterationId");
-    const convex = createConvexReadClient(await getConvexBearerForRequest(c));
+    const convexAuthToken = await getConvexBearerForRequest(c);
+    const convex = createConvexReadClient(convexAuthToken);
 
     let iteration: IterationDoc | null;
     try {
@@ -2891,6 +2908,16 @@ evals.get(
         | undefined,
       envelope as Parameters<typeof assembleStepResults>[2],
     );
+    // Unlike `/trace`, a missing envelope is not a 404 here — verdicts still
+    // return — so `traceBytes` is present only when evidence was actually
+    // resolved, and its absence is how the row says "verdicts only".
+    await recordEvalIterationRead({
+      convexAuthToken,
+      iterationId,
+      mode: "steps",
+      stepCount: assembled.length,
+      traceBytes: measureTraceBytes(envelope),
+    });
     return v1PageJson(c, assembled.map(toStepResultDto));
   },
 );

--- a/mcpjam-inspector/server/services/eval-trace-access-audit.ts
+++ b/mcpjam-inspector/server/services/eval-trace-access-audit.ts
@@ -45,6 +45,17 @@ import { reportRouteFailure } from "../utils/route-error-report.js";
 
 const ITERATION_READ_PATH = "/internal/v1/evals/iteration-read";
 
+/**
+ * How long the audit POST may stay in flight.
+ *
+ * `fetch` has no default timeout, so a backend that accepts the connection and
+ * then stalls would hold this request — and its socket — open indefinitely.
+ * The call is detached from the read path (see below), so this deadline is not
+ * about latency; it is about not accumulating pending work under a backend
+ * that is up enough to accept connections and not up enough to answer.
+ */
+const AUDIT_REQUEST_TIMEOUT_MS = 5_000;
+
 /** Which of the two per-iteration read routes served the request. */
 export type EvalIterationReadMode = "trace" | "steps";
 
@@ -73,17 +84,31 @@ export interface EvalIterationReadAudit {
  * a slow network must not turn a served response into a 500. A failure is
  * reported once through the centralized path and swallowed.
  *
- * Deliberately awaited rather than fired and forgotten. The audit row and the
- * response should not race, and a floating promise here would be an unhandled
- * rejection in the one case this function exists to survive.
+ * Callers DETACH this rather than awaiting it (`void recordEvalIterationRead`).
+ * Awaiting would put a best-effort audit write on the critical path of a read
+ * that has already succeeded — a stalled backend would then show up as a slow
+ * `/trace`, which is the caller's problem for our bookkeeping. Detaching is
+ * safe precisely because this function swallows its own failures: there is no
+ * rejection to go unhandled.
+ *
+ * That trade only works in a long-lived process, which is what the Inspector
+ * server is (Railway / Electron), NOT a serverless invocation that may be
+ * frozen the moment its response is returned. Revisit if that ever changes —
+ * there the row would be silently lost.
  */
 export async function recordEvalIterationRead(
   audit: EvalIterationReadAudit
 ): Promise<void> {
+  const controller = new AbortController();
+  const timeout = setTimeout(
+    () => controller.abort(),
+    AUDIT_REQUEST_TIMEOUT_MS
+  );
   try {
     const { convexUrl, serviceToken } = getInternalBackendConfig();
     const response = await fetch(`${convexUrl}${ITERATION_READ_PATH}`, {
       method: "POST",
+      signal: controller.signal,
       headers: {
         "content-type": "application/json",
         "x-inspector-service-token": serviceToken,
@@ -113,6 +138,8 @@ export async function recordEvalIterationRead(
       hop: "mcpjam_internal",
       context: { mode: audit.mode },
     });
+  } finally {
+    clearTimeout(timeout);
   }
 }
 

--- a/mcpjam-inspector/server/services/eval-trace-access-audit.ts
+++ b/mcpjam-inspector/server/services/eval-trace-access-audit.ts
@@ -1,0 +1,133 @@
+/**
+ * Inspector-side client for the backend's eval per-iteration read audit
+ * (`POST /internal/v1/evals/iteration-read`; see mcpjam-backend
+ * `convex/http.ts` and `convex/evalTraceAccessAudit.ts`).
+ *
+ * ============================================================================
+ * WHY THIS FORWARDS TWO CREDENTIALS
+ * ============================================================================
+ *
+ * The backend route wants both, for two different reasons, and neither
+ * substitutes for the other:
+ *
+ *   * `x-inspector-service-token` AUTHORIZES the call. Writing an audit row on
+ *     someone else's behalf is a privileged act, and possession of this token
+ *     is what says the caller is our deployed server rather than the public.
+ *
+ *   * `Authorization: Bearer <convex jwt>` NAMES THE HUMAN. The backend
+ *     resolves the actor from it.
+ *
+ * The identity deliberately is NOT derived here. Our own view of the caller is
+ * uneven: `mcpjamUserId` is set only on the API-key branch of `bearer-auth`,
+ * and the eval v1 routes do not mount `optional-actor`. Deriving the actor at
+ * this layer would therefore attribute API-key reads and silently DROP session
+ * reads — an audit trail blank for exactly the callers someone is most likely
+ * asking about, which is worse than an empty one because it looks like an
+ * answer. `getConvexBearerForRequest` already hands back a bearer for BOTH
+ * kinds of caller (a session JWT passed through, or a delegated JWT minted for
+ * an API key's WorkOS user), and both carry the person's `externalId` as
+ * `sub`, so forwarding it lets one backend path resolve either.
+ *
+ * ============================================================================
+ * DEPLOY ORDERING
+ * ============================================================================
+ *
+ * The backend route must be deployed BEFORE this ships. Until then the request
+ * hits Convex's routing 404 — which `recordEvalIterationRead` treats like any
+ * other failure: it logs once and the read still returns. That is a
+ * deliberately soft landing rather than a guarantee the ordering does not
+ * matter; an undeployed backend means no audit rows at all, which is the
+ * failure this lane exists to remove.
+ */
+
+import { getInternalBackendConfig } from "./internal-backend.js";
+import { reportRouteFailure } from "../utils/route-error-report.js";
+
+const ITERATION_READ_PATH = "/internal/v1/evals/iteration-read";
+
+/** Which of the two per-iteration read routes served the request. */
+export type EvalIterationReadMode = "trace" | "steps";
+
+export interface EvalIterationReadAudit {
+  /** The Convex bearer for the CALLING user — never the service token. */
+  convexAuthToken: string;
+  iterationId: string;
+  mode: EvalIterationReadMode;
+  /**
+   * Size of the trace envelope that was served, when one resolved at all.
+   *
+   * Omitted — not zero — when no trace resolved, which is the ordinary case
+   * for a `steps` read of a still-running iteration. "There was no trace" and
+   * "the trace was empty" are different facts and the backend keeps them
+   * distinct.
+   */
+  traceBytes?: number;
+  stepCount?: number;
+}
+
+/**
+ * Record one per-iteration read, best-effort.
+ *
+ * NEVER throws and never rejects: this is called AFTER the read the caller
+ * asked for has already resolved, so a backend outage, an undeployed route or
+ * a slow network must not turn a served response into a 500. A failure is
+ * reported once through the centralized path and swallowed.
+ *
+ * Deliberately awaited rather than fired and forgotten. The audit row and the
+ * response should not race, and a floating promise here would be an unhandled
+ * rejection in the one case this function exists to survive.
+ */
+export async function recordEvalIterationRead(
+  audit: EvalIterationReadAudit
+): Promise<void> {
+  try {
+    const { convexUrl, serviceToken } = getInternalBackendConfig();
+    const response = await fetch(`${convexUrl}${ITERATION_READ_PATH}`, {
+      method: "POST",
+      headers: {
+        "content-type": "application/json",
+        "x-inspector-service-token": serviceToken,
+        // The CALLER's bearer. The backend reads the actor off this; the
+        // service token above is only permission to ask.
+        authorization: `Bearer ${audit.convexAuthToken}`,
+      },
+      body: JSON.stringify({
+        iterationId: audit.iterationId,
+        mode: audit.mode,
+        ...(audit.traceBytes !== undefined
+          ? { traceBytes: audit.traceBytes }
+          : {}),
+        ...(audit.stepCount !== undefined
+          ? { stepCount: audit.stepCount }
+          : {}),
+      }),
+    });
+    if (!response.ok) {
+      throw new Error(`eval iteration-read audit returned ${response.status}`);
+    }
+  } catch (error) {
+    // `hop: "mcpjam_internal"` — this is our own backend, so a failure here is
+    // ours to fix rather than a caller's or a third-party server's.
+    reportRouteFailure("[v1.evals] iteration read not audited", error, {
+      source: "v1.evals.iteration-read-audit",
+      hop: "mcpjam_internal",
+      context: { mode: audit.mode },
+    });
+  }
+}
+
+/**
+ * Byte size of a resolved trace envelope, or `undefined` when there is none.
+ *
+ * A size, never a sample: the audit answers "how much left the product", not
+ * "what was in it". Serialization failure yields `undefined` rather than a
+ * guess — a wrong number in an audit row is worse than an absent one.
+ */
+export function measureTraceBytes(trace: unknown): number | undefined {
+  if (trace === null || trace === undefined) return undefined;
+  try {
+    return Buffer.byteLength(JSON.stringify(trace) ?? "", "utf8");
+  } catch {
+    return undefined;
+  }
+}


### PR DESCRIPTION
The Inspector half of Evals v2 lane G, step G2d. Backend half: **MCPJam/mcpjam-backend#1047**.

> ⚠️ **Deploy-gated.** `POST /internal/v1/evals/iteration-read` must be deployed to production before this merges. This is the same ordering that bit the API-key work, where production had not been promoted when the Inspector half was ready.

## What was missing

The two per-iteration read routes — `GET …/eval-runs/:runId/iterations/:iterationId/trace` and its `/steps` sibling — served a run's stored transcripts with no record of who pulled them.

The bulk half of that question was **already** answerable and is not what this changes: `eval` is a first-class session source type (`lib/sessionFeedFilters.ts`) and the OTLP export defaults to `direct+scenario+eval`, so eval transcripts already flow through the audited `trace_export.run` / `session_access.*` paths. What no audit saw was a caller walking a run's iterations one at a time.

## Two credentials, two jobs

The report carries **both** `INSPECTOR_SERVICE_TOKEN` and the caller's Convex bearer, and neither substitutes for the other:

- the **service token authorizes** the call — writing an audit row on someone else's behalf is privileged, and holding it is what says the caller is our deployed server rather than the public;
- the **bearer names the human**, and the platform resolves the actor from it.

**The identity is deliberately not derived here.** Our own view of the caller is uneven: `mcpjamUserId` is set only on the API-key branch of `bearer-auth.ts`, and these routes do not mount `optional-actor`. Deriving the actor at this layer would have attributed API-key reads and **silently dropped session ones** — a trail blank for exactly the callers someone is most likely asking about, which is worse than an empty trail because it looks like an answer. `getConvexBearerForRequest` already returns a bearer for both kinds of caller (a session JWT passed through, or a delegated JWT minted for an API key's WorkOS user) and both carry the person's `externalId` as `sub`, so forwarding it lets one platform path resolve either.

Both routes now hold that bearer in a local rather than inlining it into `createConvexReadClient`, so the audit row is named by the same credential the read itself used.

## It cannot fail your read

`recordEvalIterationRead` never throws. It runs after the response body has already resolved, so a platform outage, a slow network, or an undeployed route logs once through `reportRouteFailure` (`hop: "mcpjam_internal"`) and is swallowed. Trading a served trace for a missing audit row would be strictly worse than the missing row.

A `/trace` read that 404s reports **nothing** — a row is a claim that a transcript left the product, and none did. `/steps` differs on purpose, matching the route: a missing envelope is not a 404 there, so its row carries `traceBytes` only when evidence really resolved, and that field's **absence** is how the row says "verdicts only" rather than claiming zero bytes were served.

Sizes, never samples: `measureTraceBytes` returns a byte count or nothing, and a serialization failure yields `undefined` rather than a guess — a wrong number in an audit row is worse than an absent one.

## Verification

- `npm run test -w @mcpjam/inspector`: **16171 passed**, 28 skipped, **0 failed**.
- `npm run build -w @mcpjam/sdk && npm run build:inspector` — clean (this is the path CI typechecks the server through).
- The 9 new tests were **mutation-tested — 12 mutations, 12 detected**. They are not just "was a call made": putting the service token in the bearer slot, dropping either credential, letting a report failure reach the caller, auditing before the `/trace` 404, filing a steps read under the trace mode, coercing an absent trace size to zero, and reporting trace *content* instead of its size are each caught by a specific assertion.

## A note on formatting

Prettier here is v2 and the repo genuinely follows two conventions — `server/routes/v1/evals.ts` does not satisfy v2 on `main` today, while its `__tests__` siblings and `server/services/internal-backend.ts` do.

So: the two **new** files are formatted to v2, matching their direct siblings. `evals.ts` is left alone — running `--write` on it would bury three added lines under a whole-file reformat. The lines added there use only `es5` trailing commas, which both versions accept.

The `package-lock.json` churn from installing locally (`dev` → `devOptional`) was reverted; it is unrelated to this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019xjt5u3dFSVmjtoxyz15zg

---
_Generated by [Claude Code](https://claude.ai/code/session_019xjt5u3dFSVmjtoxyz15zg)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit 1bb8b078827aacc85d012fd2d91eccdbf358f9ec. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Audits who reads an eval iteration’s trace or steps in `@mcpjam/inspector`. Previously, per-iteration reads (`GET …/trace` and `GET …/steps`) were unaudited; now each successful read posts an audit event after the response, without blocking or delaying the read.

- Sends both credentials: `x-inspector-service-token` authorizes the audit write; `Authorization: Bearer <caller>` names the human. Uses the same bearer for the read and the audit.
- Detaches the audit request and bounds it with a 5s timeout; clears its timer on settle. Failures log once via `reportRouteFailure` and never affect responses.
- Records only metadata: `iterationId`, `mode` (`trace`|`steps`), `stepCount` (for steps), and `traceBytes` when evidence resolves. Never includes transcript content.
- `/trace`: on 404 (no trace), writes no audit row. `/steps`: always audits; omits `traceBytes` when no envelope resolved.
- Touchpoints: `server/routes/v1/evals.ts` now holds the bearer and calls `recordEvalIterationRead`; new `server/services/eval-trace-access-audit.ts` (`recordEvalIterationRead`, `measureTraceBytes`).

**Rollout**
- Deploy `POST /internal/v1/evals/iteration-read` on the backend first. Until then, the audit POST hits a routing 404, is logged, and ignored; reads continue and no audit rows are created.

<sup>Written for commit 6371ad07a011351d9eb7cae77e53835a786e3b4b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/MCPJam/inspector/pull/4133?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

