### PR TITLE
evals: an idempotent retry replays its run instead of running it again

### DIFF
--- a/.changeset/eval-run-idempotent-replay.md
+++ b/.changeset/eval-run-idempotent-replay.md
@@ -1,0 +1,48 @@
+---
+"@mcpjam/inspector": patch
+"@mcpjam/sdk": patch
+---
+
+Stop an idempotent retry from re-running the suite it already ran.
+
+An eval launch that carries an idempotency key is asking not to be charged
+twice. Convex honoured half of that: a repeat key returns the existing run
+instead of inserting a second row. But it returned it shaped exactly like a
+fresh launch — no marker saying it was a replay — so the inspector could not
+tell the two apart, took the run it was handed, and executed the whole suite
+against it. Every case ran a second time and billed a second time, writing over
+results that were already final. The key prevented a duplicate row and not the
+duplicate spend, which is the opposite of what the field's own documentation
+promises ("returns the EXISTING run instead of creating and billing a second
+one"), and it is why the run receipt reported a hardcoded `running` for a run
+that may have finished an hour earlier.
+
+The platform now says `deduped` and reports the run's real `status`, and every
+path that executes a prepared run consults `shouldSkipExecution` before doing
+so. This is Stripe's rule, not a new one: a duplicate key replays the original
+outcome rather than performing the work again. Crash recovery does not need to
+ride on it, because an explicit replay endpoint already exists for that.
+
+The skip is deliberately narrow — a replay of a run that has REACHED A TERMINAL
+STATUS, and nothing else. A replay of a run still marked `running` executes
+exactly as it does today: genuinely in flight and abandoned mid-flight are
+indistinguishable from here and want opposite treatments, and refusing to
+execute would strand the second. Telling them apart needs a liveness signal on
+the run, not a guess. Deploy skew is treated the same way: a backend that does
+not report `deduped` is unknown rather than fresh, so it keeps the old
+behaviour instead of gaining a refusal.
+
+Applied at every launch surface rather than the public API alone, because the
+callers that retry are the unattended ones. The scheduled worker passes its
+trigger id, so a redelivered trigger was re-running a completed scheduled run;
+the GitHub-checks worker passes its claim's trigger id, and now skips only the
+execution while still reading and reporting the finished run's verdict, which
+is what a redelivery should do.
+
+`/api/v1` responses gain `deduped` alongside the now-truthful `status`, on the
+single-run receipt and on each target of a grouped launch, so a caller can tell
+"I started this" from "this already existed" without diffing run ids across
+retries.
+
+Requires the companion backend change to be deployed first; against an older
+backend nothing changes.

--- a/docs/reference/openapi.json
+++ b/docs/reference/openapi.json
@@ -10882,7 +10882,11 @@
                 },
                 "runStatus": {
                   "type": "string",
-                  "description": "The RUN's status (always `running` at launch). Named apart from the entry's own `status` on purpose \u2014 two fields called `status` in one object is how a reader ends up branching on the wrong one."
+                  "description": "The RUN's status. `running` for a target that just launched; on a target whose run was REPLAYED (see `deduped`), that run's own status. Named apart from the entry's own `status` on purpose \u2014 two fields called `status` in one object is how a reader ends up branching on the wrong one."
+                },
+                "deduped": {
+                  "type": "boolean",
+                  "description": "Present and true when this target REPLAYED an existing run instead of starting one. A replayed run is not executed again, so the target costs no further credits."
                 },
                 "servers": {
                   "type": "array",
@@ -10988,7 +10992,11 @@
           },
           "status": {
             "type": "string",
-            "const": "running"
+            "description": "The run's status. `running` on a fresh launch; on a replay (see `deduped`), the existing run's own status, which may already be terminal."
+          },
+          "deduped": {
+            "type": "boolean",
+            "description": "Present and true when this request REPLAYED an existing run instead of starting one (an idempotency-key hit, or the short keyless dedupe window). A replayed run is not executed again, so no further credits are spent; read `status` for what that run actually is. Absent on a fresh launch."
           },
           "runGroupId": {
             "type": "string",

--- a/mcpjam-inspector/server/routes/shared/__tests__/evals.test.ts
+++ b/mcpjam-inspector/server/routes/shared/__tests__/evals.test.ts
@@ -9,6 +9,7 @@ import {
   buildCapEntriesFromPersistedCases,
   buildUpsertCaseKey,
   probeIdentityKey,
+  shouldSkipExecution,
   assertTestCaseRunWithinCap,
   buildManagerKeyToDisplayNameMap,
   fetchRunPinnedSkillsWithRetry,
@@ -904,5 +905,46 @@ describe("fetchRunPinnedSkillsWithRetry (strict pin fetch)", () => {
       fetchRunPinnedSkillsWithRetry({ query }, "run_1", noSleep)
     ).rejects.toThrow(/pinned skills after 3 attempts/);
     expect(calls).toBe(3);
+  });
+});
+
+describe("shouldSkipExecution", () => {
+  it("skips ONLY a replay of a run that already finished", () => {
+    // The one case with a single right answer: the run is done, its results
+    // are recorded, and executing again would repeat every case and bill for
+    // it — the double-spend the caller sent a key to prevent.
+    for (const status of ["completed", "failed", "cancelled", "timed_out"]) {
+      expect(shouldSkipExecution({ deduped: true, status })).toBe(true);
+    }
+  });
+
+  it("executes a replay of a run still in flight", () => {
+    // In-flight and abandoned-mid-flight are indistinguishable here and want
+    // opposite treatments, so this keeps the behaviour that predates the
+    // check: a crashed run can still be driven to completion by a retry.
+    expect(shouldSkipExecution({ deduped: true, status: "running" })).toBe(
+      false
+    );
+    expect(shouldSkipExecution({ deduped: true, status: "pending" })).toBe(
+      false
+    );
+  });
+
+  it("executes a fresh start, whatever its status says", () => {
+    expect(shouldSkipExecution({ deduped: false, status: "running" })).toBe(
+      false
+    );
+    // A fresh start reporting a terminal status is nonsense, but it must not
+    // be read as licence to skip: `deduped` is the field that decides.
+    expect(shouldSkipExecution({ deduped: false, status: "completed" })).toBe(
+      false
+    );
+  });
+
+  it("executes when the backend does not report a replay at all", () => {
+    // Deploy skew. An older backend's silence is UNKNOWN, not "fresh" and not
+    // "replayed" — and unknown must never start refusing to run work.
+    expect(shouldSkipExecution({})).toBe(false);
+    expect(shouldSkipExecution({ status: "completed" })).toBe(false);
   });
 });

--- a/mcpjam-inspector/server/routes/shared/evals.ts
+++ b/mcpjam-inspector/server/routes/shared/evals.ts
@@ -17,6 +17,7 @@ import {
   storeReplayConfig,
 } from "../../services/evals/route-helpers";
 import { loadSuiteHostConfig } from "../../services/evals/compat-runtime";
+import { isTerminalRunStatus } from "../../services/evals/run-status.js";
 import { checkEvalHarnessAdmission } from "../../services/evals/harness-admission";
 import {
   applyVisibilityPolicyAndCountSignals,
@@ -979,14 +980,60 @@ export type PreparedEvalRun = {
   };
   recorder: SuiteRunRecorder;
   /**
+   * This "start" REPLAYED an existing run rather than creating one — an
+   * idempotency-key hit, or the keyless fingerprint window. Undefined against a
+   * backend that predates the signal.
+   *
+   * Read it through {@link shouldSkipExecution}; a bare truthiness check here
+   * is the wrong question, because a replay of a run still in flight is not the
+   * same as a replay of one that finished.
+   */
+  deduped?: boolean;
+  /** The run's status as the platform holds it. `running` for a fresh start;
+   *  on a replay, whatever the existing run actually is. */
+  status?: string;
+  /**
    * Execute the prepared run to completion. `runEvalSuiteWithAiSdk` owns
    * terminal run status (completed/failed/cancelled); callers that detach
    * this (the async /api/v1 route) should still catch and defensively
    * finalize via `recorder` for errors thrown outside the runner's own
    * try.
+   *
+   * DO NOT call this unconditionally on a prepared run — see
+   * {@link shouldSkipExecution}. A replay of a finished run must not execute:
+   * the suite would run a second time and bill a second time, against a run
+   * whose results are already recorded.
    */
   execute: () => Promise<void>;
 };
+
+/**
+ * Whether a prepared run has already been run and must NOT be executed again.
+ *
+ * TRUE for exactly one case: the platform replayed an existing run AND that run
+ * is terminal. Executing then would re-run every case and bill for it, writing
+ * over results that are already final — which is the double-spend an
+ * idempotency key is sent to prevent.
+ *
+ * FALSE for a replay of a NON-terminal run, deliberately. Two situations are
+ * indistinguishable from here — a run genuinely in flight, and one abandoned
+ * when its process died mid-execution — and they want opposite treatments. The
+ * conservative answer preserves the behaviour that predates this check, so a
+ * crashed run can still be driven to completion by a retry the way it always
+ * has been. Deciding that case needs a liveness signal (a lease or heartbeat on
+ * the run), not a guess made here.
+ *
+ * FALSE against a backend with no `deduped` field, for the same reason: unknown
+ * is not a licence to change behaviour.
+ */
+export function shouldSkipExecution(prepared: {
+  deduped?: boolean;
+  status?: string;
+}): boolean {
+  return (
+    prepared.deduped === true && isTerminalRunStatus(prepared.status)
+  );
+}
 
 /**
  * A probe's identity is title + server + tool: every probe shares query ""
@@ -1979,6 +2026,8 @@ export async function prepareEvalRun(
     runId,
     config,
     recorder,
+    deduped: runWasDeduped,
+    status: existingRunStatus,
     hostConfig: runHostConfigSnapshot,
     pluginVersions: runEnvironmentPluginVersions = [],
   } = await startSuiteRunWithRecorder({
@@ -2253,6 +2302,8 @@ export async function prepareEvalRun(
       failed: failedCases,
     },
     recorder,
+    deduped: runWasDeduped,
+    status: existingRunStatus,
     execute,
   };
 }

--- a/mcpjam-inspector/server/routes/v1/__tests__/write-routes.test.ts
+++ b/mcpjam-inspector/server/routes/v1/__tests__/write-routes.test.ts
@@ -408,6 +408,137 @@ describe("v1 write routes", () => {
       });
     });
 
+    describe("idempotent replay", () => {
+      function mockReplay(status: string) {
+        const disconnectAllServers = vi.fn().mockResolvedValue(undefined);
+        createAuthorizedManagerMock.mockResolvedValue({
+          manager: { disconnectAllServers },
+          oauthServerUrls: {},
+          authenticatedUserId: null,
+        });
+        const execute = vi.fn().mockResolvedValue(undefined);
+        prepareEvalRunMock.mockResolvedValue({
+          suiteId: "suite_1",
+          runId: "run_1",
+          caseUpsert: { committed: [], failed: [] },
+          recorder: { finalize: vi.fn() },
+          execute,
+          // What the platform reports when a key (or the keyless fingerprint
+          // window) matched an existing run.
+          deduped: true,
+          status,
+        });
+        mockConvexQueries({
+          "testSuites:getSuiteRunServerSelection": () => ({
+            serverIds: ["s_alpha"],
+            serverNames: ["alpha"],
+            source: "host_config",
+          }),
+        });
+        return { execute, disconnectAllServers };
+      }
+
+      it("does NOT re-execute a replay of a FINISHED run", async () => {
+        // The whole point of sending a key. Executing here would run every
+        // case a second time and bill for it, over results already final.
+        const { execute, disconnectAllServers } = mockReplay("completed");
+
+        const res = await request(
+          makeApp(),
+          "POST",
+          "/api/v1/projects/p1/eval-runs",
+          { suiteId: "suite_1", idempotencyKey: "same-key" }
+        );
+
+        expect(res.status).toBe(202);
+        const body = (await res.json()) as any;
+        expect(body.runId).toBe("run_1");
+        // Reports what the run IS, not what a launch would have made it.
+        expect(body.status).toBe("completed");
+        expect(body.deduped).toBe(true);
+        expect(execute).not.toHaveBeenCalled();
+        // The manager and the concurrency slot are still settled — the
+        // `.finally` that normally does it belongs to an execution that never
+        // happened.
+        await vi.waitFor(() =>
+          expect(disconnectAllServers).toHaveBeenCalledTimes(1)
+        );
+      });
+
+      it("releases the concurrency slot when it skips execution", async () => {
+        // A skipped run that kept its slot would brick the org's quota just as
+        // surely as a leaked one.
+        mockReplay("completed");
+        for (let i = 0; i < 5; i += 1) {
+          const res = await request(
+            makeApp(),
+            "POST",
+            "/api/v1/projects/p1/eval-runs",
+            { suiteId: "suite_1", idempotencyKey: `key_${i}` }
+          );
+          expect(res.status).toBe(202);
+        }
+      });
+
+      it("DOES execute a replay of a run still in flight", async () => {
+        // Deliberately unchanged: an in-flight run and one abandoned mid-flight
+        // are indistinguishable from here, and refusing to execute would strand
+        // the second. Deciding that needs a liveness signal, not a guess.
+        const { execute } = mockReplay("running");
+
+        const res = await request(
+          makeApp(),
+          "POST",
+          "/api/v1/projects/p1/eval-runs",
+          { suiteId: "suite_1", idempotencyKey: "same-key" }
+        );
+
+        expect(res.status).toBe(202);
+        expect((await res.json()).status).toBe("running");
+        expect(execute).toHaveBeenCalledTimes(1);
+      });
+
+      it("executes normally against a backend with no replay signal", async () => {
+        // Deploy skew: absent `deduped` is UNKNOWN, not "fresh". Unknown must
+        // keep the old behaviour rather than start refusing to run.
+        const disconnectAllServers = vi.fn().mockResolvedValue(undefined);
+        createAuthorizedManagerMock.mockResolvedValue({
+          manager: { disconnectAllServers },
+          oauthServerUrls: {},
+          authenticatedUserId: null,
+        });
+        const execute = vi.fn().mockResolvedValue(undefined);
+        prepareEvalRunMock.mockResolvedValue({
+          suiteId: "suite_1",
+          runId: "run_1",
+          caseUpsert: { committed: [], failed: [] },
+          recorder: { finalize: vi.fn() },
+          execute,
+        });
+        mockConvexQueries({
+          "testSuites:getSuiteRunServerSelection": () => ({
+            serverIds: ["s_alpha"],
+            serverNames: ["alpha"],
+            source: "host_config",
+          }),
+        });
+
+        const res = await request(
+          makeApp(),
+          "POST",
+          "/api/v1/projects/p1/eval-runs",
+          { suiteId: "suite_1", idempotencyKey: "same-key" }
+        );
+
+        expect(res.status).toBe(202);
+        const body = (await res.json()) as any;
+        expect(body.status).toBe("running");
+        expect(body.deduped).toBeUndefined();
+        expect(execute).toHaveBeenCalledTimes(1);
+      });
+    });
+
+
     describe("environment-backed runs", () => {
       // Attach-ordered environments on the suite; the route's selection rule
       // reads this, not the caller's word.

--- a/mcpjam-inspector/server/routes/v1/evals.ts
+++ b/mcpjam-inspector/server/routes/v1/evals.ts
@@ -40,6 +40,8 @@ import {
 import { opaqueIdSchema } from "@mcpjam/sdk/contract";
 import { checkEvalHarnessStaticAdmission } from "../../services/evals/harness-admission.js";
 import { loadSuiteHostConfig } from "../../services/evals/compat-runtime.js";
+import { TERMINAL_RUN_STATUSES } from "../../services/evals/run-status.js";
+import { shouldSkipExecution } from "../shared/evals.js";
 import {
   createEvalCasesInBatches,
   partialResultOf,
@@ -1023,16 +1025,6 @@ export async function fetchSuiteRunServerSelection(
   }
   return { serverIds, serverNames };
 }
-
-const TERMINAL_RUN_STATUSES = new Set([
-  "completed",
-  "failed",
-  "cancelled",
-  // The runner finalizes run/iteration timeouts as `timed_out` before
-  // rethrowing into the detached catch. Treat it as terminal so the defensive
-  // re-finalize can't overwrite a timeout result with `failed`.
-  "timed_out",
-]);
 
 /**
  * Whether the run record already reached a terminal status. Used by the
@@ -2206,6 +2198,14 @@ async function resolveHostAttachments(
 interface LaunchedEvalRun {
   runId: string;
   suiteId: string;
+  /**
+   * What the run IS, not what a launch would make it. `running` for a fresh
+   * start; on an idempotent replay, the existing run's own status — which may
+   * already be terminal.
+   */
+  status: string;
+  /** This request replayed an existing run instead of starting one. */
+  deduped: boolean;
   caseUpsert: unknown;
   servers: Array<{ id: string; name?: string }>;
   environment: {
@@ -2323,6 +2323,41 @@ async function launchEvalRun(params: {
   // outside the runner's own try (provider construction, etc.) — it only
   // finalizes when the run record is still non-terminal, so the runner's
   // completedAt/notes are never restamped by a second terminal write.
+  // A REPLAY of a finished run executes nothing. `prepared.execute()` would
+  // re-run every case and bill for it, writing over results that are already
+  // final — the exact double-spend the caller sent an idempotency key to
+  // prevent. The slot and the manager still have to be settled here, because
+  // the `.finally` that normally does it belongs to an execution that is not
+  // going to happen.
+  if (shouldSkipExecution(prepared)) {
+    logger.info("[v1 evals] idempotent replay — not re-executing", {
+      runId: prepared.runId,
+      suiteId: prepared.suiteId,
+      status: prepared.status,
+      projectId,
+    });
+    onSettled();
+    void manager.disconnectAllServers().catch(() => {});
+    return {
+      runId: prepared.runId,
+      suiteId: prepared.suiteId,
+      status: prepared.status ?? "running",
+      deduped: true,
+      caseUpsert: prepared.caseUpsert,
+      servers: serverIds.map((serverId, index) => ({
+        id: serverId,
+        ...(serverNames?.[index] ? { name: serverNames[index] } : {}),
+      })),
+      environment: environmentLaunch
+        ? {
+            id: environmentLaunch.environmentRef.environmentId,
+            name: environmentLaunch.environmentRef.name,
+            revision: environmentLaunch.environmentRef.revision,
+          }
+        : null,
+    };
+  }
+
   void prepared
     .execute()
     .catch(async (error) => {
@@ -2352,6 +2387,10 @@ async function launchEvalRun(params: {
   return {
     runId: prepared.runId,
     suiteId: prepared.suiteId,
+    // Executing now. A replay of a run still IN FLIGHT lands here too and is
+    // reported as running, which is what it is.
+    status: prepared.status ?? "running",
+    deduped: prepared.deduped === true,
     caseUpsert: prepared.caseUpsert,
     // The servers the run connects to — explicit or derived from the
     // suite's saved selection — so callers that omitted serverIds can
@@ -2594,7 +2633,12 @@ evals.post("/projects/:projectId/eval-runs", async (c) => {
       {
         runId: launched.runId,
         suiteId: launched.suiteId,
-        status: "running",
+        // The run's REAL status. A replay of a finished run reports what it
+        // finished as; only a launch reports `running`.
+        status: launched.status,
+        // Present so a caller can tell "I started this" from "this already
+        // existed and I got it back" without diffing run ids across retries.
+        ...(launched.deduped ? { deduped: true } : {}),
         caseUpsert: launched.caseUpsert,
         servers: launched.servers,
         environment: launched.environment,
@@ -2936,11 +2980,10 @@ evals.post("/projects/:projectId/eval-run-groups", async (c) => {
         // started/failed discriminant, and two fields with one name is how a
         // reader ends up branching on the wrong one.
         //
-        // Always `running`, matching the single-run route: an idempotent
-        // replay returns the ORIGINAL run, which may have finished, and the
-        // prepare layer does not report which happened. Poll the run for its
-        // real state — this field says a run exists, not how it is doing.
-        runStatus: "running",
+        // The run's REAL status, so a target that replayed a finished run says
+        // so instead of claiming to be running.
+        runStatus: launched.status,
+        ...(launched.deduped ? { deduped: true } : {}),
         servers: launched.servers,
         environment: launched.environment,
         caseUpsert: launched.caseUpsert,
@@ -2991,7 +3034,7 @@ evals.post("/projects/:projectId/eval-run-groups", async (c) => {
             const first = entries.find((entry) => entry.status === "started")!;
             return {
               runId: first.runId,
-              status: "running",
+              status: first.runStatus,
               servers: first.servers,
               environment: first.environment,
               caseUpsert: first.caseUpsert,

--- a/mcpjam-inspector/server/services/evals/detached-run.ts
+++ b/mcpjam-inspector/server/services/evals/detached-run.ts
@@ -1,12 +1,7 @@
 import { logger } from "../../utils/logger.js";
 import { createConvexClient } from "./route-helpers.js";
-
-const TERMINAL_RUN_STATUSES = new Set([
-  "completed",
-  "failed",
-  "cancelled",
-  "timed_out",
-]);
+import { TERMINAL_RUN_STATUSES } from "./run-status.js";
+import { shouldSkipExecution } from "../../routes/shared/evals.js";
 
 type DetachableEvalRun = {
   suiteId: string;
@@ -25,6 +20,10 @@ type DetachableEvalRun = {
     }): Promise<void>;
   } | null;
   execute: () => Promise<void>;
+  /** Set when this "start" replayed an existing run — see `shouldSkipExecution`. */
+  deduped?: boolean;
+  /** The run's own status; terminal on a replay of a finished run. */
+  status?: string;
 };
 
 async function isRunAlreadyTerminal(
@@ -56,6 +55,22 @@ export function detachPreparedEvalRun(args: {
   cleanup?: () => Promise<void> | void;
 }) {
   const { prepared, convexAuthToken, logPrefix, logContext, cleanup } = args;
+
+  // A REPLAY of a finished run has nothing to execute. Running it would repeat
+  // every case and bill for it, over results that are already final — the
+  // double-spend an idempotency key is sent to prevent. Guarded here rather
+  // than at each call site so every surface that detaches a run inherits it.
+  if (shouldSkipExecution(prepared)) {
+    logger.info(`${logPrefix} idempotent replay — not re-executing`, {
+      ...logContext,
+      suiteId: prepared.suiteId,
+      runId: prepared.runId,
+      status: prepared.status,
+    });
+    void Promise.resolve(cleanup?.()).catch(() => {});
+    return;
+  }
+
   void Promise.resolve()
     .then(() => prepared.execute())
     .catch(async (error) => {

--- a/mcpjam-inspector/server/services/evals/recorder.ts
+++ b/mcpjam-inspector/server/services/evals/recorder.ts
@@ -704,6 +704,20 @@ export const startSuiteRunWithRecorder = async ({
     suiteId,
     config,
     recorder,
+    /**
+     * This start was a REPLAY of an existing run (idempotency key hit, or the
+     * keyless fingerprint window), not a launch.
+     *
+     * Absent from a backend that predates the field, which callers must read
+     * as "unknown", NOT as "fresh": treating an old backend's silence as a
+     * launch is exactly the assumption that had retries re-running a finished
+     * suite. Skew therefore keeps the old behaviour rather than gaining the
+     * new refusal.
+     */
+    deduped: response?.deduped as boolean | undefined,
+    /** The run's status as the platform holds it — `completed` on a replay of
+     *  a finished run, not the `running` a launch would report. */
+    status: response?.status as string | undefined,
     hostConfig: response?.hostConfig as
       | Record<string, unknown>
       | null

--- a/mcpjam-inspector/server/services/evals/run-status.ts
+++ b/mcpjam-inspector/server/services/evals/run-status.ts
@@ -1,0 +1,27 @@
+/**
+ * The one definition of "this run will never do more work".
+ *
+ * Three copies of this set had grown along the eval-run path, and the cost of a
+ * fourth is not the duplication itself — it is that each copy is a place a new
+ * terminal status can be added to three of four lists. A run status the
+ * detached-execution guard treats as terminal while the replay guard does not
+ * is a run that gets finalized twice, or executed twice.
+ *
+ * (`services/github-checks-worker.ts` keeps its own copy: it is a different
+ * subsystem with its own status vocabulary, and folding it in here would
+ * couple the two.)
+ */
+export const TERMINAL_RUN_STATUSES: ReadonlySet<string> = new Set([
+  "completed",
+  "failed",
+  "cancelled",
+  // The runner finalizes run/iteration timeouts as `timed_out` before
+  // rethrowing into the detached catch. Terminal, so a defensive re-finalize
+  // cannot overwrite a timeout result with `failed`.
+  "timed_out",
+]);
+
+/** Whether a run status means the run has finished, however it finished. */
+export function isTerminalRunStatus(status: unknown): boolean {
+  return typeof status === "string" && TERMINAL_RUN_STATUSES.has(status);
+}

--- a/mcpjam-inspector/server/services/github-checks-worker.ts
+++ b/mcpjam-inspector/server/services/github-checks-worker.ts
@@ -41,7 +41,9 @@ import { WEB_CALL_TIMEOUT_MS } from "../config.js";
 import { logger } from "../utils/logger";
 import { getConvexBearerForDelegation } from "../utils/v1-convex-token.js";
 import { createAuthorizedManager } from "../routes/web/auth.js";
-import { prepareEvalRun } from "../routes/shared/evals.js";
+import { prepareEvalRun,
+  shouldSkipExecution,
+} from "../routes/shared/evals.js";
 import { createConvexClient } from "./evals/route-helpers.js";
 import type { CheckRecipe } from "./github-checks/recipes.js";
 import {
@@ -1037,7 +1039,21 @@ async function defaultRunEvalSuite(args: {
     }
 
     try {
-      await prepared.execute();
+      // A redelivered claim replays the run its trigger id already started. If
+      // that run FINISHED, re-executing would run the suite a second time and
+      // bill for it — and the verdict this check needs is already recorded on
+      // it. Only the execution is skipped; everything below still reads the
+      // run's terminality and reports it, which is exactly what a redelivery
+      // should do.
+      if (shouldSkipExecution(prepared)) {
+        logger.info("[github-checks] trigger already ran — not re-executing", {
+          triggerId: args.claimed.triggerId,
+          runId: prepared.runId,
+          status: prepared.status,
+        });
+      } else {
+        await prepared.execute();
+      }
     } catch (error) {
       // A throw from `execute()` is NOT an eval verdict, and must not be read as
       // one. `runEvalSuiteWithAiSdk` finalizes a normal run — pass or fail —

--- a/mcpjam-inspector/server/services/scheduled-evals-worker.ts
+++ b/mcpjam-inspector/server/services/scheduled-evals-worker.ts
@@ -26,6 +26,7 @@ import { createAuthorizedManager } from "../routes/web/auth.js";
 import {
   prepareEvalRun,
   type PreparedEvalRun,
+  shouldSkipExecution,
 } from "../routes/shared/evals.js";
 import { fetchSuiteRunServerSelection } from "../routes/v1/evals.js";
 import { createConvexClient } from "./evals/route-helpers.js";
@@ -261,6 +262,19 @@ export async function executeClaimedRun(
         triggerId: claimed.triggerId,
         ok: false,
         failureReason: classifyFailure(error),
+      });
+      return;
+    }
+
+    // The trigger id IS this run's idempotency key, so a redelivered trigger
+    // replays the run it already started. If that run has finished, there is
+    // nothing left to do — executing would re-run the suite and bill the
+    // organization a second time for a scheduled run it only asked for once.
+    if (shouldSkipExecution(prepared)) {
+      logger.info("[scheduled-evals] trigger already ran — not re-executing", {
+        ...logContext,
+        runId: prepared.runId,
+        status: prepared.status,
       });
       return;
     }

--- a/sdk/src/platform/types.ts
+++ b/sdk/src/platform/types.ts
@@ -359,7 +359,20 @@ export interface PlatformEvalRunEnvironment {
 export interface PlatformEvalRunCreated {
   runId: string;
   suiteId: string;
+  /**
+   * The run's status. `running` on a fresh launch; on a replay (see
+   * `deduped`), the existing run's own status — which may already be terminal.
+   */
   status: string;
+  /**
+   * This request REPLAYED an existing run rather than starting one — an
+   * idempotency-key hit, or the short keyless dedupe window.
+   *
+   * A replayed run is NOT executed again, so a retry spends nothing further.
+   * Absent on a fresh launch, and on an API deployment that predates the
+   * signal — where absence means "not reported", not "fresh".
+   */
+  deduped?: boolean;
   /**
    * Echo of the request's `runGroupId`, when one was sent. A LABEL only — it
    * groups sibling rows for display and carries no quota or launch semantics.


### PR DESCRIPTION
**Depends on [mcpjam-backend#1050](https://github.com/MCPJam/mcpjam-backend/pull/1050) — deploy that first.** Against an older backend nothing changes.

## What's wrong

A launch that carries an idempotency key is asking not to be charged twice. Convex honours half of that: a repeat key returns the existing run instead of inserting a second row. But it returns it shaped exactly like a fresh launch, with no marker saying it was a replay — so the inspector cannot tell the two apart, takes the run it is handed, and executes the whole suite against it.

Every case runs a second time and bills a second time, writing over results that are already final. The key prevents a duplicate **row**, not the duplicate **spend** — the opposite of what the field's own documentation promises (*"returns the EXISTING run instead of creating and billing a second one"*). It is also why the run receipt reported a hardcoded `running` for a run that may have finished an hour earlier, which is where this started.

## Change

The platform now reports `deduped` and the run's real `status`, and every path that executes a prepared run consults `shouldSkipExecution` first.

This is Stripe's rule rather than a new one — a duplicate key replays the original outcome instead of performing the work again. Crash recovery does not need to ride on it, because an explicit replay endpoint already exists for that.

**The skip is deliberately narrow:** a replay of a run that has reached a *terminal* status, and nothing else. A replay of a run still marked `running` executes exactly as it does today — genuinely in-flight and abandoned-mid-flight are indistinguishable from here and want opposite treatments, and refusing to execute would strand the second. Telling them apart needs a liveness signal on the run, not a guess made at this seam.

Deploy skew reads the same way: a backend that does not report `deduped` is **unknown**, not fresh, so it keeps the old behaviour rather than gaining a refusal.

Applied at every launch surface rather than the public API alone, because the callers that retry are the unattended ones:

- **scheduled worker** — passes its trigger id, so a redelivered trigger was re-running a completed scheduled run.
- **GitHub-checks worker** — passes its claim's trigger id; now skips only the execution while still reading and reporting the finished run's verdict, which is what a redelivery should do.
- **`detachPreparedEvalRun`** — guarded once so every surface that detaches a run inherits it.

`/api/v1` gains `deduped` beside the now-truthful `status`, on the single-run receipt and on each target of a grouped launch, so a caller can tell "I started this" from "this already existed" without diffing run ids across retries. The spec's `status: const running` was a promise the endpoint could already break.

`TERMINAL_RUN_STATUSES` had three copies along this path and this change wanted a fourth; it has one now. A status that counts as terminal for the detached-execution guard but not for the replay guard is a run that gets finalized twice, or executed twice.

## Verification

- `server/routes/v1/__tests__/`, `server/routes/shared/__tests__/`, `server/services/evals/__tests__/`, `server/routes/web/__tests__/`, `server/routes/mcp/__tests__/` — 2,597 passed
- `server/services/__tests__/` (scheduled + GitHub-checks workers) — 525 passed
- SDK `tests/platform/` — 181 passed
- OpenAPI drift + types-parity ratchets green (the parity ratchet caught the missing SDK field, which is now declared)

New tests cover: a replay of a finished run is not executed and reports the real status; the concurrency slot and manager are still settled when execution is skipped; a replay of an in-flight run still executes; an older backend with no signal still executes. Each was confirmed to fail with the guard disabled.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit 4e0ce86f44d3da57aca17615d8cbf4788802e746. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Idempotent eval-run retries now replay the original run instead of executing again. Previously a duplicate key returned the existing run but still re-ran the suite, double-billing and overwriting results; now we skip execution when the replayed run is terminal and return its real status.

- Adds `deduped` and truthful `status` to `/api/v1` responses (single-run and group entries). `status` may be terminal on a replay; callers can distinguish “started” vs “replayed” without diffing run IDs.
- Introduces `shouldSkipExecution` and applies it across all launch surfaces: API, `detachPreparedEvalRun`, scheduled worker, and GitHub-checks worker. Skips only when `deduped=true` and status is terminal; replays of non-terminal runs still execute.
- Consolidates terminal run status into `services/evals/run-status.ts` (`TERMINAL_RUN_STATUSES`, `isTerminalRunStatus`) and removes duplicated sets.
- Ensures resources settle when execution is skipped (concurrency slot, manager disconnects), preserving quotas.
- Updates OpenAPI and `@mcpjam/sdk` types to include `deduped` and clarify `status`.

**Rollout**
- Deploy the companion backend change first; against older backends (no `deduped`) behavior is unchanged.
- Client migration optional: read `deduped` when present and use the returned `status` (do not assume `running` at launch).

<sup>Written for commit 4e0ce86f44d3da57aca17615d8cbf4788802e746. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/MCPJam/inspector/pull/4134?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

