### PR TITLE
fix(docs): dedupe the OpenAPI keys that have failed every Mintlify build since Aug 16

### DIFF
--- a/docs/reference/openapi.json
+++ b/docs/reference/openapi.json
@@ -4079,7 +4079,7 @@
             "$ref": "#/components/parameters/projectId"
           },
           {
-            "$ref": "#/components/parameters/scenarioId"
+            "$ref": "#/components/parameters/projectScenarioId"
           }
         ],
         "responses": {
@@ -8810,7 +8810,7 @@
           "type": "string"
         }
       },
-      "scenarioId": {
+      "projectScenarioId": {
         "name": "scenarioId",
         "in": "path",
         "required": true,
@@ -13517,7 +13517,7 @@
           }
         }
       },
-      "Scenario": {
+      "ProjectScenario": {
         "type": "object",
         "description": "Summary of a published scenario, as returned by the list endpoint.",
         "required": [
@@ -13748,7 +13748,7 @@
           "items": {
             "type": "array",
             "items": {
-              "$ref": "#/components/schemas/Scenario"
+              "$ref": "#/components/schemas/ProjectScenario"
             }
           }
         }


### PR DESCRIPTION
## The outage

`docs.mcpjam.com` has been serving the **Aug 15, 20:00 UTC** build for four days. Every Mintlify deploy since has failed with:

> Update failed — Failed to fetch OpenAPI file for anchor or tab

**15 docs commits are undeployed**, including the Okta SSO & SCIM guide (#4122), which is why `docs.mcpjam.com/hosted/sso` 404s. The live site also still says "chatbox" everywhere and still lists Cursor 3.4.17.

## Root cause

The chatbox → scenario rename (#4050, Aug 16 — exactly the first failed build) renamed two component keys onto names that were already taken:

| Renamed | Collided with |
|---|---|
| `components.parameters.chatboxId` → `scenarioId` | the user-testing `scenarioId` |
| `components.schemas.Chatbox` → `Scenario` | the user-testing `Scenario` |

`JSON.parse` silently keeps the **last** of a duplicate key, so every JS-side check we have passes: the file parses, operationIds are unique, no `$ref` dangles, no cycles, no equivalent-path collisions. **Mintlify parses the spec as YAML**, where a duplicate mapping key is a hard error:

```
error duplicated mapping key (8894:7)   →  "scenarioId"
error duplicated mapping key (17668:7)  →  "Scenario"
```

## The fix

Rename the ex-chatbox keys rather than dropping either definition — they describe different resources that happen to share a path segment. The 16 user-testing refs are untouched.

```
components.parameters.scenarioId → projectScenarioId   (+ its 1 ref)
components.schemas.Scenario      → ProjectScenario     (+ its 1 ref)
```

This also fixes a **silent mis-render that shipped with the rename**: because the duplicates resolved to whichever came last in the file, both `/projects/{projectId}/scenarios` endpoints were being documented with the user-testing scenario's parameter and schema.

## Verification

- `mint openapi-check` → `success OpenAPI definition is valid.`
- Duplicate-key scan of the whole file (parser with `object_pairs_hook`) → none left
- **Dereferenced**-spec diff vs `main` → exactly **2** paths change, `/projects/{projectId}/scenarios` and `/scenarios/{scenarioId}` — the two that were resolving wrong. The other 113 are byte-identical.
- `openapi-types-parity.test.ts` → 7 passed

`openapi-drift.test.ts` could not run in my worktree (missing `PluginShim.bundled.js` build artifact, unrelated to this change) — worth a local run before merge.

Once this lands, the whole 15-commit backlog deploys in one build. The dashboard's **Manual update** button will not help until this is in — it fails the same way.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit 40d79de805c20f785dae650fdbe8e05dc7fb462e. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Unblocks Mintlify docs builds by deduping OpenAPI component keys and fixing two scenario endpoints that were mis-rendered. The chatbox→scenario rename created duplicate YAML keys; we renamed the ex-chatbox parameter and schema to unique names and updated their refs.

- Old: `components.parameters.scenarioId`, `components.schemas.Scenario` (collided with user-testing keys)
- New: `components.parameters.projectScenarioId`, `components.schemas.ProjectScenario`
- No API behavior change: the path parameter is still named "scenarioId"; only component key names changed.

**Review notes**
- Changes are confined to `docs/reference/openapi.json`: rename two component keys and update their refs.
- Verify Mintlify passes and that only `/projects/{projectId}/scenarios` and `/scenarios/{scenarioId}` differ in the dereferenced spec.
- User-testing refs remain unchanged.
- Please run `openapi-drift.test.ts` locally (artifact issue prevented running it in the submitter’s worktree).

**Rollout**
- Merge to resume docs deploys; the 15-commit backlog will publish on the next Mintlify build. The dashboard’s Manual update will continue to fail until this merges.
- If you generate clients from this spec, expect the type name for project scenarios to change to `ProjectScenario`; no wire/endpoint changes required.

<sup>Written for commit 40d79de805c20f785dae650fdbe8e05dc7fb462e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/MCPJam/inspector/pull/4136?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

