### PR TITLE
changesets: release Inspector, CLI, and SDK

### DIFF
--- a/.changeset/releases-2026-08-19-2.md
+++ b/.changeset/releases-2026-08-19-2.md
@@ -1,0 +1,14 @@
+---
+"@mcpjam/inspector": minor
+"@mcpjam/cli": minor
+"@mcpjam/sdk": minor
+---
+
+Release the latest Inspector, CLI, and SDK updates.
+
+- Give agent surfaces the full eval-run target matrix: explicit fan-out, one atomic batch launch, ad-hoc composed client/model/computer/skills stacks, and a retry that replays its run instead of running it again.
+- Expose the suite settings that were app-only — LLM-as-Judge `autoRun` and threshold, minimum iterations, and the computer image — with a ratchet that stops a new settings row from shipping UI-only.
+- Make judge results readable and grading requestable from the SDK, CLI, and MCP, instead of grading into a place no agent could see.
+- Reach GitHub Checks from agents: list and connect check repositories, bind a GitHub account to a workspace, and say when a connected repository is not actually ready.
+- Load suite files from disk, and add `mcpjam eval validate` and `mcpjam eval export`.
+- Add the Claude connectors directory to the Registry tab, and make Claude readiness name the input that closes each gap rather than recommending intrusive probes.


### PR DESCRIPTION
- Adds one changeset that bumps `@mcpjam/inspector`, `@mcpjam/cli`, and `@mcpjam/sdk` a minor version each.
- This is what triggers the next release — it rolls up the 18 changesets sitting on main since v2.42.0.
- The body is a plain-English summary of that work: eval run targets, suite settings on agent surfaces, judge results, GitHub Checks, suite files, and the Claude connectors directory.
- No code changes, just the changeset file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Release minor versions of `@mcpjam/inspector`, `@mcpjam/cli`, and `@mcpjam/sdk` to roll up 18 changes on main since v2.42.0. No code changes here; this adds the changeset that triggers the release.

**Highlights**
- Agent surfaces get the full eval-run target matrix: explicit fan-out, one atomic batch launch, ad-hoc client/model/computer/skills stacks, and a retry that replays its original run instead of re-running.
- Expose previously app-only suite settings (LLM-as-Judge autoRun and threshold, minimum iterations, computer image) with a ratchet to prevent UI-only settings from shipping.
- Make judge results readable and grading requestable from SDK, CLI, and MCP (was grading into a place agents could not see).
- Reach GitHub Checks from agents: list/connect check repositories, bind a GitHub account to a workspace, and surface when a connected repository is not ready.
- Load suite files from disk; add `mcpjam eval validate` and `mcpjam eval export`.
- Add the Claude connectors directory to the Registry tab; readiness now names required inputs instead of recommending intrusive probes.

**Review notes**
- Only a `.changeset` file is added; verify minor bumps for the three packages and the summary content. Merging will allow the standard Changesets workflow to generate and publish the release.

<sup>Written for commit 3f3da690c1cb37fa3dcb4742b4f84b7c93723ee3. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/MCPJam/inspector/pull/4138?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

