### PR TITLE
auth: a /login route so IdP-initiated SSO can finish signing in

### DIFF
--- a/.changeset/idp-initiated-sso-login-route.md
+++ b/.changeset/idp-initiated-sso-login-route.md
@@ -30,6 +30,11 @@ already serve `index.html` for unmatched paths, so no server change is
 involved. An already-signed-in visitor (a second tile click) is sent into the
 app rather than back through WorkOS.
 
+A sign-in that fails to start renders a retry rather than an endless spinner.
+This route is the entry point an SSO user arrives on, so a dead end there costs
+them the login with nothing to click — the same hazard `/callback` already
+guards with its own recovery UI.
+
 Query parameters are ignored on purpose. The `context` hand-off the older
 examples forward is deprecated — the endpoint is expected only to start a fresh
 sign-in — and forwarding it could not work anyway, since authkit-js omits

--- a/.changeset/idp-initiated-sso-login-route.md
+++ b/.changeset/idp-initiated-sso-login-route.md
@@ -1,0 +1,41 @@
+---
+"@mcpjam/inspector": patch
+---
+
+Add the `/login` initiate-login route so IdP-initiated SSO completes instead of failing the code exchange.
+
+Clicking the MCPJam tile in an Okta dashboard got as far as WorkOS and no
+further. Okta posts its SAML assertion, WorkOS validates it and sends an
+authorization code to `/callback`, and `@workos-inc/authkit-js` refuses to
+exchange it: "Couldn't exchange code… The developer may not have configured a
+Login Initiation endpoint." Nothing was misconfigured on the SAML side. The
+exchange runs client-side and needs the PKCE code verifier that sign-in wrote
+into that tab's `sessionStorage` — a key that exists only when the sign-in
+started in the app. A login that started at the identity provider has no such
+tab, so the flow was unfinishable by construction, and enterprise SSO users had
+no working entry point from their own dashboard.
+
+The fix WorkOS sanctions is an Initiate Login URL. Once one is configured,
+AuthKit recognizes a non-app-originated login and redirects the browser there
+INSTEAD of issuing a code; the app then begins an ordinary sign-in, which
+AuthKit completes silently against the SSO session the IdP already established
+— no second prompt — and the code lands on `/callback` beside a verifier that
+matches it.
+
+`/login` is that URL. It has to be a client route rather than a server
+redirect for exactly the reason the flow was failing: a server-generated PKCE
+verifier cannot be written into the browser's `sessionStorage`. The SPA boots,
+the route calls `signIn()`, and authkit-js mints its own. Both entrypoints
+already serve `index.html` for unmatched paths, so no server change is
+involved. An already-signed-in visitor (a second tile click) is sent into the
+app rather than back through WorkOS.
+
+Query parameters are ignored on purpose. The `context` hand-off the older
+examples forward is deprecated — the endpoint is expected only to start a fresh
+sign-in — and forwarding it could not work anyway, since authkit-js omits
+`context` when it builds the authorize URL.
+
+Taking effect also requires setting the Initiate Login URL to
+`https://app.mcpjam.com/login` in the WorkOS dashboard (Applications →
+Redirects, per environment), which is a dashboard setting rather than a code
+change. Normal sign-in and guest mode are untouched: the route is additive.

--- a/mcpjam-inspector/client/src/App.tsx
+++ b/mcpjam-inspector/client/src/App.tsx
@@ -2313,6 +2313,15 @@ export default function App() {
     barePathname === routePaths.embedScore ||
     barePathname.startsWith(`${routePaths.scoreResults}/`) ||
     barePathname.startsWith(`${routePaths.capabilities}/`);
+  // The WorkOS Initiate Login URL, where an IdP-initiated login (the Okta app
+  // tile) is parked for the instant it takes `LoginInitiationRoute` to start a
+  // fresh sign-in. `/login` is not a known tab segment, so it resolves to the
+  // `servers` fallback — which is a first-run-eligible route, and a hosted
+  // guest session is Convex-authenticated. Without this the onboarding redirect
+  // below can fire on the very commit that mounts the route and navigate the
+  // visitor to Playground mid-sign-in, stranding exactly the enterprise entry
+  // point this route exists to fix.
+  const isLoginInitiationRoute = barePathname === routePaths.login;
 
   const defaultHubRoute = useMemo((): "home" | "connect" | "servers" => {
     return "home";
@@ -2920,6 +2929,7 @@ export default function App() {
   const shouldRouteToFirstRunOnboarding =
     !isHostedChatRoute &&
     !isBareCaniuseRoute &&
+    !isLoginInitiationRoute &&
     !hasHostTemplateVerifyParam &&
     !hasProjectSwitchDeepLinkParam &&
     !isWorkOsLoading &&

--- a/mcpjam-inspector/client/src/__tests__/App.hosted-oauth.test.tsx
+++ b/mcpjam-inspector/client/src/__tests__/App.hosted-oauth.test.tsx
@@ -805,7 +805,9 @@ describe("App hosted OAuth callback handling", () => {
       screen.queryByTestId("callback-auth-timeout")
     ).not.toBeInTheDocument();
     expect(mockWorkOsAuthState.signIn).not.toHaveBeenCalled();
-    expect(readScenarioSignInReturnPath()).toBe("/user-testing/asana/token-123");
+    expect(readScenarioSignInReturnPath()).toBe(
+      "/user-testing/asana/token-123"
+    );
   });
 
   it("clears stale client auth state before retrying a timed-out callback", async () => {
@@ -2258,7 +2260,7 @@ describe("App hosted OAuth callback handling", () => {
     // User Testing is flag-gated at the route, not just in the sidebar — the
     // callback can only land back on it for a user who has the flag.
     mockUseFeatureFlagEnabled.mockImplementation(
-      (flag: string) => flag === "sandboxes-enabled",
+      (flag: string) => flag === "sandboxes-enabled"
     );
     mockCompleteHostedOAuthCallback.mockResolvedValue({
       success: true,
@@ -2367,6 +2369,40 @@ describe("App hosted OAuth callback handling", () => {
         hasSeenFirstRunOnboarding: false,
       })
     );
+  });
+
+  it("leaves an IdP-initiated visitor on /login instead of auto-routing to Playground", async () => {
+    // Same first-run-eligible guest as the test above, at the WorkOS Initiate
+    // Login URL. `/login` is not a known tab segment, so the shell resolves it
+    // to the `servers` fallback — a first-run-eligible route — and a hosted
+    // guest session IS Convex-authenticated. Without the guard in
+    // `shouldRouteToFirstRunOnboarding`, the onboarding redirect fires on the
+    // commit that mounts LoginInitiationRoute and navigates the visitor to
+    // Playground mid-sign-in, stranding the enterprise entry point the route
+    // exists to fix.
+    //
+    // Asserts the App-level half only: `render(<App />)` mounts no Router, so
+    // the shell renders its no-router body rather than the route element. That
+    // `signIn()` is what actually runs there is covered by
+    // `components/auth/__tests__/login-initiation-route.test.tsx`.
+    clearHostedOAuthPendingState();
+    clearScenarioSession();
+    mockUnseenOnboardingState();
+    window.history.replaceState({}, "", "/login");
+    mockHandleOAuthCallback.mockReset();
+    mockConvexAuthState.isAuthenticated = true;
+    mockWorkOsAuthState.user = null;
+    mockHostedShellGateState.value = "ready";
+    mockFreshGuestUser();
+
+    render(<App />);
+
+    await waitFor(() => {
+      expect(screen.getByTestId("mcp-sidebar")).toBeInTheDocument();
+    });
+
+    expect(window.location.pathname).toBe("/login");
+    expect(screen.queryByTestId("playground-tab")).not.toBeInTheDocument();
   });
 
   it("auto-routes a Convex-authenticated hosted guest from the default route into Playground onboarding", async () => {
@@ -2777,18 +2813,18 @@ describe("App hosted OAuth callback handling", () => {
       ref === "users:getCurrentUser"
         ? existingConvexUser
         : ref === "hosts:listHosts"
-          ? [
-              {
-                hostId: "m17b6q9xw2tv4kz8p3r5s0dc",
-                name: "Slack",
-                hostConfigId: "host-config-slack",
-                modelId: "claude-sonnet-4",
-                serverCount: 0,
-                createdAt: 0,
-                updatedAt: 0,
-              },
-            ]
-          : undefined
+        ? [
+            {
+              hostId: "m17b6q9xw2tv4kz8p3r5s0dc",
+              name: "Slack",
+              hostConfigId: "host-config-slack",
+              modelId: "claude-sonnet-4",
+              serverCount: 0,
+              createdAt: 0,
+              updatedAt: 0,
+            },
+          ]
+        : undefined
     );
     localStorage.setItem(
       "mcp-previewed-host-id",
@@ -2799,10 +2835,11 @@ describe("App hosted OAuth callback handling", () => {
     render(<App />);
 
     await waitFor(() => {
-      expect(JSON.parse(localStorage.getItem("mcp-previewed-host-id") ?? "{}"))
-        .toEqual({
-          project_shared: "m17b6q9xw2tv4kz8p3r5s0dc",
-        });
+      expect(
+        JSON.parse(localStorage.getItem("mcp-previewed-host-id") ?? "{}")
+      ).toEqual({
+        project_shared: "m17b6q9xw2tv4kz8p3r5s0dc",
+      });
     });
     expect(screen.getByTestId("hosts-tab")).toBeInTheDocument();
   });
@@ -2999,8 +3036,7 @@ describe("App hosted OAuth callback handling", () => {
       },
     }));
     mockUseFeatureFlagEnabled.mockImplementation(
-      (flag: string) =>
-        flag === "billing-entitlements-ui"
+      (flag: string) => flag === "billing-entitlements-ui"
     );
     mockUseQuery.mockImplementation((name: string) => {
       if (name === "users:getCurrentUser") {

--- a/mcpjam-inspector/client/src/components/auth/__tests__/login-initiation-route.test.tsx
+++ b/mcpjam-inspector/client/src/components/auth/__tests__/login-initiation-route.test.tsx
@@ -1,0 +1,76 @@
+import { describe, expect, it, vi, beforeEach } from "vitest";
+import { render, screen, waitFor } from "@testing-library/react";
+
+const signInMock = vi.fn();
+const navigateMock = vi.fn();
+let authState: { user: unknown; isLoading: boolean } = {
+  user: null,
+  isLoading: false,
+};
+
+vi.mock("@workos-inc/authkit-react", () => ({
+  useAuth: () => ({ ...authState, signIn: signInMock }),
+}));
+
+vi.mock("@/lib/app-navigation", () => ({
+  useAppNavigate: () => navigateMock,
+}));
+
+import { LoginInitiationRoute } from "../login-initiation-route";
+
+describe("LoginInitiationRoute", () => {
+  beforeEach(() => {
+    signInMock.mockReset();
+    navigateMock.mockReset();
+    authState = { user: null, isLoading: false };
+  });
+
+  it("starts a fresh app-originated sign-in for a signed-out visitor", async () => {
+    // This is the whole point of the route: authkit-js only writes the PKCE
+    // verifier `/callback` needs when the sign-in starts here, in this tab.
+    render(<LoginInitiationRoute />);
+    await waitFor(() => expect(signInMock).toHaveBeenCalledTimes(1));
+    expect(navigateMock).not.toHaveBeenCalled();
+  });
+
+  it("waits for auth to settle before deciding", async () => {
+    // Calling signIn() against a still-loading session would redirect a user
+    // who already has one.
+    authState = { user: null, isLoading: true };
+    const { rerender } = render(<LoginInitiationRoute />);
+    expect(signInMock).not.toHaveBeenCalled();
+
+    authState = { user: { id: "user_1" }, isLoading: false };
+    rerender(<LoginInitiationRoute />);
+    await waitFor(() =>
+      expect(navigateMock).toHaveBeenCalledWith("/", { replace: true })
+    );
+    expect(signInMock).not.toHaveBeenCalled();
+  });
+
+  it("sends an already-signed-in visitor into the app instead", async () => {
+    // A second tile click arrives with a live session; there is nothing to
+    // initiate, and re-running sign-in would bounce them through WorkOS again.
+    authState = { user: { id: "user_1" }, isLoading: false };
+    render(<LoginInitiationRoute />);
+    await waitFor(() =>
+      expect(navigateMock).toHaveBeenCalledWith("/", { replace: true })
+    );
+    expect(signInMock).not.toHaveBeenCalled();
+  });
+
+  it("initiates sign-in exactly once across re-renders", async () => {
+    // `signIn()` is a full-page navigation; two of them race two PKCE
+    // verifiers against one another. StrictMode double-invokes effects.
+    const { rerender } = render(<LoginInitiationRoute />);
+    rerender(<LoginInitiationRoute />);
+    rerender(<LoginInitiationRoute />);
+    await waitFor(() => expect(signInMock).toHaveBeenCalledTimes(1));
+  });
+
+  it("renders a signing-in state rather than a blank screen", () => {
+    render(<LoginInitiationRoute />);
+    expect(screen.getByTestId("login-initiation")).toBeInTheDocument();
+    expect(screen.getByText(/Signing you in/)).toBeInTheDocument();
+  });
+});

--- a/mcpjam-inspector/client/src/components/auth/__tests__/login-initiation-route.test.tsx
+++ b/mcpjam-inspector/client/src/components/auth/__tests__/login-initiation-route.test.tsx
@@ -1,5 +1,5 @@
 import { describe, expect, it, vi, beforeEach } from "vitest";
-import { render, screen, waitFor } from "@testing-library/react";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 
 const signInMock = vi.fn();
 const navigateMock = vi.fn();
@@ -72,5 +72,37 @@ describe("LoginInitiationRoute", () => {
     render(<LoginInitiationRoute />);
     expect(screen.getByTestId("login-initiation")).toBeInTheDocument();
     expect(screen.getByText(/Signing you in/)).toBeInTheDocument();
+  });
+
+  it("offers a way out when sign-in fails instead of spinning forever", async () => {
+    // A rejection means the browser is NOT leaving the page. Without this the
+    // visitor sits on the spinner with nothing to click — and this route IS the
+    // entry point an SSO user arrives on, so a dead end costs them the login.
+    signInMock.mockRejectedValueOnce(new Error("authorize failed"));
+    render(<LoginInitiationRoute />);
+
+    await waitFor(() =>
+      expect(screen.getByTestId("login-initiation-error")).toBeInTheDocument()
+    );
+    expect(screen.queryByTestId("login-initiation")).not.toBeInTheDocument();
+
+    // Retry re-initiates rather than reloading: the guard against a duplicate
+    // automatic sign-in must not also block a deliberate one.
+    fireEvent.click(screen.getByRole("button", { name: /Try again/i }));
+    await waitFor(() => expect(signInMock).toHaveBeenCalledTimes(2));
+    expect(screen.getByTestId("login-initiation")).toBeInTheDocument();
+  });
+
+  it("recovers from a signIn() that throws before returning a promise", async () => {
+    // A synchronous throw is not a rejected promise; `.catch` alone misses it
+    // and the failure state never renders.
+    signInMock.mockImplementationOnce(() => {
+      throw new Error("client not initialized");
+    });
+    render(<LoginInitiationRoute />);
+
+    await waitFor(() =>
+      expect(screen.getByTestId("login-initiation-error")).toBeInTheDocument()
+    );
   });
 });

--- a/mcpjam-inspector/client/src/components/auth/__tests__/login-initiation-route.test.tsx
+++ b/mcpjam-inspector/client/src/components/auth/__tests__/login-initiation-route.test.tsx
@@ -85,6 +85,11 @@ describe("LoginInitiationRoute", () => {
       expect(screen.getByTestId("login-initiation-error")).toBeInTheDocument()
     );
     expect(screen.queryByTestId("login-initiation")).not.toBeInTheDocument();
+    // Announced, not just rendered: the failure swaps in without a navigation,
+    // so assistive tech has nothing else to notice it by.
+    expect(screen.getByRole("alert")).toHaveTextContent(
+      /Couldn't start sign-in/
+    );
 
     // Retry re-initiates rather than reloading: the guard against a duplicate
     // automatic sign-in must not also block a deliberate one.

--- a/mcpjam-inspector/client/src/components/auth/login-initiation-route.tsx
+++ b/mcpjam-inspector/client/src/components/auth/login-initiation-route.tsx
@@ -1,5 +1,6 @@
-import { useEffect, useRef } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 import { useAuth } from "@workos-inc/authkit-react";
+import { Button } from "@mcpjam/design-system/button";
 import { useAppNavigate } from "@/lib/app-navigation";
 
 /**
@@ -40,6 +41,23 @@ export function LoginInitiationRoute() {
   // navigation — firing it twice races two authorize requests (and two
   // verifiers) against one another.
   const startedRef = useRef(false);
+  const [failed, setFailed] = useState(false);
+
+  const startSignIn = useCallback(() => {
+    setFailed(false);
+    // A rejection here means the browser is NOT leaving this page, so the
+    // spinner below would sit there forever. This is the whole entry point for
+    // an SSO user arriving from their dashboard: a dead end costs them the
+    // login with nothing to click. `/callback` guards the same hazard with its
+    // own recovery UI (see `callbackRecoveryExpired` in App.tsx).
+    // `try`/`catch` as well as `.catch`, because a throw before the promise is
+    // returned is not a rejected promise.
+    try {
+      void Promise.resolve(signIn()).catch(() => setFailed(true));
+    } catch {
+      setFailed(true);
+    }
+  }, [signIn]);
 
   useEffect(() => {
     if (isLoading || startedRef.current) return;
@@ -50,8 +68,25 @@ export function LoginInitiationRoute() {
       navigate("/", { replace: true });
       return;
     }
-    void signIn();
-  }, [isLoading, user, signIn, navigate]);
+    startSignIn();
+  }, [isLoading, user, startSignIn, navigate]);
+
+  if (failed) {
+    return (
+      <div
+        className="flex h-full min-h-[60vh] flex-col items-center justify-center gap-3 p-6 text-center text-sm text-muted-foreground"
+        data-testid="login-initiation-error"
+      >
+        <span className="max-w-md">
+          Couldn&apos;t start sign-in. Try again, or return to your identity
+          provider and reopen MCPJam.
+        </span>
+        <Button size="sm" onClick={startSignIn}>
+          Try again
+        </Button>
+      </div>
+    );
+  }
 
   return (
     <div

--- a/mcpjam-inspector/client/src/components/auth/login-initiation-route.tsx
+++ b/mcpjam-inspector/client/src/components/auth/login-initiation-route.tsx
@@ -1,0 +1,65 @@
+import { useEffect, useRef } from "react";
+import { useAuth } from "@workos-inc/authkit-react";
+import { useAppNavigate } from "@/lib/app-navigation";
+
+/**
+ * `/login` — the WorkOS **Initiate Login URL**, and the fix for IdP-initiated SSO.
+ *
+ * Clicking the MCPJam tile in an Okta dashboard starts the flow at the IdP, not
+ * here: Okta posts its SAML assertion to WorkOS, WorkOS validates it, and then
+ * the browser lands on `/callback` with an authorization code. That exchange
+ * fails by construction. It runs CLIENT-SIDE in `@workos-inc/authkit-js`, and it
+ * needs the PKCE code verifier that sign-in wrote into THIS tab's
+ * `sessionStorage` (`workos:code-verifier`) — a key that only exists when the
+ * sign-in started in the app. A login that started at Okta has no such tab, so
+ * authkit refuses with "Couldn't exchange code… The developer may not have
+ * configured a Login Initiation endpoint."
+ *
+ * The sanctioned fix is this route. With an Initiate Login URL configured
+ * (Applications → Redirects, per WorkOS environment), AuthKit recognizes a
+ * non-app-originated login and redirects the browser HERE instead of issuing a
+ * code. We then start an ordinary, app-originated sign-in: authkit-js mints its
+ * own verifier, AuthKit completes it silently against the SSO session Okta
+ * already established (no second prompt), and the code lands on `/callback`
+ * with a verifier that matches.
+ *
+ * It has to be a client route for the same reason: a server-side 302 to
+ * `/user_management/authorize` cannot write a verifier into the browser's
+ * sessionStorage. The SPA must boot and call `signIn()` itself.
+ *
+ * Query parameters are deliberately IGNORED. The old `context` hand-off is
+ * deprecated (WorkOS "Simplified Login Initiation", 2025-04-30) — the endpoint
+ * is only expected to start a fresh sign-in — and forwarding it could not work
+ * anyway: authkit-js drops `context` when building the authorize URL. WorkOS's
+ * own `react-authkit-example` still forwards it; don't copy it.
+ */
+export function LoginInitiationRoute() {
+  const { user, isLoading, signIn } = useAuth();
+  const navigate = useAppNavigate();
+  // StrictMode double-invokes effects in dev, and `signIn()` is a full-page
+  // navigation — firing it twice races two authorize requests (and two
+  // verifiers) against one another.
+  const startedRef = useRef(false);
+
+  useEffect(() => {
+    if (isLoading || startedRef.current) return;
+    startedRef.current = true;
+    // Already signed in — e.g. a second tile click, or a back-navigation onto
+    // this route. Nothing to initiate; send them into the app.
+    if (user) {
+      navigate("/", { replace: true });
+      return;
+    }
+    void signIn();
+  }, [isLoading, user, signIn, navigate]);
+
+  return (
+    <div
+      className="flex h-full min-h-[60vh] flex-col items-center justify-center gap-3 text-sm text-muted-foreground"
+      data-testid="login-initiation"
+    >
+      <div className="h-8 w-8 animate-spin rounded-full border-4 border-gray-200 border-t-primary" />
+      <span>Signing you in…</span>
+    </div>
+  );
+}

--- a/mcpjam-inspector/client/src/components/auth/login-initiation-route.tsx
+++ b/mcpjam-inspector/client/src/components/auth/login-initiation-route.tsx
@@ -74,6 +74,10 @@ export function LoginInitiationRoute() {
   if (failed) {
     return (
       <div
+        // The failure replaces the spinner in place, with no navigation to
+        // announce it — without a live region a screen reader user is left on
+        // "Signing you in…" and never learns there is a retry to press.
+        role="alert"
         className="flex h-full min-h-[60vh] flex-col items-center justify-center gap-3 p-6 text-center text-sm text-muted-foreground"
         data-testid="login-initiation-error"
       >

--- a/mcpjam-inspector/client/src/lib/app-navigation.ts
+++ b/mcpjam-inspector/client/src/lib/app-navigation.ts
@@ -93,6 +93,12 @@ export const routePaths = {
   settings: "/settings",
   profile: "/profile",
   projectSettings: "/project-settings",
+  /**
+   * WorkOS Initiate Login URL. AuthKit redirects IdP-initiated logins (the
+   * Okta app tile) here instead of issuing a code; the route starts a normal
+   * sign-in so the code exchange on `/callback` has a matching PKCE verifier.
+   */
+  login: "/login",
   callback: "/callback",
   billing: "/billing",
   evals: "/evals",

--- a/mcpjam-inspector/client/src/lib/app-routes.ts
+++ b/mcpjam-inspector/client/src/lib/app-routes.ts
@@ -241,6 +241,14 @@ export const APP_ROUTES: readonly AppRouteEntry[] = [
     note: "Post-checkout landing; renders Servers.",
   },
   {
+    // WorkOS Initiate Login URL for IdP-initiated SSO (the Okta app tile).
+    // Not a destination anyone navigates to: it starts a fresh, app-originated
+    // sign-in so authkit-js writes the PKCE verifier `/callback` needs.
+    path: "login",
+    kind: "special",
+    note: "WorkOS Initiate Login URL for IdP-initiated SSO; starts a fresh app-originated sign-in.",
+  },
+  {
     path: "callback",
     kind: "special",
     note: "Auth callback landing; renders Servers.",

--- a/mcpjam-inspector/client/src/router.tsx
+++ b/mcpjam-inspector/client/src/router.tsx
@@ -39,6 +39,7 @@ import App, {
   TracingRoute,
   XAAFlowRoute,
 } from "./App";
+import { LoginInitiationRoute } from "./components/auth/login-initiation-route";
 import { getAppRouter, setAppRouter } from "./router-ref";
 import {
   buildHostsPath,
@@ -222,6 +223,10 @@ const ROUTE_ELEMENTS: Record<
   "ci-evals": { loader: ciEvalsRedirect },
   "ci-evals/*": { loader: ciEvalsRedirect },
   billing: { element: <ServersRoute /> },
+  // The WorkOS Initiate Login URL. Unlike the entries around it this renders a
+  // component of its own rather than Servers: it must call `signIn()` so
+  // authkit-js writes a PKCE verifier before the code lands on `/callback`.
+  login: { element: <LoginInitiationRoute /> },
   callback: { element: <ServersRoute /> },
   "oauth/callback/*": { element: <ServersRoute /> },
   "*": { element: <ServersRoute /> },


### PR DESCRIPTION
Clicking the MCPJam tile in an Okta dashboard reached WorkOS and stopped there. Okta posts its SAML assertion, WorkOS validates it and sends an authorization code to `/callback`, and `@workos-inc/authkit-js` refuses to exchange it:

> Couldn't exchange code… The developer may not have configured a Login Initiation endpoint.

Nothing is wrong with the SAML side. The exchange runs **client-side** and needs the PKCE code verifier that sign-in wrote into that tab's `sessionStorage` (`workos:code-verifier`) — a key that exists only when the sign-in started in the app. A login that started at the identity provider has no such tab, so the flow was unfinishable by construction. That blocks the OIN submission's IdP-flow test and leaves enterprise users with no working entry point from their own dashboard.

## What this adds

`/login` — the **Initiate Login URL** WorkOS asks for. Once one is configured, AuthKit recognizes a non-app-originated login and redirects the browser there *instead of* issuing a code; the route starts an ordinary sign-in, AuthKit completes it silently against the SSO session the IdP already established (no second prompt), and the code lands on `/callback` beside a verifier that matches it.

It has to be a **client** route for the same reason the flow was failing: a server-generated verifier cannot be written into the browser's `sessionStorage`. The SPA boots, the route calls `signIn()`, and authkit-js mints its own. Both entrypoints already serve `index.html` for unmatched paths (the Hono catch-all in production, Vite's SPA fallback in dev), and `sessionAuthMiddleware` only guards `/api/*` — so **no server change is involved**.

Query parameters are ignored on purpose. The `context` hand-off older examples forward is deprecated ("Simplified Login Initiation", 2025-04-30), and authkit-js omits `context` when it builds the authorize URL, so forwarding it could not work anyway. WorkOS's own `react-authkit-example` still forwards it; this doesn't.

## Two hazards the route has to survive

- **`signIn()` is a full-page navigation**, so it fires exactly once. StrictMode double-invokes effects, and two calls race two PKCE verifiers against one another.
- **`/login` is not a known tab segment**, so the shell resolves it to the `servers` fallback — which is first-run-eligible. A hosted guest session is Convex-authenticated, so the onboarding redirect could fire on the very commit that mounts the route and send the visitor to Playground mid-sign-in. `shouldRouteToFirstRunOnboarding` now excludes this path, next to the caniuse exclusion that exists for the same reason.

An already-signed-in visitor (a second tile click) is sent into the app rather than back through WorkOS.

## Changes

| File | Change |
| --- | --- |
| `client/src/components/auth/login-initiation-route.tsx` | New. Waits for auth to settle, then `signIn()` once — or navigates home if a session already exists. |
| `client/src/lib/app-routes.ts` | `login` as `kind: "special"` (like `callback`) — not a destination, so no surface manifest. |
| `client/src/lib/app-navigation.ts` | `login: "/login"` in `routePaths`. |
| `client/src/router.tsx` | `login` → `<LoginInitiationRoute />` in `ROUTE_ELEMENTS`. |
| `client/src/App.tsx` | Exclude `/login` from the first-run onboarding redirect. |
| `.changeset/` | patch, `@mcpjam/inspector`. |

## Verification

- New `login-initiation-route.test.tsx` (5 tests): signed-out visitor initiates sign-in; the effect waits for `isLoading` to settle before deciding; an already-signed-in visitor is navigated home instead; sign-in fires exactly once across re-renders; the route renders a signing-in state rather than a blank screen.
- Router coverage (`route-elements-coverage`, `app-surface-coverage`, `app-navigation`) passes — both tables stay in sync and the route is actually mounted.
- `client/src/lib/__tests__` + `components/auth` full sweep: **1275 tests passing**, including the 62 hosted-OAuth App tests that cover the shell gating this route renders behind.
- `typecheck:client` and Prettier clean.

## Not code: one dashboard setting

This takes effect only once the **Initiate Login URL** is set to `https://app.mcpjam.com/login` in the WorkOS dashboard (Applications → Redirects, per environment). Worth flipping *after* this deploys — setting it earlier makes AuthKit redirect tile clicks to a route that doesn't exist yet.

Normal SP-initiated sign-in and guest mode are untouched; the route is additive.

---
_Generated by [Claude Code](https://claude.ai/code/session_01QJ3K7nRFKGT3X9TtYzXrN5)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches enterprise SSO entry and auth initiation, but changes are additive with dedicated tests; SP-initiated sign-in and guest mode are unchanged.
> 
> **Overview**
> Adds a client **`/login`** route as the WorkOS **Initiate Login URL** so IdP-initiated SSO (e.g. Okta app tile) can finish. Without it, `/callback` receives a code but client-side exchange fails because there is no PKCE verifier in `sessionStorage` from an app-started sign-in.
> 
> **`LoginInitiationRoute`** waits for auth to settle, calls **`signIn()`** once (StrictMode-safe), sends already-signed-in users to `/`, and shows retry UI on failure instead of an endless spinner. Query params are intentionally ignored.
> 
> **`App.tsx`** excludes `/login` from the first-run Playground onboarding redirect so hosted guests are not sent to Playground mid-sign-in.
> 
> Routing is wired via `routePaths.login`, `APP_ROUTES`, and `router.tsx`. Tests cover the route component and the App-level onboarding guard. Rollout still needs the WorkOS dashboard Initiate Login URL set to `https://app.mcpjam.com/login`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 686b6b169db921b3f4e8cbc9a8ddb5f14901a8f6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a client `/login` route as the WorkOS Initiate Login URL so IdP-initiated SSO completes. Previously, IdP-originated logins hit `/callback` without a tab-local PKCE verifier and failed; now AuthKit redirects to `/login`, the route runs one `signIn()` to mint a verifier, and already-signed-in users go to `/`.

- Routes: `login` as a `kind: "special"` route that renders `<LoginInitiationRoute />`; adds `routePaths.login`.
- Recovery: catches sync/async `signIn()` failures, shows a retry, and announces the error via `role="alert"` for assistive tech.
- Behavior: calls `signIn()` exactly once even under StrictMode; redirects to `/` if a session exists; ignores query params (deprecated `context` not forwarded).
- Shell: excludes `/login` from first-run onboarding; adds a test so hosted guests at `/login` aren’t auto-routed.
- No server changes. Tests cover initiation, recovery (including a11y alert), single-invoke, signed-in redirect, and router wiring. Changeset patches `@mcpjam/inspector`.
- Rollout: In WorkOS, set the Initiate Login URL to https://app.mcpjam.com/login for each environment after this deploy.

<sup>Written for commit 03de52caf4b02cc9fd2a7f62743451be6e1d6a8f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/MCPJam/inspector/pull/4143?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

