### PR TITLE
fix(sdk): mirror Codex MCP Apps catalog

### DIFF
--- a/mcpjam-inspector/client/src/contexts/__tests__/active-host-caps-resolver.test.tsx
+++ b/mcpjam-inspector/client/src/contexts/__tests__/active-host-caps-resolver.test.tsx
@@ -158,7 +158,8 @@ describe("ActiveHostCapsResolverScope (resolver)", () => {
   it("synthesizes host caps from the template seed when activeHost is null (hosted scenario case)", () => {
     // Hosted scenario bootstrap payload doesn't carry clientCapabilities
     // yet (follow-up). Until then, the scope synthesizes them from the
-    // host style. Codex seed → no UI extension.
+    // host style. Codex now advertises MCP Apps, including the legacy
+    // ChatGPT MIME type alongside the spec one.
     const { getByTestId } = mountWithState({
       activeHost: null,
       hostStyle: "codex",
@@ -166,6 +167,9 @@ describe("ActiveHostCapsResolverScope (resolver)", () => {
       serverId: "srv",
     });
     const caps = JSON.parse(getByTestId("caps").textContent ?? "{}");
-    expect(caps.extensions).toBeUndefined();
+    expect(caps.extensions?.[MCP_UI_EXTENSION_ID]?.mimeTypes).toEqual([
+      MCP_UI_RESOURCE_MIME_TYPE,
+      "text/html+skybridge",
+    ]);
   });
 });

--- a/sdk/src/host-compat/catalog-schema.ts
+++ b/sdk/src/host-compat/catalog-schema.ts
@@ -54,6 +54,13 @@ export const mcpAppsCapabilitiesSchema = z.object({
   sandboxPermissions: z.boolean().optional(),
   cspFrameDomains: z.boolean().optional(),
   cspBaseUriDomains: z.boolean().optional(),
+  cspConnectDomains: z
+    .object({
+      fetch: z.boolean().optional(),
+      xhr: z.boolean().optional(),
+      websocket: z.boolean().optional(),
+    })
+    .optional(),
   resourcePrefersBorder: z.boolean().optional(),
   downloadFile: z.boolean().optional(),
   requestTeardown: z.boolean().optional(),

--- a/sdk/src/host-compat/catalog.generated.ts
+++ b/sdk/src/host-compat/catalog.generated.ts
@@ -625,7 +625,7 @@ export const BUNDLED_HOST_COMPAT_CATALOG = {
           clientInfo: {
             name: "claude-code",
             title: "Claude Code",
-            version: "2.1.235",
+            version: "2.1.237",
             description: "Anthropic's agentic coding tool",
             websiteUrl: "https://claude.com/claude-code",
           },
@@ -1026,7 +1026,16 @@ export const BUNDLED_HOST_COMPAT_CATALOG = {
             csp: {
               mode: "declared",
               cspDirectives: {
-                "frame-src": ["'self'", "https:", "data:", "blob:"],
+                "connect-src": [
+                  "https://cdn.jsdelivr.net",
+                  "https://unpkg.com",
+                ],
+                "script-src": ["https://cdn.jsdelivr.net", "https://unpkg.com"],
+                "style-src": ["https://cdn.jsdelivr.net", "https://unpkg.com"],
+                "img-src": ["https://cdn.jsdelivr.net", "https://unpkg.com"],
+                "font-src": ["https://cdn.jsdelivr.net", "https://unpkg.com"],
+                "media-src": ["https://cdn.jsdelivr.net", "https://unpkg.com"],
+                "frame-src": ["'self'", "data:", "blob:"],
               },
             },
             permissions: {
@@ -1059,16 +1068,9 @@ export const BUNDLED_HOST_COMPAT_CATALOG = {
             cspFrameDomains: true,
             cspBaseUriDomains: true,
             cspConnectDomains: {
-              fetch: false,
-              xhr: false,
+              fetch: true,
+              xhr: true,
               websocket: true,
-            },
-            cspResourceDomains: {
-              script: false,
-              stylesheet: false,
-              image: false,
-              font: false,
-              media: false,
             },
             resourcePrefersBorder: true,
             downloadFile: false,
@@ -2053,6 +2055,11 @@ export const BUNDLED_HOST_COMPAT_CATALOG = {
         requestTimeout: 10000,
       },
       clientCapabilities: {
+        extensions: {
+          "io.modelcontextprotocol/ui": {
+            mimeTypes: ["text/html;profile=mcp-app", "text/html+skybridge"],
+          },
+        },
         elicitation: {
           form: {},
           url: {},
@@ -2187,16 +2194,9 @@ export const BUNDLED_HOST_COMPAT_CATALOG = {
             cspFrameDomains: true,
             cspBaseUriDomains: true,
             cspConnectDomains: {
-              fetch: false,
-              xhr: false,
+              fetch: true,
+              xhr: true,
               websocket: true,
-            },
-            cspResourceDomains: {
-              script: false,
-              stylesheet: false,
-              image: false,
-              font: false,
-              media: false,
             },
             resourcePrefersBorder: true,
             toolCancelled: false,

--- a/sdk/src/host-config/canonicalize.ts
+++ b/sdk/src/host-config/canonicalize.ts
@@ -102,6 +102,7 @@ const MCP_APPS_CAPABILITY_KEYS = [
   "sandboxPermissions",
   "cspFrameDomains",
   "cspBaseUriDomains",
+  "cspConnectDomains",
   "resourcePrefersBorder",
   "downloadFile",
   "requestTeardown",
@@ -519,6 +520,29 @@ function isPlainObject(value: unknown): value is Record<string, unknown> {
   // or `null` (Object.create(null)).
   const proto = Object.getPrototypeOf(value);
   return proto === Object.prototype || proto === null;
+}
+
+function canonicalBooleanCapabilityRecord(
+  path: string,
+  value: unknown,
+  allowedKeys: readonly string[]
+): Record<string, boolean> {
+  if (!isPlainObject(value)) {
+    throw new Error(`hostConfigV2: ${path} must be a plain object`);
+  }
+  const out: Record<string, boolean> = {};
+  for (const key of Object.keys(value)) {
+    if (!allowedKeys.includes(key)) {
+      throw new Error(`hostConfigV2: ${path} has unknown key "${key}"`);
+    }
+    if (typeof value[key] !== "boolean") {
+      throw new Error(`hostConfigV2: ${path}.${key} must be a boolean`);
+    }
+  }
+  for (const key of allowedKeys) {
+    if (value[key] !== undefined) out[key] = value[key] as boolean;
+  }
+  return out;
 }
 
 // Canonicalize a CSP domain list as a SET: trim, drop empty, dedupe, sort.
@@ -1203,6 +1227,15 @@ function canonicalizeMcpProfile(
             MCP_APPS_DISPLAY_MODE_VALUES.filter((m) =>
               seen.has(m)
             ) as McpAppsCapabilities["availableDisplayModes"];
+        } else if (key === "cspConnectDomains") {
+          const domains = canonicalBooleanCapabilityRecord(
+            "mcpProfile.apps.mcpAppsOverrides.cspConnectDomains",
+            value,
+            ["fetch", "xhr", "websocket"]
+          );
+          if (Object.keys(domains).length > 0) {
+            mcpAppsOverridesOut.cspConnectDomains = domains;
+          }
         } else if (key === "widgetDisplayModeRequests") {
           if (
             typeof value !== "string" ||

--- a/sdk/src/host-config/templates/seed-host-template.ts
+++ b/sdk/src/host-config/templates/seed-host-template.ts
@@ -265,8 +265,8 @@ export interface SeedHostTemplateOptions {
    * `applyHostDefaultsToPlayground`) where flipping to MCPJam's theme on
    * every brand-pill click would be a surprise.
    *
-   * Codex ignores this — its template doesn't set `hostContext` at all
-   * (no rendering surface, so no theme to honor).
+   * Codex currently pins dark, matching the backend catalog's probed host
+   * row. Keep this option for callers that stamp other host templates.
    */
   theme?: HostThemeMode;
   /**
@@ -1355,8 +1355,7 @@ export const HOST_TEMPLATES: readonly HostTemplate[] = [
   {
     id: "codex",
     label: "Codex",
-    description:
-      "OpenAI Codex CLI. Elicitation-only client, no widget rendering.",
+    description: "OpenAI Codex host with MCP Apps support.",
     seed: () => {
       const base = emptyHostConfigInputV2({
         // Dedicated Codex skin (OpenAI Apps SDK profile + ChatGPT chat
@@ -1378,34 +1377,76 @@ export const HOST_TEMPLATES: readonly HostTemplate[] = [
         harness: "codex",
         computer: { kind: "personal" },
       });
-      // Codex CLI probe advertises only elicitation. It does NOT advertise
-      // the MCP UI extension (no widget rendering), so we replace the SDK
-      // default clientCapabilities entirely rather than spreading on top —
-      // a spread would leak `extensions["io.modelcontextprotocol/ui"]`
-      // back in and misrepresent Codex as a UI-capable client.
+      // Probed 2026-08-19. Codex advertises MCP Apps, and lists the legacy
+      // ChatGPT mime type alongside the spec one.
       base.clientCapabilities = {
-        elicitation: {},
+        extensions: {
+          [MCP_UI_EXTENSION_ID]: {
+            mimeTypes: [MCP_UI_RESOURCE_MIME_TYPE, "text/html+skybridge"],
+          },
+        },
+        elicitation: { form: {}, url: {} },
       };
-      // Codex is a CLI: it doesn't render MCP Apps views, so no
-      // hostContext (styles/displayMode/containerDimensions are
-      // meaningless without a renderer). Leaving `hostContext` as the
-      // empty object from emptyHostConfigInputV2.
-      //
-      // Same reasoning for hostCapabilitiesOverride: there's no
-      // ui/initialize negotiation, so we don't override what the preset
-      // advertises. The preset's chatgpt advertise is irrelevant in
-      // practice because no widget will ever read it from Codex.
+      base.hostContext = {
+        theme: "dark",
+        displayMode: "inline",
+        availableDisplayModes: ["inline", "fullscreen"],
+        locale: "en-US",
+        timeZone: "America/Los_Angeles",
+        userAgent: "chatgpt",
+        platform: "desktop",
+        deviceCapabilities: { touch: false, hover: true },
+        safeAreaInsets: { top: 0, right: 0, bottom: 0, left: 0 },
+      };
       base.mcpProfile = {
         profileVersion: 1,
         initialize: {
           supportedProtocolVersions: ["2025-03-26", "2025-06-18", "2025-11-25"],
-          // Verbatim from a real Codex CLI probe. `title` lands in the
-          // pass-through `Record<string, unknown>` per host-config-v2
-          // (backend soft-validates name/version only).
           clientInfo: {
             name: "codex-mcp-client",
             title: "Codex",
             version: "0.148.0-alpha.9",
+          },
+        },
+        apps: {
+          mcpAppsOverrides: {
+            availableDisplayModes: ["inline", "fullscreen"],
+            toolInputPartial: true,
+            hostContextChanged: true,
+            openLinks: true,
+            serverTools: true,
+            serverResources: true,
+            logging: true,
+            updateModelContext: true,
+            message: true,
+            toolInfo: false,
+            downloadFile: false,
+            sandboxPermissions: false,
+            cspFrameDomains: true,
+            cspBaseUriDomains: true,
+            cspConnectDomains: {
+              fetch: true,
+              xhr: true,
+              websocket: true,
+            },
+            resourcePrefersBorder: true,
+            toolCancelled: false,
+            resourceTeardown: false,
+            requestTeardown: false,
+            widgetDisplayModeRequests: "accept",
+          },
+          compatRuntime: {
+            openaiApps: true,
+            openaiAppsOverrides: {
+              requestClose: false,
+              requestModal: false,
+              uploadFile: false,
+              selectFiles: false,
+              getFileDownloadUrl: false,
+              requestCheckout: false,
+              setOpenInAppUrl: false,
+              notifyIntrinsicHeight: false,
+            },
           },
         },
       };

--- a/sdk/src/host-config/templates/seed-host-template.ts
+++ b/sdk/src/host-config/templates/seed-host-template.ts
@@ -767,7 +767,7 @@ export const HOST_TEMPLATES: readonly HostTemplate[] = [
           clientInfo: {
             name: "claude-code",
             title: "Claude Code",
-            version: "2.1.235",
+            version: "2.1.237",
             description: "Anthropic's agentic coding tool",
             websiteUrl: "https://claude.com/claude-code",
           },
@@ -858,6 +858,20 @@ export const HOST_TEMPLATES: readonly HostTemplate[] = [
           uiInitialize: {
             hostInfo: { name: "chatgpt", version: "0.0.1" },
           },
+          mcpAppsOverrides: {
+            // One directive, one answer: the declared wss endpoint connected
+            // while an undeclared one took a real connect-src violation
+            // (2026-08-19 probe). The fetch/xhr canary passed because it is in
+            // ChatGPT's own baseline allowlist, carried as `cspDirectives`.
+            cspConnectDomains: {
+              fetch: true,
+              xhr: true,
+              websocket: true,
+            },
+            // cspResourceDomains stays unknown: the declared resource origin
+            // is in that same baseline, so the probe cannot tell honored from
+            // ignored. Re-probe with an origin the baseline misses first.
+          },
           // Vendor compat-runtime shims. Real ChatGPT exposes the
           // OpenAI Apps SDK `window.openai` surface to widget HTML, so
           // emulating it here keeps existing Apps SDK widgets rendering
@@ -868,28 +882,22 @@ export const HOST_TEMPLATES: readonly HostTemplate[] = [
           compatRuntime: { openaiApps: true },
           sandbox: {
             csp: {
-              // No host-side `restrictTo` — see the Claude template for
-              // the full rationale. The host-probe resource declared the
-              // captured anthropic / openai / jsdelivr allowlist, so it is
-              // per-resource evidence rather than a global ChatGPT allowlist.
-              // The view's declaration is authoritative.
               mode: "declared",
-              // cspDirectives — verbatim from a live chatgpt response
-              // Content-Security-Policy header (captured 2026-05-18 via
-              // DevTools → Network → oaiusercontent.com response).
-              //
-              // Real ChatGPT's outer-doc CSP is strikingly minimal: only
-              // `frame-ancestors`, `frame-src`, and the CSP `sandbox`
-              // directive are emitted. There is NO `script-src`,
-              // `style-src`, `connect-src` etc. — script and style
-              // execution is effectively unconstrained at the host layer.
-              // `frame-ancestors` is dropped (controls who can embed the
-              // doc — irrelevant for widget runtime); the CSP `sandbox`
-              // directive duplicates `sandboxAttrs` below and is modeled
-              // there. That leaves just `frame-src` as the meaningful
-              // host-emitted constraint on widget behavior.
+              // ChatGPT's own baseline allowlist, merged with the widget's
+              // declared domains. The 2026-08-19 probe loaded these origins
+              // without declaring them, while undeclared frame origins were
+              // blocked. Keep this intentionally limited to what was probed.
               cspDirectives: {
-                "frame-src": ["'self'", "https:", "data:", "blob:"],
+                "connect-src": [
+                  "https://cdn.jsdelivr.net",
+                  "https://unpkg.com",
+                ],
+                "script-src": ["https://cdn.jsdelivr.net", "https://unpkg.com"],
+                "style-src": ["https://cdn.jsdelivr.net", "https://unpkg.com"],
+                "img-src": ["https://cdn.jsdelivr.net", "https://unpkg.com"],
+                "font-src": ["https://cdn.jsdelivr.net", "https://unpkg.com"],
+                "media-src": ["https://cdn.jsdelivr.net", "https://unpkg.com"],
+                "frame-src": ["'self'", "data:", "blob:"],
               },
             },
             permissions: {

--- a/sdk/src/host-config/types.ts
+++ b/sdk/src/host-config/types.ts
@@ -390,6 +390,11 @@ export type McpAppsCapabilities = {
   sandboxPermissions?: boolean;
   cspFrameDomains?: boolean;
   cspBaseUriDomains?: boolean;
+  cspConnectDomains?: {
+    fetch?: boolean;
+    xhr?: boolean;
+    websocket?: boolean;
+  };
   resourcePrefersBorder?: boolean;
   downloadFile?: boolean;
   requestTeardown?: boolean;

--- a/sdk/tests/__snapshots__/host-config-seed-host-template.test.ts.snap
+++ b/sdk/tests/__snapshots__/host-config-seed-host-template.test.ts.snap
@@ -1086,7 +1086,18 @@ exports[`seedHostTemplate > seed output matches the committed golden snapshot 1`
     "builtInToolIds": [],
     "chatUiOverride": undefined,
     "clientCapabilities": {
-      "elicitation": {},
+      "elicitation": {
+        "form": {},
+        "url": {},
+      },
+      "extensions": {
+        "io.modelcontextprotocol/ui": {
+          "mimeTypes": [
+            "text/html;profile=mcp-app",
+            "text/html+skybridge",
+          ],
+        },
+      },
     },
     "computer": {
       "kind": "personal",
@@ -1097,9 +1108,74 @@ exports[`seedHostTemplate > seed output matches the committed golden snapshot 1`
     },
     "harness": "codex",
     "hostCapabilitiesOverride": undefined,
-    "hostContext": {},
+    "hostContext": {
+      "availableDisplayModes": [
+        "inline",
+        "fullscreen",
+      ],
+      "deviceCapabilities": {
+        "hover": true,
+        "touch": false,
+      },
+      "displayMode": "inline",
+      "locale": "en-US",
+      "platform": "desktop",
+      "safeAreaInsets": {
+        "bottom": 0,
+        "left": 0,
+        "right": 0,
+        "top": 0,
+      },
+      "theme": "dark",
+      "timeZone": "America/Los_Angeles",
+      "userAgent": "chatgpt",
+    },
     "hostStyle": "codex",
     "mcpProfile": {
+      "apps": {
+        "compatRuntime": {
+          "openaiApps": true,
+          "openaiAppsOverrides": {
+            "getFileDownloadUrl": false,
+            "notifyIntrinsicHeight": false,
+            "requestCheckout": false,
+            "requestClose": false,
+            "requestModal": false,
+            "selectFiles": false,
+            "setOpenInAppUrl": false,
+            "uploadFile": false,
+          },
+        },
+        "mcpAppsOverrides": {
+          "availableDisplayModes": [
+            "inline",
+            "fullscreen",
+          ],
+          "cspBaseUriDomains": true,
+          "cspConnectDomains": {
+            "fetch": true,
+            "websocket": true,
+            "xhr": true,
+          },
+          "cspFrameDomains": true,
+          "downloadFile": false,
+          "hostContextChanged": true,
+          "logging": true,
+          "message": true,
+          "openLinks": true,
+          "requestTeardown": false,
+          "resourcePrefersBorder": true,
+          "resourceTeardown": false,
+          "sandboxPermissions": false,
+          "serverResources": true,
+          "serverTools": true,
+          "toolCancelled": false,
+          "toolInfo": false,
+          "toolInputPartial": true,
+          "updateModelContext": true,
+          "widgetDisplayModeRequests": "accept",
+        },
+      },
       "initialize": {
         "clientInfo": {
           "name": "codex-mcp-client",
@@ -1128,7 +1204,18 @@ exports[`seedHostTemplate > seed output matches the committed golden snapshot 1`
     "builtInToolIds": [],
     "chatUiOverride": undefined,
     "clientCapabilities": {
-      "elicitation": {},
+      "elicitation": {
+        "form": {},
+        "url": {},
+      },
+      "extensions": {
+        "io.modelcontextprotocol/ui": {
+          "mimeTypes": [
+            "text/html;profile=mcp-app",
+            "text/html+skybridge",
+          ],
+        },
+      },
     },
     "computer": {
       "kind": "personal",
@@ -1139,9 +1226,74 @@ exports[`seedHostTemplate > seed output matches the committed golden snapshot 1`
     },
     "harness": "codex",
     "hostCapabilitiesOverride": undefined,
-    "hostContext": {},
+    "hostContext": {
+      "availableDisplayModes": [
+        "inline",
+        "fullscreen",
+      ],
+      "deviceCapabilities": {
+        "hover": true,
+        "touch": false,
+      },
+      "displayMode": "inline",
+      "locale": "en-US",
+      "platform": "desktop",
+      "safeAreaInsets": {
+        "bottom": 0,
+        "left": 0,
+        "right": 0,
+        "top": 0,
+      },
+      "theme": "dark",
+      "timeZone": "America/Los_Angeles",
+      "userAgent": "chatgpt",
+    },
     "hostStyle": "codex",
     "mcpProfile": {
+      "apps": {
+        "compatRuntime": {
+          "openaiApps": true,
+          "openaiAppsOverrides": {
+            "getFileDownloadUrl": false,
+            "notifyIntrinsicHeight": false,
+            "requestCheckout": false,
+            "requestClose": false,
+            "requestModal": false,
+            "selectFiles": false,
+            "setOpenInAppUrl": false,
+            "uploadFile": false,
+          },
+        },
+        "mcpAppsOverrides": {
+          "availableDisplayModes": [
+            "inline",
+            "fullscreen",
+          ],
+          "cspBaseUriDomains": true,
+          "cspConnectDomains": {
+            "fetch": true,
+            "websocket": true,
+            "xhr": true,
+          },
+          "cspFrameDomains": true,
+          "downloadFile": false,
+          "hostContextChanged": true,
+          "logging": true,
+          "message": true,
+          "openLinks": true,
+          "requestTeardown": false,
+          "resourcePrefersBorder": true,
+          "resourceTeardown": false,
+          "sandboxPermissions": false,
+          "serverResources": true,
+          "serverTools": true,
+          "toolCancelled": false,
+          "toolInfo": false,
+          "toolInputPartial": true,
+          "updateModelContext": true,
+          "widgetDisplayModeRequests": "accept",
+        },
+      },
       "initialize": {
         "clientInfo": {
           "name": "codex-mcp-client",

--- a/sdk/tests/__snapshots__/host-config-seed-host-template.test.ts.snap
+++ b/sdk/tests/__snapshots__/host-config-seed-host-template.test.ts.snap
@@ -146,14 +146,44 @@ exports[`seedHostTemplate > seed output matches the committed golden snapshot 1`
         "compatRuntime": {
           "openaiApps": true,
         },
+        "mcpAppsOverrides": {
+          "cspConnectDomains": {
+            "fetch": true,
+            "websocket": true,
+            "xhr": true,
+          },
+        },
         "sandbox": {
           "csp": {
             "cspDirectives": {
+              "connect-src": [
+                "https://cdn.jsdelivr.net",
+                "https://unpkg.com",
+              ],
+              "font-src": [
+                "https://cdn.jsdelivr.net",
+                "https://unpkg.com",
+              ],
               "frame-src": [
                 "'self'",
-                "https:",
                 "data:",
                 "blob:",
+              ],
+              "img-src": [
+                "https://cdn.jsdelivr.net",
+                "https://unpkg.com",
+              ],
+              "media-src": [
+                "https://cdn.jsdelivr.net",
+                "https://unpkg.com",
+              ],
+              "script-src": [
+                "https://cdn.jsdelivr.net",
+                "https://unpkg.com",
+              ],
+              "style-src": [
+                "https://cdn.jsdelivr.net",
+                "https://unpkg.com",
               ],
             },
             "mode": "declared",
@@ -266,14 +296,44 @@ exports[`seedHostTemplate > seed output matches the committed golden snapshot 1`
         "compatRuntime": {
           "openaiApps": true,
         },
+        "mcpAppsOverrides": {
+          "cspConnectDomains": {
+            "fetch": true,
+            "websocket": true,
+            "xhr": true,
+          },
+        },
         "sandbox": {
           "csp": {
             "cspDirectives": {
+              "connect-src": [
+                "https://cdn.jsdelivr.net",
+                "https://unpkg.com",
+              ],
+              "font-src": [
+                "https://cdn.jsdelivr.net",
+                "https://unpkg.com",
+              ],
               "frame-src": [
                 "'self'",
-                "https:",
                 "data:",
                 "blob:",
+              ],
+              "img-src": [
+                "https://cdn.jsdelivr.net",
+                "https://unpkg.com",
+              ],
+              "media-src": [
+                "https://cdn.jsdelivr.net",
+                "https://unpkg.com",
+              ],
+              "script-src": [
+                "https://cdn.jsdelivr.net",
+                "https://unpkg.com",
+              ],
+              "style-src": [
+                "https://cdn.jsdelivr.net",
+                "https://unpkg.com",
               ],
             },
             "mode": "declared",
@@ -346,7 +406,7 @@ exports[`seedHostTemplate > seed output matches the committed golden snapshot 1`
           "description": "Anthropic's agentic coding tool",
           "name": "claude-code",
           "title": "Claude Code",
-          "version": "2.1.235",
+          "version": "2.1.237",
           "websiteUrl": "https://claude.com/claude-code",
         },
         "supportedProtocolVersions": [
@@ -391,7 +451,7 @@ exports[`seedHostTemplate > seed output matches the committed golden snapshot 1`
           "description": "Anthropic's agentic coding tool",
           "name": "claude-code",
           "title": "Claude Code",
-          "version": "2.1.235",
+          "version": "2.1.237",
           "websiteUrl": "https://claude.com/claude-code",
         },
         "supportedProtocolVersions": [

--- a/sdk/tests/host-config-seed-host-template.test.ts
+++ b/sdk/tests/host-config-seed-host-template.test.ts
@@ -106,6 +106,17 @@ describe("seedHostTemplate", () => {
     expect(config.computer).toEqual({ kind: "personal" });
     // Codex (like Claude Code) can't pause for interactive approval.
     expect(config.requireToolApproval).toBe(false);
+    expect(config.clientCapabilities).toMatchObject({
+      extensions: {
+        "io.modelcontextprotocol/ui": {
+          mimeTypes: ["text/html;profile=mcp-app", "text/html+skybridge"],
+        },
+      },
+      elicitation: { form: {}, url: {} },
+    });
+    expect(config.mcpProfile?.apps?.mcpAppsOverrides).toMatchObject({
+      cspConnectDomains: { fetch: true, xhr: true, websocket: true },
+    });
   });
 
   it("threads appVersion into the mcpjam template (and only it)", () => {

--- a/sdk/tests/host-config-seed-host-template.test.ts
+++ b/sdk/tests/host-config-seed-host-template.test.ts
@@ -97,6 +97,7 @@ describe("seedHostTemplate", () => {
     // requireToolApproval must be false — the harness rejects approval-gated turns.
     expect(config.requireToolApproval).toBe(false);
     expect(config.progressiveToolDiscovery).toBe(false);
+    expect(config.mcpProfile?.initialize?.clientInfo?.version).toBe("2.1.237");
   });
 
   it("seeds the real Codex harness + a personal computer", () => {
@@ -160,6 +161,17 @@ describe("seedHostTemplate", () => {
       logging: {},
     });
     expect(config.hostCapabilitiesOverride).not.toHaveProperty("downloadFile");
+    expect(config.mcpProfile?.apps?.mcpAppsOverrides).toMatchObject({
+      cspConnectDomains: { fetch: true, xhr: true, websocket: true },
+    });
+    expect(
+      config.mcpProfile?.apps?.mcpAppsOverrides?.cspResourceDomains
+    ).toBeUndefined();
+    expect(config.mcpProfile?.apps?.sandbox?.csp?.cspDirectives).toMatchObject({
+      "connect-src": ["https://cdn.jsdelivr.net", "https://unpkg.com"],
+      "script-src": ["https://cdn.jsdelivr.net", "https://unpkg.com"],
+      "frame-src": ["'self'", "data:", "blob:"],
+    });
   });
 
   it("labels and persists the Copilot documented runtime surface", () => {

--- a/sdk/tests/host-config-seed-host-template.test.ts
+++ b/sdk/tests/host-config-seed-host-template.test.ts
@@ -7,6 +7,7 @@ import {
 } from "../src/host-config/templates/index.js";
 import { XAA_MCP_EXTENSION } from "../src/xaa/mcp-init.js";
 import { readXaaEnterprisePolicy } from "../src/xaa/enterprise-policy.js";
+import { canonicalizeHostConfigV2 } from "../src/host-config/internal.js";
 
 const ALL_IDS: HostTemplateId[] = [
   "mcpjam",
@@ -118,6 +119,10 @@ describe("seedHostTemplate", () => {
     expect(config.mcpProfile?.apps?.mcpAppsOverrides).toMatchObject({
       cspConnectDomains: { fetch: true, xhr: true, websocket: true },
     });
+    const effective = canonicalizeHostConfigV2(config);
+    expect(effective.mcpProfile?.apps?.mcpAppsOverrides).toMatchObject({
+      cspConnectDomains: { fetch: true, xhr: true, websocket: true },
+    });
   });
 
   it("threads appVersion into the mcpjam template (and only it)", () => {
@@ -162,6 +167,10 @@ describe("seedHostTemplate", () => {
     });
     expect(config.hostCapabilitiesOverride).not.toHaveProperty("downloadFile");
     expect(config.mcpProfile?.apps?.mcpAppsOverrides).toMatchObject({
+      cspConnectDomains: { fetch: true, xhr: true, websocket: true },
+    });
+    const effective = canonicalizeHostConfigV2(config);
+    expect(effective.mcpProfile?.apps?.mcpAppsOverrides).toMatchObject({
       cspConnectDomains: { fetch: true, xhr: true, websocket: true },
     });
     expect(


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Mirrors the latest Codex MCP Apps catalog so Codex can render MCP Apps and stays consistent with the backend. Previously Codex was elicitation-only and `cspConnectDomains` was dropped in canonicalization; now Codex advertises MCP Apps with UI MIME types and canonicalization preserves `cspConnectDomains`.

- Seed template (Codex): adds MCP UI MIME types (`text/html;profile=mcp-app`, `text/html+skybridge`); pins hostContext (dark, inline, desktop); defines `mcpProfile.apps` overrides including `cspConnectDomains.fetch|xhr|websocket = true` and `widgetDisplayModeRequests: "accept"`; enables `compatRuntime.openaiApps`.
- Compat catalog: adds CDN CSP allowlists for `connect-src`, `script-src`, `style-src`, `img-src`, `font-src`, `media-src` to `https://cdn.jsdelivr.net` and `https://unpkg.com`; flips `cspConnectDomains.fetch|xhr` to true; removes `cspResourceDomains`; bumps Claude Code to 2.1.237.
- Schema/runtime: adds `cspConnectDomains` to the types and schema; canonicalization validates and preserves it.
- Tests: update inspector expectation to MCP UI MIME types when `activeHost` is null; assert `cspConnectDomains` and CDN CSP directives; refresh snapshots.

- Migration: Update any checks/tests that assumed Codex had no MCP UI extension. No config changes required.

<sup>Written for commit c99b9b342fc173d1eb0e06f24a761dbdd39a2749. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/MCPJam/inspector/pull/4145?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

