### PR TITLE
registry: let the tab load data

### DIFF
--- a/.changeset/registry-feature-constant-on.md
+++ b/.changeset/registry-feature-constant-on.md
@@ -1,0 +1,33 @@
+---
+"@mcpjam/inspector": patch
+---
+
+Let the Registry tab load data: `REGISTRY_FEATURE_ENABLED` is now `true`.
+
+The tab has two independent gates. The PostHog `registry-enabled` flag decides
+who can reach the route; a build-time constant in `useRegistryServers` decided
+whether the data layer did anything at all. With the constant `false` the hooks
+were fully inert — empty arrays, no fetches, no-op mutations — so a user who had
+the flag turned on reached `/registry` and was told "No servers available" by a
+screen that had never asked.
+
+The constant existed for a real reason: the flag gates the route, not the data,
+so an internal user with the flag on mounted the tab and fired requests at a
+backend that wasn't ready, producing visible errors. Its comment named the exit
+condition — flip once the registry backend is ready for real use — and that
+condition is now met. The curated registry is seeded, and the Claude connectors
+directory carries ~2,000 rows synced daily, with search over names, descriptions
+and tool names.
+
+Nothing else changes. The PostHog flag is untouched and still decides the
+audience, which today is internal users only. Both halves of the tab share this
+one constant, so they light up together rather than leaving a directory querying
+beside a dark curated catalog.
+
+The constant should not survive long. It duplicates a control that is better at
+the job — `registry-enabled` is per-user and needs no deploy, while this needs a
+build to move, so a real emergency reaches for the flag every time — and it is
+what currently forces two `useRegistryServers` suites to `describe.skip`.
+Removing it means deleting the `enabled` plumbing in both hooks and un-skipping
+those suites, which is a small refactor deliberately kept out of this change so
+that reverting "turn it on" never means reverting the refactor too.

--- a/mcpjam-inspector/client/src/hooks/useRegistryServers.ts
+++ b/mcpjam-inspector/client/src/hooks/useRegistryServers.ts
@@ -25,18 +25,31 @@ import { toast } from "@/lib/toast";
 const DEV_MOCK_REGISTRY =
   import.meta.env.DEV && import.meta.env.VITE_DEV_MOCK_REGISTRY === "true";
 
-// Kill switch for the entire registry feature. The registry UI is gated
-// behind an internal feature flag and isn't shipped to prod users yet, but
-// the hook was still firing network requests (catalog fetch, guest-stars
-// merge) for internal users with the flag on and producing visible errors.
-// While `false`, the hook is fully inert: empty data, no fetches, no-op
-// mutations. Flip to true once the registry backend is ready for real use.
+// Kill switch for the entire registry feature. It was added because the
+// PostHog `registry-enabled` flag gates the ROUTE, not the data: an internal
+// user with that flag on mounted the tab and the hook fired requests
+// (catalog fetch, guest-stars merge) at a backend that wasn't ready yet,
+// producing visible errors. While `false`, the hook is fully inert: empty
+// data, no fetches, no-op mutations.
+//
+// Its stated exit condition — "flip once the registry backend is ready for
+// real use" — is now met. Both catalogs are live: the curated registry is
+// seeded, and the Claude connectors directory carries ~2,000 rows synced
+// daily with working search.
+//
+// It is now `true` and its remaining life is short. It duplicates a control
+// that is strictly better at the job: `registry-enabled` is per-user and
+// takes effect without a deploy, while this needs a build to move, so an
+// actual emergency reaches for the flag every time. Removing it means
+// deleting the `enabled` plumbing in both hooks and un-skipping the two
+// suites it currently forces to `describe.skip` — a small refactor kept out
+// of this change so that reverting "turn it on" never means reverting that.
 //
 // EXPORTED so the Claude-directory half of the Registry tab
 // (`useClaudeDirectory`) reads the same switch. Two constants would let the
 // screen half-light: a directory that queries while the curated catalog is
 // dark is exactly the state this flag exists to prevent.
-export const REGISTRY_FEATURE_ENABLED = false;
+export const REGISTRY_FEATURE_ENABLED = true;
 
 const MOCK_REGISTRY_SERVERS: RegistryServer[] = [
   {


### PR DESCRIPTION
## Purpose

The Registry tab has **two independent gates**, and only one of them is a rollout control:

| Gate | What it decides | How it moves |
| --- | --- | --- |
| `registry-enabled` (PostHog) | who can reach the route | runtime, per-user, no deploy |
| `REGISTRY_FEATURE_ENABLED` (constant) | whether the data layer does anything | build-time, global |

With the constant `false`, both hooks are fully inert — empty arrays, no fetches, no-op mutations. So a user who had the flag turned on reached `/registry` and got **"No servers available"** from a screen that had never asked the backend anything. That is what prompted this: the flag was on, the data was live, and the page was still empty with nothing at runtime to explain why.

This flips the constant to `true`. One line, plus the comment above it and a changeset.

## Why now

The constant was not a mistake. The flag gates the *route*, not the *data*, so an internal user with the flag on mounted the tab and fired requests (catalog fetch, guest-stars merge) at a backend that wasn't ready — visible errors. The comment named its own exit condition: *flip once the registry backend is ready for real use.*

That condition is now met:

- **Curated registry** — seeded in production.
- **Claude connectors directory** — 2,023 rows synced, 0 invalid, search working over names, descriptions and tool names (`create_issue` finds Linear, Pylon, Elixion), blank query correctly falls back to browse.
- **Curated-wins dedupe** — exactly 10 directory rows are shadowed by curated cards (Asana, Figma, Linear, Lucid, Microsoft Learn, Notion, PostHog, Sentry, Stripe, monday.com).

## Blast radius

The PostHog flag is untouched, so the audience is unchanged — internal users only. Both halves of the tab read this one constant, so they light up together rather than leaving a directory querying beside a dark curated catalog.

Worth knowing when it is first exercised: the curated cards' connect flow still has its pre-existing OAuth-redirect provenance quirk (the directory flow does not — it writes provenance before anything can navigate), and the three directory endpoint kinds are all reachable — `fixed`, `options` (e.g. Braze), and `tenant` (e.g. Smartsheet).

## What this deliberately does NOT do

Remove the constant. It should go — it duplicates a control that is strictly better at the job (`registry-enabled` needs no deploy, this needs a build, so a real emergency reaches for the flag every time), and it is what currently forces two `useRegistryServers` suites to `describe.skip`.

But removing it means deleting the `enabled` plumbing threaded through both hooks and un-skipping those suites. That is a small refactor, and it is kept out of this PR so that reverting *"turn it on"* never means reverting the refactor too. It is the immediate follow-up.

## Verification

- `npx vitest run` over the registry suites: **120 passed**, 5 skipped (the two hard-coded `describe.skip` suites above — they do not auto-unskip, which is the follow-up's job).
- `npm run typecheck:client`: clean. Worth checking explicitly, since flipping a `const` narrows its literal type from `false` to `true`.
- Backend state verified directly against production before flipping, not assumed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit 9533d19e1ae5231f9b06c1796d4736dacc50f088. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Enables the Registry tab data layer by setting REGISTRY_FEATURE_ENABLED to true. Previously, internal users could reach /registry via the PostHog flag but the hooks were inert and showed “No servers available”; now the tab fetches catalog/directory data and mutations run.

- Scope remains internal: the PostHog `registry-enabled` flag still gates access.
- Both curated catalog and connectors directory load together; no half-lit UI.
- No API or schema changes. Two `useRegistryServers` test suites remain skipped; follow-up will remove the constant and unskip them.
- No migration required.

<sup>Written for commit 9533d19e1ae5231f9b06c1796d4736dacc50f088. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/MCPJam/inspector/pull/4147?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

