### PR TITLE
Registry: a detail dialog behind every Claude-directory card

### DIFF
--- a/.changeset/registry-directory-detail-dialog.md
+++ b/.changeset/registry-directory-detail-dialog.md
@@ -1,0 +1,5 @@
+---
+"@mcpjam/inspector": minor
+---
+
+Registry: clicking a Claude-directory card now opens a detail dialog showing the full upstream listing — long description, published tool and prompt names, publisher and links, categories, access notes (permissions, sensitive data, required fields), and the endpoint it connects to. The body is fetched per card from the catalog's stored upstream row (`getCatalogServer` with `includeRaw`), so the list itself stays blob-free.

--- a/mcpjam-inspector/client/src/components/RegistryTab.tsx
+++ b/mcpjam-inspector/client/src/components/RegistryTab.tsx
@@ -42,6 +42,7 @@ import {
 } from "@/hooks/useRegistryServers";
 import {
   useClaudeDirectory,
+  useDirectoryServerDetail,
   requiresEndpointChoice,
   normalizeDirectoryConnectError,
   DIRECTORY_TIERS,
@@ -49,6 +50,7 @@ import {
   type DirectoryTier,
 } from "@/hooks/useClaudeDirectory";
 import { DirectoryEndpointDialog } from "./registry/DirectoryEndpointDialog";
+import { DirectoryDetailDialog } from "./registry/DirectoryDetailDialog";
 import { toast } from "@/lib/toast";
 import { formatRegistryStarCount } from "@/lib/format-registry-star-count";
 import type { ServerFormData } from "@/shared/types.js";
@@ -256,6 +258,16 @@ export function RegistryTab({
   const [connectingDirectoryIds, setConnectingDirectoryIds] = useState<
     Set<string>
   >(new Set());
+
+  // The directory card whose detail dialog is open. The body (tool names,
+  // publisher, permissions) is fetched only while a card is open — the list
+  // stays blob-free.
+  const [detailServer, setDetailServer] = useState<DirectoryServer | null>(
+    null
+  );
+  const detailServerDetail = useDirectoryServerDetail(
+    detailServer?._id ?? null
+  );
 
   // Auto-redirect to App Builder when a pending server becomes connected.
   // We persist in localStorage to survive OAuth redirects (page remounts).
@@ -808,9 +820,35 @@ export function RegistryTab({
           directory={directory}
           statusFor={directoryStatusFor}
           onConnect={handleDirectoryConnect}
+          onOpenDetail={setDetailServer}
         />
       </div>
 
+      {detailServer && (
+        <DirectoryDetailDialog
+          open
+          onOpenChange={(open) => {
+            if (!open) setDetailServer(null);
+          }}
+          server={detailServer}
+          detail={detailServerDetail}
+          badges={<DirectoryBadges server={detailServer} />}
+          action={
+            <DirectoryAction
+              status={directoryStatusFor(detailServer)}
+              onConnect={() => {
+                // Hand off to the card's connect flow — and get out of its
+                // way: the endpoint dialog (or an OAuth redirect) may be
+                // about to take over, and a detail dialog underneath it
+                // would fight for focus.
+                const server = detailServer;
+                setDetailServer(null);
+                void handleDirectoryConnect(server);
+              }}
+            />
+          }
+        />
+      )}
       {endpointPrompt && (
         <DirectoryEndpointDialog
           open
@@ -842,10 +880,12 @@ function ClaudeDirectorySection({
   directory,
   statusFor,
   onConnect,
+  onOpenDetail,
 }: {
   directory: ReturnType<typeof useClaudeDirectory>;
   statusFor: (server: DirectoryServer) => RegistryConnectionStatus | "error";
   onConnect: (server: DirectoryServer) => void;
+  onOpenDetail: (server: DirectoryServer) => void;
 }) {
   const { items, query, setQuery, tier, setTier } = directory;
   const filtering = query.trim().length > 0 || tier !== "all";
@@ -912,6 +952,7 @@ function ClaudeDirectorySection({
               server={item}
               status={statusFor(item)}
               onConnect={() => onConnect(item)}
+              onOpenDetail={() => onOpenDetail(item)}
             />
           ))}
         </div>
@@ -937,16 +978,35 @@ function DirectoryServerCard({
   server,
   status,
   onConnect,
+  onOpenDetail,
 }: {
   server: DirectoryServer;
   status: RegistryConnectionStatus | "error";
   onConnect: () => void;
+  onOpenDetail: () => void;
 }) {
   const [iconFailed, setIconFailed] = useState(false);
   const showIcon = Boolean(server.iconUrl) && !iconFailed;
 
   return (
-    <Card className="px-4 py-3 flex flex-col gap-2">
+    <Card
+      className="px-4 py-3 flex flex-col gap-2 cursor-pointer transition-colors hover:border-muted-foreground/30"
+      // The whole card opens the detail dialog; the Connect button inside
+      // stops propagation so the two targets never fight. A real <button>
+      // cannot wrap another button, hence the ARIA affordance.
+      role="button"
+      tabIndex={0}
+      aria-label={`View details for ${server.displayName}`}
+      data-testid="directory-server-card"
+      onClick={onOpenDetail}
+      onKeyDown={(event) => {
+        if (event.target !== event.currentTarget) return;
+        if (event.key === "Enter" || event.key === " ") {
+          event.preventDefault();
+          onOpenDetail();
+        }
+      }}
+    >
       <div className="flex items-center gap-3">
         {showIcon ? (
           <img
@@ -973,23 +1033,16 @@ function DirectoryServerCard({
           </h4>
           <p className="text-xs text-muted-foreground">From Claude directory</p>
         </div>
-        <div className="flex-shrink-0">
+        <div
+          className="flex-shrink-0"
+          onClick={(event) => event.stopPropagation()}
+        >
           <DirectoryAction status={status} onConnect={onConnect} />
         </div>
       </div>
 
       <div className="flex items-center gap-1.5 flex-wrap">
-        <TierBadge tier={server.verifiedTier} />
-        {requiresEndpointChoice(server) && (
-          <Badge
-            variant="outline"
-            className="text-[11px] px-1.5 py-0.5 gap-1 border-muted-foreground/30 text-muted-foreground"
-          >
-            {server.endpointKind === "options"
-              ? "Choose endpoint"
-              : "Your instance"}
-          </Badge>
-        )}
+        <DirectoryBadges server={server} />
       </div>
 
       {server.description && (
@@ -998,6 +1051,25 @@ function DirectoryServerCard({
         </p>
       )}
     </Card>
+  );
+}
+
+/** The tier + endpoint chips, identical on the card and the detail dialog. */
+function DirectoryBadges({ server }: { server: DirectoryServer }) {
+  return (
+    <>
+      <TierBadge tier={server.verifiedTier} />
+      {requiresEndpointChoice(server) && (
+        <Badge
+          variant="outline"
+          className="text-[11px] px-1.5 py-0.5 gap-1 border-muted-foreground/30 text-muted-foreground"
+        >
+          {server.endpointKind === "options"
+            ? "Choose endpoint"
+            : "Your instance"}
+        </Badge>
+      )}
+    </>
   );
 }
 

--- a/mcpjam-inspector/client/src/components/__tests__/RegistryTab.test.tsx
+++ b/mcpjam-inspector/client/src/components/__tests__/RegistryTab.test.tsx
@@ -5,6 +5,7 @@ import {
   screen,
   fireEvent,
   waitFor,
+  within,
 } from "@testing-library/react";
 import { RegistryTab } from "../RegistryTab";
 import {
@@ -106,8 +107,15 @@ vi.mock("@/hooks/useClaudeDirectory", async (importOriginal) => {
   return {
     ...actual,
     useClaudeDirectory: () => mockDirectoryReturn,
+    // The real hook is Convex-backed; the mock answers only once a card is
+    // actually open (a null id must stay `undefined`, like the real skip).
+    useDirectoryServerDetail: (catalogServerId: string | null) =>
+      catalogServerId ? mockDirectoryDetail : undefined,
   };
 });
+
+/** What the mocked detail hook serves once a card is open. */
+let mockDirectoryDetail: unknown;
 
 function createDirectoryServer(
   overrides: Partial<DirectoryServer> = {}
@@ -198,6 +206,7 @@ describe("RegistryTab", () => {
       serverName: "Linear",
     });
     mockDirectoryReturn = directoryHookReturn();
+    mockDirectoryDetail = null;
     mockHookReturn = {
       catalogCards: [],
       categories: [],
@@ -562,6 +571,70 @@ describe("RegistryTab", () => {
       render(<RegistryTab {...defaultProps} />);
       expect(
         screen.queryByTestId("claude-directory-section")
+      ).not.toBeInTheDocument();
+    });
+  });
+
+  describe("claude directory detail dialog", () => {
+    it("clicking a card opens the detail dialog with the listing body", () => {
+      mockDirectoryReturn = directoryHookReturn({
+        items: [createDirectoryServer()],
+      });
+      mockDirectoryDetail = {
+        description: "The long-form listing description.",
+        authorName: "Linear",
+        authorUrl: "https://linear.app",
+        categories: ["productivity"],
+        toolNames: ["create_issue", "list_issues"],
+        promptNames: [],
+        permissions: "Read and write",
+        sensitiveDataTypes: [],
+        links: [],
+        authPosture: "auth_required",
+        requiredFields: [],
+      };
+
+      render(<RegistryTab {...defaultProps} />);
+      fireEvent.click(screen.getByTestId("directory-server-card"));
+
+      expect(screen.getByTestId("directory-detail-dialog")).toBeInTheDocument();
+      expect(
+        screen.getByText("The long-form listing description.")
+      ).toBeInTheDocument();
+      expect(screen.getByText("Tools (2)")).toBeInTheDocument();
+      expect(screen.getByText("create_issue")).toBeInTheDocument();
+    });
+
+    it("the card's Connect button connects without opening the dialog", async () => {
+      const server = createDirectoryServer();
+      mockDirectoryReturn = directoryHookReturn({ items: [server] });
+
+      render(<RegistryTab {...defaultProps} />);
+      fireEvent.click(screen.getByRole("button", { name: "Connect" }));
+
+      await waitFor(() => {
+        expect(mockDirectoryConnect).toHaveBeenCalledWith(server, undefined);
+      });
+      expect(
+        screen.queryByTestId("directory-detail-dialog")
+      ).not.toBeInTheDocument();
+    });
+
+    it("connecting from the dialog closes it and runs the connect flow", async () => {
+      const server = createDirectoryServer();
+      mockDirectoryReturn = directoryHookReturn({ items: [server] });
+
+      render(<RegistryTab {...defaultProps} />);
+      fireEvent.click(screen.getByTestId("directory-server-card"));
+      // Two Connects exist now (card + dialog); the dialog's is inside it.
+      const dialog = screen.getByTestId("directory-detail-dialog");
+      fireEvent.click(within(dialog).getByRole("button", { name: "Connect" }));
+
+      await waitFor(() => {
+        expect(mockDirectoryConnect).toHaveBeenCalledWith(server, undefined);
+      });
+      expect(
+        screen.queryByTestId("directory-detail-dialog")
       ).not.toBeInTheDocument();
     });
   });

--- a/mcpjam-inspector/client/src/components/registry/DirectoryDetailDialog.tsx
+++ b/mcpjam-inspector/client/src/components/registry/DirectoryDetailDialog.tsx
@@ -1,0 +1,289 @@
+import { useEffect, useState, type ReactNode } from "react";
+import { ExternalLink, KeyRound, ShieldOff } from "lucide-react";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@mcpjam/design-system/dialog";
+import { Badge } from "@mcpjam/design-system/badge";
+import { Button } from "@mcpjam/design-system/button";
+import { Skeleton } from "@mcpjam/design-system/skeleton";
+import type { DirectoryServer } from "@/hooks/useClaudeDirectory";
+import type { DirectoryServerDetail } from "@/lib/claude-directory-detail";
+
+/**
+ * Everything the directory knows about one connector, behind a card click.
+ *
+ * The card stays a one-liner; this is where the rest of the upstream listing
+ * lives — the long description, the published tool names, who publishes it,
+ * what access it asks for, and where it actually connects. Sections render
+ * only when the listing carries them: absence is upstream's statement, not a
+ * gap to paper over.
+ *
+ * `detail` is the parsed `rawJson` body:
+ *   undefined — still loading (skeletons)
+ *   null      — body unavailable; the summary the card had is all there is
+ */
+
+/** Past this many, the tool list collapses behind "Show all". */
+const TOOLS_PREVIEW_COUNT = 24;
+
+export interface DirectoryDetailDialogProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  server: DirectoryServer;
+  detail: DirectoryServerDetail | null | undefined;
+  /** Chips under the title — the card's tier/endpoint badges, unchanged. */
+  badges?: ReactNode;
+  /** The card's connect control, so the two can never disagree. */
+  action?: ReactNode;
+}
+
+/** Where a connect would go, said the way the row says it. */
+function endpointSummary(server: DirectoryServer): string | undefined {
+  switch (server.endpointKind) {
+    case "fixed":
+      return server.remoteUrl;
+    case "options":
+      return server.remoteUrlOptions?.join("  ·  ");
+    case "tenant":
+      return "Your own instance URL";
+    default:
+      return undefined;
+  }
+}
+
+export function DirectoryDetailDialog({
+  open,
+  onOpenChange,
+  server,
+  detail,
+  badges,
+  action,
+}: DirectoryDetailDialogProps) {
+  const [iconFailed, setIconFailed] = useState(false);
+  const [showAllTools, setShowAllTools] = useState(false);
+
+  // A dialog reused across cards must not carry one row's expansion (or a
+  // dead icon verdict) over to the next.
+  useEffect(() => {
+    setIconFailed(false);
+    setShowAllTools(false);
+  }, [server._id]);
+
+  const showIcon = Boolean(server.iconUrl) && !iconFailed;
+  const loading = detail === undefined;
+  const description = detail?.description ?? server.description;
+  const toolNames = detail?.toolNames ?? [];
+  const visibleTools = showAllTools
+    ? toolNames
+    : toolNames.slice(0, TOOLS_PREVIEW_COUNT);
+  const endpoint = endpointSummary(server);
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent
+        className="sm:max-w-[560px] max-h-[85vh] overflow-y-auto"
+        data-testid="directory-detail-dialog"
+      >
+        <DialogHeader>
+          <div className="flex items-center gap-3">
+            {showIcon ? (
+              <img
+                src={server.iconUrl}
+                alt=""
+                referrerPolicy="no-referrer"
+                onError={() => setIconFailed(true)}
+                className="h-10 w-10 rounded-md object-contain flex-shrink-0"
+              />
+            ) : null}
+            <div className="min-w-0">
+              <DialogTitle className="truncate">
+                {server.displayName}
+              </DialogTitle>
+              <DialogDescription>
+                {detail?.authorName
+                  ? `By ${detail.authorName} · From Claude directory`
+                  : "From Claude directory"}
+              </DialogDescription>
+            </div>
+          </div>
+          {badges ? (
+            <div className="flex items-center gap-1.5 flex-wrap pt-1">
+              {badges}
+            </div>
+          ) : null}
+        </DialogHeader>
+
+        {loading ? (
+          <div className="space-y-2" data-testid="directory-detail-loading">
+            <Skeleton className="h-4 w-full" />
+            <Skeleton className="h-4 w-4/5" />
+            <Skeleton className="h-4 w-2/3" />
+          </div>
+        ) : (
+          <div className="space-y-4 text-sm">
+            {description && (
+              <p className="text-muted-foreground whitespace-pre-line">
+                {description}
+              </p>
+            )}
+
+            {detail && detail.categories.length > 0 && (
+              <div className="flex items-center gap-1.5 flex-wrap">
+                {detail.categories.map((category) => (
+                  <Badge
+                    key={category}
+                    variant="outline"
+                    className="text-[11px] px-1.5 py-0.5 border-muted-foreground/30 text-muted-foreground"
+                  >
+                    {category}
+                  </Badge>
+                ))}
+              </div>
+            )}
+
+            {detail && detail.toolNames.length > 0 && (
+              <section data-testid="directory-detail-tools">
+                <h4 className="text-xs font-semibold uppercase tracking-wide text-muted-foreground mb-1.5">
+                  Tools ({detail.toolNames.length})
+                </h4>
+                <div className="flex gap-1.5 flex-wrap">
+                  {visibleTools.map((name) => (
+                    <code
+                      key={name}
+                      className="text-[11px] font-mono bg-muted rounded px-1.5 py-0.5"
+                    >
+                      {name}
+                    </code>
+                  ))}
+                  {!showAllTools && toolNames.length > TOOLS_PREVIEW_COUNT && (
+                    <Button
+                      variant="ghost"
+                      size="sm"
+                      className="h-5 px-1.5 text-[11px]"
+                      onClick={() => setShowAllTools(true)}
+                    >
+                      Show all {toolNames.length}
+                    </Button>
+                  )}
+                </div>
+              </section>
+            )}
+
+            {detail && detail.promptNames.length > 0 && (
+              <section>
+                <h4 className="text-xs font-semibold uppercase tracking-wide text-muted-foreground mb-1.5">
+                  Prompts ({detail.promptNames.length})
+                </h4>
+                <div className="flex gap-1.5 flex-wrap">
+                  {detail.promptNames.map((name) => (
+                    <code
+                      key={name}
+                      className="text-[11px] font-mono bg-muted rounded px-1.5 py-0.5"
+                    >
+                      {name}
+                    </code>
+                  ))}
+                </div>
+              </section>
+            )}
+
+            {detail &&
+              (detail.authPosture ||
+                detail.permissions ||
+                detail.sensitiveDataTypes.length > 0 ||
+                detail.requiredFields.length > 0) && (
+                <section className="space-y-1">
+                  <h4 className="text-xs font-semibold uppercase tracking-wide text-muted-foreground mb-1.5">
+                    Access
+                  </h4>
+                  {detail.authPosture && (
+                    <p className="text-xs text-muted-foreground flex items-center gap-1.5">
+                      {detail.authPosture === "no_auth" ? (
+                        <ShieldOff className="h-3.5 w-3.5" />
+                      ) : (
+                        <KeyRound className="h-3.5 w-3.5" />
+                      )}
+                      {detail.authPosture === "no_auth"
+                        ? "Listed as connecting without authentication"
+                        : "Listed as requiring sign-in"}
+                    </p>
+                  )}
+                  {detail.permissions && (
+                    <p className="text-xs text-muted-foreground">
+                      Permissions: {detail.permissions}
+                    </p>
+                  )}
+                  {detail.sensitiveDataTypes.length > 0 && (
+                    <p className="text-xs text-muted-foreground">
+                      Sensitive data: {detail.sensitiveDataTypes.join(", ")}
+                    </p>
+                  )}
+                  {detail.requiredFields.map((field) => (
+                    <p
+                      key={field.field}
+                      className="text-xs text-muted-foreground"
+                    >
+                      Requires <code className="font-mono">{field.field}</code>
+                      {field.sourceUrl && (
+                        <>
+                          {" — "}
+                          <a
+                            href={field.sourceUrl}
+                            target="_blank"
+                            rel="noreferrer noopener"
+                            className="underline underline-offset-2"
+                          >
+                            where to get it
+                          </a>
+                        </>
+                      )}
+                    </p>
+                  ))}
+                </section>
+              )}
+
+            {endpoint && (
+              <section>
+                <h4 className="text-xs font-semibold uppercase tracking-wide text-muted-foreground mb-1.5">
+                  Endpoint
+                </h4>
+                <p className="text-xs font-mono text-muted-foreground break-all">
+                  {endpoint}
+                </p>
+              </section>
+            )}
+
+            {detail && detail.links.length > 0 && (
+              <div className="flex items-center gap-3 flex-wrap">
+                {detail.links.map((link) => (
+                  <a
+                    key={link.url}
+                    href={link.url}
+                    target="_blank"
+                    rel="noreferrer noopener"
+                    className="text-xs text-muted-foreground hover:text-foreground underline underline-offset-2 inline-flex items-center gap-1"
+                  >
+                    {link.label}
+                    <ExternalLink className="h-3 w-3" />
+                  </a>
+                ))}
+              </div>
+            )}
+          </div>
+        )}
+
+        <DialogFooter className="gap-3">
+          <Button variant="outline" onClick={() => onOpenChange(false)}>
+            Close
+          </Button>
+          {action}
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/mcpjam-inspector/client/src/components/registry/__tests__/DirectoryDetailDialog.test.tsx
+++ b/mcpjam-inspector/client/src/components/registry/__tests__/DirectoryDetailDialog.test.tsx
@@ -1,0 +1,159 @@
+import { describe, it, expect, vi } from "vitest";
+import { render, screen, fireEvent } from "@testing-library/react";
+import { DirectoryDetailDialog } from "../DirectoryDetailDialog";
+import type { DirectoryServer } from "@/hooks/useClaudeDirectory";
+import type { DirectoryServerDetail } from "@/lib/claude-directory-detail";
+
+function server(overrides: Partial<DirectoryServer> = {}): DirectoryServer {
+  return {
+    _id: "cat_1",
+    source: "anthropic-directory",
+    sourceId: "srv-0001",
+    serverName: "com.mcpjam/anthropic-asana-1a2b3c4d",
+    displayName: "Asana",
+    description: "Coordinate tasks, projects, and goals.",
+    verifiedTier: "partner",
+    rowType: "remote",
+    endpointKind: "fixed",
+    remoteUrl: "https://mcp.asana.com/v2/mcp",
+    isAuthless: false,
+    curatedOverlap: false,
+    ...overrides,
+  };
+}
+
+function detail(
+  overrides: Partial<DirectoryServerDetail> = {}
+): DirectoryServerDetail {
+  return {
+    description: "The long-form listing description.",
+    authorName: "Asana",
+    authorUrl: "https://asana.com",
+    categories: ["productivity"],
+    toolNames: ["get_task", "update_task"],
+    promptNames: [],
+    permissions: "Read and write",
+    sensitiveDataTypes: [],
+    links: [
+      { label: "Documentation", url: "https://developers.asana.com/docs" },
+    ],
+    authPosture: "auth_required",
+    requiredFields: [],
+    ...overrides,
+  };
+}
+
+describe("DirectoryDetailDialog", () => {
+  it("renders the parsed body: description, author, tools, access, links", () => {
+    render(
+      <DirectoryDetailDialog
+        open
+        onOpenChange={vi.fn()}
+        server={server()}
+        detail={detail()}
+      />
+    );
+    expect(
+      screen.getByText("The long-form listing description.")
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText("By Asana · From Claude directory")
+    ).toBeInTheDocument();
+    expect(screen.getByText("Tools (2)")).toBeInTheDocument();
+    expect(screen.getByText("get_task")).toBeInTheDocument();
+    expect(screen.getByText("Permissions: Read and write")).toBeInTheDocument();
+    expect(screen.getByText("Listed as requiring sign-in")).toBeInTheDocument();
+    expect(screen.getByRole("link", { name: /Documentation/ })).toHaveAttribute(
+      "href",
+      "https://developers.asana.com/docs"
+    );
+    expect(
+      screen.getByText("https://mcp.asana.com/v2/mcp")
+    ).toBeInTheDocument();
+  });
+
+  it("collapses a long tool list behind Show all", () => {
+    const toolNames = Array.from({ length: 30 }, (_, i) => `tool_${i}`);
+    render(
+      <DirectoryDetailDialog
+        open
+        onOpenChange={vi.fn()}
+        server={server()}
+        detail={detail({ toolNames })}
+      />
+    );
+    expect(screen.getByText("tool_0")).toBeInTheDocument();
+    expect(screen.queryByText("tool_29")).not.toBeInTheDocument();
+    fireEvent.click(screen.getByRole("button", { name: "Show all 30" }));
+    expect(screen.getByText("tool_29")).toBeInTheDocument();
+  });
+
+  it("shows skeletons while the body loads", () => {
+    render(
+      <DirectoryDetailDialog
+        open
+        onOpenChange={vi.fn()}
+        server={server()}
+        detail={undefined}
+      />
+    );
+    expect(screen.getByTestId("directory-detail-loading")).toBeInTheDocument();
+    expect(
+      screen.queryByText("Coordinate tasks, projects, and goals.")
+    ).not.toBeInTheDocument();
+  });
+
+  it("falls back to the card summary when the body is unavailable", () => {
+    render(
+      <DirectoryDetailDialog
+        open
+        onOpenChange={vi.fn()}
+        server={server()}
+        detail={null}
+      />
+    );
+    // The summary description still shows; body-only sections do not.
+    expect(
+      screen.getByText("Coordinate tasks, projects, and goals.")
+    ).toBeInTheDocument();
+    expect(screen.queryByText(/^Tools \(/)).not.toBeInTheDocument();
+    expect(
+      screen.queryByTestId("directory-detail-loading")
+    ).not.toBeInTheDocument();
+  });
+
+  it("describes a tenant row's endpoint without inventing a URL", () => {
+    render(
+      <DirectoryDetailDialog
+        open
+        onOpenChange={vi.fn()}
+        server={server({
+          endpointKind: "tenant",
+          remoteUrl: undefined,
+          remoteUrlRegex: "https://mcp\\.[a-z0-9-]+\\.example/mcp",
+        })}
+        detail={null}
+      />
+    );
+    expect(screen.getByText("Your own instance URL")).toBeInTheDocument();
+  });
+
+  it("renders the action the caller passes and closes on Close", () => {
+    const onOpenChange = vi.fn();
+    render(
+      <DirectoryDetailDialog
+        open
+        onOpenChange={onOpenChange}
+        server={server()}
+        detail={null}
+        action={<button>Connect</button>}
+      />
+    );
+    expect(screen.getByRole("button", { name: "Connect" })).toBeInTheDocument();
+    // Two "Close" buttons exist: Radix's corner X and the footer's. The
+    // footer one renders last; either would close, this is the one we own.
+    const closeButtons = screen.getAllByRole("button", { name: "Close" });
+    fireEvent.click(closeButtons[closeButtons.length - 1]);
+    expect(onOpenChange).toHaveBeenCalledWith(false);
+  });
+});

--- a/mcpjam-inspector/client/src/hooks/useClaudeDirectory.ts
+++ b/mcpjam-inspector/client/src/hooks/useClaudeDirectory.ts
@@ -4,6 +4,10 @@ import { ConvexError } from "convex/values";
 import type { ServerFormData } from "@/shared/types.js";
 import { REGISTRY_FEATURE_ENABLED } from "@/hooks/useRegistryServers";
 import {
+  parseDirectoryServerDetail,
+  type DirectoryServerDetail,
+} from "@/lib/claude-directory-detail";
+import {
   clearPendingQuickConnect,
   writePendingQuickConnect,
   type PendingQuickConnectState,
@@ -215,6 +219,41 @@ export function requiresEndpointChoice(
   server: Pick<DirectoryServer, "endpointKind">
 ): boolean {
   return server.endpointKind === "options" || server.endpointKind === "tenant";
+}
+
+/**
+ * The full upstream row behind one directory card, parsed for the detail
+ * dialog.
+ *
+ * The card renders from the blob-free summary row; everything richer — tool
+ * names, the long description, publisher links, permissions — lives only in
+ * the ~5KB `rawJson` payload, fetched here one entry at a time when a card is
+ * actually opened. `getCatalogServer` is a public query (the catalog mirrors
+ * a public directory), so this needs no auth.
+ *
+ * Returns:
+ *   `undefined` — still loading (or `catalogServerId` is null / feature dark).
+ *   `null`      — no such row, or its body failed to parse; the dialog falls
+ *                 back to the summary it already has.
+ */
+export function useDirectoryServerDetail(
+  catalogServerId: string | null
+): DirectoryServerDetail | null | undefined {
+  const enabled = REGISTRY_FEATURE_ENABLED && catalogServerId !== null;
+  const result = useQuery(
+    "serverCatalogQueries:getCatalogServer" as any,
+    // `includeRaw` because the upstream row is what the dialog renders.
+    // `serverJson` embeds the same row under `_meta`, but is null for the few
+    // entries whose generated server.json failed validation — `rawJson` is
+    // authoritative for both.
+    enabled ? ({ catalogServerId, includeRaw: true } as any) : "skip"
+  ) as { rawJson?: string | null } | null | undefined;
+
+  return useMemo(() => {
+    if (!enabled || result === undefined) return undefined;
+    if (result === null) return null;
+    return parseDirectoryServerDetail(result.rawJson ?? null);
+  }, [enabled, result]);
 }
 
 export interface UseClaudeDirectoryOptions {

--- a/mcpjam-inspector/client/src/lib/__tests__/claude-directory-detail.test.ts
+++ b/mcpjam-inspector/client/src/lib/__tests__/claude-directory-detail.test.ts
@@ -1,0 +1,153 @@
+import { describe, it, expect } from "vitest";
+import { parseDirectoryServerDetail } from "../claude-directory-detail";
+
+/**
+ * The parser reads a `.passthrough()` capture of Anthropic's directory BFF:
+ * only four fields are contractual upstream, so these tests exercise the two
+ * postures that matter — a rich real-shaped row parses fully, and every
+ * malformed or hostile variant degrades to omission, never to a throw or a
+ * dangerous value.
+ */
+
+/** A trimmed copy of the real Asana row's shape (2026-08 snapshot). */
+const richRow = {
+  id: "41aefcf3-a829-45eb-8cee-d90b93912f57",
+  type: "remote",
+  name: "Asana",
+  display_name: "Asana",
+  description: "Access Asana's Work Graph directly from Claude.",
+  one_liner: "Connect to Asana to coordinate tasks, projects, and goals",
+  author: { name: "Asana", url: "https://asana.com" },
+  categories: ["productivity", "communication"],
+  tool_names: ["get_task", "search_tasks_preview", "update_task"],
+  prompt_names: ["weekly_report"],
+  permissions: "Read and write",
+  sensitive_data_types: ["tasks", "comments"],
+  documentation: "https://developers.asana.com/docs/mcp-server",
+  support: "https://help.asana.com/",
+  privacy_policy: "https://asana.com/terms",
+  directory_url: "https://claude.ai/directory/41aefcf3",
+  html_content: "<p>rich text</p>",
+  remote: {
+    url: "https://mcp.asana.com/v2/mcp",
+    transport: "streamable-http",
+    is_authless: false,
+    auth_posture: "auth_required",
+    required_fields: [
+      { field: "api_key", source_url: "https://asana.com/settings" },
+    ],
+  },
+};
+
+describe("parseDirectoryServerDetail", () => {
+  it("parses a real-shaped row completely", () => {
+    const detail = parseDirectoryServerDetail(JSON.stringify(richRow));
+    expect(detail).toEqual({
+      description: "Access Asana's Work Graph directly from Claude.",
+      authorName: "Asana",
+      authorUrl: "https://asana.com",
+      categories: ["productivity", "communication"],
+      toolNames: ["get_task", "search_tasks_preview", "update_task"],
+      promptNames: ["weekly_report"],
+      permissions: "Read and write",
+      sensitiveDataTypes: ["tasks", "comments"],
+      links: [
+        {
+          label: "Documentation",
+          url: "https://developers.asana.com/docs/mcp-server",
+        },
+        { label: "Support", url: "https://help.asana.com/" },
+        { label: "Privacy policy", url: "https://asana.com/terms" },
+        {
+          label: "View in Claude directory",
+          url: "https://claude.ai/directory/41aefcf3",
+        },
+      ],
+      authPosture: "auth_required",
+      requiredFields: [
+        { field: "api_key", sourceUrl: "https://asana.com/settings" },
+      ],
+    });
+  });
+
+  it("returns empty collections and no strings for a minimal row", () => {
+    const detail = parseDirectoryServerDetail(
+      JSON.stringify({ id: "x", type: "remote", name: "Bare" })
+    );
+    expect(detail).toEqual({
+      description: undefined,
+      authorName: undefined,
+      authorUrl: undefined,
+      categories: [],
+      toolNames: [],
+      promptNames: [],
+      permissions: undefined,
+      sensitiveDataTypes: [],
+      links: [],
+      authPosture: undefined,
+      requiredFields: [],
+    });
+  });
+
+  it("drops non-https link values instead of rendering them", () => {
+    const detail = parseDirectoryServerDetail(
+      JSON.stringify({
+        documentation: "http://insecure.example/docs",
+        support: "javascript:alert(1)",
+        privacy_policy: "not a url",
+        author: { name: "Acme", url: "ftp://acme.example" },
+      })
+    );
+    expect(detail?.links).toEqual([]);
+    expect(detail?.authorName).toBe("Acme");
+    expect(detail?.authorUrl).toBeUndefined();
+  });
+
+  it("keeps only string entries of upstream arrays", () => {
+    const detail = parseDirectoryServerDetail(
+      JSON.stringify({
+        tool_names: ["real_tool", 42, null, { name: "nope" }, ""],
+        categories: "productivity",
+      })
+    );
+    expect(detail?.toolNames).toEqual(["real_tool"]);
+    expect(detail?.categories).toEqual([]);
+  });
+
+  it("skips required_fields entries without a field name", () => {
+    const detail = parseDirectoryServerDetail(
+      JSON.stringify({
+        remote: {
+          required_fields: [
+            { source_url: "https://acme.example" },
+            "api_key",
+            { field: "workspace_id", source_url: "http://insecure.example" },
+          ],
+        },
+      })
+    );
+    expect(detail?.requiredFields).toEqual([
+      { field: "workspace_id", sourceUrl: undefined },
+    ]);
+  });
+
+  it.each([
+    ["null input", null],
+    ["undefined input", undefined],
+    ["empty string", ""],
+    ["broken JSON", "{not json"],
+    ["a JSON array", "[1,2]"],
+    ["a JSON scalar", '"just text"'],
+  ])("returns null for %s", (_label, input) => {
+    expect(parseDirectoryServerDetail(input as string | null)).toBeNull();
+  });
+
+  it("tolerates non-object author and remote", () => {
+    const detail = parseDirectoryServerDetail(
+      JSON.stringify({ author: "Asana", remote: "https://mcp.example" })
+    );
+    expect(detail?.authorName).toBeUndefined();
+    expect(detail?.authPosture).toBeUndefined();
+    expect(detail?.requiredFields).toEqual([]);
+  });
+});

--- a/mcpjam-inspector/client/src/lib/claude-directory-detail.ts
+++ b/mcpjam-inspector/client/src/lib/claude-directory-detail.ts
@@ -1,0 +1,153 @@
+/**
+ * Parse the upstream directory row behind a catalog entry into the shape the
+ * detail dialog renders.
+ *
+ * `serverCatalogQueries:getCatalogServer` returns the row as the canonical
+ * JSON STRING the backend stores (`rawJson`) — Convex cannot return
+ * `$`-prefixed keys, so the text travels and the consumer parses. The row is
+ * a `.passthrough()` capture of Anthropic's directory BFF: only four fields
+ * are contractual upstream, so every read here is defensive and every miss is
+ * an omission, never a placeholder. Absence is semantic — the dialog renders
+ * only sections that exist.
+ *
+ * Deliberately NOT surfaced:
+ *   html_content — upstream HTML; rendering it would be an XSS handed to
+ *     whoever edits a directory listing. The plain-text `description` carries
+ *     the same content.
+ *   popularity/trending/rank — excluded from content hashing upstream
+ *     (VOLATILE_ROW_FIELDS), so the stored copy is a stale snapshot from the
+ *     row's last substantive change, not a live number.
+ */
+
+/** A link the dialog may render as an anchor. Always https (see safeUrl). */
+export interface DirectoryDetailLink {
+  label: string;
+  url: string;
+}
+
+/** `remote.required_fields[]`: something the user must supply to connect. */
+export interface DirectoryRequiredField {
+  field: string;
+  sourceUrl?: string;
+}
+
+export interface DirectoryServerDetail {
+  /** The long-form description; the card only carries the one-liner. */
+  description?: string;
+  authorName?: string;
+  /** The author's site, if it is an https URL. */
+  authorUrl?: string;
+  categories: string[];
+  toolNames: string[];
+  promptNames: string[];
+  /** Upstream free text, e.g. "Read and write". */
+  permissions?: string;
+  sensitiveDataTypes: string[];
+  /** Documentation / support / privacy / directory listing, https-only. */
+  links: DirectoryDetailLink[];
+  /** "auth_required" | "no_auth" as published; absent when upstream is silent. */
+  authPosture?: string;
+  requiredFields: DirectoryRequiredField[];
+}
+
+function asString(value: unknown): string | undefined {
+  return typeof value === "string" && value.trim().length > 0
+    ? value
+    : undefined;
+}
+
+function asStringArray(value: unknown): string[] {
+  if (!Array.isArray(value)) return [];
+  return value.filter(
+    (item): item is string => typeof item === "string" && item.length > 0
+  );
+}
+
+/**
+ * An https URL or nothing. The row crossed two wires (Anthropic's BFF, then
+ * our mirror) and these values become clickable hrefs — the same https-only
+ * posture the ETL applies to `icon_url` applies here, and it also drops the
+ * upstream rows whose "URL" fields hold plain strings or MCP endpoints.
+ */
+function safeUrl(value: unknown): string | undefined {
+  const raw = asString(value);
+  if (!raw) return undefined;
+  try {
+    const parsed = new URL(raw);
+    return parsed.protocol === "https:" ? raw : undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+function requiredFields(value: unknown): DirectoryRequiredField[] {
+  if (!Array.isArray(value)) return [];
+  const fields: DirectoryRequiredField[] = [];
+  for (const item of value) {
+    if (typeof item !== "object" || item === null) continue;
+    const record = item as Record<string, unknown>;
+    const field = asString(record.field);
+    if (!field) continue;
+    fields.push({ field, sourceUrl: safeUrl(record.source_url) });
+  }
+  return fields;
+}
+
+/**
+ * The detail view of one upstream row, or `null` when the text is not a JSON
+ * object. `null` means "show the summary the card already had", never an
+ * error state — the row is real, only its body failed to arrive.
+ */
+export function parseDirectoryServerDetail(
+  rawJson: string | null | undefined
+): DirectoryServerDetail | null {
+  if (!rawJson) return null;
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(rawJson);
+  } catch {
+    return null;
+  }
+  if (typeof parsed !== "object" || parsed === null || Array.isArray(parsed)) {
+    return null;
+  }
+  const row = parsed as Record<string, unknown>;
+  const author = (row.author ?? {}) as Record<string, unknown>;
+  const remote = (row.remote ?? {}) as Record<string, unknown>;
+
+  const links: DirectoryDetailLink[] = [];
+  const pushLink = (label: string, value: unknown) => {
+    const url = safeUrl(value);
+    if (url) links.push({ label, url });
+  };
+  pushLink("Documentation", row.documentation);
+  pushLink("Support", row.support);
+  pushLink("Privacy policy", row.privacy_policy);
+  pushLink("View in Claude directory", row.directory_url);
+
+  return {
+    description: asString(row.description),
+    authorName:
+      typeof author === "object" && author !== null
+        ? asString(author.name)
+        : undefined,
+    authorUrl:
+      typeof author === "object" && author !== null
+        ? safeUrl(author.url)
+        : undefined,
+    categories: asStringArray(row.categories),
+    toolNames: asStringArray(row.tool_names),
+    promptNames: asStringArray(row.prompt_names),
+    permissions: asString(row.permissions),
+    sensitiveDataTypes: asStringArray(row.sensitive_data_types),
+    links,
+    authPosture:
+      typeof remote === "object" && remote !== null
+        ? asString(remote.auth_posture)
+        : undefined,
+    requiredFields:
+      typeof remote === "object" && remote !== null
+        ? requiredFields(remote.required_fields)
+        : [],
+  };
+}


### PR DESCRIPTION
## What

Clicking a Claude-directory card in the Registry tab now opens a detail dialog with the rest of the upstream listing. The card itself stays a one-liner.

The dialog shows, when the listing carries it (absence renders nothing):
- the long-form description (the card only has the one-liner)
- **published tool names** (with count; collapses past 24 behind "Show all") and prompt names
- publisher ("By Asana") with links: documentation, support, privacy policy, and "View in Claude directory"
- categories
- access notes: the listing's auth posture, permissions free-text, sensitive data types, and `required_fields` (with their "where to get it" links)
- the endpoint a connect would use (fixed URL, the option list, or "Your own instance URL" for tenant rows)
- the same tier/endpoint badges and the same Connect control as the card (connecting from the dialog closes it first, so the endpoint dialog or an OAuth redirect never stacks on top)

## How

No backend change. `serverCatalogQueries:getCatalogServer` (public) already returns the full upstream row as canonical JSON text; a new `useDirectoryServerDetail` hook fetches it with `includeRaw: true` only while a card is open — the list stays blob-free. `rawJson` is used rather than `serverJson` because it is also present for the few rows whose generated server.json failed validation.

Parsing is defensive (`parseDirectoryServerDetail`): the upstream row is a `.passthrough()` capture of Anthropic's BFF, so every field read tolerates absence or the wrong type, link values render only when https (`javascript:`/http dropped), and two things are deliberately not surfaced — `html_content` (upstream HTML; rendering it would be an XSS handed to whoever edits a listing) and popularity/trending numbers (excluded from content hashing upstream, so the stored copy is stale by design).

## Tests

- `claude-directory-detail.test.ts`: real-shaped row parses fully; minimal/malformed/hostile rows degrade to omission, never a throw
- `DirectoryDetailDialog.test.tsx`: body render, tool-list collapse, loading skeletons, summary fallback when the body is unavailable, tenant endpoint copy, close/action wiring
- `RegistryTab.test.tsx`: card click opens the dialog; the card's Connect still connects without opening it; connecting from the dialog closes it and runs the same flow

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit 5c2c28ae5336e50ab674d0edb3ba65dab7d3065b. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Opens a detail dialog when clicking a Claude-directory card in Registry, exposing the full upstream listing while keeping cards one-line. Previously cards showed only a summary; now the dialog shows long description, published tool/prompt names, publisher links, categories, access notes, and the endpoint, without changing connect behavior or loading large blobs in the list.

- Review notes
  - Data fetching: `useDirectoryServerDetail` calls `serverCatalogQueries:getCatalogServer` with `includeRaw: true` only while a card is open, reading `rawJson` (not `serverJson`) so the list stays blob-free.
  - Parsing and safety: `parseDirectoryServerDetail` is defensive (https-only links, string-only arrays), omits `html_content` and popularity/trending, and degrades to omission on malformed rows.
  - UI behavior: the whole card is a button (keyboard Enter/Space supported); the Connect button stops propagation. Dialog reuses the card’s badges and connect action, collapses tools past 24 with “Show all,” shows skeletons while loading, falls back to the card summary if the body is unavailable, and closes before starting the connect flow to avoid stacked dialogs.
  - Tests: parser unit tests; dialog render/behavior tests; RegistryTab tests for opening, non-interference with card Connect, and closing-before-connect.

<sup>Written for commit 5c2c28ae5336e50ab674d0edb3ba65dab7d3065b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/MCPJam/inspector/pull/4150?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

