### PR TITLE
fix(registry): attach the hosted bearer to the Convex registry routes

### DIFF
--- a/.changeset/registry-hosted-bearer-401.md
+++ b/.changeset/registry-hosted-bearer-401.md
@@ -1,0 +1,15 @@
+---
+"@mcpjam/inspector": patch
+---
+
+Send the hosted bearer on the registry's Convex routes so the catalog stops 401ing.
+
+Opening Registry on a hosted deployment fired two `Missing or invalid bearer token` toasts and rendered every card with zero stars. The catalog request went out with no `Authorization` header at all — signed in, signed out, or as a guest, the outcome was identical, so it never looked like an expired session.
+
+`authFetch` attaches the hosted bearer only when the request's path matches an entry in `HOSTED_AUTH_PATH_PREFIXES`. Most callers hit same-origin `/api/web/*` and are covered by that prefix; the registry client is one of the few that calls Convex directly at an absolute `https://<deployment>.convex.site/web/registry/...` URL, and `/web/oauth/` was the only `/web/` entry on the list. Every registry route fell through the match and was sent bare. On the other side, `/web/registry/catalog` opens with `ctx.auth.getUserIdentity()` and answers 401 with exactly that message when there is no identity — it needs one to resolve per-viewer `isStarred`, so there is no anonymous read to fall back to.
+
+Adding `/web/registry/` to the list covers all four routes, which share the same helper and had the same defect: `catalog`, `star`, `unstar`, and `merge-guest-stars`. The last one meant a guest's stars were silently dropped instead of merged on sign-in.
+
+This does not widen where credentials can go. A path-prefix match is necessary but not sufficient — `shouldAttachHostedAuthorization` first requires `isHostedAuthAllowedOrigin`, which admits only the app's own origin, a loopback host, or the configured `*.convex.site` hostname. A foreign origin serving the same path still gets nothing, and the accompanying test pins that.
+
+The failure mode is worth naming, because the next direct-to-Convex route will hit it too: a path missing from the prefix list produces no warning and no type error. The request simply goes out unauthenticated and surfaces as a generic 401 from the server.

--- a/mcpjam-inspector/client/src/lib/__tests__/session-token.hosted-registry.test.ts
+++ b/mcpjam-inspector/client/src/lib/__tests__/session-token.hosted-registry.test.ts
@@ -1,0 +1,66 @@
+/**
+ * Regression coverage for the hosted bearer on absolute Convex HTTP action
+ * URLs. `/web/registry/*` shipped without a `HOSTED_AUTH_PATH_PREFIXES` entry,
+ * so every catalog/star call went out unauthenticated and the Convex handler
+ * answered 401 "Missing or invalid bearer token".
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+
+vi.mock("@/lib/apis/web/context", () => ({
+  getApiAuthorizationHeader: vi.fn(async () => "Bearer hosted-bearer"),
+}));
+
+vi.mock("@/lib/convex-site-url", () => ({
+  getConvexSiteUrl: () => "https://outstanding-fennec-304.convex.site",
+}));
+
+const CONVEX_SITE = "https://outstanding-fennec-304.convex.site";
+
+describe("authFetch hosted bearer on Convex HTTP actions", () => {
+  let sessionToken: typeof import("../session-token");
+
+  beforeEach(async () => {
+    vi.resetModules();
+    delete (window as any).__MCP_SESSION_TOKEN__;
+    vi.mocked(global.fetch).mockReset();
+    vi.mocked(global.fetch).mockResolvedValue(
+      new Response("{}", { status: 200 }),
+    );
+    sessionToken = await import("../session-token");
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  function headersOf(call: number): Record<string, string> {
+    const init = vi.mocked(global.fetch).mock.calls[call]?.[1] as RequestInit;
+    return (init?.headers ?? {}) as Record<string, string>;
+  }
+
+  for (const path of [
+    "/web/registry/catalog",
+    "/web/registry/star",
+    "/web/registry/unstar",
+    "/web/registry/merge-guest-stars",
+  ]) {
+    it(`attaches the bearer to ${path}`, async () => {
+      await sessionToken.authFetch(`${CONVEX_SITE}${path}`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+      });
+
+      expect(headersOf(0).Authorization).toBe("Bearer hosted-bearer");
+    });
+  }
+
+  it("does not attach the bearer to a foreign origin on the same path", async () => {
+    await sessionToken.authFetch(
+      "https://evil.example.com/web/registry/catalog",
+      { method: "POST" },
+    );
+
+    expect(headersOf(0).Authorization).toBeUndefined();
+  });
+});

--- a/mcpjam-inspector/client/src/lib/session-token.ts
+++ b/mcpjam-inspector/client/src/lib/session-token.ts
@@ -332,6 +332,11 @@ const HOSTED_AUTH_PATH_PREFIXES = [
   "/api/mcp/computers/local-consent",
   // Convex HTTP actions called via absolute URL (OAuth completion, etc.).
   "/web/oauth/",
+  // Registry catalog/star routes are Convex HTTP actions called via absolute
+  // URL, and every one of them requires an identity (the catalog resolves
+  // per-viewer `isStarred`). Without this prefix the bearer is never attached
+  // and they all 401 with "Missing or invalid bearer token".
+  "/web/registry/",
 ];
 
 /**


### PR DESCRIPTION
Opening **Registry** on a hosted deployment fires two `Missing or invalid bearer token` toasts and renders every card with zero stars. The catalog request goes out with no `Authorization` header at all — signed in, signed out, or as a guest, the outcome is identical, which is why it never read as an expired session.

## Root cause

`authFetch` attaches the hosted bearer only when the request's path matches an entry in `HOSTED_AUTH_PATH_PREFIXES` (`client/src/lib/session-token.ts`). Most callers hit same-origin `/api/web/*` and are covered by that prefix. The registry client is one of the few that reaches Convex directly at an absolute `https://<deployment>.convex.site/web/registry/...` URL (`client/src/lib/apis/registry-http.ts`), and `/web/oauth/` was the only `/web/` entry on the list — so every registry request fell through the match and was sent bare.

On the other side, `/web/registry/catalog` opens with `ctx.auth.getUserIdentity()` and answers 401 with exactly that message when there is no identity. It needs one to resolve per-viewer `isStarred`, so there is no anonymous read to fall back to.

Two toasts rather than one is just React's double-mounted effect calling `loadCatalog` twice.

## Fix

Add `/web/registry/` to the prefix list. All four routes share the same helper and had the same defect:

| route | consequence while broken |
| --- | --- |
| `catalog` | star counts never load; two error toasts on every visit |
| `star` / `unstar` | starring a card always fails |
| `merge-guest-stars` | a guest's stars are dropped instead of merged on sign-in |

## Security

This does not widen where credentials can go. A path-prefix match is necessary but not sufficient — `shouldAttachHostedAuthorization` first calls `isHostedAuthAllowedOrigin`, which admits only the app's own origin, a loopback host, or the configured `*.convex.site` hostname. A foreign origin serving the same path still gets nothing; the new test pins that case alongside the four positive ones.

No backend change is needed — Convex already lists `Authorization` in the CORS preflight for these routes.

## Verification

- New `client/src/lib/__tests__/session-token.hosted-registry.test.ts` — 5 tests. Confirmed it fails without the one-line change (4 failed, the foreign-origin case passing as it should) and passes with it.
- Existing `client/src/lib/__tests__/session-token.test.ts` — 25 tests, still green.
- `tsc --noEmit -p client/tsconfig.typecheck.json` clean.

## Worth flagging

The failure mode is silent: a direct-to-Convex path missing from the prefix list produces no warning and no type error. The request just goes out unauthenticated and surfaces as a generic 401 from the server. The next route added this way will hit the same wall.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit fe2c8e6a667322f678b310ba6a1b879a7e79d04f. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Attach the hosted bearer to Convex Registry routes so Registry works on hosted deployments. Previously `/web/registry/*` requests went out without `Authorization`, returned 401 with two “Missing or invalid bearer token” toasts, showed zero stars, and star/merge actions failed; now these calls include the bearer and function normally.

- Adds `/web/registry/` to `HOSTED_AUTH_PATH_PREFIXES` (covers `catalog`, `star`, `unstar`, `merge-guest-stars`) while preserving origin gating; the bearer attaches only for the app origin, loopback, or the configured `*.convex.site`, not foreign origins.
- Adds regression tests for the four routes and the foreign-origin case; existing tests remain green. No backend or migration changes. Releases as a `@mcpjam/inspector` patch.

<sup>Written for commit fe2c8e6a667322f678b310ba6a1b879a7e79d04f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/MCPJam/inspector/pull/4152?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

