### PR TITLE
chrome: apply Production Redesign app shell (sectioned nav, linen chrome, inset panel)

### DIFF
--- a/design-system/src/index.css
+++ b/design-system/src/index.css
@@ -269,11 +269,19 @@
   --chart-3: oklch(0.8816 0.0276 93.128);
   --chart-4: oklch(0.8822 0.0403 298.1792);
   --chart-5: oklch(0.5608 0.1348 42.0584);
-  --sidebar: oklch(0.9663 0.008 98.8792);
+  /* Production Redesign chrome (BB-127). The sidebar + top bar are the outer
+     "linen" frame and the middle panel is the off-white working surface, so
+     the two sidebar fills swap roles relative to the old flat nav:
+       --sidebar        linen ground   #E9E6DC (= --accent / --secondary)
+       --sidebar-accent hover/active   #F5F4EE (the old --sidebar)
+     The panel fill stays --background (#FAF9F5), which is the design's
+     #FAF9F6 within rounding. Dark mode already reads this way (chrome darker
+     than the panel) and is left alone. */
+  --sidebar: oklch(0.9245 0.0138 92.9892);
   --sidebar-foreground: oklch(0.359 0.0051 106.6524);
   --sidebar-primary: oklch(0.6171 0.1375 39.0427);
   --sidebar-primary-foreground: oklch(0.9881 0 0);
-  --sidebar-accent: oklch(0.9245 0.0138 92.9892);
+  --sidebar-accent: oklch(0.9663 0.008 98.8792);
   --sidebar-accent-foreground: oklch(0.325 0 0);
   --sidebar-border: oklch(0.9401 0 0);
   --sidebar-ring: oklch(0.7731 0 0);

--- a/mcpjam-inspector/client/src/App.tsx
+++ b/mcpjam-inspector/client/src/App.tsx
@@ -79,6 +79,7 @@ import {
   useSidebar,
 } from "./components/ui/sidebar";
 import { AgentSidePanelMount } from "./components/mcpjam-agent/AgentSidePanelMount";
+import { cn } from "@/lib/utils";
 import {
   Alert,
   AlertDescription,
@@ -502,6 +503,40 @@ function AppChromeHeader({ hidden, ...props }: AppChromeHeaderProps) {
   }
 
   return <Header {...props} />;
+}
+
+/**
+ * The middle panel of the Production Redesign chrome (BB-127): the off-white
+ * working surface that sits inset in the linen sidebar/top-bar frame.
+ *
+ * The 16px top radius + shadow only make sense with the top bar above them, so
+ * they mirror `AppChromeHeader`'s visibility rule exactly (hidden on Home for
+ * signed-in users and during playground onboarding, but always shown on
+ * mobile). Without that guard the rounded corners would cut into the very top
+ * of the viewport and read as a rendering bug.
+ */
+function AppChromePanel({
+  headerHidden,
+  children,
+}: {
+  headerHidden: boolean;
+  children: React.ReactNode;
+}) {
+  const { isMobile } = useSidebar();
+  const headerVisible = !headerHidden || isMobile;
+
+  return (
+    <div
+      className={cn(
+        "bg-background flex h-full min-h-0 min-w-0 flex-1 flex-col overflow-hidden",
+        // rounded-t-2xl is 16px; it is not remapped by the theme's radius
+        // scale (only sm/md/lg/xl are), so it tracks the design value.
+        headerVisible && "rounded-t-2xl shadow-[0_2px_3px_#00000033]"
+      )}
+    >
+      {children}
+    </div>
+  );
 }
 
 import { ScoreRunnerPage } from "@/components/score/ScoreRunnerPage";
@@ -4568,6 +4603,11 @@ export default function App() {
     oauthServerModalNonce,
   };
 
+  // Shared by the top bar and the middle panel: the panel's 16px top radius +
+  // shadow are only correct when the bar is above them.
+  const appChromeHeaderHidden =
+    playgroundOnboarding || (activeTab === "home" && !!workOsUser);
+
   const appContent = (
     <SidebarProvider defaultOpen={true}>
       <AppChromeSidebar
@@ -4592,19 +4632,20 @@ export default function App() {
         createProjectDisabledReason={createProjectDisabledReason}
         onBeforeSignOut={disconnectRuntimeServersForAuthExit}
       />
-      <SidebarInset className="flex flex-col min-h-0">
+      {/* The inset is the linen shell: the sidebar and top bar read as one
+          continuous outer chrome and the off-white panel below is the working
+          surface. `bg-sidebar` overrides the primitive's `bg-background`. */}
+      <SidebarInset className="bg-sidebar flex flex-col min-h-0">
         <AppChromeHeader
           // "make nux clean" (#2868) hid this on Home for everyone, but that
           // also hid guests' only Sign in / Create account affordance there
           // (PUR-35). Keep Home clean for signed-in users; show the header
           // for guests so they still get sign-in/sign-up.
-          hidden={
-            playgroundOnboarding || (activeTab === "home" && !!workOsUser)
-          }
+          hidden={appChromeHeaderHidden}
           activeServerSelectorProps={activeServerSelectorProps}
           globalHostBarProps={globalHostBarProps}
         />
-        <div className="flex h-full min-h-0 min-w-0 flex-1 flex-col overflow-hidden">
+        <AppChromePanel headerHidden={appChromeHeaderHidden}>
           {showTrialDecisionNotice ? (
             <div className="border-b border-border/60 px-4 py-3">
               <Alert>
@@ -4624,7 +4665,7 @@ export default function App() {
               <NoRouterRouteBody activeTab={activeTab} />
             )}
           </AppRouteReactContext.Provider>
-        </div>
+        </AppChromePanel>
       </SidebarInset>
       <AgentSidePanelMount
         projectId={activeProjectId ?? null}

--- a/mcpjam-inspector/client/src/components/Header.tsx
+++ b/mcpjam-inspector/client/src/components/Header.tsx
@@ -25,7 +25,10 @@ export const Header = ({
   const { isMobile } = useSidebar();
 
   return (
-    <header className="flex shrink-0 flex-col border-b transition-[width,height] ease-linear">
+    // Production Redesign chrome (BB-127): the top bar is part of the linen
+    // frame, so it stays transparent (inheriting the inset's `bg-sidebar`) and
+    // borderless — the panel's rounded top edge is the only divider.
+    <header className="flex shrink-0 flex-col transition-[width,height] ease-linear">
       <div className="flex h-12 shrink-0 items-center gap-2 px-4 lg:px-6 drag">
         {isMobile ? (
           <div className="flex items-center gap-1 lg:gap-2 no-drag">

--- a/mcpjam-inspector/client/src/components/__tests__/mcp-sidebar-sections.test.ts
+++ b/mcpjam-inspector/client/src/components/__tests__/mcp-sidebar-sections.test.ts
@@ -1,0 +1,90 @@
+import { describe, it, expect } from "vitest";
+import { navigationSections } from "../mcp-sidebar";
+
+/**
+ * Guards the Production Redesign nav grouping (BB-127): the sidebar is five
+ * labeled sections in a fixed order, not a flat list. These assertions are the
+ * design's contract — an item quietly moving between sections, or a section
+ * losing its heading, changes the information architecture even though nothing
+ * type-errors.
+ */
+describe("sidebar section grouping", () => {
+  it("ships the five design sections, in order, each with a label", () => {
+    expect(navigationSections.map((section) => section.label)).toEqual([
+      "Explore",
+      "Measure",
+      "Verify",
+      "Inspect",
+      "Educate",
+    ]);
+    expect(navigationSections.every((section) => section.label.length > 0)).toBe(
+      true
+    );
+  });
+
+  it("places every item the design enumerates in its named section", () => {
+    const titlesIn = (label: string) =>
+      navigationSections
+        .find((section) => section.label === label)!
+        .items.map((item) => item.title);
+
+    // The design lists only the always-on items; flag-gated additions
+    // (Registry, Environments, Sessions, Compatibility) are asserted separately
+    // below so this stays readable as "the design's list, in the design's order".
+    expect(titlesIn("Explore")).toEqual(
+      expect.arrayContaining(["Home", "Connect", "Playground"])
+    );
+    expect(titlesIn("Measure")).toEqual(
+      expect.arrayContaining(["Acceptance Testing", "Swarms", "Evaluate"])
+    );
+    expect(titlesIn("Verify")).toEqual(
+      expect.arrayContaining([
+        "OAuth Debugger",
+        "XAA Debugger",
+        "Conformance",
+      ])
+    );
+    expect(titlesIn("Inspect")).toEqual([
+      "Tools",
+      "Resources",
+      "Prompts",
+      "Tasks",
+    ]);
+    expect(titlesIn("Educate")).toEqual(["Learning"]);
+  });
+
+  it("keeps flag-gated items in the section that matches what they do", () => {
+    const sectionOf = (title: string) =>
+      navigationSections.find((section) =>
+        section.items.some((item) => item.title === title)
+      )?.label;
+
+    expect(sectionOf("Registry")).toBe("Explore");
+    expect(sectionOf("Environments")).toBe("Explore");
+    // The cross-surface run feed belongs with the things it aggregates.
+    expect(sectionOf("Sessions")).toBe("Measure");
+    // Sibling of Conformance — both answer "is this implementation correct?".
+    expect(sectionOf("Compatibility")).toBe("Verify");
+  });
+
+  it("labels User Testing as Acceptance Testing while keeping its route", () => {
+    const item = navigationSections
+      .flatMap((section) => section.items)
+      .find((entry) => entry.url === "/user-testing");
+
+    expect(item?.title).toBe("Acceptance Testing");
+    expect(
+      navigationSections
+        .flatMap((section) => section.items)
+        .map((entry) => entry.title)
+    ).not.toContain("User Testing");
+  });
+
+  it("never lists the same title twice across sections", () => {
+    const titles = navigationSections.flatMap((section) =>
+      section.items.map((item) => item.title)
+    );
+
+    expect(titles).toHaveLength(new Set(titles).size);
+  });
+});

--- a/mcpjam-inspector/client/src/components/chat-v2/__tests__/model-compare-card-header.test.tsx
+++ b/mcpjam-inspector/client/src/components/chat-v2/__tests__/model-compare-card-header.test.tsx
@@ -197,8 +197,8 @@ describe("ModelCompareCardHeader", () => {
     );
 
     expect(screen.getByRole("button", { name: "Chat" })).toHaveClass(
-      "bg-sidebar-accent",
-      "text-sidebar-accent-foreground",
+      "bg-accent",
+      "text-accent-foreground",
     );
   });
 

--- a/mcpjam-inspector/client/src/components/chat-v2/model-compare-card-header.tsx
+++ b/mcpjam-inspector/client/src/components/chat-v2/model-compare-card-header.tsx
@@ -371,7 +371,7 @@ export function ModelCompareCardHeader({
                         "h-full rounded-sm transition-all duration-300",
                         isFastest
                           ? "bg-emerald-500/25 dark:bg-emerald-400/20"
-                          : "bg-sidebar-accent"
+                          : "bg-accent"
                       )}
                       style={{
                         width: `${hasComparison ? durationBarPct : 100}%`,
@@ -411,7 +411,7 @@ export function ModelCompareCardHeader({
                         "h-full rounded-sm transition-all duration-300",
                         isFewestTokens
                           ? "bg-emerald-500/25 dark:bg-emerald-400/20"
-                          : "bg-sidebar-accent"
+                          : "bg-accent"
                       )}
                       style={{
                         width: `${hasComparison ? tokensBarPct : 100}%`,

--- a/mcpjam-inspector/client/src/components/evals/__tests__/trace-view-mode-tabs.test.tsx
+++ b/mcpjam-inspector/client/src/components/evals/__tests__/trace-view-mode-tabs.test.tsx
@@ -3,7 +3,7 @@ import { describe, expect, it, vi } from "vitest";
 import { TraceViewModeTabs } from "../trace-view-mode-tabs";
 
 describe("TraceViewModeTabs", () => {
-  it("uses sidebar-accent active styling for the selected tab (default)", () => {
+  it("uses accent active styling for the selected tab (default)", () => {
     render(
       <TraceViewModeTabs
         mode="chat"
@@ -13,8 +13,8 @@ describe("TraceViewModeTabs", () => {
     );
 
     expect(screen.getByRole("button", { name: "Chat" })).toHaveClass(
-      "bg-sidebar-accent",
-      "text-sidebar-accent-foreground",
+      "bg-accent",
+      "text-accent-foreground",
     );
   });
 
@@ -29,8 +29,8 @@ describe("TraceViewModeTabs", () => {
     );
 
     expect(screen.getByRole("button", { name: "Chat" })).toHaveClass(
-      "bg-sidebar-accent",
-      "text-sidebar-accent-foreground",
+      "bg-accent",
+      "text-accent-foreground",
     );
   });
 
@@ -122,12 +122,12 @@ describe("TraceViewModeTabs", () => {
       />,
     );
     expect(screen.getByRole("button", { name: "Replay" })).toHaveClass(
-      "bg-sidebar-accent",
-      "text-sidebar-accent-foreground",
+      "bg-accent",
+      "text-accent-foreground",
     );
     // With Replay active, no standard tab is highlighted.
     expect(screen.getByRole("button", { name: "Trace" })).not.toHaveClass(
-      "bg-sidebar-accent",
+      "bg-accent",
     );
   });
 });

--- a/mcpjam-inspector/client/src/components/evals/trace-view-mode-tabs.tsx
+++ b/mcpjam-inspector/client/src/components/evals/trace-view-mode-tabs.tsx
@@ -83,7 +83,7 @@ export function TraceViewModeTabs({
           ? "bg-background font-medium text-foreground ring-1 ring-inset ring-border/60"
           : "text-muted-foreground hover:bg-background/50 hover:text-foreground"
         : active
-        ? "bg-sidebar-accent font-medium text-sidebar-accent-foreground"
+        ? "bg-accent font-medium text-accent-foreground"
         : "text-muted-foreground hover:text-foreground"
     );
 

--- a/mcpjam-inspector/client/src/components/mcp-sidebar.tsx
+++ b/mcpjam-inspector/client/src/components/mcp-sidebar.tsx
@@ -92,6 +92,11 @@ interface NavItem {
 
 interface NavSection {
   id: string;
+  /**
+   * Section heading rendered above the items ("Explore", "Measure", …).
+   * The nav is grouped by what you do with a feature, not by internals.
+   */
+  label: string;
   items: NavItem[];
 }
 
@@ -183,11 +188,18 @@ export function applyBillingGateNavState(
 }
 
 // Define sections with their respective items.
+// Grouped by intent (Explore / Measure / Verify / Inspect / Educate) per the
+// Production Redesign, so the nav reads as five short lists instead of one flat
+// column. Flag-gated items that the design didn't enumerate are placed in the
+// section that matches what they do: Registry + Environments under Explore,
+// Sessions under Measure (it's the cross-surface run feed), Compatibility under
+// Verify next to its sibling Conformance.
 // Exported so tests can assert against the real nav data (e.g. that Skills is
 // not a sidebar item — it lives in the Connect tab switcher).
 export const navigationSections: NavSection[] = [
   {
-    id: "connection",
+    id: "explore",
+    label: "Explore",
     items: [
       {
         title: "Home",
@@ -229,10 +241,13 @@ export const navigationSections: NavSection[] = [
     ],
   },
   {
-    id: "mcp-apps",
+    id: "measure",
+    label: "Measure",
     items: [
       {
-        title: "User Testing",
+        // Labeled "Acceptance Testing" in the nav; the route stays
+        // /user-testing so existing links and hash tabs keep working.
+        title: "Acceptance Testing",
         url: "/user-testing",
         icon: Users,
         featureFlag: "sandboxes-enabled",
@@ -252,7 +267,7 @@ export const navigationSections: NavSection[] = [
         billingFeature: "evals",
       },
       {
-        // Cross-surface session feed (Playground + User Testing + Evals +
+        // Cross-surface session feed (Playground + Acceptance Testing + Evals +
         // Swarms). Route-guarded on the same flag (`SessionsRoute`).
         title: "Sessions",
         url: "/sessions",
@@ -262,16 +277,22 @@ export const navigationSections: NavSection[] = [
     ],
   },
   {
-    id: "others",
+    // Auth-flow debuggers and the spec checkers: everything that answers
+    // "is this implementation correct?".
+    id: "verify",
+    label: "Verify",
     items: [
-      // Skills is not a sidebar item: it's execution-context config, so it
-      // lives as a Connect tab (Servers | Client | Computer | Skills) and is
-      // reached through that switcher.
       {
-        title: "Learning",
-        url: "/learning",
-        icon: GraduationCap,
-        featureFlag: "mcpjam-learning",
+        title: "OAuth Debugger",
+        url: "/oauth-flow",
+        icon: Workflow,
+      },
+      {
+        title: "XAA Debugger",
+        url: "/xaa-flow",
+        icon: ShieldCheck,
+        badge: "New",
+        featureFlag: "xaa",
       },
       {
         title: "Conformance",
@@ -289,34 +310,14 @@ export const navigationSections: NavSection[] = [
         // MCPJam-internal flag (same convention as `mcpjam-conformance`).
         featureFlag: "mcpjam-compatibility",
       },
-      // {
-      //   title: "Tracing",
-      //   url: "/tracing",
-      //   icon: Activity,
-      // },
     ],
   },
   {
-    // Auth-flow debuggers get their own section so they read as a related
-    // pair, separated from the surrounding nav by the section dividers.
-    id: "debuggers",
-    items: [
-      {
-        title: "OAuth Debugger",
-        url: "/oauth-flow",
-        icon: Workflow,
-      },
-      {
-        title: "XAA Debugger",
-        url: "/xaa-flow",
-        icon: ShieldCheck,
-        badge: "New",
-        featureFlag: "xaa",
-      },
-    ],
-  },
-  {
-    id: "primitives",
+    // Raw MCP primitives. Skills is deliberately absent: it's execution-context
+    // config, so it lives as a Connect tab (Servers | Client | Computer |
+    // Skills) and is reached through that switcher.
+    id: "inspect",
+    label: "Inspect",
     items: [
       {
         title: "Tools",
@@ -337,6 +338,18 @@ export const navigationSections: NavSection[] = [
         title: "Tasks",
         url: "/tasks",
         icon: ListTodo,
+      },
+    ],
+  },
+  {
+    id: "educate",
+    label: "Educate",
+    items: [
+      {
+        title: "Learning",
+        url: "/learning",
+        icon: GraduationCap,
+        featureFlag: "mcpjam-learning",
       },
     ],
   },
@@ -576,7 +589,10 @@ export function MCPSidebar({
 
   return (
     <>
-      <Sidebar collapsible="icon" {...props}>
+      {/* Production Redesign chrome (BB-127): no 1px divider between the linen
+          sidebar and the linen top bar — the inset panel's rounded top edge and
+          shadow are what separate chrome from content. */}
+      <Sidebar collapsible="icon" className="border-r-transparent" {...props}>
         <SidebarHeader className="gap-1 px-2 pt-1.5 pb-2">
           <div
             className={cn(
@@ -687,6 +703,7 @@ export function MCPSidebar({
               return (
                 <React.Fragment key={section.id}>
                   <NavMain
+                    label={section.label}
                     items={section.items.map((item) => ({
                       ...item,
                       isActive: isNavItemActive(item),

--- a/mcpjam-inspector/client/src/components/mcp-sidebar.tsx
+++ b/mcpjam-inspector/client/src/components/mcp-sidebar.tsx
@@ -589,10 +589,20 @@ export function MCPSidebar({
 
   return (
     <>
-      {/* Production Redesign chrome (BB-127): no 1px divider between the linen
+      {/* Production Redesign chrome (BB-127): no divider between the linen
           sidebar and the linen top bar — the inset panel's rounded top edge and
-          shadow are what separate chrome from content. */}
-      <Sidebar collapsible="icon" className="border-r-transparent" {...props}>
+          shadow are what separate chrome from content.
+          Drop the width, not the color: the border sits on sidebar-container,
+          which has no fill of its own (the linen is on sidebar-inner), so a
+          transparent border still reveals a 1px strip of the page behind it.
+          The variant prefix has to match the primitive's
+          `group-data-[side=left]:border-r` or tailwind-merge keeps both and the
+          more specific variant rule wins. */}
+      <Sidebar
+        collapsible="icon"
+        className="group-data-[side=left]:border-r-0"
+        {...props}
+      >
         <SidebarHeader className="gap-1 px-2 pt-1.5 pb-2">
           <div
             className={cn(

--- a/mcpjam-inspector/client/src/components/sidebar/nav-main.tsx
+++ b/mcpjam-inspector/client/src/components/sidebar/nav-main.tsx
@@ -2,6 +2,7 @@ import React from "react";
 import {
   SidebarGroup,
   SidebarGroupContent,
+  SidebarGroupLabel,
   SidebarMenu,
   SidebarMenuButton,
   SidebarMenuItem,
@@ -34,12 +35,14 @@ interface LearnMoreProps {
 
 interface NavMainProps {
   items: NavMainItem[];
+  /** Section heading ("Explore", "Measure", …). Hidden when collapsed to icons. */
+  label?: string;
   onItemClick?: (url: string) => void;
   /** Learn more hover card integration */
   learnMore?: LearnMoreProps | null;
 }
 
-export function NavMain({ items, onItemClick, learnMore }: NavMainProps) {
+export function NavMain({ items, label, onItemClick, learnMore }: NavMainProps) {
   const { open: sidebarOpen } = useSidebar();
 
   const handleClick = (url: string) => {
@@ -55,7 +58,9 @@ export function NavMain({ items, onItemClick, learnMore }: NavMainProps) {
       item.disabled
         ? "cursor-not-allowed text-muted-foreground opacity-50 hover:bg-transparent hover:text-muted-foreground active:bg-transparent active:text-muted-foreground"
         : isItemActive(item)
-        ? "[&[data-active=true]]:bg-accent cursor-pointer"
+        ? // Must be the *sidebar* accent: the linen ground (--sidebar) is the
+          // same value as --accent, so bg-accent would render invisible here.
+          "[&[data-active=true]]:bg-sidebar-accent cursor-pointer"
         : "cursor-pointer"
     );
 
@@ -120,6 +125,16 @@ export function NavMain({ items, onItemClick, learnMore }: NavMainProps) {
 
   return (
     <SidebarGroup className="py-1">
+      {label ? (
+        // Keep the primitive's `text-sidebar-foreground/70`: the design specs
+        // --secondary-foreground, but that token inverts in dark mode and the
+        // label lands at L 0.31 on an L 0.24 sidebar — invisible.
+        // -mt-5 must track h-5: the primitive collapses its own h-8 label with
+        // -mt-8 when the sidebar shrinks to icons.
+        <SidebarGroupLabel className="h-5 group-data-[collapsible=icon]:-mt-5">
+          {label}
+        </SidebarGroupLabel>
+      ) : null}
       <SidebarGroupContent>
         <SidebarMenu className="gap-0.5">
           {items.map((item) => {


### PR DESCRIPTION
Closes BB-127 — https://app.kestral.ai/workspace/yhNILB2/task/1IsrTmdH

Applies the Production Redesign app chrome: the sidebar and top bar become one continuous linen frame, and the middle content is an off-white panel inset in it. The left nav is grouped under **Explore / Measure / Verify / Inspect / Educate** instead of a flat list. App-wide — every route under the shell inherits it.

## Tokens, not hardcoded hex

The design's hex values turned out to be the palette we already ship, so this is a token change:

| Design | Existing token |
|---|---|
| `#E9E6DC` sidebar + top bar | `--accent` / `--secondary`, exactly |
| `#FAF9F6` panel fill | `--background` (`#FAF9F5`, Paper rounding) |

`--sidebar` and `--sidebar-accent` swap roles: the linen ground becomes the sidebar fill, and the old lighter sidebar value (`#F5F4EE`) becomes the hover/active fill. That swap is load-bearing — the ground now equals `--accent`, so an accent-filled active row would render invisible. The theme presets (brutalist / soft-pop / tangerine) define their own `--sidebar`, so they're unaffected.

Dark mode already read the right way round (chrome darker than the panel) and is left alone.

## Three judgment calls worth a look

1. **`#E9E6DB` (the shell behind the panel) collapses into the same chrome token** as the sidebar and top bar. It differs from `#E9E6DC` by one 8-bit step, and a separate token would break against the theme presets.
2. **Section labels keep the primitive's `--sidebar-foreground/70`, not the specced `--secondary-foreground`.** That token inverts in dark mode and lands the label at L 0.31 on an L 0.24 sidebar — invisible. Caught in the browser.
3. **Flag-gated nav items the design doesn't enumerate** are placed by function: Registry + Environments → Explore, Sessions → Measure (it aggregates those surfaces), Compatibility → Verify beside its sibling Conformance. A commented-out dead `Tracing` item went away with the section it lived in.

The panel's 16px radius + shadow are gated on the top bar actually rendering (`AppChromePanel` mirrors `AppChromeHeader`'s visibility rule) — otherwise the rounded corners cut into the top of the viewport on Home-signed-in and read as a rendering bug.

## Collateral fixed in place

Two selected-state fills outside the sidebar — model-compare metric bars and the trace view-mode tabs — were reading `--sidebar-accent` on a panel surface. They move to `--accent`, which holds the exact value `--sidebar-accent` had, so they render unchanged.

## Also

`border-r-transparent` wasn't enough to kill the sidebar divider: the border sits on `sidebar-container`, which has no fill of its own (the linen is on `sidebar-inner`), so the transparent edge still revealed a 1px strip of the page behind it. Now `group-data-[side=left]:border-r-0` — the variant prefix has to match the primitive's or tailwind-merge keeps both and the more specific rule wins.

## Verification

- `typecheck:client` clean.
- New `mcp-sidebar-sections.test.ts` pins the grouping, the Acceptance Testing label, and the untouched `/user-testing` route. Sidebar + retargeted-component suites: 66 passing.
- Checked in the browser in light and dark, sidebar expanded and collapsed to icons. Measured in the DOM: panel at `left: 256px` / `top: 48px`, radius `16px`, shadow `rgba(0,0,0,0.2) 0 2px 3px`, sidebar `border-right-width: 0px` with the linen reaching x=256 flush against the panel.

Two pre-existing failures on my machine are locale-driven, not from this change (`OrganizationsTab.billing`, `sidebar-credit-usage` assume en-US number/currency formatting; jsdom unit tests never load the CSS this touches).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Applies the Production Redesign app shell (BB-127). Old: a flat left nav and a bordered top bar. New: a continuous linen sidebar+top bar with an inset off‑white panel and a grouped left nav (Explore, Measure, Verify, Inspect, Educate).

- Tokens: `--sidebar` is now the linen ground; `--sidebar-accent` is hover/active; `--accent` and `--background` supply the design hex values; dark mode unchanged.
- App shell: adds an inset panel with a 16px rounded top and shadow that only render when the header is visible; the header stays transparent and borderless.
- Sidebar: drops the right border via the primitive’s variant so chrome and panel meet flush.
- Navigation: groups items by section; places flag-gated items by function; labels “User Testing” as “Acceptance Testing” while keeping the `/user-testing` route.
- Styling: panel-surface selected states use `--accent`; sidebar active rows use `--sidebar-accent` to remain visible now that `--sidebar` equals `--accent`.
- Tests: adds `mcp-sidebar-sections.test.ts` to pin grouping and labels; updates model compare and trace tab tests for the token changes.

Required actions:
- When adding nav items, place them in `navigationSections` under the correct section; tests will enforce order and labels.
- Use `bg-accent` for selected states on panel surfaces and `bg-sidebar-accent` for active rows inside the sidebar.

<sup>Written for commit 690645c765911e34f0127b36ea2a6e83f93faff1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/MCPJam/inspector/pull/4155?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

