### PR TITLE
Fix main: map the six readiness routes to their SDK client methods

### DIFF
--- a/mcpjam-inspector/server/routes/v1/__tests__/sdk-coverage.test.ts
+++ b/mcpjam-inspector/server/routes/v1/__tests__/sdk-coverage.test.ts
@@ -88,6 +88,18 @@ const ROUTE_TO_SDK: Readonly<Record<string, string>> = {
   "post /projects/{projectId}/servers/{serverId}/resources/read":
     "readServerResource",
 
+  // Directory readiness
+  "post /projects/{projectId}/servers/{serverId}/readiness-runs/claude":
+    "startClaudeReadinessRun",
+  "post /projects/{projectId}/servers/{serverId}/readiness-runs/openai":
+    "startOpenAIReadinessRun",
+  "get /projects/{projectId}/readiness-runs": "listReadinessRuns",
+  "get /projects/{projectId}/readiness-runs/{runId}": "getReadinessRun",
+  "get /projects/{projectId}/readiness-runs/{runId}/report":
+    "getReadinessReport",
+  "post /projects/{projectId}/readiness-runs/{runId}/cancel":
+    "cancelReadinessRun",
+
   // Hosts
   "get /projects/{projectId}/hosts": "listHosts",
   "post /projects/{projectId}/hosts": "createHost",


### PR DESCRIPTION
`Inspector Tests 3/4` is failing on main. #4153 merged before CI finished; its `sdk-coverage` drift test — the ratchet asserting every `/api/v1` route is callable from `@mcpjam/sdk` — fails because the six new readiness routes are in neither `ROUTE_TO_SDK` nor `EXCLUDED_FROM_SDK`.

The six `PlatformApiClient` methods already exist and are correct (`startClaudeReadinessRun`, `startOpenAIReadinessRun`, `listReadinessRuns`, `getReadinessRun`, `getReadinessReport`, `cancelReadinessRun`); only the map entries were missing. Mapped rather than excluded, because each route is reachable from the client exactly as the ratchet intends — and the test checks the values against the real `PlatformApiClient.prototype`, so these entries are proven, not asserted.

Verified: reproduces main's failure with the change reverted; `server/routes/v1/__tests__/` is 917/917 green with it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only map update; no runtime, auth, or API behavior changes.
> 
> **Overview**
> Fixes the `/api/v1` → SDK coverage ratchet after directory readiness routes shipped without `ROUTE_TO_SDK` entries.
> 
> Adds six mappings in `sdk-coverage.test.ts` to existing `PlatformApiClient` methods: start Claude/OpenAI runs, list/get/cancel a run, and fetch the report. No product or SDK code changes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c011dac906ccd5db1c8716034b56f8400cb3497a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Map the six readiness routes to their `PlatformApiClient` methods in the `sdk-coverage` ratchet, fixing main’s failing Inspector test. Previously, the routes existed and were reachable via `@mcpjam/sdk`, but they were not in the `ROUTE_TO_SDK` map, causing the drift check to fail.

• Added mappings for: startClaudeReadinessRun, startOpenAIReadinessRun, listReadinessRuns, getReadinessRun, getReadinessReport, cancelReadinessRun.  
• No runtime behavior change; this only updates the test map.  
• Mapped (not excluded) because each route is callable through `@mcpjam/sdk` as intended.

<sup>Written for commit c011dac906ccd5db1c8716034b56f8400cb3497a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/MCPJam/inspector/pull/4157?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

