### PR TITLE
Directory readiness: bound the archive read, honest replay receipts, deadlined report reads

### DIFF
--- a/docs/reference/openapi.json
+++ b/docs/reference/openapi.json
@@ -9050,7 +9050,33 @@
         ],
         "responses": {
           "200": {
-            "description": "The run was cancelled."
+            "description": "The run was cancelled.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "runId",
+                    "projectId",
+                    "status"
+                  ],
+                  "properties": {
+                    "runId": {
+                      "type": "string"
+                    },
+                    "projectId": {
+                      "type": "string"
+                    },
+                    "status": {
+                      "type": "string",
+                      "enum": [
+                        "cancelled"
+                      ]
+                    }
+                  }
+                }
+              }
+            }
           },
           "409": {
             "description": "The run already reached a terminal status."
@@ -19572,7 +19598,16 @@
           "lanes": {
             "type": "array",
             "items": {
-              "type": "string"
+              "type": "string",
+              "enum": [
+                "runtime-compatibility",
+                "directory-policy",
+                "optional-features",
+                "submission-artifacts",
+                "experience-insights",
+                "plugin-package",
+                "release-contract"
+              ]
             },
             "description": "The lanes this stage rolled up, so the verdict is reproducible by hand."
           }
@@ -19621,10 +19656,25 @@
         "required": [
           "id",
           "readinessKind",
+          "serverId",
           "serverUrl",
+          "submissionMode",
           "status",
+          "overallStatus",
           "lanes",
+          "stages",
+          "authMode",
+          "capabilities",
+          "attemptCount",
+          "terminalReason",
+          "errorMessage",
+          "policySnapshotDate",
+          "engineVersion",
+          "sdkVersion",
+          "includeLlmObservations",
           "llmObservations",
+          "hasReport",
+          "reportUrl",
           "createdAt",
           "updatedAt"
         ],
@@ -19638,6 +19688,11 @@
               "claude",
               "openai"
             ]
+          },
+          "serverId": {
+            "type": "string",
+            "nullable": true,
+            "description": "The saved project server this run graded. Null only on rows written before the field existed."
           },
           "serverUrl": {
             "type": "string",
@@ -19755,7 +19810,9 @@
           "projectId",
           "serverId",
           "readinessKind",
-          "status"
+          "status",
+          "deduped",
+          "includeLlmObservations"
         ],
         "properties": {
           "runId": {
@@ -19775,7 +19832,15 @@
             ]
           },
           "status": {
-            "type": "string"
+            "type": "string",
+            "enum": [
+              "pending",
+              "running",
+              "completed",
+              "failed",
+              "cancelled"
+            ],
+            "description": "The run's status when the start returned. `pending` for a fresh start; for a deduped start, whatever the existing run is already at \u2014 which may be `completed`, because a replayed idempotency key can name a run that finished long ago."
           },
           "deduped": {
             "type": "boolean",

--- a/mcpjam-inspector/server/routes/shared/readiness-runs.ts
+++ b/mcpjam-inspector/server/routes/shared/readiness-runs.ts
@@ -1,0 +1,281 @@
+/**
+ * Starting a hosted directory-readiness run, once, for every surface.
+ *
+ * Three callers create these runs — the public `/api/v1` endpoints, the
+ * `/api/web` endpoints the conformance panel uses, and (through the platform
+ * client) the CLI. What they legitimately differ on is how a caller proves who
+ * it is and what an answer looks like on the wire. What they must NOT differ
+ * on is the part in here: which transports may be graded, which submission
+ * shapes a hosted run can grade at all, where the target comes from, and
+ * whether a replayed start executes anything.
+ *
+ * The last one is why this is shared rather than copied. A surface that got
+ * the replay rule slightly wrong would dial a third party's server twice for
+ * one logical request — and it would do it only on retries, which is exactly
+ * the traffic nobody is watching when the feature is demoed.
+ *
+ * AUTHORIZATION IS THE CALLER'S JOB, deliberately. Each surface already has
+ * its own exchange for turning a request into an authorized server row, and a
+ * helper that tried to do that too would need to understand three auth
+ * schemes. This function takes the RESULT of that exchange and refuses to
+ * take a URL any other way.
+ */
+
+import type { ConvexHttpClient } from "convex/browser";
+import type { OpenAISubmissionMode } from "@mcpjam/sdk";
+import { ErrorCode, WebRouteError } from "../web/errors.js";
+import { createStreamingPinnedFetch } from "../../utils/pinned-fetch.js";
+import { executeHostedReadinessRun } from "../../services/readiness/worker.js";
+import { reportRouteFailure } from "../../utils/route-error-report.js";
+
+/** The two words the public vocabulary uses. Never `anthropic`/`chatgpt`. */
+export const READINESS_PUBLISHERS = ["claude", "openai"] as const;
+export type ReadinessPublisher = (typeof READINESS_PUBLISHERS)[number];
+
+/**
+ * The submission shapes a HOSTED run may grade.
+ *
+ * The package shapes need an uploaded archive, and no hosted surface has a way
+ * to receive one — the CLI reads it off the local disk. Listing them here and
+ * refusing them at the edge means the refusal can name the CLI, rather than
+ * surfacing later as a lane that mysteriously never evaluates.
+ */
+export const HOSTED_SUBMISSION_MODES = [
+  "mcp-only",
+  "mcp-imported-skills",
+] as const;
+
+export type HostedSubmissionMode = (typeof HOSTED_SUBMISSION_MODES)[number];
+
+/** The shape `authorizeServer` hands back, narrowed to what a start needs. */
+export interface AuthorizedReadinessServer {
+  serverConfig: {
+    transportType?: string;
+    url?: string;
+    headers?: Record<string, string>;
+    useOAuth?: boolean;
+  };
+  // `null` as well as absent: the authorize response distinguishes "this
+  // server does not use OAuth" from "it does and we hold no token", and both
+  // arrive here as a falsy value that must not become the string "null" in an
+  // Authorization header.
+  oauthAccessToken?: string | null;
+}
+
+export interface StartHostedReadinessRunInput {
+  convex: ConvexHttpClient;
+  projectId: string;
+  serverId: string;
+  publisher: ReadinessPublisher;
+  /** Required for OpenAI, absent for Claude. Never inferred from the inputs. */
+  submissionMode?: OpenAISubmissionMode;
+  idempotencyKey?: string;
+  /** The one field that can SPEND. Defaults off at every call site. */
+  includeLlmObservations: boolean;
+  /** The output of the surface's own authorize exchange. */
+  authorized: AuthorizedReadinessServer;
+  /** Maps a Convex error onto the surface's own error vocabulary. */
+  translateError: (error: unknown) => Error;
+}
+
+export type HostedReadinessRunStatus =
+  | "pending"
+  | "running"
+  | "completed"
+  | "failed"
+  | "cancelled";
+
+export interface HostedReadinessReceipt {
+  runId: string;
+  projectId: string;
+  serverId: string;
+  readinessKind: ReadinessPublisher;
+  /**
+   * The run's status at the moment this start returned.
+   *
+   * `pending` for a fresh start, and for a DEDUPED start whatever the existing
+   * run is already at. An idempotency key replayed hours later names a run
+   * that finished long ago; answering `pending` for it would send the caller
+   * into a poll loop for a result it could already read.
+   */
+  status: HostedReadinessRunStatus;
+  /** True when an idempotency key replayed an existing run. */
+  deduped: boolean;
+  includeLlmObservations: boolean;
+}
+
+/**
+ * Create the leased row and detach the execution.
+ *
+ * The TARGET comes from the saved server the caller already authorized, never
+ * from a request body. That is what makes "a caller cannot point this at an
+ * arbitrary URL" true by construction rather than by validation — a body field
+ * that could name a host would turn every one of these surfaces into an
+ * authenticated fetch primitive.
+ *
+ * Execution runs in THIS process, detached, holding the lease the mutation
+ * handed back. The backend's recovery cron is what makes that safe: a node
+ * that dies stops heartbeating and the run is re-queued with a FRESH job id,
+ * so a node returning from the dead cannot write into the attempt that
+ * replaced it.
+ */
+export async function startHostedReadinessRun(
+  input: StartHostedReadinessRunInput,
+): Promise<HostedReadinessReceipt> {
+  const config = input.authorized.serverConfig;
+  if (config.transportType !== "http" || !config.url) {
+    // Readiness grades what a HOST would see, and every host in question
+    // reaches a server over HTTP. A stdio server is not a connector these
+    // directories can list, so this is a wrong-shape refusal rather than a gap
+    // in the run's coverage.
+    throw new WebRouteError(
+      400,
+      ErrorCode.VALIDATION_ERROR,
+      "Directory readiness grades HTTP connectors; this server uses a different transport.",
+    );
+  }
+  const target = config.url;
+
+  let created: { runId: string; jobId: string; reused: boolean };
+  try {
+    created = await input.convex.mutation(
+      "claudeReadinessRuns:requestReadinessRun" as any,
+      {
+        projectId: input.projectId,
+        serverId: input.serverId,
+        serverUrl: target,
+        readinessKind: input.publisher,
+        ...(input.submissionMode
+          ? { submissionMode: input.submissionMode }
+          : {}),
+        ...(input.idempotencyKey
+          ? { idempotencyKey: input.idempotencyKey }
+          : {}),
+        includeLlmObservations: input.includeLlmObservations,
+        authMode: config.useOAuth ? "provided-token" : "headless",
+      },
+    );
+  } catch (error) {
+    throw input.translateError(error);
+  }
+
+  // A REPLAY EXECUTES NOTHING. The run it names is already in flight or
+  // already finished; starting a second execution against the same lease would
+  // dial a third party's server twice for one logical request, which is the
+  // exact thing the idempotency key was sent to prevent.
+  //
+  // It costs one extra read, though, because the caller needs the status the
+  // run ACTUALLY has rather than the `pending` a fresh start would report. A
+  // failure to read it is not a failure to start: fall back to `pending` and
+  // let the caller poll, which is what it would have done anyway.
+  let status: HostedReadinessRunStatus = "pending";
+  if (created.reused) {
+    try {
+      const existing = (await input.convex.query(
+        "claudeReadinessRuns:getReadinessRun" as any,
+        { runId: created.runId },
+      )) as { status?: HostedReadinessRunStatus } | null;
+      if (existing?.status) status = existing.status;
+    } catch {
+      // Deliberately swallowed — see above.
+    }
+  } else {
+    const headers: Record<string, string> = { ...(config.headers ?? {}) };
+    if (input.authorized.oauthAccessToken) {
+      headers.authorization = `Bearer ${input.authorized.oauthAccessToken}`;
+    }
+
+    void executeHostedReadinessRun({
+      lease: { runId: created.runId, jobId: created.jobId },
+      publisher: input.publisher,
+      target,
+      submissionMode: input.submissionMode,
+      headers: Object.keys(headers).length > 0 ? headers : undefined,
+      // The DNS-pinned transport: resolve once, refuse the disallowed answers,
+      // pin the surviving addresses into the socket, re-run it on every hop.
+      // A readiness run follows redirects by design, so a check performed only
+      // on the first URL would be a check on the least interesting hop.
+      fetchFn: createStreamingPinnedFetch({
+        targetLabel: "MCP server",
+        chainTimeoutMs: 30_000,
+        bodyIdleTimeoutMs: 120_000,
+        maxResponseBytes: 32 * 1024 * 1024,
+      }),
+      includeLlmObservations: input.includeLlmObservations,
+    }).catch((error) => {
+      // `executeHostedReadinessRun` never throws — every exit lands the run
+      // somewhere terminal. This catch exists for the impossible case, so an
+      // unhandled rejection cannot take the process with it.
+      reportRouteFailure(
+        "[readiness] detached hosted run escaped its own handler",
+        error,
+        {
+          source: "readiness.hosted_run",
+          // OUR bug, not the graded server's: the worker contracts never to
+          // throw, so reaching this means the contract broke rather than that
+          // somebody's MCP server misbehaved.
+          hop: "mcpjam_internal",
+          context: { runId: created.runId },
+        },
+      );
+    });
+  }
+
+  return {
+    runId: created.runId,
+    projectId: input.projectId,
+    serverId: input.serverId,
+    readinessKind: input.publisher,
+    status,
+    deduped: created.reused,
+    includeLlmObservations: input.includeLlmObservations,
+  };
+}
+
+/**
+ * The run row as every surface renders it.
+ *
+ * Shared for the same reason the start is: two renderers would eventually
+ * disagree about whether a run whose observations were refused for credit is
+ * `completed`. It is — the lanes graded fine — and `llmObservations.status`
+ * carries the refusal on its own axis. A DTO that folded the two together
+ * would make a billing outage look like a grading failure.
+ */
+export function toReadinessRunDto(
+  run: Record<string, any>,
+  options: { projectId: string; reportUrl?: (runId: string) => string },
+) {
+  const hasReport = run.hasReport === true;
+  return {
+    id: run.id,
+    readinessKind: run.readinessKind ?? "claude",
+    serverId: run.serverId ?? null,
+    serverUrl: run.serverUrl,
+    submissionMode: run.submissionMode ?? null,
+    status: run.status,
+    overallStatus: run.overallStatus ?? null,
+    lanes: run.lanes ?? [],
+    stages: run.stages ?? [],
+    authMode: run.authMode ?? null,
+    capabilities: run.capabilities ?? [],
+    attemptCount: run.attemptCount,
+    terminalReason: run.terminalReason ?? null,
+    errorMessage: run.errorMessage ?? null,
+    policySnapshotDate: run.policySnapshotDate ?? null,
+    engineVersion: run.engineVersion ?? null,
+    sdkVersion: run.sdkVersion ?? null,
+    // The AI axis, ALWAYS present and independent of `status`. A run whose
+    // lanes graded cleanly is `completed` even when the observation call was
+    // refused for credit, and a reader has to be able to see both.
+    includeLlmObservations: run.includeLlmObservations ?? false,
+    llmObservations: run.llmObservations ?? {
+      status: "not-requested",
+      reason: "not_requested",
+    },
+    hasReport,
+    reportUrl:
+      hasReport && options.reportUrl ? options.reportUrl(run.id) : null,
+    createdAt: run.createdAt,
+    updatedAt: run.updatedAt,
+  };
+}

--- a/mcpjam-inspector/server/routes/v1/__tests__/readiness.test.ts
+++ b/mcpjam-inspector/server/routes/v1/__tests__/readiness.test.ts
@@ -166,6 +166,11 @@ describe("v1 directory readiness", () => {
   });
 
   afterEach(() => {
+    // Globals too, not just the environment. A stubbed `fetch` restored on the
+    // last line of a test body leaks into every test after it the moment an
+    // assertion above that line fails — turning one failure into a cascade
+    // whose cause is nowhere near the test that reports it.
+    vi.unstubAllGlobals();
     for (const [key, value] of Object.entries(originalEnv)) {
       if (value) process.env[key] = value;
       else delete process.env[key];
@@ -301,6 +306,47 @@ describe("v1 directory readiness", () => {
       expect(res.status).toBe(202);
       expect(((await res.json()) as { deduped?: boolean }).deduped).toBe(true);
       expect(executeHostedReadinessRunMock).not.toHaveBeenCalled();
+    });
+
+    it("reports a replayed run's REAL status, not a decorative pending", async () => {
+      // A key replayed hours later names a run that finished long ago.
+      // Answering `pending` for it sends the caller into a poll loop for a
+      // result it could already read.
+      convexMutationMock.mockResolvedValue({
+        runId: "run_1",
+        jobId: "job_1",
+        reused: true,
+      });
+      convexQueryMock.mockResolvedValue({ id: "run_1", status: "completed" });
+      const res = await request(
+        "POST",
+        "/api/v1/projects/p1/servers/s1/readiness-runs/claude",
+        { body: { idempotencyKey: "k1" } },
+      );
+      expect(res.status).toBe(202);
+      expect(((await res.json()) as { status?: string }).status).toBe(
+        "completed",
+      );
+    });
+
+    it("falls back to pending when the replayed run cannot be read", async () => {
+      // Failing to read the status is not failing to start. The caller polls,
+      // which is what it would have done anyway.
+      convexMutationMock.mockResolvedValue({
+        runId: "run_1",
+        jobId: "job_1",
+        reused: true,
+      });
+      convexQueryMock.mockRejectedValue(new Error("convex is down"));
+      const res = await request(
+        "POST",
+        "/api/v1/projects/p1/servers/s1/readiness-runs/claude",
+        { body: { idempotencyKey: "k1" } },
+      );
+      expect(res.status).toBe(202);
+      const body = (await res.json()) as { status?: string; deduped?: boolean };
+      expect(body.status).toBe("pending");
+      expect(body.deduped).toBe(true);
     });
   });
 
@@ -449,7 +495,6 @@ describe("v1 directory readiness", () => {
       // could be used to read any blob in the deployment.
       expect(String(url)).toContain("runId=run_1");
       expect(init.headers["x-inspector-service-token"]).toBe("service-token");
-      vi.unstubAllGlobals();
     });
   });
 });

--- a/mcpjam-inspector/server/routes/v1/readiness.ts
+++ b/mcpjam-inspector/server/routes/v1/readiness.ts
@@ -41,27 +41,30 @@ import { authorizeServer, parseWithSchema } from "../web/auth.js";
 import { ErrorCode, WebRouteError } from "../web/errors.js";
 import { getConvexBearerForRequest } from "../../utils/v1-convex-token.js";
 import { getInternalBackendConfig } from "../../services/internal-backend.js";
-import { createStreamingPinnedFetch } from "../../utils/pinned-fetch.js";
-import { logger } from "../../utils/logger.js";
-import { executeHostedReadinessRun } from "../../services/readiness/worker.js";
 import { translateConvexWriteError as translateConvexError } from "./convex-errors.js";
 import { v1PageJson, v1Resource } from "./envelope.js";
+import {
+  HOSTED_SUBMISSION_MODES,
+  READINESS_PUBLISHERS as PUBLISHERS,
+  startHostedReadinessRun,
+  toReadinessRunDto,
+  type ReadinessPublisher as Publisher,
+} from "../shared/readiness-runs.js";
 import type { OpenAISubmissionMode } from "@mcpjam/sdk";
 
 const readiness = new Hono();
 
-/** The two words the public vocabulary uses. Never `anthropic`/`chatgpt`. */
-const PUBLISHERS = ["claude", "openai"] as const;
-type Publisher = (typeof PUBLISHERS)[number];
+/** The largest page this endpoint will ask the backend for. */
+const READINESS_LIST_MAX_LIMIT = 100;
 
 /**
- * The submission shapes a HOSTED run may grade.
+ * How long the service-token read of a report blob may take.
  *
- * The package shapes need an upload this API has no way to receive, and the
- * refusal names the CLI rather than pretending the shape does not exist. The
- * backend refuses them too; this is the layer that can explain why.
+ * Without it the fetch inherits no deadline at all: a backend that accepts the
+ * socket and then stalls holds this request open for as long as it pleases,
+ * and the caller cannot tell that from a very large report.
  */
-const HOSTED_SUBMISSION_MODES = ["mcp-only", "mcp-imported-skills"] as const;
+const REPORT_FETCH_TIMEOUT_MS = 30_000;
 
 function createConvexClient(convexAuthToken: string): ConvexHttpClient {
   const convexUrl = process.env.CONVEX_URL;
@@ -110,40 +113,19 @@ const startOpenAISchema = z.strictObject({
   submissionMode: z.enum(HOSTED_SUBMISSION_MODES),
 });
 
-/** The run row as the public API renders it. */
-function toRunDto(run: Record<string, any>) {
-  return {
-    id: run.id,
-    readinessKind: run.readinessKind,
-    serverUrl: run.serverUrl,
-    submissionMode: run.submissionMode ?? null,
-    status: run.status,
-    overallStatus: run.overallStatus ?? null,
-    lanes: run.lanes ?? [],
-    stages: run.stages ?? [],
-    authMode: run.authMode ?? null,
-    capabilities: run.capabilities ?? [],
-    attemptCount: run.attemptCount,
-    terminalReason: run.terminalReason ?? null,
-    errorMessage: run.errorMessage ?? null,
-    policySnapshotDate: run.policySnapshotDate ?? null,
-    engineVersion: run.engineVersion ?? null,
-    sdkVersion: run.sdkVersion ?? null,
-    // The AI axis, ALWAYS present and independent of `status`. A run whose
-    // lanes graded cleanly is `completed` even when the observation call was
-    // refused for credit, and a reader has to be able to see both.
-    includeLlmObservations: run.includeLlmObservations ?? false,
-    llmObservations: run.llmObservations ?? {
-      status: "not-requested",
-      reason: "not_requested",
-    },
-    hasReport: run.hasReport === true,
-    reportUrl: run.hasReport
-      ? `/api/v1/projects/${run.projectId ?? ""}/readiness-runs/${run.id}/report`
-      : null,
-    createdAt: run.createdAt,
-    updatedAt: run.updatedAt,
-  };
+/**
+ * The run row as the public API renders it.
+ *
+ * The projection itself is shared with the web surface; what `/api/v1` adds is
+ * a report LINK, because a public caller has no other way to discover the
+ * endpoint that serves the bytes.
+ */
+function toRunDto(run: Record<string, any>, projectId: string) {
+  return toReadinessRunDto(run, {
+    projectId,
+    reportUrl: (runId) =>
+      `/api/v1/projects/${projectId}/readiness-runs/${runId}/report`,
+  });
 }
 
 /**
@@ -170,88 +152,21 @@ async function startRun(
     projectId,
     serverId,
   );
-  const config = authorized.serverConfig;
-  if (config.transportType !== "http" || !config.url) {
-    // Readiness grades what a HOST would see, and every host in question
-    // reaches a server over HTTP. A stdio server is not a connector these
-    // directories can list, so this is a wrong-shape refusal rather than a gap.
-    throw new WebRouteError(
-      400,
-      ErrorCode.VALIDATION_ERROR,
-      "Directory readiness grades HTTP connectors; this server uses a different transport.",
-    );
-  }
 
-  const convex = createConvexClient(convexAuthToken);
-  let created: { runId: string; jobId: string; reused: boolean };
-  try {
-    created = await convex.mutation(
-      "claudeReadinessRuns:requestReadinessRun" as any,
-      {
-        projectId,
-        serverId,
-        serverUrl: config.url,
-        readinessKind: publisher,
-        ...(submissionMode ? { submissionMode } : {}),
-        ...(body.idempotencyKey
-          ? { idempotencyKey: body.idempotencyKey }
-          : {}),
-        includeLlmObservations: body.includeLlmObservations === true,
-        authMode: config.useOAuth ? "provided-token" : "headless",
-      },
-    );
-  } catch (error) {
-    throw translateConvexError(error, { resource: "Readiness run" });
-  }
+  const receipt = await startHostedReadinessRun({
+    convex: createConvexClient(convexAuthToken),
+    projectId,
+    serverId,
+    publisher,
+    submissionMode,
+    idempotencyKey: body.idempotencyKey,
+    includeLlmObservations: body.includeLlmObservations === true,
+    authorized,
+    translateError: (error) =>
+      translateConvexError(error, { resource: "Readiness run" }),
+  });
 
-  // A REPLAY EXECUTES NOTHING. The run it names is already in flight or
-  // already finished; starting a second execution against the same lease would
-  // dial a third party's server twice for one logical request, which is the
-  // exact thing the idempotency key was sent to prevent.
-  if (!created.reused) {
-    const headers: Record<string, string> = { ...(config.headers ?? {}) };
-    if (authorized.oauthAccessToken) {
-      headers.authorization = `Bearer ${authorized.oauthAccessToken}`;
-    }
-
-    void executeHostedReadinessRun({
-      lease: { runId: created.runId, jobId: created.jobId },
-      publisher,
-      target: config.url,
-      submissionMode,
-      headers: Object.keys(headers).length > 0 ? headers : undefined,
-      // The DNS-pinned transport: resolve once, refuse the disallowed answers,
-      // pin the surviving addresses into the socket, re-run it on every hop.
-      fetchFn: createStreamingPinnedFetch({
-        targetLabel: "MCP server",
-        chainTimeoutMs: 30_000,
-        bodyIdleTimeoutMs: 120_000,
-        maxResponseBytes: 32 * 1024 * 1024,
-      }),
-      includeLlmObservations: body.includeLlmObservations === true,
-    }).catch((error) => {
-      // `executeHostedReadinessRun` never throws — every exit lands the run
-      // somewhere terminal. This catch exists for the impossible case, so an
-      // unhandled rejection cannot take the process with it.
-      logger.error("[v1 readiness] detached run escaped its own handler", error, {
-        runId: created.runId,
-      });
-    });
-  }
-
-  return v1Resource(
-    c,
-    {
-      runId: created.runId,
-      projectId,
-      serverId,
-      readinessKind: publisher,
-      status: created.reused ? "pending" : "pending",
-      deduped: created.reused,
-      includeLlmObservations: body.includeLlmObservations === true,
-    },
-    202,
-  );
+  return v1Resource(c, receipt, 202);
 }
 
 // ── Start ───────────────────────────────────────────────────────────────
@@ -311,7 +226,7 @@ readiness.get("/projects/:projectId/readiness-runs/:runId", async (c) => {
   if (!run) {
     throw new WebRouteError(404, ErrorCode.NOT_FOUND, "Readiness run not found");
   }
-  return v1Resource(c, toRunDto({ ...run, projectId }));
+  return v1Resource(c, toRunDto(run, projectId));
 });
 
 readiness.get("/projects/:projectId/readiness-runs", async (c) => {
@@ -329,11 +244,18 @@ readiness.get("/projects/:projectId/readiness-runs", async (c) => {
   const serverId = c.req.query("serverId");
   const rawLimit = c.req.query("limit");
   const limit = rawLimit === undefined ? undefined : Number(rawLimit);
-  if (limit !== undefined && (!Number.isFinite(limit) || limit < 1)) {
+  // An INTEGER and a CEILING, not merely a finite number. `Number.isFinite`
+  // admits `2.5` and `1e9` alike and forwards both to the backend, so a page
+  // cap with no upper bound is an invitation to ask for every run an
+  // organization has ever recorded in one request.
+  if (
+    limit !== undefined &&
+    (!Number.isInteger(limit) || limit < 1 || limit > READINESS_LIST_MAX_LIMIT)
+  ) {
     throw new WebRouteError(
       400,
       ErrorCode.VALIDATION_ERROR,
-      "limit must be a positive integer",
+      `limit must be an integer between 1 and ${READINESS_LIST_MAX_LIMIT}`,
     );
   }
 
@@ -350,7 +272,7 @@ readiness.get("/projects/:projectId/readiness-runs", async (c) => {
   }
   return v1PageJson(
     c,
-    runs.map((run) => toRunDto({ ...run, projectId })),
+    runs.map((run) => toRunDto(run, projectId)),
   );
 });
 
@@ -414,22 +336,38 @@ readiness.get(
     // precisely so a node cannot use it to read blobs belonging to other
     // features.
     const { convexUrl, serviceToken } = getInternalBackendConfig();
-    const response = await fetch(
-      `${convexUrl}/internal/v1/claude-readiness/runs/report?runId=${encodeURIComponent(runId)}`,
-      { headers: { "x-inspector-service-token": serviceToken } },
-    );
-    if (response.status === 404) {
-      throw new WebRouteError(
-        404,
-        ErrorCode.NOT_FOUND,
-        "This readiness run's report is no longer stored.",
+    let response: Response;
+    try {
+      response = await fetch(
+        `${convexUrl}/internal/v1/claude-readiness/runs/report?runId=${encodeURIComponent(runId)}`,
+        {
+          headers: { "x-inspector-service-token": serviceToken },
+          signal: AbortSignal.timeout(REPORT_FETCH_TIMEOUT_MS),
+        },
       );
-    }
-    if (!response.ok) {
+    } catch {
+      // A DNS failure, a refused connection or the deadline above. Uncaught,
+      // each of these surfaces as an opaque 500 — the same shape the two
+      // branches below take care to report as a 502, because none of them is
+      // the caller's fault.
       throw new WebRouteError(
         502,
         ErrorCode.INTERNAL_ERROR,
         "The readiness report could not be read from storage.",
+      );
+    }
+    if (!response.ok) {
+      // Neither branch reads the body, and an unread body holds its keep-alive
+      // connection until GC. Cancelling hands it back now.
+      await response.body?.cancel().catch(() => undefined);
+      throw new WebRouteError(
+        response.status === 404 ? 404 : 502,
+        response.status === 404
+          ? ErrorCode.NOT_FOUND
+          : ErrorCode.INTERNAL_ERROR,
+        response.status === 404
+          ? "This readiness run's report is no longer stored."
+          : "The readiness report could not be read from storage.",
       );
     }
     // Streamed through rather than buffered: a readiness report carries

--- a/mcpjam-inspector/server/services/readiness/backend-client.ts
+++ b/mcpjam-inspector/server/services/readiness/backend-client.ts
@@ -296,7 +296,13 @@ export async function failReadinessRun(
     INGEST_TIMEOUT_MS,
   );
   try {
-    if (!response.ok) return { applied: false };
+    if (!response.ok) {
+      // The body is never read on this path, and an unread body holds its
+      // keep-alive connection until GC. Cancelling hands it back now — the
+      // same reason the heartbeat and finalize paths do it.
+      await response.body?.cancel().catch(() => undefined);
+      return { applied: false };
+    }
     const body = (await response.json().catch(() => null)) as {
       applied?: unknown;
     } | null;

--- a/sdk/src/directory-readiness/evidence-reuse.ts
+++ b/sdk/src/directory-readiness/evidence-reuse.ts
@@ -125,10 +125,11 @@ export function sameReadinessTarget(left: string, right: string): boolean {
       const userinfo = url.username
         ? `${url.username}${url.password ? `:${url.password}` : ""}@`
         : "";
-      const authority = `${url.protocol}//${url.host}`.toLowerCase();
-      return `${url.protocol}//${userinfo}${authority.slice(
-        url.protocol.length + 2,
-      )}${path}${url.search}`;
+      // The host alone is folded — not the whole authority string — so the
+      // fold cannot reach the userinfo beside it, and no index arithmetic has
+      // to stay in step with the length of the scheme.
+      const host = url.host.toLowerCase();
+      return `${url.protocol}//${userinfo}${host}${path}${url.search}`;
     } catch {
       return value.trim();
     }

--- a/sdk/src/platform/client.ts
+++ b/sdk/src/platform/client.ts
@@ -137,6 +137,27 @@ type ServerScope = {
  * injected. Tolerant reader: unknown response fields pass through untouched,
  * and empty success bodies (204) resolve to `undefined`.
  */
+/**
+ * The two fields a readiness start body shares, and nothing else.
+ *
+ * Undefined entries are dropped rather than serialized as `null`: the
+ * endpoint's schema types both as optional, and an explicit `null` is a value
+ * it rejects rather than an absence it ignores.
+ */
+function pickReadinessStartBody(params: {
+  idempotencyKey?: string;
+  includeLlmObservations?: boolean;
+}): Record<string, unknown> {
+  const body: Record<string, unknown> = {};
+  if (params.idempotencyKey !== undefined) {
+    body.idempotencyKey = params.idempotencyKey;
+  }
+  if (params.includeLlmObservations !== undefined) {
+    body.includeLlmObservations = params.includeLlmObservations;
+  }
+  return body;
+}
+
 export class PlatformApiClient {
   private readonly baseUrl: string;
   private readonly getAuth: () => string | Promise<string>;
@@ -1285,13 +1306,20 @@ export class PlatformApiClient {
     params: { projectId: string; serverId: string } & PlatformReadinessStartBody,
     options?: RequestOptions,
   ): Promise<PlatformReadinessRunReceipt> {
-    const { projectId, serverId, ...body } = params;
+    // Explicit picks, not a rest spread. The endpoint's body schema is
+    // `strictObject`, and TypeScript's structural typing lets a caller hand a
+    // WIDER object to this parameter — so a spread would forward whatever else
+    // that object carries and turn a valid start into a 400. Worse, the
+    // rejected request never reaches the idempotency key, so the caller's
+    // retry dedupes against nothing. `publishScenario` picks for the same
+    // reason.
+    const { projectId, serverId } = params;
     return this.request(
       "POST",
       `/projects/${encodeURIComponent(projectId)}/servers/${encodeURIComponent(
         serverId,
       )}/readiness-runs/claude`,
-      { body },
+      { body: pickReadinessStartBody(params) },
       options,
     );
   }
@@ -1311,13 +1339,14 @@ export class PlatformApiClient {
     } & PlatformOpenAIReadinessStartBody,
     options?: RequestOptions,
   ): Promise<PlatformReadinessRunReceipt> {
-    const { projectId, serverId, ...body } = params;
+    // Explicit picks — see `startClaudeReadinessRun`.
+    const { projectId, serverId, submissionMode } = params;
     return this.request(
       "POST",
       `/projects/${encodeURIComponent(projectId)}/servers/${encodeURIComponent(
         serverId,
       )}/readiness-runs/openai`,
-      { body },
+      { body: { ...pickReadinessStartBody(params), submissionMode } },
       options,
     );
   }

--- a/sdk/src/platform/types.ts
+++ b/sdk/src/platform/types.ts
@@ -2447,13 +2447,31 @@ export type PlatformReadinessSubmissionMode =
 export type PlatformReadinessLaneStatus = "ready" | "not-ready" | "incomplete";
 
 /**
+ * Every lane either publisher grades, as one union.
+ *
+ * Claude uses five of these and OpenAI seven; the union is their sum rather
+ * than two types, because a client renders a run whose publisher it learns at
+ * runtime. Spelled out rather than left as `string` so a `switch` over lane
+ * copy is exhaustiveness-checked — a lane added here becomes a compile error
+ * at every renderer instead of an unlabelled row in production.
+ */
+export type PlatformReadinessLane =
+  | "runtime-compatibility"
+  | "directory-policy"
+  | "optional-features"
+  | "submission-artifacts"
+  | "experience-insights"
+  | "plugin-package"
+  | "release-contract";
+
+/**
  * What one lane managed to look at, reported separately from what it found.
  *
  * A lane with zero violations and zero evaluated checks is not a pass, and
  * publishing the denominator is the only way to keep those apart.
  */
 export interface PlatformReadinessLaneCoverage {
-  lane: string;
+  lane: PlatformReadinessLane;
   status: PlatformReadinessLaneStatus;
   evaluated: number;
   notEvaluated: number;
@@ -2465,7 +2483,7 @@ export interface PlatformReadinessLaneCoverage {
 export interface PlatformReadinessStageResult {
   stage: "technical-preflight" | "submission-ready";
   status: PlatformReadinessLaneStatus;
-  lanes: string[];
+  lanes: PlatformReadinessLane[];
 }
 
 /**
@@ -2496,6 +2514,8 @@ export interface PlatformReadinessObservationState {
 export interface PlatformReadinessRun {
   id: string;
   readinessKind: PlatformReadinessKind;
+  /** Null only on rows written before the field existed. */
+  serverId: string | null;
   serverUrl: string;
   submissionMode: PlatformReadinessSubmissionMode | null;
   status: "pending" | "running" | "completed" | "failed" | "cancelled";
@@ -2524,8 +2544,18 @@ export interface PlatformReadinessRunReceipt {
   projectId: string;
   serverId: string;
   readinessKind: PlatformReadinessKind;
-  status: string;
-  deduped?: boolean;
+  /**
+   * The run's status at the moment the start returned.
+   *
+   * `pending` for a fresh start. For a DEDUPED start it is whatever the
+   * existing run is already at — which may be `completed`, because an
+   * idempotency key replayed hours later names a run that finished long ago.
+   * Reporting `pending` unconditionally would send such a caller into a poll
+   * loop for a result it could already read.
+   */
+  status: "pending" | "running" | "completed" | "failed" | "cancelled";
+  /** True when an idempotency key replayed an existing run. */
+  deduped: boolean;
   includeLlmObservations: boolean;
 }
 

--- a/sdk/src/plugin-bundle/node-file-sources.ts
+++ b/sdk/src/plugin-bundle/node-file-sources.ts
@@ -155,52 +155,135 @@ export async function createZipPluginFileSource(
         // WOULD be visible) before it is accepted.
         out.push({
           path: entry.dir ? path.replace(/\/+$/, "") : path,
-          size:
-            (entry as { _data?: { uncompressedSize?: number } })._data
-              ?.uncompressedSize ?? 0,
+          // A directory has no content, so 0 is a fact. For a FILE, an absent
+          // declaration is unknown rather than empty — but `size` is a
+          // required number, so the only honest fallback is the limit-free 0
+          // the parser already treats as "measure it yourself when you read
+          // it". `readBytes` is what actually bounds the read.
+          size: entry.dir ? 0 : (declaredUncompressedSize(entry) ?? 0),
           kind: entry.dir ? "directory" : "file",
         });
       });
       return out;
     },
     /**
-     * Read one entry, refusing an oversized one BEFORE it is inflated.
+     * Read one entry under a HARD output ceiling.
      *
-     * `entry.async` decompresses the whole thing into memory and only then
-     * could a caller measure it — which is the shape of a zip bomb: a few
-     * kilobytes on disk that expand to gigabytes in the heap, with the size
-     * check arriving after the damage. The central directory declares the
-     * uncompressed size, so the cheap refusal is available first.
+     * A zip bomb is a few kilobytes on disk that inflate to gigabytes in the
+     * heap. Two things have to be true to survive one, and only the second is
+     * load-bearing:
      *
-     * The post-read check STAYS. The declared size is the archive's own claim
-     * about itself, and an archive that lies about it is exactly the archive
-     * this guard is for; the second check measures what actually came out.
+     *   1. The central directory's declared uncompressed size is checked
+     *      first, because it is free and refuses the obvious case before a
+     *      single byte is inflated.
+     *   2. The inflation itself is STREAMED and counted, and aborts on the
+     *      first chunk that crosses `maxBytes`.
+     *
+     * Step 1 alone is not a guard: it reads a private JSZip field that a
+     * version bump can rename, and it trusts a number the archive supplies
+     * about itself — an archive that lies is exactly the archive this is for.
+     * `entry.async()` would accumulate the whole output before anyone could
+     * measure it, so the check would arrive after the damage.
+     *
+     * Deliberately NOT failing closed when the declaration is unavailable:
+     * step 2 bounds memory to `maxBytes` plus one chunk regardless, and
+     * refusing every archive whose private field moved would break real
+     * bundles to defend against something already defended.
      */
     async readBytes(path: string, maxBytes: number) {
       const entry = zip.file(path);
       if (!entry) throw new Error(`Bundle file "${path}" is missing`);
 
-      const declared = (entry as { _data?: { uncompressedSize?: unknown } })
-        ._data?.uncompressedSize;
-      if (
-        typeof declared === "number" &&
-        Number.isFinite(declared) &&
-        declared > maxBytes
-      ) {
+      const declared = declaredUncompressedSize(entry);
+      if (declared !== undefined && declared > maxBytes) {
         throw new Error(
-          `Bundle file "${path}" declares ${declared} bytes, over the ${maxBytes} byte limit`
+          `Bundle file "${path}" declares ${declared} bytes, over the ${maxBytes} byte limit`,
         );
       }
 
-      const bytes = await entry.async("uint8array");
-      if (bytes.byteLength > maxBytes) {
-        throw new Error(
-          `Bundle file "${path}" is ${bytes.byteLength} bytes, over the ${maxBytes} byte limit`,
-        );
-      }
-      return bytes;
+      return await readStreamBounded(entry, path, maxBytes);
     },
   };
+}
+
+/**
+ * The entry's declared uncompressed size, or `undefined` when there isn't one.
+ *
+ * `_data` is private to JSZip and has no public replacement. Every value that
+ * is not a non-negative safe integer reads as ABSENT rather than as a size:
+ * a `NaN`, a float or a value past `MAX_SAFE_INTEGER` compares unpredictably,
+ * and a comparison that silently does the wrong thing is worse than no
+ * comparison at all.
+ */
+function declaredUncompressedSize(entry: unknown): number | undefined {
+  const raw = (entry as { _data?: { uncompressedSize?: unknown } })._data
+    ?.uncompressedSize;
+  return typeof raw === "number" && Number.isSafeInteger(raw) && raw >= 0
+    ? raw
+    : undefined;
+}
+
+/**
+ * Inflate one entry, aborting the moment the output passes `maxBytes`.
+ *
+ * The stream is destroyed and the accumulated chunks are dropped on the
+ * failing path, so a refused bomb costs one chunk of memory rather than
+ * however much had already been inflated.
+ */
+async function readStreamBounded(
+  entry: JSZip.JSZipObject,
+  path: string,
+  maxBytes: number,
+): Promise<Uint8Array> {
+  const stream = entry.nodeStream("nodebuffer");
+  let chunks: Buffer[] = [];
+  let total = 0;
+
+  await new Promise<void>((resolve, reject) => {
+    let settled = false;
+    const fail = (error: Error) => {
+      if (settled) return;
+      settled = true;
+      // Free what was inflated before handing the error back: on a bomb this
+      // is the difference between one chunk held and everything up to the
+      // limit held for as long as the rejection takes to unwind.
+      chunks = [];
+      // JSZip types the return as `NodeJS.ReadableStream`, which declares no
+      // `destroy`; the object it actually hands back is a `Readable` and does
+      // have one. Pause first so the cast is belt-and-braces rather than the
+      // only thing stopping the inflation.
+      stream.pause();
+      try {
+        (stream as { destroy?: () => void }).destroy?.();
+      } catch {
+        // A stream that cannot be destroyed still stops mattering once it is
+        // paused, its chunks are dropped, and nothing reads it again.
+      }
+      reject(error);
+    };
+
+    stream.on("data", (chunk: Buffer) => {
+      if (settled) return;
+      total += chunk.length;
+      if (total > maxBytes) {
+        fail(
+          new Error(
+            `Bundle file "${path}" exceeds the ${maxBytes} byte limit`,
+          ),
+        );
+        return;
+      }
+      chunks.push(chunk);
+    });
+    stream.on("error", (error: Error) => fail(error));
+    stream.on("end", () => {
+      if (settled) return;
+      settled = true;
+      resolve();
+    });
+  });
+
+  return new Uint8Array(Buffer.concat(chunks, total));
 }
 
 /**

--- a/sdk/tests/plugin-bundle-node-file-sources.test.ts
+++ b/sdk/tests/plugin-bundle-node-file-sources.test.ts
@@ -24,6 +24,7 @@ import JSZip from "jszip";
 import {
   DIRECTORY_ARCHIVE_OBSERVATIONS,
   collectZipArchiveObservations,
+  createZipPluginFileSource,
 } from "../src/plugin-bundle/node-file-sources.js";
 
 const encoder = new TextEncoder();
@@ -223,3 +224,130 @@ describe("collectZipArchiveObservations", () => {
     expect(observed.encryptedEntryPaths).toBeUndefined();
   });
 });
+
+/**
+ * The output ceiling, which is the part that has to hold when the archive
+ * lies.
+ *
+ * A zip bomb's whole trick is that the cheap check — the central directory's
+ * declared uncompressed size — is a number the archive supplies about itself.
+ * These cases are the ones where that number is useless: absent, or smaller
+ * than what actually inflates. If the read is bounded only by the declaration,
+ * every one of them passes while the heap fills.
+ */
+describe("createZipPluginFileSource — the read ceiling", () => {
+  it("reads a file that fits", async () => {
+    const source = await createZipPluginFileSource(
+      await zipOf({ "mcpjam-plugin.json": "{}" }),
+    );
+    const bytes = await source.readBytes("mcpjam-plugin.json", 1024);
+    expect(new TextDecoder().decode(bytes)).toBe("{}");
+  });
+
+  it("refuses on the DECLARED size, before inflating anything", async () => {
+    const source = await createZipPluginFileSource(
+      await zipOf({ big: "x".repeat(4096) }),
+    );
+    await expect(source.readBytes("big", 128)).rejects.toThrow(/declares/);
+  });
+
+  it("refuses output past the limit even when the declaration is honest but the limit is smaller", async () => {
+    // Distinct from the case above only in WHICH guard fires; both must, and a
+    // regression that removed the streaming bound would still pass that one.
+    const source = await createZipPluginFileSource(
+      await zipOf({ big: "y".repeat(2048) }),
+    );
+    await expect(source.readBytes("big", 2047)).rejects.toThrow(
+      /declares|exceeds/,
+    );
+  });
+
+  it("still refuses when the archive UNDER-REPORTS its uncompressed size", async () => {
+    // The bomb case. A crafted central directory claims one byte; the entry
+    // inflates to far more. The declared check waves it through, so only the
+    // counted stream can stop it.
+    const source = await createZipPluginFileSource(
+      storedEntryZip("liar", "z".repeat(4096), 1),
+    );
+    // The message matters: `exceeds` is the STREAM's refusal. `declares` would
+    // mean the cheap check fired, which it cannot here — the archive claims
+    // one byte, comfortably under the limit.
+    await expect(source.readBytes("liar", 64)).rejects.toThrow(/exceeds/);
+  });
+
+  it("reports a missing entry as missing rather than as oversized", async () => {
+    const source = await createZipPluginFileSource(await zipOf({ a: "1" }));
+    await expect(source.readBytes("b", 1024)).rejects.toThrow(/is missing/);
+  });
+
+  it("lists a directory as zero bytes and a file by its declaration", async () => {
+    const zip = new JSZip();
+    zip.folder("dir");
+    zip.file("dir/file.txt", encoder.encode("hello"));
+    const source = await createZipPluginFileSource(
+      await zip.generateAsync({ type: "uint8array" }),
+    );
+    const entries = await source.list();
+    const dir = entries.find((e) => e.path === "dir");
+    const file = entries.find((e) => e.path === "dir/file.txt");
+    expect(dir?.kind).toBe("directory");
+    expect(dir?.size).toBe(0);
+    expect(file?.kind).toBe("file");
+    expect(file?.size).toBe(5);
+  });
+});
+
+/**
+ * A hand-built STORED zip whose central directory declares a chosen
+ * uncompressed size, honest or not.
+ *
+ * `JSZip.generateAsync` always tells the truth, so a bomb cannot be expressed
+ * through it — the bytes have to be assembled by hand.
+ */
+function storedEntryZip(
+  name: string,
+  body: string,
+  declaredSize: number,
+): Uint8Array {
+  const n = encoder.encode(name);
+  const b = encoder.encode(body);
+
+  const local = new Uint8Array(30 + n.length + b.length);
+  const lv = new DataView(local.buffer);
+  lv.setUint32(0, 0x04034b50, true);
+  lv.setUint16(4, 20, true);
+  lv.setUint16(8, 0, true); // stored, no compression
+  lv.setUint32(14, 0, true); // crc left at 0 — jszip does not verify by default
+  lv.setUint32(18, b.length, true);
+  lv.setUint32(22, declaredSize, true);
+  lv.setUint16(26, n.length, true);
+  local.set(n, 30);
+  local.set(b, 30 + n.length);
+
+  const central = new Uint8Array(46 + n.length);
+  const cv = new DataView(central.buffer);
+  cv.setUint32(0, 0x02014b50, true);
+  cv.setUint16(4, 20, true);
+  cv.setUint16(6, 20, true);
+  cv.setUint16(10, 0, true);
+  cv.setUint32(16, 0, true);
+  cv.setUint32(20, b.length, true);
+  cv.setUint32(24, declaredSize, true);
+  cv.setUint16(28, n.length, true);
+  cv.setUint32(42, 0, true);
+  central.set(n, 46);
+
+  const eocd = new Uint8Array(22);
+  const ev = new DataView(eocd.buffer);
+  ev.setUint32(0, 0x06054b50, true);
+  ev.setUint16(8, 1, true);
+  ev.setUint16(10, 1, true);
+  ev.setUint32(12, central.length, true);
+  ev.setUint32(16, local.length, true);
+
+  const out = new Uint8Array(local.length + central.length + eocd.length);
+  out.set(local, 0);
+  out.set(central, local.length);
+  out.set(eocd, local.length + central.length);
+  return out;
+}


### PR DESCRIPTION
Follow-up to #4153, from review of it. Three fixes that matter, plus the extraction that stops the third one recurring.

## The archive read now has a ceiling

`readBytes` refused a ZIP entry on the uncompressed size the central directory declares, then inflated it with `entry.async` and measured afterwards. That is the wrong way round for the only threat the check exists for: a zip bomb's whole trick is that the declared size is a number the archive supplies **about itself**. An archive that under-reports — or one whose private JSZip `_data` field a version bump renames — sailed through the cheap check and filled the heap before anything could measure it.

The inflation is now streamed and counted, and aborts on the first chunk that crosses the limit. The stream is paused, destroyed, and its accumulated chunks dropped, so a refused bomb costs one chunk rather than everything inflated so far. The declared check stays as a free early-out, not as the guard.

Deliberately **not** failing closed on an absent declaration: the streaming bound holds regardless, and refusing every archive whose private field moved would break real bundles to defend against something already defended.

Regression coverage includes a hand-built STORED archive that claims one byte and inflates to four kilobytes — `generateAsync` always tells the truth, so a lying archive has to be assembled by hand. The test asserts the *stream's* refusal message specifically, so a regression that removed the bound cannot pass by having the cheap check fire instead.

## A replayed start now reports the run's real status

The `202` receipt said `pending` unconditionally, which is false for the exact case that produces it: an idempotency key replayed hours later names a run that finished long ago, and a caller told `pending` polls for a result it could already read.

A dedupe now costs one extra read. Failing that read falls back to `pending` — failing to read a status is not failing to start, and the caller polls, which is what it would have done anyway.

## The internal report fetch has a deadline

It ran on the request thread with no timeout, so a backend that accepted the socket and then stalled held the caller's connection for as long as it liked. A DNS or connect failure was worse: nothing caught it, so it surfaced as an opaque 500 rather than the 502 the branches beside it take care to produce. Both the public and the panel report paths now abort at 30s and map transport failures to 502.

## The hosted start is now shared

Extracted to `server/routes/shared/readiness-runs.ts`. Three surfaces create these runs and they legitimately differ on credentials and envelopes — but not on which transports may be graded, where the target comes from, or whether a replay executes anything. A surface that got the last one wrong would dial a third party's server twice per retry, and retries are the traffic nobody watches.

## Smaller

- `limit` is validated as a bounded integer rather than a finite number. `Number.isFinite` admits `2.5` and `1e9` alike, and a page cap with no ceiling is an invitation to ask for every run an organization ever recorded.
- Target identity folds `url.host` directly instead of slicing the authority by the scheme's length — same result, no index arithmetic that has to stay in step with the string it measures.
- The platform client picks the two start-body fields explicitly. The endpoints are strict, structural typing admits a wider object, and a spread would turn a valid start into a `400` — whose retry then dedupes against nothing, because the rejected request never reached the key.
- Lane names are a literal union rather than `string`, so a renderer's `switch` is exhaustiveness-checked. `ReadinessRun` / `ReadinessRunReceipt` now mark as required every field the DTO always emits, and the document gains `serverId` and the cancel response body it was missing.
- The failure write cancels an unread response body, matching the heartbeat and finalize paths.
- The detached run's escape hatch reports through `reportRouteFailure` as an internal hop — reaching it means the worker's never-throw contract broke, not that somebody's MCP server misbehaved.
- The v1 suite restores stubbed globals in `afterEach`, so one failed assertion no longer leaks a stubbed `fetch` into every test after it.

## Verification

- `npm run typecheck` (root) — clean
- `npm run build:inspector` — clean
- SDK: 902 tests across the readiness, platform, browser-entry and plugin-bundle suites
- Inspector: 132 tests across the readiness, conformance, v1 and OpenAPI-drift suites

More surfaces (the conformance panel, the canonical operations, the CLI) follow on this branch.

---
_Generated by [Claude Code](https://claude.ai/code/session_01QrxvazHLzsL3JoDaPrKP8E)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Hardens ZIP inflation against zip bombs and changes hosted-run start/receipt behavior (idempotency, report fetch timeouts). Not an auth rewrite, but it sits on untrusted archives and third-party fetch.
> 
> **Overview**
> Hardens directory-readiness follow-ups: ZIP extraction, start receipts, and the hosted-run path.
> 
> **ZIP reads now abort during inflation.** `createZipPluginFileSource.readBytes` no longer inflates the whole entry then measures. It still refuses on a declared uncompressed size, then streams and counts bytes, destroying the stream and dropping chunks as soon as output exceeds `maxBytes`. That is the actual zip-bomb guard; the central-directory number is only an early-out. Tests include a hand-built STORED archive that under-reports size.
> 
> **Idempotent start receipts tell the truth.** A replayed key used to always return `pending`. Deduped starts now read the existing run’s status (falling back to `pending` if that read fails) and still execute nothing. Hosted start + DTO projection move into `startHostedReadinessRun` / `toReadinessRunDto` so v1 (and later surfaces) cannot disagree on replay or observation vs. grade status.
> 
> **Report fetch is deadlined.** The service-token report read aborts at 30s and maps transport failures to 502; unread error bodies are cancelled. List `limit` is a 1–100 integer. The platform client picks start-body fields instead of spreading a wider object into a strict schema. OpenAPI/types mark receipt status, lanes, and `ReadinessRun` fields as required.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c3b2ebf17ee3f4d75e519f08b49d2e2a7fed4ef5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Hardens directory readiness by bounding ZIP entry reads, returning honest replay statuses, and deadlining report fetches. Prevents zip bombs, removes misleading 202 receipts, and makes report reads fail fast with 502 on transport issues.

- Bounds archive reads in `sdk` by streaming inflation and aborting on the first chunk past the limit. Keeps the declared-size check as an early-out; does not fail closed when the declaration is absent. Adds regression tests with a hand-built STORED archive.
- Returns the real status on idempotency key replays (e.g., `completed`), not unconditional `pending`. Falls back to `pending` only if the status read fails.
- Adds a 30s timeout to internal report reads and maps DNS/connect/timeout failures to 502. Cancels unread bodies on failure paths.
- Extracts hosted start/run DTO logic to `server/routes/shared/readiness-runs.ts` so all surfaces share transport, submission mode, and replay semantics.
- Tightens list pagination: `limit` must be an integer between 1 and 100.
- Aligns SDK/OpenAPI types: lane names are a literal union; readiness receipt `status` is an enum; `deduped` is required; run DTO includes `serverId`; cancel now returns a JSON body. Updates `docs/reference/openapi.json` accordingly.
- Updates `@mcpjam/sdk` platform client to explicitly pick readiness start body fields to avoid leaking extras into strict endpoints.
- Minor: safer target host folding; cancel unread response bodies in failure writes; restore stubbed globals in tests.

**Migration**
- Handle non-`pending` statuses on replayed start receipts. Do not assume `pending` after a 202.
- Pass a valid `limit` (1–100) as an integer when listing runs; floats or very large values now 400.
- Update TypeScript consumers of `@mcpjam/sdk`:
  - Switches over lanes must cover the new `PlatformReadinessLane` union.
  - Treat `ReadinessRunReceipt.deduped` as required and `status` as a concrete enum.
  - Expect `ReadinessRun.serverId` (may be null on older rows).
- The cancel endpoint returns a JSON body; callers that parse responses may use it.

<sup>Written for commit c3b2ebf17ee3f4d75e519f08b49d2e2a7fed4ef5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/MCPJam/inspector/pull/4158?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

