### PR TITLE
fix(e2e): skip the caniuse pointer assertions behind staging's sign-in gate

### DIFF
--- a/mcpjam-inspector/e2e/caniuse-table-fills-viewport.spec.ts
+++ b/mcpjam-inspector/e2e/caniuse-table-fills-viewport.spec.ts
@@ -64,6 +64,34 @@ test("caniuse compare table fills the viewport and keeps its header pinned", asy
     ).toBe(true);
   }).toPass({ timeout: 30_000 });
 
+  // Everything below drives real pointer input, which a signed-out hosted
+  // deployment will not accept. `HostedShellGate` (App.tsx) wraps the whole
+  // app, and under `MCPJAM_NONPROD_LOCKDOWN` — which staging runs with — a
+  // signed-out visitor gets an overlay plus `inert` + `pointer-events-none`
+  // on the content. `scroller.hover()` then never resolves: Playwright's
+  // actionability check keeps landing on the gate's Sign in button and
+  // retries until the enclosing `toPass` gives up, which surfaces as a bare
+  // "Timeout exceeded while waiting on the predicate" with no assertion
+  // behind it. The geometry above is unaffected (the gate changes input, not
+  // layout) and still measures the real deployed table, so only this half is
+  // skipped. The un-gated local build in the `Tests` workflow runs it in
+  // full. Same reasoning as nux.spec.ts's hosted-auth skip.
+  //
+  // Only paid against a deployed target; a local build is never hosted.
+  const gated =
+    !!process.env.PLAYWRIGHT_BASE_URL &&
+    (await page
+      .getByTestId("hosted-shell-gate-overlay")
+      .waitFor({ state: "visible", timeout: 5_000 })
+      .then(
+        () => true,
+        () => false
+      ));
+  test.skip(
+    gated,
+    "signed-out hosted lockdown makes the page inert; pointer-driven scrolling can't be exercised there"
+  );
+
   // The header row stays at a fixed spot in the viewport across a real,
   // physical scroll (not just a single before/after snapshot — a
   // transform-vs-sticky mismatch can let it drift partway through). Hover the


### PR DESCRIPTION
## The failure

The post-deploy staging e2e lane has failed on **every run since the spec landed** in #3964 — it has never once passed against staging. Latest: [run 32417006440](https://github.com/MCPJam/inspector/actions/runs/32417006440/job/96582096631).

The reported error is misleading:

```
Error: Timeout 20000ms exceeded while waiting on the predicate
  > 114 |   }).toPass({ timeout: 20_000 });
```

No assertion message, so it reads like the sticky header actually drifted. It didn't.

## Root cause

Staging runs with `MCPJAM_NONPROD_LOCKDOWN`. Signed out, `HostedShellGate` (App.tsx:4709) wraps the whole app and marks the content `inert` + `pointer-events-none` behind a "Sign in to MCPJam to continue" overlay.

`scroller.hover()` then never resolves. The trace shows Playwright's actionability check resolving the gate's Sign in button as the element under the point, over and over:

```
attempting hover action
  element is visible and stable
  <button type="button" data-slot="button" class="inline-flex items-center ...
retrying hover action
  ... (until the enclosing toPass gives up)
```

The failure screenshot confirms it — the compare table is blurred behind the sign-in modal.

This is not a product bug: `nonProdLockdown` is false in production, so caniuse.dev is un-gated. It is a test that cannot run against a locked-down deployment.

## The fix

Skip only the pointer-driven half of the test, and only when the gate overlay is actually up on a deployed target:

- The geometry assertions (table reaches the viewport bottom, scrolls internally, scroll box is a direct child of the animated card) **still run against the real staging table** — the gate changes input, not layout.
- The un-gated local build in the `Tests` workflow keeps running the wheel scroll in full, so the sticky-vs-transform coverage #3964 added is untouched.
- Same reasoning and shape as `nux.spec.ts`'s existing hosted-auth skip.

## Verification

Against `https://staging.mcpjam.com`:

```
✓ 1 caniuse compare table hugs its content instead of stretching when filtered to a few rows (2.1s)
- 2 caniuse compare table fills the viewport and keeps its header pinned
  1 skipped
  1 passed (2.9s)
```

`E2E Smoke (Playwright)` in the `Tests` workflow is green on main, which is the lane that exercises the skipped half.

## Note — a separate red on main

Unrelated to this PR, but `Inspector Tests 3/4` is failing on `main` as of 73f1c2d (#4153). `routes/v1/__tests__/sdk-coverage.test.ts` reports six `/api/v1` routes with no SDK client method and no `EXCLUDED_FROM_SDK` reason:

```
get  /projects/{projectId}/readiness-runs
get  /projects/{projectId}/readiness-runs/{runId}
get  /projects/{projectId}/readiness-runs/{runId}/report
post /projects/{projectId}/readiness-runs/{runId}/cancel
post /projects/{projectId}/servers/{serverId}/readiness-runs/claude
post /projects/{projectId}/servers/{serverId}/readiness-runs/openai
```

Not fixed here — it needs a call on SDK methods vs. exclusion reasons.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> E2E-only skip for pointer input on locked-down hosted deploys; no product or security logic changes.
> 
> **Overview**
> Stops the caniuse sticky-header e2e from hanging on staging by skipping only the pointer/wheel half when `HostedShellGate` is up.
> 
> Layout checks still run against the deployed table. Wheel-scroll coverage stays on the un-gated local `Tests` workflow. Skip is gated on `PLAYWRIGHT_BASE_URL` plus a visible `hosted-shell-gate-overlay`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fa9f1c2e36bf633d104833a2319e7bddb5ffd92c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Conditionally skips the pointer-driven assertions in the caniuse E2E spec when the hosted sign-in gate is active, preventing false timeouts on staging while keeping layout coverage. Geometry checks still run on staging; full pointer scroll still runs in local CI.

- Old vs new: Staging failed with a `toPass` timeout because `HostedShellGate` under `MCPJAM_NONPROD_LOCKDOWN` makes content `inert`/`pointer-events-none`, so `scroller.hover()` never becomes actionable. Now the test detects the gate and skips only the pointer-scrolling half; no product behavior changes.
- Gate detection: Treat as gated when `PLAYWRIGHT_BASE_URL` is set and `data-testid="hosted-shell-gate-overlay"` becomes visible within 5s.
- Coverage and scope: Geometry assertions still exercise the real staging table; the un-gated `Tests` workflow continues to run the full pointer scroll. Test-only change in `mcpjam-inspector/e2e/caniuse-table-fills-viewport.spec.ts`.

<sup>Written for commit fa9f1c2e36bf633d104833a2319e7bddb5ffd92c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/MCPJam/inspector/pull/4159?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

