### PR TITLE
Registry: badge directory rows that require a pre-registered OAuth client

### DIFF
--- a/.changeset/registry-preregistered-badge.md
+++ b/.changeset/registry-preregistered-badge.md
@@ -1,0 +1,22 @@
+---
+"@mcpjam/inspector": minor
+---
+
+Badge directory rows whose OAuth probe resolved to pre-registered-only
+registration — "Requires pre-registered client" on the card and the detail
+dialog.
+
+The verdict is the backend's nightly `oauthProbe` sweep asking each
+connectable row's authorization server for its registration posture
+(DCR / CIMD / neither). It is a probe **fact**, distinct from the upstream
+listing's `authPosture` claim, and the badge renders only when the probe can
+back it:
+
+- **`resolved` verdicts only.** `no_metadata` and `unreachable` are
+  indistinguishable from a server that does not do OAuth discovery at all, so
+  they render nothing.
+- **The verdict must be about the row's current endpoint.** The ETL never
+  touches `oauthProbe`, so between an endpoint move and the next sweep a row
+  can hold a verdict about its old URL; `requiresPreregisteredClient` mirrors
+  the backend's `probeTargetFor` (fixed → `remoteUrl`, options → first
+  published endpoint) and refuses a mismatched verdict.

--- a/mcpjam-inspector/client/src/components/RegistryTab.tsx
+++ b/mcpjam-inspector/client/src/components/RegistryTab.tsx
@@ -44,6 +44,7 @@ import {
   useServerDirectory,
   useDirectoryServerDetail,
   requiresEndpointChoice,
+  requiresPreregisteredClient,
   normalizeDirectoryConnectError,
   describeExistingConnection,
   describeUnavailable,
@@ -1242,6 +1243,19 @@ function DirectoryBadges({ server }: { server: DirectoryServer }) {
           {server.endpointKind === "options"
             ? "Choose endpoint"
             : "Your instance"}
+        </Badge>
+      )}
+      {/* A probe FACT, not upstream metadata: this server's authorization
+          server answered and offers neither DCR nor CIMD, so connecting will
+          need credentials issued by the vendor. Only `resolved` verdicts
+          badge — see `requiresPreregisteredClient`. */}
+      {requiresPreregisteredClient(server) && (
+        <Badge
+          variant="outline"
+          className="text-[11px] px-1.5 py-0.5 gap-1 border-warning/30 text-warning"
+        >
+          <KeyRound className="h-3 w-3" />
+          Requires pre-registered client
         </Badge>
       )}
     </>

--- a/mcpjam-inspector/client/src/components/__tests__/RegistryTab.test.tsx
+++ b/mcpjam-inspector/client/src/components/__tests__/RegistryTab.test.tsx
@@ -485,6 +485,53 @@ describe("RegistryTab", () => {
       expect(screen.getByText("Track issues and cycles.")).toBeInTheDocument();
     });
 
+    it("badges a row whose probe resolved to pre-registered-only OAuth", () => {
+      mockDirectoryReturn = directoryHookReturn({
+        items: [
+          createDirectoryServer({
+            oauthProbe: {
+              probedAt: Date.now(),
+              endpointUrl: "https://mcp.linear.app/mcp",
+              outcome: "resolved",
+              supportsDcr: false,
+              supportsCimd: false,
+            },
+          }),
+        ],
+      });
+
+      render(<RegistryTab {...defaultProps} />);
+      expect(
+        screen.getByText("Requires pre-registered client")
+      ).toBeInTheDocument();
+    });
+
+    it("shows no pre-registration badge for a self-registering server or an unprobed row", () => {
+      // A resolved verdict WITH a registration path, and a row the sweep has
+      // not reached: both must render nothing — the badge is a probe fact,
+      // not a default.
+      mockDirectoryReturn = directoryHookReturn({
+        items: [
+          createDirectoryServer({
+            _id: "cat_dcr",
+            displayName: "Self Registering",
+            oauthProbe: {
+              probedAt: Date.now(),
+              endpointUrl: "https://mcp.linear.app/mcp",
+              outcome: "resolved",
+              supportsDcr: true,
+            },
+          }),
+          createDirectoryServer({ _id: "cat_unprobed" }),
+        ],
+      });
+
+      render(<RegistryTab {...defaultProps} />);
+      expect(
+        screen.queryByText("Requires pre-registered client")
+      ).not.toBeInTheDocument();
+    });
+
     it("renders the search box and the tier filter", () => {
       mockDirectoryReturn = directoryHookReturn({
         items: [createDirectoryServer()],

--- a/mcpjam-inspector/client/src/hooks/__tests__/requires-preregistered-client.test.ts
+++ b/mcpjam-inspector/client/src/hooks/__tests__/requires-preregistered-client.test.ts
@@ -1,0 +1,126 @@
+import { describe, it, expect } from "vitest";
+import {
+  requiresPreregisteredClient,
+  type DirectoryOAuthProbe,
+} from "@/hooks/useServerDirectory";
+
+const URL_A = "https://mcp.example.com/mcp";
+const URL_B = "https://mcp.example.com/v2/mcp";
+
+function resolvedProbe(
+  overrides: Partial<DirectoryOAuthProbe> = {}
+): DirectoryOAuthProbe {
+  return {
+    probedAt: 1755640800000,
+    endpointUrl: URL_A,
+    outcome: "resolved",
+    supportsDcr: false,
+    supportsCimd: false,
+    ...overrides,
+  };
+}
+
+describe("requiresPreregisteredClient", () => {
+  it("badges a resolved verdict offering neither DCR nor CIMD", () => {
+    expect(
+      requiresPreregisteredClient({
+        endpointKind: "fixed",
+        remoteUrl: URL_A,
+        oauthProbe: resolvedProbe(),
+      })
+    ).toBe(true);
+  });
+
+  it("treats absent supportsDcr/supportsCimd on a resolved verdict as unsupported", () => {
+    // The schema only sets the flags when outcome is resolved; a resolved
+    // verdict with both absent means the metadata answered and offered
+    // neither registration path.
+    expect(
+      requiresPreregisteredClient({
+        endpointKind: "fixed",
+        remoteUrl: URL_A,
+        oauthProbe: resolvedProbe({
+          supportsDcr: undefined,
+          supportsCimd: undefined,
+        }),
+      })
+    ).toBe(true);
+  });
+
+  it("never badges when a registration path exists", () => {
+    for (const overrides of [
+      { supportsDcr: true },
+      { supportsCimd: true },
+    ] as const) {
+      expect(
+        requiresPreregisteredClient({
+          endpointKind: "fixed",
+          remoteUrl: URL_A,
+          oauthProbe: resolvedProbe(overrides),
+        })
+      ).toBe(false);
+    }
+  });
+
+  it("never badges no_metadata or unreachable — indistinguishable from no OAuth at all", () => {
+    for (const outcome of ["no_metadata", "unreachable"] as const) {
+      expect(
+        requiresPreregisteredClient({
+          endpointKind: "fixed",
+          remoteUrl: URL_A,
+          oauthProbe: resolvedProbe({ outcome }),
+        })
+      ).toBe(false);
+    }
+  });
+
+  it("never badges a row with no verdict", () => {
+    expect(
+      requiresPreregisteredClient({
+        endpointKind: "fixed",
+        remoteUrl: URL_A,
+        oauthProbe: undefined,
+      })
+    ).toBe(false);
+  });
+
+  it("ignores a verdict about an endpoint the row no longer points at", () => {
+    // The ETL never touches oauthProbe, so between an endpoint move and the
+    // next sweep a row can hold a verdict about its OLD URL.
+    expect(
+      requiresPreregisteredClient({
+        endpointKind: "fixed",
+        remoteUrl: URL_B,
+        oauthProbe: resolvedProbe({ endpointUrl: URL_A }),
+      })
+    ).toBe(false);
+  });
+
+  it("matches options rows against their first published endpoint, like the sweep", () => {
+    const base = {
+      endpointKind: "options" as const,
+      remoteUrl: undefined,
+      remoteUrlOptions: [URL_A, URL_B],
+    };
+    expect(
+      requiresPreregisteredClient({ ...base, oauthProbe: resolvedProbe() })
+    ).toBe(true);
+    expect(
+      requiresPreregisteredClient({
+        ...base,
+        oauthProbe: resolvedProbe({ endpointUrl: URL_B }),
+      })
+    ).toBe(false);
+  });
+
+  it("never badges tenant rows — they have no probe target", () => {
+    expect(
+      requiresPreregisteredClient({
+        endpointKind: "tenant",
+        remoteUrl: undefined,
+        remoteUrlOptions: undefined,
+        oauthProbe: resolvedProbe(),
+      })
+    ).toBe(false);
+  });
+});

--- a/mcpjam-inspector/client/src/hooks/useServerDirectory.ts
+++ b/mcpjam-inspector/client/src/hooks/useServerDirectory.ts
@@ -114,6 +114,22 @@ export type DirectoryUnavailableReason =
   | "endpoint_unverified"
   | "oauth_no_resource";
 
+/**
+ * The OAuth-registration probe verdict on a summary row — OUR derivation
+ * from the server's public authorization metadata, never part of the
+ * upstream listing. Written only by the backend's nightly sweep.
+ */
+export interface DirectoryOAuthProbe {
+  probedAt: number;
+  /** The URL the verdict is about; a changed endpoint voids it. */
+  endpointUrl: string;
+  outcome: "resolved" | "no_metadata" | "unreachable";
+  /** Present only when `outcome` is `resolved`. */
+  supportsDcr?: boolean;
+  supportsCimd?: boolean;
+  authorizationServerUrl?: string;
+}
+
 /** One row of `serverCatalogQueries:searchCatalogServers`. */
 export interface DirectoryServer {
   _id: string;
@@ -135,8 +151,42 @@ export interface DirectoryServer {
   endpointConfidence?: "explicit" | "resource_verified" | "probe_verified";
   unavailableReason?: DirectoryUnavailableReason;
   authPosture?: string;
+  oauthProbe?: DirectoryOAuthProbe;
   /** A curated card already covers this row; filtered out of `items`. */
   curatedOverlap: boolean;
+}
+
+/**
+ * Should this row carry the "Requires pre-registered client" badge?
+ *
+ * `resolved` verdicts ONLY. A `no_metadata` or `unreachable` outcome is
+ * indistinguishable from a server that does not do OAuth discovery at all,
+ * so those render nothing rather than an accusation the probe cannot back.
+ *
+ * The verdict is about ONE URL (`probe.endpointUrl`), and the ETL never
+ * touches `oauthProbe` — so between an endpoint move and the next sweep
+ * (≤1 day) a row can hold a verdict about a URL it no longer points at.
+ * Badging that would present a fact about the wrong server, so the check
+ * mirrors the backend's `probeTargetFor`: `fixed` rows probe `remoteUrl`,
+ * `options` rows probe their first published endpoint, and anything else
+ * has no probe target and never badges.
+ */
+export function requiresPreregisteredClient(
+  server: Pick<
+    DirectoryServer,
+    "oauthProbe" | "endpointKind" | "remoteUrl" | "remoteUrlOptions"
+  >
+): boolean {
+  const probe = server.oauthProbe;
+  if (probe?.outcome !== "resolved") return false;
+  if (probe.supportsDcr || probe.supportsCimd) return false;
+  const target =
+    server.endpointKind === "fixed"
+      ? server.remoteUrl
+      : server.endpointKind === "options"
+        ? server.remoteUrlOptions?.[0]
+        : undefined;
+  return target !== undefined && probe.endpointUrl === target;
 }
 
 /**


### PR DESCRIPTION
## What

Phase 0 of the org-subregistries plan: make the `oauthProbe` sweep's verdict visible. Directory cards (and the detail dialog, which reuses `DirectoryBadges`) now show **"Requires pre-registered client"** when the row's authorization server was probed, resolved, and offers neither DCR nor CIMD.

## Why

Backend #1056/#1058 built and swept the verdict; nothing surfaced it. This is the data no upstream directory publishes — the proof MCPJam knows things the vendor listings don't — and it warns before a connect attempt discovers it the hard way.

## Honesty rules (both enforced in `requiresPreregisteredClient`, unit-tested)

- **`resolved` verdicts only.** `no_metadata` / `unreachable` are indistinguishable from a server that does not do OAuth discovery at all, so they render nothing rather than an accusation the probe cannot back.
- **The verdict must be about the row's current endpoint.** The ETL never touches `oauthProbe`, so between an endpoint move and the next sweep a row can hold a verdict about its old URL. The helper mirrors the backend's `probeTargetFor` (fixed → `remoteUrl`, options → first published endpoint) and refuses a mismatch.

## Verification

- Triggered the sweep on prod by hand (`catalogOAuthProbeNode:runCatalogOAuthProbeSweep`); mid-sweep tally over the public query: **869 resolved / 16 no_metadata / 3 unreachable** — overwhelmingly resolved, so the badge has real data (the plan's ship gate).
- Spot check on prod data: **Asana** resolves with neither DCR nor CIMD → badges; **Comscore** resolves with DCR → no badge; Linear unprobed yet → no badge.
- 92 tests pass (8 new helper units + 2 new component tests + existing suites); `typecheck:client` clean.

Not in this PR (next Phase 0 step): routing Connect toward credential setup instead of the dead-end toast.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI-only surfacing of existing probe data with conservative gating; no auth, connect, or backend behavior changes.
> 
> **Overview**
> Surfaces the nightly `oauthProbe` sweep on directory cards and the detail dialog as a **"Requires pre-registered client"** badge when the authorization server resolved and offers neither DCR nor CIMD.
> 
> `requiresPreregisteredClient` only badges **resolved** verdicts that still match the row’s current probe target (`fixed` → `remoteUrl`, `options` → first published endpoint). Unprobed rows, DCR/CIMD servers, `no_metadata`/`unreachable`, tenant rows, and stale verdicts after an endpoint move stay unbadged. Connect flow is unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 570aeba146d7167b1cbada3fb0a1351978fd5336. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Shows a “Requires pre-registered client” badge on directory cards and the detail dialog when the nightly OAuth probe resolves and reports neither DCR nor CIMD. Previously the probe verdict was not surfaced; now users see a warning before attempting to connect.

- The badge renders only for `resolved` probe outcomes and only when the verdict is about the row’s current endpoint. The check mirrors the backend’s probe target: fixed → `remoteUrl`, options → first published endpoint; tenant rows never badge.
- Rows that support DCR or CIMD do not badge; unprobed, `no_metadata`, and `unreachable` outcomes do not badge.
- Adds `requiresPreregisteredClient` helper with unit tests and RegistryTab component tests; no changes to connect routing yet.

<sup>Written for commit 570aeba146d7167b1cbada3fb0a1351978fd5336. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/MCPJam/inspector/pull/4161?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

