### PR TITLE
Harness evals: stop requiring a pinned computer image

### DIFF
--- a/.changeset/harness-evals-unpinned-computer.md
+++ b/.changeset/harness-evals-unpinned-computer.md
@@ -1,0 +1,38 @@
+---
+"@mcpjam/inspector": patch
+---
+
+Harness evals: stop requiring a pinned computer image
+
+A harness eval run needs a machine per iteration, and until now the only
+machine it was allowed to use was a **custom pinned image**. On a deployment
+whose image builder is the inert `stub` — the default, because
+`COMPUTERS_ENV_BUILDER` is deliberately separate from `COMPUTERS_PROVIDER` and
+the E2B build API is still unverified — every image such a deployment can build
+boots a template the model broker then refuses to lease against. So harness
+evals had no working road at all, while chat harness turns worked fine on the
+same deployment by booting the personal computer's default template.
+
+An unpinned harness run now boots the **deployment-default template**: the same
+real image chat gets, still one fresh disposable box per iteration, still
+released after. What the old rule actually protected — never borrowing the
+acting member's personal computer, which is shared and stateful — is preserved
+by always provisioning a box, not by demanding an image. (Requires the backend
+counterpart; deploy that first.)
+
+**Closes a gap where that protection did not hold.** The two single-case
+surfaces never ran the harness gate at all, so a harness host there passed
+admission, booted no box (both provisioning sites require a run), and fell
+through to `resolveHarnessSandbox` — the personal computer, the one fallback
+eval execution must never take. Single-case runs now refuse a harness host and
+say to run the case as part of a suite.
+
+The `bash`-without-a-computer refusal stays exactly as it is for **emulated**
+runs, which still boot nothing. A harness run is exempt because its premise —
+"there will be no computer" — is simply false for it.
+
+Which iterations get a box is now `needsEphemeralEvalSandbox`, its own module
+with its own tests. As an inline condition it could only be exercised by
+driving a whole iteration, which is how the harness half of the rule went
+missing: a harness run that boots no box does not fail loudly, it quietly runs
+on someone's personal computer.

--- a/mcpjam-inspector/server/routes/shared/evals.ts
+++ b/mcpjam-inspector/server/routes/shared/evals.ts
@@ -2166,19 +2166,16 @@ export async function prepareEvalRun(
       model?: string;
       provider?: string;
     }>,
-    // Read off the RUN's frozen environment — the same value the runner itself
-    // uses to decide whether to provision a box — rather than off the live
-    // environment row, so the gate judges what will actually execute.
-    // Explicitly `null` when absent: here that is a resolved fact, not
-    // "not looked up".
-    pinnedComputerImageId:
-      (config.environment as { computerEnvironmentId?: string } | undefined)
-        ?.computerEnvironmentId ?? null,
     widgetAssertingCaseTitles: casesAssertingWidgetRender(config.tests),
     // Explicitly `null` when the suite is org-level. `runHarnessTurn` needs a
     // project to resolve the box and throws without one — mid-iteration, after
     // the box was booted and paid for. This makes it a pre-flight refusal.
     projectId: projectIdForOrgConfig ?? null,
+    // NO pinned image is passed, and none is required: a harness run boots a
+    // box either way — the run's frozen image when it pins one, the
+    // deployment-default template when it doesn't. What it must never do is
+    // borrow the acting member's personal computer, and that is prevented by
+    // always provisioning, not by demanding an image.
   });
   if (!harnessAdmission.ok) {
     await failRunBeforeExecution(convexClient, recorder, runId, {

--- a/mcpjam-inspector/server/routes/v1/evals.ts
+++ b/mcpjam-inspector/server/routes/v1/evals.ts
@@ -2876,12 +2876,6 @@ evals.post("/projects/:projectId/eval-run-groups", async (c) => {
     const admission = checkEvalHarnessStaticAdmission({
       hostConfig,
       serverIds: servers.serverIds,
-      // RESOLVED, not omitted: the dry run above already resolved this
-      // target's environment, so the pin is a fact we hold. `null` is the
-      // honest answer for a target with no environment at all — there is
-      // nowhere for a pin to live — and a harness needs one either way.
-      pinnedComputerImageId:
-        servers.environmentLaunch?.computerEnvironmentId ?? null,
     });
     if (!admission.ok) {
       throw new WebRouteError(

--- a/mcpjam-inspector/server/services/evals-runner.ts
+++ b/mcpjam-inspector/server/services/evals-runner.ts
@@ -6,6 +6,7 @@ import {
   type UsageTotals,
 } from "./evals/types";
 import { buildEvalIterationVerdict } from "./evals/iteration-verdict";
+import { needsEphemeralEvalSandbox } from "./evals/needs-ephemeral-sandbox";
 import { createStepExecutionState, executeSteps } from "./evals/step-executor";
 import {
   buildLocalStepHandlers,
@@ -3535,10 +3536,18 @@ const runHostedIterationWithBrowser = async (
     const pinnedEnvironmentId = (
       environment as { computerEnvironmentId?: string } | undefined
     )?.computerEnvironmentId;
-    if (pinnedEnvironmentId && runId !== null) {
+    if (
+      needsEphemeralEvalSandbox({
+        pinnedEnvironmentId,
+        harness: resolvedExecution.harness,
+        runId,
+      })
+    ) {
       if (!isComputersDataPlaneConfigured()) {
         throw new Error(
-          "This eval pins a reproducible computer environment, but this server isn't a computers data plane (deployed servers bootstrap credentials from INSPECTOR_SERVICE_TOKEN; see docs/project-computers.md) — it could provision a sandbox but not exec or release it."
+          pinnedEnvironmentId
+            ? "This eval pins a reproducible computer environment, but this server isn't a computers data plane (deployed servers bootstrap credentials from INSPECTOR_SERVICE_TOKEN; see docs/project-computers.md) — it could provision a sandbox but not exec or release it."
+            : "This eval runs on a harness, which boots a disposable computer per iteration, but this server isn't a computers data plane (deployed servers bootstrap credentials from INSPECTOR_SERVICE_TOKEN; see docs/project-computers.md) — it could provision a sandbox but not exec or release it."
         );
       }
       evalSandbox = await provisionEvalSandbox({

--- a/mcpjam-inspector/server/services/evals/__tests__/harness-admission.test.ts
+++ b/mcpjam-inspector/server/services/evals/__tests__/harness-admission.test.ts
@@ -71,19 +71,20 @@ describe("checkEvalHarnessAdmission", () => {
     });
   });
 
-  it("REFUSES a harness host with no pinned computer, rather than borrowing one", () => {
-    // Falling back to the acting member's personal computer would carry state
-    // between iterations — the opposite of what a per-iteration box is for.
-    const verdict = checkEvalHarnessAdmission({
-      hostConfig: harnessHost(),
-      serverIds: ["s1"],
-      cases: [{ title: "a", ...HOSTED_MODEL }],
-    });
-    expect(verdict.ok).toBe(false);
-    if (verdict.ok) throw new Error("unreachable");
-    expect(verdict.harness).toBe("claude-code");
-    expect(verdict.reason).toContain("must pin a computer image");
-    expect(verdict.reason).toContain("no fallback to your personal computer");
+  it("ADMITS a harness host with no pinned computer — it boots the default image", () => {
+    // Requiring a pinned image left harness evals with no working road on a
+    // deployment whose image builder is the inert `stub`: the only permitted
+    // road was a custom image, and every image such a deployment can build
+    // boots a template the model broker then refuses to lease against. An
+    // unpinned run boots the deployment-default template instead — still a
+    // fresh disposable box per iteration, still never the personal computer.
+    expect(
+      checkEvalHarnessAdmission({
+        hostConfig: harnessHost(),
+        serverIds: ["s1"],
+        cases: [{ title: "a", ...HOSTED_MODEL }],
+      })
+    ).toEqual({ ok: true, harness: "claude-code" });
   });
 
   it("REFUSES cases asserting something a harness run cannot observe", () => {
@@ -94,7 +95,6 @@ describe("checkEvalHarnessAdmission", () => {
       hostConfig: harnessHost(),
       serverIds: ["s1"],
       cases: [{ title: "a", ...HOSTED_MODEL }],
-      pinnedComputerImageId: "img-1",
       widgetAssertingCaseTitles: ["renders the card"],
     });
     expect(verdict.ok).toBe(false);
@@ -114,7 +114,6 @@ describe("checkEvalHarnessAdmission", () => {
       // A pinned computer clears the last admission rule, so an ineligible
       // model must still fail — it routes through the direct engine, which
       // never forwards a harness.
-      pinnedComputerImageId: "img-1",
     });
     expect(verdict.ok).toBe(false);
     if (verdict.ok) throw new Error("unreachable");
@@ -131,7 +130,6 @@ describe("checkEvalHarnessAdmission", () => {
         { title: "one", ...HOSTED_MODEL },
         { title: "two", ...HOSTED_MODEL },
       ],
-      pinnedComputerImageId: "img-1",
     });
     expect(verdict.ok).toBe(false);
     if (verdict.ok) throw new Error("unreachable");
@@ -147,18 +145,16 @@ describe("checkEvalHarnessAdmission", () => {
       hostConfig: harnessHost(),
       serverIds: ["s1"],
       cases: [{ title: "probe", model: "widget-probe", provider: "none" }],
-      pinnedComputerImageId: "img-1",
     });
     expect(verdict).toEqual({ ok: true, harness: "claude-code" });
   });
 
-  it("admits an eligible harness host with a pinned computer", () => {
+  it("admits an eligible harness host", () => {
     expect(
       checkEvalHarnessAdmission({
         hostConfig: harnessHost(),
         serverIds: ["s1"],
         cases: [{ title: "a", ...HOSTED_MODEL }],
-        pinnedComputerImageId: "img-1",
       })
     ).toEqual({ ok: true, harness: "claude-code" });
   });
@@ -169,7 +165,6 @@ describe("checkEvalHarnessAdmission", () => {
       hostConfig: harnessHost(),
       serverIds: ["s1"],
       cases: [{ title: "a", ...HOSTED_MODEL }],
-      pinnedComputerImageId: "img-1",
     });
     expect(verdict.ok).toBe(false);
     if (verdict.ok) throw new Error("unreachable");
@@ -184,7 +179,6 @@ describe("checkEvalHarnessAdmission", () => {
       hostConfig: { harness: "codex" },
       serverIds: ["s1"],
       cases: [{ title: "a", model: "openai/gpt-5", provider: "openai" }],
-      pinnedComputerImageId: "img-1",
     });
     expect(verdict.ok).toBe(false);
     if (verdict.ok) throw new Error("unreachable");
@@ -193,28 +187,17 @@ describe("checkEvalHarnessAdmission", () => {
 });
 
 describe("checkEvalHarnessStaticAdmission", () => {
-  it("does NOT refuse over a pin it was never given — the batch dry run has none", () => {
+  it("never consults a pinned image — the batch dry run has none to give", () => {
     // The group route validates targets before any environment resolution, so
-    // an omitted pin means "not looked up". Refusing here would reject every
-    // harness target in a fan-out for a fact nobody had checked.
+    // it could only ever pass "not looked up". Now nothing asks: a harness run
+    // boots a box with or without a pinned image, so the fan-out's dry run has
+    // one less fact to hold and one less way to refuse a target wrongly.
     expect(
       checkEvalHarnessStaticAdmission({
         hostConfig: harnessHost(),
         serverIds: ["s1"],
       })
     ).toEqual({ ok: true, harness: "claude-code" });
-  });
-
-  it("DOES refuse an explicitly absent pin", () => {
-    // `null` is a resolved absence, which is a different claim from omission.
-    const verdict = checkEvalHarnessStaticAdmission({
-      hostConfig: harnessHost(),
-      serverIds: ["s1"],
-      pinnedComputerImageId: null,
-    });
-    expect(verdict.ok).toBe(false);
-    if (verdict.ok) throw new Error("unreachable");
-    expect(verdict.reason).toContain("must pin a computer image");
   });
 
   it("decides host-level rules with no cases at all — what batch dry-run needs", () => {
@@ -228,7 +211,6 @@ describe("checkEvalHarnessStaticAdmission", () => {
     const approvalHost = checkEvalHarnessStaticAdmission({
       hostConfig: harnessHost({ requireToolApproval: true }),
       serverIds: ["s1"],
-      pinnedComputerImageId: "img-1",
     });
     expect(approvalHost.ok).toBe(false);
   });
@@ -239,7 +221,6 @@ describe("checkEvalHarnessStaticAdmission", () => {
     const verdict = checkEvalHarnessStaticAdmission({
       hostConfig: harnessHost(),
       serverIds: ["s1"],
-      pinnedComputerImageId: "img-1",
     });
     expect(verdict).toEqual({ ok: true, harness: "claude-code" });
   });
@@ -248,7 +229,6 @@ describe("checkEvalHarnessStaticAdmission", () => {
     const verdict = checkEvalHarnessStaticAdmission({
       hostConfig: harnessHost({ modelId: "ollama/llama3" }),
       serverIds: ["s1"],
-      pinnedComputerImageId: "img-1",
     });
     expect(verdict.ok).toBe(false);
     if (verdict.ok) throw new Error("unreachable");
@@ -262,7 +242,6 @@ describe("checkEvalHarnessStaticAdmission", () => {
       hostConfig: { harness: "codex" },
       serverIds: [],
       pluginServerIds: ["plugin-server-1"],
-      pinnedComputerImageId: "img-1",
     });
     expect(verdict.ok).toBe(false);
     if (verdict.ok) throw new Error("unreachable");
@@ -294,7 +273,6 @@ describe("checkEvalHarnessAdmission — org-level suites", () => {
     hostConfig: harnessHost(),
     serverIds: ["srv-1"],
     cases: [HOSTED_MODEL],
-    pinnedComputerImageId: "env-1",
   };
 
   it("refuses a harness run with no resolved project", () => {
@@ -304,12 +282,12 @@ describe("checkEvalHarnessAdmission — org-level suites", () => {
     expect(verdict.reason).toContain("organization");
   });
 
-  it("names the missing PROJECT, not the pinned image, when both are absent", () => {
-    // An org-level suite has neither. "Pin a computer image" would send the
-    // author to a setting that cannot fix a run with no project to pin it on.
+  it("names the missing PROJECT — the one thing that still cannot be defaulted", () => {
+    // An image can be defaulted; a project cannot. There is nothing to bill or
+    // provision against, so this stays a refusal — and it must not send the
+    // author to a computer-image setting that cannot fix it.
     const verdict = checkEvalHarnessAdmission({
       ...args,
-      pinnedComputerImageId: null,
       projectId: null,
     });
     expect(verdict.ok).toBe(false);
@@ -339,7 +317,6 @@ describe("checkEvalHarnessAdmission — the pinned model must be canonical", () 
   const args = {
     hostConfig: harnessHost(),
     serverIds: ["srv-1"],
-    pinnedComputerImageId: "env-1",
     projectId: "proj-1",
   };
   // Same model as HOSTED_MODEL, written the short way — which is what the
@@ -388,7 +365,6 @@ describe("checkEvalHarnessAdmission — the pinned model must be canonical", () 
       checkEvalHarnessAdmission({
         hostConfig: { hostStyle: "mcpjam" },
         cases: [{ title: "a", ...SHORT }],
-        pinnedComputerImageId: null,
       }).ok
     ).toBe(true);
   });
@@ -432,7 +408,6 @@ describe("checkEvalExecutionAdmission", () => {
       checkEvalHarnessAdmission({
         hostConfig: emulated,
         cases: [HOSTED_MODEL],
-        pinnedComputerImageId: null,
       }).ok
     ).toBe(true);
     expect(
@@ -505,6 +480,54 @@ describe("checkEvalExecutionAdmission", () => {
         surface: "single-case",
       }).ok
     ).toBe(true);
+  });
+
+  it("REFUSES a harness on the single-case surface, whatever tools it grants", () => {
+    // The gap this closes: a single-case run boots no box, so `runHarnessTurn`
+    // would fall through to `resolveHarnessSandbox` — the acting member's
+    // PERSONAL computer. That is the one fallback eval execution must never
+    // take, and it was reachable here because this surface never ran the
+    // harness gate at all.
+    for (const hostConfig of [
+      { harness: "claude-code" },
+      { harness: "claude-code", builtInToolIds: [] },
+      { harness: "claude-code", builtInToolIds: ["bash"] },
+    ]) {
+      const verdict = checkEvalExecutionAdmission({
+        hostConfig,
+        pinnedComputerImageId: "env-1",
+        surface: "single-case",
+      });
+      expect(verdict.ok).toBe(false);
+      if (verdict.ok) throw new Error("unreachable");
+      expect(verdict.reason).toContain("as part of a suite");
+      expect(verdict.reason).toContain("personal computer");
+    }
+  });
+
+  it("ADMITS a bash-granting HARNESS host with no image — it boots its own box", () => {
+    // The rule's premise ("there will be no computer") is false for a harness
+    // run: it provisions a disposable box whether or not an image is pinned.
+    // Refusing here would re-impose the pinned-image requirement through the
+    // back door, for exactly the hosts most likely to want a shell.
+    expect(
+      checkEvalExecutionAdmission({
+        hostConfig: { harness: "claude-code", builtInToolIds: ["bash"] },
+        pinnedComputerImageId: null,
+      }).ok
+    ).toBe(true);
+  });
+
+  it("keeps refusing an EMULATED bash host with no image", () => {
+    // The exemption above is scoped to harness runs only — an emulated run
+    // still boots nothing, so the silent-missing-shell failure it prevents is
+    // still live for the much larger emulated population.
+    expect(
+      checkEvalExecutionAdmission({
+        hostConfig: { harness: "not-a-harness", builtInToolIds: ["bash"] },
+        pinnedComputerImageId: null,
+      }).ok
+    ).toBe(false);
   });
 
   it("leaves the suite surface unchanged — an image still admits it", () => {

--- a/mcpjam-inspector/server/services/evals/__tests__/needs-ephemeral-sandbox.test.ts
+++ b/mcpjam-inspector/server/services/evals/__tests__/needs-ephemeral-sandbox.test.ts
@@ -1,0 +1,67 @@
+import { describe, expect, it } from "vitest";
+
+import { needsEphemeralEvalSandbox } from "../needs-ephemeral-sandbox";
+
+/**
+ * Which iterations get a disposable box booted for them.
+ *
+ * Extracted from the runner so the rule can be exercised directly: as an inline
+ * condition the only way to test it was to drive a whole iteration, which is
+ * why the harness half of it was missing for so long. A harness run that boots
+ * NO box does not fail — it silently runs on the acting member's personal
+ * computer, because that is `runHarnessTurn`'s fallback when no sandbox binding
+ * is supplied.
+ */
+describe("needsEphemeralEvalSandbox", () => {
+  const RUN = "run-1";
+
+  it("boots for a pinned environment, harness or not", () => {
+    expect(
+      needsEphemeralEvalSandbox({ pinnedEnvironmentId: "env-1", runId: RUN })
+    ).toBe(true);
+    expect(
+      needsEphemeralEvalSandbox({
+        pinnedEnvironmentId: "env-1",
+        harness: "claude-code",
+        runId: RUN,
+      })
+    ).toBe(true);
+  });
+
+  it("boots for a HARNESS run with no pinned environment", () => {
+    // The case this function exists for. Before it, the runner keyed only on a
+    // pinned image, so an unpinned harness run emitted no `harnessSandboxBinding`
+    // and took the personal-computer path.
+    expect(
+      needsEphemeralEvalSandbox({ harness: "claude-code", runId: RUN })
+    ).toBe(true);
+  });
+
+  it("boots NOTHING for an emulated run with no pinned environment", () => {
+    // Unchanged, and deliberately so: booting a box here would start spending
+    // for the entire emulated population, which needs no machine.
+    expect(needsEphemeralEvalSandbox({ runId: RUN })).toBe(false);
+    expect(
+      needsEphemeralEvalSandbox({
+        pinnedEnvironmentId: undefined,
+        harness: undefined,
+        runId: RUN,
+      })
+    ).toBe(false);
+  });
+
+  it("boots nothing without a run — the single-case surface", () => {
+    // Both provisioning sites require a run id, so a single-case run can never
+    // get a box; the admission gate refuses a harness there rather than letting
+    // it reach the personal-computer fallback.
+    for (const runId of [null, undefined]) {
+      expect(
+        needsEphemeralEvalSandbox({
+          pinnedEnvironmentId: "env-1",
+          harness: "claude-code",
+          runId,
+        })
+      ).toBe(false);
+    }
+  });
+});

--- a/mcpjam-inspector/server/services/evals/harness-admission.ts
+++ b/mcpjam-inspector/server/services/evals/harness-admission.ts
@@ -86,22 +86,25 @@ export function harnessOfHostConfig(
 }
 
 /**
- * A harness eval iteration runs on ONE disposable box, and that box comes from
- * the environment's pinned computer image.
+ * A harness eval iteration runs on ONE disposable box — and a SUITE RUN is the
+ * only surface that boots one.
  *
- * REQUIRED, with no fallback to the acting member's personal computer. Falling
- * back would make eval runs stateful across runs — the point of a per-iteration
- * box is that every iteration starts from the same frozen image — and it would
- * quietly put a shared computer to work for a run nobody pointed at it.
+ * A single-case run passes `runId: null`, and both provisioning sites require a
+ * run, so no box is ever booted for it. Without one, `runHarnessTurn` falls
+ * through to `resolveHarnessSandbox` and runs on the acting member's PERSONAL
+ * computer — stateful, shared, and belonging to a person rather than to the run.
+ * That fallback is exactly what eval execution must never take, so the surface
+ * is refused instead. Pinning an image would not help: the surface itself is
+ * the constraint.
  */
-function harnessNeedsPinnedComputerReason(harness: Harness): string {
+function harnessNeedsSuiteRunReason(harness: Harness): string {
   const name = getHarnessAdapter(harness).displayName;
   return (
-    `the ${name} harness runs each eval iteration on a fresh computer, so this ` +
-    "run's environment must pin a computer image — pin one on the environment " +
-    "(or attach an environment that does) and retry. There is deliberately no " +
-    "fallback to your personal computer: eval iterations are disposable, and " +
-    "reusing a shared box would carry state between them."
+    `the ${name} harness runs each eval iteration on a fresh, disposable ` +
+    "computer, and a single-case run never provisions one. Run this case as " +
+    "part of a suite. There is deliberately no fallback to your personal " +
+    "computer: it is shared and stateful, and a run nobody pointed at it " +
+    "must not put it to work."
   );
 }
 
@@ -191,16 +194,6 @@ export function checkEvalHarnessStaticAdmission(args: {
    *  COUNT: a host whose MCP servers come solely from a plugin would otherwise
    *  slip the approval gate this exists to close. */
   pluginServerIds?: readonly string[];
-  /**
-   * The environment's pinned computer image, when the caller knows it.
-   *
-   * OMITTED means "not resolved here", NOT "absent", so a caller that never
-   * looked cannot refuse a run over a fact it does not hold. An explicit
-   * `null` is a RESOLVED absence and does refuse — which is what both callers
-   * pass today: the batch route resolves each target's environment during its
-   * dry run, and the prepare path reads the run's frozen environment.
-   */
-  pinnedComputerImageId?: string | null;
 }): EvalHarnessAdmission {
   const harness = harnessOfHostConfig(args.hostConfig);
   if (!harness) return { ok: true };
@@ -240,25 +233,11 @@ export function checkEvalHarnessStaticAdmission(args: {
     // empty probe id and not about anything the caller configured. Suppress it
     // here; the full check re-runs the same gate with real case models.
     if (!hostModelId && isModelKind(availability.kind)) {
-      return staticVerdict(harness, args.pinnedComputerImageId);
+      return { ok: true, harness };
     }
     return { ok: false, harness, reason: availability.reason };
   }
-  return staticVerdict(harness, args.pinnedComputerImageId);
-}
-
-/**
- * The static half's verdict. A pin the caller did not look up is not evidence
- * of a missing pin, so `undefined` admits and leaves the decision to the full
- * check; an explicit `null` is a resolved absence and refuses here.
- */
-function staticVerdict(
-  harness: Harness,
-  pinnedComputerImageId: string | null | undefined
-): EvalHarnessAdmission {
-  return pinnedComputerImageId === undefined
-    ? { ok: true, harness }
-    : admitHarness(harness, { pinnedComputerImageId });
+  return { ok: true, harness };
 }
 
 /**
@@ -274,8 +253,6 @@ export function checkEvalHarnessAdmission(args: {
   pluginServerIds?: readonly string[];
   /** The run's snapshotted cases (the recorder's `config.tests`). */
   cases: ReadonlyArray<EvalHarnessCase>;
-  /** The environment's pinned computer image; `null`/absent means none. */
-  pinnedComputerImageId?: string | null;
   /**
    * Titles of cases asserting `widgetRendered`. A harness reaches MCP through
    * the signed proxy, so the inspector's widget manager never sees those calls.
@@ -409,21 +386,15 @@ export function checkEvalHarnessAdmission(args: {
       ...(args.pluginServerIds
         ? { pluginServerIds: args.pluginServerIds }
         : {}),
-      // Explicitly `null` when absent: the FULL check has resolved the run's
-      // environment, so "no pin" here is a fact rather than "not looked up".
-      pinnedComputerImageId: args.pinnedComputerImageId ?? null,
     });
     if (!staticOnly.ok) return staticOnly;
   }
 
   return admitHarness(harness, {
-    pinnedComputerImageId: args.pinnedComputerImageId ?? null,
-    // Passed THROUGH, not coerced to null like the image above. The two are
-    // not symmetric: every caller of this check has resolved the run's
-    // environment (so "no pin" is a fact), but a caller may legitimately not
-    // know the project, and refusing over a fact we do not hold is the same
-    // mistake as admitting over one we do. The route passes an explicit `null`
-    // for an org-level suite, which is what refuses.
+    // Passed THROUGH, never coerced: a caller may legitimately not know the
+    // project, and refusing over a fact we do not hold is the same mistake as
+    // admitting over one we do. The route passes an explicit `null` for an
+    // org-level suite, which is what refuses.
     ...(args.projectId !== undefined ? { projectId: args.projectId } : {}),
     ...(args.widgetAssertingCaseTitles
       ? { widgetAssertingCaseTitles: args.widgetAssertingCaseTitles }
@@ -467,9 +438,12 @@ const COMPUTER_BACKED_BUILT_IN_TOOL_IDS: ReadonlySet<string> = new Set([
  * NOT part of the harness checks. `checkEvalHarnessAdmission` and its static
  * half both return `{ ok: true }` on their first line when no harness is
  * selected, so a rule placed there would never fire for an emulated run — and
- * emulated runs are precisely the ones this is about. (A harness run reaches
- * the same conclusion by a different route: `admitHarness` already requires a
- * pinned image outright.)
+ * emulated runs are precisely the ones this is about.
+ *
+ * A HARNESS run is exempt on the run surface: it provisions its own disposable
+ * box whether or not an image is pinned, so the premise of the rule ("there
+ * will be no computer") is simply false for it. It is refused on the
+ * single-case surface instead, where no box is booted at all.
  */
 export function checkEvalExecutionAdmission(args: {
   hostConfig: Record<string, unknown> | null | undefined;
@@ -498,11 +472,23 @@ export function checkEvalExecutionAdmission(args: {
    */
   surface?: "run" | "single-case";
 }): { ok: true } | { ok: false; reason: string } {
+  const singleCase = args.surface === "single-case";
+  const harness = harnessOfHostConfig(args.hostConfig);
+
+  // Checked BEFORE the built-in tool rule, and regardless of it: a harness on
+  // this surface would run on the acting member's personal computer no matter
+  // which tools the host grants.
+  if (singleCase && harness) {
+    return { ok: false, reason: harnessNeedsSuiteRunReason(harness) };
+  }
+
   const ids = args.hostConfig?.builtInToolIds;
   if (!Array.isArray(ids) || ids.length === 0) return { ok: true };
-  const singleCase = args.surface === "single-case";
-  // A pinned image only helps the surface that can actually boot from it.
-  if (!singleCase && args.pinnedComputerImageId) return { ok: true };
+  // A pinned image only helps the surface that can actually boot from it — and
+  // a harness run boots a box with or without one.
+  if (!singleCase && (args.pinnedComputerImageId || harness)) {
+    return { ok: true };
+  }
 
   const offending = ids.filter(
     (id): id is string =>
@@ -556,13 +542,21 @@ function isModelKind(kind: HarnessUnavailableKind): boolean {
 
 /**
  * The last two rules, applied after every shared-gate rule has passed: the run
- * needs a pinned computer image, and none of its cases may assert something a
- * harness run cannot observe.
+ * needs a project to provision and bill against, and none of its cases may
+ * assert something a harness run cannot observe.
+ *
+ * A pinned computer image is deliberately NOT among them. It used to be
+ * required outright, which on a deployment whose image builder is the inert
+ * `stub` left harness evals with no working road at all — the only permitted
+ * road was a custom image, and every image such a deployment can build boots a
+ * template the model broker then refuses to lease against. An unpinned run now
+ * boots the deployment-default template instead: still a fresh, disposable box
+ * per iteration, just not a custom one. The invariant that survives is the one
+ * that mattered — never the acting member's personal computer.
  */
 function admitHarness(
   harness: Harness,
   args: {
-    pinnedComputerImageId?: string | null;
     widgetAssertingCaseTitles?: readonly string[];
     /** `undefined` ⇒ the caller did not resolve one (the static half), so the
      *  rule is deferred to the full check rather than decided without evidence.
@@ -570,21 +564,11 @@ function admitHarness(
     projectId?: string | null;
   }
 ): EvalHarnessAdmission {
-  // Checked before the pinned-image rule: an org-level suite has neither, and
-  // "pin a computer image" would send the author to a setting that cannot fix
-  // a run with no project to pin it on.
   if (args.projectId === null) {
     return {
       ok: false,
       harness,
       reason: harnessNeedsProjectReason(harness),
-    };
-  }
-  if (!args.pinnedComputerImageId) {
-    return {
-      ok: false,
-      harness,
-      reason: harnessNeedsPinnedComputerReason(harness),
     };
   }
   const widgetCases = args.widgetAssertingCaseTitles ?? [];

--- a/mcpjam-inspector/server/services/evals/needs-ephemeral-sandbox.ts
+++ b/mcpjam-inspector/server/services/evals/needs-ephemeral-sandbox.ts
@@ -1,0 +1,37 @@
+/**
+ * Does this eval iteration need a disposable box booted for it?
+ *
+ * Its own module, not an inline condition in the runner, because the rule is
+ * load-bearing and was previously untestable without driving a whole iteration
+ * — which is how the harness half of it went missing.
+ */
+
+/**
+ * TWO reasons an iteration needs a box, not one:
+ *
+ *   - the run PINS a computer image — the box IS the reproducible environment
+ *     the author asked for, and `bash` is exposed from it;
+ *   - the run executes on a HARNESS — the harness needs a machine to be, and
+ *     the only alternative `runHarnessTurn` has is `resolveHarnessSandbox`,
+ *     i.e. the acting member's PERSONAL computer. Booting our own is what keeps
+ *     eval execution off a shared, stateful box, so this must not be
+ *     conditional on an image: an unpinned harness run simply gets the
+ *     deployment-default template. The control plane resolves which image that
+ *     is, so the provision call still names no template.
+ *
+ * A harness run that boots no box does not fail loudly — it silently runs on
+ * someone's personal computer. That is why the harness arm is here rather than
+ * left to a later "did we get a binding?" check.
+ *
+ * `runId` absent is the SINGLE-CASE surface, which never provisions (both
+ * provisioning sites require a run). Admission refuses a harness there rather
+ * than letting it reach the personal-computer fallback with no box.
+ */
+export function needsEphemeralEvalSandbox(args: {
+  pinnedEnvironmentId?: string | undefined;
+  harness?: string | undefined;
+  runId: unknown;
+}): boolean {
+  if (args.runId === null || args.runId === undefined) return false;
+  return Boolean(args.pinnedEnvironmentId) || Boolean(args.harness);
+}


### PR DESCRIPTION
## Why

You can already launch eval runs from agent surfaces — `mcpjam eval run`, the `run_eval_suite` MCP tool, the in-app agent — with the full combination matrix (#4124 landed fan-out, run groups, compose, and the harness honesty gate). What you **cannot** do is get a real harness run to execute. Every one fails.

A harness eval iteration needs a machine, and the only machine it was allowed to use was a **custom pinned image**. But `COMPUTERS_ENV_BUILDER` defaults to the inert `stub` (deliberately separate from `COMPUTERS_PROVIDER` — the E2B build API is still unverified), so every image such a deployment can build boots a template the model broker refuses to lease against. The run dies on an opaque `Not authorized for this sandbox.` 403 **after** the box has started.

Meanwhile chat/Playground harness turns work fine on the same deployment: they run on the acting member's personal computer, which boots the deployment-default template with **no image at all**. Harness evals were the only path forced down the one road that isn't paved.

## What changes

An unpinned harness run boots the **deployment-default template** — the same real image chat gets. Still one fresh disposable box per iteration, still released after.

What the old rule actually protected is preserved: eval execution must **never** borrow the acting member's personal computer, which is shared and stateful. That is guaranteed by always **provisioning** a box, not by demanding an image.

## It also closes a gap where that protection did not hold

The two single-case surfaces (`routes/shared/evals.ts`) never called the harness gate at all. A harness host there passed admission, booted no box — both provisioning sites require a run id — and fell through to `resolveHarnessSandbox`: the personal computer, the exact fallback the removed rule existed to forbid. Single-case runs now refuse a harness host and point at running the case as part of a suite.

## What is deliberately unchanged

The `bash`-without-a-computer refusal still applies in full to **emulated** runs, which boot nothing and would otherwise execute with the shell silently absent (a suite that didn't need it reports green for a host configuration that never existed). A harness run is exempt because the rule's premise — "there will be no computer" — is false for it. Without that exemption the pinned-image requirement would return through the back door, for exactly the hosts most likely to want a shell.

## `needsEphemeralEvalSandbox`

Which iterations get a box is now its own module with its own tests. As an inline condition it could only be exercised by driving a whole iteration — which is how the harness half of the rule went missing in the first place: **a harness run that boots no box does not fail loudly, it quietly runs on someone's personal computer.**

## Tests

`harness-admission.test.ts` (41): the pinned-image refusal flips to an admission; the static half no longer consults a pin at all; the project rule still refuses an org-level suite and still doesn't send the author to a computer-image setting. New: a harness refused on the single-case surface whatever tools it grants (asserting both "as part of a suite" and "personal computer"), a bash-granting harness host admitted with no image, and an emulated bash host still refused.

`needs-ephemeral-sandbox.test.ts` (new): pinned × harness × `runId` matrix.

Full server suite: **416 files / 6430 tests passing.** The one failure, `sdk-coverage > covers every route exactly once` (readiness-runs routes lacking SDK client methods), **reproduces unchanged on `mcpjam/main`** — pre-existing, unrelated.

## Deploy order

**Backend deploys FIRST**: MCPJam/mcpjam-backend#1062. Until it does, an unpinned harness run is admitted here and then fails at provision with the backend's existing refusal — a recorded failed iteration, never a stranded run. New backend + old inspector is also safe (the old inspector simply keeps refusing unpinned runs), so the two can land in either order as long as the backend **deploys** first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes which evals get a disposable computer and tightens the personal-computer isolation invariant. Wrong admission or provisioning would either spend on extra sandboxes or run harness evals on a shared member machine.
> 
> **Overview**
> Harness evals no longer require a pinned computer image. An unpinned suite run now provisions a fresh disposable box on the **deployment-default template** (same image chat uses), instead of being refused or silently falling back to the acting member’s personal computer.
> 
> Admission drops the pin check. The runner boots a sandbox when there is a pin **or** a harness and a `runId`, via extracted `needsEphemeralEvalSandbox`. Single-case surfaces still never provision, so a harness host is refused there (“run as part of a suite”). Emulated `bash` without an image still refuses; harness runs are exempt because they always boot a box.
> 
> Org-level suites still need a project. Backend counterpart should deploy first.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1e3cdfa58d35196b8663796a997ba18eb2034077. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Harness evals no longer require a pinned computer image. Unpinned harness runs now provision a fresh box from the deployment-default template, avoiding personal-computer fallback and fixing failures on deployments with `COMPUTERS_ENV_BUILDER=stub`.

- Removes pin checks from `checkEvalHarnessAdmission` and `checkEvalHarnessStaticAdmission`; harness runs are admitted regardless of image pin, but still require a project.
- Single-case runs with a harness are refused and directed to run as part of a suite (prevents falling back to the acting member’s personal computer).
- Runner now provisions when either a pinned environment is present or a harness is selected and a `runId` exists, via new `needsEphemeralEvalSandbox` module and tests.
- Keeps existing refusal for emulated hosts that grant `bash` without a computer; harness hosts are exempt because they provision their own box.

**Review and rollout**
- Focus review on `harness-admission.ts` (pin checks removed, single-case behavior), `evals-runner.ts` (provisioning decision now delegates to `needs-ephemeral-sandbox.ts`), and routes that stop passing a pin.
- Deploy backend counterpart first; until then, admitted unpinned harness runs will fail at provision but will not strand runs.

<sup>Written for commit 1e3cdfa58d35196b8663796a997ba18eb2034077. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/MCPJam/inspector/pull/4162?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

