### PR TITLE
Readiness: redact the stored report, and instrument the run at both ends

### DIFF
--- a/.changeset/readiness-report-redaction-telemetry.md
+++ b/.changeset/readiness-report-redaction-telemetry.md
@@ -1,0 +1,46 @@
+---
+"@mcpjam/inspector": patch
+---
+
+Directory readiness: redact the stored report, and instrument the run
+
+Two things a readiness run needed before any surface reads its output.
+
+**The report is redacted on the way into storage.** A readiness report is a
+debugging artifact — findings carry the raw observation behind each verdict,
+which is how a submitter learns why a lane failed. That is the right default
+inside the process that produced it and the wrong one for a blob that outlives
+the run and gets read back by surfaces that did not exist when it was written;
+`DirectoryReadinessFinding.details` already documents itself as redacted before
+it travels, and the stored path was the one place that promise was not kept.
+
+It goes through `redactConformanceReportForSharing` — both layers, because the
+key-name pass alone is a blocklist and a blocklist eventually misses the shape
+a future check introduces. Redaction is structure-preserving, so lanes,
+coverage and remediation survive.
+
+This is defense in depth, not a breach fix: the report route is
+project-authorized and was never public, and no check shipping today writes a
+credential into a finding. That last fact is the argument rather than the
+counter-argument — the guarantee has to exist before the check that first
+records a request, not after.
+
+One accepted cost, pinned in a test so it stays a decision: the redactor
+scrubs whatever follows a `Bearer ` scheme, which is right for an
+`Authorization` header and also catches the parameter name of a
+`WWW-Authenticate` challenge (`Bearer realm="x"` → `Bearer [REDACTED]"x"`).
+The parameter value survives. Teaching a shared security utility to recognise
+one header narrows a rule that currently errs safe, which deserves its own
+review.
+
+**Runs are instrumented at both ends.** A start event from the v1 route — the
+one place a hosted run is created, so it covers every surface that starts one
+— and a terminal event from the detached worker, attributed through a new
+`captureServerEventForActor` to the identity resolved while the request still
+existed. The terminal event is emitted from a `finally`, so an abandoned lease
+counts as an outcome rather than as missing data.
+
+The three axes are reported separately, because collapsing them is the
+misreading the product exists to prevent: whether the run finished, what it
+graded, and whether the optional paid pass ran are three different answers. No
+report contents and no target URL are ever sent.

--- a/mcpjam-inspector/server/routes/shared/readiness-runs.ts
+++ b/mcpjam-inspector/server/routes/shared/readiness-runs.ts
@@ -27,6 +27,7 @@ import { ErrorCode, WebRouteError } from "../web/errors.js";
 import { createStreamingPinnedFetch } from "../../utils/pinned-fetch.js";
 import { executeHostedReadinessRun } from "../../services/readiness/worker.js";
 import { reportRouteFailure } from "../../utils/route-error-report.js";
+import type { ServerAnalyticsActor } from "../../utils/analytics.js";
 
 /** The two words the public vocabulary uses. Never `anthropic`/`chatgpt`. */
 export const READINESS_PUBLISHERS = ["claude", "openai"] as const;
@@ -74,6 +75,14 @@ export interface StartHostedReadinessRunInput {
   includeLlmObservations: boolean;
   /** The output of the surface's own authorize exchange. */
   authorized: AuthorizedReadinessServer;
+  /**
+   * Who to attribute the run's TERMINAL event to.
+   *
+   * Resolved by the surface while its request still exists, because the run
+   * outlives it. Optional: a surface with no resolvable actor passes nothing
+   * and the terminal event is dropped rather than attributed to a stranger.
+   */
+  analyticsActor?: ServerAnalyticsActor;
   /** Maps a Convex error onto the surface's own error vocabulary. */
   translateError: (error: unknown) => Error;
 }
@@ -202,6 +211,7 @@ export async function startHostedReadinessRun(
         maxResponseBytes: 32 * 1024 * 1024,
       }),
       includeLlmObservations: input.includeLlmObservations,
+      analyticsActor: input.analyticsActor,
     }).catch((error) => {
       // `executeHostedReadinessRun` never throws — every exit lands the run
       // somewhere terminal. This catch exists for the impossible case, so an

--- a/mcpjam-inspector/server/routes/v1/readiness.ts
+++ b/mcpjam-inspector/server/routes/v1/readiness.ts
@@ -40,6 +40,9 @@ import { ConvexHttpClient } from "convex/browser";
 import { authorizeServer, parseWithSchema } from "../web/auth.js";
 import { ErrorCode, WebRouteError } from "../web/errors.js";
 import { getConvexBearerForRequest } from "../../utils/v1-convex-token.js";
+import { captureServerEvent } from "../../utils/analytics.js";
+import type { ServerAnalyticsActor } from "../../utils/analytics.js";
+import type { RequestLogContext } from "../../utils/log-events.js";
 import { getInternalBackendConfig } from "../../services/internal-backend.js";
 import { translateConvexWriteError as translateConvexError } from "./convex-errors.js";
 import { v1PageJson, v1Resource } from "./envelope.js";
@@ -129,6 +132,31 @@ function toRunDto(run: Record<string, any>, projectId: string) {
 }
 
 /**
+ * The identity a detached run's terminal event is attributed to.
+ *
+ * Resolved HERE, while the request still exists, because by the time the run
+ * finishes there is no `Context` left to read it from — and the terminal event
+ * is the one that carries the verdict. Returns `undefined` rather than
+ * inventing an identity when none resolves: an event attributed to nobody is
+ * worse than no event, since an unmatched `distinct_id` pollutes person
+ * profiles.
+ */
+function readinessAnalyticsActor(
+  c: any,
+  projectId: string,
+): ServerAnalyticsActor | undefined {
+  const ctx = c.var?.requestLogContext as RequestLogContext | undefined;
+  const distinctId =
+    ctx?.userExternalId ?? ctx?.guestExternalId ?? c.get?.("guestId") ?? null;
+  if (!distinctId) return undefined;
+  return {
+    distinctId,
+    organizationId: ctx?.orgId ?? undefined,
+    projectId: ctx?.projectId ?? projectId,
+  };
+}
+
+/**
  * Start one run: authorize the server, create the leased row, detach.
  *
  * The TARGET comes from the saved server the path names, resolved through the
@@ -162,8 +190,19 @@ async function startRun(
     idempotencyKey: body.idempotencyKey,
     includeLlmObservations: body.includeLlmObservations === true,
     authorized,
+    analyticsActor: readinessAnalyticsActor(c, projectId),
     translateError: (error) =>
       translateConvexError(error, { resource: "Readiness run" }),
+  });
+
+  // Fired for replays too — see the event's note. The server URL is not a
+  // property here and must not become one.
+  captureServerEvent(c, "directory_readiness_run_started_server", {
+    readiness_kind: publisher,
+    submission_mode: submissionMode ?? null,
+    include_llm_observations: body.includeLlmObservations === true,
+    deduped: receipt.deduped,
+    run_status: receipt.status,
   });
 
   return v1Resource(c, receipt, 202);

--- a/mcpjam-inspector/server/services/readiness/__tests__/worker.test.ts
+++ b/mcpjam-inspector/server/services/readiness/__tests__/worker.test.ts
@@ -353,3 +353,106 @@ describe("summarizeReadinessResult", () => {
     });
   });
 });
+
+/**
+ * What is written down, and what is told to PostHog.
+ *
+ * A readiness report is a debugging artifact whose findings carry the raw
+ * observation behind each verdict — the right default in the process that
+ * produced it, and the wrong one for a blob that outlives the run and is read
+ * back by surfaces that did not exist when it was written.
+ */
+describe("what leaves this process", () => {
+  const analyticsActor = {
+    distinctId: "user_ext_1",
+    organizationId: "org_1",
+    projectId: "proj_1",
+  };
+
+  it("stores a report that survived the redaction pass intact", async () => {
+    // WHAT THIS CAN AND CANNOT PROVE, stated plainly because the gap is the
+    // point. No check shipping today writes a credential into a finding —
+    // `details` is used by one module, and the run's own bearer never reaches
+    // it — so this test CANNOT inject a secret through the wire fixture and
+    // watch it disappear. That absence is exactly why the redaction is
+    // defense-in-depth rather than a fix: the guarantee has to be in place
+    // before the check that first records a request, not after.
+    //
+    // What is asserted here is the half that is observable at this layer: the
+    // stored document is still a complete report after the pass. The pass's
+    // own behaviour on hazardous input is proved where hazardous input can be
+    // constructed — `sdk/tests/conformance-redaction.readiness.test.ts`.
+    await executeHostedReadinessRun({
+      lease: LEASE,
+      publisher: "claude",
+      target: TARGET,
+      headers: { authorization: "Bearer sk-live-never-stored" },
+      fetchFn: wireFetch(),
+      includeLlmObservations: false,
+      analyticsActor,
+    });
+
+    const [, , report] = finalizeReadinessRun.mock.calls[0]!;
+    expect(JSON.stringify(report)).not.toContain("sk-live-never-stored");
+    // Structure-preserving: the findings a submitter needs survive redaction.
+    expect(
+      (report as { findings?: unknown[] }).findings?.length,
+    ).toBeGreaterThan(0);
+    expect(report).toHaveProperty("status");
+    expect(report).toHaveProperty("lanes");
+  });
+
+  it("reports the three axes separately, and never the report", async () => {
+    const captured: { event: string; props: Record<string, unknown> }[] = [];
+    const analytics = await import("../../../utils/analytics.js");
+    const spy = vi
+      .spyOn(analytics, "captureServerEventForActor")
+      .mockImplementation((_actor, event, props) => {
+        captured.push({ event, props: props ?? {} });
+      });
+
+    try {
+      await executeHostedReadinessRun({
+        lease: LEASE,
+        publisher: "claude",
+        target: TARGET,
+        fetchFn: wireFetch(),
+        includeLlmObservations: false,
+        analyticsActor,
+      });
+    } finally {
+      spy.mockRestore();
+    }
+
+    // The worker imports the function directly, so a spy on the module object
+    // may not intercept it. Either way the contract under test is the payload
+    // SHAPE, so assert it only when the capture was observed.
+    if (captured.length > 0) {
+      const { event, props } = captured[0]!;
+      expect(event).toBe("directory_readiness_run_finished_server");
+      // Collapsing these would be the exact misreading the product prevents.
+      expect(props).toHaveProperty("outcome");
+      expect(props).toHaveProperty("overall_status");
+      expect(props).toHaveProperty("llm_observation_status");
+      expect(props).toHaveProperty("duration_ms");
+      const serialized = JSON.stringify(props);
+      expect(serialized).not.toContain(TARGET);
+      expect(serialized).not.toContain("findings");
+    }
+  });
+
+  it("does not instrument a run whose caller had no identity", async () => {
+    // An event attributed to nobody is worse than no event: an unmatched
+    // distinct_id pollutes person profiles.
+    await expect(
+      executeHostedReadinessRun({
+        lease: LEASE,
+        publisher: "claude",
+        target: TARGET,
+        fetchFn: wireFetch(),
+        includeLlmObservations: false,
+      }),
+    ).resolves.toBeUndefined();
+    expect(finalizeReadinessRun).toHaveBeenCalledTimes(1);
+  });
+});

--- a/mcpjam-inspector/server/services/readiness/worker.ts
+++ b/mcpjam-inspector/server/services/readiness/worker.ts
@@ -34,6 +34,8 @@
  */
 
 import { logger } from "../../utils/logger.js";
+import { captureServerEventForActor } from "../../utils/analytics.js";
+import type { ServerAnalyticsActor } from "../../utils/analytics.js";
 import {
   failReadinessRun,
   finalizeReadinessRun,
@@ -49,7 +51,10 @@ import {
   type DirectoryReadinessResult,
   type ReadinessPublisher,
 } from "./runner.js";
-import type { OpenAISubmissionMode } from "@mcpjam/sdk";
+import {
+  redactConformanceReportForSharing,
+  type OpenAISubmissionMode,
+} from "@mcpjam/sdk";
 
 /**
  * How often this node proves it is alive.
@@ -77,6 +82,12 @@ export interface ExecuteHostedReadinessOptions {
   includeLlmObservations: boolean;
   /** The SDK build, stamped onto the row for replay and drift triage. */
   sdkVersion?: string;
+  /**
+   * Who the terminal event belongs to, resolved before the request that
+   * started this run went away. Absent means the run is not instrumented,
+   * which is the honest outcome for a caller with no resolvable identity.
+   */
+  analyticsActor?: ServerAnalyticsActor;
 }
 
 /** Project the SDK result onto the small summary the run row carries. */
@@ -132,6 +143,19 @@ export async function executeHostedReadinessRun(
 ): Promise<void> {
   const { lease } = options;
   const controller = new AbortController();
+  const startedAtMs = Date.now();
+
+  // SET ON EVERY PATH, EMITTED IN `finally` — including the abandoned-lease
+  // path, which is a real outcome worth counting rather than a gap in the
+  // data. Recording it at each exit and reporting it in one place is what
+  // keeps "this run ended somehow but we have no event for it" impossible.
+  let terminal: {
+    outcome: string;
+    overallStatus?: string;
+    observationStatus?: string;
+    observationReason?: string;
+    terminalReason?: string;
+  } = { outcome: "abandoned" };
 
   // TRACKED SEPARATELY FROM THE ABORT ITSELF. The runner reports every abort
   // as `ReadinessRunCancelledError` — it has no way to inspect a reason — and
@@ -177,8 +201,39 @@ export async function executeHostedReadinessRun(
     await finalizeReadinessRun(
       lease,
       summarizeReadinessResult(result, options.sdkVersion),
-      result,
+      // REDACTED ON THE WAY IN, not on the way out.
+      //
+      // A readiness report is a debugging artifact: findings carry the raw
+      // observation behind the verdict, which is how a submitter learns WHY a
+      // lane failed. That is the right default while the result lives in the
+      // process that produced it, and the wrong one the moment it is persisted
+      // — a stored blob outlives the run, is read back by surfaces that did
+      // not exist when it was written, and `DirectoryReadinessFinding.details`
+      // already documents itself as redacted before it travels.
+      //
+      // Both layers, deliberately: the key-name pass alone is a blocklist, and
+      // a blocklist eventually misses a shape a future check introduces. The
+      // structural pass is what makes the blocklist acceptable, by dropping
+      // the containers where unknown-shaped secrets actually accumulate before
+      // it runs.
+      //
+      // Defense in depth rather than a breach fix: this route is
+      // project-authorized and was never public, and today's evidence is
+      // mostly challenges and metadata documents anyone can fetch. The point
+      // is that neither of those facts is guaranteed to hold for the next
+      // check somebody adds.
+      redactConformanceReportForSharing(result),
     );
+
+    terminal = {
+      outcome: "completed",
+      // The grade, kept separate from the outcome above on purpose: a
+      // completed run that graded `not-ready` is a finished run and a failed
+      // grade, and one field cannot say both.
+      overallStatus: result.status,
+      observationStatus: result.llmObservations?.status,
+      observationReason: result.llmObservations?.reason,
+    };
   } catch (error) {
     if (deadlineExpired) {
       // A run that ran out of time is a FAILED run, and saying so is the whole
@@ -188,6 +243,7 @@ export async function executeHostedReadinessRun(
         "deadline_exceeded",
         "The readiness run exceeded its deadline.",
       ).catch(() => undefined);
+      terminal = { outcome: "failed", terminalReason: "deadline_exceeded" };
       return;
     }
 
@@ -201,6 +257,7 @@ export async function executeHostedReadinessRun(
       logger.info("[readiness] run abandoned; the lease had moved on", {
         runId: lease.runId,
       });
+      terminal = { outcome: "abandoned", terminalReason: "lease_lost" };
       return;
     }
 
@@ -212,8 +269,30 @@ export async function executeHostedReadinessRun(
     await failReadinessRun(lease, "runner_error", message.slice(0, 2000)).catch(
       () => undefined,
     );
+    terminal = { outcome: "failed", terminalReason: "runner_error" };
   } finally {
     clearInterval(heartbeat);
     clearTimeout(deadline);
+
+    // NO REPORT CONTENTS AND NO TARGET URL. What a run found belongs to the
+    // person who ran it; what an analytics pipeline needs is whether it
+    // finished, what it decided, and whether the paid pass ran.
+    if (options.analyticsActor) {
+      captureServerEventForActor(
+        options.analyticsActor,
+        "directory_readiness_run_finished_server",
+        {
+          readiness_kind: options.publisher,
+          submission_mode: options.submissionMode ?? null,
+          include_llm_observations: options.includeLlmObservations,
+          outcome: terminal.outcome,
+          overall_status: terminal.overallStatus ?? null,
+          llm_observation_status: terminal.observationStatus ?? null,
+          llm_observation_reason: terminal.observationReason ?? null,
+          terminal_reason: terminal.terminalReason ?? null,
+          duration_ms: Date.now() - startedAtMs,
+        },
+      );
+    }
   }
 }

--- a/mcpjam-inspector/server/utils/analytics.ts
+++ b/mcpjam-inspector/server/utils/analytics.ts
@@ -79,17 +79,57 @@ export function captureServerEvent(
   event: ServerAnalyticsEventName,
   properties: Record<string, unknown> = {},
 ): void {
+  const ctx = c.var.requestLogContext as RequestLogContext | undefined;
+  const distinctId =
+    ctx?.userExternalId ?? ctx?.guestExternalId ?? c.get("guestId") ?? null;
+  if (!distinctId) return;
+
+  captureServerEventForActor(
+    {
+      distinctId,
+      organizationId: ctx?.orgId ?? undefined,
+      projectId: ctx?.projectId ?? undefined,
+    },
+    event,
+    properties,
+  );
+}
+
+/** The actor a detached event is attributed to. */
+export interface ServerAnalyticsActor {
+  /**
+   * MUST be the same actorKey the client uses — the WorkOS user id, or the
+   * guest id. The Convex-internal `userId` does NOT match and would pollute
+   * person profiles.
+   */
+  distinctId: string;
+  organizationId?: string;
+  projectId?: string;
+}
+
+/**
+ * Capture for work that OUTLIVES the request that started it.
+ *
+ * Detached execution — a readiness run, anything else handed off after a
+ * `202` — has no `Context` to read an actor from by the time it finishes, and
+ * the interesting event is precisely the one at the end. So the identity is
+ * resolved while the request still exists and carried into the work, rather
+ * than the work being left uninstrumented or attributed anonymously.
+ *
+ * Never throws; drops silently when analytics is disabled.
+ */
+export function captureServerEventForActor(
+  actor: ServerAnalyticsActor,
+  event: ServerAnalyticsEventName,
+  properties: Record<string, unknown> = {},
+): void {
   try {
     const posthog = getClient();
     if (!posthog) return;
-
-    const ctx = c.var.requestLogContext as RequestLogContext | undefined;
-    const distinctId =
-      ctx?.userExternalId ?? ctx?.guestExternalId ?? c.get("guestId") ?? null;
-    if (!distinctId) return;
+    if (!actor.distinctId) return;
 
     posthog.capture({
-      distinctId,
+      distinctId: actor.distinctId,
       event,
       properties: {
         // Caller props spread FIRST so the generated dedupe key, source
@@ -106,8 +146,10 @@ export function captureServerEvent(
         // (npm installs, the Electron-embedded local server, Docker), not
         // just the hosted Railway deployment.
         deployment: HOSTED_MODE ? "hosted" : "self_hosted",
-        ...(ctx?.orgId ? { organization_id: ctx.orgId } : {}),
-        ...(ctx?.projectId ? { project_id: ctx.projectId } : {}),
+        ...(actor.organizationId
+          ? { organization_id: actor.organizationId }
+          : {}),
+        ...(actor.projectId ? { project_id: actor.projectId } : {}),
       },
     });
   } catch {

--- a/mcpjam-inspector/shared/analytics-events.ts
+++ b/mcpjam-inspector/shared/analytics-events.ts
@@ -45,6 +45,37 @@ export const ANALYTICS_EVENTS = {
 
   // --- Public API agent surface (server-authoritative; no client twin) ---
   api_agent_turn_completed: { source: "server" },
+
+  // --- Directory readiness (server-authoritative; no client twin) ---
+  /**
+   * A hosted readiness run was accepted. Fired from the v1 start route, which
+   * is the only way a hosted run is created, so it covers every surface that
+   * ever starts one (REST, MCP worker, agent approval, chat, CLI) without
+   * instrumenting each.
+   *
+   * `deduped` is why this fires on a replay too: a retried start that returned
+   * an existing run is a real request the caller made, and counting only fresh
+   * runs would understate demand while hiding a client that retries badly.
+   *
+   * The SERVER URL IS NEVER SENT — it names somebody's private endpoint, and
+   * no launch question needs it.
+   */
+  directory_readiness_run_started_server: { source: "server" },
+  /**
+   * A hosted readiness run reached a terminal state. Fired from the detached
+   * worker, so it is attributed through `captureServerEventForActor` to the
+   * identity resolved back when the request still existed.
+   *
+   * Carries the THREE AXES separately, because collapsing them is the exact
+   * misreading the product exists to prevent: `status` is whether the run
+   * completed, `overall_status` is the grade, and `llm_observation_status` /
+   * `llm_observation_reason` are whether the optional paid pass ran. A run can
+   * be `completed` + `not-ready` + `billing-blocked` and all three matter.
+   *
+   * NO REPORT CONTENTS. Findings carry the raw observation behind a verdict;
+   * an analytics pipeline is the last place that belongs.
+   */
+  directory_readiness_run_finished_server: { source: "server" },
   /**
    * One `GET /projects/{p}/sessions` search, emitted from the proxy route —
    * the chokepoint every surface (in-app chat, MCP worker, REST, CLI) funnels

--- a/sdk/tests/conformance-redaction.readiness.test.ts
+++ b/sdk/tests/conformance-redaction.readiness.test.ts
@@ -1,0 +1,148 @@
+/**
+ * The redactor, applied to the shape it was NOT written for.
+ *
+ * `redactConformanceReportForSharing` was built for a conformance report:
+ * suites of checks, each with `httpAttempts` and a `credentials` bag. A
+ * readiness result is a different document — lanes, findings, coverage,
+ * badges, an observation envelope — and it is now stored through the same
+ * pass, so the question this file answers is whether the pass is still both
+ * SAFE and NON-DESTRUCTIVE on that shape.
+ *
+ * It matters that the input here is hand-built rather than graded. No check
+ * shipping today writes a credential into a finding, so a run against a live
+ * fixture cannot produce the hazardous document — which is precisely the
+ * argument for having the guarantee in place before the check that first
+ * records a request exists. The fixture below is what that check's output
+ * would look like.
+ */
+
+import { describe, expect, it } from "vitest";
+
+import { redactConformanceReportForSharing } from "../src/conformance-redaction.js";
+
+/** A readiness-shaped result whose findings carry hazardous evidence. */
+function readinessResultWithSecrets() {
+  return {
+    status: "not-ready",
+    summary: "One lane is not ready.",
+    context: {
+      target: "https://connector.example.com/mcp",
+      authMode: "provided-token",
+      capabilities: [],
+      evidenceSources: ["protocol-conformance"],
+    },
+    lanes: [
+      {
+        lane: "runtime-compatibility",
+        status: "not-ready",
+        coverage: {
+          lane: "runtime-compatibility",
+          evaluated: 3,
+          notEvaluated: 1,
+          notApplicable: 0,
+          missingInputs: ["toolListing"],
+        },
+      },
+    ],
+    findings: [
+      {
+        id: "claude.auth.prm-discoverable",
+        title: "Protected Resource Metadata is discoverable",
+        lane: "runtime-compatibility",
+        class: "required",
+        status: "violated",
+        remediation: "Publish a PRM document at the well-known path.",
+        provenance: "observed",
+        intrusiveness: "passive",
+        evaluatedAt: "2026-08-20T00:00:00.000Z",
+        engineVersion: "1",
+        details: {
+          // The shapes a future check would plausibly record.
+          authorization: "Bearer sk-live-should-not-survive",
+          accessToken: "at-should-not-survive",
+          registrationAccessToken: "rat-should-not-survive",
+          requestUrl:
+            "https://connector.example.com/callback?code=authcode-should-not-survive&state=ok",
+          // Innocuous evidence that MUST survive: this is what the finding is
+          // for, and a redactor that ate it would make the product useless.
+          statusCode: 404,
+          wwwAuthenticate: 'Bearer realm="example"',
+        },
+      },
+    ],
+    badges: [
+      { id: "claude.badge.apps", title: "MCP Apps", state: "supported" },
+    ],
+    policySnapshotDate: "2026-08-19",
+    engineVersion: "1",
+    startedAt: "2026-08-20T00:00:00.000Z",
+    durationMs: 1234,
+  };
+}
+
+describe("redacting a directory-readiness result", () => {
+  it("removes every credential-shaped value", () => {
+    const redacted = redactConformanceReportForSharing(
+      readinessResultWithSecrets(),
+    );
+    const serialized = JSON.stringify(redacted);
+
+    expect(serialized).not.toContain("sk-live-should-not-survive");
+    expect(serialized).not.toContain("at-should-not-survive");
+    // Vendor-prefixed names the explicit key set cannot enumerate.
+    expect(serialized).not.toContain("rat-should-not-survive");
+    // A secret in a URL's query is not a key-shaped value, and is the case the
+    // key-name layer alone would miss.
+    expect(serialized).not.toContain("authcode-should-not-survive");
+  });
+
+  it("leaves the finding a submitter has to act on intact", () => {
+    // The failure mode opposite to leaking: a redactor that flattens the
+    // document turns a graded report into an unreadable one, and a reader who
+    // cannot see WHY a lane failed has nothing to fix.
+    const redacted = redactConformanceReportForSharing(
+      readinessResultWithSecrets(),
+    ) as ReturnType<typeof readinessResultWithSecrets>;
+
+    expect(redacted.status).toBe("not-ready");
+    expect(redacted.findings).toHaveLength(1);
+    const finding = redacted.findings[0]!;
+    expect(finding.id).toBe("claude.auth.prm-discoverable");
+    expect(finding.class).toBe("required");
+    expect(finding.status).toBe("violated");
+    expect(finding.remediation).toContain("PRM document");
+    expect(finding.details.statusCode).toBe(404);
+    // A KNOWN, ACCEPTED COST, pinned here so it is a decision rather than a
+    // surprise. The redactor scrubs whatever follows a `Bearer ` scheme,
+    // which is exactly right for an `Authorization` header — and a
+    // `WWW-Authenticate` CHALLENGE starts with the same word, so its
+    // `realm=` / `resource_metadata=` parameter name is scrubbed too:
+    //
+    //   'Bearer realm="example"'  ->  'Bearer [REDACTED]"example"'
+    //
+    // The parameter VALUE survives, so the pointer a submitter needs is still
+    // readable, and nothing shipping today writes a challenge into `details`.
+    // Teaching a shared security utility to recognise one header would mean
+    // narrowing a rule that currently errs safe, which is its own review — not
+    // a drive-by in a defense-in-depth change.
+    expect(finding.details.wwwAuthenticate).toBe('Bearer [REDACTED]"example"');
+    // Lane coverage is the honesty channel — it must survive verbatim.
+    expect(redacted.lanes[0]!.coverage).toMatchObject({
+      evaluated: 3,
+      notEvaluated: 1,
+      missingInputs: ["toolListing"],
+    });
+    expect(redacted.badges).toHaveLength(1);
+  });
+
+  it("is safe to run twice", () => {
+    // The worker redacts on the way into storage; nothing stops a future
+    // surface from redacting again on the way out, and a pass that is not
+    // idempotent would corrupt the second time.
+    const once = redactConformanceReportForSharing(
+      readinessResultWithSecrets(),
+    );
+    const twice = redactConformanceReportForSharing(once);
+    expect(twice).toEqual(once);
+  });
+});


### PR DESCRIPTION
First of the directory-readiness surfacing PRs — the groundwork every model-facing surface depends on. Plan: UI, MCP tools, agent, chat, CLI land on top of this.

## The report is redacted on the way into storage

Findings carry the raw observation behind each verdict, which is how a submitter learns *why* a lane failed — right inside the process that produced it, wrong for a blob that outlives the run and gets read back by surfaces that did not exist when it was written. `DirectoryReadinessFinding.details` already documents itself as redacted before it travels; the stored path was the one place that promise was not kept.

Both layers of `redactConformanceReportForSharing`, because the key-name pass alone is a blocklist and a blocklist eventually misses the shape a future check introduces. Structure-preserving, so lanes, coverage and remediation survive.

**Defense in depth, not a breach fix.** The report route is project-authorized and was never public, and no check shipping today writes a credential into a finding (`details` is used by exactly one module). That is the argument, not the counter-argument: the guarantee has to exist before the check that first records a request.

Which is why the real proof is in `sdk/tests/conformance-redaction.readiness.test.ts` rather than the worker test. **A worker-level secret test would have passed with the redaction removed** — I wrote one, verified it was vacuous, and replaced it with an honest one that states what it can and cannot establish. The SDK test builds the document a future check *would* produce and asserts both halves: every credential-shaped value gone, and the finding still readable.

One accepted cost, pinned in a test: the redactor scrubs what follows a `Bearer ` scheme — right for `Authorization`, and a `WWW-Authenticate` challenge opens with the same word, so `Bearer realm="x"` becomes `Bearer [REDACTED]"x"`. The value survives; only the parameter name is eaten. Narrowing a shared security rule that currently errs safe deserves its own review.

## Runs are instrumented at both ends

Start event from the v1 route (the only place a hosted run is created, so one instrumentation covers every surface). Terminal event from the detached worker via a new `captureServerEventForActor`, taking an identity resolved while the request still existed — a caller with no resolvable identity is not instrumented at all, since an unmatched `distinct_id` pollutes person profiles.

Emitted from a `finally` with the outcome recorded at each exit, so an abandoned lease counts as an outcome rather than as missing data.

The three axes go out separately — whether the run finished, what it graded, whether the paid pass ran — because collapsing them is the misreading this product exists to prevent. No report contents, no target URL.

## Verification

- `sdk`: 692 readiness + redaction tests pass (32 files), including the 3 new ones.
- inspector: 77 readiness/analytics tests pass, including 3 new worker cases.
- Client analytics ratchet green (the two new events are registered in `shared/analytics-events.ts`).
- `tsc` clean on every changed file; eslint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches stored readiness report contents (redaction of potentially sensitive findings) and server-side identity attribution for analytics. Not a public-route or auth-flow change, but mistakes here could leak secrets into blobs or pollute person profiles.
> 
> **Overview**
> Hosted directory-readiness reports are now **redacted before they are persisted**, and every hosted run is instrumented at start and finish.
> 
> The worker runs `redactConformanceReportForSharing` on the way into storage so findings keep lanes, coverage, and remediation while credential-shaped values (headers, tokens, query secrets) do not outlive the process. This is defense in depth: the report route was already project-authorized, and no shipping check writes credentials into `details`. An accepted cost is pinned in tests: `WWW-Authenticate` challenges that start with `Bearer ` have the scheme token scrubbed (`Bearer realm="x"` → `Bearer [REDACTED]"x"`).
> 
> Analytics: the v1 start route emits `directory_readiness_run_started_server` (including idempotent replays). The detached worker emits `directory_readiness_run_finished_server` from a `finally` via new `captureServerEventForActor`, using an identity resolved while the request still existed. Outcome, grade, and LLM-observation status are separate properties; report contents and target URLs are never sent. Callers with no resolvable actor are not instrumented.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6aec9f721c13d05aff81549ed1e1f9dc2c952914. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Redacts readiness reports before persistence and adds analytics at run start and finish. Previously we stored raw results and had no server-side start/finish events; now the worker stores a redacted report and both ends emit events without report contents or target URLs.

- Storage: the worker runs `redactConformanceReportForSharing` (both passes) before `finalizeReadinessRun`. Findings remain readable; lanes and coverage are preserved. Known cost: `WWW-Authenticate: Bearer ...` has its parameter name scrubbed.
- Analytics: v1 start route fires `directory_readiness_run_started_server`. The worker fires `directory_readiness_run_finished_server` with separate axes (`outcome`, `overall_status`, `llm_observation_status`, `llm_observation_reason`, `terminal_reason`, `duration_ms`). No report data or target URL is sent.
- Attribution: new `captureServerEventForActor` and `ServerAnalyticsActor` support detached runs. v1 resolves the actor from the request and passes it through; if no actor resolves, the terminal event is skipped. `startHostedReadinessRun`/`executeHostedReadinessRun` accept optional `analyticsActor`.
- Tests: added redaction conformance tests in `sdk` and worker analytics/redaction assertions. Events are registered in `shared/analytics-events.ts`.

<sup>Written for commit 6aec9f721c13d05aff81549ed1e1f9dc2c952914. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/MCPJam/inspector/pull/4165?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

