### PR TITLE
CLI: grade a connector or plugin locally with `mcpjam readiness check`

### DIFF
--- a/.changeset/readiness-cli-local-check.md
+++ b/.changeset/readiness-cli-local-check.md
@@ -1,0 +1,47 @@
+---
+"@mcpjam/cli": minor
+---
+
+`mcpjam readiness check` — grade a connector or plugin locally
+
+Two of OpenAI's four submission shapes carry a PACKAGE, and a package is bytes
+on the developer's disk: there is no upload for it, deliberately, so those
+shapes can only ever be graded here. Anthropic's intrusive probes are the same
+story from the other side — they register an OAuth client on the target, which
+is a thing to do to a server you own from a machine you control, not something
+a hosted worker should do on somebody's behalf.
+
+So this is not the offline fallback for the hosted endpoints. It grades what
+only the developer's machine can reach; the hosted commands grade the server as
+the PLATFORM reaches it, and the two answers are worth having separately.
+
+**The mode is declared, never inferred.** `--submission-mode` is required for
+OpenAI, and the per-mode input rules are usage errors rather than silent
+adjustments: a wire mode refuses `--package`, a package mode refuses a URL,
+and either refuses to run without the input its shape requires. Inferring
+would read a forgotten `--package` as `mcp-only`, report the package lane
+`not-applicable`, and hand a submitter a clean bill of health for an artifact
+nobody looked at. The rules are read off `OPENAI_SUBMISSION_MODE_SHAPES`, so a
+fifth mode cannot arrive with this command quietly accepting the wrong inputs.
+
+`--package` takes a directory or a `.zip`, decided by what is on disk rather
+than by suffix — someone pointing at the folder they are about to zip should
+get the same grade as someone pointing at the archive. A directory reports the
+archive-shaped checks as gaps rather than inventing answers, because it is not
+an archive yet; a zip closes them by reading the RAW central directory before
+the zip library normalizes it, since `..`, backslashes and duplicate names are
+exactly what the portal rejects and a repairing loader would hide.
+
+Exit codes match every other gate here — `0` ready, `1` not-ready, `3`
+incomplete, `2` usage — with a `directoryReadinessExitCode` of its own rather
+than a reuse of `conformanceExitCode`, whose `{passed, outcome}` shape would
+read an incomplete readiness run as a violation. No infrastructure condition
+maps to `1`.
+
+Output follows the same channel discipline as `protocol conformance`: stdout
+carries only the result (`--reporter json-summary|junit-xml` work today, since
+the report providers already know both readiness kinds), while the verdict and
+the gap list go to stderr, are suppressed by `--quiet`, and never affect the
+exit code. The gap list names the input that would close each lane, because an
+`incomplete` verdict without the next action is an adjective rather than an
+answer.

--- a/cli/src/commands/readiness.ts
+++ b/cli/src/commands/readiness.ts
@@ -1,0 +1,364 @@
+/**
+ * `mcpjam readiness check` — grade a connector or plugin locally.
+ *
+ * ## Why this runs the engine instead of calling the API
+ *
+ * The hosted endpoints exist and are bound elsewhere in this group, but they
+ * cannot do what a local run can. Two of OpenAI's four submission shapes carry
+ * a PACKAGE, and a package is bytes on the developer's disk — there is no
+ * upload for it, deliberately, so those shapes only ever grade here. The
+ * intrusive Claude probes are the same story from the other direction: they
+ * register an OAuth client on the target, which is a thing to do to a server
+ * you own from a machine you control, and never something a hosted worker
+ * should do on somebody's behalf.
+ *
+ * So the split is not "local is the offline fallback". It is: this command
+ * grades what only the developer's machine can reach, the hosted commands
+ * grade the server as the PLATFORM reaches it, and the two answers are worth
+ * having separately.
+ *
+ * ## The mode is declared, never inferred
+ *
+ * `--submission-mode` is required for OpenAI and the per-mode input rules
+ * below are usage errors rather than silent adjustments. Inferring a mode from
+ * which inputs happen to be present is the failure this whole product is
+ * built to avoid: a forgotten `--package` would read as `mcp-only`, the
+ * package lane would report `not-applicable`, and a submitter would be handed
+ * a clean bill of health for an artifact nobody looked at.
+ */
+
+import { Command } from "commander";
+import {
+  collectZipArchiveObservations,
+  createDirectoryPluginFileSource,
+  createZipPluginFileSource,
+  gatherClaudeReadinessEvidence,
+  gatherOpenAIReadinessEvidence,
+  gradeClaudeReadiness,
+  gradeOpenAIReadiness,
+  xmldomParseXml,
+  OPENAI_SUBMISSION_MODES,
+  OPENAI_SUBMISSION_MODE_SHAPES,
+  type OpenAISubmissionMode,
+} from "@mcpjam/sdk";
+import { readFile, stat } from "node:fs/promises";
+import {
+  renderConformanceForCli,
+  resolveConformanceOutputFormatForCli,
+  type ConformanceOutputFormat,
+} from "../lib/conformance-output.js";
+import {
+  directoryReadinessExitCode,
+  reportReadinessGaps,
+  reportReadinessVerdict,
+} from "../lib/directory-readiness-exit-code.js";
+import { parseReporterFormat } from "../lib/reporting.js";
+import {
+  parseHeadersOption,
+  parsePositiveInteger,
+} from "../lib/server-config.js";
+import {
+  assertNoCredentialsFileAuthConflicts,
+  resolveCredentialsFileAccessToken,
+} from "../lib/credentials-file.js";
+import { setProcessExitCode, usageError } from "../lib/output.js";
+
+interface ReadinessCheckOptions {
+  submissionMode?: string;
+  package?: string;
+  accessToken?: string;
+  credentialsFile?: string;
+  header?: string[];
+  timeout?: number;
+  reporter?: string;
+}
+
+function getFormat(
+  command: Command,
+  reporter: ReturnType<typeof parseReporterFormat>,
+): ConformanceOutputFormat {
+  const opts = command.optsWithGlobals() as { format?: string };
+  return resolveConformanceOutputFormatForCli(
+    opts.format,
+    process.stdout.isTTY,
+    reporter,
+  );
+}
+
+function writeReadinessOutput(output: string): void {
+  process.stdout.write(output.endsWith("\n") ? output : `${output}\n`);
+}
+
+/** The bearer a credentialed target needs, from either source but not both. */
+function resolveAccessToken(
+  options: ReadinessCheckOptions,
+  target: string,
+): string | undefined {
+  assertNoCredentialsFileAuthConflicts(options);
+  if (options.credentialsFile) {
+    return resolveCredentialsFileAccessToken(options.credentialsFile, target);
+  }
+  return options.accessToken?.trim() || undefined;
+}
+
+function requestHeaders(
+  options: ReadinessCheckOptions,
+  target: string,
+): Record<string, string> | undefined {
+  const headers = { ...(parseHeadersOption(options.header) ?? {}) };
+  const token = resolveAccessToken(options, target);
+  if (token) headers.authorization = `Bearer ${token}`;
+  return Object.keys(headers).length > 0 ? headers : undefined;
+}
+
+/**
+ * A directory or a `.zip`, decided by what is on disk rather than by suffix.
+ *
+ * A submitter who points this at the folder they are about to zip should get
+ * the same grade as one who points it at the archive, and a suffix check would
+ * refuse the first for no reason.
+ */
+async function openPackage(path: string): Promise<{
+  // Inferred rather than named: `PluginFileSource` is deliberately not part of
+  // the SDK's public surface, and widening that surface for one annotation
+  // would be the tail wagging the dog.
+  source: ReturnType<typeof createDirectoryPluginFileSource>;
+  archive?: Awaited<ReturnType<typeof collectZipArchiveObservations>>;
+}> {
+  let info;
+  try {
+    info = await stat(path);
+  } catch {
+    throw usageError(`Package path "${path}" does not exist.`);
+  }
+
+  if (info.isDirectory()) {
+    // A directory has no compressed size and no raw entry table, so the
+    // archive-shaped checks report their gaps rather than inventing an
+    // answer — which is the honest grade for something that is not an archive
+    // yet.
+    return { source: createDirectoryPluginFileSource(path) };
+  }
+
+  const bytes = new Uint8Array(await readFile(path));
+  return {
+    source: await createZipPluginFileSource(bytes),
+    // The RAW central directory, read before the zip library normalizes it:
+    // the portal rejects backslashes, `..` and duplicate names, and a loader
+    // that repairs those on the way in would grade a table with the
+    // violations already fixed out of it.
+    archive: await collectZipArchiveObservations(bytes),
+  };
+}
+
+/**
+ * Per-mode input rules, enforced as usage errors.
+ *
+ * Read off `OPENAI_SUBMISSION_MODE_SHAPES` rather than restated here, so a
+ * fifth mode cannot arrive with this command quietly accepting the wrong
+ * inputs for it.
+ */
+function assertModeInputs(
+  mode: OpenAISubmissionMode,
+  target: string | undefined,
+  packagePath: string | undefined,
+): void {
+  const shape = OPENAI_SUBMISSION_MODE_SHAPES[mode];
+
+  if (shape.hasMcpServer && !target) {
+    throw usageError(
+      `Submission mode "${mode}" grades an MCP server; pass its URL as the argument.`,
+    );
+  }
+  if (!shape.hasMcpServer && target) {
+    throw usageError(
+      `Submission mode "${mode}" grades a package only; drop the URL argument.`,
+    );
+  }
+  if (shape.hasUploadedPackage && !packagePath) {
+    throw usageError(
+      `Submission mode "${mode}" grades an uploaded package; pass --package <dir|zip>.`,
+    );
+  }
+  if (!shape.hasUploadedPackage && packagePath) {
+    throw usageError(
+      `Submission mode "${mode}" does not upload a package; drop --package.`,
+    );
+  }
+}
+
+async function runClaudeCheck(
+  target: string,
+  options: ReadinessCheckOptions,
+  command: Command,
+): Promise<void> {
+  const reporter = parseReporterFormat(options.reporter);
+  const format = getFormat(command, reporter);
+
+  const evidence = await gatherClaudeReadinessEvidence({
+    enteredUrl: target,
+    // The global fetch, on purpose. A hosted run pins DNS because it dials on
+    // somebody else's behalf from shared infrastructure; this one dials from
+    // the developer's own machine, where pinning would only stop them from
+    // grading a server on their own network.
+    fetchFn: fetch,
+    headers: requestHeaders(options, target),
+    timeoutMs: options.timeout,
+  });
+
+  const result = gradeClaudeReadiness(evidence);
+  writeReadinessOutput(renderConformanceForCli(result, reporter, format));
+  reportReadinessVerdict(result, command);
+  reportReadinessGaps(result, command);
+
+  const exitCode = directoryReadinessExitCode(result);
+  if (exitCode !== 0) setProcessExitCode(exitCode);
+}
+
+async function runOpenAICheck(
+  target: string | undefined,
+  options: ReadinessCheckOptions,
+  command: Command,
+): Promise<void> {
+  const reporter = parseReporterFormat(options.reporter);
+  const format = getFormat(command, reporter);
+
+  if (!options.submissionMode) {
+    throw usageError(
+      `--submission-mode is required and is never inferred. One of: ${OPENAI_SUBMISSION_MODES.join(
+        ", ",
+      )}.`,
+    );
+  }
+  if (
+    !(OPENAI_SUBMISSION_MODES as readonly string[]).includes(
+      options.submissionMode,
+    )
+  ) {
+    throw usageError(
+      `Unknown submission mode "${
+        options.submissionMode
+      }". One of: ${OPENAI_SUBMISSION_MODES.join(", ")}.`,
+    );
+  }
+  const mode = options.submissionMode as OpenAISubmissionMode;
+  assertModeInputs(mode, target, options.package);
+
+  const pkg = options.package ? await openPackage(options.package) : undefined;
+
+  const evidence = await gatherOpenAIReadinessEvidence({
+    // A package-only run has no server; the target names the artifact so the
+    // report says what was graded.
+    target: target ?? options.package ?? "package",
+    mode,
+    // Absent for a package-only run, and absent means "dialled nothing" rather
+    // than "found nothing" — the wire lanes report their gaps.
+    fetchFn: target ? fetch : undefined,
+    headers: target ? requestHeaders(options, target) : undefined,
+    timeoutMs: options.timeout,
+    packageSource: pkg?.source,
+    archive: pkg?.archive,
+    // Without an XML parser the SVG assets are recorded as a gap rather than
+    // graded, so it is passed even when no package is supplied — costing
+    // nothing and removing one way to produce a quietly weaker grade.
+    parseXml: xmldomParseXml,
+  });
+
+  const result = gradeOpenAIReadiness(evidence);
+  writeReadinessOutput(renderConformanceForCli(result, reporter, format));
+  reportReadinessVerdict(result, command);
+  reportReadinessGaps(result, command);
+
+  const exitCode = directoryReadinessExitCode(result);
+  if (exitCode !== 0) setProcessExitCode(exitCode);
+}
+
+/**
+ * Register the `readiness` group and its local `check` command.
+ *
+ * Returns the group so the hosted run commands can be attached to the same
+ * noun — `readiness check` and `readiness start` are two ways to grade one
+ * thing, and splitting them across two top-level commands would make that a
+ * detail the user has to know.
+ */
+export function registerReadinessCommands(program: Command): Command {
+  const readiness = program
+    .command("readiness")
+    .description("Grade a server or plugin against a publisher's directory");
+
+  const check = readiness
+    .command("check")
+    .description("Grade locally, without a MCPJam account (free)");
+
+  check
+    .command("claude")
+    .description("Grade an MCP server against Anthropic's connector directory")
+    .argument("<url>", "MCP server URL")
+    .option("--access-token <token>", "Bearer access token for the server")
+    .option(
+      "--credentials-file <path>",
+      "Load the access token from a file written by oauth login",
+    )
+    .option(
+      "--header <header>",
+      'HTTP header in "Key: Value" format. Repeat to send multiple headers.',
+      (value: string, previous: string[] = []) => [...previous, value],
+      [],
+    )
+    .option(
+      "--timeout <ms>",
+      "Per-request timeout in milliseconds",
+      (value: string) => parsePositiveInteger(value, "Timeout"),
+    )
+    .option(
+      "--reporter <reporter>",
+      "Structured reporter output: json-summary or junit-xml",
+    )
+    .action(async (url: string, options: ReadinessCheckOptions, command) => {
+      await runClaudeCheck(url, options, command);
+    });
+
+  check
+    .command("openai")
+    .description("Grade a server or plugin against OpenAI's app directory")
+    .argument(
+      "[url]",
+      "MCP server URL. Omit for a package-only submission shape.",
+    )
+    .requiredOption(
+      "--submission-mode <mode>",
+      `Declared submission shape: ${OPENAI_SUBMISSION_MODES.join(" | ")}`,
+    )
+    .option("--package <path>", "Plugin package directory or .zip to grade")
+    .option("--access-token <token>", "Bearer access token for the server")
+    .option(
+      "--credentials-file <path>",
+      "Load the access token from a file written by oauth login",
+    )
+    .option(
+      "--header <header>",
+      'HTTP header in "Key: Value" format. Repeat to send multiple headers.',
+      (value: string, previous: string[] = []) => [...previous, value],
+      [],
+    )
+    .option(
+      "--timeout <ms>",
+      "Per-request timeout in milliseconds",
+      (value: string) => parsePositiveInteger(value, "Timeout"),
+    )
+    .option(
+      "--reporter <reporter>",
+      "Structured reporter output: json-summary or junit-xml",
+    )
+    .action(
+      async (
+        url: string | undefined,
+        options: ReadinessCheckOptions,
+        command,
+      ) => {
+        await runOpenAICheck(url, options, command);
+      },
+    );
+
+  return readiness;
+}

--- a/cli/src/index.ts
+++ b/cli/src/index.ts
@@ -19,6 +19,7 @@ import { registerOrganizationsCommands } from "./commands/organizations.js";
 import { registerSessionsCommands } from "./commands/sessions.js";
 import { registerProjectsCommands } from "./commands/projects.js";
 import { registerProtocolCommands } from "./commands/conformance.js";
+import { registerReadinessCommands } from "./commands/readiness.js";
 import { registerOAuthCommands } from "./commands/oauth.js";
 import { registerXaaCommands } from "./commands/xaa.js";
 import { registerPromptCommands } from "./commands/prompts.js";
@@ -101,6 +102,7 @@ export async function main(
   registerOAuthCommands(program);
   registerXaaCommands(program);
   registerProtocolCommands(program);
+  registerReadinessCommands(program);
   registerAuthCommands(program);
   registerOrganizationsCommands(program);
   registerProjectsCommands(program);

--- a/cli/src/lib/directory-readiness-exit-code.ts
+++ b/cli/src/lib/directory-readiness-exit-code.ts
@@ -1,0 +1,105 @@
+/**
+ * Exit code for a finished directory-readiness run.
+ *
+ * SEPARATE FROM `conformanceExitCode`, and not because the semantics differ —
+ * they are deliberately identical — but because the SHAPES do. A conformance
+ * result reports `{passed, outcome}`; a readiness result reports a single
+ * `status` of `ready | not-ready | incomplete` and has no `passed` at all.
+ * Feeding one to the other would read `undefined` as `passed: false` and
+ * silently map every incomplete run to `1`, which is the one confusion this
+ * product exists to prevent.
+ *
+ * The three codes carry the same meanings they do everywhere else in this CLI:
+ *
+ *   0  ready       — every dispositive lane was evaluated and none failed
+ *   1  not-ready   — the target was graded and something disqualifying was found
+ *   3  incomplete  — the run did not establish enough to say either way
+ *
+ * `2` is reserved for usage errors, which is why the third state is `3`.
+ *
+ * INCOMPLETE IS NOT A FAILURE, and collapsing it into `1` would be the CI
+ * equivalent of reporting a clean bill of health for a page nobody read — a
+ * gate that fails identically whether somebody's connector is broken or our
+ * own run could not reach it teaches its owner nothing. It is also why no
+ * infrastructure condition may ever map to `1`: a timeout, an unreachable
+ * host, a cancelled run are all `3`, because none of them is a statement about
+ * the target.
+ *
+ * Read structurally rather than by SDK type so a result from an older
+ * `@mcpjam/sdk` still maps: an unrecognised status is `3`, never `0`.
+ */
+export function directoryReadinessExitCode(result: {
+  status?: string;
+}): number {
+  switch (result.status) {
+    case "ready":
+      return 0;
+    case "not-ready":
+      return 1;
+    default:
+      return 3;
+  }
+}
+
+/**
+ * The one-line verdict, on stderr.
+ *
+ * Same channel discipline as the conformance reporters beside it: stdout
+ * carries the machine-readable result and nothing else, so a `--reporter`
+ * payload stays pipeable; this line is for the human watching the terminal and
+ * is suppressed by `--quiet`. It never affects the exit code — it annotates
+ * the verdict rather than deciding it.
+ */
+export function reportReadinessVerdict(
+  result: { status?: string; summary?: string },
+  command: { optsWithGlobals(): { quiet?: boolean } },
+): void {
+  if (command.optsWithGlobals().quiet) return;
+  const status = result.status ?? "unknown";
+  const label =
+    status === "ready"
+      ? "READY"
+      : status === "not-ready"
+      ? "NOT READY"
+      : "INCOMPLETE";
+  const summary = result.summary ? ` — ${result.summary}` : "";
+  process.stderr.write(`${label}${summary}\n`);
+}
+
+/**
+ * The gaps, on stderr, when a run did not establish everything.
+ *
+ * A lane that reports `missingInputs` is telling the reader exactly what to
+ * supply to close it, and that sentence is worth more than the verdict it sits
+ * under — a submitter whose run came back `incomplete` needs the next action,
+ * not the adjective. Printed for every run, not only incomplete ones: a lane
+ * can carry a gap while the rollup still reads `ready`, and hiding that would
+ * make a partial pass look total.
+ */
+export function reportReadinessGaps(
+  result: {
+    lanes?: Array<{
+      lane: string;
+      coverage?: { missingInputs?: string[]; notEvaluated?: number };
+    }>;
+  },
+  command: { optsWithGlobals(): { quiet?: boolean } },
+): void {
+  if (command.optsWithGlobals().quiet) return;
+  const gaps = (result.lanes ?? []).filter(
+    (lane) =>
+      (lane.coverage?.missingInputs?.length ?? 0) > 0 ||
+      (lane.coverage?.notEvaluated ?? 0) > 0,
+  );
+  if (gaps.length === 0) return;
+
+  process.stderr.write(`Gaps (${gaps.length}):\n`);
+  for (const lane of gaps) {
+    const inputs = lane.coverage?.missingInputs ?? [];
+    const detail =
+      inputs.length > 0
+        ? `supply ${inputs.join(", ")}`
+        : `${lane.coverage?.notEvaluated} check(s) could not run`;
+    process.stderr.write(`  ${lane.lane}: ${detail}\n`);
+  }
+}

--- a/cli/tests/directory-readiness-exit-code.test.ts
+++ b/cli/tests/directory-readiness-exit-code.test.ts
@@ -1,0 +1,142 @@
+/**
+ * The exit code a CI job reads, and the two lines a human reads.
+ *
+ * The mapping is the same one every other gate in this CLI uses, and the
+ * reason it needs its own function rather than reusing `conformanceExitCode`
+ * is a SHAPE difference that fails silently: a conformance result reports
+ * `{passed, outcome}` and a readiness result reports a single `status`. Handed
+ * to the conformance version, an incomplete readiness run reads `passed:
+ * undefined` and maps to `1` — a run that established nothing reported as a
+ * violation.
+ */
+
+import assert from "node:assert/strict";
+import test from "node:test";
+import {
+  directoryReadinessExitCode,
+  reportReadinessGaps,
+  reportReadinessVerdict,
+} from "../src/lib/directory-readiness-exit-code.js";
+
+/** A `command` stand-in: the only thing the reporters read is `--quiet`. */
+function commandWith(quiet = false) {
+  return { optsWithGlobals: () => ({ quiet }) };
+}
+
+/** Capture stderr for the duration of one call. */
+function captureStderr(run: () => void): string {
+  const original = process.stderr.write.bind(process.stderr);
+  let captured = "";
+  (process.stderr as unknown as { write: unknown }).write = (
+    chunk: string,
+  ): boolean => {
+    captured += chunk;
+    return true;
+  };
+  try {
+    run();
+  } finally {
+    (process.stderr as unknown as { write: unknown }).write = original;
+  }
+  return captured;
+}
+
+test("ready is a pass", () => {
+  assert.equal(directoryReadinessExitCode({ status: "ready" }), 0);
+});
+
+test("not-ready is a failure", () => {
+  assert.equal(directoryReadinessExitCode({ status: "not-ready" }), 1);
+});
+
+test("incomplete gets its own code, never 1", () => {
+  // A gate that fails identically whether the connector is broken or our own
+  // run could not reach it teaches its owner nothing.
+  assert.equal(directoryReadinessExitCode({ status: "incomplete" }), 3);
+});
+
+test("an unrecognised status is incomplete, never ready", () => {
+  // Read structurally so a result from a newer or older SDK still maps. The
+  // direction matters: guessing `ready` would turn an unknown state into a
+  // green build.
+  assert.equal(directoryReadinessExitCode({ status: "surprise" }), 3);
+  assert.equal(directoryReadinessExitCode({}), 3);
+});
+
+test("the verdict line names the status and carries the summary", () => {
+  const out = captureStderr(() =>
+    reportReadinessVerdict(
+      {
+        status: "not-ready",
+        summary: "directory-policy has unmet requirements.",
+      },
+      commandWith(),
+    ),
+  );
+  assert.match(out, /NOT READY/);
+  assert.match(out, /directory-policy has unmet requirements\./);
+});
+
+test("--quiet silences the verdict, and stdout stays parseable", () => {
+  const out = captureStderr(() =>
+    reportReadinessVerdict({ status: "ready" }, commandWith(true)),
+  );
+  assert.equal(out, "");
+});
+
+test("gaps name the input that would close them", () => {
+  // The sentence a submitter acts on: an `incomplete` verdict without the
+  // next action is an adjective, not an answer.
+  const out = captureStderr(() =>
+    reportReadinessGaps(
+      {
+        lanes: [
+          {
+            lane: "directory-policy",
+            coverage: { missingInputs: ["toolListing"], notEvaluated: 2 },
+          },
+          {
+            lane: "runtime-compatibility",
+            coverage: { missingInputs: [], notEvaluated: 0 },
+          },
+        ],
+      },
+      commandWith(),
+    ),
+  );
+  assert.match(out, /Gaps \(1\):/);
+  assert.match(out, /directory-policy: supply toolListing/);
+  // A lane with nothing outstanding is not listed as a gap.
+  assert.doesNotMatch(out, /runtime-compatibility/);
+});
+
+test("a lane whose checks could not run is a gap even with no named input", () => {
+  const out = captureStderr(() =>
+    reportReadinessGaps(
+      {
+        lanes: [{ lane: "optional-features", coverage: { notEvaluated: 2 } }],
+      },
+      commandWith(),
+    ),
+  );
+  assert.match(out, /optional-features: 2 check\(s\) could not run/);
+});
+
+test("gaps are reported even when the rollup reads ready", () => {
+  // A lane can carry a gap while the headline still says ready; hiding that
+  // would make a partial pass look total.
+  const out = captureStderr(() =>
+    reportReadinessGaps(
+      {
+        lanes: [
+          {
+            lane: "optional-features",
+            coverage: { missingInputs: ["pluginBundle"] },
+          },
+        ],
+      },
+      commandWith(),
+    ),
+  );
+  assert.match(out, /optional-features: supply pluginBundle/);
+});

--- a/cli/tests/readiness-command.test.ts
+++ b/cli/tests/readiness-command.test.ts
@@ -1,0 +1,151 @@
+/**
+ * The command surface, and the one rule it exists to enforce.
+ *
+ * `--submission-mode` is required for OpenAI and its inputs are checked
+ * against the mode rather than the other way round. That asymmetry is the
+ * whole point: inferring a mode from whichever inputs happen to be present
+ * reads a forgotten `--package` as `mcp-only`, which reports the package lane
+ * `not-applicable` and hands a submitter a clean bill of health for an
+ * artifact nobody looked at. A usage error is the correct answer, and it has
+ * to arrive BEFORE anything dials.
+ */
+
+import assert from "node:assert/strict";
+import test from "node:test";
+import { Command } from "commander";
+import { registerReadinessCommands } from "../src/commands/readiness.js";
+
+/** The real Commander tree, built the way `src/index.ts` builds it. */
+function buildProgram(): Command {
+  const program = new Command();
+  program.exitOverride();
+  program.configureOutput({ writeOut: () => {}, writeErr: () => {} });
+  registerReadinessCommands(program);
+  return program;
+}
+
+/** Run the parser and return whatever it threw, or null when it did not. */
+async function runExpectingError(argv: string[]): Promise<Error | null> {
+  const program = buildProgram();
+  try {
+    await program.parseAsync(["node", "mcpjam", ...argv]);
+    return null;
+  } catch (error) {
+    return error as Error;
+  }
+}
+
+/** Walk the tree the way a user types, so the test proves the real path. */
+function resolve(program: Command, path: string[]): Command | undefined {
+  let current: Command | undefined = program;
+  for (const name of path) {
+    current = current?.commands.find(
+      (candidate) =>
+        candidate.name() === name || candidate.aliases().includes(name),
+    );
+    if (!current) return undefined;
+  }
+  return current;
+}
+
+test("the readiness group advertises both publishers under check", () => {
+  const program = buildProgram();
+  assert.ok(resolve(program, ["readiness", "check", "claude"]));
+  assert.ok(resolve(program, ["readiness", "check", "openai"]));
+});
+
+test("openai refuses to run without a declared submission mode", async () => {
+  // Commander enforces the requiredOption, which is what makes "never
+  // inferred" true at the surface rather than only in the docblock.
+  const error = await runExpectingError([
+    "readiness",
+    "check",
+    "openai",
+    "https://mcp.example.com/mcp",
+  ]);
+  assert.ok(error, "expected a usage error");
+  assert.match(String(error), /submission-mode/i);
+});
+
+test("openai refuses an unknown submission mode", async () => {
+  const error = await runExpectingError([
+    "readiness",
+    "check",
+    "openai",
+    "https://mcp.example.com/mcp",
+    "--submission-mode",
+    "not-a-mode",
+  ]);
+  assert.ok(error, "expected a usage error");
+  assert.match(String(error), /submission mode/i);
+});
+
+test("a wire mode refuses a package it cannot upload", async () => {
+  const error = await runExpectingError([
+    "readiness",
+    "check",
+    "openai",
+    "https://mcp.example.com/mcp",
+    "--submission-mode",
+    "mcp-only",
+    "--package",
+    "/tmp/does-not-matter",
+  ]);
+  assert.ok(error, "expected a usage error");
+  assert.match(String(error), /does not upload a package/i);
+});
+
+test("a package mode refuses a URL it does not grade", async () => {
+  const error = await runExpectingError([
+    "readiness",
+    "check",
+    "openai",
+    "https://mcp.example.com/mcp",
+    "--submission-mode",
+    "skills-only",
+    "--package",
+    "/tmp/does-not-matter",
+  ]);
+  assert.ok(error, "expected a usage error");
+  assert.match(String(error), /package only/i);
+});
+
+test("a package mode refuses to run with no package", async () => {
+  // The failure this whole guard exists for: without it the run grades an
+  // empty submission and reports the package lane as inapplicable.
+  const error = await runExpectingError([
+    "readiness",
+    "check",
+    "openai",
+    "--submission-mode",
+    "skills-only",
+  ]);
+  assert.ok(error, "expected a usage error");
+  assert.match(String(error), /uploaded package/i);
+});
+
+test("a wire mode refuses to run with no URL", async () => {
+  const error = await runExpectingError([
+    "readiness",
+    "check",
+    "openai",
+    "--submission-mode",
+    "mcp-only",
+  ]);
+  assert.ok(error, "expected a usage error");
+  assert.match(String(error), /pass its URL/i);
+});
+
+test("a missing package path is a usage error, not a crash", async () => {
+  const error = await runExpectingError([
+    "readiness",
+    "check",
+    "openai",
+    "--submission-mode",
+    "skills-only",
+    "--package",
+    "/tmp/definitely-not-a-real-package-path-9f3a",
+  ]);
+  assert.ok(error, "expected a usage error");
+  assert.match(String(error), /does not exist/i);
+});


### PR DESCRIPTION
Second of the directory-readiness surfacing PRs, and independent of the others — it touches no operation catalog and no drift guard. It also creates the `readiness` command group that the hosted run commands attach to later.

## Why the engine runs here rather than the API being called

Two of OpenAI's four submission shapes carry a **package**, and a package is bytes on the developer's disk — there is no upload for it, deliberately, so those shapes can only ever be graded on the machine holding them. Anthropic's intrusive probes are the same story from the other direction: they register an OAuth client on the target, which is a thing to do to a server you own from a machine you control.

So this is not the offline fallback. It grades what only the developer's machine can reach; the hosted commands grade the server as the *platform* reaches it. Two questions, both worth asking.

## The mode is declared, never inferred

`--submission-mode` is required for OpenAI and the per-mode input rules are usage errors, not silent adjustments — a wire mode refuses `--package`, a package mode refuses a URL, either refuses to run without the input its shape requires. A forgotten `--package` inferred as `mcp-only` would report the package lane `not-applicable`: a clean bill of health for an artifact nobody looked at. The rules read off `OPENAI_SUBMISSION_MODE_SHAPES`, so a fifth mode cannot arrive with this command quietly accepting the wrong inputs.

`--package` takes a directory or a `.zip`, decided by what is on disk rather than by suffix. A directory reports the archive-shaped checks as gaps rather than inventing answers; a zip closes them by reading the **raw** central directory before the zip library normalizes it, since `..`, backslashes and duplicate names are exactly what the portal rejects.

## Exit codes

`0` ready · `1` not-ready · `3` incomplete · `2` usage — via a `directoryReadinessExitCode` of its own rather than reusing `conformanceExitCode`. Not duplication: the conformance version reads `{passed, outcome}`, which a readiness result does not have, so an incomplete run would arrive as `passed: undefined` and map to `1` — a run that established nothing reported as a violation. No infrastructure condition maps to `1`.

stdout carries only the result (`--reporter json-summary|junit-xml` work today — the report providers already know both readiness kinds); the verdict and gap list go to stderr, are `--quiet`-able, and never touch the exit code. Gaps name the input that would close each lane.

## Verification

Run against a live server and a real package fixture in both directory and zip form:

```
readiness check claude https://mcp.linear.app/mcp   -> exit 3, 5 gaps named
readiness check openai --submission-mode skills-only
  --package <dir>   -> package lane evaluated 8, 3 archive gaps (honest: a dir is not an archive)
  --package <zip>   -> package lane evaluated 8, 1 gap (encryption flags, deliberately absent)
```

Every usage refusal returns `2`. 738/738 CLI tests pass (17 new); `tsc` and eslint clean.

> **Note:** `Inspector Tests 3/4` will show red until #4157 merges — main currently fails `sdk-coverage` for the six v1 readiness routes, and every branch off main inherits it. Unrelated to this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> New CLI surface that dials user-supplied MCP URLs with optional bearer tokens and inspects local plugin packages. Grading logic lives in the existing SDK; risk is mainly command-input handling and CI exit-code semantics, not auth or data-store changes.
> 
> **Overview**
> Adds a local **`mcpjam readiness check`** command so developers can grade a connector or plugin on their own machine, without an account. This is not an offline fallback for hosted runs: package-shaped OpenAI submissions and Anthropic’s intrusive probes can only be graded from a machine that holds the bytes or owns the server.
> 
> **OpenAI mode is declared, never inferred.** `--submission-mode` is required, and URL vs `--package` must match `OPENAI_SUBMISSION_MODE_SHAPES` or the command exits as usage. Packages are opened as a directory or zip from disk (not suffix); zips are graded from the raw central directory so portal-rejected paths are not repaired away.
> 
> Exit codes are `0` ready / `1` not-ready / `3` incomplete (never collapse incomplete into failure). Structured reports stay on stdout; verdict and named gaps go to stderr and respect `--quiet`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ba3afe273b24a01f266c3ba1d8405b4537fb662f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add `readiness check` to the CLI to grade connectors/plugins locally for Anthropic and OpenAI directories, covering cases the hosted flow cannot reach (local packages and on-target OAuth probes).

- `readiness check claude <url>` and `readiness check openai [url] --submission-mode <mode> [--package <dir|zip>]`. OpenAI mode is required and never inferred; per-mode input rules are enforced from `OPENAI_SUBMISSION_MODE_SHAPES`.
- `--package` accepts a directory or `.zip` based on what exists on disk. Directories surface archive-shaped checks as gaps; zips are inspected via the raw central directory to catch `..`, backslashes, and duplicate names.
- Exit codes: `0` ready, `1` not-ready, `3` incomplete, `2` usage — via a dedicated `directoryReadinessExitCode` to avoid mapping incomplete to failure.
- Output discipline: stdout carries only reporter output (`json-summary` or `junit-xml`); verdict and gap list go to stderr, are `--quiet`-able, and never affect the exit code. Gaps name the inputs needed to close each lane.
- Registers a `readiness` command group; hosted run commands will attach here. Includes tests for exit code mapping and OpenAI mode/input validation, and wires the group in the CLI entrypoint. Uses `@mcpjam/sdk` evidence gathering and grading.

<sup>Written for commit ba3afe273b24a01f266c3ba1d8405b4537fb662f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/MCPJam/inspector/pull/4166?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

