### PR TITLE
Directory readiness on /conformance

### DIFF
--- a/.changeset/readiness-conformance-ui.md
+++ b/.changeset/readiness-conformance-ui.md
@@ -1,0 +1,51 @@
+---
+"@mcpjam/inspector": minor
+---
+
+Directory readiness on the /conformance page
+
+Two new sections — Claude and OpenAI — beside the Protocol, Apps, Tasks and
+OAuth suites, behind the `mcpjam-directory-readiness` flag. The engine, the
+API and the local route already existed; this is the first surface that calls
+any of them.
+
+**Each section owns its run.** They are deliberately outside the page's shared
+"Run available checks" button: a hosted readiness run takes minutes, and
+joining the shared busy state would hold that button and the protocol-version
+selector hostage for its duration. They are also outside the pooled score,
+because readiness produces lanes and coverage rather than passed and failed
+checks — there is no number to pool, by design.
+
+**Two execution modes behind one control.** Locally the run is synchronous and
+free, and cannot spend: the route has no observations flag at all. Hosted, it
+is a durable run — `202`, poll, cancel, and a report fetched lazily when
+somebody opens the findings, because it can be megabytes. A reload mid-run
+finds its way back to the run still going, which no other suite on the page
+can do.
+
+**The three axes stay apart.** Whether the run finished, what it graded, and
+whether the optional paid pass ran are three different answers. A run that
+FAILED shows "Run failed" rather than "not ready" — our runner falling over is
+not a finding about somebody's server. A refused AI observation renders as a
+gap with the reason, never as a failure, because `billing_limit_reached` means
+"we could not afford to look" and the deterministic grade is complete without
+it.
+
+**Coverage travels with every verdict.** A lane prints what it evaluated out of
+what it selected, states `not applicable` separately from `not evaluated`, and
+names the input that would close its gap. Findings group by class in the order
+somebody fixes them — blockers, requirements, recommendations, human review,
+observations — because the class is what decides whether a finding moved the
+verdict, and a model-authored line is labelled as one.
+
+**The two package submission modes are offered but disabled**, with the CLI
+command that can run them. They need bytes on the developer's machine, and a
+shorter menu would teach a submitter that readiness cannot grade their plugin
+at all.
+
+The hosted routes needed the user's bearer, and their scope sits in the middle
+of the path so no prefix could name them. Rather than allowlisting all of
+`/api/v1/projects/` — which would hand the bearer to every project-scoped
+public route that ever ships — `HOSTED_AUTH_PATH_PREFIXES` gained a sibling
+pattern list, anchored at both ends, with tests covering the six paths that
+must carry it and six neighbours that must not.

--- a/mcpjam-inspector/client/src/components/conformance/ConformancePanel.tsx
+++ b/mcpjam-inspector/client/src/components/conformance/ConformancePanel.tsx
@@ -1,5 +1,7 @@
 import { useState, useMemo } from "react";
+import { useFeatureFlagEnabled } from "posthog-js/react";
 import { Button } from "@mcpjam/design-system/button";
+import { DirectoryReadinessSection } from "@/components/conformance/directory-readiness/DirectoryReadinessSection";
 import {
   Select,
   SelectContent,
@@ -484,6 +486,15 @@ function SuiteSection({
 }
 
 function ConformanceContent({ server }: { server: ServerWithName }) {
+  // A SECTION flag, not a route flag: `/conformance` is already gated by
+  // `mcpjam-conformance` (nav item and the route redirect in App.tsx), so
+  // these two sections only need to decide whether to render. `=== true`
+  // rather than `!== false`, because a section that pops in after PostHog
+  // hydrates is a better failure than one that flashes for users the flag
+  // excludes.
+  const directoryReadinessEnabled =
+    useFeatureFlagEnabled("mcpjam-directory-readiness") === true;
+
   // Run state, per-suite scores and the pooled headline all live in the shared
   // hook — score.mcpjam.com runs the same four suites and must pool them the
   // same way. Rendering stays here.
@@ -516,6 +527,9 @@ function ConformanceContent({ server }: { server: ServerWithName }) {
         <h2 className="text-lg font-semibold">Conformance</h2>
         <p className="text-sm text-muted-foreground">
           Run Protocol, Apps, Tasks, and OAuth checks against {server.name}.
+          {directoryReadinessEnabled
+            ? " Directory readiness grades it against Anthropic's and OpenAI's published rules."
+            : ""}
         </p>
       </div>
 
@@ -678,6 +692,21 @@ function ConformanceContent({ server }: { server: ServerWithName }) {
             </div>
           ) : null}
         </SuiteSection>
+
+        {/*
+          DELIBERATELY OUTSIDE `runAll` AND THE POOLED SCORE. A hosted
+          readiness run takes minutes, so joining the shared `isRunning` would
+          hold the Run button and the protocol-version select hostage for its
+          duration — and readiness produces lanes and coverage rather than
+          passed/failed checks, so there is no number to pool. Each section
+          owns its own run control.
+        */}
+        {directoryReadinessEnabled && (
+          <>
+            <DirectoryReadinessSection publisher="claude" server={server} />
+            <DirectoryReadinessSection publisher="openai" server={server} />
+          </>
+        )}
       </div>
     </div>
   );

--- a/mcpjam-inspector/client/src/components/conformance/directory-readiness/DirectoryReadinessReport.tsx
+++ b/mcpjam-inspector/client/src/components/conformance/directory-readiness/DirectoryReadinessReport.tsx
@@ -1,0 +1,221 @@
+/**
+ * The findings, grouped by what they mean rather than by what they say.
+ *
+ * ## Why grouping is by CLASS
+ *
+ * Readiness findings do not sort into pass and fail. A `runtime-blocker` and a
+ * `heuristic` can both read `violated` and mean completely different things:
+ * one keeps a submission out of the directory, the other is an opinion worth
+ * considering. `decideLaneStatus` only consults the dispositive classes, so a
+ * reader who cannot see the class cannot tell which findings actually moved
+ * the verdict — and a model-authored observation would look exactly like a
+ * requirement.
+ *
+ * The order is the order somebody fixes things in: what blocks, then what is
+ * required, then what is advice.
+ *
+ * ## Not-evaluated is a first-class row
+ *
+ * A finding that never ran carries its reason, and hiding it would leave the
+ * reader believing the check passed. It renders in its own muted style with
+ * the reason attached, so "nobody looked" never reads as "nothing wrong".
+ */
+
+import { useState } from "react";
+import {
+  AlertTriangle,
+  CheckCircle2,
+  ChevronDown,
+  ChevronRight,
+  Loader2,
+  MinusCircle,
+  Sparkles,
+  XCircle,
+} from "lucide-react";
+import type { DirectoryReadinessResult } from "@/lib/apis/directory-readiness-api";
+
+type FindingLike = {
+  id: string;
+  title: string;
+  lane: string;
+  class: string;
+  status: string;
+  remediation?: string;
+  provenance?: string;
+  notEvaluatedReason?: string;
+  source?: { page?: string; section?: string };
+};
+
+/** Fix-order, and the label a reader needs to know what a group costs them. */
+const CLASS_GROUPS: Array<{ key: string; title: string; blurb: string }> = [
+  {
+    key: "runtime-blocker",
+    title: "Runtime blockers",
+    blurb: "The host cannot use this server until these are fixed.",
+  },
+  {
+    key: "required",
+    title: "Directory requirements",
+    blurb: "The publisher's rules require these before a submission is listed.",
+  },
+  {
+    key: "recommended",
+    title: "Recommended",
+    blurb: "Not disqualifying, but expected of a good submission.",
+  },
+  {
+    key: "manual-review",
+    title: "Needs a human",
+    blurb: "A reviewer decides these; no automated check can.",
+  },
+  {
+    key: "heuristic",
+    title: "Observations",
+    blurb: "Judgement calls, never part of the verdict.",
+  },
+];
+
+function StatusIcon({ status }: { status: string }) {
+  if (status === "violated") {
+    return <XCircle className="h-3.5 w-3.5 text-red-400 flex-shrink-0" />;
+  }
+  if (status === "satisfied") {
+    return (
+      <CheckCircle2 className="h-3.5 w-3.5 text-green-500 flex-shrink-0" />
+    );
+  }
+  if (status === "not-evaluated") {
+    return (
+      <MinusCircle className="h-3.5 w-3.5 text-muted-foreground flex-shrink-0" />
+    );
+  }
+  return <AlertTriangle className="h-3.5 w-3.5 text-amber-500 flex-shrink-0" />;
+}
+
+function FindingRow({ finding }: { finding: FindingLike }) {
+  const [open, setOpen] = useState(false);
+  const detail = finding.notEvaluatedReason ?? finding.remediation;
+  const expandable = Boolean(detail || finding.source?.page);
+
+  return (
+    <div className="px-1 py-1">
+      <button
+        type="button"
+        className="flex w-full items-start gap-1.5 text-left"
+        onClick={() => setOpen((value) => !value)}
+        disabled={!expandable}
+        aria-expanded={expandable ? open : undefined}
+      >
+        {expandable ? (
+          open ? (
+            <ChevronDown className="mt-0.5 h-3 w-3 text-muted-foreground flex-shrink-0" />
+          ) : (
+            <ChevronRight className="mt-0.5 h-3 w-3 text-muted-foreground flex-shrink-0" />
+          )
+        ) : (
+          <span className="w-3 flex-shrink-0" />
+        )}
+        <StatusIcon status={finding.status} />
+        <span className="min-w-0 flex-1 text-[11px] leading-snug">
+          {finding.title}
+        </span>
+        {/*
+          A model wrote this line. Saying so is not a disclaimer — it is what
+          lets a reader weigh it differently from a wire observation.
+        */}
+        {finding.provenance === "llm" && (
+          <span className="flex items-center gap-0.5 text-[9px] text-muted-foreground flex-shrink-0">
+            <Sparkles className="h-2.5 w-2.5" />
+            AI
+          </span>
+        )}
+      </button>
+      {open && detail && (
+        <div className="pl-8 pr-1 pt-1 text-[10px] leading-relaxed text-muted-foreground">
+          {detail}
+          {finding.source?.page && (
+            <div className="pt-0.5 opacity-70">
+              Source: {finding.source.page}
+              {finding.source.section ? ` — ${finding.source.section}` : ""}
+            </div>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}
+
+export function DirectoryReadinessReport({
+  report,
+  loading,
+  error,
+  hasReport,
+  terminalReason,
+  errorMessage,
+}: {
+  report?: DirectoryReadinessResult;
+  loading?: boolean;
+  error?: string;
+  hasReport: boolean;
+  terminalReason?: string;
+  errorMessage?: string;
+}) {
+  if (loading) {
+    return (
+      <div className="flex items-center gap-2 px-1 py-2 text-[10px] text-muted-foreground">
+        <Loader2 className="h-3 w-3 animate-spin" />
+        Loading findings...
+      </div>
+    );
+  }
+
+  if (error) {
+    return (
+      <div className="px-1 py-2 text-[10px] text-red-400">
+        The findings could not be loaded: {error}
+      </div>
+    );
+  }
+
+  // A run that ended without a report says so. The reason is the whole value
+  // of the row — silence here would read as a run that found nothing.
+  if (!report && !hasReport) {
+    return (
+      <div className="px-1 py-2 text-[10px] text-muted-foreground">
+        {terminalReason
+          ? `No findings were stored for this run (${terminalReason}).`
+          : "No findings were stored for this run."}
+        {errorMessage ? ` ${errorMessage}` : ""}
+      </div>
+    );
+  }
+
+  if (!report) return null;
+
+  const findings = (report.findings ?? []) as FindingLike[];
+  if (findings.length === 0) return null;
+
+  return (
+    <div className="space-y-1.5">
+      {CLASS_GROUPS.map((group) => {
+        const rows = findings.filter((finding) => finding.class === group.key);
+        if (rows.length === 0) return null;
+        return (
+          <div key={group.key}>
+            <div className="px-1 pt-1 text-[10px] font-medium text-foreground/80">
+              {group.title}{" "}
+              <span className="font-normal text-muted-foreground">
+                ({rows.length}) — {group.blurb}
+              </span>
+            </div>
+            <div className="divide-y divide-border/30">
+              {rows.map((finding) => (
+                <FindingRow key={finding.id} finding={finding} />
+              ))}
+            </div>
+          </div>
+        );
+      })}
+    </div>
+  );
+}

--- a/mcpjam-inspector/client/src/components/conformance/directory-readiness/DirectoryReadinessSection.tsx
+++ b/mcpjam-inspector/client/src/components/conformance/directory-readiness/DirectoryReadinessSection.tsx
@@ -1,0 +1,339 @@
+/**
+ * One publisher's directory-readiness section on /conformance.
+ *
+ * ## Why this is not a `SuiteSection`
+ *
+ * It borrows the visual grammar deliberately — same header, same badge ladder,
+ * same collapse behaviour — so the page reads as one thing. What it cannot
+ * borrow is the CONTENT model. A suite renders checks that passed or failed
+ * and a score out of a hundred. Readiness renders lanes that were evaluated to
+ * some degree, findings whose class decides whether they count, coverage that
+ * says what was never looked at, and a paid observation pass that can be
+ * refused without the run failing. There is no score, on purpose.
+ *
+ * ## The three axes, kept apart
+ *
+ * `status` is whether the run finished. `overallStatus` is the grade.
+ * `llmObservations.status` is whether the optional paid pass ran. A completed
+ * run can be `not-ready`; a run whose observations were refused for credit is
+ * still a complete, valid grade. Collapsing any two of them into one badge is
+ * the misreading this product exists to prevent, so the header shows the grade
+ * and the observation state gets its own line.
+ */
+
+import { useCallback, useEffect, useMemo, useState } from "react";
+import {
+  AlertTriangle,
+  ChevronDown,
+  ChevronRight,
+  Loader2,
+  Play,
+  XCircle,
+} from "lucide-react";
+import {
+  CLAUDE_READINESS_LANES,
+  OPENAI_READINESS_LANES,
+  isOpenAIReadinessResult,
+} from "@mcpjam/sdk/browser";
+import { useDirectoryReadinessRun } from "@/hooks/use-directory-readiness-run";
+import {
+  HOSTED_SUBMISSION_MODES,
+  type DirectoryReadinessPublisher,
+  type HostedSubmissionMode,
+} from "@/lib/apis/directory-readiness-api";
+import { DirectoryReadinessReport } from "./DirectoryReadinessReport";
+import { ReadinessLaneList } from "./ReadinessLaneList";
+import { ObservationNotice } from "./ObservationNotice";
+
+const PUBLISHER_LABEL: Record<DirectoryReadinessPublisher, string> = {
+  claude: "Claude Directory Readiness",
+  openai: "OpenAI Directory Readiness",
+};
+
+/**
+ * Why each package mode is offered but disabled.
+ *
+ * Listed rather than hidden: a submitter grading a plugin that ships skills
+ * needs to learn that this surface cannot do it and which one can. A silently
+ * shorter menu teaches nothing.
+ */
+const PACKAGE_MODE_NOTE =
+  "needs a package on your machine — run `mcpjam readiness check`";
+
+const ALL_SUBMISSION_MODES = [
+  { value: "mcp-only", label: "MCP server only", hosted: true },
+  {
+    value: "mcp-imported-skills",
+    label: "MCP + imported skills",
+    hosted: true,
+  },
+  { value: "skills-only", label: "Skills package only", hosted: false },
+  {
+    value: "mcp-uploaded-skills",
+    label: "MCP + uploaded skills",
+    hosted: false,
+  },
+] as const;
+
+function lanesFor(publisher: DirectoryReadinessPublisher): readonly string[] {
+  return publisher === "openai"
+    ? OPENAI_READINESS_LANES
+    : CLAUDE_READINESS_LANES;
+}
+
+function gradeBadge(
+  grade: "ready" | "not-ready" | "incomplete" | null | undefined,
+) {
+  if (grade === "ready") {
+    return <span className="text-[10px] text-green-500">Ready</span>;
+  }
+  if (grade === "not-ready") {
+    return <span className="text-[10px] text-red-400">Not ready</span>;
+  }
+  if (grade === "incomplete") {
+    return <span className="text-[10px] text-amber-500">Incomplete</span>;
+  }
+  return null;
+}
+
+export function DirectoryReadinessSection({
+  publisher,
+  server,
+}: {
+  publisher: DirectoryReadinessPublisher;
+  server: { name: string; config?: unknown };
+}) {
+  const [submissionMode, setSubmissionMode] =
+    useState<HostedSubmissionMode>("mcp-only");
+  const [includeLlmObservations, setIncludeLlmObservations] = useState(false);
+  const [override, setOverride] = useState<boolean | null>(null);
+
+  const { state, hosted, run, cancel, loadReport, rediscover } =
+    useDirectoryReadinessRun({
+      publisher,
+      server,
+      submissionMode: publisher === "openai" ? submissionMode : undefined,
+      includeLlmObservations,
+    });
+
+  // A reload mid-run finds its way back to the run that is still going. Every
+  // other suite on this page loses its result on refresh; readiness is the one
+  // that persists, so not offering this would be throwing away the difference.
+  useEffect(() => {
+    void rediscover();
+  }, [rediscover]);
+
+  const running = state.status === "running";
+  const collapsible = state.status !== "unavailable";
+  const grade = state.report
+    ? (state.report.status as "ready" | "not-ready" | "incomplete")
+    : state.run?.overallStatus ?? null;
+  const hasResult = Boolean(state.report || state.run);
+  // OPEN BY DEFAULT, unlike the suite sections beside it — and for a concrete
+  // reason rather than prominence. Their run control is the page's shared
+  // "Run available checks" button, so a collapsed suite is still runnable.
+  // Readiness owns its own controls, so a collapsed section would hide the
+  // only way to start one, along with the submission mode it needs declared.
+  const expanded = collapsible && (override ?? true);
+
+  const catalogLanes = useMemo(() => lanesFor(publisher), [publisher]);
+
+  const onToggle = useCallback(() => {
+    const next = !expanded;
+    setOverride(next);
+    // The report is megabytes and the row already carries the lane summary, so
+    // it is fetched when somebody actually opens the findings.
+    if (next) void loadReport();
+  }, [expanded, loadReport]);
+
+  const badge = (() => {
+    if (running) {
+      return (
+        <span className="flex items-center gap-1 text-[10px] text-muted-foreground">
+          <Loader2 className="h-3 w-3 animate-spin" />
+          {state.run?.status === "pending" ? "Queued" : "Running"}
+        </span>
+      );
+    }
+    if (state.status === "unavailable") {
+      return (
+        <span className="text-[10px] text-muted-foreground">Unavailable</span>
+      );
+    }
+    if (state.status === "error") {
+      return <span className="text-[10px] text-red-400">Error</span>;
+    }
+    // A run that FAILED never produced a grade; saying "not ready" here would
+    // report our own failure as a verdict about somebody's server.
+    if (state.run && state.run.status === "failed") {
+      return <span className="text-[10px] text-red-400">Run failed</span>;
+    }
+    if (state.run && state.run.status === "cancelled") {
+      return (
+        <span className="text-[10px] text-muted-foreground">Cancelled</span>
+      );
+    }
+    return gradeBadge(grade);
+  })();
+
+  return (
+    <div className="rounded-md border border-border/50 overflow-hidden">
+      <button
+        type="button"
+        className="w-full flex items-center justify-between gap-2 px-3 py-2 bg-muted/30 text-left transition-colors enabled:hover:bg-muted/50 disabled:cursor-default"
+        onClick={onToggle}
+        disabled={!collapsible}
+        aria-expanded={collapsible ? expanded : undefined}
+      >
+        <span className="flex items-center gap-1.5 min-w-0">
+          {collapsible &&
+            (expanded ? (
+              <ChevronDown className="h-3.5 w-3.5 text-muted-foreground flex-shrink-0" />
+            ) : (
+              <ChevronRight className="h-3.5 w-3.5 text-muted-foreground flex-shrink-0" />
+            ))}
+          <span className="text-sm font-medium truncate">
+            {PUBLISHER_LABEL[publisher]}
+          </span>
+        </span>
+        <span className="flex items-center gap-2">{badge}</span>
+      </button>
+
+      <div className="px-2 py-1">
+        {state.status === "unavailable" && state.unavailableReason && (
+          <div className="flex items-center gap-1.5 px-1 py-2 text-xs text-muted-foreground">
+            <AlertTriangle className="h-3 w-3 flex-shrink-0" />
+            {state.unavailableReason}
+          </div>
+        )}
+        {state.status === "error" && state.error && (
+          <div className="px-1 py-2 text-xs text-red-400">{state.error}</div>
+        )}
+
+        {expanded && (
+          <div className="space-y-2 pb-1">
+            <div className="flex flex-wrap items-center gap-2 px-1 pt-1">
+              <button
+                type="button"
+                onClick={() => void run()}
+                disabled={running || state.status === "unavailable"}
+                className="inline-flex items-center gap-1.5 rounded-md bg-primary px-2.5 py-1 text-[11px] font-medium text-primary-foreground transition-colors hover:bg-primary/90 disabled:opacity-50"
+              >
+                <Play className="h-3 w-3" />
+                {hasResult ? "Run again" : "Run readiness"}
+              </button>
+
+              {running && hosted && (
+                <button
+                  type="button"
+                  onClick={() => void cancel()}
+                  className="inline-flex items-center gap-1.5 rounded-md border border-border px-2.5 py-1 text-[11px] text-muted-foreground transition-colors hover:bg-muted/50"
+                >
+                  <XCircle className="h-3 w-3" />
+                  Cancel
+                </button>
+              )}
+
+              {publisher === "openai" && (
+                <label className="flex items-center gap-1.5 text-[11px] text-muted-foreground">
+                  Submission
+                  <select
+                    value={submissionMode}
+                    onChange={(event) =>
+                      setSubmissionMode(
+                        event.target.value as HostedSubmissionMode,
+                      )
+                    }
+                    disabled={running}
+                    className="rounded border border-border bg-background px-1.5 py-0.5 text-[11px]"
+                  >
+                    {ALL_SUBMISSION_MODES.map((mode) => {
+                      const available = (
+                        HOSTED_SUBMISSION_MODES as readonly string[]
+                      ).includes(mode.value);
+                      return (
+                        <option
+                          key={mode.value}
+                          value={mode.value}
+                          disabled={!available}
+                        >
+                          {mode.label}
+                          {available ? "" : ` — ${PACKAGE_MODE_NOTE}`}
+                        </option>
+                      );
+                    })}
+                  </select>
+                </label>
+              )}
+
+              {hosted && (
+                <label className="flex items-center gap-1.5 text-[11px] text-muted-foreground">
+                  <input
+                    type="checkbox"
+                    checked={includeLlmObservations}
+                    onChange={(event) =>
+                      setIncludeLlmObservations(event.target.checked)
+                    }
+                    disabled={running}
+                    className="h-3 w-3"
+                  />
+                  Add AI observations (uses MCPJam credits)
+                </label>
+              )}
+            </div>
+
+            {/* The AI axis, on its own line, because it is its own answer. */}
+            {state.run?.llmObservations && (
+              <ObservationNotice observations={state.run.llmObservations} />
+            )}
+
+            {hasResult ? (
+              <>
+                <ReadinessLaneList
+                  lanes={
+                    state.report
+                      ? state.report.lanes.map((lane) => ({
+                          lane: lane.lane,
+                          status: lane.status,
+                          ...lane.coverage,
+                        }))
+                      : state.run?.lanes ?? []
+                  }
+                  stages={
+                    state.report && isOpenAIReadinessResult(state.report)
+                      ? state.report.stages
+                      : state.run?.stages ?? []
+                  }
+                />
+                <DirectoryReadinessReport
+                  report={state.report}
+                  loading={state.reportLoading}
+                  error={state.reportError}
+                  // A terminal run with no stored report is a fact worth
+                  // stating: it failed before it graded, or its report aged
+                  // out. Silence would read as "no findings".
+                  hasReport={
+                    state.report ? true : state.run?.hasReport ?? false
+                  }
+                  terminalReason={state.run?.terminalReason ?? undefined}
+                  errorMessage={state.run?.errorMessage ?? undefined}
+                />
+              </>
+            ) : running ? (
+              <div className="flex items-center gap-2 px-1 py-3 text-xs text-muted-foreground">
+                <Loader2 className="h-3.5 w-3.5 animate-spin" />
+                Grading {catalogLanes.length} lanes...
+              </div>
+            ) : (
+              <div className="px-1 py-1 text-[10px] text-muted-foreground">
+                {catalogLanes.length} lanes graded against{" "}
+                {publisher === "openai" ? "OpenAI's" : "Anthropic's"} published
+                directory rules — not run yet.
+              </div>
+            )}
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/mcpjam-inspector/client/src/components/conformance/directory-readiness/ObservationNotice.tsx
+++ b/mcpjam-inspector/client/src/components/conformance/directory-readiness/ObservationNotice.tsx
@@ -1,0 +1,97 @@
+/**
+ * The AI-observation axis, on its own line.
+ *
+ * It is independent of the run's status and of the grade, and rendering it as
+ * part of either would state something false. The case that matters most is
+ * `billing-blocked`: the deterministic grade is complete and valid, and the
+ * only thing missing is the optional paid reading. Folding that into the
+ * verdict would tell a submitter their server has a problem when what actually
+ * happened is that we could not afford to look — the exact confusion the
+ * machine-readable `billing_limit_reached` reason exists to prevent.
+ *
+ * So: never an error styling for a refused observation, and never silence
+ * either. A row that says nothing reads as "we looked and it was fine".
+ */
+
+import { Info, Sparkles } from "lucide-react";
+
+export interface ObservationState {
+  status:
+    | "not-requested"
+    | "pending"
+    | "completed"
+    | "billing-blocked"
+    | "provider-failed"
+    | "invalid-output";
+  reason?: string;
+  detail?: string;
+}
+
+/**
+ * What each state means to somebody reading a grade, in their terms.
+ *
+ * Keyed off `status` with `reason` only distinguishing the billing case,
+ * because `reason` is the machine-readable field and string-matching `detail`
+ * would break the moment the backend rewords a sentence.
+ */
+function describe(observations: ObservationState): {
+  tone: "muted" | "info";
+  text: string;
+} | null {
+  switch (observations.status) {
+    case "not-requested":
+      // The default. Saying "you did not ask for the paid thing" on every run
+      // would be noise.
+      return null;
+    case "pending":
+      return { tone: "muted", text: "AI observations are still running." };
+    case "completed":
+      return {
+        tone: "info",
+        text: "AI observations included — shown as non-blocking notes below.",
+      };
+    case "billing-blocked":
+      return {
+        tone: "info",
+        text:
+          observations.reason === "billing_limit_reached"
+            ? "AI observations were skipped: this organization has reached its MCPJam model limit. The grade below is complete without them."
+            : "AI observations were skipped for a billing reason. The grade below is complete without them.",
+      };
+    case "provider-failed":
+      return {
+        tone: "muted",
+        text: "AI observations could not be produced — the model provider did not answer. The grade below is unaffected.",
+      };
+    case "invalid-output":
+      return {
+        tone: "muted",
+        text: "AI observations were discarded because the model's answer did not match the expected shape. The grade below is unaffected.",
+      };
+    default:
+      return null;
+  }
+}
+
+export function ObservationNotice({
+  observations,
+}: {
+  observations: ObservationState;
+}) {
+  const described = describe(observations);
+  if (!described) return null;
+
+  const Icon = observations.status === "completed" ? Sparkles : Info;
+  return (
+    <div
+      className={`flex items-start gap-1.5 rounded-md border border-border/50 px-2 py-1.5 text-[10px] ${
+        described.tone === "info"
+          ? "text-foreground/80"
+          : "text-muted-foreground"
+      }`}
+    >
+      <Icon className="mt-0.5 h-3 w-3 flex-shrink-0" />
+      <span>{described.text}</span>
+    </div>
+  );
+}

--- a/mcpjam-inspector/client/src/components/conformance/directory-readiness/ReadinessLaneList.tsx
+++ b/mcpjam-inspector/client/src/components/conformance/directory-readiness/ReadinessLaneList.tsx
@@ -1,0 +1,127 @@
+/**
+ * Lanes, their grades, and — the part that matters — what was never looked at.
+ *
+ * COVERAGE TRAVELS WITH THE VERDICT, the same rule `ScoreHeadline` follows for
+ * the conformance score. A lane reading "ready" over three evaluated checks
+ * and five that never ran is not the same statement as one reading "ready"
+ * over eight, and a row that showed only the word would make them look
+ * identical. So every lane prints its evaluated count, and every lane with a
+ * gap prints what would close it.
+ *
+ * `missingInputs` is the actionable half: the engine already knows the run
+ * lacked a tool listing or a submission profile, and naming it turns "we could
+ * not tell" into "supply this and we can".
+ */
+
+import { CheckCircle2, MinusCircle, XCircle } from "lucide-react";
+
+type LaneStatus = "ready" | "not-ready" | "incomplete";
+
+export interface ReadinessLaneRow {
+  lane: string;
+  status: LaneStatus;
+  evaluated: number;
+  notEvaluated: number;
+  notApplicable: number;
+  missingInputs: string[];
+}
+
+export interface ReadinessStageRow {
+  stage: string;
+  status: LaneStatus;
+  lanes: string[];
+}
+
+function LaneIcon({ status }: { status: LaneStatus }) {
+  if (status === "ready") {
+    return <CheckCircle2 className="h-3.5 w-3.5 text-green-500" />;
+  }
+  if (status === "not-ready") {
+    return <XCircle className="h-3.5 w-3.5 text-red-400" />;
+  }
+  return <MinusCircle className="h-3.5 w-3.5 text-amber-500" />;
+}
+
+/** `runtime-compatibility` -> `Runtime compatibility`. */
+function laneLabel(lane: string): string {
+  const spaced = lane.replace(/-/g, " ");
+  return spaced.charAt(0).toUpperCase() + spaced.slice(1);
+}
+
+const STAGE_LABEL: Record<string, string> = {
+  "technical-preflight": "Technical preflight",
+  "submission-ready": "Submission ready",
+};
+
+export function ReadinessLaneList({
+  lanes,
+  stages,
+}: {
+  lanes: ReadinessLaneRow[];
+  stages?: ReadinessStageRow[];
+}) {
+  if (lanes.length === 0) return null;
+
+  return (
+    <div className="space-y-2">
+      {/*
+        OpenAI grades two rollups from one set of findings, and the narrower
+        one has to stay visible beside the headline: a submitter whose server
+        is fine and whose paperwork is not should read that without opening
+        anything.
+      */}
+      {stages && stages.length > 0 && (
+        <div className="flex flex-wrap gap-2 px-1">
+          {stages.map((stage) => (
+            <span
+              key={stage.stage}
+              className="inline-flex items-center gap-1.5 rounded-md border border-border/60 px-2 py-1 text-[10px]"
+            >
+              <LaneIcon status={stage.status} />
+              <span className="text-muted-foreground">
+                {STAGE_LABEL[stage.stage] ?? stage.stage}
+              </span>
+            </span>
+          ))}
+        </div>
+      )}
+
+      <div className="divide-y divide-border/40">
+        {lanes.map((lane) => {
+          const total = lane.evaluated + lane.notEvaluated;
+          const hasGap = lane.notEvaluated > 0 || lane.missingInputs.length > 0;
+          return (
+            <div key={lane.lane} className="px-1 py-1.5">
+              <div className="flex items-center justify-between gap-2">
+                <span className="flex items-center gap-1.5 min-w-0">
+                  <LaneIcon status={lane.status} />
+                  <span className="text-xs truncate">
+                    {laneLabel(lane.lane)}
+                  </span>
+                </span>
+                {/*
+                  The denominator travels with the number. `notApplicable` is
+                  stated separately rather than folded in, because "does not
+                  apply here" and "was not checked" are different facts.
+                */}
+                <span className="text-[10px] tabular-nums text-muted-foreground flex-shrink-0">
+                  {lane.evaluated}/{total} evaluated
+                  {lane.notApplicable > 0 ? ` · ${lane.notApplicable} n/a` : ""}
+                </span>
+              </div>
+              {hasGap && (
+                <div className="pl-5 pt-0.5 text-[10px] text-amber-600 dark:text-amber-500">
+                  {lane.missingInputs.length > 0
+                    ? `Supply ${lane.missingInputs.join(
+                        ", ",
+                      )} to close this gap.`
+                    : `${lane.notEvaluated} requirement(s) could not be evaluated.`}
+                </div>
+              )}
+            </div>
+          );
+        })}
+      </div>
+    </div>
+  );
+}

--- a/mcpjam-inspector/client/src/components/conformance/directory-readiness/__tests__/DirectoryReadinessSection.test.tsx
+++ b/mcpjam-inspector/client/src/components/conformance/directory-readiness/__tests__/DirectoryReadinessSection.test.tsx
@@ -1,0 +1,267 @@
+/**
+ * The readiness section, and the four things it must never say.
+ *
+ *   1. A run that FAILED is not a grade. "Not ready" is a statement about
+ *      somebody's server; a runner that fell over has not made one.
+ *   2. A refused AI observation is not a failure. The deterministic grade is
+ *      complete without it, and `billing_limit_reached` means "we could not
+ *      afford to look", never "we looked and it was fine".
+ *   3. A lane's coverage travels with its verdict, so a lane graded over three
+ *      of eight requirements cannot read like one graded over eight.
+ *   4. A package submission mode is offered but disabled, with the reason —
+ *      a shorter menu would leave a submitter thinking readiness cannot grade
+ *      their plugin at all.
+ */
+
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+
+const mockRunLocal = vi.fn();
+const mockStartHosted = vi.fn();
+const mockGetRun = vi.fn();
+const mockGetReport = vi.fn();
+const mockCancel = vi.fn();
+const mockFindLatest = vi.fn();
+const mockIsHosted = vi.fn(() => false);
+
+vi.mock("@/lib/apis/directory-readiness-api", async () => {
+  const actual = await vi.importActual<
+    typeof import("@/lib/apis/directory-readiness-api")
+  >("@/lib/apis/directory-readiness-api");
+  return {
+    ...actual,
+    runLocalReadiness: (...args: unknown[]) => mockRunLocal(...args),
+    startHostedReadiness: (...args: unknown[]) => mockStartHosted(...args),
+    getHostedReadinessRun: (...args: unknown[]) => mockGetRun(...args),
+    getHostedReadinessReport: (...args: unknown[]) => mockGetReport(...args),
+    cancelHostedReadinessRun: (...args: unknown[]) => mockCancel(...args),
+    findLatestHostedReadinessRun: (...args: unknown[]) =>
+      mockFindLatest(...args),
+    canRunHostedReadiness: () => true,
+  };
+});
+
+vi.mock("@/lib/apis/mode-client", () => ({
+  isHostedMode: () => mockIsHosted(),
+  runByMode: (arg: { local: () => unknown }) => arg.local(),
+}));
+
+import { DirectoryReadinessSection } from "../DirectoryReadinessSection";
+
+const HTTP_SERVER = {
+  name: "demo",
+  config: { url: new URL("https://demo.example.com/mcp") },
+};
+
+const STDIO_SERVER = {
+  name: "local-demo",
+  config: { command: "node", args: ["server.js"] },
+};
+
+function claudeResult(overrides: Record<string, unknown> = {}) {
+  return {
+    status: "not-ready",
+    summary: "runtime-compatibility has unmet requirements.",
+    context: { target: "https://demo.example.com/mcp" },
+    lanes: [
+      {
+        lane: "runtime-compatibility",
+        status: "not-ready",
+        coverage: {
+          lane: "runtime-compatibility",
+          evaluated: 3,
+          notEvaluated: 5,
+          notApplicable: 0,
+          missingInputs: ["toolListing"],
+        },
+      },
+    ],
+    findings: [
+      {
+        id: "claude.auth.prm",
+        title: "Protected Resource Metadata is discoverable",
+        lane: "runtime-compatibility",
+        class: "required",
+        status: "violated",
+        remediation: "Publish a PRM document.",
+      },
+      {
+        id: "claude.experience.overlap",
+        title: "Two tools appear to cover the same job",
+        lane: "experience-insights",
+        class: "heuristic",
+        status: "informational",
+        provenance: "llm",
+      },
+    ],
+    badges: [],
+    ...overrides,
+  };
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockIsHosted.mockReturnValue(false);
+  mockFindLatest.mockResolvedValue(null);
+});
+
+describe("local mode", () => {
+  it("grades inline and groups findings by what they cost", async () => {
+    mockRunLocal.mockResolvedValue({ success: true, result: claudeResult() });
+    render(
+      <DirectoryReadinessSection publisher="claude" server={HTTP_SERVER} />,
+    );
+
+    await userEvent.click(
+      screen.getByRole("button", { name: /run readiness/i }),
+    );
+
+    await waitFor(() => {
+      expect(screen.getByText(/Directory requirements/i)).toBeInTheDocument();
+    });
+    // The class decides whether a finding moved the verdict, so a reader has
+    // to be able to tell a requirement from an opinion.
+    expect(screen.getByText(/Observations/i)).toBeInTheDocument();
+    expect(screen.getByText(/Not ready/i)).toBeInTheDocument();
+  });
+
+  it("shows what a lane could not evaluate, beside its verdict", async () => {
+    mockRunLocal.mockResolvedValue({ success: true, result: claudeResult() });
+    render(
+      <DirectoryReadinessSection publisher="claude" server={HTTP_SERVER} />,
+    );
+
+    await userEvent.click(
+      screen.getByRole("button", { name: /run readiness/i }),
+    );
+
+    await waitFor(() => {
+      expect(screen.getByText(/3\/8 evaluated/)).toBeInTheDocument();
+    });
+    expect(
+      screen.getByText(/Supply toolListing to close this gap/i),
+    ).toBeInTheDocument();
+  });
+
+  it("offers no AI toggle at all, because a local run cannot spend", () => {
+    render(
+      <DirectoryReadinessSection publisher="claude" server={HTTP_SERVER} />,
+    );
+    expect(screen.queryByText(/uses MCPJam credits/i)).not.toBeInTheDocument();
+  });
+});
+
+describe("a server this cannot grade", () => {
+  it("says so instead of dialling and reading a 400", () => {
+    render(
+      <DirectoryReadinessSection publisher="claude" server={STDIO_SERVER} />,
+    );
+    expect(screen.getByText(/Unavailable/i)).toBeInTheDocument();
+    expect(
+      screen.queryByRole("button", { name: /run readiness/i }),
+    ).not.toBeInTheDocument();
+  });
+});
+
+describe("hosted mode", () => {
+  beforeEach(() => {
+    mockIsHosted.mockReturnValue(true);
+  });
+
+  it("reports a failed RUN as a failed run, never as a verdict", async () => {
+    mockStartHosted.mockResolvedValue({
+      runId: "run_1",
+      status: "pending",
+      deduped: false,
+      includeLlmObservations: false,
+      readinessKind: "claude",
+      projectId: "p",
+      serverId: "s",
+    });
+    mockGetRun.mockResolvedValue({
+      id: "run_1",
+      status: "failed",
+      overallStatus: null,
+      lanes: [],
+      stages: [],
+      terminalReason: "deadline_exceeded",
+      errorMessage: null,
+      hasReport: false,
+      llmObservations: { status: "not-requested" },
+      includeLlmObservations: false,
+    });
+
+    render(
+      <DirectoryReadinessSection publisher="claude" server={HTTP_SERVER} />,
+    );
+    await userEvent.click(
+      screen.getByRole("button", { name: /run readiness/i }),
+    );
+
+    await waitFor(() => {
+      expect(screen.getByText(/Run failed/i)).toBeInTheDocument();
+    });
+    // The distinction the product exists for: our runner falling over is not
+    // a finding about somebody else's server.
+    expect(screen.queryByText(/Not ready/i)).not.toBeInTheDocument();
+    expect(screen.getByText(/deadline_exceeded/)).toBeInTheDocument();
+  });
+
+  it("reports a refused observation as a gap, not a failure", async () => {
+    mockStartHosted.mockResolvedValue({
+      runId: "run_2",
+      status: "pending",
+      deduped: false,
+      includeLlmObservations: true,
+      readinessKind: "claude",
+      projectId: "p",
+      serverId: "s",
+    });
+    mockGetRun.mockResolvedValue({
+      id: "run_2",
+      status: "completed",
+      overallStatus: "ready",
+      lanes: [],
+      stages: [],
+      terminalReason: null,
+      errorMessage: null,
+      hasReport: true,
+      llmObservations: {
+        status: "billing-blocked",
+        reason: "billing_limit_reached",
+      },
+      includeLlmObservations: true,
+    });
+    mockGetReport.mockResolvedValue(claudeResult({ status: "ready" }));
+
+    render(
+      <DirectoryReadinessSection publisher="claude" server={HTTP_SERVER} />,
+    );
+    await userEvent.click(
+      screen.getByRole("button", { name: /run readiness/i }),
+    );
+
+    await waitFor(() => {
+      expect(
+        screen.getByText(/reached its MCPJam model limit/i),
+      ).toBeInTheDocument();
+    });
+    // The grade stands on its own; the missing paid pass does not demote it.
+    expect(
+      screen.getByText(/The grade below is complete without them/i),
+    ).toBeInTheDocument();
+    expect(screen.getByText(/^Ready$/i)).toBeInTheDocument();
+  });
+
+  it("offers the package modes disabled, with the surface that can run them", () => {
+    render(
+      <DirectoryReadinessSection publisher="openai" server={HTTP_SERVER} />,
+    );
+    const packageOption = screen.getByRole("option", {
+      name: /Skills package only/i,
+    }) as HTMLOptionElement;
+    expect(packageOption.disabled).toBe(true);
+    expect(packageOption.textContent).toMatch(/mcpjam readiness check/i);
+  });
+});

--- a/mcpjam-inspector/client/src/hooks/use-directory-readiness-run.ts
+++ b/mcpjam-inspector/client/src/hooks/use-directory-readiness-run.ts
@@ -1,0 +1,385 @@
+/**
+ * One directory-readiness section's run, in either execution mode.
+ *
+ * ## Why this is not `use-conformance-run`
+ *
+ * That hook runs four suites that are all the same shape: one await, one
+ * verdict, a score. Readiness is neither shape — locally it is a synchronous
+ * call that answers inline, and hosted it is a durable run with a lease, a
+ * poll, a cancel and a separately-fetched report. It also carries inputs no
+ * suite has (a declared submission mode, a billed opt-in) and produces a
+ * verdict vocabulary that does not compose into the pooled score.
+ *
+ * Bolting all of that onto a 690-line hook with a second consumer would make
+ * every reader of the conformance page pay for readiness's complexity.
+ *
+ * ## What is copied from it, deliberately
+ *
+ * The run-token and `serverConfigKey` discipline. Those are the genuinely
+ * subtle parts — a late response from a previous server must not land in the
+ * new server's state — and they are worth duplicating rather than sharing,
+ * because the sharing would be the coupling above.
+ */
+
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import {
+  canRunConformance,
+  isOpenAIReadinessResult,
+  type OpenAISubmissionMode,
+} from "@mcpjam/sdk/browser";
+import {
+  cancelHostedReadinessRun,
+  canRunHostedReadiness,
+  findLatestHostedReadinessRun,
+  getHostedReadinessReport,
+  getHostedReadinessRun,
+  isTerminalRunStatus,
+  runLocalReadiness,
+  startHostedReadiness,
+  type DirectoryReadinessPublisher,
+  type DirectoryReadinessResult,
+  type HostedSubmissionMode,
+  type ReadinessRun,
+} from "@/lib/apis/directory-readiness-api";
+import { isHostedMode } from "@/lib/apis/mode-client";
+
+export type ReadinessSectionStatus =
+  | "idle"
+  | "running"
+  | "done"
+  | "error"
+  | "unavailable";
+
+export interface DirectoryReadinessState {
+  status: ReadinessSectionStatus;
+  /** Why this server cannot be graded at all (stdio, no URL). */
+  unavailableReason?: string;
+  error?: string;
+  /** The hosted run row, absent for a local run. */
+  run?: ReadinessRun;
+  /** The graded report: inline locally, lazily fetched when hosted. */
+  report?: DirectoryReadinessResult;
+  /** True while the report itself is being fetched. */
+  reportLoading?: boolean;
+  reportError?: string;
+}
+
+interface ServerLike {
+  name: string;
+  config?: unknown;
+}
+
+/**
+ * Poll intervals, widening as a run proves it is long.
+ *
+ * A readiness run dials somebody else's server: the first answers arrive in
+ * seconds, and a run still going after a minute is usually waiting on a slow
+ * hop rather than about to finish. Polling every two seconds for fifteen
+ * minutes would be a request per second per open tab for a row that changes
+ * twice, so the interval widens and the tail is cheap.
+ */
+const POLL_LADDER_MS = [2_000, 5_000, 15_000] as const;
+/** Steps at each rung before widening. */
+const POLL_STEPS_PER_RUNG = 5;
+
+/**
+ * Jitter, because every tab watching the same run would otherwise poll in
+ * lockstep after a deploy or a network blip.
+ */
+function withJitter(intervalMs: number): number {
+  return intervalMs + Math.floor(Math.random() * (intervalMs * 0.2));
+}
+
+function pollIntervalFor(tick: number): number {
+  const rung = Math.min(
+    Math.floor(tick / POLL_STEPS_PER_RUNG),
+    POLL_LADDER_MS.length - 1,
+  );
+  return withJitter(POLL_LADDER_MS[rung]!);
+}
+
+export interface UseDirectoryReadinessRunOptions {
+  publisher: DirectoryReadinessPublisher;
+  server: ServerLike;
+  /** Required for OpenAI. Never inferred — see the section component. */
+  submissionMode?: HostedSubmissionMode;
+  includeLlmObservations?: boolean;
+}
+
+export function useDirectoryReadinessRun({
+  publisher,
+  server,
+  submissionMode,
+  includeLlmObservations = false,
+}: UseDirectoryReadinessRunOptions) {
+  const hosted = isHostedMode();
+
+  const initialState = useCallback((): DirectoryReadinessState => {
+    // Readiness grades an HTTP endpoint, so the transport question is the same
+    // one the protocol suite asks. Answering it here means a stdio server
+    // shows "Unavailable" rather than making the request and reading a 400.
+    const support = canRunConformance(
+      "protocol",
+      server.config as Parameters<typeof canRunConformance>[1],
+    );
+    if (!support.supported) {
+      return { status: "unavailable", unavailableReason: support.reason };
+    }
+    return { status: "idle" };
+  }, [server.config]);
+
+  const [state, setState] = useState<DirectoryReadinessState>(initialState);
+
+  // See `use-conformance-run`: the name alone is not enough, because editing a
+  // server's URL in place would leave the previous target's grade on screen.
+  const serverConfigKey = useMemo(() => {
+    const config = server.config as
+      | { url?: unknown; command?: unknown; args?: unknown }
+      | undefined;
+    return JSON.stringify([
+      server.name,
+      config?.url != null ? String(config.url) : null,
+      typeof config?.command === "string" ? config.command : null,
+      Array.isArray(config?.args) ? config.args : null,
+    ]);
+  }, [server.name, server.config]);
+
+  /** Bumped by every start and every reset; stale async work checks it. */
+  const runTokenRef = useRef(0);
+  const abortRef = useRef<AbortController | null>(null);
+  const pollTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const activeRunIdRef = useRef<string | null>(null);
+
+  const clearPoll = useCallback(() => {
+    if (pollTimerRef.current) {
+      clearTimeout(pollTimerRef.current);
+      pollTimerRef.current = null;
+    }
+  }, []);
+
+  const reset = useCallback(() => {
+    runTokenRef.current += 1;
+    abortRef.current?.abort();
+    abortRef.current = null;
+    activeRunIdRef.current = null;
+    clearPoll();
+    setState(initialState());
+  }, [clearPoll, initialState]);
+
+  useEffect(() => {
+    reset();
+    // `serverConfigKey` is the trigger; the rest is read through it.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [serverConfigKey, publisher]);
+
+  useEffect(() => {
+    return () => {
+      runTokenRef.current += 1;
+      abortRef.current?.abort();
+      clearPoll();
+    };
+  }, [clearPoll]);
+
+  const isCurrent = useCallback((token: number) => {
+    return token === runTokenRef.current;
+  }, []);
+
+  /** One poll, then schedule the next unless the run is done. */
+  const pollRun = useCallback(
+    async (runId: string, token: number, tick: number) => {
+      if (!isCurrent(token)) return;
+      // PAUSED WHILE HIDDEN. A backgrounded tab watching a fifteen-minute run
+      // is pure load with nobody reading the answer; the visibility listener
+      // below resumes with an immediate poll, so nothing is missed.
+      if (typeof document !== "undefined" && document.hidden) {
+        pollTimerRef.current = setTimeout(
+          () => void pollRun(runId, token, tick),
+          POLL_LADDER_MS[POLL_LADDER_MS.length - 1]!,
+        );
+        return;
+      }
+
+      try {
+        const run = await getHostedReadinessRun(runId);
+        if (!isCurrent(token)) return;
+        setState((prev) => ({
+          ...prev,
+          run,
+          status: isTerminalRunStatus(run.status) ? "done" : "running",
+        }));
+        if (isTerminalRunStatus(run.status)) {
+          clearPoll();
+          return;
+        }
+      } catch (error) {
+        if (!isCurrent(token)) return;
+        // A failed poll is not a failed run: the run continues on the server
+        // and the next poll may well succeed. Only a persistent failure that
+        // outlasts the run is worth surfacing, and the row's own terminal
+        // state is what eventually reports it.
+        if (import.meta.env?.DEV) {
+          console.warn("[readiness] poll failed", error);
+        }
+      }
+
+      pollTimerRef.current = setTimeout(
+        () => void pollRun(runId, token, tick + 1),
+        pollIntervalFor(tick),
+      );
+    },
+    [clearPoll, isCurrent],
+  );
+
+  // Resume immediately when the tab comes back, rather than waiting out the
+  // long interval a hidden tab was sitting on.
+  useEffect(() => {
+    if (typeof document === "undefined") return;
+    const onVisible = () => {
+      if (document.hidden) return;
+      const runId = activeRunIdRef.current;
+      if (!runId) return;
+      clearPoll();
+      void pollRun(runId, runTokenRef.current, 0);
+    };
+    document.addEventListener("visibilitychange", onVisible);
+    return () => document.removeEventListener("visibilitychange", onVisible);
+  }, [clearPoll, pollRun]);
+
+  const run = useCallback(async () => {
+    runTokenRef.current += 1;
+    const token = runTokenRef.current;
+    clearPoll();
+    setState({ status: "running" });
+
+    try {
+      if (!hosted) {
+        const controller = new AbortController();
+        abortRef.current = controller;
+        const { result } = await runLocalReadiness(publisher, server.name, {
+          submissionMode: submissionMode as OpenAISubmissionMode | undefined,
+        });
+        if (!isCurrent(token)) return;
+        setState({ status: "done", report: result });
+        return;
+      }
+
+      const receipt = await startHostedReadiness(publisher, server.name, {
+        submissionMode,
+        includeLlmObservations,
+        // One key per start press: a double-click replays onto the run it
+        // already made rather than dialling somebody's server twice.
+        idempotencyKey: `ui-${publisher}-${token}-${Date.now()}`,
+      });
+      if (!isCurrent(token)) return;
+      activeRunIdRef.current = receipt.runId;
+      void pollRun(receipt.runId, token, 0);
+    } catch (error) {
+      if (!isCurrent(token)) return;
+      setState({
+        status: "error",
+        error: error instanceof Error ? error.message : String(error),
+      });
+    }
+  }, [
+    clearPoll,
+    hosted,
+    includeLlmObservations,
+    isCurrent,
+    pollRun,
+    publisher,
+    server.name,
+    submissionMode,
+  ]);
+
+  const cancel = useCallback(async () => {
+    const runId = activeRunIdRef.current;
+    if (!hosted) {
+      // Local has no run row; stopping means abandoning the request.
+      runTokenRef.current += 1;
+      abortRef.current?.abort();
+      setState(initialState());
+      return;
+    }
+    if (!runId) return;
+    try {
+      await cancelHostedReadinessRun(runId);
+      // DELIBERATELY KEEPS POLLING. The response is a synthetic `cancelled`;
+      // the executing node only learns on its next heartbeat, so the row's
+      // real terminal state arrives later. Showing `cancelled` now and then
+      // never correcting it would be the UI asserting something it does not
+      // know yet.
+    } catch (error) {
+      setState((prev) => ({
+        ...prev,
+        error: error instanceof Error ? error.message : String(error),
+      }));
+    }
+  }, [hosted, initialState]);
+
+  /** Fetch the report on first expand — it can be megabytes. */
+  const loadReport = useCallback(async () => {
+    const runId = state.run?.id;
+    if (!runId || state.report || state.reportLoading) return;
+    if (!state.run?.hasReport) return;
+    const token = runTokenRef.current;
+    setState((prev) => ({
+      ...prev,
+      reportLoading: true,
+      reportError: undefined,
+    }));
+    try {
+      const report = await getHostedReadinessReport(runId);
+      if (!isCurrent(token)) return;
+      setState((prev) => ({ ...prev, report, reportLoading: false }));
+    } catch (error) {
+      if (!isCurrent(token)) return;
+      setState((prev) => ({
+        ...prev,
+        reportLoading: false,
+        reportError: error instanceof Error ? error.message : String(error),
+      }));
+    }
+  }, [isCurrent, state.report, state.reportLoading, state.run]);
+
+  /**
+   * Adopt the newest run for this server after a reload.
+   *
+   * Only when this section holds no run of its own, and only for a matching
+   * server and publisher — the list endpoint's "newest" is the wrong answer
+   * for somebody who was watching an older run.
+   */
+  const rediscover = useCallback(async () => {
+    if (!hosted || activeRunIdRef.current || state.status !== "idle") return;
+    if (!canRunHostedReadiness(server.name)) return;
+    const token = runTokenRef.current;
+    try {
+      const latest = await findLatestHostedReadinessRun(publisher, server.name);
+      if (!latest || !isCurrent(token)) return;
+      activeRunIdRef.current = latest.id;
+      setState({
+        run: latest,
+        status: isTerminalRunStatus(latest.status) ? "done" : "running",
+      });
+      if (!isTerminalRunStatus(latest.status)) {
+        void pollRun(latest.id, token, 0);
+      }
+    } catch {
+      // A page that could not find a previous run simply offers a new one.
+    }
+  }, [hosted, isCurrent, pollRun, publisher, server.name, state.status]);
+
+  const isOpenAI = state.report
+    ? isOpenAIReadinessResult(state.report)
+    : publisher === "openai";
+
+  return {
+    state,
+    hosted,
+    isOpenAI,
+    run,
+    cancel,
+    loadReport,
+    rediscover,
+    reset,
+  };
+}

--- a/mcpjam-inspector/client/src/lib/__tests__/session-token.readiness.test.ts
+++ b/mcpjam-inspector/client/src/lib/__tests__/session-token.readiness.test.ts
@@ -1,0 +1,96 @@
+/**
+ * The hosted bearer on the readiness routes — and, just as importantly, off
+ * everything beside them.
+ *
+ * `/web/registry/*` shipped without a `HOSTED_AUTH_PATH_PREFIXES` entry and
+ * every call went out unauthenticated, so this is the failure mode with
+ * precedent. Readiness cannot use a prefix at all: its scope sits in the
+ * MIDDLE of the path (`/api/v1/projects/{id}/readiness-runs`), and the prefix
+ * that would cover it — `/api/v1/projects/` — would hand the user's bearer to
+ * every project-scoped public-API route that ever ships.
+ *
+ * So the grant is a pattern, and the half of this file that matters most is
+ * the second half: proof that the pattern stayed narrow.
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+
+vi.mock("@/lib/apis/web/context", () => ({
+  getApiAuthorizationHeader: vi.fn(async () => "Bearer hosted-bearer"),
+}));
+
+vi.mock("@/lib/convex-site-url", () => ({
+  getConvexSiteUrl: () => "https://outstanding-fennec-304.convex.site",
+}));
+
+describe("authFetch bearer on directory-readiness routes", () => {
+  let sessionToken: typeof import("../session-token");
+
+  beforeEach(async () => {
+    vi.resetModules();
+    delete (window as any).__MCP_SESSION_TOKEN__;
+    vi.mocked(global.fetch).mockReset();
+    vi.mocked(global.fetch).mockResolvedValue(
+      new Response("{}", { status: 200 }),
+    );
+    sessionToken = await import("../session-token");
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  function headersOf(call: number): Record<string, string> {
+    const init = vi.mocked(global.fetch).mock.calls[call]?.[1] as RequestInit;
+    return (init?.headers ?? {}) as Record<string, string>;
+  }
+
+  for (const path of [
+    "/api/v1/projects/proj_1/servers/srv_1/readiness-runs/claude",
+    "/api/v1/projects/proj_1/servers/srv_1/readiness-runs/openai",
+    "/api/v1/projects/proj_1/readiness-runs",
+    "/api/v1/projects/proj_1/readiness-runs/run_1",
+    "/api/v1/projects/proj_1/readiness-runs/run_1/cancel",
+    "/api/v1/projects/proj_1/readiness-runs/run_1/report",
+  ]) {
+    it(`attaches the bearer to ${path}`, async () => {
+      await sessionToken.authFetch(path, { method: "POST" });
+      expect(headersOf(0).Authorization).toBe("Bearer hosted-bearer");
+    });
+  }
+
+  it("attaches it with a query string, which the list call always has", async () => {
+    await sessionToken.authFetch(
+      "/api/v1/projects/proj_1/readiness-runs?readinessKind=claude&limit=1",
+      { method: "GET" },
+    );
+    expect(headersOf(0).Authorization).toBe("Bearer hosted-bearer");
+  });
+
+  for (const path of [
+    // The blanket prefix this pattern exists to avoid: a sibling
+    // project-scoped route must NOT inherit the UI's bearer.
+    "/api/v1/projects/proj_1/servers/srv_1/tools",
+    "/api/v1/projects/proj_1/evals",
+    "/api/v1/projects/proj_1",
+    // A path that merely starts the same way.
+    "/api/v1/projects/proj_1/readiness-runs-export",
+    // One segment too many under a run.
+    "/api/v1/projects/proj_1/readiness-runs/run_1/report/raw",
+    // The publisher is a closed set, not a wildcard.
+    "/api/v1/projects/proj_1/servers/srv_1/readiness-runs/anthropic",
+  ]) {
+    it(`does NOT attach the bearer to ${path}`, async () => {
+      await sessionToken.authFetch(path, { method: "POST" });
+      expect(headersOf(0).Authorization).toBeUndefined();
+    });
+  }
+
+  it("does not attach the bearer to a foreign origin on a readiness path", async () => {
+    await sessionToken.authFetch(
+      "https://evil.example.com/api/v1/projects/proj_1/readiness-runs",
+      { method: "GET" },
+    );
+    expect(headersOf(0).Authorization).toBeUndefined();
+  });
+});

--- a/mcpjam-inspector/client/src/lib/apis/directory-readiness-api.ts
+++ b/mcpjam-inspector/client/src/lib/apis/directory-readiness-api.ts
@@ -1,0 +1,296 @@
+/**
+ * The /conformance page's two ways to grade a server against a directory.
+ *
+ * ## Why this is not in `mcp-conformance-api.ts`
+ *
+ * Every suite beside it is one request that returns a verdict. Readiness is
+ * two different shapes wearing one name:
+ *
+ *   LOCAL   — a synchronous call that grades and answers inline. Free, no run
+ *             row, no persistence, and structurally unable to spend: the route
+ *             has no observations flag at all.
+ *   HOSTED  — `202` with a receipt, then polling, then a separate report
+ *             fetch, with a cancel that stops traffic to somebody else's
+ *             server. It runs on `/api/v1` rather than `/api/web`, because
+ *             that is where the durable run lifecycle lives.
+ *
+ * `runByMode` cannot express that: its two branches are supposed to be the
+ * same operation against different backends, and here one returns a result
+ * while the other returns a receipt. So the mode fork is explicit, and the
+ * hook above normalizes the two into one state machine.
+ *
+ * ## Why `authFetch` and not `webPost`
+ *
+ * `webPost` speaks the `/api/web` envelope and ingests hosted RPC logs into
+ * the traffic-log store. The v1 envelope is a different contract, so the
+ * calls here go through `authFetch` directly. The visible cost is that
+ * readiness traffic does NOT appear in the traffic log where the other suites'
+ * does — a real gap, accepted rather than papered over, because faking the web
+ * envelope to get log ingestion would make readiness lie about which API it
+ * used.
+ */
+
+import type {
+  ClaudeReadinessResult,
+  OpenAIReadinessResult,
+  OpenAISubmissionMode,
+} from "@mcpjam/sdk/browser";
+import { authFetch } from "@/lib/session-token";
+import { localPost } from "@/lib/apis/local-post";
+import {
+  getHostedProjectId,
+  resolveHostedServerId,
+  tryResolveProjectServer,
+} from "@/lib/apis/web/context";
+
+export type DirectoryReadinessPublisher = "claude" | "openai";
+
+export type DirectoryReadinessResult =
+  | ClaudeReadinessResult
+  | OpenAIReadinessResult;
+
+/**
+ * The submission shapes a HOSTED run can grade.
+ *
+ * Two of OpenAI's four carry a package, and there is no upload for it — those
+ * only ever run on the CLI. Offering them here and failing at the API would
+ * teach a submitter that readiness is broken rather than that they are on the
+ * wrong surface.
+ */
+export const HOSTED_SUBMISSION_MODES = [
+  "mcp-only",
+  "mcp-imported-skills",
+] as const satisfies readonly OpenAISubmissionMode[];
+
+export type HostedSubmissionMode = (typeof HOSTED_SUBMISSION_MODES)[number];
+
+export type ReadinessRunStatus =
+  | "pending"
+  | "running"
+  | "completed"
+  | "failed"
+  | "cancelled";
+
+/** The three axes, exactly as the row carries them. */
+export interface ReadinessRun {
+  id: string;
+  readinessKind: DirectoryReadinessPublisher;
+  serverId: string | null;
+  serverUrl: string;
+  submissionMode: OpenAISubmissionMode | null;
+  /** Whether the RUN finished. Not whether it graded well. */
+  status: ReadinessRunStatus;
+  /** The GRADE. `completed` + `not-ready` is a finished run that failed. */
+  overallStatus: "ready" | "not-ready" | "incomplete" | null;
+  lanes: Array<{
+    lane: string;
+    status: "ready" | "not-ready" | "incomplete";
+    evaluated: number;
+    notEvaluated: number;
+    notApplicable: number;
+    missingInputs: string[];
+  }>;
+  stages: Array<{
+    stage: string;
+    status: "ready" | "not-ready" | "incomplete";
+    lanes: string[];
+  }>;
+  attemptCount: number;
+  terminalReason: string | null;
+  errorMessage: string | null;
+  policySnapshotDate: string | null;
+  engineVersion: string | null;
+  includeLlmObservations: boolean;
+  /** Independent of `status`: a refused observation still completes the run. */
+  llmObservations: {
+    status:
+      | "not-requested"
+      | "pending"
+      | "completed"
+      | "billing-blocked"
+      | "provider-failed"
+      | "invalid-output";
+    reason?: string;
+    detail?: string;
+  };
+  hasReport: boolean;
+  createdAt: number;
+  updatedAt: number;
+}
+
+export interface ReadinessRunReceipt {
+  runId: string;
+  projectId: string;
+  serverId: string;
+  readinessKind: DirectoryReadinessPublisher;
+  status: ReadinessRunStatus;
+  /** True when an idempotency replay returned a run that already existed. */
+  deduped: boolean;
+  includeLlmObservations: boolean;
+}
+
+/** Terminal states: nothing about this run will change again. */
+export function isTerminalRunStatus(status: ReadinessRunStatus): boolean {
+  return (
+    status === "completed" || status === "failed" || status === "cancelled"
+  );
+}
+
+/** True when the app can reach the hosted run lifecycle for this server. */
+export function canRunHostedReadiness(serverNameOrId: string): boolean {
+  return tryResolveProjectServer(serverNameOrId) !== null;
+}
+
+async function v1Json<T>(
+  path: string,
+  init?: RequestInit & { signal?: AbortSignal },
+): Promise<T> {
+  const response = await authFetch(path, {
+    ...init,
+    headers: { "content-type": "application/json", ...(init?.headers ?? {}) },
+  });
+  const text = await response.text();
+  const parsed = text ? (JSON.parse(text) as unknown) : null;
+  if (!response.ok) {
+    // The v1 envelope reports `{error: {code, message}}`; anything else is a
+    // proxy or a network edge, and the status is the only honest thing to say.
+    const message =
+      (parsed as { error?: { message?: string } } | null)?.error?.message ??
+      `Request failed (${response.status})`;
+    throw new Error(message);
+  }
+  return parsed as T;
+}
+
+// ── Local: synchronous, free, no run row ────────────────────────────────
+
+export async function runLocalReadiness(
+  publisher: DirectoryReadinessPublisher,
+  serverNameOrId: string,
+  options?: { submissionMode?: OpenAISubmissionMode },
+): Promise<{ success: boolean; result: DirectoryReadinessResult }> {
+  return localPost(`/api/mcp/conformance/readiness/${publisher}`, {
+    serverId: serverNameOrId,
+    ...(options?.submissionMode
+      ? { submissionMode: options.submissionMode }
+      : {}),
+  });
+}
+
+// ── Hosted: start, poll, cancel, report ─────────────────────────────────
+
+export async function startHostedReadiness(
+  publisher: DirectoryReadinessPublisher,
+  serverNameOrId: string,
+  options: {
+    submissionMode?: HostedSubmissionMode;
+    includeLlmObservations?: boolean;
+    idempotencyKey?: string;
+  } = {},
+): Promise<ReadinessRunReceipt> {
+  const projectId = getHostedProjectId();
+  const serverId = resolveHostedServerId(serverNameOrId);
+
+  // FIELDS PICKED, NEVER SPREAD. The start schema is a `strictObject`, so an
+  // unknown key is a 400 rather than an ignored extra — and a rejected start
+  // never reaches its idempotency key, so the retry would dedupe against
+  // nothing and start a second run against somebody's server.
+  const body: Record<string, unknown> = {};
+  if (options.idempotencyKey) body.idempotencyKey = options.idempotencyKey;
+  if (options.includeLlmObservations === true) {
+    body.includeLlmObservations = true;
+  }
+  if (publisher === "openai") {
+    if (!options.submissionMode) {
+      throw new Error(
+        "An OpenAI readiness run needs a declared submission mode.",
+      );
+    }
+    body.submissionMode = options.submissionMode;
+  }
+
+  return v1Json<ReadinessRunReceipt>(
+    `/api/v1/projects/${encodeURIComponent(
+      projectId,
+    )}/servers/${encodeURIComponent(serverId)}/readiness-runs/${publisher}`,
+    { method: "POST", body: JSON.stringify(body) },
+  );
+}
+
+export async function getHostedReadinessRun(
+  runId: string,
+  signal?: AbortSignal,
+): Promise<ReadinessRun> {
+  const projectId = getHostedProjectId();
+  return v1Json<ReadinessRun>(
+    `/api/v1/projects/${encodeURIComponent(
+      projectId,
+    )}/readiness-runs/${encodeURIComponent(runId)}`,
+    { method: "GET", signal },
+  );
+}
+
+/**
+ * The newest run for this server and publisher, for a page that was reloaded.
+ *
+ * Only ever a FALLBACK for a mount with no run id in hand: two runs started
+ * close together make "the newest" the wrong answer for whoever was watching
+ * the older one, so a caller that knows its run id must ask for that one.
+ */
+export async function findLatestHostedReadinessRun(
+  publisher: DirectoryReadinessPublisher,
+  serverNameOrId: string,
+  signal?: AbortSignal,
+): Promise<ReadinessRun | null> {
+  const scope = tryResolveProjectServer(serverNameOrId);
+  if (!scope) return null;
+  const params = new URLSearchParams({
+    readinessKind: publisher,
+    serverId: scope.serverId,
+    limit: "1",
+  });
+  const page = await v1Json<{ items?: ReadinessRun[] }>(
+    `/api/v1/projects/${encodeURIComponent(
+      scope.projectId,
+    )}/readiness-runs?${params}`,
+    { method: "GET", signal },
+  );
+  return page.items?.[0] ?? null;
+}
+
+/**
+ * Ask the platform to stop.
+ *
+ * The response is a synthetic `cancelled` rather than the row: the executing
+ * node learns on its next heartbeat, so the run's REAL terminal state arrives
+ * on a later poll. Callers keep polling after this returns.
+ */
+export async function cancelHostedReadinessRun(runId: string): Promise<void> {
+  const projectId = getHostedProjectId();
+  await v1Json<unknown>(
+    `/api/v1/projects/${encodeURIComponent(
+      projectId,
+    )}/readiness-runs/${encodeURIComponent(runId)}/cancel`,
+    { method: "POST" },
+  );
+}
+
+/**
+ * The full graded report, fetched lazily.
+ *
+ * Megabytes are possible, and the run row already carries everything the
+ * collapsed section renders — so this is called when a reader opens the
+ * findings, not alongside every poll.
+ */
+export async function getHostedReadinessReport(
+  runId: string,
+  signal?: AbortSignal,
+): Promise<DirectoryReadinessResult> {
+  const projectId = getHostedProjectId();
+  return v1Json<DirectoryReadinessResult>(
+    `/api/v1/projects/${encodeURIComponent(
+      projectId,
+    )}/readiness-runs/${encodeURIComponent(runId)}/report`,
+    { method: "GET", signal },
+  );
+}

--- a/mcpjam-inspector/client/src/lib/session-token.ts
+++ b/mcpjam-inspector/client/src/lib/session-token.ts
@@ -366,7 +366,30 @@ function isHostedAuthAllowedOrigin(parsed: URL): boolean {
   return false;
 }
 
+/**
+ * Paths whose SCOPE sits in the middle, so no prefix can name them.
+ *
+ * `/api/v1/projects/{projectId}/readiness-runs...` and its server-scoped start
+ * carry ids the UI substitutes at call time, and the interesting segment comes
+ * after them. The alternative was the prefix `/api/v1/projects/`, which would
+ * hand the user's bearer to every project-scoped public-API route that ever
+ * ships — the exact opposite of the path-by-path scoping the list above
+ * exists to maintain. A pattern keeps the grant as narrow as the prefixes are.
+ *
+ * Anchored at both ends, and the id segments match one segment each: nothing
+ * with an extra path component can slip through.
+ */
+const HOSTED_AUTH_PATH_PATTERNS = [
+  // The /conformance page starting, polling, cancelling and reading a
+  // directory-readiness run.
+  /^\/api\/v1\/projects\/[^/]+\/readiness-runs(\/[^/]+(\/(cancel|report))?)?$/,
+  /^\/api\/v1\/projects\/[^/]+\/servers\/[^/]+\/readiness-runs\/(claude|openai)$/,
+];
+
 function pathMatchesHostedPrefix(pathname: string): boolean {
+  if (HOSTED_AUTH_PATH_PATTERNS.some((pattern) => pattern.test(pathname))) {
+    return true;
+  }
   return HOSTED_AUTH_PATH_PREFIXES.some((prefix) => {
     if (prefix.endsWith("/")) return pathname.startsWith(prefix);
     // Non-trailing-slash entries match the literal path AND any sub-path


### PR DESCRIPTION
The sections that make directory readiness visible on the page. The engine, the hosted API and the free local route shipped weeks apart and nothing in the product called any of them — this is the first surface that does.

Behind `mcpjam-directory-readiness` (a **section** flag; `/conformance` is already gated by `mcpjam-conformance`, so no sidebar or route work).

## Each section owns its run

Deliberately outside the page's shared "Run available checks" button: a hosted run takes minutes, and joining the shared busy state would hold that button *and* the protocol-version selector hostage for the duration. Outside the pooled score for a different reason — readiness produces lanes and coverage, not passed/failed checks, so there is no number to pool.

That is also why these sections open by default while the suites do not. A collapsed suite is still runnable from the page button; a collapsed readiness section would hide the only way to start one, plus the submission mode it needs declared first.

## Two execution modes behind one control

| | Local | Hosted |
|---|---|---|
| Shape | synchronous, result inline | `202` → poll → cancel → lazy report |
| Cost | free, *structurally* unable to spend | opt-in AI observations |
| Survives reload | no run row | **yes** — rediscovers via the list endpoint |

Polling widens 2s → 5s → 15s with jitter and pauses on a hidden tab. The report is fetched only when somebody opens the findings — it can be megabytes and the row already carries the lane summary.

Reload-rediscovery is a **fallback only**: a section that knows its run id asks for that run, because "newest run for this server" is the wrong answer for someone watching an older one.

**Cancel keeps polling.** The route answers with a synthetic `cancelled` and the node learns on its next heartbeat, so the real terminal state arrives later. Showing `cancelled` immediately and never correcting it would assert something the UI does not know yet.

## The three axes stay apart

- A run that **failed** shows "Run failed", never "not ready" — our runner falling over is not a finding about somebody's server.
- A **refused AI observation** is a gap with its reason, never a failure. `billing_limit_reached` means "we could not afford to look"; the deterministic grade is complete without it. Keyed off the machine-readable `reason`, not the prose, so a reworded backend sentence can't turn a billing message into an outage message.

## Coverage travels with every verdict

Every lane prints what it evaluated out of what it selected, states `not applicable` separately from `not evaluated`, and names the input that would close its gap. Findings group by class in fix-order, because the class is what decides whether a finding moved the verdict — and a model-authored line is labelled as one.

The two package submission modes are offered but **disabled**, naming the CLI command that runs them. A shorter menu would teach a submitter that readiness cannot grade their plugin at all.

## The bearer

Hosted routes need the user's token and their scope sits mid-path, so no prefix names them. Rather than allowlisting `/api/v1/projects/` — which would hand the bearer to every project-scoped public route that ever ships — `HOSTED_AUTH_PATH_PREFIXES` gains a sibling pattern list, anchored at both ends. **Six paths that must carry it and six neighbours that must not** are both tested; `/web/registry/*` already shipped once without its entry and 401'd everything.

## Verification

- 48 tests in the touched areas, 1336 across `client/src/lib` + `components/conformance`. All 27 existing ConformancePanel tests still pass (flag off ⇒ unchanged page).
- `npm run build:client` succeeds, and no new file imports from `@mcpjam/sdk` outside `/browser` — the constraint that has broken this bundle twice.

Next: the operation catalog + registries (MCP tools, agent, chat), then the bots.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Touches hosted bearer attachment in `authFetch` (new path patterns for project-scoped v1 routes) and starts long-running hosted jobs that can spend credits. Flag-gated UI, but a too-wide or too-narrow match would leak or drop credentials.
> 
> **Overview**
> Adds Claude and OpenAI **directory readiness** sections on `/conformance`, gated by `mcpjam-directory-readiness`. This is the first UI that calls the existing engine, local route, and hosted run API.
> 
> Each section owns its run (outside “Run available checks” and the pooled score). Local runs grade inline and cannot spend; hosted runs start, poll with a widening interval, cancel, rediscover after reload, and fetch the report lazily. Run status, grade, and optional AI observations stay separate — a failed runner is “Run failed,” not “not ready”; billing-blocked observations are a gap, not a failure.
> 
> Lanes show coverage and missing inputs; findings group by class. OpenAI package modes that need a local upload are listed but disabled. Hosted v1 readiness paths get the user bearer via narrow `HOSTED_AUTH_PATH_PATTERNS` instead of allowlisting all of `/api/v1/projects/`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ddf12bf12d3b857e990496a899525e297efa9b59. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds Claude and OpenAI directory readiness to the /conformance page behind the `mcpjam-directory-readiness` flag. Each section runs independently (local synchronous or hosted durable), shows lane coverage and findings, and keeps run status, grade, and optional LLM observations as separate concerns.

- Findings group by class (blockers, required, recommended, manual review, observations). Lanes display evaluated vs not-evaluated counts and missing inputs.

**Review notes**
- `ConformancePanel.tsx` renders two `DirectoryReadinessSection`s when `mcpjam-directory-readiness` is on. Sections are open by default, outside the page “Run available checks” control and excluded from the pooled score.
- `use-directory-readiness-run` handles local vs hosted runs, widening poll intervals with jitter, pausing when the tab is hidden, rediscovering the newest run after reload (fallback only), idempotent starts, cancel-that-keeps-polling, and lazy report fetch.
- `directory-readiness-api.ts` calls `/api/v1/.../readiness-runs` via `authFetch` (not `webPost`). `session-token.ts` adds exact `HOSTED_AUTH_PATH_PATTERNS` so only readiness routes carry the hosted bearer; tests cover allowed and disallowed paths.
- Hosted OpenAI submission modes restrict to `mcp-only` and `mcp-imported-skills`; package modes are listed but disabled with the CLI hint (`mcpjam readiness check`). LLM-authored observations are labeled and never counted as dispositive.
- Tests cover section behavior, lane coverage display, observation states, disabled package modes, and bearer scoping. Client build passes.

**Rollout**
- Gated by `mcpjam-directory-readiness` (the route is already gated by `mcpjam-conformance`). No navigation changes.
- Hosted “Add LLM observations” consumes MCPJam credits; default off. Local runs cannot spend.
- Requires `/api/v1` readiness run endpoints to be live; otherwise the section shows Unavailable or run errors.
- Bearer pattern scope is narrow by design; verify no leakage to other project-scoped routes. Readiness traffic does not appear in the web traffic log by design.

<sup>Written for commit ddf12bf12d3b857e990496a899525e297efa9b59. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/MCPJam/inspector/pull/4168?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

