### PR TITLE
Fix main: readiness lanes wrote `lane` twice

### DIFF
--- a/mcpjam-inspector/client/src/components/conformance/directory-readiness/DirectoryReadinessSection.tsx
+++ b/mcpjam-inspector/client/src/components/conformance/directory-readiness/DirectoryReadinessSection.tsx
@@ -292,12 +292,19 @@ export function DirectoryReadinessSection({
                 <ReadinessLaneList
                   lanes={
                     state.report
-                      ? state.report.lanes.map((lane) => ({
-                          lane: lane.lane,
-                          status: lane.status,
-                          ...lane.coverage,
+                      ? // FIELD BY FIELD rather than spreading `coverage`.
+                        // Coverage carries its own `lane`, so a spread after
+                        // `lane:` writes the same key twice — harmless at
+                        // runtime, and a `tsc` error that fails the build.
+                        state.report.lanes.map((entry) => ({
+                          lane: entry.lane,
+                          status: entry.status,
+                          evaluated: entry.coverage.evaluated,
+                          notEvaluated: entry.coverage.notEvaluated,
+                          notApplicable: entry.coverage.notApplicable,
+                          missingInputs: entry.coverage.missingInputs,
                         }))
-                      : state.run?.lanes ?? []
+                      : (state.run?.lanes ?? [])
                   }
                   stages={
                     state.report && isOpenAIReadinessResult(state.report)


### PR DESCRIPTION
`typecheck:client` is failing on main with **TS2783** — my bug from #4168, and it takes `Build and Test` down with it.

The lane rows for a locally-graded result set `lane` and then spread `coverage`, which carries its own `lane`. Same value, no runtime effect, hard `tsc` error.

Built field by field instead. The spread is what let the duplicate in unnoticed; the explicit version names the four numbers the row actually renders.

**Why it escaped review:** I verified #4168 with `tsc --noEmit -p tsconfig.json` filtered to my own files. CI runs `npm run typecheck:client`, which uses `client/tsconfig.typecheck.json` — a different config, and the only one that flags this. This time I ran that exact command (exit 0), then reverted the fix and watched it fail at `DirectoryReadinessSection.tsx(296,27)`.

34 conformance component tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Narrow UI mapping change with no runtime behavior shift; it only unblocks client typecheck.
> 
> **Overview**
> Fixes a **TS2783** client typecheck failure that was breaking `typecheck:client` / CI.
> 
> `ReadinessLaneList` rows were built by setting `lane` then spreading `coverage`, which already includes `lane`. Runtime was unchanged (same value), but TypeScript rejects the duplicate key. Mapping now copies coverage counts field-by-field (`evaluated`, `notEvaluated`, `notApplicable`, `missingInputs`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8efcf656a7d1b7b0c6611526af8ea780e04cbc67. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a `TS2783` build error on `main` by removing a duplicate `lane` key when constructing readiness lanes. Previously we set `lane` and then spread `coverage` (which also includes `lane`); now we enumerate coverage fields explicitly. Runtime behavior is unchanged.

- Only change is in `mcpjam-inspector/client/src/components/conformance/directory-readiness/DirectoryReadinessSection.tsx`: the map sets `evaluated`, `notEvaluated`, `notApplicable`, and `missingInputs` directly.
- No migration needed. `npm run typecheck:client` now passes; verify locally using `client/tsconfig.typecheck.json`.

<sup>Written for commit 8efcf656a7d1b7b0c6611526af8ea780e04cbc67. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/MCPJam/inspector/pull/4171?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

