### PR TITLE
test(v1): map the readiness-run routes to their SDK client methods

### DIFF
--- a/mcpjam-inspector/server/routes/v1/__tests__/sdk-coverage.test.ts
+++ b/mcpjam-inspector/server/routes/v1/__tests__/sdk-coverage.test.ts
@@ -267,6 +267,18 @@ const ROUTE_TO_SDK: Readonly<Record<string, string>> = {
   // Tunnels
   "post /projects/{projectId}/tunnels": "createTunnel",
   "post /projects/{projectId}/tunnels/{serverId}/close": "closeTunnel",
+
+  // Directory readiness
+  "post /projects/{projectId}/servers/{serverId}/readiness-runs/claude":
+    "startClaudeReadinessRun",
+  "post /projects/{projectId}/servers/{serverId}/readiness-runs/openai":
+    "startOpenAIReadinessRun",
+  "get /projects/{projectId}/readiness-runs": "listReadinessRuns",
+  "get /projects/{projectId}/readiness-runs/{runId}": "getReadinessRun",
+  "get /projects/{projectId}/readiness-runs/{runId}/report":
+    "getReadinessReport",
+  "post /projects/{projectId}/readiness-runs/{runId}/cancel":
+    "cancelReadinessRun",
 };
 
 /**


### PR DESCRIPTION
- `sdk-coverage.test.ts` has been failing on `main` since #4153 / #4158, so every open PR inherits a red check.
- Those PRs added six `/api/v1` readiness-run routes. The test requires every route to be either mapped to an SDK client method or explicitly excluded with a reason, and these were in neither map.
- `PlatformApiClient` already has all six methods (`startClaudeReadinessRun`, `startOpenAIReadinessRun`, `listReadinessRuns`, `getReadinessRun`, `getReadinessReport`, `cancelReadinessRun`), so this maps them rather than excluding them — the routes really are reachable from the SDK.
- Test-only, no changeset. The test validates each mapped name against `PlatformApiClient.prototype`, so a wrong or renamed method would still fail.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Maps six `/api/v1` readiness-run routes in `sdk-coverage.test.ts` to their `PlatformApiClient` methods so the coverage check passes again. Previously these routes were added without a mapping or exclusion, which broke the test on `main`; now each route maps to an existing method and the test asserts the method exists on `PlatformApiClient.prototype`.

- Adds six `ROUTE_TO_SDK` mappings: `startClaudeReadinessRun`, `startOpenAIReadinessRun`, `listReadinessRuns`, `getReadinessRun`, `getReadinessReport`, `cancelReadinessRun`.
- Test-only; no runtime changes and no changeset.

<sup>Written for commit a229cf444b58ac05dfbbc0011074547b096ec1c6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/MCPJam/inspector/pull/4172?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

