### PR TITLE
fix(docs): resolve duplicate keys in openapi.json breaking Mintlify build

### DIFF
--- a/docs/reference/openapi.json
+++ b/docs/reference/openapi.json
@@ -8246,15 +8246,6 @@
           "type": "string"
         }
       },
-      "scenarioId": {
-        "name": "scenarioId",
-        "in": "path",
-        "required": true,
-        "description": "Scenario ID, as returned by the project's scenario list.",
-        "schema": {
-          "type": "string"
-        }
-      },
       "hostId": {
         "name": "hostId",
         "in": "path",
@@ -11806,7 +11797,7 @@
           }
         }
       },
-      "Scenario": {
+      "ScenarioSummary": {
         "type": "object",
         "description": "Summary of a published scenario, as returned by the list endpoint.",
         "required": [
@@ -12037,7 +12028,7 @@
           "items": {
             "type": "array",
             "items": {
-              "$ref": "#/components/schemas/Scenario"
+              "$ref": "#/components/schemas/ScenarioSummary"
             }
           }
         }


### PR DESCRIPTION
## Problem

`npx mint dev` (and any Mintlify build of the docs) fails to start with:

> Openapi file reference/openapi.json defined in group in your docs.json exists but is invalid: Invalid JSON or YAML syntax: duplicated mapping key

JSON tolerates duplicate keys (last-wins), but Mintlify's OpenAPI parser rejects them. This is pre-existing on `main` and blocks docs preview for everyone. Two collisions, both fallout from the chatbox→scenario rename (#4050):

1. **`components/parameters.scenarioId`** — defined twice. The two definitions are the same path param and differ only in `description`. Removed the shadowed first copy; the surviving one is the version already resolved by every consumer today, so the effective spec is unchanged.

2. **`components/schemas.Scenario`** — defined twice with **different shapes**:
   - a list *summary* object (`serverCount`, `serverNames`, `projectId`, …), described as "as returned by the list endpoint", and
   - a published *environment* object (`environmentId`, `accessVersion`, `link`, `created`, …).

   Because of last-wins, every `$ref: #/components/schemas/Scenario` resolved to the environment shape — so `ScenarioPage.items` (the list response) was silently documenting the **wrong** shape. Renamed the summary shape to **`ScenarioSummary`** and repointed `ScenarioPage.items` at it. The single-object responses keep `Scenario` (the environment shape), which is correct.

## Result

- `openapi.json` parses and has **zero** duplicate keys (verified with a strict parser using `object_pairs_hook`).
- The list endpoint now documents the summary shape it actually returns.
- No behavioral change to the single-object endpoints.

## Scope

Docs-only, no code changes. Unblocks `mint dev`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes duplicate keys in `docs/reference/openapi.json` that broke `mint dev` and caused the Scenario list to resolve to the wrong schema. Previously, JSON last-wins made `#/components/schemas/Scenario` point to the environment shape; now the list uses `ScenarioSummary` and the file parses under Mintlify.

- Removed the shadowed duplicate `components/parameters.scenarioId`.
- Renamed the list summary schema to `ScenarioSummary` and updated `ScenarioPage.items` to reference it; single-object endpoints still use `Scenario`.
- Docs-only; no API or runtime changes.

<sup>Written for commit 7cce4cb861737b6f6f80f5738191acc446f9b2e9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/MCPJam/inspector/pull/4174?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

