### PR TITLE
Readiness sections need no flag of their own

### DIFF
--- a/.changeset/readiness-drop-section-flag.md
+++ b/.changeset/readiness-drop-section-flag.md
@@ -1,0 +1,19 @@
+---
+"@mcpjam/inspector": patch
+---
+
+Readiness sections need no flag of their own
+
+`/conformance` is already gated by `mcpjam-conformance` — the sidebar filters
+the nav item and, more to the point, `App.tsx` redirects the route away unless
+the flag reads `true`. Nobody without it can reach the page at all, so a
+second flag on two sections inside that page gated an audience against itself.
+
+The cost was not theoretical: the sections shipped invisible, waiting on a
+flag that had to be created before anyone could see the feature that had
+already merged.
+
+Removed rather than switched to `mcpjam-conformance`, because the check adds
+nothing over the gate that already ran. A flag can be reintroduced in one line
+if readiness ever needs to lag the page — deleting one later is the harder
+direction, and this one had no consumers.

--- a/mcpjam-inspector/client/src/components/conformance/ConformancePanel.tsx
+++ b/mcpjam-inspector/client/src/components/conformance/ConformancePanel.tsx
@@ -1,5 +1,4 @@
 import { useState, useMemo } from "react";
-import { useFeatureFlagEnabled } from "posthog-js/react";
 import { Button } from "@mcpjam/design-system/button";
 import { DirectoryReadinessSection } from "@/components/conformance/directory-readiness/DirectoryReadinessSection";
 import {
@@ -486,15 +485,6 @@ function SuiteSection({
 }
 
 function ConformanceContent({ server }: { server: ServerWithName }) {
-  // A SECTION flag, not a route flag: `/conformance` is already gated by
-  // `mcpjam-conformance` (nav item and the route redirect in App.tsx), so
-  // these two sections only need to decide whether to render. `=== true`
-  // rather than `!== false`, because a section that pops in after PostHog
-  // hydrates is a better failure than one that flashes for users the flag
-  // excludes.
-  const directoryReadinessEnabled =
-    useFeatureFlagEnabled("mcpjam-directory-readiness") === true;
-
   // Run state, per-suite scores and the pooled headline all live in the shared
   // hook — score.mcpjam.com runs the same four suites and must pool them the
   // same way. Rendering stays here.
@@ -518,7 +508,7 @@ function ConformanceContent({ server }: { server: ServerWithName }) {
 
   const protocolChecks = useMemo(
     () => protocolCatalog(versionPin),
-    [versionPin]
+    [versionPin],
   );
 
   return (
@@ -526,10 +516,9 @@ function ConformanceContent({ server }: { server: ServerWithName }) {
       <div className="space-y-1 border-b border-border/50 pb-4">
         <h2 className="text-lg font-semibold">Conformance</h2>
         <p className="text-sm text-muted-foreground">
-          Run Protocol, Apps, Tasks, and OAuth checks against {server.name}.
-          {directoryReadinessEnabled
-            ? " Directory readiness grades it against Anthropic's and OpenAI's published rules."
-            : ""}
+          Run Protocol, Apps, Tasks, and OAuth checks against {server.name}.{" "}
+          Directory readiness grades it against Anthropic's and OpenAI's
+          published rules.
         </p>
       </div>
 
@@ -701,12 +690,8 @@ function ConformanceContent({ server }: { server: ServerWithName }) {
           passed/failed checks, so there is no number to pool. Each section
           owns its own run control.
         */}
-        {directoryReadinessEnabled && (
-          <>
-            <DirectoryReadinessSection publisher="claude" server={server} />
-            <DirectoryReadinessSection publisher="openai" server={server} />
-          </>
-        )}
+        <DirectoryReadinessSection publisher="claude" server={server} />
+        <DirectoryReadinessSection publisher="openai" server={server} />
       </div>
     </div>
   );

--- a/mcpjam-inspector/client/src/components/conformance/__tests__/ConformancePanel.test.tsx
+++ b/mcpjam-inspector/client/src/components/conformance/__tests__/ConformancePanel.test.tsx
@@ -274,7 +274,9 @@ describe("ConformanceTab", () => {
     });
 
     render(<ConformanceTab server={createHttpServer()} />);
-    fireEvent.click(screen.getByRole("button", { name: /run available checks/i }));
+    fireEvent.click(
+      screen.getByRole("button", { name: /run available checks/i }),
+    );
 
     // Pooled: 4/4 applicable across the suites, one SHOULD advisory (-2)
     // from protocol readiness = 98. The number appears twice: the pooled
@@ -293,14 +295,15 @@ describe("ConformanceTab", () => {
     // The advisory that deducted is visible, tier and all.
     expect(screen.getByText("Metadata Quality")).toBeInTheDocument();
     expect(screen.getByText("(SHOULD)")).toBeInTheDocument();
-
   });
 
   it("renders no score card when nothing was applicable", async () => {
     setupSuccessfulRunMocks();
 
     render(<ConformanceTab server={createHttpServer()} />);
-    fireEvent.click(screen.getByRole("button", { name: /run available checks/i }));
+    fireEvent.click(
+      screen.getByRole("button", { name: /run available checks/i }),
+    );
 
     await waitFor(() =>
       expect(screen.getByText("Protocol summary")).toBeInTheDocument(),
@@ -338,6 +341,17 @@ describe("ConformanceTab", () => {
     expect(screen.getByText("Apps")).toBeDefined();
     expect(screen.getByText("Tasks")).toBeDefined();
     expect(screen.getByText("OAuth")).toBeDefined();
+  });
+
+  it("shows the readiness sections without a flag of their own", () => {
+    // This file mocks no feature-flag provider, so the sections appearing here
+    // IS the assertion: reaching this page already required
+    // `mcpjam-conformance`, and a second flag would have gated an audience
+    // against itself. If one is ever reintroduced, this fails.
+    render(<ConformanceTab server={createHttpServer()} />);
+
+    expect(screen.getByText("Claude Directory Readiness")).toBeDefined();
+    expect(screen.getByText("OpenAI Directory Readiness")).toBeDefined();
   });
 
   it("runs the tasks suite and renders its summary with the resolved wire", async () => {
@@ -426,7 +440,9 @@ describe("ConformanceTab", () => {
     await user.click(screen.getByRole("button", { name: /Protocol/ }));
 
     expect(screen.getByText("Ping")).toBeDefined();
-    expect(screen.getByText(/checks in this suite — not run yet/)).toBeDefined();
+    expect(
+      screen.getByText(/checks in this suite — not run yet/),
+    ).toBeDefined();
   });
 
   it("explains a check when its catalog row is clicked", async () => {
@@ -437,15 +453,11 @@ describe("ConformanceTab", () => {
 
     // The row shows the canonical title; the explanation stays hidden until
     // the row itself is opened.
-    expect(
-      screen.queryByText("Server responds to ping requests."),
-    ).toBeNull();
+    expect(screen.queryByText("Server responds to ping requests.")).toBeNull();
 
     await user.click(screen.getByRole("button", { name: /^Ping/ }));
 
-    expect(
-      screen.getByText("Server responds to ping requests."),
-    ).toBeDefined();
+    expect(screen.getByText("Server responds to ping requests.")).toBeDefined();
   });
 
   it("narrows the protocol catalog to the pinned version's era", async () => {
@@ -975,5 +987,4 @@ describe("ConformanceTab", () => {
     ).toBeDefined();
     expect(screen.getAllByText("404").length).toBe(2);
   });
-
 });


### PR DESCRIPTION
Answering a question that turned out to have a better answer than the one I'd built: **can readiness just live under the conformance flag?**

It doesn't need either. `/conformance` is already gated by `mcpjam-conformance` — the sidebar filters the nav item, and `App.tsx:3977` redirects the route away unless the flag reads `true`. Nobody without it reaches the page. My `mcpjam-directory-readiness` check therefore gated an audience against itself: every reader who could see the check had already passed the same test.

The cost wasn't theoretical — the sections merged **invisible** and stayed that way, waiting on a flag someone had to create before the already-shipped feature could be seen.

**Removed rather than repointed at `mcpjam-conformance`**, because the check adds nothing over the gate that already ran, and a flag nobody needs is still one to create, remember, and eventually delete. If readiness ever needs to lag the page — the page graduating to a wider audience before this does — it's one line to reintroduce, and there'll be a real reason to pick the boundary. Deleting a flag with users is the harder direction; this one had none.

The pinning test asserts the sections render in a file that mocks **no flag provider at all**, so a reintroduced gate fails it rather than silently hiding the feature again.

## Verification

- 35 conformance component tests pass (34 existing + the new one).
- `npm run typecheck:client` clean.

**Effect: the readiness sections become visible on `/conformance` for everyone who can already open that page — no PostHog work needed.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI-only flag removal on a page already gated by `mcpjam-conformance`. No auth, data, or scoring-path changes.
> 
> **Overview**
> Always show Claude and OpenAI directory readiness on `/conformance`. The extra `mcpjam-directory-readiness` flag was redundant: the page is already gated by `mcpjam-conformance` (nav + `App.tsx` redirect), so the sections shipped invisible until a second unused flag existed.
> 
> The flag is **removed**, not remapped. Copy always mentions directory readiness. A test asserts both sections render with **no** flag provider, so a reintroduced gate would fail rather than hide the feature again.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a4a8274b1275a64e386bc8bdfca6aed6198e1a60. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make readiness sections on `/conformance` always visible to users who can access the page. Previously they were hidden behind `mcpjam-directory-readiness`; now they follow the existing `mcpjam-conformance` gate only.

- Remove `useFeatureFlagEnabled("mcpjam-directory-readiness")` and conditional rendering; always render both readiness sections (Claude and OpenAI).
- Update the page intro to always mention directory readiness.
- Add a test that asserts readiness sections render with no flag provider, preventing regressions.
- No PostHog changes required; if present, the `mcpjam-directory-readiness` flag is now unused.

<sup>Written for commit a4a8274b1275a64e386bc8bdfca6aed6198e1a60. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/MCPJam/inspector/pull/4178?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

