### PR TITLE
Evals: make case generation spend-idempotent for the callers that actually retry

### DIFF
--- a/cli/src/commands/eval.ts
+++ b/cli/src/commands/eval.ts
@@ -3071,6 +3071,10 @@ export function registerEvalCommands(program: Command): void {
         "--vary-user-styles",
         "Vary query phrasing across a realistic range of user styles"
       )
+      .option(
+        "--idempotency-key <key>",
+        "Retry-safety key: repeating the call replays the first attempt's drafts instead of generating (and billing) again"
+      )
   ).action(
     async (
       options: PlatformOptions & {
@@ -3086,6 +3090,7 @@ export function registerEvalCommands(program: Command): void {
         complex?: string;
         negative?: string;
         varyUserStyles?: boolean;
+        idempotencyKey?: string;
       },
       command
     ) => {
@@ -3122,6 +3127,9 @@ export function registerEvalCommands(program: Command): void {
           : {}),
         ...(Object.keys(caseMix).length > 0 ? { caseMix } : {}),
         ...(options.varyUserStyles ? { varyUserStyles: true } : {}),
+        ...(options.idempotencyKey
+          ? { idempotencyKey: options.idempotencyKey }
+          : {}),
       });
       await executeOp(generateEvalCasesOperation, input, options, command);
     }

--- a/docs/cli/reference.mdx
+++ b/docs/cli/reference.mdx
@@ -1440,6 +1440,7 @@ AI-generate test cases from the suite's tools (spends credits).
 | `--complex <n>` | No | How many hard / cross-server cases |
 | `--negative <n>` | No | How many negative (no-tool) cases |
 | `--vary-user-styles` | No | Vary query phrasing across a realistic range of user styles |
+| `--idempotency-key <key>` | No | Retry-safety key: repeating the call replays the first attempt's drafts instead of generating (and billing) again |
 
 ---
 

--- a/mcpjam-inspector/server/routes/v1/__tests__/agent-op-registry.test.ts
+++ b/mcpjam-inspector/server/routes/v1/__tests__/agent-op-registry.test.ts
@@ -1013,7 +1013,6 @@ describe("tier derives from operation.risk", () => {
     "delete_project_server",
     "delete_sandbox_image",
     "duplicate_host",
-    "generate_eval_cases",
     "promote_sandbox_image",
     "reset_computer",
     "restore_project_environment",
@@ -1031,11 +1030,11 @@ describe("tier derives from operation.risk", () => {
   ]);
 
   /**
-   * The 36 writes above predate `risk`. This number may only go DOWN — if
+   * The 35 writes above predate `risk`. This number may only go DOWN — if
    * you are raising it to admit a new unclassified write, classify the write
    * instead; that is one field in the SDK catalog.
    */
-  const UNCLASSIFIED_WRITES_CEILING = 36;
+  const UNCLASSIFIED_WRITES_CEILING = 35;
 
   it("pins the unclassified legacy writes — the list only shrinks", () => {
     const unclassified = ALL_OPERATIONS.filter(

--- a/mcpjam-inspector/server/routes/v1/__tests__/eval-edit.test.ts
+++ b/mcpjam-inspector/server/routes/v1/__tests__/eval-edit.test.ts
@@ -1601,6 +1601,75 @@ describe("v1 eval-edit routes", () => {
     expect(createArgs.promptTurns).toBeUndefined();
   });
 
+  it("generate carries the backend's sanitized arguments through verbatim", async () => {
+    // Producer-side regression for the assertions that could never pass. The
+    // backend now drops every expected-argument entry the case's own prompt
+    // does not determine, so what arrives here is already narrow. This pins
+    // that the inspector neither re-inflates it nor drops what survived: the
+    // step's args are EXACTLY the backend's, and an empty object stays empty
+    // (under `partial` matching that reads as "this tool was called", which is
+    // the assertion a correct server can satisfy).
+    createAuthorizedManagerMock.mockResolvedValue({
+      manager: { disconnectAllServers: vi.fn().mockResolvedValue(undefined) },
+    });
+    generateEvalTestsMock.mockResolvedValue({
+      success: true,
+      tests: [
+        {
+          title: "Draw a rectangle",
+          query: "Draw a rectangle on the canvas",
+          runs: 1,
+          expectedToolCalls: [
+            { toolName: "create_element", arguments: { type: "rectangle" } },
+          ],
+        },
+        {
+          title: "Draw a flowchart",
+          query: "Draw a flowchart of our deploy process",
+          runs: 1,
+          expectedToolCalls: [{ toolName: "create_element", arguments: {} }],
+        },
+      ],
+    });
+    convexQueryMock.mockImplementation((name: string) => {
+      if (name === "testSuites:getSuiteRunServerSelection")
+        return Promise.resolve({ serverIds: ["srv_1"], serverNames: ["S"] });
+      return defaultQueryImpl(name);
+    });
+
+    const res = await request(
+      "POST",
+      "/api/v1/projects/p1/eval-suites/suite_1/cases/generate",
+      { mode: "normal" }
+    );
+    expect(res.status).toBe(200);
+
+    const assertions = allAuthoredCaseArgs()
+      .flatMap((item: any) => item.steps ?? [])
+      .filter((step: any) => step.kind === "assert")
+      .map((step: any) => step.assertion);
+    expect(assertions).toEqual([
+      {
+        type: "toolCalledWith",
+        toolName: "create_element",
+        args: { args: { type: "rectangle" } },
+      },
+      {
+        type: "toolCalledWith",
+        toolName: "create_element",
+        args: { args: {} },
+      },
+    ]);
+    // No unmatched free-form payload anywhere: every asserted argument value
+    // is a scalar. A nested object or array here is the shape that made the
+    // 2026-08-20 Excalidraw cases unpassable.
+    for (const assertion of assertions) {
+      for (const value of Object.values(assertion.args.args)) {
+        expect(typeof value).not.toBe("object");
+      }
+    }
+  });
+
   it("generate discovers tools from the suite's environment, not its saved selection", async () => {
     createAuthorizedManagerMock.mockResolvedValue({
       manager: { disconnectAllServers: vi.fn().mockResolvedValue(undefined) },
@@ -1845,6 +1914,155 @@ describe("v1 eval-edit routes", () => {
         (c) => c[0] === "testSuites:recordCaseGeneration"
       )
     ).toBe(false);
+  });
+
+  /**
+   * The gap these close: before this, the generate route read ONLY the
+   * `x-mcpjam-idempotency-key` header, while `PlatformApiClient` sends
+   * `idempotency-key` and the operation had no body field at all. So the CLI,
+   * the MCP plugin, and direct SDK callers — exactly the surfaces that hit the
+   * 30s client timeout and retry — had no way to reach the ledger, and every
+   * retry re-spent. The failure was SILENT: a key went out on the wire and
+   * nothing read it.
+   *
+   * Each test therefore asserts against the ledger read (`getCaseGeneration`
+   * carries the key) and not merely that a key was sent.
+   */
+  function ledgerKeys(): unknown[] {
+    return convexQueryMock.mock.calls
+      .filter((c) => c[0] === "testSuites:getCaseGeneration")
+      .map((c) => (c[1] as any)?.idempotencyKey);
+  }
+
+  function withNoPriorLedger() {
+    convexQueryMock.mockImplementation((name: string) => {
+      if (name === "testSuites:getSuiteRunServerSelection")
+        return Promise.resolve({ serverIds: ["srv_1"], serverNames: ["S"] });
+      if (name === "testSuites:getCaseGeneration") return Promise.resolve(null);
+      return defaultQueryImpl(name);
+    });
+  }
+
+  async function generateWith(init: {
+    headers?: Record<string, string>;
+    body?: Record<string, unknown>;
+  }) {
+    createAuthorizedManagerMock.mockResolvedValue({
+      manager: { disconnectAllServers: vi.fn().mockResolvedValue(undefined) },
+    });
+    generateEvalTestsMock.mockResolvedValue({ success: true, tests: [] });
+    withNoPriorLedger();
+    return makeApp().request(
+      "/api/v1/projects/p1/eval-suites/suite_1/cases/generate",
+      {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          Authorization: "Bearer tok",
+          ...(init.headers ?? {}),
+        },
+        body: JSON.stringify({ mode: "normal", ...(init.body ?? {}) }),
+      }
+    );
+  }
+
+  it("generate reaches the ledger with a BODY idempotency key", async () => {
+    const res = await generateWith({ body: { idempotencyKey: "cli-run-7" } });
+    expect(res.status).toBe(200);
+    expect(ledgerKeys()).toContain("cli-run-7");
+    expect(
+      convexMutationMock.mock.calls.find(
+        (c) => c[0] === "testSuites:recordCaseGeneration"
+      )?.[1].idempotencyKey
+    ).toBe("cli-run-7");
+  });
+
+  it("generate reaches the ledger with the SDK client's transport header", async () => {
+    // `PlatformApiClient` puts `options.idempotencyKey` here, unprefixed.
+    // Reading only the prefixed spelling is what made a key sent this way
+    // degrade silently to no idempotency at all.
+    const res = await generateWith({
+      headers: { "idempotency-key": "sdk-transport-key" },
+    });
+    expect(res.status).toBe(200);
+    expect(ledgerKeys()).toContain("sdk-transport-key");
+  });
+
+  it("generate lets the prefixed HEADER win over both other channels", async () => {
+    // The agent adapter sets the prefixed header per operation; a body key
+    // could otherwise be shaped by model output, so it must never override it.
+    const res = await generateWith({
+      headers: {
+        "x-mcpjam-idempotency-key": "proposal:act_9:generate_eval_cases",
+        "idempotency-key": "sdk-transport-key",
+      },
+      body: { idempotencyKey: "body-key" },
+    });
+    expect(res.status).toBe(200);
+    expect(ledgerKeys()).toEqual(["proposal:act_9:generate_eval_cases"]);
+  });
+
+  it("generate prefers the transport header over a body key", async () => {
+    const res = await generateWith({
+      headers: { "idempotency-key": "sdk-transport-key" },
+      body: { idempotencyKey: "body-key" },
+    });
+    expect(res.status).toBe(200);
+    expect(ledgerKeys()).toEqual(["sdk-transport-key"]);
+  });
+
+  it("generate stays keyless — and reads no ledger — when no key is sent", async () => {
+    // The unkeyed path must keep working exactly as before: no ledger read,
+    // no ledger write, and certainly no fabricated key.
+    const res = await generateWith({});
+    expect(res.status).toBe(200);
+    expect(ledgerKeys()).toEqual([]);
+    expect(
+      convexMutationMock.mock.calls.some(
+        (c) => c[0] === "testSuites:recordCaseGeneration"
+      )
+    ).toBe(false);
+  });
+
+  it("generate replays the first attempt's drafts for a BODY key retry", async () => {
+    // The end-to-end property the plumbing exists for: retrying with the same
+    // key from a direct caller costs nothing and returns the same cases.
+    createAuthorizedManagerMock.mockResolvedValue({
+      manager: { disconnectAllServers: vi.fn().mockResolvedValue(undefined) },
+    });
+    convexQueryMock.mockImplementation((name: string) => {
+      if (name === "testSuites:getSuiteRunServerSelection")
+        return Promise.resolve({ serverIds: ["srv_1"], serverNames: ["S"] });
+      if (name === "testSuites:getCaseGeneration")
+        return Promise.resolve({
+          drafts: [
+            {
+              title: "Cached",
+              query: "from ledger",
+              runs: 1,
+              expectedToolCalls: [],
+            },
+          ],
+          createdCaseIds: null,
+        });
+      return defaultQueryImpl(name);
+    });
+
+    const res = await makeApp().request(
+      "/api/v1/projects/p1/eval-suites/suite_1/cases/generate",
+      {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          Authorization: "Bearer tok",
+        },
+        body: JSON.stringify({ mode: "normal", idempotencyKey: "cli-run-7" }),
+      }
+    );
+    expect(res.status).toBe(200);
+    expect((await res.json()).created).toHaveLength(1);
+    expect(generateEvalTestsMock).not.toHaveBeenCalled();
+    expect(createAuthorizedManagerMock).not.toHaveBeenCalled();
   });
 
   it("generate resolves a server NAME override to an ID before authorizing", async () => {

--- a/mcpjam-inspector/server/routes/v1/agent-op-registry.ts
+++ b/mcpjam-inspector/server/routes/v1/agent-op-registry.ts
@@ -834,6 +834,11 @@ export const AGENT_OP_REGISTRY: readonly AgentOpEntry[] = [
         `Generate eval cases for ${named(input, "suite") ?? "(unnamed)"}`,
       buttonLabel: "Generate them",
       kind: "generate",
+      // Generation calls the authoring model, so it spends credits exactly
+      // like the two run operations above. Without this the Slack and Discord
+      // approval cards omit the spend warning for the one operation whose
+      // cost is least obvious from its name.
+      confirmSeverity: "spend",
     },
   },
   {

--- a/mcpjam-inspector/server/routes/v1/evals.ts
+++ b/mcpjam-inspector/server/routes/v1/evals.ts
@@ -35,6 +35,7 @@ import { WEB_CALL_TIMEOUT_MS } from "../../config.js";
 import {
   deriveItemIdempotencyKey,
   deriveOperationIdempotencyKey,
+  readAnyIdempotencyKey,
   readIdempotencyKey,
 } from "../../utils/idempotency.js";
 import { opaqueIdSchema } from "@mcpjam/sdk/contract";
@@ -1856,6 +1857,13 @@ const generateCasesSchema = z
     // Condition the generated cases on a realistic range of user styles so the
     // queries read like different users wrote them.
     varyUserStyles: z.boolean().optional(),
+    // Body channel for the idempotency key, matching `run_eval_suite` and
+    // `run_eval_case` — the two closest siblings, which also spend. The agent
+    // surfaces set the prefixed header and win the merge below; every other
+    // caller can reach the ledger from here without controlling headers at
+    // all, which is what the CLI, the MCP plugin, and direct SDK callers
+    // could not do before.
+    idempotencyKey: z.string().min(1).max(256).optional(),
   })
   // Same mutual exclusion the run-create schema enforces: an environment's
   // closed server set is the point, so a `servers` override alongside it would
@@ -4500,7 +4508,17 @@ evals.post(
     // retry (a proposal reclaim, a redelivered click) replays the recorded
     // drafts instead of spending credits again — and each case is persisted
     // under a derived per-item key, so the persistence loop is resumable.
-    const idempotencyKey = readIdempotencyKey(c);
+    // The HEADER wins over any body value. Both are caller-supplied, but the
+    // header is the transport-level channel unattended clients use, and it is
+    // the one the agent adapter controls — a body key could otherwise be
+    // shaped by model output.
+    //
+    // `readAnyIdempotencyKey` and not `readIdempotencyKey`: the SDK client
+    // puts `options.idempotencyKey` on a bare `idempotency-key` header, so
+    // reading only the prefixed spelling would ignore an SDK caller's key and
+    // re-spend on the retry while the caller watched a key go out. This route
+    // is the one with the most to lose from that.
+    const idempotencyKey = readAnyIdempotencyKey(c) ?? body.idempotencyKey;
 
     // Project-scope guard.
     const readClient = createConvexReadClient(token);

--- a/mcpjam-inspector/server/utils/idempotency.ts
+++ b/mcpjam-inspector/server/utils/idempotency.ts
@@ -23,6 +23,22 @@ import type { Context } from "hono";
 export const IDEMPOTENCY_KEY_HEADER = "x-mcpjam-idempotency-key";
 
 /**
+ * The OTHER spelling, and it is not a typo.
+ *
+ * `PlatformApiClient` puts `options.idempotencyKey` on a bare
+ * `idempotency-key` header, and the journey / swarm / persona routes read it
+ * there directly. So the platform genuinely has two channels: this one, which
+ * every SDK caller reaches for free, and the prefixed one above, which the
+ * agent adapter sets on its internal fetch.
+ *
+ * The two not matching is a silent failure, not a loud one — a route that
+ * reads only the prefixed header ignores an SDK caller's key and re-spends
+ * on every retry, while the caller sees a key going out and assumes it took.
+ * A route that spends should accept both.
+ */
+export const IDEMPOTENCY_KEY_TRANSPORT_HEADER = "idempotency-key";
+
+/**
  * Convex's `idempotencyKey` columns are plain strings; a runaway key would be
  * stored verbatim on every row it touches. Long enough for
  * `${teamId}:${eventId}:${operation}:${sha256}` with room to spare.
@@ -38,7 +54,26 @@ const MAX_KEY_LENGTH = 256;
  * get its suite created.
  */
 export function readIdempotencyKey(c: Context): string | undefined {
-  const raw = c.req.header(IDEMPOTENCY_KEY_HEADER);
+  return readKeyHeader(c, IDEMPOTENCY_KEY_HEADER);
+}
+
+/**
+ * Read the key off EITHER header, prefixed first.
+ *
+ * For routes that spend, where "the caller sent a key on the other header and
+ * we ignored it" costs real money. Precedence keeps the prefixed header
+ * authoritative: the agent adapter sets it per operation, and on the agent
+ * surfaces an inbound transport header is not ours to trust over it.
+ */
+export function readAnyIdempotencyKey(c: Context): string | undefined {
+  return (
+    readKeyHeader(c, IDEMPOTENCY_KEY_HEADER) ??
+    readKeyHeader(c, IDEMPOTENCY_KEY_TRANSPORT_HEADER)
+  );
+}
+
+function readKeyHeader(c: Context, header: string): string | undefined {
+  const raw = c.req.header(header);
   if (typeof raw !== "string") return undefined;
   const trimmed = raw.trim();
   if (trimmed.length === 0 || trimmed.length > MAX_KEY_LENGTH) {

--- a/sdk/src/platform/operations.ts
+++ b/sdk/src/platform/operations.ts
@@ -3398,6 +3398,15 @@ const generateEvalCasesInput = z.object({
     .describe(
       "Condition generated cases on a realistic range of user styles so the queries read like different users wrote them.",
     ),
+  idempotencyKey: z
+    .string()
+    .trim()
+    .min(1)
+    .max(256)
+    .optional()
+    .describe(
+      "Retry-safety key: pass one, because generating spends model credits and a retry must not pay for a second generation. Repeating a call with the same key replays the first attempt's drafts and returns the cases it already created.",
+    ),
 });
 export type GenerateEvalCasesInput = z.infer<typeof generateEvalCasesInput>;
 
@@ -3406,9 +3415,10 @@ export const generateEvalCasesOperation: PlatformOperation<
   PlatformEvalCasesGenerated
 > = {
   name: "generate_eval_cases",
+  risk: "spend",
   title: "Generate MCPJam eval cases",
   description:
-    "AI-generate test cases from the suite's server tools and persist them into the suite. Connects the servers to discover tools and spends the organization's credits. For a suite with attached project environments, tools are discovered from the environment's closed server set — pass environment to choose which one. The authoring model is platform-controlled; set caseModels to choose the generated cases' execution models.",
+    "AI-generate test cases from the suite's server tools and persist them into the suite. Connects the servers to discover tools and spends the organization's credits. For a suite with attached project environments, tools are discovered from the environment's closed server set — pass environment to choose which one. The authoring model is platform-controlled; set caseModels to choose the generated cases' execution models. IDEMPOTENT on idempotencyKey: pass one, because generating spends model credits and a retry must not pay for a second generation.",
   readOnly: false,
   inputSchema: generateEvalCasesInput,
   async execute(input, { client, signal }) {
@@ -3446,9 +3456,23 @@ export const generateEvalCasesOperation: PlatformOperation<
           ...(input.caseModels ? { caseModels: input.caseModels } : {}),
           ...(input.caseMix ? { caseMix: input.caseMix } : {}),
           ...(input.varyUserStyles ? { varyUserStyles: true } : {}),
+          // In the BODY, like run_eval_suite and run_eval_case — the two
+          // closest siblings, which also spend. The route merges a header key
+          // over this one, so the agent surfaces keep their precedence.
+          ...(input.idempotencyKey
+            ? { idempotencyKey: input.idempotencyKey }
+            : {}),
         },
       },
-      { signal },
+      {
+        signal,
+        // Also on the transport header the client already speaks, so a caller
+        // reading the wire sees one key rather than two channels that could
+        // disagree. The route accepts either spelling.
+        ...(input.idempotencyKey
+          ? { idempotencyKey: input.idempotencyKey }
+          : {}),
+      },
     );
   },
 };

--- a/sdk/tests/platform/operations-eval-edit.test.ts
+++ b/sdk/tests/platform/operations-eval-edit.test.ts
@@ -26,15 +26,31 @@ const ENVIRONMENTS = [
 
 function makeClient(): {
   client: PlatformApiClient;
-  calls: Array<{ method: string; path: string; body?: any }>;
+  calls: Array<{
+    method: string;
+    path: string;
+    body?: any;
+    headers: Record<string, string>;
+  }>;
 } {
-  const calls: Array<{ method: string; path: string; body?: any }> = [];
+  const calls: Array<{
+    method: string;
+    path: string;
+    body?: any;
+    headers: Record<string, string>;
+  }> = [];
   const fetchMock = vi.fn(async (target: unknown, init?: RequestInit) => {
     const url = new URL(String(target));
     const path = url.pathname;
     const method = init?.method ?? "GET";
     const body = init?.body ? JSON.parse(String(init.body)) : undefined;
-    calls.push({ method, path, body });
+    const headers: Record<string, string> = {};
+    for (const [key, value] of Object.entries(
+      (init?.headers ?? {}) as Record<string, string>
+    )) {
+      headers[key.toLowerCase()] = value;
+    }
+    calls.push({ method, path, body, headers });
 
     if (path === "/api/v1/projects") return Response.json({ items: PROJECTS });
     if (/\/environments$/.test(path))
@@ -223,6 +239,38 @@ describe("eval-edit operation execution", () => {
       caseMix: { simple: 3, negative: 1 },
       varyUserStyles: true,
     });
+  });
+
+  it("generate_eval_cases forwards the idempotency key on BOTH channels", async () => {
+    // The bug this pins: the operation used to send no key at all, so the
+    // surfaces most likely to time out (CLI, MCP plugin, direct SDK) re-spent
+    // on every retry. The body is the channel the route reads by schema —
+    // matching run_eval_suite and run_eval_case, the two closest siblings that
+    // also spend — and the header is the one the client already speaks. They
+    // must carry the SAME key: two channels that could disagree would be a
+    // worse bug than the one being fixed.
+    const { client, calls } = makeClient();
+    await generateEvalCasesOperation.execute(
+      { suite: "s1", idempotencyKey: "cli-run-7" },
+      { client }
+    );
+    const gen = calls.find((c) => /\/cases\/generate$/.test(c.path));
+    expect(gen?.body).toEqual({ idempotencyKey: "cli-run-7" });
+    expect(gen?.headers["idempotency-key"]).toBe("cli-run-7");
+  });
+
+  it("generate_eval_cases sends no key when the caller passes none", async () => {
+    const { client, calls } = makeClient();
+    await generateEvalCasesOperation.execute({ suite: "s1" }, { client });
+    const gen = calls.find((c) => /\/cases\/generate$/.test(c.path));
+    expect(gen?.body).toEqual({});
+    expect(gen?.headers["idempotency-key"]).toBeUndefined();
+  });
+
+  it("generate_eval_cases is labelled as spending", () => {
+    // `operationDescription` appends the "COSTS MONEY" warning to the MCP tool
+    // off this facet, and the operation spends the organization's credits.
+    expect(generateEvalCasesOperation.risk).toBe("spend");
   });
 
   it("generate_eval_cases omits varyUserStyles when not enabled", async () => {


### PR DESCRIPTION
Step 2 of the eval-case-generation fixes. Needs no backend change; the backend half (argument sanitization) is MCPJam/mcpjam-backend#1065.

## The gap

Generating eval cases spends model credits, and the route has supported a keyed retry — replaying the first attempt's drafts instead of paying for a second generation — since the ledger shipped. The Convex side is live and needs no work: `evalCaseGeneration` (72h TTL, 500KB draft cap, cron-swept), with drafts recorded **before** any case is persisted so a crash mid-persistence is resumable without re-spending.

The agent surfaces are already protected: Slack, Discord and in-app chat execute `generate_eval_cases` through the proposal path, which mints `proposal:<actionId>`. Nobody else was. The CLI, the MCP plugin and direct SDK callers had no way to send a key **at all**.

That is exactly backwards. Those are the surfaces that hit the SDK client's 30s timeout on a generation that takes 45s against a five-tool server, so retrying is their normal reaction — and every retry paid for a second generation. The MCP plugin is the worst case: its client is constructed without `timeoutMs`, so its 30s is not raisable by anyone.

## The trap: two header spellings that don't match

The obvious one-line fix does not work, and would fail **silently**:

- `readIdempotencyKey` reads only `x-mcpjam-idempotency-key`.
- `PlatformApiClient` sends only `idempotency-key`.
- `generateCasesSchema` had no `idempotencyKey` field, so zod stripped a body key.

Passing `{ idempotencyKey }` through `RequestOptions` would have set a header nothing reads, and the route would have kept behaving exactly as before — no ledger row, full re-spend, with a key visible on the wire the whole time.

## What changed

The key now travels on all three channels, and the route reads all three in the order that keeps the agent surfaces authoritative:

**prefixed header** (the agent adapter's, set per operation) → **transport header** (the SDK client's) → **body** (the schema field).

- `server/routes/v1/evals.ts` — `idempotencyKey` on `generateCasesSchema`, header-over-body merge with the precedence comment from the run-create route ("a body key could otherwise be shaped by model output").
- `server/utils/idempotency.ts` — `readAnyIdempotencyKey`, which reads either spelling, prefixed first. This is what turns "sent the wrong way" from *likely* into *impossible*, rather than just moving where it can happen. `readIdempotencyKey` is unchanged, so no other route's precedence moves.
- `sdk/src/platform/operations.ts` — the optional input field, forwarded in the **body** (matching `run_eval_suite` and `run_eval_case`, the two closest siblings that also spend) **and** on the transport header the client already speaks, carrying the same value.
- `cli/src/commands/eval.ts` — `--idempotency-key` on `eval cases generate`, matching the five commands that already have it. Its absence here was conspicuous: this is the route with the most elaborate ledger and it was the only spend command without the flag.
- `mcp/src/tools/platformTools.ts` — free; `registerTool` gets `operation.inputSchema` directly, so declaring the field publishes it.

## Two spend labels, same root cause

This operation spends credits and was labelled as spending nowhere:

- `server/routes/v1/agent-op-registry.ts` — `confirmSeverity: "spend"`, which `run_eval_suite` and `run_eval_case` both carry. Slack and Discord approval cards were omitting the spend warning for the one eval operation whose cost is least obvious from its name.
- `sdk/src/platform/operations.ts` — the `risk: "spend"` facet, so `operationDescription` appends the "COSTS MONEY" warning to the MCP tool.

Classifying it drops it out of `UNCLASSIFIED_WRITES`, so that legacy pin shrinks 36 → 35 — the direction it is allowed to move.

## Tests

Every new test asserts against the **ledger read**, not against the key being sent. That distinction is the whole point: the bug was a key that was sent and dropped, so "we sent a key" would have passed against the broken code.

- a body key reaches `testSuites:getCaseGeneration`, and the ledger write records it;
- a key on the SDK's transport header reaches it too — the negative that motivated the fix;
- the prefixed header wins over both;
- the transport header wins over the body;
- the keyless path reads and writes no ledger, and no key is fabricated;
- a body-key retry replays the first attempt's drafts: no MCP connection, no generator call, no second spend.

Plus the producer-side regression the backend PR pairs with: a generated case's assertion carries the backend's sanitized arguments verbatim and no unmatched free-form payload — every asserted value a scalar, `{}` staying `{}`.

SDK: the key goes out on both channels with the same value, nothing goes out when the caller passes none, and the operation is labelled as spending.

## Verification

- inspector `server/routes/v1/__tests__/`: 925 passed, 1 failure pre-existing on `main` (`sdk-coverage`, unrelated readiness-runs routes)
- full inspector suite: 16,608 passed
- `@mcpjam/sdk`: 5,637 passed · `@mcpjam/cli`: 738 passed · `@mcpjam/mcp`: 53 passed
- `npm run typecheck` clean; surface-core and slack-app verify clean (discord-app has 3 failures also present on `main`)

## Where this ends up

Async generation makes the key mandatory — the job row is addressed by `(suiteId, idempotencyKey)`, so a caller that supplies none gets one minted and returned as the job id. Idempotency stops being an optional nicety and becomes structural. This ships standalone anyway, because it fixes the synchronous path that exists today, and the async work is gated on a Lane B schema request (filed in the backend PR).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KYYHwJ11qnwJ9NxAzUHPkt

---
_Generated by [Claude Code](https://claude.ai/code/session_01KYYHwJ11qnwJ9NxAzUHPkt)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches credit-spending eval generation and idempotency-key merge (headers vs body). Wrong precedence could still double-charge or let a model-shaped body key override the agent header.
> 
> **Overview**
> CLI, SDK, and MCP callers can now pass an idempotency key on `generate_eval_cases`, so a timeout retry replays the first attempt’s drafts instead of generating (and billing) again.
> 
> The generate route previously only read `x-mcpjam-idempotency-key`, while `PlatformApiClient` sends `idempotency-key` and the body had no field—so keys on the wire were silently ignored. It now accepts prefixed header → transport header → body, with `readAnyIdempotencyKey` for the two header spellings. The SDK forwards the same key on both body and transport header; the CLI adds `--idempotency-key`.
> 
> The operation is classified as `risk: "spend"` (MCP “COSTS MONEY” warning) and agent proposals use `confirmSeverity: "spend"`. Tests pin ledger reads, channel precedence, keyless behavior, and that generated assertions keep the backend’s sanitized args verbatim.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7b1a0a3e13f806171e96dbf04daef10058939618. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Makes `generate_eval_cases` spend-idempotent for CLI/SDK/MCP callers. Previously, keys from these callers were ignored (route read only `x-mcpjam-idempotency-key` and the body had no `idempotencyKey`), so timeout retries triggered a second generation and charge; the route now accepts keys from prefixed header → transport header → body, and SDK/CLI can send them.

- Route (`mcpjam-inspector/server/routes/v1/evals.ts`): adds `idempotencyKey` to the schema and merges keys with prefixed header > `idempotency-key` > body via `readAnyIdempotencyKey`; keyless behavior unchanged.
- SDK (`@mcpjam/sdk`): `generate_eval_cases` accepts `idempotencyKey`, forwards the same value in body and `idempotency-key` header, and is marked `risk: "spend"`.
- CLI (`@mcpjam/cli`): adds `--idempotency-key` to `eval cases generate`; docs updated.
- Agents: `confirmSeverity: "spend"` for approval cards; unclassified-writes ceiling drops 36 → 35 in tests.
- Tests: assert ledger reads, channel precedence, keyless path, body-key replay (no second spend), and regression that generated assertions carry sanitized scalar args. No backend change required for idempotency.

<sup>Written for commit 7b1a0a3e13f806171e96dbf04daef10058939618. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/MCPJam/inspector/pull/4179?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

