### PR TITLE
ci(staging): make the inspector's public URL durable

### DIFF
--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -75,13 +75,23 @@ jobs:
       #     `frame-ancestors` host-source syntax only accepts `*` as a
       #     leading wildcard before a dot; mid-host wildcards are ignored
       #     by browsers and would silently 404 every preview iframe.
-      - name: Refresh staging origin allowlists
+      # `MCPJAM_INSPECTOR_PUBLIC_URL` is set here too, because it decides how a
+      # harness reaches its MCP servers. `resolveWebAuthorizedHarnessStrategy()`
+      # reads it to build the `.mcp.json` the in-sandbox agent dials
+      # (`https://<this>/api/web/harness-mcp/...`), and falls back to the RELAY
+      # transport when it is absent or not publicly reachable — a transport
+      # staging has no infrastructure for, so every harness turn with a server
+      # selected dies at tunnel creation. It was previously hand-set on the
+      # service, which meant a rebuild could silently take the whole harness
+      # surface down.
+      - name: Refresh staging origin config
         run: |
           .github/scripts/railway-retry.sh .github/scripts/railway-set-vars.sh \
             -e "$RAILWAY_STAGING_ENVIRONMENT" \
             -s "$RAILWAY_INSPECTOR_SERVICE" \
             ALLOWED_ORIGINS="$STAGING_APP_URL,https://mcp-inspector-pr-*.up.railway.app" \
-            WEB_ALLOWED_ORIGINS="$STAGING_APP_URL,https://*.up.railway.app"
+            WEB_ALLOWED_ORIGINS="$STAGING_APP_URL,https://*.up.railway.app" \
+            MCPJAM_INSPECTOR_PUBLIC_URL="$STAGING_APP_URL"
 
       # Capture the most recent deployment id before we trigger a new one so
       # the wait step below can detect when *our* deploy appears (instead of


### PR DESCRIPTION
## Why

`MCPJAM_INSPECTOR_PUBLIC_URL` decides how a harness reaches its MCP servers. `resolveWebAuthorizedHarnessStrategy()` reads it to build the `.mcp.json` the in-sandbox agent dials, and falls back to the **relay** transport when it is missing or not publicly reachable.

Staging has no relay infrastructure, so without this variable every harness turn with a server selected dies at tunnel creation with *"Tunnel service not configured"* — about five seconds in.

It was hand-set directly on the Railway service, which meant any rebuild could take the whole harness surface down silently. Nothing in the repo wrote it.

## What this does

Adds it to the step that already pins staging's origin allowlists, so it is applied on every deploy. The step is renamed from "Refresh staging origin allowlists" to "Refresh staging origin config", since it now sets more than allowlists.

## Scope

One workflow file, staging only. Worth landing ahead of the rest of the harness work, since the end-to-end verification for those changes runs against staging and depends on this being durable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Staging-only CI env var pin; no app logic or production config changes. Wrong URL would break harness on staging, but it reuses the existing STAGING_APP_URL.
> 
> **Overview**
> Pins `MCPJAM_INSPECTOR_PUBLIC_URL` to the staging app URL on every Railway staging deploy, instead of relying on a one-off service setting that a rebuild could drop.
> 
> Without it, `resolveWebAuthorizedHarnessStrategy()` falls back to relay, which staging does not have, so harness turns with a selected MCP server fail at tunnel creation. The existing origin-allowlist step now also writes this var and is renamed to **Refresh staging origin config**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6ee1d425851f6c332e97eaf40d3f521055dca181. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Makes the inspector’s public URL in staging durable by setting MCPJAM_INSPECTOR_PUBLIC_URL during deploy. Previously it was manually set in Railway; rebuilds dropped it, causing harness runs to fail at tunnel creation because staging has no relay fallback.

- Changes .github/workflows/deploy-staging.yml only (staging, inspector service).
- Sets MCPJAM_INSPECTOR_PUBLIC_URL="$STAGING_APP_URL" and renames the step to "Refresh staging origin config".
- Effective on next staging deploy; no code changes or migrations.
- Post-deploy, verify the var on the Railway service and that a harness turn establishes the tunnel.

<sup>Written for commit 6ee1d425851f6c332e97eaf40d3f521055dca181. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/MCPJam/inspector/pull/4181?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

