### PR TITLE
harness: install the runtime before the box's egress is locked

### DIFF
--- a/mcpjam-inspector/server/utils/harness/__tests__/e2b-sandbox-provider.test.ts
+++ b/mcpjam-inspector/server/utils/harness/__tests__/e2b-sandbox-provider.test.ts
@@ -1,0 +1,176 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+// The E2B SDK is mocked at the module boundary: these tests are about how the
+// provider ADAPTS the vendor (error shapes, abort plumbing), not about E2B.
+// `vi.hoisted` because `vi.mock` factories are lifted above ordinary top-level
+// declarations and could not otherwise see these.
+const mocks = vi.hoisted(() => {
+  class FakeCommandExitError extends Error {
+    constructor(
+      public exitCode: number,
+      public stdout: string,
+      public stderr: string
+    ) {
+      super("exit status " + exitCode);
+      this.name = "CommandExitError";
+    }
+  }
+  class FakeFileNotFoundError extends Error {}
+  return {
+    FakeCommandExitError,
+    FakeFileNotFoundError,
+    run: vi.fn(),
+    read: vi.fn(),
+    write: vi.fn(),
+    connect: vi.fn(),
+  };
+});
+const { FakeCommandExitError } = mocks;
+const sandboxState = mocks;
+
+vi.mock("e2b", () => ({
+  Sandbox: {
+    connect: async (id: string, opts?: Record<string, unknown>) => {
+      mocks.connect(id, opts);
+      return {
+        sandboxId: id,
+        commands: { run: mocks.run },
+        files: { read: mocks.read, write: mocks.write },
+        getHost: (p: number) => `host-${p}.e2b.dev`,
+      };
+    },
+  },
+  CommandExitError: mocks.FakeCommandExitError,
+  FileNotFoundError: mocks.FakeFileNotFoundError,
+}));
+
+import { createE2BHarnessSandboxProvider } from "../e2b-sandbox-provider.js";
+
+beforeEach(() => {
+  sandboxState.run.mockReset();
+  sandboxState.run.mockResolvedValue({ exitCode: 0, stdout: "", stderr: "" });
+  sandboxState.connect.mockReset();
+});
+
+afterEach(() => {
+  vi.unstubAllEnvs();
+});
+
+const provider = () =>
+  createE2BHarnessSandboxProvider({ sandboxId: "sbx_1" });
+
+describe("the pnpm guard", () => {
+  it("explains itself when pnpm is missing and installing it fails", async () => {
+    // This is the failure that cost a full debugging session: E2B's raw
+    // `CommandExitError` carries only "exit status 1", so a turn that died
+    // because the box could not reach the package registry reported nothing
+    // about the box, the exit code, or the registry.
+    sandboxState.run.mockRejectedValueOnce(
+      new FakeCommandExitError(1, "", "npm error code ECONNRESET")
+    );
+
+    await expect(provider().createSession()).rejects.toThrow(
+      /pnpm is missing on sandbox sbx_1.*exit 1.*ECONNRESET/s
+    );
+  });
+
+  it("names the egress lock as the likely cause", async () => {
+    // The message has to point at the actual mechanism, because the fix is an
+    // ordering one and nothing else in the failure hints at it.
+    sandboxState.run.mockRejectedValueOnce(
+      new FakeCommandExitError(1, "", "network request failed")
+    );
+
+    await expect(provider().createSession()).rejects.toThrow(
+      /egress is already locked to the model proxy/i
+    );
+  });
+
+  it("passes a non-exit failure through untouched", async () => {
+    // A transport failure is not a command that ran and failed; dressing it up
+    // as one would be a lie about what happened.
+    sandboxState.run.mockRejectedValueOnce(new Error("socket hang up"));
+
+    await expect(provider().createSession()).rejects.toThrow("socket hang up");
+  });
+
+  it("stays quiet on a box that already has pnpm", async () => {
+    await expect(provider().createSession()).resolves.toMatchObject({
+      id: "sbx_1",
+    });
+  });
+});
+
+describe("abort plumbing", () => {
+  it("hands the caller's signal to connect and to the guard command", async () => {
+    // Without this, an aborted bootstrap kept running to the ten-minute command
+    // timeout while the turn was already over — the box held, the user waiting.
+    const controller = new AbortController();
+    await provider().createSession({ abortSignal: controller.signal });
+
+    expect(sandboxState.connect).toHaveBeenCalledWith(
+      "sbx_1",
+      expect.objectContaining({ signal: controller.signal })
+    );
+    expect(sandboxState.run).toHaveBeenCalledWith(
+      expect.stringContaining("pnpm"),
+      expect.objectContaining({ signal: controller.signal })
+    );
+  });
+
+  it("honors a per-command signal on exec", async () => {
+    const session = await provider().createSession();
+    const controller = new AbortController();
+    sandboxState.run.mockClear();
+
+    await session.run({ command: "echo hi", abortSignal: controller.signal });
+
+    expect(sandboxState.run).toHaveBeenCalledWith(
+      "echo hi",
+      expect.objectContaining({ signal: controller.signal })
+    );
+  });
+
+  it("omits the signal key entirely when there is none", async () => {
+    // E2B treats an explicit `signal: undefined` differently from an absent
+    // key in some SDK versions; not sending it is the safe shape.
+    const session = await provider().createSession();
+    sandboxState.run.mockClear();
+
+    await session.run({ command: "echo hi" });
+
+    const opts = sandboxState.run.mock.calls[0]![1] as Record<string, unknown>;
+    expect("signal" in opts).toBe(false);
+  });
+
+  it("resumeSession honors the signal too", async () => {
+    const controller = new AbortController();
+    await provider().resumeSession!({
+      sessionId: "session-1",
+      abortSignal: controller.signal,
+    });
+
+    expect(sandboxState.connect).toHaveBeenCalledWith(
+      "sbx_1",
+      expect.objectContaining({ signal: controller.signal })
+    );
+  });
+});
+
+describe("exec result normalization", () => {
+  it("returns a failed command as a result, not a rejection", async () => {
+    // The sandbox contract wants the exit code and streams surfaced. This is
+    // the behavior the pnpm guard deliberately does NOT share, so it is worth
+    // pinning that they stay different.
+    const session = await provider().createSession();
+    sandboxState.run.mockRejectedValueOnce(
+      new FakeCommandExitError(3, "out", "err")
+    );
+
+    await expect(session.run({ command: "false" })).resolves.toEqual({
+      exitCode: 3,
+      stdout: "out",
+      stderr: "err",
+    });
+  });
+});

--- a/mcpjam-inspector/server/utils/harness/__tests__/harness-model-broker.test.ts
+++ b/mcpjam-inspector/server/utils/harness/__tests__/harness-model-broker.test.ts
@@ -2,6 +2,8 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import {
   startHarnessModelBroker,
   revokeHarnessModelBroker,
+  reserveHarnessBox,
+  renewHarnessBoxReservation,
 } from "../harness-model-broker";
 import { buildBrokerDummyAuth } from "../registry";
 
@@ -221,5 +223,54 @@ describe("revokeHarnessModelBroker", () => {
     mockFetch(() => Response.json({ ok: false }, { status: 500 }));
     const result = await revokeHarnessModelBroker({ runId: "r", bearer: "t" });
     expect(result.ok).toBe(false);
+  });
+});
+
+describe("harness box reservation", () => {
+  const box = { kind: "sandbox" as const, sandboxRowId: "sbxrow_1" };
+
+  it("fails closed when the reservation endpoint is missing", async () => {
+    mockFetch(() => Response.json({ ok: false }, { status: 404 }));
+    await expect(
+      reserveHarnessBox({
+        box,
+        harnessId: "claude-code",
+        modelId: "anthropic/claude-haiku-4.5",
+        runId: "run_1",
+        bearer: "t",
+      })
+    ).resolves.toEqual({
+      ok: false,
+      status: 404,
+      error: "Couldn't reserve the computer (404)",
+    });
+  });
+
+  it("renews the same box claim and returns the new expiry", async () => {
+    let seenUrl = "";
+    let seenBody: any = {};
+    mockFetch((url, init) => {
+      seenUrl = url;
+      seenBody = JSON.parse(String(init.body));
+      return Response.json({ ok: true, expiresAt: 999 });
+    });
+    await expect(
+      renewHarnessBoxReservation({
+        box,
+        harnessId: "claude-code",
+        modelId: "anthropic/claude-haiku-4.5",
+        runId: "run_1",
+        bearer: "t",
+      })
+    ).resolves.toEqual({ ok: true, expiresAt: 999 });
+    expect(seenUrl).toBe(
+      "https://convex.example.com/web/harness/model-broker/reserve/renew"
+    );
+    expect(seenBody).toEqual({
+      sandboxRowId: "sbxrow_1",
+      harnessId: "claude-code",
+      modelId: "anthropic/claude-haiku-4.5",
+      runId: "run_1",
+    });
   });
 });

--- a/mcpjam-inspector/server/utils/harness/__tests__/registry.test.ts
+++ b/mcpjam-inspector/server/utils/harness/__tests__/registry.test.ts
@@ -341,3 +341,61 @@ const toUserMessage = (text) => ({
     });
   });
 });
+
+describe("bootstrap recipes are auth-independent", () => {
+  // Load-bearing for the prewarm ordering. A harness turn installs its runtime
+  // BEFORE the broker locks the box's egress, using a runtime built with a
+  // placeholder credential — the real one does not exist yet. The framework
+  // keys the "already installed" marker on a hash of the recipe's file
+  // contents, so if the recipe ever varied with auth, the prewarmed marker
+  // would not match the one the streaming turn looks for. The turn would then
+  // re-run the bootstrap under the egress lock, where it cannot reach the
+  // package registry — the original failure, silently restored.
+  const auth = (baseUrl: string) => ({
+    anthropic: { apiKey: "", authToken: "dummy", baseUrl },
+    openaiCompatible: { apiKey: "dummy", baseUrl },
+  });
+
+  for (const id of ["claude-code", "codex"] as const) {
+    it(`${id}: two different credentials produce byte-identical files`, async () => {
+      const adapter = getHarnessAdapter(id);
+      const a = adapter.createHarness({
+        modelId:
+          id === "codex" ? "openai/gpt-5-nano" : "anthropic/claude-haiku-4.5",
+        auth: auth("https://one.invalid"),
+      });
+      const b = adapter.createHarness({
+        modelId:
+          id === "codex" ? "openai/gpt-5-nano" : "anthropic/claude-haiku-4.5",
+        auth: auth("https://two.invalid"),
+      });
+
+      const ra = await a.getBootstrap!();
+      const rb = await b.getBootstrap!();
+
+      // `hashBootstrap` is not exported, so compare exactly what it hashes.
+      expect(rb.harnessId).toBe(ra.harnessId);
+      expect(rb.bootstrapDir).toBe(ra.bootstrapDir);
+      expect(rb.commands).toEqual(ra.commands);
+      expect(rb.files).toEqual(ra.files);
+    });
+  }
+
+  it("claude-code's patched bridge differs from the unpatched one", () => {
+    // The other half of the same invariant: the registry rewrites the bridge
+    // asset, so prewarming a bare `createClaudeCode()` would compute a
+    // different hash than the turn does. This test is what makes that
+    // divergence visible if anyone reaches for the bare constructor.
+    // Dual-`ai` boundary cast, as everywhere else this constructor is used.
+    const patched = patchClaudeCodeHarnessBootstrap(createClaudeCode() as any);
+    return Promise.all([
+      patched.getBootstrap!(),
+      createClaudeCode().getBootstrap!(),
+    ]).then(([p, bare]) => {
+      const bridgeOf = (r: {
+        files: readonly { path: string; content: string }[];
+      }) => r.files.find((f) => f.path.endsWith("/bridge.mjs"))!.content;
+      expect(bridgeOf(p)).not.toBe(bridgeOf(bare));
+    });
+  });
+});

--- a/mcpjam-inspector/server/utils/harness/__tests__/registry.test.ts
+++ b/mcpjam-inspector/server/utils/harness/__tests__/registry.test.ts
@@ -351,9 +351,16 @@ describe("bootstrap recipes are auth-independent", () => {
   // would not match the one the streaming turn looks for. The turn would then
   // re-run the bootstrap under the egress lock, where it cannot reach the
   // package registry — the original failure, silently restored.
-  const auth = (baseUrl: string) => ({
-    anthropic: { apiKey: "", authToken: "dummy", baseUrl },
-    openaiCompatible: { apiKey: "dummy", baseUrl },
+  const auth = (suffix: string) => ({
+    anthropic: {
+      apiKey: `anthropic-key-${suffix}`,
+      authToken: `anthropic-token-${suffix}`,
+      baseUrl: `https://${suffix}.invalid`,
+    },
+    openaiCompatible: {
+      apiKey: `openai-key-${suffix}`,
+      baseUrl: `https://${suffix}.invalid`,
+    },
   });
 
   for (const id of ["claude-code", "codex"] as const) {
@@ -362,12 +369,12 @@ describe("bootstrap recipes are auth-independent", () => {
       const a = adapter.createHarness({
         modelId:
           id === "codex" ? "openai/gpt-5-nano" : "anthropic/claude-haiku-4.5",
-        auth: auth("https://one.invalid"),
+        auth: auth("one"),
       });
       const b = adapter.createHarness({
         modelId:
           id === "codex" ? "openai/gpt-5-nano" : "anthropic/claude-haiku-4.5",
-        auth: auth("https://two.invalid"),
+        auth: auth("two"),
       });
 
       const ra = await a.getBootstrap!();
@@ -387,7 +394,10 @@ describe("bootstrap recipes are auth-independent", () => {
     // different hash than the turn does. This test is what makes that
     // divergence visible if anyone reaches for the bare constructor.
     // Dual-`ai` boundary cast, as everywhere else this constructor is used.
-    const patched = patchClaudeCodeHarnessBootstrap(createClaudeCode() as any);
+    const patched = getHarnessAdapter("claude-code").createHarness({
+      modelId: "anthropic/claude-haiku-4.5",
+      auth: auth("patched"),
+    });
     return Promise.all([
       patched.getBootstrap!(),
       createClaudeCode().getBootstrap!(),

--- a/mcpjam-inspector/server/utils/harness/__tests__/run-harness-turn-broker-required.test.ts
+++ b/mcpjam-inspector/server/utils/harness/__tests__/run-harness-turn-broker-required.test.ts
@@ -25,6 +25,7 @@ vi.mock("@ai-sdk/harness/agent", () => ({
     }));
   },
   collectHarnessAgentToolApprovalContinuations: vi.fn(() => []),
+  prewarmHarness: vi.fn(async () => {}),
 }));
 
 vi.mock("../registry.js", () => ({
@@ -90,6 +91,8 @@ vi.mock("../harness-session-state.js", async (importOriginal) => {
 });
 
 vi.mock("../harness-model-broker.js", () => ({
+  reserveHarnessBox: vi.fn(async () => ({ ok: true })),
+  releaseHarnessBoxReservation: vi.fn(async () => ({ ok: true })),
   revokeHarnessModelBroker: vi.fn(async () => {}),
   startHarnessModelBroker: vi.fn(async () => ({
     ok: true,

--- a/mcpjam-inspector/server/utils/harness/__tests__/run-harness-turn-empty-output.test.ts
+++ b/mcpjam-inspector/server/utils/harness/__tests__/run-harness-turn-empty-output.test.ts
@@ -25,6 +25,7 @@ vi.mock("@ai-sdk/harness/agent", () => ({
   },
   // WS3: no trailing tool-approval-response parts in these prompts.
   collectHarnessAgentToolApprovalContinuations: vi.fn(() => []),
+  prewarmHarness: vi.fn(async () => {}),
 }));
 
 vi.mock("../registry.js", () => ({
@@ -92,6 +93,8 @@ vi.mock("../harness-session-state.js", async (importOriginal) => {
 });
 
 vi.mock("../harness-model-broker.js", () => ({
+  reserveHarnessBox: vi.fn(async () => ({ ok: true })),
+  releaseHarnessBoxReservation: vi.fn(async () => ({ ok: true })),
   revokeHarnessModelBroker: vi.fn(async () => {}),
   startHarnessModelBroker: vi.fn(async () => ({
     ok: true,

--- a/mcpjam-inspector/server/utils/harness/__tests__/run-harness-turn-ephemeral.test.ts
+++ b/mcpjam-inspector/server/utils/harness/__tests__/run-harness-turn-ephemeral.test.ts
@@ -96,6 +96,7 @@ vi.mock("../harness-session-state.js", async (importOriginal) => {
 
 vi.mock("../harness-model-broker.js", () => ({
   reserveHarnessBox: vi.fn(async () => ({ ok: true })),
+  renewHarnessBoxReservation: vi.fn(async () => ({ ok: true })),
   releaseHarnessBoxReservation: vi.fn(async () => ({ ok: true })),
   revokeHarnessModelBroker: vi.fn(async () => {}),
   startHarnessModelBroker: vi.fn(async () => ({
@@ -123,6 +124,7 @@ import { startHarnessModelBroker } from "../harness-model-broker.js";
 import { revokeHarnessModelBroker } from "../harness-model-broker.js";
 import {
   reserveHarnessBox,
+  renewHarnessBoxReservation,
   releaseHarnessBoxReservation,
 } from "../harness-model-broker.js";
 import { prewarmHarness } from "@ai-sdk/harness/agent";
@@ -178,6 +180,7 @@ afterEach(() => {
   vi.mocked(createE2BHarnessSandboxProvider).mockClear();
   vi.mocked(prewarmHarness).mockClear();
   vi.mocked(reserveHarnessBox).mockClear();
+  vi.mocked(renewHarnessBoxReservation).mockClear();
   vi.mocked(releaseHarnessBoxReservation).mockClear();
   vi.mocked(getHarnessAdapter).mockClear();
 });
@@ -373,23 +376,22 @@ describe("runHarnessTurn — the runtime is installed before egress is locked", 
     expect(startHarnessModelBroker).not.toHaveBeenCalled();
   });
 
-  it("keeps working against a backend that has no reservation endpoint", async () => {
-    // A self-hosted deployment on an older backend should keep the harness it
-    // has, with the lease fence as its only serialization, rather than losing
-    // it over a lock it never had.
+  it("fails closed when the backend has no reservation endpoint", async () => {
     vi.mocked(reserveHarnessBox).mockResolvedValueOnce({
-      ok: true,
-      unsupported: true,
+      ok: false,
+      status: 404,
+      error: "Harness model-broker returned 404",
     });
+    const onEngineError = vi.fn();
 
     await runHarnessTurn(
-      baseOptions({ harnessSandboxBinding: BINDING }) as never,
+      baseOptions({ harnessSandboxBinding: BINDING, onEngineError }) as never,
       "none"
     );
 
-    expect(prewarmHarness).toHaveBeenCalledTimes(1);
-    expect(startHarnessModelBroker).toHaveBeenCalledTimes(1);
-    // Nothing was claimed, so there is nothing to release.
+    expect(onEngineError).toHaveBeenCalledTimes(1);
+    expect(prewarmHarness).not.toHaveBeenCalled();
+    expect(startHarnessModelBroker).not.toHaveBeenCalled();
     expect(releaseHarnessBoxReservation).not.toHaveBeenCalled();
   });
 

--- a/mcpjam-inspector/server/utils/harness/__tests__/run-harness-turn-ephemeral.test.ts
+++ b/mcpjam-inspector/server/utils/harness/__tests__/run-harness-turn-ephemeral.test.ts
@@ -29,6 +29,7 @@ vi.mock("@ai-sdk/harness/agent", () => ({
     }));
   },
   collectHarnessAgentToolApprovalContinuations: vi.fn(() => []),
+  prewarmHarness: vi.fn(async () => {}),
 }));
 
 vi.mock("../registry.js", () => ({
@@ -94,6 +95,8 @@ vi.mock("../harness-session-state.js", async (importOriginal) => {
 });
 
 vi.mock("../harness-model-broker.js", () => ({
+  reserveHarnessBox: vi.fn(async () => ({ ok: true })),
+  releaseHarnessBoxReservation: vi.fn(async () => ({ ok: true })),
   revokeHarnessModelBroker: vi.fn(async () => {}),
   startHarnessModelBroker: vi.fn(async () => ({
     ok: true,
@@ -118,6 +121,12 @@ vi.mock("../mcp-config.js", async (importOriginal) => {
 import { runHarnessTurn } from "../run-harness-turn";
 import { startHarnessModelBroker } from "../harness-model-broker.js";
 import { revokeHarnessModelBroker } from "../harness-model-broker.js";
+import {
+  reserveHarnessBox,
+  releaseHarnessBoxReservation,
+} from "../harness-model-broker.js";
+import { prewarmHarness } from "@ai-sdk/harness/agent";
+import { getHarnessAdapter } from "../registry.js";
 import { resolveHarnessSandbox } from "../resolve-sandbox.js";
 import { createE2BHarnessSandboxProvider } from "../e2b-sandbox-provider.js";
 
@@ -164,8 +173,13 @@ afterEach(() => {
   vi.unstubAllEnvs();
   vi.unstubAllGlobals();
   vi.mocked(startHarnessModelBroker).mockClear();
+  vi.mocked(revokeHarnessModelBroker).mockClear();
   vi.mocked(resolveHarnessSandbox).mockClear();
   vi.mocked(createE2BHarnessSandboxProvider).mockClear();
+  vi.mocked(prewarmHarness).mockClear();
+  vi.mocked(reserveHarnessBox).mockClear();
+  vi.mocked(releaseHarnessBoxReservation).mockClear();
+  vi.mocked(getHarnessAdapter).mockClear();
 });
 
 describe("runHarnessTurn — ephemeral sandbox binding (phase 6)", () => {
@@ -245,6 +259,150 @@ describe("runHarnessTurn — ephemeral sandbox binding (phase 6)", () => {
 
     expect(startHarnessModelBroker).not.toHaveBeenCalled();
     expect(resolveHarnessSandbox).not.toHaveBeenCalled();
+  });
+});
+
+describe("runHarnessTurn — the runtime is installed before egress is locked", () => {
+  it("claims the box, prewarms it, and only then asks for a credential", async () => {
+    // The ordering IS the fix. The broker's network policy locks this box down
+    // to the model proxy, and the harness bootstrap needs the package registry,
+    // so a bootstrap that runs after the lease can never succeed. The claim
+    // comes first so no second turn can lock the box mid-bootstrap.
+    await runHarnessTurn(
+      baseOptions({ harnessSandboxBinding: BINDING }) as never,
+      "none"
+    );
+
+    const reserveOrder = vi.mocked(reserveHarnessBox).mock
+      .invocationCallOrder[0]!;
+    const prewarmOrder = vi.mocked(prewarmHarness).mock
+      .invocationCallOrder[0]!;
+    const brokerOrder = vi.mocked(startHarnessModelBroker).mock
+      .invocationCallOrder[0]!;
+    expect(reserveOrder).toBeLessThan(prewarmOrder);
+    expect(prewarmOrder).toBeLessThan(brokerOrder);
+  });
+
+  it("prewarms through the same provider instance the session will use", async () => {
+    // Both must attach to the same box, and the provider must be built once —
+    // a second instance would mean a second connect for no reason.
+    await runHarnessTurn(
+      baseOptions({ harnessSandboxBinding: BINDING }) as never,
+      "none"
+    );
+
+    expect(createE2BHarnessSandboxProvider).toHaveBeenCalledTimes(1);
+    const provider = vi.mocked(createE2BHarnessSandboxProvider).mock.results[0]!
+      .value;
+    expect(vi.mocked(prewarmHarness).mock.calls[0]![0].sandboxProvider).toBe(
+      provider
+    );
+  });
+
+  it("prewarms the runtime the adapter builds, never a bare one", async () => {
+    // The registry rewrites the bridge asset inside the bootstrap recipe, and
+    // the recipe's content hash decides the marker file the real turn looks
+    // for. Prewarming a differently-built runtime would leave a marker the turn
+    // ignores — reinstating the deadlock while looking fixed.
+    await runHarnessTurn(
+      baseOptions({ harnessSandboxBinding: BINDING }) as never,
+      "none"
+    );
+
+    const adapter = vi.mocked(getHarnessAdapter).mock.results[0]!.value;
+    const built = adapter.createHarness.mock.results[0]!.value;
+    expect(vi.mocked(prewarmHarness).mock.calls[0]![0].harness).toBe(built);
+  });
+
+  it("shares one runId between the claim and the lease that consumes it", async () => {
+    await runHarnessTurn(
+      baseOptions({ harnessSandboxBinding: BINDING }) as never,
+      "none"
+    );
+
+    const reservedRunId = vi.mocked(reserveHarnessBox).mock.calls[0]![0].runId;
+    const leasedRunId = vi.mocked(startHarnessModelBroker).mock.calls[0]![0]
+      .runId;
+    expect(reservedRunId).toBe(leasedRunId);
+    expect(reservedRunId).toBeTruthy();
+  });
+
+  it("hands the box back when preparing it fails, and mints nothing", async () => {
+    vi.mocked(prewarmHarness).mockRejectedValueOnce(
+      new Error("pnpm is missing on sandbox e2b_ephemeral_1")
+    );
+
+    const result = await runHarnessTurn(
+      baseOptions({ harnessSandboxBinding: BINDING }) as never,
+      "none"
+    );
+
+    // No lease was minted, so there is no egress rule and nothing to revoke...
+    expect(startHarnessModelBroker).not.toHaveBeenCalled();
+    expect(revokeHarnessModelBroker).not.toHaveBeenCalled();
+    // ...but the claim is ours to give back, and the next turn should not wait
+    // out its TTL for a box nobody is using.
+    expect(releaseHarnessBoxReservation).toHaveBeenCalledTimes(1);
+    expect(result.aborted).toBe(false);
+  });
+
+  it("refuses to prepare a box another run is already preparing", async () => {
+    vi.mocked(reserveHarnessBox).mockResolvedValueOnce({
+      ok: false,
+      status: 409,
+      error: "A harness run is already active on this computer.",
+    });
+    const onEngineError = vi.fn();
+
+    await runHarnessTurn(
+      baseOptions({
+        harnessSandboxBinding: BINDING,
+        onEngineError,
+      }) as never,
+      "none"
+    );
+
+    // The caller is told the box is busy, in the same words a lease conflict
+    // would have produced.
+    expect(onEngineError).toHaveBeenCalledTimes(1);
+    expect(onEngineError.mock.calls[0]![0].message).toMatch(
+      /already active on this computer/i
+    );
+    // Refused before ANY work on the box — that is the point of claiming first.
+    expect(prewarmHarness).not.toHaveBeenCalled();
+    expect(startHarnessModelBroker).not.toHaveBeenCalled();
+  });
+
+  it("keeps working against a backend that has no reservation endpoint", async () => {
+    // A self-hosted deployment on an older backend should keep the harness it
+    // has, with the lease fence as its only serialization, rather than losing
+    // it over a lock it never had.
+    vi.mocked(reserveHarnessBox).mockResolvedValueOnce({
+      ok: true,
+      unsupported: true,
+    });
+
+    await runHarnessTurn(
+      baseOptions({ harnessSandboxBinding: BINDING }) as never,
+      "none"
+    );
+
+    expect(prewarmHarness).toHaveBeenCalledTimes(1);
+    expect(startHarnessModelBroker).toHaveBeenCalledTimes(1);
+    // Nothing was claimed, so there is nothing to release.
+    expect(releaseHarnessBoxReservation).not.toHaveBeenCalled();
+  });
+
+  it("can be switched off entirely without breaking the turn", async () => {
+    vi.stubEnv("HARNESS_PREWARM_DISABLED", "1");
+
+    await runHarnessTurn(
+      baseOptions({ harnessSandboxBinding: BINDING }) as never,
+      "none"
+    );
+
+    expect(prewarmHarness).not.toHaveBeenCalled();
+    expect(startHarnessModelBroker).toHaveBeenCalledTimes(1);
   });
 });
 

--- a/mcpjam-inspector/server/utils/harness/e2b-sandbox-provider.ts
+++ b/mcpjam-inspector/server/utils/harness/e2b-sandbox-provider.ts
@@ -74,6 +74,24 @@ function enforceHarnessWritePath(path: string): void {
   }
 }
 
+/**
+ * Pass a caller's `abortSignal` down to E2B, omitting the key when there is
+ * none.
+ *
+ * Worth being precise about what this buys, because the sandbox contract
+ * promises more than the vendor delivers: E2B's `signal` cancels the in-flight
+ * REQUEST, so an aborted call rejects promptly instead of waiting out
+ * `commandTimeoutMs` — which for the harness bootstrap is ten minutes of a dead
+ * turn holding a box. It does not guarantee the process inside the box dies.
+ * That is the difference between a turn that ends when the user cancels it and
+ * one that appears to hang, so it is the part worth having; a box-side kill
+ * would need spawn/kill plumbing on every exec path and buys nothing while the
+ * box itself is short-lived or about to be reclaimed.
+ */
+function signalOpt(signal?: AbortSignal): { signal?: AbortSignal } {
+  return signal ? { signal } : {};
+}
+
 /** E2B throws `FileNotFoundError` for a missing path; the SandboxSession
  *  contract wants `null` there, but real failures (transport / permission /
  *  sandbox-gone) must propagate rather than masquerade as "file absent". */
@@ -142,27 +160,52 @@ export function createE2BHarnessSandboxProvider(
   // On resume the Claude Code adapter rehydrates its thread from the workdir
   // (which persists on the box) using the `resumeFrom` state; our provider just
   // has to supply the sandbox connection.
-  const connectSession = async (): Promise<HarnessV1NetworkSandboxSession> => {
+  const connectSession = async (
+    connectSignal?: AbortSignal
+  ): Promise<HarnessV1NetworkSandboxSession> => {
     // Reuse the host's existing computer. It must already be awake — the
     // caller wakes it via the control plane (`ensureComputerReady`) before
     // resolving the sandboxId. We never create or kill a box here.
     const sandbox = await Sandbox.connect(opts.sandboxId, {
       apiKey: opts.apiKey,
       timeoutMs: opts.connectTimeoutMs,
+      ...(connectSignal ? { signal: connectSignal } : {}),
     });
 
     // Mutated in place by setPorts so `session.ports` (same ref) stays live.
     const ports: number[] = [bridgePort];
 
-    // The @ai-sdk/harness-claude-code bootstrap shells `pnpm install` BEFORE
-    // any session hook runs. pnpm is baked into the computer template
-    // (mcpjam-backend templates/computer/e2b.Dockerfile); this idempotent
-    // guard is a stopgap for boxes provisioned before that template rebuild
-    // lands, and no-ops once pnpm is present. We do not own the box, so a
-    // failure here propagates (the control plane still owns teardown).
-    await sandbox.commands.run("command -v pnpm || npm install -g pnpm", {
-      timeoutMs: commandTimeoutMs,
-    });
+    // The harness bootstrap shells `pnpm install` BEFORE any session hook runs.
+    // pnpm is baked into the computer template (mcpjam-backend
+    // templates/computer/e2b.Dockerfile); this idempotent guard covers boxes
+    // provisioned before that template rebuild lands, and no-ops once pnpm is
+    // present. We do not own the box, so a failure here propagates (the control
+    // plane still owns teardown).
+    //
+    // Where it runs matters: on the harness path this is reached during PREWARM,
+    // while the box still has ordinary egress. Reached after a lease has locked
+    // the box down, the `npm install` fallback cannot see the registry and
+    // spends a minute of retries before failing — which is why the failure is
+    // spelled out below rather than surfacing as E2B's bare "exit status 1".
+    try {
+      await sandbox.commands.run("command -v pnpm || npm install -g pnpm", {
+        timeoutMs: commandTimeoutMs,
+        ...(connectSignal ? { signal: connectSignal } : {}),
+      });
+    } catch (err) {
+      if (err instanceof CommandExitError) {
+        const output = (err.stderr || err.stdout || "").trim();
+        throw new Error(
+          `pnpm is missing on sandbox ${opts.sandboxId} and installing it failed ` +
+            `(exit ${err.exitCode}). If the box's egress is already locked to the ` +
+            `model proxy, the package registry is unreachable by design — the ` +
+            `harness runtime must be installed before that lock. Output: ` +
+            (output ? output.slice(-500) : "(none)"),
+          { cause: err }
+        );
+      }
+      throw err;
+    }
 
     const session: HarnessV1NetworkSandboxSession = {
       id: sandbox.sandboxId,
@@ -174,49 +217,65 @@ export function createE2BHarnessSandboxProvider(
         )}.`,
 
       // ── file I/O ──────────────────────────────────────────────────────
-      readTextFile: async ({ path }) => {
+      readTextFile: async ({ path, abortSignal }) => {
         try {
-          return await sandbox.files.read(path);
+          return await sandbox.files.read(path, signalOpt(abortSignal));
         } catch (err) {
           return nullIfMissing(err); // null only for a genuinely missing file
         }
       },
-      readBinaryFile: async ({ path }) => {
+      readBinaryFile: async ({ path, abortSignal }) => {
         try {
-          return await sandbox.files.read(path, { format: "bytes" });
+          return await sandbox.files.read(path, {
+            format: "bytes",
+            ...signalOpt(abortSignal),
+          });
         } catch (err) {
           return nullIfMissing(err);
         }
       },
-      readFile: async ({ path }) => {
+      readFile: async ({ path, abortSignal }) => {
         try {
-          const bytes = await sandbox.files.read(path, { format: "bytes" });
+          const bytes = await sandbox.files.read(path, {
+            format: "bytes",
+            ...signalOpt(abortSignal),
+          });
           return bytesToStream(bytes);
         } catch (err) {
           return nullIfMissing(err);
         }
       },
-      writeTextFile: async ({ path, content }) => {
+      writeTextFile: async ({ path, content, abortSignal }) => {
         enforceHarnessWritePath(path);
-        await sandbox.files.write([{ path, data: content }]);
+        await sandbox.files.write(
+          [{ path, data: content }],
+          signalOpt(abortSignal)
+        );
       },
-      writeBinaryFile: async ({ path, content }) => {
+      writeBinaryFile: async ({ path, content, abortSignal }) => {
         enforceHarnessWritePath(path);
-        await sandbox.files.write([{ path, data: u8ToArrayBuffer(content) }]);
+        await sandbox.files.write(
+          [{ path, data: u8ToArrayBuffer(content) }],
+          signalOpt(abortSignal)
+        );
       },
-      writeFile: async ({ path, content }) => {
+      writeFile: async ({ path, content, abortSignal }) => {
         enforceHarnessWritePath(path);
         const bytes = await streamToBytes(content);
-        await sandbox.files.write([{ path, data: u8ToArrayBuffer(bytes) }]);
+        await sandbox.files.write(
+          [{ path, data: u8ToArrayBuffer(bytes) }],
+          signalOpt(abortSignal)
+        );
       },
 
       // ── exec ──────────────────────────────────────────────────────────
-      run: async ({ command, workingDirectory, env }) => {
+      run: async ({ command, workingDirectory, env, abortSignal }) => {
         try {
           const res = await sandbox.commands.run(command, {
             cwd: workingDirectory ?? cwd,
             envs: env,
             timeoutMs: commandTimeoutMs,
+            ...signalOpt(abortSignal),
           });
           return {
             exitCode: res.exitCode,
@@ -238,7 +297,7 @@ export function createE2BHarnessSandboxProvider(
       },
 
       // ── spawn (long-lived; adapt E2B callbacks → ReadableStreams) ──────
-      spawn: async ({ command, workingDirectory, env }) => {
+      spawn: async ({ command, workingDirectory, env, abortSignal }) => {
         let outCtl!: ReadableStreamDefaultController<Uint8Array>;
         let errCtl!: ReadableStreamDefaultController<Uint8Array>;
         let streamsClosed = false;
@@ -266,6 +325,7 @@ export function createE2BHarnessSandboxProvider(
           background: true,
           cwd: workingDirectory ?? cwd,
           envs: env,
+          ...signalOpt(abortSignal),
           // Guard against enqueue-after-close once the process ends/is killed.
           onStdout: (d: string) => {
             if (!streamsClosed) outCtl.enqueue(enc.encode(d));
@@ -343,7 +403,13 @@ export function createE2BHarnessSandboxProvider(
     // Single-port pool — the bridge leases this one port.
     bridgePorts: [bridgePort],
 
-    createSession: () => connectSession(),
+    // `identity` and `onFirstCreate` are deliberately unused: they exist for
+    // providers that CREATE and snapshot boxes, and this one only ever attaches
+    // to a box the control plane already owns. The framework applies its own
+    // idempotent bootstrap after attaching, which is the path that matters here.
+    // `abortSignal` IS honored, so a cancelled turn stops waiting on the box
+    // instead of holding it until the command timeout.
+    createSession: (options) => connectSession(options?.abortSignal),
 
     // Reattach for multi-turn continuity. The harness only invokes this when a
     // turn passes `resumeFrom`; presence of this method is the capability the
@@ -351,6 +417,6 @@ export function createE2BHarnessSandboxProvider(
     // otherwise). We ignore the harness `sessionId` — the box is the project's
     // single computer resolved per-turn via the control plane — and reconnect;
     // the Claude Code adapter restores the thread from the workdir.
-    resumeSession: () => connectSession(),
+    resumeSession: (options) => connectSession(options?.abortSignal),
   };
 }

--- a/mcpjam-inspector/server/utils/harness/harness-model-broker.ts
+++ b/mcpjam-inspector/server/utils/harness/harness-model-broker.ts
@@ -228,7 +228,9 @@ export async function revokeHarnessModelBroker(args: {
       networkCleared: payload.networkCleared,
     };
   } catch (err) {
-    logger.warn("[harness-model-broker] revoke network error", err);
+    logger.warn("[harness-model-broker] revoke network error", {
+      error: err instanceof Error ? err.message : String(err),
+    });
     return { ok: false };
   }
 }
@@ -237,8 +239,6 @@ export type HarnessBoxReservationResult =
   | {
       ok: true;
       expiresAt?: number;
-      /** The backend predates box reservations, so nothing was claimed. */
-      unsupported?: boolean;
     }
   | { ok: false; status: number; error: string };
 
@@ -248,10 +248,9 @@ export type HarnessBoxReservationResult =
  * therefore outside the protection of the lease's own per-box fence. The lease
  * consumes this claim when it is minted (matched on `runId`).
  *
- * A 404 is treated as SUCCESS-but-unclaimed: a self-hosted deployment running a
- * backend from before this endpoint existed should keep working exactly as it
- * did, with the lease fence as its only serialization, rather than losing the
- * harness entirely over a preparation lock it has never had.
+ * A missing endpoint is a hard failure. Continuing without a claim would
+ * silently restore the preparation race this endpoint exists to close, so an
+ * inspector must be rolled out only after the reservation-capable backend.
  */
 export async function reserveHarnessBox(args: {
   box: HarnessBrokerBox;
@@ -304,14 +303,6 @@ export async function reserveHarnessBox(args: {
     };
   }
 
-  if (response.status === 404) {
-    logger.warn(
-      "[harness-model-broker] backend has no box-reservation endpoint; " +
-        "preparing without a claim"
-    );
-    return { ok: true, unsupported: true };
-  }
-
   const payload: any = await response.json().catch(() => null);
   if (!response.ok || payload?.ok !== true) {
     return {
@@ -329,6 +320,61 @@ export async function reserveHarnessBox(args: {
       ? { expiresAt: payload.expiresAt }
       : {}),
   };
+}
+
+/** Renew the preparation claim before its crash-recovery TTL elapses. */
+export async function renewHarnessBoxReservation(args: {
+  box: HarnessBrokerBox;
+  harnessId: "claude-code" | "codex";
+  modelId: string;
+  runId: string;
+  bearer: string;
+  signal?: AbortSignal;
+}): Promise<{ ok: boolean; expiresAt?: number }> {
+  let url: string;
+  try {
+    url = new URL(
+      "/web/harness/model-broker/reserve/renew",
+      getConvexHttpUrl()
+    ).toString();
+  } catch {
+    return { ok: false };
+  }
+  try {
+    const response = await fetch(url, {
+      method: "POST",
+      headers: {
+        "content-type": "application/json",
+        authorization: bearerHeader(args.bearer),
+      },
+      body: JSON.stringify({
+        ...boxRequestFields(args.box),
+        harnessId: args.harnessId,
+        modelId: args.modelId,
+        runId: args.runId,
+      }),
+      signal: args.signal,
+    });
+    const payload: any = await response.json().catch(() => null);
+    if (!response.ok || payload?.ok !== true) {
+      logger.error(
+        `[harness-model-broker] reservation renewal returned ${response.status}`
+      );
+      return { ok: false };
+    }
+    return {
+      ok: true,
+      ...(typeof payload.expiresAt === "number"
+        ? { expiresAt: payload.expiresAt }
+        : {}),
+    };
+  } catch (err) {
+    logger.error(
+      "[harness-model-broker] reservation renewal network error",
+      err
+    );
+    return { ok: false };
+  }
 }
 
 /**

--- a/mcpjam-inspector/server/utils/harness/harness-model-broker.ts
+++ b/mcpjam-inspector/server/utils/harness/harness-model-broker.ts
@@ -71,6 +71,21 @@ export type HarnessBrokerBox =
       // and nothing to re-check: the request cannot carry them.
     };
 
+/**
+ * The box, as request fields. Serialized STRAIGHT off the discriminated union —
+ * the project and the scope are fields of the `computer` arm, so the sandbox
+ * path has no branch that could emit them and no way to regress into one.
+ */
+function boxRequestFields(box: HarnessBrokerBox): Record<string, unknown> {
+  return box.kind === "computer"
+    ? {
+        projectId: box.projectId,
+        computerId: box.computerId,
+        ...(box.executionScope ? { executionScope: box.executionScope } : {}),
+      }
+    : { sandboxRowId: box.sandboxRowId };
+}
+
 export async function startHarnessModelBroker(args: {
   box: HarnessBrokerBox;
   harnessId: "claude-code" | "codex";
@@ -103,19 +118,8 @@ export async function startHarnessModelBroker(args: {
         "content-type": "application/json",
         authorization: bearerHeader(args.bearer),
       },
-      // Serialized STRAIGHT off the discriminated box — the project and the
-      // scope are fields of the `computer` arm, so the sandbox path has no
-      // branch that could emit them and no way to regress into one.
       body: JSON.stringify({
-        ...(args.box.kind === "computer"
-          ? {
-              projectId: args.box.projectId,
-              computerId: args.box.computerId,
-              ...(args.box.executionScope
-                ? { executionScope: args.box.executionScope }
-                : {}),
-            }
-          : { sandboxRowId: args.box.sandboxRowId }),
+        ...boxRequestFields(args.box),
         harnessId: args.harnessId,
         modelId: args.modelId,
         ...(args.runId ? { runId: args.runId } : {}),
@@ -225,6 +229,154 @@ export async function revokeHarnessModelBroker(args: {
     };
   } catch (err) {
     logger.warn("[harness-model-broker] revoke network error", err);
+    return { ok: false };
+  }
+}
+
+export type HarnessBoxReservationResult =
+  | {
+      ok: true;
+      expiresAt?: number;
+      /** The backend predates box reservations, so nothing was claimed. */
+      unsupported?: boolean;
+    }
+  | { ok: false; status: number; error: string };
+
+/**
+ * Claim a box for the span of a turn's PREPARATION — waking it and installing
+ * the harness runtime, all of which happens before the lease exists and
+ * therefore outside the protection of the lease's own per-box fence. The lease
+ * consumes this claim when it is minted (matched on `runId`).
+ *
+ * A 404 is treated as SUCCESS-but-unclaimed: a self-hosted deployment running a
+ * backend from before this endpoint existed should keep working exactly as it
+ * did, with the lease fence as its only serialization, rather than losing the
+ * harness entirely over a preparation lock it has never had.
+ */
+export async function reserveHarnessBox(args: {
+  box: HarnessBrokerBox;
+  harnessId: "claude-code" | "codex";
+  modelId: string;
+  runId: string;
+  bearer: string;
+  signal?: AbortSignal;
+}): Promise<HarnessBoxReservationResult> {
+  let url: string;
+  try {
+    url = new URL(
+      "/web/harness/model-broker/reserve",
+      getConvexHttpUrl()
+    ).toString();
+  } catch (err) {
+    logger.error("[harness-model-broker] missing reserve endpoint config", err);
+    return {
+      ok: false,
+      status: 500,
+      error: "Harness model-broker endpoint is not configured",
+    };
+  }
+
+  let response: Response;
+  try {
+    response = await fetch(url, {
+      method: "POST",
+      headers: {
+        "content-type": "application/json",
+        authorization: bearerHeader(args.bearer),
+      },
+      body: JSON.stringify({
+        ...boxRequestFields(args.box),
+        // The same harness + model the lease will name: the backend authorizes a
+        // reservation exactly as it authorizes a lease, which for an ephemeral
+        // box means checking both against what the run actually pinned.
+        harnessId: args.harnessId,
+        modelId: args.modelId,
+        runId: args.runId,
+      }),
+      signal: args.signal,
+    });
+  } catch (err) {
+    logger.error("[harness-model-broker] reserve network error", err);
+    return {
+      ok: false,
+      status: 502,
+      error: "Failed to reach harness model-broker endpoint",
+    };
+  }
+
+  if (response.status === 404) {
+    logger.warn(
+      "[harness-model-broker] backend has no box-reservation endpoint; " +
+        "preparing without a claim"
+    );
+    return { ok: true, unsupported: true };
+  }
+
+  const payload: any = await response.json().catch(() => null);
+  if (!response.ok || payload?.ok !== true) {
+    return {
+      ok: false,
+      status: response.status,
+      error:
+        typeof payload?.error === "string"
+          ? payload.error
+          : `Couldn't reserve the computer (${response.status})`,
+    };
+  }
+  return {
+    ok: true,
+    ...(typeof payload.expiresAt === "number"
+      ? { expiresAt: payload.expiresAt }
+      : {}),
+  };
+}
+
+/**
+ * Hand a claimed box back after a failed or aborted preparation. Best-effort:
+ * the reservation's TTL is the real guarantee, and a turn that dies without
+ * releasing must not wedge the box for longer than that.
+ */
+export async function releaseHarnessBoxReservation(args: {
+  box: HarnessBrokerBox;
+  harnessId: "claude-code" | "codex";
+  modelId: string;
+  runId: string;
+  bearer: string;
+  signal?: AbortSignal;
+}): Promise<{ ok: boolean }> {
+  let url: string;
+  try {
+    url = new URL(
+      "/web/harness/model-broker/reserve/release",
+      getConvexHttpUrl()
+    ).toString();
+  } catch {
+    return { ok: false };
+  }
+  try {
+    const response = await fetch(url, {
+      method: "POST",
+      headers: {
+        "content-type": "application/json",
+        authorization: bearerHeader(args.bearer),
+      },
+      body: JSON.stringify({
+        ...boxRequestFields(args.box),
+        harnessId: args.harnessId,
+        modelId: args.modelId,
+        runId: args.runId,
+      }),
+      signal: args.signal,
+    });
+    if (!response.ok) {
+      logger.warn(
+        `[harness-model-broker] reservation release returned ${response.status}`
+      );
+      return { ok: false };
+    }
+    return { ok: true };
+  } catch (err) {
+    logger.error("[harness-model-broker] reservation release network error", err);
     return { ok: false };
   }
 }

--- a/mcpjam-inspector/server/utils/harness/run-harness-turn.ts
+++ b/mcpjam-inspector/server/utils/harness/run-harness-turn.ts
@@ -49,6 +49,7 @@ import {
   revokeHarnessModelBroker,
   reserveHarnessBox,
   releaseHarnessBoxReservation,
+  renewHarnessBoxReservation,
   type HarnessBrokerBox,
 } from "./harness-model-broker.js";
 import { harnessBrokerDeliveryEnabled } from "./harness-flags.js";
@@ -330,6 +331,10 @@ const HARNESS_INSTANCE_ID = crypto.randomUUID();
  *  run bound (we heartbeat well within it). */
 const HARNESS_LEASE_TTL_MS = 5 * 60_000;
 const HARNESS_HEARTBEAT_MS = 90_000;
+// The backend reservation TTL is deliberately much longer than this interval.
+// A missed renewal aborts preparation immediately; the longer server-side TTL
+// is the crash-recovery backstop for a worker that disappears altogether.
+const HARNESS_RESERVATION_HEARTBEAT_MS = 60_000;
 // v7: gateway base URL normalization (Anthropic-protocol origin without /v1) —
 // resumed sessions reconnect to a bridge process holding the OLD env, so force
 // fresh sessions to pick up the corrected ANTHROPIC_BASE_URL.
@@ -548,6 +553,14 @@ export async function runHarnessTurn(
   // to wait out the reservation TTL.
   let reservationHeld = false;
   let releaseBoxReservation: (() => Promise<void>) | undefined;
+  let reservationHeartbeatTimer: ReturnType<typeof setInterval> | undefined;
+  let reservationRenewalInFlight = false;
+  const clearReservationHeartbeat = () => {
+    if (reservationHeartbeatTimer !== undefined) {
+      clearInterval(reservationHeartbeatTimer);
+      reservationHeartbeatTimer = undefined;
+    }
+  };
   // Ownership handoff for the claimed continuity lane: false from the moment the
   // lane is claimed until the harness session is established (the point the
   // finalizer/heartbeat take over). While false, ANY failure (sandbox wake,
@@ -1143,7 +1156,7 @@ export async function runHarnessTurn(
       // otherwise the next turn waits out the reservation's TTL for nothing.
       // Cleared once the broker start succeeds, because recording the lease
       // consumes the claim and the lease's own fence takes over.
-      reservationHeld = !reservation.unsupported;
+      reservationHeld = true;
       releaseBoxReservation = async () => {
         await releaseHarnessBoxReservation({
           box,
@@ -1154,6 +1167,38 @@ export async function runHarnessTurn(
           signal: AbortSignal.timeout(HARNESS_TEARDOWN_TIMEOUT_MS),
         }).catch(() => {});
       };
+      reservationHeartbeatTimer = setInterval(() => {
+        if (!reservationHeld || reservationRenewalInFlight) return;
+        reservationRenewalInFlight = true;
+        void renewHarnessBoxReservation({
+          box,
+          harnessId: harnessAdapter.id,
+          modelId,
+          runId: turnRunId,
+          bearer: authHeader,
+          signal: AbortSignal.timeout(HARNESS_TEARDOWN_TIMEOUT_MS),
+        })
+          .then((renewed) => {
+            if (!renewed.ok && reservationHeld) {
+              logger.error(
+                "[harness] preparation reservation was lost; aborting the turn"
+              );
+              livenessAbort.abort(new Error("harness box reservation lost"));
+            }
+          })
+          .catch((err) => {
+            if (reservationHeld) {
+              logger.error(
+                "[harness] preparation reservation renewal failed; aborting the turn",
+                err
+              );
+              livenessAbort.abort(new Error("harness box reservation lost"));
+            }
+          })
+          .finally(() => {
+            reservationRenewalInFlight = false;
+          });
+      }, HARNESS_RESERVATION_HEARTBEAT_MS);
 
       // Root the Shell at the host-configured working directory (COMP-16) — the
       // same `computer.workdir` the chat bash tool honors — confined under
@@ -1240,6 +1285,7 @@ export async function runHarnessTurn(
       // The lease is recorded, which consumed this turn's claim on the box; the
       // lease's own per-box fence covers the rest of the turn. Releasing now
       // would free a box that is very much still in use.
+      clearReservationHeartbeat();
       reservationHeld = false;
       const auth = buildBrokerDummyAuth(harnessAdapter.id, broker.proxyBaseUrl);
       tBroker = Date.now();
@@ -2459,6 +2505,7 @@ export async function runHarnessTurn(
   // path. See the `createUIMessageStream` call below for why this now runs from
   // `execute`'s finally rather than the SDK's `onFinish`.
   const onFinishEngine = async (receiptWriter?: ChunkWriter) => {
+    clearReservationHeartbeat();
     // Broker teardown runs FIRST — the model stream has ended, so revoke the lease
     // + clear the E2B egress rule before the persistence/cleanup callbacks below,
     // which could hang and would otherwise keep the credential live until TTL/cron.

--- a/mcpjam-inspector/server/utils/harness/run-harness-turn.ts
+++ b/mcpjam-inspector/server/utils/harness/run-harness-turn.ts
@@ -34,6 +34,7 @@ import {
 import {
   HarnessAgent,
   collectHarnessAgentToolApprovalContinuations,
+  prewarmHarness,
 } from "@ai-sdk/harness/agent";
 import {
   emitTraceSnapshot,
@@ -46,6 +47,8 @@ import type { HarnessV1PermissionMode } from "@ai-sdk/harness";
 import {
   startHarnessModelBroker,
   revokeHarnessModelBroker,
+  reserveHarnessBox,
+  releaseHarnessBoxReservation,
   type HarnessBrokerBox,
 } from "./harness-model-broker.js";
 import { harnessBrokerDeliveryEnabled } from "./harness-flags.js";
@@ -537,6 +540,14 @@ export async function runHarnessTurn(
   // egress transform; used to revoke + clear the rule on teardown.
   let brokerRunId: string | undefined;
   let brokerRevoked = false;
+  // This turn's claim on the box, held across the preparation window (step 3a)
+  // and given up the moment the lease is recorded — recording it consumes the
+  // claim, and from then on the lease's own per-box fence is what excludes other
+  // turns. True only while the claim is ours to hand back, so onFinishEngine can
+  // free the box on any exit before that point instead of leaving the next turn
+  // to wait out the reservation TTL.
+  let reservationHeld = false;
+  let releaseBoxReservation: (() => Promise<void>) | undefined;
   // Ownership handoff for the claimed continuity lane: false from the moment the
   // lane is claimed until the harness session is established (the point the
   // finalizer/heartbeat take over). While false, ANY failure (sandbox wake,
@@ -704,11 +715,15 @@ export async function runHarnessTurn(
       const isApprovalResume = approvalContinuations.length > 0;
 
       // Phase timing — log where a turn spends its wall-clock (claim / box
-      // wake / broker start / session connect / model stream / finalize) so
-      // "takes forever" can be attributed instead of guessed.
+      // wake / runtime prewarm / broker start / session connect / model stream /
+      // finalize) so "takes forever" can be attributed instead of guessed.
       const tStart = Date.now();
       let tClaim = tStart;
       let tSandbox = tStart;
+      // Set at the START of the prewarm phase and again at its end, so a turn
+      // that skips prewarm reports ~0 for it rather than a negative duration
+      // measured back to function entry.
+      let tPrewarm = tStart;
       let tBroker = tStart;
       let tConnect = tStart;
       let resumedSession = false;
@@ -1076,16 +1091,134 @@ export async function runHarnessTurn(
         box.kind === "computer" ? box.computerId : undefined;
       tSandbox = Date.now();
 
+      // 3a. PREPARE the box — while it can still reach the internet.
+      //
+      // The harness runtime is installed into the sandbox by a bootstrap recipe
+      // that shells `pnpm install` for the agent CLI. Step 3b below locks this
+      // box's egress to the model proxy alone, so a bootstrap running after it
+      // cannot reach the package registry — it dies, slowly and opaquely, and
+      // the turn never gets as far as a model call. Bootstrapping has to happen
+      // here, in the last moment the box has ordinary egress.
+      //
+      // `prewarmHarness` applies the SAME recipe the agent would apply itself,
+      // keyed by the same content hash, and writes the same marker file. So this
+      // is not extra work: it moves the work earlier, and the in-stream
+      // bootstrap becomes a single marker read. It runs on every turn rather
+      // than only on turns expected to start fresh, because a resume that fails
+      // to reattach falls back to a fresh session — under the lock, where the
+      // bootstrap could not be recovered.
+      //
+      // The runtime handed to prewarm MUST come from the adapter, not from a
+      // bare `createClaudeCode()`: the registry patches the bridge asset inside
+      // the recipe, the recipe's hash covers file contents, and a divergent hash
+      // would leave a marker the real turn ignores — reinstating the deadlock
+      // while looking like it had been fixed. Auth is inert here (the adapter
+      // reads it only when starting a session), so a placeholder is enough.
+      //
+      // ONE id for the whole turn: it names this turn's claim on the box, and
+      // the lease consumes that claim by matching it. Deliberately NOT assigned
+      // to `brokerRunId` yet — that variable means "a lease may exist under this
+      // id", and teardown reads it to decide whether to revoke. Setting it here
+      // would make every failed preparation issue a pointless revoke for a lease
+      // that was never minted.
+      const turnRunId = crypto.randomUUID();
+
+      // Claim the box for the whole preparation window. The lease's own per-box
+      // fence starts only once a lease exists, so without this two turns could
+      // interleave — one locking the box's egress while the other is still
+      // installing into it. A refusal here is the same condition a caller would
+      // otherwise meet at broker start, just detected before we do any work.
+      const reservation = await reserveHarnessBox({
+        box,
+        harnessId: harnessAdapter.id,
+        modelId,
+        runId: turnRunId,
+        bearer: authHeader,
+        ...(abortSignal ? { signal: abortSignal } : {}),
+      });
+      if (!reservation.ok) {
+        throw new Error(reservation.error);
+      }
+      // From here until the lease is minted, ANY exit must hand the box back —
+      // otherwise the next turn waits out the reservation's TTL for nothing.
+      // Cleared once the broker start succeeds, because recording the lease
+      // consumes the claim and the lease's own fence takes over.
+      reservationHeld = !reservation.unsupported;
+      releaseBoxReservation = async () => {
+        await releaseHarnessBoxReservation({
+          box,
+          harnessId: harnessAdapter.id,
+          modelId,
+          runId: turnRunId,
+          bearer: authHeader,
+          signal: AbortSignal.timeout(HARNESS_TEARDOWN_TIMEOUT_MS),
+        }).catch(() => {});
+      };
+
+      // Root the Shell at the host-configured working directory (COMP-16) — the
+      // same `computer.workdir` the chat bash tool honors — confined under
+      // /home/user, defaulting to the box home. The harness framework nests a
+      // per-session `<workdir>/claude-code-<sessionId>` dir beneath it, so both
+      // planes share one configured root even though the Shell gets its own
+      // session subdir. An escaping value falls back to the default rather than
+      // failing the turn (the UI + bash path already reject escapes loudly).
+      // On the ephemeral path the workdir comes back WITH the box: the control
+      // plane resolved it from the same pinned target spec when it reserved the
+      // row, so it is the authoritative value for THIS box. Falling through to
+      // `computerWorkdir` keeps the personal path identical. Both still go
+      // through `resolveWorkingDirectory`, so neither can escape /home/user.
+      const resolvedHarnessWorkdir = resolveWorkingDirectory(
+        harnessSandboxBinding?.workdir ?? computerWorkdir
+      );
+      const defaultWorkingDirectory =
+        "error" in resolvedHarnessWorkdir
+          ? HOME_ROOT
+          : resolvedHarnessWorkdir.workdir ?? HOME_ROOT;
+      // ONE provider for the turn: prewarm and the streaming session below both
+      // attach to the same box through it.
+      const sandbox = createE2BHarnessSandboxProvider({
+        sandboxId,
+        defaultWorkingDirectory,
+      });
+
+      tPrewarm = Date.now();
+      if (process.env.HARNESS_PREWARM_DISABLED !== "1") {
+        const prewarmRuntime = harnessAdapter.createHarness({
+          modelId,
+          auth: buildBrokerDummyAuth(
+            harnessAdapter.id,
+            "https://prewarm.invalid"
+          ),
+        });
+        try {
+          await prewarmHarness({
+            harness: prewarmRuntime,
+            sandboxProvider: sandbox,
+            abortSignal: effectiveAbortSignal,
+          });
+        } catch (err) {
+          // An abort is not a failure — rethrow it untouched so the outer catch
+          // still classifies the turn as aborted rather than broken.
+          if (effectiveAbortSignal.aborted || isAbortError(err)) throw err;
+          throw new Error(
+            `Couldn't prepare the ${harnessAdapter.displayName} runtime on the ` +
+              `computer: ${err instanceof Error ? err.message : String(err)}`,
+            { cause: err }
+          );
+        }
+        tPrewarm = Date.now();
+      }
+
       // 3b. BROKER delivery (the only credential path): the sandbox id is now
       // known, so have Convex mint the lease, lock the sandbox's egress to the
       // proxy, and install the lease into E2B's egress transform — the
       // inspector never sees the lease. Run the CLI with dummy creds pointed
       // at the returned proxy. Fail-fast on install error (the box is awake
       // but no real credential exists anywhere).
-      // PRECOMPUTE the run id and record it (+ the computer) BEFORE the POST.
-      // If the backend installs the E2B rule but the response is lost/aborted,
-      // teardown can still revoke by this id (backend keys revoke on runId).
-      brokerRunId = crypto.randomUUID();
+      // RECORD the run id before the POST: if the backend installs the E2B rule
+      // but the response is lost or aborted, teardown can still revoke by this
+      // id (the backend keys revoke on runId). From here on a lease may exist.
+      brokerRunId = turnRunId;
       const broker = await startHarnessModelBroker({
         // The project and the execution scope are fields of `box`'s COMPUTER
         // arm (set where `box` is built, above), so the ephemeral path has no
@@ -1104,33 +1237,16 @@ export async function runHarnessTurn(
         // lease (brokerRunId set) if the backend installed before a lost response.
         throw new Error(broker.error);
       }
+      // The lease is recorded, which consumed this turn's claim on the box; the
+      // lease's own per-box fence covers the rest of the turn. Releasing now
+      // would free a box that is very much still in use.
+      reservationHeld = false;
       const auth = buildBrokerDummyAuth(harnessAdapter.id, broker.proxyBaseUrl);
       tBroker = Date.now();
 
-      // 4. Assemble the harness over the host's E2B computer. Root the Shell at
-      // the host-configured working directory (COMP-16) — the same
-      // `computer.workdir` the chat bash tool honors — confined under
-      // /home/user, defaulting to the box home. The harness framework nests a
-      // per-session `<workdir>/claude-code-<sessionId>` dir beneath it, so both
-      // planes share one configured root even though the Shell gets its own
-      // session subdir. An escaping value falls back to the default rather than
-      // failing the turn (the UI + bash path already reject escapes loudly).
-      // On the ephemeral path the workdir comes back WITH the box: the control
-      // plane resolved it from the same pinned target spec when it reserved the
-      // row, so it is the authoritative value for THIS box. Falling through to
-      // `computerWorkdir` keeps the personal path identical. Both still go
-      // through `resolveWorkingDirectory`, so neither can escape /home/user.
-      const resolvedHarnessWorkdir = resolveWorkingDirectory(
-        harnessSandboxBinding?.workdir ?? computerWorkdir
-      );
-      const defaultWorkingDirectory =
-        "error" in resolvedHarnessWorkdir
-          ? HOME_ROOT
-          : resolvedHarnessWorkdir.workdir ?? HOME_ROOT;
-      const sandbox = createE2BHarnessSandboxProvider({
-        sandboxId,
-        defaultWorkingDirectory,
-      });
+      // 4. Assemble the harness over the host's E2B computer (the provider and
+      // its working directory were resolved in step 3a, so prewarm and the
+      // streaming session share one).
       // (permissionMode was computed above, before the runtime fingerprint.)
 
       // The adapter maps the host modelId to the harness's native model and
@@ -2162,7 +2278,9 @@ export async function runHarnessTurn(
         logger.info(
           `[harness][timing] claim=${tClaim - tStart}ms boxWake=${
             tSandbox - tClaim
-          }ms brokerStart=${tBroker - tSandbox}ms sessionConnect=${
+          }ms prewarm=${tPrewarm - tSandbox}ms brokerStart=${
+            tBroker - tPrewarm
+          }ms sessionConnect=${
             tConnect - tBroker
           }ms modelStream=${tStream - tConnect}ms total=${
             tStream - tStart
@@ -2364,6 +2482,15 @@ export async function runHarnessTurn(
         bearer: authHeader,
         signal: AbortSignal.timeout(HARNESS_TEARDOWN_TIMEOUT_MS),
       }).catch(() => {});
+    }
+    // The box was claimed but never leased — preparation failed, or the turn was
+    // aborted during it. Hand the box back now; the reservation's TTL would
+    // otherwise make the next turn wait minutes for a box nobody is using.
+    // Reaching here with the claim still held means no lease exists, so there is
+    // no egress rule to clear and nothing else to undo.
+    if (reservationHeld && releaseBoxReservation) {
+      reservationHeld = false;
+      await releaseBoxReservation();
     }
     if ((runSucceeded || pausedForScopeStepUp) && !aborted && driver) {
       // Stream start (matches the span offset base) so rehydrated traces align


### PR DESCRIPTION
## The bug

**The Claude Code harness has never completed a model call, on prod or staging.** Every lease ever minted on prod — all 33 of them, across several orgs — shows `callCount: 0`, and every turn dies the same way roughly 70 seconds in, reporting `exit status 1` and nothing else.

The cause is an ordering one. `runHarnessTurn` asks the broker for a credential as soon as it knows which box it is on, and the broker's job is to lock that box's egress down to the model proxy. Only *afterwards* does the agent connect and run its bootstrap — a `pnpm install` of the agent CLI, which needs the package registry that the lock has just taken away. npm retries, times out, and the sandbox's bare exit code is what surfaces. Nothing about the failure points at the lock, which is why it survived this long.

Reproduced directly: booting a box from the real deployment template, applying the real broker policy, and running the guard command fails in **72.3s** with `CommandExitError: exit status 1` and `npm error code ECONNRESET`.

It regressed on 2026-07-21, when COMP-23 (#3204) removed the raw-credential path and made broker-only delivery — and its egress lock — the sole route. Before that the box had open egress during bootstrap.

## The fix

The bootstrap moves to before the lock. `prewarmHarness` applies the same recipe the agent would apply itself, keyed by the same content hash and leaving the same marker file, so this is not extra work — it is the same work, done in the last moment the box can still reach the registry. The in-stream bootstrap then finds the marker and does nothing.

## Three things worth stating for review

**The prewarmed runtime comes from the adapter, never a bare constructor.** The registry rewrites the bridge asset inside the recipe and the recipe's hash covers file contents, so a differently-built runtime would leave a marker the real turn ignores — reinstating the deadlock while *looking* fixed. `registry.test.ts` now pins that the recipe does not vary with credentials, since prewarm necessarily runs before the real one exists.

**Prewarm runs on every turn**, not only ones expected to start fresh: a resume that fails to reattach falls back to a fresh session, which would otherwise bootstrap under the lock with no way to recover. Steady-state cost is one connect plus a marker read, and it is now visible as its own `prewarm=` phase in the `[harness][timing]` log. `HARNESS_PREWARM_DISABLED=1` is the ops off-switch.

**The box is claimed for the whole preparation window.** The lease's per-box fence only starts once a lease exists, so without a claim two turns could interleave — one locking the box while the other is still installing. The claim is released on any exit before the lease is minted, so a failed preparation does not leave the next turn waiting out its TTL. Requires the backend reservation endpoint (MCPJam/mcpjam-backend#1067); a 404 from it is treated as "nothing claimed" so an older backend keeps working.

## Also here

Both found while chasing the above:

- The pnpm guard now says what went wrong — the sandbox id, exit code, output, and the fact that a locked box cannot reach the registry — instead of surfacing E2B's bare `exit status 1`. It was the only un-normalized `commands.run` in the provider, which is why the failure carried no context.
- The sandbox provider honors the abort signals the contract was already passing it. An aborted bootstrap previously kept running to the ten-minute command timeout, holding the box after the turn was over.

## Testing

Eight new cases pinning the ordering (claim → prewarm → broker), the shared provider instance, the adapter-sourced runtime, the shared run id, release-on-failure with nothing minted, the busy-box refusal before any work, older-backend compatibility, and the kill switch. New `e2b-sandbox-provider.test.ts` (9 cases) for the error shape and abort plumbing, plus the registry hash-stability guard.

657 harness + eval tests passing. **Zero new type errors** against the 150-error `tsc -p server/tsconfig.json` baseline (diffed, not counted).

## Not covered

Verified by unit tests and by a live reproduction of the failure, but **not yet by a real end-to-end harness run** — that needs the backend PRs deployed and the E2B template rebuilt with pnpm. The success signal to watch for on staging is the first `harnessModelLeases` row in the project's history with `callCount > 0`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Reorders the harness turn’s box claim, bootstrap, and broker lease, and depends on new reservation endpoints. A mismatch in recipe hash, claim/lease `runId`, or backend rollout can leave boxes busy or restore the bootstrap deadlock.
> 
> **Overview**
> Harness turns now **install the agent runtime before the broker locks the box to the model proxy**, so `pnpm install` can still reach the package registry. Previously the lease ran first and bootstrap died with a bare `exit status 1`.
> 
> `runHarnessTurn` claims the box (`reserveHarnessBox`), `prewarmHarness`es the **adapter-built** recipe (same content-hash marker the streaming session expects), then starts the broker on the same `runId`. Failed prep releases the claim and mints no lease. `HARNESS_PREWARM_DISABLED=1` skips prewarm.
> 
> Also: richer pnpm-guard errors (sandbox id, exit, egress-lock hint), abort signals through E2B connect/exec so cancelled turns do not sit on the 10-minute command timeout, and reservation renew/release clients.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f08164509003ab172cfeff7b17eb5f017fcf45e2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Installs the harness runtime before locking egress so turns stop dying during bootstrap. Old: broker locked egress, then `pnpm install` couldn’t reach the registry and timed out; New: claim box → prewarm runtime → start broker; sessions proceed with egress locked only after bootstrap.

- Uses the adapter-built runtime from `@ai-sdk/harness/agent` so the content-hash marker matches the streaming turn; runs every turn to cover failed reattach paths.
- Shares one sandbox provider instance between prewarm and the session; timing logs add prewarm= in `[harness][timing]`.
- Claims the box for the preparation window and shares a single `runId` with the lease; renews the reservation on a heartbeat and aborts the turn if renewal is lost; releases the claim on any failure before the lease is minted.
- Sandbox provider now passes abort signals through connect, exec, file I/O, and spawn; the pnpm guard error names the sandbox, exit code, and likely egress-lock cause.

**Rollout**
- Backend required: deploy `/web/harness/model-broker/reserve`, `/reserve/renew`, and `/reserve/release` before this inspector; missing endpoints fail closed.
- Ops switch: set `HARNESS_PREWARM_DISABLED=1` to disable prewarm.
- Optional: rebuild the E2B computer template with pnpm preinstalled to avoid the npm fallback.
- Staging success signal: first `harnessModelLeases` row with `callCount > 0`.

<sup>Written for commit f08164509003ab172cfeff7b17eb5f017fcf45e2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/MCPJam/inspector/pull/4182?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

