### PR TITLE
Readiness findings arrive with the verdict, in the suites’ own grammar

### DIFF
--- a/.changeset/readiness-findings-visible.md
+++ b/.changeset/readiness-findings-visible.md
@@ -1,0 +1,32 @@
+---
+"@mcpjam/inspector": patch
+---
+
+Readiness findings arrive with the verdict, in the suites' own grammar
+
+The readiness sections rendered lane counts over nothing. Two causes, one
+symptom.
+
+**The findings never loaded.** The report fetch was wired to the section's
+expand click — and the sections open by default, so the click never came, the
+fetch never fired, and the report component returned `null` on the resulting
+state instead of saying anything. A run that produced 49 findings rendered
+exactly like a run that produced none. The report now loads the moment a run
+is terminal, with a regression test proving no click is involved.
+
+**The copy was the engine's wire vocabulary.** "Supply authorizationRequests,
+intrusive to close this gap" is a `missingInputs` token list, named for runner
+options a reader has never heard of. Each token now maps to a sentence that
+says what happened and what to do — complete an OAuth flow, run the CLI with
+the intrusive flags on a server you own, add a submission profile — with
+unknown tokens falling back to their raw names rather than being hidden.
+
+The report itself is regrouped to feel like the suites beside it: findings
+sit under the lane that graded them, the group header carrying the same
+"10/14 evaluated" a reader saw in the summary, red-and-gap lanes open by
+default while clean lanes stay folded. Every row expands to the sentence it
+exists to deliver — the remediation for a violation, the engine's own reason
+for a check that never ran — plus its evidence and a link to the exact page
+and section of the publisher's rules. That is the bar for an agent fixing an
+error from this screen: id, status, why, what to change, and where it is
+written.

--- a/mcpjam-inspector/client/src/components/conformance/directory-readiness/DirectoryReadinessReport.tsx
+++ b/mcpjam-inspector/client/src/components/conformance/directory-readiness/DirectoryReadinessReport.tsx
@@ -1,24 +1,26 @@
 /**
- * The findings, grouped by what they mean rather than by what they say.
+ * Every finding, under the lane it graded, in the suites' own visual grammar.
  *
- * ## Why grouping is by CLASS
+ * ## Why lanes, not classes, are the grouping
  *
- * Readiness findings do not sort into pass and fail. A `runtime-blocker` and a
- * `heuristic` can both read `violated` and mean completely different things:
- * one keeps a submission out of the directory, the other is an opinion worth
- * considering. `decideLaneStatus` only consults the dispositive classes, so a
- * reader who cannot see the class cannot tell which findings actually moved
- * the verdict — and a model-authored observation would look exactly like a
- * requirement.
+ * The first version grouped findings by class — blockers, requirements,
+ * advice — which is the right taxonomy and the wrong navigation. The suites
+ * beside this render a flat list of check rows the moment a run finishes, and
+ * that immediacy is what makes them legible: you click, you see every check,
+ * you expand the red ones. Readiness now does the same, with the lane rows
+ * the summary already showed becoming the group headers, so the number a
+ * reader saw ("10/14 evaluated") sits directly above the fourteen rows it
+ * counted. The class survives as a chip on each row, because it still decides
+ * whether that row moved the verdict.
  *
- * The order is the order somebody fixes things in: what blocks, then what is
- * required, then what is advice.
+ * ## Every row answers "so what do I do"
  *
- * ## Not-evaluated is a first-class row
- *
- * A finding that never ran carries its reason, and hiding it would leave the
- * reader believing the check passed. It renders in its own muted style with
- * the reason attached, so "nobody looked" never reads as "nothing wrong".
+ * A violated row expands to its remediation. A not-evaluated row expands to
+ * the reason it never ran — the engine writes these as real sentences — and
+ * the doc link names the exact page and section of the publisher's rules, so
+ * an agent (or a person) can go from a red row to the requirement's source
+ * without guessing. That is the "enough information to fix it" bar: id,
+ * status, why, what to change, and where it is written.
  */
 
 import { useState } from "react";
@@ -33,6 +35,11 @@ import {
   XCircle,
 } from "lucide-react";
 import type { DirectoryReadinessResult } from "@/lib/apis/directory-readiness-api";
+import {
+  CLASS_LABEL,
+  FINDING_STATUS_ORDER,
+  describeMissingInputs,
+} from "./readiness-copy";
 
 type FindingLike = {
   id: string;
@@ -43,39 +50,39 @@ type FindingLike = {
   remediation?: string;
   provenance?: string;
   notEvaluatedReason?: string;
-  source?: { page?: string; section?: string };
+  source?: { page?: string; section?: string; url?: string };
+  details?: Record<string, unknown>;
 };
 
-/** Fix-order, and the label a reader needs to know what a group costs them. */
-const CLASS_GROUPS: Array<{ key: string; title: string; blurb: string }> = [
-  {
-    key: "runtime-blocker",
-    title: "Runtime blockers",
-    blurb: "The host cannot use this server until these are fixed.",
-  },
-  {
-    key: "required",
-    title: "Directory requirements",
-    blurb: "The publisher's rules require these before a submission is listed.",
-  },
-  {
-    key: "recommended",
-    title: "Recommended",
-    blurb: "Not disqualifying, but expected of a good submission.",
-  },
-  {
-    key: "manual-review",
-    title: "Needs a human",
-    blurb: "A reviewer decides these; no automated check can.",
-  },
-  {
-    key: "heuristic",
-    title: "Observations",
-    blurb: "Judgement calls, never part of the verdict.",
-  },
-];
+type LaneLike = {
+  lane: string;
+  status: "ready" | "not-ready" | "incomplete";
+  coverage: {
+    evaluated: number;
+    notEvaluated: number;
+    notApplicable: number;
+    missingInputs: string[];
+  };
+};
 
-function StatusIcon({ status }: { status: string }) {
+function laneLabel(lane: string): string {
+  const spaced = lane.replace(/-/g, " ");
+  return spaced.charAt(0).toUpperCase() + spaced.slice(1);
+}
+
+function LaneIcon({ status }: { status: LaneLike["status"] }) {
+  if (status === "ready") {
+    return (
+      <CheckCircle2 className="h-3.5 w-3.5 text-green-500 flex-shrink-0" />
+    );
+  }
+  if (status === "not-ready") {
+    return <XCircle className="h-3.5 w-3.5 text-red-400 flex-shrink-0" />;
+  }
+  return <MinusCircle className="h-3.5 w-3.5 text-amber-500 flex-shrink-0" />;
+}
+
+function FindingIcon({ status }: { status: string }) {
   if (status === "violated") {
     return <XCircle className="h-3.5 w-3.5 text-red-400 flex-shrink-0" />;
   }
@@ -92,10 +99,32 @@ function StatusIcon({ status }: { status: string }) {
   return <AlertTriangle className="h-3.5 w-3.5 text-amber-500 flex-shrink-0" />;
 }
 
+/** `details` keys that repeat what the row already says. */
+const NOISY_DETAIL_KEYS = new Set(["missingInput"]);
+
+function detailRows(details: Record<string, unknown> | undefined) {
+  if (!details) return [];
+  return Object.entries(details).filter(
+    ([key, value]) =>
+      !NOISY_DETAIL_KEYS.has(key) &&
+      (typeof value === "string" ||
+        typeof value === "number" ||
+        typeof value === "boolean"),
+  );
+}
+
 function FindingRow({ finding }: { finding: FindingLike }) {
   const [open, setOpen] = useState(false);
-  const detail = finding.notEvaluatedReason ?? finding.remediation;
-  const expandable = Boolean(detail || finding.source?.page);
+  // The sentence the row exists to deliver: why it never ran, or how to fix
+  // it. Satisfied rows usually carry neither and stay unexpandable.
+  const explanation = finding.notEvaluatedReason ?? finding.remediation;
+  const extra = detailRows(finding.details);
+  const expandable = Boolean(explanation || extra.length > 0 || finding.source);
+
+  const chip =
+    finding.status === "satisfied" || finding.status === "not-applicable"
+      ? undefined
+      : CLASS_LABEL[finding.class];
 
   return (
     <div className="px-1 py-1">
@@ -115,30 +144,118 @@ function FindingRow({ finding }: { finding: FindingLike }) {
         ) : (
           <span className="w-3 flex-shrink-0" />
         )}
-        <StatusIcon status={finding.status} />
+        <FindingIcon status={finding.status} />
         <span className="min-w-0 flex-1 text-[11px] leading-snug">
           {finding.title}
         </span>
-        {/*
-          A model wrote this line. Saying so is not a disclaimer — it is what
-          lets a reader weigh it differently from a wire observation.
-        */}
         {finding.provenance === "llm" && (
+          // A model wrote this line; the label is what lets a reader weigh it
+          // differently from a wire observation.
           <span className="flex items-center gap-0.5 text-[9px] text-muted-foreground flex-shrink-0">
             <Sparkles className="h-2.5 w-2.5" />
             AI
           </span>
         )}
+        {chip && (
+          <span className="rounded border border-border/60 px-1 py-0.5 text-[9px] text-muted-foreground flex-shrink-0">
+            {chip}
+          </span>
+        )}
       </button>
-      {open && detail && (
-        <div className="pl-8 pr-1 pt-1 text-[10px] leading-relaxed text-muted-foreground">
-          {detail}
-          {finding.source?.page && (
-            <div className="pt-0.5 opacity-70">
-              Source: {finding.source.page}
-              {finding.source.section ? ` — ${finding.source.section}` : ""}
+      {open && (
+        <div className="pl-8 pr-1 pt-1 text-[10px] leading-relaxed text-muted-foreground space-y-1">
+          {explanation && <div>{explanation}</div>}
+          {extra.length > 0 && (
+            <div className="space-y-0.5">
+              {extra.map(([key, value]) => (
+                <div key={key} className="flex gap-1.5">
+                  <span className="opacity-70">{key}:</span>
+                  <span className="break-all">{String(value)}</span>
+                </div>
+              ))}
             </div>
           )}
+          {finding.source?.url ? (
+            <div className="opacity-80">
+              Rule:{" "}
+              <a
+                href={finding.source.url}
+                target="_blank"
+                rel="noreferrer"
+                className="underline underline-offset-2"
+              >
+                {finding.source.page ?? finding.source.url}
+                {finding.source.section ? ` ${finding.source.section}` : ""}
+              </a>
+            </div>
+          ) : finding.source?.page ? (
+            <div className="opacity-80">
+              Rule: {finding.source.page}
+              {finding.source.section ? ` ${finding.source.section}` : ""}
+            </div>
+          ) : null}
+        </div>
+      )}
+    </div>
+  );
+}
+
+function LaneGroup({
+  lane,
+  findings,
+}: {
+  lane: LaneLike;
+  findings: FindingLike[];
+}) {
+  // Open when there is something to act on; a clean lane stays folded so the
+  // red ones carry the attention.
+  const actionable = lane.status !== "ready";
+  const [open, setOpen] = useState(actionable);
+  const total = lane.coverage.evaluated + lane.coverage.notEvaluated;
+  const guidance = describeMissingInputs(lane.coverage.missingInputs);
+
+  return (
+    <div className="rounded-md border border-border/40">
+      <button
+        type="button"
+        className="w-full flex items-center justify-between gap-2 px-2 py-1.5 text-left hover:bg-muted/30"
+        onClick={() => setOpen((value) => !value)}
+        aria-expanded={open}
+      >
+        <span className="flex items-center gap-1.5 min-w-0">
+          {open ? (
+            <ChevronDown className="h-3 w-3 text-muted-foreground flex-shrink-0" />
+          ) : (
+            <ChevronRight className="h-3 w-3 text-muted-foreground flex-shrink-0" />
+          )}
+          <LaneIcon status={lane.status} />
+          <span className="text-xs font-medium truncate">
+            {laneLabel(lane.lane)}
+          </span>
+        </span>
+        {/* The denominator travels with the verdict: "ready over 3 of 8" and
+            "ready over 8" are different statements. */}
+        <span className="text-[10px] tabular-nums text-muted-foreground flex-shrink-0">
+          {lane.coverage.evaluated}/{total} evaluated
+          {lane.coverage.notApplicable > 0
+            ? ` · ${lane.coverage.notApplicable} n/a`
+            : ""}
+        </span>
+      </button>
+      {open && (
+        <div className="px-1 pb-1">
+          {guidance.length > 0 && (
+            <div className="mx-1 mb-1 rounded bg-amber-500/10 px-2 py-1.5 text-[10px] leading-relaxed text-amber-700 dark:text-amber-400 space-y-0.5">
+              {guidance.map((sentence) => (
+                <div key={sentence}>{sentence}</div>
+              ))}
+            </div>
+          )}
+          <div className="divide-y divide-border/30">
+            {findings.map((finding) => (
+              <FindingRow key={finding.id} finding={finding} />
+            ))}
+          </div>
         </div>
       )}
     </div>
@@ -177,8 +294,8 @@ export function DirectoryReadinessReport({
     );
   }
 
-  // A run that ended without a report says so. The reason is the whole value
-  // of the row — silence here would read as a run that found nothing.
+  // A run that ended without a report says so — silence would read as a run
+  // that found nothing.
   if (!report && !hasReport) {
     return (
       <div className="px-1 py-2 text-[10px] text-muted-foreground">
@@ -193,29 +310,35 @@ export function DirectoryReadinessReport({
   if (!report) return null;
 
   const findings = (report.findings ?? []) as FindingLike[];
-  if (findings.length === 0) return null;
+  const lanes = (report.lanes ?? []) as LaneLike[];
 
   return (
-    <div className="space-y-1.5">
-      {CLASS_GROUPS.map((group) => {
-        const rows = findings.filter((finding) => finding.class === group.key);
-        if (rows.length === 0) return null;
-        return (
-          <div key={group.key}>
-            <div className="px-1 pt-1 text-[10px] font-medium text-foreground/80">
-              {group.title}{" "}
-              <span className="font-normal text-muted-foreground">
-                ({rows.length}) — {group.blurb}
-              </span>
-            </div>
-            <div className="divide-y divide-border/30">
-              {rows.map((finding) => (
-                <FindingRow key={finding.id} finding={finding} />
-              ))}
-            </div>
-          </div>
-        );
-      })}
+    <div className="space-y-2">
+      {/* The engine writes this sentence for exactly this spot: what the
+          verdict is and what would change it. */}
+      {report.summary && (
+        <div className="px-1 text-[11px] leading-relaxed text-foreground/80">
+          {report.summary}
+        </div>
+      )}
+      <div className="space-y-1.5">
+        {lanes.map((lane) => {
+          const rows = findings
+            .filter((finding) => finding.lane === lane.lane)
+            .sort(
+              (left, right) =>
+                (FINDING_STATUS_ORDER[left.status] ?? 9) -
+                (FINDING_STATUS_ORDER[right.status] ?? 9),
+            );
+          if (
+            rows.length === 0 &&
+            lane.coverage.evaluated + lane.coverage.notEvaluated === 0
+          ) {
+            return null;
+          }
+          return <LaneGroup key={lane.lane} lane={lane} findings={rows} />;
+        })}
+      </div>
     </div>
   );
 }

--- a/mcpjam-inspector/client/src/components/conformance/directory-readiness/DirectoryReadinessSection.tsx
+++ b/mcpjam-inspector/client/src/components/conformance/directory-readiness/DirectoryReadinessSection.tsx
@@ -289,23 +289,11 @@ export function DirectoryReadinessSection({
 
             {hasResult ? (
               <>
+                {/* OpenAI's two staged rollups, visible beside the headline:
+                    a submitter whose server is fine and whose paperwork is
+                    not reads that here without opening anything. */}
                 <ReadinessLaneList
-                  lanes={
-                    state.report
-                      ? // FIELD BY FIELD rather than spreading `coverage`.
-                        // Coverage carries its own `lane`, so a spread after
-                        // `lane:` writes the same key twice — harmless at
-                        // runtime, and a `tsc` error that fails the build.
-                        state.report.lanes.map((entry) => ({
-                          lane: entry.lane,
-                          status: entry.status,
-                          evaluated: entry.coverage.evaluated,
-                          notEvaluated: entry.coverage.notEvaluated,
-                          notApplicable: entry.coverage.notApplicable,
-                          missingInputs: entry.coverage.missingInputs,
-                        }))
-                      : (state.run?.lanes ?? [])
-                  }
+                  lanes={state.report ? [] : state.run?.lanes ?? []}
                   stages={
                     state.report && isOpenAIReadinessResult(state.report)
                       ? state.report.stages
@@ -316,9 +304,6 @@ export function DirectoryReadinessSection({
                   report={state.report}
                   loading={state.reportLoading}
                   error={state.reportError}
-                  // A terminal run with no stored report is a fact worth
-                  // stating: it failed before it graded, or its report aged
-                  // out. Silence would read as "no findings".
                   hasReport={
                     state.report ? true : state.run?.hasReport ?? false
                   }

--- a/mcpjam-inspector/client/src/components/conformance/directory-readiness/ReadinessLaneList.tsx
+++ b/mcpjam-inspector/client/src/components/conformance/directory-readiness/ReadinessLaneList.tsx
@@ -14,6 +14,7 @@
  */
 
 import { CheckCircle2, MinusCircle, XCircle } from "lucide-react";
+import { describeMissingInputs } from "./readiness-copy";
 
 type LaneStatus = "ready" | "not-ready" | "incomplete";
 
@@ -60,7 +61,9 @@ export function ReadinessLaneList({
   lanes: ReadinessLaneRow[];
   stages?: ReadinessStageRow[];
 }) {
-  if (lanes.length === 0) return null;
+  // Stages render even with no lane rows: when the full report is mounted
+  // below, this component's only remaining job is the two OpenAI rollup chips.
+  if (lanes.length === 0 && (!stages || stages.length === 0)) return null;
 
   return (
     <div className="space-y-2">
@@ -112,9 +115,7 @@ export function ReadinessLaneList({
               {hasGap && (
                 <div className="pl-5 pt-0.5 text-[10px] text-amber-600 dark:text-amber-500">
                   {lane.missingInputs.length > 0
-                    ? `Supply ${lane.missingInputs.join(
-                        ", ",
-                      )} to close this gap.`
+                    ? describeMissingInputs(lane.missingInputs).join(" ")
                     : `${lane.notEvaluated} requirement(s) could not be evaluated.`}
                 </div>
               )}

--- a/mcpjam-inspector/client/src/components/conformance/directory-readiness/__tests__/DirectoryReadinessSection.test.tsx
+++ b/mcpjam-inspector/client/src/components/conformance/directory-readiness/__tests__/DirectoryReadinessSection.test.tsx
@@ -107,7 +107,7 @@ beforeEach(() => {
 });
 
 describe("local mode", () => {
-  it("grades inline and groups findings by what they cost", async () => {
+  it("grades inline and shows every finding under its lane, immediately", async () => {
     mockRunLocal.mockResolvedValue({ success: true, result: claudeResult() });
     render(
       <DirectoryReadinessSection publisher="claude" server={HTTP_SERVER} />,
@@ -117,16 +117,23 @@ describe("local mode", () => {
       screen.getByRole("button", { name: /run readiness/i }),
     );
 
+    // The suites' bar: a finished run renders its rows without another click.
     await waitFor(() => {
-      expect(screen.getByText(/Directory requirements/i)).toBeInTheDocument();
+      expect(
+        screen.getByText(/Protected Resource Metadata is discoverable/i),
+      ).toBeInTheDocument();
     });
-    // The class decides whether a finding moved the verdict, so a reader has
-    // to be able to tell a requirement from an opinion.
-    expect(screen.getByText(/Observations/i)).toBeInTheDocument();
+    // The class survives as a chip, because it decides whether the row moved
+    // the verdict — a requirement and an opinion must not look alike.
+    expect(screen.getByText(/^Required$/)).toBeInTheDocument();
     expect(screen.getByText(/Not ready/i)).toBeInTheDocument();
+    // The engine's own verdict sentence leads the report.
+    expect(
+      screen.getByText(/runtime-compatibility has unmet requirements/i),
+    ).toBeInTheDocument();
   });
 
-  it("shows what a lane could not evaluate, beside its verdict", async () => {
+  it("shows what a lane could not evaluate, in words rather than tokens", async () => {
     mockRunLocal.mockResolvedValue({ success: true, result: claudeResult() });
     render(
       <DirectoryReadinessSection publisher="claude" server={HTTP_SERVER} />,
@@ -139,9 +146,12 @@ describe("local mode", () => {
     await waitFor(() => {
       expect(screen.getByText(/3\/8 evaluated/)).toBeInTheDocument();
     });
+    // "Supply toolListing" is the engine's wire vocabulary; the screen says
+    // what actually happened and what to do about it.
     expect(
-      screen.getByText(/Supply toolListing to close this gap/i),
+      screen.getByText(/could not read the server's tool listing/i),
     ).toBeInTheDocument();
+    expect(screen.queryByText(/Supply toolListing/)).not.toBeInTheDocument();
   });
 
   it("offers no AI toggle at all, because a local run cannot spend", () => {
@@ -206,6 +216,50 @@ describe("hosted mode", () => {
     // a finding about somebody else's server.
     expect(screen.queryByText(/Not ready/i)).not.toBeInTheDocument();
     expect(screen.getByText(/deadline_exceeded/)).toBeInTheDocument();
+  });
+
+  it("loads the findings the moment a run completes, without a click", async () => {
+    // THE BUG THIS PINS: the report fetch was wired to the section's expand
+    // click, and the sections open by default — so the click never came, the
+    // fetch never fired, and a finished run showed lane counts over nothing.
+    // "49 findings you cannot see" renders exactly like "nothing found".
+    mockStartHosted.mockResolvedValue({
+      runId: "run_3",
+      status: "pending",
+      deduped: false,
+      includeLlmObservations: false,
+      readinessKind: "claude",
+      projectId: "p",
+      serverId: "s",
+    });
+    mockGetRun.mockResolvedValue({
+      id: "run_3",
+      status: "completed",
+      overallStatus: "not-ready",
+      lanes: [],
+      stages: [],
+      terminalReason: null,
+      errorMessage: null,
+      hasReport: true,
+      llmObservations: { status: "not-requested" },
+      includeLlmObservations: false,
+    });
+    mockGetReport.mockResolvedValue(claudeResult());
+
+    render(
+      <DirectoryReadinessSection publisher="claude" server={HTTP_SERVER} />,
+    );
+    await userEvent.click(
+      screen.getByRole("button", { name: /run readiness/i }),
+    );
+
+    // No collapse, no re-expand, no second click — the findings just arrive.
+    await waitFor(() => {
+      expect(
+        screen.getByText(/Protected Resource Metadata is discoverable/i),
+      ).toBeInTheDocument();
+    });
+    expect(mockGetReport).toHaveBeenCalledTimes(1);
   });
 
   it("reports a refused observation as a gap, not a failure", async () => {

--- a/mcpjam-inspector/client/src/components/conformance/directory-readiness/readiness-copy.ts
+++ b/mcpjam-inspector/client/src/components/conformance/directory-readiness/readiness-copy.ts
@@ -1,0 +1,68 @@
+/**
+ * The engine's vocabulary, translated for the person reading it.
+ *
+ * A lane's `missingInputs` are machine tokens — `authorizationRequests`,
+ * `intrusive`, `submissionProfile` — named for the runner option that would
+ * close the gap. Printing them raw produced sentences like "Supply
+ * authorizationRequests, intrusive to close this gap", which reads as a bug
+ * to anyone who has not read the SDK. The token IS the right wire format;
+ * this map is the right screen format, and each entry says what to actually
+ * DO, because "supply X" is only an instruction if you know where X comes
+ * from.
+ *
+ * Unknown tokens fall back to themselves rather than being hidden: a token
+ * this build does not know is a gap the reader still deserves to see, and a
+ * raw name is a better clue than silence.
+ */
+
+const INPUT_GUIDANCE: Record<string, string> = {
+  authorizationRequests:
+    "Complete an OAuth authorization against this server — the OAuth suite above drives one — so the auth checks can observe a real flow.",
+  intrusive:
+    "Intrusive probes (dynamic client registration, refresh rotation) mutate the target, so they only run from the CLI on a server you own: `mcpjam readiness check claude <url> --intrusive-dcr --intrusive-refresh`.",
+  submissionProfile:
+    "Describe the directory listing itself (name, description, test accounts, attestations) with a submission profile — gradeable today via the CLI's `--submission-profile <file>`.",
+  toolListing:
+    "This run could not read the server's tool listing, so every check over the tools reports a gap rather than a guess.",
+  appsResult:
+    "Widget evidence was unavailable — the apps dial did not complete on this run.",
+  pluginBundle:
+    "The plugin package is bytes on your machine, so it grades locally: `mcpjam readiness check openai --submission-mode <mode> --package <dir|zip>`.",
+  importedSkills:
+    "This run could not read the server's skills listing (`skills/list`).",
+  draftSnapshot:
+    "Comparing against the published version needs a draft snapshot this run did not have.",
+  publishedSnapshot:
+    "Comparing against the published version needs its snapshot — first submissions have none, and this lane will not apply.",
+  serverUrl: "This submission shape grades an MCP server; none was supplied.",
+};
+
+/** One actionable sentence per missing input, in the run's own order. */
+export function describeMissingInputs(tokens: readonly string[]): string[] {
+  return tokens.map((token) => INPUT_GUIDANCE[token] ?? `Supply ${token}.`);
+}
+
+/**
+ * What a finding's class costs the submitter, in five words or fewer.
+ *
+ * Shown as a chip on every non-passing row because the class is what decides
+ * whether a finding moved the verdict — a `heuristic` and a `runtime-blocker`
+ * can both read "violated" and mean completely different things, and a reader
+ * who cannot tell them apart will fix the wrong one first.
+ */
+export const CLASS_LABEL: Record<string, string> = {
+  "runtime-blocker": "Blocks runtime",
+  required: "Required",
+  recommended: "Recommended",
+  "manual-review": "Human review",
+  heuristic: "Advice",
+};
+
+/** Render order inside a lane: what the submitter must act on first. */
+export const FINDING_STATUS_ORDER: Record<string, number> = {
+  violated: 0,
+  "not-evaluated": 1,
+  informational: 2,
+  satisfied: 3,
+  "not-applicable": 4,
+};

--- a/mcpjam-inspector/client/src/hooks/use-directory-readiness-run.ts
+++ b/mcpjam-inspector/client/src/hooks/use-directory-readiness-run.ts
@@ -316,7 +316,14 @@ export function useDirectoryReadinessRun({
     }
   }, [hosted, initialState]);
 
-  /** Fetch the report on first expand — it can be megabytes. */
+  /**
+   * Fetch the full report. Kept callable for retries, but the effect below is
+   * the normal path — the first version wired this to the section's expand
+   * CLICK, then made the sections open by default, so the click never came
+   * and a finished run rendered lane counts with no findings under them. A
+   * fetch that only a collapse-and-reopen could trigger is a fetch that never
+   * happens.
+   */
   const loadReport = useCallback(async () => {
     const runId = state.run?.id;
     if (!runId || state.report || state.reportLoading) return;
@@ -340,6 +347,16 @@ export function useDirectoryReadinessRun({
       }));
     }
   }, [isCurrent, state.report, state.reportLoading, state.run]);
+
+  // THE FINDINGS ARRIVE WITH THE VERDICT. The moment a hosted run is terminal
+  // and a report exists, fetch it — the row alone renders coverage numbers
+  // with nothing under them, which reads as "nothing found" when the truth is
+  // "49 findings you cannot see".
+  useEffect(() => {
+    if (!state.run || !isTerminalRunStatus(state.run.status)) return;
+    if (!state.run.hasReport || state.report || state.reportLoading) return;
+    void loadReport();
+  }, [loadReport, state.report, state.reportLoading, state.run]);
 
   /**
    * Adopt the newest run for this server after a reload.


### PR DESCRIPTION
Response to direct feedback: *"the UI is very sucky … I don't see what these all mean. I would like it to feel like our other conformance checks that I click and immediately see what's happening. This should also give enough information so agents can fix errors."*

The sections rendered lane counts over nothing, and the reader was right that they meant nothing. Two causes, one symptom.

## The findings never loaded

The report fetch was wired to the section's expand **click** — and the sections open by default (#4168 made them so), so the click never came, the fetch never fired, and the report component returned `null` on the resulting state instead of saying anything. A hosted run that produced **49 findings** rendered identically to one that produced none.

Now the report loads the moment a run reaches a terminal state. The regression test drives a full hosted run and asserts the findings appear with no collapse, no re-expand, no second click — and it **fails against the old hook** (verified by reverting).

## The copy was wire vocabulary

"Supply authorizationRequests, intrusive to close this gap" is the engine's `missingInputs` token list — right on the wire, wrong on a screen. Each token now maps to a sentence saying what happened and what to *do*:

| token | now reads |
|---|---|
| `authorizationRequests` | "Complete an OAuth authorization against this server — the OAuth suite above drives one…" |
| `intrusive` | "Intrusive probes … only run from the CLI on a server you own: `mcpjam readiness check claude <url> --intrusive-dcr …`" |
| `submissionProfile` | "Describe the directory listing itself … via the CLI's `--submission-profile <file>`" |

Unknown tokens fall back to their raw names rather than being hidden.

## Regrouped to feel like the suites

Findings sit under the lane that graded them — the group header carries the same "10/14 evaluated" the summary showed, so the number sits directly above the fourteen rows it counted. Gap/red lanes open by default; clean lanes stay folded. The class survives as a chip per row (Required / Blocks runtime / Advice / AI), since it decides whether the row moved the verdict.

Every row expands to: the remediation (violations) or the engine's own reason (never-ran), the evidence details, and a **link to the exact page and section of the publisher's rules**. That's the agent-fixability bar: id, status, why, what to change, where it's written.

## Verification

- 36 conformance component tests (3 new/updated); the no-click regression test fails with the fix reverted.
- `npm run typecheck:client` (the command CI runs) clean; `build:client` succeeds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> UI-only, but it auto-fetches the full hosted report (noted as potentially large) on every terminal run and changes how findings are grouped and copied. No auth or grading-engine changes.
> 
> **Overview**
> Hosted directory-readiness findings now load as soon as a run is terminal, instead of waiting for a section expand click that never fired (sections open by default). A regression test asserts the report appears with no extra click.
> 
> The report is regrouped by **lane** (matching the suites beside it) rather than by class. Gap/red lanes open by default; class is a chip on each row. Rows expand to remediation or not-evaluated reason, evidence, and a publisher-rule link.
> 
> `missingInputs` tokens are translated into actionable sentences via `describeMissingInputs` (unknown tokens still fall back to `Supply <token>`). Once the full report is on screen, the compact lane list is suppressed so OpenAI stage chips remain without duplicating coverage rows.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d02e16a670c9b1a963c77a0067a907ce2870f41a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Readiness findings load automatically at run completion and render under their lanes with clear, human-readable guidance. Previously the report fetched on expand (which never fired because sections open by default), so runs with findings appeared empty and gap text showed wire tokens.

**Review notes**
- `use-directory-readiness-run`: auto-fetch the report when a hosted run reaches a terminal state and `hasReport` is true; keep `loadReport` for retries. Regression test pins the no-click path.
- `DirectoryReadinessReport`: group by lane (not class); show coverage (e.g., “3/8 evaluated · 2 n/a”); per-row class chip; expand to remediation or not-evaluated reason, evidence details, and a rule link; sort by status via `FINDING_STATUS_ORDER`.
- `ReadinessLaneList`: renders stages even with no lane rows; replaces token lists with `describeMissingInputs`.
- `readiness-copy.ts`: maps `missingInputs` tokens to actionable sentences; exports `CLASS_LABEL` and `FINDING_STATUS_ORDER`.
- Tests updated to assert immediate findings display and humanized gap text.
- Version bump: `@mcpjam/inspector` (patch). No migrations.

<sup>Written for commit d02e16a670c9b1a963c77a0067a907ce2870f41a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/MCPJam/inspector/pull/4183?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

