### PR TITLE
Org subregistries: the organization shelf in the Registry tab (I1 + I2 + I3)

### DIFF
--- a/mcpjam-inspector/client/src/components/RegistryTab.tsx
+++ b/mcpjam-inspector/client/src/components/RegistryTab.tsx
@@ -12,6 +12,10 @@ import {
   ChevronDown,
   BadgeCheck,
   Star,
+  Building2,
+  Plus,
+  Pencil,
+  Trash2,
 } from "lucide-react";
 import { Card } from "@mcpjam/design-system/card";
 import { Button } from "@mcpjam/design-system/button";
@@ -59,8 +63,18 @@ import {
   type DirectorySource,
   type DirectoryTier,
 } from "@/hooks/useServerDirectory";
+import {
+  useOrgRegistryServers,
+  type EnrichedOrgRegistryServer,
+  type OrgRegistrySubmission,
+} from "@/hooks/useOrgRegistryServers";
 import { DirectoryEndpointDialog } from "./registry/DirectoryEndpointDialog";
 import { DirectoryDetailDialog } from "./registry/DirectoryDetailDialog";
+import {
+  OrgRegistryServerDialog,
+  type OrgRegistryDialogSeed,
+} from "./registry/OrgRegistryServerDialog";
+import { ErrorBoundary } from "./ui/error-boundary";
 import { toast } from "@/lib/toast";
 import { formatRegistryStarCount } from "@/lib/format-registry-star-count";
 import type { ServerFormData } from "@/shared/types.js";
@@ -291,6 +305,87 @@ export function RegistryTab({
     isAuthenticated,
     onConnect,
   });
+
+  const orgRegistry = useOrgRegistryServers({
+    projectId,
+    isAuthenticated,
+    liveServers: servers,
+    onConnect,
+    onDisconnect,
+  });
+
+  /**
+   * What the add/edit dialog is currently about. `null` ⇒ closed; a seed with
+   * no `registryServerId` ⇒ the paste flow; a seed with one ⇒ editing.
+   */
+  const [orgDialog, setOrgDialog] = useState<{
+    seed: OrgRegistryDialogSeed | null;
+  } | null>(null);
+
+  const handleOrgSubmit = useCallback(
+    async (submission: OrgRegistrySubmission) => {
+      if (submission.registryServerId) {
+        await orgRegistry.update(submission);
+        toast.success("Registry entry updated");
+        return;
+      }
+      await orgRegistry.add(submission);
+      toast.success("Added to your organization's registry");
+    },
+    [orgRegistry]
+  );
+
+  const handleOrgConnect = useCallback(
+    async (server: EnrichedOrgRegistryServer) => {
+      try {
+        await orgRegistry.connect(server);
+      } catch (error) {
+        // The backend refuses a live-name collision by throwing. The project
+        // is the unit the person is looking at, so say "project" even though
+        // the invariant is enforced on the workspace mirror.
+        const message =
+          error instanceof Error &&
+          /already exists in this workspace/i.test(error.message)
+            ? `A server named "${server.displayName}" already exists in this project. Rename it, or rename the registry entry.`
+            : error instanceof Error
+            ? error.message
+            : "Could not connect this server.";
+        toast.error(message);
+      }
+    },
+    [orgRegistry]
+  );
+
+  const handleOrgDisconnect = useCallback(
+    async (server: EnrichedOrgRegistryServer) => {
+      try {
+        await orgRegistry.disconnect(server);
+      } catch (error) {
+        toast.error(
+          error instanceof Error
+            ? error.message
+            : "Could not disconnect this server."
+        );
+      }
+    },
+    [orgRegistry]
+  );
+
+  const handleOrgRemove = useCallback(
+    async (server: EnrichedOrgRegistryServer) => {
+      try {
+        await orgRegistry.remove(server._id);
+        toast.success("Removed from your organization's registry");
+      } catch (error) {
+        toast.error(
+          error instanceof Error
+            ? error.message
+            : "Could not remove this entry."
+        );
+      }
+    },
+    [orgRegistry]
+  );
 
   // Which directory row the endpoint dialog is asking about, and the choices
   // to offer. `options`/`pattern` are seeded from the card and REPLACED by
@@ -884,6 +979,39 @@ export function RegistryTab({
           </p>
         </div>
 
+        {/*
+          The organization's own shelf, above the curated one: it is the
+          smaller list and the one a team put there on purpose.
+
+          Behind its OWN boundary. This section is the only part of the tab
+          that reads functions the deployed backend may not have yet — a
+          browser can outlive a rollback, and `useQuery` for a missing function
+          throws during render. Without the boundary that takes the entire
+          Registry tab, curated catalog and directory included, down with it.
+        */}
+        <ErrorBoundary name="org-registry-section" fallback={null}>
+          <OrgRegistrySection
+            registry={orgRegistry}
+            onAdd={() => setOrgDialog({ seed: null })}
+            onEdit={(server) =>
+              setOrgDialog({
+                seed: {
+                  registryServerId: server._id,
+                  displayName: server.displayName,
+                  description: server.description,
+                  url: server.transport.url ?? "",
+                  useOAuth: server.transport.useOAuth,
+                  oauthScopes: server.transport.oauthScopes,
+                  derived: server.derived,
+                },
+              })
+            }
+            onRemove={handleOrgRemove}
+            onConnect={handleOrgConnect}
+            onDisconnect={handleOrgDisconnect}
+          />
+        </ErrorBoundary>
+
         {/* Curated cards grid */}
         {isLoading ? (
           // Same breakpoint as the grid it stands in for, so the page does
@@ -942,6 +1070,17 @@ export function RegistryTab({
           }
         />
       )}
+      {orgDialog && (
+        <OrgRegistryServerDialog
+          open
+          onOpenChange={(open) => {
+            if (!open) setOrgDialog(null);
+          }}
+          projectId={projectId}
+          seed={orgDialog.seed}
+          onSubmit={handleOrgSubmit}
+        />
+      )}
       {endpointPrompt && (
         <DirectoryEndpointDialog
           open
@@ -959,6 +1098,212 @@ export function RegistryTab({
         />
       )}
     </div>
+  );
+}
+
+/**
+ * The organization's own shelf.
+ *
+ * Renders nothing at all for a project outside an organization, or for
+ * somebody who is neither a member nor looking at any entries — an empty
+ * "Your organization" heading over a project that has no organization is
+ * noise, not information. It DOES render for a member with an empty shelf,
+ * because that is the state the invitation to add belongs in.
+ *
+ * The cards carry no star control. Stars are the identity of a consolidated
+ * PUBLIC card (`registryCardKey`), an org entry has none, and the backend's
+ * star mutation refuses a synthetic key outright — so a star here would be a
+ * button that cannot work.
+ */
+function OrgRegistrySection({
+  registry,
+  onAdd,
+  onEdit,
+  onRemove,
+  onConnect,
+  onDisconnect,
+}: {
+  registry: ReturnType<typeof useOrgRegistryServers>;
+  onAdd: () => void;
+  onEdit: (server: EnrichedOrgRegistryServer) => void;
+  onRemove: (server: EnrichedOrgRegistryServer) => void | Promise<void>;
+  onConnect: (server: EnrichedOrgRegistryServer) => void | Promise<void>;
+  onDisconnect: (server: EnrichedOrgRegistryServer) => void | Promise<void>;
+}) {
+  const { servers, isLoading, organizationId, canAdd } = registry;
+
+  if (!organizationId) return null;
+  if (!canAdd && servers.length === 0 && !isLoading) return null;
+
+  return (
+    <div className="space-y-3">
+      <div className="flex items-end justify-between gap-3">
+        <div>
+          <h3 className="text-sm font-semibold flex items-center gap-1.5">
+            <Building2 className="h-4 w-4 text-muted-foreground" />
+            Your organization
+          </h3>
+          <p className="text-xs text-muted-foreground">
+            Servers your team has shared. Visible in every project in this
+            organization.
+          </p>
+        </div>
+        {canAdd && (
+          <Button
+            type="button"
+            variant="outline"
+            size="sm"
+            className="h-7 text-xs gap-1"
+            onClick={onAdd}
+          >
+            <Plus className="h-3.5 w-3.5" />
+            Add a server
+          </Button>
+        )}
+      </div>
+
+      {isLoading ? (
+        <div className="grid grid-cols-1 lg:grid-cols-2 gap-4">
+          {Array.from({ length: 2 }).map((_, i) => (
+            <Skeleton key={i} className="h-28 w-full rounded-lg" />
+          ))}
+        </div>
+      ) : servers.length === 0 ? (
+        <Card className="px-4 py-6 text-center">
+          <p className="text-sm font-medium">Nothing shared yet</p>
+          <p className="text-xs text-muted-foreground mt-1">
+            Paste a remote server&rsquo;s address and we&rsquo;ll read the rest
+            off it — or share one you already have connected from its menu on
+            the Servers tab.
+          </p>
+        </Card>
+      ) : (
+        <div className="grid grid-cols-1 lg:grid-cols-2 gap-4">
+          {servers.map((server) => (
+            <OrgRegistryServerCard
+              key={server._id}
+              server={server}
+              canManage={canAdd}
+              onEdit={() => onEdit(server)}
+              onRemove={() => void onRemove(server)}
+              onConnect={() => void onConnect(server)}
+              onDisconnect={() => void onDisconnect(server)}
+            />
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}
+
+/**
+ * One org entry.
+ *
+ * Deliberately a sibling of `RegistryServerCard` rather than a prop on it. The
+ * curated card REQUIRES star props and a `registryCardKey`, and an org row has
+ * neither; threading "no stars" through it would leave a component whose two
+ * modes disagree about what identifies a card. The shapes are close enough to
+ * read as one family and different enough that one component would be lying.
+ */
+function OrgRegistryServerCard({
+  server,
+  canManage,
+  onEdit,
+  onRemove,
+  onConnect,
+  onDisconnect,
+}: {
+  server: EnrichedOrgRegistryServer;
+  canManage: boolean;
+  onEdit: () => void;
+  onRemove: () => void;
+  onConnect: () => void;
+  onDisconnect: () => void;
+}) {
+  const version = server.derived?.serverVersion ?? server.version;
+  const authRequired =
+    server.derived?.authRequired ?? server.transport.useOAuth ?? false;
+  /**
+   * Same rule the directory badge uses: only a server that demands auth AND
+   * resolved no way to register a client dynamically needs one in advance. An
+   * entry with no probe snapshot says nothing rather than making a claim the
+   * probe never backed.
+   */
+  const needsPreregisteredClient =
+    authRequired &&
+    server.derived !== undefined &&
+    !server.derived.supportsDcr &&
+    !server.derived.supportsCimd;
+
+  return (
+    <Card className="px-4 py-3 flex flex-col gap-2">
+      <div className="flex items-center gap-3">
+        <div className="h-8 w-8 rounded-md bg-muted flex items-center justify-center flex-shrink-0">
+          <Building2 className="h-4 w-4 text-muted-foreground" />
+        </div>
+        <div className="flex-1 min-w-0">
+          <h3 className="text-sm font-semibold truncate">
+            {server.displayName}
+          </h3>
+          <p className="text-xs text-muted-foreground truncate">
+            {server.transport.url}
+          </p>
+        </div>
+        <div className="flex-shrink-0 flex items-center gap-1">
+          <TopRightAction
+            status={server.connectionStatus}
+            onConnect={onConnect}
+            onDisconnect={onDisconnect}
+          />
+          {canManage && (
+            <DropdownMenu>
+              <DropdownMenuTrigger asChild>
+                <Button
+                  type="button"
+                  variant="ghost"
+                  size="sm"
+                  className="h-7 w-7 p-0"
+                  aria-label={`Manage ${server.displayName}`}
+                >
+                  <MoreVertical className="h-3.5 w-3.5" />
+                </Button>
+              </DropdownMenuTrigger>
+              <DropdownMenuContent align="end">
+                <DropdownMenuItem onClick={onEdit}>
+                  <Pencil className="h-3.5 w-3.5" />
+                  Edit entry
+                </DropdownMenuItem>
+                <DropdownMenuSeparator />
+                <DropdownMenuItem variant="destructive" onClick={onRemove}>
+                  <Trash2 className="h-3.5 w-3.5" />
+                  Remove from registry
+                </DropdownMenuItem>
+              </DropdownMenuContent>
+            </DropdownMenu>
+          )}
+        </div>
+      </div>
+
+      <div className="flex items-center gap-1.5 flex-wrap">
+        {version && (
+          <Badge variant="secondary" className="text-[10px]">
+            v{version}
+          </Badge>
+        )}
+        <AuthBadge useOAuth={authRequired} />
+        {needsPreregisteredClient && (
+          <Badge variant="outline" className="text-[10px]">
+            Requires pre-registered client
+          </Badge>
+        )}
+      </div>
+
+      {server.description && (
+        <p className="text-xs text-muted-foreground line-clamp-2">
+          {server.description}
+        </p>
+      )}
+    </Card>
   );
 }
 

--- a/mcpjam-inspector/client/src/components/RegistryTab.tsx
+++ b/mcpjam-inspector/client/src/components/RegistryTab.tsx
@@ -74,6 +74,7 @@ import {
   OrgRegistryServerDialog,
   type OrgRegistryDialogSeed,
 } from "./registry/OrgRegistryServerDialog";
+import { OrgRegistryRemoveDialog } from "./registry/OrgRegistryRemoveDialog";
 import { ErrorBoundary } from "./ui/error-boundary";
 import { toast } from "@/lib/toast";
 import { formatRegistryStarCount } from "@/lib/format-registry-star-count";
@@ -371,21 +372,31 @@ export function RegistryTab({
     [orgRegistry]
   );
 
-  const handleOrgRemove = useCallback(
-    async (server: EnrichedOrgRegistryServer) => {
-      try {
-        await orgRegistry.remove(server._id);
-        toast.success("Removed from your organization's registry");
-      } catch (error) {
-        toast.error(
-          error instanceof Error
-            ? error.message
-            : "Could not remove this entry."
-        );
-      }
-    },
-    [orgRegistry]
-  );
+  /**
+   * Which entry the remove confirmation is about. Removal reaches every
+   * project in the organization, not just this one, so it asks first — see
+   * `OrgRegistryRemoveDialog`.
+   */
+  const [orgRemoveTarget, setOrgRemoveTarget] =
+    useState<EnrichedOrgRegistryServer | null>(null);
+  const [orgRemoving, setOrgRemoving] = useState(false);
+
+  const handleOrgRemoveConfirmed = useCallback(async () => {
+    const server = orgRemoveTarget;
+    if (!server) return;
+    setOrgRemoving(true);
+    try {
+      await orgRegistry.remove(server._id);
+      toast.success("Removed from your organization's registry");
+      setOrgRemoveTarget(null);
+    } catch (error) {
+      toast.error(
+        error instanceof Error ? error.message : "Could not remove this entry."
+      );
+    } finally {
+      setOrgRemoving(false);
+    }
+  }, [orgRegistry, orgRemoveTarget]);
 
   // Which directory row the endpoint dialog is asking about, and the choices
   // to offer. `options`/`pattern` are seeded from the card and REPLACED by
@@ -945,20 +956,33 @@ export function RegistryTab({
     }),
   });
 
-  // Per-SECTION emptiness, not per-screen. The two halves have independent
+  // Per-SECTION emptiness, not per-screen. The three shelves have independent
   // backends: an empty curated catalog must not blank a directory that loaded
-  // fine, and vice versa. Only when BOTH are empty and neither is still
-  // loading is there genuinely nothing to show.
+  // fine, and neither may blank an organization's own entries. Only when ALL
+  // of them are empty and none is still loading is there genuinely nothing to
+  // show.
+  //
+  // The org shelf earns its place in this test rather than just rendering
+  // below it: this branch returns EARLY, so an org with servers on its shelf
+  // would be told "the registry is empty" and never see them whenever the
+  // curated catalog happened to be unseeded — a fresh deployment, or a
+  // preview environment.
   const curatedEmpty = !isLoading && catalogCards.length === 0;
   const directoryEmpty =
     !directory.isLoadingFirstPage && directory.items.length === 0;
   const directoryFiltered = isDirectoryFiltered(directory);
+  const orgShelfEmpty =
+    !orgRegistry.isLoading &&
+    orgRegistry.servers.length === 0 &&
+    // A member who can add has something to do here even with an empty shelf,
+    // so the invitation counts as content.
+    !orgRegistry.canAdd;
 
   if (isLoading && directory.isLoadingFirstPage) {
     return <LoadingSkeleton />;
   }
 
-  if (curatedEmpty && directoryEmpty && !directoryFiltered) {
+  if (curatedEmpty && directoryEmpty && orgShelfEmpty && !directoryFiltered) {
     return (
       <EmptyState
         icon={Package}
@@ -1006,7 +1030,7 @@ export function RegistryTab({
                 },
               })
             }
-            onRemove={handleOrgRemove}
+            onRemove={(server) => setOrgRemoveTarget(server)}
             onConnect={handleOrgConnect}
             onDisconnect={handleOrgDisconnect}
           />
@@ -1068,6 +1092,17 @@ export function RegistryTab({
               }}
             />
           }
+        />
+      )}
+      {orgRemoveTarget && (
+        <OrgRegistryRemoveDialog
+          open
+          onOpenChange={(open) => {
+            if (!open && !orgRemoving) setOrgRemoveTarget(null);
+          }}
+          displayName={orgRemoveTarget.displayName}
+          isRemoving={orgRemoving}
+          onConfirm={() => void handleOrgRemoveConfirmed()}
         />
       )}
       {orgDialog && (

--- a/mcpjam-inspector/client/src/components/RegistryTab.tsx
+++ b/mcpjam-inspector/client/src/components/RegistryTab.tsx
@@ -307,97 +307,6 @@ export function RegistryTab({
     onConnect,
   });
 
-  const orgRegistry = useOrgRegistryServers({
-    projectId,
-    isAuthenticated,
-    liveServers: servers,
-    onConnect,
-    onDisconnect,
-  });
-
-  /**
-   * What the add/edit dialog is currently about. `null` ⇒ closed; a seed with
-   * no `registryServerId` ⇒ the paste flow; a seed with one ⇒ editing.
-   */
-  const [orgDialog, setOrgDialog] = useState<{
-    seed: OrgRegistryDialogSeed | null;
-  } | null>(null);
-
-  const handleOrgSubmit = useCallback(
-    async (submission: OrgRegistrySubmission) => {
-      if (submission.registryServerId) {
-        await orgRegistry.update(submission);
-        toast.success("Registry entry updated");
-        return;
-      }
-      await orgRegistry.add(submission);
-      toast.success("Added to your organization's registry");
-    },
-    [orgRegistry]
-  );
-
-  const handleOrgConnect = useCallback(
-    async (server: EnrichedOrgRegistryServer) => {
-      try {
-        await orgRegistry.connect(server);
-      } catch (error) {
-        // The backend refuses a live-name collision by throwing. The project
-        // is the unit the person is looking at, so say "project" even though
-        // the invariant is enforced on the workspace mirror.
-        const message =
-          error instanceof Error &&
-          /already exists in this workspace/i.test(error.message)
-            ? `A server named "${server.displayName}" already exists in this project. Rename it, or rename the registry entry.`
-            : error instanceof Error
-            ? error.message
-            : "Could not connect this server.";
-        toast.error(message);
-      }
-    },
-    [orgRegistry]
-  );
-
-  const handleOrgDisconnect = useCallback(
-    async (server: EnrichedOrgRegistryServer) => {
-      try {
-        await orgRegistry.disconnect(server);
-      } catch (error) {
-        toast.error(
-          error instanceof Error
-            ? error.message
-            : "Could not disconnect this server."
-        );
-      }
-    },
-    [orgRegistry]
-  );
-
-  /**
-   * Which entry the remove confirmation is about. Removal reaches every
-   * project in the organization, not just this one, so it asks first — see
-   * `OrgRegistryRemoveDialog`.
-   */
-  const [orgRemoveTarget, setOrgRemoveTarget] =
-    useState<EnrichedOrgRegistryServer | null>(null);
-  const [orgRemoving, setOrgRemoving] = useState(false);
-
-  const handleOrgRemoveConfirmed = useCallback(async () => {
-    const server = orgRemoveTarget;
-    if (!server) return;
-    setOrgRemoving(true);
-    try {
-      await orgRegistry.remove(server._id);
-      toast.success("Removed from your organization's registry");
-      setOrgRemoveTarget(null);
-    } catch (error) {
-      toast.error(
-        error instanceof Error ? error.message : "Could not remove this entry."
-      );
-    } finally {
-      setOrgRemoving(false);
-    }
-  }, [orgRegistry, orgRemoveTarget]);
-
   // Which directory row the endpoint dialog is asking about, and the choices
   // to offer. `options`/`pattern` are seeded from the card and REPLACED by
   // whatever `endpoint_url_required` carried — the error is authoritative,
@@ -420,6 +329,21 @@ export function RegistryTab({
   );
   const detailServerDetail = useDirectoryServerDetail(
     detailServer?._id ?? null
+  );
+  const [orgShelfState, setOrgShelfState] = useState<{
+    hasContent: boolean;
+    isLoading: boolean;
+  } | null>(null);
+  const handleOrgShelfState = useCallback(
+    (next: { hasContent: boolean; isLoading: boolean }) => {
+      setOrgShelfState((previous) =>
+        previous?.hasContent === next.hasContent &&
+        previous?.isLoading === next.isLoading
+          ? previous
+          : next
+      );
+    },
+    []
   );
 
   // Auto-redirect to App Builder when a pending server becomes connected.
@@ -956,27 +880,20 @@ export function RegistryTab({
     }),
   });
 
-  // Per-SECTION emptiness, not per-screen. The three shelves have independent
+  // Per-SECTION emptiness, not per-screen. The two public shelves have independent
   // backends: an empty curated catalog must not blank a directory that loaded
   // fine, and neither may blank an organization's own entries. Only when ALL
   // of them are empty and none is still loading is there genuinely nothing to
   // show.
   //
-  // The org shelf earns its place in this test rather than just rendering
-  // below it: this branch returns EARLY, so an org with servers on its shelf
-  // would be told "the registry is empty" and never see them whenever the
-  // curated catalog happened to be unseeded — a fresh deployment, or a
-  // preview environment.
   const curatedEmpty = !isLoading && catalogCards.length === 0;
   const directoryEmpty =
     !directory.isLoadingFirstPage && directory.items.length === 0;
   const directoryFiltered = isDirectoryFiltered(directory);
   const orgShelfEmpty =
-    !orgRegistry.isLoading &&
-    orgRegistry.servers.length === 0 &&
-    // A member who can add has something to do here even with an empty shelf,
-    // so the invitation counts as content.
-    !orgRegistry.canAdd;
+    orgShelfState !== null &&
+    !orgShelfState.isLoading &&
+    !orgShelfState.hasContent;
 
   if (isLoading && directory.isLoadingFirstPage) {
     return <LoadingSkeleton />;
@@ -1014,25 +931,13 @@ export function RegistryTab({
           Registry tab, curated catalog and directory included, down with it.
         */}
         <ErrorBoundary name="org-registry-section" fallback={null}>
-          <OrgRegistrySection
-            registry={orgRegistry}
-            onAdd={() => setOrgDialog({ seed: null })}
-            onEdit={(server) =>
-              setOrgDialog({
-                seed: {
-                  registryServerId: server._id,
-                  displayName: server.displayName,
-                  description: server.description,
-                  url: server.transport.url ?? "",
-                  useOAuth: server.transport.useOAuth,
-                  oauthScopes: server.transport.oauthScopes,
-                  derived: server.derived,
-                },
-              })
-            }
-            onRemove={(server) => setOrgRemoveTarget(server)}
-            onConnect={handleOrgConnect}
-            onDisconnect={handleOrgDisconnect}
+          <OrgRegistrySectionContainer
+            projectId={projectId}
+            isAuthenticated={isAuthenticated}
+            liveServers={servers}
+            onConnect={onConnect}
+            onDisconnect={onDisconnect}
+            onState={handleOrgShelfState}
           />
         </ErrorBoundary>
 
@@ -1094,6 +999,159 @@ export function RegistryTab({
           }
         />
       )}
+      {endpointPrompt && (
+        <DirectoryEndpointDialog
+          open
+          onOpenChange={(open) => {
+            if (!open) setEndpointPrompt(null);
+          }}
+          displayName={endpointPrompt.server.displayName}
+          options={endpointPrompt.options}
+          pattern={endpointPrompt.pattern}
+          error={endpointPrompt.error ?? null}
+          submitting={connectingDirectoryIds.has(endpointPrompt.server._id)}
+          onSubmit={(endpointUrl) => {
+            void runDirectoryConnect(endpointPrompt.server, endpointUrl);
+          }}
+        />
+      )}
+    </div>
+  );
+}
+
+/**
+ * Keeps every Convex-backed org-registry query and mutation below the section
+ * boundary. A missing function or provider throws during render, so the hook
+ * itself must be a descendant of the ErrorBoundary rather than a sibling.
+ */
+function OrgRegistrySectionContainer({
+  projectId,
+  isAuthenticated,
+  liveServers,
+  onConnect,
+  onDisconnect,
+  onState,
+}: {
+  projectId: string | null;
+  isAuthenticated: boolean;
+  liveServers?: Record<string, ServerWithName>;
+  onConnect: (formData: ServerFormData) => void;
+  onDisconnect?: (serverName: string) => void;
+  onState: (state: { hasContent: boolean; isLoading: boolean }) => void;
+}) {
+  const orgRegistry = useOrgRegistryServers({
+    projectId,
+    isAuthenticated,
+    liveServers,
+    onConnect,
+    onDisconnect,
+  });
+  const [orgDialog, setOrgDialog] = useState<{
+    seed: OrgRegistryDialogSeed | null;
+  } | null>(null);
+  const [orgRemoveTarget, setOrgRemoveTarget] =
+    useState<EnrichedOrgRegistryServer | null>(null);
+  const [orgRemoving, setOrgRemoving] = useState(false);
+
+  useEffect(() => {
+    onState({
+      hasContent:
+        Boolean(orgRegistry.organizationId) &&
+        (orgRegistry.servers.length > 0 || orgRegistry.canAdd),
+      isLoading: orgRegistry.isLoading,
+    });
+  }, [
+    onState,
+    orgRegistry.canAdd,
+    orgRegistry.isLoading,
+    orgRegistry.organizationId,
+    orgRegistry.servers.length,
+  ]);
+
+  const handleOrgSubmit = useCallback(
+    async (submission: OrgRegistrySubmission) => {
+      if (submission.registryServerId) {
+        await orgRegistry.update(submission);
+        toast.success("Registry entry updated");
+        return;
+      }
+      await orgRegistry.add(submission);
+      toast.success("Added to your organization's registry");
+    },
+    [orgRegistry]
+  );
+
+  const handleOrgConnect = useCallback(
+    async (server: EnrichedOrgRegistryServer) => {
+      try {
+        await orgRegistry.connect(server);
+      } catch (error) {
+        const message =
+          error instanceof Error &&
+          /already exists in this workspace/i.test(error.message)
+            ? `A server named "${server.displayName}" already exists in this project. Rename it, or rename the registry entry.`
+            : error instanceof Error
+            ? error.message
+            : "Could not connect this server.";
+        toast.error(message);
+      }
+    },
+    [orgRegistry]
+  );
+
+  const handleOrgDisconnect = useCallback(
+    async (server: EnrichedOrgRegistryServer) => {
+      try {
+        await orgRegistry.disconnect(server);
+      } catch (error) {
+        toast.error(
+          error instanceof Error
+            ? error.message
+            : "Could not disconnect this server."
+        );
+      }
+    },
+    [orgRegistry]
+  );
+
+  const handleOrgRemoveConfirmed = useCallback(async () => {
+    if (!orgRemoveTarget) return;
+    setOrgRemoving(true);
+    try {
+      await orgRegistry.remove(orgRemoveTarget._id);
+      toast.success("Removed from your organization's registry");
+      setOrgRemoveTarget(null);
+    } catch (error) {
+      toast.error(
+        error instanceof Error ? error.message : "Could not remove this entry."
+      );
+    } finally {
+      setOrgRemoving(false);
+    }
+  }, [orgRegistry, orgRemoveTarget]);
+
+  return (
+    <>
+      <OrgRegistrySection
+        registry={orgRegistry}
+        onAdd={() => setOrgDialog({ seed: null })}
+        onEdit={(server) =>
+          setOrgDialog({
+            seed: {
+              registryServerId: server._id,
+              displayName: server.displayName,
+              description: server.description,
+              url: server.transport.url ?? "",
+              useOAuth: server.transport.useOAuth,
+              oauthScopes: server.transport.oauthScopes,
+              derived: server.derived,
+            },
+          })
+        }
+        onRemove={setOrgRemoveTarget}
+        onConnect={handleOrgConnect}
+        onDisconnect={handleOrgDisconnect}
+      />
       {orgRemoveTarget && (
         <OrgRegistryRemoveDialog
           open
@@ -1116,23 +1174,7 @@ export function RegistryTab({
           onSubmit={handleOrgSubmit}
         />
       )}
-      {endpointPrompt && (
-        <DirectoryEndpointDialog
-          open
-          onOpenChange={(open) => {
-            if (!open) setEndpointPrompt(null);
-          }}
-          displayName={endpointPrompt.server.displayName}
-          options={endpointPrompt.options}
-          pattern={endpointPrompt.pattern}
-          error={endpointPrompt.error ?? null}
-          submitting={connectingDirectoryIds.has(endpointPrompt.server._id)}
-          onSubmit={(endpointUrl) => {
-            void runDirectoryConnect(endpointPrompt.server, endpointUrl);
-          }}
-        />
-      )}
-    </div>
+    </>
   );
 }
 

--- a/mcpjam-inspector/client/src/components/ServersTab.tsx
+++ b/mcpjam-inspector/client/src/components/ServersTab.tsx
@@ -1214,8 +1214,13 @@ export function ServersTab({
    * it happens to share.
    */
   const orgRegistry = useOrgRegistryServers({
-    projectId: activeProjectId ?? null,
-    isAuthenticated: true,
+    // The SYNCED project id, not `activeProjectId`. The latter is this app's
+    // own project key, which for an unsynced or local-mode project is not a
+    // Convex document id at all — sending it to a Convex query (or to the
+    // derive route, which forwards it to one) is not a lookup that can
+    // succeed.
+    projectId: sharedProjectIdForHostScope,
+    isAuthenticated,
     onConnect: () => {
       /* promote never connects — the server is already here */
     },
@@ -1226,6 +1231,17 @@ export function ServersTab({
   const handleShareToOrgRegistry = useCallback(
     (server: ServerWithName) => {
       const remote = sharedProjectServersRecord[server.name];
+      // No Convex row means no `sourceServerId`, and the dialog reads that
+      // field to decide it is a PROMOTE at all — without it the user asked to
+      // share the server in front of them and would instead get a blank-slate
+      // add with an unlocked URL and no provenance, so the source project
+      // would never show the entry as connected. Say why instead.
+      if (!remote?._id) {
+        toast.error(
+          `"${server.name}" hasn't finished syncing yet. Try again in a moment.`
+        );
+        return;
+      }
       const info = server.initializationInfo as
         | { serverInfo?: { name?: string; version?: string; title?: string } }
         | undefined;
@@ -1241,7 +1257,7 @@ export function ServersTab({
           serverVersion: info?.serverInfo?.version,
           authRequired: server.useOAuth === true,
         },
-        sourceServerId: remote?._id,
+        sourceServerId: remote._id,
       });
     },
     [sharedProjectServersRecord]
@@ -2243,7 +2259,7 @@ export function ServersTab({
             onOpenChange={(open) => {
               if (!open) setOrgRegistrySeed(null);
             }}
-            projectId={activeProjectId ?? null}
+            projectId={sharedProjectIdForHostScope}
             seed={orgRegistrySeed}
             onSubmit={handleOrgRegistrySubmit}
           />

--- a/mcpjam-inspector/client/src/components/ServersTab.tsx
+++ b/mcpjam-inspector/client/src/components/ServersTab.tsx
@@ -70,6 +70,14 @@ import {
   type EnrichedRegistryServer,
 } from "@/hooks/useRegistryServers";
 import { formatRegistryStarCount } from "@/lib/format-registry-star-count";
+import {
+  useOrgRegistryServers,
+  type OrgRegistrySubmission,
+} from "@/hooks/useOrgRegistryServers";
+import {
+  OrgRegistryServerDialog,
+  type OrgRegistryDialogSeed,
+} from "./registry/OrgRegistryServerDialog";
 import { track } from "@/lib/analytics";
 import { reportCaught } from "@/lib/error-reporting";
 import {
@@ -454,6 +462,7 @@ function SortableServerCard({
   moveTargets,
   onMoveToProject,
   isMovingToProject,
+  onShareToOrgRegistry,
 }: {
   id: string;
   dndDisabled: boolean;
@@ -480,6 +489,7 @@ function SortableServerCard({
     targetProjectId: string
   ) => void | Promise<void>;
   isMovingToProject?: boolean;
+  onShareToOrgRegistry?: (server: ServerWithName) => void;
 }) {
   const { listeners, setNodeRef, transform, transition, isDragging } =
     useSortable({ id, disabled: dndDisabled });
@@ -514,6 +524,7 @@ function SortableServerCard({
       moveTargets={moveTargets}
       onMoveToProject={onMoveToProject}
       isMovingToProject={isMovingToProject}
+      onShareToOrgRegistry={onShareToOrgRegistry}
     />
   );
 
@@ -599,7 +610,9 @@ export function ServersTab({
   isRegistryEnabled = false,
   onNavigateToRegistry,
 }: ServersTabProps) {
-  const hostsConnectAddServerSlot = useContext(HostsConnectAddServerSlotContext);
+  const hostsConnectAddServerSlot = useContext(
+    HostsConnectAddServerSlotContext
+  );
   const viewPhase = useHostsConnectViewPhase();
   const { isAuthenticated } = useConvexAuth();
   const { user: signedInUser } = useAuth();
@@ -1185,6 +1198,63 @@ export function ServersTab({
       isAuthenticated,
     }
   );
+
+  /**
+   * PROMOTE: share a server that is already connected here on the
+   * organization's shelf.
+   *
+   * NO PROBE. The facts are already in this browser — `initializationInfo`
+   * holds what the server said during initialize, which is the same handshake
+   * the paste flow's probe performs. Asking the server again would be slower
+   * and no more true.
+   *
+   * `sourceServerId` is what makes the source project show the new entry as
+   * connected: the mutation writes a provenance row pointing at THIS server,
+   * so the card joins through the record rather than through the display name
+   * it happens to share.
+   */
+  const orgRegistry = useOrgRegistryServers({
+    projectId: activeProjectId ?? null,
+    isAuthenticated: true,
+    onConnect: () => {
+      /* promote never connects — the server is already here */
+    },
+  });
+  const [orgRegistrySeed, setOrgRegistrySeed] =
+    useState<OrgRegistryDialogSeed | null>(null);
+
+  const handleShareToOrgRegistry = useCallback(
+    (server: ServerWithName) => {
+      const remote = sharedProjectServersRecord[server.name];
+      const info = server.initializationInfo as
+        | { serverInfo?: { name?: string; version?: string; title?: string } }
+        | undefined;
+      setOrgRegistrySeed({
+        displayName:
+          info?.serverInfo?.title ?? info?.serverInfo?.name ?? server.name,
+        url: server.config?.url ? String(server.config.url) : "",
+        useOAuth: server.useOAuth,
+        derived: {
+          probedAt: Date.now(),
+          endpointUrl: server.config?.url ? String(server.config.url) : "",
+          serverName: info?.serverInfo?.name,
+          serverVersion: info?.serverInfo?.version,
+          authRequired: server.useOAuth === true,
+        },
+        sourceServerId: remote?._id,
+      });
+    },
+    [sharedProjectServersRecord]
+  );
+
+  const handleOrgRegistrySubmit = useCallback(
+    async (submission: OrgRegistrySubmission) => {
+      await orgRegistry.add(submission);
+      toast.success("Added to your organization's registry");
+    },
+    [orgRegistry]
+  );
+
   const detailModalHostedServerId = detailModalServer
     ? sharedProjectServersRecord[detailModalServer.name]?._id
     : undefined;
@@ -1948,6 +2018,11 @@ export function ServersTab({
                       moveTargets={moveTargets}
                       onMoveToProject={handleMoveServerToProject}
                       isMovingToProject={movingServerName === name}
+                      onShareToOrgRegistry={
+                        orgRegistry.canAdd
+                          ? handleShareToOrgRegistry
+                          : undefined
+                      }
                     />
                   );
                 })}
@@ -2115,112 +2190,127 @@ export function ServersTab({
     // hostDefaultMcpProtocolVersion prop (prop wins; see the modal's
     // resolution comment) — the provider is additive, not a replacement.
     <ActiveMcpProfileProvider value={previewedHost?.config?.mcpProfile}>
-    <div className="h-full flex flex-col">
-      {isAuthHydrating ||
-      isBillingContextPending ||
-      isLoadingProjects ||
-      !areServersHydrated
-        ? renderLoadingContent()
-        : !selectedProject
-        ? shouldQueryProjectId(activeProjectId)
+      <div className="h-full flex flex-col">
+        {isAuthHydrating ||
+        isBillingContextPending ||
+        isLoadingProjects ||
+        !areServersHydrated
           ? renderLoadingContent()
-          : renderNoProjectContent()
-        : hasAnyServers
-        ? renderConnectedContent()
-        : renderEmptyContent()}
+          : !selectedProject
+          ? shouldQueryProjectId(activeProjectId)
+            ? renderLoadingContent()
+            : renderNoProjectContent()
+          : hasAnyServers
+          ? renderConnectedContent()
+          : renderEmptyContent()}
 
-      {/* Add Server Modal */}
-      <AddServerModal
-        isOpen={isAddingServer}
-        initialData={prefilledServerDraft}
-        onClose={() => {
-          setIsAddingServer(false);
-          setPrefilledServerDraft(undefined);
-        }}
-        onSubmit={(formData) => {
-          track("connecting_server", {
-            location: "servers_tab",
-          });
-          // The wire-version pin can't be written until the hosted server
-          // row exists — stash it and let the watcher effect apply it once
-          // the Convex sync surfaces the row, then reconnect with the pin.
-          if (formData.mcpProtocolVersionOverride) {
-            setPendingAddProtocolPin({
-              serverName: formData.name,
-              version: formData.mcpProtocolVersionOverride,
+        {/* Add Server Modal */}
+        <AddServerModal
+          isOpen={isAddingServer}
+          initialData={prefilledServerDraft}
+          onClose={() => {
+            setIsAddingServer(false);
+            setPrefilledServerDraft(undefined);
+          }}
+          onSubmit={(formData) => {
+            track("connecting_server", {
+              location: "servers_tab",
             });
-          }
-          handleConnectServer(formData);
-        }}
-        projectClientConfig={selectedProject?.clientConfig}
-        organizationId={selectedProject?.organizationId ?? null}
-        isSignedIn={Boolean(signedInUser)}
-        projectXaaDefaultIdentity={
-          selectedProject?.xaaTestDefaults?.defaultIdentity ?? null
-        }
-        projectId={sharedProjectIdForHostScope}
-      />
-
-      {/* JSON Import Modal */}
-      <JsonImportModal
-        isOpen={isImportingJson}
-        onClose={() => setIsImportingJson(false)}
-        onImport={handleJsonImport}
-      />
-
-      {/* Add Plugin Modal. Mounted (not conditionally rendered) while the
-          flag is on so an import in flight — or a preview awaiting a
-          decision — survives closing the dialog and resumes on reopen. */}
-      {isPluginsEnabled ? (
-        <AddPluginModal
-          isOpen={isAddingPlugin}
-          onClose={() => setIsAddingPlugin(false)}
-          projectId={sharedProjectIdForHostScope}
-        />
-      ) : null}
-
-      {detailModalServer && (
-        <ServerDetailModal
-          key={detailModalState.sessionKey}
-          isOpen={detailModalState.isOpen}
-          onClose={handleCloseDetailModal}
-          server={detailModalServer}
-          needsReconnect={reconnectWarningByServerName[detailModalServer.name]}
-          defaultTab={detailModalState.defaultTab}
-          onSubmit={handleSubmitDetailModal}
-          onDisconnect={onDisconnect}
-          onReconnect={handleReconnectServer}
-          existingServerNames={Object.keys(projectServers)}
+            // The wire-version pin can't be written until the hosted server
+            // row exists — stash it and let the watcher effect apply it once
+            // the Convex sync surfaces the row, then reconnect with the pin.
+            if (formData.mcpProtocolVersionOverride) {
+              setPendingAddProtocolPin({
+                serverName: formData.name,
+                version: formData.mcpProtocolVersionOverride,
+              });
+            }
+            handleConnectServer(formData);
+          }}
           projectClientConfig={selectedProject?.clientConfig}
-          projectId={hostedProjectId}
-          hostedServerId={detailModalHostedServerId}
           organizationId={selectedProject?.organizationId ?? null}
           isSignedIn={Boolean(signedInUser)}
-          // The tab now mounts under ActiveMcpProfileProvider (see the
-          // root wrapper), which is the source for general host-profile
-          // reads (e.g. the auth section's enterprise-policy guidance).
-          // The protocol chip stays PROP-FIRST: this explicit value wins
-          // over the provider (see the modal's resolution comment), so
-          // its source attribution is unchanged.
-          hostDefaultMcpProtocolVersion={
-            previewedHost?.config?.mcpProfile?.mcpProtocolVersion
-          }
           projectXaaDefaultIdentity={
             selectedProject?.xaaTestDefaults?.defaultIdentity ?? null
           }
+          projectId={sharedProjectIdForHostScope}
         />
-      )}
 
-      {showServerActionsInHostsHeader && hostsConnectAddServerSlot
-        ? createPortal(
-            <>
-              {renderAutoConnectToggle()}
-              {renderServerActionsMenu()}
-            </>,
-            hostsConnectAddServerSlot
-          )
-        : null}
-    </div>
+        {/* Promote a connected server onto the organization's registry. */}
+        {orgRegistrySeed && (
+          <OrgRegistryServerDialog
+            open
+            onOpenChange={(open) => {
+              if (!open) setOrgRegistrySeed(null);
+            }}
+            projectId={activeProjectId ?? null}
+            seed={orgRegistrySeed}
+            onSubmit={handleOrgRegistrySubmit}
+          />
+        )}
+
+        {/* JSON Import Modal */}
+        <JsonImportModal
+          isOpen={isImportingJson}
+          onClose={() => setIsImportingJson(false)}
+          onImport={handleJsonImport}
+        />
+
+        {/* Add Plugin Modal. Mounted (not conditionally rendered) while the
+          flag is on so an import in flight — or a preview awaiting a
+          decision — survives closing the dialog and resumes on reopen. */}
+        {isPluginsEnabled ? (
+          <AddPluginModal
+            isOpen={isAddingPlugin}
+            onClose={() => setIsAddingPlugin(false)}
+            projectId={sharedProjectIdForHostScope}
+          />
+        ) : null}
+
+        {detailModalServer && (
+          <ServerDetailModal
+            key={detailModalState.sessionKey}
+            isOpen={detailModalState.isOpen}
+            onClose={handleCloseDetailModal}
+            server={detailModalServer}
+            needsReconnect={
+              reconnectWarningByServerName[detailModalServer.name]
+            }
+            defaultTab={detailModalState.defaultTab}
+            onSubmit={handleSubmitDetailModal}
+            onDisconnect={onDisconnect}
+            onReconnect={handleReconnectServer}
+            existingServerNames={Object.keys(projectServers)}
+            projectClientConfig={selectedProject?.clientConfig}
+            projectId={hostedProjectId}
+            hostedServerId={detailModalHostedServerId}
+            organizationId={selectedProject?.organizationId ?? null}
+            isSignedIn={Boolean(signedInUser)}
+            // The tab now mounts under ActiveMcpProfileProvider (see the
+            // root wrapper), which is the source for general host-profile
+            // reads (e.g. the auth section's enterprise-policy guidance).
+            // The protocol chip stays PROP-FIRST: this explicit value wins
+            // over the provider (see the modal's resolution comment), so
+            // its source attribution is unchanged.
+            hostDefaultMcpProtocolVersion={
+              previewedHost?.config?.mcpProfile?.mcpProtocolVersion
+            }
+            projectXaaDefaultIdentity={
+              selectedProject?.xaaTestDefaults?.defaultIdentity ?? null
+            }
+          />
+        )}
+
+        {showServerActionsInHostsHeader && hostsConnectAddServerSlot
+          ? createPortal(
+              <>
+                {renderAutoConnectToggle()}
+                {renderServerActionsMenu()}
+              </>,
+              hostsConnectAddServerSlot
+            )
+          : null}
+      </div>
     </ActiveMcpProfileProvider>
   );
 }

--- a/mcpjam-inspector/client/src/components/ServersTab.tsx
+++ b/mcpjam-inspector/client/src/components/ServersTab.tsx
@@ -1220,6 +1220,7 @@ export function ServersTab({
     // derive route, which forwards it to one) is not a lookup that can
     // succeed.
     projectId: sharedProjectIdForHostScope,
+    enabled: isRegistryEnabled,
     isAuthenticated,
     onConnect: () => {
       /* promote never connects — the server is already here */

--- a/mcpjam-inspector/client/src/components/__tests__/RegistryTab.test.tsx
+++ b/mcpjam-inspector/client/src/components/__tests__/RegistryTab.test.tsx
@@ -145,6 +145,47 @@ function createDirectoryServer(
   };
 }
 
+/**
+ * The third Convex-backed hook in this tab, mocked like the other two: this
+ * suite renders `RegistryTab` with no `ConvexProvider`, so a real `useQuery`
+ * throws before the component draws anything.
+ *
+ * The default is a project with NO organization, which is what makes every
+ * other test in this file keep asserting what it already asserted — the org
+ * section renders nothing at all in that state. Tests that care about the
+ * shelf override it.
+ */
+const mockOrgRegistryAdd = vi.fn();
+const mockOrgRegistryConnect = vi.fn();
+let mockOrgRegistryReturn: Record<string, unknown>;
+
+function orgRegistryHookReturn(
+  overrides: Partial<Record<string, unknown>> = {}
+): Record<string, unknown> {
+  return {
+    servers: [],
+    isLoading: false,
+    organizationId: null,
+    canAdd: false,
+    add: mockOrgRegistryAdd,
+    update: vi.fn(),
+    remove: vi.fn(),
+    connect: mockOrgRegistryConnect,
+    disconnect: vi.fn(),
+    ...overrides,
+  };
+}
+
+vi.mock("@/hooks/useOrgRegistryServers", async (importOriginal) => {
+  const actual = await importOriginal<
+    typeof import("@/hooks/useOrgRegistryServers")
+  >();
+  return {
+    ...actual,
+    useOrgRegistryServers: () => mockOrgRegistryReturn,
+  };
+});
+
 // Mock dropdown menu to simplify testing
 vi.mock("@mcpjam/design-system/dropdown-menu", () => ({
   DropdownMenu: ({ children }: { children: React.ReactNode }) => (
@@ -214,6 +255,7 @@ describe("RegistryTab", () => {
       serverName: "Linear",
     });
     mockDirectoryReturn = directoryHookReturn();
+    mockOrgRegistryReturn = orgRegistryHookReturn();
     mockDirectoryDetail = null;
     mockHookReturn = {
       catalogCards: [],
@@ -261,6 +303,87 @@ describe("RegistryTab", () => {
       expect(
         screen.getByText("Pre-configured MCP servers you can connect quickly.")
       ).toBeInTheDocument();
+    });
+  });
+
+  describe("organization shelf", () => {
+    const orgEntry = {
+      _id: "reg_1",
+      name: "org/org_1/internal-docs",
+      displayName: "Internal Docs",
+      description: "What the team uses.",
+      scope: "organization" as const,
+      status: "approved" as const,
+      transport: {
+        transportType: "http" as const,
+        url: "https://mcp.example.com/mcp",
+        useOAuth: true,
+      },
+      createdBy: "user_1",
+      createdAt: 1,
+      updatedAt: 1,
+      connectionStatus: "not_connected" as const,
+      connectedServerName: null,
+      derived: {
+        probedAt: 1,
+        endpointUrl: "https://mcp.example.com/mcp",
+        serverVersion: "1.4.2",
+        authRequired: true,
+        supportsDcr: true,
+      },
+      editedFields: [],
+    };
+
+    it("renders nothing at all for a project with no organization", () => {
+      render(<RegistryTab {...defaultProps} />);
+
+      expect(screen.queryByText("Your organization")).not.toBeInTheDocument();
+    });
+
+    it("renders the org's entries with their derived version, and no star control", () => {
+      mockOrgRegistryReturn = orgRegistryHookReturn({
+        organizationId: "org_1",
+        canAdd: true,
+        servers: [orgEntry],
+      });
+
+      render(<RegistryTab {...defaultProps} />);
+
+      expect(screen.getByText("Your organization")).toBeInTheDocument();
+      expect(screen.getByText("Internal Docs")).toBeInTheDocument();
+      // Version comes off the probe snapshot, not off anything typed.
+      expect(screen.getByText("v1.4.2")).toBeInTheDocument();
+      // An org row has no `registryCardKey`, so it can never carry a star.
+      expect(
+        screen.queryByRole("button", { name: /star this server/i })
+      ).not.toBeInTheDocument();
+    });
+
+    it("invites a member with an empty shelf to add one", () => {
+      mockOrgRegistryReturn = orgRegistryHookReturn({
+        organizationId: "org_1",
+        canAdd: true,
+        servers: [],
+      });
+
+      render(<RegistryTab {...defaultProps} />);
+
+      expect(screen.getByText("Nothing shared yet")).toBeInTheDocument();
+      expect(
+        screen.getByRole("button", { name: "Add a server" })
+      ).toBeInTheDocument();
+    });
+
+    it("hides the shelf from a member who cannot add and has nothing to see", () => {
+      mockOrgRegistryReturn = orgRegistryHookReturn({
+        organizationId: "org_1",
+        canAdd: false,
+        servers: [],
+      });
+
+      render(<RegistryTab {...defaultProps} />);
+
+      expect(screen.queryByText("Your organization")).not.toBeInTheDocument();
     });
   });
 

--- a/mcpjam-inspector/client/src/components/connection/ServerConnectionCard.tsx
+++ b/mcpjam-inspector/client/src/components/connection/ServerConnectionCard.tsx
@@ -39,6 +39,7 @@ import {
   AlertCircle,
   FileText,
   FolderInput,
+  Building2,
 } from "lucide-react";
 import { ServerWithName } from "@/hooks/use-app-state";
 import { exportServerApi } from "@/lib/apis/mcp-export-api";
@@ -130,6 +131,13 @@ interface ServerConnectionCardProps {
   ) => void | Promise<void>;
   /** True while a move for this server is in flight. */
   isMovingToProject?: boolean;
+  /**
+   * Share this server on the organization's registry shelf. Injected the same
+   * way `onMoveToProject` is — the card knows the server, the parent owns the
+   * dialog and the mutation. When omitted (no organization, guest role, or a
+   * surface with no registry) the item is not rendered at all.
+   */
+  onShareToOrgRegistry?: (server: ServerWithName) => void;
 }
 
 export function ServerConnectionCard({
@@ -145,6 +153,7 @@ export function ServerConnectionCard({
   moveTargets,
   onMoveToProject,
   isMovingToProject = false,
+  onShareToOrgRegistry,
 }: ServerConnectionCardProps) {
   useExploreCasesPrefetchOnConnect(projectId ?? null, server, hostedServerId);
 
@@ -157,7 +166,7 @@ export function ServerConnectionCard({
   const [previewedHostId] = usePreviewedHostId(projectId ?? null);
   const isProtocolPinFailure = isProtocolVersionPinFailure(
     server.lastNormalizedError,
-    server.lastError,
+    server.lastError
   );
   const protocolPinAction = isProtocolPinFailure
     ? {
@@ -820,6 +829,38 @@ export function ServerConnectionCard({
                           ))}
                         </DropdownMenuSubContent>
                       </DropdownMenuSub>
+                    ) : null}
+                    {/*
+                      Remote HTTP only. An org entry carries an ADDRESS, and a
+                      stdio server's address is a command on one machine —
+                      there is nothing to share.
+                    */}
+                    {onShareToOrgRegistry && server.config?.url ? (
+                      <DropdownMenuItem
+                        className="text-xs cursor-pointer"
+                        onClick={() => {
+                          track("share_server_to_org_registry_clicked", {
+                            location: "server_connection_card",
+                          });
+                          // Shown-then-refused rather than hidden. "Where did
+                          // the option go?" is a worse answer than a sentence
+                          // saying why, and the why is worth knowing: an org
+                          // entry deliberately carries no secret, and the
+                          // browser never holds these header values anyway —
+                          // a shared entry built from them would be broken as
+                          // well as unsafe.
+                          if (server.hasHeaders || server.hasBearerToken) {
+                            toast.error(
+                              "This server uses credentials that can't be shared. Organization entries carry only the address and how to sign in."
+                            );
+                            return;
+                          }
+                          onShareToOrgRegistry(server);
+                        }}
+                      >
+                        <Building2 className="h-3 w-3 mr-2" />
+                        Add to org registry
+                      </DropdownMenuItem>
                     ) : null}
                     <Separator />
                     <DropdownMenuItem

--- a/mcpjam-inspector/client/src/components/connection/__tests__/ServerConnectionCard.test.tsx
+++ b/mcpjam-inspector/client/src/components/connection/__tests__/ServerConnectionCard.test.tsx
@@ -203,7 +203,7 @@ describe("ServerConnectionCard", () => {
         expect(onShareToOrgRegistry).toHaveBeenCalledWith(server);
       });
 
-      it("hides the action for a stdio server — there is no address to share", () => {
+      it("hides the action for a stdio server — there is no address to share", async () => {
         render(
           <ServerConnectionCard
             server={createServer()}
@@ -219,6 +219,11 @@ describe("ServerConnectionCard", () => {
           { button: 0, ctrlKey: false }
         );
 
+        // The menu mounts asynchronously, so wait for an item that ALWAYS
+        // renders first. A synchronous `queryByText` here returns null before
+        // the menu exists at all and would pass whether or not the action
+        // eventually appeared — proving nothing.
+        await screen.findByText("Configure");
         expect(screen.queryByText("Add to org registry")).toBeNull();
       });
 
@@ -256,7 +261,7 @@ describe("ServerConnectionCard", () => {
         }
       );
 
-      it("hides the action entirely when the caller cannot add", () => {
+      it("hides the action entirely when the caller cannot add", async () => {
         render(
           <ServerConnectionCard server={remoteServer()} {...defaultProps} />
         );
@@ -268,6 +273,7 @@ describe("ServerConnectionCard", () => {
           { button: 0, ctrlKey: false }
         );
 
+        await screen.findByText("Configure");
         expect(screen.queryByText("Add to org registry")).toBeNull();
       });
     });

--- a/mcpjam-inspector/client/src/components/connection/__tests__/ServerConnectionCard.test.tsx
+++ b/mcpjam-inspector/client/src/components/connection/__tests__/ServerConnectionCard.test.tsx
@@ -164,6 +164,114 @@ describe("ServerConnectionCard", () => {
       expect(onMoveToProject).toHaveBeenCalledWith("test-server", "project-2");
     });
 
+    /**
+     * "Add to org registry" is the promote door. Its eligibility rules are
+     * the interesting part: an org entry carries an ADDRESS and an auth
+     * posture and nothing else, so a stdio server has nothing to share and a
+     * header-authed one has something that cannot be shared.
+     */
+    describe("add to org registry", () => {
+      const remoteServer = () =>
+        createServer({
+          name: "remote-server",
+          config: { url: "https://mcp.example.com/mcp" },
+        });
+
+      const openMenu = async (name: string) => {
+        fireEvent.pointerDown(
+          screen.getByRole("button", {
+            name: `Open actions menu for ${name}`,
+          }),
+          { button: 0, ctrlKey: false }
+        );
+        return await screen.findByText("Add to org registry");
+      };
+
+      it("offers a remote HTTP server to the organization", async () => {
+        const onShareToOrgRegistry = vi.fn();
+        const server = remoteServer();
+        render(
+          <ServerConnectionCard
+            server={server}
+            {...defaultProps}
+            onShareToOrgRegistry={onShareToOrgRegistry}
+          />
+        );
+
+        fireEvent.click(await openMenu("remote-server"));
+
+        expect(onShareToOrgRegistry).toHaveBeenCalledWith(server);
+      });
+
+      it("hides the action for a stdio server — there is no address to share", () => {
+        render(
+          <ServerConnectionCard
+            server={createServer()}
+            {...defaultProps}
+            onShareToOrgRegistry={vi.fn()}
+          />
+        );
+
+        fireEvent.pointerDown(
+          screen.getByRole("button", {
+            name: "Open actions menu for test-server",
+          }),
+          { button: 0, ctrlKey: false }
+        );
+
+        expect(screen.queryByText("Add to org registry")).toBeNull();
+      });
+
+      it.each([
+        ["custom headers", { hasHeaders: true }],
+        ["a bearer token", { hasBearerToken: true }],
+      ])(
+        "refuses a server authed with %s, and says why",
+        async (_label, credentialFlags) => {
+          const onShareToOrgRegistry = vi.fn();
+          render(
+            <ServerConnectionCard
+              server={createServer({
+                name: "remote-server",
+                config: { url: "https://mcp.example.com/mcp" },
+                ...credentialFlags,
+              })}
+              {...defaultProps}
+              onShareToOrgRegistry={onShareToOrgRegistry}
+            />
+          );
+
+          fireEvent.click(await openMenu("remote-server"));
+
+          // Shown then refused, rather than hidden: "where did the option go?"
+          // is a worse answer than a sentence saying why.
+          expect(onShareToOrgRegistry).not.toHaveBeenCalled();
+          // The app's toast wrapper renders the message inside a copyable
+          // element, so the assertion reads the element's text rather than
+          // the first argument.
+          const [rendered] = vi.mocked(toast.error).mock.calls[0] as [
+            { props?: { text?: string } }
+          ];
+          expect(rendered?.props?.text).toContain("can't be shared");
+        }
+      );
+
+      it("hides the action entirely when the caller cannot add", () => {
+        render(
+          <ServerConnectionCard server={remoteServer()} {...defaultProps} />
+        );
+
+        fireEvent.pointerDown(
+          screen.getByRole("button", {
+            name: "Open actions menu for remote-server",
+          }),
+          { button: 0, ctrlKey: false }
+        );
+
+        expect(screen.queryByText("Add to org registry")).toBeNull();
+      });
+    });
+
     it("hides the move action when there are no target projects", () => {
       render(
         <ServerConnectionCard
@@ -253,7 +361,7 @@ describe("ServerConnectionCard", () => {
 
       expect(screen.getByText("Authorizing in browser...")).toBeInTheDocument();
       expect(
-        screen.queryByText(/Complete sign-in in the browser/),
+        screen.queryByText(/Complete sign-in in the browser/)
       ).not.toBeInTheDocument();
     });
 
@@ -1076,7 +1184,7 @@ describe("ServerConnectionCard", () => {
 describe("ServerConnectionCard — protocol version pin", () => {
   const failedServer = (
     slug: string,
-    message = "MCP server \"acme\" doesn't support MCP protocol version 2026-07-28, which this client is pinned to.",
+    message = 'MCP server "acme" doesn\'t support MCP protocol version 2026-07-28, which this client is pinned to.'
   ): ServerWithName => ({
     name: "acme",
     lastConnectionTime: new Date(),
@@ -1114,11 +1222,11 @@ describe("ServerConnectionCard — protocol version pin", () => {
         server={failedServer("sdk/protocol_version_pin_unsupported")}
         projectId="proj_1"
         {...props}
-      />,
+      />
     );
 
     expect(
-      screen.getByRole("button", { name: /change protocol version/i }),
+      screen.getByRole("button", { name: /change protocol version/i })
     ).toBeInTheDocument();
   });
 
@@ -1129,15 +1237,15 @@ describe("ServerConnectionCard — protocol version pin", () => {
       <ServerConnectionCard
         server={failedServer(
           "transport/econnrefused",
-          "connect ECONNREFUSED 127.0.0.1:8080",
+          "connect ECONNREFUSED 127.0.0.1:8080"
         )}
         projectId="proj_1"
         {...props}
-      />,
+      />
     );
 
     expect(
-      screen.queryByRole("button", { name: /change protocol version/i }),
+      screen.queryByRole("button", { name: /change protocol version/i })
     ).not.toBeInTheDocument();
   });
 
@@ -1151,11 +1259,11 @@ describe("ServerConnectionCard — protocol version pin", () => {
         server={failedServer("transport/fetch_failed")}
         projectId="proj_1"
         {...props}
-      />,
+      />
     );
 
     expect(
-      screen.getByRole("button", { name: /change protocol version/i }),
+      screen.getByRole("button", { name: /change protocol version/i })
     ).toBeInTheDocument();
   });
 });

--- a/mcpjam-inspector/client/src/components/registry/OrgRegistryRemoveDialog.tsx
+++ b/mcpjam-inspector/client/src/components/registry/OrgRegistryRemoveDialog.tsx
@@ -1,0 +1,70 @@
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@mcpjam/design-system/dialog";
+import { Button } from "@mcpjam/design-system/button";
+import { Loader2 } from "lucide-react";
+
+/**
+ * Confirm taking an entry off the organization's shelf.
+ *
+ * It exists because the blast radius is not the acting project: the entry is
+ * visible to every project in the organization, so a mis-click withdraws a
+ * server from colleagues who never opened this menu.
+ *
+ * Deliberately a plain confirm rather than the type-the-word dialog the
+ * swarm delete uses. That weight is calibrated to destroying data; this
+ * destroys none — the connected servers keep running and their provenance
+ * rows survive, so the worst case is re-adding an entry. Asking someone to
+ * type "delete" for that trains them to type it without reading.
+ */
+export function OrgRegistryRemoveDialog({
+  open,
+  onOpenChange,
+  displayName,
+  isRemoving,
+  onConfirm,
+}: {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  displayName: string;
+  isRemoving: boolean;
+  onConfirm: () => void;
+}) {
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="sm:max-w-md">
+        <DialogHeader>
+          <DialogTitle>Remove “{displayName}”?</DialogTitle>
+          <DialogDescription>
+            It disappears from the registry for everyone in your organization.
+            Anyone who already connected it keeps their server — this only takes
+            the entry off the shelf.
+          </DialogDescription>
+        </DialogHeader>
+        <DialogFooter>
+          <Button
+            type="button"
+            variant="ghost"
+            onClick={() => onOpenChange(false)}
+          >
+            Cancel
+          </Button>
+          <Button
+            type="button"
+            variant="destructive"
+            disabled={isRemoving}
+            onClick={onConfirm}
+          >
+            {isRemoving && <Loader2 className="h-3.5 w-3.5 animate-spin" />}
+            Remove
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/mcpjam-inspector/client/src/components/registry/OrgRegistryServerDialog.tsx
+++ b/mcpjam-inspector/client/src/components/registry/OrgRegistryServerDialog.tsx
@@ -1,0 +1,353 @@
+import { useEffect, useMemo, useState } from "react";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@mcpjam/design-system/dialog";
+import { Button } from "@mcpjam/design-system/button";
+import { Input } from "@mcpjam/design-system/input";
+import { Label } from "@mcpjam/design-system/label";
+import { Textarea } from "@mcpjam/design-system/textarea";
+import { Badge } from "@mcpjam/design-system/badge";
+import { Loader2, ShieldCheck, Unlock } from "lucide-react";
+import {
+  deriveOrgRegistryServer,
+  snapshotFromDerivedFacts,
+  type DerivedServerFacts,
+  type OrgRegistryDerivedSnapshot,
+} from "@/lib/apis/web/org-registry-api";
+import { WebApiError } from "@/lib/apis/web/base";
+
+/**
+ * Add or edit an entry on the organization's registry shelf.
+ *
+ * TWO STEPS, AND THE FIRST ONE IS THE POINT. Paste an address; the Inspector
+ * probes it and fills the form in from what the server actually said. Version
+ * and auth posture are then READ-ONLY — they are facts about the server, and a
+ * field a person can type into is a field that will eventually disagree with
+ * the thing it describes.
+ *
+ * Three ways in, one form:
+ *
+ *   paste   — step "url", then "confirm" once the probe answers.
+ *   promote — opens straight at "confirm" with facts read off the connected
+ *             server's `initializationInfo`. No probe: the browser is already
+ *             talking to it, so asking the server again would be slower and no
+ *             more true.
+ *   edit    — opens at "confirm" with the stored row. Re-probing an existing
+ *             entry is deliberately NOT here; it is a separate action so a
+ *             refresh can never be something a person did by accident while
+ *             fixing a typo.
+ *
+ * A REFUSAL IS NOT AN ERROR TO RETRY. The route answers a blocked address with
+ * one generic sentence and a 400, and this dialog shows exactly that sentence
+ * and leaves the URL where it is. Anything more helpful would be helping the
+ * wrong person.
+ */
+
+export interface OrgRegistryDialogSeed {
+  /** Present when editing an existing row. */
+  registryServerId?: string;
+  displayName: string;
+  description?: string;
+  url: string;
+  useOAuth?: boolean;
+  oauthScopes?: string[];
+  derived?: OrgRegistryDerivedSnapshot;
+  /** Set by PROMOTE: the `servers` row this entry came from. */
+  sourceServerId?: string;
+}
+
+export interface OrgRegistryDialogSubmission {
+  registryServerId?: string;
+  displayName: string;
+  description?: string;
+  url: string;
+  useOAuth?: boolean;
+  oauthScopes?: string[];
+  derived: OrgRegistryDerivedSnapshot;
+  sourceServerId?: string;
+}
+
+export interface OrgRegistryServerDialogProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  projectId: string | null;
+  /**
+   * Absent ⇒ the paste flow starts at the URL step. Present ⇒ promote or
+   * edit, opening at the confirm step with these values.
+   */
+  seed?: OrgRegistryDialogSeed | null;
+  /** Rejecting with an Error puts its message inline; the dialog stays open. */
+  onSubmit: (submission: OrgRegistryDialogSubmission) => Promise<void>;
+}
+
+type Step = "url" | "confirm";
+
+function messageFor(error: unknown): string {
+  if (error instanceof WebApiError) return error.message;
+  if (error instanceof Error && error.message) return error.message;
+  return "Something went wrong.";
+}
+
+export function OrgRegistryServerDialog({
+  open,
+  onOpenChange,
+  projectId,
+  seed,
+  onSubmit,
+}: OrgRegistryServerDialogProps) {
+  const isEdit = Boolean(seed?.registryServerId);
+  /**
+   * On PROMOTE the URL is not editable, and that is enforcement showing
+   * through rather than a style choice: `addOrgRegistryServer` refuses a
+   * promotion whose URL does not match the source server's own
+   * ("The promoted server URL no longer matches the entry URL"). An editable
+   * field here would be a field whose every edit is a dead end. Someone who
+   * wants a different address wants the paste flow, which the copy says.
+   */
+  const isPromote = Boolean(seed?.sourceServerId) && !seed?.registryServerId;
+  const [step, setStep] = useState<Step>(seed ? "confirm" : "url");
+  const [url, setUrl] = useState(seed?.url ?? "");
+  const [displayName, setDisplayName] = useState(seed?.displayName ?? "");
+  const [description, setDescription] = useState(seed?.description ?? "");
+  const [derived, setDerived] = useState<OrgRegistryDerivedSnapshot | null>(
+    seed?.derived ?? null
+  );
+  const [probing, setProbing] = useState(false);
+  const [saving, setSaving] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  // Re-seed on OPEN rather than on every seed change: a parent that rebuilds
+  // the seed object each render would otherwise wipe what someone is typing.
+  useEffect(() => {
+    if (!open) return;
+    setStep(seed ? "confirm" : "url");
+    setUrl(seed?.url ?? "");
+    setDisplayName(seed?.displayName ?? "");
+    setDescription(seed?.description ?? "");
+    setDerived(seed?.derived ?? null);
+    setError(null);
+    setProbing(false);
+    setSaving(false);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [open]);
+
+  const authRequired = derived?.authRequired ?? seed?.useOAuth ?? false;
+  const canRegisterDynamically =
+    (derived?.supportsDcr ?? false) || (derived?.supportsCimd ?? false);
+  /**
+   * Mirrors the directory badge's rule (`requiresPreregisteredClient`): only
+   * a server that demands auth AND resolved no way to register a client on
+   * the fly needs one handed to it in advance. A row with no probe verdict
+   * says nothing rather than accusing the server of something.
+   */
+  const requiresPreregisteredClient =
+    authRequired && derived !== null && !canRegisterDynamically;
+
+  const canProbe = url.trim().length > 0 && !probing && Boolean(projectId);
+  const canSave =
+    displayName.trim().length > 0 && url.trim().length > 0 && !saving;
+
+  async function handleProbe() {
+    if (!projectId) return;
+    setProbing(true);
+    setError(null);
+    try {
+      const facts: DerivedServerFacts = await deriveOrgRegistryServer({
+        url: url.trim(),
+        projectId,
+      });
+      const snapshot = snapshotFromDerivedFacts(facts);
+      setDerived(snapshot);
+      // The server's own title is the better label when it published one; its
+      // `name` is usually a package id ("example-mcp"), which is a worse thing
+      // to put on a card than the address the person just typed.
+      setDisplayName(facts.title ?? facts.serverName ?? displayName);
+      setUrl(facts.endpointUrl);
+      setStep("confirm");
+    } catch (probeError) {
+      setError(messageFor(probeError));
+    } finally {
+      setProbing(false);
+    }
+  }
+
+  async function handleSave() {
+    setSaving(true);
+    setError(null);
+    try {
+      await onSubmit({
+        registryServerId: seed?.registryServerId,
+        displayName: displayName.trim(),
+        description: description.trim() || undefined,
+        url: url.trim(),
+        // `authRequired` is what the server said; `useOAuth` is what we will
+        // do about it. They are the same decision here, and keeping the
+        // stored value derived from the probe is what makes a later re-probe
+        // able to correct it.
+        useOAuth: authRequired,
+        oauthScopes: seed?.oauthScopes,
+        derived: derived ?? {
+          probedAt: Date.now(),
+          endpointUrl: url.trim(),
+          authRequired,
+        },
+        sourceServerId: seed?.sourceServerId,
+      });
+      onOpenChange(false);
+    } catch (saveError) {
+      setError(messageFor(saveError));
+    } finally {
+      setSaving(false);
+    }
+  }
+
+  const title = isEdit
+    ? "Edit registry entry"
+    : seed?.sourceServerId
+    ? "Add to organization registry"
+    : "Add a server to your organization";
+
+  const versionLabel = useMemo(
+    () => derived?.serverVersion ?? null,
+    [derived?.serverVersion]
+  );
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="sm:max-w-lg">
+        <DialogHeader>
+          <DialogTitle>{title}</DialogTitle>
+          <DialogDescription>
+            {step === "url"
+              ? "Paste the server's address. We'll read its name, version and sign-in requirements straight off it."
+              : "Everyone in your organization will see this entry and can connect it from their own projects."}
+          </DialogDescription>
+        </DialogHeader>
+
+        {step === "url" ? (
+          <div className="space-y-3">
+            <div className="space-y-1.5">
+              <Label htmlFor="org-registry-url">Server URL</Label>
+              <Input
+                id="org-registry-url"
+                value={url}
+                placeholder="https://mcp.example.com/mcp"
+                autoFocus
+                onChange={(event) => setUrl(event.target.value)}
+                onKeyDown={(event) => {
+                  if (event.key === "Enter" && canProbe) void handleProbe();
+                }}
+              />
+              <p className="text-xs text-muted-foreground">
+                Remote HTTP servers only. Organization entries carry the address
+                and the sign-in method — never a shared secret.
+              </p>
+            </div>
+          </div>
+        ) : (
+          <div className="space-y-3">
+            <div className="space-y-1.5">
+              <Label htmlFor="org-registry-name">Name</Label>
+              <Input
+                id="org-registry-name"
+                value={displayName}
+                autoFocus
+                onChange={(event) => setDisplayName(event.target.value)}
+              />
+            </div>
+            <div className="space-y-1.5">
+              <Label htmlFor="org-registry-description">
+                Description{" "}
+                <span className="text-muted-foreground">(optional)</span>
+              </Label>
+              <Textarea
+                id="org-registry-description"
+                value={description}
+                rows={2}
+                placeholder="What your team uses this server for."
+                onChange={(event) => setDescription(event.target.value)}
+              />
+            </div>
+            <div className="space-y-1.5">
+              <Label htmlFor="org-registry-confirm-url">Server URL</Label>
+              <Input
+                id="org-registry-confirm-url"
+                value={url}
+                readOnly={isPromote}
+                aria-readonly={isPromote}
+                className={isPromote ? "text-muted-foreground" : undefined}
+                onChange={(event) => setUrl(event.target.value)}
+              />
+              {isPromote && (
+                <p className="text-xs text-muted-foreground">
+                  Taken from the connected server. Point the org at a different
+                  address by adding it with a link instead.
+                </p>
+              )}
+            </div>
+
+            {/* Read-only: facts about the server, not fields about the entry. */}
+            <div className="flex flex-wrap items-center gap-1.5">
+              {versionLabel && (
+                <Badge variant="secondary" className="text-[10px]">
+                  v{versionLabel}
+                </Badge>
+              )}
+              <Badge variant="secondary" className="text-[10px] gap-1">
+                {authRequired ? (
+                  <>
+                    <ShieldCheck className="h-3 w-3" /> Requires sign-in
+                  </>
+                ) : (
+                  <>
+                    <Unlock className="h-3 w-3" /> Open
+                  </>
+                )}
+              </Badge>
+              {requiresPreregisteredClient && (
+                <Badge variant="outline" className="text-[10px]">
+                  Requires pre-registered client
+                </Badge>
+              )}
+            </div>
+          </div>
+        )}
+
+        {error && (
+          <p
+            role="alert"
+            className="text-xs text-destructive whitespace-pre-wrap"
+          >
+            {error}
+          </p>
+        )}
+
+        <DialogFooter>
+          <Button
+            type="button"
+            variant="ghost"
+            onClick={() => onOpenChange(false)}
+          >
+            Cancel
+          </Button>
+          {step === "url" ? (
+            <Button type="button" disabled={!canProbe} onClick={handleProbe}>
+              {probing && <Loader2 className="h-3.5 w-3.5 animate-spin" />}
+              {probing ? "Checking server…" : "Continue"}
+            </Button>
+          ) : (
+            <Button type="button" disabled={!canSave} onClick={handleSave}>
+              {saving && <Loader2 className="h-3.5 w-3.5 animate-spin" />}
+              {isEdit ? "Save changes" : "Add to registry"}
+            </Button>
+          )}
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/mcpjam-inspector/client/src/components/registry/OrgRegistryServerDialog.tsx
+++ b/mcpjam-inspector/client/src/components/registry/OrgRegistryServerDialog.tsx
@@ -37,10 +37,9 @@ import { WebApiError } from "@/lib/apis/web/base";
  *             server's `initializationInfo`. No probe: the browser is already
  *             talking to it, so asking the server again would be slower and no
  *             more true.
- *   edit    — opens at "confirm" with the stored row. Re-probing an existing
- *             entry is deliberately NOT here; it is a separate action so a
- *             refresh can never be something a person did by accident while
- *             fixing a typo.
+ *   edit    — opens at "confirm" with the stored row. If its URL changes,
+ *             saving re-probes before persisting so the facts stay paired with
+ *             the address they describe.
  *
  * A REFUSAL IS NOT AN ERROR TO RETRY. The route answers a blocked address with
  * one generic sentence and a 400, and this dialog shows exactly that sentence
@@ -69,7 +68,7 @@ export interface OrgRegistryDialogSubmission {
   useOAuth?: boolean;
   oauthScopes?: string[];
   /** Absent when no probe has run — see the note at the submit site. */
-  derived: OrgRegistryDerivedSnapshot | null;
+  derived?: OrgRegistryDerivedSnapshot;
   sourceServerId?: string;
 }
 
@@ -151,7 +150,10 @@ export function OrgRegistryServerDialog({
 
   const canProbe = url.trim().length > 0 && !probing && Boolean(projectId);
   const canSave =
-    displayName.trim().length > 0 && url.trim().length > 0 && !saving;
+    displayName.trim().length > 0 &&
+    url.trim().length > 0 &&
+    (isEdit || derived !== null) &&
+    !saving;
 
   async function handleProbe() {
     if (!projectId) return;
@@ -178,19 +180,43 @@ export function OrgRegistryServerDialog({
   }
 
   async function handleSave() {
+    if (!isEdit && !derived) {
+      setError("Check the server before adding it to the registry.");
+      return;
+    }
     setSaving(true);
     setError(null);
+    let submissionDerived = derived;
+    let submissionUrl = url.trim();
+    let submissionAuthRequired = authRequired;
     try {
+      // A URL edit changes what the read-only facts describe. Re-probe before
+      // saving so the stored snapshot cannot silently belong to the old URL.
+      if (isEdit && submissionUrl !== seed?.url.trim()) {
+        if (!projectId) {
+          throw new Error("Select a project before changing the server URL.");
+        }
+        setProbing(true);
+        const facts = await deriveOrgRegistryServer({
+          url: submissionUrl,
+          projectId,
+        });
+        submissionDerived = snapshotFromDerivedFacts(facts);
+        submissionUrl = facts.endpointUrl;
+        submissionAuthRequired = submissionDerived.authRequired ?? false;
+        setDerived(submissionDerived);
+        setUrl(submissionUrl);
+      }
       await onSubmit({
         registryServerId: seed?.registryServerId,
         displayName: displayName.trim(),
         description: description.trim() || undefined,
-        url: url.trim(),
+        url: submissionUrl,
         // `authRequired` is what the server said; `useOAuth` is what we will
         // do about it. They are the same decision here, and keeping the
         // stored value derived from the probe is what makes a later re-probe
         // able to correct it.
-        useOAuth: authRequired,
+        useOAuth: submissionAuthRequired,
         oauthScopes: seed?.oauthScopes,
         // NEVER synthesize a snapshot. Readers treat the presence of
         // `derived` as proof a probe returned a verdict — the card asserts
@@ -199,13 +225,14 @@ export function OrgRegistryServerDialog({
         // entry accuse its server of something nothing established. The paste
         // flow always probes and promote always seeds, so this is guarding
         // the field's meaning rather than a live path.
-        derived,
+        derived: submissionDerived ?? undefined,
         sourceServerId: seed?.sourceServerId,
       });
       onOpenChange(false);
     } catch (saveError) {
       setError(messageFor(saveError));
     } finally {
+      setProbing(false);
       setSaving(false);
     }
   }
@@ -239,6 +266,9 @@ export function OrgRegistryServerDialog({
               <Label htmlFor="org-registry-url">Server URL</Label>
               <Input
                 id="org-registry-url"
+                name="url"
+                type="url"
+                autoComplete="url"
                 value={url}
                 placeholder="https://mcp.example.com/mcp"
                 autoFocus
@@ -259,6 +289,7 @@ export function OrgRegistryServerDialog({
               <Label htmlFor="org-registry-name">Name</Label>
               <Input
                 id="org-registry-name"
+                name="displayName"
                 value={displayName}
                 autoFocus
                 onChange={(event) => setDisplayName(event.target.value)}
@@ -271,6 +302,7 @@ export function OrgRegistryServerDialog({
               </Label>
               <Textarea
                 id="org-registry-description"
+                name="description"
                 value={description}
                 rows={2}
                 placeholder="What your team uses this server for."
@@ -281,6 +313,9 @@ export function OrgRegistryServerDialog({
               <Label htmlFor="org-registry-confirm-url">Server URL</Label>
               <Input
                 id="org-registry-confirm-url"
+                name="url"
+                type="url"
+                autoComplete="url"
                 value={url}
                 readOnly={isPromote}
                 aria-readonly={isPromote}

--- a/mcpjam-inspector/client/src/components/registry/OrgRegistryServerDialog.tsx
+++ b/mcpjam-inspector/client/src/components/registry/OrgRegistryServerDialog.tsx
@@ -68,7 +68,8 @@ export interface OrgRegistryDialogSubmission {
   url: string;
   useOAuth?: boolean;
   oauthScopes?: string[];
-  derived: OrgRegistryDerivedSnapshot;
+  /** Absent when no probe has run — see the note at the submit site. */
+  derived: OrgRegistryDerivedSnapshot | null;
   sourceServerId?: string;
 }
 
@@ -191,11 +192,14 @@ export function OrgRegistryServerDialog({
         // able to correct it.
         useOAuth: authRequired,
         oauthScopes: seed?.oauthScopes,
-        derived: derived ?? {
-          probedAt: Date.now(),
-          endpointUrl: url.trim(),
-          authRequired,
-        },
+        // NEVER synthesize a snapshot. Readers treat the presence of
+        // `derived` as proof a probe returned a verdict — the card asserts
+        // "Requires pre-registered client" whenever it exists and names no
+        // registration strategy — so a minted one would make an unprobed
+        // entry accuse its server of something nothing established. The paste
+        // flow always probes and promote always seeds, so this is guarding
+        // the field's meaning rather than a live path.
+        derived,
         sourceServerId: seed?.sourceServerId,
       });
       onOpenChange(false);

--- a/mcpjam-inspector/client/src/components/registry/__tests__/OrgRegistryServerDialog.test.tsx
+++ b/mcpjam-inspector/client/src/components/registry/__tests__/OrgRegistryServerDialog.test.tsx
@@ -195,6 +195,37 @@ describe("OrgRegistryServerDialog — promote and edit", () => {
     expect(screen.getByLabelText("Server URL")).not.toHaveAttribute("readonly");
   });
 
+  it("re-probes when an edited URL changes the facts being saved", async () => {
+    const user = userEvent.setup();
+    const { onSubmit } = renderDialog({
+      seed: {
+        registryServerId: "reg_1",
+        displayName: "Internal Docs",
+        url: "https://old.example/mcp",
+        derived: {
+          probedAt: 1,
+          endpointUrl: "https://old.example/mcp",
+          serverVersion: "1.0.0",
+        },
+      },
+    });
+
+    const urlInput = screen.getByLabelText("Server URL");
+    await user.clear(urlInput);
+    await user.type(urlInput, "https://new.example/mcp");
+    await user.click(screen.getByRole("button", { name: "Save changes" }));
+
+    await waitFor(() => expect(onSubmit).toHaveBeenCalled());
+    expect(deriveOrgRegistryServer).toHaveBeenCalledWith({
+      url: "https://new.example/mcp",
+      projectId: "proj_1",
+    });
+    expect(onSubmit.mock.calls[0][0]).toMatchObject({
+      registryServerId: "reg_1",
+      derived: { endpointUrl: "https://mcp.example.com/mcp" },
+    });
+  });
+
   it("carries sourceServerId through so the promote writes provenance", async () => {
     const user = userEvent.setup();
     const { onSubmit } = renderDialog({

--- a/mcpjam-inspector/client/src/components/registry/__tests__/OrgRegistryServerDialog.test.tsx
+++ b/mcpjam-inspector/client/src/components/registry/__tests__/OrgRegistryServerDialog.test.tsx
@@ -1,0 +1,246 @@
+/**
+ * The add / promote / edit dialog.
+ *
+ * What matters here is that the DERIVED facts stay derived. Version and auth
+ * posture come off the probe and are rendered, never typed — a field a person
+ * can edit is a field that will eventually disagree with the server it
+ * describes. And an egress refusal shows the route's own generic sentence
+ * with no retry: the reason a target was blocked is not something to hand
+ * back to whoever supplied the URL.
+ */
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const { deriveOrgRegistryServer } = vi.hoisted(() => ({
+  deriveOrgRegistryServer: vi.fn(),
+}));
+
+vi.mock("@/lib/apis/web/org-registry-api", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("@/lib/apis/web/org-registry-api")>()),
+  deriveOrgRegistryServer,
+}));
+
+import { OrgRegistryServerDialog } from "../OrgRegistryServerDialog";
+import { WebApiError } from "@/lib/apis/web/base";
+
+const DERIVED_FACTS = {
+  status: "oauth_required" as const,
+  serverName: "example-mcp",
+  serverVersion: "1.4.2",
+  title: "Example Docs",
+  authRequired: true,
+  registrationStrategies: [] as Array<"preregistered" | "dcr" | "cimd">,
+  endpointUrl: "https://mcp.example.com/mcp",
+};
+
+function renderDialog(
+  overrides: Partial<React.ComponentProps<typeof OrgRegistryServerDialog>> = {}
+) {
+  const onSubmit = vi.fn().mockResolvedValue(undefined);
+  render(
+    <OrgRegistryServerDialog
+      open
+      onOpenChange={() => {}}
+      projectId="proj_1"
+      onSubmit={onSubmit}
+      {...overrides}
+    />
+  );
+  return { onSubmit };
+}
+
+beforeEach(() => {
+  deriveOrgRegistryServer.mockReset();
+  deriveOrgRegistryServer.mockResolvedValue(DERIVED_FACTS);
+});
+
+describe("OrgRegistryServerDialog — paste a link", () => {
+  it("probes the pasted URL and prefills from what the server said", async () => {
+    const user = userEvent.setup();
+    renderDialog();
+
+    await user.type(
+      screen.getByLabelText("Server URL"),
+      "https://mcp.example.com/mcp"
+    );
+    await user.click(screen.getByRole("button", { name: "Continue" }));
+
+    await waitFor(() =>
+      expect(screen.getByLabelText("Name")).toHaveValue("Example Docs")
+    );
+    // Read-only facts, rendered as badges rather than fields.
+    expect(screen.getByText("v1.4.2")).toBeInTheDocument();
+    expect(screen.getByText(/Requires sign-in/)).toBeInTheDocument();
+    // No DCR and no CIMD resolved, so this server needs a client handed to it.
+    expect(
+      screen.getByText("Requires pre-registered client")
+    ).toBeInTheDocument();
+  });
+
+  it("submits the derived snapshot alongside what the person typed", async () => {
+    const user = userEvent.setup();
+    const { onSubmit } = renderDialog();
+
+    await user.type(
+      screen.getByLabelText("Server URL"),
+      "https://mcp.example.com/mcp"
+    );
+    await user.click(screen.getByRole("button", { name: "Continue" }));
+    await waitFor(() =>
+      expect(screen.getByLabelText("Name")).toHaveValue("Example Docs")
+    );
+    await user.clear(screen.getByLabelText("Name"));
+    await user.type(screen.getByLabelText("Name"), "Team Docs");
+    await user.click(screen.getByRole("button", { name: "Add to registry" }));
+
+    await waitFor(() => expect(onSubmit).toHaveBeenCalled());
+    expect(onSubmit.mock.calls[0][0]).toMatchObject({
+      displayName: "Team Docs",
+      url: "https://mcp.example.com/mcp",
+      useOAuth: true,
+      derived: {
+        serverVersion: "1.4.2",
+        authRequired: true,
+        supportsDcr: false,
+        supportsCimd: false,
+      },
+    });
+  });
+
+  it("shows a refusal as-is and stays on the URL step", async () => {
+    const user = userEvent.setup();
+    deriveOrgRegistryServer.mockRejectedValue(
+      new WebApiError(
+        400,
+        "VALIDATION_ERROR",
+        "That address can't be reached from MCPJam. Organization registry entries must point at a server on the public internet, over HTTPS."
+      )
+    );
+    const { onSubmit } = renderDialog();
+
+    await user.type(
+      screen.getByLabelText("Server URL"),
+      "http://localhost/mcp"
+    );
+    await user.click(screen.getByRole("button", { name: "Continue" }));
+
+    await waitFor(() =>
+      expect(screen.getByRole("alert")).toHaveTextContent(
+        /public internet, over HTTPS/
+      )
+    );
+    // Still on step one, with the URL intact so a typo can be fixed. And
+    // nothing was saved.
+    expect(screen.getByLabelText("Server URL")).toHaveValue(
+      "http://localhost/mcp"
+    );
+    expect(onSubmit).not.toHaveBeenCalled();
+    expect(deriveOrgRegistryServer).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe("OrgRegistryServerDialog — promote and edit", () => {
+  it("opens straight at the confirm step and never probes", async () => {
+    renderDialog({
+      seed: {
+        displayName: "Internal Docs",
+        url: "https://mcp.example.com/mcp",
+        useOAuth: true,
+        sourceServerId: "srv_1",
+        derived: {
+          probedAt: 1,
+          endpointUrl: "https://mcp.example.com/mcp",
+          serverVersion: "2.0.0",
+          authRequired: true,
+          supportsDcr: true,
+        },
+      },
+    });
+
+    expect(screen.getByLabelText("Name")).toHaveValue("Internal Docs");
+    expect(screen.getByText("v2.0.0")).toBeInTheDocument();
+    // DCR resolved, so no pre-registered-client claim.
+    expect(
+      screen.queryByText("Requires pre-registered client")
+    ).not.toBeInTheDocument();
+    expect(deriveOrgRegistryServer).not.toHaveBeenCalled();
+  });
+
+  it("locks the URL on promote — the mutation refuses a mismatched one", () => {
+    renderDialog({
+      seed: {
+        displayName: "Internal Docs",
+        url: "https://mcp.example.com/mcp",
+        sourceServerId: "srv_1",
+        derived: { probedAt: 1, endpointUrl: "https://mcp.example.com/mcp" },
+      },
+    });
+
+    // `addOrgRegistryServer` compares the entry URL against the source
+    // server's own, so an editable field here would be one whose every edit
+    // is a dead end.
+    expect(screen.getByLabelText("Server URL")).toHaveAttribute("readonly");
+  });
+
+  it("leaves the URL editable when editing an existing entry", () => {
+    renderDialog({
+      seed: {
+        registryServerId: "reg_1",
+        displayName: "Internal Docs",
+        url: "https://mcp.example.com/mcp",
+      },
+    });
+
+    expect(screen.getByLabelText("Server URL")).not.toHaveAttribute("readonly");
+  });
+
+  it("carries sourceServerId through so the promote writes provenance", async () => {
+    const user = userEvent.setup();
+    const { onSubmit } = renderDialog({
+      seed: {
+        displayName: "Internal Docs",
+        url: "https://mcp.example.com/mcp",
+        sourceServerId: "srv_1",
+        derived: { probedAt: 1, endpointUrl: "https://mcp.example.com/mcp" },
+      },
+    });
+
+    await user.click(screen.getByRole("button", { name: "Add to registry" }));
+
+    await waitFor(() => expect(onSubmit).toHaveBeenCalled());
+    expect(onSubmit.mock.calls[0][0]).toMatchObject({
+      sourceServerId: "srv_1",
+    });
+  });
+
+  it("keeps a failed save on screen with the server's own message", async () => {
+    const user = userEvent.setup();
+    const onOpenChange = vi.fn();
+    const onSubmit = vi
+      .fn()
+      .mockRejectedValue(
+        new Error("Organization registry entries must use an https:// URL")
+      );
+    render(
+      <OrgRegistryServerDialog
+        open
+        onOpenChange={onOpenChange}
+        projectId="proj_1"
+        seed={{
+          registryServerId: "reg_1",
+          displayName: "Internal Docs",
+          url: "https://mcp.example.com/mcp",
+        }}
+        onSubmit={onSubmit}
+      />
+    );
+
+    await user.click(screen.getByRole("button", { name: "Save changes" }));
+
+    await waitFor(() =>
+      expect(screen.getByRole("alert")).toHaveTextContent(/https:\/\//)
+    );
+    expect(onOpenChange).not.toHaveBeenCalledWith(false);
+  });
+});

--- a/mcpjam-inspector/client/src/hooks/__tests__/useOrgRegistryServers.test.tsx
+++ b/mcpjam-inspector/client/src/hooks/__tests__/useOrgRegistryServers.test.tsx
@@ -1,0 +1,264 @@
+/**
+ * The organization registry's client half.
+ *
+ * ONE THING here is load-bearing and everything else follows from it: the
+ * status join is PROVENANCE FIRST. The curated hook matches a card to a
+ * running server by display name, which is safe there because only its own
+ * connect mutation ever mints those names. It is NOT safe for org entries,
+ * because PROMOTE creates an entry from a server that already exists — so the
+ * entry and that server share a display name in the project it came from.
+ *
+ * A name join would then show the card as connected in a project that never
+ * installed it, and the Disconnect it offers would delete the user's original
+ * server. These tests pin both halves: the join reads the provenance row's
+ * `serverName`, and disconnect does nothing without a provenance row.
+ */
+import { renderHook, act } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const { queries, mutations } = vi.hoisted(() => ({
+  queries: {} as Record<string, unknown>,
+  mutations: { calls: [] as Array<{ name: string; args: unknown }> },
+}));
+
+vi.mock("convex/react", () => ({
+  useQuery: (name: string, args: unknown) =>
+    args === "skip" ? undefined : queries[name],
+  useMutation: (name: string) => async (args: unknown) => {
+    mutations.calls.push({ name, args });
+  },
+}));
+
+import { useOrgRegistryServers } from "../useOrgRegistryServers";
+
+const ORG_ROW = {
+  _id: "reg_1",
+  name: "org/org_1/internal-docs",
+  displayName: "Internal Docs",
+  scope: "organization" as const,
+  status: "approved" as const,
+  transport: { transportType: "http" as const, url: "https://a.example/mcp" },
+  createdBy: "user_1",
+  createdAt: 1,
+  updatedAt: 1,
+  derived: {
+    probedAt: 1,
+    endpointUrl: "https://a.example/mcp",
+    serverVersion: "1.4.2",
+    authRequired: true,
+    supportsDcr: true,
+  },
+  editedFields: [],
+};
+
+function render(overrides: {
+  connections?: unknown[];
+  liveServers?: Record<string, { connectionStatus: string }>;
+  onConnect?: (formData: unknown) => void;
+  onDisconnect?: (name: string) => void;
+} = {}) {
+  queries["registryServers:listOrgRegistryServers"] = [ORG_ROW];
+  queries["registryServers:getOrgRegistryContext"] = {
+    organizationId: "org_1",
+    canAdd: true,
+  };
+  queries["registryServers:getProjectRegistryConnections"] =
+    overrides.connections ?? [];
+
+  return renderHook(() =>
+    useOrgRegistryServers({
+      projectId: "proj_1",
+      isAuthenticated: true,
+      liveServers: overrides.liveServers,
+      onConnect: overrides.onConnect ?? (() => {}),
+      onDisconnect: overrides.onDisconnect,
+    })
+  );
+}
+
+beforeEach(() => {
+  mutations.calls = [];
+  for (const key of Object.keys(queries)) delete queries[key];
+});
+
+describe("useOrgRegistryServers — status join", () => {
+  it("is not connected without a provenance row, even when a server shares its name", () => {
+    // Exactly the promote case seen from ANOTHER project: the same display
+    // name is up and running, and this project installed nothing.
+    const { result } = render({
+      connections: [],
+      liveServers: { "Internal Docs": { connectionStatus: "connected" } },
+    });
+
+    expect(result.current.servers[0].connectionStatus).toBe("not_connected");
+    expect(result.current.servers[0].connectedServerName).toBeNull();
+  });
+
+  it("reads the live server through the provenance row's own server name", () => {
+    // The provenance points at a server whose name is NOT the display name —
+    // a rename, or a promoted entry retitled after the fact.
+    const { result } = render({
+      connections: [
+        {
+          _id: "conn_1",
+          registryServerId: "reg_1",
+          serverId: "srv_1",
+          serverName: "Docs (renamed)",
+        },
+      ],
+      liveServers: {
+        "Docs (renamed)": { connectionStatus: "connected" },
+        "Internal Docs": { connectionStatus: "disconnected" },
+      },
+    });
+
+    expect(result.current.servers[0].connectionStatus).toBe("connected");
+    expect(result.current.servers[0].connectedServerName).toBe(
+      "Docs (renamed)"
+    );
+  });
+
+  it("reads 'added' when provenance exists but the server is not up", () => {
+    const { result } = render({
+      connections: [
+        {
+          _id: "conn_1",
+          registryServerId: "reg_1",
+          serverId: "srv_1",
+          serverName: "Internal Docs",
+        },
+      ],
+      liveServers: {},
+    });
+
+    expect(result.current.servers[0].connectionStatus).toBe("added");
+  });
+});
+
+describe("useOrgRegistryServers — connect and disconnect", () => {
+  it("writes the connection BEFORE handing off to the app's connect", async () => {
+    const order: string[] = [];
+    const { result } = render({
+      onConnect: () => order.push("onConnect"),
+    });
+    mutations.calls = [];
+
+    await act(async () => {
+      await result.current.connect(result.current.servers[0]);
+    });
+
+    // Mutation first: it creates the `servers` row and the provenance record
+    // before anything can redirect the browser into OAuth.
+    expect(mutations.calls[0].name).toBe(
+      "registryServers:connectRegistryServer"
+    );
+    expect(order).toEqual(["onConnect"]);
+  });
+
+  it("connects with auto discovery rather than trusting the stored posture", async () => {
+    const connectArgs: Array<Record<string, unknown>> = [];
+    const { result } = render({
+      onConnect: (formData) =>
+        connectArgs.push(formData as Record<string, unknown>),
+    });
+
+    await act(async () => {
+      await result.current.connect(result.current.servers[0]);
+    });
+
+    expect(connectArgs[0]).toMatchObject({
+      authMethod: "auto",
+      useOAuth: true,
+      url: "https://a.example/mcp",
+      registryServerId: "reg_1",
+    });
+  });
+
+  it("does nothing on disconnect without a provenance row", async () => {
+    const onDisconnect = vi.fn();
+    const { result } = render({
+      connections: [],
+      liveServers: { "Internal Docs": { connectionStatus: "connected" } },
+      onDisconnect,
+    });
+    mutations.calls = [];
+
+    await act(async () => {
+      await result.current.disconnect(result.current.servers[0]);
+    });
+
+    // The server sharing this name belongs to whoever created it. Tearing it
+    // down from here is the bug this hook exists to prevent.
+    expect(mutations.calls).toEqual([]);
+    expect(onDisconnect).not.toHaveBeenCalled();
+  });
+
+  it("disconnects the server its provenance names", async () => {
+    const onDisconnect = vi.fn();
+    const { result } = render({
+      connections: [
+        {
+          _id: "conn_1",
+          registryServerId: "reg_1",
+          serverId: "srv_1",
+          serverName: "Internal Docs",
+        },
+      ],
+      onDisconnect,
+    });
+    mutations.calls = [];
+
+    await act(async () => {
+      await result.current.disconnect(result.current.servers[0]);
+    });
+
+    expect(mutations.calls[0].name).toBe(
+      "registryServers:disconnectRegistryServer"
+    );
+    expect(onDisconnect).toHaveBeenCalledWith("Internal Docs");
+  });
+});
+
+describe("useOrgRegistryServers — adding", () => {
+  it("sends the organization resolved from the project, never one from the caller", async () => {
+    const { result } = render();
+    mutations.calls = [];
+
+    await act(async () => {
+      await result.current.add({
+        displayName: "Docs",
+        url: "https://b.example/mcp",
+        useOAuth: true,
+        derived: { probedAt: 2, endpointUrl: "https://b.example/mcp" },
+      });
+    });
+
+    expect(mutations.calls[0]).toMatchObject({
+      name: "registryServers:addOrgRegistryServer",
+      args: { organizationId: "org_1", displayName: "Docs" },
+    });
+  });
+
+  it("refuses to add for a project with no organization", async () => {
+    render();
+    queries["registryServers:getOrgRegistryContext"] = {
+      organizationId: null,
+      canAdd: false,
+    };
+    const { result } = renderHook(() =>
+      useOrgRegistryServers({
+        projectId: "proj_1",
+        isAuthenticated: true,
+        onConnect: () => {},
+      })
+    );
+
+    await expect(
+      result.current.add({
+        displayName: "Docs",
+        url: "https://b.example/mcp",
+        derived: { probedAt: 2, endpointUrl: "https://b.example/mcp" },
+      })
+    ).rejects.toThrow(/not part of an organization/);
+  });
+});

--- a/mcpjam-inspector/client/src/hooks/__tests__/useOrgRegistryServers.test.tsx
+++ b/mcpjam-inspector/client/src/hooks/__tests__/useOrgRegistryServers.test.tsx
@@ -51,12 +51,14 @@ const ORG_ROW = {
   editedFields: [],
 };
 
-function render(overrides: {
-  connections?: unknown[];
-  liveServers?: Record<string, { connectionStatus: string }>;
-  onConnect?: (formData: unknown) => void;
-  onDisconnect?: (name: string) => void;
-} = {}) {
+function render(
+  overrides: {
+    connections?: unknown[];
+    liveServers?: Record<string, { connectionStatus: string }>;
+    onConnect?: (formData: unknown) => void;
+    onDisconnect?: (name: string) => void;
+  } = {}
+) {
   queries["registryServers:listOrgRegistryServers"] = [ORG_ROW];
   queries["registryServers:getOrgRegistryContext"] = {
     organizationId: "org_1",
@@ -132,6 +134,30 @@ describe("useOrgRegistryServers — status join", () => {
     });
 
     expect(result.current.servers[0].connectionStatus).toBe("added");
+  });
+
+  it("stays loading until provenance resolves, rather than guessing", () => {
+    queries["registryServers:listOrgRegistryServers"] = [ORG_ROW];
+    queries["registryServers:getOrgRegistryContext"] = {
+      organizationId: "org_1",
+      canAdd: true,
+    };
+    // The two queries land independently. Rows first, provenance still in
+    // flight: an empty map here would read as "nothing is installed", so every
+    // installed card would flash "Connect" and a click in that window would
+    // try to install it twice.
+    queries["registryServers:getProjectRegistryConnections"] = undefined;
+
+    const { result } = renderHook(() =>
+      useOrgRegistryServers({
+        projectId: "proj_1",
+        isAuthenticated: true,
+        onConnect: () => {},
+      })
+    );
+
+    expect(result.current.servers).toEqual([]);
+    expect(result.current.isLoading).toBe(true);
   });
 });
 

--- a/mcpjam-inspector/client/src/hooks/__tests__/useOrgRegistryServers.test.tsx
+++ b/mcpjam-inspector/client/src/hooks/__tests__/useOrgRegistryServers.test.tsx
@@ -243,6 +243,32 @@ describe("useOrgRegistryServers — connect and disconnect", () => {
     );
     expect(onDisconnect).toHaveBeenCalledWith("Internal Docs");
   });
+
+  it("preserves the promoted source server on disconnect", async () => {
+    const onDisconnect = vi.fn();
+    const { result } = render({
+      connections: [
+        {
+          _id: "conn_1",
+          registryServerId: "reg_1",
+          serverId: "srv_1",
+          serverName: "Internal Docs",
+          connectionKind: "promoted_source",
+        },
+      ],
+      onDisconnect,
+    });
+    mutations.calls = [];
+
+    await act(async () => {
+      await result.current.disconnect(result.current.servers[0]);
+    });
+
+    expect(mutations.calls[0].name).toBe(
+      "registryServers:disconnectRegistryServer"
+    );
+    expect(onDisconnect).not.toHaveBeenCalled();
+  });
 });
 
 describe("useOrgRegistryServers — adding", () => {

--- a/mcpjam-inspector/client/src/hooks/useOrgRegistryServers.ts
+++ b/mcpjam-inspector/client/src/hooks/useOrgRegistryServers.ts
@@ -67,7 +67,8 @@ export interface OrgRegistrySubmission {
   url: string;
   useOAuth?: boolean;
   oauthScopes?: string[];
-  derived: OrgRegistryDerivedSnapshot;
+  /** Absent when no probe produced a verdict; never synthesized. */
+  derived: OrgRegistryDerivedSnapshot | null;
   sourceServerId?: string;
 }
 
@@ -142,7 +143,12 @@ export function useOrgRegistryServers({
   }, [connections]);
 
   const servers = useMemo<EnrichedOrgRegistryServer[]>(() => {
-    if (!enabled || !rows) return [];
+    // `connections` must be RESOLVED, not merely absent. The two queries land
+    // independently, and if rows arrive first, an empty provenance map reads
+    // as "nothing is installed" — every already-installed card would flash
+    // "Connect", and a click in that window would try to install it twice.
+    // An unresolved provenance query is a loading state, not an answer.
+    if (!enabled || !rows || connections === undefined) return [];
     return rows.map((row) => {
       const connection = provenance.get(row._id);
       const connectedServerName = connection?.serverName ?? null;
@@ -166,12 +172,20 @@ export function useOrgRegistryServers({
 
       return { ...row, connectionStatus, connectedServerName };
     });
-  }, [enabled, rows, provenance, liveServers, connectingIds]);
+  }, [enabled, rows, connections, provenance, liveServers, connectingIds]);
 
   const add = useCallback(
     async (submission: OrgRegistrySubmission) => {
       if (!context?.organizationId) {
         throw new Error("This project is not part of an organization.");
+      }
+      if (!submission.derived) {
+        // `addOrgRegistryServer` requires the snapshot, and the two doors that
+        // reach here both produce one (the paste flow probes, promote reads
+        // `initializationInfo`). Refusing beats minting a fake.
+        throw new Error(
+          "We could not read this server's details. Try the address again."
+        );
       }
       await addMutation({
         organizationId: context.organizationId,
@@ -288,7 +302,7 @@ export function useOrgRegistryServers({
   return {
     servers,
     /** Absent answer ⇒ empty shelf, never an endless spinner. */
-    isLoading: enabled && rows === undefined,
+    isLoading: enabled && (rows === undefined || connections === undefined),
     organizationId: context?.organizationId ?? null,
     canAdd: context?.canAdd ?? false,
     add,

--- a/mcpjam-inspector/client/src/hooks/useOrgRegistryServers.ts
+++ b/mcpjam-inspector/client/src/hooks/useOrgRegistryServers.ts
@@ -1,0 +1,300 @@
+import { useCallback, useMemo, useState } from "react";
+import { useMutation, useQuery } from "convex/react";
+import type { ServerFormData } from "@/shared/types.js";
+import type { RegistryServer } from "@/lib/registry-server-types";
+import type { OrgRegistryDerivedSnapshot } from "@/lib/apis/web/org-registry-api";
+import { REGISTRY_FEATURE_ENABLED } from "./useRegistryServers";
+
+/**
+ * The organization's own registry shelf.
+ *
+ * Separate from `useRegistryServers` rather than a branch inside it, and the
+ * reason is the STATUS JOIN — the one thing here that is easy to get wrong and
+ * expensive when it is.
+ *
+ * The curated hook decides "is this card connected?" by looking the card's
+ * display name up in the live-servers map. That works for curated entries
+ * because their names are minted by the connect mutation and nothing else
+ * creates a server by that name. It does NOT work for org entries: PROMOTE
+ * creates an entry FROM a server that already exists, so the entry and that
+ * server share a display name in the project it came from. A name join would
+ * show the card as connected in a project that never installed it — and worse,
+ * the Disconnect it offers would delete the user's original server.
+ *
+ * So the join here is PROVENANCE FIRST. A card is added/connected only when
+ * this project has a `registryServerConnections` row for it, and the live
+ * server is then found by THAT ROW's `serverName`. The display name is never
+ * consulted. The consequence is deliberate: a promoted entry reads as
+ * "connected" in its source project (which has the provenance row the promote
+ * wrote) and as "not connected" everywhere else, until someone connects it.
+ */
+
+export interface OrgRegistryServer extends RegistryServer {
+  derived?: OrgRegistryDerivedSnapshot;
+  editedFields?: string[];
+}
+
+export type OrgRegistryConnectionStatus =
+  | "not_connected"
+  | "added"
+  | "connected"
+  | "connecting";
+
+export interface EnrichedOrgRegistryServer extends OrgRegistryServer {
+  connectionStatus: OrgRegistryConnectionStatus;
+  /** The live server this entry's provenance points at, when there is one. */
+  connectedServerName: string | null;
+}
+
+/** One row of `registryServers:getProjectRegistryConnections`. */
+interface RegistryConnectionRow {
+  _id: string;
+  registryServerId: string;
+  serverId: string;
+  /** The `servers` row's name, or null if it was deleted underneath. */
+  serverName: string | null;
+}
+
+export interface OrgRegistryContext {
+  organizationId: string | null;
+  canAdd: boolean;
+}
+
+export interface OrgRegistrySubmission {
+  registryServerId?: string;
+  displayName: string;
+  description?: string;
+  url: string;
+  useOAuth?: boolean;
+  oauthScopes?: string[];
+  derived: OrgRegistryDerivedSnapshot;
+  sourceServerId?: string;
+}
+
+/**
+ * A Convex query for a function the deployed backend does not have yet reads
+ * as a thrown "Could not find public function". The Registry tab must survive
+ * that: the org section is new, and a browser can outlive a rollback.
+ *
+ * `useQuery` throws during render, so this cannot be caught here — the caller
+ * wraps the section in an error boundary. What this hook guarantees is the
+ * quieter half: an ABSENT answer (still loading, or skipped) is an empty
+ * shelf, never a crash and never a spinner that lasts forever.
+ */
+export function useOrgRegistryServers({
+  enabled: callerEnabled = true,
+  projectId,
+  isAuthenticated,
+  liveServers,
+  onConnect,
+  onDisconnect,
+}: {
+  enabled?: boolean;
+  projectId: string | null;
+  isAuthenticated: boolean;
+  liveServers?: Record<string, { connectionStatus: string }>;
+  onConnect: (formData: ServerFormData) => void;
+  onDisconnect?: (serverName: string) => void;
+}) {
+  const enabled =
+    REGISTRY_FEATURE_ENABLED && callerEnabled && isAuthenticated && !!projectId;
+
+  const rows = useQuery(
+    "registryServers:listOrgRegistryServers" as any,
+    enabled ? ({ projectId } as any) : "skip"
+  ) as OrgRegistryServer[] | undefined;
+
+  const context = useQuery(
+    "registryServers:getOrgRegistryContext" as any,
+    enabled ? ({ projectId } as any) : "skip"
+  ) as OrgRegistryContext | undefined;
+
+  const connections = useQuery(
+    "registryServers:getProjectRegistryConnections" as any,
+    enabled ? ({ projectId } as any) : "skip"
+  ) as RegistryConnectionRow[] | undefined;
+
+  const addMutation = useMutation(
+    "registryServers:addOrgRegistryServer" as any
+  );
+  const updateMutation = useMutation(
+    "registryServers:updateOrgRegistryServer" as any
+  );
+  const removeMutation = useMutation(
+    "registryServers:removeOrgRegistryServer" as any
+  );
+  const connectMutation = useMutation(
+    "registryServers:connectRegistryServer" as any
+  );
+  const disconnectMutation = useMutation(
+    "registryServers:disconnectRegistryServer" as any
+  );
+
+  const [connectingIds, setConnectingIds] = useState<Set<string>>(new Set());
+
+  /** registryServerId → the provenance row this project holds for it. */
+  const provenance = useMemo(() => {
+    const byRegistryId = new Map<string, RegistryConnectionRow>();
+    for (const connection of connections ?? []) {
+      byRegistryId.set(connection.registryServerId, connection);
+    }
+    return byRegistryId;
+  }, [connections]);
+
+  const servers = useMemo<EnrichedOrgRegistryServer[]>(() => {
+    if (!enabled || !rows) return [];
+    return rows.map((row) => {
+      const connection = provenance.get(row._id);
+      const connectedServerName = connection?.serverName ?? null;
+      const liveServer = connectedServerName
+        ? liveServers?.[connectedServerName]
+        : undefined;
+
+      let connectionStatus: OrgRegistryConnectionStatus = "not_connected";
+      if (connectingIds.has(row._id)) {
+        connectionStatus = "connecting";
+      } else if (liveServer?.connectionStatus === "connected") {
+        connectionStatus = "connected";
+      } else if (liveServer?.connectionStatus === "connecting") {
+        connectionStatus = "connecting";
+      } else if (connection) {
+        // Provenance without a live server: installed in this project, not
+        // currently up. "Added" rather than "connected" — the distinction the
+        // curated cards already draw.
+        connectionStatus = "added";
+      }
+
+      return { ...row, connectionStatus, connectedServerName };
+    });
+  }, [enabled, rows, provenance, liveServers, connectingIds]);
+
+  const add = useCallback(
+    async (submission: OrgRegistrySubmission) => {
+      if (!context?.organizationId) {
+        throw new Error("This project is not part of an organization.");
+      }
+      await addMutation({
+        organizationId: context.organizationId,
+        displayName: submission.displayName,
+        description: submission.description,
+        url: submission.url,
+        useOAuth: submission.useOAuth,
+        oauthScopes: submission.oauthScopes,
+        derived: submission.derived,
+        sourceServerId: submission.sourceServerId,
+      } as any);
+    },
+    [addMutation, context?.organizationId]
+  );
+
+  const update = useCallback(
+    async (submission: OrgRegistrySubmission) => {
+      if (!submission.registryServerId) {
+        throw new Error("Missing registry entry id");
+      }
+      await updateMutation({
+        registryServerId: submission.registryServerId,
+        displayName: submission.displayName,
+        description: submission.description ?? "",
+        url: submission.url,
+        useOAuth: submission.useOAuth,
+        oauthScopes: submission.oauthScopes,
+      } as any);
+    },
+    [updateMutation]
+  );
+
+  const remove = useCallback(
+    async (registryServerId: string) => {
+      await removeMutation({ registryServerId } as any);
+    },
+    [removeMutation]
+  );
+
+  /**
+   * MUTATION FIRST, then hand off to the app's own connect — the directory
+   * flow's ordering, not the curated one's.
+   *
+   * The mutation checks org membership, checks the project belongs to that
+   * org, creates the `servers` row and writes the provenance record, all
+   * BEFORE anything can redirect the browser. The curated flow connects first
+   * and records provenance from a later effect, which loses the record
+   * whenever OAuth navigates away mid-flight. Here the record exists before
+   * the redirect can happen.
+   *
+   * Resolving means INSTALLED, not connected: `onConnect` returns void and an
+   * OAuth server continues asynchronously, possibly through a full page
+   * navigation. The card learns the rest from the live-servers map.
+   */
+  const connect = useCallback(
+    async (server: EnrichedOrgRegistryServer) => {
+      if (!projectId) {
+        throw new Error("Select a project first.");
+      }
+      setConnectingIds((prev) => new Set(prev).add(server._id));
+      try {
+        await connectMutation({
+          registryServerId: server._id,
+          projectId,
+        } as any);
+
+        onConnect({
+          name: server.displayName,
+          type: "http",
+          url: server.transport.url,
+          // RUNTIME-PROBED, not metadata-trusted — the directory flow's
+          // posture. `auto` connects unauthenticated and escalates only on a
+          // real 401, so a stored `useOAuth` that has gone stale cannot turn
+          // into a server that silently never authorizes. `useOAuth: true` is
+          // the compat mirror of `auto` that `handleConnect` gates the whole
+          // discover-and-escalate branch on.
+          authMethod: "auto",
+          useOAuth: true,
+          oauthScopes: server.transport.oauthScopes,
+          registryServerId: server._id,
+        });
+      } finally {
+        setConnectingIds((prev) => {
+          const next = new Set(prev);
+          next.delete(server._id);
+          return next;
+        });
+      }
+    },
+    [connectMutation, onConnect, projectId]
+  );
+
+  /**
+   * Disconnect acts through the PROVENANCE ROW and nothing else.
+   *
+   * `disconnectRegistryServer` deletes the `servers` row its connection points
+   * at. With no provenance row in this project there is nothing this card
+   * installed here, so there is nothing for it to take down — and the server
+   * that merely shares its name (the promote case) is somebody else's.
+   */
+  const disconnect = useCallback(
+    async (server: EnrichedOrgRegistryServer) => {
+      if (!projectId) return;
+      if (!server.connectedServerName) return;
+      await disconnectMutation({
+        registryServerId: server._id,
+        projectId,
+      } as any);
+      onDisconnect?.(server.connectedServerName);
+    },
+    [disconnectMutation, onDisconnect, projectId]
+  );
+
+  return {
+    servers,
+    /** Absent answer ⇒ empty shelf, never an endless spinner. */
+    isLoading: enabled && rows === undefined,
+    organizationId: context?.organizationId ?? null,
+    canAdd: context?.canAdd ?? false,
+    add,
+    update,
+    remove,
+    connect,
+    disconnect,
+  };
+}

--- a/mcpjam-inspector/client/src/hooks/useOrgRegistryServers.ts
+++ b/mcpjam-inspector/client/src/hooks/useOrgRegistryServers.ts
@@ -44,6 +44,7 @@ export interface EnrichedOrgRegistryServer extends OrgRegistryServer {
   connectionStatus: OrgRegistryConnectionStatus;
   /** The live server this entry's provenance points at, when there is one. */
   connectedServerName: string | null;
+  connectionKind?: "installed" | "promoted_source";
 }
 
 /** One row of `registryServers:getProjectRegistryConnections`. */
@@ -53,6 +54,7 @@ interface RegistryConnectionRow {
   serverId: string;
   /** The `servers` row's name, or null if it was deleted underneath. */
   serverName: string | null;
+  connectionKind?: "installed" | "promoted_source";
 }
 
 export interface OrgRegistryContext {
@@ -68,7 +70,7 @@ export interface OrgRegistrySubmission {
   useOAuth?: boolean;
   oauthScopes?: string[];
   /** Absent when no probe produced a verdict; never synthesized. */
-  derived: OrgRegistryDerivedSnapshot | null;
+  derived?: OrgRegistryDerivedSnapshot;
   sourceServerId?: string;
 }
 
@@ -170,7 +172,12 @@ export function useOrgRegistryServers({
         connectionStatus = "added";
       }
 
-      return { ...row, connectionStatus, connectedServerName };
+      return {
+        ...row,
+        connectionStatus,
+        connectedServerName,
+        connectionKind: connection?.connectionKind,
+      };
     });
   }, [enabled, rows, connections, provenance, liveServers, connectingIds]);
 
@@ -213,6 +220,7 @@ export function useOrgRegistryServers({
         url: submission.url,
         useOAuth: submission.useOAuth,
         oauthScopes: submission.oauthScopes,
+        derived: submission.derived,
       } as any);
     },
     [updateMutation]
@@ -294,7 +302,9 @@ export function useOrgRegistryServers({
         registryServerId: server._id,
         projectId,
       } as any);
-      onDisconnect?.(server.connectedServerName);
+      if (server.connectionKind !== "promoted_source") {
+        onDisconnect?.(server.connectedServerName);
+      }
     },
     [disconnectMutation, onDisconnect, projectId]
   );

--- a/mcpjam-inspector/client/src/lib/apis/web/org-registry-api.ts
+++ b/mcpjam-inspector/client/src/lib/apis/web/org-registry-api.ts
@@ -1,0 +1,65 @@
+import { webPost } from "./base";
+
+/**
+ * Typed wrapper for `POST /api/web/registry/derive` — the paste-a-link half of
+ * the organization registry.
+ *
+ * The Inspector server probes; the browser never dials the pasted address
+ * itself. That is not only an SSRF question (a browser cannot reach a private
+ * network on our behalf anyway) — the probe needs an MCP initialize handshake
+ * and redirect-revalidating egress, neither of which belongs in a tab.
+ */
+export interface DerivedServerFacts {
+  /** `ready` — open server. `oauth_required` — it challenged. */
+  status: "ready" | "oauth_required";
+  serverName?: string;
+  serverVersion?: string;
+  title?: string;
+  authRequired: boolean;
+  registrationStrategies: Array<"preregistered" | "dcr" | "cimd">;
+  /** The URL the probe actually reached — after redirects. */
+  endpointUrl: string;
+}
+
+export async function deriveOrgRegistryServer(input: {
+  url: string;
+  projectId: string;
+}): Promise<DerivedServerFacts> {
+  return await webPost<typeof input, DerivedServerFacts>(
+    "/api/web/registry/derive",
+    input
+  );
+}
+
+/**
+ * The `derived` snapshot the Convex mutations store.
+ *
+ * Built here rather than server-side because PROMOTE produces one without any
+ * probe at all — the facts are already in the browser, on
+ * `initializationInfo`. One shape, two sources, so a promoted entry and a
+ * pasted one are the same kind of row.
+ */
+export interface OrgRegistryDerivedSnapshot {
+  probedAt: number;
+  endpointUrl: string;
+  serverName?: string;
+  serverVersion?: string;
+  authRequired?: boolean;
+  supportsDcr?: boolean;
+  supportsCimd?: boolean;
+}
+
+export function snapshotFromDerivedFacts(
+  facts: DerivedServerFacts,
+  now: number = Date.now()
+): OrgRegistryDerivedSnapshot {
+  return {
+    probedAt: now,
+    endpointUrl: facts.endpointUrl,
+    serverName: facts.serverName,
+    serverVersion: facts.serverVersion,
+    authRequired: facts.authRequired,
+    supportsDcr: facts.registrationStrategies.includes("dcr"),
+    supportsCimd: facts.registrationStrategies.includes("cimd"),
+  };
+}

--- a/mcpjam-inspector/server/middleware/__tests__/registry-derive-rate-limit.test.ts
+++ b/mcpjam-inspector/server/middleware/__tests__/registry-derive-rate-limit.test.ts
@@ -1,0 +1,85 @@
+/**
+ * The org-registry derive limiter.
+ *
+ * It is not what stands between a stranger and our egress — the route
+ * authorizes against the backend first. It bounds how much egress ONE member
+ * can spend, so what is worth pinning is the shape of the ceiling: where it
+ * bites, where it deliberately does not, and that a full map fails closed
+ * rather than handing a churner a way to reset their own bucket.
+ *
+ * `HOSTED_MODE` is read at module load, so it is stubbed before the import.
+ */
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("../../config.js", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("../../config.js")>()),
+  HOSTED_MODE: true,
+}));
+
+const {
+  REGISTRY_DERIVE_RATE_LIMIT,
+  registryDeriveRateLimitMiddleware,
+  resetRegistryDeriveRateLimitForTests,
+} = await import("../registry-derive-rate-limit.js");
+
+function call(
+  ip: string | undefined,
+  method: "POST" | "GET" = "POST"
+): Promise<Response | void> {
+  const next = vi.fn(async () => {});
+  const c = {
+    req: {
+      method,
+      header: (name: string) =>
+        name.toLowerCase() === "x-real-ip" ? ip : undefined,
+      raw: new Request("https://inspector.test/api/web/registry/derive"),
+    },
+    json: (body: unknown, status?: number, headers?: Record<string, string>) =>
+      new Response(JSON.stringify(body), { status, headers }),
+    // The limiter never reads these, but `getClientIp` walks the context.
+    env: {},
+  } as never;
+  return registryDeriveRateLimitMiddleware(c, next as never);
+}
+
+beforeEach(() => {
+  resetRegistryDeriveRateLimitForTests();
+});
+
+describe("registryDeriveRateLimitMiddleware", () => {
+  it("passes the last request inside the window and refuses the next", async () => {
+    for (let i = 0; i < REGISTRY_DERIVE_RATE_LIMIT; i++) {
+      expect(await call("198.51.100.7")).toBeUndefined();
+    }
+
+    const refused = (await call("198.51.100.7")) as Response;
+    expect(refused.status).toBe(429);
+    // A 429 with no Retry-After tells a client to guess.
+    expect(refused.headers.get("Retry-After")).toBeTruthy();
+  });
+
+  it("meters each address separately", async () => {
+    for (let i = 0; i < REGISTRY_DERIVE_RATE_LIMIT; i++) {
+      await call("198.51.100.7");
+    }
+
+    expect(await call("203.0.113.9")).toBeUndefined();
+  });
+
+  it("does not charge a request that was never going to reach the handler", async () => {
+    for (let i = 0; i < REGISTRY_DERIVE_RATE_LIMIT + 5; i++) {
+      expect(await call("198.51.100.7", "GET")).toBeUndefined();
+    }
+
+    // Otherwise a cross-site page could spend somebody's whole budget on
+    // requests the route would have ignored — turning a limiter meant to
+    // protect the flow into a way to deny it.
+    expect(await call("198.51.100.7")).toBeUndefined();
+  });
+
+  it("lets a request with no attributable address through", async () => {
+    for (let i = 0; i < REGISTRY_DERIVE_RATE_LIMIT + 5; i++) {
+      expect(await call(undefined)).toBeUndefined();
+    }
+  });
+});

--- a/mcpjam-inspector/server/middleware/__tests__/registry-derive-rate-limit.test.ts
+++ b/mcpjam-inspector/server/middleware/__tests__/registry-derive-rate-limit.test.ts
@@ -9,7 +9,7 @@
  *
  * `HOSTED_MODE` is read at module load, so it is stubbed before the import.
  */
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 vi.mock("../../config.js", async (importOriginal) => ({
   ...(await importOriginal<typeof import("../../config.js")>()),
@@ -46,6 +46,10 @@ beforeEach(() => {
   resetRegistryDeriveRateLimitForTests();
 });
 
+afterEach(() => {
+  vi.useRealTimers();
+});
+
 describe("registryDeriveRateLimitMiddleware", () => {
   it("passes the last request inside the window and refuses the next", async () => {
     for (let i = 0; i < REGISTRY_DERIVE_RATE_LIMIT; i++) {
@@ -64,6 +68,27 @@ describe("registryDeriveRateLimitMiddleware", () => {
     }
 
     expect(await call("203.0.113.9")).toBeUndefined();
+  });
+
+  it("starts a fresh window after ten minutes", async () => {
+    vi.useFakeTimers();
+    for (let i = 0; i < REGISTRY_DERIVE_RATE_LIMIT; i++) {
+      await call("198.51.100.7");
+    }
+    expect((await call("198.51.100.7")) as Response).toBeInstanceOf(Response);
+
+    vi.advanceTimersByTime(10 * 60_000 + 1);
+    expect(await call("198.51.100.7")).toBeUndefined();
+  });
+
+  it("fails closed when the bounded address map is full", async () => {
+    for (let i = 0; i < 10_000; i++) {
+      await call(`198.51.${Math.floor(i / 256)}.${i % 256}`);
+    }
+
+    const refused = (await call("203.0.113.9")) as Response;
+    expect(refused.status).toBe(429);
+    expect(refused.headers.get("Retry-After")).toBeTruthy();
   });
 
   it("does not charge a request that was never going to reach the handler", async () => {

--- a/mcpjam-inspector/server/middleware/registry-derive-rate-limit.ts
+++ b/mcpjam-inspector/server/middleware/registry-derive-rate-limit.ts
@@ -1,0 +1,109 @@
+import type { Context, Next } from "hono";
+import { ErrorCode } from "../routes/web/errors.js";
+import { getClientIp } from "../utils/client-ip.js";
+import { HOSTED_MODE } from "../config.js";
+
+/**
+ * Per-IP ceiling on org-registry URL derivation.
+ *
+ * Deriving an entry means dialing a server the caller named — an MCP
+ * initialize, an SSE fallback, resource metadata, authorization-server
+ * metadata, each with its own retries. The route authorizes first (org
+ * membership, checked against the backend with the caller's own bearer), so
+ * this is not the thing standing between a stranger and our egress. It bounds
+ * how much of that egress ONE member can spend, which authorization does not:
+ * a member is entitled to add entries, not to point us at a thousand addresses
+ * a minute.
+ *
+ * Sized for the act it meters. Adding a server to the shelf is a deliberate,
+ * occasional thing: paste, look at what came back, maybe fix a typo and paste
+ * again. Twenty in ten minutes covers a person setting up a whole team's
+ * registry in one sitting and still refuses a loop.
+ *
+ * PER PROCESS, not per fleet — the same trade `conformance-run-rate-limit.ts`
+ * documents at length. The window lives in this replica's memory, so the real
+ * ceiling is this number times the replica count and it moves when the
+ * deployment scales. It blunts abuse; making it a guarantee needs shared
+ * state, not a smaller number.
+ *
+ * Local/desktop mode is exempt: one user, dialing servers they already have.
+ */
+
+const DERIVE_RATE_LIMIT = 20;
+const DERIVE_WINDOW_MS = 10 * 60_000;
+
+/**
+ * Bounded, and FAILS CLOSED when full rather than evicting. The key comes from
+ * a client-supplied forwarding header, so sustained IP churn would otherwise
+ * grow this map until the replica died — and evicting the oldest entry would
+ * hand a churner a way to reset their own exhausted bucket, defeating the
+ * ceiling exactly where it matters.
+ */
+const IP_WINDOW_MAX_ENTRIES = 10_000;
+const ipWindows = new Map<string, { count: number; windowStart: number }>();
+
+setInterval(() => {
+  const now = Date.now();
+  for (const [ip, entry] of ipWindows) {
+    if (now - entry.windowStart > DERIVE_WINDOW_MS * 2) {
+      ipWindows.delete(ip);
+    }
+  }
+}, 5 * 60_000).unref();
+
+export const REGISTRY_DERIVE_RATE_LIMIT = DERIVE_RATE_LIMIT;
+
+export function resetRegistryDeriveRateLimitForTests(): void {
+  ipWindows.clear();
+}
+
+export async function registryDeriveRateLimitMiddleware(
+  c: Context,
+  next: Next
+): Promise<Response | void> {
+  if (!HOSTED_MODE) return next();
+
+  // Mounted on a path, so without this a request that was never going to
+  // reach the handler could spend somebody's whole budget — turning a limiter
+  // meant to protect the flow into a way to deny it.
+  if (c.req.method !== "POST") return next();
+
+  const ip = getClientIp(c);
+  // No attributable IP means no bucket to charge. Falling through matches the
+  // other limiters' posture rather than collapsing every such caller into one
+  // shared bucket, where a single header-stripped request would starve the
+  // rest.
+  if (!ip) return next();
+
+  const now = Date.now();
+  const entry = ipWindows.get(ip);
+  const tooMany = (retryAfterMs: number) =>
+    c.json(
+      {
+        code: ErrorCode.RATE_LIMITED,
+        message:
+          "Too many servers derived from this address. Try again in a few minutes.",
+      },
+      429,
+      { "Retry-After": String(Math.max(1, Math.ceil(retryAfterMs / 1000))) }
+    );
+
+  if (entry) {
+    if (now - entry.windowStart < DERIVE_WINDOW_MS) {
+      if (entry.count >= DERIVE_RATE_LIMIT) {
+        return tooMany(entry.windowStart + DERIVE_WINDOW_MS - now);
+      }
+      entry.count++;
+    } else {
+      entry.count = 1;
+      entry.windowStart = now;
+    }
+  } else {
+    if (ipWindows.size >= IP_WINDOW_MAX_ENTRIES) {
+      return tooMany(DERIVE_WINDOW_MS);
+    }
+    ipWindows.set(ip, { count: 1, windowStart: now });
+  }
+
+  return next();
+}

--- a/mcpjam-inspector/server/middleware/registry-derive-rate-limit.ts
+++ b/mcpjam-inspector/server/middleware/registry-derive-rate-limit.ts
@@ -57,23 +57,12 @@ export function resetRegistryDeriveRateLimitForTests(): void {
   ipWindows.clear();
 }
 
-export async function registryDeriveRateLimitMiddleware(
-  c: Context,
-  next: Next
-): Promise<Response | void> {
-  if (!HOSTED_MODE) return next();
-
-  // Mounted on a path, so without this a request that was never going to
-  // reach the handler could spend somebody's whole budget — turning a limiter
-  // meant to protect the flow into a way to deny it.
-  if (c.req.method !== "POST") return next();
+export function consumeRegistryDeriveRateLimit(c: Context): Response | null {
+  if (!HOSTED_MODE) return null;
+  if (c.req.method !== "POST") return null;
 
   const ip = getClientIp(c);
-  // No attributable IP means no bucket to charge. Falling through matches the
-  // other limiters' posture rather than collapsing every such caller into one
-  // shared bucket, where a single header-stripped request would starve the
-  // rest.
-  if (!ip) return next();
+  if (!ip) return null;
 
   const now = Date.now();
   const entry = ipWindows.get(ip);
@@ -105,5 +94,12 @@ export async function registryDeriveRateLimitMiddleware(
     ipWindows.set(ip, { count: 1, windowStart: now });
   }
 
-  return next();
+  return null;
+}
+
+export async function registryDeriveRateLimitMiddleware(
+  c: Context,
+  next: Next
+): Promise<Response | void> {
+  return consumeRegistryDeriveRateLimit(c) ?? next();
 }

--- a/mcpjam-inspector/server/routes/web/__tests__/registry-derive.test.ts
+++ b/mcpjam-inspector/server/routes/web/__tests__/registry-derive.test.ts
@@ -24,10 +24,9 @@ const { deriveRegistryEntry, query } = vi.hoisted(() => ({
 }));
 
 vi.mock("../../../services/registry-derive.js", async (importOriginal) => {
-  const actual =
-    await importOriginal<
-      typeof import("../../../services/registry-derive.js")
-    >();
+  const actual = await importOriginal<
+    typeof import("../../../services/registry-derive.js")
+  >();
   return { ...actual, deriveRegistryEntry };
 });
 
@@ -133,6 +132,43 @@ describe("POST /api/web/registry/derive", () => {
 
     expect(response.status).toBe(502);
     expect(deriveRegistryEntry).not.toHaveBeenCalled();
+  });
+
+  it("does not dial anything when Convex is not configured", async () => {
+    // `convexUrl` is derived from CONVEX_HTTP_URL and falls back to
+    // VITE_CONVEX_URL, so "not configured" means neither is set. The point is
+    // that the failure lands BEFORE any egress.
+    const previousViteConvexUrl = process.env.VITE_CONVEX_URL;
+    delete process.env.CONVEX_HTTP_URL;
+    delete process.env.VITE_CONVEX_URL;
+    try {
+      const response = await postDerive(BODY);
+
+      expect(response.status).toBe(500);
+      expect(deriveRegistryEntry).not.toHaveBeenCalled();
+    } finally {
+      if (previousViteConvexUrl === undefined) {
+        delete process.env.VITE_CONVEX_URL;
+      } else {
+        process.env.VITE_CONVEX_URL = previousViteConvexUrl;
+      }
+    }
+  });
+
+  it("does not leak the Convex error text to the caller", async () => {
+    query.mockRejectedValue(
+      new Error("connect ECONNREFUSED 10.1.2.3:443 backend-abc.convex.cloud")
+    );
+
+    const response = await postDerive(BODY);
+    const body = await response.json();
+
+    // An internal hop's failure names deployment hosts and addresses. It
+    // belongs in the logs, not in a reply to whoever pasted a URL.
+    expect(response.status).toBe(502);
+    expect(JSON.stringify(body)).not.toMatch(
+      /ECONNREFUSED|convex\.cloud|10\.1\.2\.3/
+    );
   });
 
   it("rejects a malformed body before authorizing or dialing", async () => {

--- a/mcpjam-inspector/server/routes/web/__tests__/registry-derive.test.ts
+++ b/mcpjam-inspector/server/routes/web/__tests__/registry-derive.test.ts
@@ -1,0 +1,182 @@
+/**
+ * POST /api/web/registry/derive.
+ *
+ * The ORDER is the contract, and it is the only thing here worth a test:
+ * authorize against the backend BEFORE anything is dialed. `/api/web/*`
+ * bypasses `sessionAuthMiddleware`, so a derive route that probed first and
+ * asked later would be an SSRF oracle with a friendly JSON envelope, however
+ * well guarded the socket underneath is.
+ *
+ * The probe is mocked out entirely — its own behaviour is pinned in
+ * `services/__tests__/registry-derive.test.ts`. What is asserted here is who
+ * gets to reach it, and how each outcome maps onto a status a client can act
+ * on (a refusal is a 400 the client must not retry; an unreachable server is a
+ * 502 it may).
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { Hono } from "hono";
+
+// `vi.hoisted`: the mock factories below are hoisted above every import, so
+// plain `const`s would not exist yet when they run.
+const { deriveRegistryEntry, query } = vi.hoisted(() => ({
+  deriveRegistryEntry: vi.fn(),
+  query: vi.fn(),
+}));
+
+vi.mock("../../../services/registry-derive.js", async (importOriginal) => {
+  const actual =
+    await importOriginal<
+      typeof import("../../../services/registry-derive.js")
+    >();
+  return { ...actual, deriveRegistryEntry };
+});
+
+vi.mock("convex/browser", () => ({
+  ConvexHttpClient: class {
+    setAuth() {}
+    query = query;
+  },
+}));
+
+import registryRoutes from "../registry.js";
+import { mapRuntimeError, webError } from "../errors.js";
+
+function createApp() {
+  const app = new Hono();
+  app.route("/api/web/registry", registryRoutes);
+  app.onError((error, c) => {
+    const routeError = mapRuntimeError(error);
+    return webError(c, routeError.status, routeError.code, routeError.message);
+  });
+  return app;
+}
+
+function postDerive(
+  body: Record<string, unknown>,
+  headers: Record<string, string> = { authorization: "Bearer token-123" }
+) {
+  return createApp().request("/api/web/registry/derive", {
+    method: "POST",
+    headers: { "content-type": "application/json", ...headers },
+    body: JSON.stringify(body),
+  });
+}
+
+const BODY = { url: "https://mcp.example.com/mcp", projectId: "project_1" };
+
+const originalConvexHttpUrl = process.env.CONVEX_HTTP_URL;
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  process.env.CONVEX_HTTP_URL = "https://backend.convex.site";
+  query.mockResolvedValue({ organizationId: "org_1", canAdd: true });
+  deriveRegistryEntry.mockResolvedValue({
+    kind: "derived",
+    facts: {
+      status: "oauth_required",
+      serverName: "example-mcp",
+      serverVersion: "1.4.2",
+      authRequired: true,
+      registrationStrategies: ["dcr"],
+      endpointUrl: "https://mcp.example.com/mcp",
+    },
+  });
+});
+
+afterEach(() => {
+  if (originalConvexHttpUrl === undefined) {
+    delete process.env.CONVEX_HTTP_URL;
+  } else {
+    process.env.CONVEX_HTTP_URL = originalConvexHttpUrl;
+  }
+});
+
+describe("POST /api/web/registry/derive", () => {
+  it("returns the derived facts for a member", async () => {
+    const response = await postDerive(BODY);
+
+    expect(response.status).toBe(200);
+    expect(await response.json()).toMatchObject({
+      status: "oauth_required",
+      serverName: "example-mcp",
+      serverVersion: "1.4.2",
+      authRequired: true,
+      registrationStrategies: ["dcr"],
+    });
+    expect(query).toHaveBeenCalledWith(
+      "registryServers:getOrgRegistryContext",
+      { projectId: "project_1" }
+    );
+  });
+
+  it("refuses a request with no bearer BEFORE asking the backend anything", async () => {
+    const response = await postDerive(BODY, {});
+
+    expect(response.status).toBe(401);
+    expect(query).not.toHaveBeenCalled();
+    expect(deriveRegistryEntry).not.toHaveBeenCalled();
+  });
+
+  it("does not dial anything for a caller who may not add", async () => {
+    query.mockResolvedValue({ organizationId: null, canAdd: false });
+
+    const response = await postDerive(BODY);
+
+    expect(response.status).toBe(403);
+    expect(deriveRegistryEntry).not.toHaveBeenCalled();
+  });
+
+  it("does not dial anything when the backend cannot be reached", async () => {
+    query.mockRejectedValue(new Error("connection reset"));
+
+    const response = await postDerive(BODY);
+
+    expect(response.status).toBe(502);
+    expect(deriveRegistryEntry).not.toHaveBeenCalled();
+  });
+
+  it("rejects a malformed body before authorizing or dialing", async () => {
+    const response = await postDerive({ url: "https://mcp.example.com/mcp" });
+
+    expect(response.status).toBe(400);
+    expect(query).not.toHaveBeenCalled();
+    expect(deriveRegistryEntry).not.toHaveBeenCalled();
+  });
+
+  it("rejects a URL long enough to be an attack rather than an address", async () => {
+    const response = await postDerive({
+      ...BODY,
+      url: `https://example.com/${"x".repeat(4_000)}`,
+    });
+
+    expect(response.status).toBe(400);
+    expect(deriveRegistryEntry).not.toHaveBeenCalled();
+  });
+
+  it("turns an egress refusal into a 400 with generic copy — never a retryable 5xx", async () => {
+    deriveRegistryEntry.mockResolvedValue({ kind: "refused" });
+
+    const response = await postDerive(BODY);
+
+    expect(response.status).toBe(400);
+    const body = await response.json();
+    expect(body.message).toContain("public internet");
+    // The guard's own reason names an address family. It must not travel back
+    // to whoever supplied the URL.
+    expect(JSON.stringify(body)).not.toMatch(/169\.254|loopback|private/i);
+  });
+
+  it("reports a non-MCP answer as 422 and an unreachable server as 502", async () => {
+    deriveRegistryEntry.mockResolvedValue({
+      kind: "not-mcp",
+      detail: "That address answered, but it is not an MCP server.",
+    });
+    expect((await postDerive(BODY)).status).toBe(422);
+
+    deriveRegistryEntry.mockResolvedValue({
+      kind: "unreachable",
+      detail: "ETIMEDOUT",
+    });
+    expect((await postDerive(BODY)).status).toBe(502);
+  });
+});

--- a/mcpjam-inspector/server/routes/web/__tests__/registry-derive.test.ts
+++ b/mcpjam-inspector/server/routes/web/__tests__/registry-derive.test.ts
@@ -131,6 +131,9 @@ describe("POST /api/web/registry/derive", () => {
     const response = await postDerive(BODY);
 
     expect(response.status).toBe(502);
+    const body = await response.json();
+    expect(body.message).toBe("Failed to reach the authorization service.");
+    expect(JSON.stringify(body)).not.toContain("connection reset");
     expect(deriveRegistryEntry).not.toHaveBeenCalled();
   });
 

--- a/mcpjam-inspector/server/routes/web/index.ts
+++ b/mcpjam-inspector/server/routes/web/index.ts
@@ -35,7 +35,6 @@ import serverSkills from "./server-skills.js";
 import caniuse from "./caniuse.js";
 import mrtrContinuation from "./mrtr-continuation.js";
 import registryWeb from "./registry.js";
-import { registryDeriveRateLimitMiddleware } from "../../middleware/registry-derive-rate-limit.js";
 import { fetchRemoteGuestJwks } from "../../utils/guest-session-source.js";
 
 const web = new Hono();
@@ -81,16 +80,10 @@ for (const startsWork of [
   web.use(startsWork, conformanceRunRateLimitMiddleware);
 }
 web.use("/checks/*", bearerAuthMiddleware, guestRateLimitMiddleware);
-// Org-registry derivation dials a server the caller named, so it carries a
-// per-IP ceiling on top of the per-guest one — and the route itself asks the
-// backend whether this caller may add to the project's organization BEFORE
-// any of that egress is spent.
-web.use(
-  "/registry/*",
-  bearerAuthMiddleware,
-  guestRateLimitMiddleware,
-  registryDeriveRateLimitMiddleware
-);
+// Org-registry derivation carries a per-IP ceiling on top of the per-guest
+// one. The route consumes that bucket only after it asks the backend whether
+// this caller may add to the project's organization and before any egress.
+web.use("/registry/*", bearerAuthMiddleware, guestRateLimitMiddleware);
 // Hosted MRTR continuation resume/cancel (MCP 2026-07-28 §12.5). Bearer +
 // guest rate limit like every MCP-operation route; the resume path re-drives a
 // tool/prompt/resource leg against a freshly-authorized manager.

--- a/mcpjam-inspector/server/routes/web/index.ts
+++ b/mcpjam-inspector/server/routes/web/index.ts
@@ -34,6 +34,8 @@ import skills from "./skills.js";
 import serverSkills from "./server-skills.js";
 import caniuse from "./caniuse.js";
 import mrtrContinuation from "./mrtr-continuation.js";
+import registryWeb from "./registry.js";
+import { registryDeriveRateLimitMiddleware } from "../../middleware/registry-derive-rate-limit.js";
 import { fetchRemoteGuestJwks } from "../../utils/guest-session-source.js";
 
 const web = new Hono();
@@ -79,6 +81,16 @@ for (const startsWork of [
   web.use(startsWork, conformanceRunRateLimitMiddleware);
 }
 web.use("/checks/*", bearerAuthMiddleware, guestRateLimitMiddleware);
+// Org-registry derivation dials a server the caller named, so it carries a
+// per-IP ceiling on top of the per-guest one — and the route itself asks the
+// backend whether this caller may add to the project's organization BEFORE
+// any of that egress is spent.
+web.use(
+  "/registry/*",
+  bearerAuthMiddleware,
+  guestRateLimitMiddleware,
+  registryDeriveRateLimitMiddleware
+);
 // Hosted MRTR continuation resume/cancel (MCP 2026-07-28 §12.5). Bearer +
 // guest rate limit like every MCP-operation route; the resume path re-drives a
 // tool/prompt/resource leg against a freshly-authorized manager.
@@ -136,6 +148,7 @@ web.route("/chat-history", chatHistory);
 web.route("/conformance", conformanceWeb);
 web.route("/checks", checks);
 web.route("/mrtr", mrtrContinuation);
+web.route("/registry", registryWeb);
 // `/computers/terminal` (the WS) is registered on the root app in
 // server/index.ts — only /config and /exec live on this sub-router.
 web.route("/computers", computers);

--- a/mcpjam-inspector/server/routes/web/registry.ts
+++ b/mcpjam-inspector/server/routes/web/registry.ts
@@ -29,6 +29,7 @@ import {
 } from "./errors.js";
 import { handleRoute } from "./auth.js";
 import { getInspectorClientRuntimeConfig } from "../../env.js";
+import { logger } from "../../utils/logger.js";
 import {
   deriveRegistryEntry,
   EGRESS_REFUSAL_MESSAGE,
@@ -72,12 +73,17 @@ async function assertCanAddToOrgRegistry(
       { projectId } as never
     )) as { organizationId: string | null; canAdd: boolean };
   } catch (error) {
+    // The Convex error text is an INTERNAL hop's failure — a deployment URL, a
+    // function name, a stack fragment. It belongs in the logs, not in a
+    // response to whoever pasted a URL. Fixed copy out, detail recorded here.
+    logger.error("Org registry authorization check failed", {
+      projectId,
+      error: error instanceof Error ? error.message : String(error),
+    });
     throw new WebRouteError(
       502,
       ErrorCode.SERVER_UNREACHABLE,
-      `Failed to reach the authorization service: ${
-        error instanceof Error ? error.message : String(error)
-      }`
+      "Couldn't check your organization permissions right now. Try again in a moment."
     );
   }
 

--- a/mcpjam-inspector/server/routes/web/registry.ts
+++ b/mcpjam-inspector/server/routes/web/registry.ts
@@ -1,0 +1,136 @@
+/**
+ * The org registry's server-side half: derive an entry from a pasted URL.
+ *
+ * One route, and the ORDER inside it is the whole design:
+ *
+ *   1. bearer → 2. authorize against the backend → 3. rate limit → 4. probe
+ *
+ * Step 2 is not a formality. `/api/web/*` bypasses `sessionAuthMiddleware`
+ * (see `server/index.ts`), so a route in this family is only as authenticated
+ * as it makes itself — and a derive endpoint that skipped it would be an SSRF
+ * oracle with a nice JSON envelope, however well guarded the socket underneath
+ * is. `bearerAuthMiddleware` proves there IS a session; the backend call
+ * proves that session may add to THIS project's organization. Both, before
+ * anything is dialed.
+ *
+ * Step 3 sits between them for the same reason it does on the handoff family:
+ * membership entitles a person to add entries, not to spend our egress in a
+ * loop.
+ */
+import { Hono } from "hono";
+import { z } from "zod";
+import { ConvexHttpClient } from "convex/browser";
+import {
+  assertBearerToken,
+  ErrorCode,
+  parseWithSchema,
+  readJsonBody,
+  WebRouteError,
+} from "./errors.js";
+import { handleRoute } from "./auth.js";
+import { getInspectorClientRuntimeConfig } from "../../env.js";
+import {
+  deriveRegistryEntry,
+  EGRESS_REFUSAL_MESSAGE,
+} from "../../services/registry-derive.js";
+
+const registry = new Hono();
+
+const deriveSchema = z.strictObject({
+  // Bounded before it reaches a URL parser or a socket. 2048 is the
+  // conventional practical URL ceiling; a longer one is not a server address
+  // anyone typed.
+  url: z.string().trim().min(1).max(2048),
+  projectId: z.string().trim().min(1),
+});
+
+/**
+ * "May this caller add to this project's organization?" — asked of the
+ * backend, with the caller's OWN bearer, so the answer is the backend's and
+ * not this process's guess.
+ */
+async function assertCanAddToOrgRegistry(
+  bearerToken: string,
+  projectId: string
+): Promise<void> {
+  const { convexUrl } = getInspectorClientRuntimeConfig();
+  if (!convexUrl) {
+    throw new WebRouteError(
+      500,
+      ErrorCode.INTERNAL_ERROR,
+      "Server missing Convex configuration"
+    );
+  }
+
+  const client = new ConvexHttpClient(convexUrl);
+  client.setAuth(bearerToken);
+
+  let context: { organizationId: string | null; canAdd: boolean };
+  try {
+    context = (await client.query(
+      "registryServers:getOrgRegistryContext" as never,
+      { projectId } as never
+    )) as { organizationId: string | null; canAdd: boolean };
+  } catch (error) {
+    throw new WebRouteError(
+      502,
+      ErrorCode.SERVER_UNREACHABLE,
+      `Failed to reach the authorization service: ${
+        error instanceof Error ? error.message : String(error)
+      }`
+    );
+  }
+
+  if (!context?.canAdd) {
+    // One answer for "not a member", "guest role" and "no such project". A
+    // caller who cannot add has no business learning which of those it was.
+    throw new WebRouteError(
+      403,
+      ErrorCode.FORBIDDEN,
+      "You do not have permission to add servers to this organization's registry."
+    );
+  }
+}
+
+// POST /api/web/registry/derive
+registry.post("/derive", async (c) =>
+  handleRoute(c, async () => {
+    const bearerToken = assertBearerToken(c);
+    const body = parseWithSchema(deriveSchema, await readJsonBody(c));
+    await assertCanAddToOrgRegistry(bearerToken, body.projectId);
+
+    // Loopback is never allowed here, whatever the deployment is: an org entry
+    // is shared with everyone in the org, and an address that only resolves on
+    // one machine is not a thing to share. The backend refuses to store one
+    // too — this just means the dialog says so before the probe rather than
+    // after.
+    const outcome = await deriveRegistryEntry({ url: body.url });
+
+    switch (outcome.kind) {
+      case "derived":
+        return outcome.facts;
+      case "refused":
+        // 400, not 502: the URL is the problem and it will be the problem
+        // next time. The client must not retry this.
+        throw new WebRouteError(
+          400,
+          ErrorCode.VALIDATION_ERROR,
+          EGRESS_REFUSAL_MESSAGE
+        );
+      case "not-mcp":
+        throw new WebRouteError(
+          422,
+          ErrorCode.VALIDATION_ERROR,
+          outcome.detail
+        );
+      case "unreachable":
+        throw new WebRouteError(
+          502,
+          ErrorCode.SERVER_UNREACHABLE,
+          outcome.detail
+        );
+    }
+  })
+);
+
+export default registry;

--- a/mcpjam-inspector/server/routes/web/registry.ts
+++ b/mcpjam-inspector/server/routes/web/registry.ts
@@ -28,8 +28,9 @@ import {
   WebRouteError,
 } from "./errors.js";
 import { handleRoute } from "./auth.js";
+import { consumeRegistryDeriveRateLimit } from "../../middleware/registry-derive-rate-limit.js";
 import { getInspectorClientRuntimeConfig } from "../../env.js";
-import { logger } from "../../utils/logger.js";
+import { reportRouteFailure } from "../../utils/route-error-report.js";
 import {
   deriveRegistryEntry,
   EGRESS_REFUSAL_MESSAGE,
@@ -73,17 +74,14 @@ async function assertCanAddToOrgRegistry(
       { projectId } as never
     )) as { organizationId: string | null; canAdd: boolean };
   } catch (error) {
-    // The Convex error text is an INTERNAL hop's failure — a deployment URL, a
-    // function name, a stack fragment. It belongs in the logs, not in a
-    // response to whoever pasted a URL. Fixed copy out, detail recorded here.
-    logger.error("Org registry authorization check failed", {
-      projectId,
-      error: error instanceof Error ? error.message : String(error),
+    reportRouteFailure("Org registry authorization lookup failed", error, {
+      source: "web.registry.authorization",
+      hop: "mcpjam_internal",
     });
     throw new WebRouteError(
       502,
       ErrorCode.SERVER_UNREACHABLE,
-      "Couldn't check your organization permissions right now. Try again in a moment."
+      "Failed to reach the authorization service."
     );
   }
 
@@ -104,6 +102,8 @@ registry.post("/derive", async (c) =>
     const bearerToken = assertBearerToken(c);
     const body = parseWithSchema(deriveSchema, await readJsonBody(c));
     await assertCanAddToOrgRegistry(bearerToken, body.projectId);
+    const rateLimitResponse = consumeRegistryDeriveRateLimit(c);
+    if (rateLimitResponse) return rateLimitResponse;
 
     // Loopback is never allowed here, whatever the deployment is: an org entry
     // is shared with everyone in the org, and an address that only resolves on

--- a/mcpjam-inspector/server/services/__tests__/registry-derive.test.ts
+++ b/mcpjam-inspector/server/services/__tests__/registry-derive.test.ts
@@ -1,0 +1,241 @@
+/**
+ * Deriving an org-registry entry from a pasted URL.
+ *
+ * Two things are worth pinning here and the rest follows from them.
+ *
+ * An EGRESS REFUSAL must never come back as "try again". The prober swallows
+ * whatever `fetchFn` throws into `status: "error"`, which reads as a transient
+ * failure — so a refusal recovered out of band has to outrank it, or an SSRF
+ * attempt lands on a retry schedule with a friendly spinner. That ordering
+ * lives in `probeThroughEgressGuard`; these tests assert this module keeps it.
+ *
+ * And `serverInfo` is arbitrary JSON from a stranger. Whatever it contains
+ * ends up on a card every member of an organization sees, so a non-string name
+ * is absent rather than "[object Object]", and a very long one is cut.
+ *
+ * The prober and the guarded fetch are injected: no socket, no DNS.
+ */
+import { describe, expect, it, vi } from "vitest";
+import type { ProbeMcpServerResult } from "@mcpjam/sdk";
+import { createGuardedFetch } from "../../utils/hosted-egress-guard.js";
+import { deriveRegistryEntry } from "../registry-derive.js";
+
+function probe(overrides: Partial<ProbeMcpServerResult>): ProbeMcpServerResult {
+  return {
+    url: "https://example.com/mcp",
+    protocolVersion: "2025-11-25",
+    status: "ready",
+    transport: { attempts: [] },
+    oauth: {
+      required: false,
+      optional: false,
+      registrationStrategies: [],
+    },
+    ...overrides,
+  } as ProbeMcpServerResult;
+}
+
+function probeReturning(
+  result: ProbeMcpServerResult
+): typeof import("@mcpjam/sdk").probeMcpServer {
+  return (async () => result) as unknown as typeof import("@mcpjam/sdk").probeMcpServer;
+}
+
+/** The real `probeMcpServer`'s behaviour: it CATCHES what `fetchFn` throws and
+ *  reports it as `status: "error"`. */
+function probeThroughFetch(): typeof import("@mcpjam/sdk").probeMcpServer {
+  return (async (config: { url: string; fetchFn?: typeof fetch }) => {
+    try {
+      await config.fetchFn?.(config.url, { method: "POST" });
+    } catch (error) {
+      return probe({
+        status: "error",
+        error: error instanceof Error ? error.message : String(error),
+      });
+    }
+    return probe({ status: "ready" });
+  }) as unknown as typeof import("@mcpjam/sdk").probeMcpServer;
+}
+
+describe("deriveRegistryEntry", () => {
+  it("reads name, version and title off an open server", async () => {
+    const outcome = await deriveRegistryEntry(
+      { url: "https://example.com/mcp" },
+      {
+        probeServer: probeReturning(
+          probe({
+            status: "ready",
+            initialize: {
+              serverInfo: {
+                name: "example-mcp",
+                version: "1.4.2",
+                title: "Example",
+              },
+            },
+          })
+        ),
+      }
+    );
+
+    expect(outcome).toEqual({
+      kind: "derived",
+      facts: {
+        status: "ready",
+        serverName: "example-mcp",
+        serverVersion: "1.4.2",
+        title: "Example",
+        authRequired: false,
+        registrationStrategies: [],
+        endpointUrl: "https://example.com/mcp",
+      },
+    });
+  });
+
+  it("carries the auth posture off an OAuth challenge", async () => {
+    const outcome = await deriveRegistryEntry(
+      { url: "https://example.com/mcp" },
+      {
+        probeServer: probeReturning(
+          probe({
+            status: "oauth_required",
+            oauth: {
+              required: true,
+              optional: false,
+              registrationStrategies: ["dcr", "cimd"],
+            },
+          })
+        ),
+      }
+    );
+
+    expect(outcome).toMatchObject({
+      kind: "derived",
+      facts: {
+        status: "oauth_required",
+        authRequired: true,
+        registrationStrategies: ["dcr", "cimd"],
+      },
+    });
+  });
+
+  it("reports the endpoint the probe actually reached, not the one pasted", async () => {
+    const outcome = await deriveRegistryEntry(
+      { url: "https://example.com/mcp" },
+      {
+        probeServer: probeReturning(
+          probe({ url: "https://example.com/mcp/v1", status: "ready" })
+        ),
+      }
+    );
+
+    expect(outcome).toMatchObject({
+      kind: "derived",
+      facts: { endpointUrl: "https://example.com/mcp/v1" },
+    });
+  });
+
+  it.each([
+    ["a non-string name", { name: { evil: true }, version: "1.0.0" }],
+    ["no serverInfo at all", undefined],
+    ["a non-object serverInfo", "example"],
+  ])("does not put %s on the card", async (_label, serverInfo) => {
+    const outcome = await deriveRegistryEntry(
+      { url: "https://example.com/mcp" },
+      {
+        probeServer: probeReturning(
+          probe({ status: "ready", initialize: { serverInfo } })
+        ),
+      }
+    );
+
+    expect(outcome).toMatchObject({ kind: "derived" });
+    if (outcome.kind !== "derived") throw new Error("unreachable");
+    expect(outcome.facts.serverName).toBeUndefined();
+  });
+
+  it("bounds a server name long enough to be a denial of a card", async () => {
+    const outcome = await deriveRegistryEntry(
+      { url: "https://example.com/mcp" },
+      {
+        probeServer: probeReturning(
+          probe({
+            status: "ready",
+            initialize: { serverInfo: { name: "x".repeat(5_000) } },
+          })
+        ),
+      }
+    );
+
+    if (outcome.kind !== "derived") throw new Error("unreachable");
+    expect(outcome.facts.serverName).toHaveLength(200);
+  });
+
+  it("refuses a literal private address before any socket exists", async () => {
+    const probeServer = vi.fn();
+    const outcome = await deriveRegistryEntry(
+      { url: "http://169.254.169.254/mcp" },
+      { probeServer: probeServer as never }
+    );
+
+    expect(outcome).toEqual({ kind: "refused" });
+    expect(probeServer).not.toHaveBeenCalled();
+  });
+
+  it("refuses a plaintext probe to a public host", async () => {
+    const outcome = await deriveRegistryEntry(
+      { url: "http://example.com/mcp" },
+      { probeServer: probeReturning(probe({ status: "ready" })) }
+    );
+
+    expect(outcome).toEqual({ kind: "refused" });
+  });
+
+  it("refuses — never 'unreachable' — a name that only turns private once DNS answers", async () => {
+    const baseFetch = vi.fn();
+    const outcome = await deriveRegistryEntry(
+      { url: "https://evil.example/mcp" },
+      {
+        probeServer: probeThroughFetch(),
+        fetchFn: createGuardedFetch({
+          hosted: true,
+          resolver: async (hostname) =>
+            hostname === "evil.example"
+              ? ["169.254.169.254"]
+              : ["93.184.216.34"],
+          baseFetch: baseFetch as unknown as typeof fetch,
+        }),
+      }
+    );
+
+    // The prober turned the guard's throw into `status: "error"`. Reporting
+    // that as retryable would put an SSRF attempt on a retry schedule.
+    expect(outcome).toEqual({ kind: "refused" });
+    expect(baseFetch).not.toHaveBeenCalled();
+  });
+
+  it("calls a server that answers with non-MCP terminal, not retryable", async () => {
+    const outcome = await deriveRegistryEntry(
+      { url: "https://example.com/mcp" },
+      {
+        probeServer: probeReturning(
+          probe({ status: "reachable", error: "HTTP 200 text/html" })
+        ),
+      }
+    );
+
+    expect(outcome).toMatchObject({ kind: "not-mcp" });
+  });
+
+  it("calls a server that did not answer unreachable", async () => {
+    const outcome = await deriveRegistryEntry(
+      { url: "https://example.com/mcp" },
+      {
+        probeServer: probeReturning(
+          probe({ status: "error", error: "ETIMEDOUT" })
+        ),
+      }
+    );
+
+    expect(outcome).toEqual({ kind: "unreachable", detail: "ETIMEDOUT" });
+  });
+});

--- a/mcpjam-inspector/server/services/registry-derive.ts
+++ b/mcpjam-inspector/server/services/registry-derive.ts
@@ -1,0 +1,151 @@
+/**
+ * Derive an org-registry entry from a pasted URL.
+ *
+ * The paste-a-link door into an organization's own registry: a member types an
+ * address, and everything the entry needs — display name, version, whether it
+ * wants OAuth, whether it can register a client dynamically — is read off the
+ * live server rather than typed. Typing those by hand is how a shelf fills up
+ * with entries that disagree with the servers they point at.
+ *
+ * TWO THINGS THIS MODULE DELIBERATELY DOES NOT DO.
+ *
+ * It does not dial anything itself. Every socket goes through
+ * `probeThroughEgressGuard`, the same guarded probe the connection-request
+ * preflight uses, so the SSRF ordering (pinned DNS, revalidated redirects, a
+ * refusal that OUTRANKS the probe's own "just an error") is written once. A
+ * second module that dialed a user-supplied URL is exactly what that module's
+ * header rules out.
+ *
+ * And it does not decide who may ask. The route does that first, against the
+ * backend, before this is ever called — an unauthenticated derive endpoint is
+ * an SSRF oracle with a nice JSON envelope, however well guarded the socket is.
+ */
+import type { ProbeMcpServerResult } from "@mcpjam/sdk";
+import {
+  DISCOVERY_TIMEOUT_MS,
+  probeThroughEgressGuard,
+  type RunDiscoveryPreflightDependencies,
+} from "./server-connection-discovery.js";
+
+/** What the add dialog prefills itself from. */
+export interface DerivedServerFacts {
+  /**
+   * `ready` — initialize succeeded with no credential; the entry is open.
+   * `oauth_required` — the server challenged; the entry is an OAuth entry.
+   *
+   * Those are the only two an entry can be created from. A server that
+   * answered but is not MCP, and one that did not answer at all, are refusals
+   * rather than facts.
+   */
+  status: "ready" | "oauth_required";
+  serverName?: string;
+  serverVersion?: string;
+  title?: string;
+  authRequired: boolean;
+  registrationStrategies: Array<"preregistered" | "dcr" | "cimd">;
+  /** The URL the probe actually talked to. */
+  endpointUrl: string;
+}
+
+export type DeriveOutcome =
+  | { kind: "derived"; facts: DerivedServerFacts }
+  /**
+   * The egress guard said no. NEVER RETRIED and never explained in detail: the
+   * guard's own message names the reason it refused, and echoing it back to
+   * whoever supplied the URL turns a refusal into a network-mapping oracle.
+   * One generic sentence, and the request is over.
+   */
+  | { kind: "refused" }
+  /** Nobody learned anything — DNS, TLS, a stall. Trying again is reasonable. */
+  | { kind: "unreachable"; detail: string }
+  /** The host answered and what it said was not MCP. Retrying cannot fix it. */
+  | { kind: "not-mcp"; detail: string };
+
+/** The copy a refusal shows. Says what happened; names nothing. */
+export const EGRESS_REFUSAL_MESSAGE =
+  "That address can't be reached from MCPJam. Organization registry entries must point at a server on the public internet, over HTTPS.";
+
+/**
+ * `serverInfo` is `unknown` on the probe result — it is whatever the target
+ * put in its initialize response, which is to say arbitrary JSON from a
+ * stranger. Read the three fields we want and ignore the rest; a non-string
+ * `name` is absent, not a crash and not an object rendered as "[object
+ * Object]" in somebody's registry.
+ */
+function readServerInfo(serverInfo: unknown): {
+  name?: string;
+  version?: string;
+  title?: string;
+} {
+  if (!serverInfo || typeof serverInfo !== "object") return {};
+  const info = serverInfo as Record<string, unknown>;
+  const str = (value: unknown): string | undefined => {
+    if (typeof value !== "string") return undefined;
+    const trimmed = value.trim();
+    // Bounded because these land in a shelf entry every member of the org
+    // sees; a server that returns a novel for its name does not get to set
+    // the card's height.
+    return trimmed ? trimmed.slice(0, 200) : undefined;
+  };
+  return {
+    name: str(info.name),
+    version: str(info.version),
+    title: str(info.title),
+  };
+}
+
+function factsFromProbe(probe: ProbeMcpServerResult): DeriveOutcome {
+  switch (probe.status) {
+    case "ready":
+    case "oauth_required": {
+      const info = readServerInfo(probe.initialize?.serverInfo);
+      return {
+        kind: "derived",
+        facts: {
+          status: probe.status,
+          serverName: info.name,
+          serverVersion: info.version,
+          title: info.title,
+          authRequired: probe.oauth.required,
+          registrationStrategies: probe.oauth.registrationStrategies,
+          endpointUrl: probe.url,
+        },
+      };
+    }
+    case "reachable":
+      return {
+        kind: "not-mcp",
+        detail:
+          probe.error ??
+          "That address answered, but it is not an MCP server (no initialize handshake).",
+      };
+    case "error":
+      return {
+        kind: "unreachable",
+        detail: probe.error ?? "Could not reach that server.",
+      };
+  }
+}
+
+export async function deriveRegistryEntry(
+  input: { url: string; allowLoopback?: boolean; timeoutMs?: number },
+  dependencies: RunDiscoveryPreflightDependencies = {}
+): Promise<DeriveOutcome> {
+  const guarded = await probeThroughEgressGuard(
+    {
+      serverUrl: input.url,
+      allowLoopback: input.allowLoopback,
+      timeoutMs: input.timeoutMs ?? DISCOVERY_TIMEOUT_MS,
+    },
+    dependencies
+  );
+
+  switch (guarded.kind) {
+    case "refused":
+      return { kind: "refused" };
+    case "unreachable":
+      return { kind: "unreachable", detail: guarded.detail };
+    case "probed":
+      return factsFromProbe(guarded.probe);
+  }
+}

--- a/mcpjam-inspector/server/services/server-connection-discovery.ts
+++ b/mcpjam-inspector/server/services/server-connection-discovery.ts
@@ -54,7 +54,7 @@ export type DiscoveredAuthMethod = "none" | "oauth" | "unsupported";
  * happened to construct it first.
  */
 function createDefaultDiscoveryFetch(
-  input: RunDiscoveryPreflightInput
+  input: RunDiscoveryPreflightInput,
 ): typeof fetch {
   return createPinnedFetch({
     allowLoopback: input.allowLoopback === true,
@@ -277,6 +277,59 @@ export interface RunDiscoveryPreflightDependencies {
 /**
  * Run one bounded, unauthenticated preflight and classify it.
  *
+ * The dialing — and every SSRF decision in it — belongs to
+ * `probeThroughEgressGuard` below. All that is left here is the mapping from
+ * "what the target did" to "who owns the request next", which
+ * `classifyDiscoveryResult` owns in turn. A `refused` guard verdict is
+ * TERMINAL rather than retryable, because the address a URL names does not
+ * become public on the next attempt.
+ */
+export async function runDiscoveryPreflight(
+  input: RunDiscoveryPreflightInput,
+  dependencies: RunDiscoveryPreflightDependencies = {},
+): Promise<DiscoveryOutcome> {
+  const guarded = await probeThroughEgressGuard(input, dependencies);
+  switch (guarded.kind) {
+    case "refused":
+      return {
+        kind: "terminal",
+        errorCode: guarded.errorCode,
+        detail: guarded.detail,
+      };
+    case "unreachable":
+      return { kind: "retryable", detail: guarded.detail };
+    case "probed":
+      return classifyDiscoveryResult(guarded.probe);
+  }
+}
+
+/**
+ * What one guarded probe attempt produced, BEFORE anyone decides what it
+ * means.
+ *
+ * Split out from `runDiscoveryPreflight` because a second caller needs the
+ * probe itself, not the discovery verdict: the org-registry derive route reads
+ * the server's name, version and registration strategies off it. The
+ * alternative — a second module that dials a user-supplied URL — is the one
+ * thing this file's header rules out, because the SSRF ordering below is
+ * subtle enough that two copies would drift and only one of them would be
+ * fixed.
+ *
+ * The three arms carry the security decision, and only the naming is new:
+ *
+ *   `refused`     — the egress guard said no. TERMINAL everywhere: the address
+ *                   a URL names does not become public on the next attempt.
+ *   `unreachable` — nobody learned anything (DNS blip, stall, deadline).
+ *   `probed`      — the target answered; what it said is the caller's to read.
+ */
+export type GuardedProbeResult =
+  | { kind: "probed"; probe: ProbeMcpServerResult }
+  | { kind: "refused"; errorCode: string; detail: string }
+  | { kind: "unreachable"; detail: string };
+
+/**
+ * Run one bounded, unauthenticated probe through the egress guard.
+ *
  * SSRF DEFENCE IS TWO LAYERS, AND ONE ALONE IS NOT ENOUGH.
  *
  * `assertOutboundOAuthUrlAllowed` is a pure RFC 6890 classifier over the URL's
@@ -311,10 +364,10 @@ export interface RunDiscoveryPreflightDependencies {
  *
  * No credential is ever attached. Discovery asks what a stranger sees.
  */
-export async function runDiscoveryPreflight(
+export async function probeThroughEgressGuard(
   input: RunDiscoveryPreflightInput,
   dependencies: RunDiscoveryPreflightDependencies = {},
-): Promise<DiscoveryOutcome> {
+): Promise<GuardedProbeResult> {
   const probeServer = dependencies.probeServer ?? probeMcpServer;
 
   try {
@@ -331,7 +384,7 @@ export async function runDiscoveryPreflight(
     // in: `http://127.0.0.1:3000/mcp` IS the local-development product.
     if (url.protocol !== "https:" && !isLoopbackOAuthUrl(input.serverUrl)) {
       return {
-        kind: "terminal",
+        kind: "refused",
         errorCode: "URL_NOT_ALLOWED",
         detail: `Refusing a plaintext discovery probe to public host "${url.hostname}"; MCP servers must be reachable over HTTPS.`,
       };
@@ -339,7 +392,7 @@ export async function runDiscoveryPreflight(
   } catch (error) {
     if (error instanceof OAuthOutboundUrlBlockedError) {
       return {
-        kind: "terminal",
+        kind: "refused",
         errorCode: "URL_NOT_ALLOWED",
         // The guard's own message names the reason (invalid-url,
         // invalid-scheme, private-host) without echoing anything the caller
@@ -382,11 +435,11 @@ export async function runDiscoveryPreflight(
    * after the race, so the deadline and the generic catch could both mask a
    * refusal.
    */
-  const refusalOutcome = (): DiscoveryOutcome | null =>
+  const refusalOutcome = (): GuardedProbeResult | null =>
     refusal.blocked === null
       ? null
       : {
-          kind: "terminal",
+          kind: "refused",
           errorCode: "URL_NOT_ALLOWED",
           detail: refusal.blocked.message,
         };
@@ -425,7 +478,7 @@ export async function runDiscoveryPreflight(
       // again.
       return (
         refusalOutcome() ?? {
-          kind: "retryable",
+          kind: "unreachable",
           detail: `Discovery did not finish within ${deadlineMs}ms`,
         }
       );
@@ -434,20 +487,20 @@ export async function runDiscoveryPreflight(
   } catch (error) {
     if (error instanceof BlockedEgressTargetError) {
       return {
-        kind: "terminal",
+        kind: "refused",
         errorCode: "URL_NOT_ALLOWED",
         detail: error.message,
       };
     }
     if (error instanceof EgressResolutionError) {
-      return refusalOutcome() ?? { kind: "retryable", detail: error.message };
+      return refusalOutcome() ?? { kind: "unreachable", detail: error.message };
     }
     // An unexpected throw means we learned nothing about the target, which is
     // the definition of retryable here — never a discovery result. A refusal
     // already on record still outranks it.
     return (
       refusalOutcome() ?? {
-        kind: "retryable",
+        kind: "unreachable",
         detail: error instanceof Error ? error.message : String(error),
       }
     );
@@ -462,5 +515,5 @@ export async function runDiscoveryPreflight(
     return recorded;
   }
 
-  return classifyDiscoveryResult(probe);
+  return { kind: "probed", probe };
 }

--- a/mcpjam-inspector/shared/analytics-events.ts
+++ b/mcpjam-inspector/shared/analytics-events.ts
@@ -262,6 +262,13 @@ export const ANALYTICS_EVENTS = {
   mcpjam_agent_tour_launched: { source: "client" },
   move_server_to_project_clicked: { source: "client" },
   /**
+   * A connected server was offered to the organization's registry from the
+   * server card's menu. Fires on the CLICK, before the eligibility refusal —
+   * how often people reach for it and are told a header-authed server cannot
+   * be shared is the thing worth knowing.
+   */
+  share_server_to_org_registry_clicked: { source: "client" },
+  /**
    * A callback arrived with a pending server name but no stored flow session,
    * so it could not be completed and the user was asked to reauthorize.
    *


### PR DESCRIPTION
The Inspector half of org subregistries — steps **I1**, **I2** and **I3**, one commit each. Depends on [mcpjam-backend#1064](https://github.com/MCPJam/mcpjam-backend/pull/1064), which must deploy first: this reads `registryServers:listOrgRegistryServers`, `getOrgRegistryContext`, `addOrgRegistryServer`, `updateOrgRegistryServer` and `removeOrgRegistryServer`.

Everything rides the existing `registry-enabled` flag — the tab does not exist without it.

## I1 — derive an entry from a pasted URL

A member types an address; the Inspector probes it and the name, version and auth posture come off the live server rather than out of someone's memory.

**The dialing is not new code.** `probeThroughEgressGuard` is extracted from `runDiscoveryPreflight` — same function, split so a second caller can read the probe itself instead of the discovery verdict. The SSRF ordering it carries (pinned DNS, revalidated redirects, and a refusal recorded out of band that **outranks** the probe's own "just an error") is subtle enough that two copies would drift and only one would get fixed. `runDiscoveryPreflight` now maps three arms onto its own taxonomy and behaves identically; its 31 existing tests are unchanged and passing.

**The route's order is the design:** bearer → authorize against the backend → rate limit → probe. `/api/web/*` bypasses `sessionAuthMiddleware`, so a route in this family is only as authenticated as it makes itself; a derive endpoint that skipped that step would be an SSRF oracle with a nice JSON envelope however well guarded the socket is. Authorization asks the backend with the **caller's own bearer**, so the answer is the backend's rather than this process's guess.

An egress refusal is a **400 with one generic sentence, never retried** — the guard's own message names the address family it refused, and handing that back to whoever supplied the URL turns a refusal into a network-mapping oracle. Non-MCP answer → 422. No answer → 502; only the last is worth retrying. The per-IP limiter is not what stands between a stranger and our egress (authorization is) — it bounds how much egress one *member* can spend.

## I2 — the organization's shelf, in the Registry tab

A "Your organization" section above the curated grid, with connect, disconnect, edit and remove.

**The status join is provenance-first**, and that is why this is a separate hook rather than a branch inside `useRegistryServers`. The curated hook matches a card to a running server by display name — safe there, because only its own connect mutation mints those names. Not safe here: promote creates an entry *from* a server that already exists, so the entry and that server share a display name in the project it came from. A name join would show the card connected in a project that never installed it, and the Disconnect it offered would delete the user's original server. So a card is added/connected only when this project holds a `registryServerConnections` row for it, and the live server is found by **that row's** `serverName`. Disconnect acts through the provenance row or does nothing.

Connect is **mutation-first** (the directory flow's ordering, not the curated one's): membership, project-belongs-to-org, `servers` row and provenance all land before anything can redirect the browser into OAuth. The curated flow records provenance from a later effect and loses it whenever OAuth navigates away mid-flight.

No star control on these cards — stars are the identity of a consolidated *public* card, an org entry has no `registryCardKey`, and the backend's star mutation refuses a synthetic key. The section sits behind its **own error boundary**: it is the only part of the tab reading functions the deployed backend may not have yet, a browser can outlive a rollback, and `useQuery` for a missing function throws during render.

## I3 — share a server you already have connected

"Add to org registry" in the server card's menu, injected like "Move to project".

**No probe** — `initializationInfo` already holds what the server said during initialize. `sourceServerId` is what makes the source project show the entry as connected, through the provenance row rather than a shared display name.

Remote HTTP only. A header- or bearer-authed server is **shown and then refused with a sentence**, not hidden: "where did the option go?" is a worse answer than one that says why. The URL is read-only on promote, because `addOrgRegistryServer` refuses a promotion whose URL does not match the source server's own — an editable field there would be one whose every edit is a dead end.

## Testing

New: 12 derive-service tests, 8 derive-route tests, 9 hook tests (the provenance-join matrix in both directions), 8 dialog tests, 5 promote-eligibility tests on `ServerConnectionCard`.

- Full **server** project: 416 files / 6431 tests passing.
- Client suites touched (components, hooks, registry): 93 files / 1120 tests passing.
- `npm run typecheck:client` clean.

**One pre-existing failure, not from this branch:** `routes/v1/__tests__/sdk-coverage.test.ts` fails on six `readiness-runs` routes that have no SDK client method. Confirmed identical on a clean checkout of `main`, so it is not this PR's to fix — flagging it rather than silently leaving it red.

## Not in scope

From the plan's Later list: org-view dedup against directory rows, a re-probe/refresh action, header-auth servers, `ui_*` agent tools for org entries (org entries are invisible to agents today, deliberately), SDK/CLI/REST surfaces, editor push, the official-registry mirror, source selector, serving `/v0.1`.

---
_Generated by [Claude Code](https://claude.ai/code/session_01UHCjj8zw77bQ4mPePKbkJp)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Adds a user-supplied-URL probe path (SSRF-adjacent egress) plus org-wide registry mutations and connect/disconnect. Authorization-before-dial and the existing egress guard mitigate this, but mistakes here affect every project in the organization.
> 
> **Overview**
> Adds an organization-owned registry shelf so teams can share remote MCP servers across every project in the org, behind the existing `registry-enabled` flag.
> 
> Members can paste a URL (Inspector probes name, version, and auth posture) or promote an already-connected HTTP server from the Servers tab. Version and auth stay derived, not typed. Promote skips a second probe and records `sourceServerId` so the source project shows as connected via provenance, not display name.
> 
> Connect/disconnect is provenance-first and mutation-first: a card is only “installed” when this project has a `registryServerConnections` row, so disconnect cannot tear down a similarly named original server. The org section sits in its own error boundary so missing backend functions cannot take down the rest of the Registry tab.
> 
> Server-side, `POST /api/web/registry/derive` authorizes org add permission before any egress, reuses `probeThroughEgressGuard` (extracted from discovery preflight), maps refusals to a generic non-retryable 400, and rate-limits per IP in hosted mode. Header/bearer-authed and stdio servers cannot be shared.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3d636ce73da28d96915602d16330d67213a829f6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds an organization shelf to the Registry tab so teams can share MCP servers across projects. Members add by pasting a URL or promoting an existing connection; facts are derived from live servers to avoid drift, and connections join by provenance to prevent accidental disconnects.

- Provenance-first join; mutation-first connect; unresolved provenance shows as loading. Disconnect acts through the provenance row or no-ops.
- Paste/derive: `POST /api/web/registry/derive` authenticates with the caller’s bearer before any egress, applies guest + per-IP limits, probes via the guarded path, and returns 400 (egress refused, no retry), 422 (non-MCP), or 502 (unreachable; sanitized). Add requires a derived snapshot.
- Promote: no probe; reuses `initializationInfo`; records `sourceServerId`; refuses when no source row exists. Remote HTTP only; header/bearer-auth and stdio servers are shown then refused with a reason. URL is read-only.
- UI/hooks: new `useOrgRegistryServers`; org section has its own error boundary and renders even when the curated catalog is empty. “Add to org registry” in server-card menu. Remove asks for confirmation. No star control. Tracks `share_server_to_org_registry_clicked`.
- Servers tab fix: uses `sharedProjectIdForHostScope` and live auth state for org actions.

**Rollout**
- Deploy backend functions first: `registryServers:listOrgRegistryServers`, `getOrgRegistryContext`, `addOrgRegistryServer`, `updateOrgRegistryServer`, `removeOrgRegistryServer`.
- Feature remains behind `registry-enabled`.

<sup>Written for commit ebe3ef497d0d6d48b6b4d49ef857121aba91dbeb. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/MCPJam/inspector/pull/4185?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

