### PR TITLE
fix(organizations): drop unclaimed invites from the actionable org list

### DIFF
--- a/mcpjam-inspector/client/src/hooks/__tests__/useOrganizations.test.tsx
+++ b/mcpjam-inspector/client/src/hooks/__tests__/useOrganizations.test.tsx
@@ -84,6 +84,26 @@ describe("useOrganizationQueries", () => {
       "joined",
     ]);
   });
+
+  // A backend predating isPendingInvite sends no flag; those orgs must survive.
+  it("keeps orgs whose flag is absent or false, drops only true", () => {
+    mockUseQuery.mockReturnValue([
+      { _id: "no-flag", updatedAt: 3 },
+      { _id: "explicit-false", updatedAt: 2, isPendingInvite: false },
+      { _id: "invited", updatedAt: 1, isPendingInvite: true },
+    ]);
+
+    const { result } = renderHook(
+      () => useOrganizationQueries({ isAuthenticated: true }),
+      { wrapper: readyWrapper(true) }
+    );
+
+    expect(result.current.sortedOrganizations.map((o) => o._id)).toEqual([
+      "no-flag",
+      "explicit-false",
+    ]);
+  });
+
   it("does not report loading for unauthenticated actors", () => {
     const { result } = renderHook(() =>
       useOrganizationQueries({ isAuthenticated: false }), {

--- a/mcpjam-inspector/client/src/hooks/__tests__/useOrganizations.test.tsx
+++ b/mcpjam-inspector/client/src/hooks/__tests__/useOrganizations.test.tsx
@@ -68,6 +68,22 @@ describe("useOrganizationQueries", () => {
     ]);
   });
 
+  // Selecting a pending-invite org made the server refuse every org-scoped call.
+  it("excludes pending invites the caller has not claimed", () => {
+    mockUseQuery.mockReturnValue([
+      { _id: "joined", updatedAt: 2, isPendingInvite: false },
+      { _id: "invited", updatedAt: 3, isPendingInvite: true },
+    ]);
+
+    const { result } = renderHook(
+      () => useOrganizationQueries({ isAuthenticated: true }),
+      { wrapper: readyWrapper(true) }
+    );
+
+    expect(result.current.sortedOrganizations.map((o) => o._id)).toEqual([
+      "joined",
+    ]);
+  });
   it("does not report loading for unauthenticated actors", () => {
     const { result } = renderHook(() =>
       useOrganizationQueries({ isAuthenticated: false }), {

--- a/mcpjam-inspector/client/src/hooks/useOrganizations.ts
+++ b/mcpjam-inspector/client/src/hooks/useOrganizations.ts
@@ -15,6 +15,8 @@ export interface Organization {
   updatedAt: number;
   myRole?: string;
   isCreator?: boolean;
+  /** Reachable only via an unclaimed email invite — visible, but not actionable. */
+  isPendingInvite?: boolean;
 }
 
 export const ORGANIZATION_CREATION_LIMIT = 1;
@@ -90,9 +92,12 @@ export function useOrganizationQueries({
   const isLoading =
     isAuthenticated && (!isUserReady || organizations === undefined);
 
+  // Every consumer treats an entry as an org the caller can act in; an unclaimed invite is not.
   const sortedOrganizations = useMemo(() => {
     if (!organizations) return [];
-    return [...organizations].sort((a, b) => b.updatedAt - a.updatedAt);
+    return organizations
+      .filter((org) => org.isPendingInvite !== true)
+      .sort((a, b) => b.updatedAt - a.updatedAt);
   }, [organizations]);
 
   const createdCount = useMemo(


### PR DESCRIPTION
Client half of MCPJam/mcpjam-backend#1071. Sentry [CONVEX-HR](https://mcpjam-gh.sentry.io/issues/CONVEX-HR): 66 events, 5 users, prod, escalating.

## The bug

`getMyOrganizations` surfaces email-keyed pending invites so an invitee can see them, but the server authorizes on a *claimed* membership (`by_org_and_user`, which never matches an invite row). Every consumer of `sortedOrganizations` treats an entry as an org the caller can act in:

- the switcher target (`sidebar-context-switcher`)
- the billing org (`mcpjam-limit-dialog`, `billing-deep-link`)
- the API-key org (`ApiKeysRoute`), the eval org (`sdk-eval-quickstart`)
- and via `effectiveOrganizations` → `validOrganizations`, the set that gates **both** the stored active-org selection (`use-app-state.ts`) and `routeOrganizationId` (`App.tsx`)

An unclaimed invite is none of those. Selecting one made the server refuse every org-scoped call.

`ensureDefaultProject` was the loudest, because its effect only marks the request completed on **success** (`use-project-state.ts`) — so it re-fired on every dependency change. One prod user produced 11 events in 24 minutes.

Note that both org inputs were already validated against `validOrganizations`; the validation was just hollow, because the list itself included orgs the server would refuse.

## The change

Filters `sortedOrganizations` on the `isPendingInvite` flag the backend PR adds. One choke point covers every consumer above.

Deploy order does not matter: without the backend change the flag is `undefined` and nothing is filtered.

## Trade-off worth a look

There is no accept-invite UI — invites are claimed only by the WorkOS login pass. Before this, an invitee saw the org in the switcher and everything failed on entry; now they do not see it at all. That removes a broken affordance, but it also means a pending invite is invisible until claimed. Happy to add an invites surface if you'd rather keep it visible.

## Tests

120 tests green across `useOrganizations`, `sidebar-context-switcher`, `MCPJamLimitDialog`, `use-project-state`, `sdk-eval-quickstart`. The new test was watched failing first. Touched files are typecheck-clean (the repo has pre-existing errors elsewhere in test files).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Drop pending-invite organizations from `sortedOrganizations` so users only see orgs they can act in. Before: pending invites appeared selectable and org-scoped calls failed; now: we filter them out to prevent server refusals and retry loops.

- Filter on backend `isPendingInvite`; only `true` is removed — absent or `false` remain (safe deploy order across repos).
- Single choke point updates all consumers: org switcher, billing selection, API keys, eval quickstart, active-org selection, and routing.
- Add unit tests covering exclusion and the `isPendingInvite` tri-state contract.

<sup>Written for commit 7f594dfb251604e71915b12bfc733b7b77029130. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/MCPJam/inspector/pull/4187?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

