### PR TITLE
cli: freeze the local command contract

### DIFF
--- a/cli/tests/fixtures/local-contract-manifest.json
+++ b/cli/tests/fixtures/local-contract-manifest.json
@@ -1,0 +1,106 @@
+{
+  "frozenTopLevelCommands": [
+    "apps",
+    "compat",
+    "inspector",
+    "mcp",
+    "oauth",
+    "prompts",
+    "protocol",
+    "readiness",
+    "resources",
+    "server",
+    "subscriptions",
+    "tasks",
+    "telemetry",
+    "tools",
+    "xaa"
+  ],
+  "help": {
+    "apps": {
+      "usage": "Usage: mcpjam apps [options] [command]",
+      "subcommands": ["conformance", "render", "session", "conformance-suite"]
+    },
+    "compat": {
+      "usage": "Usage: mcpjam compat [options]",
+      "subcommands": []
+    },
+    "inspector": {
+      "usage": "Usage: mcpjam inspector [options] [command]",
+      "subcommands": ["open", "start", "stop"]
+    },
+    "mcp": {
+      "usage": "Usage: mcpjam mcp [options]",
+      "subcommands": []
+    },
+    "oauth": {
+      "usage": "Usage: mcpjam oauth [options] [command]",
+      "subcommands": [
+        "login",
+        "conformance",
+        "conformance-suite",
+        "metadata",
+        "proxy",
+        "debug-proxy"
+      ]
+    },
+    "prompts": {
+      "usage": "Usage: mcpjam prompts [options] [command]",
+      "subcommands": ["list", "get"]
+    },
+    "protocol": {
+      "usage": "Usage: mcpjam protocol [options] [command]",
+      "subcommands": ["conformance", "conformance-suite"]
+    },
+    "readiness": {
+      "usage": "Usage: mcpjam readiness [options] [command]",
+      "subcommands": ["check", "start", "status", "list", "cancel", "report"]
+    },
+    "resources": {
+      "usage": "Usage: mcpjam resources [options] [command]",
+      "subcommands": ["list", "read", "templates"]
+    },
+    "server": {
+      "usage": "Usage: mcpjam server [options] [command]",
+      "subcommands": [
+        "probe",
+        "doctor",
+        "info",
+        "validate",
+        "ping",
+        "capabilities",
+        "export",
+        "diff"
+      ]
+    },
+    "subscriptions": {
+      "usage": "Usage: mcpjam subscriptions [options] [command]",
+      "subcommands": ["listen"]
+    },
+    "tasks": {
+      "usage": "Usage: mcpjam tasks [options] [command]",
+      "subcommands": [
+        "capabilities",
+        "list",
+        "get",
+        "result",
+        "cancel",
+        "update",
+        "watch",
+        "conformance"
+      ]
+    },
+    "telemetry": {
+      "usage": "Usage: mcpjam telemetry [options] [command]",
+      "subcommands": ["status", "disable", "enable"]
+    },
+    "tools": {
+      "usage": "Usage: mcpjam tools [options] [command]",
+      "subcommands": ["list", "call"]
+    },
+    "xaa": {
+      "usage": "Usage: mcpjam xaa [options] [command]",
+      "subcommands": ["run"]
+    }
+  }
+}

--- a/cli/tests/local-contract.test.ts
+++ b/cli/tests/local-contract.test.ts
@@ -1,0 +1,384 @@
+/**
+ * Freeze the local CLI contract.
+ *
+ * Account-bound commands are moving under `mcpjam cloud`. Local command
+ * paths, accepted/rejected flags, stdout, stderr, exit codes, MCP protocol
+ * identity, and the tool contract are CI-load-bearing and must not change.
+ *
+ * This file owns the manifest at `fixtures/local-contract-manifest.json`.
+ * Re-generate it with `UPDATE_LOCAL_CONTRACT=1 npx tsx --test
+ * tests/local-contract.test.ts` from `cli/` after an intentional local-surface
+ * change. Cloud command churn must not require updating this fixture.
+ */
+import assert from "node:assert/strict";
+import { readFileSync, writeFileSync } from "node:fs";
+import test from "node:test";
+import { fileURLToPath } from "node:url";
+import { Client } from "@modelcontextprotocol/client";
+import { createMcpJamMcpServer } from "../src/lib/mcp-server.js";
+import { runCli } from "./support/cli-run.js";
+
+const FIXTURE_PATH = fileURLToPath(
+  new URL("./fixtures/local-contract-manifest.json", import.meta.url)
+);
+
+export const FROZEN_LOCAL_COMMANDS = [
+  "apps",
+  "compat",
+  "inspector",
+  "mcp",
+  "oauth",
+  "prompts",
+  "protocol",
+  "readiness",
+  "resources",
+  "server",
+  "subscriptions",
+  "tasks",
+  "telemetry",
+  "tools",
+  "xaa",
+] as const;
+
+type FrozenLocalCommand = (typeof FROZEN_LOCAL_COMMANDS)[number];
+
+type HelpContract = {
+  usage: string;
+  subcommands: string[];
+};
+
+type LocalContractManifest = {
+  frozenTopLevelCommands: FrozenLocalCommand[];
+  help: Record<FrozenLocalCommand, HelpContract>;
+};
+
+type LinkedTransport = {
+  onclose?: () => void;
+  onerror?: (error: Error) => void;
+  onmessage?: (message: unknown) => void;
+  start(): Promise<void>;
+  close(): Promise<void>;
+  send(message: unknown): Promise<void>;
+};
+
+function createLinkedTransportPair(): [LinkedTransport, LinkedTransport] {
+  const make = (): LinkedTransport => ({
+    async start() {},
+    async close() {
+      this.onclose?.();
+    },
+    async send() {},
+  });
+
+  const left = make();
+  const right = make();
+  left.send = async (message) => {
+    queueMicrotask(() => right.onmessage?.(message));
+  };
+  right.send = async (message) => {
+    queueMicrotask(() => left.onmessage?.(message));
+  };
+  return [left, right];
+}
+
+function parseUsage(help: string): string {
+  const line = help.split("\n").find((entry) => entry.startsWith("Usage: "));
+  assert.ok(line, `help text has no Usage line:\n${help}`);
+  return line;
+}
+
+function parseCommandNames(help: string): string[] {
+  const marker = "\nCommands:\n";
+  const start = help.indexOf(marker);
+  if (start === -1) {
+    return [];
+  }
+  const names: string[] = [];
+  for (const line of help.slice(start + marker.length).split("\n")) {
+    const match = line.match(
+      /^  ([a-z][\w|-]*)(?: \[options\])?(?: \[[^\]]+\])?\s{2,}/
+    );
+    if (!match) {
+      continue;
+    }
+    const name = match[1].split("|")[0];
+    if (name !== "help") {
+      names.push(name);
+    }
+  }
+  return names;
+}
+
+function parseUsageError(stderr: string): { code: string; message: string } {
+  const payload = JSON.parse(stderr) as {
+    error?: { code?: string; message?: string };
+  };
+  const code = payload.error?.code;
+  const message = payload.error?.message;
+  if (typeof code !== "string" || typeof message !== "string") {
+    throw new Error(`stderr is not a USAGE_ERROR payload:\n${stderr}`);
+  }
+  return { code, message };
+}
+
+async function collectManifest(): Promise<LocalContractManifest> {
+  const root = await runCli(["--help"]);
+  assert.equal(root.exitCode, 0, root.stderr);
+  const rootCommands = new Set(parseCommandNames(root.stdout));
+  for (const name of FROZEN_LOCAL_COMMANDS) {
+    assert.ok(
+      rootCommands.has(name),
+      `frozen local command "${name}" missing from root help`
+    );
+  }
+
+  const help = {} as Record<FrozenLocalCommand, HelpContract>;
+  for (const name of FROZEN_LOCAL_COMMANDS) {
+    const run = await runCli([name, "--help"]);
+    assert.equal(run.exitCode, 0, `${name} --help failed:\n${run.stderr}`);
+    help[name] = {
+      usage: parseUsage(run.stdout),
+      subcommands: parseCommandNames(run.stdout),
+    };
+  }
+
+  return {
+    frozenTopLevelCommands: [...FROZEN_LOCAL_COMMANDS],
+    help,
+  };
+}
+
+function loadManifest(): LocalContractManifest {
+  return JSON.parse(
+    readFileSync(FIXTURE_PATH, "utf8")
+  ) as LocalContractManifest;
+}
+
+test("frozen local command help matches the test-owned manifest", async () => {
+  const actual = await collectManifest();
+  if (process.env.UPDATE_LOCAL_CONTRACT === "1") {
+    writeFileSync(FIXTURE_PATH, `${JSON.stringify(actual, null, 2)}\n`);
+  }
+  assert.deepEqual(actual, loadManifest());
+});
+
+test("local commands reject Cloud credential and project flags", async () => {
+  const cases: Array<{ argv: string[]; unknownOption: string }> = [
+    {
+      argv: [
+        "server",
+        "probe",
+        "--url",
+        "https://example.com/mcp",
+        "--api-key",
+        "sk_test",
+      ],
+      unknownOption: "--api-key",
+    },
+    {
+      argv: [
+        "server",
+        "doctor",
+        "--url",
+        "https://example.com/mcp",
+        "--api-url",
+        "https://app.mcpjam.com/api/v1",
+      ],
+      unknownOption: "--api-url",
+    },
+    {
+      argv: [
+        "server",
+        "probe",
+        "--url",
+        "https://example.com/mcp",
+        "--project",
+        "acme",
+      ],
+      unknownOption: "--project",
+    },
+    {
+      argv: [
+        "tools",
+        "list",
+        "--url",
+        "https://example.com/mcp",
+        "--api-url",
+        "https://app.mcpjam.com/api/v1",
+      ],
+      unknownOption: "--api-url",
+    },
+    {
+      argv: [
+        "tools",
+        "call",
+        "--url",
+        "https://example.com/mcp",
+        "--tool-name",
+        "ping",
+        "--api-key",
+        "sk_test",
+      ],
+      unknownOption: "--api-key",
+    },
+    {
+      argv: [
+        "resources",
+        "list",
+        "--url",
+        "https://example.com/mcp",
+        "--api-key",
+        "sk_test",
+      ],
+      unknownOption: "--api-key",
+    },
+    {
+      argv: [
+        "prompts",
+        "list",
+        "--url",
+        "https://example.com/mcp",
+        "--project",
+        "acme",
+      ],
+      unknownOption: "--project",
+    },
+    {
+      argv: [
+        "oauth",
+        "login",
+        "--url",
+        "https://example.com/mcp",
+        "--api-key",
+        "sk_test",
+      ],
+      unknownOption: "--api-key",
+    },
+    {
+      argv: [
+        "protocol",
+        "conformance",
+        "--url",
+        "https://example.com/mcp",
+        "--api-url",
+        "https://app.mcpjam.com/api/v1",
+      ],
+      unknownOption: "--api-url",
+    },
+    {
+      argv: [
+        "compat",
+        "--url",
+        "https://example.com/mcp",
+        "--api-key",
+        "sk_test",
+      ],
+      unknownOption: "--api-key",
+    },
+    {
+      argv: [
+        "xaa",
+        "run",
+        "--url",
+        "https://example.com/mcp",
+        "--issuer-base-url",
+        "https://issuer.example.com",
+        "--sub",
+        "user-1",
+        "--project",
+        "acme",
+      ],
+      unknownOption: "--project",
+    },
+    {
+      argv: [
+        "readiness",
+        "check",
+        "claude",
+        "https://example.com/mcp",
+        "--api-key",
+        "sk_test",
+      ],
+      unknownOption: "--api-key",
+    },
+    {
+      argv: ["telemetry", "status", "--api-key", "sk_test"],
+      unknownOption: "--api-key",
+    },
+    {
+      argv: ["mcp", "--api-url", "https://app.mcpjam.com/api/v1"],
+      unknownOption: "--api-url",
+    },
+    {
+      argv: [
+        "--api-key",
+        "sk_test",
+        "server",
+        "probe",
+        "--url",
+        "https://example.com/mcp",
+      ],
+      unknownOption: "--api-key",
+    },
+  ];
+
+  for (const { argv, unknownOption } of cases) {
+    const run = await runCli(["--format", "json", ...argv]);
+    assert.equal(run.exitCode, 2, `${argv.join(" ")}\n${run.stderr}`);
+    assert.equal(run.stdout, "", `${argv.join(" ")} wrote stdout`);
+    const error = parseUsageError(run.stderr);
+    assert.equal(error.code, "USAGE_ERROR", argv.join(" "));
+    assert.match(
+      error.message,
+      new RegExp(`unknown option '${unknownOption}'`),
+      `${argv.join(" ")}\n${run.stderr}`
+    );
+  }
+});
+
+test("representative local JSON stdout, stderr, and exit codes stay stable", async () => {
+  const missingUrl = await runCli(["--format", "json", "server", "probe"]);
+  assert.equal(missingUrl.exitCode, 2);
+  assert.equal(missingUrl.stdout, "");
+  assert.deepEqual(parseUsageError(missingUrl.stderr), {
+    code: "USAGE_ERROR",
+    message: "error: required option '--url <url>' not specified",
+  });
+
+  const missingTarget = await runCli(["--format", "json", "tools", "list"]);
+  assert.equal(missingTarget.exitCode, 2);
+  assert.equal(missingTarget.stdout, "");
+  const missingTargetError = parseUsageError(missingTarget.stderr);
+  assert.equal(missingTargetError.code, "USAGE_ERROR");
+  assert.match(missingTargetError.message, /exactly one target/);
+
+  const status = await runCli(["--format", "json", "telemetry", "status"]);
+  assert.equal(status.exitCode, 0, status.stderr);
+  assert.equal(status.stderr, "");
+  const payload = JSON.parse(status.stdout) as {
+    success?: boolean;
+    telemetry?: { enabled?: boolean; disableReason?: string | null };
+  };
+  assert.equal(payload.success, true);
+  assert.equal(payload.telemetry?.enabled, false);
+  assert.equal(payload.telemetry?.disableReason, "MCPJAM_TELEMETRY_DISABLED");
+});
+
+test("local MCP serverInfo.name remains mcpjam", async () => {
+  const handle = createMcpJamMcpServer({
+    version: "0.0.0-test",
+    defaultTimeoutMs: 15_000,
+  });
+  const [clientTransport, serverTransport] = createLinkedTransportPair();
+  const client = new Client({ name: "mcpjam-cli-tests", version: "0.0.0" });
+
+  try {
+    await handle.server.connect(serverTransport as never);
+    await client.connect(clientTransport as never);
+    const serverInfo = client.getServerVersion();
+    assert.equal(serverInfo?.name, "mcpjam");
+  } finally {
+    await client.close().catch(() => undefined);
+    await handle.close();
+  }
+});

--- a/cli/tests/support/cli-run.ts
+++ b/cli/tests/support/cli-run.ts
@@ -1,0 +1,67 @@
+import { main, type CliMainResult } from "../../src/index.js";
+
+export const telemetryDisabled = {
+  env: {
+    ...process.env,
+    MCPJAM_TELEMETRY_DISABLED: "1",
+  },
+};
+
+export async function captureProcessOutput<T>(fn: () => Promise<T>): Promise<{
+  result: T;
+  stdout: string;
+  stderr: string;
+}> {
+  const originalStdoutWrite = process.stdout.write.bind(process.stdout);
+  const originalStderrWrite = process.stderr.write.bind(process.stderr);
+  let stdout = "";
+  let stderr = "";
+
+  // String chunks are CLI output; binary chunks are the node:test runner's
+  // child-process protocol and must keep flowing to the real streams.
+  process.stdout.write = ((chunk: string | Uint8Array, ...rest: unknown[]) => {
+    if (typeof chunk === "string") {
+      stdout += chunk;
+      return true;
+    }
+    return (originalStdoutWrite as (...args: unknown[]) => boolean)(
+      chunk,
+      ...rest
+    );
+  }) as typeof process.stdout.write;
+  process.stderr.write = ((chunk: string | Uint8Array, ...rest: unknown[]) => {
+    if (typeof chunk === "string") {
+      stderr += chunk;
+      return true;
+    }
+    return (originalStderrWrite as (...args: unknown[]) => boolean)(
+      chunk,
+      ...rest
+    );
+  }) as typeof process.stderr.write;
+
+  try {
+    const result = await fn();
+    return { result, stdout, stderr };
+  } finally {
+    process.stdout.write = originalStdoutWrite;
+    process.stderr.write = originalStderrWrite;
+  }
+}
+
+export async function runCli(argv: string[]): Promise<{
+  exitCode: number;
+  stdout: string;
+  stderr: string;
+}> {
+  const run = await captureProcessOutput(() =>
+    main(["node", "mcpjam", ...argv], { telemetry: telemetryDisabled })
+  );
+  return {
+    exitCode: run.result.exitCode,
+    stdout: run.stdout,
+    stderr: run.stderr,
+  };
+}
+
+export type { CliMainResult };


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Purpose

This is **PR 0** of the CLI local-vs-cloud restructure: freeze the local CLI surface before any Cloud command paths move under `mcpjam cloud`.

Local command paths, accepted/rejected flags, stdout, stderr, exit codes, MCP protocol identity, and the tool contract are CI-load-bearing. This PR adds a tripwire so later Cloud-namespace PRs cannot silently change that surface.

## Context

The `mcpjam` CLI is two products in one binary. Account-bound commands will move below `mcpjam cloud`. Local commands must not break. This PR has **no production behavior change**.

## What changed

- Added a test-owned manifest (`cli/tests/fixtures/local-contract-manifest.json`) for every frozen local top-level command: `server`, `tools`, `resources`, `prompts`, `subscriptions`, `tasks`, `apps`, `oauth`, `protocol`, `readiness`, `xaa`, `compat`, `inspector`, `mcp`, `telemetry`.
- The test records representative `--help` (usage + subcommand names) and fails if a frozen command disappears or its subcommand list changes.
- Explicit assertions that `mcpjam server … --api-key`, `mcpjam tools … --api-url`, and equivalent local invocations remain `USAGE_ERROR` (exit 2, JSON on stderr, empty stdout).
- Representative JSON stdout (`telemetry status`) and usage-error JSON (`server probe` / `tools list` missing target).
- MCP initialization assertion that local `serverInfo.name === "mcpjam"`.

Re-generate the manifest after an intentional local-surface change:

```bash
UPDATE_LOCAL_CONTRACT=1 npx tsx --test tests/local-contract.test.ts
```

from `cli/`.

## Before / after

- **Before:** nothing systematically locked the local command tree, Cloud-flag rejection, or MCP identity.
- **After:** later PRs that rename a local command, accept `--api-key` on a local leaf, or change `serverInfo.name` fail CI.

## Rollout

Test-only. No CLI behavior, help text, or package version change. No changeset.

## Follow-ups

PR 1 introduces the `mcpjam cloud` namespace and moves account-bound groups under it. This tripwire must stay green through that move.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-880bc302-7fad-489a-b883-d890bdc3aca6?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-880bc302-7fad-489a-b883-d890bdc3aca6&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Freezes the local `mcpjam` CLI contract to prevent regressions while account-bound commands move under `mcpjam cloud`. No production behavior changes; adds CI tripwires over help output, flag rejection, JSON I/O, exit codes, and MCP identity.

- Verifies the frozen top-level command set and subcommand lists against `cli/tests/fixtures/local-contract-manifest.json`.
- Asserts local paths reject Cloud flags (`--api-key`, `--api-url`, `--project`) with `USAGE_ERROR` (exit 2, JSON on stderr, empty stdout).
- Locks representative I/O: `server probe` and `tools list` usage errors; `telemetry status` JSON shape; exit codes.
- Ensures MCP `serverInfo.name` remains `mcpjam`.
- Test-only change; no CLI behavior, help text, or version changes.

**Updating the manifest**
- After an intentional local-surface change, re-generate: `UPDATE_LOCAL_CONTRACT=1 npx tsx --test tests/local-contract.test.ts` (run from `cli/`).

<sup>Written for commit 1a3c1b34841daa058be7a81a5b77a4b17dade5fb. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/MCPJam/inspector/pull/4189?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

