### PR TITLE
cli: hoist Cloud credential flags onto mcpjam cloud

### DIFF
--- a/.changeset/cli-cloud-credential-hoist.md
+++ b/.changeset/cli-cloud-credential-hoist.md
@@ -1,0 +1,5 @@
+---
+"@mcpjam/cli": major
+---
+
+Declare `--api-key` / `--api-url` once on `mcpjam cloud` so they work on either side of descendants. Local commands still reject them. Hosted `readiness` keeps leaf flags.

--- a/cli/src/commands/auth.ts
+++ b/cli/src/commands/auth.ts
@@ -1,10 +1,7 @@
 import type { Command } from "commander";
 import { getGlobalOptions } from "../lib/server-config.js";
-import { writeResult } from "../lib/output.js";
-import {
-  runPlatformLogin,
-  runPlatformLogout,
-} from "../lib/platform-auth.js";
+import { usageError, writeResult } from "../lib/output.js";
+import { runPlatformLogin, runPlatformLogout } from "../lib/platform-auth.js";
 import {
   platformOptionsOf,
   runPlatformOperation,
@@ -18,32 +15,34 @@ export function registerAuthCommands(program: Command): void {
   program
     .command("login")
     .description(
-      "Log in to MCPJam. Opens your browser for OAuth and stores the session locally.",
+      "Log in to MCPJam. Opens your browser for OAuth and stores the session locally."
     )
-    .option(
-      "--api-url <url>",
-      "MCPJam API base URL (defaults to https://app.mcpjam.com/api/v1)",
-    )
-    .option(
-      "--no-browser",
-      "Print the login URL instead of opening a browser",
-    )
+    .option("--no-browser", "Print the login URL instead of opening a browser")
     .action(async (options, command) => {
       const globalOptions = getGlobalOptions(command);
-      const apiUrl = resolvePlatformBaseUrl(options);
-      const origin = resolvePlatformOrigin(options);
+      const platform = platformOptionsOf(command);
+      if (platform.apiKey?.trim()) {
+        throw usageError(
+          "`mcpjam cloud login` uses browser OAuth. Pass --api-key to other cloud commands, or set MCPJAM_API_KEY."
+        );
+      }
+      const apiUrl = resolvePlatformBaseUrl(platform);
+      const origin = resolvePlatformOrigin(platform);
 
-      const result = await runPlatformLogin({ origin, apiUrl }, {
-        ...(options.browser === false
-          ? {
-              openUrl: async (url: string) => {
-                process.stderr.write(
-                  `Open this URL in your browser to continue:\n\n  ${url}\n\n`,
-                );
-              },
-            }
-          : {}),
-      });
+      const result = await runPlatformLogin(
+        { origin, apiUrl },
+        {
+          ...(options.browser === false
+            ? {
+                openUrl: async (url: string) => {
+                  process.stderr.write(
+                    `Open this URL in your browser to continue:\n\n  ${url}\n\n`
+                  );
+                },
+              }
+            : {}),
+        }
+      );
 
       writeResult(
         {
@@ -54,7 +53,7 @@ export function registerAuthCommands(program: Command): void {
             ? { expiresAt: new Date(result.expiresAt).toISOString() }
             : {}),
         },
-        globalOptions.format,
+        globalOptions.format
       );
     });
 
@@ -70,18 +69,13 @@ export function registerAuthCommands(program: Command): void {
           status: result.loggedOut ? "logged_out" : "not_logged_in",
           authFile: result.authFilePath,
         },
-        globalOptions.format,
+        globalOptions.format
       );
     });
 
   program
     .command("whoami")
     .description("Show the MCPJam account behind the current credentials.")
-    .option("--api-key <key>", "MCPJam sk_ API key (overrides MCPJAM_API_KEY)")
-    .option(
-      "--api-url <url>",
-      "MCPJam API base URL (defaults to https://app.mcpjam.com/api/v1)",
-    )
     .action(async (_options, command) => {
       const globalOptions = getGlobalOptions(command);
       const result = await runPlatformOperation(
@@ -96,7 +90,7 @@ export function registerAuthCommands(program: Command): void {
             ...(me.plan ? { plan: me.plan } : {}),
             credential: credentialKind,
           };
-        },
+        }
       );
 
       writeResult(result, globalOptions.format);

--- a/cli/src/commands/chat.ts
+++ b/cli/src/commands/chat.ts
@@ -9,66 +9,18 @@
 import type { Command } from "commander";
 import {
   listChatSessionsOperation,
-  PlatformApiError,
   type PlatformOperation,
 } from "@mcpjam/sdk/platform";
 import { writeResult } from "../lib/output.js";
-import { buildPlatformClient, toCliError } from "../lib/platform-client.js";
+import {
+  platformOptionsOf,
+  runPlatformOperation as runPlatformCommand,
+  type PlatformOptions,
+} from "../lib/platform-command.js";
 import { getGlobalOptions } from "../lib/server-config.js";
 
-type PlatformOptions = {
-  apiKey?: string;
-  apiUrl?: string;
-};
 
-function addPlatformOptions(command: Command): Command {
-  return command
-    .option("--api-key <key>", "MCPJam sk_ API key (overrides MCPJAM_API_KEY)")
-    .option(
-      "--api-url <url>",
-      "MCPJam API base URL (defaults to https://app.mcpjam.com/api/v1)",
-    );
-}
 
-async function runPlatformCommand<TOutput>(
-  options: PlatformOptions,
-  timeoutMs: number,
-  execute: (context: {
-    client: ReturnType<typeof buildPlatformClient>["client"];
-    signal: AbortSignal;
-  }) => Promise<TOutput>,
-): Promise<TOutput> {
-  const controller = new AbortController();
-  const timeoutHandle = setTimeout(() => {
-    controller.abort(
-      new PlatformApiError(
-        `Request timed out after ${timeoutMs}ms`,
-        "TIMEOUT",
-        {
-          status: 0,
-        },
-      ),
-    );
-  }, timeoutMs);
-  timeoutHandle.unref?.();
-
-  try {
-    const { client } = buildPlatformClient({ ...options, timeoutMs });
-    return await execute({ client, signal: controller.signal });
-  } catch (error) {
-    // When OUR deadline fired, surface the armed TIMEOUT error rather than the
-    // bare AbortError some fetch implementations reject with.
-    if (
-      controller.signal.aborted &&
-      controller.signal.reason instanceof PlatformApiError
-    ) {
-      throw toCliError(controller.signal.reason);
-    }
-    throw toCliError(error);
-  } finally {
-    clearTimeout(timeoutHandle);
-  }
-}
 
 /** Validate against the operation's own schema so bad flags fail before the call. */
 function validateOpInput<TInput>(
@@ -90,12 +42,12 @@ function validateOpInput<TInput>(
 async function executeOp<TInput, TOutput>(
   op: PlatformOperation<TInput, TOutput>,
   input: TInput,
-  options: PlatformOptions,
+  _options: PlatformOptions,
   command: Command,
 ): Promise<void> {
   const globalOptions = getGlobalOptions(command);
   const result = await runPlatformCommand(
-    options,
+    platformOptionsOf(command),
     globalOptions.timeout,
     ({ client, signal }) => op.execute(input, { client, signal }),
   );
@@ -107,8 +59,7 @@ export function registerChatCommands(program: Command): void {
     .command("chat-sessions")
     .description("Inspect saved chat sessions");
 
-  addPlatformOptions(
-    sessions
+      sessions
       .command("list")
       .description(
         "List chat sessions, newest first (all accessible projects unless --project is given)",
@@ -117,8 +68,8 @@ export function registerChatCommands(program: Command): void {
       .option("--status <status>", "Filter by session status")
       .option("--limit <n>", "Maximum sessions to return (1-200)", (value) =>
         Number.parseInt(value, 10),
-      ),
-  ).action(
+      )
+      .action(
     async (
       options: PlatformOptions & {
         project?: string;

--- a/cli/src/commands/cloud.ts
+++ b/cli/src/commands/cloud.ts
@@ -1,4 +1,5 @@
 import type { Command } from "commander";
+import { addPlatformOptions } from "../lib/platform-command.js";
 import { registerAuthCommands } from "./auth.js";
 import { registerChatCommands } from "./chat.js";
 import { registerEnvironmentsCommands } from "./environments.js";
@@ -25,6 +26,8 @@ export function registerCloudCommands(program: Command): Command {
     .description(
       "MCPJam Cloud account commands (login, projects, evals, tunnels). Local MCP testing stays at the top level — `mcpjam oauth login` is MCP OAuth; `mcpjam cloud login` is your MCPJam account."
     );
+
+  addPlatformOptions(cloud);
 
   registerAuthCommands(cloud);
   registerOrganizationsCommands(cloud);

--- a/cli/src/commands/environments.ts
+++ b/cli/src/commands/environments.ts
@@ -11,12 +11,15 @@ import {
   resolveEnvironmentOperation,
   restoreEnvironmentOperation,
   updateEnvironmentOperation,
-  PlatformApiError,
   type PlatformOperation,
 } from "@mcpjam/sdk/platform";
 import { JsonInputContext } from "../lib/json-input.js";
 import { usageError, writeResult } from "../lib/output.js";
-import { buildPlatformClient, toCliError } from "../lib/platform-client.js";
+import {
+  platformOptionsOf,
+  runPlatformOperation as runPlatformCommand,
+  type PlatformOptions,
+} from "../lib/platform-command.js";
 import { getGlobalOptions } from "../lib/server-config.js";
 
 /**
@@ -33,57 +36,8 @@ import { getGlobalOptions } from "../lib/server-config.js";
  * rather than silently overwriting their edit.
  */
 
-type PlatformOptions = {
-  apiKey?: string;
-  apiUrl?: string;
-};
 
-function addPlatformOptions(command: Command): Command {
-  return command
-    .option("--api-key <key>", "MCPJam sk_ API key (overrides MCPJAM_API_KEY)")
-    .option(
-      "--api-url <url>",
-      "MCPJam API base URL (defaults to https://app.mcpjam.com/api/v1)"
-    );
-}
 
-async function runPlatformCommand<TOutput>(
-  options: PlatformOptions,
-  timeoutMs: number,
-  execute: (context: {
-    client: ReturnType<typeof buildPlatformClient>["client"];
-    signal: AbortSignal;
-  }) => Promise<TOutput>
-): Promise<TOutput> {
-  const controller = new AbortController();
-  const timeoutHandle = setTimeout(() => {
-    controller.abort(
-      new PlatformApiError(
-        `Request timed out after ${timeoutMs}ms`,
-        "TIMEOUT",
-        {
-          status: 0,
-        }
-      )
-    );
-  }, timeoutMs);
-  timeoutHandle.unref?.();
-
-  try {
-    const { client } = buildPlatformClient({ ...options, timeoutMs });
-    return await execute({ client, signal: controller.signal });
-  } catch (error) {
-    if (
-      controller.signal.aborted &&
-      controller.signal.reason instanceof PlatformApiError
-    ) {
-      throw toCliError(controller.signal.reason);
-    }
-    throw toCliError(error);
-  } finally {
-    clearTimeout(timeoutHandle);
-  }
-}
 
 function validateInput<TInput>(
   op: PlatformOperation<TInput, unknown>,
@@ -217,8 +171,7 @@ export function registerEnvironmentsCommands(program: Command): void {
       "List, create, and manage the project environments (host + servers + pinned skills/plugins) in your hosted MCPJam projects"
     );
 
-  addPlatformOptions(
-    environments
+      environments
       .command("list")
       .description("List the project environments in a project")
       .option(
@@ -228,8 +181,7 @@ export function registerEnvironmentsCommands(program: Command): void {
       .option(
         "--include-archived",
         "Include archived environments (needed to find one to restore)"
-      )
-  ).action(
+      ).action(
     async (
       options: PlatformOptions & {
         project?: string;
@@ -239,7 +191,7 @@ export function registerEnvironmentsCommands(program: Command): void {
     ) => {
       const globalOptions = getGlobalOptions(command);
       const result = await runPlatformCommand(
-        options,
+        platformOptionsOf(command),
         globalOptions.timeout,
         ({ client, signal }) =>
           listEnvironmentsOperation.execute(
@@ -254,22 +206,20 @@ export function registerEnvironmentsCommands(program: Command): void {
     }
   );
 
-  addPlatformOptions(
-    environments
+      environments
       .command("get")
       .description(
         "Show one environment's settings and its current revision (pass that revision to update/archive/restore)"
       )
       .requiredOption("--environment <id-or-name>", "Environment name or ID")
-      .option("--project <id-or-name>", "Project name or ID")
-  ).action(
+      .option("--project <id-or-name>", "Project name or ID").action(
     async (
       options: PlatformOptions & { project?: string; environment: string },
       command
     ) => {
       const globalOptions = getGlobalOptions(command);
       const result = await runPlatformCommand(
-        options,
+        platformOptionsOf(command),
         globalOptions.timeout,
         ({ client, signal }) =>
           getEnvironmentOperation.execute(
@@ -281,22 +231,20 @@ export function registerEnvironmentsCommands(program: Command): void {
     }
   );
 
-  addPlatformOptions(
-    environments
+      environments
       .command("resolve")
       .description(
         "Preview what an environment resolves to right now: host config, closed server set, and pinned plugin versions"
       )
       .requiredOption("--environment <id-or-name>", "Environment name or ID")
-      .option("--project <id-or-name>", "Project name or ID")
-  ).action(
+      .option("--project <id-or-name>", "Project name or ID").action(
     async (
       options: PlatformOptions & { project?: string; environment: string },
       command
     ) => {
       const globalOptions = getGlobalOptions(command);
       const result = await runPlatformCommand(
-        options,
+        platformOptionsOf(command),
         globalOptions.timeout,
         ({ client, signal }) =>
           resolveEnvironmentOperation.execute(
@@ -308,8 +256,7 @@ export function registerEnvironmentsCommands(program: Command): void {
     }
   );
 
-  addPlatformOptions(
-    environments
+      environments
       .command("create")
       .description(
         "Create a project environment (requires project admin). Body fields may be supplied via --file/--json"
@@ -330,8 +277,7 @@ export function registerEnvironmentsCommands(program: Command): void {
         "--file <path>",
         "Environment JSON file with any of name/hostId/description/serverAttachmentId/modelId/skillSelection/pluginVersionIds/sandboxImageId (or - for stdin)"
       )
-      .option("--json <json>", "Inline environment JSON (or @file, or -)")
-  ).action(
+      .option("--json <json>", "Inline environment JSON (or @file, or -)").action(
     async (
       options: PlatformOptions & {
         project?: string;
@@ -353,7 +299,10 @@ export function registerEnvironmentsCommands(program: Command): void {
       // unknown `modelId` with an opaque validator error. Ask first, and only
       // when the caller actually supplied model input — an ordinary create has
       // no reason to pay for a round-trip.
-      await assertModelOverridesSupported(options, globalOptions.timeout, {
+      await assertModelOverridesSupported(
+        platformOptionsOf(command),
+        globalOptions.timeout,
+        {
         supplied: options.model !== undefined || "modelId" in body,
         ...projectSelector(options, body),
       });
@@ -371,7 +320,7 @@ export function registerEnvironmentsCommands(program: Command): void {
           : {}),
       });
       const result = await runPlatformCommand(
-        options,
+        platformOptionsOf(command),
         globalOptions.timeout,
         ({ client, signal }) =>
           createEnvironmentOperation.execute(input, { client, signal })
@@ -380,8 +329,7 @@ export function registerEnvironmentsCommands(program: Command): void {
     }
   );
 
-  addPlatformOptions(
-    environments
+      environments
       .command("ensure-adhoc")
       .description(
         "Get or create an UNNAMED environment for a composed stack. Deduplicated by content: the same stack always returns the same environment"
@@ -406,8 +354,7 @@ export function registerEnvironmentsCommands(program: Command): void {
       .option(
         "--skill <id...>",
         "Project-shared skill IDs to pin on the composed stack"
-      )
-  ).action(
+      ).action(
     async (
       options: PlatformOptions & {
         project?: string;
@@ -435,7 +382,7 @@ export function registerEnvironmentsCommands(program: Command): void {
           : {}),
       });
       const result = await runPlatformCommand(
-        options,
+        platformOptionsOf(command),
         globalOptions.timeout,
         ({ client, signal }) =>
           ensureAdhocEnvironmentOperation.execute(input, { client, signal })
@@ -444,8 +391,7 @@ export function registerEnvironmentsCommands(program: Command): void {
     }
   );
 
-  addPlatformOptions(
-    environments
+      environments
       .command("name")
       .description(
         "Promote an UNNAMED (ad-hoc) environment to a named one, in place — the same id every existing run points at"
@@ -460,8 +406,7 @@ export function registerEnvironmentsCommands(program: Command): void {
         "The revision you last read; a stale value is rejected instead of overwriting a concurrent edit"
       )
       .option("--project <id-or-name>", "Project name or ID")
-      .option("--description <text>", "Optional description")
-  ).action(
+      .option("--description <text>", "Optional description").action(
     async (
       options: PlatformOptions & {
         project?: string;
@@ -483,7 +428,7 @@ export function registerEnvironmentsCommands(program: Command): void {
           : {}),
       });
       const result = await runPlatformCommand(
-        options,
+        platformOptionsOf(command),
         globalOptions.timeout,
         ({ client, signal }) =>
           nameEnvironmentOperation.execute(input, { client, signal })
@@ -492,8 +437,7 @@ export function registerEnvironmentsCommands(program: Command): void {
     }
   );
 
-  addPlatformOptions(
-    environments
+      environments
       .command("update")
       .description(
         "Edit an environment. Only the fields you pass change; use --clear-model, or --file/--json with a null value, to clear serverAttachmentId, modelId, skillSelection, pluginVersionIds, or sandboxImageId"
@@ -526,8 +470,7 @@ export function registerEnvironmentsCommands(program: Command): void {
         "--file <path>",
         "Environment JSON file with the fields to change (or - for stdin)"
       )
-      .option("--json <json>", "Inline environment JSON (or @file, or -)")
-  ).action(
+      .option("--json <json>", "Inline environment JSON (or @file, or -)").action(
     async (
       options: PlatformOptions & {
         project?: string;
@@ -551,7 +494,10 @@ export function registerEnvironmentsCommands(program: Command): void {
       if (options.model !== undefined && options.clearModel) {
         throw usageError("Provide either --model or --clear-model, not both.");
       }
-      await assertModelOverridesSupported(options, globalOptions.timeout, {
+      await assertModelOverridesSupported(
+        platformOptionsOf(command),
+        globalOptions.timeout,
+        {
         supplied:
           options.model !== undefined ||
           options.clearModel === true ||
@@ -577,7 +523,7 @@ export function registerEnvironmentsCommands(program: Command): void {
           : {}),
       });
       const result = await runPlatformCommand(
-        options,
+        platformOptionsOf(command),
         globalOptions.timeout,
         ({ client, signal }) =>
           updateEnvironmentOperation.execute(input, { client, signal })
@@ -586,8 +532,7 @@ export function registerEnvironmentsCommands(program: Command): void {
     }
   );
 
-  addPlatformOptions(
-    environments
+      environments
       .command("archive")
       .description(
         "Archive an environment (reversible; frees its name for a new one)"
@@ -597,8 +542,7 @@ export function registerEnvironmentsCommands(program: Command): void {
         "--expected-revision <n>",
         "The revision you last read (from `environments get`)"
       )
-      .option("--project <id-or-name>", "Project name or ID")
-  ).action(
+      .option("--project <id-or-name>", "Project name or ID").action(
     async (
       options: PlatformOptions & {
         project?: string;
@@ -609,7 +553,7 @@ export function registerEnvironmentsCommands(program: Command): void {
     ) => {
       const globalOptions = getGlobalOptions(command);
       const result = await runPlatformCommand(
-        options,
+        platformOptionsOf(command),
         globalOptions.timeout,
         ({ client, signal }) =>
           archiveEnvironmentOperation.execute(
@@ -625,8 +569,7 @@ export function registerEnvironmentsCommands(program: Command): void {
     }
   );
 
-  addPlatformOptions(
-    environments
+      environments
       .command("restore")
       .description(
         "Restore an archived environment. Plugin pins whose version no longer exists are dropped — check the returned pluginVersionIds"
@@ -636,8 +579,7 @@ export function registerEnvironmentsCommands(program: Command): void {
         "--expected-revision <n>",
         "The revision you last read (from `environments get --include-archived` via list)"
       )
-      .option("--project <id-or-name>", "Project name or ID")
-  ).action(
+      .option("--project <id-or-name>", "Project name or ID").action(
     async (
       options: PlatformOptions & {
         project?: string;
@@ -648,7 +590,7 @@ export function registerEnvironmentsCommands(program: Command): void {
     ) => {
       const globalOptions = getGlobalOptions(command);
       const result = await runPlatformCommand(
-        options,
+        platformOptionsOf(command),
         globalOptions.timeout,
         ({ client, signal }) =>
           restoreEnvironmentOperation.execute(

--- a/cli/src/commands/eval.ts
+++ b/cli/src/commands/eval.ts
@@ -121,7 +121,7 @@ import {
 } from "../lib/reporting.js";
 import { DEFAULT_PLATFORM_ORIGIN } from "../lib/platform-auth.js";
 import {
-  addPlatformOptions,
+  platformOptionsOf,
   runPlatformOperation as runPlatformCommand,
   type PlatformOptions,
 } from "../lib/platform-command.js";
@@ -539,12 +539,12 @@ function validateOpInput<TInput>(
 async function executeOp<TInput, TOutput>(
   op: PlatformOperation<TInput, TOutput>,
   input: TInput,
-  options: PlatformOptions,
+  _options: PlatformOptions,
   command: Command
 ): Promise<void> {
   const globalOptions = getGlobalOptions(command);
   const result = await runPlatformCommand(
-    options,
+    platformOptionsOf(command),
     globalOptions.timeout,
     ({ client, signal }) => op.execute(input, { client, signal })
   );
@@ -788,7 +788,7 @@ async function runEvalGate(
   let report: GateReport;
   try {
     report = await runPlatformCommand(
-      options,
+      platformOptionsOf(command),
       Math.max(globalOptions.timeout, options.wait ? waitTimeoutMs : 0),
       async ({ client, signal }) => {
         const projects = await client.listProjects({}, { signal });
@@ -944,7 +944,7 @@ async function runEvalCompare(
   let outcome: CompareOutcome;
   try {
     outcome = await runPlatformCommand(
-      options,
+      platformOptionsOf(command),
       globalOptions.timeout,
       async ({ client, signal }) => {
         const projects = await client.listProjects({}, { signal });
@@ -1135,7 +1135,7 @@ async function runEvalPull(
   };
   try {
     fetched = await runPlatformCommand(
-      options,
+      platformOptionsOf(command),
       globalOptions.timeout,
       async ({ client, signal }) => {
         const selector = {
@@ -1517,7 +1517,7 @@ async function runEvalExport(
   }
 
   const fetched = await runPlatformCommand(
-    options,
+    platformOptionsOf(command),
     globalOptions.timeout,
     async ({ client, signal }) => {
       const selector = {
@@ -1646,8 +1646,7 @@ export function registerEvalCommands(program: Command): void {
     .command("eval")
     .description("Author and run eval suites in your hosted MCPJam projects");
 
-  addPlatformOptions(
-    evals
+      evals
       .command("create")
       .description(
         "Create a runnable eval suite from authored test cases (does not run it)"
@@ -1676,12 +1675,11 @@ export function registerEvalCommands(program: Command): void {
       .option(
         "--server <name...>",
         "Project HTTP server names or IDs (overrides the file)"
-      )
-  ).action(async (options: CreateOptions, command) => {
+      ).action(async (options: CreateOptions, command) => {
     const globalOptions = getGlobalOptions(command);
     const input = loadSuiteDefinition(options);
     const result = await runPlatformCommand(
-      options,
+      platformOptionsOf(command),
       globalOptions.timeout,
       ({ client, signal }) =>
         createEvalSuiteOperation.execute(input, { client, signal })
@@ -1689,18 +1687,16 @@ export function registerEvalCommands(program: Command): void {
     writeResult(result, globalOptions.format);
   });
 
-  addPlatformOptions(
-    evals
+      evals
       .command("list")
       .description("List the eval suites saved in a project")
       .option(
         "--project <id-or-name>",
         "Project name or ID (defaults to the most recently updated project)"
-      )
-  ).action(async (options: PlatformOptions & { project?: string }, command) => {
+      ).action(async (options: PlatformOptions & { project?: string }, command) => {
     const globalOptions = getGlobalOptions(command);
     const result = await runPlatformCommand(
-      options,
+      platformOptionsOf(command),
       globalOptions.timeout,
       ({ client, signal }) =>
         listEvalSuitesOperation.execute(
@@ -1711,8 +1707,7 @@ export function registerEvalCommands(program: Command): void {
     writeResult(result, globalOptions.format);
   });
 
-  addPlatformOptions(
-    evals
+      evals
       .command("runs")
       .description("List a suite's run history, newest first")
       .requiredOption("--suite <id-or-name>", "Eval suite name or ID")
@@ -1724,8 +1719,7 @@ export function registerEvalCommands(program: Command): void {
         "--limit <n>",
         "Maximum number of runs to return (1-100)",
         (value) => Number.parseInt(value, 10)
-      )
-  ).action(
+      ).action(
     async (
       options: PlatformOptions & {
         suite: string;
@@ -1743,8 +1737,7 @@ export function registerEvalCommands(program: Command): void {
     }
   );
 
-  addPlatformOptions(
-    evals
+      evals
       .command("run")
       .description("Start an eval run of an existing suite (asynchronous)")
       .requiredOption("--suite <id-or-name>", "Eval suite name or ID")
@@ -1814,8 +1807,7 @@ export function registerEvalCommands(program: Command): void {
       .option(
         "--compose-skill <id...>",
         "Project-shared skill IDs to pin on the composed stack"
-      )
-  ).action(
+      ).action(
     async (
       options: PlatformOptions & {
         composeHost?: string;
@@ -1843,7 +1835,7 @@ export function registerEvalCommands(program: Command): void {
       const globalOptions = getGlobalOptions(command);
       let webOrigin = DEFAULT_PLATFORM_ORIGIN;
       const result = await runPlatformCommand(
-        options,
+        platformOptionsOf(command),
         globalOptions.timeout,
         (context) => {
           webOrigin = context.webOrigin;
@@ -1893,13 +1885,11 @@ export function registerEvalCommands(program: Command): void {
     }
   );
 
-  addPlatformOptions(
-    evals
+      evals
       .command("status")
       .description("Get the status and summary of an eval run")
       .requiredOption("--run <id>", "Eval run ID (from `eval run`)")
-      .requiredOption("--project <id-or-name>", "Project name or ID")
-  ).action(
+      .requiredOption("--project <id-or-name>", "Project name or ID").action(
     async (
       options: PlatformOptions & { project: string; run: string },
       command
@@ -1907,7 +1897,7 @@ export function registerEvalCommands(program: Command): void {
       const globalOptions = getGlobalOptions(command);
       let webOrigin = DEFAULT_PLATFORM_ORIGIN;
       const result = await runPlatformCommand(
-        options,
+        platformOptionsOf(command),
         globalOptions.timeout,
         (context) => {
           webOrigin = context.webOrigin;
@@ -1927,15 +1917,13 @@ export function registerEvalCommands(program: Command): void {
     }
   );
 
-  addPlatformOptions(
-    evals
+      evals
       .command("cancel")
       .description(
         "Cancel an in-flight eval run (no-op if already cancelled; errors if it already finished)"
       )
       .requiredOption("--run <id>", "Eval run ID (from `eval run`)")
-      .requiredOption("--project <id-or-name>", "Project name or ID")
-  ).action(
+      .requiredOption("--project <id-or-name>", "Project name or ID").action(
     async (
       options: PlatformOptions & { project: string; run: string },
       command
@@ -1949,8 +1937,7 @@ export function registerEvalCommands(program: Command): void {
     }
   );
 
-  addPlatformOptions(
-    evals
+      evals
       .command("judge")
       .description(
         "Grade a finished eval run with LLM as Judge (SPENDS your model budget)"
@@ -1963,8 +1950,7 @@ export function registerEvalCommands(program: Command): void {
         "Grade this run even though the judge was off when it ran"
       )
       .option("--judge-model <id>", "Judge model for this run only")
-      .option("--judge-threshold <0-1>", "Pass threshold for this run only")
-  ).action(
+      .option("--judge-threshold <0-1>", "Pass threshold for this run only").action(
     async (
       options: PlatformOptions & {
         project: string;
@@ -2004,14 +1990,12 @@ export function registerEvalCommands(program: Command): void {
     .command("checks")
     .description("Run an eval suite on a repository's pull requests");
 
-  addPlatformOptions(
-    checks
+      checks
       .command("list")
       .description(
         "List the repositories running an eval suite on their pull requests"
       )
-      .option("--project <id-or-name>", PROJECT_OPT)
-  ).action(async (options: PlatformOptions & { project?: string }, command) => {
+      .option("--project <id-or-name>", PROJECT_OPT).action(async (options: PlatformOptions & { project?: string }, command) => {
     await executeOp(
       listEvalCheckReposOperation,
       { project: options.project },
@@ -2020,8 +2004,7 @@ export function registerEvalCommands(program: Command): void {
     );
   });
 
-  addPlatformOptions(
-    checks
+      checks
       .command("connect")
       .description(
         "Run this suite on every pull request to a repository (affects everyone who opens one)"
@@ -2032,8 +2015,7 @@ export function registerEvalCommands(program: Command): void {
         "--outage-policy <fail-open|fail-closed>",
         "What the check reports when MCPJam cannot conclude"
       )
-      .option("--project <id-or-name>", PROJECT_OPT)
-  ).action(
+      .option("--project <id-or-name>", PROJECT_OPT).action(
     async (
       options: PlatformOptions & {
         project?: string;
@@ -2064,8 +2046,7 @@ export function registerEvalCommands(program: Command): void {
   );
 
   // ── Eval run iterations + traces ───────────────────────────────────
-  addPlatformOptions(
-    evals
+      evals
       .command("iterations")
       .description(
         "List per-iteration results for an eval run (pass/fail, tool calls, tokens, latency)"
@@ -2076,8 +2057,7 @@ export function registerEvalCommands(program: Command): void {
         "Project the run belongs to (name or ID)"
       )
       .option("--cursor <cursor>", "Pagination cursor from a previous response")
-      .option("--limit <n>", "Max iterations per page (1–200)")
-  ).action(
+      .option("--limit <n>", "Max iterations per page (1–200)").action(
     async (
       options: PlatformOptions & {
         project: string;
@@ -2099,8 +2079,7 @@ export function registerEvalCommands(program: Command): void {
     }
   );
 
-  addPlatformOptions(
-    evals
+      evals
       .command("gate")
       .description(
         "Apply a pass/fail policy to a finished eval run and set an exit code (0 pass, 1 eval failure, 2 usage, 3 incomplete)"
@@ -2134,8 +2113,7 @@ export function registerEvalCommands(program: Command): void {
       .option(
         "--wait-timeout <ms>",
         "Give up waiting after this many milliseconds (default 600000)"
-      )
-  ).action(
+      ).action(
     async (
       options: PlatformOptions &
         EvalGateOptions & {
@@ -2150,8 +2128,7 @@ export function registerEvalCommands(program: Command): void {
     }
   );
 
-  addPlatformOptions(
-    evals
+      evals
       .command("compare")
       .description(
         "Compare a finished eval run against a baseline and set an exit code (0 pass, 1 regression, 2 usage, 3 incomplete)"
@@ -2189,8 +2166,7 @@ export function registerEvalCommands(program: Command): void {
         "--reporter <json-summary|junit-xml>",
         "Write a structured report to stdout instead of the default output"
       )
-      .option("--out <path>", "Write the structured report to a JSON file")
-  ).action(
+      .option("--out <path>", "Write the structured report to a JSON file").action(
     async (
       options: PlatformOptions &
         EvalCompareOptions & {
@@ -2219,8 +2195,7 @@ export function registerEvalCommands(program: Command): void {
       runEvalValidate(options, command);
     });
 
-  addPlatformOptions(
-    evals
+      evals
       .command("export")
       .description(
         "Write a hosted eval suite to a local suite file, refusing anything it cannot represent losslessly"
@@ -2237,8 +2212,7 @@ export function registerEvalCommands(program: Command): void {
         "--out <path>",
         "Where to write (default .mcpjam/evals/<suite-id>.yaml)"
       )
-      .option("--force", "Replace an existing file at the output path")
-  ).action(
+      .option("--force", "Replace an existing file at the output path").action(
     async (
       options: PlatformOptions & {
         suite: string;
@@ -2252,8 +2226,7 @@ export function registerEvalCommands(program: Command): void {
     }
   );
 
-  addPlatformOptions(
-    evals
+      evals
       .command("pull")
       .description(
         "LEGACY: materialize a hosted eval suite into a corpus lock for @mcpjam/vitest — new work should use `eval export` (0 clean, 1 drift under --frozen, 2 usage, 3 incomplete)"
@@ -2274,8 +2247,7 @@ export function registerEvalCommands(program: Command): void {
       .option(
         "--skip-unsupported",
         "Omit cases a local run cannot execute instead of failing"
-      )
-  ).action(
+      ).action(
     async (
       options: PlatformOptions & {
         suite: string;
@@ -2290,8 +2262,7 @@ export function registerEvalCommands(program: Command): void {
     }
   );
 
-  addPlatformOptions(
-    evals
+      evals
       .command("trace")
       .description(
         "Fetch the full trace for one eval iteration (large: full message history + spans)"
@@ -2304,8 +2275,7 @@ export function registerEvalCommands(program: Command): void {
       .requiredOption(
         "--project <id-or-name>",
         "Project the run belongs to (name or ID)"
-      )
-  ).action(
+      ).action(
     async (
       options: PlatformOptions & {
         project: string;
@@ -2327,8 +2297,7 @@ export function registerEvalCommands(program: Command): void {
     }
   );
 
-  addPlatformOptions(
-    evals
+      evals
       .command("steps")
       .description(
         "Per-authored-step results for one eval iteration: status (ok/fail/skipped/pending), reason, and evidence (screenshot/video URLs). The fastest way to see WHICH step failed and why."
@@ -2341,8 +2310,7 @@ export function registerEvalCommands(program: Command): void {
       .requiredOption(
         "--project <id-or-name>",
         "Project the run belongs to (name or ID)"
-      )
-  ).action(
+      ).action(
     async (
       options: PlatformOptions & {
         project: string;
@@ -2364,8 +2332,7 @@ export function registerEvalCommands(program: Command): void {
     }
   );
 
-  addPlatformOptions(
-    evals
+      evals
       .command("screenshot")
       .description(
         "Show the widget screenshot(s) an eval iteration rendered — inline when the terminal supports it, otherwise the image URL"
@@ -2383,8 +2350,7 @@ export function registerEvalCommands(program: Command): void {
         "--out <path>",
         "Save the PNG(s) to a file or directory instead of rendering inline"
       )
-      .option("--index <n>", "Show only the Nth screenshot (1-based)")
-  ).action(
+      .option("--index <n>", "Show only the Nth screenshot (1-based)").action(
     async (
       options: PlatformOptions & {
         project: string;
@@ -2402,7 +2368,7 @@ export function registerEvalCommands(program: Command): void {
           : undefined;
 
       const result = await runPlatformCommand(
-        options,
+        platformOptionsOf(command),
         globalOptions.timeout,
         ({ client, signal }) =>
           getEvalIterationTraceOperation.execute(
@@ -2499,8 +2465,7 @@ export function registerEvalCommands(program: Command): void {
     }
   );
 
-  addPlatformOptions(
-    evals
+      evals
       .command("video")
       .description(
         "Get the Playwright replay video (.webm) an eval iteration recorded — prints the URL, or downloads it with --out"
@@ -2517,8 +2482,7 @@ export function registerEvalCommands(program: Command): void {
       .option(
         "--out <path>",
         "Download the .webm to this file instead of printing the URL"
-      )
-  ).action(
+      ).action(
     async (
       options: PlatformOptions & {
         project: string;
@@ -2530,7 +2494,7 @@ export function registerEvalCommands(program: Command): void {
     ) => {
       const globalOptions = getGlobalOptions(command);
       const result = await runPlatformCommand(
-        options,
+        platformOptionsOf(command),
         globalOptions.timeout,
         ({ client, signal }) =>
           getEvalIterationTraceOperation.execute(
@@ -2585,13 +2549,11 @@ export function registerEvalCommands(program: Command): void {
   );
 
   // ── Suite settings: get / update / delete / schedule ───────────────
-  addPlatformOptions(
-    evals
+      evals
       .command("get")
       .description("Show an eval suite's full settings")
       .requiredOption("--suite <id-or-name>", "Eval suite name or ID")
-      .option("--project <id-or-name>", PROJECT_OPT)
-  ).action(
+      .option("--project <id-or-name>", PROJECT_OPT).action(
     async (
       options: PlatformOptions & { project?: string; suite: string },
       command
@@ -2605,8 +2567,7 @@ export function registerEvalCommands(program: Command): void {
     }
   );
 
-  addPlatformOptions(
-    evals
+      evals
       .command("update")
       .description(
         "Edit an eval suite's settings (only the flags you pass change)"
@@ -2642,8 +2603,7 @@ export function registerEvalCommands(program: Command): void {
         "Turn LLM-as-judge grading on/off (grades every run as it completes)"
       )
       .option("--judge-model <id>", "Judge model id")
-      .option("--judge-threshold <0-1>", "Judge pass threshold, 0–1")
-  ).action(async (options: PlatformOptions & Record<string, any>, command) => {
+      .option("--judge-threshold <0-1>", "Judge pass threshold, 0–1").action(async (options: PlatformOptions & Record<string, any>, command) => {
     const input = validateOpInput(
       updateEvalSuiteOperation,
       buildSuiteUpdateInput(options)
@@ -2651,13 +2611,11 @@ export function registerEvalCommands(program: Command): void {
     await executeOp(updateEvalSuiteOperation, input, options, command);
   });
 
-  addPlatformOptions(
-    evals
+      evals
       .command("delete")
       .description("Permanently delete an eval suite (and its cases and runs)")
       .requiredOption("--suite <id-or-name>", "Eval suite name or ID")
-      .option("--project <id-or-name>", PROJECT_OPT)
-  ).action(
+      .option("--project <id-or-name>", PROJECT_OPT).action(
     async (
       options: PlatformOptions & { project?: string; suite: string },
       command
@@ -2671,8 +2629,7 @@ export function registerEvalCommands(program: Command): void {
     }
   );
 
-  addPlatformOptions(
-    evals
+      evals
       .command("schedule")
       .description("Enable or disable scheduled runs for a suite")
       .requiredOption("--suite <id-or-name>", "Eval suite name or ID")
@@ -2683,8 +2640,7 @@ export function registerEvalCommands(program: Command): void {
       .option(
         "--environment <id-or-name>",
         "Project environment the scheduled runs launch (only with --enable)"
-      )
-  ).action(
+      ).action(
     async (
       options: PlatformOptions & {
         project?: string;
@@ -2722,8 +2678,7 @@ export function registerEvalCommands(program: Command): void {
       "Attach or detach the project environments an eval suite runs against"
     );
 
-  addPlatformOptions(
-    environments
+      environments
       .command("set")
       .description(
         "Replace the suite's attached environments (this sets the whole list)"
@@ -2733,8 +2688,7 @@ export function registerEvalCommands(program: Command): void {
         "--environment <id-or-name...>",
         "Project environments to attach, in order"
       )
-      .option("--project <id-or-name>", PROJECT_OPT)
-  ).action(
+      .option("--project <id-or-name>", PROJECT_OPT).action(
     async (
       options: PlatformOptions & {
         project?: string;
@@ -2756,15 +2710,13 @@ export function registerEvalCommands(program: Command): void {
     }
   );
 
-  addPlatformOptions(
-    environments
+      environments
       .command("clear")
       .description(
         "Detach every environment, reverting the suite to its saved server selection"
       )
       .requiredOption("--suite <id-or-name>", "Eval suite name or ID")
-      .option("--project <id-or-name>", PROJECT_OPT)
-  ).action(
+      .option("--project <id-or-name>", PROJECT_OPT).action(
     async (
       options: PlatformOptions & { project?: string; suite: string },
       command
@@ -2787,13 +2739,11 @@ export function registerEvalCommands(program: Command): void {
     .command("cases")
     .description("List, author, and edit an eval suite's test cases");
 
-  addPlatformOptions(
-    cases
+      cases
       .command("list")
       .description("List a suite's test cases")
       .requiredOption("--suite <id-or-name>", "Eval suite name or ID")
-      .option("--project <id-or-name>", PROJECT_OPT)
-  ).action(
+      .option("--project <id-or-name>", PROJECT_OPT).action(
     async (
       options: PlatformOptions & { project?: string; suite: string },
       command
@@ -2807,14 +2757,12 @@ export function registerEvalCommands(program: Command): void {
     }
   );
 
-  addPlatformOptions(
-    cases
+      cases
       .command("get")
       .description("Show one test case")
       .requiredOption("--suite <id-or-name>", "Eval suite name or ID")
       .requiredOption("--case <id-or-title>", "Eval case title or ID")
-      .option("--project <id-or-name>", PROJECT_OPT)
-  ).action(
+      .option("--project <id-or-name>", PROJECT_OPT).action(
     async (
       options: PlatformOptions & {
         project?: string;
@@ -2832,8 +2780,7 @@ export function registerEvalCommands(program: Command): void {
     }
   );
 
-  addPlatformOptions(
-    cases
+      cases
       .command("run")
       .description(
         "Run a single case as a persisted, fully-queryable run (inspect it with `eval iterations` / `eval steps` like any run)"
@@ -2879,8 +2826,7 @@ export function registerEvalCommands(program: Command): void {
       .option(
         "--compose-skill <id...>",
         "Project-shared skill IDs to pin on the composed stack"
-      )
-  ).action(
+      ).action(
     async (
       options: PlatformOptions & {
         composeHost?: string;
@@ -2922,16 +2868,14 @@ export function registerEvalCommands(program: Command): void {
     }
   );
 
-  addPlatformOptions(
-    cases
+      cases
       .command("create")
       .description("Add a test case to a suite (definition via --file/--json)")
       .requiredOption("--suite <id-or-name>", "Eval suite name or ID")
       .option("--project <id-or-name>", PROJECT_OPT)
       .option("--file <path>", "Case JSON body (or - for stdin)")
       .option("--json <json>", "Inline case JSON (or @file, or -)")
-      .option("--title <title>", "Case title (overrides the body)")
-  ).action(async (options: PlatformOptions & Record<string, any>, command) => {
+      .option("--title <title>", "Case title (overrides the body)").action(async (options: PlatformOptions & Record<string, any>, command) => {
     const input = validateOpInput(
       createEvalCaseOperation,
       buildCaseInput(options, { requireCase: false })
@@ -2939,8 +2883,7 @@ export function registerEvalCommands(program: Command): void {
     await executeOp(createEvalCaseOperation, input, options, command);
   });
 
-  addPlatformOptions(
-    cases
+      cases
       .command("update")
       .description("Edit a test case (definition via --file/--json)")
       .requiredOption("--suite <id-or-name>", "Eval suite name or ID")
@@ -2948,8 +2891,7 @@ export function registerEvalCommands(program: Command): void {
       .option("--project <id-or-name>", PROJECT_OPT)
       .option("--file <path>", "Case JSON body (or - for stdin)")
       .option("--json <json>", "Inline case JSON (or @file, or -)")
-      .option("--title <title>", "Rename the case")
-  ).action(async (options: PlatformOptions & Record<string, any>, command) => {
+      .option("--title <title>", "Rename the case").action(async (options: PlatformOptions & Record<string, any>, command) => {
     const input = validateOpInput(
       updateEvalCaseOperation,
       buildCaseInput(options, { requireCase: true })
@@ -2957,14 +2899,12 @@ export function registerEvalCommands(program: Command): void {
     await executeOp(updateEvalCaseOperation, input, options, command);
   });
 
-  addPlatformOptions(
-    cases
+      cases
       .command("delete")
       .description("Permanently delete a test case")
       .requiredOption("--suite <id-or-name>", "Eval suite name or ID")
       .requiredOption("--case <id-or-title>", "Eval case title or ID")
-      .option("--project <id-or-name>", PROJECT_OPT)
-  ).action(
+      .option("--project <id-or-name>", PROJECT_OPT).action(
     async (
       options: PlatformOptions & {
         project?: string;
@@ -2982,8 +2922,7 @@ export function registerEvalCommands(program: Command): void {
     }
   );
 
-  addPlatformOptions(
-    cases
+      cases
       .command("generate")
       .description(
         "AI-generate test cases from the suite's tools (spends credits)"
@@ -3015,8 +2954,7 @@ export function registerEvalCommands(program: Command): void {
       .option(
         "--idempotency-key <key>",
         "Retry-safety key: repeating the call replays the first attempt's drafts instead of generating (and billing) again"
-      )
-  ).action(
+      ).action(
     async (
       options: PlatformOptions & {
         project?: string;

--- a/cli/src/commands/hosts.ts
+++ b/cli/src/commands/hosts.ts
@@ -8,19 +8,18 @@ import {
   updateHostOperation,
   setHostServersOperation,
   duplicateHostOperation,
-  PlatformApiError,
   type PlatformOperation,
 } from "@mcpjam/sdk/platform";
 import { HOST_TEMPLATES as SDK_HOST_TEMPLATES } from "@mcpjam/sdk/host-config/templates";
 import { JsonInputContext } from "../lib/json-input.js";
 import { usageError, writeResult } from "../lib/output.js";
-import { buildPlatformClient, toCliError } from "../lib/platform-client.js";
+import {
+  platformOptionsOf,
+  runPlatformOperation as runPlatformCommand,
+  type PlatformOptions,
+} from "../lib/platform-command.js";
 import { getGlobalOptions } from "../lib/server-config.js";
 
-type PlatformOptions = {
-  apiKey?: string;
-  apiUrl?: string;
-};
 
 /**
  * Built-in host templates surfaced by `hosts templates`, derived from the SDK
@@ -30,52 +29,7 @@ type PlatformOptions = {
 const HOST_TEMPLATES: ReadonlyArray<{ id: string; label: string }> =
   SDK_HOST_TEMPLATES.map(({ id, label }) => ({ id, label }));
 
-function addPlatformOptions(command: Command): Command {
-  return command
-    .option("--api-key <key>", "MCPJam sk_ API key (overrides MCPJAM_API_KEY)")
-    .option(
-      "--api-url <url>",
-      "MCPJam API base URL (defaults to https://app.mcpjam.com/api/v1)"
-    );
-}
 
-async function runPlatformCommand<TOutput>(
-  options: PlatformOptions,
-  timeoutMs: number,
-  execute: (context: {
-    client: ReturnType<typeof buildPlatformClient>["client"];
-    signal: AbortSignal;
-  }) => Promise<TOutput>
-): Promise<TOutput> {
-  const controller = new AbortController();
-  const timeoutHandle = setTimeout(() => {
-    controller.abort(
-      new PlatformApiError(
-        `Request timed out after ${timeoutMs}ms`,
-        "TIMEOUT",
-        {
-          status: 0,
-        }
-      )
-    );
-  }, timeoutMs);
-  timeoutHandle.unref?.();
-
-  try {
-    const { client } = buildPlatformClient({ ...options, timeoutMs });
-    return await execute({ client, signal: controller.signal });
-  } catch (error) {
-    if (
-      controller.signal.aborted &&
-      controller.signal.reason instanceof PlatformApiError
-    ) {
-      throw toCliError(controller.signal.reason);
-    }
-    throw toCliError(error);
-  } finally {
-    clearTimeout(timeoutHandle);
-  }
-}
 
 /** Read a JSON object from --file (literal path or `-` for stdin) / --json. */
 function loadConfigObject(options: {
@@ -134,18 +88,16 @@ export function registerHostsCommands(program: Command): void {
       writeResult({ items: HOST_TEMPLATES }, globalOptions.format);
     });
 
-  addPlatformOptions(
-    hosts
+      hosts
       .command("list")
       .description("List the hosts saved in a project")
       .option(
         "--project <id-or-name>",
         "Project name or ID (defaults to the most recently updated project)"
-      )
-  ).action(async (options: PlatformOptions & { project?: string }, command) => {
+      ).action(async (options: PlatformOptions & { project?: string }, command) => {
     const globalOptions = getGlobalOptions(command);
     const result = await runPlatformCommand(
-      options,
+      platformOptionsOf(command),
       globalOptions.timeout,
       ({ client, signal }) =>
         listHostsOperation.execute(
@@ -156,20 +108,18 @@ export function registerHostsCommands(program: Command): void {
     writeResult(result, globalOptions.format);
   });
 
-  addPlatformOptions(
-    hosts
+      hosts
       .command("get")
       .description("Show one host's full settings, including its host config")
       .requiredOption("--host <id-or-name>", "Host name or ID")
-      .option("--project <id-or-name>", "Project name or ID")
-  ).action(
+      .option("--project <id-or-name>", "Project name or ID").action(
     async (
       options: PlatformOptions & { project?: string; host: string },
       command
     ) => {
       const globalOptions = getGlobalOptions(command);
       const result = await runPlatformCommand(
-        options,
+        platformOptionsOf(command),
         globalOptions.timeout,
         ({ client, signal }) =>
           getHostOperation.execute(
@@ -181,8 +131,7 @@ export function registerHostsCommands(program: Command): void {
     }
   );
 
-  addPlatformOptions(
-    hosts
+      hosts
       .command("create")
       .description(
         "Create a host from a built-in template (--template) or a full host config (--file/--json)"
@@ -198,8 +147,7 @@ export function registerHostsCommands(program: Command): void {
         "Theme for the seeded config: light or dark (template only)"
       )
       .option("--file <path>", "Host config v2 JSON file (or - for stdin)")
-      .option("--json <json>", "Inline host config v2 JSON (or @file, or -)")
-  ).action(
+      .option("--json <json>", "Inline host config v2 JSON (or @file, or -)").action(
     async (
       options: PlatformOptions & {
         project?: string;
@@ -223,7 +171,7 @@ export function registerHostsCommands(program: Command): void {
         ...(config !== undefined ? { config } : {}),
       });
       const result = await runPlatformCommand(
-        options,
+        platformOptionsOf(command),
         globalOptions.timeout,
         ({ client, signal }) =>
           createHostOperation.execute(input, { client, signal })
@@ -232,8 +180,7 @@ export function registerHostsCommands(program: Command): void {
     }
   );
 
-  addPlatformOptions(
-    hosts
+      hosts
       .command("update")
       .description("Edit a host's name and/or its host config")
       .requiredOption("--host <id-or-name>", "Host name or ID")
@@ -246,8 +193,7 @@ export function registerHostsCommands(program: Command): void {
       .option(
         "--json <json>",
         "Inline replacement host config v2 JSON (or @file, or -)"
-      )
-  ).action(
+      ).action(
     async (
       options: PlatformOptions & {
         project?: string;
@@ -267,7 +213,7 @@ export function registerHostsCommands(program: Command): void {
         ...(config !== undefined ? { config } : {}),
       });
       const result = await runPlatformCommand(
-        options,
+        platformOptionsOf(command),
         globalOptions.timeout,
         ({ client, signal }) =>
           updateHostOperation.execute(input, { client, signal })
@@ -276,13 +222,11 @@ export function registerHostsCommands(program: Command): void {
     }
   );
 
-  addPlatformOptions(
-    hosts
+      hosts
       .command("delete")
       .description("Permanently delete a host from a project")
       .requiredOption("--host <id-or-name>", "Host name or ID")
-      .option("--project <id-or-name>", "Project name or ID")
-  ).action(
+      .option("--project <id-or-name>", "Project name or ID").action(
     async (
       options: PlatformOptions & {
         project?: string;
@@ -292,7 +236,7 @@ export function registerHostsCommands(program: Command): void {
     ) => {
       const globalOptions = getGlobalOptions(command);
       const result = await runPlatformCommand(
-        options,
+        platformOptionsOf(command),
         globalOptions.timeout,
         ({ client, signal }) =>
           deleteHostOperation.execute(
@@ -307,8 +251,7 @@ export function registerHostsCommands(program: Command): void {
     }
   );
 
-  addPlatformOptions(
-    hosts
+      hosts
       .command("servers")
       .description("Replace a host's required and optional server attachments")
       .requiredOption("--host <id-or-name>", "Host name or ID")
@@ -320,8 +263,7 @@ export function registerHostsCommands(program: Command): void {
         "--optional-server-ids <ids>",
         "Comma-separated optional server IDs"
       )
-      .option("--project <id-or-name>", "Project name or ID")
-  ).action(
+      .option("--project <id-or-name>", "Project name or ID").action(
     async (
       options: PlatformOptions & {
         project?: string;
@@ -346,7 +288,7 @@ export function registerHostsCommands(program: Command): void {
           : {}),
       });
       const result = await runPlatformCommand(
-        options,
+        platformOptionsOf(command),
         globalOptions.timeout,
         ({ client, signal }) =>
           setHostServersOperation.execute(input, { client, signal })
@@ -355,14 +297,12 @@ export function registerHostsCommands(program: Command): void {
     }
   );
 
-  addPlatformOptions(
-    hosts
+      hosts
       .command("duplicate")
       .description("Duplicate a host's current config")
       .requiredOption("--host <id-or-name>", "Host name or ID")
       .option("--name <name>", "Name for the new host")
-      .option("--project <id-or-name>", "Project name or ID")
-  ).action(
+      .option("--project <id-or-name>", "Project name or ID").action(
     async (
       options: PlatformOptions & {
         project?: string;
@@ -378,7 +318,7 @@ export function registerHostsCommands(program: Command): void {
         ...(options.name === undefined ? {} : { name: options.name }),
       });
       const result = await runPlatformCommand(
-        options,
+        platformOptionsOf(command),
         globalOptions.timeout,
         ({ client, signal }) =>
           duplicateHostOperation.execute(input, { client, signal })

--- a/cli/src/commands/images.ts
+++ b/cli/src/commands/images.ts
@@ -12,64 +12,18 @@ import {
   resetComputerOperation,
   updateImageOperation,
   useImageOperation,
-  PlatformApiError,
   type PlatformOperation,
 } from "@mcpjam/sdk/platform";
 import { usageError, writeResult } from "../lib/output.js";
-import { buildPlatformClient, toCliError } from "../lib/platform-client.js";
+import {
+  platformOptionsOf,
+  runPlatformOperation as runPlatformCommand,
+  type PlatformOptions,
+} from "../lib/platform-command.js";
 import { getGlobalOptions } from "../lib/server-config.js";
 
-type PlatformOptions = {
-  apiKey?: string;
-  apiUrl?: string;
-};
 
-function addPlatformOptions(command: Command): Command {
-  return command
-    .option("--api-key <key>", "MCPJam sk_ API key (overrides MCPJAM_API_KEY)")
-    .option(
-      "--api-url <url>",
-      "MCPJam API base URL (defaults to https://app.mcpjam.com/api/v1)"
-    );
-}
 
-async function runPlatformCommand<TOutput>(
-  options: PlatformOptions,
-  timeoutMs: number,
-  execute: (context: {
-    client: ReturnType<typeof buildPlatformClient>["client"];
-    signal: AbortSignal;
-  }) => Promise<TOutput>
-): Promise<TOutput> {
-  const controller = new AbortController();
-  const timeoutHandle = setTimeout(() => {
-    controller.abort(
-      new PlatformApiError(
-        `Request timed out after ${timeoutMs}ms`,
-        "TIMEOUT",
-        {
-          status: 0,
-        }
-      )
-    );
-  }, timeoutMs);
-  timeoutHandle.unref?.();
-
-  try {
-    const { client } = buildPlatformClient({ ...options, timeoutMs });
-    return await execute({ client, signal: controller.signal });
-  } catch (error) {
-    if (
-      controller.signal.aborted &&
-      controller.signal.reason instanceof PlatformApiError
-    ) {
-      throw toCliError(controller.signal.reason);
-    }
-    throw toCliError(error);
-  } finally {
-    clearTimeout(timeoutHandle);
-  }
-}
 
 /** Read blueprint YAML TEXT (not JSON) from a path, or stdin when `--file -`. */
 function loadBlueprintText(file: string): string {
@@ -107,18 +61,16 @@ export function registerImagesCommands(program: Command): void {
       "List, build, and manage custom Computer sandbox images (blueprints) in your hosted MCPJam projects"
     );
 
-  addPlatformOptions(
-    env
+      env
       .command("list")
       .description("List the sandbox images in a project")
       .option(
         "--project <id-or-name>",
         "Project name or ID (defaults to the most recently updated project)"
-      )
-  ).action(async (options: PlatformOptions & { project?: string }, command) => {
+      ).action(async (options: PlatformOptions & { project?: string }, command) => {
     const globalOptions = getGlobalOptions(command);
     const result = await runPlatformCommand(
-      options,
+      platformOptionsOf(command),
       globalOptions.timeout,
       ({ client, signal }) =>
         listImagesOperation.execute(
@@ -129,22 +81,20 @@ export function registerImagesCommands(program: Command): void {
     writeResult(result, globalOptions.format);
   });
 
-  addPlatformOptions(
-    env
+      env
       .command("get")
       .description(
         "Show one sandbox image's blueprint and latest build status"
       )
       .requiredOption("--image <id-or-name>", "Sandbox image name or ID")
-      .option("--project <id-or-name>", "Project name or ID")
-  ).action(
+      .option("--project <id-or-name>", "Project name or ID").action(
     async (
       options: PlatformOptions & { project?: string; image: string },
       command
     ) => {
       const globalOptions = getGlobalOptions(command);
       const result = await runPlatformCommand(
-        options,
+        platformOptionsOf(command),
         globalOptions.timeout,
         ({ client, signal }) =>
           getImageOperation.execute(
@@ -156,8 +106,7 @@ export function registerImagesCommands(program: Command): void {
     }
   );
 
-  addPlatformOptions(
-    env
+      env
       .command("create")
       .description(
         "Create a sandbox image from a blueprint YAML file (--file, or - for stdin)"
@@ -167,8 +116,7 @@ export function registerImagesCommands(program: Command): void {
         "--file <path>",
         "Blueprint YAML path, or - to read it from stdin"
       )
-      .option("--project <id-or-name>", "Project name or ID")
-  ).action(
+      .option("--project <id-or-name>", "Project name or ID").action(
     async (
       options: PlatformOptions & {
         project?: string;
@@ -185,7 +133,7 @@ export function registerImagesCommands(program: Command): void {
         blueprint,
       });
       const result = await runPlatformCommand(
-        options,
+        platformOptionsOf(command),
         globalOptions.timeout,
         ({ client, signal }) =>
           createImageOperation.execute(input, { client, signal })
@@ -194,8 +142,7 @@ export function registerImagesCommands(program: Command): void {
     }
   );
 
-  addPlatformOptions(
-    env
+      env
       .command("validate")
       .description(
         "Lint a blueprint YAML file without saving it (--file, or - for stdin)"
@@ -204,8 +151,7 @@ export function registerImagesCommands(program: Command): void {
         "--file <path>",
         "Blueprint YAML path, or - to read it from stdin"
       )
-      .option("--project <id-or-name>", "Project name or ID")
-  ).action(
+      .option("--project <id-or-name>", "Project name or ID").action(
     async (
       options: PlatformOptions & { project?: string; file: string },
       command
@@ -217,7 +163,7 @@ export function registerImagesCommands(program: Command): void {
         blueprint,
       });
       const result = await runPlatformCommand(
-        options,
+        platformOptionsOf(command),
         globalOptions.timeout,
         ({ client, signal }) =>
           validateImageBlueprintOperation.execute(input, { client, signal })
@@ -226,15 +172,13 @@ export function registerImagesCommands(program: Command): void {
     }
   );
 
-  addPlatformOptions(
-    env
+      env
       .command("edit")
       .description("Edit a sandbox image's name and/or blueprint")
       .requiredOption("--image <id-or-name>", "Sandbox image name or ID")
       .option("--project <id-or-name>", "Project name or ID")
       .option("--name <name>", "New display name")
-      .option("--file <path>", "Replacement blueprint YAML path (or - for stdin)")
-  ).action(
+      .option("--file <path>", "Replacement blueprint YAML path (or - for stdin)").action(
     async (
       options: PlatformOptions & {
         project?: string;
@@ -256,7 +200,7 @@ export function registerImagesCommands(program: Command): void {
         ...(blueprint !== undefined ? { blueprint } : {}),
       });
       const result = await runPlatformCommand(
-        options,
+        platformOptionsOf(command),
         globalOptions.timeout,
         ({ client, signal }) =>
           updateImageOperation.execute(input, { client, signal })
@@ -265,22 +209,20 @@ export function registerImagesCommands(program: Command): void {
     }
   );
 
-  addPlatformOptions(
-    env
+      env
       .command("build")
       .description(
         "Build the sandbox image (async — poll `images logs` for status)"
       )
       .requiredOption("--image <id-or-name>", "Sandbox image name or ID")
-      .option("--project <id-or-name>", "Project name or ID")
-  ).action(
+      .option("--project <id-or-name>", "Project name or ID").action(
     async (
       options: PlatformOptions & { project?: string; image: string },
       command
     ) => {
       const globalOptions = getGlobalOptions(command);
       const result = await runPlatformCommand(
-        options,
+        platformOptionsOf(command),
         globalOptions.timeout,
         ({ client, signal }) =>
           buildImageOperation.execute(
@@ -292,22 +234,20 @@ export function registerImagesCommands(program: Command): void {
     }
   );
 
-  addPlatformOptions(
-    env
+      env
       .command("logs")
       .description(
         "Show a sandbox image's builds (newest first) with their log preview"
       )
       .requiredOption("--image <id-or-name>", "Sandbox image name or ID")
-      .option("--project <id-or-name>", "Project name or ID")
-  ).action(
+      .option("--project <id-or-name>", "Project name or ID").action(
     async (
       options: PlatformOptions & { project?: string; image: string },
       command
     ) => {
       const globalOptions = getGlobalOptions(command);
       const result = await runPlatformCommand(
-        options,
+        platformOptionsOf(command),
         globalOptions.timeout,
         ({ client, signal }) =>
           listImageBuildsOperation.execute(
@@ -319,22 +259,20 @@ export function registerImagesCommands(program: Command): void {
     }
   );
 
-  addPlatformOptions(
-    env
+      env
       .command("use")
       .description(
         "Boot your computer from this sandbox image (rebuilds it — installed files are wiped)"
       )
       .requiredOption("--image <id-or-name>", "Sandbox image name or ID")
-      .option("--project <id-or-name>", "Project name or ID")
-  ).action(
+      .option("--project <id-or-name>", "Project name or ID").action(
     async (
       options: PlatformOptions & { project?: string; image: string },
       command
     ) => {
       const globalOptions = getGlobalOptions(command);
       const result = await runPlatformCommand(
-        options,
+        platformOptionsOf(command),
         globalOptions.timeout,
         ({ client, signal }) =>
           useImageOperation.execute(
@@ -346,17 +284,15 @@ export function registerImagesCommands(program: Command): void {
     }
   );
 
-  addPlatformOptions(
-    env
+      env
       .command("reset")
       .description(
         "Reset your computer to its current image (wipes mutable state)"
       )
-      .option("--project <id-or-name>", "Project name or ID")
-  ).action(async (options: PlatformOptions & { project?: string }, command) => {
+      .option("--project <id-or-name>", "Project name or ID").action(async (options: PlatformOptions & { project?: string }, command) => {
     const globalOptions = getGlobalOptions(command);
     const result = await runPlatformCommand(
-      options,
+      platformOptionsOf(command),
       globalOptions.timeout,
       ({ client, signal }) =>
         resetComputerOperation.execute(
@@ -367,22 +303,20 @@ export function registerImagesCommands(program: Command): void {
     writeResult(result, globalOptions.format);
   });
 
-  addPlatformOptions(
-    env
+      env
       .command("promote")
       .description(
         "Share a personal-draft sandbox image with the whole project (admin only)"
       )
       .requiredOption("--image <id-or-name>", "Sandbox image name or ID")
-      .option("--project <id-or-name>", "Project name or ID")
-  ).action(
+      .option("--project <id-or-name>", "Project name or ID").action(
     async (
       options: PlatformOptions & { project?: string; image: string },
       command
     ) => {
       const globalOptions = getGlobalOptions(command);
       const result = await runPlatformCommand(
-        options,
+        platformOptionsOf(command),
         globalOptions.timeout,
         ({ client, signal }) =>
           promoteImageOperation.execute(
@@ -394,20 +328,18 @@ export function registerImagesCommands(program: Command): void {
     }
   );
 
-  addPlatformOptions(
-    env
+      env
       .command("delete")
       .description("Permanently delete a sandbox image from a project")
       .requiredOption("--image <id-or-name>", "Sandbox image name or ID")
-      .option("--project <id-or-name>", "Project name or ID")
-  ).action(
+      .option("--project <id-or-name>", "Project name or ID").action(
     async (
       options: PlatformOptions & { project?: string; image: string },
       command
     ) => {
       const globalOptions = getGlobalOptions(command);
       const result = await runPlatformCommand(
-        options,
+        platformOptionsOf(command),
         globalOptions.timeout,
         ({ client, signal }) =>
           deleteImageOperation.execute(

--- a/cli/src/commands/journeys.ts
+++ b/cli/src/commands/journeys.ts
@@ -6,10 +6,13 @@ import {
   listJourneyRunSessionsOperation,
   listJourneyRunsOperation,
   listJourneysOperation,
-  PlatformApiError,
 } from "@mcpjam/sdk/platform";
 import { usageError, writeResult } from "../lib/output.js";
-import { buildPlatformClient, toCliError } from "../lib/platform-client.js";
+import {
+  platformOptionsOf,
+  runPlatformOperation as runPlatformCommand,
+  type PlatformOptions,
+} from "../lib/platform-command.js";
 import { getGlobalOptions } from "../lib/server-config.js";
 
 /**
@@ -28,57 +31,8 @@ import { getGlobalOptions } from "../lib/server-config.js";
  * `environments` and `images` behave for features an org lacks.
  */
 
-type PlatformOptions = {
-  apiKey?: string;
-  apiUrl?: string;
-};
 
-function addPlatformOptions(command: Command): Command {
-  return command
-    .option("--api-key <key>", "MCPJam sk_ API key (overrides MCPJAM_API_KEY)")
-    .option(
-      "--api-url <url>",
-      "MCPJam API base URL (defaults to https://app.mcpjam.com/api/v1)"
-    );
-}
 
-async function runPlatformCommand<TOutput>(
-  options: PlatformOptions,
-  timeoutMs: number,
-  execute: (context: {
-    client: ReturnType<typeof buildPlatformClient>["client"];
-    signal: AbortSignal;
-  }) => Promise<TOutput>
-): Promise<TOutput> {
-  const controller = new AbortController();
-  const timeoutHandle = setTimeout(() => {
-    controller.abort(
-      new PlatformApiError(
-        `Request timed out after ${timeoutMs}ms`,
-        "TIMEOUT",
-        {
-          status: 0,
-        }
-      )
-    );
-  }, timeoutMs);
-  timeoutHandle.unref?.();
-
-  try {
-    const { client } = buildPlatformClient({ ...options, timeoutMs });
-    return await execute({ client, signal: controller.signal });
-  } catch (error) {
-    if (
-      controller.signal.aborted &&
-      controller.signal.reason instanceof PlatformApiError
-    ) {
-      throw toCliError(controller.signal.reason);
-    }
-    throw toCliError(error);
-  } finally {
-    clearTimeout(timeoutHandle);
-  }
-}
 
 /** Commander's collector for a repeatable option (`--environment a --environment b`). */
 function collectRepeatable(value: string, previous: string[]): string[] {
@@ -136,18 +90,16 @@ export function registerJourneysCommands(program: Command): Command {
       "List journeys and inspect their runs (the Swarms product) in your hosted MCPJam projects"
     );
 
-  addPlatformOptions(
-    journeys
+      journeys
       .command("list")
       .description("List the journeys in a project")
       .option(
         "--project <id-or-name>",
         "Project name or ID (defaults to the most recently updated project)"
-      )
-  ).action(async (options: PlatformOptions & { project?: string }, command) => {
+      ).action(async (options: PlatformOptions & { project?: string }, command) => {
     const globalOptions = getGlobalOptions(command);
     const result = await runPlatformCommand(
-      options,
+      platformOptionsOf(command),
       globalOptions.timeout,
       ({ client, signal }) =>
         listJourneysOperation.execute(
@@ -158,15 +110,13 @@ export function registerJourneysCommands(program: Command): Command {
     writeResult(result, globalOptions.format);
   });
 
-  addPlatformOptions(
-    addPageOptions(
+      addPageOptions(
       journeys
         .command("runs")
         .description("List a journey's runs, newest first")
         .requiredOption("--journey <id>", "Journey ID (from `journeys list`)")
         .option("--project <id-or-name>", "Project name or ID")
-    )
-  ).action(
+    ).action(
     async (
       options: PlatformOptions &
         PageOptions & {
@@ -177,7 +127,7 @@ export function registerJourneysCommands(program: Command): Command {
     ) => {
       const globalOptions = getGlobalOptions(command);
       const result = await runPlatformCommand(
-        options,
+        platformOptionsOf(command),
         globalOptions.timeout,
         ({ client, signal }) =>
           listJourneyRunsOperation.execute(
@@ -193,22 +143,20 @@ export function registerJourneysCommands(program: Command): Command {
     }
   );
 
-  addPlatformOptions(
-    journeys
+      journeys
       .command("status")
       .description(
         "Show one run's status, target rollups, and per-session attempts. Poll this after launching; `status` leaves 'running' once every attempt has settled. A run someone stopped reports 'failed' with canceled: true."
       )
       .requiredOption("--run <id>", "Journey run ID")
-      .option("--project <id-or-name>", "Project name or ID")
-  ).action(
+      .option("--project <id-or-name>", "Project name or ID").action(
     async (
       options: PlatformOptions & { project?: string; run: string },
       command
     ) => {
       const globalOptions = getGlobalOptions(command);
       const result = await runPlatformCommand(
-        options,
+        platformOptionsOf(command),
         globalOptions.timeout,
         ({ client, signal }) =>
           getJourneyRunOperation.execute(
@@ -220,8 +168,7 @@ export function registerJourneysCommands(program: Command): Command {
     }
   );
 
-  addPlatformOptions(
-    journeys
+      journeys
       .command("run")
       .description(
         "Launch a journey. Returns as soon as the run exists — poll `journeys status` for progress."
@@ -241,8 +188,7 @@ export function registerJourneysCommands(program: Command): Command {
         "Fan out across this project environment instead of the journey's authored targets (repeatable)",
         collectRepeatable,
         [] as string[]
-      )
-  ).action(
+      ).action(
     async (
       options: PlatformOptions & {
         project?: string;
@@ -255,7 +201,7 @@ export function registerJourneysCommands(program: Command): Command {
     ) => {
       const globalOptions = getGlobalOptions(command);
       const result = await runPlatformCommand(
-        options,
+        platformOptionsOf(command),
         globalOptions.timeout,
         ({ client, signal }) =>
           launchJourneyRunOperation.execute(
@@ -277,22 +223,20 @@ export function registerJourneysCommands(program: Command): Command {
     }
   );
 
-  addPlatformOptions(
-    journeys
+      journeys
       .command("cancel")
       .description(
         "Stop a running journey run. Idempotent — cancelling an already-cancelled run succeeds; a run that finished on its own conflicts instead."
       )
       .requiredOption("--run <id>", "Journey run ID")
-      .option("--project <id-or-name>", "Project name or ID")
-  ).action(
+      .option("--project <id-or-name>", "Project name or ID").action(
     async (
       options: PlatformOptions & { project?: string; run: string },
       command
     ) => {
       const globalOptions = getGlobalOptions(command);
       const result = await runPlatformCommand(
-        options,
+        platformOptionsOf(command),
         globalOptions.timeout,
         ({ client, signal }) =>
           cancelJourneyRunOperation.execute(
@@ -304,8 +248,7 @@ export function registerJourneysCommands(program: Command): Command {
     }
   );
 
-  addPlatformOptions(
-    addPageOptions(
+      addPageOptions(
       journeys
         .command("sessions")
         .description(
@@ -313,8 +256,7 @@ export function registerJourneysCommands(program: Command): Command {
         )
         .requiredOption("--run <id>", "Journey run ID")
         .option("--project <id-or-name>", "Project name or ID")
-    )
-  ).action(
+    ).action(
     async (
       options: PlatformOptions &
         PageOptions & {
@@ -325,7 +267,7 @@ export function registerJourneysCommands(program: Command): Command {
     ) => {
       const globalOptions = getGlobalOptions(command);
       const result = await runPlatformCommand(
-        options,
+        platformOptionsOf(command),
         globalOptions.timeout,
         ({ client, signal }) =>
           listJourneyRunSessionsOperation.execute(

--- a/cli/src/commands/organizations.ts
+++ b/cli/src/commands/organizations.ts
@@ -13,62 +13,18 @@
 import type { Command } from "commander";
 import {
   listOrganizationsOperation,
-  PlatformApiError,
 } from "@mcpjam/sdk/platform";
 import { writeResult } from "../lib/output.js";
 import { formatOrganizationsHuman } from "../lib/projects-render.js";
-import { buildPlatformClient, toCliError } from "../lib/platform-client.js";
+import {
+  platformOptionsOf,
+  runPlatformOperation as runPlatformCommand,
+  type PlatformOptions,
+} from "../lib/platform-command.js";
 import { getGlobalOptions } from "../lib/server-config.js";
 
-type PlatformOptions = {
-  apiKey?: string;
-  apiUrl?: string;
-};
 
-function addPlatformOptions(command: Command): Command {
-  return command
-    .option("--api-key <key>", "MCPJam sk_ API key (overrides MCPJAM_API_KEY)")
-    .option(
-      "--api-url <url>",
-      "MCPJam API base URL (defaults to https://app.mcpjam.com/api/v1)",
-    );
-}
 
-async function runPlatformCommand<TOutput>(
-  options: PlatformOptions,
-  timeoutMs: number,
-  execute: (context: {
-    client: ReturnType<typeof buildPlatformClient>["client"];
-    signal: AbortSignal;
-  }) => Promise<TOutput>,
-): Promise<TOutput> {
-  const controller = new AbortController();
-  const timeoutHandle = setTimeout(() => {
-    controller.abort(
-      new PlatformApiError(`Request timed out after ${timeoutMs}ms`, "TIMEOUT", {
-        status: 0,
-      }),
-    );
-  }, timeoutMs);
-  timeoutHandle.unref?.();
-
-  try {
-    const { client } = buildPlatformClient({ ...options, timeoutMs });
-    return await execute({ client, signal: controller.signal });
-  } catch (error) {
-    // When OUR deadline fired, surface the armed TIMEOUT error rather than the
-    // bare AbortError some fetch implementations reject with.
-    if (
-      controller.signal.aborted &&
-      controller.signal.reason instanceof PlatformApiError
-    ) {
-      throw toCliError(controller.signal.reason);
-    }
-    throw toCliError(error);
-  } finally {
-    clearTimeout(timeoutHandle);
-  }
-}
 
 export function registerOrganizationsCommands(program: Command): void {
   const organizations = program
@@ -76,19 +32,15 @@ export function registerOrganizationsCommands(program: Command): void {
     .alias("orgs")
     .description("Inspect the MCPJam organizations you belong to");
 
-  addPlatformOptions(
-    organizations
-      .command("list")
-      .description(
-        "List your organizations and their ids (an sk_ key sees only its own)",
-      ),
-    // `--api-key` / `--api-url` are declared only here, not on the group, so
-    // Commander hands them to this action directly — no `optsWithGlobals`
-    // merge dance like `projects`, whose `servers` group duplicates them.
-  ).action(async (options: PlatformOptions, command) => {
+  organizations
+    .command("list")
+    .description(
+      "List your organizations and their ids (an sk_ key sees only its own)",
+    )
+    .action(async (_options: PlatformOptions, command) => {
     const globalOptions = getGlobalOptions(command);
     const result = await runPlatformCommand(
-      options,
+      platformOptionsOf(command),
       globalOptions.timeout,
       ({ client, signal }) =>
         listOrganizationsOperation.execute({}, { client, signal }),

--- a/cli/src/commands/projects.ts
+++ b/cli/src/commands/projects.ts
@@ -21,7 +21,6 @@ import {
 import { writeResult } from "../lib/output.js";
 import { DEFAULT_PLATFORM_ORIGIN } from "../lib/platform-auth.js";
 import {
-  addPlatformOptions,
   buildCloudClientContext,
   platformOptionsOf,
   runPlatformCommand,
@@ -112,8 +111,7 @@ export function registerProjectsCommands(program: Command): void {
       "Operate the MCP servers saved in your hosted MCPJam projects"
     );
 
-  addPlatformOptions(
-    projects
+      projects
       .command("list")
       .description("List the projects you can access")
       // The operation has always taken this filter; the CLI had no way to pass
@@ -126,8 +124,7 @@ export function registerProjectsCommands(program: Command): void {
       .option(
         "--organization-id <id>",
         "Restrict the listing to one organization (see `mcpjam cloud organizations list`)"
-      )
-  ).action(async (_options: PlatformOptions, command) => {
+      ).action(async (_options: PlatformOptions, command) => {
     const globalOptions = getGlobalOptions(command);
     const rawOrganization = (command.opts() as { organizationId?: string })
       .organizationId;
@@ -159,15 +156,13 @@ export function registerProjectsCommands(program: Command): void {
     }
   });
 
-  addPlatformOptions(
-    projects
+      projects
       .command("create")
       .description("Create a hosted MCPJam project")
       .requiredOption("--name <name>", "Project name")
       .option("--description <text>", "Project description")
       .option("--organization-id <id>", "Organization ID")
-      .option("--visibility <visibility>", "public or private")
-  ).action(
+      .option("--visibility <visibility>", "public or private").action(
     async (
       options: PlatformOptions & {
         name: string;
@@ -200,15 +195,13 @@ export function registerProjectsCommands(program: Command): void {
     }
   );
 
-  addPlatformOptions(
-    projects
+      projects
       .command("update")
       .description("Update project metadata")
       .requiredOption("--project <id-or-name>", "Project name or ID")
       .option("--name <name>", "New project name")
       .option("--description <text>", "New project description")
-      .option("--visibility <visibility>", "public or private")
-  ).action(
+      .option("--visibility <visibility>", "public or private").action(
     async (
       options: PlatformOptions & {
         name?: string;
@@ -239,12 +232,10 @@ export function registerProjectsCommands(program: Command): void {
     }
   );
 
-  addPlatformOptions(
-    projects
+      projects
       .command("delete")
       .description("Delete a project and its project-owned resources")
-      .requiredOption("--project <id-or-name>", "Project name or ID")
-  ).action(async (_options: PlatformOptions, command) => {
+      .requiredOption("--project <id-or-name>", "Project name or ID").action(async (_options: PlatformOptions, command) => {
     const globalOptions = getGlobalOptions(command);
     const platformOptions = platformOptionsOf<PlatformOptions>(command);
     const input = deleteProjectOperation.inputSchema.parse({
@@ -259,12 +250,10 @@ export function registerProjectsCommands(program: Command): void {
     writeResult(result, globalOptions.format);
   });
 
-  const servers = addPlatformOptions(
-    projects
+  const servers =     projects
       .command("servers")
       .alias("server")
-      .description("List and manage the servers saved in a project")
-  ).option(
+      .description("List and manage the servers saved in a project").option(
     "--project <id-or-name>",
     "Project name or ID (defaults to the most recently updated project)"
   );
@@ -296,14 +285,12 @@ export function registerProjectsCommands(program: Command): void {
     return parsed as Record<string, unknown>;
   };
 
-  addPlatformOptions(
-    servers
+      servers
       .command("create")
       .alias("add")
       .description("Create a saved MCP server")
       .option("--project <id-or-name>", "Project name or ID")
-      .requiredOption("--body <json>", "Server JSON body")
-  ).action(async (options: PlatformOptions & { body: string }, command) => {
+      .requiredOption("--body <json>", "Server JSON body").action(async (options: PlatformOptions & { body: string }, command) => {
     const globalOptions = getGlobalOptions(command);
     const platformOptions = platformOptionsOf<PlatformOptions>(command);
     const project = requireProject(command, platformOptions);
@@ -319,13 +306,11 @@ export function registerProjectsCommands(program: Command): void {
     writeResult(result, globalOptions.format);
   });
 
-  addPlatformOptions(
-    servers
+      servers
       .command("get")
       .description("Get one saved MCP server")
       .option("--project <id-or-name>", "Project name or ID")
-      .requiredOption("--server <id>", "Server ID")
-  ).action(async (options: PlatformOptions & { server: string }, command) => {
+      .requiredOption("--server <id>", "Server ID").action(async (options: PlatformOptions & { server: string }, command) => {
     const globalOptions = getGlobalOptions(command);
     const platformOptions = platformOptionsOf<PlatformOptions>(command);
     const project = requireProject(command, platformOptions);
@@ -341,14 +326,12 @@ export function registerProjectsCommands(program: Command): void {
     writeResult(result, globalOptions.format);
   });
 
-  addPlatformOptions(
-    servers
+      servers
       .command("update")
       .description("Update one saved MCP server")
       .option("--project <id-or-name>", "Project name or ID")
       .requiredOption("--server <id>", "Server ID")
-      .requiredOption("--body <json>", "Patch JSON body")
-  ).action(
+      .requiredOption("--body <json>", "Patch JSON body").action(
     async (
       options: PlatformOptions & { server: string; body: string },
       command
@@ -373,14 +356,12 @@ export function registerProjectsCommands(program: Command): void {
     }
   );
 
-  addPlatformOptions(
-    servers
+      servers
       .command("delete")
       .alias("remove")
       .description("Delete one saved MCP server")
       .option("--project <id-or-name>", "Project name or ID")
-      .requiredOption("--server <id>", "Server ID")
-  ).action(async (options: PlatformOptions & { server: string }, command) => {
+      .requiredOption("--server <id>", "Server ID").action(async (options: PlatformOptions & { server: string }, command) => {
     const globalOptions = getGlobalOptions(command);
     const platformOptions = platformOptionsOf<PlatformOptions>(command);
     const project = requireProject(command, platformOptions);
@@ -396,8 +377,7 @@ export function registerProjectsCommands(program: Command): void {
     writeResult(result, globalOptions.format);
   });
 
-  addPlatformOptions(
-    servers
+      servers
       .command("connect")
       .description(
         "Connect an MCP server URL to a project, authorizing in a browser if needed"
@@ -411,8 +391,7 @@ export function registerProjectsCommands(program: Command): void {
       .option("--name <name>", "Name for the server, if one is created")
       .option("--reauthorize", "Force a fresh authorization")
       .option("--no-browser", "Print the authorization link instead of opening it")
-      .option("--no-wait", "Return as soon as the request is created")
-  ).action(
+      .option("--no-wait", "Return as soon as the request is created").action(
     async (
       options: PlatformOptions & {
         url: string;
@@ -503,12 +482,10 @@ export function registerProjectsCommands(program: Command): void {
     }
   );
 
-  addPlatformOptions(
-    servers
+      servers
       .command("connect-status")
       .description("Check a connection request started by `server connect`")
-      .requiredOption("--request <id>", "Connection request id (scr_…)")
-  ).action(
+      .requiredOption("--request <id>", "Connection request id (scr_…)").action(
     async (options: PlatformOptions & { request: string }, command) => {
       const globalOptions = getGlobalOptions(command);
       const input = getProjectServerConnectionStatusOperation.inputSchema.parse({
@@ -527,8 +504,7 @@ export function registerProjectsCommands(program: Command): void {
     }
   );
 
-  addPlatformOptions(
-    projects
+      projects
       .command("status")
       .description(
         "Health-check every server in a project (hosted doctor per server)"
@@ -536,8 +512,7 @@ export function registerProjectsCommands(program: Command): void {
       .option(
         "--project <id-or-name>",
         "Project name or ID (defaults to the most recently updated project)"
-      )
-  ).action(async (_options: PlatformOptions, command) => {
+      ).action(async (_options: PlatformOptions, command) => {
     const globalOptions = getGlobalOptions(command);
     const platformOptions = platformOptionsOf<PlatformOptions>(command);
     const payload = await runPlatformCommand(

--- a/cli/src/commands/scenarios.ts
+++ b/cli/src/commands/scenarios.ts
@@ -2,12 +2,15 @@ import type { Command } from "commander";
 import {
   getScenarioOperation,
   listScenariosOperation,
-  PlatformApiError,
   publishScenarioOperation,
   unpublishScenarioOperation,
 } from "@mcpjam/sdk/platform";
 import { writeResult } from "../lib/output.js";
-import { buildPlatformClient, toCliError } from "../lib/platform-client.js";
+import {
+  platformOptionsOf,
+  runPlatformOperation as runPlatformCommand,
+  type PlatformOptions,
+} from "../lib/platform-command.js";
 import { getGlobalOptions } from "../lib/server-config.js";
 
 /**
@@ -26,57 +29,8 @@ import { getGlobalOptions } from "../lib/server-config.js";
  * a live scenario down has to keep working for an org that just lost the flag.
  */
 
-type PlatformOptions = {
-  apiKey?: string;
-  apiUrl?: string;
-};
 
-function addPlatformOptions(command: Command): Command {
-  return command
-    .option("--api-key <key>", "MCPJam sk_ API key (overrides MCPJAM_API_KEY)")
-    .option(
-      "--api-url <url>",
-      "MCPJam API base URL (defaults to https://app.mcpjam.com/api/v1)"
-    );
-}
 
-async function runPlatformCommand<TOutput>(
-  options: PlatformOptions,
-  timeoutMs: number,
-  execute: (context: {
-    client: ReturnType<typeof buildPlatformClient>["client"];
-    signal: AbortSignal;
-  }) => Promise<TOutput>
-): Promise<TOutput> {
-  const controller = new AbortController();
-  const timeoutHandle = setTimeout(() => {
-    controller.abort(
-      new PlatformApiError(
-        `Request timed out after ${timeoutMs}ms`,
-        "TIMEOUT",
-        {
-          status: 0,
-        }
-      )
-    );
-  }, timeoutMs);
-  timeoutHandle.unref?.();
-
-  try {
-    const { client } = buildPlatformClient({ ...options, timeoutMs });
-    return await execute({ client, signal: controller.signal });
-  } catch (error) {
-    if (
-      controller.signal.aborted &&
-      controller.signal.reason instanceof PlatformApiError
-    ) {
-      throw toCliError(controller.signal.reason);
-    }
-    throw toCliError(error);
-  } finally {
-    clearTimeout(timeoutHandle);
-  }
-}
 
 export function registerScenariosCommands(program: Command): void {
   const scenarios = program
@@ -91,18 +45,16 @@ export function registerScenariosCommands(program: Command): void {
     "anyone_with_link",
   ] as const;
 
-  addPlatformOptions(
-    scenarios
+      scenarios
       .command("list")
       .description("List the scenarios published from a project")
       .option(
         "--project <id-or-name>",
         "Project name or ID (defaults to the most recently updated project)"
-      )
-  ).action(async (options: PlatformOptions & { project?: string }, command) => {
+      ).action(async (options: PlatformOptions & { project?: string }, command) => {
     const globalOptions = getGlobalOptions(command);
     const result = await runPlatformCommand(
-      options,
+      platformOptionsOf(command),
       globalOptions.timeout,
       ({ client, signal }) =>
         listScenariosOperation.execute(
@@ -117,8 +69,7 @@ export function registerScenariosCommands(program: Command): void {
     writeResult(result, globalOptions.format);
   });
 
-  addPlatformOptions(
-    scenarios
+      scenarios
       .command("get")
       .description(
         "Show one scenario: access mode, attached servers, share link"
@@ -127,15 +78,14 @@ export function registerScenariosCommands(program: Command): void {
       .option(
         "--project <id-or-name>",
         "Project name or ID (defaults to the most recently updated project)"
-      )
-  ).action(
+      ).action(
     async (
       options: PlatformOptions & { scenario: string; project?: string },
       command
     ) => {
       const globalOptions = getGlobalOptions(command);
       const result = await runPlatformCommand(
-        options,
+        platformOptionsOf(command),
         globalOptions.timeout,
         ({ client, signal }) =>
           getScenarioOperation.execute(
@@ -152,8 +102,7 @@ export function registerScenariosCommands(program: Command): void {
     }
   );
 
-  addPlatformOptions(
-    scenarios
+      scenarios
       .command("publish")
       .description(
         "Publish an environment as a scenario and print its share link. Idempotent — re-publishing returns the existing scenario, with created: false. --name, --description and --mode apply at CREATE TIME, in the same call; on a re-publish they are ignored and the result says overridesIgnored: true (use `mcpjam cloud user-testing update` to change an existing scenario)."
@@ -168,8 +117,7 @@ export function registerScenariosCommands(program: Command): void {
       .option(
         "--mode <mode>",
         "Who may open the share link (create time only): project_members | invited_only | anyone_with_link"
-      )
-  ).action(
+      ).action(
     async (
       options: PlatformOptions & {
         project?: string;
@@ -192,7 +140,7 @@ export function registerScenariosCommands(program: Command): void {
         );
       }
       const result = await runPlatformCommand(
-        options,
+        platformOptionsOf(command),
         globalOptions.timeout,
         ({ client, signal }) =>
           publishScenarioOperation.execute(
@@ -212,22 +160,20 @@ export function registerScenariosCommands(program: Command): void {
     }
   );
 
-  addPlatformOptions(
-    scenarios
+      scenarios
       .command("unpublish")
       .description(
         "Take an environment's scenario down, invalidating its share link and any live guest sessions. Idempotent."
       )
       .requiredOption("--environment <id>", "Project environment ID")
-      .option("--project <id-or-name>", "Project name or ID")
-  ).action(
+      .option("--project <id-or-name>", "Project name or ID").action(
     async (
       options: PlatformOptions & { project?: string; environment: string },
       command
     ) => {
       const globalOptions = getGlobalOptions(command);
       const result = await runPlatformCommand(
-        options,
+        platformOptionsOf(command),
         globalOptions.timeout,
         ({ client, signal }) =>
           unpublishScenarioOperation.execute(

--- a/cli/src/commands/sessions.ts
+++ b/cli/src/commands/sessions.ts
@@ -24,10 +24,9 @@ import {
 } from "../lib/platform-command.js";
 
 /**
- * Extends `PlatformOptions` because `bindOperation` declares the credential
- * flags on the LEAF command and hands its action the merged options — the same
- * arrangement `organizations.ts` documents. Declaring them on the group instead
- * would put `--api-key` somewhere Commander never passes to this action.
+ * Extends `PlatformOptions` because `bindOperation` reads `--api-key` /
+ * `--api-url` from the `cloud` parent via `platformOptionsOf`. `--project`
+ * stays on this leaf so account-scoped commands do not pretend to have one.
  */
 type SearchOptions = PlatformOptions & {
   project?: string;

--- a/cli/src/commands/tunnel.ts
+++ b/cli/src/commands/tunnel.ts
@@ -4,7 +4,7 @@ import {
   type CreateTunnelResult,
 } from "@mcpjam/sdk/platform";
 import { cliError, usageError, writeResult } from "../lib/output.js";
-import { buildCloudClientContext } from "../lib/platform-command.js";
+import { buildCloudClientContext, platformOptionsOf } from "../lib/platform-command.js";
 import { toCliError } from "../lib/platform-client.js";
 import { getGlobalOptions, parseServerConfig } from "../lib/server-config.js";
 import { startLocalBridge, type TunnelTarget } from "../lib/tunnel/local-bridge.js";
@@ -90,11 +90,6 @@ export function registerTunnelCommands(program: Command): void {
       "--project <id-or-name>",
       "Project name or ID (defaults to the most recently updated project)",
     )
-    .option("--api-key <key>", "MCPJam sk_ API key (overrides MCPJAM_API_KEY)")
-    .option(
-      "--api-url <url>",
-      "MCPJam API base URL (defaults to https://app.mcpjam.com/api/v1)",
-    )
     .option(
       "-e, --env <env...>",
       'Stdio environment assignment in "KEY=VALUE" format. Pass multiple values or repeat the flag.',
@@ -141,10 +136,7 @@ export function registerTunnelCommands(program: Command): void {
         let client;
         try {
           ({ client } = buildCloudClientContext(
-            {
-              apiKey: options.apiKey,
-              apiUrl: options.apiUrl,
-            },
+            platformOptionsOf(command),
             globalOptions.timeout,
           ));
         } catch (error) {

--- a/cli/src/lib/platform-command.ts
+++ b/cli/src/lib/platform-command.ts
@@ -6,10 +6,10 @@
  * and error translation. Long-lived commands (`tunnel`) use the former;
  * bounded operations use the latter.
  *
- * Credential flags still live on each leaf in this revision so unmigrated
- * commands cannot accept-and-ignore a parent option. `platformOptionsOf`
- * walks the Commander tree nearest-first so a later hoist onto `cloud`
- * keeps working.
+ * Credential flags live on the `cloud` parent. `platformOptionsOf` walks the
+ * Commander tree nearest-first so a value typed before or after a descendant
+ * is visible to the action. Local commands, including hosted `readiness`,
+ * still declare leaf flags where they need them.
  */
 import type { Command } from "commander";
 import { PlatformApiError } from "@mcpjam/sdk/platform";
@@ -197,7 +197,21 @@ export async function runPlatformCommand<TOutput>(
  * per-command code most of these need, which is the point — a command that is
  * "call this operation with these flags" should not also be 30 lines of
  * identical error handling.
+ *
+ * Cloud commands inherit `--api-key` / `--api-url` from the `cloud` parent.
+ * Hosted `readiness` stays at the program root and still gets leaf flags.
  */
+function hasCloudAncestor(command: Command): boolean {
+  for (
+    let current: Command | null = command.parent;
+    current !== null;
+    current = current.parent
+  ) {
+    if (current.name() === "cloud") return true;
+  }
+  return false;
+}
+
 export function bindOperation<TOptions extends PlatformOptions, TInput>(
   command: Command,
   operation: {
@@ -211,18 +225,19 @@ export function bindOperation<TOptions extends PlatformOptions, TInput>(
   },
   buildInput: (options: TOptions) => TInput
 ): void {
-  addPlatformOptions(command).action(
-    async (options: TOptions, invoked: Command) => {
-      const globalOptions = getGlobalOptions(invoked);
-      const result = await runPlatformOperation(
-        platformOptionsOf<TOptions>(invoked),
-        globalOptions.timeout,
-        ({ client, signal }) =>
-          operation.execute(buildInput(options), { client, signal })
-      );
-      writeResult(result, globalOptions.format);
-    }
-  );
+  if (!hasCloudAncestor(command)) {
+    addPlatformOptions(command);
+  }
+  command.action(async (options: TOptions, invoked: Command) => {
+    const globalOptions = getGlobalOptions(invoked);
+    const result = await runPlatformOperation(
+      platformOptionsOf<TOptions>(invoked),
+      globalOptions.timeout,
+      ({ client, signal }) =>
+        operation.execute(buildInput(options), { client, signal })
+    );
+    writeResult(result, globalOptions.format);
+  });
 }
 
 /** `--project` is optional everywhere: it defaults to the newest project. */

--- a/cli/tests/cloud-credential-flags.test.ts
+++ b/cli/tests/cloud-credential-flags.test.ts
@@ -1,0 +1,205 @@
+import assert from "node:assert/strict";
+import { mkdtemp } from "node:fs/promises";
+import { createServer, type Server } from "node:http";
+import os from "node:os";
+import path from "node:path";
+import test from "node:test";
+import { main } from "../src/index.js";
+import { captureProcessOutput, runCli } from "./support/cli-run.js";
+
+async function startMeFixture(): Promise<{
+  baseUrl: string;
+  close: () => Promise<void>;
+}> {
+  const server: Server = createServer((req, res) => {
+    if (req.url?.endsWith("/me")) {
+      res.statusCode = 200;
+      res.setHeader("content-type", "application/json");
+      res.end(
+        JSON.stringify({
+          id: "user-1",
+          email: "dev@example.com",
+          name: "Dev",
+          imageUrl: null,
+          profilePictureUrl: null,
+          plan: "pro",
+          createdAt: null,
+          updatedAt: null,
+        })
+      );
+      return;
+    }
+    res.statusCode = 404;
+    res.end(JSON.stringify({ code: "NOT_FOUND", message: "no route" }));
+  });
+
+  await new Promise<void>((resolve) =>
+    server.listen(0, "127.0.0.1", () => resolve())
+  );
+  const address = server.address();
+  if (!address || typeof address === "string") {
+    throw new Error("fixture server has no address");
+  }
+
+  return {
+    baseUrl: `http://127.0.0.1:${address.port}/api/v1`,
+    close: () =>
+      new Promise<void>((resolve, reject) =>
+        server.close((error) => (error ? reject(error) : resolve()))
+      ),
+  };
+}
+
+test("cloud credential flags work after a descendant command", async () => {
+  const fixture = await startMeFixture();
+  try {
+    const run = await runCli([
+      "cloud",
+      "whoami",
+      "--api-key",
+      "sk_test",
+      "--api-url",
+      fixture.baseUrl,
+      "--format",
+      "json",
+    ]);
+    assert.equal(run.exitCode, 0, run.stderr);
+    assert.equal(JSON.parse(run.stdout).email, "dev@example.com");
+  } finally {
+    await fixture.close();
+  }
+});
+
+test("cloud credential flags work before a descendant command", async () => {
+  const fixture = await startMeFixture();
+  try {
+    const run = await runCli([
+      "cloud",
+      "--api-key",
+      "sk_test",
+      "--api-url",
+      fixture.baseUrl,
+      "whoami",
+      "--format",
+      "json",
+    ]);
+    assert.equal(run.exitCode, 0, run.stderr);
+    assert.equal(JSON.parse(run.stdout).email, "dev@example.com");
+  } finally {
+    await fixture.close();
+  }
+});
+
+test("credential flags remain invalid before cloud", async () => {
+  const run = await runCli([
+    "--api-key",
+    "sk_test",
+    "cloud",
+    "whoami",
+    "--format",
+    "json",
+  ]);
+  assert.equal(run.exitCode, 2);
+  const payload = JSON.parse(run.stderr);
+  assert.equal(payload.error.code, "USAGE_ERROR");
+  assert.match(payload.error.message, /unknown option '--api-key'/i);
+});
+
+test("local commands still reject cloud credential flags", async () => {
+  const run = await runCli([
+    "server",
+    "probe",
+    "--url",
+    "http://127.0.0.1:9/mcp",
+    "--api-key",
+    "sk_test",
+  ]);
+  assert.equal(run.exitCode, 2);
+  const payload = JSON.parse(run.stderr);
+  assert.equal(payload.error.code, "USAGE_ERROR");
+  assert.match(payload.error.message, /unknown option '--api-key'/i);
+});
+
+test("cloud login rejects --api-key instead of ignoring it", async () => {
+  const run = await runCli(["cloud", "login", "--api-key", "sk_test"]);
+  assert.equal(run.exitCode, 2);
+  const payload = JSON.parse(run.stderr);
+  assert.equal(payload.error.code, "USAGE_ERROR");
+  assert.match(payload.error.message, /browser OAuth/);
+});
+
+test("hosted readiness still accepts leaf --api-key", async () => {
+  const run = await runCli([
+    "readiness",
+    "start",
+    "claude",
+    "--server",
+    "demo",
+    "--api-key",
+    "mcpjam_legacy",
+    "--format",
+    "json",
+  ]);
+  // Unknown option would be exit 2 with unknown option. A legacy key is a
+  // usage error from credential resolution — proof the flag was accepted.
+  assert.equal(run.exitCode, 2);
+  const payload = JSON.parse(run.stderr);
+  assert.equal(payload.error.code, "USAGE_ERROR");
+  assert.match(payload.error.message, /Legacy mcpjam_ API keys/);
+});
+
+test("telemetry events never include raw cloud credential values", async () => {
+  const fixture = await startMeFixture();
+  const directory = await mkdtemp(path.join(os.tmpdir(), "mcpjam-telemetry-"));
+  const statePath = path.join(directory, "telemetry.json");
+  const events: Array<{ properties: Record<string, unknown> }> = [];
+  const env: NodeJS.ProcessEnv = { ...process.env };
+  for (const key of [
+    "DO_NOT_TRACK",
+    "MCPJAM_TELEMETRY_DISABLED",
+    "MCPJAM_TELEMETRY_DEBUG",
+    "CI",
+    "GITHUB_ACTIONS",
+  ]) {
+    delete env[key];
+  }
+
+  try {
+    const run = await captureProcessOutput(() =>
+      main(
+        [
+          "node",
+          "mcpjam",
+          "cloud",
+          "whoami",
+          "--api-key",
+          "sk_telemetry_secret",
+          "--api-url",
+          fixture.baseUrl,
+          "--format",
+          "json",
+        ],
+        {
+          telemetry: {
+            statePath,
+            env,
+            createClient: () => ({
+              capture(event) {
+                events.push(event);
+              },
+              async flush() {},
+            }),
+          },
+        }
+      )
+    );
+
+    assert.equal(run.result.exitCode, 0, run.stderr);
+    assert.ok(events.length >= 1, "expected a telemetry event");
+    const serialized = JSON.stringify(events);
+    assert.equal(serialized.includes("sk_telemetry_secret"), false);
+    assert.equal(serialized.includes(fixture.baseUrl), false);
+  } finally {
+    await fixture.close();
+  }
+});

--- a/cli/tests/scenarios-cli.test.ts
+++ b/cli/tests/scenarios-cli.test.ts
@@ -2,6 +2,7 @@ import assert from "node:assert/strict";
 import { afterEach, test } from "node:test";
 import { Command, CommanderError } from "commander";
 import { registerScenariosCommands } from "../src/commands/scenarios.js";
+import { addPlatformOptions } from "../src/lib/platform-command.js";
 
 /**
  * `mcpjam scenarios publish` — the create-time override flags.
@@ -17,7 +18,9 @@ function buildProgram(): Command {
     .name("mcpjam")
     .exitOverride()
     .configureOutput({ writeErr: () => {}, writeOut: () => {} });
-  registerScenariosCommands(program);
+  const cloud = program.command("cloud");
+  addPlatformOptions(cloud);
+  registerScenariosCommands(cloud);
   return program;
 }
 
@@ -38,6 +41,7 @@ test("publish rejects a mode outside the enum without any request", async () => 
   await assert.rejects(
     buildProgram().parseAsync(
       [
+        "cloud",
         "scenarios",
         "publish",
         "--environment",
@@ -106,6 +110,7 @@ test("publish forwards --name, --description and --mode in the PUT body", async 
 
   await buildProgram().parseAsync(
     [
+      "cloud",
       "scenarios",
       "publish",
       "--environment",


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Purpose

This is **PR 3** of the CLI local-vs-cloud restructure. Finish Cloud plumbing convergence and hoist `--api-key` / `--api-url` onto the `cloud` parent.

Stacked on #4191 (PR 2). Merge #4189 → #4190 → #4191 before this.

## Context

PR 2 introduced `platformOptionsOf`, `buildCloudClientContext`, and `runPlatformOperation`, and migrated the complex commands. Remaining Cloud groups still had per-file copies of those helpers, and credential flags still lived on every leaf so unmigrated commands could not accept-and-ignore a parent option.

Every Cloud action now reads credentials through `platformOptionsOf`, so the flags can live once on `mcpjam cloud`.

## What changed

- Migrated `images`, `organizations`, `chat-sessions`, `environments`, `hosts`, `journeys`, `scenarios`, and remaining `bindOperation` consumers onto the shared runner.
- Deleted per-file `addPlatformOptions` / `runPlatformCommand` copies.
- Declared `--api-key` / `--api-url` once on the `cloud` parent; removed leaf declarations.
- `--project` stays on project-scoped leaves.
- `bindOperation` still adds leaf credential flags for hosted `readiness` (frozen local path, not under `cloud`).
- `mcpjam cloud login` rejects `--api-key` instead of accepting and ignoring it (login is browser OAuth). `--api-url` is inherited from the parent.
- Tests cover both supported positions around descendants, prove the flags remain invalid before `cloud` and on local commands, and assert telemetry events never include raw credential values.

## Before / after

- **Before:** `mcpjam cloud projects list --api-key sk_…` only, with each leaf redeclaring the flags.
- **After:** `mcpjam cloud --api-key sk_… projects list` and `mcpjam cloud projects list --api-key sk_…` both work. `mcpjam --api-key sk_… cloud …` and `mcpjam server … --api-key` remain usage errors.

## Rollout

Breaking only in the Cloud option placement sense (parent-level flags). Publish as 4.0.0 together with later PRs; do not land the Version Packages PR until PR 12 is complete.

## Verification

- `npm run typecheck -w @mcpjam/cli`
- `npm test -w @mcpjam/cli`

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-880bc302-7fad-489a-b883-d890bdc3aca6?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-880bc302-7fad-489a-b883-d890bdc3aca6&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Hoists Cloud credential flags onto the mcpjam cloud parent and migrates remaining Cloud commands to the shared platform runner. Old: each leaf declared `--api-key`/`--api-url`. New: declare once on `mcpjam cloud`; flags work before or after descendants; local commands still reject them.

- Consolidates `images`, `organizations`, `chat-sessions`, `environments`, `hosts`, `journeys`, `scenarios`, `projects`, and other Cloud commands onto `platformOptionsOf` + `runPlatformOperation`; deletes per-file helpers. `tunnel` now reads credentials from the parent. `--project` stays on project-scoped leaves. Hosted `readiness` (local path) keeps leaf credentials.
- `mcpjam cloud login` now rejects `--api-key` (OAuth-only). It inherits `--api-url` from the parent.

**Migration/Rollout**
- Use either: `mcpjam cloud --api-key sk_… projects list` or `mcpjam cloud projects list --api-key sk_…`. `mcpjam --api-key … cloud …` remains a usage error.
- Do not pass `--api-key` to `mcpjam cloud login`; use browser OAuth. `--api-url` may be set on `cloud`.
- Breaking change to flag placement; ship in `@mcpjam/cli` 4.0.0.

<sup>Written for commit 73109d6241b7c6548bf0bcda474f6d59e46512cf. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/MCPJam/inspector/pull/4192?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

