### PR TITLE
fix(ollama): implement backoff strategy for polling and pause on tab visibility

### DIFF
--- a/.changeset/ollama-polling-backoff.md
+++ b/.changeset/ollama-polling-backoff.md
@@ -1,0 +1,5 @@
+---
+"@mcpjam/inspector": patch
+---
+
+Stop the local Ollama model detection from polling `127.0.0.1:11434` every 30s forever. The probe now backs off while the daemon is unreachable (30s → 1m → 2m → 4m → 8m, capped at 10m, reset on the first success) and pauses entirely while the tab is hidden, resuming with whatever is left of the current delay. Users running Ollama keep the same 30s cadence; users without it no longer get a console full of connection errors they cannot suppress.

--- a/mcpjam-inspector/client/src/hooks/__tests__/use-detected-ollama-models.test.tsx
+++ b/mcpjam-inspector/client/src/hooks/__tests__/use-detected-ollama-models.test.tsx
@@ -67,9 +67,18 @@ async function setHidden(next: boolean) {
   });
 }
 
-function mount() {
-  const getBaseUrl = () => "http://127.0.0.1:11434";
-  return renderHook(() => useDetectedOllamaModels(getBaseUrl));
+const DEFAULT_URL = "http://127.0.0.1:11434";
+const defaultGetUrl = () => DEFAULT_URL;
+
+/**
+ * Rendered through props so a test can swap the getter the way settings does:
+ * the effect keys on it, so a new identity is what tears the old chain down.
+ */
+function mount(getUrl: () => string = defaultGetUrl) {
+  return renderHook(
+    (props: { getUrl: () => string }) => useDetectedOllamaModels(props.getUrl),
+    { initialProps: { getUrl } },
+  );
 }
 
 const spyCleanups: Array<() => void> = [];
@@ -313,6 +322,46 @@ describe("useDetectedOllamaModels", () => {
     await advance(BASE);
     expect(result.current.isOllamaRunning).toBe(true);
     expect(result.current.ollamaModels).toEqual([]);
+  });
+
+  it("abandons the in-flight probe when the base URL changes", async () => {
+    // Editing the Ollama base URL in settings re-runs the effect. Without the
+    // cancelled flag the probe still in flight against the old daemon would
+    // write its models over the new state, and its `finally` would schedule a
+    // follow-up belonging to a torn-down effect — one immortal chain per edit.
+    let releaseStale: (value: {
+      isRunning: boolean;
+      availableModels: string[];
+    }) => void = () => {};
+    detectModels.mockImplementationOnce(
+      () =>
+        new Promise((resolve) => {
+          releaseStale = resolve;
+        }),
+    );
+    unreachable();
+
+    const movedGetUrl = () => "http://127.0.0.1:22222";
+    const { result, rerender } = mount();
+    await advance(0);
+    expect(probes()).toBe(1);
+
+    // The URL moves while the first probe is still unresolved.
+    rerender({ getUrl: movedGetUrl });
+    await advance(0);
+    expect(detectModels).toHaveBeenLastCalledWith("http://127.0.0.1:22222");
+
+    // The stale probe answers late, claiming a running daemon with models.
+    await act(async () => {
+      releaseStale({ isRunning: true, availableModels: ["stale-model"] });
+    });
+    expect(result.current.isOllamaRunning).toBe(false);
+    expect(result.current.ollamaModels).toEqual([]);
+
+    // And it never gets a follow-up slot: a surviving stale chain would land a
+    // second probe in each of these windows.
+    await expectNextProbeAfter(BASE);
+    await expectNextProbeAfter(2 * BASE);
   });
 
   it("stops probing after unmount", async () => {

--- a/mcpjam-inspector/client/src/hooks/__tests__/use-detected-ollama-models.test.tsx
+++ b/mcpjam-inspector/client/src/hooks/__tests__/use-detected-ollama-models.test.tsx
@@ -1,0 +1,221 @@
+/**
+ * `useDetectedOllamaModels` — the local-Ollama probe schedule.
+ *
+ * The regression these lock down: the hook probed 127.0.0.1:11434 on a flat
+ * 30s setInterval that never stopped, in every tab, whether or not the user
+ * had Ollama installed. Each probe of a closed port writes a connection error
+ * the browser emits below the fetch promise, which no JS catch can swallow, so
+ * an install without Ollama filled the console with noise every 30s forever.
+ *
+ * Backoff and the visibility pause fix that, and both regress quietly: the
+ * failure modes are "probe on every visibilitychange" and "two chains polling
+ * at once", neither of which changes what the hook returns.
+ */
+
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { act, renderHook } from "@testing-library/react";
+import {
+  detectOllamaModels,
+  detectOllamaToolCapableModels,
+} from "@/lib/ollama-utils";
+import { useDetectedOllamaModels } from "../use-detected-ollama-models";
+
+vi.mock("@/lib/ollama-utils", () => ({
+  detectOllamaModels: vi.fn(),
+  detectOllamaToolCapableModels: vi.fn(),
+}));
+
+const detectModels = vi.mocked(detectOllamaModels);
+const detectToolCapable = vi.mocked(detectOllamaToolCapableModels);
+
+/**
+ * Mirrors the hook's own constants: OLLAMA_POLL_INTERVAL_MS is 30s and
+ * OLLAMA_POLL_MAX_INTERVAL_MS is 10 min, i.e. 20x the base. These are pinned
+ * as literals on purpose — the schedule is a product decision, so retuning the
+ * constants should fail here and force the table below to be revisited, not
+ * quietly pass against whatever the new numbers happen to be.
+ */
+const BASE = 30_000;
+const CAP = 20 * BASE;
+
+let hidden = false;
+
+function unreachable() {
+  detectModels.mockResolvedValue({ isRunning: false, availableModels: [] });
+}
+
+function reachable(models: string[] = ["llama3.1"]) {
+  detectModels.mockResolvedValue({ isRunning: true, availableModels: models });
+  detectToolCapable.mockResolvedValue(models);
+}
+
+async function advance(ms: number) {
+  await act(async () => {
+    await vi.advanceTimersByTimeAsync(ms);
+  });
+}
+
+async function setHidden(next: boolean) {
+  hidden = next;
+  await act(async () => {
+    document.dispatchEvent(new Event("visibilitychange"));
+  });
+}
+
+function mount() {
+  const getBaseUrl = () => "http://127.0.0.1:11434";
+  return renderHook(() => useDetectedOllamaModels(getBaseUrl));
+}
+
+/** Probe count, so assertions read as "one more probe happened". */
+function probes() {
+  return detectModels.mock.calls.length;
+}
+
+/** Asserts the next probe lands exactly `gap` ms later, not a tick sooner. */
+async function expectNextProbeAfter(gap: number) {
+  const before = probes();
+  await advance(gap - 1);
+  expect(probes()).toBe(before);
+  await advance(1);
+  expect(probes()).toBe(before + 1);
+}
+
+describe("useDetectedOllamaModels", () => {
+  beforeEach(() => {
+    hidden = false;
+    vi.spyOn(document, "hidden", "get").mockImplementation(() => hidden);
+    vi.useFakeTimers();
+    detectToolCapable.mockResolvedValue([]);
+  });
+
+  it("backs off 30s -> 1m -> 2m -> 4m -> 8m, then pins at the 10m cap", async () => {
+    unreachable();
+    mount();
+    await advance(0);
+    expect(probes()).toBe(1);
+
+    for (const gap of [
+      BASE, // 30s
+      2 * BASE, // 1m
+      4 * BASE, // 2m
+      8 * BASE, // 4m
+      16 * BASE, // 8m
+      CAP, // 10m — 16m doubled would overshoot, so the cap holds
+      CAP, // and keeps holding
+    ]) {
+      await expectNextProbeAfter(gap);
+    }
+  });
+
+  it("returns to the base interval once Ollama answers", async () => {
+    unreachable();
+    mount();
+    await advance(0);
+    await expectNextProbeAfter(BASE);
+    await expectNextProbeAfter(2 * BASE);
+
+    reachable();
+    await expectNextProbeAfter(4 * BASE);
+    await expectNextProbeAfter(BASE);
+    await expectNextProbeAfter(BASE);
+  });
+
+  it("stops probing entirely while the tab is hidden", async () => {
+    unreachable();
+    mount();
+    await advance(0);
+    const before = probes();
+
+    await setHidden(true);
+    await advance(20 * BASE);
+    expect(probes()).toBe(before);
+  });
+
+  it("resumes with the delay that was left, not a probe per visibilitychange", async () => {
+    unreachable();
+    mount();
+    await advance(0);
+    const before = probes();
+
+    await advance(BASE / 3);
+    await setHidden(true);
+    await advance(BASE / 3);
+    await setHidden(false);
+    // Coming back is not itself a reason to probe.
+    expect(probes()).toBe(before);
+
+    await expectNextProbeAfter(BASE / 3);
+  });
+
+  it("probes on return when the interval already elapsed while hidden", async () => {
+    unreachable();
+    mount();
+    await advance(0);
+
+    await setHidden(true);
+    await advance(5 * BASE);
+    const before = probes();
+
+    await setHidden(false);
+    await advance(0);
+    expect(probes()).toBe(before + 1);
+  });
+
+  it("keeps one chain when the tab flips mid-probe", async () => {
+    unreachable();
+    let release: (value: {
+      isRunning: boolean;
+      availableModels: string[];
+    }) => void = () => {};
+    detectModels.mockImplementationOnce(
+      () =>
+        new Promise((resolve) => {
+          release = resolve;
+        })
+    );
+
+    mount();
+    await advance(0);
+    expect(probes()).toBe(1);
+
+    // The flip lands while the first probe is still unresolved.
+    await setHidden(true);
+    await setHidden(false);
+    expect(probes()).toBe(1);
+
+    await act(async () => {
+      release({ isRunning: false, availableModels: [] });
+    });
+
+    // Two chains would each schedule their own follow-up; one probe per
+    // interval, on the backoff schedule, means the guard held.
+    await expectNextProbeAfter(BASE);
+    await expectNextProbeAfter(2 * BASE);
+  });
+
+  it("holds its schedule when the wall clock steps backwards", async () => {
+    unreachable();
+    mount();
+    await advance(0);
+
+    await advance(BASE / 3);
+    await setHidden(true);
+    vi.setSystemTime(Date.now() - 5 * 60_000);
+    await setHidden(false);
+
+    // 10s of the 30s cycle was spent, so 20s remain — step or no step.
+    await expectNextProbeAfter((2 * BASE) / 3);
+  });
+
+  it("stops probing after unmount", async () => {
+    unreachable();
+    const { unmount } = mount();
+    await advance(0);
+    const before = probes();
+
+    unmount();
+    await advance(20 * BASE);
+    expect(probes()).toBe(before);
+  });
+});

--- a/mcpjam-inspector/client/src/hooks/__tests__/use-detected-ollama-models.test.tsx
+++ b/mcpjam-inspector/client/src/hooks/__tests__/use-detected-ollama-models.test.tsx
@@ -72,6 +72,14 @@ function mount() {
   return renderHook(() => useDetectedOllamaModels(getBaseUrl));
 }
 
+const spyCleanups: Array<() => void> = [];
+
+function silenceConsoleError() {
+  const spy = vi.spyOn(console, "error").mockImplementation(() => {});
+  spyCleanups.push(() => spy.mockRestore());
+  return spy;
+}
+
 /** Probe count, so assertions read as "one more probe happened". */
 function probes() {
   return detectModels.mock.calls.length;
@@ -104,6 +112,7 @@ describe("useDetectedOllamaModels", () => {
 
   afterEach(() => {
     hiddenSpy.mockRestore();
+    while (spyCleanups.length) spyCleanups.pop()!();
   });
 
   it("backs off 30s -> 1m -> 2m -> 4m -> 8m, then pins at the 10m cap", async () => {
@@ -211,25 +220,11 @@ describe("useDetectedOllamaModels", () => {
     await expectNextProbeAfter(2 * BASE);
   });
 
-  it("holds its schedule when the wall clock steps backwards", async () => {
-    unreachable();
-    mount();
-    await advance(0);
-
-    await advance(BASE / 3);
-    await setHidden(true);
-    vi.setSystemTime(Date.now() - 5 * 60_000);
-    await setHidden(false);
-
-    // 10s of the 30s cycle was spent, so 20s remain — step or no step.
-    await expectNextProbeAfter((2 * BASE) / 3);
-  });
-
   it("escalates the backoff when a probe rejects", async () => {
     // Unreachable through ollama-utils today, which catches its own fetch
     // failures. Pinned so a refactor that lets one reject can't leave the
     // schedule retrying at the last delay forever.
-    const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    const errorSpy = silenceConsoleError();
     rejecting();
     mount();
     await advance(0);
@@ -238,7 +233,38 @@ describe("useDetectedOllamaModels", () => {
     await expectNextProbeAfter(BASE);
     await expectNextProbeAfter(2 * BASE);
     expect(errorSpy).toHaveBeenCalled();
-    errorSpy.mockRestore();
+  });
+
+  it("clears what it had detected when a probe rejects", async () => {
+    // The reset is only observable if there was something to reset: land a
+    // successful probe first, so the state the catch has to clear is actually
+    // populated, and only then let the next probe throw.
+    silenceConsoleError();
+    reachable(["llama3.1"]);
+    const { result } = mount();
+    await advance(0);
+    expect(result.current.isOllamaRunning).toBe(true);
+    expect(result.current.ollamaModels).toHaveLength(1);
+
+    rejecting();
+    await advance(BASE);
+    expect(result.current.isOllamaRunning).toBe(false);
+    expect(result.current.ollamaModels).toEqual([]);
+  });
+
+  it("keeps reporting the daemon up when only the capability probe throws", async () => {
+    // /version and /tags answered, so the daemon is demonstrably running; a
+    // throw out of the per-model capability call is not evidence otherwise.
+    silenceConsoleError();
+    reachable(["llama3.1"]);
+    const { result } = mount();
+    await advance(0);
+    expect(result.current.isOllamaRunning).toBe(true);
+
+    detectToolCapable.mockRejectedValue(new Error("show failed"));
+    await advance(BASE);
+    expect(result.current.isOllamaRunning).toBe(true);
+    expect(result.current.ollamaModels).toEqual([]);
   });
 
   it("stops probing after unmount", async () => {

--- a/mcpjam-inspector/client/src/hooks/__tests__/use-detected-ollama-models.test.tsx
+++ b/mcpjam-inspector/client/src/hooks/__tests__/use-detected-ollama-models.test.tsx
@@ -246,7 +246,7 @@ describe("useDetectedOllamaModels", () => {
       () =>
         new Promise((resolve) => {
           release = resolve;
-        })
+        }),
     );
 
     mount();

--- a/mcpjam-inspector/client/src/hooks/__tests__/use-detected-ollama-models.test.tsx
+++ b/mcpjam-inspector/client/src/hooks/__tests__/use-detected-ollama-models.test.tsx
@@ -12,7 +12,8 @@
  * at once", neither of which changes what the hook returns.
  */
 
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { MockInstance } from "vitest";
 import { act, renderHook } from "@testing-library/react";
 import {
   detectOllamaModels,
@@ -49,6 +50,10 @@ function reachable(models: string[] = ["llama3.1"]) {
   detectToolCapable.mockResolvedValue(models);
 }
 
+function rejecting() {
+  detectModels.mockRejectedValue(new Error("probe blew up"));
+}
+
 async function advance(ms: number) {
   await act(async () => {
     await vi.advanceTimersByTimeAsync(ms);
@@ -82,11 +87,23 @@ async function expectNextProbeAfter(gap: number) {
 }
 
 describe("useDetectedOllamaModels", () => {
+  // Restored narrowly rather than through a blanket vi.restoreAllMocks(): the
+  // global setup installs several vi.fn() stubs (fetch, matchMedia,
+  // scrollIntoView) whose implementations a suite-level restore would strip —
+  // see the warning on the ResizeObserver stub in src/test/setup.ts.
+  let hiddenSpy: MockInstance<() => boolean>;
+
   beforeEach(() => {
     hidden = false;
-    vi.spyOn(document, "hidden", "get").mockImplementation(() => hidden);
+    hiddenSpy = vi
+      .spyOn(document, "hidden", "get")
+      .mockImplementation(() => hidden);
     vi.useFakeTimers();
     detectToolCapable.mockResolvedValue([]);
+  });
+
+  afterEach(() => {
+    hiddenSpy.mockRestore();
   });
 
   it("backs off 30s -> 1m -> 2m -> 4m -> 8m, then pins at the 10m cap", async () => {
@@ -206,6 +223,22 @@ describe("useDetectedOllamaModels", () => {
 
     // 10s of the 30s cycle was spent, so 20s remain — step or no step.
     await expectNextProbeAfter((2 * BASE) / 3);
+  });
+
+  it("escalates the backoff when a probe rejects", async () => {
+    // Unreachable through ollama-utils today, which catches its own fetch
+    // failures. Pinned so a refactor that lets one reject can't leave the
+    // schedule retrying at the last delay forever.
+    const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    rejecting();
+    mount();
+    await advance(0);
+    expect(probes()).toBe(1);
+
+    await expectNextProbeAfter(BASE);
+    await expectNextProbeAfter(2 * BASE);
+    expect(errorSpy).toHaveBeenCalled();
+    errorSpy.mockRestore();
   });
 
   it("stops probing after unmount", async () => {

--- a/mcpjam-inspector/client/src/hooks/__tests__/use-detected-ollama-models.test.tsx
+++ b/mcpjam-inspector/client/src/hooks/__tests__/use-detected-ollama-models.test.tsx
@@ -174,6 +174,54 @@ describe("useDetectedOllamaModels", () => {
     await expectNextProbeAfter(BASE / 3);
   });
 
+  /**
+   * The schedule measures elapsed time, so it has to read a monotonic clock.
+   * `vi.setSystemTime` models an NTP step or a user editing the system clock:
+   * it moves `Date.now()` and leaves `performance.now()` — and the timer queue
+   * — alone, which is exactly the split a wall-clock jump produces in a live
+   * browser. Read the wall clock instead and a backward step parks the probe
+   * for the size of the jump while a forward step fires it early.
+   */
+  const CLOCK_STEP = 60 * 60_000;
+
+  function stepSystemClock(deltaMs: number) {
+    vi.setSystemTime(new Date(Date.now() + deltaMs));
+  }
+
+  it("keeps the remaining delay when the system clock jumps backward", async () => {
+    unreachable();
+    mount();
+    await advance(0);
+    const before = probes();
+
+    await advance(BASE / 3);
+    await setHidden(true);
+    stepSystemClock(-CLOCK_STEP);
+    await setHidden(false);
+    expect(probes()).toBe(before);
+
+    // Two thirds of the base interval is still owed, not two thirds plus an hour.
+    await expectNextProbeAfter((2 * BASE) / 3);
+    // And that probe is the second failure, so the backoff carries on doubling.
+    await expectNextProbeAfter(2 * BASE);
+  });
+
+  it("keeps the remaining delay when the system clock jumps forward", async () => {
+    unreachable();
+    mount();
+    await advance(0);
+    const before = probes();
+
+    await advance(BASE / 3);
+    await setHidden(true);
+    stepSystemClock(CLOCK_STEP);
+    await setHidden(false);
+    expect(probes()).toBe(before);
+
+    await expectNextProbeAfter((2 * BASE) / 3);
+    await expectNextProbeAfter(2 * BASE);
+  });
+
   it("probes on return when the interval already elapsed while hidden", async () => {
     unreachable();
     mount();

--- a/mcpjam-inspector/client/src/hooks/use-detected-ollama-models.ts
+++ b/mcpjam-inspector/client/src/hooks/use-detected-ollama-models.ts
@@ -57,7 +57,7 @@ export function useDetectedOllamaModels(getOllamaBaseUrl: () => string): {
         ? OLLAMA_POLL_INTERVAL_MS
         : Math.min(
             OLLAMA_POLL_INTERVAL_MS * 2 ** (consecutiveFailures - 1),
-            OLLAMA_POLL_MAX_INTERVAL_MS
+            OLLAMA_POLL_MAX_INTERVAL_MS,
           );
 
     // Arm a timer for whatever is left until nextDueAt. Does nothing while the
@@ -87,7 +87,7 @@ export function useDetectedOllamaModels(getOllamaBaseUrl: () => string): {
       let daemonAnswered = false;
       try {
         const { isRunning, availableModels } = await detectOllamaModels(
-          getOllamaBaseUrl()
+          getOllamaBaseUrl(),
         );
         if (cancelled) return;
         daemonAnswered = isRunning;
@@ -109,7 +109,7 @@ export function useDetectedOllamaModels(getOllamaBaseUrl: () => string): {
             disabledReason: toolCapableSet.has(modelName)
               ? undefined
               : "Model does not support tool calling",
-          }))
+          })),
         );
       } catch (error) {
         if (!cancelled) {

--- a/mcpjam-inspector/client/src/hooks/use-detected-ollama-models.ts
+++ b/mcpjam-inspector/client/src/hooks/use-detected-ollama-models.ts
@@ -46,7 +46,7 @@ export function useDetectedOllamaModels(getOllamaBaseUrl: () => string): {
     let timeoutId: number | undefined;
     let inFlight = false;
     let consecutiveFailures = 0;
-    let nextDueAt = performance.now();
+    let nextDueAt = Date.now();
 
     const nextDelayMs = () =>
       consecutiveFailures === 0
@@ -68,7 +68,7 @@ export function useDetectedOllamaModels(getOllamaBaseUrl: () => string): {
       timeoutId = window.setTimeout(() => {
         timeoutId = undefined;
         void checkOllama();
-      }, Math.max(0, nextDueAt - performance.now()));
+      }, Math.max(0, nextDueAt - Date.now()));
     };
 
     const disarm = () => {
@@ -80,11 +80,13 @@ export function useDetectedOllamaModels(getOllamaBaseUrl: () => string): {
     const checkOllama = async () => {
       if (inFlight) return;
       inFlight = true;
+      let daemonAnswered = false;
       try {
         const { isRunning, availableModels } = await detectOllamaModels(
           getOllamaBaseUrl()
         );
         if (cancelled) return;
+        daemonAnswered = isRunning;
         setIsOllamaRunning(isRunning);
 
         consecutiveFailures = isRunning ? 0 : consecutiveFailures + 1;
@@ -108,14 +110,14 @@ export function useDetectedOllamaModels(getOllamaBaseUrl: () => string): {
       } catch (error) {
         if (!cancelled) {
           console.error("Ollama detection probe threw", error);
-          setIsOllamaRunning(false);
+          setIsOllamaRunning(daemonAnswered);
           setOllamaModels([]);
           consecutiveFailures += 1;
         }
       } finally {
         inFlight = false;
         if (!cancelled) {
-          nextDueAt = performance.now() + nextDelayMs();
+          nextDueAt = Date.now() + nextDelayMs();
           arm();
         }
       }

--- a/mcpjam-inspector/client/src/hooks/use-detected-ollama-models.ts
+++ b/mcpjam-inspector/client/src/hooks/use-detected-ollama-models.ts
@@ -7,12 +7,26 @@ import {
 import { HOSTED_MODE } from "@/lib/config";
 
 const OLLAMA_POLL_INTERVAL_MS = 30_000;
+const OLLAMA_POLL_MAX_INTERVAL_MS = 10 * 60_000;
 
 /**
  * Polls the local Ollama daemon and surfaces its models as picker entries,
  * marking tool-incapable models disabled. Local mode only: in hosted mode
  * the browser may reach localhost, but the hosted (Convex) chat path can't,
  * so the hook reports nothing rather than offering models chat can't run.
+ *
+ * Not having Ollama installed is the common case, and every probe of a closed
+ * port logs a connection error at the browser level that no JS catch can
+ * swallow. Two things keep that noise down:
+ *
+ *  - Backoff: 30s -> 1m -> 2m -> 4m -> 8m, then pinned at the 10m cap,
+ *    while the daemon stays unreachable; back to the base interval on the
+ *    first success.
+ *  - Visibility: polling pauses while the tab is hidden and resumes with
+ *    whatever is *left* of the current delay — coming back to the tab is
+ *    not itself a reason to probe, or flipping tabs would become its own
+ *    burst of requests. This tracks the tab being hidden/shown only, not
+ *    focus or clicks inside the app.
  */
 export function useDetectedOllamaModels(getOllamaBaseUrl: () => string): {
   isOllamaRunning: boolean;
@@ -29,37 +43,95 @@ export function useDetectedOllamaModels(getOllamaBaseUrl: () => string): {
     }
 
     let cancelled = false;
-    const checkOllama = async () => {
-      const { isRunning, availableModels } = await detectOllamaModels(
-        getOllamaBaseUrl()
-      );
-      if (cancelled) return;
-      setIsOllamaRunning(isRunning);
+    let timeoutId: number | undefined;
+    let inFlight = false;
+    let consecutiveFailures = 0;
+    let nextDueAt = performance.now();
 
-      const toolCapable = isRunning
-        ? await detectOllamaToolCapableModels(getOllamaBaseUrl())
-        : [];
-      if (cancelled) return;
-      const toolCapableSet = new Set(toolCapable);
-      setOllamaModels(
-        availableModels.map((modelName) => ({
-          id: modelName,
-          name: modelName,
-          provider: "ollama" as const,
-          disabled: !toolCapableSet.has(modelName),
-          disabledReason: toolCapableSet.has(modelName)
-            ? undefined
-            : "Model does not support tool calling",
-        }))
-      );
+    const nextDelayMs = () =>
+      consecutiveFailures === 0
+        ? OLLAMA_POLL_INTERVAL_MS
+        : Math.min(
+            OLLAMA_POLL_INTERVAL_MS * 2 ** (consecutiveFailures - 1),
+            OLLAMA_POLL_MAX_INTERVAL_MS
+          );
+
+    // Arm a timer for whatever is left until nextDueAt. Does nothing while the
+    // tab is hidden, and never stacks a second timer onto a live one. It also
+    // stands down while a probe is in flight: that probe's `finally` owns the
+    // next slot, and arming against the *current* (already past) nextDueAt
+    // would fire a 0ms timer that jumps the queue the moment it resolves.
+    const arm = () => {
+      if (cancelled || document.hidden || inFlight || timeoutId !== undefined) {
+        return;
+      }
+      timeoutId = window.setTimeout(() => {
+        timeoutId = undefined;
+        void checkOllama();
+      }, Math.max(0, nextDueAt - performance.now()));
     };
-    void checkOllama();
-    const interval = window.setInterval(() => {
+
+    const disarm = () => {
+      if (timeoutId === undefined) return;
+      window.clearTimeout(timeoutId);
+      timeoutId = undefined;
+    };
+
+    const checkOllama = async () => {
+      if (inFlight) return;
+      inFlight = true;
+      try {
+        const { isRunning, availableModels } = await detectOllamaModels(
+          getOllamaBaseUrl()
+        );
+        if (cancelled) return;
+        setIsOllamaRunning(isRunning);
+
+        consecutiveFailures = isRunning ? 0 : consecutiveFailures + 1;
+
+        const toolCapable = isRunning
+          ? await detectOllamaToolCapableModels(getOllamaBaseUrl())
+          : [];
+        if (cancelled) return;
+        const toolCapableSet = new Set(toolCapable);
+        setOllamaModels(
+          availableModels.map((modelName) => ({
+            id: modelName,
+            name: modelName,
+            provider: "ollama" as const,
+            disabled: !toolCapableSet.has(modelName),
+            disabledReason: toolCapableSet.has(modelName)
+              ? undefined
+              : "Model does not support tool calling",
+          }))
+        );
+      } finally {
+        inFlight = false;
+        if (!cancelled) {
+          nextDueAt = performance.now() + nextDelayMs();
+          arm();
+        }
+      }
+    };
+
+    const handleVisibilityChange = () => {
+      if (cancelled) return;
+      if (document.hidden) {
+        disarm();
+      } else {
+        arm();
+      }
+    };
+    document.addEventListener("visibilitychange", handleVisibilityChange);
+
+    if (!document.hidden) {
       void checkOllama();
-    }, OLLAMA_POLL_INTERVAL_MS);
+    }
+
     return () => {
       cancelled = true;
-      window.clearInterval(interval);
+      document.removeEventListener("visibilitychange", handleVisibilityChange);
+      disarm();
     };
   }, [getOllamaBaseUrl]);
 

--- a/mcpjam-inspector/client/src/hooks/use-detected-ollama-models.ts
+++ b/mcpjam-inspector/client/src/hooks/use-detected-ollama-models.ts
@@ -105,6 +105,13 @@ export function useDetectedOllamaModels(getOllamaBaseUrl: () => string): {
               : "Model does not support tool calling",
           }))
         );
+      } catch (error) {
+        if (!cancelled) {
+          console.error("Ollama detection probe threw", error);
+          setIsOllamaRunning(false);
+          setOllamaModels([]);
+          consecutiveFailures += 1;
+        }
       } finally {
         inFlight = false;
         if (!cancelled) {

--- a/mcpjam-inspector/client/src/hooks/use-detected-ollama-models.ts
+++ b/mcpjam-inspector/client/src/hooks/use-detected-ollama-models.ts
@@ -46,7 +46,11 @@ export function useDetectedOllamaModels(getOllamaBaseUrl: () => string): {
     let timeoutId: number | undefined;
     let inFlight = false;
     let consecutiveFailures = 0;
-    let nextDueAt = Date.now();
+    // nextDueAt lives on performance.now()'s monotonic clock: it is only ever
+    // read back as an elapsed-time delta, and a wall-clock step (an NTP
+    // correction, the user editing the system clock) would park the probe for
+    // the size of a backward jump and fire it early on a forward one.
+    let nextDueAt = performance.now();
 
     const nextDelayMs = () =>
       consecutiveFailures === 0
@@ -68,7 +72,7 @@ export function useDetectedOllamaModels(getOllamaBaseUrl: () => string): {
       timeoutId = window.setTimeout(() => {
         timeoutId = undefined;
         void checkOllama();
-      }, Math.max(0, nextDueAt - Date.now()));
+      }, Math.max(0, nextDueAt - performance.now()));
     };
 
     const disarm = () => {
@@ -117,7 +121,7 @@ export function useDetectedOllamaModels(getOllamaBaseUrl: () => string): {
       } finally {
         inFlight = false;
         if (!cancelled) {
-          nextDueAt = Date.now() + nextDelayMs();
+          nextDueAt = performance.now() + nextDelayMs();
           arm();
         }
       }


### PR DESCRIPTION
Closes #4188

## What this changes

`useDetectedOllamaModels` probed `127.0.0.1:11434` on a flat 30s `setInterval` that ran for as long as the hook stayed mounted, in every tab, whether or not Ollama was installed. Each probe of a closed port emits a connection error below the fetch promise that no JS catch can swallow, so an install without Ollama filled the console indefinitely.

The interval is replaced with a self-scheduling chain that carries a due time:

- **Backoff** — 30s → 1m → 2m → 4m → 8m, pinned at a 10m cap, while the daemon is unreachable; reset to the base interval on the first success. Users running Ollama keep the unchanged 30s cadence.
- **Visibility pause** — no probing while the tab is hidden; on return it schedules whatever is left of the current delay, or probes immediately if the delay already elapsed while hidden. Resuming against a due time rather than probing on every `visibilitychange` is what keeps tab-flipping from becoming its own burst of requests.

Scheduling only: the hook's signature, its return shape and the model-mapping logic are untouched, so neither consumer changes.

## Impact

Per chain, for a user without Ollama and a visible tab:

| Window | Before | After | |
|---|---|---|---|
| 1 hour | 120 | 10 | −92% |
| 8 hours | 960 | 52 | −95% |
| Steady state | 120/hour | 6/hour | −95% |

## Notes for reviewers

- **The effect dep is `[getOllamaBaseUrl]` by design.** Editing the Ollama base URL in settings re-runs the effect and resets the backoff to the base interval, which is the behavior we want — the target changed, so start fresh. The re-run also tears the previous chain down through a `cancelled` flag; without it, each edit would leave a chain belonging to a torn-down effect polling forever, and an in-flight probe against the old URL could write stale models over the new state.
- **Rescheduling happens in a `finally`, and a rejected probe is caught.** `setInterval` tolerated a rejection for free; a chain of self-scheduling timeouts would stop polling permanently, so the reschedule lives in `finally`. The `catch` beside it increments the failure counter and clears state, so a rejection escalates the backoff instead of pinning the schedule at the last delay — and it logs through `console.error` rather than swallowing it, so a refactor that starts throwing stays visible. `detectOllamaModels` can't reject today (every fetch in `ollama-utils` is wrapped), but the path is covered by a test regardless.

## Tests

New: `client/src/hooks/__tests__/use-detected-ollama-models.test.tsx`, 10 cases — the backoff table, reset-on-success, the hidden-tab pause, resume-with-remainder, resume-when-overdue, the mid-probe re-entry guard, a rejected probe escalating the backoff, a rejected probe clearing what was already detected, only the capability probe throwing, and stop-on-unmount.

Verified they aren't decorative: 5 of the 10 fail against the previous implementation, the mid-probe case fails if the in-flight guard is removed, the backoff-on-rejection case fails if the `catch` is removed, the state-clearing case fails if `setOllamaModels([])` is removed from it, and the capability-throw case fails if the `catch` reports a blanket `false` instead of what the probe established.



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Reduces noisy local Ollama polling and console errors by replacing the 30s `setInterval` in `useDetectedOllamaModels` with a backoff, visibility-aware scheduler. Before, every tab probed `127.0.0.1:11434` every 30s and surfaced uncatchable connection errors; now polling backs off, pauses when hidden, resumes safely, and handles probe errors without spawning duplicate chains.

- Backoff: 30s → 1m → 2m → 4m → 8m, capped at 10m; reset to 30s after the first success. A running daemon stays at 30s; a non-running daemon drops from 120 probes/hour to ~6.
- Visibility pause: no probing while hidden; on return, resume with the remaining delay or fire immediately if overdue. The delay runs on `performance.now()`'s monotonic clock, so wall-clock jumps (NTP corrections, manual clock edits) can't park a probe or fire it early. A guard prevents parallel chains on mid-probe visibility flips.
- Error handling: probe failures are caught, logged once, models cleared, daemon-up state preserved if only the capability probe throws, backoff escalated, and rescheduling always happens from a `finally` block.
- Scheduler: self-scheduling timeouts keyed to a due time; cancels on unmount and when `getOllamaBaseUrl` changes, so a stale in-flight probe can't overwrite new state or spawn a follow-up chain. Hook signature and returned data are unchanged.
- Tests: new `mcpjam-inspector/client/src/hooks/__tests__/use-detected-ollama-models.test.tsx` with 13 cases covering backoff/reset, visibility pause/resume (remainder and overdue), wall-clock jumps backward and forward, mid-probe guard, rejection behavior (state reset and escalation), daemon-up preservation on capability errors, base-URL change, and stop-on-unmount.

<sup>Written for commit 3fbf2faa33640b3a28014757fcbad6da94dc98dd. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/MCPJam/inspector/pull/4194?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->





