### PR TITLE
fix(sdk): resolve relative platform baseUrl so Directory Readiness runs

### DIFF
--- a/sdk/src/platform/client.ts
+++ b/sdk/src/platform/client.ts
@@ -90,6 +90,27 @@ import type {
 
 export const DEFAULT_PLATFORM_API_BASE_URL = "https://app.mcpjam.com/api/v1";
 
+/**
+ * Parse a request URL, tolerating a relative `baseUrl`.
+ *
+ * The default base and every Node caller pass an absolute origin, which
+ * `new URL` parses on its own. Browser and Worker callers may instead pass a
+ * same-origin prefix like `/api/v1` so the request rides the current origin's
+ * session (see `mcpjam-inspector`'s directory-readiness client). That prefix is
+ * not a valid URL by itself: `new URL("/api/v1/...")` throws "Failed to
+ * construct 'URL': Invalid URL" and the call never reaches `fetch`. Resolving
+ * against the document/worker origin fixes the relative case while leaving an
+ * absolute spec untouched (a second `base` argument is ignored when the first
+ * argument is already absolute).
+ */
+function resolvePlatformRequestUrl(spec: string): URL {
+  const origin =
+    typeof globalThis !== "undefined"
+      ? (globalThis as { location?: { origin?: string } }).location?.origin
+      : undefined;
+  return origin ? new URL(spec, origin) : new URL(spec);
+}
+
 export interface PlatformApiClientOptions {
   /** API origin + version prefix. Defaults to the hosted production API. */
   baseUrl?: string;
@@ -2891,7 +2912,7 @@ export class PlatformApiClient {
     init: { query?: QueryParams; body?: unknown },
     options?: RequestOptions,
   ): Promise<T> {
-    const url = new URL(`${this.baseUrl}${path}`);
+    const url = resolvePlatformRequestUrl(`${this.baseUrl}${path}`);
     for (const [name, value] of Object.entries(init.query ?? {})) {
       if (value !== undefined) {
         url.searchParams.set(name, String(value));

--- a/sdk/tests/platform/client.test.ts
+++ b/sdk/tests/platform/client.test.ts
@@ -39,6 +39,59 @@ describe("PlatformApiClient", () => {
     expect(DEFAULT_PLATFORM_API_BASE_URL).toBe("https://app.mcpjam.com/api/v1");
   });
 
+  it("resolves a relative baseUrl against the current origin (browser/worker)", async () => {
+    // The directory-readiness client passes baseUrl "/api/v1" so the request
+    // rides the current origin's session. `new URL("/api/v1/...")` throws
+    // "Invalid URL" on its own, so the origin must be supplied as the base.
+    vi.stubGlobal("location", { origin: "https://staging.mcpjam.com" });
+    try {
+      const fetchMock = vi.fn(async () => jsonResponse({ items: [] }));
+      const client = makeClient(fetchMock, { baseUrl: "/api/v1" });
+
+      await client.listReadinessRuns({
+        projectId: "p1",
+        readinessKind: "claude",
+        serverId: "s1",
+        limit: 1,
+      });
+
+      const { url } = requestOf(fetchMock);
+      expect(url.origin).toBe("https://staging.mcpjam.com");
+      expect(url.pathname).toBe("/api/v1/projects/p1/readiness-runs");
+      expect(url.searchParams.get("readinessKind")).toBe("claude");
+      expect(url.searchParams.get("serverId")).toBe("s1");
+    } finally {
+      vi.unstubAllGlobals();
+    }
+  });
+
+  it("starts a Claude readiness run through a relative baseUrl", async () => {
+    // Regression: the /conformance page's "Directory Readiness" run threw
+    // "Failed to construct 'URL': Invalid URL" because the relative baseUrl
+    // reached `new URL` with no base.
+    vi.stubGlobal("location", { origin: "https://staging.mcpjam.com" });
+    try {
+      const fetchMock = vi.fn(async () =>
+        jsonResponse({ runId: "run-1", status: "running" }, { status: 202 })
+      );
+      const client = makeClient(fetchMock, { baseUrl: "/api/v1" });
+
+      const receipt = await client.startClaudeReadinessRun({
+        projectId: "p1",
+        serverId: "s1",
+      });
+
+      const { url, init } = requestOf(fetchMock);
+      expect(url.href).toBe(
+        "https://staging.mcpjam.com/api/v1/projects/p1/servers/s1/readiness-runs/claude"
+      );
+      expect(init.method).toBe("POST");
+      expect(receipt.runId).toBe("run-1");
+    } finally {
+      vi.unstubAllGlobals();
+    }
+  });
+
   it("sends GET requests with bearer auth and skips undefined query params", async () => {
     const fetchMock = vi.fn(async () => jsonResponse({ items: [] }));
     const client = makeClient(fetchMock);


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Purpose & context

Running Directory Readiness checks against an HTTP MCP server (e.g. `https://mcp.linear.app/mcp`) on staging fails immediately with:

> Failed to construct 'URL': Invalid URL

Both **Claude Directory Readiness** and **OpenAI Directory Readiness** sections show an `Error` badge and never dispatch the run.

## Root cause

The `/conformance` page's directory-readiness client (`client/src/lib/apis/directory-readiness-api.ts`) intentionally constructs a `PlatformApiClient` with a **relative** base URL:

```ts
new PlatformApiClient({ baseUrl: "/api/v1", getAuth: () => "", fetch: readinessFetch })
```

so requests ride the current origin's session (`authFetch`). But `PlatformApiClient.request()` built the URL with:

```ts
const url = new URL(`${this.baseUrl}${path}`); // new URL("/api/v1/...") → throws
```

`new URL()` on a scheme-less string throws `Failed to construct 'URL': Invalid URL`, so the run threw before ever reaching `fetch`. Every existing `PlatformApiClient` test used an absolute base, so the relative-base path was uncovered. This was introduced when the readiness module was refactored to reuse `PlatformApiClient` instead of hand-rolling the fetch (the hand-rolled version passed relative paths straight to `fetch`, which resolves them; `new URL` does not).

Because the failure is purely about the relative base, it affected **all** hosted readiness runs, not just Linear.

## Fix

`sdk/src/platform/client.ts` now resolves the request spec against the document/worker origin when one is available:

```ts
function resolvePlatformRequestUrl(spec: string): URL {
  const origin = typeof globalThis !== "undefined"
    ? (globalThis as { location?: { origin?: string } }).location?.origin
    : undefined;
  return origin ? new URL(spec, origin) : new URL(spec);
}
```

- Relative base (browser/Worker, e.g. `/api/v1`) → resolves against `location.origin`.
- Absolute base (Node callers and the default `https://app.mcpjam.com/api/v1`) → unchanged (the `base` argument is ignored when the spec is already absolute).
- No `node:` imports or `process.env` — passes `check:platform-runtime-safety` on both `src` and `dist`.

## Before / after

```
new URL("/api/v1/projects/p1/servers/s1/readiness-runs/claude")
  BEFORE -> Invalid URL   (browser: "Failed to construct 'URL': Invalid URL")
  AFTER  -> https://staging.mcpjam.com/api/v1/projects/p1/servers/s1/readiness-runs/claude
```

## Tests

Added two regression tests to `sdk/tests/platform/client.test.ts` (both stub `location`):
- `listReadinessRuns` through a relative `baseUrl` resolves to the current origin with the right path + query.
- `startClaudeReadinessRun` through a relative `baseUrl` posts to the right absolute URL.

Validation:
- `vitest run tests/platform/client.test.ts` → 29 passed (2 new + 27 existing).
- `npm run build -w @mcpjam/sdk` → success; `npm run typecheck -w @mcpjam/sdk` → clean.
- `check:platform-runtime-safety` (src) and `check:platform-runtime-safety:dist` → pass.

## Rollout notes

SDK-only change; the client picks it up from `@mcpjam/sdk/platform`. No API or schema changes.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-75a6fa6e-3847-4546-bb37-3899185f0291?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-75a6fa6e-3847-4546-bb37-3899185f0291&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes `PlatformApiClient` URL construction so Directory Readiness runs start when using a relative `baseUrl`. Before: `new URL("/api/v1...")` threw “Invalid URL” in browser contexts and runs never dispatched. Now: the client resolves requests against `location.origin` when present; absolute bases (Node/default) are unchanged.

- Adds a URL resolver used by `request()` to support relative bases in browser/Worker contexts without affecting absolute callers.
- Adds two regression tests that stub `location` and cover list/start readiness requests.
- No API or schema changes; consumers of `@mcpjam/sdk/platform` pick up the fix automatically.

<sup>Written for commit 2fb8ad66f3e659e08add766f3aeb3b9e24b66e26. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/MCPJam/inspector/pull/4195?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

