### PR TITLE
cli: add cloud link, status, and project-scope resolution

### DIFF
--- a/.changeset/cli-project-link-status.md
+++ b/.changeset/cli-project-link-status.md
@@ -1,0 +1,5 @@
+---
+"@mcpjam/cli": major
+---
+
+Add `mcpjam cloud link` and `mcpjam cloud status`. Project-scoped Cloud commands resolve `--project`, then a `--file`/`--json` input document, then `MCPJAM_PROJECT`, then `.mcpjam/project.json`, then automatic selection (most recently updated). `MCPJAM_PROJECT_ID` does not select a Cloud CLI project.

--- a/cli/src/commands/cloud-link.ts
+++ b/cli/src/commands/cloud-link.ts
@@ -1,0 +1,274 @@
+/**
+ * `mcpjam cloud link` and `mcpjam cloud status`.
+ *
+ * Link writes a committed, secret-free `.mcpjam/project.json`. Status is
+ * zero-network: credential source, deployment, project selector, and link
+ * validity. An invalid link still emits the structured report, then exits 1.
+ */
+import type { Command } from "commander";
+import {
+  projectResolutionError,
+  resolveProject,
+} from "@mcpjam/sdk/platform";
+import { describeCloudCredential } from "../lib/credential-describe.js";
+import {
+  describeProjectScope,
+  resolveProjectSelector,
+} from "../lib/cloud-scope.js";
+import {
+  apiUrlsMatch,
+  inspectProjectLink,
+  projectLinkPathForDir,
+  projectLinkWriteDir,
+  removeProjectLinkFile,
+  writeProjectLink,
+  type ProjectLink,
+} from "../lib/project-link.js";
+import { setProcessExitCode, usageError, writeResult } from "../lib/output.js";
+import {
+  platformOptionsOf,
+  runPlatformOperation,
+  type PlatformOptions,
+} from "../lib/platform-command.js";
+import { getGlobalOptions } from "../lib/server-config.js";
+
+type LinkOptions = PlatformOptions & {
+  here?: boolean;
+  remove?: boolean;
+};
+
+type CloudStatusReport = {
+  ok: boolean;
+  credential: {
+    source: string;
+    kind: string;
+    redactedKey?: string;
+    envShadowsOauth: boolean;
+    storedOauthPresent: boolean;
+  };
+  deployment: {
+    apiUrl: string;
+    source: string;
+  };
+  project: {
+    selector: string | null;
+    source: string;
+    description: string;
+  };
+  link: {
+    path: string | null;
+    valid: boolean | null;
+    project?: { id: string; name: string };
+    organizationId?: string;
+    apiUrl?: string;
+    apiUrlMatchesDeployment?: boolean;
+    error?: string;
+  };
+  warnings: string[];
+};
+
+function mcpjamProjectIdWarning(env: NodeJS.ProcessEnv): string | undefined {
+  if (!env.MCPJAM_PROJECT_ID?.trim()) {
+    return undefined;
+  }
+  return "MCPJAM_PROJECT_ID is set; it is used only for SDK eval reporting and does not select a Cloud CLI project.";
+}
+
+function nearestLinkPath(): string | undefined {
+  const inspection = inspectProjectLink();
+  return inspection.status === "missing" ? undefined : inspection.path;
+}
+
+export function registerCloudLinkCommands(cloud: Command): void {
+  cloud
+    .command("status")
+    .description(
+      "Show how this CLI would authenticate and which Cloud project it would use, without calling the network."
+    )
+    .action((_options: PlatformOptions, command: Command) => {
+      const globalOptions = getGlobalOptions(command);
+      const platform = platformOptionsOf(command);
+      const env = process.env;
+      const warnings: string[] = [];
+      const { credential, deployment } = describeCloudCredential(platform, {
+        env,
+      });
+
+      const projectIdWarning = mcpjamProjectIdWarning(env);
+      if (projectIdWarning) {
+        warnings.push(projectIdWarning);
+      }
+      if (credential.envShadowsOauth) {
+        warnings.push(
+          "MCPJAM_API_KEY is set, so it shadows the stored OAuth login for Cloud commands."
+        );
+      }
+
+      const inspection = inspectProjectLink();
+      let ok = true;
+      let projectSelectorFailed = false;
+      let projectScopeDescription = describeProjectScope({
+        kind: "project",
+        source: "automatic",
+      });
+      let projectSource = "automatic";
+      let projectSelector: string | null = null;
+
+      try {
+        const scope = resolveProjectSelector({ env });
+        projectSource = scope.source;
+        projectSelector = scope.selector ?? null;
+        projectScopeDescription = describeProjectScope(scope);
+      } catch (error) {
+        ok = false;
+        projectSelectorFailed = true;
+        warnings.push(error instanceof Error ? error.message : String(error));
+      }
+
+      const link: CloudStatusReport["link"] =
+        inspection.status === "missing"
+          ? { path: null, valid: null }
+          : inspection.status === "invalid"
+            ? {
+                path: inspection.path,
+                valid: false,
+                error: inspection.error,
+              }
+            : {
+                path: inspection.path,
+                valid: true,
+                project: inspection.link.project,
+                ...(inspection.link.organizationId
+                  ? { organizationId: inspection.link.organizationId }
+                  : {}),
+                apiUrl: inspection.link.apiUrl,
+                apiUrlMatchesDeployment: apiUrlsMatch(
+                  inspection.link.apiUrl,
+                  deployment.apiUrl
+                ),
+              };
+
+      if (inspection.status === "invalid") {
+        ok = false;
+      }
+
+      if (link.valid === true && link.apiUrlMatchesDeployment === false) {
+        warnings.push(
+          `Project link apiUrl (${link.apiUrl}) does not match the active deployment (${deployment.apiUrl}). The active deployment is used; the link is not.`
+        );
+      }
+
+      const report: CloudStatusReport = {
+        ok,
+        credential: {
+          source: credential.source,
+          kind: credential.kind,
+          ...(credential.redactedKey
+            ? { redactedKey: credential.redactedKey }
+            : {}),
+          envShadowsOauth: credential.envShadowsOauth,
+          storedOauthPresent: credential.storedOauthPresent,
+        },
+        deployment: {
+          apiUrl: deployment.apiUrl,
+          source: deployment.source,
+        },
+        project: {
+          selector: projectSelector,
+          source: projectSource,
+          description: projectSelectorFailed
+            ? "unresolved"
+            : projectScopeDescription,
+        },
+        link,
+        warnings,
+      };
+
+      writeResult(report, globalOptions.format);
+      if (!ok) {
+        setProcessExitCode(1);
+      }
+    });
+
+  cloud
+    .command("link")
+    .description(
+      "Pin this directory to a Cloud project by writing .mcpjam/project.json. The file contains no secrets and is committed by default; per-developer setups may gitignore it."
+    )
+    .argument("[project]", "Project name or ID to pin")
+    .option(
+      "--here",
+      "Write .mcpjam/project.json in the current directory instead of the Git worktree root"
+    )
+    .option(
+      "--remove",
+      "Remove the nearest project link (current directory with --here)"
+    )
+    .action(
+      async (
+        project: string | undefined,
+        options: LinkOptions,
+        command: Command
+      ) => {
+        const globalOptions = getGlobalOptions(command);
+        const platform = platformOptionsOf(command);
+
+        if (options.remove) {
+          if (project !== undefined && project !== "") {
+            throw usageError("Do not pass a project argument with --remove.");
+          }
+          const filePath = options.here
+            ? projectLinkPathForDir(projectLinkWriteDir({ here: true }))
+            : nearestLinkPath();
+          if (!filePath) {
+            throw usageError("No project link found.");
+          }
+          removeProjectLinkFile(filePath);
+          writeResult(
+            { status: "removed", path: filePath },
+            globalOptions.format
+          );
+          return;
+        }
+
+        const selector = resolveProjectSelector({
+          flagProject: project,
+          ignoreLink: true,
+        });
+
+        const result = await runPlatformOperation(
+          platform,
+          globalOptions.timeout,
+          async ({ client, signal, baseUrl }) => {
+            const page = await client.listProjects({}, { signal });
+            const resolution = resolveProject(page.items, selector.selector);
+            if (!resolution.ok) {
+              throw projectResolutionError(resolution.message);
+            }
+            const chosen = resolution.project;
+            const directory = projectLinkWriteDir({
+              here: options.here === true,
+            });
+            const link: ProjectLink = {
+              version: 1,
+              project: { id: chosen.id, name: chosen.name },
+              ...(chosen.organizationId
+                ? { organizationId: chosen.organizationId }
+                : {}),
+              apiUrl: baseUrl,
+            };
+            const pathWritten = await writeProjectLink({ directory, link });
+            return {
+              status: "linked" as const,
+              path: pathWritten,
+              project: { id: chosen.id, name: chosen.name },
+              apiUrl: baseUrl,
+            };
+          },
+          { announce: false }
+        );
+
+        writeResult(result, globalOptions.format);
+      }
+    );
+}

--- a/cli/src/commands/cloud-link.ts
+++ b/cli/src/commands/cloud-link.ts
@@ -234,6 +234,8 @@ export function registerCloudLinkCommands(cloud: Command): void {
         const selector = resolveProjectSelector({
           flagProject: project,
           ignoreLink: true,
+          emptyFlagMessage:
+            "Project argument cannot be empty. Omit it to use MCPJAM_PROJECT or automatic selection.",
         });
 
         const result = await runPlatformOperation(

--- a/cli/src/commands/cloud-link.ts
+++ b/cli/src/commands/cloud-link.ts
@@ -154,7 +154,7 @@ export function registerCloudLinkCommands(cloud: Command): void {
 
       if (link.valid === true && link.apiUrlMatchesDeployment === false) {
         warnings.push(
-          `Project link apiUrl (${link.apiUrl}) does not match the active deployment (${deployment.apiUrl}). The active deployment is used; the link is not.`
+          `Project link apiUrl (${link.apiUrl}) does not match the active deployment (${deployment.apiUrl}). The active deployment's API URL is used; the link's project selector remains active.`
         );
       }
 

--- a/cli/src/commands/cloud.ts
+++ b/cli/src/commands/cloud.ts
@@ -2,6 +2,7 @@ import type { Command } from "commander";
 import { addPlatformOptions } from "../lib/platform-command.js";
 import { registerAuthCommands } from "./auth.js";
 import { registerChatCommands } from "./chat.js";
+import { registerCloudLinkCommands } from "./cloud-link.js";
 import { registerEnvironmentsCommands } from "./environments.js";
 import { registerEvalCommands } from "./eval.js";
 import { registerHostsCommands } from "./hosts.js";
@@ -30,6 +31,7 @@ export function registerCloudCommands(program: Command): Command {
   addPlatformOptions(cloud);
 
   registerAuthCommands(cloud);
+  registerCloudLinkCommands(cloud);
   registerOrganizationsCommands(cloud);
   registerProjectsCommands(cloud);
   registerEvalCommands(cloud);

--- a/cli/src/commands/environments.ts
+++ b/cli/src/commands/environments.ts
@@ -17,9 +17,11 @@ import { JsonInputContext } from "../lib/json-input.js";
 import { usageError, writeResult } from "../lib/output.js";
 import {
   platformOptionsOf,
+  runCloudOp,
   runPlatformOperation as runPlatformCommand,
   type PlatformOptions,
 } from "../lib/platform-command.js";
+import { resolveCloudProjectArgs } from "../lib/cloud-scope.js";
 import { getGlobalOptions } from "../lib/server-config.js";
 
 /**
@@ -95,18 +97,17 @@ async function assertModelOverridesSupported(
 
 /**
  * The project the command will actually write to, in the SAME precedence the
- * write itself uses: the explicit `--project` flag over the JSON body's
- * `project`. Absent when neither names one, which is the only case where
- * resolving the caller's default project is correct.
+ * write itself uses: `--project`, then the JSON body's `project`, then
+ * `MCPJAM_PROJECT`, a project link, then automatic selection.
  */
 function projectSelector(
   options: { project?: string },
-  body: Record<string, unknown>
+  body: Record<string, unknown> = {}
 ): { project?: string } {
-  if (options.project !== undefined) return { project: options.project };
-  return typeof body.project === "string" && body.project.trim()
-    ? { project: body.project }
-    : {};
+  const resolved = resolveCloudProjectArgs(options, {
+    inputProject: typeof body.project === "string" ? body.project : undefined,
+  });
+  return resolved.project !== undefined ? { project: resolved.project } : {};
 }
 
 /** Read a JSON object from --file (literal path or `-` for stdin) / --json. */
@@ -190,13 +191,13 @@ export function registerEnvironmentsCommands(program: Command): void {
       command
     ) => {
       const globalOptions = getGlobalOptions(command);
-      const result = await runPlatformCommand(
-        platformOptionsOf(command),
-        globalOptions.timeout,
-        ({ client, signal }) =>
+      const result = await runCloudOp(
+        command,
+        options,
+        ({ client, signal }, project) =>
           listEnvironmentsOperation.execute(
             {
-              project: options.project,
+              ...project,
               ...(options.includeArchived ? { includeArchived: true } : {}),
             },
             { client, signal }
@@ -218,12 +219,12 @@ export function registerEnvironmentsCommands(program: Command): void {
       command
     ) => {
       const globalOptions = getGlobalOptions(command);
-      const result = await runPlatformCommand(
-        platformOptionsOf(command),
-        globalOptions.timeout,
-        ({ client, signal }) =>
+      const result = await runCloudOp(
+        command,
+        options,
+        ({ client, signal }, project) =>
           getEnvironmentOperation.execute(
-            { project: options.project, environment: options.environment },
+            { ...project, environment: options.environment },
             { client, signal }
           )
       );
@@ -243,12 +244,12 @@ export function registerEnvironmentsCommands(program: Command): void {
       command
     ) => {
       const globalOptions = getGlobalOptions(command);
-      const result = await runPlatformCommand(
-        platformOptionsOf(command),
-        globalOptions.timeout,
-        ({ client, signal }) =>
+      const result = await runCloudOp(
+        command,
+        options,
+        ({ client, signal }, project) =>
           resolveEnvironmentOperation.execute(
-            { project: options.project, environment: options.environment },
+            { ...project, environment: options.environment },
             { client, signal }
           )
       );
@@ -308,7 +309,7 @@ export function registerEnvironmentsCommands(program: Command): void {
       });
       const input = validateInput(createEnvironmentOperation, {
         ...body,
-        ...(options.project !== undefined ? { project: options.project } : {}),
+        ...projectSelector(options, body),
         ...(options.name !== undefined ? { name: options.name } : {}),
         ...(options.hostId !== undefined ? { hostId: options.hostId } : {}),
         ...(options.description !== undefined
@@ -368,7 +369,7 @@ export function registerEnvironmentsCommands(program: Command): void {
     ) => {
       const globalOptions = getGlobalOptions(command);
       const input = validateInput(ensureAdhocEnvironmentOperation, {
-        ...(options.project !== undefined ? { project: options.project } : {}),
+        ...projectSelector(options),
         host: options.host,
         ...(options.serverGroup !== undefined
           ? { serverGroup: options.serverGroup }
@@ -419,7 +420,7 @@ export function registerEnvironmentsCommands(program: Command): void {
     ) => {
       const globalOptions = getGlobalOptions(command);
       const input = validateInput(nameEnvironmentOperation, {
-        ...(options.project !== undefined ? { project: options.project } : {}),
+        ...projectSelector(options),
         environment: options.environment,
         name: options.name,
         expectedRevision: parseRevision(options.expectedRevision),
@@ -506,7 +507,7 @@ export function registerEnvironmentsCommands(program: Command): void {
       });
       const input = validateInput(updateEnvironmentOperation, {
         ...body,
-        ...(options.project !== undefined ? { project: options.project } : {}),
+        ...projectSelector(options, body),
         environment: options.environment,
         expectedRevision: parseRevision(options.expectedRevision),
         ...(options.name !== undefined ? { name: options.name } : {}),
@@ -552,13 +553,13 @@ export function registerEnvironmentsCommands(program: Command): void {
       command
     ) => {
       const globalOptions = getGlobalOptions(command);
-      const result = await runPlatformCommand(
-        platformOptionsOf(command),
-        globalOptions.timeout,
-        ({ client, signal }) =>
+      const result = await runCloudOp(
+        command,
+        options,
+        ({ client, signal }, project) =>
           archiveEnvironmentOperation.execute(
             {
-              project: options.project,
+              ...project,
               environment: options.environment,
               expectedRevision: parseRevision(options.expectedRevision),
             },
@@ -589,13 +590,13 @@ export function registerEnvironmentsCommands(program: Command): void {
       command
     ) => {
       const globalOptions = getGlobalOptions(command);
-      const result = await runPlatformCommand(
-        platformOptionsOf(command),
-        globalOptions.timeout,
-        ({ client, signal }) =>
+      const result = await runCloudOp(
+        command,
+        options,
+        ({ client, signal }, project) =>
           restoreEnvironmentOperation.execute(
             {
-              project: options.project,
+              ...project,
               environment: options.environment,
               expectedRevision: parseRevision(options.expectedRevision),
             },

--- a/cli/src/commands/eval.ts
+++ b/cli/src/commands/eval.ts
@@ -123,8 +123,10 @@ import { DEFAULT_PLATFORM_ORIGIN } from "../lib/platform-auth.js";
 import {
   platformOptionsOf,
   runPlatformOperation as runPlatformCommand,
+  runCloudOp,
   type PlatformOptions,
 } from "../lib/platform-command.js";
+import { resolveCloudProjectArgs, appendProjectLinkHint } from "../lib/cloud-scope.js";
 import {
   getGlobalOptions,
   parsePositiveInteger,
@@ -539,14 +541,22 @@ function validateOpInput<TInput>(
 async function executeOp<TInput, TOutput>(
   op: PlatformOperation<TInput, TOutput>,
   input: TInput,
-  _options: PlatformOptions,
+  options: PlatformOptions & { project?: string },
   command: Command
 ): Promise<void> {
   const globalOptions = getGlobalOptions(command);
+  const inputProject =
+    options.project === undefined &&
+    typeof (input as { project?: unknown }).project === "string"
+      ? (input as { project: string }).project
+      : undefined;
+  const resolved = resolveCloudProjectArgs(options, { inputProject });
+  const filled = { ...input, project: resolved.project } as TInput;
   const result = await runPlatformCommand(
     platformOptionsOf(command),
     globalOptions.timeout,
-    ({ client, signal }) => op.execute(input, { client, signal })
+    ({ client, signal }) => op.execute(filled, { client, signal }),
+    { projectScope: resolved.projectScope }
   );
   writeResult(result, globalOptions.format);
 }
@@ -784,6 +794,7 @@ async function runEvalGate(
     options.waitTimeout !== undefined
       ? parsePositiveInteger(options.waitTimeout, "--wait-timeout")
       : DEFAULT_GATE_WAIT_TIMEOUT_MS;
+  const resolved = resolveCloudProjectArgs(options);
 
   let report: GateReport;
   try {
@@ -792,9 +803,11 @@ async function runEvalGate(
       Math.max(globalOptions.timeout, options.wait ? waitTimeoutMs : 0),
       async ({ client, signal }) => {
         const projects = await client.listProjects({}, { signal });
-        const resolution = resolveProject(projects.items, options.project);
+        const resolution = resolveProject(projects.items, resolved.project);
         if (!resolution.ok) {
-          throw usageError(resolution.message);
+          throw usageError(
+            appendProjectLinkHint(resolution.message, resolved.projectScope)
+          );
         }
         const project = resolution.project;
         const deadline = Date.now() + waitTimeoutMs;
@@ -934,6 +947,7 @@ async function runEvalCompare(
   // spending a request — and cannot be mistaken for an infrastructure failure.
   const policy = comparePolicyFromOptions(options);
   const reporter = parseReporterFormat(options.reporter);
+  const resolved = resolveCloudProjectArgs(options);
 
   type CompareOutcome = {
     report: GateReport;
@@ -948,9 +962,11 @@ async function runEvalCompare(
       globalOptions.timeout,
       async ({ client, signal }) => {
         const projects = await client.listProjects({}, { signal });
-        const resolution = resolveProject(projects.items, options.project);
+        const resolution = resolveProject(projects.items, resolved.project);
         if (!resolution.ok) {
-          throw usageError(resolution.message);
+          throw usageError(
+            appendProjectLinkHint(resolution.message, resolved.projectScope)
+          );
         }
         const project = resolution.project;
 
@@ -1121,6 +1137,7 @@ async function runEvalPull(
 ): Promise<void> {
   const globalOptions = getGlobalOptions(command);
   const lockPath = resolveCorpusLockPath(options.lock);
+  const resolved = resolveCloudProjectArgs(options);
 
   // Read the existing lock BEFORE fetching. A `--frozen` run with no lock is
   // exit 3 whatever the server would have said, and discovering that after a
@@ -1139,7 +1156,9 @@ async function runEvalPull(
       globalOptions.timeout,
       async ({ client, signal }) => {
         const selector = {
-          ...(options.project ? { project: options.project } : {}),
+          ...(resolved.project !== undefined
+            ? { project: resolved.project }
+            : {}),
           suite: options.suite,
         };
         const [detail, page] = await Promise.all([
@@ -1181,7 +1200,7 @@ async function runEvalPull(
   let corpus: LoadedCorpus;
   try {
     corpus = buildCorpus({
-      ...(options.project ? { project: options.project } : {}),
+      ...(resolved.project !== undefined ? { project: resolved.project } : {}),
       suite: fetched.suite,
       cases: fetched.cases,
       suiteChecks: fetched.suiteChecks,
@@ -1508,6 +1527,7 @@ async function runEvalExport(
   command: Command
 ): Promise<void> {
   const globalOptions = getGlobalOptions(command);
+  const resolved = resolveCloudProjectArgs(options);
 
   // Checked BEFORE the fetch when the caller named the path: refusing to
   // overwrite is not worth a round trip. With no `--out` the path is derived
@@ -1521,7 +1541,9 @@ async function runEvalExport(
     globalOptions.timeout,
     async ({ client, signal }) => {
       const selector = {
-        ...(options.project ? { project: options.project } : {}),
+        ...(resolved.project !== undefined
+          ? { project: resolved.project }
+          : {}),
         suite: options.suite,
       };
       const [detail, page] = await Promise.all([
@@ -1678,11 +1700,21 @@ export function registerEvalCommands(program: Command): void {
       ).action(async (options: CreateOptions, command) => {
     const globalOptions = getGlobalOptions(command);
     const input = loadSuiteDefinition(options);
+    const resolved = resolveCloudProjectArgs(options, {
+      inputProject:
+        options.project === undefined && typeof input.project === "string"
+          ? input.project
+          : undefined,
+    });
     const result = await runPlatformCommand(
       platformOptionsOf(command),
       globalOptions.timeout,
       ({ client, signal }) =>
-        createEvalSuiteOperation.execute(input, { client, signal })
+        createEvalSuiteOperation.execute(
+          { ...input, project: resolved.project },
+          { client, signal }
+        ),
+      { projectScope: resolved.projectScope }
     );
     writeResult(result, globalOptions.format);
   });
@@ -1695,14 +1727,11 @@ export function registerEvalCommands(program: Command): void {
         "Project name or ID (defaults to the most recently updated project)"
       ).action(async (options: PlatformOptions & { project?: string }, command) => {
     const globalOptions = getGlobalOptions(command);
-    const result = await runPlatformCommand(
-      platformOptionsOf(command),
-      globalOptions.timeout,
-      ({ client, signal }) =>
-        listEvalSuitesOperation.execute(
-          { project: options.project },
-          { client, signal }
-        )
+    const result = await runCloudOp(
+      command,
+      options,
+      ({ client, signal }, project) =>
+        listEvalSuitesOperation.execute(project, { client, signal })
     );
     writeResult(result, globalOptions.format);
   });
@@ -1834,6 +1863,7 @@ export function registerEvalCommands(program: Command): void {
     ) => {
       const globalOptions = getGlobalOptions(command);
       let webOrigin = DEFAULT_PLATFORM_ORIGIN;
+      const resolved = resolveCloudProjectArgs(options);
       const result = await runPlatformCommand(
         platformOptionsOf(command),
         globalOptions.timeout,
@@ -1841,7 +1871,7 @@ export function registerEvalCommands(program: Command): void {
           webOrigin = context.webOrigin;
           return runEvalSuiteOperation.execute(
             {
-              project: options.project,
+              project: resolved.project,
               suite: options.suite,
               ...(options.server ? { servers: options.server } : {}),
               // ONE value maps to the singular field, several to the plural:
@@ -1896,13 +1926,14 @@ export function registerEvalCommands(program: Command): void {
     ) => {
       const globalOptions = getGlobalOptions(command);
       let webOrigin = DEFAULT_PLATFORM_ORIGIN;
+      const resolved = resolveCloudProjectArgs(options);
       const result = await runPlatformCommand(
         platformOptionsOf(command),
         globalOptions.timeout,
         (context) => {
           webOrigin = context.webOrigin;
           return getEvalRunOperation.execute(
-            { project: options.project, runId: options.run },
+            { project: resolved.project, runId: options.run },
             { client: context.client, signal: context.signal }
           );
         }
@@ -2367,13 +2398,14 @@ export function registerEvalCommands(program: Command): void {
           ? parsePositiveInteger(options.index, "--index")
           : undefined;
 
+      const resolved = resolveCloudProjectArgs(options);
       const result = await runPlatformCommand(
         platformOptionsOf(command),
         globalOptions.timeout,
         ({ client, signal }) =>
           getEvalIterationTraceOperation.execute(
             {
-              project: options.project,
+              project: resolved.project,
               runId: options.run,
               iterationId: options.iteration,
             },
@@ -2493,13 +2525,14 @@ export function registerEvalCommands(program: Command): void {
       command
     ) => {
       const globalOptions = getGlobalOptions(command);
+      const resolved = resolveCloudProjectArgs(options);
       const result = await runPlatformCommand(
         platformOptionsOf(command),
         globalOptions.timeout,
         ({ client, signal }) =>
           getEvalIterationTraceOperation.execute(
             {
-              project: options.project,
+              project: resolved.project,
               runId: options.run,
               iterationId: options.iteration,
             },

--- a/cli/src/commands/eval.ts
+++ b/cli/src/commands/eval.ts
@@ -1871,7 +1871,7 @@ export function registerEvalCommands(program: Command): void {
           webOrigin = context.webOrigin;
           return runEvalSuiteOperation.execute(
             {
-              project: resolved.project,
+              project: resolved.project ?? options.project,
               suite: options.suite,
               ...(options.server ? { servers: options.server } : {}),
               // ONE value maps to the singular field, several to the plural:
@@ -1933,7 +1933,7 @@ export function registerEvalCommands(program: Command): void {
         (context) => {
           webOrigin = context.webOrigin;
           return getEvalRunOperation.execute(
-            { project: resolved.project, runId: options.run },
+            { project: resolved.project ?? options.project, runId: options.run },
             { client: context.client, signal: context.signal }
           );
         }
@@ -2405,7 +2405,7 @@ export function registerEvalCommands(program: Command): void {
         ({ client, signal }) =>
           getEvalIterationTraceOperation.execute(
             {
-              project: resolved.project,
+              project: resolved.project ?? options.project,
               runId: options.run,
               iterationId: options.iteration,
             },
@@ -2532,7 +2532,7 @@ export function registerEvalCommands(program: Command): void {
         ({ client, signal }) =>
           getEvalIterationTraceOperation.execute(
             {
-              project: resolved.project,
+              project: resolved.project ?? options.project,
               runId: options.run,
               iterationId: options.iteration,
             },

--- a/cli/src/commands/hosts.ts
+++ b/cli/src/commands/hosts.ts
@@ -18,6 +18,7 @@ import {
   runPlatformOperation as runPlatformCommand,
   type PlatformOptions,
 } from "../lib/platform-command.js";
+import { resolveCloudProjectArgs } from "../lib/cloud-scope.js";
 import { getGlobalOptions } from "../lib/server-config.js";
 
 
@@ -101,7 +102,7 @@ export function registerHostsCommands(program: Command): void {
       globalOptions.timeout,
       ({ client, signal }) =>
         listHostsOperation.execute(
-          { project: options.project },
+          { project: resolveCloudProjectArgs(options).project },
           { client, signal }
         )
     );
@@ -123,7 +124,7 @@ export function registerHostsCommands(program: Command): void {
         globalOptions.timeout,
         ({ client, signal }) =>
           getHostOperation.execute(
-            { project: options.project, host: options.host },
+            { project: resolveCloudProjectArgs(options).project, host: options.host },
             { client, signal }
           )
       );
@@ -162,7 +163,7 @@ export function registerHostsCommands(program: Command): void {
       const globalOptions = getGlobalOptions(command);
       const config = loadConfigObject(options);
       const input = validateInput(createHostOperation, {
-        project: options.project,
+        project: resolveCloudProjectArgs(options).project,
         name: options.name,
         ...(options.template !== undefined
           ? { template: options.template }
@@ -207,7 +208,7 @@ export function registerHostsCommands(program: Command): void {
       const globalOptions = getGlobalOptions(command);
       const config = loadConfigObject(options);
       const input = validateInput(updateHostOperation, {
-        project: options.project,
+        project: resolveCloudProjectArgs(options).project,
         host: options.host,
         ...(options.name !== undefined ? { name: options.name } : {}),
         ...(config !== undefined ? { config } : {}),
@@ -241,7 +242,7 @@ export function registerHostsCommands(program: Command): void {
         ({ client, signal }) =>
           deleteHostOperation.execute(
             {
-              project: options.project,
+              project: resolveCloudProjectArgs(options).project,
               host: options.host,
             },
             { client, signal }
@@ -280,7 +281,7 @@ export function registerHostsCommands(program: Command): void {
           .map((id) => id.trim())
           .filter(Boolean);
       const input = validateInput(setHostServersOperation, {
-        project: options.project,
+        project: resolveCloudProjectArgs(options).project,
         host: options.host,
         serverIds: splitIds(options.serverIds),
         ...(options.optionalServerIds
@@ -313,7 +314,7 @@ export function registerHostsCommands(program: Command): void {
     ) => {
       const globalOptions = getGlobalOptions(command);
       const input = validateInput(duplicateHostOperation, {
-        project: options.project,
+        project: resolveCloudProjectArgs(options).project,
         host: options.host,
         ...(options.name === undefined ? {} : { name: options.name }),
       });

--- a/cli/src/commands/images.ts
+++ b/cli/src/commands/images.ts
@@ -20,6 +20,7 @@ import {
   runPlatformOperation as runPlatformCommand,
   type PlatformOptions,
 } from "../lib/platform-command.js";
+import { resolveCloudProjectArgs } from "../lib/cloud-scope.js";
 import { getGlobalOptions } from "../lib/server-config.js";
 
 
@@ -74,7 +75,7 @@ export function registerImagesCommands(program: Command): void {
       globalOptions.timeout,
       ({ client, signal }) =>
         listImagesOperation.execute(
-          { project: options.project },
+          { project: resolveCloudProjectArgs(options).project },
           { client, signal }
         )
     );
@@ -98,7 +99,7 @@ export function registerImagesCommands(program: Command): void {
         globalOptions.timeout,
         ({ client, signal }) =>
           getImageOperation.execute(
-            { project: options.project, image: options.image },
+            { project: resolveCloudProjectArgs(options).project, image: options.image },
             { client, signal }
           )
       );
@@ -128,7 +129,7 @@ export function registerImagesCommands(program: Command): void {
       const globalOptions = getGlobalOptions(command);
       const blueprint = loadBlueprintText(options.file);
       const input = validateInput(createImageOperation, {
-        project: options.project,
+        project: resolveCloudProjectArgs(options).project,
         name: options.name,
         blueprint,
       });
@@ -159,7 +160,7 @@ export function registerImagesCommands(program: Command): void {
       const globalOptions = getGlobalOptions(command);
       const blueprint = loadBlueprintText(options.file);
       const input = validateInput(validateImageBlueprintOperation, {
-        project: options.project,
+        project: resolveCloudProjectArgs(options).project,
         blueprint,
       });
       const result = await runPlatformCommand(
@@ -194,7 +195,7 @@ export function registerImagesCommands(program: Command): void {
           ? loadBlueprintText(options.file)
           : undefined;
       const input = validateInput(updateImageOperation, {
-        project: options.project,
+        project: resolveCloudProjectArgs(options).project,
         image: options.image,
         ...(options.name !== undefined ? { name: options.name } : {}),
         ...(blueprint !== undefined ? { blueprint } : {}),
@@ -226,7 +227,7 @@ export function registerImagesCommands(program: Command): void {
         globalOptions.timeout,
         ({ client, signal }) =>
           buildImageOperation.execute(
-            { project: options.project, image: options.image },
+            { project: resolveCloudProjectArgs(options).project, image: options.image },
             { client, signal }
           )
       );
@@ -251,7 +252,7 @@ export function registerImagesCommands(program: Command): void {
         globalOptions.timeout,
         ({ client, signal }) =>
           listImageBuildsOperation.execute(
-            { project: options.project, image: options.image },
+            { project: resolveCloudProjectArgs(options).project, image: options.image },
             { client, signal }
           )
       );
@@ -276,7 +277,7 @@ export function registerImagesCommands(program: Command): void {
         globalOptions.timeout,
         ({ client, signal }) =>
           useImageOperation.execute(
-            { project: options.project, image: options.image },
+            { project: resolveCloudProjectArgs(options).project, image: options.image },
             { client, signal }
           )
       );
@@ -296,7 +297,7 @@ export function registerImagesCommands(program: Command): void {
       globalOptions.timeout,
       ({ client, signal }) =>
         resetComputerOperation.execute(
-          { project: options.project },
+          { project: resolveCloudProjectArgs(options).project },
           { client, signal }
         )
     );
@@ -320,7 +321,7 @@ export function registerImagesCommands(program: Command): void {
         globalOptions.timeout,
         ({ client, signal }) =>
           promoteImageOperation.execute(
-            { project: options.project, image: options.image },
+            { project: resolveCloudProjectArgs(options).project, image: options.image },
             { client, signal }
           )
       );
@@ -343,7 +344,7 @@ export function registerImagesCommands(program: Command): void {
         globalOptions.timeout,
         ({ client, signal }) =>
           deleteImageOperation.execute(
-            { project: options.project, image: options.image },
+            { project: resolveCloudProjectArgs(options).project, image: options.image },
             { client, signal }
           )
       );

--- a/cli/src/commands/journeys.ts
+++ b/cli/src/commands/journeys.ts
@@ -13,6 +13,7 @@ import {
   runPlatformOperation as runPlatformCommand,
   type PlatformOptions,
 } from "../lib/platform-command.js";
+import { resolveCloudProjectArgs } from "../lib/cloud-scope.js";
 import { getGlobalOptions } from "../lib/server-config.js";
 
 /**
@@ -103,7 +104,7 @@ export function registerJourneysCommands(program: Command): Command {
       globalOptions.timeout,
       ({ client, signal }) =>
         listJourneysOperation.execute(
-          { project: options.project },
+          { project: resolveCloudProjectArgs(options).project },
           { client, signal }
         )
     );
@@ -132,7 +133,7 @@ export function registerJourneysCommands(program: Command): Command {
         ({ client, signal }) =>
           listJourneyRunsOperation.execute(
             {
-              project: options.project,
+              project: resolveCloudProjectArgs(options).project,
               journey: options.journey,
               ...pageArgs(options),
             },
@@ -160,7 +161,7 @@ export function registerJourneysCommands(program: Command): Command {
         globalOptions.timeout,
         ({ client, signal }) =>
           getJourneyRunOperation.execute(
-            { project: options.project, run: options.run },
+            { project: resolveCloudProjectArgs(options).project, run: options.run },
             { client, signal }
           )
       );
@@ -206,7 +207,7 @@ export function registerJourneysCommands(program: Command): Command {
         ({ client, signal }) =>
           launchJourneyRunOperation.execute(
             {
-              project: options.project,
+              project: resolveCloudProjectArgs(options).project,
               journey: options.journey,
               ...(options.idempotencyKey
                 ? { idempotencyKey: options.idempotencyKey }
@@ -240,7 +241,7 @@ export function registerJourneysCommands(program: Command): Command {
         globalOptions.timeout,
         ({ client, signal }) =>
           cancelJourneyRunOperation.execute(
-            { project: options.project, run: options.run },
+            { project: resolveCloudProjectArgs(options).project, run: options.run },
             { client, signal }
           )
       );
@@ -272,7 +273,7 @@ export function registerJourneysCommands(program: Command): Command {
         ({ client, signal }) =>
           listJourneyRunSessionsOperation.execute(
             {
-              project: options.project,
+              project: resolveCloudProjectArgs(options).project,
               run: options.run,
               ...pageArgs(options),
             },

--- a/cli/src/commands/projects.ts
+++ b/cli/src/commands/projects.ts
@@ -26,6 +26,7 @@ import {
   runPlatformCommand,
   type PlatformOptions as SharedPlatformOptions,
 } from "../lib/platform-command.js";
+import { resolveCloudProjectArgs } from "../lib/cloud-scope.js";
 import { getGlobalOptions } from "../lib/server-config.js";
 import { openUrlInBrowser } from "@mcpjam/sdk";
 
@@ -47,11 +48,11 @@ type PlatformOptions = SharedPlatformOptions & {
  * merged nearest-first.
  */
 function requireProject(command: Command, options: PlatformOptions): string {
-  const project = options.project?.trim();
-  if (!project) {
+  const resolved = resolveCloudProjectArgs({ project: options.project });
+  if (resolved.projectScope.source === "automatic" || !resolved.project) {
     command.error("error: required option '--project <id-or-name>' not specified");
   }
-  return project;
+  return resolved.project;
 }
 
 /**
@@ -265,7 +266,7 @@ export function registerProjectsCommands(program: Command): void {
       globalOptions.timeout,
       ({ client, signal }) =>
         listProjectServersOperation.execute(
-          { project: platformOptions.project },
+          { project: resolveCloudProjectArgs(platformOptions).project },
           { client, signal }
         )
     );
@@ -416,7 +417,7 @@ export function registerProjectsCommands(program: Command): void {
         // and therefore consumes it, so the subcommand's own copy is always
         // undefined and this command quietly connected to the default project
         // instead of the one that was named.
-        project: platformOptions.project,
+        project: resolveCloudProjectArgs(platformOptions).project,
         serverId: options.server,
         name: options.name,
         reauthorize: options.reauthorize,
@@ -520,7 +521,7 @@ export function registerProjectsCommands(program: Command): void {
       globalOptions.timeout,
       ({ client, signal }) =>
         showServersOperation.execute(
-          { project: platformOptions.project },
+          { project: resolveCloudProjectArgs(platformOptions).project },
           { client, signal }
         )
     );

--- a/cli/src/commands/scenarios.ts
+++ b/cli/src/commands/scenarios.ts
@@ -11,6 +11,7 @@ import {
   runPlatformOperation as runPlatformCommand,
   type PlatformOptions,
 } from "../lib/platform-command.js";
+import { resolveCloudProjectArgs } from "../lib/cloud-scope.js";
 import { getGlobalOptions } from "../lib/server-config.js";
 
 /**
@@ -59,9 +60,7 @@ export function registerScenariosCommands(program: Command): void {
       ({ client, signal }) =>
         listScenariosOperation.execute(
           {
-            ...(options.project === undefined
-              ? {}
-              : { project: options.project }),
+            project: resolveCloudProjectArgs(options).project,
           },
           { client, signal }
         )
@@ -91,9 +90,7 @@ export function registerScenariosCommands(program: Command): void {
           getScenarioOperation.execute(
             {
               scenario: options.scenario,
-              ...(options.project === undefined
-                ? {}
-                : { project: options.project }),
+              project: resolveCloudProjectArgs(options).project,
             },
             { client, signal }
           )
@@ -145,7 +142,7 @@ export function registerScenariosCommands(program: Command): void {
         ({ client, signal }) =>
           publishScenarioOperation.execute(
             {
-              project: options.project,
+              project: resolveCloudProjectArgs(options).project,
               environment: options.environment,
               ...(options.name !== undefined ? { name: options.name } : {}),
               ...(options.description !== undefined
@@ -177,7 +174,7 @@ export function registerScenariosCommands(program: Command): void {
         globalOptions.timeout,
         ({ client, signal }) =>
           unpublishScenarioOperation.execute(
-            { project: options.project, environment: options.environment },
+            { project: resolveCloudProjectArgs(options).project, environment: options.environment },
             { client, signal }
           )
       );

--- a/cli/src/commands/tunnel.ts
+++ b/cli/src/commands/tunnel.ts
@@ -5,6 +5,7 @@ import {
 } from "@mcpjam/sdk/platform";
 import { cliError, usageError, writeResult } from "../lib/output.js";
 import { buildCloudClientContext, platformOptionsOf } from "../lib/platform-command.js";
+import { resolveCloudProjectArgs } from "../lib/cloud-scope.js";
 import { toCliError } from "../lib/platform-client.js";
 import { getGlobalOptions, parseServerConfig } from "../lib/server-config.js";
 import { startLocalBridge, type TunnelTarget } from "../lib/tunnel/local-bridge.js";
@@ -187,7 +188,7 @@ export function registerTunnelCommands(program: Command): void {
         const session = new TunnelSession({
           createGrant: (signal) =>
             createTunnelOperation.execute(
-              { project: options.project, name: options.id },
+              { project: resolveCloudProjectArgs(options).project, name: options.id },
               { client, signal },
             ),
           closeGrant: async (result, signal) => {

--- a/cli/src/lib/cloud-scope.ts
+++ b/cli/src/lib/cloud-scope.ts
@@ -1,0 +1,174 @@
+/**
+ * Typed Cloud resource scope and the project-selector precedence used by
+ * project-scoped `mcpjam cloud` commands.
+ *
+ * Precedence:
+ *   1. `--project`
+ *   2. explicit `project` in a `--file` / `--json` input document
+ *   3. `MCPJAM_PROJECT`
+ *   4. nearest valid `.mcpjam/project.json`
+ *   5. automatic SDK selection (most recently updated accessible project)
+ *
+ * `MCPJAM_PROJECT_ID` is SDK eval-reporting legacy and never selects a Cloud
+ * CLI project. Empty `--project` / `MCPJAM_PROJECT` are usage errors, not a
+ * fall-through to automatic.
+ */
+import {
+  inspectProjectLink,
+  readRequiredProjectLink,
+  type ProjectLinkIo,
+} from "./project-link.js";
+import { usageError } from "./output.js";
+
+export type CloudScope =
+  | { kind: "account" }
+  | { kind: "organization"; organization?: string }
+  | { kind: "all-projects" }
+  | {
+      kind: "project";
+      selector?: string;
+      source: "flag" | "input" | "env" | "link" | "automatic";
+      linkPath?: string;
+      linkedName?: string;
+    };
+
+export type ProjectCloudScope = Extract<CloudScope, { kind: "project" }>;
+
+export type ResolveProjectSelectorOptions = {
+  flagProject?: string | null;
+  inputProject?: string | null;
+  env?: NodeJS.ProcessEnv;
+  ignoreLink?: boolean;
+} & ProjectLinkIo;
+
+function present(value: string | null | undefined): value is string {
+  return typeof value === "string";
+}
+
+function requireNonEmpty(value: string, message: string): string {
+  const trimmed = value.trim();
+  if (!trimmed) {
+    throw usageError(message);
+  }
+  return trimmed;
+}
+
+export function resolveProjectSelector(
+  options: ResolveProjectSelectorOptions = {}
+): ProjectCloudScope {
+  if (present(options.flagProject)) {
+    return {
+      kind: "project",
+      selector: requireNonEmpty(
+        options.flagProject,
+        "Option --project cannot be empty. Omit it to use MCPJAM_PROJECT, a project link, or automatic selection."
+      ),
+      source: "flag",
+    };
+  }
+
+  if (present(options.inputProject)) {
+    return {
+      kind: "project",
+      selector: requireNonEmpty(
+        options.inputProject,
+        'Input document "project" cannot be empty. Omit it to use MCPJAM_PROJECT, a project link, or automatic selection.'
+      ),
+      source: "input",
+    };
+  }
+
+  const env = options.env ?? process.env;
+  if (present(env.MCPJAM_PROJECT)) {
+    return {
+      kind: "project",
+      selector: requireNonEmpty(
+        env.MCPJAM_PROJECT,
+        "MCPJAM_PROJECT cannot be empty. Unset it to use a project link or automatic selection."
+      ),
+      source: "env",
+    };
+  }
+
+  if (!options.ignoreLink) {
+    const linked = readRequiredProjectLink(options);
+    if (linked) {
+      return {
+        kind: "project",
+        selector: linked.link.project.id,
+        source: "link",
+        linkPath: linked.path,
+        linkedName: linked.link.project.name,
+      };
+    }
+  }
+
+  return { kind: "project", source: "automatic" };
+}
+
+/**
+ * Resolve the selector a project-scoped Cloud operation should send, plus the
+ * typed scope for status / stale-link hints. Does not inject into
+ * `options.project` — call sites with an input document pass `inputProject`
+ * separately so a flag-less JSON body still beats env/link.
+ */
+export function resolveCloudProjectArgs(
+  options: { project?: string },
+  extra: Omit<ResolveProjectSelectorOptions, "flagProject"> = {}
+): { project?: string; projectScope: ProjectCloudScope } {
+  const projectScope = resolveProjectSelector({
+    flagProject: options.project,
+    ...extra,
+  });
+  return {
+    ...(projectScope.selector !== undefined
+      ? { project: projectScope.selector }
+      : {}),
+    projectScope,
+  };
+}
+
+export function describeProjectScope(scope: ProjectCloudScope): string {
+  switch (scope.source) {
+    case "automatic":
+      return "automatic (most recently updated)";
+    case "flag":
+      return `flag (${scope.selector})`;
+    case "input":
+      return `input (${scope.selector})`;
+    case "env":
+      return `env (${scope.selector})`;
+    case "link":
+      return `link (${scope.linkedName ?? scope.selector})`;
+  }
+}
+
+export function isProjectSelectorFailure(message: string): boolean {
+  return (
+    message.startsWith("Project ") ||
+    message.startsWith("No accessible MCPJam projects")
+  );
+}
+
+export function appendProjectLinkHint(
+  message: string,
+  scope: ProjectCloudScope | undefined
+): string {
+  if (
+    !scope ||
+    scope.source !== "link" ||
+    !scope.linkPath ||
+    !isProjectSelectorFailure(message)
+  ) {
+    return message;
+  }
+  return `${message}\nSelector came from ${scope.linkPath} — re-run \`mcpjam cloud link\`.`;
+}
+
+/**
+ * Inspect the nearest link without throwing. `cloud status` reports invalid
+ * files instead of aborting before it can print diagnostics.
+ */
+export function inspectLinkedProject(io: ProjectLinkIo = {}) {
+  return inspectProjectLink(io);
+}

--- a/cli/src/lib/cloud-scope.ts
+++ b/cli/src/lib/cloud-scope.ts
@@ -35,6 +35,11 @@ export type ProjectCloudScope = Extract<CloudScope, { kind: "project" }>;
 
 export type ResolveProjectSelectorOptions = {
   flagProject?: string | null;
+  /**
+   * Override the empty-`--project` usage text. `cloud link` has a positional
+   * project argument, not `--project`, so it must name that argument.
+   */
+  emptyFlagMessage?: string;
   inputProject?: string | null;
   env?: NodeJS.ProcessEnv;
   ignoreLink?: boolean;
@@ -60,7 +65,8 @@ export function resolveProjectSelector(
       kind: "project",
       selector: requireNonEmpty(
         options.flagProject,
-        "Option --project cannot be empty. Omit it to use MCPJAM_PROJECT, a project link, or automatic selection."
+        options.emptyFlagMessage ??
+          "Option --project cannot be empty. Omit it to use MCPJAM_PROJECT, a project link, or automatic selection."
       ),
       source: "flag",
     };

--- a/cli/src/lib/cloud-scope.ts
+++ b/cli/src/lib/cloud-scope.ts
@@ -14,7 +14,6 @@
  * fall-through to automatic.
  */
 import {
-  inspectProjectLink,
   readRequiredProjectLink,
   type ProjectLinkIo,
 } from "./project-link.js";
@@ -163,12 +162,4 @@ export function appendProjectLinkHint(
     return message;
   }
   return `${message}\nSelector came from ${scope.linkPath} — re-run \`mcpjam cloud link\`.`;
-}
-
-/**
- * Inspect the nearest link without throwing. `cloud status` reports invalid
- * files instead of aborting before it can print diagnostics.
- */
-export function inspectLinkedProject(io: ProjectLinkIo = {}) {
-  return inspectProjectLink(io);
 }

--- a/cli/src/lib/credential-describe.ts
+++ b/cli/src/lib/credential-describe.ts
@@ -7,6 +7,9 @@
  */
 import { DEFAULT_PLATFORM_API_BASE_URL } from "@mcpjam/sdk/platform";
 import { getAuthFilePath, readStoredAuth } from "./auth-store.js";
+import { LEGACY_KEY_REMEDY } from "./platform-auth.js";
+import { validateApiUrl } from "./platform-client.js";
+import { usageError } from "./output.js";
 
 const LEGACY_API_KEY_PREFIX = "mcpjam_";
 
@@ -61,6 +64,10 @@ export function describeCloudCredential(
   const envKey = trimmed(env.MCPJAM_API_KEY);
   const usableEnvKey = envKey && isUsableSkKey(envKey) ? envKey : undefined;
 
+  if (flagKey && !isUsableSkKey(flagKey)) {
+    throw usageError(LEGACY_KEY_REMEDY);
+  }
+
   let credential: CloudCredentialDescription;
   if (flagKey) {
     credential = {
@@ -98,9 +105,12 @@ export function describeCloudCredential(
   const envUrl = trimmed(env.MCPJAM_API_URL);
   let deployment: CloudDeploymentDescription;
   if (flagUrl) {
-    deployment = { apiUrl: flagUrl, source: "flag" };
+    deployment = { apiUrl: validateApiUrl(flagUrl, "--api-url"), source: "flag" };
   } else if (envUrl) {
-    deployment = { apiUrl: envUrl, source: "env" };
+    deployment = {
+      apiUrl: validateApiUrl(envUrl, "MCPJAM_API_URL"),
+      source: "env",
+    };
   } else if (stored?.apiUrl) {
     deployment = { apiUrl: stored.apiUrl, source: "oauth" };
   } else {

--- a/cli/src/lib/credential-describe.ts
+++ b/cli/src/lib/credential-describe.ts
@@ -1,0 +1,114 @@
+/**
+ * Offline description of how this process would authenticate to MCPJam Cloud
+ * and which deployment it would talk to.
+ *
+ * Mirrors `resolvePlatformCredential` / `buildPlatformClient` precedence
+ * without calling `getAuth()` or the network. `cloud status` is the consumer.
+ */
+import { DEFAULT_PLATFORM_API_BASE_URL } from "@mcpjam/sdk/platform";
+import { getAuthFilePath, readStoredAuth } from "./auth-store.js";
+
+const LEGACY_API_KEY_PREFIX = "mcpjam_";
+
+export type CloudCredentialSource = "flag" | "env" | "oauth" | "missing";
+export type CloudDeploymentSource = "flag" | "env" | "oauth" | "default";
+
+export type CloudCredentialDescription = {
+  source: CloudCredentialSource;
+  kind: "api-key" | "oauth" | "none";
+  redactedKey?: string;
+  envShadowsOauth: boolean;
+  storedOauthPresent: boolean;
+};
+
+export type CloudDeploymentDescription = {
+  apiUrl: string;
+  source: CloudDeploymentSource;
+};
+
+export type DescribeCloudCredentialDependencies = {
+  env?: NodeJS.ProcessEnv;
+  authFilePath?: string;
+};
+
+export function redactCloudApiKey(key: string): string {
+  const last4 = key.slice(-4);
+  return `sk_…${last4}`;
+}
+
+function trimmed(value: string | undefined): string | undefined {
+  const next = value?.trim();
+  return next ? next : undefined;
+}
+
+function isUsableSkKey(value: string): boolean {
+  return !value.startsWith(LEGACY_API_KEY_PREFIX);
+}
+
+export function describeCloudCredential(
+  options: { apiKey?: string; apiUrl?: string },
+  deps: DescribeCloudCredentialDependencies = {}
+): {
+  credential: CloudCredentialDescription;
+  deployment: CloudDeploymentDescription;
+} {
+  const env = deps.env ?? process.env;
+  const authFilePath = deps.authFilePath ?? getAuthFilePath({ env });
+  const stored = readStoredAuth(authFilePath);
+  const storedOauthPresent = stored !== null;
+
+  const flagKey = trimmed(options.apiKey);
+  const envKey = trimmed(env.MCPJAM_API_KEY);
+  const usableEnvKey = envKey && isUsableSkKey(envKey) ? envKey : undefined;
+
+  let credential: CloudCredentialDescription;
+  if (flagKey) {
+    credential = {
+      source: "flag",
+      kind: "api-key",
+      redactedKey: redactCloudApiKey(flagKey),
+      envShadowsOauth: false,
+      storedOauthPresent,
+    };
+  } else if (usableEnvKey) {
+    credential = {
+      source: "env",
+      kind: "api-key",
+      redactedKey: redactCloudApiKey(usableEnvKey),
+      envShadowsOauth: storedOauthPresent,
+      storedOauthPresent,
+    };
+  } else if (stored) {
+    credential = {
+      source: "oauth",
+      kind: "oauth",
+      envShadowsOauth: false,
+      storedOauthPresent,
+    };
+  } else {
+    credential = {
+      source: "missing",
+      kind: "none",
+      envShadowsOauth: false,
+      storedOauthPresent,
+    };
+  }
+
+  const flagUrl = trimmed(options.apiUrl);
+  const envUrl = trimmed(env.MCPJAM_API_URL);
+  let deployment: CloudDeploymentDescription;
+  if (flagUrl) {
+    deployment = { apiUrl: flagUrl, source: "flag" };
+  } else if (envUrl) {
+    deployment = { apiUrl: envUrl, source: "env" };
+  } else if (stored?.apiUrl) {
+    deployment = { apiUrl: stored.apiUrl, source: "oauth" };
+  } else {
+    deployment = {
+      apiUrl: DEFAULT_PLATFORM_API_BASE_URL,
+      source: "default",
+    };
+  }
+
+  return { credential, deployment };
+}

--- a/cli/src/lib/platform-auth.ts
+++ b/cli/src/lib/platform-auth.ts
@@ -34,7 +34,7 @@ const LEGACY_API_KEY_PREFIX = "mcpjam_";
 const TOKEN_REFRESH_SKEW_MS = 60_000;
 const DEFAULT_LOGIN_TIMEOUT_MS = 5 * 60_000;
 
-const LEGACY_KEY_REMEDY =
+export const LEGACY_KEY_REMEDY =
   "Legacy mcpjam_ API keys are not supported by platform commands. Create an sk_ key at https://app.mcpjam.com/settings/api-keys or run `mcpjam cloud login`.";
 
 export interface PlatformCredential {

--- a/cli/src/lib/platform-client.ts
+++ b/cli/src/lib/platform-client.ts
@@ -23,7 +23,7 @@ export interface PlatformClientOptions {
  * hard-error: silently falling back to prod would run a login or send a
  * token somewhere the user did not ask for.
  */
-function validateApiUrl(value: string, source: string): string {
+export function validateApiUrl(value: string, source: string): string {
   let parsed: URL;
   try {
     parsed = new URL(value);

--- a/cli/src/lib/platform-command.ts
+++ b/cli/src/lib/platform-command.ts
@@ -14,12 +14,18 @@
 import type { Command } from "commander";
 import { PlatformApiError } from "@mcpjam/sdk/platform";
 import {
+  appendProjectLinkHint,
+  resolveCloudProjectArgs,
+  type ProjectCloudScope,
+  type ResolveProjectSelectorOptions,
+} from "./cloud-scope.js";
+import {
   buildPlatformClient,
   toCliError,
   webOriginForApiBaseUrl,
 } from "./platform-client.js";
 import { getGlobalOptions } from "./server-config.js";
-import { usageError, writeResult } from "./output.js";
+import { CliError, usageError, writeResult } from "./output.js";
 
 export type PlatformOptions = {
   apiKey?: string;
@@ -51,6 +57,11 @@ export type RunPlatformOperationExtras = {
    * the audience-line change lands.
    */
   announce?: boolean;
+  /**
+   * How the project selector for this operation was chosen. Used to append
+   * a re-link hint when a link-sourced selector fails online.
+   */
+  projectScope?: ProjectCloudScope;
 };
 
 /**
@@ -164,7 +175,13 @@ export async function runPlatformOperation<TOutput>(
     ) {
       throw toCliError(controller.signal.reason);
     }
-    throw toCliError(error);
+    const mapped = toCliError(error);
+    throw new CliError(
+      mapped.code,
+      appendProjectLinkHint(mapped.message, extras.projectScope),
+      mapped.exitCode,
+      mapped.details
+    );
   } finally {
     clearTimeout(timeoutHandle);
     externalSignal?.removeEventListener("abort", onExternalAbort);
@@ -212,6 +229,10 @@ function hasCloudAncestor(command: Command): boolean {
   return false;
 }
 
+function commandHasProjectOption(command: Command): boolean {
+  return command.options.some((option) => option.long === "--project");
+}
+
 export function bindOperation<TOptions extends PlatformOptions, TInput>(
   command: Command,
   operation: {
@@ -230,14 +251,58 @@ export function bindOperation<TOptions extends PlatformOptions, TInput>(
   }
   command.action(async (options: TOptions, invoked: Command) => {
     const globalOptions = getGlobalOptions(invoked);
+    const merged = platformOptionsOf<TOptions & { project?: string }>(invoked);
+    const applyAmbient =
+      hasCloudAncestor(invoked) && commandHasProjectOption(invoked);
+    const resolved = applyAmbient
+      ? resolveCloudProjectArgs({ project: merged.project })
+      : undefined;
+    const inputOptions = resolved
+      ? ({ ...options, project: resolved.project } as TOptions)
+      : options;
     const result = await runPlatformOperation(
       platformOptionsOf<TOptions>(invoked),
       globalOptions.timeout,
       ({ client, signal }) =>
-        operation.execute(buildInput(options), { client, signal })
+        operation.execute(buildInput(inputOptions), { client, signal }),
+      resolved ? { projectScope: resolved.projectScope } : {}
     );
     writeResult(result, globalOptions.format);
   });
+}
+
+/**
+ * Run a project-scoped Cloud operation, applying flag / input / env / link /
+ * automatic precedence to `--project` without writing the resolved selector
+ * back onto `options.project`.
+ */
+export async function runCloudOp<
+  TOptions extends PlatformOptions & { project?: string },
+  TOutput,
+>(
+  command: Command,
+  options: TOptions,
+  execute: (
+    context: PlatformOperationContext,
+    project: { project?: string }
+  ) => Promise<TOutput>,
+  extra: Omit<ResolveProjectSelectorOptions, "flagProject"> & {
+    extras?: RunPlatformOperationExtras;
+  } = {}
+): Promise<TOutput> {
+  const globalOptions = getGlobalOptions(command);
+  const { extras: nestedExtras, ...selectorExtra } = extra;
+  const resolved = resolveCloudProjectArgs(options, selectorExtra);
+  return runPlatformOperation(
+    platformOptionsOf(command),
+    globalOptions.timeout,
+    (context) =>
+      execute(
+        context,
+        resolved.project !== undefined ? { project: resolved.project } : {}
+      ),
+    { ...nestedExtras, projectScope: resolved.projectScope }
+  );
 }
 
 /** `--project` is optional everywhere: it defaults to the newest project. */

--- a/cli/src/lib/project-link.ts
+++ b/cli/src/lib/project-link.ts
@@ -1,0 +1,290 @@
+/**
+ * `.mcpjam/project.json` — a committed, secret-free pin from a working
+ * directory to an MCPJam Cloud project.
+ *
+ * Lookup walks from `cwd` toward the nearest Git worktree root (inclusive).
+ * Outside Git, only `cwd` is inspected so `$HOME/.mcpjam/project.json` cannot
+ * become ambient context for an unrelated directory.
+ */
+import { existsSync, readFileSync, unlinkSync } from "node:fs";
+import path from "node:path";
+import { writeFileAtomic } from "./atomic-write.js";
+import { operationalError, usageError } from "./output.js";
+
+export const PROJECT_LINK_VERSION = 1;
+export const PROJECT_LINK_RELATIVE_PATH = path.join(".mcpjam", "project.json");
+
+export type ProjectLink = {
+  version: 1;
+  project: { id: string; name: string };
+  organizationId?: string;
+  apiUrl: string;
+};
+
+export type ProjectLinkIo = {
+  cwd?: string;
+  existsSync?: (target: string) => boolean;
+  readFileSync?: (target: string, encoding: "utf8") => string;
+};
+
+export type ProjectLinkInspection =
+  | { status: "missing" }
+  | { status: "valid"; path: string; link: ProjectLink }
+  | { status: "invalid"; path: string; error: string };
+
+function exists(target: string, io: ProjectLinkIo = {}): boolean {
+  return (io.existsSync ?? existsSync)(target);
+}
+
+function readText(target: string, io: ProjectLinkIo = {}): string {
+  return (io.readFileSync ?? readFileSync)(target, "utf8");
+}
+
+function cwdOf(io: ProjectLinkIo = {}): string {
+  return path.resolve(io.cwd ?? process.cwd());
+}
+
+/**
+ * Nearest Git worktree root, walking up from `startDir`. `.git` may be a
+ * directory (normal repo) or a file (linked worktree).
+ */
+export function findGitWorktreeRoot(
+  startDir: string,
+  io: ProjectLinkIo = {}
+): string | null {
+  let current = path.resolve(startDir);
+  const { root } = path.parse(current);
+  while (true) {
+    if (exists(path.join(current, ".git"), io)) {
+      return current;
+    }
+    if (current === root) {
+      return null;
+    }
+    const parent = path.dirname(current);
+    if (parent === current) {
+      return null;
+    }
+    current = parent;
+  }
+}
+
+/** Directory `cloud link` writes to: `--here` → cwd; else Git root or cwd. */
+export function projectLinkWriteDir(
+  io: ProjectLinkIo & { here?: boolean } = {}
+): string {
+  const cwd = cwdOf(io);
+  if (io.here) {
+    return cwd;
+  }
+  return findGitWorktreeRoot(cwd, io) ?? cwd;
+}
+
+export function projectLinkPathForDir(directory: string): string {
+  return path.join(path.resolve(directory), PROJECT_LINK_RELATIVE_PATH);
+}
+
+/**
+ * Path of the nearest `.mcpjam/project.json`, or `undefined` if none exists.
+ * Existence is not validity — callers must parse.
+ */
+export function findNearestProjectLinkPath(
+  io: ProjectLinkIo = {}
+): string | undefined {
+  const start = cwdOf(io);
+  const gitRoot = findGitWorktreeRoot(start, io);
+  if (!gitRoot) {
+    const candidate = projectLinkPathForDir(start);
+    return exists(candidate, io) ? candidate : undefined;
+  }
+
+  let current = start;
+  while (true) {
+    const candidate = projectLinkPathForDir(current);
+    if (exists(candidate, io)) {
+      return candidate;
+    }
+    if (path.resolve(current) === path.resolve(gitRoot)) {
+      return undefined;
+    }
+    const parent = path.dirname(current);
+    if (parent === current) {
+      return undefined;
+    }
+    current = parent;
+  }
+}
+
+export function normalizeApiUrl(url: string): string {
+  return url.trim().replace(/\/+$/, "");
+}
+
+export function apiUrlsMatch(left: string, right: string): boolean {
+  return normalizeApiUrl(left) === normalizeApiUrl(right);
+}
+
+function canonicalHttpUrl(value: string): string | null {
+  let parsed: URL;
+  try {
+    parsed = new URL(value);
+  } catch {
+    return null;
+  }
+  if (parsed.protocol !== "http:" && parsed.protocol !== "https:") {
+    return null;
+  }
+  if (!parsed.hostname) {
+    return null;
+  }
+  return value;
+}
+
+function nonEmptyString(value: unknown): string | undefined {
+  return typeof value === "string" && value.trim() ? value.trim() : undefined;
+}
+
+export function parseProjectLink(
+  raw: unknown,
+  filePath: string
+): { ok: true; link: ProjectLink } | { ok: false; error: string } {
+  if (raw === null || typeof raw !== "object" || Array.isArray(raw)) {
+    return {
+      ok: false,
+      error: `${filePath} must be a JSON object.`,
+    };
+  }
+  const record = raw as Record<string, unknown>;
+  if (record.version !== PROJECT_LINK_VERSION) {
+    return {
+      ok: false,
+      error: `${filePath} has unsupported version ${JSON.stringify(
+        record.version
+      )}. Expected ${PROJECT_LINK_VERSION}. Re-run \`mcpjam cloud link\`.`,
+    };
+  }
+  const project = record.project;
+  if (project === null || typeof project !== "object" || Array.isArray(project)) {
+    return {
+      ok: false,
+      error: `${filePath} is missing project { id, name }.`,
+    };
+  }
+  const projectRecord = project as Record<string, unknown>;
+  const id = nonEmptyString(projectRecord.id);
+  const name = nonEmptyString(projectRecord.name);
+  if (!id || !name) {
+    return {
+      ok: false,
+      error: `${filePath} must have non-empty project.id and project.name.`,
+    };
+  }
+  if (typeof record.apiUrl !== "string" || !canonicalHttpUrl(record.apiUrl)) {
+    return {
+      ok: false,
+      error: `${filePath} must have a canonical http(s) apiUrl.`,
+    };
+  }
+  if (
+    record.organizationId !== undefined &&
+    !nonEmptyString(record.organizationId)
+  ) {
+    return {
+      ok: false,
+      error: `${filePath} organizationId must be a non-empty string when present.`,
+    };
+  }
+
+  const organizationId = nonEmptyString(record.organizationId);
+  return {
+    ok: true,
+    link: {
+      version: PROJECT_LINK_VERSION,
+      project: { id, name },
+      ...(organizationId !== undefined ? { organizationId } : {}),
+      apiUrl: record.apiUrl,
+    },
+  };
+}
+
+export function inspectProjectLink(io: ProjectLinkIo = {}): ProjectLinkInspection {
+  const filePath = findNearestProjectLinkPath(io);
+  if (!filePath) {
+    return { status: "missing" };
+  }
+
+  let text: string;
+  try {
+    text = readText(filePath, io);
+  } catch (error) {
+    return {
+      status: "invalid",
+      path: filePath,
+      error: `Could not read ${filePath}: ${
+        error instanceof Error ? error.message : String(error)
+      }`,
+    };
+  }
+
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(text);
+  } catch {
+    return {
+      status: "invalid",
+      path: filePath,
+      error: `${filePath} is not valid JSON.`,
+    };
+  }
+
+  const result = parseProjectLink(parsed, filePath);
+  if (!result.ok) {
+    return { status: "invalid", path: filePath, error: result.error };
+  }
+  return { status: "valid", path: filePath, link: result.link };
+}
+
+/**
+ * Valid nearest link, or a hard error. Missing is `null`. Callers that would
+ * fall through to automatic selection must use this rather than ignoring an
+ * unreadable file.
+ */
+export function readRequiredProjectLink(
+  io: ProjectLinkIo = {}
+): { path: string; link: ProjectLink } | null {
+  const inspection = inspectProjectLink(io);
+  if (inspection.status === "missing") {
+    return null;
+  }
+  if (inspection.status === "invalid") {
+    throw operationalError(inspection.error);
+  }
+  return { path: inspection.path, link: inspection.link };
+}
+
+export async function writeProjectLink(args: {
+  directory: string;
+  link: ProjectLink;
+}): Promise<string> {
+  const filePath = projectLinkPathForDir(args.directory);
+  const body = `${JSON.stringify(args.link, null, 2)}\n`;
+  return writeFileAtomic(filePath, body, { createParents: true });
+}
+
+export function removeProjectLinkFile(filePath: string): void {
+  try {
+    unlinkSync(filePath);
+  } catch (error) {
+    const code =
+      error && typeof error === "object" && "code" in error
+        ? String((error as { code?: unknown }).code)
+        : "";
+    if (code === "ENOENT") {
+      throw usageError(`No project link at ${filePath}.`);
+    }
+    throw operationalError(
+      `Could not remove ${filePath}: ${
+        error instanceof Error ? error.message : String(error)
+      }`
+    );
+  }
+}

--- a/cli/tests/cloud-link-status.test.ts
+++ b/cli/tests/cloud-link-status.test.ts
@@ -1,0 +1,532 @@
+/**
+ * `mcpjam cloud link` / `mcpjam cloud status` and project-selector wiring.
+ */
+import assert from "node:assert/strict";
+import { execFile as execFileCallback } from "node:child_process";
+import { mkdirSync, mkdtempSync, readFileSync, writeFileSync } from "node:fs";
+import { createServer, type Server } from "node:http";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { promisify } from "node:util";
+import test from "node:test";
+import { runCli } from "./support/cli-run.js";
+import { projectLinkPathForDir } from "../src/lib/project-link.js";
+
+const execFile = promisify(execFileCallback);
+
+const PROJECTS = [
+  {
+    id: "proj-alpha",
+    name: "Alpha",
+    description: null,
+    icon: null,
+    organizationId: "org-1",
+    visibility: null,
+    createdAt: 1,
+    updatedAt: 200,
+  },
+  {
+    id: "proj-beta",
+    name: "Beta",
+    description: null,
+    icon: null,
+    organizationId: "org-1",
+    visibility: null,
+    createdAt: 2,
+    updatedAt: 100,
+  },
+];
+
+async function startProjectFixture(): Promise<{
+  baseUrl: string;
+  suitePaths: string[];
+  close: () => Promise<void>;
+}> {
+  const suitePaths: string[] = [];
+  const server: Server = createServer((req, res) => {
+    const url = new URL(req.url ?? "/", "http://fixture");
+    res.setHeader("content-type", "application/json");
+    if (url.pathname === "/api/v1/projects") {
+      res.end(JSON.stringify({ items: PROJECTS }));
+      return;
+    }
+    const suites = url.pathname.match(
+      /^\/api\/v1\/projects\/([^/]+)\/eval-suites$/
+    );
+    if (suites) {
+      suitePaths.push(decodeURIComponent(suites[1] ?? ""));
+      if ((req.method ?? "GET") === "POST") {
+        res.statusCode = 201;
+        res.end(
+          JSON.stringify({
+            suiteId: "suite-created",
+            name: "created",
+            servers: [],
+            caseUpsert: { committed: [], failed: [] },
+          })
+        );
+        return;
+      }
+      res.end(JSON.stringify({ items: [] }));
+      return;
+    }
+    if (/^\/api\/v1\/projects\/[^/]+\/servers$/.test(url.pathname)) {
+      res.end(JSON.stringify({ items: [] }));
+      return;
+    }
+    res.statusCode = 404;
+    res.end(JSON.stringify({ code: "NOT_FOUND", message: url.pathname }));
+  });
+
+  await new Promise<void>((resolve) =>
+    server.listen(0, "127.0.0.1", () => resolve())
+  );
+  const address = server.address();
+  if (!address || typeof address === "string") {
+    throw new Error("fixture server has no address");
+  }
+
+  return {
+    baseUrl: `http://127.0.0.1:${address.port}/api/v1`,
+    suitePaths,
+    close: () =>
+      new Promise<void>((resolve, reject) =>
+        server.close((error) => (error ? reject(error) : resolve()))
+      ),
+  };
+}
+
+async function withCwd<T>(directory: string, fn: () => Promise<T>): Promise<T> {
+  const previous = process.cwd();
+  process.chdir(directory);
+  try {
+    return await fn();
+  } finally {
+    process.chdir(previous);
+  }
+}
+
+async function withEnv<T>(
+  updates: Record<string, string | undefined>,
+  fn: () => Promise<T>
+): Promise<T> {
+  const previous: Record<string, string | undefined> = {};
+  for (const key of Object.keys(updates)) {
+    previous[key] = process.env[key];
+    const value = updates[key];
+    if (value === undefined) {
+      delete process.env[key];
+    } else {
+      process.env[key] = value;
+    }
+  }
+  try {
+    return await fn();
+  } finally {
+    for (const [key, value] of Object.entries(previous)) {
+      if (value === undefined) {
+        delete process.env[key];
+      } else {
+        process.env[key] = value;
+      }
+    }
+  }
+}
+
+function isolatedEnv(
+  extra: Record<string, string | undefined> = {}
+): Record<string, string | undefined> {
+  return {
+    MCPJAM_PROJECT: undefined,
+    MCPJAM_PROJECT_ID: undefined,
+    MCPJAM_API_KEY: undefined,
+    MCPJAM_API_URL: undefined,
+    MCPJAM_AUTH_FILE: path.join(tmpdir(), "mcpjam-no-auth.json"),
+    ...extra,
+  };
+}
+
+function writeLink(
+  directory: string,
+  body: Record<string, unknown>
+): string {
+  const filePath = projectLinkPathForDir(directory);
+  mkdirSync(path.dirname(filePath), { recursive: true });
+  writeFileSync(filePath, `${JSON.stringify(body, null, 2)}\n`);
+  return filePath;
+}
+
+test("cloud status reports missing credentials and automatic project offline", async () => {
+  const cwd = mkdtempSync(path.join(tmpdir(), "mcpjam-status-"));
+  const run = await withEnv(isolatedEnv(), () =>
+    withCwd(cwd, () => runCli(["cloud", "status", "--format", "json"]))
+  );
+  assert.equal(run.exitCode, 0, run.stderr);
+  const payload = JSON.parse(run.stdout) as {
+    ok: boolean;
+    credential: { source: string };
+    project: { source: string; description: string };
+    link: { valid: boolean | null };
+  };
+  assert.equal(payload.ok, true);
+  assert.equal(payload.credential.source, "missing");
+  assert.equal(payload.project.source, "automatic");
+  assert.equal(payload.project.description, "automatic (most recently updated)");
+  assert.equal(payload.link.valid, null);
+  assert.doesNotMatch(run.stdout, /project: default/i);
+});
+
+test("cloud status names MCPJAM_PROJECT_ID as eval-reporting only", async () => {
+  const cwd = mkdtempSync(path.join(tmpdir(), "mcpjam-status-id-"));
+  const run = await withEnv(
+    isolatedEnv({ MCPJAM_PROJECT_ID: "proj-from-sdk" }),
+    () => withCwd(cwd, () => runCli(["cloud", "status", "--format", "json"]))
+  );
+  assert.equal(run.exitCode, 0, run.stderr);
+  const payload = JSON.parse(run.stdout) as { warnings: string[] };
+  assert.match(
+    payload.warnings.join("\n"),
+    /MCPJAM_PROJECT_ID is set; it is used only for SDK eval reporting/
+  );
+  assert.equal(JSON.parse(run.stdout).project.source, "automatic");
+});
+
+test("cloud status reports an invalid link and exits nonzero", async () => {
+  const cwd = mkdtempSync(path.join(tmpdir(), "mcpjam-status-bad-"));
+  writeLink(cwd, { version: 2, project: { id: "x", name: "y" } });
+  const run = await withEnv(isolatedEnv(), () =>
+    withCwd(cwd, () => runCli(["cloud", "status", "--format", "json"]))
+  );
+  assert.equal(run.exitCode, 1, run.stderr);
+  const payload = JSON.parse(run.stdout) as {
+    ok: boolean;
+    link: { valid: boolean; error?: string };
+  };
+  assert.equal(payload.ok, false);
+  assert.equal(payload.link.valid, false);
+  assert.match(payload.link.error ?? "", /unsupported version/);
+});
+
+test("cloud status warns when link apiUrl does not match the active deployment", async () => {
+  const cwd = mkdtempSync(path.join(tmpdir(), "mcpjam-status-url-"));
+  writeLink(cwd, {
+    version: 1,
+    project: { id: "proj-alpha", name: "Alpha" },
+    apiUrl: "https://staging.example.com/api/v1",
+  });
+  const run = await withEnv(isolatedEnv(), () =>
+    withCwd(cwd, () => runCli(["cloud", "status", "--format", "json"]))
+  );
+  assert.equal(run.exitCode, 0, run.stderr);
+  const payload = JSON.parse(run.stdout) as {
+    warnings: string[];
+    link: { apiUrlMatchesDeployment: boolean };
+    project: { source: string };
+  };
+  assert.equal(payload.link.apiUrlMatchesDeployment, false);
+  assert.equal(payload.project.source, "link");
+  assert.match(payload.warnings.join("\n"), /does not match the active deployment/);
+});
+
+test("cloud link writes .mcpjam/project.json at the Git worktree root", async () => {
+  const fixture = await startProjectFixture();
+  const root = mkdtempSync(path.join(tmpdir(), "mcpjam-link-git-"));
+  await execFile("git", ["init"], { cwd: root });
+  const nested = path.join(root, "pkg");
+  mkdirSync(nested);
+  try {
+    const run = await withEnv(isolatedEnv(), () =>
+      withCwd(nested, () =>
+        runCli([
+          "cloud",
+          "link",
+          "Beta",
+          "--api-key",
+          "sk_test",
+          "--api-url",
+          fixture.baseUrl,
+          "--format",
+          "json",
+        ])
+      )
+    );
+    assert.equal(run.exitCode, 0, run.stderr);
+    const payload = JSON.parse(run.stdout) as {
+      status: string;
+      path: string;
+      project: { id: string; name: string };
+    };
+    assert.equal(payload.status, "linked");
+    assert.equal(payload.project.id, "proj-beta");
+    const written = JSON.parse(readFileSync(payload.path, "utf8")) as {
+      version: number;
+      project: { id: string; name: string };
+      apiUrl: string;
+    };
+    assert.equal(written.version, 1);
+    assert.equal(written.project.name, "Beta");
+    assert.equal(written.apiUrl, fixture.baseUrl);
+    assert.equal(payload.path, projectLinkPathForDir(root));
+  } finally {
+    await fixture.close();
+  }
+});
+
+test("cloud link --here writes in cwd; --remove deletes the nearest file", async () => {
+  const fixture = await startProjectFixture();
+  const cwd = mkdtempSync(path.join(tmpdir(), "mcpjam-link-here-"));
+  try {
+    const linkRun = await withEnv(isolatedEnv(), () =>
+      withCwd(cwd, () =>
+        runCli([
+          "cloud",
+          "link",
+          "proj-alpha",
+          "--here",
+          "--api-key",
+          "sk_test",
+          "--api-url",
+          fixture.baseUrl,
+          "--format",
+          "json",
+        ])
+      )
+    );
+    assert.equal(linkRun.exitCode, 0, linkRun.stderr);
+    assert.equal(
+      JSON.parse(linkRun.stdout).path,
+      projectLinkPathForDir(cwd)
+    );
+
+    const removeRun = await withEnv(isolatedEnv(), () =>
+      withCwd(cwd, () =>
+        runCli(["cloud", "link", "--remove", "--format", "json"])
+      )
+    );
+    assert.equal(removeRun.exitCode, 0, removeRun.stderr);
+    assert.equal(JSON.parse(removeRun.stdout).status, "removed");
+    assert.throws(() => readFileSync(projectLinkPathForDir(cwd), "utf8"));
+  } finally {
+    await fixture.close();
+  }
+});
+
+test("cloud link --remove rejects a project argument", async () => {
+  const run = await runCli([
+    "cloud",
+    "link",
+    "Alpha",
+    "--remove",
+    "--format",
+    "json",
+  ]);
+  assert.equal(run.exitCode, 2);
+  assert.match(run.stderr, /Do not pass a project argument with --remove/);
+});
+
+test("eval list uses MCPJAM_PROJECT then a project link, and --project wins", async () => {
+  const fixture = await startProjectFixture();
+  const cwd = mkdtempSync(path.join(tmpdir(), "mcpjam-eval-link-"));
+  writeLink(cwd, {
+    version: 1,
+    project: { id: "proj-beta", name: "Beta" },
+    apiUrl: fixture.baseUrl,
+  });
+  try {
+    const fromLink = await withEnv(isolatedEnv(), () =>
+      withCwd(cwd, () =>
+        runCli([
+          "cloud",
+          "eval",
+          "list",
+          "--api-key",
+          "sk_test",
+          "--api-url",
+          fixture.baseUrl,
+          "--format",
+          "json",
+        ])
+      )
+    );
+    assert.equal(fromLink.exitCode, 0, fromLink.stderr);
+    assert.deepEqual(fixture.suitePaths, ["proj-beta"]);
+
+    fixture.suitePaths.length = 0;
+    const fromEnv = await withEnv(
+      isolatedEnv({ MCPJAM_PROJECT: "Alpha" }),
+      () =>
+        withCwd(cwd, () =>
+          runCli([
+            "cloud",
+            "eval",
+            "list",
+            "--api-key",
+            "sk_test",
+            "--api-url",
+            fixture.baseUrl,
+            "--format",
+            "json",
+          ])
+        )
+    );
+    assert.equal(fromEnv.exitCode, 0, fromEnv.stderr);
+    assert.deepEqual(fixture.suitePaths, ["proj-alpha"]);
+
+    fixture.suitePaths.length = 0;
+    const fromFlag = await withEnv(
+      isolatedEnv({ MCPJAM_PROJECT: "Alpha" }),
+      () =>
+        withCwd(cwd, () =>
+          runCli([
+            "cloud",
+            "eval",
+            "list",
+            "--project",
+            "Beta",
+            "--api-key",
+            "sk_test",
+            "--api-url",
+            fixture.baseUrl,
+            "--format",
+            "json",
+          ])
+        )
+    );
+    assert.equal(fromFlag.exitCode, 0, fromFlag.stderr);
+    assert.deepEqual(fixture.suitePaths, ["proj-beta"]);
+  } finally {
+    await fixture.close();
+  }
+});
+
+test("eval create JSON project beats MCPJAM_PROJECT, and --project beats JSON", async () => {
+  const fixture = await startProjectFixture();
+  const cwd = mkdtempSync(path.join(tmpdir(), "mcpjam-eval-json-"));
+  try {
+    const fromJson = await withEnv(
+      isolatedEnv({ MCPJAM_PROJECT: "Beta" }),
+      () =>
+        withCwd(cwd, () =>
+          runCli([
+            "cloud",
+            "eval",
+            "create",
+            "--json",
+            JSON.stringify({
+              project: "Alpha",
+              name: "From JSON",
+              servers: [],
+              cases: [{ title: "t", steps: [{ id: "s1", kind: "prompt", prompt: "hi" }] }],
+            }),
+            "--api-key",
+            "sk_test",
+            "--api-url",
+            fixture.baseUrl,
+            "--format",
+            "json",
+          ])
+        )
+    );
+    assert.equal(fromJson.exitCode, 0, fromJson.stderr);
+
+    const fromFlag = await withEnv(
+      isolatedEnv({ MCPJAM_PROJECT: "Beta" }),
+      () =>
+        withCwd(cwd, () =>
+          runCli([
+            "cloud",
+            "eval",
+            "create",
+            "--project",
+            "Beta",
+            "--json",
+            JSON.stringify({
+              project: "Alpha",
+              name: "From flag",
+              servers: [],
+              cases: [{ title: "t", steps: [{ id: "s1", kind: "prompt", prompt: "hi" }] }],
+            }),
+            "--api-key",
+            "sk_test",
+            "--api-url",
+            fixture.baseUrl,
+            "--format",
+            "json",
+          ])
+        )
+    );
+    assert.equal(fromFlag.exitCode, 0, fromFlag.stderr);
+    assert.deepEqual(fixture.suitePaths, ["proj-alpha", "proj-beta"]);
+  } finally {
+    await fixture.close();
+  }
+});
+
+test("empty --project is a usage error", async () => {
+  const run = await withEnv(isolatedEnv(), () =>
+    runCli([
+      "cloud",
+      "eval",
+      "list",
+      "--project",
+      "",
+      "--api-key",
+      "sk_test",
+      "--format",
+      "json",
+    ])
+  );
+  assert.equal(run.exitCode, 2);
+  assert.match(run.stderr, /--project cannot be empty/);
+});
+
+test("a stale link selector appends the re-link hint", async () => {
+  const fixture = await startProjectFixture();
+  const cwd = mkdtempSync(path.join(tmpdir(), "mcpjam-stale-link-"));
+  const linkPath = writeLink(cwd, {
+    version: 1,
+    project: { id: "proj-missing", name: "Missing" },
+    apiUrl: fixture.baseUrl,
+  });
+  try {
+    const run = await withEnv(isolatedEnv(), () =>
+      withCwd(cwd, () =>
+        runCli([
+          "cloud",
+          "eval",
+          "list",
+          "--api-key",
+          "sk_test",
+          "--api-url",
+          fixture.baseUrl,
+          "--format",
+          "json",
+        ])
+      )
+    );
+    assert.equal(run.exitCode, 1, run.stdout);
+    assert.match(run.stderr, /Project "proj-missing" was not found/);
+    assert.match(
+      run.stderr,
+      new RegExp(
+        `Selector came from ${linkPath.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")}`
+      )
+    );
+  } finally {
+    await fixture.close();
+  }
+});
+
+test("hosted readiness is not given ambient Cloud project context", async () => {
+  const cwd = mkdtempSync(path.join(tmpdir(), "mcpjam-readiness-"));
+  writeLink(cwd, {
+    version: 1,
+    project: { id: "proj-beta", name: "Beta" },
+    apiUrl: "https://app.mcpjam.com/api/v1",
+  });
+  const run = await withEnv(isolatedEnv({ MCPJAM_PROJECT: "Alpha" }), () =>
+    withCwd(cwd, () => runCli(["readiness", "start", "--help"]))
+  );
+  assert.equal(run.exitCode, 0, run.stderr);
+  assert.match(run.stdout, /--api-key/);
+});

--- a/cli/tests/cloud-link-status.test.ts
+++ b/cli/tests/cloud-link-status.test.ts
@@ -399,69 +399,6 @@ test("eval list uses MCPJAM_PROJECT then a project link, and --project wins", as
   }
 });
 
-test("eval create JSON project beats MCPJAM_PROJECT, and --project beats JSON", async () => {
-  const fixture = await startProjectFixture();
-  const cwd = mkdtempSync(path.join(tmpdir(), "mcpjam-eval-json-"));
-  try {
-    const fromJson = await withEnv(
-      isolatedEnv({ MCPJAM_PROJECT: "Beta" }),
-      () =>
-        withCwd(cwd, () =>
-          runCli([
-            "cloud",
-            "eval",
-            "create",
-            "--json",
-            JSON.stringify({
-              project: "Alpha",
-              name: "From JSON",
-              servers: [],
-              cases: [{ title: "t", steps: [{ id: "s1", kind: "prompt", prompt: "hi" }] }],
-            }),
-            "--api-key",
-            "sk_test",
-            "--api-url",
-            fixture.baseUrl,
-            "--format",
-            "json",
-          ])
-        )
-    );
-    assert.equal(fromJson.exitCode, 0, fromJson.stderr);
-
-    const fromFlag = await withEnv(
-      isolatedEnv({ MCPJAM_PROJECT: "Beta" }),
-      () =>
-        withCwd(cwd, () =>
-          runCli([
-            "cloud",
-            "eval",
-            "create",
-            "--project",
-            "Beta",
-            "--json",
-            JSON.stringify({
-              project: "Alpha",
-              name: "From flag",
-              servers: [],
-              cases: [{ title: "t", steps: [{ id: "s1", kind: "prompt", prompt: "hi" }] }],
-            }),
-            "--api-key",
-            "sk_test",
-            "--api-url",
-            fixture.baseUrl,
-            "--format",
-            "json",
-          ])
-        )
-    );
-    assert.equal(fromFlag.exitCode, 0, fromFlag.stderr);
-    assert.deepEqual(fixture.suitePaths, ["proj-alpha", "proj-beta"]);
-  } finally {
-    await fixture.close();
-  }
-});
-
 test("empty --project is a usage error", async () => {
   const run = await withEnv(isolatedEnv(), () =>
     runCli([
@@ -505,13 +442,10 @@ test("a stale link selector appends the re-link hint", async () => {
       )
     );
     assert.equal(run.exitCode, 1, run.stdout);
-    assert.match(run.stderr, /Project "proj-missing" was not found/);
-    assert.match(
-      run.stderr,
-      new RegExp(
-        `Selector came from ${linkPath.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")}`
-      )
-    );
+    assert.match(run.stderr, /proj-missing/);
+    assert.match(run.stderr, /Selector came from /);
+    assert.ok(run.stderr.includes(linkPath));
+    assert.match(run.stderr, /mcpjam cloud link/);
   } finally {
     await fixture.close();
   }
@@ -524,9 +458,19 @@ test("hosted readiness is not given ambient Cloud project context", async () => 
     project: { id: "proj-beta", name: "Beta" },
     apiUrl: "https://app.mcpjam.com/api/v1",
   });
-  const run = await withEnv(isolatedEnv({ MCPJAM_PROJECT: "Alpha" }), () =>
-    withCwd(cwd, () => runCli(["readiness", "start", "--help"]))
+  const run = await withEnv(isolatedEnv({ MCPJAM_PROJECT: "" }), () =>
+    withCwd(cwd, () =>
+      runCli([
+        "readiness",
+        "start",
+        "claude",
+        "--server",
+        "any",
+        "--format",
+        "json",
+      ])
+    )
   );
-  assert.equal(run.exitCode, 0, run.stderr);
-  assert.match(run.stdout, /--api-key/);
+  assert.notEqual(run.exitCode, 0, run.stderr);
+  assert.doesNotMatch(run.stderr, /MCPJAM_PROJECT cannot be empty/);
 });

--- a/cli/tests/cloud-link-status.test.ts
+++ b/cli/tests/cloud-link-status.test.ts
@@ -3,7 +3,13 @@
  */
 import assert from "node:assert/strict";
 import { execFile as execFileCallback } from "node:child_process";
-import { mkdirSync, mkdtempSync, readFileSync, writeFileSync } from "node:fs";
+import {
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  realpathSync,
+  writeFileSync,
+} from "node:fs";
 import { createServer, type Server } from "node:http";
 import { tmpdir } from "node:os";
 import path from "node:path";
@@ -146,6 +152,10 @@ function isolatedEnv(
   };
 }
 
+function assertSamePath(left: string, right: string): void {
+  assert.equal(realpathSync(left), realpathSync(right));
+}
+
 function writeLink(
   directory: string,
   body: Record<string, unknown>
@@ -226,6 +236,52 @@ test("cloud status warns when link apiUrl does not match the active deployment",
   assert.equal(payload.link.apiUrlMatchesDeployment, false);
   assert.equal(payload.project.source, "link");
   assert.match(payload.warnings.join("\n"), /does not match the active deployment/);
+  assert.match(
+    payload.warnings.join("\n"),
+    /The active deployment's API URL is used; the link's project selector remains active/
+  );
+});
+
+test("cloud status rejects a legacy --api-key like other Cloud commands", async () => {
+  const run = await withEnv(isolatedEnv(), () =>
+    runCli([
+      "cloud",
+      "status",
+      "--api-key",
+      "mcpjam_legacy",
+      "--format",
+      "json",
+    ])
+  );
+  assert.equal(run.exitCode, 2);
+  assert.equal(run.stdout, "");
+  const payload = JSON.parse(run.stderr) as {
+    error?: { code?: string; message?: string };
+  };
+  assert.equal(payload.error?.code, "USAGE_ERROR");
+  assert.match(payload.error?.message ?? "", /Legacy mcpjam_ API keys/);
+});
+
+test("cloud status rejects an invalid --api-url like other Cloud commands", async () => {
+  const run = await withEnv(isolatedEnv(), () =>
+    runCli([
+      "cloud",
+      "status",
+      "--api-key",
+      "sk_test",
+      "--api-url",
+      "not-a-url",
+      "--format",
+      "json",
+    ])
+  );
+  assert.equal(run.exitCode, 2);
+  assert.equal(run.stdout, "");
+  const payload = JSON.parse(run.stderr) as {
+    error?: { code?: string; message?: string };
+  };
+  assert.equal(payload.error?.code, "USAGE_ERROR");
+  assert.match(payload.error?.message ?? "", /Invalid --api-url/);
 });
 
 test("cloud link writes .mcpjam/project.json at the Git worktree root", async () => {
@@ -266,7 +322,7 @@ test("cloud link writes .mcpjam/project.json at the Git worktree root", async ()
     assert.equal(written.version, 1);
     assert.equal(written.project.name, "Beta");
     assert.equal(written.apiUrl, fixture.baseUrl);
-    assert.equal(payload.path, projectLinkPathForDir(root));
+    assertSamePath(payload.path, projectLinkPathForDir(root));
   } finally {
     await fixture.close();
   }
@@ -293,8 +349,8 @@ test("cloud link --here writes in cwd; --remove deletes the nearest file", async
       )
     );
     assert.equal(linkRun.exitCode, 0, linkRun.stderr);
-    assert.equal(
-      JSON.parse(linkRun.stdout).path,
+    assertSamePath(
+      JSON.parse(linkRun.stdout).path as string,
       projectLinkPathForDir(cwd)
     );
 

--- a/cli/tests/cloud-link-status.test.ts
+++ b/cli/tests/cloud-link-status.test.ts
@@ -367,6 +367,13 @@ test("cloud link --here writes in cwd; --remove deletes the nearest file", async
   }
 });
 
+test("cloud link empty project argument is a usage error", async () => {
+  const run = await runCli(["cloud", "link", "   ", "--format", "json"]);
+  assert.equal(run.exitCode, 2);
+  assert.match(run.stderr, /Project argument cannot be empty/);
+  assert.doesNotMatch(run.stderr, /--project cannot be empty/);
+});
+
 test("cloud link --remove rejects a project argument", async () => {
   const run = await runCli([
     "cloud",

--- a/cli/tests/cloud-namespace.test.ts
+++ b/cli/tests/cloud-namespace.test.ts
@@ -33,6 +33,8 @@ const MOVED_CLOUD_GROUPS = [
   "login",
   "logout",
   "whoami",
+  "status",
+  "link",
   "organizations",
   "projects",
   "eval",

--- a/cli/tests/cloud-scope.test.ts
+++ b/cli/tests/cloud-scope.test.ts
@@ -1,0 +1,152 @@
+import assert from "node:assert/strict";
+import { mkdirSync, mkdtempSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import test from "node:test";
+import { CliError } from "../src/lib/output.js";
+import {
+  appendProjectLinkHint,
+  describeProjectScope,
+  resolveProjectSelector,
+} from "../src/lib/cloud-scope.js";
+import { projectLinkPathForDir } from "../src/lib/project-link.js";
+
+function tmpDir(): string {
+  return mkdtempSync(path.join(tmpdir(), "mcpjam-scope-"));
+}
+
+function writeLink(
+  directory: string,
+  project: { id: string; name: string }
+): string {
+  const filePath = projectLinkPathForDir(directory);
+  mkdirSync(path.dirname(filePath), { recursive: true });
+  writeFileSync(
+    filePath,
+    `${JSON.stringify(
+      {
+        version: 1,
+        project,
+        apiUrl: "https://app.mcpjam.com/api/v1",
+      },
+      null,
+      2
+    )}\n`
+  );
+  return filePath;
+}
+
+test("project selector precedence is flag, input, env, link, automatic", () => {
+  const cwd = tmpDir();
+  const linkPath = writeLink(cwd, { id: "from-link", name: "Linked" });
+  const env = { MCPJAM_PROJECT: "from-env" };
+
+  assert.deepEqual(
+    resolveProjectSelector({
+      flagProject: "from-flag",
+      inputProject: "from-input",
+      env,
+      cwd,
+    }),
+    { kind: "project", selector: "from-flag", source: "flag" }
+  );
+
+  assert.deepEqual(
+    resolveProjectSelector({
+      inputProject: "from-input",
+      env,
+      cwd,
+    }),
+    { kind: "project", selector: "from-input", source: "input" }
+  );
+
+  assert.deepEqual(resolveProjectSelector({ env, cwd }), {
+    kind: "project",
+    selector: "from-env",
+    source: "env",
+  });
+
+  assert.deepEqual(resolveProjectSelector({ env: {}, cwd }), {
+    kind: "project",
+    selector: "from-link",
+    source: "link",
+    linkPath,
+    linkedName: "Linked",
+  });
+
+  assert.deepEqual(
+    resolveProjectSelector({ env: {}, cwd: tmpDir(), ignoreLink: true }),
+    { kind: "project", source: "automatic" }
+  );
+});
+
+test("empty flag and MCPJAM_PROJECT are usage errors, not automatic", () => {
+  assert.throws(
+    () => resolveProjectSelector({ flagProject: "  " }),
+    (error: unknown) =>
+      error instanceof CliError &&
+      error.exitCode === 2 &&
+      /--project cannot be empty/.test(error.message)
+  );
+  assert.throws(
+    () => resolveProjectSelector({ env: { MCPJAM_PROJECT: "" } }),
+    (error: unknown) =>
+      error instanceof CliError &&
+      error.exitCode === 2 &&
+      /MCPJAM_PROJECT cannot be empty/.test(error.message)
+  );
+});
+
+test("malformed link hard-errors instead of falling through to automatic", () => {
+  const cwd = tmpDir();
+  const filePath = projectLinkPathForDir(cwd);
+  mkdirSync(path.dirname(filePath), { recursive: true });
+  writeFileSync(filePath, "{ not json\n");
+
+  assert.throws(
+    () => resolveProjectSelector({ env: {}, cwd }),
+    (error: unknown) =>
+      error instanceof CliError &&
+      error.exitCode === 1 &&
+      error.message.includes(filePath)
+  );
+});
+
+test("describeProjectScope never says default", () => {
+  assert.equal(
+    describeProjectScope({ kind: "project", source: "automatic" }),
+    "automatic (most recently updated)"
+  );
+  assert.equal(
+    describeProjectScope({
+      kind: "project",
+      source: "link",
+      selector: "id",
+      linkedName: "Alpha",
+      linkPath: "/repo/.mcpjam/project.json",
+    }),
+    "link (Alpha)"
+  );
+  assert.doesNotMatch(
+    describeProjectScope({ kind: "project", source: "automatic" }),
+    /default/i
+  );
+});
+
+test("stale-link hint is appended only for project selector failures", () => {
+  const scope = {
+    kind: "project" as const,
+    source: "link" as const,
+    selector: "gone",
+    linkPath: "/repo/.mcpjam/project.json",
+    linkedName: "Gone",
+  };
+  assert.match(
+    appendProjectLinkHint('Project "gone" was not found.', scope),
+    /Selector came from \/repo\/\.mcpjam\/project\.json — re-run `mcpjam cloud link`\./
+  );
+  assert.equal(
+    appendProjectLinkHint('Eval suite "s" was not found.', scope),
+    'Eval suite "s" was not found.'
+  );
+});

--- a/cli/tests/cloud-scope.test.ts
+++ b/cli/tests/cloud-scope.test.ts
@@ -89,6 +89,19 @@ test("empty flag and MCPJAM_PROJECT are usage errors, not automatic", () => {
       /--project cannot be empty/.test(error.message)
   );
   assert.throws(
+    () =>
+      resolveProjectSelector({
+        flagProject: "  ",
+        emptyFlagMessage:
+          "Project argument cannot be empty. Omit it to use MCPJAM_PROJECT or automatic selection.",
+      }),
+    (error: unknown) =>
+      error instanceof CliError &&
+      error.exitCode === 2 &&
+      /Project argument cannot be empty/.test(error.message) &&
+      !/--project/.test(error.message)
+  );
+  assert.throws(
     () => resolveProjectSelector({ env: { MCPJAM_PROJECT: "" } }),
     (error: unknown) =>
       error instanceof CliError &&

--- a/cli/tests/credential-describe.test.ts
+++ b/cli/tests/credential-describe.test.ts
@@ -5,6 +5,7 @@ import path from "node:path";
 import test from "node:test";
 import { DEFAULT_PLATFORM_API_BASE_URL } from "@mcpjam/sdk/platform";
 import { describeCloudCredential, redactCloudApiKey } from "../src/lib/credential-describe.js";
+import { CliError } from "../src/lib/output.js";
 
 function authFile(body: Record<string, unknown>): string {
   const directory = mkdtempSync(path.join(tmpdir(), "mcpjam-cred-"));
@@ -55,6 +56,30 @@ test("credential precedence is flag, usable env key, oauth, missing", () => {
   assert.equal(missing.credential.source, "missing");
   assert.equal(missing.deployment.source, "default");
   assert.equal(missing.deployment.apiUrl, DEFAULT_PLATFORM_API_BASE_URL);
+});
+
+test("legacy mcpjam_ flag keys are a usage error", () => {
+  assert.throws(
+    () => describeCloudCredential({ apiKey: "mcpjam_legacy" }, { env: {} }),
+    (error: unknown) =>
+      error instanceof CliError &&
+      error.code === "USAGE_ERROR" &&
+      /Legacy mcpjam_ API keys/.test(error.message)
+  );
+});
+
+test("invalid explicit API URLs are a usage error", () => {
+  assert.throws(
+    () =>
+      describeCloudCredential(
+        { apiKey: "sk_test", apiUrl: "not-a-url" },
+        { env: {} }
+      ),
+    (error: unknown) =>
+      error instanceof CliError &&
+      error.code === "USAGE_ERROR" &&
+      /Invalid --api-url/.test(error.message)
+  );
 });
 
 test("legacy mcpjam_ env keys fall through to stored OAuth", () => {

--- a/cli/tests/credential-describe.test.ts
+++ b/cli/tests/credential-describe.test.ts
@@ -1,0 +1,98 @@
+import assert from "node:assert/strict";
+import { mkdtempSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import test from "node:test";
+import { DEFAULT_PLATFORM_API_BASE_URL } from "@mcpjam/sdk/platform";
+import { describeCloudCredential, redactCloudApiKey } from "../src/lib/credential-describe.js";
+
+function authFile(body: Record<string, unknown>): string {
+  const directory = mkdtempSync(path.join(tmpdir(), "mcpjam-cred-"));
+  const filePath = path.join(directory, "auth.json");
+  writeFileSync(filePath, JSON.stringify({ version: 1, ...body }));
+  return filePath;
+}
+
+test("redactCloudApiKey keeps sk_ prefix and last four characters", () => {
+  assert.equal(redactCloudApiKey("sk_live_abcd1234"), "sk_…1234");
+});
+
+test("credential precedence is flag, usable env key, oauth, missing", () => {
+  const authFilePath = authFile({
+    issuer: "https://login.example.com",
+    clientId: "c",
+    tokenEndpoint: "https://login.example.com/token",
+    accessToken: "tok",
+    apiUrl: "https://staging.example.com/api/v1",
+  });
+
+  const flag = describeCloudCredential(
+    { apiKey: "sk_flag_xxxxYYYY" },
+    { env: { MCPJAM_API_KEY: "sk_env_zzzz" }, authFilePath }
+  );
+  assert.equal(flag.credential.source, "flag");
+  assert.equal(flag.credential.redactedKey, "sk_…YYYY");
+  assert.equal(flag.credential.envShadowsOauth, false);
+
+  const env = describeCloudCredential(
+    {},
+    { env: { MCPJAM_API_KEY: "sk_env_zzzzQQQQ" }, authFilePath }
+  );
+  assert.equal(env.credential.source, "env");
+  assert.equal(env.credential.envShadowsOauth, true);
+  assert.equal(env.credential.redactedKey, "sk_…QQQQ");
+
+  const oauth = describeCloudCredential({}, { env: {}, authFilePath });
+  assert.equal(oauth.credential.source, "oauth");
+  assert.equal(oauth.credential.kind, "oauth");
+  assert.equal(oauth.deployment.source, "oauth");
+  assert.equal(oauth.deployment.apiUrl, "https://staging.example.com/api/v1");
+
+  const missing = describeCloudCredential(
+    {},
+    { env: {}, authFilePath: path.join(tmpdir(), "no-such-auth.json") }
+  );
+  assert.equal(missing.credential.source, "missing");
+  assert.equal(missing.deployment.source, "default");
+  assert.equal(missing.deployment.apiUrl, DEFAULT_PLATFORM_API_BASE_URL);
+});
+
+test("legacy mcpjam_ env keys fall through to stored OAuth", () => {
+  const authFilePath = authFile({
+    issuer: "https://login.example.com",
+    clientId: "c",
+    tokenEndpoint: "https://login.example.com/token",
+    accessToken: "tok",
+  });
+  const described = describeCloudCredential(
+    {},
+    { env: { MCPJAM_API_KEY: "mcpjam_legacy" }, authFilePath }
+  );
+  assert.equal(described.credential.source, "oauth");
+  assert.equal(described.credential.envShadowsOauth, false);
+});
+
+test("deployment precedence is flag, env, oauth, default", () => {
+  const authFilePath = authFile({
+    issuer: "https://login.example.com",
+    clientId: "c",
+    tokenEndpoint: "https://login.example.com/token",
+    accessToken: "tok",
+    apiUrl: "https://oauth.example.com/api/v1",
+  });
+
+  assert.equal(
+    describeCloudCredential(
+      { apiUrl: "https://flag.example.com/api/v1" },
+      { env: { MCPJAM_API_URL: "https://env.example.com/api/v1" }, authFilePath }
+    ).deployment.source,
+    "flag"
+  );
+  assert.equal(
+    describeCloudCredential(
+      {},
+      { env: { MCPJAM_API_URL: "https://env.example.com/api/v1" }, authFilePath }
+    ).deployment.source,
+    "env"
+  );
+});

--- a/cli/tests/project-link.test.ts
+++ b/cli/tests/project-link.test.ts
@@ -1,0 +1,130 @@
+import assert from "node:assert/strict";
+import { execFile as execFileCallback } from "node:child_process";
+import { mkdirSync, mkdtempSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { promisify } from "node:util";
+import test from "node:test";
+import {
+  findGitWorktreeRoot,
+  findNearestProjectLinkPath,
+  inspectProjectLink,
+  parseProjectLink,
+  projectLinkPathForDir,
+  projectLinkWriteDir,
+} from "../src/lib/project-link.js";
+
+const execFile = promisify(execFileCallback);
+
+function tmpDir(): string {
+  return mkdtempSync(path.join(tmpdir(), "mcpjam-link-"));
+}
+
+function writeLink(directory: string, body: unknown): string {
+  const filePath = projectLinkPathForDir(directory);
+  mkdirSync(path.dirname(filePath), { recursive: true });
+  writeFileSync(filePath, `${JSON.stringify(body, null, 2)}\n`);
+  return filePath;
+}
+
+test("parseProjectLink accepts version 1 with canonical http(s) apiUrl", () => {
+  const parsed = parseProjectLink(
+    {
+      version: 1,
+      project: { id: "proj-1", name: "Alpha" },
+      organizationId: "org-1",
+      apiUrl: "https://app.mcpjam.com/api/v1",
+    },
+    "/tmp/.mcpjam/project.json"
+  );
+  assert.equal(parsed.ok, true);
+  if (parsed.ok) {
+    assert.equal(parsed.link.project.id, "proj-1");
+    assert.equal(parsed.link.organizationId, "org-1");
+  }
+});
+
+test("parseProjectLink rejects unsupported versions and empty names", () => {
+  const version = parseProjectLink(
+    { version: 2, project: { id: "p", name: "n" }, apiUrl: "https://x/api/v1" },
+    "/x"
+  );
+  assert.equal(version.ok, false);
+
+  const empty = parseProjectLink(
+    {
+      version: 1,
+      project: { id: "p", name: "  " },
+      apiUrl: "https://app.mcpjam.com/api/v1",
+    },
+    "/x"
+  );
+  assert.equal(empty.ok, false);
+
+  const ftp = parseProjectLink(
+    {
+      version: 1,
+      project: { id: "p", name: "n" },
+      apiUrl: "ftp://example.com/api",
+    },
+    "/x"
+  );
+  assert.equal(ftp.ok, false);
+});
+
+test("outside Git, only cwd is inspected so a parent link is not ambient", () => {
+  const parent = tmpDir();
+  const child = path.join(parent, "nested");
+  mkdirSync(child);
+  writeLink(parent, {
+    version: 1,
+    project: { id: "home-proj", name: "Home" },
+    apiUrl: "https://app.mcpjam.com/api/v1",
+  });
+
+  assert.equal(findGitWorktreeRoot(child), null);
+  assert.equal(findNearestProjectLinkPath({ cwd: child }), undefined);
+  assert.equal(inspectProjectLink({ cwd: child }).status, "missing");
+  assert.equal(inspectProjectLink({ cwd: parent }).status, "valid");
+});
+
+test("inside Git, lookup walks to the worktree root inclusive", async () => {
+  const root = tmpDir();
+  await execFile("git", ["init"], { cwd: root });
+  const nested = path.join(root, "apps", "cli");
+  mkdirSync(nested, { recursive: true });
+  const filePath = writeLink(root, {
+    version: 1,
+    project: { id: "root-proj", name: "Root" },
+    apiUrl: "https://app.mcpjam.com/api/v1",
+  });
+
+  assert.equal(findGitWorktreeRoot(nested), root);
+  assert.equal(findNearestProjectLinkPath({ cwd: nested }), filePath);
+  assert.equal(projectLinkWriteDir({ cwd: nested }), root);
+  assert.equal(projectLinkWriteDir({ cwd: nested, here: true }), nested);
+});
+
+test("nearest link wins over a parent link in the same worktree", async () => {
+  const root = tmpDir();
+  await execFile("git", ["init"], { cwd: root });
+  const nested = path.join(root, "pkg");
+  mkdirSync(nested);
+  writeLink(root, {
+    version: 1,
+    project: { id: "root-proj", name: "Root" },
+    apiUrl: "https://app.mcpjam.com/api/v1",
+  });
+  const nestedPath = writeLink(nested, {
+    version: 1,
+    project: { id: "nested-proj", name: "Nested" },
+    apiUrl: "https://app.mcpjam.com/api/v1",
+  });
+
+  const inspection = inspectProjectLink({ cwd: nested });
+  assert.equal(inspection.status, "valid");
+  if (inspection.status === "valid") {
+    assert.equal(inspection.path, nestedPath);
+    assert.equal(inspection.link.project.id, "nested-proj");
+  }
+});


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Purpose

PR 5 of the CLI local-vs-cloud split. Pin a Cloud project with `mcpjam cloud link`, inspect the selector with `mcpjam cloud status`, and apply one project-selection rule to Cloud commands.

Stacked on #4193. Merge after that PR.

## Review follow-up

- `cloud status` now rejects a legacy `--api-key mcpjam_…` and an invalid `--api-url` the same way other Cloud commands do (exit 2).
- API-URL mismatch warning: the link's **API URL** is ignored; the link's **project selector remains active**.
- Link path assertions use `realpathSync` so they pass on macOS `/private/var`.

## What changed

- `.mcpjam/project.json` (no secrets) via `cloud link`; `cloud status` is zero-network.
- Precedence: `--project` > `--file`/`--json` project > `MCPJAM_PROJECT` > nearest valid link > automatic (most recently updated).
- `MCPJAM_PROJECT_ID` does not select a Cloud CLI project.
- Hosted `readiness` does not use ambient Cloud project context.

## Rollout

- `"@mcpjam/cli": major` changeset (4.0; hold Version Packages until PR 12)

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-880bc302-7fad-489a-b883-d890bdc3aca6?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-880bc302-7fad-489a-b883-d890bdc3aca6&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds directory-scoped Cloud project pinning and an offline status report to the CLI. Previously, omitting --project silently used the newest project; now Cloud commands resolve the project by clear precedence with diagnostics and link‑hinted failures.

- Adds mcpjam cloud link (writes/removes .mcpjam/project.json) and mcpjam cloud status (zero‑network report of credential, deployment, project scope, and link validity). Status rejects legacy --api-key and invalid --api-url like other Cloud commands (exit 2), warns when MCPJAM_API_KEY shadows stored OAuth, and warns when the link’s API URL differs from the active deployment (the deployment URL is used; the link’s project selector remains active).
- Project resolution order: --project > explicit project in a --file/--json input > MCPJAM_PROJECT > nearest valid .mcpjam/project.json > automatic (most recently updated). Empty --project/MCPJAM_PROJECT are usage errors. MCPJAM_PROJECT_ID is SDK eval‑reporting only. When a link‑sourced selector fails online, errors append “Selector came from <path> — re‑run mcpjam cloud link.” cloud link treats an empty positional project argument as a usage error with a specific message.
- Link behavior: written at the Git worktree root by default (--here writes in cwd); --remove deletes the nearest link. Invalid links are reported and exit 1.
- All cloud subcommands (eval, hosts, images, journeys, projects, scenarios, environments, tunnel) use the shared resolver; required eval operations fall back to the typed --project value. Hosted readiness does not receive ambient project context.

**Rollout/Migration**
- Pin repos with mcpjam cloud link or set MCPJAM_PROJECT; consider git‑ignoring .mcpjam/project.json for per‑developer setups.
- Update scripts that passed empty --project/MCPJAM_PROJECT; these now error.
- Major changeset for `@mcpjam/cli`.

<sup>Written for commit a178a7f2601594357efaac8ee6a73d2bd6981d6b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/MCPJam/inspector/pull/4196?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

