### PR TITLE
cli: print Cloud audience line and preflight credentials

### DIFF
--- a/.changeset/cli-cloud-audience.md
+++ b/.changeset/cli-cloud-audience.md
@@ -1,0 +1,5 @@
+---
+"@mcpjam/cli": major
+---
+
+Cloud commands print a stderr audience line (`Using MCPJam Cloud as … · … · …`) before the operation and fail immediately when no credential is configured. `--quiet` suppresses the line; machine-readable stdout stays unchanged. Hosted `readiness` does not print Cloud audience context.

--- a/cli/src/commands/auth.ts
+++ b/cli/src/commands/auth.ts
@@ -106,7 +106,8 @@ export function registerAuthCommands(program: Command): void {
             ...(me.plan ? { plan: me.plan } : {}),
             credential: credentialKind,
           };
-        }
+        },
+        { announce: false, quiet: globalOptions.quiet }
       );
 
       writeResult(result, globalOptions.format);

--- a/cli/src/commands/chat.ts
+++ b/cli/src/commands/chat.ts
@@ -42,7 +42,7 @@ function validateOpInput<TInput>(
 async function executeOp<TInput, TOutput>(
   op: PlatformOperation<TInput, TOutput>,
   input: TInput,
-  _options: PlatformOptions,
+  options: PlatformOptions & { project?: string },
   command: Command,
 ): Promise<void> {
   const globalOptions = getGlobalOptions(command);
@@ -50,6 +50,17 @@ async function executeOp<TInput, TOutput>(
     platformOptionsOf(command),
     globalOptions.timeout,
     ({ client, signal }) => op.execute(input, { client, signal }),
+    {
+      quiet: globalOptions.quiet,
+      cloudScope:
+        options.project !== undefined
+          ? {
+              kind: "project",
+              selector: options.project,
+              source: "flag",
+            }
+          : { kind: "all-projects" },
+    },
   );
   writeResult(result, globalOptions.format);
 }

--- a/cli/src/commands/cloud-link.ts
+++ b/cli/src/commands/cloud-link.ts
@@ -5,6 +5,7 @@
  * zero-network: credential source, deployment, project selector, and link
  * validity. An invalid link still emits the structured report, then exits 1.
  */
+import { existsSync } from "node:fs";
 import type { Command } from "commander";
 import {
   projectResolutionError,
@@ -122,6 +123,7 @@ export function registerCloudLinkCommands(cloud: Command): void {
       } catch (error) {
         ok = false;
         projectSelectorFailed = true;
+        projectSource = "unresolved";
         warnings.push(error instanceof Error ? error.message : String(error));
       }
 
@@ -214,13 +216,13 @@ export function registerCloudLinkCommands(cloud: Command): void {
         const platform = platformOptionsOf(command);
 
         if (options.remove) {
-          if (project !== undefined && project !== "") {
+          if (project !== undefined) {
             throw usageError("Do not pass a project argument with --remove.");
           }
           const filePath = options.here
             ? projectLinkPathForDir(projectLinkWriteDir({ here: true }))
             : nearestLinkPath();
-          if (!filePath) {
+          if (!filePath || !existsSync(filePath)) {
             throw usageError("No project link found.");
           }
           removeProjectLinkFile(filePath);

--- a/cli/src/commands/environments.ts
+++ b/cli/src/commands/environments.ts
@@ -101,13 +101,16 @@ async function assertModelOverridesSupported(
  * write itself uses: `--project`, then the JSON body's `project`, then
  * `MCPJAM_PROJECT`, a project link, then automatic selection.
  */
-function projectSelector(
+function resolveEnvironmentProject(
   options: { project?: string },
   body: Record<string, unknown> = {}
-): { project?: string } {
-  const resolved = resolveCloudProjectArgs(options, {
+) {
+  return resolveCloudProjectArgs(options, {
     inputProject: typeof body.project === "string" ? body.project : undefined,
   });
+}
+
+function projectFields(resolved: { project?: string }): { project?: string } {
   return resolved.project !== undefined ? { project: resolved.project } : {};
 }
 
@@ -301,16 +304,18 @@ export function registerEnvironmentsCommands(program: Command): void {
       // unknown `modelId` with an opaque validator error. Ask first, and only
       // when the caller actually supplied model input — an ordinary create has
       // no reason to pay for a round-trip.
+      const resolved = resolveEnvironmentProject(options, body);
+      const project = projectFields(resolved);
       await assertModelOverridesSupported(
         platformOptionsOf(command),
         globalOptions.timeout,
         {
         supplied: options.model !== undefined || "modelId" in body,
-        ...projectSelector(options, body),
+        ...project,
       });
       const input = validateInput(createEnvironmentOperation, {
         ...body,
-        ...projectSelector(options, body),
+        ...project,
         ...(options.name !== undefined ? { name: options.name } : {}),
         ...(options.hostId !== undefined ? { hostId: options.hostId } : {}),
         ...(options.description !== undefined
@@ -325,7 +330,8 @@ export function registerEnvironmentsCommands(program: Command): void {
         platformOptionsOf(command),
         globalOptions.timeout,
         ({ client, signal }) =>
-          createEnvironmentOperation.execute(input, { client, signal })
+          createEnvironmentOperation.execute(input, { client, signal }),
+        { projectScope: resolved.projectScope, cloudScope: resolved.projectScope }
       );
       writeResult(result, globalOptions.format);
     }
@@ -369,8 +375,9 @@ export function registerEnvironmentsCommands(program: Command): void {
       command
     ) => {
       const globalOptions = getGlobalOptions(command);
+      const resolved = resolveEnvironmentProject(options);
       const input = validateInput(ensureAdhocEnvironmentOperation, {
-        ...projectSelector(options),
+        ...projectFields(resolved),
         host: options.host,
         ...(options.serverGroup !== undefined
           ? { serverGroup: options.serverGroup }
@@ -387,7 +394,8 @@ export function registerEnvironmentsCommands(program: Command): void {
         platformOptionsOf(command),
         globalOptions.timeout,
         ({ client, signal }) =>
-          ensureAdhocEnvironmentOperation.execute(input, { client, signal })
+          ensureAdhocEnvironmentOperation.execute(input, { client, signal }),
+        { projectScope: resolved.projectScope, cloudScope: resolved.projectScope }
       );
       writeResult(result, globalOptions.format);
     }
@@ -420,8 +428,9 @@ export function registerEnvironmentsCommands(program: Command): void {
       command
     ) => {
       const globalOptions = getGlobalOptions(command);
+      const resolved = resolveEnvironmentProject(options);
       const input = validateInput(nameEnvironmentOperation, {
-        ...projectSelector(options),
+        ...projectFields(resolved),
         environment: options.environment,
         name: options.name,
         expectedRevision: parseRevision(options.expectedRevision),
@@ -433,7 +442,8 @@ export function registerEnvironmentsCommands(program: Command): void {
         platformOptionsOf(command),
         globalOptions.timeout,
         ({ client, signal }) =>
-          nameEnvironmentOperation.execute(input, { client, signal })
+          nameEnvironmentOperation.execute(input, { client, signal }),
+        { projectScope: resolved.projectScope, cloudScope: resolved.projectScope }
       );
       writeResult(result, globalOptions.format);
     }
@@ -496,6 +506,8 @@ export function registerEnvironmentsCommands(program: Command): void {
       if (options.model !== undefined && options.clearModel) {
         throw usageError("Provide either --model or --clear-model, not both.");
       }
+      const resolved = resolveEnvironmentProject(options, body);
+      const project = projectFields(resolved);
       await assertModelOverridesSupported(
         platformOptionsOf(command),
         globalOptions.timeout,
@@ -504,11 +516,11 @@ export function registerEnvironmentsCommands(program: Command): void {
           options.model !== undefined ||
           options.clearModel === true ||
           "modelId" in body,
-        ...projectSelector(options, body),
+        ...project,
       });
       const input = validateInput(updateEnvironmentOperation, {
         ...body,
-        ...projectSelector(options, body),
+        ...project,
         environment: options.environment,
         expectedRevision: parseRevision(options.expectedRevision),
         ...(options.name !== undefined ? { name: options.name } : {}),
@@ -528,7 +540,8 @@ export function registerEnvironmentsCommands(program: Command): void {
         platformOptionsOf(command),
         globalOptions.timeout,
         ({ client, signal }) =>
-          updateEnvironmentOperation.execute(input, { client, signal })
+          updateEnvironmentOperation.execute(input, { client, signal }),
+        { projectScope: resolved.projectScope, cloudScope: resolved.projectScope }
       );
       writeResult(result, globalOptions.format);
     }

--- a/cli/src/commands/environments.ts
+++ b/cli/src/commands/environments.ts
@@ -85,7 +85,8 @@ async function assertModelOverridesSupported(
       getEnvironmentCapabilitiesOperation.execute(
         { project: args.project },
         { client, signal }
-      )
+      ),
+    { announce: false }
   );
   const supported = result.capabilities.modelOverrides;
   if (!supported) {

--- a/cli/src/commands/eval.ts
+++ b/cli/src/commands/eval.ts
@@ -1194,7 +1194,8 @@ async function runEvalPull(
             ? { suiteMatchOptions: detail.settings.matchOptions }
             : {}),
         };
-      }
+      },
+      { projectScope: resolved.projectScope }
     );
   } catch (error) {
     throw corpusFetchFailure(error);
@@ -1567,7 +1568,8 @@ async function runEvalExport(
       }
 
       return { detail, cases: page.items };
-    }
+    },
+    { projectScope: resolved.projectScope }
   );
 
   const built = buildSuiteFileFromPlatform(fetched);
@@ -1903,7 +1905,8 @@ export function registerEvalCommands(program: Command): void {
             },
             { client: context.client, signal: context.signal }
           );
-        }
+        },
+        { projectScope: resolved.projectScope }
       );
       // EXACTLY ONE JSON document on `--format json`: the receipt already
       // carries every run, so appending human lines to it would make the
@@ -1939,7 +1942,8 @@ export function registerEvalCommands(program: Command): void {
             { project: resolved.project ?? options.project, runId: options.run },
             { client: context.client, signal: context.signal }
           );
-        }
+        },
+        { projectScope: resolved.projectScope }
       );
       writeResult(result, globalOptions.format);
       writeJudgeSummary(globalOptions.format, result.run.judges);
@@ -2413,7 +2417,8 @@ export function registerEvalCommands(program: Command): void {
               iterationId: options.iteration,
             },
             { client, signal }
-          )
+          ),
+        { projectScope: resolved.projectScope }
       );
 
       let shots = extractRenderedScreenshots(result);
@@ -2540,7 +2545,8 @@ export function registerEvalCommands(program: Command): void {
               iterationId: options.iteration,
             },
             { client, signal }
-          )
+          ),
+        { projectScope: resolved.projectScope }
       );
 
       const videoUrl = extractIterationVideoUrl(result);

--- a/cli/src/commands/eval.ts
+++ b/cli/src/commands/eval.ts
@@ -556,7 +556,10 @@ async function executeOp<TInput, TOutput>(
     platformOptionsOf(command),
     globalOptions.timeout,
     ({ client, signal }) => op.execute(filled, { client, signal }),
-    { projectScope: resolved.projectScope }
+    {
+      projectScope: resolved.projectScope,
+      quiet: globalOptions.quiet,
+    }
   );
   writeResult(result, globalOptions.format);
 }

--- a/cli/src/commands/organizations.ts
+++ b/cli/src/commands/organizations.ts
@@ -44,6 +44,7 @@ export function registerOrganizationsCommands(program: Command): void {
       globalOptions.timeout,
       ({ client, signal }) =>
         listOrganizationsOperation.execute({}, { client, signal }),
+      { cloudScope: { kind: "account" }, quiet: globalOptions.quiet },
     );
 
     if (globalOptions.format === "human") {

--- a/cli/src/commands/projects.ts
+++ b/cli/src/commands/projects.ts
@@ -145,7 +145,13 @@ export function registerProjectsCommands(program: Command): void {
         listProjectsOperation.execute(
           organizationId ? { organizationId } : {},
           { client, signal }
-        )
+        ),
+      {
+        quiet: globalOptions.quiet,
+        cloudScope: organizationId
+          ? { kind: "organization", organization: organizationId }
+          : { kind: "all-projects" },
+      }
     );
 
     if (globalOptions.format === "human") {
@@ -190,7 +196,8 @@ export function registerProjectsCommands(program: Command): void {
         platformOptionsOf<PlatformOptions>(command),
         globalOptions.timeout,
         ({ client, signal }) =>
-          createProjectOperation.execute(input, { client, signal })
+          createProjectOperation.execute(input, { client, signal }),
+        { cloudScope: { kind: "account" }, quiet: globalOptions.quiet }
       );
       writeResult(result, globalOptions.format);
     }
@@ -499,7 +506,8 @@ export function registerProjectsCommands(program: Command): void {
           getProjectServerConnectionStatusOperation.execute(input, {
             client,
             signal,
-          })
+          }),
+        { cloudScope: { kind: "account" }, quiet: globalOptions.quiet }
       );
       writeResult(payload, globalOptions.format);
     }

--- a/cli/src/commands/tunnel.ts
+++ b/cli/src/commands/tunnel.ts
@@ -4,6 +4,10 @@ import {
   type CreateTunnelResult,
 } from "@mcpjam/sdk/platform";
 import { cliError, usageError, writeResult } from "../lib/output.js";
+import {
+  announceCloudContext,
+  preflightCloudCredentials,
+} from "../lib/cloud-context.js";
 import { buildCloudClientContext, platformOptionsOf } from "../lib/platform-command.js";
 import { resolveCloudProjectArgs } from "../lib/cloud-scope.js";
 import { toCliError } from "../lib/platform-client.js";
@@ -134,10 +138,18 @@ export function registerTunnelCommands(program: Command): void {
         // Client request timeouts still use `--timeout`. The tunnel itself
         // is not wrapped in `runPlatformOperation`: a session is meant to
         // outlive the default 30-second whole-command deadline.
+        const platform = platformOptionsOf(command);
+        preflightCloudCredentials(platform);
+        const resolved = resolveCloudProjectArgs(options);
+        announceCloudContext({
+          scope: resolved.projectScope,
+          options: platform,
+          quiet: globalOptions.quiet,
+        });
         let client;
         try {
           ({ client } = buildCloudClientContext(
-            platformOptionsOf(command),
+            platform,
             globalOptions.timeout,
           ));
         } catch (error) {
@@ -188,7 +200,7 @@ export function registerTunnelCommands(program: Command): void {
         const session = new TunnelSession({
           createGrant: (signal) =>
             createTunnelOperation.execute(
-              { project: resolveCloudProjectArgs(options).project, name: options.id },
+              { project: resolved.project, name: options.id },
               { client, signal },
             ),
           closeGrant: async (result, signal) => {

--- a/cli/src/lib/cloud-context.ts
+++ b/cli/src/lib/cloud-context.ts
@@ -1,0 +1,107 @@
+/**
+ * Cloud audience line and credential preflight.
+ *
+ * Machine-readable results stay on stdout. Context (who you are, which
+ * project, which deployment) goes to stderr and is omitted under `--quiet`.
+ * Preflight fails with the same login guidance `getOAuthAccessToken` uses, so
+ * a missing credential does not wait for the first HTTP call.
+ */
+import { getAuthFilePath, readStoredAuth } from "./auth-store.js";
+import {
+  describeCloudCredential,
+  type DescribeCloudCredentialDependencies,
+} from "./credential-describe.js";
+import {
+  describeProjectScope,
+  type CloudScope,
+} from "./cloud-scope.js";
+import { operationalError } from "./output.js";
+
+/** Credential flags only — kept local so this module does not import `platform-command`. */
+export type CloudCredentialOptions = {
+  apiKey?: string;
+  apiUrl?: string;
+};
+
+export const MISSING_CLOUD_CREDENTIAL_MESSAGE =
+  "Not logged in. Run `mcpjam cloud login`, or pass an sk_ API key via --api-key / MCPJAM_API_KEY.";
+
+/**
+ * Cloud commands that must not print the audience line. Inner polls, whoami,
+ * and link write pass `announce` as false at the call site rather than living
+ * here.
+ */
+export const CLOUD_AUDIENCE_EXEMPTIONS = [
+  "login",
+  "logout",
+  "whoami",
+  "link",
+  "status",
+] as const;
+
+export type CloudAudienceLineInput = {
+  scope: CloudScope;
+  options: CloudCredentialOptions;
+  env?: NodeJS.ProcessEnv;
+  authFilePath?: string;
+};
+
+function identityLabel(
+  options: CloudCredentialOptions,
+  deps: DescribeCloudCredentialDependencies
+): string {
+  const { credential } = describeCloudCredential(options, deps);
+  if (credential.kind === "api-key" && credential.redactedKey) {
+    return credential.redactedKey;
+  }
+  if (credential.kind === "oauth") {
+    const authFilePath =
+      deps.authFilePath ?? getAuthFilePath({ env: deps.env ?? process.env });
+    const email = readStoredAuth(authFilePath)?.email?.trim();
+    if (email) return email;
+    return "oauth";
+  }
+  return "unauthenticated";
+}
+
+function scopeLabel(scope: CloudScope): string {
+  switch (scope.kind) {
+    case "account":
+      return "account";
+    case "organization":
+      return scope.organization
+        ? `organization ${scope.organization}`
+        : "organization";
+    case "all-projects":
+      return "all projects";
+    case "project":
+      return `project: ${describeProjectScope(scope)}`;
+  }
+}
+
+/** Pure: the audience line as printed to stderr. */
+export function formatCloudAudienceLine(input: CloudAudienceLineInput): string {
+  const deps = {
+    env: input.env ?? process.env,
+    authFilePath: input.authFilePath,
+  };
+  const { deployment } = describeCloudCredential(input.options, deps);
+  return `Using MCPJam Cloud as ${identityLabel(input.options, deps)} · ${scopeLabel(input.scope)} · ${deployment.apiUrl}`;
+}
+
+export function preflightCloudCredentials(
+  options: CloudCredentialOptions,
+  deps: DescribeCloudCredentialDependencies = {}
+): void {
+  const { credential } = describeCloudCredential(options, deps);
+  if (credential.source === "missing") {
+    throw operationalError(MISSING_CLOUD_CREDENTIAL_MESSAGE);
+  }
+}
+
+export function announceCloudContext(
+  input: CloudAudienceLineInput & { quiet?: boolean; announce?: boolean }
+): void {
+  if (input.announce === false || input.quiet === true) return;
+  process.stderr.write(`${formatCloudAudienceLine(input)}\n`);
+}

--- a/cli/src/lib/cloud-context.ts
+++ b/cli/src/lib/cloud-context.ts
@@ -15,16 +15,16 @@ import {
   describeProjectScope,
   type CloudScope,
 } from "./cloud-scope.js";
+import { MISSING_CLOUD_CREDENTIAL_MESSAGE } from "./platform-auth.js";
 import { operationalError } from "./output.js";
+
+export { MISSING_CLOUD_CREDENTIAL_MESSAGE };
 
 /** Credential flags only — kept local so this module does not import `platform-command`. */
 export type CloudCredentialOptions = {
   apiKey?: string;
   apiUrl?: string;
 };
-
-export const MISSING_CLOUD_CREDENTIAL_MESSAGE =
-  "Not logged in. Run `mcpjam cloud login`, or pass an sk_ API key via --api-key / MCPJAM_API_KEY.";
 
 /**
  * Cloud commands that must not print the audience line. Inner polls, whoami,

--- a/cli/src/lib/cloud-context.ts
+++ b/cli/src/lib/cloud-context.ts
@@ -15,7 +15,10 @@ import {
   describeProjectScope,
   type CloudScope,
 } from "./cloud-scope.js";
-import { MISSING_CLOUD_CREDENTIAL_MESSAGE } from "./platform-auth.js";
+import {
+  LEGACY_KEY_REMEDY,
+  MISSING_CLOUD_CREDENTIAL_MESSAGE,
+} from "./platform-auth.js";
 import { operationalError } from "./output.js";
 
 export { MISSING_CLOUD_CREDENTIAL_MESSAGE };
@@ -95,6 +98,12 @@ export function preflightCloudCredentials(
 ): void {
   const { credential } = describeCloudCredential(options, deps);
   if (credential.source === "missing") {
+    const envKey = (deps.env ?? process.env).MCPJAM_API_KEY?.trim();
+    if (envKey?.startsWith("mcpjam_")) {
+      throw operationalError(
+        `${MISSING_CLOUD_CREDENTIAL_MESSAGE} Ignoring legacy mcpjam_ key in MCPJAM_API_KEY for this command. ${LEGACY_KEY_REMEDY}`
+      );
+    }
     throw operationalError(MISSING_CLOUD_CREDENTIAL_MESSAGE);
   }
 }

--- a/cli/src/lib/credential-describe.ts
+++ b/cli/src/lib/credential-describe.ts
@@ -35,8 +35,13 @@ export type DescribeCloudCredentialDependencies = {
 };
 
 export function redactCloudApiKey(key: string): string {
-  const last4 = key.slice(-4);
-  return `sk_…${last4}`;
+  const separator = key.indexOf("_");
+  const prefix = separator > 0 ? key.slice(0, separator + 1) : "";
+  const secret = key.slice(prefix.length);
+  if (secret.length < 8) {
+    return `${prefix}…`;
+  }
+  return `${prefix}…${secret.slice(-4)}`;
 }
 
 function trimmed(value: string | undefined): string | undefined {

--- a/cli/src/lib/platform-auth.ts
+++ b/cli/src/lib/platform-auth.ts
@@ -27,6 +27,7 @@ import {
   writeStoredAuth,
   type StoredPlatformAuth,
 } from "./auth-store.js";
+import { MISSING_CLOUD_CREDENTIAL_MESSAGE } from "./cloud-context.js";
 import { operationalError, usageError } from "./output.js";
 
 export const DEFAULT_PLATFORM_ORIGIN = "https://app.mcpjam.com";
@@ -97,9 +98,7 @@ export async function getOAuthAccessToken(deps: {
 }): Promise<string> {
   const stored = readStoredAuth(deps.authFilePath);
   if (!stored) {
-    throw operationalError(
-      "Not logged in. Run `mcpjam cloud login`, or pass an sk_ API key via --api-key / MCPJAM_API_KEY."
-    );
+    throw operationalError(MISSING_CLOUD_CREDENTIAL_MESSAGE);
   }
 
   const now = deps.now ?? Date.now;

--- a/cli/src/lib/platform-auth.ts
+++ b/cli/src/lib/platform-auth.ts
@@ -27,7 +27,6 @@ import {
   writeStoredAuth,
   type StoredPlatformAuth,
 } from "./auth-store.js";
-import { MISSING_CLOUD_CREDENTIAL_MESSAGE } from "./cloud-context.js";
 import { operationalError, usageError } from "./output.js";
 
 export const DEFAULT_PLATFORM_ORIGIN = "https://app.mcpjam.com";
@@ -37,6 +36,9 @@ const DEFAULT_LOGIN_TIMEOUT_MS = 5 * 60_000;
 
 export const LEGACY_KEY_REMEDY =
   "Legacy mcpjam_ API keys are not supported by platform commands. Create an sk_ key at https://app.mcpjam.com/settings/api-keys or run `mcpjam cloud login`.";
+
+export const MISSING_CLOUD_CREDENTIAL_MESSAGE =
+  "Not logged in. Run `mcpjam cloud login`, or pass an sk_ API key via --api-key / MCPJAM_API_KEY.";
 
 export interface PlatformCredential {
   kind: "api-key" | "oauth";

--- a/cli/src/lib/platform-command.ts
+++ b/cli/src/lib/platform-command.ts
@@ -16,9 +16,15 @@ import { PlatformApiError } from "@mcpjam/sdk/platform";
 import {
   appendProjectLinkHint,
   resolveCloudProjectArgs,
+  resolveProjectSelector,
+  type CloudScope,
   type ProjectCloudScope,
   type ResolveProjectSelectorOptions,
 } from "./cloud-scope.js";
+import {
+  announceCloudContext,
+  preflightCloudCredentials,
+} from "./cloud-context.js";
 import {
   buildPlatformClient,
   toCliError,
@@ -52,14 +58,27 @@ export type RunPlatformOperationExtras = {
    */
   externalSignal?: AbortSignal;
   /**
-   * When true (default), announce Cloud context before the operation.
-   * Inner polls set `false` so a user command announces once. No-op until
-   * the audience-line change lands.
+   * When true (default), print the Cloud audience line to stderr before the
+   * operation. Inner polls, `cloud whoami`, `cloud link`, and hosted
+   * `readiness` set `false` so a user command announces at most once.
    */
   announce?: boolean;
   /**
+   * Suppress the audience line. Wrappers pass the global `--quiet` flag;
+   * `process.argv` is the fallback when a call site has not been updated.
+   */
+  quiet?: boolean;
+  /**
+   * Typed Cloud resource scope for the audience line. When omitted, a
+   * project-scoped selector is inferred from `--project` / env / link /
+   * automatic. Account-scoped callers pass `{ kind: "account" }` (or
+   * `all-projects` / `organization`) so they do not pick up a project link.
+   */
+  cloudScope?: CloudScope;
+  /**
    * How the project selector for this operation was chosen. Used to append
-   * a re-link hint when a link-sourced selector fails online.
+   * a re-link hint when a link-sourced selector fails online, and as the
+   * audience scope when `cloudScope` is omitted.
    */
   projectScope?: ProjectCloudScope;
 };
@@ -129,6 +148,17 @@ export function buildCloudClientContext(
   };
 }
 
+function cloudAnnounceScope(
+  options: PlatformOptions,
+  extras: RunPlatformOperationExtras
+): CloudScope {
+  if (extras.cloudScope) return extras.cloudScope;
+  if (extras.projectScope) return extras.projectScope;
+  return resolveProjectSelector({
+    flagProject: (options as { project?: string }).project,
+  });
+}
+
 /**
  * Run one bounded Cloud operation under the global timeout, translating every
  * failure into a CLI error.
@@ -144,7 +174,7 @@ export async function runPlatformOperation<TOutput>(
   execute: (context: PlatformOperationContext) => Promise<TOutput>,
   extras: RunPlatformOperationExtras = {}
 ): Promise<TOutput> {
-  void extras.announce;
+  preflightCloudCredentials(options);
   const controller = new AbortController();
   const timeoutHandle = setTimeout(() => {
     controller.abort(
@@ -167,6 +197,13 @@ export async function runPlatformOperation<TOutput>(
 
   try {
     const context = buildCloudClientContext(options, timeoutMs);
+    const quiet = extras.quiet ?? process.argv.includes("--quiet");
+    if (extras.announce !== false && quiet !== true) {
+      announceCloudContext({
+        scope: cloudAnnounceScope(options, extras),
+        options,
+      });
+    }
     return await execute({ ...context, signal: controller.signal });
   } catch (error) {
     if (
@@ -252,8 +289,8 @@ export function bindOperation<TOptions extends PlatformOptions, TInput>(
   command.action(async (options: TOptions, invoked: Command) => {
     const globalOptions = getGlobalOptions(invoked);
     const merged = platformOptionsOf<TOptions & { project?: string }>(invoked);
-    const applyAmbient =
-      hasCloudAncestor(invoked) && commandHasProjectOption(invoked);
+    const underCloud = hasCloudAncestor(invoked);
+    const applyAmbient = underCloud && commandHasProjectOption(invoked);
     const resolved = applyAmbient
       ? resolveCloudProjectArgs({ project: merged.project })
       : undefined;
@@ -265,7 +302,16 @@ export function bindOperation<TOptions extends PlatformOptions, TInput>(
       globalOptions.timeout,
       ({ client, signal }) =>
         operation.execute(buildInput(inputOptions), { client, signal }),
-      resolved ? { projectScope: resolved.projectScope } : {}
+      {
+        announce: underCloud,
+        quiet: globalOptions.quiet,
+        ...(resolved
+          ? {
+              projectScope: resolved.projectScope,
+              cloudScope: resolved.projectScope,
+            }
+          : {}),
+      }
     );
     writeResult(result, globalOptions.format);
   });
@@ -301,7 +347,12 @@ export async function runCloudOp<
         context,
         resolved.project !== undefined ? { project: resolved.project } : {}
       ),
-    { ...nestedExtras, projectScope: resolved.projectScope }
+    {
+      ...nestedExtras,
+      projectScope: resolved.projectScope,
+      cloudScope: nestedExtras?.cloudScope ?? resolved.projectScope,
+      quiet: nestedExtras?.quiet ?? globalOptions.quiet,
+    }
   );
 }
 

--- a/cli/tests/cloud-audience.test.ts
+++ b/cli/tests/cloud-audience.test.ts
@@ -210,6 +210,29 @@ test("missing Cloud credentials fail with the login string before a network call
   assert.doesNotMatch(run.stderr, /ECONNREFUSED|fetch failed|timed out/i);
 });
 
+test("missing Cloud credentials name a leftover legacy MCPJAM_API_KEY", async () => {
+  const cwd = mkdtempSync(path.join(tmpdir(), "mcpjam-audience-legacy-"));
+  const run = await withEnv(isolatedEnv({ MCPJAM_API_KEY: "mcpjam_legacy" }), () =>
+    withCwd(cwd, () =>
+      runCli([
+        "cloud",
+        "eval",
+        "list",
+        "--api-url",
+        "http://127.0.0.1:1/api/v1",
+        "--format",
+        "json",
+      ])
+    )
+  );
+  assert.equal(run.exitCode, 1, run.stderr);
+  const payload = JSON.parse(run.stderr) as { error: { message: string } };
+  assert.ok(payload.error.message.includes(MISSING_CLOUD_CREDENTIAL_MESSAGE));
+  assert.match(payload.error.message, /Ignoring legacy mcpjam_ key in MCPJAM_API_KEY/);
+  assert.match(payload.error.message, /Legacy mcpjam_ API keys/);
+  assert.doesNotMatch(run.stderr, /ECONNREFUSED|fetch failed|timed out/i);
+});
+
 test("cloud whoami does not print the audience line", async () => {
   const fixture = await startEvalListFixture();
   try {

--- a/cli/tests/cloud-audience.test.ts
+++ b/cli/tests/cloud-audience.test.ts
@@ -151,7 +151,7 @@ test("cloud eval list writes the audience line to stderr and keeps stdout JSON",
     assert.ok(Array.isArray(payload.items));
     assert.match(
       run.stderr,
-      /Using MCPJam Cloud as sk_…test · project: automatic \(most recently updated\) · /
+      /Using MCPJam Cloud as sk_… · project: automatic \(most recently updated\) · /
     );
     assert.match(run.stderr, new RegExp(fixture.baseUrl.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")));
     assert.doesNotMatch(run.stdout, /Using MCPJam Cloud/);
@@ -401,7 +401,7 @@ test("environments create audience names the JSON body project, not MCPJAM_PROJE
     assert.equal(run.exitCode, 0, run.stderr);
     assert.match(
       run.stderr,
-      /Using MCPJam Cloud as sk_…test · project: input \(proj-file\) · /
+      /Using MCPJam Cloud as sk_… · project: input \(proj-file\) · /
     );
     assert.doesNotMatch(run.stderr, /project: env \(proj-env\)/);
   } finally {

--- a/cli/tests/cloud-audience.test.ts
+++ b/cli/tests/cloud-audience.test.ts
@@ -1,0 +1,295 @@
+/**
+ * Cloud audience line and credential preflight.
+ *
+ * Machine-readable results stay on stdout. Who/where context goes to stderr
+ * and is omitted under `--quiet`. Missing credentials fail with the login
+ * guidance before a network call.
+ */
+import assert from "node:assert/strict";
+import { mkdtempSync, readdirSync, readFileSync, statSync } from "node:fs";
+import { createServer, type Server } from "node:http";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import test from "node:test";
+import { MISSING_CLOUD_CREDENTIAL_MESSAGE } from "../src/lib/cloud-context.js";
+import { runCli } from "./support/cli-run.js";
+
+const SRC_ROOT = fileURLToPath(new URL("../src", import.meta.url));
+
+async function startEvalListFixture(): Promise<{
+  baseUrl: string;
+  close: () => Promise<void>;
+}> {
+  const server: Server = createServer((req, res) => {
+    const url = new URL(req.url ?? "/", "http://fixture");
+    res.setHeader("content-type", "application/json");
+    if (url.pathname === "/api/v1/projects") {
+      res.end(
+        JSON.stringify({
+          items: [
+            {
+              id: "proj-alpha",
+              name: "Alpha",
+              description: null,
+              icon: null,
+              organizationId: "org-1",
+              visibility: null,
+              createdAt: 1,
+              updatedAt: 200,
+            },
+          ],
+        })
+      );
+      return;
+    }
+    if (url.pathname === "/api/v1/projects/proj-alpha/eval-suites") {
+      res.end(JSON.stringify({ items: [] }));
+      return;
+    }
+    if (url.pathname.endsWith("/me")) {
+      res.end(
+        JSON.stringify({
+          id: "user-1",
+          email: "dev@example.com",
+          name: "Dev",
+          imageUrl: null,
+          profilePictureUrl: null,
+          plan: "pro",
+          createdAt: null,
+          updatedAt: null,
+        })
+      );
+      return;
+    }
+    res.statusCode = 404;
+    res.end(JSON.stringify({ code: "NOT_FOUND", message: url.pathname }));
+  });
+
+  await new Promise<void>((resolve) =>
+    server.listen(0, "127.0.0.1", () => resolve())
+  );
+  const address = server.address();
+  if (!address || typeof address === "string") {
+    throw new Error("fixture server has no address");
+  }
+
+  return {
+    baseUrl: `http://127.0.0.1:${address.port}/api/v1`,
+    close: () =>
+      new Promise<void>((resolve, reject) =>
+        server.close((error) => (error ? reject(error) : resolve()))
+      ),
+  };
+}
+
+function isolatedEnv(
+  extra: Record<string, string | undefined> = {}
+): Record<string, string | undefined> {
+  return {
+    MCPJAM_PROJECT: undefined,
+    MCPJAM_PROJECT_ID: undefined,
+    MCPJAM_API_KEY: undefined,
+    MCPJAM_API_URL: undefined,
+    MCPJAM_AUTH_FILE: path.join(tmpdir(), "mcpjam-no-auth.json"),
+    ...extra,
+  };
+}
+
+async function withEnv<T>(
+  env: Record<string, string | undefined>,
+  fn: () => Promise<T>
+): Promise<T> {
+  const previous: Record<string, string | undefined> = {};
+  for (const key of Object.keys(env)) {
+    previous[key] = process.env[key];
+    const value = env[key];
+    if (value === undefined) delete process.env[key];
+    else process.env[key] = value;
+  }
+  try {
+    return await fn();
+  } finally {
+    for (const [key, value] of Object.entries(previous)) {
+      if (value === undefined) delete process.env[key];
+      else process.env[key] = value;
+    }
+  }
+}
+
+async function withCwd<T>(directory: string, fn: () => Promise<T>): Promise<T> {
+  const previous = process.cwd();
+  process.chdir(directory);
+  try {
+    return await fn();
+  } finally {
+    process.chdir(previous);
+  }
+}
+
+test("cloud eval list writes the audience line to stderr and keeps stdout JSON", async () => {
+  const fixture = await startEvalListFixture();
+  const cwd = mkdtempSync(path.join(tmpdir(), "mcpjam-audience-"));
+  try {
+    const run = await withEnv(isolatedEnv(), () =>
+      withCwd(cwd, () =>
+        runCli([
+          "cloud",
+          "eval",
+          "list",
+          "--api-key",
+          "sk_test",
+          "--api-url",
+          fixture.baseUrl,
+          "--format",
+          "json",
+        ])
+      )
+    );
+    assert.equal(run.exitCode, 0, run.stderr);
+    const payload = JSON.parse(run.stdout);
+    assert.ok(Array.isArray(payload.items));
+    assert.match(
+      run.stderr,
+      /Using MCPJam Cloud as sk_…test · project: automatic \(most recently updated\) · /
+    );
+    assert.match(run.stderr, new RegExp(fixture.baseUrl.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")));
+    assert.doesNotMatch(run.stdout, /Using MCPJam Cloud/);
+  } finally {
+    await fixture.close();
+  }
+});
+
+test("cloud eval list --quiet suppresses the audience line", async () => {
+  const fixture = await startEvalListFixture();
+  const cwd = mkdtempSync(path.join(tmpdir(), "mcpjam-audience-quiet-"));
+  try {
+    const run = await withEnv(isolatedEnv(), () =>
+      withCwd(cwd, () =>
+        runCli([
+          "--quiet",
+          "cloud",
+          "eval",
+          "list",
+          "--api-key",
+          "sk_test",
+          "--api-url",
+          fixture.baseUrl,
+          "--format",
+          "json",
+        ])
+      )
+    );
+    assert.equal(run.exitCode, 0, run.stderr);
+    assert.doesNotMatch(run.stderr, /Using MCPJam Cloud/);
+    JSON.parse(run.stdout);
+  } finally {
+    await fixture.close();
+  }
+});
+
+test("missing Cloud credentials fail with the login string before a network call", async () => {
+  const cwd = mkdtempSync(path.join(tmpdir(), "mcpjam-audience-missing-"));
+  const run = await withEnv(isolatedEnv(), () =>
+    withCwd(cwd, () =>
+      runCli([
+        "cloud",
+        "eval",
+        "list",
+        "--api-url",
+        "http://127.0.0.1:1/api/v1",
+        "--format",
+        "json",
+      ])
+    )
+  );
+  assert.equal(run.exitCode, 1, run.stderr);
+  const payload = JSON.parse(run.stderr) as { error: { message: string } };
+  assert.equal(payload.error.message, MISSING_CLOUD_CREDENTIAL_MESSAGE);
+  assert.doesNotMatch(run.stderr, /Using MCPJam Cloud/);
+  assert.doesNotMatch(run.stderr, /ECONNREFUSED|fetch failed|timed out/i);
+});
+
+test("cloud whoami does not print the audience line", async () => {
+  const fixture = await startEvalListFixture();
+  try {
+    const run = await withEnv(isolatedEnv(), () =>
+      runCli([
+        "cloud",
+        "whoami",
+        "--api-key",
+        "sk_test",
+        "--api-url",
+        fixture.baseUrl,
+        "--format",
+        "json",
+      ])
+    );
+    assert.equal(run.exitCode, 0, run.stderr);
+    assert.equal(JSON.parse(run.stdout).email, "dev@example.com");
+    assert.doesNotMatch(run.stderr, /Using MCPJam Cloud/);
+  } finally {
+    await fixture.close();
+  }
+});
+
+test("hosted readiness does not print a Cloud audience line", async () => {
+  const fixture = await startEvalListFixture();
+  try {
+    const run = await withEnv(isolatedEnv(), () =>
+      runCli([
+        "readiness",
+        "list",
+        "--api-key",
+        "sk_test",
+        "--api-url",
+        fixture.baseUrl,
+        "--format",
+        "json",
+      ])
+    );
+    assert.notEqual(run.exitCode, 0, run.stderr);
+    assert.doesNotMatch(run.stderr, /Using MCPJam Cloud/);
+  } finally {
+    await fixture.close();
+  }
+});
+
+test("announce: false is only used at the allowlisted Cloud call sites", () => {
+  const allowlist = [
+    "commands/auth.ts",
+    "commands/cloud-link.ts",
+    "commands/projects.ts",
+    "commands/environments.ts",
+  ];
+  const hits: string[] = [];
+  const walk = (directory: string) => {
+    for (const entry of readdirSync(directory)) {
+      const full = path.join(directory, entry);
+      if (statSync(full).isDirectory()) {
+        walk(full);
+        continue;
+      }
+      if (!full.endsWith(".ts")) continue;
+      const text = readFileSync(full, "utf8");
+      if (!/announce:\s*false/.test(text)) continue;
+      hits.push(path.relative(SRC_ROOT, full));
+    }
+  };
+  walk(SRC_ROOT);
+  for (const file of hits) {
+    assert.ok(
+      allowlist.some((allowed) => file.endsWith(allowed)),
+      `unexpected announce: false in ${file}`
+    );
+  }
+  assert.deepEqual([...hits].sort(), [...allowlist].sort());
+});
+
+test("bindOperation suppresses the audience line outside mcpjam cloud", () => {
+  const source = readFileSync(
+    path.join(SRC_ROOT, "lib/platform-command.ts"),
+    "utf8"
+  );
+  assert.match(source, /announce:\s*underCloud/);
+});

--- a/cli/tests/cloud-audience.test.ts
+++ b/cli/tests/cloud-audience.test.ts
@@ -293,3 +293,97 @@ test("bindOperation suppresses the audience line outside mcpjam cloud", () => {
   );
   assert.match(source, /announce:\s*underCloud/);
 });
+
+test("platform-auth does not import cloud-context", () => {
+  const source = readFileSync(
+    path.join(SRC_ROOT, "lib/platform-auth.ts"),
+    "utf8"
+  );
+  assert.doesNotMatch(source, /cloud-context/);
+});
+
+test("environments create audience names the JSON body project, not MCPJAM_PROJECT", async () => {
+  const server: Server = createServer((req, res) => {
+    const url = new URL(req.url ?? "/", "http://fixture");
+    res.setHeader("content-type", "application/json");
+    if (url.pathname === "/api/v1/projects") {
+      res.end(
+        JSON.stringify({
+          items: [
+            {
+              id: "proj-env",
+              name: "EnvProject",
+              organizationId: "org-1",
+              createdAt: 1,
+              updatedAt: 50,
+            },
+            {
+              id: "proj-file",
+              name: "FileProject",
+              organizationId: "org-1",
+              createdAt: 1,
+              updatedAt: 10,
+            },
+          ],
+        })
+      );
+      return;
+    }
+    if (
+      url.pathname === "/api/v1/projects/proj-file/environments" &&
+      req.method === "POST"
+    ) {
+      res.end(
+        JSON.stringify({
+          id: "env-1",
+          projectId: "proj-file",
+          name: "FromFile",
+          hostId: "host-1",
+          revision: 1,
+        })
+      );
+      return;
+    }
+    res.statusCode = 404;
+    res.end(JSON.stringify({ code: "NOT_FOUND", message: url.pathname }));
+  });
+  await new Promise<void>((resolve) =>
+    server.listen(0, "127.0.0.1", () => resolve())
+  );
+  const address = server.address();
+  if (!address || typeof address === "string") {
+    throw new Error("fixture server has no address");
+  }
+  const baseUrl = `http://127.0.0.1:${address.port}/api/v1`;
+  try {
+    const run = await withEnv(isolatedEnv({ MCPJAM_PROJECT: "proj-env" }), () =>
+      runCli([
+        "cloud",
+        "environments",
+        "create",
+        "--api-key",
+        "sk_test",
+        "--api-url",
+        baseUrl,
+        "--format",
+        "json",
+        "--json",
+        JSON.stringify({
+          project: "proj-file",
+          name: "FromFile",
+          hostId: "host-1",
+        }),
+      ])
+    );
+    assert.equal(run.exitCode, 0, run.stderr);
+    assert.match(
+      run.stderr,
+      /Using MCPJam Cloud as sk_…test · project: input \(proj-file\) · /
+    );
+    assert.doesNotMatch(run.stderr, /project: env \(proj-env\)/);
+  } finally {
+    await new Promise<void>((resolve, reject) =>
+      server.close((error) => (error ? reject(error) : resolve()))
+    );
+  }
+});

--- a/cli/tests/cloud-context.test.ts
+++ b/cli/tests/cloud-context.test.ts
@@ -84,3 +84,24 @@ test("preflightCloudCredentials uses the shared login guidance", () => {
     }
   );
 });
+
+test("preflightCloudCredentials names a leftover legacy MCPJAM_API_KEY", () => {
+  assert.throws(
+    () =>
+      preflightCloudCredentials(
+        {},
+        {
+          env: { MCPJAM_API_KEY: "mcpjam_legacy" },
+          authFilePath: path.join(tmpdir(), "no-auth.json"),
+        }
+      ),
+    (error: unknown) => {
+      assert.ok(error instanceof CliError);
+      assert.equal(error.exitCode, 1);
+      assert.match(error.message, new RegExp(MISSING_CLOUD_CREDENTIAL_MESSAGE));
+      assert.match(error.message, /Ignoring legacy mcpjam_ key in MCPJAM_API_KEY/);
+      assert.match(error.message, /Legacy mcpjam_ API keys/);
+      return true;
+    }
+  );
+});

--- a/cli/tests/cloud-context.test.ts
+++ b/cli/tests/cloud-context.test.ts
@@ -1,0 +1,86 @@
+import assert from "node:assert/strict";
+import { mkdtempSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import test from "node:test";
+import { DEFAULT_PLATFORM_API_BASE_URL } from "@mcpjam/sdk/platform";
+import { CliError } from "../src/lib/output.js";
+import {
+  MISSING_CLOUD_CREDENTIAL_MESSAGE,
+  formatCloudAudienceLine,
+  preflightCloudCredentials,
+} from "../src/lib/cloud-context.js";
+
+function authFile(body: Record<string, unknown>): string {
+  const directory = mkdtempSync(path.join(tmpdir(), "mcpjam-audience-"));
+  const filePath = path.join(directory, "auth.json");
+  writeFileSync(filePath, JSON.stringify({ version: 1, ...body }));
+  return filePath;
+}
+
+test("formatCloudAudienceLine redacts API keys and names project scope", () => {
+  const line = formatCloudAudienceLine({
+    scope: { kind: "project", source: "automatic" },
+    options: { apiKey: "sk_live_abcd1234", apiUrl: "https://example.test/api/v1" },
+    env: {},
+    authFilePath: path.join(tmpdir(), "no-auth.json"),
+  });
+  assert.equal(
+    line,
+    "Using MCPJam Cloud as sk_…1234 · project: automatic (most recently updated) · https://example.test/api/v1"
+  );
+});
+
+test("formatCloudAudienceLine prefers stored OAuth email over the oauth fallback", () => {
+  const authFilePath = authFile({
+    issuer: "https://login.example.com",
+    clientId: "c",
+    tokenEndpoint: "https://login.example.com/token",
+    accessToken: "tok",
+    email: "dev@example.com",
+    apiUrl: "https://staging.example.com/api/v1",
+  });
+  const withEmail = formatCloudAudienceLine({
+    scope: { kind: "account" },
+    options: {},
+    env: {},
+    authFilePath,
+  });
+  assert.equal(
+    withEmail,
+    "Using MCPJam Cloud as dev@example.com · account · https://staging.example.com/api/v1"
+  );
+
+  const noEmailPath = authFile({
+    issuer: "https://login.example.com",
+    clientId: "c",
+    tokenEndpoint: "https://login.example.com/token",
+    accessToken: "tok",
+  });
+  const withoutEmail = formatCloudAudienceLine({
+    scope: { kind: "all-projects" },
+    options: {},
+    env: {},
+    authFilePath: noEmailPath,
+  });
+  assert.equal(
+    withoutEmail,
+    `Using MCPJam Cloud as oauth · all projects · ${DEFAULT_PLATFORM_API_BASE_URL}`
+  );
+});
+
+test("preflightCloudCredentials uses the shared login guidance", () => {
+  assert.throws(
+    () =>
+      preflightCloudCredentials(
+        {},
+        { env: {}, authFilePath: path.join(tmpdir(), "no-auth.json") }
+      ),
+    (error: unknown) => {
+      assert.ok(error instanceof CliError);
+      assert.equal(error.exitCode, 1);
+      assert.equal(error.message, MISSING_CLOUD_CREDENTIAL_MESSAGE);
+      return true;
+    }
+  );
+});

--- a/cli/tests/cloud-context.test.ts
+++ b/cli/tests/cloud-context.test.ts
@@ -98,7 +98,7 @@ test("preflightCloudCredentials names a leftover legacy MCPJAM_API_KEY", () => {
     (error: unknown) => {
       assert.ok(error instanceof CliError);
       assert.equal(error.exitCode, 1);
-      assert.match(error.message, new RegExp(MISSING_CLOUD_CREDENTIAL_MESSAGE));
+      assert.ok(error.message.includes(MISSING_CLOUD_CREDENTIAL_MESSAGE));
       assert.match(error.message, /Ignoring legacy mcpjam_ key in MCPJAM_API_KEY/);
       assert.match(error.message, /Legacy mcpjam_ API keys/);
       return true;

--- a/cli/tests/cloud-link-status.test.ts
+++ b/cli/tests/cloud-link-status.test.ts
@@ -374,6 +374,47 @@ test("cloud link empty project argument is a usage error", async () => {
   assert.doesNotMatch(run.stderr, /--project cannot be empty/);
 });
 
+test("cloud link --remove rejects an empty project argument", async () => {
+  const run = await runCli([
+    "cloud",
+    "link",
+    "",
+    "--remove",
+    "--format",
+    "json",
+  ]);
+  assert.equal(run.exitCode, 2);
+  assert.match(run.stderr, /Do not pass a project argument with --remove/);
+});
+
+test("cloud status reports empty MCPJAM_PROJECT as unresolved, not automatic", async () => {
+  const cwd = mkdtempSync(path.join(tmpdir(), "mcpjam-status-empty-"));
+  const run = await withEnv(isolatedEnv({ MCPJAM_PROJECT: "   " }), () =>
+    withCwd(cwd, () => runCli(["cloud", "status", "--format", "json"]))
+  );
+  assert.equal(run.exitCode, 1, run.stderr);
+  const payload = JSON.parse(run.stdout) as {
+    ok: boolean;
+    project: { source: string; description: string };
+    warnings: string[];
+  };
+  assert.equal(payload.ok, false);
+  assert.equal(payload.project.source, "unresolved");
+  assert.equal(payload.project.description, "unresolved");
+  assert.match(payload.warnings.join("\n"), /MCPJAM_PROJECT cannot be empty/);
+});
+
+test("cloud link --here --remove without a link is a usage error", async () => {
+  const cwd = mkdtempSync(path.join(tmpdir(), "mcpjam-link-here-missing-"));
+  const run = await withEnv(isolatedEnv(), () =>
+    withCwd(cwd, () =>
+      runCli(["cloud", "link", "--here", "--remove", "--format", "json"])
+    )
+  );
+  assert.equal(run.exitCode, 2);
+  assert.match(run.stderr, /No project link found/);
+});
+
 test("cloud link --remove rejects a project argument", async () => {
   const run = await runCli([
     "cloud",

--- a/cli/tests/credential-describe.test.ts
+++ b/cli/tests/credential-describe.test.ts
@@ -18,6 +18,12 @@ test("redactCloudApiKey keeps sk_ prefix and last four characters", () => {
   assert.equal(redactCloudApiKey("sk_live_abcd1234"), "sk_…1234");
 });
 
+test("redactCloudApiKey hides short secrets and does not assume sk_", () => {
+  assert.equal(redactCloudApiKey("sk_ab"), "sk_…");
+  assert.equal(redactCloudApiKey("pk_abcd1234efgh"), "pk_…efgh");
+  assert.equal(redactCloudApiKey("short"), "…");
+});
+
 test("credential precedence is flag, usable env key, oauth, missing", () => {
   const authFilePath = authFile({
     issuer: "https://login.example.com",

--- a/cli/tests/projects.test.ts
+++ b/cli/tests/projects.test.ts
@@ -10,6 +10,21 @@ const telemetryDisabled = {
   },
 };
 
+/** Cloud audience lines share stderr with structured errors. Parse the JSON object. */
+function parseStderrJson(stderr: string): {
+  error: { code: string; message: string };
+} {
+  const line = stderr
+    .trim()
+    .split("\n")
+    .reverse()
+    .find((entry) => entry.startsWith("{"));
+  if (!line) {
+    throw new Error(`no JSON object in stderr:\n${stderr}`);
+  }
+  return JSON.parse(line);
+}
+
 async function captureProcessOutput<T>(fn: () => Promise<T>): Promise<{
   result: T;
   stdout: string;
@@ -318,7 +333,7 @@ test("projects commands honor the global timeout option", async () => {
     );
 
     assert.equal(run.result.exitCode, 1);
-    const payload = JSON.parse(run.stderr);
+    const payload = parseStderrJson(run.stderr);
     assert.equal(payload.error.code, "TIMEOUT");
     assert.match(payload.error.message, /20ms/);
   } finally {
@@ -369,7 +384,7 @@ test("command-level deadline spanning multiple requests still reports TIMEOUT", 
     );
 
     assert.equal(run.result.exitCode, 1);
-    const payload = JSON.parse(run.stderr);
+    const payload = parseStderrJson(run.stderr);
     assert.equal(payload.error.code, "TIMEOUT");
   } finally {
     server.closeAllConnections?.();
@@ -515,7 +530,7 @@ test("projects servers surfaces unknown projects as NOT_FOUND", async () => {
     );
 
     assert.equal(run.result.exitCode, 1);
-    const payload = JSON.parse(run.stderr);
+    const payload = parseStderrJson(run.stderr);
     assert.equal(payload.error.code, "NOT_FOUND");
     assert.match(payload.error.message, /Available projects/);
   } finally {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Purpose

PR 6 of the CLI local-vs-cloud split. Cloud commands now say who they are acting as, which project/scope they are using, and which API URL they will call — on stderr, before the operation. Missing credentials fail immediately with the same login guidance `mcpjam cloud login` already uses, so a forgotten key does not wait on the first HTTP timeout.

## Linked

Stacked on #4196 (`cursor/cli-project-link-status-aca6`). Merge after that PR.

## Before / after

**Before:** a Cloud command with no credentials spent the request timeout (or a connection error) before telling you to log in. Successful commands printed only the machine-readable result; there was no record of which account, project, or deployment produced it.

**After:**
- Preflight: no `sk_` key and no stored OAuth → exit 1 with `Not logged in. Run \`mcpjam cloud login\`, or pass an sk_ API key via --api-key / MCPJAM_API_KEY.`
- Audience line on stderr: `Using MCPJam Cloud as <identity> · <scope> · <apiUrl>`
- Identity is a redacted `sk_…last4` for API keys, or the stored OAuth email (else `oauth`)
- Scope is `account` / `organization …` / `all projects` / `project: <flag|input|env|link|automatic (most recently updated)>`
- `--quiet` suppresses the line
- JSON/human stdout is unchanged
- Exempt (no audience line): `cloud login`, `logout`, `whoami`, `link`, `status`
- Hosted `readiness` stays on the local surface and does **not** print Cloud audience context
- Inner connection-status polls and environment model-capability preflights announce once at most (the user-facing command)

## Rollout

- `"@mcpjam/cli": major` changeset (4.0; hold Version Packages until PR 12)
- Cloud behavior only. Frozen local commands are unchanged.
- Scripts that `JSON.parse` the entire stderr of a failing Cloud command need to parse the JSON object line; audience context is a preceding stderr line.

## Test plan

- `npm run typecheck -w @mcpjam/cli`
- `npm test -w @mcpjam/cli`
- Targeted: `cloud eval list` writes the audience line to stderr and keeps stdout JSON; `--quiet` suppresses it; missing credentials fail with the exact login string before a network call; `whoami` and hosted `readiness` do not print the line

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-880bc302-7fad-489a-b883-d890bdc3aca6?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-880bc302-7fad-489a-b883-d890bdc3aca6&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Cloud commands print a one-line audience context to stderr and preflight credentials before any network call. Before, missing credentials timed out and successful commands had no identity/scope/API trace.

- Prints: Using MCPJam Cloud as <identity> · <scope> · <apiUrl> to stderr before the operation. Identity is a redacted API key (prefix …last4 when available) or stored OAuth email; scope is account/organization/all projects or project: <selector source>. `--quiet` suppresses this line; stdout (JSON/human) is unchanged.
- Missing credentials fail fast (exit 1) with: Not logged in. Run `mcpjam cloud login`, or pass an sk_ API key via --api-key / MCPJAM_API_KEY. If `MCPJAM_API_KEY` contains a legacy `mcpjam_` key, the error names the leftover env var and includes the remedy.
- Audience scope matches the operation’s target. Environments create/update/ensure/name use the same resolved project used to write (including when provided via `--json`/`--file`). Account/org/all-projects calls (e.g., organizations list, projects list, project server connection status, create project) set explicit Cloud scope to avoid inheriting a project link.
- Exempt: `cloud login`, `logout`, `whoami`, `link`, `status` suppress the audience line; hosted `readiness` remains local. `tunnel` preflights credentials and announces once before opening a session; inner polls announce at most once per user-facing command.
- Link/status hardening: `cloud link --remove` rejects any positional project and requires the `--here` link file to exist. `cloud status` reports an unresolved project when selection fails (e.g., empty `MCPJAM_PROJECT`).

- `@mcpjam/cli`: major. Scripts that parse stderr from failing Cloud commands must parse the final JSON object line; the audience line may precede it.

<sup>Written for commit 62fd68b34c72ccc0269cfd323c6a4fa744e49796. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/MCPJam/inspector/pull/4198?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

