### PR TITLE
cli: normalize Cloud --org, tunnel --server, and placeholders

### DIFF
--- a/.changeset/cli-cloud-flag-normalize.md
+++ b/.changeset/cli-cloud-flag-normalize.md
@@ -1,0 +1,5 @@
+---
+"@mcpjam/cli": major
+---
+
+Normalize Cloud flags: `--org` replaces `--organization-id`; `mcpjam cloud tunnel` takes `--server` (hidden `--id` alias). Commander placeholders that accept a name or an id are `<id-or-name>`.

--- a/cli/src/commands/environments.ts
+++ b/cli/src/commands/environments.ts
@@ -105,8 +105,13 @@ function resolveEnvironmentProject(
   options: { project?: string },
   body: Record<string, unknown> = {}
 ) {
+  if (body.project !== undefined && typeof body.project !== "string") {
+    throw usageError(
+      '"project" must be a string when supplied in JSON input.'
+    );
+  }
   return resolveCloudProjectArgs(options, {
-    inputProject: typeof body.project === "string" ? body.project : undefined,
+    inputProject: body.project,
   });
 }
 

--- a/cli/src/commands/eval.ts
+++ b/cli/src/commands/eval.ts
@@ -1700,7 +1700,7 @@ export function registerEvalCommands(program: Command): void {
         "Suite-level default provider (overrides the file; needed for bare/custom model ids)"
       )
       .option(
-        "--server <name...>",
+        "--server <id-or-name...>",
         "Project HTTP server names or IDs (overrides the file)"
       ).action(async (options: CreateOptions, command) => {
     const globalOptions = getGlobalOptions(command);
@@ -2621,14 +2621,14 @@ export function registerEvalCommands(program: Command): void {
       .option("--name <name>", "Rename the suite")
       .option("--description <text>", "Suite description")
       .option(
-        "--server <name...>",
-        "Replace the suite's server selection (project server names)"
+        "--server <id-or-name...>",
+        "Replace the suite's server selection (project server names or IDs)"
       )
       .option(
-        "--computer-image <name-or-id|off>",
+        "--computer-image <id-or-name|off>",
         "Sandbox image eval runs boot from (see `mcpjam cloud images list`); off uses the default base image"
       )
-      .option("--host <name...>", "Replace host attachments (by name/ID)")
+      .option("--host <id-or-name...>", "Replace host attachments (by name or ID)")
       .option("--model <id>", "Execution model id")
       .option("--system-prompt <text>", "Execution system prompt")
       .option("--temperature <n>", "Execution temperature")

--- a/cli/src/commands/hosts.ts
+++ b/cli/src/commands/hosts.ts
@@ -257,11 +257,11 @@ export function registerHostsCommands(program: Command): void {
       .description("Replace a host's required and optional server attachments")
       .requiredOption("--host <id-or-name>", "Host name or ID")
       .requiredOption(
-        "--server-ids <ids>",
+        "--server-ids <id,...>",
         "Comma-separated required server IDs"
       )
       .option(
-        "--optional-server-ids <ids>",
+        "--optional-server-ids <id,...>",
         "Comma-separated optional server IDs"
       )
       .option("--project <id-or-name>", "Project name or ID").action(

--- a/cli/src/commands/organizations.ts
+++ b/cli/src/commands/organizations.ts
@@ -2,8 +2,8 @@
  * `mcpjam organizations` — the read half, which is the whole group.
  *
  * It exists because an `organizationId` had nowhere to come from. `projects
- * list --organization` and `projects create --organization-id` both take one,
- * and until now the only way to learn one was to read it out of a browser URL.
+ * list --org` and `projects create --org` both take one, and until now the
+ * only way to learn one was to read it out of a browser URL.
  *
  * Deliberately list-only. Creating an organization, inviting or removing
  * members, changing roles, transferring ownership and everything billing stay

--- a/cli/src/commands/projects.ts
+++ b/cli/src/commands/projects.ts
@@ -22,6 +22,7 @@ import {
 import { writeResult } from "../lib/output.js";
 import { DEFAULT_PLATFORM_ORIGIN } from "../lib/platform-auth.js";
 import {
+  addOrgOption,
   addProjectOption,
   bindOperation,
   buildCloudClientContext,
@@ -115,6 +116,7 @@ export function registerProjectsCommands(program: Command): void {
       "Operate the MCP servers saved in your hosted MCPJam projects"
     );
 
+      addOrgOption(
       projects
       .command("list")
       .description("List the projects you can access")
@@ -122,22 +124,17 @@ export function registerProjectsCommands(program: Command): void {
       // it, and no way to learn an id to pass either. `organizations list`
       // supplies the id, so the flag is finally usable end to end.
       //
-      // Named `--organization-id`, matching `projects create`, because both
-      // take an ID and only an ID. (`--project` elsewhere is a name-OR-id
-      // selector, which is why that one has no `-id` suffix.)
-      .option(
-        "--organization-id <id>",
-        "Restrict the listing to one organization (see `mcpjam cloud organizations list`)"
+      // Named `--org`, matching `projects create`. Both take an ID and only
+      // an ID. (`--project` elsewhere is a name-OR-id selector.)
       ).action(async (_options: PlatformOptions, command) => {
     const globalOptions = getGlobalOptions(command);
-    const rawOrganization = (command.opts() as { organizationId?: string })
-      .organizationId;
+    const rawOrganization = (command.opts() as { org?: string }).org;
     // A supplied-but-blank value is a typo, not "no filter". Silently widening
     // it to every accessible project is the wrong answer to a request that
     // asked to narrow — same reasoning as `requireProject` above.
     if (rawOrganization !== undefined && rawOrganization.trim() === "") {
       command.error(
-        "error: option '--organization-id <id>' cannot be empty"
+        "error: option '--org <id>' cannot be empty"
       );
     }
     const organizationId = rawOrganization?.trim();
@@ -166,18 +163,19 @@ export function registerProjectsCommands(program: Command): void {
     }
   });
 
+      addOrgOption(
       projects
       .command("create")
       .description("Create a hosted MCPJam project")
       .requiredOption("--name <name>", "Project name")
       .option("--description <text>", "Project description")
-      .option("--organization-id <id>", "Organization ID")
+      )
       .option("--visibility <visibility>", "public or private").action(
     async (
       options: PlatformOptions & {
         name: string;
         description?: string;
-        organizationId?: string;
+        org?: string;
         visibility?: string;
       },
       command
@@ -188,9 +186,9 @@ export function registerProjectsCommands(program: Command): void {
         ...(options.description === undefined
           ? {}
           : { description: options.description }),
-        ...(options.organizationId === undefined
+        ...(options.org === undefined
           ? {}
-          : { organizationId: options.organizationId }),
+          : { organizationId: options.org }),
         ...(options.visibility === undefined
           ? {}
           : { visibility: options.visibility }),

--- a/cli/src/commands/tunnel.ts
+++ b/cli/src/commands/tunnel.ts
@@ -1,4 +1,5 @@
 import type { Command } from "commander";
+import { addRequiredOptionWithHiddenAlias } from "../lib/commander-options.js";
 import {
   createTunnelOperation,
   type CreateTunnelResult,
@@ -17,7 +18,7 @@ import { RelayConnection } from "../lib/tunnel/relay-client.js";
 import { TunnelSession } from "../lib/tunnel/tunnel-session.js";
 
 type TunnelCommandOptions = {
-  id: string;
+  server: string;
   project?: string;
   apiKey?: string;
   apiUrl?: string;
@@ -38,7 +39,7 @@ export function parseTunnelTarget(tokens: string[]): ParsedTunnelTarget {
   const isUrl = (token: string) => /^https?:\/\//i.test(token);
   if (tokens.length === 0) {
     throw usageError(
-      "Specify a target: a local server URL (mcpjam cloud tunnel http://localhost:9090/mcp --id my-server) or a stdio command (mcpjam cloud tunnel --id my-server -- npx -y @modelcontextprotocol/server-everything).",
+      "Specify a target: a local server URL (mcpjam cloud tunnel http://localhost:9090/mcp --server my-server) or a stdio command (mcpjam cloud tunnel --server my-server -- npx -y @modelcontextprotocol/server-everything).",
     );
   }
   if (isUrl(tokens[0])) {
@@ -78,7 +79,7 @@ function publicHost(url: string): string {
 }
 
 export function registerTunnelCommands(program: Command): void {
-  program
+  const tunnel = program
     .command("tunnel")
     .description(
       "Expose a local MCP server through an MCPJam tunnel and register it as a server in your project",
@@ -86,11 +87,14 @@ export function registerTunnelCommands(program: Command): void {
     .argument(
       "[target...]",
       "Local http(s) MCP server URL, or a stdio command after `--`",
-    )
-    .requiredOption(
-      "--id <name>",
-      "Server name to register in the project (an existing server with this name is pointed at the tunnel)",
-    )
+    );
+  addRequiredOptionWithHiddenAlias(
+    tunnel,
+    "--server <name>",
+    "--id",
+    "Server name to register in the project (an existing server with this name is pointed at the tunnel)",
+  );
+  tunnel
     .option(
       "--project <id-or-name>",
       "Project name or ID (defaults to the most recently updated project)",
@@ -162,7 +166,7 @@ export function registerTunnelCommands(program: Command): void {
           if (globalOptions.format === "human") {
             process.stdout.write(
               `Tunnel live: ${result.grant.url}\n` +
-                `Registered server "${result.grant.name ?? options.id}" in project "${result.project.name}" (${result.grant.serverId})\n`,
+                `Registered server "${result.grant.name ?? options.server}" in project "${result.project.name}" (${result.grant.serverId})\n`,
             );
             status("Press Ctrl-C to stop the tunnel.");
           } else {
@@ -170,7 +174,7 @@ export function registerTunnelCommands(program: Command): void {
               {
                 url: result.grant.url,
                 serverId: result.grant.serverId,
-                name: result.grant.name ?? options.id,
+                name: result.grant.name ?? options.server,
                 slug: result.grant.slug,
                 project: result.project,
                 existed: result.grant.existed ?? false,
@@ -200,7 +204,7 @@ export function registerTunnelCommands(program: Command): void {
         const session = new TunnelSession({
           createGrant: (signal) =>
             createTunnelOperation.execute(
-              { project: resolved.project, name: options.id },
+              { project: resolved.project, name: options.server },
               { client, signal },
             ),
           closeGrant: async (result, signal) => {

--- a/cli/src/lib/commander-options.ts
+++ b/cli/src/lib/commander-options.ts
@@ -1,0 +1,26 @@
+import { Option, type Command } from "commander";
+
+/**
+ * Add a required option whose help shows only `visibleFlags`, plus a hidden
+ * long-flag alias that sets the same value.
+ *
+ * Commander stores two long flags as short+long internally (the first long
+ * flag occupies the "short" slot). Help prints `option.flags` verbatim, so
+ * this rewrites that string to the canonical spelling after construction.
+ * Both spellings still parse. `attributeName()` comes from the long flag —
+ * put the canonical name second so `--server <name>` yields `options.server`.
+ */
+export function addRequiredOptionWithHiddenAlias(
+  command: Command,
+  visibleFlags: string,
+  hiddenLongFlag: string,
+  description: string
+): Command {
+  const option = new Option(
+    `${hiddenLongFlag}, ${visibleFlags}`,
+    description
+  );
+  option.flags = visibleFlags;
+  option.makeOptionMandatory();
+  return command.addOption(option);
+}

--- a/cli/src/lib/platform-command.ts
+++ b/cli/src/lib/platform-command.ts
@@ -365,6 +365,17 @@ export function addProjectOption(command: Command): Command {
 }
 
 /**
+ * Organization filter. ID-only — unlike `--project`, which is a name-or-id
+ * selector. `mcpjam cloud organizations list` is how you learn the id.
+ */
+export function addOrgOption(command: Command): Command {
+  return command.option(
+    "--org <id>",
+    "Organization ID (see `mcpjam cloud organizations list`)"
+  );
+}
+
+/**
  * Parse an integer flag, or fail with a message that names the flag.
  *
  * Commander hands option values through as strings, and `Number("abc")` is

--- a/cli/src/lib/projects-render.ts
+++ b/cli/src/lib/projects-render.ts
@@ -29,7 +29,7 @@ function table(rows: string[][]): string[] {
 /**
  * Organizations render alongside projects rather than in their own module: an
  * organization id is only ever useful as an argument to a project command
- * (`projects list --organization`, `projects create --organization-id`), so the
+ * (`projects list --org`, `projects create --org`), so the
  * two tables want the same column widths and the same timestamp treatment.
  */
 export function formatOrganizationsHuman(

--- a/cli/tests/cloud-audience.test.ts
+++ b/cli/tests/cloud-audience.test.ts
@@ -410,3 +410,28 @@ test("environments create audience names the JSON body project, not MCPJAM_PROJE
     );
   }
 });
+
+test("environments create rejects a non-string JSON project before any write", async () => {
+  const run = await withEnv(isolatedEnv(), () =>
+    runCli([
+      "cloud",
+      "environments",
+      "create",
+      "--api-key",
+      "sk_test",
+      "--api-url",
+      "http://127.0.0.1:1/api/v1",
+      "--json",
+      JSON.stringify({
+        project: 123,
+        name: "FromFile",
+        hostId: "host-1",
+      }),
+    ])
+  );
+  assert.equal(run.exitCode, 2, run.stderr);
+  assert.match(
+    run.stderr,
+    /"project" must be a string when supplied in JSON input/
+  );
+});

--- a/cli/tests/cloud-flag-conventions.test.ts
+++ b/cli/tests/cloud-flag-conventions.test.ts
@@ -45,6 +45,7 @@ test("Cloud command sources follow flag and placeholder conventions", () => {
         "apps.ts",
         "compat.ts",
         "conformance.ts",
+        "conformance-run.ts",
         "inspector.ts",
         "mcp.ts",
         "oauth.ts",

--- a/cli/tests/cloud-flag-conventions.test.ts
+++ b/cli/tests/cloud-flag-conventions.test.ts
@@ -1,0 +1,121 @@
+/**
+ * Cloud flag spelling and Commander placeholder conventions.
+ *
+ * `--org` is the ID-only organization filter. Tunnel registers a server with
+ * `--server`; `--id` remains a hidden alias. Placeholders that accept a name
+ * or an id are `<id-or-name>`, never camelCase or `name-or-id`.
+ */
+import assert from "node:assert/strict";
+import { readdirSync, readFileSync } from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import test from "node:test";
+import { runCli } from "./support/cli-run.js";
+
+const COMMANDS_DIR = path.resolve(
+  path.dirname(fileURLToPath(import.meta.url)),
+  "../src/commands"
+);
+
+const CLOUD_COMMAND_FILES = [
+  "auth.ts",
+  "cloud.ts",
+  "cloud-link.ts",
+  "environments.ts",
+  "eval.ts",
+  "hosts.ts",
+  "images.ts",
+  "journeys.ts",
+  "organizations.ts",
+  "projects.ts",
+  "scenarios.ts",
+  "sessions.ts",
+  "swarms.ts",
+  "tunnel.ts",
+  "user-testing.ts",
+] as const;
+
+test("Cloud command sources follow flag and placeholder conventions", () => {
+  const listed = new Set<string>(CLOUD_COMMAND_FILES);
+  for (const file of readdirSync(COMMANDS_DIR)) {
+    if (!file.endsWith(".ts")) continue;
+    if (file === "readiness.ts") continue;
+    if (
+      [
+        "apps.ts",
+        "compat.ts",
+        "conformance.ts",
+        "inspector.ts",
+        "mcp.ts",
+        "oauth.ts",
+        "prompts.ts",
+        "resources.ts",
+        "server.ts",
+        "subscriptions.ts",
+        "tasks.ts",
+        "telemetry.ts",
+        "tools.ts",
+        "xaa.ts",
+      ].includes(file)
+    ) {
+      continue;
+    }
+    assert.ok(
+      listed.has(file),
+      `Cloud command file ${file} is not in CLOUD_COMMAND_FILES`
+    );
+  }
+
+  for (const file of CLOUD_COMMAND_FILES) {
+    const source = readFileSync(path.join(COMMANDS_DIR, file), "utf8");
+    assert.doesNotMatch(
+      source,
+      /--organization-id/,
+      `${file} still declares --organization-id; use --org`
+    );
+    assert.doesNotMatch(
+      source,
+      /<idOrName>/,
+      `${file} uses camelCase <idOrName>; use <id-or-name>`
+    );
+    assert.doesNotMatch(
+      source,
+      /<name-or-id/,
+      `${file} uses <name-or-id>; use <id-or-name>`
+    );
+  }
+});
+
+test("projects list and create help show --org, not --organization-id", async () => {
+  const list = await runCli(["cloud", "projects", "list", "--help"]);
+  assert.equal(list.exitCode, 0, list.stderr);
+  assert.match(list.stdout, /--org <id>/);
+  assert.doesNotMatch(list.stdout, /--organization-id/);
+
+  const create = await runCli(["cloud", "projects", "create", "--help"]);
+  assert.equal(create.exitCode, 0, create.stderr);
+  assert.match(create.stdout, /--org <id>/);
+  assert.doesNotMatch(create.stdout, /--organization-id/);
+});
+
+test("projects list --organization-id is an unknown option", async () => {
+  const run = await runCli([
+    "--format",
+    "json",
+    "cloud",
+    "projects",
+    "list",
+    "--organization-id",
+    "org-1",
+  ]);
+  assert.equal(run.exitCode, 2);
+  assert.match(run.stderr, /unknown option '--organization-id'/i);
+});
+
+test("tunnel help shows --server and hides --id", async () => {
+  const run = await runCli(["cloud", "tunnel", "--help"]);
+  assert.equal(run.exitCode, 0, run.stderr);
+  assert.match(run.stdout, /--server <name>/);
+  assert.doesNotMatch(run.stdout, /--id <name>/);
+  assert.doesNotMatch(run.stdout, /--id,/);
+});

--- a/cli/tests/commander-options.test.ts
+++ b/cli/tests/commander-options.test.ts
@@ -1,0 +1,39 @@
+import assert from "node:assert/strict";
+import { Command } from "commander";
+import test from "node:test";
+import { addRequiredOptionWithHiddenAlias } from "../src/lib/commander-options.js";
+
+test("hidden alias sets the canonical option and stays out of help", () => {
+  const command = new Command("tunnel").exitOverride();
+  addRequiredOptionWithHiddenAlias(
+    command,
+    "--server <name>",
+    "--id",
+    "Server name"
+  );
+
+  command.parse(["--id", "alpha"], { from: "user" });
+  assert.equal(command.opts().server, "alpha");
+
+  const help = command.helpInformation();
+  assert.match(help, /--server <name>/);
+  assert.doesNotMatch(help, /--id/);
+});
+
+test("canonical flag is mandatory when neither spelling is given", () => {
+  const command = new Command("tunnel").exitOverride();
+  addRequiredOptionWithHiddenAlias(
+    command,
+    "--server <name>",
+    "--id",
+    "Server name"
+  );
+
+  assert.throws(
+    () => command.parse([], { from: "user" }),
+    (error: unknown) => {
+      assert.match(String(error), /required option '--server <name>'/);
+      return true;
+    }
+  );
+});

--- a/cli/tests/projects.test.ts
+++ b/cli/tests/projects.test.ts
@@ -438,14 +438,14 @@ test("projects list emits items as JSON and a table as human output", async () =
   }
 });
 
-test("projects list --organization-id sends the filter, and refuses a blank one", async () => {
+test("projects list --org sends the filter, and refuses a blank one", async () => {
   const fixture = await startPlatformFixture();
   try {
     const run = await captureProcessOutput(() =>
       main(
         [
           ...projectsArgv(fixture.baseUrl, "list"),
-          "--organization-id",
+          "--org",
           "org-1",
           "--format",
           "json",
@@ -470,7 +470,7 @@ test("projects list --organization-id sends the filter, and refuses a blank one"
       main(
         [
           ...projectsArgv(fixture.baseUrl, "list"),
-          "--organization-id",
+          "--org",
           "   ",
           "--format",
           "json",
@@ -479,6 +479,7 @@ test("projects list --organization-id sends the filter, and refuses a blank one"
       ),
     );
     assert.notEqual(blankRun.result.exitCode, 0);
+    assert.match(blankRun.stderr, /--org/);
   } finally {
     await fixture.close();
   }

--- a/cli/tests/tunnel-command.test.ts
+++ b/cli/tests/tunnel-command.test.ts
@@ -103,7 +103,7 @@ test("tunnel without a target exits 2 with a usage error", async () => {
         "mcpjam",
         "cloud",
         "tunnel",
-        "--id",
+        "--server",
         "my-server",
         "--format",
         "json",
@@ -123,7 +123,7 @@ test("tunnel without a target exits 2 with a usage error", async () => {
   assert.match(payload.error.message, /Specify a target/);
 });
 
-test("tunnel without --id exits 2 via commander's required option", async () => {
+test("tunnel without --server exits 2 via commander's required option", async () => {
   const { result, stderr } = await captureProcessOutput(() =>
     main(
       [
@@ -144,7 +144,32 @@ test("tunnel without --id exits 2 via commander's required option", async () => 
     error: { code: string; message: string };
   };
   assert.equal(payload.error.code, "USAGE_ERROR");
-  assert.match(payload.error.message, /--id/);
+  assert.match(payload.error.message, /--server/);
+});
+
+test("tunnel accepts hidden --id as an alias of --server", async () => {
+  const { result, stderr } = await captureProcessOutput(() =>
+    main(
+      [
+        "node",
+        "mcpjam",
+        "cloud",
+        "tunnel",
+        "--id",
+        "my-server",
+        "--format",
+        "json",
+      ],
+      { telemetry: telemetryDisabled }
+    )
+  );
+
+  assert.equal(result.exitCode, 2);
+  const payload = JSON.parse(stderr.trim().split("\n").at(-1)!) as {
+    error: { code: string; message: string };
+  };
+  assert.equal(payload.error.code, "USAGE_ERROR");
+  assert.match(payload.error.message, /Specify a target/);
 });
 
 test("tunnel rejects --env with an http target", async () => {
@@ -156,7 +181,7 @@ test("tunnel rejects --env with an http target", async () => {
         "cloud",
         "tunnel",
         "http://localhost:9090/mcp",
-        "--id",
+        "--server",
         "x",
         "--env",
         "A=1",


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Purpose

PR 9 of the CLI local-vs-cloud split. Normalize Cloud flag spellings and Commander placeholders so the Cloud surface has one name for each selector.

Stacked on #4200 (`cursor/cli-cloud-consolidate-aca6`). Merge after that PR.

## What changed

- `mcpjam cloud projects list` / `create` take `--org <id>` (ID-only, same as the old `--organization-id`). `--organization-id` is no longer accepted.
- `mcpjam cloud tunnel` takes `--server <name>` to match `projects servers --server`. Hidden `--id` alias still parses; help shows only `--server`.
- Placeholder convention on Cloud commands: name-or-id values use `<id-or-name>` (and `<id-or-name...>` / `<id-or-name|off>`), never `<name-or-id>` or camelCase. Comma-separated IDs use `<id,...>`.
- Hosted `readiness` is unchanged (frozen local surface still uses `--server <idOrName>`).

## Before / after

- **Before:** `mcpjam cloud projects list --organization-id org_…`; `mcpjam cloud tunnel --id my-server …`
- **After:** `mcpjam cloud projects list --org org_…`; `mcpjam cloud tunnel --server my-server …` (`--id` still works, hidden)

## Rollout

- `"@mcpjam/cli": major` changeset (4.0; hold Version Packages until PR 12)
- Cloud-only. No local-command aliases. `--id` on tunnel is a hidden flag alias, not a command-path alias.

## Test plan

- `npm run typecheck -w @mcpjam/cli`
- `npm test -w @mcpjam/cli`
- Targeted: tunnel `--server` / hidden `--id`, projects `--org`, unknown `--organization-id`, Cloud source placeholder scan
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-880bc302-7fad-489a-b883-d890bdc3aca6?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-880bc302-7fad-489a-b883-d890bdc3aca6&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Normalizes Cloud flag names and placeholders for consistent CLI usage. Before: projects used --organization-id and tunnel required --id; now: projects use --org <id> and tunnel requires --server <name> (with a hidden --id alias). Environments writes now error on non-string JSON "project" instead of silently falling back to auto selection.

- Projects list/create accept --org; help shows only --org; --organization-id no longer parses; empty --org triggers "option '--org <id>' cannot be empty".
- Tunnel requires --server; help/usage and required-option errors name --server; hidden --id alias works but stays out of help via a new helper.
- Standardizes placeholders to <id-or-name> and <id,...> across Cloud commands (e.g., eval server/host/computer-image); the flag tripwire treats conformance-run as a local command.
- Environments create/update reject a non-string JSON "project" before any write.

**Rollout**
- Update scripts/docs to use --org and --server; remove --organization-id.
- Cloud-only change; local commands unchanged.
- Publish `@mcpjam/cli` as a major when the stack lands.

<sup>Written for commit e31c6b6cd955f1be78aaf035bfbf09e0c95792cd. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/MCPJam/inspector/pull/4201?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

