### PR TITLE
cli: apply one Cloud project-selection rule

### DIFF
--- a/.changeset/cli-project-selection-rule.md
+++ b/.changeset/cli-project-selection-rule.md
@@ -1,0 +1,5 @@
+---
+"@mcpjam/cli": major
+---
+
+Cloud project selection is one rule: `eval status` / `cancel` / `judge` take optional `--project` (flag, env, link, or automatic). `mcpjam cloud sessions list` is project-scoped the same way; pass `--all-projects` to list across every accessible project.

--- a/cli/src/commands/eval.ts
+++ b/cli/src/commands/eval.ts
@@ -2423,13 +2423,18 @@ export function registerEvalCommands(program: Command): void {
         ({ client, signal }) =>
           getEvalIterationTraceOperation.execute(
             {
-              project: resolved.project ?? options.project,
               runId: options.run,
               iterationId: options.iteration,
-            },
+              ...(resolved.project === undefined
+                ? {}
+                : { project: resolved.project }),
+            } as Parameters<typeof getEvalIterationTraceOperation.execute>[0],
             { client, signal }
           ),
-        { projectScope: resolved.projectScope }
+        {
+          projectScope: resolved.projectScope,
+          quiet: globalOptions.quiet,
+        }
       );
 
       let shots = extractRenderedScreenshots(result);
@@ -2549,13 +2554,18 @@ export function registerEvalCommands(program: Command): void {
         ({ client, signal }) =>
           getEvalIterationTraceOperation.execute(
             {
-              project: resolved.project ?? options.project,
               runId: options.run,
               iterationId: options.iteration,
-            },
+              ...(resolved.project === undefined
+                ? {}
+                : { project: resolved.project }),
+            } as Parameters<typeof getEvalIterationTraceOperation.execute>[0],
             { client, signal }
           ),
-        { projectScope: resolved.projectScope }
+        {
+          projectScope: resolved.projectScope,
+          quiet: globalOptions.quiet,
+        }
       );
 
       const videoUrl = extractIterationVideoUrl(result);

--- a/cli/src/commands/eval.ts
+++ b/cli/src/commands/eval.ts
@@ -563,7 +563,7 @@ function validateOpInput<TInput>(
       .join("; ");
     throw usageError(`Invalid input: ${detail}`);
   }
-  return parsed.data;
+  return parsed.data as TInput;
 }
 
 /** Run an operation with a pre-validated input and print the result. */

--- a/cli/src/commands/eval.ts
+++ b/cli/src/commands/eval.ts
@@ -775,7 +775,7 @@ const DEFAULT_GATE_WAIT_TIMEOUT_MS = 600_000;
 async function runEvalGate(
   options: PlatformOptions &
     EvalGateOptions & {
-      project: string;
+      project?: string;
       run: string;
       wait?: boolean;
       waitTimeout?: string;
@@ -938,7 +938,7 @@ async function runEvalGate(
 async function runEvalCompare(
   options: PlatformOptions &
     EvalCompareOptions & {
-      project: string;
+      project?: string;
       run: string;
       baseRun?: string;
       reporter?: string;
@@ -2103,48 +2103,48 @@ export function registerEvalCommands(program: Command): void {
   );
 
   // ── Eval run iterations + traces ───────────────────────────────────
+      addProjectOption(
       evals
       .command("iterations")
       .description(
         "List per-iteration results for an eval run (pass/fail, tool calls, tokens, latency)"
       )
       .requiredOption("--run <id>", "Eval run ID (from `eval run`)")
-      .requiredOption(
-        "--project <id-or-name>",
-        "Project the run belongs to (name or ID)"
       )
       .option("--cursor <cursor>", "Pagination cursor from a previous response")
       .option("--limit <n>", "Max iterations per page (1–200)").action(
     async (
       options: PlatformOptions & {
-        project: string;
+        project?: string;
         run: string;
         cursor?: string;
         limit?: string;
       },
       command
     ) => {
-      const input = validateOpInput(listEvalRunIterationsOperation, {
-        project: options.project,
-        runId: options.run,
-        ...(options.cursor !== undefined ? { cursor: options.cursor } : {}),
-        ...(options.limit !== undefined
-          ? { limit: Number(options.limit) }
-          : {}),
-      });
-      await executeOp(listEvalRunIterationsOperation, input, options, command);
+      await executeOp(
+        listEvalRunIterationsOperation,
+        {
+          runId: options.run,
+          ...(options.project === undefined ? {} : { project: options.project }),
+          ...(options.cursor !== undefined ? { cursor: options.cursor } : {}),
+          ...(options.limit !== undefined
+            ? { limit: Number(options.limit) }
+            : {}),
+        } as Parameters<typeof listEvalRunIterationsOperation.execute>[0],
+        options,
+        command
+      );
     }
   );
 
+      addProjectOption(
       evals
       .command("gate")
       .description(
         "Apply a pass/fail policy to a finished eval run and set an exit code (0 pass, 1 eval failure, 2 usage, 3 incomplete)"
       )
       .requiredOption("--run <id>", "Eval run ID (from `eval run`)")
-      .requiredOption(
-        "--project <id-or-name>",
-        "Project the run belongs to (name or ID)"
       )
       .option(
         "--min-pass-rate-percent <0-100>",
@@ -2174,7 +2174,7 @@ export function registerEvalCommands(program: Command): void {
     async (
       options: PlatformOptions &
         EvalGateOptions & {
-          project: string;
+          project?: string;
           run: string;
           wait?: boolean;
           waitTimeout?: string;
@@ -2185,15 +2185,13 @@ export function registerEvalCommands(program: Command): void {
     }
   );
 
+      addProjectOption(
       evals
       .command("compare")
       .description(
         "Compare a finished eval run against a baseline and set an exit code (0 pass, 1 regression, 2 usage, 3 incomplete)"
       )
       .requiredOption("--run <id>", "Eval run ID to compare")
-      .requiredOption(
-        "--project <id-or-name>",
-        "Project the run belongs to (name or ID)"
       )
       .option(
         "--base-run <id>",
@@ -2227,7 +2225,7 @@ export function registerEvalCommands(program: Command): void {
     async (
       options: PlatformOptions &
         EvalCompareOptions & {
-          project: string;
+          project?: string;
           run: string;
           baseRun?: string;
           reporter?: string;
@@ -2319,6 +2317,7 @@ export function registerEvalCommands(program: Command): void {
     }
   );
 
+      addProjectOption(
       evals
       .command("trace")
       .description(
@@ -2329,13 +2328,10 @@ export function registerEvalCommands(program: Command): void {
         "--iteration <id>",
         "Iteration ID (from `eval iterations`)"
       )
-      .requiredOption(
-        "--project <id-or-name>",
-        "Project the run belongs to (name or ID)"
       ).action(
     async (
       options: PlatformOptions & {
-        project: string;
+        project?: string;
         run: string;
         iteration: string;
       },
@@ -2344,16 +2340,17 @@ export function registerEvalCommands(program: Command): void {
       await executeOp(
         getEvalIterationTraceOperation,
         {
-          project: options.project,
           runId: options.run,
           iterationId: options.iteration,
-        },
+          ...(options.project === undefined ? {} : { project: options.project }),
+        } as Parameters<typeof getEvalIterationTraceOperation.execute>[0],
         options,
         command
       );
     }
   );
 
+      addProjectOption(
       evals
       .command("steps")
       .description(
@@ -2364,13 +2361,10 @@ export function registerEvalCommands(program: Command): void {
         "--iteration <id>",
         "Iteration ID (from `eval iterations`)"
       )
-      .requiredOption(
-        "--project <id-or-name>",
-        "Project the run belongs to (name or ID)"
       ).action(
     async (
       options: PlatformOptions & {
-        project: string;
+        project?: string;
         run: string;
         iteration: string;
       },
@@ -2379,16 +2373,17 @@ export function registerEvalCommands(program: Command): void {
       await executeOp(
         getEvalRunStepsOperation,
         {
-          project: options.project,
           runId: options.run,
           iterationId: options.iteration,
-        },
+          ...(options.project === undefined ? {} : { project: options.project }),
+        } as Parameters<typeof getEvalRunStepsOperation.execute>[0],
         options,
         command
       );
     }
   );
 
+      addProjectOption(
       evals
       .command("screenshot")
       .description(
@@ -2399,9 +2394,6 @@ export function registerEvalCommands(program: Command): void {
         "--iteration <id>",
         "Iteration ID (from `eval iterations`)"
       )
-      .requiredOption(
-        "--project <id-or-name>",
-        "Project the run belongs to (name or ID)"
       )
       .option(
         "--out <path>",
@@ -2410,7 +2402,7 @@ export function registerEvalCommands(program: Command): void {
       .option("--index <n>", "Show only the Nth screenshot (1-based)").action(
     async (
       options: PlatformOptions & {
-        project: string;
+        project?: string;
         run: string;
         iteration: string;
         out?: string;
@@ -2524,6 +2516,7 @@ export function registerEvalCommands(program: Command): void {
     }
   );
 
+      addProjectOption(
       evals
       .command("video")
       .description(
@@ -2534,9 +2527,6 @@ export function registerEvalCommands(program: Command): void {
         "--iteration <id>",
         "Iteration ID (from `eval iterations`)"
       )
-      .requiredOption(
-        "--project <id-or-name>",
-        "Project the run belongs to (name or ID)"
       )
       .option(
         "--out <path>",
@@ -2544,7 +2534,7 @@ export function registerEvalCommands(program: Command): void {
       ).action(
     async (
       options: PlatformOptions & {
-        project: string;
+        project?: string;
         run: string;
         iteration: string;
         out?: string;

--- a/cli/src/commands/eval.ts
+++ b/cli/src/commands/eval.ts
@@ -121,6 +121,7 @@ import {
 } from "../lib/reporting.js";
 import { DEFAULT_PLATFORM_ORIGIN } from "../lib/platform-auth.js";
 import {
+  addProjectOption,
   platformOptionsOf,
   runPlatformOperation as runPlatformCommand,
   runCloudOp,
@@ -1921,13 +1922,14 @@ export function registerEvalCommands(program: Command): void {
     }
   );
 
+      addProjectOption(
       evals
       .command("status")
       .description("Get the status and summary of an eval run")
       .requiredOption("--run <id>", "Eval run ID (from `eval run`)")
-      .requiredOption("--project <id-or-name>", "Project name or ID").action(
+      ).action(
     async (
-      options: PlatformOptions & { project: string; run: string },
+      options: PlatformOptions & { project?: string; run: string },
       command
     ) => {
       const globalOptions = getGlobalOptions(command);
@@ -1939,11 +1941,19 @@ export function registerEvalCommands(program: Command): void {
         (context) => {
           webOrigin = context.webOrigin;
           return getEvalRunOperation.execute(
-            { project: resolved.project ?? options.project, runId: options.run },
+            {
+              runId: options.run,
+              ...(resolved.project === undefined
+                ? {}
+                : { project: resolved.project }),
+            } as { project: string; runId: string },
             { client: context.client, signal: context.signal }
           );
         },
-        { projectScope: resolved.projectScope }
+        {
+          projectScope: resolved.projectScope,
+          quiet: globalOptions.quiet,
+        }
       );
       writeResult(result, globalOptions.format);
       writeJudgeSummary(globalOptions.format, result.run.judges);
@@ -1955,33 +1965,38 @@ export function registerEvalCommands(program: Command): void {
     }
   );
 
+      addProjectOption(
       evals
       .command("cancel")
       .description(
         "Cancel an in-flight eval run (no-op if already cancelled; errors if it already finished)"
       )
       .requiredOption("--run <id>", "Eval run ID (from `eval run`)")
-      .requiredOption("--project <id-or-name>", "Project name or ID").action(
+      ).action(
     async (
-      options: PlatformOptions & { project: string; run: string },
+      options: PlatformOptions & { project?: string; run: string },
       command
     ) => {
       await executeOp(
         cancelEvalRunOperation,
-        { project: options.project, runId: options.run },
+        {
+          runId: options.run,
+          ...(options.project === undefined ? {} : { project: options.project }),
+        } as { project: string; runId: string },
         options,
         command
       );
     }
   );
 
+      addProjectOption(
       evals
       .command("judge")
       .description(
         "Grade a finished eval run with LLM as Judge (SPENDS your model budget)"
       )
       .requiredOption("--run <id>", "Eval run ID (from `eval run`)")
-      .requiredOption("--project <id-or-name>", "Project name or ID")
+      )
       .option("--force", "Re-grade a run that already has a judge result")
       .option(
         "--enable",
@@ -1991,7 +2006,7 @@ export function registerEvalCommands(program: Command): void {
       .option("--judge-threshold <0-1>", "Pass threshold for this run only").action(
     async (
       options: PlatformOptions & {
-        project: string;
+        project?: string;
         run: string;
         force?: boolean;
         enable?: boolean;
@@ -2004,17 +2019,21 @@ export function registerEvalCommands(program: Command): void {
         options.judgeThreshold !== undefined
           ? parseJudgeThreshold(options.judgeThreshold)
           : undefined;
-      const input = validateOpInput(requestEvalRunJudgeOperation, {
-        project: options.project,
-        runId: options.run,
-        ...(options.force ? { force: true } : {}),
-        ...(options.enable ? { enable: true } : {}),
-        ...(options.judgeModel !== undefined
-          ? { model: options.judgeModel }
-          : {}),
-        ...(threshold !== undefined ? { threshold } : {}),
-      });
-      await executeOp(requestEvalRunJudgeOperation, input, options, command);
+      await executeOp(
+        requestEvalRunJudgeOperation,
+        {
+          runId: options.run,
+          ...(options.project === undefined ? {} : { project: options.project }),
+          ...(options.force ? { force: true } : {}),
+          ...(options.enable ? { enable: true } : {}),
+          ...(options.judgeModel !== undefined
+            ? { model: options.judgeModel }
+            : {}),
+          ...(threshold !== undefined ? { threshold } : {}),
+        } as Parameters<typeof requestEvalRunJudgeOperation.execute>[0],
+        options,
+        command
+      );
     }
   );
 

--- a/cli/src/commands/eval.ts
+++ b/cli/src/commands/eval.ts
@@ -523,12 +523,40 @@ function loadBodyObject(options: {
   return base as Record<string, unknown>;
 }
 
+/**
+ * Operation schemas still require `project`. Cloud CLI fills that later
+ * from `--project` / env / link / automatic, so callers that validate
+ * before `executeOp` must drop the requirement.
+ */
+function schemaWithOptionalProject<TInput>(
+  schema: PlatformOperation<TInput, unknown>["inputSchema"]
+): PlatformOperation<TInput, unknown>["inputSchema"] {
+  const objectSchema = schema as {
+    shape?: Record<string, unknown>;
+    partial?: (
+      mask: { project: true }
+    ) => PlatformOperation<TInput, unknown>["inputSchema"];
+  };
+  if (
+    objectSchema.shape !== undefined &&
+    "project" in objectSchema.shape &&
+    typeof objectSchema.partial === "function"
+  ) {
+    return objectSchema.partial({ project: true });
+  }
+  return schema;
+}
+
 /** Validate a merged input object against an operation's schema (usage error on failure). */
 function validateOpInput<TInput>(
   op: PlatformOperation<TInput, unknown>,
-  raw: unknown
+  raw: unknown,
+  extras: { projectOptional?: boolean } = {}
 ): TInput {
-  const parsed = op.inputSchema.safeParse(raw);
+  const schema = extras.projectOptional
+    ? schemaWithOptionalProject(op.inputSchema)
+    : op.inputSchema;
+  const parsed = schema.safeParse(raw);
   if (!parsed.success) {
     const detail = parsed.error.issues
       .map((issue) => `${issue.path.join(".") || "(root)"}: ${issue.message}`)
@@ -2019,7 +2047,7 @@ export function registerEvalCommands(program: Command): void {
         options.judgeThreshold !== undefined
           ? parseJudgeThreshold(options.judgeThreshold)
           : undefined;
-      await executeOp(
+      const input = validateOpInput(
         requestEvalRunJudgeOperation,
         {
           runId: options.run,
@@ -2030,7 +2058,12 @@ export function registerEvalCommands(program: Command): void {
             ? { model: options.judgeModel }
             : {}),
           ...(threshold !== undefined ? { threshold } : {}),
-        } as Parameters<typeof requestEvalRunJudgeOperation.execute>[0],
+        },
+        { projectOptional: true }
+      );
+      await executeOp(
+        requestEvalRunJudgeOperation,
+        input,
         options,
         command
       );
@@ -2122,7 +2155,7 @@ export function registerEvalCommands(program: Command): void {
       },
       command
     ) => {
-      await executeOp(
+      const input = validateOpInput(
         listEvalRunIterationsOperation,
         {
           runId: options.run,
@@ -2131,7 +2164,12 @@ export function registerEvalCommands(program: Command): void {
           ...(options.limit !== undefined
             ? { limit: Number(options.limit) }
             : {}),
-        } as Parameters<typeof listEvalRunIterationsOperation.execute>[0],
+        },
+        { projectOptional: true }
+      );
+      await executeOp(
+        listEvalRunIterationsOperation,
+        input,
         options,
         command
       );

--- a/cli/src/commands/sessions.ts
+++ b/cli/src/commands/sessions.ts
@@ -3,14 +3,14 @@
  * sessions.
  *
  * `search` spans every surface (Playground, user testing, evals, swarms).
- * `list` is the older Playground-only listing (`chat-sessions list`): all
- * accessible projects unless `--project` is given. Ambient `.mcpjam/project.json`
- * does not narrow `list`; that stays an explicit flag until the shared
- * project-selection rule lands.
+ * `list` is the older Playground-only listing (`chat-sessions list`). It uses
+ * the shared project-selection rule; pass `--all-projects` to list across
+ * every accessible project (the previous default).
  */
-import type { Command } from "commander";
+import { Option, type Command } from "commander";
 import {
   listChatSessionsOperation,
+  resolveProject,
   searchSessionsOperation,
   type PlatformOperation,
 } from "@mcpjam/sdk/platform";
@@ -23,6 +23,10 @@ import {
   runPlatformOperation as runPlatformCommand,
   type PlatformOptions,
 } from "../lib/platform-command.js";
+import {
+  appendProjectLinkHint,
+  resolveCloudProjectArgs,
+} from "../lib/cloud-scope.js";
 import { getGlobalOptions } from "../lib/server-config.js";
 
 type SearchOptions = PlatformOptions & {
@@ -80,12 +84,19 @@ export function registerSessionsCommands(program: Command): void {
       "List Playground chat sessions, or search conversations across Playground, user testing, evals and swarms."
     );
 
-  sessions
-    .command("list")
-    .description(
-      "List Playground chat sessions, newest first (all accessible projects unless --project is given)"
+  addProjectOption(
+    sessions
+      .command("list")
+      .description(
+        "List Playground chat sessions, newest first (one project; pass --all-projects to include every accessible project)"
+      )
+  )
+    .addOption(
+      new Option(
+        "--all-projects",
+        "List sessions across every accessible project, ignoring the project link and MCPJAM_PROJECT"
+      ).conflicts("project")
     )
-    .option("--project <id-or-name>", "Restrict to one project")
     .option("--status <status>", "Filter by session status")
     .option("--limit <n>", "Maximum sessions to return (1-200)", (value) =>
       Number.parseInt(value, 10)
@@ -94,32 +105,67 @@ export function registerSessionsCommands(program: Command): void {
       async (
         options: PlatformOptions & {
           project?: string;
+          allProjects?: boolean;
           status?: string;
           limit?: number;
         },
         command
       ) => {
-        const input = validateOpInput(listChatSessionsOperation, {
-          ...(options.project === undefined ? {} : { project: options.project }),
-          ...(options.status === undefined ? {} : { status: options.status }),
-          ...(options.limit === undefined ? {} : { limit: options.limit }),
-        });
         const globalOptions = getGlobalOptions(command);
+        if (options.allProjects) {
+          const input = validateOpInput(listChatSessionsOperation, {
+            ...(options.status === undefined ? {} : { status: options.status }),
+            ...(options.limit === undefined ? {} : { limit: options.limit }),
+          });
+          const result = await runPlatformCommand(
+            platformOptionsOf(command),
+            globalOptions.timeout,
+            ({ client, signal }) =>
+              listChatSessionsOperation.execute(input, { client, signal }),
+            {
+              quiet: globalOptions.quiet,
+              cloudScope: { kind: "all-projects" },
+            }
+          );
+          writeResult(result, globalOptions.format);
+          return;
+        }
+
+        const resolved = resolveCloudProjectArgs(options);
         const result = await runPlatformCommand(
           platformOptionsOf(command),
           globalOptions.timeout,
-          ({ client, signal }) =>
-            listChatSessionsOperation.execute(input, { client, signal }),
+          async ({ client, signal }) => {
+            let project = resolved.project;
+            if (project === undefined) {
+              const page = await client.listProjects({}, { signal });
+              const resolution = resolveProject(page.items, undefined);
+              if (!resolution.ok) {
+                throw usageError(
+                  appendProjectLinkHint(
+                    resolution.message,
+                    resolved.projectScope
+                  )
+                );
+              }
+              project = resolution.project.id;
+            }
+            const input = validateOpInput(listChatSessionsOperation, {
+              project,
+              ...(options.status === undefined
+                ? {}
+                : { status: options.status }),
+              ...(options.limit === undefined ? {} : { limit: options.limit }),
+            });
+            return listChatSessionsOperation.execute(input, {
+              client,
+              signal,
+            });
+          },
           {
             quiet: globalOptions.quiet,
-            cloudScope:
-              options.project !== undefined
-                ? {
-                    kind: "project",
-                    selector: options.project,
-                    source: "flag",
-                  }
-                : { kind: "all-projects" },
+            projectScope: resolved.projectScope,
+            cloudScope: resolved.projectScope,
           }
         );
         writeResult(result, globalOptions.format);

--- a/cli/tests/cloud-audience.test.ts
+++ b/cli/tests/cloud-audience.test.ts
@@ -430,8 +430,12 @@ test("environments create rejects a non-string JSON project before any write", a
     ])
   );
   assert.equal(run.exitCode, 2, run.stderr);
-  assert.match(
-    run.stderr,
-    /"project" must be a string when supplied in JSON input/
+  const payload = JSON.parse(run.stderr) as {
+    error?: { code?: string; message?: string };
+  };
+  assert.equal(payload.error?.code, "USAGE_ERROR");
+  assert.equal(
+    payload.error?.message,
+    '"project" must be a string when supplied in JSON input.'
   );
 });

--- a/cli/tests/cloud-project-selection.test.ts
+++ b/cli/tests/cloud-project-selection.test.ts
@@ -281,7 +281,7 @@ test("sessions list rejects --project together with --all-projects", async () =>
     "json",
   ]);
   assert.equal(run.exitCode, 2);
-  assert.match(run.stderr, /cannot be used with option '--project'/i);
+  assert.match(run.stderr, /cannot be used with option '--project/i);
 });
 
 test("sessions list --help shows --all-projects", async () => {

--- a/cli/tests/cloud-project-selection.test.ts
+++ b/cli/tests/cloud-project-selection.test.ts
@@ -64,6 +64,13 @@ async function startFixture(): Promise<{
       );
       return;
     }
+    if (
+      url.pathname ===
+      "/api/v1/projects/proj-alpha/eval-runs/run-1/iterations"
+    ) {
+      res.end(JSON.stringify({ items: [] }));
+      return;
+    }
     res.statusCode = 404;
     res.end(JSON.stringify({ code: "NOT_FOUND", message: url.pathname }));
   });
@@ -149,12 +156,46 @@ function cloudArgv(baseUrl: string, ...args: string[]): string[] {
   ];
 }
 
-test("eval status/cancel/judge help treat --project as optional", async () => {
-  for (const sub of ["status", "cancel", "judge"]) {
+test("eval run-inspection commands treat --project as optional", async () => {
+  for (const sub of [
+    "status",
+    "cancel",
+    "judge",
+    "iterations",
+    "gate",
+    "compare",
+    "trace",
+    "steps",
+    "screenshot",
+    "video",
+  ]) {
     const run = await runCli(["cloud", "eval", sub, "--help"]);
     assert.equal(run.exitCode, 0, run.stderr);
     assert.match(run.stdout, /--project <id-or-name>/);
     assert.doesNotMatch(run.stdout, /required option '--project/);
+  }
+});
+
+test("eval iterations without --project uses automatic project selection", async () => {
+  const fixture = await startFixture();
+  const cwd = mkdtempSync(path.join(tmpdir(), "mcpjam-eval-iterations-"));
+  try {
+    const run = await withEnv(isolatedEnv(), () =>
+      withCwd(cwd, () =>
+        runCli(
+          cloudArgv(fixture.baseUrl, "eval", "iterations", "--run", "run-1")
+        )
+      )
+    );
+    assert.equal(run.exitCode, 0, run.stderr);
+    assert.ok(
+      fixture.requestUrls.some((url) =>
+        url.includes("/projects/proj-alpha/eval-runs/run-1/iterations")
+      ),
+      `expected automatic proj-alpha iterations fetch, saw: ${fixture.requestUrls.join(", ")}`
+    );
+  } finally {
+    await fixture.close();
   }
 });
 

--- a/cli/tests/cloud-project-selection.test.ts
+++ b/cli/tests/cloud-project-selection.test.ts
@@ -1,0 +1,292 @@
+/**
+ * One project-selection rule: remaining eval commands take optional
+ * `--project`, and `sessions list` is project-scoped with `--all-projects`.
+ */
+import assert from "node:assert/strict";
+import { mkdtempSync, mkdirSync, writeFileSync } from "node:fs";
+import { createServer, type Server } from "node:http";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import test from "node:test";
+import { runCli } from "./support/cli-run.js";
+import { projectLinkPathForDir } from "../src/lib/project-link.js";
+
+const PROJECTS = [
+  {
+    id: "proj-alpha",
+    name: "Alpha",
+    description: null,
+    icon: null,
+    organizationId: "org-1",
+    visibility: null,
+    createdAt: 1,
+    updatedAt: 200,
+  },
+  {
+    id: "proj-beta",
+    name: "Beta",
+    description: null,
+    icon: null,
+    organizationId: "org-1",
+    visibility: null,
+    createdAt: 2,
+    updatedAt: 100,
+  },
+];
+
+async function startFixture(): Promise<{
+  baseUrl: string;
+  requestUrls: string[];
+  close: () => Promise<void>;
+}> {
+  const requestUrls: string[] = [];
+  const server: Server = createServer((req, res) => {
+    const url = new URL(req.url ?? "/", "http://fixture");
+    requestUrls.push(`${req.method} ${url.pathname}${url.search}`);
+    res.setHeader("content-type", "application/json");
+    if (url.pathname === "/api/v1/projects") {
+      res.end(JSON.stringify({ items: PROJECTS }));
+      return;
+    }
+    if (url.pathname === "/api/v1/chat-sessions") {
+      res.end(JSON.stringify({ items: [] }));
+      return;
+    }
+    if (url.pathname === "/api/v1/projects/proj-alpha/eval-runs/run-1") {
+      res.end(
+        JSON.stringify({
+          id: "run-1",
+          suiteId: "suite-1",
+          status: "completed",
+          result: "passed",
+          judges: [],
+        })
+      );
+      return;
+    }
+    res.statusCode = 404;
+    res.end(JSON.stringify({ code: "NOT_FOUND", message: url.pathname }));
+  });
+
+  await new Promise<void>((resolve) =>
+    server.listen(0, "127.0.0.1", () => resolve())
+  );
+  const address = server.address();
+  if (!address || typeof address === "string") {
+    throw new Error("fixture server has no address");
+  }
+
+  return {
+    baseUrl: `http://127.0.0.1:${address.port}/api/v1`,
+    requestUrls,
+    close: () =>
+      new Promise<void>((resolve, reject) =>
+        server.close((error) => (error ? reject(error) : resolve()))
+      ),
+  };
+}
+
+async function withCwd<T>(directory: string, fn: () => Promise<T>): Promise<T> {
+  const previous = process.cwd();
+  process.chdir(directory);
+  try {
+    return await fn();
+  } finally {
+    process.chdir(previous);
+  }
+}
+
+async function withEnv<T>(
+  updates: Record<string, string | undefined>,
+  fn: () => Promise<T>
+): Promise<T> {
+  const previous: Record<string, string | undefined> = {};
+  for (const key of Object.keys(updates)) {
+    previous[key] = process.env[key];
+    const value = updates[key];
+    if (value === undefined) {
+      delete process.env[key];
+    } else {
+      process.env[key] = value;
+    }
+  }
+  try {
+    return await fn();
+  } finally {
+    for (const [key, value] of Object.entries(previous)) {
+      if (value === undefined) {
+        delete process.env[key];
+      } else {
+        process.env[key] = value;
+      }
+    }
+  }
+}
+
+function isolatedEnv(
+  extra: Record<string, string | undefined> = {}
+): Record<string, string | undefined> {
+  return {
+    MCPJAM_PROJECT: undefined,
+    MCPJAM_PROJECT_ID: undefined,
+    MCPJAM_API_KEY: undefined,
+    MCPJAM_API_URL: undefined,
+    MCPJAM_AUTH_FILE: path.join(tmpdir(), "mcpjam-no-auth.json"),
+    ...extra,
+  };
+}
+
+function cloudArgv(baseUrl: string, ...args: string[]): string[] {
+  return [
+    "cloud",
+    ...args,
+    "--api-key",
+    "sk_test",
+    "--api-url",
+    baseUrl,
+    "--format",
+    "json",
+  ];
+}
+
+test("eval status/cancel/judge help treat --project as optional", async () => {
+  for (const sub of ["status", "cancel", "judge"]) {
+    const run = await runCli(["cloud", "eval", sub, "--help"]);
+    assert.equal(run.exitCode, 0, run.stderr);
+    assert.match(run.stdout, /--project <id-or-name>/);
+    assert.doesNotMatch(run.stdout, /required option '--project/);
+  }
+});
+
+test("eval status without --project uses automatic project selection", async () => {
+  const fixture = await startFixture();
+  const cwd = mkdtempSync(path.join(tmpdir(), "mcpjam-eval-project-"));
+  try {
+    const run = await withEnv(isolatedEnv(), () =>
+      withCwd(cwd, () =>
+        runCli(cloudArgv(fixture.baseUrl, "eval", "status", "--run", "run-1"))
+      )
+    );
+    assert.equal(run.exitCode, 0, run.stderr);
+    assert.ok(
+      fixture.requestUrls.some((url) =>
+        url.includes("/projects/proj-alpha/eval-runs/run-1")
+      ),
+      `expected automatic proj-alpha run fetch, saw: ${fixture.requestUrls.join(", ")}`
+    );
+    assert.match(
+      run.stderr,
+      /project: automatic \(most recently updated\)/
+    );
+  } finally {
+    await fixture.close();
+  }
+});
+
+test("sessions list without --project scopes to the automatic project", async () => {
+  const fixture = await startFixture();
+  const cwd = mkdtempSync(path.join(tmpdir(), "mcpjam-sessions-auto-"));
+  try {
+    const run = await withEnv(isolatedEnv(), () =>
+      withCwd(cwd, () => runCli(cloudArgv(fixture.baseUrl, "sessions", "list")))
+    );
+    assert.equal(run.exitCode, 0, run.stderr);
+    assert.ok(
+      fixture.requestUrls.some((url) =>
+        url.includes("/chat-sessions") && url.includes("projectId=proj-alpha")
+      ),
+      `expected projectId=proj-alpha, saw: ${fixture.requestUrls.join(", ")}`
+    );
+    assert.match(
+      run.stderr,
+      /project: automatic \(most recently updated\)/
+    );
+  } finally {
+    await fixture.close();
+  }
+});
+
+test("sessions list --all-projects does not send a project filter", async () => {
+  const fixture = await startFixture();
+  const cwd = mkdtempSync(path.join(tmpdir(), "mcpjam-sessions-all-"));
+  try {
+    const run = await withEnv(isolatedEnv(), () =>
+      withCwd(cwd, () =>
+        runCli(cloudArgv(fixture.baseUrl, "sessions", "list", "--all-projects"))
+      )
+    );
+    assert.equal(run.exitCode, 0, run.stderr);
+    const sessionGets = fixture.requestUrls.filter((url) =>
+      url.includes("/chat-sessions")
+    );
+    assert.equal(sessionGets.length, 1);
+    assert.doesNotMatch(sessionGets[0]!, /projectId=/);
+    assert.match(run.stderr, /all projects/);
+  } finally {
+    await fixture.close();
+  }
+});
+
+test("sessions list honors a project link and --all-projects ignores it", async () => {
+  const fixture = await startFixture();
+  const cwd = mkdtempSync(path.join(tmpdir(), "mcpjam-sessions-link-"));
+  const linkPath = projectLinkPathForDir(cwd);
+  mkdirSync(path.dirname(linkPath), { recursive: true });
+  writeFileSync(
+    linkPath,
+    `${JSON.stringify({
+      version: 1,
+      project: { id: "proj-beta", name: "Beta" },
+      apiUrl: fixture.baseUrl,
+    }, null, 2)}\n`
+  );
+  try {
+    const linked = await withEnv(isolatedEnv(), () =>
+      withCwd(cwd, () => runCli(cloudArgv(fixture.baseUrl, "sessions", "list")))
+    );
+    assert.equal(linked.exitCode, 0, linked.stderr);
+    assert.ok(
+      fixture.requestUrls.some((url) =>
+        url.includes("/chat-sessions") && url.includes("projectId=proj-beta")
+      ),
+      `expected linked proj-beta, saw: ${fixture.requestUrls.join(", ")}`
+    );
+
+    fixture.requestUrls.length = 0;
+    const all = await withEnv(isolatedEnv(), () =>
+      withCwd(cwd, () =>
+        runCli(cloudArgv(fixture.baseUrl, "sessions", "list", "--all-projects"))
+      )
+    );
+    assert.equal(all.exitCode, 0, all.stderr);
+    const sessionGets = fixture.requestUrls.filter((url) =>
+      url.includes("/chat-sessions")
+    );
+    assert.equal(sessionGets.length, 1);
+    assert.doesNotMatch(sessionGets[0]!, /projectId=/);
+  } finally {
+    await fixture.close();
+  }
+});
+
+test("sessions list rejects --project together with --all-projects", async () => {
+  const run = await runCli([
+    "cloud",
+    "sessions",
+    "list",
+    "--project",
+    "alpha",
+    "--all-projects",
+    "--format",
+    "json",
+  ]);
+  assert.equal(run.exitCode, 2);
+  assert.match(run.stderr, /cannot be used with option '--project'/i);
+});
+
+test("sessions list --help shows --all-projects", async () => {
+  const run = await runCli(["cloud", "sessions", "list", "--help"]);
+  assert.equal(run.exitCode, 0, run.stderr);
+  assert.match(run.stdout, /--all-projects/);
+  assert.match(run.stdout, /--project <id-or-name>/);
+});

--- a/cli/tests/eval.test.ts
+++ b/cli/tests/eval.test.ts
@@ -1494,6 +1494,61 @@ test("eval judge rejects a blank --judge-threshold before any request", async ()
   }
 });
 
+test("eval judge rejects a blank --judge-model before any request", async () => {
+  const fixture = await startEvalFixture();
+  try {
+    const run = await captureProcessOutput(() =>
+      main(
+        evalArgv(
+          fixture.baseUrl,
+          "judge",
+          "--project",
+          "proj-alpha",
+          "--run",
+          "run-1",
+          "--judge-model",
+          "   ",
+        ),
+        { telemetry: telemetryDisabled },
+      ),
+    );
+    assert.equal(run.result.exitCode, 2, run.stderr);
+    assert.match(run.stderr, /Invalid input:.*model/);
+    assert.equal(fixture.createBodies.length, 0);
+    assert.equal(fixture.authHeaders.length, 0);
+  } finally {
+    await fixture.close();
+  }
+});
+
+test("eval iterations rejects a bad --limit before any request", async () => {
+  const fixture = await startEvalFixture();
+  try {
+    for (const value of ["abc", "0", "201", "-1"]) {
+      const run = await captureProcessOutput(() =>
+        main(
+          evalArgv(
+            fixture.baseUrl,
+            "iterations",
+            "--project",
+            "proj-alpha",
+            "--run",
+            "run-1",
+            "--limit",
+            value,
+          ),
+          { telemetry: telemetryDisabled },
+        ),
+      );
+      assert.equal(run.result.exitCode, 2, `accepted --limit ${JSON.stringify(value)}: ${run.stderr}`);
+      assert.match(run.stderr, /Invalid input:.*limit/);
+    }
+    assert.equal(fixture.authHeaders.length, 0);
+  } finally {
+    await fixture.close();
+  }
+});
+
 test("eval status summarizes the judges that graded, and stays silent about the rest", async () => {
   const fixture = await startEvalFixture();
   try {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Purpose

PR 10 of the CLI local-vs-cloud split. One project-selection rule: `--project` is optional on Cloud eval run-inspection commands, and `sessions list` is project-scoped unless `--all-projects`.

Stacked on #4201. Merge after that PR.

## Review follow-up

Migrated the remaining seven eval commands onto `addProjectOption`:

- `iterations`, `gate`, `compare`, `trace`, `steps`, `screenshot`, `video`

`cloud eval iterations --run run_1` now uses automatic project selection instead of exiting 2 for missing `--project`.

## What changed

- `eval status|cancel|judge|iterations|gate|compare|trace|steps|screenshot|video` take optional `--project`.
- `sessions list` is project-scoped by the shared rule. `--all-projects` restores the old all-projects listing and conflicts with `--project`.

## Rollout

- `"@mcpjam/cli": major` changeset (4.0; hold Version Packages until PR 12)

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-880bc302-7fad-489a-b883-d890bdc3aca6?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-880bc302-7fad-489a-b883-d890bdc3aca6&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Applies one Cloud project-selection rule across eval run-inspection commands and sessions list. Previously eval subcommands required --project and sessions list showed all projects; now both default to the linked/env/automatic project when --project is omitted, and sessions list uses --all-projects to restore the cross-project view.

- Eval commands status|cancel|judge|iterations|gate|compare|trace|steps|screenshot|video accept optional --project and resolve via flag > MCPJAM_PROJECT > .mcpjam/project.json > automatic (most recently updated).
- sessions list scopes to one project by the same rule; --all-projects lists across every accessible project and conflicts with --project.
- Validates judge (--judge-model) and iterations (--limit) inputs before any network request, even when project is omitted.
- Unchanged: projects update|delete|servers still require --project.

**Rollout**
- `@mcpjam/cli`: major (Cloud-only).

<sup>Written for commit f7e70e9f2594ca89e6acff074cc329f759858fa7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/MCPJam/inspector/pull/4202?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

