### PR TITLE
cli: identify local MCP as MCPJam CLI

### DIFF
--- a/.changeset/cli-docs-migration.md
+++ b/.changeset/cli-docs-migration.md
@@ -1,0 +1,5 @@
+---
+"@mcpjam/cli": major
+---
+
+Document CLI 4.0: local testing stays at the top level, account-bound commands live under `mcpjam cloud`, and `docs/cli/migration.mdx` records the command-path and flag changes. Hold Version Packages; do not publish 4.0.0 yet.

--- a/.changeset/cli-local-mcp-identity.md
+++ b/.changeset/cli-local-mcp-identity.md
@@ -1,0 +1,5 @@
+---
+"@mcpjam/cli": major
+---
+
+Local `mcpjam mcp` identifies as title `MCPJam CLI` (name stays `mcpjam`) and its instructions say it is the local testing engine, not the hosted Cloud MCP.

--- a/.changeset/cli-project-selection-rule.md
+++ b/.changeset/cli-project-selection-rule.md
@@ -1,0 +1,5 @@
+---
+"@mcpjam/cli": major
+---
+
+Cloud project selection is one rule: `eval status` / `cancel` / `judge` take optional `--project` (flag, env, link, or automatic). `mcpjam cloud sessions list` is project-scoped the same way; pass `--all-projects` to list across every accessible project.

--- a/cli/README.md
+++ b/cli/README.md
@@ -1,6 +1,6 @@
 # @mcpjam/cli
 
-Test, debug, and validate MCP servers. Health checks, OAuth conformance, tool-surface diffing, and structured triage from the terminal or CI.
+Test, debug, and validate MCP servers locally, or manage MCPJam Cloud via `mcpjam cloud`. Health checks, OAuth conformance, tool-surface diffing, and structured triage from the terminal or CI.
 
 ## Install
 
@@ -16,12 +16,14 @@ npx -y @mcpjam/cli@latest --help
 
 ## Commands
 
+Local MCP testing stays at the top level. Most account-bound commands live under `mcpjam cloud`; hosted readiness is the root-level exception. See the [4.0 migration guide](https://docs.mcpjam.com/cli/migration).
+
 ```
 $ mcpjam --help
 
 Usage: mcpjam [options] [command]
 
-Test, debug, and validate MCP servers. Health checks, OAuth conformance, tool-surface diffing, and structured triage from the terminal or CI.
+Test, debug, and validate MCP servers locally, or manage MCPJam Cloud via `mcpjam cloud`. Health checks, OAuth conformance, tool-surface diffing, and structured triage from the terminal or CI.
 
 Options:
   -v, --version      output the CLI version
@@ -32,18 +34,30 @@ Options:
   --format <format>  Output format
   -h, --help         display help for command
 
-Commands:
+Local MCP testing:
   server             Inspect MCP server connectivity and capabilities
   tools              List and invoke MCP server tools
   resources          List and read MCP resources
+  subscriptions      Open a long-lived MCP subscription and stream its notifications
+  compat             Check whether an MCP server's tools and widgets work on each AI host
   prompts            List and fetch MCP prompts
-  apps               MCP Apps utilities, widget extraction, and conformance checks
+  apps               Validate MCP Apps metadata and resource wiring
+  tasks              Create, inspect and drive MCP Tasks
   oauth              Run MCP OAuth login, proxy, and conformance flows
+  xaa                Run the Cross-App Access (ID-JAG) debugger against an MCP server
   protocol           MCP protocol inspection and conformance checks
+  readiness          Grade a server or plugin against a publisher's directory
+
+MCPJam Cloud:
+  cloud              MCPJam Cloud account commands (login, projects, evals, tunnels)
+
+CLI:
   inspector          Start or attach to the local MCPJam Inspector
   mcp                Run MCPJam as an MCP server over stdio
   telemetry          Inspect and configure anonymous CLI telemetry
 ```
+
+`mcpjam oauth login` authenticates against an MCP server. `mcpjam cloud login` authenticates your MCPJam account. Run `mcpjam cloud --help` for the Cloud groups.
 
 ## Quick start
 
@@ -69,6 +83,11 @@ mcpjam tools list --url https://your-server.com/mcp --access-token $TOKEN --form
 
 # Run MCPJam itself as a stdio MCP server (for Claude Desktop, Claude Code, Cursor, ...)
 mcpjam mcp
+
+# MCPJam Cloud (account-bound)
+mcpjam cloud login
+mcpjam cloud projects list
+mcpjam cloud eval run --suite smoke
 ```
 
 ## Why

--- a/cli/src/commands/eval.ts
+++ b/cli/src/commands/eval.ts
@@ -2423,13 +2423,18 @@ export function registerEvalCommands(program: Command): void {
         ({ client, signal }) =>
           getEvalIterationTraceOperation.execute(
             {
-              project: resolved.project ?? options.project,
               runId: options.run,
               iterationId: options.iteration,
-            },
+              ...(resolved.project === undefined
+                ? {}
+                : { project: resolved.project }),
+            } as Parameters<typeof getEvalIterationTraceOperation.execute>[0],
             { client, signal }
           ),
-        { projectScope: resolved.projectScope }
+        {
+          projectScope: resolved.projectScope,
+          quiet: globalOptions.quiet,
+        }
       );
 
       let shots = extractRenderedScreenshots(result);
@@ -2549,13 +2554,18 @@ export function registerEvalCommands(program: Command): void {
         ({ client, signal }) =>
           getEvalIterationTraceOperation.execute(
             {
-              project: resolved.project ?? options.project,
               runId: options.run,
               iterationId: options.iteration,
-            },
+              ...(resolved.project === undefined
+                ? {}
+                : { project: resolved.project }),
+            } as Parameters<typeof getEvalIterationTraceOperation.execute>[0],
             { client, signal }
           ),
-        { projectScope: resolved.projectScope }
+        {
+          projectScope: resolved.projectScope,
+          quiet: globalOptions.quiet,
+        }
       );
 
       const videoUrl = extractIterationVideoUrl(result);

--- a/cli/src/commands/eval.ts
+++ b/cli/src/commands/eval.ts
@@ -563,7 +563,7 @@ function validateOpInput<TInput>(
       .join("; ");
     throw usageError(`Invalid input: ${detail}`);
   }
-  return parsed.data;
+  return parsed.data as TInput;
 }
 
 /** Run an operation with a pre-validated input and print the result. */

--- a/cli/src/commands/eval.ts
+++ b/cli/src/commands/eval.ts
@@ -775,7 +775,7 @@ const DEFAULT_GATE_WAIT_TIMEOUT_MS = 600_000;
 async function runEvalGate(
   options: PlatformOptions &
     EvalGateOptions & {
-      project: string;
+      project?: string;
       run: string;
       wait?: boolean;
       waitTimeout?: string;
@@ -938,7 +938,7 @@ async function runEvalGate(
 async function runEvalCompare(
   options: PlatformOptions &
     EvalCompareOptions & {
-      project: string;
+      project?: string;
       run: string;
       baseRun?: string;
       reporter?: string;
@@ -2103,48 +2103,48 @@ export function registerEvalCommands(program: Command): void {
   );
 
   // ── Eval run iterations + traces ───────────────────────────────────
+      addProjectOption(
       evals
       .command("iterations")
       .description(
         "List per-iteration results for an eval run (pass/fail, tool calls, tokens, latency)"
       )
       .requiredOption("--run <id>", "Eval run ID (from `eval run`)")
-      .requiredOption(
-        "--project <id-or-name>",
-        "Project the run belongs to (name or ID)"
       )
       .option("--cursor <cursor>", "Pagination cursor from a previous response")
       .option("--limit <n>", "Max iterations per page (1–200)").action(
     async (
       options: PlatformOptions & {
-        project: string;
+        project?: string;
         run: string;
         cursor?: string;
         limit?: string;
       },
       command
     ) => {
-      const input = validateOpInput(listEvalRunIterationsOperation, {
-        project: options.project,
-        runId: options.run,
-        ...(options.cursor !== undefined ? { cursor: options.cursor } : {}),
-        ...(options.limit !== undefined
-          ? { limit: Number(options.limit) }
-          : {}),
-      });
-      await executeOp(listEvalRunIterationsOperation, input, options, command);
+      await executeOp(
+        listEvalRunIterationsOperation,
+        {
+          runId: options.run,
+          ...(options.project === undefined ? {} : { project: options.project }),
+          ...(options.cursor !== undefined ? { cursor: options.cursor } : {}),
+          ...(options.limit !== undefined
+            ? { limit: Number(options.limit) }
+            : {}),
+        } as Parameters<typeof listEvalRunIterationsOperation.execute>[0],
+        options,
+        command
+      );
     }
   );
 
+      addProjectOption(
       evals
       .command("gate")
       .description(
         "Apply a pass/fail policy to a finished eval run and set an exit code (0 pass, 1 eval failure, 2 usage, 3 incomplete)"
       )
       .requiredOption("--run <id>", "Eval run ID (from `eval run`)")
-      .requiredOption(
-        "--project <id-or-name>",
-        "Project the run belongs to (name or ID)"
       )
       .option(
         "--min-pass-rate-percent <0-100>",
@@ -2174,7 +2174,7 @@ export function registerEvalCommands(program: Command): void {
     async (
       options: PlatformOptions &
         EvalGateOptions & {
-          project: string;
+          project?: string;
           run: string;
           wait?: boolean;
           waitTimeout?: string;
@@ -2185,15 +2185,13 @@ export function registerEvalCommands(program: Command): void {
     }
   );
 
+      addProjectOption(
       evals
       .command("compare")
       .description(
         "Compare a finished eval run against a baseline and set an exit code (0 pass, 1 regression, 2 usage, 3 incomplete)"
       )
       .requiredOption("--run <id>", "Eval run ID to compare")
-      .requiredOption(
-        "--project <id-or-name>",
-        "Project the run belongs to (name or ID)"
       )
       .option(
         "--base-run <id>",
@@ -2227,7 +2225,7 @@ export function registerEvalCommands(program: Command): void {
     async (
       options: PlatformOptions &
         EvalCompareOptions & {
-          project: string;
+          project?: string;
           run: string;
           baseRun?: string;
           reporter?: string;
@@ -2319,6 +2317,7 @@ export function registerEvalCommands(program: Command): void {
     }
   );
 
+      addProjectOption(
       evals
       .command("trace")
       .description(
@@ -2329,13 +2328,10 @@ export function registerEvalCommands(program: Command): void {
         "--iteration <id>",
         "Iteration ID (from `eval iterations`)"
       )
-      .requiredOption(
-        "--project <id-or-name>",
-        "Project the run belongs to (name or ID)"
       ).action(
     async (
       options: PlatformOptions & {
-        project: string;
+        project?: string;
         run: string;
         iteration: string;
       },
@@ -2344,16 +2340,17 @@ export function registerEvalCommands(program: Command): void {
       await executeOp(
         getEvalIterationTraceOperation,
         {
-          project: options.project,
           runId: options.run,
           iterationId: options.iteration,
-        },
+          ...(options.project === undefined ? {} : { project: options.project }),
+        } as Parameters<typeof getEvalIterationTraceOperation.execute>[0],
         options,
         command
       );
     }
   );
 
+      addProjectOption(
       evals
       .command("steps")
       .description(
@@ -2364,13 +2361,10 @@ export function registerEvalCommands(program: Command): void {
         "--iteration <id>",
         "Iteration ID (from `eval iterations`)"
       )
-      .requiredOption(
-        "--project <id-or-name>",
-        "Project the run belongs to (name or ID)"
       ).action(
     async (
       options: PlatformOptions & {
-        project: string;
+        project?: string;
         run: string;
         iteration: string;
       },
@@ -2379,16 +2373,17 @@ export function registerEvalCommands(program: Command): void {
       await executeOp(
         getEvalRunStepsOperation,
         {
-          project: options.project,
           runId: options.run,
           iterationId: options.iteration,
-        },
+          ...(options.project === undefined ? {} : { project: options.project }),
+        } as Parameters<typeof getEvalRunStepsOperation.execute>[0],
         options,
         command
       );
     }
   );
 
+      addProjectOption(
       evals
       .command("screenshot")
       .description(
@@ -2399,9 +2394,6 @@ export function registerEvalCommands(program: Command): void {
         "--iteration <id>",
         "Iteration ID (from `eval iterations`)"
       )
-      .requiredOption(
-        "--project <id-or-name>",
-        "Project the run belongs to (name or ID)"
       )
       .option(
         "--out <path>",
@@ -2410,7 +2402,7 @@ export function registerEvalCommands(program: Command): void {
       .option("--index <n>", "Show only the Nth screenshot (1-based)").action(
     async (
       options: PlatformOptions & {
-        project: string;
+        project?: string;
         run: string;
         iteration: string;
         out?: string;
@@ -2524,6 +2516,7 @@ export function registerEvalCommands(program: Command): void {
     }
   );
 
+      addProjectOption(
       evals
       .command("video")
       .description(
@@ -2534,9 +2527,6 @@ export function registerEvalCommands(program: Command): void {
         "--iteration <id>",
         "Iteration ID (from `eval iterations`)"
       )
-      .requiredOption(
-        "--project <id-or-name>",
-        "Project the run belongs to (name or ID)"
       )
       .option(
         "--out <path>",
@@ -2544,7 +2534,7 @@ export function registerEvalCommands(program: Command): void {
       ).action(
     async (
       options: PlatformOptions & {
-        project: string;
+        project?: string;
         run: string;
         iteration: string;
         out?: string;

--- a/cli/src/commands/eval.ts
+++ b/cli/src/commands/eval.ts
@@ -121,6 +121,7 @@ import {
 } from "../lib/reporting.js";
 import { DEFAULT_PLATFORM_ORIGIN } from "../lib/platform-auth.js";
 import {
+  addProjectOption,
   platformOptionsOf,
   runPlatformOperation as runPlatformCommand,
   runCloudOp,
@@ -1921,13 +1922,14 @@ export function registerEvalCommands(program: Command): void {
     }
   );
 
+      addProjectOption(
       evals
       .command("status")
       .description("Get the status and summary of an eval run")
       .requiredOption("--run <id>", "Eval run ID (from `eval run`)")
-      .requiredOption("--project <id-or-name>", "Project name or ID").action(
+      ).action(
     async (
-      options: PlatformOptions & { project: string; run: string },
+      options: PlatformOptions & { project?: string; run: string },
       command
     ) => {
       const globalOptions = getGlobalOptions(command);
@@ -1939,11 +1941,19 @@ export function registerEvalCommands(program: Command): void {
         (context) => {
           webOrigin = context.webOrigin;
           return getEvalRunOperation.execute(
-            { project: resolved.project ?? options.project, runId: options.run },
+            {
+              runId: options.run,
+              ...(resolved.project === undefined
+                ? {}
+                : { project: resolved.project }),
+            } as { project: string; runId: string },
             { client: context.client, signal: context.signal }
           );
         },
-        { projectScope: resolved.projectScope }
+        {
+          projectScope: resolved.projectScope,
+          quiet: globalOptions.quiet,
+        }
       );
       writeResult(result, globalOptions.format);
       writeJudgeSummary(globalOptions.format, result.run.judges);
@@ -1955,33 +1965,38 @@ export function registerEvalCommands(program: Command): void {
     }
   );
 
+      addProjectOption(
       evals
       .command("cancel")
       .description(
         "Cancel an in-flight eval run (no-op if already cancelled; errors if it already finished)"
       )
       .requiredOption("--run <id>", "Eval run ID (from `eval run`)")
-      .requiredOption("--project <id-or-name>", "Project name or ID").action(
+      ).action(
     async (
-      options: PlatformOptions & { project: string; run: string },
+      options: PlatformOptions & { project?: string; run: string },
       command
     ) => {
       await executeOp(
         cancelEvalRunOperation,
-        { project: options.project, runId: options.run },
+        {
+          runId: options.run,
+          ...(options.project === undefined ? {} : { project: options.project }),
+        } as { project: string; runId: string },
         options,
         command
       );
     }
   );
 
+      addProjectOption(
       evals
       .command("judge")
       .description(
         "Grade a finished eval run with LLM as Judge (SPENDS your model budget)"
       )
       .requiredOption("--run <id>", "Eval run ID (from `eval run`)")
-      .requiredOption("--project <id-or-name>", "Project name or ID")
+      )
       .option("--force", "Re-grade a run that already has a judge result")
       .option(
         "--enable",
@@ -1991,7 +2006,7 @@ export function registerEvalCommands(program: Command): void {
       .option("--judge-threshold <0-1>", "Pass threshold for this run only").action(
     async (
       options: PlatformOptions & {
-        project: string;
+        project?: string;
         run: string;
         force?: boolean;
         enable?: boolean;
@@ -2004,17 +2019,21 @@ export function registerEvalCommands(program: Command): void {
         options.judgeThreshold !== undefined
           ? parseJudgeThreshold(options.judgeThreshold)
           : undefined;
-      const input = validateOpInput(requestEvalRunJudgeOperation, {
-        project: options.project,
-        runId: options.run,
-        ...(options.force ? { force: true } : {}),
-        ...(options.enable ? { enable: true } : {}),
-        ...(options.judgeModel !== undefined
-          ? { model: options.judgeModel }
-          : {}),
-        ...(threshold !== undefined ? { threshold } : {}),
-      });
-      await executeOp(requestEvalRunJudgeOperation, input, options, command);
+      await executeOp(
+        requestEvalRunJudgeOperation,
+        {
+          runId: options.run,
+          ...(options.project === undefined ? {} : { project: options.project }),
+          ...(options.force ? { force: true } : {}),
+          ...(options.enable ? { enable: true } : {}),
+          ...(options.judgeModel !== undefined
+            ? { model: options.judgeModel }
+            : {}),
+          ...(threshold !== undefined ? { threshold } : {}),
+        } as Parameters<typeof requestEvalRunJudgeOperation.execute>[0],
+        options,
+        command
+      );
     }
   );
 

--- a/cli/src/commands/eval.ts
+++ b/cli/src/commands/eval.ts
@@ -523,12 +523,40 @@ function loadBodyObject(options: {
   return base as Record<string, unknown>;
 }
 
+/**
+ * Operation schemas still require `project`. Cloud CLI fills that later
+ * from `--project` / env / link / automatic, so callers that validate
+ * before `executeOp` must drop the requirement.
+ */
+function schemaWithOptionalProject<TInput>(
+  schema: PlatformOperation<TInput, unknown>["inputSchema"]
+): PlatformOperation<TInput, unknown>["inputSchema"] {
+  const objectSchema = schema as {
+    shape?: Record<string, unknown>;
+    partial?: (
+      mask: { project: true }
+    ) => PlatformOperation<TInput, unknown>["inputSchema"];
+  };
+  if (
+    objectSchema.shape !== undefined &&
+    "project" in objectSchema.shape &&
+    typeof objectSchema.partial === "function"
+  ) {
+    return objectSchema.partial({ project: true });
+  }
+  return schema;
+}
+
 /** Validate a merged input object against an operation's schema (usage error on failure). */
 function validateOpInput<TInput>(
   op: PlatformOperation<TInput, unknown>,
-  raw: unknown
+  raw: unknown,
+  extras: { projectOptional?: boolean } = {}
 ): TInput {
-  const parsed = op.inputSchema.safeParse(raw);
+  const schema = extras.projectOptional
+    ? schemaWithOptionalProject(op.inputSchema)
+    : op.inputSchema;
+  const parsed = schema.safeParse(raw);
   if (!parsed.success) {
     const detail = parsed.error.issues
       .map((issue) => `${issue.path.join(".") || "(root)"}: ${issue.message}`)
@@ -2019,7 +2047,7 @@ export function registerEvalCommands(program: Command): void {
         options.judgeThreshold !== undefined
           ? parseJudgeThreshold(options.judgeThreshold)
           : undefined;
-      await executeOp(
+      const input = validateOpInput(
         requestEvalRunJudgeOperation,
         {
           runId: options.run,
@@ -2030,7 +2058,12 @@ export function registerEvalCommands(program: Command): void {
             ? { model: options.judgeModel }
             : {}),
           ...(threshold !== undefined ? { threshold } : {}),
-        } as Parameters<typeof requestEvalRunJudgeOperation.execute>[0],
+        },
+        { projectOptional: true }
+      );
+      await executeOp(
+        requestEvalRunJudgeOperation,
+        input,
         options,
         command
       );
@@ -2122,7 +2155,7 @@ export function registerEvalCommands(program: Command): void {
       },
       command
     ) => {
-      await executeOp(
+      const input = validateOpInput(
         listEvalRunIterationsOperation,
         {
           runId: options.run,
@@ -2131,7 +2164,12 @@ export function registerEvalCommands(program: Command): void {
           ...(options.limit !== undefined
             ? { limit: Number(options.limit) }
             : {}),
-        } as Parameters<typeof listEvalRunIterationsOperation.execute>[0],
+        },
+        { projectOptional: true }
+      );
+      await executeOp(
+        listEvalRunIterationsOperation,
+        input,
         options,
         command
       );

--- a/cli/src/commands/mcp.ts
+++ b/cli/src/commands/mcp.ts
@@ -33,7 +33,7 @@ export function registerMcpCommands(program: Command): void {
 
         if (!globalOptions.quiet) {
           // stdout carries JSON-RPC in this mode; status goes to stderr only.
-          process.stderr.write("MCPJam MCP server listening on stdio\n");
+          process.stderr.write("MCPJam CLI MCP server listening on stdio\n");
         }
 
         await closed;

--- a/cli/src/commands/sessions.ts
+++ b/cli/src/commands/sessions.ts
@@ -3,14 +3,14 @@
  * sessions.
  *
  * `search` spans every surface (Playground, user testing, evals, swarms).
- * `list` is the older Playground-only listing (`chat-sessions list`): all
- * accessible projects unless `--project` is given. Ambient `.mcpjam/project.json`
- * does not narrow `list`; that stays an explicit flag until the shared
- * project-selection rule lands.
+ * `list` is the older Playground-only listing (`chat-sessions list`). It uses
+ * the shared project-selection rule; pass `--all-projects` to list across
+ * every accessible project (the previous default).
  */
-import type { Command } from "commander";
+import { Option, type Command } from "commander";
 import {
   listChatSessionsOperation,
+  resolveProject,
   searchSessionsOperation,
   type PlatformOperation,
 } from "@mcpjam/sdk/platform";
@@ -23,6 +23,10 @@ import {
   runPlatformOperation as runPlatformCommand,
   type PlatformOptions,
 } from "../lib/platform-command.js";
+import {
+  appendProjectLinkHint,
+  resolveCloudProjectArgs,
+} from "../lib/cloud-scope.js";
 import { getGlobalOptions } from "../lib/server-config.js";
 
 type SearchOptions = PlatformOptions & {
@@ -80,12 +84,19 @@ export function registerSessionsCommands(program: Command): void {
       "List Playground chat sessions, or search conversations across Playground, user testing, evals and swarms."
     );
 
-  sessions
-    .command("list")
-    .description(
-      "List Playground chat sessions, newest first (all accessible projects unless --project is given)"
+  addProjectOption(
+    sessions
+      .command("list")
+      .description(
+        "List Playground chat sessions, newest first (one project; pass --all-projects to include every accessible project)"
+      )
+  )
+    .addOption(
+      new Option(
+        "--all-projects",
+        "List sessions across every accessible project, ignoring the project link and MCPJAM_PROJECT"
+      ).conflicts("project")
     )
-    .option("--project <id-or-name>", "Restrict to one project")
     .option("--status <status>", "Filter by session status")
     .option("--limit <n>", "Maximum sessions to return (1-200)", (value) =>
       Number.parseInt(value, 10)
@@ -94,32 +105,67 @@ export function registerSessionsCommands(program: Command): void {
       async (
         options: PlatformOptions & {
           project?: string;
+          allProjects?: boolean;
           status?: string;
           limit?: number;
         },
         command
       ) => {
-        const input = validateOpInput(listChatSessionsOperation, {
-          ...(options.project === undefined ? {} : { project: options.project }),
-          ...(options.status === undefined ? {} : { status: options.status }),
-          ...(options.limit === undefined ? {} : { limit: options.limit }),
-        });
         const globalOptions = getGlobalOptions(command);
+        if (options.allProjects) {
+          const input = validateOpInput(listChatSessionsOperation, {
+            ...(options.status === undefined ? {} : { status: options.status }),
+            ...(options.limit === undefined ? {} : { limit: options.limit }),
+          });
+          const result = await runPlatformCommand(
+            platformOptionsOf(command),
+            globalOptions.timeout,
+            ({ client, signal }) =>
+              listChatSessionsOperation.execute(input, { client, signal }),
+            {
+              quiet: globalOptions.quiet,
+              cloudScope: { kind: "all-projects" },
+            }
+          );
+          writeResult(result, globalOptions.format);
+          return;
+        }
+
+        const resolved = resolveCloudProjectArgs(options);
         const result = await runPlatformCommand(
           platformOptionsOf(command),
           globalOptions.timeout,
-          ({ client, signal }) =>
-            listChatSessionsOperation.execute(input, { client, signal }),
+          async ({ client, signal }) => {
+            let project = resolved.project;
+            if (project === undefined) {
+              const page = await client.listProjects({}, { signal });
+              const resolution = resolveProject(page.items, undefined);
+              if (!resolution.ok) {
+                throw usageError(
+                  appendProjectLinkHint(
+                    resolution.message,
+                    resolved.projectScope
+                  )
+                );
+              }
+              project = resolution.project.id;
+            }
+            const input = validateOpInput(listChatSessionsOperation, {
+              project,
+              ...(options.status === undefined
+                ? {}
+                : { status: options.status }),
+              ...(options.limit === undefined ? {} : { limit: options.limit }),
+            });
+            return listChatSessionsOperation.execute(input, {
+              client,
+              signal,
+            });
+          },
           {
             quiet: globalOptions.quiet,
-            cloudScope:
-              options.project !== undefined
-                ? {
-                    kind: "project",
-                    selector: options.project,
-                    source: "flag",
-                  }
-                : { kind: "all-projects" },
+            projectScope: resolved.projectScope,
+            cloudScope: resolved.projectScope,
           }
         );
         writeResult(result, globalOptions.format);

--- a/cli/src/lib/mcp-server.ts
+++ b/cli/src/lib/mcp-server.ts
@@ -44,11 +44,14 @@ const WATCHED_NOTIFICATION_METHODS = [
   "notifications/prompts/list_changed",
 ] as const;
 
-const SERVER_INSTRUCTIONS = `MCPJam is a debugger and test harness for other MCP servers.
+export const LOCAL_MCP_SERVER_NAME = "mcpjam";
+export const LOCAL_MCP_SERVER_TITLE = "MCPJam CLI";
+
+const SERVER_INSTRUCTIONS = `This is the MCPJam CLI running locally as an MCP server. It is a debugger and test harness for other MCP servers — not the hosted MCPJam Cloud MCP at mcp.mcpjam.com.
 
 Typical flow: connect_server (stdio command or HTTP url) -> list_tools / call_tool / list_resources / read_resource / list_prompts / get_prompt -> get_notifications to see what the target emitted -> disconnect_server. Connections stay open between calls, so notifications, list_changed events, and session state are observable across calls.
 
-For one-shot triage without managing a connection, use server_doctor (full diagnostic sweep, stdio or HTTP) or probe_server (HTTP-only reachability/auth probe). Tool results are JSON payloads about the target server; call_tool returns the target's raw CallToolResult, so check its "isError" field to detect tool-level failures.`;
+For one-shot triage without managing a connection, use server_doctor (full diagnostic sweep, stdio or HTTP) or probe_server (HTTP-only reachability/auth probe). Tool results are JSON payloads about the target server; call_tool returns the target's raw CallToolResult, so check its "isError" field to detect tool-level failures. No MCPJam account is required.`;
 
 const targetConfigFields = {
   url: z
@@ -312,8 +315,8 @@ export function createMcpJamMcpServer(
 
   const server = new McpServer(
     {
-      name: "mcpjam",
-      title: "MCPJam MCP Server",
+      name: LOCAL_MCP_SERVER_NAME,
+      title: LOCAL_MCP_SERVER_TITLE,
       version: options.version,
     },
     {

--- a/cli/tests/cli-docs-4-0.test.ts
+++ b/cli/tests/cli-docs-4-0.test.ts
@@ -1,0 +1,151 @@
+/**
+ * Keep user-facing CLI docs on the 4.0 command paths.
+ *
+ * `docs/cli/migration.mdx` is the only page allowed to mention 3.x paths.
+ * Design notes remain out of scope; public API docs are included because they
+ * contain user-facing CLI examples.
+ */
+import assert from "node:assert/strict";
+import { readdirSync, readFileSync } from "node:fs";
+import path from "node:path";
+import test from "node:test";
+import { fileURLToPath } from "node:url";
+
+const REPO_ROOT = path.resolve(
+  path.dirname(fileURLToPath(import.meta.url)),
+  "../.."
+);
+const CLI_DOCS_DIR = path.join(REPO_ROOT, "docs/cli");
+const DOCS_JSON_PATH = path.join(REPO_ROOT, "docs/docs.json");
+
+const MOVED_CLOUD_GROUPS = [
+  "login",
+  "logout",
+  "whoami",
+  "organizations",
+  "projects",
+  "eval",
+  "chat-sessions",
+  "sessions",
+  "hosts",
+  "environments",
+  "capabilities",
+  "personas",
+  "journeys",
+  "scenarios",
+  "swarms",
+  "user-testing",
+  "images",
+  "tunnel",
+] as const;
+
+const movedCloudGroupPattern = MOVED_CLOUD_GROUPS.join("|");
+
+const EXTRA_DOC_PATHS = [
+  "cli/README.md",
+  "docs/reference/openapi.json",
+  "docs/inspector/evals.mdx",
+  "docs/inspector/computer.mdx",
+  "docs/getting-started.mdx",
+  "docs/contributing/evals-architecture.mdx",
+  "docs/sandbox-images-ui-cli.md",
+  "vitest/README.md",
+] as const;
+
+const STALE_PATTERNS: ReadonlyArray<{ name: string; re: RegExp }> = [
+  {
+    name: "root Cloud command path",
+    re: new RegExp(
+      "mcpjam (?:" + movedCloudGroupPattern + ")(?:\\s|…|\\x60|$)",
+      "g"
+    ),
+  },
+  {
+    name: "npx @mcpjam/cli without cloud for moved groups",
+    re: new RegExp(
+      "@mcpjam/cli(?:@\\S+)?\\s+(?:" + movedCloudGroupPattern + ")\\b",
+      "g"
+    ),
+  },
+  {
+    name: "old local MCP stderr listening line",
+    re: /MCPJam MCP server listening on stdio/g,
+  },
+  {
+    name: "stale /cli/reference#eval- anchor",
+    re: /\/cli\/reference#eval-/g,
+  },
+];
+
+function listCliGuideDocs(): string[] {
+  return readdirSync(CLI_DOCS_DIR)
+    .filter((name) => name.endsWith(".mdx") && name !== "migration.mdx")
+    .map((name) => path.join(CLI_DOCS_DIR, name));
+}
+
+function findingsIn(filePath: string, source: string): string[] {
+  const findings: string[] = [];
+  for (const { name, re } of STALE_PATTERNS) {
+    re.lastIndex = 0;
+    let match: RegExpExecArray | null;
+    while ((match = re.exec(source)) !== null) {
+      const line = source.slice(0, match.index).split("\n").length;
+      findings.push(`${path.relative(REPO_ROOT, filePath)}:${line}: ${name}`);
+    }
+  }
+  return findings;
+}
+
+test("CLI 4.0 docs do not advertise 3.x Cloud command paths", () => {
+  const files = [
+    ...listCliGuideDocs(),
+    ...EXTRA_DOC_PATHS.map((relative) => path.join(REPO_ROOT, relative)),
+  ];
+  const findings = files.flatMap((filePath) =>
+    findingsIn(filePath, readFileSync(filePath, "utf8"))
+  );
+  assert.deepEqual(findings, [], findings.join("\n"));
+});
+
+test("CLI reference has one canonical cloud eval section", () => {
+  const reference = readFileSync(
+    path.join(CLI_DOCS_DIR, "reference.mdx"),
+    "utf8"
+  );
+  const headings = reference.match(/^## `cloud eval` commands$/gm) ?? [];
+  assert.equal(headings.length, 1);
+});
+
+test("CLI reference documents removing a Cloud project link", () => {
+  const reference = readFileSync(
+    path.join(CLI_DOCS_DIR, "reference.mdx"),
+    "utf8"
+  );
+  assert.match(reference, /\| `--remove` \| Remove the nearest project link/);
+});
+
+test("docs nav includes the CLI 4.0 migration page after overview", () => {
+  const docsJson = JSON.parse(readFileSync(DOCS_JSON_PATH, "utf8")) as {
+    navigation?: {
+      tabs?: Array<{
+        tab?: string;
+        groups?: Array<{ pages?: unknown }>;
+      }>;
+    };
+  };
+  const cliTab = docsJson.navigation?.tabs?.find((tab) => tab.tab === "CLI");
+  assert.ok(cliTab, "docs.json is missing the CLI tab");
+  const guides = cliTab?.groups?.find((group) =>
+    Array.isArray(group.pages) &&
+    (group.pages as unknown[]).includes("cli/overview")
+  );
+  const pages = (guides?.pages ?? []) as string[];
+  const overviewIndex = pages.indexOf("cli/overview");
+  const migrationIndex = pages.indexOf("cli/migration");
+  assert.ok(overviewIndex >= 0, "CLI Guides must list cli/overview");
+  assert.equal(
+    migrationIndex,
+    overviewIndex + 1,
+    "cli/migration must follow cli/overview in CLI Guides"
+  );
+});

--- a/cli/tests/cloud-audience.test.ts
+++ b/cli/tests/cloud-audience.test.ts
@@ -430,8 +430,12 @@ test("environments create rejects a non-string JSON project before any write", a
     ])
   );
   assert.equal(run.exitCode, 2, run.stderr);
-  assert.match(
-    run.stderr,
-    /"project" must be a string when supplied in JSON input/
+  const payload = JSON.parse(run.stderr) as {
+    error?: { code?: string; message?: string };
+  };
+  assert.equal(payload.error?.code, "USAGE_ERROR");
+  assert.equal(
+    payload.error?.message,
+    '"project" must be a string when supplied in JSON input.'
   );
 });

--- a/cli/tests/cloud-project-selection.test.ts
+++ b/cli/tests/cloud-project-selection.test.ts
@@ -281,7 +281,7 @@ test("sessions list rejects --project together with --all-projects", async () =>
     "json",
   ]);
   assert.equal(run.exitCode, 2);
-  assert.match(run.stderr, /cannot be used with option '--project'/i);
+  assert.match(run.stderr, /cannot be used with option '--project/i);
 });
 
 test("sessions list --help shows --all-projects", async () => {

--- a/cli/tests/cloud-project-selection.test.ts
+++ b/cli/tests/cloud-project-selection.test.ts
@@ -64,6 +64,13 @@ async function startFixture(): Promise<{
       );
       return;
     }
+    if (
+      url.pathname ===
+      "/api/v1/projects/proj-alpha/eval-runs/run-1/iterations"
+    ) {
+      res.end(JSON.stringify({ items: [] }));
+      return;
+    }
     res.statusCode = 404;
     res.end(JSON.stringify({ code: "NOT_FOUND", message: url.pathname }));
   });
@@ -149,12 +156,46 @@ function cloudArgv(baseUrl: string, ...args: string[]): string[] {
   ];
 }
 
-test("eval status/cancel/judge help treat --project as optional", async () => {
-  for (const sub of ["status", "cancel", "judge"]) {
+test("eval run-inspection commands treat --project as optional", async () => {
+  for (const sub of [
+    "status",
+    "cancel",
+    "judge",
+    "iterations",
+    "gate",
+    "compare",
+    "trace",
+    "steps",
+    "screenshot",
+    "video",
+  ]) {
     const run = await runCli(["cloud", "eval", sub, "--help"]);
     assert.equal(run.exitCode, 0, run.stderr);
     assert.match(run.stdout, /--project <id-or-name>/);
     assert.doesNotMatch(run.stdout, /required option '--project/);
+  }
+});
+
+test("eval iterations without --project uses automatic project selection", async () => {
+  const fixture = await startFixture();
+  const cwd = mkdtempSync(path.join(tmpdir(), "mcpjam-eval-iterations-"));
+  try {
+    const run = await withEnv(isolatedEnv(), () =>
+      withCwd(cwd, () =>
+        runCli(
+          cloudArgv(fixture.baseUrl, "eval", "iterations", "--run", "run-1")
+        )
+      )
+    );
+    assert.equal(run.exitCode, 0, run.stderr);
+    assert.ok(
+      fixture.requestUrls.some((url) =>
+        url.includes("/projects/proj-alpha/eval-runs/run-1/iterations")
+      ),
+      `expected automatic proj-alpha iterations fetch, saw: ${fixture.requestUrls.join(", ")}`
+    );
+  } finally {
+    await fixture.close();
   }
 });
 

--- a/cli/tests/cloud-project-selection.test.ts
+++ b/cli/tests/cloud-project-selection.test.ts
@@ -1,0 +1,292 @@
+/**
+ * One project-selection rule: remaining eval commands take optional
+ * `--project`, and `sessions list` is project-scoped with `--all-projects`.
+ */
+import assert from "node:assert/strict";
+import { mkdtempSync, mkdirSync, writeFileSync } from "node:fs";
+import { createServer, type Server } from "node:http";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import test from "node:test";
+import { runCli } from "./support/cli-run.js";
+import { projectLinkPathForDir } from "../src/lib/project-link.js";
+
+const PROJECTS = [
+  {
+    id: "proj-alpha",
+    name: "Alpha",
+    description: null,
+    icon: null,
+    organizationId: "org-1",
+    visibility: null,
+    createdAt: 1,
+    updatedAt: 200,
+  },
+  {
+    id: "proj-beta",
+    name: "Beta",
+    description: null,
+    icon: null,
+    organizationId: "org-1",
+    visibility: null,
+    createdAt: 2,
+    updatedAt: 100,
+  },
+];
+
+async function startFixture(): Promise<{
+  baseUrl: string;
+  requestUrls: string[];
+  close: () => Promise<void>;
+}> {
+  const requestUrls: string[] = [];
+  const server: Server = createServer((req, res) => {
+    const url = new URL(req.url ?? "/", "http://fixture");
+    requestUrls.push(`${req.method} ${url.pathname}${url.search}`);
+    res.setHeader("content-type", "application/json");
+    if (url.pathname === "/api/v1/projects") {
+      res.end(JSON.stringify({ items: PROJECTS }));
+      return;
+    }
+    if (url.pathname === "/api/v1/chat-sessions") {
+      res.end(JSON.stringify({ items: [] }));
+      return;
+    }
+    if (url.pathname === "/api/v1/projects/proj-alpha/eval-runs/run-1") {
+      res.end(
+        JSON.stringify({
+          id: "run-1",
+          suiteId: "suite-1",
+          status: "completed",
+          result: "passed",
+          judges: [],
+        })
+      );
+      return;
+    }
+    res.statusCode = 404;
+    res.end(JSON.stringify({ code: "NOT_FOUND", message: url.pathname }));
+  });
+
+  await new Promise<void>((resolve) =>
+    server.listen(0, "127.0.0.1", () => resolve())
+  );
+  const address = server.address();
+  if (!address || typeof address === "string") {
+    throw new Error("fixture server has no address");
+  }
+
+  return {
+    baseUrl: `http://127.0.0.1:${address.port}/api/v1`,
+    requestUrls,
+    close: () =>
+      new Promise<void>((resolve, reject) =>
+        server.close((error) => (error ? reject(error) : resolve()))
+      ),
+  };
+}
+
+async function withCwd<T>(directory: string, fn: () => Promise<T>): Promise<T> {
+  const previous = process.cwd();
+  process.chdir(directory);
+  try {
+    return await fn();
+  } finally {
+    process.chdir(previous);
+  }
+}
+
+async function withEnv<T>(
+  updates: Record<string, string | undefined>,
+  fn: () => Promise<T>
+): Promise<T> {
+  const previous: Record<string, string | undefined> = {};
+  for (const key of Object.keys(updates)) {
+    previous[key] = process.env[key];
+    const value = updates[key];
+    if (value === undefined) {
+      delete process.env[key];
+    } else {
+      process.env[key] = value;
+    }
+  }
+  try {
+    return await fn();
+  } finally {
+    for (const [key, value] of Object.entries(previous)) {
+      if (value === undefined) {
+        delete process.env[key];
+      } else {
+        process.env[key] = value;
+      }
+    }
+  }
+}
+
+function isolatedEnv(
+  extra: Record<string, string | undefined> = {}
+): Record<string, string | undefined> {
+  return {
+    MCPJAM_PROJECT: undefined,
+    MCPJAM_PROJECT_ID: undefined,
+    MCPJAM_API_KEY: undefined,
+    MCPJAM_API_URL: undefined,
+    MCPJAM_AUTH_FILE: path.join(tmpdir(), "mcpjam-no-auth.json"),
+    ...extra,
+  };
+}
+
+function cloudArgv(baseUrl: string, ...args: string[]): string[] {
+  return [
+    "cloud",
+    ...args,
+    "--api-key",
+    "sk_test",
+    "--api-url",
+    baseUrl,
+    "--format",
+    "json",
+  ];
+}
+
+test("eval status/cancel/judge help treat --project as optional", async () => {
+  for (const sub of ["status", "cancel", "judge"]) {
+    const run = await runCli(["cloud", "eval", sub, "--help"]);
+    assert.equal(run.exitCode, 0, run.stderr);
+    assert.match(run.stdout, /--project <id-or-name>/);
+    assert.doesNotMatch(run.stdout, /required option '--project/);
+  }
+});
+
+test("eval status without --project uses automatic project selection", async () => {
+  const fixture = await startFixture();
+  const cwd = mkdtempSync(path.join(tmpdir(), "mcpjam-eval-project-"));
+  try {
+    const run = await withEnv(isolatedEnv(), () =>
+      withCwd(cwd, () =>
+        runCli(cloudArgv(fixture.baseUrl, "eval", "status", "--run", "run-1"))
+      )
+    );
+    assert.equal(run.exitCode, 0, run.stderr);
+    assert.ok(
+      fixture.requestUrls.some((url) =>
+        url.includes("/projects/proj-alpha/eval-runs/run-1")
+      ),
+      `expected automatic proj-alpha run fetch, saw: ${fixture.requestUrls.join(", ")}`
+    );
+    assert.match(
+      run.stderr,
+      /project: automatic \(most recently updated\)/
+    );
+  } finally {
+    await fixture.close();
+  }
+});
+
+test("sessions list without --project scopes to the automatic project", async () => {
+  const fixture = await startFixture();
+  const cwd = mkdtempSync(path.join(tmpdir(), "mcpjam-sessions-auto-"));
+  try {
+    const run = await withEnv(isolatedEnv(), () =>
+      withCwd(cwd, () => runCli(cloudArgv(fixture.baseUrl, "sessions", "list")))
+    );
+    assert.equal(run.exitCode, 0, run.stderr);
+    assert.ok(
+      fixture.requestUrls.some((url) =>
+        url.includes("/chat-sessions") && url.includes("projectId=proj-alpha")
+      ),
+      `expected projectId=proj-alpha, saw: ${fixture.requestUrls.join(", ")}`
+    );
+    assert.match(
+      run.stderr,
+      /project: automatic \(most recently updated\)/
+    );
+  } finally {
+    await fixture.close();
+  }
+});
+
+test("sessions list --all-projects does not send a project filter", async () => {
+  const fixture = await startFixture();
+  const cwd = mkdtempSync(path.join(tmpdir(), "mcpjam-sessions-all-"));
+  try {
+    const run = await withEnv(isolatedEnv(), () =>
+      withCwd(cwd, () =>
+        runCli(cloudArgv(fixture.baseUrl, "sessions", "list", "--all-projects"))
+      )
+    );
+    assert.equal(run.exitCode, 0, run.stderr);
+    const sessionGets = fixture.requestUrls.filter((url) =>
+      url.includes("/chat-sessions")
+    );
+    assert.equal(sessionGets.length, 1);
+    assert.doesNotMatch(sessionGets[0]!, /projectId=/);
+    assert.match(run.stderr, /all projects/);
+  } finally {
+    await fixture.close();
+  }
+});
+
+test("sessions list honors a project link and --all-projects ignores it", async () => {
+  const fixture = await startFixture();
+  const cwd = mkdtempSync(path.join(tmpdir(), "mcpjam-sessions-link-"));
+  const linkPath = projectLinkPathForDir(cwd);
+  mkdirSync(path.dirname(linkPath), { recursive: true });
+  writeFileSync(
+    linkPath,
+    `${JSON.stringify({
+      version: 1,
+      project: { id: "proj-beta", name: "Beta" },
+      apiUrl: fixture.baseUrl,
+    }, null, 2)}\n`
+  );
+  try {
+    const linked = await withEnv(isolatedEnv(), () =>
+      withCwd(cwd, () => runCli(cloudArgv(fixture.baseUrl, "sessions", "list")))
+    );
+    assert.equal(linked.exitCode, 0, linked.stderr);
+    assert.ok(
+      fixture.requestUrls.some((url) =>
+        url.includes("/chat-sessions") && url.includes("projectId=proj-beta")
+      ),
+      `expected linked proj-beta, saw: ${fixture.requestUrls.join(", ")}`
+    );
+
+    fixture.requestUrls.length = 0;
+    const all = await withEnv(isolatedEnv(), () =>
+      withCwd(cwd, () =>
+        runCli(cloudArgv(fixture.baseUrl, "sessions", "list", "--all-projects"))
+      )
+    );
+    assert.equal(all.exitCode, 0, all.stderr);
+    const sessionGets = fixture.requestUrls.filter((url) =>
+      url.includes("/chat-sessions")
+    );
+    assert.equal(sessionGets.length, 1);
+    assert.doesNotMatch(sessionGets[0]!, /projectId=/);
+  } finally {
+    await fixture.close();
+  }
+});
+
+test("sessions list rejects --project together with --all-projects", async () => {
+  const run = await runCli([
+    "cloud",
+    "sessions",
+    "list",
+    "--project",
+    "alpha",
+    "--all-projects",
+    "--format",
+    "json",
+  ]);
+  assert.equal(run.exitCode, 2);
+  assert.match(run.stderr, /cannot be used with option '--project'/i);
+});
+
+test("sessions list --help shows --all-projects", async () => {
+  const run = await runCli(["cloud", "sessions", "list", "--help"]);
+  assert.equal(run.exitCode, 0, run.stderr);
+  assert.match(run.stdout, /--all-projects/);
+  assert.match(run.stdout, /--project <id-or-name>/);
+});

--- a/cli/tests/eval.test.ts
+++ b/cli/tests/eval.test.ts
@@ -1494,6 +1494,61 @@ test("eval judge rejects a blank --judge-threshold before any request", async ()
   }
 });
 
+test("eval judge rejects a blank --judge-model before any request", async () => {
+  const fixture = await startEvalFixture();
+  try {
+    const run = await captureProcessOutput(() =>
+      main(
+        evalArgv(
+          fixture.baseUrl,
+          "judge",
+          "--project",
+          "proj-alpha",
+          "--run",
+          "run-1",
+          "--judge-model",
+          "   ",
+        ),
+        { telemetry: telemetryDisabled },
+      ),
+    );
+    assert.equal(run.result.exitCode, 2, run.stderr);
+    assert.match(run.stderr, /Invalid input:.*model/);
+    assert.equal(fixture.createBodies.length, 0);
+    assert.equal(fixture.authHeaders.length, 0);
+  } finally {
+    await fixture.close();
+  }
+});
+
+test("eval iterations rejects a bad --limit before any request", async () => {
+  const fixture = await startEvalFixture();
+  try {
+    for (const value of ["abc", "0", "201", "-1"]) {
+      const run = await captureProcessOutput(() =>
+        main(
+          evalArgv(
+            fixture.baseUrl,
+            "iterations",
+            "--project",
+            "proj-alpha",
+            "--run",
+            "run-1",
+            "--limit",
+            value,
+          ),
+          { telemetry: telemetryDisabled },
+        ),
+      );
+      assert.equal(run.result.exitCode, 2, `accepted --limit ${JSON.stringify(value)}: ${run.stderr}`);
+      assert.match(run.stderr, /Invalid input:.*limit/);
+    }
+    assert.equal(fixture.authHeaders.length, 0);
+  } finally {
+    await fixture.close();
+  }
+});
+
 test("eval status summarizes the judges that graded, and stays silent about the rest", async () => {
   const fixture = await startEvalFixture();
   try {

--- a/cli/tests/local-contract.test.ts
+++ b/cli/tests/local-contract.test.ts
@@ -356,6 +356,10 @@ test("local MCP serverInfo.name remains mcpjam", async () => {
     await client.connect(clientTransport as never);
     const serverInfo = client.getServerVersion();
     assert.equal(serverInfo?.name, "mcpjam");
+    assert.equal(serverInfo?.title, "MCPJam CLI");
+    const instructions = client.getInstructions() ?? "";
+    assert.match(instructions, /MCPJam CLI running locally/);
+    assert.match(instructions, /not the hosted MCPJam Cloud MCP/);
   } finally {
     await client.close().catch(() => undefined);
     await handle.close();

--- a/docs/cli/ci.mdx
+++ b/docs/cli/ci.mdx
@@ -362,7 +362,7 @@ There are two ways to wire MCPJam evals into a pipeline: trigger a **hosted eval
 
 ### Trigger a hosted eval suite
 
-`mcpjam eval run` starts an asynchronous run of a suite that lives in your MCPJam project. It prints a `runId` and returns immediately — the iterations execute on the MCPJam platform, not in your CI job. Check on the run with `mcpjam eval status`.
+`mcpjam cloud eval run` starts an asynchronous run of a suite that lives in your MCPJam project. It prints a `runId` and returns immediately — the iterations execute on the MCPJam platform, not in your CI job. Check on the run with `mcpjam cloud eval status`.
 
 **Secrets needed:**
 
@@ -375,7 +375,7 @@ There are two ways to wire MCPJam evals into a pipeline: trigger a **hosted eval
         env:
           MCPJAM_API_KEY: ${{ secrets.MCPJAM_API_KEY }}
         run: |
-          npx -y @mcpjam/cli@latest eval run \
+          npx -y @mcpjam/cli@latest cloud eval run \
             --suite "Nightly regression" \
             --project "My project" \
             --format json > eval-run.json
@@ -401,7 +401,7 @@ Poll `eval status` until `run.status` is terminal (`completed`, `failed`, or `ca
           ATTEMPTS=0
           MAX_ATTEMPTS=60   # ~30 minutes at one poll per 30 s
           while :; do
-            npx -y @mcpjam/cli@latest eval status \
+            npx -y @mcpjam/cli@latest cloud eval status \
               --run "$RUN_ID" \
               --project "My project" \
               --format json > eval-status.json
@@ -422,7 +422,7 @@ Poll `eval status` until `run.status` is terminal (`completed`, `failed`, or `ca
 The eval verdict does not control the exit code — `eval run` and `eval status` exit non-zero on API, transport, and usage errors instead. The pass/fail verdict lives in the JSON payload (`run.result`), so the final assertion above is what fails the job. `eval status` also prints a `View:` line in human format, identical to the one `eval run` prints.
 </Note>
 
-Hosted runs execute LLM iterations on the platform and consume your organization's credits or configured provider keys. See the [`eval` command reference](/cli/reference#eval-commands) for the full surface, including `eval judge` (request LLM-as-judge grading on a finished run), `eval validate` (offline suite-file validation), `eval export` (write a hosted suite to a local file), `eval checks list/connect` (GitHub Checks integration), and more.
+Hosted runs execute LLM iterations on the platform and consume your organization's credits or configured provider keys. See the [`cloud eval` command reference](/cli/reference#cloud-eval-commands) for the full surface, including `cloud eval judge` (request LLM-as-judge grading on a finished run), `cloud eval validate` (offline suite-file validation), `cloud eval export` (write a hosted suite to a local file), `cloud eval checks list/connect` (GitHub Checks integration), and more.
 
 ### Upload SDK eval results
 

--- a/docs/cli/mcp-server.mdx
+++ b/docs/cli/mcp-server.mdx
@@ -119,7 +119,7 @@ Tool results are JSON payloads describing the target server. Errors come back as
 
 ## Relationship to the hosted MCP server
 
-MCPJam also operates a hosted MCP server at `mcp.mcpjam.com/mcp` that exposes your MCPJam **account** — projects, saved servers, eval suites and runs — behind OAuth. The two are complementary:
+MCPJam also operates a hosted MCP server at `mcp.mcpjam.com/mcp` that exposes your MCPJam **account** — projects, saved servers, eval suites and runs — behind OAuth. The two are complementary. `mcpjam mcp` protocol `serverInfo.name` is `mcpjam`; its title is `MCPJam CLI`. The hosted server identifies as `MCPJam MCP`.
 
 | | `mcpjam mcp` (this page) | `mcp.mcpjam.com` |
 |---|---|---|
@@ -127,9 +127,11 @@ MCPJam also operates a hosted MCP server at `mcp.mcpjam.com/mcp` that exposes yo
 | Auth | None | MCPJam account (OAuth) |
 | Scope | Test any server reachable from your machine, including local stdio | Servers and evals saved in your projects |
 | Transport to MCPJam | stdio | Streamable HTTP |
+| Protocol name | `mcpjam` | `MCPJam MCP` |
+| Title | `MCPJam CLI` | `MCPJam MCP` |
 
 ## Troubleshooting
 
-- **Client says the server failed to start** — run `npx -y @mcpjam/cli@latest mcp` in a terminal; you should see `MCPJam MCP server listening on stdio` on stderr. First runs may be slow while `npx` downloads the package; pre-install with `npm i -g @mcpjam/cli` and use `mcpjam mcp` to avoid the download.
+- **Client says the server failed to start** — run `npx -y @mcpjam/cli@latest mcp` in a terminal; you should see `MCPJam CLI MCP server listening on stdio` on stderr. First runs may be slow while `npx` downloads the package; pre-install with `npm i -g @mcpjam/cli` and use `mcpjam mcp` to avoid the download.
 - **`connect_server` fails with `SERVER_UNREACHABLE`** — the target URL or command is wrong, or the target crashed on startup. Try `server_doctor` against the same target for a structured diagnosis.
 - **A connection name is already taken** — `connect_server` refuses to overwrite an existing name; `disconnect_server` it first or pass a different `name`.

--- a/docs/cli/migration.mdx
+++ b/docs/cli/migration.mdx
@@ -1,0 +1,59 @@
+---
+title: "Migrating to CLI 4.0"
+description: "Command-path and flag changes when account-bound mcpjam commands moved under mcpjam cloud"
+icon: "arrow-right-arrow-left"
+---
+
+`@mcpjam/cli` 4.0 separates local MCP operations from account-bound Cloud operations. Most account-bound commands live under `mcpjam cloud`; hosted readiness is the intentional root-level exception because it targets publisher directory checks and does not use Cloud project links. There are no compatibility aliases for the old Cloud command paths.
+
+```bash
+mcpjam server probe --url https://example.com/mcp       # local
+mcpjam oauth login --url https://example.com/mcp        # local MCP OAuth
+mcpjam cloud login                                      # MCPJam Cloud account
+mcpjam cloud projects list                              # MCPJam Cloud
+mcpjam cloud eval run --suite smoke                     # MCPJam Cloud
+mcpjam cloud tunnel --server dev -- npm start           # local target, Cloud registration
+```
+
+## What did not change
+
+- Frozen local commands: `server`, `tools`, `resources`, `prompts`, `subscriptions`, `tasks`, `apps`, `oauth`, `protocol`, `xaa`, `compat`, `inspector`, `mcp`, `telemetry`
+- Local commands still reject `--api-key` / `--api-url` / `--project`
+- Hosted `readiness start|status|list|cancel|report` stays under the root `readiness` command (leaf `--api-key`; no Cloud project link)
+- Local `mcpjam mcp` protocol `serverInfo.name` is still `mcpjam` (title is now `MCPJam CLI`)
+
+## Command paths
+
+| 3.x | 4.0 |
+|-----|-----|
+| `mcpjam login` / `logout` / `whoami` | `mcpjam cloud login` / `logout` / `whoami` |
+| `mcpjam organizations` | `mcpjam cloud organizations` |
+| `mcpjam projects …` | `mcpjam cloud projects …` |
+| `mcpjam eval …` | `mcpjam cloud eval …` |
+| `mcpjam chat-sessions list` | `mcpjam cloud sessions list` |
+| `mcpjam sessions search` | `mcpjam cloud sessions search` |
+| `mcpjam hosts …` | `mcpjam cloud hosts …` |
+| `mcpjam environments …` | `mcpjam cloud environments …` |
+| `mcpjam capabilities` | `mcpjam cloud projects capabilities` |
+| `mcpjam projects server …` | `mcpjam cloud projects servers …` (plural only) |
+| `mcpjam personas` / `journeys` / `scenarios` / `swarms` / `user-testing` | `mcpjam cloud …` (same names) |
+| `mcpjam images …` | `mcpjam cloud images …` |
+| `mcpjam tunnel …` | `mcpjam cloud tunnel …` |
+
+## Flags
+
+| 3.x | 4.0 |
+|-----|-----|
+| `--api-key` / `--api-url` on each Cloud leaf | Declared on `mcpjam cloud`; work before or after descendants |
+| `projects list --organization-id` | `mcpjam cloud projects list --org` |
+| `tunnel --id <name>` | `mcpjam cloud tunnel --server <name>` (`--id` still works, hidden) |
+| `eval status --project` required | Optional. Same precedence as other Cloud commands |
+| `sessions list` with no `--project` | Project-scoped (link / env / automatic). Pass `--all-projects` for the old all-projects listing |
+
+Project-selection precedence: `--project` > explicit `project` in `--file`/`--json` > `MCPJAM_PROJECT` > nearest `.mcpjam/project.json` > automatic (most recently updated). `MCPJAM_PROJECT_ID` does not select a Cloud CLI project.
+
+`mcpjam cloud link` writes `.mcpjam/project.json`; use `mcpjam cloud link --remove` to remove the nearest link. `mcpjam cloud status` is zero-network.
+
+## Local MCP identity
+
+`mcpjam mcp` still announces protocol name `mcpjam`. The display title is `MCPJam CLI`. Instructions say this is the local testing engine, not the hosted Cloud MCP at `mcp.mcpjam.com`.

--- a/docs/cli/overview.mdx
+++ b/docs/cli/overview.mdx
@@ -4,7 +4,7 @@ description: "Local MCP testing and mcpjam cloud: probing, debugging, OAuth, con
 icon: "terminal"
 ---
 
-The `mcpjam` CLI is two invocations. Local MCP testing stays at the top level: a stateless tool for inspecting, debugging, and testing MCP servers from the command line or CI (connectivity, OAuth, MCP Apps, tools/resources/prompts, protocol conformance). Account-bound commands live under `mcpjam cloud`. There are no compatibility aliases for the old Cloud paths — see [Migrating to CLI 4.0](/cli/migration).
+The `mcpjam` CLI is two invocations. Local MCP testing stays at the top level: inspect, debug, and test MCP servers from the command line or CI (connectivity, OAuth, MCP Apps, tools/resources/prompts, protocol conformance). Most local commands are one-shot; `mcpjam mcp` and `subscriptions listen` keep a process open. Account-bound commands live under `mcpjam cloud` and talk to your MCPJam account. There are no compatibility aliases for the old Cloud paths — see [Migrating to CLI 4.0](/cli/migration).
 
 ## Recommended: Use with Agent Skills
 
@@ -69,6 +69,63 @@ Account-bound commands. Declare `--api-key` / `--api-url` on `mcpjam cloud` (bef
 | [`cloud images`](/cli/reference#cloud-images-commands) | Manage custom Computer sandbox images (blueprints) | `list`, `get`, `create`, `validate`, `edit`, `build`, `logs`, `use`, `reset`, `promote`, `delete` |
 
 Also under `mcpjam cloud`: `journeys`, `scenarios`, `personas`, `swarms`, `user-testing`. Full flag tables are in the [command reference](/cli/reference).
+
+## Cloud credentials and API URL
+
+`--api-key` and `--api-url` are declared on `mcpjam cloud` and work before or after descendants (`mcpjam cloud --api-key sk_… eval list` and `mcpjam cloud eval list --api-key sk_…` are the same). Local commands, including hosted `readiness`, reject those flags at the program root. Hosted `readiness` still takes leaf `--api-key`.
+
+Credential precedence for Cloud commands:
+
+1. `--api-key` — must be an `sk_` key. A `mcpjam_…` legacy key is a usage error.
+2. `MCPJAM_API_KEY` — same `sk_` rule. A legacy value in this env var is ignored (with a warning) so SDK eval reporting can still use it.
+3. Stored OAuth from `mcpjam cloud login`
+4. Missing — Cloud commands fail with login guidance before they hit the network (`mcpjam cloud status` reports `missing` instead)
+
+API URL precedence:
+
+1. `--api-url`
+2. `MCPJAM_API_URL`
+3. The `apiUrl` stored with the OAuth login (only when that login is the credential)
+4. `https://app.mcpjam.com/api/v1`
+
+An explicit `--api-url` or `MCPJAM_API_URL` that is not an `http(s)` URL is a usage error. `mcpjam cloud status` uses the same checks.
+
+Successful Cloud commands print an audience line to stderr (`Using MCPJam Cloud as … · project: … · <apiUrl>`). `--quiet` suppresses it. Machine-readable JSON stays on stdout.
+
+## Cloud project scope
+
+Most Cloud commands pick one project:
+
+1. `--project <id-or-name>`
+2. An explicit `project` field in `--file` / `--json`
+3. `MCPJAM_PROJECT`
+4. The nearest valid `.mcpjam/project.json`
+5. Automatic — the most recently updated project you can see
+
+Empty `--project` or `MCPJAM_PROJECT` is a usage error. `MCPJAM_PROJECT_ID` does **not** select a Cloud CLI project (it is SDK eval reporting only).
+
+```bash
+mcpjam cloud login
+mcpjam cloud link                  # writes .mcpjam/project.json (no secrets)
+mcpjam cloud status                # zero-network: credential, deployment, selector
+mcpjam cloud eval list             # uses the link
+mcpjam cloud link --remove
+```
+
+`mcpjam cloud sessions list` follows the same rule. `--all-projects` restores a cross-project listing and cannot be combined with `--project`. Hosted `readiness` never reads the project link.
+
+## What `--host` means
+
+`--host` is not one flag. The meaning depends on the command:
+
+| Where | What it selects |
+|-------|-----------------|
+| `server`, `tools`, `resources`, `prompts` | An **AI client** (`claude`, `chatgpt`, `cursor`, …). The CLI sends that host's `clientInfo`, capabilities, and protocol version in `initialize`. |
+| `compat --host` | Which AI clients to report. Repeatable; default is all. |
+| `cloud eval --host`, `cloud journeys`, `cloud scenarios` | A **saved project Host** (`<id-or-name>`), the client config an eval or journey is stamped with. |
+| `cloud environments --host-id` | The project Host id the environment runs as. Distinct from eval's `--host`. |
+
+`--host` on a local command is mutually exclusive with `--client-capabilities`. A Cloud `--host` is mutually exclusive with `--server` / `--environment` when those already supply a closed server set.
 
 ## Global flags
 

--- a/docs/cli/overview.mdx
+++ b/docs/cli/overview.mdx
@@ -1,10 +1,10 @@
 ---
 title: "CLI Overview"
-description: "Stateless MCP server probing, debugging, OAuth, and conformance from your terminal"
+description: "Local MCP testing and mcpjam cloud: probing, debugging, OAuth, conformance, and hosted evals from your terminal"
 icon: "terminal"
 ---
 
-The `mcpjam` CLI is a stateless tool for inspecting, debugging, and testing MCP servers from the command line or CI. It covers the full lifecycle: connectivity checks, OAuth login, MCP Apps validation, tool/resource/prompt exploration, and protocol conformance.
+The `mcpjam` CLI is two invocations. Local MCP testing stays at the top level: a stateless tool for inspecting, debugging, and testing MCP servers from the command line or CI (connectivity, OAuth, MCP Apps, tools/resources/prompts, protocol conformance). Account-bound commands live under `mcpjam cloud`. There are no compatibility aliases for the old Cloud paths — see [Migrating to CLI 4.0](/cli/migration).
 
 ## Recommended: Use with Agent Skills
 
@@ -33,30 +33,46 @@ npx -y @mcpjam/cli@latest --help
 
 ## Command groups
 
+### Local MCP testing
+
+These stay at the program root. They reject `--api-key` / `--api-url` / `--project`.
+
 | Group | Purpose | Key commands |
 |-------|---------|-------------|
 | [`server`](/cli/server-inspection) | Triage connectivity and capabilities | `probe`, `doctor`, `info`, `validate`, `ping`, `capabilities`, `export` |
-| [`xaa`](/cli/xaa) | Run the Cross-App Access (ID-JAG) debugger against an MCP server | `run` |
-| [`oauth`](/cli/oauth-conformance) | Test OAuth flows and conformance | `conformance`, `conformance-suite`, `login`, `metadata`, `proxy` |
-| [`apps`](/cli/apps-conformance) | Validate MCP Apps metadata and resource wiring | `conformance`, `conformance-suite` |
-| [`compat`](/cli/reference#compat-command) | Check whether a server's tools and widgets work on each AI host | `compat` |
-| [`readiness`](/cli/reference#readiness-hosted-commands) | Start, poll, list, cancel, and read hosted directory-readiness runs against a saved server | `start claude`, `start openai`, `status`, `list`, `cancel`, `report` |
-| [`inspector`](/cli/reference#inspector-commands) | Start, open, or stop the local Inspector from the CLI | `open`, `start`, `stop` |
-| [`eval`](/cli/reference#eval-commands) | Author and run eval suites in your hosted MCPJam projects | `create`, `list`, `run`, `status` |
-| [`tunnel`](/cli/reference#tunnel) | Expose a local MCP server through a public MCPJam tunnel URL, registered as a server in your project | `tunnel <url>`, `tunnel -- <command>` |
 | [`tools`](/cli/tools-resources-prompts) | Exercise the tool surface | `list`, `call` |
 | [`resources`](/cli/tools-resources-prompts) | Read resources and templates | `list`, `read`, `templates` |
 | [`prompts`](/cli/tools-resources-prompts) | Fetch prompts | `list`, `get` |
+| [`subscriptions`](/cli/reference) | Open a long-lived MCP subscription and stream notifications | `listen` |
+| [`tasks`](/cli/tasks) | Drive MCP Tasks and validate the tasks wire | `list`, `get`, `cancel`, `conformance` |
+| [`apps`](/cli/apps-conformance) | Validate MCP Apps metadata and resource wiring | `conformance`, `conformance-suite` |
+| [`oauth`](/cli/oauth-conformance) | Test OAuth flows and conformance against an MCP server | `conformance`, `conformance-suite`, `login`, `metadata`, `proxy` |
 | [`protocol`](/cli/reference) | MCP protocol conformance checks | `conformance`, `conformance-suite` |
-| [`hosts`](/cli/reference#hosts-commands) | Manage hosts in your hosted MCPJam projects | `list`, `get`, `create`, `update`, `delete`, `templates` |
-| [`environments`](/cli/reference#environments-commands) | Manage project environments — the host + servers + pinned skills/plugins bundles eval suites and journeys run against | `list`, `get`, `resolve`, `create`, `update`, `archive`, `restore` |
-| [`images`](/cli/reference#images-commands) | Manage custom Computer sandbox images (blueprints) | `list`, `get`, `create`, `validate`, `edit`, `build`, `logs`, `use`, `reset`, `promote`, `delete` |
+| [`readiness`](/cli/reference#readiness-hosted-commands) | Grade a server against a publisher's directory. Hosted `start` / `status` / `list` / `cancel` / `report` stay here (leaf `--api-key`; no Cloud project link) | `check`, `start claude`, `start openai`, `status`, `list`, `cancel`, `report` |
+| [`xaa`](/cli/xaa) | Run the Cross-App Access (ID-JAG) debugger against an MCP server | `run` |
+| [`compat`](/cli/reference#compat-command) | Check whether a server's tools and widgets work on each AI host | `compat` |
+| [`inspector`](/cli/reference#inspector-commands) | Start, open, or stop the local Inspector from the CLI | `open`, `start`, `stop` |
 | [`mcp`](/cli/mcp-server) | Run MCPJam as a stdio MCP server for agents (Claude Desktop, Claude Code, Cursor, ...) | `mcp` |
 | [`telemetry`](/cli/telemetry) | Inspect and configure anonymous CLI telemetry | `status`, `disable`, `enable` |
 
+### MCPJam Cloud
+
+Account-bound commands. Declare `--api-key` / `--api-url` on `mcpjam cloud` (before or after descendants). `mcpjam oauth login` is MCP-server OAuth; `mcpjam cloud login` is your MCPJam account.
+
+| Group | Purpose | Key commands |
+|-------|---------|-------------|
+| [`cloud`](/cli/reference#cloud-workspace) | Account, project link, and workspace | `login`, `logout`, `whoami`, `link`, `status`, `organizations`, `projects`, `sessions` |
+| [`cloud eval`](/cli/reference#cloud-eval-commands) | Author and run eval suites in your hosted MCPJam projects | `create`, `list`, `run`, `status` |
+| [`cloud tunnel`](/cli/reference#cloud-tunnel) | Expose a local MCP server through a public MCPJam tunnel URL, registered as a server in your project | `tunnel --server <name> <url>`, `tunnel --server <name> -- <command>` |
+| [`cloud hosts`](/cli/reference#cloud-hosts-commands) | Manage hosts in your hosted MCPJam projects | `list`, `get`, `create`, `update`, `delete`, `templates` |
+| [`cloud environments`](/cli/reference#cloud-environments-commands) | Manage project environments — the host + servers + pinned skills/plugins bundles eval suites and journeys run against | `list`, `get`, `resolve`, `create`, `update`, `archive`, `restore` |
+| [`cloud images`](/cli/reference#cloud-images-commands) | Manage custom Computer sandbox images (blueprints) | `list`, `get`, `create`, `validate`, `edit`, `build`, `logs`, `use`, `reset`, `promote`, `delete` |
+
+Also under `mcpjam cloud`: `journeys`, `scenarios`, `personas`, `swarms`, `user-testing`. Full flag tables are in the [command reference](/cli/reference).
+
 ## Global flags
 
-These flags apply to every command.
+These flags apply to every command. Cloud credentials `--api-key` / `--api-url` are declared on `mcpjam cloud`, not the program root.
 
 | Flag | Default | Description |
 |------|---------|-------------|
@@ -202,4 +218,5 @@ Connections to servers under test stay open between tool calls, so agents can al
 - [OAuth login](/cli/oauth-login) — authenticate and debug OAuth flows
 - [MCP Apps conformance](/cli/apps-conformance) — validate `_meta.ui.resourceUri` and `ui://` resource wiring
 - [Tools, resources & prompts](/cli/tools-resources-prompts) — exercise the connected surface
+- [Migrating to CLI 4.0](/cli/migration) — command-path and flag changes under `mcpjam cloud`
 - [Full command reference](/cli/reference) — every flag for every command

--- a/docs/cli/reference.mdx
+++ b/docs/cli/reference.mdx
@@ -6,6 +6,8 @@ icon: "book"
 
 Complete flag tables for every `mcpjam` command. For guides and recipes, see the individual command pages.
 
+Account-bound Cloud commands live under `mcpjam cloud`. Local MCP testing stays at the top level (`mcpjam server`, `mcpjam oauth login`, …). Credential flags `--api-key` / `--api-url` are declared on `mcpjam cloud` and work before or after descendants. Hosted `readiness` stays at the root and still takes leaf `--api-key`. See [Migrating to CLI 4.0](/cli/migration).
+
 ## Global flags
 
 | Flag | Default | Description |
@@ -453,9 +455,9 @@ The result includes a per-host `verdict` (`works`, `degraded`, `blocked`, or `un
 
 ---
 
-## `hosts` commands
+## `cloud hosts` commands
 
-Manage the hosts saved in your hosted MCPJam projects. All `hosts` commands require an `sk_` API key (via `--api-key` or the `MCPJAM_API_KEY` environment variable) or a prior `mcpjam login`.
+Manage the hosts saved in your hosted MCPJam projects. All `hosts` commands require an `sk_` API key (via `--api-key` or the `MCPJAM_API_KEY` environment variable) or a prior `mcpjam cloud login`.
 
 ### Shared platform flags
 
@@ -464,24 +466,24 @@ Manage the hosts saved in your hosted MCPJam projects. All `hosts` commands requ
 | `--api-key <key>` | MCPJam `sk_` API key (overrides `MCPJAM_API_KEY`) |
 | `--api-url <url>` | MCPJam API base URL (defaults to `https://app.mcpjam.com/api/v1`) |
 
-### `hosts templates`
+### `cloud hosts templates`
 
-List the built-in host templates usable with `hosts create --template`. No additional flags.
+List the built-in host templates usable with `mcpjam cloud hosts create --template`. No additional flags.
 
-### `hosts list`
+### `cloud hosts list`
 
 | Flag | Description |
 |------|-------------|
 | `--project <id-or-name>` | Project name or ID (defaults to the most recently updated project) |
 
-### `hosts get`
+### `cloud hosts get`
 
 | Flag | Required | Description |
 |------|----------|-------------|
 | `--host <id-or-name>` | Yes | Host name or ID |
 | `--project <id-or-name>` | No | Project name or ID |
 
-### `hosts create`
+### `cloud hosts create`
 
 | Flag | Required | Description |
 |------|----------|-------------|
@@ -494,7 +496,7 @@ List the built-in host templates usable with `hosts create --template`. No addit
 
 Provide either `--template` or `--file`/`--json`, not both.
 
-### `hosts update`
+### `cloud hosts update`
 
 | Flag | Required | Description |
 |------|----------|-------------|
@@ -504,7 +506,7 @@ Provide either `--template` or `--file`/`--json`, not both.
 | `--file <path>` | No | Replacement host config v2 JSON (or `-` for stdin) |
 | `--json <json>` | No | Inline replacement host config v2 JSON (or `@file`, or `-`) |
 
-### `hosts delete`
+### `cloud hosts delete`
 
 | Flag | Required | Description |
 |------|----------|-------------|
@@ -513,15 +515,15 @@ Provide either `--template` or `--file`/`--json`, not both.
 
 ---
 
-## `environments` commands
+## `cloud environments` commands
 
 Manage **project environments** in your hosted MCPJam projects. A project environment is a named, live-editable execution bundle — one host, optionally a standalone server group, optionally a pinned skill selection and pinned plugin versions — that eval suites and journeys run against.
 
 <Note>
-A project environment is not a Computer sandbox image (those are `mcpjam images`), and not the STDIO environment variables you pass with `--env`.
+A project environment is not a Computer sandbox image (those are `mcpjam cloud images`), and not the STDIO environment variables you pass with `--env`.
 </Note>
 
-All `environments` commands require an `sk_` API key (via `--api-key` or the `MCPJAM_API_KEY` environment variable) or a prior `mcpjam login`. Reading requires project membership; **creating, updating, archiving, and restoring require project admin** — a key bound to a non-admin gets a `FORBIDDEN` error on those.
+All `environments` commands require an `sk_` API key (via `--api-key` or the `MCPJAM_API_KEY` environment variable) or a prior `mcpjam cloud login`. Reading requires project membership; **creating, updating, archiving, and restoring require project admin** — a key bound to a non-admin gets a `FORBIDDEN` error on those.
 
 ### Shared platform flags
 
@@ -535,27 +537,27 @@ All `environments` commands require an `sk_` API key (via `--api-key` or the `MC
 Environments use optimistic concurrency. Every write takes `--expected-revision`, the `revision` you last read:
 
 ```bash
-mcpjam environments get --environment Staging          # note the "revision" field
-mcpjam environments update --environment Staging --expected-revision 3 --name Prod
+mcpjam cloud environments get --environment Staging          # note the "revision" field
+mcpjam cloud environments update --environment Staging --expected-revision 3 --name Prod
 ```
 
 If someone else changed the environment in between, the write fails with a `CONFLICT` error (HTTP 409) instead of overwriting their edit — re-read it and retry. `CONFLICT` also covers a duplicate name and archive-state errors (archiving something already archived, editing something archived), so read the message.
 
-### `environments list`
+### `cloud environments list`
 
 | Flag | Description |
 |------|-------------|
 | `--project <id-or-name>` | Project name or ID (defaults to the most recently updated project) |
 | `--include-archived` | Include archived environments (needed to find one to restore) |
 
-### `environments get`
+### `cloud environments get`
 
 | Flag | Required | Description |
 |------|----------|-------------|
 | `--environment <id-or-name>` | Yes | Environment name or ID |
 | `--project <id-or-name>` | No | Project name or ID |
 
-### `environments resolve`
+### `cloud environments resolve`
 
 Preview what the environment resolves to right now: the host's current config, the closed server set, and the pinned plugin versions. Fails with `CONFLICT` when the environment can't currently produce a runnable configuration (for example a pinned plugin was disabled); `details.code` carries the specific reason.
 
@@ -564,7 +566,7 @@ Preview what the environment resolves to right now: the host's current config, t
 | `--environment <id-or-name>` | Yes | Environment name or ID |
 | `--project <id-or-name>` | No | Project name or ID |
 
-### `environments create`
+### `cloud environments create`
 
 | Flag | Required | Description |
 |------|----------|-------------|
@@ -578,14 +580,14 @@ Preview what the environment resolves to right now: the host's current config, t
 \* `--name` and `--host-id` may instead be supplied inside `--file`/`--json`; explicit flags override the same key in the JSON body. Use the JSON body for the structured fields that have no flag — `serverAttachmentId`, `skillSelection`, and `pluginVersionIds`:
 
 ```bash
-mcpjam environments create --project Acme --json '{
+mcpjam cloud environments create --project Acme --json '{
   "name": "Staging",
   "hostId": "h_123",
   "skillSelection": { "mode": "explicit", "skillIds": ["sk_1"] }
 }'
 ```
 
-### `environments update`
+### `cloud environments update`
 
 | Flag | Required | Description |
 |------|----------|-------------|
@@ -601,11 +603,11 @@ mcpjam environments create --project Acme --json '{
 Only the fields you pass change. To **clear** `serverAttachmentId`, `skillSelection`, or `pluginVersionIds`, send an explicit `null` in the JSON body — an empty array is rejected, it is not a way to clear:
 
 ```bash
-mcpjam environments update --environment Staging --expected-revision 3 \
+mcpjam cloud environments update --environment Staging --expected-revision 3 \
   --json '{ "pluginVersionIds": null }'
 ```
 
-### `environments archive`
+### `cloud environments archive`
 
 Archiving is reversible and frees the name for a new environment; the row is kept.
 
@@ -615,7 +617,7 @@ Archiving is reversible and frees the name for a new environment; the row is kep
 | `--expected-revision <n>` | Yes | The revision you last read |
 | `--project <id-or-name>` | No | Project name or ID |
 
-### `environments restore`
+### `cloud environments restore`
 
 Fails with `CONFLICT` if another live environment took the name while this one was archived. Plugin pins whose version no longer exists at all are dropped on restore — compare the returned `pluginVersionIds` against what you archived.
 
@@ -625,7 +627,7 @@ Fails with `CONFLICT` if another live environment took the name while this one w
 | `--expected-revision <n>` | Yes | The revision you last read (use `environments list --include-archived`) |
 | `--project <id-or-name>` | No | Project name or ID |
 
-### `environments ensure-adhoc`
+### `cloud environments ensure-adhoc`
 
 Get or create an **unnamed** environment for a composed stack. Deduplicated by content: the same stack always returns the same environment, with `created: false` on the second call. Ad-hoc environments do not appear in `environments list` — they exist so a one-off combination can be run and reproduced without adding a name to the project's list.
 
@@ -640,7 +642,7 @@ Requires project membership, not admin (pinning plugin versions still requires a
 | `--skill <id...>` | No | Project-shared skill IDs to pin |
 | `--project <id-or-name>` | No | Project name or ID |
 
-### `environments name`
+### `cloud environments name`
 
 Promote an ad-hoc environment to a named one **in place** — the same id every existing run already points at, so history stays attached. Fails with `CONFLICT` if the environment already has a name.
 
@@ -661,7 +663,7 @@ Both pin fields are narrower than they look:
 
 ---
 
-## `images` commands
+## `cloud images` commands
 
 Manage custom Computer sandbox images in your hosted MCPJam projects. An image is defined by a **blueprint** — YAML with a digest-pinned `base` image, `initialize` steps baked into the image at build time, and `maintenance` / `knowledge` text delivered to the agent at runtime (never executed automatically):
 
@@ -677,7 +679,7 @@ knowledge:
   - name: Test notes
     contents: Run `make test` before pushing.
 ```
- All `images` commands require an `sk_` API key (via `--api-key` or the `MCPJAM_API_KEY` environment variable) or a prior `mcpjam login`.
+ All `images` commands require an `sk_` API key (via `--api-key` or the `MCPJAM_API_KEY` environment variable) or a prior `mcpjam cloud login`.
 
 ### Shared platform flags
 
@@ -686,20 +688,20 @@ knowledge:
 | `--api-key <key>` | MCPJam `sk_` API key (overrides `MCPJAM_API_KEY`) |
 | `--api-url <url>` | MCPJam API base URL (defaults to `https://app.mcpjam.com/api/v1`) |
 
-### `images list`
+### `cloud images list`
 
 | Flag | Description |
 |------|-------------|
 | `--project <id-or-name>` | Project name or ID (defaults to the most recently updated project) |
 
-### `images get`
+### `cloud images get`
 
 | Flag | Required | Description |
 |------|----------|-------------|
 | `--image <id-or-name>` | Yes | Sandbox image name or ID |
 | `--project <id-or-name>` | No | Project name or ID |
 
-### `images validate`
+### `cloud images validate`
 
 Lint a blueprint without saving it. Prints `ok` plus the resolved base digest, or structured errors with the YAML path of each violation.
 
@@ -708,7 +710,7 @@ Lint a blueprint without saving it. Prints `ok` plus the resolved base digest, o
 | `--file <path>` | Yes | Blueprint YAML path, or `-` to read from stdin |
 | `--project <id-or-name>` | No | Project name or ID |
 
-### `images create`
+### `cloud images create`
 
 | Flag | Required | Description |
 |------|----------|-------------|
@@ -716,7 +718,7 @@ Lint a blueprint without saving it. Prints `ok` plus the resolved base digest, o
 | `--file <path>` | Yes | Blueprint YAML path, or `-` to read from stdin |
 | `--project <id-or-name>` | No | Project name or ID |
 
-### `images edit`
+### `cloud images edit`
 
 | Flag | Required | Description |
 |------|----------|-------------|
@@ -725,7 +727,7 @@ Lint a blueprint without saving it. Prints `ok` plus the resolved base digest, o
 | `--name <name>` | No | New display name |
 | `--file <path>` | No | Replacement blueprint YAML path (or `-` for stdin) |
 
-### `images build`
+### `cloud images build`
 
 Trigger an image build for the sandbox image (async). Poll `images logs` to check build status.
 
@@ -734,7 +736,7 @@ Trigger an image build for the sandbox image (async). Poll `images logs` to chec
 | `--image <id-or-name>` | Yes | Sandbox image name or ID |
 | `--project <id-or-name>` | No | Project name or ID |
 
-### `images logs`
+### `cloud images logs`
 
 Show a sandbox image's builds (newest first) with their log preview.
 
@@ -743,7 +745,7 @@ Show a sandbox image's builds (newest first) with their log preview.
 | `--image <id-or-name>` | Yes | Sandbox image name or ID |
 | `--project <id-or-name>` | No | Project name or ID |
 
-### `images use`
+### `cloud images use`
 
 Boot your computer from this sandbox image. This rebuilds the computer — installed files are wiped.
 
@@ -752,7 +754,7 @@ Boot your computer from this sandbox image. This rebuilds the computer — insta
 | `--image <id-or-name>` | Yes | Sandbox image name or ID |
 | `--project <id-or-name>` | No | Project name or ID |
 
-### `images reset`
+### `cloud images reset`
 
 Reset your computer to its current image, wiping mutable state.
 
@@ -760,7 +762,7 @@ Reset your computer to its current image, wiping mutable state.
 |------|----------|-------------|
 | `--project <id-or-name>` | No | Project name or ID |
 
-### `images promote`
+### `cloud images promote`
 
 Share a personal-draft sandbox image with the whole project. Requires project admin permissions.
 
@@ -769,7 +771,7 @@ Share a personal-draft sandbox image with the whole project. Requires project ad
 | `--image <id-or-name>` | Yes | Sandbox image name or ID |
 | `--project <id-or-name>` | No | Project name or ID |
 
-### `images delete`
+### `cloud images delete`
 
 Permanently delete a sandbox image from a project.
 
@@ -809,89 +811,21 @@ Stop the local Inspector if it is running.
 
 ---
 
-## `eval` commands
+## `cloud tunnel`
 
-Author and run eval suites in your hosted MCPJam projects. All `eval` subcommands require an MCPJam API key (`--api-key` or `MCPJAM_API_KEY`).
-
-### Shared platform flags
-
-| Flag | Description |
-|------|-------------|
-| `--api-key <key>` | MCPJam `sk_` API key (overrides `MCPJAM_API_KEY`) |
-| `--api-url <url>` | MCPJam API base URL (defaults to `https://app.mcpjam.com/api/v1`) |
-
-### `eval create`
-
-Create a runnable eval suite from authored test cases. The suite is persisted and returned with a `suiteId`; it is **not** run. Execute it afterward with `eval run`.
-
-| Flag | Description |
-|------|-------------|
-| `--project <id-or-name>` | Project name or ID (defaults to the most recently updated project) |
-| `--file <path>` | Path to a suite definition JSON file (or `-` for stdin) |
-| `--json <json>` | Inline suite definition JSON (or `@file`, or `-` for stdin) |
-| `--name <name>` | Suite name (overrides the file) |
-| `--model <model>` | Suite-level default model, e.g. `anthropic/claude-haiku-4.5` (overrides the file) |
-| `--provider <provider>` | Suite-level default provider (overrides the file; needed for bare or custom model ids) |
-| `--server <name...>` | Project HTTP server names or IDs (overrides the file; repeatable) |
-
-Provide the suite definition via `--file` or `--json` (not both). The definition is a JSON object with at minimum `name`, `model`, `servers`, and `cases`. Servers must be HTTP; stdio servers are rejected before any write.
-
-```bash
-mcpjam eval create \
-  --json '{"name":"smoke","model":"anthropic/claude-haiku-4.5","servers":["My Server"],"cases":[{"title":"echo works","query":"Use the echo tool to say hi","expectedToolCalls":["echo"]}]}' \
-  --api-key $MCPJAM_API_KEY
-```
-
-### `eval list`
-
-List the eval suites saved in a project.
-
-| Flag | Description |
-|------|-------------|
-| `--project <id-or-name>` | Project name or ID (defaults to the most recently updated project) |
-
-### `eval run`
-
-Start an asynchronous eval run of an existing suite. Responds immediately with a `runId`; poll status with `eval status`.
-
-| Flag | Required | Description |
-|------|----------|-------------|
-| `--suite <id-or-name>` | Yes | Eval suite name or ID |
-| `--project <id-or-name>` | No | Project name or ID (defaults to the most recently updated project) |
-| `--server <id-or-name...>` | No | Override the suite's saved server selection (HTTP servers only) |
-| `--environment <id-or-name...>` | No | Attached project environment(s) to run — several start one **paid run each** |
-| `--host <id-or-name...>` | No | Attached host(s) to run — several start one **paid run each** |
-| `--all-targets` | No | Run **every** attached environment (or, if none, every attached host) |
-
-Every remaining flag, the target-selection rules, and the exit codes are
-documented once under [Which target runs](#which-target-runs).
-
-### `eval status`
-
-Get the status and summary of an eval run.
-
-| Flag | Required | Description |
-|------|----------|-------------|
-| `--run <id>` | Yes | Eval run ID (from `eval run`) |
-| `--project <id-or-name>` | Yes | Project name or ID |
-
----
-
-## `tunnel`
-
-Expose a local MCP server through an MCPJam relay tunnel and register it as a server in your hosted project, so evals and scenarios can target it. Requires an `sk_` API key or a prior `mcpjam login`. The tunnel stays up until Ctrl-C; the server record outlives the session (calls fail fast at the edge until you re-run, which revives the same URL slug with a fresh secret).
+Expose a local MCP server through an MCPJam relay tunnel and register it as a server in your hosted project, so evals and scenarios can target it. Requires an `sk_` API key or a prior `mcpjam cloud login`. The tunnel stays up until Ctrl-C; the server record outlives the session (calls fail fast at the edge until you re-run, which revives the same URL slug with a fresh secret).
 
 ```bash
 # HTTP target
-mcpjam tunnel http://localhost:9090/mcp --id my-server --project acme
+mcpjam cloud tunnel http://localhost:9090/mcp --server my-server --project acme
 
 # stdio target (command goes after --)
-mcpjam tunnel --id everything --project acme -- npx -y @modelcontextprotocol/server-everything
+mcpjam cloud tunnel --server everything --project acme -- npx -y @modelcontextprotocol/server-everything
 ```
 
 | Flag | Required | Description |
 |------|----------|-------------|
-| `--id <name>` | Yes | Server name to register in the project. An existing server with this name is pointed at the tunnel: its URL is overwritten, and stdio records are converted to HTTP. |
+| `--server <name>` | Yes | Server name to register in the project. An existing server with this name is pointed at the tunnel: its URL is overwritten, and stdio records are converted to HTTP. Hidden alias: `--id`. |
 | `--project <id-or-name>` | No | Project name or ID (defaults to the most recently updated project) |
 | `--api-key <key>` | No | MCPJam `sk_` API key (overrides `MCPJAM_API_KEY`) |
 | `--api-url <url>` | No | MCPJam API base URL (defaults to `https://app.mcpjam.com/api/v1`) |
@@ -912,7 +846,7 @@ With `--format json`, a single machine-readable startup object (public URL, serv
 
 Grade a saved server against a publisher's directory as the platform reaches it — through the saved server row and the authorize exchange. This is the hosted half of `readiness check`: it answers a different question (what the platform sees, not what your machine sees), can optionally spend credits for model observations, and leaves a persistent record.
 
-All `readiness` hosted commands require an `sk_` API key (via `--api-key` or the `MCPJAM_API_KEY` environment variable) or a prior `mcpjam login`.
+All `readiness` hosted commands require an `sk_` API key (via `--api-key` or the `MCPJAM_API_KEY` environment variable) or a prior `mcpjam cloud login`.
 
 ### Shared platform flags
 
@@ -984,7 +918,7 @@ Read a finished run's findings, ordered most-consequential-first and capped. `tr
 
 ---
 
-## `eval` commands
+## `cloud eval` commands
 
 All `eval` commands accept the shared platform flags below.
 
@@ -995,7 +929,7 @@ All `eval` commands accept the shared platform flags below.
 | `--api-key <key>` | MCPJam `sk_` API key (overrides `MCPJAM_API_KEY`) |
 | `--api-url <url>` | MCPJam API base URL (defaults to `https://app.mcpjam.com/api/v1`) |
 
-### `eval create`
+### `cloud eval create`
 
 Create a runnable eval suite from authored test cases (does not run it).
 
@@ -1007,9 +941,9 @@ Create a runnable eval suite from authored test cases (does not run it).
 | `--name <name>` | No | Suite name (overrides the file) |
 | `--model <model>` | No | Suite-level default model (overrides the file) |
 | `--provider <provider>` | No | Suite-level default provider (overrides the file) |
-| `--server <name...>` | No | Project HTTP server names or IDs (overrides the file) |
+| `--server <id-or-name...>` | No | Project HTTP server names or IDs (overrides the file) |
 
-### `eval list`
+### `cloud eval list`
 
 List the eval suites saved in a project.
 
@@ -1017,7 +951,7 @@ List the eval suites saved in a project.
 |------|----------|-------------|
 | `--project <id-or-name>` | No | Project name or ID (defaults to the most recently updated project) |
 
-### `eval run`
+### `cloud eval run`
 
 Start an eval run of an existing suite (asynchronous).
 
@@ -1110,21 +1044,21 @@ Every run records the environment and the exact revision it used, so `eval
 status` can answer "which configuration did this run actually execute against?"
 long after the environment has been edited.
 
-### `eval status`
+### `cloud eval status`
 
 Get the status and summary of an eval run.
 
 | Flag | Required | Description |
 |------|----------|-------------|
 | `--run <id>` | Yes | Eval run ID (from `eval run`) |
-| `--project <id-or-name>` | Yes | Project name or ID |
+| `--project <id-or-name>` | No | Project name or ID (defaults to the most recently updated project) |
 
 The response carries a `judges` block with each advisory grader's state and
 per-case grades. `status: null` means that judge was never requested for the
 run — different from a judge that ran and graded nothing. In `--format human`,
 each judge that actually graded gets a one-line summary.
 
-### `eval judge`
+### `cloud eval judge`
 
 Grade a finished eval run with LLM as Judge. **Spends your organization's model
 budget.** Returns a pending receipt; read the grades from `eval status`.
@@ -1132,7 +1066,7 @@ budget.** Returns a pending receipt; read the grades from `eval status`.
 | Flag | Required | Description |
 |------|----------|-------------|
 | `--run <id>` | Yes | Eval run ID (from `eval run`) |
-| `--project <id-or-name>` | Yes | Project name or ID |
+| `--project <id-or-name>` | No | Project name or ID (defaults to the most recently updated project) |
 | `--force` | No | Re-grade a run that already has a judge result |
 | `--enable` | No | Grade this run even though the judge was off when it ran |
 | `--judge-model <id>` | No | Judge model for this run only |
@@ -1144,7 +1078,7 @@ what grades it, and it changes nothing beyond that run. Passing neither
 `--judge-model` nor `--judge-threshold` grades with the suite's own config,
 clearing any override a previous request left on the run.
 
-### `eval iterations`
+### `cloud eval iterations`
 
 List per-iteration results for an eval run (pass/fail, tool calls, tokens, latency). Results are paginated.
 
@@ -1155,7 +1089,7 @@ List per-iteration results for an eval run (pass/fail, tool calls, tokens, laten
 | `--cursor <cursor>` | No | Pagination cursor from a previous response |
 | `--limit <n>` | No | Max iterations per page (1–200) |
 
-### `eval trace`
+### `cloud eval trace`
 
 Fetch the full trace for one eval iteration (complete message history and spans). Can be large.
 
@@ -1165,7 +1099,7 @@ Fetch the full trace for one eval iteration (complete message history and spans)
 | `--iteration <id>` | Yes | Iteration ID (from `eval iterations`) |
 | `--project <id-or-name>` | Yes | Project the run belongs to (name or ID) |
 
-### `eval get`
+### `cloud eval get`
 
 Show an eval suite's full settings.
 
@@ -1174,7 +1108,7 @@ Show an eval suite's full settings.
 | `--suite <id-or-name>` | Yes | Eval suite name or ID |
 | `--project <id-or-name>` | No | Project name or ID (defaults to the most recently updated project) |
 
-### `eval validate`
+### `cloud eval validate`
 
 Validate a local eval **suite file** — the versioned declarative document that
 describes a suite, its defaults and its cases (`schemaVersion: "1"`, YAML
@@ -1239,7 +1173,7 @@ fixtures against a project's live discovery — that is project-aware validation
 it needs a network round trip, and it is deliberately deferred. A file that
 validates here can still fail to run.
 
-### `eval export`
+### `cloud eval export`
 
 Write a hosted eval suite to a local suite file.
 
@@ -1292,7 +1226,7 @@ produces the same case ids.
 The file is written through a sibling temp file and a rename, so an interrupted
 write leaves the previous file exactly as it was.
 
-### `eval update`
+### `cloud eval update`
 
 Edit an eval suite's settings (only the flags you pass change).
 
@@ -1304,8 +1238,8 @@ Edit an eval suite's settings (only the flags you pass change).
 | `--json <json>` | No | Inline suite-update JSON (or `@file`, or `-`) |
 | `--name <name>` | No | Rename the suite |
 | `--description <text>` | No | Suite description |
-| `--server <name...>` | No | Replace the suite's server selection (project server names) |
-| `--computer-image <name-or-id\|off>` | No | Sandbox image eval runs boot a fresh computer from (list them with `mcpjam images list`). `off` uses the provider's default base image |
+| `--server <id-or-name...>` | No | Replace the suite's server selection (project server names) |
+| `--computer-image <id-or-name\|off>` | No | Sandbox image eval runs boot a fresh computer from (list them with `mcpjam cloud images list`). `off` uses the provider's default base image |
 | `--host <name...>` | No | Replace host attachments (by name/ID) |
 | `--model <id>` | No | Execution model ID |
 | `--system-prompt <text>` | No | Execution system prompt |
@@ -1319,7 +1253,7 @@ Edit an eval suite's settings (only the flags you pass change).
 | `--judge-model <id>` | No | Judge model ID |
 | `--judge-threshold <0-1>` | No | Judge pass threshold, 0–1 (a case passes when its score is at or above it) |
 
-### `eval checks list`
+### `cloud eval checks list`
 
 List the repositories whose pull requests run an eval suite, plus the
 repositories the MCPJam GitHub App can reach.
@@ -1333,7 +1267,7 @@ all, so connecting a repository will not help. `connectable: null` means the
 App could not be asked (GitHub unavailable, or no installation) — different
 from an empty list, which would mean it reaches nothing.
 
-### `eval checks connect`
+### `cloud eval checks connect`
 
 Run this suite on every pull request to a repository. **Affects everyone who
 opens a pull request on that repository**, and with `fail-closed` it can block
@@ -1352,7 +1286,7 @@ this command afterwards. Retargeting a repository at a different suite, pausing
 it, and disconnecting all live in the app's Settings → Integrations, where every
 connected repository is visible at once.
 
-### `eval delete`
+### `cloud eval delete`
 
 Permanently delete an eval suite (and its cases and runs).
 
@@ -1361,7 +1295,7 @@ Permanently delete an eval suite (and its cases and runs).
 | `--suite <id-or-name>` | Yes | Eval suite name or ID |
 | `--project <id-or-name>` | No | Project name or ID (defaults to the most recently updated project) |
 
-### `eval schedule`
+### `cloud eval schedule`
 
 Enable or disable scheduled runs for a suite.
 
@@ -1381,12 +1315,12 @@ must pin one with `--environment`; a suite with exactly one defaults to it. `--e
 is rejected with `--disable`: disabling preserves the existing pin, so accepting one there
 would silently do nothing.
 
-### `eval environments` subcommands
+### `cloud eval environments` subcommands
 
 Attach or detach the project environments an eval suite runs against. Attaching is what
 makes `eval run --environment` available for the suite.
 
-#### `eval environments set`
+#### `cloud eval environments set`
 
 Replace the suite's attached environments (this sets the whole list, in order).
 
@@ -1397,13 +1331,13 @@ Replace the suite's attached environments (this sets the whole list, in order).
 | `--project <id-or-name>` | No | Project name or ID (defaults to the most recently updated project) |
 
 ```bash
-mcpjam eval environments set --suite "Checkout smoke" --environment Staging Prod
+mcpjam cloud eval environments set --suite "Checkout smoke" --environment Staging Prod
 ```
 
 Rejected if it would strand an enabled schedule pinned to an environment being removed —
 repoint the schedule (`eval schedule --enable --environment ...`) or disable it first.
 
-#### `eval environments clear`
+#### `cloud eval environments clear`
 
 Detach every environment, reverting the suite to its saved server selection.
 
@@ -1416,9 +1350,9 @@ Subject to the same schedule guard as `set`: rejected if the suite has an
 enabled schedule pinned to one of the environments being removed. Repoint the
 schedule or disable it first.
 
-### `eval cases` subcommands
+### `cloud eval cases` subcommands
 
-#### `eval cases list`
+#### `cloud eval cases list`
 
 List a suite's test cases.
 
@@ -1427,7 +1361,7 @@ List a suite's test cases.
 | `--suite <id-or-name>` | Yes | Eval suite name or ID |
 | `--project <id-or-name>` | No | Project name or ID (defaults to the most recently updated project) |
 
-#### `eval cases get`
+#### `cloud eval cases get`
 
 Show one test case.
 
@@ -1437,7 +1371,7 @@ Show one test case.
 | `--case <id-or-title>` | Yes | Eval case title or ID |
 | `--project <id-or-name>` | No | Project name or ID (defaults to the most recently updated project) |
 
-#### `eval cases run`
+#### `cloud eval cases run`
 
 Run a single case as a persisted, fully-queryable run — inspect it with `eval iterations` /
 `eval steps` like any other run.
@@ -1463,7 +1397,7 @@ Every `--compose-*` flag behaves exactly as it does for `eval run` — see
 Target selection follows the same rules ([Which target runs](#which-target-runs)),
 except that a single case run targets ONE thing — there is no `--all-targets` here.
 
-#### `eval cases create`
+#### `cloud eval cases create`
 
 Add a test case to a suite (definition via `--file`/`--json`).
 
@@ -1475,7 +1409,7 @@ Add a test case to a suite (definition via `--file`/`--json`).
 | `--json <json>` | No | Inline case JSON (or `@file`, or `-`) |
 | `--title <title>` | No | Case title (overrides the body) |
 
-#### `eval cases update`
+#### `cloud eval cases update`
 
 Edit a test case (definition via `--file`/`--json`).
 
@@ -1488,7 +1422,7 @@ Edit a test case (definition via `--file`/`--json`).
 | `--json <json>` | No | Inline case JSON (or `@file`, or `-`) |
 | `--title <title>` | No | Rename the case |
 
-#### `eval cases delete`
+#### `cloud eval cases delete`
 
 Permanently delete a test case.
 
@@ -1498,7 +1432,7 @@ Permanently delete a test case.
 | `--case <id-or-title>` | Yes | Eval case title or ID |
 | `--project <id-or-name>` | No | Project name or ID (defaults to the most recently updated project) |
 
-#### `eval cases generate`
+#### `cloud eval cases generate`
 
 AI-generate test cases from the suite's tools (spends credits).
 
@@ -1552,11 +1486,57 @@ Persistently enables anonymous CLI telemetry. If no install ID exists yet, this 
 
 ---
 
-## `login` / `logout` / `whoami` commands
+
+## `cloud` workspace
+
+`mcpjam cloud` is the account-bound namespace. Log in, link a project, then run evals, tunnels, and the rest of the Cloud groups.
+
+### Cloud account session
+
+See [`cloud login` / `logout` / `whoami`](#cloud-login--logout--whoami) below.
+
+### `cloud link`
+
+Pin the current Git worktree (or `--here` cwd) to a Cloud project by writing `.mcpjam/project.json`. No secrets. Bare `link` ignores an existing file when choosing what to pin.
+
+| Flag | Description |
+|------|-------------|
+| `[project]` | Optional project name or ID to pin. Omit to pick the most recently updated project. |
+| `--here` | Write the link in the current working directory instead of the Git worktree root. |
+| `--remove` | Remove the nearest project link (or the current-directory link with `--here`). Cannot be combined with `[project]`. |
+
+### `cloud status`
+
+Zero-network. Prints credential source and the project selector that Cloud commands would use (flag / env / link / automatic).
+
+### `cloud organizations list`
+
+List organizations and their ids. An `sk_` key sees only its own. Use the id with `mcpjam cloud projects list --org <id>`.
+
+### `cloud projects list`
+
+| Flag | Description |
+|------|-------------|
+| `--org <id>` | Restrict the listing to one organization (ID only; see `organizations list`) |
+
+### `cloud sessions list`
+
+List Playground chat sessions in the selected project. Same project-selection rule as other Cloud commands.
+
+| Flag | Description |
+|------|-------------|
+| `--project <id-or-name>` | Project name or ID (defaults to the most recently updated project) |
+| `--all-projects` | List across every accessible project. Conflicts with `--project`. |
+| `--status <status>` | Filter by session status |
+| `--limit <n>` | Maximum sessions to return (1–200) |
+
+---
+
+## `cloud login` / `logout` / `whoami`
 
 These commands manage your MCPJam platform session. `login` opens a browser for OAuth and stores the session locally; `logout` removes it; `whoami` shows the account behind the current credentials.
 
-### `login`
+### `cloud login`
 
 | Flag | Default | Description |
 |------|---------|-------------|
@@ -1588,13 +1568,13 @@ After a successful login, the result includes:
 
 Account details (`email` and `plan`) are fetched from the platform after the OAuth exchange completes. If the lookup fails, login still succeeds and a warning is printed to stderr (suppressed with `--quiet`).
 
-### `logout`
+### `cloud logout`
 
 No additional flags. Removes the stored MCPJam session.
 
 When `MCPJAM_API_KEY` is set to an active `sk_` key, `logout` prints a warning to stderr (human format only) noting that the CLI remains authenticated via the environment variable even after the stored session is cleared. JSON output is unaffected.
 
-### `whoami`
+### `cloud whoami`
 
 | Flag | Default | Description |
 |------|---------|-------------|

--- a/docs/contributing/evals-architecture.mdx
+++ b/docs/contributing/evals-architecture.mdx
@@ -8,7 +8,7 @@ The evals system spans three surfaces that share one backend:
 
 - **Inspector Evaluate UI** — author suites and cases, run them hosted, inspect traces. See [Evaluate](/inspector/evals) for the product view.
 - **`@mcpjam/sdk`** — run evals in your own process (`EvalTest` / `EvalSuite`) and upload results. See [Running Evals](/sdk/concepts/running-evals).
-- **`mcpjam` CLI** — author, start, and inspect hosted runs from a terminal (`mcpjam eval …`). See the [command reference](/cli/reference#eval-commands).
+- **`mcpjam` CLI** — author, start, and inspect hosted runs from a terminal (`mcpjam cloud eval …`). See the [command reference](/cli/reference#cloud-eval-commands).
 
 This page covers the wiring underneath: where results enter the system, how host configuration stays consistent across surfaces, and where the code lives.
 
@@ -138,7 +138,7 @@ The legacy `/sdk/v1/evals/*` endpoints and the project API keys (`mcpjam_…`) t
 
 ## Predicate gate
 
-The deterministic pass/fail layer lives in `@mcpjam/sdk/predicates` (`sdk/src/predicates/`), browser-safe so the Inspector GUI runner and the `mcpjam eval` CLI share one implementation:
+The deterministic pass/fail layer lives in `@mcpjam/sdk/predicates` (`sdk/src/predicates/`), browser-safe so the Inspector GUI runner and the `mcpjam cloud eval` CLI share one implementation:
 
 - `types.ts` — the `Predicate` union (12 types) plus Zod schemas. The union grows only when a real corpus task demands it.
 - `evaluate.ts` — `evaluatePredicate` / `evaluatePredicates` / `evaluateTurnChecks`, pure functions over an `IterationTranscript`.

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -117,6 +117,7 @@
             "icon": "map",
             "pages": [
               "cli/overview",
+              "cli/migration",
               "cli/mcp-server",
               "cli/server-inspection",
               "cli/oauth-conformance",

--- a/docs/getting-started.mdx
+++ b/docs/getting-started.mdx
@@ -91,7 +91,7 @@ You should see your server show **Connected** with a green dot in the **Connect*
   <Accordion title="Where are my files saved?" icon="folder">
     It depends what you mean. The word covers three different things:
 
-    - **OAuth credentials** from `mcpjam login`: `~/.mcpjam/config.json`. Override per command with `--credentials-out`. See [CLI OAuth login](/cli/oauth-login).
+    - **OAuth credentials** from `mcpjam oauth login`: `~/.mcpjam/config.json`. Override per command with `--credentials-out`. See [CLI OAuth login](/cli/oauth-login).
     - **Eval results**: uploaded to your MCPJam project when `MCPJAM_API_KEY` is set to an MCPJam API key (`sk_…`). See [Saving Results](/sdk/concepts/saving-results).
     - **Inspector UI changes** (server config, client edits): persisted via the **Save** button in the project view.
   </Accordion>

--- a/docs/inspector/computer.mdx
+++ b/docs/inspector/computer.mdx
@@ -105,7 +105,7 @@ knowledge:
 ```
 
 The editor lints as you type (the backend is the single validator; the CLI has
-`mcpjam images validate` for the same check). Build the image, then **Use on
+`mcpjam cloud images validate` for the same check). Build the image, then **Use on
 computer** to boot from it. `base` / `initialize` edits need a re-build;
 `maintenance` / `knowledge` edits take effect at the next chat turn without
 one. Images can be kept private to you or shared with the whole project.

--- a/docs/inspector/evals.mdx
+++ b/docs/inspector/evals.mdx
@@ -137,7 +137,7 @@ For cases where "did the right tools fire" isn't enough — anything graded on t
 
 Open a completed run and find the **LLM as Judge** panel (labelled **Goal judge** when shown inside the suite results split). Pick a judge model (default: `openai/gpt-5.4-mini`) and a threshold (default 0.7), then click **Run judge**. Each case gets a score, an advisory verdict, a one-line reason, and rubric hits. The judge never runs automatically unless you enable **Auto-run** in suite settings.
 
-Judge results are also accessible outside the app. `mcpjam eval status` returns a `judges` block in its JSON output with each grader's status, summary, model used, threshold, and per-case grades. To request grading from the CLI, use `mcpjam eval judge --run <id> --project <name>`. See the [`eval judge` reference](/cli/reference#eval-judge) for the full flag list, including `--force` to re-grade and `--enable` to grade a run recorded before the judge was turned on.
+Judge results are also accessible outside the app. `mcpjam cloud eval status` returns a `judges` block in its JSON output with each grader's status, summary, model used, threshold, and per-case grades. To request grading from the CLI, use `mcpjam cloud eval judge --run <id> --project <name>`. See the [`cloud eval judge` reference](/cli/reference#cloud-eval-judge) for the full flag list, including `--force` to re-grade and `--enable` to grade a run recorded before the judge was turned on.
 
 The same judge config and defaults are shared with **Swarm journeys**. When creating a new journey, expand **Advanced → Judge** to set the judge model and enable auto-grade for that journey. Session score badges (showing the verdict and score) appear in the Sessions list and run matrix cells whenever a session has been graded. Sessions with no transcript still expose the on-demand judge entry point so failed or empty sessions can be graded against the journey goal.
 
@@ -210,7 +210,7 @@ Each eval suite has a **Default Execution Config** section that controls the mod
 
 - **Model and prompt** — Set the default model ID, system prompt, and temperature for all runs in the suite. When running evals against MCP Apps that render widgets, the eval harness automatically enables browser interaction (screenshot, click, type) for any model that supports both vision and tool calling — not just Claude. Models that lack vision or tool calling run without browser interaction.
 - **Tool approval** — Toggle `requireToolApproval` to pause before each tool call during a run.
-- **Minimum iterations** — Set a floor on how many times each case runs. Every case runs at least this many times, regardless of its own iteration count. Use `mcpjam eval update --suite <name> --min-iterations <1-10>` to set this from the CLI; `off` removes the floor.
+- **Minimum iterations** — Set a floor on how many times each case runs. Every case runs at least this many times, regardless of its own iteration count. Use `mcpjam cloud eval update --suite <name> --min-iterations <1-10>` to set this from the CLI; `off` removes the floor.
 - **Server selection** — Servers are not configured here. They come from the suite's environment. The server picker is intentionally hidden in this editor.
 - **Save / Reset** — Click **Save config** to persist changes. Click **Reset** to revert to the last saved state. Unsaved edits are preserved if the page refreshes the config from the server, but are discarded when you switch to a different suite.
 

--- a/docs/reference/openapi.json
+++ b/docs/reference/openapi.json
@@ -79,7 +79,7 @@
     },
     {
       "name": "Tunnels",
-      "description": "Relay tunnels that expose local MCP servers through a public URL, registered as first-class project servers (the `mcpjam tunnel` CLI flow)."
+      "description": "Relay tunnels that expose local MCP servers through a public URL, registered as first-class project servers (the `mcpjam cloud tunnel` CLI flow)."
     },
     {
       "name": "Agent",
@@ -4132,7 +4132,7 @@
           "Tunnels"
         ],
         "summary": "Create (or revive) a relay tunnel for a named project server",
-        "description": "Registers a server record named `name` if missing, mints a relay tunnel grant for it, and **persists the tunnel bearer URL (including the plaintext `?k=` secret) onto the server record's `url`** so evals and scenarios can target the tunnel like any remote server. The plaintext persistence is a deliberate trade-off of the current tunnel MVP — the backend otherwise stores only a hash of the secret — mitigated by rotation: **every call rotates the secret, revokes the previous grant at the edge (disconnecting any live tunnel session for the server), and updates the stored URL**, so re-calling this route is also the rotation/recovery path.\n\nThe caller hosts the tunnel itself: connect a WebSocket to `relayWsUrl` (subprotocol `mcpjam-tunnel.v1`, `Authorization: Bearer <connectToken>`) and serve the relayed requests — this is what `mcpjam tunnel` does. When the host disconnects, the server record stays and calls to the public URL fail fast at the edge.",
+        "description": "Registers a server record named `name` if missing, mints a relay tunnel grant for it, and **persists the tunnel bearer URL (including the plaintext `?k=` secret) onto the server record's `url`** so evals and scenarios can target the tunnel like any remote server. The plaintext persistence is a deliberate trade-off of the current tunnel MVP — the backend otherwise stores only a hash of the secret — mitigated by rotation: **every call rotates the secret, revokes the previous grant at the edge (disconnecting any live tunnel session for the server), and updates the stored URL**, so re-calling this route is also the rotation/recovery path.\n\nThe caller hosts the tunnel itself: connect a WebSocket to `relayWsUrl` (subprotocol `mcpjam-tunnel.v1`, `Authorization: Bearer <connectToken>`) and serve the relayed requests — this is what `mcpjam cloud tunnel` does. When the host disconnects, the server record stays and calls to the public URL fail fast at the edge.",
         "parameters": [
           {
             "$ref": "#/components/parameters/projectId"

--- a/docs/sandbox-images-ui-cli.md
+++ b/docs/sandbox-images-ui-cli.md
@@ -151,7 +151,7 @@ Mirror the `hosts` stack: command (`cli/src/commands/hosts.ts`) → SDK operatio
 3. **`sdk/src/platform/operations.ts`** — operations with zod input schemas +
    `resolveProjectOrThrow(client, input.project, signal)`.
 4. **`cli/src/commands/images.ts`**, registered in `cli/src/index.ts`:
-   `mcpjam images list|get|create|edit|build|logs|use|reset|promote|delete`.
+   `mcpjam cloud images list|get|create|edit|build|logs|use|reset|promote|delete`.
    `create`/`edit` read the blueprint from `--file <path>` or stdin (the "edit
    them with the CLI" requirement); `--format json` like the rest.
 5. **OpenAPI:** add entries for every new route to **`docs/reference/openapi.json`**
@@ -169,8 +169,8 @@ Mirror the `hosts` stack: command (`cli/src/commands/hosts.ts`) → SDK operatio
   → build (stub ⇒ instant on dev) → attach → reset → delete. With
   `COMPUTERS_PROVIDER=e2b` + default stub builder, confirm attach is rejected with
   a clean error. Real builds need `COMPUTERS_ENV_BUILDER=e2b` on the deployment.
-- **CLI**: with an `sk_` key — `mcpjam images create --file blueprint.yaml`,
-  `mcpjam images build <name>`, `mcpjam images logs <name>`, `mcpjam images use <name>`;
+- **CLI**: with an `sk_` key — `mcpjam cloud images create --file blueprint.yaml`,
+  `mcpjam cloud images build <name>`, `mcpjam cloud images logs <name>`, `mcpjam cloud images use <name>`;
   guest token → 401.
 - typecheck + lint each package; **openapi-drift** + the new route/CLI tests pass.
 

--- a/vitest/README.md
+++ b/vitest/README.md
@@ -9,7 +9,7 @@ npm install -D @mcpjam/vitest vitest
 
 ## The flagship: gate a hosted corpus in CI
 
-Pull your hosted suite once with `mcpjam eval pull`, commit the lock, and run
+Pull your hosted suite once with `mcpjam cloud eval pull`, commit the lock, and run
 it locally on every change. The lock is the reproducibility record — the same
 cases, graded the same way, until you pull again.
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Purpose

PR 11 of the CLI local-vs-cloud split. The local `mcpjam mcp` server keeps protocol `name: "mcpjam"` and tells clients it is the CLI testing engine, not hosted Cloud MCP. Includes the merged 4.0 docs from #4204.

Stacked on #4202. Merge after that PR.

## Review follow-up

Overview now covers:

- Local vs Cloud invocations without calling the whole CLI "stateless"
- Credential and API URL precedence (same checks `cloud status` uses)
- Project scope, `cloud link` / `status` / `--remove`, and `sessions list --all-projects`
- The different `--host` meanings (AI client vs saved project Host vs `environments --host-id`)

## What changed

- `serverInfo.title` is `MCPJam CLI`. Protocol `name` remains `mcpjam`.
- 4.0 migration page and retargeted docs (from #4204).

## Rollout

- `"@mcpjam/cli": major` changeset (4.0). Hold Version Packages. Do not publish 4.0.0 until this stack reaches `main`.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-880bc302-7fad-489a-b883-d890bdc3aca6?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-880bc302-7fad-489a-b883-d890bdc3aca6&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Identifies the local `mcpjam mcp` server as MCPJam CLI and completes the CLI 4.0 split between local and Cloud commands. Old stderr: “MCPJam MCP server listening on stdio.” New: “MCPJam CLI MCP server listening on stdio.” Protocol `serverInfo.name` stays `mcpjam`; `serverInfo.title` is `MCPJam CLI`; instructions state this is the local testing engine and no account is required.

- Exports `LOCAL_MCP_SERVER_NAME`/`LOCAL_MCP_SERVER_TITLE`; updates local contract tests to assert the title and instruction text.
- Adds a 4.0 CLI migration guide; retargets Overview/Reference to `cloud` groups; documents Cloud credential/API URL precedence, project selection and link workflow, and the different `--host` meanings; updates `cli/README.md` and OpenAPI (for example, “`mcpjam cloud tunnel`”).
- Enforces docs gates with tests: block 3.x Cloud paths outside `cli/migration`, require one canonical `cloud eval` section, ensure `cli/migration` follows `cli/overview`, require documenting `cloud link --remove`, and reject the old stderr line.
- Hosted `readiness` intentionally remains at the root; `cloud tunnel` uses `--server` (hidden alias `--id`).

**Migration**
- Run account-bound commands under `mcpjam cloud …`. Local commands reject `--api-key`/`--api-url`/`--project`; hosted `readiness` still accepts leaf `--api-key`.
- `cloud eval status` no longer requires `--project`; `cloud sessions list` defaults to the selected project (`--all-projects` restores cross-project).
- Cloud credentials: `--api-key` > `MCPJAM_API_KEY` > `mcpjam cloud login`. API URL: `--api-url` > `MCPJAM_API_URL` > stored login > default.
- Project selection: `--project` > explicit `project` in `--file`/`--json` > `MCPJAM_PROJECT` > nearest `.mcpjam/project.json` > automatic. Use `mcpjam cloud link --remove` to delete a link.
- `@mcpjam/cli` is a major; hold publishing 4.0.0 until this stack lands.

<sup>Written for commit 70fd7574542a6f7ef5d08e7521db7b04689654da. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/MCPJam/inspector/pull/4203?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

