### PR TITLE
Sessions is a tab on the hosted app too

### DIFF
--- a/.changeset/sessions-hosted-allowlist.md
+++ b/.changeset/sessions-hosted-allowlist.md
@@ -1,0 +1,19 @@
+---
+"@mcpjam/inspector": patch
+---
+
+Make the Sessions tab reachable on the hosted app.
+
+The unified Sessions feed shipped with its nav item, route, and
+`unified-sessions-enabled` flag wiring all in place, but `"sessions"` was never
+added to `HOSTED_SIDEBAR_ALLOWED_TABS`. On hosted deployments the sidebar builds
+from `getHostedNavigationSections`, which drops any item whose segment is not on
+that list — and it runs *before* the feature-flag filter. So flagged-in users on
+app.mcpjam.com saw no Sessions item, and a direct `/sessions` URL fell through to
+Servers via the same policy in `App.tsx`.
+
+Nothing about the feed is hosted-specific: it reads the Convex-backed session
+rows the hosted surfaces already write. Adding the one entry restores parity
+between hosted and local, and `HOSTED_HASH_ALLOWED_TABS` picks it up because it
+spreads the sidebar list. Visibility is still governed by the PostHog flag —
+this only makes the tab reachable.

--- a/mcpjam-inspector/client/src/lib/__tests__/hosted-tab-policy.test.ts
+++ b/mcpjam-inspector/client/src/lib/__tests__/hosted-tab-policy.test.ts
@@ -40,6 +40,18 @@ describe("hosted-tab-policy", () => {
     expect(isHostedHashTabBlocked("scenarios")).toBe(false);
   });
 
+  it("keeps sessions visible in hosted navigation", () => {
+    // Regression: the Sessions nav item shipped with its PostHog flag wired up
+    // but never got an allow-list entry, so `getHostedNavigationSections`
+    // stripped it on app.mcpjam.com before the flag filter ran — the item was
+    // invisible to flagged-in users and `/sessions` fell through to Servers.
+    expect(HOSTED_SIDEBAR_ALLOWED_TABS).toContain("sessions");
+    expect(HOSTED_HASH_ALLOWED_TABS).toContain("sessions");
+    expect(isHostedSidebarTabAllowed("sessions")).toBe(true);
+    expect(isHostedHashTabAllowed("sessions")).toBe(true);
+    expect(isHostedHashTabBlocked("sessions")).toBe(false);
+  });
+
   it("allows profile and organizations hashes in hosted mode", () => {
     expect(HOSTED_HASH_ALLOWED_TABS).toContain("profile");
     expect(HOSTED_HASH_ALLOWED_TABS).toContain("organizations");

--- a/mcpjam-inspector/client/src/lib/hosted-tab-policy.ts
+++ b/mcpjam-inspector/client/src/lib/hosted-tab-policy.ts
@@ -25,6 +25,11 @@ export const HOSTED_SIDEBAR_ALLOWED_TABS = [
   "playground",
   "client-config",
   "evals",
+  // The unified Sessions feed reads the same Convex-backed session rows the
+  // hosted surfaces already write, so there is nothing hosted-specific to
+  // block. Visibility still comes from `unified-sessions-enabled` (PostHog);
+  // this entry only makes the tab REACHABLE, same as `environments` below.
+  "sessions",
   // Project Environments are Convex-backed and hosted-first; the sidebar item
   // and route are additionally gated behind `project-environments-enabled`
   // (PostHog), so this entry only makes the tab REACHABLE — visibility still


### PR DESCRIPTION
## What

Adds `"sessions"` to `HOSTED_SIDEBAR_ALLOWED_TABS` (`client/src/lib/hosted-tab-policy.ts`). One entry, plus a regression test.

## Why

The unified Sessions feed shipped complete — nav item, `/sessions` route, `unified-sessions-enabled` flag resolution (#4041) — but never got an allow-list entry.

On hosted deployments the sidebar builds from `getHostedNavigationSections`, which drops any item whose segment is off that list. It runs **before** `filterByFeatureFlags`, so the flag was never what hid Sessions — the item was stripped from the section before its flag was consulted. `App.tsx:3415` applies the same policy to hash/route resolution, so a direct `/sessions` URL fell through to Servers too.

Verified against production: the flag itself is healthy and evaluating correctly. Posting `person_properties: {email: "marcelo@mcpjam.com"}` to the app's own PostHog relay returns `unified-sessions-enabled = true, condition_match`, and the deployed bundle contains the full post-#4041 wiring — yet the item is absent from the sidebar. The allow-list is the only thing left in the path.

Nothing about the feed is hosted-specific: it reads the Convex-backed session rows the hosted surfaces already write. So this was an oversight, not a deliberate exclusion.

## Notes

- `HOSTED_HASH_ALLOWED_TABS` needs no separate change — it spreads `HOSTED_SIDEBAR_ALLOWED_TABS`.
- Visibility is still governed by the PostHog flag. This only makes the tab **reachable**, the same role the `environments` entry plays.
- `app-surface-coverage.test.ts` requires every policy entry to name a real nav segment; the `sessions` surface already declares `navSegments: ["sessions"]` and is not `hostedBlocked`, so the manifests stay consistent.

## Testing

- `hosted-tab-policy.test.ts` + `app-surface-coverage.test.ts` — 45 passed.
- `mcp-sidebar-feature-flags.test.ts` — 21 passed.
- Confirmed the new test fails on `main` without the fix: `expected [ 'home', 'clients', 'servers', …(19) ] to include 'sessions'`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SDKk2GTgKKbdjHueFR4eMh

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> One-entry navigation allow-list change plus a regression test; visibility remains flag-gated and no session data or auth logic is modified.
> 
> **Overview**
> Makes the **Sessions** tab reachable on hosted by adding `"sessions"` to `HOSTED_SIDEBAR_ALLOWED_TABS`.
> 
> Hosted nav is filtered by that list *before* the `unified-sessions-enabled` flag, so flagged-in users never saw the item and `/sessions` fell through to Servers. Hash allow-list inherits the sidebar list. Visibility is still PostHog-gated; this only restores reachability. Includes a regression test.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 482d70fbb6139d8cee6d99432aa72603c0798cc1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make Sessions reachable on hosted by adding `"sessions"` to `HOSTED_SIDEBAR_ALLOWED_TABS`. Previously hosted builds stripped the nav item and `/sessions` route before feature-flag evaluation; now they’re allowed, while visibility still depends on the PostHog `unified-sessions-enabled` flag.

- Adds `"sessions"` to `HOSTED_SIDEBAR_ALLOWED_TABS`; `HOSTED_HASH_ALLOWED_TABS` inherits it.
- Restores parity with local: this only makes the tab and route reachable; the flag still controls visibility.
- Adds a regression test to lock the policy; related tests pass.

<sup>Written for commit 482d70fbb6139d8cee6d99432aa72603c0798cc1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/MCPJam/inspector/pull/4210?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

