### PR TITLE
Hosted mode blocks tabs it can't serve, instead of allowing ones it can

### DIFF
--- a/.changeset/hosted-tab-policy-blocklist-only.md
+++ b/.changeset/hosted-tab-policy-blocklist-only.md
@@ -1,0 +1,26 @@
+---
+"@mcpjam/inspector": patch
+---
+
+Replace the hosted-mode tab allow-list with a block list derived from the surface manifests.
+
+`hosted-tab-policy.ts` was written when hosted mode was a small subset of the
+desktop app, and it never stopped being default-deny: every new tab had to be
+added to `HOSTED_SIDEBAR_ALLOWED_TABS` by hand, and one that nobody remembered
+was simply absent on app.mcpjam.com — no error, no flag that could bring it
+back, because the sidebar filter runs before `filterByFeatureFlags`. That is how
+Sessions shipped invisible (#4210), and the file had taken 37 commits of
+catch-up edits before it.
+
+The premise had inverted: of ~30 nav segments exactly one, Tracing, genuinely
+cannot run hosted (it needs the local OTLP collector). So the allow-lists and
+their two predicates are gone. `hostedBlocked` in `shared/app-surfaces.ts` — a
+field that already existed and already drove the agent atlas — is now the single
+source of truth, exposed as `listHostedBlockedNavSegments()`, and
+`isHostedTabBlocked()` is the one availability check the sidebar, hash/route
+resolution, and `ui_navigate` all share. `ui-actions.ts` already worked this way.
+
+Behavior change: a new tab is reachable on hosted the day it lands, with its
+feature flag deciding visibility. The sidebar/hash split disappears with the
+allow-lists; it only ever differed on `computer` and `skills`, neither of which
+is a sidebar item.

--- a/mcpjam-inspector/client/src/App.tsx
+++ b/mcpjam-inspector/client/src/App.tsx
@@ -185,7 +185,7 @@ import {
   readProjectDeepLinkParam,
   resolveProjectDeepLinkAction,
 } from "./lib/project-deep-link";
-import { isHostedHashTabAllowed } from "./lib/hosted-tab-policy";
+import { isHostedTabBlocked } from "./lib/hosted-tab-policy";
 import { buildOAuthTokensByServerId } from "./lib/oauth/oauth-tokens";
 import type { OAuthTrace } from "./lib/oauth/oauth-trace";
 import {
@@ -3412,7 +3412,7 @@ export default function App() {
   ]);
 
   useEffect(() => {
-    if (!HOSTED_MODE || isHostedHashTabAllowed(activeTab)) {
+    if (!HOSTED_MODE || !isHostedTabBlocked(activeTab)) {
       return;
     }
     toast.error(`${activeTab} is not available in hosted mode.`);

--- a/mcpjam-inspector/client/src/components/__tests__/mcp-sidebar-feature-flags.test.ts
+++ b/mcpjam-inspector/client/src/components/__tests__/mcp-sidebar-feature-flags.test.ts
@@ -328,9 +328,9 @@ describe("getHostedNavigationSections", () => {
       {
         id: "others",
         items: [
-          // Skills is deliberately NOT sidebar-allowed in hosted mode — it is
-          // reached through the Servers tab switcher — so it is dropped here.
-          { title: "Skills", url: "#skills", icon: FakeIcon },
+          // Tracing is the one surface hosted cannot serve (it needs the
+          // local OTLP collector), so it is the one item dropped here.
+          { title: "Tracing", url: "#tracing", icon: FakeIcon },
           { title: "Tasks", url: "#tasks", icon: FakeIcon },
           {
             title: "Testing",
@@ -352,7 +352,8 @@ describe("getHostedNavigationSections", () => {
 
     expect(result).toHaveLength(1);
     expect(result[0].items).toEqual([
-      // Tasks are hosted-capable (reconnect-per-poll routes), so the item stays.
+      // Everything else survives: the filter is a block list now, so a tab
+      // nobody thought to list is reachable rather than silently missing.
       { title: "Tasks", url: "#tasks", icon: FakeIcon },
       {
         title: "Testing",

--- a/mcpjam-inspector/client/src/components/mcp-sidebar.tsx
+++ b/mcpjam-inspector/client/src/components/mcp-sidebar.tsx
@@ -59,7 +59,7 @@ import {
 } from "@mcpjam/design-system/tooltip";
 import { HOSTED_MODE } from "@/lib/config";
 import {
-  isHostedSidebarTabAllowed,
+  isHostedTabBlocked,
   normalizeHostedHashTab,
 } from "@/lib/hosted-tab-policy";
 import { useAppNavigate } from "@/lib/app-navigation";
@@ -379,6 +379,13 @@ function SidebarNavSkeleton() {
   );
 }
 
+/**
+ * Drop the nav items a hosted deployment cannot serve. Only `hostedBlocked`
+ * surfaces are dropped: this filter runs BEFORE `filterByFeatureFlags`, so
+ * anything it removes is gone with no flag able to bring it back — which is
+ * how the Sessions item stayed invisible on app.mcpjam.com (#4210) while it
+ * was an allow-list.
+ */
 export function getHostedNavigationSections(
   sections: NavSection[]
 ): NavSection[] {
@@ -390,11 +397,11 @@ export function getHostedNavigationSections(
           item.url.replace(/^[#/]+/, "")
         );
 
-        if (isHostedSidebarTabAllowed(normalizedTab)) {
-          return [item];
+        if (isHostedTabBlocked(normalizedTab)) {
+          return [];
         }
 
-        return [];
+        return [item];
       }),
     }))
     .filter((section) => section.items.length > 0);

--- a/mcpjam-inspector/client/src/lib/__tests__/app-surface-coverage.test.ts
+++ b/mcpjam-inspector/client/src/lib/__tests__/app-surface-coverage.test.ts
@@ -24,10 +24,7 @@ import {
   parseOrganizationSection,
   routePaths,
 } from "../app-navigation";
-import {
-  HOSTED_HASH_ALLOWED_TABS,
-  HOSTED_HASH_BLOCKED_TABS,
-} from "../hosted-tab-policy";
+import { HOSTED_HASH_BLOCKED_TABS } from "../hosted-tab-policy";
 
 const screenRoutes = APP_ROUTES.filter((r) => r.kind === "screen");
 
@@ -155,23 +152,21 @@ describe("surface manifests are model-usable", () => {
 });
 
 describe("hosted tab policy stays consistent with the manifests", () => {
-  it("every hosted policy entry names a real nav segment", () => {
+  it("names a real nav segment for every blocked tab", () => {
     // The policy filters segments; it must not name one that no longer
-    // exists, or it silently stops filtering anything.
+    // exists, or it silently stops filtering anything. This holds by
+    // construction now that the list is derived — the test guards the
+    // derivation, not a hand-kept copy of it.
     const segments = new Set(listAppSurfaceNavSegments());
-    for (const tab of [
-      ...HOSTED_HASH_ALLOWED_TABS,
-      ...HOSTED_HASH_BLOCKED_TABS,
-    ]) {
+    for (const tab of HOSTED_HASH_BLOCKED_TABS) {
       expect(segments.has(tab), `policy tab "${tab}"`).toBe(true);
     }
   });
 
-  it("hostedBlocked manifests match the blocked policy list exactly", () => {
-    const blockedByManifest = APP_SURFACES.filter((s) => s.hostedBlocked)
-      .flatMap((s) => s.navSegments)
-      .sort();
-    expect(blockedByManifest).toEqual([...HOSTED_HASH_BLOCKED_TABS].sort());
+  it("blocks hosted surfaces sparingly", () => {
+    // A growing block list means screens are being written that hosted
+    // cannot serve — worth noticing deliberately rather than by drift.
+    expect(HOSTED_HASH_BLOCKED_TABS).toEqual(["tracing"]);
   });
 });
 

--- a/mcpjam-inspector/client/src/lib/__tests__/hosted-tab-policy.test.ts
+++ b/mcpjam-inspector/client/src/lib/__tests__/hosted-tab-policy.test.ts
@@ -1,11 +1,11 @@
 import { describe, expect, it } from "vitest";
 import {
-  HOSTED_HASH_ALLOWED_TABS,
+  listAppSurfaceNavSegments,
+  listHostedBlockedNavSegments,
+} from "@/shared/app-surfaces";
+import {
   HOSTED_HASH_BLOCKED_TABS,
-  HOSTED_SIDEBAR_ALLOWED_TABS,
-  isHostedHashTabAllowed,
-  isHostedHashTabBlocked,
-  isHostedSidebarTabAllowed,
+  isHostedTabBlocked,
   normalizeHostedHashTab,
 } from "../hosted-tab-policy";
 
@@ -16,127 +16,66 @@ describe("hosted-tab-policy", () => {
     expect(normalizeHostedHashTab("registry")).toBe("registry");
   });
 
-  it("keeps prompts visible in hosted sidebar allow-list", () => {
-    expect(HOSTED_SIDEBAR_ALLOWED_TABS).toContain("prompts");
-    expect(isHostedSidebarTabAllowed("prompts")).toBe(true);
+  it("every alias points at a nav segment that still exists", () => {
+    // An alias whose target was renamed resolves to nothing and the hash
+    // falls through to Servers — the same silent failure the allow-list used
+    // to cause.
+    const segments = new Set(listAppSurfaceNavSegments());
+    for (const alias of ["chat", "connect", "hosts", "user-testing", "ci-evals"]) {
+      expect(segments.has(normalizeHostedHashTab(alias)), alias).toBe(true);
+    }
   });
 
-  it("keeps evals visible in hosted sidebar allow-list, including Runs", () => {
-    // Runs is a mode under `/evals` now, not its own tab. The legacy
-    // `ci-evals` id stays an alias so old hash bookmarks resolve rather than
-    // falling through to Servers.
-    expect(HOSTED_SIDEBAR_ALLOWED_TABS).toContain("evals");
-    expect(isHostedSidebarTabAllowed("evals")).toBe(true);
-    expect(HOSTED_SIDEBAR_ALLOWED_TABS).not.toContain("ci-evals");
-    expect(normalizeHostedHashTab("ci-evals")).toBe("evals");
-    expect(isHostedSidebarTabAllowed("ci-evals")).toBe(true);
-  });
-
-  it("keeps scenarios visible in hosted navigation", () => {
-    expect(HOSTED_SIDEBAR_ALLOWED_TABS).toContain("scenarios");
-    expect(HOSTED_HASH_ALLOWED_TABS).toContain("scenarios");
-    expect(isHostedSidebarTabAllowed("scenarios")).toBe(true);
-    expect(isHostedHashTabAllowed("scenarios")).toBe(true);
-    expect(isHostedHashTabBlocked("scenarios")).toBe(false);
-  });
-
-  it("keeps sessions visible in hosted navigation", () => {
-    // Regression: the Sessions nav item shipped with its PostHog flag wired up
-    // but never got an allow-list entry, so `getHostedNavigationSections`
-    // stripped it on app.mcpjam.com before the flag filter ran — the item was
-    // invisible to flagged-in users and `/sessions` fell through to Servers.
-    expect(HOSTED_SIDEBAR_ALLOWED_TABS).toContain("sessions");
-    expect(HOSTED_HASH_ALLOWED_TABS).toContain("sessions");
-    expect(isHostedSidebarTabAllowed("sessions")).toBe(true);
-    expect(isHostedHashTabAllowed("sessions")).toBe(true);
-    expect(isHostedHashTabBlocked("sessions")).toBe(false);
-  });
-
-  it("allows profile and organizations hashes in hosted mode", () => {
-    expect(HOSTED_HASH_ALLOWED_TABS).toContain("profile");
-    expect(HOSTED_HASH_ALLOWED_TABS).toContain("organizations");
-    expect(isHostedHashTabAllowed("profile")).toBe(true);
-    expect(isHostedHashTabAllowed("organizations")).toBe(true);
-  });
-
-  it("allows tasks in hosted mode (reconnect-per-poll routes)", () => {
-    expect(HOSTED_SIDEBAR_ALLOWED_TABS).toContain("tasks");
-    expect(HOSTED_HASH_ALLOWED_TABS).toContain("tasks");
-    expect(isHostedSidebarTabAllowed("tasks")).toBe(true);
-    expect(isHostedHashTabBlocked("tasks")).toBe(false);
-  });
-
-  it("blocks the tracing hash in hosted mode", () => {
+  it("blocks tracing in hosted mode", () => {
+    // The only genuine hosted exclusion: Tracing needs the local OTLP
+    // collector, which a hosted deployment has no way to reach.
     expect(HOSTED_HASH_BLOCKED_TABS).toContain("tracing");
-    expect(isHostedHashTabBlocked("tracing")).toBe(true);
+    expect(isHostedTabBlocked("tracing")).toBe(true);
   });
 
-  // The Auth surface is retired. Without this, reintroducing it would make the
-  // policy silently permissive rather than failing here.
-  it("no longer knows about the retired auth surface", () => {
-    expect(HOSTED_HASH_BLOCKED_TABS).not.toContain("auth");
-    expect(isHostedHashTabBlocked("auth")).toBe(false);
+  it("derives the blocked list from the surface manifests", () => {
+    expect([...HOSTED_HASH_BLOCKED_TABS].sort()).toEqual(
+      listHostedBlockedNavSegments().sort()
+    );
   });
 
-  it("treats #chat as allowed after normalization to #playground", () => {
-    expect(isHostedHashTabAllowed("chat")).toBe(true);
-    expect(isHostedHashTabBlocked("chat")).toBe(false);
+  it("allows every other surface, including ones added later", () => {
+    // The point of the blocklist: a new screen is reachable on hosted the day
+    // it lands, with its feature flag — not this file — deciding visibility.
+    // `sessions` is here because it spent a release invisible on hosted for
+    // exactly the opposite reason (#4210).
+    for (const tab of [
+      "sessions",
+      "scenarios",
+      "swarms",
+      "evals",
+      "environments",
+      "conformance",
+      "compatibility",
+      "oauth-flow",
+      "xaa-flow",
+      "learning",
+      "registry",
+      "tasks",
+      "computer",
+      "skills",
+      "playground",
+    ]) {
+      expect(isHostedTabBlocked(tab), tab).toBe(false);
+    }
   });
 
-  it("hides blocked tabs from hosted sidebar", () => {
-    expect(isHostedSidebarTabAllowed("skills")).toBe(false);
-    expect(isHostedSidebarTabAllowed("tracing")).toBe(false);
-    expect(isHostedSidebarTabAllowed("evals")).toBe(true);
-    expect(isHostedHashTabBlocked("evals")).toBe(false);
+  it("resolves legacy aliases before deciding availability", () => {
+    expect(isHostedTabBlocked("chat")).toBe(false);
+    expect(isHostedTabBlocked("ci-evals")).toBe(false);
+    expect(isHostedTabBlocked("user-testing")).toBe(false);
   });
 
-  it("allows oauth-flow in hosted sidebar", () => {
-    expect(isHostedSidebarTabAllowed("oauth-flow")).toBe(true);
-    expect(isHostedHashTabAllowed("oauth-flow")).toBe(true);
-    expect(isHostedHashTabBlocked("oauth-flow")).toBe(false);
-  });
-
-  it("allows conformance in hosted sidebar", () => {
-    expect(HOSTED_SIDEBAR_ALLOWED_TABS).toContain("conformance");
-    expect(HOSTED_HASH_ALLOWED_TABS).toContain("conformance");
-    expect(isHostedSidebarTabAllowed("conformance")).toBe(true);
-    expect(isHostedHashTabAllowed("conformance")).toBe(true);
-    expect(isHostedHashTabBlocked("conformance")).toBe(false);
-  });
-
-  it("allows xaa-flow in hosted sidebar", () => {
-    expect(HOSTED_SIDEBAR_ALLOWED_TABS).toContain("xaa-flow");
-    expect(HOSTED_HASH_ALLOWED_TABS).toContain("xaa-flow");
-    expect(isHostedSidebarTabAllowed("xaa-flow")).toBe(true);
-    expect(isHostedHashTabAllowed("xaa-flow")).toBe(true);
-    expect(isHostedHashTabBlocked("xaa-flow")).toBe(false);
-  });
-
-  it("allows environments in hosted navigation (visibility stays flag-gated)", () => {
-    expect(HOSTED_SIDEBAR_ALLOWED_TABS).toContain("environments");
-    expect(HOSTED_HASH_ALLOWED_TABS).toContain("environments");
-    expect(isHostedSidebarTabAllowed("environments")).toBe(true);
-    expect(isHostedHashTabAllowed("environments")).toBe(true);
-    expect(isHostedHashTabBlocked("environments")).toBe(false);
-  });
-
-  it("allows learning in hosted navigation", () => {
-    expect(HOSTED_SIDEBAR_ALLOWED_TABS).toContain("learning");
-    expect(HOSTED_HASH_ALLOWED_TABS).toContain("learning");
-    expect(isHostedSidebarTabAllowed("learning")).toBe(true);
-    expect(isHostedHashTabAllowed("learning")).toBe(true);
-  });
-
-  it("allows the computer hash in hosted mode without adding a sidebar item", () => {
-    // Project Computers are reachable in hosted mode (E2B-backed), gated by
-    // project membership + entitlement + the `computers-enabled` flag — so the
-    // App hosted-mode effect must NOT bounce /computer back to /servers.
-    expect(HOSTED_HASH_ALLOWED_TABS).toContain("computer");
-    expect(isHostedHashTabAllowed("computer")).toBe(true);
-    expect(isHostedHashTabBlocked("computer")).toBe(false);
-    // Computer is reached via the Servers tab switcher, not its own sidebar
-    // entry, so it deliberately stays out of the sidebar allow-list.
-    expect(HOSTED_SIDEBAR_ALLOWED_TABS).not.toContain("computer");
-    expect(isHostedSidebarTabAllowed("computer")).toBe(false);
+  it("treats an unknown segment as allowed, not blocked", () => {
+    // Existence is `isKnownAppTabSegment`'s question (app-navigation.ts).
+    // This module answers availability only, and must not double as a
+    // second, staler registry of what exists.
+    expect(isHostedTabBlocked("auth")).toBe(false);
+    expect(isHostedTabBlocked("some-tab-added-next-quarter")).toBe(false);
   });
 });

--- a/mcpjam-inspector/client/src/lib/app-navigation.ts
+++ b/mcpjam-inspector/client/src/lib/app-navigation.ts
@@ -528,9 +528,10 @@ export function useActiveTab(): string {
  * unreachable by `ui_navigate` while `pathnameToActiveTab` quietly resolves
  * it to Servers. Now the manifest is the single place to add.
  *
- * The hosted policy lists (`hosted-tab-policy.ts`) stay as a FILTER over
- * these segments — availability is a separate question from existence — and
- * a test asserts every policy entry still names a real segment.
+ * The hosted policy (`hosted-tab-policy.ts`) stays as a FILTER over these
+ * segments — availability is a separate question from existence — and it is
+ * derived from the same manifests, so it cannot name a segment that no
+ * longer exists.
  */
 const KNOWN_APP_TAB_SEGMENTS = new Set<string>(listAppSurfaceNavSegments());
 

--- a/mcpjam-inspector/client/src/lib/hosted-tab-policy.ts
+++ b/mcpjam-inspector/client/src/lib/hosted-tab-policy.ts
@@ -1,3 +1,5 @@
+import { listHostedBlockedNavSegments } from "@/shared/app-surfaces";
+
 const HASH_TAB_ALIASES = {
   chat: "playground",
   /** Public hash slug; in-app tab id is `clients`. */
@@ -14,78 +16,36 @@ const HASH_TAB_ALIASES = {
   "ci-evals": "evals",
 } as const;
 
-export const HOSTED_SIDEBAR_ALLOWED_TABS = [
-  "home",
-  "clients",
-  "servers",
-  "host-compare",
-  "registry",
-  "scenarios",
-  "swarms",
-  "playground",
-  "client-config",
-  "evals",
-  // The unified Sessions feed reads the same Convex-backed session rows the
-  // hosted surfaces already write, so there is nothing hosted-specific to
-  // block. Visibility still comes from `unified-sessions-enabled` (PostHog);
-  // this entry only makes the tab REACHABLE, same as `environments` below.
-  "sessions",
-  // Project Environments are Convex-backed and hosted-first; the sidebar item
-  // and route are additionally gated behind `project-environments-enabled`
-  // (PostHog), so this entry only makes the tab REACHABLE — visibility still
-  // comes from the flag.
-  "environments",
-  "tools",
-  "resources",
-  "prompts",
-  // Hosted tasks poll through ephemeral per-request connections
-  // (`/api/web/tasks/*`), so the tab no longer needs a persistent session.
-  "tasks",
-  "support",
-  "settings",
-  "conformance",
-  "compatibility",
-  "oauth-flow",
-  "xaa-flow",
-  "learning",
-] as const;
+/**
+ * Hosted deployments block a tab only when it cannot work there — today that
+ * is Tracing alone, which needs the local OTLP collector.
+ *
+ * This was an ALLOW-list until the Sessions bug (#4210): every new tab had to
+ * be added by hand, the sidebar filter ran before the feature-flag filter, and
+ * a tab that nobody remembered to list was invisible on app.mcpjam.com with no
+ * error to explain it. Default-deny bought nothing — of ~30 nav segments, one
+ * is genuinely hosted-blocked — while costing 37 commits of catch-up edits.
+ *
+ * DERIVED from `hostedBlocked` in the surface manifests, so a screen declares
+ * its own availability next to the rest of its metadata and there is no second
+ * list to keep in sync. Same move `KNOWN_APP_TAB_SEGMENTS` already made in
+ * `app-navigation.ts`.
+ */
+export const HOSTED_HASH_BLOCKED_TABS: readonly string[] =
+  listHostedBlockedNavSegments();
 
-export const HOSTED_HASH_ALLOWED_TABS = [
-  ...HOSTED_SIDEBAR_ALLOWED_TABS,
-  "profile",
-  "organizations",
-  "project-settings",
-  // Project Computers are supported in hosted mode (access is enforced
-  // server-side, not by this list). Reached via the Servers tab switcher, not
-  // a standalone sidebar item, so it needs the hash allow-list only — see PR.
-  "computer",
-  // Cloud Skills are a project-membership resource (Convex-backed, usable in
-  // the Playground without a Computer) but gated behind the `skills-enabled`
-  // PostHog flag until QA completes. Reached via the Servers tab switcher, not
-  // a standalone sidebar item, so it needs the hash allow-list only — the tab
-  // itself is hidden while the flag is off (`useSkillsEnabled`) and the route
-  // guard (`SkillsRoute`) redirects direct navigation.
-  "skills",
-] as const;
-
-export const HOSTED_HASH_BLOCKED_TABS = ["tracing"] as const;
-
-const hostedSidebarAllowedSet = new Set<string>(HOSTED_SIDEBAR_ALLOWED_TABS);
-const hostedHashAllowedSet = new Set<string>(HOSTED_HASH_ALLOWED_TABS);
-const hostedHashBlockedSet = new Set<string>(HOSTED_HASH_BLOCKED_TABS);
+const hostedBlockedSet = new Set<string>(HOSTED_HASH_BLOCKED_TABS);
 
 export function normalizeHostedHashTab(tab: string): string {
   return HASH_TAB_ALIASES[tab as keyof typeof HASH_TAB_ALIASES] ?? tab;
 }
 
-export function isHostedSidebarTabAllowed(tab: string): boolean {
-  return hostedSidebarAllowedSet.has(normalizeHostedHashTab(tab));
-}
-
-export function isHostedHashTabAllowed(tab: string): boolean {
-  return hostedHashAllowedSet.has(normalizeHostedHashTab(tab));
-}
-
-export function isHostedHashTabBlocked(tab: string): boolean {
-  return hostedHashBlockedSet.has(normalizeHostedHashTab(tab));
+/**
+ * The single hosted-availability check, shared by the sidebar, hash/route
+ * resolution, and the agent's `ui_navigate` targets. There is deliberately no
+ * sidebar-specific variant: the two lists differed only in `computer` and
+ * `skills`, neither of which is a sidebar item to begin with.
+ */
+export function isHostedTabBlocked(tab: string): boolean {
+  return hostedBlockedSet.has(normalizeHostedHashTab(tab));
 }

--- a/mcpjam-inspector/client/src/lib/webmcp/ui-actions.ts
+++ b/mcpjam-inspector/client/src/lib/webmcp/ui-actions.ts
@@ -22,7 +22,7 @@ import {
   navigationTargetToPath,
 } from "@/lib/app-navigation";
 import {
-  isHostedHashTabBlocked,
+  isHostedTabBlocked,
   normalizeHostedHashTab,
 } from "@/lib/hosted-tab-policy";
 import { HOSTED_MODE } from "@/lib/config";
@@ -122,7 +122,7 @@ export type ResolvedNavigationTarget =
 export function listUiNavigationTargets(): string[] {
   const all = listKnownAppTabSegments();
   if (!HOSTED_MODE) return all.sort();
-  return all.filter((tab) => !isHostedHashTabBlocked(tab)).sort();
+  return all.filter((tab) => !isHostedTabBlocked(tab)).sort();
 }
 
 /**
@@ -147,7 +147,7 @@ export function resolveUiNavigationTarget(
       reason: `Unknown navigation target "${rawTarget}". Valid targets: ${listUiNavigationTargets().join(", ")}.`,
     };
   }
-  if (HOSTED_MODE && isHostedHashTabBlocked(tab)) {
+  if (HOSTED_MODE && isHostedTabBlocked(tab)) {
     trackNavigationRejected(tab, "hosted_blocked");
     return {
       ok: false,

--- a/mcpjam-inspector/shared/app-surfaces.ts
+++ b/mcpjam-inspector/shared/app-surfaces.ts
@@ -56,7 +56,11 @@ export interface AppSurfaceManifest {
   /** What users actually do here. Model-facing; keep to real actions. */
   userActivities: readonly string[];
   /**
-   * Not reachable in hosted deployments (see `HOSTED_HASH_BLOCKED_TABS`).
+   * Not reachable in hosted deployments — this field is the SOURCE OF TRUTH
+   * for that, and `hosted-tab-policy.ts` derives its block list from it. Set
+   * it only when the screen genuinely cannot work hosted (Tracing needs the
+   * local OTLP collector); a screen that merely isn't ready yet belongs
+   * behind a feature flag instead.
    * Kept out of the atlas when the atlas is built for a hosted surface, so
    * the model isn't handed a map to a door that is locked.
    */
@@ -711,6 +715,23 @@ export function getAppSurfaceByNavSegment(
 export function listAppSurfaceNavSegments(): string[] {
   const out = new Set<string>();
   for (const surface of APP_SURFACES) {
+    for (const segment of surface.navSegments) out.add(segment);
+  }
+  return [...out];
+}
+
+/**
+ * Nav segments a hosted deployment cannot serve — the manifests are the
+ * source of truth, and `hosted-tab-policy.ts` is the only caller.
+ *
+ * Reads through `listAppSurfaces()` rather than `APP_SURFACES` directly:
+ * the const assertion narrows each entry to its own literal type, so an
+ * optional field is absent from the ones that never set it.
+ */
+export function listHostedBlockedNavSegments(): string[] {
+  const out = new Set<string>();
+  for (const surface of listAppSurfaces()) {
+    if (!surface.hostedBlocked) continue;
     for (const segment of surface.navSegments) out.add(segment);
   }
   return [...out];


### PR DESCRIPTION
Follow-up to #4210, which fixed the symptom. This removes the mechanism.

## Why

`hosted-tab-policy.ts` dates from "Add hosted mode" (#1482, February), when hosted really was a small subset of the desktop app and listing what worked there was the honest description. It stayed default-deny long after that stopped being true, and the cost was paid quietly: `getHostedNavigationSections` drops any item off the list, it runs **before** `filterByFeatureFlags`, so a tab nobody remembered to add was invisible on app.mcpjam.com with no error and no flag able to bring it back. Sessions shipped that way. The file had **37 commits** behind it, most of them catch-up edits.

The premise had inverted. Of ~30 nav segments exactly one — Tracing, which needs the local OTLP collector — genuinely cannot run hosted.

## What

- Deleted `HOSTED_SIDEBAR_ALLOWED_TABS`, `HOSTED_HASH_ALLOWED_TABS`, `isHostedSidebarTabAllowed`, `isHostedHashTabAllowed`.
- `hostedBlocked` in `shared/app-surfaces.ts` is now the source of truth — a field that already existed and already drove the agent atlas, sitting next to the rest of a screen's metadata where the author is already looking. Exposed as `listHostedBlockedNavSegments()` (reads through `listAppSurfaces()`, since the const assertion narrows optional fields off entries that don't set them).
- `isHostedTabBlocked()` is the single availability check shared by the sidebar, hash/route resolution in `App.tsx`, and the agent's `ui_navigate`. `ui-actions.ts` already consulted only the block list — it was the consumer that had this right.
- Same move `KNOWN_APP_TAB_SEGMENTS` already made in `app-navigation.ts`: derive from the manifest, don't hand-maintain a parallel list.

## Behavior changes

- A new tab is reachable on hosted the day it lands; visibility is left to feature flags, where it belongs.
- The sidebar/hash split disappears. It differed only on `computer` and `skills`, and neither is a sidebar item — so the sidebar-specific predicate was checking a distinction that could not arise. One sidebar test fed it a synthetic `#skills` item to assert the drop; it now feeds `#tracing`, which is the real case.

## Testing

- `client/src/lib` + `mcp-sidebar-feature-flags` — **2497 passed** (226 files).
- `client/src/__tests__` (App-level routing, hosted OAuth, route guards) — **104 passed**.
- `npx tsc --noEmit -p client/tsconfig.typecheck.json` — clean.

Tests move with the contract rather than restating it: the manifest-consistency check now guards the derivation, and one asserts the block list is still exactly `["tracing"]`, so a surface that genuinely cannot run hosted gets noticed deliberately instead of by drift.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SDKk2GTgKKbdjHueFR4eMh

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes which screens are reachable on hosted (app.mcpjam.com): new tabs are available unless explicitly blocked. Tracing remains blocked; computer/skills hashes are no longer treated as hosted-unavailable.
> 
> **Overview**
> Hosted navigation is now **default-allow**: only surfaces marked `hostedBlocked` in the app-surface manifests are hidden. New tabs show up on hosted as soon as they land; feature flags still control visibility.
> 
> The hand-maintained sidebar/hash allow-lists and their predicates are gone. `listHostedBlockedNavSegments()` derives the block list (today just Tracing, which needs the local OTLP collector), and `isHostedTabBlocked()` is the one check used by the sidebar, route bounce in `App.tsx`, and `ui_navigate`. That removes the silent-missing-tab failure that hid Sessions (#4210).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9fc008b074525c5969791e6dcbf2d995275c7ce5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Hosted mode now blocks only tabs it cannot serve, using a manifest-derived block list. Previously, hosted used a default-deny allow-list that hid unlisted tabs before feature flags ran; now only tabs marked `hostedBlocked` are unavailable (currently just `tracing`), so new tabs are reachable by default.

- Source of truth is `hostedBlocked` in `shared/app-surfaces.ts`, exposed via `listHostedBlockedNavSegments()` and used to derive `HOSTED_HASH_BLOCKED_TABS`.
- Removed `HOSTED_SIDEBAR_ALLOWED_TABS`, `HOSTED_HASH_ALLOWED_TABS`, and per-surface predicates; unified availability check is `isHostedTabBlocked`.
- Sidebar filtering drops only blocked items; the sidebar/hash split is gone.
- `App.tsx` and `ui-actions.ts` consult the unified check; aliases still normalize before evaluation.
- Tests assert the block list matches the manifests and remains `["tracing"]`.

**Rollout**
- No migration required. When a screen truly cannot run hosted, set `hostedBlocked: true` in its surface manifest; otherwise gate visibility with feature flags.

<sup>Written for commit 9fc008b074525c5969791e6dcbf2d995275c7ce5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/MCPJam/inspector/pull/4211?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

