### PR TITLE
fix(electron): keep bundled `ws` off the empty `bufferutil` stub

### DIFF
--- a/.changeset/ws-bufferutil-empty-stub.md
+++ b/.changeset/ws-bufferutil-empty-stub.md
@@ -1,0 +1,15 @@
+---
+"@mcpjam/inspector": patch
+---
+
+Desktop tunnels forward real traffic again, instead of dying on the first MCP message.
+
+**A tunnel created in the desktop app was unusable.** The URL connected, then returned an empty 200 or `{"error":"gateway_timeout"}` for every request, and `main.log` recorded an uncaught `TypeError: mask is not a function` timed exactly to each incoming request. The cause is a bundling accident with a very narrow tell. The Electron main process bundles `ws` — `src/main.ts` dynamically imports the whole server, so `server/services/relay-client.ts` is in that graph — and `ws` decides whether a native masker is available by requiring its optional peer dep `bufferutil` inside a `try` and treating a thrown require as "not installed". `bufferutil` is not installed here, but Vite does not leave the require unresolvable: it resolves an absent optional peer dep to a frozen empty namespace. The require succeeds, returns `{}`, and `ws` installs a fast path whose `.mask` and `.unmask` do not exist.
+
+**Which is why it looked connected.** `ws` only takes the native path above a size threshold — 48 bytes to mask, 32 to unmask. The tunnel handshake and its 0-byte heartbeat pings stayed on the JS implementation and passed, so the app reported a healthy tunnel. Every real MCP JSON-RPC message clears 48 bytes and threw, uncaught, out of the relay's response pump. The relay's own control frames throw on the same line but are swallowed by an existing `try`, so the edge saw nothing at all and timed out. The `unauthorized` responses some users saw were the same thing from the other side: the local client kept dying and de-registering.
+
+**`src/ws-native-fallback.ts` sets `WS_NO_BUFFER_UTIL` before `ws` loads**, which skips the probe and keeps `ws` on its pure-JS masker — a few XORs per byte, well inside what a tunnel moves. It is the first import in `main.ts` because `ws` reads the variable at module-eval time. `WS_NO_UTF_8_VALIDATE` is set alongside it as insurance: `utf-8-validate` is stubbed identically, and is unreachable today only because `ws` prefers `node:buffer`'s `isUtf8`.
+
+**Only the desktop app was ever affected**, and both packaged builds and `electron:dev` were. The `npx` and Docker server and the `mcpjam` CLI leave `ws` as a bare import resolved from real `node_modules`, where the require genuinely throws and the fallback engages as designed. `npm run dev` bundles nothing, which is why this never reproduced locally despite shipping in every release since tunnels replaced ngrok.
+
+**The packaging step now refuses to ship the broken shape.** This class of defect exists only after bundling, so no source-level test can see it; `forge.config.ts`'s `packageAfterCopy` hook, which already inspects the built bundles before asar packing, now fails the build if the `bufferutil` stub is in the graph with nothing setting `WS_NO_BUFFER_UTIL`. It asserts the fix is present rather than the stub absent — the fix stops `ws` from using the stub, it does not remove it.

--- a/mcpjam-inspector/forge.config.ts
+++ b/mcpjam-inspector/forge.config.ts
@@ -8,6 +8,7 @@ import { VitePlugin } from "@electron-forge/plugin-vite";
 import { FusesPlugin } from "@electron-forge/plugin-fuses";
 import { FuseV1Options, FuseVersion } from "@electron/fuses";
 import { resolve } from "path";
+import { assertWsNativeFallback } from "./src/ws-native-fallback.assert";
 
 const enableMacSigning = process.platform === "darwin";
 const macSignIdentity = process.env.MAC_CODESIGN_IDENTITY?.trim();
@@ -197,7 +198,7 @@ const config: ForgeConfig = {
      * build`, and uploading it there keeps this hook to the forge-only outputs.
      *
      * The sourcemap half never throws — a Sentry outage must not fail a signed
-     * release. `assertWsNativeFallback` below deliberately DOES: it guards a
+     * release. `assertWsNativeFallback` deliberately DOES: it guards a
      * defect that only exists after bundling, and a build that ships it is
      * worse than a build that fails.
      */
@@ -307,67 +308,6 @@ function deleteMapsIn(dir: string, fs: FsBits): void {
   } catch {
     // Best effort.
   }
-}
-
-type ReadFsBits = {
-  existsSync: (p: string) => boolean;
-  readdirSync: (p: string) => string[];
-  statSync: (p: string) => { isDirectory: () => boolean };
-  readFileSync: (p: string, enc: "utf8") => string;
-};
-
-/**
- * Fail the package if the bundled `ws` would use Vite's empty stub for its
- * optional `bufferutil` dep (#4208).
- *
- * `ws` decides "no native masker" by `require('bufferutil')` THROWING. Vite
- * resolves an absent optional peer dep to a frozen empty namespace instead, so
- * the require succeeds, `ws` installs a fast path whose `.mask`/`.unmask` are
- * undefined, and every WebSocket frame over the size threshold throws —
- * silently killing tunnels while the handshake still looks healthy.
- *
- * `src/ws-native-fallback.ts` fixes that by setting `WS_NO_BUFFER_UTIL` before
- * `ws` loads. Nothing below the bundler can verify it: the stub only exists
- * after bundling, and the packaged tree is the one place both halves are
- * visible at once. So assert on the artifact — if the stub is in the graph, the
- * assignment that neutralizes it has to be there too.
- *
- * Note the assertion is "fix present", not "stub absent": the fix stops `ws`
- * from USING the stub, it does not remove it from the bundle.
- */
-function assertWsNativeFallback(buildDir: string, fs: ReadFsBits): void {
-  if (!fs.existsSync(buildDir)) return;
-
-  const chunks: string[] = [];
-  const walk = (dir: string) => {
-    for (const entry of fs.readdirSync(dir)) {
-      const full = resolve(dir, entry);
-      if (fs.statSync(full).isDirectory()) walk(full);
-      else if (entry.endsWith(".cjs") || entry.endsWith(".js"))
-        chunks.push(fs.readFileSync(full, "utf8"));
-    }
-  };
-  walk(buildDir);
-
-  const stubbed = chunks.some((c) =>
-    c.includes("__viteOptionalPeerDep_bufferutil_ws"),
-  );
-  if (!stubbed) return;
-
-  // An ASSIGNMENT, not `ws`'s own `!process.env.WS_NO_BUFFER_UTIL` read — that
-  // read is in every bundle containing `ws` and proves nothing.
-  const neutralized = chunks.some((c) =>
-    /WS_NO_BUFFER_UTIL\s*=\s*["']/.test(c),
-  );
-  if (neutralized) return;
-
-  throw new Error(
-    `[forge] ${buildDir} bundles an empty \`bufferutil\` stub for \`ws\` with ` +
-      "nothing setting WS_NO_BUFFER_UTIL. Every WebSocket frame >= 48 bytes " +
-      "would throw `mask is not a function`, and tunnels would die silently " +
-      "(#4208). Restore the `./ws-native-fallback.js` import at the top of " +
-      "src/main.ts.",
-  );
 }
 
 export default config;

--- a/mcpjam-inspector/forge.config.ts
+++ b/mcpjam-inspector/forge.config.ts
@@ -196,13 +196,26 @@ const config: ForgeConfig = {
      * server) is handled by the workflow instead: it IS built by `npm run
      * build`, and uploading it there keeps this hook to the forge-only outputs.
      *
-     * Never throws. A Sentry outage must not fail a signed release.
+     * The sourcemap half never throws — a Sentry outage must not fail a signed
+     * release. `assertWsNativeFallback` below deliberately DOES: it guards a
+     * defect that only exists after bundling, and a build that ships it is
+     * worse than a build that fails.
      */
     packageAfterCopy: async (_forgeConfig, buildPath) => {
       const { execFileSync } = await import("node:child_process");
       const { existsSync, rmSync, readdirSync, statSync, readFileSync } =
         await import("node:fs");
       const fsBits = { existsSync, rmSync, readdirSync, statSync };
+
+      // Before anything best-effort: refuse to pack a main bundle whose `ws`
+      // would reach for the empty optional-peer-dep stub. Runs on every
+      // package/make, costs a grep over already-built output.
+      assertWsNativeFallback(resolve(buildPath, ".vite/build"), {
+        existsSync,
+        readdirSync,
+        statSync,
+        readFileSync,
+      });
 
       // Release name must match what the SDKs init with: `app.getVersion()`
       // in main, `__APP_VERSION__` in the renderer — both package.json.
@@ -294,6 +307,67 @@ function deleteMapsIn(dir: string, fs: FsBits): void {
   } catch {
     // Best effort.
   }
+}
+
+type ReadFsBits = {
+  existsSync: (p: string) => boolean;
+  readdirSync: (p: string) => string[];
+  statSync: (p: string) => { isDirectory: () => boolean };
+  readFileSync: (p: string, enc: "utf8") => string;
+};
+
+/**
+ * Fail the package if the bundled `ws` would use Vite's empty stub for its
+ * optional `bufferutil` dep (#4208).
+ *
+ * `ws` decides "no native masker" by `require('bufferutil')` THROWING. Vite
+ * resolves an absent optional peer dep to a frozen empty namespace instead, so
+ * the require succeeds, `ws` installs a fast path whose `.mask`/`.unmask` are
+ * undefined, and every WebSocket frame over the size threshold throws —
+ * silently killing tunnels while the handshake still looks healthy.
+ *
+ * `src/ws-native-fallback.ts` fixes that by setting `WS_NO_BUFFER_UTIL` before
+ * `ws` loads. Nothing below the bundler can verify it: the stub only exists
+ * after bundling, and the packaged tree is the one place both halves are
+ * visible at once. So assert on the artifact — if the stub is in the graph, the
+ * assignment that neutralizes it has to be there too.
+ *
+ * Note the assertion is "fix present", not "stub absent": the fix stops `ws`
+ * from USING the stub, it does not remove it from the bundle.
+ */
+function assertWsNativeFallback(buildDir: string, fs: ReadFsBits): void {
+  if (!fs.existsSync(buildDir)) return;
+
+  const chunks: string[] = [];
+  const walk = (dir: string) => {
+    for (const entry of fs.readdirSync(dir)) {
+      const full = resolve(dir, entry);
+      if (fs.statSync(full).isDirectory()) walk(full);
+      else if (entry.endsWith(".cjs") || entry.endsWith(".js"))
+        chunks.push(fs.readFileSync(full, "utf8"));
+    }
+  };
+  walk(buildDir);
+
+  const stubbed = chunks.some((c) =>
+    c.includes("__viteOptionalPeerDep_bufferutil_ws"),
+  );
+  if (!stubbed) return;
+
+  // An ASSIGNMENT, not `ws`'s own `!process.env.WS_NO_BUFFER_UTIL` read — that
+  // read is in every bundle containing `ws` and proves nothing.
+  const neutralized = chunks.some((c) =>
+    /WS_NO_BUFFER_UTIL\s*=\s*["']/.test(c),
+  );
+  if (neutralized) return;
+
+  throw new Error(
+    `[forge] ${buildDir} bundles an empty \`bufferutil\` stub for \`ws\` with ` +
+      "nothing setting WS_NO_BUFFER_UTIL. Every WebSocket frame >= 48 bytes " +
+      "would throw `mask is not a function`, and tunnels would die silently " +
+      "(#4208). Restore the `./ws-native-fallback.js` import at the top of " +
+      "src/main.ts.",
+  );
 }
 
 export default config;

--- a/mcpjam-inspector/src/main.ts
+++ b/mcpjam-inspector/src/main.ts
@@ -1,4 +1,8 @@
 /// <reference types="@electron-forge/plugin-vite/forge-vite-env" />
+// MUST stay the first import: it sets WS_NO_BUFFER_UTIL, which `ws` reads at
+// module-eval time, and the bundled `ws` is otherwise handed an empty stub for
+// its optional `bufferutil` dep. See the file for the full story (#4208).
+import "./ws-native-fallback.js";
 import * as Sentry from "@sentry/electron/main";
 import { app, BrowserWindow, shell, Menu, dialog } from "electron";
 import { buildElectronSentryConfig } from "../shared/sentry-config.js";

--- a/mcpjam-inspector/src/ws-native-fallback.assert.test.ts
+++ b/mcpjam-inspector/src/ws-native-fallback.assert.test.ts
@@ -15,7 +15,7 @@ const BUILD = resolve("/build");
 /** An in-memory tree: path -> file contents. Directories are inferred. */
 function fakeFs(
   files: Record<string, string>,
-  overrides: Partial<ReadFsBits> = {}
+  overrides: Partial<ReadFsBits> = {},
 ): ReadFsBits {
   const paths = Object.keys(files).map((p) => resolve(p));
   const isDir = (p: string) => paths.some((f) => f.startsWith(p + "/"));
@@ -64,12 +64,24 @@ describe("assertWsNativeFallback", () => {
     expect(() => assertWsNativeFallback(BUILD, fs)).not.toThrow();
   });
 
-  it("finds chunks nested in subdirectories", () => {
-    const fs = fakeFs({
-      "/build/chunks/deep/app-abc.cjs": STUB,
-      "/build/chunks/main.cjs": FIX,
+  it("descends into subdirectories to find both halves", () => {
+    // Both assertions are load-bearing, and neither is on its own: a walk that
+    // never recursed would find NOTHING nested, and "found nothing" is
+    // indistinguishable from "no stub" — it returns early and throws nothing.
+    // So each direction has to be the one that would notice.
+
+    // Stub nested, no assignment anywhere: only a walk that descended can see
+    // the stub, and seeing it is what makes this throw.
+    const stubNested = fakeFs({ "/build/chunks/deep/app-abc.cjs": STUB });
+    expect(() => assertWsNativeFallback(BUILD, stubNested)).toThrow(/#4208/);
+
+    // Assignment nested, stub at the top: the stub is found either way, so a
+    // walk that stopped short would miss only the fix — and throw.
+    const fixNested = fakeFs({
+      "/build/app-abc.cjs": STUB,
+      "/build/chunks/deep/main.cjs": FIX,
     });
-    expect(() => assertWsNativeFallback(BUILD, fs)).not.toThrow();
+    expect(() => assertWsNativeFallback(BUILD, fixNested)).not.toThrow();
   });
 
   it("throws when the stub is bundled with nothing setting the env var", () => {

--- a/mcpjam-inspector/src/ws-native-fallback.assert.test.ts
+++ b/mcpjam-inspector/src/ws-native-fallback.assert.test.ts
@@ -1,0 +1,133 @@
+import { describe, it, expect } from "vitest";
+import { resolve } from "path";
+import {
+  assertWsNativeFallback,
+  type ReadFsBits,
+} from "./ws-native-fallback.assert";
+
+const STUB = "const __viteOptionalPeerDep_bufferutil_ws_true = {};";
+/** `ws/lib/buffer-util.js`'s own gate. Present in every bundle carrying `ws`. */
+const WS_OWN_READ = "if (!process.env.WS_NO_BUFFER_UTIL) try { require(...) }";
+const FIX = 'process.env.WS_NO_BUFFER_UTIL="1";';
+
+const BUILD = resolve("/build");
+
+/** An in-memory tree: path -> file contents. Directories are inferred. */
+function fakeFs(
+  files: Record<string, string>,
+  overrides: Partial<ReadFsBits> = {}
+): ReadFsBits {
+  const paths = Object.keys(files).map((p) => resolve(p));
+  const isDir = (p: string) => paths.some((f) => f.startsWith(p + "/"));
+
+  return {
+    existsSync: (p) => isDir(p) || paths.includes(resolve(p)),
+    readdirSync: (p) => {
+      const prefix = resolve(p) + "/";
+      const names = new Set<string>();
+      for (const f of paths) {
+        if (!f.startsWith(prefix)) continue;
+        names.add(f.slice(prefix.length).split("/")[0]!);
+      }
+      return [...names];
+    },
+    statSync: (p) => ({ isDirectory: () => isDir(resolve(p)) }),
+    readFileSync: (p) => files[resolve(p)] ?? "",
+    ...overrides,
+  };
+}
+
+describe("assertWsNativeFallback", () => {
+  it("passes when the build directory does not exist", () => {
+    expect(() => assertWsNativeFallback(BUILD, fakeFs({}))).not.toThrow();
+  });
+
+  it("passes when no stub is bundled, even with no assignment anywhere", () => {
+    // The assertion is "fix present IF stub present" — a bundle Vite never
+    // stubbed needs no fix, and demanding one would fail honest builds.
+    const fs = fakeFs({ "/build/main.cjs": WS_OWN_READ });
+    expect(() => assertWsNativeFallback(BUILD, fs)).not.toThrow();
+  });
+
+  it("passes when the stub is bundled alongside the assignment", () => {
+    const fs = fakeFs({ "/build/main.cjs": `${STUB}\n${FIX}` });
+    expect(() => assertWsNativeFallback(BUILD, fs)).not.toThrow();
+  });
+
+  it("passes when the assignment lands in a different chunk than the stub", () => {
+    // Rollup splits main.ts and the server graph into separate chunks, so the
+    // two halves routinely do NOT share a file.
+    const fs = fakeFs({
+      "/build/app-abc.cjs": STUB,
+      "/build/main.cjs": FIX,
+    });
+    expect(() => assertWsNativeFallback(BUILD, fs)).not.toThrow();
+  });
+
+  it("finds chunks nested in subdirectories", () => {
+    const fs = fakeFs({
+      "/build/chunks/deep/app-abc.cjs": STUB,
+      "/build/chunks/main.cjs": FIX,
+    });
+    expect(() => assertWsNativeFallback(BUILD, fs)).not.toThrow();
+  });
+
+  it("throws when the stub is bundled with nothing setting the env var", () => {
+    const fs = fakeFs({ "/build/main.cjs": STUB });
+    expect(() => assertWsNativeFallback(BUILD, fs)).toThrow(/#4208/);
+  });
+
+  it("throws when the only match is `ws`'s own read of the env var", () => {
+    // GUARDRAIL. That read ships in every bundle containing `ws`; accepting it
+    // would make this assertion pass on precisely the builds it exists to stop.
+    const fs = fakeFs({ "/build/main.cjs": `${STUB}\n${WS_OWN_READ}` });
+    expect(() => assertWsNativeFallback(BUILD, fs)).toThrow(/#4208/);
+  });
+
+  it("throws when the assignment is an empty string", () => {
+    // GUARDRAIL. `ws` gates on `!process.env.WS_NO_BUFFER_UTIL`, so `= ""` is
+    // falsy and leaves the probe — and the bug — fully in place.
+    const fs = fakeFs({
+      "/build/main.cjs": `${STUB}\nprocess.env.WS_NO_BUFFER_UTIL="";`,
+    });
+    expect(() => assertWsNativeFallback(BUILD, fs)).toThrow(/#4208/);
+  });
+
+  it("throws when the assignment targets an unrelated binding", () => {
+    const fs = fakeFs({
+      "/build/main.cjs": `${STUB}\nconst WS_NO_BUFFER_UTIL = "1";`,
+    });
+    expect(() => assertWsNativeFallback(BUILD, fs)).toThrow(/#4208/);
+  });
+
+  it('accepts any non-empty value, including "0"', () => {
+    // Env values are strings; `"0"` is truthy in JS and does neutralize `ws`.
+    const fs = fakeFs({
+      "/build/main.cjs": `${STUB}\nprocess.env.WS_NO_BUFFER_UTIL = '0'`,
+    });
+    expect(() => assertWsNativeFallback(BUILD, fs)).not.toThrow();
+  });
+
+  it("ignores files that are not JS chunks", () => {
+    // Sourcemaps carry the original source text, assignment included — reading
+    // them would let a map vouch for a bundle that lost the fix.
+    const fs = fakeFs({
+      "/build/main.cjs": STUB,
+      "/build/main.cjs.map": FIX,
+    });
+    expect(() => assertWsNativeFallback(BUILD, fs)).toThrow(/#4208/);
+  });
+
+  it("propagates a filesystem read error instead of passing the build", () => {
+    // A build that cannot read its own output has not been verified.
+    const fs = fakeFs(
+      { "/build/main.cjs": STUB },
+      {
+        readFileSync: () => {
+          throw new Error("EIO");
+        },
+      },
+    );
+    expect(() => assertWsNativeFallback(BUILD, fs)).toThrow("EIO");
+  });
+});

--- a/mcpjam-inspector/src/ws-native-fallback.assert.ts
+++ b/mcpjam-inspector/src/ws-native-fallback.assert.ts
@@ -1,0 +1,72 @@
+import { resolve } from "path";
+
+export type ReadFsBits = {
+  existsSync: (p: string) => boolean;
+  readdirSync: (p: string) => string[];
+  statSync: (p: string) => { isDirectory: () => boolean };
+  readFileSync: (p: string, enc: "utf8") => string;
+};
+
+/**
+ * Fail the package if the bundled `ws` would use Vite's empty stub for its
+ * optional `bufferutil` dep (#4208).
+ *
+ * `ws` decides "no native masker" by `require('bufferutil')` THROWING. Vite
+ * resolves an absent optional peer dep to a frozen empty namespace instead, so
+ * the require succeeds, `ws` installs a fast path whose `.mask`/`.unmask` are
+ * undefined, and every WebSocket frame over the size threshold throws —
+ * silently killing tunnels while the handshake still looks healthy.
+ *
+ * `src/ws-native-fallback.ts` fixes that by setting `WS_NO_BUFFER_UTIL` before
+ * `ws` loads. Nothing below the bundler can verify it: the stub only exists
+ * after bundling, and the packaged tree is the one place both halves are
+ * visible at once. So assert on the artifact — if the stub is in the graph, the
+ * assignment that neutralizes it has to be there too.
+ *
+ * Note the assertion is "fix present", not "stub absent": the fix stops `ws`
+ * from USING the stub, it does not remove it from the bundle.
+ *
+ * Lives beside the fix rather than in forge.config.ts so both halves of the
+ * contract are testable; forge.config.ts imports it (jiti loads that config,
+ * so a relative TS import resolves).
+ */
+export function assertWsNativeFallback(buildDir: string, fs: ReadFsBits): void {
+  if (!fs.existsSync(buildDir)) return;
+
+  const chunks: string[] = [];
+  const walk = (dir: string) => {
+    for (const entry of fs.readdirSync(dir)) {
+      const full = resolve(dir, entry);
+      if (fs.statSync(full).isDirectory()) walk(full);
+      else if (entry.endsWith(".cjs") || entry.endsWith(".js"))
+        chunks.push(fs.readFileSync(full, "utf8"));
+    }
+  };
+  walk(buildDir);
+
+  const stubbed = chunks.some((c) =>
+    c.includes("__viteOptionalPeerDep_bufferutil_ws"),
+  );
+  if (!stubbed) return;
+
+  // An ASSIGNMENT, not `ws`'s own `!process.env.WS_NO_BUFFER_UTIL` read — that
+  // read is in every bundle containing `ws` and proves nothing.
+  //
+  // Anchored on `process.env.` and on a NON-EMPTY literal: `ws` gates on
+  // `!process.env.WS_NO_BUFFER_UTIL`, so `= ""` would satisfy a looser pattern
+  // while leaving the probe — and the bug — fully in place. Any non-empty
+  // string is truthy and does neutralize it, `"0"` included. Verified against
+  // the real minified bundle, which emits `process.env.WS_NO_BUFFER_UTIL="1"`.
+  const neutralized = chunks.some((c) =>
+    /process\.env\.WS_NO_BUFFER_UTIL\s*=\s*(["'])(?!\1)/.test(c),
+  );
+  if (neutralized) return;
+
+  throw new Error(
+    `[forge] ${buildDir} bundles an empty \`bufferutil\` stub for \`ws\` with ` +
+      "nothing setting WS_NO_BUFFER_UTIL. Every WebSocket frame >= 48 bytes " +
+      "would throw `mask is not a function`, and tunnels would die silently " +
+      "(#4208). Restore the `./ws-native-fallback.js` import at the top of " +
+      "src/main.ts."
+  );
+}

--- a/mcpjam-inspector/src/ws-native-fallback.test.ts
+++ b/mcpjam-inspector/src/ws-native-fallback.test.ts
@@ -1,0 +1,40 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { readFileSync } from "fs";
+import { resolve } from "path";
+
+describe("ws-native-fallback", () => {
+  const saved = {
+    bufferUtil: process.env.WS_NO_BUFFER_UTIL,
+    utf8Validate: process.env.WS_NO_UTF_8_VALIDATE,
+  };
+
+  beforeEach(() => {
+    delete process.env.WS_NO_BUFFER_UTIL;
+    delete process.env.WS_NO_UTF_8_VALIDATE;
+  });
+
+  afterEach(() => {
+    process.env.WS_NO_BUFFER_UTIL = saved.bufferUtil;
+    process.env.WS_NO_UTF_8_VALIDATE = saved.utf8Validate;
+  });
+
+  it("sets both `ws` native-fallback vars to a truthy value on import", async () => {
+    await import("./ws-native-fallback.js");
+
+    // `ws` gates on `!process.env.X`, so the value only has to be non-empty.
+    expect(process.env.WS_NO_BUFFER_UTIL).toBeTruthy();
+    expect(process.env.WS_NO_UTF_8_VALIDATE).toBeTruthy();
+  });
+
+  it("is the first import in main.ts", () => {
+    // GUARDRAIL. `ws` reads these at module-eval time, so the assignment only
+    // wins if nothing that pulls `ws` in is imported first. Ordering is the
+    // whole fix, and no type or bundle check can see it (#4208).
+    const main = readFileSync(resolve(__dirname, "main.ts"), "utf8");
+    const firstImport = main
+      .split("\n")
+      .find((line) => line.startsWith("import "));
+
+    expect(firstImport).toBe('import "./ws-native-fallback.js";');
+  });
+});

--- a/mcpjam-inspector/src/ws-native-fallback.ts
+++ b/mcpjam-inspector/src/ws-native-fallback.ts
@@ -1,0 +1,39 @@
+/**
+ * Force `ws` onto its pure-JS masker before anything imports it.
+ *
+ * The main process BUNDLES `ws` — it is not in `rollupOptions.external` in
+ * vite.main.config.ts, and `src/main.ts` dynamically imports the whole server,
+ * so `server/services/relay-client.ts` (tunnels) and `@hono/node-ws` (computer
+ * terminals) both pull it into this bundle's graph.
+ *
+ * `ws` treats its optional peer deps as present-or-throwing: it requires
+ * `bufferutil` inside a `try`, installs a native fast path on success, and
+ * takes a thrown require as "no native module, stay on the JS fallback".
+ *
+ * `bufferutil` is not installed (it has no package-lock entry, and CI installs
+ * with `npm ci`), so Vite resolves it to a frozen EMPTY namespace rather than
+ * leaving the require unresolvable — `__viteOptionalPeerDep_bufferutil_ws_true`
+ * in the emitted chunk. The require then SUCCEEDS and returns `{}`, `ws`
+ * installs a fast path whose `.mask`/`.unmask` do not exist, and the process
+ * dies with `mask is not a function`.
+ *
+ * That is issue #4208. `ws` only takes the native path above a size threshold
+ * (48 bytes to mask, 32 to unmask), so the tunnel handshake and its 0-byte
+ * heartbeat pings pass and the tunnel reports "connected" — while every real
+ * MCP JSON-RPC message throws, uncaught, out of the relay's response pump.
+ *
+ * Setting the env var skips the probe entirely. The JS masker is a few XORs
+ * per byte; nothing here moves enough traffic to notice.
+ *
+ * `WS_NO_UTF_8_VALIDATE` is belt-and-braces. `ws/lib/validation.js` prefers
+ * `node:buffer`'s `isUtf8`, which exists on Electron's Node, so the
+ * `utf-8-validate` branch is unreachable today — but it is stubbed identically
+ * (`__viteOptionalPeerDep_utf8Validate_ws_true` is in the same chunk) and would
+ * fail the same way if `ws` ever reordered those checks.
+ *
+ * Imported FIRST by main.ts: `ws` reads these at module-eval time, and this has
+ * to win that race. forge.config.ts asserts the assignment survives into the
+ * shipped bundle, because nothing below the bundler can see this class of bug.
+ */
+process.env.WS_NO_BUFFER_UTIL = "1";
+process.env.WS_NO_UTF_8_VALIDATE = "1";

--- a/mcpjam-inspector/src/ws-native-fallback.ts
+++ b/mcpjam-inspector/src/ws-native-fallback.ts
@@ -37,3 +37,7 @@
  */
 process.env.WS_NO_BUFFER_UTIL = "1";
 process.env.WS_NO_UTF_8_VALIDATE = "1";
+
+// Side effects only. Marks the file as a module so it can be `import()`ed
+// under `isolatedModules` — the test clears both vars, then imports.
+export {};


### PR DESCRIPTION
Closes #4208.

- Tunnels made in the desktop app never worked. The URL connected, then every request came back empty or as `gateway_timeout`, and the log showed `TypeError: mask is not a function`.
- The desktop app bundles `ws`. `ws` checks for an optional speed-up package (`bufferutil`) by trying to load it and expecting that to fail when it isn't installed — but the bundler hands it an empty object instead, which looks like success. So `ws` calls functions that don't exist, and any WebSocket message over 48 bytes crashes.
- That's why it looked connected: the handshake and the tiny keepalive pings are under the size limit and worked fine. Every real MCP message is over it.
- The fix tells `ws` to skip that optional speed-up entirely and use its built-in version, which is plenty fast here. Packaging now fails the build if that setting ever goes missing again, since this kind of bug is invisible until after the app is bundled.
- Only the desktop app was affected — `npx`, Docker, and the CLI load `ws` normally and were always fine.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Restores working tunnels in the Electron app by forcing bundled `ws` to skip the empty `bufferutil` stub. Before: tunnels looked connected but real MCP frames crashed with “mask is not a function”; now WebSocket traffic flows and packaging guards prevent regressions.

- Import `src/ws-native-fallback.ts` first in `src/main.ts` to set `WS_NO_BUFFER_UTIL` and `WS_NO_UTF_8_VALIDATE` before `ws` loads.
- Packaging guard: `forge.config.ts` calls `assertWsNativeFallback` (in `src/ws-native-fallback.assert.ts`) to scan built output recursively and fail the build if the `bufferutil` stub is present without a non-empty `process.env.WS_NO_BUFFER_UTIL="..."` assignment; it rejects false positives (e.g., `ws`’s own env read, empty strings) and ignores non-JS chunks. Tests now cover nested-directory cases in both directions.
- Scope/Rollout: Only the Electron desktop app is affected; `npx`, Docker, and the CLI already use `ws` from real `node_modules`. No migration; builds fail fast if the guard is removed or reordered.

<sup>Written for commit 4706ea2f22f20e6ccdf70d202ed3d2f5189ca2a8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/MCPJam/inspector/pull/4213?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

