### PR TITLE
preview: point PR previews at the WorkOS app their callback is registered in

### DIFF
--- a/.github/workflows/pr-preview.yml
+++ b/.github/workflows/pr-preview.yml
@@ -152,6 +152,15 @@ jobs:
           .github/scripts/railway-retry.sh .github/scripts/railway-env.sh new "${{ steps.meta.outputs.environment }}" \
             --duplicate "$RAILWAY_PREVIEW_SOURCE_ENVIRONMENT"
 
+      # `getInspectorClientRuntimeConfig` (server/env.ts) reads the
+      # unprefixed WORKOS_* names first and only falls back to the VITE_
+      # ones, and that runtime config overrides whatever Vite inlined at
+      # build time. Preview envs are duplicated from staging, which carries
+      # a production WORKOS_CLIENT_ID -- so setting only the VITE_ names
+      # left every preview authenticating against production AuthKit while
+      # the WorkOS step below registered its callback on the staging app.
+      # Both halves succeeded, the job stayed green, and sign-in returned
+      # redirect_uri_invalid. Write both spellings.
       - name: Configure non-prod preview defaults
         run: |
           .github/scripts/railway-retry.sh .github/scripts/railway-set-vars.sh \
@@ -165,6 +174,8 @@ jobs:
             VITE_MCPJAM_HOSTED_MODE=true \
             VITE_WORKOS_CLIENT_ID="$STAGING_WORKOS_CLIENT_ID" \
             VITE_WORKOS_API_HOSTNAME="$STAGING_WORKOS_API_HOSTNAME" \
+            WORKOS_CLIENT_ID="$STAGING_WORKOS_CLIENT_ID" \
+            WORKOS_API_HOSTNAME="$STAGING_WORKOS_API_HOSTNAME" \
             ALLOWED_ORIGINS="https://*.up.railway.app,$STAGING_APP_URL" \
             WEB_ALLOWED_ORIGINS="https://*.up.railway.app,$STAGING_APP_URL" \
             VITE_CONVEX_URL="$DEFAULT_BACKEND_VITE_CONVEX_URL" \
@@ -420,6 +431,15 @@ jobs:
           .github/scripts/railway-retry.sh .github/scripts/railway-env.sh new "${{ steps.meta.outputs.environment }}" \
             --duplicate "$RAILWAY_PREVIEW_SOURCE_ENVIRONMENT"
 
+      # `getInspectorClientRuntimeConfig` (server/env.ts) reads the
+      # unprefixed WORKOS_* names first and only falls back to the VITE_
+      # ones, and that runtime config overrides whatever Vite inlined at
+      # build time. Preview envs are duplicated from staging, which carries
+      # a production WORKOS_CLIENT_ID -- so setting only the VITE_ names
+      # left every preview authenticating against production AuthKit while
+      # the WorkOS step below registered its callback on the staging app.
+      # Both halves succeeded, the job stayed green, and sign-in returned
+      # redirect_uri_invalid. Write both spellings.
       - name: Configure non-prod preview defaults
         run: |
           .github/scripts/railway-retry.sh .github/scripts/railway-set-vars.sh \
@@ -433,6 +453,8 @@ jobs:
             VITE_MCPJAM_HOSTED_MODE=true \
             VITE_WORKOS_CLIENT_ID="$STAGING_WORKOS_CLIENT_ID" \
             VITE_WORKOS_API_HOSTNAME="$STAGING_WORKOS_API_HOSTNAME" \
+            WORKOS_CLIENT_ID="$STAGING_WORKOS_CLIENT_ID" \
+            WORKOS_API_HOSTNAME="$STAGING_WORKOS_API_HOSTNAME" \
             ALLOWED_ORIGINS="https://*.up.railway.app,$STAGING_APP_URL" \
             WEB_ALLOWED_ORIGINS="https://*.up.railway.app,$STAGING_APP_URL" \
             VITE_CONVEX_URL="$DEFAULT_BACKEND_VITE_CONVEX_URL" \
@@ -806,6 +828,15 @@ jobs:
             fi
           fi
 
+      # `getInspectorClientRuntimeConfig` (server/env.ts) reads the
+      # unprefixed WORKOS_* names first and only falls back to the VITE_
+      # ones, and that runtime config overrides whatever Vite inlined at
+      # build time. Preview envs are duplicated from staging, which carries
+      # a production WORKOS_CLIENT_ID -- so setting only the VITE_ names
+      # left every preview authenticating against production AuthKit while
+      # the WorkOS step below registered its callback on the staging app.
+      # Both halves succeeded, the job stayed green, and sign-in returned
+      # redirect_uri_invalid. Write both spellings.
       - name: Update preview environment variables
         run: |
           .github/scripts/railway-retry.sh .github/scripts/railway-set-vars.sh \
@@ -819,6 +850,8 @@ jobs:
             VITE_MCPJAM_HOSTED_MODE=true \
             VITE_WORKOS_CLIENT_ID="$STAGING_WORKOS_CLIENT_ID" \
             VITE_WORKOS_API_HOSTNAME="$STAGING_WORKOS_API_HOSTNAME" \
+            WORKOS_CLIENT_ID="$STAGING_WORKOS_CLIENT_ID" \
+            WORKOS_API_HOSTNAME="$STAGING_WORKOS_API_HOSTNAME" \
             VITE_CONVEX_URL="${{ steps.backend_target.outputs.vite_convex_url }}" \
             CONVEX_HTTP_URL="${{ steps.backend_target.outputs.convex_http_url }}"
 


### PR DESCRIPTION
## The bug

Preview sign-in fails with `redirect_uri_invalid` at `login.mcpjam.com`, while `pr-preview.yml` reports success on every run.

`getInspectorClientRuntimeConfig` (`server/env.ts:156`) reads the **unprefixed** names first:

```js
getNonEmptyEnv("WORKOS_CLIENT_ID") ?? getNonEmptyEnv("VITE_WORKOS_CLIENT_ID")
```

and that runtime config **overrides the Vite build-time bake** (`client/src/main.tsx:282`). The workflow set only the `VITE_` spellings, so they were dead writes.

Preview envs are duplicated from staging, which carries a **production** `WORKOS_CLIENT_ID` and `WORKOS_API_HOSTNAME=auth.mcpjam.com`. Meanwhile the "Register preview URL with WorkOS staging" step registers the callback in the environment `STAGING_WORKOS_API_KEY` belongs to.

Registering in one WorkOS environment and authenticating against another only fails in the browser — both halves of the workflow succeed on their own, so the job stays green.

## Evidence

Live from the pr-4205 preview:

```
/servers -> workosClientId: client_01K4C1TVPBE7JTBFQJF9SDW9P9  (production)
            workosApiHostname: auth.mcpjam.com                  (production)
```

Reproduced against the WorkOS authorize endpoint with the pr-4205 callback:

| client id | result |
|---|---|
| `client_01K4C1TVPBE7JTBFQJF9SDW9P9` (prod) | `302 login.mcpjam.com/redirect-uri-invalid` — the reported error |
| `client_01KTN2EWHHJCKRB8RSR307X4SG` (`STAGING_WORKOS_CLIENT_ID`) | `302 deep-vanilla-68-test.authkit.app/bootstrap` — works |

## The fix

Write both spellings in all three places that configure a preview environment. `deriveAuthkitDomain` (`server/services/authkit-jwt.ts:64`) and its mirror in `mcpjam-backend/convex/lib/authkit.ts` already map this client id to its AuthKit domain, so verification works end to end.

The comment sits at the YAML level rather than inline — these are backslash-continued shell commands, and an inline `#` would sever the continuation.

## Verification

- `yaml.parse` — all 5 jobs intact
- all 39 `run:` blocks pass `bash -n`
- `railway-set-vars.sh` takes arbitrary `KEY=value`, no allowlist

## Not addressed here

- **Previews get development-environment WorkOS identities**, so accounts won't match the production-WorkOS records staging uses.
- **`STAGING_WORKOS_API_HOSTNAME` defaults to `api.workos.com`**, cross-site to `*.up.railway.app`, so session refresh still drops the cookie. Pre-existing today with `auth.mcpjam.com` — not a regression.
- **`staging.mcpjam.com` itself runs on production WorkOS**, and the repo var `STAGING_WORKOS_CLIENT_ID` actually holds the *development* client id. Both are worth a follow-up rename/audit.
- **Existing preview envs keep the inherited prod client id** until a run rewrites them, and a PR only picks this workflow up once its branch contains this change.

I deliberately did **not** take the alternative fix of registering preview callbacks in production WorkOS to match what the app uses. That would put reclaimable `*.up.railway.app` redirect URIs in the production app, and this file's own comment (lines 18-24) already notes envs get orphaned on force-push — anyone later claiming that subdomain could intercept production auth codes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JaQ2gC8ExT1GHK9PSP7GGV

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches preview auth configuration (WorkOS client id / hostname). Scope is CI env vars only, not production auth code, but a mis-set client would send preview logins to the wrong AuthKit environment.
> 
> **Overview**
> Fixes PR preview sign-in failing with `redirect_uri_invalid` while the workflow still went green.
> 
> Runtime config prefers unprefixed `WORKOS_CLIENT_ID` / `WORKOS_API_HOSTNAME` over the `VITE_` names, and that overrides the Vite bake. Previews duplicated from staging inherited **production** WorkOS values, so the app authenticated against prod AuthKit while the workflow registered callbacks on the staging app.
> 
> All three preview env-var steps now write both spellings from `STAGING_WORKOS_*`. Existing preview envs keep the inherited prod client until a run that includes this workflow rewrites them.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5f9608862be4012a53c634898932c081a12dc7d4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes PR preview sign-in by authenticating against the same WorkOS app that receives the registered callback. Previously, previews inherited production `WORKOS_*` values from staging while the workflow registered callbacks in staging, causing `redirect_uri_invalid`; now the workflow also sets unprefixed `WORKOS_*` alongside `VITE_*` so previews use staging WorkOS end to end.

- Updates `.github/workflows/pr-preview.yml` only: adds `WORKOS_CLIENT_ID` and `WORKOS_API_HOSTNAME` alongside existing `VITE_WORKOS_CLIENT_ID` and `VITE_WORKOS_API_HOSTNAME` in all preview configuration steps.
- Keeps `getInspectorClientRuntimeConfig` precedence unchanged; this aligns environment values with what the runtime actually reads.
- Existing preview environments retain old values until the workflow rewrites them; push a new commit or re-run the preview workflow to refresh.
- Known limits unchanged: previews use development WorkOS identities; cross-site cookie drops may still occur if `STAGING_WORKOS_API_HOSTNAME` is not same-site with `*.up.railway.app`.

<sup>Written for commit 5f9608862be4012a53c634898932c081a12dc7d4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/MCPJam/inspector/pull/4214?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

