### PR TITLE
Swarms: mint the launch environment without the Environments flag

### DIFF
--- a/mcpjam-inspector/client/src/components/swarms/__tests__/SwarmsTab.createFlow.test.tsx
+++ b/mcpjam-inspector/client/src/components/swarms/__tests__/SwarmsTab.createFlow.test.tsx
@@ -30,8 +30,17 @@ vi.mock("@/hooks/use-available-models", () => ({
   useAvailableModels: () => ({ availableModels: [] }),
 }));
 
+/**
+ * `project-environments-enabled`, as a ref: an org can hold Swarms without it
+ * (the sidebar gates the two surfaces on different flags), and that
+ * combination has its own case below.
+ */
+const { environmentsFlagRef } = vi.hoisted(() => ({
+  environmentsFlagRef: { current: true },
+}));
+
 vi.mock("@/hooks/useProjectEnvironmentsEnabled", () => ({
-  useProjectEnvironmentsEnabled: () => true,
+  useProjectEnvironmentsEnabled: () => environmentsFlagRef.current,
 }));
 
 vi.mock("@/hooks/useSkillsEnabled", () => ({
@@ -354,6 +363,7 @@ function fillDescribe(text = "Support agents answering refunds") {
 
 beforeEach(() => {
   vi.clearAllMocks();
+  environmentsFlagRef.current = true;
   // The flow now mirrors its resumable state into sessionStorage, so a leftover
   // draft would otherwise resume the previous case's slate.
   sessionStorage.clear();
@@ -1659,6 +1669,45 @@ describe("SwarmsTab — New swarm create flow", () => {
     );
     // One batch call for both clients, and no NAMED row is minted — the whole
     // point of the change is that Describe text never becomes an environment.
+    expect(ensureAdhocEnvironmentsMock).toHaveBeenCalledWith({
+      projectId: "proj-1",
+      stacks: [{ hostId: "host-1" }, { hostId: "host-2" }],
+    });
+    expect(createEnvironmentMock).not.toHaveBeenCalled();
+
+    await screen.findByTestId("new-swarm-proposed-personas");
+    fireEvent.click(screen.getByTestId("new-swarm-launch"));
+    await waitFor(() => expect(createJourneyMock).toHaveBeenCalled());
+    expect(createJourneyMock.mock.calls[0][0].environmentIds).toEqual([
+      "adhoc-host-1",
+      "adhoc-host-2",
+    ]);
+  });
+
+  it("mints ad-hoc rows for an org that has Swarms but not Environments", async () => {
+    // THE regression. Ad-hoc rows are launch substrate and the backend leaves
+    // them ungated; `createEnvironment` mints a NAMED row and is gated on
+    // `project-environments-enabled`. Reading the flag here used to send
+    // exactly the org that fails that gate down the naming path, so every
+    // swarm launch died on "Environments is not currently available for your
+    // organization" — with no saved environments to pick instead, the surface
+    // was unusable rather than degraded.
+    environmentsFlagRef.current = false;
+    environmentsRef.current = [];
+    environments = environmentsRef.current;
+    openDescribe();
+
+    fireEvent.change(screen.getByLabelText("Describe swarm"), {
+      target: { value: "Support agents answering refunds" },
+    });
+    fireEvent.click(screen.getByTestId("new-swarm-clients-picker"));
+    fireEvent.click(screen.getByRole("checkbox", { name: /^cursor$/i }));
+
+    fireEvent.click(screen.getByTestId("new-swarm-continue"));
+
+    await waitFor(() =>
+      expect(ensureAdhocEnvironmentsMock).toHaveBeenCalledTimes(1)
+    );
     expect(ensureAdhocEnvironmentsMock).toHaveBeenCalledWith({
       projectId: "proj-1",
       stacks: [{ hostId: "host-1" }, { hostId: "host-2" }],

--- a/mcpjam-inspector/client/src/components/swarms/new-swarm-create-flow.tsx
+++ b/mcpjam-inspector/client/src/components/swarms/new-swarm-create-flow.tsx
@@ -422,14 +422,6 @@ export function NewSwarmCreateFlow({
   const [previewedHostId] = usePreviewedHostId(projectId);
   const [previewedEnvironmentId] = usePreviewedEnvironmentId(projectId);
   /**
-   * On a deployment with Project Environments off the user cannot even reach
-   * `/environments`, so minting rows there would create data they can never see
-   * or clean up. Such a deployment keeps the legacy naming path. Whether the
-   * BACKEND can mint is not a flag question — `isAdhocUnavailable` answers it
-   * per call, from the deployment actually being talked to.
-   */
-  const canMintAdhoc = environmentsEnabled;
-  /**
    * The draft this mount is resuming, read ONCE so every initializer below sees
    * the same snapshot. Null on a genuine cold start.
    *
@@ -829,37 +821,55 @@ export function NewSwarmCreateFlow({
         },
       });
 
+    /**
+     * Ad-hoc rows are minted UNCONDITIONALLY — `project-environments-enabled`
+     * is not consulted here, and reading it was the bug.
+     *
+     * The backend draws the line between substrate and product, not between
+     * flagged and unflagged orgs: `ensureAdhocEnvironments` carries no
+     * environments gate ("launch-path substrate"), while `createEnvironment`,
+     * which mints a NAMED row, does. Gating this branch on the flag therefore
+     * inverted the protection — an org with Swarms but not Environments
+     * skipped the ungated path and fell back to the legacy naming
+     * materializer, the one mutation its backend refuses ("Environments is not
+     * currently available for your organization"). With no saved environments
+     * to pick either, that org could not launch a swarm at all.
+     *
+     * Rows such an org cannot see in `/environments` are the intended shape of
+     * an ad-hoc row, not a leak: unnamed, fingerprint-deduped so relaunching a
+     * setup reuses one row instead of accumulating them, and already minted
+     * for these same orgs by User Testing, which never gated this call.
+     *
+     * Whether the BACKEND can mint stays a per-call question, answered by
+     * `isAdhocUnavailable` from the deployment actually being talked to.
+     */
     let resolved: Awaited<ReturnType<typeof legacyResolve>> = null;
-    if (canMintAdhoc) {
-      try {
-        const composed = await resolveComposerTargets({
-          state: targetState,
-          liveEnvironments: liveWithOverlay,
-          max: MAX_ENVIRONMENTS_PER_JOURNEY,
-        });
-        const payload = buildEnvJourneyPayload(
-          composed.environmentIds,
-          composed.environments
-        );
-        resolved = payload
-          ? {
-              ...payload,
+    try {
+      const composed = await resolveComposerTargets({
+        state: targetState,
+        liveEnvironments: liveWithOverlay,
+        max: MAX_ENVIRONMENTS_PER_JOURNEY,
+      });
+      const payload = buildEnvJourneyPayload(
+        composed.environmentIds,
+        composed.environments
+      );
+      resolved = payload
+        ? {
+            ...payload,
+            environments: composed.environments,
+            materialized: {
+              environmentIds: composed.environmentIds,
               environments: composed.environments,
-              materialized: {
-                environmentIds: composed.environmentIds,
-                environments: composed.environments,
-                createdIds: composed.createdIds,
-                reusedIds: composed.reusedIds,
-              },
-            }
-          : null;
-      } catch (err) {
-        // An old backend is the one failure worth retrying differently; every
-        // other rejection is the user's to read.
-        if (!isAdhocUnavailable(err)) throw err;
-        resolved = await legacyResolve();
-      }
-    } else {
+              createdIds: composed.createdIds,
+              reusedIds: composed.reusedIds,
+            },
+          }
+        : null;
+    } catch (err) {
+      // An old backend is the one failure worth retrying differently; every
+      // other rejection is the user's to read.
+      if (!isAdhocUnavailable(err)) throw err;
       resolved = await legacyResolve();
     }
 
@@ -878,7 +888,6 @@ export function NewSwarmCreateFlow({
     }
     return resolved;
   }, [
-    canMintAdhoc,
     composeMode,
     createdEnvOverlay,
     envList,


### PR DESCRIPTION
An organization can hold `sandboxes-enabled` without `project-environments-enabled` — the sidebar gates Swarms and Environments on different flags — and for that organization **Swarms could not launch at all**. Every attempt died on:

> Environments is not currently available for your organization.

Reported by a user who had just been given `sandboxes-enabled`.

## The inversion

The create flow read the client flag as if it answered "can the backend mint an environment". It doesn't. The backend draws its line between **substrate** and **product**, not between flagged and unflagged organizations:

- `ensureAdhocEnvironments` — no environments gate, deliberately ("ad-hoc rows are launch-path substrate and stay ungated", `convex/projectEnvironments.ts:952`)
- `createEnvironment` — mints a NAMED row, gated on `project-environments-enabled` (`convex/projectEnvironments.ts:959`)

So `canMintAdhoc = environmentsEnabled` sent exactly the organization that fails that gate down the naming path — the one mutation its backend refuses. And because the flag also empties the saved-environment list (`effectiveEnvList`), that organization had no environment to pick instead: the surface was unusable, not degraded.

## The change

Mint ad-hoc rows unconditionally. `canMintAdhoc` and its `if/else` are gone rather than left as `if (true)`; the `catch` already routes an old backend to the legacy materializer, so whether the BACKEND can mint stays a per-call question answered by `isAdhocUnavailable` from the deployment actually being talked to.

Rows an unflagged organization cannot see in `/environments` are the intended shape of an ad-hoc row, not a leak: unnamed, fingerprint-deduped so relaunching a setup reuses one row instead of accumulating them, and **already minted for these same organizations by User Testing**, which never gated this call (`UserTestingScenarioCreateFlow.tsx:207`). This makes Swarms consistent with a path that has been live for weeks.

`environmentsEnabled` still gates the saved-environment picker, so the Environments tab stays unlaunched. No backend change, no flag change.

## Why it shipped unnoticed

`SwarmsTab.createFlow.test.tsx` hard-mocked `useProjectEnvironmentsEnabled: () => true`, so all 56 cases ran the flag-on path. The mock is now a ref and a case drives the flag-off path. Verified it fails without the fix (`ensureAdhocEnvironments` never called) and passes with it.

## Checks

- `tsc --noEmit -p client/tsconfig.typecheck.json` — clean
- `vitest run client/src/components/swarms/__tests__` — 304/304 (31 files)

Prettier reports both files unformatted; pre-existing, and every hunk it wants is on lines this PR doesn't touch.

## Note for the reporter

The fix only helps on deploy. The immediate unblock is adding him to `project-environments-enabled` in PostHog.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how launch environments are created for unflagged orgs (writes ad-hoc rows they cannot see in /environments). Logic is client-only and matches an existing User Testing path; old backends still fall back.
> 
> **Overview**
> Orgs with Swarms but without `project-environments-enabled` can launch again. The create flow no longer treats that flag as “can mint environments.”
> 
> `resolveTargets` always tries ad-hoc minting (`ensureAdhocEnvironments`). The flag used to skip that ungated path and fall through to named `createEnvironment`, which the backend refuses — so launch died with no saved envs to pick. Old backends still fall back via `isAdhocUnavailable`. The Environments picker stays flag-gated.
> 
> Adds a regression test for the flag-off path (the suite previously hard-mocked the flag on).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4e3ebd22604b3c6597d83f1b2a213cc66d5217b3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Allow Swarms to launch when `sandboxes-enabled` is on but `project-environments-enabled` is off by minting ad‑hoc environments unconditionally. Previously, the flow gated ad‑hoc minting on the Environments flag and fell back to `createEnvironment`, which is blocked for those orgs, so launches failed.

**Review notes**
- Remove the `canMintAdhoc` gate and always call `ensureAdhocEnvironments`; keep the per-call fallback to the legacy naming path only when `isAdhocUnavailable` indicates an old backend.
- Keep the saved‑environment picker gated by `project-environments-enabled`; ad‑hoc rows remain unnamed, fingerprint‑deduped, and not shown in `/environments`. No backend or flag changes.
- Tests no longer hard‑mock `useProjectEnvironmentsEnabled`; add a flag‑off case that exercises the ad‑hoc path and verifies the legacy fallback. Optional immediate unblock before deploy: add affected users to `project-environments-enabled`.

<sup>Written for commit 4e3ebd22604b3c6597d83f1b2a213cc66d5217b3. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/MCPJam/inspector/pull/4215?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

