### PR TITLE
Tasks conformance graded the undeclared-capability refusal against the wrong code

### DIFF
--- a/.changeset/tasks-missing-capability-32021.md
+++ b/.changeset/tasks-missing-capability-32021.md
@@ -1,0 +1,34 @@
+---
+"@mcpjam/sdk": patch
+"@mcpjam/inspector": patch
+---
+
+Recognize `-32021` as the tasks extension's Missing Required Client Capability
+code, not the pre-renumber `-32003`.
+
+`mcp-error-codes.ts` has recorded the right values since the 2026-07-28
+renumber: `MissingRequiredClientCapability` is `-32021`, and `-32003` sits in
+`PRE_RENUMBER_DRAFT_ERROR_CODES` under a comment saying those are "NOT final
+wire codes". Two places never got the memo and kept `-32003` as a literal:
+`TASKS_DECLARATION_REQUIRED_ERROR_CODE` in the client manager, and the tasks
+conformance runner's own copy of the constant. Both now read from the central
+table, so the next renumber is a one-line change in one file.
+
+The conformance consequence was a false verdict in both directions. A server
+answering the canonical `-32021` failed `tasks-undeclared-capability-rejected`,
+and one still answering the obsolete `-32003` passed it — on the check whose
+whole job is to prove the server refuses undeclared task work. The core suite
+already asserted `-32021` in `modern-undeclared-capability-error`, so the two
+conformance modules were grading the same requirement against different codes.
+
+ext-tasks made this change in `c523f2c`, for the reasons the commit gives:
+SEP-2663 uses `-32021` throughout, the core 2026-07-28 schema defines
+`MissingRequiredClientCapabilityError` as `-32021`, and `-32003` appears in no
+core schema version. The extension's root `index.md` still shows `-32003` and is
+stale; `specification/draft/tasks.md` is authoritative.
+
+A server that still emits `-32003` now fails — it does not conform — but it is
+told which draft it is running rather than being reported as an anonymous wrong
+code, so the fix is one line for whoever reads the report. The same naming
+applies to the `tasks-undeclared-creation-refused` warning, which stays a pass
+because no task reached a non-declaring client.

--- a/mcpjam-inspector/client/src/components/subscriptions/subscription-stream-state.ts
+++ b/mcpjam-inspector/client/src/components/subscriptions/subscription-stream-state.ts
@@ -91,7 +91,7 @@ export function unacknowledgedInterests(
       case "capability-not-advertised":
         return `${what} (not advertised)`;
       // The connection cannot put the tasks declaration on the listen, so the
-      // task-id selection was dropped rather than sent undeclared (-32003).
+      // task-id selection was dropped rather than sent undeclared (-32021).
       // Polling continues — nothing is lost but latency.
       case "tasks-declaration-unavailable":
         return `${what} (cannot declare tasks extension; polling instead)`;

--- a/mcpjam-inspector/shared/subscription-bridge.ts
+++ b/mcpjam-inspector/shared/subscription-bridge.ts
@@ -59,7 +59,7 @@ export interface SubscriptionInterestRejectionView {
     /**
      * A task-filtered listen was wanted but this connection cannot put the
      * extension's per-request eligibility declaration on the listen request
-     * (sending it undeclared would earn `-32003`). Polling continues — a
+     * (sending it undeclared would earn `-32021`). Polling continues — a
      * notification is only ever a poll-now hint, so the handle is not lost.
      */
     | "tasks-declaration-unavailable";

--- a/sdk/src/conformance-catalog.ts
+++ b/sdk/src/conformance-catalog.ts
@@ -256,12 +256,12 @@ export const TASKS_CHECK_CATALOG = {
   "tasks-undeclared-creation-refused": {
     title: "Undeclared Task Creation Refused",
     description:
-      "On the extension wire, a tools/call that did not carry the extension declaration must not come back as a CreateTaskResult: the server either answers normally or rejects with -32003.",
+      "On the extension wire, a tools/call that did not carry the extension declaration must not come back as a CreateTaskResult: the server either answers normally or rejects with -32021.",
   },
   "tasks-undeclared-capability-rejected": {
     title: "Undeclared Capability Rejected",
     description:
-      "tasks/get, tasks/update, tasks/cancel and a task-filtered subscriptions/listen sent WITHOUT the extension declaration must each be rejected with -32003 (Missing Required Client Capability).",
+      "tasks/get, tasks/update, tasks/cancel and a task-filtered subscriptions/listen sent WITHOUT the extension declaration must each be rejected with -32021 (Missing Required Client Capability).",
   },
   "tasks-ttl-shape": {
     title: "TTL And Poll Interval Shapes",

--- a/sdk/src/mcp-client-manager/MCPClientManager.ts
+++ b/sdk/src/mcp-client-manager/MCPClientManager.ts
@@ -1794,7 +1794,7 @@ export class MCPClientManager {
     options?: ClientRequestOptions
   ) {
     // Legacy-form reads carry no per-request extension declaration, so a
-    // conforming extension server MUST answer `-32003`: refuse locally instead
+    // conforming extension server MUST answer `-32021`: refuse locally instead
     // and send nothing (callers dispatch on `getTasksWire`).
     this.assertLegacyTasksReadWire(serverId, "tasks/get");
     return this.runRetryableReadOperation(serverId, options, (client) =>
@@ -1959,7 +1959,7 @@ export class MCPClientManager {
   /**
    * Opens a task-filtered `subscriptions/listen` carrying the extension's
    * per-request eligibility declaration (SEP-2663). A non-declaring
-   * task-filtered listen MUST be answered `-32003`, so this is the ONLY way a
+   * task-filtered listen MUST be answered `-32021`, so this is the ONLY way a
    * `taskIds` filter may reach the wire.
    *
    * Port contract: on `SubscriptionClientPort`, availability is expressed by

--- a/sdk/src/mcp-client-manager/subscription-coordinator.ts
+++ b/sdk/src/mcp-client-manager/subscription-coordinator.ts
@@ -180,7 +180,7 @@ export interface SubscriptionInterestRejection {
     /**
      * A task-filtered listen was wanted but this connection cannot put the
      * extension's per-request eligibility declaration on the listen request,
-     * so sending it would earn `-32003`. Polling continues; the handle is not
+     * so sending it would earn `-32021`. Polling continues; the handle is not
      * lost. See `tasks-ext-listen-meta.ts`.
      */
     | "tasks-declaration-unavailable";
@@ -277,7 +277,7 @@ export interface SubscriptionClientPort {
    * per-request eligibility declaration.
    *
    * Separate from {@link listen} on purpose. A task-filtered listen without
-   * the declaration MUST be answered `-32003` (`tasks.md:797-799`), so a
+   * the declaration MUST be answered `-32021` (`tasks.md:797-799`), so a
    * connection that cannot declare must not send one at all — it drops the
    * `taskIds` selection, records it as `tasks-declaration-unavailable`, and
    * keeps polling. Absent method ⇒ exactly that.
@@ -944,7 +944,7 @@ export class SubscriptionCoordinator {
    *
    * Kept together so every caller — reconcile and re-listen alike — sees the
    * same filter. A re-listen that skipped the gate would resurrect a `taskIds`
-   * selection this connection cannot declare and earn a `-32003` on reconnect.
+   * selection this connection cannot declare and earn a `-32021` on reconnect.
    */
   private resolveFilter(): {
     requested: SubscriptionFilterShape;
@@ -963,7 +963,7 @@ export class SubscriptionCoordinator {
     }
 
     // Drop rather than downgrade: an undeclared task-filtered listen is a
-    // guaranteed -32003, and the polling fallback loses nothing but latency.
+    // guaranteed -32021, and the polling fallback loses nothing but latency.
     //
     // Only ONE reason is reachable here. `resolveRequestedFilter` was given the
     // era, so a legacy connection already had its `taskIds` rejected as

--- a/sdk/src/mcp-client-manager/task-lifecycle-adapters.ts
+++ b/sdk/src/mcp-client-manager/task-lifecycle-adapters.ts
@@ -25,6 +25,7 @@ import type {
 } from "./tasks-ext-types.js";
 import type { TaskLifecycleObservation } from "./task-lifecycle.js";
 import type { MCPTask } from "./types.js";
+import { MCP_ERROR_CODES } from "./mcp-error-codes.js";
 
 /**
  * Extension `tasks/get` result or `notifications/tasks` params → observation.
@@ -126,8 +127,16 @@ export function legacyTaskToObservation(
  */
 export const UNKNOWN_TASK_ERROR_CODE = -32602;
 
-/** The extension's "this operation requires the tasks declaration" code. */
-export const TASKS_DECLARATION_REQUIRED_ERROR_CODE = -32003;
+/**
+ * The extension's "this operation requires the tasks declaration" code. This is
+ * `MissingRequiredClientCapability`, so it follows the renumber the central
+ * table already records: ext-tasks drafted `-32003`, a value that appears in no
+ * core schema version, and corrected it to `-32021` to match SEP-2663, the core
+ * 2026-07-28 schema and the TypeScript SDK. A server still answering `-32003`
+ * is pre-final; `PRE_RENUMBER_DRAFT_ERROR_CODES` names that value.
+ */
+export const TASKS_DECLARATION_REQUIRED_ERROR_CODE =
+  MCP_ERROR_CODES.MissingRequiredClientCapability;
 
 function errorCodeOf(error: unknown): number | undefined {
   if (typeof error !== "object" || error === null) return undefined;

--- a/sdk/src/mcp-client-manager/tasks-ext-era-gate.ts
+++ b/sdk/src/mcp-client-manager/tasks-ext-era-gate.ts
@@ -57,7 +57,7 @@
  * .outboundEnvelope` (`:3800`) attaches the
  * `io.modelcontextprotocol/clientCapabilities` `_meta` envelope that the
  * extension's per-request eligibility declaration rides in — a codec swap
- * would silently strip the declaration and earn a `-32003` from every
+ * would silently strip the declaration and earn a `-32021` from every
  * conforming server.
  *
  * ## When it is installed, and why not at connect

--- a/sdk/src/mcp-client-manager/tasks-ext-listen-meta.ts
+++ b/sdk/src/mcp-client-manager/tasks-ext-listen-meta.ts
@@ -8,7 +8,7 @@
  * `subscriptions/listen`, and — like every other extension operation — that
  * listen request MUST carry the per-request eligibility declaration in
  * `params._meta["io.modelcontextprotocol/clientCapabilities"]`. A non-declaring
- * client gets `-32003`.
+ * client gets `-32021`.
  *
  * `Client.listen(filter, options)` has no `_meta` parameter. It builds its own
  * request body (`client dist/index.mjs:3706-3713`):
@@ -86,7 +86,7 @@ export class TasksExtListenMetaSeamError extends Error {
       `Cannot declare io.modelcontextprotocol/tasks on subscriptions/listen: ${reason}. ` +
         `\`Protocol.${ENVELOPE_MEMBER}\` is a private member of @modelcontextprotocol/client ` +
         `(verified against ${VERIFIED_CLIENT_VERSION}); without it the listen request would go ` +
-        `out undeclared and a conforming server would answer -32003. Re-verify ` +
+        `out undeclared and a conforming server would answer -32021. Re-verify ` +
         `sdk/src/mcp-client-manager/tasks-ext-listen-meta.ts against the new client build, or ` +
         `disable task notifications and fall back to polling.`
     );
@@ -175,7 +175,7 @@ export function withTasksExtensionEnvelope<T>(
 
   // The seam check rides ON the pending promise rather than short-circuiting
   // it. Two reasons: a call that also rejected must surface ITS error (the
-  // server's `-32003` is more useful than our diagnosis of it), and abandoning
+  // server's `-32021` is more useful than our diagnosis of it), and abandoning
   // `pending` here would leave an unhandled rejection behind.
   return pending.then(async (value) => {
     if (!observed) {

--- a/sdk/src/mcp-client-manager/tasks-ext.ts
+++ b/sdk/src/mcp-client-manager/tasks-ext.ts
@@ -6,7 +6,7 @@
  * `params._meta["io.modelcontextprotocol/clientCapabilities"]` and MUST be
  * present on every extension operation — the `tools/call` that may produce a
  * task AND the subsequent `tasks/get` / `tasks/update` / `tasks/cancel`
- * (`-32003` otherwise).
+ * (`-32021` otherwise).
  *
  * ## The beta.4 envelope seam (investigated, PR2)
  *
@@ -166,7 +166,7 @@ export interface TasksExtCallContext {
  * (`tasks-conformance/`) issues its UNDECLARED probes directly, bypassing this
  * helper. It has to — this helper always attaches the eligibility declaration,
  * and the whole point of those probes is to observe what a server does when
- * the declaration is absent (a conforming one answers `-32003`). That bypass
+ * the declaration is absent (a conforming one answers `-32021`). That bypass
  * is the test, not a bug. Being off this path, it installs the era-gate shadow
  * itself before probing (`tasks-conformance/runner.ts`), since the probes still
  * have to reach the wire on a 2026-07-28 connection to be answered at all.
@@ -204,7 +204,7 @@ async function sendTasksExtRequest(
  * eligibility declaration.
  *
  * The declaration is mandatory on this request too — a non-declaring client
- * MUST get `-32003` (`tasks.md:797-799`) — but `Client.listen` builds its own
+ * MUST get `-32021` (`tasks.md:797-799`) — but `Client.listen` builds its own
  * `params._meta` and takes no caller `_meta`. `tasks-ext-listen-meta.ts`
  * explains the seam and why it is scoped to this one call.
  *

--- a/sdk/src/tasks-conformance/runner.ts
+++ b/sdk/src/tasks-conformance/runner.ts
@@ -5,7 +5,7 @@
  * tasks wire the connection resolves to, whether the client-side declaration
  * hygiene holds for that wire, and whether the server honours the parts of the
  * contract a debugger can observe from the outside (result-type discipline,
- * `-32003` on an undeclared capability, inline results, TTL shapes, and
+ * `-32021` on an undeclared capability, inline results, TTL shapes, and
  * `Mcp-Name` routing for HTTP transports).
  *
  * Every check is derived from a single connection and, where a task is needed,
@@ -18,6 +18,10 @@ import type {
   ListToolsResult,
   RpcLogEvent,
 } from "../mcp-client-manager/index.js";
+import {
+  MCP_ERROR_CODES,
+  PRE_RENUMBER_DRAFT_ERROR_CODES,
+} from "../mcp-client-manager/mcp-error-codes.js";
 import { MCP_TASKS_EXTENSION_ID } from "../mcp-client-manager/tasks-dispatch.js";
 import type { TasksWire } from "../mcp-client-manager/tasks-dispatch.js";
 import { CLIENT_CAPABILITIES_META_KEY } from "../mcp-client-manager/tasks-ext.js";
@@ -73,14 +77,14 @@ export const CHECK_METADATA: Record<
     category: "creation",
     title: "Undeclared Task Creation Refused",
     description:
-      "On the extension wire, a tools/call that did not carry the extension declaration must not come back as a CreateTaskResult: the server either answers normally or rejects with -32003.",
+      "On the extension wire, a tools/call that did not carry the extension declaration must not come back as a CreateTaskResult: the server either answers normally or rejects with -32021.",
   },
   "tasks-undeclared-capability-rejected": {
     id: "tasks-undeclared-capability-rejected",
     category: "lifecycle",
     title: "Undeclared Capability Rejected",
     description:
-      "tasks/get, tasks/update, tasks/cancel and a task-filtered subscriptions/listen sent WITHOUT the extension declaration must each be rejected with -32003 (Missing Required Client Capability).",
+      "tasks/get, tasks/update, tasks/cancel and a task-filtered subscriptions/listen sent WITHOUT the extension declaration must each be rejected with -32021 (Missing Required Client Capability).",
   },
   "tasks-ttl-shape": {
     id: "tasks-ttl-shape",
@@ -534,7 +538,15 @@ async function captureTaskRequestHeaders(
 const TERMINAL_STATUSES = new Set(["completed", "failed", "cancelled"]);
 
 /** Missing Required Client Capability — the only conformant answer here. */
-const MISSING_REQUIRED_CLIENT_CAPABILITY = -32003;
+const MISSING_REQUIRED_CLIENT_CAPABILITY =
+  MCP_ERROR_CODES.MissingRequiredClientCapability;
+/**
+ * The pre-renumber draft spelling of the same code. Named so a server still
+ * emitting it is told which draft it is running, rather than being reported as
+ * an anonymous wrong code.
+ */
+const OBSOLETE_MISSING_REQUIRED_CLIENT_CAPABILITY =
+  PRE_RENUMBER_DRAFT_ERROR_CODES.MissingRequiredClientCapability;
 /** Method not found: the server does not implement the method at all. */
 const METHOD_NOT_FOUND = -32601;
 /** The client gave up waiting — the server never refused the request. */
@@ -542,14 +554,14 @@ const REQUEST_TIMEOUT = -32001;
 
 /**
  * Cap on the undeclared `subscriptions/listen` probe. A conforming server
- * refuses it immediately with `-32003`; one that wrongly accepts opens a
+ * refuses it immediately with `-32021`; one that wrongly accepts opens a
  * long-lived stream, so the probe — not the server — decides when to stop.
  */
 const LISTEN_PROBE_TIMEOUT_MS = 5_000;
 
 /** What a server did with a request that carried no extension declaration. */
 export type UndeclaredProbeOutcome =
-  /** Rejected with -32003: the required behavior. */
+  /** Rejected with -32021: the required behavior. */
   | "rejected"
   /** The server served the request. */
   | "answered"
@@ -586,11 +598,13 @@ export function describeUndeclaredProbe(probe: UndeclaredProbe): string {
     case "answered":
       return `${probe.method} was answered instead of rejected`;
     case "wrong-code":
-      return `${probe.method} was rejected with ${probe.code} rather than -32003`;
+      return probe.code === OBSOLETE_MISSING_REQUIRED_CLIENT_CAPABILITY
+        ? `${probe.method} was rejected with -32003, the code the tasks extension carried before it was corrected to -32021; the server is running against a pre-final draft`
+        : `${probe.method} was rejected with ${probe.code} rather than -32021`;
     case "no-response":
       return `${probe.method} produced no JSON-RPC rejection (${
         probe.message ?? "no answer"
-      }); a conforming server refuses it immediately with -32003`;
+      }); a conforming server refuses it immediately with -32021`;
     case "probe-failed":
       return `${probe.method} never reached the server (${
         probe.message ?? "no answer"
@@ -598,7 +612,7 @@ export function describeUndeclaredProbe(probe: UndeclaredProbe): string {
     case "unsupported":
       return `${probe.method} is not implemented (-32601)`;
     case "rejected":
-      return `${probe.method} was rejected with -32003`;
+      return `${probe.method} was rejected with -32021`;
   }
 }
 
@@ -1016,7 +1030,7 @@ export class MCPTasksConformanceTest {
                   failed(
                     "tasks-undeclared-creation-refused",
                     stepDurationMs,
-                    `an undeclared tools/call returned a CreateTaskResult; a server must not create a task for a client that never declared the tasks capability (it must answer normally or reject with -32003)${
+                    `an undeclared tools/call returned a CreateTaskResult; a server must not create a task for a client that never declared the tasks capability (it must answer normally or reject with -32021)${
                       creation.discriminated
                         ? ""
                         : '. The payload also carries no resultType "task" discriminator, so it was only visible on the raw wire — a client cannot discriminate it and the task is unreachable (tasks.md:102)'
@@ -1054,7 +1068,10 @@ export class MCPTasksConformanceTest {
                     creation.outcome === "refused" &&
                       creation.code !== MISSING_REQUIRED_CLIENT_CAPABILITY
                       ? [
-                          `the undeclared tools/call was rejected with ${creation.code} rather than -32003; no task was created (which is what tasks.md:61 requires) but the refusal is not the one the extension names`,
+                          creation.code ===
+                          OBSOLETE_MISSING_REQUIRED_CLIENT_CAPABILITY
+                            ? `the undeclared tools/call was rejected with -32003, the code the tasks extension carried before it was corrected to -32021; no task was created (which is what tasks.md:61 requires) but the server is running against a pre-final draft`
+                            : `the undeclared tools/call was rejected with ${creation.code} rather than -32021; no task was created (which is what tasks.md:61 requires) but the refusal is not the one the extension names`,
                         ]
                       : undefined
                   )
@@ -1279,11 +1296,11 @@ export class MCPTasksConformanceTest {
                 checks.push(
                   couldNotRun(
                     "tasks-undeclared-capability-rejected",
-                    "the connection exposes no raw request seam, so an undeclared call could not be sent and the -32003 requirement was not tested"
+                    "the connection exposes no raw request seam, so an undeclared call could not be sent and the -32021 requirement was not tested"
                   )
                 );
               } else {
-                // tasks.md:797-799 — the server MUST answer -32003 for a
+                // tasks.md:797-799 — the server MUST answer -32021 for a
                 // non-declaring client on tasks/get, tasks/update,
                 // tasks/cancel and on task notifications requested through
                 // subscriptions/listen. This is UNCONDITIONAL; anything else
@@ -1312,7 +1329,7 @@ export class MCPTasksConformanceTest {
                         Date.now() - stepStartedAt,
                         `${
                           offenders.length
-                        } undeclared request(s) were not rejected with -32003 (Missing Required Client Capability): ${offenders
+                        } undeclared request(s) were not rejected with -32021 (Missing Required Client Capability): ${offenders
                           .map(describeUndeclaredProbe)
                           .join("; ")}`,
                         { taskId: createdTaskId, probes }
@@ -1423,7 +1440,7 @@ export class MCPTasksConformanceTest {
    *   - `created`  — a `CreateTaskResult` came back: the violation.
    *   - `answered` — a normal tool result: conformant.
    *   - `refused`  — a JSON-RPC error response: also conformant (no task was
-   *     handed to a non-declaring client), with `-32003` being the refusal the
+   *     handed to a non-declaring client), with `-32021` being the refusal the
    *     spec names and any other code carried through as a warning.
    *   - `errored`  — no JSON-RPC response exists at all. Same v2 discriminator
    *     as {@link runUndeclaredProbe}: `ProtocolError` carries a NUMERIC code

--- a/sdk/tests/extension-tasks-wire.integration.test.ts
+++ b/sdk/tests/extension-tasks-wire.integration.test.ts
@@ -13,7 +13,7 @@
  *
  * {@link RawTasksWire} survives for the cases the real client CANNOT produce
  * by construction, each marked at its use site:
- *   - undeclared requests (`-32003`): our client always attaches the
+ *   - undeclared requests (`-32021`): our client always attaches the
  *     per-request eligibility declaration, so an undeclared extension request
  *     is unreachable through it;
  *   - payloads beta.4's decoder rewrites or refuses before `tasks-ext.ts` sees
@@ -641,7 +641,7 @@ describe("tasks extension wire — protocol errors", () => {
     ).rejects.toMatchObject({ code: -32603 });
   });
 
-  it("rejects undeclared tasks/get, tasks/update and tasks/cancel with -32003", async () => {
+  it("rejects undeclared tasks/get, tasks/update and tasks/cancel with -32021", async () => {
     // RAW BY CONSTRUCTION: `tasks-ext.ts` attaches the eligibility declaration
     // to every extension request, so the real client can never emit an
     // undeclared one. The server-side MUST is still worth pinning.
@@ -654,14 +654,14 @@ describe("tasks extension wire — protocol errors", () => {
         { taskId: "ext-task-1", inputResponses: {} },
         { declare: false, routeBy: "ext-task-1" }
       );
-      expect(response.error?.code, method).toBe(-32003);
+      expect(response.error?.code, method).toBe(-32021);
       expect(response.error?.data).toEqual({
         requiredCapabilities: { extensions: { [TASKS_EXTENSION_ID]: {} } },
       });
     }
   });
 
-  it("rejects an undeclared task-filtered subscriptions/listen with -32003", async () => {
+  it("rejects an undeclared task-filtered subscriptions/listen with -32021", async () => {
     // RAW BY CONSTRUCTION: same reason as above — the undeclared leg is
     // unreachable through our client.
     const fixture = await serve();
@@ -672,7 +672,7 @@ describe("tasks extension wire — protocol errors", () => {
       { notifications: { taskIds: ["ext-task-1"] } },
       { declare: false }
     );
-    expect(rejected.error?.code).toBe(-32003);
+    expect(rejected.error?.code).toBe(-32021);
 
     // A declaring listen is accepted…
     const declared = await wire.send("subscriptions/listen", {
@@ -700,7 +700,7 @@ describe("tasks extension wire — protocol errors", () => {
  * SDK's reaction IS the interesting property, the test uses the real client.
  */
 describe("tasks extension wire — misbehaving server", () => {
-  it("can answer an undeclared tasks/get (negative case for the -32003 rule)", async () => {
+  it("can answer an undeclared tasks/get (negative case for the -32021 rule)", async () => {
     const fixture = await serve({
       misbehave: { answerUndeclaredTaskRequests: true },
     });
@@ -855,7 +855,7 @@ describe("tasks extension wire — declared subscriptions/listen (real client)",
     // request but can never deliver notifications (nor the modern ack
     // notification), so the returned promise may not settle usefully.
     // What is pinned here is the WIRE: the request that reached the server
-    // carried the declaration. The fixture answers -32003 to an UNDECLARED
+    // carried the declaration. The fixture answers -32021 to an UNDECLARED
     // task-filtered listen (asserted above), so the recorded params are the
     // exact complement of that case.
     const pending = manager

--- a/sdk/tests/subscription-coordinator.tasks.test.ts
+++ b/sdk/tests/subscription-coordinator.tasks.test.ts
@@ -9,7 +9,7 @@
  *     cannot establish the stream must degrade to polling *visibly* — the
  *     handle is never lost and the reason is always recorded.
  *  2. A task-filtered listen MUST carry the per-request eligibility
- *     declaration, or the server answers `-32003` (`tasks.md:797-799`). A
+ *     declaration, or the server answers `-32021` (`tasks.md:797-799`). A
  *     connection that cannot declare must therefore not send one at all.
  */
 
@@ -274,7 +274,7 @@ describe("opening the stream", () => {
     });
 
     // The listen still goes out for the other interests, WITHOUT taskIds: an
-    // undeclared task-filtered listen would be a guaranteed -32003.
+    // undeclared task-filtered listen would be a guaranteed -32021.
     expect(h.client.listens).toHaveLength(1);
     expect(h.client.listens[0].filter.taskIds).toBeUndefined();
 
@@ -423,7 +423,7 @@ describe("filter churn", () => {
     await new Promise((resolve) => setTimeout(resolve, 0));
 
     expect(h.client.listens).toHaveLength(2);
-    // The re-listen must go back out DECLARED, or it earns -32003 on reconnect.
+    // The re-listen must go back out DECLARED, or it earns -32021 on reconnect.
     expect(h.client.listens[1].declared).toBe(true);
     expect(h.client.listens[1].filter.taskIds).toEqual(["t1"]);
   });

--- a/sdk/tests/support/extension-tasks-fixture.ts
+++ b/sdk/tests/support/extension-tasks-fixture.ts
@@ -29,7 +29,7 @@
  *     default on) so both directions are testable;
  *   - never a `CreateTaskResult` to a `tools/call` that did not declare the
  *     extension in `_meta` (tasks.md:61);
- *   - `-32003` for `tasks/get|update|cancel` and task-filtered
+ *   - `-32021` for `tasks/get|update|cancel` and task-filtered
  *     `subscriptions/listen` from a non-declaring client (tasks.md:797-799);
  *   - `-32602` for an unknown/expired `taskId` (tasks.md:793);
  *   - per-status payloads: `inputRequests` on `input_required`, inline
@@ -63,8 +63,13 @@ export const TASKS_EXTENSION_ID = "io.modelcontextprotocol/tasks";
 export const CLIENT_CAPABILITIES_META_KEY =
   "io.modelcontextprotocol/clientCapabilities";
 
-/** `MISSING_REQUIRED_CLIENT_CAPABILITY` (tasks.md:63). */
-export const MISSING_REQUIRED_CLIENT_CAPABILITY = -32003;
+/** `MISSING_REQUIRED_CLIENT_CAPABILITY` (tasks.md:63, tasks.md:797). */
+export const MISSING_REQUIRED_CLIENT_CAPABILITY = -32021;
+/**
+ * The code the extension carried before ext-tasks corrected it to `-32021`
+ * (`c523f2c`). Kept so a test can drive a pre-final server deliberately.
+ */
+export const OBSOLETE_MISSING_REQUIRED_CLIENT_CAPABILITY = -32003;
 /** `INVALID_PARAMS`, used for unknown/expired task ids (tasks.md:793). */
 export const INVALID_PARAMS = -32602;
 

--- a/sdk/tests/task-lifecycle.test.ts
+++ b/sdk/tests/task-lifecycle.test.ts
@@ -757,7 +757,7 @@ describe("wire adapters", () => {
   it("recognizes the unknown-task error in both nested and flat shapes", () => {
     expect(isUnknownTaskError({ code: -32602 })).toBe(true);
     expect(isUnknownTaskError({ error: { code: -32602 } })).toBe(true);
-    expect(isUnknownTaskError({ code: -32003 })).toBe(false);
+    expect(isUnknownTaskError({ code: -32021 })).toBe(false);
     expect(isUnknownTaskError(null)).toBe(false);
   });
 

--- a/sdk/tests/tasks-conformance/runner-fixture.integration.test.ts
+++ b/sdk/tests/tasks-conformance/runner-fixture.integration.test.ts
@@ -9,7 +9,7 @@
  * test wants. Both bugs this file exists to pin were exactly that shape —
  * a `tools/list` the modern decoder refused (so DISCOVERY died before any
  * Tasks check ran) and an undeclared-capability probe that threw locally (so
- * the `-32003` requirement was never put to the server).
+ * the `-32021` requirement was never put to the server).
  *
  * So the assertions here are deliberately about the WIRE: the fixture's
  * `received` log is the witness that each probe actually left the process,

--- a/sdk/tests/tasks-conformance/runner.test.ts
+++ b/sdk/tests/tasks-conformance/runner.test.ts
@@ -116,7 +116,7 @@ function extensionManager(overrides: Record<string, unknown> = {}) {
       });
       return task;
     },
-    // A conformant server refuses EVERY undeclared task request with -32003
+    // A conformant server refuses EVERY undeclared task request with -32021
     // (ext-tasks tasks.md:797-799), including a task-filtered
     // subscriptions/listen.
     //
@@ -128,7 +128,7 @@ function extensionManager(overrides: Record<string, unknown> = {}) {
     getManagedClient: () => ({
       requestWithSchema: async () => {
         throw Object.assign(new Error("missing capability"), {
-          code: -32003,
+          code: -32021,
         });
       },
     }),
@@ -138,14 +138,14 @@ function extensionManager(overrides: Record<string, unknown> = {}) {
 
 /**
  * A raw request seam whose behavior is set per JSON-RPC method. Anything not
- * listed gets the conformant answer: rejected with -32003.
+ * listed gets the conformant answer: rejected with -32021.
  */
 function undeclaredSeam(perMethod: Record<string, () => unknown>) {
   return () => ({
     requestWithSchema: async (payload: { method: string }) => {
       const behavior = perMethod[payload.method];
       if (behavior) return behavior();
-      throw Object.assign(new Error("missing capability"), { code: -32003 });
+      throw Object.assign(new Error("missing capability"), { code: -32021 });
     },
   });
 }
@@ -521,7 +521,7 @@ describe("MCPTasksConformanceTest", () => {
     expect(result.passed).toBe(false);
   });
 
-  it("passes an undeclared creation the server refused, warning when the code is not -32003", async () => {
+  it("passes an undeclared creation the server refused, warning when the code is not -32021", async () => {
     const manager = extensionManager({
       executeTool: async (
         _serverId: string,
@@ -547,6 +547,34 @@ describe("MCPTasksConformanceTest", () => {
     expect(check?.status).toBe("passed");
     expect(check?.warnings?.[0]).toContain("-32602");
     expect(check?.details).toMatchObject({ undeclaredCreationCode: -32602 });
+  });
+
+  it("warns that a -32003 refusal is the pre-final draft code", async () => {
+    const manager = extensionManager({
+      executeTool: async (
+        _serverId: string,
+        _toolName: string,
+        _args: unknown,
+        options?: { allowTaskResult?: boolean }
+      ) => {
+        if (options?.allowTaskResult)
+          return { resultType: "task", taskId: "task-1" };
+        throw Object.assign(new Error("nope"), { code: -32003 });
+      },
+    });
+
+    const result = await runAgainst(manager, {
+      config: { toolName: "long_job", pollTimeoutMs: 500 },
+    });
+
+    const check = result.checks.find(
+      (c) => c.id === "tasks-undeclared-creation-refused"
+    );
+    // Still a pass — no task reached a non-declaring client — but the warning
+    // has to say the code is stale rather than merely unexpected.
+    expect(check?.status).toBe("passed");
+    expect(check?.warnings?.[0]).toContain("corrected to -32021");
+    expect(check?.warnings?.[0]).toContain("pre-final draft");
   });
 
   it("flags a server advertising the extension on 2025-11-25 without failing", async () => {
@@ -744,11 +772,11 @@ describe("MCPTasksConformanceTest", () => {
 });
 
 /**
- * ext-tasks tasks.md:797-799 — servers MUST answer -32003 for a non-declaring
+ * ext-tasks tasks.md:797-799 — servers MUST answer -32021 for a non-declaring
  * client on tasks/get, tasks/update, tasks/cancel, and on task notifications
  * requested through subscriptions/listen. Unconditional: anything else fails.
  */
-describe("undeclared task requests (-32003)", () => {
+describe("undeclared task requests (-32021)", () => {
   const runProbe = (perMethod: Record<string, () => unknown>) =>
     runAgainst(
       extensionManager({ getManagedClient: undeclaredSeam(perMethod) }),
@@ -757,7 +785,7 @@ describe("undeclared task requests (-32003)", () => {
       }
     );
 
-  it("passes when every undeclared request is rejected with -32003", async () => {
+  it("passes when every undeclared request is rejected with -32021", async () => {
     const result = await runProbe({});
 
     expect(statusMap(result)["tasks-undeclared-capability-rejected"]).toBe(
@@ -769,25 +797,25 @@ describe("undeclared task requests (-32003)", () => {
       {
         method: "tasks/get",
         outcome: "rejected",
-        code: -32003,
+        code: -32021,
         reachedWire: true,
       },
       {
         method: "tasks/update",
         outcome: "rejected",
-        code: -32003,
+        code: -32021,
         reachedWire: true,
       },
       {
         method: "subscriptions/listen",
         outcome: "rejected",
-        code: -32003,
+        code: -32021,
         reachedWire: true,
       },
       {
         method: "tasks/cancel",
         outcome: "rejected",
-        code: -32003,
+        code: -32021,
         reachedWire: true,
       },
     ]);
@@ -828,6 +856,20 @@ describe("undeclared task requests (-32003)", () => {
     });
   }
 
+  it("tells a server still emitting -32003 which draft it is running", async () => {
+    // -32003 is not just any wrong code: it is what the extension carried
+    // before ext-tasks corrected it (c523f2c). Reporting it anonymously would
+    // leave the operator to work out that their server predates the renumber.
+    const result = await runProbe({ "tasks/get": rpcError(-32003) });
+
+    expect(statusMap(result)["tasks-undeclared-capability-rejected"]).toBe(
+      "failed"
+    );
+    const check = undeclaredCheck(result);
+    expect(check?.error?.message).toContain("corrected to -32021");
+    expect(check?.error?.message).toContain("pre-final draft");
+  });
+
   it("names every offending method when several misbehave", async () => {
     const result = await runProbe({
       "tasks/update": () => ({}),
@@ -843,7 +885,7 @@ describe("undeclared task requests (-32003)", () => {
 
   it("skips the subscriptions/listen sub-probe when the server lacks the method", async () => {
     // -32601 on a core method the extension only borrows: not probeable, so
-    // it must not be judged. tasks/* still has to answer -32003.
+    // it must not be judged. tasks/* still has to answer -32021.
     const result = await runProbe({
       "subscriptions/listen": rpcError(-32601, "Method not found"),
     });
@@ -888,7 +930,7 @@ describe("undeclared task requests (-32003)", () => {
   it("fails — and says so — when a probe never reaches the server at all", async () => {
     // The shape of the bug this seam was rewritten to kill: the request dies
     // locally (a missing result schema, upstream's outbound era gate), so the
-    // -32003 requirement is never put to the server. It must never read as
+    // -32021 requirement is never put to the server. It must never read as
     // conformance, and the failure must say the probe did not run.
     const result = await runProbe({
       "tasks/get": () => {
@@ -930,7 +972,7 @@ describe("undeclared task requests (-32003)", () => {
     );
 
     const check = undeclaredCheck(result);
-    // Skipped, but as a GAP: the -32003 requirement was never put to the
+    // Skipped, but as a GAP: the -32021 requirement was never put to the
     // server, so the run cannot report conformance.
     expect(check?.status).toBe("skipped");
     expect(check?.skipReason).toBe("could-not-run");
@@ -955,7 +997,7 @@ describe("undeclared task requests (-32003)", () => {
         requestWithSchema: async (payload: { method: string }) => {
           order.push(`undeclared:${payload.method}`);
           throw Object.assign(new Error("missing capability"), {
-            code: -32003,
+            code: -32021,
           });
         },
       }),

--- a/sdk/tests/tasks-ext-listen-meta.test.ts
+++ b/sdk/tests/tasks-ext-listen-meta.test.ts
@@ -156,7 +156,7 @@ describe("fail loud", () => {
     const call = vi.fn(async () => "sent");
     // Simulates upstream moving the request literal below an `await`, or
     // dropping the envelope from listen entirely. Either way the declaration
-    // did not reach the wire, and a conforming server would answer -32003.
+    // did not reach the wire, and a conforming server would answer -32021.
     await expect(
       withTasksExtensionEnvelope(client, {}, call)
     ).rejects.toThrow(TasksExtListenMetaSeamError);
@@ -311,7 +311,7 @@ describe("the declaration on a real subscriptions/listen frame", () => {
     expect(frame).toBeDefined();
 
     // 1. The per-request eligibility declaration. Without it a conforming
-    //    server MUST answer -32003.
+    //    server MUST answer -32021.
     const capabilities = frame?.params?._meta?.[CLIENT_CAPABILITIES_META_KEY];
     expect(capabilities?.extensions?.[TASKS_EXT]).toEqual({});
     // The client's own declared capabilities survive the merge.


### PR DESCRIPTION
## What

`tasks-undeclared-capability-rejected` — the check whose whole job is to prove a server refuses task work from a client that never declared the extension — was asserting `-32003`. The canonical code is `-32021`.

The verdict was wrong in both directions: a server answering the correct `-32021` **failed**, and one answering the obsolete `-32003` **passed**.

## Why this is a one-line-value bug with a two-file cause

`sdk/src/mcp-client-manager/mcp-error-codes.ts` is the declared single source of truth and has had the right values all along:

```ts
MissingRequiredClientCapability: -32021,          // MCP_ERROR_CODES
...
PRE_RENUMBER_DRAFT_ERROR_CODES = {
  MissingRequiredClientCapability: -32003,        // "NOT final wire codes"
}
```

Two places kept `-32003` as a hard-coded literal instead of reading it:

| Site | Was | Now |
|---|---|---|
| `task-lifecycle-adapters.ts` → `TASKS_DECLARATION_REQUIRED_ERROR_CODE` (public SDK export) | `-32003` | `MCP_ERROR_CODES.MissingRequiredClientCapability` |
| `tasks-conformance/runner.ts` → private `MISSING_REQUIRED_CLIENT_CAPABILITY` | `-32003` | same central constant |

Both now read the table, so the next renumber is one line in one file.

Worth noting the codebase already disagreed with itself: the core suite's `modern-undeclared-capability-error` (`checks/modern.ts:80`) asserts `-32021`. Two conformance modules were grading the same requirement against different codes.

## Authority

ext-tasks `c523f2c` ("Fix Missing Required Client Capability error code", 2026-08-19) made this change, for the reasons its message gives: SEP-2663 uses `-32021` in all four spots, the core 2026-07-28 schema defines `MissingRequiredClientCapabilityError` as `-32021`, and **`-32003` appears in no core schema version**.

The extension's root `index.md` still shows `-32003` — it is stale. `specification/draft/tasks.md:63,797` is authoritative.

## The transition case

A server still emitting `-32003` **fails** — it does not conform. But it is named rather than reported as an anonymous wrong code:

> `tasks/get` was rejected with -32003, the code the tasks extension carried before it was corrected to -32021; the server is running against a pre-final draft

The same naming applies to the `tasks-undeclared-creation-refused` warning, which stays a **pass** — no task reached a non-declaring client, which is what `tasks.md:61` actually requires.

## Also updated

The test fixture emulates a conforming server, so it now answers `-32021`; the prose across `tasks-ext*.ts`, `subscription-coordinator.ts`, `MCPClientManager.ts` and the two app-side comments that cited `-32003` as the code a conforming server returns; and the drift-tested `conformance-catalog.ts` descriptions, which must match the runner's.

## Verification

- `npm run typecheck` — clean (exit 0)
- `npm run test` — sdk 5644 passed, inspector 16752 passed (exit 0)
- Two new regression tests cover the transition path: the failure message and the warning message must each name `-32003` as pre-final rather than anonymous.

> [!NOTE]
> Verifying this in a git worktree needs a real `npm install` in the worktree. Symlinking the main checkout's `node_modules` makes `@mcpjam/sdk` resolve through a relative symlink back to the **main** checkout's `sdk/`, so typecheck silently grades the wrong tree.

## Follow-ups, not in this PR

- The core schema requires `error.data.requiredCapabilities` on this error; our tasks fixture does not emit it and no tasks check asserts it. `modern-undeclared-capability-error` already does.
- `mcp-error-codes.ts` still describes the SDK as "v2 alpha.2" and defers a "Phase 1 reconciliation" to the beta.4 bump. The workspaces are on `2.0.0` GA, so that docblock and the deletion it schedules are both due a revisit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how tasks conformance is graded and which JSON-RPC code the SDK/fixture treat as required, so servers still emitting `-32003` will start failing that check. No auth or data-handling changes.
> 
> **Overview**
> Tasks conformance now treats **`-32021`** (`MissingRequiredClientCapability`) as the required refusal for undeclared tasks work, instead of the pre-renumber **`-32003`**. That check was failing servers that already used the canonical code and passing ones still on the obsolete draft.
> 
> `TASKS_DECLARATION_REQUIRED_ERROR_CODE` and the runner’s private constant now read `MCP_ERROR_CODES.MissingRequiredClientCapability` instead of a hardcoded `-32003`. A server that still emits `-32003` **fails** `tasks-undeclared-capability-rejected`, with a message that names the pre-final draft; `tasks-undeclared-creation-refused` still **passes** (no task reached a non-declaring client) but warns the same way.
> 
> The test fixture, catalog copy, comments, and wire tests are updated to match.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 79c5abf56bd06620f7223769441d5fc79379095a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes tasks conformance to grade undeclared-capability refusals against -32021 instead of the obsolete -32003, aligning with SEP-2663 and the core 2026‑07‑28 schema. Servers returning -32021 now pass; servers returning -32003 fail with a message that names it as a pre‑final draft code.

- Replaces hard-coded -32003 in the SDK with `MCP_ERROR_CODES.MissingRequiredClientCapability`:
  - `sdk/src/mcp-client-manager/task-lifecycle-adapters.ts` (`TASKS_DECLARATION_REQUIRED_ERROR_CODE`)
  - `sdk/src/tasks-conformance/runner.ts` (checks also use `PRE_RENUMBER_DRAFT_ERROR_CODES` for clear failure messaging)
- Updates descriptions, comments, fixtures, and tests across `@mcpjam/sdk` and `@mcpjam/inspector` to expect -32021, and adds regression tests covering the transition message.
- No change to declaring-client behavior; only rejection-code checks and messages change. Future renumbers are one-line in `mcp-error-codes.ts`.

**Migration**
- Servers and tests must emit/assert -32021 for Missing Required Client Capability on undeclared `tasks/*` and task-filtered `subscriptions/listen`. If still returning -32003, update the server; the conformance run will fail with a hint that the code predates the renumber.

<sup>Written for commit 79c5abf56bd06620f7223769441d5fc79379095a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/MCPJam/inspector/pull/4216?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

