### PR TITLE
Drop harness prewarm now that lease egress stays open

### DIFF
--- a/mcpjam-inspector/server/utils/harness/__tests__/registry.test.ts
+++ b/mcpjam-inspector/server/utils/harness/__tests__/registry.test.ts
@@ -343,14 +343,14 @@ const toUserMessage = (text) => ({
 });
 
 describe("bootstrap recipes are auth-independent", () => {
-  // Load-bearing for the prewarm ordering. A harness turn installs its runtime
-  // BEFORE the broker locks the box's egress, using a runtime built with a
-  // placeholder credential — the real one does not exist yet. The framework
-  // keys the "already installed" marker on a hash of the recipe's file
-  // contents, so if the recipe ever varied with auth, the prewarmed marker
-  // would not match the one the streaming turn looks for. The turn would then
-  // re-run the bootstrap under the egress lock, where it cannot reach the
-  // package registry — the original failure, silently restored.
+  // Load-bearing for the in-stream bootstrap. A harness turn installs its
+  // runtime inside the sandbox after the broker starts, using a runtime built
+  // with dummy broker creds. The framework keys the "already installed" marker
+  // on a hash of the recipe's file contents, so if the recipe ever varied with
+  // auth, a resume would re-run the bootstrap against a different hash. The
+  // recipe must stay auth-independent so the in-stream bootstrap is
+  // attributable to the adapter, not to whichever credential happened to be
+  // present when the files were hashed.
   const auth = (suffix: string) => ({
     anthropic: {
       apiKey: `anthropic-key-${suffix}`,
@@ -390,7 +390,7 @@ describe("bootstrap recipes are auth-independent", () => {
 
   it("claude-code's patched bridge differs from the unpatched one", () => {
     // The other half of the same invariant: the registry rewrites the bridge
-    // asset, so prewarming a bare `createClaudeCode()` would compute a
+    // asset, so bootstrapping a bare `createClaudeCode()` would compute a
     // different hash than the turn does. This test is what makes that
     // divergence visible if anyone reaches for the bare constructor.
     // Dual-`ai` boundary cast, as everywhere else this constructor is used.

--- a/mcpjam-inspector/server/utils/harness/__tests__/run-harness-turn-broker-required.test.ts
+++ b/mcpjam-inspector/server/utils/harness/__tests__/run-harness-turn-broker-required.test.ts
@@ -25,7 +25,6 @@ vi.mock("@ai-sdk/harness/agent", () => ({
     }));
   },
   collectHarnessAgentToolApprovalContinuations: vi.fn(() => []),
-  prewarmHarness: vi.fn(async () => {}),
 }));
 
 vi.mock("../registry.js", () => ({

--- a/mcpjam-inspector/server/utils/harness/__tests__/run-harness-turn-empty-output.test.ts
+++ b/mcpjam-inspector/server/utils/harness/__tests__/run-harness-turn-empty-output.test.ts
@@ -25,7 +25,6 @@ vi.mock("@ai-sdk/harness/agent", () => ({
   },
   // WS3: no trailing tool-approval-response parts in these prompts.
   collectHarnessAgentToolApprovalContinuations: vi.fn(() => []),
-  prewarmHarness: vi.fn(async () => {}),
 }));
 
 vi.mock("../registry.js", () => ({

--- a/mcpjam-inspector/server/utils/harness/__tests__/run-harness-turn-ephemeral.test.ts
+++ b/mcpjam-inspector/server/utils/harness/__tests__/run-harness-turn-ephemeral.test.ts
@@ -29,7 +29,6 @@ vi.mock("@ai-sdk/harness/agent", () => ({
     }));
   },
   collectHarnessAgentToolApprovalContinuations: vi.fn(() => []),
-  prewarmHarness: vi.fn(async () => {}),
 }));
 
 vi.mock("../registry.js", () => ({
@@ -127,8 +126,6 @@ import {
   renewHarnessBoxReservation,
   releaseHarnessBoxReservation,
 } from "../harness-model-broker.js";
-import { prewarmHarness } from "@ai-sdk/harness/agent";
-import { getHarnessAdapter } from "../registry.js";
 import { resolveHarnessSandbox } from "../resolve-sandbox.js";
 import { createE2BHarnessSandboxProvider } from "../e2b-sandbox-provider.js";
 
@@ -178,11 +175,9 @@ afterEach(() => {
   vi.mocked(revokeHarnessModelBroker).mockClear();
   vi.mocked(resolveHarnessSandbox).mockClear();
   vi.mocked(createE2BHarnessSandboxProvider).mockClear();
-  vi.mocked(prewarmHarness).mockClear();
   vi.mocked(reserveHarnessBox).mockClear();
   vi.mocked(renewHarnessBoxReservation).mockClear();
   vi.mocked(releaseHarnessBoxReservation).mockClear();
-  vi.mocked(getHarnessAdapter).mockClear();
 });
 
 describe("runHarnessTurn — ephemeral sandbox binding (phase 6)", () => {
@@ -265,12 +260,11 @@ describe("runHarnessTurn — ephemeral sandbox binding (phase 6)", () => {
   });
 });
 
-describe("runHarnessTurn — the runtime is installed before egress is locked", () => {
-  it("claims the box, prewarms it, and only then asks for a credential", async () => {
-    // The ordering IS the fix. The broker's network policy locks this box down
-    // to the model proxy, and the harness bootstrap needs the package registry,
-    // so a bootstrap that runs after the lease can never succeed. The claim
-    // comes first so no second turn can lock the box mid-bootstrap.
+describe("runHarnessTurn — reserve, then start the baseline-preserving broker lease", () => {
+  it("claims the box and only then asks for a credential", async () => {
+    // Reserve → broker start → in-stream bootstrap. The lease keeps the box's
+    // own egress baseline, so the bootstrap can reach the registry after start.
+    // The claim still comes first so a second turn cannot interleave.
     await runHarnessTurn(
       baseOptions({ harnessSandboxBinding: BINDING }) as never,
       "none"
@@ -278,43 +272,21 @@ describe("runHarnessTurn — the runtime is installed before egress is locked", 
 
     const reserveOrder = vi.mocked(reserveHarnessBox).mock
       .invocationCallOrder[0]!;
-    const prewarmOrder = vi.mocked(prewarmHarness).mock
+    const providerOrder = vi.mocked(createE2BHarnessSandboxProvider).mock
       .invocationCallOrder[0]!;
     const brokerOrder = vi.mocked(startHarnessModelBroker).mock
       .invocationCallOrder[0]!;
-    expect(reserveOrder).toBeLessThan(prewarmOrder);
-    expect(prewarmOrder).toBeLessThan(brokerOrder);
+    expect(reserveOrder).toBeLessThan(providerOrder);
+    expect(providerOrder).toBeLessThan(brokerOrder);
   });
 
-  it("prewarms through the same provider instance the session will use", async () => {
-    // Both must attach to the same box, and the provider must be built once —
-    // a second instance would mean a second connect for no reason.
+  it("builds one provider for the turn before broker start", async () => {
     await runHarnessTurn(
       baseOptions({ harnessSandboxBinding: BINDING }) as never,
       "none"
     );
 
     expect(createE2BHarnessSandboxProvider).toHaveBeenCalledTimes(1);
-    const provider = vi.mocked(createE2BHarnessSandboxProvider).mock.results[0]!
-      .value;
-    expect(vi.mocked(prewarmHarness).mock.calls[0]![0].sandboxProvider).toBe(
-      provider
-    );
-  });
-
-  it("prewarms the runtime the adapter builds, never a bare one", async () => {
-    // The registry rewrites the bridge asset inside the bootstrap recipe, and
-    // the recipe's content hash decides the marker file the real turn looks
-    // for. Prewarming a differently-built runtime would leave a marker the turn
-    // ignores — reinstating the deadlock while looking fixed.
-    await runHarnessTurn(
-      baseOptions({ harnessSandboxBinding: BINDING }) as never,
-      "none"
-    );
-
-    const adapter = vi.mocked(getHarnessAdapter).mock.results[0]!.value;
-    const built = adapter.createHarness.mock.results[0]!.value;
-    expect(vi.mocked(prewarmHarness).mock.calls[0]![0].harness).toBe(built);
   });
 
   it("shares one runId between the claim and the lease that consumes it", async () => {
@@ -330,21 +302,22 @@ describe("runHarnessTurn — the runtime is installed before egress is locked", 
     expect(reservedRunId).toBeTruthy();
   });
 
-  it("hands the box back when preparing it fails, and mints nothing", async () => {
-    vi.mocked(prewarmHarness).mockRejectedValueOnce(
-      new Error("pnpm is missing on sandbox e2b_ephemeral_1")
-    );
+  it("hands the box back when broker start fails", async () => {
+    vi.mocked(startHarnessModelBroker).mockResolvedValueOnce({
+      ok: false,
+      status: 502,
+      error: "Failed to provision the harness network.",
+    });
 
     const result = await runHarnessTurn(
       baseOptions({ harnessSandboxBinding: BINDING }) as never,
       "none"
     );
 
-    // No lease was minted, so there is no egress rule and nothing to revoke...
-    expect(startHarnessModelBroker).not.toHaveBeenCalled();
-    expect(revokeHarnessModelBroker).not.toHaveBeenCalled();
-    // ...but the claim is ours to give back, and the next turn should not wait
-    // out its TTL for a box nobody is using.
+    // The run id was recorded before the POST, so teardown still revokes in
+    // case the backend installed before a lost response — and the reservation
+    // is ours to give back so the next turn does not wait out its TTL.
+    expect(revokeHarnessModelBroker).toHaveBeenCalledTimes(1);
     expect(releaseHarnessBoxReservation).toHaveBeenCalledTimes(1);
     expect(result.aborted).toBe(false);
   });
@@ -372,7 +345,6 @@ describe("runHarnessTurn — the runtime is installed before egress is locked", 
       /already active on this computer/i
     );
     // Refused before ANY work on the box — that is the point of claiming first.
-    expect(prewarmHarness).not.toHaveBeenCalled();
     expect(startHarnessModelBroker).not.toHaveBeenCalled();
   });
 
@@ -390,21 +362,8 @@ describe("runHarnessTurn — the runtime is installed before egress is locked", 
     );
 
     expect(onEngineError).toHaveBeenCalledTimes(1);
-    expect(prewarmHarness).not.toHaveBeenCalled();
     expect(startHarnessModelBroker).not.toHaveBeenCalled();
     expect(releaseHarnessBoxReservation).not.toHaveBeenCalled();
-  });
-
-  it("can be switched off entirely without breaking the turn", async () => {
-    vi.stubEnv("HARNESS_PREWARM_DISABLED", "1");
-
-    await runHarnessTurn(
-      baseOptions({ harnessSandboxBinding: BINDING }) as never,
-      "none"
-    );
-
-    expect(prewarmHarness).not.toHaveBeenCalled();
-    expect(startHarnessModelBroker).toHaveBeenCalledTimes(1);
   });
 });
 

--- a/mcpjam-inspector/server/utils/harness/run-harness-turn.ts
+++ b/mcpjam-inspector/server/utils/harness/run-harness-turn.ts
@@ -34,7 +34,6 @@ import {
 import {
   HarnessAgent,
   collectHarnessAgentToolApprovalContinuations,
-  prewarmHarness,
 } from "@ai-sdk/harness/agent";
 import {
   emitTraceSnapshot,
@@ -728,15 +727,11 @@ export async function runHarnessTurn(
       const isApprovalResume = approvalContinuations.length > 0;
 
       // Phase timing — log where a turn spends its wall-clock (claim / box
-      // wake / runtime prewarm / broker start / session connect / model stream /
-      // finalize) so "takes forever" can be attributed instead of guessed.
+      // wake / broker start / session connect / model stream / finalize) so
+      // "takes forever" can be attributed instead of guessed.
       const tStart = Date.now();
       let tClaim = tStart;
       let tSandbox = tStart;
-      // Set at the START of the prewarm phase and again at its end, so a turn
-      // that skips prewarm reports ~0 for it rather than a negative duration
-      // measured back to function entry.
-      let tPrewarm = tStart;
       let tBroker = tStart;
       let tConnect = tStart;
       let resumedSession = false;
@@ -1104,29 +1099,16 @@ export async function runHarnessTurn(
         box.kind === "computer" ? box.computerId : undefined;
       tSandbox = Date.now();
 
-      // 3a. PREPARE the box — while it can still reach the internet.
+      // 3a. RESERVE the box, then start the baseline-preserving broker lease.
       //
       // The harness runtime is installed into the sandbox by a bootstrap recipe
-      // that shells `pnpm install` for the agent CLI. Step 3b below locks this
-      // box's egress to the model proxy alone, so a bootstrap running after it
-      // cannot reach the package registry — it dies, slowly and opaquely, and
-      // the turn never gets as far as a model call. Bootstrapping has to happen
-      // here, in the last moment the box has ordinary egress.
-      //
-      // `prewarmHarness` applies the SAME recipe the agent would apply itself,
-      // keyed by the same content hash, and writes the same marker file. So this
-      // is not extra work: it moves the work earlier, and the in-stream
-      // bootstrap becomes a single marker read. It runs on every turn rather
-      // than only on turns expected to start fresh, because a resume that fails
-      // to reattach falls back to a fresh session — under the lock, where the
-      // bootstrap could not be recovered.
-      //
-      // The runtime handed to prewarm MUST come from the adapter, not from a
-      // bare `createClaudeCode()`: the registry patches the bridge asset inside
-      // the recipe, the recipe's hash covers file contents, and a divergent hash
-      // would leave a marker the real turn ignores — reinstating the deadlock
-      // while looking like it had been fixed. Auth is inert here (the adapter
-      // reads it only when starting a session), so a placeholder is enough.
+      // that shells `pnpm install` for the agent CLI. The lease keeps the box's
+      // own egress baseline (public internet for members; web-only for guests)
+      // and only adds a header transform on the model-proxy host, so the
+      // in-stream bootstrap can reach the package registry on its own. The
+      // reservation is a concurrency/liveness control — it is NOT an egress
+      // lock — and is kept on its own merits pending an independent removal
+      // gate.
       //
       // ONE id for the whole turn: it names this turn's claim on the box, and
       // the lease consumes that claim by matching it. Deliberately NOT assigned
@@ -1138,9 +1120,9 @@ export async function runHarnessTurn(
 
       // Claim the box for the whole preparation window. The lease's own per-box
       // fence starts only once a lease exists, so without this two turns could
-      // interleave — one locking the box's egress while the other is still
-      // installing into it. A refusal here is the same condition a caller would
-      // otherwise meet at broker start, just detected before we do any work.
+      // interleave wake / bootstrap / broker-start. A refusal here is the same
+      // condition a caller would otherwise meet at broker start, just detected
+      // before we do any work.
       const reservation = await reserveHarnessBox({
         box,
         harnessId: harnessAdapter.id,
@@ -1219,47 +1201,20 @@ export async function runHarnessTurn(
         "error" in resolvedHarnessWorkdir
           ? HOME_ROOT
           : resolvedHarnessWorkdir.workdir ?? HOME_ROOT;
-      // ONE provider for the turn: prewarm and the streaming session below both
-      // attach to the same box through it.
+      // ONE provider for the turn: the streaming session below attaches to the
+      // box through it. One provider per turn is still the right shape even
+      // without a separate prewarm pass.
       const sandbox = createE2BHarnessSandboxProvider({
         sandboxId,
         defaultWorkingDirectory,
       });
 
-      tPrewarm = Date.now();
-      if (process.env.HARNESS_PREWARM_DISABLED !== "1") {
-        const prewarmRuntime = harnessAdapter.createHarness({
-          modelId,
-          auth: buildBrokerDummyAuth(
-            harnessAdapter.id,
-            "https://prewarm.invalid"
-          ),
-        });
-        try {
-          await prewarmHarness({
-            harness: prewarmRuntime,
-            sandboxProvider: sandbox,
-            abortSignal: effectiveAbortSignal,
-          });
-        } catch (err) {
-          // An abort is not a failure — rethrow it untouched so the outer catch
-          // still classifies the turn as aborted rather than broken.
-          if (effectiveAbortSignal.aborted || isAbortError(err)) throw err;
-          throw new Error(
-            `Couldn't prepare the ${harnessAdapter.displayName} runtime on the ` +
-              `computer: ${err instanceof Error ? err.message : String(err)}`,
-            { cause: err }
-          );
-        }
-        tPrewarm = Date.now();
-      }
-
       // 3b. BROKER delivery (the only credential path): the sandbox id is now
-      // known, so have Convex mint the lease, lock the sandbox's egress to the
-      // proxy, and install the lease into E2B's egress transform — the
-      // inspector never sees the lease. Run the CLI with dummy creds pointed
-      // at the returned proxy. Fail-fast on install error (the box is awake
-      // but no real credential exists anywhere).
+      // known, so have Convex mint the lease, keep the sandbox on its own
+      // egress baseline, and install the lease into E2B's egress transform on
+      // the model-proxy host — the inspector never sees the lease. Run the CLI
+      // with dummy creds pointed at the returned proxy. Fail-fast on install
+      // error (the box is awake but no real credential exists anywhere).
       // RECORD the run id before the POST: if the backend installs the E2B rule
       // but the response is lost or aborted, teardown can still revoke by this
       // id (the backend keys revoke on runId). From here on a lease may exist.
@@ -1291,8 +1246,8 @@ export async function runHarnessTurn(
       tBroker = Date.now();
 
       // 4. Assemble the harness over the host's E2B computer (the provider and
-      // its working directory were resolved in step 3a, so prewarm and the
-      // streaming session share one).
+      // its working directory were resolved in step 3a, so the streaming session
+      // uses the same one).
       // (permissionMode was computed above, before the runtime fingerprint.)
 
       // The adapter maps the host modelId to the harness's native model and
@@ -2324,8 +2279,8 @@ export async function runHarnessTurn(
         logger.info(
           `[harness][timing] claim=${tClaim - tStart}ms boxWake=${
             tSandbox - tClaim
-          }ms prewarm=${tPrewarm - tSandbox}ms brokerStart=${
-            tBroker - tPrewarm
+          }ms brokerStart=${
+            tBroker - tSandbox
           }ms sessionConnect=${
             tConnect - tBroker
           }ms modelStream=${tStream - tConnect}ms total=${


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Purpose and context

Part of the open-by-default egress correction. After backend PR https://github.com/MCPJam/mcpjam-backend/pull/1075 deploys, a brokered lease keeps the box's own baseline, so the in-stream Claude Code bootstrap can reach the package registry on its own. The bootstrap-before-lock **prewarm** is then pure per-turn latency and is removed here.

This PR does **not** infer that the reservation is useless. `reserveHarnessBox`, renew/release, heartbeat, `livenessAbort`, and on-finish release stay exactly as concurrency/liveness controls. Reservation removal is Gate 1 → PR 2B, only if that gate passes.

**Deploy after** mcpjam-backend#1075. Mixed-version is safe: the backend still supports reservations; the only behavior removed is redundant runtime prewarming.

## Before / after

**Before:** reserve → `prewarmHarness` (pnpm install under ordinary egress) → broker start (deny-all lock).

**After:** reserve → broker start (baseline-preserving lease) → in-stream bootstrap under that lease.

## What changed

- Dropped the `prewarmHarness` import and the `:1229-1255` prewarm block (including `HARNESS_PREWARM_DISABLED`).
- Kept the hoisted workdir/provider block (one provider per turn).
- Timing log is now `brokerStart=${tBroker - tSandbox}`; `prewarm=` is gone.
- Reservation acquisition still happens before broker start; the same `turnRunId` is still the broker run id.
- `onFinishEngine`: heartbeat cleanup, reservation release, and broker-revoke-first ordering are unchanged.
- `e2b-sandbox-provider.ts`: no changes (pnpm guard + abort plumbing stay).

## Tests

- Rewrote the ephemeral ordering suite: reserve → provider → broker start; broker-start failures still release the reservation; 409/404 reservation refusals still mint nothing.
- Registry auth-invariant recipe-hash tests remain; comments say bootstrap rather than prewarm.
- `e2b-sandbox-provider.test.ts` untouched.

50 harness tests green (`run-harness-turn-*`, `registry`, `e2b-sandbox-provider`).

## Rollout

1. Backend #1075 merged + deployed (Gate 0 passed).
2. This PR.
3. Staging e2e: `cc-unpinned-probe` / `smoke-cc` → `harnessModelLeases.callCount > 0`, plus a canary that `curl https://example.com` returns 200 **during** the lease.
4. Gate 1 (reservation value) is independent and does not block this.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-179444e3-1f28-45c2-afbb-37037d8af959?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-179444e3-1f28-45c2-afbb-37037d8af959&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Drops harness prewarm because broker leases now preserve box egress. Before: reserve → prewarm under ordinary egress → broker start (deny-all). After: reserve → broker start (baseline-preserving lease) → in-stream bootstrap. This reduces per-turn latency without breaking bootstraps.

- Removes `prewarmHarness` from `run-harness-turn.ts` and tests, deletes `HARNESS_PREWARM_DISABLED`, and updates timing logs (no `prewarm=`, `brokerStart` now measured from sandbox wake).
- Keeps reservation/heartbeat/renew/release for concurrency and liveness; still builds one provider per turn before broker start.
- Updates ordering tests to assert reserve → provider → broker start; keeps registry auth-invariant tests (now worded for in-stream bootstrap). Mocks no longer include `prewarmHarness`.
- On broker-start failure, teardown revokes the lease by runId and releases the reservation; 409/404 reservation refusals still mint nothing.

**Rollout**
- Deploy backend that keeps lease egress open first, then merge; mixed versions are safe.
- Remove any downstream references or mocks of `prewarmHarness` in code touching `@ai-sdk/harness/agent`.
- Verify in staging: `harnessModelLeases.callCount > 0` and `curl https://example.com` succeeds during the lease.

<sup>Written for commit 74fb202750266f448a4ebaca82c2ec9f7177595e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/MCPJam/inspector/pull/4217?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

