### PR TITLE
changesets: release Inspector, CLI, and SDK

### DIFF
--- a/.changeset/releases-2026-08-21.md
+++ b/.changeset/releases-2026-08-21.md
@@ -1,0 +1,7 @@
+---
+"@mcpjam/inspector": minor
+"@mcpjam/cli": minor
+"@mcpjam/sdk": minor
+---
+
+Release the latest Inspector, CLI, and SDK updates.


### PR DESCRIPTION
Adds one minor-release changeset for @mcpjam/inspector, @mcpjam/cli, and @mcpjam/sdk.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prepares minor releases for `@mcpjam/inspector`, `@mcpjam/cli`, and `@mcpjam/sdk` by adding a Changesets entry so the latest updates can be published. No runtime or API changes in this PR; it only queues version bumps and changelogs.

- Minor bump for: `@mcpjam/inspector`, `@mcpjam/cli`, `@mcpjam/sdk`.
- After merge, these will be included in the next Changesets versioning/publish run.
- No migration required; consumers can upgrade when published.

<sup>Written for commit 26ec73340eefdd4c09efffdc932b1cfe1e0b60fc. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/MCPJam/inspector/pull/4218?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

