### PR TITLE
Surface paid-seat invites that can't be opened yet

### DIFF
--- a/mcpjam-inspector/client/src/App.tsx
+++ b/mcpjam-inspector/client/src/App.tsx
@@ -2358,8 +2358,18 @@ export default function App() {
       ),
     [optimisticallyDeletedOrganizationIds, sortedOrganizations]
   );
+  // Orgs the user may actually open. A `seatPending` org is a paid-seat invite
+  // whose membership hasn't linked yet, so every org-scoped query for it is
+  // denied server-side — making it active crashed the route
+  // (Sentry INSPECTOR-CLIENT-24C). It stays in `effectiveOrganizations` so the
+  // switcher can list it as unavailable, but it must never become the
+  // active org, by route or by fallback.
+  const selectableOrganizations = useMemo(
+    () => effectiveOrganizations.filter((org) => !org.seatPending),
+    [effectiveOrganizations]
+  );
   const hasRouteOrganization = !!routeOrganizationId
-    ? effectiveOrganizations.some((org) => org._id === routeOrganizationId)
+    ? selectableOrganizations.some((org) => org._id === routeOrganizationId)
     : false;
 
   // Handle hosted OAuth callback: claim the callback before any hosted page renders.
@@ -2709,9 +2719,9 @@ export default function App() {
   } = useAppState({
     currentUserId: workOsUser?.id ?? null,
     currentActorKey: actorKey,
-    hasOrganizations: effectiveOrganizations.length > 0,
+    hasOrganizations: selectableOrganizations.length > 0,
     isLoadingOrganizations,
-    validOrganizations: effectiveOrganizations,
+    validOrganizations: selectableOrganizations,
     routeOrganizationId: hasRouteOrganization ? routeOrganizationId : undefined,
     requestSignIn: () => {
       void signIn();
@@ -3088,7 +3098,7 @@ export default function App() {
   const billingOrganizationId =
     !isLoadingOrganizations &&
     rawBillingOrganizationId &&
-    effectiveOrganizations.some((org) => org._id === rawBillingOrganizationId)
+    selectableOrganizations.some((org) => org._id === rawBillingOrganizationId)
       ? rawBillingOrganizationId
       : null;
   const activeProjectBillingOrganizationId =
@@ -4482,7 +4492,7 @@ export default function App() {
   const homeOrganizationId =
     !isLoadingOrganizations &&
     rawHomeOrganizationId &&
-    effectiveOrganizations.some((org) => org._id === rawHomeOrganizationId)
+    selectableOrganizations.some((org) => org._id === rawHomeOrganizationId)
       ? rawHomeOrganizationId
       : null;
 

--- a/mcpjam-inspector/client/src/App.tsx
+++ b/mcpjam-inspector/client/src/App.tsx
@@ -3917,7 +3917,7 @@ export default function App() {
 
     const projectOrgId = activeProject?.organizationId;
     const orgId = resolveCheckoutOrganizationId(
-      effectiveOrganizations,
+      selectableOrganizations,
       activeOrganizationId,
       projectOrgId
     );
@@ -3955,7 +3955,7 @@ export default function App() {
     routeOrganizationId,
     routeOrganizationSection,
     signIn,
-    effectiveOrganizations,
+    selectableOrganizations,
     workOsUser?.id,
   ]);
 
@@ -4106,7 +4106,7 @@ export default function App() {
           : [...currentIds, deletedOrganizationId]
       );
 
-      const remainingOrganizations = effectiveOrganizations.filter(
+      const remainingOrganizations = selectableOrganizations.filter(
         (organization) => organization._id !== deletedOrganizationId
       );
       const fallbackOrganizationId = resolveDeletedOrganizationFallbackId(
@@ -4142,7 +4142,7 @@ export default function App() {
       activeProject?.organizationId,
       clearLocalFallbackProjectSelection,
       clearConvexActiveProjectSelection,
-      effectiveOrganizations,
+      selectableOrganizations,
       navigateToServers,
       routeOrganizationId,
       setActiveOrganizationId,

--- a/mcpjam-inspector/client/src/components/OrganizationsTab.tsx
+++ b/mcpjam-inspector/client/src/components/OrganizationsTab.tsx
@@ -864,6 +864,9 @@ function OrganizationPage({
     }
   };
 
+  const seatInviteRemovalInFlightRef = useRef(false);
+  const [isRemovingSeatInvite, setIsRemovingSeatInvite] = useState(false);
+
   const handleRetrySeatPayment = async () => {
     try {
       const result = await retrySeatPayment();
@@ -882,12 +885,24 @@ function OrganizationPage({
   };
 
   const handleCancelSeatPayment = async () => {
+    // For a terminal charge the button says "Remove invite", and that is what
+    // it has to do: cancelSeatPayment returns immediately for anything not
+    // still active, so calling it here left the invite and the notice exactly
+    // where they were while claiming success.
+    const isInviteRemoval = activeSeatPaymentIntent?.needsRetry === true;
+    // Removal has no spinner of its own — the shared one belongs to
+    // cancelSeatPayment, which this path never calls — so a second click would
+    // fire a concurrent removeMember that finds no row and reports "Member not
+    // found" on top of the first one's success. The state below disables the
+    // button and is what normally prevents that; the ref keeps the handler
+    // self-guarding rather than depending on its own button being disabled.
+    if (isInviteRemoval) {
+      if (seatInviteRemovalInFlightRef.current) return;
+      seatInviteRemovalInFlightRef.current = true;
+      setIsRemovingSeatInvite(true);
+    }
     try {
-      // For a terminal charge the button says "Remove invite", and that is
-      // what it has to do: cancelSeatPayment returns immediately for anything
-      // not still active, so calling it here left the invite and the notice
-      // exactly where they were while claiming success.
-      if (activeSeatPaymentIntent?.needsRetry) {
+      if (isInviteRemoval && activeSeatPaymentIntent) {
         await removeMember({
           organizationId: organization._id,
           email: activeSeatPaymentIntent.email,
@@ -903,6 +918,11 @@ function OrganizationPage({
           ? error.message
           : "Failed to cancel pending seat payment"
       );
+    } finally {
+      if (isInviteRemoval) {
+        seatInviteRemovalInFlightRef.current = false;
+        setIsRemovingSeatInvite(false);
+      }
     }
   };
 
@@ -1250,7 +1270,7 @@ function OrganizationPage({
         intent={activeSeatPaymentIntent}
         isFinishingSeatPayment={isFinishingSeatPayment}
         isCompletingSeatPayment={isCompletingSeatPayment}
-        isCancelingSeatPayment={isCancelingSeatPayment}
+        isCancelingSeatPayment={isCancelingSeatPayment || isRemovingSeatInvite}
         onFinish={() =>
           void (activeSeatPaymentIntent.needsRetry
             ? handleRetrySeatPayment()

--- a/mcpjam-inspector/client/src/components/OrganizationsTab.tsx
+++ b/mcpjam-inspector/client/src/components/OrganizationsTab.tsx
@@ -883,6 +883,18 @@ function OrganizationPage({
 
   const handleCancelSeatPayment = async () => {
     try {
+      // For a terminal charge the button says "Remove invite", and that is
+      // what it has to do: cancelSeatPayment returns immediately for anything
+      // not still active, so calling it here left the invite and the notice
+      // exactly where they were while claiming success.
+      if (activeSeatPaymentIntent?.needsRetry) {
+        await removeMember({
+          organizationId: organization._id,
+          email: activeSeatPaymentIntent.email,
+        });
+        toast.success(`Invite for ${activeSeatPaymentIntent.email} removed.`);
+        return;
+      }
       await cancelSeatPayment();
       toast.success("Pending seat payment canceled.");
     } catch (error) {

--- a/mcpjam-inspector/client/src/components/OrganizationsTab.tsx
+++ b/mcpjam-inspector/client/src/components/OrganizationsTab.tsx
@@ -226,17 +226,38 @@ function PendingSeatPaymentNotice({
   onFinish: () => void;
   onCancel: () => void;
 }) {
+  const needsRetry = intent.needsRetry === true;
+
   return (
     <Alert
-      className="border-primary/20 bg-primary/[0.04]"
-      data-testid="pending-seat-payment-notice"
+      className={
+        needsRetry
+          ? "border-destructive/30 bg-destructive/[0.04]"
+          : "border-primary/20 bg-primary/[0.04]"
+      }
+      data-testid={
+        needsRetry ? "failed-seat-payment-notice" : "pending-seat-payment-notice"
+      }
     >
-      <CreditCard className="size-4 text-primary" />
-      <AlertTitle>Seat payment required</AlertTitle>
+      <CreditCard
+        className={needsRetry ? "size-4 text-destructive" : "size-4 text-primary"}
+      />
+      <AlertTitle>
+        {needsRetry ? "Seat payment didn't go through" : "Seat payment required"}
+      </AlertTitle>
       <AlertDescription className="space-y-3">
         <p>
-          Finish payment to add {intent.email}. They will not get access or
-          credits until payment succeeds.
+          {needsRetry ? (
+            <>
+              We couldn't charge for {intent.email}'s seat. They won't get
+              access or credits until it's paid.
+            </>
+          ) : (
+            <>
+              Finish payment to add {intent.email}. They will not get access or
+              credits until payment succeeds.
+            </>
+          )}
         </p>
         <div className="flex flex-wrap gap-2">
           <Button
@@ -250,7 +271,7 @@ function PendingSeatPaymentNotice({
             ) : (
               <CreditCard className="mr-2 size-4" />
             )}
-            Finish payment
+            {needsRetry ? "Retry payment" : "Finish payment"}
           </Button>
           <Button
             type="button"
@@ -262,7 +283,7 @@ function PendingSeatPaymentNotice({
             {isCancelingSeatPayment ? (
               <Loader2 className="mr-2 size-4 animate-spin" />
             ) : null}
-            Cancel
+            {needsRetry ? "Remove invite" : "Cancel"}
           </Button>
         </div>
       </AlertDescription>
@@ -599,6 +620,7 @@ function OrganizationPage({
     openIntervalChangePortal,
     cancelScheduledBillingChange,
     finishSeatPayment,
+    retrySeatPayment,
     cancelSeatPayment,
   } = useOrganizationBilling(organization._id, {
     enabled: isAuthenticated,
@@ -831,6 +853,23 @@ function OrganizationPage({
           `${
             email ?? activeSeatPaymentIntent?.email ?? "Member"
           } added to the organization.`
+        );
+      }
+    } catch (error) {
+      toast.error(
+        error instanceof Error
+          ? error.message
+          : "Payment was not completed. The member was not added."
+      );
+    }
+  };
+
+  const handleRetrySeatPayment = async () => {
+    try {
+      const result = await retrySeatPayment();
+      if (result?.status === "paid") {
+        toast.success(
+          `${activeSeatPaymentIntent?.email ?? "Member"} added to the organization.`
         );
       }
     } catch (error) {
@@ -1200,7 +1239,11 @@ function OrganizationPage({
         isFinishingSeatPayment={isFinishingSeatPayment}
         isCompletingSeatPayment={isCompletingSeatPayment}
         isCancelingSeatPayment={isCancelingSeatPayment}
-        onFinish={() => void handleFinishSeatPayment()}
+        onFinish={() =>
+          void (activeSeatPaymentIntent.needsRetry
+            ? handleRetrySeatPayment()
+            : handleFinishSeatPayment())
+        }
         onCancel={() => void handleCancelSeatPayment()}
       />
     ) : null;

--- a/mcpjam-inspector/client/src/components/__tests__/OrganizationsTab.billing.test.tsx
+++ b/mcpjam-inspector/client/src/components/__tests__/OrganizationsTab.billing.test.tsx
@@ -2,6 +2,7 @@ import { useState } from "react";
 import { describe, expect, it, beforeEach, vi } from "vitest";
 import { errorToastMessage } from "@/test/utils";
 import {
+  act,
   fireEvent,
   render,
   screen,
@@ -580,6 +581,107 @@ describe("OrganizationsTab billing", () => {
     render(<OrganizationsTab organizationId="org-1" section="billing" />);
 
     expect(screen.getByRole("button", { name: "Remove invite" })).toBeEnabled();
+  });
+
+  it("Remove invite removes the invite instead of cancelling a dead charge", async () => {
+    // cancelSeatPayment returns immediately for anything not still active, so
+    // routing this path through it left everything untouched but claimed
+    // success.
+    const cancelSeatPayment = vi.fn();
+    mockUseOrganizationBilling.mockReturnValue(
+      createBillingHookState({
+        billingStatus: billingStatusFixture({
+          plan: "team",
+          effectivePlan: "team",
+          source: "subscription",
+          billingInterval: "monthly",
+          subscriptionStatus: "active",
+          hasCustomer: true,
+          stripePriceId: "price_team_monthly",
+        }),
+        activeSeatPaymentIntent: failedSeatPaymentIntentFixture(),
+        cancelSeatPayment,
+      }),
+    );
+
+    render(<OrganizationsTab organizationId="org-1" section="billing" />);
+    fireEvent.click(screen.getByRole("button", { name: "Remove invite" }));
+
+    await waitFor(() =>
+      expect(removeMemberMock).toHaveBeenCalledWith({
+        organizationId: "org-1",
+        email: "stranded@example.com",
+      }),
+    );
+    expect(cancelSeatPayment).not.toHaveBeenCalled();
+  });
+
+  it("ignores repeated Remove invite clicks", async () => {
+    // Without a guard a second removeMember finds no row and reports "Member
+    // not found" on top of the first one's success. This covers the guard as a
+    // whole; it cannot tell the disabled button apart from the ref, since
+    // fireEvent flushes the state update between clicks.
+    let resolveRemoval: () => void = () => {};
+    removeMemberMock.mockImplementation(
+      () =>
+        new Promise<void>((resolve) => {
+          resolveRemoval = () => resolve();
+        }),
+    );
+    mockUseOrganizationBilling.mockReturnValue(
+      createBillingHookState({
+        billingStatus: billingStatusFixture({
+          plan: "team",
+          effectivePlan: "team",
+          source: "subscription",
+          billingInterval: "monthly",
+          subscriptionStatus: "active",
+          hasCustomer: true,
+          stripePriceId: "price_team_monthly",
+        }),
+        activeSeatPaymentIntent: failedSeatPaymentIntentFixture(),
+      }),
+    );
+
+    render(<OrganizationsTab organizationId="org-1" section="billing" />);
+    const button = screen.getByRole("button", { name: "Remove invite" });
+    fireEvent.click(button);
+    fireEvent.click(button);
+    fireEvent.click(button);
+
+    await waitFor(() => expect(removeMemberMock).toHaveBeenCalledTimes(1));
+    await act(async () => {
+      resolveRemoval();
+    });
+  });
+
+  it("surfaces an error when removing the invite fails", async () => {
+    removeMemberMock.mockRejectedValue(new Error("Member not found"));
+    mockUseOrganizationBilling.mockReturnValue(
+      createBillingHookState({
+        billingStatus: billingStatusFixture({
+          plan: "team",
+          effectivePlan: "team",
+          source: "subscription",
+          billingInterval: "monthly",
+          subscriptionStatus: "active",
+          hasCustomer: true,
+          stripePriceId: "price_team_monthly",
+        }),
+        activeSeatPaymentIntent: failedSeatPaymentIntentFixture(),
+      }),
+    );
+
+    render(<OrganizationsTab organizationId="org-1" section="billing" />);
+    fireEvent.click(screen.getByRole("button", { name: "Remove invite" }));
+
+    await waitFor(() => expect(toast.error).toHaveBeenCalled());
+    expect(toast.success).not.toHaveBeenCalled();
+
+    // The guard released, so a corrected retry is still possible.
+    removeMemberMock.mockResolvedValue(undefined);
+    fireEvent.click(screen.getByRole("button", { name: "Remove invite" }));
+    await waitFor(() => expect(removeMemberMock).toHaveBeenCalledTimes(2));
   });
 
   it("billing view hides Manage plan for non-owners and shows owner-only copy", () => {

--- a/mcpjam-inspector/client/src/components/__tests__/OrganizationsTab.billing.test.tsx
+++ b/mcpjam-inspector/client/src/components/__tests__/OrganizationsTab.billing.test.tsx
@@ -429,6 +429,57 @@ describe("OrganizationsTab billing", () => {
     );
   });
 
+  // A charge raised automatically when an invitee signs up fails with nobody
+  // watching. Before this, terminal charges were invisible to the owner and
+  // the invitee stayed stranded — the original bug with a nicer tooltip.
+  it("surfaces a failed seat charge with a working retry", async () => {
+    const retrySeatPayment = vi
+      .fn()
+      .mockResolvedValue({ status: "paid", seatQuantity: 4 });
+    const finishSeatPayment = vi.fn();
+    mockUseOrganizationBilling.mockReturnValue(
+      createBillingHookState({
+        billingStatus: billingStatusFixture({
+          plan: "team",
+          effectivePlan: "team",
+          source: "subscription",
+          billingInterval: "monthly",
+          subscriptionStatus: "active",
+          hasCustomer: true,
+          stripePriceId: "price_team_monthly",
+        }),
+        activeSeatPaymentIntent: {
+          _id: "seat-payment-failed",
+          organizationId: "org-1",
+          userId: "user-new",
+          email: "stranded@example.com",
+          role: "member",
+          source: "pending_invite_signup",
+          status: "failed",
+          needsRetry: true,
+          targetSeatQuantity: null,
+          stripeInvoiceId: null,
+          createdAt: 1,
+          updatedAt: 2,
+        },
+        finishSeatPayment,
+        retrySeatPayment,
+      }),
+    );
+
+    render(<OrganizationsTab organizationId="org-1" section="billing" />);
+
+    expect(screen.getByTestId("failed-seat-payment-notice")).toHaveTextContent(
+      "stranded@example.com",
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "Retry payment" }));
+    await waitFor(() => expect(retrySeatPayment).toHaveBeenCalled());
+    // Retry reopens the charge as a new attempt first; going straight to
+    // finish would be refused, since terminal charges are not revivable there.
+    expect(finishSeatPayment).not.toHaveBeenCalled();
+  });
+
   it("billing view hides Manage plan for non-owners and shows owner-only copy", () => {
     mockUseOrganizationBilling.mockReturnValue(
       createBillingHookState({

--- a/mcpjam-inspector/client/src/components/__tests__/OrganizationsTab.billing.test.tsx
+++ b/mcpjam-inspector/client/src/components/__tests__/OrganizationsTab.billing.test.tsx
@@ -429,6 +429,21 @@ describe("OrganizationsTab billing", () => {
     );
   });
 
+  const failedSeatPaymentIntentFixture = () => ({
+    _id: "seat-payment-failed",
+    organizationId: "org-1",
+    userId: "user-new",
+    email: "stranded@example.com",
+    role: "member" as const,
+    source: "pending_invite_signup",
+    status: "failed" as const,
+    needsRetry: true,
+    targetSeatQuantity: null,
+    stripeInvoiceId: null,
+    createdAt: 1,
+    updatedAt: 2,
+  });
+
   // A charge raised automatically when an invitee signs up fails with nobody
   // watching. Before this, terminal charges were invisible to the owner and
   // the invitee stayed stranded — the original bug with a nicer tooltip.
@@ -478,6 +493,93 @@ describe("OrganizationsTab billing", () => {
     // Retry reopens the charge as a new attempt first; going straight to
     // finish would be refused, since terminal charges are not revivable there.
     expect(finishSeatPayment).not.toHaveBeenCalled();
+  });
+
+  it("shows an error and no success toast when a retry is rejected", async () => {
+    const retrySeatPayment = vi
+      .fn()
+      .mockRejectedValue(new Error("Payment failed. The member was not added."));
+    mockUseOrganizationBilling.mockReturnValue(
+      createBillingHookState({
+        billingStatus: billingStatusFixture({
+          plan: "team",
+          effectivePlan: "team",
+          source: "subscription",
+          billingInterval: "monthly",
+          subscriptionStatus: "active",
+          hasCustomer: true,
+          stripePriceId: "price_team_monthly",
+        }),
+        activeSeatPaymentIntent: failedSeatPaymentIntentFixture(),
+        retrySeatPayment,
+      }),
+    );
+
+    render(<OrganizationsTab organizationId="org-1" section="billing" />);
+    fireEvent.click(screen.getByRole("button", { name: "Retry payment" }));
+
+    await waitFor(() =>
+      expect(toast.error).toHaveBeenCalledWith(
+        errorToastMessage("Payment failed. The member was not added."),
+        { duration: 8000 },
+      ),
+    );
+    expect(toast.success).not.toHaveBeenCalled();
+  });
+
+  it("shows an error when the charge can no longer be retried", async () => {
+    // retrySeatPayment resolves undefined when the cancel-version guard trips
+    // or the backend has nothing retryable left. Silence here would leave the
+    // owner thinking it worked.
+    const retrySeatPayment = vi.fn().mockResolvedValue(undefined);
+    mockUseOrganizationBilling.mockReturnValue(
+      createBillingHookState({
+        billingStatus: billingStatusFixture({
+          plan: "team",
+          effectivePlan: "team",
+          source: "subscription",
+          billingInterval: "monthly",
+          subscriptionStatus: "active",
+          hasCustomer: true,
+          stripePriceId: "price_team_monthly",
+        }),
+        activeSeatPaymentIntent: failedSeatPaymentIntentFixture(),
+        retrySeatPayment,
+      }),
+    );
+
+    render(<OrganizationsTab organizationId="org-1" section="billing" />);
+    fireEvent.click(screen.getByRole("button", { name: "Retry payment" }));
+
+    await waitFor(() => expect(retrySeatPayment).toHaveBeenCalled());
+    expect(toast.success).not.toHaveBeenCalled();
+  });
+
+  it("keeps Remove invite available while a retry is in flight", () => {
+    // Cancelling mid-retry stays possible on purpose — the owner may be stuck
+    // in a 3DS modal that never resolves and needs a way out. Safety comes
+    // from retrySeatPayment's cancel-version guard, which refuses to reopen
+    // payment on a charge that was cancelled underneath it, not from taking
+    // the escape hatch away.
+    mockUseOrganizationBilling.mockReturnValue(
+      createBillingHookState({
+        billingStatus: billingStatusFixture({
+          plan: "team",
+          effectivePlan: "team",
+          source: "subscription",
+          billingInterval: "monthly",
+          subscriptionStatus: "active",
+          hasCustomer: true,
+          stripePriceId: "price_team_monthly",
+        }),
+        activeSeatPaymentIntent: failedSeatPaymentIntentFixture(),
+        isFinishingSeatPayment: true,
+      }),
+    );
+
+    render(<OrganizationsTab organizationId="org-1" section="billing" />);
+
+    expect(screen.getByRole("button", { name: "Remove invite" })).toBeEnabled();
   });
 
   it("billing view hides Manage plan for non-owners and shows owner-only copy", () => {

--- a/mcpjam-inspector/client/src/components/notifications/NotificationsPanel.tsx
+++ b/mcpjam-inspector/client/src/components/notifications/NotificationsPanel.tsx
@@ -1,4 +1,10 @@
-import { ActivitySquare, Building2, FolderKanban, Inbox } from "lucide-react";
+import {
+  ActivitySquare,
+  Building2,
+  CreditCard,
+  FolderKanban,
+  Inbox,
+} from "lucide-react";
 import { useConvexAuth } from "convex/react";
 import { Button } from "@mcpjam/design-system/button";
 import { PopoverContent } from "@mcpjam/design-system/popover";
@@ -27,6 +33,9 @@ function formatTimeAgo(timestamp: number): string {
 }
 
 function getNotificationIcon(type: NotificationType) {
+  if (type === "organization_seat_payment_required") {
+    return <CreditCard className="h-4 w-4" />;
+  }
   if (type.startsWith("project")) {
     return <FolderKanban className="h-4 w-4" />;
   }
@@ -49,6 +58,12 @@ function getNotificationMessage(notification: Notification): string {
       return `${actor} added you to organization "${entityName}"`;
     case "organization_removed":
       return `${actor} removed you from organization "${entityName}"`;
+    case "workspace_added":
+      return `${actor} added you to workspace "${entityName}"`;
+    case "workspace_removed":
+      return `${actor} removed you from workspace "${entityName}"`;
+    case "organization_seat_payment_required":
+      return `${actor} signed up and needs a paid seat in "${entityName}"`;
     case "scheduled_eval_failed":
       return `Scheduled run failed for suite "${entityName}"`;
     case "scheduled_eval_paused":
@@ -82,9 +97,11 @@ function NotificationItem({
       <div
         className={cn(
           "flex items-center justify-center h-8 w-8 rounded-full shrink-0",
-          notification.type.includes("added")
-            ? "bg-success/10 text-success"
-            : "bg-destructive/10 text-destructive"
+          notification.type === "organization_seat_payment_required"
+            ? "bg-primary/10 text-primary"
+            : notification.type.includes("added")
+              ? "bg-success/10 text-success"
+              : "bg-destructive/10 text-destructive"
         )}
       >
         {getNotificationIcon(notification.type)}

--- a/mcpjam-inspector/client/src/components/notifications/__tests__/NotificationsPanel.test.tsx
+++ b/mcpjam-inspector/client/src/components/notifications/__tests__/NotificationsPanel.test.tsx
@@ -120,7 +120,9 @@ describe("NotificationsPanelContent", () => {
   it("still styles ordinary grants and removals distinctly", () => {
     const { container } = renderWith([
       notification({ _id: "n-org-added", type: "organization_added" }),
+      notification({ _id: "n-org-removed", type: "organization_removed" }),
     ]);
     expect(container.querySelector(".bg-success\\/10")).not.toBeNull();
+    expect(container.querySelector(".bg-destructive\\/10")).not.toBeNull();
   });
 });

--- a/mcpjam-inspector/client/src/components/notifications/__tests__/NotificationsPanel.test.tsx
+++ b/mcpjam-inspector/client/src/components/notifications/__tests__/NotificationsPanel.test.tsx
@@ -1,0 +1,126 @@
+import { render, screen } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { ReactNode } from "react";
+import type { Notification } from "@/hooks/useNotifications";
+
+const mockUseConvexAuth = vi.fn();
+const mockUseNotifications = vi.fn();
+const mockUseNotificationMutations = vi.fn();
+
+vi.mock("convex/react", () => ({
+  useConvexAuth: (...args: unknown[]) => mockUseConvexAuth(...args),
+}));
+
+vi.mock("@/hooks/useNotifications", async (importOriginal) => ({
+  ...(await importOriginal<Record<string, unknown>>()),
+  useNotifications: (...args: unknown[]) => mockUseNotifications(...args),
+  useNotificationMutations: (...args: unknown[]) =>
+    mockUseNotificationMutations(...args),
+}));
+
+vi.mock("@mcpjam/design-system/popover", () => ({
+  PopoverContent: ({ children }: { children: ReactNode }) => (
+    <div>{children}</div>
+  ),
+}));
+
+vi.mock("@mcpjam/design-system/scroll-area", () => ({
+  ScrollArea: ({ children }: { children: ReactNode }) => <div>{children}</div>,
+}));
+
+vi.mock("@mcpjam/design-system/button", () => ({
+  Button: ({ children, ...props }: { children: ReactNode }) => (
+    <button type="button" {...props}>
+      {children}
+    </button>
+  ),
+}));
+
+import { NotificationsPanelContent } from "../NotificationsPanel";
+
+function notification(overrides: Partial<Notification>): Notification {
+  return {
+    _id: "n1",
+    userId: "user_1",
+    type: "organization_added",
+    entityId: "org_1",
+    entityName: "Acme",
+    actorName: "Ada",
+    isRead: false,
+    createdAt: Date.now(),
+    ...overrides,
+  } as Notification;
+}
+
+function renderWith(notifications: Notification[]) {
+  mockUseNotifications.mockReturnValue({ notifications, isLoading: false });
+  return render(<NotificationsPanelContent />);
+}
+
+describe("NotificationsPanelContent", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockUseConvexAuth.mockReturnValue({
+      isAuthenticated: true,
+      isLoading: false,
+    });
+    mockUseNotificationMutations.mockReturnValue({
+      markAsRead: vi.fn(),
+      markAllAsRead: vi.fn(),
+      clearAllNotifications: vi.fn(),
+    });
+  });
+
+  it("renders workspace membership messages", () => {
+    renderWith([
+      notification({
+        _id: "n-added",
+        type: "workspace_added",
+        entityName: "Platform",
+      }),
+      notification({
+        _id: "n-removed",
+        type: "workspace_removed",
+        entityName: "Platform",
+      }),
+    ]);
+
+    expect(
+      screen.getByText('Ada added you to workspace "Platform"')
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText('Ada removed you from workspace "Platform"')
+    ).toBeInTheDocument();
+  });
+
+  it("renders the seat-payment request with its own icon and neutral styling", () => {
+    // Owner-targeted, and neither a grant nor a removal — the panel used to
+    // colour purely on whether the type contained "added", which would have
+    // styled this as a destructive event.
+    const { container } = renderWith([
+      notification({
+        _id: "n-seat",
+        type: "organization_seat_payment_required",
+        entityName: "Acme",
+        actorName: "Joey",
+      }),
+    ]);
+
+    expect(
+      screen.getByText('Joey signed up and needs a paid seat in "Acme"')
+    ).toBeInTheDocument();
+
+    const icon = container.querySelector(".bg-primary\\/10");
+    expect(icon).not.toBeNull();
+    expect(icon?.className).toContain("text-primary");
+    expect(container.querySelector(".bg-destructive\\/10")).toBeNull();
+    expect(container.querySelector(".bg-success\\/10")).toBeNull();
+  });
+
+  it("still styles ordinary grants and removals distinctly", () => {
+    const { container } = renderWith([
+      notification({ _id: "n-org-added", type: "organization_added" }),
+    ]);
+    expect(container.querySelector(".bg-success\\/10")).not.toBeNull();
+  });
+});

--- a/mcpjam-inspector/client/src/components/sidebar/__tests__/sidebar-context-switcher.test.tsx
+++ b/mcpjam-inspector/client/src/components/sidebar/__tests__/sidebar-context-switcher.test.tsx
@@ -368,6 +368,65 @@ describe("SidebarContextSwitcher", () => {
     expect(screen.queryByTestId("org-switch-list")).not.toBeInTheDocument();
   });
 
+  // A `seatPending` org is a paid-seat invite whose membership hasn't linked
+  // yet. Every org-scoped query for it is denied server-side, so opening it
+  // crashed the route (Sentry INSPECTOR-CLIENT-24C). It stays visible so the
+  // user knows they were invited, but it must not be openable.
+  it("shows a seat-pending org as disabled with a 'Seat not paid yet' tooltip", () => {
+    mockUseOrganizationQueries.mockReturnValue({
+      sortedOrganizations: [orgs[0], { ...orgs[1], seatPending: true }],
+      isLoading: false,
+      createdCount: 0,
+      canCreateOrganization: true,
+    });
+    render(
+      <SidebarContextSwitcher
+        activeProjectId="p1"
+        activeOrganizationId="org_a"
+        projects={projects}
+        onSwitchProject={vi.fn()}
+        onCreateProject={vi.fn(async () => "")}
+        onDeleteProject={vi.fn()}
+        onSwitchActiveOrganization={vi.fn()}
+      />
+    );
+    openMainDropdown();
+    openOrgSwitchList();
+
+    const row = screen.getByTestId("org-row-org_b");
+    expect(row).toBeInTheDocument();
+    expect(row).toHaveAttribute("aria-disabled", "true");
+    expect(screen.getByText("Seat not paid yet")).toBeInTheDocument();
+  });
+
+  it("clicking a seat-pending org does not switch to it", () => {
+    const onSwitchActiveOrganization = vi.fn();
+    mockUseOrganizationQueries.mockReturnValue({
+      sortedOrganizations: [orgs[0], { ...orgs[1], seatPending: true }],
+      isLoading: false,
+      createdCount: 0,
+      canCreateOrganization: true,
+    });
+    render(
+      <SidebarContextSwitcher
+        activeProjectId="p1"
+        activeOrganizationId="org_a"
+        projects={projects}
+        onSwitchProject={vi.fn()}
+        onCreateProject={vi.fn(async () => "")}
+        onDeleteProject={vi.fn()}
+        onSwitchActiveOrganization={onSwitchActiveOrganization}
+      />
+    );
+    openMainDropdown();
+    openOrgSwitchList();
+
+    fireEvent.click(screen.getByTestId("org-row-org_b"));
+    expect(onSwitchActiveOrganization).not.toHaveBeenCalled();
+    // The menu stays open — nothing happened.
+    expect(screen.getByTestId("org-switch-list")).toBeInTheDocument();
+  });
+
   it("clicking the already-active org in the switch list does not call onSwitchActiveOrganization", () => {
     const onSwitchActiveOrganization = vi.fn();
     render(

--- a/mcpjam-inspector/client/src/components/sidebar/__tests__/sidebar-context-switcher.test.tsx
+++ b/mcpjam-inspector/client/src/components/sidebar/__tests__/sidebar-context-switcher.test.tsx
@@ -421,7 +421,15 @@ describe("SidebarContextSwitcher", () => {
     openMainDropdown();
     openOrgSwitchList();
 
-    fireEvent.click(screen.getByTestId("org-row-org_b"));
+    const row = screen.getByTestId("org-row-org_b");
+    // Removed from the tab order too — reachable by keyboard would imply
+    // activatable, and it is not.
+    expect(row).toHaveAttribute("tabindex", "-1");
+
+    fireEvent.click(row);
+    fireEvent.keyDown(row, { key: "Enter" });
+    fireEvent.keyDown(row, { key: " " });
+
     expect(onSwitchActiveOrganization).not.toHaveBeenCalled();
     // The menu stays open — nothing happened.
     expect(screen.getByTestId("org-switch-list")).toBeInTheDocument();

--- a/mcpjam-inspector/client/src/components/sidebar/sidebar-context-switcher.tsx
+++ b/mcpjam-inspector/client/src/components/sidebar/sidebar-context-switcher.tsx
@@ -463,13 +463,19 @@ export function SidebarContextSwitcher({
                       <div data-testid="org-switch-list" className="mt-0.5">
                         {sortedOrganizations.map((org) => {
                           const tint = getOrgTint(org._id);
-                          return (
+                          // Paid-seat invite that hasn't linked yet: the
+                          // backend denies every query for this org, so the
+                          // row is shown but not openable.
+                          const isSeatPending = org.seatPending === true;
+                          const row = (
                             <div
                               key={org._id}
                               role="menuitem"
-                              tabIndex={0}
+                              tabIndex={isSeatPending ? -1 : 0}
+                              aria-disabled={isSeatPending || undefined}
                               data-testid={`org-row-${org._id}`}
                               onClick={() => {
+                                if (isSeatPending) return;
                                 if (org._id !== activeOrganizationId) {
                                   onSwitchActiveOrganization?.(org._id);
                                 }
@@ -478,6 +484,7 @@ export function SidebarContextSwitcher({
                               onKeyDown={(e) => {
                                 if (e.key === "Enter" || e.key === " ") {
                                   e.preventDefault();
+                                  if (isSeatPending) return;
                                   if (org._id !== activeOrganizationId) {
                                     onSwitchActiveOrganization?.(org._id);
                                   }
@@ -485,10 +492,13 @@ export function SidebarContextSwitcher({
                                 }
                               }}
                               className={cn(
-                                "group/org flex items-center gap-2.5 rounded-md px-2 py-1.5 text-[13px] cursor-pointer",
+                                "group/org flex items-center gap-2.5 rounded-md px-2 py-1.5 text-[13px]",
+                                isSeatPending
+                                  ? "cursor-not-allowed opacity-50"
+                                  : "cursor-pointer",
                                 org._id === activeOrganizationId
                                   ? "bg-accent"
-                                  : "hover:bg-accent/60"
+                                  : !isSeatPending && "hover:bg-accent/60"
                               )}
                             >
                               <div
@@ -503,7 +513,7 @@ export function SidebarContextSwitcher({
                               <span className="flex-1 truncate font-medium">
                                 {org.name}
                               </span>
-                              {onSwitchOrganization ? (
+                              {onSwitchOrganization && !isSeatPending ? (
                                 <button
                                   type="button"
                                   aria-label={`Open ${org.name} settings`}
@@ -519,6 +529,16 @@ export function SidebarContextSwitcher({
                                 </button>
                               ) : null}
                             </div>
+                          );
+
+                          if (!isSeatPending) return row;
+                          return (
+                            <Tooltip key={org._id}>
+                              <TooltipTrigger asChild>{row}</TooltipTrigger>
+                              <TooltipContent side="right">
+                                Seat not paid yet
+                              </TooltipContent>
+                            </Tooltip>
                           );
                         })}
                         {newOrganizationRow}

--- a/mcpjam-inspector/client/src/hooks/__tests__/useOrganizationBilling.seat-retry.test.tsx
+++ b/mcpjam-inspector/client/src/hooks/__tests__/useOrganizationBilling.seat-retry.test.tsx
@@ -82,7 +82,12 @@ describe("useOrganizationBilling seat payment retry", () => {
       retryPromise = result.current.retrySeatPayment();
     });
 
-    // Owner hits "Remove invite" while the charge is being reopened.
+    // Owner hits Cancel while the charge is being reopened. Note this is the
+    // cancelSeatPayment path, which the button uses once a retry has made the
+    // charge active again. The separate "Remove invite" action on a terminal
+    // charge calls removeMember instead, and is fenced server-side by
+    // removeMember terminalizing the intent in its own transaction — a client
+    // ref could not cover that anyway, since the owner may have two tabs open.
     await act(async () => {
       await result.current.cancelSeatPayment();
     });

--- a/mcpjam-inspector/client/src/hooks/__tests__/useOrganizationBilling.seat-retry.test.tsx
+++ b/mcpjam-inspector/client/src/hooks/__tests__/useOrganizationBilling.seat-retry.test.tsx
@@ -1,0 +1,136 @@
+import { act, renderHook, waitFor } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+// Exercises the retry/cancel race at the hook boundary rather than through a
+// mocked component, so the real cancel-version bookkeeping runs.
+
+const convexFns = vi.hoisted(() => ({
+  retrySeatPayment: vi.fn(),
+  startSeatPayment: vi.fn(),
+  cancelSeatPayment: vi.fn(),
+  completeSeatPayment: vi.fn(),
+}));
+
+const activeSeatPaymentIntent = {
+  _id: "seat-payment-1",
+  organizationId: "org-1",
+  userId: "user-new",
+  email: "stranded@example.com",
+  role: "member" as const,
+  source: "pending_invite_signup",
+  status: "failed" as const,
+  needsRetry: true,
+  targetSeatQuantity: null,
+  stripeInvoiceId: null,
+  createdAt: 1,
+  updatedAt: 2,
+};
+
+vi.mock("convex/react", () => ({
+  useQuery: (name: string) =>
+    name === "billing:getActiveOrganizationSeatPaymentIntent"
+      ? activeSeatPaymentIntent
+      : undefined,
+  useMutation: (name: string) =>
+    name === "billing:retrySeatPayment"
+      ? convexFns.retrySeatPayment
+      : vi.fn(),
+  useAction: (name: string) => {
+    if (name === "billing:startSeatPayment") return convexFns.startSeatPayment;
+    if (name === "billing:cancelSeatPayment")
+      return convexFns.cancelSeatPayment;
+    if (name === "billing:completeSeatPayment")
+      return convexFns.completeSeatPayment;
+    return vi.fn();
+  },
+}));
+
+vi.mock("@/lib/stripe-elements", () => ({
+  confirmSeatPaymentWithStripe: vi.fn(),
+}));
+
+import { useOrganizationBilling } from "../useOrganizationBilling";
+
+describe("useOrganizationBilling seat payment retry", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    convexFns.cancelSeatPayment.mockResolvedValue(undefined);
+    convexFns.startSeatPayment.mockResolvedValue({
+      status: "paid",
+      seatQuantity: 4,
+    });
+  });
+
+  it("does not start payment when the charge is cancelled mid-retry", async () => {
+    // Reopening the charge and starting payment are two round trips. Cancel
+    // lands in between; finishSeatPayment's own guard reads the cancel version
+    // at its own start, which is already too late to notice.
+    let resolveRetry: (value: unknown) => void = () => {};
+    convexFns.retrySeatPayment.mockImplementation(
+      () =>
+        new Promise((resolve) => {
+          resolveRetry = resolve;
+        })
+    );
+
+    const { result } = renderHook(() =>
+      useOrganizationBilling({ organizationId: "org-1" })
+    );
+
+    let retryPromise: Promise<unknown> | undefined;
+    act(() => {
+      retryPromise = result.current.retrySeatPayment();
+    });
+
+    // Owner hits "Remove invite" while the charge is being reopened.
+    await act(async () => {
+      await result.current.cancelSeatPayment();
+    });
+
+    await act(async () => {
+      resolveRetry({ restarted: true, seatPaymentIntentId: "seat-payment-1" });
+      await retryPromise;
+    });
+
+    expect(convexFns.cancelSeatPayment).toHaveBeenCalledTimes(1);
+    // The whole point: payment must not be reopened on a cancelled charge.
+    expect(convexFns.startSeatPayment).not.toHaveBeenCalled();
+  });
+
+  it("starts payment normally when nothing cancels it", async () => {
+    convexFns.retrySeatPayment.mockResolvedValue({
+      restarted: true,
+      seatPaymentIntentId: "seat-payment-1",
+    });
+
+    const { result } = renderHook(() =>
+      useOrganizationBilling({ organizationId: "org-1" })
+    );
+
+    await act(async () => {
+      await result.current.retrySeatPayment();
+    });
+
+    await waitFor(() =>
+      expect(convexFns.startSeatPayment).toHaveBeenCalledTimes(1)
+    );
+  });
+
+  it("surfaces an error when there is nothing left to retry", async () => {
+    convexFns.retrySeatPayment.mockResolvedValue({
+      restarted: false,
+      seatPaymentIntentId: null,
+    });
+
+    const { result } = renderHook(() =>
+      useOrganizationBilling({ organizationId: "org-1" })
+    );
+
+    await act(async () => {
+      await expect(result.current.retrySeatPayment()).rejects.toThrow(
+        "can no longer be retried"
+      );
+    });
+    expect(convexFns.startSeatPayment).not.toHaveBeenCalled();
+  });
+});

--- a/mcpjam-inspector/client/src/hooks/useNotifications.ts
+++ b/mcpjam-inspector/client/src/hooks/useNotifications.ts
@@ -3,8 +3,14 @@ import { useQuery, useMutation } from "convex/react";
 export type NotificationType =
   | "project_added"
   | "project_removed"
+  | "workspace_added"
+  | "workspace_removed"
   | "organization_added"
   | "organization_removed"
+  // Owner-targeted, unlike the rest: someone they invited has signed up and
+  // the automatic seat charge needs them. Here the actor is the SUBJECT — the
+  // person waiting on the seat — not whoever performed an action.
+  | "organization_seat_payment_required"
   | "scheduled_eval_failed"
   | "scheduled_eval_paused";
 

--- a/mcpjam-inspector/client/src/hooks/useOrganizationBilling.ts
+++ b/mcpjam-inspector/client/src/hooks/useOrganizationBilling.ts
@@ -126,7 +126,14 @@ export interface OrganizationSeatPaymentIntent {
   email: string;
   role: "guest" | "member";
   source: string;
-  status: "pending" | "requires_action";
+  status: "pending" | "requires_action" | "failed" | "canceled";
+  /**
+   * The charge ended terminally and the invitee is still waiting. Only ever
+   * true for charges raised automatically at signup — when an owner starts one
+   * themselves they see the failure inline and just try again. Unattended,
+   * nothing would surface it, so the notice renders a retry variant instead.
+   */
+  needsRetry?: boolean;
   targetSeatQuantity: number | null;
   stripeInvoiceId: string | null;
   createdAt: number;
@@ -292,6 +299,9 @@ export function useOrganizationBilling(
     "billing:completeSeatPayment" as any
   );
   const cancelSeatPaymentAction = useAction("billing:cancelSeatPayment" as any);
+  const retrySeatPaymentMutation = useMutation(
+    "billing:retrySeatPayment" as any,
+  );
 
   const [isStartingPlanChange, setIsStartingPlanChange] = useState(false);
   const [pendingPlanChangeTarget, setPendingPlanChangeTarget] = useState<
@@ -555,6 +565,42 @@ export function useOrganizationBilling(
     ]
   );
 
+  /**
+   * Retry a seat charge that died with nobody watching.
+   *
+   * Two steps on purpose. `startSeatPayment` refuses terminal charges — it is
+   * also reached by a stale browser tab, and that must never resurrect a
+   * charge the owner cancelled — so retrying first reopens the charge as a new
+   * attempt, then runs the ordinary finish flow. Going through that flow is
+   * also what makes a 3DS challenge possible, since it needs the owner here.
+   */
+  const retrySeatPayment = useCallback(async () => {
+    if (!organizationId) return;
+    setError(null);
+    setIsFinishingSeatPayment(true);
+    try {
+      const result = (await retrySeatPaymentMutation({
+        organizationId,
+      } as any)) as {
+        restarted: boolean;
+        seatPaymentIntentId: string | null;
+      };
+      if (!result?.restarted || !result.seatPaymentIntentId) {
+        throw new Error(
+          "This seat payment can no longer be retried. Try adding the member again.",
+        );
+      }
+      return await finishSeatPayment(result.seatPaymentIntentId);
+    } catch (err) {
+      const message =
+        err instanceof Error ? err.message : "Failed to retry seat payment";
+      setError(message);
+      throw err;
+    } finally {
+      setIsFinishingSeatPayment(false);
+    }
+  }, [finishSeatPayment, organizationId, retrySeatPaymentMutation]);
+
   const cancelSeatPayment = useCallback(
     async (seatPaymentIntentId?: string): Promise<void> => {
       if (!organizationId) throw new Error("Organization is required");
@@ -632,6 +678,7 @@ export function useOrganizationBilling(
     cancelScheduledBillingChange,
     selectFreeAfterTrial,
     finishSeatPayment,
+    retrySeatPayment,
     cancelSeatPayment,
   };
 }

--- a/mcpjam-inspector/client/src/hooks/useOrganizationBilling.ts
+++ b/mcpjam-inspector/client/src/hooks/useOrganizationBilling.ts
@@ -578,6 +578,12 @@ export function useOrganizationBilling(
     if (!organizationId) return;
     setError(null);
     setIsFinishingSeatPayment(true);
+    // Captured BEFORE the mutation, not inside finishSeatPayment: reopening
+    // the charge and starting payment are two round trips, and the owner can
+    // hit "Remove invite" in between. finishSeatPayment's own guard reads the
+    // version at its own start, which is already after such a cancel, so it
+    // would happily reopen a charge the owner just cancelled.
+    const cancelVersionAtStart = seatPaymentCancelVersionRef.current;
     try {
       const result = (await retrySeatPaymentMutation({
         organizationId,
@@ -589,6 +595,10 @@ export function useOrganizationBilling(
         throw new Error(
           "This seat payment can no longer be retried. Try adding the member again.",
         );
+      }
+      if (seatPaymentCancelVersionRef.current !== cancelVersionAtStart) {
+        // Cancelled while we were reopening it. Leave it cancelled.
+        return;
       }
       return await finishSeatPayment(result.seatPaymentIntentId);
     } catch (err) {

--- a/mcpjam-inspector/client/src/hooks/useOrganizations.ts
+++ b/mcpjam-inspector/client/src/hooks/useOrganizations.ts
@@ -15,6 +15,13 @@ export interface Organization {
   updatedAt: number;
   myRole?: string;
   isCreator?: boolean;
+  /**
+   * The user was invited by email to a paid-seat org, but the membership stays
+   * unlinked until that seat is paid — so every org-scoped query for it is
+   * denied server-side. Surface it as unavailable; never make it the active
+   * org (opening one crashed the route: Sentry INSPECTOR-CLIENT-24C).
+   */
+  seatPending?: boolean;
 }
 
 export const ORGANIZATION_CREATION_LIMIT = 1;


### PR DESCRIPTION
- If you were invited to a paid team org whose seat isn't paid for yet, that org showed up normally in your switcher — and clicking it crashed the entire page. It now shows greyed out with a "Seat not paid yet" tooltip and can't be clicked into.
- It also can't become your active org by any other route, so nothing else can land you in it accidentally.
- Adds the owner side of the fix: if a seat charge fails or gets cancelled, the org page now shows it with a Retry button. Before, a failure disappeared as soon as you left the page.
- Pairs with MCPJam/mcpjam-backend#1076 — the backend half is what actually raises the charge. This PR alone stops the crash but doesn't make anyone payable.

Fixes INSPECTOR-CLIENT-24C

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Surface paid-seat invites that can’t be opened and make failed/canceled seat charges recoverable, preventing org‑scoped route crashes (INSPECTOR-CLIENT-24C). Before, seat‑pending orgs appeared selectable and could become active via route, checkout deep‑link, or deletion fallback; now they render disabled with a “Seat not paid yet” tooltip and never become active.

- Org selection: introduce selectableOrganizations and use it for route guard, checkout deep‑link billing org lookup, home‑org resolution, and deleted‑org fallback. In the sidebar, seatPending rows are disabled, removed from tab order, ignore click/Enter/Space, and show the tooltip.
- Billing: add retrySeatPayment to reopen terminal seat charges, then run the normal finish flow; capture the cancel version before reopening to guard the retry/cancel race. Keep Cancel enabled during retry. On terminal charges, “Remove invite” now removes the invite, guards repeated clicks, and surfaces failures.
- Notifications: add organization_seat_payment_required with a credit‑card icon and neutral styling; add workspace_added/workspace_removed. Tests cover messages, styling, retry success/rejection/nothing to retry, the hook‑level retry/cancel race, and invite removal.
- Types/hooks/tests: add Organization.seatPending; extend OrganizationSeatPaymentIntent.status with failed/canceled and needsRetry; expose retrySeatPayment from useOrganizationBilling. Add tests for seat‑pending UI and the hook‑level retry/cancel guard.

Pairs with MCPJam/mcpjam-backend#1076 to raise charges. This client change alone prevents the crash but does not make seats payable.

<sup>Written for commit 99513063ec2fca95dce64072473fa0800c5eefc4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/MCPJam/inspector/pull/4219?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

