### PR TITLE
Apps conformance failed servers for two rules the spec does not state

### DIFF
--- a/.changeset/apps-conformance-overstrict.md
+++ b/.changeset/apps-conformance-overstrict.md
@@ -1,0 +1,29 @@
+---
+"@mcpjam/sdk": patch
+"@mcpjam/inspector": patch
+---
+
+Stop failing MCP Apps servers for two things the spec does not require.
+
+`ui-listed-resources-valid` failed any `resources/list` entry whose `mimeType`
+was not `text/html;profile=mcp-app`. In `apps.mdx` that value is a **SHOULD** on
+the listing (`UIResource.mimeType`: "SHOULD be `text/html;profile=mcp-app` for
+HTML-based UIs in the initial MVP"). It is a **MUST** on the read result, under
+Content Requirements — and `ui-resource-contents-valid` already enforces it
+there. So the listing rule now warns instead of failing, and says why. The
+`ui://` scheme on the same entry is a genuine MUST and still fails.
+
+`ui-resource-contents-valid` required `resources/read` to return exactly one
+content entry. No such rule exists: the Content Requirements are stated per
+content item and never cap the array, and the single-element `contents: [{…}]`
+in the spec is an example. A server returning two valid HTML payloads was
+reported as defective. The check now requires at least one entry — an empty
+array is still a violation, since there is nothing to render — and grades every
+entry that comes back against all four Content Requirements.
+
+The second change is the riskier one, because "not exactly one" was also what
+stopped the loop: a regression test now proves a bad second entry is still
+caught rather than silently skipped once multiple entries are allowed.
+
+Neither check gained or lost an id, so the pool is still seven and scores move
+only for servers that were being failed for these two reasons.

--- a/sdk/src/apps-conformance/runner.ts
+++ b/sdk/src/apps-conformance/runner.ts
@@ -57,7 +57,7 @@ export const APPS_CHECK_METADATA: Record<
     category: "resources",
     title: "Listed UI Resources Valid",
     description:
-      "UI resources returned by resources/list use ui:// URIs and the MCP Apps HTML MIME type.",
+      "UI resources returned by resources/list use ui:// URIs; declaring the MCP Apps HTML MIME type there is a SHOULD, so a different value warns rather than fails.",
   },
   "ui-resources-readable": {
     id: "ui-resources-readable",
@@ -71,7 +71,7 @@ export const APPS_CHECK_METADATA: Record<
     category: "resources",
     title: "UI Resource Contents Valid",
     description:
-      "UI resource contents use the MCP Apps HTML MIME type and provide exactly one HTML payload via text or blob.",
+      "resources/read returns at least one content entry, and every entry uses the MCP Apps HTML MIME type and carries an HTML document via text or blob.",
   },
   "ui-resource-meta-valid": {
     id: "ui-resource-meta-valid",
@@ -764,7 +764,15 @@ export class MCPAppsConformanceTest {
                 ),
               );
             } else {
+              // The two rules on a LISTING entry carry different force. The
+              // `ui://` scheme is a MUST ("MUST use the `ui://` URI scheme",
+              // apps.mdx UIResource.uri), so it fails. The mimeType VALUE is
+              // only a SHOULD there ("SHOULD be `text/html;profile=mcp-app`
+              // ... in the initial MVP", apps.mdx UIResource.mimeType), so it
+              // warns. The same value IS a MUST on the read result, and
+              // `ui-resource-contents-valid` enforces it there.
               const violations: string[] = [];
+              const warnings: string[] = [];
 
               for (const resource of listedUiResources) {
                 if (!resource.uri.startsWith("ui://")) {
@@ -773,11 +781,18 @@ export class MCPAppsConformanceTest {
                   );
                 }
                 if (resource.mimeType !== MCP_UI_RESOURCE_MIME_TYPE) {
-                  violations.push(
-                    `Listed UI resource ${resource.uri} uses mimeType "${resource.mimeType ?? "<missing>"}" instead of "${MCP_UI_RESOURCE_MIME_TYPE}"`,
+                  warnings.push(
+                    `Listed UI resource ${resource.uri} declares mimeType "${resource.mimeType ?? "<missing>"}" rather than "${MCP_UI_RESOURCE_MIME_TYPE}"; the listing value is a SHOULD, so this does not fail — but resources/read MUST return the MCP Apps type`,
                   );
                 }
               }
+
+              const listingDetails = {
+                listedUiResourceCount: listedUiResources.length,
+                listedUiResourceUris: listedUiResources.map(
+                  (resource) => resource.uri,
+                ),
+              };
 
               if (violations.length > 0) {
                 checks.push(
@@ -785,12 +800,9 @@ export class MCPAppsConformanceTest {
                     "ui-listed-resources-valid",
                     Date.now() - stepStartedAt,
                     `${violations.length} listed UI resource violation(s) found`,
-                    {
-                      violations,
-                      listedUiResourceUris: listedUiResources.map(
-                        (resource) => resource.uri,
-                      ),
-                    },
+                    { violations, ...listingDetails },
+                    undefined,
+                    warnings,
                   ),
                 );
               } else {
@@ -798,12 +810,8 @@ export class MCPAppsConformanceTest {
                   passedResult(
                     "ui-listed-resources-valid",
                     Date.now() - stepStartedAt,
-                    {
-                      listedUiResourceCount: listedUiResources.length,
-                      listedUiResourceUris: listedUiResources.map(
-                        (resource) => resource.uri,
-                      ),
-                    },
+                    listingDetails,
+                    warnings,
                   ),
                 );
               }
@@ -873,9 +881,14 @@ export class MCPAppsConformanceTest {
                   ? outcome.result.contents
                   : [];
 
-                if (contents.length !== 1) {
+                // The spec's Content Requirements are stated per content item
+                // and never cap the array: the single-element `contents: [{…}]`
+                // in apps.mdx is an example, not a bound. So an empty array is
+                // the violation — there is no content to render — and every
+                // entry that IS returned has to satisfy the four MUSTs below.
+                if (contents.length === 0) {
                   violations.push(
-                    `${outcome.uri} must return exactly one content entry from resources/read (got ${contents.length})`,
+                    `${outcome.uri} returned no content entries from resources/read`,
                   );
                   continue;
                 }

--- a/sdk/src/conformance-catalog.ts
+++ b/sdk/src/conformance-catalog.ts
@@ -217,7 +217,7 @@ export const APPS_CHECK_CATALOG = {
   "ui-listed-resources-valid": {
     title: "Listed UI Resources Valid",
     description:
-      "UI resources returned by resources/list use ui:// URIs and the MCP Apps HTML MIME type.",
+      "UI resources returned by resources/list use ui:// URIs; declaring the MCP Apps HTML MIME type there is a SHOULD, so a different value warns rather than fails.",
   },
   "ui-resources-readable": {
     title: "UI Resources Readable",
@@ -227,7 +227,7 @@ export const APPS_CHECK_CATALOG = {
   "ui-resource-contents-valid": {
     title: "UI Resource Contents Valid",
     description:
-      "UI resource contents use the MCP Apps HTML MIME type and provide exactly one HTML payload via text or blob.",
+      "resources/read returns at least one content entry, and every entry uses the MCP Apps HTML MIME type and carries an HTML document via text or blob.",
   },
   "ui-resource-meta-valid": {
     title: "UI Resource Metadata Valid",

--- a/sdk/tests/apps-conformance/runner.test.ts
+++ b/sdk/tests/apps-conformance/runner.test.ts
@@ -8,6 +8,38 @@ import {
   startConformanceMockServer,
 } from "../mock-servers/conformance-mcp-server.js";
 
+/**
+ * A manager exposing one UI tool and one UI resource, where the caller decides
+ * exactly what `resources/read` hands back and how the resource is declared in
+ * `resources/list`. Lets a test isolate one Content Requirement at a time.
+ */
+function uiResourceManager(
+  contents: unknown[],
+  options: { listedMimeType?: string } = {},
+) {
+  return {
+    listTools: jest.fn().mockResolvedValue({
+      tools: [
+        {
+          name: "ui_tool",
+          inputSchema: { type: "object" },
+          _meta: { ui: { resourceUri: CONFORMANCE_UI_RESOURCE_URI } },
+        },
+      ],
+    }),
+    listResources: jest.fn().mockResolvedValue({
+      resources: [
+        {
+          name: "UI Dashboard",
+          uri: CONFORMANCE_UI_RESOURCE_URI,
+          mimeType: options.listedMimeType ?? "text/html;profile=mcp-app",
+        },
+      ],
+    }),
+    readResource: jest.fn().mockResolvedValue({ contents }),
+  };
+}
+
 describe("MCPAppsConformanceTest", () => {
   it("passes the full apps conformance suite against the dedicated mock server", async () => {
     const mockServer = await startConformanceMockServer();
@@ -97,7 +129,7 @@ describe("MCPAppsConformanceTest", () => {
     }
   });
 
-  it("fails when resources/read returns more than one HTML payload for a UI resource", async () => {
+  it("accepts more than one HTML payload when every entry is a valid UI content", async () => {
     const withEphemeralClientSpy = jest
       .spyOn(operations, "withEphemeralClient")
       .mockImplementation(async (_config, fn) => {
@@ -152,19 +184,122 @@ describe("MCPAppsConformanceTest", () => {
 
       const result = await test.run();
 
-      expect(result.passed).toBe(false);
+      // apps.mdx states its Content Requirements per content item and never
+      // caps the array — the single-element `contents: [{…}]` in the spec is
+      // an example. Two conforming entries are not a violation.
+      expect(result.passed).toBe(true);
       expect(result.checks).toHaveLength(1);
       expect(result.checks[0]).toEqual(
         expect.objectContaining({
           id: "ui-resource-contents-valid",
-          status: "failed",
-          details: expect.objectContaining({
-            violations: [
-              `${CONFORMANCE_UI_RESOURCE_URI} must return exactly one content entry from resources/read (got 2)`,
-            ],
-          }),
+          status: "passed",
         }),
       );
+    } finally {
+      withEphemeralClientSpy.mockRestore();
+    }
+  });
+
+  /**
+   * Dropping the exactly-one rule must not become "only the first entry is
+   * graded" — every returned entry still has to satisfy the four Content
+   * Requirements, and an empty array is still a violation.
+   */
+  it("still grades every content entry once more than one is allowed", async () => {
+    const withEphemeralClientSpy = jest
+      .spyOn(operations, "withEphemeralClient")
+      .mockImplementation(async (_config, fn) =>
+        fn(
+          uiResourceManager([
+            {
+              uri: CONFORMANCE_UI_RESOURCE_URI,
+              mimeType: "text/html;profile=mcp-app",
+              text: "<!DOCTYPE html><html><body>First</body></html>",
+            },
+            {
+              uri: CONFORMANCE_UI_RESOURCE_URI,
+              mimeType: "text/plain",
+              text: "<!DOCTYPE html><html><body>Second</body></html>",
+            },
+          ]) as never,
+          "__apps_conformance__",
+        ),
+      );
+
+    try {
+      const result = await new MCPAppsConformanceTest({
+        url: "https://example.com/mcp",
+        timeout: 10_000,
+        checkIds: ["ui-resource-contents-valid"],
+      }).run();
+
+      expect(result.passed).toBe(false);
+      expect(result.checks[0]?.details?.violations).toEqual([
+        `${CONFORMANCE_UI_RESOURCE_URI} contents[1] returned mimeType "text/plain" instead of "text/html;profile=mcp-app"`,
+      ]);
+    } finally {
+      withEphemeralClientSpy.mockRestore();
+    }
+  });
+
+  it("fails a resources/read that returns no content entries at all", async () => {
+    const withEphemeralClientSpy = jest
+      .spyOn(operations, "withEphemeralClient")
+      .mockImplementation(async (_config, fn) =>
+        fn(uiResourceManager([]) as never, "__apps_conformance__"),
+      );
+
+    try {
+      const result = await new MCPAppsConformanceTest({
+        url: "https://example.com/mcp",
+        timeout: 10_000,
+        checkIds: ["ui-resource-contents-valid"],
+      }).run();
+
+      expect(result.passed).toBe(false);
+      expect(result.checks[0]?.details?.violations).toEqual([
+        `${CONFORMANCE_UI_RESOURCE_URI} returned no content entries from resources/read`,
+      ]);
+    } finally {
+      withEphemeralClientSpy.mockRestore();
+    }
+  });
+
+  /**
+   * apps.mdx makes the listing-level mimeType a SHOULD and the read-level one a
+   * MUST. A server that gets the listing "wrong" is still conformant, so the
+   * check has to warn without failing — otherwise the suite reports a defect
+   * the spec does not describe.
+   */
+  it("warns without failing when a listed UI resource declares another mimeType", async () => {
+    const withEphemeralClientSpy = jest
+      .spyOn(operations, "withEphemeralClient")
+      .mockImplementation(async (_config, fn) =>
+        fn(
+          uiResourceManager(
+            [
+              {
+                uri: CONFORMANCE_UI_RESOURCE_URI,
+                mimeType: "text/html;profile=mcp-app",
+                text: "<!DOCTYPE html><html><body>ok</body></html>",
+              },
+            ],
+            { listedMimeType: "text/html" },
+          ) as never,
+          "__apps_conformance__",
+        ),
+      );
+
+    try {
+      const result = await new MCPAppsConformanceTest({
+        url: "https://example.com/mcp",
+        timeout: 10_000,
+        checkIds: ["ui-listed-resources-valid"],
+      }).run();
+
+      expect(result.passed).toBe(true);
+      expect(result.checks[0]?.status).toBe("passed");
+      expect(result.checks[0]?.warnings?.[0]).toContain("is a SHOULD");
     } finally {
       withEphemeralClientSpy.mockRestore();
     }


### PR DESCRIPTION
Second in the conformance-gap series (after #4216). Both fixes are false positives — servers we report as defective that the MCP Apps spec says are fine.

## 1. Listing-level `mimeType` is a SHOULD, not a MUST

`ui-listed-resources-valid` failed any `resources/list` entry whose `mimeType` wasn't `text/html;profile=mcp-app`. The spec splits these:

| Where | `apps.mdx` says | Force |
|---|---|---|
| `resources/list` — `UIResource.mimeType` | "**SHOULD** be `text/html;profile=mcp-app` for HTML-based UIs in the initial MVP" | SHOULD |
| `resources/read` — Content Requirements | "`mimeType` **MUST** be `text/html;profile=mcp-app`" | MUST |

`ui-resource-contents-valid` already enforces the read-side MUST, so nothing is lost by relaxing the listing. It now warns and names the distinction:

> Listed UI resource `ui://…` declares mimeType "text/html" rather than "text/html;profile=mcp-app"; the listing value is a SHOULD, so this does not fail — but resources/read MUST return the MCP Apps type

The `ui://` scheme rule checked beside it (`"MUST use the ui:// URI scheme"`) is a real MUST and still fails.

## 2. There is no "exactly one content entry" rule

`ui-resource-contents-valid` required `resources/read` to return exactly one entry. The spec's Content Requirements are stated **per content item** and never cap the array; the single-element `contents: [{…}]` is an example, not a bound. A server returning two valid HTML payloads was reported as defective.

Now: an empty array is the violation (nothing to render), and every entry returned is graded against all four Content Requirements.

> [!IMPORTANT]
> The `length !== 1` branch was also the loop guard — it `continue`d past per-entry validation. Removing it risks turning "exactly one is graded" into "only the first is graded". A regression test pins that a bad **second** entry is still caught, plus one that an empty array still fails.

## Test changes

The existing test `"fails when resources/read returns more than one HTML payload"` asserted the removed rule using two *fully valid* entries — it encoded the false positive, so it's now `"accepts more than one HTML payload when every entry is a valid UI content"`. Three tests added: the multi-entry grading guard, the empty-array case, and the listing SHOULD warning.

## Verification

- `npm run typecheck` — clean (exit 0)
- `npm run test` — sdk 5654 passed, inspector 16766 passed (exit 0)
- apps-conformance + catalog drift: 20 passed

## Scope notes

- No check ids added or removed — the pool is still seven. Scores move only for servers previously failed on these two rules.
- Apps conformance has **no spec-version pinning at all** today, so there was nothing to re-pin here. Pinning scored Apps checks to stable `2026-01-26` belongs with the per-revision profile work.
- Draft-only drift found while verifying, for that same later PR: draft adds a "Metadata Location" section allowing `_meta.ui` on `resources/list` entries (content item wins, hosts MUST check both). Stable has no such section, and `ui-resource-meta-valid` only looks at read-result `_meta`. Not a false positive today — it's a gap that opens when draft promotes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Relaxes two Apps conformance fail conditions, so previously failing servers can pass. The multi-entry change is the riskier one (the old length check also skipped remaining entries); tests pin that later invalid entries are still caught.
> 
> **Overview**
> MCP Apps conformance no longer treats two spec-optional behaviors as defects. Check ids are unchanged; scores only move for servers previously failed on these rules.
> 
> **`ui-listed-resources-valid`:** a listing `mimeType` other than `text/html;profile=mcp-app` is now a **warning** (spec SHOULD). The `ui://` scheme remains a MUST and still fails. Read-side MIME type is still enforced by `ui-resource-contents-valid`.
> 
> **`ui-resource-contents-valid`:** `resources/read` may return more than one content entry. Empty arrays still fail; every returned entry is graded against the Content Requirements. Tests cover multi-entry pass, a bad second entry, empty contents, and the listing SHOULD warning.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 739d3a0dbe84cd987b2468c0adcb0280cdf6522b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Aligns Apps conformance with the MCP Apps spec to remove two false positives. Listing-level `mimeType` is now treated as a SHOULD (warns, not fails), and `resources/read` may return multiple content entries (requires at least one and validates each).

- ui-listed-resources-valid: previously failed when `resources/list` `mimeType` wasn’t `text/html;profile=mcp-app`; now warns and explains the SHOULD vs MUST split. The `ui://` scheme remains a MUST and still fails.
- ui-resource-contents-valid: previously required exactly one content entry; now requires at least one entry and validates every entry against the four MUSTs. Empty arrays fail. Tests added to ensure non-first entries are still graded.
- No check IDs changed; only servers previously failed by these rules will see score changes. Patch releases for `@mcpjam/sdk` and `@mcpjam/inspector`.

<sup>Written for commit 739d3a0dbe84cd987b2468c0adcb0280cdf6522b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/MCPJam/inspector/pull/4221?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

