### PR TITLE
fix(ci): extend backend production wait

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -382,7 +382,7 @@ jobs:
             });
 
             const sleep = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
-            for (let attempt = 0; attempt < 40; attempt += 1) {
+            for (let attempt = 0; attempt < 120; attempt += 1) {
               await sleep(15000);
               const { data } = await github.rest.actions.listWorkflowRuns({
                 owner,
@@ -397,7 +397,7 @@ jobs:
               );
 
               if (!matchingRun) {
-                core.info(`No backend production workflow run found yet (attempt ${attempt + 1}/40).`);
+                core.info(`No backend production workflow run found yet (attempt ${attempt + 1}/120).`);
                 continue;
               }
 


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Extends the release workflow’s wait for the backend production workflow run from ~10 minutes to ~30 minutes to avoid premature timeouts during deploys. Polling remains every 15 seconds; attempts increased from 40 to 120 and the log message matches.

- Old behavior: release job gave up after ~10m; new behavior: waits up to ~30m for the backend production run to appear.
- Side effects: longer worst-case runtime and higher GitHub Actions minutes; no change when the backend run appears earlier.
- Review focus: confirm loop bound and info log were updated consistently; no other workflow steps changed.

<sup>Written for commit 6186bd6bfa24f9c4ad2a0937a1822c896d3c68c2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/MCPJam/inspector/pull/4222?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

