### PR TITLE
Production Redesign follow-ups: unsaved-edit loss, one missed token, three shared seams

### DIFF
--- a/mcpjam-inspector/client/src/components/chat-v2/history/__tests__/chat-history-theme.test.ts
+++ b/mcpjam-inspector/client/src/components/chat-v2/history/__tests__/chat-history-theme.test.ts
@@ -1,0 +1,23 @@
+import { describe, expect, it } from "vitest";
+import { CHAT_HISTORY_STRONG_BG_CLASS } from "../chat-history-theme";
+
+/**
+ * The rail is a PANEL surface, so its active row has to be painted from the
+ * `accent` family like the rest of the panel.
+ *
+ * Pinned because the failure is silent and easy to reintroduce: the Production
+ * Redesign (BB-127) swapped what `--sidebar` and `--sidebar-accent` mean, which
+ * left a `bg-sidebar-accent` row here PALER than this same rail's own
+ * `hover:bg-accent/50` — the selected chat looked unselected, and nothing
+ * type-errored.
+ */
+describe("chat history active-row tokens", () => {
+  it("paints every host family from the accent family, never the sidebar's", () => {
+    for (const [family, classes] of Object.entries(
+      CHAT_HISTORY_STRONG_BG_CLASS
+    )) {
+      expect(classes, family).toContain("bg-accent");
+      expect(classes, family).not.toContain("sidebar");
+    }
+  });
+});

--- a/mcpjam-inspector/client/src/components/chat-v2/history/chat-history-theme.ts
+++ b/mcpjam-inspector/client/src/components/chat-v2/history/chat-history-theme.ts
@@ -1,11 +1,23 @@
 import type { HostStyleFamily } from "@/lib/client-styles";
 
 /**
- * Token sets keyed on the user's host-style preference. ChatGPT mimics use the
- * general `accent` family; Claude mimics tie into `sidebar-accent` so the
- * highlight feels like a continuation of the sidebar tab.
+ * Token sets keyed on the user's host-style preference, for the active row of
+ * the chat history rail.
+ *
+ * Both families use the general `accent` family because the rail is a PANEL
+ * surface (`bg-background`, inside the inset panel) — not the app sidebar.
+ * Claude mimics used to reach for `sidebar-accent` to feel like a continuation
+ * of the sidebar tab, but the Production Redesign (BB-127) swapped what those
+ * two sidebar tokens mean: `--sidebar` became the linen ground and
+ * `--sidebar-accent` the pale hover value. On the panel that left the ACTIVE
+ * row paler than this same rail's own `hover:bg-accent/50`, which reads as the
+ * selection having been lost.
+ *
+ * The map stays even though the two entries agree today: which token a host
+ * family highlights with is a real per-family decision, and collapsing it would
+ * make the next divergence a refactor instead of an edit.
  */
 export const CHAT_HISTORY_STRONG_BG_CLASS: Record<HostStyleFamily, string> = {
   chatgpt: "bg-accent text-accent-foreground",
-  claude: "bg-sidebar-accent text-sidebar-accent-foreground",
+  claude: "bg-accent text-accent-foreground",
 };

--- a/mcpjam-inspector/client/src/components/scenarios/UserTestingScenarioCreateFlow.tsx
+++ b/mcpjam-inspector/client/src/components/scenarios/UserTestingScenarioCreateFlow.tsx
@@ -260,6 +260,7 @@ export function UserTestingScenarioCreateFlow({
       // per environment, so on a collision the existing study keeps its own
       // settings — silently rewriting its rating widget would be this screen
       // reconfiguring someone else's study.
+      let ratingsFailed = false;
       if (created) {
         try {
           await onSetPerTurnFeedback(scenarioId, {
@@ -270,20 +271,26 @@ export function UserTestingScenarioCreateFlow({
           // The study exists; only the ratings setting did not land. Say which
           // half failed and where to fix it, rather than reporting a failed
           // creation the user can see succeeded.
+          ratingsFailed = true;
           toast.error(
             "Study created, but the per-turn ratings setting didn't save. Turn it on from the study's settings."
           );
         }
       }
 
-      toast.success(
-        created
-          ? "Study created"
-          : // Publishing is idempotent per environment, and composing makes a
-            // collision likelier: an identical setup resolves to the SAME row,
-            // whose scenario keeps its own name and access.
-            "This setup is already published — opening its study, with the name and access it already has",
-      );
+      // The error above already opens with "Study created" — pairing it with a
+      // bare success toast makes the screen say two things about one outcome
+      // and reads like one of them is stale.
+      if (!ratingsFailed) {
+        toast.success(
+          created
+            ? "Study created"
+            : // Publishing is idempotent per environment, and composing makes a
+              // collision likelier: an identical setup resolves to the SAME row,
+              // whose scenario keeps its own name and access.
+              "This setup is already published — opening its study, with the name and access it already has",
+        );
+      }
     } catch (err) {
       // Surface the backend's copy verbatim: publishing is project-admin
       // gated, and "you need admin" is a different problem than "it failed".

--- a/mcpjam-inspector/client/src/components/scenarios/__tests__/UserTestingScenarioCreateFlow.test.tsx
+++ b/mcpjam-inspector/client/src/components/scenarios/__tests__/UserTestingScenarioCreateFlow.test.tsx
@@ -666,9 +666,10 @@ describe("UserTestingScenarioCreateFlow — create study (Production Redesign)",
     expect(toastError).toHaveBeenCalledWith(
       expect.stringMatching(/study created, but the per-turn ratings setting/i)
     );
-    expect(toastSuccess).toHaveBeenCalledWith(
-      expect.stringMatching(/study created/i)
-    );
+    // And it is not ALSO reported as a plain success: that error already opens
+    // with "Study created", so a success toast beside it would make the screen
+    // say two things about one outcome.
+    expect(toastSuccess).not.toHaveBeenCalled();
   });
 });
 

--- a/mcpjam-inspector/client/src/components/shared/__tests__/progress-stepper.test.tsx
+++ b/mcpjam-inspector/client/src/components/shared/__tests__/progress-stepper.test.tsx
@@ -96,6 +96,26 @@ describe("ProgressStepper", () => {
     expect(connectors).toHaveLength(STEPS.length - 1);
     expect(screen.getByTestId("stepper")).toBeInTheDocument();
   });
+
+  it("keeps every step a real list item, and the connectors out of the list", () => {
+    // The steps used to be `display: contents`, which drops the <li> from the
+    // layout — and, in Safari before 16.4, from the accessibility tree too,
+    // taking `listitem` and this component's `aria-current` contract with it.
+    // The connectors are decoration, so they are hidden instead of counted.
+    render(<ProgressStepper steps={STEPS} activeIndex={1} />);
+
+    const items = screen.getAllByRole("listitem");
+    expect(items).toHaveLength(STEPS.length);
+    expect(items.map((item) => item.textContent)).toEqual([
+      expect.stringContaining("Describe"),
+      expect.stringContaining("Confirm personas"),
+      expect.stringContaining("Running"),
+      expect.stringContaining("Findings"),
+    ]);
+    for (const item of items) {
+      expect(item.className).not.toContain("contents");
+    }
+  });
 });
 
 describe("clampStepIndex", () => {

--- a/mcpjam-inspector/client/src/components/shared/progress-stepper.tsx
+++ b/mcpjam-inspector/client/src/components/shared/progress-stepper.tsx
@@ -14,6 +14,7 @@
  * last step, not a fifth circle that can never be current.
  */
 
+import { Fragment } from "react";
 import { Check } from "lucide-react";
 import { cn } from "@/lib/utils";
 
@@ -94,24 +95,32 @@ export function ProgressStepper({
         const isLast = index === steps.length - 1;
 
         return (
-          <li
-            key={step.id}
-            // `contents` keeps the connector a sibling of the pills in the
-            // parent flex row: nested in the <li>, `grow` would measure against
-            // the item instead of the whole rail and the lines would not
-            // divide the leftover width evenly.
-            className="contents"
-            aria-current={state === "current" ? "step" : undefined}
-          >
-            <StepMarker
-              step={step}
-              index={index}
-              state={state}
-              canSelect={canSelect}
-              onSelect={onStepSelect}
-            />
+          // The connector is its own <li> rather than a child of the step's.
+          // It has to be a sibling of the pills in the flex row — nested, its
+          // `grow` would measure against the item instead of the whole rail and
+          // the lines would not divide the leftover width evenly — and
+          // `display: contents` bought that by dropping the <li> from the
+          // layout, which in older Safari also drops it from the accessibility
+          // tree, taking `listitem` and this component's whole `aria-current`
+          // contract with it.
+          <Fragment key={step.id}>
+            <li
+              // The marker used to be the flex item itself; the <li> inherits
+              // its sizing so the pills still keep their width and only the
+              // connectors take up the slack.
+              className="flex shrink-0"
+              aria-current={state === "current" ? "step" : undefined}
+            >
+              <StepMarker
+                step={step}
+                index={index}
+                state={state}
+                canSelect={canSelect}
+                onSelect={onStepSelect}
+              />
+            </li>
             {isLast ? null : (
-              <span
+              <li
                 aria-hidden
                 className={cn(
                   "h-0.5 min-w-4 grow rounded-full",
@@ -119,7 +128,7 @@ export function ProgressStepper({
                 )}
               />
             )}
-          </li>
+          </Fragment>
         );
       })}
     </ol>

--- a/mcpjam-inspector/client/src/components/shared/section-label.tsx
+++ b/mcpjam-inspector/client/src/components/shared/section-label.tsx
@@ -1,0 +1,18 @@
+/**
+ * Field-group label for persona surfaces: the small uppercase band above
+ * "Persona", "Use cases & context" and "Goals".
+ *
+ * Lives in `shared/` rather than in the Confirm step it was born in (BB-123):
+ * the Personas library consumes it too, and importing a label out of a
+ * 1,400-line step file made the step look like the owner of a rule that is
+ * really about how a persona is described anywhere.
+ */
+import type { ReactNode } from "react";
+
+export function SectionLabel({ children }: { children: ReactNode }) {
+  return (
+    <p className="text-[10px] font-semibold uppercase tracking-wide text-muted-foreground">
+      {children}
+    </p>
+  );
+}

--- a/mcpjam-inspector/client/src/components/swarms/SwarmsTab.tsx
+++ b/mcpjam-inspector/client/src/components/swarms/SwarmsTab.tsx
@@ -56,7 +56,7 @@ import { ErrorBoundary } from "@/components/ui/error-boundary";
 import { TextareaAutosize } from "@/components/ui/textarea-autosize";
 import { PersonaPixelAvatar } from "@/components/swarms/persona-pixel-avatar";
 import { PersonaAvatarLookPicker } from "@/components/swarms/persona-avatar-look-picker";
-import { SectionLabel } from "@/components/swarms/new-swarm-confirm-step";
+import { SectionLabel } from "@/components/shared/section-label";
 import { JourneyNetworkBackdrop } from "@/components/swarms/journey-network-backdrop";
 import { SwarmsEmptyHero } from "@/components/swarms/swarms-empty-hero";
 import {

--- a/mcpjam-inspector/client/src/components/swarms/__tests__/SwarmsTab.createFlow.test.tsx
+++ b/mcpjam-inspector/client/src/components/swarms/__tests__/SwarmsTab.createFlow.test.tsx
@@ -265,7 +265,12 @@ vi.mock("@/lib/app-navigation", async (importOriginal) => {
 vi.mock("@/lib/analytics", () => ({ track: vi.fn() }));
 
 vi.mock("@/lib/toast", () => ({
-  toast: { success: vi.fn(), warning: vi.fn(), error: vi.fn() },
+  toast: {
+    success: vi.fn(),
+    warning: vi.fn(),
+    error: vi.fn(),
+    info: vi.fn(),
+  },
 }));
 
 vi.mock("@/components/swarms/journey-rubric-editor", () => ({
@@ -2292,6 +2297,22 @@ describe("SwarmsTab — Confirm personas (Production Redesign)", () => {
     ).toBeInTheDocument();
   });
 
+  it("does not announce the card itself as a button around two more", async () => {
+    // A widget containing widgets is the one nesting assistive tech cannot
+    // describe: the row used to announce itself as a single button whose
+    // contents were Edit and Remove. Pointer users keep the whole-card click.
+    await reachConfirm();
+
+    const card = screen.getAllByTestId("new-swarm-persona-compact")[0];
+    expect(card).not.toHaveAttribute("role", "button");
+    expect(card).not.toHaveAttribute("tabindex");
+
+    fireEvent.click(card);
+    expect(
+      await screen.findByTestId("new-swarm-persona-detail")
+    ).toBeInTheDocument();
+  });
+
   it("edits every field of a proposed persona in place, then closes on Save", async () => {
     await reachConfirm();
     fireEvent.click(screen.getAllByTestId("new-swarm-persona-compact")[0]);
@@ -2506,5 +2527,55 @@ describe("SwarmsTab — a reused persona whose save fails", () => {
     expect(
       within(detail).getByDisplayValue("Reconcile payouts weekly")
     ).toBeInTheDocument();
+  });
+
+  /**
+   * Escape is a CANCEL for a reused persona, not just a collapse.
+   *
+   * Keeping the draft instead would leave an edit that the collapsed card
+   * doesn't show and the launch doesn't use: the swarm runs with the stored
+   * values and the user only learns their typing did nothing afterwards.
+   */
+  it("discards a reused persona's unsaved edits on Escape, and says so", async () => {
+    const detail = await openReusedPersona();
+
+    fireEvent.change(within(detail).getByLabelText("Persona role"), {
+      target: { value: "Finance ops" },
+    });
+    fireEvent.keyDown(within(detail).getByLabelText("Persona role"), {
+      key: "Escape",
+    });
+
+    await vi.waitFor(() => {
+      expect(
+        screen.queryByTestId("new-swarm-persona-detail")
+      ).not.toBeInTheDocument();
+    });
+    // Nothing reached the shared row.
+    expect(updatePersonaMock).not.toHaveBeenCalled();
+    // Silently dropping typed text is the other half of the same problem.
+    expect(toast.info).toHaveBeenCalledWith(
+      expect.stringContaining("Discarded unsaved changes to Ana")
+    );
+
+    // Reopening shows the stored persona, not the abandoned draft.
+    fireEvent.click(screen.getByTestId("new-swarm-persona-compact"));
+    const reopened = await screen.findByTestId("new-swarm-persona-detail");
+    expect(within(reopened).getByLabelText("Persona role")).toHaveValue("Ops");
+  });
+
+  it("says nothing when Escape closes a panel nobody edited", async () => {
+    const detail = await openReusedPersona();
+
+    fireEvent.keyDown(detail, { key: "Escape" });
+
+    await vi.waitFor(() => {
+      expect(
+        screen.queryByTestId("new-swarm-persona-detail")
+      ).not.toBeInTheDocument();
+    });
+    // A discard notice for a discard that didn't happen is just noise.
+    expect(toast.info).not.toHaveBeenCalled();
+    expect(updatePersonaMock).not.toHaveBeenCalled();
   });
 });

--- a/mcpjam-inspector/client/src/components/swarms/__tests__/reused-persona-draft.test.ts
+++ b/mcpjam-inspector/client/src/components/swarms/__tests__/reused-persona-draft.test.ts
@@ -1,0 +1,90 @@
+/**
+ * `diffReusedDraft` answers "what would this draft write?" for two callers with
+ * opposite motives — Save sends exactly this, and closing the panel asks
+ * whether anything is about to be thrown away. They have to agree: a discard
+ * warning that disagrees with what a save would have done is worse than none.
+ */
+import { describe, expect, it } from "vitest";
+import {
+  diffReusedDraft,
+  type ReusedPersona,
+} from "../new-swarm-confirm-step";
+
+const ANA: ReusedPersona = {
+  _id: "p-1",
+  name: "Ana",
+  role: "Ops",
+  notes: "Closes the books monthly.",
+};
+
+const GOALS = [{ journeyId: "j-1", label: "Reconcile payouts" }];
+
+const draftOf = (overrides: Partial<Record<string, unknown>> = {}) => ({
+  name: ANA.name,
+  role: ANA.role,
+  notes: ANA.notes,
+  goals: { "j-1": "Reconcile payouts" },
+  ...overrides,
+});
+
+describe("diffReusedDraft", () => {
+  it("is clean with no draft at all", () => {
+    const { patch, goalEdits, dirty } = diffReusedDraft(undefined, ANA, GOALS);
+    expect(patch).toEqual({});
+    expect(goalEdits).toEqual([]);
+    expect(dirty).toBe(false);
+  });
+
+  it("is clean for a draft that was opened but never typed in", () => {
+    // Opening the panel seeds a draft from the stored row, so "a draft exists"
+    // is not the same as "something changed" — treating it as such would fire a
+    // discard notice for every Escape and send a no-op patch on every Save,
+    // bumping `updatedAt` for every other swarm reusing the row.
+    expect(diffReusedDraft(draftOf(), ANA, GOALS).dirty).toBe(false);
+  });
+
+  it("sends only the fields that moved", () => {
+    const { patch, dirty } = diffReusedDraft(
+      draftOf({ role: "Finance ops" }),
+      ANA,
+      GOALS
+    );
+    expect(patch).toEqual({ role: "Finance ops" });
+    expect(dirty).toBe(true);
+  });
+
+  it("treats a changed goal as an edit of its own", () => {
+    const { patch, goalEdits, dirty } = diffReusedDraft(
+      draftOf({ goals: { "j-1": "Reconcile payouts weekly" } }),
+      ANA,
+      GOALS
+    );
+    expect(patch).toEqual({});
+    expect(goalEdits).toEqual([
+      { journeyId: "j-1", goal: "Reconcile payouts weekly" },
+    ]);
+    expect(dirty).toBe(true);
+  });
+
+  it("ignores an emptied goal, which is nothing it could save", () => {
+    // The backend throws on an empty goal, so this is never sent — and since it
+    // can't be saved, closing the panel loses nothing by dropping it.
+    const { goalEdits, dirty } = diffReusedDraft(
+      draftOf({ goals: { "j-1": "   " } }),
+      ANA,
+      GOALS
+    );
+    expect(goalEdits).toEqual([]);
+    expect(dirty).toBe(false);
+  });
+
+  it("reads an absent `notes` on the stored row as an empty string", () => {
+    const nameless = { ...ANA, notes: undefined } as unknown as ReusedPersona;
+    expect(diffReusedDraft(draftOf({ notes: "" }), nameless, GOALS).dirty).toBe(
+      false
+    );
+    expect(
+      diffReusedDraft(draftOf({ notes: "New context" }), nameless, GOALS).patch
+    ).toEqual({ notes: "New context" });
+  });
+});

--- a/mcpjam-inspector/client/src/components/swarms/new-swarm-confirm-step.tsx
+++ b/mcpjam-inspector/client/src/components/swarms/new-swarm-confirm-step.tsx
@@ -12,15 +12,12 @@ import {
   useState,
   type ReactNode,
 } from "react";
-import { ChevronDown, Loader2, Plus, Trash2, X } from "lucide-react";
+import { ChevronDown, Loader2, Trash2, X } from "lucide-react";
 import { useQuery } from "convex/react";
 import { Button } from "@mcpjam/design-system/button";
 import { Input } from "@mcpjam/design-system/input";
-import {
-  Popover,
-  PopoverContent,
-  PopoverTrigger,
-} from "@mcpjam/design-system/popover";
+import { PersonaPickerPopover } from "@/components/swarms/persona-picker-popover";
+import { SectionLabel } from "@/components/shared/section-label";
 import { JudgesSection } from "@/components/evals/judges-section";
 import { areAllChecksValid } from "@/components/evals/checks-section";
 import { JourneyRubricEditor } from "@/components/swarms/journey-rubric-editor";
@@ -46,18 +43,6 @@ import {
 } from "@/shared/journey-rubric";
 import { toast } from "@/lib/toast";
 import { cn } from "@/lib/utils";
-
-/**
- * Field-group label shared with the Personas library (BB-123), so a persona
- * reads the same in the library as it does on Confirm.
- */
-export function SectionLabel({ children }: { children: ReactNode }) {
-  return (
-    <p className="text-[10px] font-semibold uppercase tracking-wide text-muted-foreground">
-      {children}
-    </p>
-  );
-}
 
 /** A generated persona + journeys, still only in memory. */
 export type ProposedPersona = {
@@ -158,6 +143,57 @@ type ReusedResolved = {
   grading: { journeyId: string; rubric: JourneyCriterion[] }[];
 };
 
+/** Uncommitted edits to one EXISTING persona, held while its panel is open. */
+export type ReusedPersonaDraft = {
+  name: string;
+  role: string;
+  notes: string;
+  goals: Record<string, string>;
+};
+
+/**
+ * What a draft would actually write.
+ *
+ * One definition of "what moved", because two callers ask the same question for
+ * opposite reasons: Save sends exactly this, and closing the panel uses it to
+ * know whether anything is about to be thrown away. Deriving them separately is
+ * how a discard warning starts disagreeing with what a save would have done.
+ */
+export function diffReusedDraft(
+  draft: ReusedPersonaDraft | undefined,
+  persona: ReusedPersona,
+  goals: readonly ReusedGoal[]
+): {
+  patch: { name?: string; role?: string; notes?: string };
+  goalEdits: { journeyId: string; goal: string }[];
+  dirty: boolean;
+} {
+  const patch: { name?: string; role?: string; notes?: string } = {};
+  const goalEdits: { journeyId: string; goal: string }[] = [];
+  if (!draft) return { patch, goalEdits, dirty: false };
+
+  if (draft.name !== persona.name) patch.name = draft.name;
+  if (draft.role !== persona.role) patch.role = draft.role;
+  if (draft.notes !== (persona.notes ?? "")) patch.notes = draft.notes;
+
+  for (const goal of goals) {
+    const next = draft.goals[goal.journeyId];
+    // A journey needs a goal — the backend throws on an empty one, so an
+    // emptied field is dropped rather than sent and surfaced as an error the
+    // user cannot act on from here. It is not a pending edit either: there is
+    // nothing this panel could save, so closing loses nothing.
+    if (next === undefined || next.trim().length === 0) continue;
+    if (next === goal.label) continue;
+    goalEdits.push({ journeyId: goal.journeyId, goal: next });
+  }
+
+  return {
+    patch,
+    goalEdits,
+    dirty: Object.keys(patch).length > 0 || goalEdits.length > 0,
+  };
+}
+
 function journeyLabel(journey: { name?: string; goal: string }): string {
   const name = journey.name?.trim();
   if (name) return name;
@@ -207,17 +243,16 @@ function CompactPersonaCard({
 }) {
   return (
     <li>
+      {/* A plain div, not `role="button"`: it holds the real Edit and Remove
+          buttons, and a widget that contains other widgets is exactly the
+          nesting assistive tech cannot describe — the row announced itself as
+          one button whose content was two more. The click handler stays, so
+          clicking anywhere on the card still expands it for pointer users;
+          keyboard users reach the same thing through Edit, which is a real
+          focusable control and names its persona. */}
       <div
-        role="button"
-        tabIndex={0}
         data-testid="new-swarm-persona-compact"
         onClick={onSelect}
-        onKeyDown={(event) => {
-          if (event.key === "Enter" || event.key === " ") {
-            event.preventDefault();
-            onSelect();
-          }
-        }}
         className={cn(
           "flex w-full cursor-pointer items-start gap-4 rounded-xl border border-border/50 bg-muted/15 p-4 text-left transition-colors hover:bg-muted/25",
           muted && "opacity-70"
@@ -309,6 +344,11 @@ function CompactPersonaCard({
  * draft and this is what commits them — mirroring keystrokes into a shared row
  * would rewrite other people's swarms as you type. A failed save keeps the
  * panel open with the draft intact.
+ *
+ * The two exits therefore mean two different things for a reused persona, and
+ * both are honest about it: Save commits and collapses, Escape discards and
+ * collapses. Neither leaves an edit that the collapsed card doesn't show and
+ * the launch wouldn't use.
  */
 function PersonaDetailPanel({
   seed,
@@ -346,7 +386,11 @@ function PersonaDetailPanel({
   loadingGoals?: boolean;
   /** In-memory row: edits apply immediately, no Save. */
   draftEditable?: boolean;
-  /** Collapse the editor. Reached by Escape — the design shows no close button. */
+  /**
+   * Leave the editor WITHOUT saving. Reached by Escape — the design shows no
+   * close button. For a persisted persona the caller discards the draft, so
+   * what the collapsed card shows is always what launches.
+   */
   onClose: () => void;
   onRemoveGoal?: (goalKey: string) => void;
   onRemoveCheck?: (goalKey: string, checkId: string) => void;
@@ -927,10 +971,7 @@ export function NewSwarmConfirmStep({
    * and cannot show a stale "saved" value.
    */
   const [reusedDrafts, setReusedDrafts] = useState<
-    Record<
-      string,
-      { name: string; role: string; notes: string; goals: Record<string, string> }
-    >
+    Record<string, ReusedPersonaDraft>
   >({});
   const [savingReusedId, setSavingReusedId] = useState<string | null>(null);
   const [addExistingOpen, setAddExistingOpen] = useState(false);
@@ -981,21 +1022,12 @@ export function NewSwarmConfirmStep({
       try {
         // Only what actually moved. A no-op patch would still bump the row's
         // `updatedAt` for every other swarm reusing it.
-        const patch: { name?: string; role?: string; notes?: string } = {};
-        if (draft.name !== persona.name) patch.name = draft.name;
-        if (draft.role !== persona.role) patch.role = draft.role;
-        if (draft.notes !== (persona.notes ?? "")) patch.notes = draft.notes;
+        const { patch, goalEdits } = diffReusedDraft(draft, persona, goals);
         if (Object.keys(patch).length > 0) {
           await onSaveReusedPersona(persona._id, patch);
         }
-        for (const goal of goals) {
-          const next = draft.goals[goal.journeyId];
-          // A journey needs a goal — the backend throws on an empty one, so an
-          // emptied field is dropped rather than sent and surfaced as an error
-          // the user cannot act on from here.
-          if (next === undefined || next.trim().length === 0) continue;
-          if (next === goal.label) continue;
-          await onSaveReusedGoal(goal.journeyId, next);
+        for (const edit of goalEdits) {
+          await onSaveReusedGoal(edit.journeyId, edit.goal);
         }
         setReusedDrafts((drafts) => {
           const { [persona._id]: _saved, ...rest } = drafts;
@@ -1019,6 +1051,33 @@ export function NewSwarmConfirmStep({
       }
     },
     [onSaveReusedGoal, onSaveReusedPersona, reusedDrafts]
+  );
+
+  /**
+   * Close WITHOUT saving — the Escape route out of a reused persona's editor.
+   *
+   * It discards, rather than keeping the draft around: this row is never
+   * launched from the draft, so a kept-but-uncommitted edit is one the collapsed
+   * card doesn't show and the launch doesn't use, and the user only finds out
+   * their typing did nothing after the swarm has run. Whatever the collapsed
+   * card shows is what launches, on both exits.
+   *
+   * A toast, and only when something was actually lost: silently dropping text
+   * somebody typed is the other half of the same problem.
+   */
+  const discardReused = useCallback(
+    (persona: ReusedPersona, goals: ReusedGoal[]) => {
+      const { dirty } = diffReusedDraft(reusedDrafts[persona._id], persona, goals);
+      if (dirty) {
+        setReusedDrafts((drafts) => {
+          const { [persona._id]: _discarded, ...rest } = drafts;
+          return rest;
+        });
+        toast.info(`Discarded unsaved changes to ${persona.name}.`);
+      }
+      setSelected(null);
+    },
+    [reusedDrafts]
   );
 
   const personasAvailableToAdd = useMemo(
@@ -1214,7 +1273,7 @@ export function NewSwarmConfirmStep({
                             }
                             avatarShape={persona.avatarShape}
                             avatarPalette={persona.avatarPalette}
-                            onClose={() => setSelected(null)}
+                            onClose={() => discardReused(persona, goals)}
                             onChangeName={(name) =>
                               patchReusedDraft(persona, goals, { name })
                             }
@@ -1264,56 +1323,17 @@ export function NewSwarmConfirmStep({
             + Add persona
           </button>
           {personasAvailableToAdd.length > 0 ? (
-            <Popover
+            // Add-only: what is already attached is dropped from the list, and
+            // detaching is the card's own Remove.
+            <PersonaPickerPopover
+              personas={personasAvailableToAdd}
               open={addExistingOpen}
               onOpenChange={setAddExistingOpen}
-            >
-              <PopoverTrigger asChild>
-                <Button
-                  type="button"
-                  variant="secondary"
-                  size="sm"
-                  data-testid="new-swarm-confirm-add-existing"
-                >
-                  <Plus className="mr-1.5 size-4" />
-                  Add existing personas
-                </Button>
-              </PopoverTrigger>
-              <PopoverContent align="start" className="w-80 p-1">
-                <div
-                  role="group"
-                  aria-label="Add existing personas"
-                  className="max-h-72 space-y-0.5 overflow-y-auto"
-                >
-                  {personasAvailableToAdd.map((persona) => (
-                    <button
-                      key={persona._id}
-                      type="button"
-                      aria-label={`Add ${persona.name}`}
-                      onClick={() => onAddReused(persona._id)}
-                      className="flex w-full items-center gap-2.5 rounded-md px-2 py-1.5 text-left text-sm text-muted-foreground transition-colors hover:bg-accent/60"
-                    >
-                      <PersonaPixelAvatar
-                        seed={persona._id}
-                        shapeIndex={persona.avatarShape}
-                        paletteIndex={persona.avatarPalette}
-                        size="sm"
-                      />
-                      <span className="min-w-0 flex-1">
-                        <span className="block truncate font-medium text-foreground">
-                          {persona.name}
-                        </span>
-                        {persona.role ? (
-                          <span className="block truncate text-xs text-muted-foreground">
-                            {persona.role}
-                          </span>
-                        ) : null}
-                      </span>
-                    </button>
-                  ))}
-                </div>
-              </PopoverContent>
-            </Popover>
+              groupLabel="Add existing personas"
+              triggerSize="sm"
+              triggerTestId="new-swarm-confirm-add-existing"
+              mode={{ kind: "add", onAdd: onAddReused }}
+            />
           ) : null}
         </div>
 

--- a/mcpjam-inspector/client/src/components/swarms/new-swarm-create-flow.tsx
+++ b/mcpjam-inspector/client/src/components/swarms/new-swarm-create-flow.tsx
@@ -14,13 +14,9 @@ import { useConvexAuth, useQuery } from "convex/react";
 import { Button } from "@mcpjam/design-system/button";
 import { Input } from "@mcpjam/design-system/input";
 import { Label } from "@mcpjam/design-system/label";
-import {
-  Popover,
-  PopoverContent,
-  PopoverTrigger,
-} from "@mcpjam/design-system/popover";
 import { Textarea } from "@mcpjam/design-system/textarea";
-import { ChevronLeft, Loader2, Plus, X } from "lucide-react";
+import { ChevronLeft, Loader2, X } from "lucide-react";
+import { PersonaPickerPopover } from "@/components/swarms/persona-picker-popover";
 import { ProgressStepper } from "@/components/shared/progress-stepper";
 import { RequiredMark } from "@/components/shared/required-mark";
 import { ErrorBoundary } from "@/components/ui/error-boundary";
@@ -1913,73 +1909,27 @@ export function NewSwarmCreateFlow({
               ) : null}
 
               {personaList.length > 0 ? (
-                <Popover
+                // The whole library, as a checklist: this picker is where
+                // Describe both attaches and detaches.
+                <PersonaPickerPopover
+                  personas={personaList}
                   open={personaPickerOpen}
                   onOpenChange={setPersonaPickerOpen}
-                >
-                  <PopoverTrigger asChild>
-                    <Button
-                      type="button"
-                      variant="secondary"
-                      className="w-fit"
-                      data-testid="new-swarm-add-existing-personas"
-                    >
-                      <Plus className="mr-1.5 size-4" />
-                      Add existing personas
-                    </Button>
-                  </PopoverTrigger>
-                  <PopoverContent align="start" className="w-80 p-1">
-                    <div
-                      role="group"
-                      aria-label="Choose personas"
-                      className="max-h-72 space-y-0.5 overflow-y-auto"
-                      data-testid="new-swarm-existing-personas"
-                    >
-                      {personaList.map((persona) => {
-                        const selected = reusedIds.includes(persona._id);
-                        return (
-                          <button
-                            key={persona._id}
-                            type="button"
-                            role="checkbox"
-                            aria-checked={selected}
-                            aria-label={"Include " + persona.name}
-                            onClick={() =>
-                              setReusedIds((ids) =>
-                                selected
-                                  ? ids.filter((id) => id !== persona._id)
-                                  : [...ids, persona._id]
-                              )
-                            }
-                            className={cn(
-                              "flex w-full items-center gap-2.5 rounded-md px-2 py-1.5 text-left text-sm transition-colors",
-                              selected
-                                ? "bg-accent text-foreground"
-                                : "text-muted-foreground hover:bg-accent/60"
-                            )}
-                          >
-                            <PersonaPixelAvatar
-                              seed={persona._id}
-                              shapeIndex={persona.avatarShape}
-                              paletteIndex={persona.avatarPalette}
-                              size="sm"
-                            />
-                            <span className="min-w-0 flex-1">
-                              <span className="block truncate font-medium text-foreground">
-                                {persona.name}
-                              </span>
-                              {persona.role ? (
-                                <span className="block truncate text-xs text-muted-foreground">
-                                  {persona.role}
-                                </span>
-                              ) : null}
-                            </span>
-                          </button>
-                        );
-                      })}
-                    </div>
-                  </PopoverContent>
-                </Popover>
+                  groupLabel="Choose personas"
+                  triggerClassName="w-fit"
+                  triggerTestId="new-swarm-add-existing-personas"
+                  listTestId="new-swarm-existing-personas"
+                  mode={{
+                    kind: "toggle",
+                    selectedIds: reusedIds,
+                    onToggle: (personaId) =>
+                      setReusedIds((ids) =>
+                        ids.includes(personaId)
+                          ? ids.filter((id) => id !== personaId)
+                          : [...ids, personaId]
+                      ),
+                  }}
+                />
               ) : null}
             </div>
 

--- a/mcpjam-inspector/client/src/components/swarms/persona-picker-popover.tsx
+++ b/mcpjam-inspector/client/src/components/swarms/persona-picker-popover.tsx
@@ -1,0 +1,144 @@
+/**
+ * "Add existing personas" — the popover that lets a swarm pull in personas the
+ * project already has.
+ *
+ * One component for both call sites in the create flow (BB-122/123). Describe
+ * and Confirm shipped it as two near-identical 40-line bodies, which is exactly
+ * how a persona row starts reading differently in two places that are supposed
+ * to be the same list.
+ *
+ * The two sites do NOT have the same semantics, though, so that difference is
+ * the prop rather than something the component papers over:
+ *
+ *  - Describe offers the whole library as a CHECKLIST — the picker is where you
+ *    both attach and detach, so its rows are `role="checkbox"` and carry their
+ *    selected state.
+ *  - Confirm offers only what is not already attached, as an ADD list —
+ *    detaching there is the card's own Remove button, so a checkbox that could
+ *    never be unchecked from inside the popover would be a lie.
+ */
+import { Plus } from "lucide-react";
+import { Button } from "@mcpjam/design-system/button";
+import {
+  Popover,
+  PopoverContent,
+  PopoverTrigger,
+} from "@mcpjam/design-system/popover";
+import { PersonaPixelAvatar } from "@/components/swarms/persona-pixel-avatar";
+import { cn } from "@/lib/utils";
+
+/** The persona fields this picker draws. */
+export type PersonaPickerOption = {
+  _id: string;
+  name: string;
+  role: string;
+  avatarShape?: number;
+  avatarPalette?: number;
+};
+
+export type PersonaPickerMode =
+  /** Attach and detach from inside the list. */
+  | {
+      kind: "toggle";
+      selectedIds: readonly string[];
+      onToggle: (personaId: string) => void;
+    }
+  /** Attach only; the caller has already filtered out what is attached. */
+  | { kind: "add"; onAdd: (personaId: string) => void };
+
+export function PersonaPickerPopover({
+  personas,
+  open,
+  onOpenChange,
+  mode,
+  groupLabel,
+  triggerLabel = "Add existing personas",
+  triggerSize,
+  triggerClassName,
+  triggerTestId,
+  listTestId,
+}: {
+  personas: readonly PersonaPickerOption[];
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  mode: PersonaPickerMode;
+  /** Names the list for assistive tech; the two sites describe it differently. */
+  groupLabel: string;
+  triggerLabel?: string;
+  triggerSize?: "sm";
+  triggerClassName?: string;
+  triggerTestId?: string;
+  listTestId?: string;
+}) {
+  return (
+    <Popover open={open} onOpenChange={onOpenChange}>
+      <PopoverTrigger asChild>
+        <Button
+          type="button"
+          variant="secondary"
+          size={triggerSize}
+          className={triggerClassName}
+          data-testid={triggerTestId}
+        >
+          <Plus className="mr-1.5 size-4" />
+          {triggerLabel}
+        </Button>
+      </PopoverTrigger>
+      <PopoverContent align="start" className="w-80 p-1">
+        <div
+          role="group"
+          aria-label={groupLabel}
+          className="max-h-72 space-y-0.5 overflow-y-auto"
+          data-testid={listTestId}
+        >
+          {personas.map((persona) => {
+            const selected =
+              mode.kind === "toggle" && mode.selectedIds.includes(persona._id);
+            return (
+              <button
+                key={persona._id}
+                type="button"
+                // Checkbox only where the row can actually be unchecked.
+                role={mode.kind === "toggle" ? "checkbox" : undefined}
+                aria-checked={mode.kind === "toggle" ? selected : undefined}
+                aria-label={
+                  mode.kind === "toggle"
+                    ? `Include ${persona.name}`
+                    : `Add ${persona.name}`
+                }
+                onClick={() =>
+                  mode.kind === "toggle"
+                    ? mode.onToggle(persona._id)
+                    : mode.onAdd(persona._id)
+                }
+                className={cn(
+                  "flex w-full items-center gap-2.5 rounded-md px-2 py-1.5 text-left text-sm transition-colors",
+                  selected
+                    ? "bg-accent text-foreground"
+                    : "text-muted-foreground hover:bg-accent/60"
+                )}
+              >
+                <PersonaPixelAvatar
+                  seed={persona._id}
+                  shapeIndex={persona.avatarShape}
+                  paletteIndex={persona.avatarPalette}
+                  size="sm"
+                />
+                <span className="min-w-0 flex-1">
+                  <span className="block truncate font-medium text-foreground">
+                    {persona.name}
+                  </span>
+                  {persona.role ? (
+                    <span className="block truncate text-xs text-muted-foreground">
+                      {persona.role}
+                    </span>
+                  ) : null}
+                </span>
+              </button>
+            );
+          })}
+        </div>
+      </PopoverContent>
+    </Popover>
+  );
+}


### PR DESCRIPTION
Follow-ups from the review of #4205. Nothing here blocked that merge; this is the list it produced.

## The one that costs a user something

Escape out of a **reused** persona's editor collapsed the panel but kept the uncommitted draft. Nothing else reads that draft: the collapsed card and the launch both take the stored row. So an edit + Escape + Launch ran the swarm with the old values, said nothing, and the abandoned edit reappeared the next time the panel opened.

Escape is a cancel now. It discards, and toasts only when there was something to discard — silently dropping typed text is the other half of the same problem. Save still commits. **Whatever the collapsed card shows is what launches, on both exits.**

The two paths now ask one function, `diffReusedDraft`, what moved. Save sends exactly that; close asks it whether anything is about to be lost. Deriving them separately is how a discard warning starts disagreeing with what a save would have done. It also pins the case that reads backwards: opening a panel seeds a draft from the stored row, so "a draft exists" is not "something changed" — otherwise every Escape warns and every Save sends a no-op patch that bumps `updatedAt` for every other swarm reusing the row.

## A missed step in #4205's own token migration

`chat-history-theme.ts` still painted the Claude-mimic active row with `bg-sidebar-accent`. That rail is a **panel** surface (`bg-background`, inside the inset panel), not the app sidebar, so after the `--sidebar` / `--sidebar-accent` role swap the ACTIVE row rendered paler than the same rail's own `hover:bg-accent/50` — the selected chat looked unselected. Both host families now use the accent family. The map stays: which token a family highlights with is a real per-family decision, and collapsing it would make the next divergence a refactor instead of an edit.

## Two toasts about one outcome

A study whose ratings write failed showed the error that opens *"Study created, but the per-turn ratings setting didn't save…"* **and** a bare *"Study created"* beside it. The error already reports the created study, so the success toast is suppressed on exactly that branch.

## Two a11y shapes jsdom cannot see

Both are pinned by tests that assert the structure, since nothing renders in CI:

- **The stepper's steps were `display: contents`.** That drops the `<li>` from the layout — which is what the trick was for — and, in Safari before 16.4, from the accessibility tree too, taking `listitem` and this component's entire "exactly one step is current" contract with it. The connector is its own `aria-hidden` `<li>` now, and the steps are real list items.
- **The persona card announced itself as one button whose contents were two more buttons.** A widget containing widgets is the one nesting assistive tech cannot describe. It is a plain div with a click handler now: pointer users keep the whole-card click, keyboard users reach the same editor through Edit, which is a real control that names its persona.

## The sharing #4205 left on the floor

- **`PersonaPickerPopover`** — Describe and Confirm shipped the "Add existing personas" list as two near-identical 40-line bodies, which is how the same list starts reading differently in two places. One component now, with the difference where it actually is: Describe offers the whole library as a **checklist** (it both attaches and detaches, so its rows are `role="checkbox"`), Confirm offers only what is not attached as an **add** list (detaching there is the card's Remove, so a checkbox that could never be unchecked would be a lie).
- **`SectionLabel`** moves out of the 1,400-line confirm step into `components/shared/`. Importing a label out of a step file made that step look like the owner of a rule that is really about how a persona is described anywhere.

## Deliberately not here

The Personas library's own `SectionLabel`-adjacent variants (`tracing/HttpExchangeDetails`, evals' `runDetailSectionLabelClass`) are different type ramps, not this label — left alone.

## Verification

- `typecheck:client` clean.
- Full suite via `npm test`: **16,869 passed, 0 failed** (1,347 files). One file reported a failure on the first run — a `rmSync` teardown race in `server/utils/computers/__tests__/local-machine.test.ts`, on a temp dir unrelated to these client-only changes; it passes on its own and no test in it failed.
- New coverage: `diffReusedDraft`'s six cases, discard-on-Escape and its silent no-op counterpart, the card's missing `role="button"`, the stepper's list items, and the chat-history tokens.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PC5PkQCaP1HB3PgpWhDU3Y

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how shared persona drafts are discarded vs saved, which can drop typed edits and skip no-op writes to reused rows. Remaining work is UI/a11y/token follow-ups with no auth or backend surface.
> 
> **Overview**
> Escaping a **reused** persona editor now **cancels**: unsaved drafts are dropped (with an info toast only when something actually changed) so the collapsed card and launch always match the stored row. Save still commits. Both paths share `diffReusedDraft` so discard and persist agree on what moved.
> 
> Also fixes a few Production Redesign leftovers: Claude chat-history selection uses `bg-accent` (the rail is a panel, not the sidebar); study create no longer pairs a success toast with the “created but ratings didn’t save” error; the stepper keeps real `<li>`s instead of `display: contents`; persona compact cards are no longer nested buttons.
> 
> Extracts `PersonaPickerPopover` (toggle vs add modes) and moves `SectionLabel` into `shared/`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e6077e6f5221d277eada1f2ee2e940c4533c7758. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes post-redesign regressions that could confuse users or assistive tech. Old: pressing Escape in a reused persona editor collapsed the panel but kept an unsaved draft, while launches used the stored row. New: Escape cancels (discards + info toast when something would be lost); Save still commits; launches always match the collapsed card.

- Reused persona edits: centralizes change detection in `diffReusedDraft` so Save sends exactly what changed and Escape knows whether anything would be lost. Prevents no-op patches and mismatched discard prompts; adds focused tests.
- Persona picker dedup: replaces two near-identical popovers with a single `PersonaPickerPopover` supporting “toggle” (Describe) and “add-only” (Confirm) modes. Moves `SectionLabel` to `components/shared/section-label`. Migration: update imports to `@/components/shared/section-label`.
- A11y fixes: progress stepper steps are real list items; connectors are separate `aria-hidden` siblings. Persona card is no longer a button wrapping buttons; whole-card click remains for pointers, keyboard users use the Edit button.
- Chat history active-row token: both host families now use `bg-accent` on the panel rail; adds a test to pin against sidebar token regressions.
- Study creation toasts: suppresses the plain “Study created” toast when the ratings setting write fails; the error already communicates creation.

<sup>Written for commit e6077e6f5221d277eada1f2ee2e940c4533c7758. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/MCPJam/inspector/pull/4224?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

