### PR TITLE
Gate "Add to org registry" by the registry-enabled flag

### DIFF
--- a/mcpjam-inspector/client/src/components/ServersTab.tsx
+++ b/mcpjam-inspector/client/src/components/ServersTab.tsx
@@ -2036,7 +2036,7 @@ export function ServersTab({
                       onMoveToProject={handleMoveServerToProject}
                       isMovingToProject={movingServerName === name}
                       onShareToOrgRegistry={
-                        orgRegistry.canAdd
+                        isRegistryEnabled && orgRegistry.canAdd
                           ? handleShareToOrgRegistry
                           : undefined
                       }

--- a/mcpjam-inspector/client/src/components/connection/ServerConnectionCard.tsx
+++ b/mcpjam-inspector/client/src/components/connection/ServerConnectionCard.tsx
@@ -71,6 +71,7 @@ import {
 } from "@/lib/apis/mcp-tunnels-api";
 import { useAuth } from "@workos-inc/authkit-react";
 import { useConvexAuth } from "convex/react";
+import { useFeatureFlagEnabled } from "posthog-js/react";
 import { HOSTED_MODE } from "@/lib/config";
 import { useExploreCasesPrefetchOnConnect } from "@/hooks/use-explore-cases-prefetch-on-connect";
 import { getOAuthTraceFailureStep } from "@/lib/oauth/oauth-trace";
@@ -135,7 +136,9 @@ interface ServerConnectionCardProps {
    * Share this server on the organization's registry shelf. Injected the same
    * way `onMoveToProject` is — the card knows the server, the parent owns the
    * dialog and the mutation. When omitted (no organization, guest role, or a
-   * surface with no registry) the item is not rendered at all.
+   * surface with no registry) the item is not rendered at all. Also hidden
+   * when the `registry-enabled` PostHog flag is off, even if a callback is
+   * provided — the flag is the rollout door, not the caller's permission.
    */
   onShareToOrgRegistry?: (server: ServerWithName) => void;
 }
@@ -156,6 +159,7 @@ export function ServerConnectionCard({
   onShareToOrgRegistry,
 }: ServerConnectionCardProps) {
   useExploreCasesPrefetchOnConnect(projectId ?? null, server, hostedServerId);
+  const registryEnabled = useFeatureFlagEnabled("registry-enabled") === true;
 
   // A pinned protocol version the server doesn't offer is the one connect
   // failure with an exact, one-click fix, so the card offers it instead of
@@ -831,11 +835,14 @@ export function ServerConnectionCard({
                       </DropdownMenuSub>
                     ) : null}
                     {/*
-                      Remote HTTP only. An org entry carries an ADDRESS, and a
+                      Remote HTTP only, and only while the registry rollout
+                      flag is on. An org entry carries an ADDRESS, and a
                       stdio server's address is a command on one machine —
                       there is nothing to share.
                     */}
-                    {onShareToOrgRegistry && server.config?.url ? (
+                    {onShareToOrgRegistry &&
+                    registryEnabled &&
+                    server.config?.url ? (
                       <DropdownMenuItem
                         className="text-xs cursor-pointer"
                         onClick={() => {

--- a/mcpjam-inspector/client/src/components/connection/__tests__/ServerConnectionCard.test.tsx
+++ b/mcpjam-inspector/client/src/components/connection/__tests__/ServerConnectionCard.test.tsx
@@ -14,12 +14,18 @@ vi.mock("@/lib/generate-agent-brief", () => ({
   generateAgentBrief: vi.fn().mockReturnValue("mocked brief"),
 }));
 
+const mockUseFeatureFlagEnabled = vi.hoisted(() => vi.fn(() => false));
+
 // Mock posthog
 vi.mock("posthog-js/react", () => ({
   usePostHog: () => ({
     capture: vi.fn(),
   }),
-  useFeatureFlagEnabled: () => false,
+  // ServerConnectionCard gates "Add to org registry" on
+  // `registry-enabled`. Default off so existing tests keep the pre-flag
+  // menu; org-registry cases turn it on per-suite.
+  useFeatureFlagEnabled: (...args: unknown[]) =>
+    mockUseFeatureFlagEnabled(...args),
 }));
 
 vi.mock("@/lib/analytics", () => ({
@@ -115,6 +121,8 @@ describe("ServerConnectionCard", () => {
 
   beforeEach(() => {
     vi.clearAllMocks();
+    mockUseFeatureFlagEnabled.mockReset();
+    mockUseFeatureFlagEnabled.mockReturnValue(false);
   });
 
   describe("rendering", () => {
@@ -168,7 +176,8 @@ describe("ServerConnectionCard", () => {
      * "Add to org registry" is the promote door. Its eligibility rules are
      * the interesting part: an org entry carries an ADDRESS and an auth
      * posture and nothing else, so a stdio server has nothing to share and a
-     * header-authed one has something that cannot be shared.
+     * header-authed one has something that cannot be shared. The
+     * `registry-enabled` flag is the rollout door on top of those rules.
      */
     describe("add to org registry", () => {
       const remoteServer = () =>
@@ -186,6 +195,12 @@ describe("ServerConnectionCard", () => {
         );
         return await screen.findByText("Add to org registry");
       };
+
+      beforeEach(() => {
+        mockUseFeatureFlagEnabled.mockImplementation(
+          (flag: unknown) => flag === "registry-enabled"
+        );
+      });
 
       it("offers a remote HTTP server to the organization", async () => {
         const onShareToOrgRegistry = vi.fn();
@@ -264,6 +279,27 @@ describe("ServerConnectionCard", () => {
       it("hides the action entirely when the caller cannot add", async () => {
         render(
           <ServerConnectionCard server={remoteServer()} {...defaultProps} />
+        );
+
+        fireEvent.pointerDown(
+          screen.getByRole("button", {
+            name: "Open actions menu for remote-server",
+          }),
+          { button: 0, ctrlKey: false }
+        );
+
+        await screen.findByText("Configure");
+        expect(screen.queryByText("Add to org registry")).toBeNull();
+      });
+
+      it("hides the action when the registry flag is off, even if the caller can add", async () => {
+        mockUseFeatureFlagEnabled.mockReturnValue(false);
+        render(
+          <ServerConnectionCard
+            server={remoteServer()}
+            {...defaultProps}
+            onShareToOrgRegistry={vi.fn()}
+          />
         );
 
         fireEvent.pointerDown(


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Purpose

Hide the server-card **Add to org registry** action unless the `registry-enabled` PostHog flag is on. The promote door should follow the same rollout gate as the Registry nav and Servers-tab registry surfaces.

## Context

The menu item currently appeared whenever the parent injected `onShareToOrgRegistry` and the server had a URL. That let the action show even when the registry feature was flagged off.

## Before / after

**Before:** A remote HTTP server with org-add permission showed "Add to org registry" regardless of the `registry-enabled` flag.

**After:**
- The card hides the item unless `useFeatureFlagEnabled("registry-enabled") === true` (fail-closed while the flag is unresolved).
- `ServersTab` also withholds the callback unless `isRegistryEnabled && orgRegistry.canAdd`.

## Linked issues

n/a

## Rollout

- No schema or API change. Users without the flag lose a menu item they should not have had.
- Existing eligibility rules (HTTP-only, shown-then-refused for credentialed servers) are unchanged when the flag is on.

## Testing

- Unit: `ServerConnectionCard` org-registry cases now turn the flag on; added a case that the item stays hidden when the flag is off even if a share callback is provided.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-ade8c9d4-7e63-4095-ade4-34acdfd665f7?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ade8c9d4-7e63-4095-ade4-34acdfd665f7&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Gate the “Add to org registry” action behind the `registry-enabled` PostHog flag to align with the registry rollout. Previously the item appeared whenever a share callback existed for a remote HTTP server; now it only shows when the flag is true and fails closed while the flag is unresolved.

- `ServerConnectionCard` hides “Add to org registry” unless `useFeatureFlagEnabled("registry-enabled") === true` and the server has a URL; it ignores a provided `onShareToOrgRegistry` when the flag is off.
- `ServersTab` injects `onShareToOrgRegistry` only when `isRegistryEnabled && orgRegistry.canAdd`.
- Uses `useFeatureFlagEnabled` from `posthog-js/react`; existing eligibility rules (remote HTTP only, credentialed servers excluded) are unchanged when the flag is on.
- No API or schema changes; users without the flag lose a menu item they should not see.
- Tests cover the flag gating, including hiding the action when the flag is off even if a callback is provided.

<sup>Written for commit 8472eeb06d7236463b758c079e88a62f16aa0388. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/MCPJam/inspector/pull/4225?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

