### PR TITLE
Reject unknown eval-suite op keys on CLI and MCP

### DIFF
--- a/.changeset/strict-eval-suite-op-bodies.md
+++ b/.changeset/strict-eval-suite-op-bodies.md
@@ -1,0 +1,6 @@
+---
+"@mcpjam/sdk": patch
+"@mcpjam/cli": patch
+---
+
+`mcpjam eval create/update --json` (and `--file`) now reject unknown top-level keys as a usage error instead of silently dropping them. The MCP `create_eval_suite` / `update_eval_suite` tools publish the same closed input shape.

--- a/cli/tests/eval.test.ts
+++ b/cli/tests/eval.test.ts
@@ -774,6 +774,39 @@ test("eval create rejects an invalid suite definition as a usage error", async (
   }
 });
 
+test("eval create rejects an unknown --json key as a usage error", async () => {
+  const fixture = await startEvalFixture();
+  try {
+    const run = await captureProcessOutput(() =>
+      main(
+        evalArgv(
+          fixture.baseUrl,
+          "create",
+          "--json",
+          JSON.stringify({
+            project: "proj-alpha",
+            name: "Authored smoke",
+            servers: ["Ready Server"],
+            model: "anthropic/claude-haiku-4.5",
+            cases: [
+              { title: "t", steps: [{ id: "s1", kind: "prompt", prompt: "q" }] },
+            ],
+            hostz: [],
+          }),
+        ),
+        { telemetry: telemetryDisabled },
+      ),
+    );
+
+    assert.equal(run.result.exitCode, 2);
+    assert.equal(fixture.createBodies.length, 0);
+    assert.match(run.stderr, /USAGE_ERROR/);
+    assert.match(run.stderr, /hostz/);
+  } finally {
+    await fixture.close();
+  }
+});
+
 test("eval create rejects malformed JSON in --json", async () => {
   const fixture = await startEvalFixture();
   try {
@@ -1013,6 +1046,32 @@ test("eval run rejects --environment together with --server before any request",
     // The CLI calls the operation directly, so this guard has to live in the
     // execute body — a schema-only refine would never fire here.
     assert.equal(fixture.createBodies.length, 0);
+  } finally {
+    await fixture.close();
+  }
+});
+
+test("eval update rejects an unknown --json key as a usage error", async () => {
+  const fixture = await startEvalFixture();
+  try {
+    const run = await captureProcessOutput(() =>
+      main(
+        evalArgv(
+          fixture.baseUrl,
+          "update",
+          "--suite",
+          "suite-1",
+          "--json",
+          JSON.stringify({ hostz: [] }),
+        ),
+        { telemetry: telemetryDisabled },
+      ),
+    );
+
+    assert.equal(run.result.exitCode, 2);
+    assert.equal(fixture.createBodies.length, 0);
+    assert.match(run.stderr, /USAGE_ERROR/);
+    assert.match(run.stderr, /hostz/);
   } finally {
     await fixture.close();
   }

--- a/sdk/src/platform/operations.ts
+++ b/sdk/src/platform/operations.ts
@@ -2871,7 +2871,9 @@ const evalCaseInput = z.object({
     ),
 });
 
-const createEvalSuiteInput = z.object({
+// STRICT: `--json` / MCP args that invent a top-level key must fail
+// validation, not be stripped before the request is built.
+const createEvalSuiteInput = z.strictObject({
   project: z
     .string()
     .trim()
@@ -3116,7 +3118,9 @@ export const getEvalSuiteOperation: PlatformOperation<
   },
 };
 
-const updateEvalSuiteInput = z.object({
+// STRICT: the reported silent no-op (`hostIds` / top-level `servers`)
+// was stripped here before the HTTP body was ever built.
+const updateEvalSuiteInput = z.strictObject({
   project: z
     .string()
     .trim()

--- a/sdk/tests/platform/operations-eval-edit.test.ts
+++ b/sdk/tests/platform/operations-eval-edit.test.ts
@@ -108,6 +108,19 @@ describe("eval-edit operation input validation", () => {
     ).toBe(false);
   });
 
+  it("update_eval_suite rejects an unknown top-level key rather than stripping it", () => {
+    const parsed = updateEvalSuiteOperation.inputSchema.safeParse({
+      suite: "s1",
+      hostIds: ["h1"],
+      servers: ["echo"],
+    });
+    expect(parsed.success).toBe(false);
+    if (parsed.success) return;
+    const detail = parsed.error.issues.map((issue) => issue.message).join("; ");
+    expect(detail).toContain("hostIds");
+    expect(detail).toContain("servers");
+  });
+
   it("update_eval_suite rejects an out-of-range minimumAccuracy", () => {
     expect(
       updateEvalSuiteOperation.inputSchema.safeParse({

--- a/sdk/tests/platform/operations.test.ts
+++ b/sdk/tests/platform/operations.test.ts
@@ -1233,6 +1233,23 @@ describe("createEvalSuiteOperation", () => {
     ).toBe(true);
   });
 
+  it("rejects an unknown top-level key rather than stripping it", () => {
+    const parsed = createEvalSuiteOperation.inputSchema.safeParse({
+      name: "s",
+      model: "anthropic/claude-haiku-4.5",
+      servers: ["echo"],
+      cases: [
+        { title: "t", steps: [{ id: "s1", kind: "prompt", prompt: "q" }] },
+      ],
+      hostz: [],
+    });
+    expect(parsed.success).toBe(false);
+    if (parsed.success) return;
+    expect(parsed.error.issues.some((issue) => /hostz/.test(issue.message))).toBe(
+      true
+    );
+  });
+
   it("requires a name, at least one server, and at least one case", () => {
     expect(createEvalSuiteOperation.inputSchema.safeParse({}).success).toBe(
       false


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Purpose and context

PR 2 of 2. PR 1 (#4226, merged) made the **server** reject unknown eval/host write-body keys. That is not enough for `mcpjam eval update --json '{...}'` or the MCP `update_eval_suite` tool: SDK op input schemas validate **before** the HTTP request is built, and they were non-strict — unknown keys died client-side, silently.

Follows the review-merge gate after #4226.

## Before / after

**Before**
- `mcpjam eval update --suite X --json '{"hostz": []}'` validated, stripped `hostz`, and PATCHed a no-op body (or a body missing the intended attachment).
- MCP `update_eval_suite` accepted hallucinated args and dropped them.

**After**
- Those two top-level op schemas (`createEvalSuiteInput`, `updateEvalSuiteInput`) are `z.strictObject`. Unknown keys are a usage/tool error that names the key.
- CLI flag-merging is unchanged: `buildSuiteUpdateInput` / `buildSuiteDefinition` only write declared keys.
- Nested `.passthrough()` shapes (step variants, `advancedConfig`, `publicCheckSchema`) stay open by design.

## Out of scope (follow-up, not this PR)

- Blanket `.strict()` across all ~180 op schemas — needs a per-command audit of the other `validateOpInput` copies and of `projects.ts` bare `.parse()` sites.
- A spec↔code strictness-parity test in `openapi-drift.test.ts`.

## Rollout notes

- Patch changeset for `@mcpjam/sdk` and `@mcpjam/cli`.
- Behavior change only for callers who were sending undeclared top-level keys (those calls were already no-ops).

## Test plan

- SDK: `operations.test.ts` + `operations-eval-edit.test.ts` unknown-key cases.
- CLI: `eval create/update --json` with `hostz` → exit 2 / `USAGE_ERROR` / key named; no write.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-4a059646-dc79-43d1-a61e-ace25be316d0?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-4a059646-dc79-43d1-a61e-ace25be316d0&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Rejects unknown top-level keys in eval suite create/update input for the CLI and MCP to prevent silent no-ops. Previously the SDK schemas stripped unknown keys before building the request; now validation fails and names the offending key.

- Makes `createEvalSuiteInput` and `updateEvalSuiteInput` strict (`z.strictObject`); MCP tools publish closed input shapes.
- CLI: `mcpjam eval create/update --json|--file` with an unknown top-level key exits 2 (USAGE_ERROR); no request is sent.
- Keeps nested passthrough objects open by design (step variants, `advancedConfig`, `publicCheckSchema`); no change to flag-merging helpers.
- Migration: remove or correct undeclared top-level keys (e.g., `hostz`, `hostIds`, top-level `servers`) in payloads.
- Patch releases for `@mcpjam/sdk` and `@mcpjam/cli`; tests added for the new failures.

<sup>Written for commit 18c639fd83c948de60df77994edf1845b4fb6947. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/MCPJam/inspector/pull/4232?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

