### PR TITLE
Block paid-seat retry until invoice cleanup

### DIFF
--- a/mcpjam-inspector/client/src/components/OrganizationsTab.tsx
+++ b/mcpjam-inspector/client/src/components/OrganizationsTab.tsx
@@ -227,6 +227,7 @@ function PendingSeatPaymentNotice({
   onCancel: () => void;
 }) {
   const needsRetry = intent.needsRetry === true;
+  const cleanupPending = intent.status === "cleanup_pending";
 
   return (
     <Alert
@@ -247,7 +248,12 @@ function PendingSeatPaymentNotice({
       </AlertTitle>
       <AlertDescription className="space-y-3">
         <p>
-          {needsRetry ? (
+          {cleanupPending ? (
+            <>
+              Stripe is closing {intent.email}'s declined invoice. Retry will
+              unlock as soon as cleanup is confirmed.
+            </>
+          ) : needsRetry ? (
             <>
               We couldn't charge for {intent.email}'s seat. They won't get
               access or credits until it's paid.
@@ -264,9 +270,13 @@ function PendingSeatPaymentNotice({
             type="button"
             size="sm"
             onClick={onFinish}
-            disabled={isFinishingSeatPayment || isCancelingSeatPayment}
+            disabled={
+              cleanupPending ||
+              isFinishingSeatPayment ||
+              isCancelingSeatPayment
+            }
           >
-            {isFinishingSeatPayment ? (
+            {cleanupPending || isFinishingSeatPayment ? (
               <Loader2 className="mr-2 size-4 animate-spin" />
             ) : (
               <CreditCard className="mr-2 size-4" />
@@ -868,6 +878,7 @@ function OrganizationPage({
   const [isRemovingSeatInvite, setIsRemovingSeatInvite] = useState(false);
 
   const handleRetrySeatPayment = async () => {
+    if (activeSeatPaymentIntent?.status === "cleanup_pending") return;
     try {
       const result = await retrySeatPayment();
       if (result?.status === "paid") {
@@ -910,8 +921,20 @@ function OrganizationPage({
         toast.success(`Invite for ${activeSeatPaymentIntent.email} removed.`);
         return;
       }
-      await cancelSeatPayment();
-      toast.success("Pending seat payment canceled.");
+      const result = await cancelSeatPayment();
+      if (result.outcome === "canceled") {
+        toast.success("Pending seat payment canceled.");
+      } else if (result.outcome === "deferred") {
+        toast.error(
+          "Stripe could not confirm cancellation yet. The payment is still pending; try again."
+        );
+      } else if (result.outcome === "paid") {
+        toast.success(
+          "Payment completed before cancellation; the member was added."
+        );
+      } else {
+        toast.error("This seat payment is no longer active.");
+      }
     } catch (error) {
       toast.error(
         error instanceof Error

--- a/mcpjam-inspector/client/src/components/__tests__/OrganizationsTab.billing.test.tsx
+++ b/mcpjam-inspector/client/src/components/__tests__/OrganizationsTab.billing.test.tsx
@@ -415,18 +415,18 @@ describe("OrganizationsTab billing", () => {
           updatedAt: 2,
         },
         finishSeatPayment,
-      }),
+      })
     );
 
     render(<OrganizationsTab organizationId="org-1" section="billing" />);
 
     expect(screen.getByTestId("pending-seat-payment-notice")).toHaveTextContent(
-      "Finish payment to add new@example.com",
+      "Finish payment to add new@example.com"
     );
 
     fireEvent.click(screen.getByRole("button", { name: "Finish payment" }));
     await waitFor(() =>
-      expect(finishSeatPayment).toHaveBeenCalledWith(undefined),
+      expect(finishSeatPayment).toHaveBeenCalledWith(undefined)
     );
   });
 
@@ -443,6 +443,55 @@ describe("OrganizationsTab billing", () => {
     stripeInvoiceId: null,
     createdAt: 1,
     updatedAt: 2,
+  });
+
+  const pendingSeatPaymentIntentFixture = () => ({
+    _id: "seat-payment-pending",
+    organizationId: "org-1",
+    userId: "user-new",
+    email: "new@example.com",
+    role: "member" as const,
+    source: "pending_invite_signup",
+    status: "requires_action" as const,
+    targetSeatQuantity: 4,
+    stripeInvoiceId: "in_123",
+    createdAt: 1,
+    updatedAt: 2,
+  });
+
+  it("does not claim success when Stripe defers seat cancellation", async () => {
+    const cancelSeatPayment = vi.fn().mockResolvedValue({
+      voided: false,
+      outcome: "deferred",
+    });
+    mockUseOrganizationBilling.mockReturnValue(
+      createBillingHookState({
+        billingStatus: billingStatusFixture({
+          plan: "team",
+          effectivePlan: "team",
+          source: "subscription",
+          billingInterval: "monthly",
+          subscriptionStatus: "active",
+          hasCustomer: true,
+          stripePriceId: "price_team_monthly",
+        }),
+        activeSeatPaymentIntent: pendingSeatPaymentIntentFixture(),
+        cancelSeatPayment,
+      })
+    );
+
+    render(<OrganizationsTab organizationId="org-1" section="billing" />);
+    fireEvent.click(screen.getByRole("button", { name: "Cancel" }));
+
+    await waitFor(() =>
+      expect(toast.error).toHaveBeenCalledWith(
+        errorToastMessage(
+          "Stripe could not confirm cancellation yet. The payment is still pending; try again."
+        ),
+        { duration: 8000 }
+      )
+    );
+    expect(toast.success).not.toHaveBeenCalled();
   });
 
   // A charge raised automatically when an invitee signs up fails with nobody
@@ -480,13 +529,13 @@ describe("OrganizationsTab billing", () => {
         },
         finishSeatPayment,
         retrySeatPayment,
-      }),
+      })
     );
 
     render(<OrganizationsTab organizationId="org-1" section="billing" />);
 
     expect(screen.getByTestId("failed-seat-payment-notice")).toHaveTextContent(
-      "stranded@example.com",
+      "stranded@example.com"
     );
 
     fireEvent.click(screen.getByRole("button", { name: "Retry payment" }));
@@ -496,10 +545,44 @@ describe("OrganizationsTab billing", () => {
     expect(finishSeatPayment).not.toHaveBeenCalled();
   });
 
+  it("disables Retry until declined-invoice cleanup is confirmed", () => {
+    const retrySeatPayment = vi.fn();
+    mockUseOrganizationBilling.mockReturnValue(
+      createBillingHookState({
+        billingStatus: billingStatusFixture({
+          plan: "team",
+          effectivePlan: "team",
+          source: "subscription",
+          billingInterval: "monthly",
+          subscriptionStatus: "active",
+          hasCustomer: true,
+          stripePriceId: "price_team_monthly",
+        }),
+        activeSeatPaymentIntent: {
+          ...failedSeatPaymentIntentFixture(),
+          status: "cleanup_pending",
+          stripeInvoiceId: "in_declined",
+        },
+        retrySeatPayment,
+      })
+    );
+
+    render(<OrganizationsTab organizationId="org-1" section="billing" />);
+
+    expect(screen.getByText(/Retry will unlock/)).toBeInTheDocument();
+    const retryButton = screen.getByRole("button", { name: "Retry payment" });
+    expect(retryButton).toBeDisabled();
+    expect(screen.getByRole("button", { name: "Remove invite" })).toBeEnabled();
+    fireEvent.click(retryButton);
+    expect(retrySeatPayment).not.toHaveBeenCalled();
+  });
+
   it("shows an error and no success toast when a retry is rejected", async () => {
     const retrySeatPayment = vi
       .fn()
-      .mockRejectedValue(new Error("Payment failed. The member was not added."));
+      .mockRejectedValue(
+        new Error("Payment failed. The member was not added.")
+      );
     mockUseOrganizationBilling.mockReturnValue(
       createBillingHookState({
         billingStatus: billingStatusFixture({
@@ -513,7 +596,7 @@ describe("OrganizationsTab billing", () => {
         }),
         activeSeatPaymentIntent: failedSeatPaymentIntentFixture(),
         retrySeatPayment,
-      }),
+      })
     );
 
     render(<OrganizationsTab organizationId="org-1" section="billing" />);
@@ -522,8 +605,8 @@ describe("OrganizationsTab billing", () => {
     await waitFor(() =>
       expect(toast.error).toHaveBeenCalledWith(
         errorToastMessage("Payment failed. The member was not added."),
-        { duration: 8000 },
-      ),
+        { duration: 8000 }
+      )
     );
     expect(toast.success).not.toHaveBeenCalled();
   });
@@ -546,7 +629,7 @@ describe("OrganizationsTab billing", () => {
         }),
         activeSeatPaymentIntent: failedSeatPaymentIntentFixture(),
         retrySeatPayment,
-      }),
+      })
     );
 
     render(<OrganizationsTab organizationId="org-1" section="billing" />);
@@ -575,7 +658,7 @@ describe("OrganizationsTab billing", () => {
         }),
         activeSeatPaymentIntent: failedSeatPaymentIntentFixture(),
         isFinishingSeatPayment: true,
-      }),
+      })
     );
 
     render(<OrganizationsTab organizationId="org-1" section="billing" />);
@@ -601,7 +684,7 @@ describe("OrganizationsTab billing", () => {
         }),
         activeSeatPaymentIntent: failedSeatPaymentIntentFixture(),
         cancelSeatPayment,
-      }),
+      })
     );
 
     render(<OrganizationsTab organizationId="org-1" section="billing" />);
@@ -611,7 +694,7 @@ describe("OrganizationsTab billing", () => {
       expect(removeMemberMock).toHaveBeenCalledWith({
         organizationId: "org-1",
         email: "stranded@example.com",
-      }),
+      })
     );
     expect(cancelSeatPayment).not.toHaveBeenCalled();
   });
@@ -626,7 +709,7 @@ describe("OrganizationsTab billing", () => {
       () =>
         new Promise<void>((resolve) => {
           resolveRemoval = () => resolve();
-        }),
+        })
     );
     mockUseOrganizationBilling.mockReturnValue(
       createBillingHookState({
@@ -640,7 +723,7 @@ describe("OrganizationsTab billing", () => {
           stripePriceId: "price_team_monthly",
         }),
         activeSeatPaymentIntent: failedSeatPaymentIntentFixture(),
-      }),
+      })
     );
 
     render(<OrganizationsTab organizationId="org-1" section="billing" />);
@@ -669,7 +752,7 @@ describe("OrganizationsTab billing", () => {
           stripePriceId: "price_team_monthly",
         }),
         activeSeatPaymentIntent: failedSeatPaymentIntentFixture(),
-      }),
+      })
     );
 
     render(<OrganizationsTab organizationId="org-1" section="billing" />);
@@ -1159,7 +1242,7 @@ describe("OrganizationsTab billing", () => {
     });
     expect(toast.error).toHaveBeenCalledWith(
       errorToastMessage(
-        "This organization has reached its member limit (3). Ask an organization owner to upgrade.",
+        "This organization has reached its member limit (3). Ask an organization owner to upgrade."
       ),
       { duration: 8000 }
     );

--- a/mcpjam-inspector/client/src/hooks/__tests__/useOrganizationBilling.seat-retry.test.tsx
+++ b/mcpjam-inspector/client/src/hooks/__tests__/useOrganizationBilling.seat-retry.test.tsx
@@ -10,6 +10,9 @@ const convexFns = vi.hoisted(() => ({
   cancelSeatPayment: vi.fn(),
   completeSeatPayment: vi.fn(),
 }));
+const stripeFns = vi.hoisted(() => ({
+  confirmSeatPaymentWithStripe: vi.fn(),
+}));
 
 const activeSeatPaymentIntent = {
   _id: "seat-payment-1",
@@ -45,20 +48,22 @@ vi.mock("convex/react", () => ({
   },
 }));
 
-vi.mock("@/lib/stripe-elements", () => ({
-  confirmSeatPaymentWithStripe: vi.fn(),
-}));
+vi.mock("@/lib/seat-payment-stripe", () => stripeFns);
 
 import { useOrganizationBilling } from "../useOrganizationBilling";
 
 describe("useOrganizationBilling seat payment retry", () => {
   beforeEach(() => {
     vi.clearAllMocks();
-    convexFns.cancelSeatPayment.mockResolvedValue(undefined);
+    convexFns.cancelSeatPayment.mockResolvedValue({
+      voided: true,
+      outcome: "canceled",
+    });
     convexFns.startSeatPayment.mockResolvedValue({
       status: "paid",
       seatQuantity: 4,
     });
+    stripeFns.confirmSeatPaymentWithStripe.mockResolvedValue(undefined);
   });
 
   it("does not start payment when the charge is cancelled mid-retry", async () => {
@@ -73,9 +78,7 @@ describe("useOrganizationBilling seat payment retry", () => {
         })
     );
 
-    const { result } = renderHook(() =>
-      useOrganizationBilling({ organizationId: "org-1" })
-    );
+    const { result } = renderHook(() => useOrganizationBilling("org-1"));
 
     let retryPromise: Promise<unknown> | undefined;
     act(() => {
@@ -108,9 +111,7 @@ describe("useOrganizationBilling seat payment retry", () => {
       seatPaymentIntentId: "seat-payment-1",
     });
 
-    const { result } = renderHook(() =>
-      useOrganizationBilling({ organizationId: "org-1" })
-    );
+    const { result } = renderHook(() => useOrganizationBilling("org-1"));
 
     await act(async () => {
       await result.current.retrySeatPayment();
@@ -121,15 +122,54 @@ describe("useOrganizationBilling seat payment retry", () => {
     );
   });
 
+  it("returns the backend cancellation outcome", async () => {
+    convexFns.cancelSeatPayment.mockResolvedValue({
+      voided: false,
+      outcome: "deferred",
+    });
+
+    const { result } = renderHook(() => useOrganizationBilling("org-1"));
+
+    await expect(result.current.cancelSeatPayment()).resolves.toEqual({
+      voided: false,
+      outcome: "deferred",
+    });
+  });
+
+  it("marks browser confirmation failures for cleanup before retry", async () => {
+    convexFns.startSeatPayment.mockResolvedValue({
+      status: "requires_action",
+      clientSecret: "cs_declined",
+      publishableKey: "pk_test",
+      stripeInvoiceId: "in_declined",
+      seatQuantity: 4,
+    });
+    stripeFns.confirmSeatPaymentWithStripe.mockRejectedValue(
+      new Error("Your card was declined")
+    );
+
+    const { result } = renderHook(() => useOrganizationBilling("org-1"));
+
+    await act(async () => {
+      await expect(result.current.finishSeatPayment()).rejects.toThrow(
+        "Your card was declined"
+      );
+    });
+    expect(convexFns.cancelSeatPayment).toHaveBeenCalledWith({
+      organizationId: "org-1",
+      seatPaymentIntentId: "seat-payment-1",
+      stripeInvoiceId: "in_declined",
+      terminalStatus: "failed",
+    });
+  });
+
   it("surfaces an error when there is nothing left to retry", async () => {
     convexFns.retrySeatPayment.mockResolvedValue({
       restarted: false,
       seatPaymentIntentId: null,
     });
 
-    const { result } = renderHook(() =>
-      useOrganizationBilling({ organizationId: "org-1" })
-    );
+    const { result } = renderHook(() => useOrganizationBilling("org-1"));
 
     await act(async () => {
       await expect(result.current.retrySeatPayment()).rejects.toThrow(

--- a/mcpjam-inspector/client/src/hooks/useOrganizationBilling.ts
+++ b/mcpjam-inspector/client/src/hooks/useOrganizationBilling.ts
@@ -126,7 +126,12 @@ export interface OrganizationSeatPaymentIntent {
   email: string;
   role: "guest" | "member";
   source: string;
-  status: "pending" | "requires_action" | "failed" | "canceled";
+  status:
+    | "pending"
+    | "requires_action"
+    | "cleanup_pending"
+    | "failed"
+    | "canceled";
   /**
    * The charge ended terminally and the invitee is still waiting. Only ever
    * true for charges raised automatically at signup — when an owner starts one
@@ -144,6 +149,11 @@ export type SeatPaymentResult =
   | { status: "paid"; seatQuantity: number; stripeInvoiceId?: string }
   | { status: "failed"; stripeInvoiceId?: string; reason?: string }
   | { status: "noop"; reason: string };
+
+export type SeatPaymentCancelResult = {
+  voided: boolean;
+  outcome: "canceled" | "deferred" | "paid" | "not_active";
+};
 
 export interface PlanCatalogEntry {
   plan: OrganizationPlan;
@@ -503,6 +513,7 @@ export function useOrganizationBilling(
                 organizationId,
                 seatPaymentIntentId: activeSeatPaymentIntentId,
                 stripeInvoiceId: startResult.stripeInvoiceId,
+                terminalStatus: "failed",
               } as any);
             } catch (cancelError) {
               console.warn(
@@ -612,27 +623,27 @@ export function useOrganizationBilling(
   }, [finishSeatPayment, organizationId, retrySeatPaymentMutation]);
 
   const cancelSeatPayment = useCallback(
-    async (seatPaymentIntentId?: string): Promise<void> => {
+    async (seatPaymentIntentId?: string): Promise<SeatPaymentCancelResult> => {
       if (!organizationId) throw new Error("Organization is required");
       const activeSeatPaymentIntentId =
         seatPaymentIntentId ?? activeSeatPaymentIntent?._id;
       if (!activeSeatPaymentIntentId) {
-        return;
+        return { voided: false, outcome: "not_active" };
       }
       if (seatPaymentCompletionInFlightRef.current) {
-        return;
+        return { voided: false, outcome: "not_active" };
       }
 
       setIsCancelingSeatPayment(true);
       seatPaymentCancelVersionRef.current += 1;
       setError(null);
       try {
-        await cancelSeatPaymentAction({
+        return (await cancelSeatPaymentAction({
           organizationId,
           seatPaymentIntentId: activeSeatPaymentIntentId,
           stripeInvoiceId:
             activeSeatPaymentIntent?.stripeInvoiceId ?? undefined,
-        } as any);
+        } as any)) as SeatPaymentCancelResult;
       } catch (err) {
         const message =
           err instanceof Error ? err.message : "Failed to cancel seat payment";


### PR DESCRIPTION
Follow-up to #4219 and MCPJam/mcpjam-backend#1080.

- Mark browser payment-confirmation failures for backend invoice cleanup.
- Disable Retry while cleanup_pending, while keeping Remove invite available.
- Handle confirmed, deferred, paid, and inactive cancellation outcomes.
- Guard repeated invite-removal clicks and cover removal errors.
- No historical invite backfill.

Validation: 53 tests passed; client typecheck passed.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Blocks seat payment retry until Stripe closes a declined invoice and surfaces precise cancel outcomes in the UI. Previously Retry stayed enabled after a browser confirmation failure; now we mark the intent for cleanup, disable Retry while cleanup is pending, and keep Remove invite available.

- Add a new status cleanup_pending and message in the billing notice; disable Retry (with spinner) while cleanup is pending; keep Remove invite enabled.
- When Stripe confirmation fails in the browser, call cancelSeatPayment with terminalStatus: failed and stripeInvoiceId to trigger backend invoice cleanup before any retry.
- Return a structured SeatPaymentCancelResult from cancelSeatPayment and handle outcomes: canceled (success), deferred (error and no success), paid (success; member added), not_active (error).
- Prevent duplicate cancel/remove actions while an operation is in flight.
- No historical invite backfill; only new failures enter cleanup_pending.

<sup>Written for commit 2b14800a0c8259c88ba2c47aa66c0f03cee97102. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/MCPJam/inspector/pull/4234?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

