### PR TITLE
I1: Extract generic ShareSection from scenario share UI

### DIFF
--- a/mcpjam-inspector/client/src/components/scenarios/ScenarioShareSection.tsx
+++ b/mcpjam-inspector/client/src/components/scenarios/ScenarioShareSection.tsx
@@ -1,8 +1,6 @@
 import { useEffect, useMemo, useState } from "react";
-import { ChevronDown, Clock, Globe, Link2, Lock, Users } from "lucide-react";
 import { useAuth } from "@workos-inc/authkit-react";
 import { useConvexAuth } from "convex/react";
-import { toast } from "@/lib/toast";
 import { useProfilePicture } from "@/hooks/useProfilePicture";
 import {
   type ScenarioMember,
@@ -10,36 +8,31 @@ import {
   useScenarioMutations,
 } from "@/hooks/useScenarios";
 import { buildScenarioLink } from "@/lib/scenario-session";
-import { copyToClipboard } from "@/lib/clipboard";
-import { getInitials } from "@/lib/utils";
 import {
   scenarioAccessPresetFromSettings,
   settingsFromScenarioAccessPreset,
   type ScenarioAccessPreset,
 } from "@/lib/scenario-access-presets";
-import {
-  Avatar,
-  AvatarFallback,
-  AvatarImage,
-} from "@mcpjam/design-system/avatar";
-import { Button } from "@mcpjam/design-system/button";
-import { Input } from "@mcpjam/design-system/input";
-import {
-  DropdownMenu,
-  DropdownMenuContent,
-  DropdownMenuItem,
-  DropdownMenuRadioGroup,
-  DropdownMenuRadioItem,
-  DropdownMenuTrigger,
-} from "@mcpjam/design-system/dropdown-menu";
-
-const INVITE_EMAIL_PATTERN = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+import { ShareSection } from "@/components/sharing/ShareSection";
+import type { ShareMemberView } from "@/components/sharing/share-types";
 
 interface ScenarioShareSectionProps {
   scenario: ScenarioSettings;
   onUpdated?: (scenario: ScenarioSettings) => void;
   /** Shown as the project-wide access option label (e.g. current project name). */
   projectName?: string | null;
+}
+
+function memberView(member: ScenarioMember): ShareMemberView {
+  return {
+    id: member._id,
+    email: member.email,
+    userId: member.userId,
+    revokedAt: member.revokedAt,
+    acceptedAt: member.acceptedAt,
+    role: member.role,
+    user: member.user,
+  };
 }
 
 export function ScenarioShareSection({
@@ -50,21 +43,20 @@ export function ScenarioShareSection({
   const { isAuthenticated } = useConvexAuth();
   const { user } = useAuth();
   const { profilePictureUrl } = useProfilePicture();
-  const { setScenarioMode, upsertScenarioMember, removeScenarioMember } =
-    useScenarioMutations();
+  const {
+    setScenarioMode,
+    upsertScenarioMember,
+    removeScenarioMember,
+    rotateScenarioLink,
+  } = useScenarioMutations();
 
   const [settings, setSettings] = useState<ScenarioSettings>(scenario);
-  const [email, setEmail] = useState("");
-  const [isInviting, setIsInviting] = useState(false);
-  const [isModeBusy, setIsModeBusy] = useState(false);
-  const [isMemberBusy, setIsMemberBusy] = useState(false);
 
   useEffect(() => {
     setSettings(scenario);
   }, [scenario]);
 
   const projectLabel = projectName?.trim() || "Project";
-
   const accessPreset = scenarioAccessPresetFromSettings(
     settings.mode,
     settings.allowGuestAccess,
@@ -72,440 +64,115 @@ export function ScenarioShareSection({
 
   const displayName =
     [user?.firstName, user?.lastName].filter(Boolean).join(" ") || "You";
-  const displayInitials = getInitials(displayName);
   const selfEmailLower = user?.email?.toLowerCase() ?? "";
 
-  const { acceptedInvitees, pendingInvitees } = useMemo(() => {
-    const active = settings.members.filter((m) => !m.revokedAt);
-    const accepted = active.filter((m) => Boolean(m.userId));
-    const pending = active.filter((m) => !m.userId);
-    return { acceptedInvitees: accepted, pendingInvitees: pending };
-  }, [settings.members]);
-
-  const otherAccepted = useMemo(
-    () =>
-      acceptedInvitees.filter((m) => m.email.toLowerCase() !== selfEmailLower),
-    [acceptedInvitees, selfEmailLower],
-  );
-
-  const normalizedEmail = email.trim().toLowerCase();
-  const emailValidationError =
-    normalizedEmail && !INVITE_EMAIL_PATTERN.test(normalizedEmail)
-      ? "Enter a valid email address."
-      : null;
-
-  const updateSettings = (next: ScenarioSettings) => {
-    setSettings(next);
-    onUpdated?.(next);
-  };
-
-  const handleAccessPresetChange = async (preset: ScenarioAccessPreset) => {
-    if (preset === accessPreset) return;
-
-    const target = settingsFromScenarioAccessPreset(preset);
-    setIsModeBusy(true);
-    try {
-      let next = settings;
-      if (target.mode !== settings.mode) {
-        next = (await setScenarioMode({
-          scenarioId: settings.scenarioId,
-          mode: target.mode,
-        })) as ScenarioSettings;
-      }
-      updateSettings(next);
-    } catch (error) {
-      toast.error(
-        error instanceof Error
-          ? error.message
-          : "Failed to update access settings",
-      );
-    } finally {
-      setIsModeBusy(false);
-    }
-  };
-
-  const handleInvite = async () => {
-    if (!normalizedEmail || emailValidationError || unrunnableReason) return;
-
-    setIsInviting(true);
-    try {
-      const next = (await upsertScenarioMember({
-        scenarioId: settings.scenarioId,
-        email: normalizedEmail,
-        sendInviteEmail: true,
-      })) as ScenarioSettings;
-      updateSettings(next);
-      setEmail("");
-      toast.success(`Invited ${normalizedEmail}`);
-    } catch (error) {
-      toast.error(error instanceof Error ? error.message : "Failed to invite");
-    } finally {
-      setIsInviting(false);
-    }
-  };
-
-  const handleRemoveMember = async (member: ScenarioMember) => {
-    setIsMemberBusy(true);
-    try {
-      const next = (await removeScenarioMember({
-        scenarioId: settings.scenarioId,
-        memberIdOrEmail: member.email,
-      })) as ScenarioSettings;
-      updateSettings(next);
-      toast.success(`Removed ${member.email}`);
-    } catch (error) {
-      toast.error(
-        error instanceof Error ? error.message : "Failed to remove member",
-      );
-    } finally {
-      setIsMemberBusy(false);
-    }
-  };
-
-  const accessTriggerSummary = () => {
-    switch (accessPreset) {
-      case "project":
-        return projectLabel;
-      case "invited_only":
-        return "Invited users only";
-      case "link_guests":
-        return "Anyone with the link (guests included)";
-    }
-  };
-
-  const AccessIcon =
-    accessPreset === "project"
-      ? Users
-      : accessPreset === "link_guests"
-        ? Globe
-        : Lock;
-
-  /**
-   * Why this scenario cannot be handed to anyone right now: its environment
-   * doesn't resolve (archived, a pinned plugin disabled, its host gone), so a
-   * tester opening the link would be the one to find out. Read from the
-   * envelope, which every settings-returning mutation carries — and REACTIVE,
-   * so rebinding to a working environment restores the link on the next update.
-   * Nothing is rotated or revoked; the same token is simply withheld while the
-   * scenario can't run.
-   */
   const unrunnableReason = settings.environmentError?.message ?? null;
-
   const shareLink =
     settings.link?.token && !unrunnableReason
       ? buildScenarioLink(settings.link.token, settings.name)
       : null;
   const displayLink = shareLink?.replace(/^https?:\/\//, "") ?? null;
 
-  const handleCopyLink = async () => {
-    if (!shareLink) return;
-    const ok = await copyToClipboard(shareLink);
-    if (ok) toast.success("Link copied");
-    else toast.error("Failed to copy share link");
+  const members = useMemo(
+    () => settings.members.map(memberView),
+    [settings.members],
+  );
+
+  const presets = useMemo(
+    () => [
+      {
+        value: "invited_only",
+        label: "Invited users only",
+        description: "Only people you invite by email can open this scenario.",
+      },
+      {
+        value: "link_guests",
+        label: "Anyone with the link (guests included)",
+        description:
+          "Anyone with the link can open the scenario, including guests without an account.",
+      },
+      {
+        value: "project",
+        label: projectLabel,
+        description:
+          "Signed-in members of this project can open the scenario with the link. Guests cannot.",
+      },
+    ],
+    [projectLabel],
+  );
+
+  const updateSettings = (next: ScenarioSettings) => {
+    setSettings(next);
+    onUpdated?.(next);
   };
 
-  if (!isAuthenticated) {
-    return (
-      <p className="pt-4 text-sm text-muted-foreground">
-        Sign in to manage scenario access.
-      </p>
-    );
-  }
-
   return (
-    <div className="space-y-6">
-      <div className="space-y-2">
-        <label className="text-sm font-medium" htmlFor="scenario-tester-link">
-          Tester link
-        </label>
-        <div className="flex gap-2">
-          {/* `output` rather than a div: the label above needs a LABELABLE
-              control to point at, and this is a read-only value, not an input. */}
-          <output
-            id="scenario-tester-link"
-            className="flex min-w-0 flex-1 items-center rounded-md border border-input bg-muted/30 px-3 py-2"
-            title={shareLink ?? undefined}
-          >
-            <span className="truncate text-sm text-muted-foreground">
-              {displayLink ??
-                (unrunnableReason
-                  ? "Withheld — this scenario can't run."
-                  : "No share link yet.")}
-            </span>
-          </output>
-          <Button
-            type="button"
-            variant="outline"
-            disabled={!shareLink}
-            onClick={() => void handleCopyLink()}
-            data-testid="scenario-copy-tester-link"
-          >
-            <Link2 className="mr-1.5 size-4" />
-            Copy link
-          </Button>
-        </div>
-        {unrunnableReason ? (
-          <p
-            className="text-xs text-muted-foreground"
-            data-testid="scenario-share-unrunnable"
-          >
-            {unrunnableReason} Point this scenario at a working environment to
-            share it again — its link and its sessions are unchanged.
-          </p>
-        ) : null}
-      </div>
-
-      <div className="space-y-2">
-        <label className="text-sm font-medium" htmlFor="scenario-share-email">
-          Invite with email
-        </label>
-        <div className="flex gap-2">
-          <div className="flex flex-1 items-center rounded-md border border-input focus-within:ring-2 focus-within:ring-ring focus-within:ring-offset-2">
-            <Input
-              id="scenario-share-email"
-              type="email"
-              placeholder="Add people, emails..."
-              value={email}
-              // Inviting mails the same link out, so it is gated on the same
-              // condition: an invite to a scenario that can't run is a broken
-              // session with someone else's name on it.
-              disabled={Boolean(unrunnableReason)}
-              onChange={(e) => setEmail(e.target.value)}
-              onKeyDown={(e) => {
-                if (e.key === "Enter") {
-                  e.preventDefault();
-                  void handleInvite();
-                }
-              }}
-              aria-invalid={emailValidationError ? true : undefined}
-              className="flex-1 border-0 focus-visible:ring-0 focus-visible:ring-offset-0"
-            />
-          </div>
-          <Button
-            onClick={() => void handleInvite()}
-            disabled={
-              !normalizedEmail ||
-              !!emailValidationError ||
-              isInviting ||
-              Boolean(unrunnableReason)
-            }
-          >
-            {isInviting ? "..." : "Invite"}
-          </Button>
-        </div>
-        {emailValidationError ? (
-          <p className="text-sm text-destructive">{emailValidationError}</p>
-        ) : null}
-      </div>
-
-      <div className="space-y-2">
-        <label className="text-sm font-medium">Access settings</label>
-        <DropdownMenu>
-          <DropdownMenuTrigger asChild>
-            <button
-              type="button"
-              className="flex w-full items-center gap-2 rounded-md border border-input bg-background px-3 py-2 text-sm transition-colors hover:bg-accent hover:text-accent-foreground disabled:opacity-50"
-              disabled={isModeBusy}
-            >
-              <AccessIcon className="size-4 shrink-0" />
-              <span className="flex-1 text-left">{accessTriggerSummary()}</span>
-              <ChevronDown className="size-4 shrink-0 text-muted-foreground" />
-            </button>
-          </DropdownMenuTrigger>
-          <DropdownMenuContent
-            align="start"
-            className="w-[--radix-dropdown-menu-trigger-width]"
-          >
-            <DropdownMenuRadioGroup
-              value={accessPreset}
-              onValueChange={(v) =>
-                void handleAccessPresetChange(v as ScenarioAccessPreset)
-              }
-            >
-              {/* Ordered by how a scenario is usually shared: a named tester
-                  first, the open link second, the whole project last. */}
-              <DropdownMenuRadioItem
-                value="invited_only"
-                className="items-start"
-              >
-                <div>
-                  <div className="flex items-center gap-2 font-medium">
-                    <Lock className="size-4" />
-                    Invited users only
-                  </div>
-                  <p className="text-xs font-normal text-muted-foreground">
-                    Only people you invite by email can open this scenario.
-                  </p>
-                </div>
-              </DropdownMenuRadioItem>
-              <DropdownMenuRadioItem
-                value="link_guests"
-                className="items-start"
-              >
-                <div>
-                  <div className="flex items-center gap-2 font-medium">
-                    <Globe className="size-4" />
-                    Anyone with the link (guests included)
-                  </div>
-                  <p className="text-xs font-normal text-muted-foreground">
-                    Anyone with the link can open the scenario, including
-                    guests without an account.
-                  </p>
-                </div>
-              </DropdownMenuRadioItem>
-              <DropdownMenuRadioItem value="project" className="items-start">
-                <div>
-                  <div className="flex items-center gap-2 font-medium">
-                    <Users className="size-4" />
-                    {projectLabel}
-                  </div>
-                  <p className="text-xs font-normal text-muted-foreground">
-                    Signed-in members of this project can open the scenario
-                    with the link. Guests cannot.
-                  </p>
-                </div>
-              </DropdownMenuRadioItem>
-            </DropdownMenuRadioGroup>
-          </DropdownMenuContent>
-        </DropdownMenu>
-        {/* Guests run the same environment a member does — computer, skills,
-            harness — on the organization's credits, bounded by the platform
-            daily caps. Say so where the exposure is created rather than
-            burying it in a settings panel. */}
-        {accessPreset === "link_guests" ? (
+    <ShareSection
+      envelope={settings}
+      onUpdated={updateSettings}
+      isAuthenticated={isAuthenticated}
+      displayName={displayName}
+      displayEmail={user?.email}
+      profilePictureUrl={profilePictureUrl}
+      selfEmailLower={selfEmailLower}
+      members={members}
+      shareUrl={shareLink}
+      displayLink={displayLink}
+      currentPreset={accessPreset}
+      presets={presets}
+      disabledReason={unrunnableReason}
+      activeNote={
+        accessPreset === "link_guests" ? (
           <p className="text-xs leading-relaxed text-muted-foreground">
             Guest usage runs on your organization&apos;s credits. Guests are
             people who open the link without being invited.
           </p>
-        ) : null}
-      </div>
-
-      <div className="space-y-2">
-        <label className="text-sm font-medium">Has access</label>
-        <div className="max-h-[300px] space-y-1 overflow-y-auto">
-          <div className="flex items-center gap-3 rounded-md p-2">
-            <Avatar className="size-9">
-              <AvatarImage src={profilePictureUrl} alt={displayName} />
-              <AvatarFallback className="text-sm">
-                {displayInitials}
-              </AvatarFallback>
-            </Avatar>
-            <div className="min-w-0 flex-1">
-              <div className="flex items-center gap-1.5">
-                <p className="truncate text-sm font-medium">{displayName}</p>
-                <span className="text-xs text-muted-foreground">(you)</span>
-              </div>
-              <p className="truncate text-xs text-muted-foreground">
-                {user?.email}
-              </p>
-            </div>
-            <span className="shrink-0 text-sm text-muted-foreground">
-              Owner
-            </span>
-          </div>
-
-          {otherAccepted.map((member) => {
-            const name = member.user?.name || member.email;
-            const initials = getInitials(name);
-            return (
-              <div
-                key={member._id}
-                className="flex items-center gap-3 rounded-md p-2 hover:bg-muted/50"
-              >
-                <Avatar className="size-9">
-                  <AvatarImage
-                    src={member.user?.imageUrl || undefined}
-                    alt={name}
-                  />
-                  <AvatarFallback className="text-sm">
-                    {initials}
-                  </AvatarFallback>
-                </Avatar>
-                <div className="min-w-0 flex-1">
-                  <div className="flex items-center gap-1.5">
-                    <p className="truncate text-sm font-medium">{name}</p>
-                  </div>
-                  <p className="truncate text-xs text-muted-foreground">
-                    {member.email}
-                  </p>
-                </div>
-                <DropdownMenu>
-                  <DropdownMenuTrigger asChild>
-                    <Button
-                      variant="ghost"
-                      size="sm"
-                      className="shrink-0 gap-1 text-sm"
-                      disabled={isMemberBusy}
-                    >
-                      Member
-                      <ChevronDown className="size-3" />
-                    </Button>
-                  </DropdownMenuTrigger>
-                  <DropdownMenuContent align="end">
-                    <DropdownMenuItem
-                      className="text-destructive focus:text-destructive"
-                      onClick={() => void handleRemoveMember(member)}
-                    >
-                      Remove access
-                    </DropdownMenuItem>
-                  </DropdownMenuContent>
-                </DropdownMenu>
-              </div>
-            );
-          })}
-
-          {otherAccepted.length === 0 && pendingInvitees.length === 0 ? (
-            <p className="px-2 py-2 text-sm text-muted-foreground">
-              No one has been invited yet.
-            </p>
-          ) : null}
-        </div>
-      </div>
-
-      {pendingInvitees.length > 0 ? (
-        <div className="space-y-2">
-          <label className="text-sm font-medium">Invited</label>
-          <div className="max-h-[220px] space-y-1 overflow-y-auto">
-            {pendingInvitees.map((member) => (
-              <div
-                key={member._id}
-                className="flex items-center gap-3 rounded-md p-2 hover:bg-muted/50"
-              >
-                <div className="flex size-9 shrink-0 items-center justify-center rounded-full bg-muted">
-                  <Clock className="size-4 text-muted-foreground" />
-                </div>
-                <div className="min-w-0 flex-1">
-                  <p className="truncate text-sm font-medium">{member.email}</p>
-                  <p className="text-xs text-muted-foreground">
-                    Invitation pending — they can access after signing in
-                  </p>
-                </div>
-                <DropdownMenu>
-                  <DropdownMenuTrigger asChild>
-                    <Button
-                      variant="ghost"
-                      size="sm"
-                      className="shrink-0 gap-1 text-sm"
-                      disabled={isMemberBusy}
-                    >
-                      Pending
-                      <ChevronDown className="size-3" />
-                    </Button>
-                  </DropdownMenuTrigger>
-                  <DropdownMenuContent align="end">
-                    <DropdownMenuItem
-                      className="text-destructive focus:text-destructive"
-                      onClick={() => void handleRemoveMember(member)}
-                    >
-                      Cancel invite
-                    </DropdownMenuItem>
-                  </DropdownMenuContent>
-                </DropdownMenu>
-              </div>
-            ))}
-          </div>
-        </div>
-      ) : null}
-    </div>
+        ) : null
+      }
+      copy={{
+        linkLabel: "Tester link",
+        signedOutMessage: "Sign in to manage scenario access.",
+        withheldLabel: "Withheld — this scenario can't run.",
+        rotateConfirmTitle: "Rotate this tester link?",
+        rotateConfirmBody:
+          "Anyone with the old URL will no longer be able to redeem it. Testers who already opened the link keep their access until you remove them.",
+      }}
+      testIds={{
+        copy: "scenario-copy-tester-link",
+        unrunnable: "scenario-share-unrunnable",
+        rotate: "scenario-share-link-menu",
+        rotateConfirm: "scenario-rotate-confirm",
+        email: "scenario-share-email",
+        linkOutput: "scenario-tester-link",
+      }}
+      onSetPreset={async (preset) => {
+        const target = settingsFromScenarioAccessPreset(
+          preset as ScenarioAccessPreset,
+        );
+        if (target.mode === settings.mode) return settings;
+        return (await setScenarioMode({
+          scenarioId: settings.scenarioId,
+          mode: target.mode,
+        })) as ScenarioSettings;
+      }}
+      onInvite={async (email) =>
+        (await upsertScenarioMember({
+          scenarioId: settings.scenarioId,
+          email,
+          sendInviteEmail: true,
+        })) as ScenarioSettings
+      }
+      onRemoveMember={async (member) =>
+        (await removeScenarioMember({
+          scenarioId: settings.scenarioId,
+          memberIdOrEmail: member.email,
+        })) as ScenarioSettings
+      }
+      onRotateLink={async () =>
+        (await rotateScenarioLink({
+          scenarioId: settings.scenarioId,
+        })) as ScenarioSettings
+      }
+    />
   );
 }

--- a/mcpjam-inspector/client/src/components/scenarios/__tests__/ScenarioShareSection.test.tsx
+++ b/mcpjam-inspector/client/src/components/scenarios/__tests__/ScenarioShareSection.test.tsx
@@ -27,6 +27,7 @@ vi.mock("@/hooks/useScenarios", () => ({
     updateScenario: vi.fn(),
     upsertScenarioMember: vi.fn(),
     removeScenarioMember: vi.fn(),
+    rotateScenarioLink: vi.fn(),
   }),
 }));
 
@@ -195,5 +196,10 @@ describe("ScenarioShareSection", () => {
 
     expect(screen.getByText("Invited")).toBeInTheDocument();
     expect(screen.getByText("pending@example.com")).toBeInTheDocument();
+  });
+
+  it("exposes a rotate-link kebab next to copy", () => {
+    render(<ScenarioShareSection scenario={createScenario()} />);
+    expect(screen.getByTestId("scenario-share-link-menu")).toBeInTheDocument();
   });
 });

--- a/mcpjam-inspector/client/src/components/scenarios/__tests__/ScenarioShareSection.test.tsx
+++ b/mcpjam-inspector/client/src/components/scenarios/__tests__/ScenarioShareSection.test.tsx
@@ -1,7 +1,16 @@
 import { render, screen } from "@testing-library/react";
-import { describe, expect, it, vi } from "vitest";
+import userEvent from "@testing-library/user-event";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { ScenarioSettings } from "@/hooks/useScenarios";
 import { ScenarioShareSection } from "../ScenarioShareSection";
+
+const scenarioMutations = vi.hoisted(() => ({
+  setScenarioMode: vi.fn(),
+  updateScenario: vi.fn(),
+  upsertScenarioMember: vi.fn(),
+  removeScenarioMember: vi.fn(),
+  rotateScenarioLink: vi.fn(),
+}));
 
 vi.mock("convex/react", () => ({
   useConvexAuth: () => ({ isAuthenticated: true }),
@@ -22,18 +31,16 @@ vi.mock("@/hooks/useProfilePicture", () => ({
 }));
 
 vi.mock("@/hooks/useScenarios", () => ({
-  useScenarioMutations: () => ({
-    setScenarioMode: vi.fn(),
-    updateScenario: vi.fn(),
-    upsertScenarioMember: vi.fn(),
-    removeScenarioMember: vi.fn(),
-    rotateScenarioLink: vi.fn(),
-  }),
+  useScenarioMutations: () => scenarioMutations,
 }));
 
-vi.mock("sonner", () => ({
-  toast: { success: vi.fn(), error: vi.fn() },
+const toast = vi.hoisted(() => ({
+  success: vi.fn(),
+  error: vi.fn(),
 }));
+
+vi.mock("sonner", () => ({ toast }));
+vi.mock("@/lib/toast", () => ({ toast }));
 
 function createScenario(overrides: Partial<ScenarioSettings> = {}): ScenarioSettings {
   return {
@@ -61,6 +68,10 @@ function createScenario(overrides: Partial<ScenarioSettings> = {}): ScenarioSett
 }
 
 describe("ScenarioShareSection", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
   it("renders the same section structure as the project share dialog", () => {
     render(
       <ScenarioShareSection scenario={createScenario()} projectName="Acme" />,
@@ -201,5 +212,56 @@ describe("ScenarioShareSection", () => {
   it("exposes a rotate-link kebab next to copy", () => {
     render(<ScenarioShareSection scenario={createScenario()} />);
     expect(screen.getByTestId("scenario-share-link-menu")).toBeInTheDocument();
+  });
+
+  it("confirms rotate and calls rotateScenarioLink with the scenario id", async () => {
+    const user = userEvent.setup();
+    const next = createScenario({
+      link: {
+        token: "rotated",
+        path: "/c/rotated",
+        url: "https://example.com/c/rotated",
+        rotatedAt: 2,
+        updatedAt: 2,
+      },
+    });
+    scenarioMutations.rotateScenarioLink.mockResolvedValue(next);
+    const onUpdated = vi.fn();
+
+    render(
+      <ScenarioShareSection
+        scenario={createScenario()}
+        onUpdated={onUpdated}
+      />,
+    );
+
+    await user.click(screen.getByTestId("scenario-share-link-menu"));
+    await user.click(screen.getByTestId("share-rotate-link"));
+    expect(scenarioMutations.rotateScenarioLink).not.toHaveBeenCalled();
+    await user.click(screen.getByTestId("scenario-rotate-confirm"));
+    expect(scenarioMutations.rotateScenarioLink).toHaveBeenCalledWith({
+      scenarioId: "cb-1",
+    });
+    expect(onUpdated).toHaveBeenCalledWith(next);
+    expect(screen.getByLabelText("Tester link")).toHaveTextContent(
+      "/user-testing/my-scenario/rotated",
+    );
+  });
+
+  it("surfaces a rejected rotate mutation", async () => {
+    const user = userEvent.setup();
+    scenarioMutations.rotateScenarioLink.mockRejectedValue(
+      new Error("rotate failed"),
+    );
+
+    render(<ScenarioShareSection scenario={createScenario()} />);
+
+    await user.click(screen.getByTestId("scenario-share-link-menu"));
+    await user.click(screen.getByTestId("share-rotate-link"));
+    await user.click(screen.getByTestId("scenario-rotate-confirm"));
+    expect(scenarioMutations.rotateScenarioLink).toHaveBeenCalledWith({
+      scenarioId: "cb-1",
+    });
+    expect(toast.error).toHaveBeenCalledWith("rotate failed");
   });
 });

--- a/mcpjam-inspector/client/src/components/sharing/ShareDialog.tsx
+++ b/mcpjam-inspector/client/src/components/sharing/ShareDialog.tsx
@@ -1,0 +1,36 @@
+import type { ReactNode } from "react";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+} from "@mcpjam/design-system/dialog";
+
+export function ShareDialog({
+  open,
+  onOpenChange,
+  title,
+  description,
+  children,
+}: {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  title: string;
+  description?: string;
+  children: ReactNode;
+}) {
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="max-h-[85vh] overflow-y-auto sm:max-w-lg">
+        <DialogHeader>
+          <DialogTitle>{title}</DialogTitle>
+          {description ? (
+            <DialogDescription>{description}</DialogDescription>
+          ) : null}
+        </DialogHeader>
+        {children}
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/mcpjam-inspector/client/src/components/sharing/ShareSection.tsx
+++ b/mcpjam-inspector/client/src/components/sharing/ShareSection.tsx
@@ -1,0 +1,562 @@
+import { useMemo, useState, type ReactNode } from "react";
+import {
+  ChevronDown,
+  Clock,
+  Globe,
+  Link2,
+  Lock,
+  MoreHorizontal,
+  Users,
+} from "lucide-react";
+import { toast } from "@/lib/toast";
+import { copyToClipboard } from "@/lib/clipboard";
+import { getInitials } from "@/lib/utils";
+import {
+  Avatar,
+  AvatarFallback,
+  AvatarImage,
+} from "@mcpjam/design-system/avatar";
+import { Button } from "@mcpjam/design-system/button";
+import { Input } from "@mcpjam/design-system/input";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuRadioGroup,
+  DropdownMenuRadioItem,
+  DropdownMenuTrigger,
+} from "@mcpjam/design-system/dropdown-menu";
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from "@mcpjam/design-system/alert-dialog";
+import type {
+  ShareAccessOption,
+  ShareMemberView,
+  ShareSectionCopy,
+} from "./share-types";
+
+const INVITE_EMAIL_PATTERN = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+
+export type ShareSectionProps<TEnvelope> = {
+  envelope: TEnvelope;
+  onUpdated?: (next: TEnvelope) => void;
+  isAuthenticated: boolean;
+  displayName: string;
+  displayEmail?: string;
+  profilePictureUrl?: string | null;
+  selfEmailLower: string;
+  members: ShareMemberView[];
+  shareUrl: string | null;
+  displayLink: string | null;
+  currentPreset: string;
+  presets: readonly ShareAccessOption[];
+  onSetPreset: (preset: string) => Promise<TEnvelope>;
+  onInvite: (email: string) => Promise<TEnvelope>;
+  onRemoveMember: (member: ShareMemberView) => Promise<TEnvelope>;
+  onRotateLink?: () => Promise<TEnvelope>;
+  onRevokeAll?: () => Promise<TEnvelope>;
+  disabledReason?: string | null;
+  footerSlot?: ReactNode;
+  activeNote?: ReactNode;
+  copy: ShareSectionCopy;
+  testIds: {
+    copy: string;
+    unrunnable?: string;
+    rotate?: string;
+    rotateConfirm?: string;
+    email?: string;
+    linkOutput?: string;
+  };
+};
+
+export function ShareSection<TEnvelope>({
+  onUpdated,
+  isAuthenticated,
+  displayName,
+  displayEmail,
+  profilePictureUrl,
+  selfEmailLower,
+  members,
+  shareUrl,
+  displayLink,
+  currentPreset,
+  presets,
+  onSetPreset,
+  onInvite,
+  onRemoveMember,
+  onRotateLink,
+  onRevokeAll,
+  disabledReason,
+  footerSlot,
+  activeNote,
+  copy,
+  testIds,
+}: ShareSectionProps<TEnvelope>) {
+  const [email, setEmail] = useState("");
+  const [isInviting, setIsInviting] = useState(false);
+  const [isModeBusy, setIsModeBusy] = useState(false);
+  const [isMemberBusy, setIsMemberBusy] = useState(false);
+  const [isRotateBusy, setIsRotateBusy] = useState(false);
+  const [rotateOpen, setRotateOpen] = useState(false);
+
+  const { acceptedInvitees, pendingInvitees } = useMemo(() => {
+    const active = members.filter((m) => !m.revokedAt);
+    const accepted = active.filter((m) => Boolean(m.userId));
+    const pending = active.filter((m) => !m.userId);
+    return { acceptedInvitees: accepted, pendingInvitees: pending };
+  }, [members]);
+
+  const otherAccepted = useMemo(
+    () =>
+      acceptedInvitees.filter((m) => m.email.toLowerCase() !== selfEmailLower),
+    [acceptedInvitees, selfEmailLower],
+  );
+
+  const normalizedEmail = email.trim().toLowerCase();
+  const emailValidationError =
+    normalizedEmail && !INVITE_EMAIL_PATTERN.test(normalizedEmail)
+      ? "Enter a valid email address."
+      : null;
+
+  const updateSettings = (next: TEnvelope) => {
+    onUpdated?.(next);
+  };
+
+  const handlePresetChange = async (preset: string) => {
+    if (preset === currentPreset) return;
+    setIsModeBusy(true);
+    try {
+      updateSettings(await onSetPreset(preset));
+    } catch (error) {
+      toast.error(
+        error instanceof Error
+          ? error.message
+          : "Failed to update access settings",
+      );
+    } finally {
+      setIsModeBusy(false);
+    }
+  };
+
+  const handleInvite = async () => {
+    if (!normalizedEmail || emailValidationError || disabledReason) return;
+    setIsInviting(true);
+    try {
+      updateSettings(await onInvite(normalizedEmail));
+      setEmail("");
+      toast.success(`Invited ${normalizedEmail}`);
+    } catch (error) {
+      toast.error(error instanceof Error ? error.message : "Failed to invite");
+    } finally {
+      setIsInviting(false);
+    }
+  };
+
+  const handleRemoveMember = async (member: ShareMemberView) => {
+    setIsMemberBusy(true);
+    try {
+      updateSettings(await onRemoveMember(member));
+      toast.success(`Removed ${member.email}`);
+    } catch (error) {
+      toast.error(
+        error instanceof Error ? error.message : "Failed to remove member",
+      );
+    } finally {
+      setIsMemberBusy(false);
+    }
+  };
+
+  const handleCopyLink = async () => {
+    if (!shareUrl) return;
+    const ok = await copyToClipboard(shareUrl);
+    if (ok) toast.success("Link copied");
+    else toast.error("Failed to copy share link");
+  };
+
+  const handleRotate = async () => {
+    if (!onRotateLink) return;
+    setIsRotateBusy(true);
+    try {
+      updateSettings(await onRotateLink());
+      toast.success("Share link rotated");
+      setRotateOpen(false);
+    } catch (error) {
+      toast.error(
+        error instanceof Error ? error.message : "Failed to rotate link",
+      );
+    } finally {
+      setIsRotateBusy(false);
+    }
+  };
+
+  const handleRevokeAll = async () => {
+    if (!onRevokeAll) return;
+    setIsMemberBusy(true);
+    try {
+      updateSettings(await onRevokeAll());
+      toast.success("All share access revoked");
+    } catch (error) {
+      toast.error(
+        error instanceof Error ? error.message : "Failed to revoke access",
+      );
+    } finally {
+      setIsMemberBusy(false);
+    }
+  };
+
+  const currentOption = presets.find((p) => p.value === currentPreset);
+  const AccessIcon =
+    currentPreset === "project" || currentPreset === "project_members"
+      ? Users
+      : currentPreset === "link_guests" ||
+          currentPreset === "anyone_with_link"
+        ? Globe
+        : Lock;
+
+  if (!isAuthenticated) {
+    return (
+      <p className="pt-4 text-sm text-muted-foreground">
+        {copy.signedOutMessage ?? "Sign in to manage access."}
+      </p>
+    );
+  }
+
+  return (
+    <div className="space-y-6">
+      <div className="space-y-2">
+        <label className="text-sm font-medium" htmlFor={testIds.linkOutput}>
+          {copy.linkLabel}
+        </label>
+        <div className="flex gap-2">
+          <output
+            id={testIds.linkOutput}
+            className="flex min-w-0 flex-1 items-center rounded-md border border-input bg-muted/30 px-3 py-2"
+            title={shareUrl ?? undefined}
+          >
+            <span className="truncate text-sm text-muted-foreground">
+              {displayLink ??
+                (disabledReason
+                  ? (copy.withheldLabel ?? "Withheld — this can't be shared.")
+                  : (copy.emptyLinkLabel ?? "No share link yet."))}
+            </span>
+          </output>
+          <Button
+            type="button"
+            variant="outline"
+            disabled={!shareUrl}
+            onClick={() => void handleCopyLink()}
+            data-testid={testIds.copy}
+          >
+            <Link2 className="mr-1.5 size-4" />
+            Copy link
+          </Button>
+          {onRotateLink ? (
+            <DropdownMenu>
+              <DropdownMenuTrigger asChild>
+                <Button
+                  type="button"
+                  variant="outline"
+                  size="icon"
+                  aria-label="Share link actions"
+                  data-testid={testIds.rotate ?? "share-rotate-menu"}
+                >
+                  <MoreHorizontal className="size-4" />
+                </Button>
+              </DropdownMenuTrigger>
+              <DropdownMenuContent align="end">
+                <DropdownMenuItem
+                  onClick={() => setRotateOpen(true)}
+                  data-testid="share-rotate-link"
+                >
+                  {copy.rotateLabel ?? "Rotate link"}
+                </DropdownMenuItem>
+                {onRevokeAll ? (
+                  <DropdownMenuItem
+                    className="text-destructive focus:text-destructive"
+                    onClick={() => void handleRevokeAll()}
+                    data-testid="share-revoke-all"
+                  >
+                    {copy.revokeAllLabel ?? "Revoke all access"}
+                  </DropdownMenuItem>
+                ) : null}
+              </DropdownMenuContent>
+            </DropdownMenu>
+          ) : null}
+        </div>
+        {disabledReason ? (
+          <p
+            className="text-xs text-muted-foreground"
+            data-testid={testIds.unrunnable}
+          >
+            {disabledReason} Point this at a working environment to share it
+            again — its link and its sessions are unchanged.
+          </p>
+        ) : null}
+      </div>
+
+      <div className="space-y-2">
+        <label className="text-sm font-medium" htmlFor={testIds.email}>
+          {copy.inviteLabel ?? "Invite with email"}
+        </label>
+        <div className="flex gap-2">
+          <div className="flex flex-1 items-center rounded-md border border-input focus-within:ring-2 focus-within:ring-ring focus-within:ring-offset-2">
+            <Input
+              id={testIds.email}
+              type="email"
+              placeholder="Add people, emails..."
+              value={email}
+              disabled={Boolean(disabledReason)}
+              onChange={(e) => setEmail(e.target.value)}
+              onKeyDown={(e) => {
+                if (e.key === "Enter") {
+                  e.preventDefault();
+                  void handleInvite();
+                }
+              }}
+              aria-invalid={emailValidationError ? true : undefined}
+              className="flex-1 border-0 focus-visible:ring-0 focus-visible:ring-offset-0"
+            />
+          </div>
+          <Button
+            onClick={() => void handleInvite()}
+            disabled={
+              !normalizedEmail ||
+              !!emailValidationError ||
+              isInviting ||
+              Boolean(disabledReason)
+            }
+          >
+            {isInviting ? "..." : "Invite"}
+          </Button>
+        </div>
+        {emailValidationError ? (
+          <p className="text-sm text-destructive">{emailValidationError}</p>
+        ) : null}
+      </div>
+
+      <div className="space-y-2">
+        <label className="text-sm font-medium">
+          {copy.accessLabel ?? "Access settings"}
+        </label>
+        <DropdownMenu>
+          <DropdownMenuTrigger asChild>
+            <button
+              type="button"
+              className="flex w-full items-center gap-2 rounded-md border border-input bg-background px-3 py-2 text-sm transition-colors hover:bg-accent hover:text-accent-foreground disabled:opacity-50"
+              disabled={isModeBusy}
+            >
+              <AccessIcon className="size-4 shrink-0" />
+              <span className="flex-1 text-left">
+                {currentOption?.label ?? currentPreset}
+              </span>
+              <ChevronDown className="size-4 shrink-0 text-muted-foreground" />
+            </button>
+          </DropdownMenuTrigger>
+          <DropdownMenuContent
+            align="start"
+            className="w-[--radix-dropdown-menu-trigger-width]"
+          >
+            <DropdownMenuRadioGroup
+              value={currentPreset}
+              onValueChange={(v) => void handlePresetChange(v)}
+            >
+              {presets.map((option) => (
+                <DropdownMenuRadioItem
+                  key={option.value}
+                  value={option.value}
+                  className="items-start"
+                >
+                  <div>
+                    <div className="flex items-center gap-2 font-medium">
+                      {option.value === "project" ||
+                      option.value === "project_members" ? (
+                        <Users className="size-4" />
+                      ) : option.value === "link_guests" ||
+                        option.value === "anyone_with_link" ? (
+                        <Globe className="size-4" />
+                      ) : (
+                        <Lock className="size-4" />
+                      )}
+                      {option.label}
+                    </div>
+                    <p className="text-xs font-normal text-muted-foreground">
+                      {option.description}
+                    </p>
+                  </div>
+                </DropdownMenuRadioItem>
+              ))}
+            </DropdownMenuRadioGroup>
+          </DropdownMenuContent>
+        </DropdownMenu>
+        {activeNote}
+      </div>
+
+      <div className="space-y-2">
+        <label className="text-sm font-medium">
+          {copy.hasAccessLabel ?? "Has access"}
+        </label>
+        <div className="max-h-[300px] space-y-1 overflow-y-auto">
+          <div className="flex items-center gap-3 rounded-md p-2">
+            <Avatar className="size-9">
+              <AvatarImage src={profilePictureUrl ?? undefined} alt={displayName} />
+              <AvatarFallback className="text-sm">
+                {getInitials(displayName)}
+              </AvatarFallback>
+            </Avatar>
+            <div className="min-w-0 flex-1">
+              <div className="flex items-center gap-1.5">
+                <p className="truncate text-sm font-medium">{displayName}</p>
+                <span className="text-xs text-muted-foreground">(you)</span>
+              </div>
+              <p className="truncate text-xs text-muted-foreground">
+                {displayEmail}
+              </p>
+            </div>
+            <span className="shrink-0 text-sm text-muted-foreground">
+              Owner
+            </span>
+          </div>
+
+          {otherAccepted.map((member) => {
+            const name = member.user?.name || member.email;
+            const initials = getInitials(name);
+            return (
+              <div
+                key={member.id}
+                className="flex items-center gap-3 rounded-md p-2 hover:bg-muted/50"
+              >
+                <Avatar className="size-9">
+                  <AvatarImage
+                    src={member.user?.imageUrl || undefined}
+                    alt={name}
+                  />
+                  <AvatarFallback className="text-sm">
+                    {initials}
+                  </AvatarFallback>
+                </Avatar>
+                <div className="min-w-0 flex-1">
+                  <div className="flex items-center gap-1.5">
+                    <p className="truncate text-sm font-medium">{name}</p>
+                  </div>
+                  <p className="truncate text-xs text-muted-foreground">
+                    {member.email}
+                  </p>
+                </div>
+                <DropdownMenu>
+                  <DropdownMenuTrigger asChild>
+                    <Button
+                      variant="ghost"
+                      size="sm"
+                      className="shrink-0 gap-1 text-sm"
+                      disabled={isMemberBusy}
+                    >
+                      Member
+                      <ChevronDown className="size-3" />
+                    </Button>
+                  </DropdownMenuTrigger>
+                  <DropdownMenuContent align="end">
+                    <DropdownMenuItem
+                      className="text-destructive focus:text-destructive"
+                      onClick={() => void handleRemoveMember(member)}
+                    >
+                      Remove access
+                    </DropdownMenuItem>
+                  </DropdownMenuContent>
+                </DropdownMenu>
+              </div>
+            );
+          })}
+
+          {otherAccepted.length === 0 && pendingInvitees.length === 0 ? (
+            <p className="px-2 py-2 text-sm text-muted-foreground">
+              No one has been invited yet.
+            </p>
+          ) : null}
+        </div>
+      </div>
+
+      {pendingInvitees.length > 0 ? (
+        <div className="space-y-2">
+          <label className="text-sm font-medium">
+            {copy.invitedLabel ?? "Invited"}
+          </label>
+          <div className="max-h-[220px] space-y-1 overflow-y-auto">
+            {pendingInvitees.map((member) => (
+              <div
+                key={member.id}
+                className="flex items-center gap-3 rounded-md p-2 hover:bg-muted/50"
+              >
+                <div className="flex size-9 shrink-0 items-center justify-center rounded-full bg-muted">
+                  <Clock className="size-4 text-muted-foreground" />
+                </div>
+                <div className="min-w-0 flex-1">
+                  <p className="truncate text-sm font-medium">{member.email}</p>
+                  <p className="text-xs text-muted-foreground">
+                    Invitation pending — they can access after signing in
+                  </p>
+                </div>
+                <DropdownMenu>
+                  <DropdownMenuTrigger asChild>
+                    <Button
+                      variant="ghost"
+                      size="sm"
+                      className="shrink-0 gap-1 text-sm"
+                      disabled={isMemberBusy}
+                    >
+                      Pending
+                      <ChevronDown className="size-3" />
+                    </Button>
+                  </DropdownMenuTrigger>
+                  <DropdownMenuContent align="end">
+                    <DropdownMenuItem
+                      className="text-destructive focus:text-destructive"
+                      onClick={() => void handleRemoveMember(member)}
+                    >
+                      Cancel invite
+                    </DropdownMenuItem>
+                  </DropdownMenuContent>
+                </DropdownMenu>
+              </div>
+            ))}
+          </div>
+        </div>
+      ) : null}
+
+      {footerSlot}
+
+      <AlertDialog open={rotateOpen} onOpenChange={setRotateOpen}>
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle>
+              {copy.rotateConfirmTitle ?? "Rotate this share link?"}
+            </AlertDialogTitle>
+            <AlertDialogDescription>
+              {copy.rotateConfirmBody ??
+                "Anyone with the old URL will no longer be able to redeem it. People who already opened the link keep their access until you remove them."}
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogCancel disabled={isRotateBusy}>Cancel</AlertDialogCancel>
+            <AlertDialogAction
+              disabled={isRotateBusy}
+              onClick={(event) => {
+                event.preventDefault();
+                void handleRotate();
+              }}
+              data-testid={testIds.rotateConfirm ?? "share-rotate-confirm"}
+            >
+              {isRotateBusy ? "Rotating…" : "Rotate link"}
+            </AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
+    </div>
+  );
+}

--- a/mcpjam-inspector/client/src/components/sharing/ShareSection.tsx
+++ b/mcpjam-inspector/client/src/components/sharing/ShareSection.tsx
@@ -174,7 +174,7 @@ export function ShareSection<TEnvelope>({
   };
 
   const handleCopyLink = async () => {
-    if (!shareUrl) return;
+    if (disabledReason || !shareUrl) return;
     const ok = await copyToClipboard(shareUrl);
     if (ok) toast.success("Link copied");
     else toast.error("Failed to copy share link");
@@ -241,23 +241,23 @@ export function ShareSection<TEnvelope>({
             title={shareUrl ?? undefined}
           >
             <span className="truncate text-sm text-muted-foreground">
-              {displayLink ??
-                (disabledReason
-                  ? (copy.withheldLabel ?? "Withheld — this can't be shared.")
-                  : (copy.emptyLinkLabel ?? "No share link yet."))}
+              {disabledReason
+                ? (copy.withheldLabel ?? "Withheld — this can't be shared.")
+                : (displayLink ??
+                  (copy.emptyLinkLabel ?? "No share link yet."))}
             </span>
           </output>
           <Button
             type="button"
             variant="outline"
-            disabled={!shareUrl}
+            disabled={!shareUrl || Boolean(disabledReason)}
             onClick={() => void handleCopyLink()}
             data-testid={testIds.copy}
           >
             <Link2 className="mr-1.5 size-4" />
             Copy link
           </Button>
-          {onRotateLink ? (
+          {onRotateLink || onRevokeAll ? (
             <DropdownMenu>
               <DropdownMenuTrigger asChild>
                 <Button
@@ -271,12 +271,14 @@ export function ShareSection<TEnvelope>({
                 </Button>
               </DropdownMenuTrigger>
               <DropdownMenuContent align="end">
-                <DropdownMenuItem
-                  onClick={() => setRotateOpen(true)}
-                  data-testid="share-rotate-link"
-                >
-                  {copy.rotateLabel ?? "Rotate link"}
-                </DropdownMenuItem>
+                {onRotateLink ? (
+                  <DropdownMenuItem
+                    onClick={() => setRotateOpen(true)}
+                    data-testid="share-rotate-link"
+                  >
+                    {copy.rotateLabel ?? "Rotate link"}
+                  </DropdownMenuItem>
+                ) : null}
                 {onRevokeAll ? (
                   <DropdownMenuItem
                     className="text-destructive focus:text-destructive"

--- a/mcpjam-inspector/client/src/components/sharing/SharedArtifactPage.tsx
+++ b/mcpjam-inspector/client/src/components/sharing/SharedArtifactPage.tsx
@@ -1,0 +1,39 @@
+import type { ReactNode } from "react";
+
+export const SHARE_LINK_DENIED_MESSAGE =
+  "This share link is invalid or has been revoked.";
+
+/**
+ * Chrome-less shell for redeemed artifact viewers. All denials collapse
+ * to {@link SHARE_LINK_DENIED_MESSAGE}. Token stripping and fetch live
+ * in `useSharedArtifact` (I2).
+ */
+export function SharedArtifactPage({
+  title,
+  loading,
+  error,
+  children,
+}: {
+  title: string;
+  loading?: boolean;
+  error?: string | null;
+  children?: ReactNode;
+}) {
+  return (
+    <div className="min-h-screen bg-background px-6 py-10">
+      <meta name="robots" content="noindex, nofollow" />
+      <div className="mx-auto w-full max-w-3xl space-y-4">
+        <h1 className="text-xl font-semibold">{title}</h1>
+        {loading ? (
+          <p className="text-sm text-muted-foreground">Loading…</p>
+        ) : null}
+        {error ? (
+          <p className="text-sm text-muted-foreground" role="alert">
+            {SHARE_LINK_DENIED_MESSAGE}
+          </p>
+        ) : null}
+        {!loading && !error ? children : null}
+      </div>
+    </div>
+  );
+}

--- a/mcpjam-inspector/client/src/components/sharing/__tests__/ShareDialog.test.tsx
+++ b/mcpjam-inspector/client/src/components/sharing/__tests__/ShareDialog.test.tsx
@@ -1,0 +1,62 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, expect, it, vi } from "vitest";
+import { ShareDialog } from "../ShareDialog";
+
+describe("ShareDialog", () => {
+  it("renders title, description, and children when open", () => {
+    render(
+      <ShareDialog
+        open
+        onOpenChange={vi.fn()}
+        title="Share this run"
+        description="Anyone with the link can view it."
+      >
+        <p>panel body</p>
+      </ShareDialog>,
+    );
+
+    expect(screen.getByRole("dialog")).toBeInTheDocument();
+    expect(screen.getByText("Share this run")).toBeInTheDocument();
+    expect(
+      screen.getByText("Anyone with the link can view it."),
+    ).toBeInTheDocument();
+    expect(screen.getByText("panel body")).toBeInTheDocument();
+  });
+
+  it("omits the description when none is provided", () => {
+    render(
+      <ShareDialog open onOpenChange={vi.fn()} title="Share">
+        <span>child</span>
+      </ShareDialog>,
+    );
+
+    expect(screen.getByText("Share")).toBeInTheDocument();
+    expect(screen.queryByText("Anyone with the link can view it.")).not.toBeInTheDocument();
+  });
+
+  it("is controlled: closed until open is true", async () => {
+    const user = userEvent.setup();
+    const onOpenChange = vi.fn();
+    const { rerender } = render(
+      <ShareDialog open={false} onOpenChange={onOpenChange} title="Share">
+        <span>hidden child</span>
+      </ShareDialog>,
+    );
+
+    expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
+    expect(screen.queryByText("hidden child")).not.toBeInTheDocument();
+
+    rerender(
+      <ShareDialog open onOpenChange={onOpenChange} title="Share">
+        <span>hidden child</span>
+      </ShareDialog>,
+    );
+
+    expect(screen.getByRole("dialog")).toBeInTheDocument();
+    expect(screen.getByText("hidden child")).toBeInTheDocument();
+
+    await user.keyboard("{Escape}");
+    expect(onOpenChange).toHaveBeenCalledWith(false);
+  });
+});

--- a/mcpjam-inspector/client/src/components/sharing/__tests__/ShareSection.test.tsx
+++ b/mcpjam-inspector/client/src/components/sharing/__tests__/ShareSection.test.tsx
@@ -1,16 +1,20 @@
 import { render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { describe, expect, it, vi } from "vitest";
-import { ShareSection } from "../ShareSection";
-import type { ShareSettingsEnvelope } from "../share-types";
+import { ShareSection, type ShareSectionProps } from "../ShareSection";
+import type { ShareMemberView, ShareSettingsEnvelope } from "../share-types";
 
 vi.mock("@/lib/clipboard", () => ({
   copyToClipboard: vi.fn(async () => true),
 }));
 
-vi.mock("sonner", () => ({
-  toast: { success: vi.fn(), error: vi.fn() },
+const toast = vi.hoisted(() => ({
+  success: vi.fn(),
+  error: vi.fn(),
 }));
+
+vi.mock("sonner", () => ({ toast }));
+vi.mock("@/lib/toast", () => ({ toast }));
 
 function envelope(
   overrides: Partial<ShareSettingsEnvelope> = {},
@@ -35,6 +39,30 @@ const presets = [
   },
   { value: "project", label: "Acme", description: "Project members" },
 ] as const;
+
+function renderShare(
+  overrides: Partial<ShareSectionProps<ShareSettingsEnvelope>> = {},
+) {
+  const props: ShareSectionProps<ShareSettingsEnvelope> = {
+    envelope: envelope(),
+    isAuthenticated: true,
+    displayName: "Test User",
+    displayEmail: "test@example.com",
+    selfEmailLower: "test@example.com",
+    members: [],
+    shareUrl: "https://example.com/s/tok",
+    displayLink: "example.com/s/tok",
+    currentPreset: "invited_only",
+    presets,
+    onSetPreset: vi.fn(),
+    onInvite: vi.fn(),
+    onRemoveMember: vi.fn(),
+    copy: { linkLabel: "Share link" },
+    testIds: { copy: "share-copy", linkOutput: "share-link", email: "share-email" },
+    ...overrides,
+  };
+  return render(<ShareSection {...props} />);
+}
 
 describe("ShareSection", () => {
   it("replaces the envelope after a mutation and does not copy on mode change", async () => {
@@ -158,6 +186,90 @@ describe("ShareSection", () => {
     expect(onRotateLink).toHaveBeenCalledTimes(1);
     expect(onUpdated).toHaveBeenCalledWith(
       expect.objectContaining({ policyVersion: 3 }),
+    );
+  });
+
+  it("does not copy a stale URL when sharing is disabled", async () => {
+    const user = userEvent.setup();
+    const { copyToClipboard } = await import("@/lib/clipboard");
+
+    renderShare({
+      disabledReason: "This scenario's environment was archived.",
+      copy: {
+        linkLabel: "Share link",
+        withheldLabel: "Withheld — this scenario can't run.",
+      },
+    });
+
+    expect(screen.getByLabelText("Share link")).toHaveTextContent(
+      "Withheld — this scenario can't run.",
+    );
+    expect(screen.getByTestId("share-copy")).toBeDisabled();
+    await user.click(screen.getByTestId("share-copy"));
+    expect(copyToClipboard).not.toHaveBeenCalled();
+  });
+
+  it("rejects invalid invite emails before calling onInvite", async () => {
+    const user = userEvent.setup();
+    const onInvite = vi.fn();
+
+    renderShare({ onInvite });
+
+    await user.type(screen.getByPlaceholderText("Add people, emails..."), "not-an-email");
+    expect(screen.getByText("Enter a valid email address.")).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Invite", exact: true })).toBeDisabled();
+    await user.click(screen.getByRole("button", { name: "Invite", exact: true }));
+    expect(onInvite).not.toHaveBeenCalled();
+  });
+
+  it("surfaces invite mutation rejection", async () => {
+    const user = userEvent.setup();
+    const onInvite = vi.fn(async () => {
+      throw new Error("invite denied");
+    });
+
+    renderShare({ onInvite });
+
+    await user.type(screen.getByPlaceholderText("Add people, emails..."), "a@b.com");
+    await user.click(screen.getByRole("button", { name: "Invite", exact: true }));
+    expect(onInvite).toHaveBeenCalledWith("a@b.com");
+    expect(toast.error).toHaveBeenCalledWith("invite denied");
+  });
+
+  it("removes an accepted member", async () => {
+    const user = userEvent.setup();
+    const member: ShareMemberView = {
+      id: "m1",
+      email: "member@example.com",
+      userId: "u-2",
+      user: { name: "Member" },
+    };
+    const onRemoveMember = vi.fn(async () => envelope());
+    const onUpdated = vi.fn();
+
+    renderShare({ members: [member], onRemoveMember, onUpdated });
+
+    await user.click(screen.getByRole("button", { name: /Member/i }));
+    await user.click(screen.getByText("Remove access"));
+    expect(onRemoveMember).toHaveBeenCalledWith(member);
+    expect(onUpdated).toHaveBeenCalled();
+  });
+
+  it("exposes revoke-all without requiring rotate", async () => {
+    const user = userEvent.setup();
+    const onRevokeAll = vi.fn(async () =>
+      envelope({ policyVersion: 4, members: [] }),
+    );
+    const onUpdated = vi.fn();
+
+    renderShare({ onRevokeAll, onUpdated });
+
+    expect(screen.queryByTestId("share-rotate-link")).not.toBeInTheDocument();
+    await user.click(screen.getByTestId("share-rotate-menu"));
+    await user.click(screen.getByTestId("share-revoke-all"));
+    expect(onRevokeAll).toHaveBeenCalledTimes(1);
+    expect(onUpdated).toHaveBeenCalledWith(
+      expect.objectContaining({ policyVersion: 4 }),
     );
   });
 });

--- a/mcpjam-inspector/client/src/components/sharing/__tests__/ShareSection.test.tsx
+++ b/mcpjam-inspector/client/src/components/sharing/__tests__/ShareSection.test.tsx
@@ -1,0 +1,163 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, expect, it, vi } from "vitest";
+import { ShareSection } from "../ShareSection";
+import type { ShareSettingsEnvelope } from "../share-types";
+
+vi.mock("@/lib/clipboard", () => ({
+  copyToClipboard: vi.fn(async () => true),
+}));
+
+vi.mock("sonner", () => ({
+  toast: { success: vi.fn(), error: vi.fn() },
+}));
+
+function envelope(
+  overrides: Partial<ShareSettingsEnvelope> = {},
+): ShareSettingsEnvelope {
+  return {
+    resourceType: "scenario",
+    resourceId: "r1",
+    mode: "invited_only",
+    policyVersion: 1,
+    link: { token: "tok" },
+    members: [],
+    ...overrides,
+  };
+}
+
+const presets = [
+  { value: "invited_only", label: "Invited users only", description: "Invitees" },
+  {
+    value: "link_guests",
+    label: "Anyone with the link",
+    description: "Open link",
+  },
+  { value: "project", label: "Acme", description: "Project members" },
+] as const;
+
+describe("ShareSection", () => {
+  it("replaces the envelope after a mutation and does not copy on mode change", async () => {
+    const user = userEvent.setup();
+    const onUpdated = vi.fn();
+    const onSetPreset = vi.fn(async () =>
+      envelope({ mode: "anyone_with_link", policyVersion: 2 }),
+    );
+    const { copyToClipboard } = await import("@/lib/clipboard");
+
+    render(
+      <ShareSection
+        envelope={envelope()}
+        onUpdated={onUpdated}
+        isAuthenticated
+        displayName="Test User"
+        displayEmail="test@example.com"
+        selfEmailLower="test@example.com"
+        members={[]}
+        shareUrl="https://example.com/user-testing/x/tok"
+        displayLink="example.com/user-testing/x/tok"
+        currentPreset="invited_only"
+        presets={presets}
+        onSetPreset={onSetPreset}
+        onInvite={vi.fn()}
+        onRemoveMember={vi.fn()}
+        copy={{ linkLabel: "Share link" }}
+        testIds={{ copy: "share-copy", linkOutput: "share-link" }}
+      />,
+    );
+
+    await user.click(screen.getByRole("button", { name: /Invited users only/i }));
+    await user.click(screen.getByText("Anyone with the link"));
+    expect(onSetPreset).toHaveBeenCalledWith("link_guests");
+    expect(onUpdated).toHaveBeenCalledWith(
+      expect.objectContaining({ policyVersion: 2 }),
+    );
+    expect(copyToClipboard).not.toHaveBeenCalled();
+  });
+
+  it("disables copy and invite when disabledReason is set", () => {
+    render(
+      <ShareSection
+        envelope={envelope()}
+        isAuthenticated
+        displayName="Test User"
+        selfEmailLower="test@example.com"
+        members={[]}
+        shareUrl={null}
+        displayLink={null}
+        currentPreset="invited_only"
+        presets={presets}
+        onSetPreset={vi.fn()}
+        onInvite={vi.fn()}
+        onRemoveMember={vi.fn()}
+        disabledReason="This scenario's environment was archived."
+        copy={{
+          linkLabel: "Tester link",
+          withheldLabel: "Withheld — this scenario can't run.",
+        }}
+        testIds={{
+          copy: "scenario-copy-tester-link",
+          unrunnable: "scenario-share-unrunnable",
+          linkOutput: "scenario-tester-link",
+        }}
+      />,
+    );
+
+    expect(screen.getByLabelText("Tester link")).toHaveTextContent(
+      "Withheld — this scenario can't run.",
+    );
+    expect(screen.getByTestId("scenario-copy-tester-link")).toBeDisabled();
+    expect(screen.getByRole("button", { name: "Invite", exact: true })).toBeDisabled();
+    expect(screen.getByTestId("scenario-share-unrunnable")).toHaveTextContent(
+      "This scenario's environment was archived.",
+    );
+  });
+
+  it("copy does not mutate; rotate asks for confirm then calls rotate", async () => {
+    const user = userEvent.setup();
+    const onRotateLink = vi.fn(async () =>
+      envelope({ link: { token: "new" }, policyVersion: 3 }),
+    );
+    const onUpdated = vi.fn();
+    const { copyToClipboard } = await import("@/lib/clipboard");
+
+    render(
+      <ShareSection
+        envelope={envelope()}
+        onUpdated={onUpdated}
+        isAuthenticated
+        displayName="Test User"
+        selfEmailLower="test@example.com"
+        members={[]}
+        shareUrl="https://example.com/s/tok"
+        displayLink="example.com/s/tok"
+        currentPreset="invited_only"
+        presets={presets}
+        onSetPreset={vi.fn()}
+        onInvite={vi.fn()}
+        onRemoveMember={vi.fn()}
+        onRotateLink={onRotateLink}
+        copy={{ linkLabel: "Share link" }}
+        testIds={{
+          copy: "share-copy",
+          rotate: "share-rotate-menu",
+          rotateConfirm: "share-rotate-confirm",
+          linkOutput: "share-link",
+        }}
+      />,
+    );
+
+    await user.click(screen.getByTestId("share-copy"));
+    expect(copyToClipboard).toHaveBeenCalledWith("https://example.com/s/tok");
+    expect(onRotateLink).not.toHaveBeenCalled();
+
+    await user.click(screen.getByTestId("share-rotate-menu"));
+    await user.click(screen.getByTestId("share-rotate-link"));
+    expect(onRotateLink).not.toHaveBeenCalled();
+    await user.click(screen.getByTestId("share-rotate-confirm"));
+    expect(onRotateLink).toHaveBeenCalledTimes(1);
+    expect(onUpdated).toHaveBeenCalledWith(
+      expect.objectContaining({ policyVersion: 3 }),
+    );
+  });
+});

--- a/mcpjam-inspector/client/src/components/sharing/__tests__/SharedArtifactPage.test.tsx
+++ b/mcpjam-inspector/client/src/components/sharing/__tests__/SharedArtifactPage.test.tsx
@@ -1,0 +1,54 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import {
+  SHARE_LINK_DENIED_MESSAGE,
+  SharedArtifactPage,
+} from "../SharedArtifactPage";
+
+describe("SharedArtifactPage", () => {
+  it("shows loading and hides children", () => {
+    render(
+      <SharedArtifactPage title="Shared run" loading>
+        <p>secret content</p>
+      </SharedArtifactPage>,
+    );
+
+    expect(screen.getByText("Shared run")).toBeInTheDocument();
+    expect(screen.getByText("Loading…")).toBeInTheDocument();
+    expect(screen.queryByText("secret content")).not.toBeInTheDocument();
+  });
+
+  it("collapses any error to the denied message", () => {
+    render(
+      <SharedArtifactPage title="Shared run" error="token expired">
+        <p>secret content</p>
+      </SharedArtifactPage>,
+    );
+
+    expect(screen.getByRole("alert")).toHaveTextContent(
+      SHARE_LINK_DENIED_MESSAGE,
+    );
+    expect(screen.queryByText("token expired")).not.toBeInTheDocument();
+    expect(screen.queryByText("secret content")).not.toBeInTheDocument();
+  });
+
+  it("renders children when not loading and not denied", () => {
+    render(
+      <SharedArtifactPage title="Shared run">
+        <p>artifact body</p>
+      </SharedArtifactPage>,
+    );
+
+    expect(screen.getByText("artifact body")).toBeInTheDocument();
+    expect(screen.queryByText("Loading…")).not.toBeInTheDocument();
+    expect(screen.queryByRole("alert")).not.toBeInTheDocument();
+  });
+
+  it("renders nothing in the body when children are omitted", () => {
+    render(<SharedArtifactPage title="Shared run" />);
+
+    expect(screen.getByText("Shared run")).toBeInTheDocument();
+    expect(screen.queryByText("Loading…")).not.toBeInTheDocument();
+    expect(screen.queryByRole("alert")).not.toBeInTheDocument();
+  });
+});

--- a/mcpjam-inspector/client/src/components/sharing/share-types.ts
+++ b/mcpjam-inspector/client/src/components/sharing/share-types.ts
@@ -26,7 +26,7 @@ export type ShareSettingsEnvelope = {
   workspaceId?: string;
   projectId?: string;
   mode: ShareMode;
-  policyVersion?: number;
+  policyVersion: number;
   inviteEpoch?: number;
   linkGrantEpoch?: number;
   allowGuestAccess?: boolean;

--- a/mcpjam-inspector/client/src/components/sharing/share-types.ts
+++ b/mcpjam-inspector/client/src/components/sharing/share-types.ts
@@ -1,0 +1,65 @@
+export type ShareMode =
+  | "project_members"
+  | "invited_only"
+  | "anyone_with_link";
+
+export type ShareGrantRole = "chat" | "viewer";
+
+export type ShareMemberView = {
+  id: string;
+  email: string;
+  userId?: string | null;
+  revokedAt?: number;
+  acceptedAt?: number;
+  role?: ShareGrantRole;
+  user?: { name?: string | null; imageUrl?: string | null } | null;
+};
+
+/**
+ * Every share mutation resolves to this envelope. `policyVersion` is
+ * present from day one so clients can treat it as the cache epoch.
+ */
+export type ShareSettingsEnvelope = {
+  resourceType?: "scenario" | "conformanceRun" | "evalRun";
+  resourceId: string;
+  organizationId?: string;
+  workspaceId?: string;
+  projectId?: string;
+  mode: ShareMode;
+  policyVersion?: number;
+  inviteEpoch?: number;
+  linkGrantEpoch?: number;
+  allowGuestAccess?: boolean;
+  link: {
+    token: string;
+    path?: string;
+    url?: string;
+    rotatedAt?: number;
+    updatedAt?: number;
+  } | null;
+  linkExpiresAt?: number;
+  artifactGeneration?: number;
+  artifactStatus?: "building" | "ready" | "failed";
+  members: ShareMemberView[];
+};
+
+export type ShareAccessOption = {
+  value: string;
+  label: string;
+  description: string;
+};
+
+export type ShareSectionCopy = {
+  linkLabel: string;
+  inviteLabel?: string;
+  accessLabel?: string;
+  hasAccessLabel?: string;
+  invitedLabel?: string;
+  signedOutMessage?: string;
+  withheldLabel?: string;
+  emptyLinkLabel?: string;
+  rotateLabel?: string;
+  rotateConfirmTitle?: string;
+  rotateConfirmBody?: string;
+  revokeAllLabel?: string;
+};


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Purpose and context

**I1** of the unified shareable-resource layer. Pure inspector refactor against today's backend — no new Convex refs.

Sharing chrome lived only in `ScenarioShareSection`. Conformance still uses a binary toggle; evals have no share UI. This extracts a generic `components/sharing/` so later PRs (I3/I4) can reuse it.

## What landed

- `ShareSection` with adapter props: presets, `disabledReason` (generalizes `environmentError`), `footerSlot`, `activeNote`, `linkLabel`, rotate kebab + confirm dialog, copy-URL-without-toggling.
- `ShareDialog` and `SharedArtifactPage` shells (viewer fetch lands in I2).
- `share-types.ts` includes `ShareSettingsEnvelope` with `policyVersion` from day one.
- `ScenarioShareSection` is a thin wrapper: same export name, props, and test ids (`scenario-copy-tester-link`, `scenario-share-unrunnable`). Rotate is wired to existing `scenarios:rotateScenarioLink`.
- `scenario-access-presets.ts` unchanged.

## Before / after

- **Before:** Rotate mutation existed with zero UI callsites. Copy and mode lived in the scenario-only section.
- **After:** Rotate has a confirm dialog. Mode dropdown is the only exposure change. Copy never mutates.

## Behavior changes & accepted breakage

None versus today's backend. Tester links keep working.

## Rollout

Independent of B1. Safe to merge/deploy anytime. No feature flag.

## Verification

- `ShareSection` tests: envelope replacement + `policyVersion`, `disabledReason`, rotate confirm, copy-without-mutation.
- `ScenarioShareSection.test.tsx` unchanged except rotate-menu mock/assertion — existing structure, guest-credit, withhold, and invited cases still pass.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-8d845b4e-801b-4a36-ad22-ffbb08e0fdd7?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-8d845b4e-801b-4a36-ad22-ffbb08e0fdd7&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Extracts a generic `ShareSection` from the scenario share UI to start the unified shareable-resource layer (I1). Old copy sometimes mutated mode; new copy never mutates, rotate now confirms, and sharing-disabled states withhold the link and disable copying to avoid stale URLs.

- `ScenarioShareSection` now wraps `components/sharing/ShareSection`; export name and test IDs unchanged; rotate is wired to existing scenarios:rotateScenarioLink.
- `ShareSection` adds adapter props (presets, disabledReason, activeNote, footerSlot, linkLabel), provides copy, mode dropdown, and a kebab menu with rotate confirm; link is withheld and Copy is disabled when disabledReason is set; shows an actions menu even when only revoke-all is provided.
- Adds `ShareDialog` and `SharedArtifactPage` shells (viewer fetch lands in I2).
- Introduces `share-types` with `ShareSettingsEnvelope` and a required `policyVersion` for cache epoching.
- Tests cover envelope replacement and `policyVersion`, disabledReason gating and copy-disable, rotate confirm, revoke-all menu, and the `ScenarioShareSection` wrapper.

**Rollout**
- No backend changes or feature flag; safe to merge/deploy anytime.

<sup>Written for commit 9e40d29b160dc551b55c3232f17332d60ca383e1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/MCPJam/inspector/pull/4235?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

