### PR TITLE
I2: Unified share hooks, contract fixture, and share routes

### DIFF
--- a/mcpjam-inspector/client/src/components/scenarios/ScenarioShareSection.tsx
+++ b/mcpjam-inspector/client/src/components/scenarios/ScenarioShareSection.tsx
@@ -1,8 +1,6 @@
 import { useEffect, useMemo, useState } from "react";
-import { ChevronDown, Clock, Globe, Link2, Lock, Users } from "lucide-react";
 import { useAuth } from "@workos-inc/authkit-react";
 import { useConvexAuth } from "convex/react";
-import { toast } from "@/lib/toast";
 import { useProfilePicture } from "@/hooks/useProfilePicture";
 import {
   type ScenarioMember,
@@ -10,36 +8,31 @@ import {
   useScenarioMutations,
 } from "@/hooks/useScenarios";
 import { buildScenarioLink } from "@/lib/scenario-session";
-import { copyToClipboard } from "@/lib/clipboard";
-import { getInitials } from "@/lib/utils";
 import {
   scenarioAccessPresetFromSettings,
   settingsFromScenarioAccessPreset,
   type ScenarioAccessPreset,
 } from "@/lib/scenario-access-presets";
-import {
-  Avatar,
-  AvatarFallback,
-  AvatarImage,
-} from "@mcpjam/design-system/avatar";
-import { Button } from "@mcpjam/design-system/button";
-import { Input } from "@mcpjam/design-system/input";
-import {
-  DropdownMenu,
-  DropdownMenuContent,
-  DropdownMenuItem,
-  DropdownMenuRadioGroup,
-  DropdownMenuRadioItem,
-  DropdownMenuTrigger,
-} from "@mcpjam/design-system/dropdown-menu";
-
-const INVITE_EMAIL_PATTERN = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+import { ShareSection } from "@/components/sharing/ShareSection";
+import type { ShareMemberView } from "@/components/sharing/share-types";
 
 interface ScenarioShareSectionProps {
   scenario: ScenarioSettings;
   onUpdated?: (scenario: ScenarioSettings) => void;
   /** Shown as the project-wide access option label (e.g. current project name). */
   projectName?: string | null;
+}
+
+function memberView(member: ScenarioMember): ShareMemberView {
+  return {
+    id: member._id,
+    email: member.email,
+    userId: member.userId,
+    revokedAt: member.revokedAt,
+    acceptedAt: member.acceptedAt,
+    role: member.role,
+    user: member.user,
+  };
 }
 
 export function ScenarioShareSection({
@@ -50,21 +43,20 @@ export function ScenarioShareSection({
   const { isAuthenticated } = useConvexAuth();
   const { user } = useAuth();
   const { profilePictureUrl } = useProfilePicture();
-  const { setScenarioMode, upsertScenarioMember, removeScenarioMember } =
-    useScenarioMutations();
+  const {
+    setScenarioMode,
+    upsertScenarioMember,
+    removeScenarioMember,
+    rotateScenarioLink,
+  } = useScenarioMutations();
 
   const [settings, setSettings] = useState<ScenarioSettings>(scenario);
-  const [email, setEmail] = useState("");
-  const [isInviting, setIsInviting] = useState(false);
-  const [isModeBusy, setIsModeBusy] = useState(false);
-  const [isMemberBusy, setIsMemberBusy] = useState(false);
 
   useEffect(() => {
     setSettings(scenario);
   }, [scenario]);
 
   const projectLabel = projectName?.trim() || "Project";
-
   const accessPreset = scenarioAccessPresetFromSettings(
     settings.mode,
     settings.allowGuestAccess,
@@ -72,440 +64,115 @@ export function ScenarioShareSection({
 
   const displayName =
     [user?.firstName, user?.lastName].filter(Boolean).join(" ") || "You";
-  const displayInitials = getInitials(displayName);
   const selfEmailLower = user?.email?.toLowerCase() ?? "";
 
-  const { acceptedInvitees, pendingInvitees } = useMemo(() => {
-    const active = settings.members.filter((m) => !m.revokedAt);
-    const accepted = active.filter((m) => Boolean(m.userId));
-    const pending = active.filter((m) => !m.userId);
-    return { acceptedInvitees: accepted, pendingInvitees: pending };
-  }, [settings.members]);
-
-  const otherAccepted = useMemo(
-    () =>
-      acceptedInvitees.filter((m) => m.email.toLowerCase() !== selfEmailLower),
-    [acceptedInvitees, selfEmailLower],
-  );
-
-  const normalizedEmail = email.trim().toLowerCase();
-  const emailValidationError =
-    normalizedEmail && !INVITE_EMAIL_PATTERN.test(normalizedEmail)
-      ? "Enter a valid email address."
-      : null;
-
-  const updateSettings = (next: ScenarioSettings) => {
-    setSettings(next);
-    onUpdated?.(next);
-  };
-
-  const handleAccessPresetChange = async (preset: ScenarioAccessPreset) => {
-    if (preset === accessPreset) return;
-
-    const target = settingsFromScenarioAccessPreset(preset);
-    setIsModeBusy(true);
-    try {
-      let next = settings;
-      if (target.mode !== settings.mode) {
-        next = (await setScenarioMode({
-          scenarioId: settings.scenarioId,
-          mode: target.mode,
-        })) as ScenarioSettings;
-      }
-      updateSettings(next);
-    } catch (error) {
-      toast.error(
-        error instanceof Error
-          ? error.message
-          : "Failed to update access settings",
-      );
-    } finally {
-      setIsModeBusy(false);
-    }
-  };
-
-  const handleInvite = async () => {
-    if (!normalizedEmail || emailValidationError || unrunnableReason) return;
-
-    setIsInviting(true);
-    try {
-      const next = (await upsertScenarioMember({
-        scenarioId: settings.scenarioId,
-        email: normalizedEmail,
-        sendInviteEmail: true,
-      })) as ScenarioSettings;
-      updateSettings(next);
-      setEmail("");
-      toast.success(`Invited ${normalizedEmail}`);
-    } catch (error) {
-      toast.error(error instanceof Error ? error.message : "Failed to invite");
-    } finally {
-      setIsInviting(false);
-    }
-  };
-
-  const handleRemoveMember = async (member: ScenarioMember) => {
-    setIsMemberBusy(true);
-    try {
-      const next = (await removeScenarioMember({
-        scenarioId: settings.scenarioId,
-        memberIdOrEmail: member.email,
-      })) as ScenarioSettings;
-      updateSettings(next);
-      toast.success(`Removed ${member.email}`);
-    } catch (error) {
-      toast.error(
-        error instanceof Error ? error.message : "Failed to remove member",
-      );
-    } finally {
-      setIsMemberBusy(false);
-    }
-  };
-
-  const accessTriggerSummary = () => {
-    switch (accessPreset) {
-      case "project":
-        return projectLabel;
-      case "invited_only":
-        return "Invited users only";
-      case "link_guests":
-        return "Anyone with the link (guests included)";
-    }
-  };
-
-  const AccessIcon =
-    accessPreset === "project"
-      ? Users
-      : accessPreset === "link_guests"
-        ? Globe
-        : Lock;
-
-  /**
-   * Why this scenario cannot be handed to anyone right now: its environment
-   * doesn't resolve (archived, a pinned plugin disabled, its host gone), so a
-   * tester opening the link would be the one to find out. Read from the
-   * envelope, which every settings-returning mutation carries — and REACTIVE,
-   * so rebinding to a working environment restores the link on the next update.
-   * Nothing is rotated or revoked; the same token is simply withheld while the
-   * scenario can't run.
-   */
   const unrunnableReason = settings.environmentError?.message ?? null;
-
   const shareLink =
     settings.link?.token && !unrunnableReason
       ? buildScenarioLink(settings.link.token, settings.name)
       : null;
   const displayLink = shareLink?.replace(/^https?:\/\//, "") ?? null;
 
-  const handleCopyLink = async () => {
-    if (!shareLink) return;
-    const ok = await copyToClipboard(shareLink);
-    if (ok) toast.success("Link copied");
-    else toast.error("Failed to copy share link");
+  const members = useMemo(
+    () => settings.members.map(memberView),
+    [settings.members],
+  );
+
+  const presets = useMemo(
+    () => [
+      {
+        value: "invited_only",
+        label: "Invited users only",
+        description: "Only people you invite by email can open this scenario.",
+      },
+      {
+        value: "link_guests",
+        label: "Anyone with the link (guests included)",
+        description:
+          "Anyone with the link can open the scenario, including guests without an account.",
+      },
+      {
+        value: "project",
+        label: projectLabel,
+        description:
+          "Signed-in members of this project can open the scenario with the link. Guests cannot.",
+      },
+    ],
+    [projectLabel],
+  );
+
+  const updateSettings = (next: ScenarioSettings) => {
+    setSettings(next);
+    onUpdated?.(next);
   };
 
-  if (!isAuthenticated) {
-    return (
-      <p className="pt-4 text-sm text-muted-foreground">
-        Sign in to manage scenario access.
-      </p>
-    );
-  }
-
   return (
-    <div className="space-y-6">
-      <div className="space-y-2">
-        <label className="text-sm font-medium" htmlFor="scenario-tester-link">
-          Tester link
-        </label>
-        <div className="flex gap-2">
-          {/* `output` rather than a div: the label above needs a LABELABLE
-              control to point at, and this is a read-only value, not an input. */}
-          <output
-            id="scenario-tester-link"
-            className="flex min-w-0 flex-1 items-center rounded-md border border-input bg-muted/30 px-3 py-2"
-            title={shareLink ?? undefined}
-          >
-            <span className="truncate text-sm text-muted-foreground">
-              {displayLink ??
-                (unrunnableReason
-                  ? "Withheld — this scenario can't run."
-                  : "No share link yet.")}
-            </span>
-          </output>
-          <Button
-            type="button"
-            variant="outline"
-            disabled={!shareLink}
-            onClick={() => void handleCopyLink()}
-            data-testid="scenario-copy-tester-link"
-          >
-            <Link2 className="mr-1.5 size-4" />
-            Copy link
-          </Button>
-        </div>
-        {unrunnableReason ? (
-          <p
-            className="text-xs text-muted-foreground"
-            data-testid="scenario-share-unrunnable"
-          >
-            {unrunnableReason} Point this scenario at a working environment to
-            share it again — its link and its sessions are unchanged.
-          </p>
-        ) : null}
-      </div>
-
-      <div className="space-y-2">
-        <label className="text-sm font-medium" htmlFor="scenario-share-email">
-          Invite with email
-        </label>
-        <div className="flex gap-2">
-          <div className="flex flex-1 items-center rounded-md border border-input focus-within:ring-2 focus-within:ring-ring focus-within:ring-offset-2">
-            <Input
-              id="scenario-share-email"
-              type="email"
-              placeholder="Add people, emails..."
-              value={email}
-              // Inviting mails the same link out, so it is gated on the same
-              // condition: an invite to a scenario that can't run is a broken
-              // session with someone else's name on it.
-              disabled={Boolean(unrunnableReason)}
-              onChange={(e) => setEmail(e.target.value)}
-              onKeyDown={(e) => {
-                if (e.key === "Enter") {
-                  e.preventDefault();
-                  void handleInvite();
-                }
-              }}
-              aria-invalid={emailValidationError ? true : undefined}
-              className="flex-1 border-0 focus-visible:ring-0 focus-visible:ring-offset-0"
-            />
-          </div>
-          <Button
-            onClick={() => void handleInvite()}
-            disabled={
-              !normalizedEmail ||
-              !!emailValidationError ||
-              isInviting ||
-              Boolean(unrunnableReason)
-            }
-          >
-            {isInviting ? "..." : "Invite"}
-          </Button>
-        </div>
-        {emailValidationError ? (
-          <p className="text-sm text-destructive">{emailValidationError}</p>
-        ) : null}
-      </div>
-
-      <div className="space-y-2">
-        <label className="text-sm font-medium">Access settings</label>
-        <DropdownMenu>
-          <DropdownMenuTrigger asChild>
-            <button
-              type="button"
-              className="flex w-full items-center gap-2 rounded-md border border-input bg-background px-3 py-2 text-sm transition-colors hover:bg-accent hover:text-accent-foreground disabled:opacity-50"
-              disabled={isModeBusy}
-            >
-              <AccessIcon className="size-4 shrink-0" />
-              <span className="flex-1 text-left">{accessTriggerSummary()}</span>
-              <ChevronDown className="size-4 shrink-0 text-muted-foreground" />
-            </button>
-          </DropdownMenuTrigger>
-          <DropdownMenuContent
-            align="start"
-            className="w-[--radix-dropdown-menu-trigger-width]"
-          >
-            <DropdownMenuRadioGroup
-              value={accessPreset}
-              onValueChange={(v) =>
-                void handleAccessPresetChange(v as ScenarioAccessPreset)
-              }
-            >
-              {/* Ordered by how a scenario is usually shared: a named tester
-                  first, the open link second, the whole project last. */}
-              <DropdownMenuRadioItem
-                value="invited_only"
-                className="items-start"
-              >
-                <div>
-                  <div className="flex items-center gap-2 font-medium">
-                    <Lock className="size-4" />
-                    Invited users only
-                  </div>
-                  <p className="text-xs font-normal text-muted-foreground">
-                    Only people you invite by email can open this scenario.
-                  </p>
-                </div>
-              </DropdownMenuRadioItem>
-              <DropdownMenuRadioItem
-                value="link_guests"
-                className="items-start"
-              >
-                <div>
-                  <div className="flex items-center gap-2 font-medium">
-                    <Globe className="size-4" />
-                    Anyone with the link (guests included)
-                  </div>
-                  <p className="text-xs font-normal text-muted-foreground">
-                    Anyone with the link can open the scenario, including
-                    guests without an account.
-                  </p>
-                </div>
-              </DropdownMenuRadioItem>
-              <DropdownMenuRadioItem value="project" className="items-start">
-                <div>
-                  <div className="flex items-center gap-2 font-medium">
-                    <Users className="size-4" />
-                    {projectLabel}
-                  </div>
-                  <p className="text-xs font-normal text-muted-foreground">
-                    Signed-in members of this project can open the scenario
-                    with the link. Guests cannot.
-                  </p>
-                </div>
-              </DropdownMenuRadioItem>
-            </DropdownMenuRadioGroup>
-          </DropdownMenuContent>
-        </DropdownMenu>
-        {/* Guests run the same environment a member does — computer, skills,
-            harness — on the organization's credits, bounded by the platform
-            daily caps. Say so where the exposure is created rather than
-            burying it in a settings panel. */}
-        {accessPreset === "link_guests" ? (
+    <ShareSection
+      envelope={settings}
+      onUpdated={updateSettings}
+      isAuthenticated={isAuthenticated}
+      displayName={displayName}
+      displayEmail={user?.email}
+      profilePictureUrl={profilePictureUrl}
+      selfEmailLower={selfEmailLower}
+      members={members}
+      shareUrl={shareLink}
+      displayLink={displayLink}
+      currentPreset={accessPreset}
+      presets={presets}
+      disabledReason={unrunnableReason}
+      activeNote={
+        accessPreset === "link_guests" ? (
           <p className="text-xs leading-relaxed text-muted-foreground">
             Guest usage runs on your organization&apos;s credits. Guests are
             people who open the link without being invited.
           </p>
-        ) : null}
-      </div>
-
-      <div className="space-y-2">
-        <label className="text-sm font-medium">Has access</label>
-        <div className="max-h-[300px] space-y-1 overflow-y-auto">
-          <div className="flex items-center gap-3 rounded-md p-2">
-            <Avatar className="size-9">
-              <AvatarImage src={profilePictureUrl} alt={displayName} />
-              <AvatarFallback className="text-sm">
-                {displayInitials}
-              </AvatarFallback>
-            </Avatar>
-            <div className="min-w-0 flex-1">
-              <div className="flex items-center gap-1.5">
-                <p className="truncate text-sm font-medium">{displayName}</p>
-                <span className="text-xs text-muted-foreground">(you)</span>
-              </div>
-              <p className="truncate text-xs text-muted-foreground">
-                {user?.email}
-              </p>
-            </div>
-            <span className="shrink-0 text-sm text-muted-foreground">
-              Owner
-            </span>
-          </div>
-
-          {otherAccepted.map((member) => {
-            const name = member.user?.name || member.email;
-            const initials = getInitials(name);
-            return (
-              <div
-                key={member._id}
-                className="flex items-center gap-3 rounded-md p-2 hover:bg-muted/50"
-              >
-                <Avatar className="size-9">
-                  <AvatarImage
-                    src={member.user?.imageUrl || undefined}
-                    alt={name}
-                  />
-                  <AvatarFallback className="text-sm">
-                    {initials}
-                  </AvatarFallback>
-                </Avatar>
-                <div className="min-w-0 flex-1">
-                  <div className="flex items-center gap-1.5">
-                    <p className="truncate text-sm font-medium">{name}</p>
-                  </div>
-                  <p className="truncate text-xs text-muted-foreground">
-                    {member.email}
-                  </p>
-                </div>
-                <DropdownMenu>
-                  <DropdownMenuTrigger asChild>
-                    <Button
-                      variant="ghost"
-                      size="sm"
-                      className="shrink-0 gap-1 text-sm"
-                      disabled={isMemberBusy}
-                    >
-                      Member
-                      <ChevronDown className="size-3" />
-                    </Button>
-                  </DropdownMenuTrigger>
-                  <DropdownMenuContent align="end">
-                    <DropdownMenuItem
-                      className="text-destructive focus:text-destructive"
-                      onClick={() => void handleRemoveMember(member)}
-                    >
-                      Remove access
-                    </DropdownMenuItem>
-                  </DropdownMenuContent>
-                </DropdownMenu>
-              </div>
-            );
-          })}
-
-          {otherAccepted.length === 0 && pendingInvitees.length === 0 ? (
-            <p className="px-2 py-2 text-sm text-muted-foreground">
-              No one has been invited yet.
-            </p>
-          ) : null}
-        </div>
-      </div>
-
-      {pendingInvitees.length > 0 ? (
-        <div className="space-y-2">
-          <label className="text-sm font-medium">Invited</label>
-          <div className="max-h-[220px] space-y-1 overflow-y-auto">
-            {pendingInvitees.map((member) => (
-              <div
-                key={member._id}
-                className="flex items-center gap-3 rounded-md p-2 hover:bg-muted/50"
-              >
-                <div className="flex size-9 shrink-0 items-center justify-center rounded-full bg-muted">
-                  <Clock className="size-4 text-muted-foreground" />
-                </div>
-                <div className="min-w-0 flex-1">
-                  <p className="truncate text-sm font-medium">{member.email}</p>
-                  <p className="text-xs text-muted-foreground">
-                    Invitation pending — they can access after signing in
-                  </p>
-                </div>
-                <DropdownMenu>
-                  <DropdownMenuTrigger asChild>
-                    <Button
-                      variant="ghost"
-                      size="sm"
-                      className="shrink-0 gap-1 text-sm"
-                      disabled={isMemberBusy}
-                    >
-                      Pending
-                      <ChevronDown className="size-3" />
-                    </Button>
-                  </DropdownMenuTrigger>
-                  <DropdownMenuContent align="end">
-                    <DropdownMenuItem
-                      className="text-destructive focus:text-destructive"
-                      onClick={() => void handleRemoveMember(member)}
-                    >
-                      Cancel invite
-                    </DropdownMenuItem>
-                  </DropdownMenuContent>
-                </DropdownMenu>
-              </div>
-            ))}
-          </div>
-        </div>
-      ) : null}
-    </div>
+        ) : null
+      }
+      copy={{
+        linkLabel: "Tester link",
+        signedOutMessage: "Sign in to manage scenario access.",
+        withheldLabel: "Withheld — this scenario can't run.",
+        rotateConfirmTitle: "Rotate this tester link?",
+        rotateConfirmBody:
+          "Anyone with the old URL will no longer be able to redeem it. Testers who already opened the link keep their access until you remove them.",
+      }}
+      testIds={{
+        copy: "scenario-copy-tester-link",
+        unrunnable: "scenario-share-unrunnable",
+        rotate: "scenario-share-link-menu",
+        rotateConfirm: "scenario-rotate-confirm",
+        email: "scenario-share-email",
+        linkOutput: "scenario-tester-link",
+      }}
+      onSetPreset={async (preset) => {
+        const target = settingsFromScenarioAccessPreset(
+          preset as ScenarioAccessPreset,
+        );
+        if (target.mode === settings.mode) return settings;
+        return (await setScenarioMode({
+          scenarioId: settings.scenarioId,
+          mode: target.mode,
+        })) as ScenarioSettings;
+      }}
+      onInvite={async (email) =>
+        (await upsertScenarioMember({
+          scenarioId: settings.scenarioId,
+          email,
+          sendInviteEmail: true,
+        })) as ScenarioSettings
+      }
+      onRemoveMember={async (member) =>
+        (await removeScenarioMember({
+          scenarioId: settings.scenarioId,
+          memberIdOrEmail: member.email,
+        })) as ScenarioSettings
+      }
+      onRotateLink={async () =>
+        (await rotateScenarioLink({
+          scenarioId: settings.scenarioId,
+        })) as ScenarioSettings
+      }
+    />
   );
 }

--- a/mcpjam-inspector/client/src/components/scenarios/__tests__/ScenarioShareSection.test.tsx
+++ b/mcpjam-inspector/client/src/components/scenarios/__tests__/ScenarioShareSection.test.tsx
@@ -27,6 +27,7 @@ vi.mock("@/hooks/useScenarios", () => ({
     updateScenario: vi.fn(),
     upsertScenarioMember: vi.fn(),
     removeScenarioMember: vi.fn(),
+    rotateScenarioLink: vi.fn(),
   }),
 }));
 
@@ -195,5 +196,10 @@ describe("ScenarioShareSection", () => {
 
     expect(screen.getByText("Invited")).toBeInTheDocument();
     expect(screen.getByText("pending@example.com")).toBeInTheDocument();
+  });
+
+  it("exposes a rotate-link kebab next to copy", () => {
+    render(<ScenarioShareSection scenario={createScenario()} />);
+    expect(screen.getByTestId("scenario-share-link-menu")).toBeInTheDocument();
   });
 });

--- a/mcpjam-inspector/client/src/components/scenarios/__tests__/ScenarioShareSection.test.tsx
+++ b/mcpjam-inspector/client/src/components/scenarios/__tests__/ScenarioShareSection.test.tsx
@@ -1,7 +1,16 @@
 import { render, screen } from "@testing-library/react";
-import { describe, expect, it, vi } from "vitest";
+import userEvent from "@testing-library/user-event";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { ScenarioSettings } from "@/hooks/useScenarios";
 import { ScenarioShareSection } from "../ScenarioShareSection";
+
+const scenarioMutations = vi.hoisted(() => ({
+  setScenarioMode: vi.fn(),
+  updateScenario: vi.fn(),
+  upsertScenarioMember: vi.fn(),
+  removeScenarioMember: vi.fn(),
+  rotateScenarioLink: vi.fn(),
+}));
 
 vi.mock("convex/react", () => ({
   useConvexAuth: () => ({ isAuthenticated: true }),
@@ -22,18 +31,16 @@ vi.mock("@/hooks/useProfilePicture", () => ({
 }));
 
 vi.mock("@/hooks/useScenarios", () => ({
-  useScenarioMutations: () => ({
-    setScenarioMode: vi.fn(),
-    updateScenario: vi.fn(),
-    upsertScenarioMember: vi.fn(),
-    removeScenarioMember: vi.fn(),
-    rotateScenarioLink: vi.fn(),
-  }),
+  useScenarioMutations: () => scenarioMutations,
 }));
 
-vi.mock("sonner", () => ({
-  toast: { success: vi.fn(), error: vi.fn() },
+const toast = vi.hoisted(() => ({
+  success: vi.fn(),
+  error: vi.fn(),
 }));
+
+vi.mock("sonner", () => ({ toast }));
+vi.mock("@/lib/toast", () => ({ toast }));
 
 function createScenario(overrides: Partial<ScenarioSettings> = {}): ScenarioSettings {
   return {
@@ -61,6 +68,10 @@ function createScenario(overrides: Partial<ScenarioSettings> = {}): ScenarioSett
 }
 
 describe("ScenarioShareSection", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
   it("renders the same section structure as the project share dialog", () => {
     render(
       <ScenarioShareSection scenario={createScenario()} projectName="Acme" />,
@@ -201,5 +212,56 @@ describe("ScenarioShareSection", () => {
   it("exposes a rotate-link kebab next to copy", () => {
     render(<ScenarioShareSection scenario={createScenario()} />);
     expect(screen.getByTestId("scenario-share-link-menu")).toBeInTheDocument();
+  });
+
+  it("confirms rotate and calls rotateScenarioLink with the scenario id", async () => {
+    const user = userEvent.setup();
+    const next = createScenario({
+      link: {
+        token: "rotated",
+        path: "/c/rotated",
+        url: "https://example.com/c/rotated",
+        rotatedAt: 2,
+        updatedAt: 2,
+      },
+    });
+    scenarioMutations.rotateScenarioLink.mockResolvedValue(next);
+    const onUpdated = vi.fn();
+
+    render(
+      <ScenarioShareSection
+        scenario={createScenario()}
+        onUpdated={onUpdated}
+      />,
+    );
+
+    await user.click(screen.getByTestId("scenario-share-link-menu"));
+    await user.click(screen.getByTestId("share-rotate-link"));
+    expect(scenarioMutations.rotateScenarioLink).not.toHaveBeenCalled();
+    await user.click(screen.getByTestId("scenario-rotate-confirm"));
+    expect(scenarioMutations.rotateScenarioLink).toHaveBeenCalledWith({
+      scenarioId: "cb-1",
+    });
+    expect(onUpdated).toHaveBeenCalledWith(next);
+    expect(screen.getByLabelText("Tester link")).toHaveTextContent(
+      "/user-testing/my-scenario/rotated",
+    );
+  });
+
+  it("surfaces a rejected rotate mutation", async () => {
+    const user = userEvent.setup();
+    scenarioMutations.rotateScenarioLink.mockRejectedValue(
+      new Error("rotate failed"),
+    );
+
+    render(<ScenarioShareSection scenario={createScenario()} />);
+
+    await user.click(screen.getByTestId("scenario-share-link-menu"));
+    await user.click(screen.getByTestId("share-rotate-link"));
+    await user.click(screen.getByTestId("scenario-rotate-confirm"));
+    expect(scenarioMutations.rotateScenarioLink).toHaveBeenCalledWith({
+      scenarioId: "cb-1",
+    });
+    expect(toast.error).toHaveBeenCalledWith("rotate failed");
   });
 });

--- a/mcpjam-inspector/client/src/components/sharing/ShareDialog.tsx
+++ b/mcpjam-inspector/client/src/components/sharing/ShareDialog.tsx
@@ -1,0 +1,36 @@
+import type { ReactNode } from "react";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+} from "@mcpjam/design-system/dialog";
+
+export function ShareDialog({
+  open,
+  onOpenChange,
+  title,
+  description,
+  children,
+}: {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  title: string;
+  description?: string;
+  children: ReactNode;
+}) {
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="max-h-[85vh] overflow-y-auto sm:max-w-lg">
+        <DialogHeader>
+          <DialogTitle>{title}</DialogTitle>
+          {description ? (
+            <DialogDescription>{description}</DialogDescription>
+          ) : null}
+        </DialogHeader>
+        {children}
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/mcpjam-inspector/client/src/components/sharing/ShareSection.tsx
+++ b/mcpjam-inspector/client/src/components/sharing/ShareSection.tsx
@@ -1,0 +1,562 @@
+import { useMemo, useState, type ReactNode } from "react";
+import {
+  ChevronDown,
+  Clock,
+  Globe,
+  Link2,
+  Lock,
+  MoreHorizontal,
+  Users,
+} from "lucide-react";
+import { toast } from "@/lib/toast";
+import { copyToClipboard } from "@/lib/clipboard";
+import { getInitials } from "@/lib/utils";
+import {
+  Avatar,
+  AvatarFallback,
+  AvatarImage,
+} from "@mcpjam/design-system/avatar";
+import { Button } from "@mcpjam/design-system/button";
+import { Input } from "@mcpjam/design-system/input";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuRadioGroup,
+  DropdownMenuRadioItem,
+  DropdownMenuTrigger,
+} from "@mcpjam/design-system/dropdown-menu";
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from "@mcpjam/design-system/alert-dialog";
+import type {
+  ShareAccessOption,
+  ShareMemberView,
+  ShareSectionCopy,
+} from "./share-types";
+
+const INVITE_EMAIL_PATTERN = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+
+export type ShareSectionProps<TEnvelope> = {
+  envelope: TEnvelope;
+  onUpdated?: (next: TEnvelope) => void;
+  isAuthenticated: boolean;
+  displayName: string;
+  displayEmail?: string;
+  profilePictureUrl?: string | null;
+  selfEmailLower: string;
+  members: ShareMemberView[];
+  shareUrl: string | null;
+  displayLink: string | null;
+  currentPreset: string;
+  presets: readonly ShareAccessOption[];
+  onSetPreset: (preset: string) => Promise<TEnvelope>;
+  onInvite: (email: string) => Promise<TEnvelope>;
+  onRemoveMember: (member: ShareMemberView) => Promise<TEnvelope>;
+  onRotateLink?: () => Promise<TEnvelope>;
+  onRevokeAll?: () => Promise<TEnvelope>;
+  disabledReason?: string | null;
+  footerSlot?: ReactNode;
+  activeNote?: ReactNode;
+  copy: ShareSectionCopy;
+  testIds: {
+    copy: string;
+    unrunnable?: string;
+    rotate?: string;
+    rotateConfirm?: string;
+    email?: string;
+    linkOutput?: string;
+  };
+};
+
+export function ShareSection<TEnvelope>({
+  onUpdated,
+  isAuthenticated,
+  displayName,
+  displayEmail,
+  profilePictureUrl,
+  selfEmailLower,
+  members,
+  shareUrl,
+  displayLink,
+  currentPreset,
+  presets,
+  onSetPreset,
+  onInvite,
+  onRemoveMember,
+  onRotateLink,
+  onRevokeAll,
+  disabledReason,
+  footerSlot,
+  activeNote,
+  copy,
+  testIds,
+}: ShareSectionProps<TEnvelope>) {
+  const [email, setEmail] = useState("");
+  const [isInviting, setIsInviting] = useState(false);
+  const [isModeBusy, setIsModeBusy] = useState(false);
+  const [isMemberBusy, setIsMemberBusy] = useState(false);
+  const [isRotateBusy, setIsRotateBusy] = useState(false);
+  const [rotateOpen, setRotateOpen] = useState(false);
+
+  const { acceptedInvitees, pendingInvitees } = useMemo(() => {
+    const active = members.filter((m) => !m.revokedAt);
+    const accepted = active.filter((m) => Boolean(m.userId));
+    const pending = active.filter((m) => !m.userId);
+    return { acceptedInvitees: accepted, pendingInvitees: pending };
+  }, [members]);
+
+  const otherAccepted = useMemo(
+    () =>
+      acceptedInvitees.filter((m) => m.email.toLowerCase() !== selfEmailLower),
+    [acceptedInvitees, selfEmailLower],
+  );
+
+  const normalizedEmail = email.trim().toLowerCase();
+  const emailValidationError =
+    normalizedEmail && !INVITE_EMAIL_PATTERN.test(normalizedEmail)
+      ? "Enter a valid email address."
+      : null;
+
+  const updateSettings = (next: TEnvelope) => {
+    onUpdated?.(next);
+  };
+
+  const handlePresetChange = async (preset: string) => {
+    if (preset === currentPreset) return;
+    setIsModeBusy(true);
+    try {
+      updateSettings(await onSetPreset(preset));
+    } catch (error) {
+      toast.error(
+        error instanceof Error
+          ? error.message
+          : "Failed to update access settings",
+      );
+    } finally {
+      setIsModeBusy(false);
+    }
+  };
+
+  const handleInvite = async () => {
+    if (!normalizedEmail || emailValidationError || disabledReason) return;
+    setIsInviting(true);
+    try {
+      updateSettings(await onInvite(normalizedEmail));
+      setEmail("");
+      toast.success(`Invited ${normalizedEmail}`);
+    } catch (error) {
+      toast.error(error instanceof Error ? error.message : "Failed to invite");
+    } finally {
+      setIsInviting(false);
+    }
+  };
+
+  const handleRemoveMember = async (member: ShareMemberView) => {
+    setIsMemberBusy(true);
+    try {
+      updateSettings(await onRemoveMember(member));
+      toast.success(`Removed ${member.email}`);
+    } catch (error) {
+      toast.error(
+        error instanceof Error ? error.message : "Failed to remove member",
+      );
+    } finally {
+      setIsMemberBusy(false);
+    }
+  };
+
+  const handleCopyLink = async () => {
+    if (!shareUrl) return;
+    const ok = await copyToClipboard(shareUrl);
+    if (ok) toast.success("Link copied");
+    else toast.error("Failed to copy share link");
+  };
+
+  const handleRotate = async () => {
+    if (!onRotateLink) return;
+    setIsRotateBusy(true);
+    try {
+      updateSettings(await onRotateLink());
+      toast.success("Share link rotated");
+      setRotateOpen(false);
+    } catch (error) {
+      toast.error(
+        error instanceof Error ? error.message : "Failed to rotate link",
+      );
+    } finally {
+      setIsRotateBusy(false);
+    }
+  };
+
+  const handleRevokeAll = async () => {
+    if (!onRevokeAll) return;
+    setIsMemberBusy(true);
+    try {
+      updateSettings(await onRevokeAll());
+      toast.success("All share access revoked");
+    } catch (error) {
+      toast.error(
+        error instanceof Error ? error.message : "Failed to revoke access",
+      );
+    } finally {
+      setIsMemberBusy(false);
+    }
+  };
+
+  const currentOption = presets.find((p) => p.value === currentPreset);
+  const AccessIcon =
+    currentPreset === "project" || currentPreset === "project_members"
+      ? Users
+      : currentPreset === "link_guests" ||
+          currentPreset === "anyone_with_link"
+        ? Globe
+        : Lock;
+
+  if (!isAuthenticated) {
+    return (
+      <p className="pt-4 text-sm text-muted-foreground">
+        {copy.signedOutMessage ?? "Sign in to manage access."}
+      </p>
+    );
+  }
+
+  return (
+    <div className="space-y-6">
+      <div className="space-y-2">
+        <label className="text-sm font-medium" htmlFor={testIds.linkOutput}>
+          {copy.linkLabel}
+        </label>
+        <div className="flex gap-2">
+          <output
+            id={testIds.linkOutput}
+            className="flex min-w-0 flex-1 items-center rounded-md border border-input bg-muted/30 px-3 py-2"
+            title={shareUrl ?? undefined}
+          >
+            <span className="truncate text-sm text-muted-foreground">
+              {displayLink ??
+                (disabledReason
+                  ? (copy.withheldLabel ?? "Withheld — this can't be shared.")
+                  : (copy.emptyLinkLabel ?? "No share link yet."))}
+            </span>
+          </output>
+          <Button
+            type="button"
+            variant="outline"
+            disabled={!shareUrl}
+            onClick={() => void handleCopyLink()}
+            data-testid={testIds.copy}
+          >
+            <Link2 className="mr-1.5 size-4" />
+            Copy link
+          </Button>
+          {onRotateLink ? (
+            <DropdownMenu>
+              <DropdownMenuTrigger asChild>
+                <Button
+                  type="button"
+                  variant="outline"
+                  size="icon"
+                  aria-label="Share link actions"
+                  data-testid={testIds.rotate ?? "share-rotate-menu"}
+                >
+                  <MoreHorizontal className="size-4" />
+                </Button>
+              </DropdownMenuTrigger>
+              <DropdownMenuContent align="end">
+                <DropdownMenuItem
+                  onClick={() => setRotateOpen(true)}
+                  data-testid="share-rotate-link"
+                >
+                  {copy.rotateLabel ?? "Rotate link"}
+                </DropdownMenuItem>
+                {onRevokeAll ? (
+                  <DropdownMenuItem
+                    className="text-destructive focus:text-destructive"
+                    onClick={() => void handleRevokeAll()}
+                    data-testid="share-revoke-all"
+                  >
+                    {copy.revokeAllLabel ?? "Revoke all access"}
+                  </DropdownMenuItem>
+                ) : null}
+              </DropdownMenuContent>
+            </DropdownMenu>
+          ) : null}
+        </div>
+        {disabledReason ? (
+          <p
+            className="text-xs text-muted-foreground"
+            data-testid={testIds.unrunnable}
+          >
+            {disabledReason} Point this at a working environment to share it
+            again — its link and its sessions are unchanged.
+          </p>
+        ) : null}
+      </div>
+
+      <div className="space-y-2">
+        <label className="text-sm font-medium" htmlFor={testIds.email}>
+          {copy.inviteLabel ?? "Invite with email"}
+        </label>
+        <div className="flex gap-2">
+          <div className="flex flex-1 items-center rounded-md border border-input focus-within:ring-2 focus-within:ring-ring focus-within:ring-offset-2">
+            <Input
+              id={testIds.email}
+              type="email"
+              placeholder="Add people, emails..."
+              value={email}
+              disabled={Boolean(disabledReason)}
+              onChange={(e) => setEmail(e.target.value)}
+              onKeyDown={(e) => {
+                if (e.key === "Enter") {
+                  e.preventDefault();
+                  void handleInvite();
+                }
+              }}
+              aria-invalid={emailValidationError ? true : undefined}
+              className="flex-1 border-0 focus-visible:ring-0 focus-visible:ring-offset-0"
+            />
+          </div>
+          <Button
+            onClick={() => void handleInvite()}
+            disabled={
+              !normalizedEmail ||
+              !!emailValidationError ||
+              isInviting ||
+              Boolean(disabledReason)
+            }
+          >
+            {isInviting ? "..." : "Invite"}
+          </Button>
+        </div>
+        {emailValidationError ? (
+          <p className="text-sm text-destructive">{emailValidationError}</p>
+        ) : null}
+      </div>
+
+      <div className="space-y-2">
+        <label className="text-sm font-medium">
+          {copy.accessLabel ?? "Access settings"}
+        </label>
+        <DropdownMenu>
+          <DropdownMenuTrigger asChild>
+            <button
+              type="button"
+              className="flex w-full items-center gap-2 rounded-md border border-input bg-background px-3 py-2 text-sm transition-colors hover:bg-accent hover:text-accent-foreground disabled:opacity-50"
+              disabled={isModeBusy}
+            >
+              <AccessIcon className="size-4 shrink-0" />
+              <span className="flex-1 text-left">
+                {currentOption?.label ?? currentPreset}
+              </span>
+              <ChevronDown className="size-4 shrink-0 text-muted-foreground" />
+            </button>
+          </DropdownMenuTrigger>
+          <DropdownMenuContent
+            align="start"
+            className="w-[--radix-dropdown-menu-trigger-width]"
+          >
+            <DropdownMenuRadioGroup
+              value={currentPreset}
+              onValueChange={(v) => void handlePresetChange(v)}
+            >
+              {presets.map((option) => (
+                <DropdownMenuRadioItem
+                  key={option.value}
+                  value={option.value}
+                  className="items-start"
+                >
+                  <div>
+                    <div className="flex items-center gap-2 font-medium">
+                      {option.value === "project" ||
+                      option.value === "project_members" ? (
+                        <Users className="size-4" />
+                      ) : option.value === "link_guests" ||
+                        option.value === "anyone_with_link" ? (
+                        <Globe className="size-4" />
+                      ) : (
+                        <Lock className="size-4" />
+                      )}
+                      {option.label}
+                    </div>
+                    <p className="text-xs font-normal text-muted-foreground">
+                      {option.description}
+                    </p>
+                  </div>
+                </DropdownMenuRadioItem>
+              ))}
+            </DropdownMenuRadioGroup>
+          </DropdownMenuContent>
+        </DropdownMenu>
+        {activeNote}
+      </div>
+
+      <div className="space-y-2">
+        <label className="text-sm font-medium">
+          {copy.hasAccessLabel ?? "Has access"}
+        </label>
+        <div className="max-h-[300px] space-y-1 overflow-y-auto">
+          <div className="flex items-center gap-3 rounded-md p-2">
+            <Avatar className="size-9">
+              <AvatarImage src={profilePictureUrl ?? undefined} alt={displayName} />
+              <AvatarFallback className="text-sm">
+                {getInitials(displayName)}
+              </AvatarFallback>
+            </Avatar>
+            <div className="min-w-0 flex-1">
+              <div className="flex items-center gap-1.5">
+                <p className="truncate text-sm font-medium">{displayName}</p>
+                <span className="text-xs text-muted-foreground">(you)</span>
+              </div>
+              <p className="truncate text-xs text-muted-foreground">
+                {displayEmail}
+              </p>
+            </div>
+            <span className="shrink-0 text-sm text-muted-foreground">
+              Owner
+            </span>
+          </div>
+
+          {otherAccepted.map((member) => {
+            const name = member.user?.name || member.email;
+            const initials = getInitials(name);
+            return (
+              <div
+                key={member.id}
+                className="flex items-center gap-3 rounded-md p-2 hover:bg-muted/50"
+              >
+                <Avatar className="size-9">
+                  <AvatarImage
+                    src={member.user?.imageUrl || undefined}
+                    alt={name}
+                  />
+                  <AvatarFallback className="text-sm">
+                    {initials}
+                  </AvatarFallback>
+                </Avatar>
+                <div className="min-w-0 flex-1">
+                  <div className="flex items-center gap-1.5">
+                    <p className="truncate text-sm font-medium">{name}</p>
+                  </div>
+                  <p className="truncate text-xs text-muted-foreground">
+                    {member.email}
+                  </p>
+                </div>
+                <DropdownMenu>
+                  <DropdownMenuTrigger asChild>
+                    <Button
+                      variant="ghost"
+                      size="sm"
+                      className="shrink-0 gap-1 text-sm"
+                      disabled={isMemberBusy}
+                    >
+                      Member
+                      <ChevronDown className="size-3" />
+                    </Button>
+                  </DropdownMenuTrigger>
+                  <DropdownMenuContent align="end">
+                    <DropdownMenuItem
+                      className="text-destructive focus:text-destructive"
+                      onClick={() => void handleRemoveMember(member)}
+                    >
+                      Remove access
+                    </DropdownMenuItem>
+                  </DropdownMenuContent>
+                </DropdownMenu>
+              </div>
+            );
+          })}
+
+          {otherAccepted.length === 0 && pendingInvitees.length === 0 ? (
+            <p className="px-2 py-2 text-sm text-muted-foreground">
+              No one has been invited yet.
+            </p>
+          ) : null}
+        </div>
+      </div>
+
+      {pendingInvitees.length > 0 ? (
+        <div className="space-y-2">
+          <label className="text-sm font-medium">
+            {copy.invitedLabel ?? "Invited"}
+          </label>
+          <div className="max-h-[220px] space-y-1 overflow-y-auto">
+            {pendingInvitees.map((member) => (
+              <div
+                key={member.id}
+                className="flex items-center gap-3 rounded-md p-2 hover:bg-muted/50"
+              >
+                <div className="flex size-9 shrink-0 items-center justify-center rounded-full bg-muted">
+                  <Clock className="size-4 text-muted-foreground" />
+                </div>
+                <div className="min-w-0 flex-1">
+                  <p className="truncate text-sm font-medium">{member.email}</p>
+                  <p className="text-xs text-muted-foreground">
+                    Invitation pending — they can access after signing in
+                  </p>
+                </div>
+                <DropdownMenu>
+                  <DropdownMenuTrigger asChild>
+                    <Button
+                      variant="ghost"
+                      size="sm"
+                      className="shrink-0 gap-1 text-sm"
+                      disabled={isMemberBusy}
+                    >
+                      Pending
+                      <ChevronDown className="size-3" />
+                    </Button>
+                  </DropdownMenuTrigger>
+                  <DropdownMenuContent align="end">
+                    <DropdownMenuItem
+                      className="text-destructive focus:text-destructive"
+                      onClick={() => void handleRemoveMember(member)}
+                    >
+                      Cancel invite
+                    </DropdownMenuItem>
+                  </DropdownMenuContent>
+                </DropdownMenu>
+              </div>
+            ))}
+          </div>
+        </div>
+      ) : null}
+
+      {footerSlot}
+
+      <AlertDialog open={rotateOpen} onOpenChange={setRotateOpen}>
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle>
+              {copy.rotateConfirmTitle ?? "Rotate this share link?"}
+            </AlertDialogTitle>
+            <AlertDialogDescription>
+              {copy.rotateConfirmBody ??
+                "Anyone with the old URL will no longer be able to redeem it. People who already opened the link keep their access until you remove them."}
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogCancel disabled={isRotateBusy}>Cancel</AlertDialogCancel>
+            <AlertDialogAction
+              disabled={isRotateBusy}
+              onClick={(event) => {
+                event.preventDefault();
+                void handleRotate();
+              }}
+              data-testid={testIds.rotateConfirm ?? "share-rotate-confirm"}
+            >
+              {isRotateBusy ? "Rotating…" : "Rotate link"}
+            </AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
+    </div>
+  );
+}

--- a/mcpjam-inspector/client/src/components/sharing/ShareSection.tsx
+++ b/mcpjam-inspector/client/src/components/sharing/ShareSection.tsx
@@ -174,7 +174,7 @@ export function ShareSection<TEnvelope>({
   };
 
   const handleCopyLink = async () => {
-    if (!shareUrl) return;
+    if (disabledReason || !shareUrl) return;
     const ok = await copyToClipboard(shareUrl);
     if (ok) toast.success("Link copied");
     else toast.error("Failed to copy share link");
@@ -241,23 +241,23 @@ export function ShareSection<TEnvelope>({
             title={shareUrl ?? undefined}
           >
             <span className="truncate text-sm text-muted-foreground">
-              {displayLink ??
-                (disabledReason
-                  ? (copy.withheldLabel ?? "Withheld — this can't be shared.")
-                  : (copy.emptyLinkLabel ?? "No share link yet."))}
+              {disabledReason
+                ? (copy.withheldLabel ?? "Withheld — this can't be shared.")
+                : (displayLink ??
+                  (copy.emptyLinkLabel ?? "No share link yet."))}
             </span>
           </output>
           <Button
             type="button"
             variant="outline"
-            disabled={!shareUrl}
+            disabled={!shareUrl || Boolean(disabledReason)}
             onClick={() => void handleCopyLink()}
             data-testid={testIds.copy}
           >
             <Link2 className="mr-1.5 size-4" />
             Copy link
           </Button>
-          {onRotateLink ? (
+          {onRotateLink || onRevokeAll ? (
             <DropdownMenu>
               <DropdownMenuTrigger asChild>
                 <Button
@@ -271,12 +271,14 @@ export function ShareSection<TEnvelope>({
                 </Button>
               </DropdownMenuTrigger>
               <DropdownMenuContent align="end">
-                <DropdownMenuItem
-                  onClick={() => setRotateOpen(true)}
-                  data-testid="share-rotate-link"
-                >
-                  {copy.rotateLabel ?? "Rotate link"}
-                </DropdownMenuItem>
+                {onRotateLink ? (
+                  <DropdownMenuItem
+                    onClick={() => setRotateOpen(true)}
+                    data-testid="share-rotate-link"
+                  >
+                    {copy.rotateLabel ?? "Rotate link"}
+                  </DropdownMenuItem>
+                ) : null}
                 {onRevokeAll ? (
                   <DropdownMenuItem
                     className="text-destructive focus:text-destructive"

--- a/mcpjam-inspector/client/src/components/sharing/SharedArtifactPage.tsx
+++ b/mcpjam-inspector/client/src/components/sharing/SharedArtifactPage.tsx
@@ -1,0 +1,39 @@
+import type { ReactNode } from "react";
+
+export const SHARE_LINK_DENIED_MESSAGE =
+  "This share link is invalid or has been revoked.";
+
+/**
+ * Chrome-less shell for redeemed artifact viewers. All denials collapse
+ * to {@link SHARE_LINK_DENIED_MESSAGE}. Token stripping and fetch live
+ * in `useSharedArtifact` (I2).
+ */
+export function SharedArtifactPage({
+  title,
+  loading,
+  error,
+  children,
+}: {
+  title: string;
+  loading?: boolean;
+  error?: string | null;
+  children?: ReactNode;
+}) {
+  return (
+    <div className="min-h-screen bg-background px-6 py-10">
+      <meta name="robots" content="noindex, nofollow" />
+      <div className="mx-auto w-full max-w-3xl space-y-4">
+        <h1 className="text-xl font-semibold">{title}</h1>
+        {loading ? (
+          <p className="text-sm text-muted-foreground">Loading…</p>
+        ) : null}
+        {error ? (
+          <p className="text-sm text-muted-foreground" role="alert">
+            {SHARE_LINK_DENIED_MESSAGE}
+          </p>
+        ) : null}
+        {!loading && !error ? children : null}
+      </div>
+    </div>
+  );
+}

--- a/mcpjam-inspector/client/src/components/sharing/__tests__/ShareDialog.test.tsx
+++ b/mcpjam-inspector/client/src/components/sharing/__tests__/ShareDialog.test.tsx
@@ -1,0 +1,62 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, expect, it, vi } from "vitest";
+import { ShareDialog } from "../ShareDialog";
+
+describe("ShareDialog", () => {
+  it("renders title, description, and children when open", () => {
+    render(
+      <ShareDialog
+        open
+        onOpenChange={vi.fn()}
+        title="Share this run"
+        description="Anyone with the link can view it."
+      >
+        <p>panel body</p>
+      </ShareDialog>,
+    );
+
+    expect(screen.getByRole("dialog")).toBeInTheDocument();
+    expect(screen.getByText("Share this run")).toBeInTheDocument();
+    expect(
+      screen.getByText("Anyone with the link can view it."),
+    ).toBeInTheDocument();
+    expect(screen.getByText("panel body")).toBeInTheDocument();
+  });
+
+  it("omits the description when none is provided", () => {
+    render(
+      <ShareDialog open onOpenChange={vi.fn()} title="Share">
+        <span>child</span>
+      </ShareDialog>,
+    );
+
+    expect(screen.getByText("Share")).toBeInTheDocument();
+    expect(screen.queryByText("Anyone with the link can view it.")).not.toBeInTheDocument();
+  });
+
+  it("is controlled: closed until open is true", async () => {
+    const user = userEvent.setup();
+    const onOpenChange = vi.fn();
+    const { rerender } = render(
+      <ShareDialog open={false} onOpenChange={onOpenChange} title="Share">
+        <span>hidden child</span>
+      </ShareDialog>,
+    );
+
+    expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
+    expect(screen.queryByText("hidden child")).not.toBeInTheDocument();
+
+    rerender(
+      <ShareDialog open onOpenChange={onOpenChange} title="Share">
+        <span>hidden child</span>
+      </ShareDialog>,
+    );
+
+    expect(screen.getByRole("dialog")).toBeInTheDocument();
+    expect(screen.getByText("hidden child")).toBeInTheDocument();
+
+    await user.keyboard("{Escape}");
+    expect(onOpenChange).toHaveBeenCalledWith(false);
+  });
+});

--- a/mcpjam-inspector/client/src/components/sharing/__tests__/ShareSection.test.tsx
+++ b/mcpjam-inspector/client/src/components/sharing/__tests__/ShareSection.test.tsx
@@ -1,16 +1,20 @@
 import { render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { describe, expect, it, vi } from "vitest";
-import { ShareSection } from "../ShareSection";
-import type { ShareSettingsEnvelope } from "../share-types";
+import { ShareSection, type ShareSectionProps } from "../ShareSection";
+import type { ShareMemberView, ShareSettingsEnvelope } from "../share-types";
 
 vi.mock("@/lib/clipboard", () => ({
   copyToClipboard: vi.fn(async () => true),
 }));
 
-vi.mock("sonner", () => ({
-  toast: { success: vi.fn(), error: vi.fn() },
+const toast = vi.hoisted(() => ({
+  success: vi.fn(),
+  error: vi.fn(),
 }));
+
+vi.mock("sonner", () => ({ toast }));
+vi.mock("@/lib/toast", () => ({ toast }));
 
 function envelope(
   overrides: Partial<ShareSettingsEnvelope> = {},
@@ -35,6 +39,30 @@ const presets = [
   },
   { value: "project", label: "Acme", description: "Project members" },
 ] as const;
+
+function renderShare(
+  overrides: Partial<ShareSectionProps<ShareSettingsEnvelope>> = {},
+) {
+  const props: ShareSectionProps<ShareSettingsEnvelope> = {
+    envelope: envelope(),
+    isAuthenticated: true,
+    displayName: "Test User",
+    displayEmail: "test@example.com",
+    selfEmailLower: "test@example.com",
+    members: [],
+    shareUrl: "https://example.com/s/tok",
+    displayLink: "example.com/s/tok",
+    currentPreset: "invited_only",
+    presets,
+    onSetPreset: vi.fn(),
+    onInvite: vi.fn(),
+    onRemoveMember: vi.fn(),
+    copy: { linkLabel: "Share link" },
+    testIds: { copy: "share-copy", linkOutput: "share-link", email: "share-email" },
+    ...overrides,
+  };
+  return render(<ShareSection {...props} />);
+}
 
 describe("ShareSection", () => {
   it("replaces the envelope after a mutation and does not copy on mode change", async () => {
@@ -158,6 +186,90 @@ describe("ShareSection", () => {
     expect(onRotateLink).toHaveBeenCalledTimes(1);
     expect(onUpdated).toHaveBeenCalledWith(
       expect.objectContaining({ policyVersion: 3 }),
+    );
+  });
+
+  it("does not copy a stale URL when sharing is disabled", async () => {
+    const user = userEvent.setup();
+    const { copyToClipboard } = await import("@/lib/clipboard");
+
+    renderShare({
+      disabledReason: "This scenario's environment was archived.",
+      copy: {
+        linkLabel: "Share link",
+        withheldLabel: "Withheld — this scenario can't run.",
+      },
+    });
+
+    expect(screen.getByLabelText("Share link")).toHaveTextContent(
+      "Withheld — this scenario can't run.",
+    );
+    expect(screen.getByTestId("share-copy")).toBeDisabled();
+    await user.click(screen.getByTestId("share-copy"));
+    expect(copyToClipboard).not.toHaveBeenCalled();
+  });
+
+  it("rejects invalid invite emails before calling onInvite", async () => {
+    const user = userEvent.setup();
+    const onInvite = vi.fn();
+
+    renderShare({ onInvite });
+
+    await user.type(screen.getByPlaceholderText("Add people, emails..."), "not-an-email");
+    expect(screen.getByText("Enter a valid email address.")).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Invite", exact: true })).toBeDisabled();
+    await user.click(screen.getByRole("button", { name: "Invite", exact: true }));
+    expect(onInvite).not.toHaveBeenCalled();
+  });
+
+  it("surfaces invite mutation rejection", async () => {
+    const user = userEvent.setup();
+    const onInvite = vi.fn(async () => {
+      throw new Error("invite denied");
+    });
+
+    renderShare({ onInvite });
+
+    await user.type(screen.getByPlaceholderText("Add people, emails..."), "a@b.com");
+    await user.click(screen.getByRole("button", { name: "Invite", exact: true }));
+    expect(onInvite).toHaveBeenCalledWith("a@b.com");
+    expect(toast.error).toHaveBeenCalledWith("invite denied");
+  });
+
+  it("removes an accepted member", async () => {
+    const user = userEvent.setup();
+    const member: ShareMemberView = {
+      id: "m1",
+      email: "member@example.com",
+      userId: "u-2",
+      user: { name: "Member" },
+    };
+    const onRemoveMember = vi.fn(async () => envelope());
+    const onUpdated = vi.fn();
+
+    renderShare({ members: [member], onRemoveMember, onUpdated });
+
+    await user.click(screen.getByRole("button", { name: /Member/i }));
+    await user.click(screen.getByText("Remove access"));
+    expect(onRemoveMember).toHaveBeenCalledWith(member);
+    expect(onUpdated).toHaveBeenCalled();
+  });
+
+  it("exposes revoke-all without requiring rotate", async () => {
+    const user = userEvent.setup();
+    const onRevokeAll = vi.fn(async () =>
+      envelope({ policyVersion: 4, members: [] }),
+    );
+    const onUpdated = vi.fn();
+
+    renderShare({ onRevokeAll, onUpdated });
+
+    expect(screen.queryByTestId("share-rotate-link")).not.toBeInTheDocument();
+    await user.click(screen.getByTestId("share-rotate-menu"));
+    await user.click(screen.getByTestId("share-revoke-all"));
+    expect(onRevokeAll).toHaveBeenCalledTimes(1);
+    expect(onUpdated).toHaveBeenCalledWith(
+      expect.objectContaining({ policyVersion: 4 }),
     );
   });
 });

--- a/mcpjam-inspector/client/src/components/sharing/__tests__/ShareSection.test.tsx
+++ b/mcpjam-inspector/client/src/components/sharing/__tests__/ShareSection.test.tsx
@@ -1,0 +1,163 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, expect, it, vi } from "vitest";
+import { ShareSection } from "../ShareSection";
+import type { ShareSettingsEnvelope } from "../share-types";
+
+vi.mock("@/lib/clipboard", () => ({
+  copyToClipboard: vi.fn(async () => true),
+}));
+
+vi.mock("sonner", () => ({
+  toast: { success: vi.fn(), error: vi.fn() },
+}));
+
+function envelope(
+  overrides: Partial<ShareSettingsEnvelope> = {},
+): ShareSettingsEnvelope {
+  return {
+    resourceType: "scenario",
+    resourceId: "r1",
+    mode: "invited_only",
+    policyVersion: 1,
+    link: { token: "tok" },
+    members: [],
+    ...overrides,
+  };
+}
+
+const presets = [
+  { value: "invited_only", label: "Invited users only", description: "Invitees" },
+  {
+    value: "link_guests",
+    label: "Anyone with the link",
+    description: "Open link",
+  },
+  { value: "project", label: "Acme", description: "Project members" },
+] as const;
+
+describe("ShareSection", () => {
+  it("replaces the envelope after a mutation and does not copy on mode change", async () => {
+    const user = userEvent.setup();
+    const onUpdated = vi.fn();
+    const onSetPreset = vi.fn(async () =>
+      envelope({ mode: "anyone_with_link", policyVersion: 2 }),
+    );
+    const { copyToClipboard } = await import("@/lib/clipboard");
+
+    render(
+      <ShareSection
+        envelope={envelope()}
+        onUpdated={onUpdated}
+        isAuthenticated
+        displayName="Test User"
+        displayEmail="test@example.com"
+        selfEmailLower="test@example.com"
+        members={[]}
+        shareUrl="https://example.com/user-testing/x/tok"
+        displayLink="example.com/user-testing/x/tok"
+        currentPreset="invited_only"
+        presets={presets}
+        onSetPreset={onSetPreset}
+        onInvite={vi.fn()}
+        onRemoveMember={vi.fn()}
+        copy={{ linkLabel: "Share link" }}
+        testIds={{ copy: "share-copy", linkOutput: "share-link" }}
+      />,
+    );
+
+    await user.click(screen.getByRole("button", { name: /Invited users only/i }));
+    await user.click(screen.getByText("Anyone with the link"));
+    expect(onSetPreset).toHaveBeenCalledWith("link_guests");
+    expect(onUpdated).toHaveBeenCalledWith(
+      expect.objectContaining({ policyVersion: 2 }),
+    );
+    expect(copyToClipboard).not.toHaveBeenCalled();
+  });
+
+  it("disables copy and invite when disabledReason is set", () => {
+    render(
+      <ShareSection
+        envelope={envelope()}
+        isAuthenticated
+        displayName="Test User"
+        selfEmailLower="test@example.com"
+        members={[]}
+        shareUrl={null}
+        displayLink={null}
+        currentPreset="invited_only"
+        presets={presets}
+        onSetPreset={vi.fn()}
+        onInvite={vi.fn()}
+        onRemoveMember={vi.fn()}
+        disabledReason="This scenario's environment was archived."
+        copy={{
+          linkLabel: "Tester link",
+          withheldLabel: "Withheld — this scenario can't run.",
+        }}
+        testIds={{
+          copy: "scenario-copy-tester-link",
+          unrunnable: "scenario-share-unrunnable",
+          linkOutput: "scenario-tester-link",
+        }}
+      />,
+    );
+
+    expect(screen.getByLabelText("Tester link")).toHaveTextContent(
+      "Withheld — this scenario can't run.",
+    );
+    expect(screen.getByTestId("scenario-copy-tester-link")).toBeDisabled();
+    expect(screen.getByRole("button", { name: "Invite", exact: true })).toBeDisabled();
+    expect(screen.getByTestId("scenario-share-unrunnable")).toHaveTextContent(
+      "This scenario's environment was archived.",
+    );
+  });
+
+  it("copy does not mutate; rotate asks for confirm then calls rotate", async () => {
+    const user = userEvent.setup();
+    const onRotateLink = vi.fn(async () =>
+      envelope({ link: { token: "new" }, policyVersion: 3 }),
+    );
+    const onUpdated = vi.fn();
+    const { copyToClipboard } = await import("@/lib/clipboard");
+
+    render(
+      <ShareSection
+        envelope={envelope()}
+        onUpdated={onUpdated}
+        isAuthenticated
+        displayName="Test User"
+        selfEmailLower="test@example.com"
+        members={[]}
+        shareUrl="https://example.com/s/tok"
+        displayLink="example.com/s/tok"
+        currentPreset="invited_only"
+        presets={presets}
+        onSetPreset={vi.fn()}
+        onInvite={vi.fn()}
+        onRemoveMember={vi.fn()}
+        onRotateLink={onRotateLink}
+        copy={{ linkLabel: "Share link" }}
+        testIds={{
+          copy: "share-copy",
+          rotate: "share-rotate-menu",
+          rotateConfirm: "share-rotate-confirm",
+          linkOutput: "share-link",
+        }}
+      />,
+    );
+
+    await user.click(screen.getByTestId("share-copy"));
+    expect(copyToClipboard).toHaveBeenCalledWith("https://example.com/s/tok");
+    expect(onRotateLink).not.toHaveBeenCalled();
+
+    await user.click(screen.getByTestId("share-rotate-menu"));
+    await user.click(screen.getByTestId("share-rotate-link"));
+    expect(onRotateLink).not.toHaveBeenCalled();
+    await user.click(screen.getByTestId("share-rotate-confirm"));
+    expect(onRotateLink).toHaveBeenCalledTimes(1);
+    expect(onUpdated).toHaveBeenCalledWith(
+      expect.objectContaining({ policyVersion: 3 }),
+    );
+  });
+});

--- a/mcpjam-inspector/client/src/components/sharing/__tests__/SharedArtifactPage.test.tsx
+++ b/mcpjam-inspector/client/src/components/sharing/__tests__/SharedArtifactPage.test.tsx
@@ -1,0 +1,54 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import {
+  SHARE_LINK_DENIED_MESSAGE,
+  SharedArtifactPage,
+} from "../SharedArtifactPage";
+
+describe("SharedArtifactPage", () => {
+  it("shows loading and hides children", () => {
+    render(
+      <SharedArtifactPage title="Shared run" loading>
+        <p>secret content</p>
+      </SharedArtifactPage>,
+    );
+
+    expect(screen.getByText("Shared run")).toBeInTheDocument();
+    expect(screen.getByText("Loading…")).toBeInTheDocument();
+    expect(screen.queryByText("secret content")).not.toBeInTheDocument();
+  });
+
+  it("collapses any error to the denied message", () => {
+    render(
+      <SharedArtifactPage title="Shared run" error="token expired">
+        <p>secret content</p>
+      </SharedArtifactPage>,
+    );
+
+    expect(screen.getByRole("alert")).toHaveTextContent(
+      SHARE_LINK_DENIED_MESSAGE,
+    );
+    expect(screen.queryByText("token expired")).not.toBeInTheDocument();
+    expect(screen.queryByText("secret content")).not.toBeInTheDocument();
+  });
+
+  it("renders children when not loading and not denied", () => {
+    render(
+      <SharedArtifactPage title="Shared run">
+        <p>artifact body</p>
+      </SharedArtifactPage>,
+    );
+
+    expect(screen.getByText("artifact body")).toBeInTheDocument();
+    expect(screen.queryByText("Loading…")).not.toBeInTheDocument();
+    expect(screen.queryByRole("alert")).not.toBeInTheDocument();
+  });
+
+  it("renders nothing in the body when children are omitted", () => {
+    render(<SharedArtifactPage title="Shared run" />);
+
+    expect(screen.getByText("Shared run")).toBeInTheDocument();
+    expect(screen.queryByText("Loading…")).not.toBeInTheDocument();
+    expect(screen.queryByRole("alert")).not.toBeInTheDocument();
+  });
+});

--- a/mcpjam-inspector/client/src/components/sharing/share-types.ts
+++ b/mcpjam-inspector/client/src/components/sharing/share-types.ts
@@ -26,7 +26,7 @@ export type ShareSettingsEnvelope = {
   workspaceId?: string;
   projectId?: string;
   mode: ShareMode;
-  policyVersion?: number;
+  policyVersion: number;
   inviteEpoch?: number;
   linkGrantEpoch?: number;
   allowGuestAccess?: boolean;

--- a/mcpjam-inspector/client/src/components/sharing/share-types.ts
+++ b/mcpjam-inspector/client/src/components/sharing/share-types.ts
@@ -1,0 +1,65 @@
+export type ShareMode =
+  | "project_members"
+  | "invited_only"
+  | "anyone_with_link";
+
+export type ShareGrantRole = "chat" | "viewer";
+
+export type ShareMemberView = {
+  id: string;
+  email: string;
+  userId?: string | null;
+  revokedAt?: number;
+  acceptedAt?: number;
+  role?: ShareGrantRole;
+  user?: { name?: string | null; imageUrl?: string | null } | null;
+};
+
+/**
+ * Every share mutation resolves to this envelope. `policyVersion` is
+ * present from day one so clients can treat it as the cache epoch.
+ */
+export type ShareSettingsEnvelope = {
+  resourceType?: "scenario" | "conformanceRun" | "evalRun";
+  resourceId: string;
+  organizationId?: string;
+  workspaceId?: string;
+  projectId?: string;
+  mode: ShareMode;
+  policyVersion?: number;
+  inviteEpoch?: number;
+  linkGrantEpoch?: number;
+  allowGuestAccess?: boolean;
+  link: {
+    token: string;
+    path?: string;
+    url?: string;
+    rotatedAt?: number;
+    updatedAt?: number;
+  } | null;
+  linkExpiresAt?: number;
+  artifactGeneration?: number;
+  artifactStatus?: "building" | "ready" | "failed";
+  members: ShareMemberView[];
+};
+
+export type ShareAccessOption = {
+  value: string;
+  label: string;
+  description: string;
+};
+
+export type ShareSectionCopy = {
+  linkLabel: string;
+  inviteLabel?: string;
+  accessLabel?: string;
+  hasAccessLabel?: string;
+  invitedLabel?: string;
+  signedOutMessage?: string;
+  withheldLabel?: string;
+  emptyLinkLabel?: string;
+  rotateLabel?: string;
+  rotateConfirmTitle?: string;
+  rotateConfirmBody?: string;
+  revokeAllLabel?: string;
+};

--- a/mcpjam-inspector/client/src/hooks/useSharedArtifact.ts
+++ b/mcpjam-inspector/client/src/hooks/useSharedArtifact.ts
@@ -1,0 +1,135 @@
+import { useAuth } from "@workos-inc/authkit-react";
+import { useCallback, useEffect, useState } from "react";
+import { SHARE_LINK_DENIED_MESSAGE } from "@/components/sharing/SharedArtifactPage";
+import { getOrCreateGuestSession } from "@/lib/guest-session";
+
+export type SharedResourceType = "conformanceRun" | "evalRun" | "scenario";
+
+export type SharedArtifactState = {
+  loading: boolean;
+  error: string | null;
+  artifact: unknown | null;
+  redeem: {
+    resourceType: string;
+    resourceId: string;
+    role: string;
+    mode: string;
+    projectId: string | null;
+    accessVersion: number;
+  } | null;
+};
+
+async function bearerForViewer(
+  getAccessToken: (() => Promise<string | undefined>) | undefined,
+): Promise<string | null> {
+  if (getAccessToken) {
+    const token = await getAccessToken().catch(() => undefined);
+    if (token) return token;
+  }
+  const guest = await getOrCreateGuestSession();
+  return guest?.token ?? null;
+}
+
+function stripTokenFromUrl() {
+  if (typeof window === "undefined") return;
+  const url = new URL(window.location.href);
+  if (!url.searchParams.has("token") && !url.pathname.includes("/shared/")) {
+    return;
+  }
+  const next = url.pathname.replace(/\/shared\/[^/]+$/, "/shared");
+  window.history.replaceState({}, "", next + url.search);
+}
+
+export function useSharedArtifact({
+  resourceType,
+  token,
+}: {
+  resourceType: SharedResourceType;
+  token: string | undefined;
+}): SharedArtifactState {
+  const { getAccessToken, user } = useAuth();
+  const [state, setState] = useState<SharedArtifactState>({
+    loading: true,
+    error: null,
+    artifact: null,
+    redeem: null,
+  });
+
+  const load = useCallback(async () => {
+    if (!token) {
+      setState({
+        loading: false,
+        error: SHARE_LINK_DENIED_MESSAGE,
+        artifact: null,
+        redeem: null,
+      });
+      return;
+    }
+    setState((prev) => ({ ...prev, loading: true, error: null }));
+    try {
+      const bearer = await bearerForViewer(getAccessToken);
+      if (!bearer) {
+        throw new Error("unauthenticated");
+      }
+      const redeemRes = await fetch("/api/web/shared/redeem", {
+        method: "POST",
+        credentials: "include",
+        headers: {
+          "content-type": "application/json",
+          authorization: `Bearer ${bearer}`,
+        },
+        body: JSON.stringify({ resourceType, token }),
+      });
+      const redeemBody = (await redeemRes.json().catch(() => null)) as {
+        ok?: boolean;
+        resourceType?: string;
+        resourceId?: string;
+        role?: string;
+        mode?: string;
+        projectId?: string | null;
+        accessVersion?: number;
+      } | null;
+      if (!redeemRes.ok || !redeemBody?.ok || !redeemBody.resourceId) {
+        throw new Error("denied");
+      }
+      const artifactRes = await fetch(
+        `/api/web/shared/${encodeURIComponent(redeemBody.resourceType ?? resourceType)}/${encodeURIComponent(redeemBody.resourceId)}/artifact`,
+        {
+          credentials: "include",
+          headers: { authorization: `Bearer ${bearer}` },
+        },
+      );
+      if (!artifactRes.ok) {
+        throw new Error("denied");
+      }
+      const artifact = await artifactRes.json().catch(() => null);
+      stripTokenFromUrl();
+      setState({
+        loading: false,
+        error: null,
+        artifact,
+        redeem: {
+          resourceType: redeemBody.resourceType ?? resourceType,
+          resourceId: redeemBody.resourceId,
+          role: redeemBody.role ?? "viewer",
+          mode: redeemBody.mode ?? "anyone_with_link",
+          projectId: redeemBody.projectId ?? null,
+          accessVersion: redeemBody.accessVersion ?? 0,
+        },
+      });
+    } catch {
+      setState({
+        loading: false,
+        error: SHARE_LINK_DENIED_MESSAGE,
+        artifact: null,
+        redeem: null,
+      });
+    }
+  }, [getAccessToken, resourceType, token, user?.id]);
+
+  useEffect(() => {
+    void load();
+  }, [load]);
+
+  return state;
+}

--- a/mcpjam-inspector/client/src/hooks/useSharedArtifact.ts
+++ b/mcpjam-inspector/client/src/hooks/useSharedArtifact.ts
@@ -33,11 +33,40 @@ async function bearerForViewer(
 function stripTokenFromUrl() {
   if (typeof window === "undefined") return;
   const url = new URL(window.location.href);
-  if (!url.searchParams.has("token") && !url.pathname.includes("/shared/")) {
+  const hasQueryToken = url.searchParams.has("token");
+  if (!hasQueryToken && !url.pathname.includes("/shared/")) {
     return;
+  }
+  // The query form has to be dropped explicitly: re-appending `url.search`
+  // would otherwise carry the credential straight back into the address bar.
+  if (hasQueryToken) {
+    url.searchParams.delete("token");
   }
   const next = url.pathname.replace(/\/shared\/[^/]+$/, "/shared");
   window.history.replaceState({}, "", next + url.search);
+}
+
+/**
+ * Read a pre-shareable-layer conformance share link. The legacy endpoint is
+ * unauthenticated by design (the HMAC token IS the credential) and returns
+ * the same redacted public artifact. Deleted with the HMAC scheme at I6/B6.
+ */
+async function loadLegacyConformanceArtifact(
+  token: string,
+): Promise<unknown | null> {
+  try {
+    const res = await fetch(
+      `/api/web/conformance-shared/${encodeURIComponent(token)}`,
+      { credentials: "include" },
+    );
+    if (!res.ok) return null;
+    const body = (await res.json().catch(() => null)) as {
+      artifact?: unknown;
+    } | null;
+    return body?.artifact ?? null;
+  } catch {
+    return null;
+  }
 }
 
 export function useSharedArtifact({
@@ -104,6 +133,7 @@ export function useSharedArtifact({
       }
       const artifact = await artifactRes.json().catch(() => null);
       stripTokenFromUrl();
+
       setState({
         loading: false,
         error: null,
@@ -118,6 +148,28 @@ export function useSharedArtifact({
         },
       });
     } catch {
+      // MIXED-VERSION FALLBACK, REMOVED AT I6/B6.
+      //
+      // Conformance links minted before the shareable layer are stateless
+      // HMAC tokens: they were never registered in `shareResources`, so the
+      // redeem above can never find them. Without this, deploying the new
+      // viewer would kill every conformance share link already in the wild —
+      // and, while the management flag is off, the legacy toggle keeps
+      // minting exactly those links, so sharing would mint dead links.
+      if (resourceType === "conformanceRun") {
+        const legacy = await loadLegacyConformanceArtifact(token);
+        if (legacy) {
+          stripTokenFromUrl();
+          setState({
+            loading: false,
+            error: null,
+            artifact: legacy,
+            redeem: null,
+          });
+          return;
+        }
+      }
+      stripTokenFromUrl();
       setState({
         loading: false,
         error: SHARE_LINK_DENIED_MESSAGE,

--- a/mcpjam-inspector/client/src/hooks/useShares.ts
+++ b/mcpjam-inspector/client/src/hooks/useShares.ts
@@ -1,0 +1,64 @@
+import { useMutation, useQuery } from "convex/react";
+import type { ShareSettingsEnvelope } from "@/components/sharing/share-types";
+
+export type ShareResourceType = "scenario" | "conformanceRun" | "evalRun";
+export type ShareMode = ShareSettingsEnvelope["mode"];
+
+export function useShareSettings({
+  isAuthenticated,
+  resourceType,
+  resourceId,
+}: {
+  isAuthenticated: boolean;
+  resourceType: ShareResourceType | null;
+  resourceId: string | null;
+}) {
+  const enabled = isAuthenticated && !!resourceType && !!resourceId;
+  const settings = useQuery(
+    "shares:getShareSettings" as never,
+    enabled
+      ? ({ resourceType, resourceId } as never)
+      : "skip",
+  ) as ShareSettingsEnvelope | null | undefined;
+
+  return {
+    settings,
+    isLoading: enabled && settings === undefined,
+  };
+}
+
+export function useShareMutations() {
+  const setShareMode = useMutation("shares:setShareMode" as never);
+  const rotateShareLink = useMutation("shares:rotateShareLink" as never);
+  const upsertShareMember = useMutation("shares:upsertShareMember" as never);
+  const removeShareMember = useMutation("shares:removeShareMember" as never);
+  const revokeAllShares = useMutation("shares:revokeAllShares" as never);
+
+  return {
+    setShareMode: (args: {
+      resourceType: ShareResourceType;
+      resourceId: string;
+      mode: ShareMode;
+      allowGuestAccess?: boolean;
+    }) => setShareMode(args as never) as Promise<ShareSettingsEnvelope>,
+    rotateShareLink: (args: {
+      resourceType: ShareResourceType;
+      resourceId: string;
+    }) => rotateShareLink(args as never) as Promise<ShareSettingsEnvelope>,
+    upsertShareMember: (args: {
+      resourceType: ShareResourceType;
+      resourceId: string;
+      email: string;
+      sendInviteEmail: boolean;
+    }) => upsertShareMember(args as never) as Promise<ShareSettingsEnvelope>,
+    removeShareMember: (args: {
+      resourceType: ShareResourceType;
+      resourceId: string;
+      memberIdOrEmail: string;
+    }) => removeShareMember(args as never) as Promise<ShareSettingsEnvelope>,
+    revokeAllShares: (args: {
+      resourceType: ShareResourceType;
+      resourceId: string;
+    }) => revokeAllShares(args as never) as Promise<ShareSettingsEnvelope>,
+  };
+}

--- a/mcpjam-inspector/client/src/lib/PosthogUtils.ts
+++ b/mcpjam-inspector/client/src/lib/PosthogUtils.ts
@@ -67,8 +67,22 @@ function getPostHogBootstrap() {
  * with a placeholder before anything leaves the browser; the path itself is
  * still useful, and the token never was.
  */
+// Every path whose LAST segment is a bearer credential. Autocapture attaches
+// `$current_url` to each event, so a share viewer's address bar would ship the
+// redeem token to PostHog on every click if these were not redacted.
+const CREDENTIAL_PATH_PREFIXES = [
+  "/results/",
+  "/conformance/shared/",
+  "/evals/shared/",
+];
+
 export function scrubSensitiveUrl(value: string): string {
-  return value.replace(/(\/results\/)[^/?#]+/g, "$1[redacted]");
+  let out = value;
+  for (const prefix of CREDENTIAL_PATH_PREFIXES) {
+    const escaped = prefix.replace(/[/\-\\^$*+?.()|[\]{}]/g, "\\$&");
+    out = out.replace(new RegExp(`(${escaped})[^/?#]+`, "g"), "$1[redacted]");
+  }
+  return out;
 }
 
 function sanitizeAnalyticsProperties(

--- a/mcpjam-inspector/client/src/lib/__tests__/share-envelope.contract.test.ts
+++ b/mcpjam-inspector/client/src/lib/__tests__/share-envelope.contract.test.ts
@@ -4,29 +4,57 @@ import { fileURLToPath } from "node:url";
 import { describe, expect, it } from "vitest";
 import fixture from "../fixtures/share-envelope.json";
 
+const here = dirname(fileURLToPath(import.meta.url));
+const hookSource = readFileSync(join(here, "../../hooks/useShares.ts"), "utf8");
+
 describe("share envelope contract fixture", () => {
-  it("pins the five Convex refs and envelope keys", () => {
+  it("pins the Convex refs and envelope keys", () => {
     expect(Object.keys(fixture.convexRefs)).toEqual([
       "shares:getShareSettings",
       "shares:setShareMode",
       "shares:rotateShareLink",
       "shares:upsertShareMember",
       "shares:removeShareMember",
+      "shares:revokeAllShares",
     ]);
     expect(fixture.shareSettingsEnvelope).toMatchObject({
       resourceType: "conformanceRun",
       mode: "anyone_with_link",
       policyVersion: 1,
     });
-    const disk = JSON.parse(
-      readFileSync(
-        join(
-          dirname(fileURLToPath(import.meta.url)),
-          "../fixtures/share-envelope.json",
-        ),
-        "utf8",
-      ),
+  });
+
+  // The point of the fixture is to catch cross-repo drift, so it has to be
+  // bound to something real. Comparing the imported JSON to a re-read of the
+  // same file can never fail; these two assertions can.
+  it("matches every ref the client actually calls", () => {
+    const called = [...hookSource.matchAll(/"(shares:[A-Za-z]+)"/g)].map(
+      (match) => match[1],
     );
-    expect(disk).toEqual(fixture);
+    expect(called.length).toBeGreaterThan(0);
+
+    const pinned = new Set(Object.keys(fixture.convexRefs));
+    // A ref the hook calls but the fixture does not pin is exactly the gap
+    // that let `shares:revokeAllShares` ship unpinned.
+    for (const ref of new Set(called)) {
+      expect(pinned.has(ref), `${ref} is called but not pinned`).toBe(true);
+    }
+    // And a pinned ref nothing calls is a stale contract entry.
+    for (const ref of pinned) {
+      expect(called.includes(ref), `${ref} is pinned but never called`).toBe(
+        true,
+      );
+    }
+  });
+
+  it("pins arg names that appear in the hook's call sites", () => {
+    for (const [ref, spec] of Object.entries(fixture.convexRefs)) {
+      if (ref === "shares:getShareSettings") continue;
+      for (const arg of (spec as { args: string[] }).args) {
+        const name = arg.replace(/\?$/, "");
+        if (name === "resourceType" || name === "resourceId") continue;
+        expect(hookSource.includes(name), `${ref} arg ${name}`).toBe(true);
+      }
+    }
   });
 });

--- a/mcpjam-inspector/client/src/lib/__tests__/share-envelope.contract.test.ts
+++ b/mcpjam-inspector/client/src/lib/__tests__/share-envelope.contract.test.ts
@@ -1,0 +1,32 @@
+import { readFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { describe, expect, it } from "vitest";
+import fixture from "../fixtures/share-envelope.json";
+
+describe("share envelope contract fixture", () => {
+  it("pins the five Convex refs and envelope keys", () => {
+    expect(Object.keys(fixture.convexRefs)).toEqual([
+      "shares:getShareSettings",
+      "shares:setShareMode",
+      "shares:rotateShareLink",
+      "shares:upsertShareMember",
+      "shares:removeShareMember",
+    ]);
+    expect(fixture.shareSettingsEnvelope).toMatchObject({
+      resourceType: "conformanceRun",
+      mode: "anyone_with_link",
+      policyVersion: 1,
+    });
+    const disk = JSON.parse(
+      readFileSync(
+        join(
+          dirname(fileURLToPath(import.meta.url)),
+          "../fixtures/share-envelope.json",
+        ),
+        "utf8",
+      ),
+    );
+    expect(disk).toEqual(fixture);
+  });
+});

--- a/mcpjam-inspector/client/src/lib/fixtures/share-envelope.json
+++ b/mcpjam-inspector/client/src/lib/fixtures/share-envelope.json
@@ -1,0 +1,58 @@
+{
+  "convexRefs": {
+    "shares:getShareSettings": {
+      "args": ["resourceType", "resourceId"],
+      "returns": "ShareSettingsEnvelope | null"
+    },
+    "shares:setShareMode": {
+      "args": ["resourceType", "resourceId", "mode", "allowGuestAccess?"],
+      "returns": "ShareSettingsEnvelope"
+    },
+    "shares:rotateShareLink": {
+      "args": ["resourceType", "resourceId"],
+      "returns": "ShareSettingsEnvelope"
+    },
+    "shares:upsertShareMember": {
+      "args": ["resourceType", "resourceId", "email", "sendInviteEmail"],
+      "returns": "ShareSettingsEnvelope"
+    },
+    "shares:removeShareMember": {
+      "args": ["resourceType", "resourceId", "memberIdOrEmail"],
+      "returns": "ShareSettingsEnvelope"
+    }
+  },
+  "shareSettingsEnvelope": {
+    "resourceType": "conformanceRun",
+    "resourceId": "jd7…",
+    "organizationId": "jd7…",
+    "workspaceId": "jd7…",
+    "projectId": "jd7…",
+    "mode": "anyone_with_link",
+    "policyVersion": 1,
+    "inviteEpoch": 1,
+    "linkGrantEpoch": 1,
+    "link": { "token": "nanoid-token", "rotatedAt": 0 },
+    "artifactGeneration": 1,
+    "artifactStatus": "ready",
+    "members": [
+      {
+        "id": "jd7…",
+        "email": "invitee@example.com",
+        "role": "viewer",
+        "invitedAt": 0
+      }
+    ]
+  },
+  "shareRedeemResponse": {
+    "ok": true,
+    "resourceType": "conformanceRun",
+    "resourceId": "jd7…",
+    "role": "viewer",
+    "mode": "anyone_with_link",
+    "projectId": "jd7…",
+    "accessVersion": 1,
+    "payload": {}
+  },
+  "resourceTypes": ["scenario", "conformanceRun", "evalRun"],
+  "modes": ["project_members", "invited_only", "anyone_with_link"]
+}

--- a/mcpjam-inspector/client/src/lib/fixtures/share-envelope.json
+++ b/mcpjam-inspector/client/src/lib/fixtures/share-envelope.json
@@ -19,6 +19,10 @@
     "shares:removeShareMember": {
       "args": ["resourceType", "resourceId", "memberIdOrEmail"],
       "returns": "ShareSettingsEnvelope"
+    },
+    "shares:revokeAllShares": {
+      "args": ["resourceType", "resourceId"],
+      "returns": "ShareSettingsEnvelope"
     }
   },
   "shareSettingsEnvelope": {

--- a/mcpjam-inspector/server/routes/v1/__tests__/openapi-drift.test.ts
+++ b/mcpjam-inspector/server/routes/v1/__tests__/openapi-drift.test.ts
@@ -91,6 +91,12 @@ const KNOWN_UNDOCUMENTED = new Set([
   // contract — documenting it would invite external callers to depend on the
   // shape of an internal list that changes with every tool we add.
   "get /agent-ops",
+  // Unified share control plane — REST ships in I2; OpenAPI + SDK in I5.
+  "get /projects/{projectId}/shares/{resourceType}/{resourceId}",
+  "patch /projects/{projectId}/shares/{resourceType}/{resourceId}",
+  "post /projects/{projectId}/shares/{resourceType}/{resourceId}/rotate-link",
+  "put /projects/{projectId}/shares/{resourceType}/{resourceId}/members",
+  "delete /projects/{projectId}/shares/{resourceType}/{resourceId}/members/{memberIdOrEmail}",
 ]);
 
 /**

--- a/mcpjam-inspector/server/routes/v1/__tests__/sdk-coverage.test.ts
+++ b/mcpjam-inspector/server/routes/v1/__tests__/sdk-coverage.test.ts
@@ -337,6 +337,16 @@ const EXCLUDED_FROM_SDK: Readonly<Record<string, string>> = {
     "Keeps a long-running uploaded conformance run from looking stale.",
   "post /projects/{projectId}/conformance-ingest/runs/finalize":
     "Closes the incremental conformance ingest the reporter opened.",
+  "get /projects/{projectId}/shares/{resourceType}/{resourceId}":
+    "Unified share settings. REST-first in I2; SDK wrappers ship in I5.",
+  "patch /projects/{projectId}/shares/{resourceType}/{resourceId}":
+    "Unified set-share-mode. REST-first in I2; SDK wrappers ship in I5.",
+  "post /projects/{projectId}/shares/{resourceType}/{resourceId}/rotate-link":
+    "Unified rotate-share-link. REST-first in I2; SDK wrappers ship in I5.",
+  "put /projects/{projectId}/shares/{resourceType}/{resourceId}/members":
+    "Share member upsert stays REST-only for now.",
+  "delete /projects/{projectId}/shares/{resourceType}/{resourceId}/members/{memberIdOrEmail}":
+    "Share member removal stays REST-only for now.",
 };
 
 describe("/api/v1 -> SDK coverage", () => {

--- a/mcpjam-inspector/server/routes/v1/__tests__/shares.test.ts
+++ b/mcpjam-inspector/server/routes/v1/__tests__/shares.test.ts
@@ -1,0 +1,112 @@
+import { describe, expect, it, vi } from "vitest";
+import { Hono } from "hono";
+
+const { queryMock, mutationMock } = vi.hoisted(() => ({
+  queryMock: vi.fn(),
+  mutationMock: vi.fn(),
+}));
+
+vi.mock("convex/browser", () => ({
+  ConvexHttpClient: class {
+    setAuth() {}
+    query(...args: unknown[]) {
+      return queryMock(...args);
+    }
+    mutation(...args: unknown[]) {
+      return mutationMock(...args);
+    }
+  },
+}));
+
+vi.mock("../../../utils/v1-convex-token.js", () => ({
+  getConvexBearerForRequest: async () => "convex-jwt",
+}));
+
+import shares from "../shares.js";
+import { v1OnError } from "../envelope.js";
+
+const PROJECT = "proj_a";
+const OTHER = "proj_b";
+const RUN = "run_1";
+const BASE = `/api/v1/projects/${PROJECT}/shares/conformanceRun/${RUN}`;
+
+function makeApp() {
+  const app = new Hono();
+  app.onError(v1OnError);
+  app.route("/api/v1", shares);
+  return app;
+}
+
+function call(method: string, path: string, body?: unknown) {
+  return makeApp().request(path, {
+    method,
+    ...(body !== undefined
+      ? {
+          body: JSON.stringify(body),
+          headers: { "content-type": "application/json" },
+        }
+      : {}),
+  });
+}
+
+const envelope = {
+  resourceType: "conformanceRun",
+  resourceId: RUN,
+  projectId: PROJECT,
+  mode: "anyone_with_link",
+  policyVersion: 2,
+  link: { token: "tok" },
+  members: [],
+};
+
+describe("v1 shares", () => {
+  it("cross-project preflight is 404", async () => {
+    queryMock.mockResolvedValueOnce({ ...envelope, projectId: OTHER });
+    const res = await call("GET", BASE);
+    expect(res.status).toBe(404);
+    expect(mutationMock).not.toHaveBeenCalled();
+  });
+
+  it("GET is projected, never spread", async () => {
+    queryMock.mockResolvedValue(envelope);
+    const res = await call("GET", BASE);
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.data).toEqual({
+      resourceType: "conformanceRun",
+      resourceId: RUN,
+      projectId: PROJECT,
+      mode: "anyone_with_link",
+      policyVersion: 2,
+      link: { token: "tok" },
+      members: [],
+    });
+    expect(body.data).not.toHaveProperty("inviteEpoch");
+  });
+
+  it("forwards sendInviteEmail explicitly, defaulting false", async () => {
+    queryMock.mockResolvedValue(envelope);
+    mutationMock.mockResolvedValue(envelope);
+    await call("PUT", `${BASE}/members`, { email: "a@example.com" });
+    expect(mutationMock).toHaveBeenCalledWith(
+      "shares:upsertShareMember",
+      expect.objectContaining({
+        email: "a@example.com",
+        sendInviteEmail: false,
+      }),
+    );
+  });
+
+  it("honors sendInviteEmail: true", async () => {
+    queryMock.mockResolvedValue(envelope);
+    mutationMock.mockResolvedValue(envelope);
+    await call("PUT", `${BASE}/members`, {
+      email: "a@example.com",
+      sendInviteEmail: true,
+    });
+    expect(mutationMock).toHaveBeenCalledWith(
+      "shares:upsertShareMember",
+      expect.objectContaining({ sendInviteEmail: true }),
+    );
+  });
+});

--- a/mcpjam-inspector/server/routes/v1/__tests__/shares.test.ts
+++ b/mcpjam-inspector/server/routes/v1/__tests__/shares.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it, vi } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 import { Hono } from "hono";
 
 const { queryMock, mutationMock } = vi.hoisted(() => ({
@@ -60,6 +60,12 @@ const envelope = {
 };
 
 describe("v1 shares", () => {
+  beforeEach(() => {
+    queryMock.mockReset();
+    mutationMock.mockReset();
+    vi.stubEnv("CONVEX_URL", "https://convex.test");
+  });
+
   it("cross-project preflight is 404", async () => {
     queryMock.mockResolvedValueOnce({ ...envelope, projectId: OTHER });
     const res = await call("GET", BASE);
@@ -72,7 +78,7 @@ describe("v1 shares", () => {
     const res = await call("GET", BASE);
     expect(res.status).toBe(200);
     const body = await res.json();
-    expect(body.data).toEqual({
+    expect(body).toEqual({
       resourceType: "conformanceRun",
       resourceId: RUN,
       projectId: PROJECT,
@@ -81,7 +87,7 @@ describe("v1 shares", () => {
       link: { token: "tok" },
       members: [],
     });
-    expect(body.data).not.toHaveProperty("inviteEpoch");
+    expect(body).not.toHaveProperty("inviteEpoch");
   });
 
   it("forwards sendInviteEmail explicitly, defaulting false", async () => {

--- a/mcpjam-inspector/server/routes/v1/index.ts
+++ b/mcpjam-inspector/server/routes/v1/index.ts
@@ -35,6 +35,7 @@ import swarmInsights from "./swarm-insights.js";
 import swarmGenerateV1 from "./swarm-generate.js";
 import scenarios from "./scenarios.js";
 import userTesting from "./user-testing.js";
+import shares from "./shares.js";
 import sandboxImages from "./images.js";
 import evalIngest from "./eval-ingest.js";
 import conformanceIngest from "./conformance-ingest.js";
@@ -151,6 +152,9 @@ v1.route("/", scenarios);
 // publishing (keyed by environment, because the scenario does not exist yet);
 // this is keyed by the scenario. Guest-DENIED by default, same as publishing.
 v1.route("/", userTesting);
+// Unified share control plane. Guest-DENIED (no GUEST_ALLOWED_V1_RULES
+// entry). Existing user-testing share endpoints stay as wrappers.
+v1.route("/", shares);
 // Computer sandbox images stay OFF the guest allowlist (no
 // GUEST_ALLOWED_V1_RULES entry) — every operation requires an authenticated,
 // project-scoped caller.

--- a/mcpjam-inspector/server/routes/v1/shares.ts
+++ b/mcpjam-inspector/server/routes/v1/shares.ts
@@ -1,0 +1,265 @@
+/**
+ * Generic share management. Guest-DENIED (no guest-allowed-paths entry).
+ *
+ * Preflight: getShareSettings must resolve AND projectId must match the path,
+ * else 404. Writes are PROJECTED, never spread. sendInviteEmail is always
+ * forwarded explicitly.
+ */
+import { Hono } from "hono";
+import { z } from "zod";
+import type { ConvexHttpClient } from "convex/browser";
+import { createConvexClient } from "./convex-client.js";
+import { ErrorCode, WebRouteError } from "../web/errors.js";
+import { getConvexBearerForRequest } from "../../utils/v1-convex-token.js";
+import { v1Resource } from "./envelope.js";
+import { translateConvexWriteError } from "./convex-errors.js";
+import { translateConvexReadError } from "./convex-read-errors.js";
+
+const shares = new Hono();
+const BASE = "/projects/:projectId/shares/:resourceType/:resourceId";
+
+type ShareEnvelope = {
+  resourceType?: string;
+  resourceId: string;
+  projectId?: string;
+  mode?: string;
+  policyVersion?: number;
+  link?: { token?: string } | null;
+  members?: Array<{ id: string; email: string }>;
+};
+
+const RESOURCE_TYPES = new Set(["scenario", "conformanceRun", "evalRun"]);
+
+function translateReadError(error: unknown): WebRouteError {
+  return translateConvexReadError(error, { scope: "v1.shares" });
+}
+
+function translatePreflightReadError(error: unknown): WebRouteError {
+  return translateConvexReadError(error, {
+    scope: "v1.shares",
+    notFoundMessage: "Share not found",
+    redactedIsRefusal: true,
+  });
+}
+
+function translateWriteError(error: unknown): WebRouteError {
+  return translateConvexWriteError(error, {
+    resource: "Share",
+    adminFailureIsForbidden: true,
+  });
+}
+
+async function parseBody<T>(
+  c: { req: { json: () => Promise<unknown> } },
+  schema: z.ZodType<T>,
+): Promise<T> {
+  let raw: unknown;
+  try {
+    raw = await c.req.json();
+  } catch {
+    throw new WebRouteError(
+      400,
+      ErrorCode.VALIDATION_ERROR,
+      "Request body must be JSON",
+    );
+  }
+  const parsed = schema.safeParse(raw);
+  if (!parsed.success) {
+    throw new WebRouteError(
+      400,
+      ErrorCode.VALIDATION_ERROR,
+      parsed.error.issues[0]?.message ?? "Invalid request body",
+    );
+  }
+  return parsed.data;
+}
+
+function requireResourceType(value: string): "scenario" | "conformanceRun" | "evalRun" {
+  if (!RESOURCE_TYPES.has(value)) {
+    throw new WebRouteError(404, ErrorCode.NOT_FOUND, "Share not found");
+  }
+  return value as "scenario" | "conformanceRun" | "evalRun";
+}
+
+function projectEnvelope(
+  envelope: ShareEnvelope,
+  projectId: string,
+): {
+  resourceType: string;
+  resourceId: string;
+  projectId: string;
+  mode: string | null;
+  policyVersion: number | null;
+  link: { token?: string } | null;
+  members: Array<{ id: string; email: string }>;
+} {
+  return {
+    resourceType: envelope.resourceType ?? "",
+    resourceId: envelope.resourceId,
+    projectId,
+    mode: envelope.mode ?? null,
+    policyVersion: envelope.policyVersion ?? null,
+    link: envelope.link ?? null,
+    members: envelope.members ?? [],
+  };
+}
+
+async function requireShareInProject(
+  client: ConvexHttpClient,
+  projectId: string,
+  resourceType: string,
+  resourceId: string,
+): Promise<ShareEnvelope> {
+  let row: ShareEnvelope | null;
+  try {
+    row = (await client.query(
+      "shares:getShareSettings" as never,
+      { resourceType, resourceId } as never,
+    )) as ShareEnvelope | null;
+  } catch (error) {
+    throw translatePreflightReadError(error);
+  }
+  if (!row || String(row.projectId ?? "") !== projectId) {
+    throw new WebRouteError(404, ErrorCode.NOT_FOUND, "Share not found");
+  }
+  return row;
+}
+
+async function scopedShare(c: {
+  req: { param: (k: string) => string };
+}): Promise<{
+  client: ConvexHttpClient;
+  projectId: string;
+  resourceType: "scenario" | "conformanceRun" | "evalRun";
+  resourceId: string;
+}> {
+  const projectId = c.req.param("projectId");
+  const resourceType = requireResourceType(c.req.param("resourceType"));
+  const resourceId = c.req.param("resourceId");
+  const client = createConvexClient(
+    await getConvexBearerForRequest(c as never),
+  );
+  await requireShareInProject(client, projectId, resourceType, resourceId);
+  return { client, projectId, resourceType, resourceId };
+}
+
+shares.get(BASE, async (c) => {
+  const { client, projectId, resourceType, resourceId } = await scopedShare(c);
+  let row: ShareEnvelope | null;
+  try {
+    row = (await client.query(
+      "shares:getShareSettings" as never,
+      { resourceType, resourceId } as never,
+    )) as ShareEnvelope | null;
+  } catch (error) {
+    throw translateReadError(error);
+  }
+  if (!row) {
+    throw new WebRouteError(404, ErrorCode.NOT_FOUND, "Share not found");
+  }
+  return v1Resource(c, projectEnvelope(row, projectId));
+});
+
+const patchSchema = z.strictObject({
+  mode: z.enum(["project_members", "invited_only", "anyone_with_link"]),
+  allowGuestAccess: z.boolean().optional(),
+});
+
+shares.patch(BASE, async (c) => {
+  const body = await parseBody(c, patchSchema);
+  const { client, projectId, resourceType, resourceId } = await scopedShare(c);
+  let result: ShareEnvelope;
+  try {
+    result = (await client.mutation(
+      "shares:setShareMode" as never,
+      {
+        resourceType,
+        resourceId,
+        mode: body.mode,
+        ...(body.allowGuestAccess !== undefined
+          ? { allowGuestAccess: body.allowGuestAccess }
+          : {}),
+      } as never,
+    )) as ShareEnvelope;
+  } catch (error) {
+    throw translateWriteError(error);
+  }
+  return v1Resource(c, projectEnvelope(result, projectId));
+});
+
+shares.post(`${BASE}/rotate-link`, async (c) => {
+  const { client, projectId, resourceType, resourceId } = await scopedShare(c);
+  let result: ShareEnvelope;
+  try {
+    result = (await client.mutation(
+      "shares:rotateShareLink" as never,
+      { resourceType, resourceId } as never,
+    )) as ShareEnvelope;
+  } catch (error) {
+    throw translateWriteError(error);
+  }
+  return v1Resource(c, {
+    resourceType,
+    resourceId,
+    projectId,
+    rotated: true,
+    link: result?.link ?? null,
+    policyVersion: result?.policyVersion ?? null,
+  });
+});
+
+const upsertMemberSchema = z.strictObject({
+  email: z.string().trim().min(3).max(320),
+  sendInviteEmail: z.boolean().optional(),
+});
+
+shares.put(`${BASE}/members`, async (c) => {
+  const body = await parseBody(c, upsertMemberSchema);
+  const { client, projectId, resourceType, resourceId } = await scopedShare(c);
+  let result: ShareEnvelope;
+  try {
+    result = (await client.mutation(
+      "shares:upsertShareMember" as never,
+      {
+        resourceType,
+        resourceId,
+        email: body.email,
+        sendInviteEmail: body.sendInviteEmail ?? false,
+      } as never,
+    )) as ShareEnvelope;
+  } catch (error) {
+    throw translateWriteError(error);
+  }
+  return v1Resource(c, {
+    resourceType,
+    resourceId,
+    projectId,
+    email: body.email,
+    members: result?.members ?? [],
+    policyVersion: result?.policyVersion ?? null,
+  });
+});
+
+shares.delete(`${BASE}/members/:memberIdOrEmail`, async (c) => {
+  const { client, projectId, resourceType, resourceId } = await scopedShare(c);
+  const memberIdOrEmail = c.req.param("memberIdOrEmail");
+  let result: ShareEnvelope;
+  try {
+    result = (await client.mutation(
+      "shares:removeShareMember" as never,
+      { resourceType, resourceId, memberIdOrEmail } as never,
+    )) as ShareEnvelope;
+  } catch (error) {
+    throw translateWriteError(error);
+  }
+  return v1Resource(c, {
+    resourceType,
+    resourceId,
+    projectId,
+    removed: memberIdOrEmail,
+    members: result?.members ?? [],
+    policyVersion: result?.policyVersion ?? null,
+  });
+});
+
+export default shares;

--- a/mcpjam-inspector/server/routes/web/index.ts
+++ b/mcpjam-inspector/server/routes/web/index.ts
@@ -27,6 +27,7 @@ import guestToken from "./guest-token.js";
 import chatHistory from "./chat-history.js";
 import conformanceWeb from "./conformance.js";
 import conformanceShared from "./conformance-shared.js";
+import sharedResources from "./shared-resources.js";
 import score from "./score.js";
 import checks from "./checks.js";
 import apiKeys from "./api-keys.js";
@@ -64,6 +65,7 @@ web.use(
 );
 web.use("/chat-history/*", bearerAuthMiddleware, guestRateLimitMiddleware);
 web.use("/conformance/*", bearerAuthMiddleware, guestRateLimitMiddleware);
+web.use("/shared/*", bearerAuthMiddleware, guestRateLimitMiddleware);
 // Conformance runs dial a caller-named third party, so they carry a per-IP
 // ceiling on top of the per-guest one — guest identities are free to mint, and
 // only the IP bounds how much of our egress a single actor can spend.
@@ -162,6 +164,7 @@ web.route("/score", score);
 // as `/score`: the token is the credential, and the backend only returns the
 // redacted public artifact.
 web.route("/conformance-shared", conformanceShared);
+web.route("/shared", sharedResources);
 // `/api-keys` carries its own bearer-auth `.use()` because
 // `sessionAuthMiddleware` bypasses `/api/web/*` entirely. Nothing on this
 // sub-router is reachable without a session JWT (WorkOS `sk_…` keys are

--- a/mcpjam-inspector/server/routes/web/shared-resources.ts
+++ b/mcpjam-inspector/server/routes/web/shared-resources.ts
@@ -1,0 +1,129 @@
+/**
+ * Bearer-forwarded proxies for the unified share redeem + artifact routes.
+ * Token-in-URL HMAC serving stays on /conformance-shared until I6.
+ */
+import { Hono } from "hono";
+import { z } from "zod";
+import {
+  ErrorCode,
+  WebRouteError,
+  assertBearerToken,
+  handleRoute,
+  parseWithSchema,
+  readJsonBody,
+} from "./auth.js";
+import {
+  fetchShareArtifact,
+  redeemShareToken,
+} from "../../utils/share-redeem.js";
+
+const shared = new Hono();
+const BACKEND_TIMEOUT_MS = 15_000;
+
+const redeemSchema = z.object({
+  resourceType: z.enum(["scenario", "conformanceRun", "evalRun"]),
+  token: z.string().min(1),
+});
+
+function mapStatus(status: number): ErrorCode {
+  if (status === 401) return ErrorCode.UNAUTHORIZED;
+  if (status === 403) return ErrorCode.FORBIDDEN;
+  if (status === 404) return ErrorCode.NOT_FOUND;
+  if (status === 429) return ErrorCode.RATE_LIMITED;
+  if (status === 502 || status === 503 || status === 504) {
+    return ErrorCode.SERVER_UNREACHABLE;
+  }
+  return ErrorCode.INTERNAL_ERROR;
+}
+
+shared.post("/redeem", async (c) =>
+  handleRoute(c, async () => {
+    if (!process.env.CONVEX_HTTP_URL) {
+      throw new WebRouteError(
+        500,
+        ErrorCode.INTERNAL_ERROR,
+        "Server missing CONVEX_HTTP_URL configuration",
+      );
+    }
+    const bearerToken = assertBearerToken(c);
+    const body = parseWithSchema(redeemSchema, await readJsonBody<unknown>(c));
+    const controller = new AbortController();
+    const timeout = setTimeout(() => controller.abort(), BACKEND_TIMEOUT_MS);
+    let result;
+    try {
+      result = await redeemShareToken({
+        resourceType: body.resourceType,
+        token: body.token,
+        bearer: bearerToken,
+        signal: controller.signal,
+      });
+    } finally {
+      clearTimeout(timeout);
+    }
+    if (!result.ok) {
+      throw new WebRouteError(
+        result.status || 502,
+        mapStatus(result.status),
+        result.error,
+      );
+    }
+    c.header("x-robots-tag", "noindex, nofollow");
+    c.header("cache-control", "private, no-store");
+    return result;
+  }),
+);
+
+shared.get("/:type/:id/artifact", async (c) => {
+  if (!process.env.CONVEX_HTTP_URL) {
+    throw new WebRouteError(
+      500,
+      ErrorCode.INTERNAL_ERROR,
+      "Server missing CONVEX_HTTP_URL configuration",
+    );
+  }
+  const resourceType = c.req.param("type");
+  const resourceId = c.req.param("id");
+  if (
+    resourceType !== "conformanceRun" &&
+    resourceType !== "evalRun" &&
+    resourceType !== "scenario"
+  ) {
+    throw new WebRouteError(400, ErrorCode.VALIDATION_ERROR, "Invalid type");
+  }
+  const bearerToken = assertBearerToken(c);
+  const controller = new AbortController();
+  const timeout = setTimeout(() => controller.abort(), BACKEND_TIMEOUT_MS);
+  let result;
+  try {
+    result = await fetchShareArtifact({
+      resourceType,
+      resourceId,
+      bearer: bearerToken,
+      signal: controller.signal,
+    });
+  } catch {
+    throw new WebRouteError(
+      502,
+      ErrorCode.SERVER_UNREACHABLE,
+      "Failed to load shared artifact",
+    );
+  } finally {
+    clearTimeout(timeout);
+  }
+  if (!result.ok) {
+    throw new WebRouteError(
+      result.status === 403 ? 403 : result.status === 404 ? 404 : 502,
+      result.status === 403
+        ? ErrorCode.FORBIDDEN
+        : result.status === 404
+          ? ErrorCode.NOT_FOUND
+          : ErrorCode.SERVER_UNREACHABLE,
+      result.error,
+    );
+  }
+  c.header("x-robots-tag", "noindex, nofollow");
+  c.header("cache-control", "private, no-store");
+  return c.json(result.body ?? {}, 200);
+});
+
+export default shared;

--- a/mcpjam-inspector/server/utils/share-redeem.ts
+++ b/mcpjam-inspector/server/utils/share-redeem.ts
@@ -1,0 +1,142 @@
+/**
+ * Generic share-link redeem. Forwards bearer to Convex POST /web/share/redeem.
+ */
+
+import { logger } from "./logger.js";
+
+export type ShareRedeemSuccess = {
+  ok: true;
+  resourceType: string;
+  resourceId: string;
+  role: string;
+  mode: string;
+  projectId: string | null;
+  accessVersion: number;
+  payload: unknown;
+};
+
+export type ShareRedeemFailure = {
+  ok: false;
+  status: number;
+  error: string;
+};
+
+export type ShareRedeemResult = ShareRedeemSuccess | ShareRedeemFailure;
+
+function convexHttpUrl(): string {
+  const url = process.env.CONVEX_HTTP_URL;
+  if (!url) {
+    throw new Error("CONVEX_HTTP_URL is required for share redeem");
+  }
+  return url;
+}
+
+export async function redeemShareToken(args: {
+  resourceType: string;
+  token: string;
+  bearer: string;
+  signal?: AbortSignal;
+}): Promise<ShareRedeemResult> {
+  const authorization = args.bearer.startsWith("Bearer ")
+    ? args.bearer
+    : `Bearer ${args.bearer}`;
+  const url = new URL("/web/share/redeem", convexHttpUrl()).toString();
+  let response: Response;
+  try {
+    response = await fetch(url, {
+      method: "POST",
+      headers: {
+        "content-type": "application/json",
+        authorization,
+      },
+      body: JSON.stringify({
+        resourceType: args.resourceType,
+        token: args.token,
+      }),
+      signal: args.signal,
+    });
+  } catch (err) {
+    logger.error("[share-redeem] network error", err);
+    return {
+      ok: false,
+      status: 502,
+      error: "Failed to reach share redeem endpoint",
+    };
+  }
+
+  const payload = (await response.json().catch(() => null)) as {
+    ok?: boolean;
+    error?: string;
+    resourceType?: string;
+    resourceId?: string;
+    role?: string;
+    mode?: string;
+    projectId?: string | null;
+    accessVersion?: number;
+    payload?: unknown;
+  } | null;
+
+  if (!response.ok || !payload?.ok || !payload.resourceId) {
+    return {
+      ok: false,
+      status: response.ok ? 502 : response.status,
+      error:
+        typeof payload?.error === "string"
+          ? payload.error
+          : "This share link is invalid or has been revoked.",
+    };
+  }
+
+  return {
+    ok: true,
+    resourceType: payload.resourceType ?? args.resourceType,
+    resourceId: payload.resourceId,
+    role: payload.role ?? "viewer",
+    mode: payload.mode ?? "anyone_with_link",
+    projectId: payload.projectId ?? null,
+    accessVersion: payload.accessVersion ?? 0,
+    payload: payload.payload ?? null,
+  };
+}
+
+export async function fetchShareArtifact(args: {
+  resourceType: string;
+  resourceId: string;
+  bearer: string;
+  signal?: AbortSignal;
+}): Promise<{ ok: true; body: unknown } | ShareRedeemFailure> {
+  const authorization = args.bearer.startsWith("Bearer ")
+    ? args.bearer
+    : `Bearer ${args.bearer}`;
+  const url = new URL("/web/share/artifact", convexHttpUrl());
+  url.searchParams.set("type", args.resourceType);
+  url.searchParams.set("id", args.resourceId);
+  let response: Response;
+  try {
+    response = await fetch(url, {
+      method: "GET",
+      headers: { authorization },
+      signal: args.signal,
+      redirect: "manual",
+    });
+  } catch (err) {
+    logger.error("[share-artifact] network error", err);
+    return {
+      ok: false,
+      status: 502,
+      error: "Failed to load shared artifact",
+    };
+  }
+  if (response.status >= 300 && response.status < 400) {
+    return { ok: false, status: 502, error: "Shared artifact lookup redirected" };
+  }
+  const body = await response.json().catch(() => null);
+  if (!response.ok) {
+    return {
+      ok: false,
+      status: response.status === 403 ? 403 : response.status === 404 ? 404 : 502,
+      error: "This share link is invalid or has been revoked.",
+    };
+  }
+  return { ok: true, body };
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Purpose

Additive inspector plumbing for the unified share control plane: client hooks, the pinned contract fixture, `/api/web/shared/*` redeem+artifact proxies, and `/api/v1/projects/:p/shares/:type/:id` management routes.

Depends on I1 (`cursor/share-section-extract-fdd7`) for the generic `components/sharing/` types. Needs B4 deployed for the Convex refs to exist.

## Context

I2 is hooks + routes only. No Share dialog, no viewer-page rewrite, no SDK tools. Those ship in I3/I4/I5.

## Before / after

- **Before:** inspector talks to scenario-specific Convex refs and the HMAC `/api/web/conformance-shared/:token` path.
- **After:**
  - `useShares` / `useShareMutations` call the 5 pinned `shares:*` refs and return the full `ShareSettingsEnvelope`.
  - `useSharedArtifact` redeems via guest session or WorkOS bearer, fetches the artifact, and strips the token from the URL.
  - `POST /api/web/shared/redeem` and `GET /api/web/shared/:type/:id/artifact` forward bearer to Convex (noindex/no-store, 15s timeout, 404/502 taxonomy).
  - v1 shares routes: preflight `getShareSettings` + project match → 404; projection-never-spread; `sendInviteEmail` always forwarded (default `false`); **not guest-allowed**.
  - `/api/web/scenarios/redeem` and `/api/web/conformance-shared` stay as-is.

## Behavior changes & accepted breakage

None for existing UI. Flags and viewer rewrites come later. Old HMAC conformance links still work on the old page until I6/B6.

## Rollout

Independently deployable after B4. I3/I4 consume these hooks.

## Verification

- `client/src/lib/__tests__/share-envelope.contract.test.ts` — 5 refs + envelope keys match the backend fixture.
- `server/routes/v1/__tests__/shares.test.ts` — cross-project 404, projection discipline, explicit `sendInviteEmail`.
- `sdk-coverage.test.ts` / `openapi-drift.test.ts` — new routes inventoried (SDK wrappers in I5).

## Follow-ups

- I3: conformance Share dialog (`unified-share-conformance`) + redeem-based `ConformanceSharedPage`.
- I4: eval Share button + `/evals/shared/:token`.
- I5: SDK/MCP tools.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-8d845b4e-801b-4a36-ad22-ffbb08e0fdd7?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-8d845b4e-801b-4a36-ad22-ffbb08e0fdd7&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Unifies share management behind client hooks and shared REST/web routes so scenarios, conformance runs, and evals use one control plane. Keeps legacy HMAC conformance links working and scrubs share tokens from analytics.

- Client: `useShareSettings`/`useShareMutations` call six pinned `shares:*` refs and return a `ShareSettingsEnvelope` with required `policyVersion`. `useSharedArtifact` redeems with a guest or WorkOS bearer, strips the token from the URL on success and denial, collapses errors to a denied message, and falls back to `/api/web/conformance-shared/:token` until I6/B6.
- Share UI: `ShareSection` disables copy when `disabledReason` is set and shows the menu when only `onRevokeAll` is provided; rotation and invite flows surface errors. New tests cover `ShareDialog`, `ShareSection`, and `SharedArtifactPage`.
- Web proxies: `POST /api/web/shared/redeem` and `GET /api/web/shared/:type/:id/artifact` forward the bearer to Convex, set noindex/no-store, time out at 15s, and map 401/403/404/429/50x errors.
- v1 routes: `/api/v1/projects/:projectId/shares/:resourceType/:resourceId` supports GET, PATCH (set share mode), POST (rotate link), PUT/DELETE (members). Preflight must match project or 404. Responses are flat projections. Guest access is denied. `sendInviteEmail` is always forwarded (default false). OpenAPI drift and SDK exclusions updated pending I5.
- Analytics: `scrubSensitiveUrl` now redacts tokens in `/results/`, `/conformance/shared/`, and `/evals/shared/`.
- Tests/contract: Fixture pins six `shares:*` refs including `shares:revokeAllShares`; v1 tests assert flat bodies, explicit `sendInviteEmail`, and cross-project 404 preflight.

**Rollout**
- Requires B4 for Convex refs. Safe to ship independently; I3/I4 will consume these hooks.
- No migrations; existing HMAC conformance links continue to work.

<sup>Written for commit cae2da20726e4371ad57eadaf886f0f30b0758c3. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/MCPJam/inspector/pull/4236?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

