### PR TITLE
score: surface pending checks on the shared results page

### DIFF
--- a/mcpjam-inspector/client/src/components/score/ScoreResultsPage.tsx
+++ b/mcpjam-inspector/client/src/components/score/ScoreResultsPage.tsx
@@ -21,14 +21,17 @@ const SUITE_TITLES: Record<string, string> = {
 
 /**
  * The same sentence the SDK's `describeConformanceScore` produces, rebuilt
- * from the stored counts.
+ * from the stored counts plus the pending count derived from each suite
+ * report's `profile.pendingCheckIds` (same intersection as `partitionByStamp`).
  *
- * The stored row carries `advisoryCount` rather than the advisory objects the
- * SDK helper wants, and re-deriving the number here would be worse: the score
- * was computed once, at run time, by the engine that owns the arithmetic. This
- * only re-renders what was already decided.
+ * Advice wording is a count only: the stored row carries `advisoryCount`,
+ * not `advicePointsLost`, so the SDK's `(−N)` deduction cannot be
+ * reconstructed honestly and is left off. Pending is derived from the
+ * report blob (already stored) rather than a flat summary field — adding
+ * `pending` to `ScoreSummary`/`summarySchema` is a backend follow-up for
+ * surfaces that list summaries without reports.
  */
-function describeStoredScore(summary: ScoreSummary): string {
+function describeStoredScore(summary: ScoreSummary, pending = 0): string {
   if (summary.score === null) {
     return `not scored — 0 applicable checks (${summary.notApplicable} not applicable)`;
   }
@@ -44,6 +47,9 @@ function describeStoredScore(summary: ScoreSummary): string {
         summary.advisoryCount === 1 ? "y" : "ies"
       }`
     );
+  }
+  if (pending > 0) {
+    parts.push(`${pending} pending (unscored by this profile)`);
   }
   const version = summary.protocolVersion
     ? ` [${summary.protocolVersion}]`
@@ -67,6 +73,7 @@ interface ReportCheck {
   status?: string;
   error?: { message?: string };
   skipReason?: string;
+  pending?: boolean;
 }
 
 /**
@@ -84,6 +91,20 @@ function collectChecks(suite: unknown): ReportCheck[] {
     ? record.steps
     : [];
   return items as ReportCheck[];
+}
+
+/**
+ * Pending ids stamped on a suite report. An absent `profile` (legacy stored
+ * runs, and suites that have no stamp yet) yields an empty set — those
+ * pages render exactly as they did before profiles existed.
+ */
+function pendingIdsFromSuite(suite: unknown): Set<string> {
+  const record = suite as
+    | { profile?: { pendingCheckIds?: unknown } }
+    | undefined;
+  const ids = record?.profile?.pendingCheckIds;
+  if (!Array.isArray(ids)) return new Set();
+  return new Set(ids.filter((id): id is string => typeof id === "string"));
 }
 
 export function ScoreResultsPage() {
@@ -122,13 +143,25 @@ export function ScoreResultsPage() {
   const suites = useMemo(() => {
     if (!run) return [];
     return (["protocol", "apps", "tasks", "oauth"] as const)
-      .map((suiteId) => ({
-        suiteId,
-        summary: run.suiteSummaries.find((s) => s.suiteId === suiteId),
-        checks: collectChecks(run.report[suiteId]),
-      }))
+      .map((suiteId) => {
+        const report = run.report[suiteId];
+        const pendingIds = pendingIdsFromSuite(report);
+        const checks = collectChecks(report).map((check) => ({
+          ...check,
+          pending: Boolean(check.id && pendingIds.has(check.id)),
+        }));
+        return {
+          suiteId,
+          summary: run.suiteSummaries.find((s) => s.suiteId === suiteId),
+          checks,
+          // Same derivation as `partitionByStamp`: |checks ∩ pendingIds|.
+          pending: checks.filter((check) => check.pending).length,
+        };
+      })
       .filter((entry) => entry.summary || entry.checks.length > 0);
   }, [run]);
+
+  const pendingTotal = suites.reduce((total, suite) => total + suite.pending, 0);
 
   if (notFound) {
     return (
@@ -189,7 +222,7 @@ export function ScoreResultsPage() {
                 : "Fully conformant"}
             </div>
             <div className="text-xs text-muted-foreground">
-              {describeStoredScore(run)}
+              {describeStoredScore(run, pendingTotal)}
               {run.notApplicable > 0
                 ? ` · ${run.notApplicable} not applicable`
                 : ""}
@@ -199,7 +232,7 @@ export function ScoreResultsPage() {
       )}
 
       <div className="space-y-4">
-        {suites.map(({ suiteId, summary, checks }) => (
+        {suites.map(({ suiteId, summary, checks, pending }) => (
           <section
             key={suiteId}
             className="overflow-hidden rounded-md border border-border/50"
@@ -211,7 +244,7 @@ export function ScoreResultsPage() {
                 </div>
                 {summary && (
                   <div className="truncate text-[11px] text-muted-foreground">
-                    {describeStoredScore(summary)}
+                    {describeStoredScore(summary, pending)}
                   </div>
                 )}
               </div>
@@ -232,6 +265,14 @@ export function ScoreResultsPage() {
                     className="flex items-start gap-2 border-b border-border/30 px-4 py-2 last:border-b-0"
                   >
                     <CheckIcon status={check.status ?? "skipped"} />
+                    {check.pending ? (
+                      <span
+                        title="unscored by this run's profile"
+                        className="mt-0.5 shrink-0 rounded-sm border border-border/60 px-1 py-px text-[10px] leading-none text-muted-foreground"
+                      >
+                        unscored
+                      </span>
+                    ) : null}
                     <div className="min-w-0">
                       <div className="text-xs">
                         {check.title ?? check.id ?? "check"}

--- a/mcpjam-inspector/client/src/components/score/__tests__/ScoreResultsPage.test.tsx
+++ b/mcpjam-inspector/client/src/components/score/__tests__/ScoreResultsPage.test.tsx
@@ -1,0 +1,159 @@
+import { render, screen, waitFor } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { MemoryRouter, Route, Routes } from "react-router";
+import type { ScoreSummary, StoredScoreRun } from "@/lib/apis/score-api";
+
+const { mockFetchScoreRun } = vi.hoisted(() => ({
+  mockFetchScoreRun: vi.fn(),
+}));
+
+vi.mock("@/lib/apis/score-api", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@/lib/apis/score-api")>();
+  return {
+    ...actual,
+    fetchScoreRun: (...args: unknown[]) => mockFetchScoreRun(...args),
+  };
+});
+
+import { ScoreResultsPage } from "../ScoreResultsPage";
+
+function summary(overrides: Partial<ScoreSummary> = {}): ScoreSummary {
+  return {
+    score: 100,
+    outcome: "passed",
+    applicable: 1,
+    passed: 1,
+    failed: 0,
+    couldNotRun: 0,
+    notApplicable: 0,
+    advisoryCount: 0,
+    protocolVersion: "2025-11-25",
+    ...overrides,
+  };
+}
+
+/**
+ * A stored run whose protocol report stamps `wire-schema-valid` as pending
+ * while that check failed. The headline can still claim 100/100 — that is
+ * the retroactive-failure hole this page used to hide.
+ */
+function pendingBearingRun(): StoredScoreRun {
+  const headline = summary();
+  return {
+    ...headline,
+    serverUrl: "https://mcp.example.com/mcp",
+    createdAt: 1_700_000_000_000,
+    suiteSummaries: [{ suiteId: "protocol", ...headline }],
+    report: {
+      protocol: {
+        checks: [
+          {
+            id: "initialize",
+            title: "Initialize handshake",
+            status: "passed",
+          },
+          {
+            id: "wire-schema-valid",
+            title: "Wire schema is valid",
+            status: "failed",
+            error: { message: "schema mismatch" },
+          },
+        ],
+        profile: {
+          pendingCheckIds: ["wire-schema-valid"],
+        },
+      } as StoredScoreRun["report"]["protocol"],
+    },
+  };
+}
+
+/** Pre-profile stored run: no `profile` key, failed check stays a scored fail. */
+function stampLessLegacyRun(): StoredScoreRun {
+  const headline = summary({
+    score: 91,
+    outcome: "failed",
+    applicable: 2,
+    passed: 1,
+    failed: 1,
+  });
+  return {
+    ...headline,
+    serverUrl: "https://mcp.example.com/mcp",
+    createdAt: 1_700_000_000_000,
+    suiteSummaries: [{ suiteId: "protocol", ...headline }],
+    report: {
+      protocol: {
+        checks: [
+          {
+            id: "initialize",
+            title: "Initialize handshake",
+            status: "passed",
+          },
+          {
+            id: "wire-schema-valid",
+            title: "Wire schema is valid",
+            status: "failed",
+            error: { message: "schema mismatch" },
+          },
+        ],
+      } as StoredScoreRun["report"]["protocol"],
+    },
+  };
+}
+
+function renderPage() {
+  return render(
+    <MemoryRouter initialEntries={["/results/tok_test"]}>
+      <Routes>
+        <Route path="/results/:runToken" element={<ScoreResultsPage />} />
+      </Routes>
+    </MemoryRouter>,
+  );
+}
+
+describe("ScoreResultsPage pending profile stamp", () => {
+  beforeEach(() => {
+    mockFetchScoreRun.mockReset();
+  });
+
+  it("names pending in the headline and marks the pending failed row unscored", async () => {
+    mockFetchScoreRun.mockResolvedValue(pendingBearingRun());
+    renderPage();
+
+    await waitFor(() => {
+      expect(
+        screen.getAllByText(/1 pending \(unscored by this profile\)/).length,
+      ).toBeGreaterThan(0);
+    });
+
+    const pendingRow = screen.getByText("Wire schema is valid").closest("li");
+    expect(pendingRow).toBeTruthy();
+    expect(pendingRow).toHaveTextContent("unscored");
+    expect(
+      screen.getByTitle("unscored by this run's profile").closest("li"),
+    ).toBe(pendingRow);
+    // The fail icon stays: pending is orthogonal to execution status.
+    expect(pendingRow?.querySelector("svg")).toBeTruthy();
+
+    const scoredRow = screen.getByText("Initialize handshake").closest("li");
+    expect(scoredRow).not.toHaveTextContent("unscored");
+  });
+
+  it("renders a stamp-less legacy run unchanged — no pending clause, no unscored badge", async () => {
+    mockFetchScoreRun.mockResolvedValue(stampLessLegacyRun());
+    renderPage();
+
+    await waitFor(() => {
+      expect(
+        screen.getAllByText(/1\/2 applicable checks passed, 1 failed/).length,
+      ).toBeGreaterThan(0);
+    });
+
+    expect(
+      screen.queryByText(/pending \(unscored by this profile\)/),
+    ).not.toBeInTheDocument();
+    expect(screen.queryByText("unscored")).not.toBeInTheDocument();
+    expect(screen.getByText("Wire schema is valid")).toBeInTheDocument();
+    expect(screen.getByText("schema mismatch")).toBeInTheDocument();
+  });
+});

--- a/mcpjam-inspector/client/src/lib/apis/score-api.ts
+++ b/mcpjam-inspector/client/src/lib/apis/score-api.ts
@@ -18,7 +18,13 @@ import type { OAuthConformanceStartResult } from "@/lib/apis/mcp-conformance-api
 
 export type ScoreSuiteId = "protocol" | "apps" | "tasks" | "oauth";
 
-/** The flat headline stored on a run. Mirrors `ConformanceScore` minus advisories. */
+/**
+ * The flat headline stored on a run. Mirrors `ConformanceScore` minus
+ * advisories and pending. Pending is derived on the results page from
+ * `report[suite].profile.pendingCheckIds` (the share fetch always includes
+ * the report blob). A flat `pending` int is a backend follow-up for
+ * surfaces that list summaries without reports.
+ */
 export interface ScoreSummary {
   score: number | null;
   outcome: "passed" | "failed" | "incomplete";


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Purpose and context

PR #4229 landed frozen conformance profiles: new checks run **pending** — reported but unscored — so published scores cannot move retroactively. The SDK seams (`scoreFromProtocolResult`, `toConformanceReport`) already propagate this. The score.mcpjam.com results page did not: `ScoreSummary` is a hand-mirror of `ConformanceScore` minus `pending`, the headline omitted the "N pending (unscored)" clause, and a failed pending check rendered as a plain red ✗ under a headline that can claim 100/100.

This is **PR A** of the conformance-surfacing series (A → B → C0 → C). Client-only; no backend change. Stopping here for review per the one-PR-per-step gate.

## Before / after

**Before**
- Headline rebuilt from stored counts never mentioned pending.
- A failed pending check looked identical to a scored failure.
- A 100/100 headline could sit above a red ✗ that the profile did not score.

**After**
- `suites` reads `report[suiteId].profile.pendingCheckIds` and marks each collected check `pending` when its id is in that set (`|checks ∩ pendingIds|`, same as `partitionByStamp`).
- `describeStoredScore` appends `N pending (unscored by this profile)` from those derived counts. Advice still omits the SDK's `(−N)` deduction — `advicePointsLost` is not stored.
- Pending rows keep their real pass/fail icon and get an **unscored** badge (`title`: "unscored by this run's profile").
- Stamp-less legacy reports (no `profile` key) render exactly as today.

Deliberately **not** adding a flat `pending` int to `ScoreSummary` / `summarySchema` / Convex. The results page fetches the full run (report included) in one request. A flat field only matters for a future summary-only list surface — backend follow-up, not this PR.

## Tests

- `mcpjam-inspector/client/src/components/score/__tests__/ScoreResultsPage.test.tsx`
  - Stored run with `profile.pendingCheckIds: ["wire-schema-valid"]` and a failed check of that id: headline names pending, row is marked unscored, scored sibling is not.
  - Stamp-less legacy run: no pending clause, no unscored badge.

## Verification

- Root `typecheck`: passed
- `ScoreResultsPage` + other score client tests: 13/13 passed
- Score relay route tests: 14/14 passed
- `npm run build:inspector`: passed
- Full `npm run verify` aborted on a pre-existing `discord-app` flake (`journey-watcher.test.js` cancelledByParent / event-loop still pending). Unrelated to this client-only change; reproduced on a second isolated `npm run verify -w @mcpjam/discord-app`.

Manual share-flow check against a live stored token was not run here — this environment has no Convex score-run credentials. The page test covers the pending-bearing and legacy report shapes the share fetch already returns.

## Rollout

- Client-only render change. No schema, no persistence, no deploy-order constraint.
- Old stored runs without `profile` are unchanged.
- Follow-ups after merge: PR B (in-product `ConformancePanel` per-row marker), PR C0 (backend pending-parity bug + per-suite profile identity), PR C (agent start→poll ops).

## Follow-ups (not in this PR)

- Flat `pending` on `ScoreSummary` / backend `summarySchema` for summary-only list surfaces.
- Advice `(−N)` wording on the share page (needs `advicePointsLost` stored).
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-bcc24dbc-32bc-4afe-b700-68c976d3ec6d?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-bcc24dbc-32bc-4afe-b700-68c976d3ec6d&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Surface pending checks on the shared score results page so headlines and rows reflect unscored checks. Previously, pending checks were omitted from the headline and looked like scored failures; now the headline includes “N pending (unscored)” and pending rows carry an “unscored” badge while keeping their pass/fail icon.

- Derives pending per suite from `report[suite].profile.pendingCheckIds`, marks matching checks `pending`, and passes pending counts into the headline builder.
- Renders an “unscored” badge (title: “unscored by this run's profile”) for pending rows; legacy runs without `profile` render unchanged.
- No schema or API changes. `ScoreSummary` remains flat; a doc note clarifies that pending is derived from the report. Client-only change; no deploy order constraints.
- Adds tests for pending stamping and legacy runs.

<sup>Written for commit 49edbe0d52541d85031dde2453821e678fc87866. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/MCPJam/inspector/pull/4260?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

