### PR TITLE
feat: Home tab shared Slack Connect channel card

### DIFF
--- a/mcpjam-inspector/client/src/components/HomeTab.tsx
+++ b/mcpjam-inspector/client/src/components/HomeTab.tsx
@@ -11,12 +11,14 @@ import { useAuth } from "@workos-inc/authkit-react";
 import { track } from "@/lib/analytics";
 import { ArrowLeft, Plus } from "lucide-react";
 import { useAppNavigate } from "@/lib/app-navigation";
+import { ErrorBoundary } from "@/components/ui/error-boundary";
 import { Button } from "@mcpjam/design-system/button";
 import { Skeleton } from "@mcpjam/design-system/skeleton";
 import { OrgStatsStrip } from "./home/OrgStatsStrip";
 import { RecommendedServers } from "./home/RecommendedServers";
 import { RecommendedHosts } from "./home/RecommendedHosts";
 import { ProductUpdatesRow } from "./home/ProductUpdatesRow";
+import { SharedSlackChannelCard } from "./home/SharedSlackChannelCard";
 import { McpjamAgentHero } from "./mcpjam-agent/McpjamAgentHero";
 import { McpjamAgentThread } from "./mcpjam-agent/McpjamAgentThread";
 import {
@@ -373,6 +375,10 @@ export function HomeTab({
         />
 
         <ProductUpdatesRow />
+
+        <ErrorBoundary name="home-shared-slack-channel" fallback={null}>
+          <SharedSlackChannelCard organizationId={organizationId} />
+        </ErrorBoundary>
 
         <div className="grid gap-4 sm:grid-cols-2">
           <RecommendedServers

--- a/mcpjam-inspector/client/src/components/home/SharedSlackChannelCard.tsx
+++ b/mcpjam-inspector/client/src/components/home/SharedSlackChannelCard.tsx
@@ -1,0 +1,378 @@
+import {
+  useCallback,
+  useEffect,
+  useRef,
+  useState,
+  type ReactNode,
+} from "react";
+import { useAction, useQuery } from "convex/react";
+import { ExternalLink, Hash, Loader2 } from "lucide-react";
+import { useSharedSlackChannelEnabled } from "@/hooks/useSharedSlackChannelEnabled";
+import { track } from "@/lib/analytics";
+import { convexErrMessage } from "@/lib/convex-error";
+import { toast } from "@/lib/toast";
+
+/**
+ * Hand-mirrored DTO from `orgSharedSlackChannels.getForOrganization`.
+ * The backend deploys first; the client does not import Convex generated
+ * types from mcpjam-backend.
+ */
+export type SharedSlackChannelStatus =
+  | "provisioning"
+  | "invite_sent"
+  | "pending_admin_approval"
+  | "active"
+  | "invite_declined"
+  | "invite_expired"
+  | "error";
+
+export type SharedSlackChannelView = {
+  status: SharedSlackChannelStatus;
+  inviteExpiresAt?: number;
+  invitedEmail?: string;
+  channelName?: string;
+  openUrl: string | null;
+  errorCode?: string;
+  inviteUrl?: string;
+};
+
+export type SharedSlackChannelDto = {
+  channel: SharedSlackChannelView | null;
+  canProvision: boolean;
+  canManageInvite: boolean;
+};
+
+function convexErrCode(err: unknown): string | undefined {
+  if (err && typeof err === "object" && "data" in err) {
+    const data = (err as { data: unknown }).data;
+    if (data && typeof data === "object" && "code" in data) {
+      const code = (data as { code: unknown }).code;
+      if (typeof code === "string" && code.trim()) return code;
+    }
+  }
+  return undefined;
+}
+
+function formatExpiry(epochMs: number): string {
+  return new Date(epochMs).toLocaleDateString(undefined, {
+    month: "short",
+    day: "numeric",
+    year: "numeric",
+  });
+}
+
+function errorCopy(
+  errorCode: string | undefined,
+  invitedEmail?: string
+): string {
+  switch (errorCode) {
+    case "slack_config":
+      return "Slack Connect isn't available right now — our team has been notified.";
+    case "slack_connect_limit":
+      return "This Slack workspace has reached its Slack Connect connection limit.";
+    case "invite_email_rejected":
+      return invitedEmail
+        ? `Slack rejected the invite email (${invitedEmail}).`
+        : "Slack rejected the invite email.";
+    case "channel_name_conflict":
+      return "Could not create a unique shared channel name. Contact support.";
+    case "retry_limit":
+      return "Too many setup attempts. Contact support to finish this channel.";
+    case "provision_in_flight":
+      return "Channel setup is already in progress. Try again in a few minutes.";
+    case "not_configured":
+      return "Slack Connect is not configured on this deployment.";
+    case "invite_declined":
+      return "The Slack Connect invite was declined. Free Slack workspaces cannot accept Connect invites — contact support if that isn't the case.";
+    case "invite_expired":
+      return "The Slack Connect invite expired. Request a new one.";
+    default:
+      return "Could not set up the shared Slack channel. Try again.";
+  }
+}
+
+function cardState(
+  channel: SharedSlackChannelView | null
+): SharedSlackChannelStatus | "none" {
+  return channel?.status ?? "none";
+}
+
+function SharedSlackSkeleton() {
+  return (
+    <section
+      className="rounded-xl border border-border/60"
+      aria-busy="true"
+      aria-label="Loading shared Slack channel"
+    >
+      <div className="border-b border-border/60 px-4 py-2">
+        <div className="h-3.5 w-40 animate-pulse rounded-sm bg-muted" />
+      </div>
+      <div className="flex items-center gap-2.5 px-4 py-3">
+        <div className="size-6 shrink-0 animate-pulse rounded bg-muted" />
+        <div className="h-3.5 w-56 animate-pulse rounded-sm bg-muted" />
+      </div>
+    </section>
+  );
+}
+
+function CardShell({
+  children,
+  title = "Shared Slack channel",
+}: {
+  children: ReactNode;
+  title?: string;
+}) {
+  return (
+    <section className="rounded-xl border border-border/60">
+      <div className="border-b border-border/60 px-4 py-2">
+        <h2 className="text-[13px] font-medium text-foreground">{title}</h2>
+      </div>
+      {children}
+    </section>
+  );
+}
+
+/**
+ * Home-tab Slack Connect card.
+ *
+ * Renders purely from the backend DTO (`channel`, `canProvision`,
+ * `canManageInvite`). It never discovers the viewer's org role itself.
+ * `organizationId` is the home org HomeTab already resolved — the card
+ * does not re-derive it.
+ */
+export function SharedSlackChannelCard({
+  organizationId,
+}: {
+  organizationId: string | null;
+}) {
+  const enabled = useSharedSlackChannelEnabled();
+  const dto = useQuery(
+    "orgSharedSlackChannels:getForOrganization" as any,
+    enabled && organizationId ? ({ organizationId } as any) : "skip"
+  ) as SharedSlackChannelDto | undefined;
+  const provision = useAction("orgSharedSlackChannelsNode:provision" as any);
+  const refreshStatus = useAction(
+    "orgSharedSlackChannelsNode:refreshStatus" as any
+  );
+
+  const [busy, setBusy] = useState(false);
+  const viewedKey = useRef<string | null>(null);
+  const refreshedFor = useRef<string | null>(null);
+
+  const status = dto?.channel?.status;
+  useEffect(() => {
+    if (!organizationId) return;
+    if (status !== "invite_sent" && status !== "pending_admin_approval") {
+      return;
+    }
+    const key = `${organizationId}:${status}`;
+    if (refreshedFor.current === key) return;
+    refreshedFor.current = key;
+    refreshStatus({ organizationId }).catch(() => {
+      // Rate-limited / transient — the card keeps current data.
+    });
+  }, [organizationId, status, refreshStatus]);
+
+  useEffect(() => {
+    if (!enabled || !organizationId || dto === undefined) return;
+    if (dto.channel === null && !dto.canProvision) return;
+    const state = cardState(dto.channel);
+    const key = `${organizationId}:${state}`;
+    if (viewedKey.current === key) return;
+    viewedKey.current = key;
+    track("home_shared_slack_card_viewed", { location: "home", state });
+  }, [enabled, organizationId, dto]);
+
+  const runProvision = useCallback(
+    async (kind: "provision" | "retry") => {
+      if (!organizationId) return;
+      const state = cardState(dto?.channel ?? null);
+      track(
+        kind === "retry"
+          ? "home_shared_slack_retry_clicked"
+          : "home_shared_slack_provision_clicked",
+        { location: "home", state }
+      );
+      setBusy(true);
+      try {
+        const result = (await provision({ organizationId })) as {
+          status?: string;
+        };
+        if (result?.status === "invite_sent") {
+          toast.success(
+            dto?.channel?.invitedEmail
+              ? `Invite sent to ${dto.channel.invitedEmail}`
+              : "Slack Connect invite sent"
+          );
+        } else if (result?.status === "active") {
+          toast.success("Your shared Slack channel is ready");
+        }
+      } catch (err) {
+        toast.error(convexErrMessage(err, errorCopy(convexErrCode(err))));
+      } finally {
+        setBusy(false);
+      }
+    },
+    [organizationId, dto, provision]
+  );
+
+  if (!enabled || !organizationId) return null;
+  if (dto === undefined) return <SharedSlackSkeleton />;
+  if (dto.channel === null && !dto.canProvision) return null;
+
+  const channel = dto.channel;
+  const showSpinner = busy || channel?.status === "provisioning";
+
+  if (showSpinner && (channel === null || channel.status === "provisioning")) {
+    return (
+      <CardShell>
+        <div className="flex items-center gap-2.5 px-4 py-3 text-[13px] text-muted-foreground">
+          <Loader2 className="size-4 animate-spin" aria-hidden />
+          Setting up your shared Slack channel…
+        </div>
+      </CardShell>
+    );
+  }
+
+  if (channel === null) {
+    return (
+      <CardShell>
+        <div className="flex items-center gap-2.5 px-4 py-3">
+          <div className="grid size-6 shrink-0 place-items-center rounded bg-muted/60 text-muted-foreground">
+            <Hash className="size-3.5" strokeWidth={1.75} />
+          </div>
+          <div className="min-w-0 flex-1">
+            <p className="text-[13px] text-foreground">
+              Set up your shared Slack channel
+            </p>
+            <p className="text-[11px] text-muted-foreground">
+              A Slack Connect channel with the MCPJam team, invited to your
+              login email.
+            </p>
+          </div>
+          {dto.canProvision ? (
+            <button
+              type="button"
+              disabled={busy}
+              onClick={() => void runProvision("provision")}
+              className="shrink-0 text-[11px] font-medium text-muted-foreground transition hover:text-foreground disabled:opacity-50"
+            >
+              Set up
+            </button>
+          ) : null}
+        </div>
+      </CardShell>
+    );
+  }
+
+  if (channel.status === "invite_sent") {
+    const expiry = channel.inviteExpiresAt
+      ? formatExpiry(channel.inviteExpiresAt)
+      : null;
+    return (
+      <CardShell>
+        <div className="space-y-2 px-4 py-3">
+          <p className="text-[13px] text-foreground">
+            Invite sent
+            {channel.invitedEmail ? ` to ${channel.invitedEmail}` : ""}
+            {expiry ? `, expires ${expiry}` : ""}.
+          </p>
+          <p className="text-[11px] text-muted-foreground">
+            Check your email for Slack&apos;s invite — that is the official
+            path. The in-app link is a convenience when we have one.
+          </p>
+          {channel.inviteUrl ? (
+            <a
+              href={channel.inviteUrl}
+              target="_blank"
+              rel="noreferrer"
+              onClick={() =>
+                track("home_shared_slack_invite_opened", {
+                  location: "home",
+                  state: "invite_sent",
+                })
+              }
+              className="inline-flex items-center gap-1 text-[11px] font-medium text-foreground hover:underline"
+            >
+              Accept the invite in Slack
+              <ExternalLink className="size-3" />
+            </a>
+          ) : null}
+        </div>
+      </CardShell>
+    );
+  }
+
+  if (channel.status === "pending_admin_approval") {
+    return (
+      <CardShell>
+        <p className="px-4 py-3 text-[13px] text-foreground">
+          Waiting on your Slack workspace admin to approve the Connect invite.
+        </p>
+      </CardShell>
+    );
+  }
+
+  if (channel.status === "active") {
+    return (
+      <CardShell>
+        <div className="flex items-center gap-2.5 px-4 py-3">
+          <div className="grid size-6 shrink-0 place-items-center rounded bg-muted/60 text-muted-foreground">
+            <Hash className="size-3.5" strokeWidth={1.75} />
+          </div>
+          <p className="min-w-0 flex-1 truncate text-[13px] text-foreground">
+            {channel.channelName
+              ? `#${channel.channelName}`
+              : "Your shared Slack channel"}
+          </p>
+          {channel.openUrl ? (
+            <a
+              href={channel.openUrl}
+              target="_blank"
+              rel="noreferrer"
+              onClick={() =>
+                track("home_shared_slack_channel_opened", {
+                  location: "home",
+                  state: "active",
+                })
+              }
+              className="inline-flex shrink-0 items-center gap-1 text-[11px] font-medium text-muted-foreground transition hover:text-foreground"
+            >
+              Open your shared Slack channel
+              <ExternalLink className="size-3" />
+            </a>
+          ) : (
+            <span className="text-[11px] text-muted-foreground">
+              Shared channel is connected
+            </span>
+          )}
+        </div>
+      </CardShell>
+    );
+  }
+
+  return (
+    <CardShell>
+      <div className="flex items-start gap-2.5 px-4 py-3">
+        <div className="min-w-0 flex-1">
+          <p className="text-[13px] text-foreground">
+            {errorCopy(
+              channel.errorCode ?? channel.status,
+              channel.invitedEmail
+            )}
+          </p>
+        </div>
+        {dto.canManageInvite ? (
+          <button
+            type="button"
+            disabled={busy}
+            onClick={() => void runProvision("retry")}
+            className="shrink-0 text-[11px] font-medium text-muted-foreground transition hover:text-foreground disabled:opacity-50"
+          >
+            Retry
+          </button>
+        ) : null}
+      </div>
+    </CardShell>
+  );
+}

--- a/mcpjam-inspector/client/src/components/home/__tests__/SharedSlackChannelCard.test.tsx
+++ b/mcpjam-inspector/client/src/components/home/__tests__/SharedSlackChannelCard.test.tsx
@@ -1,0 +1,247 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  SharedSlackChannelCard,
+  type SharedSlackChannelDto,
+} from "../SharedSlackChannelCard";
+
+const mockUseQuery = vi.fn();
+const mockProvision = vi.fn();
+const mockRefresh = vi.fn();
+const flagMock = vi.fn();
+const trackMock = vi.fn();
+const toastError = vi.fn();
+const toastSuccess = vi.fn();
+
+vi.mock("convex/react", () => ({
+  useQuery: (...args: unknown[]) => mockUseQuery(...args),
+  useAction: (name: string) => {
+    if (name === "orgSharedSlackChannelsNode:provision") return mockProvision;
+    if (name === "orgSharedSlackChannelsNode:refreshStatus") return mockRefresh;
+    return vi.fn();
+  },
+}));
+
+vi.mock("@/hooks/useSharedSlackChannelEnabled", () => ({
+  useSharedSlackChannelEnabled: () => flagMock(),
+  SHARED_SLACK_CHANNEL_FEATURE_FLAG: "shared-slack-channel-enabled",
+}));
+
+vi.mock("@/lib/analytics", () => ({
+  track: (...args: unknown[]) => trackMock(...args),
+}));
+
+vi.mock("@/lib/toast", () => ({
+  toast: {
+    error: (...args: unknown[]) => toastError(...args),
+    success: (...args: unknown[]) => toastSuccess(...args),
+  },
+}));
+
+function dto(
+  overrides: Partial<SharedSlackChannelDto> & {
+    channel?: SharedSlackChannelDto["channel"];
+  } = {}
+): SharedSlackChannelDto {
+  return {
+    channel: null,
+    canProvision: true,
+    canManageInvite: true,
+    ...overrides,
+  };
+}
+
+describe("SharedSlackChannelCard", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    flagMock.mockReturnValue(true);
+    mockRefresh.mockResolvedValue({ refreshed: false });
+    mockProvision.mockResolvedValue({ status: "invite_sent" });
+  });
+
+  it("renders nothing when the flag is off", () => {
+    flagMock.mockReturnValue(false);
+    mockUseQuery.mockReturnValue(undefined);
+    const { container } = render(
+      <SharedSlackChannelCard organizationId="org_1" />
+    );
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it("renders nothing when there is no organization", () => {
+    mockUseQuery.mockReturnValue(undefined);
+    const { container } = render(
+      <SharedSlackChannelCard organizationId={null} />
+    );
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it("shows a skeleton while the query is settling — never the empty-state", () => {
+    mockUseQuery.mockReturnValue(undefined);
+    render(<SharedSlackChannelCard organizationId="org_1" />);
+    expect(
+      screen.getByLabelText("Loading shared Slack channel")
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByText("Set up your shared Slack channel")
+    ).not.toBeInTheDocument();
+  });
+
+  it("renders nothing for a member who cannot provision and has no row", () => {
+    mockUseQuery.mockReturnValue(
+      dto({ canProvision: false, canManageInvite: false, channel: null })
+    );
+    const { container } = render(
+      <SharedSlackChannelCard organizationId="org_1" />
+    );
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it("shows the setup CTA when the org has no channel and the viewer can provision", () => {
+    mockUseQuery.mockReturnValue(dto());
+    render(<SharedSlackChannelCard organizationId="org_1" />);
+    expect(
+      screen.getByText("Set up your shared Slack channel")
+    ).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Set up" })).toBeInTheDocument();
+    expect(trackMock).toHaveBeenCalledWith("home_shared_slack_card_viewed", {
+      location: "home",
+      state: "none",
+    });
+  });
+
+  it("shows a spinner while provisioning", () => {
+    mockUseQuery.mockReturnValue(
+      dto({
+        channel: {
+          status: "provisioning",
+          openUrl: null,
+        },
+      })
+    );
+    render(<SharedSlackChannelCard organizationId="org_1" />);
+    expect(
+      screen.getByText("Setting up your shared Slack channel…")
+    ).toBeInTheDocument();
+  });
+
+  it("shows invite_sent copy, expiry, and the accept link only when inviteUrl is present", () => {
+    mockUseQuery.mockReturnValue(
+      dto({
+        channel: {
+          status: "invite_sent",
+          invitedEmail: "sam@acme.com",
+          inviteExpiresAt: Date.UTC(2026, 8, 5),
+          inviteUrl: "https://slack.com/invite",
+          openUrl: null,
+        },
+      })
+    );
+    render(<SharedSlackChannelCard organizationId="org_1" />);
+    expect(screen.getByText(/Invite sent to sam@acme.com/)).toBeInTheDocument();
+    expect(
+      screen.getByText(/Check your email for Slack's invite/)
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("link", { name: /Accept the invite in Slack/ })
+    ).toHaveAttribute("href", "https://slack.com/invite");
+    expect(mockRefresh).toHaveBeenCalledWith({ organizationId: "org_1" });
+  });
+
+  it("omits the accept link when inviteUrl is authorization-scoped away", () => {
+    mockUseQuery.mockReturnValue(
+      dto({
+        canManageInvite: false,
+        canProvision: false,
+        channel: {
+          status: "invite_sent",
+          invitedEmail: "sam@acme.com",
+          openUrl: null,
+        },
+      })
+    );
+    render(<SharedSlackChannelCard organizationId="org_1" />);
+    expect(
+      screen.queryByRole("link", { name: /Accept the invite in Slack/ })
+    ).not.toBeInTheDocument();
+    expect(screen.getByText(/Invite sent to sam@acme.com/)).toBeInTheDocument();
+  });
+
+  it("shows pending admin approval copy", () => {
+    mockUseQuery.mockReturnValue(
+      dto({
+        channel: { status: "pending_admin_approval", openUrl: null },
+      })
+    );
+    render(<SharedSlackChannelCard organizationId="org_1" />);
+    expect(
+      screen.getByText(/Waiting on your Slack workspace admin to approve/)
+    ).toBeInTheDocument();
+  });
+
+  it("shows the open-channel link when active", () => {
+    mockUseQuery.mockReturnValue(
+      dto({
+        channel: {
+          status: "active",
+          channelName: "ext-acme-mcpjam",
+          openUrl: "https://app.slack.com/client/T1/C1",
+        },
+      })
+    );
+    render(<SharedSlackChannelCard organizationId="org_1" />);
+    expect(screen.getByText("#ext-acme-mcpjam")).toBeInTheDocument();
+    expect(
+      screen.getByRole("link", { name: /Open your shared Slack channel/ })
+    ).toHaveAttribute("href", "https://app.slack.com/client/T1/C1");
+  });
+
+  it("shows per-code error copy and Retry for an admin", () => {
+    mockUseQuery.mockReturnValue(
+      dto({
+        channel: {
+          status: "error",
+          errorCode: "slack_config",
+          openUrl: null,
+        },
+      })
+    );
+    render(<SharedSlackChannelCard organizationId="org_1" />);
+    expect(screen.getByText(/our team has been notified/)).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Retry" })).toBeInTheDocument();
+  });
+
+  it("hides Retry when the viewer cannot manage the invite", () => {
+    mockUseQuery.mockReturnValue(
+      dto({
+        canManageInvite: false,
+        canProvision: false,
+        channel: {
+          status: "invite_expired",
+          errorCode: "invite_expired",
+          openUrl: null,
+        },
+      })
+    );
+    render(<SharedSlackChannelCard organizationId="org_1" />);
+    expect(
+      screen.queryByRole("button", { name: "Retry" })
+    ).not.toBeInTheDocument();
+  });
+
+  it("toasts ConvexError.data.message when provision fails", async () => {
+    mockUseQuery.mockReturnValue(dto());
+    mockProvision.mockRejectedValue({
+      data: { code: "slack_connect_limit", message: "limit hit" },
+    });
+    render(<SharedSlackChannelCard organizationId="org_1" />);
+    fireEvent.click(screen.getByRole("button", { name: "Set up" }));
+    expect(trackMock).toHaveBeenCalledWith(
+      "home_shared_slack_provision_clicked",
+      { location: "home", state: "none" }
+    );
+    await vi.waitFor(() => {
+      expect(toastError).toHaveBeenCalledWith("limit hit");
+    });
+  });
+});

--- a/mcpjam-inspector/client/src/components/home/__tests__/SharedSlackChannelCard.test.tsx
+++ b/mcpjam-inspector/client/src/components/home/__tests__/SharedSlackChannelCard.test.tsx
@@ -138,13 +138,27 @@ describe("SharedSlackChannelCard", () => {
       })
     );
     render(<SharedSlackChannelCard organizationId="org_1" />);
-    expect(screen.getByText(/Invite sent to sam@acme.com/)).toBeInTheDocument();
+    const expectedExpiry = new Date(Date.UTC(2026, 8, 5)).toLocaleDateString(
+      undefined,
+      { month: "short", day: "numeric", year: "numeric" }
+    );
+    expect(
+      screen.getByText(
+        `Invite sent to sam@acme.com, expires ${expectedExpiry}.`
+      )
+    ).toBeInTheDocument();
     expect(
       screen.getByText(/Check your email for Slack's invite/)
     ).toBeInTheDocument();
-    expect(
-      screen.getByRole("link", { name: /Accept the invite in Slack/ })
-    ).toHaveAttribute("href", "https://slack.com/invite");
+    const inviteLink = screen.getByRole("link", {
+      name: /Accept the invite in Slack/,
+    });
+    expect(inviteLink).toHaveAttribute("href", "https://slack.com/invite");
+    fireEvent.click(inviteLink);
+    expect(trackMock).toHaveBeenCalledWith("home_shared_slack_invite_opened", {
+      location: "home",
+      state: "invite_sent",
+    });
     expect(mockRefresh).toHaveBeenCalledWith({ organizationId: "org_1" });
   });
 
@@ -191,9 +205,18 @@ describe("SharedSlackChannelCard", () => {
     );
     render(<SharedSlackChannelCard organizationId="org_1" />);
     expect(screen.getByText("#ext-acme-mcpjam")).toBeInTheDocument();
-    expect(
-      screen.getByRole("link", { name: /Open your shared Slack channel/ })
-    ).toHaveAttribute("href", "https://app.slack.com/client/T1/C1");
+    const channelLink = screen.getByRole("link", {
+      name: /Open your shared Slack channel/,
+    });
+    expect(channelLink).toHaveAttribute(
+      "href",
+      "https://app.slack.com/client/T1/C1"
+    );
+    fireEvent.click(channelLink);
+    expect(trackMock).toHaveBeenCalledWith("home_shared_slack_channel_opened", {
+      location: "home",
+      state: "active",
+    });
   });
 
   it("shows per-code error copy and Retry for an admin", () => {
@@ -208,7 +231,12 @@ describe("SharedSlackChannelCard", () => {
     );
     render(<SharedSlackChannelCard organizationId="org_1" />);
     expect(screen.getByText(/our team has been notified/)).toBeInTheDocument();
-    expect(screen.getByRole("button", { name: "Retry" })).toBeInTheDocument();
+    fireEvent.click(screen.getByRole("button", { name: "Retry" }));
+    expect(trackMock).toHaveBeenCalledWith("home_shared_slack_retry_clicked", {
+      location: "home",
+      state: "error",
+    });
+    expect(mockProvision).toHaveBeenCalledWith({ organizationId: "org_1" });
   });
 
   it("hides Retry when the viewer cannot manage the invite", () => {

--- a/mcpjam-inspector/client/src/hooks/useSharedSlackChannelEnabled.ts
+++ b/mcpjam-inspector/client/src/hooks/useSharedSlackChannelEnabled.ts
@@ -1,0 +1,16 @@
+import { useFeatureFlagEnabled } from "posthog-js/react";
+
+export const SHARED_SLACK_CHANNEL_FEATURE_FLAG = "shared-slack-channel-enabled";
+
+/**
+ * Home-tab shared Slack Connect channel card. Same PostHog key the backend
+ * gates writes with (`shared-slack-channel-enabled`). One lever, both repos.
+ *
+ * `useFeatureFlagEnabled` returns `undefined` while flags load, and that is
+ * treated as OFF. Fail-closed is the right default for a dark feature: the
+ * cost is a missing card until flags arrive, not a flash of a provision
+ * button an unflagged org should never see.
+ */
+export function useSharedSlackChannelEnabled(): boolean {
+  return useFeatureFlagEnabled(SHARED_SLACK_CHANNEL_FEATURE_FLAG) === true;
+}

--- a/mcpjam-inspector/shared/analytics-events.ts
+++ b/mcpjam-inspector/shared/analytics-events.ts
@@ -396,6 +396,16 @@ export const ANALYTICS_EVENTS = {
   ui_navigation_rejected: { source: "client" },
   ui_tool_call_completed: { source: "client" },
   ui_tool_call_started: { source: "client" },
+
+  // --- Home: shared Slack Connect channel card ---
+  // Flag-dark (`shared-slack-channel-enabled`). Props: location ("home"),
+  // state (none | provisioning | invite_sent | pending_admin_approval |
+  // active | invite_declined | invite_expired | error).
+  home_shared_slack_card_viewed: { source: "client" },
+  home_shared_slack_provision_clicked: { source: "client" },
+  home_shared_slack_invite_opened: { source: "client" },
+  home_shared_slack_retry_clicked: { source: "client" },
+  home_shared_slack_channel_opened: { source: "client" },
 } as const satisfies Record<string, { source: "client" | "server" }>;
 
 export type AnalyticsEventName = keyof typeof ANALYTICS_EVENTS;


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Purpose

PR4 of the Shared Slack Channel on Home sequence (client). Flag-dark Home card that mirrors the backend DTO by hand. Deploy **after** backend PR1–PR3 (`orgSharedSlackChannels` + Node provision/refresh).

## Context

MCPJam already has ~20 Slack Connect channels that the product does not know about. This card is the customer-facing surface: orgs with a channel get “Open your shared Slack channel”; orgs without one (admins, flagged in) get self-serve setup. The card never discovers the viewer’s org role — `canProvision` / `canManageInvite` / scoped `inviteUrl` come from `getForOrganization`.

## Before / after

- **Before:** Home goes from product updates straight to the recommended grid.
- **After:** A `SharedSlackChannelCard` mounts between them when the PostHog flag `shared-slack-channel-enabled` is on and the query returns a row or `canProvision`.
  - Flag off / no org / guest query throw (`ErrorBoundary fallback={null}`) / (`channel === null` && `!canProvision`) → render nothing.
  - Query `undefined` → skeleton (never flash the empty-state).
  - States: none → Set up; provisioning → spinner; invite_sent → sent to `{email}`, expires `{date}`, “check your email”, Accept link only when `inviteUrl` is present; pending_admin_approval → waiting on workspace admin; active → open `openUrl`; declined/expired/error → per-code copy + Retry for admins.
  - On-view `refreshStatus` only for `invite_sent` | `pending_admin_approval`.
  - Toasts via `@/lib/toast` using `ConvexError.data`.

## Verification

- Vitest `SharedSlackChannelCard.test.tsx` (13 cases): flag-off → null; no-org → null; skeleton before empty-state; member-without-row → null; per-state render; inviteUrl scoped away; Retry hidden for non-admins; ConvexError toast.
- Analytics ratchet still green (`home_shared_slack_*` registered first).
- `npm run typecheck:client` clean.

## Rollout

- Flag stays dark. Un-dark in PostHog after backend deploys and a manual E2E (start marcelo-only).
- `organizationId` is passed from `HomeTab` (already resolved) rather than re-derived inside the card.

## Linked

- Backend: ops #1090 · schema #1091 · provision #1092 · reconcile #1093

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-28c024ca-fcb3-4bff-93bd-e5c84dfaf2cb?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-28c024ca-fcb3-4bff-93bd-e5c84dfaf2cb&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a feature‑flagged Shared Slack Connect channel card to the Home tab, rendered from `orgSharedSlackChannels.getForOrganization`. Before, Home jumped from product updates to recommendations; now, the card appears between them when the flag is on and the org has a channel or can provision.

- Gates with PostHog flag `shared-slack-channel-enabled` via `posthog-js/react`; shows a skeleton while flags/query load and renders nothing for guests/errors (`ErrorBoundary` `fallback={null}`).
- Renders strictly from DTO fields (`channel`, `canProvision`, `canManageInvite`, scoped `inviteUrl`); `organizationId` flows from `HomeTab`.
- States: none → setup CTA; provisioning → spinner; invite_sent → email/expiry plus accept link when `inviteUrl`; pending_admin_approval; active → open via `openUrl`; declined/expired/error → per‑code copy with Retry only when `canManageInvite`. Refresh runs on view for invite_sent/pending.
- Invokes `convex/react` actions for provision/refresh; toasts via `@/lib/toast`. Tracks `home_shared_slack_*` events in `shared/analytics-events.ts`.
- Tests cover gating, state rendering, permissions, toasts, expiry formatting, and click handlers for invite/channel links.

**Rollout**
- Deploy after backend support for `orgSharedSlackChannels` and node provision/refresh is live; keep the flag dark until a manual E2E passes.
- No client migrations; enable the PostHog flag per org to roll out.

<sup>Written for commit d661d7a2e1b7236bf5b8ce79ba883243a3ddd409. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/MCPJam/inspector/pull/4262?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

