### PR TITLE
cli: report cloud status validity without throwing

### DIFF
--- a/.changeset/cli-cloud-status-diagnostics.md
+++ b/.changeset/cli-cloud-status-diagnostics.md
@@ -1,0 +1,5 @@
+---
+"@mcpjam/cli": patch
+---
+
+`mcpjam cloud status` reports credential and deployment validity in-band (`valid` / `error`) and exits 1 with a complete JSON report for invalid explicit configuration. Missing credentials stay informational. Other Cloud commands still reject those values with exit code 2.

--- a/cli/src/commands/cloud-link.ts
+++ b/cli/src/commands/cloud-link.ts
@@ -43,6 +43,8 @@ type CloudStatusReport = {
   credential: {
     source: string;
     kind: string;
+    valid: boolean | null;
+    error?: string;
     redactedKey?: string;
     envShadowsOauth: boolean;
     storedOauthPresent: boolean;
@@ -50,6 +52,8 @@ type CloudStatusReport = {
   deployment: {
     apiUrl: string;
     source: string;
+    valid: boolean;
+    error?: string;
   };
   project: {
     selector: string | null;
@@ -106,7 +110,7 @@ export function registerCloudLinkCommands(cloud: Command): void {
       }
 
       const inspection = inspectProjectLink();
-      let ok = true;
+      let ok = credential.valid !== false && deployment.valid;
       let projectSelectorFailed = false;
       let projectScopeDescription = describeProjectScope({
         kind: "project",
@@ -165,6 +169,8 @@ export function registerCloudLinkCommands(cloud: Command): void {
         credential: {
           source: credential.source,
           kind: credential.kind,
+          valid: credential.valid,
+          ...(credential.error ? { error: credential.error } : {}),
           ...(credential.redactedKey
             ? { redactedKey: credential.redactedKey }
             : {}),
@@ -174,6 +180,8 @@ export function registerCloudLinkCommands(cloud: Command): void {
         deployment: {
           apiUrl: deployment.apiUrl,
           source: deployment.source,
+          valid: deployment.valid,
+          ...(deployment.error ? { error: deployment.error } : {}),
         },
         project: {
           selector: projectSelector,

--- a/cli/src/lib/cloud-context.ts
+++ b/cli/src/lib/cloud-context.ts
@@ -19,7 +19,7 @@ import {
   LEGACY_KEY_REMEDY,
   MISSING_CLOUD_CREDENTIAL_MESSAGE,
 } from "./platform-auth.js";
-import { operationalError } from "./output.js";
+import { operationalError, usageError } from "./output.js";
 
 export { MISSING_CLOUD_CREDENTIAL_MESSAGE };
 
@@ -96,7 +96,13 @@ export function preflightCloudCredentials(
   options: CloudCredentialOptions,
   deps: DescribeCloudCredentialDependencies = {}
 ): void {
-  const { credential } = describeCloudCredential(options, deps);
+  const { credential, deployment } = describeCloudCredential(options, deps);
+  if (credential.valid === false) {
+    throw usageError(credential.error ?? LEGACY_KEY_REMEDY);
+  }
+  if (!deployment.valid) {
+    throw usageError(deployment.error ?? "Invalid API URL.");
+  }
   if (credential.source === "missing") {
     const envKey = (deps.env ?? process.env).MCPJAM_API_KEY?.trim();
     if (envKey?.startsWith("mcpjam_")) {

--- a/cli/src/lib/credential-describe.ts
+++ b/cli/src/lib/credential-describe.ts
@@ -7,9 +7,8 @@
  */
 import { DEFAULT_PLATFORM_API_BASE_URL } from "@mcpjam/sdk/platform";
 import { getAuthFilePath, readStoredAuth } from "./auth-store.js";
-import { LEGACY_KEY_REMEDY } from "./platform-auth.js";
-import { validateApiUrl } from "./platform-client.js";
-import { usageError } from "./output.js";
+import { inspectExplicitApiKey } from "./platform-auth.js";
+import { inspectApiUrl } from "./platform-client.js";
 
 const LEGACY_API_KEY_PREFIX = "mcpjam_";
 
@@ -19,6 +18,12 @@ export type CloudDeploymentSource = "flag" | "env" | "oauth" | "default";
 export type CloudCredentialDescription = {
   source: CloudCredentialSource;
   kind: "api-key" | "oauth" | "none";
+  /**
+   * `true` when a usable credential is configured, `false` when an explicit
+   * credential is invalid (legacy `--api-key`), `null` when none is configured.
+   */
+  valid: boolean | null;
+  error?: string;
   redactedKey?: string;
   envShadowsOauth: boolean;
   storedOauthPresent: boolean;
@@ -27,6 +32,8 @@ export type CloudCredentialDescription = {
 export type CloudDeploymentDescription = {
   apiUrl: string;
   source: CloudDeploymentSource;
+  valid: boolean;
+  error?: string;
 };
 
 export type DescribeCloudCredentialDependencies = {
@@ -69,15 +76,14 @@ export function describeCloudCredential(
   const envKey = trimmed(env.MCPJAM_API_KEY);
   const usableEnvKey = envKey && isUsableSkKey(envKey) ? envKey : undefined;
 
-  if (flagKey && !isUsableSkKey(flagKey)) {
-    throw usageError(LEGACY_KEY_REMEDY);
-  }
-
   let credential: CloudCredentialDescription;
   if (flagKey) {
+    const inspected = inspectExplicitApiKey(flagKey);
     credential = {
       source: "flag",
       kind: "api-key",
+      valid: inspected.ok,
+      ...(inspected.ok ? {} : { error: inspected.error }),
       redactedKey: redactCloudApiKey(flagKey),
       envShadowsOauth: false,
       storedOauthPresent,
@@ -86,6 +92,7 @@ export function describeCloudCredential(
     credential = {
       source: "env",
       kind: "api-key",
+      valid: true,
       redactedKey: redactCloudApiKey(usableEnvKey),
       envShadowsOauth: storedOauthPresent,
       storedOauthPresent,
@@ -94,6 +101,7 @@ export function describeCloudCredential(
     credential = {
       source: "oauth",
       kind: "oauth",
+      valid: true,
       envShadowsOauth: false,
       storedOauthPresent,
     };
@@ -101,6 +109,7 @@ export function describeCloudCredential(
     credential = {
       source: "missing",
       kind: "none",
+      valid: null,
       envShadowsOauth: false,
       storedOauthPresent,
     };
@@ -110,18 +119,28 @@ export function describeCloudCredential(
   const envUrl = trimmed(env.MCPJAM_API_URL);
   let deployment: CloudDeploymentDescription;
   if (flagUrl) {
-    deployment = { apiUrl: validateApiUrl(flagUrl, "--api-url"), source: "flag" };
-  } else if (envUrl) {
+    const inspected = inspectApiUrl(flagUrl, "--api-url");
     deployment = {
-      apiUrl: validateApiUrl(envUrl, "MCPJAM_API_URL"),
+      apiUrl: inspected.ok ? inspected.apiUrl : flagUrl,
+      source: "flag",
+      valid: inspected.ok,
+      ...(inspected.ok ? {} : { error: inspected.error }),
+    };
+  } else if (envUrl) {
+    const inspected = inspectApiUrl(envUrl, "MCPJAM_API_URL");
+    deployment = {
+      apiUrl: inspected.ok ? inspected.apiUrl : envUrl,
       source: "env",
+      valid: inspected.ok,
+      ...(inspected.ok ? {} : { error: inspected.error }),
     };
   } else if (stored?.apiUrl) {
-    deployment = { apiUrl: stored.apiUrl, source: "oauth" };
+    deployment = { apiUrl: stored.apiUrl, source: "oauth", valid: true };
   } else {
     deployment = {
       apiUrl: DEFAULT_PLATFORM_API_BASE_URL,
       source: "default",
+      valid: true,
     };
   }
 

--- a/cli/src/lib/platform-auth.ts
+++ b/cli/src/lib/platform-auth.ts
@@ -37,6 +37,22 @@ const DEFAULT_LOGIN_TIMEOUT_MS = 5 * 60_000;
 export const LEGACY_KEY_REMEDY =
   "Legacy mcpjam_ API keys are not supported by platform commands. Create an sk_ key at https://app.mcpjam.com/settings/api-keys or run `mcpjam cloud login`.";
 
+export type ExplicitApiKeyInspection =
+  | { ok: true }
+  | { ok: false; error: string };
+
+/**
+ * Classify an explicit `--api-key` without throwing. A `mcpjam_…` value is
+ * invalid for Cloud commands. `cloud status` reports this in-band; other
+ * commands still reject via {@link resolvePlatformCredential}.
+ */
+export function inspectExplicitApiKey(value: string): ExplicitApiKeyInspection {
+  if (value.startsWith(LEGACY_API_KEY_PREFIX)) {
+    return { ok: false, error: LEGACY_KEY_REMEDY };
+  }
+  return { ok: true };
+}
+
 export const MISSING_CLOUD_CREDENTIAL_MESSAGE =
   "Not logged in. Run `mcpjam cloud login`, or pass an sk_ API key via --api-key / MCPJAM_API_KEY.";
 
@@ -63,8 +79,9 @@ export function resolvePlatformCredential(
 
   const flagKey = options.apiKey?.trim();
   if (flagKey) {
-    if (flagKey.startsWith(LEGACY_API_KEY_PREFIX)) {
-      throw usageError(LEGACY_KEY_REMEDY);
+    const inspected = inspectExplicitApiKey(flagKey);
+    if (!inspected.ok) {
+      throw usageError(inspected.error);
     }
     return { kind: "api-key", getAuth: async () => flagKey };
   }

--- a/cli/src/lib/platform-client.ts
+++ b/cli/src/lib/platform-client.ts
@@ -18,26 +18,44 @@ export interface PlatformClientOptions {
   timeoutMs?: number;
 }
 
+export type ApiUrlInspection =
+  | { ok: true; apiUrl: string }
+  | { ok: false; error: string };
+
+/**
+ * Classify an explicit API URL without throwing. `cloud status` reports the
+ * error in-band; other Cloud commands still reject via {@link validateApiUrl}.
+ */
+export function inspectApiUrl(value: string, source: string): ApiUrlInspection {
+  let parsed: URL;
+  try {
+    parsed = new URL(value);
+  } catch {
+    return {
+      ok: false,
+      error: `Invalid ${source} value "${value}". Expected a full URL like ${DEFAULT_PLATFORM_API_BASE_URL}.`,
+    };
+  }
+  if (parsed.protocol !== "http:" && parsed.protocol !== "https:") {
+    return {
+      ok: false,
+      error: `Invalid ${source} value "${value}". Expected an http(s) URL like ${DEFAULT_PLATFORM_API_BASE_URL}.`,
+    };
+  }
+  return { ok: true, apiUrl: value };
+}
+
 /**
  * An explicitly supplied API URL (flag or env) that does not parse must
  * hard-error: silently falling back to prod would run a login or send a
  * token somewhere the user did not ask for.
  */
 export function validateApiUrl(value: string, source: string): string {
-  let parsed: URL;
-  try {
-    parsed = new URL(value);
-  } catch {
-    throw usageError(
-      `Invalid ${source} value "${value}". Expected a full URL like ${DEFAULT_PLATFORM_API_BASE_URL}.`,
-    );
+  const inspected = inspectApiUrl(value, source);
+  if (!inspected.ok) {
+    throw usageError(inspected.error);
   }
-  if (parsed.protocol !== "http:" && parsed.protocol !== "https:") {
-    throw usageError(
-      `Invalid ${source} value "${value}". Expected an http(s) URL like ${DEFAULT_PLATFORM_API_BASE_URL}.`,
-    );
-  }
-  return value;
+  return inspected.apiUrl;
 }
 
 /** The API URL the user explicitly asked for, if any (flag wins over env). */

--- a/cli/tests/cloud-context.test.ts
+++ b/cli/tests/cloud-context.test.ts
@@ -85,6 +85,40 @@ test("preflightCloudCredentials uses the shared login guidance", () => {
   );
 });
 
+test("preflightCloudCredentials rejects a legacy --api-key as a usage error", () => {
+  assert.throws(
+    () =>
+      preflightCloudCredentials(
+        { apiKey: "mcpjam_legacy" },
+        { env: {}, authFilePath: path.join(tmpdir(), "no-auth.json") }
+      ),
+    (error: unknown) => {
+      assert.ok(error instanceof CliError);
+      assert.equal(error.code, "USAGE_ERROR");
+      assert.equal(error.exitCode, 2);
+      assert.match(error.message, /Legacy mcpjam_ API keys/);
+      return true;
+    }
+  );
+});
+
+test("preflightCloudCredentials rejects an invalid --api-url as a usage error", () => {
+  assert.throws(
+    () =>
+      preflightCloudCredentials(
+        { apiKey: "sk_test", apiUrl: "not-a-url" },
+        { env: {}, authFilePath: path.join(tmpdir(), "no-auth.json") }
+      ),
+    (error: unknown) => {
+      assert.ok(error instanceof CliError);
+      assert.equal(error.code, "USAGE_ERROR");
+      assert.equal(error.exitCode, 2);
+      assert.match(error.message, /Invalid --api-url/);
+      return true;
+    }
+  );
+});
+
 test("preflightCloudCredentials names a leftover legacy MCPJAM_API_KEY", () => {
   assert.throws(
     () =>

--- a/cli/tests/cloud-link-status.test.ts
+++ b/cli/tests/cloud-link-status.test.ts
@@ -174,16 +174,52 @@ test("cloud status reports missing credentials and automatic project offline", a
   assert.equal(run.exitCode, 0, run.stderr);
   const payload = JSON.parse(run.stdout) as {
     ok: boolean;
-    credential: { source: string };
+    credential: { source: string; valid: boolean | null };
+    deployment: { valid: boolean };
     project: { source: string; description: string };
     link: { valid: boolean | null };
   };
   assert.equal(payload.ok, true);
   assert.equal(payload.credential.source, "missing");
+  assert.equal(payload.credential.valid, null);
+  assert.equal(payload.deployment.valid, true);
   assert.equal(payload.project.source, "automatic");
   assert.equal(payload.project.description, "automatic (most recently updated)");
   assert.equal(payload.link.valid, null);
   assert.doesNotMatch(run.stdout, /project: default/i);
+});
+
+test("cloud status reports a valid configuration without leaking the key", async () => {
+  const cwd = mkdtempSync(path.join(tmpdir(), "mcpjam-status-ok-"));
+  const run = await withEnv(isolatedEnv(), () =>
+    withCwd(cwd, () =>
+      runCli([
+        "cloud",
+        "status",
+        "--api-key",
+        "sk_live_abcd1234efgh",
+        "--format",
+        "json",
+      ])
+    )
+  );
+  assert.equal(run.exitCode, 0, run.stderr);
+  const payload = JSON.parse(run.stdout) as {
+    ok: boolean;
+    credential: {
+      source: string;
+      valid: boolean | null;
+      redactedKey?: string;
+    };
+    deployment: { valid: boolean; source: string };
+  };
+  assert.equal(payload.ok, true);
+  assert.equal(payload.credential.source, "flag");
+  assert.equal(payload.credential.valid, true);
+  assert.equal(payload.credential.redactedKey, "sk_…efgh");
+  assert.equal(payload.deployment.valid, true);
+  assert.doesNotMatch(run.stdout, /sk_live_abcd1234efgh/);
+  assert.doesNotMatch(run.stderr, /sk_live_abcd1234efgh/);
 });
 
 test("cloud status names MCPJAM_PROJECT_ID as eval-reporting only", async () => {
@@ -242,11 +278,73 @@ test("cloud status warns when link apiUrl does not match the active deployment",
   );
 });
 
-test("cloud status rejects a legacy --api-key like other Cloud commands", async () => {
+test("cloud status reports a legacy --api-key in JSON and exits 1", async () => {
+  const cwd = mkdtempSync(path.join(tmpdir(), "mcpjam-status-legacy-"));
+  const run = await withEnv(isolatedEnv(), () =>
+    withCwd(cwd, () =>
+      runCli([
+        "cloud",
+        "status",
+        "--api-key",
+        "mcpjam_legacy_secret",
+        "--format",
+        "json",
+      ])
+    )
+  );
+  assert.equal(run.exitCode, 1, run.stderr);
+  const payload = JSON.parse(run.stdout) as {
+    ok: boolean;
+    credential: {
+      valid: boolean | null;
+      error?: string;
+      redactedKey?: string;
+    };
+  };
+  assert.equal(payload.ok, false);
+  assert.equal(payload.credential.valid, false);
+  assert.match(payload.credential.error ?? "", /Legacy mcpjam_ API keys/);
+  assert.equal(payload.credential.redactedKey, "mcpjam_…cret");
+  assert.doesNotMatch(run.stdout, /mcpjam_legacy_secret/);
+});
+
+test("cloud status reports an invalid --api-url in JSON and exits 1", async () => {
+  const cwd = mkdtempSync(path.join(tmpdir(), "mcpjam-status-badurl-"));
+  const run = await withEnv(isolatedEnv(), () =>
+    withCwd(cwd, () =>
+      runCli([
+        "cloud",
+        "status",
+        "--api-key",
+        "sk_test_xxxxYYYY",
+        "--api-url",
+        "not-a-url",
+        "--format",
+        "json",
+      ])
+    )
+  );
+  assert.equal(run.exitCode, 1, run.stderr);
+  const payload = JSON.parse(run.stdout) as {
+    ok: boolean;
+    credential: { valid: boolean | null; redactedKey?: string };
+    deployment: { valid: boolean; error?: string; apiUrl: string };
+  };
+  assert.equal(payload.ok, false);
+  assert.equal(payload.credential.valid, true);
+  assert.equal(payload.credential.redactedKey, "sk_…YYYY");
+  assert.equal(payload.deployment.valid, false);
+  assert.equal(payload.deployment.apiUrl, "not-a-url");
+  assert.match(payload.deployment.error ?? "", /Invalid --api-url/);
+  assert.doesNotMatch(run.stdout, /sk_test_xxxxYYYY/);
+});
+
+test("other Cloud commands still reject a legacy --api-key with exit 2", async () => {
   const run = await withEnv(isolatedEnv(), () =>
     runCli([
       "cloud",
-      "status",
+      "eval",
+      "list",
       "--api-key",
       "mcpjam_legacy",
       "--format",
@@ -262,11 +360,12 @@ test("cloud status rejects a legacy --api-key like other Cloud commands", async 
   assert.match(payload.error?.message ?? "", /Legacy mcpjam_ API keys/);
 });
 
-test("cloud status rejects an invalid --api-url like other Cloud commands", async () => {
+test("other Cloud commands still reject an invalid --api-url with exit 2", async () => {
   const run = await withEnv(isolatedEnv(), () =>
     runCli([
       "cloud",
-      "status",
+      "eval",
+      "list",
       "--api-key",
       "sk_test",
       "--api-url",

--- a/cli/tests/credential-describe.test.ts
+++ b/cli/tests/credential-describe.test.ts
@@ -5,7 +5,7 @@ import path from "node:path";
 import test from "node:test";
 import { DEFAULT_PLATFORM_API_BASE_URL } from "@mcpjam/sdk/platform";
 import { describeCloudCredential, redactCloudApiKey } from "../src/lib/credential-describe.js";
-import { CliError } from "../src/lib/output.js";
+import { LEGACY_KEY_REMEDY } from "../src/lib/platform-auth.js";
 
 function authFile(body: Record<string, unknown>): string {
   const directory = mkdtempSync(path.join(tmpdir(), "mcpjam-cred-"));
@@ -38,8 +38,10 @@ test("credential precedence is flag, usable env key, oauth, missing", () => {
     { env: { MCPJAM_API_KEY: "sk_env_zzzz" }, authFilePath }
   );
   assert.equal(flag.credential.source, "flag");
+  assert.equal(flag.credential.valid, true);
   assert.equal(flag.credential.redactedKey, "sk_…YYYY");
   assert.equal(flag.credential.envShadowsOauth, false);
+  assert.equal(flag.deployment.valid, true);
 
   const env = describeCloudCredential(
     {},
@@ -60,32 +62,37 @@ test("credential precedence is flag, usable env key, oauth, missing", () => {
     { env: {}, authFilePath: path.join(tmpdir(), "no-such-auth.json") }
   );
   assert.equal(missing.credential.source, "missing");
+  assert.equal(missing.credential.valid, null);
   assert.equal(missing.deployment.source, "default");
+  assert.equal(missing.deployment.valid, true);
   assert.equal(missing.deployment.apiUrl, DEFAULT_PLATFORM_API_BASE_URL);
 });
 
-test("legacy mcpjam_ flag keys are a usage error", () => {
-  assert.throws(
-    () => describeCloudCredential({ apiKey: "mcpjam_legacy" }, { env: {} }),
-    (error: unknown) =>
-      error instanceof CliError &&
-      error.code === "USAGE_ERROR" &&
-      /Legacy mcpjam_ API keys/.test(error.message)
+test("legacy mcpjam_ flag keys are reported without throwing", () => {
+  const described = describeCloudCredential(
+    { apiKey: "mcpjam_legacy_secret" },
+    { env: {} }
+  );
+  assert.equal(described.credential.valid, false);
+  assert.equal(described.credential.error, LEGACY_KEY_REMEDY);
+  assert.equal(described.credential.source, "flag");
+  assert.equal(described.credential.redactedKey, "mcpjam_…cret");
+  assert.doesNotMatch(
+    JSON.stringify(described),
+    /mcpjam_legacy_secret/
   );
 });
 
-test("invalid explicit API URLs are a usage error", () => {
-  assert.throws(
-    () =>
-      describeCloudCredential(
-        { apiKey: "sk_test", apiUrl: "not-a-url" },
-        { env: {} }
-      ),
-    (error: unknown) =>
-      error instanceof CliError &&
-      error.code === "USAGE_ERROR" &&
-      /Invalid --api-url/.test(error.message)
+test("invalid explicit API URLs are reported without throwing", () => {
+  const described = describeCloudCredential(
+    { apiKey: "sk_test_xxxxYYYY", apiUrl: "not-a-url" },
+    { env: {} }
   );
+  assert.equal(described.credential.valid, true);
+  assert.equal(described.deployment.valid, false);
+  assert.equal(described.deployment.apiUrl, "not-a-url");
+  assert.match(described.deployment.error ?? "", /Invalid --api-url/);
+  assert.equal(described.credential.redactedKey, "sk_…YYYY");
 });
 
 test("legacy mcpjam_ env keys fall through to stored OAuth", () => {

--- a/cli/tests/platform-client.test.ts
+++ b/cli/tests/platform-client.test.ts
@@ -10,6 +10,7 @@ import {
 import { CliError } from "../src/lib/output.js";
 import {
   buildPlatformClient,
+  inspectApiUrl,
   resolvePlatformBaseUrl,
   resolvePlatformOrigin,
 } from "../src/lib/platform-client.js";
@@ -75,6 +76,21 @@ test("resolvePlatformBaseUrl prefers the flag over env over the default", () => 
     resolvePlatformBaseUrl({}, {}),
     "https://app.mcpjam.com/api/v1",
   );
+});
+
+test("inspectApiUrl classifies invalid values without throwing", () => {
+  const malformed = inspectApiUrl("not-a-url", "--api-url");
+  assert.equal(malformed.ok, false);
+  if (!malformed.ok) {
+    assert.match(malformed.error, /Invalid --api-url/);
+  }
+  const ftp = inspectApiUrl("ftp://example.com/api", "MCPJAM_API_URL");
+  assert.equal(ftp.ok, false);
+  const ok = inspectApiUrl("https://app.mcpjam.com/api/v1", "--api-url");
+  assert.equal(ok.ok, true);
+  if (ok.ok) {
+    assert.equal(ok.apiUrl, "https://app.mcpjam.com/api/v1");
+  }
 });
 
 test("an invalid --api-url hard-errors instead of falling back to prod", () => {

--- a/cli/tests/project-link.test.ts
+++ b/cli/tests/project-link.test.ts
@@ -1,6 +1,6 @@
 import assert from "node:assert/strict";
 import { execFile as execFileCallback } from "node:child_process";
-import { mkdirSync, mkdtempSync, writeFileSync } from "node:fs";
+import { mkdirSync, mkdtempSync, realpathSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import path from "node:path";
 import { promisify } from "node:util";
@@ -25,6 +25,10 @@ function writeLink(directory: string, body: unknown): string {
   mkdirSync(path.dirname(filePath), { recursive: true });
   writeFileSync(filePath, `${JSON.stringify(body, null, 2)}\n`);
   return filePath;
+}
+
+function assertSamePath(left: string, right: string): void {
+  assert.equal(realpathSync(left), realpathSync(right));
 }
 
 test("parseProjectLink accepts version 1 with canonical http(s) apiUrl", () => {
@@ -99,10 +103,10 @@ test("inside Git, lookup walks to the worktree root inclusive", async () => {
     apiUrl: "https://app.mcpjam.com/api/v1",
   });
 
-  assert.equal(findGitWorktreeRoot(nested), root);
-  assert.equal(findNearestProjectLinkPath({ cwd: nested }), filePath);
-  assert.equal(projectLinkWriteDir({ cwd: nested }), root);
-  assert.equal(projectLinkWriteDir({ cwd: nested, here: true }), nested);
+  assertSamePath(findGitWorktreeRoot(nested) ?? "", root);
+  assertSamePath(findNearestProjectLinkPath({ cwd: nested }) ?? "", filePath);
+  assertSamePath(projectLinkWriteDir({ cwd: nested }), root);
+  assertSamePath(projectLinkWriteDir({ cwd: nested, here: true }), nested);
 });
 
 test("nearest link wins over a parent link in the same worktree", async () => {
@@ -124,7 +128,7 @@ test("nearest link wins over a parent link in the same worktree", async () => {
   const inspection = inspectProjectLink({ cwd: nested });
   assert.equal(inspection.status, "valid");
   if (inspection.status === "valid") {
-    assert.equal(inspection.path, nestedPath);
+    assertSamePath(inspection.path, nestedPath);
     assert.equal(inspection.link.project.id, "nested-proj");
   }
 });


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Purpose

`mcpjam cloud status` should stay network-free and always emit a complete structured report, including when explicit credentials or API URLs are invalid. Other Cloud commands must keep rejecting those values with exit code `2`.

## Context

Follow-up to the merged Cloud CLI stack (`cloud link` / `cloud status` / project selection). Offline status previously threw on a legacy `--api-key` or a malformed `--api-url`, so scripts that parse the JSON report got an empty stdout and exit `2`.

## Before / after

**Before**
- `cloud status --api-key mcpjam_…` and `cloud status --api-url not-a-url` exited `2` with no JSON report.
- The status payload had no `credential.valid` / `deployment.valid` metadata.
- Link-path assertions compared raw strings and could fail on macOS `/var` vs `/private/var`.

**After**
- Shared `inspectExplicitApiKey` / `inspectApiUrl` classify values without throwing.
- Normal Cloud commands still reject invalid values via the throwing wrappers (exit `2`).
- `cloud status` emits the full JSON report, sets `ok: false`, exits `1`, and includes actionable `credential.error` / `deployment.error`.
- `credential.valid: null` means no credential is configured and remains a successful informational status.
- Secret-safe key redaction is preserved even for invalid keys.
- Deployment mismatch warning states that the active deployment URL is used while the link’s project selector remains active.
- Link-path tests compare `realpathSync` canonical paths. Product path-writing is unchanged.

## Rollout

CLI patch changeset only (`@mcpjam/cli`). No backend or SDK schema changes.

## Test plan

- `npm run typecheck -w @mcpjam/cli`
- Targeted tests: `credential-describe`, `cloud-link-status`, `project-link`, `platform-client`, `cloud-context`, `platform-auth`
- Confirm invalid status inputs produce JSON with exit `1`
- Confirm missing credentials remain informational and successful
- Confirm `cloud eval list` still exits `2` for the same invalid inputs

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-3eeca1ad-a367-4656-9761-f879cc235489?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-3eeca1ad-a367-4656-9761-f879cc235489&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Cloud status now reports credential and deployment validity without throwing. Previously it exited 2 with no JSON for invalid explicit values; now it emits a full JSON report with ok: false and exits 1, while other Cloud commands still reject invalid inputs with exit 2.

- Add shared inspectors: inspectExplicitApiKey and inspectApiUrl classify explicit values without throwing for status; throwing wrappers still guard other commands.
- Extend status payload: credential.valid (boolean | null) and deployment.valid plus error fields; null means no credential configured; preserve secret-safe key redaction.
- Update preflightCloudCredentials to use the shared description and reject invalid explicit inputs as usage errors for non-status commands.
- Canonicalize link-path comparisons via realpathSync to avoid /var vs /private/var mismatches; do not change path writing.
- Rollout: patch to `@mcpjam/cli` only; no backend or SDK schema changes.

<sup>Written for commit 7824586d25e00490463426aa3a4a2c8a414250eb. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/MCPJam/inspector/pull/4264?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

