### PR TITLE
cli: finish eval inspection project selection

### DIFF
--- a/.changeset/cli-eval-inspection-project.md
+++ b/.changeset/cli-eval-inspection-project.md
@@ -1,0 +1,5 @@
+---
+"@mcpjam/cli": patch
+---
+
+Complete Cloud project selection for all ten `mcpjam cloud eval` run-inspection commands. `--project` is optional; omitting it uses MCPJAM_PROJECT, the nearest project link, or automatic newest-project selection, and the project field is omitted from the operation input when no explicit selector exists.

--- a/cli/src/commands/eval.ts
+++ b/cli/src/commands/eval.ts
@@ -580,11 +580,16 @@ async function executeOp<TInput, TOutput>(
       ? (input as { project: string }).project
       : undefined;
   const resolved = resolveCloudProjectArgs(options, { inputProject });
-  const filled = { ...input, project: resolved.project } as TInput;
+  const filled = { ...(input as TInput & { project?: string }) };
+  delete filled.project;
+  if (resolved.project !== undefined) {
+    filled.project = resolved.project;
+  }
   const result = await runPlatformCommand(
     platformOptionsOf(command),
     globalOptions.timeout,
-    ({ client, signal }) => op.execute(filled, { client, signal }),
+    ({ client, signal }) =>
+      op.execute(filled as TInput, { client, signal }),
     {
       projectScope: resolved.projectScope,
       quiet: globalOptions.quiet,

--- a/cli/tests/cloud-project-selection.test.ts
+++ b/cli/tests/cloud-project-selection.test.ts
@@ -34,6 +34,22 @@ const PROJECTS = [
   },
 ];
 
+function evalRunStub(status = "completed"): Record<string, unknown> {
+  return {
+    id: "run-1",
+    suiteId: "suite-1",
+    runNumber: 1,
+    status,
+    result: status === "completed" ? "passed" : null,
+    summary: null,
+    source: "api",
+    notes: null,
+    createdAt: 1,
+    completedAt: status === "completed" ? 2 : null,
+    judges: {},
+  };
+}
+
 async function startFixture(): Promise<{
   baseUrl: string;
   requestUrls: string[];
@@ -52,25 +68,62 @@ async function startFixture(): Promise<{
       res.end(JSON.stringify({ items: [] }));
       return;
     }
-    if (url.pathname === "/api/v1/projects/proj-alpha/eval-runs/run-1") {
-      res.end(
-        JSON.stringify({
-          id: "run-1",
-          suiteId: "suite-1",
-          status: "completed",
-          result: "passed",
-          judges: [],
-        })
-      );
-      return;
+
+    const evalRun = url.pathname.match(
+      /^\/api\/v1\/projects\/([^/]+)\/eval-runs\/run-1(?:\/(.*))?$/
+    );
+    if (evalRun) {
+      const rest = evalRun[2] ?? "";
+      if (rest === "" && (req.method ?? "GET") === "GET") {
+        res.end(JSON.stringify(evalRunStub("running")));
+        return;
+      }
+      if (rest === "iterations") {
+        res.end(JSON.stringify({ items: [] }));
+        return;
+      }
+      if (rest === "cancel" && req.method === "POST") {
+        res.end(JSON.stringify(evalRunStub("cancelled")));
+        return;
+      }
+      if (rest === "judge" && req.method === "POST") {
+        res.statusCode = 202;
+        res.end(
+          JSON.stringify({
+            runId: "run-1",
+            projectId: evalRun[1],
+            status: "pending",
+          })
+        );
+        return;
+      }
+      if (rest === "compare") {
+        res.end(
+          JSON.stringify({
+            runId: "run-1",
+            baseRunId: "run-0",
+            cases: [],
+          })
+        );
+        return;
+      }
+      if (rest === "iterations/iter-1/trace") {
+        res.end(
+          JSON.stringify({
+            traceVersion: 1,
+            messages: [],
+            widgetRenderObservations: [],
+            browserInteractionSteps: [],
+          })
+        );
+        return;
+      }
+      if (rest === "iterations/iter-1/steps") {
+        res.end(JSON.stringify({ items: [] }));
+        return;
+      }
     }
-    if (
-      url.pathname ===
-      "/api/v1/projects/proj-alpha/eval-runs/run-1/iterations"
-    ) {
-      res.end(JSON.stringify({ items: [] }));
-      return;
-    }
+
     res.statusCode = 404;
     res.end(JSON.stringify({ code: "NOT_FOUND", message: url.pathname }));
   });
@@ -156,71 +209,132 @@ function cloudArgv(baseUrl: string, ...args: string[]): string[] {
   ];
 }
 
+function writeLink(
+  directory: string,
+  body: Record<string, unknown>
+): string {
+  const filePath = projectLinkPathForDir(directory);
+  mkdirSync(path.dirname(filePath), { recursive: true });
+  writeFileSync(filePath, `${JSON.stringify(body, null, 2)}\n`);
+  return filePath;
+}
+
+const INSPECTION_COMMANDS: ReadonlyArray<{
+  name: string;
+  args: string[];
+  pathIncludes: string;
+}> = [
+  { name: "status", args: ["status", "--run", "run-1"], pathIncludes: "/eval-runs/run-1" },
+  { name: "cancel", args: ["cancel", "--run", "run-1"], pathIncludes: "/eval-runs/run-1/cancel" },
+  { name: "judge", args: ["judge", "--run", "run-1"], pathIncludes: "/eval-runs/run-1/judge" },
+  {
+    name: "iterations",
+    args: ["iterations", "--run", "run-1"],
+    pathIncludes: "/eval-runs/run-1/iterations",
+  },
+  { name: "gate", args: ["gate", "--run", "run-1"], pathIncludes: "/eval-runs/run-1" },
+  { name: "compare", args: ["compare", "--run", "run-1"], pathIncludes: "/eval-runs/run-1/compare" },
+  {
+    name: "trace",
+    args: ["trace", "--run", "run-1", "--iteration", "iter-1"],
+    pathIncludes: "/eval-runs/run-1/iterations/iter-1/trace",
+  },
+  {
+    name: "steps",
+    args: ["steps", "--run", "run-1", "--iteration", "iter-1"],
+    pathIncludes: "/eval-runs/run-1/iterations/iter-1/steps",
+  },
+  {
+    name: "screenshot",
+    args: ["screenshot", "--run", "run-1", "--iteration", "iter-1"],
+    pathIncludes: "/eval-runs/run-1/iterations/iter-1/trace",
+  },
+  {
+    name: "video",
+    args: ["video", "--run", "run-1", "--iteration", "iter-1"],
+    pathIncludes: "/eval-runs/run-1/iterations/iter-1/trace",
+  },
+];
+
 test("eval run-inspection commands treat --project as optional", async () => {
-  for (const sub of [
-    "status",
-    "cancel",
-    "judge",
-    "iterations",
-    "gate",
-    "compare",
-    "trace",
-    "steps",
-    "screenshot",
-    "video",
-  ]) {
-    const run = await runCli(["cloud", "eval", sub, "--help"]);
+  for (const { name } of INSPECTION_COMMANDS) {
+    const run = await runCli(["cloud", "eval", name, "--help"]);
     assert.equal(run.exitCode, 0, run.stderr);
     assert.match(run.stdout, /--project <id-or-name>/);
     assert.doesNotMatch(run.stdout, /required option '--project/);
   }
 });
 
-test("eval iterations without --project uses automatic project selection", async () => {
-  const fixture = await startFixture();
-  const cwd = mkdtempSync(path.join(tmpdir(), "mcpjam-eval-iterations-"));
-  try {
-    const run = await withEnv(isolatedEnv(), () =>
-      withCwd(cwd, () =>
-        runCli(
-          cloudArgv(fixture.baseUrl, "eval", "iterations", "--run", "run-1")
-        )
-      )
-    );
-    assert.equal(run.exitCode, 0, run.stderr);
-    assert.ok(
-      fixture.requestUrls.some((url) =>
-        url.includes("/projects/proj-alpha/eval-runs/run-1/iterations")
-      ),
-      `expected automatic proj-alpha iterations fetch, saw: ${fixture.requestUrls.join(", ")}`
-    );
-  } finally {
-    await fixture.close();
-  }
-});
+test("eval inspection commands select automatic, linked, env, and explicit projects", async () => {
+  const cases: ReadonlyArray<{
+    title: string;
+    env?: Record<string, string | undefined>;
+    linkProject?: { id: string; name: string };
+    extraArgs?: string[];
+    projectId: string;
+  }> = [
+    { title: "automatic", projectId: "proj-alpha" },
+    {
+      title: "linked",
+      linkProject: { id: "proj-beta", name: "Beta" },
+      projectId: "proj-beta",
+    },
+    {
+      title: "environment",
+      env: { MCPJAM_PROJECT: "Alpha" },
+      linkProject: { id: "proj-beta", name: "Beta" },
+      projectId: "proj-alpha",
+    },
+    {
+      title: "explicit",
+      env: { MCPJAM_PROJECT: "Alpha" },
+      linkProject: { id: "proj-alpha", name: "Alpha" },
+      extraArgs: ["--project", "Beta"],
+      projectId: "proj-beta",
+    },
+  ];
 
-test("eval status without --project uses automatic project selection", async () => {
-  const fixture = await startFixture();
-  const cwd = mkdtempSync(path.join(tmpdir(), "mcpjam-eval-project-"));
-  try {
-    const run = await withEnv(isolatedEnv(), () =>
-      withCwd(cwd, () =>
-        runCli(cloudArgv(fixture.baseUrl, "eval", "status", "--run", "run-1"))
-      )
-    );
-    assert.equal(run.exitCode, 0, run.stderr);
-    assert.ok(
-      fixture.requestUrls.some((url) =>
-        url.includes("/projects/proj-alpha/eval-runs/run-1")
-      ),
-      `expected automatic proj-alpha run fetch, saw: ${fixture.requestUrls.join(", ")}`
-    );
-    assert.match(
-      run.stderr,
-      /project: automatic \(most recently updated\)/
-    );
-  } finally {
-    await fixture.close();
+  for (const selection of cases) {
+    for (const command of INSPECTION_COMMANDS) {
+      const fixture = await startFixture();
+      const cwd = mkdtempSync(
+        path.join(tmpdir(), `mcpjam-eval-${command.name}-${selection.title}-`)
+      );
+      if (selection.linkProject) {
+        writeLink(cwd, {
+          version: 1,
+          project: selection.linkProject,
+          apiUrl: fixture.baseUrl,
+        });
+      }
+      try {
+        const run = await withEnv(isolatedEnv(selection.env), () =>
+          withCwd(cwd, () =>
+            runCli(
+              cloudArgv(
+                fixture.baseUrl,
+                "eval",
+                ...command.args,
+                ...(selection.extraArgs ?? [])
+              )
+            )
+          )
+        );
+        assert.notEqual(
+          run.exitCode,
+          2,
+          `${command.name} ${selection.title} failed at usage parsing: ${run.stderr}`
+        );
+        assert.doesNotMatch(run.stderr, /required option '--project/i);
+        const needle = `/projects/${selection.projectId}${command.pathIncludes}`;
+        assert.ok(
+          fixture.requestUrls.some((url) => url.includes(needle)),
+          `${command.name} ${selection.title} expected ${needle}, saw: ${fixture.requestUrls.join(", ")}\nstderr: ${run.stderr}`
+        );
+      } finally {
+        await fixture.close();
+      }
+    }
   }
 });
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Purpose

Complete the Cloud project-selection migration for all ten `mcpjam cloud eval` run-inspection commands so omitting `--project` is no longer a Commander usage error.

## Context

Follow-up to the merged Cloud CLI stack. `status`, `screenshot`, and `video` already resolved ambient project context. The remaining inspection commands declared optional `--project` but still forwarded an unset `project` field, and coverage did not prove automatic / link / env / explicit selection for the full set.

## Before / after

**Before**
- Help listed `--project` as optional, but execution tests only covered `status` and `iterations` for automatic selection.
- `executeOp` always wrote `project: resolved.project`, including `undefined` for automatic selection.

**After**
- All ten commands use `addProjectOption()` (`status`, `cancel`, `judge`, `iterations`, `gate`, `compare`, `trace`, `steps`, `screenshot`, `video`).
- Option types stay optional. When no explicit selector exists, the project field is omitted so the existing Cloud resolver / SDK runtime picks the project.
- Precedence is unchanged: `--project` → input selector → `MCPJAM_PROJECT` → nearest project link → automatic newest accessible project.
- SDK operation schemas are unchanged.
- Table-driven help test covers all ten commands.
- Fixture-backed tests prove automatic, linked, environment, and explicit selection without real Cloud side effects.

## Rollout

CLI patch changeset only (`@mcpjam/cli`). No backend or SDK schema changes.

## Test plan

- Help assertions for all ten commands
- Mocked API requests for automatic, link, environment, and explicit selection
- Confirm no command fails at Commander parsing solely because `--project` is omitted
- Confirm explicit `--project` still wins over env and link

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-3eeca1ad-a367-4656-9761-f879cc235489?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-3eeca1ad-a367-4656-9761-f879cc235489&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Finish Cloud project selection for all `mcpjam cloud eval` run-inspection commands so omitting `--project` no longer triggers a usage error and defers to env/link/automatic selection. When no explicit selector is provided, the CLI now omits the project field so the Cloud resolver picks the project.

- All ten commands use the shared project option; `--project` remains optional and parsing no longer fails when it’s missing.
- Precedence unchanged: `--project` → input selector → `MCPJAM_PROJECT` → nearest project link → automatic newest accessible project.
- The CLI no longer forwards `project: undefined`; it leaves the field out unless an explicit selector exists.
- SDK schemas and backend behavior are unchanged; patch release to `@mcpjam/cli` only.
- Tests cover help output for all commands and verify automatic, linked, environment, and explicit selection paths.

<sup>Written for commit 020fc72ab3cbba0115a5be9c5f376ed235198ada. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/MCPJam/inspector/pull/4265?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

