### PR TITLE
caniuse: one grammar for style-variable rows

### DIFF
--- a/.changeset/caniuse-style-variable-normalization.md
+++ b/.changeset/caniuse-style-variable-normalization.md
@@ -1,0 +1,20 @@
+---
+"@mcpjam/inspector": patch
+---
+
+Read every host's style variables the same way on the compare matrix.
+
+Hosts state the same fact in two notations: Claude sends one `light-dark(a, b)`
+string, ChatGPT and Codex send a resolved literal per theme. The Apps · Styles
+rows rendered those differently — a raw CSS function in one column against a
+stacked LIGHT/DARK pair in the next — which is precisely the comparison the
+matrix exists to make and the one it made hardest. A `light-dark(…)` value is
+now split into its two themes (on the top-level comma, so the commas inside
+`rgba(…)` don't end the first argument) and every host reads down the column in
+one grammar. The literal the host actually sends is kept on the row and shown
+on hover, and a value that cannot be split — a malformed call, a
+`color-mix(…)` — is still shown verbatim rather than guessed at.
+
+Color rows also gain a swatch over a checkerboard, so two hex strings are
+comparable at a glance and a fully transparent `…-ghost` token is
+distinguishable from an opaque white one.

--- a/mcpjam-inspector/client/src/components/hosts/comparison/host-config-comparison-matrix.tsx
+++ b/mcpjam-inspector/client/src/components/hosts/comparison/host-config-comparison-matrix.tsx
@@ -588,6 +588,32 @@ function FieldRow({
   );
 }
 
+/**
+ * Color chip for a style-variable cell. The value is assigned as a real CSS
+ * property (never spliced into a CSS string), so a token this build does not
+ * understand — a `color-mix(…)` an older browser rejects, or a malformed
+ * value from a user-built host — is dropped by the CSSOM and leaves an empty
+ * chip rather than corrupting the cell. The checkerboard behind it is what
+ * makes a fully transparent `…-ghost` token distinguishable from an opaque
+ * white one.
+ */
+function StyleColorSwatch({ value }: { value: string }) {
+  return (
+    <span
+      aria-hidden
+      className="inline-block size-3 shrink-0 overflow-hidden rounded-[3px] border border-border/70 align-middle"
+      style={{
+        backgroundImage:
+          "linear-gradient(45deg, rgba(120,120,120,0.35) 25%, transparent 25%, transparent 75%, rgba(120,120,120,0.35) 75%), linear-gradient(45deg, rgba(120,120,120,0.35) 25%, transparent 25%, transparent 75%, rgba(120,120,120,0.35) 75%)",
+        backgroundSize: "6px 6px",
+        backgroundPosition: "0 0, 3px 3px",
+      }}
+    >
+      <span className="block size-full" style={{ backgroundColor: value }} />
+    </span>
+  );
+}
+
 function FieldCell({
   field,
   subject,
@@ -714,13 +740,24 @@ function FieldCell({
 
     case "style-variable": {
       const v = value as StyleVariableByTheme;
+      // Colors get a chip: two hex strings are only comparable at a glance
+      // once you can see them. Sizes, radii and shadows have nothing to show.
+      const isColor = field.label.startsWith("--color-");
       // One string answering both themes renders bare — labelling it "light"
       // and "dark" twice would imply a distinction the host does not make.
+      // A `light-dark(…)` value is NOT this case: it is decoded upstream into
+      // the pair below, so the notation a host happens to use never changes
+      // the shape of its cell.
       if ("same" in v) {
-        return <span className="font-mono text-[12px] break-all">{v.same}</span>;
+        return (
+          <span className="inline-flex items-center gap-1.5">
+            {isColor ? <StyleColorSwatch value={v.same} /> : null}
+            <span className="font-mono text-[12px] break-all">{v.same}</span>
+          </span>
+        );
       }
       return (
-        <div className="flex flex-col gap-1">
+        <div className="flex flex-col gap-1" title={v.raw}>
           {(["light", "dark"] as const).map((theme) => (
             <div key={theme} className="flex flex-col gap-0.5">
               <span className="text-[10px] uppercase tracking-wide text-muted-foreground/60">
@@ -729,8 +766,11 @@ function FieldCell({
               {v[theme] === undefined ? (
                 <span className="text-[12px] text-muted-foreground/60">—</span>
               ) : (
-                <span className="font-mono text-[12px] break-all">
-                  {v[theme]}
+                <span className="inline-flex items-center gap-1.5">
+                  {isColor ? <StyleColorSwatch value={v[theme]} /> : null}
+                  <span className="font-mono text-[12px] break-all">
+                    {v[theme]}
+                  </span>
                 </span>
               )}
             </div>

--- a/mcpjam-inspector/client/src/lib/__tests__/host-config-field-schema.test.ts
+++ b/mcpjam-inspector/client/src/lib/__tests__/host-config-field-schema.test.ts
@@ -7,6 +7,7 @@ import {
   HOST_CONFIG_FIELDS,
   HOST_CONFIG_SECTIONS,
   NOT_SUPPORTED,
+  parseLightDarkPair,
   type HostConfigFieldDef,
 } from "@/lib/host-config-field-schema";
 
@@ -385,5 +386,78 @@ describe("CSP subtype rows", () => {
     expect(
       fieldById("appsCap.cspConnectDomains.fetch").read(cfg)
     ).toBeUndefined();
+  });
+});
+
+describe("parseLightDarkPair", () => {
+  it("splits on the top-level comma, not the ones inside rgba()", () => {
+    expect(
+      parseLightDarkPair(
+        "light-dark(rgba(50, 102, 173, 1), rgba(128, 170, 221, 1))"
+      )
+    ).toEqual({
+      light: "rgba(50, 102, 173, 1)",
+      dark: "rgba(128, 170, 221, 1)",
+    });
+  });
+
+  it("returns null for anything that is not a light-dark() call", () => {
+    expect(parseLightDarkPair("#fff")).toBeNull();
+    expect(
+      parseLightDarkPair("color-mix(in oklab,#fff 0%,transparent)")
+    ).toBeNull();
+    // Malformed: one argument, so there is no pair to report.
+    expect(parseLightDarkPair("light-dark(#fff)")).toBeNull();
+    expect(parseLightDarkPair("light-dark(#fff, )")).toBeNull();
+  });
+});
+
+describe("Apps · Styles rows", () => {
+  const field = () => fieldById("styles.--color-text-info");
+
+  it("reads a per-theme probe capture as the pair", () => {
+    const cfg = makeConfig({
+      styleVariablesByTheme: {
+        light: { "--color-text-info": "#3a83f7" },
+        dark: { "--color-text-info": "#539af8" },
+      },
+    } as Partial<HostConfigDtoV2>);
+    expect(field().read(cfg)).toEqual({ light: "#3a83f7", dark: "#539af8" });
+  });
+
+  it("decodes a light-dark() host into the same pair shape, keeping the literal", () => {
+    // The whole point of the normalization: this host and the one above are
+    // stating the same fact, so the matrix must not render them differently.
+    const cfg = makeConfig({
+      hostContext: {
+        styles: {
+          variables: {
+            "--color-text-info":
+              "light-dark(rgba(50, 102, 173, 1), rgba(128, 170, 221, 1))",
+          },
+        },
+      },
+    });
+    expect(field().read(cfg)).toEqual({
+      light: "rgba(50, 102, 173, 1)",
+      dark: "rgba(128, 170, 221, 1)",
+      raw: "light-dark(rgba(50, 102, 173, 1), rgba(128, 170, 221, 1))",
+    });
+  });
+
+  it("keeps a genuinely theme-agnostic value bare", () => {
+    const cfg = makeConfig({
+      hostContext: { styles: { variables: { "--color-text-info": "#fff" } } },
+    });
+    expect(field().read(cfg)).toEqual({ same: "#fff" });
+  });
+
+  it("reports an unsplittable value verbatim rather than guessing", () => {
+    const cfg = makeConfig({
+      hostContext: {
+        styles: { variables: { "--color-text-info": "light-dark(#fff)" } },
+      },
+    });
+    expect(field().read(cfg)).toEqual({ same: "light-dark(#fff)" });
   });
 });

--- a/mcpjam-inspector/client/src/lib/host-config-field-schema.ts
+++ b/mcpjam-inspector/client/src/lib/host-config-field-schema.ts
@@ -315,7 +315,49 @@ export const NOT_SUPPORTED = Symbol("not-supported");
 /** One variable's value in each theme; `same` when a single string answers both. */
 export type StyleVariableByTheme =
   | { same: string }
-  | { light?: string; dark?: string };
+  /**
+   * `raw` is set when the pair was decoded from a single `light-dark(…)`
+   * string rather than probed per theme — the split is for reading, and the
+   * literal the host actually sends stays available for anyone who needs it.
+   */
+  | { light?: string; dark?: string; raw?: string };
+
+/**
+ * Split a CSS `light-dark(a, b)` value into its two themes.
+ *
+ * Hosts encode the same fact two ways: Claude sends one `light-dark(…)`
+ * string, ChatGPT and Codex send a resolved literal per theme. Rendering
+ * those differently makes a row impossible to compare down the column, so
+ * the pair is normalized here. Returns null for anything else, including a
+ * malformed call — a value we can't split is shown verbatim rather than
+ * guessed at.
+ *
+ * Splits on the top-level comma: the arguments are themselves functions
+ * (`rgba(50, 102, 173, 1)`) whose commas must not end the first argument.
+ */
+export function parseLightDarkPair(
+  value: string
+): { light: string; dark: string } | null {
+  const trimmed = value.trim();
+  const prefix = "light-dark(";
+  if (!trimmed.toLowerCase().startsWith(prefix) || !trimmed.endsWith(")")) {
+    return null;
+  }
+  const inner = trimmed.slice(prefix.length, -1);
+  let depth = 0;
+  for (let i = 0; i < inner.length; i += 1) {
+    const char = inner[i];
+    if (char === "(") depth += 1;
+    else if (char === ")") depth -= 1;
+    else if (char === "," && depth === 0) {
+      const light = inner.slice(0, i).trim();
+      const dark = inner.slice(i + 1).trim();
+      if (!light || !dark) return null;
+      return { light, dark };
+    }
+  }
+  return null;
+}
 
 function readStyleVariable(
   cfg: HostConfigDtoV2,
@@ -342,7 +384,12 @@ function readStyleVariable(
   // A single value answers both themes — either because it is theme-agnostic
   // (`light-dark(…)`) or because only one theme was ever captured. Both read
   // the same way here; the catalog's per-theme pair is what distinguishes them.
-  if (typeof value === "string") return { same: value };
+  if (typeof value === "string") {
+    // A `light-dark(…)` host and a per-theme-probed host state the same fact
+    // in different notations; normalize so the column compares.
+    const pair = parseLightDarkPair(value);
+    return pair ? { ...pair, raw: value } : { same: value };
+  }
 
   // Only a probed host can be said not to support the variable: we connected,
   // read its host context, and it sent nothing here. For a vendor-doc or
@@ -354,11 +401,14 @@ function readStyleVariable(
 /**
  * Apps · Styles — one row per spec variable, showing the value each host sends.
  *
- * These are probed values, so the row shows them: `light-dark(rgba(255, 255,
- * 255, 1), ...)` against `#fff` is the comparison a widget author is here to
- * make, and collapsing it to a yes/no chip would discard the finding. A probed
- * host that sends nothing reads as an explicit "Not supported"; one nobody has
- * probed stays an em dash, so absence stays legible either way.
+ * These are probed values, so the row shows them: the value a widget actually
+ * receives is the comparison a widget author is here to make, and collapsing
+ * it to a yes/no chip would discard the finding. Hosts differ in notation —
+ * one `light-dark(…)` string vs a resolved literal per theme — so the pair is
+ * normalized (`parseLightDarkPair`) and every host reads down the column the
+ * same way. A probed host that sends nothing reads as an explicit "Not
+ * supported"; one nobody has probed stays an em dash, so absence stays
+ * legible either way.
  *
  * The trade is that value rows are not support-shaped: the only chip they ever
  * render is that `NOT_SUPPORTED` one, and they take no part in the coverage


### PR DESCRIPTION
- On the compare matrix, Claude's style variables showed as a raw `light-dark(rgba(...), rgba(...))` string while ChatGPT/Codex showed stacked LIGHT/DARK hexes — same fact, two shapes, in the one place you're there to compare them.
- `light-dark(a, b)` is now split into the same light/dark pair the probed hosts report, so every host reads down the column identically. The split is on the top-level comma so the commas inside `rgba(...)` don't break it.
- The literal the host actually sends is kept and shown on hover; anything that can't be split (a malformed call, a `color-mix(...)`) still shows verbatim rather than being guessed at.
- Color rows get a small swatch over a checkerboard, so two hexes are comparable at a glance and a transparent `-ghost` token no longer looks like an opaque white one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Normalize style-variable rows in the compare matrix and add color swatches, so all hosts render the same light/dark pair. Previously Claude showed a raw `light-dark(...)` string while ChatGPT/Codex showed per-theme values; now we split `light-dark(a, b)` into light/dark, keep the original literal on hover, and show unsplittable values verbatim.

- **Review notes**
  - Adds `parseLightDarkPair` to split on the top-level comma; returns null for non-`light-dark()` or malformed input. Tests cover parsing and field reading.
  - UI shows a checkerboard-backed color swatch for `--color-*` rows. We assign the value via `backgroundColor`, so unsupported or invalid values fail safely.
  - `@mcpjam/inspector` changeset marks a patch: no behavior change for non-color variables; probed hosts with missing values still show Not supported.

<sup>Written for commit aef10b4c81b4b8015a78d54a5594bdff8f21335c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/MCPJam/inspector/pull/4269?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

