### PR TITLE
caniuse: stop hiding Claude Code and Codex behind the rollout flags

### DIFF
--- a/.changeset/caniuse-shows-flag-gated-hosts.md
+++ b/.changeset/caniuse-shows-flag-gated-hosts.md
@@ -1,0 +1,21 @@
+---
+"@mcpjam/inspector": patch
+---
+
+Show Claude Code and Codex on the public caniuse surfaces.
+
+`claude-code-host-enabled` and `codex-host-enabled` gate the New Host template
+picker while those profiles are iterated on, and are scoped to @mcpjam.com
+users. The public caniuse pages consulted the same flags, and both hooks read
+an unresolved flag as off — so the two hosts were invisible to every anonymous
+visitor. caniuse documents what a third-party host supports, which is a
+different question from whether MCPJam will let you create one, so the gate no
+longer applies there.
+
+The signed-in Host Compare keeps it: a preset column there sits beside hosts
+you can actually create. The Compat tab and the template picker are unchanged.
+This also settles a disagreement between the two public surfaces, where the
+capability page hid only Claude Code while the compare matrix hid both.
+
+Both hosts land past the six-chip inline limit, so they appear in the compare
+matrix's "More" menu rather than the default row.

--- a/mcpjam-inspector/client/src/components/hosts/comparison/CaniuseCapabilityPage.tsx
+++ b/mcpjam-inspector/client/src/components/hosts/comparison/CaniuseCapabilityPage.tsx
@@ -2,7 +2,6 @@ import { useMemo, type ReactNode } from "react";
 import { Button } from "@mcpjam/design-system/button";
 import { ChevronLeft } from "lucide-react";
 import { getScenarioHostLogo } from "@/lib/scenario-client-style";
-import { useClaudeCodeHostEnabled } from "@/hooks/useClaudeCodeHostEnabled";
 import { useHostCatalog } from "@/lib/host-compat/use-host-catalog";
 import { usePreferencesStore } from "@/stores/preferences/preferences-provider";
 import { cn } from "@/lib/utils";
@@ -32,20 +31,17 @@ export function CaniuseCapabilityPage({
 }: CaniuseCapabilityPageProps) {
   const capability = getCaniuseCapabilityBySlug(capabilitySlug);
   const themeMode = usePreferencesStore((s) => s.themeMode);
-  const claudeCodeEnabled = useClaudeCodeHostEnabled();
   const catalogState = useHostCatalog();
   const compareCatalog = catalogState.catalog ?? bundledHostCompatCatalog();
-  const excludedPresetTemplateIds = useMemo(() => {
-    const excluded = new Set<string>();
-    if (!claudeCodeEnabled) excluded.add("claude-code");
-    return excluded;
-  }, [claudeCodeEnabled]);
+  // No feature-flag gate here. `claude-code-host-enabled` / `codex-host-enabled`
+  // gate the New Host template picker while those profiles are iterated on;
+  // this page is public reference data about what a third-party host supports,
+  // which is a different question from whether MCPJam will let you create one.
+  // Consulting the flags also hid both hosts from every anonymous visitor: the
+  // hooks read an unresolved flag as off, and the flags are @mcpjam.com-scoped.
   const presets = useMemo(
-    () =>
-      buildPresetCompareEntries(compareCatalog, {
-        excludedTemplateIds: excludedPresetTemplateIds,
-      }),
-    [compareCatalog, excludedPresetTemplateIds]
+    () => buildPresetCompareEntries(compareCatalog),
+    [compareCatalog]
   );
   const hosts = useMemo(
     () => sortCaniusePresetHosts(presets.hosts),

--- a/mcpjam-inspector/client/src/components/hosts/comparison/HostConfigCompareView.tsx
+++ b/mcpjam-inspector/client/src/components/hosts/comparison/HostConfigCompareView.tsx
@@ -237,12 +237,20 @@ export function HostConfigCompareView({
   const themeMode = usePreferencesStore((s) => s.themeMode);
   const claudeCodeEnabled = useClaudeCodeHostEnabled();
   const codexEnabled = useCodexHostEnabled();
+  // The flags gate the New Host template picker, not this matrix — so they
+  // apply only to the signed-in surface, where a preset column sits next to
+  // hosts you can actually create. In public (caniuse) mode the matrix is
+  // reference data about third-party hosts and shows every catalog row;
+  // gating it there hid Claude Code and Codex from every anonymous visitor,
+  // since the hooks read an unresolved flag as off and the flags are scoped
+  // to @mcpjam.com users.
   const excludedPresetTemplateIds = useMemo(() => {
     const excluded = new Set<string>();
+    if (presetOnly) return excluded;
     if (!claudeCodeEnabled) excluded.add("claude-code");
     if (!codexEnabled) excluded.add("codex");
     return excluded;
-  }, [claudeCodeEnabled, codexEnabled]);
+  }, [claudeCodeEnabled, codexEnabled, presetOnly]);
   const presets = useMemo(() => {
     if (!compareCatalog) {
       return { hosts: [], subjects: {} as Record<string, HostComparisonSubject> };

--- a/mcpjam-inspector/client/src/components/hosts/comparison/__tests__/CaniuseCapabilityPage.test.tsx
+++ b/mcpjam-inspector/client/src/components/hosts/comparison/__tests__/CaniuseCapabilityPage.test.tsx
@@ -47,6 +47,15 @@ describe("CaniuseCapabilityPage", () => {
     );
   });
 
+  it("shows the flag-gated hosts — the flags gate creation, not this page", () => {
+    // `useFeatureFlagEnabled` is mocked false above: the anonymous-visitor
+    // case, and the one that used to hide these two from caniuse entirely.
+    render(<CaniuseCapabilityPage capabilitySlug="sampling" />);
+
+    expect(screen.getByText("Claude Code")).toBeInTheDocument();
+    expect(screen.getByText("Codex")).toBeInTheDocument();
+  });
+
   it("renders a not-found state for unknown capability slugs", () => {
     render(<CaniuseCapabilityPage capabilitySlug="not-a-capability" />);
 

--- a/mcpjam-inspector/client/src/components/hosts/comparison/__tests__/HostConfigCompareView.public.test.tsx
+++ b/mcpjam-inspector/client/src/components/hosts/comparison/__tests__/HostConfigCompareView.public.test.tsx
@@ -126,11 +126,22 @@ describe("HostConfigCompareView public mode", () => {
     expect(screen.getByText("Codex")).toBeInTheDocument();
     unmount();
 
+    // Signed in with a project, so the matrix actually renders hosts. With
+    // `projectId={null}` it short-circuits to the sign-in placeholder and the
+    // absence below would hold no matter what the gate did.
     render(
       <MemoryRouter>
-        <HostConfigCompareView projectId={null} isAuthenticated={false} />
+        <HostConfigCompareView projectId="abc123" isAuthenticated />
       </MemoryRouter>
     );
+    // Presets render here at all...
+    expect(
+      screen.getByTestId("host-compare-chip-preset:claude")
+    ).toBeInTheDocument();
+    fireEvent.click(screen.getByTestId("host-compare-overflow-trigger"));
+    // ...and the overflow menu opened and lists other unranked presets, so
+    // the two absences below are the gate, not an unrendered menu.
+    expect(await screen.findByText("Notion")).toBeInTheDocument();
     expect(screen.queryByText("Claude Code")).not.toBeInTheDocument();
     expect(screen.queryByText("Codex")).not.toBeInTheDocument();
   });

--- a/mcpjam-inspector/client/src/components/hosts/comparison/__tests__/HostConfigCompareView.public.test.tsx
+++ b/mcpjam-inspector/client/src/components/hosts/comparison/__tests__/HostConfigCompareView.public.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen, waitFor } from "@testing-library/react";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { MemoryRouter, useLocation } from "react-router";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
@@ -103,6 +103,36 @@ describe("HostConfigCompareView public mode", () => {
       value: originalMatchMedia,
     });
     document.documentElement.classList.remove("dark");
+  });
+
+  it("offers the flag-gated hosts in public mode but not in the signed-in matrix", async () => {
+    // `useFeatureFlagEnabled` is mocked false above — the anonymous-visitor
+    // case, and the one that used to drop these two from caniuse entirely.
+    // They sit past the 6-chip inline limit, so assert them where they live:
+    // the More menu. Public caniuse is reference data and lists every catalog
+    // host; the signed-in matrix sits beside hosts you can actually create,
+    // so it keeps the rollout gate. Pinned together so the split can't drift.
+    const { unmount } = render(
+      <MemoryRouter>
+        <HostConfigCompareView
+          projectId={null}
+          isAuthenticated={false}
+          presetOnly
+        />
+      </MemoryRouter>
+    );
+    fireEvent.click(screen.getByTestId("host-compare-overflow-trigger"));
+    expect(await screen.findByText("Claude Code")).toBeInTheDocument();
+    expect(screen.getByText("Codex")).toBeInTheDocument();
+    unmount();
+
+    render(
+      <MemoryRouter>
+        <HostConfigCompareView projectId={null} isAuthenticated={false} />
+      </MemoryRouter>
+    );
+    expect(screen.queryByText("Claude Code")).not.toBeInTheDocument();
+    expect(screen.queryByText("Codex")).not.toBeInTheDocument();
   });
 
   it("renders preset compare content without requiring sign-in or a project", async () => {


### PR DESCRIPTION
- Claude Code and Codex were missing from caniuse.dev for everyone outside the team: the public pages checked `claude-code-host-enabled` / `codex-host-enabled`, which are scoped to @mcpjam.com users, and the hooks treat an unresolved flag as off.
- Those flags exist to keep the two templates out of the New Host picker while their profiles are iterated on. caniuse is reference data about what a third-party host supports — a different question — so it no longer consults them.
- The signed-in Host Compare still respects them (a preset column there sits next to hosts you can actually create). The Compat tab and the template picker are untouched.
- Also fixes a disagreement between the two public surfaces: the capability page hid only Claude Code, the compare matrix hid both.
- Both land past the six-chip inline limit, so on the matrix they show in the "More" menu rather than the default row. Promoting them into the default six would push Slack and VS Code out, so I left the ordering alone — say the word if you want that swap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Shows Claude Code and Codex on public caniuse surfaces by removing rollout flag checks there. Previously, both were hidden from anonymous users because `claude-code-host-enabled`/`codex-host-enabled` are `@mcpjam.com`-scoped and unresolved flags read as off; the signed-in compare still gates creation-adjacent views.

- Public capability page and preset compare (`presetOnly`) always list all catalog hosts; the signed-in matrix keeps the gate.
- Fixes the mismatch where the capability page hid only Claude Code while the compare matrix hid both.
- Both hosts appear via the More menu (past the six-chip inline limit); ordering, the Compat tab, and the New Host template picker are unchanged.
- Tests pin the split: public shows both; signed-in with a project hides them via the gate, with overflow menu assertions to ensure the surface renders.
- Publishes a patch to `@mcpjam/inspector`.

<sup>Written for commit 0d76faa8f168c878b81e944db7a969ee9414f675. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/MCPJam/inspector/pull/4270?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

