### PR TITLE
conformance: mark pending panel rows as unscored

### DIFF
--- a/mcpjam-inspector/client/src/components/conformance/ConformancePanel.tsx
+++ b/mcpjam-inspector/client/src/components/conformance/ConformancePanel.tsx
@@ -149,10 +149,18 @@ function formatDetailValue(value: unknown) {
   }
 }
 
+function pendingIdSet(
+  result: { profile?: { pendingCheckIds?: string[] } } | undefined,
+): Set<string> {
+  return new Set(result?.profile?.pendingCheckIds ?? []);
+}
+
 function CheckRow({
   check,
+  pending = false,
 }: {
   check: MCPCheckResult | MCPAppsCheckResult | MCPTasksCheckResult;
+  pending?: boolean;
 }) {
   const [expanded, setExpanded] = useState(false);
   const detailEntries = Object.entries(check.details ?? {});
@@ -167,6 +175,14 @@ function CheckRow({
         aria-expanded={expanded}
       >
         <StatusIcon status={check.status} />
+        {pending ? (
+          <span
+            title="unscored by this run's profile"
+            className="shrink-0 rounded-sm border border-border/60 px-1 py-px text-[10px] leading-none text-muted-foreground"
+          >
+            unscored
+          </span>
+        ) : null}
         <span className="text-xs flex-1 min-w-0 truncate">{check.title}</span>
         {expanded ? (
           <ChevronDown className="h-3 w-3 text-muted-foreground flex-shrink-0" />
@@ -521,6 +537,8 @@ function ConformanceContent({
     () => protocolCatalog(versionPin),
     [versionPin],
   );
+  const protocolPendingIds = pendingIdSet(protocol.result);
+  const tasksPendingIds = pendingIdSet(tasks.result);
 
   return (
     <div className="flex h-full flex-col overflow-hidden">
@@ -628,7 +646,11 @@ function ConformanceContent({
                 </div>
               )}
               {protocol.result.checks.map((check) => (
-                <CheckRow key={`${runVersion}-${check.id}`} check={check} />
+                <CheckRow
+                  key={`${runVersion}-${check.id}`}
+                  check={check}
+                  pending={protocolPendingIds.has(check.id)}
+                />
               ))}
             </div>
           ) : null}
@@ -668,7 +690,11 @@ function ConformanceContent({
                 {tasks.result.summary} (wire: {tasks.result.discovery.wire})
               </div>
               {tasks.result.checks.map((check) => (
-                <CheckRow key={`${runVersion}-${check.id}`} check={check} />
+                <CheckRow
+                  key={`${runVersion}-${check.id}`}
+                  check={check}
+                  pending={tasksPendingIds.has(check.id)}
+                />
               ))}
             </div>
           ) : null}

--- a/mcpjam-inspector/client/src/components/conformance/__tests__/ConformancePanel.test.tsx
+++ b/mcpjam-inspector/client/src/components/conformance/__tests__/ConformancePanel.test.tsx
@@ -904,6 +904,56 @@ describe("ConformanceTab", () => {
     expect(screen.getByText("Failed")).toBeDefined();
   });
 
+  it("marks a pending failed protocol check unscored and leaves a scored failure unmarked", async () => {
+    setupSuccessfulRunMocks({
+      protocol: createProtocolResult({
+        passed: true,
+        checks: [
+          {
+            id: "ping",
+            category: "core",
+            title: "Ping",
+            description: "Ping.",
+            status: "failed",
+            durationMs: 1,
+            error: { message: "pong missing" },
+          },
+          {
+            id: "wire-schema-valid",
+            category: "protocol",
+            title: "Wire schema is valid",
+            description: "Schema check.",
+            status: "failed",
+            durationMs: 1,
+            error: { message: "schema mismatch" },
+          },
+        ],
+        profile: {
+          profileId: "mcp-protocol",
+          profileVersion: "1",
+          manifestDigest: "digest",
+          checkerVersion: "1",
+          pendingCheckIds: ["wire-schema-valid"],
+        },
+      }),
+    });
+
+    render(<ConformanceTab server={createHttpServer()} />);
+    fireEvent.click(screen.getByText("Run available checks"));
+    await screen.findByText("Protocol summary");
+
+    const pendingRow = screen
+      .getByText("Wire schema is valid")
+      .closest("button");
+    expect(pendingRow).toHaveTextContent("unscored");
+    expect(
+      screen.getByTitle("unscored by this run's profile").closest("button"),
+    ).toBe(pendingRow);
+
+    const scoredRow = screen.getByText("Ping").closest("button");
+    expect(scoredRow).not.toHaveTextContent("unscored");
+  });
+
   it("badges an incomplete tasks run distinctly from a passing one", async () => {
     setupSuccessfulRunMocks();
     mockRunTasks.mockResolvedValue({


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Purpose and context

PR A (#4260) surfaced pending checks on the shared results page. The in-product `ConformancePanel` already names pending in the pooled `ScoreHeadline`, but a failed pending **row** still looked identical to a scored failure.

This is **PR B** of the conformance-surfacing series (A → B → C0 → C). Client-only.

## Before / after

**Before**
- Headline says `N pending (unscored by this profile)`.
- A failed pending `CheckRow` is a plain red ✗, same as a scored fail.

**After**
- Protocol and tasks compute a pending-id set from `result.profile?.pendingCheckIds` (apps/oauth have no stamp — pass nothing).
- `CheckRow` takes optional `pending` and renders the same **unscored** badge as the share page (`title`: "unscored by this run's profile").
- `StatusIcon` is unchanged — pending is orthogonal to execution status.

Skipped the optional pre-run `CatalogRow` mark: there is no pin→profile lookup already exposed, and the plan said not to add SDK surface for it.

## Tests

- `ConformancePanel.test.tsx`: a protocol result with a pending failed check shows the badge; a scored failed sibling does not.

## Rollout

- Client-only. No schema or deploy-order constraint.
- Next: PR C0 (backend pending-parity bug + per-suite profile identity), then PR C (agent start→poll ops).
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-bcc24dbc-32bc-4afe-b700-68c976d3ec6d?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-bcc24dbc-32bc-4afe-b700-68c976d3ec6d&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Marks pending conformance panel rows as unscored so failed pending checks are visually distinct from scored failures. Previously, pending failures looked identical to scored failures; now rows with IDs in the profile’s pending list show an “unscored” badge, while the status icon behavior is unchanged.

- Review notes
  - Build a pending ID set from `result.profile?.pendingCheckIds` for protocol and tasks; apps/oauth without a profile pass none.
  - Pass `pending` to `CheckRow`; it renders an “unscored” badge with title “unscored by this run's profile”.
  - `StatusIcon` remains unchanged; pending is orthogonal to execution status.
  - Catalog pre-run rows remain unchanged; there is no pin→profile lookup exposed.

<sup>Written for commit 5f70d23c2dc638692eae9c87d64b2d3f79af798c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/MCPJam/inspector/pull/4271?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

