### PR TITLE
mcp: partition the share operations, unbreaking the catalog check

### DIFF
--- a/.changeset/platform-catalog-share-tools.md
+++ b/.changeset/platform-catalog-share-tools.md
@@ -1,0 +1,18 @@
+---
+"@mcpjam/mcp": patch
+---
+
+Partition the three share operations, unbreaking the platform catalog check.
+
+`get_share_settings`, `set_share_mode` and `rotate_share_link` reached the SDK
+operation list without being placed on either side of the MCP catalog
+partition, so `platformTools.ts` threw "Platform MCP catalog partition drift"
+at module load and took three `@mcpjam/mcp` suites down with it.
+
+They are split the way the surrounding entries already split: the read
+(`get_share_settings`) joins the catalog, and both writes are excluded.
+`set_share_mode` is `risk: 'exposure'` — `anyone_with_link` widens a resource
+to every holder of the URL, guests included — and `rotate_share_link` is
+`risk: 'destructive'`, immediately locking out everyone holding the old link.
+Neither is something an unattended caller should decide. Reading the current
+setting tells a caller nothing it could not learn by opening the UI.

--- a/mcp/README.md
+++ b/mcp/README.md
@@ -139,6 +139,7 @@ so results respect the caller's project access.
 | `upsert_user_testing_member` | Grant one person access to a scenario by email. | — |
 | `remove_user_testing_member` | Revoke one person's access. | — |
 | `rebind_user_testing_scenario` | Swap the environment behind a scenario, keeping its link, members and history. | — |
+| `get_share_settings` | Read who can open a shared scenario, conformance run or eval run: mode, link token and invited members. Changing it is not on this surface. | — |
 
 <!-- The rows above are the CATALOG, not a hand-written summary: they are
      checked against `PLATFORM_CATALOG_OPERATIONS` by

--- a/mcp/src/tools/platformTools.ts
+++ b/mcp/src/tools/platformTools.ts
@@ -113,6 +113,7 @@ import {
   getUserTestingSessionOperation,
   getUserTestingMetricsOperation,
   getUserTestingUsageOperation,
+  getShareSettingsOperation,
   listUserTestingFindingsOperation,
   getUserTestingSignalsOperation,
   getUserTestingInsightsOperation,
@@ -297,6 +298,12 @@ export const PLATFORM_CATALOG_OPERATIONS: ReadonlyArray<
   upsertUserTestingMemberOperation,
   removeUserTestingMemberOperation,
   rebindUserTestingScenarioOperation,
+  // The share READ is on the catalog surface; its two writes are excluded
+  // below. Reading who can already open a resource tells a caller nothing it
+  // could not learn by opening the UI, and without it the two exclusions read
+  // as "sharing is invisible here" rather than "sharing is not yours to
+  // change".
+  getShareSettingsOperation,
 ];
 
 /** Every SDK operation not exposed by the generic MCP catalog, with policy. */
@@ -372,6 +379,10 @@ export const EXCLUDED_FROM_CATALOG: Readonly<Record<string, string>> = {
     "Computer lifecycle writes are not offered on the unattended catalog surface.",
   delete_sandbox_image:
     "Sandbox image lifecycle writes are not offered on the unattended catalog surface.",
+  set_share_mode:
+    "Share-access writes are not offered on the unattended catalog surface: the operation is `risk: 'exposure'` and `anyone_with_link` widens a resource to every holder of the URL, guests included. The read (get_share_settings) is in the catalog.",
+  rotate_share_link:
+    "Share-access writes are not offered on the unattended catalog surface: the operation is `risk: 'destructive'` and immediately locks out everyone holding the old URL. The read (get_share_settings) is in the catalog.",
 };
 
 const catalogOperationNames = new Set(

--- a/mcp/tests/platformTools.test.ts
+++ b/mcp/tests/platformTools.test.ts
@@ -210,6 +210,7 @@ const PLAIN_TOOLS = [
   "upsert_user_testing_member",
   "remove_user_testing_member",
   "rebind_user_testing_scenario",
+  "get_share_settings",
 ];
 
 function stubPlatformFetch(routes: Record<string, unknown>) {
@@ -428,6 +429,7 @@ describe("platform tool registration", () => {
       "upsert_user_testing_member",
       "remove_user_testing_member",
       "rebind_user_testing_scenario",
+      "get_share_settings",
     ]);
     expect(registrations).toHaveLength(PLATFORM_CATALOG_OPERATIONS.length);
     for (const registration of registrations) {


### PR DESCRIPTION
- `main` is red: `platformTools.ts` throws `Platform MCP catalog partition drift: uncovered=get_share_settings,set_share_mode,rotate_share_link` at module load, failing three `@mcpjam/mcp` suites. Every open PR inherits it.
- #4242 added those three operations to the SDK list without putting them on either side of the MCP catalog partition, which that file asserts is total.
- Split them the way the neighbouring entries already split — the read goes in the catalog, the writes stay out. `set_share_mode` is `risk: 'exposure'` (`anyone_with_link` opens a resource to anyone holding the URL, guests included) and `rotate_share_link` is `risk: 'destructive'` (immediately locks out everyone with the old link). Reading the current setting shows nothing you couldn't see by opening the UI.
- Adding the read meant a README table row and three expectation lists in the tests.
- If sharing was meant to be fully drivable from the unattended surface, the fix is to move the two writes into the catalog instead — say so and I'll flip it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Partitions the platform MCP share operations to restore the catalog check. Before: `platformTools.ts` threw at load for uncovered `get_share_settings`, `set_share_mode`, and `rotate_share_link`, breaking `@mcpjam/mcp` suites. Now: `get_share_settings` is in the catalog; the two write operations are excluded with policy.

- Catalog includes `get_share_settings`; README catalog row and tests updated.
- `set_share_mode` (risk: exposure) and `rotate_share_link` (risk: destructive) remain off the unattended catalog; callers cannot change sharing via the catalog.

<sup>Written for commit a68edf12fea19a534ef7f2651dbf7b8941de09f1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/MCPJam/inspector/pull/4273?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

