### PR TITLE
eval: hedge single-cell compose attach in approvals

### DIFF
--- a/mcpjam-inspector/server/routes/v1/__tests__/agent-op-registry.test.ts
+++ b/mcpjam-inspector/server/routes/v1/__tests__/agent-op-registry.test.ts
@@ -264,7 +264,11 @@ describe("agent op registry", () => {
     expect(composed).toContain("composed");
     expect(composed).toContain("Claude Code");
     expect(composed).toContain("one paid run");
-    expect(composed).toContain("without attaching it to the suite");
+    // Inherit-only compose ATTACHES on a backend that cannot launch
+    // ephemerally. Do not promise "without attaching" from saveTargets
+    // alone — describe cannot probe the flag.
+    expect(composed).toContain("ephemeral when supported; otherwise attached");
+    expect(composed).not.toContain("without attaching");
     expect(composed).not.toContain("attached to the suite");
 
     expect(
@@ -276,7 +280,18 @@ describe("agent op registry", () => {
         },
       })
     ).toBe(
-      "Start 2 paid eval runs of suite smoke: 1 client × 2 model choices = 2 runs, without attaching them to the suite"
+      "Start 2 paid eval runs of suite smoke (Claude Code): 1 client × 2 model choices = 2 runs, without attaching them to the suite"
+    );
+    expect(
+      describeRun({
+        suite: "smoke",
+        compose: {
+          host: "ChatGPT",
+          models: ["anthropic/claude-haiku-4.5", "google/gemini-2.5-flash"],
+        },
+      })
+    ).toBe(
+      "Start 2 paid eval runs of suite smoke (ChatGPT): 1 client × 2 model choices = 2 runs, without attaching them to the suite"
     );
     expect(
       describeRun({
@@ -288,7 +303,7 @@ describe("agent op registry", () => {
         },
       })
     ).toBe(
-      "Start 3 paid eval runs of suite smoke: 1 client × 3 model choices = 3 runs, without attaching them to the suite"
+      "Start 3 paid eval runs of suite smoke (Claude Code): 1 client × 3 model choices = 3 runs, without attaching them to the suite"
     );
     expect(
       describeRun({

--- a/mcpjam-inspector/server/routes/v1/agent-op-registry.ts
+++ b/mcpjam-inspector/server/routes/v1/agent-op-registry.ts
@@ -356,28 +356,35 @@ function describeComposeEvalSuiteRun(
   compose: Record<string, unknown>,
 ): string {
   const host = named(compose, "host");
+  const hostNote = host ? ` (${host})` : "";
   const choices = expandComposeModelChoices({
     model: named(compose, "model"),
     models: readStringList(compose, "models"),
     includeClientDefault: compose.includeClientDefault === true,
   });
   const n = choices.length;
+  // `saveTargets` is the only attach the caller opted into. A single cell
+  // against a backend that cannot launch ephemerally still ATTACHES (the
+  // SDK compat fallback in `composeLaunchPolicy`). This copy must not
+  // promise "without attaching" on that path — describe is sync and cannot
+  // probe capabilities, so inherit-only hedges. Multi-cell refuses rather
+  // than attaching, so that sentence can stay ephemeral.
   const attach =
     compose.saveTargets === true
       ? n <= 1
         ? "and the composed environment is attached to the suite"
         : "and the composed environments are attached to the suite"
       : n <= 1
-        ? "without attaching it to the suite"
+        ? "ephemeral when supported; otherwise attached"
         : "without attaching them to the suite";
   if (n <= 1) {
     return (
-      `Run eval suite ${suite} on a composed setup${host ? ` (${host})` : ""}` +
+      `Run eval suite ${suite} on a composed setup${hostNote}` +
       ` — one paid run, ${attach}`
     );
   }
   return (
-    `Start ${n} paid eval runs of suite ${suite}: 1 client × ${n} model choices = ${n} runs, ${attach}`
+    `Start ${n} paid eval runs of suite ${suite}${hostNote}: 1 client × ${n} model choices = ${n} runs, ${attach}`
   );
 }
 

--- a/mcpjam-inspector/server/routes/v1/agent-op-registry.ts
+++ b/mcpjam-inspector/server/routes/v1/agent-op-registry.ts
@@ -321,10 +321,11 @@ function evalRunResource(
 function describeEvalSuiteRun(input: Record<string, unknown>): string {
   const suite = named(input, "suite") ?? "(unnamed)";
   // COMPOSE fans out to N paid runs (client × model choices) and, when
-  // `saveTargets` is set, also edits the suite. Default is ephemeral: mint
-  // and launch without attaching. The spend line must state the multiplier
-  // so a `confirmSeverity: "spend"` proposal does not understate N×, and
-  // must mention an attach when the click would persist one.
+  // `saveTargets` is set, also edits the suite. Default is ephemeral on a
+  // capable backend; a single cell still attaches on an older one. The
+  // spend line must state the multiplier so a `confirmSeverity: "spend"`
+  // proposal does not understate N×, and must not promise "without
+  // attaching" when the click can still persist.
   const compose = input.compose;
   if (compose && typeof compose === "object") {
     return describeComposeEvalSuiteRun(


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Purpose

Follow-up to #4263 (Codex P1 + P2 on the merged registry PR). Compose approval copy was deriving attach solely from `saveTargets`, which does not match the SDK compatibility policy.

## Before / after

**Before**
- Inherit-only compose (`compose: { host }`) said “without attaching it to the suite”.
- On an older or unreachable backend, `composeLaunchPolicy` still attaches that single cell, so the approval promised ephemeral while the click edited the suite.
- Multi-model lines dropped the host, so two proposals with the same suite and model count but different clients looked identical.

**After**
- Single-cell default copy hedges: `ephemeral when supported; otherwise attached`. `saveTargets: true` still says the environment is attached.
- Multi-model copy keeps the composed host in parentheses (`suite smoke (Claude Code)` vs `(ChatGPT)`). Multi-cell still says “without attaching” because that path refuses rather than silently attaching.

## Linked

- Follow-up to #4263.
- Matches `composeLaunchPolicy` in the SDK (`saveTargets || (!ephemeralOk && choiceCount === 1)`).

## Rollout

- Approval-copy only. No backend deploy, no schema change.
- Existing persisted proposals keep their stored description until reminted.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-3b148fcd-1274-4c8f-8adb-ac26b09ec27f?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-3b148fcd-1274-4c8f-8adb-ac26b09ec27f&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Hedges single-cell inherit-only compose approvals to match SDK compatibility and adds the composed host to multi-model lines, preventing misleading “ephemeral” promises and disambiguating proposals by client.

- Single-cell inherit-only: old “without attaching it to the suite”; new “ephemeral when supported; otherwise attached.” `saveTargets: true` still states the environment is attached.
- Multi-model: append the composed host in parentheses after the suite name; multi-cell still says “without attaching.”
- Updated `describeEvalSuiteRun`, `describeComposeEvalSuiteRun`, comments, and tests. Copy-only change; no backend or schema changes. Existing persisted proposals keep prior text until reminted.

<sup>Written for commit 09337050b5a3ecbdd5b7eb1571e1c8c8b446deb7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/MCPJam/inspector/pull/4281?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

