### PR TITLE
docs(skills): inlined catalog, metadata budget, per-surface tool table

### DIFF
--- a/docs/inspector/skills.mdx
+++ b/docs/inspector/skills.mdx
@@ -76,7 +76,25 @@ npx skills update
 
 ### Progressive Disclosure
 
-When you have skills available, MCPJam injects a lightweight list of all skill names and descriptions into the LLM's system prompt. The LLM decides which skills are relevant to your prompt and calls `loadSkill` to load only the instructions it needs. Once a skill is loaded, the LLM can also browse and read its supporting files using `listSkillFiles` and `readSkillFile`.
+When you have skills available, MCPJam inlines the skill catalog — each skill's name and a one-line description — directly into the LLM's system prompt. The LLM decides which skills are relevant to your prompt and calls `loadSkill` to load only the full instructions it needs. Once a skill is loaded, the LLM can also browse and read its supporting files using `listSkillFiles` and `readSkillFile`.
+
+The catalog is not a tool call. There is no general `listSkills` tool — a turn with no skills gets no skill tools and no catalog section at all, so an empty project never spends a discovery turn on tools that would return nothing.
+
+#### Catalog Size Limit
+
+The catalog is capped at **2% of the model's context window** (MCPJam follows OpenAI's plugin guidance here, measured in characters at roughly 4 characters per token). When a model definition carries no context length, the cap falls back to **8,000 characters**.
+
+If your skills do not fit, MCPJam shortens descriptions first, and only omits whole skills as a last resort. An omission is always reported in the catalog itself:
+
+```
+(3 more skills could not be listed within this model's skill-metadata budget.)
+```
+
+An omitted skill is invisible to the model and cannot be loaded, so keep skill descriptions to a single line if you have many skills installed.
+
+#### Catalog Fetch Failures (Hosted)
+
+In the hosted app, the catalog is fetched from your project when the prompt is built, with a **3 second timeout**. If that fetch fails or times out, the turn proceeds with no skills rather than failing — the LLM sees no catalog and no skill tools. MCPJam records the failure separately from a genuinely empty project, so a run that silently lost its skills is distinguishable after the fact.
 
 ### Deterministic Injection
 
@@ -96,12 +114,22 @@ The `/` picker works in both local and hosted modes. In the hosted app, it lists
 
 ## LLM Tool Integration
 
-When skills are available, the LLM has access to three tools:
+When at least one skill is available, the LLM is given `loadSkill`, and — on surfaces that can serve supporting files — the two file tools as well:
 
-| Tool | Description |
-|------|-------------|
-| `loadSkill(name)` | Load the full skill instructions by name |
-| `listSkillFiles(name)` | List all files in the skill directory |
-| `readSkillFile(name, path)` | Read the content of a specific supporting file |
+| Tool | Description | When advertised |
+|------|-------------|-----------------|
+| `loadSkill(name)` | Load the full skill instructions by name | Whenever the turn has at least one skill |
+| `listSkillFiles(name)` | List all files in the skill directory | Only when the turn's skills can carry supporting files |
+| `readSkillFile(name, path)` | Read the content of a specific supporting file | Only when the turn's skills can carry supporting files |
 
-These tools allow the LLM to progressively discover and load skill content as needed during a conversation, rather than injecting all skill content upfront.
+The file tools are not advertised everywhere, because promising them for skills that have no files invites the model to go looking:
+
+- **Local and hosted Playground chat** — all three tools.
+- **Eval runs with pinned skills** — `loadSkill` only. Pinned eval skills are `SKILL.md`-only, so there are no files to browse.
+- **Environment-resolved turns** — all three, but only when the resolved set actually contains a file-bearing skill.
+
+Together with the inlined catalog, these tools let the LLM progressively load skill content as needed during a conversation, rather than injecting every skill's content upfront.
+
+<Note>
+`listSkills` is not a general discovery tool. It appears only when a connected MCP server provides skills through the [Skills over MCP](https://aaif.io/blog/skills-over-mcp) extension (SEP-2640), and it lists those server-provided skills only — their catalog is fetched from the server on demand rather than inlined in the prompt.
+</Note>


### PR DESCRIPTION
## Purpose

`docs/inspector/skills.mdx` still describes the pre-#4223 skill delivery path, and never covered three behaviors that are visible to users. #4227 fixed only the first of those and was closed unmerged; this replaces it.

Checked against the [Agent Plugins client spec](https://agent-plugins.org/client-implementers/implement-an-agent-plugins-client), [loading and discovery](https://agent-plugins.org/client-implementers/loading-and-discovery), and [Skills over MCP](https://aaif.io/blog/skills-over-mcp). Both Agent Plugins pages put skill *presentation* explicitly outside the portable contract ("how skills are shown to users or models"), so nothing here is conformance-bearing — the loading/discovery contract lives in `sdk/src/plugin-bundle/` and is untouched.

## What changed

- **Progressive Disclosure** — the catalog (name + one-line description) is inlined in the system prompt rather than discovered via a tool. A turn with no skills gets no skill tools and no catalog section.
- **New: Catalog Size Limit** — the 2%-of-context budget (`skill-metadata-budget.ts`), its 8,000-char fallback when a model carries no context length, truncate-before-omit ordering, and the overflow notice a user will actually see. An omitted skill is invisible and unloadable, so this belongs in the docs.
- **New: Catalog Fetch Failures (Hosted)** — `CLOUD_SKILLS_FETCH_TIMEOUT_MS` (3s) at prompt-build time, and that a failed fetch drops skills for the turn rather than failing it.
- **LLM Tool Integration** — the table claimed all three tools are always advertised. It now carries a "When advertised" column plus the per-surface breakdown: pinned eval runs get `loadSkill` only (SKILL.md-only pins, decision 8c), and the file tools appear only where skills can carry files.
- **`listSkills`** scoped to MCP-server-provided skills (SEP-2640); it is not a general discovery tool.

Headings stay Title Case to match the rest of the page (#4227 switched two of them to sentence case).

## Known gap, not fixed here

`skill-tools.ts:385` still emits a `## Available Skills` stanza with the older trigger sentence, while the cloud/pinned/effective paths emit `## Skills`. That is a prompt-fidelity fix in the server, not a docs change.

## Test plan

- [ ] Mintlify preview renders the new `####` subsections and the 3-column table

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MMtQomATznePkNaSVwRq6b

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change to inspector skills docs; no runtime, auth, or data-handling code is modified.
> 
> **Overview**
> Updates `docs/inspector/skills.mdx` so skill delivery matches current behavior: the catalog (name + one-line description) is **inlined in the system prompt**, not discovered via a tool. Empty turns get no catalog and no skill tools.
> 
> Documents the **2% context-window metadata budget** (8,000-char fallback), truncate-then-omit overflow, and hosted **3s catalog fetch** that drops skills for the turn instead of failing it.
> 
> Clarifies LLM tools: `loadSkill` whenever skills exist; file tools only on surfaces that can serve supporting files (Playground vs pinned evals vs environment-resolved turns). Scopes `listSkills` to Skills-over-MCP (SEP-2640) only.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a60b7afad9298e4c396228fc8580219dd279deb4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Aligns `docs/inspector/skills.mdx` with the current skill-delivery path. Previously the page described tool-based discovery and always-advertised tools; it now documents the inlined catalog and conditional tool exposure, plus user-visible limits and hosted fetch behavior.

- Key behaviors
  - Catalog is inlined into the system prompt, not discovered via a tool; capped at 2% of model context with an 8,000‑char fallback, truncates descriptions before omitting skills, and shows an omission notice when over budget.
  - Hosted fetch uses a 3s timeout (`CLOUD_SKILLS_FETCH_TIMEOUT_MS`); on failure, the turn proceeds with no skills (no catalog, no skill tools).
  - Tool table corrected: `loadSkill` is advertised when any skill is available; `listSkillFiles` and `readSkillFile` only where skills can carry files; pinned eval runs expose `loadSkill` only (`SKILL.md`‑only).
  - `listSkills` is scoped to MCP server-provided skills (SEP‑2640) and is not a general discovery tool.

<sup>Written for commit a60b7afad9298e4c396228fc8580219dd279deb4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/MCPJam/inspector/pull/4282?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

