### PR TITLE
eval: keep compose host label on frozen approvals

### DIFF
--- a/mcpjam-inspector/server/routes/v1/__tests__/agent-op-registry.test.ts
+++ b/mcpjam-inspector/server/routes/v1/__tests__/agent-op-registry.test.ts
@@ -512,11 +512,48 @@ describe("agent op registry", () => {
       suite: "smoke",
       compose: {
         host: "host_a",
+        hostLabel: "Claude Code",
         models: ["google/gemini-2.5-flash"],
         includeClientDefault: true,
         saveTargets: true,
       },
     });
+  });
+
+  it("keeps the host display name on the approval after freeze", async () => {
+    // persistProposal describes the FROZEN input. Without hostLabel the
+    // card would read `suite smoke (host_a)` after name → id rewrite.
+    const client = {
+      listHosts: async () => ({
+        items: [
+          { id: "host_a", name: "Claude Code" },
+          { id: "host_b", name: "ChatGPT" },
+        ],
+      }),
+    } as unknown as Parameters<
+      ReturnType<typeof proposalMetaFor>["normalizeArgs"]
+    >[1]["client"];
+
+    const frozen = await proposalMetaFor(
+      runEvalSuiteOperation.name
+    ).normalizeArgs(
+      {
+        suite: "smoke",
+        compose: {
+          host: "Claude Code",
+          models: ["anthropic/claude-haiku-4.5", "google/gemini-2.5-flash"],
+        },
+      },
+      { projectId: "p1", client }
+    );
+    const description = proposalMetaFor(
+      runEvalSuiteOperation.name
+    ).description(frozen);
+    expect(description).toContain("Claude Code");
+    expect(description).not.toContain("host_a");
+    expect(description).toBe(
+      "Start 2 paid eval runs of suite smoke (Claude Code): 1 client × 2 model choices = 2 runs, without attaching them to the suite"
+    );
   });
 
   it("merges compose.model into compose.models and leaves an id host alone", async () => {
@@ -544,8 +581,35 @@ describe("agent op registry", () => {
       suite: "smoke",
       compose: {
         host: "host_a",
+        hostLabel: "Claude Code",
         models: ["google/gemini-2.5-flash", "anthropic/claude-haiku-4.5"],
       },
+    });
+  });
+
+  it("drops a caller-supplied hostLabel unless listHosts confirms the host", async () => {
+    const client = {
+      listHosts: async () => ({
+        items: [{ id: "host_a", name: "Claude Code" }],
+      }),
+    } as unknown as Parameters<
+      ReturnType<typeof proposalMetaFor>["normalizeArgs"]
+    >[1]["client"];
+
+    expect(
+      await proposalMetaFor(runEvalSuiteOperation.name).normalizeArgs(
+        {
+          suite: "smoke",
+          compose: {
+            host: "missing-host",
+            hostLabel: "Looks Friendly",
+          },
+        },
+        { projectId: "p1", client }
+      )
+    ).toEqual({
+      suite: "smoke",
+      compose: { host: "missing-host" },
     });
   });
 

--- a/mcpjam-inspector/server/routes/v1/agent-op-registry.ts
+++ b/mcpjam-inspector/server/routes/v1/agent-op-registry.ts
@@ -356,7 +356,10 @@ function describeComposeEvalSuiteRun(
   suite: string,
   compose: Record<string, unknown>,
 ): string {
-  const host = named(compose, "host");
+  // Prefer the freeze-time display name. `host` is rewritten to an id so
+  // approval executes the same client; without `hostLabel` the card would
+  // read `suite smoke (host_a)` after a successful `listHosts`.
+  const host = named(compose, "hostLabel") ?? named(compose, "host");
   const hostNote = host ? ` (${host})` : "";
   const choices = expandComposeModelChoices({
     model: named(compose, "model"),
@@ -522,6 +525,11 @@ async function freezeEvalRunTargets(
  * `includeClientDefault` and `saveTargets` stay as written — they are
  * closed choices, not pointers. Compose itself is kept: dropping it would
  * turn an approved compose into a default-target launch.
+ *
+ * `hostLabel` is describe-only: the approval card needs the human name
+ * after `host` is rewritten to an id. Execute ignores unknown compose
+ * fields (zod strips them). A caller-supplied label is dropped unless
+ * `listHosts` confirms it, so a spoofed label cannot outlive a resolved id.
  */
 async function freezeComposeRunTarget(
   input: Record<string, unknown>,
@@ -529,17 +537,20 @@ async function freezeComposeRunTarget(
   { projectId, client }: { projectId: string; client: PlatformApiClient },
 ): Promise<Record<string, unknown>> {
   const nextCompose: Record<string, unknown> = { ...compose };
+  delete nextCompose.hostLabel;
   const hostSelector = named(compose, "host");
   if (hostSelector) {
     try {
       const page = await client.listHosts({ projectId });
-      const byId = new Set(page.items.map((host) => host.id));
-      if (!byId.has(hostSelector)) {
-        const byName = new Map(
-          page.items.map((host) => [host.name.toLocaleLowerCase(), host.id]),
+      const match =
+        page.items.find((host) => host.id === hostSelector) ??
+        page.items.find(
+          (host) =>
+            host.name.toLocaleLowerCase() === hostSelector.toLocaleLowerCase(),
         );
-        nextCompose.host =
-          byName.get(hostSelector.toLocaleLowerCase()) ?? hostSelector;
+      if (match) {
+        nextCompose.host = match.id;
+        nextCompose.hostLabel = match.name;
       }
     } catch {
       // Same posture as the suite lookup: a platform that cannot answer


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Purpose

Follow-up to #4281 (Codex P2). Freeze rewrites `compose.host` to an id so a rename cannot repoint the spend. `persistProposal` then describes that frozen input, so real approval cards showed `suite smoke (host_a)` instead of `Claude Code`.

## Before / after

**Before**
- `freezeComposeRunTarget` kept only the host id.
- Describe tests called `description` on unnormalized `{ host: "Claude Code" }`, so they never saw the mint path.
- Approvers could not tell which client they were authorizing after a successful `listHosts`.

**After**
- Freeze stores `hostLabel` from the matched `listHosts` row (name or id lookup).
- Describe prefers `hostLabel` over `host`.
- A caller-supplied `hostLabel` is dropped unless `listHosts` confirms the host, so a spoofed label cannot outlive an unresolved selector.
- `hostLabel` is describe-only; the SDK compose schema does not accept it, so execute ignores/strips it.

## Linked

- Follow-up to #4281 / Codex review on the merged hedge PR.

## Rollout

- Approval-copy only. No backend deploy.
- Existing persisted proposals without `hostLabel` still render the id until reminted.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-3b148fcd-1274-4c8f-8adb-ac26b09ec27f?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-3b148fcd-1274-4c8f-8adb-ac26b09ec27f&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Show the client display name on frozen compose approvals while still freezing `compose.host` to an id to prevent repointing. Previously approvals displayed the host id (e.g., host_a); now they prefer the resolved label (e.g., Claude Code) when available.

- Freeze stores `hostLabel` from `listHosts` when resolving a host by id or name; `description` prefers `hostLabel` over `host`.
- Drop a caller-supplied `hostLabel` unless `listHosts` confirms the host, preventing spoofed labels from persisting.
- `hostLabel` is describe-only; execute ignores it because the SDK schema strips unknown compose fields.
- Tests cover keeping the display name after freeze, leaving unresolved hosts unchanged, and merging `compose.model` into `compose.models`.

**Rollout**
- Approval copy only; no backend deploy.
- Existing persisted proposals without `hostLabel` continue to show the id until reminted.

<sup>Written for commit 12eaba9c30818b4ee4466bcf66af7fcf87babf51. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/MCPJam/inspector/pull/4283?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

