### PR TITLE
eval: omit hostLabel from proposal identity hash

### DIFF
--- a/mcpjam-inspector/server/routes/v1/__tests__/agent-op-registry.test.ts
+++ b/mcpjam-inspector/server/routes/v1/__tests__/agent-op-registry.test.ts
@@ -21,6 +21,7 @@ import {
   AGENT_OP_REGISTRY,
   EXCLUDED_FROM_AGENT,
   conformanceRunResource,
+  proposalInputForIdempotency,
   proposalMetaFor,
   WRITE_OPERATION_NAMES,
   gatedEntryFor,
@@ -611,6 +612,27 @@ describe("agent op registry", () => {
       suite: "smoke",
       compose: { host: "missing-host" },
     });
+  });
+
+  it("excludes hostLabel from the proposal identity hash", () => {
+    // persistProposal hashes the frozen input. A host rename changes
+    // hostLabel but not host; that must not mint a second spend control.
+    const renamed = proposalInputForIdempotency({
+      suite: "smoke",
+      compose: { host: "host_a", hostLabel: "Claude" },
+    });
+    const original = proposalInputForIdempotency({
+      suite: "smoke",
+      compose: { host: "host_a", hostLabel: "Claude Code" },
+    });
+    expect(renamed).toEqual({ suite: "smoke", compose: { host: "host_a" } });
+    expect(renamed).toEqual(original);
+    expect(
+      proposalMetaFor(runEvalSuiteOperation.name).hashInput({
+        suite: "smoke",
+        compose: { host: "host_a", hostLabel: "Claude Code" },
+      })
+    ).toEqual(original);
   });
 
   it("leaves a compose host alone when listHosts cannot answer", async () => {

--- a/mcpjam-inspector/server/routes/v1/agent-op-registry.ts
+++ b/mcpjam-inspector/server/routes/v1/agent-op-registry.ts
@@ -572,6 +572,28 @@ async function freezeComposeRunTarget(
   return { ...input, compose: nextCompose };
 }
 
+/**
+ * Drop describe-only compose fields before hashing a proposal identity.
+ *
+ * `hostLabel` is a display name captured at freeze time. A host rename
+ * between Slack redeliveries would otherwise change the normalized input,
+ * mint a second action id, and leave two approval controls for the same
+ * paid run. The stored row still keeps the label so the card can render it.
+ */
+export function proposalInputForIdempotency(
+  input: Record<string, unknown>,
+): Record<string, unknown> {
+  const compose = input.compose;
+  if (!compose || typeof compose !== "object" || Array.isArray(compose)) {
+    return input;
+  }
+  const { hostLabel: _dropped, ...restCompose } = compose as Record<
+    string,
+    unknown
+  >;
+  return { ...input, compose: restCompose };
+}
+
 /** Read a string array off validated input, dropping non-strings. */
 function readStringList(input: Record<string, unknown>, key: string): string[] {
   const value = input[key];
@@ -2020,6 +2042,11 @@ export function proposalMetaFor(operationName: string): {
     input: Record<string, unknown>,
     context: { projectId: string; client: PlatformApiClient },
   ) => Promise<Record<string, unknown>>;
+  /**
+   * Canonicalize frozen input for the proposal action-id hash.
+   * Display-only fields (compose.hostLabel) must not remint a spend control.
+   */
+  hashInput: (input: Record<string, unknown>) => Record<string, unknown>;
   /** Keys the frozen input must carry, or the proposal is refused. */
   requiredFrozenKeys: readonly string[];
 } {
@@ -2032,6 +2059,7 @@ export function proposalMetaFor(operationName: string): {
       severityFor: () => undefined,
       targetFor: () => undefined,
       normalizeArgs: async (input) => input,
+      hashInput: proposalInputForIdempotency,
       requiredFrozenKeys: [],
     };
   }
@@ -2072,6 +2100,7 @@ export function proposalMetaFor(operationName: string): {
         return input;
       }
     },
+    hashInput: proposalInputForIdempotency,
     requiredFrozenKeys: entry.proposal.requiredFrozenKeys ?? [],
   };
 }

--- a/mcpjam-inspector/server/routes/v1/agent.ts
+++ b/mcpjam-inspector/server/routes/v1/agent.ts
@@ -295,7 +295,7 @@ async function persistProposal(opts: {
     ? deriveOperationIdempotencyKey(
         opts.turnIdempotencyKey,
         `proposal:${operation.name}`,
-        input
+        meta.hashInput(input)
       )
     : randomUUID();
   if (!isValidAgentActionId(actionId)) {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Purpose

Follow-up to #4283 (Codex P2). `hostLabel` is describe-only, but `persistProposal` hashed the entire frozen input. A host rename between Slack redeliveries changed the label, minted a new action id, and left two approval controls that can both launch the same paid run.

## Before / after

**Before**
- Freeze stored `{ host: "host_a", hostLabel: "Claude Code" }`.
- Redelivery after rename stored `{ host: "host_a", hostLabel: "Claude" }`.
- Different hashes → two spend proposals for the same host id.

**After**
- `proposalInputForIdempotency` drops `compose.hostLabel` before the action-id hash.
- The persisted row still keeps `hostLabel` so the approval card can render the client name.
- Host id, models, and `saveTargets` still distinguish proposals.

## Linked

- Follow-up to #4283.

## Rollout

- Proposal identity only. No backend deploy.
- In-flight proposals keep their existing action ids.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-3b148fcd-1274-4c8f-8adb-ac26b09ec27f?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-3b148fcd-1274-4c8f-8adb-ac26b09ec27f&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Omits `compose.hostLabel` from the proposal identity hash to prevent duplicate spend controls when a host is renamed. Previously we hashed the full frozen input; now we hash a canonicalized input without the label.

- Adds `proposalInputForIdempotency` and uses it as `hashInput` in `proposalMetaFor`; `persistProposal` now hashes `meta.hashInput(input)`.
- Keeps `hostLabel` in the stored row for card rendering; identity is still distinguished by host id, models, and `saveTargets`.
- Adds a test that verifies the same action id across host label changes.

**Rollout**
- No backend deploy changes; proposal identity only.
- No migration; in-flight proposals keep their existing action ids.

<sup>Written for commit 88085dd274a6a49883658f455398bd3c60198384. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/MCPJam/inspector/pull/4284?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

