### PR TITLE
evals: feed the cross-host matrix the environments a model fan-out mints

### DIFF
--- a/mcpjam-inspector/client/src/components/environment-composer/environment-composer.tsx
+++ b/mcpjam-inspector/client/src/components/environment-composer/environment-composer.tsx
@@ -31,6 +31,7 @@ import {
   composerStateFromEnvironments,
   composerTargetCount,
   emptyEnvironmentStack,
+  emptyModelSelection,
   environmentsCarryModels,
   environmentsCarryPluginPins,
   environmentsExceedOneStack,
@@ -327,7 +328,13 @@ export function EnvironmentComposer({
         {modelsEnabled ? (
           <ModelsPill
             projectId={projectId}
-            value={value.stack.modelSelection}
+            // The stack's own contract says a state can genuinely arrive
+            // without a selection (a draft persisted before the field existed),
+            // and that a missed guard should read as "client defaults" rather
+            // than throw mid-render. Every other reader here goes through
+            // `modelChoiceCount`, which absorbs it; this was the one that
+            // dereferenced the value directly.
+            value={value.stack.modelSelection ?? emptyModelSelection()}
             onChange={(modelSelection) => patchStack({ modelSelection })}
             mode="multiple"
             disabled={slotsDisabled}

--- a/mcpjam-inspector/client/src/components/environment-composer/environment-stack.ts
+++ b/mcpjam-inspector/client/src/components/environment-composer/environment-stack.ts
@@ -472,6 +472,23 @@ export function stackFieldsEqual(
   );
 }
 
+/**
+ * Model equality for environment REUSE, where absent means "inherit the
+ * client's model" and is a real, distinct choice — never a wildcard.
+ *
+ * Deliberately not folded into `stackFieldsEqual`: that predicate also backs
+ * the round-trip checks, which treat the model slot separately. So every site
+ * that reuses an existing row has to pair the two — and this lives here, beside
+ * its partner, because when it existed privately in one resolver the second
+ * matcher simply did not compare models at all.
+ */
+export function sameOptionalModel(
+  left: string | undefined,
+  right: string | undefined
+): boolean {
+  return (left ?? null) === (right ?? null);
+}
+
 /** Shared product-cap copy for both pills (D6). */
 export function targetProductCapReason(
   hostCount: number,

--- a/mcpjam-inspector/client/src/components/environment-composer/resolve-stacks.ts
+++ b/mcpjam-inspector/client/src/components/environment-composer/resolve-stacks.ts
@@ -16,6 +16,7 @@ import {
   expandModelChoices,
   isComposeMode,
   modelChoiceCount,
+  sameOptionalModel,
   stackFieldsEqual,
   targetProductCapReason,
   type EnvironmentComposerState,
@@ -132,13 +133,6 @@ function sharedFields(
  * environment is a strictly different stack — reusing it would silently run
  * pinned plugin versions the user never asked for.
  */
-function sameOptionalModel(
-  left: string | undefined,
-  right: string | undefined
-): boolean {
-  return (left ?? null) === (right ?? null);
-}
-
 function matchingNamedEnvironment(
   hostId: string,
   fields: ReturnType<typeof sharedFields>,

--- a/mcpjam-inspector/client/src/components/evals/__tests__/suite-environment-composer-bar.test.tsx
+++ b/mcpjam-inspector/client/src/components/evals/__tests__/suite-environment-composer-bar.test.tsx
@@ -291,6 +291,52 @@ describe("SuiteEnvironmentComposerBar — environment mode", () => {
     expect(screen.getByTestId("suite-env-attachments-collapse-hint")).toBeInTheDocument();
     expect(screen.getByTestId("suite-env-clients-picker")).toBeDisabled();
   });
+
+  it("blocks editing when a lone attachment pins a model the strip cannot show", () => {
+    // `useModelMatrixCapability` is mocked false here, so there is no models
+    // slot. One attachment means the attachments AGREE, so the collapse check
+    // passes it — and seeding reads the absent slot as "client defaults", so
+    // the first pill edit would resolve a row without the override and move
+    // the suite onto another model without saying so.
+    environmentsRef.current = [
+      {
+        environmentId: "env-a",
+        projectId: "proj-1",
+        name: "A",
+        origin: "named",
+        hostId: "host-1",
+        modelId: "anthropic/claude-haiku-4.5",
+        revision: 1,
+      },
+    ];
+    renderBar({ environmentIds: ["env-a"] } as any);
+
+    expect(
+      screen.getByTestId("suite-env-attachments-collapse-hint"),
+    ).toBeInTheDocument();
+    expect(screen.getByTestId("suite-env-clients-picker")).toBeDisabled();
+  });
+
+  it("leaves an inherit-only attachment editable", () => {
+    // The guard must not fire on every environment — only ones carrying an
+    // override the strip has nowhere to put.
+    environmentsRef.current = [
+      {
+        environmentId: "env-a",
+        projectId: "proj-1",
+        name: "A",
+        origin: "named",
+        hostId: "host-1",
+        revision: 1,
+      },
+    ];
+    renderBar({ environmentIds: ["env-a"] } as any);
+
+    expect(
+      screen.queryByTestId("suite-env-attachments-collapse-hint"),
+    ).not.toBeInTheDocument();
+    expect(screen.getByTestId("suite-env-clients-picker")).not.toBeDisabled();
+  });
 });
 
 describe("SuiteEnvironmentComposerBar — legacy mode", () => {

--- a/mcpjam-inspector/client/src/components/evals/suite-environment-composer-bar.tsx
+++ b/mcpjam-inspector/client/src/components/evals/suite-environment-composer-bar.tsx
@@ -31,6 +31,7 @@ import { SandboxImagePill } from "@/components/environment-composer/sandbox-imag
 import {
   composerHasTarget,
   composerStateFromEnvironments,
+  environmentsCarryModels,
   environmentsCarryPluginPins,
   environmentsExceedOneStack,
   type EnvironmentComposerState,
@@ -250,7 +251,22 @@ function EnvironmentModeBar({
       computersEnabled,
       modelsEnabled,
     }) ||
-    (seeded.customized && environmentsCarryPluginPins(attachedEnvironments));
+    (seeded.customized && environmentsCarryPluginPins(attachedEnvironments)) ||
+    // A model override with no slot to show it in. `environmentsExceedOneStack`
+    // only catches a DISAGREEMENT between attachments, so a suite whose
+    // attachments all pin the SAME model slips past it — and seeding then reads
+    // the slot as "client defaults", so the first pill edit resolves rows
+    // without the override and silently moves the suite to another model.
+    (!modelsEnabled && environmentsCarryModels(attachedEnvironments));
+  /**
+   * The capability probe has not answered yet. Distinct from `collapsesByHost`:
+   * nothing is wrong with the attachments, we just cannot yet tell whether the
+   * models slot exists — and until we can, `modelsEnabled` reads false, which
+   * is the same input that makes a model-bearing attachment look uneditable.
+   * Disabling (rather than declaring a collapse) keeps the hint from flashing
+   * on every load, matching how the environment list is handled above.
+   */
+  const modelCapabilityPending = Boolean(projectId) && modelMatrix === undefined;
 
   const [state, setState] = useState<EnvironmentComposerState>(seeded);
   const [saving, setSaving] = useState(false);
@@ -329,6 +345,7 @@ function EnvironmentModeBar({
             disabled ||
             saving ||
             environmentsLoading ||
+            modelCapabilityPending ||
             unresolvedCount > 0 ||
             collapsesByHost
           }
@@ -351,9 +368,9 @@ function EnvironmentModeBar({
           data-testid="suite-env-attachments-collapse-hint"
         >
           This suite&apos;s environments don&apos;t fit one editable setup —
-          they differ by client, server group, skills or image, or pin plugin
-          versions — so this strip can&apos;t change them without changing what
-          some of them run. Adjust them in suite settings.
+          they differ by client, server group, skills, model or image, or pin
+          plugin versions — so this strip can&apos;t change them without changing
+          what some of them run. Adjust them in suite settings.
         </p>
       ) : null}
     </div>

--- a/mcpjam-inspector/client/src/components/evals/suite-iterations-view.tsx
+++ b/mcpjam-inspector/client/src/components/evals/suite-iterations-view.tsx
@@ -484,12 +484,22 @@ export function SuiteIterationsView({
   // control (header Run all, run-detail rerun/replay, per-case play buttons
   // in both dashboards), so deriving any lower down leaves some of them
   // ungated. Folded into the same disabled-reason channel billing uses.
-  const attachedEnvironments = useProjectEnvironments(
-    (suite.environmentIds?.length ?? 0) > 0 ? (projectId ?? null) : null
+  // Ad-hoc rows INCLUDED, and not gated on the suite having attachments —
+  // both because of what a model matrix is. Every cell it mints is an ad-hoc
+  // row, and a compose-and-run launches without attaching at all, so the
+  // narrower read returned a list with none of the environments the runs below
+  // actually reference: the matrix could not tell two models on one client
+  // apart, and the collision split never had two rows to compare.
+  //
+  // Widening is safe for `evalSuitePinsSandboxImage`, which looks up only the
+  // ids the suite itself lists — a superset cannot make it read true.
+  const projectEnvironments = useProjectEnvironments(
+    projectEnvironmentsEnabled ? (projectId ?? null) : null,
+    { includeAdhoc: true }
   );
   const suitePinsSandboxImage = evalSuitePinsSandboxImage(
     suite,
-    attachedEnvironments ?? undefined
+    projectEnvironments ?? undefined
   );
   const evalRunsDisabledReason =
     evalRunsDisabledReasonProp ??
@@ -892,7 +902,7 @@ export function SuiteIterationsView({
           );
         }}
         hostNamesById={hostNamesById}
-        environments={attachedEnvironments}
+        environments={projectEnvironments}
       />
     ) : undefined;
 
@@ -948,7 +958,7 @@ export function SuiteIterationsView({
       isGeneratingTestCases={isGeneratingTestCases}
       onCreateTestCase={onCreateTestCase}
       hostNamesById={hostNamesById}
-      environments={attachedEnvironments}
+      environments={projectEnvironments}
       {...extra}
     />
   );
@@ -1342,7 +1352,7 @@ export function SuiteIterationsView({
                       isGeneratingTestCases={isGeneratingTestCases}
                       onCreateTestCase={onCreateTestCase}
                       hostNamesById={hostNamesById}
-                      environments={attachedEnvironments}
+                      environments={projectEnvironments}
                     />
                   )}
                 </motion.div>

--- a/mcpjam-inspector/client/src/components/swarms/__tests__/swarm-target-materialize.test.ts
+++ b/mcpjam-inspector/client/src/components/swarms/__tests__/swarm-target-materialize.test.ts
@@ -67,6 +67,53 @@ describe("findMatchingLiveEnvironment", () => {
       )?.environmentId
     ).toBe("bare");
   });
+
+  it("never reuses a row carrying a model override", () => {
+    // The swarm strip has no model slot, so its composition always means
+    // "inherit the client's model". Matching a row that pins one on the
+    // strength of the other slots would run the swarm on a model nobody
+    // selected here, under a name that says nothing about it.
+    const live = [
+      env({
+        environmentId: "pinned",
+        hostId: "h1",
+        modelId: "anthropic/claude-haiku-4.5",
+      }),
+      env({ environmentId: "inherit", hostId: "h1" }),
+    ];
+    expect(
+      findMatchingLiveEnvironment(
+        "h1",
+        {
+          serverAttachmentId: null,
+          skillSelection: null,
+          computerEnvironmentId: null,
+        },
+        live
+      )?.environmentId
+    ).toBe("inherit");
+  });
+
+  it("returns nothing when the only same-stack row pins a model", () => {
+    const live = [
+      env({
+        environmentId: "pinned",
+        hostId: "h1",
+        modelId: "google/gemini-2.5-flash",
+      }),
+    ];
+    expect(
+      findMatchingLiveEnvironment(
+        "h1",
+        {
+          serverAttachmentId: null,
+          skillSelection: null,
+          computerEnvironmentId: null,
+        },
+        live
+      )
+    ).toBeUndefined();
+  });
 });
 
 describe("materializeSwarmTargets", () => {

--- a/mcpjam-inspector/client/src/components/swarms/swarm-target-materialize.ts
+++ b/mcpjam-inspector/client/src/components/swarms/swarm-target-materialize.ts
@@ -9,6 +9,7 @@ import {
   MAX_ENVIRONMENTS_PER_JOURNEY,
 } from "@/components/swarms/journey-environments";
 import {
+  sameOptionalModel,
   stackFieldsEqual,
   type EnvironmentStack,
 } from "@/components/environment-composer/environment-stack";
@@ -54,7 +55,15 @@ export class SwarmTargetMaterializeError extends Error {
   }
 }
 
-/** Live (non-archived) env matching host + shared stack fields. */
+/**
+ * Live (non-archived) env matching host + shared stack fields.
+ *
+ * A row carrying a model OVERRIDE never matches. The swarm strip has no model
+ * slot, so its composition always means "inherit the client's model" — and
+ * absent is a real choice here, not a wildcard. Reusing an overridden row
+ * because the other slots line up would run the swarm on a model nobody
+ * selected on this screen, under a name that says nothing about it.
+ */
 export function findMatchingLiveEnvironment(
   hostId: string,
   stack: Pick<
@@ -67,6 +76,7 @@ export function findMatchingLiveEnvironment(
     (env) =>
       !env.archivedAt &&
       env.hostId === hostId &&
+      sameOptionalModel(env.modelId, undefined) &&
       stackFieldsEqual(
         {
           serverAttachmentId: env.serverAttachmentId ?? null,

--- a/mcpjam-inspector/client/src/hooks/use-model-matrix-capability.ts
+++ b/mcpjam-inspector/client/src/hooks/use-model-matrix-capability.ts
@@ -57,20 +57,12 @@ export function useModelMatrixCapability(
           (caps as { modelMatrix?: unknown }).modelMatrix === true;
         if (!cancelled) setState(modelMatrix);
       })
-      .catch((err: unknown) => {
-        if (cancelled) return;
-        const data = (err as { data?: unknown } | null)?.data;
-        const message =
-          typeof data === "string"
-            ? data
-            : err instanceof Error
-              ? err.message
-              : String(err);
-        if (/could not find public function/i.test(message)) {
-          setState(false);
-          return;
-        }
-        setState(false);
+      .catch(() => {
+        // Every failure means the same thing to a caller: do not offer the
+        // models slot, and do not let the resolver send a `modelId`. Skew (the
+        // function is missing) and any other error were previously separate
+        // branches setting the identical value.
+        if (!cancelled) setState(false);
       });
     return () => {
       cancelled = true;


### PR DESCRIPTION
Post-merge robustness audit of the client × model fan-out (#4256/#4261/#4263). Inspector client half; the backend half is MCPJam/mcpjam-backend#1107, which **deploys first**.

## SEV-1 — the matrix could not see the feature's own environments

`suite-iterations-view.tsx` read the environment list **without `includeAdhoc`** and gated it on the suite having attachments. But every cell a model fan-out mints is an ad-hoc row, and a compose-and-run launches *without attaching at all* — so the list arrived with none of the environments the runs on screen actually reference.

All three consequences were silent:
- an attached-but-not-yet-run model cell got **no column**;
- the shared-slot **collision split never had two rows to compare** — dead code in production;
- the **pre-attribution model fallback** could never resolve.

Its sibling on the same screen (`suite-environment-composer-bar.tsx`) already passed `includeAdhoc: true`. This was the inconsistency, not a deliberate narrowing.

Widening is safe for `evalSuitePinsSandboxImage`, which looks up only the ids the suite itself lists — a superset cannot make it read true.

## SEV-1 — swarm reuse still ignored the model

`matchingNamedEnvironment` (the resolver) was fixed when the fan-out landed. `findMatchingLiveEnvironment` — the **parallel matcher** swarm materialization uses — was not. The swarm strip has no model slot, so its composition always means "inherit the client's model"; matching a row that pins one on the strength of the other slots runs the swarm on a model nobody selected, under a name that says nothing about it.

The comparison now lives beside `stackFieldsEqual` as `sameOptionalModel`, and **both** call sites import it — keeping it private to one resolver is precisely how the second matcher came to not compare models at all.

## SEV-2 — a lone model-bearing attachment shed its override

`environmentsExceedOneStack` only catches a **disagreement** between attachments, so a suite whose attachments all pin the *same* model slipped past it. Seeding then read the absent slot as "client defaults", and the first pill edit would resolve rows without the override.

The composer bar is the right home for this check: it is computed from the **persisted attachments**, which is exactly the case the composer's own guard cannot see (ad-hoc rows seed as a composition, where there is no saved selection left to protect). The strip is also disabled while the capability probe is unsettled — until it answers, `modelsEnabled` reads false, the same input that makes a model-bearing attachment look uneditable, so without this the hint would flash on every load.

## Smaller

- `ModelsPill` was the one `modelSelection` reader that dereferenced the value rather than degrading to client defaults — contradicting the stack's own documented contract that a missed guard should read as "client defaults" instead of throwing mid-render.
- The capability probe's two `catch` branches set the identical value; collapsed to one.

## Known gap, deliberately NOT fixed here

Seeding a **model-less surface** (User Testing detail, swarm composer) from an ad-hoc environment that carries a model still sheds it, and no guard can currently catch it: `composerStateFromEnvironments` returns `environmentIds: []` for a non-named row, so the composer's `stackEditBlock` has nothing to inspect. The two candidate fixes both need a product call:

- **preserve the model invisibly** — correct for reuse (same fingerprint ⇒ same row), but `resolve-stacks` refuses to send a `modelId` unless `modelMatrix === true`, and an environment can legitimately carry a model on a backend advertising only `modelOverrides`. That turns a silent shed into a hard `BACKEND_REJECTED` mid-rollout;
- **carry seeding provenance in the composer state** so the guard can see the rows — a wider change than a fix-pack should make.

Filed rather than guessed.

## Verification

- Full inspector client suite: **9,807 passed**, 29 skipped (pre-existing).
- `tsc -p client --noEmit`: **533 errors before, 533 after** — zero new (all pre-existing, from the shared workspace `node_modules`).
- New tests: swarm matcher refuses a model-bearing row (and returns nothing when it is the only candidate); the bar blocks a lone model-pinning attachment; an inherit-only attachment stays editable.
- Local `prettier --check` flags these files both before and after my changes (v2, no repo config), so it is not a signal here — no reformatting done.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PN6sCF8o9nvo65j4WyQr7d

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches environment reuse and evals matrix data, so a matcher or lookup mistake could still run the wrong model or hide columns. Changes are defensive (wider reads, refuse reuse, disable edits) rather than new launch paths.
> 
> **Overview**
> Fixes silent model-fan-out bugs: the evals matrix now sees the ad-hoc environments those runs actually use, and reuse/edit paths no longer drop or steal a model override.
> 
> **Matrix lookup.** `SuiteIterationsView` loads project environments with `includeAdhoc: true` and no longer waits for suite attachments. Fan-out cells are ad-hoc (and compose-and-run may attach nothing), so the old list could not distinguish two models on one client or feed the collision split.
> 
> **Reuse.** Swarm materialization now treats “inherit client model” as a real choice via shared `sameOptionalModel`, so it will not reuse a row that pins a model. The helper lives next to `stackFieldsEqual` so both matchers stay in sync.
> 
> **Edit guards.** The suite composer bar blocks edits when attachments pin a model the strip cannot show (including a lone same-model pin that `environmentsExceedOneStack` missed), and stays disabled while the capability probe is pending so the hint does not flash. `ModelsPill` falls back to `emptyModelSelection()` instead of throwing on a missing field.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0aa7ec1043d90afe3294191799ce018dd02a801d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Feeds the evals cross‑host matrix the ad‑hoc environments minted by model fan‑out and makes swarm reuse model‑aware. Previously the matrix ignored ad‑hoc rows and swarm matching could reuse model‑pinned environments; now the matrix includes ad‑hoc rows and the swarm matcher refuses reuse when a model override exists, preventing silent model changes.

- Review notes:
  - Suite iterations now reads project environments with ad‑hoc rows included and not gated on attachments; this is safe for `evalSuitePinsSandboxImage`.
  - Introduces `sameOptionalModel` and uses it in both environment matchers so “inherit client model” is a distinct, comparable choice; `findMatchingLiveEnvironment` now rejects rows that pin a model.
  - The suite composer bar collapses/blocks editing when attachments carry models but the models slot is unavailable or capability probing is pending; inherit‑only attachments remain editable.
  - `ModelsPill` tolerates absent `modelSelection` by defaulting to client settings; the model capability hook simplifies failure handling.

- Rollout:
  - Requires backend support in `mcpjam-backend#1107` to deploy first. No migrations or config changes required.

<sup>Written for commit 0aa7ec1043d90afe3294191799ce018dd02a801d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/MCPJam/inspector/pull/4286?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

