### PR TITLE
eval: freeze what a case-run proposal approves, and preflight compose models

### DIFF
--- a/mcpjam-inspector/server/routes/v1/__tests__/agent-op-registry.test.ts
+++ b/mcpjam-inspector/server/routes/v1/__tests__/agent-op-registry.test.ts
@@ -314,6 +314,32 @@ describe("agent op registry", () => {
     ).toContain("attached to the suite");
   });
 
+  it("says when a case run composes, and when composing edits the suite", () => {
+    // "Run eval case checkout" approved a compose (which mints an
+    // environment) and, with saveTargets, a persistent suite attachment —
+    // neither of which the line mentioned.
+    const describeCase = proposalMetaFor(runEvalCaseOperation.name).description;
+    expect(describeCase({ suite: "smoke", case: "checkout" })).toBe(
+      "Run eval case checkout"
+    );
+    const composed = describeCase({
+      suite: "smoke",
+      case: "checkout",
+      compose: { host: "Claude Code" },
+    });
+    expect(composed).toContain("composed setup");
+    expect(composed).toContain("Claude Code");
+    expect(composed).toContain("one paid run");
+    expect(composed).not.toContain("attached to the suite");
+    expect(
+      describeCase({
+        suite: "smoke",
+        case: "checkout",
+        compose: { host: "Claude Code", saveTargets: true },
+      })
+    ).toContain("attached to the suite");
+  });
+
   it("marks both eval-run proposals as SPEND", () => {
     // Every eval run consumes credits, and a fan-out consumes them N times —
     // the host's default confirmation copy does not say so.
@@ -516,6 +542,81 @@ describe("agent op registry", () => {
         hostLabel: "Claude Code",
         models: ["google/gemini-2.5-flash"],
         includeClientDefault: true,
+        saveTargets: true,
+      },
+    });
+  });
+
+  it("freezes compose.computer, which is a name-or-id pointer like the host", async () => {
+    // `computer` is documented as "name or ID" and resolved by name at execute
+    // time, so an image renamed or replaced between the proposal and the click
+    // repoints which sandbox the approved run boots.
+    const client = {
+      listHosts: async () => ({
+        items: [{ id: "host_a", name: "Claude Code" }],
+      }),
+      listImages: async () => ({
+        items: [
+          { id: "img_a", name: "playwright-base" },
+          { id: "img_b", name: "node-22" },
+        ],
+      }),
+    } as unknown as Parameters<
+      ReturnType<typeof proposalMetaFor>["normalizeArgs"]
+    >[1]["client"];
+
+    expect(
+      await proposalMetaFor(runEvalSuiteOperation.name).normalizeArgs(
+        {
+          suite: "smoke",
+          compose: { host: "Claude Code", computer: "playwright-base" },
+        },
+        { projectId: "p1", client }
+      )
+    ).toEqual({
+      suite: "smoke",
+      compose: {
+        host: "host_a",
+        hostLabel: "Claude Code",
+        computer: "img_a",
+      },
+    });
+  });
+
+  it("freezes a case run's compose the same way the suite run's is frozen", async () => {
+    // run_eval_case takes the full compose input — including `saveTargets`,
+    // which ATTACHES the minted cell to the suite. Without normalization its
+    // proposal stored repointable names and the approval covered a persistent
+    // edit it never mentioned.
+    const client = {
+      listHosts: async () => ({
+        items: [{ id: "host_a", name: "Claude Code" }],
+      }),
+      listImages: async () => ({ items: [] }),
+    } as unknown as Parameters<
+      ReturnType<typeof proposalMetaFor>["normalizeArgs"]
+    >[1]["client"];
+
+    expect(
+      await proposalMetaFor(runEvalCaseOperation.name).normalizeArgs(
+        {
+          suite: "smoke",
+          case: "checkout",
+          compose: {
+            host: "Claude Code",
+            model: "google/gemini-2.5-flash",
+            saveTargets: true,
+          },
+        },
+        { projectId: "p1", client }
+      )
+    ).toEqual({
+      suite: "smoke",
+      case: "checkout",
+      compose: {
+        host: "host_a",
+        hostLabel: "Claude Code",
+        models: ["google/gemini-2.5-flash"],
         saveTargets: true,
       },
     });

--- a/mcpjam-inspector/server/routes/v1/agent-op-registry.ts
+++ b/mcpjam-inspector/server/routes/v1/agent-op-registry.ts
@@ -352,6 +352,34 @@ function describeEvalSuiteRun(input: Record<string, unknown>): string {
     : `Run eval suite ${suite}`;
 }
 
+/**
+ * The approval line for a single eval CASE run.
+ *
+ * Composing is available here exactly as it is on the suite run, and
+ * `saveTargets` makes it ATTACH the minted cell to the suite — a persistent
+ * edit to shared configuration. A card that said only "Run eval case X" asked
+ * for approval of the run and got approval for the edit too.
+ *
+ * The case run refuses more than one model choice, so the count is always one
+ * paid run and no multiplier is stated.
+ */
+function describeEvalCaseRun(input: Record<string, unknown>): string {
+  const testCase = named(input, "case") ?? "(unnamed)";
+  const compose = input.compose;
+  if (compose && typeof compose === "object") {
+    const composeRecord = compose as Record<string, unknown>;
+    const host =
+      named(composeRecord, "hostLabel") ?? named(composeRecord, "host");
+    const hostNote = host ? ` (${host})` : "";
+    const attach =
+      composeRecord.saveTargets === true
+        ? ", and the composed environment is attached to the suite"
+        : "";
+    return `Run eval case ${testCase} on a composed setup${hostNote} — one paid run${attach}`;
+  }
+  return `Run eval case ${testCase}`;
+}
+
 function describeComposeEvalSuiteRun(
   suite: string,
   compose: Record<string, unknown>,
@@ -520,7 +548,15 @@ async function freezeEvalRunTargets(
 }
 
 /**
- * Freeze a compose proposal: host name → id, scalar `model` into `models`.
+ * Freeze a compose proposal: host and computer names → ids, scalar `model`
+ * into `models`.
+ *
+ * `computer` is frozen for exactly the reason `host` is. It is documented as
+ * "name or ID" and resolved by name at execute time, so an image renamed or
+ * replaced between the proposal and the click repoints which sandbox the
+ * approved run boots — the pointer problem this function exists to close, one
+ * slot over. `serverGroup`, `skills.skillIds` and `pluginVersionIds` are
+ * ID-only by contract and so are not pointers to freeze.
  *
  * `includeClientDefault` and `saveTargets` stay as written — they are
  * closed choices, not pointers. Compose itself is kept: dropping it would
@@ -555,6 +591,24 @@ async function freezeComposeRunTarget(
     } catch {
       // Same posture as the suite lookup: a platform that cannot answer
       // must not cost the caller the proposal.
+    }
+  }
+
+  const computerSelector = named(compose, "computer");
+  if (computerSelector) {
+    try {
+      const page = await client.listImages({ projectId });
+      const match =
+        page.items.find((image) => image.id === computerSelector) ??
+        page.items.find(
+          (image) =>
+            image.name?.toLocaleLowerCase() ===
+            computerSelector.toLocaleLowerCase(),
+        );
+      if (match) nextCompose.computer = match.id;
+    } catch {
+      // Same posture as the host lookup: a platform that cannot answer must
+      // not cost the caller the proposal. Execute still resolves the selector.
     }
   }
 
@@ -1335,13 +1389,19 @@ export const AGENT_OP_REGISTRY: readonly AgentOpEntry[] = [
     operation: runEvalCaseOperation,
     tier: "gated",
     proposal: {
-      describe: (input) =>
-        `Run eval case ${named(input, "case") ?? "(unnamed)"}`,
+      describe: describeEvalCaseRun,
       buttonLabel: "Run it",
       kind: "start",
       confirmSeverity: "spend",
       resource: evalRunResource,
       target: evalSuiteTarget,
+      // Same freeze as the suite run, and for the same reasons. This operation
+      // takes the full `compose` input, so without it `compose.host` and
+      // `compose.computer` stay names — pointers that can be repointed between
+      // the proposal and the click — and `saveTargets` can additionally ATTACH
+      // the minted cell to the suite, a persistent edit the old one-line
+      // describe never mentioned.
+      normalizeProposalArgs: freezeEvalRunTargets,
     },
   },
   {

--- a/sdk/src/platform/operations.ts
+++ b/sdk/src/platform/operations.ts
@@ -2064,14 +2064,50 @@ export function expandComposeModelChoices(stack: {
 }
 
 /**
+ * What a compose already wrote, as a sentence for an error that came after it.
+ *
+ * ONE formatter, because both places that report this are reporting the same
+ * two facts (which cells exist, whether the suite was edited) and a caller
+ * deciding "did this touch my suite?" must not get a different answer
+ * depending on which step failed.
+ */
+function composedCellsNote(
+  cells: ReadonlyArray<{ id: string; created: boolean; modelId?: string }>,
+  attached: boolean,
+): string {
+  const cellNote = cells
+    .map(
+      (cell) =>
+        `${cell.id}${cell.created ? " (created)" : " (reused)"}${
+          cell.modelId ? ` · ${cell.modelId}` : ""
+        }`,
+    )
+    .join(", ");
+  return `(The composed environment${cells.length === 1 ? "" : "s"} ${
+    cellNote
+  } ${
+    attached ? "were attached to the suite" : "were minted without attaching"
+  }; retrying is safe — it will reuse them.)`;
+}
+
+/**
  * Turn a composed stack into runnable target cells: ensure one ad-hoc
  * environment per model choice (host-major inherit-then-explicit).
  *
  * DEFAULT IS EPHEMERAL — mint and launch without mutating the suite. Attach
  * is opt-in (`saveTargets` / `--save-targets`) because permanently appending
- * on every compose experiment accumulates toward the 10-cap. When attach is
- * requested, the union `|existing ∪ newCells|` is pre-flighted so a product
- * that fits still cannot grow the suite past the cap mid-way.
+ * on every compose experiment accumulates toward the 10-cap.
+ *
+ * When attach is requested, the union `|existing ∪ newCells|` is checked
+ * before the first attach, so the suite is never grown past the cap and never
+ * left half-appended by it. Note what that check CANNOT be: exact before the
+ * cells exist. Ad-hoc ids are content-addressed by the backend, so whether a
+ * cell is new or resolves onto a row the suite already has is not knowable
+ * client-side — an `existing + choices` estimate would reject re-composing a
+ * stack that is already attached, which fits fine. Minting first and checking
+ * the real union keeps the answer exact; the cost is ad-hoc rows that no
+ * suite references, which is the standing posture for them anyway (content-
+ * addressed, hidden from lists, reused on the next identical compose).
  */
 async function composeRunEnvironment(
   client: PlatformApiClient,
@@ -2121,19 +2157,34 @@ async function composeRunEnvironment(
     const union = new Set([...existing, ...cells.map((cell) => cell.id)]);
     if (union.size > 10) {
       throw operationInputError(
-        `Attaching these composed cells would grow the suite to ${union.size} environments (limit 10). Detach some first, or omit --save-targets / saveTargets to launch ephemerally.`,
+        `Attaching these composed cells would grow the suite to ${union.size} environments (limit 10). Detach some first, or omit --save-targets / saveTargets to launch ephemerally. ${composedCellsNote(cells, false)}`,
       );
     }
     for (const cell of cells) {
-      const attachment = await client.attachEvalSuiteEnvironment(
-        {
-          projectId: project.id,
-          suiteId: suite.id,
-          environmentId: cell.id,
-        },
-        { signal },
-      );
-      attached = attached || attachment.attached === true;
+      try {
+        const attachment = await client.attachEvalSuiteEnvironment(
+          {
+            projectId: project.id,
+            suiteId: suite.id,
+            environmentId: cell.id,
+          },
+          { signal },
+        );
+        attached = attached || attachment.attached === true;
+      } catch (error) {
+        // The suite is now PARTIALLY appended, and this loop runs before the
+        // launch — so the annotator that reports compose writes does not exist
+        // yet (it is handed a finished `ComposedRunEnvironment`). Without this
+        // the caller is told the attach failed and never that some of it
+        // landed. Annotated in place so an abort stays an abort.
+        if (error instanceof Error) {
+          error.message = `${error.message} ${composedCellsNote(
+            cells,
+            attached,
+          )}`;
+        }
+        throw error;
+      }
     }
   }
 
@@ -2159,25 +2210,32 @@ async function composeRunEnvironment(
 }
 
 /**
- * Probe whether this deployment accepts `ephemeralEnvironment` on launch.
+ * Probe what this deployment can do with a composed stack, in ONE read.
  *
- * A missing capabilities route (older inspector) or a capabilities payload
- * that omits the flag both mean "do not send the arg" — an unknown field is
- * a hard 400 on a strict schema, not a silently ignored one.
+ * A missing capabilities route (older inspector) or a payload that omits a
+ * flag both mean "do not send it" — an unknown field is a hard 400 on a strict
+ * schema, not a silently ignored one.
+ *
+ * `modelOverrides` rides along rather than getting a second round-trip: both
+ * questions are answered by the same route, and the compose path has to ask
+ * both whenever a model is named.
  */
-async function probeEphemeralEnvironmentLaunch(
+async function probeComposeCapabilities(
   client: PlatformApiClient,
   projectId: string,
   signal: AbortSignal | undefined,
-): Promise<boolean> {
+): Promise<{ ephemeralLaunch: boolean; modelOverrides: boolean }> {
   try {
     const capabilities = await client.getEnvironmentCapabilities(
       { projectId },
       { signal },
     );
-    return capabilities.ephemeralEnvironmentLaunch === true;
+    return {
+      ephemeralLaunch: capabilities.ephemeralEnvironmentLaunch === true,
+      modelOverrides: capabilities.modelOverrides === true,
+    };
   } catch {
-    return false;
+    return { ephemeralLaunch: false, modelOverrides: false };
   }
 }
 
@@ -2194,8 +2252,22 @@ function composeLaunchPolicy(input: {
   choiceCount: number;
   saveTargets: boolean;
   ephemeralOk: boolean;
+  /** Explicit model ids were named (an inherit-only compose names none). */
+  explicitModels: boolean;
+  modelOverridesOk: boolean;
   refreshSnapshot?: boolean;
 }): { attach: boolean; ephemeralLaunch: boolean } {
+  if (input.explicitModels && !input.modelOverridesOk) {
+    // The same preflight `environments create --model` performs, on the path
+    // that actually grew a model axis. Without it a skew deployment answers a
+    // `--compose-model` with the raw validator error from `ensureAdhocEnvironment`
+    // — the opaque failure that guard exists to replace — and the CLI, remote
+    // MCP and in-app agent all take THIS path, so putting it here is what makes
+    // the three agree with the web composer, which already refuses.
+    throw operationInputError(
+      "This MCPJam deployment does not support environment model overrides. Upgrade the platform, or omit --compose-model / compose.models.",
+    );
+  }
   if (input.choiceCount > 1 && input.refreshSnapshot) {
     throw operationInputError(
       "refreshSnapshot cannot be used with a multi-target launch — it PERSISTS one host-config snapshot on the suite, and several runs racing to write it would leave the suite pinned to whichever finished last. Run one target at a time to refresh it.",
@@ -2259,21 +2331,10 @@ async function createEvalRunOrReportCompose<T>(
     return await launch();
   } catch (error) {
     const cells = composed.report.environments ?? [composed.report.environment];
-    const cellNote = cells
-      .map(
-        (cell) =>
-          `${cell.id}${cell.created ? " (created)" : " (reused)"}${
-            cell.modelId ? ` · ${cell.modelId}` : ""
-          }`,
-      )
-      .join(", ");
-    const note = `(The composed environment${cells.length === 1 ? "" : "s"} ${
-      cellNote
-    } ${
-      composed.report.attachment.attached
-        ? "were attached to the suite"
-        : "were minted without attaching"
-    }; retrying is safe — it will reuse them.)`;
+    const note = composedCellsNote(
+      cells,
+      composed.report.attachment.attached === true,
+    );
     if (error instanceof PlatformApiError) {
       throw new PlatformApiError(`${error.message} ${note}`, error.code, {
         status: error.status,
@@ -2761,14 +2822,19 @@ export const runEvalSuiteOperation: PlatformOperation<
     let composeAttach = false;
     let ephemeralLaunch = false;
     if (input.compose) {
+      const capabilities = await probeComposeCapabilities(
+        client,
+        project.id,
+        signal,
+      );
       const policy = composeLaunchPolicy({
         choiceCount: composeChoices.length,
         saveTargets: input.compose.saveTargets === true,
-        ephemeralOk: await probeEphemeralEnvironmentLaunch(
-          client,
-          project.id,
-          signal,
+        ephemeralOk: capabilities.ephemeralLaunch,
+        explicitModels: composeChoices.some(
+          (choice) => choice.modelId !== undefined,
         ),
+        modelOverridesOk: capabilities.modelOverrides,
         ...(input.refreshSnapshot ? { refreshSnapshot: true } : {}),
       });
       composeAttach = policy.attach;
@@ -3141,14 +3207,19 @@ export const runEvalCaseOperation: PlatformOperation<
     let composeAttach = false;
     let ephemeralLaunch = false;
     if (input.compose) {
+      const capabilities = await probeComposeCapabilities(
+        client,
+        project.id,
+        signal,
+      );
       const policy = composeLaunchPolicy({
         choiceCount: composeChoices.length,
         saveTargets: input.compose.saveTargets === true,
-        ephemeralOk: await probeEphemeralEnvironmentLaunch(
-          client,
-          project.id,
-          signal,
+        ephemeralOk: capabilities.ephemeralLaunch,
+        explicitModels: composeChoices.some(
+          (choice) => choice.modelId !== undefined,
         ),
+        modelOverridesOk: capabilities.modelOverrides,
       });
       composeAttach = policy.attach;
       ephemeralLaunch = policy.ephemeralLaunch;
@@ -3894,14 +3965,52 @@ export const setEvalSuiteEnvironmentsOperation: PlatformOperation<
         { projectId: project.id },
         { signal },
       );
-      const resolved = input.environments.map((selector) =>
-        resolveByIdOrName(
-          page.items,
-          selector,
-          "Project environment",
-          `project "${project.name}"`,
-        ),
-      );
+      const resolved: PlatformEnvironment[] = [];
+      for (const selector of input.environments) {
+        try {
+          resolved.push(
+            resolveByIdOrName(
+              page.items,
+              selector,
+              "Project environment",
+              `project "${project.name}"`,
+            ),
+          );
+          continue;
+        } catch (error) {
+          // Ad-hoc rows are list-hidden, so a composed cell is unresolvable
+          // here — and because this is a REPLACE, that also made it impossible
+          // to add one named environment alongside cells a compose attached
+          // without silently detaching them. `GET /environments/:id` serves
+          // them, so an id-shaped selector the listing did not know gets one
+          // direct read before we report it missing.
+          const trimmed = selector.trim();
+          if (!looksLikeEnvironmentId(trimmed)) throw error;
+          if (signal?.aborted || isAbortError(error)) throw error;
+          let byId: PlatformEnvironment;
+          try {
+            byId = await client.getEnvironment(
+              { projectId: project.id, environmentId: trimmed },
+              { signal },
+            );
+          } catch (lookupError) {
+            if (signal?.aborted || isAbortError(lookupError)) {
+              throw lookupError;
+            }
+            // Report the ENUMERATED not-found from the listing, not this
+            // lookup's bare 404 — it is the message that tells the caller what
+            // they could have picked.
+            throw error;
+          }
+          resolved.push({
+            ...byId,
+            name:
+              typeof byId.name === "string" && byId.name.trim().length > 0
+                ? byId.name
+                : byId.id,
+          });
+        }
+      }
       // Duplicates are detected AFTER resolution, because two DIFFERENT
       // selectors (an id and its name) can name the same environment — a
       // pre-resolution string comparison would wave that through and let the

--- a/sdk/tests/platform/operations-compose.test.ts
+++ b/sdk/tests/platform/operations-compose.test.ts
@@ -77,6 +77,8 @@ interface Fixture {
   alreadyNamed?: boolean;
   /** Omit / lie about ephemeralEnvironmentLaunch (old backend). */
   ephemeralLaunch?: boolean;
+  /** Deployment that predates environment model overrides. */
+  modelOverrides?: boolean;
   /** Suite already has these attached environment ids (union-cap tests). */
   attachedEnvironmentIds?: string[];
 }
@@ -93,8 +95,8 @@ function makeClient(fixture: Fixture = {}) {
     }
     if (/\/environments\/capabilities$/.test(path)) {
       return Response.json({
-        modelOverrides: true,
-        modelMatrix: true,
+        modelOverrides: fixture.modelOverrides !== false,
+        modelMatrix: fixture.modelOverrides !== false,
         ephemeralEnvironmentLaunch: fixture.ephemeralLaunch !== false,
       });
     }
@@ -445,6 +447,42 @@ describe("run_eval_suite compose", () => {
       "ephemeralEnvironmentLaunch",
     );
     expect(bodyOf(fetchMock, /ensure-adhoc$/)).toBeUndefined();
+  });
+
+  it("refuses a named model when the backend lacks model overrides", async () => {
+    // `environments create --model` has always preflighted this. The compose
+    // path — the one that grew a model axis — did not, so a skew deployment
+    // answered --compose-model with the raw validator error from
+    // ensure-adhoc. Refused before any write.
+    const { client, fetchMock } = makeClient({ modelOverrides: false });
+    const error = await runEvalSuiteOperation
+      .execute(
+        {
+          suite: "Smoke",
+          compose: {
+            host: "Claude Code",
+            models: ["anthropic/claude-haiku-4.5"],
+          },
+        },
+        { client },
+      )
+      .catch((caught: unknown) => caught);
+    expect((error as PlatformApiError).message).toContain(
+      "does not support environment model overrides",
+    );
+    expect(bodyOf(fetchMock, /ensure-adhoc$/)).toBeUndefined();
+  });
+
+  it("still composes an inherit-only stack on a backend without model overrides", async () => {
+    // Nothing sends a modelId here, so the missing capability is irrelevant —
+    // gating on "compose was used" rather than "a model was named" would
+    // break every composed run against an older deployment.
+    const { client, fetchMock } = makeClient({ modelOverrides: false });
+    await runEvalSuiteOperation.execute(
+      { suite: "Smoke", compose: { host: "Claude Code" } },
+      { client },
+    );
+    expect(bodyOf(fetchMock, /ensure-adhoc$/)).toBeDefined();
   });
 
   it("falls back to attach for a single cell on an old backend", async () => {


### PR DESCRIPTION
Post-merge robustness audit of the client × model fan-out (#4256/#4261/#4263). Agent-op + SDK half. Independent of #4286 (no shared files); the backend half is MCPJam/mcpjam-backend#1107.

## Approval integrity

**`run_eval_case` had no `normalizeProposalArgs` at all.** It accepts the full `compose` input, so an approved proposal could mint an ad-hoc environment and — with `saveTargets` — **attach it to the suite**: a persistent edit to shared configuration that the approval line ("Run eval case checkout") never mentioned. Its `compose.host` and `compose.computer` also stayed *names*, and a name is a pointer that can be repointed between the proposal and the click.

It now runs the same freeze as the suite run, and its describe says when a run composes and when composing edits the suite.

**`compose.computer` was unfrozen on both paths.** It is documented as "name or ID" and resolved by name at execute time, so renaming or replacing an image between proposal and approval repoints which sandbox the approved run boots — the same hazard the host freeze exists to close, one slot over. `serverGroup`, `skills.skillIds` and `pluginVersionIds` are ID-only by contract and so are not pointers to freeze.

## Version-skew symmetry

`--compose-model` never preflighted `modelOverrides`, which its sibling `environments create --model` has always done — so a skew deployment answered it with the raw validator error from `ensure-adhoc`, the opaque failure that guard exists to replace.

The check goes in the **SDK's compose policy**, not the CLI: the CLI, remote MCP and in-app agent all take that path, and putting it there is what makes the three agree with the web composer, which already refuses. It fires only when explicit models are **named** — gating on "compose was used" would break every composed run against an older deployment — and rides on the capability read the ephemeral probe already performs, so there is no extra round-trip.

## Honest reporting

**A mid-loop attach failure never said the suite was partially edited.** The annotator that reports compose writes is handed a *finished* `ComposedRunEnvironment`, so it does not exist yet while the attach loop is running. Annotated in place there too, through one shared formatter — a caller asking "did this touch my suite?" must not get a different answer depending on which step failed.

**`eval environments set` could not name a composed cell.** Ad-hoc rows are list-hidden, and because this op *replaces*, that also made it impossible to add one named environment alongside cells a compose had attached without silently detaching them. An id-shaped selector the listing does not know now gets one direct read before we report it missing; a genuinely bad selector still gets the enumerated not-found message, which is the one that tells the caller what they could have picked.

## A docstring that overclaimed

The compose cap docstring said the union was pre-flighted *before* minting. It is not, and **cannot be**: ad-hoc ids are content-addressed by the backend, so whether a cell is new or resolves onto a row the suite already has is not knowable client-side. An `existing + choices` estimate would reject re-composing a stack that is already attached and fits fine. Minting first and checking the real union keeps the answer exact; the cost is ad-hoc rows no suite references, which is the standing posture for them anyway (content-addressed, hidden from lists, reused on the next identical compose). Corrected to say what the code does and why that order is the right trade.

## Verification

- SDK: **5,887 passed**, 8 skipped. `tsc --noEmit` clean.
- Server: **110 failed files / 2 failed tests before and after** — byte-identical to baseline, all from build artifacts a fresh worktree lacks (`HarnessPageBundle.generated`, `PluginShim.bundled.js`, `SandboxProxyHtml.bundled.ts`). My additions account for the +3 passing.
- `tsc -p server --noEmit`: **198 errors before, 198 after** — zero new.
- New tests: `compose.computer` name→id freeze; case-run compose frozen like the suite run's; case-run describe states composing and attaching; model named on a backend without `modelOverrides` is refused **before any write**; an inherit-only compose still works on that same backend.
- **CLI suite not run here**: this worktree's `node_modules` symlink resolves `@mcpjam/sdk` to the primary checkout, so the CLI loads a stale SDK and fails at import (`getRegistryDirectoryServerOperation` missing) regardless of this change. No CLI source is modified, and the SDK compose tests exercise the same code path. Worth a CI confirmation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PN6sCF8o9nvo65j4WyQr7d

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches gated eval-run approval (what a click executes and how it is described) plus suite attach/replace paths. Failures still degrade freeze lookups rather than dropping proposals, but a freeze or policy bug could mis-target a paid run or persist a suite edit.
> 
> **Overview**
> Closes approval TOCTOU and honesty gaps on composed eval runs, and makes compose fail the same way as the rest of the product on older backends.
> 
> **`run_eval_case` now freezes compose like the suite run** (`host`/`computer` names → ids, `model` → `models`) and its approval line says when a run composes and when `saveTargets` attaches the minted cell to the suite. `compose.computer` is frozen on both paths so a renamed image cannot repoint an already-approved sandbox.
> 
> **Compose policy preflights `modelOverrides`** on the same capabilities read as ephemeral launch, so `--compose-model` is refused before any write on a skew deployment. Inherit-only compose still works without that flag.
> 
> **Errors now report whether compose already edited the suite**, including mid-loop attach failures, via one shared `composedCellsNote`. `eval environments set` can resolve list-hidden ad-hoc cells by id so a replace does not silently drop composed attachments.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 050bb8a1ccbefe35fe317041bf92a779f4d10e10. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Hardens eval compose flows by freezing what a case-run proposal approves and by preflighting model overrides. Prevents proposal repointing, rejects unsupported model overrides before any write, and reports partial attaches honestly.

- Freeze compose for case runs just like suite runs: resolve `compose.host` and `compose.computer` names to IDs, normalize scalar `model` to `models`, and keep `hostLabel`. The approval line now states when the run composes and when `saveTargets` will attach to the suite.
- Freeze `compose.computer` on both paths; resolve via image listing. Do not touch ID-only fields (`serverGroup`, `skills.skillIds`, `pluginVersionIds`).
- Add a single capability probe used by the SDK compose policy. If explicit models are named and `modelOverrides` is unsupported, fail fast with a clear error before minting; inherit-only compose still works. No extra round-trip.
- On attach failures mid-loop, annotate the error with created/reused cell IDs and whether any attach landed, using one shared formatter.
- `eval environments set` can now accept a composed environment by ID: when a selector looks like an ID and list-lookup fails, try a direct read before reporting not found. Bad selectors still get the enumerated not-found message.
- Correct compose docs to reflect mint-then-check union logic due to content-addressed ad-hoc IDs.

Bolded review and rollout
- Review `sdk/src/platform/operations.ts` (capability probe, compose policy, attach error annotation) and `mcpjam-inspector/server/routes/v1/agent-op-registry.ts` (case-run describe and `normalizeProposalArgs`). Tests cover computer freeze, case-run freezing/describe, and model-override preflight.
- Compatibility: older deployments without `modelOverrides` reject named models early; inherit-only compose and backends lacking ephemeral launch still work (attach fallback). No migrations.

<sup>Written for commit 050bb8a1ccbefe35fe317041bf92a779f4d10e10. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/MCPJam/inspector/pull/4287?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

