### PR TITLE
fix(github-checks): wait for auth before finishing an installation bind

### DIFF
--- a/.changeset/github-bind-callback-waits-for-auth.md
+++ b/.changeset/github-bind-callback-waits-for-auth.md
@@ -1,0 +1,5 @@
+---
+"@mcpjam/inspector": patch
+---
+
+Wait for authentication before finishing a GitHub App installation bind. GitHub's redirect is a full page load, so the Convex client had not attached a token when the callback fired its `signedInAction` — every bind failed with a bare "Server Error" and left the one-time state unconsumed.

--- a/mcpjam-inspector/client/src/components/settings/GithubInstallCallbackRoute.tsx
+++ b/mcpjam-inspector/client/src/components/settings/GithubInstallCallbackRoute.tsx
@@ -1,7 +1,9 @@
 import { useCallback, useEffect, useRef, useState } from "react";
 import { useSearchParams } from "react-router";
+import { useConvexAuth } from "convex/react";
 import { Github } from "lucide-react";
 import { Button } from "@mcpjam/design-system/button";
+import { useDbUserReady } from "@/contexts/db-user-ready-context";
 import { useAppNavigate } from "@/lib/app-navigation";
 import { toast } from "@/lib/toast";
 import { redirectToGithub } from "@/lib/github-external-redirect";
@@ -9,6 +11,7 @@ import {
   githubChecksWriteErrorMessage,
   GITHUB_BINDING_FAILED_MESSAGE,
   GITHUB_CALLBACK_INCOMPLETE_MESSAGE,
+  GITHUB_SIGNED_OUT_MESSAGE,
 } from "@/lib/github-checks-errors";
 import {
   useGithubInstallCallbacks,
@@ -69,6 +72,24 @@ export function GithubInstallCallbackRoute() {
   const [phase, setPhase] = useState<Phase>({ kind: "working" });
   const [claiming, setClaiming] = useState<number | null>(null);
 
+  // BOTH legs call `signedInAction`s, and this page is reached by a FULL PAGE
+  // LOAD from GitHub's redirect — so the Convex client has not attached a token
+  // yet when the effect below first runs. Calling either action in that window
+  // throws `Authentication required`, which is a plain `Error` and therefore
+  // reaches the user as a bare `Server Error` through the production mask, with
+  // the one-time state left unconsumed and the flow dead.
+  //
+  // Every other surface in this app gates its reads the same way
+  // (`useGithubChecksSettings`'s `canQuery`); this one has to gate a one-shot
+  // effect rather than a resubscribing query, which is exactly why it was easy
+  // to miss: a `useQuery` simply re-runs once auth lands, an action does not.
+  const { isLoading: isAuthLoading, isAuthenticated } = useConvexAuth();
+  const isUserReady = useDbUserReady();
+  // `isUserReady` matters as well as `isAuthenticated`: the actions resolve the
+  // WorkOS identity to a Convex user row, which does not exist until the
+  // bootstrap that provisions it has finished.
+  const canCall = isAuthenticated && isUserReady;
+
   // GitHub's redirect is a full page load, but React 18 StrictMode runs effects
   // twice in development — and both legs CONSUME a one-time state, so a second
   // run would burn it and land the user on "we could not finish connecting"
@@ -93,6 +114,19 @@ export function GithubInstallCallbackRoute() {
 
   useEffect(() => {
     if (startedRef.current) return;
+
+    // Wait, rather than fail, while auth is still settling. `startedRef` is
+    // deliberately NOT set on this path: the effect must be free to run again
+    // when the token lands, which is the whole point of waiting.
+    if (isAuthLoading || !canCall) {
+      // Signed out for real — auth finished resolving and said no. Say so
+      // instead of spinning forever on "Finishing up with GitHub…".
+      if (!isAuthLoading && !isAuthenticated) {
+        setPhase({ kind: "failed", message: GITHUB_SIGNED_OUT_MESSAGE });
+      }
+      return;
+    }
+
     startedRef.current = true;
 
     // The SETUP leg. `installation_id` is a claim; we forward it and let the
@@ -149,11 +183,14 @@ export function GithubInstallCallbackRoute() {
     setPhase({ kind: "failed", message: GITHUB_CALLBACK_INCOMPLETE_MESSAGE });
   }, [
     appNavigate,
+    canCall,
     code,
     completeInstallSetup,
     completeUserAuthorization,
     fail,
     installationId,
+    isAuthLoading,
+    isAuthenticated,
     state,
   ]);
 

--- a/mcpjam-inspector/client/src/components/settings/__tests__/github-install-callback-route.test.tsx
+++ b/mcpjam-inspector/client/src/components/settings/__tests__/github-install-callback-route.test.tsx
@@ -28,12 +28,28 @@ const {
   mockClaimProvenInstallation,
   mockRedirectToGithub,
   mockNavigate,
+  mockAuth,
+  mockUserReady,
 } = vi.hoisted(() => ({
   mockCompleteInstallSetup: vi.fn(),
   mockCompleteUserAuthorization: vi.fn(),
   mockClaimProvenInstallation: vi.fn(),
   mockRedirectToGithub: vi.fn(),
   mockNavigate: vi.fn(),
+  // Both legs are `signedInAction`s reached by a FULL PAGE LOAD from GitHub,
+  // so auth state is a real input to this page and not scaffolding: the
+  // default here is the settled, signed-in case, and the tests that matter
+  // move it.
+  mockAuth: vi.fn(() => ({ isLoading: false, isAuthenticated: true })),
+  mockUserReady: vi.fn(() => true),
+}));
+
+vi.mock("convex/react", () => ({
+  useConvexAuth: () => mockAuth(),
+}));
+
+vi.mock("@/contexts/db-user-ready-context", () => ({
+  useDbUserReady: () => mockUserReady(),
 }));
 
 vi.mock("@/hooks/useGithubChecksSettings", () => ({
@@ -88,6 +104,86 @@ function renderCallback(query: string) {
 
 beforeEach(() => {
   vi.clearAllMocks();
+  mockAuth.mockReturnValue({ isLoading: false, isAuthenticated: true });
+  mockUserReady.mockReturnValue(true);
+});
+
+// ═══════════════════════════════════════════════════════════════════════════
+// AUTH MUST LAND BEFORE EITHER LEG IS CALLED
+// ═══════════════════════════════════════════════════════════════════════════
+//
+// This page is reached by a full page load from GitHub's redirect, so the
+// Convex client has NOT attached a token when the effect first runs. Calling a
+// `signedInAction` in that window throws `Authentication required` — a plain
+// `Error`, which the production mask turns into a bare `Server Error` — and
+// leaves the one-time state unconsumed with the flow dead.
+//
+// This shipped and broke every bind in production. A `useQuery` would have
+// survived it by re-running once auth arrived; a one-shot effect does not,
+// which is precisely why the gate has to be explicit here.
+describe("waiting for authentication", () => {
+  it("calls neither leg while auth is still resolving", async () => {
+    mockAuth.mockReturnValue({ isLoading: true, isAuthenticated: false });
+    renderCallback("?code=gh-code&state=raw-oauth-state");
+
+    await waitFor(() => expect(screen.getByRole("status")).toBeTruthy());
+    expect(mockCompleteUserAuthorization).not.toHaveBeenCalled();
+    expect(mockCompleteInstallSetup).not.toHaveBeenCalled();
+    // Still "working" — an unresolved session is not a refusal.
+    expect(screen.getByRole("status").textContent).toContain("Finishing up");
+  });
+
+  it("calls neither leg while the Convex user row is still being provisioned", async () => {
+    // Authenticated with WorkOS is not the same as resolvable to a Convex user,
+    // and the actions resolve the second.
+    mockUserReady.mockReturnValue(false);
+    renderCallback("?code=gh-code&state=raw-oauth-state");
+
+    await waitFor(() => expect(screen.getByRole("status")).toBeTruthy());
+    expect(mockCompleteUserAuthorization).not.toHaveBeenCalled();
+  });
+
+  it("runs the leg once auth arrives, without a remount", async () => {
+    mockAuth.mockReturnValue({ isLoading: true, isAuthenticated: false });
+    mockCompleteUserAuthorization.mockResolvedValue({
+      status: "bound",
+      accountLogin: "acme",
+    });
+    const { rerender } = renderCallback("?code=gh-code&state=raw-oauth-state");
+    expect(mockCompleteUserAuthorization).not.toHaveBeenCalled();
+
+    // The token lands. The guard must not have burned itself while waiting.
+    mockAuth.mockReturnValue({ isLoading: false, isAuthenticated: true });
+    rerender(
+      <StrictMode>
+        <MemoryRouter
+          initialEntries={[`${PATH}?code=gh-code&state=raw-oauth-state`]}
+        >
+          <Routes>
+            <Route path={PATH} element={<GithubInstallCallbackRoute />} />
+          </Routes>
+        </MemoryRouter>
+      </StrictMode>
+    );
+
+    await waitFor(() =>
+      expect(mockCompleteUserAuthorization).toHaveBeenCalledTimes(1)
+    );
+    expect(mockCompleteUserAuthorization).toHaveBeenCalledWith({
+      code: "gh-code",
+      state: "raw-oauth-state",
+    });
+  });
+
+  it("says so plainly when auth resolves to signed out", async () => {
+    mockAuth.mockReturnValue({ isLoading: false, isAuthenticated: false });
+    renderCallback("?code=gh-code&state=raw-oauth-state");
+
+    await waitFor(() =>
+      expect(screen.getByText(/not signed in to MCPJam/i)).toBeTruthy()
+    );
+    expect(mockCompleteUserAuthorization).not.toHaveBeenCalled();
+  });
 });
 
 describe("the setup leg", () => {

--- a/mcpjam-inspector/client/src/lib/github-checks-errors.ts
+++ b/mcpjam-inspector/client/src/lib/github-checks-errors.ts
@@ -144,3 +144,14 @@ export const GITHUB_BINDING_FAILED_MESSAGE =
  */
 export const GITHUB_CALLBACK_INCOMPLETE_MESSAGE =
   "This page finishes connecting a GitHub account, and it was opened without the details GitHub sends. Start again from Settings.";
+
+/**
+ * The return trip from GitHub landed with nobody signed in to MCPJam.
+ *
+ * Worth its own sentence rather than the generic binding failure: nothing is
+ * wrong with the GitHub account or the app, the session here simply is not
+ * there — and "sign in and start again" is an instruction, where the generic
+ * copy would send someone to re-check GitHub settings that are already fine.
+ */
+export const GITHUB_SIGNED_OUT_MESSAGE =
+  "You are not signed in to MCPJam, so we could not finish connecting that GitHub account. Sign in and start again from Settings.";


### PR DESCRIPTION
Every GitHub App installation bind failed in production with a bare `Server Error`. This is the fix.

## What happened

`/settings/integrations/github/callback` is reached by a **full page load** from GitHub's redirect. Both of its legs call `signedInAction`s. On that first render the Convex client has not attached a token yet, so the action threw `Authentication required` — a plain `Error`, which Convex's production error mask turns into `Server Error` with no readable message.

The one-time state was never consumed, so the link session sat at `pending_user_verification` forever and the flow was dead with nothing on screen anyone could act on.

## Why it got through review and CI

Every other surface here gates on `isAuthenticated && isUserReady` (`useGithubChecksSettings`'s `canQuery`). This page had to gate a **one-shot effect** rather than a resubscribing query — and that difference is the whole bug. A `useQuery` fired too early simply re-runs when auth lands and nobody notices; an action fired too early throws once and stays thrown.

The component tests mount the route directly with the hook mocked, so no test had an opinion about auth state at all. That is now fixed too: auth is an explicit input to these tests.

## The fix

Wait for auth, and wait **without burning `startedRef`**, so the leg runs the moment the token arrives rather than being permanently skipped. `isUserReady` is checked alongside `isAuthenticated` because the actions resolve the WorkOS identity to a Convex user row, which does not exist until bootstrap has provisioned it.

A failure is only reported once auth has actually resolved to signed out, and that case gets its own sentence: "sign in and start again" is an instruction, where the generic binding copy would send someone to re-check GitHub settings that are already fine.

## Tests

Four new cases, all **red-probed** — reverting the gate fails all four:

| | |
|---|---|
| auth still resolving | neither leg is called; the page stays on "Finishing up…" rather than showing a refusal |
| Convex user row still provisioning | neither leg is called |
| token arrives later | the leg runs exactly once, with the parameters forwarded verbatim, without a remount |
| resolved to signed out | the signed-out copy renders and no leg is called |

`npx vitest run --project client` on the touched file: **17 passed**. Prettier clean on changed files only; `tsc` clean. Changeset included.

## How it was found

Running the flow against production, where it failed 100% of the time. The masked `Server Error` gives you nothing, so: the link session row showed `pending_user_verification` with no `failureReason`, which ruled out every handled failure path (they all stamp a reason first); calling `findSessionByOauthState`, `failLinkSession` and `recordProvenInstallations` directly showed the data layer was fine; and invoking `completeUserAuthorization` through the CLI — which is not subject to the mask — printed `Uncaught Error: Authentication required`.

## Note for whoever deploys

Production already has the binding enabled (`requireInstallationBinding` is on, with zero connected repositories, so there is nothing to break). This fix is what makes the first bind possible, so it wants a promote reasonably promptly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches the GitHub App bind callback and one-time OAuth/install state. The change is a small client gate, but it is the production path that previously failed 100% of binds.
> 
> **Overview**
> Fixes GitHub App installation bind, which failed on every production callback because GitHub’s redirect is a full page load and the one-shot effect fired `signedInAction`s before a Convex token (and user row) existed.
> 
> `GithubInstallCallbackRoute` now waits until `isAuthenticated && isUserReady` without setting `startedRef`, so the setup/OAuth leg runs once the session lands. If auth resolves signed out, it shows dedicated copy instead of spinning or the generic bind failure.
> 
> Tests cover waiting, late token arrival without remount, and the signed-out path.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9c52e4c3ff063261fd9abd91d3082b395e0b7c5c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Waits for authentication on the GitHub App installation callback before invoking signed-in actions. Previously the callback ran on a full page load before the Convex token attached, throwing “Authentication required,” surfacing as a masked “Server Error,” and leaving sessions stuck at pending_user_verification; now it gates on `isAuthenticated && isUserReady`, runs once when the token lands, and shows explicit copy if auth resolves to signed out.

- Review notes
  - Adds auth/user readiness gate in `GithubInstallCallbackRoute.tsx` via `useConvexAuth()` and `useDbUserReady()`, and avoids setting `startedRef` while waiting.
  - Introduces `GITHUB_SIGNED_OUT_MESSAGE` for the signed-out case; no API changes.
  - Adds four component tests covering waiting, provisioning, token arrival, and signed-out behavior. Changeset publishes a patch to `@mcpjam/inspector`.

- Rollout
  - No migrations or config changes. Promote promptly; production has binding enabled and this unblocks the first successful bind.

<sup>Written for commit 9c52e4c3ff063261fd9abd91d3082b395e0b7c5c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/MCPJam/inspector/pull/4288?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

