### PR TITLE
fix(github-checks): require a WorkOS user to finish an installation bind

### DIFF
--- a/.changeset/github-bind-callback-requires-workos-user.md
+++ b/.changeset/github-bind-callback-requires-workos-user.md
@@ -1,0 +1,5 @@
+---
+"@mcpjam/inspector": patch
+---
+
+Require a WorkOS user, not just Convex auth, before finishing a GitHub App installation bind. Guests are authenticated to Convex by design, so the previous gate let a guest call the member-only action and made the sign-in message unreachable.

--- a/mcpjam-inspector/client/src/components/settings/GithubInstallCallbackRoute.tsx
+++ b/mcpjam-inspector/client/src/components/settings/GithubInstallCallbackRoute.tsx
@@ -1,5 +1,6 @@
 import { useCallback, useEffect, useRef, useState } from "react";
 import { useSearchParams } from "react-router";
+import { useAuth } from "@workos-inc/authkit-react";
 import { useConvexAuth } from "convex/react";
 import { Github } from "lucide-react";
 import { Button } from "@mcpjam/design-system/button";
@@ -83,12 +84,25 @@ export function GithubInstallCallbackRoute() {
   // (`useGithubChecksSettings`'s `canQuery`); this one has to gate a one-shot
   // effect rather than a resubscribing query, which is exactly why it was easy
   // to miss: a `useQuery` simply re-runs once auth lands, an action does not.
-  const { isLoading: isAuthLoading, isAuthenticated } = useConvexAuth();
+  // THE WORKOS USER IS THE ONE THAT DECIDES, and `useConvexAuth` alone will not
+  // do. Guests are authenticated to Convex on purpose: `unified-convex-auth`
+  // hands the provider a guest token and a `GUEST_USER_PLACEHOLDER` so guests
+  // travel the same provider chain as members, and `useEnsureDbUser` marks them
+  // ready too. So `isAuthenticated && isUserReady` is TRUE for a guest, who
+  // would then call a `signedInAction` and get the generic binding failure —
+  // while the signed-out branch below never fired at all.
+  //
+  // GitHub Checks is member-only, and the sibling surface already reads it this
+  // way (`useGithubChecksSettings`: `isAuthenticated && user && isUserReady`).
+  // This is the same rule, not a guest special case.
+  const { user: workosUser, isLoading: isWorkosLoading } = useAuth();
+  const { isLoading: isConvexAuthLoading, isAuthenticated } = useConvexAuth();
   const isUserReady = useDbUserReady();
-  // `isUserReady` matters as well as `isAuthenticated`: the actions resolve the
-  // WorkOS identity to a Convex user row, which does not exist until the
-  // bootstrap that provisions it has finished.
-  const canCall = isAuthenticated && isUserReady;
+  const isAuthSettling = isWorkosLoading || isConvexAuthLoading;
+  // `isUserReady` matters as well: the actions resolve the WorkOS identity to a
+  // Convex user row, which does not exist until the bootstrap that provisions
+  // it has finished.
+  const canCall = Boolean(isAuthenticated && workosUser && isUserReady);
 
   // GitHub's redirect is a full page load, but React 18 StrictMode runs effects
   // twice in development — and both legs CONSUME a one-time state, so a second
@@ -118,10 +132,11 @@ export function GithubInstallCallbackRoute() {
     // Wait, rather than fail, while auth is still settling. `startedRef` is
     // deliberately NOT set on this path: the effect must be free to run again
     // when the token lands, which is the whole point of waiting.
-    if (isAuthLoading || !canCall) {
-      // Signed out for real — auth finished resolving and said no. Say so
-      // instead of spinning forever on "Finishing up with GitHub…".
-      if (!isAuthLoading && !isAuthenticated) {
+    if (isAuthSettling || !canCall) {
+      // No WorkOS user once auth has settled — signed out, or a guest, which
+      // for a member-only surface is the same answer and the same instruction.
+      // Say it instead of spinning forever on "Finishing up with GitHub…".
+      if (!isAuthSettling && !workosUser) {
         setPhase({ kind: "failed", message: GITHUB_SIGNED_OUT_MESSAGE });
       }
       return;
@@ -189,9 +204,9 @@ export function GithubInstallCallbackRoute() {
     completeUserAuthorization,
     fail,
     installationId,
-    isAuthLoading,
-    isAuthenticated,
+    isAuthSettling,
     state,
+    workosUser,
   ]);
 
   const handleClaim = async (

--- a/mcpjam-inspector/client/src/components/settings/__tests__/github-install-callback-route.test.tsx
+++ b/mcpjam-inspector/client/src/components/settings/__tests__/github-install-callback-route.test.tsx
@@ -30,6 +30,7 @@ const {
   mockNavigate,
   mockAuth,
   mockUserReady,
+  mockWorkosAuth,
 } = vi.hoisted(() => ({
   mockCompleteInstallSetup: vi.fn(),
   mockCompleteUserAuthorization: vi.fn(),
@@ -42,10 +43,22 @@ const {
   // move it.
   mockAuth: vi.fn(() => ({ isLoading: false, isAuthenticated: true })),
   mockUserReady: vi.fn(() => true),
+  // The WORKOS user, which is the one that decides. Convex reports guests as
+  // authenticated on purpose (`unified-convex-auth` gives them a token and a
+  // placeholder user), so this mock is not a duplicate of `mockAuth` — it is
+  // the only thing that tells a member from a guest.
+  mockWorkosAuth: vi.fn(() => ({
+    user: { id: "user_workos" } as unknown,
+    isLoading: false,
+  })),
 }));
 
 vi.mock("convex/react", () => ({
   useConvexAuth: () => mockAuth(),
+}));
+
+vi.mock("@workos-inc/authkit-react", () => ({
+  useAuth: () => mockWorkosAuth(),
 }));
 
 vi.mock("@/contexts/db-user-ready-context", () => ({
@@ -106,6 +119,10 @@ beforeEach(() => {
   vi.clearAllMocks();
   mockAuth.mockReturnValue({ isLoading: false, isAuthenticated: true });
   mockUserReady.mockReturnValue(true);
+  mockWorkosAuth.mockReturnValue({
+    user: { id: "user_workos" },
+    isLoading: false,
+  });
 });
 
 // ═══════════════════════════════════════════════════════════════════════════
@@ -145,6 +162,7 @@ describe("waiting for authentication", () => {
 
   it("runs the leg once auth arrives, without a remount", async () => {
     mockAuth.mockReturnValue({ isLoading: true, isAuthenticated: false });
+    mockWorkosAuth.mockReturnValue({ user: null, isLoading: true });
     mockCompleteUserAuthorization.mockResolvedValue({
       status: "bound",
       accountLogin: "acme",
@@ -154,6 +172,10 @@ describe("waiting for authentication", () => {
 
     // The token lands. The guard must not have burned itself while waiting.
     mockAuth.mockReturnValue({ isLoading: false, isAuthenticated: true });
+    mockWorkosAuth.mockReturnValue({
+      user: { id: "user_workos" },
+      isLoading: false,
+    });
     rerender(
       <StrictMode>
         <MemoryRouter
@@ -175,8 +197,37 @@ describe("waiting for authentication", () => {
     });
   });
 
+  it("calls neither leg while the WorkOS session is still resolving", async () => {
+    // Convex can already say "authenticated" here — a guest token satisfies it.
+    mockWorkosAuth.mockReturnValue({ user: null, isLoading: true });
+    renderCallback("?code=gh-code&state=raw-oauth-state");
+
+    await waitFor(() => expect(screen.getByRole("status")).toBeTruthy());
+    expect(mockCompleteUserAuthorization).not.toHaveBeenCalled();
+    expect(screen.getByRole("status").textContent).toContain("Finishing up");
+  });
+
+  it("refuses a GUEST with the sign-in message, and calls no action", async () => {
+    // THE CASE `useConvexAuth` ALONE CANNOT SEE. `unified-convex-auth` gives a
+    // guest a real Convex token and a placeholder user, so `isAuthenticated` is
+    // true and `useEnsureDbUser` marks them ready — a gate built on those two
+    // would send a guest into a member-only `signedInAction` and surface the
+    // generic binding failure, and the sign-in branch would never fire.
+    mockAuth.mockReturnValue({ isLoading: false, isAuthenticated: true });
+    mockUserReady.mockReturnValue(true);
+    mockWorkosAuth.mockReturnValue({ user: null, isLoading: false });
+    renderCallback("?code=gh-code&state=raw-oauth-state");
+
+    await waitFor(() =>
+      expect(screen.getByText(/not signed in to MCPJam/i)).toBeTruthy()
+    );
+    expect(mockCompleteUserAuthorization).not.toHaveBeenCalled();
+    expect(mockCompleteInstallSetup).not.toHaveBeenCalled();
+  });
+
   it("says so plainly when auth resolves to signed out", async () => {
     mockAuth.mockReturnValue({ isLoading: false, isAuthenticated: false });
+    mockWorkosAuth.mockReturnValue({ user: null, isLoading: false });
     renderCallback("?code=gh-code&state=raw-oauth-state");
 
     await waitFor(() =>


### PR DESCRIPTION
Follow-up to #4288. Codex flagged this on that PR ([discussion_r3837511015](https://github.com/MCPJam/inspector/pull/4288#discussion_r3837511015)) and it is correct — I verified the claim in the code and reproduced it in a test before fixing.

## What #4288 missed

It gated the callback on `isAuthenticated && isUserReady`. **Both are true for a guest.** That is deliberate, not a bug elsewhere: `unified-convex-auth` hands the Convex provider a guest token and a `GUEST_USER_PLACEHOLDER` precisely so guests travel the same provider chain as members without guest-specific branches in feature surfaces (`client/src/lib/unified-convex-auth.ts`), and `useEnsureDbUser` marks guest identities ready too.

So in any guest-enabled deployment — which is every deployment — a guest landing on the callback would call the member-only `signedInAction` and get the generic binding failure, and the signed-out message #4288 added could never render.

## The fix

Require the **WorkOS** user. That is the value that actually distinguishes a member, and the sibling surface already reads it exactly this way:

```ts
// useGithubChecksSettings
const canQuery = Boolean(isAuthenticated && user && isUserReady && organizationId);
```

This is that same rule applied to the callback rather than a guest special case. GitHub Checks is member-only, so a guest and a signed-out visitor get the same answer and the same actionable instruction — sign in and start again.

Waiting now also covers the WorkOS session still loading, which Convex can report as authenticated before it resolves.

## Tests

Two new cases on top of #4288's four:

| | |
|---|---|
| WorkOS session still loading | neither leg called, page stays on "Finishing up…" |
| **guest** (Convex authenticated, user ready, no WorkOS user) | sign-in message renders, no action called |

**Red-probed:** restoring #4288's gate fails the guest test and nothing else — which is the useful shape, since it shows the test pins this specific regression rather than the surrounding behaviour.

`npx vitest run --project client` on the touched file: **19 passed**. Prettier clean on changed files only; `tsc` clean. Changeset included.

## Deploy note

Production has the binding enabled with zero connected repositories, and #4288 is on `main` but the first successful bind still has not happened. This wants to ride the same promote.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches the GitHub installation bind callback’s auth gate. Scope is small and client-only, but a wrong gate can still fire member-only actions or block legitimate binds.
> 
> **Overview**
> Tightens the GitHub App install callback so it only runs member-only bind actions when a **WorkOS user** is present, not merely Convex auth plus a ready DB user.
> 
> Guests are Convex-authenticated by design, so the previous `isAuthenticated && isUserReady` gate let them hit `signedInAction`s and never showed the sign-in message. The callback now waits for WorkOS (and Convex) to settle, then treats guests like signed-out visitors: show sign-in copy, call no action. Tests cover WorkOS still loading and the guest case.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2076c351bb53daaa8e44f8e2bf2eaf6bb7a0a7e5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Require a WorkOS user to finish the GitHub App installation bind callback. Previously we gated on Convex auth and DB user readiness, which are also true for guests; guests could trigger the member-only action and the sign-in message was unreachable.

- Gate now requires Convex authenticated, WorkOS user present, and DB user ready; wait while WorkOS session loads; show the sign-in message if no WorkOS user after auth settles.
- Aligns the callback with the existing rule used in settings; no guest-specific branch.
- Tests add coverage for a loading WorkOS session and a guest (Convex authenticated, user ready, no WorkOS user).
- No API or config changes; safe to promote alongside #4288.

<sup>Written for commit 2076c351bb53daaa8e44f8e2bf2eaf6bb7a0a7e5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/MCPJam/inspector/pull/4290?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

