### PR TITLE
evals: measure connection and discovery at run setup (D6)

### DIFF
--- a/.changeset/eval-d6-setup-stages.md
+++ b/.changeset/eval-d6-setup-stages.md
@@ -5,7 +5,7 @@
 
 The eval user-value chain can now measure its top two stages: `connection` and `discovery`.
 
-Connect and tools-list happen once per run, above the iteration boundary where no span sink exists. Hosted runs now record a structured `setupSignals` evidence field (precedent: `toolSignals`), fold every configured target behind a two-phase `Promise.allSettled` barrier, and persist synthetic `connection` / `discovery` spans for the timeline only — they never enter derivation evidence.
+Connect and tools-list happen once per run, above the iteration boundary where no span sink exists. Hosted runs now record a structured `setupSignals` evidence field (precedent: `toolSignals`), fold every configured target behind a `Promise.allSettled` barrier so no verdict is decided while another server is still settling, and persist synthetic `connection` / `discovery` spans for the timeline only — they never enter derivation evidence. Both phases are observed from the one `getToolsForAiSdk` call a run already makes, so no server is dialled twice.
 
 `connection: failed` requires positive evidence our own egress works (a lazy `GET ${convexHttpUrl}/health` canary, only on a theirs-shaped failure). Without that, the row stays `notMeasured` / `egressUnverified` or `setupAborted`. A completed initialize is itself the egress evidence for `discovery`. `failureCategory` stays `setup`; rates that want measured failures filter on `firstFailedStage`.
 

--- a/.changeset/eval-d6-setup-stages.md
+++ b/.changeset/eval-d6-setup-stages.md
@@ -1,0 +1,16 @@
+---
+"@mcpjam/sdk": minor
+"@mcpjam/inspector": minor
+---
+
+The eval user-value chain can now measure its top two stages: `connection` and `discovery`.
+
+Connect and tools-list happen once per run, above the iteration boundary where no span sink exists. Hosted runs now record a structured `setupSignals` evidence field (precedent: `toolSignals`), fold every configured target behind a two-phase `Promise.allSettled` barrier, and persist synthetic `connection` / `discovery` spans for the timeline only — they never enter derivation evidence.
+
+`connection: failed` requires positive evidence our own egress works (a lazy `GET ${convexHttpUrl}/health` canary, only on a theirs-shaped failure). Without that, the row stays `notMeasured` / `egressUnverified` or `setupAborted`. A completed initialize is itself the egress evidence for `discovery`. `failureCategory` stays `setup`; rates that want measured failures filter on `firstFailedStage`.
+
+The SDK path is types-only: a user-code `beforeAll` connect failure never reaches ingestion, so there is nothing to emit. Analyzer version is now 2. `noSpanChannel` stays in the vocabulary for old producers; v2 emits `noEvidenceCaptured` instead.
+
+A run-level connect failure no longer strands the run: pending iterations are written with the folded signals, re-read, retried once if still pending, and only then swept.
+
+Requires the mcpjam-backend D6 vocabulary widening (connection/discovery span categories + `connectFailed` / `toolsListFailed` / `egressUnverified`) to be **merged and promoted to production** before this inspector ships. Rollback order is inspector first, backend second.

--- a/chat-ui/src/internal/trace-timeline/eval-trace.ts
+++ b/chat-ui/src/internal/trace-timeline/eval-trace.ts
@@ -9,7 +9,13 @@
 // Keep these field names in lockstep with the inspector type; a drift here only
 // affects what the timeline can read, never what is persisted.
 
-export type TraceSpanCategory = "step" | "llm" | "tool" | "error";
+export type TraceSpanCategory =
+  | "step"
+  | "llm"
+  | "tool"
+  | "error"
+  | "connection"
+  | "discovery";
 export type TraceSpanStatus = "ok" | "error";
 
 export type TraceSpan = {

--- a/chat-ui/src/internal/trace-timeline/recorded-trace-toolbar.tsx
+++ b/chat-ui/src/internal/trace-timeline/recorded-trace-toolbar.tsx
@@ -3,21 +3,30 @@ import { Expand, Shrink } from "lucide-react";
 import { Button } from "./ui";
 import { cn } from "../cn";
 
-export const TRACE_TIMELINE_FILTERS = ["all", "llm", "tool", "error"] as const;
+export const TRACE_TIMELINE_FILTERS = [
+  "all",
+  "connection",
+  "discovery",
+  "llm",
+  "tool",
+  "error",
+] as const;
 export type TimelineFilter = (typeof TRACE_TIMELINE_FILTERS)[number];
 
 export function timelineFilterLabel(entry: TimelineFilter): string {
   switch (entry) {
     case "all":
       return "All";
+    case "connection":
+      return "Connect";
+    case "discovery":
+      return "Discovery";
     case "llm":
       return "LLM";
     case "tool":
       return "Tool";
     case "error":
       return "Error";
-    default:
-      return entry;
   }
 }
 

--- a/chat-ui/src/internal/trace-timeline/trace-timeline.tsx
+++ b/chat-ui/src/internal/trace-timeline/trace-timeline.tsx
@@ -211,6 +211,10 @@ export type TraceRevealSelection = {
 
 function categoryRank(category: EvalTraceSpanCategory): number {
   switch (category) {
+    case "connection":
+      return -2;
+    case "discovery":
+      return -1;
     case "step":
       return 0;
     case "llm":
@@ -219,8 +223,6 @@ function categoryRank(category: EvalTraceSpanCategory): number {
       return 2;
     case "error":
       return 3;
-    default:
-      return 9;
   }
 }
 
@@ -559,11 +561,11 @@ function getWaterfallBarClass(
     case "tool":
       return "trace-waterfall-bar-tool";
     case "step":
+    case "connection":
+    case "discovery":
       return "trace-waterfall-bar-step";
     case "error":
       return "trace-waterfall-bar-error";
-    default:
-      return "trace-waterfall-bar-step";
   }
 }
 
@@ -581,8 +583,9 @@ function getCategoryIconClass(
       return "trace-waterfall-glyph-tool";
     case "error":
       return "trace-waterfall-glyph-error";
-    default:
-      return "text-muted-foreground";
+    case "connection":
+    case "discovery":
+      return "trace-waterfall-glyph-step";
   }
 }
 
@@ -602,9 +605,9 @@ function getRowBorderAccentClass(
     case "error":
       return "trace-waterfall-row-accent-error";
     case "step":
+    case "connection":
+    case "discovery":
       return "trace-waterfall-row-accent-step";
-    default:
-      return "border-l-muted-foreground";
   }
 }
 
@@ -668,6 +671,8 @@ export function buildPromptGroups(spans: EvalTraceSpan[]): PromptGroup[] {
         llm: 0,
         tool: 0,
         error: 0,
+        connection: 0,
+        discovery: 0,
       };
       for (const span of promptSpans) {
         if (span.category in counts) {
@@ -1065,8 +1070,9 @@ function CategoryGlyph({
       return <Wrench className={iconClass} aria-hidden />;
     case "error":
       return <AlertCircle className={iconClass} aria-hidden />;
+    case "connection":
+    case "discovery":
     case "step":
-    default:
       return <ListTree className={iconClass} aria-hidden />;
   }
 }
@@ -2262,6 +2268,8 @@ export function TraceTimeline({
             {(
               [
                 { label: "User", cls: "trace-waterfall-bar-prompt" },
+                { label: "Connect", cls: "trace-waterfall-bar-step" },
+                { label: "Discovery", cls: "trace-waterfall-bar-step" },
                 { label: "LLM",  cls: "trace-waterfall-bar-llm" },
                 { label: "Tool", cls: "trace-waterfall-bar-tool" },
                 { label: "Step", cls: "trace-waterfall-bar-step" },

--- a/chat-ui/src/internal/trace-timeline/trace-timeline.tsx
+++ b/chat-ui/src/internal/trace-timeline/trace-timeline.tsx
@@ -209,6 +209,19 @@ export type TraceRevealSelection = {
   highlightSourceIndices: number[];
 };
 
+/**
+ * Compile-time exhaustiveness with a runtime fallback.
+ *
+ * Every known category must be handled above, or `never` stops the build.
+ * A category this build has never heard of still renders: the backend's
+ * primary eval-trace writer accepts spans as `v.any()`, so a newer producer
+ * reaches an older client, and dropping the row would hide real evidence.
+ */
+function assertExhaustiveCategory<T>(category: never, fallback: T): T {
+  void category;
+  return fallback;
+}
+
 function categoryRank(category: EvalTraceSpanCategory): number {
   switch (category) {
     case "connection":
@@ -223,6 +236,11 @@ function categoryRank(category: EvalTraceSpanCategory): number {
       return 2;
     case "error":
       return 3;
+    default:
+      // A category this build does not know still has to sort. The backend
+      // primary trace writer takes spans as `v.any()`, so a newer producer
+      // can reach an older client.
+      return assertExhaustiveCategory(category, 9);
   }
 }
 
@@ -555,7 +573,8 @@ function getWaterfallBarClass(
     return "trace-waterfall-bar-error";
   }
   if (row.kind !== "span") return "trace-waterfall-bar-step";
-  switch (row.span.category) {
+  const spanCategory = row.span.category;
+  switch (spanCategory) {
     case "llm":
       return "trace-waterfall-bar-llm";
     case "tool":
@@ -566,6 +585,8 @@ function getWaterfallBarClass(
       return "trace-waterfall-bar-step";
     case "error":
       return "trace-waterfall-bar-error";
+    default:
+      return assertExhaustiveCategory(spanCategory, "trace-waterfall-bar-step");
   }
 }
 
@@ -586,6 +607,8 @@ function getCategoryIconClass(
     case "connection":
     case "discovery":
       return "trace-waterfall-glyph-step";
+    default:
+      return assertExhaustiveCategory(category, "text-muted-foreground");
   }
 }
 
@@ -608,6 +631,8 @@ function getRowBorderAccentClass(
     case "connection":
     case "discovery":
       return "trace-waterfall-row-accent-step";
+    default:
+      return assertExhaustiveCategory(cat, "border-l-muted-foreground");
   }
 }
 
@@ -1073,6 +1098,9 @@ function CategoryGlyph({
     case "connection":
     case "discovery":
     case "step":
+      return <ListTree className={iconClass} aria-hidden />;
+    default:
+      // Unknown category: still draw a row rather than rendering nothing.
       return <ListTree className={iconClass} aria-hidden />;
   }
 }

--- a/mcpjam-inspector/client/src/components/evals/__tests__/recorded-trace-toolbar.test.ts
+++ b/mcpjam-inspector/client/src/components/evals/__tests__/recorded-trace-toolbar.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it } from "vitest";
+import {
+  TRACE_TIMELINE_FILTERS,
+  timelineFilterLabel,
+  type TimelineFilter,
+} from "../recorded-trace-toolbar";
+
+describe("recorded-trace toolbar filters", () => {
+  it("includes connection and discovery and labels every entry", () => {
+    expect(TRACE_TIMELINE_FILTERS).toEqual([
+      "all",
+      "connection",
+      "discovery",
+      "llm",
+      "tool",
+      "error",
+    ]);
+    for (const entry of TRACE_TIMELINE_FILTERS) {
+      expect(timelineFilterLabel(entry).length).toBeGreaterThan(0);
+    }
+    expect(timelineFilterLabel("connection")).toBe("Connect");
+    expect(timelineFilterLabel("discovery")).toBe("Discovery");
+  });
+
+  it("does not treat empty, null, or unknown values as known filters", () => {
+    const known = new Set<string>(TRACE_TIMELINE_FILTERS);
+    for (const value of ["", null, undefined, "handshake", "step"]) {
+      expect(known.has(value as TimelineFilter)).toBe(false);
+    }
+  });
+});

--- a/mcpjam-inspector/client/src/components/evals/recorded-trace-toolbar.tsx
+++ b/mcpjam-inspector/client/src/components/evals/recorded-trace-toolbar.tsx
@@ -10,21 +10,30 @@ import {
 } from "@mcpjam/design-system/dropdown-menu";
 import { cn } from "@/lib/utils";
 
-export const TRACE_TIMELINE_FILTERS = ["all", "llm", "tool", "error"] as const;
+export const TRACE_TIMELINE_FILTERS = [
+  "all",
+  "connection",
+  "discovery",
+  "llm",
+  "tool",
+  "error",
+] as const;
 export type TimelineFilter = (typeof TRACE_TIMELINE_FILTERS)[number];
 
 export function timelineFilterLabel(entry: TimelineFilter): string {
   switch (entry) {
     case "all":
       return "All";
+    case "connection":
+      return "Connect";
+    case "discovery":
+      return "Discovery";
     case "llm":
       return "LLM";
     case "tool":
       return "Tool";
     case "error":
       return "Error";
-    default:
-      return entry;
   }
 }
 

--- a/mcpjam-inspector/client/src/components/evals/trace-timeline.tsx
+++ b/mcpjam-inspector/client/src/components/evals/trace-timeline.tsx
@@ -233,6 +233,19 @@ export type TraceRevealSelection = {
   highlightSourceIndices: number[];
 };
 
+/**
+ * Compile-time exhaustiveness with a runtime fallback.
+ *
+ * Every known category must be handled above, or `never` stops the build.
+ * A category this build has never heard of still renders: the backend's
+ * primary eval-trace writer accepts spans as `v.any()`, so a newer producer
+ * reaches an older client, and dropping the row would hide real evidence.
+ */
+function assertExhaustiveCategory<T>(category: never, fallback: T): T {
+  void category;
+  return fallback;
+}
+
 function categoryRank(category: EvalTraceSpanCategory): number {
   switch (category) {
     case "connection":
@@ -247,6 +260,11 @@ function categoryRank(category: EvalTraceSpanCategory): number {
       return 2;
     case "error":
       return 3;
+    default:
+      // A category this build does not know still has to sort. The backend
+      // primary trace writer takes spans as `v.any()`, so a newer producer
+      // can reach an older client.
+      return assertExhaustiveCategory(category, 9);
   }
 }
 
@@ -585,7 +603,8 @@ function getWaterfallBarClass(
     return "trace-waterfall-bar-error";
   }
   if (row.kind !== "span") return "trace-waterfall-bar-step";
-  switch (row.span.category) {
+  const spanCategory = row.span.category;
+  switch (spanCategory) {
     case "llm":
       return "trace-waterfall-bar-llm";
     case "tool":
@@ -596,6 +615,8 @@ function getWaterfallBarClass(
       return "trace-waterfall-bar-step";
     case "error":
       return "trace-waterfall-bar-error";
+    default:
+      return assertExhaustiveCategory(spanCategory, "trace-waterfall-bar-step");
   }
 }
 
@@ -617,6 +638,8 @@ function getCategoryIconClass(
     case "connection":
     case "discovery":
       return "trace-waterfall-glyph-step";
+    default:
+      return assertExhaustiveCategory(category, "text-muted-foreground");
   }
 }
 
@@ -644,6 +667,8 @@ function getRowBorderAccentClass(
     case "connection":
     case "discovery":
       return "trace-waterfall-row-accent-step";
+    default:
+      return assertExhaustiveCategory(cat, "border-l-muted-foreground");
   }
 }
 
@@ -1111,6 +1136,9 @@ function CategoryGlyph({
     case "connection":
     case "discovery":
     case "step":
+      return <ListTree className={iconClass} aria-hidden />;
+    default:
+      // Unknown category: still draw a row rather than rendering nothing.
       return <ListTree className={iconClass} aria-hidden />;
   }
 }

--- a/mcpjam-inspector/client/src/components/evals/trace-timeline.tsx
+++ b/mcpjam-inspector/client/src/components/evals/trace-timeline.tsx
@@ -235,6 +235,10 @@ export type TraceRevealSelection = {
 
 function categoryRank(category: EvalTraceSpanCategory): number {
   switch (category) {
+    case "connection":
+      return -2;
+    case "discovery":
+      return -1;
     case "step":
       return 0;
     case "llm":
@@ -243,8 +247,6 @@ function categoryRank(category: EvalTraceSpanCategory): number {
       return 2;
     case "error":
       return 3;
-    default:
-      return 9;
   }
 }
 
@@ -589,11 +591,11 @@ function getWaterfallBarClass(
     case "tool":
       return "trace-waterfall-bar-tool";
     case "step":
+    case "connection":
+    case "discovery":
       return "trace-waterfall-bar-step";
     case "error":
       return "trace-waterfall-bar-error";
-    default:
-      return "trace-waterfall-bar-step";
   }
 }
 
@@ -612,8 +614,9 @@ function getCategoryIconClass(
       return "trace-waterfall-glyph-tool";
     case "error":
       return "trace-waterfall-glyph-error";
-    default:
-      return "text-muted-foreground";
+    case "connection":
+    case "discovery":
+      return "trace-waterfall-glyph-step";
   }
 }
 
@@ -638,9 +641,9 @@ function getRowBorderAccentClass(
     case "error":
       return "trace-waterfall-row-accent-error";
     case "step":
+    case "connection":
+    case "discovery":
       return "trace-waterfall-row-accent-step";
-    default:
-      return "border-l-muted-foreground";
   }
 }
 
@@ -704,6 +707,8 @@ export function buildPromptGroups(spans: EvalTraceSpan[]): PromptGroup[] {
         llm: 0,
         tool: 0,
         error: 0,
+        connection: 0,
+        discovery: 0,
       };
       for (const span of promptSpans) {
         if (span.category in counts) {
@@ -1103,8 +1108,9 @@ function CategoryGlyph({
       return <MousePointerClick className={iconClass} aria-hidden />;
     case "error":
       return <AlertCircle className={iconClass} aria-hidden />;
+    case "connection":
+    case "discovery":
     case "step":
-    default:
       return <ListTree className={iconClass} aria-hidden />;
   }
 }
@@ -2433,6 +2439,8 @@ export function TraceTimeline({
             {(
               [
                 { label: "User", cls: "trace-waterfall-bar-prompt" },
+                { label: "Connect", cls: "trace-waterfall-bar-step" },
+                { label: "Discovery", cls: "trace-waterfall-bar-step" },
                 { label: "LLM",  cls: "trace-waterfall-bar-llm" },
                 { label: "Tool", cls: "trace-waterfall-bar-tool" },
                 { label: "Step", cls: "trace-waterfall-bar-step" },

--- a/mcpjam-inspector/server/services/evals-runner.ts
+++ b/mcpjam-inspector/server/services/evals-runner.ts
@@ -707,10 +707,7 @@ async function getEvalToolsForAiSdkOrThrow(args: {
 
   if (observer) {
     const signals = observer.buildSignals();
-    const theirsFailure =
-      signals?.connection?.attribution === "theirs" ||
-      signals?.discovery?.attribution === "theirs";
-    if (theirsFailure) {
+    if (signals?.connection?.attribution === "theirs") {
       await observer.ensureEgressCanary();
     }
   }

--- a/mcpjam-inspector/server/services/evals-runner.ts
+++ b/mcpjam-inspector/server/services/evals-runner.ts
@@ -1285,20 +1285,29 @@ async function persistRunSetupFailure(args: {
   const setupSpans = args.observer.buildSyntheticSpans(args.runStartedAt);
   const setupAudit = args.observer.buildAuditMetadata();
 
-  const listPending = async () => {
-    const details = (await args.convexClient.query(
-      "testSuites:getTestSuiteRunDetails" as any,
-      { runId: args.runId }
-    )) as { iterations?: Array<Record<string, unknown>> } | null;
-    return (details?.iterations ?? []).filter(
-      (row) => row.status === "pending"
-    );
+  const listPending = async (): Promise<Array<Record<string, unknown>> | null> => {
+    try {
+      const details = (await args.convexClient.query(
+        "testSuites:getTestSuiteRunDetails" as any,
+        { runId: args.runId }
+      )) as { iterations?: Array<Record<string, unknown>> } | null;
+      return (details?.iterations ?? []).filter(
+        (row) => row.status === "pending"
+      );
+    } catch (readError) {
+      logger.warn("[evals] Failed to read pending setup iterations", {
+        runId: args.runId,
+        error:
+          readError instanceof Error ? readError.message : String(readError),
+      });
+      return null;
+    }
   };
 
   const persistPending = async (
     pending: Array<Record<string, unknown>>
   ) => {
-    await Promise.all(
+    await Promise.allSettled(
       pending.map(async (row) => {
         const iterationId =
           typeof row._id === "string"
@@ -1347,13 +1356,16 @@ async function persistRunSetupFailure(args: {
     );
   };
 
-  await persistPending(await listPending());
+  const first = await listPending();
+  if (first) {
+    await persistPending(first);
+  }
   const afterFirst = await listPending();
-  if (afterFirst.length > 0) {
+  if (afterFirst && afterFirst.length > 0) {
     await persistPending(afterFirst);
   }
   const residual = await listPending();
-  if (residual.length > 0) {
+  if (residual === null || residual.length > 0) {
     try {
       await args.convexClient.mutation(
         "testSuites:markSetupPendingIterationsFailed" as any,
@@ -2595,15 +2607,25 @@ export const runEvalSuiteWithAiSdk = async ({
     // `blockTerminal` cannot strand the run, and so the sweep cannot strip
     // stage metadata from a row whose write failed.
     if (runId !== null) {
-      await persistRunSetupFailure({
-        runId,
-        convexClient,
-        recorder,
-        observer: setupObserver,
-        errorMessage,
-        tests,
-        runStartedAt: runSetupStartedAt,
-      });
+      try {
+        await persistRunSetupFailure({
+          runId,
+          convexClient,
+          recorder,
+          observer: setupObserver,
+          errorMessage,
+          tests,
+          runStartedAt: runSetupStartedAt,
+        });
+      } catch (setupPersistError) {
+        logger.warn("[evals] Failed to persist run-setup failure evidence", {
+          runId,
+          error:
+            setupPersistError instanceof Error
+              ? setupPersistError.message
+              : String(setupPersistError),
+        });
+      }
     }
 
     // Only finalize if we have a recorder (suite runs, not quick runs)

--- a/mcpjam-inspector/server/services/evals-runner.ts
+++ b/mcpjam-inspector/server/services/evals-runner.ts
@@ -614,71 +614,24 @@ async function getEvalToolsForAiSdkOrThrow(args: {
   const firstError: { error: unknown; serverId: string; phase: SetupPhase }[] =
     [];
 
-  // Phase 1 — every connect is observed before any tools-list starts.
-  // `Promise.allSettled` does not abort in-flight siblings; we wait for all
-  // of them so folding cannot race.
-  await Promise.allSettled(
+  // ONE round trip per server. `getToolsForAiSdk` already ensures the
+  // session before it lists, so probing connect separately would make every
+  // lazily-connected run hit the customer's server twice for no new
+  // information. `Promise.allSettled` does not abort in-flight siblings, so
+  // this single barrier is what keeps folding race-free: every expected
+  // target has settled before `buildSignals` runs, and a discovery failure
+  // can never be folded while another server's connect is still open.
+  const perServerTools = await Promise.allSettled(
     args.serverIds.map(async (serverId) => {
       const startedAt = now();
-      if (args.mcpClientManager.getConnectionStatus(serverId) === "connected") {
-        observer?.recordConnect(serverId, {
-          outcome: "ok",
-          startedAt,
-          endedAt: now(),
-        });
-        return;
-      }
-      try {
-        // listTools ensureConnected; a throw before status flips is a connect miss.
-        await args.mcpClientManager.listTools(serverId);
-        observer?.recordConnect(serverId, {
-          outcome: "ok",
-          startedAt,
-          endedAt: now(),
-        });
-      } catch (error) {
-        const connected =
-          args.mcpClientManager.getConnectionStatus(serverId) === "connected";
-        const endedAt = now();
-        if (!connected) {
-          observer?.recordConnect(serverId, {
-            outcome: "failed",
-            error,
-            startedAt,
-            endedAt,
-          });
-          firstError.push({ error, serverId, phase: "connection" });
-          return;
-        }
-        observer?.recordConnect(serverId, {
-          outcome: "ok",
-          startedAt,
-          endedAt,
-        });
-        observer?.recordToolsList(serverId, {
-          outcome: "failed",
-          error,
-          startedAt,
-          endedAt,
-        });
-        firstError.push({ error, serverId, phase: "discovery" });
-      }
-    })
-  );
-
-  // Phase 2 — tools/list for every server whose connect settled ok and
-  // whose list has not already been recorded (a connect-ok + list-fail
-  // above already filled that slot).
-  const listTargets = observer
-    ? args.serverIds.filter(
-        (serverId) =>
-          observer.connectOutcome(serverId) === "ok" &&
-          !observer.hasToolsList(serverId)
-      )
-    : args.serverIds;
-  const perServerTools = await Promise.allSettled(
-    listTargets.map(async (serverId) => {
-      const startedAt = now();
+      const alreadyConnected =
+        args.mcpClientManager.getConnectionStatus(serverId) === "connected";
+      // One call cannot time the two phases apart. An already-connected
+      // server spent the whole call listing; a lazily-connected one is
+      // credited to connect, with the list window closing at the same
+      // instant. Neither phase ever claims more than the call took.
+      const splitAt = (endedAt: number) =>
+        alreadyConnected ? startedAt : endedAt;
       try {
         const tools = toolOptions
           ? await args.mcpClientManager.getToolsForAiSdk(
@@ -686,21 +639,48 @@ async function getEvalToolsForAiSdkOrThrow(args: {
               toolOptions
             )
           : await args.mcpClientManager.getToolsForAiSdk([serverId]);
-        observer?.recordToolsList(serverId, {
+        const endedAt = now();
+        observer?.recordConnect(serverId, {
           outcome: "ok",
           startedAt,
-          endedAt: now(),
+          endedAt: splitAt(endedAt),
+        });
+        observer?.recordToolsList(serverId, {
+          outcome: "ok",
+          startedAt: splitAt(endedAt),
+          endedAt,
         });
         return tools;
       } catch (error) {
+        const endedAt = now();
+        const connected =
+          args.mcpClientManager.getConnectionStatus(serverId) === "connected";
+        if (!connected || isMissingRuntimeServerError(error)) {
+          // A connect miss: tools/list never ran for this server, so it
+          // gets NO discovery observation. `foldPhase` reads that absence
+          // as "the phase never executed" rather than as a failed list.
+          observer?.recordConnect(serverId, {
+            outcome: "failed",
+            error,
+            startedAt,
+            endedAt,
+          });
+          firstError.push({ error, serverId, phase: "connection" });
+          return null;
+        }
+        observer?.recordConnect(serverId, {
+          outcome: "ok",
+          startedAt,
+          endedAt: splitAt(endedAt),
+        });
         observer?.recordToolsList(serverId, {
           outcome: "failed",
           error,
-          startedAt,
-          endedAt: now(),
+          startedAt: splitAt(endedAt),
+          endedAt,
         });
         firstError.push({ error, serverId, phase: "discovery" });
-        throw error;
+        return null;
       }
     })
   );
@@ -727,7 +707,7 @@ async function getEvalToolsForAiSdkOrThrow(args: {
 
   const flattened: ToolSet = {};
   for (const result of perServerTools) {
-    if (result.status === "fulfilled") {
+    if (result.status === "fulfilled" && result.value) {
       Object.assign(flattened, result.value);
     }
   }

--- a/mcpjam-inspector/server/services/evals-runner.ts
+++ b/mcpjam-inspector/server/services/evals-runner.ts
@@ -125,8 +125,16 @@ import {
   buildIterationFinishParams,
   buildStageMetadata,
 } from "./evals/finalize-iteration.js";
-import type { StageAuthoredCase } from "@mcpjam/sdk/contract";
+import type {
+  StageAuthoredCase,
+  StageSetupSignals,
+} from "@mcpjam/sdk/contract";
 import { buildStageAuthoredCase } from "./evals/stage-inputs.js";
+import {
+  createRunSetupObserver,
+  type RunSetupObserver,
+  type SetupPhase,
+} from "./evals/run-setup-signals.js";
 import {
   dispatchEvalIterationFinalize,
   finalizeWithBrowserArtifacts,
@@ -523,6 +531,58 @@ function isMissingRuntimeServerError(error: unknown): boolean {
   );
 }
 
+class EvalSetupPhaseError extends WebRouteError {
+  readonly serverId: string;
+  readonly phase: SetupPhase;
+
+  constructor(args: {
+    status: number;
+    code: ErrorCode;
+    message: string;
+    serverId: string;
+    phase: SetupPhase;
+    details?: Record<string, unknown>;
+  }) {
+    super(args.status, args.code, args.message, {
+      ...args.details,
+      serverId: args.serverId,
+      phase: args.phase,
+    });
+    this.name = "EvalSetupPhaseError";
+    this.serverId = args.serverId;
+    this.phase = args.phase;
+  }
+}
+
+function throwSetupPhaseError(args: {
+  serverId: string;
+  phase: SetupPhase;
+  error: unknown;
+  environment: RunEvalSuiteOptions["config"]["environment"] | undefined;
+}): never {
+  const serverLabel = getServerLabelForEvalError(args.serverId, args.environment);
+  if (isMissingRuntimeServerError(args.error) || args.phase === "connection") {
+    throw new EvalSetupPhaseError({
+      status: 409,
+      code: ErrorCode.SERVER_UNREACHABLE,
+      message: `Could not start eval because "${serverLabel}" is not connected. Reconnect the server and try again.`,
+      serverId: args.serverId,
+      phase: args.phase,
+      details: { serverId: args.serverId, serverName: serverLabel },
+    });
+  }
+  const cause =
+    args.error instanceof Error ? args.error.message : String(args.error);
+  throw new EvalSetupPhaseError({
+    status: 502,
+    code: ErrorCode.SERVER_UNREACHABLE,
+    message: `Could not start eval because "${serverLabel}" failed to list tools. Reconnect the server and try again.`,
+    serverId: args.serverId,
+    phase: args.phase,
+    details: { serverId: args.serverId, serverName: serverLabel, cause },
+  });
+}
+
 async function getEvalToolsForAiSdkOrThrow(args: {
   mcpClientManager: MCPClientManager;
   serverIds: string[];
@@ -535,6 +595,7 @@ async function getEvalToolsForAiSdkOrThrow(args: {
    */
   tasks?: ToolTaskSeamOptions;
   environment: RunEvalSuiteOptions["config"]["environment"] | undefined;
+  setupObserver?: RunSetupObserver;
 }): Promise<ToolSet> {
   const hasModelVisiblePolicy = args.modelVisibleMcpToolResults !== undefined;
   const toolOptions =
@@ -548,42 +609,130 @@ async function getEvalToolsForAiSdkOrThrow(args: {
         }
       : undefined;
 
-  const perServerTools = await Promise.all(
+  const now = () => Date.now();
+  const observer = args.setupObserver;
+  const firstError: { error: unknown; serverId: string; phase: SetupPhase }[] =
+    [];
+
+  // Phase 1 — every connect is observed before any tools-list starts.
+  // `Promise.allSettled` does not abort in-flight siblings; we wait for all
+  // of them so folding cannot race.
+  await Promise.allSettled(
     args.serverIds.map(async (serverId) => {
+      const startedAt = now();
+      if (args.mcpClientManager.getConnectionStatus(serverId) === "connected") {
+        observer?.recordConnect(serverId, {
+          outcome: "ok",
+          startedAt,
+          endedAt: now(),
+        });
+        return;
+      }
       try {
-        return toolOptions
+        // listTools ensureConnected; a throw before status flips is a connect miss.
+        await args.mcpClientManager.listTools(serverId);
+        observer?.recordConnect(serverId, {
+          outcome: "ok",
+          startedAt,
+          endedAt: now(),
+        });
+      } catch (error) {
+        const connected =
+          args.mcpClientManager.getConnectionStatus(serverId) === "connected";
+        const endedAt = now();
+        if (!connected) {
+          observer?.recordConnect(serverId, {
+            outcome: "failed",
+            error,
+            startedAt,
+            endedAt,
+          });
+          firstError.push({ error, serverId, phase: "connection" });
+          return;
+        }
+        observer?.recordConnect(serverId, {
+          outcome: "ok",
+          startedAt,
+          endedAt,
+        });
+        observer?.recordToolsList(serverId, {
+          outcome: "failed",
+          error,
+          startedAt,
+          endedAt,
+        });
+        firstError.push({ error, serverId, phase: "discovery" });
+      }
+    })
+  );
+
+  // Phase 2 — tools/list for every server whose connect settled ok and
+  // whose list has not already been recorded (a connect-ok + list-fail
+  // above already filled that slot).
+  const listTargets = observer
+    ? args.serverIds.filter(
+        (serverId) =>
+          observer.connectOutcome(serverId) === "ok" &&
+          !observer.hasToolsList(serverId)
+      )
+    : args.serverIds;
+  const perServerTools = await Promise.allSettled(
+    listTargets.map(async (serverId) => {
+      const startedAt = now();
+      try {
+        const tools = toolOptions
           ? await args.mcpClientManager.getToolsForAiSdk(
               [serverId],
               toolOptions
             )
           : await args.mcpClientManager.getToolsForAiSdk([serverId]);
+        observer?.recordToolsList(serverId, {
+          outcome: "ok",
+          startedAt,
+          endedAt: now(),
+        });
+        return tools;
       } catch (error) {
-        const serverLabel = getServerLabelForEvalError(
-          serverId,
-          args.environment
-        );
-        if (isMissingRuntimeServerError(error)) {
-          throw new WebRouteError(
-            409,
-            ErrorCode.SERVER_UNREACHABLE,
-            `Could not start eval because "${serverLabel}" is not connected. Reconnect the server and try again.`,
-            { serverId, serverName: serverLabel }
-          );
-        }
-        const cause = error instanceof Error ? error.message : String(error);
-        throw new WebRouteError(
-          502,
-          ErrorCode.SERVER_UNREACHABLE,
-          `Could not start eval because "${serverLabel}" failed to list tools. Reconnect the server and try again.`,
-          { serverId, serverName: serverLabel, cause }
-        );
+        observer?.recordToolsList(serverId, {
+          outcome: "failed",
+          error,
+          startedAt,
+          endedAt: now(),
+        });
+        firstError.push({ error, serverId, phase: "discovery" });
+        throw error;
       }
     })
   );
 
+  if (observer) {
+    const signals = observer.buildSignals();
+    const theirsFailure =
+      signals?.connection?.attribution === "theirs" ||
+      signals?.discovery?.attribution === "theirs";
+    if (theirsFailure) {
+      await observer.ensureEgressCanary();
+    }
+  }
+
+  if (firstError.length > 0) {
+    // Connection failures dominate: a mixed bag must never earn
+    // `connection: failed` from a later discovery throw.
+    const connectFail = firstError.find((row) => row.phase === "connection");
+    const chosen = connectFail ?? firstError[0]!;
+    throwSetupPhaseError({
+      serverId: chosen.serverId,
+      phase: chosen.phase,
+      error: chosen.error,
+      environment: args.environment,
+    });
+  }
+
   const flattened: ToolSet = {};
-  for (const toolset of perServerTools) {
-    Object.assign(flattened, toolset);
+  for (const result of perServerTools) {
+    if (result.status === "fulfilled") {
+      Object.assign(flattened, result.value);
+    }
   }
   return flattened;
 }
@@ -1075,6 +1224,9 @@ async function persistSetupFailedIteration(args: {
    * that cannot say what the case authored stays honest.
    */
   stageCase?: StageAuthoredCase;
+  setupSignals?: StageSetupSignals;
+  setupSpans?: EvalTraceSpan[];
+  setupAudit?: Record<string, unknown>;
   recorder: SuiteRunRecorder | null;
   convexClient: ConvexHttpClient;
 }): Promise<void> {
@@ -1092,19 +1244,131 @@ async function persistSetupFailedIteration(args: {
       ...args.iterationMetadataBase,
       ...buildStageMetadata({
         ...(args.stageCase ? { stageCase: args.stageCase } : {}),
-        // No spans, no prompts, no messages: the analyzer reads that as
-        // `traceAbsent` and degrades the whole chain to a setup abort rather
-        // than reporting six unexplained evidence gaps.
+        // No real spans/prompts/messages: the analyzer reads that as
+        // `traceAbsent`. When setupSignals are present it measures the top
+        // two stages instead of blanking the whole chain.
+        ...(args.setupSignals ? { setupSignals: args.setupSignals } : {}),
         status: "failed",
         error: args.errorMessage,
       }),
+      ...(args.setupAudit ?? {}),
     },
+    ...(args.setupSpans?.length ? { spans: args.setupSpans } : {}),
   };
   await dispatchEvalIterationFinalize({
     recorder: args.recorder,
     convexClient: args.convexClient,
     finishParams: failParams,
   });
+}
+
+/**
+ * Un-strand a run that died at run-level connect / tools-list.
+ *
+ * Pre-created iterations sit `pending` and `blockTerminal` would otherwise
+ * soft-block the terminal transition. Each evidence-carrying write is
+ * acknowledged: we re-read the run details after the batch and retry any
+ * residual still-pending rows once before the `markSetupPendingIterationsFailed`
+ * sweep, so the sweep can never silently strip stage metadata from a row
+ * whose write failed.
+ */
+async function persistRunSetupFailure(args: {
+  runId: string;
+  convexClient: ConvexHttpClient;
+  recorder: SuiteRunRecorder | null;
+  observer: RunSetupObserver;
+  errorMessage: string;
+  tests: EvalTestCase[];
+  runStartedAt: number;
+}): Promise<void> {
+  const setupSignals = args.observer.buildSignals();
+  const setupSpans = args.observer.buildSyntheticSpans(args.runStartedAt);
+  const setupAudit = args.observer.buildAuditMetadata();
+
+  const listPending = async () => {
+    const details = (await args.convexClient.query(
+      "testSuites:getTestSuiteRunDetails" as any,
+      { runId: args.runId }
+    )) as { iterations?: Array<Record<string, unknown>> } | null;
+    return (details?.iterations ?? []).filter(
+      (row) => row.status === "pending"
+    );
+  };
+
+  const persistPending = async (
+    pending: Array<Record<string, unknown>>
+  ) => {
+    await Promise.all(
+      pending.map(async (row) => {
+        const iterationId =
+          typeof row._id === "string"
+            ? row._id
+            : typeof row.iterationId === "string"
+              ? row.iterationId
+              : undefined;
+        const test = args.tests.find(
+          (candidate) =>
+            candidate.testCaseId && candidate.testCaseId === row.testCaseId
+        );
+        const snapshot = row.testCaseSnapshot as
+          | { query?: string; expectedToolCalls?: unknown[] }
+          | undefined;
+        await persistSetupFailedIteration({
+          iterationId,
+          runStartedAt: args.runStartedAt,
+          errorMessage: args.errorMessage,
+          iterationMetadataBase: {},
+          ...(test
+            ? {
+                stageCase: buildStageAuthoredCase({
+                  test,
+                  turns: test.promptTurns,
+                  caseNeedsModel: true,
+                }),
+              }
+            : snapshot
+              ? {
+                  stageCase: buildStageAuthoredCase({
+                    test: {
+                      query: snapshot.query,
+                      expectedToolCalls: snapshot.expectedToolCalls,
+                    } as EvalTestCase,
+                    caseNeedsModel: true,
+                  }),
+                }
+              : {}),
+          ...(setupSignals ? { setupSignals } : {}),
+          ...(setupSpans.length ? { setupSpans } : {}),
+          ...(setupAudit ? { setupAudit } : {}),
+          recorder: args.recorder,
+          convexClient: args.convexClient,
+        });
+      })
+    );
+  };
+
+  await persistPending(await listPending());
+  const afterFirst = await listPending();
+  if (afterFirst.length > 0) {
+    await persistPending(afterFirst);
+  }
+  const residual = await listPending();
+  if (residual.length > 0) {
+    try {
+      await args.convexClient.mutation(
+        "testSuites:markSetupPendingIterationsFailed" as any,
+        { runId: args.runId, error: args.errorMessage }
+      );
+    } catch (cleanupError) {
+      logger.warn("[evals] Failed to mark residual setup iterations failed", {
+        runId: args.runId,
+        error:
+          cleanupError instanceof Error
+            ? cleanupError.message
+            : String(cleanupError),
+      });
+    }
+  }
 }
 
 /**
@@ -1175,6 +1439,12 @@ type RunIterationBaseParams = {
   hostPolicy?: HostExecutionPolicy;
   /** Pre-computed tool exposure signals for this run (set by runEvalSuiteWithAiSdk). */
   toolSignals?: ToolExposureSignals;
+  /** Folded run-level connect / tools-list evidence (D6). */
+  setupSignals?: StageSetupSignals;
+  /** Synthetic connection/discovery spans (timeline only). */
+  setupSpans?: EvalTraceSpan[];
+  /** Bounded producer-owned setup audit record. */
+  setupAudit?: Record<string, unknown>;
   /**
    * Raw suite hostConfig record — the same one the route layer feeds
    * to `extractHostExecutionPolicy` for the `hostPolicy` field above.
@@ -1559,6 +1829,9 @@ const executeTestCase = async (params: {
   hostPolicy?: HostExecutionPolicy;
   /** Pre-computed tool exposure signals for metadata stamping. */
   toolSignals?: ToolExposureSignals;
+  setupSignals?: StageSetupSignals;
+  setupSpans?: EvalTraceSpan[];
+  setupAudit?: Record<string, unknown>;
   /** Raw suite hostConfig record. PR 4d — see RunIterationBaseParams. */
   suiteHostConfig?: Record<string, unknown> | null;
   /**
@@ -1596,6 +1869,9 @@ const executeTestCase = async (params: {
     injectOpenAiCompat,
     hostPolicy,
     toolSignals,
+    setupSignals,
+    setupSpans,
+    setupAudit,
     suiteHostConfig,
     environment,
     pinnedSkillSource,
@@ -1679,6 +1955,9 @@ const executeTestCase = async (params: {
         injectOpenAiCompat,
         hostPolicy,
         toolSignals,
+        setupSignals,
+        setupSpans,
+        setupAudit,
         suiteHostConfig,
         environment,
         pinnedSkillSource,
@@ -1803,6 +2082,9 @@ const executeTestCase = async (params: {
         injectOpenAiCompat,
         hostPolicy,
         toolSignals,
+        setupSignals,
+        setupSpans,
+        setupAudit,
         suiteHostConfig,
         environment,
         pinnedSkillSource,
@@ -1852,6 +2134,9 @@ const executeTestCase = async (params: {
         injectOpenAiCompat,
         hostPolicy,
         toolSignals,
+        setupSignals,
+        setupSpans,
+        setupAudit,
         suiteHostConfig,
         environment,
         pinnedSkillSource,
@@ -1895,6 +2180,9 @@ const executeTestCase = async (params: {
       injectOpenAiCompat,
       hostPolicy,
       toolSignals,
+      setupSignals,
+      setupSpans,
+      setupAudit,
       suiteHostConfig,
       // `environment` resolves a pinned turn's server (local hybrids); harmless
       // for prompt-only cases.
@@ -1997,6 +2285,12 @@ export const runEvalSuiteWithAiSdk = async ({
     await: { signal: abortController.signal },
   });
 
+  const runSetupStartedAt = Date.now();
+  const setupObserver = createRunSetupObserver({
+    expectedServerIds: serverIds,
+    convexHttpUrl,
+  });
+
   try {
     // When a host policy is present we need the full tool set (including
     // app-only) so `applyVisibilityPolicyAndCountSignals` can:
@@ -2015,6 +2309,7 @@ export const runEvalSuiteWithAiSdk = async ({
       // be able to switch tasks on for a suite whose host said off.
       ...(evalTasksSeam ? { tasks: evalTasksSeam } : {}),
       environment: config.environment,
+      setupObserver,
     });
 
     // Apply visibility filtering when a host policy is present. The filter
@@ -2027,6 +2322,10 @@ export const runEvalSuiteWithAiSdk = async ({
           hostExecutionPolicy
         )
       : undefined;
+    const resolvedSetupSignals = setupObserver.buildSignals();
+    const resolvedSetupSpans =
+      setupObserver.buildSyntheticSpans(runSetupStartedAt);
+    const resolvedSetupAudit = setupObserver.buildAuditMetadata();
 
     // Note: Iterations are now pre-created in startSuiteRunWithRecorder
     // This code is no longer needed as precreateIterationsForRun is called there
@@ -2084,6 +2383,11 @@ export const runEvalSuiteWithAiSdk = async ({
         injectOpenAiCompat,
         hostPolicy: hostExecutionPolicy,
         toolSignals: resolvedToolSignals,
+        ...(resolvedSetupSignals ? { setupSignals: resolvedSetupSignals } : {}),
+        ...(resolvedSetupSpans.length
+          ? { setupSpans: resolvedSetupSpans }
+          : {}),
+        ...(resolvedSetupAudit ? { setupAudit: resolvedSetupAudit } : {}),
         suiteHostConfig,
         environment: config.environment,
         // BOTH frozen-skill channels, from one place — see
@@ -2285,6 +2589,22 @@ export const runEvalSuiteWithAiSdk = async ({
     return undefined;
   } catch (error) {
     const passRate = summary.total > 0 ? summary.passed / summary.total : 0;
+    const errorMessage = error instanceof Error ? error.message : String(error);
+
+    // Persist evidence onto every still-pending row BEFORE finalize so
+    // `blockTerminal` cannot strand the run, and so the sweep cannot strip
+    // stage metadata from a row whose write failed.
+    if (runId !== null) {
+      await persistRunSetupFailure({
+        runId,
+        convexClient,
+        recorder,
+        observer: setupObserver,
+        errorMessage,
+        tests,
+        runStartedAt: runSetupStartedAt,
+      });
+    }
 
     // Only finalize if we have a recorder (suite runs, not quick runs)
     if (recorder) {
@@ -2370,6 +2690,9 @@ const runLocalIteration = async ({
   injectOpenAiCompat,
   hostPolicy,
   toolSignals,
+  setupSignals,
+  setupSpans,
+  setupAudit,
   suiteHostConfig,
   environment,
   convexAuthToken,
@@ -3078,6 +3401,9 @@ const runLocalIteration = async ({
       iterationMetadataBase,
       ...(hostPolicy ? { hostPolicy } : {}),
       ...(toolSignals ? { toolSignals } : {}),
+      ...(setupSignals ? { setupSignals } : {}),
+      ...(setupSpans?.length ? { setupSpans } : {}),
+      ...(setupAudit ? { setupAudit } : {}),
       injectOpenAiCompat,
     });
 
@@ -3250,6 +3576,9 @@ const runLocalIteration = async ({
       iterationMetadataBase,
       ...(hostPolicy ? { hostPolicy } : {}),
       ...(toolSignals ? { toolSignals } : {}),
+      ...(setupSignals ? { setupSignals } : {}),
+      ...(setupSpans?.length ? { setupSpans } : {}),
+      ...(setupAudit ? { setupAudit } : {}),
       injectOpenAiCompat,
     });
 
@@ -3312,6 +3641,9 @@ const runHostedIterationWithBrowser = async (
     injectOpenAiCompat,
     hostPolicy,
     toolSignals,
+    setupSignals,
+    setupSpans,
+    setupAudit,
     suiteHostConfig,
     orgModelConfigTarget,
     // Pinned reproducible-env id lives on the run environment; drives per-
@@ -3643,6 +3975,11 @@ const runHostedIterationWithBrowser = async (
         turns: resolvedTest.promptTurns,
         caseNeedsModel: true,
       }),
+      // Classify the error but never guess a culprit span: prepareChatV2's
+      // getToolsForAiSdk rethrow does not identify the failing server.
+      ...(setupSignals ? { setupSignals } : {}),
+      ...(setupSpans?.length ? { setupSpans } : {}),
+      ...(setupAudit ? { setupAudit } : {}),
       recorder,
       convexClient,
     });
@@ -3984,6 +4321,9 @@ const runHostedIterationWithBrowser = async (
     iterationMetadataBase,
     ...(hostPolicy ? { hostPolicy } : {}),
     ...(toolSignals ? { toolSignals } : {}),
+    ...(setupSignals ? { setupSignals } : {}),
+    ...(setupSpans?.length ? { setupSpans } : {}),
+    ...(setupAudit ? { setupAudit } : {}),
     injectOpenAiCompat,
   });
 

--- a/mcpjam-inspector/server/services/evals/__tests__/__snapshots__/runner-parity.test.ts.snap
+++ b/mcpjam-inspector/server/services/evals/__tests__/__snapshots__/runner-parity.test.ts.snap
@@ -96,6 +96,24 @@ exports[`runner parity (golden Convex payload + event sequence) > hosted-batch h
         ],
         "spans": [
           {
+            "category": "connection",
+            "endMs": "<scrubbed>",
+            "id": "run-connect-srv-1",
+            "name": "connect",
+            "serverId": "srv-1",
+            "startMs": "<scrubbed>",
+            "status": "ok",
+          },
+          {
+            "category": "discovery",
+            "endMs": "<scrubbed>",
+            "id": "run-toolslist-srv-1",
+            "name": "tools/list",
+            "serverId": "srv-1",
+            "startMs": "<scrubbed>",
+            "status": "ok",
+          },
+          {
             "category": "step",
             "endMs": "<scrubbed>",
             "finishReason": "stop",
@@ -157,23 +175,26 @@ exports[`runner parity (golden Convex payload + event sequence) > hosted-batch h
       "iterationId": "iter-1",
       "metadata": {
         "argumentMismatchCount": 0,
+        "egressCanary": {
+          "ran": false,
+        },
         "failedTurnCount": 0,
         "inputTokens": 1,
         "mismatchCount": 0,
         "missingCount": 0,
         "multiTurn": true,
         "outputTokens": 2,
-        "stageAnalyzerVersion": 1,
+        "stageAnalyzerVersion": 2,
         "stageResults": [
           {
-            "reason": "noSpanChannel",
+            "reason": "observed",
             "stage": "connection",
-            "state": "notMeasured",
+            "state": "passed",
           },
           {
-            "reason": "noSpanChannel",
+            "reason": "observed",
             "stage": "discovery",
-            "state": "notMeasured",
+            "state": "passed",
           },
           {
             "reason": "observed",
@@ -196,6 +217,14 @@ exports[`runner parity (golden Convex payload + event sequence) > hosted-batch h
             "state": "notApplicable",
           },
         ],
+        "stageSetupSignals": {
+          "connection": {
+            "outcome": "ok",
+          },
+          "discovery": {
+            "outcome": "ok",
+          },
+        },
         "stepResults": [
           {
             "kind": "toolCall",
@@ -304,7 +333,26 @@ exports[`runner parity (golden Convex payload + event sequence) > hosted-batch h
             "role": "assistant",
           },
         ],
-        "spans": [],
+        "spans": [
+          {
+            "category": "connection",
+            "endMs": "<scrubbed>",
+            "id": "run-connect-srv-1",
+            "name": "connect",
+            "serverId": "srv-1",
+            "startMs": "<scrubbed>",
+            "status": "ok",
+          },
+          {
+            "category": "discovery",
+            "endMs": "<scrubbed>",
+            "id": "run-toolslist-srv-1",
+            "name": "tools/list",
+            "serverId": "srv-1",
+            "startMs": "<scrubbed>",
+            "status": "ok",
+          },
+        ],
         "turnEndedAt": "<scrubbed>",
         "turnStartedAt": "<scrubbed>",
         "widgets": [],
@@ -320,6 +368,9 @@ exports[`runner parity (golden Convex payload + event sequence) > hosted-batch h
       "iterationId": "iter-1",
       "metadata": {
         "argumentMismatchCount": 0,
+        "egressCanary": {
+          "ran": false,
+        },
         "failedTurnCount": 0,
         "inputTokens": 0,
         "mismatchCount": 0,
@@ -334,17 +385,17 @@ exports[`runner parity (golden Convex payload + event sequence) > hosted-batch h
             "stepIndex": 1,
           },
         ],
-        "stageAnalyzerVersion": 1,
+        "stageAnalyzerVersion": 2,
         "stageResults": [
           {
-            "reason": "noSpanChannel",
+            "reason": "observed",
             "stage": "connection",
-            "state": "notMeasured",
+            "state": "passed",
           },
           {
-            "reason": "noSpanChannel",
+            "reason": "observed",
             "stage": "discovery",
-            "state": "notMeasured",
+            "state": "passed",
           },
           {
             "reason": "observed",
@@ -367,6 +418,14 @@ exports[`runner parity (golden Convex payload + event sequence) > hosted-batch h
             "state": "notApplicable",
           },
         ],
+        "stageSetupSignals": {
+          "connection": {
+            "outcome": "ok",
+          },
+          "discovery": {
+            "outcome": "ok",
+          },
+        },
         "stepResults": [
           {
             "kind": "toolCall",
@@ -541,6 +600,24 @@ exports[`runner parity (golden Convex payload + event sequence) > hosted-batch m
         ],
         "spans": [
           {
+            "category": "connection",
+            "endMs": "<scrubbed>",
+            "id": "run-connect-srv-1",
+            "name": "connect",
+            "serverId": "srv-1",
+            "startMs": "<scrubbed>",
+            "status": "ok",
+          },
+          {
+            "category": "discovery",
+            "endMs": "<scrubbed>",
+            "id": "run-toolslist-srv-1",
+            "name": "tools/list",
+            "serverId": "srv-1",
+            "startMs": "<scrubbed>",
+            "status": "ok",
+          },
+          {
             "category": "step",
             "endMs": "<scrubbed>",
             "finishReason": "stop",
@@ -595,23 +672,26 @@ exports[`runner parity (golden Convex payload + event sequence) > hosted-batch m
       "iterationId": "iter-1",
       "metadata": {
         "argumentMismatchCount": 0,
+        "egressCanary": {
+          "ran": false,
+        },
         "failedTurnCount": 0,
         "inputTokens": 2,
         "mismatchCount": 0,
         "missingCount": 0,
         "multiTurn": true,
         "outputTokens": 4,
-        "stageAnalyzerVersion": 1,
+        "stageAnalyzerVersion": 2,
         "stageResults": [
           {
-            "reason": "noSpanChannel",
+            "reason": "observed",
             "stage": "connection",
-            "state": "notMeasured",
+            "state": "passed",
           },
           {
-            "reason": "noSpanChannel",
+            "reason": "observed",
             "stage": "discovery",
-            "state": "notMeasured",
+            "state": "passed",
           },
           {
             "reason": "observed",
@@ -634,6 +714,14 @@ exports[`runner parity (golden Convex payload + event sequence) > hosted-batch m
             "state": "notApplicable",
           },
         ],
+        "stageSetupSignals": {
+          "connection": {
+            "outcome": "ok",
+          },
+          "discovery": {
+            "outcome": "ok",
+          },
+        },
         "stepResults": [
           {
             "kind": "prompt",
@@ -709,6 +797,24 @@ exports[`runner parity (golden Convex payload + event sequence) > hosted-batch p
         ],
         "spans": [
           {
+            "category": "connection",
+            "endMs": "<scrubbed>",
+            "id": "run-connect-srv-1",
+            "name": "connect",
+            "serverId": "srv-1",
+            "startMs": "<scrubbed>",
+            "status": "ok",
+          },
+          {
+            "category": "discovery",
+            "endMs": "<scrubbed>",
+            "id": "run-toolslist-srv-1",
+            "name": "tools/list",
+            "serverId": "srv-1",
+            "startMs": "<scrubbed>",
+            "status": "ok",
+          },
+          {
             "category": "step",
             "endMs": "<scrubbed>",
             "finishReason": "stop",
@@ -763,22 +869,25 @@ exports[`runner parity (golden Convex payload + event sequence) > hosted-batch p
       "iterationId": "iter-1",
       "metadata": {
         "argumentMismatchCount": 0,
+        "egressCanary": {
+          "ran": false,
+        },
         "failedTurnCount": 0,
         "inputTokens": 1,
         "mismatchCount": 0,
         "missingCount": 0,
         "outputTokens": 2,
-        "stageAnalyzerVersion": 1,
+        "stageAnalyzerVersion": 2,
         "stageResults": [
           {
-            "reason": "noSpanChannel",
+            "reason": "observed",
             "stage": "connection",
-            "state": "notMeasured",
+            "state": "passed",
           },
           {
-            "reason": "noSpanChannel",
+            "reason": "observed",
             "stage": "discovery",
-            "state": "notMeasured",
+            "state": "passed",
           },
           {
             "reason": "observed",
@@ -801,6 +910,14 @@ exports[`runner parity (golden Convex payload + event sequence) > hosted-batch p
             "state": "notApplicable",
           },
         ],
+        "stageSetupSignals": {
+          "connection": {
+            "outcome": "ok",
+          },
+          "discovery": {
+            "outcome": "ok",
+          },
+        },
         "stepResults": [
           {
             "kind": "prompt",
@@ -992,15 +1109,15 @@ exports[`runner parity (golden Convex payload + event sequence) > hosted-stream 
         "missingCount": 0,
         "multiTurn": true,
         "outputTokens": 2,
-        "stageAnalyzerVersion": 1,
+        "stageAnalyzerVersion": 2,
         "stageResults": [
           {
-            "reason": "noSpanChannel",
+            "reason": "noEvidenceCaptured",
             "stage": "connection",
             "state": "notMeasured",
           },
           {
-            "reason": "noSpanChannel",
+            "reason": "noEvidenceCaptured",
             "stage": "discovery",
             "state": "notMeasured",
           },
@@ -1210,15 +1327,15 @@ exports[`runner parity (golden Convex payload + event sequence) > hosted-stream 
         "mismatchCount": 0,
         "missingCount": 0,
         "outputTokens": 2,
-        "stageAnalyzerVersion": 1,
+        "stageAnalyzerVersion": 2,
         "stageResults": [
           {
-            "reason": "noSpanChannel",
+            "reason": "noEvidenceCaptured",
             "stage": "connection",
             "state": "notMeasured",
           },
           {
-            "reason": "noSpanChannel",
+            "reason": "noEvidenceCaptured",
             "stage": "discovery",
             "state": "notMeasured",
           },
@@ -1345,7 +1462,26 @@ exports[`runner parity (golden Convex payload + event sequence) > local-batch ca
             "role": "assistant",
           },
         ],
-        "spans": [],
+        "spans": [
+          {
+            "category": "connection",
+            "endMs": "<scrubbed>",
+            "id": "run-connect-srv-1",
+            "name": "connect",
+            "serverId": "srv-1",
+            "startMs": "<scrubbed>",
+            "status": "ok",
+          },
+          {
+            "category": "discovery",
+            "endMs": "<scrubbed>",
+            "id": "run-toolslist-srv-1",
+            "name": "tools/list",
+            "serverId": "srv-1",
+            "startMs": "<scrubbed>",
+            "status": "ok",
+          },
+        ],
         "turnEndedAt": "<scrubbed>",
         "turnStartedAt": "<scrubbed>",
         "widgets": [],
@@ -1361,6 +1497,9 @@ exports[`runner parity (golden Convex payload + event sequence) > local-batch ca
       "iterationId": "iter-1",
       "metadata": {
         "argumentMismatchCount": 0,
+        "egressCanary": {
+          "ran": false,
+        },
         "failedTurnCount": 0,
         "inputTokens": 1,
         "mismatchCount": 0,
@@ -1387,17 +1526,17 @@ exports[`runner parity (golden Convex payload + event sequence) > local-batch ca
             },
           },
         ],
-        "stageAnalyzerVersion": 1,
+        "stageAnalyzerVersion": 2,
         "stageResults": [
           {
-            "reason": "noSpanChannel",
+            "reason": "observed",
             "stage": "connection",
-            "state": "notMeasured",
+            "state": "passed",
           },
           {
-            "reason": "noSpanChannel",
+            "reason": "observed",
             "stage": "discovery",
-            "state": "notMeasured",
+            "state": "passed",
           },
           {
             "reason": "observed",
@@ -1420,6 +1559,14 @@ exports[`runner parity (golden Convex payload + event sequence) > local-batch ca
             "state": "passed",
           },
         ],
+        "stageSetupSignals": {
+          "connection": {
+            "outcome": "ok",
+          },
+          "discovery": {
+            "outcome": "ok",
+          },
+        },
         "stepResults": [
           {
             "kind": "prompt",
@@ -1543,7 +1690,26 @@ exports[`runner parity (golden Convex payload + event sequence) > local-batch in
             "role": "assistant",
           },
         ],
-        "spans": [],
+        "spans": [
+          {
+            "category": "connection",
+            "endMs": "<scrubbed>",
+            "id": "run-connect-srv-1",
+            "name": "connect",
+            "serverId": "srv-1",
+            "startMs": "<scrubbed>",
+            "status": "ok",
+          },
+          {
+            "category": "discovery",
+            "endMs": "<scrubbed>",
+            "id": "run-toolslist-srv-1",
+            "name": "tools/list",
+            "serverId": "srv-1",
+            "startMs": "<scrubbed>",
+            "status": "ok",
+          },
+        ],
         "turnEndedAt": "<scrubbed>",
         "turnStartedAt": "<scrubbed>",
         "widgetRenderObservations": [
@@ -1576,6 +1742,9 @@ exports[`runner parity (golden Convex payload + event sequence) > local-batch in
       "iterationId": "iter-1",
       "metadata": {
         "argumentMismatchCount": 0,
+        "egressCanary": {
+          "ran": false,
+        },
         "failedTurnCount": 0,
         "failureCategory": "userValue",
         "firstFailedStage": "userValue",
@@ -1602,17 +1771,17 @@ exports[`runner parity (golden Convex payload + event sequence) > local-batch in
             },
           },
         ],
-        "stageAnalyzerVersion": 1,
+        "stageAnalyzerVersion": 2,
         "stageResults": [
           {
-            "reason": "noSpanChannel",
+            "reason": "observed",
             "stage": "connection",
-            "state": "notMeasured",
+            "state": "passed",
           },
           {
-            "reason": "noSpanChannel",
+            "reason": "observed",
             "stage": "discovery",
-            "state": "notMeasured",
+            "state": "passed",
           },
           {
             "reason": "observed",
@@ -1640,6 +1809,14 @@ exports[`runner parity (golden Convex payload + event sequence) > local-batch in
             "state": "failed",
           },
         ],
+        "stageSetupSignals": {
+          "connection": {
+            "outcome": "ok",
+          },
+          "discovery": {
+            "outcome": "ok",
+          },
+        },
         "stepResults": [
           {
             "kind": "prompt",
@@ -1709,7 +1886,26 @@ exports[`runner parity (golden Convex payload + event sequence) > local-batch mo
             "role": "assistant",
           },
         ],
-        "spans": [],
+        "spans": [
+          {
+            "category": "connection",
+            "endMs": "<scrubbed>",
+            "id": "run-connect-srv-1",
+            "name": "connect",
+            "serverId": "srv-1",
+            "startMs": "<scrubbed>",
+            "status": "ok",
+          },
+          {
+            "category": "discovery",
+            "endMs": "<scrubbed>",
+            "id": "run-toolslist-srv-1",
+            "name": "tools/list",
+            "serverId": "srv-1",
+            "startMs": "<scrubbed>",
+            "status": "ok",
+          },
+        ],
         "turnEndedAt": "<scrubbed>",
         "turnStartedAt": "<scrubbed>",
         "widgets": [],
@@ -1725,6 +1921,9 @@ exports[`runner parity (golden Convex payload + event sequence) > local-batch mo
       "iterationId": "iter-1",
       "metadata": {
         "argumentMismatchCount": 0,
+        "egressCanary": {
+          "ran": false,
+        },
         "failedTurnCount": 0,
         "inputTokens": 0,
         "mismatchCount": 0,
@@ -1739,17 +1938,17 @@ exports[`runner parity (golden Convex payload + event sequence) > local-batch mo
             "reason": "no widget render observations recorded",
           },
         ],
-        "stageAnalyzerVersion": 1,
+        "stageAnalyzerVersion": 2,
         "stageResults": [
           {
-            "reason": "noSpanChannel",
+            "reason": "observed",
             "stage": "connection",
-            "state": "notMeasured",
+            "state": "passed",
           },
           {
-            "reason": "noSpanChannel",
+            "reason": "observed",
             "stage": "discovery",
-            "state": "notMeasured",
+            "state": "passed",
           },
           {
             "reason": "notAuthored",
@@ -1772,6 +1971,14 @@ exports[`runner parity (golden Convex payload + event sequence) > local-batch mo
             "state": "notApplicable",
           },
         ],
+        "stageSetupSignals": {
+          "connection": {
+            "outcome": "ok",
+          },
+          "discovery": {
+            "outcome": "ok",
+          },
+        },
         "stepResults": [
           {
             "kind": "toolCall",
@@ -1882,7 +2089,26 @@ exports[`runner parity (golden Convex payload + event sequence) > local-batch mu
             "role": "assistant",
           },
         ],
-        "spans": [],
+        "spans": [
+          {
+            "category": "connection",
+            "endMs": "<scrubbed>",
+            "id": "run-connect-srv-1",
+            "name": "connect",
+            "serverId": "srv-1",
+            "startMs": "<scrubbed>",
+            "status": "ok",
+          },
+          {
+            "category": "discovery",
+            "endMs": "<scrubbed>",
+            "id": "run-toolslist-srv-1",
+            "name": "tools/list",
+            "serverId": "srv-1",
+            "startMs": "<scrubbed>",
+            "status": "ok",
+          },
+        ],
         "turnEndedAt": "<scrubbed>",
         "turnStartedAt": "<scrubbed>",
         "widgets": [],
@@ -1898,23 +2124,26 @@ exports[`runner parity (golden Convex payload + event sequence) > local-batch mu
       "iterationId": "iter-1",
       "metadata": {
         "argumentMismatchCount": 0,
+        "egressCanary": {
+          "ran": false,
+        },
         "failedTurnCount": 0,
         "inputTokens": 2,
         "mismatchCount": 0,
         "missingCount": 0,
         "multiTurn": true,
         "outputTokens": 4,
-        "stageAnalyzerVersion": 1,
+        "stageAnalyzerVersion": 2,
         "stageResults": [
           {
-            "reason": "noSpanChannel",
+            "reason": "observed",
             "stage": "connection",
-            "state": "notMeasured",
+            "state": "passed",
           },
           {
-            "reason": "noSpanChannel",
+            "reason": "observed",
             "stage": "discovery",
-            "state": "notMeasured",
+            "state": "passed",
           },
           {
             "reason": "observed",
@@ -1937,6 +2166,14 @@ exports[`runner parity (golden Convex payload + event sequence) > local-batch mu
             "state": "notApplicable",
           },
         ],
+        "stageSetupSignals": {
+          "connection": {
+            "outcome": "ok",
+          },
+          "discovery": {
+            "outcome": "ok",
+          },
+        },
         "stepResults": [
           {
             "kind": "prompt",
@@ -2005,7 +2242,26 @@ exports[`runner parity (golden Convex payload + event sequence) > local-batch ne
             "role": "assistant",
           },
         ],
-        "spans": [],
+        "spans": [
+          {
+            "category": "connection",
+            "endMs": "<scrubbed>",
+            "id": "run-connect-srv-1",
+            "name": "connect",
+            "serverId": "srv-1",
+            "startMs": "<scrubbed>",
+            "status": "ok",
+          },
+          {
+            "category": "discovery",
+            "endMs": "<scrubbed>",
+            "id": "run-toolslist-srv-1",
+            "name": "tools/list",
+            "serverId": "srv-1",
+            "startMs": "<scrubbed>",
+            "status": "ok",
+          },
+        ],
         "turnEndedAt": "<scrubbed>",
         "turnStartedAt": "<scrubbed>",
         "widgets": [],
@@ -2021,22 +2277,25 @@ exports[`runner parity (golden Convex payload + event sequence) > local-batch ne
       "iterationId": "iter-1",
       "metadata": {
         "argumentMismatchCount": 0,
+        "egressCanary": {
+          "ran": false,
+        },
         "failedTurnCount": 0,
         "inputTokens": 1,
         "mismatchCount": 0,
         "missingCount": 0,
         "outputTokens": 2,
-        "stageAnalyzerVersion": 1,
+        "stageAnalyzerVersion": 2,
         "stageResults": [
           {
-            "reason": "noSpanChannel",
+            "reason": "observed",
             "stage": "connection",
-            "state": "notMeasured",
+            "state": "passed",
           },
           {
-            "reason": "noSpanChannel",
+            "reason": "observed",
             "stage": "discovery",
-            "state": "notMeasured",
+            "state": "passed",
           },
           {
             "reason": "observed",
@@ -2064,6 +2323,14 @@ exports[`runner parity (golden Convex payload + event sequence) > local-batch ne
             "state": "notApplicable",
           },
         ],
+        "stageSetupSignals": {
+          "connection": {
+            "outcome": "ok",
+          },
+          "discovery": {
+            "outcome": "ok",
+          },
+        },
         "stepResults": [
           {
             "kind": "prompt",
@@ -2126,7 +2393,26 @@ exports[`runner parity (golden Convex payload + event sequence) > local-batch pr
             "role": "assistant",
           },
         ],
-        "spans": [],
+        "spans": [
+          {
+            "category": "connection",
+            "endMs": "<scrubbed>",
+            "id": "run-connect-srv-1",
+            "name": "connect",
+            "serverId": "srv-1",
+            "startMs": "<scrubbed>",
+            "status": "ok",
+          },
+          {
+            "category": "discovery",
+            "endMs": "<scrubbed>",
+            "id": "run-toolslist-srv-1",
+            "name": "tools/list",
+            "serverId": "srv-1",
+            "startMs": "<scrubbed>",
+            "status": "ok",
+          },
+        ],
         "turnEndedAt": "<scrubbed>",
         "turnStartedAt": "<scrubbed>",
         "widgets": [],
@@ -2142,22 +2428,25 @@ exports[`runner parity (golden Convex payload + event sequence) > local-batch pr
       "iterationId": "iter-1",
       "metadata": {
         "argumentMismatchCount": 0,
+        "egressCanary": {
+          "ran": false,
+        },
         "failedTurnCount": 0,
         "inputTokens": 1,
         "mismatchCount": 0,
         "missingCount": 0,
         "outputTokens": 2,
-        "stageAnalyzerVersion": 1,
+        "stageAnalyzerVersion": 2,
         "stageResults": [
           {
-            "reason": "noSpanChannel",
+            "reason": "observed",
             "stage": "connection",
-            "state": "notMeasured",
+            "state": "passed",
           },
           {
-            "reason": "noSpanChannel",
+            "reason": "observed",
             "stage": "discovery",
-            "state": "notMeasured",
+            "state": "passed",
           },
           {
             "reason": "observed",
@@ -2180,6 +2469,14 @@ exports[`runner parity (golden Convex payload + event sequence) > local-batch pr
             "state": "notApplicable",
           },
         ],
+        "stageSetupSignals": {
+          "connection": {
+            "outcome": "ok",
+          },
+          "discovery": {
+            "outcome": "ok",
+          },
+        },
         "stepResults": [
           {
             "kind": "prompt",
@@ -2275,7 +2572,26 @@ exports[`runner parity (golden Convex payload + event sequence) > local-batch to
             "role": "assistant",
           },
         ],
-        "spans": [],
+        "spans": [
+          {
+            "category": "connection",
+            "endMs": "<scrubbed>",
+            "id": "run-connect-srv-1",
+            "name": "connect",
+            "serverId": "srv-1",
+            "startMs": "<scrubbed>",
+            "status": "ok",
+          },
+          {
+            "category": "discovery",
+            "endMs": "<scrubbed>",
+            "id": "run-toolslist-srv-1",
+            "name": "tools/list",
+            "serverId": "srv-1",
+            "startMs": "<scrubbed>",
+            "status": "ok",
+          },
+        ],
         "turnEndedAt": "<scrubbed>",
         "turnStartedAt": "<scrubbed>",
         "widgets": [],
@@ -2298,6 +2614,9 @@ exports[`runner parity (golden Convex payload + event sequence) > local-batch to
       "iterationId": "iter-1",
       "metadata": {
         "argumentMismatchCount": 0,
+        "egressCanary": {
+          "ran": false,
+        },
         "failedTurnCount": 0,
         "inputTokens": 1,
         "mismatchCount": 0,
@@ -2322,17 +2641,17 @@ exports[`runner parity (golden Convex payload + event sequence) > local-batch to
             },
           },
         ],
-        "stageAnalyzerVersion": 1,
+        "stageAnalyzerVersion": 2,
         "stageResults": [
           {
-            "reason": "noSpanChannel",
+            "reason": "observed",
             "stage": "connection",
-            "state": "notMeasured",
+            "state": "passed",
           },
           {
-            "reason": "noSpanChannel",
+            "reason": "observed",
             "stage": "discovery",
-            "state": "notMeasured",
+            "state": "passed",
           },
           {
             "reason": "observed",
@@ -2355,6 +2674,14 @@ exports[`runner parity (golden Convex payload + event sequence) > local-batch to
             "state": "passed",
           },
         ],
+        "stageSetupSignals": {
+          "connection": {
+            "outcome": "ok",
+          },
+          "discovery": {
+            "outcome": "ok",
+          },
+        },
         "stepResults": [
           {
             "kind": "prompt",
@@ -2439,7 +2766,26 @@ exports[`runner parity (golden Convex payload + event sequence) > local-batch to
             "role": "tool",
           },
         ],
-        "spans": [],
+        "spans": [
+          {
+            "category": "connection",
+            "endMs": "<scrubbed>",
+            "id": "run-connect-srv-1",
+            "name": "connect",
+            "serverId": "srv-1",
+            "startMs": "<scrubbed>",
+            "status": "ok",
+          },
+          {
+            "category": "discovery",
+            "endMs": "<scrubbed>",
+            "id": "run-toolslist-srv-1",
+            "name": "tools/list",
+            "serverId": "srv-1",
+            "startMs": "<scrubbed>",
+            "status": "ok",
+          },
+        ],
         "turnEndedAt": "<scrubbed>",
         "turnStartedAt": "<scrubbed>",
         "widgets": [],
@@ -2455,22 +2801,25 @@ exports[`runner parity (golden Convex payload + event sequence) > local-batch to
       "iterationId": "iter-1",
       "metadata": {
         "argumentMismatchCount": 0,
+        "egressCanary": {
+          "ran": false,
+        },
         "failedTurnCount": 0,
         "inputTokens": 1,
         "mismatchCount": 0,
         "missingCount": 0,
         "outputTokens": 2,
-        "stageAnalyzerVersion": 1,
+        "stageAnalyzerVersion": 2,
         "stageResults": [
           {
-            "reason": "noSpanChannel",
+            "reason": "observed",
             "stage": "connection",
-            "state": "notMeasured",
+            "state": "passed",
           },
           {
-            "reason": "noSpanChannel",
+            "reason": "observed",
             "stage": "discovery",
-            "state": "notMeasured",
+            "state": "passed",
           },
           {
             "reason": "observed",
@@ -2493,6 +2842,14 @@ exports[`runner parity (golden Convex payload + event sequence) > local-batch to
             "state": "notApplicable",
           },
         ],
+        "stageSetupSignals": {
+          "connection": {
+            "outcome": "ok",
+          },
+          "discovery": {
+            "outcome": "ok",
+          },
+        },
         "stepResults": [
           {
             "kind": "prompt",
@@ -2570,7 +2927,26 @@ exports[`runner parity (golden Convex payload + event sequence) > local-batch to
             "role": "tool",
           },
         ],
-        "spans": [],
+        "spans": [
+          {
+            "category": "connection",
+            "endMs": "<scrubbed>",
+            "id": "run-connect-srv-1",
+            "name": "connect",
+            "serverId": "srv-1",
+            "startMs": "<scrubbed>",
+            "status": "ok",
+          },
+          {
+            "category": "discovery",
+            "endMs": "<scrubbed>",
+            "id": "run-toolslist-srv-1",
+            "name": "tools/list",
+            "serverId": "srv-1",
+            "startMs": "<scrubbed>",
+            "status": "ok",
+          },
+        ],
         "turnEndedAt": "<scrubbed>",
         "turnStartedAt": "<scrubbed>",
         "widgets": [],
@@ -2586,22 +2962,25 @@ exports[`runner parity (golden Convex payload + event sequence) > local-batch to
       "iterationId": "iter-1",
       "metadata": {
         "argumentMismatchCount": 0,
+        "egressCanary": {
+          "ran": false,
+        },
         "failedTurnCount": 0,
         "inputTokens": 1,
         "mismatchCount": 0,
         "missingCount": 0,
         "outputTokens": 2,
-        "stageAnalyzerVersion": 1,
+        "stageAnalyzerVersion": 2,
         "stageResults": [
           {
-            "reason": "noSpanChannel",
+            "reason": "observed",
             "stage": "connection",
-            "state": "notMeasured",
+            "state": "passed",
           },
           {
-            "reason": "noSpanChannel",
+            "reason": "observed",
             "stage": "discovery",
-            "state": "notMeasured",
+            "state": "passed",
           },
           {
             "reason": "observed",
@@ -2624,6 +3003,14 @@ exports[`runner parity (golden Convex payload + event sequence) > local-batch to
             "state": "notApplicable",
           },
         ],
+        "stageSetupSignals": {
+          "connection": {
+            "outcome": "ok",
+          },
+          "discovery": {
+            "outcome": "ok",
+          },
+        },
         "stepResults": [
           {
             "kind": "prompt",
@@ -2686,7 +3073,26 @@ exports[`runner parity (golden Convex payload + event sequence) > local-batch un
             "role": "assistant",
           },
         ],
-        "spans": [],
+        "spans": [
+          {
+            "category": "connection",
+            "endMs": "<scrubbed>",
+            "id": "run-connect-srv-1",
+            "name": "connect",
+            "serverId": "srv-1",
+            "startMs": "<scrubbed>",
+            "status": "ok",
+          },
+          {
+            "category": "discovery",
+            "endMs": "<scrubbed>",
+            "id": "run-toolslist-srv-1",
+            "name": "tools/list",
+            "serverId": "srv-1",
+            "startMs": "<scrubbed>",
+            "status": "ok",
+          },
+        ],
         "turnEndedAt": "<scrubbed>",
         "turnStartedAt": "<scrubbed>",
         "widgets": [],
@@ -2702,22 +3108,25 @@ exports[`runner parity (golden Convex payload + event sequence) > local-batch un
       "iterationId": "iter-1",
       "metadata": {
         "argumentMismatchCount": 0,
+        "egressCanary": {
+          "ran": false,
+        },
         "failedTurnCount": 0,
         "inputTokens": 1,
         "mismatchCount": 0,
         "missingCount": 0,
         "outputTokens": 2,
-        "stageAnalyzerVersion": 1,
+        "stageAnalyzerVersion": 2,
         "stageResults": [
           {
-            "reason": "noSpanChannel",
+            "reason": "observed",
             "stage": "connection",
-            "state": "notMeasured",
+            "state": "passed",
           },
           {
-            "reason": "noSpanChannel",
+            "reason": "observed",
             "stage": "discovery",
-            "state": "notMeasured",
+            "state": "passed",
           },
           {
             "reason": "observed",
@@ -2740,6 +3149,14 @@ exports[`runner parity (golden Convex payload + event sequence) > local-batch un
             "state": "notApplicable",
           },
         ],
+        "stageSetupSignals": {
+          "connection": {
+            "outcome": "ok",
+          },
+          "discovery": {
+            "outcome": "ok",
+          },
+        },
         "stepResults": [
           {
             "kind": "prompt",
@@ -2802,7 +3219,26 @@ exports[`runner parity (golden Convex payload + event sequence) > local-batch wi
             "role": "assistant",
           },
         ],
-        "spans": [],
+        "spans": [
+          {
+            "category": "connection",
+            "endMs": "<scrubbed>",
+            "id": "run-connect-srv-1",
+            "name": "connect",
+            "serverId": "srv-1",
+            "startMs": "<scrubbed>",
+            "status": "ok",
+          },
+          {
+            "category": "discovery",
+            "endMs": "<scrubbed>",
+            "id": "run-toolslist-srv-1",
+            "name": "tools/list",
+            "serverId": "srv-1",
+            "startMs": "<scrubbed>",
+            "status": "ok",
+          },
+        ],
         "turnEndedAt": "<scrubbed>",
         "turnStartedAt": "<scrubbed>",
         "widgetRenderObservations": [
@@ -2828,6 +3264,9 @@ exports[`runner parity (golden Convex payload + event sequence) > local-batch wi
       "iterationId": "iter-1",
       "metadata": {
         "argumentMismatchCount": 0,
+        "egressCanary": {
+          "ran": false,
+        },
         "failedTurnCount": 0,
         "inputTokens": 1,
         "mismatchCount": 0,
@@ -2842,17 +3281,17 @@ exports[`runner parity (golden Convex payload + event sequence) > local-batch wi
             "reason": "widget rendered (1/1 observation(s))",
           },
         ],
-        "stageAnalyzerVersion": 1,
+        "stageAnalyzerVersion": 2,
         "stageResults": [
           {
-            "reason": "noSpanChannel",
+            "reason": "observed",
             "stage": "connection",
-            "state": "notMeasured",
+            "state": "passed",
           },
           {
-            "reason": "noSpanChannel",
+            "reason": "observed",
             "stage": "discovery",
-            "state": "notMeasured",
+            "state": "passed",
           },
           {
             "reason": "observed",
@@ -2875,6 +3314,14 @@ exports[`runner parity (golden Convex payload + event sequence) > local-batch wi
             "state": "passed",
           },
         ],
+        "stageSetupSignals": {
+          "connection": {
+            "outcome": "ok",
+          },
+          "discovery": {
+            "outcome": "ok",
+          },
+        },
         "stepResults": [
           {
             "kind": "prompt",
@@ -3021,15 +3468,15 @@ exports[`runner parity (golden Convex payload + event sequence) > local-stream h
         "missingCount": 0,
         "multiTurn": true,
         "outputTokens": 2,
-        "stageAnalyzerVersion": 1,
+        "stageAnalyzerVersion": 2,
         "stageResults": [
           {
-            "reason": "noSpanChannel",
+            "reason": "noEvidenceCaptured",
             "stage": "connection",
             "state": "notMeasured",
           },
           {
-            "reason": "noSpanChannel",
+            "reason": "noEvidenceCaptured",
             "stage": "discovery",
             "state": "notMeasured",
           },
@@ -3245,15 +3692,15 @@ exports[`runner parity (golden Convex payload + event sequence) > local-stream m
         "missingCount": 0,
         "multiTurn": true,
         "outputTokens": 4,
-        "stageAnalyzerVersion": 1,
+        "stageAnalyzerVersion": 2,
         "stageResults": [
           {
-            "reason": "noSpanChannel",
+            "reason": "noEvidenceCaptured",
             "stage": "connection",
             "state": "notMeasured",
           },
           {
-            "reason": "noSpanChannel",
+            "reason": "noEvidenceCaptured",
             "stage": "discovery",
             "state": "notMeasured",
           },
@@ -3424,15 +3871,15 @@ exports[`runner parity (golden Convex payload + event sequence) > local-stream p
         "mismatchCount": 0,
         "missingCount": 0,
         "outputTokens": 0,
-        "stageAnalyzerVersion": 1,
+        "stageAnalyzerVersion": 2,
         "stageResults": [
           {
-            "reason": "noSpanChannel",
+            "reason": "noEvidenceCaptured",
             "stage": "connection",
             "state": "notMeasured",
           },
           {
-            "reason": "noSpanChannel",
+            "reason": "noEvidenceCaptured",
             "stage": "discovery",
             "state": "notMeasured",
           },
@@ -3550,15 +3997,15 @@ exports[`runner parity (golden Convex payload + event sequence) > local-stream p
         "mismatchCount": 0,
         "missingCount": 0,
         "outputTokens": 2,
-        "stageAnalyzerVersion": 1,
+        "stageAnalyzerVersion": 2,
         "stageResults": [
           {
-            "reason": "noSpanChannel",
+            "reason": "noEvidenceCaptured",
             "stage": "connection",
             "state": "notMeasured",
           },
           {
-            "reason": "noSpanChannel",
+            "reason": "noEvidenceCaptured",
             "stage": "discovery",
             "state": "notMeasured",
           },

--- a/mcpjam-inspector/server/services/evals/__tests__/__snapshots__/runner-parity.test.ts.snap
+++ b/mcpjam-inspector/server/services/evals/__tests__/__snapshots__/runner-parity.test.ts.snap
@@ -175,9 +175,6 @@ exports[`runner parity (golden Convex payload + event sequence) > hosted-batch h
       "iterationId": "iter-1",
       "metadata": {
         "argumentMismatchCount": 0,
-        "egressCanary": {
-          "ran": false,
-        },
         "failedTurnCount": 0,
         "inputTokens": 1,
         "mismatchCount": 0,
@@ -217,12 +214,17 @@ exports[`runner parity (golden Convex payload + event sequence) > hosted-batch h
             "state": "notApplicable",
           },
         ],
-        "stageSetupSignals": {
-          "connection": {
-            "outcome": "ok",
+        "stageSetupAudit": {
+          "egressCanary": {
+            "ran": false,
           },
-          "discovery": {
-            "outcome": "ok",
+          "signals": {
+            "connection": {
+              "outcome": "ok",
+            },
+            "discovery": {
+              "outcome": "ok",
+            },
           },
         },
         "stepResults": [
@@ -368,9 +370,6 @@ exports[`runner parity (golden Convex payload + event sequence) > hosted-batch h
       "iterationId": "iter-1",
       "metadata": {
         "argumentMismatchCount": 0,
-        "egressCanary": {
-          "ran": false,
-        },
         "failedTurnCount": 0,
         "inputTokens": 0,
         "mismatchCount": 0,
@@ -418,12 +417,17 @@ exports[`runner parity (golden Convex payload + event sequence) > hosted-batch h
             "state": "notApplicable",
           },
         ],
-        "stageSetupSignals": {
-          "connection": {
-            "outcome": "ok",
+        "stageSetupAudit": {
+          "egressCanary": {
+            "ran": false,
           },
-          "discovery": {
-            "outcome": "ok",
+          "signals": {
+            "connection": {
+              "outcome": "ok",
+            },
+            "discovery": {
+              "outcome": "ok",
+            },
           },
         },
         "stepResults": [
@@ -672,9 +676,6 @@ exports[`runner parity (golden Convex payload + event sequence) > hosted-batch m
       "iterationId": "iter-1",
       "metadata": {
         "argumentMismatchCount": 0,
-        "egressCanary": {
-          "ran": false,
-        },
         "failedTurnCount": 0,
         "inputTokens": 2,
         "mismatchCount": 0,
@@ -714,12 +715,17 @@ exports[`runner parity (golden Convex payload + event sequence) > hosted-batch m
             "state": "notApplicable",
           },
         ],
-        "stageSetupSignals": {
-          "connection": {
-            "outcome": "ok",
+        "stageSetupAudit": {
+          "egressCanary": {
+            "ran": false,
           },
-          "discovery": {
-            "outcome": "ok",
+          "signals": {
+            "connection": {
+              "outcome": "ok",
+            },
+            "discovery": {
+              "outcome": "ok",
+            },
           },
         },
         "stepResults": [
@@ -869,9 +875,6 @@ exports[`runner parity (golden Convex payload + event sequence) > hosted-batch p
       "iterationId": "iter-1",
       "metadata": {
         "argumentMismatchCount": 0,
-        "egressCanary": {
-          "ran": false,
-        },
         "failedTurnCount": 0,
         "inputTokens": 1,
         "mismatchCount": 0,
@@ -910,12 +913,17 @@ exports[`runner parity (golden Convex payload + event sequence) > hosted-batch p
             "state": "notApplicable",
           },
         ],
-        "stageSetupSignals": {
-          "connection": {
-            "outcome": "ok",
+        "stageSetupAudit": {
+          "egressCanary": {
+            "ran": false,
           },
-          "discovery": {
-            "outcome": "ok",
+          "signals": {
+            "connection": {
+              "outcome": "ok",
+            },
+            "discovery": {
+              "outcome": "ok",
+            },
           },
         },
         "stepResults": [
@@ -1497,9 +1505,6 @@ exports[`runner parity (golden Convex payload + event sequence) > local-batch ca
       "iterationId": "iter-1",
       "metadata": {
         "argumentMismatchCount": 0,
-        "egressCanary": {
-          "ran": false,
-        },
         "failedTurnCount": 0,
         "inputTokens": 1,
         "mismatchCount": 0,
@@ -1559,12 +1564,17 @@ exports[`runner parity (golden Convex payload + event sequence) > local-batch ca
             "state": "passed",
           },
         ],
-        "stageSetupSignals": {
-          "connection": {
-            "outcome": "ok",
+        "stageSetupAudit": {
+          "egressCanary": {
+            "ran": false,
           },
-          "discovery": {
-            "outcome": "ok",
+          "signals": {
+            "connection": {
+              "outcome": "ok",
+            },
+            "discovery": {
+              "outcome": "ok",
+            },
           },
         },
         "stepResults": [
@@ -1742,9 +1752,6 @@ exports[`runner parity (golden Convex payload + event sequence) > local-batch in
       "iterationId": "iter-1",
       "metadata": {
         "argumentMismatchCount": 0,
-        "egressCanary": {
-          "ran": false,
-        },
         "failedTurnCount": 0,
         "failureCategory": "userValue",
         "firstFailedStage": "userValue",
@@ -1809,12 +1816,17 @@ exports[`runner parity (golden Convex payload + event sequence) > local-batch in
             "state": "failed",
           },
         ],
-        "stageSetupSignals": {
-          "connection": {
-            "outcome": "ok",
+        "stageSetupAudit": {
+          "egressCanary": {
+            "ran": false,
           },
-          "discovery": {
-            "outcome": "ok",
+          "signals": {
+            "connection": {
+              "outcome": "ok",
+            },
+            "discovery": {
+              "outcome": "ok",
+            },
           },
         },
         "stepResults": [
@@ -1921,9 +1933,6 @@ exports[`runner parity (golden Convex payload + event sequence) > local-batch mo
       "iterationId": "iter-1",
       "metadata": {
         "argumentMismatchCount": 0,
-        "egressCanary": {
-          "ran": false,
-        },
         "failedTurnCount": 0,
         "inputTokens": 0,
         "mismatchCount": 0,
@@ -1971,12 +1980,17 @@ exports[`runner parity (golden Convex payload + event sequence) > local-batch mo
             "state": "notApplicable",
           },
         ],
-        "stageSetupSignals": {
-          "connection": {
-            "outcome": "ok",
+        "stageSetupAudit": {
+          "egressCanary": {
+            "ran": false,
           },
-          "discovery": {
-            "outcome": "ok",
+          "signals": {
+            "connection": {
+              "outcome": "ok",
+            },
+            "discovery": {
+              "outcome": "ok",
+            },
           },
         },
         "stepResults": [
@@ -2124,9 +2138,6 @@ exports[`runner parity (golden Convex payload + event sequence) > local-batch mu
       "iterationId": "iter-1",
       "metadata": {
         "argumentMismatchCount": 0,
-        "egressCanary": {
-          "ran": false,
-        },
         "failedTurnCount": 0,
         "inputTokens": 2,
         "mismatchCount": 0,
@@ -2166,12 +2177,17 @@ exports[`runner parity (golden Convex payload + event sequence) > local-batch mu
             "state": "notApplicable",
           },
         ],
-        "stageSetupSignals": {
-          "connection": {
-            "outcome": "ok",
+        "stageSetupAudit": {
+          "egressCanary": {
+            "ran": false,
           },
-          "discovery": {
-            "outcome": "ok",
+          "signals": {
+            "connection": {
+              "outcome": "ok",
+            },
+            "discovery": {
+              "outcome": "ok",
+            },
           },
         },
         "stepResults": [
@@ -2277,9 +2293,6 @@ exports[`runner parity (golden Convex payload + event sequence) > local-batch ne
       "iterationId": "iter-1",
       "metadata": {
         "argumentMismatchCount": 0,
-        "egressCanary": {
-          "ran": false,
-        },
         "failedTurnCount": 0,
         "inputTokens": 1,
         "mismatchCount": 0,
@@ -2323,12 +2336,17 @@ exports[`runner parity (golden Convex payload + event sequence) > local-batch ne
             "state": "notApplicable",
           },
         ],
-        "stageSetupSignals": {
-          "connection": {
-            "outcome": "ok",
+        "stageSetupAudit": {
+          "egressCanary": {
+            "ran": false,
           },
-          "discovery": {
-            "outcome": "ok",
+          "signals": {
+            "connection": {
+              "outcome": "ok",
+            },
+            "discovery": {
+              "outcome": "ok",
+            },
           },
         },
         "stepResults": [
@@ -2428,9 +2446,6 @@ exports[`runner parity (golden Convex payload + event sequence) > local-batch pr
       "iterationId": "iter-1",
       "metadata": {
         "argumentMismatchCount": 0,
-        "egressCanary": {
-          "ran": false,
-        },
         "failedTurnCount": 0,
         "inputTokens": 1,
         "mismatchCount": 0,
@@ -2469,12 +2484,17 @@ exports[`runner parity (golden Convex payload + event sequence) > local-batch pr
             "state": "notApplicable",
           },
         ],
-        "stageSetupSignals": {
-          "connection": {
-            "outcome": "ok",
+        "stageSetupAudit": {
+          "egressCanary": {
+            "ran": false,
           },
-          "discovery": {
-            "outcome": "ok",
+          "signals": {
+            "connection": {
+              "outcome": "ok",
+            },
+            "discovery": {
+              "outcome": "ok",
+            },
           },
         },
         "stepResults": [
@@ -2614,9 +2634,6 @@ exports[`runner parity (golden Convex payload + event sequence) > local-batch to
       "iterationId": "iter-1",
       "metadata": {
         "argumentMismatchCount": 0,
-        "egressCanary": {
-          "ran": false,
-        },
         "failedTurnCount": 0,
         "inputTokens": 1,
         "mismatchCount": 0,
@@ -2674,12 +2691,17 @@ exports[`runner parity (golden Convex payload + event sequence) > local-batch to
             "state": "passed",
           },
         ],
-        "stageSetupSignals": {
-          "connection": {
-            "outcome": "ok",
+        "stageSetupAudit": {
+          "egressCanary": {
+            "ran": false,
           },
-          "discovery": {
-            "outcome": "ok",
+          "signals": {
+            "connection": {
+              "outcome": "ok",
+            },
+            "discovery": {
+              "outcome": "ok",
+            },
           },
         },
         "stepResults": [
@@ -2801,9 +2823,6 @@ exports[`runner parity (golden Convex payload + event sequence) > local-batch to
       "iterationId": "iter-1",
       "metadata": {
         "argumentMismatchCount": 0,
-        "egressCanary": {
-          "ran": false,
-        },
         "failedTurnCount": 0,
         "inputTokens": 1,
         "mismatchCount": 0,
@@ -2842,12 +2861,17 @@ exports[`runner parity (golden Convex payload + event sequence) > local-batch to
             "state": "notApplicable",
           },
         ],
-        "stageSetupSignals": {
-          "connection": {
-            "outcome": "ok",
+        "stageSetupAudit": {
+          "egressCanary": {
+            "ran": false,
           },
-          "discovery": {
-            "outcome": "ok",
+          "signals": {
+            "connection": {
+              "outcome": "ok",
+            },
+            "discovery": {
+              "outcome": "ok",
+            },
           },
         },
         "stepResults": [
@@ -2962,9 +2986,6 @@ exports[`runner parity (golden Convex payload + event sequence) > local-batch to
       "iterationId": "iter-1",
       "metadata": {
         "argumentMismatchCount": 0,
-        "egressCanary": {
-          "ran": false,
-        },
         "failedTurnCount": 0,
         "inputTokens": 1,
         "mismatchCount": 0,
@@ -3003,12 +3024,17 @@ exports[`runner parity (golden Convex payload + event sequence) > local-batch to
             "state": "notApplicable",
           },
         ],
-        "stageSetupSignals": {
-          "connection": {
-            "outcome": "ok",
+        "stageSetupAudit": {
+          "egressCanary": {
+            "ran": false,
           },
-          "discovery": {
-            "outcome": "ok",
+          "signals": {
+            "connection": {
+              "outcome": "ok",
+            },
+            "discovery": {
+              "outcome": "ok",
+            },
           },
         },
         "stepResults": [
@@ -3108,9 +3134,6 @@ exports[`runner parity (golden Convex payload + event sequence) > local-batch un
       "iterationId": "iter-1",
       "metadata": {
         "argumentMismatchCount": 0,
-        "egressCanary": {
-          "ran": false,
-        },
         "failedTurnCount": 0,
         "inputTokens": 1,
         "mismatchCount": 0,
@@ -3149,12 +3172,17 @@ exports[`runner parity (golden Convex payload + event sequence) > local-batch un
             "state": "notApplicable",
           },
         ],
-        "stageSetupSignals": {
-          "connection": {
-            "outcome": "ok",
+        "stageSetupAudit": {
+          "egressCanary": {
+            "ran": false,
           },
-          "discovery": {
-            "outcome": "ok",
+          "signals": {
+            "connection": {
+              "outcome": "ok",
+            },
+            "discovery": {
+              "outcome": "ok",
+            },
           },
         },
         "stepResults": [
@@ -3264,9 +3292,6 @@ exports[`runner parity (golden Convex payload + event sequence) > local-batch wi
       "iterationId": "iter-1",
       "metadata": {
         "argumentMismatchCount": 0,
-        "egressCanary": {
-          "ran": false,
-        },
         "failedTurnCount": 0,
         "inputTokens": 1,
         "mismatchCount": 0,
@@ -3314,12 +3339,17 @@ exports[`runner parity (golden Convex payload + event sequence) > local-batch wi
             "state": "passed",
           },
         ],
-        "stageSetupSignals": {
-          "connection": {
-            "outcome": "ok",
+        "stageSetupAudit": {
+          "egressCanary": {
+            "ran": false,
           },
-          "discovery": {
-            "outcome": "ok",
+          "signals": {
+            "connection": {
+              "outcome": "ok",
+            },
+            "discovery": {
+              "outcome": "ok",
+            },
           },
         },
         "stepResults": [

--- a/mcpjam-inspector/server/services/evals/__tests__/build-iteration-finish-params.test.ts
+++ b/mcpjam-inspector/server/services/evals/__tests__/build-iteration-finish-params.test.ts
@@ -80,7 +80,7 @@ describe("buildIterationFinishParams — stage derivation", () => {
   test("writes a full chain when the authored case is supplied", () => {
     const params = build({ stageCase: authoredCase, spans: [okToolSpan] });
     const metadata = params.metadata as Record<string, unknown>;
-    expect(metadata.stageAnalyzerVersion).toBe(1);
+    expect(metadata.stageAnalyzerVersion).toBe(2);
     expect(rowsOf(params)).toHaveLength(6);
     expect(stage(params, "call").state).toBe("passed");
   });
@@ -177,7 +177,7 @@ describe("buildStageMetadata — the seam a setup abort finalizes through", () =
     expect(applicable.every((r) => r.state === "notMeasured")).toBe(true);
     expect(applicable.every((r) => r.reason === "setupAborted")).toBe(true);
     expect(metadata.failureCategory).toBe("setup");
-    expect(metadata.stageAnalyzerVersion).toBe(1);
+    expect(metadata.stageAnalyzerVersion).toBe(2);
     // Never a fabricated failure: nothing was measured, so nothing "failed".
     expect(metadata.firstFailedStage).toBeUndefined();
   });
@@ -200,5 +200,44 @@ describe("buildStageMetadata — the seam a setup abort finalizes through", () =
     }).metadata as Record<string, unknown>;
     expect(viaHelper.stageResults).toEqual(viaFinishParams.stageResults);
     expect(viaHelper.failureCategory).toBe(viaFinishParams.failureCategory);
+  });
+
+  test("synthetic setup spans persist on the trace and stay out of evidence", () => {
+    const setupSpan = {
+      id: "run-connect-s1",
+      name: "connect",
+      category: "connection",
+      startMs: 0,
+      endMs: 12,
+      status: "error",
+      serverId: "s1",
+    } as unknown as EvalTraceSpan;
+    const params = build({
+      stageCase: authoredCase,
+      status: "failed",
+      error: "connection refused",
+      messages: [],
+      setupSpans: [setupSpan],
+      setupSignals: {
+        connection: {
+          outcome: "failed",
+          attribution: "theirs",
+          egressVerified: true,
+          spanIds: ["run-connect-s1"],
+        },
+      },
+    });
+    expect(params.spans).toEqual([setupSpan]);
+    expect(stage(params, "connection")).toMatchObject({
+      state: "failed",
+      reason: "connectFailed",
+      evidence: { spanIds: ["run-connect-s1"] },
+    });
+    // The analyzer's `traceAbsent` fallback still fired — synthetic spans
+    // never entered evidence — so later stages stay notReached, not implied.
+    expect(stage(params, "selection")).toMatchObject({
+      state: "notReached",
+      reason: "earlierStageFailed",
+    });
   });
 });

--- a/mcpjam-inspector/server/services/evals/__tests__/eval-trace-capture.test.ts
+++ b/mcpjam-inspector/server/services/evals/__tests__/eval-trace-capture.test.ts
@@ -6,6 +6,7 @@ import {
   finalizeAiSdkTraceOnFailure,
   patchAiSdkRecordedSpansMessageRangesFromSteps,
   pushAiSdkTrailingErrorSpan,
+  pushRunSetupSpans,
   pushBackendStepLlmFailureSpans,
   pushBackendStepSuccessSpans,
   pushBackendStepToolFailureSpans,
@@ -331,6 +332,31 @@ describe("eval-trace-capture", () => {
     const spans: EvalTraceSpan[] = [];
     pushAiSdkTrailingErrorSpan(spans, runAt, runAt + 10, runAt + 10);
     expect(spans[0]!.endMs).toBeGreaterThan(spans[0]!.startMs);
+  });
+
+  it("unshifts synthetic run-setup spans ahead of captured spans", () => {
+    const spans: EvalTraceSpan[] = [
+      {
+        id: "tool-1",
+        name: "tool.search",
+        category: "tool",
+        startMs: 5,
+        endMs: 9,
+        status: "ok",
+      },
+    ];
+    pushRunSetupSpans(spans, [
+      {
+        id: "run-connect-s1",
+        name: "connect",
+        category: "connection",
+        startMs: 0,
+        endMs: 12,
+        status: "error",
+        serverId: "s1",
+      },
+    ]);
+    expect(spans.map((s) => s.id)).toEqual(["run-connect-s1", "tool-1"]);
   });
 
   it("backend wrapped tools emit per-call spans with tool metadata", async () => {

--- a/mcpjam-inspector/server/services/evals/__tests__/eval-trace-capture.test.ts
+++ b/mcpjam-inspector/server/services/evals/__tests__/eval-trace-capture.test.ts
@@ -359,6 +359,30 @@ describe("eval-trace-capture", () => {
     expect(spans.map((s) => s.id)).toEqual(["run-connect-s1", "tool-1"]);
   });
 
+  it("leaves captured spans unchanged when setupSpans is empty", () => {
+    const spans: EvalTraceSpan[] = [
+      {
+        id: "tool-1",
+        name: "tool.search",
+        category: "tool",
+        startMs: 5,
+        endMs: 9,
+        status: "ok",
+      },
+    ];
+    pushRunSetupSpans(spans, []);
+    expect(spans).toEqual([
+      {
+        id: "tool-1",
+        name: "tool.search",
+        category: "tool",
+        startMs: 5,
+        endMs: 9,
+        status: "ok",
+      },
+    ]);
+  });
+
   it("backend wrapped tools emit per-call spans with tool metadata", async () => {
     let wall = runAt;
     vi.spyOn(Date, "now").mockImplementation(() => wall);

--- a/mcpjam-inspector/server/services/evals/__tests__/evals-runner.test.ts
+++ b/mcpjam-inspector/server/services/evals/__tests__/evals-runner.test.ts
@@ -117,6 +117,8 @@ describe("runEvalSuiteWithAiSdk compare session metadata", () => {
   };
   const mcpClientManager = {
     getToolsForAiSdk: vi.fn(),
+    listTools: vi.fn(),
+    getConnectionStatus: vi.fn(),
     listServers: vi.fn(),
     // PR 3 of the engine consolidation: the engine that
     // `runIterationViaBackend` now drives calls
@@ -141,6 +143,8 @@ describe("runEvalSuiteWithAiSdk compare session metadata", () => {
     convexClient.query.mockResolvedValue({ status: "running" });
     convexClient.action.mockResolvedValue(undefined);
     mcpClientManager.getToolsForAiSdk.mockResolvedValue({});
+    mcpClientManager.listTools.mockResolvedValue({ tools: [] });
+    mcpClientManager.getConnectionStatus.mockReturnValue("connected");
     mcpClientManager.listServers.mockReturnValue(["srv-1"]);
     mcpClientManager.executeTool.mockResolvedValue({
       content: [{ type: "text", text: "Pinned result" }],

--- a/mcpjam-inspector/server/services/evals/__tests__/run-setup-failure.test.ts
+++ b/mcpjam-inspector/server/services/evals/__tests__/run-setup-failure.test.ts
@@ -258,4 +258,66 @@ describe("run-level connect failure — D6 non-vacuity", () => {
       reason: "egressUnverified",
     });
   });
+
+  it("finalizes even when pending-row reads throw", async () => {
+    mcpClientManager.getConnectionStatus.mockReturnValue("disconnected");
+    const refused = new Error("connect ECONNREFUSED 203.0.113.10:443");
+    (refused as Error & { code: string }).code = "ECONNREFUSED";
+    mcpClientManager.listTools.mockRejectedValue(refused);
+
+    convexClient.query.mockImplementation(async (ref: string) => {
+      if (ref === "testSuites:getTestSuiteRunDetails") {
+        throw new Error("convex unavailable");
+      }
+      return { status: "running" };
+    });
+
+    const recorder = {
+      runId: "run-1",
+      suiteId: "suite-1",
+      startIteration: vi.fn(),
+      finishIteration: vi.fn(),
+      finalize: vi.fn(),
+    };
+
+    await expect(
+      runEvalSuiteWithAiSdk({
+        suiteId: "suite-1",
+        runId: "run-1",
+        recorder,
+        config: {
+          tests: [
+            {
+              title: "Case",
+              query: "Hello",
+              runs: 1,
+              model: "gpt-4-turbo",
+              provider: "openai",
+              expectedToolCalls: [],
+              promptTurns: [
+                { id: "turn-1", prompt: "Hello", expectedToolCalls: [] },
+              ],
+              testCaseId: "case-1",
+            },
+          ],
+          environment: { servers: ["srv-1"] },
+        },
+        modelApiKeys: { openai: "sk-test" },
+        convexClient: convexClient as any,
+        convexHttpUrl: "https://example.convex.site",
+        convexAuthToken: "token",
+        mcpClientManager: mcpClientManager as any,
+        testCaseId: "case-1",
+      } as any)
+    ).rejects.toThrow("is not connected");
+
+    expect(recorder.finalize).toHaveBeenCalledWith({
+      status: "failed",
+      summary: undefined,
+    });
+    expect(convexClient.mutation).toHaveBeenCalledWith(
+      "testSuites:markSetupPendingIterationsFailed",
+      expect.objectContaining({ runId: "run-1" })
+    );
+  });
 });

--- a/mcpjam-inspector/server/services/evals/__tests__/run-setup-failure.test.ts
+++ b/mcpjam-inspector/server/services/evals/__tests__/run-setup-failure.test.ts
@@ -1,0 +1,261 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+/**
+ * Non-vacuity: a run-level connect failure must persist
+ * `stageResults[0].reason === "connectFailed"` when the canary is ok.
+ * Reverting the observer → finalize threading fails this test.
+ */
+
+const generateTextMock = vi.hoisted(() => vi.fn());
+const streamTextMock = vi.hoisted(() => vi.fn());
+const pinnedFetchMock = vi.hoisted(() => vi.fn());
+
+vi.mock("ai", async () => {
+  const actual = await vi.importActual<typeof import("ai")>("ai");
+  return {
+    ...actual,
+    generateText: (...args: unknown[]) => generateTextMock(...args),
+    streamText: (...args: unknown[]) => streamTextMock(...args),
+    stepCountIs: vi.fn(() => undefined),
+  };
+});
+
+vi.mock("../../../utils/chat-helpers", async () => {
+  const actual = await vi.importActual<
+    typeof import("../../../utils/chat-helpers")
+  >("../../../utils/chat-helpers");
+  return {
+    ...actual,
+    createLlmModel: vi.fn(() => ({ id: "mock-model" })),
+  };
+});
+
+vi.mock("../../../utils/mcpjam-tool-helpers", () => ({
+  serializeToolsForConvex: vi.fn(() => []),
+}));
+
+vi.mock("@/shared/http-tool-calls", () => ({
+  hasUnresolvedToolCalls: vi.fn().mockReturnValue(false),
+  executeToolCallsFromMessages: vi.fn().mockResolvedValue([]),
+}));
+
+vi.mock("../../../utils/chat-v2-orchestration", () => ({
+  prepareChatV2: vi.fn(async (options: any) => ({
+    allTools: {},
+    enhancedSystemPrompt: options?.systemPrompt ?? "",
+    resolvedTemperature: options?.temperature,
+    scrubMessages: (msgs: unknown[]) => msgs,
+    progressivePlan: { enabled: false },
+    discoveryState: {
+      loadedToolIds: new Set<string>(),
+      catalogVersion: 0,
+    },
+  })),
+}));
+
+vi.mock("../../../utils/pinned-fetch", () => ({
+  createPinnedFetch: () => pinnedFetchMock,
+}));
+
+import { runEvalSuiteWithAiSdk } from "../../evals-runner";
+
+describe("run-level connect failure — D6 non-vacuity", () => {
+  const convexClient = {
+    mutation: vi.fn(),
+    query: vi.fn(),
+    action: vi.fn(),
+  };
+  const mcpClientManager = {
+    getToolsForAiSdk: vi.fn(),
+    listTools: vi.fn(),
+    getConnectionStatus: vi.fn(),
+    listServers: vi.fn(),
+    getAllToolsMetadata: vi.fn().mockReturnValue({}),
+    executeTool: vi.fn(),
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    process.env.CONVEX_HTTP_URL = "https://example.convex.site";
+    convexClient.mutation.mockResolvedValue({ iterationId: "iter-1" });
+    convexClient.action.mockResolvedValue(undefined);
+    mcpClientManager.listServers.mockReturnValue(["srv-1"]);
+    mcpClientManager.getToolsForAiSdk.mockResolvedValue({});
+    pinnedFetchMock.mockResolvedValue({ ok: true });
+  });
+
+  afterEach(() => {
+    delete process.env.CONVEX_HTTP_URL;
+  });
+
+  it("persists connectFailed on a theirs-shaped refused connect with a verified canary", async () => {
+    mcpClientManager.getConnectionStatus.mockReturnValue("disconnected");
+    const refused = new Error("connect ECONNREFUSED 203.0.113.10:443");
+    (refused as Error & { code: string }).code = "ECONNREFUSED";
+    mcpClientManager.listTools.mockRejectedValue(refused);
+
+    let detailsCalls = 0;
+    convexClient.query.mockImplementation(async (ref: string) => {
+      if (ref === "testSuites:getTestSuiteRunDetails") {
+        detailsCalls += 1;
+        // First read (and the retry read if the write is treated as
+        // unacked) still sees pending; after finishIteration the next
+        // re-read is empty so the sweep never strips stage metadata.
+        if (detailsCalls <= 1) {
+          return {
+            iterations: [
+              {
+                _id: "iter-pending",
+                status: "pending",
+                testCaseId: "case-1",
+                testCaseSnapshot: {
+                  query: "Hello",
+                  expectedToolCalls: [],
+                },
+              },
+            ],
+          };
+        }
+        return { iterations: [] };
+      }
+      return { status: "running" };
+    });
+
+    const recorder = {
+      runId: "run-1",
+      suiteId: "suite-1",
+      startIteration: vi.fn(),
+      finishIteration: vi.fn(),
+      finalize: vi.fn(),
+    };
+
+    await expect(
+      runEvalSuiteWithAiSdk({
+        suiteId: "suite-1",
+        runId: "run-1",
+        recorder,
+        config: {
+          tests: [
+            {
+              title: "Case",
+              query: "Hello",
+              runs: 1,
+              model: "gpt-4-turbo",
+              provider: "openai",
+              expectedToolCalls: [],
+              promptTurns: [
+                { id: "turn-1", prompt: "Hello", expectedToolCalls: [] },
+              ],
+              testCaseId: "case-1",
+            },
+          ],
+          environment: { servers: ["srv-1"] },
+        },
+        modelApiKeys: { openai: "sk-test" },
+        convexClient: convexClient as any,
+        convexHttpUrl: "https://example.convex.site",
+        convexAuthToken: "token",
+        mcpClientManager: mcpClientManager as any,
+        testCaseId: "case-1",
+      } as any)
+    ).rejects.toThrow("is not connected");
+
+    expect(pinnedFetchMock).toHaveBeenCalled();
+    expect(recorder.finishIteration).toHaveBeenCalled();
+    const finish = recorder.finishIteration.mock.calls[0]![0] as {
+      metadata?: {
+        stageResults?: Array<{ stage: string; state: string; reason?: string }>;
+      };
+      spans?: Array<{ id: string; category: string }>;
+    };
+    expect(finish.metadata?.stageResults?.[0]).toMatchObject({
+      stage: "connection",
+      state: "failed",
+      reason: "connectFailed",
+    });
+    expect(finish.spans?.some((s) => s.category === "connection")).toBe(true);
+    expect(recorder.finalize).toHaveBeenCalledWith({
+      status: "failed",
+      summary: undefined,
+    });
+    expect(convexClient.mutation).not.toHaveBeenCalledWith(
+      "testSuites:markSetupPendingIterationsFailed",
+      expect.anything()
+    );
+  });
+
+  it("does not guess a connectFailed when the canary itself fails", async () => {
+    mcpClientManager.getConnectionStatus.mockReturnValue("disconnected");
+    const refused = new Error("connect ECONNREFUSED 203.0.113.10:443");
+    (refused as Error & { code: string }).code = "ECONNREFUSED";
+    mcpClientManager.listTools.mockRejectedValue(refused);
+    pinnedFetchMock.mockResolvedValue({ ok: false });
+
+    convexClient.query.mockImplementation(async (ref: string) => {
+      if (ref === "testSuites:getTestSuiteRunDetails") {
+        return {
+          iterations: [
+            {
+              _id: "iter-pending",
+              status: "pending",
+              testCaseId: "case-1",
+            },
+          ],
+        };
+      }
+      return { status: "running" };
+    });
+
+    const recorder = {
+      runId: "run-1",
+      suiteId: "suite-1",
+      startIteration: vi.fn(),
+      finishIteration: vi.fn().mockImplementation(async () => {
+        // Leave the row pending so we exercise retry; the assertion is
+        // the reason, not the sweep.
+      }),
+      finalize: vi.fn(),
+    };
+
+    await expect(
+      runEvalSuiteWithAiSdk({
+        suiteId: "suite-1",
+        runId: "run-1",
+        recorder,
+        config: {
+          tests: [
+            {
+              title: "Case",
+              query: "Hello",
+              runs: 1,
+              model: "gpt-4-turbo",
+              provider: "openai",
+              expectedToolCalls: [],
+              promptTurns: [
+                { id: "turn-1", prompt: "Hello", expectedToolCalls: [] },
+              ],
+              testCaseId: "case-1",
+            },
+          ],
+          environment: { servers: ["srv-1"] },
+        },
+        modelApiKeys: { openai: "sk-test" },
+        convexClient: convexClient as any,
+        convexHttpUrl: "https://example.convex.site",
+        convexAuthToken: "token",
+        mcpClientManager: mcpClientManager as any,
+        testCaseId: "case-1",
+      } as any)
+    ).rejects.toThrow("is not connected");
+
+    const finish = recorder.finishIteration.mock.calls[0]![0] as {
+      metadata?: {
+        stageResults?: Array<{ reason?: string; state?: string }>;
+      };
+    };
+    expect(finish.metadata?.stageResults?.[0]).toMatchObject({
+      state: "notMeasured",
+      reason: "egressUnverified",
+    });
+  });
+});

--- a/mcpjam-inspector/server/services/evals/__tests__/run-setup-failure.test.ts
+++ b/mcpjam-inspector/server/services/evals/__tests__/run-setup-failure.test.ts
@@ -92,7 +92,11 @@ describe("run-level connect failure — D6 non-vacuity", () => {
     mcpClientManager.getConnectionStatus.mockReturnValue("disconnected");
     const refused = new Error("connect ECONNREFUSED 203.0.113.10:443");
     (refused as Error & { code: string }).code = "ECONNREFUSED";
-    mcpClientManager.listTools.mockRejectedValue(refused);
+    // Connect and tools/list are ONE round trip now: `getToolsForAiSdk`
+    // ensures the session before listing, so a connect miss surfaces
+    // as a rejection from it while `getConnectionStatus` stays
+    // disconnected — that pairing is what marks the connection phase.
+    mcpClientManager.getToolsForAiSdk.mockRejectedValue(refused);
 
     let detailsCalls = 0;
     convexClient.query.mockImplementation(async (ref: string) => {
@@ -188,7 +192,11 @@ describe("run-level connect failure — D6 non-vacuity", () => {
     mcpClientManager.getConnectionStatus.mockReturnValue("disconnected");
     const refused = new Error("connect ECONNREFUSED 203.0.113.10:443");
     (refused as Error & { code: string }).code = "ECONNREFUSED";
-    mcpClientManager.listTools.mockRejectedValue(refused);
+    // Connect and tools/list are ONE round trip now: `getToolsForAiSdk`
+    // ensures the session before listing, so a connect miss surfaces
+    // as a rejection from it while `getConnectionStatus` stays
+    // disconnected — that pairing is what marks the connection phase.
+    mcpClientManager.getToolsForAiSdk.mockRejectedValue(refused);
     pinnedFetchMock.mockResolvedValue({ ok: false });
 
     convexClient.query.mockImplementation(async (ref: string) => {
@@ -263,7 +271,11 @@ describe("run-level connect failure — D6 non-vacuity", () => {
     mcpClientManager.getConnectionStatus.mockReturnValue("disconnected");
     const refused = new Error("connect ECONNREFUSED 203.0.113.10:443");
     (refused as Error & { code: string }).code = "ECONNREFUSED";
-    mcpClientManager.listTools.mockRejectedValue(refused);
+    // Connect and tools/list are ONE round trip now: `getToolsForAiSdk`
+    // ensures the session before listing, so a connect miss surfaces
+    // as a rejection from it while `getConnectionStatus` stays
+    // disconnected — that pairing is what marks the connection phase.
+    mcpClientManager.getToolsForAiSdk.mockRejectedValue(refused);
 
     convexClient.query.mockImplementation(async (ref: string) => {
       if (ref === "testSuites:getTestSuiteRunDetails") {

--- a/mcpjam-inspector/server/services/evals/__tests__/run-setup-failure.test.ts
+++ b/mcpjam-inspector/server/services/evals/__tests__/run-setup-failure.test.ts
@@ -320,4 +320,77 @@ describe("run-level connect failure — D6 non-vacuity", () => {
       expect.objectContaining({ runId: "run-1" })
     );
   });
+
+  it("does not run the canary for a theirs tools/list miss after initialize", async () => {
+    mcpClientManager.getConnectionStatus.mockReturnValue("connected");
+    const refused = new Error("connect ECONNREFUSED 203.0.113.10:443");
+    (refused as Error & { code: string }).code = "ECONNREFUSED";
+    mcpClientManager.getToolsForAiSdk.mockRejectedValue(refused);
+
+    convexClient.query.mockImplementation(async (ref: string) => {
+      if (ref === "testSuites:getTestSuiteRunDetails") {
+        return {
+          iterations: [
+            {
+              _id: "iter-pending",
+              status: "pending",
+              testCaseId: "case-1",
+              testCaseSnapshot: { query: "Hello", expectedToolCalls: [] },
+            },
+          ],
+        };
+      }
+      return { status: "running" };
+    });
+
+    const recorder = {
+      runId: "run-1",
+      suiteId: "suite-1",
+      startIteration: vi.fn(),
+      finishIteration: vi.fn(),
+      finalize: vi.fn(),
+    };
+
+    await expect(
+      runEvalSuiteWithAiSdk({
+        suiteId: "suite-1",
+        runId: "run-1",
+        recorder,
+        config: {
+          tests: [
+            {
+              title: "Case",
+              query: "Hello",
+              runs: 1,
+              model: "gpt-4-turbo",
+              provider: "openai",
+              expectedToolCalls: [],
+              promptTurns: [
+                { id: "turn-1", prompt: "Hello", expectedToolCalls: [] },
+              ],
+              testCaseId: "case-1",
+            },
+          ],
+          environment: { servers: ["srv-1"] },
+        },
+        modelApiKeys: { openai: "sk-test" },
+        convexClient: convexClient as any,
+        convexHttpUrl: "https://example.convex.site",
+        convexAuthToken: "token",
+        mcpClientManager: mcpClientManager as any,
+        testCaseId: "case-1",
+      } as any)
+    ).rejects.toThrow();
+
+    expect(pinnedFetchMock).not.toHaveBeenCalled();
+    const finish = recorder.finishIteration.mock.calls[0]![0] as {
+      metadata?: {
+        stageResults?: Array<{ stage: string; state: string; reason?: string }>;
+      };
+    };
+    expect(finish.metadata?.stageResults?.find((r) => r.stage === "discovery")).toMatchObject({
+      state: "failed",
+      reason: "toolsListFailed",
+    });
+  });
 });

--- a/mcpjam-inspector/server/services/evals/__tests__/run-setup-signals.test.ts
+++ b/mcpjam-inspector/server/services/evals/__tests__/run-setup-signals.test.ts
@@ -1,0 +1,262 @@
+import { describe, expect, it, vi } from "vitest";
+import {
+  BlockedEgressTargetError,
+  EgressResolutionError,
+} from "../../../utils/hosted-egress-guard.js";
+import {
+  classifySetupAttribution,
+  connectSpanId,
+  createRunSetupObserver,
+  toolsListSpanId,
+} from "../run-setup-signals.js";
+
+function nodeError(code: string, message = code): Error {
+  const error = new Error(message);
+  (error as Error & { code: string }).code = code;
+  return error;
+}
+
+function httpError(status: number, message = `HTTP ${status}`): Error {
+  const error = new Error(message);
+  (error as Error & { status: number }).status = status;
+  return error;
+}
+
+describe("classifySetupAttribution", () => {
+  it("classifies DNS / blocked egress as ours", () => {
+    expect(classifySetupAttribution(new EgressResolutionError("no such host"))).toBe(
+      "ours"
+    );
+    expect(
+      classifySetupAttribution(new BlockedEgressTargetError("169.254.169.254"))
+    ).toBe("ours");
+    expect(classifySetupAttribution(nodeError("ENOTFOUND"))).toBe("ours");
+  });
+
+  it("classifies 401/403 and transport-local MCP codes as ours", () => {
+    expect(classifySetupAttribution(httpError(401))).toBe("ours");
+    expect(classifySetupAttribution(httpError(403))).toBe("ours");
+    const mcp = new Error("request timeout");
+    (mcp as Error & { mcpErrorCode: number }).mcpErrorCode = -32001;
+    expect(classifySetupAttribution(mcp)).toBe("ours");
+  });
+
+  it("classifies refused / TLS / timeout / 5xx as theirs", () => {
+    expect(classifySetupAttribution(nodeError("ECONNREFUSED"))).toBe("theirs");
+    expect(classifySetupAttribution(nodeError("ETIMEDOUT"))).toBe("theirs");
+    expect(classifySetupAttribution(httpError(502))).toBe("theirs");
+    expect(
+      classifySetupAttribution(new Error("unable to verify the first certificate"))
+    ).toBe("theirs");
+  });
+
+  it("classifies everything else as unknown", () => {
+    expect(classifySetupAttribution(new Error("something odd"))).toBe("unknown");
+  });
+});
+
+describe("createRunSetupObserver folding", () => {
+  it("omits signals when no servers are configured", () => {
+    const observer = createRunSetupObserver({ expectedServerIds: [] });
+    observer.recordConnect("ghost", {
+      outcome: "ok",
+      startedAt: 0,
+      endedAt: 1,
+    });
+    expect(observer.buildSignals()).toBeUndefined();
+  });
+
+  it("folds all-ok as outcome ok", () => {
+    const observer = createRunSetupObserver({
+      expectedServerIds: ["a", "b"],
+    });
+    for (const id of ["a", "b"]) {
+      observer.recordConnect(id, { outcome: "ok", startedAt: 0, endedAt: 1 });
+      observer.recordToolsList(id, { outcome: "ok", startedAt: 1, endedAt: 2 });
+    }
+    expect(observer.buildSignals()).toEqual({
+      connection: { outcome: "ok" },
+      discovery: { outcome: "ok" },
+    });
+  });
+
+  it("lets ours dominate a mixed bag so it cannot earn connection:failed", () => {
+    const observer = createRunSetupObserver({
+      expectedServerIds: ["a", "b"],
+    });
+    observer.recordConnect("a", {
+      outcome: "failed",
+      error: nodeError("ECONNREFUSED"),
+      startedAt: 0,
+      endedAt: 1,
+    });
+    observer.recordConnect("b", {
+      outcome: "failed",
+      error: nodeError("ENOTFOUND"),
+      startedAt: 0,
+      endedAt: 1,
+    });
+    const signals = observer.buildSignals();
+    expect(signals?.connection).toMatchObject({
+      outcome: "failed",
+      attribution: "ours",
+      spanIds: [connectSpanId("a"), connectSpanId("b")],
+    });
+  });
+
+  it("lets unknown dominate verified-theirs", () => {
+    const observer = createRunSetupObserver({
+      expectedServerIds: ["a", "b"],
+    });
+    observer.recordConnect("a", {
+      outcome: "failed",
+      error: nodeError("ECONNREFUSED"),
+      startedAt: 0,
+      endedAt: 1,
+    });
+    observer.recordConnect("b", {
+      outcome: "failed",
+      error: new Error("something odd"),
+      startedAt: 0,
+      endedAt: 1,
+    });
+    expect(observer.buildSignals()?.connection?.attribution).toBe("unknown");
+  });
+
+  it("folds an unobserved target as unknown", () => {
+    const observer = createRunSetupObserver({
+      expectedServerIds: ["a", "b"],
+    });
+    observer.recordConnect("a", {
+      outcome: "ok",
+      startedAt: 0,
+      endedAt: 1,
+    });
+    expect(observer.buildSignals()?.connection).toMatchObject({
+      outcome: "failed",
+      attribution: "unknown",
+    });
+  });
+
+  it("caps culprit span ids at 5", () => {
+    const ids = ["a", "b", "c", "d", "e", "f"];
+    const observer = createRunSetupObserver({ expectedServerIds: ids });
+    for (const id of ids) {
+      observer.recordConnect(id, {
+        outcome: "failed",
+        error: nodeError("ECONNREFUSED"),
+        startedAt: 0,
+        endedAt: 1,
+      });
+    }
+    expect(observer.buildSignals()?.connection?.spanIds).toHaveLength(5);
+  });
+});
+
+describe("createRunSetupObserver canary + spans", () => {
+  it("never runs the canary for an ours failure", async () => {
+    const canary = vi.fn(async () => true);
+    const observer = createRunSetupObserver({
+      expectedServerIds: ["srv"],
+      canary,
+    });
+    observer.recordConnect("srv", {
+      outcome: "failed",
+      error: nodeError("ENOTFOUND"),
+      startedAt: 0,
+      endedAt: 1,
+    });
+    expect(observer.buildSignals()?.connection).toMatchObject({
+      outcome: "failed",
+      attribution: "ours",
+    });
+    expect(observer.buildSignals()?.connection?.egressVerified).toBeUndefined();
+    expect(canary).not.toHaveBeenCalled();
+  });
+
+  it("runs the canary once per run, only when asked, on theirs", async () => {
+    const canary = vi.fn(async () => true);
+    const observer = createRunSetupObserver({
+      expectedServerIds: ["srv"],
+      canary,
+    });
+    observer.recordConnect("srv", {
+      outcome: "failed",
+      error: nodeError("ECONNREFUSED"),
+      startedAt: 0,
+      endedAt: 1,
+    });
+    expect(canary).not.toHaveBeenCalled();
+    await expect(observer.ensureEgressCanary()).resolves.toBe(true);
+    await expect(observer.ensureEgressCanary()).resolves.toBe(true);
+    expect(canary).toHaveBeenCalledTimes(1);
+    expect(observer.buildSignals()?.connection).toMatchObject({
+      outcome: "failed",
+      attribution: "theirs",
+      egressVerified: true,
+    });
+  });
+
+  it("clamps synthetic span position to offset 0 and keeps duration", () => {
+    const observer = createRunSetupObserver({
+      expectedServerIds: ["srv"],
+    });
+    observer.recordConnect("srv", {
+      outcome: "failed",
+      error: nodeError("ECONNREFUSED"),
+      startedAt: 1_000,
+      endedAt: 1_042,
+    });
+    observer.recordToolsList("srv", {
+      outcome: "ok",
+      startedAt: 1_042,
+      endedAt: 1_050,
+    });
+    const spans = observer.buildSyntheticSpans(500);
+    expect(spans).toEqual([
+      {
+        id: connectSpanId("srv"),
+        name: "connect",
+        category: "connection",
+        status: "error",
+        serverId: "srv",
+        startMs: 0,
+        endMs: 42,
+      },
+      {
+        id: toolsListSpanId("srv"),
+        name: "tools/list",
+        category: "discovery",
+        status: "ok",
+        serverId: "srv",
+        startMs: 0,
+        endMs: 8,
+      },
+    ]);
+  });
+
+  it("persists a bounded audit record with the folded signals", async () => {
+    const observer = createRunSetupObserver({
+      expectedServerIds: ["srv"],
+      canary: async () => true,
+      now: () => 99,
+    });
+    observer.recordConnect("srv", {
+      outcome: "failed",
+      error: nodeError("ECONNREFUSED"),
+      startedAt: 0,
+      endedAt: 1,
+    });
+    await observer.ensureEgressCanary();
+    const audit = observer.buildAuditMetadata();
+    expect(audit?.stageSetupSignals).toMatchObject({
+      connection: {
+        outcome: "failed",
+        attribution: "theirs",
+        egressVerified: true,
+      },
+    });
+    expect(audit?.egressCanary).toEqual({ ran: true, ok: true, at: 99 });
+    expect(JSON.stringify(audit).length).toBeLessThanOrEqual(2048);
+  });
+});

--- a/mcpjam-inspector/server/services/evals/__tests__/run-setup-signals.test.ts
+++ b/mcpjam-inspector/server/services/evals/__tests__/run-setup-signals.test.ts
@@ -261,6 +261,31 @@ describe("createRunSetupObserver canary + spans", () => {
     expect(JSON.stringify(audit).length).toBeLessThanOrEqual(2048);
   });
 
+  it("does not attach a failed canary to a theirs discovery after connect ok", async () => {
+    const canary = vi.fn(async () => false);
+    const observer = createRunSetupObserver({
+      expectedServerIds: ["srv"],
+      canary,
+    });
+    observer.recordConnect("srv", {
+      outcome: "ok",
+      startedAt: 0,
+      endedAt: 1,
+    });
+    observer.recordToolsList("srv", {
+      outcome: "failed",
+      error: nodeError("ECONNREFUSED"),
+      startedAt: 1,
+      endedAt: 2,
+    });
+    expect(observer.buildSignals()).toMatchObject({
+      connection: { outcome: "ok" },
+      discovery: { outcome: "failed", attribution: "theirs" },
+    });
+    expect(observer.buildSignals()?.discovery?.egressVerified).toBeUndefined();
+    expect(canary).not.toHaveBeenCalled();
+  });
+
   it("shares one canary promise instead of polling", async () => {
     let resolveCanary!: (ok: boolean) => void;
     const canary = vi.fn(

--- a/mcpjam-inspector/server/services/evals/__tests__/run-setup-signals.test.ts
+++ b/mcpjam-inspector/server/services/evals/__tests__/run-setup-signals.test.ts
@@ -4,6 +4,7 @@ import {
   EgressResolutionError,
 } from "../../../utils/hosted-egress-guard.js";
 import {
+  capSetupAuditMetadata,
   classifySetupAttribution,
   connectSpanId,
   createRunSetupObserver,
@@ -258,5 +259,47 @@ describe("createRunSetupObserver canary + spans", () => {
     });
     expect(audit?.egressCanary).toEqual({ ran: true, ok: true, at: 99 });
     expect(JSON.stringify(audit).length).toBeLessThanOrEqual(2048);
+  });
+
+  it("shares one canary promise instead of polling", async () => {
+    let resolveCanary!: (ok: boolean) => void;
+    const canary = vi.fn(
+      () =>
+        new Promise<boolean>((resolve) => {
+          resolveCanary = resolve;
+        })
+    );
+    const observer = createRunSetupObserver({
+      expectedServerIds: ["srv"],
+      canary,
+    });
+    const first = observer.ensureEgressCanary();
+    const second = observer.ensureEgressCanary();
+    expect(canary).toHaveBeenCalledTimes(1);
+    resolveCanary(true);
+    expect(await first).toBe(true);
+    expect(await second).toBe(true);
+    expect(await observer.ensureEgressCanary()).toBe(true);
+    expect(canary).toHaveBeenCalledTimes(1);
+  });
+
+  it("sheds span ids when the audit blob exceeds the cap", () => {
+    const raw = {
+      stageSetupSignals: {
+        connection: {
+          outcome: "failed" as const,
+          attribution: "theirs" as const,
+          spanIds: ["run-connect-aaaaaaaaaaaaaaaa"],
+        },
+      },
+      egressCanary: { ran: true, ok: true, at: 1 },
+    };
+    const capped = capSetupAuditMetadata(raw, 10);
+    expect(capped.truncated).toBe(true);
+    expect(
+      (capped.stageSetupSignals as { connection?: { spanIds?: string[] } })
+        .connection?.spanIds
+    ).toBeUndefined();
+    expect(JSON.stringify(capped).length).toBeLessThan(JSON.stringify(raw).length);
   });
 });

--- a/mcpjam-inspector/server/services/evals/__tests__/run-setup-signals.test.ts
+++ b/mcpjam-inspector/server/services/evals/__tests__/run-setup-signals.test.ts
@@ -8,7 +8,9 @@ import {
   classifySetupAttribution,
   connectSpanId,
   createRunSetupObserver,
+  SETUP_AUDIT_METADATA_KEY,
   toolsListSpanId,
+  type SetupAuditRecord,
 } from "../run-setup-signals.js";
 
 function nodeError(code: string, message = code): Error {
@@ -53,6 +55,34 @@ describe("classifySetupAttribution", () => {
 
   it("classifies everything else as unknown", () => {
     expect(classifySetupAttribution(new Error("something odd"))).toBe("unknown");
+  });
+
+  // A cancelled run says NOTHING about the target server. Without this arm
+  // an abort classifies `unknown`, and an `unknown` tools/list failure on a
+  // server whose initialize completed derives `discovery: failed` — the
+  // user pressing stop, reported as the server's fault.
+  it("classifies our own cancellation as ours, by name and by code", () => {
+    const abort = new Error("The operation was aborted");
+    abort.name = "AbortError";
+    expect(classifySetupAttribution(abort)).toBe("ours");
+    expect(classifySetupAttribution(nodeError("ABORT_ERR"))).toBe("ours");
+    expect(classifySetupAttribution(nodeError("ERR_CANCELED"))).toBe("ours");
+    const canceled = new Error("canceled");
+    canceled.name = "CanceledError";
+    expect(classifySetupAttribution(canceled)).toBe("ours");
+    expect(
+      classifySetupAttribution(new Error("This operation was aborted"))
+    ).toBe("ours");
+  });
+
+  // The guard on the cancellation heuristic: ECONNABORTED contains the word
+  // "aborted" and is a real peer-side reset, so a loose /abort/i would flip
+  // a measurable server failure into a setup abort.
+  it("keeps ECONNABORTED as theirs — the word 'aborted' is not enough", () => {
+    expect(classifySetupAttribution(nodeError("ECONNABORTED"))).toBe("theirs");
+    expect(
+      classifySetupAttribution(new Error("connect ECONNABORTED 10.0.0.1:443"))
+    ).toBe("theirs");
   });
 });
 
@@ -137,6 +167,22 @@ describe("createRunSetupObserver folding", () => {
       outcome: "failed",
       attribution: "unknown",
     });
+  });
+
+  // Absence of evidence, not evidence of failure: when connect fails for
+  // every target, tools/list never runs, so the phase reports nothing and
+  // the stage falls through to `notReached` behind the connection failure.
+  it("emits no signal for a phase that never ran for any target", () => {
+    const observer = createRunSetupObserver({ expectedServerIds: ["a"] });
+    observer.recordConnect("a", {
+      outcome: "failed",
+      error: nodeError("ECONNREFUSED"),
+      startedAt: 0,
+      endedAt: 1,
+    });
+    const signals = observer.buildSignals();
+    expect(signals?.connection).toMatchObject({ outcome: "failed" });
+    expect(signals?.discovery).toBeUndefined();
   });
 
   it("caps culprit span ids at 5", () => {
@@ -250,14 +296,19 @@ describe("createRunSetupObserver canary + spans", () => {
     });
     await observer.ensureEgressCanary();
     const audit = observer.buildAuditMetadata();
-    expect(audit?.stageSetupSignals).toMatchObject({
+    // ONE top-level metadata key. Iteration metadata is a flat open record
+    // shared by every producer, so the audit record nests rather than
+    // scattering generic words like `egressCanary` across it.
+    expect(Object.keys(audit ?? {})).toEqual([SETUP_AUDIT_METADATA_KEY]);
+    const record = audit?.[SETUP_AUDIT_METADATA_KEY] as SetupAuditRecord;
+    expect(record.signals).toMatchObject({
       connection: {
         outcome: "failed",
         attribution: "theirs",
         egressVerified: true,
       },
     });
-    expect(audit?.egressCanary).toEqual({ ran: true, ok: true, at: 99 });
+    expect(record.egressCanary).toEqual({ ran: true, ok: true, at: 99 });
     expect(JSON.stringify(audit).length).toBeLessThanOrEqual(2048);
   });
 
@@ -286,6 +337,29 @@ describe("createRunSetupObserver canary + spans", () => {
     expect(canary).not.toHaveBeenCalled();
   });
 
+  // "we did not check" and "we checked and our egress is down" are
+  // different states. Only an explicit `true` may ever earn
+  // `connection: failed`, so an unrun canary leaves the field absent
+  // rather than stamping a false.
+  it("omits egressVerified entirely when the canary never ran", () => {
+    const observer = createRunSetupObserver({
+      expectedServerIds: ["srv"],
+      canary: async () => true,
+    });
+    observer.recordConnect("srv", {
+      outcome: "failed",
+      error: nodeError("ECONNREFUSED"),
+      startedAt: 0,
+      endedAt: 1,
+    });
+    const connection = observer.buildSignals()?.connection;
+    expect(connection).toMatchObject({
+      outcome: "failed",
+      attribution: "theirs",
+    });
+    expect(connection && "egressVerified" in connection).toBe(false);
+  });
+
   it("shares one canary promise instead of polling", async () => {
     let resolveCanary!: (ok: boolean) => void;
     const canary = vi.fn(
@@ -310,7 +384,7 @@ describe("createRunSetupObserver canary + spans", () => {
 
   it("sheds span ids when the audit blob exceeds the cap", () => {
     const raw = {
-      stageSetupSignals: {
+      signals: {
         connection: {
           outcome: "failed" as const,
           attribution: "theirs" as const,
@@ -321,10 +395,7 @@ describe("createRunSetupObserver canary + spans", () => {
     };
     const capped = capSetupAuditMetadata(raw, 10);
     expect(capped.truncated).toBe(true);
-    expect(
-      (capped.stageSetupSignals as { connection?: { spanIds?: string[] } })
-        .connection?.spanIds
-    ).toBeUndefined();
+    expect(capped.signals.connection?.spanIds).toBeUndefined();
     expect(JSON.stringify(capped).length).toBeLessThan(JSON.stringify(raw).length);
   });
 });

--- a/mcpjam-inspector/server/services/evals/__tests__/runner-parity.test.ts
+++ b/mcpjam-inspector/server/services/evals/__tests__/runner-parity.test.ts
@@ -199,6 +199,8 @@ describe("runner parity (golden Convex payload + event sequence)", () => {
   };
   const mcpClientManager = {
     getToolsForAiSdk: vi.fn(),
+    listTools: vi.fn(),
+    getConnectionStatus: vi.fn(),
     listServers: vi.fn(),
     getAllToolsMetadata: vi.fn().mockReturnValue({}),
     // Pinned (`toolCall`) turns execute directly; inert for prompt-only cases.
@@ -218,6 +220,8 @@ describe("runner parity (golden Convex payload + event sequence)", () => {
     convexClient.query.mockResolvedValue({ status: "running" });
     convexClient.action.mockResolvedValue(undefined);
     mcpClientManager.getToolsForAiSdk.mockResolvedValue({});
+    mcpClientManager.listTools.mockResolvedValue({ tools: [] });
+    mcpClientManager.getConnectionStatus.mockReturnValue("connected");
     mcpClientManager.listServers.mockReturnValue(["srv-1"]);
     streamTextMock.mockReturnValue({
       consumeStream: async () => {},

--- a/mcpjam-inspector/server/services/evals/eval-trace-capture.ts
+++ b/mcpjam-inspector/server/services/evals/eval-trace-capture.ts
@@ -741,6 +741,22 @@ export function pushAiSdkTrailingErrorSpan(
   });
 }
 
+/**
+ * Append synthetic run-level connect / tools-list spans.
+ *
+ * Position is clamped to offset 0 (they happen above the iteration
+ * boundary); duration is whatever the observer already preserved.
+ * These spans are persistence/timeline-only — they never enter stage
+ * derivation evidence.
+ */
+export function pushRunSetupSpans(
+  spans: EvalTraceSpan[],
+  setupSpans: readonly EvalTraceSpan[],
+): void {
+  if (setupSpans.length === 0) return;
+  spans.unshift(...setupSpans);
+}
+
 export function wrapBackendToolsForTrace<T extends Record<string, unknown>>(
   tools: T,
   params: {

--- a/mcpjam-inspector/server/services/evals/finalize-iteration.ts
+++ b/mcpjam-inspector/server/services/evals/finalize-iteration.ts
@@ -221,8 +221,9 @@ export function buildIterationFinishParams(args: {
   toolSignals?: ToolExposureSignals;
   /**
    * Folded run-level connect / tools-list evidence. Threaded into the
-   * analyzer; also persisted under `metadata.stageSetupSignals` so a v2
-   * verdict can be audited or recomputed.
+   * analyzer; the same signals are also persisted under
+   * `metadata.stageSetupAudit.signals` (see `setupAudit`) so a v2 verdict
+   * can be audited or recomputed.
    */
   setupSignals?: StageSetupSignals;
   /**

--- a/mcpjam-inspector/server/services/evals/finalize-iteration.ts
+++ b/mcpjam-inspector/server/services/evals/finalize-iteration.ts
@@ -29,6 +29,7 @@ import {
   deriveStageResults,
   stageDerivationToMetadata,
   type StageAuthoredCase,
+  type StageSetupSignals,
 } from "@mcpjam/sdk/contract";
 import {
   lockEvalSessionAfterUpdate,
@@ -67,6 +68,7 @@ function buildStageEvidence(args: {
    */
   toolErrors?: unknown[];
   toolSignals?: ToolExposureSignals;
+  setupSignals?: StageSetupSignals;
 }) {
   const hasSpans = (args.spans?.length ?? 0) > 0;
   const hasPrompts = (args.prompts?.length ?? 0) > 0;
@@ -94,6 +96,7 @@ function buildStageEvidence(args: {
         }
       : {}),
     ...(args.toolSignals ? { toolSignals: args.toolSignals } : {}),
+    ...(args.setupSignals ? { setupSignals: args.setupSignals } : {}),
     traceAbsent: !hasSpans && !hasPrompts && !hasMessages,
     traceLacksSpanChannel: !hasSpans && (hasPrompts || hasMessages),
   };
@@ -121,6 +124,7 @@ export function buildStageMetadata(args: {
   widgetRenderObservations?: RunnerWidgetRenderObservation[];
   stageToolErrors?: unknown[];
   toolSignals?: ToolExposureSignals;
+  setupSignals?: StageSetupSignals;
   status: "completed" | "failed";
   error?: string;
 }): Record<string, unknown> {
@@ -137,6 +141,7 @@ export function buildStageMetadata(args: {
         widgetRenderObservations: args.widgetRenderObservations,
         toolErrors: args.stageToolErrors,
         toolSignals: args.toolSignals,
+        setupSignals: args.setupSignals,
       }),
       iteration: { status, ...(error ? { error } : {}) },
     }),
@@ -214,6 +219,19 @@ export function buildIterationFinishParams(args: {
   iterationMetadataBase: Record<string, string | number | boolean>;
   hostPolicy?: HostExecutionPolicy;
   toolSignals?: ToolExposureSignals;
+  /**
+   * Folded run-level connect / tools-list evidence. Threaded into the
+   * analyzer; also persisted under `metadata.stageSetupSignals` so a v2
+   * verdict can be audited or recomputed.
+   */
+  setupSignals?: StageSetupSignals;
+  /**
+   * Synthetic connection/discovery spans. Persisted on the trace (timeline)
+   * but never enter stage-derivation evidence.
+   */
+  setupSpans?: EvalTraceSpan[];
+  /** Bounded canary/audit extras from the run-setup observer. */
+  setupAudit?: Record<string, unknown>;
   injectOpenAiCompat?: boolean;
 }): Omit<FinalizeEvalIterationParams, "convexClient" | "videoBytes"> {
   const {
@@ -241,8 +259,15 @@ export function buildIterationFinishParams(args: {
     iterationMetadataBase,
     hostPolicy,
     toolSignals,
+    setupSignals,
+    setupSpans,
+    setupAudit,
     injectOpenAiCompat,
   } = args;
+  const persistedSpans = [
+    ...(setupSpans ?? []),
+    ...(spans ?? []),
+  ];
   const stageMetadata = buildStageMetadata({
     ...(stageCase ? { stageCase } : {}),
     spans,
@@ -252,6 +277,7 @@ export function buildIterationFinishParams(args: {
     widgetRenderObservations,
     stageToolErrors,
     toolSignals,
+    setupSignals,
     status,
     ...(error ? { error } : {}),
   });
@@ -263,7 +289,7 @@ export function buildIterationFinishParams(args: {
     messages,
     ...(modelId ? { modelId } : {}),
     ...(systemPrompt ? { systemPrompt } : {}),
-    ...(spans?.length ? { spans } : {}),
+    ...(persistedSpans.length ? { spans: persistedSpans } : {}),
     ...(prompts?.length ? { prompts } : {}),
     ...(widgetSnapshots?.length ? { widgetSnapshots } : {}),
     ...(widgetRenderObservations?.length ? { widgetRenderObservations } : {}),
@@ -280,6 +306,7 @@ export function buildIterationFinishParams(args: {
       ...(skippedSteps?.length ? { skippedSteps } : {}),
       ...(stepResults?.length ? { stepResults } : {}),
       ...stageMetadata,
+      ...(setupAudit ?? {}),
       ...(hostPolicy && toolSignals
         ? buildHostIterationMetadata(
             hostPolicy,

--- a/mcpjam-inspector/server/services/evals/run-setup-signals.ts
+++ b/mcpjam-inspector/server/services/evals/run-setup-signals.ts
@@ -1,0 +1,450 @@
+/**
+ * Run-level connect / tools-list observation for D6.
+ *
+ * Connect and tools-list happen once per run, above the iteration boundary
+ * where no span sink exists. This observer records every expected target,
+ * folds them deterministically, and emits:
+ *
+ *   - `StageSetupSignals` — the derivation input (never spans)
+ *   - synthetic `connection` / `discovery` spans — persistence/timeline only
+ *
+ * Multi-server observation is race-free: callers must use a two-phase
+ * `Promise.allSettled` barrier (all connects, then all tools-lists) so every
+ * expected target is observed before `buildSignals`.
+ */
+
+import {
+  classifyNegotiationFailureClass,
+  unwrapEraNegotiationCause,
+} from "@mcpjam/sdk";
+import type { StageSetupPhaseSignal, StageSetupSignals } from "@mcpjam/sdk/contract";
+import type { EvalTraceSpan } from "@/shared/eval-trace";
+import { HOSTED_MODE } from "../../config.js";
+import { createPinnedFetch } from "../../utils/pinned-fetch.js";
+import {
+  BlockedEgressTargetError,
+  EgressResolutionError,
+} from "../../utils/hosted-egress-guard.js";
+
+export type SetupAttribution = "ours" | "theirs" | "unknown";
+export type SetupPhase = "connection" | "discovery";
+
+export type SetupTargetObservation = {
+  serverId: string;
+  outcome: "ok" | "failed";
+  attribution?: SetupAttribution;
+  error?: unknown;
+  startedAt: number;
+  endedAt: number;
+};
+
+const TRANSPORT_LOCAL_MCP_CODES = new Set([-32000, -32001]);
+const OURS_NODE_CODES = new Set([
+  "ENOTFOUND",
+  "EAI_AGAIN",
+  "EAI_FAIL",
+  "EAI_NODATA",
+  "EAI_NONAME",
+]);
+const THEIRS_NODE_CODES = new Set([
+  "ECONNREFUSED",
+  "ECONNRESET",
+  "ECONNABORTED",
+  "ETIMEDOUT",
+  "ESOCKETTIMEDOUT",
+  "UND_ERR_CONNECT_TIMEOUT",
+  "UND_ERR_SOCKET",
+]);
+
+const MAX_CULPRIT_SPAN_IDS = 5;
+const CANARY_TIMEOUT_MS = 5_000;
+const SETUP_SIGNALS_METADATA_CAP_BYTES = 2_048;
+
+export function connectSpanId(serverId: string): string {
+  return `run-connect-${serverId}`;
+}
+
+export function toolsListSpanId(serverId: string): string {
+  return `run-toolslist-${serverId}`;
+}
+
+function numericField(error: unknown, key: string): number | undefined {
+  if (!error || typeof error !== "object") return undefined;
+  const value = (error as Record<string, unknown>)[key];
+  return typeof value === "number" ? value : undefined;
+}
+
+function stringField(error: unknown, key: string): string | undefined {
+  if (!error || typeof error !== "object") return undefined;
+  const value = (error as Record<string, unknown>)[key];
+  return typeof value === "string" ? value : undefined;
+}
+
+function collectMessage(error: unknown): string {
+  if (error instanceof Error) return error.message;
+  if (typeof error === "string") return error;
+  return "";
+}
+
+/**
+ * Classify a connect / tools-list failure for D6 attribution.
+ *
+ *   ours   — DNS (`EgressResolutionError` / ENOTFOUND), blocked egress,
+ *            401/403 (suite-credential config), MCP −32000/−32001
+ *   theirs — refused / TLS / timeout-to-their-host / 5xx
+ *   unknown — everything else
+ *
+ * Reuses hosted-egress-guard error types and the era-negotiation unwrap so a
+ * wrapped transport failure is classified on the real cause.
+ */
+export function classifySetupAttribution(error: unknown): SetupAttribution {
+  const cause = unwrapEraNegotiationCause(error);
+
+  if (cause instanceof EgressResolutionError) return "ours";
+  if (cause instanceof BlockedEgressTargetError) return "ours";
+
+  const status =
+    numericField(cause, "statusCode") ??
+    numericField(cause, "status") ??
+    (typeof numericField(cause, "code") === "number" &&
+    (numericField(cause, "code") as number) >= 100 &&
+    (numericField(cause, "code") as number) <= 599
+      ? numericField(cause, "code")
+      : undefined);
+
+  if (status === 401 || status === 403) return "ours";
+  if (status !== undefined && status >= 500) return "theirs";
+
+  const mcpCode =
+    numericField(cause, "mcpErrorCode") ??
+    (typeof numericField(cause, "code") === "number" &&
+    (numericField(cause, "code") as number) < 0
+      ? numericField(cause, "code")
+      : undefined);
+  if (mcpCode !== undefined && TRANSPORT_LOCAL_MCP_CODES.has(mcpCode)) {
+    return "ours";
+  }
+
+  const nodeCode =
+    stringField(cause, "code") ??
+    (typeof numericField(cause, "code") === "number"
+      ? undefined
+      : stringField(error, "code"));
+  if (nodeCode && OURS_NODE_CODES.has(nodeCode)) return "ours";
+  if (nodeCode && THEIRS_NODE_CODES.has(nodeCode)) return "theirs";
+
+  const klass = classifyNegotiationFailureClass(cause);
+  if (klass === "UnauthorizedError" || klass === "401" || klass === "403") {
+    return "ours";
+  }
+  if (OURS_NODE_CODES.has(klass)) return "ours";
+  if (THEIRS_NODE_CODES.has(klass)) return "theirs";
+
+  const message = `${klass} ${collectMessage(cause)} ${collectMessage(error)}`;
+  if (/\b401\b|\b403\b|unauthorized|forbidden/i.test(message)) return "ours";
+  if (
+    /ECONNREFUSED|ECONNRESET|ECONNABORTED|ETIMEDOUT|ESOCKETTIMEDOUT|UND_ERR_CONNECT_TIMEOUT/i.test(
+      message
+    )
+  ) {
+    return "theirs";
+  }
+  if (/certificate|CERT_|UNABLE_TO_VERIFY|SSL|TLS|ERR_TLS/i.test(message)) {
+    return "theirs";
+  }
+  if (/ENOTFOUND|EAI_AGAIN|getaddrinfo/i.test(message)) return "ours";
+  if (/\b5\d\d\b/.test(message) && /status|http|server/i.test(message)) {
+    return "theirs";
+  }
+
+  return "unknown";
+}
+
+function foldAttribution(
+  failures: readonly SetupTargetObservation[]
+): SetupAttribution {
+  if (failures.some((f) => f.attribution === "ours")) return "ours";
+  if (failures.some((f) => f.attribution === "unknown" || !f.attribution)) {
+    return "unknown";
+  }
+  return "theirs";
+}
+
+function foldPhase(
+  expectedIds: readonly string[],
+  observations: ReadonlyMap<string, SetupTargetObservation>,
+  spanIdFor: (serverId: string) => string
+): StageSetupPhaseSignal | undefined {
+  if (expectedIds.length === 0) return undefined;
+
+  const observed: SetupTargetObservation[] = [];
+  const missing: string[] = [];
+  for (const id of expectedIds) {
+    const row = observations.get(id);
+    if (!row) missing.push(id);
+    else observed.push(row);
+  }
+
+  const failures = observed.filter((row) => row.outcome === "failed");
+  // A target that never settled is an incomplete observation → unknown.
+  if (missing.length > 0) {
+    return {
+      outcome: "failed",
+      attribution: foldAttribution([
+        ...failures,
+        ...missing.map((serverId) => ({
+          serverId,
+          outcome: "failed" as const,
+          attribution: "unknown" as const,
+          startedAt: 0,
+          endedAt: 0,
+        })),
+      ]),
+      spanIds: [...failures, ...missing.map((id) => ({ serverId: id }))]
+        .map((row) => spanIdFor(row.serverId))
+        .slice(0, MAX_CULPRIT_SPAN_IDS),
+    };
+  }
+
+  if (failures.length > 0) {
+    return {
+      outcome: "failed",
+      attribution: foldAttribution(failures),
+      spanIds: failures
+        .map((row) => spanIdFor(row.serverId))
+        .slice(0, MAX_CULPRIT_SPAN_IDS),
+    };
+  }
+
+  if (observed.every((row) => row.outcome === "ok")) {
+    return { outcome: "ok" };
+  }
+
+  return {
+    outcome: "failed",
+    attribution: "unknown",
+  };
+}
+
+export type RunSetupObserver = {
+  recordConnect: (
+    serverId: string,
+    init: {
+      outcome: "ok" | "failed";
+      error?: unknown;
+      startedAt: number;
+      endedAt: number;
+    }
+  ) => void;
+  recordToolsList: (
+    serverId: string,
+    init: {
+      outcome: "ok" | "failed";
+      error?: unknown;
+      startedAt: number;
+      endedAt: number;
+    }
+  ) => void;
+  hasConnect: (serverId: string) => boolean;
+  hasToolsList: (serverId: string) => boolean;
+  connectOutcome: (serverId: string) => "ok" | "failed" | undefined;
+  /**
+   * Lazy, once per run, only on a theirs-shaped failure. Never called for
+   * `ours`. Returns whether `GET ${convexHttpUrl}/health` succeeded.
+   */
+  ensureEgressCanary: () => Promise<boolean>;
+  buildSignals: () => StageSetupSignals | undefined;
+  buildSyntheticSpans: (runStartedAt: number) => EvalTraceSpan[];
+  /**
+   * Bounded producer-owned audit record. Open metadata; the backend ignores
+   * it. Hard-capped so a v2 verdict can be recomputed without an unbounded blob.
+   */
+  buildAuditMetadata: () => Record<string, unknown> | undefined;
+};
+
+export type CreateRunSetupObserverOptions = {
+  expectedServerIds: readonly string[];
+  convexHttpUrl?: string;
+  /** Injected canary. Tests stub this so we never touch the control plane. */
+  canary?: () => Promise<boolean>;
+  now?: () => number;
+};
+
+async function defaultCanary(convexHttpUrl: string): Promise<boolean> {
+  const pinned = createPinnedFetch({
+    timeoutMs: CANARY_TIMEOUT_MS,
+    allowLoopback: !HOSTED_MODE,
+  });
+  const url = `${convexHttpUrl.replace(/\/+$/, "")}/health`;
+  const response = await pinned(url);
+  return response.ok;
+}
+
+export function createRunSetupObserver(
+  options: CreateRunSetupObserverOptions
+): RunSetupObserver {
+  const expected = [...options.expectedServerIds];
+  const connects = new Map<string, SetupTargetObservation>();
+  const lists = new Map<string, SetupTargetObservation>();
+  let canaryResult: boolean | undefined;
+  let canaryStarted = false;
+
+  const record = (
+    into: Map<string, SetupTargetObservation>,
+    serverId: string,
+    init: {
+      outcome: "ok" | "failed";
+      error?: unknown;
+      startedAt: number;
+      endedAt: number;
+    }
+  ) => {
+    const attribution =
+      init.outcome === "failed"
+        ? classifySetupAttribution(init.error)
+        : undefined;
+    into.set(serverId, {
+      serverId,
+      outcome: init.outcome,
+      ...(attribution ? { attribution } : {}),
+      ...(init.error !== undefined ? { error: init.error } : {}),
+      startedAt: init.startedAt,
+      endedAt: init.endedAt,
+    });
+  };
+
+  const ensureEgressCanary = async (): Promise<boolean> => {
+    if (canaryResult !== undefined) return canaryResult;
+    if (canaryStarted) {
+      // In-flight: wait by polling the settled slot. The canary is one GET.
+      while (canaryResult === undefined) {
+        await new Promise((resolve) => setTimeout(resolve, 5));
+      }
+      return canaryResult;
+    }
+    canaryStarted = true;
+    try {
+      if (options.canary) {
+        canaryResult = await options.canary();
+      } else if (options.convexHttpUrl) {
+        canaryResult = await defaultCanary(options.convexHttpUrl);
+      } else {
+        canaryResult = false;
+      }
+    } catch {
+      canaryResult = false;
+    }
+    return canaryResult;
+  };
+
+  const buildSignals = (): StageSetupSignals | undefined => {
+    if (expected.length === 0) return undefined;
+    const connection = foldPhase(expected, connects, connectSpanId);
+    const discovery = foldPhase(expected, lists, toolsListSpanId);
+    if (!connection && !discovery) return undefined;
+
+    const attachCanary = (
+      signal: StageSetupPhaseSignal | undefined
+    ): StageSetupPhaseSignal | undefined => {
+      if (!signal || signal.outcome !== "failed") return signal;
+      if (signal.attribution !== "theirs") return signal;
+      return {
+        ...signal,
+        egressVerified: canaryResult === true,
+      };
+    };
+
+    return {
+      ...(connection ? { connection: attachCanary(connection) } : {}),
+      ...(discovery ? { discovery: attachCanary(discovery) } : {}),
+    };
+  };
+
+  return {
+    recordConnect: (serverId, init) => record(connects, serverId, init),
+    recordToolsList: (serverId, init) => record(lists, serverId, init),
+    hasConnect: (serverId) => connects.has(serverId),
+    hasToolsList: (serverId) => lists.has(serverId),
+    connectOutcome: (serverId) => connects.get(serverId)?.outcome,
+    ensureEgressCanary,
+    buildSignals,
+    buildSyntheticSpans: (runStartedAt) =>
+      buildSyntheticSetupSpans({
+        expected,
+        connects,
+        lists,
+        runStartedAt,
+      }),
+    buildAuditMetadata: () => {
+      const signals = buildSignals();
+      if (!signals) return undefined;
+      const raw = {
+        stageSetupSignals: signals,
+        egressCanary:
+          canaryResult === undefined
+            ? { ran: false }
+            : {
+                ran: true,
+                ok: canaryResult,
+                at: (options.now ?? Date.now)(),
+              },
+      };
+      const serialized = JSON.stringify(raw);
+      if (serialized.length <= SETUP_SIGNALS_METADATA_CAP_BYTES) return raw;
+      return {
+        stageSetupSignals: signals,
+        egressCanary: raw.egressCanary,
+        truncated: true,
+      };
+    },
+  };
+}
+
+function clampSpanToOffsetZero(
+  startedAt: number,
+  endedAt: number
+): { startMs: number; endMs: number } {
+  const duration = Math.max(1, endedAt - startedAt);
+  return { startMs: 0, endMs: duration };
+}
+
+function buildSyntheticSetupSpans(args: {
+  expected: readonly string[];
+  connects: ReadonlyMap<string, SetupTargetObservation>;
+  lists: ReadonlyMap<string, SetupTargetObservation>;
+  runStartedAt: number;
+}): EvalTraceSpan[] {
+  const spans: EvalTraceSpan[] = [];
+  for (const serverId of args.expected) {
+    const connect = args.connects.get(serverId);
+    if (connect) {
+      spans.push({
+        id: connectSpanId(serverId),
+        name: "connect",
+        category: "connection",
+        status: connect.outcome === "ok" ? "ok" : "error",
+        serverId,
+        ...clampSpanToOffsetZero(connect.startedAt, connect.endedAt),
+      });
+    }
+    const list = args.lists.get(serverId);
+    if (list) {
+      spans.push({
+        id: toolsListSpanId(serverId),
+        name: "tools/list",
+        category: "discovery",
+        status: list.outcome === "ok" ? "ok" : "error",
+        serverId,
+        ...clampSpanToOffsetZero(list.startedAt, list.endedAt),
+      });
+    }
+  }
+  void args.runStartedAt;
+  return spans;
+}
+
+export function isTheirsAttribution(
+  attribution: SetupAttribution | undefined
+): boolean {
+  return attribution === "theirs";
+}

--- a/mcpjam-inspector/server/services/evals/run-setup-signals.ts
+++ b/mcpjam-inspector/server/services/evals/run-setup-signals.ts
@@ -60,6 +60,47 @@ const MAX_CULPRIT_SPAN_IDS = 5;
 const CANARY_TIMEOUT_MS = 5_000;
 const SETUP_SIGNALS_METADATA_CAP_BYTES = 2_048;
 
+function slimPhaseSignal(
+  signal: StageSetupPhaseSignal | undefined
+): StageSetupPhaseSignal | undefined {
+  if (!signal) return undefined;
+  return {
+    outcome: signal.outcome,
+    ...(signal.attribution ? { attribution: signal.attribution } : {}),
+    ...(signal.egressVerified !== undefined
+      ? { egressVerified: signal.egressVerified }
+      : {}),
+  };
+}
+
+/**
+ * Hard-cap the producer-owned audit blob. Over the cap, drop span ids so
+ * the serialized payload shrinks; `truncated: true` marks the shed.
+ */
+export function capSetupAuditMetadata(
+  raw: {
+    stageSetupSignals: StageSetupSignals;
+    egressCanary: unknown;
+  },
+  capBytes: number = SETUP_SIGNALS_METADATA_CAP_BYTES
+): Record<string, unknown> {
+  const serialized = JSON.stringify(raw);
+  if (serialized.length <= capBytes) return raw;
+  const signals = raw.stageSetupSignals;
+  return {
+    stageSetupSignals: {
+      ...(signals.connection
+        ? { connection: slimPhaseSignal(signals.connection) }
+        : {}),
+      ...(signals.discovery
+        ? { discovery: slimPhaseSignal(signals.discovery) }
+        : {}),
+    },
+    egressCanary: raw.egressCanary,
+    truncated: true,
+  };
+}
+
 export function connectSpanId(serverId: string): string {
   return `run-connect-${serverId}`;
 }
@@ -287,7 +328,7 @@ export function createRunSetupObserver(
   const connects = new Map<string, SetupTargetObservation>();
   const lists = new Map<string, SetupTargetObservation>();
   let canaryResult: boolean | undefined;
-  let canaryStarted = false;
+  let canaryPromise: Promise<boolean> | undefined;
 
   const record = (
     into: Map<string, SetupTargetObservation>,
@@ -315,25 +356,16 @@ export function createRunSetupObserver(
 
   const ensureEgressCanary = async (): Promise<boolean> => {
     if (canaryResult !== undefined) return canaryResult;
-    if (canaryStarted) {
-      // In-flight: wait by polling the settled slot. The canary is one GET.
-      while (canaryResult === undefined) {
-        await new Promise((resolve) => setTimeout(resolve, 5));
+    canaryPromise ??= (async () => {
+      try {
+        if (options.canary) return await options.canary();
+        if (options.convexHttpUrl) return await defaultCanary(options.convexHttpUrl);
+        return false;
+      } catch {
+        return false;
       }
-      return canaryResult;
-    }
-    canaryStarted = true;
-    try {
-      if (options.canary) {
-        canaryResult = await options.canary();
-      } else if (options.convexHttpUrl) {
-        canaryResult = await defaultCanary(options.convexHttpUrl);
-      } else {
-        canaryResult = false;
-      }
-    } catch {
-      canaryResult = false;
-    }
+    })();
+    canaryResult = await canaryPromise;
     return canaryResult;
   };
 
@@ -378,24 +410,20 @@ export function createRunSetupObserver(
     buildAuditMetadata: () => {
       const signals = buildSignals();
       if (!signals) return undefined;
-      const raw = {
-        stageSetupSignals: signals,
-        egressCanary:
-          canaryResult === undefined
-            ? { ran: false }
-            : {
-                ran: true,
-                ok: canaryResult,
-                at: (options.now ?? Date.now)(),
-              },
-      };
-      const serialized = JSON.stringify(raw);
-      if (serialized.length <= SETUP_SIGNALS_METADATA_CAP_BYTES) return raw;
-      return {
-        stageSetupSignals: signals,
-        egressCanary: raw.egressCanary,
-        truncated: true,
-      };
+      return capSetupAuditMetadata(
+        {
+          stageSetupSignals: signals,
+          egressCanary:
+            canaryResult === undefined
+              ? { ran: false }
+              : {
+                  ran: true,
+                  ok: canaryResult,
+                  at: (options.now ?? Date.now)(),
+                },
+        },
+        SETUP_SIGNALS_METADATA_CAP_BYTES
+      );
     },
   };
 }

--- a/mcpjam-inspector/server/services/evals/run-setup-signals.ts
+++ b/mcpjam-inspector/server/services/evals/run-setup-signals.ts
@@ -375,7 +375,10 @@ export function createRunSetupObserver(
     const discovery = foldPhase(expected, lists, toolsListSpanId);
     if (!connection && !discovery) return undefined;
 
-    const attachCanary = (
+    // Canary is connection-only. A completed initialize is the egress
+    // evidence for discovery; stamping a failed control-plane GET onto a
+    // tools/list miss would lie about whether we reached their host.
+    const attachConnectionCanary = (
       signal: StageSetupPhaseSignal | undefined
     ): StageSetupPhaseSignal | undefined => {
       if (!signal || signal.outcome !== "failed") return signal;
@@ -387,8 +390,8 @@ export function createRunSetupObserver(
     };
 
     return {
-      ...(connection ? { connection: attachCanary(connection) } : {}),
-      ...(discovery ? { discovery: attachCanary(discovery) } : {}),
+      ...(connection ? { connection: attachConnectionCanary(connection) } : {}),
+      ...(discovery ? { discovery } : {}),
     };
   };
 

--- a/mcpjam-inspector/server/services/evals/run-setup-signals.ts
+++ b/mcpjam-inspector/server/services/evals/run-setup-signals.ts
@@ -8,9 +8,15 @@
  *   - `StageSetupSignals` — the derivation input (never spans)
  *   - synthetic `connection` / `discovery` spans — persistence/timeline only
  *
- * Multi-server observation is race-free: callers must use a two-phase
- * `Promise.allSettled` barrier (all connects, then all tools-lists) so every
- * expected target is observed before `buildSignals`.
+ * Multi-server observation is race-free: the caller must settle EVERY
+ * expected target (`Promise.allSettled`, which unlike `Promise.all` does not
+ * abort in-flight siblings) before calling `buildSignals`. Folding while one
+ * server's connect is still open would let a discovery failure decide the
+ * chain ahead of a connection failure that had not landed yet.
+ *
+ * Connect and tools/list are observed from ONE `getToolsForAiSdk` call per
+ * server — it ensures the session and lists in a single round trip, so
+ * probing them separately would bill the customer's server twice.
  */
 
 import {
@@ -74,21 +80,37 @@ function slimPhaseSignal(
 }
 
 /**
+ * The ONE metadata key this module owns.
+ *
+ * Everything the audit record carries nests under it. Iteration metadata is
+ * a flat open record shared by every producer, so a bare `truncated` (or
+ * `egressCanary`) at top level is a name collision waiting for the next
+ * writer that wants the same generic word.
+ */
+export const SETUP_AUDIT_METADATA_KEY = "stageSetupAudit";
+
+export type SetupAuditRecord = {
+  signals: StageSetupSignals;
+  egressCanary: unknown;
+  truncated?: true;
+};
+
+/**
  * Hard-cap the producer-owned audit blob. Over the cap, drop span ids so
  * the serialized payload shrinks; `truncated: true` marks the shed.
  */
 export function capSetupAuditMetadata(
   raw: {
-    stageSetupSignals: StageSetupSignals;
+    signals: StageSetupSignals;
     egressCanary: unknown;
   },
   capBytes: number = SETUP_SIGNALS_METADATA_CAP_BYTES
-): Record<string, unknown> {
+): SetupAuditRecord {
   const serialized = JSON.stringify(raw);
   if (serialized.length <= capBytes) return raw;
-  const signals = raw.stageSetupSignals;
+  const signals = raw.signals;
   return {
-    stageSetupSignals: {
+    signals: {
       ...(signals.connection
         ? { connection: slimPhaseSignal(signals.connection) }
         : {}),
@@ -127,11 +149,47 @@ function collectMessage(error: unknown): string {
   return "";
 }
 
+const CANCELLATION_ERROR_NAMES = new Set(["AbortError", "CanceledError"]);
+const CANCELLATION_CODES = new Set([
+  "ABORT_ERR",
+  "ERR_CANCELED",
+  "ERR_CANCELLED",
+]);
+
+/**
+ * True when the failure is OUR cancellation — the caller aborted, the run
+ * was stopped, the deadline fired — rather than anything the target did.
+ *
+ * Matched structurally (error `name` / `code`) and, only as a fallback, on
+ * phrases that cannot appear in a transport error. A loose `/abort/i` on
+ * the message would swallow `ECONNABORTED`, which is a real peer-side reset
+ * and belongs to `theirs`; that is why this never tests the bare word.
+ *
+ * Without this arm a cancelled run classifies `unknown`, and an `unknown`
+ * tools/list failure on a server whose initialize completed derives
+ * `discovery: failed` — reporting a user pressing stop as the server's
+ * fault, which is exactly the confidently-wrong funnel top D6 exists to
+ * prevent.
+ */
+function isCancellation(error: unknown, cause: unknown): boolean {
+  for (const candidate of [cause, error]) {
+    const name = stringField(candidate, "name");
+    if (name && CANCELLATION_ERROR_NAMES.has(name)) return true;
+    const code = stringField(candidate, "code");
+    if (code && CANCELLATION_CODES.has(code)) return true;
+  }
+  const message = `${collectMessage(cause)} ${collectMessage(error)}`;
+  return /\boperation was aborted\b|\brequest (?:was )?(?:aborted|cancell?ed)\b|\baborted by (?:the )?(?:user|caller)\b|\bthe user aborted a request\b/i.test(
+    message
+  );
+}
+
 /**
  * Classify a connect / tools-list failure for D6 attribution.
  *
- *   ours   — DNS (`EgressResolutionError` / ENOTFOUND), blocked egress,
- *            401/403 (suite-credential config), MCP −32000/−32001
+ *   ours   — our own cancellation, DNS (`EgressResolutionError` /
+ *            ENOTFOUND), blocked egress, 401/403 (suite-credential
+ *            config), MCP −32000/−32001
  *   theirs — refused / TLS / timeout-to-their-host / 5xx
  *   unknown — everything else
  *
@@ -140,6 +198,10 @@ function collectMessage(error: unknown): string {
  */
 export function classifySetupAttribution(error: unknown): SetupAttribution {
   const cause = unwrapEraNegotiationCause(error);
+
+  // Before every transport heuristic: a cancelled run says nothing about
+  // the target server.
+  if (isCancellation(error, cause)) return "ours";
 
   if (cause instanceof EgressResolutionError) return "ours";
   if (cause instanceof BlockedEgressTargetError) return "ours";
@@ -226,6 +288,13 @@ function foldPhase(
     else observed.push(row);
   }
 
+  // The phase never ran for ANY target — connect failed everywhere, so
+  // tools/list was never attempted. That is an absence of evidence, not a
+  // failed tools/list: emit no signal and let the stage fall through to
+  // `notReached` behind the connection failure. Folding it as `failed`
+  // would put a discovery verdict on a phase that never executed.
+  if (observed.length === 0) return undefined;
+
   const failures = observed.filter((row) => row.outcome === "failed");
   // A target that never settled is an incomplete observation → unknown.
   if (missing.length > 0) {
@@ -286,9 +355,6 @@ export type RunSetupObserver = {
       endedAt: number;
     }
   ) => void;
-  hasConnect: (serverId: string) => boolean;
-  hasToolsList: (serverId: string) => boolean;
-  connectOutcome: (serverId: string) => "ok" | "failed" | undefined;
   /**
    * Lazy, once per run, only on a theirs-shaped failure. Never called for
    * `ours`. Returns whether `GET ${convexHttpUrl}/health` succeeded.
@@ -383,9 +449,13 @@ export function createRunSetupObserver(
     ): StageSetupPhaseSignal | undefined => {
       if (!signal || signal.outcome !== "failed") return signal;
       if (signal.attribution !== "theirs") return signal;
+      // Absent when the canary never ran: "we did not check" and "we
+      // checked and our egress is down" are different states, and only
+      // `true` may ever earn `connection: failed`.
+      if (canaryResult === undefined) return signal;
       return {
         ...signal,
-        egressVerified: canaryResult === true,
+        egressVerified: canaryResult,
       };
     };
 
@@ -398,9 +468,6 @@ export function createRunSetupObserver(
   return {
     recordConnect: (serverId, init) => record(connects, serverId, init),
     recordToolsList: (serverId, init) => record(lists, serverId, init),
-    hasConnect: (serverId) => connects.has(serverId),
-    hasToolsList: (serverId) => lists.has(serverId),
-    connectOutcome: (serverId) => connects.get(serverId)?.outcome,
     ensureEgressCanary,
     buildSignals,
     buildSyntheticSpans: (runStartedAt) =>
@@ -413,20 +480,22 @@ export function createRunSetupObserver(
     buildAuditMetadata: () => {
       const signals = buildSignals();
       if (!signals) return undefined;
-      return capSetupAuditMetadata(
-        {
-          stageSetupSignals: signals,
-          egressCanary:
-            canaryResult === undefined
-              ? { ran: false }
-              : {
-                  ran: true,
-                  ok: canaryResult,
-                  at: (options.now ?? Date.now)(),
-                },
-        },
-        SETUP_SIGNALS_METADATA_CAP_BYTES
-      );
+      return {
+        [SETUP_AUDIT_METADATA_KEY]: capSetupAuditMetadata(
+          {
+            signals,
+            egressCanary:
+              canaryResult === undefined
+                ? { ran: false }
+                : {
+                    ran: true,
+                    ok: canaryResult,
+                    at: (options.now ?? Date.now)(),
+                  },
+          },
+          SETUP_SIGNALS_METADATA_CAP_BYTES
+        ),
+      };
     },
   };
 }

--- a/mcpjam-inspector/shared/__tests__/eval-trace.test.ts
+++ b/mcpjam-inspector/shared/__tests__/eval-trace.test.ts
@@ -219,6 +219,29 @@ describe("trace-span parity fixtures (inspector evalTraceSpanZ side)", () => {
       }).success,
     ).toBe(false);
   });
+
+  it("accepts connection and discovery categories and rejects unknowns", () => {
+    const base = { id: "s", name: "connect", startMs: 0, endMs: 1 };
+    expect(
+      evalTraceSpanZ.safeParse({ ...base, category: "connection" }).success,
+    ).toBe(true);
+    expect(
+      evalTraceSpanZ.safeParse({
+        ...base,
+        name: "tools/list",
+        category: "discovery",
+      }).success,
+    ).toBe(true);
+    expect(
+      evalTraceSpanZ.safeParse({ ...base, category: "handshake" }).success,
+    ).toBe(false);
+    expect(
+      evalTraceSpanZ.safeParse({ ...base, category: "" }).success,
+    ).toBe(false);
+    expect(
+      evalTraceSpanZ.safeParse({ ...base, category: null }).success,
+    ).toBe(false);
+  });
 });
 
 describe("normalizeFinishReason", () => {

--- a/mcpjam-inspector/shared/eval-trace.ts
+++ b/mcpjam-inspector/shared/eval-trace.ts
@@ -4,7 +4,13 @@ import type { PromptTurnToolCall } from "./steps";
 import type { PredicateResult } from "@mcpjam/sdk/predicates";
 
 /** Persisted eval trace span categories (Convex: use the same literals in traceSpanValidator). */
-export type EvalTraceSpanCategory = "step" | "llm" | "tool" | "error";
+export type EvalTraceSpanCategory =
+  | "step"
+  | "llm"
+  | "tool"
+  | "error"
+  | "connection"
+  | "discovery";
 export type EvalTraceSpanStatus = "ok" | "error";
 
 export type EvalTraceSpan = {
@@ -495,7 +501,14 @@ export const evalTraceSpanZ = z.object({
   id: z.string(),
   parentId: z.string().optional(),
   name: z.string(),
-  category: z.enum(["step", "llm", "tool", "error"]),
+  category: z.enum([
+    "step",
+    "llm",
+    "tool",
+    "error",
+    "connection",
+    "discovery",
+  ]),
   startMs: z.number(),
   endMs: z.number(),
   promptIndex: z.number().optional(),

--- a/sdk/src/contract/index.ts
+++ b/sdk/src/contract/index.ts
@@ -152,6 +152,8 @@ export type {
   StageReason,
   StageRenderObservationLike,
   StageResultRow,
+  StageSetupPhaseSignal,
+  StageSetupSignals,
   StageSpanLike,
   StageToolErrorLike,
 } from "./stage-derivation.js";

--- a/sdk/src/contract/stage-derivation.ts
+++ b/sdk/src/contract/stage-derivation.ts
@@ -484,11 +484,13 @@ function deriveDiscovery(e: StageEvidence): StageResultRow {
   }
   if (signal?.outcome === "failed") {
     const refs = signalEvidence(signal);
-    // Failed + initialize completed + not our fault ⇒ measured discovery miss.
+    // Failed + initialize completed + theirs ⇒ measured discovery miss.
     // A completed initialize is the egress evidence; no canary needed.
+    // Unknown (unobserved tools/list) stays notMeasured — incomplete
+    // observation is not a server failure.
     if (
       connectionPositivelyReached(e) &&
-      signal.attribution !== "ours"
+      signal.attribution === "theirs"
     ) {
       return row("discovery", "failed", "toolsListFailed", refs);
     }

--- a/sdk/src/contract/stage-derivation.ts
+++ b/sdk/src/contract/stage-derivation.ts
@@ -61,7 +61,7 @@ import {
  * reason `sessionReadiness` stamps `READINESS_ANALYZER_VERSION` on every
  * record it writes.
  */
-export const STAGE_ANALYZER_VERSION = 1;
+export const STAGE_ANALYZER_VERSION = 2;
 
 /**
  * Why a stage landed where it did.
@@ -94,6 +94,21 @@ export const STAGE_REASONS = [
   "evaluatorError",
   /** The harness never got to the test (setup abort). */
   "setupAborted",
+  /**
+   * The run reached the configured server's host and initialize failed
+   * there (attribution `theirs`, egress canary verified).
+   */
+  "connectFailed",
+  /**
+   * Initialize succeeded but tools/list failed on a reached server. A
+   * completed initialize is itself the egress evidence.
+   */
+  "toolsListFailed",
+  /**
+   * A connection/discovery failure without positive evidence our own
+   * egress works. Never `connection: failed`.
+   */
+  "egressUnverified",
   /** The run was stopped mid-flight (cancel / timeout). */
   "lifecycleStopped",
   // ── the stage does not apply ──
@@ -232,6 +247,26 @@ export type StageAuthoredCase = {
   assertionCount?: number;
 };
 
+/**
+ * One run-level setup phase (connect or tools/list), folded across every
+ * configured target. Connect and tools-list happen once per run above the
+ * iteration boundary, so this is the derivation input — not spans.
+ */
+export type StageSetupPhaseSignal = {
+  outcome: "ok" | "failed";
+  /** Present on a failure only. */
+  attribution?: "ours" | "theirs" | "unknown";
+  /** Positive canary evidence that our own egress works. */
+  egressVerified?: boolean;
+  /** Culprit synthetic-span ids (`run-connect-<id>` / `run-toolslist-<id>`). */
+  spanIds?: string[];
+};
+
+export type StageSetupSignals = {
+  connection?: StageSetupPhaseSignal;
+  discovery?: StageSetupPhaseSignal;
+};
+
 /** Everything the run actually captured. */
 export type StageEvidence = {
   spans?: readonly StageSpanLike[];
@@ -250,6 +285,12 @@ export type StageEvidence = {
   renderObservations?: readonly StageRenderObservationLike[];
   /** `tools_total_before` / `tools_exposed` — the one direct discovery signal. */
   toolSignals?: { toolsTotalBefore?: number; toolsExposed?: number };
+  /**
+   * Structured connect / tools-list evidence, threaded per-iteration
+   * (precedent: `toolSignals`). Synthetic `connection`/`discovery` spans
+   * are persistence/timeline-only and never enter this field.
+   */
+  setupSignals?: StageSetupSignals;
   /** The grader threw. Never folded into a server-side category. */
   evaluatorErrored?: boolean;
 };
@@ -356,45 +397,108 @@ function applicability(
 
 // ── per-stage evaluators ─────────────────────────────────────────────────────
 
-function deriveConnection(e: StageEvidence): StageResultRow {
-  const tools = (e.spans ?? []).filter(isToolSpan);
-  // A tool span that is not a transport-local failure proves we reached the
-  // server. This is retroactive, and it is the ONLY positive signal available:
-  // there is no `connection` span category anywhere in the span contract.
-  const reached = tools.filter(
+function nonTransportLocalToolSpans(
+  e: StageEvidence
+): StageSpanLike[] {
+  return (e.spans ?? []).filter(
     (s) =>
+      isToolSpan(s) &&
       !(
         typeof s.mcpErrorCode === "number" &&
         TRANSPORT_LOCAL_MCP_CODES.has(s.mcpErrorCode)
       )
   );
+}
+
+function signalEvidence(signal: StageSetupPhaseSignal): StageEvidenceRefs {
+  return signal.spanIds?.length
+    ? { spanIds: signal.spanIds.slice(0, 5) }
+    : {};
+}
+
+function deriveConnection(e: StageEvidence): StageResultRow {
+  const signal = e.setupSignals?.connection;
+  // (1) Structured signal says every expected target connected.
+  if (signal?.outcome === "ok") {
+    return row("connection", "passed", "observed", signalEvidence(signal));
+  }
+  // (2) A tool span that is not a transport-local failure proves we reached
+  // the server. Measured later evidence outranks a contradictory classification.
+  const reached = nonTransportLocalToolSpans(e);
   if (reached.length > 0) {
     return row("connection", "passed", "impliedByLaterEvidence", {
       spanIds: spanIds(reached).slice(0, 5),
     });
   }
+  // (3) A tools-list count is the same retroactive proof.
   if ((e.toolSignals?.toolsTotalBefore ?? 0) > 0) {
     return row("connection", "passed", "impliedByLaterEvidence");
   }
+  if (signal?.outcome === "failed") {
+    const refs = signalEvidence(signal);
+    // (4) Theirs + positive canary ⇒ the only honest `connection: failed`.
+    if (signal.attribution === "theirs" && signal.egressVerified === true) {
+      return row("connection", "failed", "connectFailed", refs);
+    }
+    // (5) Theirs without a canary, or (6) unknown: we cannot name their server.
+    if (
+      signal.attribution === "theirs" ||
+      signal.attribution === "unknown" ||
+      signal.attribution === undefined
+    ) {
+      return row("connection", "notMeasured", "egressUnverified", refs);
+    }
+    // (7) Ours (DNS, blocked egress, 401/403, transport-local MCP codes).
+    return row("connection", "notMeasured", "setupAborted", refs);
+  }
+  // (8)
   if (e.traceAbsent) return row("connection", "notMeasured", "traceAbsent");
-  // Not `noEvidenceCaptured`: there is no channel to capture on, so no amount
-  // of instrumentation on the current contract would have decided this.
-  return row("connection", "notMeasured", "noSpanChannel");
+  // (9) v2 fallthrough. `noSpanChannel` stays in the vocabulary (old
+  // producers still emit it) but this analyzer no longer does.
+  return row("connection", "notMeasured", "noEvidenceCaptured");
+}
+
+function connectionPositivelyReached(e: StageEvidence): boolean {
+  if (e.setupSignals?.connection?.outcome === "ok") return true;
+  if ((e.toolSignals?.toolsTotalBefore ?? 0) > 0) return true;
+  if (nonTransportLocalToolSpans(e).length > 0) return true;
+  // A discovery *signal* is not enough: foldPhase emits one for an
+  // unobserved target too. Only a completed initialize (connection ok)
+  // or later tool evidence proves we reached their host.
+  return false;
 }
 
 function deriveDiscovery(e: StageEvidence): StageResultRow {
+  const signal = e.setupSignals?.discovery;
+  if (signal?.outcome === "ok") {
+    return row("discovery", "passed", "observed", signalEvidence(signal));
+  }
   if ((e.toolSignals?.toolsTotalBefore ?? 0) > 0) {
     return row("discovery", "passed", "observed");
   }
   const tools = (e.spans ?? []).filter(isToolSpan);
   if (tools.length > 0) {
-    // We called a tool, so it must have been discovered.
     return row("discovery", "passed", "impliedByLaterEvidence", {
       spanIds: spanIds(tools).slice(0, 5),
     });
   }
+  if (signal?.outcome === "failed") {
+    const refs = signalEvidence(signal);
+    // Failed + initialize completed + not our fault ⇒ measured discovery miss.
+    // A completed initialize is the egress evidence; no canary needed.
+    if (
+      connectionPositivelyReached(e) &&
+      signal.attribution !== "ours"
+    ) {
+      return row("discovery", "failed", "toolsListFailed", refs);
+    }
+    if (signal.attribution === "ours") {
+      return row("discovery", "notMeasured", "setupAborted", refs);
+    }
+    return row("discovery", "notMeasured", "egressUnverified", refs);
+  }
   if (e.traceAbsent) return row("discovery", "notMeasured", "traceAbsent");
-  return row("discovery", "notMeasured", "noSpanChannel");
+  return row("discovery", "notMeasured", "noEvidenceCaptured");
 }
 
 const promptIndexes = (prompts: readonly StagePromptSummaryLike[]): number[] =>
@@ -673,15 +777,41 @@ export function deriveStageResults(
     evidence.traceAbsent &&
     noEvidenceAtAll
   ) {
-    return finalize(
-      USER_VALUE_STAGES.map((stage) =>
-        applies[stage]
-          ? row(stage, "notMeasured", "setupAborted")
-          : inapplicable(stage)
-      ),
-      evidence,
-      "setup"
+    const hasSetupSignals =
+      evidence.setupSignals?.connection !== undefined ||
+      evidence.setupSignals?.discovery !== undefined;
+    // No signals ⇒ byte-identical to the v1 chain (modulo analyzer version).
+    if (!hasSetupSignals) {
+      return finalize(
+        USER_VALUE_STAGES.map((stage) =>
+          applies[stage]
+            ? row(stage, "notMeasured", "setupAborted")
+            : inapplicable(stage)
+        ),
+        evidence,
+        "setup"
+      );
+    }
+    // Signals present ⇒ measure the top two stages. Remaining stages are
+    // `notReached` after a measured failure, else `notMeasured/setupAborted`.
+    // `failureCategory` stays `setup` (no honest `server` bucket; rates
+    // filter on `firstFailedStage`).
+    const connection = deriveConnection(evidence);
+    const discoveryRaw = deriveDiscovery(evidence);
+    const discovery =
+      connection.state === "failed" && discoveryRaw.state === "notMeasured"
+        ? row("discovery", "notReached", "earlierStageFailed")
+        : discoveryRaw;
+    const topFailed =
+      connection.state === "failed" || discovery.state === "failed";
+    const rest = USER_VALUE_STAGES.slice(2).map((stage) =>
+      applies[stage]
+        ? topFailed
+          ? row(stage, "notReached", "earlierStageFailed")
+          : row(stage, "notMeasured", "setupAborted")
+        : inapplicable(stage)
     );
+    return finalize([connection, discovery, ...rest], evidence, "setup");
   }
 
   const derived: StageResultRow[] = USER_VALUE_STAGES.map((stage) => {

--- a/sdk/src/eval-reporting-types.ts
+++ b/sdk/src/eval-reporting-types.ts
@@ -15,7 +15,13 @@ export type EvalCiMetadata = {
   commitSha?: string;
 };
 
-export type EvalTraceSpanCategory = "step" | "llm" | "tool" | "error";
+export type EvalTraceSpanCategory =
+  | "step"
+  | "llm"
+  | "tool"
+  | "error"
+  | "connection"
+  | "discovery";
 export type EvalTraceSpanStatus = "ok" | "error";
 
 export type EvalTraceSpanInput = {

--- a/sdk/src/index.ts
+++ b/sdk/src/index.ts
@@ -215,6 +215,7 @@ export {
   isInsufficientScopeError,
   extractInsufficientScopeChallenge,
   unwrapEraNegotiationCause,
+  classifyNegotiationFailureClass,
   MCPTasksWireError,
   isMCPTasksWireError,
 } from "./mcp-client-manager/index.js";

--- a/sdk/src/mcp-client-manager/index.ts
+++ b/sdk/src/mcp-client-manager/index.ts
@@ -147,6 +147,7 @@ export {
   extractInsufficientScopeChallenge,
   isMCPAuthError,
   unwrapEraNegotiationCause,
+  classifyNegotiationFailureClass,
   MCPTasksWireError,
   isMCPTasksWireError,
 } from "./errors.js";

--- a/sdk/tests/stage-derivation.test.ts
+++ b/sdk/tests/stage-derivation.test.ts
@@ -16,6 +16,7 @@ import {
   MAX_EVIDENCE_REASONS,
   MAX_EVIDENCE_REASON_CHARS,
   STAGE_ANALYZER_VERSION,
+  STAGE_REASONS,
   USER_VALUE_STAGES,
   deriveStageResults,
   stageDerivationSchema,
@@ -221,7 +222,7 @@ describe("connection & discovery", () => {
     });
   });
 
-  test("no spans and no signals is `noSpanChannel`, not a failure", () => {
+  test("no spans and no signals is `noEvidenceCaptured`, not a failure", () => {
     const { stageResults } = deriveStageResults({
       authored: modelDrivenCase,
       evidence: { traceLacksSpanChannel: true },
@@ -229,7 +230,224 @@ describe("connection & discovery", () => {
     });
     expect(stateOf(stageResults, "connection")).toMatchObject({
       state: "notMeasured",
-      reason: "noSpanChannel",
+      reason: "noEvidenceCaptured",
+    });
+    expect(stateOf(stageResults, "discovery")).toMatchObject({
+      state: "notMeasured",
+      reason: "noEvidenceCaptured",
+    });
+  });
+
+  test("`noSpanChannel` stays in the vocabulary for old producers", () => {
+    expect(STAGE_REASONS).toContain("noSpanChannel");
+  });
+
+  test("signal ok ⇒ connection passed/observed", () => {
+    const { stageResults } = deriveStageResults({
+      authored: modelDrivenCase,
+      evidence: {
+        setupSignals: { connection: { outcome: "ok" } },
+      },
+      iteration: { status: "completed" },
+    });
+    expect(stateOf(stageResults, "connection")).toMatchObject({
+      state: "passed",
+      reason: "observed",
+    });
+  });
+
+  test("failed + theirs + egressVerified ⇒ connection failed/connectFailed", () => {
+    const { stageResults, firstFailedStage, failureCategory } =
+      deriveStageResults({
+        authored: modelDrivenCase,
+        evidence: {
+          setupSignals: {
+            connection: {
+              outcome: "failed",
+              attribution: "theirs",
+              egressVerified: true,
+              spanIds: ["run-connect-s1"],
+            },
+          },
+        },
+        iteration: { status: "failed" },
+      });
+    expect(stateOf(stageResults, "connection")).toMatchObject({
+      state: "failed",
+      reason: "connectFailed",
+      evidence: { spanIds: ["run-connect-s1"] },
+    });
+    expect(firstFailedStage).toBe("connection");
+    expect(failureCategory).toBe("setup");
+  });
+
+  test("failed + theirs without canary ⇒ notMeasured/egressUnverified", () => {
+    const { stageResults, firstFailedStage } = deriveStageResults({
+      authored: modelDrivenCase,
+      evidence: {
+        setupSignals: {
+          connection: {
+            outcome: "failed",
+            attribution: "theirs",
+          },
+        },
+      },
+      iteration: { status: "failed" },
+    });
+    expect(stateOf(stageResults, "connection")).toMatchObject({
+      state: "notMeasured",
+      reason: "egressUnverified",
+    });
+    expect(firstFailedStage).toBeUndefined();
+  });
+
+  test("unknown attribution ⇒ notMeasured/egressUnverified", () => {
+    const { stageResults } = deriveStageResults({
+      authored: modelDrivenCase,
+      evidence: {
+        setupSignals: {
+          connection: { outcome: "failed", attribution: "unknown" },
+        },
+      },
+      iteration: { status: "failed" },
+    });
+    expect(stateOf(stageResults, "connection")).toMatchObject({
+      state: "notMeasured",
+      reason: "egressUnverified",
+    });
+  });
+
+  test("ours attribution ⇒ notMeasured/setupAborted", () => {
+    const { stageResults, failureCategory } = deriveStageResults({
+      authored: modelDrivenCase,
+      evidence: {
+        setupSignals: {
+          connection: { outcome: "failed", attribution: "ours" },
+        },
+      },
+      iteration: { status: "failed" },
+    });
+    expect(stateOf(stageResults, "connection")).toMatchObject({
+      state: "notMeasured",
+      reason: "setupAborted",
+    });
+    expect(failureCategory).toBe("setup");
+  });
+
+  test("later tool spans outrank a contradictory failed classification", () => {
+    const { stageResults } = deriveStageResults({
+      authored: modelDrivenCase,
+      evidence: {
+        spans: [toolSpan()],
+        setupSignals: {
+          connection: {
+            outcome: "failed",
+            attribution: "theirs",
+            egressVerified: true,
+          },
+        },
+      },
+      iteration: { status: "completed" },
+    });
+    expect(stateOf(stageResults, "connection")).toMatchObject({
+      state: "passed",
+      reason: "impliedByLaterEvidence",
+    });
+  });
+
+  test("toolsTotalBefore outranks a failed classification", () => {
+    const { stageResults } = deriveStageResults({
+      authored: modelDrivenCase,
+      evidence: {
+        toolSignals: { toolsTotalBefore: 3 },
+        setupSignals: {
+          connection: {
+            outcome: "failed",
+            attribution: "theirs",
+            egressVerified: true,
+          },
+        },
+      },
+      iteration: { status: "completed" },
+    });
+    expect(stateOf(stageResults, "connection")).toMatchObject({
+      state: "passed",
+      reason: "impliedByLaterEvidence",
+    });
+  });
+
+  test("discovery signal ok ⇒ passed/observed", () => {
+    const { stageResults } = deriveStageResults({
+      authored: modelDrivenCase,
+      evidence: {
+        setupSignals: {
+          connection: { outcome: "ok" },
+          discovery: { outcome: "ok" },
+        },
+      },
+      iteration: { status: "completed" },
+    });
+    expect(stateOf(stageResults, "discovery")).toMatchObject({
+      state: "passed",
+      reason: "observed",
+    });
+  });
+
+  test("discovery failed + reached + not ours ⇒ failed/toolsListFailed", () => {
+    const { stageResults, firstFailedStage, failureCategory } =
+      deriveStageResults({
+        authored: modelDrivenCase,
+        evidence: {
+          setupSignals: {
+            connection: { outcome: "ok" },
+            discovery: {
+              outcome: "failed",
+              attribution: "theirs",
+              spanIds: ["run-toolslist-s1"],
+            },
+          },
+        },
+        iteration: { status: "failed" },
+      });
+    expect(stateOf(stageResults, "discovery")).toMatchObject({
+      state: "failed",
+      reason: "toolsListFailed",
+      evidence: { spanIds: ["run-toolslist-s1"] },
+    });
+    expect(firstFailedStage).toBe("discovery");
+    expect(failureCategory).toBe("setup");
+  });
+
+  test("discovery failed + ours ⇒ notMeasured/setupAborted", () => {
+    const { stageResults } = deriveStageResults({
+      authored: modelDrivenCase,
+      evidence: {
+        setupSignals: {
+          connection: { outcome: "ok" },
+          discovery: { outcome: "failed", attribution: "ours" },
+        },
+      },
+      iteration: { status: "failed" },
+    });
+    expect(stateOf(stageResults, "discovery")).toMatchObject({
+      state: "notMeasured",
+      reason: "setupAborted",
+    });
+  });
+
+  test("discovery failed without a reached connection ⇒ egressUnverified", () => {
+    const { stageResults } = deriveStageResults({
+      authored: modelDrivenCase,
+      evidence: {
+        setupSignals: {
+          discovery: { outcome: "failed", attribution: "theirs" },
+        },
+      },
+      iteration: { status: "failed" },
+    });
+    expect(stateOf(stageResults, "discovery")).toMatchObject({
+      state: "notMeasured",
+      reason: "egressUnverified",
     });
   });
 
@@ -661,6 +879,59 @@ describe("honest degradation for rows that never produced a verdict", () => {
       expect(failureCategory).toBe("setup");
     }
   );
+
+  test("no-signals failed+traceAbsent is byte-identical to v1 (modulo version)", () => {
+    const { stageResults, firstFailedStage, failureCategory, stageAnalyzerVersion } =
+      deriveStageResults({
+        authored: modelDrivenCase,
+        evidence: { traceAbsent: true },
+        iteration: { status: "failed", error: "server not connected" },
+      });
+    expect(stageAnalyzerVersion).toBe(2);
+    const applicable = stageResults.filter((r) => r.state !== "notApplicable");
+    expect(applicable.map((r) => ({ stage: r.stage, state: r.state, reason: r.reason }))).toEqual(
+      applicable.map((r) => ({
+        stage: r.stage,
+        state: "notMeasured",
+        reason: "setupAborted",
+      }))
+    );
+    expect(firstFailedStage).toBeUndefined();
+    expect(failureCategory).toBe("setup");
+  });
+
+  test("failed+traceAbsent WITH signals measures the top two stages", () => {
+    const { stageResults, firstFailedStage, failureCategory } =
+      deriveStageResults({
+        authored: modelDrivenCase,
+        evidence: {
+          traceAbsent: true,
+          setupSignals: {
+            connection: {
+              outcome: "failed",
+              attribution: "theirs",
+              egressVerified: true,
+              spanIds: ["run-connect-s1"],
+            },
+          },
+        },
+        iteration: { status: "failed", error: "connection refused" },
+      });
+    expect(stateOf(stageResults, "connection")).toMatchObject({
+      state: "failed",
+      reason: "connectFailed",
+    });
+    expect(stateOf(stageResults, "discovery")).toMatchObject({
+      state: "notReached",
+      reason: "earlierStageFailed",
+    });
+    expect(stateOf(stageResults, "selection")).toMatchObject({
+      state: "notReached",
+      reason: "earlierStageFailed",
+    });
+    expect(firstFailedStage).toBe("connection");
+    expect(failureCategory).toBe("setup");
+  });
 
   test("a `failed` row with no trace is read as a setup abort", () => {
     // `persistSetupFailedIteration` writes status "failed" because the update

--- a/sdk/tests/stage-derivation.test.ts
+++ b/sdk/tests/stage-derivation.test.ts
@@ -419,6 +419,27 @@ describe("connection & discovery", () => {
     expect(failureCategory).toBe("setup");
   });
 
+  test("discovery failed + reached + theirs ignores a failed canary stamp", () => {
+    const { stageResults } = deriveStageResults({
+      authored: modelDrivenCase,
+      evidence: {
+        setupSignals: {
+          connection: { outcome: "ok" },
+          discovery: {
+            outcome: "failed",
+            attribution: "theirs",
+            egressVerified: false,
+          },
+        },
+      },
+      iteration: { status: "failed" },
+    });
+    expect(stateOf(stageResults, "discovery")).toMatchObject({
+      state: "failed",
+      reason: "toolsListFailed",
+    });
+  });
+
   test("discovery failed + reached + unknown ⇒ notMeasured", () => {
     const { stageResults, firstFailedStage } = deriveStageResults({
       authored: modelDrivenCase,

--- a/sdk/tests/stage-derivation.test.ts
+++ b/sdk/tests/stage-derivation.test.ts
@@ -394,7 +394,7 @@ describe("connection & discovery", () => {
     });
   });
 
-  test("discovery failed + reached + not ours ⇒ failed/toolsListFailed", () => {
+  test("discovery failed + reached + theirs ⇒ failed/toolsListFailed", () => {
     const { stageResults, firstFailedStage, failureCategory } =
       deriveStageResults({
         authored: modelDrivenCase,
@@ -417,6 +417,24 @@ describe("connection & discovery", () => {
     });
     expect(firstFailedStage).toBe("discovery");
     expect(failureCategory).toBe("setup");
+  });
+
+  test("discovery failed + reached + unknown ⇒ notMeasured", () => {
+    const { stageResults, firstFailedStage } = deriveStageResults({
+      authored: modelDrivenCase,
+      evidence: {
+        setupSignals: {
+          connection: { outcome: "ok" },
+          discovery: { outcome: "failed", attribution: "unknown" },
+        },
+      },
+      iteration: { status: "failed" },
+    });
+    expect(stateOf(stageResults, "discovery")).toMatchObject({
+      state: "notMeasured",
+      reason: "egressUnverified",
+    });
+    expect(firstFailedStage).toBeUndefined();
   });
 
   test("discovery failed + ours ⇒ notMeasured/setupAborted", () => {

--- a/sdk/tests/stage-derivation.test.ts
+++ b/sdk/tests/stage-derivation.test.ts
@@ -321,6 +321,7 @@ describe("connection & discovery", () => {
     const { stageResults, failureCategory } = deriveStageResults({
       authored: modelDrivenCase,
       evidence: {
+        traceAbsent: true,
         setupSignals: {
           connection: { outcome: "failed", attribution: "ours" },
         },


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Purpose

Lane D step D6: make the eval funnel's top two stages (`connection`, `discovery`) measurable. Connect and tools-list happen once per run, above the iteration boundary where no span sink exists. Today a run-level connect failure also **strands the run** — the catch only called `recorder.finalize({failed})`, pre-created iterations sat `pending`, and the backend `blockTerminal` guard soft-blocked the terminal transition.

## Dependency order (do not merge this first)

**mcpjam-backend #1108 must merge AND production must be promoted before this PR merges.**

A v2 inspector against an un-widened backend would quarantine the new `STAGE_REASONS` and hard-fail `category: "connection"` spans on the W1 fallback writer.

- Rollback order: **inspector first, backend second**. Never revert the backend while a v2 inspector is live.
- Feature flag: none. Deploy order is the safety mechanism.

## Before / after

**Before:** `connection` and `discovery` could never be `failed`. A refused/timed-out server collapsed into a generic setup-abort chain (`notMeasured` / `setupAborted`). A run-level connect miss left iterations `pending` and the run stranded.

**After:**
- Run-level connect / tools-list are observed behind a two-phase `Promise.allSettled` barrier (all connects, then all tools-lists) so folding cannot race.
- Folded `setupSignals` are threaded per-iteration (precedent: `toolSignals`). Synthetic `connection` / `discovery` spans persist for the timeline only and never enter derivation evidence.
- `connection: failed` / `connectFailed` requires attribution `theirs` **and** a verified egress canary (`GET ${convexHttpUrl}/health`, lazy, once per run, never on `ours`). Otherwise the row stays `notMeasured` (`egressUnverified` / `setupAborted`).
- A completed initialize is itself the egress evidence for `discovery: failed` / `toolsListFailed`.
- Run-level failure writes every pending iteration with those signals, re-reads, retries residual pending rows once, and only then runs `markSetupPendingIterationsFailed` — so the sweep cannot silently strip stage metadata.
- Analyzer version 2. `noSpanChannel` stays in the vocabulary for old producers; v2 emits `noEvidenceCaptured`.

## Producer scope (narrowed from the board pin)

The board row said "emit them at session-init and tools-list on ALL producers". The SDK path is **types-only**: a user-code `beforeAll` connect failure never reaches ingestion, so there is nothing to emit. `buildSdkStageEvidence` is unchanged.

Step 0 (revise the D6 board row in `evals-v2-implementation.md` + `evals-d6-brief.md` before either PR) could not be committed here: the `mcpjam-docs` repo is not in this workspace.

## Flagged decisions (defaults; overridable at review)

- **`failureCategory` stays `setup`** for a measured connection/discovery failure. `FAILURE_CATEGORIES` has no honest `server` bucket (`serverData` = "server answered with unusable data") and is Wave-0 mirror-pinned. Measured-failure rates filter on `firstFailedStage`. Adding a `server` category is out of D6 scope.
- GitHub from-source connect failures that occur in the check worker **before the run exists** stay check-level `server_unhealthy`. D6 covers `runEvalSuiteWithAiSdk` onward.
- 401/403 classify as `ours` (suite-credential config), noted as a future `credentials` attribution refinement.

## Tests

- `sdk/tests/stage-derivation.test.ts` — one case per decision-table row; no-signals fallback is v1-identical modulo analyzer version; `noSpanChannel` remains in the vocabulary.
- New `run-setup-signals` unit suite: classification, any-failed folding, canary laziness, span clamping.
- Non-vacuity: run-level refused connect + mocked canary ok persists `stageResults[0].reason === "connectFailed"`.
- `build-iteration-finish-params`: synthetic spans persist on the trace and stay out of derivation evidence.

## Rollout

1. Merge + deploy backend #1108 (staging auto). **Promote production.**
2. Merge this inspector PR.
3. No backfill. Historical iterations keep v1 chains; `stageAnalyzerVersion` is the recompute hook.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-e8a0c25d-277c-4706-8b86-64b3838665f6?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-e8a0c25d-277c-4706-8b86-64b3838665f6&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Measures run-setup connection and discovery so the top eval stages are observable, and run-level connect failures no longer strand runs. Previously we did not record connect/tools-list at the run level and a failed connect left iterations pending; now we fold all targets behind a barrier, classify outcomes, persist timeline-only synthetic spans, and write pending iterations before finalize with best-effort recovery.

- Server: Add a run-setup observer with a two-phase barrier (all connects, then tools-list) sourced from one `getToolsForAiSdk` call per server. Emit per-run `setupSignals`, generate synthetic connection/discovery spans, share a lazy connection-only egress canary, and treat unknown discovery as not a server failure. Classify cancellation as ours. On setup failure, stamp all pending iterations, retry once, and still sweep even if residual reads fail. Nest setup audit under one key and shed span IDs past the cap.
- SDK (`@mcpjam/sdk`): Analyzer v2. Derive connection/discovery from `setupSignals`. Add reasons `connectFailed`, `toolsListFailed` (theirs-only), and `egressUnverified`. Replace `noSpanChannel` with `noEvidenceCaptured` (retain the former in the vocabulary for older producers). `failureCategory` remains `setup`.
- UI (`chat-ui`, `@mcpjam/inspector`): Add `connection`/`discovery` categories and filters; render synthetic spans ahead of captured spans. Keep compile-time exhaustiveness with a runtime fallback so newer categories still render.

- Rollout
  - Deploy backend vocabulary widening (new span categories and reasons) to production before `@mcpjam/inspector`/`chat-ui`. Roll back in reverse.
  - No feature flag or backfill. Historical data stays v1; `stageAnalyzerVersion = 2` gates recompute.

<sup>Written for commit af000e5e8534cd36cc3898f3c4e4eca408edf9af. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/MCPJam/inspector/pull/4291?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

