### PR TITLE
v1: add durationMs to tools/call

### DIFF
--- a/.changeset/v1-tools-call-duration.md
+++ b/.changeset/v1-tools-call-duration.md
@@ -1,0 +1,5 @@
+---
+"@mcpjam/inspector": patch
+---
+
+`POST /v1/projects/{projectId}/servers/{serverId}/tools/call` returns an additive `durationMs` — wall-clock milliseconds spent in the tool call itself, so an agent can read latency without a second request. A server that already returns its own top-level `durationMs` keeps it; MCPJam never overwrites the field. Non-object results (arrays, primitives, `null`) are returned unchanged.

--- a/docs/reference/openapi.json
+++ b/docs/reference/openapi.json
@@ -1629,7 +1629,7 @@
           "Execution"
         ],
         "summary": "Call a tool",
-        "description": "Executes a tool on the server and returns the MCP `CallToolResult` directly. Tool-level failures (`isError: true` in the result) are **successful calls** — the server answered; only transport/auth errors use the error envelope.",
+        "description": "Executes a tool on the server and returns the MCP `CallToolResult` plus an additive `durationMs` (wall-clock time of `executeTool`). Tool-level failures (`isError: true` in the result) are **successful calls** — the server answered; only transport/auth errors use the error envelope.",
         "parameters": [
           {
             "$ref": "#/components/parameters/projectId"
@@ -1670,7 +1670,7 @@
         },
         "responses": {
           "200": {
-            "description": "The MCP `CallToolResult`. Check `isError` for tool-level failures.",
+            "description": "The MCP `CallToolResult` plus additive `durationMs`. Check `isError` for tool-level failures.",
             "content": {
               "application/json": {
                 "schema": {
@@ -1682,7 +1682,8 @@
                       "type": "text",
                       "text": "Issue created: #42"
                     }
-                  ]
+                  ],
+                  "durationMs": 42
                 }
               }
             }
@@ -11529,7 +11530,7 @@
       },
       "CallToolResult": {
         "type": "object",
-        "description": "MCP tool execution result, returned verbatim from the server.",
+        "description": "MCP tool execution result, returned verbatim from the server, plus additive `durationMs` measured at the public API boundary.",
         "required": [
           "content"
         ],
@@ -11550,6 +11551,11 @@
           "isError": {
             "type": "boolean",
             "description": "`true` when the **tool** reported a failure. The HTTP call still succeeds — the server answered."
+          },
+          "durationMs": {
+            "type": "integer",
+            "minimum": 0,
+            "description": "Wall-clock milliseconds spent in `executeTool` on this request. Additive MCPJam field; not part of the MCP `CallToolResult` spec."
           }
         },
         "additionalProperties": true

--- a/docs/reference/openapi.json
+++ b/docs/reference/openapi.json
@@ -11555,7 +11555,7 @@
           "durationMs": {
             "type": "integer",
             "minimum": 0,
-            "description": "Wall-clock milliseconds spent in `executeTool` on this request. Additive MCPJam field; not part of the MCP `CallToolResult` spec."
+            "description": "Wall-clock milliseconds spent in `executeTool` on this request. Additive MCPJam field; not part of the MCP `CallToolResult` spec. A server that already returns its own top-level `durationMs` keeps it — MCPJam never overwrites the field — so this value is MCPJam's measurement only when the server did not report one."
           }
         },
         "additionalProperties": true

--- a/docs/reference/public-api.mdx
+++ b/docs/reference/public-api.mdx
@@ -256,7 +256,7 @@ plugin pins whose version no longer exists.
 | `POST .../doctor` | Full health workflow: probe → connect → initialize → capabilities |
 | `POST .../check-oauth` | Does this server require an OAuth grant? |
 | `POST .../tools` | List the server's tools |
-| `POST .../tools/call` | Execute a tool; returns the MCP `CallToolResult` verbatim |
+| `POST .../tools/call` | Execute a tool; returns the MCP `CallToolResult` plus additive `durationMs` |
 | `POST .../prompts` | List the server's prompts |
 | `POST .../prompts/get` | Render a prompt; returns the MCP `GetPromptResult` verbatim |
 | `POST .../resources` | List the server's resources |

--- a/mcpjam-inspector/server/routes/v1/__tests__/tools-call.test.ts
+++ b/mcpjam-inspector/server/routes/v1/__tests__/tools-call.test.ts
@@ -111,6 +111,25 @@ describe("POST /v1/projects/:projectId/servers/:serverId/tools/call", () => {
     expect(await res.json()).toEqual(result);
   });
 
+  it("never overwrites a durationMs the server reported itself", async () => {
+    stubConnection(
+      vi.fn().mockResolvedValue({
+        content: [{ type: "text", text: "ok" }],
+        durationMs: 7,
+      })
+    );
+
+    const res = await postToolsCall();
+
+    expect(res.status).toBe(200);
+    // `CallToolResult` allows extra keys. Reporting our own number by
+    // destroying the server's is worse than not reporting one.
+    expect(await res.json()).toEqual({
+      content: [{ type: "text", text: "ok" }],
+      durationMs: 7,
+    });
+  });
+
   it.each([
     ["taskOptions", { taskOptions: { ttl: 1_000 } }],
     ["allowTaskResult", { allowTaskResult: true }],

--- a/mcpjam-inspector/server/routes/v1/__tests__/tools-call.test.ts
+++ b/mcpjam-inspector/server/routes/v1/__tests__/tools-call.test.ts
@@ -1,0 +1,71 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { Hono } from "hono";
+
+const { runEphemeralConnectionMock, validateGuestTokenMock } = vi.hoisted(
+  () => ({
+    runEphemeralConnectionMock: vi.fn(),
+    validateGuestTokenMock: vi.fn(),
+  })
+);
+
+vi.mock("../../../services/guest-token.js", () => ({
+  validateGuestTokenDetailedAsync: validateGuestTokenMock,
+}));
+
+vi.mock("../../web/auth.js", async () => {
+  const actual = await vi.importActual<typeof import("../../web/auth.js")>(
+    "../../web/auth.js"
+  );
+  return { ...actual, runEphemeralConnection: runEphemeralConnectionMock };
+});
+
+import v1Routes from "../index.js";
+
+function makeApp(): Hono {
+  const app = new Hono();
+  app.route("/api/v1", v1Routes);
+  return app;
+}
+
+describe("POST /v1/projects/:projectId/servers/:serverId/tools/call", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    validateGuestTokenMock.mockResolvedValue({ valid: false });
+  });
+
+  it("returns the MCP CallToolResult plus additive durationMs", async () => {
+    const executeTool = vi.fn().mockImplementation(async () => {
+      await new Promise((resolve) => setTimeout(resolve, 5));
+      return {
+        content: [{ type: "text", text: "ok" }],
+      };
+    });
+
+    runEphemeralConnectionMock.mockImplementation(
+      async (_c, _rawBody, _schema, coreFn) =>
+        coreFn({ executeTool }, { serverId: "s1", toolName: "echo", parameters: {} })
+    );
+
+    const res = await makeApp().request(
+      "/api/v1/projects/p1/servers/s1/tools/call",
+      {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          Authorization: "Bearer tok",
+        },
+        body: JSON.stringify({ toolName: "echo" }),
+      }
+    );
+
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as {
+      content?: unknown[];
+      durationMs?: number;
+    };
+    expect(body.content).toEqual([{ type: "text", text: "ok" }]);
+    expect(typeof body.durationMs).toBe("number");
+    expect(body.durationMs).toBeGreaterThanOrEqual(5);
+    expect(executeTool).toHaveBeenCalledWith("s1", "echo", {});
+  });
+});

--- a/mcpjam-inspector/server/routes/v1/__tests__/tools-call.test.ts
+++ b/mcpjam-inspector/server/routes/v1/__tests__/tools-call.test.ts
@@ -27,6 +27,30 @@ function makeApp(): Hono {
   return app;
 }
 
+function stubConnection(
+  executeTool: ReturnType<typeof vi.fn>,
+  body: Record<string, unknown> = {
+    serverId: "s1",
+    toolName: "echo",
+    parameters: {},
+  }
+) {
+  runEphemeralConnectionMock.mockImplementation(
+    async (_c, _rawBody, _schema, coreFn) => coreFn({ executeTool }, body)
+  );
+}
+
+async function postToolsCall(): Promise<Response> {
+  return makeApp().request("/api/v1/projects/p1/servers/s1/tools/call", {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      Authorization: "Bearer tok",
+    },
+    body: JSON.stringify({ toolName: "echo" }),
+  });
+}
+
 describe("POST /v1/projects/:projectId/servers/:serverId/tools/call", () => {
   beforeEach(() => {
     vi.clearAllMocks();
@@ -40,23 +64,9 @@ describe("POST /v1/projects/:projectId/servers/:serverId/tools/call", () => {
         content: [{ type: "text", text: "ok" }],
       };
     });
+    stubConnection(executeTool);
 
-    runEphemeralConnectionMock.mockImplementation(
-      async (_c, _rawBody, _schema, coreFn) =>
-        coreFn({ executeTool }, { serverId: "s1", toolName: "echo", parameters: {} })
-    );
-
-    const res = await makeApp().request(
-      "/api/v1/projects/p1/servers/s1/tools/call",
-      {
-        method: "POST",
-        headers: {
-          "Content-Type": "application/json",
-          Authorization: "Bearer tok",
-        },
-        body: JSON.stringify({ toolName: "echo" }),
-      }
-    );
+    const res = await postToolsCall();
 
     expect(res.status).toBe(200);
     const body = (await res.json()) as {
@@ -67,5 +77,69 @@ describe("POST /v1/projects/:projectId/servers/:serverId/tools/call", () => {
     expect(typeof body.durationMs).toBe("number");
     expect(body.durationMs).toBeGreaterThanOrEqual(5);
     expect(executeTool).toHaveBeenCalledWith("s1", "echo", {});
+  });
+
+  it("clamps durationMs to zero when the clock moves backward", async () => {
+    const executeTool = vi.fn().mockResolvedValue({
+      content: [{ type: "text", text: "ok" }],
+    });
+    stubConnection(executeTool);
+    const now = vi.spyOn(Date, "now");
+    now.mockReturnValueOnce(1_000).mockReturnValueOnce(900);
+
+    try {
+      const res = await postToolsCall();
+
+      expect(res.status).toBe(200);
+      const body = (await res.json()) as { durationMs?: number };
+      expect(body.durationMs).toBe(0);
+    } finally {
+      now.mockRestore();
+    }
+  });
+
+  it.each([
+    ["null", null],
+    ["primitive", "ok"],
+    ["array", [{ name: "echo" }]],
+  ] as const)("preserves a %s result without durationMs", async (_label, result) => {
+    stubConnection(vi.fn().mockResolvedValue(result));
+
+    const res = await postToolsCall();
+
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual(result);
+  });
+
+  it.each([
+    ["taskOptions", { taskOptions: { ttl: 1_000 } }],
+    ["allowTaskResult", { allowTaskResult: true }],
+  ])("rejects %s with FEATURE_NOT_SUPPORTED", async (_label, extra) => {
+    const executeTool = vi.fn();
+    stubConnection(executeTool, {
+      serverId: "s1",
+      toolName: "echo",
+      parameters: {},
+      ...extra,
+    });
+
+    const res = await postToolsCall();
+    const body = (await res.json()) as { code?: string };
+
+    expect(res.status).toBe(422);
+    expect(body.code).toBe("FEATURE_NOT_SUPPORTED");
+    expect(executeTool).not.toHaveBeenCalled();
+  });
+
+  it("maps executeTool failures through the v1 error envelope", async () => {
+    stubConnection(vi.fn().mockRejectedValue(new Error("tool exploded")));
+
+    const res = await postToolsCall();
+    const body = (await res.json()) as { code?: string; message?: string };
+
+    expect(res.status).toBeGreaterThanOrEqual(400);
+    expect(typeof body.code).toBe("string");
+    expect(body.code).not.toBeUndefined();
+    expect(body).not.toHaveProperty("durationMs");
   });
 });

--- a/mcpjam-inspector/server/routes/v1/tools.ts
+++ b/mcpjam-inspector/server/routes/v1/tools.ts
@@ -49,7 +49,7 @@ tools.post("/projects/:projectId/servers/:serverId/tools/call", async (c) =>
         body.toolName,
         body.parameters
       );
-      const durationMs = Date.now() - startedAt;
+      const durationMs = Math.max(0, Date.now() - startedAt);
       // Additive sibling on the MCP CallToolResult. `v1Resource` returns the
       // object verbatim, so agents can read latency without a second hop.
       if (result && typeof result === "object" && !Array.isArray(result)) {

--- a/mcpjam-inspector/server/routes/v1/tools.ts
+++ b/mcpjam-inspector/server/routes/v1/tools.ts
@@ -23,10 +23,11 @@ tools.post("/projects/:projectId/servers/:serverId/tools", async (c) =>
 );
 
 // POST /v1/projects/:projectId/servers/:serverId/tools/call
-// Execute a tool and return the MCP CallToolResult directly. Tool-level
-// failures (result.isError === true) are successful calls — the server
-// answered; only transport/auth errors flow through the v1 error envelope.
-// Mirrors /api/web/tools/execute, including the hosted task restriction.
+// Execute a tool and return the MCP CallToolResult plus additive durationMs.
+// Tool-level failures (result.isError === true) are successful calls — the
+// server answered; only transport/auth errors flow through the v1 error
+// envelope. Mirrors /api/web/tools/execute, including the hosted task
+// restriction.
 tools.post("/projects/:projectId/servers/:serverId/tools/call", async (c) =>
   runV1ServerOp(
     c,
@@ -42,11 +43,19 @@ tools.post("/projects/:projectId/servers/:serverId/tools/call", async (c) =>
           "Task-augmented tool execution is not supported on /api/v1"
         );
       }
-      return await manager.executeTool(
+      const startedAt = Date.now();
+      const result = await manager.executeTool(
         body.serverId,
         body.toolName,
         body.parameters
       );
+      const durationMs = Date.now() - startedAt;
+      // Additive sibling on the MCP CallToolResult. `v1Resource` returns the
+      // object verbatim, so agents can read latency without a second hop.
+      if (result && typeof result === "object" && !Array.isArray(result)) {
+        return { ...(result as Record<string, unknown>), durationMs };
+      }
+      return result;
     },
     (ctx, result) => v1Resource(ctx, result)
   )

--- a/mcpjam-inspector/server/routes/v1/tools.ts
+++ b/mcpjam-inspector/server/routes/v1/tools.ts
@@ -53,7 +53,12 @@ tools.post("/projects/:projectId/servers/:serverId/tools/call", async (c) =>
       // Additive sibling on the MCP CallToolResult. `v1Resource` returns the
       // object verbatim, so agents can read latency without a second hop.
       if (result && typeof result === "object" && !Array.isArray(result)) {
-        return { ...(result as Record<string, unknown>), durationMs };
+        const record = result as Record<string, unknown>;
+        // Never shadow the server's own field. `CallToolResult` allows extra
+        // keys, so a server may already report a `durationMs` of its own —
+        // overwriting it would destroy upstream data to report our copy of
+        // roughly the same number.
+        return "durationMs" in record ? record : { ...record, durationMs };
       }
       return result;
     },


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Purpose

Playground-for-Agents **PR 1 (WS3)**: `POST /v1/projects/:projectId/servers/:serverId/tools/call` already ran `manager.executeTool` but discarded the latency. Agents need that number inline.

## Before / after

- **Before:** the route returned the MCP `CallToolResult` verbatim with no timing.
- **After:** the same object plus additive `durationMs` (wall-clock milliseconds of `executeTool`). `v1Resource` still returns the object directly — no envelope wrap.

## What changed

- Time `manager.executeTool` in `routes/v1/tools.ts` and merge `durationMs` onto object results.
- Document the field on `CallToolResult` in OpenAPI + `docs/reference/public-api.mdx`.
- Route test: mocked runner returns the MCP result plus a measured `durationMs`.

## Verification

```
npx vitest run server/routes/v1/__tests__/tools-call.test.ts server/routes/v1/__tests__/openapi-drift.test.ts
```

7 passed (tools-call + openapi-drift).

## Rollout

Additive, backward-compatible (`additionalProperties: true` already allowed unknown fields). No backend deploy. Independent of later chat-session PRs.

## Follow-ups

PR 2 (CLI `_durationMs`), PR 3 (step-replay `elapsedMs`).
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-2fa398fa-2d31-4ce0-8ccf-8202b731e384?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-2fa398fa-2d31-4ce0-8ccf-8202b731e384&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds durationMs to POST /v1/projects/:projectId/servers/:serverId/tools/call so agents can read per-call latency inline. Before, the route returned the MCP CallToolResult only; now it returns the same result with an additive durationMs measured around executeTool, and it never overwrites a server-reported durationMs.

- Adds durationMs to object results; leaves null/primitives/arrays unchanged; clamps durationMs to a minimum of 0.
- Preserves a server’s own top-level durationMs when present.
- Tool-level failures (isError: true) still return 200; executeTool rejections use the v1 error envelope.
- Rejects taskOptions and allowTaskResult with 422 FEATURE_NOT_SUPPORTED.
- Updates OpenAPI and docs; adds route tests for durationMs, result shapes, unsupported options, and failures.
- Backward-compatible; clients may start reading durationMs when present.

<sup>Written for commit 37bd3554ea87dae048ee03a466a0e91284208cf8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/MCPJam/inspector/pull/4292?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

