### PR TITLE
eval: add `eval run --file` for versioned suite files

### DIFF
--- a/.changeset/eval-run-file.md
+++ b/.changeset/eval-run-file.md
@@ -1,0 +1,6 @@
+---
+"@mcpjam/cli": patch
+"@mcpjam/sdk": patch
+---
+
+`mcpjam cloud eval run --file` uploads a versioned suite file (declared identity, provenance, case sync) and starts a run. `eval create --file` on a suite file now points at `eval run --file`. File-owned suite export writes `suite.id` from the declared id.

--- a/.changeset/eval-run-file.md
+++ b/.changeset/eval-run-file.md
@@ -5,3 +5,5 @@
 ---
 
 `mcpjam cloud eval run --file` uploads a versioned suite file (declared identity, provenance, case sync) and starts a run. `eval create --file` on a suite file now points at `eval run --file`. File-owned suite export writes `suite.id` from the declared id.
+
+Case sync distinguishes the two ways a case stops running: one the file no longer declares is deleted from the hosted suite, while one the file still declares as `disabled: true` keeps its hosted history and is only left out of the launch.

--- a/.changeset/eval-run-file.md
+++ b/.changeset/eval-run-file.md
@@ -1,6 +1,7 @@
 ---
-"@mcpjam/cli": patch
-"@mcpjam/sdk": patch
+"@mcpjam/cli": minor
+"@mcpjam/sdk": minor
+"@mcpjam/inspector": minor
 ---
 
 `mcpjam cloud eval run --file` uploads a versioned suite file (declared identity, provenance, case sync) and starts a run. `eval create --file` on a suite file now points at `eval run --file`. File-owned suite export writes `suite.id` from the declared id.

--- a/cli/src/commands/eval.ts
+++ b/cli/src/commands/eval.ts
@@ -84,6 +84,10 @@ import {
   type SuiteExportFinding,
 } from "../lib/eval-suite-export.js";
 import {
+  executeEvalRunFromFile,
+  looksLikeVersionedSuiteFile,
+} from "../lib/eval-run-file.js";
+import {
   CORPUS_DRIFT_EXIT_CODE,
   CORPUS_INCOMPLETE_EXIT_CODE,
   CORPUS_USAGE_EXIT_CODE,
@@ -488,6 +492,11 @@ function loadSuiteDefinition(options: CreateOptions): CreateEvalSuiteInput {
     if (text.trim() === "") {
       throw usageError("--file input is empty.");
     }
+    if (looksLikeVersionedSuiteFile(text)) {
+      throw usageError(
+        "That looks like a versioned suite file. Use `eval run --file` to upload and run it."
+      );
+    }
     try {
       base = JSON.parse(text);
     } catch (error) {
@@ -504,6 +513,11 @@ function loadSuiteDefinition(options: CreateOptions): CreateEvalSuiteInput {
   }
   if (typeof base !== "object" || Array.isArray(base)) {
     throw usageError("Suite definition must be a JSON object.");
+  }
+  if ("schemaVersion" in (base as Record<string, unknown>)) {
+    throw usageError(
+      "That looks like a versioned suite file. Use `eval run --file` to upload and run it."
+    );
   }
 
   const merged = {
@@ -1476,10 +1490,18 @@ const SUITE_FILE_USAGE_EXIT_CODE = 2;
  * the buffer's length travels with the text rather than being re-derived from
  * it.
  */
-function readSuiteFileInput(value: string): { text: string; bytes: number } {
+function readSuiteFileInput(value: string): {
+  text: string;
+  bytes: number;
+  buffer: Buffer;
+} {
   try {
     const buffer = value === "-" ? readFileSync(0) : readFileSync(value);
-    return { text: buffer.toString("utf8"), bytes: buffer.byteLength };
+    return {
+      text: buffer.toString("utf8"),
+      bytes: buffer.byteLength,
+      buffer,
+    };
   } catch (error) {
     throw usageError(
       value === "-"
@@ -1749,7 +1771,7 @@ export function registerEvalCommands(program: Command): void {
       )
       .option(
         "--file <path>",
-        "Path to a suite definition JSON file (or - for stdin)"
+        "Path to a create-API JSON body (or - for stdin). A versioned suite file belongs on `eval run --file`"
       )
       .option(
         "--json <json>",
@@ -1838,8 +1860,14 @@ export function registerEvalCommands(program: Command): void {
 
       evals
       .command("run")
-      .description("Start an eval run of an existing suite (asynchronous)")
-      .requiredOption("--suite <id-or-name>", "Eval suite name or ID")
+      .description(
+        "Start an eval run of an existing suite, or upload a versioned suite file and run it"
+      )
+      .option("--suite <id-or-name>", "Eval suite name or ID")
+      .option(
+        "--file <path>",
+        "Versioned suite file to upload and run (.yaml or .json, or - for stdin)"
+      )
       .option(
         "--project <id-or-name>",
         "Project name or ID (defaults to the most recently updated project)"
@@ -1925,7 +1953,8 @@ export function registerEvalCommands(program: Command): void {
         composeServerGroup?: string;
         composeSkill?: string[];
         project?: string;
-        suite: string;
+        suite?: string;
+        file?: string;
         server?: string[];
         environment?: string[];
         host?: string[];
@@ -1941,6 +1970,12 @@ export function registerEvalCommands(program: Command): void {
       },
       command
     ) => {
+      if (options.file && options.suite) {
+        throw usageError("Provide either --file or --suite, not both.");
+      }
+      if (!options.file && !options.suite) {
+        throw usageError("Provide --suite <id-or-name> or --file <path>.");
+      }
       const globalOptions = getGlobalOptions(command);
       let webOrigin = DEFAULT_PLATFORM_ORIGIN;
       const resolved = resolveCloudProjectArgs(options);
@@ -1949,10 +1984,50 @@ export function registerEvalCommands(program: Command): void {
         globalOptions.timeout,
         (context) => {
           webOrigin = context.webOrigin;
+          if (options.file) {
+            const source = readSuiteFileInput(options.file);
+            return executeEvalRunFromFile(
+              { client: context.client, signal: context.signal },
+              {
+                source,
+                label: options.file === "-" ? "<stdin>" : options.file,
+                projectSelector: resolved.project ?? options.project,
+                knobs: {
+                  ...(options.server ? { server: options.server } : {}),
+                  ...(options.environment
+                    ? { environment: options.environment }
+                    : {}),
+                  ...(options.host ? { host: options.host } : {}),
+                  ...(options.allTargets ? { allTargets: true } : {}),
+                  ...(options.iterations !== undefined
+                    ? { iterations: options.iterations }
+                    : {}),
+                  ...(options.case?.length ? { case: options.case } : {}),
+                  ...(options.excludeSkills ? { excludeSkills: true } : {}),
+                  ...(options.refreshSnapshot ? { refreshSnapshot: true } : {}),
+                  ...(options.notes !== undefined ? { notes: options.notes } : {}),
+                  ...(options.minPassRate !== undefined
+                    ? { minPassRate: options.minPassRate }
+                    : {}),
+                  ...(options.matchOptions
+                    ? {
+                        matchOptions: parseMatchOptionsOption(
+                          options.matchOptions
+                        ),
+                      }
+                    : {}),
+                  ...(options.idempotencyKey
+                    ? { idempotencyKey: options.idempotencyKey }
+                    : {}),
+                  ...composeField(options),
+                },
+              }
+            );
+          }
           return runEvalSuiteOperation.execute(
             {
               project: resolved.project ?? options.project,
-              suite: options.suite,
+              suite: options.suite!,
               ...(options.server ? { servers: options.server } : {}),
               // ONE value maps to the singular field, several to the plural:
               // the op rejects sending both, and the singular carries the

--- a/cli/src/lib/eval-run-file.ts
+++ b/cli/src/lib/eval-run-file.ts
@@ -21,6 +21,7 @@ import {
   projectResolutionError,
   resolveProject,
   runEvalSuiteOperation,
+  setEvalSuiteEnvironmentsOperation,
   type PlatformApiClient,
   type PlatformEvalCase,
   type RunEvalSuiteInput,
@@ -129,6 +130,51 @@ export function fileCaseToUpdateBody(
   };
 }
 
+function refuseEmptyEnabledSet(loaded: {
+  resolved: { enabledCases: ResolvedEvalSuiteFileCase[] };
+}): void {
+  if (loaded.resolved.enabledCases.length === 0) {
+    throw cliError(
+      "NO_ENABLED_CASES",
+      "This suite file has no enabled cases. Hosted launch without a case filter runs every persisted case, including rows the file marked disabled. Enable at least one case — the file is refused rather than executed unscoped.",
+      SUITE_FILE_RUN_INVALID_EXIT_CODE,
+    );
+  }
+}
+
+function refuseUnsupportedHostedSemantics(loaded: {
+  authored: {
+    defaults: {
+      toolPolicy?: unknown;
+      validity: {
+        minEligibleTrials?: number;
+        minCompletionRate?: number;
+        maxEvaluatorErrorRate?: number;
+      };
+    };
+  };
+}): void {
+  if (loaded.authored.defaults.toolPolicy !== undefined) {
+    throw cliError(
+      "TOOL_POLICY_UNSUPPORTED",
+      "defaults.toolPolicy is not representable on a hosted run. The platform would execute the unrestricted tool set while stamping this file's hash. Remove toolPolicy, or run the suite locally.",
+      SUITE_FILE_RUN_INVALID_EXIT_CODE,
+    );
+  }
+  const validity = loaded.authored.defaults.validity;
+  if (
+    validity.minEligibleTrials !== undefined ||
+    validity.minCompletionRate !== undefined ||
+    validity.maxEvaluatorErrorRate !== undefined
+  ) {
+    throw cliError(
+      "VALIDITY_UNSUPPORTED",
+      "defaults.validity sets a gate the hosted runner does not enforce (minEligibleTrials, minCompletionRate, or maxEvaluatorErrorRate). A run could be reported as a pass or fail when the file would call it INVALID. Leave validity as {} — or run the suite locally.",
+      SUITE_FILE_RUN_INVALID_EXIT_CODE,
+    );
+  }
+}
+
 function refusePerCasePassThreshold(loaded: {
   resolved: {
     defaults: { passThreshold: number };
@@ -215,6 +261,7 @@ export async function syncFileOwnedCases(
   deleted: number;
   batches: number;
   enabledCaseIds: string[];
+  enabledCases: Array<{ id: string; declaredId: string; title: string }>;
 }> {
   const existing = await client.listEvalCases(
     { projectId: params.projectId, suiteId: params.suiteId },
@@ -252,7 +299,8 @@ export async function syncFileOwnedCases(
     code: string;
     message: string;
   }> = [];
-  const createdIds: string[] = [];
+  const createdCases: Array<{ id: string; declaredId: string; title: string }> =
+    [];
   for (
     let offset = 0;
     offset < toCreate.length;
@@ -270,7 +318,14 @@ export async function syncFileOwnedCases(
         { signal: params.signal },
       );
       for (const entry of result.created ?? []) {
-        createdIds.push(entry.id);
+        const declaredId = entry.declaredId ?? chunk[entry.index]?.id;
+        if (declaredId) {
+          createdCases.push({
+            id: entry.id,
+            declaredId,
+            title: entry.title ?? chunk[entry.index]?.title ?? "",
+          });
+        }
       }
       for (const entry of result.failed ?? []) {
         failed.push({
@@ -361,15 +416,21 @@ export async function syncFileOwnedCases(
     );
   }
 
+  const enabledCases = [
+    ...toUpdate.map(({ row, file }) => ({
+      id: row.id,
+      declaredId: file.id,
+      title: file.title,
+    })),
+    ...createdCases,
+  ];
   return {
     created: toCreate.length,
     updated: toUpdate.length,
     deleted: toDelete.length,
     batches,
-    enabledCaseIds: [
-      ...toUpdate.map(({ row }) => row.id),
-      ...createdIds,
-    ],
+    enabledCaseIds: enabledCases.map((entry) => entry.id),
+    enabledCases,
   };
 }
 
@@ -424,6 +485,52 @@ export function deriveFileRunIdempotencyKey(params: {
   });
 }
 
+function selectEnabledRunCases(
+  enabledCases: Array<{ id: string; declaredId: string; title: string }>,
+  allCases: ResolvedEvalSuiteFileCase[],
+  selectors: string[] | undefined,
+): string[] {
+  if (!selectors?.length) {
+    return enabledCases.map((entry) => entry.id);
+  }
+  const byDeclared = new Map(
+    enabledCases.map((entry) => [entry.declaredId, entry] as const),
+  );
+  const byTitle = new Map(
+    enabledCases.map((entry) => [entry.title, entry] as const),
+  );
+  const byRowId = new Map(enabledCases.map((entry) => [entry.id, entry] as const));
+  const selected: string[] = [];
+  for (const selector of selectors) {
+    const hit =
+      byDeclared.get(selector) ??
+      byRowId.get(selector) ??
+      byTitle.get(selector);
+    if (hit) {
+      selected.push(hit.id);
+      continue;
+    }
+    const disabled = allCases.find(
+      (testCase) =>
+        testCase.disabled &&
+        (testCase.id === selector || testCase.title === selector),
+    );
+    if (disabled) {
+      throw cliError(
+        "CASE_DISABLED",
+        `Case "${selector}" is marked disabled in the suite file and is left out of the launch. Remove --case ${selector}, or enable the case in the file.`,
+        SUITE_FILE_RUN_INVALID_EXIT_CODE,
+      );
+    }
+    throw cliError(
+      "CASE_NOT_IN_FILE",
+      `Case "${selector}" is not an enabled case in this suite file.`,
+      SUITE_FILE_RUN_INVALID_EXIT_CODE,
+    );
+  }
+  return selected;
+}
+
 /**
  * Auth has already happened: the caller invoked this inside
  * `runPlatformCommand` so the first network request is project resolution.
@@ -462,6 +569,8 @@ export async function executeEvalRunFromFile(
 
   refuseRepetitions(loaded);
   refusePerCasePassThreshold(loaded);
+  refuseEmptyEnabledSet(loaded);
+  refuseUnsupportedHostedSemantics(loaded);
 
   const passPercent = fractionToPercent(loaded.resolved.defaults.passThreshold);
   if (passPercent === null) {
@@ -504,7 +613,6 @@ export async function executeEvalRunFromFile(
           systemPrompt: "",
           temperature: 0,
         },
-        minIterations: authored.defaults.repetitions,
         defaultPassCriteria: { minimumPassRate: passPercent },
       },
     },
@@ -533,9 +641,21 @@ export async function executeEvalRunFromFile(
     !hasExplicitTarget && authored.target.environment
       ? authored.target.environment
       : undefined;
-  const runCases = knobs.case?.length
-    ? knobs.case
-    : syncedCases.enabledCaseIds;
+  if (fileEnvironment) {
+    await setEvalSuiteEnvironmentsOperation.execute(
+      {
+        project: project.id,
+        suite: synced.suite.id,
+        environments: [fileEnvironment],
+      },
+      { client: context.client, signal: context.signal },
+    );
+  }
+  const runCases = selectEnabledRunCases(
+    syncedCases.enabledCases,
+    loaded.resolved.cases,
+    knobs.case,
+  );
 
   const idempotencyKey = deriveFileRunIdempotencyKey({
     sourceHash,
@@ -569,7 +689,7 @@ export async function executeEvalRunFromFile(
       ...(knobs.iterations !== undefined
         ? { iterations: knobs.iterations }
         : {}),
-      ...(runCases.length ? { cases: runCases } : {}),
+      cases: runCases,
       ...(knobs.excludeSkills ? { excludeSkills: true } : {}),
       ...(knobs.refreshSnapshot ? { refreshSnapshot: true } : {}),
       ...(knobs.notes !== undefined ? { notes: knobs.notes } : {}),

--- a/cli/src/lib/eval-run-file.ts
+++ b/cli/src/lib/eval-run-file.ts
@@ -79,15 +79,18 @@ export function looksLikeCreateEvalApiJson(text: string): boolean {
   }
 }
 
-export function fileCaseToCreateBody(
-  testCase: ResolvedEvalSuiteFileCase,
-): Record<string, unknown> {
-  const models = [
+function fileCaseModels(testCase: ResolvedEvalSuiteFileCase) {
+  return [
     {
       model: testCase.model,
       ...(testCase.provider ? { provider: testCase.provider } : {}),
     },
   ];
+}
+
+export function fileCaseToCreateBody(
+  testCase: ResolvedEvalSuiteFileCase,
+): Record<string, unknown> {
   return {
     id: testCase.id,
     title: testCase.title,
@@ -97,19 +100,51 @@ export function fileCaseToCreateBody(
       ? { expectedOutput: testCase.expectedOutput }
       : {}),
     ...(testCase.isNegativeTest ? { isNegative: true } : {}),
-    models,
+    models: fileCaseModels(testCase),
     ...(testCase.assertions.length > 0
       ? { checks: { mode: "replace", list: testCase.assertions } }
       : {}),
   };
 }
 
-function fileCaseToUpdateBody(
+/**
+ * Replacement-style PATCH body. Create omits false/empty fields; PATCH
+ * treats omit as "leave the stored value", so a later file that drops
+ * `isNegativeTest` or assertions must send an explicit clear.
+ */
+export function fileCaseToUpdateBody(
   testCase: ResolvedEvalSuiteFileCase,
 ): Record<string, unknown> {
-  const body = fileCaseToCreateBody(testCase);
-  delete body.id;
-  return body;
+  return {
+    title: testCase.title,
+    steps: testCase.steps,
+    iterations: testCase.repetitions,
+    expectedOutput: testCase.expectedOutput ?? "",
+    isNegative: testCase.isNegativeTest,
+    models: fileCaseModels(testCase),
+    checks:
+      testCase.assertions.length > 0
+        ? { mode: "replace", list: testCase.assertions }
+        : null,
+  };
+}
+
+function refusePerCasePassThreshold(loaded: {
+  resolved: {
+    defaults: { passThreshold: number };
+    cases: ResolvedEvalSuiteFileCase[];
+  };
+}): void {
+  const suiteThreshold = loaded.resolved.defaults.passThreshold;
+  for (const testCase of loaded.resolved.cases) {
+    if (testCase.passThreshold !== suiteThreshold) {
+      throw cliError(
+        "CASE_PASS_THRESHOLD",
+        `Hosted runs grade every case against the suite's defaults.passThreshold (${suiteThreshold}); case "${testCase.id}" overrides passThreshold to ${testCase.passThreshold}. The platform has no per-case pass threshold, so this file is refused rather than graded against a different bar than it declares.`,
+        SUITE_FILE_RUN_INVALID_EXIT_CODE,
+      );
+    }
+  }
 }
 
 function refuseRepetitions(loaded: {
@@ -163,7 +198,13 @@ export async function syncFileOwnedCases(
     cases: ResolvedEvalSuiteFileCase[];
     signal?: AbortSignal;
   },
-): Promise<{ created: number; updated: number; batches: number }> {
+): Promise<{
+  created: number;
+  updated: number;
+  deleted: number;
+  batches: number;
+  enabledCaseIds: string[];
+}> {
   const existing = await client.listEvalCases(
     { projectId: params.projectId, suiteId: params.suiteId },
     { signal: params.signal },
@@ -173,15 +214,22 @@ export async function syncFileOwnedCases(
     if (row.declaredId) byDeclaredId.set(row.declaredId, row);
   }
 
+  const enabledDeclaredIds = new Set(params.cases.map((testCase) => testCase.id));
   const toCreate: ResolvedEvalSuiteFileCase[] = [];
   const toUpdate: Array<{
     row: PlatformEvalCase;
     file: ResolvedEvalSuiteFileCase;
   }> = [];
+  const toDelete: PlatformEvalCase[] = [];
   for (const testCase of params.cases) {
     const row = byDeclaredId.get(testCase.id);
     if (row) toUpdate.push({ row, file: testCase });
     else toCreate.push(testCase);
+  }
+  for (const row of existing.items) {
+    if (!row.declaredId || !enabledDeclaredIds.has(row.declaredId)) {
+      toDelete.push(row);
+    }
   }
 
   let batches = 0;
@@ -191,6 +239,7 @@ export async function syncFileOwnedCases(
     code: string;
     message: string;
   }> = [];
+  const createdIds: string[] = [];
   for (
     let offset = 0;
     offset < toCreate.length;
@@ -206,6 +255,9 @@ export async function syncFileOwnedCases(
       },
       { signal: params.signal },
     );
+    for (const entry of result.created ?? []) {
+      createdIds.push(entry.id);
+    }
     for (const entry of result.failed ?? []) {
       failed.push({
         index: offset + entry.index,
@@ -246,12 +298,57 @@ export async function syncFileOwnedCases(
         failed,
         created: toCreate.length,
         updated: toUpdate.length,
+        deleted: 0,
         batches,
       },
     );
   }
 
-  return { created: toCreate.length, updated: toUpdate.length, batches };
+  for (const row of toDelete) {
+    try {
+      await client.deleteEvalCase(
+        {
+          projectId: params.projectId,
+          suiteId: params.suiteId,
+          caseId: row.id,
+        },
+        { signal: params.signal },
+      );
+    } catch (error) {
+      failed.push({
+        index: -1,
+        ...(row.declaredId ? { declaredId: row.declaredId } : {}),
+        code: "DELETE_FAILED",
+        message: error instanceof Error ? error.message : String(error),
+      });
+    }
+  }
+
+  if (failed.length > 0) {
+    throw cliError(
+      "CASE_SYNC_FAILED",
+      `Failed to remove ${failed.length} stale case(s) from the suite file; the run was not started.`,
+      SUITE_FILE_RUN_INVALID_EXIT_CODE,
+      {
+        failed,
+        created: toCreate.length,
+        updated: toUpdate.length,
+        deleted: toDelete.length - failed.length,
+        batches,
+      },
+    );
+  }
+
+  return {
+    created: toCreate.length,
+    updated: toUpdate.length,
+    deleted: toDelete.length,
+    batches,
+    enabledCaseIds: [
+      ...toUpdate.map(({ row }) => row.id),
+      ...createdIds,
+    ],
+  };
 }
 
 export type EvalRunFileKnobs = {
@@ -269,6 +366,41 @@ export type EvalRunFileKnobs = {
   idempotencyKey?: string;
   compose?: RunEvalSuiteInput["compose"];
 };
+
+/**
+ * File-run idempotency covers the bytes AND every knob that changes what
+ * launches. Same file + `--iterations 1` vs `--iterations 10` must not
+ * collapse onto one run.
+ */
+export function deriveFileRunIdempotencyKey(params: {
+  sourceHash: string;
+  declaredSuiteId: string;
+  projectId: string;
+  target: unknown;
+  knobs: EvalRunFileKnobs;
+  fileEnvironment?: string;
+}): string {
+  if (params.knobs.idempotencyKey) return params.knobs.idempotencyKey;
+  return canonicalDigest({
+    sourceHash: params.sourceHash,
+    declaredSuiteId: params.declaredSuiteId,
+    project: params.projectId,
+    target: params.target,
+    servers: params.knobs.server ?? null,
+    environments:
+      params.knobs.environment ??
+      (params.fileEnvironment ? [params.fileEnvironment] : null),
+    hosts: params.knobs.host ?? null,
+    allTargets: params.knobs.allTargets === true,
+    iterations: params.knobs.iterations ?? null,
+    cases: params.knobs.case ?? null,
+    excludeSkills: params.knobs.excludeSkills === true,
+    refreshSnapshot: params.knobs.refreshSnapshot === true,
+    minPassRate: params.knobs.minPassRate ?? null,
+    matchOptions: params.knobs.matchOptions ?? null,
+    compose: params.knobs.compose ?? null,
+  });
+}
 
 /**
  * Auth has already happened: the caller invoked this inside
@@ -307,6 +439,7 @@ export async function executeEvalRunFromFile(
   }
 
   refuseRepetitions(loaded);
+  refusePerCasePassThreshold(loaded);
 
   const passPercent = fractionToPercent(loaded.resolved.defaults.passThreshold);
   if (passPercent === null) {
@@ -356,7 +489,7 @@ export async function executeEvalRunFromFile(
     { signal: context.signal },
   );
 
-  await syncFileOwnedCases(context.client, {
+  const syncedCases = await syncFileOwnedCases(context.client, {
     projectId: project.id,
     suiteId: synced.suite.id,
     cases: loaded.resolved.enabledCases,
@@ -375,15 +508,18 @@ export async function executeEvalRunFromFile(
     !hasExplicitTarget && authored.target.environment
       ? authored.target.environment
       : undefined;
+  const runCases = knobs.case?.length
+    ? knobs.case
+    : syncedCases.enabledCaseIds;
 
-  const idempotencyKey =
-    knobs.idempotencyKey ??
-    canonicalDigest({
-      sourceHash,
-      declaredSuiteId: authored.suite.id,
-      project: project.id,
-      target: authored.target,
-    });
+  const idempotencyKey = deriveFileRunIdempotencyKey({
+    sourceHash,
+    declaredSuiteId: authored.suite.id,
+    projectId: project.id,
+    target: authored.target,
+    knobs,
+    fileEnvironment,
+  });
 
   return runEvalSuiteOperation.execute(
     {
@@ -408,7 +544,7 @@ export async function executeEvalRunFromFile(
       ...(knobs.iterations !== undefined
         ? { iterations: knobs.iterations }
         : {}),
-      ...(knobs.case?.length ? { cases: knobs.case } : {}),
+      ...(runCases.length ? { cases: runCases } : {}),
       ...(knobs.excludeSkills ? { excludeSkills: true } : {}),
       ...(knobs.refreshSnapshot ? { refreshSnapshot: true } : {}),
       ...(knobs.notes !== undefined ? { notes: knobs.notes } : {}),

--- a/cli/src/lib/eval-run-file.ts
+++ b/cli/src/lib/eval-run-file.ts
@@ -247,23 +247,32 @@ export async function syncFileOwnedCases(
   ) {
     const chunk = toCreate.slice(offset, offset + MAX_BATCH_CREATE_CASES);
     batches += 1;
-    const result = await client.createEvalCases(
-      {
-        projectId: params.projectId,
-        suiteId: params.suiteId,
-        body: { cases: chunk.map(fileCaseToCreateBody) },
-      },
-      { signal: params.signal },
-    );
-    for (const entry of result.created ?? []) {
-      createdIds.push(entry.id);
-    }
-    for (const entry of result.failed ?? []) {
+    try {
+      const result = await client.createEvalCases(
+        {
+          projectId: params.projectId,
+          suiteId: params.suiteId,
+          body: { cases: chunk.map(fileCaseToCreateBody) },
+        },
+        { signal: params.signal },
+      );
+      for (const entry of result.created ?? []) {
+        createdIds.push(entry.id);
+      }
+      for (const entry of result.failed ?? []) {
+        failed.push({
+          index: offset + entry.index,
+          ...(entry.declaredId ? { declaredId: entry.declaredId } : {}),
+          code: entry.code,
+          message: entry.message,
+        });
+      }
+    } catch (error) {
       failed.push({
-        index: offset + entry.index,
-        ...(entry.declaredId ? { declaredId: entry.declaredId } : {}),
-        code: entry.code,
-        message: entry.message,
+        index: offset,
+        ...(chunk[0] ? { declaredId: chunk[0].id } : {}),
+        code: "CREATE_FAILED",
+        message: error instanceof Error ? error.message : String(error),
       });
     }
   }

--- a/cli/src/lib/eval-run-file.ts
+++ b/cli/src/lib/eval-run-file.ts
@@ -178,11 +178,11 @@ function refuseUnsupportedHostedSemantics(loaded: {
 function refusePerCasePassThreshold(loaded: {
   resolved: {
     defaults: { passThreshold: number };
-    cases: ResolvedEvalSuiteFileCase[];
+    enabledCases: ResolvedEvalSuiteFileCase[];
   };
 }): void {
   const suiteThreshold = loaded.resolved.defaults.passThreshold;
-  for (const testCase of loaded.resolved.cases) {
+  for (const testCase of loaded.resolved.enabledCases) {
     if (testCase.passThreshold !== suiteThreshold) {
       throw cliError(
         "CASE_PASS_THRESHOLD",
@@ -293,6 +293,7 @@ export async function syncFileOwnedCases(
   }
 
   let batches = 0;
+  let updatedCount = 0;
   const failed: Array<{
     index: number;
     declaredId?: string;
@@ -356,6 +357,7 @@ export async function syncFileOwnedCases(
         },
         { signal: params.signal },
       );
+      updatedCount += 1;
     } catch (error) {
       failed.push({
         index: -1,
@@ -373,8 +375,8 @@ export async function syncFileOwnedCases(
       SUITE_FILE_RUN_INVALID_EXIT_CODE,
       {
         failed,
-        created: toCreate.length,
-        updated: toUpdate.length,
+        created: createdCases.length,
+        updated: updatedCount,
         deleted: 0,
         batches,
       },
@@ -408,8 +410,8 @@ export async function syncFileOwnedCases(
       SUITE_FILE_RUN_INVALID_EXIT_CODE,
       {
         failed,
-        created: toCreate.length,
-        updated: toUpdate.length,
+        created: createdCases.length,
+        updated: updatedCount,
         deleted: toDelete.length - failed.length,
         batches,
       },

--- a/cli/src/lib/eval-run-file.ts
+++ b/cli/src/lib/eval-run-file.ts
@@ -1,0 +1,423 @@
+/**
+ * `eval run --file` — after auth, validate a repo suite file, snapshot it as
+ * a file-owned suite, sync its cases, and launch a run.
+ *
+ * Auth happens first on purpose: an invalid file on this command exits 2
+ * (1 is reserved for a real verdict), and the caller must have been a
+ * credentialed request when that verdict is reached. `eval validate` stays
+ * offline and still exits 1 for a contract-invalid file.
+ */
+
+import { createHash } from "node:crypto";
+import {
+  canonicalDigest,
+  formatSuiteFileFindings,
+  loadEvalSuiteFile,
+  type ResolvedEvalSuiteFileCase,
+  type SuiteFileLoadFailure,
+} from "@mcpjam/sdk";
+import { MAX_BATCH_CREATE_CASES } from "@mcpjam/sdk/contract";
+import {
+  projectResolutionError,
+  resolveProject,
+  runEvalSuiteOperation,
+  type PlatformApiClient,
+  type PlatformEvalCase,
+  type RunEvalSuiteInput,
+  type RunEvalSuiteResult,
+} from "@mcpjam/sdk/platform";
+import { cliError, usageError } from "./output.js";
+import { fractionToPercent } from "./eval-suite-export.js";
+
+/** Hosted runs refuse more than this many iterations — named, not clamped. */
+export const HOSTED_ITERATIONS_CAP = 10;
+
+/** Invalid file on `eval run --file`. Distinct from validate's exit 1. */
+export const SUITE_FILE_RUN_INVALID_EXIT_CODE = 2;
+
+export function sha256HexOfBuffer(buffer: Uint8Array): string {
+  return createHash("sha256").update(buffer).digest("hex");
+}
+
+/**
+ * True when the text is a versioned suite file — JSON with `schemaVersion`,
+ * or YAML whose first non-empty line (or any line) declares `schemaVersion:`.
+ */
+export function looksLikeVersionedSuiteFile(text: string): boolean {
+  try {
+    const parsed = JSON.parse(text) as unknown;
+    if (
+      parsed !== null &&
+      typeof parsed === "object" &&
+      !Array.isArray(parsed) &&
+      "schemaVersion" in parsed
+    ) {
+      return true;
+    }
+  } catch {
+    // YAML, or not JSON. Fall through to the text sniff.
+  }
+  return /^\s*schemaVersion\s*:/m.test(text);
+}
+
+/**
+ * True when the text is JSON that looks like `eval create --file` API JSON
+ * (a `tests` or `cases` array, no `schemaVersion`, no `suite` object).
+ */
+export function looksLikeCreateEvalApiJson(text: string): boolean {
+  try {
+    const parsed = JSON.parse(text) as unknown;
+    if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
+      return false;
+    }
+    const rec = parsed as Record<string, unknown>;
+    if (rec.schemaVersion !== undefined) return false;
+    if (rec.suite !== undefined && typeof rec.suite === "object") return false;
+    return Array.isArray(rec.tests) || Array.isArray(rec.cases);
+  } catch {
+    return false;
+  }
+}
+
+export function fileCaseToCreateBody(
+  testCase: ResolvedEvalSuiteFileCase,
+): Record<string, unknown> {
+  const models = [
+    {
+      model: testCase.model,
+      ...(testCase.provider ? { provider: testCase.provider } : {}),
+    },
+  ];
+  return {
+    id: testCase.id,
+    title: testCase.title,
+    steps: testCase.steps,
+    iterations: testCase.repetitions,
+    ...(testCase.expectedOutput !== undefined
+      ? { expectedOutput: testCase.expectedOutput }
+      : {}),
+    ...(testCase.isNegativeTest ? { isNegative: true } : {}),
+    models,
+    ...(testCase.assertions.length > 0
+      ? { checks: { mode: "replace", list: testCase.assertions } }
+      : {}),
+  };
+}
+
+function fileCaseToUpdateBody(
+  testCase: ResolvedEvalSuiteFileCase,
+): Record<string, unknown> {
+  const body = fileCaseToCreateBody(testCase);
+  delete body.id;
+  return body;
+}
+
+function refuseRepetitions(loaded: {
+  resolved: {
+    defaults: { repetitions: number };
+    enabledCases: ResolvedEvalSuiteFileCase[];
+  };
+}): void {
+  const suiteReps = loaded.resolved.defaults.repetitions;
+  if (suiteReps > HOSTED_ITERATIONS_CAP) {
+    throw cliError(
+      "REPETITIONS_CAP",
+      `Hosted runs accept at most ${HOSTED_ITERATIONS_CAP} iterations; the file's repetitions (${suiteReps}) exceed that cap. Reduce repetitions to ${HOSTED_ITERATIONS_CAP} or fewer — the value is not clamped.`,
+      SUITE_FILE_RUN_INVALID_EXIT_CODE,
+    );
+  }
+  for (const testCase of loaded.resolved.enabledCases) {
+    if (testCase.repetitions > HOSTED_ITERATIONS_CAP) {
+      throw cliError(
+        "REPETITIONS_CAP",
+        `Hosted runs accept at most ${HOSTED_ITERATIONS_CAP} iterations; case "${testCase.id}" sets repetitions ${testCase.repetitions}. Reduce repetitions to ${HOSTED_ITERATIONS_CAP} or fewer — the value is not clamped.`,
+        SUITE_FILE_RUN_INVALID_EXIT_CODE,
+      );
+    }
+  }
+}
+
+function suiteFileLoadError(label: string, loaded: SuiteFileLoadFailure) {
+  const summary =
+    loaded.findings.length === 1
+      ? `${label}: invalid (1 finding)`
+      : `${label}: invalid (${loaded.findings.length} findings)`;
+  return cliError(
+    "SUITE_FILE_INVALID",
+    `${summary}\n${formatSuiteFileFindings(loaded.findings)}`,
+    SUITE_FILE_RUN_INVALID_EXIT_CODE,
+    {
+      valid: false,
+      file: label,
+      stage: loaded.stage,
+      findings: [...loaded.findings],
+    },
+  );
+}
+
+export async function syncFileOwnedCases(
+  client: PlatformApiClient,
+  params: {
+    projectId: string;
+    suiteId: string;
+    cases: ResolvedEvalSuiteFileCase[];
+    signal?: AbortSignal;
+  },
+): Promise<{ created: number; updated: number; batches: number }> {
+  const existing = await client.listEvalCases(
+    { projectId: params.projectId, suiteId: params.suiteId },
+    { signal: params.signal },
+  );
+  const byDeclaredId = new Map<string, PlatformEvalCase>();
+  for (const row of existing.items) {
+    if (row.declaredId) byDeclaredId.set(row.declaredId, row);
+  }
+
+  const toCreate: ResolvedEvalSuiteFileCase[] = [];
+  const toUpdate: Array<{
+    row: PlatformEvalCase;
+    file: ResolvedEvalSuiteFileCase;
+  }> = [];
+  for (const testCase of params.cases) {
+    const row = byDeclaredId.get(testCase.id);
+    if (row) toUpdate.push({ row, file: testCase });
+    else toCreate.push(testCase);
+  }
+
+  let batches = 0;
+  const failed: Array<{
+    index: number;
+    declaredId?: string;
+    code: string;
+    message: string;
+  }> = [];
+  for (
+    let offset = 0;
+    offset < toCreate.length;
+    offset += MAX_BATCH_CREATE_CASES
+  ) {
+    const chunk = toCreate.slice(offset, offset + MAX_BATCH_CREATE_CASES);
+    batches += 1;
+    const result = await client.createEvalCases(
+      {
+        projectId: params.projectId,
+        suiteId: params.suiteId,
+        body: { cases: chunk.map(fileCaseToCreateBody) },
+      },
+      { signal: params.signal },
+    );
+    for (const entry of result.failed ?? []) {
+      failed.push({
+        index: offset + entry.index,
+        ...(entry.declaredId ? { declaredId: entry.declaredId } : {}),
+        code: entry.code,
+        message: entry.message,
+      });
+    }
+  }
+
+  for (const { row, file } of toUpdate) {
+    try {
+      await client.updateEvalCase(
+        {
+          projectId: params.projectId,
+          suiteId: params.suiteId,
+          caseId: row.id,
+          body: fileCaseToUpdateBody(file),
+        },
+        { signal: params.signal },
+      );
+    } catch (error) {
+      failed.push({
+        index: -1,
+        declaredId: file.id,
+        code: "UPDATE_FAILED",
+        message: error instanceof Error ? error.message : String(error),
+      });
+    }
+  }
+
+  if (failed.length > 0) {
+    throw cliError(
+      "CASE_SYNC_FAILED",
+      `Failed to sync ${failed.length} case(s) from the suite file; the run was not started.`,
+      SUITE_FILE_RUN_INVALID_EXIT_CODE,
+      {
+        failed,
+        created: toCreate.length,
+        updated: toUpdate.length,
+        batches,
+      },
+    );
+  }
+
+  return { created: toCreate.length, updated: toUpdate.length, batches };
+}
+
+export type EvalRunFileKnobs = {
+  server?: string[];
+  environment?: string[];
+  host?: string[];
+  allTargets?: boolean;
+  iterations?: number;
+  case?: string[];
+  excludeSkills?: boolean;
+  refreshSnapshot?: boolean;
+  notes?: string;
+  minPassRate?: number;
+  matchOptions?: RunEvalSuiteInput["matchOptions"];
+  idempotencyKey?: string;
+  compose?: RunEvalSuiteInput["compose"];
+};
+
+/**
+ * Auth has already happened: the caller invoked this inside
+ * `runPlatformCommand` so the first network request is project resolution.
+ */
+export async function executeEvalRunFromFile(
+  context: {
+    client: PlatformApiClient;
+    signal: AbortSignal;
+  },
+  params: {
+    source: { text: string; bytes: number; buffer: Uint8Array };
+    label: string;
+    knobs: EvalRunFileKnobs;
+    projectSelector?: string;
+  },
+): Promise<RunEvalSuiteResult> {
+  const page = await context.client.listProjects({}, { signal: context.signal });
+  const resolution = resolveProject(page.items, params.projectSelector);
+  if (!resolution.ok) {
+    throw projectResolutionError(resolution.message);
+  }
+  const project = resolution.project;
+
+  if (looksLikeCreateEvalApiJson(params.source.text)) {
+    throw usageError(
+      "That looks like an eval create API body, not a versioned suite file. Use `eval create --file` to author a suite from that JSON.",
+    );
+  }
+
+  const loaded = loadEvalSuiteFile(params.source.text, {
+    byteLength: params.source.bytes,
+  });
+  if (!loaded.ok) {
+    throw suiteFileLoadError(params.label, loaded);
+  }
+
+  refuseRepetitions(loaded);
+
+  const passPercent = fractionToPercent(loaded.resolved.defaults.passThreshold);
+  if (passPercent === null) {
+    throw cliError(
+      "PASS_THRESHOLD",
+      `defaults.passThreshold ${loaded.resolved.defaults.passThreshold} cannot be converted to a hosted percent without losing a digit.`,
+      SUITE_FILE_RUN_INVALID_EXIT_CODE,
+    );
+  }
+
+  const sourceHash = sha256HexOfBuffer(params.source.buffer);
+  const authored = loaded.authored;
+  const servers = authored.target.servers;
+  const synced = await context.client.syncFileOwnedEvalSuite(
+    {
+      projectId: project.id,
+      body: {
+        declaredSuiteId: authored.suite.id,
+        name: authored.suite.name,
+        ...(authored.suite.description !== undefined
+          ? { description: authored.suite.description }
+          : {}),
+        sourceHash,
+        ...(authored.provenance ? { provenance: authored.provenance } : {}),
+        environment: {
+          servers: servers.map((server) => server.name),
+          ...(servers.some((server) => server.id)
+            ? {
+                serverBindings: servers
+                  .filter((server) => server.id)
+                  .map((server) => ({
+                    serverName: server.name,
+                    projectServerId: server.id,
+                  })),
+              }
+            : {}),
+        },
+        defaultConfig: {
+          modelId: authored.defaults.model,
+          systemPrompt: "",
+          temperature: 0,
+        },
+        minIterations: authored.defaults.repetitions,
+        defaultPassCriteria: { minimumPassRate: passPercent },
+      },
+    },
+    { signal: context.signal },
+  );
+
+  await syncFileOwnedCases(context.client, {
+    projectId: project.id,
+    suiteId: synced.suite.id,
+    cases: loaded.resolved.enabledCases,
+    signal: context.signal,
+  });
+
+  const knobs = params.knobs;
+  const hasExplicitTarget = Boolean(
+    knobs.environment?.length ||
+      knobs.host?.length ||
+      knobs.allTargets ||
+      knobs.server?.length ||
+      knobs.compose,
+  );
+  const fileEnvironment =
+    !hasExplicitTarget && authored.target.environment
+      ? authored.target.environment
+      : undefined;
+
+  const idempotencyKey =
+    knobs.idempotencyKey ??
+    canonicalDigest({
+      sourceHash,
+      declaredSuiteId: authored.suite.id,
+      project: project.id,
+      target: authored.target,
+    });
+
+  return runEvalSuiteOperation.execute(
+    {
+      project: project.id,
+      suite: synced.suite.id,
+      sourceHash,
+      idempotencyKey,
+      ...(knobs.server ? { servers: knobs.server } : {}),
+      ...(knobs.environment?.length === 1
+        ? { environment: knobs.environment[0] }
+        : knobs.environment?.length
+          ? { environments: knobs.environment }
+          : fileEnvironment
+            ? { environment: fileEnvironment }
+            : {}),
+      ...(knobs.host?.length === 1
+        ? { host: knobs.host[0] }
+        : knobs.host?.length
+          ? { hosts: knobs.host }
+          : {}),
+      ...(knobs.allTargets ? { allAttached: true } : {}),
+      ...(knobs.iterations !== undefined
+        ? { iterations: knobs.iterations }
+        : {}),
+      ...(knobs.case?.length ? { cases: knobs.case } : {}),
+      ...(knobs.excludeSkills ? { excludeSkills: true } : {}),
+      ...(knobs.refreshSnapshot ? { refreshSnapshot: true } : {}),
+      ...(knobs.notes !== undefined ? { notes: knobs.notes } : {}),
+      ...(knobs.minPassRate !== undefined
+        ? { minPassRate: knobs.minPassRate }
+        : {}),
+      ...(knobs.matchOptions ? { matchOptions: knobs.matchOptions } : {}),
+      ...(knobs.compose ? { compose: knobs.compose } : {}),
+    },
+    { client: context.client, signal: context.signal },
+  );
+}

--- a/cli/src/lib/eval-run-file.ts
+++ b/cli/src/lib/eval-run-file.ts
@@ -196,6 +196,17 @@ export async function syncFileOwnedCases(
     projectId: string;
     suiteId: string;
     cases: ResolvedEvalSuiteFileCase[];
+    /**
+     * Every case id the file DECLARES, enabled or not.
+     *
+     * The deletion guard reads this, never `cases`. A `disabled: true` case is
+     * still declared — the contract calls it "the loader skips this case (it
+     * stays in the file)" — so deleting it would destroy the case's hosted
+     * history the moment somebody parks a flaky test, and re-enabling it a day
+     * later would not bring the iterations back. Disabled cases are excluded
+     * from the RUN instead, which `enabledCaseIds` already does.
+     */
+    declaredCaseIds: ReadonlySet<string>;
     signal?: AbortSignal;
   },
 ): Promise<{
@@ -214,7 +225,6 @@ export async function syncFileOwnedCases(
     if (row.declaredId) byDeclaredId.set(row.declaredId, row);
   }
 
-  const enabledDeclaredIds = new Set(params.cases.map((testCase) => testCase.id));
   const toCreate: ResolvedEvalSuiteFileCase[] = [];
   const toUpdate: Array<{
     row: PlatformEvalCase;
@@ -227,7 +237,10 @@ export async function syncFileOwnedCases(
     else toCreate.push(testCase);
   }
   for (const row of existing.items) {
-    if (!row.declaredId || !enabledDeclaredIds.has(row.declaredId)) {
+    // Stale means "the file no longer declares this case" — NOT "the file does
+    // not run it right now". A row the file still declares as `disabled` is
+    // kept, with its history, and simply left out of `enabledCaseIds`.
+    if (!row.declaredId || !params.declaredCaseIds.has(row.declaredId)) {
       toDelete.push(row);
     }
   }
@@ -502,6 +515,9 @@ export async function executeEvalRunFromFile(
     projectId: project.id,
     suiteId: synced.suite.id,
     cases: loaded.resolved.enabledCases,
+    declaredCaseIds: new Set(
+      loaded.resolved.cases.map((testCase) => testCase.id),
+    ),
     signal: context.signal,
   });
 

--- a/cli/src/lib/eval-suite-export.ts
+++ b/cli/src/lib/eval-suite-export.ts
@@ -164,19 +164,26 @@ export function fractionToPercent(fraction: number): number | null {
   const digits = `${whole}${decimals}`;
   const newPoint = whole.length + 2;
   const padded = digits.padEnd(newPoint, "0");
+  // Always keep a decimal point so the trailing-zero strip only eats the
+  // FRACTIONAL side. Without it, a left-shift that lands on an integer
+  // (`0.8` → `080`) would have `\.?0+$` turn `80` into `8`.
   const shifted =
     newPoint >= padded.length
-      ? padded
+      ? `${padded}.0`
       : `${padded.slice(0, newPoint)}.${padded.slice(newPoint)}`;
-  const normalized = `${sign}${shifted}`
+  const stripped = `${sign}${shifted}`
     .replace(/^(-?)0+(?=\d)/, "$1")
     .replace(/\.?0+$/, "");
-  const value = Number(
-    normalized === "" || normalized === "-" ? "0" : normalized
-  );
+  const normalized = stripped === "" || stripped === "-" ? "0" : stripped;
+  const value = Number(normalized);
 
   if (!Number.isFinite(value)) return null;
-  return plainDecimal(value) === normalized ? value : null;
+  if (plainDecimal(value) !== normalized) return null;
+  // Close the inverse: this percent must convert back to the same fraction.
+  // A left-shift that Number can hold is still refused when it is not the
+  // image of {@link percentToFraction} (the dashboard would grade a
+  // different threshold).
+  return percentToFraction(value) === fraction ? value : null;
 }
 
 /**

--- a/cli/src/lib/eval-suite-export.ts
+++ b/cli/src/lib/eval-suite-export.ts
@@ -146,6 +146,40 @@ export function percentToFraction(percent: number): number | null {
 }
 
 /**
+ * Shift a decimal number two places left of the point, in DECIMAL.
+ *
+ * The inverse of {@link percentToFraction}: a suite file stores
+ * `passThreshold` as a fraction, and the hosted suite grades on a percent.
+ * The same discipline applies — refuse rather than approximate — so a
+ * threshold that cannot be written as a percent without losing a digit is
+ * not uploaded as a nearby value the dashboard would grade differently.
+ */
+export function fractionToPercent(fraction: number): number | null {
+  if (!Number.isFinite(fraction)) return null;
+  const text = plainDecimal(fraction);
+  const match = /^(-?)(\d+)(?:\.(\d+))?$/.exec(text);
+  if (!match) return null;
+
+  const [, sign, whole, decimals = ""] = match;
+  const digits = `${whole}${decimals}`;
+  const newPoint = whole.length + 2;
+  const padded = digits.padEnd(newPoint, "0");
+  const shifted =
+    newPoint >= padded.length
+      ? padded
+      : `${padded.slice(0, newPoint)}.${padded.slice(newPoint)}`;
+  const normalized = `${sign}${shifted}`
+    .replace(/^(-?)0+(?=\d)/, "$1")
+    .replace(/\.?0+$/, "");
+  const value = Number(
+    normalized === "" || normalized === "-" ? "0" : normalized
+  );
+
+  if (!Number.isFinite(value)) return null;
+  return plainDecimal(value) === normalized ? value : null;
+}
+
+/**
  * A number's shortest round-tripping decimal, never in exponential notation.
  *
  * `toString` switches to `1e-7` below 1e-6, and the comparison above is against
@@ -730,7 +764,10 @@ export function buildSuiteFileFromPlatform(
     mode: "agentWorkflow",
     reportingMode: "standard",
     suite: {
-      id: detail.id,
+      // File-owned suites keep the declared id the file authored. A UI suite
+      // has none, so export still writes the Convex document id — running that
+      // file back is the ownership refusal, not an attach.
+      id: detail.declaredId ?? detail.id,
       name: (detail.name ?? "").trim(),
       ...(detail.description === null || detail.description === undefined
         ? {}

--- a/cli/src/lib/op-bindings.ts
+++ b/cli/src/lib/op-bindings.ts
@@ -168,10 +168,7 @@ export const CLI_BINDINGS: Readonly<Record<string, CliBinding>> = {
   list_eval_cases: { command: "cloud eval cases list" },
   get_eval_case: { command: "cloud eval cases get" },
   create_eval_case: { command: "cloud eval cases create" },
-  create_eval_cases: {
-    excluded:
-      'Authoring several cases from a shell means passing a FILE, and that file\'s format is now settled: the versioned eval suite file (`schemaVersion: "1"`, YAML canonical, JSON accepted, conventionally `.mcpjam/evals/*.yaml`), which `eval validate` reads offline and `eval export` writes. What is still missing is the UPLOAD half — a suite file has cases with declared ids and the batch surface takes cases inline, and deciding which of the two owns identity on the way up is the same decision as `eval run --file`\'s ownership rules. So this binds when that command lands, not before; a batch command today would ship a second spelling of "send these cases" ahead of it. The bulk writers meanwhile are the agent surfaces (MCP `create_eval_cases`, `POST …/cases/batch`), which take the cases inline.',
-  },
+  create_eval_cases: { command: "cloud eval run --file" },
   update_eval_case: { command: "cloud eval cases update" },
   delete_eval_case: { command: "cloud eval cases delete" },
   generate_eval_cases: { command: "cloud eval cases generate" },

--- a/cli/tests/eval-suite-file.test.ts
+++ b/cli/tests/eval-suite-file.test.ts
@@ -1921,6 +1921,44 @@ describe("eval run --file", () => {
     }
   });
 
+  test("a disabled case keeps its hosted history and simply does not run", async () => {
+    // `disabled: true` means "the loader skips this case (it stays in the
+    // file)". Deleting the hosted row would destroy the case's iterations the
+    // moment somebody parks a flaky test, and re-enabling it tomorrow would
+    // not bring them back. Declared-but-disabled is kept; only cases the file
+    // no longer declares AT ALL are stale.
+    const fixture = await startFileRunFixture({
+      existingCases: [
+        { id: "row_c_refund", declaredId: "c_refund", title: "Refunds" },
+        { id: "row_c_parked", declaredId: "c_parked", title: "Parked" },
+      ],
+    });
+    try {
+      await withTempDir(async (dir) => {
+        const file = path.join(dir, "suite.yaml");
+        await writeFile(
+          file,
+          `${VALID_SUITE_FILE}  - id: c_parked\n    title: Parked\n    disabled: true\n    steps:\n      - id: step-1\n        kind: prompt\n        prompt: Parked for now.\n`,
+          "utf8"
+        );
+        const run = await captureProcessOutput(() =>
+          main(
+            runFileArgv(fixture.baseUrl, "--file", file, "--project", "Alpha"),
+            { telemetry: telemetryDisabled }
+          )
+        );
+        assert.equal(run.result.exitCode, 0, run.stderr);
+        // Kept — not deleted.
+        assert.deepEqual(fixture.deletedCaseIds, []);
+        // And not run: the launch names only the enabled case.
+        const launched = fixture.runBodies[0] as { caseIds: string[] };
+        assert.deepEqual(launched.caseIds, ["row_c_refund"]);
+      });
+    } finally {
+      await fixture.close();
+    }
+  });
+
   test("updating a file-owned case clears removed negative and check fields", async () => {
     const fixture = await startFileRunFixture({
       existingCases: [

--- a/cli/tests/eval-suite-file.test.ts
+++ b/cli/tests/eval-suite-file.test.ts
@@ -1399,6 +1399,7 @@ async function startFileRunFixture(options?: {
   batchBodies: unknown[];
   updateBodies: unknown[];
   deletedCaseIds: string[];
+  suitePatches: unknown[];
   runBodies: unknown[];
   close: () => Promise<void>;
 }> {
@@ -1407,7 +1408,9 @@ async function startFileRunFixture(options?: {
   const batchBodies: unknown[] = [];
   const updateBodies: unknown[] = [];
   const deletedCaseIds: string[] = [];
+  const suitePatches: unknown[] = [];
   const runBodies: unknown[] = [];
+  let environmentIds: string[] = [];
   const casesByDeclaredId = new Map<
     string,
     { id: string; declaredId: string; title: string }
@@ -1584,7 +1587,54 @@ async function startFileRunFixture(options?: {
           environment: { servers: ["billing"] },
           executionConfig: { model: "anthropic/claude-sonnet-4-6" },
           hosts: [],
-          environmentIds: [],
+          environmentIds,
+          settings: {},
+          schedule: {},
+          createdAt: 1,
+          updatedAt: 2,
+        })
+      );
+      return;
+    }
+
+    if (
+      url.pathname === "/api/v1/projects/proj-alpha/environments" &&
+      method === "GET"
+    ) {
+      res.end(
+        JSON.stringify({
+          items: [
+            {
+              id: "env-prod",
+              name: "prod",
+              archived: false,
+            },
+          ],
+        })
+      );
+      return;
+    }
+
+    if (
+      url.pathname === "/api/v1/projects/proj-alpha/eval-suites/suite-file-1" &&
+      method === "PATCH"
+    ) {
+      const body = raw ? JSON.parse(raw) : {};
+      suitePatches.push(body);
+      if (Array.isArray(body.environmentIds)) {
+        environmentIds = body.environmentIds;
+      }
+      res.end(
+        JSON.stringify({
+          id: "suite-file-1",
+          declaredId: "s_billing",
+          name: "Billing smoke",
+          description: null,
+          projectId: "proj-alpha",
+          environment: { servers: ["billing"] },
+          executionConfig: { model: "anthropic/claude-sonnet-4-6" },
+          hosts: [],
+          environmentIds,
           settings: {},
           schedule: {},
           createdAt: 1,
@@ -1638,6 +1688,7 @@ async function startFileRunFixture(options?: {
     batchBodies,
     updateBodies,
     deletedCaseIds,
+    suitePatches,
     runBodies,
     close: () =>
       new Promise<void>((resolve, reject) =>
@@ -2035,6 +2086,191 @@ describe("eval run --file", () => {
           (entry) => JSON.parse(entry.stdout).runId
         );
         assert.deepEqual(ids, ["run-file-1", "run-file-2"]);
+      });
+    } finally {
+      await fixture.close();
+    }
+  });
+
+  test("a file with every case disabled is refused rather than run unscoped", async () => {
+    const fixture = await startFileRunFixture({
+      existingCases: [
+        { id: "row_c_refund", declaredId: "c_refund", title: "Refunds" },
+      ],
+    });
+    try {
+      await withTempDir(async (dir) => {
+        const file = path.join(dir, "suite.yaml");
+        await writeFile(
+          file,
+          VALID_SUITE_FILE.replace(
+            "    title: Refunds a duplicate charge",
+            "    disabled: true\n    title: Refunds a duplicate charge"
+          ),
+          "utf8"
+        );
+        const run = await captureProcessOutput(() =>
+          main(runFileArgv(fixture.baseUrl, "--file", file, "--project", "Alpha"), {
+            telemetry: telemetryDisabled,
+          })
+        );
+        assert.equal(run.result.exitCode, 2, run.stderr);
+        assert.match(run.stderr, /NO_ENABLED_CASES/);
+        assert.equal(fixture.runBodies.length, 0);
+      });
+    } finally {
+      await fixture.close();
+    }
+  });
+
+  test("--case cannot launch a disabled case the file still declares", async () => {
+    const fixture = await startFileRunFixture({
+      existingCases: [
+        { id: "row_c_refund", declaredId: "c_refund", title: "Refunds" },
+        { id: "row_c_parked", declaredId: "c_parked", title: "Parked" },
+      ],
+    });
+    try {
+      await withTempDir(async (dir) => {
+        const file = path.join(dir, "suite.yaml");
+        await writeFile(
+          file,
+          `${VALID_SUITE_FILE}  - id: c_parked\n    title: Parked\n    disabled: true\n    steps:\n      - id: step-1\n        kind: prompt\n        prompt: Parked for now.\n`,
+          "utf8"
+        );
+        const run = await captureProcessOutput(() =>
+          main(
+            runFileArgv(
+              fixture.baseUrl,
+              "--file",
+              file,
+              "--project",
+              "Alpha",
+              "--case",
+              "c_parked"
+            ),
+            { telemetry: telemetryDisabled }
+          )
+        );
+        assert.equal(run.result.exitCode, 2, run.stderr);
+        assert.match(run.stderr, /CASE_DISABLED/);
+        assert.equal(fixture.runBodies.length, 0);
+      });
+    } finally {
+      await fixture.close();
+    }
+  });
+
+  test("defaults.repetitions is not uploaded as a minIterations floor", async () => {
+    const fixture = await startFileRunFixture();
+    try {
+      await withTempDir(async (dir) => {
+        const file = path.join(dir, "suite.yaml");
+        await writeFile(
+          file,
+          VALID_SUITE_FILE.replace(
+            "    title: Refunds a duplicate charge",
+            "    repetitions: 1\n    title: Refunds a duplicate charge"
+          ),
+          "utf8"
+        );
+        const run = await captureProcessOutput(() =>
+          main(runFileArgv(fixture.baseUrl, "--file", file, "--project", "Alpha"), {
+            telemetry: telemetryDisabled,
+          })
+        );
+        assert.equal(run.result.exitCode, 0, run.stderr);
+        const synced = fixture.fromFileBodies[0] as Record<string, unknown>;
+        assert.equal("minIterations" in synced, false);
+        const batch = fixture.batchBodies[0] as {
+          cases: Array<{ iterations: number }>;
+        };
+        assert.equal(batch.cases[0].iterations, 1);
+      });
+    } finally {
+      await fixture.close();
+    }
+  });
+
+  test("authored toolPolicy and validity gates are refused", async () => {
+    const fixture = await startFileRunFixture();
+    try {
+      await withTempDir(async (dir) => {
+        const policyFile = path.join(dir, "policy.yaml");
+        await writeFile(
+          policyFile,
+          VALID_SUITE_FILE.replace(
+            "  validity: {}",
+            "  toolPolicy:\n    mode: readOnly\n  validity: {}"
+          ),
+          "utf8"
+        );
+        const policy = await captureProcessOutput(() =>
+          main(
+            runFileArgv(fixture.baseUrl, "--file", policyFile, "--project", "Alpha"),
+            { telemetry: telemetryDisabled }
+          )
+        );
+        assert.equal(policy.result.exitCode, 2, policy.stderr);
+        assert.match(policy.stderr, /TOOL_POLICY_UNSUPPORTED/);
+
+        const validityFile = path.join(dir, "validity.yaml");
+        await writeFile(
+          validityFile,
+          VALID_SUITE_FILE.replace(
+            "  validity: {}",
+            "  validity:\n    minEligibleTrials: 3"
+          ),
+          "utf8"
+        );
+        const validity = await captureProcessOutput(() =>
+          main(
+            runFileArgv(
+              fixture.baseUrl,
+              "--file",
+              validityFile,
+              "--project",
+              "Alpha"
+            ),
+            { telemetry: telemetryDisabled }
+          )
+        );
+        assert.equal(validity.result.exitCode, 2, validity.stderr);
+        assert.match(validity.stderr, /VALIDITY_UNSUPPORTED/);
+        assert.equal(fixture.runBodies.length, 0);
+      });
+    } finally {
+      await fixture.close();
+    }
+  });
+
+  test("target.environment is attached before the run starts", async () => {
+    const fixture = await startFileRunFixture();
+    try {
+      await withTempDir(async (dir) => {
+        const file = path.join(dir, "suite.yaml");
+        await writeFile(
+          file,
+          VALID_SUITE_FILE.replace(
+            "target:\n  servers:\n    - name: billing\n",
+            "target:\n  environment: prod\n  servers:\n    - name: billing\n"
+          ),
+          "utf8"
+        );
+        const run = await captureProcessOutput(() =>
+          main(runFileArgv(fixture.baseUrl, "--file", file, "--project", "Alpha"), {
+            telemetry: telemetryDisabled,
+          })
+        );
+        assert.equal(run.result.exitCode, 0, run.stderr);
+        assert.equal(fixture.suitePatches.length, 1);
+        assert.deepEqual(
+          (fixture.suitePatches[0] as { environmentIds: string[] })
+            .environmentIds,
+          ["env-prod"]
+        );
+        const launched = fixture.runBodies[0] as { environmentId?: string };
+        assert.equal(launched.environmentId, "env-prod");
       });
     } finally {
       await fixture.close();

--- a/cli/tests/eval-suite-file.test.ts
+++ b/cli/tests/eval-suite-file.test.ts
@@ -1740,6 +1740,12 @@ describe("eval run --file", () => {
           (fixture.runBodies[0] as { idempotencyKey: string }).idempotencyKey,
           "file-key-1"
         );
+        assert.equal(fixture.updateBodies.length, 1);
+        const updated = fixture.updateBodies[0] as Record<string, unknown>;
+        assert.equal(updated.id, undefined);
+        assert.equal(updated.title, "Refunds a duplicate charge");
+        assert.equal(updated.isNegative, false);
+        assert.equal(updated.checks, null);
       });
     } finally {
       await fixture.close();

--- a/cli/tests/eval-suite-file.test.ts
+++ b/cli/tests/eval-suite-file.test.ts
@@ -1392,6 +1392,12 @@ ${cases}
 
 async function startFileRunFixture(options?: {
   existingCases?: Array<{ id: string; declaredId: string; title: string }>;
+  /**
+   * Batch-create indexes to put in `failed` instead of `created`. Used to
+   * assert CASE_SYNC_FAILED reports landed writes, not attempted totals.
+   */
+  failCreateIndexes?: readonly number[];
+  failUpdates?: boolean;
 }): Promise<{
   baseUrl: string;
   authHeaders: string[];
@@ -1497,26 +1503,49 @@ async function startFileRunFixture(options?: {
     ) {
       const body = raw ? JSON.parse(raw) : {};
       batchBodies.push(body);
-      const created = (body.cases as Array<{ id?: string; title: string }>).map(
+      const created: Array<{
+        index: number;
+        id: string;
+        declaredId: string;
+        title: string;
+        replayed: boolean;
+      }> = [];
+      const failed: Array<{
+        index: number;
+        declaredId: string;
+        code: string;
+        message: string;
+      }> = [];
+      const failCreate = new Set(options?.failCreateIndexes ?? []);
+      (body.cases as Array<{ id?: string; title: string }>).forEach(
         (testCase, index) => {
           const declaredId = testCase.id ?? `minted_${index}`;
+          if (failCreate.has(index)) {
+            failed.push({
+              index,
+              declaredId,
+              code: "CREATE_FAILED",
+              message: `fixture refused ${declaredId}`,
+            });
+            return;
+          }
           const id = `row_${declaredId}`;
           casesByDeclaredId.set(declaredId, {
             id,
             declaredId,
             title: testCase.title,
           });
-          return {
+          created.push({
             index,
             id,
             declaredId,
             title: testCase.title,
             replayed: false,
-          };
+          });
         }
       );
       res.statusCode = 201;
-      res.end(JSON.stringify({ created, failed: [], duplicatePolicy: "block" }));
+      res.end(JSON.stringify({ created, failed, duplicatePolicy: "block" }));
       return;
     }
 
@@ -1527,6 +1556,11 @@ async function startFileRunFixture(options?: {
       method === "PATCH"
     ) {
       updateBodies.push(raw ? JSON.parse(raw) : {});
+      if (options?.failUpdates) {
+        res.statusCode = 500;
+        res.end(JSON.stringify({ error: { code: "UPDATE_FAILED", message: "fixture update failed" } }));
+        return;
+      }
       res.end(JSON.stringify({ id: "row_c_refund", title: "updated" }));
       return;
     }
@@ -1908,6 +1942,104 @@ describe("eval run --file", () => {
         assert.equal(run.result.exitCode, 2, run.stderr);
         assert.match(run.stderr, /eval create --file/);
         assert.equal(fixture.fromFileBodies.length, 0);
+        assert.equal(fixture.runBodies.length, 0);
+      });
+    } finally {
+      await fixture.close();
+    }
+  });
+
+  test("a disabled case with a passThreshold override does not refuse the run", async () => {
+    const fixture = await startFileRunFixture({
+      existingCases: [
+        { id: "row_c_refund", declaredId: "c_refund", title: "Refunds" },
+        { id: "row_c_parked", declaredId: "c_parked", title: "Parked" },
+      ],
+    });
+    try {
+      await withTempDir(async (dir) => {
+        const file = path.join(dir, "suite.yaml");
+        await writeFile(
+          file,
+          `${VALID_SUITE_FILE}  - id: c_parked\n    title: Parked\n    disabled: true\n    passThreshold: 0.95\n    steps:\n      - id: step-1\n        kind: prompt\n        prompt: Parked for now.\n`,
+          "utf8"
+        );
+        const run = await captureProcessOutput(() =>
+          main(runFileArgv(fixture.baseUrl, "--file", file, "--project", "Alpha"), {
+            telemetry: telemetryDisabled,
+          })
+        );
+        assert.equal(run.result.exitCode, 0, run.stderr);
+        assert.equal(fixture.runBodies.length, 1);
+        const launched = fixture.runBodies[0] as { caseIds: string[] };
+        assert.deepEqual(launched.caseIds, ["row_c_refund"]);
+      });
+    } finally {
+      await fixture.close();
+    }
+  });
+
+  test("CASE_SYNC_FAILED reports landed writes, not attempted totals", async () => {
+    const fixture = await startFileRunFixture({
+      failCreateIndexes: [1],
+    });
+    try {
+      await withTempDir(async (dir) => {
+        const file = path.join(dir, "suite.yaml");
+        await writeFile(file, suiteFileWithCases(2), "utf8");
+        const run = await captureProcessOutput(() =>
+          main(runFileArgv(fixture.baseUrl, "--file", file, "--project", "Alpha"), {
+            telemetry: telemetryDisabled,
+          })
+        );
+        assert.equal(run.result.exitCode, 2, run.stderr);
+        assert.match(run.stderr, /CASE_SYNC_FAILED/);
+        const jsonLine = run.stderr
+          .split("\n")
+          .reverse()
+          .find((line) => line.startsWith("{"));
+        assert.ok(jsonLine, run.stderr);
+        const payload = JSON.parse(jsonLine) as {
+          error: { details: { created: number; updated: number; deleted: number } };
+        };
+        assert.equal(payload.error.details.created, 1);
+        assert.equal(payload.error.details.updated, 0);
+        assert.equal(payload.error.details.deleted, 0);
+        assert.equal(fixture.runBodies.length, 0);
+      });
+    } finally {
+      await fixture.close();
+    }
+  });
+
+  test("CASE_SYNC_FAILED counts only updates that landed", async () => {
+    const fixture = await startFileRunFixture({
+      existingCases: [
+        { id: "row_c_refund", declaredId: "c_refund", title: "Refunds" },
+      ],
+      failUpdates: true,
+    });
+    try {
+      await withTempDir(async (dir) => {
+        const file = path.join(dir, "suite.yaml");
+        await writeFile(file, VALID_SUITE_FILE, "utf8");
+        const run = await captureProcessOutput(() =>
+          main(runFileArgv(fixture.baseUrl, "--file", file, "--project", "Alpha"), {
+            telemetry: telemetryDisabled,
+          })
+        );
+        assert.equal(run.result.exitCode, 2, run.stderr);
+        assert.match(run.stderr, /CASE_SYNC_FAILED/);
+        const jsonLine = run.stderr
+          .split("\n")
+          .reverse()
+          .find((line) => line.startsWith("{"));
+        assert.ok(jsonLine, run.stderr);
+        const payload = JSON.parse(jsonLine) as {
+          error: { details: { created: number; updated: number } };
+        };
+        assert.equal(payload.error.details.created, 0);
+        assert.equal(payload.error.details.updated, 0);
         assert.equal(fixture.runBodies.length, 0);
       });
     } finally {

--- a/cli/tests/eval-suite-file.test.ts
+++ b/cli/tests/eval-suite-file.test.ts
@@ -36,9 +36,15 @@ import path from "node:path";
 import { fileURLToPath } from "node:url";
 import { loadEvalSuiteFile } from "@mcpjam/sdk";
 import {
+  fractionToPercent,
   modalRepetitions,
   percentToFraction,
 } from "../src/lib/eval-suite-export.js";
+import {
+  looksLikeCreateEvalApiJson,
+  looksLikeVersionedSuiteFile,
+  sha256HexOfBuffer,
+} from "../src/lib/eval-run-file.js";
 import { main } from "../src/index.js";
 
 const telemetryDisabled = {
@@ -369,6 +375,69 @@ describe("percentToFraction", () => {
     ]) {
       assert.equal(percentToFraction(percent), null, String(percent));
     }
+  });
+});
+
+describe("fractionToPercent", () => {
+  test("is the inverse of percentToFraction on the hosted values", () => {
+    const percents = [
+      0, 1, 7, 20, 80, 85, 99, 100, 0.5, 5.5, 12.345, 33.333333, 0.0001,
+      0.00001, 1e-7,
+    ];
+    for (const percent of percents) {
+      const fraction = percentToFraction(percent);
+      assert.notEqual(fraction, null, `${percent}%`);
+      assert.equal(fractionToPercent(fraction!), percent, `${percent}%`);
+    }
+  });
+
+  test("refuses anything it cannot represent without losing a digit", () => {
+    for (const fraction of [
+      Number.NaN,
+      Number.POSITIVE_INFINITY,
+      0.1 + 0.2,
+    ]) {
+      assert.equal(fractionToPercent(fraction), null, String(fraction));
+    }
+  });
+});
+
+describe("directed --file overload", () => {
+  test("sniffs a versioned suite file in YAML and JSON", () => {
+    assert.equal(looksLikeVersionedSuiteFile(VALID_SUITE_FILE), true);
+    assert.equal(
+      looksLikeVersionedSuiteFile(
+        JSON.stringify({
+          schemaVersion: "1",
+          mode: "agentWorkflow",
+          suite: { id: "s_billing", name: "Billing" },
+        })
+      ),
+      true
+    );
+    assert.equal(looksLikeVersionedSuiteFile('{"name":"smoke","cases":[]}'), false);
+  });
+
+  test("detects create-API JSON and ignores suite files", () => {
+    assert.equal(
+      looksLikeCreateEvalApiJson(
+        JSON.stringify({
+          name: "Authored smoke",
+          cases: [{ title: "echo", steps: [] }],
+        })
+      ),
+      true
+    );
+    assert.equal(
+      looksLikeCreateEvalApiJson(
+        JSON.stringify({
+          name: "Authored smoke",
+          tests: [{ title: "echo", steps: [] }],
+        })
+      ),
+      true
+    );
+    assert.equal(looksLikeCreateEvalApiJson(VALID_SUITE_FILE), false);
   });
 });
 
@@ -710,6 +779,23 @@ describe("eval validate", () => {
 // ── eval export ──────────────────────────────────────────────────────────────
 
 describe("eval export", () => {
+  test("writes declaredId as suite.id for a file-owned suite", async () => {
+    await withTempDir(async () => {
+      const run = await runExport(
+        { detail: { declaredId: "s_billing_file" } },
+        "--suite",
+        "Billing smoke"
+      );
+      assert.equal(run.exitCode, 0, run.stderr);
+      const loaded = loadEvalSuiteFile(
+        await readFile(JSON.parse(run.stdout).path, "utf8")
+      );
+      assert.equal(loaded.ok, true);
+      if (!loaded.ok) return;
+      assert.equal(loaded.authored.suite.id, "s_billing_file");
+    });
+  });
+
   test("writes a file that reads back as the same suite", async () => {
     await withTempDir(async (dir) => {
       const run = await runExport({}, "--suite", "Billing smoke");
@@ -1245,5 +1331,495 @@ describe("eval export", () => {
       );
       assert.deepEqual(leftovers, []);
     });
+  });
+});
+
+// ── eval run --file ──────────────────────────────────────────────────────────
+
+function runFileArgv(baseUrl: string, ...args: string[]): string[] {
+  return [
+    "node",
+    "mcpjam",
+    "cloud",
+    "eval",
+    "run",
+    ...args,
+    "--api-key",
+    "sk_test",
+    "--api-url",
+    baseUrl,
+    "--format",
+    "json",
+  ];
+}
+
+function suiteFileWithCases(count: number): string {
+  const cases = Array.from({ length: count }, (_, i) =>
+    [
+      `  - id: c_case_${i}`,
+      `    title: Case ${i}`,
+      `    steps:`,
+      `      - id: step-${i}`,
+      `        kind: prompt`,
+      `        prompt: Do thing ${i}.`,
+    ].join("\n")
+  ).join("\n");
+  return `schemaVersion: "1"
+mode: agentWorkflow
+reportingMode: standard
+suite:
+  id: s_bulk
+  name: Bulk
+target:
+  servers:
+    - name: billing
+defaults:
+  model: anthropic/claude-sonnet-4-6
+  repetitions: 1
+  passThreshold: 0.8
+  validity: {}
+cases:
+${cases}
+`;
+}
+
+async function startFileRunFixture(): Promise<{
+  baseUrl: string;
+  authHeaders: string[];
+  fromFileBodies: unknown[];
+  batchBodies: unknown[];
+  updateBodies: unknown[];
+  runBodies: unknown[];
+  close: () => Promise<void>;
+}> {
+  const authHeaders: string[] = [];
+  const fromFileBodies: unknown[] = [];
+  const batchBodies: unknown[] = [];
+  const updateBodies: unknown[] = [];
+  const runBodies: unknown[] = [];
+  const casesByDeclaredId = new Map<
+    string,
+    { id: string; declaredId: string; title: string }
+  >();
+  const runsByKey = new Map<string, string>();
+  let runCounter = 0;
+
+  const server: Server = createServer(async (req, res) => {
+    let raw = "";
+    for await (const chunk of req) {
+      raw += chunk;
+    }
+    authHeaders.push(req.headers.authorization ?? "");
+    const url = new URL(req.url ?? "/", "http://fixture");
+    res.setHeader("content-type", "application/json");
+    const method = req.method ?? "GET";
+
+    if (url.pathname === "/api/v1/projects") {
+      res.end(
+        JSON.stringify({
+          items: [
+            {
+              id: "proj-alpha",
+              name: "Alpha",
+              description: null,
+              icon: null,
+              organizationId: "org-1",
+              visibility: null,
+              createdAt: 1,
+              updatedAt: 200,
+            },
+          ],
+        })
+      );
+      return;
+    }
+
+    if (
+      url.pathname === "/api/v1/projects/proj-alpha/eval-suites/from-file" &&
+      method === "POST"
+    ) {
+      const body = raw ? JSON.parse(raw) : {};
+      fromFileBodies.push(body);
+      res.statusCode = fromFileBodies.length === 1 ? 201 : 200;
+      res.end(
+        JSON.stringify({
+          created: fromFileBodies.length === 1,
+          suite: {
+            id: "suite-file-1",
+            declaredId: body.declaredSuiteId,
+            name: body.name ?? "Billing smoke",
+            description: null,
+            projectId: "proj-alpha",
+            environment: { servers: ["billing"], computerEnvironment: null },
+            executionConfig: { model: body.defaultConfig?.modelId ?? "m" },
+            hosts: [],
+            environmentIds: [],
+            settings: {},
+            schedule: {},
+            createdAt: 1,
+            updatedAt: 2,
+          },
+        })
+      );
+      return;
+    }
+
+    if (
+      url.pathname ===
+        "/api/v1/projects/proj-alpha/eval-suites/suite-file-1/cases" &&
+      method === "GET"
+    ) {
+      res.end(JSON.stringify({ items: [...casesByDeclaredId.values()] }));
+      return;
+    }
+
+    if (
+      url.pathname ===
+        "/api/v1/projects/proj-alpha/eval-suites/suite-file-1/cases/batch" &&
+      method === "POST"
+    ) {
+      const body = raw ? JSON.parse(raw) : {};
+      batchBodies.push(body);
+      const created = (body.cases as Array<{ id?: string; title: string }>).map(
+        (testCase, index) => {
+          const declaredId = testCase.id ?? `minted_${index}`;
+          const id = `row_${declaredId}`;
+          casesByDeclaredId.set(declaredId, {
+            id,
+            declaredId,
+            title: testCase.title,
+          });
+          return {
+            index,
+            id,
+            declaredId,
+            title: testCase.title,
+            replayed: false,
+          };
+        }
+      );
+      res.statusCode = 201;
+      res.end(JSON.stringify({ created, failed: [], duplicatePolicy: "block" }));
+      return;
+    }
+
+    if (
+      url.pathname.startsWith(
+        "/api/v1/projects/proj-alpha/eval-suites/suite-file-1/cases/"
+      ) &&
+      method === "PATCH"
+    ) {
+      updateBodies.push(raw ? JSON.parse(raw) : {});
+      res.end(JSON.stringify({ id: "row_c_refund", title: "updated" }));
+      return;
+    }
+
+    if (
+      url.pathname === "/api/v1/projects/proj-alpha/eval-suites" &&
+      method === "GET"
+    ) {
+      res.end(
+        JSON.stringify({
+          items: [
+            {
+              id: "suite-file-1",
+              name: "Billing smoke",
+              projectId: "proj-alpha",
+              createdAt: 1,
+              updatedAt: 2,
+              latestRun: null,
+              totals: { passed: 0, failed: 0, runs: 0 },
+              passRateTrend: [],
+            },
+          ],
+        })
+      );
+      return;
+    }
+
+    if (
+      url.pathname === "/api/v1/projects/proj-alpha/eval-suites/suite-file-1" &&
+      method === "GET"
+    ) {
+      res.end(
+        JSON.stringify({
+          id: "suite-file-1",
+          declaredId: "s_billing",
+          name: "Billing smoke",
+          description: null,
+          projectId: "proj-alpha",
+          environment: { servers: ["billing"] },
+          executionConfig: { model: "anthropic/claude-sonnet-4-6" },
+          hosts: [],
+          environmentIds: [],
+          settings: {},
+          schedule: {},
+          createdAt: 1,
+          updatedAt: 2,
+        })
+      );
+      return;
+    }
+
+    if (
+      url.pathname === "/api/v1/projects/proj-alpha/eval-runs" &&
+      method === "POST"
+    ) {
+      const body = raw ? JSON.parse(raw) : {};
+      runBodies.push(body);
+      const key =
+        typeof body.idempotencyKey === "string" ? body.idempotencyKey : "";
+      let runId = runsByKey.get(key);
+      if (!runId) {
+        runCounter += 1;
+        runId = `run-file-${runCounter}`;
+        if (key) runsByKey.set(key, runId);
+      }
+      res.statusCode = 202;
+      res.end(
+        JSON.stringify({
+          runId,
+          suiteId: "suite-file-1",
+          status: "running",
+          caseUpsert: { committed: [], failed: [] },
+          servers: [{ id: "srv-billing", name: "billing" }],
+          environment: null,
+        })
+      );
+      return;
+    }
+
+    res.statusCode = 404;
+    res.end(JSON.stringify({ error: { message: `no route ${url.pathname}` } }));
+  });
+
+  await new Promise<void>((resolve) => server.listen(0, "127.0.0.1", resolve));
+  const address = server.address();
+  if (typeof address === "string" || address === null) {
+    throw new Error("fixture server did not bind a port");
+  }
+  return {
+    baseUrl: `http://127.0.0.1:${address.port}/api/v1`,
+    authHeaders,
+    fromFileBodies,
+    batchBodies,
+    updateBodies,
+    runBodies,
+    close: () =>
+      new Promise<void>((resolve, reject) =>
+        server.close((error) => (error ? reject(error) : resolve()))
+      ),
+  };
+}
+
+describe("eval run --file", () => {
+  test("invalid file exits 2 after auth and creates no run", async () => {
+    const fixture = await startFileRunFixture();
+    try {
+      await withTempDir(async (dir) => {
+        const file = path.join(dir, "suite.yaml");
+        await writeFile(
+          file,
+          VALID_SUITE_FILE.replace("id: c_refund", 'id: "not a valid id"'),
+          "utf8"
+        );
+        const run = await captureProcessOutput(() =>
+          main(runFileArgv(fixture.baseUrl, "--file", file), {
+            telemetry: telemetryDisabled,
+          })
+        );
+        assert.equal(run.result.exitCode, 2, run.stderr);
+        assert.ok(fixture.authHeaders.length > 0, "auth request must arrive first");
+        assert.equal(fixture.fromFileBodies.length, 0);
+        assert.equal(fixture.runBodies.length, 0);
+        assert.match(run.stderr, /SUITE_FILE_INVALID/);
+      });
+    } finally {
+      await fixture.close();
+    }
+  });
+
+  test("valid file creates one run with the declared ids", async () => {
+    const fixture = await startFileRunFixture();
+    try {
+      await withTempDir(async (dir) => {
+        const file = path.join(dir, "suite.yaml");
+        await writeFile(file, VALID_SUITE_FILE, "utf8");
+        const expectedHash = sha256HexOfBuffer(Buffer.from(VALID_SUITE_FILE));
+        const run = await captureProcessOutput(() =>
+          main(runFileArgv(fixture.baseUrl, "--file", file, "--project", "Alpha"), {
+            telemetry: telemetryDisabled,
+          })
+        );
+        assert.equal(run.result.exitCode, 0, run.stderr);
+        assert.equal(fixture.fromFileBodies.length, 1);
+        const synced = fixture.fromFileBodies[0] as Record<string, unknown>;
+        assert.equal(synced.declaredSuiteId, "s_billing");
+        assert.equal(synced.sourceHash, expectedHash);
+        assert.equal(fixture.batchBodies.length, 1);
+        const batch = fixture.batchBodies[0] as { cases: Array<{ id: string }> };
+        assert.equal(batch.cases[0].id, "c_refund");
+        assert.equal(fixture.runBodies.length, 1);
+        const launched = fixture.runBodies[0] as Record<string, unknown>;
+        assert.equal(launched.suiteId, "suite-file-1");
+        assert.equal(launched.sourceHash, expectedHash);
+        assert.equal(typeof launched.idempotencyKey, "string");
+        const payload = JSON.parse(run.stdout);
+        assert.equal(payload.outcome, "started");
+        assert.equal(payload.runId, "run-file-1");
+      });
+    } finally {
+      await fixture.close();
+    }
+  });
+
+  test("same file twice with one idempotency key starts exactly one run", async () => {
+    const fixture = await startFileRunFixture();
+    try {
+      await withTempDir(async (dir) => {
+        const file = path.join(dir, "suite.yaml");
+        await writeFile(file, VALID_SUITE_FILE, "utf8");
+        const argv = runFileArgv(
+          fixture.baseUrl,
+          "--file",
+          file,
+          "--project",
+          "Alpha",
+          "--idempotency-key",
+          "file-key-1"
+        );
+        const first = await captureProcessOutput(() =>
+          main(argv, { telemetry: telemetryDisabled })
+        );
+        const second = await captureProcessOutput(() =>
+          main(argv, { telemetry: telemetryDisabled })
+        );
+        assert.equal(first.result.exitCode, 0, first.stderr);
+        assert.equal(second.result.exitCode, 0, second.stderr);
+        assert.equal(fixture.runBodies.length, 2);
+        const ids = [first, second].map(
+          (entry) => JSON.parse(entry.stdout).runId
+        );
+        assert.deepEqual(ids, ["run-file-1", "run-file-1"]);
+        assert.equal(
+          (fixture.runBodies[0] as { idempotencyKey: string }).idempotencyKey,
+          "file-key-1"
+        );
+      });
+    } finally {
+      await fixture.close();
+    }
+  });
+
+  test("repetitions: 50 is refused naming the hosted cap of 10", async () => {
+    const fixture = await startFileRunFixture();
+    try {
+      await withTempDir(async (dir) => {
+        const file = path.join(dir, "suite.yaml");
+        await writeFile(
+          file,
+          VALID_SUITE_FILE.replace("repetitions: 5", "repetitions: 50"),
+          "utf8"
+        );
+        const run = await captureProcessOutput(() =>
+          main(runFileArgv(fixture.baseUrl, "--file", file, "--project", "Alpha"), {
+            telemetry: telemetryDisabled,
+          })
+        );
+        assert.equal(run.result.exitCode, 2, run.stderr);
+        assert.match(run.stderr, /REPETITIONS_CAP/);
+        assert.match(run.stderr, /10/);
+        assert.equal(fixture.fromFileBodies.length, 0);
+        assert.equal(fixture.runBodies.length, 0);
+      });
+    } finally {
+      await fixture.close();
+    }
+  });
+
+  test("250-case file uploads in three batches", async () => {
+    const fixture = await startFileRunFixture();
+    try {
+      await withTempDir(async (dir) => {
+        const file = path.join(dir, "suite.yaml");
+        await writeFile(file, suiteFileWithCases(250), "utf8");
+        const run = await captureProcessOutput(() =>
+          main(runFileArgv(fixture.baseUrl, "--file", file, "--project", "Alpha"), {
+            telemetry: telemetryDisabled,
+          })
+        );
+        assert.equal(run.result.exitCode, 0, run.stderr);
+        assert.equal(fixture.batchBodies.length, 3);
+        const sizes = fixture.batchBodies.map(
+          (body) => (body as { cases: unknown[] }).cases.length
+        );
+        assert.deepEqual(sizes, [100, 100, 50]);
+      });
+    } finally {
+      await fixture.close();
+    }
+  });
+
+  test("--format json is byte-identical across two runs of the same file", async () => {
+    const fixture = await startFileRunFixture();
+    try {
+      await withTempDir(async (dir) => {
+        const file = path.join(dir, "suite.yaml");
+        await writeFile(file, VALID_SUITE_FILE, "utf8");
+        const argv = runFileArgv(
+          fixture.baseUrl,
+          "--file",
+          file,
+          "--project",
+          "Alpha",
+          "--idempotency-key",
+          "stable-json"
+        );
+        const first = await captureProcessOutput(() =>
+          main(argv, { telemetry: telemetryDisabled })
+        );
+        const second = await captureProcessOutput(() =>
+          main(argv, { telemetry: telemetryDisabled })
+        );
+        assert.equal(first.result.exitCode, 0, first.stderr);
+        assert.equal(second.result.exitCode, 0, second.stderr);
+        assert.equal(first.stdout, second.stdout);
+      });
+    } finally {
+      await fixture.close();
+    }
+  });
+
+  test("create-API JSON on eval run --file points at eval create --file", async () => {
+    const fixture = await startFileRunFixture();
+    try {
+      await withTempDir(async (dir) => {
+        const file = path.join(dir, "create.json");
+        await writeFile(
+          file,
+          JSON.stringify({
+            name: "Authored smoke",
+            cases: [
+              {
+                title: "echo",
+                steps: [{ id: "s1", kind: "prompt", prompt: "hi" }],
+              },
+            ],
+          }),
+          "utf8"
+        );
+        const run = await captureProcessOutput(() =>
+          main(runFileArgv(fixture.baseUrl, "--file", file, "--project", "Alpha"), {
+            telemetry: telemetryDisabled,
+          })
+        );
+        assert.equal(run.result.exitCode, 2, run.stderr);
+        assert.match(run.stderr, /eval create --file/);
+        assert.equal(fixture.fromFileBodies.length, 0);
+        assert.equal(fixture.runBodies.length, 0);
+      });
+    } finally {
+      await fixture.close();
+    }
   });
 });

--- a/cli/tests/eval-suite-file.test.ts
+++ b/cli/tests/eval-suite-file.test.ts
@@ -395,7 +395,11 @@ describe("fractionToPercent", () => {
     for (const fraction of [
       Number.NaN,
       Number.POSITIVE_INFINITY,
-      0.1 + 0.2,
+      // More significant digits than a double keeps after the two-place
+      // left-shift. `0.1 + 0.2` is the refuse case the OTHER direction
+      // (`percentToFraction`); shifting it left lands on a representable
+      // percent, so it is not a loss here.
+      Number("0.123456789012345678"),
     ]) {
       assert.equal(fractionToPercent(fraction), null, String(fraction));
     }

--- a/cli/tests/eval-suite-file.test.ts
+++ b/cli/tests/eval-suite-file.test.ts
@@ -41,6 +41,9 @@ import {
   percentToFraction,
 } from "../src/lib/eval-suite-export.js";
 import {
+  deriveFileRunIdempotencyKey,
+  fileCaseToCreateBody,
+  fileCaseToUpdateBody,
   looksLikeCreateEvalApiJson,
   looksLikeVersionedSuiteFile,
   sha256HexOfBuffer,
@@ -1387,12 +1390,15 @@ ${cases}
 `;
 }
 
-async function startFileRunFixture(): Promise<{
+async function startFileRunFixture(options?: {
+  existingCases?: Array<{ id: string; declaredId: string; title: string }>;
+}): Promise<{
   baseUrl: string;
   authHeaders: string[];
   fromFileBodies: unknown[];
   batchBodies: unknown[];
   updateBodies: unknown[];
+  deletedCaseIds: string[];
   runBodies: unknown[];
   close: () => Promise<void>;
 }> {
@@ -1400,11 +1406,15 @@ async function startFileRunFixture(): Promise<{
   const fromFileBodies: unknown[] = [];
   const batchBodies: unknown[] = [];
   const updateBodies: unknown[] = [];
+  const deletedCaseIds: string[] = [];
   const runBodies: unknown[] = [];
   const casesByDeclaredId = new Map<
     string,
     { id: string; declaredId: string; title: string }
   >();
+  for (const row of options?.existingCases ?? []) {
+    casesByDeclaredId.set(row.declaredId, row);
+  }
   const runsByKey = new Map<string, string>();
   let runCounter = 0;
 
@@ -1519,6 +1529,25 @@ async function startFileRunFixture(): Promise<{
     }
 
     if (
+      url.pathname.startsWith(
+        "/api/v1/projects/proj-alpha/eval-suites/suite-file-1/cases/"
+      ) &&
+      method === "DELETE"
+    ) {
+      const caseId = url.pathname.split("/").pop() ?? "";
+      deletedCaseIds.push(caseId);
+      for (const [declaredId, row] of casesByDeclaredId) {
+        if (row.id === caseId) {
+          casesByDeclaredId.delete(declaredId);
+          break;
+        }
+      }
+      res.statusCode = 200;
+      res.end(JSON.stringify({ id: caseId, deleted: true }));
+      return;
+    }
+
+    if (
       url.pathname === "/api/v1/projects/proj-alpha/eval-suites" &&
       method === "GET"
     ) {
@@ -1608,6 +1637,7 @@ async function startFileRunFixture(): Promise<{
     fromFileBodies,
     batchBodies,
     updateBodies,
+    deletedCaseIds,
     runBodies,
     close: () =>
       new Promise<void>((resolve, reject) =>
@@ -1668,6 +1698,7 @@ describe("eval run --file", () => {
         assert.equal(launched.suiteId, "suite-file-1");
         assert.equal(launched.sourceHash, expectedHash);
         assert.equal(typeof launched.idempotencyKey, "string");
+        assert.deepEqual(launched.caseIds, ["row_c_refund"]);
         const payload = JSON.parse(run.stdout);
         assert.equal(payload.outcome, "started");
         assert.equal(payload.runId, "run-file-1");
@@ -1825,5 +1856,187 @@ describe("eval run --file", () => {
     } finally {
       await fixture.close();
     }
+  });
+
+  test("a per-case passThreshold override is refused, not silently dropped", async () => {
+    const fixture = await startFileRunFixture();
+    try {
+      await withTempDir(async (dir) => {
+        const file = path.join(dir, "suite.yaml");
+        await writeFile(
+          file,
+          VALID_SUITE_FILE.replace(
+            "    title: Refunds a duplicate charge",
+            "    passThreshold: 0.95\n    title: Refunds a duplicate charge"
+          ),
+          "utf8"
+        );
+        const run = await captureProcessOutput(() =>
+          main(runFileArgv(fixture.baseUrl, "--file", file, "--project", "Alpha"), {
+            telemetry: telemetryDisabled,
+          })
+        );
+        assert.equal(run.result.exitCode, 2, run.stderr);
+        assert.match(run.stderr, /CASE_PASS_THRESHOLD/);
+        assert.match(run.stderr, /c_refund/);
+        assert.equal(fixture.fromFileBodies.length, 0);
+        assert.equal(fixture.runBodies.length, 0);
+      });
+    } finally {
+      await fixture.close();
+    }
+  });
+
+  test("a later file deletes a case that is no longer enabled", async () => {
+    const fixture = await startFileRunFixture({
+      existingCases: [
+        { id: "row_c_refund", declaredId: "c_refund", title: "Refunds" },
+        { id: "row_c_stale", declaredId: "c_stale", title: "Removed" },
+      ],
+    });
+    try {
+      await withTempDir(async (dir) => {
+        const file = path.join(dir, "suite.yaml");
+        await writeFile(file, VALID_SUITE_FILE, "utf8");
+        const run = await captureProcessOutput(() =>
+          main(runFileArgv(fixture.baseUrl, "--file", file, "--project", "Alpha"), {
+            telemetry: telemetryDisabled,
+          })
+        );
+        assert.equal(run.result.exitCode, 0, run.stderr);
+        assert.deepEqual(fixture.deletedCaseIds, ["row_c_stale"]);
+        assert.equal(fixture.batchBodies.length, 0);
+        assert.equal(fixture.updateBodies.length, 1);
+        const launched = fixture.runBodies[0] as { caseIds: string[] };
+        assert.deepEqual(launched.caseIds, ["row_c_refund"]);
+      });
+    } finally {
+      await fixture.close();
+    }
+  });
+
+  test("updating a file-owned case clears removed negative and check fields", async () => {
+    const fixture = await startFileRunFixture({
+      existingCases: [
+        {
+          id: "row_c_refund",
+          declaredId: "c_refund",
+          title: "Refunds a duplicate charge",
+        },
+      ],
+    });
+    try {
+      await withTempDir(async (dir) => {
+        const file = path.join(dir, "suite.yaml");
+        await writeFile(file, VALID_SUITE_FILE, "utf8");
+        const run = await captureProcessOutput(() =>
+          main(runFileArgv(fixture.baseUrl, "--file", file, "--project", "Alpha"), {
+            telemetry: telemetryDisabled,
+          })
+        );
+        assert.equal(run.result.exitCode, 0, run.stderr);
+        assert.equal(fixture.updateBodies.length, 1);
+        const body = fixture.updateBodies[0] as Record<string, unknown>;
+        assert.equal(body.isNegative, false);
+        assert.equal(body.checks, null);
+        assert.equal(body.expectedOutput, "");
+      });
+    } finally {
+      await fixture.close();
+    }
+  });
+
+  test("the same file with different --iterations is not treated as a retry", async () => {
+    const fixture = await startFileRunFixture();
+    try {
+      await withTempDir(async (dir) => {
+        const file = path.join(dir, "suite.yaml");
+        await writeFile(file, VALID_SUITE_FILE, "utf8");
+        const first = await captureProcessOutput(() =>
+          main(
+            runFileArgv(
+              fixture.baseUrl,
+              "--file",
+              file,
+              "--project",
+              "Alpha",
+              "--iterations",
+              "1"
+            ),
+            { telemetry: telemetryDisabled }
+          )
+        );
+        const second = await captureProcessOutput(() =>
+          main(
+            runFileArgv(
+              fixture.baseUrl,
+              "--file",
+              file,
+              "--project",
+              "Alpha",
+              "--iterations",
+              "10"
+            ),
+            { telemetry: telemetryDisabled }
+          )
+        );
+        assert.equal(first.result.exitCode, 0, first.stderr);
+        assert.equal(second.result.exitCode, 0, second.stderr);
+        const keys = fixture.runBodies.map(
+          (body) => (body as { idempotencyKey: string }).idempotencyKey
+        );
+        assert.equal(keys.length, 2);
+        assert.notEqual(keys[0], keys[1]);
+        const ids = [first, second].map(
+          (entry) => JSON.parse(entry.stdout).runId
+        );
+        assert.deepEqual(ids, ["run-file-1", "run-file-2"]);
+      });
+    } finally {
+      await fixture.close();
+    }
+  });
+});
+
+describe("file-owned case bodies and idempotency", () => {
+  test("an update body clears isNegative and checks when the file dropped them", () => {
+    const loaded = loadEvalSuiteFile(VALID_SUITE_FILE);
+    assert.equal(loaded.ok, true);
+    if (!loaded.ok) return;
+    const testCase = loaded.resolved.enabledCases[0];
+    const created = fileCaseToCreateBody(testCase);
+    assert.equal("isNegative" in created, false);
+    assert.equal("checks" in created, false);
+    const updated = fileCaseToUpdateBody(testCase);
+    assert.equal(updated.isNegative, false);
+    assert.equal(updated.checks, null);
+    assert.equal(updated.expectedOutput, "");
+  });
+
+  test("derived idempotency keys differ when run knobs differ", () => {
+    const shared = {
+      sourceHash: "a".repeat(64),
+      declaredSuiteId: "s_billing",
+      projectId: "proj-alpha",
+      target: { servers: [{ name: "billing" }] },
+    };
+    const one = deriveFileRunIdempotencyKey({
+      ...shared,
+      knobs: { iterations: 1 },
+    });
+    const ten = deriveFileRunIdempotencyKey({
+      ...shared,
+      knobs: { iterations: 10 },
+    });
+    const env = deriveFileRunIdempotencyKey({
+      ...shared,
+      knobs: { environment: ["prod"] },
+    });
+    assert.notEqual(one, ten);
+    assert.notEqual(one, env);
+    assert.equal(
+      deriveFileRunIdempotencyKey({ ...shared, knobs: { iterations: 1 } }),
+      one
+    );
   });
 });

--- a/cli/tests/eval.test.ts
+++ b/cli/tests/eval.test.ts
@@ -772,6 +772,33 @@ test("eval create rejects stdio servers before any write", async () => {
   }
 });
 
+test("eval create --json with schemaVersion points at eval run --file", async () => {
+  const fixture = await startEvalFixture();
+  try {
+    const run = await captureProcessOutput(() =>
+      main(
+        evalArgv(
+          fixture.baseUrl,
+          "create",
+          "--json",
+          JSON.stringify({
+            schemaVersion: "1",
+            mode: "agentWorkflow",
+            suite: { id: "s_billing", name: "Billing" },
+          }),
+        ),
+        { telemetry: telemetryDisabled },
+      ),
+    );
+
+    assert.equal(run.result.exitCode, 2);
+    assert.equal(fixture.createBodies.length, 0);
+    assert.match(run.stderr, /eval run --file/);
+  } finally {
+    await fixture.close();
+  }
+});
+
 test("eval create rejects an invalid suite definition as a usage error", async () => {
   const fixture = await startEvalFixture();
   try {

--- a/docs/cli/reference.mdx
+++ b/docs/cli/reference.mdx
@@ -1056,9 +1056,12 @@ File `passThreshold` is a fraction; the hosted suite grades on a percent. The
 conversion refuses rather than approximates. File `repetitions` above **10**
 are refused by name (`REPETITIONS_CAP`) and are not clamped.
 
-Cases are synced in batches of at most 100 (`create_eval_cases`). Disabled
-or removed file cases are deleted from the hosted suite before launch, and
-the run is scoped to the remaining enabled cases. A later run updates
+Cases are synced in batches of at most 100 (`create_eval_cases`). A case the
+file **no longer declares** is deleted from the hosted suite before launch. A
+case the file still declares but marks `disabled: true` is **kept, with its
+history** — it is simply left out of the launch, so parking a flaky test does
+not destroy its past results and re-enabling it later resumes the same case.
+The run is scoped to the enabled cases either way. A later run updates
 existing cases by declared id and creates new ones. A case that overrides
 `passThreshold` is refused: hosted grading is suite-wide.
 

--- a/docs/cli/reference.mdx
+++ b/docs/cli/reference.mdx
@@ -1061,9 +1061,15 @@ file **no longer declares** is deleted from the hosted suite before launch. A
 case the file still declares but marks `disabled: true` is **kept, with its
 history** — it is simply left out of the launch, so parking a flaky test does
 not destroy its past results and re-enabling it later resumes the same case.
-The run is scoped to the enabled cases either way. A later run updates
+The run is scoped to the enabled cases either way. A file with no enabled
+cases is refused (`NO_ENABLED_CASES`) rather than launching the whole
+persisted suite. `--case` may only name an enabled case. A later run updates
 existing cases by declared id and creates new ones. A case that overrides
-`passThreshold` is refused: hosted grading is suite-wide.
+`passThreshold` is refused: hosted grading is suite-wide. Authored
+`defaults.toolPolicy` and non-empty `defaults.validity` gates are refused —
+the hosted runner cannot enforce them. File `defaults.repetitions` is
+inherited per case and is not uploaded as a suite `minIterations` floor.
+`target.environment` is attached to the suite before launch.
 
 Without `--idempotency-key`, the CLI derives one from the file's SHA-256,
 declared suite id, project, target, and every run-affecting knob

--- a/docs/cli/reference.mdx
+++ b/docs/cli/reference.mdx
@@ -936,7 +936,7 @@ Create a runnable eval suite from authored test cases (does not run it).
 | Flag | Required | Description |
 |------|----------|-------------|
 | `--project <id-or-name>` | No | Project name or ID (defaults to the most recently updated project) |
-| `--file <path>` | No | Path to a suite definition JSON file (or `-` for stdin) |
+| `--file <path>` | No | Path to a **create-API JSON** body (or `-` for stdin). A versioned suite file (`schemaVersion: "1"`) belongs on `eval run --file` |
 | `--json <json>` | No | Inline suite definition JSON (or `@file`, or `-` for stdin) |
 | `--name <name>` | No | Suite name (overrides the file) |
 | `--model <model>` | No | Suite-level default model (overrides the file) |
@@ -953,11 +953,14 @@ List the eval suites saved in a project.
 
 ### `cloud eval run`
 
-Start an eval run of an existing suite (asynchronous).
+Start an eval run of an existing suite, or upload a versioned suite file and run it (asynchronous). Provide **either** `--suite` **or** `--file`, not both.
+
+There is **no `--wait`**. The command prints a launch receipt and exits 0 when the run started. Poll `eval status` for a verdict. Exit 1 is reserved for a real verdict (and for a partial fan-out). An invalid suite file on this command exits **2** — `eval validate` still exits 1 for the same contract failure, because it is a verdict on the file and this command is not.
 
 | Flag | Required | Description |
 |------|----------|-------------|
-| `--suite <id-or-name>` | Yes | Eval suite name or ID |
+| `--suite <id-or-name>` | Yes, unless `--file` | Eval suite name or ID |
+| `--file <path>` | Yes, unless `--suite` | Versioned suite file to upload and run (`.yaml` or `.json`, or `-` for stdin) |
 | `--project <id-or-name>` | No | Project name or ID (defaults to the most recently updated project) |
 | `--server <id-or-name...>` | No | Override the suite's saved server selection (HTTP servers only) |
 | `--environment <id-or-name...>` | No | Attached project environment(s) to run. Several values start one **paid run each**. |
@@ -1036,6 +1039,38 @@ line per failure.
 A partial or wholly failed fan-out **exits 1**. A per-target failure does not
 abort its siblings, so exiting 0 would let a pipeline read "1 of 3 runs never
 started" as a clean launch.
+
+#### `--file`: upload and run a suite file
+
+`eval run --file` reads the versioned suite file (`schemaVersion: "1"`),
+authenticates, then validates. A contract-invalid file exits **2** after the
+auth request — it does not start a run. `eval validate` on the same bytes
+still exits 1: that command is a verdict on the file; this one is not.
+
+The file's `suite.id` is the declared suite identity. The first run creates a
+file-owned suite stamped with that id; later runs of the same id in the same
+project update that suite rather than creating a second one. A UI-authored
+suite has no declared id, so no file can claim it. Resolve is never by name.
+
+File `passThreshold` is a fraction; the hosted suite grades on a percent. The
+conversion refuses rather than approximates. File `repetitions` above **10**
+are refused by name (`REPETITIONS_CAP`) and are not clamped.
+
+Cases are synced in batches of at most 100 (`create_eval_cases`). Disabled
+file cases are skipped. A later run updates existing cases by declared id and
+creates new ones.
+
+Without `--idempotency-key`, the CLI derives one from the file's SHA-256,
+declared suite id, project, and target, so repeating the same file against
+the same project and target returns the run it already started.
+
+`--file` pointing at create-API JSON (no `schemaVersion`) is a usage error
+that names `eval create --file`. The converse is also true: `eval create --file`
+on a versioned suite file names `eval run --file`.
+
+Export of a file-owned suite writes `declaredId` as `suite.id`. Export of a
+UI suite still writes the Convex id; running that file back is the ownership
+refusal.
 
 When the run targets an **attached project environment** (`eval environments
 set`), it executes against that environment's resolved host config, closed
@@ -1128,7 +1163,7 @@ no API key. It never touches the network.
 | Exit code | Meaning |
 |-----------|---------|
 | `0` | Valid |
-| `1` | Parsed, but invalid against the suite-file contract. Every finding is reported, not just the first |
+| `1` | Parsed, but invalid against the suite-file contract. Every finding is reported, not just the first. `eval run --file` on the same bytes exits **2** — 1 is reserved there for a real verdict |
 | `2` | Nothing was validated: unreadable path, input over the 1 MiB limit, or malformed YAML |
 
 Input is capped at **1,048,576 bytes (1 MiB) of UTF-8** and is never truncated —

--- a/docs/cli/reference.mdx
+++ b/docs/cli/reference.mdx
@@ -1064,8 +1064,10 @@ not destroy its past results and re-enabling it later resumes the same case.
 The run is scoped to the enabled cases either way. A file with no enabled
 cases is refused (`NO_ENABLED_CASES`) rather than launching the whole
 persisted suite. `--case` may only name an enabled case. A later run updates
-existing cases by declared id and creates new ones. A case that overrides
-`passThreshold` is refused: hosted grading is suite-wide. Authored
+existing cases by declared id and creates new ones. An enabled case that
+overrides `passThreshold` is refused: hosted grading is suite-wide. A
+disabled case with the same override is ignored, matching how repetitions
+are checked. Authored
 `defaults.toolPolicy` and non-empty `defaults.validity` gates are refused —
 the hosted runner cannot enforce them. File `defaults.repetitions` is
 inherited per case and is not uploaded as a suite `minIterations` floor.

--- a/docs/cli/reference.mdx
+++ b/docs/cli/reference.mdx
@@ -1057,12 +1057,18 @@ conversion refuses rather than approximates. File `repetitions` above **10**
 are refused by name (`REPETITIONS_CAP`) and are not clamped.
 
 Cases are synced in batches of at most 100 (`create_eval_cases`). Disabled
-file cases are skipped. A later run updates existing cases by declared id and
-creates new ones.
+or removed file cases are deleted from the hosted suite before launch, and
+the run is scoped to the remaining enabled cases. A later run updates
+existing cases by declared id and creates new ones. A case that overrides
+`passThreshold` is refused: hosted grading is suite-wide.
 
 Without `--idempotency-key`, the CLI derives one from the file's SHA-256,
-declared suite id, project, and target, so repeating the same file against
-the same project and target returns the run it already started.
+declared suite id, project, target, and every run-affecting knob
+(`--iterations`, `--case`, `--min-pass-rate`, `--exclude-skills`,
+`--match-options`, `--environment` / `--host` / `--server` / `--all-targets`,
+`--refresh-snapshot`, and compose flags). Repeating the same file with the
+same knobs returns the run it already started; changing a knob starts a new
+one. `--notes` is not part of the key.
 
 `--file` pointing at create-API JSON (no `schemaVersion`) is a usage error
 that names `eval create --file`. The converse is also true: `eval create --file`

--- a/docs/reference/openapi.json
+++ b/docs/reference/openapi.json
@@ -3162,6 +3162,77 @@
         }
       }
     },
+    "/projects/{projectId}/eval-suites/from-file": {
+      "post": {
+        "operationId": "syncFileOwnedEvalSuite",
+        "tags": [
+          "Eval runs"
+        ],
+        "summary": "Resolve or create a file-owned eval suite",
+        "description": "Resolve a file-owned suite by declared id within the project, or create one. Lookup is by `(projectId, declaredSuiteId)` and never by name. A UI-authored suite has no declared id and cannot be claimed. The inspector parses the suite file; this body is the declared identity, source hash, optional provenance, and hosted settings — not the raw file.\n\n`201` on first create; `200` on a later update of the same declared id.",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/projectId"
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/EvalSuiteFromFileRequest"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "The existing file-owned suite was updated.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/EvalSuiteFromFileSynced"
+                }
+              }
+            }
+          },
+          "201": {
+            "description": "A new file-owned suite was created.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/EvalSuiteFromFileSynced"
+                }
+              }
+            }
+          },
+          "400": {
+            "$ref": "#/components/responses/ValidationError"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "403": {
+            "$ref": "#/components/responses/Forbidden"
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound"
+          },
+          "409": {
+            "$ref": "#/components/responses/Conflict"
+          },
+          "429": {
+            "$ref": "#/components/responses/RateLimited"
+          },
+          "500": {
+            "$ref": "#/components/responses/InternalError"
+          },
+          "502": {
+            "$ref": "#/components/responses/ServerUnreachable"
+          }
+        }
+      }
+    },
     "/projects/{projectId}/eval-suites/{suiteId}": {
       "get": {
         "operationId": "getEvalSuite",
@@ -11881,6 +11952,147 @@
           }
         }
       },
+      "EvalSuiteFromFileRequest": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+          "declaredSuiteId",
+          "name",
+          "sourceHash"
+        ],
+        "description": "Declared identity and hosted settings for a file-owned suite. The inspector parses the suite file; this is not the raw file.",
+        "properties": {
+          "declaredSuiteId": {
+            "type": "string",
+            "description": "The file's `suite.id`. Lookup is by this id within the project, never by name."
+          },
+          "name": {
+            "type": "string"
+          },
+          "description": {
+            "type": "string"
+          },
+          "sourceHash": {
+            "type": "string",
+            "pattern": "^[a-f0-9]{64}$",
+            "description": "SHA-256 hex of the suite-file bytes. Lowercase, 64 characters."
+          },
+          "provenance": {
+            "type": "object",
+            "additionalProperties": false,
+            "required": [
+              "sourceHash",
+              "sourceFormat",
+              "reportHash"
+            ],
+            "properties": {
+              "sourceHash": {
+                "type": "string"
+              },
+              "sourceFormat": {
+                "type": "string"
+              },
+              "sourceFormatVersion": {
+                "type": "string"
+              },
+              "converter": {
+                "type": "string"
+              },
+              "converterVersion": {
+                "type": "string"
+              },
+              "model": {
+                "type": "string"
+              },
+              "discoverySnapshotHash": {
+                "type": "string"
+              },
+              "reportHash": {
+                "type": "string"
+              },
+              "importedAt": {
+                "type": "string"
+              }
+            }
+          },
+          "environment": {
+            "type": "object",
+            "properties": {
+              "servers": {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                }
+              },
+              "serverBindings": {
+                "type": "array",
+                "items": {
+                  "type": "object",
+                  "required": [
+                    "serverName"
+                  ],
+                  "properties": {
+                    "serverName": {
+                      "type": "string"
+                    },
+                    "projectServerId": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "defaultConfig": {
+            "type": "object",
+            "required": [
+              "modelId",
+              "systemPrompt",
+              "temperature"
+            ],
+            "properties": {
+              "modelId": {
+                "type": "string"
+              },
+              "systemPrompt": {
+                "type": "string"
+              },
+              "temperature": {
+                "type": "number"
+              }
+            }
+          },
+          "minIterations": {
+            "type": "integer",
+            "minimum": 1,
+            "maximum": 10
+          },
+          "defaultPassCriteria": {
+            "type": "object",
+            "properties": {
+              "minimumPassRate": {
+                "type": "number"
+              }
+            }
+          }
+        }
+      },
+      "EvalSuiteFromFileSynced": {
+        "type": "object",
+        "required": [
+          "created",
+          "suite"
+        ],
+        "properties": {
+          "created": {
+            "type": "boolean",
+            "description": "True on the first upload of this declared id in the project; false on a later update of the same suite."
+          },
+          "suite": {
+            "$ref": "#/components/schemas/EvalSuiteDetail"
+          }
+        }
+      },
       "EvalSuiteDetail": {
         "type": "object",
         "required": [
@@ -11894,6 +12106,10 @@
         "properties": {
           "id": {
             "type": "string"
+          },
+          "declaredId": {
+            "type": "string",
+            "description": "The suite's declared file identity (`suite.id` in a suite file). Present on file-owned suites; absent on UI-authored suites, which have no declared id and cannot be claimed by `eval run --file`."
           },
           "name": {
             "type": [
@@ -12241,6 +12457,11 @@
             "type": "string",
             "maxLength": 256,
             "description": "Write-idempotency key. A repeat call with the same key (same actor and suite) returns the EXISTING run instead of creating and billing a second one. The `Idempotency-Key` header carries the same value and WINS over this field — it is the transport-level channel unattended clients control, whereas a body key could be shaped by model output."
+          },
+          "sourceHash": {
+            "type": "string",
+            "pattern": "^[a-f0-9]{64}$",
+            "description": "SHA-256 hex of the suite-file bytes that launched this run. Lowercase, 64 characters. Set by `eval run --file`; a UI or API launch that did not come from a file omits it."
           }
         },
         "additionalProperties": false

--- a/mcpjam-inspector/server/routes/shared/__tests__/evals.test.ts
+++ b/mcpjam-inspector/server/routes/shared/__tests__/evals.test.ts
@@ -205,6 +205,34 @@ describe("RunEvalsRequestSchema runs cap", () => {
   });
 });
 
+describe("RunEvalsRequestSchema sourceHash", () => {
+  it("accepts a lowercase 64-char SHA-256 hex digest", () => {
+    const result = RunEvalsRequestSchema.safeParse({
+      ...buildSuiteRequest(),
+      sourceHash: "a".repeat(64),
+    });
+    expect(result.success).toBe(true);
+    expect(result.success ? result.data.sourceHash : undefined).toBe(
+      "a".repeat(64)
+    );
+  });
+
+  it("refuses uppercase or the wrong length", () => {
+    expect(
+      RunEvalsRequestSchema.safeParse({
+        ...buildSuiteRequest(),
+        sourceHash: "A".repeat(64),
+      }).success
+    ).toBe(false);
+    expect(
+      RunEvalsRequestSchema.safeParse({
+        ...buildSuiteRequest(),
+        sourceHash: "a".repeat(63),
+      }).success
+    ).toBe(false);
+  });
+});
+
 describe("RunEvalsRequestSchema widget_probe invariant", () => {
   const baseTest = {
     title: "t",

--- a/mcpjam-inspector/server/routes/shared/evals.ts
+++ b/mcpjam-inspector/server/routes/shared/evals.ts
@@ -354,6 +354,16 @@ export const RunEvalsRequestSchema = z.object({
    */
   idempotencyKey: z.string().min(1).max(256).optional(),
   /**
+   * SHA-256 hex of the suite-file bytes that launched this run. Lowercase,
+   * 64 characters. Forwarded to Convex `startTestSuiteRun.sourceHash` so a
+   * file-owned run records the exact bytes it ran. Absent on UI / API
+   * launches that did not come from a file.
+   */
+  sourceHash: z
+    .string()
+    .regex(/^[a-f0-9]{64}$/, "sourceHash must be a 64-character lowercase SHA-256 hex digest")
+    .optional(),
+  /**
    * Project-environment launch (one per attached env on a Run-all fan-out;
    * always sent explicitly, even single-env). `prepareEvalRun` resolves the
    * environment's closed server set via
@@ -1876,6 +1886,7 @@ export async function prepareEvalRun(
     resolvedEnvironment,
     source,
     idempotencyKey,
+    sourceHash,
     skillsOverride,
     ephemeralEnvironment,
   } = request;
@@ -2070,6 +2081,7 @@ export async function prepareEvalRun(
       : undefined,
     source,
     idempotencyKey,
+    ...(sourceHash ? { sourceHash } : {}),
     skillsOverride,
     ...(ephemeralEnvironment === true ? { ephemeralEnvironment: true } : {}),
   });

--- a/mcpjam-inspector/server/routes/v1/__tests__/openapi-types-parity.test.ts
+++ b/mcpjam-inspector/server/routes/v1/__tests__/openapi-types-parity.test.ts
@@ -83,6 +83,7 @@ const PAIRS: Readonly<Record<string, string>> = {
   EvalSuiteSchedule: "PlatformEvalSuiteSchedule",
   EvalSuiteComputerEnvironment: "PlatformEvalSuiteComputerEnvironment",
   EvalSuiteDetail: "PlatformEvalSuiteDetail",
+  EvalSuiteFromFileSynced: "PlatformFileOwnedEvalSuiteSynced",
   EvalIteration: "PlatformEvalIteration",
   EvalCase: "PlatformEvalCase",
   EvalDeleted: "PlatformEvalSuiteDeleted",

--- a/mcpjam-inspector/server/routes/v1/__tests__/sdk-coverage.test.ts
+++ b/mcpjam-inspector/server/routes/v1/__tests__/sdk-coverage.test.ts
@@ -169,6 +169,7 @@ const ROUTE_TO_SDK: Readonly<Record<string, string>> = {
   "get /projects/{projectId}/sessions": "listSessions",
   "get /projects/{projectId}/eval-suites": "listEvalSuites",
   "post /projects/{projectId}/eval-suites": "createEvalSuite",
+  "post /projects/{projectId}/eval-suites/from-file": "syncFileOwnedEvalSuite",
   "get /projects/{projectId}/eval-suites/{suiteId}": "getEvalSuite",
   "patch /projects/{projectId}/eval-suites/{suiteId}": "updateEvalSuite",
   "delete /projects/{projectId}/eval-suites/{suiteId}": "deleteEvalSuite",

--- a/mcpjam-inspector/server/routes/v1/evals.ts
+++ b/mcpjam-inspector/server/routes/v1/evals.ts
@@ -482,6 +482,68 @@ const createEvalSuiteSchema = z.strictObject({
 
 type CreateEvalSuiteBody = z.infer<typeof createEvalSuiteSchema>;
 
+const SOURCE_HASH_PATTERN = /^[a-f0-9]{64}$/;
+
+const evalSuiteFileProvenanceWireSchema = z
+  .object({
+    sourceHash: z.string().min(1),
+    sourceFormat: z.string().min(1),
+    sourceFormatVersion: z.string().min(1).optional(),
+    converter: z.string().min(1).optional(),
+    converterVersion: z.string().min(1).optional(),
+    model: z.string().min(1).optional(),
+    discoverySnapshotHash: z.string().min(1).optional(),
+    reportHash: z.string().min(1),
+    importedAt: z.string().optional(),
+  })
+  .strict();
+
+/**
+ * Body for `POST /eval-suites/from-file`: resolve or create a file-owned
+ * suite by declared id. The inspector parses the suite file; this is the
+ * declared identity + provenance + hosted settings, not the raw file.
+ */
+const syncFileOwnedSuiteSchema = z
+  .object({
+    declaredSuiteId: opaqueIdSchema,
+    name: z.string().trim().min(1).max(200),
+    description: z.string().optional(),
+    sourceHash: z
+      .string()
+      .regex(
+        SOURCE_HASH_PATTERN,
+        "sourceHash must be a 64-character lowercase SHA-256 hex digest",
+      ),
+    provenance: evalSuiteFileProvenanceWireSchema.optional(),
+    environment: z
+      .object({
+        servers: z.array(z.string()).optional(),
+        serverBindings: z
+          .array(
+            z.object({
+              serverName: z.string(),
+              projectServerId: z.string().optional(),
+            }),
+          )
+          .optional(),
+      })
+      .optional(),
+    defaultConfig: z
+      .object({
+        modelId: z.string(),
+        systemPrompt: z.string(),
+        temperature: z.number(),
+      })
+      .optional(),
+    minIterations: z.number().int().min(1).max(10).optional(),
+    defaultPassCriteria: z
+      .object({
+        minimumPassRate: z.number(),
+      })
+      .optional(),
+  })
+  .strict();
+
 /**
  * Expand the ergonomic authoring tests into the full
  * `RunEvalsRequestSchema.shape.tests` element shape: fill `runs`, resolve
@@ -1488,6 +1550,9 @@ function toSuiteDetailDto(
   const goal = suite.judgeConfig?.goalCompletion;
   return {
     id: String(suite._id),
+    ...(typeof suite.declaredSuiteId === "string"
+      ? { declaredId: suite.declaredSuiteId }
+      : {}),
     name: suite.name ?? null,
     description: suite.description ?? null,
     projectId: suite.projectId ? String(suite.projectId) : null,
@@ -3226,6 +3291,65 @@ evals.post("/projects/:projectId/eval-suites", async (c) => {
   } finally {
     await manager.disconnectAllServers().catch(() => {});
   }
+});
+
+// POST /v1/projects/:projectId/eval-suites/from-file
+//
+// Resolve or create a FILE-OWNED suite by declared id. Lookup is by
+// `(projectId, declaredSuiteId)` and never by name. A UI-authored suite has
+// no declared id, so this cannot claim it. Must be registered before
+// `/:suiteId` so "from-file" is not captured as a suite id.
+evals.post("/projects/:projectId/eval-suites/from-file", async (c) => {
+  const projectId = c.req.param("projectId");
+  const body = parseWithSchema(
+    syncFileOwnedSuiteSchema,
+    await readJsonObjectBody(c),
+  );
+  const token = await getConvexBearerForRequest(c);
+  const { convexClient } = createConvexClients(token);
+  let result: { created: boolean; suite: SuiteDoc | null };
+  try {
+    result = (await convexClient.mutation(
+      "testSuites:resolveOrCreateFileOwnedSuite" as any,
+      {
+        projectId,
+        declaredSuiteId: body.declaredSuiteId,
+        name: body.name,
+        ...(body.description !== undefined
+          ? { description: body.description }
+          : {}),
+        sourceHash: body.sourceHash,
+        ...(body.provenance ? { provenance: body.provenance } : {}),
+        ...(body.environment ? { environment: body.environment } : {}),
+        ...(body.defaultConfig ? { defaultConfig: body.defaultConfig } : {}),
+        ...(body.minIterations !== undefined
+          ? { minIterations: body.minIterations }
+          : {}),
+        ...(body.defaultPassCriteria
+          ? { defaultPassCriteria: body.defaultPassCriteria }
+          : {}),
+      },
+    )) as { created: boolean; suite: SuiteDoc | null };
+  } catch (error) {
+    throw translateConvexWriteError(error);
+  }
+  if (!result.suite) {
+    throw new WebRouteError(
+      500,
+      ErrorCode.INTERNAL_ERROR,
+      "File-owned suite resolve returned no suite",
+    );
+  }
+  const detail = await readSuiteDetail(
+    token,
+    projectId,
+    String(result.suite._id),
+  );
+  return v1Resource(
+    c,
+    { created: result.created, suite: detail },
+    result.created ? 201 : 200,
+  );
 });
 
 // GET /v1/projects/:projectId/eval-runs/:runId

--- a/mcpjam-inspector/server/services/evals/recorder.ts
+++ b/mcpjam-inspector/server/services/evals/recorder.ts
@@ -358,6 +358,7 @@ export const startSuiteRunWithRecorder = async ({
   expectedEnvironmentServerIds,
   source,
   idempotencyKey,
+  sourceHash,
   skillsOverride,
   ephemeralEnvironment,
 }: {
@@ -459,6 +460,12 @@ export const startSuiteRunWithRecorder = async ({
    */
   idempotencyKey?: string;
   /**
+   * SHA-256 hex of the suite-file bytes that launched this run. Forwarded to
+   * Convex `startTestSuiteRun.sourceHash` so a file-owned run records the
+   * exact bytes it ran.
+   */
+  sourceHash?: string;
+  /**
    * The A/B "without skills" arm. `'exclude'` tells `startTestSuiteRun` to pin
    * NO skills from any channel and to mark the run `skillsExcluded`, so the
    * comparison arm is labelled rather than merely empty. See the wire schema
@@ -501,6 +508,7 @@ export const startSuiteRunWithRecorder = async ({
           : {}),
         ...(source ? { source } : {}),
         ...(idempotencyKey ? { idempotencyKey } : {}),
+        ...(sourceHash ? { sourceHash } : {}),
         ...(skillsOverride ? { skillsOverride } : {}),
         ...(ephemeralEnvironment === true ? { ephemeralEnvironment: true } : {}),
         runnerCapabilities: RUNNER_CAPABILITIES,

--- a/sdk/src/platform/client.ts
+++ b/sdk/src/platform/client.ts
@@ -22,6 +22,7 @@ import type {
   PlatformEvalCasesGenerated,
   PlatformEvalSuite,
   PlatformEvalSuiteCreated,
+  PlatformFileOwnedEvalSuiteSynced,
   PlatformEvalSuiteDeleted,
   PlatformEvalSuiteDetail,
   PlatformEvalStepResult,
@@ -1282,6 +1283,24 @@ export class PlatformApiClient {
     return this.request(
       "POST",
       `/projects/${encodeURIComponent(params.projectId)}/eval-suites`,
+      { body: params.body },
+      options,
+    );
+  }
+
+  /**
+   * `POST /projects/{p}/eval-suites/from-file` — resolve or create a
+   * file-owned suite by declared id. Lookup is by declared id within the
+   * project, never by name. A UI-authored suite has no declared id and
+   * cannot be claimed.
+   */
+  syncFileOwnedEvalSuite(
+    params: { projectId: string; body: Record<string, unknown> },
+    options?: RequestOptions,
+  ): Promise<PlatformFileOwnedEvalSuiteSynced> {
+    return this.request(
+      "POST",
+      `/projects/${encodeURIComponent(params.projectId)}/eval-suites/from-file`,
       { body: params.body },
       options,
     );

--- a/sdk/src/platform/index.ts
+++ b/sdk/src/platform/index.ts
@@ -115,6 +115,7 @@ export type {
   PlatformEvalSuiteCreated,
   PlatformEvalSuiteDeleted,
   PlatformEvalSuiteDetail,
+  PlatformFileOwnedEvalSuiteSynced,
   PlatformEvalSuiteHost,
   PlatformEvalSuiteSchedule,
   PlatformEvalSuiteSettings,

--- a/sdk/src/platform/operations.ts
+++ b/sdk/src/platform/operations.ts
@@ -2000,6 +2000,7 @@ function runKnobBody(
     matchOptions?: z.infer<typeof publicMatchOptionsSchema>;
     excludeSkills?: boolean;
     idempotencyKey?: string;
+    sourceHash?: string;
   },
   caseIds: string[] | undefined,
 ): Record<string, unknown> {
@@ -2015,6 +2016,7 @@ function runKnobBody(
       ? { passCriteria: { minimumPassRate: input.minPassRate } }
       : {}),
     ...(input.idempotencyKey ? { idempotencyKey: input.idempotencyKey } : {}),
+    ...(input.sourceHash ? { sourceHash: input.sourceHash } : {}),
   };
 }
 
@@ -2557,6 +2559,16 @@ const RUN_KNOB_FIELDS = {
     .optional()
     .describe(
       "Retry-safety key. Repeating a call with the same key returns the run it already started instead of starting (and billing) a second one. On a multi-target launch the key covers the whole group: a retry returns the same group and the same runs.",
+    ),
+  sourceHash: z
+    .string()
+    .regex(
+      /^[a-f0-9]{64}$/,
+      "sourceHash must be a 64-character lowercase SHA-256 hex digest",
+    )
+    .optional()
+    .describe(
+      "SHA-256 hex of the suite-file bytes that launched this run. Set by `eval run --file`; a UI or API launch that did not come from a file omits it.",
     ),
 } as const;
 

--- a/sdk/src/platform/types.ts
+++ b/sdk/src/platform/types.ts
@@ -713,6 +713,12 @@ export interface PlatformEvalSuiteSchedule {
  */
 export interface PlatformEvalSuiteDetail {
   id: string;
+  /**
+   * The suite's declared file identity (`suite.id` in a suite file). Present
+   * on file-owned suites; absent on UI-authored suites, which have no
+   * declared id and cannot be claimed by `eval run --file`.
+   */
+  declaredId?: string;
   name: string | null;
   description: string | null;
   projectId: string | null;
@@ -746,6 +752,16 @@ export interface PlatformEvalSuiteDetail {
   schedule: PlatformEvalSuiteSchedule;
   createdAt: number | null;
   updatedAt: number | null;
+}
+
+/**
+ * `POST /eval-suites/from-file` — resolve or create a file-owned suite by
+ * declared id. `created` is true on the first upload of that id in the
+ * project; later uploads update the same suite.
+ */
+export interface PlatformFileOwnedEvalSuiteSynced {
+  created: boolean;
+  suite: PlatformEvalSuiteDetail;
 }
 
 export interface PlatformEvalCaseModel {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Purpose

Evals v2 lane B step B2b: `mcpjam cloud eval run --file` validates a versioned suite file, snapshots it as a file-owned suite (declared identity + provenance), syncs cases, and starts a run.

Companion to the backend B2a change (declared suite identity, `resolveOrCreateFileOwnedSuite`, `sourceHash` on the run). **Deploy that backend change before this inspector build hits an environment that will receive `--file` uploads.**

## Context

A versioned suite file (`schemaVersion: "1"`) carries a stable `suite.id`. That id is the declared suite identity. Resolve is by declared id within the project, never by name. A suite with a declared id is file-owned; a UI-authored suite has none, so no file can claim it.

This PR is the inspector/CLI half: v1 `POST /eval-suites/from-file`, SDK client, CLI orchestration, export writing `declaredId` as `suite.id`, docs, OpenAPI, and the `create_eval_cases` → `cloud eval run --file` binding.

## Before

- `eval run` required `--suite`. There was no file upload path.
- `eval create --file` accepted any JSON body; a versioned suite file would fail as the wrong shape with no directed error.
- Suite export always wrote the platform row id as `suite.id`, including for file-owned suites.
- `create_eval_cases` had no CLI binding.

## After

- `eval run --file <path>` authenticates first, then validates. A contract-invalid file exits **2** (1 stays reserved for a real verdict). `eval validate` on the same bytes still exits 1.
- First upload of a declared id creates a file-owned suite; later uploads update that suite. Cases sync in batches of 100; existing rows update by declared id. Disabled file cases are skipped.
- File `repetitions` above 10 are refused by name (`REPETITIONS_CAP`) and are not clamped. `passThreshold` fraction→percent refuses rather than approximates.
- Without `--idempotency-key`, the CLI derives one from `sourceHash` + declared suite id + project + target. There is **no `--wait`**.
- Directed overloads: suite file on `eval create --file` names `eval run --file`; create-API JSON on `eval run --file` names `eval create --file`.
- Export of a file-owned suite writes `declaredId` as `suite.id`. Export of a UI suite still writes the Convex id; running that file back is the ownership refusal.

## Rollout

1. Deploy backend B2a first (`declaredSuiteId`, `sourceHash`, `provenance`, `resolveOrCreateFileOwnedSuite`). Old inspector clients ignore the new optional fields.
2. Then deploy this inspector/CLI change.
3. Until B2a is live, `eval run --file` against that environment will 404/fail on `POST …/eval-suites/from-file` because Convex will not have the mutation.
4. Rollback of this PR is a revert; file-owned suites already written remain readable.

## Testing

- CLI fixture tests in `cli/tests/eval-suite-file.test.ts` (`eval run --file`: invalid→exit 2 after auth, happy path, idempotency, repetitions cap, 250-case batching, directed overload).
- `cli/tests/eval.test.ts` (`eval create --json` with `schemaVersion` points at `eval run --file`).
- `cli/tests/op-bindings.test.ts` ratchet.
- v1 OpenAPI drift/parity, SDK coverage, and `sourceHash` schema tests.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-b47f6e5f-13cd-434a-a041-0e71af7694be?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-b47f6e5f-13cd-434a-a041-0e71af7694be&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds eval run --file to upload a versioned suite file, resolve or create its declared‑id suite, sync cases, and start a run with recorded sourceHash and keyed idempotency. Previously eval run required --suite; file workflows now have one entry point with declared identity and provenance.

- Validates after auth; contract‑invalid files exit 2. Directed overloads: eval run --file refuses create‑API JSON and names eval create --file; eval create --file on a suite file names eval run --file.
- Case sync: batches up to 100, updates by declared id, keeps disabled cases (history preserved) and excludes them from the run, deletes only cases the file no longer declares, reports created/updated/deleted counts, and ignores passThreshold on disabled cases. Update PATCH bodies clear removed fields (isNegative, checks, expectedOutput). Create‑batch transport failures fold into CASE_SYNC_FAILED and the run does not start.
- Hosted constraints: repetitions cap 10 (not clamped); refuse per‑case passThreshold overrides; refuse lossy fraction→percent conversions (fractionToPercent fixed to invert percentToFraction); refuse authored defaults.toolPolicy and non‑empty defaults.validity; refuse files with all cases disabled; --case must select enabled cases only; defaults.repetitions is not uploaded as a suite minIterations floor.
- Target/environment: when no CLI override is given, target.environment from the file is attached to the suite before launch and used for the run.
- Accepts either --suite or --file (mutually exclusive). Derives the idempotency key from the file’s SHA‑256, declared suite id, project, target, and run‑affecting knobs; same file + knobs returns the same run. There is no --wait.
- Export writes declaredId as suite.id for file‑owned suites; UI suites still export the platform id. Adds run payload sourceHash, OpenAPI for POST /projects/{projectId}/eval-suites/from-file, SDK syncFileOwnedEvalSuite, and binds create_eval_cases to cloud eval run --file.

**Rollout**
- Deploy backend first: new from‑file endpoint, declared suite identity, sourceHash on run, and SDK route. Old inspectors ignore the new optional fields.
- Until the backend is live, eval run --file will 404 on the from‑file endpoint.
- Revert is safe; existing file‑owned suites remain readable.

<sup>Written for commit 1a8c381bf14b88c17ec7b09fc94900b312fed526. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/MCPJam/inspector/pull/4294?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

