### PR TITLE
eval: surface elapsedMs on step-replay tool calls

### DIFF
--- a/mcpjam-inspector/shared/__tests__/eval-step-replay.test.ts
+++ b/mcpjam-inspector/shared/__tests__/eval-step-replay.test.ts
@@ -44,7 +44,7 @@ describe("assembleStepResults", () => {
           locatorLabel: "Add to cart",
           ok: false,
           videoOffsetMs: 4200,
-          widgetToolCalls: [{ name: "view-cart", args: {}, ok: true }],
+          widgetToolCalls: [{ name: "view-cart", args: {}, ok: true, elapsedMs: 18 }],
         },
       ],
       widgetRenderObservations: [
@@ -72,12 +72,33 @@ describe("assembleStepResults", () => {
       // videoUrl present only because this step is seekable (has an offset).
       videoOffsetMs: 4200,
       videoUrl: "https://blob/run.webm",
-      toolCalls: [{ name: "view-cart", ok: true }],
+      toolCalls: [{ name: "view-cart", ok: true, elapsedMs: 18 }],
     });
     // widgetRendered assert picks up the render-observation screenshot.
     expect(out[2].evidence?.screenshotUrl).toBe("https://blob/s3.png");
     // A step with no artifact has no evidence key at all.
     expect(out[0].evidence).toBeUndefined();
+  });
+
+  it("omits elapsedMs on widget tool calls that did not record it", () => {
+    const metadata = {
+      stepResults: [
+        { stepId: "s4", stepIndex: 3, kind: "interact", status: "ok" },
+      ],
+    };
+    const envelope = {
+      browserInteractionSteps: [
+        {
+          authoredStepId: "s4",
+          widgetToolCalls: [{ name: "view-cart", args: {}, ok: true }],
+        },
+      ],
+    };
+    const out = assembleStepResults(steps, metadata, envelope);
+    expect(out[3].evidence?.toolCalls).toEqual([
+      { name: "view-cart", args: {}, ok: true },
+    ]);
+    expect(out[3].evidence?.toolCalls?.[0]).not.toHaveProperty("elapsedMs");
   });
 
   it("falls back to browser rows + skippedSteps when stepResults is absent", () => {

--- a/mcpjam-inspector/shared/eval-step-replay.ts
+++ b/mcpjam-inspector/shared/eval-step-replay.ts
@@ -45,7 +45,14 @@ export type EvalStepResultRecord = {
 /** Public-safe evidence for one step, lifted from the resolved trace envelope. */
 export type EvalStepEvidence = {
   /** Widget→host tool calls a click/interact triggered (name + sanitized args). */
-  toolCalls?: Array<{ name: string; args: unknown; ok: boolean; error?: string }>;
+  toolCalls?: Array<{
+    name: string;
+    args: unknown;
+    ok: boolean;
+    error?: string;
+    /** Wall-clock ms for this widget→host call, when the harness recorded it. */
+    elapsedMs?: number;
+  }>;
   /** Resolved screenshot URL (render observation or interaction step). */
   screenshotUrl?: string;
   /** Resolved iteration replay `.webm` URL (iteration-level; same on every row). */
@@ -142,12 +149,16 @@ function toEvidence(
   if (locatorLabel) ev.locatorLabel = locatorLabel;
   const widgetToolCalls = interaction?.widgetToolCalls;
   if (Array.isArray(widgetToolCalls) && widgetToolCalls.length > 0) {
-    ev.toolCalls = widgetToolCalls.map((c: Record<string, unknown>) => ({
-      name: str(c.name) ?? "",
-      args: c.args,
-      ok: c.ok === true,
-      ...(str(c.error) ? { error: str(c.error) } : {}),
-    }));
+    ev.toolCalls = widgetToolCalls.map((c: Record<string, unknown>) => {
+      const elapsedMs = num(c.elapsedMs);
+      return {
+        name: str(c.name) ?? "",
+        args: c.args,
+        ok: c.ok === true,
+        ...(str(c.error) ? { error: str(c.error) } : {}),
+        ...(elapsedMs !== undefined ? { elapsedMs } : {}),
+      };
+    });
   }
   return Object.keys(ev).length > 0 ? ev : undefined;
 }

--- a/sdk/src/platform/types.ts
+++ b/sdk/src/platform/types.ts
@@ -1480,6 +1480,8 @@ export interface PlatformEvalStepEvidence {
     args: unknown;
     ok: boolean;
     error?: string;
+    /** Wall-clock ms for this widget→host call, when the harness recorded it. */
+    elapsedMs?: number;
   }>;
   /** Resolved screenshot URL for the step's render/interaction. */
   screenshotUrl?: string;


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Purpose

Playground-for-Agents **PR 3 (WS3)**: eval step replay already joined widget→host tool calls onto `EvalStepEvidence.toolCalls` but dropped `elapsedMs` the harness records on `EvalTraceWidgetToolCall`.

## Before / after

- **Before:** step evidence tool calls were `{ name, args, ok, error? }`.
- **After:** the same object plus optional `elapsedMs` when the harness recorded it. Absent on legacy rows that never stored it.

## What changed

- `shared/eval-step-replay.ts` — map `elapsedMs` through `toEvidence`
- `sdk/src/platform/types.ts` — widen `PlatformEvalStepEvidence.toolCalls`
- Unit test: present when recorded, omitted when not

## Verification

```
npm run build -w @mcpjam/sdk
npx vitest run shared/__tests__/eval-step-replay.test.ts
```

10 passed. Live `mcpjam eval steps` smoke is deferred (no hosted eval fixture in this environment).

## Rollout

Additive optional field. Independent of #4292 / #4293.

## Follow-ups

PR 4 (mcpjam-backend): `"api"` origin + `claimTurnLease`. Backend deploys first before inspector turn/read routes.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-2fa398fa-2d31-4ce0-8ccf-8202b731e384?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-2fa398fa-2d31-4ce0-8ccf-8202b731e384&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Expose elapsedMs on step-replay tool calls so consumers can see per-call latency. Previously toolCalls were { name, args, ok, error? }; now they may include elapsedMs when the harness recorded it, and it’s absent on legacy rows.

- Map elapsedMs through in `mcpjam-inspector/shared/eval-step-replay.ts` and widen `PlatformEvalStepEvidence.toolCalls` in `sdk/src/platform/types.ts`.
- Unit tests verify presence when recorded and omission when not.

**Rollout**
- Additive, backward-compatible field; no migration required.
- Consumers may start reading `elapsedMs` from `PlatformEvalStepEvidence.toolCalls` in `@mcpjam/sdk` when present.

<sup>Written for commit 0f237c76ef9b61cf7dde4847d62a54371181caed. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/MCPJam/inspector/pull/4295?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

