### PR TITLE
sessions: mirror ChatOrigin api and harden origin chips

### DIFF
--- a/mcpjam-inspector/client/src/components/sessions/SessionsPanel.tsx
+++ b/mcpjam-inspector/client/src/components/sessions/SessionsPanel.tsx
@@ -48,6 +48,7 @@ import {
   SESSIONS_FEED_PAGE_SIZE,
   SESSIONS_FEED_QUERIES,
   SESSION_SOURCE_TYPE_LABELS,
+  sessionOriginChipLabel,
   sessionParentChipLabel,
   type SessionFeedItem,
   type SessionFeedSourceType,
@@ -353,6 +354,7 @@ function SessionFeedRow({
   onSelect: () => void;
 }) {
   const parentChip = sessionParentChipLabel(row.parentRef);
+  const originChip = sessionOriginChipLabel(row.origin);
   const title = row.title?.trim() || row.firstMessagePreview || "Untitled";
 
   return (
@@ -379,6 +381,14 @@ function SessionFeedRow({
         <span className="rounded-full border border-border/60 px-1.5 py-0 text-[10px] font-medium uppercase tracking-wide text-muted-foreground">
           {SESSION_SOURCE_TYPE_LABELS[row.sourceType] ?? row.sourceType}
         </span>
+        {originChip ? (
+          <span
+            data-testid="session-origin-chip"
+            className="rounded-full border border-border/60 px-1.5 py-0 text-[10px] font-medium uppercase tracking-wide text-muted-foreground"
+          >
+            {originChip}
+          </span>
+        ) : null}
         {row.ownedByViewer ? (
           <span className="rounded-full border border-border/60 px-1.5 py-0 text-[10px] font-medium text-muted-foreground">
             Yours

--- a/mcpjam-inspector/client/src/components/sessions/__tests__/SessionsPanel.test.tsx
+++ b/mcpjam-inspector/client/src/components/sessions/__tests__/SessionsPanel.test.tsx
@@ -225,6 +225,32 @@ describe("SessionsPanel — rows and detail", () => {
     expect(quick.getByText("Quick Run")).toBeInTheDocument();
   });
 
+  test("renders an API origin chip and falls back for unknown origins", () => {
+    setRows([
+      makeRow({
+        chatSessionId: "cs_api",
+        sourceType: "direct",
+        origin: "api",
+        title: "Agent turn",
+      }),
+      makeRow({
+        chatSessionId: "cs_future",
+        sourceType: "direct",
+        origin: "future_surface",
+        title: "Unknown origin",
+      }),
+    ]);
+    render(<SessionsPanel projectId="p1" />);
+
+    const apiRow = within(screen.getByTestId("session-row-cs_api"));
+    expect(apiRow.getByTestId("session-origin-chip")).toHaveTextContent("API");
+
+    const future = within(screen.getByTestId("session-row-cs_future"));
+    expect(future.getByTestId("session-origin-chip")).toHaveTextContent(
+      "future_surface"
+    );
+  });
+
   test("clicking a row opens the detail pane with the row's `id`, not its chatSessionId", () => {
     setRows([
       makeRow({ id: "doc_abc", chatSessionId: "cs_abc", title: "Pick me" }),

--- a/mcpjam-inspector/client/src/components/sessions/__tests__/SessionsPanel.test.tsx
+++ b/mcpjam-inspector/client/src/components/sessions/__tests__/SessionsPanel.test.tsx
@@ -239,6 +239,12 @@ describe("SessionsPanel — rows and detail", () => {
         origin: "future_surface",
         title: "Unknown origin",
       }),
+      makeRow({
+        chatSessionId: "cs_proto",
+        sourceType: "direct",
+        origin: "constructor",
+        title: "Inherited key",
+      }),
     ]);
     render(<SessionsPanel projectId="p1" />);
 
@@ -248,6 +254,11 @@ describe("SessionsPanel — rows and detail", () => {
     const future = within(screen.getByTestId("session-row-cs_future"));
     expect(future.getByTestId("session-origin-chip")).toHaveTextContent(
       "future_surface"
+    );
+
+    const proto = within(screen.getByTestId("session-row-cs_proto"));
+    expect(proto.getByTestId("session-origin-chip")).toHaveTextContent(
+      "constructor"
     );
   });
 

--- a/mcpjam-inspector/client/src/lib/sessions-feed-api.ts
+++ b/mcpjam-inspector/client/src/lib/sessions-feed-api.ts
@@ -126,7 +126,11 @@ export function sessionOriginChipLabel(
   origin: string | null | undefined
 ): string | null {
   if (!origin) return null;
-  return SESSION_ORIGIN_LABELS[origin] ?? origin;
+  // Own-key only: "constructor" / "toString" / "__proto__" are inherited
+  // and must render as the raw origin, not a Function or Object.
+  return Object.hasOwn(SESSION_ORIGIN_LABELS, origin)
+    ? SESSION_ORIGIN_LABELS[origin]
+    : origin;
 }
 
 /**

--- a/mcpjam-inspector/client/src/lib/sessions-feed-api.ts
+++ b/mcpjam-inspector/client/src/lib/sessions-feed-api.ts
@@ -112,6 +112,23 @@ export const SESSION_SOURCE_TYPE_LABELS: Record<SessionFeedSourceType, string> =
     swarm: "Swarm",
   };
 
+/** Product-surface labels. Unknown origins render as the raw string (spike 6). */
+export const SESSION_ORIGIN_LABELS: Record<string, string> = {
+  playground: "Playground",
+  mcpjam_agent: "Agent",
+  scenario: "User Testing",
+  eval: "Eval",
+  swarm: "Swarm",
+  api: "API",
+};
+
+export function sessionOriginChipLabel(
+  origin: string | null | undefined
+): string | null {
+  if (!origin) return null;
+  return SESSION_ORIGIN_LABELS[origin] ?? origin;
+}
+
 /**
  * The parent chip for a row. Falls back to naming the run kind when the
  * parent's own label is gone, and calls out Quick Runs (which genuinely have

--- a/mcpjam-inspector/server/utils/chat-ingestion.ts
+++ b/mcpjam-inspector/server/utils/chat-ingestion.ts
@@ -222,7 +222,10 @@ export type ChatOrigin =
   | "mcpjam_agent"
   | "scenario"
   | "eval"
-  | "swarm";
+  | "swarm"
+  // Agent Playground turn route. Validator ships with backend PR 4; this
+  // mirror must exist before anything emits `"api"`.
+  | "api";
 
 interface PersistChatSessionOptions {
   chatSessionId: string;

--- a/mcpjam-inspector/server/utils/log-events.ts
+++ b/mcpjam-inspector/server/utils/log-events.ts
@@ -262,7 +262,13 @@ export type RequestEventMap = {
     // CAUTION: this `origin` is a DIFFERENT axis from the ErrorOrigin field
     // of the same name on `http.request.failed` / `route.operation.failed` —
     // never join the two in an APL query.
-    origin?: "playground" | "mcpjam_agent" | "scenario" | "eval" | "swarm";
+    origin?:
+      | "playground"
+      | "mcpjam_agent"
+      | "scenario"
+      | "eval"
+      | "swarm"
+      | "api";
   };
   /**
    * The backend accepted the request but declined the write, judging the
@@ -272,7 +278,13 @@ export type RequestEventMap = {
    */
   "chat.session.persist.skipped": {
     sourceType?: "scenario" | "direct" | "eval" | "swarm";
-    origin?: "playground" | "mcpjam_agent" | "scenario" | "eval" | "swarm";
+    origin?:
+      | "playground"
+      | "mcpjam_agent"
+      | "scenario"
+      | "eval"
+      | "swarm"
+      | "api";
     /** False means the payload had no idempotency key to dedupe on. */
     hasTurnId: boolean;
   };


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Purpose

Playground-for-Agents **PR 5 (inspector)**. Mirrors backend #1110's `ChatOrigin "api"` and hardens the Sessions list for unknown origins (spike 6).

Depends on backend #1110 deploying first. This PR does **not** emit `"api"` — it only accepts and displays it.

## Before / after

- **Before:** inspector `ChatOrigin` is a closed set without `"api"`. Sessions rows chip `sourceType` only; an unknown origin is ignored.
- **After:** `"api"` is a valid writer-boundary origin. Sessions rows show an origin chip (`API` for `"api"`, raw string for unknown values) so a future origin cannot blank the row.

## What changed

- `server/utils/chat-ingestion.ts` + `log-events.ts` — add `"api"`
- `sessions-feed-api.ts` — `SESSION_ORIGIN_LABELS` + `sessionOriginChipLabel`
- `SessionsPanel` origin chip
- Panel test: API label + unknown-origin fallback

## Verification

```
npx vitest run client/src/components/sessions/__tests__/SessionsPanel.test.tsx
```

10 passed.

## Rollout

Additive UI. Safe to merge after or with #1110. Nothing writes `origin: "api"` until PR 7 (turn route).

## Follow-ups

PR 6: `GET /v1/chat-sessions/:id` + incremental trace.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-2fa398fa-2d31-4ce0-8ccf-8202b731e384?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-2fa398fa-2d31-4ce0-8ccf-8202b731e384&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Accepts backend `ChatOrigin` value "api" and adds a Sessions origin chip. Previously unknown origins were ignored and only `sourceType` showed; now "api" is allowed and the chip shows "API" or the raw origin string. Lookup uses own-property checks to avoid inherited keys like "constructor".

- Verify `SESSION_ORIGIN_LABELS` and `sessionOriginChipLabel` map "api" → "API"; own-property lookup falls back to raw strings for unknown/inherited keys; `SessionsPanel` renders the chip only when an origin exists.
- Server typing mirrors "api" in `ChatOrigin` and `RequestEventMap`; this PR does not emit "api".
- Deploy after backend #1110. No migrations; additive UI with tests covering API label and unknown/inherited-origin fallback.

<sup>Written for commit 34e1bdce65297ec679a2d0ca5c8150f09186e528. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/MCPJam/inspector/pull/4296?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

