### PR TITLE
ci: add a standalone Deploy Webapp workflow for production

### DIFF
--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -127,4 +127,4 @@ jobs:
 
   smoke:
     needs: deploy
-    uses: ./.github/workflows/post-deploy-staging.yml
+    uses: ./.github/workflows/post-deploy-smoke.yml

--- a/.github/workflows/deploy-webapp.yml
+++ b/.github/workflows/deploy-webapp.yml
@@ -1,0 +1,209 @@
+name: Deploy Webapp
+
+# The hosted inspector's only path to production used to be the promote job
+# inside release.yml, which refuses to run unless an inspector changeset is in
+# scope. That made "redeploy prod at the current SHA" and "roll back prod to
+# the last good SHA" impossible without cutting an npm release — precisely the
+# thing you cannot wait on during an incident.
+#
+# This is that deploy, extracted: dispatchable on its own, and called by
+# release.yml so there is exactly ONE code path to production instead of two
+# that drift.
+#
+# Deliberately NOT here: the service-variable refresh that deploy-staging.yml
+# does. Staging can rewrite its own origin allowlists because their contents
+# are derivable from this file. Production's `ALLOWED_ORIGINS` /
+# `WEB_ALLOWED_ORIGINS` are hand-set on the Railway service and their full
+# membership is not recorded anywhere in this repo, so writing a guessed value
+# on every deploy would trade a rare drift bug for a routine outage. Prod
+# carries the same "hand-set vars vanish on rebuild" hazard the staging
+# comment describes; closing it needs the real allowlist written down first.
+#
+# Boolean inputs are compared against BOTH `true` and `'true'`: a
+# `workflow_call` caller passes a real boolean, while a manual dispatch of the
+# same input can arrive as a string. `if: inputs.flag` alone is the classic
+# footgun here — the string 'false' is truthy.
+
+on:
+  workflow_dispatch:
+    inputs:
+      ref:
+        description: "Branch, tag, or SHA to deploy (defaults to the dispatch ref)"
+        required: false
+        type: string
+      require_staging_green:
+        description: "Require a successful Deploy Staging run for the deployed SHA"
+        required: false
+        default: true
+        type: boolean
+      run_e2e:
+        description: "Run the Playwright suite against production after deploy"
+        required: false
+        default: false
+        type: boolean
+  workflow_call:
+    inputs:
+      ref:
+        description: "Branch, tag, or SHA to deploy (defaults to the caller's SHA)"
+        required: false
+        type: string
+      apply_release_patch:
+        description: "Apply the shared release patch artifact before deploying"
+        required: false
+        default: false
+        type: boolean
+      require_staging_green:
+        description: "Require a successful Deploy Staging run for the deployed SHA"
+        required: false
+        default: true
+        type: boolean
+      run_e2e:
+        description: "Run the Playwright suite against production after deploy"
+        required: false
+        default: false
+        type: boolean
+
+permissions:
+  contents: read
+  # The staging gate below lists workflow runs.
+  actions: read
+
+concurrency:
+  # Never let two production deploys race. `cancel-in-progress: false` because
+  # cancelling mid-`railway up` leaves the service half-promoted.
+  group: inspector-production
+  cancel-in-progress: false
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    environment:
+      name: production
+      url: ${{ vars.PRODUCTION_APP_URL || 'https://app.mcpjam.com' }}
+    env:
+      RAILWAY_API_TOKEN: ${{ secrets.RAILWAY_API_TOKEN }}
+      RAILWAY_PROJECT_ID: ${{ vars.RAILWAY_PROJECT_ID }}
+      RAILWAY_INSPECTOR_SERVICE: ${{ vars.RAILWAY_INSPECTOR_SERVICE }}
+      RAILWAY_PRODUCTION_ENVIRONMENT: ${{ vars.RAILWAY_PRODUCTION_ENVIRONMENT }}
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.ref || github.sha }}
+
+      # `railway up` uploads the working tree, so the deployed code is whatever
+      # this checkout resolved to. Record the SHA explicitly: it is what the
+      # staging gate below asks about and the only thing that tells an operator
+      # reading this run months later what actually shipped.
+      - name: Resolve deployed SHA
+        id: resolved
+        run: |
+          SHA="$(git rev-parse HEAD)"
+          echo "sha=$SHA" >> "$GITHUB_OUTPUT"
+          echo "Deploying $SHA (ref: ${{ inputs.ref || github.sha }})"
+
+      - name: Require green staging run for the deployed SHA
+        if: ${{ inputs.require_staging_green == true || inputs.require_staging_green == 'true' }}
+        uses: actions/github-script@v7
+        env:
+          DEPLOY_SHA: ${{ steps.resolved.outputs.sha }}
+        with:
+          script: |
+            const workflowId = "deploy-staging.yml";
+            const { owner, repo } = context.repo;
+            const headSha = process.env.DEPLOY_SHA;
+            // Fetch without branch/status filters — GitHub's search index
+            // can lag minutes behind, causing false negatives on recent runs.
+            // JS-side filtering on head_sha + conclusion is authoritative.
+            const runs = await github.paginate(github.rest.actions.listWorkflowRuns, {
+              owner,
+              repo,
+              workflow_id: workflowId,
+              per_page: 100,
+            });
+
+            const matchingRun = runs.find(
+              (run) => run.head_sha === headSha && run.conclusion === "success"
+            );
+
+            if (!matchingRun) {
+              core.setFailed(
+                `No successful ${workflowId} run found for ${headSha}. Deploy that SHA to staging first, or re-run with require_staging_green=false if you are rolling back to a SHA that predates the staging workflow.`
+              );
+              return;
+            }
+
+            core.info(`Found successful staging deploy run ${matchingRun.id} for ${headSha}.`);
+
+      # release.yml versions packages in its preflight job and passes the diff
+      # along as an artifact, so production ships the same tree that was
+      # published to npm rather than the pre-bump one.
+      - name: Download release patch
+        if: ${{ inputs.apply_release_patch == true || inputs.apply_release_patch == 'true' }}
+        uses: actions/download-artifact@v4
+        with:
+          name: release-plan
+          path: .release-plan
+
+      - name: Apply release patch
+        if: ${{ inputs.apply_release_patch == true || inputs.apply_release_patch == 'true' }}
+        run: git apply --binary .release-plan/release.patch
+
+      # Pinned to match deploy-staging.yml and pr-preview.yml. An unpinned
+      # install picks up whatever shipped that morning, on the one workflow
+      # where a CLI regression is most expensive.
+      - name: Install Railway CLI
+        run: npm install -g @railway/cli@4.57.1
+
+      # Capture the newest deployment id before we trigger a new one so the
+      # wait step below can tell *our* deploy from the previous-good one.
+      - name: Snapshot latest deployment id
+        id: previous_deploy
+        run: |
+          PREV=$(.github/scripts/railway-wait-deploy.sh --latest \
+            -s "$RAILWAY_INSPECTOR_SERVICE" \
+            -e "$RAILWAY_PRODUCTION_ENVIRONMENT")
+          echo "id=$PREV" >> "$GITHUB_OUTPUT"
+          echo "Previous deployment: ${PREV:-<none>}"
+
+      # `--detach` uploads and returns immediately. See railway-wait-deploy.sh
+      # for why `--ci`'s build-log stream is not a usable success signal.
+      - name: Deploy inspector to Railway production
+        run: |
+          .github/scripts/railway-retry.sh railway up \
+            --detach \
+            --project "$RAILWAY_PROJECT_ID" \
+            --environment "$RAILWAY_PRODUCTION_ENVIRONMENT" \
+            --service "$RAILWAY_INSPECTOR_SERVICE"
+
+      - name: Wait for Railway production deploy to finish
+        timeout-minutes: 20
+        env:
+          PREVIOUS_DEPLOY_ID: ${{ steps.previous_deploy.outputs.id }}
+        run: |
+          .github/scripts/railway-wait-deploy.sh \
+            -s "$RAILWAY_INSPECTOR_SERVICE" \
+            -e "$RAILWAY_PRODUCTION_ENVIRONMENT" \
+            -p "$PREVIOUS_DEPLOY_ID"
+
+      - name: Summarize deploy
+        env:
+          DEPLOY_SHA: ${{ steps.resolved.outputs.sha }}
+          APP_URL: ${{ vars.PRODUCTION_APP_URL || 'https://app.mcpjam.com' }}
+          PREVIOUS_DEPLOY_ID: ${{ steps.previous_deploy.outputs.id }}
+        run: |
+          {
+            echo "## 🚀 Webapp deployed to production"
+            echo ""
+            echo "- SHA: \`$DEPLOY_SHA\`"
+            echo "- Target: \`$APP_URL\`"
+            echo "- Previous Railway deployment: \`${PREVIOUS_DEPLOY_ID:-<none>}\` (roll back by re-running this workflow with that deployment's SHA)"
+          } >> "$GITHUB_STEP_SUMMARY"
+
+  smoke:
+    needs: deploy
+    uses: ./.github/workflows/post-deploy-smoke.yml
+    with:
+      base_url: ${{ vars.PRODUCTION_APP_URL || 'https://app.mcpjam.com' }}
+      label: production
+      run_e2e: ${{ inputs.run_e2e == true || inputs.run_e2e == 'true' }}

--- a/.github/workflows/post-deploy-smoke.yml
+++ b/.github/workflows/post-deploy-smoke.yml
@@ -1,18 +1,47 @@
-name: Post-Deploy Staging Smoke
+name: Post-Deploy Smoke
+
+# Shared by deploy-staging.yml and deploy-webapp.yml. Every input defaults to
+# staging's previous behavior, so the staging caller stays a bare `uses:` and
+# only the production caller has to say what it wants.
+#
+# Boolean inputs are compared against BOTH `true` and `'true'`: a
+# `workflow_call` caller passes a real boolean, while a manual dispatch of the
+# same input can arrive as a string. `if: inputs.flag` alone is the classic
+# footgun here — the string 'false' is truthy.
 
 on:
   workflow_call:
     inputs:
       base_url:
-        description: "Optional staging base URL override"
+        description: "Base URL to smoke (defaults to staging)"
         required: false
         type: string
+      label:
+        description: "Environment name used in the run summary and artifacts"
+        required: false
+        default: staging
+        type: string
+      run_e2e:
+        description: "Run the Playwright suite against the target"
+        required: false
+        default: true
+        type: boolean
   workflow_dispatch:
     inputs:
       base_url:
-        description: "Optional staging base URL override"
+        description: "Base URL to smoke (defaults to staging)"
         required: false
         type: string
+      label:
+        description: "Environment name used in the run summary and artifacts"
+        required: false
+        default: staging
+        type: string
+      run_e2e:
+        description: "Run the Playwright suite against the target"
+        required: false
+        default: true
+        type: boolean
 
 env:
   NODE_VERSION: "24.14.0"
@@ -23,7 +52,7 @@ jobs:
     outputs:
       base_url: ${{ steps.target.outputs.base_url }}
     steps:
-      - name: Resolve staging URL
+      - name: Resolve target URL
         id: target
         shell: bash
         run: |
@@ -65,14 +94,21 @@ jobs:
       - name: Summarize smoke result
         env:
           BASE_URL: ${{ steps.target.outputs.base_url }}
+          LABEL: ${{ inputs.label || 'staging' }}
         run: |
-          echo "## ✅ Staging HTTP smoke passed" >> "$GITHUB_STEP_SUMMARY"
-          echo "" >> "$GITHUB_STEP_SUMMARY"
-          echo "- Target: \`$BASE_URL\`" >> "$GITHUB_STEP_SUMMARY"
-          echo "- Checked: \`/health\`, \`/api/mcp/health\`, \`/api/apps/health\`, unauthenticated \`/api/web/tools/list\`" >> "$GITHUB_STEP_SUMMARY"
+          {
+            echo "## ✅ ${LABEL} HTTP smoke passed"
+            echo ""
+            echo "- Target: \`$BASE_URL\`"
+            echo "- Checked: \`/health\`, \`/api/mcp/health\`, \`/api/apps/health\`, unauthenticated \`/api/web/tools/list\`"
+          } >> "$GITHUB_STEP_SUMMARY"
 
   e2e:
     needs: smoke
+    # Off by default for production: the suite drives a real browser through
+    # real sign-in and session surfaces, so pointing it at prod writes prod
+    # data. Callers that want it there must opt in deliberately.
+    if: ${{ inputs.run_e2e == true || inputs.run_e2e == 'true' }}
     runs-on: ubuntu-latest
     # Non-gating during the initial soak. deploy-staging.yml calls this workflow
     # and release.yml polls deploy-staging.yml success as the release gate, so a
@@ -100,7 +136,7 @@ jobs:
       - name: Install workspace dependencies
         run: npm ci --legacy-peer-deps
 
-      - name: Run Playwright smoke against staging
+      - name: Run Playwright smoke against the deployed target
         # PLAYWRIGHT_BASE_URL makes the config skip the local webServer and drive
         # the deployed URL, so no inspector build is needed here. Sourced from the
         # smoke job's output because step outputs are job-local.
@@ -112,7 +148,7 @@ jobs:
         if: failure()
         uses: actions/upload-artifact@v4
         with:
-          name: playwright-report-staging
+          name: playwright-report-${{ inputs.label || 'staging' }}
           path: |
             mcpjam-inspector/playwright-report/
             mcpjam-inspector/test-results/

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,8 +17,8 @@ on:
         required: false
         default: false
         type: boolean
-      promote_production:
-        description: "Deploy inspector production after publish"
+      deploy_webapp:
+        description: "Deploy the webapp to production after publish"
         required: false
         default: false
         type: boolean
@@ -112,7 +112,7 @@ jobs:
         env:
           RELEASE_SCOPE: ${{ inputs.scope }}
           DEPLOY_BACKEND_PROD: ${{ inputs.deploy_backend_prod }}
-          PROMOTE_PRODUCTION: ${{ inputs.promote_production }}
+          DEPLOY_WEBAPP: ${{ inputs.deploy_webapp }}
         run: |
           node <<'NODE'
           const fs = require("node:fs");
@@ -165,11 +165,11 @@ jobs:
           }
 
           if (
-            process.env.PROMOTE_PRODUCTION === "true" &&
+            process.env.DEPLOY_WEBAPP === "true" &&
             !selected.inspector
           ) {
             throw new Error(
-              "promote_production=true requires an inspector release in the selected scope."
+              "deploy_webapp=true requires an inspector release in the selected scope. To deploy production without cutting a release, dispatch deploy-webapp.yml directly."
             );
           }
 
@@ -419,104 +419,55 @@ jobs:
 
             core.setFailed("Timed out waiting for backend production deployment to finish.");
 
-  promote-production:
+  # The production deploy itself lives in deploy-webapp.yml so it can also be
+  # dispatched on its own — a release is not the only reason to ship or roll
+  # back the webapp. `require_staging_green` is false here because preflight
+  # already gated this exact SHA on a green staging run.
+  deploy-webapp:
     needs:
       - preflight
       - publish-packages
       - deploy-backend-prod
     if: |
       always() &&
-      fromJSON(inputs.promote_production) &&
+      fromJSON(inputs.deploy_webapp) &&
       needs.preflight.result == 'success' &&
       needs.publish-packages.result == 'success' &&
       (
         !fromJSON(inputs.deploy_backend_prod) ||
         needs.deploy-backend-prod.result == 'success'
       )
-    runs-on: ubuntu-latest
-    environment:
-      name: production
-      url: ${{ vars.PRODUCTION_APP_URL || 'https://mcpjam.com' }}
-    env:
-      RAILWAY_API_TOKEN: ${{ secrets.RAILWAY_API_TOKEN }}
-      RAILWAY_PROJECT_ID: ${{ vars.RAILWAY_PROJECT_ID }}
-      RAILWAY_INSPECTOR_SERVICE: ${{ vars.RAILWAY_INSPECTOR_SERVICE }}
-      RAILWAY_PRODUCTION_ENVIRONMENT: ${{ vars.RAILWAY_PRODUCTION_ENVIRONMENT }}
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v4
-
-      - name: Download release patch
-        uses: actions/download-artifact@v4
-        with:
-          name: release-plan
-          path: .release-plan
-
-      - name: Apply release patch
-        run: git apply --binary .release-plan/release.patch
-
-      # Pinned to match deploy-staging.yml and pr-preview.yml. An unpinned
-      # install picks up whatever shipped that morning, on the one workflow
-      # where a CLI regression is most expensive.
-      - name: Install Railway CLI
-        run: npm install -g @railway/cli@4.57.1
-
-      # Capture the newest deployment id before we trigger a new one so the
-      # wait step below can tell *our* deploy from the previous-good one.
-      - name: Snapshot latest deployment id
-        id: previous_deploy
-        run: |
-          PREV=$(.github/scripts/railway-wait-deploy.sh --latest \
-            -s "$RAILWAY_INSPECTOR_SERVICE" \
-            -e "$RAILWAY_PRODUCTION_ENVIRONMENT")
-          echo "id=$PREV" >> "$GITHUB_OUTPUT"
-          echo "Previous deployment: ${PREV:-<none>}"
-
-      # `--detach` uploads and returns immediately. See railway-wait-deploy.sh
-      # for why `--ci`'s build-log stream is not a usable success signal.
-      - name: Deploy inspector to Railway production
-        run: |
-          .github/scripts/railway-retry.sh railway up \
-            --detach \
-            --project "$RAILWAY_PROJECT_ID" \
-            --environment "$RAILWAY_PRODUCTION_ENVIRONMENT" \
-            --service "$RAILWAY_INSPECTOR_SERVICE"
-
-      - name: Wait for Railway production deploy to finish
-        timeout-minutes: 20
-        env:
-          PREVIOUS_DEPLOY_ID: ${{ steps.previous_deploy.outputs.id }}
-        run: |
-          .github/scripts/railway-wait-deploy.sh \
-            -s "$RAILWAY_INSPECTOR_SERVICE" \
-            -e "$RAILWAY_PRODUCTION_ENVIRONMENT" \
-            -p "$PREVIOUS_DEPLOY_ID"
+    uses: ./.github/workflows/deploy-webapp.yml
+    with:
+      apply_release_patch: true
+      require_staging_green: false
+    secrets: inherit
 
   # The two Railway satellites. Their own workflows already redeploy on
   # ordinary main pushes touching their paths; these jobs make a RELEASE
-  # redeploy them too, ordered AFTER the inspector promote — both render the
+  # redeploy them too, ordered AFTER the webapp deploy — both render the
   # server's contract, so they must never ship ahead of it. A same-SHA
   # push-triggered run may queue behind these (per-service concurrency
   # groups, cancel-in-progress: false); the duplicate deploy is idempotent.
   deploy-slack-app:
     needs:
       - preflight
-      - promote-production
+      - deploy-webapp
     if: |
       always() &&
-      fromJSON(inputs.promote_production) &&
-      needs.promote-production.result == 'success'
+      fromJSON(inputs.deploy_webapp) &&
+      needs.deploy-webapp.result == 'success'
     uses: ./.github/workflows/deploy-slack-app.yml
     secrets: inherit
 
   deploy-soundcheck:
     needs:
       - preflight
-      - promote-production
+      - deploy-webapp
     if: |
       always() &&
-      fromJSON(inputs.promote_production) &&
-      needs.promote-production.result == 'success'
+      fromJSON(inputs.deploy_webapp) &&
+      needs.deploy-webapp.result == 'success'
     uses: ./.github/workflows/deploy-soundcheck.yml
     secrets: inherit
 
@@ -525,7 +476,7 @@ jobs:
       - preflight
       - publish-packages
       - deploy-backend-prod
-      - promote-production
+      - deploy-webapp
       - deploy-slack-app
       - deploy-soundcheck
     if: |


### PR DESCRIPTION
## Why

Production could only be reached through the `promote-production` job inside `release.yml`, and that job refuses to run unless an inspector changeset is in scope (`release.yml` preflight throws otherwise). So today there is no way to:

- redeploy production at the current `main` SHA,
- retry a production deploy that failed *after* `changeset publish` succeeded,
- roll back to the last good SHA,

without cutting a full npm release. That is the one thing you cannot wait on during an incident.

## What

**`deploy-webapp.yml` (new)** — the production deploy, extracted so it can be dispatched on its own *and* called by the release:

- `ref` input (branch, tag, or SHA) — rollback is "re-run with the last good SHA". The resolved SHA is recorded in the step summary, since `railway up` uploads the working tree and nothing else in the run says what shipped.
- `require_staging_green` (default `true`) — the same green-staging gate `release.yml` preflight uses, applied to the resolved SHA, with an escape hatch for incidents.
- `environment: production` keeps the existing approval gate; `concurrency: inspector-production` with `cancel-in-progress: false` so two prod deploys never race and none is cancelled mid-`railway up`.
- Same snapshot → `railway up --detach` → `railway-wait-deploy.sh` sequence staging uses.

**`post-deploy-staging.yml` → `post-deploy-smoke.yml`** — parameterized by `base_url`, `label`, and `run_e2e`. Every input defaults to staging's previous behavior, so `deploy-staging.yml` stays a bare `uses:`.

**`release.yml`** — `promote-production` is now a `uses:` of `deploy-webapp.yml` with `apply_release_patch: true` and `require_staging_green: false` (preflight already gated that SHA). Input `promote_production` → `deploy_webapp`; satellite and `finalize` `needs` follow. Net −84 lines.

## Two judgment calls worth a look

**Playwright is off by default against production.** The suite drives real sign-in and session surfaces, so pointing it at prod writes prod data. Production gets the HTTP smoke; `run_e2e: true` opts in.

**The service-variable refresh is deliberately not included.** `deploy-staging.yml` rewrites `ALLOWED_ORIGINS` / `WEB_ALLOWED_ORIGINS` / `MCPJAM_INSPECTOR_PUBLIC_URL` on every deploy because a rebuild silently dropped hand-set vars. Staging can do that because the values are derivable from the workflow file. Production's allowlists are hand-set on the Railway service and their full membership is recorded nowhere in this repo — writing a guessed value on every deploy would trade a rare drift bug for a routine outage. Prod still carries the hazard; it is documented in the new file rather than silently omitted. Closing it needs the real allowlist written down first.

## Drive-by fix

`release.yml` linked the production environment to `https://mcpjam.com`, which 308-redirects. `app.mcpjam.com` serves `/health` and is what `prod-canary.yml` already probes; the fallback now matches.

## Verification

`actionlint` is clean on both new files. `release.yml`'s expression-warning count is unchanged from baseline (7 — a pre-existing `fromJSON(<bool>)` idiom I matched rather than diverged from).

Not otherwise exercised: this is untested until the first dispatch. Suggested first run is `deploy-webapp.yml` dispatched against current `main` with defaults, which should be a no-op redeploy of what is already live.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AJefojJD5LY5gPeTqUMWGU

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Changes the only path that deploys the inspector to Railway production, including gates, concurrency, and post-deploy smoke. A workflow bug here can ship or block production.
> 
> **Overview**
> Production inspector deploys are no longer trapped inside `release.yml`. A new `deploy-webapp.yml` is the single Railway production path: dispatchable with a `ref` (for redeploy/rollback) and reusable from release.
> 
> The workflow keeps the production environment approval, serializes on `inspector-production` without canceling in-flight `railway up`, optionally requires a green staging run for the resolved SHA, and can apply the release patch so published npm trees match what ships. Playwright against prod is **off by default**; HTTP smoke still runs. Production origin allowlists are **not** rewritten on deploy (unlike staging).
> 
> `post-deploy-staging.yml` is generalized to `post-deploy-smoke.yml` (`base_url`, `label`, `run_e2e`). `release.yml` replaces `promote_production` with `deploy_webapp` and calls the new workflow; satellite deploys still wait on it. Production URL fallback is `https://app.mcpjam.com`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 950871560674778802da92baf5125ed44a468992. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a standalone Deploy Webapp workflow for production and wires `release.yml` to call it. This removes the release-only path to prod and enables redeploys, retries, and rollbacks without cutting an npm release.

- New `.github/workflows/deploy-webapp.yml`: dispatchable or `workflow_call`, with `ref` (branch/tag/SHA), `require_staging_green` (default true), and `run_e2e` (default false). It records the deployed SHA, enforces single-flight via `concurrency: inspector-production`, reuses the staging deploy steps, and runs shared post-deploy smoke.
- `release.yml`: replaces the inline promote job with a `uses:` of the new workflow (`apply_release_patch: true`, `require_staging_green: false`). Input renamed to `deploy_webapp`; downstream satellites now depend on this job.
- `post-deploy-staging.yml` renamed to `post-deploy-smoke.yml` with `base_url`, `label`, and `run_e2e`; staging defaults unchanged. Production smoke runs HTTP checks; Playwright is opt-in.
- Production environment URL fallback fixed to `https://app.mcpjam.com`. Railway CLI pinned to `@railway/cli@4.57.1`.

- Required actions:
  - For releases, use `deploy_webapp` instead of `promote_production`.
  - To roll back, re-dispatch `deploy-webapp.yml` with `ref` set to the last good SHA; set `require_staging_green=false` only when necessary.
  - Production allowlists are not auto-refreshed; keep Railway `ALLOWED_ORIGINS`/`WEB_ALLOWED_ORIGINS` up to date manually until codified.

<sup>Written for commit 950871560674778802da92baf5125ed44a468992. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/MCPJam/inspector/pull/4297?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

