### PR TITLE
fix(soundcheck): send deploy_webapp, the input release.yml actually takes

### DIFF
--- a/soundcheck/src/app/api/release/dispatch/route.ts
+++ b/soundcheck/src/app/api/release/dispatch/route.ts
@@ -49,7 +49,7 @@ type Scope = "none" | "packages-only" | "inspector-only" | "full";
 interface DispatchBody {
   scope: Scope;
   deploy_backend_prod: boolean;
-  promote_production: boolean;
+  deploy_webapp: boolean;
   deploy_mcp_production: boolean;
   skip_verify: boolean;
 }
@@ -68,7 +68,7 @@ function parseBody(raw: unknown): DispatchBody | null {
   const body = raw as Record<string, unknown>;
   if (!isScope(body.scope)) return null;
   if (typeof body.deploy_backend_prod !== "boolean") return null;
-  if (typeof body.promote_production !== "boolean") return null;
+  if (typeof body.deploy_webapp !== "boolean") return null;
   if (typeof body.deploy_mcp_production !== "boolean") return null;
   if (
     body.skip_verify !== undefined &&
@@ -79,7 +79,7 @@ function parseBody(raw: unknown): DispatchBody | null {
   return {
     scope: body.scope,
     deploy_backend_prod: body.deploy_backend_prod,
-    promote_production: body.promote_production,
+    deploy_webapp: body.deploy_webapp,
     deploy_mcp_production: body.deploy_mcp_production,
     skip_verify: body.skip_verify ?? false
   };
@@ -129,7 +129,7 @@ export async function POST(request: Request) {
     return NextResponse.json(
       {
         error:
-          "Expected { scope, deploy_backend_prod, promote_production, deploy_mcp_production } with optional boolean skip_verify"
+          "Expected { scope, deploy_backend_prod, deploy_webapp, deploy_mcp_production } with optional boolean skip_verify"
       },
       { status: 400 }
     );
@@ -179,7 +179,7 @@ export async function POST(request: Request) {
       email: user.email,
       scope: parsed.scope,
       deploy_backend_prod: parsed.deploy_backend_prod,
-      promote_production: parsed.promote_production,
+      deploy_webapp: parsed.deploy_webapp,
       deploy_mcp_production: parsed.deploy_mcp_production,
       skip_verify: effectiveSkipVerify,
       workflows_attempted: attemptedWorkflows
@@ -204,7 +204,7 @@ export async function POST(request: Request) {
           scope: parsed.scope,
           // Workflow dispatch inputs go over the wire as strings.
           deploy_backend_prod: String(parsed.deploy_backend_prod),
-          promote_production: String(parsed.promote_production),
+          deploy_webapp: String(parsed.deploy_webapp),
           skip_verify: String(effectiveSkipVerify)
         },
         writeToken
@@ -260,7 +260,7 @@ export async function POST(request: Request) {
       email: user.email,
       scope: parsed.scope,
       deploy_backend_prod: parsed.deploy_backend_prod,
-      promote_production: parsed.promote_production,
+      deploy_webapp: parsed.deploy_webapp,
       deploy_mcp_production: parsed.deploy_mcp_production,
       skip_verify: effectiveSkipVerify,
       workflows_attempted: attemptedWorkflows,

--- a/soundcheck/src/components/run-release.tsx
+++ b/soundcheck/src/components/run-release.tsx
@@ -4,7 +4,7 @@
  * Run Release tile — the single dispatch form for every production deploy
  * Soundcheck can trigger:
  *
- *   - release.yml (scope + promote_production + deploy_backend_prod)
+ *   - release.yml (scope + deploy_webapp + deploy_backend_prod)
  *   - deploy-mcp-prod.yml (deploy_mcp_production)
  *
  * MCP lives here rather than in its own tile because it's another flavor
@@ -55,7 +55,7 @@ export function RunRelease() {
   const router = useRouter();
   const [scope, setScope] = useState<Scope>("full");
   const [deployBackend, setDeployBackend] = useState(false);
-  const [promoteProd, setPromoteProd] = useState(false);
+  const [deployWebapp, setDeployWebapp] = useState(false);
   const [deployMcp, setDeployMcp] = useState(false);
   const [skipVerify, setSkipVerify] = useState(false);
   const [confirming, setConfirming] = useState(false);
@@ -68,7 +68,7 @@ export function RunRelease() {
   const [isPending, startTransition] = useTransition();
 
   const runsRelease = scope !== "none";
-  const impactsProd = deployBackend || promoteProd || deployMcp;
+  const impactsProd = deployBackend || deployWebapp || deployMcp;
   const hasAnyTarget = runsRelease || deployMcp;
   const effectiveSkipVerify = runsRelease && skipVerify;
 
@@ -78,7 +78,7 @@ export function RunRelease() {
   function changeScope(next: Scope) {
     setScope(next);
     if (next !== "full") setDeployBackend(false);
-    if (next === "packages-only" || next === "none") setPromoteProd(false);
+    if (next === "packages-only" || next === "none") setDeployWebapp(false);
     if (next === "none") setSkipVerify(false);
     setFeedback({ kind: "idle" });
   }
@@ -87,8 +87,8 @@ export function RunRelease() {
     setDeployBackend(v);
     setFeedback({ kind: "idle" });
   }
-  function changePromoteProd(v: boolean) {
-    setPromoteProd(v);
+  function changeDeployWebapp(v: boolean) {
+    setDeployWebapp(v);
     setFeedback({ kind: "idle" });
   }
   function changeDeployMcp(v: boolean) {
@@ -115,7 +115,7 @@ export function RunRelease() {
           body: JSON.stringify({
             scope,
             deploy_backend_prod: deployBackend,
-            promote_production: promoteProd,
+            deploy_webapp: deployWebapp,
             deploy_mcp_production: deployMcp,
             skip_verify: effectiveSkipVerify
           })
@@ -235,10 +235,10 @@ export function RunRelease() {
               description="Dispatch backend production deploy (scope=full only)."
             />
             <FlagRow
-              id="promote-prod"
-              name="promote_production"
-              checked={promoteProd}
-              onChange={changePromoteProd}
+              id="deploy-webapp"
+              name="deploy_webapp"
+              checked={deployWebapp}
+              onChange={changeDeployWebapp}
               disabled={scope === "packages-only" || scope === "none"}
               description="Deploy inspector to Railway prod after publish."
             />
@@ -310,7 +310,7 @@ export function RunRelease() {
         busy={isPending}
         scope={scope}
         deployBackend={deployBackend}
-        promoteProd={promoteProd}
+        deployWebapp={deployWebapp}
         deployMcp={deployMcp}
         skipVerify={effectiveSkipVerify}
       />
@@ -365,7 +365,7 @@ function ConfirmModal({
   busy,
   scope,
   deployBackend,
-  promoteProd,
+  deployWebapp,
   deployMcp,
   skipVerify
 }: {
@@ -375,11 +375,11 @@ function ConfirmModal({
   busy: boolean;
   scope: Scope;
   deployBackend: boolean;
-  promoteProd: boolean;
+  deployWebapp: boolean;
   deployMcp: boolean;
   skipVerify: boolean;
 }) {
-  const impactsProd = deployBackend || promoteProd || deployMcp;
+  const impactsProd = deployBackend || deployWebapp || deployMcp;
   const runsRelease = scope !== "none";
   const dispatchedWorkflows = [
     runsRelease ? "release.yml" : null,
@@ -441,15 +441,15 @@ function ConfirmModal({
           </div>
           <div className="flex gap-3">
             <dt className="w-44 font-mono text-xs text-muted-foreground">
-              promote_production
+              deploy_webapp
             </dt>
             <dd
               className={
                 "font-mono text-xs " +
-                (promoteProd ? "text-warning" : "text-muted-foreground")
+                (deployWebapp ? "text-warning" : "text-muted-foreground")
               }
             >
-              {String(promoteProd)}
+              {String(deployWebapp)}
             </dd>
           </div>
           <div className="flex gap-3">


### PR DESCRIPTION
- Soundcheck's "Run release" button was silently broken: it sent an input named `promote_production`, but release.yml renamed that input to `deploy_webapp` in #4297. GitHub rejects a dispatch with an unknown input, so release.yml never started.
- The MCP deploy has no inputs, so it still fired — that's why the tile said PARTIAL instead of just failing.
- This renames the flag to `deploy_webapp` everywhere in Soundcheck: the API payload, its validation, the audit logs, the checkbox, and the confirmation popup.
- No behavior change beyond the name — same flag, same meaning (deploy the webapp to Railway prod after publish).
- Merging this auto-ships Soundcheck (deploy-soundcheck.yml runs on any `soundcheck/**` change to main).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes Soundcheck’s Run release by sending deploy_webapp instead of promote_production so release.yml runs again. Previously GitHub rejected the unknown input and release.yml didn’t start; MCP still ran, so the tile showed PARTIAL.

- Renames the flag end to end: API payload contract and validation, error text, audit logs, form state, checkbox, and confirmation modal.
- No semantic change: the flag still deploys the webapp to Railway prod after publish. release.yml now starts; MCP path unchanged.
- Migration: POST /api/release/dispatch now requires deploy_webapp. Calls using promote_production will 400 and must be updated. Merging auto-deploys Soundcheck.

<sup>Written for commit 69509c9f61847b46156ddf290b2b4312037c07a5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/MCPJam/inspector/pull/4299?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

