### PR TITLE
v1: chat-session detail and incremental trace

### DIFF
--- a/.changeset/v1-chat-session-detail.md
+++ b/.changeset/v1-chat-session-detail.md
@@ -1,0 +1,5 @@
+---
+"@mcpjam/inspector": patch
+---
+
+Add `GET /v1/chat-sessions/{sessionId}` (paged, scrubbed transcript) and `GET /v1/chat-sessions/{sessionId}/trace` (incremental inlined spans). Blob URLs never leave the gateway.

--- a/docs/reference/openapi.json
+++ b/docs/reference/openapi.json
@@ -4030,6 +4030,170 @@
         }
       }
     },
+    "/chat-sessions/{sessionId}": {
+      "parameters": [
+        {
+          "$ref": "#/components/parameters/sessionId"
+        }
+      ],
+      "get": {
+        "operationId": "getChatSession",
+        "tags": [
+          "Catalog"
+        ],
+        "summary": "Get a chat session",
+        "description": "One session's metadata plus a paged, scrubbed transcript. Tool payloads and blobs are dropped, and the stored blob URL is never returned.\n\nCheck `transcriptUnavailable` before trusting `messageCount`: an unreadable transcript reports `null`, never `0`.\n\nOptional `projectId` is a filter, not an owning scope. A session that exists but belongs to a different project reads as `404 NOT_FOUND` — never `403`.",
+        "parameters": [
+          {
+            "name": "projectId",
+            "in": "query",
+            "required": false,
+            "description": "When set, a session whose `projectId` does not match reads as `404 NOT_FOUND`.",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "limit",
+            "in": "query",
+            "required": false,
+            "description": "Page size, 1–200. Defaults to 50.",
+            "schema": {
+              "type": "integer",
+              "minimum": 1,
+              "maximum": 200,
+              "default": 50
+            }
+          },
+          {
+            "name": "cursor",
+            "in": "query",
+            "required": false,
+            "description": "Offset returned as `nextCursor` by a previous page. Must be a non-negative integer.",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "The session and one page of messages.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ChatSessionDetail"
+                }
+              }
+            }
+          },
+          "400": {
+            "$ref": "#/components/responses/ValidationError"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound"
+          },
+          "429": {
+            "$ref": "#/components/responses/RateLimited"
+          },
+          "500": {
+            "$ref": "#/components/responses/InternalError"
+          },
+          "502": {
+            "$ref": "#/components/responses/ServerUnreachable"
+          }
+        }
+      }
+    },
+    "/chat-sessions/{sessionId}/trace": {
+      "parameters": [
+        {
+          "$ref": "#/components/parameters/sessionId"
+        }
+      ],
+      "get": {
+        "operationId": "getChatSessionTrace",
+        "tags": [
+          "Catalog"
+        ],
+        "summary": "Get incremental chat-session traces",
+        "description": "Per-turn traces with spans inlined. The stored `spansBlobUrl` is never returned: the gateway fetches each blob itself (bounded, timed out).\n\nPass `afterPromptIndex` (or the previous page's `nextCursor` as `cursor`) to receive only unseen turns. `cursor` wins when both are present.\n\nA session the caller cannot see, or a `projectId` that does not match, reads as `404 NOT_FOUND` — never `403`.",
+        "parameters": [
+          {
+            "name": "projectId",
+            "in": "query",
+            "required": false,
+            "description": "When set, a session whose `projectId` does not match reads as `404 NOT_FOUND`.",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "afterPromptIndex",
+            "in": "query",
+            "required": false,
+            "description": "Return turns whose `promptIndex` is strictly greater than this value. Ignored when `cursor` is also present.",
+            "schema": {
+              "type": "integer",
+              "minimum": 0
+            }
+          },
+          {
+            "name": "cursor",
+            "in": "query",
+            "required": false,
+            "description": "The previous page's `nextCursor` (a `promptIndex`). Wins over `afterPromptIndex`.",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "limit",
+            "in": "query",
+            "required": false,
+            "description": "Page size, 1–50. Defaults to 20.",
+            "schema": {
+              "type": "integer",
+              "minimum": 1,
+              "maximum": 50,
+              "default": 20
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Unseen turns, oldest first, with spans inlined.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ChatSessionTrace"
+                }
+              }
+            }
+          },
+          "400": {
+            "$ref": "#/components/responses/ValidationError"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound"
+          },
+          "429": {
+            "$ref": "#/components/responses/RateLimited"
+          },
+          "500": {
+            "$ref": "#/components/responses/InternalError"
+          },
+          "502": {
+            "$ref": "#/components/responses/ServerUnreachable"
+          }
+        }
+      }
+    },
     "/projects/{projectId}/scenarios": {
       "get": {
         "operationId": "listScenarios",
@@ -15112,6 +15276,307 @@
           "nextCursor": {
             "type": "string",
             "description": "Pass as `before` to fetch the next page. Omitted on the last page."
+          }
+        }
+      },
+      "ChatSessionResumePins": {
+        "type": "object",
+        "description": "First-turn pins persisted on the session. Continuations cannot rewrite these.",
+        "properties": {
+          "modelId": {
+            "type": "string"
+          },
+          "toolMode": {
+            "type": "string",
+            "enum": [
+              "read_only",
+              "auto"
+            ]
+          },
+          "environmentId": {
+            "type": "string"
+          },
+          "serverIds": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          }
+        }
+      },
+      "ChatSessionDetail": {
+        "type": "object",
+        "description": "A session's metadata plus a paged, scrubbed transcript. The stored blob URL is NEVER returned.",
+        "required": [
+          "id",
+          "chatSessionId",
+          "projectId",
+          "title",
+          "status",
+          "origin",
+          "sourceType",
+          "version",
+          "modelId",
+          "startedAt",
+          "lastActivityAt",
+          "messageCount",
+          "messages"
+        ],
+        "properties": {
+          "id": {
+            "type": "string"
+          },
+          "chatSessionId": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "projectId": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "title": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "status": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "origin": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "sourceType": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "version": {
+            "type": [
+              "integer",
+              "null"
+            ]
+          },
+          "modelId": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "startedAt": {
+            "type": [
+              "number",
+              "null"
+            ],
+            "description": "Epoch milliseconds."
+          },
+          "lastActivityAt": {
+            "type": [
+              "number",
+              "null"
+            ],
+            "description": "Epoch milliseconds."
+          },
+          "resumeConfig": {
+            "$ref": "#/components/schemas/ChatSessionResumePins"
+          },
+          "messageCount": {
+            "type": [
+              "integer",
+              "null"
+            ],
+            "description": "`null` — never `0` — when the transcript could not be read. Zero would be a claim the visitor said nothing."
+          },
+          "transcriptUnavailable": {
+            "type": "boolean",
+            "description": "True when the stored conversation could not be read. Distinct from an empty `messages` array."
+          },
+          "messages": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/TranscriptMessage"
+            }
+          },
+          "nextCursor": {
+            "type": "string",
+            "description": "Pass as `cursor` to fetch the next page. Omitted on the last page."
+          }
+        }
+      },
+      "ChatSessionTurnTrace": {
+        "type": "object",
+        "required": [
+          "turnId",
+          "promptIndex",
+          "startedAt",
+          "endedAt",
+          "spanCount",
+          "spans"
+        ],
+        "properties": {
+          "turnId": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "promptIndex": {
+            "type": [
+              "integer",
+              "null"
+            ]
+          },
+          "startedAt": {
+            "type": [
+              "number",
+              "null"
+            ]
+          },
+          "endedAt": {
+            "type": [
+              "number",
+              "null"
+            ]
+          },
+          "finishReason": {
+            "type": "string"
+          },
+          "usage": {
+            "type": "object",
+            "additionalProperties": true
+          },
+          "spanCount": {
+            "type": "integer"
+          },
+          "modelId": {
+            "type": "string"
+          },
+          "pluginVersionsAtTurn": {
+            "description": "Absent on turns that recorded no plugin pins."
+          },
+          "spans": {
+            "type": "array",
+            "description": "Inlined span objects from the stored blob. Empty when `spansUnavailable` is true.",
+            "items": {
+              "type": "object",
+              "additionalProperties": true
+            }
+          },
+          "spansUnavailable": {
+            "type": "boolean",
+            "description": "True when the stored span blob could not be read."
+          }
+        }
+      },
+      "ChatSessionTrace": {
+        "type": "object",
+        "description": "Incremental per-turn traces. The stored `spansBlobUrl` is NEVER returned.",
+        "required": [
+          "id",
+          "chatSessionId",
+          "projectId",
+          "title",
+          "status",
+          "origin",
+          "sourceType",
+          "version",
+          "modelId",
+          "startedAt",
+          "lastActivityAt",
+          "turnCount",
+          "turns"
+        ],
+        "properties": {
+          "id": {
+            "type": "string"
+          },
+          "chatSessionId": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "projectId": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "title": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "status": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "origin": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "sourceType": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "version": {
+            "type": [
+              "integer",
+              "null"
+            ]
+          },
+          "modelId": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "startedAt": {
+            "type": [
+              "number",
+              "null"
+            ]
+          },
+          "lastActivityAt": {
+            "type": [
+              "number",
+              "null"
+            ]
+          },
+          "resumeConfig": {
+            "$ref": "#/components/schemas/ChatSessionResumePins"
+          },
+          "turnCount": {
+            "type": "integer",
+            "description": "Unseen turns remaining after `afterPromptIndex` / `cursor`, not just this page."
+          },
+          "turns": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/ChatSessionTurnTrace"
+            }
+          },
+          "nextCursor": {
+            "type": "string",
+            "description": "The last `promptIndex` on this page. Pass as `cursor` (or `afterPromptIndex`) to fetch the next page. Omitted on the last page."
           }
         }
       },

--- a/docs/reference/public-api.mdx
+++ b/docs/reference/public-api.mdx
@@ -228,6 +228,8 @@ and an interactive playground — under **Endpoints** in the sidebar.
 | `GET`, `POST /projects/{projectId}/hosts` | List hosts, or create one from a template or full config |
 | `GET`, `PATCH`, `DELETE /projects/{projectId}/hosts/{hostId}` | Read, rename/edit, or delete a host |
 | `GET /chat-sessions` | Chat sessions (`?projectId=&status=&limit=&before=`) |
+| `GET /chat-sessions/{sessionId}` | One session's metadata plus a paged, scrubbed transcript. Optional `?projectId=` 404s (never 403) when the session lives elsewhere. The stored blob URL is never returned |
+| `GET /chat-sessions/{sessionId}/trace` | Incremental per-turn traces with spans inlined. Pass `afterPromptIndex` or the previous `nextCursor` as `cursor` to fetch only unseen turns |
 
 **Project environments** — the named execution bundles (one host, optionally a
 standalone server group, optionally pinned skills and plugin versions) that eval

--- a/mcpjam-inspector/server/routes/v1/__tests__/chat-sessions.test.ts
+++ b/mcpjam-inspector/server/routes/v1/__tests__/chat-sessions.test.ts
@@ -1,0 +1,349 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { Hono } from "hono";
+
+/**
+ * The chat-session DETAIL surface (`chat-sessions.ts`).
+ *
+ * These pin the things that would fail quietly and expose something:
+ *
+ *   1. NO BLOB URL EVER. `getSession` / `getSessionTurnTraces` return
+ *      direct handles on stored blobs with no further authorization.
+ *      Returning one would turn one authorized read into an unbounded,
+ *      shareable one.
+ *   2. OPAQUE 404. Unauthorized, missing, and cross-project all read as
+ *      the same 404. Never 403 — that confirms the id exists.
+ *   3. GUEST DENY. The allowlist stays the exact match `/chat-sessions`.
+ *      Detail and trace must not inherit it.
+ *   4. BOUNDED READ. A chunked oversized blob reports unavailability
+ *      rather than landing in memory.
+ */
+
+const { queryMock, fetchMock } = vi.hoisted(() => ({
+  queryMock: vi.fn(),
+  fetchMock: vi.fn(),
+}));
+
+vi.mock("convex/browser", () => ({
+  ConvexHttpClient: class {
+    setAuth() {}
+    query(...args: unknown[]) {
+      return queryMock(...args);
+    }
+  },
+}));
+
+vi.mock("../../../utils/v1-convex-token.js", () => ({
+  getConvexBearerForRequest: async () => "convex-jwt",
+}));
+
+import chatSessions from "../chat-sessions.js";
+import { v1OnError } from "../envelope.js";
+import { isGuestAllowedV1Request } from "../guest-allowed-paths.js";
+
+const SESSION = "sess_1";
+const PROJECT = "proj_a";
+const OTHER_PROJECT = "proj_b";
+const BASE = `/api/v1/chat-sessions/${SESSION}`;
+
+function makeApp() {
+  const app = new Hono();
+  app.onError(v1OnError);
+  app.route("/api/v1", chatSessions);
+  return app;
+}
+
+function call(method: string, path: string) {
+  return makeApp().request(path, { method });
+}
+
+function sessionRow(overrides: Record<string, unknown> = {}) {
+  return {
+    _id: SESSION,
+    chatSessionId: "cs_1",
+    projectId: PROJECT,
+    customTitle: "Refunds",
+    status: "active",
+    origin: "playground",
+    sourceType: "direct",
+    version: 3,
+    modelId: "openai/gpt-4.1",
+    startedAt: 1_700_000_000_000,
+    lastActivityAt: 1_700_000_100_000,
+    messagesBlobUrl: "https://storage.test/secret-messages",
+    resumeConfig: {
+      modelId: "openai/gpt-4.1",
+      toolMode: "read_only",
+      environmentId: "env_1",
+      serverIds: ["srv_1"],
+      systemPrompt: "you are a secret",
+    },
+    ...overrides,
+  };
+}
+
+function answerQueries(answers: Record<string, unknown>) {
+  queryMock.mockImplementation((name: string) => {
+    const fn = String(name).split(":").pop() ?? "";
+    if (Object.prototype.hasOwnProperty.call(answers, fn)) {
+      return Promise.resolve(answers[fn]);
+    }
+    return Promise.resolve(null);
+  });
+}
+
+const OVERSIZED_MESSAGE_COUNT = 16;
+
+function oversizedTranscriptStream(): ReadableStream<Uint8Array> {
+  const encoder = new TextEncoder();
+  const message = `{"role":"user","content":"${"x".repeat(1024 * 1024)}"}`;
+  let sent = 0;
+  return new ReadableStream({
+    pull(controller) {
+      if (sent === 0) controller.enqueue(encoder.encode("["));
+      if (sent >= OVERSIZED_MESSAGE_COUNT) {
+        controller.enqueue(encoder.encode("]"));
+        controller.close();
+        return;
+      }
+      const separator = sent === 0 ? "" : ",";
+      sent += 1;
+      controller.enqueue(encoder.encode(separator + message));
+    },
+  });
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  vi.stubEnv("CONVEX_URL", "https://convex.test");
+  vi.stubGlobal("fetch", fetchMock);
+  queryMock.mockReset();
+  answerQueries({ getSession: sessionRow() });
+});
+afterEach(() => {
+  vi.clearAllMocks();
+  vi.unstubAllEnvs();
+  vi.unstubAllGlobals();
+});
+
+describe("guest allowlist", () => {
+  it("keeps the list open and the detail + trace closed", () => {
+    expect(isGuestAllowedV1Request("GET", "/api/v1/chat-sessions")).toBe(true);
+    expect(
+      isGuestAllowedV1Request("GET", `/api/v1/chat-sessions/${SESSION}`)
+    ).toBe(false);
+    expect(
+      isGuestAllowedV1Request("GET", `/api/v1/chat-sessions/${SESSION}/trace`)
+    ).toBe(false);
+  });
+});
+
+describe("session detail", () => {
+  it("NEVER returns the stored blob URL or first-turn secrets", async () => {
+    fetchMock.mockResolvedValue(
+      new Response(JSON.stringify([{ role: "user", content: "hello" }]), {
+        status: 200,
+      })
+    );
+    const res = await call("GET", BASE);
+    const raw = await res.text();
+    expect(raw).not.toContain("secret-messages");
+    expect(raw).not.toContain("messagesBlobUrl");
+    expect(raw).not.toContain("you are a secret");
+    expect(JSON.parse(raw)).toMatchObject({
+      id: SESSION,
+      chatSessionId: "cs_1",
+      projectId: PROJECT,
+      title: "Refunds",
+      origin: "playground",
+      sourceType: "direct",
+      version: 3,
+      resumeConfig: {
+        modelId: "openai/gpt-4.1",
+        toolMode: "read_only",
+        environmentId: "env_1",
+        serverIds: ["srv_1"],
+      },
+      messages: [{ role: "user", text: "hello" }],
+    });
+  });
+
+  it("404s a session that belongs to a DIFFERENT project", async () => {
+    answerQueries({
+      getSession: sessionRow({ projectId: OTHER_PROJECT }),
+    });
+    const res = await call("GET", `${BASE}?projectId=${PROJECT}`);
+    expect(res.status).toBe(404);
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it("404s a missing session the same way as an unauthorized one", async () => {
+    answerQueries({});
+    const missing = await call("GET", BASE);
+    expect(missing.status).toBe(404);
+
+    queryMock.mockRejectedValue(
+      new Error("ChatSession not found or unauthorized")
+    );
+    const unauthorized = await call("GET", BASE);
+    expect(unauthorized.status).toBe(404);
+    expect(unauthorized.status).not.toBe(403);
+  });
+
+  it("pages long transcripts instead of returning the whole thing", async () => {
+    fetchMock.mockResolvedValue(
+      new Response(
+        JSON.stringify(
+          Array.from({ length: 120 }, (_, index) => ({
+            role: "user",
+            content: `m${index}`,
+          }))
+        ),
+        { status: 200 }
+      )
+    );
+    const res = await call("GET", `${BASE}?limit=50`);
+    const body = (await res.json()) as {
+      messages: unknown[];
+      messageCount: number;
+      nextCursor?: string;
+    };
+    expect(body.messages).toHaveLength(50);
+    expect(body.messageCount).toBe(120);
+    expect(body.nextCursor).toBe("50");
+  });
+
+  it("400s an unparseable cursor instead of re-serving page one", async () => {
+    const res = await call("GET", `${BASE}?cursor=oops`);
+    expect(res.status).toBe(400);
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it("reports a null messageCount when the transcript is unreadable", async () => {
+    fetchMock.mockRejectedValue(new Error("network down"));
+    const res = await call("GET", BASE);
+    const body = (await res.json()) as {
+      messageCount: number | null;
+      transcriptUnavailable?: boolean;
+      messages: unknown[];
+    };
+    expect(body.messageCount).toBeNull();
+    expect(body.transcriptUnavailable).toBe(true);
+    expect(body.messages).toEqual([]);
+  });
+
+  it("still refuses when the blob declares NO content-length", async () => {
+    fetchMock.mockResolvedValue(
+      new Response(oversizedTranscriptStream(), { status: 200 })
+    );
+    const res = await call("GET", BASE);
+    const body = (await res.json()) as {
+      transcriptUnavailable?: boolean;
+      messageCount: number | null;
+    };
+    expect(body.transcriptUnavailable).toBe(true);
+    expect(body.messageCount).toBeNull();
+  });
+});
+
+describe("incremental trace", () => {
+  function turn(
+    promptIndex: number,
+    url = `https://storage.test/spans-${promptIndex}`
+  ) {
+    return {
+      turnId: `turn_${promptIndex}`,
+      promptIndex,
+      startedAt: 1_000 + promptIndex,
+      endedAt: 2_000 + promptIndex,
+      finishReason: "stop",
+      usage: { inputTokens: 10, outputTokens: 4 },
+      spanCount: 1,
+      modelId: "openai/gpt-4.1",
+      spansBlobUrl: url,
+    };
+  }
+
+  it("NEVER returns a spansBlobUrl and inlines the fetched spans", async () => {
+    answerQueries({
+      getSession: sessionRow(),
+      getSessionTurnTraces: [turn(0, "https://storage.test/secret-spans")],
+    });
+    fetchMock.mockResolvedValue(
+      new Response(JSON.stringify([{ name: "llm", durationMs: 12 }]), {
+        status: 200,
+      })
+    );
+    const res = await call("GET", `${BASE}/trace`);
+    const raw = await res.text();
+    expect(raw).not.toContain("secret-spans");
+    expect(raw).not.toContain("spansBlobUrl");
+    expect(JSON.parse(raw)).toMatchObject({
+      id: SESSION,
+      turnCount: 1,
+      turns: [
+        {
+          turnId: "turn_0",
+          promptIndex: 0,
+          spans: [{ name: "llm", durationMs: 12 }],
+        },
+      ],
+    });
+  });
+
+  it("pages from afterPromptIndex so a poller does not re-download", async () => {
+    answerQueries({
+      getSession: sessionRow(),
+      getSessionTurnTraces: [turn(0), turn(1), turn(2)],
+    });
+    fetchMock.mockResolvedValue(
+      new Response(JSON.stringify([]), { status: 200 })
+    );
+    const res = await call("GET", `${BASE}/trace?afterPromptIndex=0&limit=1`);
+    const body = (await res.json()) as {
+      turns: Array<{ promptIndex: number }>;
+      turnCount: number;
+      nextCursor?: string;
+    };
+    expect(body.turns.map((row) => row.promptIndex)).toEqual([1]);
+    expect(body.turnCount).toBe(2);
+    expect(body.nextCursor).toBe("1");
+  });
+
+  it("lets cursor win over a stale afterPromptIndex", async () => {
+    answerQueries({
+      getSession: sessionRow(),
+      getSessionTurnTraces: [turn(0), turn(1), turn(2)],
+    });
+    fetchMock.mockResolvedValue(
+      new Response(JSON.stringify([]), { status: 200 })
+    );
+    const res = await call("GET", `${BASE}/trace?afterPromptIndex=0&cursor=1`);
+    const body = (await res.json()) as {
+      turns: Array<{ promptIndex: number }>;
+    };
+    expect(body.turns.map((row) => row.promptIndex)).toEqual([2]);
+  });
+
+  it("404s a cross-project probe the same as a missing session", async () => {
+    answerQueries({
+      getSession: sessionRow({ projectId: OTHER_PROJECT }),
+    });
+    const res = await call("GET", `${BASE}/trace?projectId=${PROJECT}`);
+    expect(res.status).toBe(404);
+    expect(res.status).not.toBe(403);
+  });
+
+  it("marks spansUnavailable when the blob cannot be read", async () => {
+    answerQueries({
+      getSession: sessionRow(),
+      getSessionTurnTraces: [turn(0)],
+    });
+    fetchMock.mockRejectedValue(new Error("network down"));
+    const res = await call("GET", `${BASE}/trace`);
+    const body = (await res.json()) as {
+      turns: Array<{ spansUnavailable?: boolean; spans: unknown[] }>;
+    };
+    expect(body.turns[0]?.spansUnavailable).toBe(true);
+    expect(body.turns[0]?.spans).toEqual([]);
+  });
+});

--- a/mcpjam-inspector/server/routes/v1/__tests__/chat-sessions.test.ts
+++ b/mcpjam-inspector/server/routes/v1/__tests__/chat-sessions.test.ts
@@ -218,8 +218,8 @@ describe("session detail", () => {
     expect(fetchMock).not.toHaveBeenCalled();
   });
 
-  it("400s a zero or unparseable limit", async () => {
-    for (const limit of ["0", "oops"]) {
+  it("400s a zero, fractional, or unparseable limit", async () => {
+    for (const limit of ["0", "1.5", "oops"]) {
       const res = await call("GET", `${BASE}?limit=${limit}`);
       expect(res.status).toBe(400);
     }
@@ -385,8 +385,8 @@ describe("incremental trace", () => {
     expect(body.turns[0]?.spans).toEqual([]);
   });
 
-  it("400s a zero or unparseable trace limit", async () => {
-    for (const limit of ["0", "oops"]) {
+  it("400s a zero, fractional, or unparseable trace limit", async () => {
+    for (const limit of ["0", "1.5", "oops"]) {
       const res = await call("GET", `${BASE}/trace?limit=${limit}`);
       expect(res.status).toBe(400);
     }
@@ -412,5 +412,65 @@ describe("incremental trace", () => {
     expect(body.turns).toHaveLength(50);
     expect(body.turnCount).toBe(60);
     expect(body.nextCursor).toBe("49");
+  });
+
+  it("treats a missing or non-array trace list as empty", async () => {
+    for (const traces of [[], { nope: true }, null]) {
+      answerQueries({
+        getSession: sessionRow(),
+        getSessionTurnTraces: traces,
+      });
+      const res = await call("GET", `${BASE}/trace`);
+      const body = (await res.json()) as {
+        turns: unknown[];
+        turnCount: number;
+      };
+      expect(body.turns).toEqual([]);
+      expect(body.turnCount).toBe(0);
+    }
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it("marks spansUnavailable when the blob is not a JSON array", async () => {
+    answerQueries({
+      getSession: sessionRow(),
+      getSessionTurnTraces: [turn(0)],
+    });
+    fetchMock.mockResolvedValue(
+      new Response(JSON.stringify({ spans: [] }), { status: 200 })
+    );
+    const res = await call("GET", `${BASE}/trace`);
+    const body = (await res.json()) as {
+      turns: Array<{ spansUnavailable?: boolean; spans: unknown[] }>;
+    };
+    expect(body.turns[0]?.spansUnavailable).toBe(true);
+    expect(body.turns[0]?.spans).toEqual([]);
+  });
+
+  it("fetches at most four span blobs at once", async () => {
+    answerQueries({
+      getSession: sessionRow(),
+      getSessionTurnTraces: Array.from({ length: 8 }, (_, index) =>
+        turn(index)
+      ),
+    });
+    let inFlight = 0;
+    let maxInFlight = 0;
+    fetchMock.mockImplementation(
+      () =>
+        new Promise((resolve) => {
+          inFlight += 1;
+          maxInFlight = Math.max(maxInFlight, inFlight);
+          setTimeout(() => {
+            inFlight -= 1;
+            resolve(new Response(JSON.stringify([]), { status: 200 }));
+          }, 20);
+        })
+    );
+    const res = await call("GET", `${BASE}/trace?limit=8`);
+    expect(res.status).toBe(200);
+    expect(maxInFlight).toBeLessThanOrEqual(4);
+    expect(maxInFlight).toBe(4);
+    expect(fetchMock).toHaveBeenCalledTimes(8);
   });
 });

--- a/mcpjam-inspector/server/routes/v1/__tests__/chat-sessions.test.ts
+++ b/mcpjam-inspector/server/routes/v1/__tests__/chat-sessions.test.ts
@@ -218,6 +218,44 @@ describe("session detail", () => {
     expect(fetchMock).not.toHaveBeenCalled();
   });
 
+  it("400s a zero or unparseable limit", async () => {
+    for (const limit of ["0", "oops"]) {
+      const res = await call("GET", `${BASE}?limit=${limit}`);
+      expect(res.status).toBe(400);
+    }
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it("clamps an oversized limit to the documented ceiling", async () => {
+    fetchMock.mockResolvedValue(
+      new Response(
+        JSON.stringify(
+          Array.from({ length: 250 }, (_, index) => ({
+            role: "user",
+            content: `m${index}`,
+          }))
+        ),
+        { status: 200 }
+      )
+    );
+    const res = await call("GET", `${BASE}?limit=999`);
+    const body = (await res.json()) as {
+      messages: unknown[];
+      nextCursor?: string;
+    };
+    expect(body.messages).toHaveLength(200);
+    expect(body.nextCursor).toBe("200");
+  });
+
+  it("does not follow redirects and treats them as unreadable", async () => {
+    fetchMock.mockResolvedValue(new Response(null, { status: 302 }));
+    const res = await call("GET", BASE);
+    const body = (await res.json()) as { transcriptUnavailable?: boolean };
+    expect(body.transcriptUnavailable).toBe(true);
+    const [, init] = fetchMock.mock.calls[0] as [string, RequestInit];
+    expect(init.redirect).toBe("manual");
+  });
+
   it("reports a null messageCount when the transcript is unreadable", async () => {
     fetchMock.mockRejectedValue(new Error("network down"));
     const res = await call("GET", BASE);
@@ -345,5 +383,34 @@ describe("incremental trace", () => {
     };
     expect(body.turns[0]?.spansUnavailable).toBe(true);
     expect(body.turns[0]?.spans).toEqual([]);
+  });
+
+  it("400s a zero or unparseable trace limit", async () => {
+    for (const limit of ["0", "oops"]) {
+      const res = await call("GET", `${BASE}/trace?limit=${limit}`);
+      expect(res.status).toBe(400);
+    }
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it("clamps an oversized trace limit to the documented ceiling", async () => {
+    answerQueries({
+      getSession: sessionRow(),
+      getSessionTurnTraces: Array.from({ length: 60 }, (_, index) =>
+        turn(index)
+      ),
+    });
+    fetchMock.mockResolvedValue(
+      new Response(JSON.stringify([]), { status: 200 })
+    );
+    const res = await call("GET", `${BASE}/trace?limit=999`);
+    const body = (await res.json()) as {
+      turns: unknown[];
+      turnCount: number;
+      nextCursor?: string;
+    };
+    expect(body.turns).toHaveLength(50);
+    expect(body.turnCount).toBe(60);
+    expect(body.nextCursor).toBe("49");
   });
 });

--- a/mcpjam-inspector/server/routes/v1/__tests__/sdk-coverage.test.ts
+++ b/mcpjam-inspector/server/routes/v1/__tests__/sdk-coverage.test.ts
@@ -355,6 +355,10 @@ const EXCLUDED_FROM_SDK: Readonly<Record<string, string>> = {
     "Share member upsert stays REST-only for now.",
   "delete /projects/{projectId}/shares/{resourceType}/{resourceId}/members/{memberIdOrEmail}":
     "Share member removal stays REST-only for now.",
+  "get /chat-sessions/{sessionId}":
+    "Session detail is the pair of the agent turn POST. Shipping a client method without sendChatMessage would let callers poll a session they have no way to continue; both land together.",
+  "get /chat-sessions/{sessionId}/trace":
+    "Incremental traces are only useful after a turn writes them. The SDK exposes this next to sendChatMessage so a caller cannot fetch spans for a session they cannot create.",
 };
 
 describe("/api/v1 -> SDK coverage", () => {

--- a/mcpjam-inspector/server/routes/v1/chat-sessions.ts
+++ b/mcpjam-inspector/server/routes/v1/chat-sessions.ts
@@ -40,6 +40,15 @@ const BLOB_FETCH_TIMEOUT_MS = 10_000;
  * a capacity fact about us, not a reason to take the process down.
  */
 const BLOB_MAX_BYTES = 8 * 1024 * 1024;
+/**
+ * Ceiling on ALL span blobs one trace request will buffer.
+ *
+ * The per-blob cap alone would admit `TRACE_MAX_PAGE_SIZE × 8 MiB` at
+ * once. A handful of concurrent callers at that size is enough to
+ * exhaust the heap, which is the failure the cap exists to avoid.
+ */
+const TRACE_REQUEST_MAX_BYTES = 32 * 1024 * 1024;
+const TRACE_FETCH_CONCURRENCY = 4;
 
 function translatePreflightReadError(
   error: unknown,
@@ -225,7 +234,10 @@ function projectResumePins(raw: unknown): Record<string, unknown> | null {
 async function loadAuthorizedSession(
   c: Context,
   sessionId: string
-): Promise<SessionDoc> {
+): Promise<{
+  session: SessionDoc;
+  client: ReturnType<typeof createConvexClient>;
+}> {
   const client = createConvexClient(await getConvexBearerForRequest(c));
   let session: SessionDoc | null;
   try {
@@ -252,20 +264,57 @@ async function loadAuthorizedSession(
   ) {
     throw notFound();
   }
-  return session;
+  return { session, client };
 }
 
+type ByteBudget = { remaining: number };
+
+function reserveBytes(budget: ByteBudget | undefined, want: number): number {
+  if (!budget) return want;
+  const n = Math.min(want, Math.max(0, budget.remaining));
+  budget.remaining -= n;
+  return n;
+}
+
+function refundBytes(budget: ByteBudget | undefined, unused: number): void {
+  if (!budget || unused <= 0) return;
+  budget.remaining += unused;
+}
+
+/**
+ * Fetch a Convex storage blob as JSON.
+ *
+ * URLs come from `ctx.storage.getUrl` after `getSession` /
+ * `getSessionTurnTraces` authorized the caller — the same source
+ * `user-testing.ts` fetches, and there is no caller-facing write that
+ * can plant one. There is also no configured storage-origin allowlist
+ * in this repo, so we do not invent one. What we do harden: do not
+ * follow redirects, and cancel a body we have already decided not to
+ * parse.
+ */
 async function fetchJsonBlob(
-  url: string
-): Promise<{ ok: true; value: unknown } | { ok: false }> {
+  url: string,
+  maxBytes: number = BLOB_MAX_BYTES
+): Promise<{ ok: true; value: unknown; bytes: number } | { ok: false }> {
+  if (maxBytes <= 0) return { ok: false };
   try {
     const response = await fetch(url, {
       signal: AbortSignal.timeout(BLOB_FETCH_TIMEOUT_MS),
+      redirect: "manual",
     });
-    if (!response.ok) return { ok: false };
-    const text = await readCapped(response, BLOB_MAX_BYTES);
+    if (!response.ok) {
+      // A 3xx under `redirect: "manual"` lands here too. Stop the
+      // transfer rather than draining a body we will not parse.
+      await response.body?.cancel();
+      return { ok: false };
+    }
+    const text = await readCapped(response, maxBytes);
     if (text === null) return { ok: false };
-    return { ok: true, value: JSON.parse(text) };
+    return {
+      ok: true,
+      value: JSON.parse(text),
+      bytes: Buffer.byteLength(text, "utf8"),
+    };
   } catch {
     return { ok: false };
   }
@@ -337,7 +386,7 @@ chatSessions.get("/chat-sessions/:sessionId", async (c) => {
     TRANSCRIPT_MAX_PAGE_SIZE
   );
   const offset = parseNonNegativeIntQuery(c.req.query("cursor"), "cursor") ?? 0;
-  const session = await loadAuthorizedSession(c, sessionId);
+  const { session } = await loadAuthorizedSession(c, sessionId);
   const { messages, transcriptUnavailable } = await loadMessages(session);
   const page = messages.slice(offset, offset + limit);
   return v1Resource(c, {
@@ -360,21 +409,11 @@ function asPromptIndex(value: unknown): number | null {
   return typeof value === "number" && Number.isInteger(value) ? value : null;
 }
 
-async function hydrateTurn(
-  trace: TurnTraceDoc
-): Promise<Record<string, unknown>> {
-  let spans: unknown[] = [];
-  let spansUnavailable = false;
-  if (typeof trace.spansBlobUrl === "string") {
-    const fetched = await fetchJsonBlob(trace.spansBlobUrl);
-    if (!fetched.ok || !Array.isArray(fetched.value)) {
-      spansUnavailable = true;
-    } else {
-      spans = fetched.value;
-    }
-  } else {
-    spansUnavailable = true;
-  }
+function turnMeta(
+  trace: TurnTraceDoc,
+  spans: unknown[],
+  spansUnavailable: boolean
+): Record<string, unknown> {
   const usage =
     trace.usage &&
     typeof trace.usage === "object" &&
@@ -399,6 +438,48 @@ async function hydrateTurn(
     spans,
     ...(spansUnavailable ? { spansUnavailable: true } : {}),
   };
+}
+
+async function hydrateTurn(
+  trace: TurnTraceDoc,
+  budget: ByteBudget
+): Promise<Record<string, unknown>> {
+  if (typeof trace.spansBlobUrl !== "string") {
+    return turnMeta(trace, [], true);
+  }
+  const reserved = reserveBytes(budget, BLOB_MAX_BYTES);
+  if (reserved <= 0) {
+    return turnMeta(trace, [], true);
+  }
+  const fetched = await fetchJsonBlob(trace.spansBlobUrl, reserved);
+  if (!fetched.ok) {
+    refundBytes(budget, reserved);
+    return turnMeta(trace, [], true);
+  }
+  refundBytes(budget, reserved - fetched.bytes);
+  if (!Array.isArray(fetched.value)) {
+    return turnMeta(trace, [], true);
+  }
+  return turnMeta(trace, fetched.value, false);
+}
+
+async function mapPool<T, R>(
+  items: T[],
+  concurrency: number,
+  worker: (item: T) => Promise<R>
+): Promise<R[]> {
+  const results: R[] = new Array(items.length);
+  let next = 0;
+  const run = async () => {
+    for (;;) {
+      const index = next++;
+      if (index >= items.length) return;
+      results[index] = await worker(items[index] as T);
+    }
+  };
+  const width = Math.min(Math.max(1, concurrency), Math.max(items.length, 1));
+  await Promise.all(Array.from({ length: width }, () => run()));
+  return results;
 }
 
 // GET /v1/chat-sessions/:sessionId/trace
@@ -426,8 +507,7 @@ chatSessions.get("/chat-sessions/:sessionId/trace", async (c) => {
   // a caller also left a stale `afterPromptIndex` on the URL.
   const afterPromptIndex = cursorAfter ?? explicitAfter ?? -1;
 
-  const session = await loadAuthorizedSession(c, sessionId);
-  const client = createConvexClient(await getConvexBearerForRequest(c));
+  const { session, client } = await loadAuthorizedSession(c, sessionId);
   let traces: TurnTraceDoc[];
   try {
     traces = (await client.query(
@@ -449,7 +529,10 @@ chatSessions.get("/chat-sessions/:sessionId/trace", async (c) => {
     return index !== null && index > afterPromptIndex;
   });
   const page = unseen.slice(0, limit);
-  const turns = await Promise.all(page.map(hydrateTurn));
+  const budget: ByteBudget = { remaining: TRACE_REQUEST_MAX_BYTES };
+  const turns = await mapPool(page, TRACE_FETCH_CONCURRENCY, (trace) =>
+    hydrateTurn(trace, budget)
+  );
   const last = page[page.length - 1];
   const lastIndex = last ? asPromptIndex(last.promptIndex) : null;
 

--- a/mcpjam-inspector/server/routes/v1/chat-sessions.ts
+++ b/mcpjam-inspector/server/routes/v1/chat-sessions.ts
@@ -180,14 +180,14 @@ function parsePositiveLimit(
 ): number {
   if (raw === undefined) return fallback;
   const parsed = Number(raw);
-  if (!Number.isFinite(parsed) || parsed <= 0) {
+  if (!Number.isInteger(parsed) || parsed <= 0) {
     throw new WebRouteError(
       400,
       ErrorCode.VALIDATION_ERROR,
       `limit must be an integer between 1 and ${max}`
     );
   }
-  return Math.min(Math.floor(parsed), max);
+  return Math.min(parsed, max);
 }
 
 function parseNonNegativeIntQuery(

--- a/mcpjam-inspector/server/routes/v1/chat-sessions.ts
+++ b/mcpjam-inspector/server/routes/v1/chat-sessions.ts
@@ -1,0 +1,466 @@
+/**
+ * Public v1 chat-session DETAIL reads — one session's transcript and its
+ * incremental per-turn traces.
+ *
+ * Distinct from the catalog proxy at `GET /chat-sessions` (the list). That
+ * route forwards to Convex `/v1/chat-sessions`. These routes call Convex
+ * FUNCTIONS (`chatSessions:getSession`, `chatSessions:getSessionTurnTraces`)
+ * and then fetch the stored blobs themselves so a caller never receives a
+ * `messagesBlobUrl` or `spansBlobUrl`. Those URLs are direct handles with no
+ * further authorization and no expiry the caller can reason about.
+ *
+ * CROSS-PROJECT: optional `?projectId=` is a filter, not an owning path
+ * segment (same as the list). A real session that lives in a different
+ * project reads as `404 NOT_FOUND` — never `403`, which would confirm the
+ * id exists somewhere the caller cannot see.
+ *
+ * Guest-DENIED. The allowlist entry is the exact match `/^\/chat-sessions$/`
+ * and must stay that way: a guest who can list their own rows must not
+ * inherit transcript + span reads for free.
+ */
+import { Hono, type Context } from "hono";
+import { createConvexClient } from "./convex-client.js";
+import { ErrorCode, WebRouteError } from "../web/errors.js";
+import { getConvexBearerForRequest } from "../../utils/v1-convex-token.js";
+import { v1Resource } from "./envelope.js";
+import { translateConvexReadError } from "./convex-read-errors.js";
+
+const chatSessions = new Hono();
+
+const TRANSCRIPT_PAGE_SIZE = 50;
+const TRANSCRIPT_MAX_PAGE_SIZE = 200;
+const TRACE_PAGE_SIZE = 20;
+const TRACE_MAX_PAGE_SIZE = 50;
+const BLOB_FETCH_TIMEOUT_MS = 10_000;
+/**
+ * Ceiling on a transcript or span blob we will buffer to serve a page.
+ *
+ * Above this the session reports `transcriptUnavailable` / `spansUnavailable`
+ * rather than being pulled into memory — a conversation too large to hold is
+ * a capacity fact about us, not a reason to take the process down.
+ */
+const BLOB_MAX_BYTES = 8 * 1024 * 1024;
+
+function translatePreflightReadError(
+  error: unknown,
+  notFoundMessage: string
+): WebRouteError {
+  return translateConvexReadError(error, {
+    scope: "v1.chat-sessions",
+    notFoundMessage,
+    redactedIsRefusal: true,
+  });
+}
+
+function notFound(): WebRouteError {
+  return new WebRouteError(404, ErrorCode.NOT_FOUND, "Session not found");
+}
+
+/**
+ * Read a response body as text, giving up once `maxBytes` have arrived.
+ *
+ * Returns `null` when the body is over the ceiling or cannot be streamed, so
+ * the caller reports unavailability rather than a silent truncation — a
+ * transcript cut mid-array would either fail to parse or, worse, parse into
+ * a conversation that stops early with no sign that it did.
+ *
+ * The counting is on RECEIVED bytes. Checking `content-length` instead would
+ * miss the two cases that matter: a chunked response has no such header, and
+ * a present one is a claim, not a measurement.
+ */
+async function readCapped(
+  response: Response,
+  maxBytes: number
+): Promise<string | null> {
+  const body = response.body;
+  if (!body) return null;
+  const reader = body.getReader();
+  const chunks: Uint8Array[] = [];
+  let total = 0;
+  try {
+    for (;;) {
+      const { done, value } = await reader.read();
+      if (done) break;
+      if (!value) continue;
+      total += value.byteLength;
+      if (total > maxBytes) {
+        await reader.cancel();
+        return null;
+      }
+      chunks.push(value);
+    }
+  } finally {
+    reader.releaseLock();
+  }
+  return Buffer.concat(chunks).toString("utf8");
+}
+
+type RawMessage = {
+  role?: unknown;
+  content?: unknown;
+  parts?: unknown;
+  createdAt?: unknown;
+  toolName?: unknown;
+};
+
+/**
+ * Flatten a message's content to text.
+ *
+ * Deliberately LOSSY. A stored message can carry tool payloads, base64
+ * images and provider-specific blobs; this projects the parts that are
+ * words and drops the rest rather than passing an unbounded structure
+ * through a public API.
+ */
+function messageText(message: RawMessage): string {
+  if (typeof message.content === "string") return message.content;
+  const parts = Array.isArray(message.parts)
+    ? message.parts
+    : Array.isArray(message.content)
+    ? message.content
+    : [];
+  return parts
+    .map((part) => {
+      if (typeof part === "string") return part;
+      if (part && typeof part === "object") {
+        const text = (part as { text?: unknown }).text;
+        if (typeof text === "string") return text;
+      }
+      return "";
+    })
+    .filter((text) => text.length > 0)
+    .join("\n");
+}
+
+function projectMessage(message: RawMessage): Record<string, unknown> {
+  return {
+    role: typeof message.role === "string" ? message.role : "unknown",
+    text: messageText(message),
+    ...(typeof message.toolName === "string"
+      ? { toolName: message.toolName }
+      : {}),
+    ...(typeof message.createdAt === "number"
+      ? { createdAt: message.createdAt }
+      : {}),
+  };
+}
+
+type SessionDoc = Record<string, unknown> & {
+  messagesBlobUrl?: string;
+  projectId?: unknown;
+  chatSessionId?: unknown;
+  resumeConfig?: unknown;
+};
+
+type TurnTraceDoc = {
+  turnId?: unknown;
+  promptIndex?: unknown;
+  startedAt?: unknown;
+  endedAt?: unknown;
+  finishReason?: unknown;
+  usage?: unknown;
+  spanCount?: unknown;
+  modelId?: unknown;
+  pluginVersionsAtTurn?: unknown;
+  spansBlobUrl?: unknown;
+};
+
+function parsePositiveLimit(
+  raw: string | undefined,
+  fallback: number,
+  max: number
+): number {
+  if (raw === undefined) return fallback;
+  const parsed = Number(raw);
+  if (!Number.isFinite(parsed) || parsed <= 0) {
+    throw new WebRouteError(
+      400,
+      ErrorCode.VALIDATION_ERROR,
+      `limit must be an integer between 1 and ${max}`
+    );
+  }
+  return Math.min(Math.floor(parsed), max);
+}
+
+function parseNonNegativeIntQuery(
+  raw: string | undefined,
+  name: string
+): number | undefined {
+  if (raw === undefined) return undefined;
+  const parsed = Number(raw);
+  if (!Number.isInteger(parsed) || parsed < 0) {
+    throw new WebRouteError(
+      400,
+      ErrorCode.VALIDATION_ERROR,
+      `${name} must be a value returned as nextCursor by this endpoint`
+    );
+  }
+  return parsed;
+}
+
+/**
+ * First-turn pins only. The stored `resumeConfig` also carries system
+ * prompt, plugin provenance, and image-rendering knobs that a public
+ * reader does not need and that we will not start leaking here.
+ */
+function projectResumePins(raw: unknown): Record<string, unknown> | null {
+  if (!raw || typeof raw !== "object" || Array.isArray(raw)) return null;
+  const cfg = raw as Record<string, unknown>;
+  const pins: Record<string, unknown> = {};
+  if (typeof cfg.modelId === "string") pins.modelId = cfg.modelId;
+  if (cfg.toolMode === "read_only" || cfg.toolMode === "auto") {
+    pins.toolMode = cfg.toolMode;
+  }
+  if (typeof cfg.environmentId === "string") {
+    pins.environmentId = cfg.environmentId;
+  }
+  if (
+    Array.isArray(cfg.serverIds) &&
+    cfg.serverIds.every((id) => typeof id === "string")
+  ) {
+    pins.serverIds = cfg.serverIds;
+  }
+  return Object.keys(pins).length > 0 ? pins : null;
+}
+
+async function loadAuthorizedSession(
+  c: Context,
+  sessionId: string
+): Promise<SessionDoc> {
+  const client = createConvexClient(await getConvexBearerForRequest(c));
+  let session: SessionDoc | null;
+  try {
+    session = (await client.query(
+      "chatSessions:getSession" as never,
+      {
+        sessionId,
+      } as never
+    )) as SessionDoc | null;
+  } catch (error) {
+    // Preflight semantics: `getSession` refuses with a plain
+    // "ChatSession not found or unauthorized" (redacted in production),
+    // and the id came from the caller — so refusal and absence must be
+    // the same 404 here too. Never 403: that is an existence oracle.
+    throw translatePreflightReadError(error, "Session not found");
+  }
+  if (!session) throw notFound();
+
+  const projectId = c.req.query("projectId");
+  if (
+    typeof projectId === "string" &&
+    projectId.length > 0 &&
+    String(session.projectId ?? "") !== projectId
+  ) {
+    throw notFound();
+  }
+  return session;
+}
+
+async function fetchJsonBlob(
+  url: string
+): Promise<{ ok: true; value: unknown } | { ok: false }> {
+  try {
+    const response = await fetch(url, {
+      signal: AbortSignal.timeout(BLOB_FETCH_TIMEOUT_MS),
+    });
+    if (!response.ok) return { ok: false };
+    const text = await readCapped(response, BLOB_MAX_BYTES);
+    if (text === null) return { ok: false };
+    return { ok: true, value: JSON.parse(text) };
+  } catch {
+    return { ok: false };
+  }
+}
+
+async function loadMessages(session: SessionDoc): Promise<{
+  messages: RawMessage[];
+  transcriptUnavailable: boolean;
+}> {
+  if (typeof session.messagesBlobUrl !== "string") {
+    return { messages: [], transcriptUnavailable: true };
+  }
+  const fetched = await fetchJsonBlob(session.messagesBlobUrl);
+  if (!fetched.ok) {
+    return { messages: [], transcriptUnavailable: true };
+  }
+  const candidate = Array.isArray(fetched.value)
+    ? fetched.value
+    : (fetched.value as { messages?: unknown })?.messages;
+  if (!Array.isArray(candidate)) {
+    return { messages: [], transcriptUnavailable: true };
+  }
+  return { messages: candidate as RawMessage[], transcriptUnavailable: false };
+}
+
+function sessionMeta(
+  sessionId: string,
+  session: SessionDoc
+): Record<string, unknown> {
+  const resumeConfig = projectResumePins(session.resumeConfig);
+  return {
+    id: sessionId,
+    chatSessionId:
+      typeof session.chatSessionId === "string" ? session.chatSessionId : null,
+    projectId: typeof session.projectId === "string" ? session.projectId : null,
+    title: typeof session.customTitle === "string" ? session.customTitle : null,
+    status: typeof session.status === "string" ? session.status : null,
+    origin: typeof session.origin === "string" ? session.origin : null,
+    sourceType:
+      typeof session.sourceType === "string" ? session.sourceType : null,
+    version: typeof session.version === "number" ? session.version : null,
+    modelId: typeof session.modelId === "string" ? session.modelId : null,
+    startedAt: typeof session.startedAt === "number" ? session.startedAt : null,
+    lastActivityAt:
+      typeof session.lastActivityAt === "number"
+        ? session.lastActivityAt
+        : null,
+    ...(resumeConfig ? { resumeConfig } : {}),
+  };
+}
+
+// GET /v1/chat-sessions/:sessionId
+//
+// The transcript, PAGED and PROJECTED. Two things this deliberately does
+// not do:
+//
+//   1. It never returns `messagesBlobUrl`. That URL is a direct handle on
+//      the stored conversation with no further authorization — handing it
+//      out would turn one authorized read into an unbounded, unrevocable
+//      one, shareable by anyone who receives it. The gateway fetches the
+//      blob itself and serves the contents.
+//   2. It does not return raw message objects. Stored messages carry tool
+//      payloads and provider blobs; the DTO projects role, text and timing.
+chatSessions.get("/chat-sessions/:sessionId", async (c) => {
+  const sessionId = c.req.param("sessionId");
+  const limit = parsePositiveLimit(
+    c.req.query("limit"),
+    TRANSCRIPT_PAGE_SIZE,
+    TRANSCRIPT_MAX_PAGE_SIZE
+  );
+  const offset = parseNonNegativeIntQuery(c.req.query("cursor"), "cursor") ?? 0;
+  const session = await loadAuthorizedSession(c, sessionId);
+  const { messages, transcriptUnavailable } = await loadMessages(session);
+  const page = messages.slice(offset, offset + limit);
+  return v1Resource(c, {
+    ...sessionMeta(sessionId, session),
+    /**
+     * `null` — never 0 — when the transcript could not be read. Zero is a
+     * claim that the visitor said nothing, which is the opposite of what
+     * an unreadable blob means.
+     */
+    messageCount: transcriptUnavailable ? null : messages.length,
+    ...(transcriptUnavailable ? { transcriptUnavailable: true } : {}),
+    messages: page.map(projectMessage),
+    ...(offset + page.length < messages.length
+      ? { nextCursor: String(offset + page.length) }
+      : {}),
+  });
+});
+
+function asPromptIndex(value: unknown): number | null {
+  return typeof value === "number" && Number.isInteger(value) ? value : null;
+}
+
+async function hydrateTurn(
+  trace: TurnTraceDoc
+): Promise<Record<string, unknown>> {
+  let spans: unknown[] = [];
+  let spansUnavailable = false;
+  if (typeof trace.spansBlobUrl === "string") {
+    const fetched = await fetchJsonBlob(trace.spansBlobUrl);
+    if (!fetched.ok || !Array.isArray(fetched.value)) {
+      spansUnavailable = true;
+    } else {
+      spans = fetched.value;
+    }
+  } else {
+    spansUnavailable = true;
+  }
+  const usage =
+    trace.usage &&
+    typeof trace.usage === "object" &&
+    !Array.isArray(trace.usage)
+      ? trace.usage
+      : undefined;
+  return {
+    turnId: typeof trace.turnId === "string" ? trace.turnId : null,
+    promptIndex: asPromptIndex(trace.promptIndex),
+    startedAt: typeof trace.startedAt === "number" ? trace.startedAt : null,
+    endedAt: typeof trace.endedAt === "number" ? trace.endedAt : null,
+    ...(typeof trace.finishReason === "string"
+      ? { finishReason: trace.finishReason }
+      : {}),
+    ...(usage ? { usage } : {}),
+    spanCount:
+      typeof trace.spanCount === "number" ? trace.spanCount : spans.length,
+    ...(typeof trace.modelId === "string" ? { modelId: trace.modelId } : {}),
+    ...(trace.pluginVersionsAtTurn !== undefined
+      ? { pluginVersionsAtTurn: trace.pluginVersionsAtTurn }
+      : {}),
+    spans,
+    ...(spansUnavailable ? { spansUnavailable: true } : {}),
+  };
+}
+
+// GET /v1/chat-sessions/:sessionId/trace
+//
+// Incremental per-turn traces. `getSessionTurnTraces` returns metadata plus
+// a `spansBlobUrl` per turn; this route fetches those blobs (bounded,
+// timed out) and inlines the spans. The URL itself never leaves.
+//
+// `afterPromptIndex` (or `cursor`, the previous page's `nextCursor`) keeps
+// the payload to turns the caller has not seen — an agent polling after
+// each send does not re-download the whole session.
+chatSessions.get("/chat-sessions/:sessionId/trace", async (c) => {
+  const sessionId = c.req.param("sessionId");
+  const limit = parsePositiveLimit(
+    c.req.query("limit"),
+    TRACE_PAGE_SIZE,
+    TRACE_MAX_PAGE_SIZE
+  );
+  const cursorAfter = parseNonNegativeIntQuery(c.req.query("cursor"), "cursor");
+  const explicitAfter = parseNonNegativeIntQuery(
+    c.req.query("afterPromptIndex"),
+    "afterPromptIndex"
+  );
+  // `cursor` wins so the documented pagination loop pages correctly when
+  // a caller also left a stale `afterPromptIndex` on the URL.
+  const afterPromptIndex = cursorAfter ?? explicitAfter ?? -1;
+
+  const session = await loadAuthorizedSession(c, sessionId);
+  const client = createConvexClient(await getConvexBearerForRequest(c));
+  let traces: TurnTraceDoc[];
+  try {
+    traces = (await client.query(
+      "chatSessions:getSessionTurnTraces" as never,
+      { sessionId } as never
+    )) as TurnTraceDoc[];
+  } catch (error) {
+    throw translatePreflightReadError(error, "Session not found");
+  }
+  if (!Array.isArray(traces)) traces = [];
+
+  const ordered = [...traces].sort((left, right) => {
+    const a = asPromptIndex(left.promptIndex) ?? 0;
+    const b = asPromptIndex(right.promptIndex) ?? 0;
+    return a - b;
+  });
+  const unseen = ordered.filter((trace) => {
+    const index = asPromptIndex(trace.promptIndex);
+    return index !== null && index > afterPromptIndex;
+  });
+  const page = unseen.slice(0, limit);
+  const turns = await Promise.all(page.map(hydrateTurn));
+  const last = page[page.length - 1];
+  const lastIndex = last ? asPromptIndex(last.promptIndex) : null;
+
+  return v1Resource(c, {
+    ...sessionMeta(sessionId, session),
+    turnCount: unseen.length,
+    turns,
+    ...(lastIndex !== null && page.length < unseen.length
+      ? { nextCursor: String(lastIndex) }
+      : {}),
+  });
+});
+
+export default chatSessions;

--- a/mcpjam-inspector/server/routes/v1/guest-allowed-paths.ts
+++ b/mcpjam-inspector/server/routes/v1/guest-allowed-paths.ts
@@ -31,6 +31,11 @@ const GUEST_ALLOWED_V1_RULES: readonly GuestRule[] = [
   // Mounted before the auth middleware (fully public), so this rule is
   // defense-in-depth for guests if the mount order ever changes; GET-only.
   { pattern: /^\/host-catalog$/, methods: ["GET"] },
+  // EXACT MATCH. `/chat-sessions/:id` and `/chat-sessions/:id/trace`
+  // stay guest-DENIED: they return a scrubbed transcript and per-turn
+  // spans, which is a larger disclosure than the list, and they wait
+  // for their own guest security review. Widening this pattern would
+  // hand those reads to every minted guest token for free.
   { pattern: /^\/chat-sessions$/ },
   // The unified sessions feed, reachable by the `search_sessions` platform
   // tool. The allowlist's stated contract is "exactly the platform MCP tool

--- a/mcpjam-inspector/server/routes/v1/index.ts
+++ b/mcpjam-inspector/server/routes/v1/index.ts
@@ -42,6 +42,7 @@ import conformanceIngest from "./conformance-ingest.js";
 import agent from "./agent.js";
 import proposedActionsRoutes from "./proposed-actions.js";
 import oauth from "./oauth.js";
+import chatSessions from "./chat-sessions.js";
 import catalog from "./catalog.js";
 import registry from "./registry.js";
 import organizations from "./organizations.js";
@@ -171,6 +172,11 @@ v1.route("/", agent);
 // GUEST_ALLOWED_V1_RULES entry) — every approved action spends.
 v1.route("/", proposedActionsRoutes);
 v1.route("/", oauth);
+// Chat-session DETAIL + incremental trace. Mounted BEFORE the catalog
+// proxy so `GET /chat-sessions/:sessionId` cannot be swallowed by a later
+// `/chat-sessions` catch-all, and so the gateway — not Convex HTTP —
+// is the thing that fetches `messagesBlobUrl` / `spansBlobUrl`.
+v1.route("/", chatSessions);
 v1.route("/", catalog);
 // Registry — directory search/detail/sources (guest-allowed reads) plus
 // project-scoped card/connection reads and install/uninstall writes. Mounted


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Purpose

Agent playground reads need one durable session id they can poll after a turn. The list (`GET /chat-sessions`) already exists; this adds the detail and incremental-trace reads so a caller can fetch a bounded, scrubbed transcript and only the turns they have not seen.

## Before / after

**Before:** `GET /v1/chat-sessions` listed sessions. There was no public way to read one session’s messages or per-turn spans without going through the user-testing scenario URL or the Playground UI. `getSession` / `getSessionTurnTraces` return storage URLs that must not leave the gateway.

**After:**
- `GET /v1/chat-sessions/{sessionId}` — metadata + paged, scrubbed messages. `messagesBlobUrl` never appears. Unreadable blobs report `transcriptUnavailable` and `messageCount: null` (never `0`).
- `GET /v1/chat-sessions/{sessionId}/trace` — incremental turns with spans inlined. `afterPromptIndex` / `cursor` skip already-seen turns. `spansBlobUrl` never appears.
- Optional `?projectId=` 404s (never 403) when the session lives elsewhere. Unauthorized and missing are the same 404.
- Guest allowlist stays the exact match `/^\/chat-sessions$/`. Detail and trace are guest-denied.

## Notes

- Mounted **before** the catalog Convex HTTP proxy so these routes call Convex functions and fetch blobs themselves.
- SDK client methods are intentionally excluded here; they ship with `sendChatMessage` so a caller cannot poll a session they cannot continue.
- Does **not** emit `origin: "api"`. That waits for the turn POST.

## Rollout

Inspector-only. Safe to merge independently of the backend lease deploy; these reads use `getSession` / `getSessionTurnTraces`, which already accept delegated JWTs.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-2fa398fa-2d31-4ce0-8ccf-8202b731e384?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-2fa398fa-2d31-4ce0-8ccf-8202b731e384&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds chat-session detail and incremental trace reads so clients can poll a durable session for a scrubbed transcript and unseen turns. Before: only GET /v1/chat-sessions listed sessions. Now: GET /v1/chat-sessions/{sessionId} returns paged, scrubbed messages and GET /v1/chat-sessions/{sessionId}/trace returns incremental turns with inlined spans; blob URLs never leave the gateway and unauthorized/cross-project reads are 404.

- API and pagination: transcripts default to 50 (max 200) with cursor; traces default to 20 (max 50) with afterPromptIndex or cursor (cursor wins). nextCursor drives subsequent pages. Optional ?projectId filters; mismatch returns 404 (never 403). Non-integer, fractional, or zero limits return 400; cursor must be a non-negative integer.
- Safety and security: gateway never returns messagesBlobUrl or spansBlobUrl. Blob fetches are bounded and hardened: 8 MiB per blob, 32 MiB per trace request total, up to 4 blobs in flight, 10s timeout, and redirects are not followed. Unreadable transcripts set transcriptUnavailable and messageCount: null; unreadable spans set spansUnavailable. Missing or non-array trace payloads are treated as empty.
- Auth/guests and routing: guests cannot access detail or trace; the allowlist remains the exact match /chat-sessions. Routes mount before the catalog proxy so these call Convex functions and fetch blobs in the gateway.
- SDK/docs/rollout: OpenAPI and docs updated. Endpoints remain excluded from the SDK until they ship with sendChatMessage. Inspector-only rollout; uses existing getSession and getSessionTurnTraces with delegated JWTs.

<sup>Written for commit 8a1dfaaa2557b83783f4a24fbea44bb8ad8c3dac. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/MCPJam/inspector/pull/4300?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

