### PR TITLE
fix(changeset): drop the ignored @mcpjam/mcp from the registry-ops changeset

### DIFF
--- a/.changeset/registry-ops-catalog.md
+++ b/.changeset/registry-ops-catalog.md
@@ -1,6 +1,5 @@
 ---
 "@mcpjam/sdk": patch
-"@mcpjam/mcp": patch
 ---
 
 Add eight registry PlatformOperations (search/list/install/uninstall) to the shared catalog, MCP worker tools, and in-app chat toolset.


### PR DESCRIPTION
- The release is blocked at preflight: `npx changeset status` exits 1 with "Mixed changesets that contain both ignored and not ignored packages are not allowed".
- The culprit is `.changeset/registry-ops-catalog.md` from #4253 — it lists both `@mcpjam/sdk` (published) and `@mcpjam/mcp` (in the `ignore` list, never published to npm).
- This drops the `@mcpjam/mcp` line. Nothing is lost — an ignored package never gets a version bump anyway.
- After this, the pending release is exactly inspector + cli + sdk, and it was the only mixed changeset on main.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Unblocks the release by removing ignored package `@mcpjam/mcp` from `.changeset/registry-ops-catalog.md`. Before: the changeset mixed `@mcpjam/sdk` (published) with ignored `@mcpjam/mcp`, causing `npx changeset status` to exit 1; after: only `@mcpjam/sdk` remains, so preflight passes.

No side effects: ignored packages never receive a version bump. Pending release remains inspector + cli + sdk; this was the only mixed changeset on main.

<sup>Written for commit d843c64344a793db34fec501c28ec795fec585bb. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/MCPJam/inspector/pull/4303?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

