### PR TITLE
feat(widgets): let agents see and drive MCP App widgets

### DIFF
--- a/.changeset/agent-widget-inspection.md
+++ b/.changeset/agent-widget-inspection.md
@@ -1,0 +1,45 @@
+---
+"@mcpjam/inspector": minor
+"@mcpjam/sdk": minor
+---
+
+Let agents see and drive MCP App widgets, not just read their HTML.
+
+A tool that returns a `ui://` resource is two products in one: the tool result a
+model reads, and the interface a person sees. Every machine surface could
+inspect the first half. Nothing could inspect the second — an agent debugging
+its own MCP App could fetch the widget's HTML and had no way to learn whether it
+actually rendered, what it showed, or which tools it fired.
+
+**Widgets as text.** The browser harness gains `captureSnapshot()`: the widget's
+accessibility tree plus its interactive elements, returned in the *same*
+role/name/testId vocabulary the interaction steps already accept, so a caller
+reads a control and addresses it directly. This is what makes the surface usable
+by a text-only model at all — every existing way to drive a widget was
+coordinate-based (`[x, y]`), which silently assumed the caller could see pixels.
+A model handed a screenshot and no handles has nothing to click.
+
+**Locally** (`/api/mcp/widget-session`), two new endpoints pair with it:
+`GET /:id/snapshot` reads the widget without consuming its interaction budget —
+looking is not acting, and a caller forced to spend steps on looking would
+interact blind to save them — and `POST /:id/scripted-step` drives it by
+role/name/testId instead of by coordinate. `POST /api/mcp/widget-render` gains
+`includeSnapshot`.
+
+**Hosted**, `POST /v1/projects/{p}/servers/{s}/widgets/render`
+(`render_server_widget`) calls the tool, mounts its widget in real headless
+Chromium running the production host bridge, and returns the render verdict, the
+console errors, the blocked requests, and the tree. Stateless by construction —
+connect, call, render, read, dispose in one request — which is what makes it
+safe on a plane with no session affinity; interactive sessions stay local
+because they hold a live browser in process.
+
+Its payload defaults are the reverse of the local route's, deliberately: the
+snapshot is on and the screenshot is off, because this endpoint's caller is
+usually a model, for which a base64 image it may not even be able to see is the
+most expensive possible way to say nothing.
+
+The op executes the caller's tool, so it inherits `call_server_tool`'s gating: a
+human approves it, with the arguments previewed. It annotates as destructive and
+explicitly **not** idempotent — nobody can promise that running a third party's
+tool twice is safe.

--- a/.changeset/agent-widget-inspection.md
+++ b/.changeset/agent-widget-inspection.md
@@ -1,6 +1,7 @@
 ---
 "@mcpjam/inspector": minor
 "@mcpjam/sdk": minor
+"@mcpjam/cli": minor
 ---
 
 Let agents see and drive MCP App widgets, not just read their HTML.

--- a/cli/src/commands/apps.ts
+++ b/cli/src/commands/apps.ts
@@ -55,6 +55,7 @@ import {
   runWidgetSessionSnapshot,
   runWidgetSessionScriptedStep,
   parseScriptedStepInput,
+  parsePriorWidgetToolCalls,
 } from "../lib/widget-session.js";
 
 const APPS_CHECK_IDS_BY_CATEGORY: Record<
@@ -551,6 +552,10 @@ export function registerAppsCommands(program: Command): void {
     .requiredOption("--session <id>", "Session id from `apps session start`")
     .requiredOption("--step <json>", "The step, as a JSON object")
     .option(
+      "--prior-tool-calls <json>",
+      "The `widgetToolCalls` earlier steps returned, as a JSON array. Required for a `widgetToolCalled` assertion: the server drains its buffer after every step, so history is the caller's to carry.",
+    )
+    .option(
       "--screenshot-out <path>",
       "Write the post-step screenshot to a file",
     )
@@ -564,6 +569,7 @@ export function registerAppsCommands(program: Command): void {
         options: {
           session?: string;
           step?: string;
+          priorToolCalls?: string;
           screenshotOut?: string;
           screenshotBase64?: boolean;
           inspectorUrl?: string;
@@ -576,11 +582,15 @@ export function registerAppsCommands(program: Command): void {
           throw usageError("--session is required.");
         }
         const step = parseScriptedStepInput(options.step);
+        const priorWidgetToolCalls = parsePriorWidgetToolCalls(
+          options.priorToolCalls,
+        );
 
         const response = await runWidgetSessionScriptedStep({
           baseUrl: options.inspectorUrl,
           sessionId,
           step,
+          ...(priorWidgetToolCalls ? { priorWidgetToolCalls } : {}),
           timeoutMs: globalOptions.timeout,
         });
 

--- a/cli/src/commands/apps.ts
+++ b/cli/src/commands/apps.ts
@@ -52,6 +52,9 @@ import {
   runWidgetSessionAction,
   runWidgetSessionClose,
   runWidgetSessionStart,
+  runWidgetSessionSnapshot,
+  runWidgetSessionScriptedStep,
+  parseScriptedStepInput,
 } from "../lib/widget-session.js";
 
 const APPS_CHECK_IDS_BY_CATEGORY: Record<
@@ -355,7 +358,7 @@ export function registerAppsCommands(program: Command): void {
   const session = apps
     .command("session")
     .description(
-      "Interactive headless widget sessions (start, action, close) via the local Inspector",
+      "Interactive headless widget sessions via the local Inspector. `action` drives by pixel coordinate; `snapshot` + `step` drive by role/name/testId, which is what a caller that cannot see the screenshot needs.",
     );
 
   addSharedServerOptions(
@@ -513,6 +516,95 @@ export function registerAppsCommands(program: Command): void {
         globalOptions.format,
       );
     });
+
+  session
+    .command("snapshot")
+    .description(
+      "Read the mounted widget as an accessibility tree plus addressable controls. A read: it refreshes the session TTL but does not spend the widget's interaction budget.",
+    )
+    .requiredOption("--session <id>", "Session id from `apps session start`")
+    .option("--inspector-url <url>", "Local Inspector base URL")
+    .action(
+      async (
+        options: { session?: string; inspectorUrl?: string },
+        command,
+      ) => {
+        const globalOptions = getGlobalOptions(command);
+        const sessionId = options.session?.trim();
+        if (!sessionId) {
+          throw usageError("--session is required.");
+        }
+        const response = await runWidgetSessionSnapshot({
+          baseUrl: options.inspectorUrl,
+          sessionId,
+          timeoutMs: globalOptions.timeout,
+        });
+        writeResult(response, globalOptions.format);
+      },
+    );
+
+  session
+    .command("step")
+    .description(
+      'Drive one semantic step, addressed by role/name/testId rather than by coordinate. Pass the step as JSON, e.g. --step \'{"kind":"click","target":{"role":{"role":"button","name":"Submit"}}}\'. Use `apps session snapshot` to find the targets.',
+    )
+    .requiredOption("--session <id>", "Session id from `apps session start`")
+    .requiredOption("--step <json>", "The step, as a JSON object")
+    .option(
+      "--screenshot-out <path>",
+      "Write the post-step screenshot to a file",
+    )
+    .option(
+      "--screenshot-base64",
+      "Include the screenshot inline as base64 in the JSON output",
+    )
+    .option("--inspector-url <url>", "Local Inspector base URL")
+    .action(
+      async (
+        options: {
+          session?: string;
+          step?: string;
+          screenshotOut?: string;
+          screenshotBase64?: boolean;
+          inspectorUrl?: string;
+        },
+        command,
+      ) => {
+        const globalOptions = getGlobalOptions(command);
+        const sessionId = options.session?.trim();
+        if (!sessionId) {
+          throw usageError("--session is required.");
+        }
+        const step = parseScriptedStepInput(options.step);
+
+        const response = await runWidgetSessionScriptedStep({
+          baseUrl: options.inspectorUrl,
+          sessionId,
+          step,
+          timeoutMs: globalOptions.timeout,
+        });
+
+        const screenshotPath = await writeScreenshotIfRequested(
+          response.screenshotBase64,
+          options.screenshotOut,
+        );
+
+        const { screenshotBase64, ...rest } = response;
+        writeResult(
+          {
+            ...rest,
+            ...(screenshotPath ? { screenshotPath } : {}),
+            // Base64 only on request: a frame per step is the largest thing
+            // this command emits, and the caller driving by role does not
+            // need it.
+            ...(options.screenshotBase64 === true && screenshotBase64
+              ? { screenshotBase64 }
+              : {}),
+          },
+          globalOptions.format,
+        );
+      },
+    );
 
   session
     .command("close")

--- a/cli/src/lib/op-bindings.ts
+++ b/cli/src/lib/op-bindings.ts
@@ -246,6 +246,10 @@ export const CLI_BINDINGS: Readonly<Record<string, CliBinding>> = {
     excluded:
       "`tools call` connects to the server directly, so it works without a project or an API key.",
   },
+  render_server_widget: {
+    excluded:
+      "`apps render` connects to the server directly and mounts the widget in the developer's OWN Chromium, so it works without a project or an API key — and spends no hosted browser to answer a question the local command already answers.",
+  },
   list_server_prompts: {
     excluded:
       "`prompts list` connects to the server directly, so it works without a project or an API key.",

--- a/cli/src/lib/widget-session.ts
+++ b/cli/src/lib/widget-session.ts
@@ -283,6 +283,45 @@ export async function runWidgetSessionScriptedStep(
  * server accepts. This only guarantees the server receives a shape it can
  * parse and report on.
  */
+/**
+ * Parse `--prior-tool-calls` — the widget tool calls earlier steps produced.
+ *
+ * The server DRAINS its buffer after every step, so it cannot see history: a
+ * `widgetToolCalled` assertion is only answerable against what the caller has
+ * accumulated. Without this the assertion always saw an empty list and could
+ * never pass, even when the previous step's own output showed the call.
+ */
+export function parsePriorWidgetToolCalls(
+  raw: string | undefined,
+): WidgetToolCall[] | undefined {
+  const text = raw?.trim();
+  if (!text) return undefined;
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(text);
+  } catch (error) {
+    throw usageError(
+      `--prior-tool-calls is not valid JSON: ${
+        error instanceof Error ? error.message : String(error)
+      }`,
+    );
+  }
+  if (
+    !Array.isArray(parsed) ||
+    !parsed.every(
+      (entry) =>
+        entry !== null &&
+        typeof entry === "object" &&
+        typeof (entry as { name?: unknown }).name === "string",
+    )
+  ) {
+    throw usageError(
+      "--prior-tool-calls must be a JSON array of the `widgetToolCalls` entries earlier steps returned.",
+    );
+  }
+  return parsed as WidgetToolCall[];
+}
+
 export function parseScriptedStepInput(raw: string | undefined): unknown {
   const text = raw?.trim();
   if (!text) {

--- a/cli/src/lib/widget-session.ts
+++ b/cli/src/lib/widget-session.ts
@@ -13,6 +13,11 @@ import {
  * `mcpjam apps session start|action|close`. Like widget-render.ts, the wire
  * contract is mirrored here (the CLI doesn't depend on `@mcpjam/inspector`); the
  * session is held server-side and the external agent steps through it.
+ *
+ * TWO WAYS TO DRIVE, and the second is why a text-only agent can use this at
+ * all: `action` is COORDINATE-based, which assumes the caller can see pixels.
+ * `snapshot` + `scripted-step` close that — the snapshot returns controls by
+ * role/name/testId and the step accepts the same vocabulary back.
  */
 
 /** A Computer-Use action the harness can apply (mirror of the server spec). */
@@ -164,6 +169,139 @@ export async function runWidgetSessionAction(
   );
 
   return normalizeActionResponse(response, options.action);
+}
+
+/** One addressable control from a snapshot. */
+export interface SnapshotElement {
+  role?: { role: string; name?: string };
+  testId?: string;
+  text?: string;
+  ambiguous?: true;
+}
+
+export interface WidgetSnapshotResponse {
+  snapshot: {
+    mode: string;
+    tree: string;
+    elements: SnapshotElement[];
+    truncated?: true;
+    capturedAt: number;
+    note?: string;
+  };
+  expiresAt?: number;
+}
+
+export interface WidgetScriptedStepResponse {
+  step: unknown;
+  ok: boolean;
+  reason?: string;
+  screenshotBase64?: string;
+  widgetToolCalls: WidgetToolCall[];
+  followUps: string[];
+  note?: string;
+  elapsedMs?: number;
+  expiresAt?: number;
+}
+
+export interface RunWidgetSessionSnapshotOptions {
+  baseUrl?: string;
+  sessionId: string;
+  timeoutMs: number;
+}
+
+/**
+ * Read the mounted widget as an accessibility tree plus addressable controls.
+ *
+ * A READ: it refreshes the session's idle TTL but does not spend the widget's
+ * interaction budget, so an agent can look before every step without trading
+ * away the steps it came to make.
+ */
+export async function runWidgetSessionSnapshot(
+  options: RunWidgetSessionSnapshotOptions,
+  deps: { client?: WidgetRenderClient } = {},
+): Promise<WidgetSnapshotResponse> {
+  const client =
+    deps.client ?? new InspectorApiClient({ baseUrl: options.baseUrl });
+  await client.ensureBackend({
+    startIfNeeded: false,
+    timeoutMs: options.timeoutMs,
+  });
+  const response = (await client.request(
+    `/api/mcp/widget-session/${encodeURIComponent(options.sessionId)}/snapshot`,
+    { method: "GET", timeoutMs: options.timeoutMs },
+  )) as WidgetSnapshotResponse;
+  if (!response?.snapshot) {
+    throw operationalError("The Inspector returned no snapshot.");
+  }
+  return response;
+}
+
+export interface RunWidgetSessionScriptedStepOptions {
+  baseUrl?: string;
+  sessionId: string;
+  step: unknown;
+  priorWidgetToolCalls?: WidgetToolCall[];
+  timeoutMs: number;
+}
+
+/**
+ * Drive one SEMANTIC step — click/type/key/scroll/wait/assert — addressed by
+ * role, name or test id rather than by pixel coordinate.
+ */
+export async function runWidgetSessionScriptedStep(
+  options: RunWidgetSessionScriptedStepOptions,
+  deps: { client?: WidgetRenderClient } = {},
+): Promise<WidgetScriptedStepResponse> {
+  const client =
+    deps.client ?? new InspectorApiClient({ baseUrl: options.baseUrl });
+  await client.ensureBackend({
+    startIfNeeded: false,
+    timeoutMs: options.timeoutMs,
+  });
+  return (await client.request(
+    `/api/mcp/widget-session/${encodeURIComponent(
+      options.sessionId,
+    )}/scripted-step`,
+    {
+      method: "POST",
+      body: {
+        step: options.step,
+        ...(options.priorWidgetToolCalls
+          ? { priorWidgetToolCalls: options.priorWidgetToolCalls }
+          : {}),
+      },
+      timeoutMs: options.timeoutMs,
+    },
+  )) as WidgetScriptedStepResponse;
+}
+
+/**
+ * Parse `--step` as JSON and reject anything that is not an object.
+ *
+ * Deliberately NOT validated field-by-field here: the server owns the step
+ * schema, and a second copy in the CLI would drift into rejecting steps the
+ * server accepts. This only guarantees the server receives a shape it can
+ * parse and report on.
+ */
+export function parseScriptedStepInput(raw: string | undefined): unknown {
+  const text = raw?.trim();
+  if (!text) {
+    throw usageError("--step needs a JSON object, e.g. --step '{\"kind\":\"click\",\"target\":{\"role\":{\"role\":\"button\",\"name\":\"Submit\"}}}'.");
+  }
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(text);
+  } catch (error) {
+    throw usageError(
+      `--step is not valid JSON: ${
+        error instanceof Error ? error.message : String(error)
+      }`,
+    );
+  }
+  if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
+    throw usageError("--step must be a JSON object.");
+  }
+  return parsed;
 }
 
 export interface RunWidgetSessionCloseOptions {

--- a/docs/reference/openapi.json
+++ b/docs/reference/openapi.json
@@ -10608,6 +10608,80 @@
           }
         }
       }
+    },
+    "/projects/{projectId}/servers/{serverId}/widgets/render": {
+      "post": {
+        "operationId": "renderServerWidget",
+        "tags": [
+          "Execution"
+        ],
+        "summary": "Render an MCP App widget headlessly",
+        "description": "Call an MCP App tool and mount its `ui://` widget in real headless Chromium running the production host bridge, then report whether it rendered, what it logged, what it was blocked from fetching, and the widget as an accessibility tree with addressable elements.\n\n**Executes the tool**, so it has whatever side effects that tool has — the render is what happens afterwards.\n\nStateless: connect, call, render, read, dispose, all inside one request. Interactive widget sessions are a local-Inspector capability (`/api/mcp/widget-session`) because they hold a live browser in process, which a no-affinity hosted plane cannot serve.\n\nEach render launches a browser, so the endpoint carries a per-replica concurrency cap and answers 429 when it is full.",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/projectId"
+          },
+          {
+            "$ref": "#/components/parameters/serverId"
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/RenderServerWidgetRequest"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "The render verdict and its evidence.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/WidgetRenderResult"
+                }
+              }
+            }
+          },
+          "400": {
+            "$ref": "#/components/responses/ValidationError"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "403": {
+            "$ref": "#/components/responses/Forbidden"
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound"
+          },
+          "422": {
+            "description": "The tool declares no MCP App UI resource, or headless Chromium is unavailable on this deployment.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          },
+          "429": {
+            "$ref": "#/components/responses/RateLimited"
+          },
+          "500": {
+            "$ref": "#/components/responses/InternalError"
+          },
+          "502": {
+            "$ref": "#/components/responses/ServerUnreachable"
+          },
+          "504": {
+            "$ref": "#/components/responses/Timeout"
+          }
+        }
+      }
     }
   },
   "components": {
@@ -22565,6 +22639,169 @@
           },
           "latestPromptIndex": {
             "type": "integer"
+          }
+        }
+      },
+      "WidgetSnapshotElement": {
+        "type": "object",
+        "properties": {
+          "role": {
+            "type": "object",
+            "properties": {
+              "role": {
+                "type": "string"
+              },
+              "name": {
+                "type": "string"
+              }
+            }
+          },
+          "testId": {
+            "type": "string"
+          },
+          "text": {
+            "type": "string"
+          },
+          "ambiguous": {
+            "type": "boolean",
+            "description": "More than one element matched this role and name."
+          }
+        }
+      },
+      "WidgetSnapshot": {
+        "type": "object",
+        "required": [
+          "mode",
+          "tree",
+          "elements",
+          "capturedAt"
+        ],
+        "properties": {
+          "mode": {
+            "type": "string",
+            "enum": [
+              "a11y"
+            ]
+          },
+          "tree": {
+            "type": "string",
+            "description": "Playwright ARIA snapshot of the widget frame."
+          },
+          "elements": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/WidgetSnapshotElement"
+            },
+            "description": "Interactive elements, in the same role/name/testId vocabulary the interaction steps accept."
+          },
+          "truncated": {
+            "type": "boolean",
+            "description": "The tree hit the character ceiling and was clipped."
+          },
+          "capturedAt": {
+            "type": "integer"
+          },
+          "note": {
+            "type": "string",
+            "description": "Why nothing was captured, when nothing was."
+          }
+        }
+      },
+      "WidgetRenderResult": {
+        "type": "object",
+        "required": [
+          "status"
+        ],
+        "properties": {
+          "status": {
+            "type": "string",
+            "description": "The render verdict, e.g. `rendered`."
+          },
+          "resourceUri": {
+            "type": "string"
+          },
+          "bridgeInitialized": {
+            "type": "boolean"
+          },
+          "consoleErrors": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "blockedRequests": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "description": "Requests the render sandbox refused. A widget that renders while every fetch is blocked photographs perfectly and is broken, so this is reported even on a success."
+          },
+          "snapshot": {
+            "$ref": "#/components/schemas/WidgetSnapshot"
+          },
+          "screenshot": {
+            "type": "object",
+            "description": "Present only when `includeScreenshot` was explicitly requested.",
+            "properties": {
+              "mimeType": {
+                "type": "string"
+              },
+              "base64": {
+                "type": "string"
+              }
+            }
+          },
+          "timings": {
+            "type": "object",
+            "properties": {
+              "renderMs": {
+                "type": "integer"
+              },
+              "totalMs": {
+                "type": "integer"
+              }
+            }
+          }
+        }
+      },
+      "RenderServerWidgetRequest": {
+        "type": "object",
+        "required": [
+          "toolName"
+        ],
+        "properties": {
+          "toolName": {
+            "type": "string",
+            "description": "The MCP App tool to render. A tool that declares no `ui://` UI resource is refused (422) rather than run."
+          },
+          "parameters": {
+            "type": "object",
+            "additionalProperties": true
+          },
+          "includeSnapshot": {
+            "type": "boolean",
+            "default": true,
+            "description": "Return the widget as an accessibility tree with addressable elements. **Default true** — the reverse of the local Inspector route, because this endpoint's caller is usually a model for which a base64 image is the most expensive way to say nothing."
+          },
+          "includeScreenshot": {
+            "type": "boolean",
+            "default": false,
+            "description": "Also return a base64 image. **Default false**: it is by far the largest field this returns."
+          },
+          "injectOpenAiCompat": {
+            "type": "boolean",
+            "description": "Mount with the OpenAI Apps compatibility shims instead of the spec-default MCP-UI bridge."
+          },
+          "viewport": {
+            "type": "object",
+            "properties": {
+              "width": {
+                "type": "integer"
+              },
+              "height": {
+                "type": "integer"
+              }
+            }
           }
         }
       }

--- a/mcp/README.md
+++ b/mcp/README.md
@@ -40,6 +40,7 @@ so results respect the caller's project access.
 | `diagnose_server` | Diagnose a saved MCP server's connection: probe the URL, connect, initialize, and report capabilities and what failed. | — |
 | `list_server_tools` | List the tools a saved MCP server exposes: names, descriptions, and input schemas. | — |
 | `call_server_tool` | Execute a tool on a saved MCP server and return its result. | — |
+| `render_server_widget` | Call an MCP App tool and mount its `ui://` widget in real headless Chromium, then report whether it rendered, what it logged, what it was blocked from fetching, and the widget as an accessibility tree with addressable elements. Returns the tree by default and the screenshot only on request. Executes the tool. | — |
 | `list_server_prompts` | List the prompts a saved MCP server exposes: names, descriptions, and arguments. | — |
 | `get_server_prompt` | Render a prompt from a saved MCP server with the given arguments and return its messages. | — |
 | `list_server_resources` | List the resources a saved MCP server exposes: uris, names, and mime types. | — |

--- a/mcp/src/tools/platformTools.ts
+++ b/mcp/src/tools/platformTools.ts
@@ -9,6 +9,7 @@
  */
 import {
   callServerToolOperation,
+  renderServerWidgetOperation,
   checkHostCompatibilityOperation,
   startClaudeReadinessRunOperation,
   startOpenAIReadinessRunOperation,
@@ -189,6 +190,7 @@ export const PLATFORM_CATALOG_OPERATIONS: ReadonlyArray<
   diagnoseServerOperation,
   listServerToolsOperation,
   callServerToolOperation,
+  renderServerWidgetOperation,
   listServerPromptsOperation,
   getServerPromptOperation,
   listServerResourcesOperation,
@@ -502,6 +504,13 @@ const DESTRUCTIVE_OPERATION_NAMES: ReadonlySet<string> = new Set(
  * just handed back.
  */
 const NON_IDEMPOTENT_DESTRUCTIVE_NAMES: ReadonlySet<string> = new Set([
+  // A widget render EXECUTES the caller's tool first, and nobody can promise
+  // that running a third party's tool twice is safe. It reaches this list
+  // rather than `call_server_tool`'s absent-hints branch because its
+  // `risk: "destructive"` classification takes precedence above — which lands
+  // it STRICTER than the bare tool call (explicitly destructive, explicitly
+  // not retryable), never looser.
+  renderServerWidgetOperation.name,
   deletePersonaOperation.name,
   archiveJourneyOperation.name,
   archiveSwarmOperation.name,

--- a/mcp/tests/platformTools.test.ts
+++ b/mcp/tests/platformTools.test.ts
@@ -107,6 +107,10 @@ const PLAIN_TOOLS = [
   "diagnose_server",
   "list_server_tools",
   "call_server_tool",
+  // The render verdict is structured evidence (tree, console errors, blocked
+  // requests). A widget PANEL here would be a second, drifting copy of the
+  // Apps tab.
+  "render_server_widget",
   "list_server_prompts",
   "get_server_prompt",
   "list_server_resources",
@@ -347,6 +351,7 @@ describe("platform tool registration", () => {
       "diagnose_server",
       "list_server_tools",
       "call_server_tool",
+      "render_server_widget",
       "list_server_prompts",
       "get_server_prompt",
       "list_server_resources",
@@ -583,6 +588,9 @@ describe("platform tool registration", () => {
     // Destructive AND not safe to repeat — for opposite reasons: the soft
     // deletes 404 on a retry, the rotation mints another link.
     const NON_IDEMPOTENT_DESTRUCTIVE = new Set([
+      // Executes the caller's tool before rendering, and nobody can promise
+      // that running a third party's tool twice is safe.
+      "render_server_widget",
       "delete_persona",
       "archive_journey",
       "archive_swarm",
@@ -590,6 +598,11 @@ describe("platform tool registration", () => {
       "rotate_user_testing_link",
     ]);
     const DESTRUCTIVE_OPS = new Set([
+      // `risk: "destructive"` is the CONSERVATIVE reading of an unknowable
+      // effect, not a claim that this removes a specific record. Overclaiming
+      // destructiveness is the safe direction, and it matches what the spec
+      // tells a client to assume when the hints are absent anyway.
+      "render_server_widget",
       "delete_eval_suite",
       "delete_eval_case",
       // Cancelling a run terminates in-flight work, so it announces destructive.

--- a/mcpjam-inspector/server/routes/mcp/__tests__/widget-session.test.ts
+++ b/mcpjam-inspector/server/routes/mcp/__tests__/widget-session.test.ts
@@ -29,6 +29,20 @@ const harnessState = vi.hoisted(() => ({
     ],
     elapsedMs: 3,
   } as Record<string, unknown>,
+  snapshot: {
+    mode: "a11y",
+    tree: "- button \"Reserve\"",
+    elements: [{ role: { role: "button", name: "Reserve" } }],
+    capturedAt: 1,
+  } as Record<string, unknown>,
+  stepResult: {
+    ok: true,
+    widgetToolCalls: [
+      { name: "reserve", args: { seat: 12 }, ok: true, elapsedMs: 1 },
+    ],
+    followUps: [],
+    elapsedMs: 4,
+  } as Record<string, unknown>,
   disposeCalls: 0,
   /** When set, dispose() awaits it — lets a test hold a teardown open. */
   disposeGate: null as Promise<void> | null,
@@ -44,6 +58,20 @@ const harnessState = vi.hoisted(() => ({
         { name: "reserve", args: { seat: 12 }, ok: true, elapsedMs: 1 },
       ],
       elapsedMs: 3,
+    };
+    this.snapshot = {
+      mode: "a11y",
+      tree: "- button \"Reserve\"",
+      elements: [{ role: { role: "button", name: "Reserve" } }],
+      capturedAt: 1,
+    };
+    this.stepResult = {
+      ok: true,
+      widgetToolCalls: [
+        { name: "reserve", args: { seat: 12 }, ok: true, elapsedMs: 1 },
+      ],
+      followUps: [],
+      elapsedMs: 4,
     };
     this.disposeCalls = 0;
     this.disposeGate = null;
@@ -68,6 +96,12 @@ vi.mock("../../../utils/mcp-app-browser-harness", async () => {
     }
     async executeAction(input: { action: unknown }) {
       return { action: input.action, ...harnessState.actionResult };
+    }
+    async captureSnapshot() {
+      return harnessState.snapshot;
+    }
+    async runScriptedStep(input: { step: unknown }) {
+      return { step: input.step, ...harnessState.stepResult };
     }
     async dispose() {
       harnessState.disposeCalls += 1;
@@ -301,6 +335,119 @@ describe("widget-session route", () => {
         );
         expect(res.status, JSON.stringify(action)).toBe(400);
       }
+    });
+  });
+
+  describe("snapshot + scripted-step (the text-only driving path)", () => {
+    async function openSession(): Promise<string> {
+      const started = await startSession(app);
+      return (await started.json()).sessionId as string;
+    }
+
+    it("returns the widget as an addressable tree", async () => {
+      const sessionId = await openSession();
+      const response = await app.request(
+        `/api/mcp/widget-session/${sessionId}/snapshot`,
+      );
+      const body = await response.json();
+      expect(response.status).toBe(200);
+      expect(body.snapshot.mode).toBe("a11y");
+      // The elements come back in the SAME vocabulary a scripted step takes,
+      // which is the whole point: an agent reads one and posts it straight back
+      // rather than translating between two locator languages.
+      expect(body.snapshot.elements[0]).toEqual({
+        role: { role: "button", name: "Reserve" },
+      });
+      expect(typeof body.expiresAt).toBe("number");
+    });
+
+    it("drives the widget by role instead of by coordinate", async () => {
+      const sessionId = await openSession();
+      const response = await app.request(
+        `/api/mcp/widget-session/${sessionId}/scripted-step`,
+        {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({
+            step: {
+              kind: "click",
+              target: { role: { role: "button", name: "Reserve" } },
+            },
+          }),
+        },
+      );
+      const body = await response.json();
+      expect(response.status).toBe(200);
+      expect(body.ok).toBe(true);
+      // The tool calls the widget fired IN RESPONSE are the evidence an agent
+      // is actually here for — "the button fired the wrong tool" is the bug
+      // this loop exists to find.
+      expect(body.widgetToolCalls).toEqual([
+        { name: "reserve", args: { seat: 12 }, ok: true, elapsedMs: 1 },
+      ]);
+    });
+
+    it("rejects a malformed step rather than half-running it", async () => {
+      const sessionId = await openSession();
+      const response = await app.request(
+        `/api/mcp/widget-session/${sessionId}/scripted-step`,
+        {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ step: { kind: "click" } }),
+        },
+      );
+      expect(response.status).toBe(400);
+      expect((await response.json()).error).toMatch(/step is invalid/);
+    });
+
+    it("404s both new routes on an unknown session", async () => {
+      expect(
+        (await app.request("/api/mcp/widget-session/nope/snapshot")).status,
+      ).toBe(404);
+      const step = await app.request(
+        "/api/mcp/widget-session/nope/scripted-step",
+        {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({
+            step: { kind: "key", key: "Enter" },
+          }),
+        },
+      );
+      expect(step.status).toBe(404);
+    });
+
+    it("reports a failed assertion as a 200 with ok:false", async () => {
+      // A failed assertion is an ANSWER, not a transport error: the widget was
+      // driven successfully and did not do the thing. Returning 500 would make
+      // a caller retry a step that will keep failing.
+      harnessState.stepResult = {
+        ok: false,
+        reason: "expected tool `reserve` to have been called",
+        widgetToolCalls: [],
+        followUps: [],
+        elapsedMs: 2,
+      };
+      const sessionId = await openSession();
+      const response = await app.request(
+        `/api/mcp/widget-session/${sessionId}/scripted-step`,
+        {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({
+            step: {
+              kind: "assert",
+              assertion: { type: "widgetToolCalled", toolName: "reserve" },
+            },
+          }),
+        },
+      );
+      expect(response.status).toBe(200);
+      expect(await response.json()).toMatchObject({
+        ok: false,
+        reason: "expected tool `reserve` to have been called",
+      });
     });
   });
 

--- a/mcpjam-inspector/server/routes/mcp/__tests__/widget-session.test.ts
+++ b/mcpjam-inspector/server/routes/mcp/__tests__/widget-session.test.ts
@@ -418,6 +418,39 @@ describe("widget-session route", () => {
       expect(step.status).toBe(404);
     });
 
+    it("stops driving once the per-widget step budget is spent", async () => {
+      // `executeAction` has always enforced this; `runScriptedStep` only
+      // incremented the counter. Exposing the step path as its own route made
+      // that a reachable bypass — a caller posting only semantic steps could
+      // drive a runaway widget forever, refreshing the session TTL each time,
+      // while the coordinate path next door capped out at twelve.
+      harnessState.stepResult = {
+        ok: false,
+        reason: "per-widget step budget exhausted",
+        widgetToolCalls: [],
+        followUps: [],
+        elapsedMs: 1,
+        note: "step_budget_exceeded",
+      };
+      const sessionId = await openSession();
+      const response = await app.request(
+        `/api/mcp/widget-session/${sessionId}/scripted-step`,
+        {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ step: { kind: "key", key: "Enter" } }),
+        },
+      );
+      expect(response.status).toBe(200);
+      expect((await response.json()).note).toBe("step_budget_exceeded");
+      // A terminal note disposes the session, so the NEXT call 404s rather
+      // than holding Chromium for a widget nothing can drive.
+      const after = await app.request(
+        `/api/mcp/widget-session/${sessionId}/snapshot`,
+      );
+      expect(after.status).toBe(404);
+    });
+
     it("reports a failed assertion as a 200 with ok:false", async () => {
       // A failed assertion is an ANSWER, not a transport error: the widget was
       // driven successfully and did not do the thing. Returning 500 would make

--- a/mcpjam-inspector/server/routes/mcp/__tests__/widget-session.test.ts
+++ b/mcpjam-inspector/server/routes/mcp/__tests__/widget-session.test.ts
@@ -31,7 +31,7 @@ const harnessState = vi.hoisted(() => ({
   } as Record<string, unknown>,
   snapshot: {
     mode: "a11y",
-    tree: "- button \"Reserve\"",
+    tree: '- button "Reserve"',
     elements: [{ role: { role: "button", name: "Reserve" } }],
     capturedAt: 1,
   } as Record<string, unknown>,
@@ -61,7 +61,7 @@ const harnessState = vi.hoisted(() => ({
     };
     this.snapshot = {
       mode: "a11y",
-      tree: "- button \"Reserve\"",
+      tree: '- button "Reserve"',
       elements: [{ role: { role: "button", name: "Reserve" } }],
       capturedAt: 1,
     };
@@ -401,6 +401,53 @@ describe("widget-session route", () => {
       expect((await response.json()).error).toMatch(/step is invalid/);
     });
 
+    it("400s a malformed priorWidgetToolCalls instead of failing inside the harness", async () => {
+      // A `widgetToolCalled` assertion reads `.name` off each entry, so
+      // `[null]` used to reach the harness as a TypeError and come back as a
+      // 200 with a failed step and an internal message — a malformed request
+      // reported as a widget problem. The caller can only fix what we name.
+      const sessionId = await openSession();
+      for (const prior of [[null], ["reserve"], {}, [{ ok: true }]]) {
+        const response = await app.request(
+          `/api/mcp/widget-session/${sessionId}/scripted-step`,
+          {
+            method: "POST",
+            headers: { "Content-Type": "application/json" },
+            body: JSON.stringify({
+              step: {
+                kind: "assert",
+                assertion: { type: "widgetToolCalled", toolName: "reserve" },
+              },
+              priorWidgetToolCalls: prior,
+            }),
+          },
+        );
+        expect(response.status).toBe(400);
+        expect((await response.json()).error).toMatch(/priorWidgetToolCalls/);
+      }
+    });
+
+    it("accepts a well-formed tool-call history", async () => {
+      const sessionId = await openSession();
+      const response = await app.request(
+        `/api/mcp/widget-session/${sessionId}/scripted-step`,
+        {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({
+            step: {
+              kind: "assert",
+              assertion: { type: "widgetToolCalled", toolName: "reserve" },
+            },
+            priorWidgetToolCalls: [
+              { name: "reserve", args: {}, ok: true, elapsedMs: 1 },
+            ],
+          }),
+        },
+      );
+      expect(response.status).toBe(200);
+    });
+
     it("404s both new routes on an unknown session", async () => {
       expect(
         (await app.request("/api/mcp/widget-session/nope/snapshot")).status,
@@ -498,10 +545,9 @@ describe("widget-session route", () => {
     });
 
     it("reports closed:false for an unknown session", async () => {
-      const res = await app.request(
-        "/api/mcp/widget-session/does-not-exist",
-        { method: "DELETE" },
-      );
+      const res = await app.request("/api/mcp/widget-session/does-not-exist", {
+        method: "DELETE",
+      });
       expect(res.status).toBe(200);
       expect((await res.json()).closed).toBe(false);
     });

--- a/mcpjam-inspector/server/routes/mcp/widget-render.ts
+++ b/mcpjam-inspector/server/routes/mcp/widget-render.ts
@@ -44,8 +44,14 @@ widgetRender.post("/", async (c) => {
   if (!parsed.ok) {
     return c.json({ error: parsed.error }, 400);
   }
-  const { serverId, toolName, parameters, injectOpenAiCompat, viewport } =
-    parsed.value;
+  const {
+    serverId,
+    toolName,
+    parameters,
+    injectOpenAiCompat,
+    viewport,
+    includeSnapshot,
+  } = parsed.value;
 
   let result;
   try {
@@ -57,6 +63,7 @@ widgetRender.post("/", async (c) => {
       injectOpenAiCompat,
       viewport,
       keepMounted: false,
+      ...(includeSnapshot ? { captureSnapshot: true } : {}),
     });
   } catch (error) {
     return c.json(
@@ -68,7 +75,13 @@ widgetRender.post("/", async (c) => {
   }
 
   try {
-    return c.json(buildWidgetRenderResponseBody(result.observation), 200);
+    return c.json(
+      {
+        ...buildWidgetRenderResponseBody(result.observation),
+        ...(result.snapshot ? { snapshot: result.snapshot } : {}),
+      },
+      200,
+    );
   } finally {
     // One-shot: always tear the browser down (best-effort; the response is
     // already committed). Log a disposal failure so a leaked context is

--- a/mcpjam-inspector/server/routes/mcp/widget-session.ts
+++ b/mcpjam-inspector/server/routes/mcp/widget-session.ts
@@ -1,4 +1,5 @@
 import { Hono } from "hono";
+import type { Context } from "hono";
 import "../../types/hono";
 import { DEFAULT_VIEWPORT } from "../../utils/mcp-app-browser-harness";
 import type { BrowserActionSpec } from "../../utils/mcp-app-browser-harness";
@@ -16,12 +17,22 @@ import {
   WidgetSessionUnavailableError,
 } from "../../services/widget-render-session";
 import { logger } from "../../utils/logger";
+import { scriptedStepSchema } from "@/shared/scripted-steps";
 
 /**
  * widget-session.ts — interactive headless widget sessions:
  *   POST   /api/mcp/widget-session            start (render keepMounted)
  *   POST   /api/mcp/widget-session/:id/action drive a Computer-Use action
+ *   GET    /api/mcp/widget-session/:id/snapshot  read the widget as TEXT
+ *   POST   /api/mcp/widget-session/:id/scripted-step  act by role/name/testId
  *   DELETE /api/mcp/widget-session/:id         close + dispose
+ *
+ * TWO WAYS TO DRIVE, and the second is not a convenience. `/action` is
+ * COORDINATE-based, which silently assumes the caller can see pixels — a
+ * text-only model handed a screenshot has nothing to click. `/snapshot` +
+ * `/scripted-step` close that: the snapshot hands back interactive elements in
+ * the same role/name/testId vocabulary the step accepts, so an agent reads a
+ * control and posts it straight back as a target.
  *
  * Same local-only, gate-first render core as the one-shot widget-render route;
  * the difference is the harness is kept mounted and handed to the session
@@ -237,6 +248,78 @@ widgetSession.post("/", async (c) => {
   }
 });
 
+// ── snapshot ─────────────────────────────────────────────────────────────
+// Returns { snapshot: { mode, tree, elements, truncated?, note? }, expiresAt }.
+// A READ: it refreshes the idle TTL but does not consume the widget's step
+// budget, because a caller forced to spend interaction steps on looking would
+// interact blind to save them.
+widgetSession.get("/:id/snapshot", async (c) => {
+  const sessionId = c.req.param("id");
+  try {
+    const { snapshot, expiresAt } =
+      await widgetRenderSessions.captureSnapshot(sessionId);
+    return c.json({ snapshot, expiresAt }, 200);
+  } catch (error) {
+    return widgetSessionErrorResponse(c, error, "Snapshot failed");
+  }
+});
+
+// ── scripted-step ────────────────────────────────────────────────────────
+// Body: { step: ScriptedStep, priorWidgetToolCalls?: WidgetToolCall[] }.
+// The semantic sibling of /action: targets by role/name/testId — the same
+// vocabulary /snapshot returns — instead of by pixel coordinate.
+widgetSession.post("/:id/scripted-step", async (c) => {
+  const sessionId = c.req.param("id");
+  let body: unknown;
+  try {
+    body = await c.req.json();
+  } catch {
+    return c.json({ error: "Invalid JSON body" }, 400);
+  }
+  const parsed = scriptedStepSchema.safeParse((body as { step?: unknown })?.step);
+  if (!parsed.success) {
+    return c.json(
+      {
+        error: `step is invalid: ${parsed.error.issues
+          .map((issue) => `${issue.path.join(".") || "(root)"}: ${issue.message}`)
+          .join("; ")}`,
+      },
+      400,
+    );
+  }
+  const prior = (body as { priorWidgetToolCalls?: unknown })
+    ?.priorWidgetToolCalls;
+
+  try {
+    const { result, expiresAt } = await widgetRenderSessions.runScriptedStep(
+      sessionId,
+      parsed.data,
+      // An `assert` step can check "the widget called tool X", which is only
+      // answerable against the calls the CALLER has accumulated across steps —
+      // the harness drains its buffer each step and cannot see the history.
+      Array.isArray(prior) ? (prior as never[]) : undefined,
+    );
+    return c.json(
+      {
+        step: result.step,
+        ok: result.ok,
+        ...(result.reason ? { reason: result.reason } : {}),
+        ...(result.screenshotBase64
+          ? { screenshotBase64: result.screenshotBase64 }
+          : {}),
+        widgetToolCalls: result.widgetToolCalls,
+        followUps: result.followUps,
+        ...(result.note ? { note: result.note } : {}),
+        elapsedMs: result.elapsedMs,
+        expiresAt,
+      },
+      200,
+    );
+  } catch (error) {
+    return widgetSessionErrorResponse(c, error, "Step failed");
+  }
+});
+
 // ── action ───────────────────────────────────────────────────────────────
 // Body: { action: BrowserActionSpec }. Drives the mounted widget and returns
 // { screenshotBase64?, widgetToolCalls, note?, action, elapsedMs, expiresAt }.
@@ -297,3 +380,27 @@ widgetSession.delete("/:id", async (c) => {
 });
 
 export default widgetSession;
+
+/**
+ * ONE status mapping for every session entry point.
+ *
+ * Three handlers that each re-derive "not found is 404, busy is 409" is three
+ * places for one of them to drift — and the drift would be invisible, because
+ * each handler's own tests would still pass.
+ */
+function widgetSessionErrorResponse(
+  c: Context,
+  error: unknown,
+  fallbackMessage: string,
+) {
+  if (error instanceof WidgetSessionNotFoundError) {
+    return c.json({ error: error.message }, 404);
+  }
+  if (error instanceof WidgetSessionBusyError) {
+    return c.json({ error: error.message }, 409);
+  }
+  return c.json(
+    { error: error instanceof Error ? error.message : fallbackMessage },
+    500,
+  );
+}

--- a/mcpjam-inspector/server/routes/mcp/widget-session.ts
+++ b/mcpjam-inspector/server/routes/mcp/widget-session.ts
@@ -115,7 +115,10 @@ function parseBrowserAction(
   }
   if (a.scrollAmount !== undefined && a.scrollAmount !== null) {
     if (!isFiniteNumber(a.scrollAmount) || a.scrollAmount <= 0) {
-      return { ok: false, error: "scrollAmount must be a number greater than 0" };
+      return {
+        ok: false,
+        error: "scrollAmount must be a number greater than 0",
+      };
     }
     spec.scrollAmount = a.scrollAmount;
   }
@@ -256,8 +259,9 @@ widgetSession.post("/", async (c) => {
 widgetSession.get("/:id/snapshot", async (c) => {
   const sessionId = c.req.param("id");
   try {
-    const { snapshot, expiresAt } =
-      await widgetRenderSessions.captureSnapshot(sessionId);
+    const { snapshot, expiresAt } = await widgetRenderSessions.captureSnapshot(
+      sessionId,
+    );
     return c.json({ snapshot, expiresAt }, 200);
   } catch (error) {
     return widgetSessionErrorResponse(c, error, "Snapshot failed");
@@ -276,19 +280,49 @@ widgetSession.post("/:id/scripted-step", async (c) => {
   } catch {
     return c.json({ error: "Invalid JSON body" }, 400);
   }
-  const parsed = scriptedStepSchema.safeParse((body as { step?: unknown })?.step);
+  const parsed = scriptedStepSchema.safeParse(
+    (body as { step?: unknown })?.step,
+  );
   if (!parsed.success) {
     return c.json(
       {
         error: `step is invalid: ${parsed.error.issues
-          .map((issue) => `${issue.path.join(".") || "(root)"}: ${issue.message}`)
+          .map(
+            (issue) => `${issue.path.join(".") || "(root)"}: ${issue.message}`,
+          )
           .join("; ")}`,
       },
       400,
     );
   }
-  const prior = (body as { priorWidgetToolCalls?: unknown })
+  const priorInput = (body as { priorWidgetToolCalls?: unknown })
     ?.priorWidgetToolCalls;
+  // VALIDATED, not forwarded. A `widgetToolCalled` assertion reads `.name` off
+  // each entry, so `[null]` reached the harness as a TypeError and came back
+  // as a 200 with a failed step and an internal error message — a malformed
+  // request reported as a widget problem. The caller can only fix what we
+  // name, so this is a 400.
+  let prior: Array<{ name: string }> | undefined;
+  if (priorInput !== undefined) {
+    if (
+      !Array.isArray(priorInput) ||
+      !priorInput.every(
+        (entry) =>
+          entry !== null &&
+          typeof entry === "object" &&
+          typeof (entry as { name?: unknown }).name === "string",
+      )
+    ) {
+      return c.json(
+        {
+          error:
+            "priorWidgetToolCalls must be an array of objects with a string `name` — pass the widgetToolCalls from earlier steps.",
+        },
+        400,
+      );
+    }
+    prior = priorInput as Array<{ name: string }>;
+  }
 
   try {
     const { result, expiresAt } = await widgetRenderSessions.runScriptedStep(
@@ -297,7 +331,7 @@ widgetSession.post("/:id/scripted-step", async (c) => {
       // An `assert` step can check "the widget called tool X", which is only
       // answerable against the calls the CALLER has accumulated across steps —
       // the harness drains its buffer each step and cannot see the history.
-      Array.isArray(prior) ? (prior as never[]) : undefined,
+      prior as never[] | undefined,
     );
     return c.json(
       {

--- a/mcpjam-inspector/server/routes/v1/__tests__/agent-op-registry.test.ts
+++ b/mcpjam-inspector/server/routes/v1/__tests__/agent-op-registry.test.ts
@@ -1607,6 +1607,17 @@ describe("tier derives from operation.risk", () => {
         "the project may talk to your servers. That is a human decision the " +
         "agent should not even propose.",
     },
+    render_server_widget: {
+      tier: "gated",
+      reason:
+        "Destructive would derive excluded, but this is `call_server_tool` " +
+        "with a browser attached — and that op is gated, not excluded, " +
+        "because the argument preview turns the approval into a real " +
+        "decision. Excluding the render while gating the bare call would " +
+        "mean an agent may propose running a tool but not propose finding " +
+        "out whether its widget works, which is the weaker of the two " +
+        "capabilities.",
+    },
     start_conformance_run: {
       tier: "gated",
       reason:
@@ -1844,6 +1855,7 @@ const EXPECTED_PROMPT_NOTES = [
   "- `request_eval_run_judge` returns a pending receipt, not results. Read the grades from `get_eval_run`'s `judges.goalCompletion` once its `status` is `completed`; requesting again only spends again.",
   "- `connect_eval_check_repo` affects everyone who opens a pull request on that repository, and `outagePolicy: fail_closed` can block their merges. Ask which policy the user wants — never pick one for them — and check `list_eval_check_repos` first: a repository missing from `connectable` needs the MCPJam GitHub App installed on it, which no tool here can do.",
   "- `call_server_tool` runs a real tool on the user's MCP server, as them, with effects MCPJam cannot undo. Calling it PROPOSES the call; a person approves it. Read the tool's schema from `list_server_tools` first and pass exactly the arguments you mean — the arguments you send are shown to the approver and are what will run, so a placeholder is a lie they will act on. Never call a tool to 'test' or 'see what happens'.",
+  "- `render_server_widget` EXECUTES the tool and then mounts its widget in a browser. It is not a read: use it to find out whether an MCP App actually renders, what it logs, and what it was blocked from fetching — never to 'look at' a tool whose side effects you have not read.",
   "- Before planning anything that authors, launches or publishes, call `get_capabilities` for the project. Your tool list is identical for every caller, so it cannot tell you that this organization is not in the Swarms beta or that you are a member where the action needs an admin. The `can` block answers both. Finding out from a 403 means you have already told someone you were doing it.",
   "- A journey run produces `targets x sessionsPerTarget` conversations, and that total is what spends. Read `get_journey` before proposing a launch so the number in your proposal is the real one.",
   "- After a launch is approved, poll `get_journey_run`. It leaves `running` once every attempt has settled; `canceled` and `stale` are separate booleans, so a deliberate stop and a runner that went silent do not both read as failure.",

--- a/mcpjam-inspector/server/routes/v1/__tests__/sdk-coverage.test.ts
+++ b/mcpjam-inspector/server/routes/v1/__tests__/sdk-coverage.test.ts
@@ -303,6 +303,10 @@ const ROUTE_TO_SDK: Readonly<Record<string, string>> = {
   "delete /projects/{projectId}/environments/{environmentId}/scenario":
     "unpublishScenario",
 
+  // MCP App widget render
+  "post /projects/{projectId}/servers/{serverId}/widgets/render":
+    "renderServerWidget",
+
   // Agent Playground
   "post /chat-sessions/messages": "sendChatMessage",
   "get /chat-sessions/{sessionId}": "getChatSession",

--- a/mcpjam-inspector/server/routes/v1/__tests__/widgets.test.ts
+++ b/mcpjam-inspector/server/routes/v1/__tests__/widgets.test.ts
@@ -190,4 +190,36 @@ describe("POST /v1/projects/:projectId/servers/:serverId/widgets/render", () => 
     await post();
     expect(disposeMock).toHaveBeenCalledTimes(1);
   });
+
+  it("labels a re-encoded screenshot as JPEG, not PNG", async () => {
+    // The harness re-shoots as progressively lower-quality JPEG when the PNG
+    // is over its byte budget — the common path for photographic widgets — so
+    // a hardcoded image/png mislabels exactly the screenshots most likely to
+    // be re-encoded, and a client that trusts the type fails to render a
+    // perfectly good image. `/9j/` is base64 for JPEG's SOI marker.
+    renderWidgetMock.mockResolvedValue(
+      renderedResult({ screenshotBase64: "/9j/4AAQSkZJRg==" }),
+    );
+    const body = await (
+      await post({ toolName: "show_map", includeScreenshot: true })
+    ).json();
+    expect(body.screenshot.mimeType).toBe("image/jpeg");
+  });
+
+  it("gives up on a render that outruns the wall clock", async () => {
+    // The first cut set a timer that only logged, and `runV1ServerOp`'s
+    // timeoutMs bounds the MCP manager rather than the Playwright render — so
+    // a stuck widget held its request, its Chromium and its concurrency slot
+    // indefinitely, past the wall clock the module advertises.
+    vi.useFakeTimers();
+    try {
+      renderWidgetMock.mockImplementation(() => new Promise(() => {}) as never);
+      const pending = post();
+      await vi.advanceTimersByTimeAsync(46_000);
+      const response = await pending;
+      expect(response.status).toBe(504);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
 });

--- a/mcpjam-inspector/server/routes/v1/__tests__/widgets.test.ts
+++ b/mcpjam-inspector/server/routes/v1/__tests__/widgets.test.ts
@@ -1,0 +1,193 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { Hono } from "hono";
+
+/**
+ * `POST /v1/projects/:p/servers/:s/widgets/render`.
+ *
+ * The browser is stubbed at the render core, so this pins the ROUTE's
+ * decisions rather than Chromium's:
+ *
+ *   1. PAYLOAD DEFAULTS ARE REVERSED from the local Inspector route — snapshot
+ *      on, screenshot off. This endpoint's caller is usually a model, and a
+ *      base64 image it may not be able to see is the most expensive possible
+ *      way to say nothing. A regression here is invisible in a test that only
+ *      checks the status code and expensive in production.
+ *   2. A TOOL WITH NO WIDGET IS REFUSED, not reported as a successful render
+ *      of nothing.
+ *   3. THE HARNESS IS ALWAYS DISPOSED. A leaked Chromium is the failure that
+ *      takes a replica out.
+ *   4. BLOCKED REQUESTS SURVIVE a successful render: a widget that renders
+ *      while every fetch is blocked photographs perfectly and is broken.
+ */
+
+const { runEphemeralConnectionMock, renderWidgetMock, validateGuestTokenMock } =
+  vi.hoisted(() => ({
+    runEphemeralConnectionMock: vi.fn(),
+    renderWidgetMock: vi.fn(),
+    validateGuestTokenMock: vi.fn(),
+  }));
+
+vi.mock("../../../services/guest-token.js", () => ({
+  validateGuestTokenDetailedAsync: validateGuestTokenMock,
+}));
+
+vi.mock("../../web/auth.js", async () => {
+  const actual = await vi.importActual<typeof import("../../web/auth.js")>(
+    "../../web/auth.js",
+  );
+  return { ...actual, runEphemeralConnection: runEphemeralConnectionMock };
+});
+
+vi.mock("../../../utils/widget-render-core.js", async () => {
+  const actual = await vi.importActual<
+    typeof import("../../../utils/widget-render-core.js")
+  >("../../../utils/widget-render-core.js");
+  return { ...actual, renderWidgetForRequest: renderWidgetMock };
+});
+
+import v1Routes from "../index.js";
+
+function makeApp(): Hono {
+  const app = new Hono();
+  app.route("/api/v1", v1Routes);
+  return app;
+}
+
+const disposeMock = vi.fn().mockResolvedValue(undefined);
+
+/** A rendered observation with every diagnostic populated. */
+function renderedResult(overrides: Record<string, unknown> = {}) {
+  return {
+    observation: {
+      toolCallId: "tc_1",
+      toolName: "show_map",
+      serverId: "s1",
+      status: "rendered",
+      resourceUri: "ui://widget/map",
+      bridgeInitialized: true,
+      screenshotBase64: "aW1hZ2U=",
+      consoleErrors: ["TypeError: x is not a function"],
+      blockedRequests: ["https://cdn.example.com/tiles.js"],
+      elapsedMs: 120,
+      ts: Date.now(),
+      ...overrides,
+    },
+    snapshot: {
+      mode: "a11y",
+      tree: '- button "Zoom in"',
+      elements: [{ role: { role: "button", name: "Zoom in" } }],
+      capturedAt: 1,
+    },
+    harness: { dispose: disposeMock },
+  };
+}
+
+function post(body: Record<string, unknown> = { toolName: "show_map" }) {
+  return makeApp().request("/api/v1/projects/p1/servers/s1/widgets/render", {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      Authorization: "Bearer tok",
+    },
+    body: JSON.stringify(body),
+  });
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  validateGuestTokenMock.mockResolvedValue({ valid: false });
+  disposeMock.mockResolvedValue(undefined);
+  runEphemeralConnectionMock.mockImplementation(
+    async (
+      _c: unknown,
+      rawBody: Record<string, unknown>,
+      _schema: unknown,
+      coreFn: (m: unknown, b: unknown) => Promise<unknown>,
+    ) => coreFn({}, rawBody),
+  );
+});
+
+describe("POST /v1/projects/:projectId/servers/:serverId/widgets/render", () => {
+  it("returns the tree by default and withholds the screenshot", async () => {
+    renderWidgetMock.mockResolvedValue(renderedResult());
+    const response = await post();
+    const body = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(body.snapshot.elements).toEqual([
+      { role: { role: "button", name: "Zoom in" } },
+    ]);
+    // The screenshot EXISTS on the observation and is deliberately not
+    // returned: the caller did not ask, and it is the largest field here.
+    expect(body.screenshot).toBeUndefined();
+    expect(renderWidgetMock.mock.calls[0]![0]).toMatchObject({
+      captureSnapshot: true,
+      keepMounted: false,
+    });
+  });
+
+  it("returns the screenshot only when asked", async () => {
+    renderWidgetMock.mockResolvedValue(renderedResult());
+    const body = await (
+      await post({ toolName: "show_map", includeScreenshot: true })
+    ).json();
+    expect(body.screenshot).toEqual({
+      mimeType: "image/png",
+      base64: "aW1hZ2U=",
+    });
+  });
+
+  it("skips the snapshot when explicitly disabled", async () => {
+    renderWidgetMock.mockResolvedValue({
+      ...renderedResult(),
+      snapshot: undefined,
+    });
+    await post({ toolName: "show_map", includeSnapshot: false });
+    expect(renderWidgetMock.mock.calls[0]![0]).not.toHaveProperty(
+      "captureSnapshot",
+    );
+  });
+
+  it("keeps the console and network evidence on a SUCCESSFUL render", async () => {
+    renderWidgetMock.mockResolvedValue(renderedResult());
+    const body = await (await post()).json();
+    // A widget that renders while every fetch is blocked looks perfect in a
+    // screenshot. These two fields are how an agent finds that out.
+    expect(body.consoleErrors).toEqual(["TypeError: x is not a function"]);
+    expect(body.blockedRequests).toEqual(["https://cdn.example.com/tiles.js"]);
+  });
+
+  it("refuses a tool that declares no widget instead of reporting an empty render", async () => {
+    renderWidgetMock.mockResolvedValue({
+      observation: {
+        toolCallId: "tc_2",
+        toolName: "plain_tool",
+        serverId: "s1",
+        status: "no_ui_resource",
+        elapsedMs: 3,
+        ts: Date.now(),
+      },
+      harness: null,
+    });
+    const response = await post({ toolName: "plain_tool" });
+    expect(response.status).toBe(422);
+    expect((await response.json()).message).toMatch(/UI resource/);
+  });
+
+  it("disposes the harness even when the render is refused", async () => {
+    renderWidgetMock.mockResolvedValue(
+      renderedResult({ status: "browser_unavailable" }),
+    );
+    const response = await post();
+    expect(response.status).not.toBe(200);
+    // A leaked Chromium is the failure that takes a replica out, so teardown
+    // must not be conditional on the happy path.
+    expect(disposeMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("disposes the harness on the happy path too", async () => {
+    renderWidgetMock.mockResolvedValue(renderedResult());
+    await post();
+    expect(disposeMock).toHaveBeenCalledTimes(1);
+  });
+});

--- a/mcpjam-inspector/server/routes/v1/__tests__/widgets.test.ts
+++ b/mcpjam-inspector/server/routes/v1/__tests__/widgets.test.ts
@@ -97,13 +97,20 @@ beforeEach(() => {
   vi.clearAllMocks();
   validateGuestTokenMock.mockResolvedValue({ valid: false });
   disposeMock.mockResolvedValue(undefined);
+  // Faithful to the real `runEphemeralConnection`: it PARSES the body against
+  // the route's schema before calling the core. A mock that skipped that would
+  // make every validation test here a test of the mock — the route's own
+  // rejections would never run.
   runEphemeralConnectionMock.mockImplementation(
     async (
       _c: unknown,
       rawBody: Record<string, unknown>,
-      _schema: unknown,
+      schema: { parse: (value: unknown) => unknown },
       coreFn: (m: unknown, b: unknown) => Promise<unknown>,
-    ) => coreFn({}, rawBody),
+    ) => {
+      const { parseWithSchema } = await import("../../web/errors.js");
+      return coreFn({}, parseWithSchema(schema as never, rawBody));
+    },
   );
 });
 
@@ -204,6 +211,27 @@ describe("POST /v1/projects/:projectId/servers/:serverId/widgets/render", () => 
       await post({ toolName: "show_map", includeScreenshot: true })
     ).json();
     expect(body.screenshot.mimeType).toBe("image/jpeg");
+  });
+
+  it("rejects a malformed body without touching the renderer", async () => {
+    for (const body of [
+      { toolName: "" },
+      { toolName: "show_map", parameters: null },
+      { toolName: "show_map", viewport: { width: 0, height: 100 } },
+      { toolName: "show_map", viewport: { width: 99_999, height: 100 } },
+      {},
+    ]) {
+      const response = await post(body as Record<string, unknown>);
+      expect(response.status).toBe(400);
+    }
+    // Nothing invalid should ever reach a browser launch.
+    expect(renderWidgetMock).not.toHaveBeenCalled();
+  });
+
+  it("surfaces a renderer failure as a 5xx rather than a partial 200", async () => {
+    renderWidgetMock.mockRejectedValue(new Error("listTools exploded"));
+    const response = await post();
+    expect(response.status).toBeGreaterThanOrEqual(500);
   });
 
   it("gives up on a render that outruns the wall clock", async () => {

--- a/mcpjam-inspector/server/routes/v1/agent-op-registry.ts
+++ b/mcpjam-inspector/server/routes/v1/agent-op-registry.ts
@@ -36,6 +36,7 @@
  */
 import {
   callServerToolOperation,
+  renderServerWidgetOperation,
   getChatSessionOperation,
   getChatSessionTraceOperation,
   sendChatMessageOperation,
@@ -1649,6 +1650,31 @@ export const AGENT_OP_REGISTRY: readonly AgentOpEntry[] = [
     promptNotes: [
       "- `call_server_tool` runs a real tool on the user's MCP server, as them, with effects MCPJam cannot undo. Calling it PROPOSES the call; a person approves it. Read the tool's schema from `list_server_tools` first and pass exactly the arguments you mean — the arguments you send are shown to the approver and are what will run, so a placeholder is a lie they will act on. Never call a tool to 'test' or 'see what happens'.",
       UNTRUSTED_SERVER_CONTENT_NOTE,
+    ],
+  },
+
+  // Rendering a widget RUNS THE TOOL first — the browser is what happens
+  // afterwards. So it inherits `call_server_tool`'s approval exactly, with the
+  // same argument preview: an approver deciding whether to let a tool run
+  // needs to see which tool and with what.
+  {
+    operation: renderServerWidgetOperation,
+    tier: "gated",
+    proposal: {
+      describe: (input) => {
+        const toolName = named(input, "toolName") ?? "(unnamed tool)";
+        const server = named(input, "server");
+        const preview = previewToolCall(toolName, input.parameters);
+        return server
+          ? `Render the widget for ${preview} on ${server}`
+          : `Render the widget for ${preview}`;
+      },
+      buttonLabel: "Render it",
+      kind: "external",
+      confirmSeverity: "external",
+    },
+    promptNotes: [
+      "- `render_server_widget` EXECUTES the tool and then mounts its widget in a browser. It is not a read: use it to find out whether an MCP App actually renders, what it logs, and what it was blocked from fetching — never to 'look at' a tool whose side effects you have not read.",
     ],
   },
 

--- a/mcpjam-inspector/server/routes/v1/index.ts
+++ b/mcpjam-inspector/server/routes/v1/index.ts
@@ -44,6 +44,7 @@ import proposedActionsRoutes from "./proposed-actions.js";
 import oauth from "./oauth.js";
 import catalog from "./catalog.js";
 import chatSessions from "./chat-sessions.js";
+import widgets from "./widgets.js";
 import registry from "./registry.js";
 import organizations from "./organizations.js";
 import evalChecks from "./eval-checks.js";
@@ -182,6 +183,10 @@ v1.route("/", oauth);
 // allowlist entry is the exact-match `/^\/chat-sessions$/`, so no subpath
 // here matches it, and a turn spends hosted-model credits.
 v1.route("/", chatSessions);
+// Headless MCP App widget render. Guest-DENIED by default (no
+// GUEST_ALLOWED_V1_RULES entry) — it launches a browser and executes the
+// caller's tool. Its own per-replica Chromium cap lives in the module.
+v1.route("/", widgets);
 v1.route("/", catalog);
 // Registry — directory search/detail/sources (guest-allowed reads) plus
 // project-scoped card/connection reads and install/uninstall writes. Mounted

--- a/mcpjam-inspector/server/routes/v1/widgets.ts
+++ b/mcpjam-inspector/server/routes/v1/widgets.ts
@@ -1,0 +1,228 @@
+/**
+ * `POST /v1/projects/:projectId/servers/:serverId/widgets/render` — render an
+ * MCP App widget headlessly and describe what it produced.
+ *
+ * WHAT THIS IS FOR. A tool that returns a `ui://` resource is two products in
+ * one: the tool result a model reads, and the interface a person sees. Every
+ * other machine surface can inspect the first half. Nothing could inspect the
+ * second — an agent debugging its own MCP App could read the widget's HTML and
+ * had no way to learn whether it actually rendered, what it showed, or which
+ * tools it fired on mount.
+ *
+ * This calls the tool, mounts its widget in real headless Chromium running the
+ * production host bridge, and returns the render verdict plus the widget as an
+ * ACCESSIBILITY TREE with addressable elements.
+ *
+ * DEFAULTS ARE REVERSED FROM THE LOCAL ROUTE, and deliberately. The local
+ * `POST /api/mcp/widget-render` defaults to a screenshot because its caller is
+ * a person looking at pixels. This one defaults to a SNAPSHOT and omits the
+ * screenshot, because its caller is usually a model: a base64 PNG it may not
+ * even be able to see is the most expensive possible way to say nothing, and
+ * a text tree is both cheaper and directly actionable.
+ *
+ * STATELESS BY CONSTRUCTION. Connect, call, render, read, dispose — all inside
+ * one request. That is what makes it safe on the hosted plane, which has no
+ * session affinity: the interactive session registry (`/api/mcp/widget-session`)
+ * keeps a live Chromium and a live manager in module scope, so a follow-up
+ * request would land on a replica that has never heard of the session. Making
+ * interactive sessions work there needs a dedicated single-replica renderer
+ * service, not a route.
+ *
+ * CHROMIUM IS THE SCARCE RESOURCE. Each render launches a browser, so the route
+ * carries its own concurrency cap. It is deliberately NOT the eval runner's:
+ * that semaphore is module-private to `evals-runner.ts` and bounds a different
+ * workload (a long fan-out) on a different budget. Sharing one number between
+ * an interactive request and a batch job would let either starve the other.
+ */
+import { Hono } from "hono";
+import { z } from "zod";
+import { HOSTED_MODE } from "../../config.js";
+import { ErrorCode, WebRouteError } from "../web/errors.js";
+import { renderWidgetForRequest } from "../../utils/widget-render-core.js";
+import { CHROMIUM_INSTALL_HINT } from "../../utils/widget-render-core.js";
+import { logger } from "../../utils/logger.js";
+import { runV1ServerOp } from "./adapter.js";
+import { v1Resource } from "./envelope.js";
+
+const widgets = new Hono();
+
+/**
+ * Concurrent renders per replica.
+ *
+ * Each one holds a Chromium context for the length of a page load, so this is
+ * a memory ceiling as much as a fairness one. Four matches the render budget
+ * the eval runner settled on for the same hardware.
+ */
+const MAX_CONCURRENT_RENDERS = (() => {
+  const raw = Number(process.env.MCPJAM_MAX_CONCURRENT_WIDGET_RENDERS);
+  return Number.isFinite(raw) && raw >= 1 ? Math.floor(raw) : 4;
+})();
+
+/**
+ * Wall clock for one render.
+ *
+ * Shorter than a chat turn because there is no model in the loop: connect,
+ * one tool call, one page load. A widget that has not painted in this long is
+ * a finding, not a reason to hold the request open.
+ */
+const RENDER_WALL_CLOCK_MS = 45_000;
+
+let activeRenders = 0;
+
+const renderSchema = z
+  .object({
+    // Injected by `synthesizeServerBody` from the path — declared so the
+    // schema accepts the synthesized body, not because a caller sends them.
+    projectId: z.string().min(1),
+    serverId: z.string().min(1),
+    toolName: z.string().min(1),
+    parameters: z.record(z.string(), z.unknown()).optional(),
+    /**
+     * The widget as a text tree. DEFAULT ON — see the module docblock.
+     */
+    includeSnapshot: z.boolean().optional(),
+    /**
+     * A base64 PNG/JPEG of the rendered widget. DEFAULT OFF: it is by far the
+     * largest field this endpoint can return, and a caller that cannot see
+     * images pays for it anyway.
+     */
+    includeScreenshot: z.boolean().optional(),
+    /**
+     * Mount with the OpenAI Apps compatibility shims instead of the plain
+     * MCP-UI bridge — what to pass when the widget is being validated against
+     * ChatGPT's host rather than a spec-default one.
+     */
+    injectOpenAiCompat: z.boolean().optional(),
+    viewport: z
+      .object({
+        width: z.number().int().min(1).max(8192),
+        height: z.number().int().min(1).max(8192),
+      })
+      .optional(),
+  })
+  // NOT `.strict()`: `synthesizeServerBody` merges the path params in, and a
+  // strict schema laid over a synthesized body rejects the very fields this
+  // module injected. The named fields above are the contract; the OpenAPI
+  // entry documents them as the whole of it.
+  .describe("Widget render request");
+
+widgets.post(
+  "/projects/:projectId/servers/:serverId/widgets/render",
+  async (c) =>
+    runV1ServerOp(
+      c,
+      renderSchema,
+      async (manager, body) => {
+        if (activeRenders >= MAX_CONCURRENT_RENDERS) {
+          throw new WebRouteError(
+            429,
+            ErrorCode.RATE_LIMITED,
+            `Too many widget renders in flight (max ${MAX_CONCURRENT_RENDERS}). Retry shortly.`,
+          );
+        }
+        activeRenders += 1;
+        const startedAt = Date.now();
+        // The wall clock guards the RENDER, which is the unbounded part: a
+        // widget that fetches from a slow CDN can sit in load forever, and the
+        // harness's own per-phase timeouts do not compose into a request-level
+        // ceiling.
+        const timeout = setTimeout(() => {
+          logger.warn("[v1/widgets] render exceeded its wall clock", {
+            toolName: body.toolName,
+          });
+        }, RENDER_WALL_CLOCK_MS);
+
+        let result:
+          | Awaited<ReturnType<typeof renderWidgetForRequest>>
+          | undefined;
+        try {
+          result = await renderWidgetForRequest({
+            mcpClientManager: manager,
+            serverId: body.serverId,
+            toolName: body.toolName,
+            parameters: body.parameters ?? {},
+            injectOpenAiCompat: body.injectOpenAiCompat === true,
+            ...(body.viewport ? { viewport: body.viewport } : {}),
+            keepMounted: false,
+            // D12: snapshot by default, screenshot on request.
+            ...(body.includeSnapshot === false
+              ? {}
+              : { captureSnapshot: true }),
+          });
+
+          const observation = result.observation;
+          if (observation.status === "no_ui_resource") {
+            throw new WebRouteError(
+              422,
+              ErrorCode.FEATURE_NOT_SUPPORTED,
+              `Tool "${body.toolName}" does not declare an MCP App UI resource, so there is no widget to render.`,
+            );
+          }
+          if (observation.status === "browser_unavailable") {
+            throw new WebRouteError(
+              // The deployment cannot do this, which is a capability fact
+              // about us — not the caller's input and not the server's fault.
+              503 as never,
+              ErrorCode.FEATURE_NOT_SUPPORTED,
+              `Headless Chromium is unavailable on this deployment (${CHROMIUM_INSTALL_HINT}).`,
+            );
+          }
+
+          return {
+            status: observation.status,
+            ...(observation.resourceUri
+              ? { resourceUri: observation.resourceUri }
+              : {}),
+            ...(observation.bridgeInitialized !== undefined
+              ? { bridgeInitialized: observation.bridgeInitialized }
+              : {}),
+            // The evidence an agent debugging a widget is actually after: what
+            // the page logged, and what it was blocked from reaching. A widget
+            // that "renders" while every fetch is blocked looks fine in a
+            // screenshot and is broken.
+            ...(observation.consoleErrors?.length
+              ? { consoleErrors: observation.consoleErrors }
+              : {}),
+            ...(observation.blockedRequests?.length
+              ? { blockedRequests: observation.blockedRequests }
+              : {}),
+            ...(result.snapshot ? { snapshot: result.snapshot } : {}),
+            ...(body.includeScreenshot === true && observation.screenshotBase64
+              ? {
+                  screenshot: {
+                    mimeType: "image/png",
+                    base64: observation.screenshotBase64,
+                  },
+                }
+              : {}),
+            timings: {
+              renderMs: observation.elapsedMs,
+              totalMs: Date.now() - startedAt,
+            },
+          };
+        } finally {
+          clearTimeout(timeout);
+          activeRenders -= 1;
+          // Always tear the browser down. Detached but observably so — a
+          // leaked Chromium is the failure mode that takes a replica out, and
+          // it must never be silent.
+          void result?.harness?.dispose().catch((error) => {
+            logger.warn("[v1/widgets] harness disposal failed", {
+              error: error instanceof Error ? error.message : String(error),
+            });
+          });
+        }
+      },
+      (ctx, result) => v1Resource(ctx, result),
+      { timeoutMs: RENDER_WALL_CLOCK_MS },
+    ),
+);
+
+export default widgets;
+
+/** Exported for the route test, which must not reach into module state. */
+export const __testing = {
+  MAX_CONCURRENT_RENDERS,
+  renderSchema,
+  isHosted: () => HOSTED_MODE,
+};

--- a/mcpjam-inspector/server/routes/v1/widgets.ts
+++ b/mcpjam-inspector/server/routes/v1/widgets.ts
@@ -41,6 +41,7 @@ import { ErrorCode, WebRouteError } from "../web/errors.js";
 import { renderWidgetForRequest } from "../../utils/widget-render-core.js";
 import { CHROMIUM_INSTALL_HINT } from "../../utils/widget-render-core.js";
 import { logger } from "../../utils/logger.js";
+import { reportRouteFailure } from "../../utils/route-error-report.js";
 import { runV1ServerOp } from "./adapter.js";
 import { v1Resource } from "./envelope.js";
 
@@ -173,35 +174,69 @@ widgets.post(
         activeRenders += 1;
         const startedAt = Date.now();
 
-        let result:
-          | Awaited<ReturnType<typeof renderWidgetForRequest>>
-          | undefined;
+        // TEARDOWN IS CHAINED TO THE RENDER, NOT TO THE RACE, and that is the
+        // whole point of this shape.
+        //
+        // The previous revision assigned `result` only after `raceDeadline`
+        // resolved, so on a timeout `result` stayed `undefined` and the
+        // cleanup's `result?.harness?.dispose()` was a no-op — while the
+        // orphaned render kept its Chromium alive and the slot was freed
+        // anyway. Repeated timeouts would then exhaust the replica: exactly
+        // the stuck-widget case the deadline exists to bound, made worse by
+        // the deadline.
+        //
+        // So the render promise is held separately and disposal hangs off IT.
+        // A render that loses the race keeps running (the core takes no abort
+        // signal), and whenever it eventually settles its harness is disposed
+        // and only then is the slot released.
+        const renderPromise = renderWidgetForRequest({
+          mcpClientManager: manager,
+          serverId: body.serverId,
+          toolName: body.toolName,
+          parameters: body.parameters ?? {},
+          injectOpenAiCompat: body.injectOpenAiCompat === true,
+          ...(body.viewport ? { viewport: body.viewport } : {}),
+          keepMounted: false,
+          // D12: snapshot by default, screenshot on request.
+          ...(body.includeSnapshot === false ? {} : { captureSnapshot: true }),
+        });
+
+        const teardown = renderPromise
+          .then(
+            (rendered) => rendered.harness?.dispose(),
+            // A render that REJECTED never produced a harness to dispose.
+            // Swallowed here because the awaiting caller below reports it;
+            // rethrowing would surface an unhandled rejection on the timeout
+            // path, where nobody is awaiting this chain.
+            () => undefined,
+          )
+          .catch((error: unknown) => {
+            // A leaked Chromium is the failure that takes a replica out, so
+            // this pages rather than only landing in Axiom: `logger.warn` is
+            // deliberately Sentry-free, and per AGENTS.md a route catch-site
+            // reports through `reportRouteFailure` so the origin policy makes
+            // the capture decision.
+            reportRouteFailure(
+              "[v1.widgets] headless browser disposal failed",
+              error,
+              {
+                source: "v1.widgets.render.dispose",
+                hop: "mcpjam_internal",
+                context: { toolName: body.toolName },
+              },
+            );
+          })
+          .finally(() => {
+            // Released only once the browser is actually gone. Decrementing
+            // any earlier would let the next request launch a browser while
+            // this one still existed, which is not a ceiling.
+            activeRenders -= 1;
+          });
+
+        let result: Awaited<ReturnType<typeof renderWidgetForRequest>>;
         try {
-          // A REAL deadline, not a log line. The first cut set a timer that
-          // only warned, and `runV1ServerOp`'s `timeoutMs` configures the
-          // ephemeral MCP manager rather than the Playwright render that
-          // follows it — so a widget stuck loading from a slow CDN held its
-          // request, its Chromium, and its concurrency slot indefinitely,
-          // past the wall clock the module advertises.
-          //
-          // The loser of this race is not cancelled (the render core takes no
-          // abort signal), but the `finally` disposes the harness, which is
-          // what actually kills the browser and frees the slot. So the
-          // resources are bounded even though the promise may dangle.
           result = await raceDeadline(
-            renderWidgetForRequest({
-              mcpClientManager: manager,
-              serverId: body.serverId,
-              toolName: body.toolName,
-              parameters: body.parameters ?? {},
-              injectOpenAiCompat: body.injectOpenAiCompat === true,
-              ...(body.viewport ? { viewport: body.viewport } : {}),
-              keepMounted: false,
-              // D12: snapshot by default, screenshot on request.
-              ...(body.includeSnapshot === false
-                ? {}
-                : { captureSnapshot: true }),
-            }),
+            renderPromise,
             RENDER_WALL_CLOCK_MS,
             body.toolName,
           );
@@ -271,27 +306,11 @@ widgets.post(
             },
           };
         } finally {
-          // THE SLOT IS HELD UNTIL THE BROWSER IS ACTUALLY GONE. Decrementing
-          // before a detached `dispose()` settles would let the next request
-          // launch a browser while every previous context still existed —
-          // which defeats the per-replica ceiling this counter exists to be,
-          // and accumulates Chromium processes until the replica dies.
-          //
-          // Still detached from the RESPONSE: the caller is not made to wait
-          // for teardown, only the next render is.
-          void (async () => {
-            try {
-              await result?.harness?.dispose();
-            } catch (error) {
-              // A leaked Chromium is the failure mode that takes a replica
-              // out; it must never be silent.
-              logger.warn("[v1/widgets] harness disposal failed", {
-                error: error instanceof Error ? error.message : String(error),
-              });
-            } finally {
-              activeRenders -= 1;
-            }
-          })();
+          // Nothing to do here: `teardown` was scheduled the moment the render
+          // started and runs on every path, including the one where this
+          // function threw before `result` existed. Referenced so the chain is
+          // visibly intentional rather than looking like a floating promise.
+          void teardown;
         }
       },
       (ctx, result) => v1Resource(ctx, result),

--- a/mcpjam-inspector/server/routes/v1/widgets.ts
+++ b/mcpjam-inspector/server/routes/v1/widgets.ts
@@ -47,6 +47,56 @@ import { v1Resource } from "./envelope.js";
 const widgets = new Hono();
 
 /**
+ * Resolve `work`, or reject once `ms` have passed.
+ *
+ * The loser is NOT cancelled — the render core takes no abort signal — so this
+ * bounds the REQUEST, and the caller's `finally` (disposing the harness) is
+ * what bounds the browser. Both are needed: without the race a stuck widget
+ * holds the request forever; without the disposal it holds Chromium forever.
+ */
+async function raceDeadline<T>(
+  work: Promise<T>,
+  ms: number,
+  toolName: string,
+): Promise<T> {
+  let timer: ReturnType<typeof setTimeout> | undefined;
+  try {
+    return await Promise.race([
+      work,
+      new Promise<never>((_resolve, reject) => {
+        timer = setTimeout(() => {
+          logger.warn("[v1/widgets] render exceeded its wall clock", {
+            toolName,
+          });
+          reject(
+            new WebRouteError(
+              504,
+              ErrorCode.TIMEOUT,
+              `Rendering "${toolName}" exceeded the ${ms / 1000}s limit.`,
+            ),
+          );
+        }, ms);
+      }),
+    ]);
+  } finally {
+    if (timer) clearTimeout(timer);
+  }
+}
+
+/**
+ * Read an image's type from its own first bytes.
+ *
+ * Only PNG and JPEG are possible here (the harness shoots one or the other),
+ * and an unrecognised prefix falls back to PNG — the harness's default and the
+ * only other thing it emits.
+ */
+function detectImageMimeType(base64: string): string {
+  // `/9j/` is the base64 prefix of JPEG's SOI marker; `iVBORw0KG` is PNG's.
+  if (base64.startsWith("/9j/")) return "image/jpeg";
+  return "image/png";
+}
+
+/**
  * Concurrent renders per replica.
  *
  * Each one holds a Chromium context for the length of a page load, so this is
@@ -122,33 +172,39 @@ widgets.post(
         }
         activeRenders += 1;
         const startedAt = Date.now();
-        // The wall clock guards the RENDER, which is the unbounded part: a
-        // widget that fetches from a slow CDN can sit in load forever, and the
-        // harness's own per-phase timeouts do not compose into a request-level
-        // ceiling.
-        const timeout = setTimeout(() => {
-          logger.warn("[v1/widgets] render exceeded its wall clock", {
-            toolName: body.toolName,
-          });
-        }, RENDER_WALL_CLOCK_MS);
 
         let result:
           | Awaited<ReturnType<typeof renderWidgetForRequest>>
           | undefined;
         try {
-          result = await renderWidgetForRequest({
-            mcpClientManager: manager,
-            serverId: body.serverId,
-            toolName: body.toolName,
-            parameters: body.parameters ?? {},
-            injectOpenAiCompat: body.injectOpenAiCompat === true,
-            ...(body.viewport ? { viewport: body.viewport } : {}),
-            keepMounted: false,
-            // D12: snapshot by default, screenshot on request.
-            ...(body.includeSnapshot === false
-              ? {}
-              : { captureSnapshot: true }),
-          });
+          // A REAL deadline, not a log line. The first cut set a timer that
+          // only warned, and `runV1ServerOp`'s `timeoutMs` configures the
+          // ephemeral MCP manager rather than the Playwright render that
+          // follows it — so a widget stuck loading from a slow CDN held its
+          // request, its Chromium, and its concurrency slot indefinitely,
+          // past the wall clock the module advertises.
+          //
+          // The loser of this race is not cancelled (the render core takes no
+          // abort signal), but the `finally` disposes the harness, which is
+          // what actually kills the browser and frees the slot. So the
+          // resources are bounded even though the promise may dangle.
+          result = await raceDeadline(
+            renderWidgetForRequest({
+              mcpClientManager: manager,
+              serverId: body.serverId,
+              toolName: body.toolName,
+              parameters: body.parameters ?? {},
+              injectOpenAiCompat: body.injectOpenAiCompat === true,
+              ...(body.viewport ? { viewport: body.viewport } : {}),
+              keepMounted: false,
+              // D12: snapshot by default, screenshot on request.
+              ...(body.includeSnapshot === false
+                ? {}
+                : { captureSnapshot: true }),
+            }),
+            RENDER_WALL_CLOCK_MS,
+            body.toolName,
+          );
 
           const observation = result.observation;
           if (observation.status === "no_ui_resource") {
@@ -160,9 +216,16 @@ widgets.post(
           }
           if (observation.status === "browser_unavailable") {
             throw new WebRouteError(
-              // The deployment cannot do this, which is a capability fact
-              // about us — not the caller's input and not the server's fault.
-              503 as never,
+              // 422, and the status argument is NOT what decides that:
+              // `v1OnError` derives the wire status from the public CODE
+              // (`V1_ERROR_STATUS`), so the earlier `503 as never` cast here
+              // was decoration that changed nothing while implying it did.
+              //
+              // 422 is also the honest answer. The public union has no 503,
+              // and "this deployment does not have a browser" is a standing
+              // capability fact rather than a transient outage — a caller
+              // should stop asking, not back off and retry.
+              422,
               ErrorCode.FEATURE_NOT_SUPPORTED,
               `Headless Chromium is unavailable on this deployment (${CHROMIUM_INSTALL_HINT}).`,
             );
@@ -190,7 +253,14 @@ widgets.post(
             ...(body.includeScreenshot === true && observation.screenshotBase64
               ? {
                   screenshot: {
-                    mimeType: "image/png",
+                    // DETECTED, not assumed. The harness re-shoots as
+                    // progressively lower-quality JPEG when the PNG is over
+                    // its byte budget — the common path for photographic or
+                    // complex widgets — so a hardcoded `image/png` mislabels
+                    // exactly the screenshots most likely to be re-encoded,
+                    // and a client that trusts the type fails to render a
+                    // perfectly good image.
+                    mimeType: detectImageMimeType(observation.screenshotBase64),
                     base64: observation.screenshotBase64,
                   },
                 }
@@ -201,16 +271,27 @@ widgets.post(
             },
           };
         } finally {
-          clearTimeout(timeout);
-          activeRenders -= 1;
-          // Always tear the browser down. Detached but observably so — a
-          // leaked Chromium is the failure mode that takes a replica out, and
-          // it must never be silent.
-          void result?.harness?.dispose().catch((error) => {
-            logger.warn("[v1/widgets] harness disposal failed", {
-              error: error instanceof Error ? error.message : String(error),
-            });
-          });
+          // THE SLOT IS HELD UNTIL THE BROWSER IS ACTUALLY GONE. Decrementing
+          // before a detached `dispose()` settles would let the next request
+          // launch a browser while every previous context still existed —
+          // which defeats the per-replica ceiling this counter exists to be,
+          // and accumulates Chromium processes until the replica dies.
+          //
+          // Still detached from the RESPONSE: the caller is not made to wait
+          // for teardown, only the next render is.
+          void (async () => {
+            try {
+              await result?.harness?.dispose();
+            } catch (error) {
+              // A leaked Chromium is the failure mode that takes a replica
+              // out; it must never be silent.
+              logger.warn("[v1/widgets] harness disposal failed", {
+                error: error instanceof Error ? error.message : String(error),
+              });
+            } finally {
+              activeRenders -= 1;
+            }
+          })();
         }
       },
       (ctx, result) => v1Resource(ctx, result),

--- a/mcpjam-inspector/server/services/widget-render-session.ts
+++ b/mcpjam-inspector/server/services/widget-render-session.ts
@@ -22,14 +22,21 @@ import type {
   BrowserActionResult,
   BrowserActionSpec,
   McpAppBrowserHarness,
+  ScriptedStepResult,
+  WidgetSnapshot,
+  WidgetToolCall,
 } from "../utils/mcp-app-browser-harness";
+import type { ScriptedStep } from "@/shared/scripted-steps";
 import { logger } from "../utils/logger";
 
 /** The harness surface the registry drives. A real McpAppBrowserHarness
  *  satisfies it; tests pass a fake. */
 export type SessionHarness = Pick<
   McpAppBrowserHarness,
-  "executeAction" | "dispose"
+  // `captureSnapshot` and `runScriptedStep` join the Pick so a text-only
+  // caller can drive a widget at all: `executeAction` alone is coordinate-based
+  // and silently assumes the caller can see pixels.
+  "executeAction" | "captureSnapshot" | "runScriptedStep" | "dispose"
 >;
 
 /** Public (serializable) view of a session — never exposes the harness. */
@@ -288,13 +295,7 @@ export class WidgetRenderSessionRegistry {
     sessionId: string,
     action: BrowserActionSpec,
   ): Promise<{ result: BrowserActionResult; expiresAt: number }> {
-    const session = this.sessions.get(sessionId);
-    if (!session || this.isIdleExpired(session)) {
-      if (session) void this.disposeSession(sessionId, "idle");
-      throw new WidgetSessionNotFoundError(
-        `Widget session "${sessionId}" not found or expired.`,
-      );
-    }
+    const session = this.requireLiveSession(sessionId);
     // The harness is a single page — overlapping actions would interleave input
     // and corrupt the result. Serialize by rejecting while one is in flight.
     if (session.inFlight > 0) {
@@ -334,6 +335,101 @@ export class WidgetRenderSessionRegistry {
     } finally {
       session.inFlight -= 1;
     }
+  }
+
+  /**
+   * Capture a text view of the session's mounted widget.
+   *
+   * REFRESHES the TTL but does not take the in-flight lock: a snapshot only
+   * reads, so two concurrent snapshots cannot interleave input the way two
+   * actions would. It is still refused while an ACTION is in flight — reading
+   * the tree halfway through a click would describe a state that never existed
+   * as far as the caller is concerned.
+   */
+  async captureSnapshot(
+    sessionId: string,
+  ): Promise<{ snapshot: WidgetSnapshot; expiresAt: number }> {
+    const session = this.requireLiveSession(sessionId);
+    if (session.inFlight > 0) {
+      throw new WidgetSessionBusyError(
+        `Widget session "${sessionId}" is already running an action.`,
+      );
+    }
+    const snapshot = await session.harness.captureSnapshot(
+      session.mountedWidgetId,
+    );
+    if (this.sessions.get(sessionId) !== session) {
+      throw new WidgetSessionNotFoundError(
+        `Widget session "${sessionId}" was closed during the snapshot.`,
+      );
+    }
+    session.expiresAt = this.now() + this.idleTimeoutMs;
+    return { snapshot, expiresAt: session.expiresAt };
+  }
+
+  /**
+   * Replay one SEMANTIC step (`click`/`type`/`assert`/…) against the mounted
+   * widget.
+   *
+   * The sibling of `executeAction`, and the one a text-only caller can
+   * actually use: it targets by role/name/testId — the same vocabulary
+   * `captureSnapshot` hands back — instead of by pixel coordinate. Serialized
+   * against actions for the same reason actions are serialized against each
+   * other: one page, one input stream.
+   */
+  async runScriptedStep(
+    sessionId: string,
+    step: ScriptedStep,
+    priorWidgetToolCalls?: WidgetToolCall[],
+  ): Promise<{ result: ScriptedStepResult; expiresAt: number }> {
+    const session = this.requireLiveSession(sessionId);
+    if (session.inFlight > 0) {
+      throw new WidgetSessionBusyError(
+        `Widget session "${sessionId}" is already running an action.`,
+      );
+    }
+    session.inFlight += 1;
+    try {
+      const result = await session.harness.runScriptedStep({
+        toolCallId: session.mountedWidgetId,
+        step,
+        ...(priorWidgetToolCalls ? { priorWidgetToolCalls } : {}),
+      });
+      if (this.sessions.get(sessionId) !== session) {
+        throw new WidgetSessionNotFoundError(
+          `Widget session "${sessionId}" was closed during the step.`,
+        );
+      }
+      // Same terminal-note handling as `executeAction`: a widget that is gone
+      // has nothing left to step, and a client retrying against it would hold
+      // Chromium indefinitely.
+      if (result.note && TERMINAL_ACTION_NOTES.has(result.note)) {
+        void this.disposeSession(sessionId, "terminal");
+        return { result, expiresAt: session.expiresAt };
+      }
+      session.expiresAt = this.now() + this.idleTimeoutMs;
+      return { result, expiresAt: session.expiresAt };
+    } finally {
+      session.inFlight -= 1;
+    }
+  }
+
+  /**
+   * Resolve a live session or throw, disposing one that expired while idle.
+   *
+   * Extracted so the three entry points cannot drift on WHEN a session counts
+   * as gone — the check that sweeps an idle session is the same check that
+   * refuses to act on it.
+   */
+  private requireLiveSession(sessionId: string): RegisteredSession {
+    const session = this.sessions.get(sessionId);
+    if (!session || this.isIdleExpired(session)) {
+      if (session) void this.disposeSession(sessionId, "idle");
+      throw new WidgetSessionNotFoundError(
+        `Widget session "${sessionId}" not found or expired.`,
+      );
+    }
+    return session;
   }
 
   /** Dispose + remove a session. Returns false if it didn't exist. */

--- a/mcpjam-inspector/server/services/widget-render-session.ts
+++ b/mcpjam-inspector/server/services/widget-render-session.ts
@@ -340,11 +340,17 @@ export class WidgetRenderSessionRegistry {
   /**
    * Capture a text view of the session's mounted widget.
    *
-   * REFRESHES the TTL but does not take the in-flight lock: a snapshot only
-   * reads, so two concurrent snapshots cannot interleave input the way two
-   * actions would. It is still refused while an ACTION is in flight — reading
-   * the tree halfway through a click would describe a state that never existed
-   * as far as the caller is concerned.
+   * TAKES THE IN-FLIGHT LOCK for the whole capture, exactly as the action
+   * paths do. Checking `inFlight` and then not claiming it looked safe — a
+   * snapshot only reads — and was not: an action arriving after the check
+   * still saw `inFlight === 0` and drove the same page, so the tree and the
+   * element enrichment could describe two different DOM states. Worse, an
+   * unmarked capture is not protected from the idle sweep, which could dispose
+   * the page mid-read.
+   *
+   * It does NOT consume the widget's step budget. Looking is not acting, and a
+   * caller forced to spend interaction steps on looking would interact blind
+   * to save them.
    */
   async captureSnapshot(
     sessionId: string,
@@ -355,16 +361,21 @@ export class WidgetRenderSessionRegistry {
         `Widget session "${sessionId}" is already running an action.`,
       );
     }
-    const snapshot = await session.harness.captureSnapshot(
-      session.mountedWidgetId,
-    );
-    if (this.sessions.get(sessionId) !== session) {
-      throw new WidgetSessionNotFoundError(
-        `Widget session "${sessionId}" was closed during the snapshot.`,
+    session.inFlight += 1;
+    try {
+      const snapshot = await session.harness.captureSnapshot(
+        session.mountedWidgetId,
       );
+      if (this.sessions.get(sessionId) !== session) {
+        throw new WidgetSessionNotFoundError(
+          `Widget session "${sessionId}" was closed during the snapshot.`,
+        );
+      }
+      session.expiresAt = this.now() + this.idleTimeoutMs;
+      return { snapshot, expiresAt: session.expiresAt };
+    } finally {
+      session.inFlight -= 1;
     }
-    session.expiresAt = this.now() + this.idleTimeoutMs;
-    return { snapshot, expiresAt: session.expiresAt };
   }
 
   /**

--- a/mcpjam-inspector/server/utils/__tests__/widget-snapshot-elements.test.ts
+++ b/mcpjam-inspector/server/utils/__tests__/widget-snapshot-elements.test.ts
@@ -1,0 +1,64 @@
+import { describe, expect, it } from "vitest";
+import { parseSnapshotElements } from "../mcp-app-browser-harness";
+
+/**
+ * Snapshot targets are parsed OUT OF the ARIA tree rather than read off DOM
+ * attributes, and that is the whole correctness story.
+ *
+ * The first implementation used `aria-label` with an `innerText` fallback,
+ * which is absent or empty for most real controls — a `<label for>`, an
+ * `aria-labelledby`, an image's `alt`, a button's `title`. Those came back
+ * role-only and ambiguous while the tree printed directly beside them showed
+ * the name perfectly well. The snapshot contradicted itself, and the
+ * read-a-control-and-post-it-back workflow it exists for broke on exactly the
+ * widgets people build.
+ */
+describe("parseSnapshotElements", () => {
+  it("reads the computed accessible name the tree already carries", () => {
+    // None of these would have an `aria-label`; all of them have a name here.
+    const tree = [
+      '- button "Submit"',
+      '  - textbox "Email address"',
+      '- link "Docs" [ref=e3]',
+    ].join("\n");
+    expect(parseSnapshotElements(tree)).toEqual([
+      { role: { role: "button", name: "Submit" } },
+      { role: { role: "textbox", name: "Email address" } },
+      { role: { role: "link", name: "Docs" } },
+    ]);
+  });
+
+  it("lists only roles a step can act on", () => {
+    // A target the caller cannot use is noise they still pay tokens for.
+    const tree = [
+      '- heading "Checkout"',
+      '- paragraph "Enter your details"',
+      '- button "Pay"',
+    ].join("\n");
+    expect(parseSnapshotElements(tree)).toEqual([
+      { role: { role: "button", name: "Pay" } },
+    ]);
+  });
+
+  it("flags EVERY occurrence of a duplicated (role, name), including the first", () => {
+    // Only the second sighting proves the collision, but the caller needs to
+    // know before using either one — otherwise they discover it when the step
+    // fails on a strict-mode violation.
+    const tree = ['- button "Delete"', '- button "Delete"'].join("\n");
+    const parsed = parseSnapshotElements(tree);
+    expect(parsed).toHaveLength(2);
+    expect(parsed.every((entry) => entry.ambiguous === true)).toBe(true);
+  });
+
+  it("keeps an unnamed control addressable by role alone", () => {
+    expect(parseSnapshotElements("- textbox")).toEqual([
+      { role: { role: "textbox" } },
+    ]);
+  });
+
+  it("unescapes a quoted name", () => {
+    expect(parseSnapshotElements(String.raw`- button "Say \"hi\""`)).toEqual([
+      { role: { role: "button", name: 'Say "hi"' } },
+    ]);
+  });
+});

--- a/mcpjam-inspector/server/utils/__tests__/widget-snapshot-elements.test.ts
+++ b/mcpjam-inspector/server/utils/__tests__/widget-snapshot-elements.test.ts
@@ -22,10 +22,22 @@ describe("parseSnapshotElements", () => {
       '- link "Docs" [ref=e3]',
     ].join("\n");
     expect(parseSnapshotElements(tree)).toEqual([
-      { role: { role: "button", name: "Submit" } },
-      { role: { role: "textbox", name: "Email address" } },
-      { role: { role: "link", name: "Docs" } },
+      { role: { role: "button", name: "Submit", exact: true } },
+      { role: { role: "textbox", name: "Email address", exact: true } },
+      { role: { role: "link", name: "Docs", exact: true } },
     ]);
+  });
+
+  it("emits EXACT targets so a name is not a substring match", () => {
+    // Playwright's getByRole name matching is substring and case-insensitive
+    // by default. Without `exact`, these two are unambiguous by name yet
+    // `{ name: "Save" }` matches both, and posting it back fails the step with
+    // a strict-mode violation — the target the snapshot handed you.
+    const parsed = parseSnapshotElements(
+      ['- button "Save"', '- button "Save as"'].join("\n"),
+    );
+    expect(parsed.every((entry) => entry.role?.exact === true)).toBe(true);
+    expect(parsed.every((entry) => entry.ambiguous)).toBeFalsy();
   });
 
   it("lists only roles a step can act on", () => {
@@ -36,18 +48,26 @@ describe("parseSnapshotElements", () => {
       '- button "Pay"',
     ].join("\n");
     expect(parseSnapshotElements(tree)).toEqual([
-      { role: { role: "button", name: "Pay" } },
+      { role: { role: "button", name: "Pay", exact: true } },
     ]);
   });
 
-  it("flags EVERY occurrence of a duplicated (role, name), including the first", () => {
+  it("flags EVERY occurrence of a duplicated (role, name) and numbers them", () => {
     // Only the second sighting proves the collision, but the caller needs to
     // know before using either one — otherwise they discover it when the step
-    // fails on a strict-mode violation.
+    // fails on a strict-mode violation. `nth` ships with the flag so the
+    // target is disambiguable in the same object.
     const tree = ['- button "Delete"', '- button "Delete"'].join("\n");
     const parsed = parseSnapshotElements(tree);
     expect(parsed).toHaveLength(2);
     expect(parsed.every((entry) => entry.ambiguous === true)).toBe(true);
+    expect(parsed.map((entry) => entry.nth)).toEqual([0, 1]);
+  });
+
+  it("omits nth on a unique target", () => {
+    // `nth` on a unique match adds nothing and reads like a warning.
+    const parsed = parseSnapshotElements('- button "Only"');
+    expect(parsed[0]).not.toHaveProperty("nth");
   });
 
   it("keeps an unnamed control addressable by role alone", () => {
@@ -58,7 +78,7 @@ describe("parseSnapshotElements", () => {
 
   it("unescapes a quoted name", () => {
     expect(parseSnapshotElements(String.raw`- button "Say \"hi\""`)).toEqual([
-      { role: { role: "button", name: 'Say "hi"' } },
+      { role: { role: "button", name: 'Say "hi"', exact: true } },
     ]);
   });
 });

--- a/mcpjam-inspector/server/utils/built-in-tools/mcpjam.ts
+++ b/mcpjam-inspector/server/utils/built-in-tools/mcpjam.ts
@@ -260,6 +260,11 @@ export const EXCLUDED_FROM_WORKSPACE: Readonly<Record<string, string>> = {
     "Spends against the organization's shared daily insights budget. The Swarms tab has the button, next to the wave it applies to.",
   cancel_wave_insights:
     "Paired with the request above; offering the cancel without the request is an odd half-surface.",
+  // Launches a browser and executes the caller's tool. The Apps tab renders
+  // the same widget interactively, with the console and network panes beside
+  // it — a chat tool would hand back a verdict with none of that context.
+  render_server_widget:
+    "The Apps tab renders the widget interactively, with the console and network evidence beside it. Available on REST/CLI/MCP.",
   // Agent Playground. `send_chat_message` runs an assistant turn, and this
   // toolset IS an assistant turn — offering it here lets a chat turn spawn
   // chat turns, which is recursive spend with no natural floor. The two reads

--- a/mcpjam-inspector/server/utils/mcp-app-browser-harness.ts
+++ b/mcpjam-inspector/server/utils/mcp-app-browser-harness.ts
@@ -195,11 +195,26 @@ export interface ScriptedStepResult {
  * harness would accept.
  */
 export interface SnapshotElement {
-  role?: { role: string; name?: string };
+  /**
+   * `exact` is always TRUE on a generated target, and that is load-bearing:
+   * Playwright's `getByRole` name matching is substring and case-insensitive
+   * by default, so a widget with `Save` and `Save as` buttons would emit two
+   * unambiguous-looking targets, and posting `{ name: "Save" }` back would
+   * match both and fail the step with a strict-mode violation. The names here
+   * come from the ARIA tree and are already complete, so exact matching is
+   * both correct and what makes them usable.
+   */
+  role?: { role: string; name?: string; exact?: boolean };
   testId?: string;
   /** Visible text, when neither an accessible name nor a test id is available. */
   text?: string;
-  /** True when more than one element matched — pass `nth` to disambiguate. */
+  /**
+   * Which occurrence this is, when a `(role, name)` pair repeats. Present
+   * exactly when `ambiguous` is — a target the caller must disambiguate is
+   * given the means to do it in the same object.
+   */
+  nth?: number;
+  /** True when more than one element matched — use `nth` to disambiguate. */
   ambiguous?: true;
 }
 
@@ -286,12 +301,20 @@ export function parseSnapshotElements(tree: string): SnapshotElement[] {
       ? match[2].replace(/\\(["\\])/g, "$1")
       : undefined;
     const key = `${role}\u0000${name ?? ""}`;
-    counts.set(key, (counts.get(key) ?? 0) + 1);
-    elements.push({ role: { role, ...(name ? { name } : {}) } });
+    const occurrence = counts.get(key) ?? 0;
+    counts.set(key, occurrence + 1);
+    elements.push({
+      role: { role, ...(name ? { name, exact: true } : {}) },
+      // Carried on every element and only KEPT below for the ambiguous ones —
+      // an unambiguous target reads cleaner without it, and `nth` on a unique
+      // match adds nothing.
+      nth: occurrence,
+    });
   }
   for (const element of elements) {
     const key = `${element.role!.role}\u0000${element.role!.name ?? ""}`;
     if ((counts.get(key) ?? 0) > 1) element.ambiguous = true;
+    else delete element.nth;
   }
   return elements;
 }
@@ -1314,16 +1337,29 @@ export class McpAppBrowserHarness {
     // only the eval runner drove it, with its own bounded step list.
     const stepBudgetExceeded =
       widget.actionCount >= this.budgets.maxBrowserStepsPerWidget;
+    // The screenshot budget is per-ITERATION and shared across widgets, so a
+    // scripted step can exhaust it even on a widget with steps to spare —
+    // every successful step captures a frame. Checked with the same split
+    // `executeAction` uses: the step cap DISMISSES the widget (terminal, per
+    // its contract), the screenshot cap only refuses further steps on it.
+    const screenshotBudgetExceeded =
+      this.screenshotCount >= this.budgets.totalScreenshotsPerIteration;
     if (stepBudgetExceeded) {
       await this.unmount(input.toolCallId);
+    }
+    if (stepBudgetExceeded || screenshotBudgetExceeded) {
       return {
         step,
         ok: false,
-        reason: "per-widget step budget exhausted",
+        reason: stepBudgetExceeded
+          ? "per-widget step budget exhausted"
+          : "per-iteration screenshot budget exhausted",
         widgetToolCalls: [],
         followUps: [],
         elapsedMs: Date.now() - started,
-        note: "step_budget_exceeded",
+        note: stepBudgetExceeded
+          ? "step_budget_exceeded"
+          : "screenshot_budget_exceeded",
       };
     }
     widget.actionCount += 1;
@@ -1647,17 +1683,23 @@ export class McpAppBrowserHarness {
     for (const element of elements) {
       if (!element.role?.name) continue;
       try {
-        const testId = await frame
-          .getByRole(
-            element.role.role as Parameters<FrameLocator["getByRole"]>[0],
-            { name: element.role.name, exact: true },
-          )
-          .first()
-          .getAttribute("data-testid", { timeout: SNAPSHOT_ATTRIBUTE_TIMEOUT_MS });
+        const matches = frame.getByRole(
+          element.role.role as Parameters<FrameLocator["getByRole"]>[0],
+          { name: element.role.name, exact: true },
+        );
+        // THIS occurrence, not `.first()`. Reading the first match for every
+        // sibling of an ambiguous pair labelled them all with the first one's
+        // test id — actively misleading precisely when the caller is reaching
+        // for a test id to tell them apart.
+        const testId = await matches
+          .nth(element.nth ?? 0)
+          .getAttribute("data-testid", {
+            timeout: SNAPSHOT_ATTRIBUTE_TIMEOUT_MS,
+          });
         if (testId) element.testId = testId;
       } catch {
-        // A detached or ambiguous element simply has no test id listed. It is
-        // still addressable by role and name.
+        // A detached element simply has no test id listed. It is still
+        // addressable by role, name and nth.
       }
     }
 

--- a/mcpjam-inspector/server/utils/mcp-app-browser-harness.ts
+++ b/mcpjam-inspector/server/utils/mcp-app-browser-harness.ts
@@ -254,6 +254,48 @@ const SNAPSHOT_INTERACTIVE_ROLES = [
   "spinbutton",
 ] as const;
 
+/** Per-element attribute lookup budget while enriching a snapshot. */
+const SNAPSHOT_ATTRIBUTE_TIMEOUT_MS = 1_000;
+
+/**
+ * Pull addressable `(role, name)` pairs out of a Playwright ARIA snapshot.
+ *
+ * The snapshot is line-oriented YAML-ish: `- button "Submit"`, `- textbox`,
+ * `- link "Docs" [ref=e3]`. Only the roles a scripted step can act on are
+ * listed, because a target the caller cannot use is noise they still pay
+ * tokens for.
+ *
+ * A `(role, name)` pair seen more than once is marked `ambiguous` on EVERY
+ * occurrence — including the first, which only the second sighting proves —
+ * so a caller knows to add `nth` before using it rather than discovering the
+ * collision when the step fails.
+ */
+export function parseSnapshotElements(tree: string): SnapshotElement[] {
+  const roles = new Set<string>(SNAPSHOT_INTERACTIVE_ROLES);
+  const elements: SnapshotElement[] = [];
+  const counts = new Map<string, number>();
+  for (const line of tree.split("\n")) {
+    if (elements.length >= SNAPSHOT_MAX_ELEMENTS) break;
+    // `- <role>` optionally followed by a quoted accessible name. Anything
+    // after (refs, state flags like `[checked]`) is deliberately ignored.
+    const match = /^\s*-\s+([a-z]+)(?:\s+"((?:[^"\\]|\\.)*)")?/.exec(line);
+    if (!match) continue;
+    const role = match[1]!;
+    if (!roles.has(role)) continue;
+    const name = match[2]
+      ? match[2].replace(/\\(["\\])/g, "$1")
+      : undefined;
+    const key = `${role}\u0000${name ?? ""}`;
+    counts.set(key, (counts.get(key) ?? 0) + 1);
+    elements.push({ role: { role, ...(name ? { name } : {}) } });
+  }
+  for (const element of elements) {
+    const key = `${element.role!.role}\u0000${element.role!.name ?? ""}`;
+    if ((counts.get(key) ?? 0) > 1) element.ambiguous = true;
+  }
+  return elements;
+}
+
 export interface HarnessBudgets {
   /** Per-rendered-widget cap on `executeAction` calls before forced dismiss. */
   maxBrowserStepsPerWidget: number;
@@ -1263,6 +1305,27 @@ export class McpAppBrowserHarness {
         note: "no_rendered_widget",
       };
     }
+    // The SAME per-widget budget `executeAction` enforces, and for the same
+    // reason: a scripted step drives the page and captures a frame, so a
+    // caller that only ever posts semantic steps would otherwise drive a
+    // runaway widget forever — refreshing the session TTL on every call —
+    // while the coordinate path next door is capped at twelve. This became
+    // reachable when the step path was exposed as its own route; before that
+    // only the eval runner drove it, with its own bounded step list.
+    const stepBudgetExceeded =
+      widget.actionCount >= this.budgets.maxBrowserStepsPerWidget;
+    if (stepBudgetExceeded) {
+      await this.unmount(input.toolCallId);
+      return {
+        step,
+        ok: false,
+        reason: "per-widget step budget exhausted",
+        widgetToolCalls: [],
+        followUps: [],
+        elapsedMs: Date.now() - started,
+        note: "step_budget_exceeded",
+      };
+    }
     widget.actionCount += 1;
     this.toolCallBuffer = [];
     this.followUpBuffer = [];
@@ -1564,62 +1627,37 @@ export class McpAppBrowserHarness {
       truncated = true;
     }
 
-    const elements: SnapshotElement[] = [];
-    for (const role of SNAPSHOT_INTERACTIVE_ROLES) {
-      if (elements.length >= SNAPSHOT_MAX_ELEMENTS) break;
-      let handles: Locator[];
+    // ELEMENTS ARE DERIVED FROM THE TREE, not from DOM attributes.
+    //
+    // The first cut read `aria-label` and fell back to `innerText`, which is
+    // wrong for most real forms: a control named through `<label for>`,
+    // `aria-labelledby`, an `alt`, or a `title` has no `aria-label` and often
+    // no text of its own, so it came back role-only and ambiguous — while the
+    // tree printed directly above it showed the name perfectly well. The
+    // snapshot contradicted itself, and the read-a-control-and-post-it-back
+    // workflow this exists for broke on exactly the widgets people build.
+    //
+    // Playwright's ARIA snapshot already carries the COMPUTED accessible name,
+    // which is the same string `getByRole(role, { name })` matches on. Parsing
+    // it means the elements can only ever agree with the tree beside them.
+    const elements = parseSnapshotElements(tree);
+    // Test ids are not in the tree, so they are looked up only for the
+    // elements already selected — bounded work, and purely additive: a target
+    // is usable without one.
+    for (const element of elements) {
+      if (!element.role?.name) continue;
       try {
-        handles = await frame
-          .getByRole(role as Parameters<FrameLocator["getByRole"]>[0])
-          .all();
+        const testId = await frame
+          .getByRole(
+            element.role.role as Parameters<FrameLocator["getByRole"]>[0],
+            { name: element.role.name, exact: true },
+          )
+          .first()
+          .getAttribute("data-testid", { timeout: SNAPSHOT_ATTRIBUTE_TIMEOUT_MS });
+        if (testId) element.testId = testId;
       } catch {
-        continue;
-      }
-      // Count per accessible NAME, not per role: `nth` in a scripted-step
-      // target disambiguates within a (role, name) pair, so that is the pair
-      // whose multiplicity the caller needs told about.
-      const seen = new Map<string, number>();
-      for (const handle of handles) {
-        if (elements.length >= SNAPSHOT_MAX_ELEMENTS) break;
-        let name = "";
-        let testId: string | undefined;
-        try {
-          name = (
-            await handle.getAttribute("aria-label", {
-              timeout: SCRIPTED_STEP_TIMEOUT_MS,
-            })
-          )?.trim() ??
-            (await handle.innerText({ timeout: SCRIPTED_STEP_TIMEOUT_MS }))
-              .trim();
-          testId =
-            (await handle.getAttribute("data-testid", {
-              timeout: SCRIPTED_STEP_TIMEOUT_MS,
-            })) ?? undefined;
-        } catch {
-          // An element that detached mid-walk is simply not listed. It cannot
-          // be targeted either, so omitting it is the honest answer.
-          continue;
-        }
-        const key = `${role}\u0000${name}`;
-        const index = seen.get(key) ?? 0;
-        seen.set(key, index + 1);
-        elements.push({
-          role: { role, ...(name ? { name } : {}) },
-          ...(testId ? { testId } : {}),
-          ...(index > 0 ? { ambiguous: true as const } : {}),
-        });
-      }
-      // Retro-flag the FIRST of a duplicated (role, name): the caller needs to
-      // know the target is ambiguous before it uses it, and only the second
-      // sighting proves it.
-      for (const [key, count] of seen) {
-        if (count <= 1) continue;
-        const [dupRole, dupName] = key.split("\u0000");
-        const first = elements.find(
-          (entry) =>
-            entry.role?.role === dupRole && (entry.role?.name ?? "") === dupName
-        );
-        if (first) first.ambiguous = true;
+        // A detached or ambiguous element simply has no test id listed. It is
+        // still addressable by role and name.
       }
     }
 

--- a/mcpjam-inspector/server/utils/mcp-app-browser-harness.ts
+++ b/mcpjam-inspector/server/utils/mcp-app-browser-harness.ts
@@ -184,6 +184,76 @@ export interface ScriptedStepResult {
   note?: string;
 }
 
+/**
+ * One interactive element the caller can address, in the SAME vocabulary
+ * `runScriptedStep` accepts.
+ *
+ * The point is that a snapshot is ACTIONABLE, not merely descriptive: an
+ * agent reads `{role: {role: "button", name: "Submit"}}` here and posts it
+ * straight back as a step target. A snapshot that described the DOM in some
+ * other vocabulary would still leave the caller guessing which locator this
+ * harness would accept.
+ */
+export interface SnapshotElement {
+  role?: { role: string; name?: string };
+  testId?: string;
+  /** Visible text, when neither an accessible name nor a test id is available. */
+  text?: string;
+  /** True when more than one element matched — pass `nth` to disambiguate. */
+  ambiguous?: true;
+}
+
+/**
+ * A text view of the mounted widget, for callers that cannot see pixels.
+ *
+ * WHY THIS EXISTS. Every other way to drive a widget here is COORDINATE-based
+ * (`executeAction` takes `[x, y]`), which silently assumes a multimodal
+ * caller: a text-only model can be handed a screenshot and still have nothing
+ * to click. Chrome DevTools MCP hit the same wall and solved it the same way —
+ * pair the pixels with an accessibility tree carrying addressable handles.
+ * Without this, half the agents that could debug an MCP App cannot reach it.
+ */
+export interface WidgetSnapshot {
+  mode: "a11y";
+  /** Playwright ARIA snapshot (YAML-ish) of the widget frame. */
+  tree: string;
+  /** Interactive elements, ready to use as `runScriptedStep` targets. */
+  elements: SnapshotElement[];
+  /** The tree hit the character ceiling and was clipped. */
+  truncated?: true;
+  capturedAt: number;
+  /** `"no_rendered_widget"` when nothing is mounted. */
+  note?: string;
+}
+
+/**
+ * Ceiling on a captured tree.
+ *
+ * A snapshot is handed to a model, so its cost is tokens. A deeply nested
+ * widget can produce an enormous tree, and an unbounded one would blow the
+ * caller's context on the one call that was supposed to make the widget
+ * legible.
+ */
+const SNAPSHOT_MAX_CHARS = 32_000;
+/** How many addressable elements to list. Beyond this the tree is the answer. */
+const SNAPSHOT_MAX_ELEMENTS = 100;
+/** Roles worth listing: the ones a scripted step can actually act on. */
+const SNAPSHOT_INTERACTIVE_ROLES = [
+  "button",
+  "link",
+  "textbox",
+  "checkbox",
+  "radio",
+  "combobox",
+  "slider",
+  "switch",
+  "tab",
+  "menuitem",
+  "option",
+  "searchbox",
+  "spinbutton",
+] as const;
+
 export interface HarnessBudgets {
   /** Per-rendered-widget cap on `executeAction` calls before forced dismiss. */
   maxBrowserStepsPerWidget: number;
@@ -1439,6 +1509,127 @@ export class McpAppBrowserHarness {
       `screenshot exceeds byte budget after re-encoding ` +
         `(${jpeg.byteLength} > ${this.budgets.screenshotMaxBytes} bytes)`
     );
+  }
+
+  /**
+   * Capture a TEXT view of the mounted widget: its accessibility tree plus
+   * the interactive elements a scripted step can target.
+   *
+   * Read-only and cheap — it does not count against `maxBrowserStepsPerWidget`,
+   * because looking is not acting and a caller forced to spend its interaction
+   * budget on looking would interact blind to save steps.
+   *
+   * Failure returns a snapshot with a `note`, never a throw. A snapshot is
+   * diagnostic; making it able to fail an interaction session would let the
+   * observability break the thing it observes.
+   */
+  async captureSnapshot(toolCallId?: string): Promise<WidgetSnapshot> {
+    const capturedAt = Date.now();
+    const mounted =
+      toolCallId !== undefined
+        ? this.mounted.get(toolCallId)
+        : this.mounted.size > 0;
+    if (!mounted || !this.page) {
+      return {
+        mode: "a11y",
+        tree: "",
+        elements: [],
+        capturedAt,
+        note: "no_rendered_widget",
+      };
+    }
+    const frame = this.widgetFrame();
+    let tree = "";
+    let truncated = false;
+    try {
+      tree = await frame
+        .locator("body")
+        .ariaSnapshot({ timeout: SCRIPTED_STEP_TIMEOUT_MS });
+    } catch (error) {
+      return {
+        mode: "a11y",
+        tree: "",
+        elements: [],
+        capturedAt,
+        note: `snapshot_failed: ${
+          error instanceof Error ? error.message : String(error)
+        }`,
+      };
+    }
+    if (tree.length > SNAPSHOT_MAX_CHARS) {
+      // Clipped VISIBLY and flagged. A silently shortened tree would read as a
+      // complete description of a smaller widget, and the caller would conclude
+      // the control it wanted does not exist.
+      tree = `${tree.slice(0, SNAPSHOT_MAX_CHARS)}\n… [truncated]`;
+      truncated = true;
+    }
+
+    const elements: SnapshotElement[] = [];
+    for (const role of SNAPSHOT_INTERACTIVE_ROLES) {
+      if (elements.length >= SNAPSHOT_MAX_ELEMENTS) break;
+      let handles: Locator[];
+      try {
+        handles = await frame
+          .getByRole(role as Parameters<FrameLocator["getByRole"]>[0])
+          .all();
+      } catch {
+        continue;
+      }
+      // Count per accessible NAME, not per role: `nth` in a scripted-step
+      // target disambiguates within a (role, name) pair, so that is the pair
+      // whose multiplicity the caller needs told about.
+      const seen = new Map<string, number>();
+      for (const handle of handles) {
+        if (elements.length >= SNAPSHOT_MAX_ELEMENTS) break;
+        let name = "";
+        let testId: string | undefined;
+        try {
+          name = (
+            await handle.getAttribute("aria-label", {
+              timeout: SCRIPTED_STEP_TIMEOUT_MS,
+            })
+          )?.trim() ??
+            (await handle.innerText({ timeout: SCRIPTED_STEP_TIMEOUT_MS }))
+              .trim();
+          testId =
+            (await handle.getAttribute("data-testid", {
+              timeout: SCRIPTED_STEP_TIMEOUT_MS,
+            })) ?? undefined;
+        } catch {
+          // An element that detached mid-walk is simply not listed. It cannot
+          // be targeted either, so omitting it is the honest answer.
+          continue;
+        }
+        const key = `${role}\u0000${name}`;
+        const index = seen.get(key) ?? 0;
+        seen.set(key, index + 1);
+        elements.push({
+          role: { role, ...(name ? { name } : {}) },
+          ...(testId ? { testId } : {}),
+          ...(index > 0 ? { ambiguous: true as const } : {}),
+        });
+      }
+      // Retro-flag the FIRST of a duplicated (role, name): the caller needs to
+      // know the target is ambiguous before it uses it, and only the second
+      // sighting proves it.
+      for (const [key, count] of seen) {
+        if (count <= 1) continue;
+        const [dupRole, dupName] = key.split("\u0000");
+        const first = elements.find(
+          (entry) =>
+            entry.role?.role === dupRole && (entry.role?.name ?? "") === dupName
+        );
+        if (first) first.ambiguous = true;
+      }
+    }
+
+    return {
+      mode: "a11y",
+      tree,
+      elements,
+      ...(truncated ? { truncated: true as const } : {}),
+      capturedAt,
+    };
   }
 
   /**

--- a/mcpjam-inspector/server/utils/widget-render-core.ts
+++ b/mcpjam-inspector/server/utils/widget-render-core.ts
@@ -17,6 +17,7 @@ import {
   McpAppBrowserHarness,
   ChromiumNotInstalledError,
   type WidgetRenderObservation,
+  type WidgetSnapshot,
 } from "./mcp-app-browser-harness";
 import {
   renderMcpAppToolResult,
@@ -40,10 +41,27 @@ export interface RenderWidgetForRequestParams {
   viewport?: { width: number; height: number };
   /** Keep the widget mounted (for an interactive session) vs one-shot. */
   keepMounted: boolean;
+  /**
+   * Also capture a TEXT view of the rendered widget (accessibility tree +
+   * addressable elements).
+   *
+   * Handled HERE rather than by each caller because the timing is the whole
+   * difficulty: a one-shot render unmounts the widget when it is done, so a
+   * caller that tried to snapshot afterwards would find nothing. Requesting it
+   * keeps the widget mounted just long enough to read, then lets the normal
+   * teardown proceed.
+   */
+  captureSnapshot?: boolean;
 }
 
 export interface RenderWidgetForRequestResult {
   observation: WidgetRenderObservation;
+  /**
+   * Present only when `captureSnapshot` was requested AND a widget actually
+   * mounted. Absent rather than empty on a failed render: an empty tree would
+   * claim the widget rendered with no content.
+   */
+  snapshot?: WidgetSnapshot;
   /**
    * The harness, when one was created (the tool was renderable). `null` for the
    * `no_ui_resource` gate (no browser launched). The CALLER owns disposal.
@@ -130,9 +148,27 @@ export async function renderWidgetForRequest(
       mcpClientManager,
       injectOpenAiCompat: params.injectOpenAiCompat,
       harness,
-      keepMounted: params.keepMounted,
+      // A snapshot needs something mounted to read. Requesting one therefore
+      // implies keeping the widget up through the read; the caller's teardown
+      // is unchanged and still runs immediately after.
+      keepMounted: params.keepMounted || params.captureSnapshot === true,
     });
-    return { observation, harness };
+    let snapshot: WidgetSnapshot | undefined;
+    if (params.captureSnapshot && observation.status === "rendered") {
+      // Best-effort: a snapshot is diagnostic, and failing a completed render
+      // because the text view could not be read would be the observability
+      // breaking the thing it observes.
+      snapshot = await harness
+        .captureSnapshot(observation.toolCallId)
+        .catch(() => undefined);
+      // Restore the one-shot contract: the caller asked for a render, not a
+      // live session, and leaving the widget mounted would change teardown
+      // semantics for a diagnostic opt-in.
+      if (!params.keepMounted) {
+        await harness.dismissWidget(observation.toolCallId).catch(() => {});
+      }
+    }
+    return { observation, ...(snapshot ? { snapshot } : {}), harness };
   } catch (error) {
     // The harness maps a missing-Chromium launch to a `browser_unavailable`
     // observation itself (it does NOT throw); this defensive branch covers the

--- a/mcpjam-inspector/server/utils/widget-render-request.ts
+++ b/mcpjam-inspector/server/utils/widget-render-request.ts
@@ -16,6 +16,8 @@ export interface ParsedWidgetRenderRequest {
   parameters: Record<string, unknown>;
   injectOpenAiCompat: boolean;
   viewport?: { width: number; height: number };
+  /** Also return the widget as an accessibility tree (see the core's option). */
+  includeSnapshot: boolean;
 }
 
 export type WidgetRenderRequestParse =
@@ -82,6 +84,11 @@ export function parseWidgetRenderRequestBody(
     };
   }
 
+  // Diagnostic opt-in, default OFF on this LOCAL route: its caller
+  // (`mcpjam apps render`) is a person looking at a screenshot. The hosted v1
+  // op reverses the default, because its caller is a model that cannot see one.
+  const includeSnapshot = b.includeSnapshot === true;
+
   return {
     ok: true,
     value: {
@@ -90,6 +97,7 @@ export function parseWidgetRenderRequestBody(
       parameters,
       injectOpenAiCompat: b.injectOpenAiCompat === true,
       viewport,
+      includeSnapshot,
     },
   };
 }

--- a/sdk/src/platform/client.ts
+++ b/sdk/src/platform/client.ts
@@ -7,6 +7,7 @@ import type {
   PlatformChatSessionTrace,
   PlatformChatTurn,
   PlatformToolMode,
+  PlatformWidgetRender,
   PlatformDoctorReport,
   PlatformEvalIteration,
   PlatformEvalRun,
@@ -2183,6 +2184,34 @@ export class PlatformApiClient {
     options?: RequestOptions,
   ): Promise<Record<string, unknown>> {
     return this.serverOp(params, "tools/call", options);
+  }
+
+  /**
+   * `POST /projects/{p}/servers/{s}/widgets/render` — render an MCP App
+   * widget headlessly and describe what it produced.
+   *
+   * Defaults return the widget as an ACCESSIBILITY TREE and omit the
+   * screenshot. That is the reverse of the local Inspector route, and
+   * deliberate: the caller here is usually a model, for which a base64 image
+   * it may not be able to see is the most expensive possible way to say
+   * nothing.
+   */
+  renderServerWidget(
+    params: ServerScope & {
+      body: {
+        toolName: string;
+        parameters?: Record<string, unknown>;
+        includeSnapshot?: boolean;
+        includeScreenshot?: boolean;
+        injectOpenAiCompat?: boolean;
+        viewport?: { width: number; height: number };
+      };
+    },
+    options?: RequestOptions,
+  ): Promise<PlatformWidgetRender> {
+    return this.serverOp(params, "widgets/render", options) as Promise<
+      PlatformWidgetRender
+    >;
   }
 
   /** `POST /projects/{p}/servers/{s}/prompts/get` — render one prompt. */

--- a/sdk/src/platform/index.ts
+++ b/sdk/src/platform/index.ts
@@ -36,6 +36,9 @@ export type {
   PlatformScenarioLink,
   PlatformScenarioServer,
   PlatformChatSession,
+  PlatformSnapshotElement,
+  PlatformWidgetSnapshot,
+  PlatformWidgetRender,
   PlatformChatSessionDetail,
   PlatformChatSessionTrace,
   PlatformChatMessage,
@@ -240,6 +243,7 @@ export {
 export {
   buildImageOperation,
   callServerToolOperation,
+  renderServerWidgetOperation,
   closeTunnelOperation,
   createProjectOperation,
   createProjectServerOperation,

--- a/sdk/src/platform/operations.ts
+++ b/sdk/src/platform/operations.ts
@@ -901,7 +901,12 @@ export const renderServerWidgetOperation: PlatformOperation<
     );
     return {
       project: toSelectedProjectInfo(project),
-      server,
+      // NARROWED, like every other live-server operation in this file.
+      // Assigning the raw row would ship a whole `PlatformProjectServer` —
+      // including its config — through a field the type says is `{id, name}`,
+      // so consumers would see fields the contract does not promise and the
+      // published shape would disagree with the declared one.
+      server: toServerInfo(server),
       render,
     };
   },

--- a/sdk/src/platform/operations.ts
+++ b/sdk/src/platform/operations.ts
@@ -37,6 +37,7 @@ import type {
   PlatformScenarioSummary,
   PlatformScenarioDetail,
   PlatformChatSession,
+  PlatformWidgetRender,
   PlatformChatTurn,
   PlatformChatSessionTrace,
   PlatformChatSessionDetail,
@@ -802,6 +803,108 @@ export type CallServerToolResult = {
   project: SelectedProjectInfo;
   server: ResolvedServerInfo;
   result: Record<string, unknown>;
+};
+
+const renderServerWidgetInput = serverScopedInput.extend({
+  toolName: z
+    .string()
+    .trim()
+    .min(1)
+    .describe(
+      "The MCP App tool to render. It must declare a `ui://` UI resource; a tool that does not is refused rather than run.",
+    ),
+  parameters: z
+    .record(z.string(), z.unknown())
+    .optional()
+    .describe("Tool arguments matching the tool's input schema."),
+  includeSnapshot: z
+    .boolean()
+    .optional()
+    .describe(
+      "Return the widget as an accessibility tree with addressable elements. DEFAULT TRUE — it is the cheap, readable answer.",
+    ),
+  includeScreenshot: z
+    .boolean()
+    .optional()
+    .describe(
+      "Also return a base64 image. DEFAULT FALSE: it is by far the largest field this returns, and a caller that cannot see images pays for it anyway.",
+    ),
+  injectOpenAiCompat: z
+    .boolean()
+    .optional()
+    .describe(
+      "Mount with the OpenAI Apps compatibility shims instead of the spec-default MCP-UI bridge.",
+    ),
+  viewport: z
+    .object({
+      width: z.number().int().min(1).max(8192),
+      height: z.number().int().min(1).max(8192),
+    })
+    .optional(),
+});
+
+export type RenderServerWidgetInput = z.infer<typeof renderServerWidgetInput>;
+
+export type RenderServerWidgetResult = {
+  project: SelectedProjectInfo;
+  server: ResolvedServerInfo;
+  render: PlatformWidgetRender;
+};
+
+export const renderServerWidgetOperation: PlatformOperation<
+  RenderServerWidgetInput,
+  RenderServerWidgetResult
+> = {
+  name: "render_server_widget",
+  title: "Render an MCP App widget",
+  description:
+    "Call an MCP App tool and mount its `ui://` widget in real headless Chromium, then report whether it rendered, what it logged, what it was blocked from fetching, and the widget as an accessibility tree with addressable elements. Returns the tree by default and the screenshot only on request. EXECUTES THE TOOL, so it has whatever side effects that tool has.",
+  readOnly: false,
+  // Same unknowability as `call_server_tool`, because it IS a tool call — the
+  // render is what happens afterwards. Softening the destructive default would
+  // claim a safety this cannot verify.
+  mayBeDestructive: true,
+  // The conservative reading of an unknowable effect. `none` would claim the
+  // call is reversible and free, which is exactly what nobody can promise
+  // about a third party's tool. The agent surface then treats this as
+  // approval-worthy rather than silently callable — see the TIER_EXCEPTIONS
+  // entry, which explains why it is gated rather than excluded outright.
+  risk: "destructive",
+  inputSchema: renderServerWidgetInput,
+  async execute(input, { client, signal }) {
+    const { project } = await resolveProjectOrThrow(
+      client,
+      input.project,
+      signal,
+    );
+    const server = await resolveLiveServer(client, project, input.server, signal);
+    const render = await client.renderServerWidget(
+      {
+        projectId: project.id,
+        serverId: server.id,
+        body: {
+          toolName: input.toolName,
+          ...(input.parameters ? { parameters: input.parameters } : {}),
+          ...(input.includeSnapshot !== undefined
+            ? { includeSnapshot: input.includeSnapshot }
+            : {}),
+          ...(input.includeScreenshot !== undefined
+            ? { includeScreenshot: input.includeScreenshot }
+            : {}),
+          ...(input.injectOpenAiCompat !== undefined
+            ? { injectOpenAiCompat: input.injectOpenAiCompat }
+            : {}),
+          ...(input.viewport ? { viewport: input.viewport } : {}),
+        },
+      },
+      { signal },
+    );
+    return {
+      project: toSelectedProjectInfo(project),
+      server,
+      render,
+    };
+  },
 };
 
 export const callServerToolOperation: PlatformOperation<
@@ -10637,6 +10740,7 @@ export const ALL_OPERATIONS: readonly AnyPlatformOperation[] = [
   listServerPromptsOperation,
   listServerResourcesOperation,
   callServerToolOperation,
+  renderServerWidgetOperation,
   getServerPromptOperation,
   readServerResourceOperation,
   checkHostCompatibilityOperation,

--- a/sdk/src/platform/types.ts
+++ b/sdk/src/platform/types.ts
@@ -369,6 +369,49 @@ export interface PlatformChatSessionTrace {
   latestPromptIndex?: number;
 }
 
+/** One interactive element in a widget snapshot, ready to use as a step target. */
+export interface PlatformSnapshotElement {
+  role?: { role: string; name?: string };
+  testId?: string;
+  text?: string;
+  /** More than one element matched — pass `nth` on a step target to pick one. */
+  ambiguous?: true;
+}
+
+/**
+ * A rendered MCP App widget as TEXT.
+ *
+ * The point is that it is ACTIONABLE, not merely descriptive: the elements come
+ * back in the same role/name/testId vocabulary the interaction steps accept, so
+ * a caller reads a control here and addresses it directly.
+ */
+export interface PlatformWidgetSnapshot {
+  mode: "a11y";
+  tree: string;
+  elements: PlatformSnapshotElement[];
+  truncated?: true;
+  capturedAt: number;
+  note?: string;
+}
+
+/** The verdict and evidence from one headless widget render. */
+export interface PlatformWidgetRender {
+  status: string;
+  resourceUri?: string;
+  bridgeInitialized?: boolean;
+  /**
+   * What the widget logged, and what it was blocked from reaching. Both matter
+   * more than they look: a widget that "renders" while every fetch is blocked
+   * photographs perfectly and is broken.
+   */
+  consoleErrors?: string[];
+  blockedRequests?: string[];
+  snapshot?: PlatformWidgetSnapshot;
+  /** Present only when `includeScreenshot` was explicitly requested. */
+  screenshot?: { mimeType: string; base64: string };
+  timings?: { renderMs?: number; totalMs?: number };
+}
+
 /**
  * Which session surface a row came from. Open-ended on the wire: switch on it
  * and tolerate an unknown value rather than assuming this list is closed.

--- a/sdk/tests/platform/operations.test.ts
+++ b/sdk/tests/platform/operations.test.ts
@@ -2044,6 +2044,7 @@ describe("operation catalog consistency", () => {
     },
     get_chat_session: { sessionId: "cs_1" },
     get_chat_session_trace: { sessionId: "cs_1" },
+    render_server_widget: { server: "srv", toolName: "show_map" },
     delete_sandbox_image: { image: "i" },
     search_registry_directory: {},
     get_registry_directory_server: { catalogServerId: "cs" },
@@ -2214,6 +2215,9 @@ describe("operation catalog consistency", () => {
       "install_registry_directory_server",
       "install_registry_server",
       "uninstall_registry_server",
+      // Executes the tool, then renders its widget. A write for the same
+      // reason `call_server_tool` is: the tool runs.
+      "render_server_widget",
       // One agent Playground turn. A write because it appends to a durable
       // transcript, and `risk: "spend"` because it runs a model — the two
       // reads beside it (get_chat_session, get_chat_session_trace) stay reads.
@@ -2233,6 +2237,9 @@ describe("operation catalog consistency", () => {
     const destructive = new Set([
       "call_server_tool",
       "archive_project_environment",
+      // It IS a tool call — the render is what happens afterwards — so it
+      // inherits `call_server_tool`'s unknowability exactly.
+      "render_server_widget",
       // Under `toolMode: "auto"` this executes arbitrary third-party tools,
       // which is `call_server_tool`'s unknowability with a model choosing the
       // arguments. Softening the destructive default would claim a safety the


### PR DESCRIPTION
> Stacked on #4309. Review that one first; this diff is only the second commit.

## What

A tool that returns a `ui://` resource is two products in one: the tool result a model reads, and the interface a person sees. Every machine surface could inspect the first half. Nothing could inspect the second — an agent debugging its own MCP App could fetch the widget's HTML and had no way to learn whether it actually rendered, what it showed, or which tools it fired.

## Widgets as text — the piece that makes this reachable at all

`McpAppBrowserHarness.captureSnapshot()` returns the widget's accessibility tree plus its interactive elements, in the **same** role/name/testId vocabulary `runScriptedStep` already accepts. An agent reads a control and posts it straight back as a target, instead of translating between two locator languages.

That matters more than it looks. Every existing way to drive a widget was **coordinate-based** (`[x, y]`), which silently assumed the caller could see pixels — a text-only model handed a screenshot has nothing to click. Chrome DevTools MCP hit the same wall and solved it the same way: pair the pixels with an accessibility tree carrying addressable handles. Without this, half the agents that could debug an MCP App cannot reach it.

## Local

| Route | |
|---|---|
| `GET /api/mcp/widget-session/:id/snapshot` | read the widget as text |
| `POST /api/mcp/widget-session/:id/scripted-step` | act by role/name/testId |

The snapshot refreshes the idle TTL but **does not consume the widget's step budget** — looking is not acting, and a caller forced to spend interaction steps on looking would interact blind to save them. Both are serialized against in-flight actions: one page, one input stream.

`POST /api/mcp/widget-render` gains `includeSnapshot`, handled in the shared core because the *timing* is the difficulty: a one-shot render unmounts when it is done, so a caller that tried to snapshot afterwards would find nothing.

## Hosted

`POST /v1/projects/:p/servers/:s/widgets/render` (`render_server_widget`) calls the tool, mounts its widget in real headless Chromium running the production host bridge, and returns the verdict, console errors, blocked requests and the tree.

**Stateless by construction** — connect, call, render, read, dispose inside one request. That is what makes it safe on a plane with no session affinity. Interactive sessions stay local because they hold a live browser in module scope; making those hosted needs a dedicated single-replica renderer service, not a route. Nothing here forecloses that: `widget-render-core.ts` is surface-neutral and the registry is service-shaped.

**Payload defaults are the reverse of the local route's, deliberately:** snapshot on, screenshot off. The local caller is a person looking at pixels; this one is usually a model, for which a base64 image it may not even be able to see is the most expensive possible way to say nothing.

Console errors and blocked requests are reported on a **successful** render, not just a failed one — a widget that renders while every fetch is blocked photographs perfectly and is broken.

Chromium is the scarce resource, so the route carries its own per-replica cap rather than borrowing the eval runner's: that semaphore is module-private and bounds a batch fan-out, and sharing one number between an interactive request and a batch job would let either starve the other.

## Gating — the one call worth arguing with

It mirrors `call_server_tool`, because it **is** a tool call; the render is what happens afterwards. Gated on the agent surface with the arguments previewed, and annotated destructive **and explicitly non-idempotent** — nobody can promise that running a third party's tool twice is safe.

`risk: "destructive"` is the conservative reading of an *unknowable* effect rather than a claim that this removes a specific record. It lands the op **stricter** than the bare tool call (which leaves the hints absent), never looser, and the `TIER_EXCEPTIONS` entry records why it is gated rather than excluded: excluding the render while gating the call would let an agent propose running a tool but not propose finding out whether its widget works — the weaker of the two capabilities.

## Verification

- 7 new v1 route tests + 5 new local session tests; **1109** v1, **5903** SDK, **5397** inspector server (v1 + mcp + services + utils), **911** CLI, **53** MCP — all green
- Ratchets: SDK operations, MCP ordered catalog + annotations + README table, CLI op-bindings, agent-registry `TIER_BY_RISK` + prompt notes, workspace toolset, `sdk-coverage`, `openapi-drift`
- Typecheck clean for the touched projects

**Not exercised against real Chromium in CI.** The route tests stub at the render core, so they pin the route's decisions (defaults, refusals, disposal) rather than the browser's. The harness's `captureSnapshot` needs a hosted-staging smoke against a real MCP Apps server before this is trusted end to end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UPTvP8ktMFuw9YHTQ4moJF

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Executes third-party MCP tools and launches Chromium on both local sessions and a hosted replica-capped route. Gating, disposal, concurrency, and timeout behavior are security- and reliability-critical.
> 
> **Overview**
> Lets agents **inspect and drive MCP App widgets as text**, not just pixels. The harness now returns an accessibility tree plus interactive elements in the same role/name/testId vocabulary used to click/type/assert.
> 
> **Local sessions** add `GET …/snapshot` (read; refreshes TTL, does not spend the step budget) and `POST …/scripted-step` (semantic drive). Coordinate `action` remains. Scripted steps now share the per-widget step budget so they cannot bypass the cap. One-shot `widget-render` can opt into `includeSnapshot` before unmount.
> 
> **Hosted** `POST /v1/projects/{p}/servers/{s}/widgets/render` (`render_server_widget`) is a **stateless** connect-call-render-dispose. Snapshot defaults **on**, screenshot **off**. It reports console errors and blocked requests even on success, 422s tools with no `ui://` or missing Chromium, 429s at a per-replica cap, and 504s after 45s. Harness disposal is chained to the render promise so timeouts still free Chromium.
> 
> The op is **gated** like `call_server_tool` (argument preview) and marked destructive/non-idempotent. CLI gets `apps session snapshot` and `step`; hosted render is excluded from CLI because local `apps render` already uses the developer’s browser.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a050e791bf3a010158833a4f172449e10dbfcc88. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Lets agents inspect and drive MCP App widgets as text instead of pixels, and adds a hosted render that enforces real resource limits. Previously agents clicked by coordinates without render verification and hosted renders could time out while leaking Chromium; now they can snapshot the accessibility tree and act by role/name/testId, while the hosted plane returns structured evidence, enforces a 45s wall clock (504), and frees concurrency only after teardown.

- Local sessions: add GET `/api/mcp/widget-session/:id/snapshot` (text snapshot; parsed from the ARIA tree; takes the session lock; refreshes idle TTL; does not spend the step budget) and POST `/api/mcp/widget-session/:id/scripted-step` (drive by role/name/testId with exact name matching; ambiguous targets include `nth` and correct `testId`; enforces the per-widget step budget and the shared screenshot budget; serialized). One-shot `POST /api/mcp/widget-render` can include `includeSnapshot` to capture before unmount.
- Hosted render: new POST `/v1/projects/{p}/servers/{s}/widgets/render` (`render_server_widget`) calls the tool, renders in headless Chromium, and returns the verdict, console errors, blocked requests, and a snapshot by default (screenshot only when requested). Refuses tools without `ui://` (422); reports no-browser as unsupported (422); caps concurrent Chromium per replica (default 4 via `MCPJAM_MAX_CONCURRENT_WIDGET_RENDERS`); imposes a real 45s deadline (504); always disposes the harness and releases the slot only after disposal; detects JPEG vs PNG from bytes; reports disposal failures.
- SDK/CLI and gating: adds `render_server_widget` to `@mcpjam/sdk` (client, types, OpenAPI); classified destructive and non-idempotent and gated like `call_server_tool` with argument preview; excluded from the CLI op bindings (local `apps render` uses the developer’s Chromium). CLI adds `apps session snapshot` and `apps session step` with `--prior-tool-calls`; screenshots are optional in output.

<sup>Written for commit a050e791bf3a010158833a4f172449e10dbfcc88. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/MCPJam/inspector/pull/4312?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

