### PR TITLE
fix(cli): unredact eval launch codes, harden JUnit, keep the --wait receipt

### DIFF
--- a/.changeset/eval-run-report-files.md
+++ b/.changeset/eval-run-report-files.md
@@ -4,3 +4,9 @@
 ---
 
 Add atomic JSON and JUnit report files for completed hosted eval runs and gates.
+
+JUnit rendering now escapes the characters XML 1.0 forbids outright (most C0
+controls, unpaired surrogates) rather than emitting them verbatim. This applies
+to every structured reporter, not only the new eval one: previously a control
+character in any failure message produced a report file no JUnit parser would
+read.

--- a/cli/src/commands/eval.ts
+++ b/cli/src/commands/eval.ts
@@ -896,7 +896,13 @@ function launchFailureCases(
         category: "launch",
         passed: false,
         error: target.error.message,
-        details: { code: target.error.code },
+        // `errorCode`, not `code`: the telemetry redactor treats any key
+        // normalizing to "code" as a possible OAuth authorization code and
+        // keeps only SCREAMING_SNAKE values. The v1 API's launch failures are
+        // lowercase snake_case (`billing_limit_reached`, `rate_limited`), so
+        // under the shorter name every one of them reached the CI artifact as
+        // "[REDACTED]" — the out-of-credits case included.
+        details: { errorCode: target.error.code },
       },
     ];
   });
@@ -2359,11 +2365,14 @@ export function registerEvalCommands(program: Command): void {
           );
 
           if (!needsReport) {
-            if (waitErrors.length > 0) {
-              throw operationalError(
-                waitErrors.map((entry) => entry.error).join("; ")
-              );
-            }
+            // Deliberately does NOT throw on `waitErrors` here. Throwing from
+            // inside the platform command skips the receipt below, and the
+            // receipt is the only place the launched run ids are printed: a
+            // `--wait --format json > out.json` that timed out would leave
+            // `out.json` EMPTY, with the ids surviving only as prose inside a
+            // stderr message. The caller cannot find, resume, or cancel the
+            // runs it just paid for. The shared exit path below raises the
+            // same failure after the receipt is on stdout.
             return {
               runs,
               waitErrors,
@@ -2441,15 +2450,31 @@ export function registerEvalCommands(program: Command): void {
         writeRunGroupSummary(globalOptions.format, webOrigin, result);
       }
 
+      // Everything above has already been written — report file, reporter
+      // stdout, or the launch receipt. Only now may this fail.
       const reportingErrors = completion.reportInputs.filter(
         (input) => !input.iterationsComplete || input.iterationError
       );
       if (reportingErrors.length > 0 || completion.waitErrors.length > 0) {
+        const affectedRunIds = [
+          ...reportingErrors.map((input) => input.run.id),
+          ...completion.waitErrors.map((entry) => entry.runId),
+        ];
         throw operationalError(
-          `Completed eval run report is incomplete for: ${[
-            ...reportingErrors.map((input) => input.run.id),
-            ...completion.waitErrors.map((entry) => entry.runId),
-          ].join(", ")}.`
+          needsReport
+            ? `Completed eval run report is incomplete for: ${affectedRunIds.join(
+                ", "
+              )}.`
+            : `Did not observe completion for: ${affectedRunIds.join(", ")}.`,
+          {
+            // Machine-readable, because the message is not: a pipeline that
+            // needs to resume or cancel these runs should not have to parse
+            // English out of stderr.
+            runIds: affectedRunIds,
+            ...(completion.waitErrors.length > 0
+              ? { waitErrors: completion.waitErrors }
+              : {}),
+          }
         );
       }
 

--- a/cli/tests/eval.test.ts
+++ b/cli/tests/eval.test.ts
@@ -198,6 +198,8 @@ interface EvalFixtureOptions {
   /** Target ids the grouped-launch endpoint should report as failures. */
   groupFailures?: Record<string, { code: string; message: string }>;
   runCaseResult?: "passed" | "failed";
+  /** Non-terminal keeps `--wait` polling until its deadline. */
+  runCaseStatus?: "running" | "completed";
   runCaseIterationFetchError?: boolean;
   runOneResult?: "passed" | "failed";
 }
@@ -555,7 +557,7 @@ async function startEvalFixture(options: EvalFixtureOptions = {}): Promise<{
           id: "run-case",
           suiteId: "suite-1",
           runNumber: 4,
-          status: "completed",
+          status: options.runCaseStatus ?? "completed",
           result,
           summary:
             result === "passed"
@@ -1958,6 +1960,100 @@ test("eval run writes completed cases and launch failures before a partial exit"
         { category: "launch", passed: false, error: "host unavailable" },
       ],
     );
+  } finally {
+    await fixture.close();
+  }
+});
+
+test("eval run --wait still prints the launch receipt when the wait times out", async () => {
+  // The run ids are the only handle a caller has on runs it has already PAID
+  // for. Raising the timeout before the receipt is written left
+  // `--wait --format json > out.json` holding an empty file.
+  const fixture = await startEvalFixture({ runCaseStatus: "running" });
+  try {
+    const run = await captureProcessOutput(() =>
+      main(
+        evalArgv(
+          fixture.baseUrl,
+          "run",
+          "--project",
+          "proj-alpha",
+          "--suite",
+          "suite-1",
+          "--wait",
+          "--wait-timeout",
+          "1",
+          "--format",
+          "json",
+        ),
+        { telemetry: telemetryDisabled },
+      ),
+    );
+
+    assert.equal(run.result.exitCode, 1);
+    const receipt = JSON.parse(run.stdout.trim());
+    assert.equal(receipt.launch.targets[0].runId, "run-case");
+    assert.deepEqual(receipt.runs, []);
+    // The failure itself is still reported, and names the runs machine-readably
+    // so a pipeline never has to parse English out of stderr.
+    // stderr also carries the cloud-context announce line; the error document
+    // is the last thing written to it.
+    const stderrLines = run.stderr.trim().split("\n");
+    const failure = JSON.parse(stderrLines[stderrLines.length - 1]);
+    assert.equal(failure.error.code, "OPERATIONAL_ERROR");
+    assert.deepEqual(failure.error.details.runIds, ["run-case"]);
+  } finally {
+    await fixture.close();
+  }
+});
+
+test("eval run keeps a lowercase launch failure code out of the redactor", async () => {
+  // `billing_limit_reached` and friends are the v1 API's real vocabulary. Under
+  // the key name `code` the telemetry redactor read them as OAuth authorization
+  // codes and replaced every one with "[REDACTED]" — the out-of-credits case
+  // included. SCREAMING_SNAKE codes survived either way, which is why the
+  // sibling test above never caught it.
+  const fixture = await startEvalFixture({
+    suiteDetail: {
+      hosts: [
+        { id: "host-claude", name: "Claude Code" },
+        { id: "host-chatgpt", name: "ChatGPT" },
+      ],
+    },
+    groupFailures: {
+      "host-chatgpt": {
+        code: "billing_limit_reached",
+        message: "out of credits",
+      },
+    },
+  });
+  const directory = await mkdtemp(path.join(os.tmpdir(), "mcpjam-eval-run-"));
+  const jsonPath = path.join(directory, "report.json");
+  try {
+    await captureProcessOutput(() =>
+      main(
+        evalArgv(
+          fixture.baseUrl,
+          "run",
+          "--project",
+          "proj-alpha",
+          "--suite",
+          "suite-1",
+          "--all-targets",
+          "--wait",
+          "--out",
+          jsonPath,
+        ),
+        { telemetry: telemetryDisabled },
+      ),
+    );
+    const report = JSON.parse(await readFile(jsonPath, "utf8"));
+    const launchCase = report.cases.find(
+      (entry: { category: string }) => entry.category === "launch",
+    );
+
+    assert.equal(launchCase.error, "out of credits");
+    assert.equal(launchCase.details.errorCode, "billing_limit_reached");
   } finally {
     await fixture.close();
   }

--- a/docs/cli/ci.mdx
+++ b/docs/cli/ci.mdx
@@ -416,8 +416,14 @@ This line is only emitted in human format — `--format json` output is unchange
 
 Use `--wait-timeout <ms>` to replace the 10-minute default. `--out` defaults to the structured JSON format; add `--reporter junit-xml` to write JUnit XML instead. When `--reporter` is present, the same report is also written to stdout.
 
+<Warning>
+**`eval run --wait` exits 0 even when the evals failed.** Waiting for a run is not the same as judging it: `--wait` keeps `eval run`'s existing exit codes, where `1` means a run never launched, not that a run came back red. The report it writes records the verdict faithfully (`passed: false`, and a JUnit `failures` count above zero), but the process still exits 0.
+
+So the `eval gate` step above is what fails the job — do not drop it and rely on the first step's exit code. If you only want the artifact and not the gate, assert on the verdict yourself: `[ "$(jq -r '.passed' eval-report.json)" = "true" ]`.
+</Warning>
+
 <Note>
-`eval run` keeps its existing exit codes: a completed failing run still writes its report without introducing verdict-based exit codes. Use `eval gate` when the job must fail on a policy; its report is written before the gate exit code is set. `eval status` also prints a `View:` line in human format, identical to the one `eval run` prints.
+`eval gate` sets a verdict-based exit code, and writes its report before doing so: `0` passed, `1` an eval verdict failed, `2` usage error, `3` incomplete or non-gateable. Infrastructure conditions never map to `1`, so retrying on `3` is safe. `eval status` also prints a `View:` line in human format, identical to the one `eval run` prints.
 </Note>
 
 #### Decision summary in human format

--- a/docs/cli/reference.mdx
+++ b/docs/cli/reference.mdx
@@ -956,7 +956,9 @@ List the eval suites saved in a project.
 
 Start an eval run of an existing suite, or upload a versioned suite file and run it. Provide **either** `--suite` **or** `--file`, not both.
 
-By default the command prints a launch receipt and returns immediately. `--wait` polls every launched run to a terminal state. This does not introduce verdict-based exit codes: a completed failing run still uses the existing exit behavior, while a partial fan-out remains exit 1. An invalid suite file on this command exits **2** — `eval validate` still exits 1 for the same contract failure, because it is a verdict on the file and this command is not.
+By default the command prints a launch receipt and returns immediately. `--wait` polls every launched run to a terminal state.
+
+`--wait` does **not** introduce verdict-based exit codes. A run that completes having failed its cases still **exits 0** — read `passed` in the report, or use [`cloud eval gate`](#cloud-eval-gate), which is the command that turns a verdict into an exit code. On this command `1` still means a launch or completion problem (a partial fan-out, a wait that timed out, a report that could not be assembled), never "the evals failed". An invalid suite file exits **2** — `eval validate` still exits 1 for the same contract failure, because it is a verdict on the file and this command is not.
 
 | Flag | Required | Description |
 |------|----------|-------------|
@@ -1177,6 +1179,23 @@ run before evaluating it.
 
 Report files are flushed before gate exit codes are set, including failed and
 incomplete gate outcomes.
+
+**Exit codes.** `eval gate` is the command that fails a build, so it is the one
+that maps a verdict onto an exit code. It keeps four:
+
+| Code | Meaning |
+|------|---------|
+| `0` | Every requested gate passed |
+| `1` | An eval **verdict** failed. Reserved for exactly that |
+| `2` | Usage error — an unknown scorer, or a threshold out of range |
+| `3` | Incomplete: the run was cancelled, the wait timed out, the network failed, or the run is non-gateable (its score evidence did not verify) |
+
+No infrastructure condition ever maps to `1`. A job that fails a release because
+a network call flaked, and reports it as a regression, teaches people to ignore
+the gate — so retry on `3`, and treat `1` as a real finding about the server.
+
+These four are deliberately **not** the same set `eval run --wait` uses; see
+that command above.
 
 ### `cloud eval trace`
 

--- a/sdk/src/structured-reporting.ts
+++ b/sdk/src/structured-reporting.ts
@@ -366,8 +366,42 @@ function sanitizeToken(value: string): string {
   return value.replace(/[^a-zA-Z0-9_.-]/g, "-");
 }
 
+/**
+ * Make a string legal to put inside XML 1.0 at all.
+ *
+ * Entity-escaping is not enough. XML 1.0 forbids most control characters
+ * OUTRIGHT — they cannot even be written as character references — and an
+ * unpaired surrogate is equally fatal. One of either in a `<failure message=…>`
+ * produces a file no JUnit parser will read, and the failure then surfaces
+ * inside the CI runner's parser with nothing pointing back at the report that
+ * caused it.
+ *
+ * This is reachable input, not a theoretical one: an eval case's failure text
+ * is an iteration's `error`, which is model- and server-authored.
+ *
+ * Rendered as a visible `\uXXXX` escape rather than dropped, because the byte
+ * is usually the interesting half of the message.
+ */
+function toXmlSafeText(value: string): string {
+  return (
+    value
+      // C0 controls except tab (\u0009), LF (\u000A) and CR (\u000D), plus DEL.
+      .replace(
+        /[\u0000-\u0008\u000B\u000C\u000E-\u001F\u007F]/gu,
+        escapeAsCodePoint
+      )
+      // With the `u` flag a matched surrogate is necessarily an UNPAIRED one:
+      // a valid pair is one code point above the BMP and never enters this class.
+      .replace(/[\uD800-\uDFFF]/gu, escapeAsCodePoint)
+  );
+}
+
+function escapeAsCodePoint(char: string): string {
+  return `\\u${(char.codePointAt(0) ?? 0).toString(16).padStart(4, "0")}`;
+}
+
 function escapeXml(value: string): string {
-  return value
+  return toXmlSafeText(value)
     .replace(/&/g, "&amp;")
     .replace(/</g, "&lt;")
     .replace(/>/g, "&gt;")

--- a/sdk/tests/structured-reporting.test.ts
+++ b/sdk/tests/structured-reporting.test.ts
@@ -135,6 +135,49 @@ describe("renderStructuredRunJUnitXml", () => {
     expect(xml).toContain('name="validation-passed"');
   });
 
+  it("escapes the characters XML 1.0 forbids outright", () => {
+    // A failing eval case carries an iteration's `error`, which is model- and
+    // server-authored. XML 1.0 rejects most control characters and any
+    // unpaired surrogate OUTRIGHT — they cannot even be written as character
+    // references — so one of them here produces a report no JUnit parser will
+    // read, and the CI job then fails inside the parser with nothing pointing
+    // back at us.
+    const xml = renderStructuredRunJUnitXml({
+      schemaVersion: 1,
+      kind: "eval-run",
+      passed: false,
+      summary: summarizeStructuredCases([]),
+      cases: [
+        {
+          id: "run-1:case-a",
+          title: "Case A",
+          category: "eval",
+          passed: false,
+          error: "tool returned \u0000 then gave up\u001b[0m",
+          details: { tail: "truncated\ud800" },
+        },
+      ],
+      durationMs: 0,
+      metadata: {},
+    });
+
+    // The invariant, asserted directly: nothing illegal survives anywhere in
+    // the document. (`@xmldom/xmldom` is too lenient to serve as the oracle —
+    // it parses a NUL without complaint, where the parsers CI actually runs
+    // do not.)
+    expect(xml).not.toMatch(
+      /[\u0000-\u0008\u000B\u000C\u000E-\u001F\u007F]|[\uD800-\uDFFF]/u
+    );
+    // Escaped, not dropped: the byte is usually the interesting half.
+    expect(xml).toContain("\\u0000");
+    expect(xml).toContain("\\u001b");
+    expect(xml).toContain("\\ud800");
+
+    const parsed = parseJUnitXmlArtifact(xml);
+    expect(parsed).toHaveLength(1);
+    expect(parsed[0].passed).toBe(false);
+  });
+
   it("emits a synthetic failure when an empty run failed overall", () => {
     const xml = renderStructuredRunJUnitXml({
       schemaVersion: 1,


### PR DESCRIPTION
Follow-up to #4310. Three defects and two documentation gaps that merged with it, each fix carrying a regression test verified to fail without it.

All three were confirmed live on `main` after #4310 merged.

## 1. The telemetry redactor was eating the launch failure code

`launchFailureCases` keyed the detail as `code`. `shouldRedactKey` treats any key normalizing to `code` as a possible OAuth authorization code and keeps only SCREAMING_SNAKE values, but the v1 API's launch codes are lowercase snake_case — `grep 'code: "' mcpjam-inspector/server/routes/v1/` returns `billing_limit_reached`, `rate_limited`, `endpoint_url_not_allowed`, `catalog_server_not_found`, and friends.

Run through the real redactor:

```
details: { code: "billing_limit_reached" }  ->  details: { code: "[REDACTED]" }
details: { code: "TARGET_REQUIRED" }        ->  details: { code: "TARGET_REQUIRED" }
```

So the most common launch failure — out of credits — reached the CI artifact as `[REDACTED]`. Renamed to `errorCode`, which normalizes to `errorcode` and is not matched.

The existing test used `HOST_OFFLINE`, which survives either way. That is why this passed review and CI. The new test uses a lowercase code.

## 2. JUnit was not hardened against the text it now carries

`escapeXml` handled `& < > " '` but not the characters XML 1.0 forbids **outright** — most C0 controls and unpaired surrogates cannot be written even as character references. #4310 is the first thing to route model- and server-authored text (an iteration's `error`) into a `<failure message=…>`, so one such byte produces a file no JUnit parser will read, and the job then fails inside the CI runner's parser with nothing pointing back at the report.

Escaped visibly as `\uXXXX` rather than dropped — the byte is usually the interesting half of the message. This affects **every** structured reporter, not just evals, so the changeset says so.

`@xmldom/xmldom` parses a NUL without complaint, so it cannot serve as the oracle here; the test asserts the invariant directly.

## 3. `--wait` lost the launch receipt on a wait timeout

With neither `--reporter` nor `--out`, the `waitErrors` branch threw from *inside* the `runPlatformCommand` callback, so `writeResult(result, …)` never ran. `mcpjam cloud eval run --wait --format json > out.json` that timed out wrote an **empty** `out.json`, with the run ids surviving only as prose inside the stderr message — stranding runs the caller had already paid for, with no handle to find, resume, or cancel them.

The failure now raises on the shared exit path, after the receipt is on stdout, and names the runs in machine-readable `details.runIds` rather than only in English.

## 4-5. Documentation

- **`eval gate`'s four exit codes.** #4310 added the first-ever `cloud eval gate` reference section and omitted them; `grep` over `docs/` found the contract nowhere. Added, including the rule that no infrastructure condition ever maps to `1`. Lane E's brief is explicit that two undocumented exit-code contracts must not emerge.
- **`eval run --wait` exits 0 on a completed failing run.** The merged note said "keeps its existing exit codes … without introducing verdict-based exit codes", which is accurate but indirect: a reader who copies the first workflow step and skips the gate step gets a green build on a failing eval. Now stated plainly, with the `jq` assertion for anyone who wants the artifact without the gate.

## Verification

- `npm run -w @mcpjam/cli test` — 921 passed, 0 failed
- `npx vitest run` in `sdk/` — 5,915 passed, 8 skipped, 281 files
- `npm run -w @mcpjam/cli typecheck`, `npm run -w @mcpjam/sdk typecheck` — both clean
- Each of the three code fixes reverted in turn with its test retained: all three fail, then pass again with the fix restored
- Prettier compared against the base blob through the same command — the two files that warn already warned before this change, so no new divergence. No `--write`.

Exit-code semantics are unchanged; that remains Lane E's E1, which is now a migration rather than an addition, since `--wait` shipped ahead of it under the legacy codes.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit e4643f5f52ad2fc1a7f332c33a87058fdd5f0f7a. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes three eval reporting regressions and hardens JUnit output. Launch failure codes are no longer redacted, JUnit XML is now valid under XML 1.0, and `--wait` timeouts no longer drop the launch receipt.

- Launch failures: rename `details.code` to `details.errorCode` so lowercase launch codes (for example, billing_limit_reached) survive telemetry redaction.
- JUnit: escape characters XML 1.0 forbids outright by rendering them as visible `\uXXXX`. This applies to all structured reporters in `@mcpjam/sdk`.
- Wait flow: `@mcpjam/cli` always writes the launch receipt before raising on a wait timeout or incomplete report. Errors now include `details.runIds` (and `waitErrors`) for machine-readable recovery.
- Docs: clarify that `cloud eval run --wait` exits 0 even when runs fail, and document `cloud eval gate`’s four exit codes.

Migration
- If you parse launch failure cases, read `details.errorCode` (was `details.code`).

<sup>Written for commit e4643f5f52ad2fc1a7f332c33a87058fdd5f0f7a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/MCPJam/inspector/pull/4313?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

