### PR TITLE
docs(evals): tool-policy refusals and replay inheritance

### DIFF
--- a/docs/contributing/evals-architecture.mdx
+++ b/docs/contributing/evals-architecture.mdx
@@ -187,9 +187,30 @@ Harness evals with `toolPolicy` are refused at launch because their MCP calls
 run out of process and cannot reach this execution gate. Harness enforcement is
 deferred to D4b. Policy blocks remain separate from eval failures.
 
+A policy that cannot be enforced refuses the run rather than running without
+it. Three launch-time refusals, all of them cases where continuing would look
+like a policied run and behave like an unrestricted one:
+
+| Code | Cause |
+| --- | --- |
+| `TOOL_POLICY_UNSUPPORTED` | The run resolves to a harness host (see above), or a hosted CLI launch declares `defaults.toolPolicy`. |
+| `TOOL_POLICY_INVALID` | A `deny` name matches no available tool. Per-iteration injected tools (`computer`, `finish_widget`, the sandbox `bash`) are accepted; skill and progressive-discovery meta-tool names are deferred with a warning, since whether they appear depends on the run. |
+| `TOOL_POLICY_ANNOTATIONS_UNAVAILABLE` | The annotation cache is cold for a selected server. Empty annotations classify every tool `unknown`, and `default` mode permits `unknown` — so the `destructiveHint` deny-by-default would silently become a no-op. |
+
+Replays inherit the policy. A replay is not recorded playback: `buildReplayManager`
+builds a real `MCPClientManager` from the stored `MCPServerReplayConfig` and
+re-dials the original servers with the original credentials, so a replay that
+lost the policy would execute for real the calls the source run blocked. The run
+row has no field to carry a policy yet, so the effective policy is snapshotted on
+each iteration's metadata and recovered from the source run at replay time. A
+source run showing policy activity (`policyBlockCount` / `policyWarnings`) with
+no recoverable snapshot refuses with `REPLAY_TOOL_POLICY_UNRECOVERABLE`:
+inferring "no policy" is the one default that cannot be safe.
+
 Hosted platform-authored suites currently lack the backend field required to
 carry this policy. The hosted CLI therefore continues to refuse authored
-`defaults.toolPolicy` rather than running without enforcement.
+`defaults.toolPolicy` rather than running without enforcement. When that field
+lands, the run-level value supersedes the per-iteration snapshot.
 
 ## Where the code lives
 


### PR DESCRIPTION
Docs only. Follows #4308 and #4318, which merged today.

The architecture page's tool-policy section documented the precedence, the untrusted-annotation rule, and the harness refusal — but not the two run-start refusals that shipped alongside them, nor what a replay does with a policy. Those are the two places where a run could look policied and behave otherwise, so they are exactly what a contributor needs stated.

Adds:

- **The refusal table.** `TOOL_POLICY_UNSUPPORTED` (harness host, or hosted CLI launch with `defaults.toolPolicy`), `TOOL_POLICY_INVALID` (a `deny` name matching no available tool — with the per-iteration injected names that ARE accepted, and the skill/meta names that are deferred with a warning), and `TOOL_POLICY_ANNOTATIONS_UNAVAILABLE` (cold annotation cache, where empty annotations classify everything `unknown` and `default` mode permits `unknown`, so the deny-by-default would silently no-op). Each row says why it refuses rather than warns.
- **Replay inheritance.** That a replay re-dials the original servers with the original credentials rather than serving recorded responses; that the effective policy is therefore snapshotted per iteration and recovered from the source run; and that an unrecoverable snapshot refuses with `REPLAY_TOOL_POLICY_UNRECOVERABLE` because inferring "no policy" is the one default that cannot be safe.
- One line on what changes when the backend `toolPolicy` field lands: the run-level value supersedes the per-iteration snapshot.

No behavior change, no code touched.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only update to the evals architecture page; no runtime or enforcement behavior changes.
> 
> **Overview**
> Documents the fail-closed tool-policy launch path on the evals architecture page: a policy that cannot be enforced refuses the run instead of running unrestricted.
> 
> Adds a table for `TOOL_POLICY_UNSUPPORTED`, `TOOL_POLICY_INVALID`, and `TOOL_POLICY_ANNOTATIONS_UNAVAILABLE`, including why a cold annotation cache would silently no-op deny-by-default.
> 
> Explains replay inheritance: replays re-dial original servers, so policy is snapshotted per iteration and recovered from the source run; missing snapshots with policy activity refuse with `REPLAY_TOOL_POLICY_UNRECOVERABLE`. Notes that a future run-level backend field will supersede the snapshot.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e62a20ffa09fec48b856a2eb64dc9c26ac060b6f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Documents eval tool-policy refusal cases and how replays inherit policy, so runs don’t appear policied while executing without enforcement.

- Lists launch-time refusal codes and why they refuse: `TOOL_POLICY_UNSUPPORTED` (harness host or hosted CLI with `defaults.toolPolicy`), `TOOL_POLICY_INVALID` (deny names match no available tool), and `TOOL_POLICY_ANNOTATIONS_UNAVAILABLE` (cold annotations would turn deny-by-default into a silent no-op).
- Explains replay inheritance: replays re-dial original servers using stored config; the effective policy is snapshotted per iteration and recovered at replay; an unrecoverable snapshot refuses with `REPLAY_TOOL_POLICY_UNRECOVERABLE`.
- Notes hosted behavior: until the backend run-level `toolPolicy` field exists, the hosted CLI continues to refuse authored `defaults.toolPolicy`; once it lands, the run-level value supersedes the per-iteration snapshot.

<sup>Written for commit e62a20ffa09fec48b856a2eb64dc9c26ac060b6f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/MCPJam/inspector/pull/4321?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

