### PR TITLE
fix caniuse gated host verification

### DIFF
--- a/mcpjam-inspector/client/src/App.tsx
+++ b/mcpjam-inspector/client/src/App.tsx
@@ -266,6 +266,8 @@ import {
   seedFromHostTemplate,
   type HostTemplateId,
 } from "@mcpjam/sdk/host-config/templates";
+import { useClaudeCodeHostEnabledState } from "./hooks/useClaudeCodeHostEnabled";
+import { useCodexHostEnabledState } from "./hooks/useCodexHostEnabled";
 import {
   HOST_VERIFY_TAB_PARAM,
   HOST_VERIFY_TEMPLATE_PARAM,
@@ -956,6 +958,8 @@ function useTemplateVerifyDeepLink({
     projectId,
   });
   const { createHost } = useHostMutations();
+  const claudeCodeEnabled = useClaudeCodeHostEnabledState();
+  const codexEnabled = useCodexHostEnabledState();
   const requestedTemplateId = useMemo<HostTemplateId | null>(() => {
     if (typeof window === "undefined") return null;
     const raw = new URLSearchParams(window.location.search).get(
@@ -982,15 +986,35 @@ function useTemplateVerifyDeepLink({
     if (hostsLoading || !shouldQueryProjectId(projectId)) return;
     const template = HOST_TEMPLATES.find((t) => t.id === requestedTemplateId);
     if (!template) return;
-    handledRef.current = true;
 
     const existing = hosts.find((h) => h.name === template.label);
     if (existing) {
+      handledRef.current = true;
       navigate(buildHostVerifyLandingPath(existing.hostId, requestedFocusTab), {
         replace: true,
       });
       return;
     }
+
+    const templateEnabled =
+      requestedTemplateId === "claude-code"
+        ? claudeCodeEnabled
+        : requestedTemplateId === "codex"
+        ? codexEnabled
+        : true;
+    // These templates remain visible on caniuse.dev as reference profiles,
+    // but they are not available for new-host creation until their rollout
+    // flags are enabled. Wait for PostHog before deciding so flagged users do
+    // not get bounced during a cold load.
+    if (templateEnabled === undefined) return;
+    if (!templateEnabled) {
+      handledRef.current = true;
+      navigate(routePaths.hosts, { replace: true });
+      toast.error(`${template.label} is not available yet.`);
+      return;
+    }
+
+    handledRef.current = true;
 
     void (async () => {
       try {
@@ -1021,6 +1045,8 @@ function useTemplateVerifyDeepLink({
     hosts,
     projectId,
     requestedFocusTab,
+    claudeCodeEnabled,
+    codexEnabled,
     themeMode,
     createHost,
     navigate,

--- a/mcpjam-inspector/client/src/__tests__/HostsRoute.non-id-url.test.tsx
+++ b/mcpjam-inspector/client/src/__tests__/HostsRoute.non-id-url.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen } from "@testing-library/react";
+import { render, screen, waitFor } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { routePaths } from "../lib/app-navigation";
 
@@ -22,6 +22,8 @@ const {
   mockNavigate,
   mockParams,
   mockHostList,
+  mockCreateHost,
+  mockFeatureFlags,
   mockPreviewed,
   mockSetPreviewedHostId,
   mockSetHostsTabSelectedHostId,
@@ -41,6 +43,11 @@ const {
   mockHostList: {
     hosts: [] as Array<{ hostId: string }>,
     isLoading: false,
+  },
+  mockCreateHost: vi.fn(),
+  mockFeatureFlags: {
+    claudeCode: false,
+    codex: false,
   },
   mockPreviewed: { value: null as string | null },
   mockSetPreviewedHostId: vi.fn(),
@@ -78,13 +85,26 @@ vi.mock("../hooks/useClients", async (importOriginal) => {
     ...actual,
     useHostList: () => mockHostList,
     useHostMutations: () => ({
-      createHost: vi.fn(),
+      createHost: mockCreateHost,
       updateHostServers: vi.fn(),
       deleteHost: vi.fn(),
       duplicateHost: vi.fn(),
     }),
   };
 });
+
+vi.mock("posthog-js/react", () => ({
+  useFeatureFlagEnabled: (flag: string) =>
+    flag === "claude-code-host-enabled"
+      ? mockFeatureFlags.claudeCode
+      : flag === "codex-host-enabled"
+      ? mockFeatureFlags.codex
+      : false,
+}));
+
+vi.mock("../lib/toast", () => ({
+  toast: { error: vi.fn(), success: vi.fn(), message: vi.fn() },
+}));
 
 vi.mock("../lib/app-navigation", async (importOriginal) => {
   const actual = await importOriginal<typeof import("../lib/app-navigation")>();
@@ -145,9 +165,13 @@ beforeEach(() => {
   mockRouteContext.setHostsTabSelectedHostId = mockSetHostsTabSelectedHostId;
   mockPreviewed.value = null;
   mockParams.hostId = undefined;
+  window.history.replaceState({}, "", routePaths.hosts);
   // Loaded, and the id this suite opens is a live client of the project.
   mockHostList.hosts = [{ hostId: CONVEX_HOST_ID }];
   mockHostList.isLoading = false;
+  mockCreateHost.mockReset();
+  mockFeatureFlags.claudeCode = false;
+  mockFeatureFlags.codex = false;
 });
 
 afterEach(() => {
@@ -155,6 +179,20 @@ afterEach(() => {
 });
 
 describe("HostsRoute — a URL segment that is not a Convex host id", () => {
+  it("does not create a gated host from a direct verify URL", async () => {
+    mockHostList.hosts = [];
+    window.history.replaceState({}, "", `${routePaths.hosts}?template=codex`);
+
+    render(<HostsRoute />);
+
+    await waitFor(() => {
+      expect(mockNavigate).toHaveBeenCalledWith(routePaths.hosts, {
+        replace: true,
+      });
+    });
+    expect(mockCreateHost).not.toHaveBeenCalled();
+  });
+
   it("sends a catalog slug to the clients list instead of opening it", () => {
     mockParams.hostId = "chatgpt";
 

--- a/mcpjam-inspector/client/src/components/hosts/comparison/HostConfigCompareView.tsx
+++ b/mcpjam-inspector/client/src/components/hosts/comparison/HostConfigCompareView.tsx
@@ -251,6 +251,14 @@ export function HostConfigCompareView({
     if (!codexEnabled) excluded.add("codex");
     return excluded;
   }, [claudeCodeEnabled, codexEnabled, presetOnly]);
+  // Public caniuse still displays flag-gated hosts as reference data, but
+  // must not offer their verify links because those links auto-create a host.
+  const disabledVerifyTemplateIds = useMemo(() => {
+    const disabled = new Set<string>();
+    if (presetOnly || !claudeCodeEnabled) disabled.add("claude-code");
+    if (presetOnly || !codexEnabled) disabled.add("codex");
+    return disabled;
+  }, [claudeCodeEnabled, codexEnabled, presetOnly]);
   const presets = useMemo(() => {
     if (!compareCatalog) {
       return { hosts: [], subjects: {} as Record<string, HostComparisonSubject> };
@@ -689,6 +697,7 @@ export function HostConfigCompareView({
                         selectedHostIdSet.size > 1 ? handleToggleHost : undefined
                       }
                       verifyBaseUrl={verifyBaseUrl}
+                      disabledVerifyTemplateIds={disabledVerifyTemplateIds}
                     />
                   </div>
                 ) : (

--- a/mcpjam-inspector/client/src/components/hosts/comparison/__tests__/host-config-comparison-matrix.test.tsx
+++ b/mcpjam-inspector/client/src/components/hosts/comparison/__tests__/host-config-comparison-matrix.test.tsx
@@ -104,6 +104,35 @@ describe("HostConfigComparisonMatrix", () => {
     );
   });
 
+  it("does not link public reference-only gated hosts to host creation", () => {
+    render(
+      <HostConfigComparisonMatrix
+        subjects={[
+          makeSubject("preset:claude-code", "Claude Code"),
+          makeSubject("preset:codex", "Codex"),
+          makeSubject("preset:claude", "Claude"),
+        ]}
+        verifyBaseUrl="https://app.mcpjam.com"
+        disabledVerifyTemplateIds={new Set(["claude-code", "codex"])}
+      />
+    );
+
+    expect(
+      screen.queryByRole("link", {
+        name: "Verify Claude Code against your server",
+      })
+    ).not.toBeInTheDocument();
+    expect(
+      screen.queryByRole("link", { name: "Verify Codex against your server" })
+    ).not.toBeInTheDocument();
+    expect(
+      screen.getByRole("link", { name: "Verify Claude against your server" })
+    ).toHaveAttribute(
+      "href",
+      "https://app.mcpjam.com/hosts?template=claude&hostTab=agent"
+    );
+  });
+
   it("shows per-host verified dates only in public caniuse mode", () => {
     const subject = makeSubject(
       "preset:claude",

--- a/mcpjam-inspector/client/src/components/hosts/comparison/host-config-comparison-matrix.tsx
+++ b/mcpjam-inspector/client/src/components/hosts/comparison/host-config-comparison-matrix.tsx
@@ -71,6 +71,8 @@ interface HostConfigComparisonMatrixProps {
    * surface (`presetOnly`), where every column is a synthetic preset host.
    */
   verifyBaseUrl?: string;
+  /** Template ids that are visible for reference but cannot be verified yet. */
+  disabledVerifyTemplateIds?: ReadonlySet<string>;
 }
 
 /**
@@ -92,6 +94,7 @@ export function HostConfigComparisonMatrix({
   themeMode = "light",
   mobileOptimized = false,
   verifyBaseUrl,
+  disabledVerifyTemplateIds,
 }: HostConfigComparisonMatrixProps) {
   const groups = useMemo(() => groupHostConfigFields(fields), [fields]);
   const configs = useMemo(() => subjects.map((s) => s.config), [subjects]);
@@ -248,6 +251,7 @@ export function HostConfigComparisonMatrix({
                   onRemove={onRemoveHost}
                   themeMode={themeMode}
                   verifyBaseUrl={verifyBaseUrl}
+                  disabledVerifyTemplateIds={disabledVerifyTemplateIds}
                 />
               ))}
             </tr>
@@ -903,11 +907,13 @@ function HostColumnHeader({
   onRemove,
   themeMode,
   verifyBaseUrl,
+  disabledVerifyTemplateIds,
 }: {
   subject: HostComparisonSubject;
   onRemove?: (hostId: string) => void;
   themeMode: HostThemeMode;
   verifyBaseUrl?: string;
+  disabledVerifyTemplateIds?: ReadonlySet<string>;
 }) {
   const logoSrc = getScenarioHostLogo(
     subject.hostStyle,
@@ -915,7 +921,11 @@ function HostColumnHeader({
     themeMode
   );
   const reduceMotion = useReducedMotion();
-  const verifyHref = buildVerifyHref(verifyBaseUrl, subject.hostId);
+  const verifyHref = buildVerifyHref(
+    verifyBaseUrl,
+    subject.hostId,
+    disabledVerifyTemplateIds
+  );
 
   return (
     <th className="sticky top-0 z-20 border-b border-l border-border bg-card px-3 py-3 text-center align-top sm:px-4 sm:py-4">
@@ -984,11 +994,13 @@ function HostColumnHeader({
  */
 function buildVerifyHref(
   baseUrl: string | undefined,
-  hostId: string
+  hostId: string,
+  disabledVerifyTemplateIds?: ReadonlySet<string>
 ): string | null {
   if (!baseUrl) return null;
   if (!hostId.startsWith(PRESET_HOST_ID_PREFIX)) return baseUrl;
   const templateId = hostId.slice(PRESET_HOST_ID_PREFIX.length);
+  if (disabledVerifyTemplateIds?.has(templateId)) return null;
   return `${baseUrl}/hosts?${buildHostVerifySearch(templateId, "behavior")}`;
 }
 

--- a/mcpjam-inspector/client/src/hooks/useClaudeCodeHostEnabled.ts
+++ b/mcpjam-inspector/client/src/hooks/useClaudeCodeHostEnabled.ts
@@ -13,6 +13,11 @@ import { useFeatureFlagEnabled } from "posthog-js/react";
  */
 export const CLAUDE_CODE_HOST_FEATURE_FLAG = "claude-code-host-enabled";
 
+/** Tri-state flag value for route guards that must wait for PostHog. */
+export function useClaudeCodeHostEnabledState(): boolean | undefined {
+  return useFeatureFlagEnabled(CLAUDE_CODE_HOST_FEATURE_FLAG);
+}
+
 export function useClaudeCodeHostEnabled(): boolean {
-  return useFeatureFlagEnabled(CLAUDE_CODE_HOST_FEATURE_FLAG) === true;
+  return useClaudeCodeHostEnabledState() === true;
 }

--- a/mcpjam-inspector/client/src/hooks/useCodexHostEnabled.ts
+++ b/mcpjam-inspector/client/src/hooks/useCodexHostEnabled.ts
@@ -14,6 +14,11 @@ import { useFeatureFlagEnabled } from "posthog-js/react";
  */
 export const CODEX_HOST_FEATURE_FLAG = "codex-host-enabled";
 
+/** Tri-state flag value for route guards that must wait for PostHog. */
+export function useCodexHostEnabledState(): boolean | undefined {
+  return useFeatureFlagEnabled(CODEX_HOST_FEATURE_FLAG);
+}
+
 export function useCodexHostEnabled(): boolean {
-  return useFeatureFlagEnabled(CODEX_HOST_FEATURE_FLAG) === true;
+  return useCodexHostEnabledState() === true;
 }


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Fixes verify links for feature-gated templates on caniuse: `claude-code` and `codex` no longer auto-create hosts unless their feature flags are enabled. Previously, visiting a verify URL created a host and could bounce before flags loaded; now we wait for PostHog, block creation when disabled, and redirect to Hosts with an error toast.

- Route guard: deep-link host creation waits for tri-state flags via `useClaudeCodeHostEnabledState` and `useCodexHostEnabledState`. If a template is disabled, navigate to `routePaths.hosts` and show a toast. Flags: `claude-code-host-enabled`, `codex-host-enabled`.
- Compare view: caniuse shows gated presets as reference data but omits their verify links via `disabledVerifyTemplateIds`.
- Tests: add coverage to prevent gated host creation from direct verify URLs and to ensure verify links are suppressed for gated presets.

<sup>Written for commit 85a360594d2598c4c9fa6738c38d233e6396debd. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/MCPJam/inspector/pull/4324?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

