### PR TITLE
Add toolListChanged and toolResult probe fields to mcpProfile

### DIFF
--- a/mcpjam-inspector/client/src/App.tsx
+++ b/mcpjam-inspector/client/src/App.tsx
@@ -3448,6 +3448,14 @@ export default function App() {
         : undefined;
     const supportsMrtr =
       activeMcpProfile?.mrtrSupport === "none" ? (false as const) : undefined;
+    const suppressListenChannel =
+      activeMcpProfile?.toolListChanged?.listens === false
+        ? (true as const)
+        : undefined;
+    const dropToolListChanged =
+      activeMcpProfile?.toolListChanged?.refetches === false
+        ? (true as const)
+        : undefined;
 
     return {
       clientInfo,
@@ -3459,6 +3467,8 @@ export default function App() {
       mirrorToolParamHeaders,
       firstPageOnly,
       supportsMrtr,
+      suppressListenChannel,
+      dropToolListChanged,
       xaaPolicy,
     };
   }, [

--- a/mcpjam-inspector/client/src/components/chat-v2/thread/mcp-apps/__tests__/host-app-bridge.test.ts
+++ b/mcpjam-inspector/client/src/components/chat-v2/thread/mcp-apps/__tests__/host-app-bridge.test.ts
@@ -264,6 +264,59 @@ describe("registerHostBridgeHandlers — app-tool invocation lifecycle", () => {
     expect((updates[0] as { id: string }).id).toBe("parent-1:app-tool:7");
   });
 
+  it("shapes the returned result by the host's toolResult policy", async () => {
+    const bridge = makeStubBridge();
+    const updates: Array<{ status: string; output?: unknown }> = [];
+    const raw = {
+      content: [
+        { type: "text", text: "keep" },
+        { type: "image", data: "aGk=", mimeType: "image/png" },
+      ],
+      structuredContent: { dropped: true },
+    };
+    register(bridge, {
+      getMatrix: () => ({
+        toolResult: {
+          structuredContent: false,
+          content: { image: false },
+        },
+      }),
+      callbacks: {
+        onCallTool: vi.fn().mockResolvedValue(raw),
+        onAppToolInvocation: (u) => updates.push(u),
+      },
+    });
+
+    const returned = await (
+      bridge.oncalltool as (p: unknown, e: unknown) => Promise<{
+        content: Array<{ type: string }>;
+        structuredContent?: unknown;
+      }>
+    )({ name: "go", arguments: {} }, {});
+
+    // What the widget receives.
+    expect("structuredContent" in returned).toBe(false);
+    expect(returned.content.map((b) => b.type)).toEqual(["text"]);
+    // ...and what the inspector's panel records is the SAME shaped value, so
+    // a widget author debugging a Cursor-style host sees what the widget saw.
+    expect(updates[1].output).toEqual(returned);
+    // The upstream result object is never mutated.
+    expect(raw.structuredContent).toEqual({ dropped: true });
+  });
+
+  it("passes the result through untouched when no policy is configured", async () => {
+    const bridge = makeStubBridge();
+    const raw = { content: [{ type: "text", text: "x" }], structuredContent: {} };
+    register(bridge, {
+      callbacks: { onCallTool: vi.fn().mockResolvedValue(raw) },
+    });
+
+    const returned = await (
+      bridge.oncalltool as (p: unknown, e: unknown) => Promise<unknown>
+    )({ name: "go", arguments: {} }, {});
+    expect(returned).toBe(raw);
+  });
+
   it("emits running → error and cancels when the dispatch throws", async () => {
     const bridge = makeStubBridge();
     const updates: Array<{ status: string; errorText?: string }> = [];

--- a/mcpjam-inspector/client/src/components/chat-v2/thread/mcp-apps/__tests__/mcp-apps-renderer.test.tsx
+++ b/mcpjam-inspector/client/src/components/chat-v2/thread/mcp-apps/__tests__/mcp-apps-renderer.test.tsx
@@ -1246,16 +1246,59 @@ describe("MCPAppsRenderer tool input streaming", () => {
       expect(mcpAppsModalPropsRef.current).not.toBeNull();
     });
     // ChatGPT honors the declared connect list (one directive, proven by the
-    // declared wss endpoint connecting while an undeclared one was blocked)
-    // and its resource subtypes are unknown, so they never reach the proxy.
+    // declared wss endpoint connecting while an undeclared one was blocked).
+    // Its resource subtypes were unknown until the 2026-08-23 paired probe
+    // declared `fastly.jsdelivr.net` — outside ChatGPT's baseline allowlist —
+    // and every subtype loaded, so they are now measured-true rather than
+    // absent.
     const expected = {
       cspConnectDomains: { fetch: true, xhr: true, websocket: true },
-      cspResourceDomains: undefined,
+      cspResourceDomains: {
+        script: true,
+        stylesheet: true,
+        image: true,
+        font: true,
+        media: true,
+      },
     };
     expect(sandboxedIframePropsRef.current.cspSubtypePolicy).toEqual(expected);
     expect(mcpAppsModalPropsRef.current?.widgetCspSubtypePolicy).toEqual(
       expected
     );
+  });
+
+  it("forwards browserStorage to inline and modal sandboxes, unchanged", async () => {
+    mcpAppsModalPropsRef.current = null;
+    const profile: HostConfigMcpProfileV1 = {
+      profileVersion: 1,
+      apps: { sandbox: { browserStorage: { localStorage: false } } },
+    };
+    render(
+      <ActiveMcpProfileProvider value={profile}>
+        <HostedRenderer {...baseProps} />
+      </ActiveMcpProfileProvider>
+    );
+    await vi.waitFor(() => {
+      expect(mcpAppsModalPropsRef.current).not.toBeNull();
+    });
+    // Passed through verbatim: the proxy, not the renderer, decides what a
+    // `false` leaf means. Both surfaces must agree — a widget moved to the
+    // modal cannot regain an API the inline frame denied it.
+    const expected = { localStorage: false };
+    expect(sandboxedIframePropsRef.current.browserStorage).toEqual(expected);
+    expect(mcpAppsModalPropsRef.current?.widgetBrowserStorage).toEqual(
+      expected
+    );
+  });
+
+  it("leaves browserStorage undefined when the profile never mentions it", async () => {
+    render(<HostedRenderer {...baseProps} />);
+    await vi.waitFor(() => {
+      expect(screen.getByTestId("sandboxed-iframe")).toBeInTheDocument();
+    });
+    // Absent must stay absent all the way to the proxy — an empty object
+    // would arm the guard machinery for a host nobody probed.
+    expect(sandboxedIframePropsRef.current.browserStorage).toBeUndefined();
   });
 
   it("keeps a permissive replay permissive when the host's subtype policy allows everything", async () => {

--- a/mcpjam-inspector/client/src/components/hosts/comparison/CaniuseCapabilityPage.tsx
+++ b/mcpjam-inspector/client/src/components/hosts/comparison/CaniuseCapabilityPage.tsx
@@ -173,7 +173,18 @@ export function CaniuseCapabilityPage({
                   </span>
                 </div>
                 <div>
-                  <SupportChip level={level} label={label} truncateLabel />
+                  {level === "unknown" ? (
+                    // Not probed yet. An em dash rather than a chip: a chip
+                    // reads as a verdict, and we have not measured this host.
+                    <span
+                      className="text-muted-foreground"
+                      title="Not yet tested"
+                    >
+                      —
+                    </span>
+                  ) : (
+                    <SupportChip level={level} label={label} truncateLabel />
+                  )}
                 </div>
                 <div className="text-xs tabular-nums text-muted-foreground">
                   {CANIUSE_LAST_VERIFIED_DATE}

--- a/mcpjam-inspector/client/src/components/hosts/comparison/__tests__/caniuse-capability-catalog.test.ts
+++ b/mcpjam-inspector/client/src/components/hosts/comparison/__tests__/caniuse-capability-catalog.test.ts
@@ -73,6 +73,30 @@ describe("caniuse capability catalog", () => {
     expect(getCaniuseSupportLabel("unknown")).toBe("Not yet tested");
   });
 
+  it("publishes pagination as a yes/no row, unknown until probed", () => {
+    const ids = PUBLIC_CAN_I_USE_FIELDS.map((field) => field.id);
+    expect(ids).toContain("paginationTraversal");
+
+    const field = hostConfigField("paginationTraversal");
+    const withValue = (value: string) =>
+      ({
+        ...emptyHostConfigInputV2(),
+        mcpProfile: { profileVersion: 1, paginationTraversal: value },
+      }) as never;
+
+    // Binary by design: a client either follows nextCursor or stops at page
+    // one. There is no partial state to render.
+    expect(getCaniuseSupportLevel(field, withValue("full"))).toBe("supported");
+    expect(getCaniuseSupportLevel(field, withValue("firstPageOnly"))).toBe(
+      "unsupported"
+    );
+
+    // A host nobody probed must never be published as failing.
+    expect(
+      getCaniuseSupportLevel(field, emptyHostConfigInputV2() as never)
+    ).toBe("unknown");
+  });
+
   it("excludes config-only fields from public capability pages", () => {
     const ids = PUBLIC_CAN_I_USE_FIELDS.map((field) => field.id);
     expect(ids).not.toContain("modelId");

--- a/mcpjam-inspector/client/src/components/hosts/comparison/__tests__/caniuse-capability-catalog.test.ts
+++ b/mcpjam-inspector/client/src/components/hosts/comparison/__tests__/caniuse-capability-catalog.test.ts
@@ -6,7 +6,10 @@ import {
   buildCaniuseCapabilityPath,
   getCaniuseCapabilityForField,
   getCaniuseCapabilityBySlug,
+  getCaniuseSupportLabel,
+  getCaniuseSupportLevel,
 } from "../caniuse-capability-catalog";
+import { emptyHostConfigInputV2 } from "@/lib/client-config-v2";
 import { hostConfigField } from "@/lib/host-config-field-schema";
 
 describe("caniuse capability catalog", () => {
@@ -45,6 +48,29 @@ describe("caniuse capability catalog", () => {
         "appsCap.cspBaseUriDomains",
       ])
     );
+  });
+
+  it("includes the widget tool-result and sandbox storage probe rows", () => {
+    const ids = PUBLIC_CAN_I_USE_FIELDS.map((field) => field.id);
+    expect(ids).toEqual(
+      expect.arrayContaining([
+        "toolResult.structuredContent",
+        "toolResult.content.text",
+        "toolResult.content.resourceLink",
+        "sandbox.browserStorage.localStorage",
+        "sandbox.browserStorage.sessionStorage",
+        "sandbox.browserStorage.indexedDB",
+      ])
+    );
+
+    const config = emptyHostConfigInputV2() as never;
+    expect(
+      getCaniuseSupportLevel(
+        hostConfigField("toolResult.structuredContent"),
+        config
+      )
+    ).toBe("unknown");
+    expect(getCaniuseSupportLabel("unknown")).toBe("Not yet tested");
   });
 
   it("excludes config-only fields from public capability pages", () => {

--- a/mcpjam-inspector/client/src/components/hosts/comparison/caniuse-capability-catalog.ts
+++ b/mcpjam-inspector/client/src/components/hosts/comparison/caniuse-capability-catalog.ts
@@ -166,7 +166,11 @@ export function getCaniuseSupportLevel(
   if (
     (field.id.startsWith("toolResult.") ||
       field.id.startsWith("sandbox.browserStorage.") ||
-      field.id.startsWith("toolListChanged.")) &&
+      field.id.startsWith("toolListChanged.") ||
+      // Enum rather than boolean, so it resolves to "neutral" rather than
+      // undefined when unset — and "neutral" renders as "Not supported".
+      // Without this an unprobed host publicly claims it cannot paginate.
+      field.id === "paginationTraversal") &&
     field.read(config) === undefined
   ) {
     return "unknown";

--- a/mcpjam-inspector/client/src/components/hosts/comparison/caniuse-capability-catalog.ts
+++ b/mcpjam-inspector/client/src/components/hosts/comparison/caniuse-capability-catalog.ts
@@ -41,6 +41,9 @@ export interface CaniuseCapability {
   field: HostConfigFieldDef;
 }
 
+/** A public capability page can say "not yet measured" without treating it as a failure. */
+export type CaniuseSupportLevel = SupportLevel | "unknown";
+
 function toKebab(input: string): string {
   return input
     .replace(/([a-z0-9])([A-Z])/g, "$1-$2")
@@ -155,11 +158,23 @@ export function sortCaniusePresetHosts<T extends Pick<HostListItem, "hostId">>(
 export function getCaniuseSupportLevel(
   field: HostConfigFieldDef,
   config: HostConfigDtoV2,
-): SupportLevel {
-  return getSupportLevel(field, config) ?? "neutral";
+): CaniuseSupportLevel {
+  // These probe families were added after the catalog had shipped. An absent
+  // value means we have not run that probe for this host yet — not that its
+  // browser iframe, widget relay, or notification channel failed. Other
+  // boolean rows retain their established absent = not supported semantics.
+  if (
+    (field.id.startsWith("toolResult.") ||
+      field.id.startsWith("sandbox.browserStorage.") ||
+      field.id.startsWith("toolListChanged.")) &&
+    field.read(config) === undefined
+  ) {
+    return "unknown";
+  }
+  return getSupportLevel(field, config) ?? "unknown";
 }
 
-export function getCaniuseSupportLabel(level: SupportLevel): string {
+export function getCaniuseSupportLabel(level: CaniuseSupportLevel): string {
   switch (level) {
     case "supported":
       return "Supported";
@@ -168,5 +183,7 @@ export function getCaniuseSupportLabel(level: SupportLevel): string {
     case "neutral":
     case "unsupported":
       return "Not supported";
+    case "unknown":
+      return "Not yet tested";
   }
 }

--- a/mcpjam-inspector/client/src/components/hosts/comparison/support-chip.tsx
+++ b/mcpjam-inspector/client/src/components/hosts/comparison/support-chip.tsx
@@ -1,24 +1,28 @@
 import { cn } from "@/lib/utils";
 import type { SupportLevel } from "./support-level";
 
+type SupportChipLevel = SupportLevel | "unknown";
+
 /**
  * caniuse-style support pill: a colored dot + label. Tinted surface (`/40–/50`)
  * with a full-token dot and `text-foreground`, per the surface-vs-foreground
  * opacity convention.
  */
 
-const LEVEL_SURFACE: Record<SupportLevel, string> = {
+const LEVEL_SURFACE: Record<SupportChipLevel, string> = {
   supported: "bg-success/50 text-foreground",
   partial: "bg-warning/50 text-foreground",
   neutral: "bg-muted/40 text-muted-foreground",
   unsupported: "bg-destructive/50 text-foreground",
+  unknown: "bg-muted/40 text-muted-foreground",
 };
 
-const LEVEL_DOT: Record<SupportLevel, string> = {
+const LEVEL_DOT: Record<SupportChipLevel, string> = {
   supported: "bg-success",
   partial: "bg-warning",
   neutral: "bg-muted-foreground/50",
   unsupported: "bg-destructive",
+  unknown: "bg-muted-foreground/50",
 };
 
 export function SupportChip({
@@ -27,7 +31,7 @@ export function SupportChip({
   className,
   truncateLabel = false,
 }: {
-  level: SupportLevel;
+  level: SupportChipLevel;
   label: string;
   className?: string;
   truncateLabel?: boolean;

--- a/mcpjam-inspector/client/src/components/hosts/redesigned/focus/AppsExtensionTab.tsx
+++ b/mcpjam-inspector/client/src/components/hosts/redesigned/focus/AppsExtensionTab.tsx
@@ -481,13 +481,12 @@ function appsToJson(draft: HostConfigInputV2): AppsDoc {
   // sparsity convention).
   const mcpAppsOverrides = draft.mcpProfile?.apps?.mcpAppsOverrides;
   if (mcpAppsOverrides !== undefined) {
-    // Tool Result delivery is a base MCP concern. It is stored on the
-    // widget relay override, but belongs in the Protocol tab; do not make it
-    // look like an `app.*` capability here. The parser preserves it below.
-    const { toolResult: _toolResult, ...appsOverridesForEditor } =
-      mcpAppsOverrides;
-    if (Object.keys(appsOverridesForEditor).length > 0) {
-      doc.mcpAppsOverrides = appsOverridesForEditor;
+    // `toolResult` is emitted alongside the `app.*` rows even though it is
+    // not one: this tab owns the card that edits it, and a JSON editor that
+    // hid a value the tab above it can change would read as data loss the
+    // first time someone toggled a part and saw nothing appear.
+    if (Object.keys(mcpAppsOverrides).length > 0) {
+      doc.mcpAppsOverrides = mcpAppsOverrides;
     }
   }
 
@@ -594,16 +593,44 @@ export function applyJsonToDraft(
     if (Object.keys(out).length > 0) nextMcpAppsOverrides = out;
   }
 
-  // This editor owns `app.*` capability rows, not base-MCP tool results.
-  // Keep the Protocol-tab value intact when a user saves Apps JSON or edits
-  // the matrix. Its physical nesting under mcpAppsOverrides must not turn it
-  // into an accidental casualty of an Apps-tab save.
-  const previousToolResult = prev.mcpProfile?.apps?.mcpAppsOverrides?.toolResult;
-  if (previousToolResult !== undefined) {
-    nextMcpAppsOverrides = {
-      ...(nextMcpAppsOverrides ?? {}),
-      toolResult: previousToolResult,
-    };
+  // `toolResult` round-trips through this editor rather than being preserved
+  // from `prev`: the card that edits it lives in this tab, so deleting the
+  // key here has to mean "clear it" like every other key. Validated per leaf
+  // because the matrix path strips unknown shapes and this one would
+  // otherwise persist whatever was typed.
+  const parsedOverridesRecord = isPlainObject(parsed.mcpAppsOverrides)
+    ? (parsed.mcpAppsOverrides as Record<string, unknown>)
+    : undefined;
+  const incomingToolResult = parsedOverridesRecord?.toolResult;
+  if (isPlainObject(incomingToolResult)) {
+    const nextToolResult: NonNullable<McpAppsCapabilities["toolResult"]> = {};
+    if (typeof incomingToolResult.structuredContent === "boolean") {
+      nextToolResult.structuredContent = incomingToolResult.structuredContent;
+    }
+    if (isPlainObject(incomingToolResult.content)) {
+      const content: NonNullable<
+        NonNullable<McpAppsCapabilities["toolResult"]>["content"]
+      > = {};
+      for (const key of [
+        "text",
+        "image",
+        "audio",
+        "resource",
+        "resourceLink",
+      ] as const) {
+        const value = (incomingToolResult.content as Record<string, unknown>)[
+          key
+        ];
+        if (typeof value === "boolean") content[key] = value;
+      }
+      if (Object.keys(content).length > 0) nextToolResult.content = content;
+    }
+    if (Object.keys(nextToolResult).length > 0) {
+      nextMcpAppsOverrides = {
+        ...(nextMcpAppsOverrides ?? {}),
+        toolResult: nextToolResult,
+      };
+    }
   }
 
   // hostCapabilities — the user sees the EFFECTIVE merged value, so on
@@ -1876,6 +1903,125 @@ function BrowserStorageCard({
   );
 }
 
+/**
+ * `mcpProfile.apps.mcpAppsOverrides.toolResult` — which halves of a tool
+ * result the emulated host relays to a widget that called the tool.
+ *
+ * Deliberately its own card rather than a row in the capability matrix: the
+ * matrix gates whether an app.* handler EXISTS, while this shapes the value a
+ * live handler returns. `apps-capability-dimensions` excludes it for the same
+ * reason. It shares the matrix's storage only because its physical nesting
+ * sits under `mcpAppsOverrides`.
+ */
+function WidgetToolResultsCard({
+  draft,
+  onDraftChange,
+}: {
+  draft: HostConfigInputV2;
+  onDraftChange: (
+    updater: (prev: HostConfigInputV2) => HostConfigInputV2
+  ) => void;
+}) {
+  const toolResult = draft.mcpProfile?.apps?.mcpAppsOverrides?.toolResult;
+  const setToolResultPart = (
+    key:
+      | "structuredContent"
+      | "text"
+      | "image"
+      | "audio"
+      | "resource"
+      | "resourceLink",
+    enabled: boolean
+  ) => {
+    onDraftChange((prev) => {
+      const base: HostConfigMcpProfileV1 = prev.mcpProfile ?? {
+        profileVersion: 1,
+      };
+      const apps = base.apps ?? {};
+      const overrides = { ...(apps.mcpAppsOverrides ?? {}) };
+      const next = { ...(overrides.toolResult ?? {}) };
+      // Absence means the part is forwarded, so only the non-default finding
+      // is persisted — same discipline as every probe knob.
+      if (key === "structuredContent") {
+        if (enabled) delete next.structuredContent;
+        else next.structuredContent = false;
+      } else {
+        const content = { ...(next.content ?? {}) };
+        if (enabled) delete content[key];
+        else content[key] = false;
+        if (Object.keys(content).length > 0) next.content = content;
+        else delete next.content;
+      }
+      if (Object.keys(next).length > 0) overrides.toolResult = next;
+      else delete overrides.toolResult;
+
+      const nextApps = { ...apps };
+      if (Object.keys(overrides).length > 0) {
+        nextApps.mcpAppsOverrides = overrides;
+      } else {
+        delete nextApps.mcpAppsOverrides;
+      }
+      const updated: HostConfigMcpProfileV1 = {
+        ...base,
+        apps: Object.keys(nextApps).length > 0 ? nextApps : undefined,
+      };
+      // Collapse to absence, or toggling a part off and back on leaves
+      // `{ profileVersion: 1 }` behind and mints a new config hash for a
+      // user who changed nothing.
+      return {
+        ...prev,
+        mcpProfile: isMcpProfileEmpty(updated) ? undefined : updated,
+      };
+    });
+  };
+
+  return (
+    <section className="rounded-[10px] border border-border bg-background">
+      <div className="border-b border-border px-3.5 py-2.5">
+        <div className="text-[12px] font-medium">Widget tool results</div>
+        <p className="mt-0.5 text-[11px] leading-snug text-muted-foreground">
+          Which parts of a tool result survive the trip back to a widget that
+          called it. Turn one off to emulate a host that drops it.
+        </p>
+      </div>
+      <div className="flex items-center justify-between gap-3 px-3.5 py-2">
+        <span className="text-[12px]">Structured content</span>
+        <Switch
+          checked={toolResult?.structuredContent !== false}
+          onCheckedChange={(checked) =>
+            setToolResultPart("structuredContent", checked)
+          }
+          aria-label="Structured content reaches widgets"
+        />
+      </div>
+      <div className="border-t border-border/50 bg-muted/30 px-3.5 py-1.5 text-[11px] font-medium text-muted-foreground">
+        Content
+      </div>
+      {(
+        [
+          ["text", "Text"],
+          ["image", "Image"],
+          ["audio", "Audio"],
+          ["resource", "Embedded resource"],
+          ["resourceLink", "Resource link"],
+        ] as const
+      ).map(([key, label]) => (
+        <div
+          key={key}
+          className="flex items-center justify-between gap-3 border-t border-border/50 px-3.5 py-2"
+        >
+          <span className="text-[12px]">{label}</span>
+          <Switch
+            checked={toolResult?.content?.[key] !== false}
+            onCheckedChange={(checked) => setToolResultPart(key, checked)}
+            aria-label={`${label} tool result reaches widgets`}
+          />
+        </div>
+      ))}
+    </section>
+  );
+}
+
 export function AppsExtensionTab({
   draft,
   onDraftChange,
@@ -1917,6 +2063,7 @@ export function AppsExtensionTab({
             confuse them. */}
         <McpAppsCapabilityMatrix draft={draft} onDraftChange={onDraftChange} />
         <BrowserStorageCard draft={draft} onDraftChange={onDraftChange} />
+        <WidgetToolResultsCard draft={draft} onDraftChange={onDraftChange} />
         {/* Read-only companion to the two matrices: the capability rows say
             what the host CAN do, this says what it LOOKS like to a view. */}
         <HostStyleTokens draft={draft} />

--- a/mcpjam-inspector/client/src/components/hosts/redesigned/focus/AppsExtensionTab.tsx
+++ b/mcpjam-inspector/client/src/components/hosts/redesigned/focus/AppsExtensionTab.tsx
@@ -3,6 +3,7 @@ import { ChevronDown } from "lucide-react";
 import { JsonEditor, type JsonEditorMode } from "@/components/ui/json-editor";
 import {
   hostCapabilitiesOverrideToMatrix,
+  isMcpProfileEmpty,
   resolveEffectiveHostCapabilities,
   resolveEffectiveMcpAppsCapabilities,
   setMcpAppsOverridesOnDraft,
@@ -1830,9 +1831,14 @@ function BrowserStorageCard({
         ...base,
         apps: Object.keys(nextApps).length > 0 ? nextApps : undefined,
       };
+      // Collapse to absence like every ProtocolTab setter. Without this,
+      // toggling an API off and back on leaves `{ profileVersion: 1 }`
+      // behind, which canonicalizes to a DIFFERENT hash than the absent
+      // profile the config started with — a user who changed nothing would
+      // mint a new config row just by flipping a switch twice.
       return {
         ...prev,
-        mcpProfile: updated,
+        mcpProfile: isMcpProfileEmpty(updated) ? undefined : updated,
       };
     });
   };

--- a/mcpjam-inspector/client/src/components/hosts/redesigned/focus/AppsExtensionTab.tsx
+++ b/mcpjam-inspector/client/src/components/hosts/redesigned/focus/AppsExtensionTab.tsx
@@ -98,6 +98,8 @@ const SEGMENT_BUTTON_CLASSES =
  *   sandbox.permissionsPolicy        Permissions Policy entries on the
  *                                    iframe `allow=` attribute beyond the
  *                                    4 SEP-blessed features
+ *   sandbox.browserStorage            observed browser storage APIs in the
+ *                                    sandboxed iframe (not an MCP concept)
  *
  * Inspector-internal resolver fields (`mode`, `extensions`) stay out of
  * the JSON entirely — they're owned by the structured editor and preserved
@@ -145,6 +147,16 @@ type SandboxDocCsp = SpecSandboxCsp & {
 type SandboxDoc = {
   csp?: SandboxDocCsp;
   permissions?: SpecSandboxPermissions;
+  /**
+   * Observed browser APIs available inside the sandboxed widget iframe.
+   * These are not negotiated MCP capabilities; each key is a browser API
+   * that a host probe measured separately.
+   */
+  browserStorage?: {
+    localStorage?: boolean;
+    sessionStorage?: boolean;
+    indexedDB?: boolean;
+  };
   /**
    * Inspector-only: extra tokens for the proxy iframe's HTML `sandbox=`
    * attribute, on top of the spec-required `allow-scripts allow-same-origin`.
@@ -254,6 +266,12 @@ function sandboxFromPolicy(
     }
     if (Object.keys(perms).length > 0) out.permissions = perms;
   }
+  // Kept immediately below CSP / permissions in the document: it describes
+  // the same iframe boundary, even though it is browser behavior rather than
+  // a portable MCP Apps field.
+  if (policy.browserStorage !== undefined) {
+    out.browserStorage = { ...policy.browserStorage };
+  }
 
   // Inspector-only knobs round-trip with their full undefined-vs-empty
   // semantics so the JSON faithfully represents what's in storage.
@@ -266,7 +284,6 @@ function sandboxFromPolicy(
   if (policy.allowFeatures !== undefined) {
     out.permissionsPolicy = { ...policy.allowFeatures };
   }
-
   return Object.keys(out).length > 0 ? out : undefined;
 }
 
@@ -368,12 +385,14 @@ function liftSandboxIntoPolicy(args: {
   // block is present (absent under a present block = user cleared it).
   const nextSandboxAttrs = incoming?.iframeSandboxAttrs;
   const nextAllowFeatures = incoming?.permissionsPolicy;
+  const nextBrowserStorage = incoming?.browserStorage;
 
   if (
     !cspNonEmpty &&
     !permsNonEmpty &&
     nextSandboxAttrs === undefined &&
-    nextAllowFeatures === undefined
+    nextAllowFeatures === undefined &&
+    nextBrowserStorage === undefined
   ) {
     return undefined;
   }
@@ -382,6 +401,7 @@ function liftSandboxIntoPolicy(args: {
   if (permsNonEmpty) next.permissions = nextPerms;
   if (nextSandboxAttrs !== undefined) next.sandboxAttrs = nextSandboxAttrs;
   if (nextAllowFeatures !== undefined) next.allowFeatures = nextAllowFeatures;
+  if (nextBrowserStorage !== undefined) next.browserStorage = nextBrowserStorage;
   return next;
 }
 
@@ -459,11 +479,15 @@ function appsToJson(draft: HostConfigInputV2): AppsDoc {
   // preset". Surfaced only when non-empty (matches `openaiAppsOverrides`'
   // sparsity convention).
   const mcpAppsOverrides = draft.mcpProfile?.apps?.mcpAppsOverrides;
-  if (
-    mcpAppsOverrides !== undefined &&
-    Object.keys(mcpAppsOverrides).length > 0
-  ) {
-    doc.mcpAppsOverrides = { ...mcpAppsOverrides };
+  if (mcpAppsOverrides !== undefined) {
+    // Tool Result delivery is a base MCP concern. It is stored on the
+    // widget relay override, but belongs in the Protocol tab; do not make it
+    // look like an `app.*` capability here. The parser preserves it below.
+    const { toolResult: _toolResult, ...appsOverridesForEditor } =
+      mcpAppsOverrides;
+    if (Object.keys(appsOverridesForEditor).length > 0) {
+      doc.mcpAppsOverrides = appsOverridesForEditor;
+    }
   }
 
   return doc;
@@ -567,6 +591,18 @@ export function applyJsonToDraft(
       out.widgetDisplayModeRequests = widgetDisplayModeRequests;
     }
     if (Object.keys(out).length > 0) nextMcpAppsOverrides = out;
+  }
+
+  // This editor owns `app.*` capability rows, not base-MCP tool results.
+  // Keep the Protocol-tab value intact when a user saves Apps JSON or edits
+  // the matrix. Its physical nesting under mcpAppsOverrides must not turn it
+  // into an accidental casualty of an Apps-tab save.
+  const previousToolResult = prev.mcpProfile?.apps?.mcpAppsOverrides?.toolResult;
+  if (previousToolResult !== undefined) {
+    nextMcpAppsOverrides = {
+      ...(nextMcpAppsOverrides ?? {}),
+      toolResult: previousToolResult,
+    };
   }
 
   // hostCapabilities — the user sees the EFFECTIVE merged value, so on
@@ -720,6 +756,21 @@ export function applyJsonToDraft(
           if (typeof v === "string") pp[k] = v;
         }
         parsedSandbox.permissionsPolicy = pp;
+      }
+      if (isPlainObject(sandboxBlock.browserStorage)) {
+        const storage: NonNullable<SandboxDoc["browserStorage"]> = {};
+        for (const key of [
+          "localStorage",
+          "sessionStorage",
+          "indexedDB",
+        ] as const) {
+          if (typeof sandboxBlock.browserStorage[key] === "boolean") {
+            storage[key] = sandboxBlock.browserStorage[key];
+          }
+        }
+        // The parent key itself is meaningful: an empty record clears an
+        // earlier measurement when the JSON block is saved.
+        parsedSandbox.browserStorage = storage;
       }
       incomingSandbox = parsedSandbox;
     }
@@ -1415,7 +1466,7 @@ function McpAppsCapabilityMatrix({
 
   /** Set or clear a boolean dimension override. Pass `undefined` to revert to preset. */
   const setBooleanOverride = (
-    key: Exclude<keyof McpAppsCapabilities, "availableDisplayModes">,
+    key: McpAppsDimensionKey,
     nextEffective: boolean
   ) => {
     onDraftChange((prev) => {
@@ -1736,6 +1787,89 @@ function McpAppsDimensionRow({
   );
 }
 
+/**
+ * Probe findings about browser storage inside the sandboxed widget iframe.
+ * This deliberately lives outside both Apps capability matrices: storage is
+ * a browser consequence of the iframe sandbox, not an MCP Apps `app.*`
+ * feature or an OpenAI compatibility shim method.
+ */
+function BrowserStorageCard({
+  draft,
+  onDraftChange,
+}: {
+  draft: HostConfigInputV2;
+  onDraftChange: (
+    updater: (prev: HostConfigInputV2) => HostConfigInputV2
+  ) => void;
+}) {
+  const storage = draft.mcpProfile?.apps?.sandbox?.browserStorage;
+  const setStorageApi = (
+    key: "localStorage" | "sessionStorage" | "indexedDB",
+    enabled: boolean
+  ) => {
+    onDraftChange((prev) => {
+      const base: HostConfigMcpProfileV1 = prev.mcpProfile ?? {
+        profileVersion: 1,
+      };
+      const apps = base.apps ?? {};
+      const sandbox = { ...(apps.sandbox ?? {}) };
+      const browserStorage = { ...(sandbox.browserStorage ?? {}) };
+      // Absence means the normal browser behavior is available, so only
+      // persist the non-default failure finding.
+      if (enabled) delete browserStorage[key];
+      else browserStorage[key] = false;
+      if (Object.keys(browserStorage).length > 0) {
+        sandbox.browserStorage = browserStorage;
+      } else {
+        delete sandbox.browserStorage;
+      }
+      const nextApps = { ...apps };
+      if (Object.keys(sandbox).length > 0) nextApps.sandbox = sandbox;
+      else delete nextApps.sandbox;
+      const updated: HostConfigMcpProfileV1 = {
+        ...base,
+        apps: Object.keys(nextApps).length > 0 ? nextApps : undefined,
+      };
+      return {
+        ...prev,
+        mcpProfile: updated,
+      };
+    });
+  };
+
+  return (
+    <section className="rounded-[10px] border border-border bg-background">
+      <div className="border-b border-border px-3.5 py-2.5">
+        <div className="text-[12px] font-medium">Browser storage</div>
+        <p className="mt-0.5 text-[11px] leading-snug text-muted-foreground">
+          Storage your app can use while running in this client.
+        </p>
+      </div>
+      {(
+        [
+          ["localStorage", "localStorage"],
+          ["sessionStorage", "sessionStorage"],
+          ["indexedDB", "IndexedDB"],
+        ] as const
+      ).map(([key, label], index) => (
+        <div
+          key={key}
+          className={`flex items-center justify-between gap-3 px-3.5 py-2 ${
+            index > 0 ? "border-t border-border/50" : ""
+          }`}
+        >
+          <span className="font-mono text-[12px]">{label}</span>
+          <Switch
+            checked={storage?.[key] !== false}
+            onCheckedChange={(checked) => setStorageApi(key, checked)}
+            aria-label={`${label} available in sandbox`}
+          />
+        </div>
+      ))}
+    </section>
+  );
+}
+
 export function AppsExtensionTab({
   draft,
   onDraftChange,
@@ -1776,6 +1910,7 @@ export function AppsExtensionTab({
             subtitle on each section makes this explicit so users don't
             confuse them. */}
         <McpAppsCapabilityMatrix draft={draft} onDraftChange={onDraftChange} />
+        <BrowserStorageCard draft={draft} onDraftChange={onDraftChange} />
         {/* Read-only companion to the two matrices: the capability rows say
             what the host CAN do, this says what it LOOKS like to a view. */}
         <HostStyleTokens draft={draft} />

--- a/mcpjam-inspector/client/src/components/hosts/redesigned/focus/ProtocolTab.tsx
+++ b/mcpjam-inspector/client/src/components/hosts/redesigned/focus/ProtocolTab.tsx
@@ -1254,12 +1254,11 @@ export function ProtocolTab({
         <div className="mt-2.5 border-t border-border/50 pt-2.5">
           <div className="min-w-0">
             <span className="text-[12px] font-medium">
-              Tool results received by widgets
+              Widget tool results
             </span>
             <p className="text-[11px] leading-snug text-muted-foreground">
-              When an MCP App widget calls a tool, choose which normal MCP
-              tool-result parts reach it. This does not describe MCP Apps
-              capabilities.
+              Which parts of a tool result survive the trip back to a widget
+              that called it. Turn one off to emulate a host that drops it.
             </p>
           </div>
           <div className="mt-2 flex flex-col divide-y divide-border/50 rounded-md border border-border/50">

--- a/mcpjam-inspector/client/src/components/hosts/redesigned/focus/ProtocolTab.tsx
+++ b/mcpjam-inspector/client/src/components/hosts/redesigned/focus/ProtocolTab.tsx
@@ -241,23 +241,7 @@ type ProtocolDoc = {
     listens?: boolean;
     refetches?: boolean;
   };
-  /**
-   * Which parts of a tool result make it back to an MCP App widget after
-   * that widget calls a tool. These are MCP Tool Result fields, not MCP Apps
-   * capabilities; the nested storage location is only an implementation
-   * detail of the host profile.
-   */
-  toolResultsToWidgets?: {
-    structuredContent?: boolean;
-    content?: {
-      text?: boolean;
-      image?: boolean;
-      audio?: boolean;
-      resource?: boolean;
-      resourceLink?: boolean;
-    };
-  };
-  capabilities?: Record<string, unknown>;
+    capabilities?: Record<string, unknown>;
   /**
    * Host-level MCP profile extensions (`mcpProfile.extensions`) — freeform
    * JSON deep-sorted into the canonical hash. Carries the enterprise-managed
@@ -332,18 +316,6 @@ export function protocolToJson(draft: HostConfigInputV2): ProtocolDoc {
   const toolListChanged = draft.mcpProfile?.toolListChanged;
   if (toolListChanged && Object.keys(toolListChanged).length > 0) {
     doc.toolListChanged = { ...toolListChanged };
-  }
-
-  const toolResult = draft.mcpProfile?.apps?.mcpAppsOverrides?.toolResult;
-  if (toolResult && Object.keys(toolResult).length > 0) {
-    doc.toolResultsToWidgets = {
-      ...(toolResult.structuredContent !== undefined
-        ? { structuredContent: toolResult.structuredContent }
-        : {}),
-      ...(toolResult.content && Object.keys(toolResult.content).length > 0
-        ? { content: { ...toolResult.content } }
-        : {}),
-    };
   }
 
   if (
@@ -600,36 +572,6 @@ export function applyJsonToDraft(
     if (Object.keys(next).length > 0) toolListChangedParsed = next;
   }
 
-  // Tool Result fields belong in this MCP Protocol view. The host profile
-  // stores them below apps.mcpAppsOverrides because they were measured on the
-  // widget relay, but that does not make them an MCP Apps capability.
-  let toolResult: NonNullable<
-    NonNullable<HostConfigMcpProfileV1["apps"]>["mcpAppsOverrides"]
-  >["toolResult"];
-  if (isPlainObject(parsed.toolResultsToWidgets)) {
-    const incoming = parsed.toolResultsToWidgets;
-    const next: NonNullable<typeof toolResult> = {};
-    if (typeof incoming.structuredContent === "boolean") {
-      next.structuredContent = incoming.structuredContent;
-    }
-    if (isPlainObject(incoming.content)) {
-      const content: NonNullable<typeof next.content> = {};
-      for (const key of [
-        "text",
-        "image",
-        "audio",
-        "resource",
-        "resourceLink",
-      ] as const) {
-        if (typeof incoming.content[key] === "boolean") {
-          content[key] = incoming.content[key];
-        }
-      }
-      if (Object.keys(content).length > 0) next.content = content;
-    }
-    if (Object.keys(next).length > 0) toolResult = next;
-  }
-
   // capabilities — pass through verbatim as Record<string, unknown> only if
   // the user supplied an object. Absence vs `{}` is preserved: missing key
   // clears clientCapabilities; explicit `{}` advertises nothing but keeps
@@ -703,20 +645,10 @@ export function applyJsonToDraft(
       mrtrSupport,
       toolListChanged: toolListChangedParsed,
       extensions: profileExtensions,
-      apps: (() => {
-        const previousApps = base.apps;
-        const previousOverrides = previousApps?.mcpAppsOverrides;
-        const nextOverrides = { ...previousOverrides };
-        if (toolResult) nextOverrides.toolResult = toolResult;
-        else delete nextOverrides.toolResult;
-        const hasOverrides = Object.keys(nextOverrides).length > 0;
-        const nextApps = {
-          ...previousApps,
-          ...(hasOverrides ? { mcpAppsOverrides: nextOverrides } : {}),
-        };
-        if (!hasOverrides) delete nextApps.mcpAppsOverrides;
-        return Object.keys(nextApps).length > 0 ? nextApps : undefined;
-      })(),
+      // `apps` is owned by the Apps tab (including the widget tool-result
+      // policy that used to be edited here); this view must pass it through
+      // untouched rather than rebuild it.
+      apps: base.apps,
     };
 
     return isMcpProfileEmpty(next) ? undefined : next;
@@ -881,7 +813,6 @@ export function ProtocolTab({
   // and only the degraded value is stored.
   const storedPagination = draft.mcpProfile?.paginationTraversal;
   const storedMrtrSupport = draft.mcpProfile?.mrtrSupport;
-  const storedToolResult = draft.mcpProfile?.apps?.mcpAppsOverrides?.toolResult;
   const setConformanceKnob = <K extends "paginationTraversal" | "mrtrSupport">(
     key: K,
     next: HostConfigMcpProfileV1[K] | undefined
@@ -899,7 +830,7 @@ export function ProtocolTab({
   };
 
   const storedToolListChanged = draft.mcpProfile?.toolListChanged;
-  // Delete-on-default, exactly like `setToolResultPart`: absence IS the
+  // Delete-on-default: absence IS the
   // conforming answer, so a re-enabled switch must leave no trace behind.
   const setToolListChangedPart = (
     key: "listens" | "refetches",
@@ -918,43 +849,6 @@ export function ProtocolTab({
       } else {
         delete updated.toolListChanged;
       }
-      return {
-        ...prev,
-        mcpProfile: isMcpProfileEmpty(updated) ? undefined : updated,
-      };
-    });
-  };
-
-  const setToolResultPart = (
-    key: "structuredContent" | "text" | "image" | "audio" | "resource" | "resourceLink",
-    enabled: boolean
-  ) => {
-    onDraftChange((prev) => {
-      const base: HostConfigMcpProfileV1 = prev.mcpProfile ?? {
-        profileVersion: 1,
-      };
-      const apps = base.apps ?? {};
-      const overrides = { ...(apps.mcpAppsOverrides ?? {}) };
-      const toolResult = { ...(overrides.toolResult ?? {}) };
-      if (key === "structuredContent") {
-        if (enabled) delete toolResult.structuredContent;
-        else toolResult.structuredContent = false;
-      } else {
-        const content = { ...(toolResult.content ?? {}) };
-        if (enabled) delete content[key];
-        else content[key] = false;
-        if (Object.keys(content).length > 0) toolResult.content = content;
-        else delete toolResult.content;
-      }
-      if (Object.keys(toolResult).length > 0) overrides.toolResult = toolResult;
-      else delete overrides.toolResult;
-      const nextApps = { ...apps };
-      if (Object.keys(overrides).length > 0) nextApps.mcpAppsOverrides = overrides;
-      else delete nextApps.mcpAppsOverrides;
-      const updated: HostConfigMcpProfileV1 = {
-        ...base,
-        apps: Object.keys(nextApps).length > 0 ? nextApps : undefined,
-      };
       return {
         ...prev,
         mcpProfile: isMcpProfileEmpty(updated) ? undefined : updated,
@@ -1249,55 +1143,6 @@ export function ProtocolTab({
                 aria-label="Re-fetches tools after the notification"
               />
             </div>
-          </div>
-        </div>
-        <div className="mt-2.5 border-t border-border/50 pt-2.5">
-          <div className="min-w-0">
-            <span className="text-[12px] font-medium">
-              Widget tool results
-            </span>
-            <p className="text-[11px] leading-snug text-muted-foreground">
-              Which parts of a tool result survive the trip back to a widget
-              that called it. Turn one off to emulate a host that drops it.
-            </p>
-          </div>
-          <div className="mt-2 flex flex-col divide-y divide-border/50 rounded-md border border-border/50">
-            <div className="flex items-center justify-between gap-3 px-3 py-2">
-              <span className="text-[12px]">Structured content</span>
-              <Switch
-                checked={storedToolResult?.structuredContent !== false}
-                onCheckedChange={(checked) =>
-                  setToolResultPart("structuredContent", checked)
-                }
-                disabled={readOnly}
-                aria-label="Structured content reaches widgets"
-              />
-            </div>
-            <div className="bg-muted/30 px-3 py-1.5 text-[11px] font-medium text-muted-foreground">
-              Content
-            </div>
-            {(
-              [
-                ["text", "Text"],
-                ["image", "Image"],
-                ["audio", "Audio"],
-                ["resource", "Embedded resource"],
-                ["resourceLink", "Resource link"],
-              ] as const
-            ).map(([key, label]) => (
-              <div
-                key={key}
-                className="flex items-center justify-between gap-3 px-3 py-2"
-              >
-                <span className="text-[12px]">{label}</span>
-                <Switch
-                  checked={storedToolResult?.content?.[key] !== false}
-                  onCheckedChange={(checked) => setToolResultPart(key, checked)}
-                  disabled={readOnly}
-                  aria-label={`${label} tool result reaches widgets`}
-                />
-              </div>
-            ))}
           </div>
         </div>
         {showPolicyToggle && (

--- a/mcpjam-inspector/client/src/components/hosts/redesigned/focus/ProtocolTab.tsx
+++ b/mcpjam-inspector/client/src/components/hosts/redesigned/focus/ProtocolTab.tsx
@@ -241,7 +241,7 @@ type ProtocolDoc = {
     listens?: boolean;
     refetches?: boolean;
   };
-    capabilities?: Record<string, unknown>;
+  capabilities?: Record<string, unknown>;
   /**
    * Host-level MCP profile extensions (`mcpProfile.extensions`) — freeform
    * JSON deep-sorted into the canonical hash. Carries the enterprise-managed
@@ -710,14 +710,14 @@ export function ProtocolTab({
     draft.hostStyle === "mcpjam"
       ? undefined
       : initializeProtocolVersions === undefined ||
-          initializeProtocolVersions.length === 0
-        ? initializeProtocolVersions
-        : Array.from(
-            new Set([
-              ...initializeProtocolVersions,
-              ...(catalogProtocolVersions ?? []),
-            ])
-          );
+        initializeProtocolVersions.length === 0
+      ? initializeProtocolVersions
+      : Array.from(
+          new Set([
+            ...initializeProtocolVersions,
+            ...(catalogProtocolVersions ?? []),
+          ])
+        );
   const protocolOptions = visibleHostProtocolOptions(
     advertisedProtocolVersions,
     selectedDropdownValue
@@ -979,13 +979,26 @@ export function ProtocolTab({
         {/* Without this line a preset-backed client reads as a broken control:
             the missing revisions look arbitrary, and the list that removed them
             is invisible unless the JSON editor below is open. Name both. The
-            list constrains every concrete pin, including 2026. */}
+            list constrains every concrete pin, including 2026.
+
+            A client can advertise a revision MCPJam itself does not speak —
+            Copilot advertises 2024-11-05, which is not in MCP_PROTOCOL_VERSIONS
+            — and that version can never appear in the dropdown however the list
+            is edited. Say so inline rather than leaving the reader to edit the
+            JSON and find nothing changed. */}
         {protocolOptionsRestricted && (
           <p className="mt-1.5 text-[11px] leading-snug text-muted-foreground">
             This client advertises{" "}
-            {(advertisedProtocolVersions ?? []).join(", ")}, so no other version
-            can be pinned. Edit <code>supportedProtocolVersions</code> in the
-            JSON below to offer more.
+            {(advertisedProtocolVersions ?? [])
+              .map((version) =>
+                (MCP_PROTOCOL_VERSIONS as readonly string[]).includes(version)
+                  ? version
+                  : `${version} (which MCPJam doesn't support)`
+              )
+              .join(", ")}
+            , so no other version can be pinned. Edit{" "}
+            <code>supportedProtocolVersions</code> in the JSON below to offer
+            more.
           </p>
         )}
         {/* Fires independently of the option count above: force-keeping the
@@ -1139,7 +1152,12 @@ export function ProtocolTab({
                 onCheckedChange={(checked) =>
                   setToolListChangedPart("refetches", checked)
                 }
-                disabled={readOnly || storedToolListChanged?.listens === false}
+                // NOT gated on `listens`. The 2026-08-26 Copilot capture
+                // re-fetched without ever opening the channel: the server
+                // published `list_changed` on an open tools/call response
+                // stream, which reaches a client that never opened the
+                // standalone one. off + on is a real combination.
+                disabled={readOnly}
                 aria-label="Re-fetches tools after the notification"
               />
             </div>

--- a/mcpjam-inspector/client/src/components/hosts/redesigned/focus/ProtocolTab.tsx
+++ b/mcpjam-inspector/client/src/components/hosts/redesigned/focus/ProtocolTab.tsx
@@ -231,6 +231,32 @@ type ProtocolDoc = {
    */
   paginationTraversal?: PaginationTraversalMode;
   mrtrSupport?: MrtrSupport;
+  /**
+   * How the client handles `notifications/tools/list_changed`. `listens` is
+   * whether it opens the server→client channel at all; `refetches` is whether
+   * it acts on the notification once one arrives. Absent means conforming
+   * (both), so only an explicit `false` is ever written.
+   */
+  toolListChanged?: {
+    listens?: boolean;
+    refetches?: boolean;
+  };
+  /**
+   * Which parts of a tool result make it back to an MCP App widget after
+   * that widget calls a tool. These are MCP Tool Result fields, not MCP Apps
+   * capabilities; the nested storage location is only an implementation
+   * detail of the host profile.
+   */
+  toolResultsToWidgets?: {
+    structuredContent?: boolean;
+    content?: {
+      text?: boolean;
+      image?: boolean;
+      audio?: boolean;
+      resource?: boolean;
+      resourceLink?: boolean;
+    };
+  };
   capabilities?: Record<string, unknown>;
   /**
    * Host-level MCP profile extensions (`mcpProfile.extensions`) — freeform
@@ -301,6 +327,23 @@ export function protocolToJson(draft: HostConfigInputV2): ProtocolDoc {
   }
   if (draft.mcpProfile?.mrtrSupport !== undefined) {
     doc.mrtrSupport = draft.mcpProfile.mrtrSupport;
+  }
+
+  const toolListChanged = draft.mcpProfile?.toolListChanged;
+  if (toolListChanged && Object.keys(toolListChanged).length > 0) {
+    doc.toolListChanged = { ...toolListChanged };
+  }
+
+  const toolResult = draft.mcpProfile?.apps?.mcpAppsOverrides?.toolResult;
+  if (toolResult && Object.keys(toolResult).length > 0) {
+    doc.toolResultsToWidgets = {
+      ...(toolResult.structuredContent !== undefined
+        ? { structuredContent: toolResult.structuredContent }
+        : {}),
+      ...(toolResult.content && Object.keys(toolResult.content).length > 0
+        ? { content: { ...toolResult.content } }
+        : {}),
+    };
   }
 
   if (
@@ -547,6 +590,46 @@ export function applyJsonToDraft(
   const mrtrSupport: MrtrSupport | undefined =
     rawMrtr === "full" || rawMrtr === "none" ? rawMrtr : undefined;
 
+  let toolListChangedParsed: HostConfigMcpProfileV1["toolListChanged"];
+  if (isPlainObject(parsed.toolListChanged)) {
+    const incoming = parsed.toolListChanged;
+    const next: NonNullable<typeof toolListChangedParsed> = {};
+    for (const key of ["listens", "refetches"] as const) {
+      if (typeof incoming[key] === "boolean") next[key] = incoming[key];
+    }
+    if (Object.keys(next).length > 0) toolListChangedParsed = next;
+  }
+
+  // Tool Result fields belong in this MCP Protocol view. The host profile
+  // stores them below apps.mcpAppsOverrides because they were measured on the
+  // widget relay, but that does not make them an MCP Apps capability.
+  let toolResult: NonNullable<
+    NonNullable<HostConfigMcpProfileV1["apps"]>["mcpAppsOverrides"]
+  >["toolResult"];
+  if (isPlainObject(parsed.toolResultsToWidgets)) {
+    const incoming = parsed.toolResultsToWidgets;
+    const next: NonNullable<typeof toolResult> = {};
+    if (typeof incoming.structuredContent === "boolean") {
+      next.structuredContent = incoming.structuredContent;
+    }
+    if (isPlainObject(incoming.content)) {
+      const content: NonNullable<typeof next.content> = {};
+      for (const key of [
+        "text",
+        "image",
+        "audio",
+        "resource",
+        "resourceLink",
+      ] as const) {
+        if (typeof incoming.content[key] === "boolean") {
+          content[key] = incoming.content[key];
+        }
+      }
+      if (Object.keys(content).length > 0) next.content = content;
+    }
+    if (Object.keys(next).length > 0) toolResult = next;
+  }
+
   // capabilities — pass through verbatim as Record<string, unknown> only if
   // the user supplied an object. Absence vs `{}` is preserved: missing key
   // clears clientCapabilities; explicit `{}` advertises nothing but keeps
@@ -618,7 +701,22 @@ export function applyJsonToDraft(
       toolParamHeaderMirroring,
       paginationTraversal,
       mrtrSupport,
+      toolListChanged: toolListChangedParsed,
       extensions: profileExtensions,
+      apps: (() => {
+        const previousApps = base.apps;
+        const previousOverrides = previousApps?.mcpAppsOverrides;
+        const nextOverrides = { ...previousOverrides };
+        if (toolResult) nextOverrides.toolResult = toolResult;
+        else delete nextOverrides.toolResult;
+        const hasOverrides = Object.keys(nextOverrides).length > 0;
+        const nextApps = {
+          ...previousApps,
+          ...(hasOverrides ? { mcpAppsOverrides: nextOverrides } : {}),
+        };
+        if (!hasOverrides) delete nextApps.mcpAppsOverrides;
+        return Object.keys(nextApps).length > 0 ? nextApps : undefined;
+      })(),
     };
 
     return isMcpProfileEmpty(next) ? undefined : next;
@@ -783,6 +881,7 @@ export function ProtocolTab({
   // and only the degraded value is stored.
   const storedPagination = draft.mcpProfile?.paginationTraversal;
   const storedMrtrSupport = draft.mcpProfile?.mrtrSupport;
+  const storedToolResult = draft.mcpProfile?.apps?.mcpAppsOverrides?.toolResult;
   const setConformanceKnob = <K extends "paginationTraversal" | "mrtrSupport">(
     key: K,
     next: HostConfigMcpProfileV1[K] | undefined
@@ -792,6 +891,70 @@ export function ProtocolTab({
         profileVersion: 1,
       };
       const updated: HostConfigMcpProfileV1 = { ...base, [key]: next };
+      return {
+        ...prev,
+        mcpProfile: isMcpProfileEmpty(updated) ? undefined : updated,
+      };
+    });
+  };
+
+  const storedToolListChanged = draft.mcpProfile?.toolListChanged;
+  // Delete-on-default, exactly like `setToolResultPart`: absence IS the
+  // conforming answer, so a re-enabled switch must leave no trace behind.
+  const setToolListChangedPart = (
+    key: "listens" | "refetches",
+    enabled: boolean
+  ) => {
+    onDraftChange((prev) => {
+      const base: HostConfigMcpProfileV1 = prev.mcpProfile ?? {
+        profileVersion: 1,
+      };
+      const toolListChanged = { ...(base.toolListChanged ?? {}) };
+      if (enabled) delete toolListChanged[key];
+      else toolListChanged[key] = false;
+      const updated: HostConfigMcpProfileV1 = { ...base };
+      if (Object.keys(toolListChanged).length > 0) {
+        updated.toolListChanged = toolListChanged;
+      } else {
+        delete updated.toolListChanged;
+      }
+      return {
+        ...prev,
+        mcpProfile: isMcpProfileEmpty(updated) ? undefined : updated,
+      };
+    });
+  };
+
+  const setToolResultPart = (
+    key: "structuredContent" | "text" | "image" | "audio" | "resource" | "resourceLink",
+    enabled: boolean
+  ) => {
+    onDraftChange((prev) => {
+      const base: HostConfigMcpProfileV1 = prev.mcpProfile ?? {
+        profileVersion: 1,
+      };
+      const apps = base.apps ?? {};
+      const overrides = { ...(apps.mcpAppsOverrides ?? {}) };
+      const toolResult = { ...(overrides.toolResult ?? {}) };
+      if (key === "structuredContent") {
+        if (enabled) delete toolResult.structuredContent;
+        else toolResult.structuredContent = false;
+      } else {
+        const content = { ...(toolResult.content ?? {}) };
+        if (enabled) delete content[key];
+        else content[key] = false;
+        if (Object.keys(content).length > 0) toolResult.content = content;
+        else delete toolResult.content;
+      }
+      if (Object.keys(toolResult).length > 0) overrides.toolResult = toolResult;
+      else delete overrides.toolResult;
+      const nextApps = { ...apps };
+      if (Object.keys(overrides).length > 0) nextApps.mcpAppsOverrides = overrides;
+      else delete nextApps.mcpAppsOverrides;
+      const updated: HostConfigMcpProfileV1 = {
+        ...base,
+        apps: Object.keys(nextApps).length > 0 ? nextApps : undefined,
+      };
       return {
         ...prev,
         mcpProfile: isMcpProfileEmpty(updated) ? undefined : updated,
@@ -1044,6 +1207,99 @@ export function ProtocolTab({
               <SelectItem value="none">Not supported</SelectItem>
             </SelectContent>
           </Select>
+        </div>
+        <div className="mt-2.5 border-t border-border/50 pt-2.5">
+          <div className="min-w-0">
+            <span className="text-[12px] font-medium">
+              Tool list changed notifications
+            </span>
+            <p className="text-[11px] leading-snug text-muted-foreground">
+              Whether this client opens the server-to-client notification
+              channel, and whether it acts on
+              <code className="mx-1 text-[10px]">
+                notifications/tools/list_changed
+              </code>
+              once one arrives.
+            </p>
+          </div>
+          <div className="mt-2 flex flex-col divide-y divide-border/50 rounded-md border border-border/50">
+            <div className="flex items-center justify-between gap-3 px-3 py-2">
+              <span className="text-[12px]">Opens notification channel</span>
+              <Switch
+                checked={storedToolListChanged?.listens !== false}
+                onCheckedChange={(checked) =>
+                  setToolListChangedPart("listens", checked)
+                }
+                disabled={readOnly}
+                aria-label="Opens notification channel"
+              />
+            </div>
+            {/* Disabled when the channel is closed: nothing can arrive, so
+                this answer is unobservable rather than merely unset. */}
+            <div className="flex items-center justify-between gap-3 px-3 py-2">
+              <span className="text-[12px]">
+                Re-fetches tools after the notification
+              </span>
+              <Switch
+                checked={storedToolListChanged?.refetches !== false}
+                onCheckedChange={(checked) =>
+                  setToolListChangedPart("refetches", checked)
+                }
+                disabled={readOnly || storedToolListChanged?.listens === false}
+                aria-label="Re-fetches tools after the notification"
+              />
+            </div>
+          </div>
+        </div>
+        <div className="mt-2.5 border-t border-border/50 pt-2.5">
+          <div className="min-w-0">
+            <span className="text-[12px] font-medium">
+              Tool results received by widgets
+            </span>
+            <p className="text-[11px] leading-snug text-muted-foreground">
+              When an MCP App widget calls a tool, choose which normal MCP
+              tool-result parts reach it. This does not describe MCP Apps
+              capabilities.
+            </p>
+          </div>
+          <div className="mt-2 flex flex-col divide-y divide-border/50 rounded-md border border-border/50">
+            <div className="flex items-center justify-between gap-3 px-3 py-2">
+              <span className="text-[12px]">Structured content</span>
+              <Switch
+                checked={storedToolResult?.structuredContent !== false}
+                onCheckedChange={(checked) =>
+                  setToolResultPart("structuredContent", checked)
+                }
+                disabled={readOnly}
+                aria-label="Structured content reaches widgets"
+              />
+            </div>
+            <div className="bg-muted/30 px-3 py-1.5 text-[11px] font-medium text-muted-foreground">
+              Content
+            </div>
+            {(
+              [
+                ["text", "Text"],
+                ["image", "Image"],
+                ["audio", "Audio"],
+                ["resource", "Embedded resource"],
+                ["resourceLink", "Resource link"],
+              ] as const
+            ).map(([key, label]) => (
+              <div
+                key={key}
+                className="flex items-center justify-between gap-3 px-3 py-2"
+              >
+                <span className="text-[12px]">{label}</span>
+                <Switch
+                  checked={storedToolResult?.content?.[key] !== false}
+                  onCheckedChange={(checked) => setToolResultPart(key, checked)}
+                  disabled={readOnly}
+                  aria-label={`${label} tool result reaches widgets`}
+                />
+              </div>
+            ))}
+          </div>
         </div>
         {showPolicyToggle && (
           <div className="mt-2.5 flex items-center justify-between gap-3 border-t border-border/50 pt-2.5">

--- a/mcpjam-inspector/client/src/components/hosts/redesigned/focus/__tests__/AppsExtensionTab.sandbox.test.ts
+++ b/mcpjam-inspector/client/src/components/hosts/redesigned/focus/__tests__/AppsExtensionTab.sandbox.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "vitest";
 import {
   emptyHostConfigInputV2,
   resolveEffectiveHostCapabilities,
+  type HostConfigInputV2,
 } from "@/lib/client-config-v2";
 import { applyJsonToDraft } from "../AppsExtensionTab";
 import {
@@ -676,5 +677,82 @@ describe("AppsExtensionTab — CSP subtype override round-trip", () => {
       emptyHostConfigInputV2(),
     );
     expect(next?.mcpProfile?.apps?.mcpAppsOverrides).toBeUndefined();
+  });
+});
+
+describe("AppsExtensionTab — widget tool results round-trip", () => {
+  it("keeps the toolResult policy through a JSON save", () => {
+    // Moved here from the Protocol tab along with the card that edits it.
+    const prev: HostConfigInputV2 = {
+      ...emptyHostConfigInputV2(),
+      mcpProfile: {
+        profileVersion: 1,
+        apps: {
+          mcpAppsOverrides: {
+            toolResult: {
+              structuredContent: false,
+              content: { text: true, image: false, resourceLink: true },
+            },
+          },
+        },
+      },
+    };
+
+    const next = applyJsonToDraft(
+      {
+        hostContext: {},
+        mcpAppsOverrides: {
+          toolResult: {
+            structuredContent: false,
+            content: { text: true, image: false, resourceLink: true },
+          },
+        },
+      },
+      prev
+    );
+
+    expect(
+      next?.mcpProfile?.apps?.mcpAppsOverrides?.toolResult
+    ).toEqual({
+      structuredContent: false,
+      content: { text: true, image: false, resourceLink: true },
+    });
+  });
+
+  it("clears the policy when the key is deleted from the JSON", () => {
+    // The card lives in this tab, so an absent key must mean "cleared" —
+    // preserving the previous value would make the JSON uneditable.
+    const prev: HostConfigInputV2 = {
+      ...emptyHostConfigInputV2(),
+      mcpProfile: {
+        profileVersion: 1,
+        apps: {
+          mcpAppsOverrides: { toolResult: { structuredContent: false } },
+        },
+      },
+    };
+
+    const next = applyJsonToDraft({ hostContext: {} }, prev);
+    expect(
+      next?.mcpProfile?.apps?.mcpAppsOverrides?.toolResult
+    ).toBeUndefined();
+  });
+
+  it("ignores non-boolean leaves rather than persisting them", () => {
+    const next = applyJsonToDraft(
+      {
+        hostContext: {},
+        mcpAppsOverrides: {
+          toolResult: {
+            structuredContent: "no",
+            content: { text: 1, image: false },
+          },
+        },
+      },
+      emptyHostConfigInputV2()
+    );
+    expect(
+      next?.mcpProfile?.apps?.mcpAppsOverrides?.toolResult
+    ).toEqual({ content: { image: false } });
   });
 });

--- a/mcpjam-inspector/client/src/components/hosts/redesigned/focus/__tests__/AppsExtensionTab.sandbox.test.ts
+++ b/mcpjam-inspector/client/src/components/hosts/redesigned/focus/__tests__/AppsExtensionTab.sandbox.test.ts
@@ -41,6 +41,29 @@ describe("focusTabForNodeId — sandbox routing", () => {
 });
 
 describe("AppsExtensionTab — sandbox JSON round-trip", () => {
+  it("round-trips browser storage API findings below CSP and permissions", () => {
+    const next = applyJsonToDraft(
+      {
+        hostContext: {},
+        sandbox: {
+          csp: { connectDomains: ["https://api.openai.com"] },
+          permissions: { clipboardWrite: {} },
+          browserStorage: {
+            localStorage: true,
+            sessionStorage: false,
+            indexedDB: true,
+          },
+        },
+      },
+      emptyHostConfigInputV2(),
+    );
+    expect(next?.mcpProfile?.apps?.sandbox?.browserStorage).toEqual({
+      localStorage: true,
+      sessionStorage: false,
+      indexedDB: true,
+    });
+  });
+
   it("reads the four spec CSP allowlists from spec position into restrictTo storage", () => {
     // The user types SEP-1865 shape: the four allowlists live directly
     // under `sandbox.csp` (no `restrictTo` wrapper) so they map to

--- a/mcpjam-inspector/client/src/components/hosts/redesigned/focus/__tests__/ProtocolTab.conformanceKnobs.test.tsx
+++ b/mcpjam-inspector/client/src/components/hosts/redesigned/focus/__tests__/ProtocolTab.conformanceKnobs.test.tsx
@@ -196,36 +196,6 @@ describe("ProtocolTab JSON round-trip for the conformance knobs", () => {
   });
 });
 
-describe("ProtocolTab tool results received by widgets", () => {
-  it("round-trips structured content and the observed content kinds", () => {
-    const draft: HostConfigInputV2 = {
-      ...emptyHostConfigInputV2(),
-      mcpProfile: {
-        profileVersion: 1,
-        apps: {
-          mcpAppsOverrides: {
-            toolResult: {
-              structuredContent: false,
-              content: { text: true, image: false, resourceLink: true },
-            },
-          },
-        },
-      },
-    };
-
-    const doc = protocolToJson(draft);
-    expect(doc.toolResultsToWidgets).toEqual({
-      structuredContent: false,
-      content: { text: true, image: false, resourceLink: true },
-    });
-
-    const applied = applyJsonToDraft(doc, emptyHostConfigInputV2());
-    expect(applied?.mcpProfile?.apps?.mcpAppsOverrides?.toolResult).toEqual(
-      draft.mcpProfile.apps?.mcpAppsOverrides?.toolResult,
-    );
-  });
-});
-
 describe("ProtocolTab tool list changed controls", () => {
   const listensSwitch = () =>
     screen.getByRole("switch", { name: "Opens notification channel" });

--- a/mcpjam-inspector/client/src/components/hosts/redesigned/focus/__tests__/ProtocolTab.conformanceKnobs.test.tsx
+++ b/mcpjam-inspector/client/src/components/hosts/redesigned/focus/__tests__/ProtocolTab.conformanceKnobs.test.tsx
@@ -231,13 +231,21 @@ describe("ProtocolTab tool list changed controls", () => {
     expect(screen.getByTestId("profile")).toHaveTextContent("<no-profile>");
   });
 
-  it("disables re-fetch once the channel is closed", async () => {
-    // Nothing can arrive, so the answer is unobservable rather than merely
-    // unset — the UI must not invite a claim the probe could never make.
+  it("keeps re-fetch editable once the channel is closed", async () => {
+    // The two are independent. This used to disable re-fetch on the theory
+    // that nothing can arrive without a channel; the 2026-08-26 Copilot
+    // capture disproved it — the server published `list_changed` on an open
+    // tools/call response stream and Copilot re-fetched, having never opened
+    // the standalone channel. closed + re-fetches is a real, probed pair, so
+    // the UI has to be able to express it.
     const user = userEvent.setup();
     render(<Harness initial={emptyHostConfigInputV2()} />);
     await user.click(listensSwitch());
-    expect(refetchesSwitch()).toBeDisabled();
+    expect(refetchesSwitch()).toBeEnabled();
+
+    await user.click(refetchesSwitch());
+    expect(screen.getByTestId("listens")).toHaveTextContent("false");
+    expect(screen.getByTestId("refetches")).toHaveTextContent("false");
   });
 
   it("round-trips through the JSON document", () => {

--- a/mcpjam-inspector/client/src/components/hosts/redesigned/focus/__tests__/ProtocolTab.conformanceKnobs.test.tsx
+++ b/mcpjam-inspector/client/src/components/hosts/redesigned/focus/__tests__/ProtocolTab.conformanceKnobs.test.tsx
@@ -35,6 +35,12 @@ function Harness({ initial }: { initial: HostConfigInputV2 }) {
       <div data-testid="mrtr">
         {draft.mcpProfile?.mrtrSupport ?? "<undefined>"}
       </div>
+      <div data-testid="listens">
+        {String(draft.mcpProfile?.toolListChanged?.listens ?? "<undefined>")}
+      </div>
+      <div data-testid="refetches">
+        {String(draft.mcpProfile?.toolListChanged?.refetches ?? "<undefined>")}
+      </div>
       <div data-testid="profile">
         {draft.mcpProfile === undefined ? "<no-profile>" : "profile"}
       </div>
@@ -187,5 +193,111 @@ describe("ProtocolTab JSON round-trip for the conformance knobs", () => {
     expect(applied).not.toBeNull();
     expect(applied!.mcpProfile?.paginationTraversal).toBeUndefined();
     expect(applied!.mcpProfile?.mrtrSupport).toBeUndefined();
+  });
+});
+
+describe("ProtocolTab tool results received by widgets", () => {
+  it("round-trips structured content and the observed content kinds", () => {
+    const draft: HostConfigInputV2 = {
+      ...emptyHostConfigInputV2(),
+      mcpProfile: {
+        profileVersion: 1,
+        apps: {
+          mcpAppsOverrides: {
+            toolResult: {
+              structuredContent: false,
+              content: { text: true, image: false, resourceLink: true },
+            },
+          },
+        },
+      },
+    };
+
+    const doc = protocolToJson(draft);
+    expect(doc.toolResultsToWidgets).toEqual({
+      structuredContent: false,
+      content: { text: true, image: false, resourceLink: true },
+    });
+
+    const applied = applyJsonToDraft(doc, emptyHostConfigInputV2());
+    expect(applied?.mcpProfile?.apps?.mcpAppsOverrides?.toolResult).toEqual(
+      draft.mcpProfile.apps?.mcpAppsOverrides?.toolResult,
+    );
+  });
+});
+
+describe("ProtocolTab tool list changed controls", () => {
+  const listensSwitch = () =>
+    screen.getByRole("switch", { name: "Opens notification channel" });
+  const refetchesSwitch = () =>
+    screen.getByRole("switch", {
+      name: "Re-fetches tools after the notification",
+    });
+
+  it("renders conforming defaults with nothing stored", () => {
+    render(<Harness initial={emptyHostConfigInputV2()} />);
+    expect(listensSwitch()).toBeChecked();
+    expect(refetchesSwitch()).toBeChecked();
+    expect(screen.getByTestId("listens")).toHaveTextContent("<undefined>");
+    expect(screen.getByTestId("profile")).toHaveTextContent("<no-profile>");
+  });
+
+  it("stores false when a switch is turned off", async () => {
+    const user = userEvent.setup();
+    render(<Harness initial={emptyHostConfigInputV2()} />);
+    await user.click(listensSwitch());
+    expect(screen.getByTestId("listens")).toHaveTextContent("false");
+  });
+
+  it("writes ABSENCE when switched back on, collapsing the profile", async () => {
+    // The whole point of the knob: re-enabling must leave no trace, or a host
+    // that merely visited this tab mints a new canonical hash.
+    const user = userEvent.setup();
+    render(<Harness initial={emptyHostConfigInputV2()} />);
+    await user.click(listensSwitch());
+    expect(screen.getByTestId("profile")).toHaveTextContent("profile");
+    await user.click(listensSwitch());
+    expect(screen.getByTestId("listens")).toHaveTextContent("<undefined>");
+    expect(screen.getByTestId("profile")).toHaveTextContent("<no-profile>");
+  });
+
+  it("disables re-fetch once the channel is closed", async () => {
+    // Nothing can arrive, so the answer is unobservable rather than merely
+    // unset — the UI must not invite a claim the probe could never make.
+    const user = userEvent.setup();
+    render(<Harness initial={emptyHostConfigInputV2()} />);
+    await user.click(listensSwitch());
+    expect(refetchesSwitch()).toBeDisabled();
+  });
+
+  it("round-trips through the JSON document", () => {
+    const draft = {
+      ...emptyHostConfigInputV2(),
+      mcpProfile: {
+        profileVersion: 1 as const,
+        toolListChanged: { listens: false },
+      },
+    };
+    const doc = protocolToJson(draft);
+    expect(doc.toolListChanged).toEqual({ listens: false });
+
+    const applied = applyJsonToDraft(doc, emptyHostConfigInputV2());
+    expect(applied).not.toBeNull();
+    expect(applied?.mcpProfile?.toolListChanged).toEqual({ listens: false });
+  });
+
+  it("drops non-boolean leaves from the document", () => {
+    const applied = applyJsonToDraft(
+      {
+        ...protocolToJson(emptyHostConfigInputV2()),
+        toolListChanged: { listens: "no", refetches: false },
+      } as unknown as ReturnType<typeof protocolToJson>,
+      emptyHostConfigInputV2(),
+    );
+    // Assert the save SURVIVED first — a rejected document also reads as
+    // `undefined` below, which would pass for the wrong reason.
+    expect(applied).not.toBeNull();
+    // Fail-closed: an unreadable leaf reads as conforming, not as degraded.
+    expect(applied?.mcpProfile?.toolListChanged).toEqual({ refetches: false });
   });
 });

--- a/mcpjam-inspector/client/src/components/ui/__tests__/sandboxed-iframe.test.tsx
+++ b/mcpjam-inspector/client/src/components/ui/__tests__/sandboxed-iframe.test.tsx
@@ -362,6 +362,60 @@ describe("SandboxedIframe — resource-ready delivery", () => {
   });
 });
 
+describe("SandboxedIframe — browser storage policy delivery", () => {
+  function dispatchFromIframe(iframe: HTMLIFrameElement, data: unknown): void {
+    const proxyOrigin = new URL(iframe.src).origin;
+    window.dispatchEvent(
+      new MessageEvent("message", {
+        data,
+        source: iframe.contentWindow!,
+        origin: proxyOrigin,
+      })
+    );
+  }
+
+  it("forwards browserStorage in the payload and resends when it changes", async () => {
+    const renderIframe = (localStorageAllowed: boolean) => (
+      <SandboxedIframe
+        html="<html><body>widget</body></html>"
+        browserStorage={{ localStorage: localStorageAllowed }}
+        onMessage={() => {}}
+      />
+    );
+    const { container, rerender } = render(renderIframe(false));
+    const iframe = container.querySelector("iframe") as HTMLIFrameElement;
+    const postMessageSpy = vi.spyOn(iframe.contentWindow!, "postMessage");
+
+    act(() => {
+      dispatchFromIframe(iframe, {
+        jsonrpc: "2.0",
+        method: "ui/notifications/sandbox-proxy-ready",
+      });
+    });
+
+    await vi.waitFor(() => expect(postMessageSpy).toHaveBeenCalledTimes(1));
+    expect(postMessageSpy).toHaveBeenLastCalledWith(
+      expect.objectContaining({
+        params: expect.objectContaining({
+          browserStorage: { localStorage: false },
+        }),
+      }),
+      expect.any(String)
+    );
+
+    // Semantically unchanged — no resend.
+    rerender(renderIframe(false));
+    await act(async () => Promise.resolve());
+    expect(postMessageSpy).toHaveBeenCalledTimes(1);
+
+    // Flipping the toggle MUST re-post, or the guard would keep running
+    // against a policy the user already changed. This is what including
+    // browserStorage in `resourceReadyKey` buys.
+    rerender(renderIframe(true));
+    await vi.waitFor(() => expect(postMessageSpy).toHaveBeenCalledTimes(2));
+  });
+});
+
 describe("SandboxedIframe — non-JSON-RPC message allow-list", () => {
   // The handler at sandboxed-iframe.tsx:165-205 only forwards messages that
   // either (a) match a small non-JSON-RPC allow-list or (b) carry

--- a/mcpjam-inspector/client/src/hooks/hosted/use-hosted-api-context.ts
+++ b/mcpjam-inspector/client/src/hooks/hosted/use-hosted-api-context.ts
@@ -18,6 +18,8 @@ interface UseApiContextOptions {
   // Sibling conformance knobs; only the non-default value is ever set.
   firstPageOnly?: true;
   supportsMrtr?: false;
+  suppressListenChannel?: true;
+  dropToolListChanged?: true;
   // Active host's enterprise-managed authorization policy (validated `on`
   // value only) — rides ad-hoc chat/eval request bodies.
   xaaPolicy?: XaaEnterprisePolicy;
@@ -43,6 +45,8 @@ export function useApiContext({
   mirrorToolParamHeaders,
   firstPageOnly,
   supportsMrtr,
+  suppressListenChannel,
+  dropToolListChanged,
   xaaPolicy,
   clientConfigSyncPending,
   getAccessToken,
@@ -73,6 +77,8 @@ export function useApiContext({
       mirrorToolParamHeaders,
       firstPageOnly,
       supportsMrtr,
+      suppressListenChannel,
+      dropToolListChanged,
       xaaPolicy,
       clientConfigSyncPending,
       getAccessToken,
@@ -97,6 +103,8 @@ export function useApiContext({
     mirrorToolParamHeaders,
     firstPageOnly,
     supportsMrtr,
+    suppressListenChannel,
+    dropToolListChanged,
     xaaPolicy,
     clientConfigSyncPending,
     getAccessToken,

--- a/mcpjam-inspector/client/src/hooks/use-server-state.ts
+++ b/mcpjam-inspector/client/src/hooks/use-server-state.ts
@@ -1447,6 +1447,14 @@ export function useServerState({
       if (mcpProfile?.mrtrSupport === "none") {
         defaults.supportsMrtr = false;
       }
+      // Nested record rather than an enum, but the same rule: only an
+      // explicit `false` leaf travels.
+      if (mcpProfile?.toolListChanged?.listens === false) {
+        defaults.suppressListenChannel = true;
+      }
+      if (mcpProfile?.toolListChanged?.refetches === false) {
+        defaults.dropToolListChanged = true;
+      }
       // Enterprise-managed authorization policy from the active host's
       // mcpProfile. Sent only when validly ON; an `invalid` stored policy
       // fails the connect client-side with an actionable message instead of

--- a/mcpjam-inspector/client/src/lib/__tests__/client-config-v2-mcp-profile.test.ts
+++ b/mcpjam-inspector/client/src/lib/__tests__/client-config-v2-mcp-profile.test.ts
@@ -428,9 +428,21 @@ describe("isMcpProfileEmpty (shared by every profile write path)", () => {
       },
       { profileVersion: 1 as const, mrtrSupport: "none" as const },
       { profileVersion: 1 as const, toolParamHeaderMirroring: "omit" as const },
+      {
+        profileVersion: 1 as const,
+        toolListChanged: { listens: false },
+      },
     ]) {
       expect(isMcpProfileEmpty(profile)).toBe(false);
     }
+  });
+
+  it("treats an all-absent toolListChanged record as empty", () => {
+    // A record with no leaves carries nothing the canonicalizer would keep,
+    // so persisting it would mint a row hashing identically to no profile.
+    expect(
+      isMcpProfileEmpty({ profileVersion: 1, toolListChanged: {} })
+    ).toBe(true);
   });
 
   it("treats an EMPTY initialize envelope as empty", () => {

--- a/mcpjam-inspector/client/src/lib/__tests__/client-config-v2-mcp-profile.test.ts
+++ b/mcpjam-inspector/client/src/lib/__tests__/client-config-v2-mcp-profile.test.ts
@@ -437,6 +437,22 @@ describe("isMcpProfileEmpty (shared by every profile write path)", () => {
     }
   });
 
+  it("treats a profile whose only content was a storage toggle as empty", () => {
+    // The BrowserStorageCard setter deletes the leaf when an API is switched
+    // back on, leaving `{ profileVersion: 1, apps: undefined }`. If that does
+    // not read as empty, flipping a switch off and on again mints a config
+    // row whose hash differs from the absent profile it started from.
+    expect(
+      isMcpProfileEmpty({ profileVersion: 1, apps: undefined })
+    ).toBe(true);
+    expect(
+      isMcpProfileEmpty({
+        profileVersion: 1,
+        apps: { sandbox: { browserStorage: { localStorage: false } } },
+      })
+    ).toBe(false);
+  });
+
   it("treats an all-absent toolListChanged record as empty", () => {
     // A record with no leaves carries nothing the canonicalizer would keep,
     // so persisting it would mint a row hashing identically to no profile.

--- a/mcpjam-inspector/client/src/lib/apis/web/context.ts
+++ b/mcpjam-inspector/client/src/lib/apis/web/context.ts
@@ -48,6 +48,8 @@ export interface ApiContext {
    */
   firstPageOnly?: true;
   supportsMrtr?: false;
+  suppressListenChannel?: true;
+  dropToolListChanged?: true;
   /**
    * The active host's enterprise-managed authorization policy (validated
    * `on` value only). Rides ad-hoc chat/eval bodies; ignored server-side
@@ -444,6 +446,8 @@ function conformanceWireFields(apiContext: ApiContext): {
   mirrorToolParamHeaders?: false;
   firstPageOnly?: true;
   supportsMrtr?: false;
+  suppressListenChannel?: true;
+  dropToolListChanged?: true;
 } {
   return {
     ...(apiContext.mirrorToolParamHeaders === false
@@ -451,6 +455,12 @@ function conformanceWireFields(apiContext: ApiContext): {
       : {}),
     ...(apiContext.firstPageOnly === true
       ? { firstPageOnly: true as const }
+      : {}),
+    ...(apiContext.suppressListenChannel === true
+      ? { suppressListenChannel: true as const }
+      : {}),
+    ...(apiContext.dropToolListChanged === true
+      ? { dropToolListChanged: true as const }
       : {}),
     ...(apiContext.supportsMrtr === false
       ? { supportsMrtr: false as const }
@@ -522,6 +532,8 @@ export function buildServerBatchRequest(serverNamesOrIds: string[]): {
   mirrorToolParamHeaders?: boolean;
   firstPageOnly?: true;
   supportsMrtr?: false;
+  suppressListenChannel?: true;
+  dropToolListChanged?: true;
   xaaPolicy?: XaaEnterprisePolicy;
   oauthTokens?: Record<string, string>;
   accessScope?: HostedAccessScope;
@@ -599,6 +611,8 @@ export function buildResolvedServerBatchRequest(input: {
   mirrorToolParamHeaders?: boolean;
   firstPageOnly?: true;
   supportsMrtr?: false;
+  suppressListenChannel?: true;
+  dropToolListChanged?: true;
   xaaPolicy?: XaaEnterprisePolicy;
   oauthTokens?: Record<string, string>;
   accessScope?: HostedAccessScope;
@@ -644,6 +658,8 @@ export function buildHostedEvalServerBatchRequest(serverNamesOrIds: string[]): {
   mirrorToolParamHeaders?: boolean;
   firstPageOnly?: true;
   supportsMrtr?: false;
+  suppressListenChannel?: true;
+  dropToolListChanged?: true;
   xaaPolicy?: XaaEnterprisePolicy;
   oauthTokens?: Record<string, string>;
   accessScope?: HostedAccessScope;

--- a/mcpjam-inspector/client/src/lib/apis/web/servers-api.ts
+++ b/mcpjam-inspector/client/src/lib/apis/web/servers-api.ts
@@ -55,6 +55,8 @@ export type HostedServerValidateContext = {
    */
   firstPageOnly?: true;
   supportsMrtr?: false;
+  suppressListenChannel?: true;
+  dropToolListChanged?: true;
 };
 
 export interface HostedServerValidateResponse {
@@ -140,6 +142,12 @@ export async function validateHostedServer(
           : {}),
         ...(hostedContext.supportsMrtr === false
           ? { supportsMrtr: false }
+          : {}),
+        ...(hostedContext.suppressListenChannel === true
+          ? { suppressListenChannel: true }
+          : {}),
+        ...(hostedContext.dropToolListChanged === true
+          ? { dropToolListChanged: true }
           : {}),
       }
     : buildServerRequest(serverNameOrId);

--- a/mcpjam-inspector/client/src/lib/apps-capability-dimensions.ts
+++ b/mcpjam-inspector/client/src/lib/apps-capability-dimensions.ts
@@ -15,7 +15,7 @@ import type {
 /** Boolean MCP Apps spec-bridge dimensions (excludes the two non-boolean fields). */
 export type McpAppsDimensionKey = Exclude<
   keyof McpAppsCapabilities,
-  "availableDisplayModes" | "widgetDisplayModeRequests"
+  "availableDisplayModes" | "widgetDisplayModeRequests" | "toolResult"
 >;
 
 /** Per-dimension matrix metadata. Description is shown on row hover. */

--- a/mcpjam-inspector/client/src/lib/client-config-v2.ts
+++ b/mcpjam-inspector/client/src/lib/client-config-v2.ts
@@ -687,6 +687,23 @@ export function mergeMcpAppsCapabilities(
     base.cspResourceDomains || override.cspResourceDomains
       ? { ...base.cspResourceDomains, ...override.cspResourceDomains }
       : undefined;
+  // Two levels deep, so a shallow spread would let an override that names
+  // only `structuredContent` erase the preset's per-block-kind answers.
+  const toolResult =
+    base.toolResult || override.toolResult
+      ? {
+          ...base.toolResult,
+          ...override.toolResult,
+          ...(base.toolResult?.content || override.toolResult?.content
+            ? {
+                content: {
+                  ...base.toolResult?.content,
+                  ...override.toolResult?.content,
+                },
+              }
+            : {}),
+        }
+      : undefined;
   return {
     availableDisplayModes,
     toolInputPartial: override.toolInputPartial ?? base.toolInputPartial,
@@ -705,6 +722,7 @@ export function mergeMcpAppsCapabilities(
     cspBaseUriDomains: override.cspBaseUriDomains ?? base.cspBaseUriDomains,
     cspConnectDomains,
     cspResourceDomains,
+    toolResult,
     resourcePrefersBorder:
       override.resourcePrefersBorder ?? base.resourcePrefersBorder,
     downloadFile: override.downloadFile ?? base.downloadFile,

--- a/mcpjam-inspector/client/src/lib/client-config-v2.ts
+++ b/mcpjam-inspector/client/src/lib/client-config-v2.ts
@@ -844,6 +844,12 @@ export function isMcpProfileEmpty(profile: HostConfigMcpProfileV1): boolean {
     profile.toolParamHeaderMirroring === undefined &&
     profile.paginationTraversal === undefined &&
     profile.mrtrSupport === undefined &&
+    // A record, so emptiness is per-leaf: `{}` carries nothing (the
+    // canonicalizer drops it), but any boolean leaf is a real setting.
+    (profile.toolListChanged === undefined ||
+      Object.values(profile.toolListChanged).every(
+        (value) => value === undefined
+      )) &&
     !profile.apps &&
     !profile.extensions
   );

--- a/mcpjam-inspector/client/src/lib/client-styles/__tests__/sdk-matrix-parity.test.ts
+++ b/mcpjam-inspector/client/src/lib/client-styles/__tests__/sdk-matrix-parity.test.ts
@@ -70,9 +70,17 @@ describe("SDK-sourced MCP Apps matrices are complete resolved surfaces", () => {
       xhr: true,
       websocket: true,
     });
-    // Unknown, not false: ChatGPT's own baseline allowlist covers the probe's
-    // declared resource origin, so no result separates honored from ignored.
-    expect(MCP_APPS_CHATGPT_SURFACE.cspResourceDomains).toBeUndefined();
+    // Measured true since the 2026-08-23 paired probe: it declared
+    // `fastly.jsdelivr.net`, an origin OUTSIDE ChatGPT's baseline allowlist,
+    // and every declared resource subtype loaded — which is what separates
+    // honored from ignored, and is why this is no longer "unknown".
+    expect(MCP_APPS_CHATGPT_SURFACE.cspResourceDomains).toEqual({
+      script: true,
+      stylesheet: true,
+      image: true,
+      font: true,
+      media: true,
+    });
     expect(MCP_APPS_CURSOR_SURFACE.cspResourceDomains?.media).toBe(true);
     expect(MCP_APPS_GOOSE_SURFACE.cspConnectDomains).toEqual({
       fetch: false,

--- a/mcpjam-inspector/client/src/lib/client-styles/types.ts
+++ b/mcpjam-inspector/client/src/lib/client-styles/types.ts
@@ -264,6 +264,24 @@ export type McpAppsCspResourceDomains = {
   media?: boolean;
 };
 
+/**
+ * Which halves of an MCP Tool Result the host relays to a widget that called
+ * a tool. Named (not inlined) because BOTH the authoring surface
+ * (`McpAppsCapabilities`) and the resolved surface
+ * (`ResolvedMcpAppsCapabilities`) carry it, and the merge function converts
+ * one into the other — inlining it twice is how they drift apart.
+ */
+export type McpAppsToolResultPolicy = {
+  structuredContent?: boolean;
+  content?: {
+    text?: boolean;
+    image?: boolean;
+    audio?: boolean;
+    resource?: boolean;
+    resourceLink?: boolean;
+  };
+};
+
 export type McpAppsCapabilities = {
   /** Allow-list of display modes advertised in HostContext. */
   availableDisplayModes?: ("inline" | "fullscreen" | "pip")[];
@@ -288,20 +306,11 @@ export type McpAppsCapabilities = {
   requestTeardown?: boolean;
   /**
    * Probe-measured MCP Tool Result relay behavior for widget-initiated tool
-   * calls. It shares storage with the app bridge overrides but is not an
-   * `app.*` capability, so the resolved bridge surface intentionally ignores
-   * it.
+   * calls. Shares storage with the app bridge overrides but is not an
+   * `app.*` capability — it shapes the VALUE a live handler returns rather
+   * than gating whether a handler exists.
    */
-  toolResult?: {
-    structuredContent?: boolean;
-    content?: {
-      text?: boolean;
-      image?: boolean;
-      audio?: boolean;
-      resource?: boolean;
-      resourceLink?: boolean;
-    };
-  };
+  toolResult?: McpAppsToolResultPolicy;
   /**
    * Host policy for `ui/request-display-mode` originating from the widget.
    * SEP-1865 permits the host to decline these requests; this row exposes
@@ -362,6 +371,12 @@ export type ResolvedMcpAppsCapabilities = {
   downloadFile: boolean;
   requestTeardown: boolean;
   widgetDisplayModeRequests: "accept" | "user-initiated-only" | "decline";
+  /**
+   * Optional like the CSP subtype records above: absent means the host
+   * forwards the whole tool result. `mergeMcpAppsCapabilities` resolves it
+   * and `host-app-bridge` enforces it on every result relayed to a widget.
+   */
+  toolResult?: McpAppsToolResultPolicy;
 };
 
 /**

--- a/mcpjam-inspector/client/src/lib/client-styles/types.ts
+++ b/mcpjam-inspector/client/src/lib/client-styles/types.ts
@@ -287,6 +287,22 @@ export type McpAppsCapabilities = {
   downloadFile?: boolean;
   requestTeardown?: boolean;
   /**
+   * Probe-measured MCP Tool Result relay behavior for widget-initiated tool
+   * calls. It shares storage with the app bridge overrides but is not an
+   * `app.*` capability, so the resolved bridge surface intentionally ignores
+   * it.
+   */
+  toolResult?: {
+    structuredContent?: boolean;
+    content?: {
+      text?: boolean;
+      image?: boolean;
+      audio?: boolean;
+      resource?: boolean;
+      resourceLink?: boolean;
+    };
+  };
+  /**
    * Host policy for `ui/request-display-mode` originating from the widget.
    * SEP-1865 permits the host to decline these requests; this row exposes
    * that decision as a knob.

--- a/mcpjam-inspector/client/src/lib/host-config-field-schema.ts
+++ b/mcpjam-inspector/client/src/lib/host-config-field-schema.ts
@@ -640,7 +640,7 @@ const TOOL_RESULT_CONTENT_KINDS = [
 const TOOL_RESULT_WIDGET_FIELDS: ReadonlyArray<HostConfigFieldDef> = [
   {
     id: "toolResult.structuredContent",
-    section: "protocol",
+    section: "apps",
     subsection: "Widget tool results",
     label: "Structured content",
     path: "mcpProfile.apps.mcpAppsOverrides.toolResult.structuredContent",
@@ -653,7 +653,7 @@ const TOOL_RESULT_WIDGET_FIELDS: ReadonlyArray<HostConfigFieldDef> = [
   ...TOOL_RESULT_CONTENT_KINDS.map(
     ([key, label]): HostConfigFieldDef => ({
       id: `toolResult.content.${key}`,
-      section: "protocol",
+      section: "apps",
       subsection: "Widget tool results",
       label,
       path: `mcpProfile.apps.mcpAppsOverrides.toolResult.content.${key}`,
@@ -941,10 +941,6 @@ export const HOST_CONFIG_FIELDS: ReadonlyArray<HostConfigFieldDef> = [
       mcpProfile(cfg)?.initialize?.supportedProtocolVersions,
   },
 
-  // ============================================================
-  // Protocol · Widget tool results
-  // ============================================================
-  ...TOOL_RESULT_WIDGET_FIELDS,
 
   // ============================================================
   // Protocol · Client capabilities supported
@@ -1122,6 +1118,11 @@ export const HOST_CONFIG_FIELDS: ReadonlyArray<HostConfigFieldDef> = [
   },
   ...SANDBOX_PERMISSION_FIELDS,
   ...BROWSER_STORAGE_FIELDS,
+
+  // ============================================================
+  // Apps · Widget tool results
+  // ============================================================
+  ...TOOL_RESULT_WIDGET_FIELDS,
   ...TOOL_LIST_CHANGED_FIELDS,
   {
     id: "sandbox.sandboxAttrs",

--- a/mcpjam-inspector/client/src/lib/host-config-field-schema.ts
+++ b/mcpjam-inspector/client/src/lib/host-config-field-schema.ts
@@ -641,11 +641,11 @@ const TOOL_RESULT_WIDGET_FIELDS: ReadonlyArray<HostConfigFieldDef> = [
   {
     id: "toolResult.structuredContent",
     section: "protocol",
-    subsection: "Tool results received by widgets",
+    subsection: "Widget tool results",
     label: "Structured content",
     path: "mcpProfile.apps.mcpAppsOverrides.toolResult.structuredContent",
     description:
-      "Forwards structuredContent to an MCP App widget after it calls a tool.",
+      "Whether the structuredContent half of a tool result reaches a widget that called the tool.",
     kind: { kind: "boolean" },
     read: (cfg) =>
       mcpProfile(cfg)?.apps?.mcpAppsOverrides?.toolResult?.structuredContent,
@@ -654,10 +654,10 @@ const TOOL_RESULT_WIDGET_FIELDS: ReadonlyArray<HostConfigFieldDef> = [
     ([key, label]): HostConfigFieldDef => ({
       id: `toolResult.content.${key}`,
       section: "protocol",
-      subsection: "Tool results received by widgets",
+      subsection: "Widget tool results",
       label,
       path: `mcpProfile.apps.mcpAppsOverrides.toolResult.content.${key}`,
-      description: `Forwards ${label.toLowerCase()} content to an MCP App widget after it calls a tool.`,
+      description: `Whether ${label.toLowerCase()} blocks in a tool result reach a widget that called the tool.`,
       kind: { kind: "boolean" },
       read: (cfg) =>
         cfg.mcpProfile?.apps?.mcpAppsOverrides?.toolResult?.content?.[key],
@@ -942,7 +942,7 @@ export const HOST_CONFIG_FIELDS: ReadonlyArray<HostConfigFieldDef> = [
   },
 
   // ============================================================
-  // Protocol · Tool results received by widgets
+  // Protocol · Widget tool results
   // ============================================================
   ...TOOL_RESULT_WIDGET_FIELDS,
 

--- a/mcpjam-inspector/client/src/lib/host-config-field-schema.ts
+++ b/mcpjam-inspector/client/src/lib/host-config-field-schema.ts
@@ -716,6 +716,31 @@ const TOOL_LIST_CHANGED_FIELDS: ReadonlyArray<HostConfigFieldDef> = (
   })
 );
 
+/**
+ * `mcpProfile.paginationTraversal` — whether the client walks `nextCursor`
+ * to the end of a paginated list, or stops at page one.
+ *
+ * Rendered as a support chip rather than the literal, because the question a
+ * reader has is binary: will this host see tools past the first page? An
+ * absent value maps to "unknown" through the shared fallback, so a host
+ * nobody probed is never published as failing.
+ */
+const PAGINATION_FIELD: HostConfigFieldDef = {
+  id: "paginationTraversal",
+  section: "protocol",
+  subsection: "Pagination",
+  label: "Follows nextCursor",
+  path: "mcpProfile.paginationTraversal",
+  description:
+    "Client requests further pages of a paginated list instead of treating page one as the whole result.",
+  kind: {
+    kind: "enum",
+    options: ["full", "firstPageOnly"],
+    support: { full: "supported", firstPageOnly: "unsupported" },
+  },
+  read: (cfg) => mcpProfile(cfg)?.paginationTraversal,
+};
+
 export const HOST_CONFIG_FIELDS: ReadonlyArray<HostConfigFieldDef> = [
   // ============================================================
   // Agent · Agent tooling
@@ -1124,6 +1149,7 @@ export const HOST_CONFIG_FIELDS: ReadonlyArray<HostConfigFieldDef> = [
   // ============================================================
   ...TOOL_RESULT_WIDGET_FIELDS,
   ...TOOL_LIST_CHANGED_FIELDS,
+  PAGINATION_FIELD,
   {
     id: "sandbox.sandboxAttrs",
     section: "apps",

--- a/mcpjam-inspector/client/src/lib/host-config-field-schema.ts
+++ b/mcpjam-inspector/client/src/lib/host-config-field-schema.ts
@@ -700,7 +700,7 @@ const TOOL_LIST_CHANGED_FIELDS: ReadonlyArray<HostConfigFieldDef> = (
     [
       "refetches",
       "Re-fetches after list_changed",
-      "Client acts on notifications/tools/list_changed instead of keeping its cached tool list. Only observable when the channel is open.",
+      "Client acts on notifications/tools/list_changed instead of keeping its cached tool list. Independent of the channel: a server can publish the notification on an open tools/call response stream, which reaches a client that never opened one.",
     ],
   ] as const
 ).map(

--- a/mcpjam-inspector/client/src/lib/host-config-field-schema.ts
+++ b/mcpjam-inspector/client/src/lib/host-config-field-schema.ts
@@ -629,6 +629,93 @@ const SANDBOX_PERMISSION_FIELDS: ReadonlyArray<HostConfigFieldDef> =
     })
   );
 
+/** Tool Result parts relayed back only to a widget that called the tool. */
+const TOOL_RESULT_CONTENT_KINDS = [
+  ["text", "Text"],
+  ["image", "Image"],
+  ["audio", "Audio"],
+  ["resource", "Embedded resource"],
+  ["resourceLink", "Resource link"],
+] as const;
+const TOOL_RESULT_WIDGET_FIELDS: ReadonlyArray<HostConfigFieldDef> = [
+  {
+    id: "toolResult.structuredContent",
+    section: "protocol",
+    subsection: "Tool results received by widgets",
+    label: "Structured content",
+    path: "mcpProfile.apps.mcpAppsOverrides.toolResult.structuredContent",
+    description:
+      "Forwards structuredContent to an MCP App widget after it calls a tool.",
+    kind: { kind: "boolean" },
+    read: (cfg) =>
+      mcpProfile(cfg)?.apps?.mcpAppsOverrides?.toolResult?.structuredContent,
+  },
+  ...TOOL_RESULT_CONTENT_KINDS.map(
+    ([key, label]): HostConfigFieldDef => ({
+      id: `toolResult.content.${key}`,
+      section: "protocol",
+      subsection: "Tool results received by widgets",
+      label,
+      path: `mcpProfile.apps.mcpAppsOverrides.toolResult.content.${key}`,
+      description: `Forwards ${label.toLowerCase()} content to an MCP App widget after it calls a tool.`,
+      kind: { kind: "boolean" },
+      read: (cfg) =>
+        cfg.mcpProfile?.apps?.mcpAppsOverrides?.toolResult?.content?.[key],
+    })
+  ),
+];
+
+/** Browser APIs observed inside the sandboxed widget iframe. */
+const BROWSER_STORAGE_KEYS = [
+  "localStorage",
+  "sessionStorage",
+  "indexedDB",
+] as const;
+const BROWSER_STORAGE_FIELDS: ReadonlyArray<HostConfigFieldDef> =
+  BROWSER_STORAGE_KEYS.map(
+    (key): HostConfigFieldDef => ({
+    id: `sandbox.browserStorage.${key}`,
+    section: "apps",
+    subsection: "Sandbox",
+    label: key === "indexedDB" ? "IndexedDB" : key,
+    path: `mcpProfile.apps.sandbox.browserStorage.${key}`,
+    description: `${key} works inside the sandboxed app iframe (probe-measured browser behavior, not MCP).`,
+    kind: { kind: "boolean" },
+    read: (cfg) => mcpProfile(cfg)?.apps?.sandbox?.browserStorage?.[key],
+    })
+  );
+
+/**
+ * How the client handles `notifications/tools/list_changed`. Two
+ * independently-measured facts: whether it opens the server→client channel at
+ * all, and whether it acts on the notification once one arrives.
+ */
+const TOOL_LIST_CHANGED_FIELDS: ReadonlyArray<HostConfigFieldDef> = (
+  [
+    [
+      "listens",
+      "Opens notification channel",
+      "Client opens the server-to-client notification channel (legacy: standalone GET SSE stream; 2026-07-28: subscriptions/listen).",
+    ],
+    [
+      "refetches",
+      "Re-fetches after list_changed",
+      "Client acts on notifications/tools/list_changed instead of keeping its cached tool list. Only observable when the channel is open.",
+    ],
+  ] as const
+).map(
+  ([key, label, description]): HostConfigFieldDef => ({
+    id: `toolListChanged.${key}`,
+    section: "protocol",
+    subsection: "Tool list changed",
+    label,
+    path: `mcpProfile.toolListChanged.${key}`,
+    description,
+    kind: { kind: "boolean" },
+    read: (cfg) => mcpProfile(cfg)?.toolListChanged?.[key],
+  })
+);
+
 export const HOST_CONFIG_FIELDS: ReadonlyArray<HostConfigFieldDef> = [
   // ============================================================
   // Agent · Agent tooling
@@ -855,6 +942,11 @@ export const HOST_CONFIG_FIELDS: ReadonlyArray<HostConfigFieldDef> = [
   },
 
   // ============================================================
+  // Protocol · Tool results received by widgets
+  // ============================================================
+  ...TOOL_RESULT_WIDGET_FIELDS,
+
+  // ============================================================
   // Protocol · Client capabilities supported
   // ============================================================
   {
@@ -1029,6 +1121,8 @@ export const HOST_CONFIG_FIELDS: ReadonlyArray<HostConfigFieldDef> = [
     read: (cfg) => mcpProfile(cfg)?.apps?.sandbox?.permissions?.mode,
   },
   ...SANDBOX_PERMISSION_FIELDS,
+  ...BROWSER_STORAGE_FIELDS,
+  ...TOOL_LIST_CHANGED_FIELDS,
   {
     id: "sandbox.sandboxAttrs",
     section: "apps",

--- a/mcpjam-inspector/client/src/state/mcp-api.ts
+++ b/mcpjam-inspector/client/src/state/mcp-api.ts
@@ -112,6 +112,12 @@ function buildHostedValidationContext(
     ...(options.connectionDefaults?.supportsMrtr === false
       ? { supportsMrtr: false }
       : {}),
+    ...(options.connectionDefaults?.suppressListenChannel === true
+      ? { suppressListenChannel: true }
+      : {}),
+    ...(options.connectionDefaults?.dropToolListChanged === true
+      ? { dropToolListChanged: true }
+      : {}),
   };
 }
 

--- a/mcpjam-inspector/server/__tests__/sandbox-proxy-buildCSP.test.ts
+++ b/mcpjam-inspector/server/__tests__/sandbox-proxy-buildCSP.test.ts
@@ -51,6 +51,7 @@ function extract(name: string): string {
 const sanitize = extract("sanitizeDomain");
 const build = extract("buildCSP");
 const buildGuard = extract("buildConnectGuardScript");
+const buildStorageGuard = extract("buildBrowserStorageGuardScript");
 
 // eslint-disable-next-line @typescript-eslint/no-implied-eval
 const buildCSP = new Function(
@@ -73,6 +74,12 @@ const buildConnectGuardScript = new Function(
   cspSubtypePolicy?: Record<string, unknown>,
   cspDirectives?: Record<string, string[]>
 ) => string;
+
+// eslint-disable-next-line @typescript-eslint/no-implied-eval
+const buildBrowserStorageGuardScript = new Function(
+  "browserStorage",
+  `${buildStorageGuard}\nreturn buildBrowserStorageGuardScript(browserStorage);`
+) as (browserStorage?: Record<string, unknown>) => string;
 
 describe("sandbox-proxy buildCSP merge rule", () => {
   it("emits 'none' when no domains and no cspDirectives for an empty directive", () => {
@@ -791,5 +798,84 @@ describe("sandbox-proxy connect guard — CSP source matching", () => {
       fetchAllowed(["https://h.test"], "https://other.test/x")
     ).resolves.toBe(false);
     await expect(fetchAllowed([], "https://h.test/x")).resolves.toBe(false);
+  });
+});
+
+describe("sandbox-proxy browser storage guard", () => {
+  it("throws SecurityError on a blocked API and leaves the others working", () => {
+    const script = buildBrowserStorageGuardScript({ localStorage: false });
+    const dom = new JSDOM(
+      `<!doctype html><html><head>${script}</head></html>`,
+      { runScripts: "dangerously", url: "https://widget.example.test/" }
+    );
+
+    // Access itself throws — matching a real iframe without
+    // `allow-same-origin`, so a widget's `try { localStorage } catch`
+    // feature-detect takes the same branch here as in production.
+    let caught: unknown;
+    try {
+      void dom.window.localStorage;
+    } catch (error) {
+      caught = error;
+    }
+    expect((caught as DOMException | undefined)?.name).toBe("SecurityError");
+
+    // Unlisted APIs are untouched.
+    expect(() => dom.window.sessionStorage).not.toThrow();
+  });
+
+  it("blocks every listed API, including indexedDB", () => {
+    const script = buildBrowserStorageGuardScript({
+      localStorage: false,
+      sessionStorage: false,
+      indexedDB: false,
+    });
+    const dom = new JSDOM(
+      `<!doctype html><html><head>${script}</head></html>`,
+      { runScripts: "dangerously", url: "https://widget.example.test/" }
+    );
+
+    for (const api of ["localStorage", "sessionStorage", "indexedDB"] as const) {
+      let caught: unknown;
+      try {
+        void (dom.window as unknown as Record<string, unknown>)[api];
+      } catch (error) {
+        caught = error;
+      }
+      expect((caught as DOMException | undefined)?.name).toBe("SecurityError");
+    }
+  });
+
+  it("emits nothing when no API is blocked, so the fast path stays free", () => {
+    // Absent, empty, and all-true are the same statement: nothing is denied.
+    expect(buildBrowserStorageGuardScript(undefined)).toBe("");
+    expect(buildBrowserStorageGuardScript({})).toBe("");
+    expect(
+      buildBrowserStorageGuardScript({
+        localStorage: true,
+        sessionStorage: true,
+        indexedDB: true,
+      })
+    ).toBe("");
+  });
+
+  it("only an explicit false blocks — true and absent both mean available", () => {
+    const script = buildBrowserStorageGuardScript({
+      localStorage: true,
+      indexedDB: false,
+    });
+    const dom = new JSDOM(
+      `<!doctype html><html><head>${script}</head></html>`,
+      { runScripts: "dangerously", url: "https://widget.example.test/" }
+    );
+    expect(() => dom.window.localStorage).not.toThrow();
+    expect(() => dom.window.sessionStorage).not.toThrow();
+    let caught: unknown;
+    try {
+      void dom.window.indexedDB;
+    } catch (error) {
+      caught = error;
+    }
+    expect((caught as DOMException | undefined)?.name).toBe("SecurityError");
   });
 });

--- a/mcpjam-inspector/server/routes/apps/mcp-apps/sandbox-proxy.html
+++ b/mcpjam-inspector/server/routes/apps/mcp-apps/sandbox-proxy.html
@@ -622,6 +622,69 @@ document.addEventListener('securitypolicyviolation', function(e) {
       }
 
       /**
+       * Block browser storage APIs the host profile turned off.
+       *
+       * `mcpProfile.apps.sandbox.browserStorage` is a probe-measured fact: a
+       * host either lets a widget reach these APIs or it does not. Absent (or
+       * true) means available, so only explicit `false` blocks — matching the
+       * omit-when-absent discipline every other profile knob uses.
+       *
+       * Access throws rather than returning null/undefined because that is
+       * what a real iframe without `allow-same-origin` does: the getter
+       * itself raises SecurityError. A widget's `try { localStorage } catch`
+       * feature-detect must take the same branch here as in production.
+       *
+       * NOT a CSP concern, so unlike the connect guard above this posts no
+       * synthetic violation — nothing is watching for one, and storage never
+       * produces a securitypolicyviolation event.
+       *
+       * @param {object|undefined} browserStorage - per-API policy
+       * @returns {string} script tag, or "" when nothing is blocked
+       */
+      function buildBrowserStorageGuardScript(browserStorage) {
+        if (!browserStorage || typeof browserStorage !== "object") return "";
+        const blocked = ["localStorage", "sessionStorage", "indexedDB"].filter(
+          (api) => browserStorage[api] === false
+        );
+        if (blocked.length === 0) return "";
+
+        const configJson = JSON.stringify({ blocked }).replace(
+          /</g,
+          "\\u003c"
+        );
+
+        return `<script>
+(function() {
+  var config = ${configJson};
+  for (var i = 0; i < config.blocked.length; i++) {
+    (function(api) {
+      try {
+        Object.defineProperty(window, api, {
+          configurable: false,
+          get: function() {
+            throw new DOMException(
+              "Blocked by host browser-storage policy",
+              "SecurityError"
+            );
+          }
+        });
+      } catch (error) {
+        // A non-configurable own property (or a runtime that refuses the
+        // redefine) leaves the API reachable. Fail loud in the console
+        // rather than silently reporting an unenforced policy as enforced.
+        try {
+          console.error(
+            "[mcpjam] could not block " + api + " in this sandbox", error
+          );
+        } catch (_) {}
+      }
+    })(config.blocked[i]);
+  }
+})();
+<\/script>`;
+      }
+
+      /**
        * Inject CSP meta tag and violation listener into HTML
        * @param {string} html - Original HTML content
        * @param {string} cspValue - CSP policy string
@@ -762,6 +825,7 @@ document.addEventListener('securitypolicyviolation', function(e) {
               sandboxAttrs,
               cspDirectives,
               cspSubtypePolicy,
+              browserStorage,
               permissive,
               colorScheme,
               recordMode,
@@ -784,6 +848,12 @@ document.addEventListener('securitypolicyviolation', function(e) {
               cspSubtypePolicy,
               cspDirectives
             );
+            // Storage is independent of CSP mode: a host that serves a
+            // permissive CSP can still deny storage, so this guard rides
+            // BOTH branches below while the connect guard rides only the
+            // CSP one.
+            const browserStorageGuardScript =
+              buildBrowserStorageGuardScript(browserStorage);
             recorderDebug("resource ready", {
               recordMode: !!recordMode,
               recorderScript: !!recorderScript,
@@ -867,7 +937,7 @@ document.addEventListener('securitypolicyviolation', function(e) {
                   html,
                   permissiveCsp,
                   recorderScript,
-                  ""
+                  browserStorageGuardScript
                 );
                 inner.srcdoc = processedHtml;
               } else {
@@ -879,7 +949,7 @@ document.addEventListener('securitypolicyviolation', function(e) {
                   html,
                   cspValue,
                   recorderScript,
-                  connectGuardScript
+                  connectGuardScript + browserStorageGuardScript
                 );
                 inner.srcdoc = processedHtml;
               }

--- a/mcpjam-inspector/server/utils/__tests__/effective-auth.test.ts
+++ b/mcpjam-inspector/server/utils/__tests__/effective-auth.test.ts
@@ -230,6 +230,63 @@ describe("applyHostParamMirroring", () => {
   });
 });
 
+describe("conformanceKnobsFromMcpProfile — toolListChanged", () => {
+  it("reads each false leaf", () => {
+    expect(
+      conformanceKnobsFromMcpProfile({
+        toolListChanged: { listens: false, refetches: false },
+      })
+    ).toEqual({
+      firstPageOnly: undefined,
+      supportsMrtr: undefined,
+      suppressListenChannel: true,
+      dropToolListChanged: true,
+    });
+  });
+
+  it("treats true leaves, an empty record and junk as conforming", () => {
+    for (const toolListChanged of [
+      { listens: true, refetches: true },
+      {},
+      null,
+      "nope",
+    ]) {
+      const knobs = conformanceKnobsFromMcpProfile({ toolListChanged });
+      expect(knobs.suppressListenChannel).toBeUndefined();
+      expect(knobs.dropToolListChanged).toBeUndefined();
+    }
+  });
+});
+
+describe("applyHostConformanceKnobs — toolListChanged", () => {
+  const conforming = {
+    firstPageOnly: undefined,
+    supportsMrtr: undefined,
+    suppressListenChannel: undefined,
+    dropToolListChanged: undefined,
+  } as const;
+
+  it("adds the host's knobs to a body that carried none", () => {
+    expect(
+      applyHostConformanceKnobs(undefined, {
+        ...conforming,
+        suppressListenChannel: true,
+      })
+    ).toEqual({ suppressListenChannel: true });
+  });
+
+  it("REMOVES a body-supplied knob when the host is conforming", () => {
+    // The security property: a share-link body must not be able to silence a
+    // conforming host's notifications by posting the pin itself.
+    expect(
+      applyHostConformanceKnobs(
+        { suppressListenChannel: true, dropToolListChanged: true },
+        conforming
+      )
+    ).toEqual({});
+  });
+});
+
 describe("conformanceKnobsFromMcpProfile", () => {
   it("reads the non-default literals", () => {
     expect(
@@ -237,7 +294,12 @@ describe("conformanceKnobsFromMcpProfile", () => {
         paginationTraversal: "firstPageOnly",
         mrtrSupport: "none",
       })
-    ).toEqual({ firstPageOnly: true, supportsMrtr: false });
+    ).toEqual({
+      firstPageOnly: true,
+      supportsMrtr: false,
+      suppressListenChannel: undefined,
+      dropToolListChanged: undefined,
+    });
   });
 
   it("collapses the default literals, an absent profile and junk to undefined", () => {
@@ -253,6 +315,8 @@ describe("conformanceKnobsFromMcpProfile", () => {
       expect(conformanceKnobsFromMcpProfile(profile)).toEqual({
         firstPageOnly: undefined,
         supportsMrtr: undefined,
+        suppressListenChannel: undefined,
+        dropToolListChanged: undefined,
       });
     }
   });

--- a/mcpjam-inspector/server/utils/effective-auth.ts
+++ b/mcpjam-inspector/server/utils/effective-auth.ts
@@ -238,18 +238,35 @@ export function applyHostParamMirroring<
 export function conformanceKnobsFromMcpProfile(mcpProfile: unknown): {
   firstPageOnly: true | undefined;
   supportsMrtr: false | undefined;
+  suppressListenChannel: true | undefined;
+  dropToolListChanged: true | undefined;
 } {
   const profile =
     mcpProfile !== null && typeof mcpProfile === "object"
       ? (mcpProfile as {
           paginationTraversal?: unknown;
           mrtrSupport?: unknown;
+          toolListChanged?: unknown;
+        })
+      : undefined;
+  // Nested record, so it is narrowed separately; an unreadable value falls
+  // through to `undefined` — conforming — like every knob here.
+  const toolListChanged =
+    profile?.toolListChanged !== null &&
+    typeof profile?.toolListChanged === "object"
+      ? (profile.toolListChanged as {
+          listens?: unknown;
+          refetches?: unknown;
         })
       : undefined;
   return {
     firstPageOnly:
       profile?.paginationTraversal === "firstPageOnly" ? true : undefined,
     supportsMrtr: profile?.mrtrSupport === "none" ? false : undefined,
+    suppressListenChannel:
+      toolListChanged?.listens === false ? true : undefined,
+    dropToolListChanged:
+      toolListChanged?.refetches === false ? true : undefined,
   };
 }
 
@@ -264,16 +281,27 @@ export function conformanceKnobsFromMcpProfile(mcpProfile: unknown): {
  * authoritative: it could turn a knob on but never keep it off, and a
  * share-link body could post `firstPageOnly: true` or `supportsMrtr: false`
  * to make a conforming host silently execute as a degraded client — hiding
- * tools from the model, or dropping MRTR rounds mid-conversation.
+ * tools from the model, dropping MRTR rounds mid-conversation, or (with the
+ * `toolListChanged` pair) silencing every server notification.
  *
  * Every other pin is passed through, and an absent-pins body stays absent
  * unless the host actually asks for a non-default knob.
  */
 export function applyHostConformanceKnobs<
-  T extends { firstPageOnly?: boolean; supportsMrtr?: boolean }
+  T extends {
+    firstPageOnly?: boolean;
+    supportsMrtr?: boolean;
+    suppressListenChannel?: boolean;
+    dropToolListChanged?: boolean;
+  }
 >(
   pins: T | undefined,
-  host: { firstPageOnly: true | undefined; supportsMrtr: false | undefined }
+  host: {
+    firstPageOnly: true | undefined;
+    supportsMrtr: false | undefined;
+    suppressListenChannel: true | undefined;
+    dropToolListChanged: true | undefined;
+  }
 ): T | undefined {
   let next = pins;
   if (host.firstPageOnly === true) {
@@ -286,6 +314,18 @@ export function applyHostConformanceKnobs<
     next = { ...((next ?? {}) as T), supportsMrtr: false };
   } else if (next?.supportsMrtr !== undefined) {
     const { supportsMrtr: _hostOverrides, ...rest } = next;
+    next = rest as T;
+  }
+  if (host.suppressListenChannel === true) {
+    next = { ...((next ?? {}) as T), suppressListenChannel: true };
+  } else if (next?.suppressListenChannel !== undefined) {
+    const { suppressListenChannel: _hostOverrides, ...rest } = next;
+    next = rest as T;
+  }
+  if (host.dropToolListChanged === true) {
+    next = { ...((next ?? {}) as T), dropToolListChanged: true };
+  } else if (next?.dropToolListChanged !== undefined) {
+    const { dropToolListChanged: _hostOverrides, ...rest } = next;
     next = rest as T;
   }
   return next;

--- a/mcpjam-inspector/shared/connection-defaults.ts
+++ b/mcpjam-inspector/shared/connection-defaults.ts
@@ -88,6 +88,14 @@ export type ConnectionDefaults = {
   firstPageOnly?: true;
   supportsMrtr?: false;
   /**
+   * Resolved from `mcpProfile.toolListChanged`. `suppressListenChannel` stops
+   * the client opening the server→client notification stream at all;
+   * `dropToolListChanged` lets it open but ignores
+   * `notifications/tools/list_changed`. Same only-the-non-default rule.
+   */
+  suppressListenChannel?: true;
+  dropToolListChanged?: true;
+  /**
    * The host's enterprise-managed authorization policy, resolved client-side
    * via `readXaaEnterprisePolicy(hostConfig.mcpProfile)`. Present only when
    * the policy is validly ON — the client surfaces an `invalid` policy as a

--- a/sdk/src/host-compat/capabilities.ts
+++ b/sdk/src/host-compat/capabilities.ts
@@ -122,8 +122,9 @@ export const MCP_APPS_CURSOR: McpAppsCapabilities = frozen({
     font: true,
     media: true,
   },
-  // downloadFile stays inherited-true and requestTeardown is an explicit
-  // false, both per the catalog row this matrix is supposed to mirror.
+  // Both explicit false per the catalog row this matrix mirrors. downloadFile
+  // was flipped 2026-08-26: it is absent from Cursor's hostCapabilities.
+  downloadFile: false,
   requestTeardown: false,
 });
 

--- a/sdk/src/host-compat/capabilities.ts
+++ b/sdk/src/host-compat/capabilities.ts
@@ -75,14 +75,21 @@ export const MCP_APPS_CLAUDE: McpAppsCapabilities = frozen({
  * ChatGPT's own baseline allowlist, which the catalog row carries as
  * `cspDirectives`; it is not evidence the declaration was ignored.
  *
- * `cspResourceDomains` is deliberately absent (unknown): the only declared
- * resource origin was `cdn.jsdelivr.net`, which is in that same baseline, so
- * nothing in the probe separates honored from ignored. Re-probe with a
- * declared origin the baseline does not cover before writing `false`.
+ * The 2026-08-23 paired probe (captured 2026-08-24Z) declared
+ * `fastly.jsdelivr.net`, outside that baseline, and every declared resource
+ * subtype loaded in the treatment fixture, so the resource declaration is
+ * honored.
  */
 export const MCP_APPS_CHATGPT: McpAppsCapabilities = frozen({
   ...MCP_APPS_FULL,
   cspConnectDomains: { fetch: true, xhr: true, websocket: true },
+  cspResourceDomains: {
+    script: true,
+    stylesheet: true,
+    image: true,
+    font: true,
+    media: true,
+  },
   downloadFile: false,
   requestTeardown: false,
 });

--- a/sdk/src/host-compat/catalog-schema.ts
+++ b/sdk/src/host-compat/catalog-schema.ts
@@ -74,6 +74,15 @@ export const mcpAppsCapabilitiesSchema = z.object({
   toolResult: z
     .object({
       structuredContent: z.boolean().optional(),
+      content: z
+        .object({
+          text: z.boolean().optional(),
+          image: z.boolean().optional(),
+          audio: z.boolean().optional(),
+          resource: z.boolean().optional(),
+          resourceLink: z.boolean().optional(),
+        })
+        .optional(),
     })
     .optional(),
   resourcePrefersBorder: z.boolean().optional(),

--- a/sdk/src/host-compat/catalog-schema.ts
+++ b/sdk/src/host-compat/catalog-schema.ts
@@ -71,6 +71,11 @@ export const mcpAppsCapabilitiesSchema = z.object({
     })
     .optional(),
   resourceCacheTtl: z.boolean().optional(),
+  toolResult: z
+    .object({
+      structuredContent: z.boolean().optional(),
+    })
+    .optional(),
   resourcePrefersBorder: z.boolean().optional(),
   downloadFile: z.boolean().optional(),
   requestTeardown: z.boolean().optional(),

--- a/sdk/src/host-compat/catalog.generated.ts
+++ b/sdk/src/host-compat/catalog.generated.ts
@@ -248,7 +248,7 @@ export const BUNDLED_HOST_COMPAT_CATALOG = {
         "2025-11-25",
         "2026-07-28",
       ],
-      verifiedAt: 1787097600000,
+      verifiedAt: 1787702400000,
       modelVisibleMcpToolResults: {
         directContent: {
           image: true,
@@ -452,6 +452,7 @@ export const BUNDLED_HOST_COMPAT_CATALOG = {
       mcpProfile: {
         profileVersion: 1,
         mcpProtocolVersion: "auto",
+        paginationTraversal: "full",
         initialize: {
           supportedProtocolVersions: ["2025-03-26", "2025-06-18", "2025-11-25"],
           clientInfo: {
@@ -518,6 +519,11 @@ export const BUNDLED_HOST_COMPAT_CATALOG = {
             allowFeatures: {
               fullscreen: "*",
             },
+            browserStorage: {
+              localStorage: true,
+              sessionStorage: true,
+              indexedDB: true,
+            },
           },
           mcpAppsOverrides: {
             availableDisplayModes: ["inline", "fullscreen"],
@@ -546,6 +552,16 @@ export const BUNDLED_HOST_COMPAT_CATALOG = {
               image: true,
               font: true,
               media: true,
+            },
+            toolResult: {
+              structuredContent: true,
+              content: {
+                text: true,
+                image: true,
+                audio: true,
+                resource: true,
+                resourceLink: true,
+              },
             },
             resourcePrefersBorder: true,
             downloadFile: true,
@@ -1112,7 +1128,7 @@ export const BUNDLED_HOST_COMPAT_CATALOG = {
       provenance: "probe",
       rendersMcpApps: true,
       supportedProtocolVersions: ["2025-11-25"],
-      verifiedAt: 1784764800000,
+      verifiedAt: 1787702400000,
       modelVisibleMcpToolResults: {
         directContent: {
           image: false,
@@ -1212,6 +1228,7 @@ export const BUNDLED_HOST_COMPAT_CATALOG = {
       },
       mcpProfile: {
         profileVersion: 1,
+        paginationTraversal: "full",
         initialize: {
           supportedProtocolVersions: ["2025-11-25"],
           clientInfo: {
@@ -1240,8 +1257,30 @@ export const BUNDLED_HOST_COMPAT_CATALOG = {
             updateModelContext: true,
             message: true,
             sandboxPermissions: true,
-            cspFrameDomains: false,
-            cspBaseUriDomains: false,
+            cspFrameDomains: true,
+            cspBaseUriDomains: true,
+            cspConnectDomains: {
+              fetch: true,
+              xhr: true,
+              websocket: true,
+            },
+            cspResourceDomains: {
+              script: true,
+              stylesheet: true,
+              image: true,
+              font: true,
+              media: true,
+            },
+            toolResult: {
+              structuredContent: true,
+              content: {
+                text: true,
+                image: true,
+                audio: true,
+                resource: true,
+                resourceLink: true,
+              },
+            },
             resourcePrefersBorder: false,
             downloadFile: false,
             requestTeardown: false,
@@ -1261,6 +1300,11 @@ export const BUNDLED_HOST_COMPAT_CATALOG = {
               },
             },
             sandboxAttrs: ["allow-forms"],
+            browserStorage: {
+              localStorage: true,
+              sessionStorage: true,
+              indexedDB: true,
+            },
           },
         },
       },
@@ -1510,7 +1554,7 @@ export const BUNDLED_HOST_COMPAT_CATALOG = {
       provenance: "probe",
       rendersMcpApps: true,
       supportedProtocolVersions: ["2025-06-18"],
-      verifiedAt: 1784764800000,
+      verifiedAt: 1787702400000,
       modelVisibleMcpToolResults: {
         directContent: {
           image: false,
@@ -1558,6 +1602,9 @@ export const BUNDLED_HOST_COMPAT_CATALOG = {
       },
       clientCapabilities: {
         extensions: {
+          "io.slack/block-kit": {
+            mimeTypes: ["application/vnd.slack.blocks+json"],
+          },
           "io.modelcontextprotocol/ui": {
             mimeTypes: ["text/html;profile=mcp-app"],
           },
@@ -1693,10 +1740,32 @@ export const BUNDLED_HOST_COMPAT_CATALOG = {
             serverResources: true,
             logging: true,
             updateModelContext: false,
-            message: false,
+            message: true,
             sandboxPermissions: false,
             cspFrameDomains: false,
             cspBaseUriDomains: false,
+            cspConnectDomains: {
+              fetch: true,
+              xhr: true,
+              websocket: false,
+            },
+            cspResourceDomains: {
+              script: true,
+              stylesheet: true,
+              image: true,
+              font: true,
+              media: true,
+            },
+            toolResult: {
+              structuredContent: true,
+              content: {
+                text: true,
+                image: true,
+                audio: true,
+                resource: true,
+                resourceLink: true,
+              },
+            },
             resourcePrefersBorder: false,
             downloadFile: false,
             requestTeardown: false,
@@ -1714,6 +1783,11 @@ export const BUNDLED_HOST_COMPAT_CATALOG = {
               allow: {},
             },
             sandboxAttrs: ["allow-forms"],
+            browserStorage: {
+              localStorage: true,
+              sessionStorage: true,
+              indexedDB: true,
+            },
           },
         },
       },
@@ -1724,7 +1798,7 @@ export const BUNDLED_HOST_COMPAT_CATALOG = {
       provenance: "probe",
       rendersMcpApps: true,
       supportedProtocolVersions: ["2025-11-25"],
-      verifiedAt: 1786665600000,
+      verifiedAt: 1787702400000,
       modelVisibleMcpToolResults: {
         directContent: {
           image: true,
@@ -1798,6 +1872,11 @@ export const BUNDLED_HOST_COMPAT_CATALOG = {
       },
       mcpProfile: {
         profileVersion: 1,
+        paginationTraversal: "firstPageOnly",
+        toolListChanged: {
+          listens: true,
+          refetches: true,
+        },
         initialize: {
           supportedProtocolVersions: ["2025-11-25"],
           clientInfo: {
@@ -1821,6 +1900,11 @@ export const BUNDLED_HOST_COMPAT_CATALOG = {
               allow: {
                 clipboardWrite: true,
               },
+            },
+            browserStorage: {
+              localStorage: true,
+              sessionStorage: true,
+              indexedDB: true,
             },
           },
           mcpAppsOverrides: {
@@ -1851,8 +1935,18 @@ export const BUNDLED_HOST_COMPAT_CATALOG = {
               font: true,
               media: true,
             },
+            toolResult: {
+              structuredContent: true,
+              content: {
+                text: true,
+                image: true,
+                audio: true,
+                resource: true,
+                resourceLink: true,
+              },
+            },
             resourcePrefersBorder: true,
-            downloadFile: true,
+            downloadFile: false,
             requestTeardown: false,
             widgetDisplayModeRequests: "accept",
           },
@@ -1865,7 +1959,7 @@ export const BUNDLED_HOST_COMPAT_CATALOG = {
       provenance: "probe",
       rendersMcpApps: true,
       supportedProtocolVersions: ["2025-03-26", "2025-06-18", "2025-11-25"],
-      verifiedAt: 1787097600000,
+      verifiedAt: 1787702400000,
       styleVariablesByTheme: {
         light: {
           "--color-background-primary": "rgb(255, 255, 255)",
@@ -2195,6 +2289,11 @@ export const BUNDLED_HOST_COMPAT_CATALOG = {
       },
       mcpProfile: {
         profileVersion: 1,
+        paginationTraversal: "firstPageOnly",
+        toolListChanged: {
+          listens: true,
+          refetches: false,
+        },
         initialize: {
           supportedProtocolVersions: ["2025-03-26", "2025-06-18", "2025-11-25"],
           clientInfo: {
@@ -2204,6 +2303,29 @@ export const BUNDLED_HOST_COMPAT_CATALOG = {
           },
         },
         apps: {
+          sandbox: {
+            csp: {
+              mode: "declared",
+              cspDirectives: {
+                "connect-src": [
+                  "https://cdn.jsdelivr.net",
+                  "https://unpkg.com",
+                ],
+                "script-src": ["https://cdn.jsdelivr.net", "https://unpkg.com"],
+                "style-src": ["https://cdn.jsdelivr.net", "https://unpkg.com"],
+                "img-src": ["https://cdn.jsdelivr.net", "https://unpkg.com"],
+                "font-src": ["https://cdn.jsdelivr.net", "https://unpkg.com"],
+                "media-src": ["https://cdn.jsdelivr.net", "https://unpkg.com"],
+                "frame-src": ["'self'", "data:", "blob:"],
+                "base-uri": ["'none'"],
+              },
+            },
+            browserStorage: {
+              localStorage: true,
+              sessionStorage: true,
+              indexedDB: true,
+            },
+          },
           mcpAppsOverrides: {
             availableDisplayModes: ["inline", "fullscreen"],
             toolInputPartial: true,
@@ -2223,6 +2345,23 @@ export const BUNDLED_HOST_COMPAT_CATALOG = {
               fetch: true,
               xhr: true,
               websocket: true,
+            },
+            cspResourceDomains: {
+              script: true,
+              stylesheet: true,
+              image: true,
+              font: true,
+              media: true,
+            },
+            toolResult: {
+              structuredContent: true,
+              content: {
+                text: true,
+                image: true,
+                audio: true,
+                resource: true,
+                resourceLink: true,
+              },
             },
             resourcePrefersBorder: true,
             toolCancelled: false,
@@ -2251,8 +2390,8 @@ export const BUNDLED_HOST_COMPAT_CATALOG = {
       label: "Copilot",
       provenance: "vendor-doc",
       rendersMcpApps: true,
-      supportedProtocolVersions: ["2025-11-25"],
-      verifiedAt: 1784764800000,
+      supportedProtocolVersions: ["2024-11-05"],
+      verifiedAt: 1787702400000,
       compatibilityEvidence: {
         profileLabel: "Copilot",
         sourceUrl:
@@ -2596,11 +2735,19 @@ export const BUNDLED_HOST_COMPAT_CATALOG = {
       },
       mcpProfile: {
         profileVersion: 1,
+        paginationTraversal: "full",
+        toolListChanged: {
+          listens: false,
+          refetches: true,
+        },
         initialize: {
-          supportedProtocolVersions: ["2025-11-25"],
+          supportedProtocolVersions: ["2024-11-05"],
           clientInfo: {
-            name: "ms-copilot",
-            version: "1.0.1",
+            name: "mcs",
+            version: "1.0.0",
+            channelId: "pva-studio",
+            lcat: "M365_COPILOT_USER",
+            agentAuthenticationMode: "Integrated",
           },
         },
         apps: {
@@ -2667,7 +2814,7 @@ export const BUNDLED_HOST_COMPAT_CATALOG = {
       provenance: "probe",
       rendersMcpApps: true,
       supportedProtocolVersions: ["2025-11-25"],
-      verifiedAt: 1784764800000,
+      verifiedAt: 1787702400000,
       modelVisibleMcpToolResults: {
         directContent: {
           image: true,
@@ -2855,18 +3002,23 @@ export const BUNDLED_HOST_COMPAT_CATALOG = {
       },
       mcpProfile: {
         profileVersion: 1,
+        paginationTraversal: "full",
+        toolListChanged: {
+          listens: true,
+          refetches: true,
+        },
         initialize: {
           supportedProtocolVersions: ["2025-11-25"],
           clientInfo: {
             name: "Visual Studio Code",
-            version: "1.130.0",
+            version: "1.134.0",
           },
         },
         apps: {
           uiInitialize: {
             hostInfo: {
               name: "Visual Studio Code",
-              version: "1.130.0",
+              version: "1.134.0",
             },
           },
           compatRuntime: {
@@ -2893,6 +3045,11 @@ export const BUNDLED_HOST_COMPAT_CATALOG = {
               "local-network-access": "'src'",
               "clipboard-read": "'src'",
             },
+            browserStorage: {
+              localStorage: true,
+              sessionStorage: true,
+              indexedDB: true,
+            },
           },
           mcpAppsOverrides: {
             availableDisplayModes: ["inline"],
@@ -2910,6 +3067,28 @@ export const BUNDLED_HOST_COMPAT_CATALOG = {
             sandboxPermissions: true,
             cspFrameDomains: true,
             cspBaseUriDomains: true,
+            cspConnectDomains: {
+              fetch: true,
+              xhr: true,
+              websocket: true,
+            },
+            cspResourceDomains: {
+              script: true,
+              stylesheet: true,
+              image: true,
+              font: true,
+              media: true,
+            },
+            toolResult: {
+              structuredContent: true,
+              content: {
+                text: true,
+                image: true,
+                audio: true,
+                resource: true,
+                resourceLink: true,
+              },
+            },
             resourcePrefersBorder: true,
             downloadFile: true,
             requestTeardown: true,

--- a/sdk/src/host-compat/catalog.generated.ts
+++ b/sdk/src/host-compat/catalog.generated.ts
@@ -833,7 +833,7 @@ export const BUNDLED_HOST_COMPAT_CATALOG = {
         "2025-11-25",
         "2026-07-28",
       ],
-      verifiedAt: 1787097600000,
+      verifiedAt: 1787443200000,
       modelVisibleMcpToolResults: {
         directContent: {
           image: true,
@@ -1071,6 +1071,13 @@ export const BUNDLED_HOST_COMPAT_CATALOG = {
               fetch: true,
               xhr: true,
               websocket: true,
+            },
+            cspResourceDomains: {
+              script: true,
+              stylesheet: true,
+              image: true,
+              font: true,
+              media: true,
             },
             resourcePrefersBorder: true,
             downloadFile: false,

--- a/sdk/src/host-compat/catalog.generated.ts
+++ b/sdk/src/host-compat/catalog.generated.ts
@@ -1005,6 +1005,10 @@ export const BUNDLED_HOST_COMPAT_CATALOG = {
       mcpProfile: {
         profileVersion: 1,
         mcpProtocolVersion: "auto",
+        paginationTraversal: "full",
+        toolListChanged: {
+          listens: false,
+        },
         initialize: {
           supportedProtocolVersions: ["2025-03-26", "2025-06-18", "2025-11-25"],
           clientInfo: {
@@ -1045,6 +1049,11 @@ export const BUNDLED_HOST_COMPAT_CATALOG = {
                 clipboardWrite: true,
               },
             },
+            browserStorage: {
+              localStorage: true,
+              sessionStorage: true,
+              indexedDB: true,
+            },
             sandboxAttrs: [
               "allow-forms",
               "allow-popups",
@@ -1078,6 +1087,16 @@ export const BUNDLED_HOST_COMPAT_CATALOG = {
               image: true,
               font: true,
               media: true,
+            },
+            toolResult: {
+              structuredContent: true,
+              content: {
+                text: true,
+                image: true,
+                audio: true,
+                resource: true,
+                resourceLink: true,
+              },
             },
             resourcePrefersBorder: true,
             downloadFile: false,

--- a/sdk/src/host-config/canonicalize.ts
+++ b/sdk/src/host-config/canonicalize.ts
@@ -105,6 +105,7 @@ const MCP_APPS_CAPABILITY_KEYS = [
   "cspConnectDomains",
   "cspResourceDomains",
   "resourceCacheTtl",
+  "toolResult",
   "resourcePrefersBorder",
   "downloadFile",
   "requestTeardown",
@@ -846,6 +847,21 @@ function canonicalizeMcpProfile(
     }
   }
 
+  // Sibling to the enum-typed conformance knobs above, but a nested boolean
+  // record (two independently-measured facts) rather than a mode string.
+  // Same omit-when-absent discipline: absent -> spec-conforming, hashes
+  // stable.
+  if (input.toolListChanged !== undefined) {
+    const listChanged = canonicalBooleanCapabilityRecord(
+      "mcpProfile.toolListChanged",
+      input.toolListChanged,
+      ["listens", "refetches"]
+    );
+    if (Object.keys(listChanged).length > 0) {
+      out.toolListChanged = listChanged;
+    }
+  }
+
   // A legacy pin must be one of the versions accepted by initialize. Derive a
   // missing list because initialize needs one. Modern pins use server/discover
   // and are deliberately separate from the legacy initialize accept-list.
@@ -1235,6 +1251,15 @@ function canonicalizeMcpProfile(
           );
           if (Object.keys(domains).length > 0) {
             mcpAppsOverridesOut.cspResourceDomains = domains;
+          }
+        } else if (key === "toolResult") {
+          const toolResult = canonicalBooleanCapabilityRecord(
+            "mcpProfile.apps.mcpAppsOverrides.toolResult",
+            value,
+            ["structuredContent"]
+          );
+          if (Object.keys(toolResult).length > 0) {
+            mcpAppsOverridesOut.toolResult = toolResult;
           }
         } else if (key === "widgetDisplayModeRequests") {
           if (

--- a/sdk/src/host-config/canonicalize.ts
+++ b/sdk/src/host-config/canonicalize.ts
@@ -1026,6 +1026,19 @@ function canonicalizeMcpProfile(
         sandboxOut.permissions = sortedPerms;
       }
 
+      if ((sandboxIn as { storage?: unknown }).storage !== undefined) {
+        const storage = canonicalBooleanCapabilityRecord(
+          "mcpProfile.apps.sandbox.storage",
+          (sandboxIn as { storage?: unknown }).storage,
+          ["localStorage", "sessionStorage", "indexedDB"]
+        );
+        if (Object.keys(storage).length > 0) {
+          (
+            sandboxOut as { storage?: Record<string, boolean> }
+          ).storage = storage;
+        }
+      }
+
       if (
         (sandboxIn as { sandboxAttrs?: unknown }).sandboxAttrs !== undefined
       ) {
@@ -1253,13 +1266,50 @@ function canonicalizeMcpProfile(
             mcpAppsOverridesOut.cspResourceDomains = domains;
           }
         } else if (key === "toolResult") {
-          const toolResult = canonicalBooleanCapabilityRecord(
-            "mcpProfile.apps.mcpAppsOverrides.toolResult",
-            value,
-            ["structuredContent"]
-          );
-          if (Object.keys(toolResult).length > 0) {
-            mcpAppsOverridesOut.toolResult = toolResult;
+          // Two levels: a flat `structuredContent` boolean and a nested
+          // `content` record of ContentBlock kinds. Both collapse to absent
+          // when empty so a probe that measured nothing hashes identically
+          // to a config that never mentioned the field.
+          if (!isPlainObject(value)) {
+            throw new Error(
+              "hostConfigV2: mcpProfile.apps.mcpAppsOverrides.toolResult must be a plain object"
+            );
+          }
+          for (const k of Object.keys(value)) {
+            if (k !== "structuredContent" && k !== "content") {
+              throw new Error(
+                `hostConfigV2: mcpProfile.apps.mcpAppsOverrides.toolResult has unknown key "${k}"`
+              );
+            }
+          }
+          const toolResultOut: NonNullable<McpAppsCapabilities["toolResult"]> =
+            {};
+          if (value.structuredContent !== undefined) {
+            if (typeof value.structuredContent !== "boolean") {
+              throw new Error(
+                "hostConfigV2: mcpProfile.apps.mcpAppsOverrides.toolResult.structuredContent must be a boolean"
+              );
+            }
+            toolResultOut.structuredContent = value.structuredContent;
+          }
+          if (value.content !== undefined) {
+            const content = canonicalBooleanCapabilityRecord(
+              "mcpProfile.apps.mcpAppsOverrides.toolResult.content",
+              value.content,
+              ["text", "image", "audio", "resource", "resourceLink"]
+            );
+            if (Object.keys(content).length > 0) {
+              toolResultOut.content = content;
+            }
+          }
+          if (Object.keys(toolResultOut).length > 0) {
+            const sortedToolResult = {} as typeof toolResultOut;
+            for (const k of Object.keys(toolResultOut).sort()) {
+              (sortedToolResult as Record<string, unknown>)[k] = (
+                toolResultOut as Record<string, unknown>
+              )[k];
+            }
+            mcpAppsOverridesOut.toolResult = sortedToolResult;
           }
         } else if (key === "widgetDisplayModeRequests") {
           if (

--- a/sdk/src/host-config/canonicalize.ts
+++ b/sdk/src/host-config/canonicalize.ts
@@ -1026,16 +1026,18 @@ function canonicalizeMcpProfile(
         sandboxOut.permissions = sortedPerms;
       }
 
-      if ((sandboxIn as { storage?: unknown }).storage !== undefined) {
-        const storage = canonicalBooleanCapabilityRecord(
-          "mcpProfile.apps.sandbox.storage",
-          (sandboxIn as { storage?: unknown }).storage,
+      if (
+        (sandboxIn as { browserStorage?: unknown }).browserStorage !== undefined
+      ) {
+        const browserStorage = canonicalBooleanCapabilityRecord(
+          "mcpProfile.apps.sandbox.browserStorage",
+          (sandboxIn as { browserStorage?: unknown }).browserStorage,
           ["localStorage", "sessionStorage", "indexedDB"]
         );
-        if (Object.keys(storage).length > 0) {
+        if (Object.keys(browserStorage).length > 0) {
           (
-            sandboxOut as { storage?: Record<string, boolean> }
-          ).storage = storage;
+            sandboxOut as { browserStorage?: Record<string, boolean> }
+          ).browserStorage = browserStorage;
         }
       }
 

--- a/sdk/src/host-config/host-connection.ts
+++ b/sdk/src/host-config/host-connection.ts
@@ -42,6 +42,19 @@ export interface HostConnectionProfile {
    * the profile → wire mapping in one place.
    */
   supportsMrtr?: false;
+  /**
+   * `true` = the client never opens the server→client notification channel
+   * (legacy: the standalone GET SSE stream; 2026-07-28:
+   * `subscriptions/listen`). ChatGPT measures this way — prober saw it never
+   * open one — so a host emulating ChatGPT must not either.
+   */
+  suppressListenChannel?: true;
+  /**
+   * `true` = the client ignores `notifications/tools/list_changed` instead of
+   * acting on it. Only meaningful when the channel is open, since nothing can
+   * arrive otherwise.
+   */
+  dropToolListChanged?: true;
   /** undefined = spec default (filter app-only tools); false = host opts out. */
   respectToolVisibility: boolean | undefined;
 }
@@ -107,6 +120,17 @@ export function hostConnectionProfile(
       : undefined;
   const supportsMrtr =
     mcpProfile?.mrtrSupport === "none" ? (false as const) : undefined;
+  // A nested record rather than an enum, but the same discipline: only an
+  // explicit `false` leaf degrades, and absent stays absent. Narrowed like
+  // `initialize` above — `mcpProfile` is an untyped record here.
+  const toolListChanged =
+    mcpProfile && isRecord(mcpProfile.toolListChanged)
+      ? mcpProfile.toolListChanged
+      : undefined;
+  const suppressListenChannel =
+    toolListChanged?.listens === false ? (true as const) : undefined;
+  const dropToolListChanged =
+    toolListChanged?.refetches === false ? (true as const) : undefined;
 
   const clientCapabilities = isRecord(hostConfig.clientCapabilities)
     ? hostConfig.clientCapabilities
@@ -126,6 +150,8 @@ export function hostConnectionProfile(
       : {}),
     ...(firstPageOnly ? { firstPageOnly } : {}),
     ...(supportsMrtr === false ? { supportsMrtr: false } : {}),
+    ...(suppressListenChannel ? { suppressListenChannel } : {}),
+    ...(dropToolListChanged ? { dropToolListChanged } : {}),
     respectToolVisibility,
   };
 }

--- a/sdk/src/host-config/templates/seed-host-template.ts
+++ b/sdk/src/host-config/templates/seed-host-template.ts
@@ -586,6 +586,12 @@ export const HOST_TEMPLATES: readonly HostTemplate[] = [
       };
       base.mcpProfile = {
         profileVersion: 1,
+        // Probed 2026-08-26 on the 2026-07-28 `server/discover` lane: Claude
+        // followed `nextCursor` and fetched page two of tools/list.
+        paginationTraversal: "full",
+        // No `toolListChanged` here: that capture came back `not-deliverable`
+        // (the prober deployment holds no `subscriptions/listen` stream to
+        // publish on), so neither half of the pair was actually asked.
         mcpProtocolVersion: "auto",
         mrtrModes: {
           requestState: false,
@@ -693,6 +699,14 @@ export const HOST_TEMPLATES: readonly HostTemplate[] = [
             // sandbox-proxy.html: inner gets spec-4 only), matching real
             // claude.ai's outer-grants / inner-trims pattern.
             allowFeatures: { fullscreen: "*" },
+            // All three browser storage APIs were readable and writable from
+            // inside the widget sandbox. Not an MCP concept — the MCP Apps
+            // spec says nothing about storage.
+            browserStorage: {
+              localStorage: true,
+              sessionStorage: true,
+              indexedDB: true,
+            },
           },
           mcpAppsOverrides: {
             availableDisplayModes: ["inline", "fullscreen"],
@@ -725,6 +739,18 @@ export const HOST_TEMPLATES: readonly HostTemplate[] = [
               media: true,
             },
             resourceCacheTtl: true,
+            // A widget-initiated tools/call came back with all five
+            // ContentBlock kinds unchanged and `structuredContent` intact.
+            toolResult: {
+              structuredContent: true,
+              content: {
+                text: true,
+                image: true,
+                audio: true,
+                resource: true,
+                resourceLink: true,
+              },
+            },
             resourcePrefersBorder: true,
             downloadFile: true,
             requestTeardown: false,
@@ -1078,6 +1104,11 @@ export const HOST_TEMPLATES: readonly HostTemplate[] = [
       };
       base.mcpProfile = {
         profileVersion: 1,
+        // Probed 2026-08-25: Le Chat followed `nextCursor` and fetched page
+        // two of tools/list.
+        paginationTraversal: "full",
+        // No `toolListChanged`: probe-list-changed was never run against this
+        // client (verdict `not-sent`), so `refetches` was never asked.
         initialize: {
           supportedProtocolVersions: ["2025-11-25"],
           clientInfo: { name: "mcp", version: "0.1.0" },
@@ -1100,8 +1131,35 @@ export const HOST_TEMPLATES: readonly HostTemplate[] = [
             updateModelContext: true,
             message: true,
             sandboxPermissions: true,
-            cspFrameDomains: false,
-            cspBaseUriDomains: false,
+            // Flipped by the 2026-08-25 paired capture. Le Chat ships no
+            // baseline allowlist of its own, so every canary that loaded did
+            // so because the widget declared the origin.
+            cspFrameDomains: true,
+            cspBaseUriDomains: true,
+            cspConnectDomains: {
+              fetch: true,
+              xhr: true,
+              websocket: true,
+            },
+            cspResourceDomains: {
+              script: true,
+              stylesheet: true,
+              image: true,
+              font: true,
+              media: true,
+            },
+            // A widget-initiated tools/call came back with all five
+            // ContentBlock kinds unchanged and `structuredContent` intact.
+            toolResult: {
+              structuredContent: true,
+              content: {
+                text: true,
+                image: true,
+                audio: true,
+                resource: true,
+                resourceLink: true,
+              },
+            },
             resourcePrefersBorder: false,
             downloadFile: false,
             requestTeardown: false,
@@ -1117,6 +1175,13 @@ export const HOST_TEMPLATES: readonly HostTemplate[] = [
               allow: { clipboardWrite: true },
             },
             sandboxAttrs: ["allow-forms"],
+            // All three browser storage APIs were readable and writable from
+            // inside the widget sandbox.
+            browserStorage: {
+              localStorage: true,
+              sessionStorage: true,
+              indexedDB: true,
+            },
           },
         },
       };
@@ -1268,19 +1333,26 @@ export const HOST_TEMPLATES: readonly HostTemplate[] = [
       // advertises only the MCP UI extension. Preserve that exact surface.
       base.clientCapabilities = {
         extensions: {
+          // Probed 2026-08-26: Slack advertises its own Block Kit extension
+          // alongside the spec's MCP Apps one.
+          "io.slack/block-kit": {
+            mimeTypes: ["application/vnd.slack.blocks+json"],
+          },
           [MCP_UI_EXTENSION_ID]: {
             mimeTypes: [MCP_UI_RESOURCE_MIME_TYPE],
           },
         },
       };
 
-      // Captured from Slackbot's `ui/initialize` response. No
-      // updateModelContext/message/downloadFile claims were present.
+      // Captured from Slack's `ui/initialize` response. Re-probed 2026-08-26:
+      // `message: { text: {} }` IS present; updateModelContext and
+      // downloadFile still are not.
       base.hostCapabilitiesOverride = {
         openLinks: {},
         serverTools: {},
         serverResources: {},
         logging: {},
+        message: { text: {} },
       };
 
       // Per-resource environment context Slackbot exposes to MCP apps.
@@ -1303,8 +1375,14 @@ export const HOST_TEMPLATES: readonly HostTemplate[] = [
 
       base.mcpProfile = {
         profileVersion: 1,
+        // Neither paginationTraversal nor toolListChanged is written here: the
+        // 2026-08-26 capture never saw a `tools/list` from Slack, and
+        // probe-list-changed was never run against it.
         initialize: {
           supportedProtocolVersions: ["2025-06-18"],
+          // "Slackbot" is the product name this catalog uses throughout. The
+          // 2026-08-26 capture reports "Slack MCP Client" / "Slack" on the
+          // wire; the established name is kept here deliberately.
           clientInfo: { name: "Slackbot MCP Client", version: "1.0.0" },
         },
         apps: {
@@ -1322,11 +1400,42 @@ export const HOST_TEMPLATES: readonly HostTemplate[] = [
             serverTools: true,
             serverResources: true,
             logging: true,
+            // Confirmed 2026-08-26: the widget's updateModelContext call
+            // came back -32601 Method not found.
             updateModelContext: false,
-            message: false,
+            // Flipped: hostCapabilities advertises `message: { text: {} }`.
+            message: true,
             sandboxPermissions: false,
             cspFrameDomains: false,
             cspBaseUriDomains: false,
+            // Paired capture 2026-08-26: Slack honors the declared list for
+            // fetch, XHR and every resource subtype, and blocks the declared
+            // WebSocket origin — the only host probed where one connect
+            // method diverges from the other two.
+            cspConnectDomains: {
+              fetch: true,
+              xhr: true,
+              websocket: false,
+            },
+            cspResourceDomains: {
+              script: true,
+              stylesheet: true,
+              image: true,
+              font: true,
+              media: true,
+            },
+            // Every ContentBlock kind reached the widget with an unchanged
+            // fingerprint and `structuredContent` was forwarded.
+            toolResult: {
+              structuredContent: true,
+              content: {
+                text: true,
+                image: true,
+                audio: true,
+                resource: true,
+                resourceLink: true,
+              },
+            },
             resourcePrefersBorder: false,
             downloadFile: false,
             requestTeardown: false,
@@ -1351,6 +1460,14 @@ export const HOST_TEMPLATES: readonly HostTemplate[] = [
             // `allow-scripts allow-same-origin allow-forms`. The first two
             // are the renderer baseline; `allow-forms` is Slack's addition.
             sandboxAttrs: ["allow-forms"],
+            // All three browser storage APIs were readable and writable from
+            // inside the widget sandbox — the iframe's own behavior, since
+            // Slack publishes no `sandbox` capability at all.
+            browserStorage: {
+              localStorage: true,
+              sessionStorage: true,
+              indexedDB: true,
+            },
           },
         },
       };
@@ -1420,6 +1537,14 @@ export const HOST_TEMPLATES: readonly HostTemplate[] = [
       };
       base.mcpProfile = {
         profileVersion: 1,
+        // Probed 2026-08-26 (Cursor 3.14.27): asked for tools/list and never
+        // sent back the `nextCursor` it was handed.
+        paginationTraversal: "firstPageOnly",
+        // Same capture: opened the GET SSE stream, took list_changed on the
+        // call's response stream, and re-issued tools/list 240 ms later.
+        // Written out so the caniuse row reads "supported" rather than the em
+        // dash an absent knob renders as.
+        toolListChanged: { listens: true, refetches: true },
         initialize: {
           supportedProtocolVersions: ["2025-11-25"],
           // Base MCP protocol: clientInfo sent to MCP servers during
@@ -1448,6 +1573,21 @@ export const HOST_TEMPLATES: readonly HostTemplate[] = [
               font: true,
               media: true,
             },
+            // A widget-initiated tools/call came back with all five
+            // ContentBlock kinds unchanged and `structuredContent` intact.
+            toolResult: {
+              structuredContent: true,
+              content: {
+                text: true,
+                image: true,
+                audio: true,
+                resource: true,
+                resourceLink: true,
+              },
+            },
+            // Flipped 2026-08-26: `downloadFile` is absent from Cursor's
+            // hostCapabilities.
+            downloadFile: false,
           },
           sandbox: {
             csp: {
@@ -1461,6 +1601,13 @@ export const HOST_TEMPLATES: readonly HostTemplate[] = [
               // Only clipboardWrite per probe; everything else stays off.
               mode: "custom",
               allow: { clipboardWrite: true },
+            },
+            // All three browser storage APIs were readable and writable from
+            // inside the widget sandbox.
+            browserStorage: {
+              localStorage: true,
+              sessionStorage: true,
+              indexedDB: true,
             },
           },
         },
@@ -1516,6 +1663,13 @@ export const HOST_TEMPLATES: readonly HostTemplate[] = [
       };
       base.mcpProfile = {
         profileVersion: 1,
+        // Probed 2026-08-26: Codex asked for tools/list once and never sent
+        // back the `nextCursor` it was handed.
+        paginationTraversal: "firstPageOnly",
+        // Same capture: Codex opens the standalone GET SSE stream and
+        // list_changed reached it on the call's response stream, but no
+        // tools/list followed.
+        toolListChanged: { listens: true, refetches: false },
         initialize: {
           supportedProtocolVersions: ["2025-03-26", "2025-06-18", "2025-11-25"],
           clientInfo: {
@@ -1525,6 +1679,34 @@ export const HOST_TEMPLATES: readonly HostTemplate[] = [
           },
         },
         apps: {
+          sandbox: {
+            // Codex honors the widget's declared CSP lists; the directives
+            // below are its own baseline, merged on top of that declaration.
+            csp: {
+              mode: "declared",
+              cspDirectives: {
+                "connect-src": [
+                  "https://cdn.jsdelivr.net",
+                  "https://unpkg.com",
+                ],
+                "script-src": ["https://cdn.jsdelivr.net", "https://unpkg.com"],
+                "style-src": ["https://cdn.jsdelivr.net", "https://unpkg.com"],
+                "img-src": ["https://cdn.jsdelivr.net", "https://unpkg.com"],
+                "font-src": ["https://cdn.jsdelivr.net", "https://unpkg.com"],
+                "media-src": ["https://cdn.jsdelivr.net", "https://unpkg.com"],
+                "frame-src": ["'self'", "data:", "blob:"],
+                "base-uri": ["'none'"],
+              },
+            },
+            // All three browser storage APIs were readable and writable from
+            // inside the widget sandbox. Not an MCP concept — the MCP Apps
+            // spec says nothing about storage.
+            browserStorage: {
+              localStorage: true,
+              sessionStorage: true,
+              indexedDB: true,
+            },
+          },
           mcpAppsOverrides: {
             availableDisplayModes: ["inline", "fullscreen"],
             toolInputPartial: true,
@@ -1544,6 +1726,28 @@ export const HOST_TEMPLATES: readonly HostTemplate[] = [
               fetch: true,
               xhr: true,
               websocket: true,
+            },
+            // Paired capture 2026-08-26: the treatment fixture declared
+            // fastly.jsdelivr.net, outside the baseline above, and every
+            // declared resource subtype loaded.
+            cspResourceDomains: {
+              script: true,
+              stylesheet: true,
+              image: true,
+              font: true,
+              media: true,
+            },
+            // A widget-initiated tools/call came back with all five
+            // ContentBlock kinds unchanged and `structuredContent` intact.
+            toolResult: {
+              structuredContent: true,
+              content: {
+                text: true,
+                image: true,
+                audio: true,
+                resource: true,
+                resourceLink: true,
+              },
             },
             resourcePrefersBorder: true,
             toolCancelled: false,
@@ -1653,13 +1857,33 @@ export const HOST_TEMPLATES: readonly HostTemplate[] = [
       };
       base.mcpProfile = {
         profileVersion: 1,
+        // Probed 2026-08-26: followed `nextCursor` and fetched page two.
+        paginationTraversal: "full",
+        // Same capture, and the odd one out: Copilot never opened the GET SSE
+        // stream, yet list_changed still reached it on the tools/call response
+        // stream and a tools/list followed. Hence listens:false + refetches:
+        // true — a real combination, see the note on the field itself.
+        // The re-fetch was 30,496 ms late (VS Code and Cursor: ~200 ms), close
+        // enough to a routine listing that the pairing rule cannot separate
+        // reaction from coincidence.
+        toolListChanged: { listens: false, refetches: true },
+        // Parked: probed but not published (no field, no caniuse row).
+        // 2026-08-26: no tools/call carried `_meta.progressToken` (0/3).
+        // progressToken: "never",
         initialize: {
-          supportedProtocolVersions: ["2025-11-25"],
-          // Base MCP protocol: clientInfo sent during MCP `initialize`.
-          // Matches Microsoft's "ms-copilot" identity convention. The
-          // name is an emulation convention and 1.0.1 labels MCPJam's
-          // vendor-doc profile, not a Microsoft product build.
-          clientInfo: { name: "ms-copilot", version: "1.0.1" },
+          // Measured on the wire 2026-08-26: Copilot proposes 2024-11-05, the
+          // oldest MCP revision, not the 2025-11-25 previously assumed.
+          supportedProtocolVersions: ["2024-11-05"],
+          // The real handshake sends `name: "mcs"` plus Copilot's routing
+          // fields. `agentName`, `appId` and `cdsBotId` are in the capture too
+          // and are deliberately omitted: they identify one tenant's agent.
+          clientInfo: {
+            name: "mcs",
+            version: "1.0.0",
+            channelId: "pva-studio",
+            lcat: "M365_COPILOT_USER",
+            agentAuthenticationMode: "Integrated",
+          },
         },
         apps: {
           uiInitialize: {
@@ -1813,13 +2037,22 @@ export const HOST_TEMPLATES: readonly HostTemplate[] = [
       };
       base.mcpProfile = {
         profileVersion: 1,
+        // Probed 2026-08-24 (VS Code 1.134.0): followed `nextCursor` and
+        // fetched page two of tools/list.
+        paginationTraversal: "full",
+        // Same capture — the only host probed so far that completes the round
+        // trip: it opened the GET SSE stream, took list_changed on the call's
+        // response stream, and re-issued tools/list 209 ms later. Written out
+        // (rather than left to the default) so the caniuse row reads
+        // "supported" instead of the em dash an absent knob renders as.
+        toolListChanged: { listens: true, refetches: true },
         initialize: {
           supportedProtocolVersions: ["2025-11-25"],
-          clientInfo: { name: "Visual Studio Code", version: "1.130.0" },
+          clientInfo: { name: "Visual Studio Code", version: "1.134.0" },
         },
         apps: {
           uiInitialize: {
-            hostInfo: { name: "Visual Studio Code", version: "1.130.0" },
+            hostInfo: { name: "Visual Studio Code", version: "1.134.0" },
           },
           compatRuntime: { openaiApps: false },
           sandbox: {
@@ -1846,6 +2079,13 @@ export const HOST_TEMPLATES: readonly HostTemplate[] = [
               "local-network-access": "'src'",
               "clipboard-read": "'src'",
             },
+            // All three browser storage APIs were readable and writable from
+            // inside the widget sandbox.
+            browserStorage: {
+              localStorage: true,
+              sessionStorage: true,
+              indexedDB: true,
+            },
           },
           mcpAppsOverrides: {
             availableDisplayModes: ["inline"],
@@ -1866,6 +2106,32 @@ export const HOST_TEMPLATES: readonly HostTemplate[] = [
             sandboxPermissions: true,
             cspFrameDomains: true,
             cspBaseUriDomains: true,
+            // Paired capture 2026-08-24: VS Code emits the widget's declared
+            // origins verbatim and adds no third-party baseline of its own.
+            cspConnectDomains: {
+              fetch: true,
+              xhr: true,
+              websocket: true,
+            },
+            cspResourceDomains: {
+              script: true,
+              stylesheet: true,
+              image: true,
+              font: true,
+              media: true,
+            },
+            // Every ContentBlock kind reached the widget with an unchanged
+            // fingerprint and `structuredContent` was forwarded.
+            toolResult: {
+              structuredContent: true,
+              content: {
+                text: true,
+                image: true,
+                audio: true,
+                resource: true,
+                resourceLink: true,
+              },
+            },
             resourcePrefersBorder: true,
             downloadFile: true,
             requestTeardown: true,

--- a/sdk/src/host-config/templates/seed-host-template.ts
+++ b/sdk/src/host-config/templates/seed-host-template.ts
@@ -909,9 +909,17 @@ export const HOST_TEMPLATES: readonly HostTemplate[] = [
               xhr: true,
               websocket: true,
             },
-            // cspResourceDomains stays unknown: the declared resource origin
-            // is in that same baseline, so the probe cannot tell honored from
-            // ignored. Re-probe with an origin the baseline misses first.
+            // The 2026-08-23 paired probe (captured 2026-08-24Z) declared
+            // fastly.jsdelivr.net, an
+            // origin outside the baseline above, and every declared resource
+            // subtype loaded in the treatment fixture.
+            cspResourceDomains: {
+              script: true,
+              stylesheet: true,
+              image: true,
+              font: true,
+              media: true,
+            },
           },
           // Vendor compat-runtime shims. Real ChatGPT exposes the
           // OpenAI Apps SDK `window.openai` surface to widget HTML, so

--- a/sdk/src/host-config/templates/seed-host-template.ts
+++ b/sdk/src/host-config/templates/seed-host-template.ts
@@ -900,6 +900,8 @@ export const HOST_TEMPLATES: readonly HostTemplate[] = [
             hostInfo: { name: "chatgpt", version: "0.0.1" },
           },
           mcpAppsOverrides: {
+            cspFrameDomains: true,
+            cspBaseUriDomains: true,
             // One directive, one answer: the declared wss endpoint connected
             // while an undeclared one took a real connect-src violation
             // (2026-08-19 probe). The fetch/xhr canary passed because it is in

--- a/sdk/src/host-config/templates/seed-host-template.ts
+++ b/sdk/src/host-config/templates/seed-host-template.ts
@@ -885,6 +885,13 @@ export const HOST_TEMPLATES: readonly HostTemplate[] = [
       base.mcpProfile = {
         profileVersion: 1,
         mcpProtocolVersion: "auto",
+        // The 2026-08-24 prober capture (2026-07-28 lane) walked `nextCursor`
+        // and fetched page two of tools/list.
+        paginationTraversal: "full",
+        // Same capture: ChatGPT never opened a `subscriptions/listen` stream,
+        // so no server notification can reach it. `refetches` stays absent —
+        // unprovable while nothing is ever delivered.
+        toolListChanged: { listens: false },
         initialize: {
           supportedProtocolVersions: ["2025-03-26", "2025-06-18", "2025-11-25"],
           // Stored in the established connection-profile envelope. The
@@ -921,6 +928,21 @@ export const HOST_TEMPLATES: readonly HostTemplate[] = [
               image: true,
               font: true,
               media: true,
+            },
+            // The 2026-08-24 capture called a tool FROM the widget and
+            // compared fingerprints on the way back: every ContentBlock kind
+            // arrived unchanged and `structuredContent` was forwarded. Widget
+            // axis — distinct from `modelVisibleMcpToolResults` (model) and
+            // `mcpToolResultImageRendering` (mcpjam's own chat UI).
+            toolResult: {
+              structuredContent: true,
+              content: {
+                text: true,
+                image: true,
+                audio: true,
+                resource: true,
+                resourceLink: true,
+              },
             },
           },
           // Vendor compat-runtime shims. Real ChatGPT exposes the
@@ -960,6 +982,15 @@ export const HOST_TEMPLATES: readonly HostTemplate[] = [
               // widget testing in MCPJam-as-ChatGPT actually gets what
               // the production iframe grants.
               allow: { microphone: true, clipboardWrite: true },
+            },
+            // The 2026-08-24 capture read and wrote all three web-storage
+            // APIs from inside the widget sandbox — every one available,
+            // no error. A browser-sandbox fact, not an MCP-protocol one,
+            // which is why it sits beside `csp` and `permissions`.
+            storage: {
+              localStorage: true,
+              sessionStorage: true,
+              indexedDB: true,
             },
             // sandboxAttrs — captured 2026-05-18 from the outer and
             // inner iframe `sandbox=` attributes. There's an asymmetry:

--- a/sdk/src/host-config/templates/seed-host-template.ts
+++ b/sdk/src/host-config/templates/seed-host-template.ts
@@ -983,11 +983,11 @@ export const HOST_TEMPLATES: readonly HostTemplate[] = [
               // the production iframe grants.
               allow: { microphone: true, clipboardWrite: true },
             },
-            // The 2026-08-24 capture read and wrote all three web-storage
-            // APIs from inside the widget sandbox — every one available,
-            // no error. A browser-sandbox fact, not an MCP-protocol one,
-            // which is why it sits beside `csp` and `permissions`.
-            storage: {
+            // The 2026-08-24 capture read and wrote all three browser
+            // storage APIs from inside the widget sandbox — every one
+            // available, no error. A browser fact, not an MCP one: the MCP
+            // Apps spec never mentions storage.
+            browserStorage: {
               localStorage: true,
               sessionStorage: true,
               indexedDB: true,

--- a/sdk/src/host-config/types.ts
+++ b/sdk/src/host-config/types.ts
@@ -293,7 +293,13 @@ export type HostConfigMcpProfileV1 = {
   //               all (legacy: the standalone GET SSE stream; 2026-07-28:
   //               `subscriptions/listen`).
   //   refetches — after receiving the notification, the client re-issues
-  //               `tools/list`. Only measurable when `listens` is true.
+  //               `tools/list`.
+  //
+  // The two are independent. `refetches` was originally documented as only
+  // measurable when `listens` is true; the 2026-08-26 Copilot capture
+  // disproved that — a server can publish the notification on an open
+  // `tools/call` response stream, reaching a client that never opened the
+  // standalone channel, so `listens: false, refetches: true` is real.
   //
   // Absent -> spec-conforming (listens and refetches), like every knob above.
   toolListChanged?: {

--- a/sdk/src/host-config/types.ts
+++ b/sdk/src/host-config/types.ts
@@ -329,6 +329,18 @@ export type HostConfigMcpProfileV1 = {
         allow?: Record<string, boolean>;
         extensions?: Record<string, unknown>;
       };
+      // Whether web storage works inside the widget iframe (probe-measured).
+      // Not an MCP-protocol fact - a browser-sandbox one, which is why it
+      // sits beside `csp` and `permissions` rather than on the profile root.
+      // A widget that persists state breaks silently on a host that blocks
+      // these. Each API is measured separately because a host can block one
+      // and not the others (Safari private mode exposes `localStorage` and
+      // throws only on write). Absent -> available.
+      storage?: {
+        localStorage?: boolean;
+        sessionStorage?: boolean;
+        indexedDB?: boolean;
+      };
       // Extra outer/inner iframe `sandbox=` tokens unioned with the
       // mandatory `allow-scripts allow-same-origin`. Inspector-only.
       sandboxAttrs?: string[];
@@ -426,6 +438,24 @@ export type McpAppsCapabilities = {
   // widget reading it silently breaks. Absent -> forwarded (spec-conforming).
   toolResult?: {
     structuredContent?: boolean;
+    // Which `ContentBlock` kinds survive the host->widget relay, per the MCP
+    // spec "Tool Result" section under server/tools. Each kind names the
+    // revision it arrived in: `text`/`image`/`resource` since 2024-11-05,
+    // `audio` since 2025-03-26, `resource_link` since 2025-06-18.
+    //
+    // THIRD AXIS - do not merge with the two that already exist:
+    //   `modelVisibleMcpToolResults`   - what the MODEL sees
+    //   `mcpToolResultImageRendering`  - what mcpjam's own chat UI renders
+    //   this field                     - what a WIDGET receives when it calls
+    //                                    a tool itself
+    // Absent -> relayed (spec-conforming).
+    content?: {
+      text?: boolean;
+      image?: boolean;
+      audio?: boolean;
+      resource?: boolean;
+      resourceLink?: boolean;
+    };
   };
   resourcePrefersBorder?: boolean;
   downloadFile?: boolean;

--- a/sdk/src/host-config/types.ts
+++ b/sdk/src/host-config/types.ts
@@ -285,6 +285,21 @@ export type HostConfigMcpProfileV1 = {
   // Whether the client drives MRTR retry rounds at all. WHICH elicitation
   // modes it fulfills stays in `clientCapabilities.elicitation`.
   mrtrSupport?: MrtrSupport;
+  // How the client handles `notifications/tools/list_changed` (probe-measured;
+  // MCP spec "List Changed Notification" under server/tools, every revision
+  // since 2024-11-05). Two independently-measured facts, not one flag:
+  //
+  //   listens   — the client opens the server->client notification channel at
+  //               all (legacy: the standalone GET SSE stream; 2026-07-28:
+  //               `subscriptions/listen`).
+  //   refetches — after receiving the notification, the client re-issues
+  //               `tools/list`. Only measurable when `listens` is true.
+  //
+  // Absent -> spec-conforming (listens and refetches), like every knob above.
+  toolListChanged?: {
+    listens?: boolean;
+    refetches?: boolean;
+  };
   initialize?: {
     // Order is semantic. The first entry is sent in
     // `initialize.params.protocolVersion`; all entries form the
@@ -403,6 +418,15 @@ export type McpAppsCapabilities = {
     media?: boolean;
   };
   resourceCacheTtl?: boolean;
+  // Whether the host forwards the `structuredContent` half of a tool result
+  // to the widget when the widget itself calls a tool (probe-measured; MCP
+  // spec "Tool Result" -> "Structured Content" under server/tools). A tool
+  // result has two halves - `content` blocks and `structuredContent` - and
+  // some hosts strip the JSON half on the way back (Cursor 3.4 does), so a
+  // widget reading it silently breaks. Absent -> forwarded (spec-conforming).
+  toolResult?: {
+    structuredContent?: boolean;
+  };
   resourcePrefersBorder?: boolean;
   downloadFile?: boolean;
   requestTeardown?: boolean;

--- a/sdk/src/host-config/types.ts
+++ b/sdk/src/host-config/types.ts
@@ -329,14 +329,22 @@ export type HostConfigMcpProfileV1 = {
         allow?: Record<string, boolean>;
         extensions?: Record<string, unknown>;
       };
-      // Whether web storage works inside the widget iframe (probe-measured).
-      // Not an MCP-protocol fact - a browser-sandbox one, which is why it
-      // sits beside `csp` and `permissions` rather than on the profile root.
-      // A widget that persists state breaks silently on a host that blocks
-      // these. Each API is measured separately because a host can block one
-      // and not the others (Safari private mode exposes `localStorage` and
-      // throws only on write). Absent -> available.
-      storage?: {
+      // Whether the browser storage APIs work inside the widget iframe
+      // (probe-measured).
+      //
+      // NOT AN MCP CONCEPT. The MCP Apps spec (2026-01-26) says nothing about
+      // storage — its `sandbox` object defines only `permissions` and `csp`.
+      // This is an observed consequence of the sandboxed iframe the spec does
+      // mandate ("MCP App HTML runs in a sandboxed iframe with no same-origin
+      // server"), recorded because widgets that persist state break silently
+      // on a host that blocks it. Named `browserStorage`, with the literal
+      // browser API identifiers as keys, so nobody reads it as a capability
+      // MCP negotiates.
+      //
+      // Each API is measured separately because a host can block one and not
+      // the others (Safari private mode exposes `localStorage` and throws only
+      // on write). Absent -> available.
+      browserStorage?: {
         localStorage?: boolean;
         sessionStorage?: boolean;
         indexedDB?: boolean;

--- a/sdk/src/mcp-client-manager/MCPClientManager.ts
+++ b/sdk/src/mcp-client-manager/MCPClientManager.ts
@@ -2850,7 +2850,11 @@ export class MCPClientManager {
 
     const sseTransport = new SSEClientTransport(url, {
       requestInit,
-      fetch: this.buildTransportFetch(serverId, config),
+      // `listenGuard: false` — see `buildTransportFetch`. On this transport a
+      // GET SSE is the connection, not the listen channel, so `listens:false`
+      // is a documented no-op here rather than a connection failure (a real
+      // client on HTTP+SSE cannot not-listen either).
+      fetch: this.buildTransportFetch(serverId, config, { listenGuard: false }),
       eventSourceInit: config.eventSourceInit,
       authProvider: effectiveAuthProvider,
     });
@@ -3680,7 +3684,20 @@ export class MCPClientManager {
    */
   private buildTransportFetch(
     serverId: string,
-    config: MCPServerConfig
+    config: MCPServerConfig,
+    /**
+     * Streamable HTTP only. The listen guard identifies the notification
+     * stream as "a GET with `Accept: text/event-stream`" — under Streamable
+     * HTTP that IS the standalone listen stream, but under the legacy
+     * `SSEClientTransport` the very same request is how the transport OPENS
+     * the connection (`_startOrAuth` in @modelcontextprotocol/client sends it
+     * through this injected fetch with that header). Guarding it there would
+     * 405 the connection itself and make every SSE-only server unreachable
+     * for any profile carrying `listens: false` — including the shipped
+     * ChatGPT template. Header inspection cannot separate the two cases, so
+     * the CALLER declares which transport is asking.
+     */
+    options?: { listenGuard?: boolean }
   ): typeof fetch {
     const httpLogger = this.resolveHttpLogger(config);
     // `baseFetch` is the INNERMOST layer, under the logger: the guard has to
@@ -3695,7 +3712,7 @@ export class MCPClientManager {
     // network, so logging it would invent a request that was not made. The
     // absence in the log IS the observation.
     const listenGuarded =
-      config.suppressListenChannel === true
+      config.suppressListenChannel === true && options?.listenGuard !== false
         ? wrapFetchForNoListenChannel(logged)
         : logged;
     return wrapFetchForTaskRouting(listenGuarded);

--- a/sdk/src/mcp-client-manager/MCPClientManager.ts
+++ b/sdk/src/mcp-client-manager/MCPClientManager.ts
@@ -91,6 +91,8 @@ import {
   wrapTransportForLogging,
   wrapTransportForTaskResults,
   wrapTransportForFirstPageOnly,
+  wrapTransportForDroppedListChanged,
+  wrapFetchForNoListenChannel,
   wrapFetchForTaskRouting,
   TASK_CREATED_META_KEY,
   createDefaultRpcLogger,
@@ -2614,12 +2616,15 @@ export class MCPClientManager {
     });
 
     const logger = this.resolveRpcLogger(config);
-    const transport = this.applyFirstPageOnly(
+    const transport = this.applyDroppedListChanged(
       config,
-      wrapTransportForTaskResults(
-        logger
-          ? wrapTransportForLogging(serverId, logger, underlying)
-          : underlying
+      this.applyFirstPageOnly(
+        config,
+        wrapTransportForTaskResults(
+          logger
+            ? wrapTransportForLogging(serverId, logger, underlying)
+            : underlying
+        )
       )
     );
 
@@ -2749,12 +2754,15 @@ export class MCPClientManager {
       client.onclose = undefined;
       try {
         const logger = this.resolveRpcLogger(config);
-        const wrapped = this.applyFirstPageOnly(
+        const wrapped = this.applyDroppedListChanged(
           config,
-          wrapTransportForTaskResults(
-            logger
-              ? wrapTransportForLogging(serverId, logger, streamableTransport)
-              : streamableTransport
+          this.applyFirstPageOnly(
+            config,
+            wrapTransportForTaskResults(
+              logger
+                ? wrapTransportForLogging(serverId, logger, streamableTransport)
+                : streamableTransport
+            )
           )
         );
         await client.connect(wrapped, {
@@ -2849,12 +2857,15 @@ export class MCPClientManager {
 
     try {
       const logger = this.resolveRpcLogger(config);
-      const wrapped = this.applyFirstPageOnly(
+      const wrapped = this.applyDroppedListChanged(
         config,
-        wrapTransportForTaskResults(
-          logger
-            ? wrapTransportForLogging(serverId, logger, sseTransport)
-            : sseTransport
+        this.applyFirstPageOnly(
+          config,
+          wrapTransportForTaskResults(
+            logger
+              ? wrapTransportForLogging(serverId, logger, sseTransport)
+              : sseTransport
+          )
         )
       );
       await client.connect(wrapped, { timeout });
@@ -3677,11 +3688,17 @@ export class MCPClientManager {
     // added above it, and the logger has to record the bytes that guard sent.
     // Absent ⇒ both wrappers fall back to `globalThis.fetch` exactly as before.
     const baseFetch = config.baseFetch ?? this.defaultBaseFetch;
-    return wrapFetchForTaskRouting(
-      httpLogger
-        ? wrapFetchForHttpLogging(serverId, httpLogger, baseFetch)
-        : baseFetch
-    );
+    const logged = httpLogger
+      ? wrapFetchForHttpLogging(serverId, httpLogger, baseFetch)
+      : baseFetch;
+    // ABOVE the logger deliberately: a refused listen stream never reaches the
+    // network, so logging it would invent a request that was not made. The
+    // absence in the log IS the observation.
+    const listenGuarded =
+      config.suppressListenChannel === true
+        ? wrapFetchForNoListenChannel(logged)
+        : logged;
+    return wrapFetchForTaskRouting(listenGuarded);
   }
 
   private cacheToolsMetadata(
@@ -4086,6 +4103,23 @@ export class MCPClientManager {
   ): Transport {
     return config.firstPageOnly === true
       ? wrapTransportForFirstPageOnly(transport)
+      : transport;
+  }
+
+  /**
+   * Drop `notifications/tools/list_changed` before the client sees it, for a
+   * host whose `mcpProfile.toolListChanged.refetches` is `false`.
+   *
+   * Composed alongside `applyFirstPageOnly` at every transport site: both are
+   * inbound-frame edits, and both belong outside the logging transport so the
+   * wire log keeps what the server really sent.
+   */
+  private applyDroppedListChanged(
+    config: { dropToolListChanged?: boolean },
+    transport: Transport
+  ): Transport {
+    return config.dropToolListChanged === true
+      ? wrapTransportForDroppedListChanged(transport)
       : transport;
   }
 

--- a/sdk/src/mcp-client-manager/transport-utils.ts
+++ b/sdk/src/mcp-client-manager/transport-utils.ts
@@ -281,6 +281,132 @@ export function wrapFetchForTaskRouting(
   }) as typeof fetch;
 }
 
+/**
+ * Simulates a client that never opens the server→client notification channel
+ * — `hostConfig.mcpProfile.toolListChanged.listens: false`.
+ *
+ * WHY A FETCH WRAPPER. The upstream client opens the standalone GET SSE
+ * stream itself, from inside `StreamableHTTPClientTransport._send`, the moment
+ * the server answers `202` to `notifications/initialized`. It exposes no
+ * option to skip it, so the injected fetch is the only seam we own.
+ *
+ * The refusal is a local `405`, which is exactly what the Streamable HTTP spec
+ * says a server returns when it does not offer a stream, and what the upstream
+ * transport already tolerates: it swallows that status and leaves the
+ * connection healthy on the POST channel. Answering with a network error
+ * instead would surface as a broken connection rather than a client that
+ * chose not to listen.
+ *
+ * NOT APPLICABLE to the legacy HTTP+SSE transport, where the GET stream IS the
+ * connection — a real client on that transport cannot not-listen either, so
+ * the knob is a documented no-op there rather than a connection failure.
+ */
+export function wrapFetchForNoListenChannel(
+  fetchFn?: typeof fetch
+): typeof fetch {
+  const base =
+    fetchFn ?? ((...args: Parameters<typeof fetch>) => fetch(...args));
+  return ((input: Parameters<typeof fetch>[0], init?: RequestInit) => {
+    // The standalone listen stream is the ONLY GET the Streamable HTTP
+    // transport issues; every request carrying a JSON-RPC message is a POST,
+    // so method alone identifies it without sniffing bodies.
+    const method = (init?.method ?? "GET").toUpperCase();
+    if (method !== "GET") {
+      return base(input as never, init as never);
+    }
+    const accept = new Headers(init?.headers).get("accept") ?? "";
+    if (!accept.includes("text/event-stream")) {
+      return base(input as never, init as never);
+    }
+    return Promise.resolve(
+      new Response(null, {
+        status: 405,
+        statusText: "Method Not Allowed",
+      })
+    );
+  }) as typeof fetch;
+}
+
+/**
+ * Simulates a client that ignores `notifications/tools/list_changed` —
+ * `hostConfig.mcpProfile.toolListChanged.refetches: false`.
+ *
+ * MECHANISM. mcpjam never registers an auto-refetch handler (we do not pass
+ * `ClientOptions.listChanged`), so the observable "re-fetch" is upstream's
+ * unconditional response-cache eviction: on this notification the client
+ * evicts its cached `tools/list`, and the next `listTools()` therefore goes to
+ * the wire instead of serving cache. Dropping the frame before the client sees
+ * it keeps the cache — and the stale tool list — in place, which is precisely
+ * what a server author sees from a host that ignores the notification.
+ *
+ * Dropping at the transport rather than filtering the handler also stops the
+ * notification reaching the subscription coordinator, so one wrapper covers
+ * every consumer instead of each one remembering to check the knob.
+ *
+ * Compose OUTERMOST for the same reason as the first-page-only wrapper: the
+ * logging transport underneath still records the frame the server really sent,
+ * so the wire log shows the notification arriving and being ignored, not a
+ * server that never sent it.
+ */
+export function wrapTransportForDroppedListChanged(
+  transport: Transport
+): Transport {
+  class DroppedListChangedTransport implements Transport {
+    onclose?: () => void;
+    onerror?: (error: Error) => void;
+    onmessage?: (message: JSONRPCMessage, extra?: MessageExtraInfo) => void;
+
+    constructor(private readonly inner: Transport) {
+      this.inner.onmessage = (
+        message: JSONRPCMessage,
+        extra?: MessageExtraInfo
+      ) => {
+        const record = message as { method?: unknown; id?: unknown };
+        // Notifications only: a request carrying an id must never be
+        // swallowed, or the caller would wait forever for a response.
+        if (
+          record.id === undefined &&
+          record.method === "notifications/tools/list_changed"
+        ) {
+          return;
+        }
+        this.onmessage?.(message, extra);
+      };
+      this.inner.onclose = () => this.onclose?.();
+      this.inner.onerror = (error: Error) => this.onerror?.(error);
+    }
+
+    async start(): Promise<void> {
+      if (typeof (this.inner as any).start === "function") {
+        await (this.inner as any).start();
+      }
+    }
+
+    async send(
+      message: JSONRPCMessage,
+      options?: TransportSendOptions
+    ): Promise<void> {
+      await this.inner.send(message as any, options as any);
+    }
+
+    async close(): Promise<void> {
+      await this.inner.close();
+    }
+
+    get sessionId(): string | undefined {
+      return (this.inner as any).sessionId;
+    }
+
+    setProtocolVersion?(version: string): void {
+      if (typeof this.inner.setProtocolVersion === "function") {
+        this.inner.setProtocolVersion(version);
+      }
+    }
+  }
+
+  return new DroppedListChangedTransport(transport);
+}
+
 // ============================================================================
 // Tasks extension: recovering `resultType: "task"` responses from beta.4
 // ============================================================================

--- a/sdk/src/mcp-client-manager/types.ts
+++ b/sdk/src/mcp-client-manager/types.ts
@@ -304,6 +304,33 @@ export type BaseServerConfig = {
    */
   firstPageOnly?: boolean;
   /**
+   * Whether the client opens the server→client notification channel at all.
+   *
+   * `undefined` (the default) and `false` both open it. `true` simulates a
+   * client that never does — ChatGPT measures this way — so a server author
+   * can see that its `notifications/*` never reach that host, no matter what
+   * the server declares.
+   *
+   * On Streamable HTTP this refuses the standalone GET SSE stream the
+   * upstream client opens after `notifications/initialized`. On the legacy
+   * HTTP+SSE transport the GET stream IS the connection, so this cannot
+   * apply — a real client on that transport cannot not-listen either.
+   *
+   * Wired via `hostConfig.mcpProfile.toolListChanged.listens === false`.
+   */
+  suppressListenChannel?: boolean;
+  /**
+   * Whether the client acts on `notifications/tools/list_changed`.
+   *
+   * `undefined` (the default) and `false` both act on it. `true` simulates a
+   * client that ignores it: the notification is dropped before the client
+   * sees it, so its `tools/list` cache is never evicted and the stale list
+   * stays in use — exactly what a server author sees from such a host.
+   *
+   * Wired via `hostConfig.mcpProfile.toolListChanged.refetches === false`.
+   */
+  dropToolListChanged?: boolean;
+  /**
    * Whether the client drives MRTR (`resultType: "input_required"`) retry
    * rounds at all.
    *

--- a/sdk/src/widget-runtime/host-app-bridge.ts
+++ b/sdk/src/widget-runtime/host-app-bridge.ts
@@ -27,6 +27,10 @@
  */
 
 import { AppBridge } from "@modelcontextprotocol/ext-apps/app-bridge";
+import {
+  applyToolResultPolicy,
+  type ToolResultPolicy,
+} from "./tool-result-policy.js";
 import { isVisibleToModelOnly } from "./tool-visibility.js";
 import type { AppToolInvocationUpdate } from "./app-tool-invocations.js";
 
@@ -163,6 +167,12 @@ export interface HostBridgeMatrix {
   toolCancelled?: boolean;
   /** When false, do not install the view-initiated teardown handler. */
   requestTeardown?: boolean;
+  /**
+   * Which halves of a tool result this host relays back to the widget.
+   * Unlike the gates above — which decide whether a handler exists at all —
+   * this one shapes the VALUE a live handler returns.
+   */
+  toolResult?: ToolResultPolicy;
 }
 
 /**
@@ -382,7 +392,15 @@ export function registerHostBridgeHandlers(
       }
 
       try {
-        const result = await callbacks.onCallTool(name, invocationInput);
+        const rawResult = await callbacks.onCallTool(name, invocationInput);
+        // Shape the result BEFORE recording the invocation, so the
+        // inspector's app-tool panel shows what the widget actually
+        // received rather than what the server sent. A host that strips
+        // `structuredContent` is invisible to the widget author otherwise.
+        const result = applyToolResultPolicy(
+          rawResult,
+          getMatrix?.()?.toolResult,
+        );
         callbacks.onAppToolInvocation?.({
           id: invocationId,
           parentToolCallId,

--- a/sdk/src/widget-runtime/index.ts
+++ b/sdk/src/widget-runtime/index.ts
@@ -20,6 +20,9 @@ export { LoggingTransport } from "./logging-transport.js";
 // Pure JSON helpers shared with the inspector + widget renderer (Phase 3d-ii).
 export { extractMethod, stableStringifyJson } from "./json-utils.js";
 
+export { applyToolResultPolicy } from "./tool-result-policy.js";
+export type { ToolResultPolicy } from "./tool-result-policy.js";
+
 export {
   DEFAULT_IFRAME_SANDBOX,
   buildOuterAllowAttribute,

--- a/sdk/src/widget-runtime/index.ts
+++ b/sdk/src/widget-runtime/index.ts
@@ -21,7 +21,10 @@ export { LoggingTransport } from "./logging-transport.js";
 export { extractMethod, stableStringifyJson } from "./json-utils.js";
 
 export { applyToolResultPolicy } from "./tool-result-policy.js";
-export type { ToolResultPolicy } from "./tool-result-policy.js";
+export type {
+  BrowserStoragePolicy,
+  ToolResultPolicy,
+} from "./tool-result-policy.js";
 
 export {
   DEFAULT_IFRAME_SANDBOX,

--- a/sdk/src/widget-runtime/tool-result-policy.ts
+++ b/sdk/src/widget-runtime/tool-result-policy.ts
@@ -1,0 +1,92 @@
+import type { CallToolResult } from "@modelcontextprotocol/client";
+
+/**
+ * Which halves of a tool result a host relays to a widget that called a tool.
+ *
+ * A tool result has two halves — the `content` block array and
+ * `structuredContent` (MCP spec, "Tool Result" under server/tools) — and real
+ * hosts differ in what they forward. Cursor 3.4 strips `structuredContent`, so
+ * a widget reading it breaks silently there while working everywhere else.
+ *
+ * This is the WIDGET axis, deliberately distinct from the two mcpjam already
+ * models: `modelVisibleMcpToolResults` (what the model sees) and
+ * `mcpToolResultImageRendering` (what mcpjam's own chat UI draws). Same tool
+ * result, three different pipes.
+ *
+ * Absent or `true` means forwarded, matching the omit-when-absent discipline
+ * every probe knob uses: only an explicit `false` drops anything.
+ */
+export interface ToolResultPolicy {
+  structuredContent?: boolean;
+  content?: {
+    text?: boolean;
+    image?: boolean;
+    audio?: boolean;
+    resource?: boolean;
+    resourceLink?: boolean;
+  };
+}
+
+/**
+ * Spec `ContentBlock.type` values mapped to their policy key. `resource_link`
+ * is the only one whose wire name differs from its camelCase config key.
+ */
+const CONTENT_TYPE_TO_POLICY_KEY: Record<
+  string,
+  keyof NonNullable<ToolResultPolicy["content"]>
+> = {
+  text: "text",
+  image: "image",
+  audio: "audio",
+  resource: "resource",
+  resource_link: "resourceLink",
+};
+
+/**
+ * Drop the halves of `result` this host does not forward to widgets.
+ *
+ * Returns the ORIGINAL object when nothing is dropped, so the common case
+ * costs no allocation and referential equality is preserved for consumers
+ * that memoize on it.
+ *
+ * A block whose `type` is not in the spec's five kinds is always kept: the
+ * policy cannot describe it, and silently swallowing an unknown block would
+ * make a future spec addition look like host breakage.
+ */
+export function applyToolResultPolicy<T extends Partial<CallToolResult>>(
+  result: T,
+  policy: ToolResultPolicy | null | undefined,
+): T {
+  if (!policy || !result || typeof result !== "object") return result;
+
+  const dropStructured =
+    policy.structuredContent === false && "structuredContent" in result;
+
+  const contentPolicy = policy.content;
+  const blocks = Array.isArray(result.content) ? result.content : null;
+  const filteredBlocks =
+    contentPolicy && blocks
+      ? blocks.filter((block) => {
+          const type = (block as { type?: unknown } | null)?.type;
+          if (typeof type !== "string") return true;
+          const key = CONTENT_TYPE_TO_POLICY_KEY[type];
+          if (key === undefined) return true;
+          return contentPolicy[key] !== false;
+        })
+      : null;
+
+  const dropsBlocks =
+    filteredBlocks !== null && blocks !== null &&
+    filteredBlocks.length !== blocks.length;
+
+  if (!dropStructured && !dropsBlocks) return result;
+
+  const next = { ...result } as T;
+  if (dropStructured) {
+    delete (next as { structuredContent?: unknown }).structuredContent;
+  }
+  if (dropsBlocks) {
+    (next as { content?: unknown }).content = filteredBlocks;
+  }
+  return next;
+}

--- a/sdk/src/widget-runtime/tool-result-policy.ts
+++ b/sdk/src/widget-runtime/tool-result-policy.ts
@@ -90,3 +90,24 @@ export function applyToolResultPolicy<T extends Partial<CallToolResult>>(
   }
   return next;
 }
+
+/**
+ * Which browser storage APIs a widget can reach inside the host's sandbox.
+ *
+ * NOT an MCP concept — the MCP Apps spec's `sandbox` defines only
+ * `permissions` and `csp`. This is an observed consequence of the sandboxed
+ * iframe the spec does mandate, measured because widgets that persist state
+ * break silently on a host that blocks it.
+ *
+ * Named and exported because the same shape crosses five seams (profile
+ * type, widget-host projection, renderer, sandboxed-iframe prop, modal
+ * prop). Adding a fourth API — cookies, OPFS — must be a one-line change,
+ * not five edits in lockstep where a missed copy drops the field silently.
+ *
+ * Absent or `true` means available; only an explicit `false` blocks.
+ */
+export interface BrowserStoragePolicy {
+  localStorage?: boolean;
+  sessionStorage?: boolean;
+  indexedDB?: boolean;
+}

--- a/sdk/tests/__snapshots__/host-config-seed-host-template.test.ts.snap
+++ b/sdk/tests/__snapshots__/host-config-seed-host-template.test.ts.snap
@@ -766,12 +766,27 @@ exports[`seedHostTemplate > seed output matches the committed golden snapshot 1`
           "serverTools": true,
           "toolInfo": true,
           "toolInputPartial": true,
+          "toolResult": {
+            "content": {
+              "audio": true,
+              "image": true,
+              "resource": true,
+              "resourceLink": true,
+              "text": true,
+            },
+            "structuredContent": true,
+          },
           "updateModelContext": true,
           "widgetDisplayModeRequests": "accept",
         },
         "sandbox": {
           "allowFeatures": {
             "fullscreen": "*",
+          },
+          "browserStorage": {
+            "indexedDB": true,
+            "localStorage": true,
+            "sessionStorage": true,
           },
           "csp": {
             "cspDirectives": {
@@ -856,6 +871,7 @@ exports[`seedHostTemplate > seed output matches the committed golden snapshot 1`
         "elicitation": false,
         "requestState": false,
       },
+      "paginationTraversal": "full",
       "profileVersion": 1,
     },
     "modelId": "anthropic/claude-haiku-4.5",
@@ -1106,12 +1122,27 @@ exports[`seedHostTemplate > seed output matches the committed golden snapshot 1`
           "serverTools": true,
           "toolInfo": true,
           "toolInputPartial": true,
+          "toolResult": {
+            "content": {
+              "audio": true,
+              "image": true,
+              "resource": true,
+              "resourceLink": true,
+              "text": true,
+            },
+            "structuredContent": true,
+          },
           "updateModelContext": true,
           "widgetDisplayModeRequests": "accept",
         },
         "sandbox": {
           "allowFeatures": {
             "fullscreen": "*",
+          },
+          "browserStorage": {
+            "indexedDB": true,
+            "localStorage": true,
+            "sessionStorage": true,
           },
           "csp": {
             "cspDirectives": {
@@ -1196,6 +1227,7 @@ exports[`seedHostTemplate > seed output matches the committed golden snapshot 1`
         "elicitation": false,
         "requestState": false,
       },
+      "paginationTraversal": "full",
       "profileVersion": 1,
     },
     "modelId": "anthropic/claude-haiku-4.5",
@@ -1354,6 +1386,13 @@ exports[`seedHostTemplate > seed output matches the committed golden snapshot 1`
             "xhr": true,
           },
           "cspFrameDomains": true,
+          "cspResourceDomains": {
+            "font": true,
+            "image": true,
+            "media": true,
+            "script": true,
+            "stylesheet": true,
+          },
           "downloadFile": false,
           "hostContextChanged": true,
           "logging": true,
@@ -1368,8 +1407,62 @@ exports[`seedHostTemplate > seed output matches the committed golden snapshot 1`
           "toolCancelled": false,
           "toolInfo": false,
           "toolInputPartial": true,
+          "toolResult": {
+            "content": {
+              "audio": true,
+              "image": true,
+              "resource": true,
+              "resourceLink": true,
+              "text": true,
+            },
+            "structuredContent": true,
+          },
           "updateModelContext": true,
           "widgetDisplayModeRequests": "accept",
+        },
+        "sandbox": {
+          "browserStorage": {
+            "indexedDB": true,
+            "localStorage": true,
+            "sessionStorage": true,
+          },
+          "csp": {
+            "cspDirectives": {
+              "base-uri": [
+                "'none'",
+              ],
+              "connect-src": [
+                "https://cdn.jsdelivr.net",
+                "https://unpkg.com",
+              ],
+              "font-src": [
+                "https://cdn.jsdelivr.net",
+                "https://unpkg.com",
+              ],
+              "frame-src": [
+                "'self'",
+                "data:",
+                "blob:",
+              ],
+              "img-src": [
+                "https://cdn.jsdelivr.net",
+                "https://unpkg.com",
+              ],
+              "media-src": [
+                "https://cdn.jsdelivr.net",
+                "https://unpkg.com",
+              ],
+              "script-src": [
+                "https://cdn.jsdelivr.net",
+                "https://unpkg.com",
+              ],
+              "style-src": [
+                "https://cdn.jsdelivr.net",
+                "https://unpkg.com",
+              ],
+            },
+            "mode": "declared",
+          },
         },
       },
       "initialize": {
@@ -1384,7 +1477,12 @@ exports[`seedHostTemplate > seed output matches the committed golden snapshot 1`
           "2025-11-25",
         ],
       },
+      "paginationTraversal": "firstPageOnly",
       "profileVersion": 1,
+      "toolListChanged": {
+        "listens": true,
+        "refetches": false,
+      },
     },
     "modelId": "openai/gpt-5-nano",
     "optionalServerIds": [],
@@ -1472,6 +1570,13 @@ exports[`seedHostTemplate > seed output matches the committed golden snapshot 1`
             "xhr": true,
           },
           "cspFrameDomains": true,
+          "cspResourceDomains": {
+            "font": true,
+            "image": true,
+            "media": true,
+            "script": true,
+            "stylesheet": true,
+          },
           "downloadFile": false,
           "hostContextChanged": true,
           "logging": true,
@@ -1486,8 +1591,62 @@ exports[`seedHostTemplate > seed output matches the committed golden snapshot 1`
           "toolCancelled": false,
           "toolInfo": false,
           "toolInputPartial": true,
+          "toolResult": {
+            "content": {
+              "audio": true,
+              "image": true,
+              "resource": true,
+              "resourceLink": true,
+              "text": true,
+            },
+            "structuredContent": true,
+          },
           "updateModelContext": true,
           "widgetDisplayModeRequests": "accept",
+        },
+        "sandbox": {
+          "browserStorage": {
+            "indexedDB": true,
+            "localStorage": true,
+            "sessionStorage": true,
+          },
+          "csp": {
+            "cspDirectives": {
+              "base-uri": [
+                "'none'",
+              ],
+              "connect-src": [
+                "https://cdn.jsdelivr.net",
+                "https://unpkg.com",
+              ],
+              "font-src": [
+                "https://cdn.jsdelivr.net",
+                "https://unpkg.com",
+              ],
+              "frame-src": [
+                "'self'",
+                "data:",
+                "blob:",
+              ],
+              "img-src": [
+                "https://cdn.jsdelivr.net",
+                "https://unpkg.com",
+              ],
+              "media-src": [
+                "https://cdn.jsdelivr.net",
+                "https://unpkg.com",
+              ],
+              "script-src": [
+                "https://cdn.jsdelivr.net",
+                "https://unpkg.com",
+              ],
+              "style-src": [
+                "https://cdn.jsdelivr.net",
+                "https://unpkg.com",
+              ],
+            },
+            "mode": "declared",
+          },
         },
       },
       "initialize": {
@@ -1502,7 +1661,12 @@ exports[`seedHostTemplate > seed output matches the committed golden snapshot 1`
           "2025-11-25",
         ],
       },
+      "paginationTraversal": "firstPageOnly",
       "profileVersion": 1,
+      "toolListChanged": {
+        "listens": true,
+        "refetches": false,
+      },
     },
     "modelId": "openai/gpt-5-nano",
     "optionalServerIds": [],
@@ -1612,14 +1776,22 @@ exports[`seedHostTemplate > seed output matches the committed golden snapshot 1`
       },
       "initialize": {
         "clientInfo": {
-          "name": "ms-copilot",
-          "version": "1.0.1",
+          "agentAuthenticationMode": "Integrated",
+          "channelId": "pva-studio",
+          "lcat": "M365_COPILOT_USER",
+          "name": "mcs",
+          "version": "1.0.0",
         },
         "supportedProtocolVersions": [
-          "2025-11-25",
+          "2024-11-05",
         ],
       },
+      "paginationTraversal": "full",
       "profileVersion": 1,
+      "toolListChanged": {
+        "listens": false,
+        "refetches": true,
+      },
     },
     "modelId": "openai/gpt-5.3-chat",
     "optionalServerIds": [],
@@ -1729,14 +1901,22 @@ exports[`seedHostTemplate > seed output matches the committed golden snapshot 1`
       },
       "initialize": {
         "clientInfo": {
-          "name": "ms-copilot",
-          "version": "1.0.1",
+          "agentAuthenticationMode": "Integrated",
+          "channelId": "pva-studio",
+          "lcat": "M365_COPILOT_USER",
+          "name": "mcs",
+          "version": "1.0.0",
         },
         "supportedProtocolVersions": [
-          "2025-11-25",
+          "2024-11-05",
         ],
       },
+      "paginationTraversal": "full",
       "profileVersion": 1,
+      "toolListChanged": {
+        "listens": false,
+        "refetches": true,
+      },
     },
     "modelId": "openai/gpt-5.3-chat",
     "optionalServerIds": [],
@@ -1813,8 +1993,24 @@ exports[`seedHostTemplate > seed output matches the committed golden snapshot 1`
             "script": true,
             "stylesheet": true,
           },
+          "downloadFile": false,
+          "toolResult": {
+            "content": {
+              "audio": true,
+              "image": true,
+              "resource": true,
+              "resourceLink": true,
+              "text": true,
+            },
+            "structuredContent": true,
+          },
         },
         "sandbox": {
+          "browserStorage": {
+            "indexedDB": true,
+            "localStorage": true,
+            "sessionStorage": true,
+          },
           "csp": {
             "mode": "declared",
           },
@@ -1841,7 +2037,12 @@ exports[`seedHostTemplate > seed output matches the committed golden snapshot 1`
           "2025-11-25",
         ],
       },
+      "paginationTraversal": "firstPageOnly",
       "profileVersion": 1,
+      "toolListChanged": {
+        "listens": true,
+        "refetches": true,
+      },
     },
     "modelId": "anthropic/claude-sonnet-4.5",
     "optionalServerIds": [],
@@ -1918,8 +2119,24 @@ exports[`seedHostTemplate > seed output matches the committed golden snapshot 1`
             "script": true,
             "stylesheet": true,
           },
+          "downloadFile": false,
+          "toolResult": {
+            "content": {
+              "audio": true,
+              "image": true,
+              "resource": true,
+              "resourceLink": true,
+              "text": true,
+            },
+            "structuredContent": true,
+          },
         },
         "sandbox": {
+          "browserStorage": {
+            "indexedDB": true,
+            "localStorage": true,
+            "sessionStorage": true,
+          },
           "csp": {
             "mode": "declared",
           },
@@ -1946,7 +2163,12 @@ exports[`seedHostTemplate > seed output matches the committed golden snapshot 1`
           "2025-11-25",
         ],
       },
+      "paginationTraversal": "firstPageOnly",
       "profileVersion": 1,
+      "toolListChanged": {
+        "listens": true,
+        "refetches": true,
+      },
     },
     "modelId": "anthropic/claude-sonnet-4.5",
     "optionalServerIds": [],
@@ -2918,8 +3140,20 @@ exports[`seedHostTemplate > seed output matches the committed golden snapshot 1`
             "inline",
             "fullscreen",
           ],
-          "cspBaseUriDomains": false,
-          "cspFrameDomains": false,
+          "cspBaseUriDomains": true,
+          "cspConnectDomains": {
+            "fetch": true,
+            "websocket": true,
+            "xhr": true,
+          },
+          "cspFrameDomains": true,
+          "cspResourceDomains": {
+            "font": true,
+            "image": true,
+            "media": true,
+            "script": true,
+            "stylesheet": true,
+          },
           "downloadFile": false,
           "hostContextChanged": true,
           "logging": true,
@@ -2934,10 +3168,25 @@ exports[`seedHostTemplate > seed output matches the committed golden snapshot 1`
           "toolCancelled": false,
           "toolInfo": false,
           "toolInputPartial": true,
+          "toolResult": {
+            "content": {
+              "audio": true,
+              "image": true,
+              "resource": true,
+              "resourceLink": true,
+              "text": true,
+            },
+            "structuredContent": true,
+          },
           "updateModelContext": true,
           "widgetDisplayModeRequests": "accept",
         },
         "sandbox": {
+          "browserStorage": {
+            "indexedDB": true,
+            "localStorage": true,
+            "sessionStorage": true,
+          },
           "csp": {
             "mode": "declared",
           },
@@ -2967,6 +3216,7 @@ exports[`seedHostTemplate > seed output matches the committed golden snapshot 1`
           "2025-11-25",
         ],
       },
+      "paginationTraversal": "full",
       "profileVersion": 1,
     },
     "modelId": "mistralai/mistral-large-2512",
@@ -3069,8 +3319,20 @@ exports[`seedHostTemplate > seed output matches the committed golden snapshot 1`
             "inline",
             "fullscreen",
           ],
-          "cspBaseUriDomains": false,
-          "cspFrameDomains": false,
+          "cspBaseUriDomains": true,
+          "cspConnectDomains": {
+            "fetch": true,
+            "websocket": true,
+            "xhr": true,
+          },
+          "cspFrameDomains": true,
+          "cspResourceDomains": {
+            "font": true,
+            "image": true,
+            "media": true,
+            "script": true,
+            "stylesheet": true,
+          },
           "downloadFile": false,
           "hostContextChanged": true,
           "logging": true,
@@ -3085,10 +3347,25 @@ exports[`seedHostTemplate > seed output matches the committed golden snapshot 1`
           "toolCancelled": false,
           "toolInfo": false,
           "toolInputPartial": true,
+          "toolResult": {
+            "content": {
+              "audio": true,
+              "image": true,
+              "resource": true,
+              "resourceLink": true,
+              "text": true,
+            },
+            "structuredContent": true,
+          },
           "updateModelContext": true,
           "widgetDisplayModeRequests": "accept",
         },
         "sandbox": {
+          "browserStorage": {
+            "indexedDB": true,
+            "localStorage": true,
+            "sessionStorage": true,
+          },
           "csp": {
             "mode": "declared",
           },
@@ -3118,6 +3395,7 @@ exports[`seedHostTemplate > seed output matches the committed golden snapshot 1`
           "2025-11-25",
         ],
       },
+      "paginationTraversal": "full",
       "profileVersion": 1,
     },
     "modelId": "mistralai/mistral-large-2512",
@@ -3350,6 +3628,11 @@ exports[`seedHostTemplate > seed output matches the committed golden snapshot 1`
             "text/html;profile=mcp-app",
           ],
         },
+        "io.slack/block-kit": {
+          "mimeTypes": [
+            "application/vnd.slack.blocks+json",
+          ],
+        },
       },
     },
     "computer": undefined,
@@ -3360,6 +3643,9 @@ exports[`seedHostTemplate > seed output matches the committed golden snapshot 1`
     "harness": undefined,
     "hostCapabilitiesOverride": {
       "logging": {},
+      "message": {
+        "text": {},
+      },
       "openLinks": {},
       "serverResources": {},
       "serverTools": {},
@@ -3477,11 +3763,23 @@ exports[`seedHostTemplate > seed output matches the committed golden snapshot 1`
             "fullscreen",
           ],
           "cspBaseUriDomains": false,
+          "cspConnectDomains": {
+            "fetch": true,
+            "websocket": false,
+            "xhr": true,
+          },
           "cspFrameDomains": false,
+          "cspResourceDomains": {
+            "font": true,
+            "image": true,
+            "media": true,
+            "script": true,
+            "stylesheet": true,
+          },
           "downloadFile": false,
           "hostContextChanged": false,
           "logging": true,
-          "message": false,
+          "message": true,
           "openLinks": true,
           "requestTeardown": false,
           "resourcePrefersBorder": false,
@@ -3492,10 +3790,25 @@ exports[`seedHostTemplate > seed output matches the committed golden snapshot 1`
           "toolCancelled": false,
           "toolInfo": true,
           "toolInputPartial": false,
+          "toolResult": {
+            "content": {
+              "audio": true,
+              "image": true,
+              "resource": true,
+              "resourceLink": true,
+              "text": true,
+            },
+            "structuredContent": true,
+          },
           "updateModelContext": false,
           "widgetDisplayModeRequests": "accept",
         },
         "sandbox": {
+          "browserStorage": {
+            "indexedDB": true,
+            "localStorage": true,
+            "sessionStorage": true,
+          },
           "csp": {
             "mode": "declared",
           },
@@ -3545,6 +3858,11 @@ exports[`seedHostTemplate > seed output matches the committed golden snapshot 1`
             "text/html;profile=mcp-app",
           ],
         },
+        "io.slack/block-kit": {
+          "mimeTypes": [
+            "application/vnd.slack.blocks+json",
+          ],
+        },
       },
     },
     "computer": undefined,
@@ -3555,6 +3873,9 @@ exports[`seedHostTemplate > seed output matches the committed golden snapshot 1`
     "harness": undefined,
     "hostCapabilitiesOverride": {
       "logging": {},
+      "message": {
+        "text": {},
+      },
       "openLinks": {},
       "serverResources": {},
       "serverTools": {},
@@ -3672,11 +3993,23 @@ exports[`seedHostTemplate > seed output matches the committed golden snapshot 1`
             "fullscreen",
           ],
           "cspBaseUriDomains": false,
+          "cspConnectDomains": {
+            "fetch": true,
+            "websocket": false,
+            "xhr": true,
+          },
           "cspFrameDomains": false,
+          "cspResourceDomains": {
+            "font": true,
+            "image": true,
+            "media": true,
+            "script": true,
+            "stylesheet": true,
+          },
           "downloadFile": false,
           "hostContextChanged": false,
           "logging": true,
-          "message": false,
+          "message": true,
           "openLinks": true,
           "requestTeardown": false,
           "resourcePrefersBorder": false,
@@ -3687,10 +4020,25 @@ exports[`seedHostTemplate > seed output matches the committed golden snapshot 1`
           "toolCancelled": false,
           "toolInfo": true,
           "toolInputPartial": false,
+          "toolResult": {
+            "content": {
+              "audio": true,
+              "image": true,
+              "resource": true,
+              "resourceLink": true,
+              "text": true,
+            },
+            "structuredContent": true,
+          },
           "updateModelContext": false,
           "widgetDisplayModeRequests": "accept",
         },
         "sandbox": {
+          "browserStorage": {
+            "indexedDB": true,
+            "localStorage": true,
+            "sessionStorage": true,
+          },
           "csp": {
             "mode": "declared",
           },
@@ -3894,7 +4242,19 @@ exports[`seedHostTemplate > seed output matches the committed golden snapshot 1`
             "inline",
           ],
           "cspBaseUriDomains": true,
+          "cspConnectDomains": {
+            "fetch": true,
+            "websocket": true,
+            "xhr": true,
+          },
           "cspFrameDomains": true,
+          "cspResourceDomains": {
+            "font": true,
+            "image": true,
+            "media": true,
+            "script": true,
+            "stylesheet": true,
+          },
           "downloadFile": true,
           "hostContextChanged": true,
           "logging": true,
@@ -3909,6 +4269,16 @@ exports[`seedHostTemplate > seed output matches the committed golden snapshot 1`
           "toolCancelled": true,
           "toolInfo": false,
           "toolInputPartial": true,
+          "toolResult": {
+            "content": {
+              "audio": true,
+              "image": true,
+              "resource": true,
+              "resourceLink": true,
+              "text": true,
+            },
+            "structuredContent": true,
+          },
           "updateModelContext": true,
           "widgetDisplayModeRequests": "accept",
         },
@@ -3918,6 +4288,11 @@ exports[`seedHostTemplate > seed output matches the committed golden snapshot 1`
             "clipboard-read": "'src'",
             "cross-origin-isolated": "'src'",
             "local-network-access": "'src'",
+          },
+          "browserStorage": {
+            "indexedDB": true,
+            "localStorage": true,
+            "sessionStorage": true,
           },
           "csp": {
             "mode": "declared",
@@ -3937,20 +4312,25 @@ exports[`seedHostTemplate > seed output matches the committed golden snapshot 1`
         "uiInitialize": {
           "hostInfo": {
             "name": "Visual Studio Code",
-            "version": "1.130.0",
+            "version": "1.134.0",
           },
         },
       },
       "initialize": {
         "clientInfo": {
           "name": "Visual Studio Code",
-          "version": "1.130.0",
+          "version": "1.134.0",
         },
         "supportedProtocolVersions": [
           "2025-11-25",
         ],
       },
+      "paginationTraversal": "full",
       "profileVersion": 1,
+      "toolListChanged": {
+        "listens": true,
+        "refetches": true,
+      },
     },
     "modelId": "anthropic/claude-sonnet-4.5",
     "optionalServerIds": [],
@@ -4126,7 +4506,19 @@ exports[`seedHostTemplate > seed output matches the committed golden snapshot 1`
             "inline",
           ],
           "cspBaseUriDomains": true,
+          "cspConnectDomains": {
+            "fetch": true,
+            "websocket": true,
+            "xhr": true,
+          },
           "cspFrameDomains": true,
+          "cspResourceDomains": {
+            "font": true,
+            "image": true,
+            "media": true,
+            "script": true,
+            "stylesheet": true,
+          },
           "downloadFile": true,
           "hostContextChanged": true,
           "logging": true,
@@ -4141,6 +4533,16 @@ exports[`seedHostTemplate > seed output matches the committed golden snapshot 1`
           "toolCancelled": true,
           "toolInfo": false,
           "toolInputPartial": true,
+          "toolResult": {
+            "content": {
+              "audio": true,
+              "image": true,
+              "resource": true,
+              "resourceLink": true,
+              "text": true,
+            },
+            "structuredContent": true,
+          },
           "updateModelContext": true,
           "widgetDisplayModeRequests": "accept",
         },
@@ -4150,6 +4552,11 @@ exports[`seedHostTemplate > seed output matches the committed golden snapshot 1`
             "clipboard-read": "'src'",
             "cross-origin-isolated": "'src'",
             "local-network-access": "'src'",
+          },
+          "browserStorage": {
+            "indexedDB": true,
+            "localStorage": true,
+            "sessionStorage": true,
           },
           "csp": {
             "mode": "declared",
@@ -4169,20 +4576,25 @@ exports[`seedHostTemplate > seed output matches the committed golden snapshot 1`
         "uiInitialize": {
           "hostInfo": {
             "name": "Visual Studio Code",
-            "version": "1.130.0",
+            "version": "1.134.0",
           },
         },
       },
       "initialize": {
         "clientInfo": {
           "name": "Visual Studio Code",
-          "version": "1.130.0",
+          "version": "1.134.0",
         },
         "supportedProtocolVersions": [
           "2025-11-25",
         ],
       },
+      "paginationTraversal": "full",
       "profileVersion": 1,
+      "toolListChanged": {
+        "listens": true,
+        "refetches": true,
+      },
     },
     "modelId": "anthropic/claude-sonnet-4.5",
     "optionalServerIds": [],

--- a/sdk/tests/__snapshots__/host-config-seed-host-template.test.ts.snap
+++ b/sdk/tests/__snapshots__/host-config-seed-host-template.test.ts.snap
@@ -152,6 +152,13 @@ exports[`seedHostTemplate > seed output matches the committed golden snapshot 1`
             "websocket": true,
             "xhr": true,
           },
+          "cspResourceDomains": {
+            "font": true,
+            "image": true,
+            "media": true,
+            "script": true,
+            "stylesheet": true,
+          },
         },
         "sandbox": {
           "csp": {
@@ -301,6 +308,13 @@ exports[`seedHostTemplate > seed output matches the committed golden snapshot 1`
             "fetch": true,
             "websocket": true,
             "xhr": true,
+          },
+          "cspResourceDomains": {
+            "font": true,
+            "image": true,
+            "media": true,
+            "script": true,
+            "stylesheet": true,
           },
         },
         "sandbox": {

--- a/sdk/tests/__snapshots__/host-config-seed-host-template.test.ts.snap
+++ b/sdk/tests/__snapshots__/host-config-seed-host-template.test.ts.snap
@@ -161,6 +161,16 @@ exports[`seedHostTemplate > seed output matches the committed golden snapshot 1`
             "script": true,
             "stylesheet": true,
           },
+          "toolResult": {
+            "content": {
+              "audio": true,
+              "image": true,
+              "resource": true,
+              "resourceLink": true,
+              "text": true,
+            },
+            "structuredContent": true,
+          },
         },
         "sandbox": {
           "csp": {
@@ -209,6 +219,11 @@ exports[`seedHostTemplate > seed output matches the committed golden snapshot 1`
             "allow-popups",
             "allow-popups-to-escape-sandbox",
           ],
+          "storage": {
+            "indexedDB": true,
+            "localStorage": true,
+            "sessionStorage": true,
+          },
         },
         "uiInitialize": {
           "hostInfo": {
@@ -229,7 +244,11 @@ exports[`seedHostTemplate > seed output matches the committed golden snapshot 1`
         ],
       },
       "mcpProtocolVersion": "auto",
+      "paginationTraversal": "full",
       "profileVersion": 1,
+      "toolListChanged": {
+        "listens": false,
+      },
     },
     "modelId": "openai/gpt-5.6-luna",
     "optionalServerIds": [],
@@ -320,6 +339,16 @@ exports[`seedHostTemplate > seed output matches the committed golden snapshot 1`
             "script": true,
             "stylesheet": true,
           },
+          "toolResult": {
+            "content": {
+              "audio": true,
+              "image": true,
+              "resource": true,
+              "resourceLink": true,
+              "text": true,
+            },
+            "structuredContent": true,
+          },
         },
         "sandbox": {
           "csp": {
@@ -368,6 +397,11 @@ exports[`seedHostTemplate > seed output matches the committed golden snapshot 1`
             "allow-popups",
             "allow-popups-to-escape-sandbox",
           ],
+          "storage": {
+            "indexedDB": true,
+            "localStorage": true,
+            "sessionStorage": true,
+          },
         },
         "uiInitialize": {
           "hostInfo": {
@@ -388,7 +422,11 @@ exports[`seedHostTemplate > seed output matches the committed golden snapshot 1`
         ],
       },
       "mcpProtocolVersion": "auto",
+      "paginationTraversal": "full",
       "profileVersion": 1,
+      "toolListChanged": {
+        "listens": false,
+      },
     },
     "modelId": "openai/gpt-5.6-luna",
     "optionalServerIds": [],

--- a/sdk/tests/__snapshots__/host-config-seed-host-template.test.ts.snap
+++ b/sdk/tests/__snapshots__/host-config-seed-host-template.test.ts.snap
@@ -173,6 +173,11 @@ exports[`seedHostTemplate > seed output matches the committed golden snapshot 1`
           },
         },
         "sandbox": {
+          "browserStorage": {
+            "indexedDB": true,
+            "localStorage": true,
+            "sessionStorage": true,
+          },
           "csp": {
             "cspDirectives": {
               "connect-src": [
@@ -219,11 +224,6 @@ exports[`seedHostTemplate > seed output matches the committed golden snapshot 1`
             "allow-popups",
             "allow-popups-to-escape-sandbox",
           ],
-          "storage": {
-            "indexedDB": true,
-            "localStorage": true,
-            "sessionStorage": true,
-          },
         },
         "uiInitialize": {
           "hostInfo": {
@@ -351,6 +351,11 @@ exports[`seedHostTemplate > seed output matches the committed golden snapshot 1`
           },
         },
         "sandbox": {
+          "browserStorage": {
+            "indexedDB": true,
+            "localStorage": true,
+            "sessionStorage": true,
+          },
           "csp": {
             "cspDirectives": {
               "connect-src": [
@@ -397,11 +402,6 @@ exports[`seedHostTemplate > seed output matches the committed golden snapshot 1`
             "allow-popups",
             "allow-popups-to-escape-sandbox",
           ],
-          "storage": {
-            "indexedDB": true,
-            "localStorage": true,
-            "sessionStorage": true,
-          },
         },
         "uiInitialize": {
           "hostInfo": {

--- a/sdk/tests/__snapshots__/host-config-seed-host-template.test.ts.snap
+++ b/sdk/tests/__snapshots__/host-config-seed-host-template.test.ts.snap
@@ -147,11 +147,13 @@ exports[`seedHostTemplate > seed output matches the committed golden snapshot 1`
           "openaiApps": true,
         },
         "mcpAppsOverrides": {
+          "cspBaseUriDomains": true,
           "cspConnectDomains": {
             "fetch": true,
             "websocket": true,
             "xhr": true,
           },
+          "cspFrameDomains": true,
           "cspResourceDomains": {
             "font": true,
             "image": true,
@@ -304,11 +306,13 @@ exports[`seedHostTemplate > seed output matches the committed golden snapshot 1`
           "openaiApps": true,
         },
         "mcpAppsOverrides": {
+          "cspBaseUriDomains": true,
           "cspConnectDomains": {
             "fetch": true,
             "websocket": true,
             "xhr": true,
           },
+          "cspFrameDomains": true,
           "cspResourceDomains": {
             "font": true,
             "image": true,

--- a/sdk/tests/host-compat-market-hosts.test.ts
+++ b/sdk/tests/host-compat-market-hosts.test.ts
@@ -5,6 +5,7 @@ import {
   evaluateMarketHosts,
   MCP_APPS_FULL,
   MCP_APPS_CLAUDE,
+  MCP_APPS_CHATGPT,
   type HostCompatToolsInput,
 } from "../src/host-compat/index";
 import {
@@ -66,6 +67,13 @@ describe("buildMarketHostProfiles", () => {
       toolInputPartial: true,
       toolCancelled: true,
       resourceTeardown: true,
+      cspResourceDomains: {
+        script: true,
+        stylesheet: true,
+        image: true,
+        font: true,
+        media: true,
+      },
       downloadFile: false,
     });
   });
@@ -150,6 +158,7 @@ describe("buildMarketHostProfiles", () => {
     expect(Object.isFrozen(MCP_APPS_FULL.availableDisplayModes)).toBe(true);
     expect(Object.isFrozen(MCP_APPS_CLAUDE.cspConnectDomains)).toBe(true);
     expect(Object.isFrozen(MCP_APPS_CLAUDE.cspResourceDomains)).toBe(true);
+    expect(Object.isFrozen(MCP_APPS_CHATGPT.cspResourceDomains)).toBe(true);
     expect(() => {
       (MCP_APPS_FULL as { message?: boolean }).message = false;
     }).toThrow();

--- a/sdk/tests/host-config-canonicalize.test.ts
+++ b/sdk/tests/host-config-canonicalize.test.ts
@@ -717,7 +717,7 @@ describe("canonicalizeHostConfigV2 — toolListChanged / toolResult probe fields
     expect(absent.mcpProfile).toBeUndefined();
   });
 
-  it("round-trips toolResult.content and sandbox.storage", () => {
+  it("round-trips toolResult.content and sandbox.browserStorage", () => {
     const c = canonicalizeHostConfigV2(
       base({
         mcpProfile: {
@@ -736,7 +736,7 @@ describe("canonicalizeHostConfigV2 — toolListChanged / toolResult probe fields
               },
             },
             sandbox: {
-              storage: {
+              browserStorage: {
                 localStorage: true,
                 sessionStorage: false,
                 indexedDB: true,
@@ -756,7 +756,7 @@ describe("canonicalizeHostConfigV2 — toolListChanged / toolResult probe fields
       },
       structuredContent: true,
     });
-    expect(c.mcpProfile?.apps?.sandbox?.storage).toEqual({
+    expect(c.mcpProfile?.apps?.sandbox?.browserStorage).toEqual({
       localStorage: true,
       sessionStorage: false,
       indexedDB: true,
@@ -771,7 +771,7 @@ describe("canonicalizeHostConfigV2 — toolListChanged / toolResult probe fields
           toolListChanged: {},
           apps: {
             mcpAppsOverrides: { toolResult: { content: {} } },
-            sandbox: { storage: {} },
+            sandbox: { browserStorage: {} },
           },
         },
       })
@@ -824,11 +824,13 @@ describe("canonicalizeHostConfigV2 — toolListChanged / toolResult probe fields
         base({
           mcpProfile: {
             profileVersion: 1,
-            apps: { sandbox: { storage: { cookies: true } } as never },
+            apps: {
+              sandbox: { browserStorage: { cookies: true } } as never,
+            },
           },
         })
       )
-    ).toThrow(/sandbox\.storage has unknown key "cookies"/);
+    ).toThrow(/sandbox\.browserStorage has unknown key "cookies"/);
   });
 });
 

--- a/sdk/tests/host-config-canonicalize.test.ts
+++ b/sdk/tests/host-config-canonicalize.test.ts
@@ -695,6 +695,70 @@ describe("canonicalizeHostConfigV2 — client-conformance knobs", () => {
   });
 });
 
+describe("canonicalizeHostConfigV2 — toolListChanged / toolResult probe fields", () => {
+  it("round-trips both fields and omits them when absent", () => {
+    const c = canonicalizeHostConfigV2(
+      base({
+        mcpProfile: {
+          profileVersion: 1,
+          toolListChanged: { listens: false },
+          apps: {
+            mcpAppsOverrides: { toolResult: { structuredContent: false } },
+          },
+        },
+      })
+    );
+    expect(c.mcpProfile).toMatchObject({
+      toolListChanged: { listens: false },
+      apps: { mcpAppsOverrides: { toolResult: { structuredContent: false } } },
+    });
+
+    const absent = canonicalizeHostConfigV2(base());
+    expect(absent.mcpProfile).toBeUndefined();
+  });
+
+  it("hashes an empty record the same as absent, so pre-feature configs keep their hash", async () => {
+    const emptyHash = await hash(
+      base({
+        mcpProfile: {
+          profileVersion: 1,
+          toolListChanged: {},
+          apps: { mcpAppsOverrides: { toolResult: {} } },
+        },
+      })
+    );
+    const absentHash = await hash(
+      base({ mcpProfile: { profileVersion: 1 } })
+    );
+    expect(emptyHash).toBe(absentHash);
+  });
+
+  it("throws on an unknown key rather than storing it", () => {
+    expect(() =>
+      canonicalizeHostConfigV2(
+        base({
+          mcpProfile: {
+            profileVersion: 1,
+            toolListChanged: { subscribes: true } as never,
+          },
+        })
+      )
+    ).toThrow(/toolListChanged has unknown key "subscribes"/);
+    expect(() =>
+      canonicalizeHostConfigV2(
+        base({
+          mcpProfile: {
+            profileVersion: 1,
+            apps: {
+              mcpAppsOverrides: { toolResult: { content: true } as never },
+            },
+          },
+        })
+      )
+    ).toThrow(/toolResult has unknown key "content"/);
+  });
+});
+
 describe("canonicalizeHostConfigV2 — tightening (Stage B)", () => {
   // Item 5: fail-fast on missing required record fields. The previous
   // `?? {}` coalescing silently merged undefined-cap rows with explicit-{}

--- a/sdk/tests/host-config-canonicalize.test.ts
+++ b/sdk/tests/host-config-canonicalize.test.ts
@@ -717,13 +717,62 @@ describe("canonicalizeHostConfigV2 — toolListChanged / toolResult probe fields
     expect(absent.mcpProfile).toBeUndefined();
   });
 
+  it("round-trips toolResult.content and sandbox.storage", () => {
+    const c = canonicalizeHostConfigV2(
+      base({
+        mcpProfile: {
+          profileVersion: 1,
+          apps: {
+            mcpAppsOverrides: {
+              toolResult: {
+                structuredContent: true,
+                content: {
+                  text: true,
+                  image: false,
+                  audio: true,
+                  resource: false,
+                  resourceLink: true,
+                },
+              },
+            },
+            sandbox: {
+              storage: {
+                localStorage: true,
+                sessionStorage: false,
+                indexedDB: true,
+              },
+            },
+          },
+        },
+      })
+    );
+    expect(c.mcpProfile?.apps?.mcpAppsOverrides?.toolResult).toEqual({
+      content: {
+        text: true,
+        image: false,
+        audio: true,
+        resource: false,
+        resourceLink: true,
+      },
+      structuredContent: true,
+    });
+    expect(c.mcpProfile?.apps?.sandbox?.storage).toEqual({
+      localStorage: true,
+      sessionStorage: false,
+      indexedDB: true,
+    });
+  });
+
   it("hashes an empty record the same as absent, so pre-feature configs keep their hash", async () => {
     const emptyHash = await hash(
       base({
         mcpProfile: {
           profileVersion: 1,
           toolListChanged: {},
-          apps: { mcpAppsOverrides: { toolResult: {} } },
+          apps: {
+            mcpAppsOverrides: { toolResult: { content: {} } },
+            sandbox: { storage: {} },
+          },
         },
       })
     );
@@ -750,12 +799,36 @@ describe("canonicalizeHostConfigV2 — toolListChanged / toolResult probe fields
           mcpProfile: {
             profileVersion: 1,
             apps: {
-              mcpAppsOverrides: { toolResult: { content: true } as never },
+              mcpAppsOverrides: { toolResult: { structured: true } as never },
             },
           },
         })
       )
-    ).toThrow(/toolResult has unknown key "content"/);
+    ).toThrow(/toolResult has unknown key "structured"/);
+    expect(() =>
+      canonicalizeHostConfigV2(
+        base({
+          mcpProfile: {
+            profileVersion: 1,
+            apps: {
+              mcpAppsOverrides: {
+                toolResult: { content: { video: true } } as never,
+              },
+            },
+          },
+        })
+      )
+    ).toThrow(/toolResult\.content has unknown key "video"/);
+    expect(() =>
+      canonicalizeHostConfigV2(
+        base({
+          mcpProfile: {
+            profileVersion: 1,
+            apps: { sandbox: { storage: { cookies: true } } as never },
+          },
+        })
+      )
+    ).toThrow(/sandbox\.storage has unknown key "cookies"/);
   });
 });
 

--- a/sdk/tests/host-config-seed-host-template.test.ts
+++ b/sdk/tests/host-config-seed-host-template.test.ts
@@ -252,9 +252,15 @@ describe("seedHostTemplate", () => {
     const config = seedHostTemplate("copilot", { theme: "dark" });
     const profile = config.mcpProfile;
 
+    // Probed 2026-08-26: the real handshake sends `mcs` 1.0.0 plus Copilot's
+    // routing fields. hostInfo below stays at the vendor-doc profile — no
+    // ui/initialize was ever observed, so nothing measured contradicts it.
     expect(profile?.initialize?.clientInfo).toEqual({
-      name: "ms-copilot",
-      version: "1.0.1",
+      name: "mcs",
+      version: "1.0.0",
+      channelId: "pva-studio",
+      lcat: "M365_COPILOT_USER",
+      agentAuthenticationMode: "Integrated",
     });
     expect(profile?.apps?.uiInitialize?.hostInfo).toEqual({
       name: "Copilot",
@@ -317,6 +323,9 @@ describe("seedHostTemplate", () => {
 
     expect(config.clientCapabilities).toEqual({
       extensions: {
+        "io.slack/block-kit": {
+          mimeTypes: ["application/vnd.slack.blocks+json"],
+        },
         "io.modelcontextprotocol/ui": {
           mimeTypes: ["text/html;profile=mcp-app"],
         },
@@ -327,6 +336,7 @@ describe("seedHostTemplate", () => {
       serverTools: {},
       serverResources: {},
       logging: {},
+      message: { text: {} },
     });
     expect((config.hostContext as any).theme).toBe("dark");
     expect((config.hostContext as any).containerDimensions).toEqual({
@@ -355,12 +365,12 @@ describe("seedHostTemplate", () => {
       serverResources: true,
       logging: true,
       updateModelContext: false,
-      message: false,
+      message: true,
       sandboxPermissions: false,
     });
   });
 
-  it("keeps VS Code 1.130 handshake facts and deliberate emulator defaults", () => {
+  it("keeps VS Code 1.134 handshake facts and deliberate emulator defaults", () => {
     const config = seedHostTemplate("vscode", { theme: "dark" });
     const profile = config.mcpProfile;
     const hostContext = config.hostContext as {
@@ -411,11 +421,11 @@ describe("seedHostTemplate", () => {
     ).toBe("#ffffff");
     expect(profile?.initialize).toEqual({
       supportedProtocolVersions: ["2025-11-25"],
-      clientInfo: { name: "Visual Studio Code", version: "1.130.0" },
+      clientInfo: { name: "Visual Studio Code", version: "1.134.0" },
     });
     expect(profile?.apps?.uiInitialize?.hostInfo).toEqual({
       name: "Visual Studio Code",
-      version: "1.130.0",
+      version: "1.134.0",
     });
     expect(profile?.apps?.compatRuntime).toEqual({ openaiApps: false });
     expect(profile?.apps?.mcpAppsOverrides).toMatchObject({

--- a/sdk/tests/host-config-seed-host-template.test.ts
+++ b/sdk/tests/host-config-seed-host-template.test.ts
@@ -213,11 +213,15 @@ describe("seedHostTemplate", () => {
     expect(effective.mcpProfile?.apps?.mcpAppsOverrides).toMatchObject({
       cspConnectDomains: { fetch: true, xhr: true, websocket: true },
     });
-    // Unknown, not false — the probe's declared resource origin is also in
-    // ChatGPT's own baseline allowlist, so it separates nothing.
-    expect(
-      config.mcpProfile?.apps?.mcpAppsOverrides
-    ).not.toHaveProperty("cspResourceDomains");
+    expect(config.mcpProfile?.apps?.mcpAppsOverrides).toMatchObject({
+      cspResourceDomains: {
+        script: true,
+        stylesheet: true,
+        image: true,
+        font: true,
+        media: true,
+      },
+    });
     expect(config.mcpProfile?.apps?.sandbox?.csp?.cspDirectives).toMatchObject({
       "connect-src": ["https://cdn.jsdelivr.net", "https://unpkg.com"],
       "script-src": ["https://cdn.jsdelivr.net", "https://unpkg.com"],

--- a/sdk/tests/host-config-seed-host-template.test.ts
+++ b/sdk/tests/host-config-seed-host-template.test.ts
@@ -207,6 +207,8 @@ describe("seedHostTemplate", () => {
     // declared wss endpoint connected while an undeclared one took a real
     // violation, so the declared list is honored for fetch and XHR too.
     expect(config.mcpProfile?.apps?.mcpAppsOverrides).toMatchObject({
+      cspFrameDomains: true,
+      cspBaseUriDomains: true,
       cspConnectDomains: { fetch: true, xhr: true, websocket: true },
     });
     const effective = canonicalizeHostConfigV2(config);

--- a/sdk/tests/host-connection.test.ts
+++ b/sdk/tests/host-connection.test.ts
@@ -136,6 +136,44 @@ describe("hostConnectionProfile", () => {
       }
     });
 
+    it("reduces the toolListChanged record per leaf", () => {
+      const p = hostConnectionProfile({
+        mcpProfile: {
+          profileVersion: 1,
+          toolListChanged: { listens: false, refetches: false },
+        },
+      });
+      expect(p.suppressListenChannel).toBe(true);
+      expect(p.dropToolListChanged).toBe(true);
+    });
+
+    it("reduces only the leaf that is set", () => {
+      // ChatGPT's real shape: measured not-listening, with `refetches`
+      // deliberately unmeasured because nothing is ever delivered to it.
+      const p = hostConnectionProfile({
+        mcpProfile: {
+          profileVersion: 1,
+          toolListChanged: { listens: false },
+        },
+      });
+      expect(p.suppressListenChannel).toBe(true);
+      expect("dropToolListChanged" in p).toBe(false);
+    });
+
+    it("collapses true leaves, an empty record, and absence alike", () => {
+      for (const toolListChanged of [
+        { listens: true, refetches: true },
+        {},
+        undefined,
+      ]) {
+        const p = hostConnectionProfile({
+          mcpProfile: { profileVersion: 1, ...(toolListChanged ? { toolListChanged } : {}) },
+        });
+        expect("suppressListenChannel" in p).toBe(false);
+        expect("dropToolListChanged" in p).toBe(false);
+      }
+    });
+
     it("fails closed on unrecognized literals", () => {
       // A future mode this SDK build does not know must not read as the
       // non-default value.

--- a/sdk/tests/tool-list-changed.integration.test.ts
+++ b/sdk/tests/tool-list-changed.integration.test.ts
@@ -1,0 +1,143 @@
+import { afterEach, describe, expect, it } from "vitest";
+import { MCPClientManager } from "../src/mcp-client-manager/index.js";
+import { wrapTransportForDroppedListChanged } from "../src/mcp-client-manager/transport-utils.js";
+import {
+  serveMultiPageFixtureOnPort,
+  type ServedMultiPageFixture,
+} from "./support/multi-page-fixture.js";
+import { getWireField } from "./support/raw-capture.js";
+
+/**
+ * `mcpProfile.toolListChanged` — simulating a client that never opens the
+ * server→client notification channel (`listens: false`, which is how prober
+ * measured ChatGPT), or opens it but ignores
+ * `notifications/tools/list_changed` (`refetches: false`).
+ *
+ * Asserted on a real socket, because both facts are only observable as wire
+ * behavior: a GET that never happens, and a `tools/list` that never repeats.
+ * Every claim has an explicit knob-off control, so a passing test cannot be
+ * explained by the fixture simply never doing the thing.
+ */
+
+describe("tool list changed knobs", () => {
+  let served: ServedMultiPageFixture | undefined;
+  let manager: MCPClientManager | undefined;
+
+  afterEach(async () => {
+    await manager?.disconnectAllServers().catch(() => {});
+    await served?.close();
+    served = undefined;
+    manager = undefined;
+  });
+
+  async function connect(options: {
+    suppressListenChannel?: boolean;
+    dropToolListChanged?: boolean;
+  }) {
+    served = await serveMultiPageFixtureOnPort({});
+    manager = new MCPClientManager();
+    // The legacy era: 2026-07-28 never opens a listen stream at connect, so
+    // the standalone GET only exists to be refused here.
+    await manager.connectToServer("fixture", {
+      url: served.url,
+      mcpProtocolVersion: "2025-11-25",
+      ...(options.suppressListenChannel !== undefined
+        ? { suppressListenChannel: options.suppressListenChannel }
+        : {}),
+      ...(options.dropToolListChanged !== undefined
+        ? { dropToolListChanged: options.dropToolListChanged }
+        : {}),
+      timeout: 10_000,
+    });
+    return { served: served!, manager: manager! };
+  }
+
+  /** The standalone listen stream is the only GET this transport issues. */
+  const listenStreamRequests = () =>
+    served!.exchanges.filter(
+      (e) =>
+        e.request.method.toUpperCase() === "GET" &&
+        (e.request.headers["accept"] ?? "").includes("text/event-stream")
+    );
+
+  const toolsListRequests = () =>
+    served!.exchanges.filter(
+      (e) => getWireField(e.request.json, "method") === "tools/list"
+    );
+
+  it("never opens the notification channel when listens is false", async () => {
+    await connect({ suppressListenChannel: true });
+    // Give the transport the same window it would use to open the stream.
+    await new Promise((resolve) => setTimeout(resolve, 150));
+    expect(listenStreamRequests()).toHaveLength(0);
+  });
+
+  it("opens the notification channel by default (control)", async () => {
+    await connect({});
+    await new Promise((resolve) => setTimeout(resolve, 150));
+    // Proves the assertion above measures a real refusal rather than a
+    // fixture that never gets asked.
+    expect(listenStreamRequests().length).toBeGreaterThan(0);
+  });
+
+  it("still serves tool calls with the channel refused", async () => {
+    // The refusal must not break the connection: a real client that does not
+    // listen still works over the POST channel.
+    const { manager } = await connect({ suppressListenChannel: true });
+    const result = await manager.listTools("fixture");
+    expect(result.tools.length).toBeGreaterThan(0);
+  });
+});
+
+describe("wrapTransportForDroppedListChanged", () => {
+  function fakeTransport() {
+    const inner: Record<string, any> = {
+      sent: [] as unknown[],
+      async start() {},
+      async send(message: unknown) {
+        inner.sent.push(message);
+      },
+      async close() {},
+    };
+    return inner;
+  }
+
+  it("swallows the notification and passes everything else", () => {
+    const inner = fakeTransport();
+    const wrapped = wrapTransportForDroppedListChanged(inner as never);
+    const seen: unknown[] = [];
+    wrapped.onmessage = (message) => seen.push(message);
+
+    inner.onmessage({
+      jsonrpc: "2.0",
+      method: "notifications/tools/list_changed",
+    });
+    inner.onmessage({
+      jsonrpc: "2.0",
+      method: "notifications/resources/list_changed",
+    });
+    inner.onmessage({ jsonrpc: "2.0", id: 1, result: {} });
+
+    expect(seen).toEqual([
+      { jsonrpc: "2.0", method: "notifications/resources/list_changed" },
+      { jsonrpc: "2.0", id: 1, result: {} },
+    ]);
+  });
+
+  it("never swallows a request that carries an id", () => {
+    // A server-initiated REQUEST named like the notification would otherwise
+    // be dropped, leaving the peer waiting for a response forever.
+    const inner = fakeTransport();
+    const wrapped = wrapTransportForDroppedListChanged(inner as never);
+    const seen: unknown[] = [];
+    wrapped.onmessage = (message) => seen.push(message);
+
+    const request = {
+      jsonrpc: "2.0",
+      id: 7,
+      method: "notifications/tools/list_changed",
+    };
+    inner.onmessage(request);
+    expect(seen).toEqual([request]);
+  });
+});

--- a/sdk/tests/tool-list-changed.integration.test.ts
+++ b/sdk/tests/tool-list-changed.integration.test.ts
@@ -80,6 +80,62 @@ describe("tool list changed knobs", () => {
     expect(listenStreamRequests().length).toBeGreaterThan(0);
   });
 
+  it("does NOT guard the fetch handed to the legacy SSE transport", async () => {
+    // Regression: the guard refuses "a GET with Accept: text/event-stream",
+    // which under Streamable HTTP is the standalone listen stream — but under
+    // SSEClientTransport is how the transport OPENS the connection. Guarding
+    // both made every SSE-only server unreachable for any profile carrying
+    // `listens: false`, including the shipped ChatGPT template. Header
+    // inspection cannot tell the two apart, so the call site declares which
+    // transport is asking; this asserts that opt-out is honored.
+    const seen: string[] = [];
+    const baseFetch = (async (input: RequestInfo | URL) => {
+      seen.push(String(input));
+      return new Response("", { status: 200 });
+    }) as unknown as typeof fetch;
+
+    const mgr = new MCPClientManager();
+    const config = {
+      url: "https://example.test/mcp",
+      suppressListenChannel: true,
+      baseFetch,
+    } as never;
+    const sseRequest = {
+      method: "GET",
+      headers: { accept: "text/event-stream" },
+    };
+
+    // Streamable HTTP (default): the listen stream is refused locally and
+    // never reaches the network.
+    const guarded = (
+      mgr as unknown as {
+        buildTransportFetch: (
+          id: string,
+          c: unknown,
+          o?: { listenGuard?: boolean }
+        ) => typeof fetch;
+      }
+    ).buildTransportFetch("fixture", config);
+    const refused = await guarded("https://example.test/mcp", sseRequest);
+    expect(refused.status).toBe(405);
+    expect(seen).toHaveLength(0);
+
+    // Legacy SSE transport: the very same request must go through, or the
+    // connection cannot be established at all.
+    const unguarded = (
+      mgr as unknown as {
+        buildTransportFetch: (
+          id: string,
+          c: unknown,
+          o?: { listenGuard?: boolean }
+        ) => typeof fetch;
+      }
+    ).buildTransportFetch("fixture", config, { listenGuard: false });
+    const passed = await unguarded("https://example.test/mcp", sseRequest);
+    expect(passed.status).toBe(200);
+    expect(seen).toHaveLength(1);
+  });
+
   it("still serves tool calls with the channel refused", async () => {
     // The refusal must not break the connection: a real client that does not
     // listen still works over the POST channel.

--- a/sdk/tests/widget-runtime/tool-result-policy.test.ts
+++ b/sdk/tests/widget-runtime/tool-result-policy.test.ts
@@ -1,0 +1,80 @@
+import { describe, expect, it } from "vitest";
+import { applyToolResultPolicy } from "../../src/widget-runtime/tool-result-policy";
+
+const result = {
+  content: [
+    { type: "text", text: "hello" },
+    { type: "image", data: "aGk=", mimeType: "image/png" },
+    { type: "audio", data: "aGk=", mimeType: "audio/wav" },
+    { type: "resource", resource: { uri: "x://1", text: "r" } },
+    { type: "resource_link", uri: "x://2", name: "link" },
+  ],
+  structuredContent: { ok: true },
+};
+
+describe("applyToolResultPolicy", () => {
+  it("returns the SAME object when nothing is dropped", () => {
+    // Referential equality matters: consumers memoize on the result, and the
+    // common case (a conforming host) must not churn them.
+    expect(applyToolResultPolicy(result, undefined)).toBe(result);
+    expect(applyToolResultPolicy(result, {})).toBe(result);
+    expect(
+      applyToolResultPolicy(result, {
+        structuredContent: true,
+        content: { text: true, image: true },
+      })
+    ).toBe(result);
+  });
+
+  it("drops structuredContent without touching content", () => {
+    const out = applyToolResultPolicy(result, { structuredContent: false });
+    expect(out).not.toBe(result);
+    expect("structuredContent" in out).toBe(false);
+    expect(out.content).toBe(result.content);
+    // The input is never mutated — the original still carries both halves.
+    expect(result.structuredContent).toEqual({ ok: true });
+  });
+
+  it("drops only the content kinds set to false", () => {
+    const out = applyToolResultPolicy(result, {
+      content: { image: false, resourceLink: false },
+    });
+    expect(out.content.map((b) => b.type)).toEqual([
+      "text",
+      "audio",
+      "resource",
+    ]);
+    expect(out.structuredContent).toEqual({ ok: true });
+  });
+
+  it("maps resource_link, whose wire name differs from its config key", () => {
+    const out = applyToolResultPolicy(result, {
+      content: { resourceLink: false },
+    });
+    expect(out.content.some((b) => b.type === "resource_link")).toBe(false);
+    expect(out.content).toHaveLength(4);
+  });
+
+  it("keeps blocks the policy cannot describe", () => {
+    // A future spec kind must not vanish just because this host config
+    // predates it — that would read as host breakage in the probe.
+    const withUnknown = {
+      content: [{ type: "text", text: "a" }, { type: "video-of-the-future" }],
+    };
+    const out = applyToolResultPolicy(withUnknown, {
+      content: { text: false },
+    });
+    expect(out.content.map((b) => b.type)).toEqual(["video-of-the-future"]);
+  });
+
+  it("survives results with no content array", () => {
+    const bare = { structuredContent: { a: 1 } };
+    expect(
+      applyToolResultPolicy(bare, { content: { text: false } })
+    ).toBe(bare);
+    expect(
+      "structuredContent" in
+        applyToolResultPolicy(bare, { structuredContent: false })
+    ).toBe(false);
+  });
+});

--- a/widget-react/src/mcp-apps-modal.tsx
+++ b/widget-react/src/mcp-apps-modal.tsx
@@ -13,6 +13,7 @@ import {
 import type { CallToolResult } from "@modelcontextprotocol/client";
 import {
   applyToolResultPolicy,
+  type BrowserStoragePolicy,
   extractMethod,
   LoggingTransport,
   type ToolResultPolicy,
@@ -67,9 +68,7 @@ export interface McpAppsModalProps {
    * pushes itself, below.
    */
   widgetToolResult: ToolResultPolicy | undefined;
-  widgetBrowserStorage:
-    | { localStorage?: boolean; sessionStorage?: boolean; indexedDB?: boolean }
-    | undefined;
+  widgetBrowserStorage: BrowserStoragePolicy | undefined;
   hostContextRef: React.RefObject<McpUiHostContext | null>;
   serverId: string;
   resourceUri: string;

--- a/widget-react/src/mcp-apps-modal.tsx
+++ b/widget-react/src/mcp-apps-modal.tsx
@@ -10,7 +10,13 @@ import {
 } from "@modelcontextprotocol/ext-apps/app-bridge";
 // Pure JSON-RPC parser + logging transport are shared, framework-free runtime
 // helpers in the SDK.
-import { extractMethod, LoggingTransport } from "@mcpjam/sdk/widget-runtime";
+import type { CallToolResult } from "@modelcontextprotocol/client";
+import {
+  applyToolResultPolicy,
+  extractMethod,
+  LoggingTransport,
+  type ToolResultPolicy,
+} from "@mcpjam/sdk/widget-runtime";
 // The `CspMode` type comes from the package's `WidgetHost` contract.
 import { type CspMode, type CspSubtypePolicy } from "./widget-host";
 // The package owns lifecycle + bridge; the inspector injects modal CHROME
@@ -54,6 +60,13 @@ export interface McpAppsModalProps {
   widgetAllowFeatures: Record<string, string> | undefined;
   widgetCspDirectives: Record<string, string[]> | undefined;
   widgetCspSubtypePolicy: CspSubtypePolicy | undefined;
+  /**
+   * Host policy for the tool result the modal widget is born with. The
+   * modal's `oncalltool` path already inherits this via the renderer's
+   * `registerBridgeHandlers`; this prop covers the ONE result the modal
+   * pushes itself, below.
+   */
+  widgetToolResult: ToolResultPolicy | undefined;
   widgetBrowserStorage:
     | { localStorage?: boolean; sessionStorage?: boolean; indexedDB?: boolean }
     | undefined;
@@ -129,6 +142,7 @@ export function McpAppsModal({
   widgetAllowFeatures,
   widgetCspDirectives,
   widgetCspSubtypePolicy,
+  widgetToolResult,
   widgetBrowserStorage,
   hostContextRef,
   serverId,
@@ -295,7 +309,10 @@ export function McpAppsModal({
         // identical but nominally distinct CallToolResult; cast to exactly what
         // the bridge accepts at this Apps-compat seam (§1D).
         bridge.sendToolResult(
-          toolOutputRef.current as Parameters<typeof bridge.sendToolResult>[0]
+          applyToolResultPolicy(
+            toolOutputRef.current as Partial<CallToolResult>,
+            widgetToolResult
+          ) as Parameters<typeof bridge.sendToolResult>[0]
         );
       }
 

--- a/widget-react/src/mcp-apps-modal.tsx
+++ b/widget-react/src/mcp-apps-modal.tsx
@@ -54,6 +54,9 @@ export interface McpAppsModalProps {
   widgetAllowFeatures: Record<string, string> | undefined;
   widgetCspDirectives: Record<string, string[]> | undefined;
   widgetCspSubtypePolicy: CspSubtypePolicy | undefined;
+  widgetBrowserStorage:
+    | { localStorage?: boolean; sessionStorage?: boolean; indexedDB?: boolean }
+    | undefined;
   hostContextRef: React.RefObject<McpUiHostContext | null>;
   serverId: string;
   resourceUri: string;
@@ -126,6 +129,7 @@ export function McpAppsModal({
   widgetAllowFeatures,
   widgetCspDirectives,
   widgetCspSubtypePolicy,
+  widgetBrowserStorage,
   hostContextRef,
   serverId,
   resourceUri,
@@ -443,6 +447,7 @@ export function McpAppsModal({
             allowFeatures={widgetAllowFeatures}
             cspDirectives={widgetCspDirectives}
             cspSubtypePolicy={widgetCspSubtypePolicy}
+            browserStorage={widgetBrowserStorage}
             colorScheme={modalColorScheme}
             onMessage={handleModalMessage}
             title={`MCP App Modal: ${title}`}

--- a/widget-react/src/mcp-apps-renderer.tsx
+++ b/widget-react/src/mcp-apps-renderer.tsx
@@ -9,6 +9,7 @@
  * Uses SandboxedIframe for DRY double-iframe setup.
  */
 
+import type { BrowserStoragePolicy } from "@mcpjam/sdk/widget-runtime";
 import {
   useRef,
   useState,
@@ -2636,9 +2637,7 @@ export function MCPAppsRendererSurface({
     allowFeatures: Record<string, string> | undefined;
     cspDirectives: Record<string, string[]> | undefined;
     cspSubtypePolicy: CspSubtypePolicy | undefined;
-    browserStorage:
-      | { localStorage?: boolean; sessionStorage?: boolean; indexedDB?: boolean }
-      | undefined;
+    browserStorage: BrowserStoragePolicy | undefined;
   }>(() => {
     const cspSubtypePolicy: CspSubtypePolicy | undefined =
       earlyEffectiveMcpAppsCapabilities.cspConnectDomains ||

--- a/widget-react/src/mcp-apps-renderer.tsx
+++ b/widget-react/src/mcp-apps-renderer.tsx
@@ -2557,6 +2557,13 @@ export function MCPAppsRendererSurface({
     () => profileSandbox?.csp?.cspDirectives,
     [activeMcpProfileKey]
   );
+  // Browser storage availability, straight from the profile like the knobs
+  // above. Deliberately NOT folded into `cspSubtypePolicy`: storage is not a
+  // CSP concern, and its guard applies in permissive mode too.
+  const browserStoragePolicy = useMemo(
+    () => profileSandbox?.browserStorage,
+    [activeMcpProfileKey]
+  );
   // Hosted-mode clamp for cspDirectives. The resolver's
   // `hostedClampExtraDeny` strips MCPJam app/API origins from the
   // widget-declared CSP (`restrictTo` + resource declaration), but
@@ -2629,6 +2636,9 @@ export function MCPAppsRendererSurface({
     allowFeatures: Record<string, string> | undefined;
     cspDirectives: Record<string, string[]> | undefined;
     cspSubtypePolicy: CspSubtypePolicy | undefined;
+    browserStorage:
+      | { localStorage?: boolean; sessionStorage?: boolean; indexedDB?: boolean }
+      | undefined;
   }>(() => {
     const cspSubtypePolicy: CspSubtypePolicy | undefined =
       earlyEffectiveMcpAppsCapabilities.cspConnectDomains ||
@@ -2768,6 +2778,10 @@ export function MCPAppsRendererSurface({
         allowFeatures: allowFeaturesPolicy,
         cspDirectives: cspDirectivesEffective,
         cspSubtypePolicy: undefined,
+        // Unlike `cspSubtypePolicy` above, storage is NOT dropped in
+        // permissive mode: a host that serves no CSP can still deny storage,
+        // and the proxy arms the guard on both branches.
+        browserStorage: browserStoragePolicy,
       };
     }
 
@@ -2934,6 +2948,7 @@ export function MCPAppsRendererSurface({
       allowFeatures: allowFeaturesPolicy,
       cspDirectives: cspDirectivesEffective,
       cspSubtypePolicy: effectiveCspSubtypePolicy,
+      browserStorage: browserStoragePolicy,
     };
   }, [
     cspMode,
@@ -2948,6 +2963,7 @@ export function MCPAppsRendererSurface({
     sandboxAttrsPolicy,
     allowFeaturesPolicy,
     cspDirectivesEffective,
+    browserStoragePolicy,
     earlyEffectiveMcpAppsCapabilities.cspConnectDomains,
     earlyEffectiveMcpAppsCapabilities.cspResourceDomains,
   ]);
@@ -4164,6 +4180,7 @@ export function MCPAppsRendererSurface({
       allowFeatures={effectiveSandbox.allowFeatures}
       cspDirectives={effectiveSandbox.cspDirectives}
       cspSubtypePolicy={effectiveSandbox.cspSubtypePolicy}
+      browserStorage={effectiveSandbox.browserStorage}
       colorScheme={resolvedTheme}
       recordMode={recordMode}
       onProxyReady={() => {
@@ -4354,6 +4371,7 @@ export function MCPAppsRendererSurface({
         widgetAllowFeatures={effectiveSandbox.allowFeatures}
         widgetCspDirectives={effectiveSandbox.cspDirectives}
         widgetCspSubtypePolicy={effectiveSandbox.cspSubtypePolicy}
+        widgetBrowserStorage={effectiveSandbox.browserStorage}
         hostContextRef={hostContextRef}
         serverId={serverId}
         resourceUri={resourceUri}

--- a/widget-react/src/mcp-apps-renderer.tsx
+++ b/widget-react/src/mcp-apps-renderer.tsx
@@ -4372,6 +4372,7 @@ export function MCPAppsRendererSurface({
         widgetCspDirectives={effectiveSandbox.cspDirectives}
         widgetCspSubtypePolicy={effectiveSandbox.cspSubtypePolicy}
         widgetBrowserStorage={effectiveSandbox.browserStorage}
+        widgetToolResult={earlyEffectiveMcpAppsCapabilities.toolResult}
         hostContextRef={hostContextRef}
         serverId={serverId}
         resourceUri={resourceUri}

--- a/widget-react/src/sandboxed-iframe.tsx
+++ b/widget-react/src/sandboxed-iframe.tsx
@@ -92,6 +92,18 @@ interface SandboxedIframeProps {
   cspDirectives?: Record<string, string[]>;
   /** Probe-derived host policy for individual CSP-backed browser APIs. */
   cspSubtypePolicy?: CspSubtypePolicy;
+  /**
+   * Probe-derived host policy for browser storage inside the widget.
+   * Absent or `true` means available; `false` makes the proxy install a guard
+   * that throws `SecurityError` on access, as a real iframe without
+   * `allow-same-origin` does. Not a CSP concern — applies in permissive mode
+   * too.
+   */
+  browserStorage?: {
+    localStorage?: boolean;
+    sessionStorage?: boolean;
+    indexedDB?: boolean;
+  };
   /** Skip CSP injection entirely (for permissive/testing mode) */
   permissive?: boolean;
   /**
@@ -149,6 +161,7 @@ export const SandboxedIframe = forwardRef<
     allowFeatures,
     cspDirectives,
     cspSubtypePolicy,
+    browserStorage,
     permissive,
     recordMode,
     onProxyReady,
@@ -351,6 +364,7 @@ export const SandboxedIframe = forwardRef<
         csp: csp ?? null,
         cspDirectives: cspDirectives ?? null,
         cspSubtypePolicy: cspSubtypePolicy ?? null,
+        browserStorage: browserStorage ?? null,
         html: html ?? null,
         permissive: permissive ?? null,
         permissions: permissions ?? null,
@@ -364,6 +378,7 @@ export const SandboxedIframe = forwardRef<
       csp,
       cspDirectives,
       cspSubtypePolicy,
+      browserStorage,
       html,
       permissive,
       permissions,
@@ -403,6 +418,7 @@ export const SandboxedIframe = forwardRef<
           // field.
           cspDirectives,
           cspSubtypePolicy,
+          browserStorage,
           permissive,
           colorScheme,
           recordMode,

--- a/widget-react/src/sandboxed-iframe.tsx
+++ b/widget-react/src/sandboxed-iframe.tsx
@@ -13,6 +13,7 @@
  * and potentially future OpenAI SDK consolidation.
  */
 
+import type { BrowserStoragePolicy } from "@mcpjam/sdk/widget-runtime";
 import {
   stableStringifyJson,
   buildOuterAllowAttribute,
@@ -99,11 +100,7 @@ interface SandboxedIframeProps {
    * `allow-same-origin` does. Not a CSP concern — applies in permissive mode
    * too.
    */
-  browserStorage?: {
-    localStorage?: boolean;
-    sessionStorage?: boolean;
-    indexedDB?: boolean;
-  };
+  browserStorage?: BrowserStoragePolicy;
   /** Skip CSP injection entirely (for permissive/testing mode) */
   permissive?: boolean;
   /**

--- a/widget-react/src/useToolInputStreaming.ts
+++ b/widget-react/src/useToolInputStreaming.ts
@@ -15,6 +15,8 @@ import {
   useEffect,
   useLayoutEffect,
 } from "react";
+import { applyToolResultPolicy } from "@mcpjam/sdk/widget-runtime";
+import type { CallToolResult } from "@modelcontextprotocol/client";
 import type { AppBridge } from "@modelcontextprotocol/ext-apps/app-bridge";
 // Re-exported from the WidgetHost contract module so this cluster file stays
 // free of `@/lib/client-styles` (Tier-B guard).
@@ -475,12 +477,28 @@ export function useToolInputStreaming({
     const outputKey = `${toolCallId}:${serialized}`;
     if (lastToolOutputRef.current === outputKey) return;
     lastToolOutputRef.current = outputKey;
+    // Same host policy the widget's OWN tool calls go through
+    // (host-app-bridge `oncalltool`): a host that strips `structuredContent`
+    // strips it from the result the widget is born with too, not just from
+    // results it fetches later.
+    const shaped = applyToolResultPolicy(
+      toolOutput as Partial<CallToolResult>,
+      mcpAppsCapabilitiesRef.current?.toolResult,
+    );
     // Apps-compat seam (§1D): cast to the bridge's own CallToolResult
     // (ext-apps v1-sdk peer) rather than the v2 client's nominal type.
     bridge.sendToolResult(
-      toolOutput as Parameters<typeof bridge.sendToolResult>[0],
+      shaped as Parameters<typeof bridge.sendToolResult>[0],
     );
-  }, [isReady, toolCallId, toolOutput, toolState, bridgeRef, reinitCount]);
+  }, [
+    isReady,
+    toolCallId,
+    toolOutput,
+    toolState,
+    bridgeRef,
+    reinitCount,
+    mcpAppsCapabilitiesRef,
+  ]);
 
   // 7. Tool error/cancellation delivery
   useEffect(() => {

--- a/widget-react/src/widget-host.ts
+++ b/widget-react/src/widget-host.ts
@@ -466,6 +466,17 @@ export interface WidgetHostProfileSandbox {
   permissions?: SandboxPermissionsPolicy;
   sandboxAttrs?: string[];
   allowFeatures?: Record<string, string>;
+  /**
+   * Probe-measured browser-storage availability inside the widget iframe.
+   * Absent or `true` = available; `false` makes the sandbox proxy throw
+   * `SecurityError` on access. This projection is minimal by design, so a
+   * field missing here silently disappears before reaching the renderer.
+   */
+  browserStorage?: {
+    localStorage?: boolean;
+    sessionStorage?: boolean;
+    indexedDB?: boolean;
+  };
 }
 
 /**

--- a/widget-react/src/widget-host.ts
+++ b/widget-react/src/widget-host.ts
@@ -7,6 +7,7 @@
 //
 // These types are STRUCTURAL replicas of the inspector shapes (the profile/store
 // systems stay in the inspector by design, so the package can't import them).
+import type { ToolResultPolicy } from "@mcpjam/sdk/widget-runtime";
 // Drift-safety is enforced by the inspector's `use-widget-host.ts` adapter:
 // it builds the host from the real stores/resolvers and returns it typed as this
 // contract, so any source-shape drift fails typecheck there.
@@ -149,6 +150,11 @@ export type ResolvedMcpAppsCapabilities = {
   cspBaseUriDomains: boolean;
   cspConnectDomains?: McpAppsCspConnectDomains;
   cspResourceDomains?: McpAppsCspResourceDomains;
+  /**
+   * Which halves of a tool result reach a widget. Optional like the CSP
+   * subtype records above: absent means the host forwards everything.
+   */
+  toolResult?: ToolResultPolicy;
   resourcePrefersBorder: boolean;
   downloadFile: boolean;
   requestTeardown: boolean;

--- a/widget-react/src/widget-host.ts
+++ b/widget-react/src/widget-host.ts
@@ -7,7 +7,10 @@
 //
 // These types are STRUCTURAL replicas of the inspector shapes (the profile/store
 // systems stay in the inspector by design, so the package can't import them).
-import type { ToolResultPolicy } from "@mcpjam/sdk/widget-runtime";
+import type {
+  BrowserStoragePolicy,
+  ToolResultPolicy,
+} from "@mcpjam/sdk/widget-runtime";
 // Drift-safety is enforced by the inspector's `use-widget-host.ts` adapter:
 // it builds the host from the real stores/resolvers and returns it typed as this
 // contract, so any source-shape drift fails typecheck there.
@@ -478,11 +481,7 @@ export interface WidgetHostProfileSandbox {
    * `SecurityError` on access. This projection is minimal by design, so a
    * field missing here silently disappears before reaching the renderer.
    */
-  browserStorage?: {
-    localStorage?: boolean;
-    sessionStorage?: boolean;
-    indexedDB?: boolean;
-  };
+  browserStorage?: BrowserStoragePolicy;
 }
 
 /**


### PR DESCRIPTION
## Summary
Adds the host-config fields for prober's new client measurements, and fills ChatGPT's template with real probed values. The SDK's `HostConfigMcpProfileV1` is the canonical source the backend hand-mirrors — companion PR: [MCPJam/mcpjam-backend#1123](https://github.com/MCPJam/mcpjam-backend/pull/1123).

### New fields
- `mcpProfile.toolListChanged?: { listens?, refetches? }` — whether a client opens the server→client `notifications/tools/list_changed` channel and re-fetches `tools/list` after it.
- `mcpProfile.apps.mcpAppsOverrides.toolResult?: { structuredContent?, content?: { text?, image?, audio?, resource?, resourceLink? } }` — what a **widget** receives of a tool result when it calls a tool itself. Cursor 3.4 strips `structuredContent`.
- `mcpProfile.apps.sandbox.storage?: { localStorage?, sessionStorage?, indexedDB? }` — whether web storage works inside the widget iframe. A browser-sandbox fact, so it sits beside `csp`/`permissions`.

All follow the existing client-conformance-knob discipline (see `paginationTraversal`, `cspConnectDomains`): optional, validated, absent → spec-conforming default → pre-feature rows keep their hash.

### Why `toolResult.content` is not a duplicate
Three distinct axes, documented on the type so they don't get merged later:
| Field | Axis |
| --- | --- |
| `modelVisibleMcpToolResults` | what the **model** sees (existing) |
| `mcpToolResultImageRendering` | what **mcpjam's own chat UI** renders (existing) |
| `toolResult.content` | what a **widget** receives (new) |

The existing caniuse image rows come from a separate fixture server that measures the first two axes by human judgement; it has no widget, no `structuredContent`, and no storage probing.

### ChatGPT template — measured values (2026-08-24 capture, 2026-07-28 lane)
- `paginationTraversal: "full"` — walked `nextCursor` to page two
- `toolListChanged: { listens: false }` — never opened `subscriptions/listen`; `refetches` deliberately absent, unprovable while nothing is delivered
- `toolResult` — all five content kinds and `structuredContent` forwarded, identity-checked against fingerprints
- `sandbox.storage` — all three APIs available

Also extends `mcpAppsCapabilitiesSchema` in `host-compat/catalog-schema.ts`; that file has a compile-time drift guard against `McpAppsCapabilities` that fails the build otherwise. (`sandbox` is `.passthrough()` in the catalog schema, so `storage` needs no mirror there.)

## Test plan
- [x] `npm run typecheck` (sdk)
- [x] Full sdk suite: **6009 passed**, 8 skipped (286 files)
- [x] New round-trip / hash-stability / unknown-key tests for every field
- [x] Golden template snapshot re-blessed; diff is pure additions confined to ChatGPT's two theme variants

## Not in this PR
- Runtime **enforcement** of the new knobs (filtering at the host→widget bridge, storage guard script) — follow-up.
- `progressToken` — prober must first separate model-initiated from widget-proxied calls; ChatGPT's "sometimes 10/13" is an artifact of pooling them.
- caniuse rows — `neutral` currently renders "Not supported", so an unprobed-host provenance gate is needed first.