### PR TITLE
fix(conformance): protocol suite entry mapping + JSON-safe report persistence

### DIFF
--- a/.changeset/conformance-run-protocol-entry-and-error-serialization.md
+++ b/.changeset/conformance-run-protocol-entry-and-error-serialization.md
@@ -1,0 +1,25 @@
+---
+"@mcpjam/inspector": patch
+"@mcpjam/sdk": patch
+---
+
+Fix two hosted conformance-run bugs found live against an OAuth-protected server.
+
+The protocol suite could never start from `runConformance`: the suite entry
+spread the server config (which carries `url`) into `MCPConformanceConfig`
+(which needs `serverUrl`), so normalization crashed with `Cannot read
+properties of undefined (reading 'trim')` before dialing anything and the run
+recorded a bare `protocol-could-not-run` skip. The HTTP fields are now mapped
+explicitly, an absent `protocolVersion` keeps the default negotiation path,
+and a missing `serverUrl` reports the clear configuration error instead of a
+TypeError.
+
+Finished suite reports also no longer get destroyed at persistence. Checks
+used to attach the raw thrown value (e.g. an `MCPAuthError` class instance)
+as `details.errorDetails`; Convex rejected the whole report ("is not a
+supported Convex type") and the executor replaced the finished report with a
+`could-not-run` skip. Error payloads are now converted to plain JSON-safe
+data at the producer (own enumerable props plus name/message/code/statusCode),
+the executor deep-sanitizes every report at the persistence boundary, and if
+a report body still cannot be written the run keeps the suite's real verdict
+and score instead of fabricating a could-not-run result.

--- a/mcpjam-inspector/server/services/__tests__/conformance-run-executor.test.ts
+++ b/mcpjam-inspector/server/services/__tests__/conformance-run-executor.test.ts
@@ -114,6 +114,185 @@ describe("executePersistedConformanceRun replay", () => {
     expect(runConformanceMock).not.toHaveBeenCalled();
   });
 
+  it("sanitizes report payloads at the persistence boundary", async () => {
+    // A live run against an OAuth-protected server put a raw MCPAuthError
+    // instance into details.errorDetails; the Convex write rejected the whole
+    // FINISHED report ("is not a supported Convex type") and the failure path
+    // replaced it with a could-not-run skip. The upsert must only ever see
+    // plain JSON data.
+    const { action } = convexClient({
+      runId: "run_1",
+      reused: false,
+      status: "queued",
+    });
+    class FakeAuthError extends Error {
+      readonly code = "AUTH_ERROR";
+      constructor(
+        message: string,
+        readonly statusCode: number
+      ) {
+        super(message);
+        this.name = "MCPAuthError";
+      }
+    }
+    const report = {
+      schemaVersion: 1,
+      kind: "apps-conformance",
+      name: "apps",
+      passed: false,
+      outcome: "failed",
+      durationMs: 5,
+      groups: [
+        {
+          id: "apps",
+          title: "Apps",
+          target: "",
+          passed: false,
+          durationMs: 5,
+          cases: [
+            {
+              id: "ui-tools-present",
+              title: "UI Tools Present",
+              status: "failed",
+              durationMs: 5,
+              category: "tools",
+              error: "HTTP 401",
+              details: { errorDetails: new FakeAuthError("HTTP 401", 401) },
+            },
+          ],
+        },
+      ],
+    };
+    runConformanceMock.mockImplementation(
+      async (config: {
+        onProgress?: (event: unknown) => Promise<void>;
+      }) => {
+        await config.onProgress?.({
+          suiteKind: "apps",
+          status: "completed",
+          report,
+        });
+        return { outcome: "failed", score: { score: 0 } };
+      }
+    );
+
+    await executePersistedConformanceRun({
+      convexToken: "tok",
+      projectId: "p1",
+      server: SERVER as never,
+      suites: ["apps"],
+      source: "api",
+      target: { kind: "server", serverId: "s1" },
+    });
+
+    const upsert = action.mock.calls.find(
+      (call) => (call as unknown[])[0] === "conformanceRuns:upsertReportAction"
+    ) as unknown as
+      | [string, { report: typeof report; status: string }]
+      | undefined;
+    expect(upsert).toBeDefined();
+    expect(upsert![1].status).toBe("completed");
+    const persistedDetails = upsert![1].report.groups[0]!.cases[0]!
+      .details as unknown as { errorDetails: Record<string, unknown> };
+    expect(persistedDetails.errorDetails).toEqual({
+      name: "MCPAuthError",
+      message: "HTTP 401",
+      code: "AUTH_ERROR",
+      statusCode: 401,
+    });
+    expect(Object.getPrototypeOf(persistedDetails.errorDetails)).toBe(
+      Object.prototype
+    );
+    expect(() => JSON.stringify(upsert![1].report)).not.toThrow();
+  });
+
+  it("keeps a finished suite's verdict when its report body cannot be persisted", async () => {
+    const mutation = vi.fn(async (fn: string) => {
+      if (fn === "conformanceRuns:startRun") {
+        return { runId: "run_1", reused: false, status: "queued" };
+      }
+      if (fn === "conformanceRuns:finalizeRun") {
+        return { outcome: "failed", score: 37 };
+      }
+      return {};
+    });
+    const action = vi
+      .fn()
+      .mockRejectedValueOnce(
+        new Error(
+          "Validator error: MCPAuthError {} is not a supported Convex type"
+        )
+      )
+      .mockResolvedValue(undefined);
+    createConvexClientMock.mockReturnValue({ mutation, action });
+
+    const report = {
+      schemaVersion: 1,
+      kind: "apps-conformance",
+      name: "apps",
+      passed: false,
+      outcome: "failed",
+      score: { score: 37 },
+      durationMs: 9,
+      groups: [
+        {
+          id: "apps",
+          title: "Apps",
+          target: "",
+          passed: false,
+          durationMs: 9,
+          cases: [],
+        },
+      ],
+    };
+    runConformanceMock.mockImplementation(
+      async (config: {
+        onProgress?: (event: unknown) => Promise<void>;
+      }) => {
+        await config.onProgress?.({
+          suiteKind: "apps",
+          status: "completed",
+          report,
+        });
+        return { outcome: "failed", score: { score: 37 } };
+      }
+    );
+
+    await executePersistedConformanceRun({
+      convexToken: "tok",
+      projectId: "p1",
+      server: SERVER as never,
+      suites: ["apps"],
+      source: "api",
+      target: { kind: "server", serverId: "s1" },
+    });
+
+    const upserts = action.mock.calls.filter(
+      (call) => call[0] === "conformanceRuns:upsertReportAction"
+    );
+    expect(upserts).toHaveLength(2);
+    const fallback = upserts[1]![1] as {
+      status: string;
+      report: {
+        passed: boolean;
+        outcome?: string;
+        score?: { score: number };
+        groups: Array<{ cases: Array<{ id: string; error?: string }> }>;
+      };
+    };
+    // The verdict survives — never rewritten as a could-not-run failure.
+    expect(fallback.status).toBe("completed");
+    expect(fallback.report.passed).toBe(false);
+    expect(fallback.report.outcome).toBe("failed");
+    expect(fallback.report.score?.score).toBe(37);
+    expect(fallback.report.groups[0]!.cases[0]!.id).toBe(
+      "apps-report-not-persisted"
+    );
+    expect(fallback.report.groups[0]!.cases[0]!.error).toMatch(
+      /not a supported Convex type/
+    );
+  });
+
   it("runs conformance for a freshly inserted row", async () => {
     const { mutation } = convexClient({
       runId: "run_1",

--- a/mcpjam-inspector/server/services/conformance-run-executor.ts
+++ b/mcpjam-inspector/server/services/conformance-run-executor.ts
@@ -67,6 +67,111 @@ export type ExecutePersistedConformanceResult = {
   score?: number | null;
 };
 
+/**
+ * Deep-copy a report into plain JSON-safe data before it crosses the Convex
+ * boundary. The SDK's check helpers already sanitize what they attach, but
+ * this write is where one stray class instance (a live run put a raw
+ * `MCPAuthError` into `details.errorDetails`) turned a FINISHED report into a
+ * "not a supported Convex type" rejection — and the failure handler then
+ * replaced the whole report with a could-not-run skip. Kept local on purpose:
+ * the persistence boundary must hold no matter which SDK version produced the
+ * payload.
+ */
+function jsonSafeReport(value: unknown, depth = 0, seen = new WeakSet<object>()): unknown {
+  if (value === null) return null;
+  switch (typeof value) {
+    case "string":
+    case "boolean":
+      return value;
+    case "number":
+      return Number.isFinite(value) ? value : String(value);
+    case "bigint":
+      return value.toString();
+    case "undefined":
+    case "function":
+    case "symbol":
+      return undefined;
+    default:
+      break;
+  }
+  const obj = value as object;
+  if (seen.has(obj)) return "[circular]";
+  if (depth >= 16) return "[max-depth]";
+  if (obj instanceof Date) return obj.toISOString();
+  seen.add(obj);
+  try {
+    if (Array.isArray(obj)) {
+      return obj.map((entry) => jsonSafeReport(entry, depth + 1, seen) ?? null);
+    }
+    const out: Record<string, unknown> = {};
+    if (obj instanceof Error) {
+      out.name = obj.name;
+      out.message = obj.message;
+      const coded = obj as Error & { code?: unknown; statusCode?: unknown };
+      if (coded.code !== undefined) {
+        out.code = jsonSafeReport(coded.code, depth + 1, seen);
+      }
+      if (coded.statusCode !== undefined) {
+        out.statusCode = jsonSafeReport(coded.statusCode, depth + 1, seen);
+      }
+    }
+    for (const [key, entry] of Object.entries(obj)) {
+      const safe = jsonSafeReport(entry, depth + 1, seen);
+      if (safe !== undefined) out[key] = safe;
+    }
+    return out;
+  } finally {
+    seen.delete(obj);
+  }
+}
+
+/**
+ * When persisting the full report body still fails, the run must keep the
+ * finished suite's VERDICT — outcome, score, pass/fail — rather than
+ * fabricating a could-not-run skip that erases real results. Only the group
+ * detail is degraded, with one case naming the persistence failure.
+ */
+function summaryFallbackReport(
+  report: ConformanceReport,
+  kind: ConformanceSuiteKind,
+  persistError: string
+): ConformanceReport {
+  return {
+    schemaVersion: report.schemaVersion,
+    kind: report.kind,
+    name: report.name,
+    passed: report.passed,
+    ...(report.outcome !== undefined ? { outcome: report.outcome } : {}),
+    ...(report.incompleteReason !== undefined
+      ? { incompleteReason: report.incompleteReason }
+      : {}),
+    ...(report.score !== undefined
+      ? { score: jsonSafeReport(report.score) as ConformanceReport["score"] }
+      : {}),
+    durationMs: report.durationMs,
+    groups: [
+      {
+        id: "execution",
+        title: "Execution",
+        target: "",
+        passed: report.passed,
+        durationMs: report.durationMs,
+        cases: [
+          {
+            id: `${kind}-report-not-persisted`,
+            title: "Suite finished but its detailed report could not be saved",
+            status: "skipped",
+            skipReason: "could-not-run",
+            durationMs: 0,
+            category: "execution",
+            error: persistError,
+          },
+        ],
+      },
+    ],
+  };
+}
+
 function syntheticIncompleteReport(
   kind: ConformanceSuiteKind,
   error: string
@@ -200,16 +305,56 @@ export async function executePersistedConformanceRun(
                   event.suiteKind,
                   event.error ?? "suite did not produce a report"
                 );
-              await client.action(
-                "conformanceRuns:upsertReportAction" as never,
-                {
-                  runId: started.runId,
-                  suiteKind: event.suiteKind,
-                  report: body,
-                  status: event.status === "completed" ? "completed" : "failed",
-                  durationMs: body.durationMs,
-                } as never
-              );
+              const status =
+                event.status === "completed" ? "completed" : "failed";
+              try {
+                await client.action(
+                  "conformanceRuns:upsertReportAction" as never,
+                  {
+                    runId: started.runId,
+                    suiteKind: event.suiteKind,
+                    report: jsonSafeReport(body),
+                    status,
+                    durationMs: body.durationMs,
+                  } as never
+                );
+              } catch (persistError) {
+                // A persistence failure must not rewrite a FINISHED suite as
+                // could-not-run: throwing here would bubble into the SDK's
+                // suite catch, which reports the suite failed with the
+                // serialization complaint as its error. Keep the verdict and
+                // degrade only the detail.
+                if (event.status !== "completed" || !event.report) {
+                  throw persistError;
+                }
+                const message =
+                  persistError instanceof Error
+                    ? persistError.message
+                    : String(persistError);
+                logger.warn(
+                  "[conformance-run] report body could not be persisted; keeping suite summary",
+                  {
+                    runId: started.runId,
+                    suiteKind: event.suiteKind,
+                    error: message,
+                  }
+                );
+                const fallback = summaryFallbackReport(
+                  event.report,
+                  event.suiteKind,
+                  message
+                );
+                await client.action(
+                  "conformanceRuns:upsertReportAction" as never,
+                  {
+                    runId: started.runId,
+                    suiteKind: event.suiteKind,
+                    report: jsonSafeReport(fallback),
+                    status,
+                    durationMs: fallback.durationMs,
+                  } as never
+                );
+              }
             },
           })
         : null;

--- a/sdk/src/apps-conformance/runner.ts
+++ b/sdk/src/apps-conformance/runner.ts
@@ -11,6 +11,7 @@ import {
   type MCPResource,
   type MCPServerConfig,
 } from "../mcp-client-manager/index.js";
+import { deepJsonSafe } from "../json-safe.js";
 import { withEphemeralClient } from "../operations.js";
 import {
   MCP_APPS_CHECK_IDS,
@@ -130,7 +131,11 @@ function failedResult(
     durationMs,
     error: {
       message,
-      ...(rawError === undefined ? {} : { details: rawError }),
+      // Raw thrown values are often class instances (e.g. MCPAuthError), and
+      // the persistence layer rejects those wholesale — one live instance in
+      // `errorDetails` used to destroy the entire finished report at the
+      // Convex write. Reports carry plain JSON data only.
+      ...(rawError === undefined ? {} : { details: deepJsonSafe(rawError) }),
     },
     ...(details ? { details } : {}),
     ...(warnings && warnings.length > 0 ? { warnings } : {}),

--- a/sdk/src/conformance-reporting.ts
+++ b/sdk/src/conformance-reporting.ts
@@ -11,6 +11,7 @@ import {
   scoreFromTasksResult,
   type ConformanceScore,
 } from "./conformance-score.js";
+import { deepJsonSafe } from "./json-safe.js";
 import { redactForTelemetry } from "./telemetry-redaction.js";
 import type { ConformanceProfileStamp } from "./conformance-profile.js";
 import type {
@@ -218,7 +219,11 @@ function buildDetailPayload(parts: Record<string, unknown>): unknown {
     return undefined;
   }
 
-  return Object.fromEntries(entries);
+  // Reports get persisted, and the persistence layer rejects class instances
+  // (a raw MCPAuthError in `errorDetails` used to fail the whole report
+  // write). The check helpers already sanitize what they attach; this is the
+  // shared last line for every suite's detail payload.
+  return deepJsonSafe(Object.fromEntries(entries));
 }
 
 function summarizeHttpAttempts(

--- a/sdk/src/conformance-run.ts
+++ b/sdk/src/conformance-run.ts
@@ -61,6 +61,15 @@ export type RunConformanceConfig = {
   onProgress?: (event: ConformanceRunProgress) => void | Promise<void>;
 };
 
+function isHeaderRecord(value: unknown): value is Record<string, string> {
+  return (
+    typeof value === "object" &&
+    value !== null &&
+    !Array.isArray(value) &&
+    Object.values(value).every((entry) => typeof entry === "string")
+  );
+}
+
 async function runSuite(
   kind: ConformanceSuiteKind,
   config: RunConformanceConfig,
@@ -68,8 +77,24 @@ async function runSuite(
   const server = config.server;
   switch (kind) {
     case "protocol": {
+      // MCPConformanceConfig names its target `serverUrl`, while
+      // MCPServerConfig carries `url`. Spreading the server config verbatim
+      // left `serverUrl` undefined and normalization crashed on `.trim()`
+      // before dialing anything, so map the HTTP fields explicitly. An absent
+      // `protocolVersion` stays absent: the suite then adopts the version the
+      // server actually negotiates instead of pinning one.
+      const http = server as {
+        url?: string | URL;
+        accessToken?: string;
+        requestInit?: { headers?: unknown };
+      };
+      const headers = http.requestInit?.headers;
       const result = await new MCPConformanceTest({
-        ...server,
+        ...(http.url !== undefined ? { serverUrl: String(http.url) } : {}),
+        ...(http.accessToken !== undefined
+          ? { accessToken: http.accessToken }
+          : {}),
+        ...(isHeaderRecord(headers) ? { customHeaders: headers } : {}),
         ...config.protocol,
         ...(config.protocolVersion
           ? { protocolVersion: config.protocolVersion }

--- a/sdk/src/json-safe.ts
+++ b/sdk/src/json-safe.ts
@@ -1,0 +1,121 @@
+/**
+ * JSON-safe payloads for persisted reports.
+ *
+ * Conformance checks attach the raw thrown value as `error.details` so
+ * operators can see WHY a check failed. Those reports get persisted, and the
+ * persistence layer (Convex) rejects class instances outright: a live run
+ * against an OAuth-protected server put an `MCPAuthError` instance into
+ * `details.errorDetails`, the report write failed with "is not a supported
+ * Convex type", and the executor then replaced the FINISHED report with a
+ * `could-not-run` skip. Sanitize at the producer: every value entering a
+ * report must already be plain JSON data — no class instances, no
+ * `undefined`, no functions.
+ */
+
+const MAX_DEPTH = 8;
+
+/**
+ * Deeply convert an arbitrary value into plain JSON-safe data.
+ *
+ * - Primitives pass through (`NaN`/`Infinity` and bigints become strings).
+ * - `undefined`, functions and symbols are dropped from objects and become
+ *   `null` inside arrays, matching `JSON.stringify` semantics.
+ * - Errors become plain objects carrying `name`, `message`, `code`,
+ *   `statusCode` and `cause` when present, plus their own enumerable
+ *   properties. Stacks are deliberately omitted.
+ * - Any other class instance is flattened to its own enumerable properties.
+ * - Dates and URLs become strings; Maps and Sets become arrays.
+ * - Cycles are replaced with `"[circular]"` and depth is capped so a
+ *   pathological payload cannot blow up the report.
+ */
+export function deepJsonSafe(value: unknown): unknown {
+  return jsonSafeValue(value, 0, new WeakSet());
+}
+
+function jsonSafeValue(
+  value: unknown,
+  depth: number,
+  seen: WeakSet<object>,
+): unknown {
+  if (value === null) {
+    return null;
+  }
+  switch (typeof value) {
+    case "string":
+    case "boolean":
+      return value;
+    case "number":
+      return Number.isFinite(value) ? value : String(value);
+    case "bigint":
+      return value.toString();
+    case "undefined":
+    case "function":
+    case "symbol":
+      return undefined;
+    default:
+      break;
+  }
+
+  const obj = value as object;
+  if (seen.has(obj)) {
+    return "[circular]";
+  }
+  if (depth >= MAX_DEPTH) {
+    return "[max-depth]";
+  }
+  if (obj instanceof Date) {
+    return obj.toISOString();
+  }
+  if (obj instanceof URL) {
+    return obj.toString();
+  }
+
+  seen.add(obj);
+  try {
+    if (Array.isArray(obj)) {
+      return obj.map(
+        (entry) => jsonSafeValue(entry, depth + 1, seen) ?? null,
+      );
+    }
+    if (obj instanceof Map) {
+      return [...obj.entries()].map(([key, entry]) => [
+        jsonSafeValue(key, depth + 1, seen) ?? null,
+        jsonSafeValue(entry, depth + 1, seen) ?? null,
+      ]);
+    }
+    if (obj instanceof Set) {
+      return [...obj].map(
+        (entry) => jsonSafeValue(entry, depth + 1, seen) ?? null,
+      );
+    }
+
+    const out: Record<string, unknown> = {};
+    if (obj instanceof Error) {
+      out.name = obj.name;
+      out.message = obj.message;
+      const coded = obj as Error & {
+        code?: unknown;
+        statusCode?: unknown;
+        cause?: unknown;
+      };
+      if (coded.code !== undefined) {
+        out.code = jsonSafeValue(coded.code, depth + 1, seen);
+      }
+      if (coded.statusCode !== undefined) {
+        out.statusCode = jsonSafeValue(coded.statusCode, depth + 1, seen);
+      }
+      if (coded.cause !== undefined) {
+        out.cause = jsonSafeValue(coded.cause, depth + 1, seen);
+      }
+    }
+    for (const [key, entry] of Object.entries(obj)) {
+      const safe = jsonSafeValue(entry, depth + 1, seen);
+      if (safe !== undefined) {
+        out[key] = safe;
+      }
+    }
+    return out;
+  } finally {
+    seen.delete(obj);
+  }
+}

--- a/sdk/src/mcp-conformance/checks/helpers.ts
+++ b/sdk/src/mcp-conformance/checks/helpers.ts
@@ -1,3 +1,4 @@
+import { deepJsonSafe } from "../../json-safe.js";
 import type {
   MCPCheckSkipReason, MCPCheckEra, MCPCheckResult } from "../types.js";
 
@@ -32,7 +33,11 @@ export function failedResult(
     durationMs,
     error: {
       message,
-      details: errorDetails,
+      // Raw thrown values are often class instances (e.g. MCPAuthError), and
+      // the persistence layer rejects those wholesale — one live instance in
+      // `errorDetails` used to destroy the entire finished report at the
+      // Convex write. Reports carry plain JSON data only.
+      details: deepJsonSafe(errorDetails),
     },
     details,
   };

--- a/sdk/src/mcp-conformance/validation.ts
+++ b/sdk/src/mcp-conformance/validation.ts
@@ -201,7 +201,11 @@ function normalizeFixtures(
 export function normalizeMCPConformanceConfig(
   config: MCPConformanceConfig,
 ): NormalizedMCPConformanceConfig {
-  const serverUrl = config.serverUrl.trim();
+  // A caller that forgot the field entirely must get the clear configuration
+  // error below, not a `Cannot read properties of undefined (reading 'trim')`
+  // TypeError recorded as the run's failure reason.
+  const serverUrl =
+    typeof config.serverUrl === "string" ? config.serverUrl.trim() : "";
   if (!serverUrl) {
     throw new Error("MCP conformance config requires serverUrl");
   }

--- a/sdk/src/tasks-conformance/runner.ts
+++ b/sdk/src/tasks-conformance/runner.ts
@@ -27,6 +27,7 @@ import type { TasksWire } from "../mcp-client-manager/tasks-dispatch.js";
 import { CLIENT_CAPABILITIES_META_KEY } from "../mcp-client-manager/tasks-ext.js";
 import { ensureTasksExtensionEraGateShadow } from "../mcp-client-manager/tasks-ext-era-gate.js";
 import { TASK_CREATED_META_KEY } from "../mcp-client-manager/transport-utils.js";
+import { deepJsonSafe } from "../json-safe.js";
 import { withEphemeralClient } from "../operations.js";
 import {
   buildOutcomeSummary,
@@ -211,7 +212,11 @@ function failed(
     durationMs,
     error: {
       message,
-      ...(rawError === undefined ? {} : { details: rawError }),
+      // Raw thrown values are often class instances (e.g. MCPAuthError), and
+      // the persistence layer rejects those wholesale — one live instance in
+      // `errorDetails` used to destroy the entire finished report at the
+      // Convex write. Reports carry plain JSON data only.
+      ...(rawError === undefined ? {} : { details: deepJsonSafe(rawError) }),
     },
     ...(details ? { details } : {}),
   };

--- a/sdk/tests/conformance-run.test.ts
+++ b/sdk/tests/conformance-run.test.ts
@@ -89,6 +89,46 @@ describe("conformance run bundle", () => {
     expect(detectConformanceCiMetadata({})).toBeUndefined();
   });
 
+  it("enters the protocol suite from an MCPServerConfig without a protocolVersion", async () => {
+    // Regression: the protocol case spread `server` (which has `url`) into
+    // MCPConformanceConfig (which needs `serverUrl`), so every hosted protocol
+    // run died in normalization with "Cannot read properties of undefined
+    // (reading 'trim')" and was recorded as a bare could-not-run skip. The
+    // suite must reach the server and settle like apps/tasks do — here every
+    // request answers 401, mirroring an OAuth-protected target.
+    const originalFetch = global.fetch;
+    global.fetch = vi.fn(
+      async () => new Response("Unauthorized", { status: 401 })
+    ) as never;
+    try {
+      const events: Array<{ status: string; error?: string }> = [];
+      const report = await runConformance({
+        server: { url: "http://127.0.0.1:65535/mcp" },
+        suites: ["protocol"],
+        protocol: { checkIds: ["server-initialize"], checkTimeout: 2_000 },
+        onProgress: (event) => {
+          events.push({ status: event.status, error: event.error });
+        },
+      });
+      for (const event of events) {
+        expect(event.error ?? "").not.toMatch(/reading 'trim'/);
+      }
+      expect(events.some((event) => event.status === "failed")).toBe(false);
+      const protocol = report.reports.protocol;
+      expect(protocol).toBeDefined();
+      const cases = protocol!.groups.flatMap((group) => group.cases);
+      expect(cases.length).toBeGreaterThan(0);
+      // The auth failure is reported as a check verdict with JSON-safe
+      // details, never as a suite crash.
+      expect(() => JSON.stringify(report)).not.toThrow();
+      for (const reportCase of cases) {
+        expect(reportCase.error ?? "").not.toMatch(/reading 'trim'/);
+      }
+    } finally {
+      global.fetch = originalFetch;
+    }
+  }, 30_000);
+
   it("throws when OAuth is requested without a strategy config", async () => {
     await expect(
       runConformance({

--- a/sdk/tests/json-safe.test.ts
+++ b/sdk/tests/json-safe.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, it } from "vitest";
+import { deepJsonSafe } from "../src/json-safe.js";
+import { MCPAuthError } from "../src/mcp-client-manager/errors.js";
+
+describe("deepJsonSafe", () => {
+  it("flattens an MCPAuthError instance to plain JSON-safe data", () => {
+    const safe = deepJsonSafe(new MCPAuthError("HTTP 401", 401));
+    expect(safe).toEqual({
+      name: "MCPAuthError",
+      message: "HTTP 401",
+      code: "AUTH_ERROR",
+      statusCode: 401,
+    });
+    // Plain object, not a class instance — this is exactly what the Convex
+    // write rejects otherwise.
+    expect(Object.getPrototypeOf(safe)).toBe(Object.prototype);
+    expect(JSON.parse(JSON.stringify(safe))).toEqual(safe);
+  });
+
+  it("sanitizes errors nested inside detail payloads", () => {
+    const cause = new Error("socket closed");
+    const safe = deepJsonSafe({
+      attempt: 1,
+      error: new MCPAuthError("HTTP 401", 401, { cause }),
+      missing: undefined,
+      fn: () => "never",
+    }) as Record<string, unknown>;
+    expect(safe.attempt).toBe(1);
+    expect(safe.error).toMatchObject({
+      name: "MCPAuthError",
+      statusCode: 401,
+      cause: { name: "Error", message: "socket closed" },
+    });
+    expect("missing" in safe).toBe(false);
+    expect("fn" in safe).toBe(false);
+  });
+
+  it("handles cycles, dates, and non-finite numbers", () => {
+    const circular: Record<string, unknown> = { n: Number.NaN };
+    circular.self = circular;
+    circular.when = new Date("2026-08-24T00:00:00.000Z");
+    const safe = deepJsonSafe(circular) as Record<string, unknown>;
+    expect(safe.self).toBe("[circular]");
+    expect(safe.n).toBe("NaN");
+    expect(safe.when).toBe("2026-08-24T00:00:00.000Z");
+    expect(() => JSON.stringify(safe)).not.toThrow();
+  });
+
+  it("turns undefined array entries into null, matching JSON semantics", () => {
+    expect(deepJsonSafe([1, undefined, () => 2])).toEqual([1, null, null]);
+  });
+});


### PR DESCRIPTION
Two bugs in the hosted conformance-run pipeline, found via a live `start_conformance_run` (suites protocol+apps+tasks, no OAuth) against Linear (`https://mcp.linear.app/mcp`, answers 401 unauthenticated).

## Bug 1 — protocol suite crashed pre-auth

Observed: the protocol suite died with

```
Cannot read properties of undefined (reading 'trim')
```

and the run recorded a bare `protocol-could-not-run` skip with that text, while apps and tasks ran against the same server and failed cleanly at auth.

Root cause: `runSuite` in `sdk/src/conformance-run.ts` built the protocol suite's config by spreading the `MCPServerConfig` (which carries `url`) into `MCPConformanceConfig` (which needs `serverUrl`). `normalizeMCPConformanceConfig` then called `config.serverUrl.trim()` on `undefined` — the protocol suite could never start through `runConformance`, regardless of target.

Fix:
- Map the HTTP fields explicitly (`url` → `serverUrl`, plus `accessToken` and plain-object `requestInit.headers` → `customHeaders`), same mapping the server routes already use. An absent `protocolVersion` stays absent, so normalization keeps the default negotiation path.
- Guard `normalizeMCPConformanceConfig` so a missing `serverUrl` throws the clear "MCP conformance config requires serverUrl" error instead of a TypeError.

## Bug 2 — finished suite reports destroyed at persistence

Observed: apps and tasks produced complete reports whose failing checks carried the raw error instance in `details.errorDetails` (`{"code":"AUTH_ERROR","name":"MCPAuthError","statusCode":401}`), and the Convex write failed with

```
MCPAuthError ... is not a supported Convex type (present at path .report.groups[0].cases[0].details.errorDetails ...)
```

The executor then replaced the entire finished report with a `<suite>-could-not-run` skip whose error text was the serialization complaint.

Fix (sanitize at the producer, defense at the boundary):
- New `sdk/src/json-safe.ts` (`deepJsonSafe`): converts thrown values to plain JSON-safe data — name/message/code/statusCode/cause plus own enumerable props for errors; drops `undefined`/functions/symbols; handles cycles, depth, Dates, Maps/Sets, non-finite numbers.
- Applied where `errorDetails` is attached: the protocol check helpers, the apps runner, and the tasks runner, plus the shared `buildDetailPayload` in `conformance-reporting.ts` so every suite's detail payload (OAuth steps included) is plain JSON.
- The executor (`server/services/conformance-run-executor.ts`) deep-sanitizes every report at the Convex boundary, and if a report body still cannot be written it persists a summary report that keeps the suite's real verdict, outcome, and score instead of fabricating could-not-run.

## Tests

- `sdk/tests/json-safe.test.ts`: MCPAuthError flattens to plain data; nested/circular/undefined cases.
- `sdk/tests/conformance-run.test.ts`: the protocol suite enters from an `MCPServerConfig` with no `protocolVersion` (401-answering stub, mirroring Linear) and settles with a report instead of crashing — verified red on the unfixed code.
- `server/services/__tests__/conformance-run-executor.test.ts`: the upsert payload is JSON-safe even when a report carries an Error instance; a persistence failure keeps the finished suite's verdict/score.

All conformance-related SDK suites pass (29 files, 365 tests) and the executor suite passes (5 tests). `tsc` on the server project reports no errors in the touched files (the project has ~194 pre-existing errors elsewhere, unchanged by this PR).

Changeset included (patch for `@mcpjam/sdk` and `@mcpjam/inspector`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Dt9Hqa8Hn7KSqCrK79aLUr

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes hosted conformance execution and Convex persistence boundaries; fixes are defensive but affect how run verdicts and error details are stored and surfaced.
> 
> **Overview**
> Fixes two hosted **conformance-run** bugs found against OAuth-protected targets.
> 
> **Protocol suite could not start from `runConformance`** because server config `url` was spread into `MCPConformanceConfig` without mapping to `serverUrl`, so normalization crashed on `.trim()` and runs recorded a bare `protocol-could-not-run` skip. HTTP fields are now mapped explicitly (`url` → `serverUrl`, tokens/headers), missing `serverUrl` yields a clear config error, and omitting `protocolVersion` keeps default negotiation.
> 
> **Finished suite reports were lost at persistence** when checks attached raw error class instances (e.g. `MCPAuthError`) in `details.errorDetails`; Convex rejected the write and the executor replaced the whole report with a could-not-run skip. New **`deepJsonSafe`** sanitizes error payloads in the SDK (check helpers, apps/tasks runners, shared detail building); the executor **deep-sanitizes** every report before Convex and, if the body still cannot be saved, persists a **summary fallback** that keeps the suite’s real pass/fail, outcome, and score.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c637f1b92457850a6b8d042edc1ba523e7427faf. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes protocol suite entry mapping and makes conformance reports JSON-safe so hosted runs no longer crash pre-auth or get rewritten at persistence. Previously the protocol suite crashed on missing serverUrl mapping; now it maps HTTP fields explicitly and validates cleanly. Previously reports persisted raw Error instances and Convex rejected FINISHED reports; now we sanitize payloads and preserve the suite’s verdict even if persistence fails.

- Protocol suite: map `url`→`serverUrl`, include `accessToken` and plain-object headers→`customHeaders`; leave `protocolVersion` unset to negotiate. Guard `normalizeMCPConformanceConfig` to error clearly when `serverUrl` is missing (no TypeError).
- Reports: add `deepJsonSafe` to flatten thrown values (name/message/code/statusCode and own props); apply in protocol check helpers, apps/tasks runners, and shared detail payload builder. At the server boundary, deep-sanitize reports before upsert; on write failure, persist a summary that keeps the suite’s real outcome/score instead of fabricating could-not-run.
- Tests: cover protocol entry regression, JSON-safety for error payloads (including circular/undefined cases), and executor behavior on persistence failure.

- Rollout: no migrations. Error payloads in reports are now plain JSON objects (not class instances). Patch releases: `@mcpjam/sdk`, `@mcpjam/inspector`.

<sup>Written for commit c637f1b92457850a6b8d042edc1ba523e7427faf. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/MCPJam/inspector/pull/4333?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

