### PR TITLE
fix(connect): wait for AuthKit before claiming a handoff link

### DIFF
--- a/.changeset/connect-handoff-waits-for-authkit.md
+++ b/.changeset/connect-handoff-waits-for-authkit.md
@@ -1,0 +1,25 @@
+---
+"@mcpjam/inspector": patch
+---
+
+Fix the connect handoff telling a signed-in owner to sign in, forever.
+
+Opening a `/connect/server/<token>` link while correctly signed in as the
+account that created it showed "Sign in to finish connecting" — and clicking
+Sign in came straight back to the same screen, with no way out.
+
+`AuthKitProvider` swaps its `getAccessToken` when the client finishes
+initializing; before that it is literally
+`() => Promise.reject(new LoginRequiredError())`. The page claimed the token on
+mount, and `bestEffortAccessToken` cannot tell that rejection from a genuinely
+signed-out visitor — they are the same error — so the claim went out with no
+bearer, the backend saw an anonymous caller, and refused `SIGN_IN_REQUIRED`.
+
+It looped because signing in succeeds instantly for someone who already has a
+session: AuthKit returns to the same URL (the handoff token is only stripped
+after a claim succeeds), the page cold-mounts, and hydration races the claim
+again. Every cold load of a handoff link is exactly the case that loses that
+race, which is every load that matters.
+
+The claim now waits for `useAuth().isLoading` to clear, the same gate the app
+shell already applies in two places.

--- a/mcpjam-inspector/client/src/components/server-connections/ServerConnectionHandoff.tsx
+++ b/mcpjam-inspector/client/src/components/server-connections/ServerConnectionHandoff.tsx
@@ -85,7 +85,7 @@ interface HandoffState {
  * guest-owned request exactly as before.
  */
 async function bestEffortAccessToken(
-  getAccessToken: () => Promise<string | undefined>
+  getAccessToken: () => Promise<string | undefined>,
 ): Promise<string | null> {
   try {
     const token = await getAccessToken();
@@ -104,10 +104,7 @@ async function bestEffortAccessToken(
  * lives in `details`, not in the prose.
  */
 class HandoffCallError extends Error {
-  constructor(
-    message: string,
-    readonly details?: unknown
-  ) {
+  constructor(message: string, readonly details?: unknown) {
     super(message);
     this.name = "HandoffCallError";
   }
@@ -116,7 +113,7 @@ class HandoffCallError extends Error {
 async function call<T>(
   path: string,
   body?: unknown,
-  accessToken?: string | null
+  accessToken?: string | null,
 ): Promise<T> {
   const response = await fetch(`${API}${path}`, {
     method: body === undefined ? "GET" : "POST",
@@ -139,7 +136,7 @@ async function call<T>(
   if (!response.ok) {
     throw new HandoffCallError(
       payload?.message ?? "Something went wrong. Please try again.",
-      payload?.details
+      payload?.details,
     );
   }
   if (!payload) throw new Error("The server sent an unreadable response.");
@@ -192,7 +189,9 @@ function ClaimRefusal({
     return (
       <Shell>
         <div className="space-y-2">
-          <h1 className="text-lg font-semibold">Sign in to finish connecting</h1>
+          <h1 className="text-lg font-semibold">
+            Sign in to finish connecting
+          </h1>
           <p className="text-sm text-muted-foreground">
             {owner
               ? `This connection request was created by ${owner}. Sign in to that account to continue.`
@@ -258,7 +257,13 @@ function ClaimRefusal({
 }
 
 export function ServerConnectionHandoff() {
-  const { getAccessToken, signIn, signOut, user } = useAuth();
+  const {
+    getAccessToken,
+    isLoading: isAuthLoading,
+    signIn,
+    signOut,
+    user,
+  } = useAuth();
   const [state, setState] = useState<HandoffState | null>(null);
   const [error, setError] = useState<string | null>(null);
   const [refusal, setRefusal] = useState<ClaimRefusalDetails | null>(null);
@@ -274,7 +279,25 @@ export function ServerConnectionHandoff() {
   }, []);
 
   // First load: trade the token for the cookie, then take it out of the URL.
+  //
+  // WAITS FOR AUTHKIT, and that wait is the difference between this page
+  // working and looping forever for a correctly signed-in user.
+  //
+  // `AuthKitProvider` swaps its `getAccessToken` when the client finishes
+  // initializing: before that it is literally
+  // `() => Promise.reject(new LoginRequiredError())`. `bestEffortAccessToken`
+  // cannot tell that rejection from a genuinely signed-out visitor — the two
+  // are the same error — so a claim issued during hydration went out with no
+  // bearer, the backend saw an anonymous caller, and refused with
+  // SIGN_IN_REQUIRED.
+  //
+  // Which then LOOPED, because signing in "succeeds" instantly for someone who
+  // already has a session: AuthKit returns to this same URL (the token is only
+  // stripped after a claim succeeds), the page cold-mounts, hydration races the
+  // claim again, and the same screen comes back. Every cold load of a handoff
+  // link is exactly the case that loses this race.
   useEffect(() => {
+    if (isAuthLoading) return;
     if (claimed.current) return;
     claimed.current = true;
 
@@ -290,14 +313,14 @@ export function ServerConnectionHandoff() {
             { handoffToken: route.handoffToken },
             // Only the claim carries identity. Every later step authenticates
             // with the continuation cookie, which is scoped to this request.
-            await bestEffortAccessToken(getAccessToken)
+            await bestEffortAccessToken(getAccessToken),
           );
           // `replaceState`, not push: the token URL must not be somewhere the
           // back button can return to, and it is single-use anyway.
           window.history.replaceState(
             {},
             "",
-            handoffRequestPath(result.requestId)
+            handoffRequestPath(result.requestId),
           );
         } else if (callbackMatchesPending(pending, callback)) {
           // Returned from the authorization server. The cookie travelled with
@@ -311,7 +334,7 @@ export function ServerConnectionHandoff() {
           window.history.replaceState(
             {},
             "",
-            handoffRequestPath(pending!.requestId)
+            handoffRequestPath(pending!.requestId),
           );
         }
       } catch (cause) {
@@ -328,7 +351,7 @@ export function ServerConnectionHandoff() {
       }
       await refresh();
     })();
-  }, [refresh]);
+  }, [isAuthLoading, refresh]);
 
   // Poll only while the outstanding step is someone else's.
   useEffect(() => {
@@ -350,7 +373,7 @@ export function ServerConnectionHandoff() {
         setBusy(false);
       }
     },
-    [refresh]
+    [refresh],
   );
 
   /**
@@ -368,7 +391,7 @@ export function ServerConnectionHandoff() {
     try {
       const result = await call<{ status: string }>("/cancel", {});
       setState((current) =>
-        current ? { ...current, status: result.status, live: false } : current
+        current ? { ...current, status: result.status, live: false } : current,
       );
     } catch (cause) {
       setError(cause instanceof Error ? cause.message : String(cause));
@@ -383,7 +406,7 @@ export function ServerConnectionHandoff() {
     try {
       const { authorizationUrl } = await call<{ authorizationUrl: string }>(
         "/authorize",
-        {}
+        {},
       );
       // Written before navigating, because after `assign` nothing here runs
       // again. The request id is all it holds; the authority to finish is the
@@ -413,10 +436,10 @@ export function ServerConnectionHandoff() {
     setBusy(true);
     const nonce = rememberHandoffSignInReturn(
       `${window.location.pathname}${window.location.search}`,
-      window.location.origin
+      window.location.origin,
     );
     void Promise.resolve(
-      signIn(nonce ? { state: { [HANDOFF_SIGN_IN_STATE_KEY]: nonce } } : {})
+      signIn(nonce ? { state: { [HANDOFF_SIGN_IN_STATE_KEY]: nonce } } : {}),
     ).catch((cause) => {
       setBusy(false);
       setError(cause instanceof Error ? cause.message : String(cause));
@@ -529,7 +552,7 @@ export function ServerConnectionHandoff() {
                   className="w-full rounded-md border px-3 py-2 text-left text-sm hover:bg-muted disabled:opacity-50"
                   onClick={() =>
                     void act(() =>
-                      call("/select-project", { projectId: project.id })
+                      call("/select-project", { projectId: project.id }),
                     )
                   }
                 >

--- a/mcpjam-inspector/client/src/components/server-connections/__tests__/ServerConnectionHandoff.test.tsx
+++ b/mcpjam-inspector/client/src/components/server-connections/__tests__/ServerConnectionHandoff.test.tsx
@@ -24,6 +24,7 @@ import {
   waitFor,
 } from "@testing-library/react";
 const authkit = vi.hoisted(() => ({
+  isLoading: false,
   getAccessToken: vi.fn(async (): Promise<string | undefined> => undefined),
   signIn: vi.fn(async () => undefined),
   signOut: vi.fn(async () => undefined),
@@ -34,6 +35,7 @@ const authkit = vi.hoisted(() => ({
 // only part of it this component touches.
 vi.mock("@workos-inc/authkit-react", () => ({
   useAuth: () => ({
+    isLoading: authkit.isLoading,
     getAccessToken: authkit.getAccessToken,
     signIn: authkit.signIn,
     signOut: authkit.signOut,
@@ -89,7 +91,7 @@ function mockApi(handlers: Record<string, () => unknown>) {
         });
       }
       return new Response(JSON.stringify(handler()), { status: 200 });
-    }
+    },
   );
   vi.stubGlobal("fetch", fetchMock);
   return calls;
@@ -153,15 +155,15 @@ describe("the claim", () => {
         async () =>
           new Response(JSON.stringify({ message: "That link has expired." }), {
             status: 404,
-          })
-      )
+          }),
+      ),
     );
     goTo("/connect/server/dead-token");
 
     render(<ServerConnectionHandoff />);
 
     expect(
-      await screen.findByText("That link has expired.")
+      await screen.findByText("That link has expired."),
     ).toBeInTheDocument();
   });
 });
@@ -185,7 +187,7 @@ describe("what the page shows", () => {
     await screen.findByText("Personal");
 
     expect(
-      screen.getByText("https://target.example.com/mcp?key=REDACTED")
+      screen.getByText("https://target.example.com/mcp?key=REDACTED"),
     ).toBeInTheDocument();
     expect(container.textContent).toContain("query parameters");
     expect(container.textContent).not.toContain("sk-live-99");
@@ -239,7 +241,7 @@ describe("what the page shows", () => {
     fireEvent.click(await screen.findByText("Cancel this request"));
 
     await waitFor(() =>
-      expect(screen.queryByText("Cancel this request")).not.toBeInTheDocument()
+      expect(screen.queryByText("Cancel this request")).not.toBeInTheDocument(),
     );
     // `/cancel` clears the continuation cookie — that is the point. A follow-up
     // `/state` would have nothing to authenticate with, come back 401, and show
@@ -299,7 +301,7 @@ describe("polling", () => {
       await tick(6_000);
 
       expect(
-        calls.filter((c) => c.path === "/state").length
+        calls.filter((c) => c.path === "/state").length,
       ).toBeGreaterThanOrEqual(3);
     } finally {
       vi.useRealTimers();
@@ -323,8 +325,8 @@ describe("returning from the authorization server", () => {
 
     await waitFor(() =>
       expect(
-        calls.find((call) => call.path === "/authorize/complete")
-      ).toBeDefined()
+        calls.find((call) => call.path === "/authorize/complete"),
+      ).toBeDefined(),
     );
     expect(calls.find((c) => c.path === "/authorize/complete")?.body).toEqual({
       state: "st",
@@ -337,7 +339,7 @@ describe("returning from the authorization server", () => {
     // in this tab — including one belonging to the Inspector's own OAuth flow.
     expect(readPendingAuthorization()).toBeNull();
     await waitFor(() =>
-      expect(window.location.pathname).toBe("/connect/server/request/scr_1")
+      expect(window.location.pathname).toBe("/connect/server/request/scr_1"),
     );
   });
 
@@ -352,7 +354,7 @@ describe("returning from the authorization server", () => {
     rememberPendingAuthorization("scr_1", AUTH_URL);
     goTo(
       "/oauth/callback",
-      "?error=access_denied&error_description=User+declined&state=st"
+      "?error=access_denied&error_description=User+declined&state=st",
     );
 
     render(<ServerConnectionHandoff />);
@@ -385,14 +387,14 @@ describe("proving who the visitor is", () => {
       vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
         const url = String(input);
         const headers = new Headers(
-          (init?.headers ?? undefined) as HeadersInit | undefined
+          (init?.headers ?? undefined) as HeadersInit | undefined,
         );
         seen.push({ url, auth: headers.get("authorization") });
         const path = url.replace("/api/web/server-connections", "");
         if (path === "/claim") {
           return new Response(
             JSON.stringify({ requestId: "scr_1", status: "awaiting_project" }),
-            { status: 200 }
+            { status: 200 },
           );
         }
         if (path === "/state") {
@@ -401,7 +403,7 @@ describe("proving who the visitor is", () => {
         return new Response(JSON.stringify({ message: "unhandled" }), {
           status: 500,
         });
-      })
+      }),
     );
     return seen;
   }
@@ -412,6 +414,39 @@ describe("proving who the visitor is", () => {
     goTo("/connect/server/handoff-token-abc");
 
     render(<ServerConnectionHandoff />);
+    await screen.findByText("Personal");
+
+    const claim = seen.find((entry) => entry.url.endsWith("/claim"));
+    expect(claim?.auth).toBe("Bearer access-token-value");
+  });
+
+  it("WAITS for AuthKit before claiming, so a signed-in owner is not told to sign in", async () => {
+    // The bug this pins, and it looped rather than merely failing.
+    //
+    // `AuthKitProvider` swaps `getAccessToken` when its client finishes
+    // initializing; before that it is `() => Promise.reject(LoginRequiredError)`.
+    // Claiming during that window sent no bearer, so the backend saw an
+    // anonymous caller and refused SIGN_IN_REQUIRED — and signing in returns
+    // instantly for someone who already has a session, landing back on the same
+    // URL to lose the same race again. Every cold load of a handoff link is the
+    // case that loses it.
+    authkit.isLoading = true;
+    authkit.getAccessToken.mockRejectedValue(new Error("Login required"));
+    const seen = mockWithHeaders();
+    goTo("/connect/server/handoff-token-abc");
+
+    const view = render(<ServerConnectionHandoff />);
+    // Nothing claimed yet: the page has no identity to claim WITH.
+    await act(async () => {
+      await Promise.resolve();
+    });
+    expect(seen.some((entry) => entry.url.endsWith("/claim"))).toBe(false);
+
+    // AuthKit finishes; now the token is real and the claim carries it.
+    authkit.isLoading = false;
+    authkit.getAccessToken.mockReset();
+    authkit.getAccessToken.mockResolvedValue("access-token-value");
+    view.rerender(<ServerConnectionHandoff />);
     await screen.findByText("Personal");
 
     const claim = seen.find((entry) => entry.url.endsWith("/claim"));
@@ -459,8 +494,8 @@ function refuseClaim(details: unknown, message = "Refused.") {
     "fetch",
     vi.fn(
       async () =>
-        new Response(JSON.stringify({ message, details }), { status: 403 })
-    )
+        new Response(JSON.stringify({ message, details }), { status: 403 }),
+    ),
   );
 }
 
@@ -532,9 +567,9 @@ describe("a refused claim", () => {
     // browser's history. The handoff token must be in none of those.
     expect(JSON.stringify(state)).not.toContain("handoff-token-abc");
     // The path itself stayed in same-origin storage.
-    expect(
-      takeHandoffSignInReturn(nonce, window.location.origin)
-    ).toBe("/connect/server/handoff-token-abc");
+    expect(takeHandoffSignInReturn(nonce, window.location.origin)).toBe(
+      "/connect/server/handoff-token-abc",
+    );
   });
 
   it("falls back to plain prose when the backend sent no reason", async () => {
@@ -547,7 +582,9 @@ describe("a refused claim", () => {
     render(<ServerConnectionHandoff />);
     await screen.findByText("This link cannot be used");
 
-    expect(screen.getByText("This link cannot be used right now.")).toBeTruthy();
+    expect(
+      screen.getByText("This link cannot be used right now."),
+    ).toBeTruthy();
     expect(screen.queryByRole("button", { name: "Sign in" })).toBeNull();
   });
 });


### PR DESCRIPTION
## What

Opening a `/connect/server/<token>` link while **correctly signed in as the account that created it** shows "Sign in to finish connecting" — and clicking Sign in comes straight back to the same screen, with no way out. Hit in prod against a real CLI-created link.

## Root cause

`AuthKitProvider` swaps its `getAccessToken` when the client finishes initializing. Before that it is literally:

```js
getAccessToken: () => Promise.reject(new LoginRequiredError())
```

and after, the real client method.

The page claims on **mount**, and `bestEffortAccessToken` cannot tell that rejection from a genuinely signed-out visitor — they are the same error, which is precisely why it was written to swallow it. So the claim went out with no bearer, the backend saw an anonymous caller, and refused `SIGN_IN_REQUIRED`.

## Why it loops rather than just failing

Signing in **succeeds instantly** for someone who already has a session. AuthKit returns to the same URL — the handoff token is only stripped after a claim *succeeds* — the page cold-mounts, and hydration races the claim again.

Every cold load of a handoff link loses that race, and since these arrive as pasted links, that's every load that matters. The user is left clicking a button that cannot work.

## Fix

Wait for `useAuth().isLoading` to clear before claiming. `App.tsx` already gates on that flag in two places; this page destructured everything except it.

## Test

Mounts mid-hydration, asserts **nothing** was claimed, then flips the flag and asserts the claim carries the bearer. I reverted the gate to confirm it fails without it.

58 tests green across `server-connections` + the handoff lib; client typecheck clean.

## Note

This is the failure mode #4177 set out to make recoverable — it correctly renders the "sign in" screen, but for a user who *is* signed in, so the recovery it offers cannot succeed. The screens from that work are right; they were just being handed the wrong verdict.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UPTvP8ktMFuw9YHTQ4moJF

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches the critical connect handoff path and auth timing on cold loads; scope is narrow and covered by new tests, but wrong gating could still block or mis-attribute claims.
> 
> **Overview**
> Fixes a **production loop** where a signed-in owner opening `/connect/server/<token>` always saw “Sign in to finish connecting” and Sign in returned to the same screen.
> 
> The handoff page used to **claim on mount** while AuthKit was still hydrating. Until initialization finishes, `getAccessToken` rejects with `LoginRequiredError`—the same outcome `bestEffortAccessToken` treats as “no session”—so `/claim` ran **without a bearer**, the backend answered `SIGN_IN_REQUIRED`, and an already-signed-in user could not recover because the token URL stays until claim succeeds.
> 
> **Change:** defer the initial claim (and related mount logic) until `useAuth().isLoading` is false, matching the hydration gate the main app already uses. Guest flows still claim without a header when there is no token.
> 
> Adds a regression test that asserts **no claim** while AuthKit is loading, then a claim with `Bearer` after loading completes. Includes a changeset for `@mcpjam/inspector`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9bdb58119377256ab5a5d8c97d31bfec1d8e4ec2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stops the infinite “Sign in to finish connecting” loop when opening a handoff link as its signed-in owner. Before: the page claimed on mount while `@workos-inc/authkit-react` was still loading, sent no bearer, and got `SIGN_IN_REQUIRED`. Now: it waits for `useAuth().isLoading` to clear so the claim includes a bearer and proceeds.

- Gates only the initial claim on `useAuth().isLoading`; subsequent steps are unchanged.
- Preserves guest-owned flows: still claims if access token refresh rejects.
- Adds tests that reproduce the race and verify the Authorization header; no API changes.
- Releases a patch to `@mcpjam/inspector`; no migration required.

<sup>Written for commit 9bdb58119377256ab5a5d8c97d31bfec1d8e4ec2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/MCPJam/inspector/pull/4335?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

