### PR TITLE
fix(github-checks): stop the MCP OAuth handler hijacking the bind callback

### DIFF
--- a/.changeset/github-bind-callback-oauth-hijack.md
+++ b/.changeset/github-bind-callback-oauth-hijack.md
@@ -1,0 +1,11 @@
+---
+"@mcpjam/inspector": patch
+---
+
+Stop the MCP connection OAuth handler from hijacking other routes' callbacks.
+
+The effect that completes an MCP server's OAuth flow ran on every route and treated any URL carrying `?code=` as its own. Its only exclusion was the OAuth debugger path, so the GitHub App installation bind — which returns to `/settings/integrations/github/callback` — was claimed by it too: the handler tried to complete an MCP flow that did not exist, failed with "No pending OAuth flow found", raised that toast, and then navigated away, stripping GitHub's `code` and `state` out of the URL before the route that owned them could read them. The bind page then reported "opened without the details GitHub sends", which is true and completely misleading about the cause. Connecting a GitHub account failed every time in production.
+
+The handler now declines a callback when no MCP OAuth flow is pending. That fact is derived rather than declared: both completion paths read the same pending marker and throw "No pending OAuth flow found" when it is absent, so with no marker there was never an MCP flow to complete and claiming the callback could only ever have failed. A path exclusion list was deliberately not used — it would need a new entry for every future OAuth-shaped route and would silently break whichever one nobody remembered to add.
+
+One deliberate consequence: a genuinely orphaned MCP callback, where the pending marker was lost to cleared storage or another tab, no longer raises an error toast. It was unrecoverable either way, and the message named nothing the user could act on.

--- a/mcpjam-inspector/client/src/hooks/__tests__/use-server-state.hosted-oauth.test.tsx
+++ b/mcpjam-inspector/client/src/hooks/__tests__/use-server-state.hosted-oauth.test.tsx
@@ -237,6 +237,51 @@ describe("useServerState hosted OAuth callback guards", () => {
     readStoredOAuthConfigMock.mockReturnValue({});
   });
 
+  // A `?code=` on a route this hook does not own must not be claimed. The
+  // GitHub App bind returns to `/settings/integrations/github/callback`, and
+  // this effect used to complete it as an MCP flow, fail, toast "No pending
+  // OAuth flow found", and navigate away — stripping GitHub's `code`/`state`
+  // before `GithubInstallCallbackRoute` could read them, so the bind failed
+  // 100% in production with a misleading "opened without the details GitHub
+  // sends".
+  it("leaves a GitHub App bind callback alone when no MCP flow is pending", async () => {
+    window.history.replaceState(
+      {},
+      "",
+      "/settings/integrations/github/callback?code=gh-code&state=gh-state",
+    );
+
+    renderHostedServerState();
+
+    await waitFor(() => {
+      expect(mockListServers).toHaveBeenCalled();
+    });
+
+    expect(mockHandleOAuthCallback).not.toHaveBeenCalled();
+    // The params must survive for the route that actually owns them.
+    const params = new URLSearchParams(window.location.search);
+    expect(params.get("code")).toBe("gh-code");
+    expect(params.get("state")).toBe("gh-state");
+  });
+
+  // Non-vacuity for the guard above: it must refuse only callbacks with no
+  // pending MCP flow, never disable the handler outright.
+  it("still completes an MCP callback when a flow IS pending", async () => {
+    window.history.replaceState({}, "", "/oauth/callback?code=oauth-code");
+    localStorage.setItem("mcp-oauth-pending", "asana");
+    localStorage.setItem("mcp-serverUrl-asana", "https://mcp.asana.com/sse");
+    mockHandleOAuthCallback.mockResolvedValue({
+      success: true,
+      serverName: "asana",
+    });
+
+    renderHostedServerState();
+
+    await waitFor(() => {
+      expect(mockHandleOAuthCallback).toHaveBeenCalled();
+    });
+  });
+
   it("defers hosted scenario OAuth callbacks to App.tsx", async () => {
     writeHostedOAuthPendingMarker({
       surface: "scenario",

--- a/mcpjam-inspector/client/src/hooks/use-server-state.ts
+++ b/mcpjam-inspector/client/src/hooks/use-server-state.ts
@@ -3130,16 +3130,42 @@ export function useServerState({
       if (oauthCallbackHandledRef.current) {
         return;
       }
-      oauthCallbackHandledRef.current = true;
 
-      // Dispatch "connecting" immediately so SYNC_AGENT_STATUS (which fires
-      // concurrently) cannot set the server back to "disconnected" while the
-      // token exchange is still in flight.
       // Prefer the hostedOAuthCallbackContext server name (already validated),
       // fall back to the legacy localStorage key.
       const earlyPendingName =
         hostedOAuthCallbackContext?.serverName ??
         localStorage.getItem(OAUTH_PENDING_STORAGE_KEY);
+
+      // A `?code=` in the URL is NOT proof the callback is ours. This effect
+      // runs on every route, so any other OAuth-shaped return lands here too —
+      // notably the GitHub App bind at `/settings/integrations/github/callback`,
+      // which this handler used to claim, fail, toast "No pending OAuth flow
+      // found", and then navigate away from, stripping GitHub's `code`/`state`
+      // out of the URL before the route that owned them could read them.
+      //
+      // The guard is DERIVED, not a path denylist: both completion paths read
+      // exactly this pending marker and throw "No pending OAuth flow found"
+      // when it is absent (`mcp-oauth.ts` — `handleOAuthCallback` and
+      // `completeHostedOAuthCallback`). So with no marker there is no MCP flow
+      // to complete and claiming the callback could only ever have failed. A
+      // path list would have to grow by hand for every future OAuth route and
+      // would silently break the one nobody remembered to add.
+      //
+      // Deliberate consequence: a genuinely orphaned MCP callback (marker lost
+      // to a cleared localStorage or another tab) no longer raises a toast. It
+      // was unrecoverable either way, the message named nothing the user could
+      // act on, and leaving the URL intact is more honest than navigating away
+      // from a callback we cannot attribute.
+      if (!earlyPendingName) {
+        return;
+      }
+
+      oauthCallbackHandledRef.current = true;
+
+      // Dispatch "connecting" immediately so SYNC_AGENT_STATUS (which fires
+      // concurrently) cannot set the server back to "disconnected" while the
+      // token exchange is still in flight.
       if (earlyPendingName) {
         const earlyServer = effectiveServers[earlyPendingName];
         if (earlyServer) {


### PR DESCRIPTION
## What broke

Connecting a GitHub account failed 100% in production, *after* #4288/#4290 had already fixed the auth-gating defects in that callback. This is a different, fifth defect in the same flow.

The effect at `client/src/hooks/use-server-state.ts:3092` completes an MCP server's OAuth flow. It runs on **every** route and treats any URL carrying `?code=` as its own. Its only exclusion is `isDebugOAuthCallbackPath` — the OAuth *debugger* path. It does not know `/settings/integrations/github/callback` exists.

So on the GitHub bind return it claimed the callback, tried to complete an MCP flow that was never started, threw `No pending OAuth flow found`, toasted that, and then called `navigateApp(..., { replace: true })` — stripping GitHub's `code`/`state` out of the URL before `GithubInstallCallbackRoute` could read them.

That produces both observed symptoms from one cause:

- toast: `Error completing OAuth flow: No pending OAuth flow found`
- page: *"This page finishes connecting a GitHub account, and it was opened without the details GitHub sends"* — accurate, and completely misleading about why.

## The fix, and why it is not a path list

The handler now declines a callback when no MCP OAuth flow is pending.

That fact is **derived, not declared**. Both completion paths read exactly this pending marker and throw `No pending OAuth flow found` when it is absent (`mcp-oauth.ts` — `handleOAuthCallback:3470`, `completeHostedOAuthCallback:3023`). So with no marker there is no MCP flow to complete, and claiming the callback could only ever have failed. The guard removes no working behaviour.

A path exclusion list was deliberately rejected: it would need a hand-added entry for every future OAuth-shaped route, and would silently break whichever one nobody remembered to add — the same shape as the bug being fixed here.

`App.tsx`'s hosted-OAuth interception was checked and is **not** affected: it keys off a stored pending marker and already bails when there is none.

## Deliberate consequence

A genuinely orphaned MCP callback — marker lost to cleared storage or another tab — no longer raises an error toast. It was unrecoverable either way, the message named nothing the user could act on, and leaving the URL intact is more honest than navigating away from a callback we cannot attribute. Calling this out because it is a real, if small, behaviour change.

## Tests

Two added to `use-server-state.hosted-oauth.test.tsx`:

- the regression: a GitHub bind callback with no pending MCP flow is not claimed, and `code`/`state` survive in the URL for the route that owns them
- non-vacuity: a callback **with** a pending flow still completes, so the guard cannot pass by disabling the handler

**Red-probed.** With the source fix reverted, exactly the new regression test fails (`mockHandleOAuthCallback` called once — the hijack), and the control test still passes. Full file: 10/10 green with the fix.

## Scope

Lane C, C5. Inspector-only — no backend change, no schema change, no contract change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TtFX8cVdF25V5k7YEMqcHL

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches global OAuth callback routing in hosted mode; incorrect guarding could break MCP server OAuth or leave other OAuth routes hijacked, though scope is narrow and covered by new tests.
> 
> **Overview**
> Fixes **GitHub account connection failing in production** because the global MCP OAuth callback effect in `use-server-state.ts` treated any URL with `?code=` as its own, including GitHub App returns at `/settings/integrations/github/callback`. It would fail with no pending MCP flow, toast an error, and navigate away—**stripping `code` and `state`** before the GitHub callback route could run.
> 
> The handler now **bails out when no MCP OAuth pending marker** is present (from hosted context or `mcp-oauth-pending` in localStorage), instead of claiming the callback first. That guard is derived from what the completion paths already require, not a growing path denylist. **MCP callbacks with a pending flow still complete** as before.
> 
> **Behavior change:** orphaned MCP callbacks (lost pending marker) no longer show an error toast; the URL is left intact.
> 
> Adds regression tests for the GitHub bind case and for non-vacuity when a flow is pending, plus a patch changeset for `@mcpjam/inspector`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 22afe6760810a73bb6517c1c0e4472107aa2899b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents the MCP OAuth handler from hijacking the GitHub bind callback. Previously, it claimed any URL with `?code=` on all routes, attempted an MCP completion, showed “No pending OAuth flow found,” and stripped `code`/`state`, breaking GitHub account connection.

- Uses a derived guard: only handles callbacks when an MCP OAuth pending marker exists. This avoids a brittle path denylist and leaves `/settings/integrations/github/callback` untouched.
- Intentional behavior change: orphaned MCP callbacks no longer show an error toast; the URL remains unchanged.

**Review notes**
- Tests cover both edges: GitHub bind callback is not claimed without a pending marker; MCP callback still completes when pending.
- No backend, schema, or contract changes. No migration actions required.

<sup>Written for commit 22afe6760810a73bb6517c1c0e4472107aa2899b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/MCPJam/inspector/pull/4336?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

