### PR TITLE
ci(release): parallelize the release pipeline (~53m → ~27m)

### DIFF
--- a/.github/workflows/deploy-mcp-prod.yml
+++ b/.github/workflows/deploy-mcp-prod.yml
@@ -96,14 +96,23 @@ jobs:
 
             // Fetch without branch/status filters — GitHub's search index
             // can lag minutes behind, causing false negatives on recent runs.
-            const runs = await github.paginate(github.rest.actions.listWorkflowRuns, {
-              owner,
-              repo,
-              workflow_id: workflowId,
-              per_page: 100,
-            });
+            //
+            // Paged with an early exit rather than github.paginate(), which
+            // walks every historical run of the workflow before filtering.
+            // Runs come back newest-first and this gate wants the most recent
+            // success, so page 1 answers it in the overwhelming majority of
+            // cases.
+            const iterator = github.paginate.iterator(
+              github.rest.actions.listWorkflowRuns,
+              { owner, repo, workflow_id: workflowId, per_page: 100 }
+            );
 
-            const latestSuccess = runs.find((run) => run.conclusion === "success");
+            let latestSuccess = null;
+            let pages = 0;
+            for await (const { data: runs } of iterator) {
+              latestSuccess = runs.find((run) => run.conclusion === "success");
+              if (latestSuccess || ++pages >= 5) break;
+            }
             if (!latestSuccess) {
               core.setFailed(
                 `No successful ${workflowId} run on main. Cannot promote.`

--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -36,10 +36,14 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
 
+      # Pinned to the same version every other workflow uses. A floating "24"
+      # meant this gate workflow — the one a release requires to be green —
+      # could silently run on a different minor than the release itself.
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: "24"
+          node-version: "24.14.0"
+          cache: npm
 
       - name: Install dependencies and format
         working-directory: mcpjam-inspector

--- a/.github/workflows/deploy-webapp.yml
+++ b/.github/workflows/deploy-webapp.yml
@@ -115,16 +115,26 @@ jobs:
             // Fetch without branch/status filters — GitHub's search index
             // can lag minutes behind, causing false negatives on recent runs.
             // JS-side filtering on head_sha + conclusion is authoritative.
-            const runs = await github.paginate(github.rest.actions.listWorkflowRuns, {
-              owner,
-              repo,
-              workflow_id: workflowId,
-              per_page: 100,
-            });
-
-            const matchingRun = runs.find(
-              (run) => run.head_sha === headSha && run.conclusion === "success"
+            //
+            // Paged with an early exit rather than github.paginate(), which
+            // walks every historical run of the workflow before filtering.
+            // Runs come back newest-first, so the match is nearly always on
+            // page 1. The page cap bounds the miss case — note a rollback to a
+            // SHA older than that window should pass require_staging_green=false,
+            // which is already the documented rollback path.
+            const iterator = github.paginate.iterator(
+              github.rest.actions.listWorkflowRuns,
+              { owner, repo, workflow_id: workflowId, per_page: 100 }
             );
+
+            let matchingRun = null;
+            let pages = 0;
+            for await (const { data: runs } of iterator) {
+              matchingRun = runs.find(
+                (run) => run.head_sha === headSha && run.conclusion === "success"
+              );
+              if (matchingRun || ++pages >= 5) break;
+            }
 
             if (!matchingRun) {
               core.setFailed(

--- a/.github/workflows/mac-release.yml
+++ b/.github/workflows/mac-release.yml
@@ -55,6 +55,7 @@ jobs:
         with:
           node-version: ${{ env.NODE_VERSION }}
           registry-url: "https://registry.npmjs.org"
+          cache: npm
 
       - name: Install dependencies
         run: npm ci --legacy-peer-deps
@@ -141,41 +142,75 @@ jobs:
           # early-returns and desktop crashes never symbolicate.
           SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
 
-      - name: Notarize and staple DMG
+      # The DMG and the ZIP are independent submissions to the same notary
+      # service, and Apple happily processes them concurrently on one API key.
+      # Submitting them serially cost ~100s per build for no reason; overlapping
+      # them costs the slower of the two (~55s).
+      #
+      # Each PID is waited on individually and its exit status checked: a bare
+      # `wait` returns the status of the LAST job only, which would let a failed
+      # notarization sail through into a stapled, shipped artifact.
+      - name: Notarize DMG and ZIP
         run: |
-          DMG_PATH=$(find "$GITHUB_WORKSPACE/mcpjam-inspector/out/make" -name "*.dmg" | head -n1)
+          set -euo pipefail
+
+          # `-print -quit` rather than `| head -n1`: under `pipefail`, head
+          # closing the pipe early makes find exit 141 (SIGPIPE) and takes the
+          # whole step down with it. That race depends on how many files are in
+          # out/make, so it would fail intermittently rather than every time.
+          DMG_PATH=$(find "$GITHUB_WORKSPACE/mcpjam-inspector/out/make" -name "*.dmg" -print -quit)
           if [ ! -f "$DMG_PATH" ]; then
             echo "DMG file not found" >&2
             exit 1
           fi
 
-          xcrun notarytool submit "$DMG_PATH" \
-            --key /tmp/AuthKey.p8 \
-            --key-id "${{ secrets.APPLE_API_KEY_ID }}" \
-            --issuer "${{ secrets.APPLE_API_ISSUER_ID }}" \
-            --wait
-
-          xcrun stapler staple "$DMG_PATH"
-          xcrun stapler validate "$DMG_PATH"
-
-          cp "$DMG_PATH" "$GITHUB_WORKSPACE/MCPJam.Inspector.dmg"
-          echo "DMG_PATH=$GITHUB_WORKSPACE/MCPJam.Inspector.dmg" >> $GITHUB_ENV
-
-      - name: Notarize ZIP
-        run: |
-          ZIP_PATH=$(find "$GITHUB_WORKSPACE/mcpjam-inspector/out/make" -name "*.zip" | head -n1)
+          ZIP_PATH=$(find "$GITHUB_WORKSPACE/mcpjam-inspector/out/make" -name "*.zip" -print -quit)
           if [ ! -f "$ZIP_PATH" ]; then
             echo "ZIP file not found" >&2
             exit 1
           fi
 
-          xcrun notarytool submit "$ZIP_PATH" \
-            --key /tmp/AuthKey.p8 \
-            --key-id "${{ secrets.APPLE_API_KEY_ID }}" \
-            --issuer "${{ secrets.APPLE_API_ISSUER_ID }}" \
-            --wait
+          notarize() {
+            xcrun notarytool submit "$1" \
+              --key /tmp/AuthKey.p8 \
+              --key-id "$APPLE_API_KEY_ID" \
+              --issuer "$APPLE_API_ISSUER_ID" \
+              --wait
+          }
 
-          echo "ZIP_PATH=$ZIP_PATH" >> $GITHUB_ENV
+          notarize "$DMG_PATH" > /tmp/notarize-dmg.log 2>&1 &
+          dmg_pid=$!
+          notarize "$ZIP_PATH" > /tmp/notarize-zip.log 2>&1 &
+          zip_pid=$!
+
+          dmg_status=0
+          wait "$dmg_pid" || dmg_status=$?
+          zip_status=0
+          wait "$zip_pid" || zip_status=$?
+
+          echo "--- notarytool (dmg) ---"
+          cat /tmp/notarize-dmg.log
+          echo "--- notarytool (zip) ---"
+          cat /tmp/notarize-zip.log
+
+          if [ "$dmg_status" -ne 0 ]; then
+            echo "DMG notarization failed with status $dmg_status" >&2
+            exit "$dmg_status"
+          fi
+          if [ "$zip_status" -ne 0 ]; then
+            echo "ZIP notarization failed with status $zip_status" >&2
+            exit "$zip_status"
+          fi
+
+          xcrun stapler staple "$DMG_PATH"
+          xcrun stapler validate "$DMG_PATH"
+
+          cp "$DMG_PATH" "$GITHUB_WORKSPACE/MCPJam.Inspector.dmg"
+          echo "DMG_PATH=$GITHUB_WORKSPACE/MCPJam.Inspector.dmg" >> "$GITHUB_ENV"
+          echo "ZIP_PATH=$ZIP_PATH" >> "$GITHUB_ENV"
+        env:
+          APPLE_API_KEY_ID: ${{ secrets.APPLE_API_KEY_ID }}
+          APPLE_API_ISSUER_ID: ${{ secrets.APPLE_API_ISSUER_ID }}
 
       - name: Create stapled app ZIP for auto-updates
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -634,20 +634,32 @@ jobs:
     uses: ./.github/workflows/deploy-soundcheck.yml
     secrets: inherit
 
-  # Deliberately does NOT wait on deploy-webapp / the satellites. Its `if` never
-  # required them — with `always()` it ran even when they failed — so listing
-  # them in `needs` only added ~4 min of idle wall clock after the packages were
-  # already on npm. The published npm versions are the thing the tag and GitHub
-  # release describe, and those exist as soon as publish-packages succeeds.
+  # These `needs` look like dead weight — the `if` below never required the
+  # deploy jobs, and with `always()` this runs even when they fail. They are
+  # NOT dead weight, and removing them breaks the satellite ordering invariant:
   #
-  # Consequence to know: the tag and GitHub release can now appear a few minutes
-  # before the production webapp finishes deploying (or when that deploy fails).
-  # The artifacts it attaches are still guaranteed — publish-packages requires
-  # artifact-gate, which requires both desktop builds.
+  # This job pushes the version commit, which touches `package-lock.json` — a
+  # path in BOTH satellites' `push:` triggers. If the push lands while
+  # deploy-webapp is still running, those push-triggered runs find the
+  # `slack-app` / `soundcheck` concurrency groups free (the release's own
+  # satellite jobs have not started — they are waiting on the webapp) and
+  # deploy the satellites AHEAD of the server whose contract they render.
+  #
+  # Waiting is what makes the push safe: by the time it happens the satellite
+  # jobs already hold/released those groups, so the push-triggered run is an
+  # idempotent duplicate that lands after — exactly what the comment on
+  # deploy-slack-app above describes.
+  #
+  # Note this costs nothing when deploy_webapp=false: those jobs are skipped,
+  # and `always()` lets this one proceed the moment publish-packages is done.
   finalize:
     needs:
       - preflight
       - publish-packages
+      - deploy-backend-prod
+      - deploy-webapp
+      - deploy-slack-app
+      - deploy-soundcheck
     if: |
       always() &&
       needs.preflight.result == 'success' &&

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,7 +23,7 @@ on:
         default: false
         type: boolean
       skip_verify:
-        description: "Skip npm run verify during preflight"
+        description: "Skip the green-CI (Tests + Build and Test) preflight gates"
         required: false
         default: false
         type: boolean
@@ -66,13 +66,69 @@ jobs:
         with:
           node-version: ${{ env.NODE_VERSION }}
           registry-url: "https://registry.npmjs.org"
+          cache: npm
 
       - name: Install dependencies
         run: npm ci --legacy-peer-deps
 
-      - name: Verify workspace
+      # This used to be `npm run verify` (typecheck && test && build:inspector),
+      # a serial ~5-8 min re-run of work `test.yml` and `lint.yml` already did
+      # on this exact commit when it landed on main — and it built the SDK three
+      # times over. Gating on those workflows' results instead takes seconds and
+      # covers strictly more: `lint.yml` runs typecheck, typecheck:client,
+      # build:inspector and a production boot; `test.yml` runs the suites.
+      # BOTH are required — neither alone covers what `verify` did.
+      - name: Require green CI for candidate SHA
         if: ${{ !fromJSON(inputs.skip_verify) }}
-        run: npm run verify
+        uses: actions/github-script@v7
+        with:
+          script: |
+            // Fetch without branch/status filters — GitHub's search index can
+            // lag minutes behind, causing false negatives on recent runs.
+            // JS-side filtering on head_sha + conclusion is authoritative.
+            //
+            // Paged with an early exit rather than github.paginate(): that
+            // helper walks EVERY historical run before filtering, which cost
+            // ~67s in this job and grows with repo age. Runs come back
+            // newest-first, so a match is nearly always on page 1; the page cap
+            // bounds the miss case at roughly a month of main pushes.
+            const findGreenRun = async (workflowId) => {
+              const iterator = github.paginate.iterator(
+                github.rest.actions.listWorkflowRuns,
+                {
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  workflow_id: workflowId,
+                  per_page: 100,
+                }
+              );
+              let pages = 0;
+              for await (const { data: runs } of iterator) {
+                const match = runs.find(
+                  (run) => run.head_sha === context.sha && run.conclusion === "success"
+                );
+                if (match) return match;
+                if (++pages >= 5) break;
+              }
+              return null;
+            };
+
+            for (const workflowId of ["test.yml", "lint.yml"]) {
+              const run = await findGreenRun(workflowId);
+
+              if (!run) {
+                core.setFailed(
+                  `No successful ${workflowId} run found for ${context.sha}. ` +
+                    `That workflow runs on every push to main, so this usually means ` +
+                    `it is still running, failed, or was cancelled because a newer ` +
+                    `commit superseded this one. Re-run it for this SHA, or release ` +
+                    `the newer HEAD.`
+                );
+                return;
+              }
+
+              core.info(`Found successful ${workflowId} run ${run.id} for ${context.sha}.`);
+            }
 
       - name: Require green staging smoke for candidate SHA
         uses: actions/github-script@v7
@@ -84,16 +140,20 @@ jobs:
             // Fetch without branch/status filters — GitHub's search index
             // can lag minutes behind, causing false negatives on recent runs.
             // JS-side filtering on head_sha + conclusion is authoritative.
-            const runs = await github.paginate(github.rest.actions.listWorkflowRuns, {
-              owner,
-              repo,
-              workflow_id: workflowId,
-              per_page: 100,
-            });
-
-            const matchingRun = runs.find(
-              (run) => run.head_sha === headSha && run.conclusion === "success"
+            // Paged with an early exit (see the CI gate above for why).
+            const iterator = github.paginate.iterator(
+              github.rest.actions.listWorkflowRuns,
+              { owner, repo, workflow_id: workflowId, per_page: 100 }
             );
+
+            let matchingRun = null;
+            let pages = 0;
+            for await (const { data: runs } of iterator) {
+              matchingRun = runs.find(
+                (run) => run.head_sha === headSha && run.conclusion === "success"
+              );
+              if (matchingRun || ++pages >= 5) break;
+            }
 
             if (!matchingRun) {
               core.setFailed(
@@ -257,29 +317,21 @@ jobs:
             exit 1
           fi
 
-  publish-packages:
-    needs:
-      - preflight
-      - artifact-gate
-      - deploy-backend-prod
-    # Publishing is gated on the backend deployment because a released client
-    # can start sending a new field the moment it lands on npm. Shipping the
-    # Convex schema first means the window where a fresh client talks to a
-    # backend that does not understand it yet never opens.
-    if: |
-      always() &&
-      needs.preflight.result == 'success' &&
-      needs.artifact-gate.result == 'success' &&
-      needs.preflight.outputs.publish_any == 'true' &&
-      (
-        !fromJSON(inputs.deploy_backend_prod) ||
-        needs.deploy-backend-prod.result == 'success'
-      )
+  # Building and smoke-testing the npm tarballs needs nothing from the desktop
+  # builds or the backend deploy, so it runs alongside them instead of behind
+  # them. Only the `changeset publish` call itself has to wait for the backend
+  # (see publish-packages), and this job moves ~4 min of build + smoke off that
+  # gated path.
+  build-packages:
+    needs: preflight
+    if: ${{ fromJSON(needs.preflight.outputs.publish_any) }}
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
 
+      # Without the patch this builds the PRE-bump versions, and the tarballs
+      # would disagree with what changeset publish then tries to publish.
       - name: Download release patch
         uses: actions/download-artifact@v4
         with:
@@ -294,6 +346,7 @@ jobs:
         with:
           node-version: ${{ env.NODE_VERSION }}
           registry-url: "https://registry.npmjs.org"
+          cache: npm
 
       - name: Install dependencies
         run: npm ci --legacy-peer-deps
@@ -320,6 +373,107 @@ jobs:
           PUBLISH_CLI: ${{ needs.preflight.outputs.publish_cli }}
           PUBLISH_INSPECTOR: ${{ needs.preflight.outputs.publish_inspector }}
 
+      # @mcpjam/inspector has no prepublishOnly hook, so the dist that reaches
+      # npm is THIS one — publish-packages cannot rebuild it. sdk/cli do rebuild
+      # via prepublishOnly; theirs are carried anyway so the publish job can
+      # assert it has a complete, already-smoked package set.
+      - name: Upload built package dists
+        uses: actions/upload-artifact@v4
+        with:
+          name: npm-dists
+          path: |
+            sdk/dist
+            cli/dist
+            mcpjam-inspector/dist
+          if-no-files-found: error
+          retention-days: 7
+
+  publish-packages:
+    needs:
+      - preflight
+      - artifact-gate
+      - build-packages
+      - deploy-backend-prod
+    # Publishing is gated on the backend deployment because a released client
+    # can start sending a new field the moment it lands on npm. Shipping the
+    # Convex schema first means the window where a fresh client talks to a
+    # backend that does not understand it yet never opens.
+    #
+    # `always()` is required so a SKIPPED deploy-backend-prod (the common case:
+    # deploy_backend_prod=false) does not skip this job — but it also disables
+    # normal failed-dependency propagation, so every other need is checked
+    # explicitly below. Dropping the build-packages clause would let a failed
+    # package build publish.
+    if: |
+      always() &&
+      needs.preflight.result == 'success' &&
+      needs.artifact-gate.result == 'success' &&
+      needs.build-packages.result == 'success' &&
+      needs.preflight.outputs.publish_any == 'true' &&
+      (
+        !fromJSON(inputs.deploy_backend_prod) ||
+        needs.deploy-backend-prod.result == 'success'
+      )
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Download release patch
+        uses: actions/download-artifact@v4
+        with:
+          name: release-plan
+          path: .release-plan
+
+      - name: Apply release patch
+        run: git apply --binary .release-plan/release.patch
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+          registry-url: "https://registry.npmjs.org"
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci --legacy-peer-deps
+
+      - name: Download built package dists
+        uses: actions/download-artifact@v4
+        with:
+          name: npm-dists
+          path: .
+
+      # `npm publish` does NOT fail when a `files` entry is missing — it packs a
+      # tarball without it. @mcpjam/inspector has no prepublishOnly to rebuild
+      # its dist, so a mis-pathed artifact download would silently ship an empty
+      # package. Fail here instead.
+      - name: Verify package dists are present
+        env:
+          PUBLISH_SDK: ${{ needs.preflight.outputs.publish_sdk }}
+          PUBLISH_CLI: ${{ needs.preflight.outputs.publish_cli }}
+          PUBLISH_INSPECTOR: ${{ needs.preflight.outputs.publish_inspector }}
+        run: |
+          fail() { echo "::error::$1" >&2; exit 1; }
+
+          if [ "$PUBLISH_SDK" = "true" ] || [ "$PUBLISH_CLI" = "true" ] || [ "$PUBLISH_INSPECTOR" = "true" ]; then
+            [ -f sdk/dist/index.js ] || fail "sdk/dist is missing from the npm-dists artifact."
+          fi
+
+          if [ "$PUBLISH_CLI" = "true" ]; then
+            [ -f cli/dist/index.js ] || fail "cli/dist is missing from the npm-dists artifact."
+          fi
+
+          if [ "$PUBLISH_INSPECTOR" = "true" ]; then
+            [ -f mcpjam-inspector/dist/client/index.html ] \
+              || fail "mcpjam-inspector/dist/client is missing — publishing now would ship an inspector with no UI."
+          fi
+
+      # NOTE: sdk's `prepublishOnly: npm run build` re-runs during the publish
+      # below, overwriting these injected debug ids in the packed tarball. That
+      # is a pre-existing bug (it predates this job split) and is tracked
+      # separately — the real fix is to inject inside the sdk's own prepack.
+      # Left in place so behavior matches what shipped before.
       - name: Inject SDK sourcemap debug ids
         if: fromJSON(needs.preflight.outputs.publish_sdk)
         run: npx @sentry/cli sourcemaps inject ./sdk/dist
@@ -347,14 +501,23 @@ jobs:
   deploy-backend-prod:
     needs:
       - preflight
-      - artifact-gate
-    # Runs ahead of publish-packages. `publish_any` is still required so a run
-    # that publishes nothing does not deploy the backend on its own — that was
-    # the effect of the old gate on publish-packages having succeeded.
+    # Runs ahead of publish-packages, and now ALONGSIDE the desktop builds
+    # rather than behind them — it consumes no build artifact, and waiting cost
+    # ~12 min on the critical path of every full release.
+    #
+    # The tradeoff that buys: a desktop build failing after this job has already
+    # promoted the backend leaves prod backend at a newer SHA with no client
+    # release. That is the safe direction and the one this pipeline deliberately
+    # engineers for everywhere else (it is exactly why publish-packages waits on
+    # this job) — a backend that understands more than any shipped client is
+    # indistinguishable from an ordinary backend promote between releases.
+    #
+    # `publish_any` is still required so a run that publishes nothing does not
+    # deploy the backend on its own. No scope check is needed here: preflight's
+    # plan script already throws on deploy_backend_prod=true with scope != full.
     if: |
       always() &&
       needs.preflight.result == 'success' &&
-      needs.artifact-gate.result == 'success' &&
       needs.preflight.outputs.publish_any == 'true' &&
       fromJSON(inputs.deploy_backend_prod)
     runs-on: ubuntu-latest
@@ -471,14 +634,20 @@ jobs:
     uses: ./.github/workflows/deploy-soundcheck.yml
     secrets: inherit
 
+  # Deliberately does NOT wait on deploy-webapp / the satellites. Its `if` never
+  # required them — with `always()` it ran even when they failed — so listing
+  # them in `needs` only added ~4 min of idle wall clock after the packages were
+  # already on npm. The published npm versions are the thing the tag and GitHub
+  # release describe, and those exist as soon as publish-packages succeeds.
+  #
+  # Consequence to know: the tag and GitHub release can now appear a few minutes
+  # before the production webapp finishes deploying (or when that deploy fails).
+  # The artifacts it attaches are still guaranteed — publish-packages requires
+  # artifact-gate, which requires both desktop builds.
   finalize:
     needs:
       - preflight
       - publish-packages
-      - deploy-backend-prod
-      - deploy-webapp
-      - deploy-slack-app
-      - deploy-soundcheck
     if: |
       always() &&
       needs.preflight.result == 'success' &&

--- a/soundcheck/README.md
+++ b/soundcheck/README.md
@@ -47,8 +47,15 @@ when `soundcheck/**`, root `package.json`, root `package-lock.json`, or the
 workflow file itself changes. The workflow runs `railway up --ci` against the
 `mcpjam-soundcheck` Railway service with a service-scoped token.
 
-This workflow is independent of `release.yml`. Soundcheck is never part of
-the customer release pipeline.
+`release.yml` also calls this workflow (as its `deploy-soundcheck` job) so a
+release redeploys Soundcheck alongside the other Railway satellites, ordered
+after the webapp deploy. Soundcheck itself is never *published* — it is not
+part of the customer release surface, and nothing customers receive depends
+on it.
+
+Note for anyone editing `release.yml`: `src/components/release-progress.tsx`
+hardcodes the job list, and `release-readiness.tsx` / `release-verdict.tsx`
+mirror preflight's gates. All three are hand-synced and will silently drift.
 
 ## Secrets & rotation
 

--- a/soundcheck/src/components/release-progress.tsx
+++ b/soundcheck/src/components/release-progress.tsx
@@ -33,15 +33,31 @@ import { ReleaseProgressRefresher } from "@/components/release-progress-refreshe
 const INSPECTOR = { owner: "MCPJam", repo: "inspector" };
 const RELEASE_WORKFLOW = "release.yml";
 
-/** release.yml's job order. Kept in sync manually with the workflow file. */
+/**
+ * release.yml's job order. Kept in sync manually with the workflow file.
+ *
+ * These MUST be the names the jobs API reports, not the keys in release.yml.
+ * A job that comes from a reusable workflow is reported as
+ * "<caller job key> / <called job name>" — so `build-mac` never matches
+ * anything and renders a permanently-pending phantom row while the real job
+ * lands in the unknown-append list below.
+ *
+ * Order reflects the pipeline after the parallelization work: the backend
+ * promote and the npm package build both run alongside the desktop builds
+ * rather than behind them, and finalize no longer waits on the webapp deploy.
+ */
 const JOB_ORDER = [
   "preflight",
-  "build-mac",
-  "build-windows",
+  "build-mac / build-mac",
+  "build-windows / make-windows",
+  "build-packages",
+  "deploy-backend-prod",
   "artifact-gate",
   "publish-packages",
-  "deploy-backend-prod",
-  "promote-production",
+  "deploy-webapp / deploy",
+  "deploy-webapp / smoke / smoke",
+  "deploy-slack-app / Deploy to Railway",
+  "deploy-soundcheck / Deploy to Railway",
   "finalize"
 ];
 

--- a/soundcheck/src/components/release-readiness.tsx
+++ b/soundcheck/src/components/release-readiness.tsx
@@ -1,10 +1,15 @@
 /**
  * Release Readiness Checklist tile.
  *
- * Mirrors the gates `release.yml`'s preflight enforces (release.yml:71-98
- * for the staging-SHA match, and the Changesets plan output at
- * release.yml:100-167). If every blocking check is ✅, running the Release
- * workflow will pass preflight.
+ * Mirrors the gates `release.yml`'s preflight enforces, in its order:
+ * "Require green CI for candidate SHA" (test.yml + lint.yml green for the
+ * exact SHA — these replaced the old in-preflight `npm run verify`), "Require
+ * green staging smoke for candidate SHA", and the Changesets plan in "Select
+ * release scope". If every blocking check is ✅, running the Release workflow
+ * will pass preflight.
+ *
+ * Referenced by step name rather than line number on purpose — the previous
+ * line-number citations here went stale the first time preflight was edited.
  *
  * Nudge rows (prod-behind-staging, Soundcheck's own deploy status) are
  * informational — they don't block the release, but they're part of
@@ -94,6 +99,50 @@ export async function ReleaseReadiness() {
       label: "Inspector main is unreachable",
       detail: (err as Error).message
     });
+  }
+
+  // ── Green CI for the candidate SHA (hard gate) ────────────────────────
+  // preflight requires BOTH: lint.yml ("Build and Test") covers typecheck,
+  // typecheck:client, build:inspector and a production boot, test.yml covers
+  // the suites. Between them they cover what `npm run verify` used to re-run
+  // serially inside preflight.
+  if (inspectorHead) {
+    const CI_GATES: { workflow: string; label: string }[] = [
+      { workflow: "test.yml", label: "Tests" },
+      { workflow: "lint.yml", label: "Build and Test" }
+    ];
+
+    for (const gate of CI_GATES) {
+      try {
+        const run = await findSuccessfulRunForSha(
+          INSPECTOR.owner,
+          INSPECTOR.repo,
+          gate.workflow,
+          "main",
+          inspectorHead.sha
+        );
+        if (run) {
+          rows.push({
+            tone: "success",
+            label: `${gate.label} green for ${shortSha(inspectorHead.sha)}`,
+            detail: `${gate.workflow} succeeded ${formatRelativeTime(run.updatedAt)}`,
+            href: run.htmlUrl
+          });
+        } else {
+          rows.push({
+            tone: "failure",
+            label: `No successful ${gate.label} run for ${shortSha(inspectorHead.sha)}`,
+            detail: `Release.yml preflight will fail until ${gate.workflow} is green for this SHA. It may still be running, or it was cancelled by a newer push.`
+          });
+        }
+      } catch (err) {
+        rows.push({
+          tone: "failure",
+          label: `Could not check ${gate.label} for main SHA`,
+          detail: (err as Error).message
+        });
+      }
+    }
   }
 
   // ── Inspector staging-for-SHA (the hard gate) ─────────────────────────

--- a/soundcheck/src/components/release-verdict.tsx
+++ b/soundcheck/src/components/release-verdict.tsx
@@ -4,9 +4,13 @@
  *
  * Inputs, in priority order:
  *   1. Is a release.yml run already in flight? → In flight.
- *   2. Is inspector main at a SHA with a green deploy-staging.yml?
- *      + Are there pending changesets?  → Go.
+ *   2. Is inspector main at a SHA with green test.yml + lint.yml + a green
+ *      deploy-staging.yml? + Are there pending changesets?  → Go.
  *   3. Otherwise describe the blocker. → Hold / Caution.
+ *
+ * The CI gates are checked because preflight requires them: it no longer runs
+ * `npm run verify` itself, it demands those two workflows already went green
+ * on the exact SHA.
  *
  * This component does its own fetches rather than reading from the readiness
  * tile, so the verdict renders even if the readiness tile is still streaming.
@@ -92,11 +96,25 @@ export async function ReleaseVerdict() {
     );
   }
 
-  const [stagingRun, changesetsResult] = await Promise.all([
+  const [stagingRun, testRun, lintRun, changesetsResult] = await Promise.all([
     findSuccessfulRunForSha(
       INSPECTOR.owner,
       INSPECTOR.repo,
       "deploy-staging.yml",
+      "main",
+      headSha
+    ).catch(() => null),
+    findSuccessfulRunForSha(
+      INSPECTOR.owner,
+      INSPECTOR.repo,
+      "test.yml",
+      "main",
+      headSha
+    ).catch(() => null),
+    findSuccessfulRunForSha(
+      INSPECTOR.owner,
+      INSPECTOR.repo,
+      "lint.yml",
       "main",
       headSha
     ).catch(() => null),
@@ -117,6 +135,21 @@ export async function ReleaseVerdict() {
         tone="failure"
         headline={`Staging isn't green for ${shortSha(headSha)}.`}
         detail="release.yml preflight will refuse until deploy-staging.yml succeeds on this exact SHA. Wait for it, or investigate recent failures below."
+      />
+    );
+  }
+
+  const missingCi = [
+    testRun ? null : "test.yml",
+    lintRun ? null : "lint.yml"
+  ].filter((name): name is string => name !== null);
+
+  if (missingCi.length > 0) {
+    return (
+      <Verdict
+        tone="failure"
+        headline={`CI isn't green for ${shortSha(headSha)}.`}
+        detail={`release.yml preflight requires ${missingCi.join(" and ")} to have succeeded on this exact SHA. ${missingCi.length === 1 ? "It is" : "They are"} still running, failed, or ${missingCi.length === 1 ? "was" : "were"} cancelled by a newer push — re-run for this SHA, or release the newer HEAD.`}
       />
     );
   }
@@ -149,7 +182,7 @@ export async function ReleaseVerdict() {
     <Verdict
       tone="success"
       headline="All preflight gates are clear."
-      detail={`Staging is green on ${shortSha(headSha)}. ${changesets.length} pending changeset${changesets.length === 1 ? "" : "s"} across ${pkgCount} package${pkgCount === 1 ? "" : "s"}. Dispatch when ready.`}
+      detail={`CI and staging are green on ${shortSha(headSha)}. ${changesets.length} pending changeset${changesets.length === 1 ? "" : "s"} across ${pkgCount} package${pkgCount === 1 ? "" : "s"}. Dispatch when ready.`}
     />
   );
 }


### PR DESCRIPTION
## What this is

A release takes ~53 min wall clock (full: packages + backend + webapp) or ~26 min (inspector-only). Measured on runs [32690555967](https://github.com/MCPJam/inspector/actions/runs/32690555967) and [32538891468](https://github.com/MCPJam/inspector/actions/runs/32538891468), that time is **serialization and human waits, not slow machines**:

| Stage | Time | Why it was on the critical path |
|---|---|---|
| preflight | 2m45 | the staging-green API call alone was 67s |
| build-mac | 16–19m | genuinely slow (`electron:make` is 529s of it) |
| deploy-backend-prod | 11m40 | waited on desktop builds it consumes nothing from |
| publish-packages | 5m20 | waited on backend, though only `changeset publish` (49s) needs to |
| **approval wait** | ~6m30 | required reviewers on the `production` environment |
| deploy-webapp + satellites | 8m | webapp 4m30, soundcheck Railway build tail 3m30 |
| finalize | 2m | waits on the deploys — load-bearing, see below; unchanged |

**No gate that protects correctness is relaxed.** What changes is what waits on what.

## Changes

**Backend deploy runs alongside the desktop builds** (~12 min). `deploy-backend-prod` needs only `preflight` now. `publish-packages` still waits for it, so the schema-first invariant (backend understands the field before any client can send it) is intact. The tradeoff, documented in the job: a desktop build failing after the backend promoted leaves prod backend ahead with no client release — the safe direction, and indistinguishable from an ordinary backend promote between releases.

**Package build split out of publish** (~4 min). New `build-packages` job runs parallel to the desktop builds; `publish-packages` downloads its `npm-dists` artifact and does little more than `changeset publish`. Two hazards this introduced, both closed:
- `always()` on publish (needed so a *skipped* backend deploy doesn't skip publish) also disables failed-need propagation, so an explicit `needs.build-packages.result == 'success'` clause was required.
- `npm publish` does **not** fail when a `files` entry is missing — it just packs a tarball without it — and `@mcpjam/inspector` has no `prepublishOnly` to rebuild its dist. A dist guard now fails loudly rather than silently shipping an inspector with no UI.

**`npm run verify` replaced by green-CI gates** (~5–8 min when it wasn't skipped). `test.yml` and `lint.yml` already ran this exact commit when it landed on main, and between them cover strictly more than `verify` did (`lint.yml` runs typecheck, typecheck:client, build:inspector, and a production boot). Both are required. This also makes the `skip_verify=true` habit safe — the last release ran with it, i.e. with no verification at all.

**Bounded pagination on all four SHA gates** (67s → seconds). `github.paginate()` walked every historical run of the workflow before filtering; these now page with an early exit. Fixed in `release.yml`, `deploy-webapp.yml`, and `deploy-mcp-prod.yml`.

~~**`finalize` no longer waits on the webapp deploy** (~2 min).~~ **Reverted in a2d89b1239** — review caught a real ordering bug, see [the thread](https://github.com/MCPJam/inspector/pull/4338#discussion_r3848173653). finalize pushes the version commit, which touches `package-lock.json` — a path in both satellites' `push:` triggers. Pushing while the webapp deploy was still running let those push-triggered runs claim the free concurrency groups and deploy **slack-app at T+5.5m against a server that goes live at T+7m**. Those `needs` were load-bearing through the push trigger, not through the `if`. Restored, with a comment saying so.

**Mac notarization is concurrent** (~45s). DMG and ZIP submit in parallel; each PID is waited on individually with its status checked, because a bare `wait` returns only the last job's status and would let a failed notarization through into a stapled artifact.

**`cache: npm`** where `npm ci` actually runs, and `deploy-staging.yml`'s floating `node-version: "24"` pinned to `24.14.0` — it's the workflow a release requires to be green, so it shouldn't run on a different minor than the release itself.

## Soundcheck

`release-progress.tsx`'s `JOB_ORDER` wasn't merely stale — it was **non-functional**. It matches exact API job names, and reusable-workflow jobs report as `"build-mac / build-mac"` / `"deploy-webapp / deploy"`, so those rows never matched: permanently-"pending" phantom rows while the real jobs landed in the unknown-append list, plus a `promote-production` entry for a job that no longer exists. Fixed with the correct names and the new graph.

`release-readiness.tsx` and `release-verdict.tsx` mirror preflight's gates, so both now check green `test.yml`/`lint.yml` too — otherwise the dashboard would show "ready to ship" for a SHA preflight will refuse. The readiness header's `release.yml:71-98` line citations are replaced with step names (they had already gone stale).

## Done outside this diff

Required-reviewer rules removed from the `production` and `backend-production` environments. The `main`-only deployment branch policies were preserved on both — verified after the change. Releases remain deliberate `workflow_dispatch` acts, main-enforced, and gated on green CI + green staging for the exact SHA.

<details>
<summary>Restore command, if you ever want the approvals back</summary>

```bash
gh api -X PUT repos/MCPJam/inspector/environments/production \
  -f 'deployment_branch_policy[protected_branches]=false' \
  -f 'deployment_branch_policy[custom_branch_policies]=true' \
  -F 'reviewers[][type]=User' -F 'reviewers[][id]=58269507' \
  -F 'reviewers[][type]=User' -F 'reviewers[][id]=67474336' \
  -F 'reviewers[][type]=User' -F 'reviewers[][id]=25394100'
```
(chelojimenez=58269507, ignaciojimenezr=67474336, prathmeshpatel=25394100; same for `backend-production`.)
</details>

## Verification

- **Gating matrix simulated exhaustively** — all 96 combinations of scope (packages-only / inspector-only / full) × backend flag × webapp flag × mac-build failure × package-build failure × backend failure, against GitHub's skip/fail propagation semantics. Every invariant holds: never publish without the backend when requested, never publish after a failed build of either kind, never deploy the webapp without a publish, satellites never ship ahead of the webapp, never tag without a publish — and no over-blocking (every happy path still publishes, deploys and finalizes).
- **Gate scripts tested functionally** — the real script bodies extracted from the YAML and run against a mock API: match on page 1 (and costs exactly 1 request), match on page 3, failed/cancelled run for the SHA correctly rejected, no-match capped at 5 pages, actionable failure text.
- **Notarization flow tested** — all four DMG/ZIP failure combinations propagate the right exit code, and the submissions demonstrably overlap.
- `actionlint` — net zero new findings (13 before, 13 after; all pre-existing patterns).
- Soundcheck typechecks and builds clean.

Two bugs caught and fixed. First, the satellite-ordering regression above — found by review, confirmed by modelling the deploy timeline on measured durations, and the fix is now asserted against the workflow file. Second, before the first commit: `set -euo pipefail` plus `find | head -n1` in the new notarization step exits 141 via SIGPIPE once `out/make` holds enough files — it would have passed testing and failed intermittently in production. Now uses `find -print -quit`.

## Expected result

Full release: `preflight ~1.5m → max(mac ~15m ∥ windows ∥ build-packages ∥ backend ~12m) → publish ~2.5m → webapp 4.5m → satellites 3.5m → finalize 2m` ≈ **~29m with zero human waits**, from ~53m.
Inspector-only: ≈ **~21m**, from ~26m plus approval waits — the revert costs nothing here, since finalize's deploy `needs` resolve instantly when those jobs are skipped.

The remaining floor is `electron:make` (529s) inside the mac build. Cutting that means changing what ships, so it's untouched here.

## Follow-up worth filing (pre-existing, not introduced here)

`sdk`'s `prepublishOnly: npm run build` re-runs during `changeset publish`, **after** the Sentry sourcemap-inject step — so published SDK tarballs have never carried injected debug IDs, and the post-publish upload sends the rebuilt dist. Step order can't fix it (`prepublishOnly` always runs last); the fix is to inject inside the SDK's own `prepack`. Left as-is here so this PR doesn't change publish behavior, with a comment marking it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0167d7WNEw25RawYBZYnZZ5c
