### PR TITLE
harness: Codex delivers the host's MCP servers as host-executed tools (COMP-39)

### DIFF
--- a/.changeset/codex-harness-host-executed-mcp.md
+++ b/.changeset/codex-harness-host-executed-mcp.md
@@ -1,0 +1,31 @@
+---
+"@mcpjam/inspector": minor
+---
+
+Codex hosts can now use the host's selected MCP servers.
+
+The Codex CLI does not make an MCP server's tools model-callable in the mode the
+SDK drives (`codex exec --experimental-json`) — the handshake completes and
+`tools/list` answers, but nothing becomes callable (openai/codex#19425). Writing
+`~/.codex/config.toml` merges cleanly and is a silent no-op, so MCPJam does not
+write it. Instead, each selected server's tools are enumerated at turn start and
+handed to the agent as **host-executed** tools, which the harness bridge relays
+back out of the sandbox and MCPJam executes in-process against the already
+authorized `MCPClientManager`.
+
+The adapter's `supportsSelectedMcpServers: boolean` is replaced by
+`mcpDelivery: "native" | "host-executed"`, a discriminated union in which only
+the native arm may carry `deliverMcpServers` — so the two paths are mutually
+exclusive by construction and the model can never see the same MCP tool twice.
+Projected tools are named `mcp__<server>__<tool>`, exactly as Claude Code names
+them, so traces and eval assertions attribute identically across the two
+harnesses. The `mcp-servers` pre-flight refusal (which blocked every Codex host
+with a server attached, and therefore every Codex eval suite) is gone; a Codex
+host that requires tool approval is still refused, because Codex cannot pause a
+host-executed tool.
+
+Fidelity caveat: this is not equivalent to Claude Code's native MCP client. The
+bridge injects each tool's description into the prompt and the model invokes
+them through a CLI shim, so tool-selection behavior differs from a native MCP
+client, and the tools run on MCPJam's server rather than in the sandbox. Tool
+schemas are read once per turn — there is no `tools/list_changed` subscription.

--- a/.changeset/codex-harness-host-executed-mcp.md
+++ b/.changeset/codex-harness-host-executed-mcp.md
@@ -24,6 +24,19 @@ with a server attached, and therefore every Codex eval suite) is gone; a Codex
 host that requires tool approval is still refused, because Codex cannot pause a
 host-executed tool.
 
+Scope step-up (SEP-2350) is carried on this path too. A host-executed call never
+touches the signed proxy that extracts an `insufficient_scope` challenge on the
+native path, so the projected tools observe it in-process with the same shared
+extractor and publish into the same turn-level bridge. A hosted-OAuth server that
+needs a step-up therefore pauses a Codex turn and offers re-authorization, rather
+than reporting an ordinary tool failure to the model.
+
+Tool-approval refusals no longer depend on whether MCP servers happen to be
+selected. The pre-flight and the in-turn backstop now ask one shared helper, so a
+runtime that cannot pause on its own native tools is refused under
+`requireToolApproval` either way — closing a gap where an eval or synthetic run
+(which skips the pre-flight) could execute host-executed built-ins unapproved.
+
 Fidelity caveat: this is not equivalent to Claude Code's native MCP client. The
 bridge injects each tool's description into the prompt and the model invokes
 them through a CLI shim, so tool-selection behavior differs from a native MCP

--- a/.changeset/codex-harness-host-executed-mcp.md
+++ b/.changeset/codex-harness-host-executed-mcp.md
@@ -24,12 +24,32 @@ with a server attached, and therefore every Codex eval suite) is gone; a Codex
 host that requires tool approval is still refused, because Codex cannot pause a
 host-executed tool.
 
+What the model sees is the tool's own **model-facing projection**, not the raw
+MCP result. The harness host-tool loop submits whatever `execute()` returns and
+never calls `toModelOutput`, so a projected MCP App tool would have shipped its
+client-only `_meta` and `structuredContent` straight into the model's context —
+token cost and context leakage for a payload a harness cannot render at all —
+and would have bypassed the host's `modelVisibleMcpToolResults` policy. The
+relay now carries the projection while the raw result is kept for the UI, the
+trace and the transcript, so a Codex turn still shows what the server actually
+returned.
+
 Scope step-up (SEP-2350) is carried on this path too. A host-executed call never
 touches the signed proxy that extracts an `insufficient_scope` challenge on the
 native path, so the projected tools observe it in-process with the same shared
 extractor and publish into the same turn-level bridge. A hosted-OAuth server that
 needs a step-up therefore pauses a Codex turn and offers re-authorization, rather
-than reporting an ordinary tool failure to the model.
+than reporting an ordinary tool failure to the model. The turn correlates a
+challenge to its tool call by `toolCallId` when the publisher has one, falling
+back to the (server, tool, input) tuple only for the proxy, which has no id to
+give — two identical calls in one turn used to resume the first, whichever one
+actually failed.
+
+`toolPolicy` admission is delivery-aware. It used to refuse any policied harness
+run on a deployment that could not seal the policy into a proxy token, which
+wrongly refused every policied Codex eval on a deployment whose terminal secret
+was merely too short — host-executed delivery mints no such token and enforces
+the snapshot in-process. Native delivery still fails closed exactly as before.
 
 Tool-approval refusals no longer depend on whether MCP servers happen to be
 selected. The pre-flight and the in-turn backstop now ask one shared helper, so a

--- a/.changeset/codex-harness-host-executed-mcp.md
+++ b/.changeset/codex-harness-host-executed-mcp.md
@@ -84,6 +84,23 @@ runtime that cannot pause on its own native tools is refused under
 `requireToolApproval` either way — closing a gap where an eval or synthetic run
 (which skips the pre-flight) could execute host-executed built-ins unapproved.
 
+The host editor now tells the truth about which of these knobs bite. **Respect tool
+visibility** is editable on a Codex host, because host-executed delivery honors it;
+it stays gray on Claude Code, whose CLI lists tools from inside the sandbox through
+a proxy that relays `tools/list` unmodified. Crucially, the editor no longer
+*declares* that per harness — a hardcoded `enforced: true` is a promise about
+server behavior that nothing keeps in sync, and it went stale the same day this
+projection started reading the knob. Which mode a harness uses is now stated once,
+in a module the client and the runtime registry both read, and every
+tool-construction-time control is derived from it, so changing a harness's delivery
+moves the runtime and the editor's claim about it in one edit. A test asserts the
+registry's adapters and that declaration can never disagree.
+
+The two tool-approval notes were corrected while auditing the same table. Both said
+"not enforced yet", which describes the one outcome that never happens: a harness
+host requiring approval is **refused** — before streaming on the chat routes, and by
+an in-turn backstop everywhere else — rather than run unapproved. They now say so.
+
 Fidelity caveat: this is not equivalent to Claude Code's native MCP client. The
 bridge injects each tool's description into the prompt and the model invokes
 them through a CLI shim, so tool-selection behavior differs from a native MCP

--- a/.changeset/codex-harness-host-executed-mcp.md
+++ b/.changeset/codex-harness-host-executed-mcp.md
@@ -34,6 +34,23 @@ relay now carries the projection while the raw result is kept for the UI, the
 trace and the transcript, so a Codex turn still shows what the server actually
 returned.
 
+The projection also runs under the **host's own tool-construction options**, not
+the SDK's defaults. `getToolsForAiSdk` states outright that it will not read a
+host config itself, so anything the caller does not pass is not defaulted — it is
+gone, and a Codex turn was projecting results under a `modelVisibleMcpToolResults`
+policy the host never chose. `respectToolVisibility` (SEP-1865 app-only tools)
+and the resolved MCP Tasks seam were dropped the same way, which made two
+host-level policies mean something different on host-executed delivery than on
+every other engine. All three now travel through one shared builder that the
+emulated engine and both eval runners use as well, so a surface that forgets a
+field forgets it in one visible place rather than silently at its own call site;
+with nothing set it still answers "no options", so a default turn's tools are
+byte-identical. `needsApproval` is deliberately not in that set on this path:
+host-executed approval is enforced by the harness agent's own `toolApproval` map
+(and refused outright for a runtime that cannot pause), while the AI SDK flag is
+read only by the emulated loop — passing it would add a second, inert approval
+declaration that reads like enforcement.
+
 Scope step-up (SEP-2350) is carried on this path too. A host-executed call never
 touches the signed proxy that extracts an `insufficient_scope` challenge on the
 native path, so the projected tools observe it in-process with the same shared

--- a/.changeset/codex-harness-host-executed-mcp.md
+++ b/.changeset/codex-harness-host-executed-mcp.md
@@ -51,6 +51,16 @@ host-executed approval is enforced by the harness agent's own `toolApproval` map
 read only by the emulated loop — passing it would add a second, inert approval
 declaration that reads like enforcement.
 
+Hosted **evals** reach that projection with the same policies as chat. The eval
+runner drives its turns through its own facade rather than the chat routes, and
+that facade forwarded none of the three — so a hosted Codex eval built its MCP
+tools under the SDK's defaults even though the run's own host had chosen
+otherwise, and the run measured a configuration that never existed. All three
+now travel from the run's resolved host policy and its single MCP Tasks seam
+down to the projection. Emulated evals are untouched: the fields ride the
+facade's existing harness gate, and the two the emulated engine never reads
+could not have moved it anyway.
+
 Scope step-up (SEP-2350) is carried on this path too. A host-executed call never
 touches the signed proxy that extracts an `insufficient_scope` challenge on the
 native path, so the projected tools observe it in-process with the same shared

--- a/docs/inspector/claude-code-host.mdx
+++ b/docs/inspector/claude-code-host.mdx
@@ -7,7 +7,7 @@ icon: "terminal"
 MCPJam supports two harness hosts that run a real agent runtime inside your project's Computer (a cloud Linux sandbox) instead of MCPJam's emulated chat loop. You are observing the actual runtime — its native tools, its own agent loop, its real execution behavior — not a simulation of it.
 
 - **Claude Code** — runs the real Claude Code agent with Anthropic models. Supports selected MCP servers and native tool approval.
-- **Codex** — runs the real Codex CLI agent with OpenAI gpt-5 family models. Supports skills; does not support selected MCP servers.
+- **Codex** — runs the real Codex CLI agent with OpenAI gpt-5 family models. Supports skills and selected MCP servers (through a host-executed relay — see the caveat below).
 
 <Note>
   The Claude Code and Codex hosts are available to organizations where the
@@ -20,7 +20,9 @@ MCPJam supports two harness hosts that run a real agent runtime inside your proj
 1. **Pre-flight check.** Before the stream opens, MCPJam verifies that the host can run: the model is supported by the selected harness, the Computer data plane is configured, and the host settings are ones the runtime can honor. Any failure returns a clear error before the turn starts — a turn never silently falls back to the emulated engine.
 2. **Computer wake.** The host's project Computer is reserved or woken (provisioned on first use). Both harness hosts **require** a Computer — there is no local fallback.
 3. **Credential delivery.** MCPJam installs a short-lived model credential into the sandbox's egress layer outside the VM. Neither the sandbox nor your browser ever holds a real model key. The agent runs pointed at MCPJam's model proxy, which verifies the credential and meters every generation. There is no raw-key fallback.
-4. **MCP delivery.** For Claude Code hosts, selected MCP servers are written into the session's MCP config, each pointed at MCPJam's per-server proxy tunnel — no upstream credentials enter the sandbox. Codex hosts do not support selected MCP servers.
+4. **MCP delivery.** The two harnesses deliver MCP servers differently:
+   - **Claude Code (native)** — selected MCP servers are written into the session's MCP config, each pointed at MCPJam's per-server proxy tunnel. The runtime's own MCP client connects to them and the model calls the tools through native function calling. No upstream credentials enter the sandbox.
+   - **Codex (host-executed)** — the Codex CLI does not make MCP server tools model-callable in the mode MCPJam drives ([openai/codex#19425](https://github.com/openai/codex/issues/19425)), so MCPJam instead enumerates each selected server's tools at turn start and hands them to the agent as *host-executed* tools. The bridge injects their descriptions into the prompt, the model invokes them through a CLI shim, and **MCPJam executes them on its own server** against the already-authorized connection. Nothing about your servers — no URL, no token — enters the sandbox.
 5. **The turn runs.** The agent's own loop executes; native tools run inside the sandbox; file changes land on the Computer's disk; the transcript and trace persist like any other chat.
 
 ## Host settings
@@ -44,7 +46,7 @@ MCPJam supports two harness hosts that run a real agent runtime inside your proj
 | Model | Honored — must be an MCPJam-provided OpenAI gpt-5 family model. Other models are not supported and fail closed. |
 | System prompt | Honored — passed to the runtime. |
 | Require tool approval | Not supported — the Codex runtime does not pause for tool approval. The toggle is disabled. |
-| Selected MCP servers | Not supported — Codex does not make MCP server tools model-callable. A Codex host with selected servers is rejected at pre-flight. |
+| Selected MCP servers | Honored, via a host-executed relay rather than a native MCP client. Tools are named identically to Claude Code (`mcp__<server>__<tool>`), so traces and eval assertions match across the two harnesses. See the fidelity caveat below. |
 | Skills | Honored — runtime skills are materialized into the sandbox. |
 | Temperature and other sampling controls | Not honored — the Codex runtime owns its own sampling. These controls are grayed out in the UI. |
 | Progressive tool disclosure | Not applied — the real runtime owns tool discovery. |
@@ -54,6 +56,17 @@ MCPJam supports two harness hosts that run a real agent runtime inside your proj
   for harness runs. Controls the runtime cannot honor are disabled in the UI
   rather than silently ignored.
 </Note>
+
+## Codex MCP fidelity caveat
+
+Codex's MCP support is **not** equivalent to Claude Code's, and the difference matters if you are using it to benchmark a connector:
+
+- The model does **not** call your tools through native function calling. The harness bridge injects each tool's name, description, and input schema into the prompt, and the model runs `node <shim> <toolName> '<json>'` through its built-in `bash` tool. Tool-selection behavior therefore reflects how well the model follows those shim instructions, not how a native MCP client would behave.
+- Tools execute **host-side**, in MCPJam's server process, not in the sandbox. For a remote HTTP connector the difference is small (the same outbound request, from a different origin). For a stdio/local server it is larger — the server runs where MCPJam runs, not next to the agent.
+- Tool schemas are enumerated **once, at turn start**. There is no `tools/list_changed` subscription, so a server that changes its tool list mid-turn is only picked up on the next turn.
+- Every projected tool's description is part of the prompt, so a server with many tools inflates each turn of the conversation.
+
+Claude Code hosts are unaffected by all of the above — they use the runtime's real MCP client.
 
 ## Requirements
 
@@ -77,7 +90,7 @@ None of these fall back to the emulated engine — a turn that says it ran the r
 |---|---|
 | Enterprise-managed authorization policy on the host | Pre-flight error — the combination is rejected rather than silently bypassed. |
 | Require tool approval + selected MCP servers (Claude Code) | Pre-flight error — turn approval off or remove the MCP servers. |
-| Selected MCP servers on a Codex host | Pre-flight error — Codex does not support MCP server tool delivery. |
+| Require tool approval + selected MCP servers (Codex) | Pre-flight error — Codex runs the host's MCP tools on MCPJam's server and cannot pause them for approval. Turn approval off or remove the MCP servers. |
 | Computer data plane not configured | Pre-flight error naming the data plane requirement. |
 | Model not supported by the selected harness | Pre-flight error asking you to pick an eligible model. |
 | Computer at daily start cap | Start-limit dialog with upgrade option. |

--- a/mcpjam-inspector/client/src/components/hosts/redesigned/focus/__tests__/BehaviorTab.harness.test.tsx
+++ b/mcpjam-inspector/client/src/components/hosts/redesigned/focus/__tests__/BehaviorTab.harness.test.tsx
@@ -71,6 +71,50 @@ describe("BehaviorTab harness gray-out", () => {
     expect(screen.getByLabelText("Off")).toHaveAttribute("data-state", "on");
   });
 
+  it("leaves tool visibility EDITABLE for a codex host, with no stale warning", () => {
+    // Codex delivers the host's MCP servers as host-executed tools that MCPJam
+    // builds itself, under the host's own options — so `respectToolVisibility`
+    // reaches them (COMP-39). The switch stayed disabled after that landed,
+    // blocking the user from a setting that works and explaining it with a
+    // reason that was no longer true.
+    renderBehaviorTab({ harness: "codex" });
+
+    expect(
+      screen.getByRole("switch", { name: /respect tool visibility/i }),
+    ).toBeEnabled();
+    expect(
+      screen.queryByText(/can't filter its tool list/i),
+    ).not.toBeInTheDocument();
+    expect(
+      screen.queryByText(/not enforced for the codex harness/i),
+    ).not.toBeInTheDocument();
+
+    // The controls Codex genuinely can't honor are still gated — this is not a
+    // blanket un-graying. Their note says the turn is REFUSED, which is what
+    // actually happens; "not enforced" described an outcome (run anyway,
+    // unapproved) the pre-flight never produces.
+    expect(
+      screen.getByRole("switch", { name: /require tool approval/i }),
+    ).toBeDisabled();
+    expect(
+      screen.getByText(/refused rather than run unapproved/i),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText(/codex does its own tool discovery/i),
+    ).toBeInTheDocument();
+  });
+
+  it("keeps tool visibility gated for claude-code, which lists tools in-sandbox", () => {
+    renderBehaviorTab({ harness: "claude-code" });
+
+    expect(
+      screen.getByRole("switch", { name: /respect tool visibility/i }),
+    ).toBeDisabled();
+    expect(
+      screen.getByText(/connects to MCP servers itself/i),
+    ).toBeInTheDocument();
+  });
+
   it("leaves every control enabled for an emulated (no-harness) host", () => {
     const { container } = renderBehaviorTab();
 

--- a/mcpjam-inspector/client/src/lib/__tests__/harness-capabilities.test.ts
+++ b/mcpjam-inspector/client/src/lib/__tests__/harness-capabilities.test.ts
@@ -1,0 +1,95 @@
+import { describe, expect, it } from "vitest";
+import { HARNESS_MCP_DELIVERY } from "@/shared/harness-mcp-delivery";
+import type { HostConfigHarnessV2 } from "@/lib/client-config-v2";
+import {
+  harnessControlState,
+  type HarnessGatedControl,
+} from "@/lib/harness-capabilities";
+
+const HARNESSES = Object.keys(
+  HARNESS_MCP_DELIVERY,
+) as HostConfigHarnessV2[];
+
+describe("harnessControlState — tool visibility is DERIVED from delivery mode", () => {
+  // The regression this file exists for: `respectToolVisibility` was a
+  // hardcoded `{enforced:false}` per harness. When Codex's host-executed
+  // projection started threading `includeAppOnly` from the knob (COMP-39), the
+  // literal stayed stale — the editor disabled a switch that worked and blamed
+  // it on a limitation that no longer existed. This asserts the COUPLING, not
+  // the current answer, so it fails again the moment the two diverge.
+  it("tracks the shared delivery declaration for EVERY harness", () => {
+    for (const harness of HARNESSES) {
+      const state = harnessControlState(harness, "respectToolVisibility");
+      expect(
+        state.enforced,
+        `respectToolVisibility for ${harness} (delivery=${HARNESS_MCP_DELIVERY[harness]})`,
+      ).toBe(HARNESS_MCP_DELIVERY[harness] === "host-executed");
+    }
+    // Guard the guard: if this ever stops covering both arms, the loop above
+    // could pass vacuously while proving nothing about the derivation.
+    const modes = new Set(HARNESSES.map((h) => HARNESS_MCP_DELIVERY[h]));
+    expect(modes).toEqual(new Set(["native", "host-executed"]));
+  });
+
+  it("Codex enforces it — MCPJam builds those tools itself", () => {
+    // Host-executed delivery runs the SAME `getToolsForAiSdk` projection the
+    // emulated engine runs, under the host's own options, so the knob bites.
+    expect(harnessControlState("codex", "respectToolVisibility")).toEqual({
+      enforced: true,
+    });
+  });
+
+  it("Claude Code does not — and says why in terms of the mechanism", () => {
+    const state = harnessControlState("claude-code", "respectToolVisibility");
+    expect(state.enforced).toBe(false);
+    // The note must describe the DELIVERY mechanism, not a per-harness "yet",
+    // so it stays true for any future natively-delivering harness.
+    expect(state.enforced === false && state.note).toMatch(
+      /connects to MCP servers itself/i,
+    );
+  });
+});
+
+describe("harnessControlState — loop-owned controls", () => {
+  const LOOP_CONTROLS: HarnessGatedControl[] = [
+    "temperature",
+    "requireToolApproval",
+    "progressiveToolDiscovery",
+  ];
+
+  it("stay unenforced on both harnesses (the harness owns its own loop)", () => {
+    for (const harness of HARNESSES) {
+      for (const control of LOOP_CONTROLS) {
+        const state = harnessControlState(harness, control);
+        expect(state.enforced, `${harness}.${control}`).toBe(false);
+        expect(state.enforced === false && state.note.length).toBeGreaterThan(0);
+      }
+    }
+  });
+});
+
+describe("harnessControlState — emulated engine", () => {
+  it("enforces every control when there is no harness", () => {
+    const controls: HarnessGatedControl[] = [
+      "temperature",
+      "requireToolApproval",
+      "respectToolVisibility",
+      "progressiveToolDiscovery",
+    ];
+    for (const control of controls) {
+      expect(harnessControlState(undefined, control)).toEqual({
+        enforced: true,
+      });
+    }
+  });
+
+  it("fails OPEN for an unknown harness id rather than graying a control out", () => {
+    const unknown = "pi" as HostConfigHarnessV2;
+    expect(harnessControlState(unknown, "temperature").enforced).toBe(true);
+    // The derived arm needs its own fail-open: an id with no delivery
+    // declaration must not silently read as `native` and disable the switch.
+    expect(harnessControlState(unknown, "respectToolVisibility").enforced).toBe(
+      true,
+    );
+  });
+});

--- a/mcpjam-inspector/client/src/lib/harness-capabilities.ts
+++ b/mcpjam-inspector/client/src/lib/harness-capabilities.ts
@@ -71,8 +71,10 @@ const HARNESS_CONTROL_STATE: Record<
       enforced: false,
       note: "Not enforced for the Codex harness yet.",
     },
-    // Codex v1 doesn't attach MCP servers through MCPJam, so there's no
-    // visibility boundary to enforce.
+    // Codex DOES reach the host's MCP servers now, but as host-executed tools
+    // MCPJam projects at turn start — and that projection uses the spec default
+    // (app-only tools hidden) rather than reading this knob, so an explicit
+    // opt-out still wouldn't bite.
     respectToolVisibility: {
       enforced: false,
       note: "Not enforced for the Codex harness yet.",

--- a/mcpjam-inspector/client/src/lib/harness-capabilities.ts
+++ b/mcpjam-inspector/client/src/lib/harness-capabilities.ts
@@ -1,4 +1,8 @@
 import type { HostConfigHarnessV2 } from "@/lib/client-config-v2";
+import {
+  harnessMcpDelivery,
+  type HarnessMcpDelivery,
+} from "@/shared/harness-mcp-delivery";
 
 /**
  * Per-harness capability map — the seed of the harness registry.
@@ -6,14 +10,41 @@ import type { HostConfigHarnessV2 } from "@/lib/client-config-v2";
  * The host page promises "edit a knob → see it in the runtime." For the
  * EMULATED engine that's automatic because MCPJam *is* the runtime and enforces
  * every host-config knob itself. A real **harness** (e.g. Claude Code) runs its
- * own agent loop and connects to MCP servers itself, so some knobs only take
- * effect once the MCP proxy mediates that traffic — and a few never can.
+ * own agent loop, so some knobs only take effect once MCPJam mediates the
+ * traffic they act on — and a few never can.
  *
  * This map records, per harness, which Behavior-tab controls are actually
  * enforced. The host editor reads it to gray-out + annotate controls that
- * wouldn't bite, so the page never silently lies. As each proxy phase lands,
- * flip a control's entry to `ENFORCED` (a one-line change) and the editor
- * un-grays it automatically.
+ * wouldn't bite, so the page never silently lies.
+ *
+ * ## Derived where it can be, declared only where it can't
+ *
+ * The controls split into two kinds, and only one of them is a per-harness fact:
+ *
+ *  - **Loop-owned** (`temperature`, `requireToolApproval`,
+ *    `progressiveToolDiscovery`) — decided by what the harness's own agent loop
+ *    can do. Nothing MCPJam builds changes the answer, so these are declared per
+ *    harness below.
+ *  - **Tool-construction-time** (`respectToolVisibility`) — acts when the MCP
+ *    tool set is BUILT, so the answer is a function of the harness's
+ *    {@link HarnessMcpDelivery}, not of its name:
+ *      - `host-executed` — MCPJam enumerates the servers itself, through the
+ *        very same `getToolsForAiSdk` projection the emulated engine uses and
+ *        under the same host-derived options, so the knob bites exactly as it
+ *        does on the emulated engine (COMP-39);
+ *      - `native` — the runtime's own MCP client lists tools from inside the
+ *        sandbox, through a proxy that relays `tools/list` unmodified, so
+ *        MCPJam never constructs those tools and cannot filter them.
+ *    These are DERIVED from `@/shared/harness-mcp-delivery`, the same
+ *    declaration the server registry's adapters read.
+ *
+ * That split is the point. A hardcoded `enforced: true` here is a promise about
+ * server behavior that nothing keeps in sync — and it went stale the first time
+ * it was tried: `respectToolVisibility` was pinned `false` for Codex, and stayed
+ * `false` after the host-executed projection started honoring it, so the editor
+ * disabled a switch that worked and explained why with a reason that was no
+ * longer true. Deriving from delivery mode means flipping a harness's delivery
+ * moves the runtime and the editor's claim about it in one edit.
  */
 
 /** Behavior-tab controls whose value may not cross into a harness runtime. */
@@ -29,11 +60,15 @@ export type HarnessControlState =
 
 const ENFORCED: HarnessControlState = { enforced: true };
 
+/** Controls owned by the harness's own agent loop — no MCPJam-side mediation
+ *  can change these answers, so they are declared per harness. */
+type HarnessLoopControl = Exclude<HarnessGatedControl, "respectToolVisibility">;
+
 // Keyed by harness id. A host with no harness (emulated engine) enforces
 // everything — callers pass `undefined` and get ENFORCED for every control.
-const HARNESS_CONTROL_STATE: Record<
+const HARNESS_LOOP_CONTROL_STATE: Record<
   HostConfigHarnessV2,
-  Record<HarnessGatedControl, HarnessControlState>
+  Record<HarnessLoopControl, HarnessControlState>
 > = {
   "claude-code": {
     // Permanent: the Claude Code CLI exposes no temperature knob.
@@ -41,20 +76,21 @@ const HARNESS_CONTROL_STATE: Record<
       enforced: false,
       note: "Claude Code runs its own loop and ignores temperature.",
     },
-    // Pending the MCP proxy: the harness calls servers directly today, so
-    // MCPJam can't gate its tool calls yet (lifts when proxy approval lands).
+    // Claude Code CAN pause — on its own built-ins (`approvalPermissionMode:
+    // "allow-edits"`) and on host-executed tools. What it can't cover is its MCP
+    // tools: the CLI's own client lists and calls those from inside the sandbox,
+    // where MCPJam has nothing to interpose on. Rather than half-honor approval,
+    // `checkHarnessRuntimeAvailable` REFUSES a turn on an approval host with any
+    // server selected. So the note must not say "ignored" — that is the one
+    // outcome that never happens. (This entry stays gated because the state has
+    // no server-selection input to distinguish the two cases; see the PR
+    // discussion — widening it is a deliberate product change, not a copy fix.)
     requireToolApproval: {
       enforced: false,
-      note: "Not enforced for the Claude Code harness yet.",
-    },
-    // Pending the MCP proxy: visibility filtering happens at the MCP boundary,
-    // which MCPJam doesn't yet mediate for the harness.
-    respectToolVisibility: {
-      enforced: false,
-      note: "Not enforced for the Claude Code harness yet.",
+      note: "Claude Code can't pause for approval of MCP-server tools, so a turn on this host is refused rather than run unapproved.",
     },
     // The real Claude Code owns its own tool discovery; MCPJam's progressive
-    // meta-tools don't apply to a harness loop.
+    // meta-tools are an emulated-loop mechanism and don't apply to a harness.
     progressiveToolDiscovery: {
       enforced: false,
       note: "Claude Code does its own tool discovery.",
@@ -66,18 +102,13 @@ const HARNESS_CONTROL_STATE: Record<
       enforced: false,
       note: "Codex runs its own loop and ignores temperature.",
     },
-    // Codex can't pause for interactive tool approval (allow-all only).
+    // Codex can't pause for interactive tool approval on ANY surface (allow-all
+    // only) — not its native built-ins, not host-executed tools. The pre-flight
+    // refuses the turn outright, so "not enforced" would describe an outcome
+    // (run anyway, unapproved) that cannot occur.
     requireToolApproval: {
       enforced: false,
-      note: "Not enforced for the Codex harness yet.",
-    },
-    // Codex DOES reach the host's MCP servers now, but as host-executed tools
-    // MCPJam projects at turn start — and that projection uses the spec default
-    // (app-only tools hidden) rather than reading this knob, so an explicit
-    // opt-out still wouldn't bite.
-    respectToolVisibility: {
-      enforced: false,
-      note: "Not enforced for the Codex harness yet.",
+      note: "Codex can't pause for tool approval, so a turn on this host is refused rather than run unapproved.",
     },
     // The real Codex owns its own tool discovery.
     progressiveToolDiscovery: {
@@ -86,6 +117,23 @@ const HARNESS_CONTROL_STATE: Record<
     },
   },
 };
+
+/**
+ * Whether tool-visibility filtering (SEP-1865 app-only tools) reaches this
+ * harness's MCP tools — a question about WHO BUILDS the tool set, answered from
+ * the shared delivery declaration rather than restated per harness.
+ */
+function toolVisibilityState(
+  delivery: HarnessMcpDelivery,
+): HarnessControlState {
+  if (delivery === "host-executed") return ENFORCED;
+  return {
+    enforced: false,
+    // Stated in terms of the mechanism, so it reads correctly for any future
+    // harness that also delivers natively.
+    note: "This harness connects to MCP servers itself, so MCPJam can't filter its tool list.",
+  };
+}
 
 /**
  * Whether `control` is enforced for a host using `harness`. No harness
@@ -98,5 +146,11 @@ export function harnessControlState(
   control: HarnessGatedControl,
 ): HarnessControlState {
   if (!harness) return ENFORCED;
-  return HARNESS_CONTROL_STATE[harness]?.[control] ?? ENFORCED;
+  if (control === "respectToolVisibility") {
+    const delivery = harnessMcpDelivery(harness);
+    // Same fail-open contract as below: an id with no delivery declaration is
+    // not something we can reason about, so don't gray the control out.
+    return delivery ? toolVisibilityState(delivery) : ENFORCED;
+  }
+  return HARNESS_LOOP_CONTROL_STATE[harness]?.[control] ?? ENFORCED;
 }

--- a/mcpjam-inspector/server/routes/mcp/chat-v2.ts
+++ b/mcpjam-inspector/server/routes/mcp/chat-v2.ts
@@ -1439,6 +1439,12 @@ chatV2.post("/", async (c) => {
         selectedServers,
         requireToolApproval,
         modelVisibleMcpToolResults,
+        // Harness engine only: it builds its own MCP tool set (host-executed
+        // delivery) rather than consuming `allTools`, so the host's
+        // tool-construction policies have to reach it separately. Inert on the
+        // emulated path, which is handed tools already built by prepareChatV2.
+        respectToolVisibility,
+        ...(tasksSeam ? { tasks: tasksSeam } : {}),
         ...(scopeStepUpEngineResume
           ? { scopeStepUpResume: scopeStepUpEngineResume }
           : {}),

--- a/mcpjam-inspector/server/routes/shared/evals.ts
+++ b/mcpjam-inspector/server/routes/shared/evals.ts
@@ -2214,13 +2214,15 @@ export async function prepareEvalRun(
       { reason: "HARNESS_UNAVAILABLE", harness: harnessAdmission.harness }
     );
   }
-  // Harness MCP calls run out of process, so the policy is enforced at the MCP
-  // proxy the generated `.mcp.json` points at — sealed into the proxy token, so
-  // dropping the policy drops the credential. Refused only when this deployment
-  // cannot seal it.
+  // A NATIVE-delivery harness makes its MCP calls out of process, so the policy
+  // is enforced at the MCP proxy the generated `.mcp.json` points at — sealed
+  // into the proxy token, so dropping the policy drops the credential. Refused
+  // only when this deployment cannot seal it. A host-executed adapter never
+  // mints that token (it enforces in-process), and the refusal reads its
+  // delivery off the adapter rather than off a bare "is a harness" boolean.
   const harnessPolicyRefusal = harnessToolPolicyLaunchRefusal({
     hasToolPolicy: Boolean(toolPolicy),
-    harness: Boolean(harnessAdmission.harness),
+    harness: harnessAdmission.harness,
   });
   if (harnessPolicyRefusal) {
     await failRunBeforeExecution(convexClient, recorder, runId, {
@@ -2534,11 +2536,12 @@ export async function runEvalTestCaseWithManager(
     suiteHostConfig,
     namedHostId
   );
-  // Enforced at the MCP proxy for harness runs (see the suite path); refused
-  // only where this deployment cannot seal the policy into the proxy token.
+  // Enforced at the MCP proxy for NATIVE-delivery harness runs (see the suite
+  // path); refused only where this deployment cannot seal the policy into the
+  // proxy token. Host-executed delivery enforces in-process and mints no token.
   const harnessPolicyRefusal = harnessToolPolicyLaunchRefusal({
     hasToolPolicy: Boolean(toolPolicy),
-    harness: Boolean(harnessOfHostConfig(effectiveHostConfig)),
+    harness: harnessOfHostConfig(effectiveHostConfig),
   });
   if (harnessPolicyRefusal) {
     throw new WebRouteError(
@@ -2958,11 +2961,12 @@ export async function streamEvalTestCaseWithManager(
     suiteHostConfig,
     namedHostId
   );
-  // Enforced at the MCP proxy for harness runs (see the suite path); refused
-  // only where this deployment cannot seal the policy into the proxy token.
+  // Enforced at the MCP proxy for NATIVE-delivery harness runs (see the suite
+  // path); refused only where this deployment cannot seal the policy into the
+  // proxy token. Host-executed delivery enforces in-process and mints no token.
   const harnessPolicyRefusal = harnessToolPolicyLaunchRefusal({
     hasToolPolicy: Boolean(toolPolicy),
-    harness: Boolean(harnessOfHostConfig(effectiveHostConfig)),
+    harness: harnessOfHostConfig(effectiveHostConfig),
   });
   if (harnessPolicyRefusal) {
     throw new WebRouteError(

--- a/mcpjam-inspector/server/routes/shared/evals.ts
+++ b/mcpjam-inspector/server/routes/shared/evals.ts
@@ -3,6 +3,7 @@ import type { MCPClientManager, MCPServerReplayConfig } from "@mcpjam/sdk";
 import { readTasksPolicy } from "@mcpjam/sdk";
 import { evalSuiteFileToolPolicySchema } from "@mcpjam/sdk/contract";
 import { resolveToolTaskSeam } from "../../utils/task-seam.js";
+import { mcpToolOptionsFor } from "../../utils/mcp-tool-options.js";
 import { z } from "zod";
 import { generateTestCases } from "../../services/eval-agent";
 import {
@@ -3136,18 +3137,20 @@ export async function streamEvalTestCaseWithManager(
     // the run's own teardown, which aborts through this signal.
     await: { signal: streamAbortController.signal },
   });
+  // `includeAppOnly` is tied to the PRESENCE of a host policy, not to
+  // `respectToolVisibility`: eval wants the full set so the visibility gate
+  // below can both filter and COUNT the drops honestly.
+  const singleCaseToolOptions = mcpToolOptionsFor({
+    includeAppOnly: Boolean(suiteHostPolicy),
+    modelVisibleMcpToolResults: suiteHostPolicy?.modelVisibleMcpToolResults,
+    tasks: singleCaseTasksSeam,
+  });
   const tools = (
-    suiteHostPolicy || singleCaseTasksSeam
-      ? await clientManager.getToolsForAiSdk(resolvedServerIds, {
-          ...(suiteHostPolicy
-            ? {
-                includeAppOnly: true,
-                modelVisibleMcpToolResults:
-                  suiteHostPolicy.modelVisibleMcpToolResults,
-              }
-            : {}),
-          ...(singleCaseTasksSeam ? { tasks: singleCaseTasksSeam } : {}),
-        })
+    singleCaseToolOptions
+      ? await clientManager.getToolsForAiSdk(
+          resolvedServerIds,
+          singleCaseToolOptions
+        )
       : await clientManager.getToolsForAiSdk(resolvedServerIds)
   ) as Record<string, any>;
   const streamToolSignals = suiteHostPolicy

--- a/mcpjam-inspector/server/services/evals-runner.ts
+++ b/mcpjam-inspector/server/services/evals-runner.ts
@@ -31,6 +31,7 @@ import {
   type ToolTaskSeamOptions,
 } from "@mcpjam/sdk";
 import { resolveToolTaskSeam } from "../utils/task-seam.js";
+import { mcpToolOptionsFor } from "../utils/mcp-tool-options.js";
 import {
   createLlmModel,
   type BaseUrls,
@@ -611,17 +612,14 @@ async function getEvalToolsForAiSdkOrThrow(args: {
   environment: RunEvalSuiteOptions["config"]["environment"] | undefined;
   setupObserver?: RunSetupObserver;
 }): Promise<ToolSet> {
-  const hasModelVisiblePolicy = args.modelVisibleMcpToolResults !== undefined;
-  const toolOptions =
-    args.includeAppOnly || hasModelVisiblePolicy || args.tasks !== undefined
-      ? {
-          ...(args.includeAppOnly ? { includeAppOnly: true } : {}),
-          ...(args.modelVisibleMcpToolResults !== undefined
-            ? { modelVisibleMcpToolResults: args.modelVisibleMcpToolResults }
-            : {}),
-          ...(args.tasks !== undefined ? { tasks: args.tasks } : {}),
-        }
-      : undefined;
+  // `undefined` ⇒ the no-options overload, keeping a default run byte-identical.
+  // `needsApproval` is deliberately not an input here: an eval run is auto-deny
+  // by construction, so the AI SDK approval flag has nothing to gate.
+  const toolOptions = mcpToolOptionsFor({
+    includeAppOnly: args.includeAppOnly,
+    modelVisibleMcpToolResults: args.modelVisibleMcpToolResults,
+    tasks: args.tasks,
+  });
 
   const now = () => Date.now();
   const observer = args.setupObserver;

--- a/mcpjam-inspector/server/services/evals-runner.ts
+++ b/mcpjam-inspector/server/services/evals-runner.ts
@@ -1516,6 +1516,18 @@ type RunIterationBaseParams = {
   /** The run's frozen skills in harness shape (see
    *  {@link RunEvalSuiteOptions.pinnedHarnessSkills}). */
   pinnedHarnessSkills?: PinnedSkillArtifact[];
+  /**
+   * The run's resolved MCP Tasks seam (`resolveToolTaskSeam`, surface
+   * `"eval"`), or absent for tasks-off.
+   *
+   * Resolved ONCE per run, at the run boundary, because the `await` driver it
+   * carries is bound to the run's own abort signal — a per-iteration
+   * re-derivation would either lose that binding or build a second driver. The
+   * emulated path consumes it indirectly (the tool set is already built under
+   * it); the HARNESS path needs the seam itself, because `runHarnessTurn`
+   * rebuilds its MCP tools and reads `tasks` off the handler options.
+   */
+  tasks?: ToolTaskSeamOptions;
 };
 
 type RunIterationAiSdkParams = RunIterationBaseParams & {
@@ -1881,6 +1893,8 @@ const executeTestCase = async (params: {
   /** The run's frozen skills in harness shape (see
    *  RunEvalSuiteOptions.pinnedHarnessSkills). */
   pinnedHarnessSkills?: PinnedSkillArtifact[];
+  /** The run's resolved Tasks seam — see RunIterationBaseParams.tasks. */
+  tasks?: ToolTaskSeamOptions;
   toolPolicy?: EvalSuiteFileToolPolicy;
   toolAnnotations?: ToolAnnotationsLookup;
   toolPolicyWarnings?: string[];
@@ -1914,6 +1928,7 @@ const executeTestCase = async (params: {
     environment,
     pinnedSkillSource,
     pinnedHarnessSkills,
+    tasks,
     toolPolicy,
     toolAnnotations,
     toolPolicyWarnings,
@@ -2133,6 +2148,10 @@ const executeTestCase = async (params: {
         environment,
         pinnedSkillSource,
         pinnedHarnessSkills,
+        // The run's Tasks seam. Hosted-only: it exists so the HARNESS turn can
+        // rebuild its MCP tools under the same seam the emulated tool set was
+        // already built with (`getEvalToolsForAiSdkOrThrow`).
+        ...(tasks ? { tasks } : {}),
         ...(toolPolicy
           ? { toolPolicy, toolAnnotations, toolPolicyWarnings }
           : {}),
@@ -2188,6 +2207,10 @@ const executeTestCase = async (params: {
         environment,
         pinnedSkillSource,
         pinnedHarnessSkills,
+        // The run's Tasks seam. Hosted-only: it exists so the HARNESS turn can
+        // rebuild its MCP tools under the same seam the emulated tool set was
+        // already built with (`getEvalToolsForAiSdkOrThrow`).
+        ...(tasks ? { tasks } : {}),
         ...(toolPolicy
           ? { toolPolicy, toolAnnotations, toolPolicyWarnings }
           : {}),
@@ -2521,6 +2544,12 @@ export const runEvalSuiteWithAiSdk = async ({
         // `runFrozenSkillOptions`. Forwarding only the emulated one used to
         // leave the harness path falling through to a live project-wide fetch.
         ...runFrozenSkillOptions({ pinnedSkillSource, pinnedHarnessSkills }),
+        // The run's ONE Tasks seam — the same object `getEvalToolsForAiSdkOrThrow`
+        // built the emulated tool set with, so the harness (which rebuilds its
+        // own MCP tools) cannot end up on a different row of the policy matrix.
+        // Never re-resolved downstream: its `await` driver is bound to THIS
+        // run's abort signal.
+        ...(evalTasksSeam ? { tasks: evalTasksSeam } : {}),
       });
     const testPromises = tests.map((test) =>
       // Cap concurrent headless browsers for every model-free render check
@@ -3836,6 +3865,7 @@ const runHostedIterationWithBrowser = async (
     environment,
     pinnedSkillSource,
     pinnedHarnessSkills,
+    tasks,
     toolPolicy,
     toolAnnotations,
     toolPolicyWarnings,
@@ -4361,6 +4391,33 @@ const runHostedIterationWithBrowser = async (
     // nowhere else, so supplying only `tools` would hand the runtime a turn
     // with no built-ins and no way to notice.
     ...(builtInTools ? { builtInTools } : {}),
+    // The host's MCP tool-CONSTRUCTION policies, for the same reason and with
+    // the same hazard as `builtInTools` above.
+    //
+    // The `prepareChatV2` call a few dozen lines up builds THIS iteration's
+    // emulated tool set from `hostPolicy`. A harness turn never consumes that
+    // set — `runHarnessTurn` rebuilds the model-facing MCP tools itself — and
+    // reads each policy off these fields and nowhere else, so a policy that
+    // stops here does not exist at all on host-executed delivery.
+    // `driveHostedEvalTurn` gates all three behind `harness`, so an emulated
+    // iteration is unaffected by any of this.
+    //
+    // `tasks` is the run-level seam (`resolveToolTaskSeam`, resolved once in
+    // `runEvalSuiteWithAiSdk` and threaded down) rather than anything derived
+    // here — same object `getEvalToolsForAiSdkOrThrow` built the run's tool set
+    // with. Note the per-iteration `prepareChatV2` above does NOT take it; that
+    // is a pre-existing emulated-path gap, deliberately left alone here because
+    // closing it would change emulated eval behaviour.
+    //
+    // Definedness, not truthiness: `respectToolVisibility: false` IS the
+    // SEP-1865 opt-out.
+    ...(hostPolicy?.modelVisibleMcpToolResults !== undefined
+      ? { modelVisibleMcpToolResults: hostPolicy.modelVisibleMcpToolResults }
+      : {}),
+    ...(hostPolicy?.respectToolVisibility !== undefined
+      ? { respectToolVisibility: hostPolicy.respectToolVisibility }
+      : {}),
+    ...(tasks !== undefined ? { tasks } : {}),
     ...(builtInTarget && "projectId" in builtInTarget
       ? { projectId: builtInTarget.projectId }
       : {}),

--- a/mcpjam-inspector/server/services/evals/__tests__/drive-hosted-eval-turn.test.ts
+++ b/mcpjam-inspector/server/services/evals/__tests__/drive-hosted-eval-turn.test.ts
@@ -220,9 +220,39 @@ describe("harness execution options reach the engine", () => {
     expect(options.runtimeSkillsOverride).toBeUndefined();
   });
 
+  it("forwards the host's MCP tool-CONSTRUCTION policies", async () => {
+    // `runHarnessTurn` REBUILDS this turn's MCP tools instead of consuming
+    // `tools`, and reads each of these off the handler options and nowhere
+    // else. Dropping one does not fall back to the host's intent — it falls
+    // back to the SDK's default, silently. Definedness, not truthiness:
+    // `respectToolVisibility: false` IS the SEP-1865 opt-out.
+    const modelVisibleMcpToolResults = { directContent: { image: false } };
+    const tasks = { mode: "await" };
+    const options = await engineOptionsFor({
+      ...HARNESS_OPTIONS,
+      modelVisibleMcpToolResults,
+      respectToolVisibility: false,
+      tasks,
+    } as unknown as Partial<DriveHostedEvalTurnParams>);
+
+    expect(options.modelVisibleMcpToolResults).toEqual(
+      modelVisibleMcpToolResults,
+    );
+    expect(options.respectToolVisibility).toBe(false);
+    expect(options.tasks).toEqual(tasks);
+  });
+
   it("keeps an EMULATED turn byte-identical — none of it leaks through", async () => {
     // Every harness option is gated on the selector, so a non-harness eval
     // sends exactly what it sent before.
+    //
+    // The three tool-construction policies matter most here. Two of them
+    // (`respectToolVisibility`, `tasks`) are read only by `runHarnessTurn`, so
+    // they could not change an emulated turn even ungated — but
+    // `modelVisibleMcpToolResults` IS read by the emulated loop's tool-result
+    // projection, and the emulated eval tool set was already built under it by
+    // `getEvalToolsForAiSdkOrThrow`. This gate is what keeps that path
+    // byte-identical, so a regression that ungated it must fail here.
     const options = await engineOptionsFor({
       harnessSandboxBinding: {
         sandboxRowId: "row-1",
@@ -231,6 +261,9 @@ describe("harness execution options reach the engine", () => {
       harnessMcpProxy: { plane: "web-authorized", mode: "relay" },
       builtInTools: { web_search: {} },
       pinnedHarnessSkills: [],
+      modelVisibleMcpToolResults: { directContent: { image: false } },
+      respectToolVisibility: false,
+      tasks: { mode: "await" },
     } as unknown as Partial<DriveHostedEvalTurnParams>);
 
     expect(options.harness).toBeUndefined();
@@ -238,5 +271,8 @@ describe("harness execution options reach the engine", () => {
     expect(options.harnessMcpProxy).toBeUndefined();
     expect(options.builtInTools).toBeUndefined();
     expect(options.pinnedHarnessSkills).toBeUndefined();
+    expect(options.modelVisibleMcpToolResults).toBeUndefined();
+    expect(options.respectToolVisibility).toBeUndefined();
+    expect(options.tasks).toBeUndefined();
   });
 });

--- a/mcpjam-inspector/server/services/evals/__tests__/harness-admission.test.ts
+++ b/mcpjam-inspector/server/services/evals/__tests__/harness-admission.test.ts
@@ -171,18 +171,18 @@ describe("checkEvalHarnessAdmission", () => {
     expect(verdict.reason).toContain("broker");
   });
 
-  it("refuses a harness that cannot deliver the suite's MCP servers", () => {
-    // An eval suite ALWAYS has servers, so Codex (supportsSelectedMcpServers:
-    // false) can never run one — surfaced as the gate's reason, not as a
-    // half-configured run.
-    const verdict = checkEvalHarnessAdmission({
-      hostConfig: { harness: "codex" },
-      serverIds: ["s1"],
-      cases: [{ title: "a", model: "openai/gpt-5", provider: "openai" }],
-    });
-    expect(verdict.ok).toBe(false);
-    if (verdict.ok) throw new Error("unreachable");
-    expect(verdict.reason).toContain("MCP servers");
+  it("admits Codex for a suite with MCP servers (host-executed delivery)", () => {
+    // COMP-39 inverts this case. An eval suite ALWAYS has servers, so the old
+    // "Codex cannot deliver MCP servers" refusal meant Codex could never run
+    // ANY eval suite. It now delivers them as host-executed tools, so a Codex
+    // suite is admissible on the same terms as a Claude Code one.
+    expect(
+      checkEvalHarnessAdmission({
+        hostConfig: { harness: "codex" },
+        serverIds: ["s1"],
+        cases: [{ title: "a", model: "openai/gpt-5", provider: "openai" }],
+      })
+    ).toEqual({ ok: true, harness: "codex" });
   });
 });
 
@@ -235,17 +235,31 @@ describe("checkEvalHarnessStaticAdmission", () => {
     expect(verdict.reason).toContain("MCPJam-provided models");
   });
 
-  it("counts PLUGIN-contributed servers toward the MCP gate", () => {
+  it("counts PLUGIN-contributed servers toward the MCP-tool approval gate", () => {
     // A host whose servers come solely from a plugin would otherwise slip the
-    // rule the gate exists to enforce.
+    // rule the gate exists to enforce. (This used to be asserted through the
+    // MCP-delivery refusal, which is gone — every harness delivers MCP servers
+    // now — so it is asserted through the approval rule that still keys off
+    // `hasSelectedMcpServers`.)
     const verdict = checkEvalHarnessStaticAdmission({
-      hostConfig: { harness: "codex" },
+      hostConfig: { harness: "claude-code", requireToolApproval: true },
       serverIds: [],
       pluginServerIds: ["plugin-server-1"],
     });
     expect(verdict.ok).toBe(false);
     if (verdict.ok) throw new Error("unreachable");
-    expect(verdict.reason).toContain("MCP servers");
+    expect(verdict.reason).toContain("MCP-server tools");
+  });
+
+  it("an approval host with NO servers at all is not caught by that gate", () => {
+    // The control for the case above: without the plugin servers the same host
+    // passes, so the refusal really did come from counting them.
+    expect(
+      checkEvalHarnessStaticAdmission({
+        hostConfig: { harness: "claude-code", requireToolApproval: true },
+        serverIds: [],
+      })
+    ).toEqual({ ok: true, harness: "claude-code" });
   });
 });
 

--- a/mcpjam-inspector/server/services/evals/__tests__/hosted-eval-harness-tool-options.test.ts
+++ b/mcpjam-inspector/server/services/evals/__tests__/hosted-eval-harness-tool-options.test.ts
@@ -1,0 +1,287 @@
+/**
+ * A HOSTED EVAL on a host-executed-delivery harness must build its MCP tools
+ * under the eval host's policies — end to end, from the eval facade down to the
+ * SDK call that actually constructs them.
+ *
+ * `run-harness-turn-host-executed-options.test.ts` pins the turn→projection
+ * wiring for the CHAT routes. This file pins the leg the chat routes do not
+ * exercise: `driveHostedEvalTurn` → `runAssistantTurn` → `runHarnessTurn` →
+ * `projectSelectedMcpServersAsHostTools` → `MCPClientManager.getToolsForAiSdk`.
+ * Only the harness sandbox/broker/agent boundary is mocked; every layer that
+ * carries a policy is real.
+ *
+ * ## What is asserted, and why it is the observable
+ *
+ * `getToolsForAiSdk` refuses to resolve host-derived inputs itself ("the mode
+ * is resolved by the CALLER"), so the arguments it receives ARE the tools it
+ * produces: a policy that does not reach this call does not reach the model's
+ * tool set, and the SDK's defaults silently take over. That is the whole
+ * failure mode — no error, no log, just a Codex eval running under a policy its
+ * host never chose. Asserting on this call is asserting on what the harness
+ * turn ends up with, one layer below where it could be faked by a pass-through.
+ *
+ * The `harness` cases here FAIL against 3ac4cda2c7, where the eval facade
+ * forwarded none of these and the enumeration took the no-options overload.
+ * The emulated case passes both before and after — it is the byte-identity
+ * guard for the gate that keeps it that way.
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const harnessState = vi.hoisted(() => ({
+  session: {
+    sessionId: "session-1",
+    stop: vi.fn(async () => ({})),
+    destroy: vi.fn(async () => {}),
+  },
+}));
+
+vi.mock("@ai-sdk/harness/agent", () => ({
+  HarnessAgent: class {
+    createSession = vi.fn(async () => harnessState.session);
+    stream = vi.fn(async () => ({
+      fullStream: (async function* () {
+        yield { type: "finish", finishReason: "stop" };
+      })(),
+      text: Promise.resolve("done"),
+    }));
+  },
+  collectHarnessAgentToolApprovalContinuations: vi.fn(() => []),
+}));
+
+vi.mock("../../../utils/harness/registry.js", () => ({
+  buildBrokerDummyAuth: vi.fn(() => ({
+    anthropic: {
+      apiKey: "",
+      authToken: "mcpjam-broker-dummy",
+      baseUrl: "https://broker.example",
+    },
+  })),
+  getHarnessAdapter: vi.fn(() => ({
+    id: "codex",
+    displayName: "Codex",
+    defaultPermissionMode: "allow-all",
+    supportsSkills: false,
+    supportsNativeToolApproval: false,
+    supportsHostExecutedToolApproval: false,
+    supportsMcpToolApproval: false,
+    // The delivery mode under test: no `.mcp.json`, so MCPJam builds the
+    // model-facing MCP tools itself instead of consuming `tools`.
+    mcpDelivery: "host-executed",
+    supportsModel: vi.fn(() => true),
+    createHarness: vi.fn(() => ({ harnessId: "codex" })),
+    parseToolName: vi.fn((toolName: string) => ({ toolName })),
+  })),
+}));
+
+vi.mock("../../../utils/harness/resolve-sandbox.js", () => ({
+  resolveHarnessSandbox: vi.fn(async () => ({
+    computerId: "computer-1",
+    sandboxId: "sandbox-1",
+  })),
+}));
+
+vi.mock("../../../utils/harness/e2b-sandbox-provider.js", () => ({
+  createE2BHarnessSandboxProvider: vi.fn(() => ({ sandboxId: "sandbox-1" })),
+}));
+
+vi.mock("../../../utils/harness/runtime-skills.js", () => ({
+  frontmatterSafeSkills: vi.fn((skills) => skills),
+  fetchRuntimeSkills: vi.fn(async () => ({ ok: true, skills: [] })),
+  skillsFingerprint: vi.fn(() => "empty-skills"),
+}));
+
+vi.mock("../../../utils/harness/reconcile-skill-dirs.js", () => ({
+  reconcileSkillDirs: vi.fn(async () => {}),
+}));
+
+vi.mock("../../../utils/harness/harness-session-state.js", async (
+  importOriginal
+) => {
+  const actual = await importOriginal<
+    typeof import("../../../utils/harness/harness-session-state.js")
+  >();
+  return {
+    ...actual,
+    claimHarnessSessionState: vi.fn(async () => ({
+      ok: true,
+      leaseId: "lease-1",
+      stateVersion: 1,
+      state: null,
+      fingerprintChanged: false,
+    })),
+    commitHarnessSessionState: vi.fn(async () => true),
+    heartbeatHarnessSessionState: vi.fn(async () => "ok"),
+    releaseHarnessSessionState: vi.fn(async () => {}),
+  };
+});
+
+vi.mock("../../../utils/harness/harness-model-broker.js", () => ({
+  reserveHarnessBox: vi.fn(async () => ({ ok: true })),
+  releaseHarnessBoxReservation: vi.fn(async () => ({ ok: true })),
+  revokeHarnessModelBroker: vi.fn(async () => {}),
+  startHarnessModelBroker: vi.fn(async () => ({
+    ok: true,
+    proxyBaseUrl: "https://broker.example",
+  })),
+}));
+
+import { driveHostedEvalTurn } from "../drive-hosted-eval-turn";
+import type { DriveHostedEvalTurnParams } from "../drive-hosted-eval-turn";
+import {
+  __resetHostedModelCatalogForTests,
+  __setHostedCatalogForTests,
+} from "../../hosted-model-catalog.js";
+
+const HARNESS_MODEL_ID = "openai/gpt-5";
+
+/** The eval's authorized manager. `getToolsForAiSdk` is the assertion surface. */
+function makeManager() {
+  return {
+    getServerConfig: vi.fn(() => ({ url: "https://srv.example/mcp" })),
+    getToolsForAiSdk: vi.fn(async () => ({})),
+  };
+}
+
+function baseParams(
+  manager: ReturnType<typeof makeManager>,
+  overrides: Partial<DriveHostedEvalTurnParams> = {}
+): DriveHostedEvalTurnParams {
+  const browser = {
+    setActivePromptIndex: vi.fn(),
+    setActiveWidgetChecks: vi.fn(),
+    dismissCarriedWidget: vi.fn(async () => {}),
+    computerWidgetTools: {},
+    noteToolCallInput: vi.fn(),
+    handleEngineToolResult: vi.fn(async () => {}),
+    drainFollowUps: vi.fn(() => [] as string[]),
+  };
+  return {
+    promptIndex: 0,
+    prompt: "list the open issues",
+    browser: browser as unknown as DriveHostedEvalTurnParams["browser"],
+    prepared: {
+      allTools: {},
+      enhancedSystemPrompt: "You are Codex.",
+      resolvedTemperature: undefined,
+      progressivePlan: undefined,
+      discoveryState: undefined,
+    } as unknown as DriveHostedEvalTurnParams["prepared"],
+    modelDefinition: {
+      id: HARNESS_MODEL_ID,
+      provider: "openai",
+    } as never,
+    modelId: HARNESS_MODEL_ID,
+    // An eval suite always has servers — that is what makes the projection run.
+    selectedServers: ["srv-a"],
+    mcpClientManager: manager as never,
+    evalAuthContext: { kind: "user_bearer", token: "Bearer test" },
+    endpointPath: "/stream",
+    extraBodyFields: undefined,
+    toolChoice: undefined,
+    abortSignal: undefined,
+    maxSteps: 5,
+    runStartedAt: Date.now(),
+    isAborted: () => false,
+    extractToolCalls: () => [],
+    projectId: "project-1",
+    harnessSandboxBinding: {
+      sandboxRowId: "row-1",
+      sandboxId: "sbx-1",
+    } as never,
+    harnessMcpProxy: { plane: "local-mcp" } as never,
+    acc: {
+      messageHistory: [],
+      capturedSpans: [],
+      accumulatedUsage: {},
+      toolsCalledByPrompt: [],
+    },
+    ...overrides,
+  };
+}
+
+/**
+ * Drive one hosted eval turn and return the options the SDK was asked to build
+ * this turn's MCP tools with. `undefined` means the no-options overload — the
+ * shape a DEFAULT turn must keep, and the shape the bug produced for every
+ * turn.
+ */
+async function toolBuildOptionsFor(
+  overrides: Partial<DriveHostedEvalTurnParams>
+): Promise<Record<string, unknown> | undefined> {
+  const manager = makeManager();
+  await driveHostedEvalTurn(baseParams(manager, overrides));
+  expect(manager.getToolsForAiSdk).toHaveBeenCalledTimes(1);
+  const call = manager.getToolsForAiSdk.mock.calls[0] as unknown as unknown[];
+  expect(call[0]).toEqual(["srv-a"]);
+  return call[1] as Record<string, unknown> | undefined;
+}
+
+const MODEL_VISIBLE_POLICY = {
+  directContent: { image: false },
+  embeddedResources: { blob: { image: false } },
+  linkedResources: { blob: { image: false } },
+};
+
+const HARNESS_PARAMS = {
+  harness: "codex",
+} as unknown as Partial<DriveHostedEvalTurnParams>;
+
+describe("hosted eval on a host-executed harness builds MCP tools under the HOST's policies", () => {
+  beforeEach(() => {
+    vi.stubEnv("MCPJAM_HARNESS_BROKER_DELIVERY", "true");
+    // The harness arm is gated on the model being MCPJam-provided; without a
+    // seeded catalog `runAssistantTurn` would surface a fallback to the
+    // emulated engine and the projection would never run.
+    __setHostedCatalogForTests([HARNESS_MODEL_ID]);
+  });
+  afterEach(() => {
+    vi.unstubAllEnvs();
+    __resetHostedModelCatalogForTests();
+  });
+
+  it("carries the eval host's modelVisibleMcpToolResults into the tool build", async () => {
+    // THE REPORTED BUG: the eval facade dropped this, so the SDK's default
+    // applied and content the eval host disabled could reach the model.
+    const options = await toolBuildOptionsFor({
+      ...HARNESS_PARAMS,
+      modelVisibleMcpToolResults: MODEL_VISIBLE_POLICY as never,
+    });
+    expect(options).toMatchObject({
+      modelVisibleMcpToolResults: MODEL_VISIBLE_POLICY,
+    });
+  });
+
+  it("carries an explicit respectToolVisibility=false through as includeAppOnly", async () => {
+    // The SEP-1865 opt-out. `false` is the meaningful value, so a truthiness
+    // check anywhere on the path erases it silently.
+    const options = await toolBuildOptionsFor({
+      ...HARNESS_PARAMS,
+      respectToolVisibility: false,
+    });
+    expect(options).toMatchObject({ includeAppOnly: true });
+  });
+
+  it("carries the run's resolved Tasks seam", async () => {
+    // Without it a harness turn drops to the no-`_meta` path — MCP Tasks off,
+    // on a run whose host turned them on.
+    const tasks = { mode: "await" } as never;
+    const options = await toolBuildOptionsFor({ ...HARNESS_PARAMS, tasks });
+    expect(options).toMatchObject({ tasks: { mode: "await" } });
+  });
+
+  it("keeps a policy-free harness turn on the no-options overload", async () => {
+    // Byte-identity guard (green before this change too): a host that set none
+    // of these must still produce exactly the tools it produced before any of
+    // this plumbing existed.
+    expect(await toolBuildOptionsFor(HARNESS_PARAMS)).toBeUndefined();
+  });
+});
+
+// `needsApproval` is deliberately absent from this projection on every surface
+// (host-executed approval is `HarnessAgent`'s own `toolApproval` map, not the
+// AI SDK flag). That is pinned where it is decided —
+// `harness/__tests__/host-executed-mcp-tools.test.ts` and
+// `run-harness-turn-host-executed-options.test.ts` — and is not re-asserted
+// here: an eval that sets `requireToolApproval` on a Codex host is REFUSED by
+// `harnessToolApprovalRefusalReason` before any tool is built, so this file
+// could only ever test the refusal, which has its own coverage.

--- a/mcpjam-inspector/server/services/evals/drive-hosted-eval-turn.ts
+++ b/mcpjam-inspector/server/services/evals/drive-hosted-eval-turn.ts
@@ -191,6 +191,54 @@ export interface DriveHostedEvalTurnParams {
    * whole program exists to eliminate.
    */
   builtInTools?: RunAssistantTurnOptions["builtInTools"];
+  /**
+   * The host's MCP tool-CONSTRUCTION policies, for the HARNESS path.
+   *
+   * ## Why these are passed explicitly, like `builtInTools`
+   *
+   * On the emulated path this facade hands `runAssistantTurn` a tool set that
+   * `prepareChatV2` / `getEvalToolsForAiSdkOrThrow` already built under exactly
+   * these policies, so nothing downstream has to re-derive them. A HARNESS turn
+   * does not consume that set: `runHarnessTurn` rebuilds the model-facing MCP
+   * tools itself (`projectSelectedMcpServersAsHostTools`), because a
+   * host-executed runtime needs its own projection. It reads each policy off
+   * these fields **and nowhere else** — so omitting one does not fall back to
+   * the host's intent, it falls back to the SDK's default. That is the same
+   * silent-degradation shape `builtInTools` above is documented against:
+   * content the eval's host disabled reaches the model, an explicit visibility
+   * opt-out is ignored, and MCP Tasks drops to the no-`_meta` path, all without
+   * a single error.
+   *
+   * ## What is deliberately NOT done here
+   *
+   * The prepared/traced tool set (`tracedTools` below) is NOT handed to the
+   * harness. It is the EMULATED engine's tool set wrapped in eval-trace
+   * instrumentation; the harness path layers its own model-output projection,
+   * scope-step-up observer and policy gate over the manager's tools, and
+   * feeding it `tracedTools` would double-wrap and collide with that layering.
+   * The fix for a dropped policy is to forward the POLICY, not to reuse the
+   * prepared tools.
+   *
+   * ## Emulated evals are unchanged
+   *
+   * All three ride inside the `params.harness` gate at the `runAssistantTurn`
+   * call, for the same reason `requireToolApproval` / `projectId` /
+   * `harnessMcpProxy` already do. Two of them could not affect an emulated turn
+   * even ungated (`MCPJamHandlerOptions.respectToolVisibility` and `.tasks` are
+   * read only by `runHarnessTurn`), but `modelVisibleMcpToolResults` IS read by
+   * the emulated loop's tool-result projection — so the gate is what keeps an
+   * emulated eval byte-identical rather than an argument about read sites.
+   */
+  modelVisibleMcpToolResults?: RunAssistantTurnOptions["modelVisibleMcpToolResults"];
+  /** See {@link DriveHostedEvalTurnParams.modelVisibleMcpToolResults}. Only an
+   *  explicit `false` opts out of SEP-1865 filtering, so this is forwarded on
+   *  definedness. */
+  respectToolVisibility?: RunAssistantTurnOptions["respectToolVisibility"];
+  /** See {@link DriveHostedEvalTurnParams.modelVisibleMcpToolResults}. The run
+   *  resolves ONE seam for the whole run (`resolveToolTaskSeam`, surface
+   *  `"eval"`, bound to the run's abort signal); it is threaded here, never
+   *  re-derived per turn. */
+  tasks?: RunAssistantTurnOptions["tasks"];
   mcpClientManager: MCPClientManager;
   evalAuthContext: { kind: "user_bearer"; token: string };
   endpointPath: string;
@@ -464,6 +512,25 @@ export async function driveHostedEvalTurn(
             ...(params.builtInTools
               ? { builtInTools: params.builtInTools }
               : {}),
+            // The host's MCP tool-CONSTRUCTION policies. `runHarnessTurn`
+            // rebuilds this turn's MCP tools instead of consuming `tools`
+            // above, and reads each of these off the handler options and
+            // nowhere else — omitting one hands the harness the SDK's default,
+            // not the host's choice. Harness-gated like every field in this
+            // block: `modelVisibleMcpToolResults` is also read by the EMULATED
+            // loop, so the gate is what keeps emulated evals byte-identical.
+            // Forwarded on DEFINEDNESS — `respectToolVisibility: false` is the
+            // opt-out and a truthy check would erase it.
+            ...(params.modelVisibleMcpToolResults !== undefined
+              ? {
+                  modelVisibleMcpToolResults:
+                    params.modelVisibleMcpToolResults,
+                }
+              : {}),
+            ...(params.respectToolVisibility !== undefined
+              ? { respectToolVisibility: params.respectToolVisibility }
+              : {}),
+            ...(params.tasks !== undefined ? { tasks: params.tasks } : {}),
           }
         : {}),
       endpointPath: params.endpointPath,

--- a/mcpjam-inspector/server/utils/__tests__/mcp-tool-options.test.ts
+++ b/mcpjam-inspector/server/utils/__tests__/mcp-tool-options.test.ts
@@ -1,0 +1,72 @@
+/**
+ * The ONE builder for `getToolsForAiSdk`'s host-derived options.
+ *
+ * These assertions pin the property that four call sites depend on and that a
+ * fifth (the harness host-executed projection) silently violated by building
+ * nothing at all: absent-everything answers `undefined`, so a default turn
+ * takes the no-options overload and produces byte-identical tools.
+ */
+import { describe, expect, it } from "vitest";
+import { mcpToolOptionsFor } from "../mcp-tool-options";
+
+describe("mcpToolOptionsFor", () => {
+  it("answers undefined when no host input applies", () => {
+    expect(mcpToolOptionsFor({})).toBeUndefined();
+    expect(
+      mcpToolOptionsFor({
+        needsApproval: false,
+        includeAppOnly: false,
+        modelVisibleMcpToolResults: undefined,
+        tasks: undefined,
+      })
+    ).toBeUndefined();
+  });
+
+  it("omits a field rather than writing a falsy default", () => {
+    // `{ includeAppOnly: false }` and `{ needsApproval: false }` are the SDK's
+    // own defaults; writing them would make an all-default turn take the
+    // options overload for no reason.
+    expect(mcpToolOptionsFor({ needsApproval: true })).toEqual({
+      needsApproval: true,
+    });
+    expect(mcpToolOptionsFor({ includeAppOnly: true })).toEqual({
+      includeAppOnly: true,
+    });
+  });
+
+  it("carries a defined policy object through unchanged", () => {
+    const policy = { directContent: { image: true } } as never;
+    expect(
+      mcpToolOptionsFor({ modelVisibleMcpToolResults: policy })
+    ).toEqual({ modelVisibleMcpToolResults: policy });
+  });
+
+  it("treats an absent task seam as tasks-off", () => {
+    // `task-seam.ts` returns `undefined` for "this surface must not run tasks",
+    // and that is the same value a caller passes for "no tasks" — one disabled
+    // path, and it must not put a `tasks` key on the wire.
+    expect(mcpToolOptionsFor({ tasks: undefined })).toBeUndefined();
+    const seam = { mode: "await" } as never;
+    expect(mcpToolOptionsFor({ tasks: seam })).toEqual({ tasks: seam });
+  });
+
+  it("reproduces the emulated engine's four-field object", () => {
+    // The shape `chat-v2-orchestration` built by hand before this helper
+    // existed, from the same four host-derived inputs.
+    const policy = { directContent: { image: false } } as never;
+    const seam = { mode: "detach" } as never;
+    expect(
+      mcpToolOptionsFor({
+        needsApproval: true,
+        includeAppOnly: true,
+        modelVisibleMcpToolResults: policy,
+        tasks: seam,
+      })
+    ).toEqual({
+      needsApproval: true,
+      includeAppOnly: true,
+      modelVisibleMcpToolResults: policy,
+      tasks: seam,
+    });
+  });
+});

--- a/mcpjam-inspector/server/utils/assistant-turn.ts
+++ b/mcpjam-inspector/server/utils/assistant-turn.ts
@@ -116,6 +116,30 @@ export interface RunAssistantTurnOptions {
   requireToolApproval?: boolean;
   /** Host/client policy for eligible MCP tool-result content/resources. */
   modelVisibleMcpToolResults?: ModelVisibleMcpToolResults;
+  /**
+   * Host-level SEP-1865 `_meta.ui.visibility` switch, forwarded to the HARNESS
+   * engine only (`MCPJamHandlerOptions.respectToolVisibility` is read by
+   * `runHarnessTurn` and by nothing else — the emulated engine consumes the
+   * tool set `prepareChatV2` already built under this same policy).
+   *
+   * Exposed here because a harness turn REBUILDS its MCP tool set from the
+   * manager (`projectSelectedMcpServersAsHostTools`). A caller that omits this
+   * does not get "the host's default" — it gets the SDK's, which is how an
+   * explicit visibility opt-out came to be ignored on host-executed delivery.
+   * Only an explicit `false` opts out; `undefined`/`true` filter (spec default).
+   */
+  respectToolVisibility?: MCPJamHandlerOptions["respectToolVisibility"];
+  /**
+   * Resolved MCP Tasks seam for this turn, forwarded to the HARNESS engine only
+   * (same read-site rule as `respectToolVisibility` above).
+   *
+   * The MODE is resolved by the CALLER — each surface owns its own row in the
+   * policy matrix (`task-seam.ts`) — and is never re-derived downstream.
+   * Absent keeps a harness turn on the pre-existing no-`_meta` path,
+   * byte-for-byte; dropping it on a surface whose host DID enable tasks
+   * silently degrades that surface to the same path with no way to notice.
+   */
+  tasks?: MCPJamHandlerOptions["tasks"];
 
   /**
    * Which real agent harness runs this turn. Absent ⇒ MCPJam's emulated engine
@@ -471,6 +495,13 @@ function buildHandlerOptions(
     ...(opts.modelVisibleMcpToolResults !== undefined
       ? { modelVisibleMcpToolResults: opts.modelVisibleMcpToolResults }
       : {}),
+    // Harness-only tool-CONSTRUCTION inputs (see the option docblocks). Both
+    // are forwarded on DEFINEDNESS, not truthiness: `respectToolVisibility:
+    // false` IS the opt-out, and would vanish under a truthy check.
+    ...(opts.respectToolVisibility !== undefined
+      ? { respectToolVisibility: opts.respectToolVisibility }
+      : {}),
+    ...(opts.tasks !== undefined ? { tasks: opts.tasks } : {}),
     ...(opts.approvalMode !== undefined
       ? { approvalMode: opts.approvalMode }
       : {}),

--- a/mcpjam-inspector/server/utils/chat-v2-orchestration.ts
+++ b/mcpjam-inspector/server/utils/chat-v2-orchestration.ts
@@ -18,6 +18,7 @@
 import type { ModelMessage } from "@ai-sdk/provider-utils";
 import { jsonSchema, tool, type ToolSet } from "ai";
 import { markUserServerHop } from "./route-error-report.js";
+import { mcpToolOptionsFor } from "./mcp-tool-options.js";
 import {
   MCPClientManager,
   describeError,
@@ -989,24 +990,14 @@ export async function prepareChatV2(
     mcpClientManager.hasServer(id)
   );
 
-  const toolOptions =
-    requireToolApproval ||
-    respectToolVisibility === false ||
-    modelVisibleMcpToolResults !== undefined ||
-    tasks !== undefined
-      ? {
-          ...(requireToolApproval
-            ? { needsApproval: requireToolApproval }
-            : {}),
-          ...(respectToolVisibility === false ? { includeAppOnly: true } : {}),
-          ...(modelVisibleMcpToolResults !== undefined
-            ? { modelVisibleMcpToolResults }
-            : {}),
-          // Absent for every default turn, which is what keeps those turns on
-          // the pre-existing no-options overload.
-          ...(tasks !== undefined ? { tasks } : {}),
-        }
-      : undefined;
+  // `undefined` for every default turn, which is what keeps those turns on the
+  // pre-existing no-options overload. See `mcpToolOptionsFor`.
+  const toolOptions = mcpToolOptionsFor({
+    needsApproval: requireToolApproval,
+    includeAppOnly: respectToolVisibility === false,
+    modelVisibleMcpToolResults,
+    tasks,
+  });
 
   // 1. Get MCP + skill tools
   let mcpTools;

--- a/mcpjam-inspector/server/utils/harness/__tests__/harness-availability.test.ts
+++ b/mcpjam-inspector/server/utils/harness/__tests__/harness-availability.test.ts
@@ -142,13 +142,38 @@ describe("checkHarnessRuntimeAvailable", () => {
     if (!r.ok) expect(r.reason).toMatch(/Codex harness/);
   });
 
-  it("blocks a Codex host that has selected MCP servers (v1: no MCP)", () => {
+  it("allows a Codex host with selected MCP servers (host-executed delivery)", () => {
+    // COMP-39: this used to be the `mcp-servers` refusal, which blocked every
+    // Codex host with a server attached — and therefore every Codex eval, since
+    // an eval suite always has servers. Codex now gets those servers as
+    // host-executed tools, so there is nothing left to refuse.
+    setFullyAvailable();
+    expect(
+      checkHarnessRuntimeAvailable(
+        args({
+          harnessId: "codex",
+          hasSelectedMcpServers: true,
+          model: { id: "openai/gpt-5-nano", provider: "openai" },
+        })
+      )
+    ).toEqual({ ok: true });
+  });
+
+  it("still blocks a Codex approval host with MCP servers (approval can't be honored)", () => {
+    // Advertise = enforce: Codex's MCP tools run on MCPJam's server as
+    // host-executed tools, and Codex declares no host-executed tool approval.
+    // Delivering the servers must NOT quietly turn approval into a no-op.
     setFullyAvailable();
     const r = checkHarnessRuntimeAvailable(
-      args({ harnessId: "codex", hasSelectedMcpServers: true })
+      args({
+        harnessId: "codex",
+        hasSelectedMcpServers: true,
+        requireToolApproval: true,
+        model: { id: "openai/gpt-5-nano", provider: "openai" },
+      })
     );
     expect(r.ok).toBe(false);
-    if (!r.ok) expect(r.reason).toMatch(/doesn't support MCP servers/);
+    if (!r.ok) expect(r.kind).toBe("tool-approval");
   });
 
   it("allows a Claude Code host with selected MCP servers (it delivers them)", () => {

--- a/mcpjam-inspector/server/utils/harness/__tests__/harness-availability.test.ts
+++ b/mcpjam-inspector/server/utils/harness/__tests__/harness-availability.test.ts
@@ -1,6 +1,9 @@
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
-import { checkHarnessRuntimeAvailable } from "../harness-availability";
-import type { HarnessId } from "../registry";
+import {
+  checkHarnessRuntimeAvailable,
+  harnessToolApprovalRefusalReason,
+} from "../harness-availability";
+import { getHarnessAdapter, type HarnessId } from "../registry";
 
 // The capability-driven preflight that lets the chat-v2 routes fail closed with a
 // clear message when a harness host (claude-code | codex) can't run on this server.
@@ -231,4 +234,104 @@ describe("checkHarnessRuntimeAvailable", () => {
       expect(checkHarnessRuntimeAvailable(args())).toEqual({ ok: true });
     }
   );
+});
+
+/**
+ * The approval rules as a standalone value, because `runHarnessTurn` re-asserts
+ * them for the eval / synthetic / unified paths, which never reach the
+ * pre-flight above. Two hand-copied conditions would drift; these assert the
+ * matrix ONE function answers for both.
+ */
+describe("harnessToolApprovalRefusalReason", () => {
+  const claudeCode = getHarnessAdapter("claude-code");
+  const codex = getHarnessAdapter("codex");
+
+  it.each([
+    ["claude-code", false],
+    ["claude-code", true],
+    ["codex", false],
+    ["codex", true],
+  ] as const)(
+    "%s with approval OFF is sound (servers attached: %s)",
+    (harnessId, hasSelectedMcpServers) => {
+      expect(
+        harnessToolApprovalRefusalReason({
+          adapter: getHarnessAdapter(harnessId),
+          requireToolApproval: false,
+          hasSelectedMcpServers,
+        })
+      ).toBeUndefined();
+    }
+  );
+
+  // The gap this closes: Codex's NATIVE tools can't pause either, and its
+  // built-in host-executed tools (web_search) are not approval-gated because
+  // `supportsHostExecutedToolApproval` is false. Conditioning the refusal on
+  // there being MCP servers would let a zero-server eval run them unapproved.
+  it("refuses Codex under approval even with NO servers selected", () => {
+    expect(
+      harnessToolApprovalRefusalReason({
+        adapter: codex,
+        requireToolApproval: true,
+        hasSelectedMcpServers: false,
+      })
+    ).toMatch(/doesn't support interactive tool approval/);
+  });
+
+  it("refuses Codex under approval with servers selected", () => {
+    expect(
+      harnessToolApprovalRefusalReason({
+        adapter: codex,
+        requireToolApproval: true,
+        hasSelectedMcpServers: true,
+      })
+    ).toBeDefined();
+  });
+
+  // Claude Code pauses on its own native tools (WS3), so approval alone is
+  // fine — but it declares no MCP-tool approval, so attaching a server makes
+  // the combination unsound. This is the NATIVE arm of the delivery split.
+  it("allows Claude Code under approval with no servers", () => {
+    expect(
+      harnessToolApprovalRefusalReason({
+        adapter: claudeCode,
+        requireToolApproval: true,
+        hasSelectedMcpServers: false,
+      })
+    ).toBeUndefined();
+  });
+
+  it("refuses Claude Code under approval once a server is attached", () => {
+    expect(claudeCode.mcpDelivery).toBe("native");
+    expect(
+      harnessToolApprovalRefusalReason({
+        adapter: claudeCode,
+        requireToolApproval: true,
+        hasSelectedMcpServers: true,
+      })
+    ).toMatch(/MCP-server tools/);
+  });
+
+  // The bypass the delivery split exists to prevent: Codex's MCP tools are
+  // host-executed, so reading `supportsMcpToolApproval` (false for BOTH
+  // adapters, and irrelevant here) would have looked like the right check.
+  it("reads the capability for the surface each adapter's MCP tools run on", () => {
+    expect(codex.mcpDelivery).toBe("host-executed");
+    expect(codex.supportsHostExecutedToolApproval).toBe(false);
+    const stillApproves = {
+      ...codex,
+      supportsNativeToolApproval: true,
+      supportsHostExecutedToolApproval: true,
+      // Left false on purpose: under host-executed delivery this must not be
+      // what the gate consults.
+      supportsMcpToolApproval: false,
+    } as typeof codex;
+    expect(
+      harnessToolApprovalRefusalReason({
+        adapter: stillApproves,
+        requireToolApproval: true,
+        hasSelectedMcpServers: true,
+      })
+    ).toBeUndefined();
+  });
 });

--- a/mcpjam-inspector/server/utils/harness/__tests__/harness-availability.test.ts
+++ b/mcpjam-inspector/server/utils/harness/__tests__/harness-availability.test.ts
@@ -119,13 +119,24 @@ describe("checkHarnessRuntimeAvailable", () => {
     expect(r.ok).toBe(true);
   });
 
+  // Claude Code's own MCP tools take the NATIVE arm of the delivery split, and
+  // it declares no MCP-tool approval. `kind` is asserted alongside the copy on
+  // purpose: eval admission branches on the kind, so a copy edit must not be
+  // what decides whether this stays a refusal.
   it("still blocks an approval host WITH selected MCP servers (no MCP approval knob)", () => {
     setFullyAvailable();
     const r = checkHarnessRuntimeAvailable(
-      args({ requireToolApproval: true, hasSelectedMcpServers: true })
+      args({
+        harnessId: "claude-code",
+        requireToolApproval: true,
+        hasSelectedMcpServers: true,
+      })
     );
     expect(r.ok).toBe(false);
-    if (!r.ok) expect(r.reason).toMatch(/MCP-server tools/);
+    if (!r.ok) {
+      expect(r.kind).toBe("tool-approval");
+      expect(r.reason).toMatch(/MCP-server tools/);
+    }
   });
 
   it("still blocks an approval host on Codex (no native approval)", () => {

--- a/mcpjam-inspector/server/utils/harness/__tests__/harness-proxy-policy-enforcement.test.ts
+++ b/mcpjam-inspector/server/utils/harness/__tests__/harness-proxy-policy-enforcement.test.ts
@@ -22,6 +22,7 @@ import {
 import { buildIterationFinishParams } from "../../../services/evals/finalize-iteration.js";
 import { buildHarnessToolPolicySnapshots } from "../../../services/evals/tool-policy-gate.js";
 import { buildHarnessProxyMcpJson } from "../mcp-config.js";
+import { getHarnessAdapter } from "../registry.js";
 
 describe("resolveBridgeToolCallTarget", () => {
   const hasServer = (id: string) => id === "srv-b";
@@ -185,29 +186,75 @@ describe("harnessToolPolicyLaunchRefusal", () => {
 
   it("permits a policied harness run on a deployment that can seal", () => {
     expect(
-      harnessToolPolicyLaunchRefusal({ hasToolPolicy: true, harness: true })
+      harnessToolPolicyLaunchRefusal({
+        hasToolPolicy: true,
+        harness: "claude-code",
+      })
     ).toBeNull();
   });
 
   it("refuses rather than running unpoliced when the seal secret is unusable", () => {
     delete process.env.COMPUTERS_TERMINAL_TOKEN_SECRET;
     expect(
-      harnessToolPolicyLaunchRefusal({ hasToolPolicy: true, harness: true })
+      harnessToolPolicyLaunchRefusal({
+        hasToolPolicy: true,
+        harness: "claude-code",
+      })
     ).toBe(HARNESS_TOOL_POLICY_SEAL_UNAVAILABLE_REASON);
     process.env.COMPUTERS_TERMINAL_TOKEN_SECRET = "short";
     expect(
-      harnessToolPolicyLaunchRefusal({ hasToolPolicy: true, harness: true })
+      harnessToolPolicyLaunchRefusal({
+        hasToolPolicy: true,
+        harness: "claude-code",
+      })
     ).toBe(HARNESS_TOOL_POLICY_SEAL_UNAVAILABLE_REASON);
   });
 
   it("says nothing about non-harness runs or unpolicied harness runs", () => {
     delete process.env.COMPUTERS_TERMINAL_TOKEN_SECRET;
     expect(
-      harnessToolPolicyLaunchRefusal({ hasToolPolicy: true, harness: false })
+      harnessToolPolicyLaunchRefusal({
+        hasToolPolicy: true,
+        harness: undefined,
+      })
     ).toBeNull();
     expect(
-      harnessToolPolicyLaunchRefusal({ hasToolPolicy: false, harness: true })
+      harnessToolPolicyLaunchRefusal({
+        hasToolPolicy: false,
+        harness: "claude-code",
+      })
     ).toBeNull();
+  });
+
+  // COMP-39. The seal exists to carry a policy OUT of this process. A
+  // host-executed adapter's MCP calls never leave it — they are gated in-process
+  // by `projectSelectedMcpServersAsHostTools` — so admission must not demand a
+  // token that will never be minted. Before this, a deployment whose terminal
+  // secret was merely too SHORT (nonempty, under the 16-char minimum) refused
+  // every policied Codex eval outright.
+  it("exempts host-executed delivery from the proxy-seal requirement", () => {
+    expect(getHarnessAdapter("codex").mcpDelivery).toBe("host-executed");
+    process.env.COMPUTERS_TERMINAL_TOKEN_SECRET = "short";
+    expect(
+      harnessToolPolicyLaunchRefusal({ hasToolPolicy: true, harness: "codex" })
+    ).toBeNull();
+    delete process.env.COMPUTERS_TERMINAL_TOKEN_SECRET;
+    expect(
+      harnessToolPolicyLaunchRefusal({ hasToolPolicy: true, harness: "codex" })
+    ).toBeNull();
+  });
+
+  // …and the exemption is delivery-scoped, never a general softening: the
+  // native path still fails CLOSED on the same deployment.
+  it("keeps NATIVE delivery failing closed on the same weak-secret deployment", () => {
+    process.env.COMPUTERS_TERMINAL_TOKEN_SECRET = "short";
+    expect(getHarnessAdapter("claude-code").mcpDelivery).toBe("native");
+    expect(
+      harnessToolPolicyLaunchRefusal({
+        hasToolPolicy: true,
+        harness: "claude-code",
+      })
+    ).toBe(HARNESS_TOOL_POLICY_SEAL_UNAVAILABLE_REASON);
   });
 });
 

--- a/mcpjam-inspector/server/utils/harness/__tests__/harness-scope-step-up.test.ts
+++ b/mcpjam-inspector/server/utils/harness/__tests__/harness-scope-step-up.test.ts
@@ -3,9 +3,11 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 import {
   __resetHarnessScopeStepUpForTests,
   harnessScopeStepUpServerMatches,
+  matchHarnessScopeStepUpToolCall,
   normalizeHarnessScopeStepUpCorrelationId,
   publishHarnessScopeStepUp,
   publishHarnessScopeStepUpFromToolError,
+  stableHarnessValue,
   subscribeHarnessScopeStepUp,
 } from "../harness-scope-step-up.js";
 import { inspectorCommandBus } from "../../../services/inspector-command-bus.js";
@@ -201,5 +203,124 @@ describe("harness scope step-up correlation", () => {
     expect(harnessScopeStepUpServerMatches(undefined, "auth-bench")).toBe(
       false,
     );
+  });
+});
+
+/**
+ * Which observed tool call a challenge resumes.
+ *
+ * `runHarnessTurn` suspends exactly one `toolCallId` and resumes THAT call after
+ * the step-up, so picking the wrong one re-runs a call that already succeeded
+ * and abandons the one that actually failed.
+ */
+describe("matchHarnessScopeStepUpToolCall", () => {
+  const first = {
+    toolCallId: "call-1",
+    serverId: "cal",
+    toolName: "create_event",
+    input: { title: "standup" },
+  };
+  const second = {
+    toolCallId: "call-2",
+    serverId: "cal",
+    toolName: "create_event",
+    input: { title: "standup" },
+  };
+
+  it("resumes the call the challenge came from, not the first identical one", () => {
+    // The regression: two byte-identical calls in one turn. The tuple matcher
+    // returns `find`'s FIRST hit, so a challenge raised by the second call
+    // resumed the first. A host-executed call carries the AI SDK `toolCallId`
+    // straight out of `execute()`, so there is no need to guess.
+    expect(
+      matchHarnessScopeStepUpToolCall({
+        observed: [first, second],
+        challenge: {
+          serverId: "cal",
+          toolCallId: "call-2",
+          requiredScope: "calendar.write",
+          toolName: "create_event",
+          toolInput: { title: "standup" },
+        },
+      }),
+    ).toBe(second);
+  });
+
+  it("falls back to the tuple when the publisher had no id (the proxy path)", () => {
+    // The signed proxy only ever saw an HTTP `tools/call`; it has no AI SDK id
+    // to publish, so the tuple stays the correlator for native delivery.
+    expect(
+      matchHarnessScopeStepUpToolCall({
+        observed: [
+          {
+            toolCallId: "call-9",
+            serverId: "cal",
+            toolName: "list_events",
+            input: { range: "week", limit: 5 },
+          },
+        ],
+        challenge: {
+          serverId: "CAL",
+          requiredScope: "calendar.read",
+          toolName: "list_events",
+          // Key ORDER must not matter — the proxy reserializes the arguments.
+          toolInput: { limit: 5, range: "week" },
+        },
+      })?.toolCallId,
+    ).toBe("call-9");
+  });
+
+  it("waits rather than degrading to the tuple when the id is not observed yet", () => {
+    // A challenge can land before its own `tool-call` part is consumed. Falling
+    // back to the tuple here is exactly how the wrong call gets resumed; the
+    // correlator is re-run on every later observed call, so returning nothing
+    // costs only a retry.
+    expect(
+      matchHarnessScopeStepUpToolCall({
+        observed: [first],
+        challenge: {
+          serverId: "cal",
+          toolCallId: "call-2",
+          requiredScope: "calendar.write",
+          toolName: "create_event",
+          toolInput: { title: "standup" },
+        },
+      }),
+    ).toBeUndefined();
+  });
+
+  it("ignores a tuple match on a different server or tool", () => {
+    expect(
+      matchHarnessScopeStepUpToolCall({
+        observed: [first],
+        challenge: {
+          serverId: "other",
+          requiredScope: "x",
+          toolName: "create_event",
+          toolInput: { title: "standup" },
+        },
+      }),
+    ).toBeUndefined();
+    expect(
+      matchHarnessScopeStepUpToolCall({
+        observed: [first],
+        challenge: {
+          serverId: "cal",
+          requiredScope: "x",
+          toolName: "delete_event",
+          toolInput: { title: "standup" },
+        },
+      }),
+    ).toBeUndefined();
+  });
+});
+
+describe("stableHarnessValue", () => {
+  it("is order-independent for objects and order-sensitive for arrays", () => {
+    expect(stableHarnessValue({ a: 1, b: [2, { d: 4, c: 3 }] })).toBe(
+      stableHarnessValue({ b: [2, { c: 3, d: 4 }], a: 1 }),
+    );
+    expect(stableHarnessValue([1, 2])).not.toBe(stableHarnessValue([2, 1]));
+    expect(stableHarnessValue(undefined)).toBe("null");
   });
 });

--- a/mcpjam-inspector/server/utils/harness/__tests__/host-executed-mcp-tools.test.ts
+++ b/mcpjam-inspector/server/utils/harness/__tests__/host-executed-mcp-tools.test.ts
@@ -1,0 +1,249 @@
+/**
+ * COMP-39 — host-executed MCP delivery for the Codex harness.
+ *
+ * Every assertion here fails against the previous behaviour, where Codex had no
+ * MCP delivery at all and a Codex host with selected servers was refused before
+ * a turn ever opened.
+ */
+import { describe, expect, it, vi } from "vitest";
+import { buildToolPolicySnapshot } from "@mcpjam/sdk/contract";
+import {
+  harnessMcpToolName,
+  projectSelectedMcpServersAsHostTools,
+} from "../host-executed-mcp-tools";
+import {
+  buildHarnessProxyMcpJson,
+  parseHarnessToolName,
+} from "../mcp-config";
+import { getHarnessAdapter } from "../registry";
+
+type FakeTool = {
+  description?: string;
+  execute: (input: unknown, options: unknown) => Promise<unknown>;
+};
+
+/** A manager stub exposing only what the projection consumes. */
+function fakeManager(servers: Record<string, Record<string, FakeTool>>) {
+  const getToolsForAiSdk = vi.fn(async (ids: string[]) => {
+    const id = ids[0]!;
+    // Mirrors the real manager: ONE call per server id, tools keyed by their
+    // un-namespaced name.
+    return { ...(servers[id] ?? {}) };
+  });
+  return {
+    getServerConfig: vi.fn((id: string) =>
+      Object.prototype.hasOwnProperty.call(servers, id) ? { url: "x" } : undefined
+    ),
+    getToolsForAiSdk,
+  } as never as Parameters<
+    typeof projectSelectedMcpServersAsHostTools
+  >[0]["manager"] & {
+    getToolsForAiSdk: typeof getToolsForAiSdk;
+  };
+}
+
+function tool(result: unknown = { ok: true }): FakeTool {
+  return { description: "d", execute: vi.fn(async () => result) };
+}
+
+describe("projectSelectedMcpServersAsHostTools", () => {
+  it("names projected tools exactly as Claude Code namespaces its MCP tools", async () => {
+    const manager = fakeManager({
+      "weather-api": { get_forecast: tool() },
+    });
+    const projected = await projectSelectedMcpServersAsHostTools({
+      manager,
+      selectedServerIds: ["weather-api"],
+    });
+
+    // The name the model sees must be byte-identical to the one Claude Code's
+    // own MCP client produces from the SAME server id, or a trace/eval
+    // assertion written against a Claude Code run stops matching on Codex.
+    const claudeKey = Object.keys(
+      buildHarnessProxyMcpJson([
+        { name: "weather-api", proxyUrl: "https://example.com/mcp" },
+      ]).mcpServers
+    )[0]!;
+    expect(Object.keys(projected.tools)).toEqual([
+      `mcp__${claudeKey}__get_forecast`,
+    ]);
+    // `sanitizeServerName` keeps hyphens, so this id survives unchanged.
+    expect(Object.keys(projected.tools)[0]).toBe(
+      "mcp__weather-api__get_forecast"
+    );
+  });
+
+  it("round-trips a relayed call back to the right serverId via parseToolName", async () => {
+    const manager = fakeManager({
+      "weather-api": { get_forecast: tool() },
+      "docs.server": { search: tool() },
+    });
+    const projected = await projectSelectedMcpServersAsHostTools({
+      manager,
+      selectedServerIds: ["weather-api", "docs.server"],
+    });
+
+    // This is what `runHarnessTurn` does with the name the codex bridge relays
+    // back — through the ADAPTER, so the Codex adapter's own parseToolName is
+    // the thing under test, not just the helper.
+    const codex = getHarnessAdapter("codex");
+    for (const name of Object.keys(projected.tools)) {
+      const attribution = codex.parseToolName(name, projected.keyToServerId);
+      expect(attribution.serverId).toBeDefined();
+      expect(name).toBe(
+        harnessMcpToolName(
+          Object.entries(projected.keyToServerId).find(
+            ([, serverId]) => serverId === attribution.serverId
+          )![0],
+          attribution.toolName
+        )
+      );
+    }
+    expect(
+      codex.parseToolName(
+        "mcp__weather-api__get_forecast",
+        projected.keyToServerId
+      )
+    ).toEqual({ serverId: "weather-api", toolName: "get_forecast" });
+    expect(
+      codex.parseToolName("mcp__docs_server__search", projected.keyToServerId)
+    ).toEqual({ serverId: "docs.server", toolName: "search" });
+  });
+
+  it("keeps same-named tools from two servers distinct (per-server enumeration)", async () => {
+    // The manager's multi-id form flattens last-in-wins, which would silently
+    // drop one of these. The projection must call it once per server.
+    const manager = fakeManager({
+      alpha: { search: tool("alpha") },
+      beta: { search: tool("beta") },
+    });
+    const projected = await projectSelectedMcpServersAsHostTools({
+      manager,
+      selectedServerIds: ["alpha", "beta"],
+    });
+    expect(Object.keys(projected.tools).sort()).toEqual([
+      "mcp__alpha__search",
+      "mcp__beta__search",
+    ]);
+    expect(manager.getToolsForAiSdk).toHaveBeenCalledTimes(2);
+    expect(manager.getToolsForAiSdk).toHaveBeenCalledWith(["alpha"]);
+    expect(manager.getToolsForAiSdk).toHaveBeenCalledWith(["beta"]);
+  });
+
+  it("de-duplicates server keys that sanitize to the same name", async () => {
+    const manager = fakeManager({
+      "a.b": { t: tool() },
+      "a-b": { t: tool() },
+    });
+    const projected = await projectSelectedMcpServersAsHostTools({
+      manager,
+      selectedServerIds: ["a.b", "a-b"],
+    });
+    expect(Object.keys(projected.tools)).toHaveLength(2);
+    expect(new Set(Object.values(projected.keyToServerId))).toEqual(
+      new Set(["a.b", "a-b"])
+    );
+  });
+
+  it("executes through the manager's own tool, not a re-implementation", async () => {
+    const inner = tool({ content: [{ type: "text", text: "hi" }] });
+    const manager = fakeManager({ srv: { ping: inner } });
+    const projected = await projectSelectedMcpServersAsHostTools({
+      manager,
+      selectedServerIds: ["srv"],
+    });
+    // No policy in force ⇒ the manager's tool object is passed through
+    // untouched, so there is exactly one execution path for an MCP call.
+    expect(projected.tools["mcp__srv__ping"]).toBe(inner);
+  });
+
+  it("skips a selected server with no live config rather than failing the turn", async () => {
+    const manager = fakeManager({ live: { t: tool() } });
+    const projected = await projectSelectedMcpServersAsHostTools({
+      manager,
+      selectedServerIds: ["live", "stale"],
+    });
+    expect(Object.keys(projected.tools)).toEqual(["mcp__live__t"]);
+    expect(projected.keyToServerId).toEqual({ live: "live" });
+  });
+
+  it("returns nothing when no server is selected", async () => {
+    const manager = fakeManager({});
+    await expect(
+      projectSelectedMcpServersAsHostTools({
+        manager,
+        selectedServerIds: [],
+      })
+    ).resolves.toEqual({ tools: {}, keyToServerId: {} });
+    expect(manager.getToolsForAiSdk).not.toHaveBeenCalled();
+  });
+
+  describe("toolPolicy is enforced in-process (the proxy seal has no role here)", () => {
+    const snapshot = buildToolPolicySnapshot({
+      policy: { mode: "default", deny: ["delete_all"] },
+      tools: [{ name: "delete_all" }, { name: "read_thing" }],
+    });
+
+    it("blocks a denied tool before it reaches the server", async () => {
+      const denied = tool();
+      const manager = fakeManager({
+        srv: { delete_all: denied, read_thing: tool() },
+      });
+      const projected = await projectSelectedMcpServersAsHostTools({
+        manager,
+        selectedServerIds: ["srv"],
+        toolPolicy: { srv: snapshot },
+      });
+      const gated = projected.tools["mcp__srv__delete_all"] as FakeTool;
+      const result = (await gated.execute({}, {})) as {
+        content: Array<{ text: string }>;
+        _meta: Record<string, { reason: string }>;
+      };
+      expect(denied.execute).not.toHaveBeenCalled();
+      // The SAME envelope the proxy answers with, so the turn's existing
+      // detectors account it as blockedByPolicy rather than as a tool failure.
+      expect(result.content[0]!.text).toMatch(/^Call blocked by tool policy: /);
+      expect(result._meta["mcpjam/policyBlock"]!.reason).toBe("denyList");
+    });
+
+    it("lets an allowed tool through untouched", async () => {
+      const allowed = tool("real result");
+      const manager = fakeManager({ srv: { read_thing: allowed } });
+      const projected = await projectSelectedMcpServersAsHostTools({
+        manager,
+        selectedServerIds: ["srv"],
+        toolPolicy: { srv: snapshot },
+      });
+      const gated = projected.tools["mcp__srv__read_thing"] as FakeTool;
+      await expect(gated.execute({ a: 1 }, {})).resolves.toBe("real result");
+      expect(allowed.execute).toHaveBeenCalledWith({ a: 1 }, {});
+    });
+
+    it("blocks a tool that appeared after launch (unknownAtLaunch)", async () => {
+      const late = tool();
+      const manager = fakeManager({ srv: { brand_new: late } });
+      const projected = await projectSelectedMcpServersAsHostTools({
+        manager,
+        selectedServerIds: ["srv"],
+        toolPolicy: { srv: snapshot },
+      });
+      const gated = projected.tools["mcp__srv__brand_new"] as FakeTool;
+      const result = (await gated.execute({}, {})) as {
+        _meta: Record<string, { reason: string }>;
+      };
+      expect(late.execute).not.toHaveBeenCalled();
+      expect(result._meta["mcpjam/policyBlock"]!.reason).toBe("unknownAtLaunch");
+    });
+  });
+});
+
+describe("harnessMcpToolName", () => {
+  it("is the same scheme parseHarnessToolName reverses", () => {
+    const name = harnessMcpToolName("weather", "get_forecast");
+    expect(name).toBe("mcp__weather__get_forecast");
+    expect(parseHarnessToolName(name, { weather: "srv-1" })).toEqual({
+      serverId: "srv-1",
+      toolName: "get_forecast",
+    });
+  });
+});

--- a/mcpjam-inspector/server/utils/harness/__tests__/host-executed-mcp-tools.test.ts
+++ b/mcpjam-inspector/server/utils/harness/__tests__/host-executed-mcp-tools.test.ts
@@ -7,6 +7,8 @@
  */
 import { describe, expect, it, vi } from "vitest";
 import { buildToolPolicySnapshot } from "@mcpjam/sdk/contract";
+import { scrubMetaAndStructuredContentFromToolResult } from "@mcpjam/sdk";
+import type { CallToolResult } from "@modelcontextprotocol/client";
 import {
   harnessMcpToolName,
   projectSelectedMcpServersAsHostTools,
@@ -273,6 +275,172 @@ describe("projectSelectedMcpServersAsHostTools", () => {
           selectedServerIds: ["ok", "broken"],
         })
       ).rejects.toThrow(/server went away mid-enumeration/);
+    });
+  });
+
+  /**
+   * The relay is a MODEL channel. `execute()` answers the raw MCP result (the
+   * inspector's UI renders widgets off it); `toModelOutput()` is the projection
+   * the model is allowed to see. The harness host-tool loop only ever calls
+   * `execute()`, so without the wrapper an MCP App tool's client-only `_meta`
+   * and `structuredContent` rode straight into Codex's context.
+   */
+  describe("the relay carries the model-facing projection, not the raw result", () => {
+    /** An app tool the way `convertMCPToolsToVercelTools` builds one: raw from
+     *  `execute`, scrubbed through `toModelOutput`, wrapped in the AI SDK's
+     *  `{type:"json"}` transport envelope. */
+    function appTool(raw: CallToolResult) {
+      return {
+        description: "d",
+        execute: vi.fn(async () => raw),
+        toModelOutput: vi.fn(
+          (opts: { toolCallId: string; input: unknown; output: unknown }) => ({
+            type: "json" as const,
+            value: scrubMetaAndStructuredContentFromToolResult(
+              opts.output as CallToolResult
+            ),
+          })
+        ),
+      };
+    }
+
+    const rawAppResult: CallToolResult = {
+      content: [{ type: "text", text: "42 open issues" }],
+      structuredContent: { count: 42 },
+      _meta: { "openai/outputTemplate": "ui://widget/issues.html" },
+    };
+
+    it("scrubs client-only _meta and structuredContent off what the model sees", async () => {
+      const inner = appTool(rawAppResult);
+      const manager = fakeManager({ gh: { list_issues: inner } });
+      const projected = await projectSelectedMcpServersAsHostTools({
+        manager,
+        selectedServerIds: ["gh"],
+      });
+      const relayed = await (
+        projected.tools["mcp__gh__list_issues"] as FakeTool
+      ).execute({}, { toolCallId: "call-1" });
+
+      // The envelope is unwrapped, so the wire shape is unchanged for a tool
+      // with nothing to scrub — but the widget payload is gone.
+      expect(relayed).toEqual({
+        content: [{ type: "text", text: "42 open issues" }],
+      });
+      expect(relayed).not.toHaveProperty("_meta");
+      expect(relayed).not.toHaveProperty("structuredContent");
+      // Not re-implemented here: it is the manager tool's OWN projection, so the
+      // harness and the emulated engine cannot disagree about model visibility.
+      expect(inner.toModelOutput).toHaveBeenCalledTimes(1);
+      expect(inner.toModelOutput.mock.calls[0]![0]!.output).toBe(rawAppResult);
+    });
+
+    it("hands the RAW result back for the UI, keyed by toolCallId", async () => {
+      // The runtime echoes back only what it was given, so without this the UI,
+      // the trace and the transcript would all show the scrubbed copy — a
+      // divergence from every other engine.
+      const seen: Array<{ toolCallId: string; raw: unknown }> = [];
+      const manager = fakeManager({ gh: { list_issues: appTool(rawAppResult) } });
+      const projected = await projectSelectedMcpServersAsHostTools({
+        manager,
+        selectedServerIds: ["gh"],
+        onRawResult: (a) => seen.push(a),
+      });
+      await (projected.tools["mcp__gh__list_issues"] as FakeTool).execute(
+        {},
+        { toolCallId: "call-7" }
+      );
+      expect(seen).toEqual([{ toolCallId: "call-7", raw: rawAppResult }]);
+    });
+
+    it("leaves a tool with no projection untouched, by identity", async () => {
+      // Most MCP tools are not app tools. They must not pay a wrapper, and the
+      // single-execution-path property has to survive this change.
+      const inner = tool({ content: [{ type: "text", text: "hi" }] });
+      const manager = fakeManager({ srv: { ping: inner } });
+      const projected = await projectSelectedMcpServersAsHostTools({
+        manager,
+        selectedServerIds: ["srv"],
+      });
+      expect(projected.tools["mcp__srv__ping"]).toBe(inner);
+      await expect(
+        (projected.tools["mcp__srv__ping"] as FakeTool).execute({}, {})
+      ).resolves.toEqual({ content: [{ type: "text", text: "hi" }] });
+    });
+
+    it("passes a non-json output envelope through as-is", async () => {
+      // The image/linked-resource projection is a genuinely different,
+      // self-describing shape; flattening it would make the model guess.
+      const contentOutput = {
+        type: "content" as const,
+        value: [{ type: "media", data: "…", mediaType: "image/png" }],
+      };
+      const inner = {
+        description: "d",
+        execute: vi.fn(async () => ({ content: [] })),
+        toModelOutput: vi.fn(() => contentOutput),
+      };
+      const manager = fakeManager({ srv: { shot: inner } });
+      const projected = await projectSelectedMcpServersAsHostTools({
+        manager,
+        selectedServerIds: ["srv"],
+      });
+      await expect(
+        (projected.tools["mcp__srv__shot"] as FakeTool).execute({}, {})
+      ).resolves.toEqual(contentOutput);
+    });
+
+    it("does not project a policy block envelope (projection is innermost)", async () => {
+      // Above the gate, the projection would scrub the `_meta` marker the turn
+      // recognises its OWN block by, and a refusal would be misaccounted as the
+      // customer's tool failing.
+      const inner = appTool(rawAppResult);
+      const manager = fakeManager({ srv: { delete_all: inner } });
+      const projected = await projectSelectedMcpServersAsHostTools({
+        manager,
+        selectedServerIds: ["srv"],
+        toolPolicy: {
+          srv: buildToolPolicySnapshot({
+            policy: { mode: "default", deny: ["delete_all"] },
+            tools: [{ name: "delete_all" }],
+          }),
+        },
+      });
+      const result = (await (
+        projected.tools["mcp__srv__delete_all"] as FakeTool
+      ).execute({}, {})) as { _meta: Record<string, { reason: string }> };
+      expect(result._meta["mcpjam/policyBlock"]!.reason).toBe("denyList");
+      expect(inner.toModelOutput).not.toHaveBeenCalled();
+    });
+
+    it("still observes a scope challenge through the projection wrapper", async () => {
+      // Layering must not cost the SEP-2350 bridge: the error is raised by the
+      // innermost `execute`, below the projection, and still reaches the sink.
+      const error = Object.assign(new Error("Forbidden"), {
+        name: "InsufficientScopeError",
+        requiredScope: "repo.write",
+      });
+      const inner = {
+        description: "d",
+        execute: vi.fn(async () => {
+          throw error;
+        }),
+        toModelOutput: vi.fn(() => ({ type: "json" as const, value: {} })),
+      };
+      const manager = fakeManager({ gh: { create_issue: inner } });
+      const seen: unknown[] = [];
+      const projected = await projectSelectedMcpServersAsHostTools({
+        manager,
+        selectedServerIds: ["gh"],
+        onScopeStepUpChallenge: (event) => seen.push(event),
+      });
+      await expect(
+        (projected.tools["mcp__gh__create_issue"] as FakeTool).execute(
+          {},
+          { toolCallId: "call-2" }
+        )
+      ).rejects.toBe(error);
+      expect(seen).toHaveLength(1);
+      expect(inner.toModelOutput).not.toHaveBeenCalled();
     });
   });
 

--- a/mcpjam-inspector/server/utils/harness/__tests__/host-executed-mcp-tools.test.ts
+++ b/mcpjam-inspector/server/utils/harness/__tests__/host-executed-mcp-tools.test.ts
@@ -235,6 +235,177 @@ describe("projectSelectedMcpServersAsHostTools", () => {
       expect(result._meta["mcpjam/policyBlock"]!.reason).toBe("unknownAtLaunch");
     });
   });
+
+  describe("a projection failure fails the turn instead of quietly shrinking it", () => {
+    const plugin = {
+      pluginId: "p1",
+      pluginVersionId: "pv1",
+      name: "Calendar Pack",
+      bundleHash: "abc",
+    };
+
+    it("refuses when a PLUGIN-contributed server has no live connection", async () => {
+      // Hosts are plugin-blind: the environment pinned this version precisely to
+      // get these tools, so a silently reduced tool set would surface only as
+      // the agent "not doing the thing". Name the plugin and refuse.
+      const manager = fakeManager({ live: { t: tool() } });
+      await expect(
+        projectSelectedMcpServersAsHostTools({
+          manager,
+          selectedServerIds: ["live", "from-plugin"],
+          pluginOrigins: { "from-plugin": plugin },
+        })
+      ).rejects.toThrow(/Calendar Pack/);
+    });
+
+    it("propagates an enumeration failure rather than returning a partial set", async () => {
+      // Half a tool set is worse than none: the model would silently plan
+      // around tools the user believes are attached.
+      const manager = fakeManager({ ok: { t: tool() }, broken: {} });
+      (manager.getToolsForAiSdk as unknown as ReturnType<typeof vi.fn>)
+        .mockImplementationOnce(async () => ({ t: tool() }))
+        .mockImplementationOnce(async () => {
+          throw new Error("server went away mid-enumeration");
+        });
+      await expect(
+        projectSelectedMcpServersAsHostTools({
+          manager,
+          selectedServerIds: ["ok", "broken"],
+        })
+      ).rejects.toThrow(/server went away mid-enumeration/);
+    });
+  });
+
+  describe("scope step-up (SEP-2350) survives in-process execution", () => {
+    /** What a live 403 `insufficient_scope` surfaces as, per the SDK's
+     *  `isInsufficientScopeNode` (branded class name + challenge fields). */
+    function insufficientScope(): Error {
+      const error = new Error("Forbidden");
+      error.name = "InsufficientScopeError";
+      return Object.assign(error, {
+        requiredScope: "calendar.write",
+        resourceMetadataUrl: new URL(
+          "https://cal.example/.well-known/oauth-protected-resource"
+        ),
+      });
+    }
+
+    function throwing(error: Error): FakeTool {
+      return {
+        description: "d",
+        execute: vi.fn(async () => {
+          throw error;
+        }),
+      };
+    }
+
+    it("publishes the exact tuple the turn correlates a challenge on", async () => {
+      const error = insufficientScope();
+      const manager = fakeManager({ cal: { create_event: throwing(error) } });
+      const seen: unknown[] = [];
+      const projected = await projectSelectedMcpServersAsHostTools({
+        manager,
+        selectedServerIds: ["cal"],
+        onScopeStepUpChallenge: (event) => seen.push(event),
+      });
+
+      const t = projected.tools["mcp__cal__create_event"] as FakeTool;
+      // The error still reaches the caller — this observes, never swallows.
+      await expect(
+        t.execute({ title: "x" }, { toolCallId: "call-1" })
+      ).rejects.toBe(error);
+
+      // `runHarnessTurn` matches a challenge to its observed tool call on
+      // exactly (serverId, UN-namespaced toolName, raw input). Anything else
+      // here and the correlation silently never fires.
+      expect(seen).toEqual([
+        {
+          serverId: "cal",
+          toolCallId: "call-1",
+          requiredScope: "calendar.write",
+          resourceMetadataUrl:
+            "https://cal.example/.well-known/oauth-protected-resource",
+          errorDescription: undefined,
+          toolName: "create_event",
+          toolInput: { title: "x" },
+        },
+      ]);
+    });
+
+    it("stays quiet on an ordinary tool failure", async () => {
+      const manager = fakeManager({
+        srv: { t: throwing(new Error("upstream 500")) },
+      });
+      const seen: unknown[] = [];
+      const projected = await projectSelectedMcpServersAsHostTools({
+        manager,
+        selectedServerIds: ["srv"],
+        onScopeStepUpChallenge: (event) => seen.push(event),
+      });
+      await expect(
+        (projected.tools["mcp__srv__t"] as FakeTool).execute({}, {})
+      ).rejects.toThrow("upstream 500");
+      expect(seen).toEqual([]);
+    });
+
+    it("passes the manager's tool through by identity when no sink is given", async () => {
+      // Eval/synthetic callers supply no sink and cannot pause anyway; they must
+      // not pay a wrapper, so the single-execution-path property still holds.
+      const inner = tool();
+      const manager = fakeManager({ srv: { ping: inner } });
+      const projected = await projectSelectedMcpServersAsHostTools({
+        manager,
+        selectedServerIds: ["srv"],
+      });
+      expect(projected.tools["mcp__srv__ping"]).toBe(inner);
+    });
+
+    it("still observes when a policy snapshot is also in force", async () => {
+      const error = insufficientScope();
+      const manager = fakeManager({ srv: { read_thing: throwing(error) } });
+      const seen: unknown[] = [];
+      const projected = await projectSelectedMcpServersAsHostTools({
+        manager,
+        selectedServerIds: ["srv"],
+        toolPolicy: {
+          srv: buildToolPolicySnapshot({
+            policy: { mode: "default", deny: ["delete_all"] },
+            tools: [{ name: "delete_all" }, { name: "read_thing" }],
+          }),
+        },
+        onScopeStepUpChallenge: (event) => seen.push(event),
+      });
+      await expect(
+        (projected.tools["mcp__srv__read_thing"] as FakeTool).execute({}, {})
+      ).rejects.toBe(error);
+      expect(seen).toHaveLength(1);
+    });
+
+    it("does not fire for a call the policy blocked (gate is outermost)", async () => {
+      // A denied call reaches no server, so there is no challenge to raise —
+      // and it returns the block envelope rather than throwing at all.
+      const manager = fakeManager({
+        srv: { delete_all: throwing(insufficientScope()) },
+      });
+      const seen: unknown[] = [];
+      const projected = await projectSelectedMcpServersAsHostTools({
+        manager,
+        selectedServerIds: ["srv"],
+        toolPolicy: {
+          srv: buildToolPolicySnapshot({
+            policy: { mode: "default", deny: ["delete_all"] },
+            tools: [{ name: "delete_all" }],
+          }),
+        },
+        onScopeStepUpChallenge: (event) => seen.push(event),
+      });
+      const result = (await (
+        projected.tools["mcp__srv__delete_all"] as FakeTool
+      ).execute({}, {})) as { _meta: Record<string, { reason: string }> };
+      expect(result._meta["mcpjam/policyBlock"]!.reason).toBe("denyList");
+      expect(seen).toEqual([]);
+    });
+  });
 });
 
 describe("harnessMcpToolName", () => {

--- a/mcpjam-inspector/server/utils/harness/__tests__/host-executed-mcp-tools.test.ts
+++ b/mcpjam-inspector/server/utils/harness/__tests__/host-executed-mcp-tools.test.ts
@@ -576,6 +576,248 @@ describe("projectSelectedMcpServersAsHostTools", () => {
   });
 });
 
+/**
+ * The host's tool-CONSTRUCTION options must reach `getToolsForAiSdk`.
+ *
+ * `getToolsForAiSdk(serverIds?, options = {})` says outright that it will not
+ * read a host config itself — "the mode is resolved by the CALLER". This
+ * projection called it with NO options object, so every host-derived input was
+ * dropped and a Codex turn's MCP tools were built under the SDK's defaults. The
+ * previous fix wired `toModelOutput` through; the tool it ran was still built
+ * with the wrong policy, so the turn projected under a policy the host never
+ * chose.
+ *
+ * Every assertion in this block fails against that behaviour.
+ */
+describe("host-derived tool-construction options reach the SDK conversion", () => {
+  /**
+   * A manager stub that HONORS the options, the way the real one does.
+   *
+   * The point is that the assertions below read the RELAYED VALUE, not the
+   * arguments: `toModelOutput` drops a direct image block unless
+   * `directContent.image` is on — the same gate `model-output.ts` applies — and
+   * an app-only tool is omitted from the set unless `includeAppOnly` is set,
+   * the same gate `tool-converters.ts` applies. A projection that forwards
+   * nothing therefore produces observably different tools and observably
+   * different model-facing output.
+   */
+  function policyHonoringManager(
+    servers: Record<
+      string,
+      Record<string, { appOnly?: boolean; result: unknown }>
+    >
+  ) {
+    const getToolsForAiSdk = vi.fn(
+      async (
+        ids: string[],
+        options?: {
+          includeAppOnly?: boolean;
+          modelVisibleMcpToolResults?: {
+            directContent?: { image?: boolean };
+          };
+          tasks?: unknown;
+          needsApproval?: boolean;
+        }
+      ) => {
+        const id = ids[0]!;
+        const out: Record<string, unknown> = {};
+        for (const [name, spec] of Object.entries(servers[id] ?? {})) {
+          if (spec.appOnly && !options?.includeAppOnly) continue;
+          out[name] = {
+            description: "d",
+            // Presence of a task seam is observable on the built tool, exactly
+            // as the SDK's seam is (it changes what a call sends).
+            ...(options?.tasks !== undefined ? { _tasksSeam: true } : {}),
+            ...(options?.needsApproval !== undefined
+              ? { needsApproval: options.needsApproval }
+              : {}),
+            execute: vi.fn(async () => spec.result),
+            toModelOutput: ({ output }: { output: unknown }) => {
+              const raw = output as { content?: Array<{ type?: string }> };
+              const allowImages =
+                options?.modelVisibleMcpToolResults?.directContent?.image ===
+                true;
+              return {
+                type: "json" as const,
+                value: {
+                  content: (raw.content ?? []).filter(
+                    (block) => allowImages || block.type !== "image"
+                  ),
+                },
+              };
+            },
+          };
+        }
+        return out;
+      }
+    );
+    return {
+      getServerConfig: vi.fn((id: string) =>
+        Object.prototype.hasOwnProperty.call(servers, id)
+          ? { url: "x" }
+          : undefined
+      ),
+      getToolsForAiSdk,
+    } as never as Parameters<
+      typeof projectSelectedMcpServersAsHostTools
+    >[0]["manager"] & { getToolsForAiSdk: typeof getToolsForAiSdk };
+  }
+
+  const withImage = {
+    content: [
+      { type: "text", text: "here is the chart" },
+      { type: "image", data: "iVBOR…", mimeType: "image/png" },
+    ],
+  };
+
+  it("applies the HOST's modelVisibleMcpToolResults to what the relay carries", async () => {
+    // THE REPORTED BUG. Without the option the tool is built under the SDK
+    // default, so the projection runs — with the wrong policy. The image the
+    // host explicitly allowed never reaches the model.
+    const manager = policyHonoringManager({
+      charts: { render: { result: withImage } },
+    });
+    const projected = await projectSelectedMcpServersAsHostTools({
+      manager,
+      selectedServerIds: ["charts"],
+      toolOptions: {
+        modelVisibleMcpToolResults: {
+          directContent: { image: true },
+        } as never,
+      },
+    });
+    const relayed = await (
+      projected.tools["mcp__charts__render"] as FakeTool
+    ).execute({}, { toolCallId: "call-1" });
+    expect(relayed).toEqual(withImage);
+  });
+
+  it("omits the image when the host policy disallows it", async () => {
+    // The other direction, so the assertion above cannot pass by accident on a
+    // projection that ignores the policy in a permissive way.
+    const manager = policyHonoringManager({
+      charts: { render: { result: withImage } },
+    });
+    const projected = await projectSelectedMcpServersAsHostTools({
+      manager,
+      selectedServerIds: ["charts"],
+      toolOptions: {
+        modelVisibleMcpToolResults: {
+          directContent: { image: false },
+        } as never,
+      },
+    });
+    const relayed = await (
+      projected.tools["mcp__charts__render"] as FakeTool
+    ).execute({}, { toolCallId: "call-1" });
+    expect(relayed).toEqual({
+      content: [{ type: "text", text: "here is the chart" }],
+    });
+  });
+
+  it("includes SEP-1865 app-only tools when the host opts out of visibility", async () => {
+    // `respectToolVisibility === false` (Cursor/VS Code templates today) is a
+    // host declaring it does not filter app-only tools. Latent on Codex right
+    // now — no harness template sets it — but the same dropped-option class.
+    const manager = policyHonoringManager({
+      gh: {
+        list_issues: { result: { ok: true } },
+        render_widget: { appOnly: true, result: { ok: true } },
+      },
+    });
+    const optedOut = await projectSelectedMcpServersAsHostTools({
+      manager,
+      selectedServerIds: ["gh"],
+      toolOptions: { includeAppOnly: true },
+    });
+    expect(Object.keys(optedOut.tools).sort()).toEqual([
+      "mcp__gh__list_issues",
+      "mcp__gh__render_widget",
+    ]);
+
+    // …and the spec default still hides it.
+    const filtered = await projectSelectedMcpServersAsHostTools({
+      manager,
+      selectedServerIds: ["gh"],
+      toolOptions: { includeAppOnly: false },
+    });
+    expect(Object.keys(filtered.tools)).toEqual(["mcp__gh__list_issues"]);
+  });
+
+  it("carries the resolved task seam into the built tools", async () => {
+    // Dropping the seam degrades MCP Tasks to the pre-existing no-`_meta` path
+    // on this delivery mode only — a host-level policy silently meaning
+    // something different on Codex than on Claude Code.
+    const manager = policyHonoringManager({ srv: { t: { result: {} } } });
+    const projected = await projectSelectedMcpServersAsHostTools({
+      manager,
+      selectedServerIds: ["srv"],
+      toolOptions: { tasks: { mode: "await" } as never },
+    });
+    expect(projected.tools["mcp__srv__t"]).toMatchObject({
+      _tasksSeam: true,
+    });
+  });
+
+  it("never sets needsApproval — host-executed approval is the agent's own gate", async () => {
+    // Deliberately absent, not forgotten: `HarnessAgent`'s `toolApproval` map
+    // is what gates a host-executed call, and the AI SDK flag is read by the
+    // EMULATED loop, which never runs on this path. A second, inert approval
+    // declaration would read like enforcement.
+    const manager = policyHonoringManager({ srv: { t: { result: {} } } });
+    await projectSelectedMcpServersAsHostTools({
+      manager,
+      selectedServerIds: ["srv"],
+      toolOptions: {
+        modelVisibleMcpToolResults: {
+          directContent: { image: true },
+        } as never,
+      },
+    });
+    const passed = manager.getToolsForAiSdk.mock.calls[0]![1];
+    // An options object IS built (the host set a policy) — it just never
+    // carries the approval flag.
+    expect(passed).toBeDefined();
+    expect(passed).not.toHaveProperty("needsApproval");
+  });
+
+  it("takes the NO-OPTIONS overload when no host input applies", async () => {
+    // The byte-identity property: a default harness turn must produce exactly
+    // the tools it produced before any of this existed. Passing `{}` would be
+    // behaviorally equal today and would quietly invite a future default in.
+    const manager = policyHonoringManager({ srv: { t: { result: {} } } });
+    await projectSelectedMcpServersAsHostTools({
+      manager,
+      selectedServerIds: ["srv"],
+      toolOptions: {
+        modelVisibleMcpToolResults: undefined,
+        includeAppOnly: false,
+        tasks: undefined,
+      },
+    });
+    expect(manager.getToolsForAiSdk).toHaveBeenCalledWith(["srv"]);
+    expect(manager.getToolsForAiSdk.mock.calls[0]).toHaveLength(1);
+  });
+
+  it("builds ONE options object for the whole projection", async () => {
+    // The options are host-level. Two selected servers must not be able to get
+    // different ones.
+    const manager = policyHonoringManager({
+      a: { t: { result: {} } },
+      b: { t: { result: {} } },
+    });
+    await projectSelectedMcpServersAsHostTools({
+      manager,
+      selectedServerIds: ["a", "b"],
+      toolOptions: { includeAppOnly: true },
+    });
+    expect(manager.getToolsForAiSdk).toHaveBeenCalledTimes(2);
+    expect(manager.getToolsForAiSdk.mock.calls[0]![1]).toBe(
+      manager.getToolsForAiSdk.mock.calls[1]![1]
+    );
+  });
+});
+
 describe("harnessMcpToolName", () => {
   it("is the same scheme parseHarnessToolName reverses", () => {
     const name = harnessMcpToolName("weather", "get_forecast");

--- a/mcpjam-inspector/server/utils/harness/__tests__/registry.test.ts
+++ b/mcpjam-inspector/server/utils/harness/__tests__/registry.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "vitest";
 import { HARNESS_IDS } from "@mcpjam/sdk/host-config/internal";
+import { HARNESS_MCP_DELIVERY } from "@/shared/harness-mcp-delivery";
 import { createClaudeCode } from "@ai-sdk/harness-claude-code";
 import {
   getHarnessAdapter,
@@ -309,6 +310,30 @@ const toUserMessage = (text) => ({
       // adds MCP tools to its host-executed tool set and the model never sees
       // the same tool twice.
       expect(getHarnessAdapter("claude-code").mcpDelivery).toBe("native");
+    });
+
+    it("every adapter's delivery mode IS the shared declaration the client reads", () => {
+      // `@/shared/harness-mcp-delivery` is the one declaration of which mode a
+      // harness uses, because the CLIENT has to derive Behavior-tab promises
+      // from it (a tool-construction-time knob like `respectToolVisibility`
+      // bites on host-executed delivery and cannot on native) and cannot import
+      // this server-only registry.
+      //
+      // This is the anti-drift guard for that split. If someone flips an
+      // adapter's `mcpDelivery` back to a literal — or changes the shared map
+      // without the adapters — the host editor would start disabling a control
+      // that works (or enabling one that doesn't) with no compile error. Fail
+      // here instead.
+      for (const id of registeredHarnessIds()) {
+        expect(getHarnessAdapter(id).mcpDelivery).toBe(
+          HARNESS_MCP_DELIVERY[id]
+        );
+      }
+      // …and the shared map covers exactly the SDK's harness ids, so a new
+      // harness cannot get an adapter without a delivery declaration.
+      expect(Object.keys(HARNESS_MCP_DELIVERY).sort()).toEqual(
+        [...HARNESS_IDS].sort()
+      );
     });
   });
 

--- a/mcpjam-inspector/server/utils/harness/__tests__/registry.test.ts
+++ b/mcpjam-inspector/server/utils/harness/__tests__/registry.test.ts
@@ -17,10 +17,11 @@ describe("harness registry", () => {
     const a = getHarnessAdapter("codex");
     expect(a.id).toBe("codex");
     expect(a.displayName).toBe("Codex");
-    // Codex: no MCP servers (the CLI never makes an MCP tool model-callable in
-    // the mode the SDK drives), no native plugin install, can't pause for tool
-    // approval — but skills ARE delivered (INS-8), under its own root.
-    expect(a.supportsSelectedMcpServers).toBe(false);
+    // Codex: MCP servers arrive as HOST-EXECUTED tools (the CLI never makes an
+    // MCP tool model-callable in the mode the SDK drives), no native plugin
+    // install, can't pause for tool approval — and skills ARE delivered
+    // (INS-8), under its own root.
+    expect(a.mcpDelivery).toBe("host-executed");
     expect(a.supportsSkills).toBe(true);
     expect(a.skillsBaseDir).toBe("/home/user/.agents/skills");
     expect(a.supportsPluginBundles).toBe(false);
@@ -35,8 +36,15 @@ describe("harness registry", () => {
     // CI, for every registered adapter, before a turn is ever attempted.
     for (const id of registeredHarnessIds()) {
       const adapter = getHarnessAdapter(id);
-      if (adapter.supportsSelectedMcpServers) {
+      // The two MCP delivery modes are mutually exclusive BY TYPE (the native
+      // arm requires `deliverMcpServers`, the host-executed arm forbids it), so
+      // this asserts the runtime shape matches the declared mode — the check
+      // the compiler makes for real adapters, made again for a hand-edited one.
+      if (adapter.mcpDelivery === "native") {
         expect(adapter.deliverMcpServers).toBeTypeOf("function");
+      } else {
+        expect(adapter.mcpDelivery).toBe("host-executed");
+        expect(adapter.deliverMcpServers).toBeUndefined();
       }
       if (adapter.supportsPluginBundles) {
         expect(adapter.deliverPluginBundles).toBeTypeOf("function");
@@ -234,7 +242,7 @@ const toUserMessage = (text) => ({
     );
   });
 
-  it("Claude Code attributes mcp__ tool names; Codex passes them through", () => {
+  it("Claude Code attributes mcp__ tool names", () => {
     const keyToServerId = { weather: "srv_123" };
     expect(
       getHarnessAdapter("claude-code").parseToolName(
@@ -242,13 +250,8 @@ const toUserMessage = (text) => ({
         keyToServerId
       )
     ).toEqual({ serverId: "srv_123", toolName: "forecast" });
-    // Codex has no MCP namespacing — names pass through as native tools.
-    expect(
-      getHarnessAdapter("codex").parseToolName(
-        "mcp__weather__forecast",
-        keyToServerId
-      )
-    ).toEqual({ toolName: "mcp__weather__forecast" });
+    // Codex used to pass these through verbatim (it had no MCP tools to name).
+    // It now uses the SAME scheme — see the parity block below.
   });
 
   it("isHarnessId narrows registered ids and rejects junk", () => {
@@ -291,9 +294,56 @@ const toUserMessage = (text) => ({
       expect(JSON.parse(writes[0]!.content)).toEqual(mcpJson);
     });
 
-    it("Codex declares no MCP delivery (no model-callable MCP tools)", () => {
-      expect(getHarnessAdapter("codex").deliverMcpServers).toBeUndefined();
-      expect(getHarnessAdapter("codex").supportsSelectedMcpServers).toBe(false);
+    it("Codex writes no sandbox MCP config — its servers are host-executed", () => {
+      // The COMP-39 spike proved `~/.codex/config.toml` `[mcp_servers]` merges
+      // cleanly and is still a silent no-op (the model never gets a callable
+      // tool). Writing it anyway would be the trap; the relay is the mechanism.
+      const codex = getHarnessAdapter("codex");
+      expect(codex.mcpDelivery).toBe("host-executed");
+      expect(codex.deliverMcpServers).toBeUndefined();
+    });
+
+    it("Claude Code's tools are NOT projected as host-executed (no double exposure)", () => {
+      // The mutual-exclusion invariant, from the consumer's side: the native
+      // adapter must stay on the `.mcp.json` path, so `runHarnessTurn` never
+      // adds MCP tools to its host-executed tool set and the model never sees
+      // the same tool twice.
+      expect(getHarnessAdapter("claude-code").mcpDelivery).toBe("native");
+    });
+  });
+
+  describe("parseToolName (cross-harness attribution parity)", () => {
+    const keyToServerId = { weather: "srv-weather" };
+
+    it("both harnesses resolve mcp__<server>__<tool> to the same identity", () => {
+      // Eval assertions and trace spans key off `{ serverId, toolName }`. A
+      // Codex run must attribute a relayed call exactly as a Claude Code run
+      // attributes the native one, or the same suite scores differently per
+      // harness for reasons that have nothing to do with the server.
+      for (const id of registeredHarnessIds()) {
+        expect(
+          getHarnessAdapter(id).parseToolName(
+            "mcp__weather__get_forecast",
+            keyToServerId
+          )
+        ).toEqual({ serverId: "srv-weather", toolName: "get_forecast" });
+      }
+    });
+
+    it("a harness-native tool name keeps no server attribution", () => {
+      for (const id of registeredHarnessIds()) {
+        expect(getHarnessAdapter(id).parseToolName("bash", keyToServerId)).toEqual(
+          { toolName: "bash" }
+        );
+      }
+    });
+
+    it("an unknown server key is returned verbatim, never fabricated", () => {
+      for (const id of registeredHarnessIds()) {
+        expect(
+          getHarnessAdapter(id).parseToolName("mcp__ghost__do_thing", {})
+        ).toEqual({ toolName: "mcp__ghost__do_thing" });
+      }
     });
   });
 

--- a/mcpjam-inspector/server/utils/harness/__tests__/run-harness-turn-broker-required.test.ts
+++ b/mcpjam-inspector/server/utils/harness/__tests__/run-harness-turn-broker-required.test.ts
@@ -40,7 +40,7 @@ vi.mock("../registry.js", () => ({
     displayName: "Claude Code",
     defaultPermissionMode: "allow-all",
     supportsSkills: false,
-    supportsSelectedMcpServers: false,
+    mcpDelivery: "host-executed",
     supportsModel: vi.fn(() => true),
     createHarness: vi.fn(() => ({ harnessId: "claude-code" })),
     parseToolName: vi.fn((toolName: string) => ({ toolName })),

--- a/mcpjam-inspector/server/utils/harness/__tests__/run-harness-turn-empty-output.test.ts
+++ b/mcpjam-inspector/server/utils/harness/__tests__/run-harness-turn-empty-output.test.ts
@@ -42,7 +42,7 @@ vi.mock("../registry.js", () => ({
     displayName: "Claude Code",
     defaultPermissionMode: "allow-all",
     supportsSkills: false,
-    supportsSelectedMcpServers: false,
+    mcpDelivery: "host-executed",
     supportsModel: vi.fn(() => true),
     createHarness: vi.fn(() => ({ harnessId: "claude-code" })),
     parseToolName: vi.fn((toolName: string) => ({ toolName })),

--- a/mcpjam-inspector/server/utils/harness/__tests__/run-harness-turn-ephemeral.test.ts
+++ b/mcpjam-inspector/server/utils/harness/__tests__/run-harness-turn-ephemeral.test.ts
@@ -44,7 +44,7 @@ vi.mock("../registry.js", () => ({
     displayName: "Claude Code",
     defaultPermissionMode: "allow-all",
     supportsSkills: false,
-    supportsSelectedMcpServers: false,
+    mcpDelivery: "host-executed",
     supportsModel: vi.fn(() => true),
     createHarness: vi.fn(() => ({ harnessId: "claude-code" })),
     parseToolName: vi.fn((toolName: string) => ({ toolName })),

--- a/mcpjam-inspector/server/utils/harness/__tests__/run-harness-turn-host-executed-options.test.ts
+++ b/mcpjam-inspector/server/utils/harness/__tests__/run-harness-turn-host-executed-options.test.ts
@@ -1,0 +1,238 @@
+/**
+ * The turn must hand the HOST's tool-construction inputs to the host-executed
+ * MCP projection.
+ *
+ * `getToolsForAiSdk` resolves none of them itself, so anything the turn does
+ * not forward is not "defaulted" — it is gone. This file pins the wiring;
+ * `host-executed-mcp-tools.test.ts` pins what the projection then does with it.
+ *
+ * The `modelVisibleMcpToolResults` and `tasks` assertions fail against the
+ * previous behaviour, where the projection was called with no options at all.
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { ModelMessage } from "@ai-sdk/provider-utils";
+
+const harnessState = vi.hoisted(() => ({
+  streamParts: [{ type: "finish", finishReason: "stop" }] as Array<
+    Record<string, unknown> & { type?: string }
+  >,
+  finalText: "done",
+  session: {
+    sessionId: "session-1",
+    stop: vi.fn(async () => ({})),
+    destroy: vi.fn(async () => {}),
+  },
+}));
+
+vi.mock("@ai-sdk/harness/agent", () => ({
+  HarnessAgent: class {
+    createSession = vi.fn(async () => harnessState.session);
+    stream = vi.fn(async () => ({
+      fullStream: (async function* () {
+        for (const part of harnessState.streamParts) {
+          yield part;
+        }
+      })(),
+      text: Promise.resolve(harnessState.finalText),
+    }));
+  },
+  collectHarnessAgentToolApprovalContinuations: vi.fn(() => []),
+}));
+
+vi.mock("../registry.js", () => ({
+  buildBrokerDummyAuth: vi.fn(() => ({
+    anthropic: {
+      apiKey: "",
+      authToken: "mcpjam-broker-dummy",
+      baseUrl: "https://broker.example",
+    },
+  })),
+  getHarnessAdapter: vi.fn(() => ({
+    id: "codex",
+    displayName: "Codex",
+    defaultPermissionMode: "allow-all",
+    supportsSkills: false,
+    supportsNativeToolApproval: false,
+    supportsHostExecutedToolApproval: false,
+    supportsMcpToolApproval: false,
+    // The delivery mode under test: no `.mcp.json`, the servers ride as
+    // host-executed tools MCPJam builds itself.
+    mcpDelivery: "host-executed",
+    supportsModel: vi.fn(() => true),
+    createHarness: vi.fn(() => ({ harnessId: "codex" })),
+    parseToolName: vi.fn((toolName: string) => ({ toolName })),
+  })),
+}));
+
+/** The projection itself is covered by its own file; here it is a spy. */
+const projectSpy = vi.hoisted(() =>
+  vi.fn(async () => ({ tools: {}, keyToServerId: {} }))
+);
+vi.mock("../host-executed-mcp-tools.js", async (importOriginal) => {
+  const actual = await importOriginal<
+    typeof import("../host-executed-mcp-tools.js")
+  >();
+  return { ...actual, projectSelectedMcpServersAsHostTools: projectSpy };
+});
+
+vi.mock("../resolve-sandbox.js", () => ({
+  resolveHarnessSandbox: vi.fn(async () => ({
+    computerId: "computer-1",
+    sandboxId: "sandbox-1",
+  })),
+}));
+
+vi.mock("../e2b-sandbox-provider.js", () => ({
+  createE2BHarnessSandboxProvider: vi.fn(() => ({ sandboxId: "sandbox-1" })),
+}));
+
+vi.mock("../runtime-skills.js", () => ({
+  frontmatterSafeSkills: vi.fn((skills) => skills),
+  fetchRuntimeSkills: vi.fn(async () => ({ ok: true, skills: [] })),
+  skillsFingerprint: vi.fn(() => "empty-skills"),
+}));
+
+vi.mock("../reconcile-skill-dirs.js", () => ({
+  reconcileSkillDirs: vi.fn(async () => {}),
+}));
+
+vi.mock("../harness-session-state.js", async (importOriginal) => {
+  const actual = await importOriginal<
+    typeof import("../harness-session-state.js")
+  >();
+  return {
+    ...actual,
+    claimHarnessSessionState: vi.fn(async () => ({
+      ok: true,
+      leaseId: "lease-1",
+      stateVersion: 1,
+      state: null,
+      fingerprintChanged: false,
+    })),
+    commitHarnessSessionState: vi.fn(async () => true),
+    heartbeatHarnessSessionState: vi.fn(async () => "ok"),
+    releaseHarnessSessionState: vi.fn(async () => {}),
+  };
+});
+
+vi.mock("../harness-model-broker.js", () => ({
+  reserveHarnessBox: vi.fn(async () => ({ ok: true })),
+  releaseHarnessBoxReservation: vi.fn(async () => ({ ok: true })),
+  revokeHarnessModelBroker: vi.fn(async () => {}),
+  startHarnessModelBroker: vi.fn(async () => ({
+    ok: true,
+    proxyBaseUrl: "https://broker.example",
+  })),
+}));
+
+import { runHarnessTurn } from "../run-harness-turn";
+import { mcpToolOptionsFor } from "../../mcp-tool-options.js";
+
+function baseOptions(overrides: Record<string, unknown> = {}) {
+  const messages: ModelMessage[] = [
+    {
+      role: "user",
+      content: [{ type: "text", text: "list the open issues" }],
+    } as unknown as ModelMessage,
+  ];
+  return {
+    messages,
+    modelId: "openai/gpt-5",
+    provider: "openai",
+    systemPrompt: "You are Codex.",
+    authHeader: "Bearer test",
+    projectId: "project-1",
+    mcpClientManager: { getServerConfig: vi.fn(() => ({ url: "x" })) },
+    selectedServers: ["srv-a"],
+    // Required whenever servers are selected, even on host-executed delivery
+    // (the turn asserts it before it knows which arm it is on).
+    harnessMcpProxy: { plane: "local-mcp" as const },
+    requireToolApproval: false,
+    sourceType: "eval",
+    harness: "codex",
+    ...overrides,
+  };
+}
+
+/** The `toolOptions` the turn handed the projection. */
+function forwardedToolOptions() {
+  expect(projectSpy).toHaveBeenCalledTimes(1);
+  return (projectSpy.mock.calls[0]![0] as unknown as {
+    toolOptions?: Record<string, unknown>;
+  }).toolOptions;
+}
+
+describe("runHarnessTurn forwards host tool-construction options", () => {
+  beforeEach(() => {
+    vi.stubEnv("MCPJAM_HARNESS_BROKER_DELIVERY", "true");
+    projectSpy.mockClear();
+  });
+  afterEach(() => {
+    vi.unstubAllEnvs();
+  });
+
+  it("forwards the host's modelVisibleMcpToolResults", async () => {
+    // THE REPORTED BUG: the projection used to be called with no options, so
+    // this policy never reached the tool the relay executes.
+    const policy = {
+      directContent: { image: true },
+      embeddedResources: { blob: { image: false } },
+      linkedResources: { blob: { image: false } },
+    };
+    await runHarnessTurn(
+      baseOptions({ modelVisibleMcpToolResults: policy }) as never,
+      "none"
+    );
+    expect(forwardedToolOptions()).toMatchObject({
+      modelVisibleMcpToolResults: policy,
+    });
+  });
+
+  it("forwards the resolved task seam", async () => {
+    const tasks = { mode: "await" };
+    await runHarnessTurn(baseOptions({ tasks }) as never, "none");
+    expect(forwardedToolOptions()).toMatchObject({ tasks });
+  });
+
+  it("turns an explicit respectToolVisibility=false into includeAppOnly", async () => {
+    await runHarnessTurn(
+      baseOptions({ respectToolVisibility: false }) as never,
+      "none"
+    );
+    expect(forwardedToolOptions()).toMatchObject({ includeAppOnly: true });
+  });
+
+  it("keeps the spec default when respectToolVisibility is unset or true", async () => {
+    // `undefined` and `true` both filter app-only tools; only an explicit
+    // `false` opts out, exactly as `prepareChatV2` reads it. A `false` here is
+    // dropped by `mcpToolOptionsFor`, so it never reaches the SDK.
+    await runHarnessTurn(baseOptions() as never, "none");
+    expect(forwardedToolOptions()?.includeAppOnly).toBe(false);
+
+    projectSpy.mockClear();
+    await runHarnessTurn(
+      baseOptions({ respectToolVisibility: true }) as never,
+      "none"
+    );
+    expect(forwardedToolOptions()?.includeAppOnly).toBe(false);
+  });
+
+  it("forwards nothing that would build a needsApproval flag", async () => {
+    // Host-executed approval is `HarnessAgent`'s `toolApproval` map, not the AI
+    // SDK flag — which nothing on this path reads. Absent by construction.
+    await runHarnessTurn(
+      baseOptions({ requireToolApproval: false }) as never,
+      "none"
+    );
+    expect(forwardedToolOptions() ?? {}).not.toHaveProperty("needsApproval");
+  });
+
+  it("leaves a DEFAULT turn on the no-options path", async () => {
+    // Byte-identity guard (it passes against the previous behaviour too, and
+    // is here to keep passing): whatever the turn forwards for a host that set
+    // none of these must still build to `undefined`, so the enumeration calls
+    // `getToolsForAiSdk(ids)` exactly as it did before any of this existed.
+    await runHarnessTurn(baseOptions() as never, "none");
+    expect(mcpToolOptionsFor(forwardedToolOptions() ?? {})).toBeUndefined();
+  });
+});

--- a/mcpjam-inspector/server/utils/harness/__tests__/run-harness-turn-tool-policy.test.ts
+++ b/mcpjam-inspector/server/utils/harness/__tests__/run-harness-turn-tool-policy.test.ts
@@ -50,7 +50,8 @@ vi.mock("../registry.js", () => ({
     displayName: "Claude Code",
     defaultPermissionMode: "allow-all",
     supportsSkills: false,
-    supportsSelectedMcpServers: true,
+    mcpDelivery: "native",
+    deliverMcpServers: vi.fn(async () => {}),
     supportsModel: vi.fn(() => true),
     createHarness: vi.fn(() => ({ harnessId: "claude-code" })),
     // The real adapter's MCP tool names are `mcp__<key>__<tool>`; the turn only

--- a/mcpjam-inspector/server/utils/harness/harness-availability.ts
+++ b/mcpjam-inspector/server/utils/harness/harness-availability.ts
@@ -20,7 +20,59 @@ import { isComputersDataPlaneConfigured } from "../computers/control-plane-clien
 import { getCanonicalModelId } from "@/shared/types";
 import { isHostedCatalogModel } from "../../services/hosted-model-catalog.js";
 import { harnessBrokerDeliveryEnabled } from "./harness-flags.js";
-import { getHarnessAdapter, type HarnessId } from "./registry.js";
+import {
+  getHarnessAdapter,
+  type HarnessId,
+  type HarnessRuntimeAdapter,
+} from "./registry.js";
+
+/**
+ * The approval half of this pre-flight, as a value both gate sites share.
+ *
+ * `runHarnessTurn` has to re-assert exactly these rules, because the eval,
+ * synthetic and unified paths never call {@link checkHarnessRuntimeAvailable} —
+ * and an approval rule that holds on the chat route but not on an eval run is
+ * the silent bypass. Two hand-copied conditions would drift on the next
+ * capability added, so the conditions live HERE and the turn calls this.
+ *
+ * Returns the refusal copy, or `undefined` when the combination is sound.
+ *
+ * Note the MCP arm is gated on the surface the adapter's MCP tools ACTUALLY run
+ * on: `native` delivery runs them in-sandbox (`supportsMcpToolApproval`),
+ * `host-executed` runs them on MCPJam's server as ordinary host tools
+ * (`supportsHostExecutedToolApproval`). Reading the wrong one is the bypass this
+ * function exists to make unrepresentable — Codex's MCP tools are host-executed,
+ * so `supportsMcpToolApproval` says nothing about them.
+ */
+export function harnessToolApprovalRefusalReason(args: {
+  adapter: HarnessRuntimeAdapter;
+  requireToolApproval: boolean;
+  /** Whether the host has any selected MCP servers. Selects whether the
+   *  MCP-surface arm applies; the native-surface arm applies regardless. */
+  hasSelectedMcpServers: boolean;
+}): string | undefined {
+  if (!args.requireToolApproval) return undefined;
+  const name = args.adapter.displayName;
+  // The runtime runs its own native tools in-sandbox. If it can't pause on
+  // those, approval is unsound for the whole turn — servers or no servers.
+  if (!args.adapter.supportsNativeToolApproval) {
+    return (
+      `the ${name} harness doesn't support interactive tool approval yet — ` +
+      "turn off requireToolApproval on this host"
+    );
+  }
+  const mcpToolApproval =
+    args.adapter.mcpDelivery === "native"
+      ? args.adapter.supportsMcpToolApproval
+      : args.adapter.supportsHostExecutedToolApproval;
+  if (args.hasSelectedMcpServers && !mcpToolApproval) {
+    return (
+      `the ${name} harness can't pause for approval of MCP-server tools — ` +
+      "turn off requireToolApproval on this host"
+    );
+  }
+  return undefined;
+}
 
 /**
  * Why a harness was refused, as a value rather than a sentence.
@@ -125,36 +177,16 @@ export function checkHarnessRuntimeAvailable(args: {
     };
   }
 
-  // Approval is gated against the surfaces the host actually uses. The runtime
-  // runs its native tools (and any MCP tools) itself in-sandbox, so it can't
-  // pause for approval on them. Both adapters set these false for v1.
-  if (args.requireToolApproval && !adapter.supportsNativeToolApproval) {
-    return {
-      ok: false,
-      kind: "tool-approval",
-      reason:
-        `the ${name} harness doesn't support interactive tool approval yet — ` +
-        "turn off requireToolApproval on this host",
-    };
-  }
-  // MCP-tool approval, gated against the surface this adapter's MCP tools
-  // ACTUALLY run on. Under `native` delivery they run in-sandbox
-  // (`supportsMcpToolApproval`); under `host-executed` they run on MCPJam's
-  // server as ordinary host tools (`supportsHostExecutedToolApproval`). Reading
-  // the wrong capability here would be the silent bypass: Codex's MCP tools are
-  // host-executed, so `supportsMcpToolApproval` says nothing about them.
-  const mcpToolApproval =
-    adapter.mcpDelivery === "native"
-      ? adapter.supportsMcpToolApproval
-      : adapter.supportsHostExecutedToolApproval;
-  if (args.requireToolApproval && args.hasSelectedMcpServers && !mcpToolApproval) {
-    return {
-      ok: false,
-      kind: "tool-approval",
-      reason:
-        `the ${name} harness can't pause for approval of MCP-server tools — ` +
-        "turn off requireToolApproval on this host",
-    };
+  // Approval is gated against the surfaces the host actually uses, by the same
+  // helper `runHarnessTurn`'s backstop calls — so the pre-flight and the turn
+  // can never disagree about which combinations are sound.
+  const approvalRefusal = harnessToolApprovalRefusalReason({
+    adapter,
+    requireToolApproval: args.requireToolApproval,
+    hasSelectedMcpServers: args.hasSelectedMcpServers,
+  });
+  if (approvalRefusal) {
+    return { ok: false, kind: "tool-approval", reason: approvalRefusal };
   }
 
   // There is no MCP gate. Every adapter delivers the host's selected servers

--- a/mcpjam-inspector/server/utils/harness/harness-availability.ts
+++ b/mcpjam-inspector/server/utils/harness/harness-availability.ts
@@ -37,7 +37,6 @@ export type HarnessUnavailableKind =
   | "enterprise-policy"
   | "computers-unconfigured"
   | "tool-approval"
-  | "mcp-servers"
   | "model-not-hosted"
   | "model-unsupported";
 
@@ -51,8 +50,9 @@ export function checkHarnessRuntimeAvailable(args: {
   /** The host's resolved approval gate. The runtimes can't pause for native/MCP
    *  tool approval, so an approval host is rejected (capability-driven). */
   requireToolApproval: boolean;
-  /** Whether the host has any selected MCP servers. Rejected for a harness that
-   *  can't deliver them (Codex v1). */
+  /** Whether the host has any selected MCP servers. No longer a refusal on its
+   *  own — every harness delivers them — but it still selects which approval
+   *  capability has to hold. */
   hasSelectedMcpServers: boolean;
   /**
    * The host's RESOLVED model — id plus provider, exactly as the turn resolved
@@ -137,11 +137,17 @@ export function checkHarnessRuntimeAvailable(args: {
         "turn off requireToolApproval on this host",
     };
   }
-  if (
-    args.requireToolApproval &&
-    args.hasSelectedMcpServers &&
-    !adapter.supportsMcpToolApproval
-  ) {
+  // MCP-tool approval, gated against the surface this adapter's MCP tools
+  // ACTUALLY run on. Under `native` delivery they run in-sandbox
+  // (`supportsMcpToolApproval`); under `host-executed` they run on MCPJam's
+  // server as ordinary host tools (`supportsHostExecutedToolApproval`). Reading
+  // the wrong capability here would be the silent bypass: Codex's MCP tools are
+  // host-executed, so `supportsMcpToolApproval` says nothing about them.
+  const mcpToolApproval =
+    adapter.mcpDelivery === "native"
+      ? adapter.supportsMcpToolApproval
+      : adapter.supportsHostExecutedToolApproval;
+  if (args.requireToolApproval && args.hasSelectedMcpServers && !mcpToolApproval) {
     return {
       ok: false,
       kind: "tool-approval",
@@ -151,17 +157,12 @@ export function checkHarnessRuntimeAvailable(args: {
     };
   }
 
-  // MCP gate: a harness that can't deliver the host's selected servers (Codex
-  // v1) must not silently run without them.
-  if (args.hasSelectedMcpServers && !adapter.supportsSelectedMcpServers) {
-    return {
-      ok: false,
-      kind: "mcp-servers",
-      reason:
-        `the ${name} harness doesn't support MCP servers yet — remove the ` +
-        "selected servers from this host to run it",
-    };
-  }
+  // There is no MCP gate. Every adapter delivers the host's selected servers
+  // one way or the other (`HarnessMcpDelivery`: `native` config in the sandbox,
+  // or `host-executed` tools MCPJam runs itself), so "this harness can't do MCP
+  // at all" is no longer a representable state — the refusal it produced (kind
+  // `mcp-servers`, which blocked every Codex host with a server attached, and
+  // therefore every Codex eval) is gone with it.
 
   // Model eligibility: harness runtimes authenticate via the MCPJam gateway
   // credential, not org BYOK. A non-eligible model can't run the real runtime,

--- a/mcpjam-inspector/server/utils/harness/harness-proxy-policy-enforcement.ts
+++ b/mcpjam-inspector/server/utils/harness/harness-proxy-policy-enforcement.ts
@@ -25,6 +25,7 @@ import {
 } from "@mcpjam/sdk/contract";
 import { resolveBridgeToolCallTarget } from "../../services/mcp-tool-call-target.js";
 import { isHarnessProxyPolicySealAvailable } from "./harness-proxy-policy-seal.js";
+import { getHarnessAdapter, type HarnessId } from "./registry.js";
 
 export { resolveBridgeToolCallTarget };
 
@@ -147,12 +148,26 @@ export const HARNESS_TOOL_POLICY_SEAL_UNAVAILABLE_REASON =
  * token, or an assembled `.mcp.json` entry that ended up with a bare token) are
  * only knowable once the config is built, and are refused there —
  * `buildHarnessProxyMcpJsonFromManager`.
+ *
+ * DELIVERY-AWARE (COMP-39). The seal only exists to carry a policy OUT of this
+ * process, into a sandbox that calls the customer's server itself. That is
+ * `mcpDelivery: "native"`. A `host-executed` adapter's MCP calls never leave
+ * this process — `projectSelectedMcpServersAsHostTools` gates them in-process
+ * with the same `decideToolPolicyFromSnapshot` and the same block envelope — so
+ * a deployment with a weak or absent `COMPUTERS_TERMINAL_TOKEN_SECRET` was
+ * refusing every policied Codex eval over a token it would never mint.
+ *
+ * The harness is taken as an ID rather than a boolean precisely so no caller
+ * can forget to say which delivery it gets: the adapter is the one source of
+ * that answer, and the fail-closed native arm is untouched.
  */
 export function harnessToolPolicyLaunchRefusal(args: {
   hasToolPolicy: boolean;
-  harness: boolean;
+  /** The run's harness, or undefined for the emulated engine. */
+  harness: HarnessId | undefined;
 }): string | null {
   if (!args.hasToolPolicy || !args.harness) return null;
+  if (getHarnessAdapter(args.harness).mcpDelivery !== "native") return null;
   return isHarnessProxyPolicySealAvailable()
     ? null
     : HARNESS_TOOL_POLICY_SEAL_UNAVAILABLE_REASON;

--- a/mcpjam-inspector/server/utils/harness/harness-scope-step-up.ts
+++ b/mcpjam-inspector/server/utils/harness/harness-scope-step-up.ts
@@ -74,6 +74,73 @@ export function harnessScopeStepUpServerMatches(
   );
 }
 
+/** Order-independent structural key for a tool input, so `{a,b}` and `{b,a}`
+ *  correlate. Lives beside the matcher that is its only consumer. */
+export function stableHarnessValue(value: unknown): string {
+  if (value === null || typeof value !== "object") {
+    return JSON.stringify(value) ?? "null";
+  }
+  if (Array.isArray(value)) {
+    return `[${value.map(stableHarnessValue).join(",")}]`;
+  }
+  const record = value as Record<string, unknown>;
+  return `{${Object.keys(record)
+    .sort()
+    .map((key) => `${JSON.stringify(key)}:${stableHarnessValue(record[key])}`)
+    .join(",")}}`;
+}
+
+/** One tool call the turn observed on the harness stream, as the correlator
+ *  needs it. */
+export interface ObservedHarnessToolCall {
+  toolCallId: string;
+  serverId?: string;
+  toolName: string;
+  input: unknown;
+}
+
+/**
+ * Which observed tool call a scope challenge belongs to.
+ *
+ * TWO correlators, and the ID one wins whenever it can:
+ *
+ *  - `toolCallId`. A HOST-EXECUTED call raises its challenge inside `execute()`,
+ *    where the AI SDK hands it the very `toolCallId` the stream reported for
+ *    that call. That id is unique per call, so it is exact.
+ *  - the (serverId, toolName, input) tuple. The NATIVE path's publisher is the
+ *    signed proxy, which only ever saw an HTTP `tools/call` and has no id to
+ *    give — so the tuple is all there is, and it stays the fallback.
+ *
+ * The tuple ALONE is wrong when a turn makes the same call twice with the same
+ * arguments: `find` returns the FIRST match, so a challenge raised by the second
+ * call would suspend and later resume the first, re-running a call that already
+ * succeeded and leaving the failing one unresumed. When the challenge carries a
+ * usable id, an id miss returns `undefined` rather than degrading to the tuple —
+ * the correlator is re-run on every subsequent observed call, so a challenge
+ * that lands before its own `tool-call` part still correlates, and never onto
+ * the wrong call.
+ */
+export function matchHarnessScopeStepUpToolCall(args: {
+  observed: readonly ObservedHarnessToolCall[];
+  challenge: HarnessScopeStepUpEvent;
+}): ObservedHarnessToolCall | undefined {
+  const { observed, challenge } = args;
+  const toolCallId = challenge.toolCallId?.trim();
+  if (toolCallId) {
+    return observed.find((call) => call.toolCallId === toolCallId);
+  }
+  return observed.find(
+    (call) =>
+      harnessScopeStepUpServerMatches(
+        call.serverId ? [call.serverId] : [],
+        challenge.serverId
+      ) &&
+      call.toolName === challenge.toolName &&
+      stableHarnessValue(call.input) ===
+        stableHarnessValue(challenge.toolInput ?? {})
+  );
+}
+
 function notifyListener(
   listener: Listener,
   info: HarnessScopeStepUpEvent

--- a/mcpjam-inspector/server/utils/harness/host-executed-mcp-tools.ts
+++ b/mcpjam-inspector/server/utils/harness/host-executed-mcp-tools.ts
@@ -1,0 +1,187 @@
+/**
+ * Project a host's selected MCP servers into HOST-EXECUTED AI SDK tools, for a
+ * harness whose runtime cannot make an MCP tool model-callable itself
+ * (`mcpDelivery: "host-executed"` — Codex today).
+ *
+ * ## Why this exists
+ *
+ * Codex's only mode the SDK drives (`codex exec --experimental-json`) completes
+ * the MCP handshake and answers `tools/list`, but never registers the tools as
+ * model-callable functions (openai/codex#19425). Writing `~/.codex/config.toml`
+ * `[mcp_servers]` MERGES cleanly with what the bridge sets and is still a
+ * silent no-op — the COMP-39 spike proved that end to end. The harness authors
+ * hit the same wall for their own host tools and built a CLI relay instead
+ * (`@ai-sdk/harness-codex`'s `src/bridge/cli-relay.ts`), which is the mechanism
+ * this module feeds: the bridge injects each tool's description into the
+ * prompt, the model shells out via `bash node <shim> <toolName> <json>`, and the
+ * invocation is relayed back over HTTP to the agent — which runs `execute()`
+ * HERE, on MCPJam's server.
+ *
+ * ## Direct, not through the harness MCP proxy
+ *
+ * The signed proxy (`routes/web/harness-mcp.ts` / the adapter-http tunnel)
+ * exists so code INSIDE THE SANDBOX can reach a server it has no credentials
+ * for. A host-executed tool does not run in the sandbox: it runs in this
+ * process, where the authorized `MCPClientManager` connection already lives. So
+ * these tools call the manager directly — reusing the SAME projection the
+ * emulated engine uses (`getToolsForAiSdk`), not a second hand-rolled
+ * converter. Routing them back out through the proxy would add an HTTP hop from
+ * this server to itself and would have to mint a token for it. Going direct is
+ * also strictly safer: no proxy token and no server URL ever enters the
+ * sandbox, so a compromised sandbox cannot reach the servers off-turn at all.
+ *
+ * The one thing the proxy did that we must NOT lose is out-of-process
+ * `toolPolicy` enforcement (the sealed token). That moves in-process here —
+ * same `decideToolPolicyFromSnapshot`, same block envelope — so a denied call
+ * still never reaches the customer's server and still accounts as
+ * `blockedByPolicy`, never `failed`.
+ *
+ * ## Known limitations (stated, not papered over)
+ *
+ *  - Schemas are enumerated ONCE, at turn start. There is no `tools/list_changed`
+ *    subscription: a server that adds or removes a tool mid-turn is not
+ *    reflected until the next turn.
+ *  - Every projected tool's description is injected into the PROMPT by the
+ *    bridge, so a server with many tools inflates every turn of the
+ *    conversation. There is no cap here — MCPJam has no tool-count budget to
+ *    respect, and inventing one would silently hide the user's own servers.
+ */
+import {
+  decideToolPolicyFromSnapshot,
+  type ToolPolicySnapshot,
+} from "@mcpjam/sdk/contract";
+import type { MCPJamHandlerOptions } from "../mcpjam-stream-handler.js";
+import { logger } from "../logger.js";
+import { harnessServerKeyToName } from "./mcp-config.js";
+import {
+  HARNESS_POLICY_BLOCK_META_KEY,
+  HARNESS_POLICY_BLOCK_TEXT_PREFIX,
+  type HarnessPolicyBlockMarker,
+} from "./harness-proxy-policy-enforcement.js";
+import { selectDeliverableServerIds } from "./plugin-delivery.js";
+import type { RuntimePluginVersion } from "../../services/environments/effective-capabilities.js";
+
+/** The harness tool-name prefix. Claude Code's native scheme, reused verbatim so
+ *  a Codex run attributes identically to a Claude Code run. */
+export function harnessMcpToolName(serverKey: string, toolName: string): string {
+  return `mcp__${serverKey}__${toolName}`;
+}
+
+export interface HostExecutedMcpProjection {
+  /** Name-keyed AI SDK tools to merge into the agent's host-executed `tools`. */
+  tools: Record<string, unknown>;
+  /** Sanitized server key → serverId, the SAME map shape the `.mcp.json` path
+   *  produces, so `parseToolName` attributes a relayed call to its server. */
+  keyToServerId: Record<string, string>;
+}
+
+/**
+ * Enumerate each selected server's tools and project them into namespaced,
+ * host-executed AI SDK tools.
+ *
+ * The per-server `getToolsForAiSdk([id])` call is deliberate: the manager's
+ * multi-id form FLATTENS every server into one name-keyed record (last-in
+ * wins), which would both lose the server attribution this projection is built
+ * on and silently drop a tool whose name another selected server also uses.
+ * One call per server, then namespace — the same shape `evals-runner` uses.
+ */
+export async function projectSelectedMcpServersAsHostTools(args: {
+  manager: MCPJamHandlerOptions["mcpClientManager"];
+  selectedServerIds: string[];
+  /** Plugin origin per server id (INS-7): a plugin-contributed server with no
+   *  live connection fails the turn instead of being silently skipped. */
+  pluginOrigins?: Record<string, RuntimePluginVersion>;
+  /** Per-server resolved `toolPolicy` decisions for this run. A server with a
+   *  snapshot gets its calls gated IN-PROCESS before they reach the server. */
+  toolPolicy?: Record<string, ToolPolicySnapshot>;
+}): Promise<HostExecutedMcpProjection> {
+  const configured = selectDeliverableServerIds({
+    selectedServerIds: args.selectedServerIds,
+    hasLiveConfig: (id) => Boolean(args.manager.getServerConfig(id)),
+    ...(args.pluginOrigins ? { pluginOrigins: args.pluginOrigins } : {}),
+    onSkipped: (id) =>
+      logger.warn(
+        `[harness] selected server has no live config; skipping serverId=${id}`
+      ),
+  });
+  if (configured.length === 0) return { tools: {}, keyToServerId: {} };
+
+  // Same sanitize + dedup + ordering as the `.mcp.json` keys, from the same
+  // helper — so the two delivery modes cannot drift into different tool names.
+  const keyToServerId = harnessServerKeyToName(
+    configured.map((id) => ({ name: id }))
+  );
+  const serverIdToKey = new Map<string, string>();
+  for (const [key, serverId] of Object.entries(keyToServerId)) {
+    serverIdToKey.set(serverId, key);
+  }
+
+  const tools: Record<string, unknown> = {};
+  for (const serverId of configured) {
+    const key = serverIdToKey.get(serverId);
+    // Unreachable: every configured id got a key above. Fail loud rather than
+    // ship the server's tools under a name nothing can attribute.
+    if (!key) {
+      throw new Error(
+        `Harness host-executed MCP projection: no name key for serverId=${serverId}`
+      );
+    }
+    // REUSE the manager's own AI SDK conversion (schemas, result shaping,
+    // SEP-1865 app-only visibility filtering, `_serverId` tagging) — the same
+    // one the emulated engine runs on. A second converter here would be a
+    // second place for the two engines to disagree about a tool.
+    const serverTools = await args.manager.getToolsForAiSdk([serverId]);
+    const snapshot = args.toolPolicy?.[serverId];
+    for (const [toolName, tool] of Object.entries(serverTools)) {
+      tools[harnessMcpToolName(key, toolName)] = snapshot
+        ? withToolPolicyGate({ tool, toolName, snapshot })
+        : tool;
+    }
+  }
+  return { tools, keyToServerId };
+}
+
+/**
+ * In-process replacement for the proxy's sealed-token gate.
+ *
+ * Returns the SAME envelope `evaluateHarnessProxyToolPolicy` answers with — a
+ * successful MCP result carrying the block marker in `_meta` and the block
+ * wording in its text — so `readHarnessPolicyBlockFromResult` recognises it
+ * through either detector, and a blocked call is accounted `notMeasured` +
+ * `blockedByPolicy` rather than as a failure of the customer's tool.
+ */
+function withToolPolicyGate(args: {
+  tool: unknown;
+  toolName: string;
+  snapshot: ToolPolicySnapshot;
+}): unknown {
+  const tool = args.tool as {
+    execute?: (input: unknown, options: unknown) => unknown;
+  };
+  const originalExecute = tool.execute?.bind(tool);
+  if (!originalExecute) return args.tool;
+  return {
+    ...tool,
+    execute: async (input: unknown, options: unknown) => {
+      const decision = decideToolPolicyFromSnapshot({
+        snapshot: args.snapshot,
+        toolName: args.toolName,
+      });
+      if (decision.allowed) return originalExecute(input, options);
+      const marker: HarnessPolicyBlockMarker = {
+        toolName: args.toolName,
+        reason: decision.reason,
+        classification: decision.classification,
+      };
+      return {
+        content: [
+          {
+            type: "text",
+            text: `${HARNESS_POLICY_BLOCK_TEXT_PREFIX}${decision.reason}`,
+          },
+        ],
+        _meta: { [HARNESS_POLICY_BLOCK_META_KEY]: marker },
+      };
+    },
+  };
+}

--- a/mcpjam-inspector/server/utils/harness/host-executed-mcp-tools.ts
+++ b/mcpjam-inspector/server/utils/harness/host-executed-mcp-tools.ts
@@ -45,6 +45,12 @@
  *    raised by an in-process call is extracted with the same shared helper the
  *    proxy path uses and handed to the turn's existing bridge (see
  *    {@link projectSelectedMcpServersAsHostTools}'s `onScopeStepUpChallenge`).
+ *  - The RELAY carries the model-facing projection of a result, not the raw
+ *    one: `toModelOutput` is the manager tool's own, so app-tool `_meta` /
+ *    `structuredContent` never reaches the model and `modelVisibleMcpToolResults`
+ *    still applies (see {@link withModelOutputProjection}). The raw result is
+ *    handed back through `onRawResult` so the UI keeps rendering what the server
+ *    actually returned.
  *  - Every projected tool's description is injected into the PROMPT by the
  *    bridge, so a server with many tools inflates every turn of the
  *    conversation. There is no cap here — MCPJam has no tool-count budget to
@@ -112,6 +118,16 @@ export async function projectSelectedMcpServersAsHostTools(args: {
    * behaviour for a turn that cannot pause anyway.
    */
   onScopeStepUpChallenge?: (event: HarnessScopeStepUpEvent) => void;
+  /**
+   * Sink for the RAW MCP result of each call, keyed by the AI SDK `toolCallId`.
+   *
+   * The relay receives the model-facing projection (see
+   * {@link withModelOutputProjection}), and the runtime echoes back only what it
+   * was given — so the turn needs this to keep showing the UI, the trace and the
+   * transcript what the server actually returned, exactly as the emulated engine
+   * does. Omitted ⇒ the raw result is simply not retained.
+   */
+  onRawResult?: (args: { toolCallId: string; raw: unknown }) => void;
 }): Promise<HostExecutedMcpProjection> {
   const configured = selectDeliverableServerIds({
     selectedServerIds: args.selectedServerIds,
@@ -151,13 +167,20 @@ export async function projectSelectedMcpServersAsHostTools(args: {
     const serverTools = await args.manager.getToolsForAiSdk([serverId]);
     const snapshot = args.toolPolicy?.[serverId];
     for (const [toolName, tool] of Object.entries(serverTools)) {
-      // Layered inward-out, and the order is load-bearing: the policy gate must
-      // be OUTERMOST so a denied call short-circuits to the block envelope
-      // without ever entering the observer (a blocked call reaches no server and
-      // so can raise no scope challenge). With neither layer in force the
-      // manager's own tool object is passed through by IDENTITY, keeping exactly
-      // one execution path for an MCP call.
-      let projected: unknown = tool;
+      // Layered inward-out, and the order is load-bearing:
+      //  - the MODEL-OUTPUT projection is INNERMOST, so it only ever sees a real
+      //    server result. Above the policy gate it would scrub the block
+      //    envelope's `_meta` marker and the turn would stop recognising its own
+      //    block.
+      //  - the policy gate is OUTERMOST, so a denied call short-circuits to that
+      //    envelope without entering the observer (a blocked call reaches no
+      //    server and so can raise no scope challenge).
+      // With no layer in force the manager's own tool object is passed through
+      // by IDENTITY, keeping exactly one execution path for an MCP call.
+      let projected: unknown = withModelOutputProjection({
+        tool,
+        ...(args.onRawResult ? { onRawResult: args.onRawResult } : {}),
+      });
       if (args.onScopeStepUpChallenge) {
         projected = withScopeStepUpObserver({
           tool: projected,
@@ -173,6 +196,105 @@ export async function projectSelectedMcpServersAsHostTools(args: {
     }
   }
   return { tools, keyToServerId };
+}
+
+/**
+ * Relay the MODEL-FACING projection of an MCP result, not the raw one.
+ *
+ * The manager's AI SDK tool answers TWO shapes on purpose: `execute()` returns
+ * the raw `CallToolResult` (which the inspector's own UI renders — MCP App
+ * widgets read `_meta` and `structuredContent` off it), while `toModelOutput()`
+ * is the model-facing projection — app-tool `_meta`/`structuredContent`
+ * scrubbed, and the host's `modelVisibleMcpToolResults` policy applied to
+ * images and embedded/linked resources.
+ *
+ * The AI SDK's own loop calls both. The harness host-tool loop calls NEITHER
+ * but `execute()`: `maybeExecuteHostTool` submits that value straight to
+ * `control.submitToolResult`, which the bridge JSON-serializes onto the CLI
+ * relay's stdout. So without this wrapper a projected app tool would ship its
+ * client-only `_meta` and `structuredContent` into the model's context — pure
+ * token cost and context leakage, since a harness cannot render a widget at all
+ * (`widgetRendered` is refused at eval admission for exactly that reason) — and
+ * `modelVisibleMcpToolResults` would be bypassed entirely.
+ *
+ * The projection is NOT re-implemented here: it is the tool's own
+ * `toModelOutput`, so the harness and the emulated engine can never disagree
+ * about what a model may see. A tool that has none (or no `execute`) is passed
+ * through BY IDENTITY, so the single-execution-path property still holds.
+ *
+ * `toModelOutput` answers an AI SDK `ToolResultOutput` envelope rather than a
+ * `CallToolResult`, so the envelope is unwrapped before it goes on the wire —
+ * see {@link unwrapToolResultOutput}. It is also STRIPPED from the returned
+ * tool: having already projected, a future harness that learns to call it must
+ * not project a second time.
+ */
+function withModelOutputProjection(args: {
+  tool: unknown;
+  onRawResult?: (a: { toolCallId: string; raw: unknown }) => void;
+}): unknown {
+  const tool = args.tool as {
+    execute?: (input: unknown, options: unknown) => unknown;
+    toModelOutput?: (opts: {
+      toolCallId: string;
+      input: unknown;
+      output: unknown;
+      abortSignal?: AbortSignal;
+    }) => unknown;
+  };
+  const originalExecute = tool.execute?.bind(tool);
+  const toModelOutput = tool.toModelOutput?.bind(tool);
+  if (!originalExecute || !toModelOutput) return args.tool;
+  const { toModelOutput: _projected, ...rest } = tool;
+  return {
+    ...rest,
+    execute: async (input: unknown, options: unknown) => {
+      const raw = await originalExecute(input, options);
+      const callOptions = options as
+        | { toolCallId?: unknown; abortSignal?: unknown }
+        | undefined;
+      const toolCallId =
+        typeof callOptions?.toolCallId === "string"
+          ? callOptions.toolCallId
+          : undefined;
+      if (toolCallId) args.onRawResult?.({ toolCallId, raw });
+      const modelOutput = await toModelOutput({
+        toolCallId: toolCallId ?? "",
+        input,
+        output: raw,
+        // Linked-resource reads happen inside the projection; pass the turn's
+        // signal so a cancelled turn stops them promptly.
+        ...(callOptions?.abortSignal instanceof AbortSignal
+          ? { abortSignal: callOptions.abortSignal }
+          : {}),
+      });
+      return unwrapToolResultOutput(modelOutput, raw);
+    },
+  };
+}
+
+/**
+ * Unwrap an AI SDK `ToolResultOutput` back to the value the relay should carry.
+ *
+ * `json` / `text` / `error-text` are transport envelopes around a value the
+ * relay can serialize directly, and unwrapping them keeps the wire shape
+ * IDENTICAL to today's raw path (an ordinary MCP result projects to
+ * `{type:"json", value: <result>}`), so this change is invisible to a tool with
+ * nothing to scrub. `content` is a genuinely different, self-describing shape
+ * (the image/resource projection), so it rides as-is rather than being flattened
+ * into something the model would have to guess at. Anything unrecognised falls
+ * back to the raw result rather than putting an unknown envelope on the wire.
+ */
+function unwrapToolResultOutput(modelOutput: unknown, raw: unknown): unknown {
+  if (!modelOutput || typeof modelOutput !== "object") return raw;
+  const envelope = modelOutput as { type?: unknown; value?: unknown };
+  if (
+    envelope.type === "json" ||
+    envelope.type === "text" ||
+    envelope.type === "error-text"
+  ) {
+    return envelope.value;
+  }
+  return modelOutput;
 }
 
 /**

--- a/mcpjam-inspector/server/utils/harness/host-executed-mcp-tools.ts
+++ b/mcpjam-inspector/server/utils/harness/host-executed-mcp-tools.ts
@@ -24,8 +24,10 @@
  * for. A host-executed tool does not run in the sandbox: it runs in this
  * process, where the authorized `MCPClientManager` connection already lives. So
  * these tools call the manager directly — reusing the SAME projection the
- * emulated engine uses (`getToolsForAiSdk`), not a second hand-rolled
- * converter. Routing them back out through the proxy would add an HTTP hop from
+ * emulated engine uses (`getToolsForAiSdk`), and under the SAME host-derived
+ * options (`mcpToolOptionsFor`, shared with the emulated engine and both eval
+ * runners), not a second hand-rolled converter. Routing them back out through
+ * the proxy would add an HTTP hop from
  * this server to itself and would have to mint a token for it. Going direct is
  * also strictly safer: no proxy token and no server URL ever enters the
  * sandbox, so a compromised sandbox cannot reach the servers off-turn at all.
@@ -69,6 +71,10 @@ import {
   type HarnessPolicyBlockMarker,
 } from "./harness-proxy-policy-enforcement.js";
 import { selectDeliverableServerIds } from "./plugin-delivery.js";
+import {
+  mcpToolOptionsFor,
+  type McpToolOptionsInput,
+} from "../mcp-tool-options.js";
 import { scopeStepUpInfoFromToolError } from "../insufficient-scope-step-up.js";
 import type { HarnessScopeStepUpEvent } from "./harness-scope-step-up.js";
 import type { RuntimePluginVersion } from "../../services/environments/effective-capabilities.js";
@@ -128,6 +134,37 @@ export async function projectSelectedMcpServersAsHostTools(args: {
    * does. Omitted ⇒ the raw result is simply not retained.
    */
   onRawResult?: (args: { toolCallId: string; raw: unknown }) => void;
+  /**
+   * The HOST-DERIVED tool-construction inputs, resolved by the caller.
+   *
+   * `getToolsForAiSdk` states plainly that it will not read a host config
+   * itself, so anything the host decided about how a tool is BUILT has to
+   * arrive here. Omitting them (as this function used to) does not fall back to
+   * the host's intent — it falls back to the SDK's defaults, which is how a
+   * Codex turn came to run `toModelOutput` under a policy the host never chose.
+   *
+   * Two of the four `getToolsForAiSdk` options are deliberately NOT accepted:
+   *
+   *  - `needsApproval` — the AI SDK approval flag is read by MCPJam's EMULATED
+   *    loop, which never runs on this path. Host-executed approval is enforced
+   *    by `HarnessAgent`'s own `toolApproval` map, which `runHarnessTurn`
+   *    builds over every key of `hostExecutedTools` (these projections
+   *    included) whenever the host requires approval and the adapter advertises
+   *    `supportsHostExecutedToolApproval`; unsound combinations are refused
+   *    outright by `harnessToolApprovalRefusalReason`, at the route pre-flight
+   *    AND at the in-turn backstop. Setting `needsApproval` here would add a
+   *    SECOND approval declaration that nothing on this path reads — inert, and
+   *    indistinguishable on inspection from enforcement. So the field is
+   *    absent by construction rather than dropped by omission, and a future
+   *    host-executed adapter that flips `supportsHostExecutedToolApproval` is
+   *    already covered by the map, not by this argument.
+   *  - `schemas` — no harness surface overrides tool schemas.
+   *
+   * Built by the shared {@link mcpToolOptionsFor}, so absent-everything yields
+   * `undefined` and the enumeration takes the no-options overload: a default
+   * harness turn produces exactly the tools it produced before this existed.
+   */
+  toolOptions?: McpToolOptionsInput;
 }): Promise<HostExecutedMcpProjection> {
   const configured = selectDeliverableServerIds({
     selectedServerIds: args.selectedServerIds,
@@ -150,6 +187,12 @@ export async function projectSelectedMcpServersAsHostTools(args: {
     serverIdToKey.set(serverId, key);
   }
 
+  // Built ONCE for the whole projection: the options are host-level, and the
+  // per-server loop below must not be able to hand two servers different ones.
+  const toolOptions = args.toolOptions
+    ? mcpToolOptionsFor(args.toolOptions)
+    : undefined;
+
   const tools: Record<string, unknown> = {};
   for (const serverId of configured) {
     const key = serverIdToKey.get(serverId);
@@ -164,7 +207,13 @@ export async function projectSelectedMcpServersAsHostTools(args: {
     // SEP-1865 app-only visibility filtering, `_serverId` tagging) — the same
     // one the emulated engine runs on. A second converter here would be a
     // second place for the two engines to disagree about a tool.
-    const serverTools = await args.manager.getToolsForAiSdk([serverId]);
+    //
+    // …and reuse it under the HOST's options, not the SDK's defaults. The
+    // no-options overload is kept for a default turn so those tools stay
+    // byte-identical to what this projection produced before.
+    const serverTools = toolOptions
+      ? await args.manager.getToolsForAiSdk([serverId], toolOptions)
+      : await args.manager.getToolsForAiSdk([serverId]);
     const snapshot = args.toolPolicy?.[serverId];
     for (const [toolName, tool] of Object.entries(serverTools)) {
       // Layered inward-out, and the order is load-bearing:

--- a/mcpjam-inspector/server/utils/harness/host-executed-mcp-tools.ts
+++ b/mcpjam-inspector/server/utils/harness/host-executed-mcp-tools.ts
@@ -41,6 +41,10 @@
  *  - Schemas are enumerated ONCE, at turn start. There is no `tools/list_changed`
  *    subscription: a server that adds or removes a tool mid-turn is not
  *    reflected until the next turn.
+ *  - Scope step-up (SEP-2350) IS carried: an `insufficient_scope` challenge
+ *    raised by an in-process call is extracted with the same shared helper the
+ *    proxy path uses and handed to the turn's existing bridge (see
+ *    {@link projectSelectedMcpServersAsHostTools}'s `onScopeStepUpChallenge`).
  *  - Every projected tool's description is injected into the PROMPT by the
  *    bridge, so a server with many tools inflates every turn of the
  *    conversation. There is no cap here — MCPJam has no tool-count budget to
@@ -59,6 +63,8 @@ import {
   type HarnessPolicyBlockMarker,
 } from "./harness-proxy-policy-enforcement.js";
 import { selectDeliverableServerIds } from "./plugin-delivery.js";
+import { scopeStepUpInfoFromToolError } from "../insufficient-scope-step-up.js";
+import type { HarnessScopeStepUpEvent } from "./harness-scope-step-up.js";
 import type { RuntimePluginVersion } from "../../services/environments/effective-capabilities.js";
 
 /** The harness tool-name prefix. Claude Code's native scheme, reused verbatim so
@@ -94,6 +100,18 @@ export async function projectSelectedMcpServersAsHostTools(args: {
   /** Per-server resolved `toolPolicy` decisions for this run. A server with a
    *  snapshot gets its calls gated IN-PROCESS before they reach the server. */
   toolPolicy?: Record<string, ToolPolicySnapshot>;
+  /**
+   * Sink for an actionable SEP-2350 scope challenge raised by one of these
+   * calls. Publishes into the turn's EXISTING harness scope step-up bridge —
+   * the same one the proxy publishes into on the native path — so a hosted-OAuth
+   * server that needs a step-up pauses the turn here exactly as it does there,
+   * instead of surfacing to the model as an ordinary tool failure.
+   *
+   * Omitted (eval/synthetic callers with no writer) ⇒ tools are passed through
+   * unwrapped and a challenge stays an ordinary error, which is the pre-existing
+   * behaviour for a turn that cannot pause anyway.
+   */
+  onScopeStepUpChallenge?: (event: HarnessScopeStepUpEvent) => void;
 }): Promise<HostExecutedMcpProjection> {
   const configured = selectDeliverableServerIds({
     selectedServerIds: args.selectedServerIds,
@@ -133,12 +151,83 @@ export async function projectSelectedMcpServersAsHostTools(args: {
     const serverTools = await args.manager.getToolsForAiSdk([serverId]);
     const snapshot = args.toolPolicy?.[serverId];
     for (const [toolName, tool] of Object.entries(serverTools)) {
-      tools[harnessMcpToolName(key, toolName)] = snapshot
-        ? withToolPolicyGate({ tool, toolName, snapshot })
-        : tool;
+      // Layered inward-out, and the order is load-bearing: the policy gate must
+      // be OUTERMOST so a denied call short-circuits to the block envelope
+      // without ever entering the observer (a blocked call reaches no server and
+      // so can raise no scope challenge). With neither layer in force the
+      // manager's own tool object is passed through by IDENTITY, keeping exactly
+      // one execution path for an MCP call.
+      let projected: unknown = tool;
+      if (args.onScopeStepUpChallenge) {
+        projected = withScopeStepUpObserver({
+          tool: projected,
+          serverId,
+          toolName,
+          onChallenge: args.onScopeStepUpChallenge,
+        });
+      }
+      if (snapshot) {
+        projected = withToolPolicyGate({ tool: projected, toolName, snapshot });
+      }
+      tools[harnessMcpToolName(key, toolName)] = projected;
     }
   }
   return { tools, keyToServerId };
+}
+
+/**
+ * Carry an actionable SEP-2350 scope challenge out of an in-process MCP call.
+ *
+ * The native path gets this for free: the sandbox's call goes through the signed
+ * proxy, which extracts the challenge and publishes it under the turn's
+ * correlation id. A host-executed call never touches the proxy — it runs right
+ * here — so without this wrapper an `insufficient_scope` response degrades into
+ * a plain tool error and the user is never offered the step-up.
+ *
+ * The extraction and the actionability gate are NOT re-implemented: this calls
+ * {@link scopeStepUpInfoFromToolError}, the same helper the proxy path calls,
+ * so "which challenges are worth surfacing" has exactly one answer.
+ *
+ * `toolName` is the UN-NAMESPACED name and `toolInput` the raw arguments,
+ * because that is the tuple the turn's bridge correlates a challenge against the
+ * observed tool call on (serverId + toolName + input). Errors are always
+ * rethrown — this observes, it never swallows.
+ */
+function withScopeStepUpObserver(args: {
+  tool: unknown;
+  serverId: string;
+  toolName: string;
+  onChallenge: (event: HarnessScopeStepUpEvent) => void;
+}): unknown {
+  const tool = args.tool as {
+    execute?: (input: unknown, options: unknown) => unknown;
+  };
+  const originalExecute = tool.execute?.bind(tool);
+  if (!originalExecute) return args.tool;
+  return {
+    ...tool,
+    execute: async (input: unknown, options: unknown) => {
+      try {
+        return await originalExecute(input, options);
+      } catch (error) {
+        const toolCallId = (options as { toolCallId?: unknown } | undefined)
+          ?.toolCallId;
+        const info = scopeStepUpInfoFromToolError({
+          error,
+          serverId: args.serverId,
+          ...(typeof toolCallId === "string" ? { toolCallId } : {}),
+        });
+        if (info) {
+          args.onChallenge({
+            ...info,
+            toolName: args.toolName,
+            toolInput: input,
+          });
+        }
+        throw error;
+      }
+    },
+  };
 }
 
 /**

--- a/mcpjam-inspector/server/utils/harness/registry.ts
+++ b/mcpjam-inspector/server/utils/harness/registry.ts
@@ -150,7 +150,36 @@ export type HarnessBuiltinToolInfo = {
   inputSchema?: Record<string, unknown>;
 };
 
-export type HarnessRuntimeAdapter = {
+/**
+ * HOW a harness gets the host's selected MCP servers — a MODE, not a boolean,
+ * so the two mechanisms are mutually exclusive by construction rather than by
+ * comment. Every adapter has exactly one, so "this harness can't do MCP at all"
+ * is no longer representable (the state the old `supportsSelectedMcpServers:
+ * false` encoded, which forced a pre-flight refusal).
+ *
+ *  - `native` — the runtime's own MCP client connects to the servers. The
+ *    adapter writes runtime-specific config into the sandbox
+ *    (`deliverMcpServers`), pointed at MCPJam's signed per-server proxy, and
+ *    the model calls the tools through native function calling. Claude Code.
+ *
+ *  - `host-executed` — the runtime cannot make an MCP tool model-callable
+ *    (Codex: `codex exec --experimental-json` completes the MCP handshake and
+ *    answers `tools/list`, but never registers the tools as callable functions
+ *    — openai/codex#19425, and see `@ai-sdk/harness-codex`'s
+ *    `src/bridge/cli-relay.ts`, whose whole existence is the harness authors
+ *    hitting this same wall for their OWN host tools). MCPJam instead projects
+ *    each selected server's tools into host-executed AI SDK tools passed as the
+ *    agent's `tools`, which the bridge relays back out of the sandbox and
+ *    MCPJam executes IN-PROCESS against the already-authorized
+ *    `MCPClientManager`. See `host-executed-mcp-tools.ts`.
+ *
+ * The two must never both run for one turn or the model would see every MCP
+ * tool twice (once natively, once as a host tool); the adapter union below
+ * makes that unrepresentable.
+ */
+export type HarnessMcpDelivery = "native" | "host-executed";
+
+type HarnessRuntimeAdapterBase = {
   id: HarnessId;
   /** Human-facing runtime name for preflight/availability messages + UI. */
   displayName: string;
@@ -175,10 +204,10 @@ export type HarnessRuntimeAdapter = {
   /** Can host-executed AI SDK tools (run on MCPJam's server) be approval-gated?
    *  Modeled separately; false for v1 (not wired/tested in MCPJam yet). */
   supportsHostExecutedToolApproval: boolean;
-  /** Does the adapter deliver the host's selected MCP servers into the sandbox?
-   *  Claude Code: yes (`.mcp.json`). Codex v1: no (bridge MCP limits) — a Codex
-   *  host with selected servers fails the preflight. */
-  supportsSelectedMcpServers: boolean;
+  /** HOW this adapter gets the host's selected MCP servers to the model — see
+   *  `HarnessMcpDelivery`. Every adapter delivers them one way or the other, so
+   *  there is no "MCP unsupported" arm and no MCP pre-flight refusal. */
+  mcpDelivery: HarnessMcpDelivery;
   /** Does the adapter deliver runtime (Cloud) skills into the sandbox? Claude
    *  Code: yes. Codex: yes (INS-8) — its `writeSkills` materializes the same
    *  `skills` param under its own root before the CLI starts. */
@@ -238,13 +267,35 @@ export type HarnessRuntimeAdapter = {
     rawToolName: string,
     keyToServerId: Record<string, string>
   ): HarnessToolAttribution;
-  /** Write the host's MCP servers into a fresh sandbox session. Present only when
-   *  `supportsSelectedMcpServers`. */
-  deliverMcpServers?(args: HarnessMcpDeliveryArgs): Promise<void>;
   /** Install verified plugin bundles into a fresh sandbox session, before the
    *  runtime process starts. REQUIRED when `supportsPluginBundles`. */
   deliverPluginBundles?(args: HarnessPluginDeliveryArgs): Promise<void>;
 };
+
+/**
+ * The two MCP-delivery arms, as a discriminated union rather than a boolean +
+ * an optional hook. This is what makes "the model never sees a tool twice" a
+ * TYPE invariant:
+ *   - `native` REQUIRES `deliverMcpServers` (advertise = implement, checked by
+ *     the compiler instead of by a runtime throw in `runHarnessTurn`);
+ *   - `host-executed` FORBIDS it (`?: never`), so an adapter cannot half-adopt
+ *     the relay while still writing runtime MCP config.
+ */
+export type HarnessRuntimeAdapter = HarnessRuntimeAdapterBase &
+  (
+    | {
+        mcpDelivery: "native";
+        /** Write the host's MCP servers into a fresh sandbox session, before the
+         *  runtime process starts. */
+        deliverMcpServers(args: HarnessMcpDeliveryArgs): Promise<void>;
+      }
+    | {
+        mcpDelivery: "host-executed";
+        /** Never present: this arm's servers reach the model as host-executed
+         *  tools, not as runtime config in the sandbox. */
+        deliverMcpServers?: never;
+      }
+  );
 
 const CLAUDE_CODE_BRIDGE_USER_MESSAGE_NEEDLE = 'type: "user",\n    message: {';
 const CLAUDE_CODE_BRIDGE_USER_MESSAGE_PATCH =
@@ -570,7 +621,9 @@ const claudeCodeAdapter: HarnessRuntimeAdapter = {
   // WS3 wires host-executed tools through `toolApproval` (the agent pauses on
   // tool-approval-request and resumes with the decision), same path as native.
   supportsHostExecutedToolApproval: true,
-  supportsSelectedMcpServers: true,
+  // The CLI's own MCP client connects to the servers from inside the sandbox,
+  // via the `.mcp.json` written below — real native function calling.
+  mcpDelivery: "native",
   supportsSkills: true,
   skillsBaseDir: CLAUDE_CODE_SKILLS_BASE,
   prepareSkills: prepareClaudeCodeSkills,
@@ -626,14 +679,16 @@ const codexAdapter: HarnessRuntimeAdapter = {
   // Codex docs say host-executed AI SDK approvals can work, but it's not wired/
   // tested in MCPJam yet — keep false for v1; flip without code churn later.
   supportsHostExecutedToolApproval: false,
-  // Still no MCP servers on Codex, and INS-8 did NOT change that. `.mcp.json` is
-  // Claude-specific, and the codex bridge documents that codex never registers
-  // an MCP tool as model-callable in `codex exec --experimental-json` (the mode
-  // the SDK drives): the handshake completes and `tools/list` answers, but the
-  // model can't call anything (openai/codex#19425). Delivering config the model
-  // can't use would advertise MCP support that does not exist, so this stays
-  // false and the preflight keeps blocking a Codex host with selected servers.
-  supportsSelectedMcpServers: false,
+  // COMP-39: Codex reaches the host's MCP servers, but NOT through
+  // `mcp_servers`. Writing `~/.codex/config.toml` merges cleanly and is a
+  // silent no-op — the codex bridge documents that codex never registers an MCP
+  // tool as model-callable in `codex exec --experimental-json` (the mode the
+  // SDK drives): the handshake completes and `tools/list` answers, but the
+  // model can't call anything (openai/codex#19425). So MCPJam projects each
+  // selected server's tools into HOST-EXECUTED AI SDK tools instead; the bridge
+  // relays the invocations back out (`cli-relay.ts`) and MCPJam runs them
+  // in-process. See `HarnessMcpDelivery` and `host-executed-mcp-tools.ts`.
+  mcpDelivery: "host-executed",
   // INS-8: skills ARE delivered. `codex-harness.ts` writes every `skills` entry
   // to `$HOME/.agents/skills/<name>/SKILL.md` during `doStart`, before it spawns
   // the CLI, and points the process at that HOME — the same delivery contract
@@ -643,9 +698,9 @@ const codexAdapter: HarnessRuntimeAdapter = {
   supportsSkills: true,
   skillsBaseDir: CODEX_SKILLS_BASE,
   prepareSkills: prepareCodexSkills,
-  // Codex has no plugin-install interface in the installed harness, and its MCP
-  // half is unusable (see supportsSelectedMcpServers) — a "plugin install" that
-  // silently drops the plugin's MCP components is not an install.
+  // Codex has no plugin-install interface in the installed harness — MCPJam
+  // still projects a plugin's components (skills param, host-executed MCP
+  // tools), which is not the same contract as a native bundle install.
   supportsPluginBundles: false,
   // Codex surfaces file mutations as `file-change` stream parts (some don't
   // originate from a model-callable tool); we render them as this native tool.
@@ -655,8 +710,13 @@ const codexAdapter: HarnessRuntimeAdapter = {
   // Codex only runs the gpt-5 family it maps; anything else would silently fall
   // back to Codex's default model, so the preflight rejects it.
   supportsModel: (modelId) => toCodexModel(modelId) !== undefined,
-  // No MCP namespacing in v1 — pass the name through as a native tool.
-  parseToolName: (rawToolName) => ({ toolName: rawToolName }),
+  // SAME scheme as Claude Code, deliberately: the projected host tools are named
+  // `mcp__<sanitizedServer>__<tool>` (see `host-executed-mcp-tools.ts`), so a
+  // relayed call attributes back to its serverId exactly as a native Claude Code
+  // call does — eval assertions and trace spans written against a Claude Code
+  // run match a Codex run tool-for-tool. Codex's own natives arrive as common
+  // names (`bash`, `read`, …), which have no prefix and pass through unchanged.
+  parseToolName: parseHarnessToolName,
   createHarness({ modelId, auth }) {
     const nativeModel = toCodexModel(modelId);
     // Same dual-`ai` boundary cast as Claude Code. `auth.openaiCompatible` is

--- a/mcpjam-inspector/server/utils/harness/registry.ts
+++ b/mcpjam-inspector/server/utils/harness/registry.ts
@@ -18,6 +18,10 @@ import type { HarnessV1PermissionMode } from "@ai-sdk/harness";
 import { asSchema } from "ai";
 import { type Harness } from "@mcpjam/sdk/host-config/internal";
 import {
+  HARNESS_MCP_DELIVERY,
+  type HarnessMcpDelivery,
+} from "@/shared/harness-mcp-delivery";
+import {
   parseHarnessToolName,
   serializeHarnessMcpJson,
   type HarnessMcpJson,
@@ -176,8 +180,15 @@ export type HarnessBuiltinToolInfo = {
  * The two must never both run for one turn or the model would see every MCP
  * tool twice (once natively, once as a host tool); the adapter union below
  * makes that unrepresentable.
+ *
+ * WHICH mode each harness uses is declared in `@/shared/harness-mcp-delivery`,
+ * not here: the CLIENT has to derive its Behavior-tab promises from the same
+ * answer (a knob that acts at tool-construction time bites on `host-executed`
+ * and cannot on `native`), and it cannot import this server-only module. The
+ * adapters below read that map, and `__tests__/registry.test.ts` asserts the two
+ * can never disagree.
  */
-export type HarnessMcpDelivery = "native" | "host-executed";
+export type { HarnessMcpDelivery };
 
 type HarnessRuntimeAdapterBase = {
   id: HarnessId;
@@ -622,8 +633,10 @@ const claudeCodeAdapter: HarnessRuntimeAdapter = {
   // tool-approval-request and resumes with the decision), same path as native.
   supportsHostExecutedToolApproval: true,
   // The CLI's own MCP client connects to the servers from inside the sandbox,
-  // via the `.mcp.json` written below — real native function calling.
-  mcpDelivery: "native",
+  // via the `.mcp.json` written below — real native function calling. Read from
+  // the shared declaration so the host editor's promises about which knobs bite
+  // move with this, instead of being re-asserted by hand on the client.
+  mcpDelivery: HARNESS_MCP_DELIVERY["claude-code"],
   supportsSkills: true,
   skillsBaseDir: CLAUDE_CODE_SKILLS_BASE,
   prepareSkills: prepareClaudeCodeSkills,
@@ -688,7 +701,10 @@ const codexAdapter: HarnessRuntimeAdapter = {
   // selected server's tools into HOST-EXECUTED AI SDK tools instead; the bridge
   // relays the invocations back out (`cli-relay.ts`) and MCPJam runs them
   // in-process. See `HarnessMcpDelivery` and `host-executed-mcp-tools.ts`.
-  mcpDelivery: "host-executed",
+  // Read from the shared declaration — the client's Behavior tab derives from
+  // the same value, so "MCPJam builds these tools, so the host's construction
+  // knobs apply" is stated once for both sides.
+  mcpDelivery: HARNESS_MCP_DELIVERY.codex,
   // INS-8: skills ARE delivered. `codex-harness.ts` writes every `skills` entry
   // to `$HOME/.agents/skills/<name>/SKILL.md` during `doStart`, before it spawns
   // the CLI, and points the process at that HOME — the same delivery contract

--- a/mcpjam-inspector/server/utils/harness/run-harness-turn.ts
+++ b/mcpjam-inspector/server/utils/harness/run-harness-turn.ts
@@ -157,6 +157,7 @@ import {
   emitInsufficientScopeChunk,
   emitScopeStepUpRequiredChunk,
 } from "../../routes/web/hosted-elicitation.js";
+import { harnessToolApprovalRefusalReason } from "./harness-availability.js";
 
 /** A minimal writer matching what `createUIMessageStream` hands `execute` and
  *  what the no-op (`streamSink: "none"`) path supplies. */
@@ -795,22 +796,36 @@ export async function runHarnessTurn(
           emitInsufficientScopeChunk(writer, undefined, challenge);
         });
     };
+    /**
+     * The turn's ONE scope step-up intake, with two publishers:
+     *
+     *  - NATIVE delivery — the signed proxy, which saw the sandbox's own
+     *    `tools/call` and publishes under this turn's correlation id
+     *    (subscription below);
+     *  - HOST-EXECUTED delivery — the in-process projected tools, which raise
+     *    the challenge inside `execute()` and hand it straight here
+     *    (`onScopeStepUpChallenge`, wired at the projection below).
+     *
+     * Both arrive as the same event and take the same path, so a Codex turn
+     * pauses for a step-up exactly like a Claude Code turn does. Ordering
+     * against the tool-call observation is handled by `tryCreate…` being called
+     * from both sides — whichever lands second completes the correlation.
+     */
+    const receiveScopeStepUpChallenge = (info: HarnessScopeStepUpEvent) => {
+      if (!harnessScopeStepUpServerMatches(selectedServers, info.serverId)) {
+        return;
+      }
+      pendingScopeChallenge = info;
+      if (!info.toolName || !createHarnessScopeStepUpContinuation) {
+        emitInsufficientScopeChunk(writer, undefined, info);
+        return;
+      }
+      tryCreateHarnessScopeStepUp();
+    };
     const stopScopeStepUpBridge = harnessMcpProxy
       ? subscribeHarnessScopeStepUp(
           turnId,
-          (info) => {
-            if (
-              !harnessScopeStepUpServerMatches(selectedServers, info.serverId)
-            ) {
-              return;
-            }
-            pendingScopeChallenge = info;
-            if (!info.toolName || !createHarnessScopeStepUpContinuation) {
-              emitInsufficientScopeChunk(writer, undefined, info);
-              return;
-            }
-            tryCreateHarnessScopeStepUp();
-          },
+          receiveScopeStepUpChallenge,
           selectedServers
         )
       : () => {};
@@ -918,26 +933,22 @@ export async function runHarnessTurn(
             "support but has no deliverPluginBundles strategy (adapter misconfigured)."
         );
       }
-      //   (b) approval invariant for HOST-EXECUTED MCP delivery (COMP-39).
-      //       On that path the host's MCP tools run through the agent's
-      //       host-executed `tools`, which are only approval-gated when the
-      //       adapter declares `supportsHostExecutedToolApproval`. Codex does
-      //       not, so an approval host must fail closed HERE rather than have
-      //       its MCP calls silently bypass approval. The route preflight
-      //       already refuses this combination; eval/synthetic/unified paths
-      //       skip that preflight, which is exactly what this backstops.
-      //       (Advertise = enforce.)
-      if (
-        harnessAdapter.mcpDelivery === "host-executed" &&
-        requireToolApproval &&
-        !harnessAdapter.supportsHostExecutedToolApproval &&
-        (selectedServers?.length ?? 0) > 0
-      ) {
-        throw new Error(
-          `The ${harnessAdapter.displayName} harness runs the host's MCP tools ` +
-            "on MCPJam's server and can't pause them for approval — turn off " +
-            "requireToolApproval on this host to run it."
-        );
+      //   (b) approval invariant (advertise = enforce). The route pre-flight
+      //       already refuses every unsound approval combination; the eval,
+      //       synthetic and unified paths never call it, which is exactly what
+      //       this backstops. It asks the SAME helper the pre-flight asks, so
+      //       the two can't drift — and it is deliberately NOT conditioned on
+      //       there being selected servers: a runtime that can't pause on its
+      //       own native tools (Codex) is unsound under approval whether or not
+      //       any MCP server is attached, and its host-executed built-ins
+      //       (web_search) would otherwise run unapproved here.
+      const approvalRefusal = harnessToolApprovalRefusalReason({
+        adapter: harnessAdapter,
+        requireToolApproval,
+        hasSelectedMcpServers: (selectedServers?.length ?? 0) > 0,
+      });
+      if (approvalRefusal) {
+        throw new Error(`Can't run this turn: ${approvalRefusal}.`);
       }
 
       // 1. Credential delivery gate. BROKER-ONLY (COMP-23): the lease is
@@ -1033,6 +1044,11 @@ export async function runHarnessTurn(
               // IN-PROCESS instead of by a sealed proxy token — same decision
               // function, same block envelope.
               ...(harnessToolPolicy ? { toolPolicy: harnessToolPolicy } : {}),
+              // …and, for the same reason, no proxy to extract a SEP-2350
+              // challenge either. Publish straight into the turn's step-up
+              // intake so a hosted-OAuth server pauses this turn instead of
+              // reporting an ordinary tool failure to the model.
+              onScopeStepUpChallenge: receiveScopeStepUpChallenge,
             })
           : { tools: {}, keyToServerId: {} };
       // The attribution map is whichever mode produced one; they are the same

--- a/mcpjam-inspector/server/utils/harness/run-harness-turn.ts
+++ b/mcpjam-inspector/server/utils/harness/run-harness-turn.ts
@@ -496,6 +496,9 @@ export async function runHarnessTurn(
     failureReporter: failureReporterOption,
     onLiveTextDelta,
     requireToolApproval,
+    modelVisibleMcpToolResults,
+    respectToolVisibility,
+    tasks,
     chatSessionId,
     scenarioId,
     sourceType,
@@ -1043,6 +1046,18 @@ export async function runHarnessTurn(
               // shows what the server returned, like every other engine.
               onRawResult: ({ toolCallId, raw }) => {
                 hostExecutedRawResults.set(toolCallId, raw);
+              },
+              // The host's own tool-CONSTRUCTION inputs. Everything the
+              // emulated engine derives for `getToolsForAiSdk` lands here too,
+              // via the same shared builder — this projection is the host's
+              // MCP tool set for a Codex turn, so a policy that changes how a
+              // tool is built has to reach it or it does not exist on this
+              // delivery mode at all. (`needsApproval` is intentionally not in
+              // this set — see `projectSelectedMcpServersAsHostTools`.)
+              toolOptions: {
+                modelVisibleMcpToolResults,
+                includeAppOnly: respectToolVisibility === false,
+                tasks,
               },
             })
           : { tools: {}, keyToServerId: {} };

--- a/mcpjam-inspector/server/utils/harness/run-harness-turn.ts
+++ b/mcpjam-inspector/server/utils/harness/run-harness-turn.ts
@@ -150,8 +150,10 @@ import {
 import type { ToolPolicySnapshot } from "@mcpjam/sdk/contract";
 import {
   harnessScopeStepUpServerMatches,
+  matchHarnessScopeStepUpToolCall,
   subscribeHarnessScopeStepUp,
   type HarnessScopeStepUpEvent,
+  type ObservedHarnessToolCall,
 } from "./harness-scope-step-up.js";
 import {
   emitInsufficientScopeChunk,
@@ -334,20 +336,6 @@ function coerceToolInput(raw: unknown): unknown {
   } catch {
     return raw;
   }
-}
-
-function stableHarnessValue(value: unknown): string {
-  if (value === null || typeof value !== "object") {
-    return JSON.stringify(value) ?? "null";
-  }
-  if (Array.isArray(value)) {
-    return `[${value.map(stableHarnessValue).join(",")}]`;
-  }
-  const record = value as Record<string, unknown>;
-  return `{${Object.keys(record)
-    .sort()
-    .map((key) => `${JSON.stringify(key)}:${stableHarnessValue(record[key])}`)
-    .join(",")}}`;
 }
 
 /** AI-SDK `ToolResultPart.output` discriminators we must NOT re-wrap. */
@@ -744,12 +732,16 @@ export async function runHarnessTurn(
     // in-process tool wrapper emits. Exact turn correlation handles concurrent
     // chats; the registry's server fallback is used only when one live turn can
     // possibly receive a stale resumed-session event.
-    const observedHarnessToolCalls: Array<{
-      toolCallId: string;
-      serverId?: string;
-      toolName: string;
-      input: unknown;
-    }> = [];
+    const observedHarnessToolCalls: ObservedHarnessToolCall[] = [];
+    // HOST-EXECUTED delivery only: the RAW MCP result of a projected call,
+    // captured at `execute()` time and keyed by the AI SDK `toolCallId`. The
+    // relay carries the MODEL-FACING projection instead (see
+    // `projectSelectedMcpServersAsHostTools`), and the runtime echoes back only
+    // what it was given — so without this the UI, the trace and the transcript
+    // would all see the scrubbed copy, diverging from the emulated engine,
+    // which shows the raw result and projects for the model alone. Claimed once
+    // per tool result and then dropped, so the map cannot outgrow the turn.
+    const hostExecutedRawResults = new Map<string, unknown>();
     let pendingScopeChallenge: HarnessScopeStepUpEvent | undefined;
     let suspendedHarnessToolCallId: string | undefined;
     let scopeStepUpCreation: Promise<void> | undefined;
@@ -762,16 +754,13 @@ export async function runHarnessTurn(
         return;
       }
       const challenge = pendingScopeChallenge;
-      const matchingCall = observedHarnessToolCalls.find(
-        (call) =>
-          harnessScopeStepUpServerMatches(
-            call.serverId ? [call.serverId] : [],
-            challenge.serverId
-          ) &&
-          call.toolName === challenge.toolName &&
-          stableHarnessValue(call.input) ===
-            stableHarnessValue(challenge.toolInput ?? {})
-      );
+      // `toolCallId` first, tuple only when the publisher had no id to give —
+      // see `matchHarnessScopeStepUpToolCall`. Two identical calls in one turn
+      // otherwise resume the FIRST one, whichever raised the challenge.
+      const matchingCall = matchHarnessScopeStepUpToolCall({
+        observed: observedHarnessToolCalls,
+        challenge,
+      });
       if (!matchingCall) return;
       suspendedHarnessToolCallId = matchingCall.toolCallId;
       scopeStepUpCreation = Promise.resolve(
@@ -1049,6 +1038,12 @@ export async function runHarnessTurn(
               // intake so a hosted-OAuth server pauses this turn instead of
               // reporting an ordinary tool failure to the model.
               onScopeStepUpChallenge: receiveScopeStepUpChallenge,
+              // The relay carries the MODEL-FACING projection of each result;
+              // keep the raw one for the UI/trace/transcript so a Codex turn
+              // shows what the server returned, like every other engine.
+              onRawResult: ({ toolCallId, raw }) => {
+                hostExecutedRawResults.set(toolCallId, raw);
+              },
             })
           : { tools: {}, keyToServerId: {} };
       // The attribution map is whichever mode produced one; they are the same
@@ -2192,9 +2187,17 @@ export async function runHarnessTurn(
             const toolCallId = String(
               (part as { toolCallId?: unknown }).toolCallId ?? ""
             );
-            const output =
-              (part as { output?: unknown }).output ??
-              (part as { result?: unknown }).result;
+            // HOST-EXECUTED delivery: prefer the raw result captured at
+            // `execute()` time over the runtime's echo, which is the model-facing
+            // projection we handed it. `has` rather than a truthiness check —
+            // a tool may legitimately resolve `undefined`.
+            const hasRawHostExecuted = hostExecutedRawResults.has(toolCallId);
+            const rawHostExecuted = hostExecutedRawResults.get(toolCallId);
+            hostExecutedRawResults.delete(toolCallId);
+            const output = hasRawHostExecuted
+              ? rawHostExecuted
+              : (part as { output?: unknown }).output ??
+                (part as { result?: unknown }).result;
             // Surface tool failures the harness reports so eval/trace consumers
             // that key off isError classify them correctly.
             const isError =

--- a/mcpjam-inspector/server/utils/harness/run-harness-turn.ts
+++ b/mcpjam-inspector/server/utils/harness/run-harness-turn.ts
@@ -70,6 +70,7 @@ import {
   pluginOriginByServerId,
   type RuntimePluginVersion,
 } from "../../services/environments/effective-capabilities.js";
+import { projectSelectedMcpServersAsHostTools } from "./host-executed-mcp-tools.js";
 import {
   capabilitySkillFiles,
   deliveredPluginSkillOrigins,
@@ -917,15 +918,25 @@ export async function runHarnessTurn(
             "support but has no deliverPluginBundles strategy (adapter misconfigured)."
         );
       }
-      //   (b) a harness that can't deliver the host's selected MCP servers must
-      //       NOT silently run without them.
+      //   (b) approval invariant for HOST-EXECUTED MCP delivery (COMP-39).
+      //       On that path the host's MCP tools run through the agent's
+      //       host-executed `tools`, which are only approval-gated when the
+      //       adapter declares `supportsHostExecutedToolApproval`. Codex does
+      //       not, so an approval host must fail closed HERE rather than have
+      //       its MCP calls silently bypass approval. The route preflight
+      //       already refuses this combination; eval/synthetic/unified paths
+      //       skip that preflight, which is exactly what this backstops.
+      //       (Advertise = enforce.)
       if (
-        !harnessAdapter.supportsSelectedMcpServers &&
+        harnessAdapter.mcpDelivery === "host-executed" &&
+        requireToolApproval &&
+        !harnessAdapter.supportsHostExecutedToolApproval &&
         (selectedServers?.length ?? 0) > 0
       ) {
         throw new Error(
-          `The ${harnessAdapter.displayName} harness doesn't support MCP servers yet, ` +
-            `but this host has ${selectedServers?.length} selected — remove them to run it.`
+          `The ${harnessAdapter.displayName} harness runs the host's MCP tools ` +
+            "on MCPJam's server and can't pause them for approval — turn off " +
+            "requireToolApproval on this host to run it."
         );
       }
 
@@ -962,39 +973,73 @@ export async function runHarnessTurn(
       // own discovery. Re-applying the emulation would double it, defeat the
       // "observe the real runtime" purpose, and isn't expressible anyway —
       // .mcp.json has no knob to inject MCPJam meta-tools into the real loop.
-      // Only adapters that deliver MCP servers (Claude Code) build the config;
-      // the undeliverable-servers case already failed closed in step 0(b) above.
-      // Fail closed: with MCP servers selected but no plane strategy, the
-      // harness would silently get zero MCP tools (the exact failure we hit).
-      if ((selectedServers?.length ?? 0) > 0 && !harnessMcpProxy) {
+      // Which of the two delivery modes this adapter uses. Mutually exclusive
+      // by construction (`HarnessMcpDelivery`), so the model can never see the
+      // same MCP tool twice.
+      const nativeMcpDelivery = harnessAdapter.mcpDelivery === "native";
+      // Fail closed: with MCP servers selected but no plane strategy, a NATIVE
+      // adapter would silently get zero MCP tools (the exact failure we hit).
+      // Host-executed delivery needs no proxy at all — its tools run in THIS
+      // process against the already-authorized manager — so requiring a
+      // strategy there would refuse a turn that has everything it needs.
+      if (
+        nativeMcpDelivery &&
+        (selectedServers?.length ?? 0) > 0 &&
+        !harnessMcpProxy
+      ) {
         throw new Error(
           "harness turn has MCP servers but no harnessMcpProxy strategy — the caller route must set options.harnessMcpProxy"
         );
       }
-      const { mcpJson, keyToServerId } =
-        harnessAdapter.supportsSelectedMcpServers
-          ? await buildHarnessProxyMcpJsonFromManager({
+      const pluginServerOrigins = effectiveCapabilities
+        ? pluginOriginByServerId(effectiveCapabilities)
+        : undefined;
+      const { mcpJson, keyToServerId } = nativeMcpDelivery
+        ? await buildHarnessProxyMcpJsonFromManager({
+            manager: mcpClientManager,
+            selectedServerIds: selectedServers ?? [],
+            authHeader,
+            projectId,
+            strategy: harnessMcpProxy ?? { plane: "local-mcp" },
+            scopeStepUpCorrelationId: turnId,
+            // Policied servers get a SEALED token instead of a bare one, so
+            // the sandbox's own MCP calls are enforced at the proxy.
+            ...(harnessToolPolicy ? { toolPolicy: harnessToolPolicy } : {}),
+            // INS-7: plugin-contributed servers ride this SAME proxy path as
+            // ordinary server ids (they are ordinary server ids) — the origin
+            // map only decides how a delivery failure is reported.
+            ...(pluginServerOrigins
+              ? { pluginOrigins: pluginServerOrigins }
+              : {}),
+          })
+        : { mcpJson: { mcpServers: {} }, keyToServerId: {} };
+
+      // HOST-EXECUTED delivery (COMP-39): the runtime can't make an MCP tool
+      // model-callable, so MCPJam enumerates each selected server's tools NOW
+      // and hands them to the agent as host-executed tools named exactly as
+      // Claude Code names them (`mcp__<key>__<tool>`). Enumerated once, at turn
+      // start — there is no `tools/list_changed` subscription, so a mid-turn
+      // schema change is only picked up on the next turn. Done here, before the
+      // box is woken, so an unreachable server fails the turn cheaply.
+      const hostExecutedMcp =
+        !nativeMcpDelivery && (selectedServers?.length ?? 0) > 0
+          ? await projectSelectedMcpServersAsHostTools({
               manager: mcpClientManager,
               selectedServerIds: selectedServers ?? [],
-              authHeader,
-              projectId,
-              strategy: harnessMcpProxy ?? { plane: "local-mcp" },
-              scopeStepUpCorrelationId: turnId,
-              // Policied servers get a SEALED token instead of a bare one, so
-              // the sandbox's own MCP calls are enforced at the proxy.
-              ...(harnessToolPolicy ? { toolPolicy: harnessToolPolicy } : {}),
-              // INS-7: plugin-contributed servers ride this SAME proxy path as
-              // ordinary server ids (they are ordinary server ids) — the origin
-              // map only decides how a delivery failure is reported.
-              ...(effectiveCapabilities
-                ? {
-                    pluginOrigins: pluginOriginByServerId(
-                      effectiveCapabilities
-                    ),
-                  }
+              ...(pluginServerOrigins
+                ? { pluginOrigins: pluginServerOrigins }
                 : {}),
+              // No proxy on this path, so the run's `toolPolicy` is enforced
+              // IN-PROCESS instead of by a sealed proxy token — same decision
+              // function, same block envelope.
+              ...(harnessToolPolicy ? { toolPolicy: harnessToolPolicy } : {}),
             })
-          : { mcpJson: { mcpServers: {} }, keyToServerId: {} };
+          : { tools: {}, keyToServerId: {} };
+      // The attribution map is whichever mode produced one; they are the same
+      // shape and the same sanitize+dedup, so `parseToolName` is identical.
+      const harnessKeyToServerId = nativeMcpDelivery
+        ? keyToServerId
+        : hostExecutedMcp.keyToServerId;
 
       // 2b. Claim the harness session lane (multi-turn continuity). Done BEFORE
       // waking the box so a "turn already running" (409) doesn't provision it.
@@ -1415,14 +1460,27 @@ export async function runHarnessTurn(
       // CLI-native alias `sonnet|opus|haiku`; the raw gateway id makes the CLI
       // do zero inference). Returns the HarnessAgent boundary type directly.
       const harnessRuntime = harnessAdapter.createHarness({ modelId, auth });
-      // MCPJam's server-executed built-in tools (e.g. web_search). The harness
-      // forwards each as a tool spec to the runtime; when Claude Code calls one
-      // it pauses, the agent runs the tool's `execute()` HERE on MCPJam's
-      // server, and submits the result back. MCP-server tools are NOT included
-      // (they reach the runtime via `.mcp.json` and its own MCP client), so the
-      // model never sees a tool twice. Cast across the dual-`ai` boundary, same
-      // as the harness adapter above (structurally identical ToolSet types).
-      const hostExecutedTools = (builtInTools ?? {}) as Record<string, unknown>;
+      // MCPJam's server-executed tools. The harness forwards each as a tool spec
+      // to the runtime; when the runtime calls one it pauses, the agent runs the
+      // tool's `execute()` HERE on MCPJam's server, and submits the result back.
+      // Cast across the dual-`ai` boundary, same as the harness adapter above
+      // (structurally identical ToolSet types).
+      //
+      // Two sources, and never both for the same MCP tool:
+      //   - the host's built-ins (e.g. web_search), always;
+      //   - on HOST-EXECUTED delivery only, the selected servers' MCP tools.
+      //     Under NATIVE delivery `hostExecutedMcp.tools` is empty by
+      //     construction (the branch above never ran), because those tools reach
+      //     the runtime via `.mcp.json` and its own MCP client — so the model
+      //     never sees a tool twice.
+      // Built-ins are spread LAST: their names are unprefixed, MCP projections
+      // are `mcp__…`-prefixed, so the two sets cannot collide — but if a future
+      // built-in ever took an `mcp__` name, the host's own built-in wins rather
+      // than being shadowed by a server.
+      const hostExecutedTools = {
+        ...hostExecutedMcp.tools,
+        ...((builtInTools ?? {}) as Record<string, unknown>),
+      } as Record<string, unknown>;
       const agent = new HarnessAgent({
         harness: harnessRuntime,
         sandbox,
@@ -1466,20 +1524,17 @@ export async function runHarnessTurn(
           // pass (the finally's agent session has no file I/O). Stays valid until
           // the box is detached/destroyed, which happens AFTER adoption.
           sandboxFileSession = session;
-          // Deliver the host's MCP servers into the session before the runtime
-          // starts, via the adapter's own strategy (Claude Code writes a
-          // `.mcp.json`). Codex v1 has no delivery (`supportsSelectedMcpServers:
-          // false`), so this is a no-op there.
-          if (harnessAdapter.supportsSelectedMcpServers) {
-            // Capability invariant: an adapter that advertises MCP support MUST
-            // provide a delivery strategy. Treating a missing hook as a no-op
-            // would silently run without the host's servers — fail loud instead.
-            if (!harnessAdapter.deliverMcpServers) {
-              throw new Error(
-                `The ${harnessAdapter.displayName} harness advertises MCP support ` +
-                  "but has no deliverMcpServers strategy (adapter misconfigured)."
-              );
-            }
+          // NATIVE delivery only: write the host's MCP servers into the session
+          // before the runtime starts, via the adapter's own strategy (Claude
+          // Code writes a `.mcp.json`). A host-executed adapter has nothing to
+          // write — its servers already went out as `tools` above — and the
+          // adapter union forbids it from carrying `deliverMcpServers` at all.
+          if (harnessAdapter.mcpDelivery === "native") {
+            // The "advertises MCP but has no delivery strategy" throw that used
+            // to guard this call is GONE, not relaxed: the native arm of
+            // `HarnessRuntimeAdapter` now REQUIRES `deliverMcpServers`, so the
+            // misconfiguration it caught is a compile error instead of a
+            // turn-time one (tsc reports the old check's body as `never`).
             await harnessAdapter.deliverMcpServers({
               // Bind to the live session here (it lives behind the dual-`ai`
               // boundary) so the adapter stays free of the harness session type.
@@ -2058,7 +2113,7 @@ export async function runHarnessTurn(
             // tools (Bash, Read, …) have no prefix → serverId stays undefined.
             const { serverId, toolName } = harnessAdapter.parseToolName(
               rawToolName,
-              keyToServerId
+              harnessKeyToServerId
             );
             const input = coerceToolInput(
               (part as { input?: unknown }).input ??
@@ -2135,7 +2190,7 @@ export async function runHarnessTurn(
               toolMeta.get(toolCallId) ??
               harnessAdapter.parseToolName(
                 String((part as { toolName?: unknown }).toolName ?? "tool"),
-                keyToServerId
+                harnessKeyToServerId
               );
             // A tool call the MCP proxy blocked on policy, recognised only when
             // THIS run sealed a policy for that server, and only ever with the

--- a/mcpjam-inspector/server/utils/mcp-tool-options.ts
+++ b/mcpjam-inspector/server/utils/mcp-tool-options.ts
@@ -1,0 +1,82 @@
+/**
+ * ONE builder for `getToolsForAiSdk`'s host-derived options.
+ *
+ * `MCPClientManager.getToolsForAiSdk(serverIds?, options = {})` takes four
+ * host-derived inputs and, by its own docblock, refuses to resolve any of them
+ * itself ("the mode is resolved by the CALLER — this class must not read host
+ * configs"). Every execution surface therefore has to build the same object,
+ * and until this helper existed four of them built it by hand:
+ *
+ *   - `chat-v2-orchestration.ts` (the emulated engine)
+ *   - `services/evals-runner.ts`
+ *   - `routes/shared/evals.ts` (single-case stream)
+ *   - `harness/host-executed-mcp-tools.ts` — which built NOTHING, and so
+ *     projected a Codex turn's MCP tools under the SDK's defaults rather than
+ *     the host's policy. That is the bug this helper exists to make
+ *     unrepresentable: a surface that forgets a field now forgets it in one
+ *     place, visibly, instead of silently dropping it at its own call site.
+ *
+ * ## The property that must not be lost
+ *
+ * When NO host input applies this returns `undefined`, and callers then use the
+ * **no-options overload** (`getToolsForAiSdk(ids)`). That is deliberate and
+ * load-bearing: a default turn must produce byte-identical tools to what it
+ * produced before any of these options existed, and the SDK's `tasks` seam
+ * documents the same rule from the other side ("omit and every call takes the
+ * pre-existing path, byte-for-byte"). Passing `{}` instead of `undefined` would
+ * be *behaviorally* identical today and would quietly invite a future default
+ * into the object; returning `undefined` keeps the two paths distinguishable at
+ * every call site and in every test assertion.
+ *
+ * Each field is included only when it is actually asserted:
+ *  - `needsApproval` when true (a `false` approval flag is the default);
+ *  - `includeAppOnly` when true (the caller resolves `respectToolVisibility
+ *    === false` into it — an explicit opt-out of SEP-1865 filtering);
+ *  - `modelVisibleMcpToolResults` when defined (a policy object, no default);
+ *  - `tasks` when defined (absent === tasks off; see `task-seam.ts`).
+ */
+import type { MCPClientManager, ToolTaskSeamOptions } from "@mcpjam/sdk";
+import type { ModelVisibleMcpToolResults } from "@mcpjam/sdk/host-config/internal";
+
+/**
+ * The manager's own options type, derived from the method rather than
+ * re-declared — so a field added to the SDK cannot silently bypass this
+ * builder's input surface without a type error here.
+ */
+export type McpToolOptions = NonNullable<
+  Parameters<InstanceType<typeof MCPClientManager>["getToolsForAiSdk"]>[1]
+>;
+
+export interface McpToolOptionsInput {
+  /** Host's `requireToolApproval`, for surfaces whose engine reads the AI SDK
+   *  approval flag. NOT every surface does — see the harness note in
+   *  `host-executed-mcp-tools.ts`. */
+  needsApproval?: boolean | undefined;
+  /**
+   * Include SEP-1865 app-only tools in the model-visible set. Callers pass
+   * `respectToolVisibility === false` (chat) or their own explicit decision
+   * (eval, which wants the full set so a visibility drop can be COUNTED).
+   */
+  includeAppOnly?: boolean | undefined;
+  modelVisibleMcpToolResults?: ModelVisibleMcpToolResults | undefined;
+  /** Resolved task seam, or absent for tasks-off. Never re-derived here: the
+   *  surface owns its own row in the policy matrix (`task-seam.ts`). */
+  tasks?: ToolTaskSeamOptions | undefined;
+}
+
+/**
+ * @returns the options object, or `undefined` when no host input applies — the
+ * signal to call `getToolsForAiSdk` with no options at all.
+ */
+export function mcpToolOptionsFor(
+  input: McpToolOptionsInput
+): McpToolOptions | undefined {
+  const options: McpToolOptions = {};
+  if (input.needsApproval) options.needsApproval = true;
+  if (input.includeAppOnly) options.includeAppOnly = true;
+  if (input.modelVisibleMcpToolResults !== undefined) {
+    options.modelVisibleMcpToolResults = input.modelVisibleMcpToolResults;
+  }
+  if (input.tasks !== undefined) options.tasks = input.tasks;
+  return Object.keys(options).length > 0 ? options : undefined;
+}

--- a/mcpjam-inspector/server/utils/mcpjam-stream-handler.ts
+++ b/mcpjam-inspector/server/utils/mcpjam-stream-handler.ts
@@ -24,7 +24,11 @@ import type {
 } from "ai";
 import type { ModelMessage } from "@ai-sdk/provider-utils";
 import { zodSchema } from "@ai-sdk/provider-utils";
-import type { MCPClientManager, Harness } from "@mcpjam/sdk";
+import type {
+  MCPClientManager,
+  Harness,
+  ToolTaskSeamOptions,
+} from "@mcpjam/sdk";
 import {
   describeAsSlug,
   describeError,
@@ -678,6 +682,28 @@ export interface MCPJamHandlerOptions {
    * UI/debug history.
    */
   modelVisibleMcpToolResults?: ModelVisibleMcpToolResults;
+  /**
+   * Host-level switch for SEP-1865 `_meta.ui.visibility` filtering — the same
+   * field `prepareChatV2` takes. `undefined`/`true` filter (spec default); only
+   * an explicit `false` opts out.
+   *
+   * Read ONLY by the HARNESS engine, which builds its own MCP tool set
+   * (`projectSelectedMcpServersAsHostTools`) instead of consuming the one
+   * `prepareChatV2` prepared. The emulated engine is handed `tools` already
+   * built, so it neither needs nor reads this.
+   */
+  respectToolVisibility?: boolean;
+  /**
+   * Resolved task-seam options, or absent for "tasks off". Same field and same
+   * rule as `PrepareChatV2Options.tasks`: the MODE is resolved by the CALLER
+   * (each surface is its own row in the policy matrix), never here.
+   *
+   * Read ONLY by the HARNESS engine, and for the same reason as
+   * `respectToolVisibility` — the emulated engine's seam already rode in
+   * through `prepareChatV2`. Absent keeps a harness turn on the pre-existing
+   * no-`_meta` path, byte-for-byte.
+   */
+  tasks?: ToolTaskSeamOptions;
   /**
    * Approval-pause policy. `"prompt"` (default) is the real-chat path:
    * approval-required tool calls pause the loop until the user answers

--- a/mcpjam-inspector/server/utils/web-chat-turn.ts
+++ b/mcpjam-inspector/server/utils/web-chat-turn.ts
@@ -1082,6 +1082,14 @@ export async function streamWebChatTurn(
       persist.requireToolApproval
     ),
     modelVisibleMcpToolResults: prepare.modelVisibleMcpToolResults,
+    // Harness engine only: it builds its own MCP tool set (host-executed
+    // delivery) rather than consuming `allTools`, so the host's
+    // tool-construction policies have to reach it separately. Inert on the
+    // emulated path, which is handed tools already built by prepareChatV2.
+    ...(prepare.respectToolVisibility !== undefined
+      ? { respectToolVisibility: prepare.respectToolVisibility }
+      : {}),
+    ...(prepare.tasks ? { tasks: prepare.tasks } : {}),
     ...(persist.harness ? { harness: persist.harness } : {}),
     // Presence is semantic (even an empty array): the harness turn then skips
     // the live project-wide skills fetch entirely.

--- a/mcpjam-inspector/shared/harness-mcp-delivery.ts
+++ b/mcpjam-inspector/shared/harness-mcp-delivery.ts
@@ -1,0 +1,65 @@
+/**
+ * HOW each harness gets the host's selected MCP servers to the model — the one
+ * declaration, shared by the server runtime registry and the client.
+ *
+ *  - `native`        — the runtime's own MCP client connects from inside the
+ *                      sandbox, to config MCPJam writes there (Claude Code's
+ *                      `.mcp.json`). MCPJam does not build those tools, so
+ *                      nothing MCPJam decides about how a tool is BUILT can
+ *                      reach them.
+ *  - `host-executed` — MCPJam enumerates each server's tools at turn start and
+ *                      runs them in-process, relaying invocations out of the
+ *                      sandbox (Codex, COMP-39). These tools come from the SAME
+ *                      `getToolsForAiSdk` projection the emulated engine uses,
+ *                      so host-level tool-construction knobs apply here exactly
+ *                      as they do on the emulated engine.
+ *
+ * ## Why this lives in `shared/` rather than in the registry
+ *
+ * The registry (`server/utils/harness/registry.ts`) is server-only — it imports
+ * the real `@ai-sdk/harness-*` adapters — so the client cannot read an adapter's
+ * `mcpDelivery` from it. But the client's Behavior-tab capability map
+ * (`client/src/lib/harness-capabilities.ts`) has to answer "does this knob bite
+ * on this harness?", and for every knob that acts at tool-CONSTRUCTION time the
+ * honest answer is a function of delivery mode, not of the harness's name.
+ *
+ * Hand-declaring that answer per harness is exactly the promise that goes stale:
+ * it did, the day Codex started reading `respectToolVisibility`. So the delivery
+ * mode is declared HERE, once, and both sides derive:
+ *
+ *  - the registry's adapters set `mcpDelivery: HARNESS_MCP_DELIVERY[<id>]`
+ *    (the `as const` keeps the literal type, so the adapter union still
+ *    discriminates and `native` still requires `deliverMcpServers`);
+ *  - the client capability map keys its construction-time controls off
+ *    {@link harnessMcpDelivery}.
+ *
+ * Changing a harness's delivery mode is therefore a ONE-LINE change that moves
+ * the server behavior and the editor's promise about it together.
+ */
+import { HARNESS_IDS, type Harness } from "@mcpjam/sdk/host-config/internal";
+
+/** The two MCP-delivery arms. Every harness uses one; there is no "no MCP" arm. */
+export type HarnessMcpDelivery = "native" | "host-executed";
+
+/**
+ * Delivery mode per harness id.
+ *
+ * `satisfies Record<Harness, HarnessMcpDelivery>` makes a new SDK harness id
+ * without an entry a COMPILE error, the same way `HARNESS_ADAPTERS` does — and
+ * `as const` preserves each literal so the registry's discriminated union still
+ * narrows on it.
+ */
+export const HARNESS_MCP_DELIVERY = {
+  "claude-code": "native",
+  codex: "host-executed",
+} as const satisfies Record<Harness, HarnessMcpDelivery>;
+
+/** Delivery mode for `harness`. Callers holding a narrower union (the client's
+ *  `HostConfigHarnessV2`) index the map directly and keep the literal type. */
+export function harnessMcpDelivery(harness: Harness): HarnessMcpDelivery {
+  return HARNESS_MCP_DELIVERY[harness];
+}
+
+/** Every harness id that has a delivery declaration — the SDK's list, so the
+ *  parity test can iterate without re-listing the ids. */
+export const HARNESS_MCP_DELIVERY_IDS: readonly Harness[] = HARNESS_IDS;


### PR DESCRIPTION
## What this does

A Codex host can now use the host's selected MCP servers, the way a Claude Code host can.

The adapter capability `supportsSelectedMcpServers: boolean` is replaced by a **delivery mode**:

```ts
type HarnessRuntimeAdapter = Base & (
  | { mcpDelivery: "native";        deliverMcpServers(args): Promise<void> }  // required
  | { mcpDelivery: "host-executed"; deliverMcpServers?: never }               // forbidden
);
```

Claude Code is `native`; Codex is `host-executed`. The union is what enforces the "the model never sees a tool twice" invariant — it is no longer a comment, and "this harness can't do MCP at all" is no longer a representable state.

## Mechanism, and why native `mcp_servers` was rejected

`codex exec --experimental-json` — the only mode `@openai/codex-sdk` drives — **never registers an MCP tool as model-callable**. The handshake completes, `tools/list` answers, and the model still cannot call anything (openai/codex#19425).

Two pieces of evidence, neither of which depends on the state of an external tracker:

- **The COMP-39 spike** (`mcpjam/comp-39-codex-mcp-spike`, `server/utils/harness/docs/codex-mcp-spike.md`) answered the literal question — writing `~/.codex/config.toml` `[mcp_servers]` **merges** with the bridge's programmatic `-c mcp_servers.*` flags, in both the host-tools-present and host-tools-absent cases. It is mechanically safe *and* a silent no-op: the file lands, the handshake succeeds, the model still can't call the tools. Flipping the capability on that basis would have lifted the pre-flight gate and let users attach servers that look connected and do nothing — strictly worse than blocking.
- **The installed harness's own code.** `@ai-sdk/harness-codex`'s `src/bridge/cli-relay.ts` opens with exactly this explanation, and exists *because the harness authors hit the same wall for their own host tools*. If `mcp_servers` worked in exec mode, that file would not exist. Still true in the latest `@ai-sdk/harness-codex@1.0.88`.

So this PR does **not** write `config.toml` and does **not** pass `mcpServers` to the bridge. It uses the mechanism the bridge already supports and MCPJam already uses for `web_search`: **host-executed AI SDK tools** passed as the agent's `tools`. The bridge writes a CLI shim, injects tool descriptions into the prompt, and relays invocations back over HTTP (`dist/bridge/index.mjs:522-557`, `598-599`).

No package versions were bumped. `registry.ts` carries hand-written string-patch monkeypatches of the Claude Code bridge that break on drift; a bump was neither needed nor wanted.

## Implementation

New module `server/utils/harness/host-executed-mcp-tools.ts`:

1. **Reuses the existing projection.** `MCPClientManager.getToolsForAiSdk` — the same converter the emulated engine runs on (schemas, result shaping, SEP-1865 app-only filtering, `_serverId` tagging). No second converter. Called **once per server id**, not with the multi-id form, because that form flattens last-in-wins and would both lose server attribution and silently drop a tool name two selected servers share.
2. **Names match Claude Code exactly** — `mcp__<sanitizedServer>__<tool>`, from the *same* `assignServerKeys`/`harnessServerKeyToName` helpers that produce `.mcp.json` keys, so the two modes cannot drift into different names. A test asserts the projected name is byte-identical to the key `buildHarnessProxyMcpJson` produces for the same server id.
3. **Codex gets a real `parseToolName`** — `parseHarnessToolName`, the same function Claude Code uses (it was a pass-through before). A relayed call attributes back to its `serverId`; Codex's own natives arrive as common names (`bash`, `read`) with no prefix and pass through unchanged.
4. **Execution goes direct, not through the signed proxy.** See below.
5. **Gate flipped.** The `mcp-servers` refusal kind and the `run-harness-turn` throw are **deleted**, not disabled — with a 2-arm union no adapter can lack MCP delivery, so both were genuinely dead. The `advertises MCP but has no deliverMcpServers` throw is deleted too: `tsc` reports its body as `never`, because the native arm now *requires* the hook.

## Direct execution vs. the harness MCP proxy — decision

**Direct, through the already-constructed authorized `MCPClientManager`.**

The signed proxy (`routes/web/harness-mcp.ts` / the adapter-http tunnel) exists so code **inside the sandbox** can reach a server it holds no credentials for. A host-executed tool does not run in the sandbox — it runs in this process, where the authorized connection already lives. Routing it back out through the proxy would be an HTTP hop from the server to itself, and would require minting a token for that hop.

**Security upside:** on this path *no proxy token and no server URL ever enters the sandbox at all*. Claude Code has to put a `?k=` tunnel secret and an `X-MCPJam-Proxy-Token` in `.mcp.json`; Codex's sandbox holds nothing but a CLI shim pointed at `127.0.0.1`.

The one thing the proxy did that could not be lost is **out-of-process `toolPolicy` enforcement** (the sealed token). That moves in-process: the projected tool's `execute` is wrapped with the same `decideToolPolicyFromSnapshot`, and a denied call returns the *same* block envelope the proxy answers with (`_meta["mcpjam/policyBlock"]` + the `Call blocked by tool policy: ` text), so `readHarnessPolicyBlockFromResult` recognises it through either detector and the call still accounts as `notMeasured` + `blockedByPolicy`, never as a failure of the customer's tool. `unknownAtLaunch` is enforced too.

## Fidelity caveat — please read before benchmarking a connector with this

**This is not equivalent to Claude Code's MCP support.**

- The model does **not** call MCP tools through native function calling. The bridge injects each tool's name, description, and input schema into the **prompt**, and the model shells out via `bash node <shim> <toolName> '<json>'`. **Tool-selection behavior therefore differs from a native MCP client** — you are partly measuring the model's ability to follow shim instructions.
- Tools execute **host-side**, in MCPJam's server process, not in the sandbox. For a **remote HTTP connector** the difference is small (the same outbound request, from a different origin). For a **stdio/local server** it is larger: the server runs where MCPJam runs, not next to the agent.
- **No `tools/list_changed`.** Schemas are enumerated once, at turn start; a server that changes its tool list mid-turn is only picked up next turn. Stated in code comments and in the docs page.
- **Prompt cost.** Every projected tool's description is part of the prompt, so a server with many tools inflates every turn of the conversation. There is no existing tool-count or budget guard in this path to respect, and I did not invent a cap — silently hiding a user's own servers would be worse than the cost. Flagging the exposure here instead.

## Approval — advertise = enforce

Codex has `supportsHostExecutedToolApproval: false`, and MCP tools now *are* host-executed tools on Codex. Two changes keep approval honest:

- The pre-flight's MCP-tool approval gate now reads the capability for the surface the tools actually run on (`supportsMcpToolApproval` under native, `supportsHostExecutedToolApproval` under host-executed). Reading the wrong one would have been the silent bypass.
- `runHarnessTurn` gained a fail-closed backstop for the same combination, because eval/synthetic/unified paths skip the route pre-flight.

A Codex host with `requireToolApproval` and selected servers is still refused, exactly as before.

## Refusals and tests removed

| Removed | Why it is dead |
|---|---|
| `HarnessUnavailableKind` member `"mcp-servers"` + its refusal in `harness-availability.ts` | No adapter can lack MCP delivery. Not referenced anywhere else (`isModelKind` in eval admission only branches on the two model kinds). |
| `run-harness-turn.ts` "doesn't support MCP servers yet" throw | Same. Replaced by the approval backstop above. |
| `run-harness-turn.ts` "advertises MCP support but has no deliverMcpServers" throw | The native arm requires the hook; `tsc` types the old check's body as `never`. |
| test: `harness-availability` "blocks a Codex host that has selected MCP servers" | Inverted — now asserts it is admitted, plus a new test that the approval combination is still refused. |
| test: `harness-admission` "refuses a harness that cannot deliver the suite's MCP servers" | Inverted — an eval suite always has servers, so this rule meant Codex could never run *any* suite. |
| test: `harness-admission` "counts PLUGIN-contributed servers toward the MCP gate" | Rewritten against the surviving rule that still keys off `hasSelectedMcpServers` (MCP-tool approval), with a control case, so the property it guarded is still asserted. |
| test: `registry` "Codex passes mcp__ names through" | Superseded by a cross-harness attribution-parity block. |

## Tests

New `server/utils/harness/__tests__/host-executed-mcp-tools.test.ts` (11 tests) + a parity block in `registry.test.ts`. These fail against `main`:

- a Codex host with selected servers is no longer refused (pre-flight **and** eval admission);
- projected names are byte-identical to Claude Code's namespacing for the same server id;
- `parseToolName` round-trips a relayed call to the right `serverId`, through the Codex **adapter**, for every registered harness;
- Claude Code's `.mcp.json` path is unchanged and its `hostExecutedTools` get no MCP tools (`mcpDelivery === "native"` ⇒ the projection branch never runs);
- per-server enumeration keeps same-named tools from two servers distinct; sanitized-key collisions de-duplicate;
- with no policy the manager's own tool object is passed through by identity (one execution path);
- `toolPolicy` blocks `denyList` and `unknownAtLaunch` in-process, with the proxy's exact envelope, and lets allowed tools through.

**Honest results**

- `vitest run --project server` — **453 files / 7028 tests, all pass.**
- `client/src/components/hosts/redesigned/focus/__tests__/BehaviorTab.harness.test.tsx` — 4/4 pass.
- `tsc --noEmit -p client/tsconfig.typecheck.json` — clean.
- `npm run build:inspector` — clean.

**Pre-existing issues I did not cause and did not fix:**

- A repo-wide `tsc -p mcpjam-inspector/tsconfig.json` reports ~6000 errors on `main` (it pulls in every test file and a stale `@mcpjam/sdk` dist). CI does not run that config; it runs `typecheck:client` + `build:inspector`, both of which are clean here.
- In a fresh worktree, several test files fail to *load* until the gitignored generated bundles are copied from the main checkout (`HarnessPageBundle.generated.ts`, `SandboxProxyHtml.bundled.ts`, `McpAppsOpenAICompatibleRuntime.bundled.ts`, `PluginShim.bundled.ts`). Environment, not code — after copying them the suite is fully green.
- `utils/computers/__tests__/local-machine.test.ts` flaked once on a tmpdir `ENOTEMPTY` cleanup and passed on re-run.

## Known residual (conservative, fails closed)

`harnessToolPolicyLaunchRefusal` still refuses *any* policied harness run when the deployment cannot seal a proxy token — including Codex, which no longer uses the seal at all. It takes `harness: boolean`, not a harness id, so making it delivery-aware is a separate change. Left as-is because it errs toward refusing, never toward running unenforced.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Dt9Hqa8Hn7KSqCrK79aLUr

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes harness MCP execution, eval admission, and in-process tool policy/OAuth step-up paths with broad test coverage, but mistakes could mis-attribute tool calls or apply wrong visibility/policy on Codex turns.
> 
> **Overview**
> Codex harness hosts can now use **selected MCP servers** by projecting each server’s tools at turn start as **host-executed** AI SDK tools (`mcp__<server>__<tool>`), relayed out of the sandbox and executed **in-process** on MCPJam’s authorized `MCPClientManager`—because Codex exec mode never makes MCP tools model-callable via native config.
> 
> Harness adapters switch from `supportsSelectedMcpServers` to **`mcpDelivery: "native" | "host-executed"`** (mutually exclusive with `deliverMcpServers` only on native). The old **`mcp-servers` pre-flight/eval refusal** for Codex is removed; **require tool approval** combinations that cannot pause MCP tools are still refused via a shared **`harnessToolApprovalRefusalReason`** (chat pre-flight and in-turn backstop).
> 
> The relay returns each tool’s **model-facing projection** (`toModelOutput`) while preserving **raw results** for UI/trace, and builds tools under the **host’s** `modelVisibleMcpToolResults`, **respect tool visibility** / `includeAppOnly`, and **MCP Tasks** seam through shared **`mcpToolOptionsFor`** (chat, eval runners, and projection). Hosted evals forward those policies into **`runHarnessTurn`** so harness turns don’t silently use SDK defaults.
> 
> **In-process `toolPolicy`** and **OAuth scope step-up** work on this path (policy seal exemption for host-executed; challenges correlate by **`toolCallId`** when available). The host Behavior tab **enables respect tool visibility for Codex** by deriving control state from the shared delivery declaration; docs add a **Codex MCP fidelity caveat**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 53534df305be5ea8ec2324fac402b596245d8e2d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Codex delivers the host’s selected MCP servers as host‑executed tools and applies the host’s visibility, tasks, approval, and policy gates end to end. Previously Codex refused runs with selected servers; now it projects server tools to the model, enforces policy in‑process, correlates OAuth scope step‑ups by toolCallId, and keeps default turns byte‑identical when no options are set. Connects to COMP-39.

- Introduces `mcpDelivery: "native" | "host-executed"` (Codex is `host-executed`; Claude Code stays `native`). Only the `native` arm may define `deliverMcpServers`, preventing double exposure. The client derives tool‑visibility enforcement from this shared declaration (`shared/harness-mcp-delivery.ts`), so the Codex “Respect tool visibility” switch is enabled.
- Projects each selected server’s tools once per turn via the manager and names them `mcp__<server>__<tool>`; `parseToolName` parity is preserved for attribution. Executes tools in‑process and enforces tool policy in‑process, returning the same block envelope the proxy would. Wraps host‑executed tools to return the manager’s `toModelOutput` to the model while the UI/trace use the raw result.
- Builds host‑executed tools under the host’s options across chat and hosted evals: threads `modelVisibleMcpToolResults`, `respectToolVisibility` (controls `includeAppOnly`), and `tasks`, via a shared builder (`mcpToolOptionsFor`). Approval remains in `HarnessAgent`; pre‑flight and in‑turn backstop share `harnessToolApprovalRefusalReason`.
- Carries OAuth scope step‑up for host‑executed calls: observes and publishes challenges; correlates by `toolCallId` (fallback to server/tool/input), and waits on id misses to avoid mismatches.
- Makes policy‑seal checks delivery‑aware: `native` still requires a proxy seal; `host‑executed` is exempt because policy is enforced in‑process. Removes the `mcp-servers` refusal and unifies approval on the actual surface. Docs now state Codex supports selected MCP servers via a host‑executed relay.

**Migration**
- Adapters must adopt `mcpDelivery`; keep `deliverMcpServers` only on the `native` arm; delete `supportsSelectedMcpServers`.
- If you parse tool names, ensure your parser handles `mcp__<server>__<tool>`.
- Update gates/tests that referenced the `mcp-servers` refusal to use `harnessToolApprovalRefusalReason`.

<sup>Written for commit 53534df305be5ea8ec2324fac402b596245d8e2d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/MCPJam/inspector/pull/4339?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

