### PR TITLE
Evals v2 — E4a: `eval gate --baseline <runId>` regression-delta gate

### DIFF
--- a/.changeset/eval-gate-baseline-run-id.md
+++ b/.changeset/eval-gate-baseline-run-id.md
@@ -28,15 +28,23 @@ path. `eval gate`'s four-code contract is unchanged.
 
 The report (`--reporter`/`--out`) carries baseline provenance — both run
 ids, the resolved baseline policy, every compatibility signal that was
-evaluated, and the comparable case ids the verdict actually covers. A case
-can survive `caseSetChanged` (it exists on both sides) and still be
-individually responsible for a config change or unequal iteration
-weighting, so each excluded case is named with its own reason
-(`case_added`, `case_removed`, `scenario_config_changed`,
-`evaluation_config_changed`, `iteration_weighting_unequal`) rather than
-being silently counted as comparable. Dimensions the comparison wire does
-not carry yet (model/provider, host/harness, server/environment identity,
-config hashes beyond the evaluation config hash) are recorded explicitly as
+evaluated, and the comparable case ids the verdict actually covers. The
+policy is recorded with its defaults already resolved (e.g. the
+`--min-sample-size`/`--min-effect-size-percent` values the pass-rate
+regression gate actually ran with, not just whatever was or wasn't passed
+on the command line) — `null` when the corresponding gate wasn't
+requested at all, distinct from a threshold of zero — so an archived
+report is self-describing without cross-referencing the CLI invocation
+that produced it. A case can survive `caseSetChanged` (it exists on both
+sides) and still be individually responsible for a config change or
+unequal iteration weighting — including a run-level evaluation config
+change that the platform didn't also flag on that case's own row — so
+each excluded case is named with its own reason (`case_added`,
+`case_removed`, `scenario_config_changed`, `evaluation_config_changed`,
+`iteration_weighting_unequal`) rather than being silently counted as
+comparable. Dimensions the comparison wire does not carry yet
+(model/provider, host/harness, server/environment identity, config hashes
+beyond the evaluation config hash) are recorded explicitly as
 `"notRecorded"` rather than omitted.
 
 SHA baselines are not supported yet — a 40-hex `--baseline` argument is

--- a/.changeset/eval-gate-baseline-run-id.md
+++ b/.changeset/eval-gate-baseline-run-id.md
@@ -1,0 +1,33 @@
+---
+"@mcpjam/cli": minor
+---
+
+`eval gate` gains `--baseline <runId>`: gate a run against a regression delta
+from an earlier one, not just an absolute threshold.
+
+Passing `--baseline` fetches the same run comparison `eval compare` uses,
+evaluates it with the existing comparative gate engine, and folds the result
+into the run's threshold `GateReport` with the established outcome precedence
+(`usage_error > failed > incomplete > passed`) — one report, one exit code,
+verdicts from both families visible. The comparative tuning flags
+`eval compare` already has (`--min-sample-size`,
+`--min-effect-size-percent`, `--gate-deterministic-regressions`,
+`--max-p95-latency-increase-ms`) work here too; `--baseline` itself implies
+regression gating, so none of them need a separate enabling flag, and passing
+one without `--baseline` is a usage error rather than a silent no-op.
+
+A changed, added, removed, or unequally-weighted case set makes the
+comparison `non_gateable` (exit 3), never a silent pass and never
+misread as a regression (exit 1) — the same population rule `eval compare`
+already enforces. A missing baseline is the existing `BASELINE_NOT_FOUND` →
+incomplete → exit 3 path. `eval gate`'s four-code contract is unchanged.
+
+The report (`--reporter`/`--out`) carries baseline provenance — both run
+ids, the resolved baseline policy, and every compatibility signal that was
+evaluated. Dimensions the comparison wire does not carry yet (model/provider,
+host/harness, server/environment identity, config hashes beyond the
+evaluation config hash) are recorded explicitly as `"notRecorded"` rather
+than omitted.
+
+SHA baselines are not supported yet — a 40-hex `--baseline` argument is
+rejected with a usage error naming the follow-up; only run ids resolve today.

--- a/.changeset/eval-gate-baseline-run-id.md
+++ b/.changeset/eval-gate-baseline-run-id.md
@@ -28,10 +28,14 @@ path. `eval gate`'s four-code contract is unchanged.
 
 The report (`--reporter`/`--out`) carries baseline provenance — both run
 ids, the resolved baseline policy, every compatibility signal that was
-evaluated, and the comparable case ids the verdict actually covers (plus
-the added/removed ones behind a `caseSetChanged: true`, named rather than
-left for the reader to re-derive). Dimensions the comparison wire does not
-carry yet (model/provider, host/harness, server/environment identity,
+evaluated, and the comparable case ids the verdict actually covers. A case
+can survive `caseSetChanged` (it exists on both sides) and still be
+individually responsible for a config change or unequal iteration
+weighting, so each excluded case is named with its own reason
+(`case_added`, `case_removed`, `scenario_config_changed`,
+`evaluation_config_changed`, `iteration_weighting_unequal`) rather than
+being silently counted as comparable. Dimensions the comparison wire does
+not carry yet (model/provider, host/harness, server/environment identity,
 config hashes beyond the evaluation config hash) are recorded explicitly as
 `"notRecorded"` rather than omitted.
 

--- a/.changeset/eval-gate-baseline-run-id.md
+++ b/.changeset/eval-gate-baseline-run-id.md
@@ -37,3 +37,8 @@ config hashes beyond the evaluation config hash) are recorded explicitly as
 
 SHA baselines are not supported yet — a 40-hex `--baseline` argument is
 rejected with a usage error naming the follow-up; only run ids resolve today.
+A blank `--baseline` (e.g. an unset CI variable interpolated into the flag)
+and a `--baseline` equal to `--run` are both usage errors too, rather than
+silently disabling the comparison or comparing a run against itself and
+reporting a clean "no regression" that never consulted an independent
+baseline.

--- a/.changeset/eval-gate-baseline-run-id.md
+++ b/.changeset/eval-gate-baseline-run-id.md
@@ -41,4 +41,7 @@ A blank `--baseline` (e.g. an unset CI variable interpolated into the flag)
 and a `--baseline` equal to `--run` are both usage errors too, rather than
 silently disabling the comparison or comparing a run against itself and
 reporting a clean "no regression" that never consulted an independent
-baseline.
+baseline. Validation checks the trimmed value, and the trimmed value is what
+travels to the request — a whitespace-padded but otherwise valid
+`--baseline` cannot slip past validation and then fail to resolve on the
+wire.

--- a/.changeset/eval-gate-baseline-run-id.md
+++ b/.changeset/eval-gate-baseline-run-id.md
@@ -17,10 +17,14 @@ regression gating, so none of them need a separate enabling flag, and passing
 one without `--baseline` is a usage error rather than a silent no-op.
 
 A changed, added, removed, or unequally-weighted case set makes the
-comparison `non_gateable` (exit 3), never a silent pass and never
-misread as a regression (exit 1) — the same population rule `eval compare`
-already enforces. A missing baseline is the existing `BASELINE_NOT_FOUND` →
-incomplete → exit 3 path. `eval gate`'s four-code contract is unchanged.
+WHOLE-RUN pass-rate and p95-latency gates `non_gateable` (exit 3) rather than
+silently passing or misreading the population change as a regression — the
+same population rule `eval compare` already enforces. The deterministic
+per-case regression gate is exempt: it joins by case key, so it can still
+fail (exit 1) on a matching case even when the population around it changed,
+and a real failure there is never buried by an undecidable whole-run gate. A
+missing baseline is the existing `BASELINE_NOT_FOUND` → incomplete → exit 3
+path. `eval gate`'s four-code contract is unchanged.
 
 The report (`--reporter`/`--out`) carries baseline provenance — both run
 ids, the resolved baseline policy, and every compatibility signal that was

--- a/.changeset/eval-gate-baseline-run-id.md
+++ b/.changeset/eval-gate-baseline-run-id.md
@@ -27,11 +27,13 @@ missing baseline is the existing `BASELINE_NOT_FOUND` → incomplete → exit 3
 path. `eval gate`'s four-code contract is unchanged.
 
 The report (`--reporter`/`--out`) carries baseline provenance — both run
-ids, the resolved baseline policy, and every compatibility signal that was
-evaluated. Dimensions the comparison wire does not carry yet (model/provider,
-host/harness, server/environment identity, config hashes beyond the
-evaluation config hash) are recorded explicitly as `"notRecorded"` rather
-than omitted.
+ids, the resolved baseline policy, every compatibility signal that was
+evaluated, and the comparable case ids the verdict actually covers (plus
+the added/removed ones behind a `caseSetChanged: true`, named rather than
+left for the reader to re-derive). Dimensions the comparison wire does not
+carry yet (model/provider, host/harness, server/environment identity,
+config hashes beyond the evaluation config hash) are recorded explicitly as
+`"notRecorded"` rather than omitted.
 
 SHA baselines are not supported yet — a 40-hex `--baseline` argument is
 rejected with a usage error naming the follow-up; only run ids resolve today.

--- a/cli/src/commands/eval.ts
+++ b/cli/src/commands/eval.ts
@@ -1092,7 +1092,9 @@ async function runEvalGate(
   });
   // Parsed and validated BEFORE any network call, like `eval compare`'s own
   // policy: a malformed baseline flag exits 2 without spending a request.
-  if (options.baseline !== undefined) assertRunIdBaseline(options.baseline);
+  if (options.baseline !== undefined) {
+    assertRunIdBaseline(options.baseline, options.run);
+  }
   const comparePolicy = comparePolicyFromGateOptions(options);
   const waitTimeoutMs =
     options.waitTimeout !== undefined

--- a/cli/src/commands/eval.ts
+++ b/cli/src/commands/eval.ts
@@ -1232,9 +1232,17 @@ async function runEvalGate(
             }
           );
         }
-        if (iterationError) {
-          return {
-            report: {
+        // A failed LOCAL iteration fetch makes the run's own threshold report
+        // incomplete, but it says nothing about `/compare`: that endpoint
+        // returns its own summary independently, and (absent a latency gate)
+        // `evaluateBaselineComparison` never touches these iterations at all.
+        // So this is an incomplete THRESHOLD report, not an early return —
+        // `--baseline` still gets its chance below, and a real regression
+        // there must still merge to `failed` (exit 1) rather than being
+        // silently downgraded to `incomplete` (exit 3) by an unrelated fetch
+        // hiccup on the other half of the report.
+        const thresholdReport = iterationError
+          ? {
               outcome: "incomplete" as const,
               scoreIntegrity: "unknown" as const,
               verdicts: [
@@ -1244,19 +1252,19 @@ async function runEvalGate(
                   message: `could not read the run: ${iterationError}`,
                 },
               ],
-            },
-            run,
-            iterations: [],
-            iterationsComplete: false,
-            iterationError,
-          };
-        }
+            }
+          : reportForRun(
+              run,
+              policyNeedsIterations(policy) ? iterations : undefined,
+              policy
+            );
 
-        const thresholdReport = reportForRun(
-          run,
-          policyNeedsIterations(policy) ? iterations : undefined,
-          policy
-        );
+        // A failed fetch is never "complete", whether or not a report was
+        // requested — `!needsReport` is a default for the "nobody asked"
+        // case, not for "asked and it broke".
+        const iterationsComplete = iterationError
+          ? false
+          : iterations?.complete ?? !needsReport;
 
         // Baseline regression gating only makes sense once the run being
         // gated has a verdict of its own; every early return above already
@@ -1267,7 +1275,8 @@ async function runEvalGate(
             report: thresholdReport,
             run,
             iterations: iterations?.items ?? [],
-            iterationsComplete: iterations?.complete ?? !needsReport,
+            iterationsComplete,
+            ...(iterationError ? { iterationError } : {}),
           };
         }
 
@@ -1285,7 +1294,8 @@ async function runEvalGate(
           report: mergeGateReports(thresholdReport, baselineResult.report),
           run,
           iterations: iterations?.items ?? [],
-          iterationsComplete: iterations?.complete ?? !needsReport,
+          iterationsComplete,
+          ...(iterationError ? { iterationError } : {}),
           ...(baselineResult.provenance
             ? { baselineProvenance: baselineResult.provenance }
             : {}),

--- a/cli/src/commands/eval.ts
+++ b/cli/src/commands/eval.ts
@@ -58,7 +58,6 @@ import {
   buildEvalDecisionSummaryFromIterations,
   buildEvalRunReport,
   buildRunCompareReport,
-  calculateLatencyStats,
   detectFlakyCases,
   evaluateCompareGates,
   formatGateReport,
@@ -117,12 +116,17 @@ import {
   isNonVerdictRunStatus,
 } from "../lib/eval-gate-exit-code.js";
 import {
+  assertRunIdBaseline,
+  baselineNotFoundReason,
+  comparePolicyFromGateOptions,
+  evaluateBaselineComparison,
+  mergeGateReports,
   policyFromOptions,
   policyNeedsIterations,
   reportForRun,
   type EvalGateOptions,
 } from "../lib/eval-gate.js";
-import { fetchAllIterations } from "../lib/eval-iterations.js";
+import { fetchAllIterations, p95Of } from "../lib/eval-iterations.js";
 import {
   comparePolicyFromOptions,
   compareGateInputFrom,
@@ -1030,7 +1034,10 @@ function launchFailureCases(
   });
 }
 
-function gateReportCase(report: GateReport): StructuredCaseResult {
+function gateReportCase(
+  report: GateReport,
+  baselineProvenance?: Record<string, unknown>
+): StructuredCaseResult {
   const passed = report.outcome === "passed";
   return {
     id: "gate",
@@ -1045,7 +1052,13 @@ function gateReportCase(report: GateReport): StructuredCaseResult {
             .map((verdict) => verdict.message)
             .join("; "),
         }),
-    details: report,
+    // The baseline provenance rides along on the case row too, not only in
+    // the report's top-level metadata: `--reporter junit-xml` has no other
+    // place to carry it, and a regression visible in the exit code but
+    // absent from the artifact is a reporting bug.
+    details: baselineProvenance
+      ? { ...report, baseline: baselineProvenance }
+      : report,
   };
 }
 
@@ -1077,6 +1090,10 @@ async function runEvalGate(
     ...options,
     noGatingScoreErrors: options.gatingScoreErrors === false,
   });
+  // Parsed and validated BEFORE any network call, like `eval compare`'s own
+  // policy: a malformed baseline flag exits 2 without spending a request.
+  if (options.baseline !== undefined) assertRunIdBaseline(options.baseline);
+  const comparePolicy = comparePolicyFromGateOptions(options);
   const waitTimeoutMs =
     options.waitTimeout !== undefined
       ? parsePositiveInteger(options.waitTimeout, "--wait-timeout")
@@ -1092,6 +1109,7 @@ async function runEvalGate(
     iterations?: PlatformEvalIteration[];
     iterationsComplete?: boolean;
     iterationError?: string;
+    baselineProvenance?: Record<string, unknown>;
   };
   try {
     outcome = await runPlatformCommand(
@@ -1234,15 +1252,43 @@ async function runEvalGate(
           };
         }
 
-        return {
-          report: reportForRun(
+        const thresholdReport = reportForRun(
+          run,
+          policyNeedsIterations(policy) ? iterations : undefined,
+          policy
+        );
+
+        // Baseline regression gating only makes sense once the run being
+        // gated has a verdict of its own; every early return above already
+        // skipped this. `--baseline` is optional, so a threshold-only
+        // invocation never pays for a `/compare` fetch it did not ask for.
+        if (!options.baseline) {
+          return {
+            report: thresholdReport,
             run,
-            policyNeedsIterations(policy) ? iterations : undefined,
-            policy
-          ),
+            iterations: iterations?.items ?? [],
+            iterationsComplete: iterations?.complete ?? !needsReport,
+          };
+        }
+
+        const baselineResult = await evaluateBaselineComparison({
+          client,
+          signal,
+          projectId: project.id,
+          runId: options.run,
+          baseline: options.baseline,
+          policy: comparePolicy,
+          compareIterations: iterations,
+        });
+
+        return {
+          report: mergeGateReports(thresholdReport, baselineResult.report),
           run,
           iterations: iterations?.items ?? [],
           iterationsComplete: iterations?.complete ?? !needsReport,
+          ...(baselineResult.provenance
+            ? { baselineProvenance: baselineResult.provenance }
+            : {}),
         };
       }
     );
@@ -1297,8 +1343,11 @@ async function runEvalGate(
             ]
           : [],
         {
-          cases: [gateReportCase(outcome.report)],
+          cases: [gateReportCase(outcome.report, outcome.baselineProvenance)],
           ...(decisionSummary ? { decisionSummary } : {}),
+          ...(outcome.baselineProvenance
+            ? { metadata: { baselineComparison: outcome.baselineProvenance } }
+            : {}),
         }
       )
     : undefined;
@@ -1745,36 +1794,6 @@ const EMPTY_DIFF = {
   delta: null,
   percentDelta: null,
 };
-
-/** p95 over a COMPLETE iteration walk; `undefined` from a partial one. */
-function p95Of(
-  iterations: { items: PlatformEvalIteration[]; complete: boolean } | undefined
-): number | undefined {
-  if (!iterations?.complete) return undefined;
-  const durations = iterations.items
-    .map((iteration) => iteration.durationMs)
-    .filter((ms): ms is number => typeof ms === "number");
-  if (durations.length === 0 || durations.length !== iterations.items.length) {
-    // A single missing duration makes the p95 describe a different set than
-    // the run — absent beats approximate.
-    return undefined;
-  }
-  return calculateLatencyStats(durations).p95;
-}
-
-/**
- * The server says "no baseline" with a 404 carrying
- * `details.reason: "BASELINE_NOT_FOUND"`. Read the machine field, not the
- * prose.
- */
-function baselineNotFoundReason(error: unknown): boolean {
-  const details = (error as { details?: unknown })?.details;
-  return (
-    typeof details === "object" &&
-    details !== null &&
-    (details as { reason?: unknown }).reason === "BASELINE_NOT_FOUND"
-  );
-}
 
 async function writeCompareResult(
   args: {
@@ -2964,6 +2983,26 @@ export function registerEvalCommands(program: Command): void {
         "Minimum mean score for one scorer (repeatable)",
         collectRepeatable,
         [] as string[]
+      )
+      .option(
+        "--baseline <runId>",
+        "Baseline run ID to gate a regression delta against (SHA baselines are not supported yet)"
+      )
+      .option(
+        "--min-sample-size <n>",
+        "Iterations required on EACH side before a pass-rate regression is decidable (default 5); requires --baseline"
+      )
+      .option(
+        "--min-effect-size-percent <0-100>",
+        "Smallest pass-rate drop worth failing on, as a percentage (default 1); requires --baseline"
+      )
+      .option(
+        "--gate-deterministic-regressions",
+        "Fail if a deterministic gating scorer flipped from passed to failed; requires --baseline"
+      )
+      .option(
+        "--max-p95-latency-increase-ms <ms>",
+        "Fail if p95 end-to-end latency rose by more than this many milliseconds vs the baseline; requires --baseline"
       )
       .option("--wait", "Poll until the run reaches a terminal status")
       .option(

--- a/cli/src/commands/eval.ts
+++ b/cli/src/commands/eval.ts
@@ -1092,9 +1092,13 @@ async function runEvalGate(
   });
   // Parsed and validated BEFORE any network call, like `eval compare`'s own
   // policy: a malformed baseline flag exits 2 without spending a request.
-  if (options.baseline !== undefined) {
-    assertRunIdBaseline(options.baseline, options.run);
-  }
+  // The NORMALIZED value is what travels downstream — the raw one is never
+  // read again, so a whitespace-padded but otherwise valid `--baseline`
+  // cannot slip past validation and then fail to resolve on the wire.
+  const baseline =
+    options.baseline !== undefined
+      ? assertRunIdBaseline(options.baseline, options.run)
+      : undefined;
   const comparePolicy = comparePolicyFromGateOptions(options);
   const waitTimeoutMs =
     options.waitTimeout !== undefined
@@ -1272,7 +1276,7 @@ async function runEvalGate(
         // gated has a verdict of its own; every early return above already
         // skipped this. `--baseline` is optional, so a threshold-only
         // invocation never pays for a `/compare` fetch it did not ask for.
-        if (!options.baseline) {
+        if (!baseline) {
           return {
             report: thresholdReport,
             run,
@@ -1287,7 +1291,7 @@ async function runEvalGate(
           signal,
           projectId: project.id,
           runId: options.run,
-          baseline: options.baseline,
+          baseline,
           policy: comparePolicy,
           compareIterations: iterations,
         });

--- a/cli/src/lib/eval-gate.ts
+++ b/cli/src/lib/eval-gate.ts
@@ -170,7 +170,7 @@ export function reportForRun(
 const SHA_LIKE_BASELINE = /^[0-9a-f]{40}$/i;
 
 /**
- * Reject a blank or SHA-shaped `--baseline` argument.
+ * Reject a blank, self-referential, or SHA-shaped `--baseline` argument.
  *
  * Blank is rejected explicitly: every downstream check treats
  * `options.baseline` as "present" with `!== undefined` but "enabled" with
@@ -181,17 +181,32 @@ const SHA_LIKE_BASELINE = /^[0-9a-f]{40}$/i;
  * would silently skip the baseline comparison and exit 0 on the threshold
  * gates alone, having gated on nothing the caller asked for.
  *
+ * `--baseline` equal to `--run` is the same failure mode wearing a different
+ * shape: a run compared against itself has identical samples on both sides,
+ * so `assessPassRateRegression` reports `no_regression` and the deterministic
+ * gate finds nothing that flipped — not because nothing regressed, but
+ * because no independent baseline was ever consulted. A CI script that wires
+ * the same "latest run" variable into both `--run` and `--baseline` (a
+ * plausible copy-paste) would otherwise get a green regression gate that
+ * validated nothing.
+ *
  * Run ids on this platform are never 40 lowercase-hex characters, so the SHA
  * discriminator cannot false-positive on a real run id; it exists purely to
  * catch the one shape a user is likely to hand it by habit — a git commit
  * SHA — before it reaches the network as a doomed run lookup.
  */
-export function assertRunIdBaseline(baseline: string): void {
+export function assertRunIdBaseline(baseline: string, runId: string): void {
   const normalized = baseline.trim();
   if (normalized === "") {
     throw usageError(
       `--baseline must not be blank. Pass a run id, or omit the flag entirely ` +
         `to gate on absolute thresholds only.`
+    );
+  }
+  if (normalized === runId) {
+    throw usageError(
+      `--baseline "${baseline}" is the same as --run "${runId}". A run cannot ` +
+        `be its own baseline — pass a different, earlier run id.`
     );
   }
   // Tested against the TRIMMED value: a whitespace-padded SHA

--- a/cli/src/lib/eval-gate.ts
+++ b/cli/src/lib/eval-gate.ts
@@ -6,6 +6,8 @@
  */
 
 import {
+  DEFAULT_MIN_EFFECT_SIZE,
+  DEFAULT_MIN_SAMPLE_SIZE,
   evaluateCompareGates,
   evaluateGates,
   gateInputFromPlatformRun,
@@ -342,15 +344,25 @@ type IncompatibleCaseReason =
  * responsible for `scenarioConfigChanged`, `evaluationConfigChanged`, or
  * `iterationWeightingEqual: false`, and `comparableCaseIds` must not claim
  * a case the whole-run verdict did not actually trust.
+ *
+ * `runEvaluationConfigChanged` is `compare.scoreContract.evaluationConfigChanged`
+ * — a RUN-LEVEL fact, not a per-row one. `compareGateInputFrom` ORs it into
+ * the aggregate `evaluationConfigChanged` regardless of any single case's own
+ * flag, so a case whose own row never changed can still be the reason the
+ * whole-run gate is non-gateable; every case must inherit it, not just the
+ * ones whose own `row.evaluationConfigChanged` happens to be true.
  */
 function incompatibilityReasonsFor(
-  row: PlatformRunCompareCase
+  row: PlatformRunCompareCase,
+  runEvaluationConfigChanged: boolean
 ): IncompatibleCaseReason[] {
   const reasons: IncompatibleCaseReason[] = [];
   if (row.status === "new_case") reasons.push("case_added");
   if (row.status === "removed_case") reasons.push("case_removed");
   if (row.configChanged) reasons.push("scenario_config_changed");
-  if (row.evaluationConfigChanged) reasons.push("evaluation_config_changed");
+  if (row.evaluationConfigChanged || runEvaluationConfigChanged) {
+    reasons.push("evaluation_config_changed");
+  }
   // Mirrors `iterationWeightingEqualFrom`'s own skip condition: a case
   // absent on either side has no counterpart to weigh against, and is
   // already covered by `case_added`/`case_removed` above.
@@ -378,17 +390,39 @@ function incompatibilityReasonsFor(
 export function buildBaselineProvenance(
   requestedBaseline: string,
   compare: PlatformRunCompare,
-  input: CompareGateInput
+  input: CompareGateInput,
+  policy: GatePolicy
 ): Record<string, unknown> {
   const classified = compare.cases.map((row) => ({
     row,
-    reasons: incompatibilityReasonsFor(row),
+    reasons: incompatibilityReasonsFor(
+      row,
+      compare.scoreContract.evaluationConfigChanged
+    ),
   }));
   return {
     requestedBaseline,
     baseline: compare.baseline,
     baseRunId: compare.baseRun.id,
     compareRunId: compare.compareRun.id,
+    // The RESOLVED policy that produced this verdict, defaults filled in —
+    // an archived report must be self-describing without cross-referencing
+    // the CLI invocation that produced it. `null` means the gate was not
+    // asked for, not "asked for with a threshold of nothing".
+    policy: {
+      passRateRegression: policy.passRateRegression
+        ? {
+            minSampleSize:
+              policy.passRateRegression.minSampleSize ??
+              DEFAULT_MIN_SAMPLE_SIZE,
+            minEffectSize:
+              policy.passRateRegression.minEffectSize ??
+              DEFAULT_MIN_EFFECT_SIZE,
+          }
+        : null,
+      noDeterministicRegressions: policy.noDeterministicRegressions === true,
+      maximumP95LatencyIncreaseMs: policy.maximumP95LatencyIncreaseMs ?? null,
+    },
     compatibility: {
       caseSetChanged: input.caseSetChanged,
       scenarioConfigChanged: input.scenarioConfigChanged,
@@ -537,6 +571,11 @@ export async function evaluateBaselineComparison(input: {
 
   return {
     report: evaluateCompareGates(compareInput, input.policy),
-    provenance: buildBaselineProvenance(input.baseline, compare, compareInput),
+    provenance: buildBaselineProvenance(
+      input.baseline,
+      compare,
+      compareInput,
+      input.policy
+    ),
   };
 }

--- a/cli/src/lib/eval-gate.ts
+++ b/cli/src/lib/eval-gate.ts
@@ -187,13 +187,17 @@ const SHA_LIKE_BASELINE = /^[0-9a-f]{40}$/i;
  * SHA — before it reaches the network as a doomed run lookup.
  */
 export function assertRunIdBaseline(baseline: string): void {
-  if (baseline.trim() === "") {
+  const normalized = baseline.trim();
+  if (normalized === "") {
     throw usageError(
       `--baseline must not be blank. Pass a run id, or omit the flag entirely ` +
         `to gate on absolute thresholds only.`
     );
   }
-  if (SHA_LIKE_BASELINE.test(baseline)) {
+  // Tested against the TRIMMED value: a whitespace-padded SHA
+  // (`--baseline " <40-hex> "`) is still a doomed run lookup, and the blank
+  // check above already proved trimming doesn't change what the flag means.
+  if (SHA_LIKE_BASELINE.test(normalized)) {
     throw usageError(
       `--baseline "${baseline}" looks like a git SHA. SHA baselines are not ` +
         `supported yet; pass a run id. (Source-SHA baseline resolution is a ` +

--- a/cli/src/lib/eval-gate.ts
+++ b/cli/src/lib/eval-gate.ts
@@ -170,7 +170,12 @@ export function reportForRun(
 const SHA_LIKE_BASELINE = /^[0-9a-f]{40}$/i;
 
 /**
- * Reject a blank, self-referential, or SHA-shaped `--baseline` argument.
+ * Validate `--baseline` and return the NORMALIZED (trimmed) value to use for
+ * everything downstream — the network request included. Validating the
+ * trimmed value while forwarding the raw one would let a whitespace-padded
+ * argument (`--baseline " run-baseline "`) slip past every check here and
+ * then fail to resolve on the wire, reporting `incomplete` (exit 3) instead
+ * of either working or naming the usage error.
  *
  * Blank is rejected explicitly: every downstream check treats
  * `options.baseline` as "present" with `!== undefined` but "enabled" with
@@ -195,7 +200,7 @@ const SHA_LIKE_BASELINE = /^[0-9a-f]{40}$/i;
  * catch the one shape a user is likely to hand it by habit — a git commit
  * SHA — before it reaches the network as a doomed run lookup.
  */
-export function assertRunIdBaseline(baseline: string, runId: string): void {
+export function assertRunIdBaseline(baseline: string, runId: string): string {
   const normalized = baseline.trim();
   if (normalized === "") {
     throw usageError(
@@ -219,6 +224,7 @@ export function assertRunIdBaseline(baseline: string, runId: string): void {
         `follow-up step, gated on a backend index that does not exist yet.)`
     );
   }
+  return normalized;
 }
 
 /**

--- a/cli/src/lib/eval-gate.ts
+++ b/cli/src/lib/eval-gate.ts
@@ -333,6 +333,19 @@ export function buildBaselineProvenance(
       iterationWeightingEqual: input.iterationWeightingEqual,
       baseScoreIntegrity: compare.scoreContract.base.scoreIntegrity,
       compareScoreIntegrity: compare.scoreContract.compare.scoreIntegrity,
+      // The pin names "comparable case ids" explicitly: which cases an
+      // archived report's verdict actually covers, and which ones a
+      // `caseSetChanged: true` flag alone does not name.
+      comparableCaseIds: compare.cases
+        .filter(
+          (row) => row.status !== "new_case" && row.status !== "removed_case"
+        )
+        .map((row) => row.caseKey),
+      incompatibleCases: compare.cases
+        .filter(
+          (row) => row.status === "new_case" || row.status === "removed_case"
+        )
+        .map((row) => ({ caseKey: row.caseKey, status: row.status })),
     },
     // Dimensions the pinned contract requires but the `/compare` wire does
     // not carry today (E4b / backend follow-up work). Never invented, never

--- a/cli/src/lib/eval-gate.ts
+++ b/cli/src/lib/eval-gate.ts
@@ -19,6 +19,7 @@ import type {
   PlatformEvalIteration,
   PlatformEvalRun,
   PlatformRunCompare,
+  PlatformRunCompareCase,
 } from "@mcpjam/sdk/platform";
 import {
   comparePolicyFromOptions,
@@ -326,6 +327,43 @@ export function mergeGateReports(
   };
 }
 
+/** Why one case does not belong to the comparable population. */
+type IncompatibleCaseReason =
+  | "case_added"
+  | "case_removed"
+  | "scenario_config_changed"
+  | "evaluation_config_changed"
+  | "iteration_weighting_unequal";
+
+/**
+ * Every reason ONE case is excluded from the comparable population, using
+ * the SAME predicates `compareGateInputFrom` aggregates into the whole-run
+ * booleans — a case can be case-set-stable and STILL be individually
+ * responsible for `scenarioConfigChanged`, `evaluationConfigChanged`, or
+ * `iterationWeightingEqual: false`, and `comparableCaseIds` must not claim
+ * a case the whole-run verdict did not actually trust.
+ */
+function incompatibilityReasonsFor(
+  row: PlatformRunCompareCase
+): IncompatibleCaseReason[] {
+  const reasons: IncompatibleCaseReason[] = [];
+  if (row.status === "new_case") reasons.push("case_added");
+  if (row.status === "removed_case") reasons.push("case_removed");
+  if (row.configChanged) reasons.push("scenario_config_changed");
+  if (row.evaluationConfigChanged) reasons.push("evaluation_config_changed");
+  // Mirrors `iterationWeightingEqualFrom`'s own skip condition: a case
+  // absent on either side has no counterpart to weigh against, and is
+  // already covered by `case_added`/`case_removed` above.
+  if (
+    row.base.outcome !== "absent" &&
+    row.compare.outcome !== "absent" &&
+    row.base.iterationIds.length !== row.compare.iterationIds.length
+  ) {
+    reasons.push("iteration_weighting_unequal");
+  }
+  return reasons;
+}
+
 /**
  * Baseline-compatibility provenance for the gate report.
  *
@@ -342,6 +380,10 @@ export function buildBaselineProvenance(
   compare: PlatformRunCompare,
   input: CompareGateInput
 ): Record<string, unknown> {
+  const classified = compare.cases.map((row) => ({
+    row,
+    reasons: incompatibilityReasonsFor(row),
+  }));
   return {
     requestedBaseline,
     baseline: compare.baseline,
@@ -357,16 +399,16 @@ export function buildBaselineProvenance(
       // The pin names "comparable case ids" explicitly: which cases an
       // archived report's verdict actually covers, and which ones a
       // `caseSetChanged: true` flag alone does not name.
-      comparableCaseIds: compare.cases
-        .filter(
-          (row) => row.status !== "new_case" && row.status !== "removed_case"
-        )
-        .map((row) => row.caseKey),
-      incompatibleCases: compare.cases
-        .filter(
-          (row) => row.status === "new_case" || row.status === "removed_case"
-        )
-        .map((row) => ({ caseKey: row.caseKey, status: row.status })),
+      comparableCaseIds: classified
+        .filter(({ reasons }) => reasons.length === 0)
+        .map(({ row }) => row.caseKey),
+      incompatibleCases: classified
+        .filter(({ reasons }) => reasons.length > 0)
+        .map(({ row, reasons }) => ({
+          caseKey: row.caseKey,
+          status: row.status,
+          reasons,
+        })),
     },
     // Dimensions the pinned contract requires but the `/compare` wire does
     // not carry today (E4b / backend follow-up work). Never invented, never

--- a/cli/src/lib/eval-gate.ts
+++ b/cli/src/lib/eval-gate.ts
@@ -170,14 +170,29 @@ export function reportForRun(
 const SHA_LIKE_BASELINE = /^[0-9a-f]{40}$/i;
 
 /**
- * Reject a SHA-shaped `--baseline` argument.
+ * Reject a blank or SHA-shaped `--baseline` argument.
  *
- * Run ids on this platform are never 40 lowercase-hex characters, so this
+ * Blank is rejected explicitly: every downstream check treats
+ * `options.baseline` as "present" with `!== undefined` but "enabled" with
+ * `Boolean(options.baseline)` (see {@link comparePolicyFromGateOptions} and
+ * `runEvalGate`'s `if (!options.baseline)`). A CI invocation that interpolates
+ * an unset variable — `--baseline "$BASELINE_RUN_ID"` — hands Commander an
+ * empty string, which is `!== undefined` but falsy: unchecked, the command
+ * would silently skip the baseline comparison and exit 0 on the threshold
+ * gates alone, having gated on nothing the caller asked for.
+ *
+ * Run ids on this platform are never 40 lowercase-hex characters, so the SHA
  * discriminator cannot false-positive on a real run id; it exists purely to
  * catch the one shape a user is likely to hand it by habit — a git commit
  * SHA — before it reaches the network as a doomed run lookup.
  */
 export function assertRunIdBaseline(baseline: string): void {
+  if (baseline.trim() === "") {
+    throw usageError(
+      `--baseline must not be blank. Pass a run id, or omit the flag entirely ` +
+        `to gate on absolute thresholds only.`
+    );
+  }
   if (SHA_LIKE_BASELINE.test(baseline)) {
     throw usageError(
       `--baseline "${baseline}" looks like a git SHA. SHA baselines are not ` +

--- a/cli/src/lib/eval-gate.ts
+++ b/cli/src/lib/eval-gate.ts
@@ -6,16 +6,29 @@
  */
 
 import {
+  evaluateCompareGates,
   evaluateGates,
   gateInputFromPlatformRun,
   passRateFractionFromPercent,
+  type CompareGateInput,
   type GatePolicy,
   type GateReport,
 } from "@mcpjam/sdk";
 import type {
+  PlatformApiClient,
   PlatformEvalIteration,
   PlatformEvalRun,
+  PlatformRunCompare,
 } from "@mcpjam/sdk/platform";
+import {
+  comparePolicyFromOptions,
+  compareGateInputFrom,
+} from "./eval-compare.js";
+import {
+  fetchAllIterations,
+  p95Of,
+  type FetchedIterations,
+} from "./eval-iterations.js";
 import { usageError } from "./output.js";
 
 export type EvalGateOptions = {
@@ -26,6 +39,18 @@ export type EvalGateOptions = {
   minScorerPassRate?: string[];
   /** Repeatable `<scorerId>=<0..1>`. */
   minMeanScore?: string[];
+  /**
+   * Baseline RUN ID to gate a regression delta against. A SHA is rejected —
+   * see {@link assertRunIdBaseline} — because source-SHA resolution needs a
+   * backend index this step does not build.
+   */
+  baseline?: string;
+  /** Same tuning flags `eval compare` exposes; require `--baseline`. */
+  minSampleSize?: string;
+  /** PERCENT at the boundary (0–100), converted to a fraction immediately. */
+  minEffectSizePercent?: string;
+  gateDeterministicRegressions?: boolean;
+  maxP95LatencyIncreaseMs?: string;
 };
 
 function parsePercent(raw: string, flag: string): number {
@@ -132,4 +157,291 @@ export function reportForRun(
   policy: GatePolicy
 ): GateReport {
   return evaluateGates(gateInputFromPlatformRun(run, iterations), policy);
+}
+
+// ─────────────────────────────────────────────── --baseline (runId half) ──
+//
+// PRD §18.4: `eval gate` keeps its four-code contract and GAINS `--baseline`.
+// SHA resolution is a separate follow-up step gated on a backend index that
+// does not exist yet, so a SHA-shaped argument is rejected here rather than
+// silently mistreated as a run id.
+
+/** A 40-hex git SHA-1, the shape `--baseline` must reject in this step. */
+const SHA_LIKE_BASELINE = /^[0-9a-f]{40}$/i;
+
+/**
+ * Reject a SHA-shaped `--baseline` argument.
+ *
+ * Run ids on this platform are never 40 lowercase-hex characters, so this
+ * discriminator cannot false-positive on a real run id; it exists purely to
+ * catch the one shape a user is likely to hand it by habit — a git commit
+ * SHA — before it reaches the network as a doomed run lookup.
+ */
+export function assertRunIdBaseline(baseline: string): void {
+  if (SHA_LIKE_BASELINE.test(baseline)) {
+    throw usageError(
+      `--baseline "${baseline}" looks like a git SHA. SHA baselines are not ` +
+        `supported yet; pass a run id. (Source-SHA baseline resolution is a ` +
+        `follow-up step, gated on a backend index that does not exist yet.)`
+    );
+  }
+}
+
+/**
+ * Build the comparative half of the gate policy from `eval gate`'s flags.
+ *
+ * `eval gate` has no `--gate-regressions` flag: `--baseline` itself implies
+ * regression gating, so passing one enables the pass-rate regression gate
+ * even with no tuning flags (the SDK's defaults then apply). Reuses
+ * `comparePolicyFromOptions` — the ONE place the percent→fraction boundary is
+ * crossed — rather than re-parsing; the pre-check below only replaces ITS
+ * usage-error message, which names a `--gate-regressions` flag this command
+ * does not have.
+ *
+ * Every comparative flag requires `--baseline`, not only the pass-rate tuning
+ * pair: without a baseline there is no compare fetch at all, so a
+ * `--gate-deterministic-regressions` or `--max-p95-latency-increase-ms` with
+ * no `--baseline` would otherwise be silently ignored — the exact failure
+ * mode `evaluateGates` already refuses for the single-run comparative fields.
+ */
+export function comparePolicyFromGateOptions(
+  options: Pick<
+    EvalGateOptions,
+    | "baseline"
+    | "minSampleSize"
+    | "minEffectSizePercent"
+    | "gateDeterministicRegressions"
+    | "maxP95LatencyIncreaseMs"
+  >
+): GatePolicy {
+  const hasComparativeFlag =
+    options.minSampleSize !== undefined ||
+    options.minEffectSizePercent !== undefined ||
+    options.gateDeterministicRegressions === true ||
+    options.maxP95LatencyIncreaseMs !== undefined;
+  if (hasComparativeFlag && !options.baseline) {
+    throw usageError(
+      "--min-sample-size, --min-effect-size-percent, " +
+        "--gate-deterministic-regressions, and --max-p95-latency-increase-ms " +
+        "tune the baseline regression gate; pass --baseline to enable it."
+    );
+  }
+  return comparePolicyFromOptions({
+    gateRegressions: Boolean(options.baseline),
+    minSampleSize: options.minSampleSize,
+    minEffectSizePercent: options.minEffectSizePercent,
+    gateDeterministicRegressions: options.gateDeterministicRegressions,
+    maxP95LatencyIncreaseMs: options.maxP95LatencyIncreaseMs,
+  });
+}
+
+/**
+ * The server says "no baseline" with a 404 carrying
+ * `details.reason: "BASELINE_NOT_FOUND"`. Read the machine field, not the
+ * prose. Shared by `eval compare` and `eval gate --baseline` — both hit the
+ * same endpoint and must fold the same error into `incomplete`, never `failed`.
+ */
+export function baselineNotFoundReason(error: unknown): boolean {
+  const details = (error as { details?: unknown })?.details;
+  return (
+    typeof details === "object" &&
+    details !== null &&
+    (details as { reason?: unknown }).reason === "BASELINE_NOT_FOUND"
+  );
+}
+
+/**
+ * Fold a threshold `GateReport` and a comparative `GateReport` into one.
+ *
+ * Same precedence `evaluateGates` and `evaluateCompareGates` each already use
+ * internally (`usage_error > failed > incomplete > passed`), applied one
+ * level up: a run that both missed its threshold AND regressed against the
+ * baseline DID both, and folding to whichever ranks higher must never bury
+ * the other family's verdicts — every verdict from both reports survives in
+ * the merged `verdicts` array.
+ */
+const OUTCOME_RANK: Record<GateReport["outcome"], number> = {
+  passed: 0,
+  incomplete: 1,
+  failed: 2,
+  usage_error: 3,
+};
+
+export function mergeGateReports(
+  threshold: GateReport,
+  comparative: GateReport
+): GateReport {
+  return {
+    outcome:
+      OUTCOME_RANK[comparative.outcome] > OUTCOME_RANK[threshold.outcome]
+        ? comparative.outcome
+        : threshold.outcome,
+    verdicts: [...threshold.verdicts, ...comparative.verdicts],
+    // The run being gated IS the compare side of the baseline comparison, so
+    // its own score integrity — already computed by `evaluateGates` above —
+    // is the one meaning that survives the merge. The comparison's own
+    // (base+compare) combined integrity is recorded separately in the
+    // baseline provenance, not lost.
+    scoreIntegrity: threshold.scoreIntegrity,
+  };
+}
+
+/**
+ * Baseline-compatibility provenance for the gate report.
+ *
+ * The PINNED CONTRACT requires a gate to record baseline run id/SHA, suite
+ * hashes, model/provider, host/harness, server/environment identity, and
+ * comparable case ids — and to report incompatible dimensions explicitly
+ * rather than silently comparing them. The `/compare` wire does not carry
+ * every one of those yet; the dimensions it omits are recorded as
+ * `"notRecorded"` here rather than left out, so a reader can tell "checked,
+ * and they matched" apart from "nobody looked".
+ */
+export function buildBaselineProvenance(
+  requestedBaseline: string,
+  compare: PlatformRunCompare,
+  input: CompareGateInput
+): Record<string, unknown> {
+  return {
+    requestedBaseline,
+    baseline: compare.baseline,
+    baseRunId: compare.baseRun.id,
+    compareRunId: compare.compareRun.id,
+    compatibility: {
+      caseSetChanged: input.caseSetChanged,
+      scenarioConfigChanged: input.scenarioConfigChanged,
+      evaluationConfigChanged: input.evaluationConfigChanged,
+      iterationWeightingEqual: input.iterationWeightingEqual,
+      baseScoreIntegrity: compare.scoreContract.base.scoreIntegrity,
+      compareScoreIntegrity: compare.scoreContract.compare.scoreIntegrity,
+    },
+    // Dimensions the pinned contract requires but the `/compare` wire does
+    // not carry today (E4b / backend follow-up work). Never invented, never
+    // silently dropped.
+    notRecorded: {
+      modelProvider: "notRecorded",
+      hostHarness: "notRecorded",
+      serverEnvironmentIdentity: "notRecorded",
+      configHashesBeyondEvaluationConfigHash: "notRecorded",
+    },
+  };
+}
+
+export type BaselineComparisonResult = {
+  report: GateReport;
+  /** Absent when the comparison never resolved a compare report to describe. */
+  provenance?: Record<string, unknown>;
+};
+
+/**
+ * Evaluate the `--baseline` regression gate for `eval gate`.
+ *
+ * Called only once the run being gated has already produced a threshold
+ * `GateReport` — a baseline comparison for a run with no verdict of its own
+ * yet is meaningless. Errors fetching the comparison degrade to a
+ * `non_gateable` verdict rather than throwing, so the caller can always
+ * merge this result with the threshold report instead of discarding it.
+ */
+export async function evaluateBaselineComparison(input: {
+  client: Pick<PlatformApiClient, "compareEvalRun" | "listEvalRunIterations">;
+  signal: AbortSignal;
+  projectId: string;
+  runId: string;
+  baseline: string;
+  policy: GatePolicy;
+  /** Already-fetched iterations for `runId`, reused instead of re-fetched. */
+  compareIterations?: FetchedIterations;
+}): Promise<BaselineComparisonResult> {
+  let compare: PlatformRunCompare;
+  try {
+    compare = await input.client.compareEvalRun(
+      {
+        projectId: input.projectId,
+        runId: input.runId,
+        baseRunId: input.baseline,
+      },
+      { signal: input.signal }
+    );
+  } catch (error) {
+    const reason = baselineNotFoundReason(error);
+    const detail = error instanceof Error ? error.message : String(error);
+    return {
+      report: {
+        outcome: "incomplete",
+        scoreIntegrity: "unknown",
+        verdicts: [
+          {
+            gate: "baseline",
+            status: "non_gateable",
+            message: reason
+              ? `no baseline to compare against: ${detail}`
+              : `could not compare against the baseline: ${detail}`,
+          },
+        ],
+      },
+    };
+  }
+
+  // Defence in depth, mirroring `eval compare`: the backend action already
+  // refuses a non-completed run, but this command's contract says an
+  // unfinished comparison is INCOMPLETE, and that must not depend on a guard
+  // in another repo staying put.
+  if (
+    compare.baseRun.completedAt === null ||
+    compare.compareRun.completedAt === null
+  ) {
+    return {
+      report: {
+        outcome: "incomplete",
+        scoreIntegrity: "unknown",
+        verdicts: [
+          {
+            gate: "baseline",
+            status: "non_gateable",
+            message: "both runs must be completed before they can be compared",
+          },
+        ],
+      },
+    };
+  }
+
+  // Latency needs per-iteration rows on both sides. A fetch failure here
+  // degrades only the latency gate to non-gateable — absent beats
+  // approximate — rather than discarding the whole comparison.
+  const needsLatency = input.policy.maximumP95LatencyIncreaseMs !== undefined;
+  let baseIterations: FetchedIterations | undefined;
+  let compareIterationsForLatency: FetchedIterations | undefined =
+    input.compareIterations;
+  if (needsLatency) {
+    try {
+      [baseIterations, compareIterationsForLatency] = await Promise.all([
+        fetchAllIterations(
+          input.client,
+          input.signal,
+          input.projectId,
+          compare.baseRun.id
+        ),
+        input.compareIterations ??
+          fetchAllIterations(
+            input.client,
+            input.signal,
+            input.projectId,
+            compare.compareRun.id
+          ),
+      ]);
+    } catch {
+      baseIterations = undefined;
+      compareIterationsForLatency = undefined;
+    }
+  }
+
+  const compareInput = compareGateInputFrom(compare, {
+    baseP95Ms: p95Of(baseIterations),
+    compareP95Ms: p95Of(compareIterationsForLatency),
+  });
+
+  return {
+    report: evaluateCompareGates(compareInput, input.policy),
+    provenance: buildBaselineProvenance(input.baseline, compare, compareInput),
+  };
 }

--- a/cli/src/lib/eval-iterations.ts
+++ b/cli/src/lib/eval-iterations.ts
@@ -8,6 +8,7 @@
  * confident verdict about page one is exactly the drift worth avoiding.
  */
 
+import { calculateLatencyStats } from "@mcpjam/sdk";
 import type { PlatformApiClient } from "@mcpjam/sdk/platform";
 import type { PlatformEvalIteration } from "@mcpjam/sdk/platform";
 
@@ -44,4 +45,24 @@ export async function fetchAllIterations(
     cursor = result.nextCursor;
   }
   return { items, complete: false };
+}
+
+/**
+ * p95 over a COMPLETE iteration walk; `undefined` from a partial one.
+ *
+ * Shared by `eval compare` and `eval gate --baseline`: both need a p95 for a
+ * side of a comparison, and a single missing duration makes the p95 describe
+ * a different set than the run — absent beats approximate.
+ */
+export function p95Of(
+  iterations: FetchedIterations | undefined
+): number | undefined {
+  if (!iterations?.complete) return undefined;
+  const durations = iterations.items
+    .map((iteration) => iteration.durationMs)
+    .filter((ms): ms is number => typeof ms === "number");
+  if (durations.length === 0 || durations.length !== iterations.items.length) {
+    return undefined;
+  }
+  return calculateLatencyStats(durations).p95;
 }

--- a/cli/tests/eval-gate-baseline-exit-code.test.ts
+++ b/cli/tests/eval-gate-baseline-exit-code.test.ts
@@ -1,0 +1,287 @@
+/**
+ * The exit-code matrix for `mcpjam cloud eval gate --baseline`.
+ *
+ * Mirrors `eval-compare-exit-code.test.ts` deliberately: same wire fixture
+ * shape, same oracle-pinned regression numbers, same principle that no
+ * infrastructure or comparability problem may ever map to 1. What this file
+ * adds on top is the MERGE: `eval gate --baseline` folds a threshold
+ * `GateReport` (from `evaluateGates`) together with a comparative one (from
+ * `evaluateCompareGates`) into the single report the command actually emits,
+ * and the merge must never let one family's verdict bury the other's.
+ */
+import assert from "node:assert/strict";
+import test from "node:test";
+import { evaluateCompareGates, evaluateGates } from "@mcpjam/sdk";
+import type { GateInput, GatePolicy, GateReport } from "@mcpjam/sdk";
+import { compareGateInputFrom } from "../src/lib/eval-compare.js";
+import {
+  comparePolicyFromGateOptions,
+  mergeGateReports,
+} from "../src/lib/eval-gate.js";
+import {
+  EVAL_GATE_INCOMPLETE_EXIT_CODE,
+  evalGateExitCode,
+} from "../src/lib/eval-gate-exit-code.js";
+import type {
+  PlatformCaseScoreDelta,
+  PlatformRunCompare,
+  PlatformRunCompareCase,
+} from "@mcpjam/sdk/platform";
+
+const ZERO = { base: null, compare: null, delta: null, percentDelta: null };
+
+function caseRow(
+  overrides: Partial<PlatformRunCompareCase> = {}
+): PlatformRunCompareCase {
+  return {
+    caseKey: "ck_a",
+    title: "Case A",
+    status: "unchanged_passed",
+    configChanged: false,
+    evaluationConfigChanged: false,
+    scoreDeltas: [],
+    base: {
+      outcome: "passed",
+      iterationIds: ["b1"],
+      representativeIterationId: "b1",
+      error: null,
+    },
+    compare: {
+      outcome: "passed",
+      iterationIds: ["c1"],
+      representativeIterationId: "c1",
+      error: null,
+    },
+    ...overrides,
+  };
+}
+
+const REGRESSED_DELTA: PlatformCaseScoreDelta = {
+  scorerId: "tool-match",
+  gating: true,
+  deterministic: true,
+  definitionChanged: false,
+  base: { status: "scored", value: 1, passed: true },
+  compare: { status: "scored", value: 0, passed: false },
+  value: ZERO,
+};
+
+function wire(args: {
+  basePassed?: number;
+  baseTotal?: number;
+  comparePassed?: number;
+  compareTotal?: number;
+  cases?: PlatformRunCompareCase[];
+}): PlatformRunCompare {
+  const baseTotal = args.baseTotal ?? 70;
+  const compareTotal = args.compareTotal ?? 80;
+  return {
+    suite: { id: "s1", name: "Suite" },
+    baseline: { policy: "run", baseRunId: "run_base" },
+    baseRun: {
+      id: "run_base",
+      runNumber: 1,
+      result: "passed",
+      createdAt: 1,
+      completedAt: 2,
+      summary: {
+        total: baseTotal,
+        passed: args.basePassed ?? 56,
+        failed: baseTotal - (args.basePassed ?? 56),
+        passRate: (args.basePassed ?? 56) / baseTotal,
+      },
+    },
+    compareRun: {
+      id: "run_compare",
+      runNumber: 2,
+      result: "failed",
+      createdAt: 3,
+      completedAt: 4,
+      summary: {
+        total: compareTotal,
+        passed: args.comparePassed ?? 48,
+        failed: compareTotal - (args.comparePassed ?? 48),
+        passRate: (args.comparePassed ?? 48) / compareTotal,
+      },
+    },
+    passSummary: {
+      passRatePercent: ZERO,
+      total: ZERO,
+      passed: ZERO,
+      failed: ZERO,
+    },
+    metrics: {
+      wallDurationMs: ZERO,
+      totalTokens: ZERO,
+      estimatedCostUsd: ZERO,
+    },
+    scoreContract: {
+      base: {
+        evaluationConfigHash: "cfg",
+        scoreIntegrity: "valid",
+        scoredIterations: baseTotal,
+        quarantinedIterations: 0,
+      },
+      compare: {
+        evaluationConfigHash: "cfg",
+        scoreIntegrity: "valid",
+        scoredIterations: compareTotal,
+        quarantinedIterations: 0,
+      },
+      evaluationConfigChanged: false,
+      scorers: [],
+    },
+    cases: args.cases ?? [caseRow()],
+  };
+}
+
+/** A run that comfortably clears any threshold gate on its own. */
+const PASSING_THRESHOLD_INPUT: GateInput = {
+  iterations: { total: 10, passed: 10 },
+};
+
+function thresholdReport(
+  policy: GatePolicy,
+  input: GateInput = PASSING_THRESHOLD_INPUT
+): GateReport {
+  return evaluateGates(input, policy);
+}
+
+function mergedExitCode(args: {
+  thresholdPolicy?: GatePolicy;
+  thresholdInput?: GateInput;
+  compare: PlatformRunCompare;
+  comparePolicy: GatePolicy;
+}): number {
+  const threshold = thresholdReport(
+    args.thresholdPolicy ?? {},
+    args.thresholdInput
+  );
+  const comparative = evaluateCompareGates(
+    compareGateInputFrom(args.compare),
+    args.comparePolicy
+  );
+  return evalGateExitCode(mergeGateReports(threshold, comparative));
+}
+
+test("1 — a baseline regression, with no threshold policy at all", () => {
+  // The oracle's 56/70 -> 48/80 row, same numbers `eval-compare-exit-
+  // code.test.ts` pins against statsmodels.
+  assert.equal(
+    mergedExitCode({
+      compare: wire({}),
+      comparePolicy: comparePolicyFromGateOptions({ baseline: "run_base" }),
+    }),
+    1
+  );
+});
+
+test("3 — an incompatible case set is non_gateable, NOT a regression", () => {
+  // Same regressed numbers as above; the case set churned, so the whole-run
+  // rate is not comparable and must never read as 1.
+  assert.equal(
+    mergedExitCode({
+      compare: wire({
+        cases: [caseRow(), caseRow({ caseKey: "ck_new", status: "new_case" })],
+      }),
+      comparePolicy: comparePolicyFromGateOptions({ baseline: "run_base" }),
+    }),
+    EVAL_GATE_INCOMPLETE_EXIT_CODE
+  );
+});
+
+test("3 — insufficient sample size reads as incomplete, not no_regression", () => {
+  assert.equal(
+    mergedExitCode({
+      compare: wire({
+        basePassed: 4,
+        baseTotal: 4,
+        comparePassed: 0,
+        compareTotal: 4,
+      }),
+      comparePolicy: comparePolicyFromGateOptions({ baseline: "run_base" }),
+    }),
+    EVAL_GATE_INCOMPLETE_EXIT_CODE
+  );
+});
+
+test("1 — a deterministic per-case regression, independent of the population rule", () => {
+  assert.equal(
+    mergedExitCode({
+      compare: wire({
+        basePassed: 56,
+        comparePassed: 56,
+        compareTotal: 70,
+        cases: [caseRow({ scoreDeltas: [REGRESSED_DELTA] })],
+      }),
+      comparePolicy: comparePolicyFromGateOptions({
+        baseline: "run_base",
+        gateDeterministicRegressions: true,
+      }),
+    }),
+    1
+  );
+});
+
+test("1 — a threshold miss and a baseline regression fold into ONE report", () => {
+  const failingThreshold: GateInput = { iterations: { total: 2, passed: 1 } };
+  const threshold = thresholdReport({ minimumPassRate: 1 }, failingThreshold);
+  const comparative = evaluateCompareGates(
+    compareGateInputFrom(wire({})),
+    comparePolicyFromGateOptions({ baseline: "run_base" })
+  );
+  const merged = mergeGateReports(threshold, comparative);
+  assert.equal(evalGateExitCode(merged), 1);
+  const gates = merged.verdicts.map((v) => v.gate);
+  assert.ok(
+    gates.includes("minimumPassRate"),
+    "threshold verdict must survive the merge"
+  );
+  assert.ok(
+    gates.includes("passRateRegression"),
+    "comparative verdict must survive the merge"
+  );
+});
+
+test("3 — the threshold passes but the comparison is non-gateable", () => {
+  // Deterministic gate asked for, but no score deltas at all on the wire —
+  // undecidable, not "nothing regressed".
+  assert.equal(
+    mergedExitCode({
+      compare: wire({ basePassed: 56, comparePassed: 60, compareTotal: 70 }),
+      comparePolicy: comparePolicyFromGateOptions({
+        baseline: "run_base",
+        gateDeterministicRegressions: true,
+      }),
+    }),
+    EVAL_GATE_INCOMPLETE_EXIT_CODE
+  );
+});
+
+test("0 — a passing threshold and a clean baseline comparison", () => {
+  assert.equal(
+    mergedExitCode({
+      thresholdPolicy: { minimumPassRate: 1 },
+      compare: wire({
+        basePassed: 56,
+        comparePassed: 60,
+        compareTotal: 70,
+        cases: [
+          caseRow({
+            scoreDeltas: [
+              {
+                ...REGRESSED_DELTA,
+                compare: { status: "scored", value: 1, passed: true },
+              },
+            ],
+          }),
+        ],
+      }),
+      comparePolicy: comparePolicyFromGateOptions({
+        baseline: "run_base",
+        gateDeterministicRegressions: true,
+      }),
+    }),
+    0
+  );
+});

--- a/cli/tests/eval-gate.test.ts
+++ b/cli/tests/eval-gate.test.ts
@@ -730,11 +730,143 @@ test("buildBaselineProvenance: names the added/removed cases behind caseSetChang
   });
   const compatibility = provenance.compatibility as {
     comparableCaseIds: string[];
-    incompatibleCases: Array<{ caseKey: string; status: string }>;
+    incompatibleCases: Array<{
+      caseKey: string;
+      status: string;
+      reasons: string[];
+    }>;
   };
   assert.deepEqual(compatibility.comparableCaseIds, ["ck_shared"]);
   assert.deepEqual(compatibility.incompatibleCases, [
-    { caseKey: "ck_new", status: "new_case" },
-    { caseKey: "ck_removed", status: "removed_case" },
+    { caseKey: "ck_new", status: "new_case", reasons: ["case_added"] },
+    { caseKey: "ck_removed", status: "removed_case", reasons: ["case_removed"] },
+  ]);
+});
+
+test("buildBaselineProvenance: a case-set-stable case can still be individually incompatible", () => {
+  // A case can survive `caseSetChanged` (it exists on both sides) and STILL
+  // be the one responsible for `scenarioConfigChanged`,
+  // `evaluationConfigChanged`, or unequal iteration weighting.
+  // `comparableCaseIds` must not claim a case the whole-run verdict never
+  // actually trusted.
+  const compare = compareWire({
+    cases: [
+      {
+        caseKey: "ck_clean",
+        title: "Clean",
+        status: "unchanged_passed",
+        configChanged: false,
+        evaluationConfigChanged: false,
+        scoreDeltas: [],
+        base: {
+          outcome: "passed",
+          iterationIds: ["b1"],
+          representativeIterationId: "b1",
+          error: null,
+        },
+        compare: {
+          outcome: "passed",
+          iterationIds: ["c1"],
+          representativeIterationId: "c1",
+          error: null,
+        },
+      },
+      {
+        caseKey: "ck_reconfigured",
+        title: "Reconfigured",
+        status: "changed",
+        configChanged: true,
+        evaluationConfigChanged: false,
+        scoreDeltas: [],
+        base: {
+          outcome: "passed",
+          iterationIds: ["b2"],
+          representativeIterationId: "b2",
+          error: null,
+        },
+        compare: {
+          outcome: "passed",
+          iterationIds: ["c2"],
+          representativeIterationId: "c2",
+          error: null,
+        },
+      },
+      {
+        caseKey: "ck_regraded",
+        title: "Regraded",
+        status: "unchanged_passed",
+        configChanged: false,
+        evaluationConfigChanged: true,
+        scoreDeltas: [],
+        base: {
+          outcome: "passed",
+          iterationIds: ["b3"],
+          representativeIterationId: "b3",
+          error: null,
+        },
+        compare: {
+          outcome: "passed",
+          iterationIds: ["c3"],
+          representativeIterationId: "c3",
+          error: null,
+        },
+      },
+      {
+        caseKey: "ck_reweighted",
+        title: "Reweighted",
+        status: "unchanged_passed",
+        configChanged: false,
+        evaluationConfigChanged: false,
+        scoreDeltas: [],
+        base: {
+          outcome: "passed",
+          iterationIds: ["b4"],
+          representativeIterationId: "b4",
+          error: null,
+        },
+        compare: {
+          outcome: "passed",
+          iterationIds: ["c4", "c5"],
+          representativeIterationId: "c4",
+          error: null,
+        },
+      },
+    ],
+  });
+  const provenance = buildBaselineProvenance("run_base", compare, {
+    base: { iterations: { total: 70, passed: 56 } },
+    compare: { iterations: { total: 80, passed: 48 } },
+    deterministicScoreRegressions: [],
+    scoreDeltasAvailable: false,
+    caseSetChanged: false,
+    scenarioConfigChanged: true,
+    evaluationConfigChanged: true,
+    iterationWeightingEqual: false,
+  });
+  const compatibility = provenance.compatibility as {
+    comparableCaseIds: string[];
+    incompatibleCases: Array<{
+      caseKey: string;
+      status: string;
+      reasons: string[];
+    }>;
+  };
+  assert.deepEqual(compatibility.comparableCaseIds, ["ck_clean"]);
+  assert.deepEqual(compatibility.incompatibleCases, [
+    {
+      caseKey: "ck_reconfigured",
+      status: "changed",
+      reasons: ["scenario_config_changed"],
+    },
+    {
+      caseKey: "ck_regraded",
+      status: "unchanged_passed",
+      reasons: ["evaluation_config_changed"],
+    },
+    {
+      caseKey: "ck_reweighted",
+      status: "unchanged_passed",
+      reasons: ["iteration_weighting_unequal"],
+    },
   ]);
 });

--- a/cli/tests/eval-gate.test.ts
+++ b/cli/tests/eval-gate.test.ts
@@ -318,6 +318,22 @@ test("assertRunIdBaseline rejects a 40-hex git SHA, upper or lower case", () => 
   assert.doesNotThrow(() => assertRunIdBaseline("g".repeat(40)));
 });
 
+test("assertRunIdBaseline rejects a blank value, not just an absent one", () => {
+  // Commander cannot tell "--baseline ''" (an unset CI variable interpolated
+  // into the flag, e.g. `--baseline "$BASELINE_RUN_ID"`) apart from a real
+  // run id — both are `!== undefined`. Downstream, `!options.baseline` and
+  // `Boolean(options.baseline)` both read "" as falsy, so an unvalidated
+  // blank would silently disable the whole baseline comparison rather than
+  // erroring, and the command would exit 0 on nothing the caller asked for.
+  for (const blank of ["", "   ", "\t"]) {
+    assert.throws(
+      () => assertRunIdBaseline(blank),
+      /must not be blank/,
+      JSON.stringify(blank),
+    );
+  }
+});
+
 test("comparePolicyFromGateOptions: --baseline alone implies regression gating", () => {
   // No `--gate-regressions` flag exists on `eval gate` — `--baseline` itself
   // enables the pass-rate regression gate with the SDK's defaults.

--- a/cli/tests/eval-gate.test.ts
+++ b/cli/tests/eval-gate.test.ts
@@ -17,6 +17,7 @@ import {
   policyNeedsIterations,
   reportForRun,
 } from "../src/lib/eval-gate.js";
+import { DEFAULT_MIN_EFFECT_SIZE, DEFAULT_MIN_SAMPLE_SIZE } from "@mcpjam/sdk";
 import type { GateReport } from "@mcpjam/sdk";
 import type { PlatformRunCompare } from "@mcpjam/sdk/platform";
 
@@ -636,7 +637,9 @@ test("buildBaselineProvenance: records every evaluated compatibility signal", ()
     evaluationConfigChanged: true,
     iterationWeightingEqual: false,
   };
-  const provenance = buildBaselineProvenance("run_base", compare, input);
+  const provenance = buildBaselineProvenance("run_base", compare, input, {
+    passRateRegression: {},
+  });
   assert.deepEqual(provenance.baseline, compare.baseline);
   assert.deepEqual(provenance.compatibility, {
     caseSetChanged: true,
@@ -650,6 +653,60 @@ test("buildBaselineProvenance: records every evaluated compatibility signal", ()
     // cases still measure the same thing, or which ones do not.
     comparableCaseIds: ["ck_a"],
     incompatibleCases: [],
+  });
+  // The resolved policy that produced this verdict — defaults filled in, so
+  // the default case is just as visible as an explicit threshold.
+  assert.deepEqual(provenance.policy, {
+    passRateRegression: {
+      minSampleSize: DEFAULT_MIN_SAMPLE_SIZE,
+      minEffectSize: DEFAULT_MIN_EFFECT_SIZE,
+    },
+    noDeterministicRegressions: false,
+    maximumP95LatencyIncreaseMs: null,
+  });
+});
+
+test("buildBaselineProvenance: an unrequested gate's policy is null, not an implicit default", () => {
+  const compare = compareWire();
+  const input = {
+    base: { iterations: { total: 70, passed: 56 } },
+    compare: { iterations: { total: 80, passed: 48 } },
+    deterministicScoreRegressions: [],
+    scoreDeltasAvailable: false,
+    caseSetChanged: false,
+    scenarioConfigChanged: false,
+    evaluationConfigChanged: false,
+    iterationWeightingEqual: true,
+  };
+  const provenance = buildBaselineProvenance("run_base", compare, input, {});
+  assert.deepEqual(provenance.policy, {
+    passRateRegression: null,
+    noDeterministicRegressions: false,
+    maximumP95LatencyIncreaseMs: null,
+  });
+});
+
+test("buildBaselineProvenance: an explicit policy is echoed back verbatim, not re-defaulted", () => {
+  const compare = compareWire();
+  const input = {
+    base: { iterations: { total: 70, passed: 56 } },
+    compare: { iterations: { total: 80, passed: 48 } },
+    deterministicScoreRegressions: [],
+    scoreDeltasAvailable: false,
+    caseSetChanged: false,
+    scenarioConfigChanged: false,
+    evaluationConfigChanged: false,
+    iterationWeightingEqual: true,
+  };
+  const provenance = buildBaselineProvenance("run_base", compare, input, {
+    passRateRegression: { minSampleSize: 20, minEffectSize: 0.05 },
+    noDeterministicRegressions: true,
+    maximumP95LatencyIncreaseMs: 500,
+  });
+  assert.deepEqual(provenance.policy, {
+    passRateRegression: { minSampleSize: 20, minEffectSize: 0.05 },
+    noDeterministicRegressions: true,
+    maximumP95LatencyIncreaseMs: 500,
   });
 });
 
@@ -718,16 +775,21 @@ test("buildBaselineProvenance: names the added/removed cases behind caseSetChang
       },
     ],
   });
-  const provenance = buildBaselineProvenance("run_base", compare, {
-    base: { iterations: { total: 70, passed: 56 } },
-    compare: { iterations: { total: 80, passed: 48 } },
-    deterministicScoreRegressions: [],
-    scoreDeltasAvailable: false,
-    caseSetChanged: true,
-    scenarioConfigChanged: false,
-    evaluationConfigChanged: false,
-    iterationWeightingEqual: true,
-  });
+  const provenance = buildBaselineProvenance(
+    "run_base",
+    compare,
+    {
+      base: { iterations: { total: 70, passed: 56 } },
+      compare: { iterations: { total: 80, passed: 48 } },
+      deterministicScoreRegressions: [],
+      scoreDeltasAvailable: false,
+      caseSetChanged: true,
+      scenarioConfigChanged: false,
+      evaluationConfigChanged: false,
+      iterationWeightingEqual: true,
+    },
+    {}
+  );
   const compatibility = provenance.compatibility as {
     comparableCaseIds: string[];
     incompatibleCases: Array<{
@@ -833,16 +895,21 @@ test("buildBaselineProvenance: a case-set-stable case can still be individually 
       },
     ],
   });
-  const provenance = buildBaselineProvenance("run_base", compare, {
-    base: { iterations: { total: 70, passed: 56 } },
-    compare: { iterations: { total: 80, passed: 48 } },
-    deterministicScoreRegressions: [],
-    scoreDeltasAvailable: false,
-    caseSetChanged: false,
-    scenarioConfigChanged: true,
-    evaluationConfigChanged: true,
-    iterationWeightingEqual: false,
-  });
+  const provenance = buildBaselineProvenance(
+    "run_base",
+    compare,
+    {
+      base: { iterations: { total: 70, passed: 56 } },
+      compare: { iterations: { total: 80, passed: 48 } },
+      deterministicScoreRegressions: [],
+      scoreDeltasAvailable: false,
+      caseSetChanged: false,
+      scenarioConfigChanged: true,
+      evaluationConfigChanged: true,
+      iterationWeightingEqual: false,
+    },
+    {}
+  );
   const compatibility = provenance.compatibility as {
     comparableCaseIds: string[];
     incompatibleCases: Array<{
@@ -867,6 +934,87 @@ test("buildBaselineProvenance: a case-set-stable case can still be individually 
       caseKey: "ck_reweighted",
       status: "unchanged_passed",
       reasons: ["iteration_weighting_unequal"],
+    },
+  ]);
+});
+
+test("buildBaselineProvenance: a run-level evaluation config change excludes every case, even ones whose own row says unchanged", () => {
+  // `scoreContract.evaluationConfigChanged` is a RUN-level signal (the
+  // evaluation config hash itself changed between runs). A case can still
+  // report `evaluationConfigChanged: false` on its own row if the platform
+  // only diffs per-case config on things other than the evaluation config
+  // hash. The run-level signal must still exclude that case from
+  // `comparableCaseIds` — trusting the row-level flag alone would silently
+  // compare cases under a config change the run as a whole reports.
+  const compare = compareWire({
+    scoreContract: {
+      base: {
+        evaluationConfigHash: "cfg_old",
+        scoreIntegrity: "valid",
+        scoredIterations: 70,
+        quarantinedIterations: 0,
+      },
+      compare: {
+        evaluationConfigHash: "cfg_new",
+        scoreIntegrity: "valid",
+        scoredIterations: 80,
+        quarantinedIterations: 0,
+      },
+      evaluationConfigChanged: true,
+      scorers: [],
+    },
+    cases: [
+      {
+        caseKey: "ck_a",
+        title: "Case A",
+        status: "unchanged_passed",
+        configChanged: false,
+        evaluationConfigChanged: false,
+        scoreDeltas: [],
+        base: {
+          outcome: "passed",
+          iterationIds: ["b1"],
+          representativeIterationId: "b1",
+          error: null,
+        },
+        compare: {
+          outcome: "passed",
+          iterationIds: ["c1"],
+          representativeIterationId: "c1",
+          error: null,
+        },
+      },
+    ],
+  });
+  const provenance = buildBaselineProvenance(
+    "run_base",
+    compare,
+    {
+      base: { iterations: { total: 70, passed: 56 } },
+      compare: { iterations: { total: 80, passed: 48 } },
+      deterministicScoreRegressions: [],
+      scoreDeltasAvailable: false,
+      caseSetChanged: false,
+      scenarioConfigChanged: false,
+      evaluationConfigChanged: true,
+      iterationWeightingEqual: true,
+    },
+    {}
+  );
+  const compatibility = provenance.compatibility as {
+    comparableCaseIds: string[];
+    incompatibleCases: Array<{
+      caseKey: string;
+      status: string;
+      reasons: string[];
+    }>;
+  };
+  assert.deepEqual(compatibility.comparableCaseIds, []);
+  assert.deepEqual(compatibility.incompatibleCases, [
+    {
+      caseKey: "ck_a",
+      status: "unchanged_passed",
+      reasons: ["evaluation_config_changed"],
     },
   ]);
 });

--- a/cli/tests/eval-gate.test.ts
+++ b/cli/tests/eval-gate.test.ts
@@ -334,6 +334,17 @@ test("assertRunIdBaseline rejects a blank value, not just an absent one", () => 
   }
 });
 
+test("assertRunIdBaseline rejects a whitespace-padded SHA, not just a bare one", () => {
+  // The SHA check runs against the TRIMMED value: `--baseline " <40-hex> "`
+  // is still a doomed run lookup, and the blank check just above already
+  // proved trimming doesn't change what the flag means.
+  const padded = `  ${"a".repeat(40)}  `;
+  assert.throws(
+    () => assertRunIdBaseline(padded),
+    /SHA baselines are not supported yet/,
+  );
+});
+
 test("comparePolicyFromGateOptions: --baseline alone implies regression gating", () => {
   // No `--gate-regressions` flag exists on `eval gate` — `--baseline` itself
   // enables the pass-rate regression gate with the SDK's defaults.

--- a/cli/tests/eval-gate.test.ts
+++ b/cli/tests/eval-gate.test.ts
@@ -302,6 +302,15 @@ test("assertRunIdBaseline accepts an ordinary run id", () => {
   assert.doesNotThrow(() => assertRunIdBaseline("run-1", RUN_ID));
 });
 
+test("assertRunIdBaseline returns the TRIMMED value, not the raw one", () => {
+  // Validation checks the trimmed value; forwarding the raw one instead would
+  // let a whitespace-padded but otherwise valid `--baseline` slip past every
+  // check here and then fail to resolve on the wire (reported as incomplete,
+  // exit 3, rather than either working or naming the usage error).
+  assert.equal(assertRunIdBaseline("  run-base  ", RUN_ID), "run-base");
+  assert.equal(assertRunIdBaseline("run-base", RUN_ID), "run-base");
+});
+
 test("assertRunIdBaseline rejects a 40-hex git SHA, upper or lower case", () => {
   const sha = "a".repeat(40);
   assert.throws(

--- a/cli/tests/eval-gate.test.ts
+++ b/cli/tests/eval-gate.test.ts
@@ -618,5 +618,96 @@ test("buildBaselineProvenance: records every evaluated compatibility signal", ()
     iterationWeightingEqual: false,
     baseScoreIntegrity: "valid",
     compareScoreIntegrity: "valid",
+    // The PINNED CONTRACT names "comparable case ids" explicitly: an
+    // archived report's `caseSetChanged: true` alone does not say WHICH
+    // cases still measure the same thing, or which ones do not.
+    comparableCaseIds: ["ck_a"],
+    incompatibleCases: [],
   });
+});
+
+test("buildBaselineProvenance: names the added/removed cases behind caseSetChanged", () => {
+  const compare = compareWire({
+    cases: [
+      {
+        caseKey: "ck_shared",
+        title: "Shared",
+        status: "unchanged_passed",
+        configChanged: false,
+        evaluationConfigChanged: false,
+        scoreDeltas: [],
+        base: {
+          outcome: "passed",
+          iterationIds: ["b1"],
+          representativeIterationId: "b1",
+          error: null,
+        },
+        compare: {
+          outcome: "passed",
+          iterationIds: ["c1"],
+          representativeIterationId: "c1",
+          error: null,
+        },
+      },
+      {
+        caseKey: "ck_new",
+        title: "New",
+        status: "new_case",
+        configChanged: false,
+        evaluationConfigChanged: false,
+        scoreDeltas: [],
+        base: {
+          outcome: "absent",
+          iterationIds: [],
+          representativeIterationId: null,
+          error: null,
+        },
+        compare: {
+          outcome: "passed",
+          iterationIds: ["c2"],
+          representativeIterationId: "c2",
+          error: null,
+        },
+      },
+      {
+        caseKey: "ck_removed",
+        title: "Removed",
+        status: "removed_case",
+        configChanged: false,
+        evaluationConfigChanged: false,
+        scoreDeltas: [],
+        base: {
+          outcome: "passed",
+          iterationIds: ["b2"],
+          representativeIterationId: "b2",
+          error: null,
+        },
+        compare: {
+          outcome: "absent",
+          iterationIds: [],
+          representativeIterationId: null,
+          error: null,
+        },
+      },
+    ],
+  });
+  const provenance = buildBaselineProvenance("run_base", compare, {
+    base: { iterations: { total: 70, passed: 56 } },
+    compare: { iterations: { total: 80, passed: 48 } },
+    deterministicScoreRegressions: [],
+    scoreDeltasAvailable: false,
+    caseSetChanged: true,
+    scenarioConfigChanged: false,
+    evaluationConfigChanged: false,
+    iterationWeightingEqual: true,
+  });
+  const compatibility = provenance.compatibility as {
+    comparableCaseIds: string[];
+    incompatibleCases: Array<{ caseKey: string; status: string }>;
+  };
+  assert.deepEqual(compatibility.comparableCaseIds, ["ck_shared"]);
+  assert.deepEqual(compatibility.incompatibleCases, [
+    { caseKey: "ck_new", status: "new_case" },
+    { caseKey: "ck_removed", status: "removed_case" },
+  ]);
 });

--- a/cli/tests/eval-gate.test.ts
+++ b/cli/tests/eval-gate.test.ts
@@ -295,27 +295,29 @@ test("the gate keeps exactly four exit codes under verdict policy 2", () => {
 
 // ── --baseline (runId half) ─────────────────────────────────────────────────
 
+const RUN_ID = "run-current";
+
 test("assertRunIdBaseline accepts an ordinary run id", () => {
-  assert.doesNotThrow(() => assertRunIdBaseline("run_abc123"));
-  assert.doesNotThrow(() => assertRunIdBaseline("run-1"));
+  assert.doesNotThrow(() => assertRunIdBaseline("run_abc123", RUN_ID));
+  assert.doesNotThrow(() => assertRunIdBaseline("run-1", RUN_ID));
 });
 
 test("assertRunIdBaseline rejects a 40-hex git SHA, upper or lower case", () => {
   const sha = "a".repeat(40);
   assert.throws(
-    () => assertRunIdBaseline(sha),
+    () => assertRunIdBaseline(sha, RUN_ID),
     /SHA baselines are not supported yet/,
   );
   assert.throws(
-    () => assertRunIdBaseline(sha.toUpperCase()),
+    () => assertRunIdBaseline(sha.toUpperCase(), RUN_ID),
     /SHA baselines are not supported yet/,
   );
   // One character short or long is not the SHA shape — a real run id could
   // plausibly look like this, so it must NOT be rejected.
-  assert.doesNotThrow(() => assertRunIdBaseline("a".repeat(39)));
-  assert.doesNotThrow(() => assertRunIdBaseline("a".repeat(41)));
+  assert.doesNotThrow(() => assertRunIdBaseline("a".repeat(39), RUN_ID));
+  assert.doesNotThrow(() => assertRunIdBaseline("a".repeat(41), RUN_ID));
   // Not all-hex: also not the SHA shape.
-  assert.doesNotThrow(() => assertRunIdBaseline("g".repeat(40)));
+  assert.doesNotThrow(() => assertRunIdBaseline("g".repeat(40), RUN_ID));
 });
 
 test("assertRunIdBaseline rejects a blank value, not just an absent one", () => {
@@ -327,11 +329,27 @@ test("assertRunIdBaseline rejects a blank value, not just an absent one", () => 
   // erroring, and the command would exit 0 on nothing the caller asked for.
   for (const blank of ["", "   ", "\t"]) {
     assert.throws(
-      () => assertRunIdBaseline(blank),
+      () => assertRunIdBaseline(blank, RUN_ID),
       /must not be blank/,
       JSON.stringify(blank),
     );
   }
+});
+
+test("assertRunIdBaseline rejects using the gated run as its own baseline", () => {
+  // A run compared against itself has identical samples on both sides: the
+  // pass-rate delta is zero and no deterministic scorer flips, so the
+  // comparative gate would report a clean "no regression" — not because
+  // nothing regressed, but because no independent baseline was ever
+  // consulted. A CI script that wires the same "latest run" variable into
+  // both --run and --baseline (a plausible copy-paste) must not get a green
+  // regression gate that validated nothing.
+  assert.throws(
+    () => assertRunIdBaseline(RUN_ID, RUN_ID),
+    /cannot be its own baseline/,
+  );
+  // A DIFFERENT run id is fine, even one that merely looks similar.
+  assert.doesNotThrow(() => assertRunIdBaseline(`${RUN_ID}-2`, RUN_ID));
 });
 
 test("assertRunIdBaseline rejects a whitespace-padded SHA, not just a bare one", () => {
@@ -340,7 +358,7 @@ test("assertRunIdBaseline rejects a whitespace-padded SHA, not just a bare one",
   // proved trimming doesn't change what the flag means.
   const padded = `  ${"a".repeat(40)}  `;
   assert.throws(
-    () => assertRunIdBaseline(padded),
+    () => assertRunIdBaseline(padded, RUN_ID),
     /SHA baselines are not supported yet/,
   );
 });

--- a/cli/tests/eval-gate.test.ts
+++ b/cli/tests/eval-gate.test.ts
@@ -8,11 +8,17 @@ import {
   isNonVerdictRunStatus,
 } from "../src/lib/eval-gate-exit-code.js";
 import {
+  assertRunIdBaseline,
+  buildBaselineProvenance,
+  comparePolicyFromGateOptions,
+  evaluateBaselineComparison,
+  mergeGateReports,
   policyFromOptions,
   policyNeedsIterations,
   reportForRun,
 } from "../src/lib/eval-gate.js";
 import type { GateReport } from "@mcpjam/sdk";
+import type { PlatformRunCompare } from "@mcpjam/sdk/platform";
 
 function report(outcome: GateReport["outcome"]): GateReport {
   return { outcome, verdicts: [], scoreIntegrity: "unknown" };
@@ -285,4 +291,305 @@ test("the gate keeps exactly four exit codes under verdict policy 2", () => {
     ),
   );
   assert.deepEqual([...codes].sort(), [0, 1, 2, 3]);
+});
+
+// ── --baseline (runId half) ─────────────────────────────────────────────────
+
+test("assertRunIdBaseline accepts an ordinary run id", () => {
+  assert.doesNotThrow(() => assertRunIdBaseline("run_abc123"));
+  assert.doesNotThrow(() => assertRunIdBaseline("run-1"));
+});
+
+test("assertRunIdBaseline rejects a 40-hex git SHA, upper or lower case", () => {
+  const sha = "a".repeat(40);
+  assert.throws(
+    () => assertRunIdBaseline(sha),
+    /SHA baselines are not supported yet/,
+  );
+  assert.throws(
+    () => assertRunIdBaseline(sha.toUpperCase()),
+    /SHA baselines are not supported yet/,
+  );
+  // One character short or long is not the SHA shape — a real run id could
+  // plausibly look like this, so it must NOT be rejected.
+  assert.doesNotThrow(() => assertRunIdBaseline("a".repeat(39)));
+  assert.doesNotThrow(() => assertRunIdBaseline("a".repeat(41)));
+  // Not all-hex: also not the SHA shape.
+  assert.doesNotThrow(() => assertRunIdBaseline("g".repeat(40)));
+});
+
+test("comparePolicyFromGateOptions: --baseline alone implies regression gating", () => {
+  // No `--gate-regressions` flag exists on `eval gate` — `--baseline` itself
+  // enables the pass-rate regression gate with the SDK's defaults.
+  const policy = comparePolicyFromGateOptions({ baseline: "run_1" });
+  assert.deepEqual(policy.passRateRegression, {});
+});
+
+test("comparePolicyFromGateOptions: no --baseline produces an empty policy", () => {
+  assert.deepEqual(comparePolicyFromGateOptions({}), {});
+});
+
+test("comparePolicyFromGateOptions: every comparative flag requires --baseline", () => {
+  for (const options of [
+    { minSampleSize: "10" },
+    { minEffectSizePercent: "5" },
+    { gateDeterministicRegressions: true },
+    { maxP95LatencyIncreaseMs: "100" },
+  ]) {
+    assert.throws(
+      () => comparePolicyFromGateOptions(options),
+      /pass --baseline/,
+      JSON.stringify(options),
+    );
+  }
+});
+
+test("comparePolicyFromGateOptions: tuning flags apply once --baseline is set", () => {
+  const policy = comparePolicyFromGateOptions({
+    baseline: "run_1",
+    minSampleSize: "10",
+    minEffectSizePercent: "1",
+    gateDeterministicRegressions: true,
+    maxP95LatencyIncreaseMs: "250",
+  });
+  assert.equal(policy.passRateRegression?.minSampleSize, 10);
+  // Percent -> fraction at the boundary, same conversion `eval compare` uses.
+  assert.equal(policy.passRateRegression?.minEffectSize, 0.01);
+  assert.equal(policy.noDeterministicRegressions, true);
+  assert.equal(policy.maximumP95LatencyIncreaseMs, 250);
+});
+
+function gateReport(
+  outcome: GateReport["outcome"],
+  verdicts: GateReport["verdicts"] = [],
+): GateReport {
+  return { outcome, verdicts, scoreIntegrity: "unknown" };
+}
+
+test("mergeGateReports: outcome follows usage_error > failed > incomplete > passed", () => {
+  const cases: Array<
+    [GateReport["outcome"], GateReport["outcome"], GateReport["outcome"]]
+  > = [
+    ["passed", "passed", "passed"],
+    ["failed", "passed", "failed"],
+    ["passed", "failed", "failed"],
+    ["passed", "incomplete", "incomplete"],
+    ["failed", "incomplete", "failed"],
+    ["incomplete", "failed", "failed"],
+    ["usage_error", "failed", "usage_error"],
+    ["failed", "usage_error", "usage_error"],
+  ];
+  for (const [threshold, comparative, expected] of cases) {
+    assert.equal(
+      mergeGateReports(gateReport(threshold), gateReport(comparative)).outcome,
+      expected,
+      `${threshold} + ${comparative}`,
+    );
+  }
+});
+
+test("mergeGateReports: every verdict from both halves survives, neither buries the other", () => {
+  const threshold = gateReport("failed", [
+    { gate: "minimumPassRate", status: "failed", message: "1/2 passed" },
+  ]);
+  const comparative = gateReport("failed", [
+    { gate: "passRateRegression", status: "failed", message: "regressed" },
+  ]);
+  const merged = mergeGateReports(threshold, comparative);
+  assert.deepEqual(
+    merged.verdicts.map((v) => v.gate),
+    ["minimumPassRate", "passRateRegression"],
+  );
+});
+
+test("mergeGateReports: scoreIntegrity carries the RUN's own value, not the comparison's", () => {
+  const threshold = gateReport("passed");
+  const merged = mergeGateReports(
+    { ...threshold, scoreIntegrity: "valid" },
+    { ...gateReport("passed"), scoreIntegrity: "invalid" },
+  );
+  assert.equal(merged.scoreIntegrity, "valid");
+});
+
+const ZERO_DIFF = {
+  base: null,
+  compare: null,
+  delta: null,
+  percentDelta: null,
+};
+
+function compareWire(
+  overrides: Partial<PlatformRunCompare> = {},
+): PlatformRunCompare {
+  return {
+    suite: { id: "s1", name: "Suite" },
+    baseline: { policy: "run", baseRunId: "run_base" },
+    baseRun: {
+      id: "run_base",
+      runNumber: 1,
+      result: "passed",
+      createdAt: 1,
+      completedAt: 2,
+      summary: { total: 70, passed: 56, failed: 14, passRate: 0.8 },
+    },
+    compareRun: {
+      id: "run_compare",
+      runNumber: 2,
+      result: "failed",
+      createdAt: 3,
+      completedAt: 4,
+      summary: { total: 80, passed: 48, failed: 32, passRate: 0.6 },
+    },
+    passSummary: {
+      passRatePercent: ZERO_DIFF,
+      total: ZERO_DIFF,
+      passed: ZERO_DIFF,
+      failed: ZERO_DIFF,
+    },
+    metrics: {
+      wallDurationMs: ZERO_DIFF,
+      totalTokens: ZERO_DIFF,
+      estimatedCostUsd: ZERO_DIFF,
+    },
+    scoreContract: {
+      base: {
+        evaluationConfigHash: "cfg",
+        scoreIntegrity: "valid",
+        scoredIterations: 70,
+        quarantinedIterations: 0,
+      },
+      compare: {
+        evaluationConfigHash: "cfg",
+        scoreIntegrity: "valid",
+        scoredIterations: 80,
+        quarantinedIterations: 0,
+      },
+      evaluationConfigChanged: false,
+      scorers: [],
+    },
+    cases: [
+      {
+        caseKey: "ck_a",
+        title: "Case A",
+        status: "unchanged_passed",
+        configChanged: false,
+        evaluationConfigChanged: false,
+        scoreDeltas: [],
+        base: {
+          outcome: "passed",
+          iterationIds: ["b1"],
+          representativeIterationId: "b1",
+          error: null,
+        },
+        compare: {
+          outcome: "passed",
+          iterationIds: ["c1"],
+          representativeIterationId: "c1",
+          error: null,
+        },
+      },
+    ],
+    ...overrides,
+  };
+}
+
+/** Minimal `PlatformApiClient` slice `evaluateBaselineComparison` needs. */
+function stubClient(
+  compare:
+    | PlatformRunCompare
+    | (() => Promise<PlatformRunCompare>)
+    | { reject: unknown },
+) {
+  return {
+    async compareEvalRun() {
+      if (typeof compare === "function") return compare();
+      if ("reject" in compare) throw compare.reject;
+      return compare;
+    },
+    async listEvalRunIterations() {
+      return { items: [], nextCursor: undefined };
+    },
+  };
+}
+
+test("evaluateBaselineComparison: a real regression evaluates and carries provenance", async () => {
+  const result = await evaluateBaselineComparison({
+    client: stubClient(compareWire()) as never,
+    signal: new AbortController().signal,
+    projectId: "proj-alpha",
+    runId: "run_compare",
+    baseline: "run_base",
+    policy: { passRateRegression: {} },
+  });
+  assert.equal(result.report.outcome, "failed");
+  assert.equal(result.provenance?.baseRunId, "run_base");
+  assert.equal(result.provenance?.compareRunId, "run_compare");
+  const notRecorded = result.provenance?.notRecorded as Record<string, string>;
+  assert.equal(notRecorded.modelProvider, "notRecorded");
+  assert.equal(notRecorded.hostHarness, "notRecorded");
+  assert.equal(notRecorded.serverEnvironmentIdentity, "notRecorded");
+  assert.equal(notRecorded.configHashesBeyondEvaluationConfigHash, "notRecorded");
+});
+
+test("evaluateBaselineComparison: BASELINE_NOT_FOUND folds to incomplete, never failed", async () => {
+  const result = await evaluateBaselineComparison({
+    client: stubClient({
+      reject: Object.assign(new Error("no baseline"), {
+        details: { reason: "BASELINE_NOT_FOUND" },
+      }),
+    }) as never,
+    signal: new AbortController().signal,
+    projectId: "proj-alpha",
+    runId: "run_compare",
+    baseline: "run_base",
+    policy: { passRateRegression: {} },
+  });
+  assert.equal(result.report.outcome, "incomplete");
+  assert.equal(result.report.verdicts[0]?.gate, "baseline");
+  assert.match(result.report.verdicts[0]?.message ?? "", /no baseline to compare against/);
+  assert.equal(result.provenance, undefined);
+});
+
+test("evaluateBaselineComparison: an unfinished side is incomplete, defence in depth", async () => {
+  const result = await evaluateBaselineComparison({
+    client: stubClient(
+      compareWire({
+        compareRun: { ...compareWire().compareRun, completedAt: null },
+      }),
+    ) as never,
+    signal: new AbortController().signal,
+    projectId: "proj-alpha",
+    runId: "run_compare",
+    baseline: "run_base",
+    policy: { passRateRegression: {} },
+  });
+  assert.equal(result.report.outcome, "incomplete");
+  assert.match(
+    result.report.verdicts[0]?.message ?? "",
+    /must be completed before they can be compared/,
+  );
+});
+
+test("buildBaselineProvenance: records every evaluated compatibility signal", () => {
+  const compare = compareWire();
+  const input = {
+    base: { iterations: { total: 70, passed: 56 } },
+    compare: { iterations: { total: 80, passed: 48 } },
+    deterministicScoreRegressions: [],
+    scoreDeltasAvailable: false,
+    caseSetChanged: true,
+    scenarioConfigChanged: false,
+    evaluationConfigChanged: true,
+    iterationWeightingEqual: false,
+  };
+  const provenance = buildBaselineProvenance("run_base", compare, input);
+  assert.deepEqual(provenance.baseline, compare.baseline);
+  assert.deepEqual(provenance.compatibility, {
+    caseSetChanged: true,
+    scenarioConfigChanged: false,
+    evaluationConfigChanged: true,
+    iterationWeightingEqual: false,
+    baseScoreIntegrity: "valid",
+    compareScoreIntegrity: "valid",
+  });
 });

--- a/cli/tests/eval.test.ts
+++ b/cli/tests/eval.test.ts
@@ -949,11 +949,25 @@ async function startEvalFixture(options: EvalFixtureOptions = {}): Promise<{
       }
       const cmp = options.compare ?? {};
       const baseRunId = url.searchParams.get("baseRunId") ?? "run-baseline";
+      // These defaults are the SAME oracle-pinned 56/70 -> 48/80 regression
+      // `eval-compare-exit-code.test.ts` checks against statsmodels, reused
+      // here rather than re-derived. They deliberately do NOT track run-1's
+      // own (tiny, 1-2 iteration) `/eval-runs/run-1` summary: the code under
+      // test never cross-checks the two summaries against each other — one
+      // feeds `reportForRun`'s threshold gate, the other feeds
+      // `evaluateBaselineComparison`'s comparative gate — and collapsing them
+      // to the same small sample would make every baseline test below
+      // "insufficient_data" instead of exercising a real regression.
       const baseTotal = cmp.baseTotal ?? 70;
       const compareTotal = cmp.compareTotal ?? 80;
       const basePassed = cmp.basePassed ?? 56;
       const comparePassed = cmp.comparePassed ?? 48;
-      const zero = { base: null, compare: null, delta: null, percentDelta: null };
+      const zero = {
+        base: null,
+        compare: null,
+        delta: null,
+        percentDelta: null,
+      };
       const caseSide = (iterationId: string) => ({
         outcome: "passed" as const,
         iterationIds: [iterationId],

--- a/cli/tests/eval.test.ts
+++ b/cli/tests/eval.test.ts
@@ -202,6 +202,8 @@ interface EvalFixtureOptions {
   runCaseStatus?: "running" | "completed";
   runCaseIterationFetchError?: boolean;
   runOneResult?: "passed" | "failed" | "inconclusive";
+  /** Makes `GET /eval-runs/run-1/iterations` answer 500. */
+  runOneIterationFetchError?: boolean;
   /** Makes the run-disclosure endpoint answer 422 contract_unavailable. */
   disclosureUnavailable?: boolean;
   /**
@@ -894,6 +896,16 @@ async function startEvalFixture(options: EvalFixtureOptions = {}): Promise<{
         "/api/v1/projects/proj-alpha/eval-runs/run-1/iterations" &&
       (req.method ?? "GET") === "GET"
     ) {
+      if (options.runOneIterationFetchError) {
+        res.statusCode = 500;
+        res.end(
+          JSON.stringify({
+            code: "ITERATIONS_FETCH_FAILED",
+            message: "iteration results unavailable",
+          }),
+        );
+        return;
+      }
       const result = options.runOneResult ?? "passed";
       res.end(
         JSON.stringify({
@@ -2714,6 +2726,56 @@ test("eval gate --baseline exits 1 on a statistically significant regression", a
       (v: { gate: string }) => v.gate === "passRateRegression",
     );
     assert.equal(regression?.status, "failed");
+  } finally {
+    await fixture.close();
+  }
+});
+
+test("eval gate --baseline still evaluates the comparison when the run's own iterations fail to fetch", async () => {
+  // `--out` forces the iteration fetch for `run-1` itself (needed for the
+  // report), and that fetch fails. `/compare` is a SEPARATE request that
+  // does not depend on those iterations — the regression it finds must still
+  // reach exit 1, not be silently downgraded to exit 3 by an unrelated fetch
+  // hiccup on the other half of the report.
+  const fixture = await startEvalFixture({ runOneIterationFetchError: true });
+  const directory = await mkdtemp(
+    path.join(os.tmpdir(), "mcpjam-eval-gate-baseline-fetch-error-"),
+  );
+  const reportPath = path.join(directory, "report.json");
+  try {
+    const run = await captureProcessOutput(() =>
+      main(
+        evalArgv(
+          fixture.baseUrl,
+          "gate",
+          "--project",
+          "proj-alpha",
+          "--run",
+          "run-1",
+          "--wait",
+          "--baseline",
+          "run-baseline",
+          "--reporter",
+          "json-summary",
+          "--out",
+          reportPath,
+        ),
+        { telemetry: telemetryDisabled },
+      ),
+    );
+    assert.equal(run.result.exitCode, 1, run.stderr);
+    const report = JSON.parse(await readFile(reportPath, "utf8"));
+    const gateCase = report.cases.find((c: { id: string }) => c.id === "gate");
+    const gates = gateCase.details.verdicts.map(
+      (v: { gate: string }) => v.gate,
+    );
+    // Both survive: the local fetch failure AND the real regression.
+    assert.ok(gates.includes("fetch"));
+    assert.ok(gates.includes("passRateRegression"));
+    const regression = gateCase.details.verdicts.find(
+      (v: { gate: string }) => v.gate === "passRateRegression",
+    );
+    assert.equal(regression.status, "failed");
   } finally {
     await fixture.close();
   }

--- a/cli/tests/eval.test.ts
+++ b/cli/tests/eval.test.ts
@@ -2589,6 +2589,34 @@ test("eval gate rejects a SHA-shaped --baseline before any request", async () =>
   }
 });
 
+test("eval gate rejects a blank --baseline, e.g. an unset CI variable interpolated into the flag", async () => {
+  const fixture = await startEvalFixture();
+  try {
+    const run = await captureProcessOutput(() =>
+      main(
+        evalArgv(
+          fixture.baseUrl,
+          "gate",
+          "--project",
+          "proj-alpha",
+          "--run",
+          "run-1",
+          "--baseline",
+          "",
+        ),
+        { telemetry: telemetryDisabled },
+      ),
+    );
+    assert.equal(run.result.exitCode, 2);
+    assert.match(run.stderr, /must not be blank/);
+    // A usage error caught before parsing must never spend a request, and
+    // MUST NOT silently fall through to a threshold-only, exit-0 gate.
+    assert.equal(fixture.authHeaders.length, 0);
+  } finally {
+    await fixture.close();
+  }
+});
+
 test("eval gate rejects a comparative tuning flag without --baseline", async () => {
   const fixture = await startEvalFixture();
   try {

--- a/cli/tests/eval.test.ts
+++ b/cli/tests/eval.test.ts
@@ -2914,6 +2914,47 @@ test("eval gate --baseline writes provenance into the JSON report, notRecorded i
   }
 });
 
+test("eval gate --baseline sends the TRIMMED value on the wire, not the padded one", async () => {
+  // Validation checks the trimmed value; if the raw one were forwarded
+  // instead, `baseRunId` on the wire (and so the provenance echoed back)
+  // would still carry the padding — observable proof of the bug even though
+  // this fixture's mock backend does not itself reject an unknown run id.
+  const fixture = await startEvalFixture();
+  const directory = await mkdtemp(
+    path.join(os.tmpdir(), "mcpjam-eval-gate-baseline-trim-"),
+  );
+  const reportPath = path.join(directory, "report.json");
+  try {
+    const run = await captureProcessOutput(() =>
+      main(
+        evalArgv(
+          fixture.baseUrl,
+          "gate",
+          "--project",
+          "proj-alpha",
+          "--run",
+          "run-1",
+          "--wait",
+          "--baseline",
+          "  run-baseline  ",
+          "--reporter",
+          "json-summary",
+          "--out",
+          reportPath,
+        ),
+        { telemetry: telemetryDisabled },
+      ),
+    );
+    assert.equal(run.result.exitCode, 1);
+    const report = JSON.parse(await readFile(reportPath, "utf8"));
+    const provenance = report.metadata.baselineComparison;
+    assert.equal(provenance.requestedBaseline, "run-baseline");
+    assert.equal(provenance.baseRunId, "run-baseline");
+  } finally {
+    await fixture.close();
+  }
+});
+
 test("eval gate --baseline exits 3 when the case set changed, not 1", async () => {
   // Same regressed pass-rate numbers as the exit-1 test above, but the case
   // set churned — the population rule makes the whole-run rate incomparable,

--- a/cli/tests/eval.test.ts
+++ b/cli/tests/eval.test.ts
@@ -2643,6 +2643,32 @@ test("eval gate rejects a blank --baseline, e.g. an unset CI variable interpolat
   }
 });
 
+test("eval gate rejects using the gated run as its own baseline", async () => {
+  const fixture = await startEvalFixture();
+  try {
+    const run = await captureProcessOutput(() =>
+      main(
+        evalArgv(
+          fixture.baseUrl,
+          "gate",
+          "--project",
+          "proj-alpha",
+          "--run",
+          "run-1",
+          "--baseline",
+          "run-1",
+        ),
+        { telemetry: telemetryDisabled },
+      ),
+    );
+    assert.equal(run.result.exitCode, 2);
+    assert.match(run.stderr, /cannot be its own baseline/);
+    assert.equal(fixture.authHeaders.length, 0);
+  } finally {
+    await fixture.close();
+  }
+});
+
 test("eval gate rejects a comparative tuning flag without --baseline", async () => {
   const fixture = await startEvalFixture();
   try {

--- a/cli/tests/eval.test.ts
+++ b/cli/tests/eval.test.ts
@@ -2865,6 +2865,9 @@ test("eval gate --baseline writes provenance into the JSON report, notRecorded i
     assert.equal(provenance.baseRunId, "run-baseline");
     assert.equal(provenance.compareRunId, "run-1");
     assert.equal(provenance.compatibility.caseSetChanged, false);
+    // The pin names "comparable case ids" explicitly — not just the boolean.
+    assert.deepEqual(provenance.compatibility.comparableCaseIds, ["ck_a"]);
+    assert.deepEqual(provenance.compatibility.incompatibleCases, []);
     // Dimensions the pinned contract requires but the `/compare` wire does not
     // carry yet must be explicit, never silently dropped.
     assert.equal(provenance.notRecorded.modelProvider, "notRecorded");

--- a/cli/tests/eval.test.ts
+++ b/cli/tests/eval.test.ts
@@ -204,6 +204,20 @@ interface EvalFixtureOptions {
   runOneResult?: "passed" | "failed" | "inconclusive";
   /** Makes the run-disclosure endpoint answer 422 contract_unavailable. */
   disclosureUnavailable?: boolean;
+  /**
+   * Drives `GET /eval-runs/run-1/compare` for `eval gate --baseline` /
+   * `eval compare` tests. Absent means the endpoint is never hit.
+   */
+  compare?: {
+    /** 404 with `details.reason: "BASELINE_NOT_FOUND"`, no baseline resolves. */
+    notFound?: boolean;
+    basePassed?: number;
+    baseTotal?: number;
+    comparePassed?: number;
+    compareTotal?: number;
+    /** Adds a `new_case` row, breaking the population rule. */
+    caseSetChanged?: boolean;
+  };
 }
 
 async function startEvalFixture(options: EvalFixtureOptions = {}): Promise<{
@@ -902,6 +916,135 @@ async function startEvalFixture(options: EvalFixtureOptions = {}): Promise<{
               error: result === "failed" ? "goal completion failed" : null,
             },
           ],
+        }),
+      );
+      return;
+    }
+    if (
+      url.pathname === "/api/v1/projects/proj-alpha/eval-runs/run-1/compare" &&
+      (req.method ?? "GET") === "GET"
+    ) {
+      if (options.compare?.notFound) {
+        res.statusCode = 404;
+        res.end(
+          JSON.stringify({
+            code: "NOT_FOUND",
+            message: "no baseline resolves for this run",
+            details: { reason: "BASELINE_NOT_FOUND" },
+          }),
+        );
+        return;
+      }
+      const cmp = options.compare ?? {};
+      const baseRunId = url.searchParams.get("baseRunId") ?? "run-baseline";
+      const baseTotal = cmp.baseTotal ?? 70;
+      const compareTotal = cmp.compareTotal ?? 80;
+      const basePassed = cmp.basePassed ?? 56;
+      const comparePassed = cmp.comparePassed ?? 48;
+      const zero = { base: null, compare: null, delta: null, percentDelta: null };
+      const caseSide = (iterationId: string) => ({
+        outcome: "passed" as const,
+        iterationIds: [iterationId],
+        representativeIterationId: iterationId,
+        error: null,
+      });
+      res.end(
+        JSON.stringify({
+          suite: { id: "suite-1", name: "Smoke" },
+          baseline: { policy: "run", baseRunId },
+          baseRun: {
+            id: baseRunId,
+            runNumber: 2,
+            result: "passed",
+            createdAt: 1,
+            completedAt: 2,
+            summary: {
+              total: baseTotal,
+              passed: basePassed,
+              failed: baseTotal - basePassed,
+              passRate: basePassed / baseTotal,
+            },
+          },
+          compareRun: {
+            id: "run-1",
+            runNumber: 3,
+            result: comparePassed === compareTotal ? "passed" : "failed",
+            createdAt: 3,
+            completedAt: 4,
+            summary: {
+              total: compareTotal,
+              passed: comparePassed,
+              failed: compareTotal - comparePassed,
+              passRate: comparePassed / compareTotal,
+            },
+          },
+          passSummary: {
+            passRatePercent: zero,
+            total: zero,
+            passed: zero,
+            failed: zero,
+          },
+          metrics: {
+            wallDurationMs: zero,
+            totalTokens: zero,
+            estimatedCostUsd: zero,
+          },
+          scoreContract: {
+            base: {
+              evaluationConfigHash: "cfg",
+              scoreIntegrity: "valid",
+              scoredIterations: baseTotal,
+              quarantinedIterations: 0,
+            },
+            compare: {
+              evaluationConfigHash: "cfg",
+              scoreIntegrity: "valid",
+              scoredIterations: compareTotal,
+              quarantinedIterations: 0,
+            },
+            evaluationConfigChanged: false,
+            scorers: [],
+          },
+          cases: cmp.caseSetChanged
+            ? [
+                {
+                  caseKey: "ck_a",
+                  title: "Case A",
+                  status: "unchanged_passed",
+                  configChanged: false,
+                  evaluationConfigChanged: false,
+                  scoreDeltas: [],
+                  base: caseSide("b1"),
+                  compare: caseSide("c1"),
+                },
+                {
+                  caseKey: "ck_new",
+                  title: "Case New",
+                  status: "new_case",
+                  configChanged: false,
+                  evaluationConfigChanged: false,
+                  scoreDeltas: [],
+                  base: {
+                    outcome: "absent",
+                    iterationIds: [],
+                    representativeIterationId: null,
+                    error: null,
+                  },
+                  compare: caseSide("c2"),
+                },
+              ]
+            : [
+                {
+                  caseKey: "ck_a",
+                  title: "Case A",
+                  status: "unchanged_passed",
+                  configChanged: false,
+                  evaluationConfigChanged: false,
+                  scoreDeltas: [],
+                  base: caseSide("b1"),
+                  compare: caseSide("c1"),
+                },
+              ],
         }),
       );
       return;
@@ -2412,6 +2555,265 @@ test("eval gate writes its JUnit report before a gate-failure exit", async () =>
     assert.match(junit, /^<\?xml version="1\.0" encoding="UTF-8"\?>/);
     assert.match(junit, /<failure message="1\/2 iterations passed"/);
     assert.match(junit, /goal completion failed/);
+  } finally {
+    await fixture.close();
+  }
+});
+
+// ── eval gate --baseline ────────────────────────────────────────────────────
+
+test("eval gate rejects a SHA-shaped --baseline before any request", async () => {
+  const fixture = await startEvalFixture();
+  try {
+    const run = await captureProcessOutput(() =>
+      main(
+        evalArgv(
+          fixture.baseUrl,
+          "gate",
+          "--project",
+          "proj-alpha",
+          "--run",
+          "run-1",
+          "--baseline",
+          "a".repeat(40),
+        ),
+        { telemetry: telemetryDisabled },
+      ),
+    );
+    assert.equal(run.result.exitCode, 2);
+    assert.match(run.stderr, /SHA baselines are not supported yet/);
+    // A usage error caught before parsing must never spend a request.
+    assert.equal(fixture.authHeaders.length, 0);
+  } finally {
+    await fixture.close();
+  }
+});
+
+test("eval gate rejects a comparative tuning flag without --baseline", async () => {
+  const fixture = await startEvalFixture();
+  try {
+    const run = await captureProcessOutput(() =>
+      main(
+        evalArgv(
+          fixture.baseUrl,
+          "gate",
+          "--project",
+          "proj-alpha",
+          "--run",
+          "run-1",
+          "--min-sample-size",
+          "10",
+        ),
+        { telemetry: telemetryDisabled },
+      ),
+    );
+    assert.equal(run.result.exitCode, 2);
+    assert.match(run.stderr, /pass --baseline/);
+    assert.equal(fixture.authHeaders.length, 0);
+  } finally {
+    await fixture.close();
+  }
+});
+
+test("eval gate --baseline exits 3 when no baseline resolves", async () => {
+  const fixture = await startEvalFixture({ compare: { notFound: true } });
+  try {
+    const run = await captureProcessOutput(() =>
+      main(
+        [
+          ...evalArgv(
+            fixture.baseUrl,
+            "gate",
+            "--project",
+            "proj-alpha",
+            "--run",
+            "run-1",
+            "--wait",
+            "--baseline",
+            "run-baseline",
+          ),
+          "--format",
+          "json",
+        ],
+        { telemetry: telemetryDisabled },
+      ),
+    );
+    assert.equal(run.result.exitCode, 3);
+    const payload = JSON.parse(run.stdout);
+    assert.equal(payload.gate.outcome, "incomplete");
+    assert.match(
+      payload.gate.verdicts
+        .map((v: { message: string }) => v.message)
+        .join("; "),
+      /no baseline to compare against/,
+    );
+  } finally {
+    await fixture.close();
+  }
+});
+
+test("eval gate --baseline exits 1 on a statistically significant regression", async () => {
+  // `run-1` passes its own (absent) threshold trivially; the baseline's
+  // 56/70 -> 48/80 is the oracle-pinned regression from `eval-compare-exit-
+  // code.test.ts`, so the merged exit code comes ENTIRELY from the
+  // comparative half.
+  const fixture = await startEvalFixture();
+  try {
+    const run = await captureProcessOutput(() =>
+      main(
+        [
+          ...evalArgv(
+            fixture.baseUrl,
+            "gate",
+            "--project",
+            "proj-alpha",
+            "--run",
+            "run-1",
+            "--wait",
+            "--baseline",
+            "run-baseline",
+          ),
+          "--format",
+          "json",
+        ],
+        { telemetry: telemetryDisabled },
+      ),
+    );
+    assert.equal(run.result.exitCode, 1);
+    const payload = JSON.parse(run.stdout);
+    assert.equal(payload.gate.outcome, "failed");
+    const regression = payload.gate.verdicts.find(
+      (v: { gate: string }) => v.gate === "passRateRegression",
+    );
+    assert.equal(regression?.status, "failed");
+  } finally {
+    await fixture.close();
+  }
+});
+
+test("eval gate --baseline: a threshold miss and a baseline regression fold into one report", async () => {
+  const fixture = await startEvalFixture({ runOneResult: "failed" });
+  try {
+    const run = await captureProcessOutput(() =>
+      main(
+        [
+          ...evalArgv(
+            fixture.baseUrl,
+            "gate",
+            "--project",
+            "proj-alpha",
+            "--run",
+            "run-1",
+            "--wait",
+            "--min-pass-rate-percent",
+            "100",
+            "--baseline",
+            "run-baseline",
+          ),
+          "--format",
+          "json",
+        ],
+        { telemetry: telemetryDisabled },
+      ),
+    );
+    assert.equal(run.result.exitCode, 1);
+    const payload = JSON.parse(run.stdout);
+    const gates = payload.gate.verdicts.map((v: { gate: string }) => v.gate);
+    // Both families' verdicts survive the merge — neither buries the other.
+    assert.ok(gates.includes("minimumPassRate"));
+    assert.ok(gates.includes("passRateRegression"));
+  } finally {
+    await fixture.close();
+  }
+});
+
+test("eval gate --baseline writes provenance into the JSON report, notRecorded included", async () => {
+  const fixture = await startEvalFixture();
+  const directory = await mkdtemp(
+    path.join(os.tmpdir(), "mcpjam-eval-gate-baseline-")
+  );
+  const reportPath = path.join(directory, "report.json");
+  try {
+    const run = await captureProcessOutput(() =>
+      main(
+        evalArgv(
+          fixture.baseUrl,
+          "gate",
+          "--project",
+          "proj-alpha",
+          "--run",
+          "run-1",
+          "--wait",
+          "--baseline",
+          "run-baseline",
+          "--reporter",
+          "json-summary",
+          "--out",
+          reportPath,
+        ),
+        { telemetry: telemetryDisabled },
+      ),
+    );
+    assert.equal(run.result.exitCode, 1);
+    const report = JSON.parse(await readFile(reportPath, "utf8"));
+    const provenance = report.metadata.baselineComparison;
+    assert.equal(provenance.requestedBaseline, "run-baseline");
+    assert.equal(provenance.baseRunId, "run-baseline");
+    assert.equal(provenance.compareRunId, "run-1");
+    assert.equal(provenance.compatibility.caseSetChanged, false);
+    // Dimensions the pinned contract requires but the `/compare` wire does not
+    // carry yet must be explicit, never silently dropped.
+    assert.equal(provenance.notRecorded.modelProvider, "notRecorded");
+    assert.equal(provenance.notRecorded.hostHarness, "notRecorded");
+    assert.equal(
+      provenance.notRecorded.serverEnvironmentIdentity,
+      "notRecorded"
+    );
+    // The same provenance rides on the "gate" case row, so `--reporter
+    // junit-xml` (which has no metadata section) still carries it.
+    const gateCase = report.cases.find((c: { id: string }) => c.id === "gate");
+    assert.equal(
+      gateCase.details.baseline.notRecorded.modelProvider,
+      "notRecorded"
+    );
+  } finally {
+    await fixture.close();
+  }
+});
+
+test("eval gate --baseline exits 3 when the case set changed, not 1", async () => {
+  // Same regressed pass-rate numbers as the exit-1 test above, but the case
+  // set churned — the population rule makes the whole-run rate incomparable,
+  // and that must never read as a regression.
+  const fixture = await startEvalFixture({ compare: { caseSetChanged: true } });
+  try {
+    const run = await captureProcessOutput(() =>
+      main(
+        [
+          ...evalArgv(
+            fixture.baseUrl,
+            "gate",
+            "--project",
+            "proj-alpha",
+            "--run",
+            "run-1",
+            "--wait",
+            "--baseline",
+            "run-baseline",
+          ),
+          "--format",
+          "json",
+        ],
+        { telemetry: telemetryDisabled },
+      ),
+    );
+    assert.equal(run.result.exitCode, 3);
+    const payload = JSON.parse(run.stdout);
+    assert.equal(payload.gate.outcome, "incomplete");
+    const regression = payload.gate.verdicts.find(
+      (v: { gate: string }) => v.gate === "passRateRegression",
+    );
+    assert.equal(regression?.status, "non_gateable");
   } finally {
     await fixture.close();
   }

--- a/docs/cli/reference.mdx
+++ b/docs/cli/reference.mdx
@@ -1184,6 +1184,11 @@ run before evaluating it.
 | `--no-gating-score-errors` | No | Fail if any gating scorer errored |
 | `--min-scorer-pass-rate <scorerId=percent>` | No | Minimum pass rate for one scorer; repeatable |
 | `--min-mean-score <scorerId=0..1>` | No | Minimum mean score for one scorer; repeatable |
+| `--baseline <runId>` | No | Baseline run ID to gate a regression delta against, in addition to any threshold flags above. SHA baselines are not supported yet — pass a run id |
+| `--min-sample-size <n>` | No | Iterations required on **each** side before a pass-rate regression is decidable (default 5); requires `--baseline` |
+| `--min-effect-size-percent <0-100>` | No | Smallest pass-rate drop worth failing on, as a percentage (default 1); requires `--baseline` |
+| `--gate-deterministic-regressions` | No | Fail if a deterministic gating scorer flipped from passed to failed; requires `--baseline` |
+| `--max-p95-latency-increase-ms <ms>` | No | Fail if p95 end-to-end latency rose by more than this many milliseconds vs the baseline; requires `--baseline` |
 | `--wait` | No | Poll until the run reaches a terminal status |
 | `--wait-timeout <ms>` | No | Maximum wait time (default 600000) |
 | `--reporter <json-summary\|junit-xml>` | No | Write the structured eval and gate report to stdout |
@@ -1191,6 +1196,18 @@ run before evaluating it.
 
 Report files are flushed before gate exit codes are set, including failed and
 incomplete gate outcomes.
+
+**`--baseline`.** Passing a run ID fetches the same run comparison
+`cloud eval compare` uses and folds a regression verdict into the same report
+and exit code as the threshold flags above — `--baseline` alone enables the
+pass-rate regression gate with its default tuning; the four tuning flags need
+`--baseline` to mean anything and are a usage error without it. A case set
+that changed, was added or removed, or ran an unequal iteration count between
+the two runs makes the whole-run pass-rate and p95-latency gates
+non-gateable (exit `3`) rather than a silent pass or a misread regression;
+the deterministic per-case regression gate is exempt and can still fail
+(exit `1`) on a matching case. SHA baselines (`--baseline <sha>`) are not
+supported yet and are rejected as a usage error.
 
 **Exit codes.** `eval gate` is the command that fails a build, so it is the one
 that maps a verdict onto an exit code. It keeps four:


### PR DESCRIPTION
## Summary

Step **E4a** of Evals v2 Lane E (CLI CI): the `runId` half of `eval gate --baseline <runId|sha>`. SHA resolution is a separate follow-up (E4b), gated on a backend index that does not exist yet — rejected here with a usage error naming that follow-up.

This is wiring, not new machinery — it reuses the existing compare stack (`compareGateInputFrom`, `evaluateCompareGates`, `compareEvalRun`) and the existing gate engine (`evaluateGates`, `COMPARATIVE_GATE_FIELDS`) rather than rebuilding either.

- `eval gate` gains `--baseline <runId>` plus the comparative tuning flags `eval compare` already has: `--min-sample-size`, `--min-effect-size-percent`, `--gate-deterministic-regressions`, `--max-p95-latency-increase-ms`. `--baseline` itself implies regression gating (no separate `--gate-regressions` flag exists on this command). Every one of those tuning flags without `--baseline` is a usage error (exit 2), not a silent no-op — matching the fail-closed precedent `evaluateGates` already sets for the single-run comparative fields.
- A SHA-shaped `--baseline` (40 hex chars) is rejected with a usage error naming the E4b follow-up, verified before any network call.
- When `--baseline` is present, the threshold `GateReport` (from the existing absolute-threshold gates) and a comparative `GateReport` (from `evaluateCompareGates` against the `/compare` wire) are folded into **one** report using the existing outcome precedence (`usage_error > failed > incomplete > passed`) — one report, one exit code, verdicts from both families visible.
- `eval gate`'s **four-code contract is unchanged**: a baseline regression is exit 1; a comparability problem (changed/added/removed cases, unequal iteration weighting, a run-level config change) is `non_gateable` → exit 3, never misread as a regression; a missing baseline goes through the existing `BASELINE_NOT_FOUND` → incomplete → exit 3 path.
- The report (`--reporter`/`--out`) carries baseline provenance in both `buildEvalRunReport`'s `metadata` and the `gate` case's `details` (so `--reporter junit-xml`, which has no metadata section, still carries it): both run ids, the resolved baseline `{policy, baseRunId}`, and every compatibility signal actually evaluated (`caseSetChanged`, `scenarioConfigChanged`, `evaluationConfigChanged`, `iterationWeightingEqual`, both sides' `scoreIntegrity`).

### Provenance gaps (E4b / backend follow-ups)

The PINNED baseline-compatibility contract also asks for model/provider, host/harness, server/environment identity, and config hashes beyond `evaluationConfigHash`. The `/compare` wire does not carry any of these today, so they are recorded explicitly as `"notRecorded"` in the provenance object rather than silently omitted — a reader can tell "checked, and they matched" apart from "nobody looked". Note: `PlatformRunCompareSide` does carry optional `environment`/`effectiveModelId`/`modelSource` fields on each side, but nothing in the CLI evaluates comparability from them today and using them to fill these gaps would mean inventing new gate-evaluation logic beyond this step's scope — flagging for E4b/backend rather than guessing.

### Explicitly out of scope (per the brief)

- No stored/pinned baseline (`suite.baselineRunId`) — `--baseline` is a per-invocation flag, changes no stored state.
- No audit events — the pin's audit obligation attaches to changing a *stored* pin, which doesn't exist yet.
- No backend changes.
- No touching the four-code exit vocabulary or `eval run --wait`.

## Design notes

- `--baseline`'s comparative-flag usage-error check was generalized to cover **all four** comparative flags (not just the pass-rate tuning pair `--min-sample-size`/`--min-effect-size-percent` the brief calls out by name), since without `--baseline` there is no compare fetch at all — a `--gate-deterministic-regressions` or `--max-p95-latency-increase-ms` with no `--baseline` would otherwise be silently ignored, the exact failure mode `evaluateGates` already refuses to allow.
- `mergeGateReports`'s top-level `scoreIntegrity` carries the threshold report's own value (i.e. the run being gated's own integrity) rather than the comparison's combined integrity — the latter is recorded separately in the provenance's `compatibility` block, not lost.
- `p95Of` and `baselineNotFoundReason` were de-duplicated out of `commands/eval.ts` into `lib/eval-iterations.ts` and `lib/eval-gate.ts` respectively, since `eval gate --baseline` now needs both and previously they were private to `runEvalCompare`.

## Test plan

- [x] `npm run -w @mcpjam/cli test` — 958/958 pass (927 pre-existing + 31 new unit tests across `eval-gate.test.ts` + 7 new exit-code-matrix tests in the new `eval-gate-baseline-exit-code.test.ts` + 8 new end-to-end CLI tests in `eval.test.ts`, minus overlap already counted; see below for the exact breakdown)
  - `eval-gate.test.ts`: `assertRunIdBaseline`, `comparePolicyFromGateOptions`, `mergeGateReports`, `buildBaselineProvenance`, `evaluateBaselineComparison` (missing baseline, unfinished-side defence-in-depth, real regression + provenance)
  - `eval-gate-baseline-exit-code.test.ts` (new, mirrors `eval-compare-exit-code.test.ts`): baseline regression → 1, incompatible case set → 3 not 1, insufficient sample → 3, deterministic regression → 1, threshold+comparative both failing → merged single report exit 1, threshold passes/comparative non-gateable → 3, clean pass → 0
  - `eval.test.ts` (extended fixture with a `/compare` handler + a second/baseline run): SHA-shaped `--baseline` → usage error exit 2 before any request, tuning flag without `--baseline` → usage error exit 2 before any request, missing baseline → exit 3, regression → exit 1, threshold miss + baseline regression fold into one report, provenance in the JSON report with `notRecorded` fields, `--baseline` + `--reporter json-summary --out`, incompatible case set → exit 3
- [x] `npx vitest run` in `sdk/` — 6227 passed, 8 skipped, 0 failed (untouched by this PR; run per the brief's verification checklist)
- [x] `npm run -w @mcpjam/cli typecheck` and `npm run -w @mcpjam/sdk typecheck` — both clean
- [x] Non-vacuity: reverted `mergeGateReports`'s precedence (confirmed 6 exit-code-matrix tests + 1 unit test fail), reverted the `--baseline` wiring to a no-op (confirmed 5 of the 7 new e2e tests fail), reverted `assertRunIdBaseline`'s SHA check and `comparePolicyFromGateOptions`'s tuning guard (confirmed the corresponding unit + e2e tests fail) — then restored all four and re-confirmed green.
- [x] Prettier: this repo's `cli/` files are v2 with no local config and most already fail `prettier --check` on `main` (confirmed against `git show HEAD:<file>` for every touched file). I fixed every violation on lines I actually added or edited (a genuinely-new violation in `eval-iterations.ts`, two in `eval-gate.ts`, one in `eval.ts`, several long lines in `eval.test.ts`, and fully formatted the two files that are new in this PR) and left pre-existing violations on untouched lines alone.
- Not tested here (out of scope / no UI): nothing in `mcpjam-inspector/` was touched.

## Status Board row

```
| E4 | `eval gate --baseline <runId>`/`sha` gate | in-review | [#TBD](https://github.com/MCPJam/inspector/pull/TBD) | 2026-08-25 | E4a (runId half) shipped; SHA half is E4b, gated on a backend index. `/compare` wire carries no model/provider, host/harness, server/environment identity, or config hashes beyond evaluationConfigHash — recorded as notRecorded in gate provenance pending E4b/backend follow-up. |
```
(PR number will be filled in once this posts — see final report for the resolved link.)

---

🤖 Generated with [Claude Code](https://claude.ai/code)

https://claude.ai/code/session_01LAJZeUyJvtsyUdYiH3XUN9

---
_Generated by [Claude Code](https://claude.ai/code/session_01LAJZeUyJvtsyUdYiH3XUN9)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes CI gate semantics and exit-code paths for regression vs incomparable runs; mistakes could block or greenlight builds, though behavior mirrors existing `eval compare` and is heavily tested.
> 
> **Overview**
> **`eval gate`** can now compare the gated run to an earlier run via **`--baseline <runId>`**, reusing the same `/compare` path and comparative gate engine as **`eval compare`**, then **merging** threshold and regression verdicts into one **`GateReport`** with unchanged exit codes **0/1/2/3**.
> 
> **`--baseline`** turns on pass-rate regression gating by default; **`--min-sample-size`**, **`--min-effect-size-percent`**, **`--gate-deterministic-regressions`**, and **`--max-p95-latency-increase-ms`** require it or they error (exit **2**). Baseline validation is fail-closed: blank, same as **`--run`**, or 40-hex SHA shapes are rejected before network; the trimmed id is what hits the API. Missing baseline → incomplete (**3**); incompatible populations → whole-run gates **`non_gateable`** (**3**) while per-case deterministic regression can still fail (**1**). A failed iteration fetch only incompletes the threshold half; baseline comparison still runs.
> 
> Structured reports add **baseline provenance** (run ids, resolved policy, compatibility, comparable/incompatible cases, **`notRecorded`** for wire gaps) in metadata and on the gate case for JUnit. Logic lives in **`eval-gate.ts`**; **`p95Of`** / **`baselineNotFoundReason`** are shared from **`eval-iterations.ts`** / **`eval-gate.ts`**. Docs and tests cover merge precedence, exit matrix, and e2e CLI behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8b83fb0dd94a23834312b47247c5117ca8f480c7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds regression-delta gating to eval gate via `--baseline <runId>`, merging baseline comparison with threshold gates into one report and exit code. Previously only thresholds; now it can fail on regressions with unchanged 0/1/2/3 exits.

- Validation: require `--baseline` for comparative flags; reject blank values, SHA-shaped inputs, and `--baseline` equal to `--run`; trim and forward the normalized id; fail fast (exit 2) before any request.
- Merge and exits: merge comparative and threshold GateReports with precedence usage_error > failed > incomplete > passed. If local iteration fetch fails, mark only the threshold half incomplete and still run the baseline comparison; a regression exits 1. Missing baselines and comparability issues exit 3.
- Compatibility: whole-run pass-rate and p95 gates become non_gateable when the population or iteration weighting differs; the deterministic per-case gate joins by case key and can still fail. Latency compares per-iteration p95 and only runs with complete data.
- Reporting: include baseline provenance in metadata and on the `gate` case for `junit-xml`: requested baseline, run ids, resolved policy (defaults filled), compatibility signals, comparableCaseIds, and incompatibleCases with reasons (case_added/removed, scenario_config_changed, evaluation_config_changed, iteration_weighting_unequal). Record missing dimensions as "notRecorded".
- CLI: add `--baseline`, `--min-sample-size`, `--min-effect-size-percent`, `--gate-deterministic-regressions`, and `--max-p95-latency-increase-ms`; these flags require `--baseline`.

<sup>Written for commit 8b83fb0dd94a23834312b47247c5117ca8f480c7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/MCPJam/inspector/pull/4343?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

