### PR TITLE
ci(release): drop deploy-soundcheck from the release (~2.5m)

### DIFF
--- a/.github/workflows/deploy-soundcheck.yml
+++ b/.github/workflows/deploy-soundcheck.yml
@@ -9,8 +9,12 @@ on:
       - "package-lock.json"
       - ".github/workflows/deploy-soundcheck.yml"
   workflow_dispatch:
-  # Called from release.yml so a release redeploys Soundcheck after the
-  # inspector promote (same reasoning as deploy-slack-app.yml).
+  # Deliberately NOT called from release.yml. Soundcheck talks only to
+  # api.github.com — never to the inspector server — so it has no contract to
+  # keep behind the server deploy the way deploy-slack-app.yml does. A release
+  # still redeploys it: the version commit touches root package-lock.json,
+  # which is in the `paths` filter above. `workflow_call` is kept so it can be
+  # composed if that ever changes.
   workflow_call:
 
 concurrency:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -606,12 +606,21 @@ jobs:
       require_staging_green: false
     secrets: inherit
 
-  # The two Railway satellites. Their own workflows already redeploy on
-  # ordinary main pushes touching their paths; these jobs make a RELEASE
-  # redeploy them too, ordered AFTER the webapp deploy — both render the
-  # server's contract, so they must never ship ahead of it. A same-SHA
-  # push-triggered run may queue behind these (per-service concurrency
-  # groups, cancel-in-progress: false); the duplicate deploy is idempotent.
+  # The Slack bot renders the server's envelope, so a release redeploys it
+  # ordered AFTER the webapp — it must never ship ahead of the server whose
+  # contract it renders. Its own workflow also redeploys it on ordinary main
+  # pushes touching its paths; a same-SHA push-triggered run queues behind this
+  # one (per-service concurrency group, cancel-in-progress: false) and the
+  # duplicate deploy is idempotent.
+  #
+  # Soundcheck used to sit here too, as "the other Railway satellite". It does
+  # not belong: it talks only to api.github.com, never to the inspector server,
+  # so the ordering rationale above does not apply to it. It was also the
+  # slowest job in this tail (~3.5 min vs ~1 min) and it deployed TWICE per
+  # release — once here, then again from finalize's version commit, which
+  # touches root package-lock.json, a path in its own push trigger. That push
+  # trigger still redeploys it after every release; this job was the redundant
+  # half.
   deploy-slack-app:
     needs:
       - preflight
@@ -623,32 +632,23 @@ jobs:
     uses: ./.github/workflows/deploy-slack-app.yml
     secrets: inherit
 
-  deploy-soundcheck:
-    needs:
-      - preflight
-      - deploy-webapp
-    if: |
-      always() &&
-      fromJSON(inputs.deploy_webapp) &&
-      needs.deploy-webapp.result == 'success'
-    uses: ./.github/workflows/deploy-soundcheck.yml
-    secrets: inherit
-
   # These `needs` look like dead weight — the `if` below never required the
   # deploy jobs, and with `always()` this runs even when they fail. They are
   # NOT dead weight, and removing them breaks the satellite ordering invariant:
   #
   # This job pushes the version commit, which touches `package-lock.json` — a
-  # path in BOTH satellites' `push:` triggers. If the push lands while
+  # path in BOTH satellite workflows' `push:` triggers (soundcheck's included,
+  # even though it no longer has a job here). If the push lands while
   # deploy-webapp is still running, those push-triggered runs find the
-  # `slack-app` / `soundcheck` concurrency groups free (the release's own
-  # satellite jobs have not started — they are waiting on the webapp) and
-  # deploy the satellites AHEAD of the server whose contract they render.
+  # `slack-app` / `soundcheck` concurrency groups free and deploy AHEAD of the
+  # server whose contract they render.
   #
-  # Waiting is what makes the push safe: by the time it happens the satellite
-  # jobs already hold/released those groups, so the push-triggered run is an
-  # idempotent duplicate that lands after — exactly what the comment on
-  # deploy-slack-app above describes.
+  # `deploy-slack-app` is the load-bearing entry: waiting for it means that by
+  # the time the push happens, the slack-app group has already been through
+  # this release's deploy, so the push-triggered run is an idempotent duplicate
+  # landing after. Waiting for `deploy-webapp` covers soundcheck, whose only
+  # release-time deploy IS that push-triggered run — the server is live before
+  # the push, so it cannot land early.
   #
   # Note this costs nothing when deploy_webapp=false: those jobs are skipped,
   # and `always()` lets this one proceed the moment publish-packages is done.
@@ -659,7 +659,6 @@ jobs:
       - deploy-backend-prod
       - deploy-webapp
       - deploy-slack-app
-      - deploy-soundcheck
     if: |
       always() &&
       needs.preflight.result == 'success' &&

--- a/soundcheck/README.md
+++ b/soundcheck/README.md
@@ -47,11 +47,18 @@ when `soundcheck/**`, root `package.json`, root `package-lock.json`, or the
 workflow file itself changes. The workflow runs `railway up --ci` against the
 `mcpjam-soundcheck` Railway service with a service-scoped token.
 
-`release.yml` also calls this workflow (as its `deploy-soundcheck` job) so a
-release redeploys Soundcheck alongside the other Railway satellites, ordered
-after the webapp deploy. Soundcheck itself is never *published* — it is not
-part of the customer release surface, and nothing customers receive depends
-on it.
+`release.yml` does **not** call this workflow. It used to, as a
+`deploy-soundcheck` job alongside `deploy-slack-app`, but the two are not
+alike: the Slack bot renders the inspector server's envelope and so must
+deploy after it, whereas Soundcheck talks only to `api.github.com` and has no
+such contract. Being in the release also made it deploy twice — once as the
+job, then again from the release's own version commit, which touches root
+`package-lock.json` and trips the `paths` filter above. That push trigger is
+now the single path: a release still redeploys Soundcheck, just after
+`finalize` rather than before it.
+
+Soundcheck is never *published* — it is not part of the customer release
+surface, and nothing customers receive depends on it.
 
 Note for anyone editing `release.yml`: `src/components/release-progress.tsx`
 hardcodes the job list, and `release-readiness.tsx` / `release-verdict.tsx`

--- a/soundcheck/src/components/release-progress.tsx
+++ b/soundcheck/src/components/release-progress.tsx
@@ -57,7 +57,6 @@ const JOB_ORDER = [
   "deploy-webapp / deploy",
   "deploy-webapp / smoke / smoke",
   "deploy-slack-app / Deploy to Railway",
-  "deploy-soundcheck / Deploy to Railway",
   "finalize"
 ];
 


### PR DESCRIPTION
Follow-up to #4338. Takes ~2.5 min off the release tail by removing a job that was there by grouping rather than by need.

## Why soundcheck doesn't belong in the release

It sat in `release.yml` as "the other Railway satellite", next to `deploy-slack-app`. The two were grouped by deployment mechanism, not by coupling, and the shared rationale in the comment — *"both render the server's contract, so they must never ship ahead of it"* — is only true of one of them:

- **The Slack bot really does render the server's envelope**, so it genuinely must deploy after the server. Its ordering stays exactly as-is.
- **Soundcheck only talks to `api.github.com`.** Grepping its source, the only external hosts anywhere in `soundcheck/src` are `api.github.com` and `github.com`. It never calls the inspector server, so there is no contract to keep behind the webapp deploy.

It was also **deploying twice per release**. Once as the job, then again from `finalize`'s version commit, which touches root `package-lock.json` — a path in soundcheck's own `push:` trigger. The pre-existing comment half-noticed this ("the duplicate deploy is idempotent"); the job was the redundant half of it.

And it was the expensive one: **~3.5 min against the Slack bot's ~1 min**, sitting on the critical path in front of `finalize`.

## Effect

Tail goes from `webapp → 3.5m → finalize` to `webapp → 1m → finalize`.

A release still redeploys Soundcheck — the version commit's push trigger does it, just after `finalize` instead of before. Nothing about the dashboard needs to be current *during* a run, since what it renders comes from the GitHub API rather than its own build.

## Ordering is still safe

The push-triggered run has no explicit ordering in the release, so it's worth being precise about why it can't race:

- `finalize` keeps its `deploy-webapp` need, so the push cannot happen until the server is live. Soundcheck therefore cannot deploy ahead of the server even though nothing orders it directly.
- `finalize` keeps `deploy-slack-app` for the reason it was restored in #4338: it's what makes the push land *after* the slack-app concurrency group has already been through this release's deploy, so that push-triggered run stays an idempotent duplicate.

`deploy-soundcheck.yml` keeps `workflow_call` (nothing calls it now) with a comment recording why it's deliberately not wired into the release, so this doesn't get "fixed" back later.

## Not included

I'd floated pairing this with parallelizing `finalize`. **Those two conflict** and it shouldn't be done: the finalize parallelization works by suppressing push-triggered satellite runs for the release commit, which is now soundcheck's *only* release-time deploy path. Together they'd stop soundcheck redeploying on releases entirely.

## Verification

- 12 assertions against the parsed workflow YAML: the job is gone and nothing references `deploy-soundcheck.yml`; `finalize` keeps `deploy-webapp` + `deploy-slack-app`; both satellites' push triggers still cover `package-lock.json` (the mechanism this now relies on); the dashboard's `JOB_ORDER` dropped the soundcheck row, kept slack-app, and every remaining plain entry still resolves to a real job.
- `actionlint` clean — findings drop 7 → 6 for `release.yml` (one fewer job), no new ones.
- Soundcheck typechecks and builds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0167d7WNEw25RawYBZYnZZ5c

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI orchestration and internal dashboard job list only; Soundcheck still redeploys on release via the existing push trigger.
> 
> **Overview**
> Removes the **`deploy-soundcheck`** job from **`release.yml`**, shortening the release tail by roughly **2.5–3.5 minutes** (Soundcheck was the slowest satellite and was redundant with its own push deploy).
> 
> **`deploy-slack-app`** stays ordered after **`deploy-webapp`** because the Slack bot still depends on the server contract. Soundcheck is decoupled: it only hits **`api.github.com`**, so it no longer belongs in that ordered block. Releases still redeploy Soundcheck once via **`finalize`**’s version commit touching root **`package-lock.json`**, which matches **`deploy-soundcheck.yml`**’s path filter.
> 
> Comments in **`deploy-soundcheck.yml`**, **`release.yml`**, and **`soundcheck/README.md`** document why **`workflow_call`** remains but release no longer invokes it, and why **`finalize`** still **`needs`** **`deploy-webapp`** + **`deploy-slack-app`** for safe push-trigger ordering. The Soundcheck release progress stepper drops the **`deploy-soundcheck`** row from **`JOB_ORDER`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fbd74afc7b42b12395554b2c57950b19a14e4acd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removes the Soundcheck deploy job from `release.yml` to shorten the release tail and eliminate a redundant deploy. Previously the release redeployed Soundcheck before `finalize`; now Soundcheck redeploys only via its push trigger after `finalize`, cutting the tail by ~2.5 minutes while keeping ordering safe.

- **Reviewer notes**
  - `finalize` still needs `deploy-webapp` and `deploy-slack-app` to keep push-triggered satellite runs from landing early; this preserves Slack bot ordering and ensures Soundcheck’s push happens after the server is live.
  - `deploy-soundcheck.yml` keeps `workflow_call` but is not wired into the release; an inline comment documents why.
  - The Soundcheck dashboard dropped the `deploy-soundcheck` row from its `JOB_ORDER`, and the README explains the push-triggered redeploy path via root `package-lock.json`.
  - No migration required; the Slack bot’s release-time deploy remains unchanged and Soundcheck still redeploys on every release via the version commit.

<sup>Written for commit fbd74afc7b42b12395554b2c57950b19a14e4acd. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/MCPJam/inspector/pull/4346?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

