### PR TITLE
eval: let a structured launch refusal reach the caller instead of a 500

### DIFF
--- a/mcpjam-inspector/server/services/environments/__tests__/resolve.test.ts
+++ b/mcpjam-inspector/server/services/environments/__tests__/resolve.test.ts
@@ -3,6 +3,7 @@ import { ConvexError } from "convex/values";
 import {
   environmentEffectiveServerIds,
   environmentLaunchConflictError,
+  environmentLaunchRejectionError,
   environmentServerIds,
   environmentServerNames,
   isEnvironmentLaunchConflict,
@@ -258,5 +259,52 @@ describe("environmentLaunchConflictError", () => {
     );
     expect(err.status).toBe(409);
     expect(err.message).toMatch(/host or server group changed/i);
+  });
+});
+
+describe("environmentLaunchRejectionError", () => {
+  it("forwards a structured launch refusal as the caller's 400, not a 500", () => {
+    // The whole point of the backend raising ConvexError for these: Convex
+    // redacts a plain Error's message in production, so an untranslated throw
+    // reaches the caller as "Server Error" and they cannot tell a bad request
+    // from a broken server.
+    const err = environmentLaunchRejectionError(
+      new ConvexError({
+        code: "VALIDATION",
+        message:
+          "ephemeralEnvironment requires environmentId — it names the environment to run without attaching it.",
+      })
+    )!;
+    expect(err).toBeInstanceOf(WebRouteError);
+    expect(err.status).toBe(400);
+    expect(err.message).toMatch(/requires environmentId/i);
+    expect((err.details as Record<string, unknown>).reason).toBe("validation");
+  });
+
+  it("answers 404 for cross-project and missing, so the route cannot be used to probe", () => {
+    for (const code of ["ENV_CROSS_PROJECT", "ENV_NOT_FOUND"]) {
+      const err = environmentLaunchRejectionError(
+        new ConvexError({ code, message: "nope" })
+      )!;
+      expect(err.status).toBe(404);
+    }
+  });
+
+  it("keeps a non-member or ambiguous selection a 400 the caller can act on", () => {
+    for (const code of ["ENV_NOT_A_MEMBER", "ENV_AMBIGUOUS", "ENV_ARCHIVED"]) {
+      const err = environmentLaunchRejectionError(
+        new ConvexError({ code, message: "nope" })
+      )!;
+      expect(err.status).toBe(400);
+      expect((err.details as Record<string, unknown>).code).toBe(code);
+    }
+  });
+
+  it("returns null for anything unrecognized so a real fault stays a logged 500", () => {
+    expect(
+      environmentLaunchRejectionError(new ConvexError({ code: "SOMETHING_NEW" }))
+    ).toBeNull();
+    expect(environmentLaunchRejectionError(new Error("boom"))).toBeNull();
+    expect(environmentLaunchRejectionError(null)).toBeNull();
   });
 });

--- a/mcpjam-inspector/server/services/environments/__tests__/resolve.test.ts
+++ b/mcpjam-inspector/server/services/environments/__tests__/resolve.test.ts
@@ -281,13 +281,34 @@ describe("environmentLaunchRejectionError", () => {
     expect((err.details as Record<string, unknown>).reason).toBe("validation");
   });
 
-  it("answers 404 for cross-project and missing, so the route cannot be used to probe", () => {
-    for (const code of ["ENV_CROSS_PROJECT", "ENV_NOT_FOUND"]) {
-      const err = environmentLaunchRejectionError(
-        new ConvexError({ code, message: "nope" })
-      )!;
+  it("makes cross-project and missing INDISTINGUISHABLE, not merely both 404", () => {
+    // Deliberately distinct backend messages: if either reached the caller,
+    // submitting an arbitrary id would reveal which project it lives in — the
+    // enumeration answering 404 exists to prevent. A shared status with a
+    // differing body collapses nothing, so the whole payload is compared.
+    const crossProject = environmentLaunchRejectionError(
+      new ConvexError({
+        code: "ENV_CROSS_PROJECT",
+        message: "Environment belongs to a different project.",
+        details: { environmentId: "env_someone_elses" },
+      })
+    )!;
+    const missing = environmentLaunchRejectionError(
+      new ConvexError({
+        code: "ENV_NOT_FOUND",
+        message: "Environment not found.",
+        details: { environmentId: "env_never_existed" },
+      })
+    )!;
+
+    for (const err of [crossProject, missing]) {
       expect(err.status).toBe(404);
     }
+    expect(crossProject.message).toBe(missing.message);
+    expect(crossProject.details).toEqual(missing.details);
+    // And neither leaks the backend's wording or the originating code.
+    expect(JSON.stringify(crossProject)).not.toMatch(/different project/i);
+    expect(JSON.stringify(crossProject)).not.toMatch(/CROSS_PROJECT/);
   });
 
   it("keeps a non-member or ambiguous selection a 400 the caller can act on", () => {
@@ -306,5 +327,16 @@ describe("environmentLaunchRejectionError", () => {
     ).toBeNull();
     expect(environmentLaunchRejectionError(new Error("boom"))).toBeNull();
     expect(environmentLaunchRejectionError(null)).toBeNull();
+  });
+
+  it("returns null for structured payloads carrying no usable code", () => {
+    // These reach the guards rather than the code lookup, and each is a shape
+    // a backend can actually produce. Falling through to a 500 is right: we
+    // cannot name a reason we were not given.
+    expect(environmentLaunchRejectionError({ data: {} })).toBeNull();
+    expect(environmentLaunchRejectionError({ data: { code: "" } })).toBeNull();
+    expect(environmentLaunchRejectionError({ data: { code: 42 } })).toBeNull();
+    expect(environmentLaunchRejectionError({ data: [] })).toBeNull();
+    expect(environmentLaunchRejectionError({ data: null })).toBeNull();
   });
 });

--- a/mcpjam-inspector/server/services/environments/resolve.ts
+++ b/mcpjam-inspector/server/services/environments/resolve.ts
@@ -285,6 +285,20 @@ export function environmentLaunchRejectionError(
   if (!code) return null;
   const status = LAUNCH_REJECTION_STATUS[code];
   if (!status) return null;
+  // The 404s collapse ENTIRELY — one message, one code, one reason, no backend
+  // details — because collapsing only the STATUS does not collapse anything a
+  // caller reads. Forwarding "Environment belongs to a different project"
+  // under `ENV_CROSS_PROJECT` next to "Environment not found" under
+  // `ENV_NOT_FOUND` lets someone submit an arbitrary id and learn which
+  // project it lives in, which is the enumeration answering 404 was meant to
+  // prevent, reintroduced one field lower. Matches how the shared Convex
+  // translator answers every 404: the resource noun, and nothing else.
+  if (status === 404) {
+    return new WebRouteError(404, ErrorCode.NOT_FOUND, "Environment not found", {
+      code: "ENV_NOT_FOUND",
+      reason: "env_not_found",
+    });
+  }
   const message =
     typeof record.message === "string" && record.message.trim()
       ? record.message
@@ -295,12 +309,11 @@ export function environmentLaunchRejectionError(
     !Array.isArray(record.details)
       ? (record.details as Record<string, unknown>)
       : {};
-  return new WebRouteError(
-    status,
-    status === 404 ? ErrorCode.NOT_FOUND : ErrorCode.VALIDATION_ERROR,
-    message,
-    { code, ...details, reason: code.toLowerCase() }
-  );
+  return new WebRouteError(status, ErrorCode.VALIDATION_ERROR, message, {
+    code,
+    ...details,
+    reason: code.toLowerCase(),
+  });
 }
 
 export function environmentModelRequiredError(

--- a/mcpjam-inspector/server/services/environments/resolve.ts
+++ b/mcpjam-inspector/server/services/environments/resolve.ts
@@ -234,6 +234,75 @@ function environmentConflictKind(error: unknown): "drift" | "revision" {
  * null rather than throwing so call sites read as one line next to the other
  * translations.
  */
+/**
+ * Every OTHER structured refusal `startTestSuiteRun` can raise before it
+ * creates anything: a bad `ephemeralEnvironment` request, an environment that
+ * is not a suite member, an ambiguous multi-environment launch, and the
+ * resolver's own cross-project / archived / missing verdicts.
+ *
+ * Without this they reach the caller as `500 "Server Error"`. The backend
+ * deliberately raises `ConvexError` for these so the reason SURVIVES
+ * production redaction — Convex redacts a plain `Error`'s message and keeps a
+ * `ConvexError`'s data — and then the launch path threw the whole thing away
+ * by rethrowing it raw into the generic handler. Converting the throw and not
+ * translating it buys nothing: the caller still cannot tell "you named an
+ * environment this suite does not have" from "the server broke".
+ *
+ * Codes, not prose: the message is the backend's and is forwarded verbatim,
+ * but the branch is on `code`, so rewording a backend message cannot silently
+ * change which status a caller sees.
+ *
+ * Returns null for anything unrecognized, so a genuinely unknown failure stays
+ * a logged 500 rather than being relabelled as the caller's mistake.
+ */
+const LAUNCH_REJECTION_STATUS: Record<string, 400 | 404> = {
+  // Malformed request: the argument combination cannot mean anything.
+  VALIDATION: 400,
+  // Named an environment the suite does not have, or named none when the
+  // suite has several. Both are fixable by the caller, and naming the id back
+  // reveals nothing they did not already send.
+  ENV_NOT_A_MEMBER: 400,
+  ENV_AMBIGUOUS: 400,
+  // Archived is a state the caller can see and undo; cross-project and
+  // not-found both answer 404, so a probe cannot use this route to learn
+  // whether an id exists in someone else's project.
+  ENV_ARCHIVED: 400,
+  ENV_CROSS_PROJECT: 404,
+  ENV_NOT_FOUND: 404,
+};
+
+export function environmentLaunchRejectionError(
+  error: unknown
+): WebRouteError | null {
+  const data = (error as { data?: unknown } | null)?.data;
+  if (!data || typeof data !== "object" || Array.isArray(data)) return null;
+  const record = data as {
+    code?: unknown;
+    message?: unknown;
+    details?: unknown;
+  };
+  const code = typeof record.code === "string" ? record.code : undefined;
+  if (!code) return null;
+  const status = LAUNCH_REJECTION_STATUS[code];
+  if (!status) return null;
+  const message =
+    typeof record.message === "string" && record.message.trim()
+      ? record.message
+      : "This eval run could not be started as requested.";
+  const details =
+    record.details &&
+    typeof record.details === "object" &&
+    !Array.isArray(record.details)
+      ? (record.details as Record<string, unknown>)
+      : {};
+  return new WebRouteError(
+    status,
+    status === 404 ? ErrorCode.NOT_FOUND : ErrorCode.VALIDATION_ERROR,
+    message,
+    { code, ...details, reason: code.toLowerCase() }
+  );
+}
+
 export function environmentModelRequiredError(
   error: unknown
 ): WebRouteError | null {

--- a/mcpjam-inspector/server/services/evals/recorder.ts
+++ b/mcpjam-inspector/server/services/evals/recorder.ts
@@ -20,6 +20,7 @@ import { ErrorCode, WebRouteError } from "../../routes/web/errors.js";
 import { ConvexError } from "convex/values";
 import {
   environmentLaunchConflictError,
+  environmentLaunchRejectionError,
   environmentModelRequiredError,
   isEnvironmentLaunchConflict,
 } from "../environments/resolve.js";
@@ -554,6 +555,17 @@ export const startSuiteRunWithRecorder = async ({
       isEnvironmentLaunchConflict(error)
     ) {
       throw environmentLaunchConflictError(error);
+    }
+    // The remaining structured refusals — a bad ephemeralEnvironment request,
+    // a non-member or ambiguous environment, the resolver's cross-project /
+    // archived / missing verdicts. Each aborts BEFORE any run row exists, and
+    // each names something the caller can act on; rethrowing raw handed them
+    // all to the generic handler as `500 "Server Error"`, which is what the
+    // backend raising ConvexError instead of Error was meant to prevent.
+    // Returns null for anything unrecognized, so a real fault stays a 500.
+    const rejection = environmentLaunchRejectionError(error);
+    if (rejection) {
+      throw rejection;
     }
     throw error;
   }


### PR DESCRIPTION
Found by running the acceptance against **production, the moment #1107 deployed**. The backend half works — `ephemeralEnvironment: true` with no `environmentId` no longer silently launches a paid run (verified: no run row created). But the caller is told:

```json
{"code":"INTERNAL_ERROR","message":"[Request ID: 611c222bb8b497d9] Server Error"}
```

which is the exact outcome that converting those throws to `ConvexError` was meant to prevent.

## Why it happens

Convex redacts a plain `Error`'s message in production and preserves a `ConvexError`'s data. #1107 made the backend raise the reason — and then `startTestSuiteRun`'s catch in `recorder.ts` threw it away, rethrowing raw into the generic handler.

That catch translated exactly three shapes: billing, `ENV_MODEL_REQUIRED`, and the launch conflict. Every *other* structured refusal it can raise **before creating anything** therefore became a 500:

- the two `ephemeralEnvironment` validations (`VALIDATION`)
- a non-member environment (`ENV_NOT_A_MEMBER`)
- an ambiguous multi-environment launch (`ENV_AMBIGUOUS`)
- the resolver's own `ENV_CROSS_PROJECT`, `ENV_ARCHIVED`, `ENV_NOT_FOUND`

Converting the backend throw and not translating it buys nothing: the caller still cannot tell "you named an environment this suite does not have" from "the server broke".

## The fix

`environmentLaunchRejectionError` translates them, following the existing `environmentModelRequiredError` idiom in the same file (code + backend `details` + a stable `reason` slug).

- Branches on **`code`, not prose**, so rewording a backend message cannot silently move a status.
- `ENV_CROSS_PROJECT` and `ENV_NOT_FOUND` answer **404 together**, so this route cannot be used to learn whether an id exists in someone else's project.
- The rest are 400s naming something the caller can fix.
- Anything unrecognized returns `null` and stays a **logged 500** — a write path we do not understand is ours, not theirs.

## Verification

- `resolve.test.ts` + `recorder.test.ts`: **32 passed**, including four new cases (forwarded 400 with reason; 404 for cross-project/missing; 400 for non-member/ambiguous/archived; null for unrecognized, plain `Error`, and `null`).
- `tsc -p server --noEmit`: **199 errors before, 199 after** — zero new.

## Live evidence this is worth it

Against production before this change, the probe that should be a free validation error returned a 500. Against production *before #1107*, the same call didn't error at all — it **launched and billed a real eval run** that completed before a cancel could land. #1107 stopped the spend; this makes the refusal legible.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PN6sCF8o9nvo65j4WyQr7d

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes eval launch error handling on a billing-adjacent path; incorrect mapping could mislabel server faults as client errors or leak environment existence, though unrecognized codes still fall through to 500.
> 
> **Overview**
> Fixes eval suite launch failures where the backend already raised structured `ConvexError` refusals (e.g. invalid `ephemeralEnvironment`, wrong environment for the suite) but `startTestSuiteRun`'s catch in `recorder.ts` only translated billing, model-required, and launch-conflict errors—everything else bubbled as a generic **500**.
> 
> Adds **`environmentLaunchRejectionError`** in `resolve.ts` (same pattern as existing launch translators): maps known refusal **codes** to `WebRouteError` **400** (`VALIDATION`, `ENV_NOT_A_MEMBER`, `ENV_AMBIGUOUS`, `ENV_ARCHIVED`) or **404** (`ENV_CROSS_PROJECT`, `ENV_NOT_FOUND`), with backend message/details and a stable `details.reason` on 400s. **404 responses are fully normalized** so cross-project and missing environments look identical and cannot be probed for ID enumeration.
> 
> The recorder's `startTestSuiteRun` catch now throws that translation when present; **unknown errors still return null and stay logged 500s**. New unit tests in `resolve.test.ts` cover forwarding, 404 collapsing, and null fallthrough.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 16f83ff47e1f070afbf39bd74a925c9f5be56015. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Surfaces structured eval launch rejections to callers as actionable 400/404 instead of a generic 500, and collapses cross‑project vs missing into one indistinguishable 404 payload to prevent probing.

- The recorder catch uses environmentLaunchRejectionError to map `VALIDATION`, `ENV_NOT_A_MEMBER`, `ENV_AMBIGUOUS`, and `ENV_ARCHIVED` to 400; `ENV_CROSS_PROJECT` and `ENV_NOT_FOUND` return the same 404 payload ("Environment not found"); unknowns still bubble as logged 500s.
- Branches on error code, not prose; 400s forward the backend message and include a `reason` slug; 404s use a fixed message and strip backend details to avoid environment ID probing.
- Tests assert indistinguishable 404s, cover 400 cases, and ensure `null` for unrecognized and structured-but-codeless payloads; no migrations or client changes required.

<sup>Written for commit 16f83ff47e1f070afbf39bd74a925c9f5be56015. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/MCPJam/inspector/pull/4348?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

