### PR TITLE
eval: type toolCallId at the persistence boundary instead of casting it

### DIFF
--- a/.changeset/eval-tool-call-id-typed-at-boundary.md
+++ b/.changeset/eval-tool-call-id-typed-at-boundary.md
@@ -1,0 +1,9 @@
+---
+"@mcpjam/inspector": patch
+---
+
+`toolCallId` is now part of the runner's tool-call type instead of a cast, so the eval persistence boundary is type-checked again.
+
+Tool-policy enforcement gave the runner a reason to carry the provider's `toolCallId` on every extracted tool call — `extractToolCallsExcludingPolicyBlocks` matches blocked calls by it. The field was attached with an `as ToolCall` cast at all three push sites, and `type ToolCall` was never widened to admit it. That cast is precisely what suppressed TypeScript's excess-property check, and the same array is what gets persisted as `updateTestIteration.actualToolCalls` — where a Convex object validator that had never heard of `toolCallId` rejected it outright. Every eval iteration that called a tool failed to record its result; only prose-only iterations, which send `[]`, got through.
+
+This change is type-only and alters no runtime behavior — the runtime fix is the matching backend widening, which has to deploy first. What it buys is that the boundary can't silently drift again: `ToolCall` and `finalize-iteration`'s `ToolCallRecord` now both name `toolCallId`, the three casts are gone, and adding another undeclared field to a persisted tool call is a compile error rather than a production `ArgumentValidationError` that surfaces sixty seconds later as `Worker heartbeat lost`.

--- a/mcpjam-inspector/server/services/evals-runner.ts
+++ b/mcpjam-inspector/server/services/evals-runner.ts
@@ -521,7 +521,23 @@ function delay(ms: number): Promise<void> {
 }
 
 type ToolSet = Record<string, any>;
-type ToolCall = { toolName: string; arguments: Record<string, any> };
+type ToolCall = {
+  toolName: string;
+  arguments: Record<string, any>;
+  /**
+   * The provider's id for this call, when the source part carried one.
+   *
+   * Declared here rather than smuggled in behind a cast: this value is BOTH
+   * read locally (`extractToolCallsExcludingPolicyBlocks` matches blocked
+   * calls by it) and persisted (`updateTestIteration.actualToolCalls`), and
+   * the casts that used to hide it are how it reached a Convex validator that
+   * had never been told about it — an unknown field there is a hard
+   * ArgumentValidationError, so every tool-calling iteration failed to
+   * finalize. Keeping it on the type is what makes the persistence boundary
+   * type-checked again.
+   */
+  toolCallId?: string;
+};
 type TraceSnapshotKind = "step_finish" | "turn_finish" | "failure";
 
 function getServerLabelForEvalError(
@@ -972,7 +988,7 @@ function extractToolCallsFromConversation(params: {
             ...(typeof call.toolCallId === "string"
               ? { toolCallId: call.toolCallId }
               : {}),
-          } as ToolCall);
+          });
         }
       }
     }
@@ -999,7 +1015,7 @@ function extractToolCallsFromConversation(params: {
                 ...(typeof item.toolCallId === "string"
                   ? { toolCallId: item.toolCallId }
                   : {}),
-              } as ToolCall);
+              });
             }
           }
         }
@@ -1024,7 +1040,7 @@ function extractToolCallsFromConversation(params: {
               ...(typeof call.toolCallId === "string"
                 ? { toolCallId: call.toolCallId }
                 : {}),
-            } as ToolCall);
+            });
           }
         }
       }
@@ -1041,13 +1057,11 @@ function extractToolCallsExcludingPolicyBlocks(
   },
   blockedToolCallIds: ReadonlySet<string>
 ): ToolCall[] {
-  return extractToolCallsFromConversation(params).filter((toolCall) => {
-    const toolCallId = (toolCall as ToolCall & { toolCallId?: unknown })
-      .toolCallId;
-    return (
-      typeof toolCallId !== "string" || !blockedToolCallIds.has(toolCallId)
-    );
-  });
+  return extractToolCallsFromConversation(params).filter(
+    (toolCall) =>
+      toolCall.toolCallId === undefined ||
+      !blockedToolCallIds.has(toolCall.toolCallId)
+  );
 }
 
 function toolCallIdentity(toolCall: ToolCall): string {

--- a/mcpjam-inspector/server/services/evals/finalize-iteration.ts
+++ b/mcpjam-inspector/server/services/evals/finalize-iteration.ts
@@ -67,7 +67,18 @@ import { isTerminalIterationStatus } from "./run-status.js";
  */
 type IterationStatus = ContractIterationStatus;
 
-type ToolCallRecord = { toolName: string; arguments: Record<string, any> };
+type ToolCallRecord = {
+  toolName: string;
+  arguments: Record<string, any>;
+  /**
+   * Mirrors the runner's `ToolCall.toolCallId`. This type describes exactly
+   * what goes over the wire as `updateTestIteration.actualToolCalls`, so it
+   * has to name every field the runner actually sends — the whole reason
+   * `toolCallId` reached a validator that rejected it is that no type on this
+   * path admitted the field existed.
+   */
+  toolCallId?: string;
+};
 type PolicyBlockRecord = { reason?: unknown };
 
 /**
@@ -596,7 +607,7 @@ export type FinalizeEvalIterationParams = {
   convexClient: ConvexHttpClient;
   iterationId?: string;
   passed: boolean;
-  toolsCalled: Array<{ toolName: string; arguments: Record<string, any> }>;
+  toolsCalled: ToolCallRecord[];
   usage: UsageTotals;
   messages: ModelMessage[];
   /** Effective model used by the iteration; persisted on the eval session. */


### PR DESCRIPTION
Type-only. Companion to **MCPJam/mcpjam-backend#1134**, which carries the actual runtime fix and must deploy first.

## Context

Every eval iteration that calls a tool has failed to record its result since 08-23. `updateTestIteration` rejects the finalize write:

```
ArgumentValidationError: Object contains extra field `toolCallId` that is not in the validator.
Path: .actualToolCalls[0]
Validator: v.object({arguments: v.any(), toolName: v.string()})
```

It surfaced as `Worker heartbeat lost` because the error is three steps from the fault: the throw is masked as `Server Error` in prod, `finalize-iteration`'s catch matches none of `not found` / `unauthorized` / `cancelled` so it takes the transient branch and leaves the iteration running, and 60s later the backend's stale sweep stamps it. The heartbeat was healthy throughout, and `tokensUsed: 0` didn't mean the model never ran — the write carrying the token count is the rejected one.

## What this PR fixes

Not the crash — the reason nothing caught it.

`1bea9340c8` (#4308, tool-policy enforcement, Lane D/D4) gave the runner a legitimate need for the provider's `toolCallId`: `extractToolCallsExcludingPolicyBlocks` filters blocked calls by it. But the field was attached with an `as ToolCall` cast at all three push sites in `extractToolCallsFromConversation`, while `type ToolCall` stayed `{ toolName, arguments }`.

That cast is precisely what suppressed the excess-property check that would have caught this at compile time. And the same array is what ships to Convex as `actualToolCalls`, so a field no type on the path admitted existed reached a validator that rejected it.

- `type ToolCall` now declares `toolCallId?: string`
- the three `as ToolCall` casts are gone
- `extractToolCallsExcludingPolicyBlocks` drops its `as ToolCall & { toolCallId?: unknown }` cast and reads the field directly
- `finalize-iteration`'s `ToolCallRecord` gains the same field, and the `toolsCalled` param stops re-declaring the shape inline — this type describes exactly what goes over the wire, so it has to name every field the runner sends

Adding another undeclared field to a persisted tool call is now a compile error.

## Why not just strip the id before sending

That would fix the crash — the id is consumed and discarded inside the same function — but it's the wrong trade. `widgetRenderObservations` is indexed `by_session_and_toolCallId`, so persisting it is what lets a recorded tool call be joined to the widget render it drove. The backend PR widens the validator to keep it.

## Verification

- `npx tsc --noEmit` diffed before vs after across `evals-runner.ts`, `finalize-iteration.ts`, and `evals-runner.test.ts`: **no new errors** (only line-number shifts on pre-existing ones)
- `evals-runner.test.ts` (90), `tool-policy-gate.test.ts`, `runner-parity.test.ts` (27), `build-iteration-finish-params.test.ts` — all pass

## Merge order

Backend #1134 first. This PR changes no runtime behavior — the inspector already sends `toolCallId` in production today, so nothing here alters what goes over the wire.

## Follow-ups, not in this PR

1. **`finalize-iteration.ts` classifies `ArgumentValidationError` as transient.** A validation failure is permanent — retrying can't fix it — and swallowing it produced a 60s-delayed, actively misleading error. Should be fatal and surfaced with its real cause.
2. **Log the Convex request id alongside the inspector-side error.** The real message sat in `mcpjam-backend-prod` in Axiom the whole time, keyed by `data.function.request_id`; prod redaction hides it at the only place a human reads it.

## Why the tests didn't catch it

Every test #4308 added is inspector-side, so no Convex validator ever ran against the new shape. `runner-parity.test.ts.snap` does snapshot `actualToolCalls`, but its fixture tool call carries no `toolCallId` — so the snapshot recorded `{arguments, toolName}` and stayed green. The backend PR adds the test that actually exercises the boundary.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0143FPiXSfkYoPJBSQJ17v8Q

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Compile-time typing only; runtime payloads are unchanged and depend on the backend deploy that accepts `toolCallId`.
> 
> **Overview**
> **Type-only companion to the backend validator widening** — no runtime wire change; the inspector already sends `toolCallId` on `actualToolCalls`.
> 
> The runner’s `ToolCall` type now declares optional **`toolCallId`** (used for tool-policy blocking and persisted as `updateTestIteration.actualToolCalls`). The three `as ToolCall` casts in `extractToolCallsFromConversation` are removed, and `extractToolCallsExcludingPolicyBlocks` reads the field directly instead of casting.
> 
> `finalize-iteration`’s **`ToolCallRecord`** and **`FinalizeEvalIterationParams.toolsCalled`** are aligned so every field the runner sends is named before Convex — undeclared fields become compile errors instead of production `ArgumentValidationError` on tool-calling iterations.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 903cb5daa6264791a1e738f6b9841a4b62283612. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Types `toolCallId` on the eval runner’s tool-call records and at the finalize-iteration boundary, replacing casts, so the payload sent to Convex is type-checked. This closes the gap that let an unexpected `toolCallId` reach the validator and reject `actualToolCalls`.

- Review notes
  - Runner `ToolCall` now includes `toolCallId?: string`; the three casts are removed and `extractToolCallsExcludingPolicyBlocks` reads the field directly.
  - `finalize-iteration`’s `ToolCallRecord` mirrors the same field and is used for `toolsCalled`.
  - Adding an undeclared field to persisted tool calls is now a compile error; no runtime behavior changes here.

- Rollout
  - Deploy MCPJam/mcpjam-backend#1134 first; it widens the Convex validator to accept `toolCallId`.

<sup>Written for commit 903cb5daa6264791a1e738f6b9841a4b62283612. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/MCPJam/inspector/pull/4351?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

