### PR TITLE
Changeset: keep #1131 off a line start (markdownlint MD018)

### DIFF
--- a/.changeset/eval-run-disclosure-host-axis.md
+++ b/.changeset/eval-run-disclosure-host-axis.md
@@ -42,7 +42,7 @@ different contract than the one the audit stamp records. The refusal now
 names that limit rather than the retired "no host selector" one.
 
 **Requires a backend carrying the `namedHostId` argument** (mcpjam-backend
-#1131), and the ordering matters in one direction. The runner capability
+`#1131`), and the ordering matters in one direction. The runner capability
 handshake is sent on EVERY disclosure request, not only host-targeted ones —
 the backend gates the disclosed engine on it for the environment axis too — so
 against a deployment that predates #1131, strict argument validation rejects


### PR DESCRIPTION
One-line follow-up to #4350. **Close it if you'd rather not spend the review** — it's cosmetic.

CodeRabbit flagged MD018 on the G4c changeset: `#1131` opens line 45, so markdown parses it as an ATX heading. That matters slightly beyond the lint, because changeset prose folds into `CHANGELOG.md` at release — the reference could render as a heading there. The changeset is still in `main` unreleased, so this lands before that happens.

Wrapped in backticks; nothing else touched.

```diff
 **Requires a backend carrying the `namedHostId` argument** (mcpjam-backend
-#1131), and the ordering matters in one direction. The runner capability
+`#1131`), and the ordering matters in one direction. The runner capability
```

Not fixed, deliberately: `MD041` still reports on this file, as it does on **every** changeset in the directory (they open with frontmatter, not a heading), and `MD013` isn't enforced either — sibling changesets run past 800 columns. Fixing those would be a directory-wide reformat unrelated to this work.

---

### Unrelated: a flaky test worth someone's attention

`Inspector Tests 1/4` failed on `45e05bd` in `server/routes/v1/__tests__/tools-call.test.ts` — not a file this PR or #4350 touches (last changed in #4292):

```
AssertionError: expected 4 to be greater than or equal to 5
 ❯ routes/v1/__tests__/tools-call.test.ts:78:29
```

The test stubs a tool with `setTimeout(resolve, 5)` and asserts `durationMs >= 5`. That's inherently racy: `setTimeout(5)` can complete in slightly under 5ms of measured wall time, and integer-millisecond clock deltas truncate. It passed on the re-run against `3f4e9ba`, which is why #4350 went green.

Proposed patch, if you want it — assert the additive field is present and sane rather than racing the timer:

```diff
-    expect(body.durationMs).toBeGreaterThanOrEqual(5);
+    // Not `>= 5`: the stub sleeps 5ms, but integer-ms clock deltas truncate
+    // and a 5ms timer can measure 4. The contract here is that durationMs is
+    // present and non-negative — the clamp case has its own test below.
+    expect(body.durationMs).toBeGreaterThanOrEqual(0);
```

I left it out of this PR rather than widening it into an unrelated file — happy to send it separately if you'd like.


---
_Generated by [Claude Code](https://claude.ai/code/session_013H75MBKVk84LoCb7hnCNtx)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only markdown tweak in an unreleased changeset; no runtime or security impact.
> 
> **Overview**
> **Cosmetic changeset fix** so release notes / `CHANGELOG.md` don’t mis-render a backend reference as a heading.
> 
> In `.changeset/eval-run-disclosure-host-axis.md`, the line that continued “mcpjam-backend” now uses `` `#1131` `` instead of a bare ``#1131`` at the start of the line. That addresses **markdownlint MD018** (no `#` at the beginning of a line outside a heading), which also avoids ATX-heading parsing when the changeset is folded into the changelog.
> 
> No product code, APIs, or eval disclosure behavior changes—only how that one reference is written in unreleased changeset prose.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8ef8dee433a3263d8e7a06ea05ca0c9ef009fa7c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents the G4c changeset from parsing `#1131` as an ATX heading by wrapping it in backticks. This satisfies `markdownlint MD018` and avoids a stray heading when the changeset folds into `CHANGELOG.md`. No runtime behavior change.

- Only change: wrap `#1131` in `.changeset/eval-run-disclosure-host-axis.md`; text unchanged otherwise.
- Leaves `MD041` and `MD013` as-is to match the directory; out of scope for this PR.

<sup>Written for commit 8ef8dee433a3263d8e7a06ea05ca0c9ef009fa7c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/MCPJam/inspector/pull/4352?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

