### PR TITLE
chat-input: clear the file-error timeout on unmount

### DIFF
--- a/mcpjam-inspector/client/src/components/chat-v2/chat-input.tsx
+++ b/mcpjam-inspector/client/src/components/chat-v2/chat-input.tsx
@@ -506,6 +506,7 @@ export function ChatInput({
   const recordingCapTimerRef = useRef<ReturnType<typeof setTimeout> | null>(
     null
   );
+  const fileErrorTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const recordingStartedAtRef = useRef<number | null>(null);
   const recordingDurationSecondsRef = useRef<number>(0);
   const transcriptionRunRef = useRef(0);
@@ -610,12 +611,19 @@ export function ChatInput({
     recordingCapTimerRef.current = null;
   }, []);
 
+  const clearFileErrorTimer = useCallback(() => {
+    if (!fileErrorTimerRef.current) return;
+    clearTimeout(fileErrorTimerRef.current);
+    fileErrorTimerRef.current = null;
+  }, []);
+
   useEffect(() => {
     mountedRef.current = true;
     return () => {
       mountedRef.current = false;
       clearStopFallbackTimer();
       clearRecordingCapTimer();
+      clearFileErrorTimer();
       if (mediaRecorderRef.current?.state === "recording") {
         mediaRecorderRef.current.stop();
       }
@@ -623,7 +631,12 @@ export function ChatInput({
       transcriptionAbortRef.current = null;
       stopAudioStream();
     };
-  }, [clearRecordingCapTimer, clearStopFallbackTimer, stopAudioStream]);
+  }, [
+    clearRecordingCapTimer,
+    clearStopFallbackTimer,
+    clearFileErrorTimer,
+    stopAudioStream,
+  ]);
 
   useLayoutEffect(() => {
     if (moveCaretToEndTrigger === undefined) return;
@@ -691,12 +704,16 @@ export function ChatInput({
       if (errors.length > 0) {
         setFileError(errors.join("\n"));
         // Clear error after 5 seconds
-        setTimeout(() => setFileError(null), 5000);
+        clearFileErrorTimer();
+        fileErrorTimerRef.current = setTimeout(() => {
+          fileErrorTimerRef.current = null;
+          setFileError(null);
+        }, 5000);
       }
 
       return true;
     },
-    [fileAttachments, onChangeFileAttachments]
+    [fileAttachments, onChangeFileAttachments, clearFileErrorTimer]
   );
 
   const handleFileInputChange = useCallback(


### PR DESCRIPTION
## What

The 5-second auto-dismiss for file-attachment errors in `ChatInput` used a bare `setTimeout(() => setFileError(null), 5000)`. If the component unmounts before it fires (which every ChatInput test does), the callback calls `setState` into a torn-down environment. In CI this intermittently kills an Inspector Tests shard: vitest reports `ReferenceError: window is not defined` as an unhandled error and exits 1 **with all tests passing** — this is what put main (`a4e0b80`) on Hold in Soundcheck tonight (run 32806127983; its rerun went green).

## Fix

Track the timer in `fileErrorTimerRef` following the existing recording-timer pattern, clear it in the unmount cleanup effect, and reset any pending timer when a new error arrives (so a second error isn't dismissed early by the first error's timer).

## Verification

- `npx vitest run client/src/components/chat-v2/__tests__/ChatInput.test.tsx` — 59/59 pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CpgZWJjv3u2JD8GbaTbdsN

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Timer lifecycle cleanup only in the chat composer; no changes to auth, APIs, or attachment validation rules.
> 
> **Overview**
> **ChatInput** no longer leaves a bare `setTimeout` running when file-attachment validation fails. The 5-second auto-dismiss is stored in **`fileErrorTimerRef`**, cleared on unmount (same pattern as the voice recording timers), and reset when a new error is shown so an older timer cannot hide a newer message early.
> 
> This avoids **`setFileError(null)`** firing after the component tears down—behavior that was causing intermittent Vitest **`window is not defined`** unhandled errors in **`ChatInput`** tests even when assertions passed.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cba17d7016616e0bd260d6c57225ba1ee9536da9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents setState after unmount in `ChatInput` by tracking the 5s file-error auto-dismiss timer and clearing it on unmount. Previously a bare `setTimeout` could fire after unmount and crash CI; now the timer is ref-based, cleared in cleanup, and reset when a new error arrives.

- Adds `fileErrorTimerRef` and `clearFileErrorTimer`, cleared in the unmount effect alongside existing timers.
- Resets the dismissal timer on subsequent errors so a second error is not dismissed early.
- No API changes; user behavior is unchanged aside from proper handling of back-to-back errors and elimination of intermittent CI flakes.

<sup>Written for commit cba17d7016616e0bd260d6c57225ba1ee9536da9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/MCPJam/inspector/pull/4353?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

