### PR TITLE
Evals v2 — G4d: the agent proposal card carries the pre-run disclosure

### DIFF
--- a/.changeset/proposal-card-run-disclosure.md
+++ b/.changeset/proposal-card-run-disclosure.md
@@ -1,0 +1,67 @@
+---
+"@mcpjam/sdk": minor
+"@mcpjam/inspector": minor
+---
+
+Carry the pre-run disclosure on the agent's run proposal cards (Evals v2, Lane
+G, step G4d).
+
+G4b/G4c disclose a run to the person who LAUNCHES it. A proposal is the one
+place where that is not the same person: the agent picked the suite, and
+someone else is about to click "Run it" on a card in Slack with nothing in
+front of them but a one-line description and a spend warning. This puts the
+same facts on that card.
+
+- `@mcpjam/sdk/public-api`: `ProposedAction` gains an additive `disclosure?`
+  (`ProposedActionDisclosure`) — engine, sandbox, the providers the run's own
+  models reach, the judge providers it does NOT already reach, retention, and
+  a BYOK flag, plus the `digest` that joins the summary back to the full
+  contract. Deliberately small: an approval card states what a person did not
+  choose and cannot infer, and links the rest by digest.
+  `get_eval_run_disclosure` still serves the whole payload for a host that
+  wants it.
+- `POST /v1/projects/{projectId}/agent`: the two eval-run proposals declare a
+  `carriesDisclosure` hook in the op registry, and `persistProposal` fetches a
+  disclosure for the FROZEN input — the same object the click will execute —
+  through `get_eval_run_disclosure`, so what was disclosed is what will run
+  rather than a second, independently resolved target. Going through the
+  operation is what keeps the runner-capability handshake, the composed
+  `execution.locus` and the recomputed digest at ONE site instead of two.
+- The Slack bot renders one line per disclosed proposal, in the same wording
+  register as the app's own run-disclosure hint.
+
+Three properties this had to have, and one honest limit:
+
+1. **One resolution.** Never re-resolved from raw selectors. `allAttached`
+   re-expands against whatever is attached at the time, so a disclosure
+   derived from it could describe a set the click does not run — the freeze
+   already drops it, and an input where it survived is refused rather than
+   disclosed.
+2. **Best-effort, independently bounded.** Its own 3s timeout, its own
+   try/catch, skipped entirely without a client. A timeout, a transient error,
+   or a backend predating the contract (`422 FEATURE_NOT_SUPPORTED`) leaves
+   the field absent and mints the proposal exactly as before. Logged at info,
+   because an absent disclosure is a designed outcome of this path, not a
+   fault.
+3. **Absence is unknown, never safe.** Nothing substitutes a reassuring
+   default for a fact it could not obtain: no engine rather than "emulated",
+   no sandbox clause rather than "no sandbox", no provider list rather than an
+   empty one. `runProviders` is all-or-nothing (a model that declined
+   classification omits the whole list rather than naming fewer destinations
+   than the run reaches), and a compose run or a multi-target host group is
+   refused outright — the suite-base derivation those would fall back to is
+   the exact "emulated, no sandbox moments before a harness booted" failure
+   G4c refused for the host axis.
+
+**The limit:** this describes the plan as of the MINT, the same guarantee the
+proposal's `description` already carries. An attachment edit between the mint
+and the click is not re-disclosed here; the launch receipt's own disclosure
+(`run_eval_suite`'s `onDisclosure`) stays the authoritative at-click answer.
+The disclosure is envelope data only — it is not persisted with the proposal
+and is never accepted back from a host, because the click executes from the
+stored input and a disclosure that round-tripped would be a claim the host
+could author.
+
+No backend change and no deploy coupling: against a deployment predating the
+contract the fetch fails and the field is simply absent, which is the designed
+degrade.

--- a/docs/reference/openapi.json
+++ b/docs/reference/openapi.json
@@ -18055,6 +18055,76 @@
                     }
                   },
                   "description": "What the proposal is about, for correlating it with other turn output (e.g. suppressing a duplicate run affordance on the created suite it already offers to run). Display/dedup only — never an instruction. Absent means match-unknown; fall back to coarser behavior."
+                },
+                "disclosure": {
+                  "type": "object",
+                  "required": [
+                    "digest"
+                  ],
+                  "properties": {
+                    "digest": {
+                      "type": "string",
+                      "description": "Digest of the full disclosure contract this summarizes — the join key for correlating it with `GET /projects/{projectId}/eval-suites/{suiteId}/run-disclosure` and with the run's own audit record."
+                    },
+                    "engine": {
+                      "type": "string",
+                      "description": "`emulated`, `mixed`, or `harness:<id>`. Absent means UNKNOWN — never `emulated`, which is the reassuring reading."
+                    },
+                    "sandbox": {
+                      "type": "object",
+                      "required": [
+                        "engaged"
+                      ],
+                      "properties": {
+                        "engaged": {
+                          "type": "boolean"
+                        },
+                        "vendor": {
+                          "type": "string"
+                        }
+                      },
+                      "description": "Whether a sandbox is engaged for this plan, and whose. Absent means unknown — do not render \"no sandbox\" for it."
+                    },
+                    "runProviders": {
+                      "type": "array",
+                      "items": {
+                        "type": "string"
+                      },
+                      "description": "Providers the run's own models egress to, deduped. Absent when the plan's models did not resolve, or when any declined classification — a partial list would understate where content goes."
+                    },
+                    "judgeProviders": {
+                      "type": "array",
+                      "items": {
+                        "type": "string"
+                      },
+                      "description": "Providers reached by analysis/judge touchpoints that can fire, minus the run's own — the egress an approver did not choose. Absent means nothing extra to state or not derivable; never \"no judge egress\"."
+                    },
+                    "retention": {
+                      "type": "object",
+                      "required": [
+                        "policyDays",
+                        "effectiveToday"
+                      ],
+                      "properties": {
+                        "policyDays": {
+                          "type": [
+                            "integer",
+                            "null"
+                          ],
+                          "description": "The POLICY number from plan entitlements; `null` means uncapped by policy."
+                        },
+                        "effectiveToday": {
+                          "type": "string",
+                          "description": "What actually happens today (`kept-indefinitely` / `swept-after-policy-days`). Never re-derive it from `policyDays` — an unenforced policy keeps data indefinitely whatever its number."
+                        }
+                      }
+                    },
+                    "byok": {
+                      "type": "boolean",
+                      "description": "True when any of the run's models runs on an org-configured key rather than the managed rail. Absent means unknown, not `false`."
+                    }
+                  },
+                  "description": "What a run of this proposal would disclose, as of MINT TIME — present only on the eval-run proposals, and only when the pre-run disclosure contract answered for the frozen input the click will execute. A SUMMARY, not the contract: call `get_eval_run_disclosure` for the whole payload, joined by `digest`. ABSENT MEANS UNKNOWN, NEVER SAFE — render nothing for a missing field rather than a reassuring default. Describes the plan at mint; the launch receipt's own disclosure is the authoritative at-click answer."
                 }
               }
             }

--- a/mcpjam-inspector/server/routes/v1/__tests__/agent-op-registry.test.ts
+++ b/mcpjam-inspector/server/routes/v1/__tests__/agent-op-registry.test.ts
@@ -198,6 +198,26 @@ describe("agent op registry", () => {
     }
   });
 
+  it("declares the pre-run disclosure hook on exactly the two eval-run entries", () => {
+    // A REGISTRY FLAG, not a name check at the mint site. The two run
+    // operations are the ones whose click sends content to models the
+    // approver never chose; every other gated op either spends without
+    // egressing content the approver can be surprised by, or has no launch
+    // plan to disclose at all. A disclosure attached to one of those would be
+    // a claim about a plan nobody resolved.
+    const declaring = AGENT_API_GATED_OPERATIONS.map((op) => op.name).filter(
+      (name) => proposalMetaFor(name).carriesDisclosure
+    );
+    expect(declaring.sort()).toEqual(
+      [runEvalSuiteOperation.name, runEvalCaseOperation.name].sort()
+    );
+    // An operation this build does not gate must never carry one either — the
+    // neutral fallback is what a caller that should have refused already gets.
+    expect(proposalMetaFor("not_a_registered_operation").carriesDisclosure).toBe(
+      false
+    );
+  });
+
   it("describes each gated proposal by its TARGET, not its cost", () => {
     // Any number here would be an estimate, and an estimate rendered next to
     // an approval button reads as a promise.

--- a/mcpjam-inspector/server/routes/v1/__tests__/agent-proposal-disclosure.test.ts
+++ b/mcpjam-inspector/server/routes/v1/__tests__/agent-proposal-disclosure.test.ts
@@ -114,13 +114,16 @@ describe("disclosureInputForProposal", () => {
 
   it("maps a frozen suite run onto the disclosure operation's own vocabulary", () => {
     expect(
-      disclosureInputForProposal(suite, {
-        project: "p1",
-        suite: "s1",
-        environments: ["env_1", "env_2"],
-        cases: ["c1"],
-        repetitions: 3,
-      })
+      disclosureInputForProposal(
+        suite,
+        {
+          suite: "s1",
+          environments: ["env_1", "env_2"],
+          cases: ["c1"],
+          repetitions: 3,
+        },
+        "p1"
+      )
     ).toEqual({
       project: "p1",
       suite: "s1",
@@ -133,12 +136,11 @@ describe("disclosureInputForProposal", () => {
     // The two selector vocabularies overlap but are not the same, and this is
     // the one place they differ by more than a name.
     expect(
-      disclosureInputForProposal(runEvalCaseOperation.name, {
-        project: "p1",
-        suite: "s1",
-        case: "case_7",
-        host: "host_1",
-      })
+      disclosureInputForProposal(
+        runEvalCaseOperation.name,
+        { suite: "s1", case: "case_7", host: "host_1" },
+        "p1"
+      )
     ).toEqual({
       project: "p1",
       suite: "s1",
@@ -149,11 +151,7 @@ describe("disclosureInputForProposal", () => {
 
   it("collapses a single frozen `hosts` entry onto the singular selector", () => {
     expect(
-      disclosureInputForProposal(suite, {
-        project: "p1",
-        suite: "s1",
-        hosts: ["host_1"],
-      })
+      disclosureInputForProposal(suite, { suite: "s1", hosts: ["host_1"] }, "p1")
     ).toEqual({ project: "p1", suite: "s1", host: "host_1" });
   });
 
@@ -162,11 +160,7 @@ describe("disclosureInputForProposal", () => {
     // single engine or model set, and stitching N round trips would be a
     // different contract than the audit stamp records.
     expect(
-      disclosureInputForProposal(suite, {
-        project: "p1",
-        suite: "s1",
-        hosts: ["host_1", "host_2"],
-      })
+      disclosureInputForProposal(suite, { suite: "s1", hosts: ["host_1", "host_2"] }, "p1")
     ).toBeUndefined();
   });
 
@@ -176,11 +170,7 @@ describe("disclosureInputForProposal", () => {
     // contradict. That is the exact "emulated, no sandbox moments before a
     // harness booted" failure G4c refused for the host axis.
     expect(
-      disclosureInputForProposal(suite, {
-        project: "p1",
-        suite: "s1",
-        compose: { models: ["anthropic/claude-x"] },
-      })
+      disclosureInputForProposal(suite, { suite: "s1", compose: { models: ["anthropic/claude-x"] } }, "p1")
     ).toBeUndefined();
   });
 
@@ -188,28 +178,38 @@ describe("disclosureInputForProposal", () => {
     // Still present means the freeze degraded, so the target set is whatever
     // is attached at CLICK time — unknown now, nothing honest to disclose.
     expect(
-      disclosureInputForProposal(suite, {
-        project: "p1",
-        suite: "s1",
-        allAttached: true,
-      })
+      disclosureInputForProposal(suite, { suite: "s1", allAttached: true }, "p1")
     ).toBeUndefined();
   });
 
   it("refuses an incoherent host+environment pair rather than letting the op throw", () => {
     expect(
-      disclosureInputForProposal(suite, {
-        project: "p1",
-        suite: "s1",
-        host: "host_1",
-        environment: "env_1",
-      })
+      disclosureInputForProposal(suite, { suite: "s1", host: "host_1", environment: "env_1" }, "p1")
     ).toBeUndefined();
   });
 
-  it("refuses without a project or a suite", () => {
-    expect(disclosureInputForProposal(suite, { suite: "s1" })).toBeUndefined();
-    expect(disclosureInputForProposal(suite, { project: "p1" })).toBeUndefined();
+  it("refuses without a suite, or without a project to run it in", () => {
+    // The project comes from the CALLER, not the input: the approval route
+    // re-clamps the stored input to the persisted project, so that is what the
+    // click actually uses. An input naming a different one cannot widen it.
+    expect(disclosureInputForProposal(suite, {}, "p1")).toBeUndefined();
+    expect(disclosureInputForProposal(suite, { suite: "s1" }, "")).toBeUndefined();
+    expect(
+      disclosureInputForProposal(suite, { suite: "s1" }, "   ")
+    ).toBeUndefined();
+  });
+
+  it("takes the project from the caller, never from the frozen input", () => {
+    // `input.project` is overwritten at click time
+    // (`proposed-actions.ts`: `{ ...claim.input, project: claim.projectId }`),
+    // so disclosing against it would describe a project the run will not use.
+    expect(
+      disclosureInputForProposal(suite, { project: "p_other", suite: "s1" }, "p1")
+    ).toEqual({ project: "p1", suite: "s1" });
+    // And a frozen input with no `project` at all still discloses.
+    expect(
+      disclosureInputForProposal(suite, { suite: "s1" }, "p1")
+    ).toEqual({ project: "p1", suite: "s1" });
   });
 });
 
@@ -373,7 +373,8 @@ describe("disclosureForProposal", () => {
   // contract — bound the fetch, swallow every failure, never call out for a
   // plan the mapping already refused.
   const client = {} as PlatformApiClient;
-  const FROZEN = { project: "p1", suite: "ts_1" };
+  const FROZEN = { suite: "ts_1" };
+  const PROJECT_ID = "p1";
 
   afterEach(() => {
     vi.restoreAllMocks();
@@ -395,6 +396,7 @@ describe("disclosureForProposal", () => {
     const summary = await disclosureForProposal({
       operationName: runEvalCaseOperation.name,
       input: { ...FROZEN, case: "case_7" },
+      projectId: PROJECT_ID,
       client,
     });
     expect(summary).toMatchObject({ digest: "deadbeef", engine: "emulated" });
@@ -422,6 +424,7 @@ describe("disclosureForProposal", () => {
       await disclosureForProposal({
         operationName: runEvalSuiteOperation.name,
         input: FROZEN,
+        projectId: PROJECT_ID,
         client,
       });
       expect(captured).toBeInstanceOf(AbortSignal);
@@ -443,6 +446,7 @@ describe("disclosureForProposal", () => {
       disclosureForProposal({
         operationName: runEvalSuiteOperation.name,
         input: FROZEN,
+        projectId: PROJECT_ID,
         client,
       })
     ).resolves.toBeUndefined();
@@ -458,6 +462,7 @@ describe("disclosureForProposal", () => {
       disclosureForProposal({
         operationName: runEvalSuiteOperation.name,
         input: FROZEN,
+        projectId: PROJECT_ID,
         client,
       })
     ).resolves.toBeUndefined();
@@ -473,6 +478,7 @@ describe("disclosureForProposal", () => {
       disclosureForProposal({
         operationName: runEvalSuiteOperation.name,
         input: FROZEN,
+        projectId: PROJECT_ID,
         client,
       })
     ).resolves.toBeUndefined();
@@ -489,6 +495,7 @@ describe("disclosureForProposal", () => {
       disclosureForProposal({
         operationName: runEvalSuiteOperation.name,
         input: FROZEN,
+        projectId: PROJECT_ID,
         client,
       })
     ).resolves.toBeUndefined();
@@ -508,6 +515,7 @@ describe("disclosureForProposal", () => {
         disclosureForProposal({
           operationName: runEvalSuiteOperation.name,
           input,
+          projectId: PROJECT_ID,
           client,
         })
       ).resolves.toBeUndefined();
@@ -517,21 +525,21 @@ describe("disclosureForProposal", () => {
 
   it("refuses empty and missing selectors without calling out", async () => {
     const spy = mockLookup(async () => baseDisclosure());
-    for (const input of [
-      {},
-      { project: "p1" },
-      { suite: "ts_1" },
-      // Whitespace-only is empty: a selector that trims to nothing cannot
-      // identify a plan, and sending it would just move the failure one hop.
-      { project: "   ", suite: "ts_1" },
-      { project: "p1", suite: "   " },
-      { project: null, suite: "ts_1" },
-      { project: "p1", suite: 42 },
-    ] as Array<Record<string, unknown>>) {
+    // Whitespace-only is empty: a selector that trims to nothing cannot
+    // identify a plan, and sending it would just move the failure one hop.
+    for (const [input, projectId] of [
+      [{}, PROJECT_ID],
+      [{ suite: "   " }, PROJECT_ID],
+      [{ suite: 42 }, PROJECT_ID],
+      [{ suite: null }, PROJECT_ID],
+      [{ suite: "ts_1" }, ""],
+      [{ suite: "ts_1" }, "   "],
+    ] as Array<[Record<string, unknown>, string]>) {
       await expect(
         disclosureForProposal({
           operationName: runEvalSuiteOperation.name,
           input,
+          projectId,
           client,
         })
       ).resolves.toBeUndefined();

--- a/mcpjam-inspector/server/routes/v1/__tests__/agent-proposal-disclosure.test.ts
+++ b/mcpjam-inspector/server/routes/v1/__tests__/agent-proposal-disclosure.test.ts
@@ -1,0 +1,362 @@
+/**
+ * The proposal disclosure's two halves: which frozen inputs the contract can
+ * be asked about at all, and what a full contract projects down to on an
+ * approval card.
+ *
+ * Almost every assertion here is about an ABSENCE. That is the point: for a
+ * disclosure, the reassuring value ("emulated, no sandbox", "nothing leaves")
+ * is exactly what an unanswered question must never become, so the tests that
+ * matter most are the ones proving a field stays OFF rather than defaulting on.
+ */
+import { describe, expect, it } from "vitest";
+import { runEvalCaseOperation, runEvalSuiteOperation } from "@mcpjam/sdk/platform";
+import type { PlatformEvalRunDisclosure } from "@mcpjam/sdk/platform";
+import {
+  disclosureInputForProposal,
+  summarizeDisclosure,
+} from "../agent-proposal-disclosure.js";
+
+function baseDisclosure(
+  overrides: Partial<PlatformEvalRunDisclosure> = {}
+): PlatformEvalRunDisclosure {
+  return {
+    contractVersion: 1,
+    computedAt: 0,
+    digest: "deadbeef",
+    execution: {
+      engine: "emulated",
+      sandbox: { engaged: false, because: "no computer environment" },
+      locus: { known: true, hosted: true },
+      models: [
+        {
+          modelId: "anthropic/claude-x",
+          provider: "anthropic",
+          tenantEgress: "mcpjam-hosted",
+          rail: {
+            managed: true,
+            possibleDestinations: ["gateway"],
+            outcomeIfRunNow: {
+              destination: "gateway",
+              observedAt: 0,
+              volatile: true,
+            },
+            inputs: {
+              mode: "auto",
+              gatewayEligible: true,
+              hasOpenRouterFallback: null,
+            },
+            ruleLocation: "resolveChatProvider",
+            authoritativePerRequestRecord: "the run's own record",
+          },
+        },
+      ],
+    },
+    analysis: [],
+    capture: {
+      captureLevel: "summary",
+      reportingMode: "standard",
+      tiersImplemented: false,
+      redaction: {
+        kind: "regex",
+        module: "redact.ts",
+        isDlp: false,
+        limitation: "patterns only",
+        appliesTo: ["prompts"],
+      },
+      exportDefaults: {
+        includeContent: false,
+        ruleLocation: "export.ts",
+        note: "content excluded by default",
+      },
+    },
+    retention: {
+      planName: "pro",
+      policyDays: 30,
+      source: "entitlements",
+      enforced: true,
+      enforcementBlockers: [],
+      effectiveToday: "swept-after-policy-days",
+      evidentiaryClasses: ["runs"],
+      backupStatement: {
+        vendor: "convex",
+        capturedAt: "2026-01-01",
+        sourceUrl: "https://example.invalid",
+        statements: [],
+      },
+    },
+    region: { stated: false, reason: "not derivable" },
+    subprocessors: [],
+    ...overrides,
+  };
+}
+
+/** One analysis touchpoint that CAN fire, on the named model. */
+function touchpoint(model: string, fires: "auto-on-completion" | { disabled: true; reason: string }) {
+  return {
+    touchpoint: "goalCompletion" as const,
+    label: "Goal-completion judge",
+    model,
+    rail: { fixed: "openrouter" as const, because: "fixed" },
+    destinations: ["OpenRouter (openrouter.ai)"],
+    evidenceSent: ["case prompt"],
+    fires,
+  };
+}
+
+describe("disclosureInputForProposal", () => {
+  const suite = runEvalSuiteOperation.name;
+
+  it("maps a frozen suite run onto the disclosure operation's own vocabulary", () => {
+    expect(
+      disclosureInputForProposal(suite, {
+        project: "p1",
+        suite: "s1",
+        environments: ["env_1", "env_2"],
+        cases: ["c1"],
+        repetitions: 3,
+      })
+    ).toEqual({
+      project: "p1",
+      suite: "s1",
+      cases: ["c1"],
+      environments: ["env_1", "env_2"],
+    });
+  });
+
+  it("maps a case run's singular `case` onto `cases`", () => {
+    // The two selector vocabularies overlap but are not the same, and this is
+    // the one place they differ by more than a name.
+    expect(
+      disclosureInputForProposal(runEvalCaseOperation.name, {
+        project: "p1",
+        suite: "s1",
+        case: "case_7",
+        host: "host_1",
+      })
+    ).toEqual({
+      project: "p1",
+      suite: "s1",
+      cases: ["case_7"],
+      host: "host_1",
+    });
+  });
+
+  it("collapses a single frozen `hosts` entry onto the singular selector", () => {
+    expect(
+      disclosureInputForProposal(suite, {
+        project: "p1",
+        suite: "s1",
+        hosts: ["host_1"],
+      })
+    ).toEqual({ project: "p1", suite: "s1", host: "host_1" });
+  });
+
+  it("refuses a MULTI-TARGET host group — no single plan to disclose", () => {
+    // The contract answers per launch plan; a fan-out spanning hosts has no
+    // single engine or model set, and stitching N round trips would be a
+    // different contract than the audit stamp records.
+    expect(
+      disclosureInputForProposal(suite, {
+        project: "p1",
+        suite: "s1",
+        hosts: ["host_1", "host_2"],
+      })
+    ).toBeUndefined();
+  });
+
+  it("refuses a COMPOSE run — the suite-base derivation would contradict it", () => {
+    // Composed models are attached to nothing, so the only query available is
+    // the selector-less suite-base one, which the composed models can flatly
+    // contradict. That is the exact "emulated, no sandbox moments before a
+    // harness booted" failure G4c refused for the host axis.
+    expect(
+      disclosureInputForProposal(suite, {
+        project: "p1",
+        suite: "s1",
+        compose: { models: ["anthropic/claude-x"] },
+      })
+    ).toBeUndefined();
+  });
+
+  it("refuses an input where `allAttached` survived the freeze", () => {
+    // Still present means the freeze degraded, so the target set is whatever
+    // is attached at CLICK time — unknown now, nothing honest to disclose.
+    expect(
+      disclosureInputForProposal(suite, {
+        project: "p1",
+        suite: "s1",
+        allAttached: true,
+      })
+    ).toBeUndefined();
+  });
+
+  it("refuses an incoherent host+environment pair rather than letting the op throw", () => {
+    expect(
+      disclosureInputForProposal(suite, {
+        project: "p1",
+        suite: "s1",
+        host: "host_1",
+        environment: "env_1",
+      })
+    ).toBeUndefined();
+  });
+
+  it("refuses without a project or a suite", () => {
+    expect(disclosureInputForProposal(suite, { suite: "s1" })).toBeUndefined();
+    expect(disclosureInputForProposal(suite, { project: "p1" })).toBeUndefined();
+  });
+});
+
+describe("summarizeDisclosure", () => {
+  it("carries the digest, engine, sandbox, providers and retention", () => {
+    expect(summarizeDisclosure(baseDisclosure())).toEqual({
+      digest: "deadbeef",
+      engine: "emulated",
+      sandbox: { engaged: false },
+      runProviders: ["anthropic"],
+      byok: false,
+      retention: { policyDays: 30, effectiveToday: "swept-after-policy-days" },
+    });
+  });
+
+  it("names the sandbox vendor when one is engaged", () => {
+    const disclosure = baseDisclosure();
+    disclosure.execution!.sandbox = {
+      engaged: true,
+      vendor: "e2b",
+      because: "computer environment",
+    };
+    expect(summarizeDisclosure(disclosure).sandbox).toEqual({
+      engaged: true,
+      vendor: "e2b",
+    });
+  });
+
+  it("says NOTHING about execution when the contract resolved no plan", () => {
+    // The reassuring reading of an absent execution section is the one thing
+    // this must never produce: no engine, no sandbox, no providers, no byok.
+    const disclosure = baseDisclosure();
+    delete disclosure.execution;
+    disclosure.executionAbsence = {
+      kind: "plan-unresolved",
+      reason: "environments did not resolve",
+    };
+    const summary = summarizeDisclosure(disclosure);
+    expect(summary.engine).toBeUndefined();
+    expect(summary.sandbox).toBeUndefined();
+    expect(summary.runProviders).toBeUndefined();
+    expect(summary.byok).toBeUndefined();
+    // The digest and retention still hold — they are facts about content, not
+    // about a launch plan.
+    expect(summary.digest).toBe("deadbeef");
+    expect(summary.retention).toEqual({
+      policyDays: 30,
+      effectiveToday: "swept-after-policy-days",
+    });
+  });
+
+  it("omits providers and byok when the models did not resolve", () => {
+    // An empty `models` with `modelsUnresolved` means models WILL run and are
+    // not derivable here. An empty provider list would read as "nothing
+    // egresses" — the same collapse, one field over.
+    const disclosure = baseDisclosure();
+    disclosure.execution!.models = [];
+    disclosure.execution!.modelsUnresolved = { reason: "no environment" };
+    const summary = summarizeDisclosure(disclosure);
+    expect(summary.runProviders).toBeUndefined();
+    expect(summary.byok).toBeUndefined();
+    // The engine and sandbox DID resolve, so they are still stated.
+    expect(summary.engine).toBe("emulated");
+  });
+
+  it("omits runProviders entirely when any model declined classification", () => {
+    // ALL-OR-NOTHING: a list with the unclassified model quietly missing names
+    // fewer destinations than the run actually reaches.
+    const disclosure = baseDisclosure();
+    disclosure.execution!.models = [
+      ...disclosure.execution!.models,
+      {
+        modelId: "custom/thing",
+        provider: null,
+        tenantEgress: "unknown",
+        rail: {
+          managed: false,
+          notApplicable: true,
+          reason: "custom provider",
+          authoritativePerRequestRecord: "the run's own record",
+        },
+      },
+    ];
+    expect(summarizeDisclosure(disclosure).runProviders).toBeUndefined();
+  });
+
+  it("reports byok from either the byok block or the tenant egress", () => {
+    const viaBlock = baseDisclosure();
+    viaBlock.execution!.models[0]!.byok = {
+      providerKey: "k1",
+      runtimeLocation: "cloud",
+    };
+    expect(summarizeDisclosure(viaBlock).byok).toBe(true);
+
+    const viaEgress = baseDisclosure();
+    viaEgress.execution!.models[0]!.tenantEgress = "byok-local";
+    expect(summarizeDisclosure(viaEgress).byok).toBe(true);
+  });
+
+  it("lists only judge providers the run does NOT already reach", () => {
+    const disclosure = baseDisclosure({
+      analysis: [
+        touchpoint("openai/gpt-5.4-mini", "auto-on-completion"),
+        // Same provider the run itself uses: not a surprise, so not stated.
+        touchpoint("anthropic/claude-x", "auto-on-completion"),
+      ],
+    });
+    expect(summarizeDisclosure(disclosure).judgeProviders).toEqual(["openai"]);
+  });
+
+  it("ignores touchpoints that cannot fire", () => {
+    // Warning about egress that cannot happen is the mirror image of hiding
+    // egress that can — dishonest in the other direction.
+    const disclosure = baseDisclosure({
+      analysis: [
+        touchpoint("openai/gpt-5.4-mini", {
+          disabled: true,
+          reason: "no analyzer key",
+        }),
+      ],
+    });
+    expect(summarizeDisclosure(disclosure).judgeProviders).toBeUndefined();
+  });
+
+  it("lists every firing judge when the run's own providers are unknown", () => {
+    // Nothing to subtract, so nothing is subtracted — erring toward
+    // disclosing more, the only direction a disclosure may err.
+    const disclosure = baseDisclosure({
+      analysis: [touchpoint("openai/gpt-5.4-mini", "auto-on-completion")],
+    });
+    disclosure.execution!.models[0]!.provider = null;
+    const summary = summarizeDisclosure(disclosure);
+    expect(summary.runProviders).toBeUndefined();
+    expect(summary.judgeProviders).toEqual(["openai"]);
+  });
+
+  it("omits judgeProviders when a judge model carries no vendor prefix", () => {
+    const disclosure = baseDisclosure({
+      analysis: [
+        touchpoint("openai/gpt-5.4-mini", "auto-on-completion"),
+        touchpoint("some-bare-model-id", "auto-on-completion"),
+      ],
+    });
+    expect(summarizeDisclosure(disclosure).judgeProviders).toBeUndefined();
+  });
+
+  it("takes `effectiveToday` from the contract, never from policyDays", () => {
+    // An unenforced policy keeps data indefinitely whatever its number says.
+    const disclosure = baseDisclosure();
+    disclosure.retention.effectiveToday = "kept-indefinitely";
+    expect(summarizeDisclosure(disclosure).retention).toEqual({
+      policyDays: 30,
+      effectiveToday: "kept-indefinitely",
+    });
+  });
+});

--- a/mcpjam-inspector/server/routes/v1/__tests__/agent-proposal-disclosure.test.ts
+++ b/mcpjam-inspector/server/routes/v1/__tests__/agent-proposal-disclosure.test.ts
@@ -8,10 +8,16 @@
  * is exactly what an unanswered question must never become, so the tests that
  * matter most are the ones proving a field stays OFF rather than defaulting on.
  */
-import { describe, expect, it } from "vitest";
-import { runEvalCaseOperation, runEvalSuiteOperation } from "@mcpjam/sdk/platform";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+  getEvalRunDisclosureOperation,
+  runEvalCaseOperation,
+  runEvalSuiteOperation,
+  type PlatformApiClient,
+} from "@mcpjam/sdk/platform";
 import type { PlatformEvalRunDisclosure } from "@mcpjam/sdk/platform";
 import {
+  disclosureForProposal,
   disclosureInputForProposal,
   summarizeDisclosure,
 } from "../agent-proposal-disclosure.js";
@@ -358,5 +364,178 @@ describe("summarizeDisclosure", () => {
       policyDays: 30,
       effectiveToday: "kept-indefinitely",
     });
+  });
+});
+
+describe("disclosureForProposal", () => {
+  // The operation is the only thing this wrapper talks to, so it is the only
+  // thing mocked: everything else under test here is the wrapper's own
+  // contract — bound the fetch, swallow every failure, never call out for a
+  // plan the mapping already refused.
+  const client = {} as PlatformApiClient;
+  const FROZEN = { project: "p1", suite: "ts_1" };
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  function mockLookup(
+    implementation: (
+      input: unknown,
+      context: { client: PlatformApiClient; signal?: AbortSignal }
+    ) => Promise<unknown>
+  ) {
+    return vi
+      .spyOn(getEvalRunDisclosureOperation, "execute")
+      .mockImplementation(implementation as never);
+  }
+
+  it("summarizes a successful lookup, asked with the MAPPED input", async () => {
+    const spy = mockLookup(async () => baseDisclosure());
+    const summary = await disclosureForProposal({
+      operationName: runEvalCaseOperation.name,
+      input: { ...FROZEN, case: "case_7" },
+      client,
+    });
+    expect(summary).toMatchObject({ digest: "deadbeef", engine: "emulated" });
+    // The wrapper hands over the disclosure vocabulary, not the run's.
+    expect(spy).toHaveBeenCalledWith(
+      { project: "p1", suite: "ts_1", cases: ["case_7"] },
+      expect.objectContaining({ client })
+    );
+  });
+
+  it(
+    "bounds the fetch with a signal that aborts ON ITS OWN",
+    async () => {
+      // The single most important safety property of this path: a stalled
+      // backend must not be able to hold a mint open indefinitely. Asserting
+      // "an AbortSignal was passed" would pass for a signal nobody ever
+      // aborts, so this waits for the abort to actually fire and checks it
+      // came from a TIMEOUT rather than a caller — there is no caller signal
+      // here, deliberately, so nothing else could have aborted it.
+      let captured: AbortSignal | undefined;
+      mockLookup(async (_input, context) => {
+        captured = context.signal;
+        return baseDisclosure();
+      });
+      await disclosureForProposal({
+        operationName: runEvalSuiteOperation.name,
+        input: FROZEN,
+        client,
+      });
+      expect(captured).toBeInstanceOf(AbortSignal);
+      expect(captured!.aborted).toBe(false);
+      await new Promise<void>((resolve) =>
+        captured!.addEventListener("abort", () => resolve(), { once: true })
+      );
+      expect((captured!.reason as Error | undefined)?.name).toBe("TimeoutError");
+    },
+    10_000
+  );
+
+  it("returns undefined — never throws — when the lookup rejects", async () => {
+    // A transient error, a 5xx, anything. The mint proceeds without a line.
+    mockLookup(async () => {
+      throw new Error("upstream exploded");
+    });
+    await expect(
+      disclosureForProposal({
+        operationName: runEvalSuiteOperation.name,
+        input: FROZEN,
+        client,
+      })
+    ).resolves.toBeUndefined();
+  });
+
+  it("returns undefined on a backend that predates the contract", async () => {
+    // `422 FEATURE_NOT_SUPPORTED` is the DESIGNED degrade, not a fault — it is
+    // what every mint gets until the backend half is promoted.
+    mockLookup(async () => {
+      throw new Error("FEATURE_NOT_SUPPORTED: contract_unavailable");
+    });
+    await expect(
+      disclosureForProposal({
+        operationName: runEvalSuiteOperation.name,
+        input: FROZEN,
+        client,
+      })
+    ).resolves.toBeUndefined();
+  });
+
+  it("returns undefined when the fetch is aborted by its own timeout", async () => {
+    const abortError = new Error("The operation was aborted");
+    abortError.name = "TimeoutError";
+    mockLookup(async () => {
+      throw abortError;
+    });
+    await expect(
+      disclosureForProposal({
+        operationName: runEvalSuiteOperation.name,
+        input: FROZEN,
+        client,
+      })
+    ).resolves.toBeUndefined();
+  });
+
+  it("returns undefined on the operation's own one-plan refusal", async () => {
+    // A suite with several attached targets and no selector, or a group the
+    // contract cannot answer for: the operation throws, and that reaches the
+    // approver as an absent line rather than a failed mint.
+    mockLookup(async () => {
+      throw new Error("Disclosure covers ONE launch plan");
+    });
+    await expect(
+      disclosureForProposal({
+        operationName: runEvalSuiteOperation.name,
+        input: FROZEN,
+        client,
+      })
+    ).resolves.toBeUndefined();
+  });
+
+  it("never calls out for a plan the mapping already refused", async () => {
+    // Not just "returns undefined": a refused mapping must cost ZERO round
+    // trips, because the answer is already known and a mint is waiting on it.
+    const spy = mockLookup(async () => baseDisclosure());
+    for (const input of [
+      { ...FROZEN, hosts: ["h1", "h2"] },
+      { ...FROZEN, compose: { models: ["anthropic/claude-x"] } },
+      { ...FROZEN, allAttached: true },
+      { ...FROZEN, host: "h1", environment: "env_1" },
+    ]) {
+      await expect(
+        disclosureForProposal({
+          operationName: runEvalSuiteOperation.name,
+          input,
+          client,
+        })
+      ).resolves.toBeUndefined();
+    }
+    expect(spy).not.toHaveBeenCalled();
+  });
+
+  it("refuses empty and missing selectors without calling out", async () => {
+    const spy = mockLookup(async () => baseDisclosure());
+    for (const input of [
+      {},
+      { project: "p1" },
+      { suite: "ts_1" },
+      // Whitespace-only is empty: a selector that trims to nothing cannot
+      // identify a plan, and sending it would just move the failure one hop.
+      { project: "   ", suite: "ts_1" },
+      { project: "p1", suite: "   " },
+      { project: null, suite: "ts_1" },
+      { project: "p1", suite: 42 },
+    ] as Array<Record<string, unknown>>) {
+      await expect(
+        disclosureForProposal({
+          operationName: runEvalSuiteOperation.name,
+          input,
+          client,
+        })
+      ).resolves.toBeUndefined();
+    }
+    expect(spy).not.toHaveBeenCalled();
   });
 });

--- a/mcpjam-inspector/server/routes/v1/__tests__/agent.test.ts
+++ b/mcpjam-inspector/server/routes/v1/__tests__/agent.test.ts
@@ -132,6 +132,7 @@ import {
   cancelEvalRunOperation,
   createEvalSuiteOperation,
   getEvalIterationTraceOperation,
+  getEvalRunDisclosureOperation,
   getEvalRunOperation,
   installRegistryDirectoryServerOperation,
   listProjectServersOperation,
@@ -185,6 +186,92 @@ const VALID_CREATE_INPUT = {
       ],
     },
   ],
+};
+
+/**
+ * A pre-run disclosure as `get_eval_run_disclosure` answers it, trimmed to the
+ * sections the proposal summary actually reads. The projection's own branches
+ * (absent execution, unresolved models, unclassified providers) are covered in
+ * `agent-proposal-disclosure.test.ts`; here it only has to be a plausible
+ * success so the ENVELOPE plumbing is what is under test.
+ */
+const RUN_DISCLOSURE = {
+  contractVersion: 1,
+  computedAt: 0,
+  digest: "digest_1",
+  execution: {
+    engine: "harness:claude-code",
+    sandbox: { engaged: true, vendor: "e2b", because: "harness" },
+    locus: { known: true, hosted: true },
+    models: [
+      {
+        modelId: "anthropic/claude-x",
+        provider: "anthropic",
+        tenantEgress: "mcpjam-hosted",
+        rail: {
+          managed: true,
+          possibleDestinations: ["gateway"],
+          outcomeIfRunNow: {
+            destination: "gateway",
+            observedAt: 0,
+            volatile: true,
+          },
+          inputs: {
+            mode: "auto",
+            gatewayEligible: true,
+            hasOpenRouterFallback: null,
+          },
+          ruleLocation: "resolveChatProvider",
+          authoritativePerRequestRecord: "the run's own record",
+        },
+      },
+    ],
+  },
+  analysis: [
+    {
+      touchpoint: "goalCompletion",
+      label: "Goal-completion judge",
+      model: "openai/gpt-5.4-mini",
+      rail: { fixed: "openrouter", because: "fixed" },
+      destinations: ["OpenRouter (openrouter.ai)"],
+      evidenceSent: ["case prompt"],
+      fires: "auto-on-completion",
+    },
+  ],
+  capture: {
+    captureLevel: "summary",
+    reportingMode: "standard",
+    tiersImplemented: false,
+    redaction: {
+      kind: "regex",
+      module: "redact.ts",
+      isDlp: false,
+      limitation: "patterns only",
+      appliesTo: ["prompts"],
+    },
+    exportDefaults: {
+      includeContent: false,
+      ruleLocation: "export.ts",
+      note: "content excluded by default",
+    },
+  },
+  retention: {
+    planName: "pro",
+    policyDays: 30,
+    source: "entitlements",
+    enforced: true,
+    enforcementBlockers: [],
+    effectiveToday: "swept-after-policy-days",
+    evidentiaryClasses: ["runs"],
+    backupStatement: {
+      vendor: "convex",
+      capturedAt: "2026-01-01",
+      sourceUrl: "https://example.invalid",
+      statements: [],
+    },
+  },
+  region: { stated: false, reason: "not derivable" },
+  subprocessors: [],
 };
 
 function okTurnResult(overrides: Record<string, unknown> = {}) {
@@ -1108,6 +1195,222 @@ describe("gated proposal tools", () => {
       })
     );
     executeSpy.mockRestore();
+  });
+
+  it("carries the pre-run disclosure on a run proposal, from the FROZEN input", async () => {
+    // ONE RESOLUTION: the fetch is keyed by the input the CLICK will execute,
+    // so "what was disclosed" is "what will run" — never a second,
+    // independently resolved target that could name different models.
+    const app = makeApp();
+    const disclosureSpy = vi
+      .spyOn(getEvalRunDisclosureOperation, "execute")
+      .mockResolvedValue(RUN_DISCLOSURE as never);
+    let captured: Record<string, GatedTool> | undefined;
+    prepareChatV2Mock.mockImplementation(async (opts: any) => {
+      captured = opts.builtInTools;
+      return {
+        allTools: opts.builtInTools ?? {},
+        enhancedSystemPrompt: opts.systemPrompt,
+      };
+    });
+    runUnifiedAssistantTurnMock.mockImplementation(async () => {
+      await captured![runEvalSuiteOperation.name]!.execute(
+        { suite: "smoke", cases: ["case_a"] },
+        {}
+      );
+      return okTurnResult();
+    });
+
+    const res = await app.request("/api/v1/projects/p1/agent", {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        Authorization: `Bearer ${SLACK_TOKEN}`,
+        "x-mcpjam-slack-team-id": "T1",
+        "x-mcpjam-slack-user-id": "U1",
+      },
+      body: JSON.stringify({ ...OK_BODY, conversationId: "C1" }),
+    });
+    const body = (await res.json()) as {
+      proposedActions: Array<Record<string, unknown>>;
+    };
+    expect(body.proposedActions).toHaveLength(1);
+    expect(body.proposedActions[0]!.disclosure).toEqual({
+      digest: "digest_1",
+      engine: "harness:claude-code",
+      sandbox: { engaged: true, vendor: "e2b" },
+      runProviders: ["anthropic"],
+      byok: false,
+      judgeProviders: ["openai"],
+      retention: { policyDays: 30, effectiveToday: "swept-after-policy-days" },
+    });
+    // Asked in the DISCLOSURE operation's own vocabulary, about the same
+    // project/suite/cases the stored proposal carries.
+    expect(disclosureSpy).toHaveBeenCalledWith(
+      expect.objectContaining({
+        project: "p1",
+        suite: "smoke",
+        cases: ["case_a"],
+      }),
+      expect.anything()
+    );
+    // The disclosure is ENVELOPE data. `createProposedAction` stores the
+    // frozen input and nothing else — a disclosure that round-tripped through
+    // a host would be a claim the host could author.
+    expect(createProposedActionMock).toHaveBeenLastCalledWith(
+      expect.not.objectContaining({ disclosure: expect.anything() })
+    );
+    // And the input still never leaves the server.
+    expect(body.proposedActions[0]).not.toHaveProperty("input");
+    disclosureSpy.mockRestore();
+  });
+
+  it("mints the run proposal anyway when the disclosure fetch fails", async () => {
+    // BEST-EFFORT: a timeout, a backend predating the contract, a transient
+    // error — none of them may cost the user the button. The field is simply
+    // absent, and every renderer's rule for absent is "render nothing".
+    const app = makeApp();
+    const disclosureSpy = vi
+      .spyOn(getEvalRunDisclosureOperation, "execute")
+      .mockRejectedValue(new Error("FEATURE_NOT_SUPPORTED"));
+    let captured: Record<string, GatedTool> | undefined;
+    prepareChatV2Mock.mockImplementation(async (opts: any) => {
+      captured = opts.builtInTools;
+      return {
+        allTools: opts.builtInTools ?? {},
+        enhancedSystemPrompt: opts.systemPrompt,
+      };
+    });
+    runUnifiedAssistantTurnMock.mockImplementation(async () => {
+      await captured![runEvalSuiteOperation.name]!.execute(
+        { suite: "smoke" },
+        {}
+      );
+      return okTurnResult();
+    });
+
+    const res = await app.request("/api/v1/projects/p1/agent", {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        Authorization: `Bearer ${SLACK_TOKEN}`,
+        "x-mcpjam-slack-team-id": "T1",
+        "x-mcpjam-slack-user-id": "U1",
+      },
+      body: JSON.stringify({ ...OK_BODY, conversationId: "C1" }),
+    });
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as {
+      proposedActions: Array<Record<string, unknown>>;
+    };
+    expect(body.proposedActions).toHaveLength(1);
+    expect(body.proposedActions[0]).toMatchObject({
+      operation: runEvalSuiteOperation.name,
+      buttonLabel: "Run it",
+    });
+    expect(body.proposedActions[0]).not.toHaveProperty("disclosure");
+    disclosureSpy.mockRestore();
+  });
+
+  it("does not disclose for a proposal whose operation launches nothing", async () => {
+    // The hook is a registry flag, and only the two eval-run entries declare
+    // it. A disclosure on a cancellation would be a claim about a launch plan
+    // nobody resolved.
+    const app = makeApp();
+    const disclosureSpy = vi
+      .spyOn(getEvalRunDisclosureOperation, "execute")
+      .mockResolvedValue(RUN_DISCLOSURE as never);
+    let captured: Record<string, GatedTool> | undefined;
+    prepareChatV2Mock.mockImplementation(async (opts: any) => {
+      captured = opts.builtInTools;
+      return {
+        allTools: opts.builtInTools ?? {},
+        enhancedSystemPrompt: opts.systemPrompt,
+      };
+    });
+    runUnifiedAssistantTurnMock.mockImplementation(async () => {
+      await captured![cancelEvalRunOperation.name]!.execute(
+        { runId: "run_1" },
+        {}
+      );
+      return okTurnResult();
+    });
+
+    const res = await app.request("/api/v1/projects/p1/agent", {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        Authorization: `Bearer ${SLACK_TOKEN}`,
+        "x-mcpjam-slack-team-id": "T1",
+        "x-mcpjam-slack-user-id": "U1",
+      },
+      body: JSON.stringify({ ...OK_BODY, conversationId: "C1" }),
+    });
+    const body = (await res.json()) as {
+      proposedActions: Array<Record<string, unknown>>;
+    };
+    expect(body.proposedActions).toHaveLength(1);
+    expect(body.proposedActions[0]).not.toHaveProperty("disclosure");
+    expect(disclosureSpy).not.toHaveBeenCalled();
+    disclosureSpy.mockRestore();
+  });
+
+  it("discloses the post-create run offer too, without special-casing it", async () => {
+    // The offer path mints through the SAME `persistProposal`, so it gets the
+    // suite-base disclosure for free. Asserted rather than assumed — "for
+    // free" is exactly the kind of claim that stops being true silently.
+    const app = makeApp();
+    const disclosureSpy = vi
+      .spyOn(getEvalRunDisclosureOperation, "execute")
+      .mockResolvedValue(RUN_DISCLOSURE as never);
+    const executeSpy = vi
+      .spyOn(createEvalSuiteOperation, "execute")
+      .mockResolvedValue({
+        project: { id: "p1" },
+        suite: { id: "ts_1", name: "smoke" },
+        servers: [],
+      } as never);
+    let captured: Record<string, GatedTool> | undefined;
+    prepareChatV2Mock.mockImplementation(async (opts: any) => {
+      captured = opts.builtInTools;
+      return {
+        allTools: opts.builtInTools ?? {},
+        enhancedSystemPrompt: opts.systemPrompt,
+      };
+    });
+    runUnifiedAssistantTurnMock.mockImplementation(async () => {
+      await captured![createEvalSuiteOperation.name]!.execute(
+        VALID_CREATE_INPUT,
+        {}
+      );
+      return okTurnResult();
+    });
+
+    const res = await app.request("/api/v1/projects/p1/agent", {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        Authorization: `Bearer ${SLACK_TOKEN}`,
+        "x-mcpjam-slack-team-id": "T1",
+        "x-mcpjam-slack-user-id": "U1",
+      },
+      body: JSON.stringify({ ...OK_BODY, conversationId: "C1" }),
+    });
+    const body = (await res.json()) as {
+      proposedActions: Array<Record<string, unknown>>;
+    };
+    expect(body.proposedActions).toHaveLength(1);
+    expect(body.proposedActions[0]).toMatchObject({
+      operation: runEvalSuiteOperation.name,
+      disclosure: { digest: "digest_1", engine: "harness:claude-code" },
+    });
+    // The offer selects by suite ID, and that is what gets disclosed.
+    expect(disclosureSpy).toHaveBeenCalledWith(
+      expect.objectContaining({ project: "p1", suite: "ts_1" }),
+      expect.anything()
+    );
+    executeSpy.mockRestore();
+    disclosureSpy.mockRestore();
   });
 
   it("does not offer a SECOND run button when the model already proposed one", async () => {

--- a/mcpjam-inspector/server/routes/v1/agent-op-registry.ts
+++ b/mcpjam-inspector/server/routes/v1/agent-op-registry.ts
@@ -247,6 +247,22 @@ export interface GatedProposalMeta {
    * depth against rows minted before this contract existed.
    */
   requiredFrozenKeys?: readonly string[];
+  /**
+   * Mint this proposal with a PRE-RUN DISCLOSURE attached, when the contract
+   * can answer for its frozen input.
+   *
+   * A registry FLAG rather than a name check at the mint site: `persistProposal`
+   * stays generic, and an operation that starts spending on models later
+   * declares it here instead of being special-cased in the route. Only the
+   * eval-run entries carry it today — they are the ones whose click sends
+   * content to models the approver never chose.
+   *
+   * Purely additive and BEST-EFFORT: the fetch is bounded by its own timeout
+   * and swallowed on any failure, so a proposal that declares this still mints
+   * normally with the field simply absent. Absence is UNKNOWN, never "nothing
+   * leaves" — see `ProposedActionDisclosure`.
+   */
+  carriesDisclosure?: boolean;
 }
 
 /** Read a string off an unknown result, at a dotted path. */
@@ -1491,6 +1507,9 @@ export const AGENT_OP_REGISTRY: readonly AgentOpEntry[] = [
       resource: evalRunResource,
       target: evalSuiteTarget,
       normalizeProposalArgs: freezeEvalRunTargets,
+      // The click sends this suite's content to models the approver did not
+      // choose. Disclose the plan on the card, from the FROZEN input above.
+      carriesDisclosure: true,
     },
   },
   {
@@ -1510,6 +1529,9 @@ export const AGENT_OP_REGISTRY: readonly AgentOpEntry[] = [
       // the minted cell to the suite, a persistent edit the old one-line
       // describe never mentioned.
       normalizeProposalArgs: freezeEvalRunTargets,
+      // Same reason as the suite run: one case is a smaller spend, not a
+      // different disclosure story.
+      carriesDisclosure: true,
     },
   },
   {
@@ -2242,6 +2264,12 @@ export function proposalMetaFor(operationName: string): {
   hashInput: (input: Record<string, unknown>) => Record<string, unknown>;
   /** Keys the frozen input must carry, or the proposal is refused. */
   requiredFrozenKeys: readonly string[];
+  /**
+   * Whether this proposal should carry a pre-run disclosure. `false` for
+   * every operation this build does not gate — a disclosure attached to an
+   * unknown operation would be a claim about a plan nobody resolved.
+   */
+  carriesDisclosure: boolean;
 } {
   const entry = GATED_BY_NAME.get(operationName);
   if (!entry) {
@@ -2254,6 +2282,7 @@ export function proposalMetaFor(operationName: string): {
       normalizeArgs: async (input) => input,
       hashInput: proposalInputForIdempotency,
       requiredFrozenKeys: [],
+      carriesDisclosure: false,
     };
   }
   const severity = entry.proposal.confirmSeverity;
@@ -2295,6 +2324,7 @@ export function proposalMetaFor(operationName: string): {
     },
     hashInput: proposalInputForIdempotency,
     requiredFrozenKeys: entry.proposal.requiredFrozenKeys ?? [],
+    carriesDisclosure: entry.proposal.carriesDisclosure === true,
   };
 }
 

--- a/mcpjam-inspector/server/routes/v1/agent-proposal-disclosure.ts
+++ b/mcpjam-inspector/server/routes/v1/agent-proposal-disclosure.ts
@@ -1,0 +1,300 @@
+/**
+ * The pre-run disclosure a run proposal carries on its approval card
+ * (Evals v2, Lane G, step G4d).
+ *
+ * G4b/G4c disclose a run to the person who LAUNCHES it. A proposal is the one
+ * place where the person who launches it is not the person who chose it: the
+ * agent picked the suite, and someone else is about to click "Run it" on a
+ * card in Slack. This is what puts the same facts on that card.
+ *
+ * Three properties, none of them negotiable:
+ *
+ *  1. ONE RESOLUTION. The disclosure is fetched for the FROZEN proposal input
+ *     — the object `normalizeProposalArgs` (`freezeEvalRunTargets`) returned,
+ *     which is byte-for-byte what the approval route will execute. Never
+ *     re-resolved from the raw selectors the model wrote: `allAttached: true`
+ *     re-expands against whatever is attached at the time, so disclosing from
+ *     it would describe a set the click may not run. The freeze already
+ *     dropped `allAttached`; frozen ids re-resolving to themselves cannot
+ *     widen.
+ *  2. BEST-EFFORT, INDEPENDENTLY BOUNDED. This must never block, delay
+ *     materially, or fail a mint. Its own short timeout, its own try/catch,
+ *     and no client ⇒ skipped entirely — the same degrade the freeze itself
+ *     already takes. On any failure the field is simply absent and the
+ *     proposal mints exactly as it does today.
+ *  3. ABSENCE IS UNKNOWN, NEVER SAFE. Nothing here ever substitutes a
+ *     reassuring default for a fact it could not obtain. A summary that
+ *     cannot name the engine omits `engine`; it does not say "emulated". The
+ *     renderers carry the other half of this rule: absent field ⇒ render
+ *     nothing.
+ *
+ * Going through `getEvalRunDisclosureOperation` rather than calling Convex is
+ * deliberate. The operation self-dispatches through
+ * `GET .../eval-suites/{id}/run-disclosure`, and that route asserts the
+ * runner's capability handshake (`RUNNER_CAPABILITIES` — "TWO CALLERS, ONE
+ * LIST"), composes `execution.locus`, and recomputes the digest. A direct
+ * Convex read from the mint site would re-implement all three at a second
+ * site, and the two would drift.
+ */
+import type {
+  PlatformApiClient,
+  PlatformEvalRunDisclosure,
+} from "@mcpjam/sdk/platform";
+import { getEvalRunDisclosureOperation } from "@mcpjam/sdk/platform";
+import type { ProposedActionDisclosure } from "@mcpjam/sdk/public-api";
+import { runEvalCaseOperation } from "@mcpjam/sdk/platform";
+import { logger } from "../../utils/logger.js";
+
+/**
+ * Ceiling on the mint-time disclosure fetch, independent of the turn's own
+ * deadline — the same rationale as the SDK's `boundedDisclosureSignal`, which
+ * is module-private there.
+ *
+ * A mint is inside a model turn with a ~90s wall clock, and a proposal is
+ * worth far more to the user than the line beneath it. Short enough that a
+ * stalled backend costs the turn a blink rather than a tool call, and a single
+ * lightweight GET to our own API has no business needing longer.
+ */
+const DISCLOSURE_MINT_TIMEOUT_MS = 3_000;
+
+/** Read a trimmed non-empty string off validated-but-loosely-typed input. */
+function str(input: Record<string, unknown>, key: string): string | undefined {
+  const value = input[key];
+  return typeof value === "string" && value.trim() ? value.trim() : undefined;
+}
+
+/** Read a list of non-empty strings; `[]` for anything else. */
+function strList(input: Record<string, unknown>, key: string): string[] {
+  const value = input[key];
+  if (!Array.isArray(value)) return [];
+  return value.filter(
+    (item): item is string => typeof item === "string" && item.trim().length > 0,
+  );
+}
+
+/**
+ * Map a FROZEN run-proposal input onto `get_eval_run_disclosure`'s input, or
+ * refuse.
+ *
+ * The two vocabularies overlap but are not the same: a run says `case`
+ * (singular) where the disclosure says `cases`, and a run can say `hosts`
+ * where the disclosure has only `host`. Refusing is a first-class outcome
+ * here — every `undefined` below is a plan the contract cannot answer for
+ * honestly, and an honest absence beats a confident wrong answer.
+ */
+export function disclosureInputForProposal(
+  operationName: string,
+  input: Record<string, unknown>,
+): Record<string, unknown> | undefined {
+  const project = str(input, "project");
+  const suite = str(input, "suite");
+  if (!project || !suite) return undefined;
+
+  // COMPOSE is an ad-hoc target: models and a host the caller assembled for
+  // this run alone, attached to nothing. The disclosure contract keys on the
+  // suite's ATTACHED targets, so the only query available for a compose run
+  // is the selector-less suite-base derivation — which the composed models
+  // can flatly contradict. That is the exact failure G4c refused for the host
+  // axis ("emulated, no sandbox" moments before a harness sandbox booted), so
+  // refuse it here for the same reason rather than disclose the wrong plan.
+  if (input.compose && typeof input.compose === "object") return undefined;
+
+  // `allAttached` should have been dropped by `freezeEvalRunTargets`. Still
+  // present means the freeze degraded (no client, an unresolvable suite) and
+  // the target set is whatever is attached at CLICK time — unknown now, so
+  // there is nothing honest to disclose.
+  if (input.allAttached === true) return undefined;
+
+  const hosts = strList(input, "hosts");
+  // A multi-target host group has no single engine or model set to disclose:
+  // the contract answers per launch plan and its one-axis rule refuses a host
+  // alongside an environment. `getEvalRunDisclosureOperation` throws its own
+  // one-plan refusal for this, and catching that would work — but the launch
+  // path already recognises the shape up front (`isMultiTargetHostLaunch`),
+  // and skipping a round trip we know the answer to is cheaper than a caught
+  // throw.
+  if (hosts.length > 1) return undefined;
+
+  const host = str(input, "host") ?? hosts[0];
+  const environment = str(input, "environment");
+  const environments = strList(input, "environments");
+  // The operation asserts these are coherent and throws otherwise. A run
+  // input is validated coherent already, but the mapping above can only make
+  // that worse, never better — bail rather than hand the operation a shape it
+  // will reject.
+  if (host && (environment || environments.length > 0)) return undefined;
+
+  const cases =
+    operationName === runEvalCaseOperation.name
+      ? // A single-case run says `case`; the disclosure narrows by `cases`.
+        (() => {
+          const single = str(input, "case");
+          return single ? [single] : [];
+        })()
+      : strList(input, "cases");
+
+  return {
+    project,
+    suite,
+    ...(cases.length > 0 ? { cases } : {}),
+    ...(environment ? { environment } : {}),
+    ...(environments.length > 0 ? { environments } : {}),
+    ...(host ? { host } : {}),
+  };
+}
+
+/** Dedupe, preserving first-appearance order. */
+function dedupe(values: readonly string[]): string[] {
+  return Array.from(new Set(values));
+}
+
+/**
+ * The vendor half of a judge's model id (`openai/gpt-5.4-mini` → `openai`).
+ *
+ * `undefined` when the id carries no vendor prefix — which makes the whole
+ * `judgeProviders` field unknown rather than partially populated, because a
+ * list that quietly dropped an unclassifiable judge would understate where
+ * evidence goes.
+ */
+function judgeProviderOf(modelId: string): string | undefined {
+  const slash = modelId.indexOf("/");
+  if (slash <= 0) return undefined;
+  const vendor = modelId.slice(0, slash).trim();
+  return vendor || undefined;
+}
+
+/**
+ * Project the full contract down to what an approval card states.
+ *
+ * The rule for every field: state it only when the contract answered it.
+ * `PlatformEvalRunDisclosure` distinguishes "no models" from "models not
+ * derivable" (`modelsUnresolved`) and "did not execute" from "will execute,
+ * unresolved" (`executionAbsence.kind`) precisely so a surface cannot collapse
+ * them, and collapsing them HERE would put the reassuring half of each pair on
+ * a card someone is about to click.
+ */
+export function summarizeDisclosure(
+  disclosure: PlatformEvalRunDisclosure,
+): ProposedActionDisclosure {
+  const summary: ProposedActionDisclosure = { digest: disclosure.digest };
+  const execution = disclosure.execution;
+
+  // No `execution` section ⇒ engine, sandbox, providers and BYOK are all
+  // UNKNOWN. Not "emulated", not "no sandbox", not "managed rail" — the two
+  // `executionAbsence` kinds mean different things and neither of them means
+  // "nothing leaves", so the card says nothing about execution at all.
+  if (execution) {
+    summary.engine = execution.engine;
+    summary.sandbox = {
+      engaged: execution.sandbox.engaged,
+      ...(execution.sandbox.vendor ? { vendor: execution.sandbox.vendor } : {}),
+    };
+    // An empty `models` with `modelsUnresolved` means models WILL run and are
+    // simply not derivable here. Publishing an empty provider list for that
+    // would read as "nothing egresses", so the field stays absent — and so
+    // does `byok`, which is a fact ABOUT those unresolved models.
+    const resolvedModels = execution.modelsUnresolved
+      ? undefined
+      : execution.models;
+    if (resolvedModels) {
+      // ALL-OR-NOTHING. A `null` provider is the classifier declining, and a
+      // list with that model silently missing would name fewer destinations
+      // than the run actually reaches.
+      const classified = resolvedModels.every(
+        (model) => typeof model.provider === "string" && model.provider,
+      );
+      if (classified) {
+        summary.runProviders = dedupe(
+          resolvedModels.map((model) => model.provider as string),
+        );
+      }
+      summary.byok = resolvedModels.some(
+        (model) =>
+          model.byok !== undefined ||
+          model.tenantEgress === "byok-cloud" ||
+          model.tenantEgress === "byok-local",
+      );
+    }
+  }
+
+  // Only touchpoints that CAN fire. A disabled one sends nothing, and listing
+  // its provider would warn about egress that cannot happen — the mirror image
+  // of the absence rule, and just as dishonest.
+  const firing = disclosure.analysis.filter(
+    (touchpoint) => typeof touchpoint.fires === "string",
+  );
+  if (firing.length > 0) {
+    const providers = firing.map((touchpoint) =>
+      judgeProviderOf(touchpoint.model),
+    );
+    if (providers.every((provider): provider is string => Boolean(provider))) {
+      // "Different from the run's own" is the surprise worth stating; a judge
+      // on a provider the run already reaches tells the approver nothing new.
+      // When the run's own providers are UNKNOWN this subtracts nothing, so
+      // every firing judge is listed — erring toward disclosing more, which is
+      // the only direction a disclosure may err.
+      const own = new Set(
+        (summary.runProviders ?? []).map((provider) =>
+          provider.toLocaleLowerCase(),
+        ),
+      );
+      const extra = dedupe(providers).filter(
+        (provider) => !own.has(provider.toLocaleLowerCase()),
+      );
+      if (extra.length > 0) summary.judgeProviders = extra;
+    }
+  }
+
+  summary.retention = {
+    policyDays: disclosure.retention.policyDays,
+    // Straight from the contract, NEVER re-derived from `policyDays` — an
+    // unenforced policy keeps data indefinitely whatever its number says.
+    effectiveToday: disclosure.retention.effectiveToday,
+  };
+  return summary;
+}
+
+/**
+ * Fetch and summarize the disclosure for one frozen run-proposal input.
+ *
+ * Returns `undefined` for every failure mode there is, and never throws: no
+ * client, a plan the contract cannot answer for, a backend predating G4a's
+ * query (`422 FEATURE_NOT_SUPPORTED`), a timeout, a transient error. The
+ * caller mints regardless.
+ */
+export async function disclosureForProposal(opts: {
+  operationName: string;
+  /** The FROZEN input — what the click will execute. Never the raw input. */
+  input: Record<string, unknown>;
+  client: PlatformApiClient;
+}): Promise<ProposedActionDisclosure | undefined> {
+  try {
+    // Inside the try with the fetch, not before it. The mapping is pure
+    // property reads behind type guards and cannot throw today — but "cannot
+    // fail a mint" is the property, and a property that depends on nobody
+    // adding a throw to a helper later is not one.
+    const mapped = disclosureInputForProposal(opts.operationName, opts.input);
+    if (!mapped) return undefined;
+    const disclosure = await getEvalRunDisclosureOperation.execute(
+      mapped as Parameters<typeof getEvalRunDisclosureOperation.execute>[0],
+      {
+        client: opts.client,
+        // ITS OWN deadline. The turn's signal is not threaded in on purpose:
+        // this fetch must be unable to consume budget the mint itself needs,
+        // and a mint that already survived validation should not be lost to a
+        // line of context beneath it.
+        signal: AbortSignal.timeout(DISCLOSURE_MINT_TIMEOUT_MS),
+      },
+    );
+    return summarizeDisclosure(disclosure);
+  } catch (error) {
+    // INFO, not error: an absent disclosure is a designed outcome of this
+    // path, not a fault. A backend predating the contract answers 422 here on
+    // every single mint, and paging on that would be noise.
+    logger.info("[v1/agent] no pre-run disclosure for a run proposal", {
+      operation: opts.operationName,
+      error: error instanceof Error ? error.message : String(error),
+    });
+    return undefined;
+  }
+}

--- a/mcpjam-inspector/server/routes/v1/agent-proposal-disclosure.ts
+++ b/mcpjam-inspector/server/routes/v1/agent-proposal-disclosure.ts
@@ -85,8 +85,22 @@ function strList(input: Record<string, unknown>, key: string): string[] {
 export function disclosureInputForProposal(
   operationName: string,
   input: Record<string, unknown>,
+  /**
+   * The project the click will run in — `persistProposal`'s own, which is what
+   * gets persisted on the proposal row.
+   *
+   * NOT `input.project`, deliberately. The approval route executes
+   * `{ ...claim.input, project: claim.projectId }` (`proposed-actions.ts`), so
+   * the stored input's own `project` is overwritten at click time and is not
+   * the authority on where the run lands. Both agree today — the gated tool
+   * clamps `project` before validating — but keying the disclosure off the
+   * value the click actually uses makes that structural rather than incidental,
+   * and removes a refusal branch that would silently drop the disclosure if a
+   * normalizer ever stopped carrying the key.
+   */
+  projectId: string,
 ): Record<string, unknown> | undefined {
-  const project = str(input, "project");
+  const project = projectId.trim();
   const suite = str(input, "suite");
   if (!project || !suite) return undefined;
 
@@ -266,6 +280,8 @@ export async function disclosureForProposal(opts: {
   operationName: string;
   /** The FROZEN input — what the click will execute. Never the raw input. */
   input: Record<string, unknown>;
+  /** The project the click will run in. See `disclosureInputForProposal`. */
+  projectId: string;
   client: PlatformApiClient;
 }): Promise<ProposedActionDisclosure | undefined> {
   try {
@@ -273,7 +289,11 @@ export async function disclosureForProposal(opts: {
     // property reads behind type guards and cannot throw today — but "cannot
     // fail a mint" is the property, and a property that depends on nobody
     // adding a throw to a helper later is not one.
-    const mapped = disclosureInputForProposal(opts.operationName, opts.input);
+    const mapped = disclosureInputForProposal(
+      opts.operationName,
+      opts.input,
+      opts.projectId,
+    );
     if (!mapped) return undefined;
     const disclosure = await getEvalRunDisclosureOperation.execute(
       mapped as Parameters<typeof getEvalRunDisclosureOperation.execute>[0],

--- a/mcpjam-inspector/server/routes/v1/agent.ts
+++ b/mcpjam-inspector/server/routes/v1/agent.ts
@@ -62,6 +62,7 @@ import {
   runEvalSuiteOperation,
 } from "@mcpjam/sdk/platform";
 import type { ProposedAction as PublicProposedAction } from "@mcpjam/sdk/public-api";
+import { disclosureForProposal } from "./agent-proposal-disclosure.js";
 import {
   AGENT_API_GATED_OPERATIONS,
   AGENT_API_OPERATIONS,
@@ -223,6 +224,10 @@ function toWireProposal(proposal: ProposedAction): PublicProposedAction {
       ? { confirmSeverity: proposal.confirmSeverity }
       : {}),
     ...(proposal.target ? { target: proposal.target } : {}),
+    // Additive like the two above, and dropped the same way when absent —
+    // a spread that forgot this field would lose the disclosure silently
+    // between the mint and the wire.
+    ...(proposal.disclosure ? { disclosure: proposal.disclosure } : {}),
   };
 }
 
@@ -349,6 +354,24 @@ async function persistProposal(opts: {
   // control per entry would otherwise show two for a single spend — the exact
   // duplicate the derived id exists to prevent.
   if (!proposed.some((existing) => existing.actionId === actionId)) {
+    // BEST-EFFORT, and deliberately here: after the row is persisted (so a
+    // stalled fetch cannot cost the proposal), and gated on the dedupe above
+    // (so a re-proposed action does not pay for a line it already has).
+    //
+    // FROZEN INPUT, never `opts.input` — `input` is what the click will
+    // execute, so what this discloses is what will run. Bounded and swallowed
+    // inside `disclosureForProposal`: it returns `undefined` for every failure
+    // there is, and an absent field means UNKNOWN to every renderer, never
+    // "nothing leaves". Skipped without a client for the same reason the
+    // freeze degrades without one.
+    const disclosure =
+      meta.carriesDisclosure && opts.client
+        ? await disclosureForProposal({
+            operationName: operation.name,
+            input,
+            client: opts.client,
+          })
+        : undefined;
     proposed.push({
       actionId,
       operation: operation.name,
@@ -368,6 +391,11 @@ async function persistProposal(opts: {
       // What the proposal is about, so a host can correlate it with the turn's
       // created resources instead of guessing from the operation name.
       ...(meta.targetFor(input) ? { target: meta.targetFor(input) } : {}),
+      // What a run of this would disclose, as of the mint. NOT persisted with
+      // the proposal: the click executes from the stored `input`, and a
+      // disclosure that round-tripped through a host would be a claim the host
+      // could author. Rendering data, one direction only.
+      ...(disclosure ? { disclosure } : {}),
     });
   }
   return { actionId, description: meta.description(input) };

--- a/mcpjam-inspector/server/routes/v1/agent.ts
+++ b/mcpjam-inspector/server/routes/v1/agent.ts
@@ -369,6 +369,10 @@ async function persistProposal(opts: {
         ? await disclosureForProposal({
             operationName: operation.name,
             input,
+            // The project the CLICK will run in: the approval route re-clamps
+            // the stored input to the persisted project, so this — not
+            // `input.project` — is what the run actually uses.
+            projectId,
             client: opts.client,
           })
         : undefined;

--- a/sdk/src/public-api/index.ts
+++ b/sdk/src/public-api/index.ts
@@ -285,6 +285,84 @@ export interface ProposedAction {
    * unknown" and fall back to its coarser behavior.
    */
   target?: ProposedActionTarget;
+  /**
+   * What a run of this proposal would disclose, as of MINT TIME.
+   *
+   * Populated only for the eval-run proposals, and only when the pre-run
+   * disclosure contract answered for the FROZEN input the click will execute
+   * — so what was disclosed is what will run, not a second, independently
+   * resolved target that could name different models.
+   *
+   * A SUMMARY, never the contract: it carries the facts a person did not
+   * choose and cannot infer from the description, plus the `digest` that ties
+   * it back to the full payload (`get_eval_run_disclosure`, which a host that
+   * wants everything should call).
+   *
+   * ABSENT MEANS UNKNOWN, NEVER SAFE. The fetch is best-effort and bounded —
+   * a timeout, a deployment predating the contract, or a plan the contract
+   * cannot answer for all leave the field off, and a host must then render
+   * NOTHING rather than a reassuring default. Rendering only; a host that
+   * echoed it back would be re-opening the hole `actionId` closes.
+   *
+   * Describes the plan as of the mint. An attachment edit between the mint
+   * and the click is not re-disclosed here — the launch receipt's own
+   * disclosure is the authoritative at-click answer.
+   */
+  disclosure?: ProposedActionDisclosure;
+}
+
+/**
+ * The pre-run disclosure summary a proposal carries, projected from
+ * `PlatformEvalRunDisclosure`.
+ *
+ * SMALL ON PURPOSE. An approval card is not a compliance document: it states
+ * what a person did not choose and cannot infer, and links the rest by
+ * digest. Every field but `digest` is optional, and every absence means
+ * UNKNOWN — never the reassuring reading. Absent `sandbox` is not "no
+ * sandbox"; absent `engine` is not "emulated"; absent `judgeProviders` is not
+ * "no judge egress".
+ */
+export interface ProposedActionDisclosure {
+  /**
+   * Digest of the full contract payload this summarizes — the join key that
+   * lets a host or an auditor line this summary up with the whole disclosure
+   * and with the run's own audit record. The one always-present field.
+   */
+  digest: string;
+  /**
+   * `'emulated'`, `'mixed'`, or `harness:<id>`. Absent ⇒ the contract did not
+   * resolve an execution section, which is UNKNOWN — never `'emulated'`, the
+   * value that reads as reassuring.
+   */
+  engine?: string;
+  /**
+   * Whether a sandbox is engaged for this plan, and whose. Absent ⇒ unknown;
+   * a host must not render "no sandbox" for it.
+   */
+  sandbox?: { engaged: boolean; vendor?: string };
+  /**
+   * The providers the run's OWN models egress to, deduped. Absent when the
+   * plan's models did not resolve, or when any of them declined
+   * classification — a partial list would understate where content goes.
+   */
+  runProviders?: readonly string[];
+  /**
+   * Providers reached by analysis/judge touchpoints that CAN fire, minus the
+   * run's own — the surprise worth stating on an approval card. Absent ⇒
+   * nothing extra to state, or not derivable; never "no judge egress".
+   */
+  judgeProviders?: readonly string[];
+  /**
+   * `policyDays` is the POLICY number (`null` ⇒ uncapped by policy);
+   * `effectiveToday` is what actually happens — never re-derive one from the
+   * other, an unenforced policy keeps data indefinitely whatever its number.
+   */
+  retention?: { policyDays: number | null; effectiveToday: string };
+  /**
+   * True when any of the run's models runs on an org-configured key (BYOK)
+   * rather than the managed rail. Absent ⇒ unknown, not `false`.
+   */
+  byok?: boolean;
 }
 
 /**

--- a/slack-app/agent/mcpjam-client.js
+++ b/slack-app/agent/mcpjam-client.js
@@ -54,6 +54,15 @@ const DEFAULT_BASE_URL = 'https://app.mcpjam.com';
  *   about, in the operation's own selector vocabulary (id or name — match
  *   both). Absent on older servers and unTargeted operations: treat as
  *   match-unknown.
+ * @property {{ digest: string, engine?: string,
+ *   sandbox?: { engaged: boolean, vendor?: string },
+ *   runProviders?: string[], judgeProviders?: string[],
+ *   retention?: { policyDays: number | null, effectiveToday: string },
+ *   byok?: boolean }} [disclosure] what a run of this proposal would disclose,
+ *   as of mint time — only on the eval-run proposals, and only when the
+ *   contract answered for the frozen input. ABSENT MEANS UNKNOWN, NEVER SAFE:
+ *   render nothing for a missing field rather than a reassuring default. Every
+ *   inner field is optional for the same reason and follows the same rule.
  */
 
 /**

--- a/slack-app/listeners/views/proposal-builder.js
+++ b/slack-app/listeners/views/proposal-builder.js
@@ -18,6 +18,17 @@ export const PROPOSAL_ACTION_ID = 'mcpjam_approve_action';
  * Slack allows 50 blocks per message and this reply already carries suite
  * blocks and feedback blocks. Leave room rather than letting the post reject
  * and take the whole answer down with it.
+ *
+ * THE MESSAGE BUDGET IS EXACTLY FULL, which is why the pre-run disclosure
+ * (`disclosureLine`) rides INSIDE a proposal's own section rather than in a
+ * `context` block after it. Worst case on the replay path
+ * (`events/run-and-reply.js`): 1 reply section + 40 created-resource blocks +
+ * 1 resource overflow + 5 proposal sections + 1 proposal overflow + 1 replay
+ * note + 1 feedback = 50, dead on Slack's ceiling. One extra block per
+ * disclosed proposal would make that 55 and reject the post — losing the
+ * answer, the suite links and every approval button, to add a hint. So the
+ * disclosure costs zero blocks and spends section characters instead, of
+ * which there are 3,000 and roughly 2,200 spare.
  */
 const MAX_PROPOSAL_BLOCKS = 5;
 
@@ -147,6 +158,79 @@ function confirmCopy(severity, description) {
 }
 
 /**
+ * Budget for the pre-run disclosure line, in ESCAPED characters.
+ *
+ * Shares the section's 3,000-character ceiling with the description (400) and
+ * the severity note, so this is generous headroom rather than a tight fit. It
+ * exists because the disclosure is SERVER-derived text entering mrkdwn, and an
+ * unbounded string in a section is how one long provider list takes down a
+ * whole reply.
+ */
+const MAX_DISCLOSURE_CHARS = 300;
+
+/**
+ * One line saying what a run of this proposal would disclose.
+ *
+ * ABSENT MEANS UNKNOWN, NEVER SAFE — the whole point of the field. Every
+ * clause below is emitted only from a field that is actually PRESENT: a
+ * proposal with no `disclosure` gets no line at all, and one whose disclosure
+ * could not name an engine says nothing about the engine rather than
+ * "emulated". A default line here would be the one failure mode a disclosure
+ * must not have, because the reassuring reading is exactly the one absence
+ * would become.
+ *
+ * `sandbox.engaged: false` IS rendered ("no sandbox"): the field is present,
+ * so that is a fact the contract answered, not a guess standing in for one.
+ *
+ * Wording tracks `run-disclosure-hint.tsx` / the CLI's disclosure block, so a
+ * person who has seen this in the app reads the same claims here.
+ *
+ * @param {{ engine?: string, sandbox?: { engaged?: boolean, vendor?: string },
+ *   runProviders?: string[], judgeProviders?: string[], byok?: boolean,
+ *   retention?: { policyDays?: number | null, effectiveToday?: string } } | undefined} disclosure
+ * @returns {string} escaped mrkdwn, or '' when there is nothing honest to say
+ */
+export function disclosureLine(disclosure) {
+  if (!disclosure || typeof disclosure !== 'object') return '';
+  /** @type {string[]} */
+  const parts = [];
+  if (typeof disclosure.engine === 'string' && disclosure.engine) {
+    parts.push(`runs via ${disclosure.engine}`);
+  }
+  const sandbox = disclosure.sandbox;
+  if (sandbox && typeof sandbox === 'object' && typeof sandbox.engaged === 'boolean') {
+    parts.push(sandbox.engaged ? `sandboxed${sandbox.vendor ? ` (${sandbox.vendor})` : ''}` : 'no sandbox');
+  }
+  // Only when TRUE. `false` is the managed rail every approver already assumes,
+  // and a clause restating the default would crowd out the ones that do not.
+  if (disclosure.byok === true) parts.push("on your organization's own API key");
+  const runProviders = Array.isArray(disclosure.runProviders) ? disclosure.runProviders : [];
+  if (runProviders.length > 0) parts.push(`models reach ${runProviders.join(', ')}`);
+  const judgeProviders = Array.isArray(disclosure.judgeProviders) ? disclosure.judgeProviders : [];
+  if (judgeProviders.length > 0) {
+    // The surprise worth stating: the server already subtracted the run's own
+    // providers, so anything left is somewhere the approver did not choose.
+    parts.push(`judges also send evidence to ${judgeProviders.join(', ')}`);
+  }
+  const retention = disclosure.retention;
+  if (retention && typeof retention === 'object') {
+    // Straight from `effectiveToday` — NEVER re-derived from `policyDays`, an
+    // unenforced policy keeps data indefinitely whatever its number says.
+    if (retention.effectiveToday === 'kept-indefinitely') {
+      parts.push('kept indefinitely');
+    } else if (retention.effectiveToday === 'swept-after-policy-days') {
+      parts.push(
+        typeof retention.policyDays === 'number'
+          ? `swept after ${retention.policyDays} day${retention.policyDays === 1 ? '' : 's'}`
+          : 'swept after the plan policy',
+      );
+    }
+  }
+  if (parts.length === 0) return '';
+  return capEscaped(parts.join(' · '), MAX_DISCLOSURE_CHARS);
+}
+
+/**
  * The line under the description, chosen by the SAME severity the confirm
  * dialog reads.
  *
@@ -216,13 +300,20 @@ export function buildProposalBlocks(proposals) {
         BUTTON_LABELS[/** @type {keyof typeof BUTTON_LABELS} */ (proposal.operation)] ||
         'Approve',
     ).slice(0, MAX_BUTTON_LABEL);
+    // Already escaped and capped. Empty for a proposal the server did not
+    // disclose — an older server, an operation that carries no disclosure, or
+    // a fetch that failed — and an empty string renders NOTHING, never a
+    // stand-in line.
+    const disclosure = disclosureLine(proposal.disclosure);
     blocks.push({
       type: 'section',
       text: {
         type: 'mrkdwn',
         // Capped, then escaped: raw `<`/`>` in mrkdwn can forge a mention or a
         // link, and an uncapped section fails the whole post.
-        text: `:hourglass_flowing_sand: *${toDescription(String(proposal.description || 'Action'))}*\n${sectionNote(proposal.confirmSeverity)}`,
+        text: `:hourglass_flowing_sand: *${toDescription(String(proposal.description || 'Action'))}*\n${sectionNote(proposal.confirmSeverity)}${
+          disclosure ? `\n_${disclosure}_` : ''
+        }`,
       },
       accessory: {
         type: 'button',

--- a/slack-app/tests/listeners/actions/proposal-button.test.js
+++ b/slack-app/tests/listeners/actions/proposal-button.test.js
@@ -5,6 +5,7 @@ import { purgeChannelBindings } from '../../../agent/turn-target.js';
 import { announcementFor, handleProposalButton } from '../../../listeners/actions/proposal-button.js';
 import {
   buildProposalBlocks,
+  disclosureLine,
   PROPOSAL_ACTION_ID,
   rendersRunProposalFor,
 } from '../../../listeners/views/proposal-builder.js';
@@ -14,6 +15,71 @@ const PROPOSAL = {
   operation: 'run_eval_suite',
   description: 'Run eval suite ts_1',
 };
+
+describe('disclosureLine', () => {
+  it('is empty when there is no disclosure at all', () => {
+    // The whole absence rule in one assertion: nothing known, nothing said.
+    assert.strictEqual(disclosureLine(undefined), '');
+    assert.strictEqual(disclosureLine(null), '');
+    assert.strictEqual(disclosureLine({ digest: 'd1' }), '');
+  });
+
+  it('states only the fields the contract actually answered', () => {
+    // A disclosure that could not name an engine says nothing about the
+    // engine — never "emulated", the value that reads as reassuring.
+    assert.strictEqual(
+      disclosureLine({ digest: 'd1', retention: { policyDays: null, effectiveToday: 'kept-indefinitely' } }),
+      'kept indefinitely',
+    );
+    assert.strictEqual(disclosureLine({ digest: 'd1', engine: 'emulated' }), 'runs via emulated');
+  });
+
+  it('states "no sandbox" only when the contract SAID so', () => {
+    // `engaged: false` is a fact the contract answered, not a guess standing
+    // in for one — the difference between a present false and an absent field.
+    assert.match(disclosureLine({ digest: 'd1', sandbox: { engaged: false } }), /no sandbox/);
+    assert.ok(!/sandbox/.test(disclosureLine({ digest: 'd1', engine: 'emulated' })));
+  });
+
+  it('mentions BYOK only when it is true', () => {
+    assert.match(disclosureLine({ digest: 'd1', byok: true }), /own API key/);
+    assert.strictEqual(disclosureLine({ digest: 'd1', byok: false }), '');
+  });
+
+  it('pluralises the retention window and falls back without a number', () => {
+    assert.match(
+      disclosureLine({ digest: 'd1', retention: { policyDays: 1, effectiveToday: 'swept-after-policy-days' } }),
+      /swept after 1 day$/,
+    );
+    assert.match(
+      disclosureLine({ digest: 'd1', retention: { policyDays: null, effectiveToday: 'swept-after-policy-days' } }),
+      /swept after the plan policy/,
+    );
+  });
+
+  it('escapes server-derived text entering mrkdwn', () => {
+    // The values come from a trusted server, but they pass through model- and
+    // user-influenced names (a custom provider, a harness id). Raw `<`/`>` in
+    // mrkdwn can forge a mention, and a failed block takes the whole post down.
+    const line = disclosureLine({ digest: 'd1', engine: 'harness:<!channel>' });
+    assert.ok(!line.includes('<!channel>'));
+    assert.match(line, /&lt;!channel&gt;/);
+  });
+
+  it('stays inside its character budget however long the providers are', () => {
+    const line = disclosureLine({
+      digest: 'd1',
+      runProviders: Array.from({ length: 200 }, (_, index) => `provider-${index}`),
+    });
+    assert.ok(line.length <= 300, `disclosure line was ${line.length} chars`);
+  });
+
+  it('keeps an ESCAPE-EXPANDING value inside the budget, entities intact', () => {
+    const line = disclosureLine({ digest: 'd1', engine: '&'.repeat(500) });
+    assert.ok(line.length <= 300, `disclosure line was ${line.length} chars`);
+    assert.strictEqual(line.split('&').length - 1, line.split('&amp;').length - 1);
+  });
+});
 
 describe('buildProposalBlocks', () => {
   it('renders one confirming button carrying only the action id', () => {
@@ -32,6 +98,47 @@ describe('buildProposalBlocks', () => {
     const text = /** @type {any} */ (blocks[0]).text.text;
     assert.ok(!text.includes('<!channel>'), 'a forged mention must not survive');
     assert.ok(text.includes('&lt;!channel&gt;'));
+  });
+
+  it('states what a disclosed run would do, under the description', () => {
+    const blocks = buildProposalBlocks([
+      {
+        ...PROPOSAL,
+        disclosure: {
+          digest: 'digest_1',
+          engine: 'harness:claude-code',
+          sandbox: { engaged: true, vendor: 'e2b' },
+          runProviders: ['anthropic'],
+          judgeProviders: ['openai'],
+          retention: { policyDays: 30, effectiveToday: 'swept-after-policy-days' },
+        },
+      },
+    ]);
+    // ZERO extra blocks: the message budget is exactly full (see
+    // MAX_PROPOSAL_BLOCKS), so the disclosure spends section characters.
+    assert.strictEqual(blocks.length, 1);
+    const text = /** @type {any} */ (blocks[0]).text.text;
+    assert.match(text, /runs via harness:claude-code/);
+    assert.match(text, /sandboxed \(e2b\)/);
+    assert.match(text, /models reach anthropic/);
+    assert.match(text, /judges also send evidence to openai/);
+    assert.match(text, /swept after 30 days/);
+    // The description and the severity note are untouched.
+    assert.match(text, /Run eval suite ts_1/);
+    assert.match(text, /This one costs/);
+  });
+
+  it('renders NOTHING for a proposal the server did not disclose', () => {
+    // Absence is UNKNOWN, never safe. The reassuring reading ("emulated, no
+    // sandbox") is exactly what an absent disclosure must never become, so a
+    // default line here would be the one failure mode this feature must not
+    // have.
+    const blocks = buildProposalBlocks([PROPOSAL]);
+    const text = /** @type {any} */ (blocks[0]).text.text;
+    assert.ok(!/runs via/.test(text));
+    assert.ok(!/sandbox/.test(text));
+    assert.ok(!/retention|swept|indefinitely/i.test(text));
+    assert.strictEqual(text.split('\n').length, 2);
   });
 
   it('returns nothing for an empty or missing list', () => {


### PR DESCRIPTION
G4b/G4c disclose a run to the person who **launches** it. A proposal is the one place where that is not the same person: the agent picked the suite, and someone else is about to click "Run it" on a card in Slack with nothing in front of them but a one-line description and a spend warning. This is the half of G4c that did not ship — it puts the same facts on that card.

## What changed

- **`@mcpjam/sdk/public-api`** — additive `ProposedAction.disclosure?`, a new `ProposedActionDisclosure`: `digest`, `engine`, `sandbox`, `runProviders`, `judgeProviders`, `retention`, `byok`. Small on purpose (per the G4 product decision that the UI panel ships dark): it carries the facts a person did not choose and cannot infer, plus the digest that ties the summary to the full contract. Hosts that want everything still call `get_eval_run_disclosure`.
- **`server/routes/v1/agent-op-registry.ts`** — a `carriesDisclosure` flag on `GatedProposalMeta`, set on exactly `run_eval_suite` and `run_eval_case`, exposed through `proposalMetaFor` (default `false`). A registry hook rather than a name check, so `persistProposal` stays generic.
- **`server/routes/v1/agent-proposal-disclosure.ts`** (new) — maps a frozen run-proposal input onto `get_eval_run_disclosure`'s vocabulary and projects `PlatformEvalRunDisclosure` down to the summary.
- **`server/routes/v1/agent.ts`** — `persistProposal` fetches the disclosure between persisting the row and pushing into `proposed`; `toWireProposal` spreads it conditionally.
- **`slack-app`** — one disclosure line per disclosed proposal, in `run-disclosure-hint.tsx`'s wording register.
- `docs/reference/openapi.json` documents the new envelope field.

## The three properties

**One resolution.** The fetch is keyed by the **frozen** input — what `freezeEvalRunTargets` returned, byte-for-byte what the approval route will execute — so "what was disclosed" equals "what will run". Never re-resolved from raw selectors: `allAttached` re-expands against whatever is attached at the time, and an input where it survived the freeze is *refused* rather than disclosed. Going through the operation (which self-dispatches through `GET .../run-disclosure`) is deliberate — the route asserts `RUNNER_CAPABILITIES`, composes `execution.locus`, and recomputes the digest, and a direct Convex read from the mint site would re-implement all three at a second site.

**Best-effort, independently bounded.** Its own 3s timeout, its own try/catch, skipped entirely without a client (mirroring how `normalizeArgs` already degrades). A timeout, a transient error, or a backend predating the contract (`422 FEATURE_NOT_SUPPORTED`) leaves the field absent and mints the proposal exactly as before. Logged at info, not error — an absent disclosure is a designed outcome of this path.

**Absence is unknown, never safe.** Nothing substitutes a reassuring default for a fact it could not obtain: no `engine` rather than `"emulated"`, no sandbox clause rather than "no sandbox", no provider list rather than an empty one. `runProviders` is all-or-nothing — a model that declined classification omits the whole list rather than naming fewer destinations than the run reaches. `sandbox.engaged: false` **is** rendered, because a present `false` is a fact the contract answered.

Two plans are refused outright rather than answered from the suite-base derivation they would fall back to:
- a **multi-target host group** — the contract answers per launch plan, so a fan-out spanning hosts has no single engine or model set (same rule as `isMultiTargetHostLaunch` at launch);
- a **compose run** — composed models are attached to nothing, and the suite-base derivation can flatly contradict them. That is the exact "emulated, no sandbox moments before a harness sandbox booted" failure G4c refused for the host axis.

## Not persisted

`createProposedAction` stores the frozen `input` and nothing else. The disclosure is envelope/rendering data: it never round-trips and must never be accepted back from a host, because the click executes from the stored input.

## Known limit (stated deliberately)

This describes the plan **as of the mint**, the same guarantee `description` already carries. An attachment edit between the mint and the click is not re-disclosed here; the launch-time receipt disclosure (`runEvalSuiteOperation`'s `onDisclosure`) stays the authoritative at-click answer.

## Two deviations from the plan, both load-bearing

**Slack gets a section line, not a `context` block.** The plan asked for a context block and told me to check the arithmetic. I checked, and the message budget is *exactly* full. Worst case on the replay path (`events/run-and-reply.js`): 1 reply section + 40 created-resource blocks + 1 resource overflow + 5 proposal sections + 1 proposal overflow + 1 replay note + 1 feedback = **50**, dead on Slack's ceiling. One extra block per disclosed proposal makes that 55 and rejects the post — losing the answer, the suite links and every approval button, to add a hint. So the disclosure costs zero blocks and spends section characters instead (3,000 available, ~2,200 spare). Same content, same absence rule, capped with `capEscaped` because this is server-derived text entering mrkdwn.

**Discord is skipped.** `discord-app/renderer.js` renders proposals as bare buttons with no per-proposal text at all — there is nothing for a disclosure line to attach to, and with two proposals a floating line has no identifiable subject. An absent rendering is correct behaviour; a wrong one is not. `surface-core` passes `proposedActions` through opaquely and renders nothing, so the field reaches both surfaces intact and neither invents a default.

## Tests

- `agent.test.ts` — the envelope carries `disclosure` on a run proposal when the fetch succeeds (asserting the disclosure op was asked in *its* vocabulary about the same project/suite/cases the stored proposal carries); absent when it fails; the mint succeeds either way; `input` still never leaks; a non-run proposal never fetches; **the post-create offer carries it too** (asserted, not assumed — "for free" is exactly the claim that stops being true silently).
- `agent-proposal-disclosure.test.ts` (new, 19 cases) — the mapping's refusals and the projection's absences. Almost every assertion is about a field staying *off*.
- `agent-op-registry.test.ts` — exactly the two eval-run entries declare the hook; an unregistered op does not.
- `proposal-button.test.js` — renders the line when present, renders nothing when absent, escapes hostile text, stays inside its budget with escape-expanding input and entities intact.

**Verified:** all 1,185 `server/routes/v1` tests pass; `npm run typecheck` (all releasable packages) clean; `npm run verify -w @mcpjam/slack-app` clean (the one remaining biome warning is pre-existing in `journey-run-watcher.js`); `surface-core` clean. `discord-app` has 3 pre-existing failures on `main`, unrelated and untouched by this diff.

## Ship notes

- **Changeset:** `@mcpjam/sdk: minor` + `@mcpjam/inspector: minor`. Slack/Discord apps are on the ignore list, so no entry for them.
- **No backend change and no deploy coupling for merge** — against a backend predating the contract the fetch fails and the field is absent, which is the designed degrade.
- **End-to-end verification against prod wants G4c's promote fired first.** I could not confirm from this checkout whether it has happened (prod was `d972fca4` on 2026-08-25, without G4c); until it has, prod mints will simply carry no disclosure, which is the intended degrade rather than a regression.
- Board row `G4d` in `evals-v2-implementation.md` (`~/mcpjam-docs`, branch `include-cli-start`) is **not updated** — that checkout is not present in this environment. Handing the row to the operator:

  `| G4d | Proposal card carries the pre-run disclosure | inspector | Done — in review | Additive ProposedAction.disclosure; mint-time fetch from the frozen input; Slack renders one line, Discord skipped (no per-proposal text to anchor to) |`

---
_Generated by [Claude Code](https://claude.ai/code/session_01DBtUjC852EAfcbFYSFpYP3)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches agent proposal minting and user-facing approval copy for spend actions; failures degrade to no disclosure rather than blocking mints, but incorrect summary wording could mislead approvers about data egress.
> 
> **Overview**
> Eval-run **approval cards** now carry a mint-time **pre-run disclosure** summary so someone clicking “Run it” in Slack (not the person who chose the suite) sees where content would go—engine, sandbox, providers, judges, retention, BYOK—aligned with the app’s run-disclosure hint.
> 
> **API & contract:** `@mcpjam/sdk` adds optional `ProposedAction.disclosure` (`ProposedActionDisclosure`) and OpenAPI documents it. Missing fields mean **unknown**, not safe defaults; `digest` joins to full `get_eval_run_disclosure`.
> 
> **Server:** `run_eval_suite` and `run_eval_case` set registry flag `carriesDisclosure`. After the proposal row is persisted, `persistProposal` calls `get_eval_run_disclosure` for the **frozen** input (same object the click executes), via new `agent-proposal-disclosure.ts` (mapping, projection, **3s** bounded fetch, swallow errors). Compose runs, multi-host fan-out, and degraded `allAttached` are **refused** for disclosure. Disclosure is **wire-only**—not stored on the proposal and not accepted from hosts.
> 
> **Slack:** `disclosureLine` is embedded in each proposal **section** (block budget), capped and escaped; no line when disclosure is absent.
> 
> **Tests** cover registry hook scope, mapping/summary absence rules, agent envelope plumbing, and Slack rendering.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5a1583a8ca569985576b1ad5d04bd71b1aaeabfb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Carries pre-run disclosure on eval-run proposal cards so approvers see where content goes before clicking Run. Previously only launchers saw this at run time; now Slack proposal sections show a one-line summary derived from the frozen input and the persisted project the click will run in; absence means unknown.

- Adds `disclosure?` to `@mcpjam/sdk` `ProposedAction` and documents it in OpenAPI (digest, engine, sandbox, runProviders, judgeProviders, retention, byok).
- Server marks only `run_eval_suite` and `run_eval_case` with `carriesDisclosure`; after persisting and deduping a proposal, it fetches disclosure via `get_eval_run_disclosure` using the frozen input and the persisted projectId (not `input.project`), with a 3s timeout; refuses compose runs, multi-host groups, surviving `allAttached`, and incoherent host+environment; never persists the disclosure; `toWireProposal` spreads it conditionally.
- Slack renders a capped one-line hint inside the proposal section; no extra blocks; Discord unchanged.
- Tests cover mapping (including projectId source), bounded lookup and independent timeout, zero round trips for refused inputs, envelope plumbing, and Slack rendering.
- Rollout: no backend change required; older backends yield no `disclosure`. Bumps `@mcpjam/sdk` and `@mcpjam/inspector` minor; surfaces must render only when `disclosure` is present and must not persist or echo it back.

<sup>Written for commit 5a1583a8ca569985576b1ad5d04bd71b1aaeabfb. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/MCPJam/inspector/pull/4355?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

