### PR TITLE
evals: project actualToolCalls onto the persisted shape at the wire

### DIFF
--- a/mcpjam-inspector/server/services/evals/__tests__/convex-sanitize.test.ts
+++ b/mcpjam-inspector/server/services/evals/__tests__/convex-sanitize.test.ts
@@ -50,6 +50,12 @@ describe("sanitizeForConvexTransport", () => {
 });
 
 describe("toPersistedToolCalls", () => {
+  it("returns an empty array for an iteration that called no tools", () => {
+    // The common case: `actualToolCalls: []` is what a no-tool iteration
+    // persists, and the validator requires an array, not a missing field.
+    expect(toPersistedToolCalls([])).toEqual([]);
+  });
+
   it("keeps exactly the fields the backend validator accepts", () => {
     expect(
       toPersistedToolCalls([

--- a/mcpjam-inspector/server/services/evals/__tests__/convex-sanitize.test.ts
+++ b/mcpjam-inspector/server/services/evals/__tests__/convex-sanitize.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "vitest";
 import {
   desanitizeFromConvexTransport,
   sanitizeForConvexTransport,
+  toPersistedToolCalls,
 } from "../convex-sanitize.js";
 
 describe("sanitizeForConvexTransport", () => {
@@ -45,5 +46,64 @@ describe("sanitizeForConvexTransport", () => {
     expect(
       desanitizeFromConvexTransport(sanitizeForConvexTransport(original)),
     ).toEqual(original);
+  });
+});
+
+describe("toPersistedToolCalls", () => {
+  it("keeps exactly the fields the backend validator accepts", () => {
+    expect(
+      toPersistedToolCalls([
+        {
+          toolName: "connector_list",
+          arguments: { includeSourceConnectors: true },
+        },
+        {
+          toolName: "search",
+          arguments: { q: "coffee" },
+          toolCallId: "toolu_01SCzFBPBXj3sQjxBSxaQcoM",
+        },
+      ]),
+    ).toEqual([
+      {
+        toolName: "connector_list",
+        arguments: { includeSourceConnectors: true },
+      },
+      {
+        toolName: "search",
+        arguments: { q: "coffee" },
+        toolCallId: "toolu_01SCzFBPBXj3sQjxBSxaQcoM",
+      },
+    ]);
+  });
+
+  it("drops a field the strict validator would reject (CONVEX-1QF)", () => {
+    // `updateTestIteration.actualToolCalls` is a strict `v.object`: an
+    // unrecognized key fails the whole finalize call, so the boundary has to
+    // project rather than trust whatever the runner attached upstream.
+    const calls = toPersistedToolCalls([
+      {
+        toolName: "connector_list",
+        arguments: { includeSourceConnectors: true },
+        toolCallId: "toolu_01SCzFBPBXj3sQjxBSxaQcoM",
+        providerExecuted: true,
+        state: "output-available",
+      } as never,
+    ]);
+
+    expect(Object.keys(calls[0]!).sort()).toEqual([
+      "arguments",
+      "toolCallId",
+      "toolName",
+    ]);
+  });
+
+  it("omits toolCallId rather than sending undefined when absent", () => {
+    // `v.optional(v.string())` accepts a missing key; an explicit `undefined`
+    // is what Convex serialization rejects.
+    const [call] = toPersistedToolCalls([
+      { toolName: "echo", arguments: {}, toolCallId: undefined },
+    ]);
+
+    expect("toolCallId" in call!).toBe(false);
   });
 });

--- a/mcpjam-inspector/server/services/evals/__tests__/finalize-iteration.test.ts
+++ b/mcpjam-inspector/server/services/evals/__tests__/finalize-iteration.test.ts
@@ -186,6 +186,41 @@ describe("finalizeEvalIteration", () => {
     expect(update!.args.messages).toBeDefined();
   });
 
+  test("actualToolCalls reaches the wire projected to the persisted shape", async () => {
+    // CONVEX-1QF: `updateTestIteration.actualToolCalls` is a strict Convex
+    // `v.object`, so one unrecognized field fails the whole finalize rather
+    // than being dropped. The mapper's unit tests cover the projection; this
+    // pins that finalize actually applies it to what it sends.
+    const { client, calls } = makeClient({});
+    await finalizeEvalIteration({
+      convexClient: client,
+      iterationId: "iter1",
+      passed: true,
+      toolsCalled: [
+        {
+          toolName: "connector_list",
+          arguments: { includeSourceConnectors: true },
+          toolCallId: "toolu_01SCzFBPBXj3sQjxBSxaQcoM",
+          // Not in the validator — the shape the runner could drift into.
+          providerExecuted: true,
+        } as never,
+      ],
+      usage: usageZero,
+      messages,
+    });
+    const update = calls.find(
+      (c) => c.ref === "testSuites:updateTestIteration",
+    );
+    expect(update).toBeDefined();
+    expect(update!.args.actualToolCalls).toEqual([
+      {
+        toolName: "connector_list",
+        arguments: { includeSourceConnectors: true },
+        toolCallId: "toolu_01SCzFBPBXj3sQjxBSxaQcoM",
+      },
+    ]);
+  });
+
   test("W1 fallback omits systemPrompt when unset", async () => {
     const { client, calls } = makeClient({
       appendThrows: new Error("fanout pre-turn failure"),

--- a/mcpjam-inspector/server/services/evals/convex-sanitize.ts
+++ b/mcpjam-inspector/server/services/evals/convex-sanitize.ts
@@ -2,3 +2,47 @@ export {
   sanitizeForConvexTransport,
   desanitizeFromConvexTransport,
 } from "@/shared/convex-sanitize";
+
+/**
+ * The exact persisted shape of one `testIteration.actualToolCalls` entry —
+ * mirrors the backend's `evalIterationToolCallValidator` (mcpjam-backend
+ * `convex/lib/evalAnalysis.ts`), which is a strict `v.object`.
+ */
+export type PersistedToolCall = {
+  toolName: string;
+  arguments: Record<string, unknown>;
+  toolCallId?: string;
+};
+
+/**
+ * Project tool calls onto exactly the fields that
+ * `updateTestIteration.actualToolCalls` accepts, dropping anything else.
+ *
+ * Convex object validators are STRICT: one unrecognized field is a hard
+ * `ArgumentValidationError`, not a silent drop — so an extra key here doesn't
+ * degrade a write, it fails the whole iteration finalize. That is what
+ * CONVEX-1QF was: the runner began attaching `toolCallId` (inspector #4308, to
+ * filter policy-blocked calls by id) and every eval iteration carrying a tool
+ * call stopped persisting until the validator was widened (backend #1134).
+ *
+ * Each producer currently builds these objects field-by-field, so today's
+ * payload is already clean. This makes that a property of the boundary rather
+ * than of every producer remembering: the runner reads tool calls out of
+ * `any`-typed AI SDK step objects, so the next field added upstream would
+ * otherwise reach the validator the same way.
+ */
+export function toPersistedToolCalls(
+  toolCalls: ReadonlyArray<{
+    toolName: string;
+    arguments: Record<string, unknown>;
+    toolCallId?: string;
+  }>,
+): PersistedToolCall[] {
+  return toolCalls.map((call) => ({
+    toolName: call.toolName,
+    arguments: call.arguments,
+    ...(typeof call.toolCallId === "string"
+      ? { toolCallId: call.toolCallId }
+      : {}),
+  }));
+}

--- a/mcpjam-inspector/server/services/evals/finalize-iteration.ts
+++ b/mcpjam-inspector/server/services/evals/finalize-iteration.ts
@@ -10,7 +10,10 @@ import type {
 import { logger } from "../../utils/logger.js";
 import { uploadVideoBlob } from "../../utils/mcp-app-widget-capture.js";
 import type { UsageTotals } from "./types.js";
-import { sanitizeForConvexTransport } from "./convex-sanitize.js";
+import {
+  sanitizeForConvexTransport,
+  toPersistedToolCalls,
+} from "./convex-sanitize.js";
 import { emitBrowserEvalMetrics } from "./browser-eval-metrics.js";
 import {
   serializeBrowserStepsForBackend,
@@ -964,7 +967,9 @@ export async function finalizeEvalIteration(
       iterationId,
       status: iterationStatus === "completed" ? "completed" : iterationStatus,
       result,
-      actualToolCalls: sanitizeForConvexTransport(toolsCalled),
+      actualToolCalls: sanitizeForConvexTransport(
+        toPersistedToolCalls(toolsCalled),
+      ),
       tokensUsed: usage.totalTokens ?? 0,
       ...(useW1Fallback
         ? {


### PR DESCRIPTION
Follow-up hardening for Sentry [CONVEX-1QF](https://mcpjam-gh.sentry.io/issues/CONVEX-1QF) (51 events, 6 users, prod).

## What happened

`updateTestIteration.actualToolCalls` is validated by a **strict** Convex `v.object`. An unrecognized field there is a hard `ArgumentValidationError` — not a silent drop — so it fails the *entire* iteration finalize:

```
ArgumentValidationError: Object contains extra field `toolCallId` that is not in the validator.
Path: .actualToolCalls[0]
Validator: v.object({arguments: v.any(), toolName: v.string()})
```

#4308 taught the runner to attach `toolCallId` to each extracted tool call (so policy-blocked calls could be filtered by id) without widening the backend validator. From 2026-08-24 14:47 UTC every eval iteration that called a tool stopped persisting, until mcpjam-backend #1134 widened the validator (deployed 03:05 UTC; last event 03:19 UTC).

## Why this PR

The bug itself is already fixed on both sides (backend #1134, inspector #4351) and deployed. What's still missing is a guard against the *class*.

The wire payload's shape was only ever a property of each producer happening to build its objects field-by-field. `extractToolCallsFromConversation` reads tool calls out of `any`-typed AI SDK step objects, and `sanitizeForConvexTransport` forwards every key it's given — it escapes reserved `$` prefixes, it doesn't constrain shape. So the next field added upstream reaches the strict validator exactly the same way, and the failure mode is a silent 12-hour prod outage on eval persistence.

## What changed

- `toPersistedToolCalls()` in `server/services/evals/convex-sanitize.ts` projects each entry onto exactly `{toolName, arguments, toolCallId?}` — mirroring the backend's `evalIterationToolCallValidator`.
- Applied at the single wire boundary (`finalize-iteration.ts`, the `updateTestIteration` call).
- Tests pin the contract, including the exact CONVEX-1QF payload and the `toolCallId: undefined` case (`v.optional` accepts a missing key; an explicit `undefined` is what serialization rejects).

`appendEvalTurnTrace` needs no equivalent — its `prompts` arg is `v.array(v.any())`.

**No behavior change on today's payload** — every current producer already emits only these three fields. This makes that guaranteed at the boundary instead of remembered at each producer.

## Testing

- `npx vitest run server/services/evals/__tests__/convex-sanitize.test.ts` — 6 passed
- `finalize-iteration` / `build-iteration-finish-params` / `persist-eval-trace` — 66 passed
- `npm run typecheck` — clean for these files (7 pre-existing `commandsGroup` errors in `cli/` on `main`, untouched here)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Projects eval actualToolCalls onto the backend’s strict shape at the wire so extra fields can’t fail iteration finalize. Previously we forwarded all keys; now we send only {toolName, arguments, toolCallId?} and drop others, omitting undefined ids; current behavior is unchanged.

**Bug Fixes**
- Persist actualToolCalls: [] for no‑tool iterations to satisfy the strict validator.
- Omit toolCallId when absent rather than sending undefined.
- Add tests that pin the projection at the finalize payload and the mapper, including the CONVEX-1QF case.

<sup>Written for commit 2de9ae7651f8ff093ab79b15f96db79f114a2028. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/MCPJam/inspector/pull/4357?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

