### PR TITLE
Declare the user-server hop on ephemeral connections

### DIFF
--- a/.changeset/ephemeral-connection-user-server-hop.md
+++ b/.changeset/ephemeral-connection-user-server-hop.md
@@ -1,0 +1,32 @@
+---
+"@mcpjam/inspector": patch
+---
+
+Declare the user-server hop on the hosted ephemeral connection.
+
+`withEphemeralConnection` is the highest-traffic error path in the server —
+`/api/web/tools/list` and `/api/web/servers/validate` alone produced 2,266 of
+2,851 prod `http.request.failed` rows in 7 days — and its catch declared
+nothing about which hop failed, so every one of those rows was unattributed.
+
+The declaration is a span, not a whole-route flag, and the distinction is the
+whole point. Everything before the manager op is MCPJam's hop:
+`getConvexBearerForRequest`, `fetchScenarioRuntimeConfig` and
+`createAuthorizedManager` all reach our own Convex deployment. Marking the
+entire catch would stop paging us during a Convex outage and simultaneously
+tell the user their MCP server was down — strictly worse than the noise it
+would fix. `createAuthorizedManager` returns without awaiting its connects (the
+constructor queues them as microtasks), so the first thing that actually
+touches the user's server is the manager op inside `fn`, which makes that the
+narrowest span still catching connect failures.
+
+`runEphemeralConnection` marks failures from that span with the existing
+`markUserServerHop`, and the route catch reads the mark to record
+`hop: "user_server_hop"`. Anything reaching the catch unmarked — a malformed
+body, an authorize failure, our own Convex refusing — stays unattributed,
+because absent means unknown and never "the user's".
+
+Attribution only: no status changes. Answering 424 for an unreachable target,
+as `chat-v2` already does, goes through `namesAnMcpServer` and needs the server
+name threaded to the catch rather than recovered from the message. That is the
+one user-visible change in this program and it ships separately.

--- a/mcpjam-inspector/server/routes/web/__tests__/ephemeral-connection-hop.test.ts
+++ b/mcpjam-inspector/server/routes/web/__tests__/ephemeral-connection-hop.test.ts
@@ -1,0 +1,176 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { Hono } from "hono";
+
+/**
+ * `withEphemeralConnection`'s catch is the highest-traffic error path in the
+ * server — `/api/web/tools/list` and `/api/web/servers/validate` alone
+ * produced 2,266 of 2,851 prod `http.request.failed` rows in 7 days — and it
+ * declared nothing about which hop failed.
+ *
+ * The declaration has to be a SPAN, not a whole-route flag, and that split is
+ * what these tests pin. Everything before `fn` is MCPJam's hop:
+ * `getConvexBearerForRequest`, `fetchScenarioRuntimeConfig` and
+ * `createAuthorizedManager` all reach our own Convex deployment. Marking the
+ * whole catch would stop paging us during a Convex outage AND tell the user
+ * their MCP server was down — strictly worse than the noise being fixed.
+ *
+ * `createAuthorizedManager` returns without awaiting its connects (the
+ * constructor queues them as microtasks), so the first thing that actually
+ * touches the user's server is the manager op inside `fn`. That makes `fn`
+ * the narrowest span that still catches connect failures.
+ */
+vi.mock("@sentry/node", () => ({
+  captureException: vi.fn(),
+  captureMessage: vi.fn(),
+}));
+
+vi.mock("../../../utils/logger.js", async () => {
+  const actual = await vi.importActual<
+    typeof import("../../../utils/logger.js")
+  >("../../../utils/logger.js");
+  return { ...actual, logger: { ...actual.logger, event: vi.fn() } };
+});
+
+/** The user's server refuses the connection on the first manager op. */
+const TARGET_FAILURE = Object.assign(new TypeError("fetch failed"), {
+  code: "ECONNREFUSED",
+});
+
+vi.mock("@mcpjam/sdk", async () => {
+  const actual = await vi.importActual<typeof import("@mcpjam/sdk")>(
+    "@mcpjam/sdk"
+  );
+  class MockMCPClientManager {
+    async listTools() {
+      // The real failure shape: `createAuthorizedManager` has already
+      // returned, and the queued connect fails when the first op awaits it.
+      throw TARGET_FAILURE;
+    }
+    getAllToolsMetadata() {
+      return undefined;
+    }
+    setPerRequestLogLevel() {}
+    async disconnectAllServers() {
+      return undefined;
+    }
+  }
+  return {
+    ...actual,
+    MCPClientManager: MockMCPClientManager,
+    isMCPAuthError: vi.fn().mockReturnValue(false),
+  };
+});
+
+import { logger } from "../../../utils/logger.js";
+import { requestLogContextMiddleware } from "../../../middleware/request-log-context.js";
+import toolsRoutes from "../tools.js";
+
+function createTestApp(): Hono {
+  const app = new Hono();
+  app.use("/api/*", requestLogContextMiddleware);
+  app.use("*", async (c, next) => {
+    c.set("guestId", "guest-1");
+    await next();
+  });
+  app.route("/api/web/tools", toolsRoutes);
+  return app;
+}
+
+function postList(app: Hono) {
+  return app.request("/api/web/tools/list", {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      Authorization: "Bearer test-token",
+    },
+    body: JSON.stringify({
+      projectId: "project-1",
+      serverId: "srv-1",
+      serverName: "Notion",
+    }),
+  });
+}
+
+function failedEvent() {
+  const calls = vi
+    .mocked(logger.event)
+    .mock.calls.filter(([name]) => name === "http.request.failed");
+  expect(calls).toHaveLength(1);
+  return calls[0][2] as Record<string, unknown>;
+}
+
+describe("withEphemeralConnection hop declaration", () => {
+  const originalFetch = global.fetch;
+  const originalConvexHttpUrl = process.env.CONVEX_HTTP_URL;
+
+  /** Convex authorizes successfully — MCPJam's hop succeeds. */
+  function authorizeSucceeds() {
+    global.fetch = vi.fn(async (input) => {
+      if (String(input).endsWith("/web/authorize-batch")) {
+        return new Response(
+          JSON.stringify({
+            results: {
+              "srv-1": {
+                ok: true,
+                role: "member",
+                accessLevel: "project_member",
+                permissions: { chatOnly: false },
+                serverConfig: {
+                  transportType: "http",
+                  url: "https://server.example.com/mcp",
+                  headers: {},
+                  useOAuth: false,
+                },
+              },
+            },
+          }),
+          { status: 200, headers: { "Content-Type": "application/json" } }
+        );
+      }
+      throw new Error(`Unexpected fetch: ${String(input)}`);
+    }) as typeof fetch;
+  }
+
+  beforeEach(() => {
+    process.env.CONVEX_HTTP_URL = "https://convex.example.com";
+    vi.mocked(logger.event).mockClear();
+  });
+
+  afterEach(() => {
+    global.fetch = originalFetch;
+    if (originalConvexHttpUrl) {
+      process.env.CONVEX_HTTP_URL = originalConvexHttpUrl;
+    } else {
+      delete process.env.CONVEX_HTTP_URL;
+    }
+  });
+
+  it("declares user_server_hop when the manager op fails", async () => {
+    authorizeSucceeds();
+
+    const res = await postList(createTestApp());
+    const payload = failedEvent();
+
+    expect(payload.hop).toBe("user_server_hop");
+    // Attribution only. The 424 downgrade `chat-v2` already applies to an
+    // unreachable target is a separate, user-visible change; this one must
+    // not move the status, so the assertion pins that too.
+    expect(res.status).toBe(502);
+    expect(payload.statusCode).toBe(502);
+  });
+
+  it("leaves a failure in MCPJam's own hop unattributed", async () => {
+    // Convex — our deployment — is what breaks here. This is the converse
+    // that keeps the span honest: if this row ever carries
+    // `user_server_hop`, the new monitor goes blind during our own outage.
+    global.fetch = vi.fn(async () => {
+      throw new TypeError("fetch failed");
+    }) as typeof fetch;
+
+    await postList(createTestApp());
+    const payload = failedEvent();
+
+    expect(payload.hop).toBeUndefined();
+    expect("hop" in payload).toBe(false);
+  });
+});

--- a/mcpjam-inspector/server/routes/web/auth.ts
+++ b/mcpjam-inspector/server/routes/web/auth.ts
@@ -43,6 +43,10 @@ import {
 import type { ExecutionScope } from "../../utils/execution-scope.js";
 import type { RequestLogContext } from "../../utils/log-events.js";
 import {
+  isUserServerHopFault,
+  markUserServerHop,
+} from "../../utils/route-error-report.js";
+import {
   type InternalLogContext,
   mapInternalToRequestContext,
 } from "../../utils/internal-log-context.js";
@@ -2076,6 +2080,17 @@ export async function runEphemeralConnection<S extends z.ZodTypeAny, T>(
 
   try {
     return await fn(manager, body);
+  } catch (error) {
+    // The span boundary, and the reason it is HERE rather than on the whole
+    // route catch. Everything above this line is MCPJam's hop —
+    // `getConvexBearerForRequest`, `fetchScenarioRuntimeConfig` and
+    // `createAuthorizedManager` all reach our own Convex deployment, and a
+    // Convex outage must keep paging us. `createAuthorizedManager` returns
+    // without awaiting its connects (the constructor queues them as
+    // microtasks), so the first thing that actually touches the user's server
+    // is the manager op inside `fn` — which makes this the narrowest span that
+    // still catches connect failures.
+    throw markUserServerHop(error);
   } finally {
     await manager.disconnectAllServers();
   }
@@ -2308,11 +2323,27 @@ export async function withEphemeralConnection<S extends z.ZodTypeAny, T>(
 
     return c.json(attachHostedRpcLogs(result, rpcCollector), 200);
   } catch (error) {
+    // Only a failure the span above positively marked is the user's hop.
+    // Anything else — a malformed body, an authorize failure, our own Convex
+    // refusing — reaches here unmarked and stays unattributed, because absent
+    // means unknown and never "the user's".
+    //
+    // Attribution only: the status is deliberately unchanged. Answering 424
+    // here, as `chat-v2` already does for an unreachable target, goes through
+    // `namesAnMcpServer` and so needs the server name threaded to this catch
+    // rather than recovered from the message. That is the one user-visible
+    // change in this program and it ships on its own.
+    const userServerHop = isUserServerHopFault(error);
     const routeError = mapRuntimeError(error);
     return webErrorFromRoute(
       c,
       routeError,
-      rpcCollector?.buildEnvelope() as Record<string, unknown> | undefined
+      {
+        ...((rpcCollector?.buildEnvelope() as
+          | Record<string, unknown>
+          | undefined) ?? {}),
+        ...(userServerHop ? { hop: "user_server_hop" as const } : {}),
+      }
     );
   }
 }

--- a/mcpjam-inspector/server/utils/route-error-report.ts
+++ b/mcpjam-inspector/server/utils/route-error-report.ts
@@ -204,7 +204,15 @@ export function markUserServerHop(error: unknown): unknown {
 /** How far to walk a `.cause` chain before giving up. Mirrors the capture walk. */
 const MAX_CAUSE_DEPTH = 8;
 
-function isUserServerHopFault(error: unknown): boolean {
+/**
+ * Read the mark {@link markUserServerHop} leaves.
+ *
+ * Exported so a route catch can record the hop on `http.request.failed`, not
+ * only suppress a Sentry capture. `route-error-report.ts` used the mark for
+ * the capture decision and nothing else, which is why the one declaration
+ * meaning "this hop was not ours" reached no telemetry at all.
+ */
+export function isUserServerHopFault(error: unknown): boolean {
   const seen = new Set<unknown>();
   let current: unknown = error;
   for (let depth = 0; depth < MAX_CAUSE_DEPTH; depth += 1) {


### PR DESCRIPTION
> **Stacked on #4360.** Base is `fix/axiom-5xx-origin`, not `main` — review that
> one first. #4360 adds the `hop` field; this supplies the first value for it.
> Retarget to `main` once #4360 merges.

## What broke

`withEphemeralConnection`'s catch is the highest-traffic error path in the
server. `/api/web/tools/list` and `/api/web/servers/validate` alone produced
**2,266 of 2,851** prod `http.request.failed` rows in 7 days, and the catch
declared nothing about which hop failed — so all of them were unattributed.
That is what leaves `MCPJam Inspector 5xx rate (prod)` unable to tell "MCPJam
is broken" from "someone pointed us at a dead server".

## Why this is a span, not a route flag

The catch wraps more than the user's server. Everything before the manager op
is MCPJam's own hop:

- `getConvexBearerForRequest`
- `fetchScenarioRuntimeConfig`
- `createAuthorizedManager` — `/web/authorize-batch`

All three reach our Convex deployment. Marking the whole catch
`user_server_hop` would stop paging us during a Convex outage **and** tell the
user their MCP server was down. That is strictly worse than the noise it fixes,
and it is the "declared too broadly" risk the plan called out.

`createAuthorizedManager` returns **without awaiting its connects** — the
constructor queues them as microtasks (`auth.ts:1839`, "SYNCHRONOUS, before any
`await` — the constructor above queued its connects"). So the first thing that
actually touches the user's server is the manager op inside `fn`. That makes
`fn` the narrowest span that still catches connect failures, and that is where
the mark goes.

## What this does

- `runEphemeralConnection` marks failures thrown by the `fn` span using the
  existing `markUserServerHop`, rather than inventing a second convention. The
  mark already survives re-wrapping — `isUserServerHopFault` walks the `.cause`
  chain — and already handles the awkward cases (`throw "failure"`, frozen and
  sealed errors) via `ensureStampable`.
- The route catch reads it and records `hop: "user_server_hop"`.
  `isUserServerHopFault` is now exported: the mark drove the Sentry capture
  decision and reached no telemetry at all, which is the underlying reason the
  one declaration meaning "not ours" was recorded nowhere.
- Anything reaching the catch unmarked — a malformed body, an authorize
  failure, our own Convex refusing — stays unattributed. Absent means unknown,
  never "the user's".

## Not here: the 424

Attribution only. No status changes.

Answering 424 for an unreachable target, as `chat-v2` has done since #3961,
runs through `namesAnMcpServer`, which tests the message for a literal
`MCP server "`. The common production message — `Couldn't reach the MCP server
(fetch failed)` — does not match it, so the downgrade needs the server name
threaded to this catch rather than recovered from the message. It is also the
only user-visible change in this program and an open question on the plan
(does `/api/web/tools/list` answering 424 break the client?). It ships on its
own.

## Tests

`server/routes/web/__tests__/ephemeral-connection-hop.test.ts`, driving the
real route through `requestLogContextMiddleware` and asserting the emitted
`http.request.failed` payload:

- a failing manager op records `hop: "user_server_hop"` and leaves the status
  at 502;
- **a failure in MCPJam's own Convex hop records no hop at all.**

The second is the one that matters. If that row ever carries
`user_server_hop`, the new monitor goes blind during our own outage — so the
span split is pinned by a test rather than by the comment explaining it.

## Verification

| check | result |
|---|---|
| server typecheck | clean on touched files; 264 pre-existing errors, unchanged from baseline |
| `test -w @mcpjam/inspector` | 17,763 passed; same 7 inherited failing files as #4360 |

`ScenarioChatPage` and `oauth-redaction-ratchet` went red in the full parallel
run and pass 41/41 in isolation — flaky under load on Windows, and this diff is
server-only.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds hop attribution for ephemeral connection failures so we can tell user-server failures from our own outages. Previously, failures in `withEphemeralConnection` were unattributed; now manager-op failures are recorded with hop "user_server_hop" in `http.request.failed`.

- Uses a narrow span around the manager operation to mark only user-server connect failures.
- Exports `isUserServerHopFault` and sets the hop in the route catch based on that mark.
- Leaves authorization/body/Convex failures without a hop to avoid misattribution.
- Keeps response statuses unchanged; the 424 downgrade is out of scope.
- Adds tests that pin the span boundary and verify both attributed and unattributed paths.

<sup>Written for commit 39c7ca068eeba7db38976d837fe30ac1d32f5971. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/MCPJam/inspector/pull/4361?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

