### PR TITLE
fix(sdk): name the version when a legacy protocol pin is refused

### DIFF
--- a/.changeset/protocol-pin-mismatch-error.md
+++ b/.changeset/protocol-pin-mismatch-error.md
@@ -1,0 +1,20 @@
+---
+"@mcpjam/inspector": patch
+"@mcpjam/sdk": patch
+"@mcpjam/cli": patch
+---
+
+Report a legacy protocol-version pin mismatch as a version problem instead of "the server appears to be down"
+
+Pinning a stateful MCP protocol version (e.g. 2025-11-25) against a server that
+answers with a different one — Slack and HubSpot both answer 2025-06-18 — failed
+the connect with a generic 502 and "Couldn't reach the MCP server". Tools came
+back silently empty and reconnects looked like someone else's outage rather than
+the version setting they actually were.
+
+The `ProtocolVersionPinUnsupported` path that already produces a 424, names both
+versions, and offers "Change protocol version" only ever fired for modern
+(2026-07-28) pins: the detector bailed out for stateful pins, and the failure
+parser did not recognize the wording the upstream client uses when it refuses a
+server's `initialize` reply. Both now handle it, and the message names the
+version the server actually offered.

--- a/sdk/src/mcp-client-manager/MCPClientManager.ts
+++ b/sdk/src/mcp-client-manager/MCPClientManager.ts
@@ -2947,9 +2947,18 @@ export class MCPClientManager {
     const pin = config.mcpProtocolVersion;
     if (!pin) return undefined;
     const negotiation = resolveVersionNegotiation(pin);
-    // `undefined` is a legacy pin (exact `initialize`, no discover probe) and
-    // `"auto"` falls back on its own. Only an explicit modern pin refuses.
-    if (!negotiation || negotiation.mode === "auto") return undefined;
+    // `"auto"` falls back on its own, so it can never refuse — and a config
+    // with no pin already returned above.
+    //
+    // A legacy pin (`undefined` here: exact `initialize`, no discover probe)
+    // DOES refuse, and used to be excluded. It narrows the accept-list to the
+    // pinned version, so a server whose `initialize` reply names anything else
+    // — e.g. a 2025-11-25 pin against a server that answers 2025-06-18 — fails
+    // the connect just as a modern pin does. Excluding it sent that failure to
+    // the generic connection patterns, which report the user's own version
+    // setting as "the server appears to be down". The verdict below is what
+    // keeps a real outage out: it only matches a version refusal.
+    if (negotiation?.mode === "auto") return undefined;
     for (const error of errors) {
       // NOT "is this an era-negotiation error": that code also covers a probe
       // that hit an HTTP status, a network failure, or a closed transport —

--- a/sdk/src/mcp-client-manager/errors.ts
+++ b/sdk/src/mcp-client-manager/errors.ts
@@ -141,9 +141,10 @@ export function isEraNegotiationError(error: unknown): boolean {
  * resolves `@modelcontextprotocol/client` to a different copy than the app
  * does, and the whole point of these helpers is to survive that.
  *
- * Returns the server's advertised versions when they are known (they are only
- * present on the `UnsupportedProtocolVersionError` shape), or an empty array
- * when the failure was a pin refusal that carried no list.
+ * Returns the server's advertised versions when they are known — the
+ * `UnsupportedProtocolVersionError` shape carries the full list, and the
+ * legacy `initialize` refusal names the single version it counter-offered —
+ * or an empty array when the failure was a pin refusal that carried neither.
  */
 export function readUnsupportedVersionFailure(
   error: unknown
@@ -176,6 +177,32 @@ export function readUnsupportedVersionFailure(
       /did not offer pinned protocol version/i.test(named.message)
     ) {
       return { supported: [] };
+    }
+    // The LEGACY-pin refusal, thrown by the upstream `Client` when the
+    // server's `initialize` reply names a version outside the accept-list a
+    // stateful pin narrowed to. It is a plain `Error` — no `supported` array,
+    // no era-negotiation code — so neither branch above sees it, and without
+    // this the failure falls through to the generic connection patterns and
+    // gets reported as "the server appears to be down" (a 502) rather than as
+    // the version setting it actually is.
+    //
+    // The captured version is the one the server OFFERED, which is exactly
+    // what the caller cannot get from the config: the pin is already in hand,
+    // the counter-offer is not. Returned as the `supported` list so the
+    // existing message builder names both sides.
+    //
+    // Matched as a date-shaped token rather than `\S+` because the manager
+    // folds this into a composite message ("… Streamable HTTP error: Server's
+    // protocol version is not supported: 2025-06-18. SSE error: …"), where a
+    // greedy non-whitespace capture takes the sentence's period with it and
+    // reports the server as offering "2025-06-18.".
+    if (typeof named.message === "string") {
+      const offered = /protocol version is not supported:\s*(\d{4}-\d{2}-\d{2})/i.exec(
+        named.message
+      );
+      if (offered) {
+        return { supported: [offered[1]] };
+      }
     }
   }
   return undefined;

--- a/sdk/src/mcp-client-manager/managed-mcp-client.ts
+++ b/sdk/src/mcp-client-manager/managed-mcp-client.ts
@@ -380,11 +380,11 @@ export class ProtocolVersionPinUnsupported extends Error {
   /**
    * What the server said it DOES speak, when it said so.
    *
-   * Present only when the failure arrived as `UnsupportedProtocolVersionError`
-   * — the shape raised after `server/discover` parsed cleanly and listed no
-   * usable version, which is the only one that carries the server's list. A
-   * pin refusal with no list yields `[]`, and the message simply omits the
-   * clause rather than guessing.
+   * Carried by two failure shapes: `UnsupportedProtocolVersionError` — raised
+   * after `server/discover` parsed cleanly and listed no usable version — and
+   * the legacy `initialize` refusal, whose message names the single version
+   * the server's reply offered. A pin refusal that carried no version at all
+   * yields `[]`, and the message simply omits the clause rather than guessing.
    */
   readonly supportedVersions: readonly string[];
   constructor(

--- a/sdk/tests/unsupported-version-failure.test.ts
+++ b/sdk/tests/unsupported-version-failure.test.ts
@@ -80,6 +80,42 @@ describe("readUnsupportedVersionFailure", () => {
     });
   });
 
+  // The legacy-pin refusal: a stateful pin narrows the accept-list, the
+  // server's `initialize` reply names something else, and the upstream client
+  // throws a plain `Error`. Neither shape above matches it, so before this was
+  // recognized the failure was reported as "the server appears to be down".
+  it("reads the version a legacy initialize refusal names", () => {
+    const verdict = readUnsupportedVersionFailure(
+      new Error("Server's protocol version is not supported: 2025-06-18"),
+    );
+
+    expect(verdict).toEqual({ supported: ["2025-06-18"] });
+  });
+
+  // Verbatim from a production connect against mcp.slack.com with a 2025-11-25
+  // pin. The manager folds every transport's failure into one message, so the
+  // clause lands mid-sentence followed by a period — a greedy capture reports
+  // the server as offering "2025-06-18.".
+  it("does not swallow sentence punctuation from the wrapped composite", () => {
+    const verdict = readUnsupportedVersionFailure(
+      new Error(
+        'Failed to connect to MCP server "slack" using HTTP transports. ' +
+          "Streamable HTTP error: Server's protocol version is not supported: 2025-06-18. " +
+          "SSE error: SSE error: Non-200 status code (405).",
+      ),
+    );
+
+    expect(verdict).toEqual({ supported: ["2025-06-18"] });
+  });
+
+  it("ignores a refusal that names no version", () => {
+    expect(
+      readUnsupportedVersionFailure(
+        new Error("Server's protocol version is not supported: banana"),
+      ),
+    ).toBeUndefined();
+  });
+
   it("terminates on a cyclic cause chain", () => {
     const a = new Error("a") as Error & { cause?: unknown };
     const b = new Error("b") as Error & { cause?: unknown };


### PR DESCRIPTION
- If you pin an MCP protocol version (e.g. 2025-11-25) and the server only speaks an older one, the connect fails — but we reported it as a 502 "the server appears to be down". Tools came back silently empty and reconnects looked like someone else's outage.
- Slack and HubSpot both hit this: they answer 2025-06-18, so a Nov-25 pin breaks them. On auto they connect fine.
- We already had the nice version of this error — a 424 that names both versions and shows a "Change protocol version" button. It just never fired for 2025-* pins, only for 2026-07-28 ones.
- Two small fixes: stop the detector from bailing out on older pins, and teach it the wording the client uses when it rejects a server's `initialize` reply, so we can pull out the version the server actually offered.
- Now you get "doesn't support 2025-11-25, which this client is pinned to. It offers 2025-06-18." instead of a generic outage message.

🤖 Generated with [Claude Code](https://claude.com/claude-code)