### PR TITLE
fix(chat): contain stack overflow from deeply nested markdown

### DIFF
--- a/mcpjam-inspector/client/src/__tests__/router-sentry-instrumentation.test.ts
+++ b/mcpjam-inspector/client/src/__tests__/router-sentry-instrumentation.test.ts
@@ -1,0 +1,56 @@
+import { describe, expect, it, vi } from "vitest";
+// Static, not `await import` inside the test: importing App's module graph
+// costs ~20s, and inside a test body that counts against the 30s timeout.
+import { createAppRouter } from "@/router";
+
+// `vi.hoisted`, because the static import above makes the mock factory run
+// during collection, before a plain `const` would be initialized.
+const { createSentryBrowserRouter } = vi.hoisted(() => ({
+  createSentryBrowserRouter: vi.fn(() => ({ routes: [] })),
+}));
+
+// Stub every route component. `buildRouteChildren` walks APP_ROUTES, not the
+// elements, so the tree shape this asserts on is unchanged — and loading the
+// real App graph costs ~40s of collect for one assertion.
+vi.mock("@/App", () => {
+  const Stub = () => null;
+  return new Proxy(
+    { default: Stub },
+    {
+      // `then` must stay undefined or the module namespace looks thenable and
+      // the dynamic import never resolves.
+      get: (target, prop) =>
+        prop === "then" ? undefined : (Reflect.get(target, prop) ?? Stub),
+      has: () => true,
+    },
+  );
+});
+
+// Only the factory is stubbed; the rest of lib/sentry is real, because App's
+// module graph pulls other exports from it.
+vi.mock("@/lib/sentry", async () => {
+  const actual =
+    await vi.importActual<typeof import("@/lib/sentry")>("@/lib/sentry");
+  return { ...actual, createSentryBrowserRouter };
+});
+
+/**
+ * Guards the half of the Sentry wiring that `sentry.test.ts` cannot see.
+ *
+ * That file asserts `wrapCreateBrowserRouterV7` was called with
+ * `createBrowserRouter` — a fact about `lib/sentry`. Swapping `router.tsx` back
+ * to the bare `createBrowserRouter` left all of it green, and transactions
+ * would silently go back to being named after the pageload URL.
+ */
+describe("createAppRouter", () => {
+  it("builds the route tree through the Sentry-instrumented factory", () => {
+    createAppRouter();
+
+    expect(createSentryBrowserRouter).toHaveBeenCalledTimes(1);
+    // The real app shell, not an empty placeholder.
+    const routes = createSentryBrowserRouter.mock.calls[0][0] as {
+      children?: unknown[];
+    }[];
+    expect(routes.some((route) => (route.children ?? []).length > 0)).toBe(true);
+  });
+});

--- a/mcpjam-inspector/client/src/components/chat-v2/thread/__tests__/memoized-markdown.test.tsx
+++ b/mcpjam-inspector/client/src/components/chat-v2/thread/__tests__/memoized-markdown.test.tsx
@@ -1,5 +1,5 @@
 import { render, screen } from "@testing-library/react";
-import { describe, expect, it, vi } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 import { MemoizedMarkdown } from "../memomized-markdown";
 
 // Stand-in for Streamdown: keeps the remark/mermaid/shiki graph out of jsdom,
@@ -14,10 +14,62 @@ vi.mock("streamdown", () => ({
   defaultUrlTransform: (url: string) => url,
 }));
 
+// `vi.hoisted`: the static import above makes this factory run during
+// collection, before a plain `const` would be initialized.
+const { lexerCalls } = vi.hoisted(() => ({ lexerCalls: vi.fn() }));
+
+// Real lexer, plus a call counter and one sentinel that exercises the `catch`.
+vi.mock("marked", async () => {
+  const actual = await vi.importActual<typeof import("marked")>("marked");
+  return {
+    marked: {
+      ...actual.marked,
+      lexer: (markdown: string) => {
+        lexerCalls(markdown);
+        if (markdown.includes("LEXER_THROWS")) {
+          throw new RangeError("Maximum call stack size exceeded");
+        }
+        return actual.marked.lexer(markdown);
+      },
+    },
+  };
+});
+
 // INSPECTOR-CLIENT-253: ~2KB of nesting exhausts the stack in marked's lexer.
 const pathologicallyNested = `- x\n  ${">".repeat(2500)} deep`;
 
 describe("MemoizedMarkdown", () => {
+  beforeEach(() => {
+    lexerCalls.mockClear();
+  });
+
+  it("blocks inline emphasis runs before they reach the lexer", () => {
+    // No indentation and no `>` markers, so the block-nesting scan scored this
+    // 0 and handed 10KB straight to marked, which overflows on it.
+    const run = "*".repeat(5000);
+    render(<MemoizedMarkdown content={`${run}x${run}`} />);
+
+    expect(screen.queryByTestId("streamdown")).not.toBeInTheDocument();
+    expect(screen.getByTestId("markdown-plain-text")).toBeInTheDocument();
+    // Caught by the deterministic scan, not by the `try/catch` behind it.
+    expect(lexerCalls).not.toHaveBeenCalled();
+  });
+
+  it("stops re-lexing once a parse has failed mid-stream", () => {
+    // `useMemo` is keyed on the whole content, which grows every streaming
+    // tick; without the latch each tick re-enters the lexer and re-throws.
+    const { rerender } = render(<MemoizedMarkdown content="LEXER_THROWS a" />);
+    const callsAfterFirstTick = lexerCalls.mock.calls.length;
+
+    rerender(<MemoizedMarkdown content="LEXER_THROWS ab" />);
+    rerender(<MemoizedMarkdown content="LEXER_THROWS abc" />);
+
+    expect(lexerCalls.mock.calls.length).toBe(callsAfterFirstTick);
+    expect(screen.getByTestId("markdown-plain-text")).toHaveTextContent(
+      "LEXER_THROWS abc",
+    );
+  });
+
   it("splits ordinary markdown into Streamdown blocks", () => {
     render(<MemoizedMarkdown content={"# Title\n\nA paragraph.\n"} />);
 
@@ -40,6 +92,46 @@ describe("MemoizedMarkdown", () => {
     // Plain text, not markdown: Streamdown recurses per nesting level too.
     expect(screen.queryByTestId("streamdown")).not.toBeInTheDocument();
     expect(screen.getByTestId("markdown-plain-text")).toHaveTextContent("deep");
+  });
+
+  it("counts two-space list indentation at marked's own granularity", () => {
+    // 202 levels of the tightest nesting marked recognises must exceed the
+    // cap; counting indentation any coarser would let it through.
+    const nestedList = Array.from(
+      { length: 202 },
+      (_, level) => `${" ".repeat(level * 2)}- x`,
+    ).join("\n");
+
+    render(<MemoizedMarkdown content={nestedList} />);
+
+    expect(screen.queryByTestId("streamdown")).not.toBeInTheDocument();
+    expect(screen.getByTestId("markdown-plain-text")).toBeInTheDocument();
+  });
+
+  it("renders content past the size cap as plain text", () => {
+    // One character over MAX_MARKDOWN_CHARS.
+    render(<MemoizedMarkdown content={"a".repeat(512_001)} />);
+
+    expect(screen.queryByTestId("streamdown")).not.toBeInTheDocument();
+    expect(screen.getByTestId("markdown-plain-text")).toBeInTheDocument();
+  });
+
+  it("renders plain text when the lexer itself throws", () => {
+    // The `catch` in parseMarkdownIntoBlocks, not the boundary — so nothing
+    // should reach console.error here.
+    const consoleError = vi
+      .spyOn(console, "error")
+      .mockImplementation(() => {});
+
+    render(<MemoizedMarkdown content="LEXER_THROWS here" />);
+
+    expect(screen.queryByTestId("streamdown")).not.toBeInTheDocument();
+    expect(screen.getByTestId("markdown-plain-text")).toHaveTextContent(
+      "LEXER_THROWS here",
+    );
+    expect(consoleError).not.toHaveBeenCalled();
+
+    consoleError.mockRestore();
   });
 
   it("falls back to the raw text when the markdown renderer throws", () => {

--- a/mcpjam-inspector/client/src/components/chat-v2/thread/__tests__/memoized-markdown.test.tsx
+++ b/mcpjam-inspector/client/src/components/chat-v2/thread/__tests__/memoized-markdown.test.tsx
@@ -70,6 +70,33 @@ describe("MemoizedMarkdown", () => {
     );
   });
 
+  it("gives a different document a fresh attempt after a failed parse", () => {
+    // SkillFileViewer mounts MemoizedMarkdown with no key, so switching file
+    // reuses this instance. The latch must not outlive the content it fired on.
+    const { rerender } = render(<MemoizedMarkdown content="LEXER_THROWS a" />);
+    expect(screen.getByTestId("markdown-plain-text")).toBeInTheDocument();
+
+    rerender(<MemoizedMarkdown content={"# Another file\n\nFine.\n"} />);
+
+    expect(screen.getAllByTestId("streamdown").length).toBeGreaterThan(0);
+  });
+
+  it("gives a different document a fresh attempt after a renderer throw", () => {
+    const consoleError = vi
+      .spyOn(console, "error")
+      .mockImplementation(() => {});
+
+    const { rerender } = render(
+      <MemoizedMarkdown content="THROW_ON_RENDER a" />,
+    );
+    expect(screen.getByTestId("markdown-plain-text")).toBeInTheDocument();
+
+    rerender(<MemoizedMarkdown content={"# Another file\n\nFine.\n"} />);
+
+    expect(screen.getAllByTestId("streamdown").length).toBeGreaterThan(0);
+    consoleError.mockRestore();
+  });
+
   it("splits ordinary markdown into Streamdown blocks", () => {
     render(<MemoizedMarkdown content={"# Title\n\nA paragraph.\n"} />);
 

--- a/mcpjam-inspector/client/src/components/chat-v2/thread/__tests__/memoized-markdown.test.tsx
+++ b/mcpjam-inspector/client/src/components/chat-v2/thread/__tests__/memoized-markdown.test.tsx
@@ -1,0 +1,59 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import { MemoizedMarkdown } from "../memomized-markdown";
+
+// Stand-in for Streamdown: keeps the remark/mermaid/shiki graph out of jsdom,
+// and gives the boundary test a deterministic way to throw mid-render.
+vi.mock("streamdown", () => ({
+  Streamdown: ({ children }: { children: string }) => {
+    if (children.includes("THROW_ON_RENDER")) {
+      throw new RangeError("Maximum call stack size exceeded");
+    }
+    return <div data-testid="streamdown">{children}</div>;
+  },
+  defaultUrlTransform: (url: string) => url,
+}));
+
+// INSPECTOR-CLIENT-253: ~2KB of nesting exhausts the stack in marked's lexer.
+const pathologicallyNested = `- x\n  ${">".repeat(2500)} deep`;
+
+describe("MemoizedMarkdown", () => {
+  it("splits ordinary markdown into Streamdown blocks", () => {
+    render(<MemoizedMarkdown content={"# Title\n\nA paragraph.\n"} />);
+
+    const blocks = screen.getAllByTestId("streamdown");
+    expect(blocks.length).toBeGreaterThan(0);
+    expect(blocks.map((b) => b.textContent).join("")).toContain("A paragraph.");
+  });
+
+  it("still renders markdown at ordinary nesting depth", () => {
+    render(<MemoizedMarkdown content={"> > > quoted three deep\n"} />);
+
+    expect(screen.getAllByTestId("streamdown").length).toBeGreaterThan(0);
+  });
+
+  it("renders pathologically nested markdown as plain text instead of crashing", () => {
+    expect(() =>
+      render(<MemoizedMarkdown content={pathologicallyNested} />),
+    ).not.toThrow();
+
+    // Plain text, not markdown: Streamdown recurses per nesting level too.
+    expect(screen.queryByTestId("streamdown")).not.toBeInTheDocument();
+    expect(screen.getByTestId("markdown-plain-text")).toHaveTextContent("deep");
+  });
+
+  it("falls back to the raw text when the markdown renderer throws", () => {
+    const consoleError = vi
+      .spyOn(console, "error")
+      .mockImplementation(() => {});
+
+    expect(() =>
+      render(<MemoizedMarkdown content="THROW_ON_RENDER please" />),
+    ).not.toThrow();
+    expect(screen.getByTestId("markdown-plain-text")).toHaveTextContent(
+      "THROW_ON_RENDER please",
+    );
+
+    consoleError.mockRestore();
+  });
+});

--- a/mcpjam-inspector/client/src/components/chat-v2/thread/memomized-markdown.tsx
+++ b/mcpjam-inspector/client/src/components/chat-v2/thread/memomized-markdown.tsx
@@ -210,17 +210,31 @@ function MarkdownBlocks({
 }
 
 export const MemoizedMarkdown = memo(
-  ({ content, className }: { content: string; className?: string }) => (
-    // The fuse: a throw here used to unmount the whole route through the
-    // router's errorElement, taking the conversation with it. Once tripped it
-    // stays on plain text for this message, which still shows every character.
-    <ErrorBoundary
-      name="markdown-render"
-      fallback={<PlainTextMarkdown content={content} className={className} />}
-    >
-      <MarkdownBlocks content={content} className={className} />
-    </ErrorBoundary>
-  ),
+  ({ content, className }: { content: string; className?: string }) => {
+    // Both fuses below latch for the life of their instance — ErrorBoundary
+    // through `hasError`, MarkdownBlocks through its ref. Callers reuse one
+    // instance across unrelated documents (SkillFileViewer switches file with
+    // no key), so remount when the content stops being the same message
+    // streaming in. A prefix is what tells the two apart.
+    const previousContent = useRef("");
+    const documentGeneration = useRef(0);
+    if (!content.startsWith(previousContent.current)) {
+      documentGeneration.current += 1;
+    }
+    previousContent.current = content;
+
+    return (
+      // The fuse: a throw here used to unmount the whole route through the
+      // router's errorElement, taking the conversation with it.
+      <ErrorBoundary
+        key={documentGeneration.current}
+        name="markdown-render"
+        fallback={<PlainTextMarkdown content={content} className={className} />}
+      >
+        <MarkdownBlocks content={content} className={className} />
+      </ErrorBoundary>
+    );
+  },
   (prevProps, nextProps) => {
     if (prevProps.content !== nextProps.content) return false;
     if (prevProps.className !== nextProps.className) return false;

--- a/mcpjam-inspector/client/src/components/chat-v2/thread/memomized-markdown.tsx
+++ b/mcpjam-inspector/client/src/components/chat-v2/thread/memomized-markdown.tsx
@@ -4,10 +4,12 @@ import {
   memo,
   useContext,
   useMemo,
+  useRef,
   type ReactNode,
 } from "react";
 import { Streamdown, defaultUrlTransform, type UrlTransform } from "streamdown";
 import { ErrorBoundary } from "@/components/ui/error-boundary";
+import { cn } from "@/lib/utils";
 
 // Per-surface markdown rendering knobs for surfaces that inline content
 // authored elsewhere — e.g. the MCPJam Agent home, which streams docs from
@@ -77,9 +79,10 @@ const MAX_MARKDOWN_NESTING = 200;
 // Backstop for inputs that are merely enormous rather than deep.
 const MAX_MARKDOWN_CHARS = 512_000;
 
-// Cheap O(n) upper bound on nesting: `>` markers are one level each, leading
-// whitespace is over-counted at 4 columns per level. Over-counting only costs
-// a plain-text render, so it errs on the safe side.
+// Cheap O(n) proxy over the three nesting axes: `>` markers (one level each),
+// indentation (two columns per level, marked's tightest list nesting), and
+// `*`/`_` runs (two delimiters per emphasis level). Over-counting a deeply
+// indented code block only costs a plain-text render.
 function blockNestingDepth(markdown: string): number {
   let max = 0;
   let i = 0;
@@ -94,10 +97,28 @@ function blockNestingDepth(markdown: string): number {
       else break;
       i += 1;
     }
-    const depth = markers + (columns >> 2);
-    if (depth > max) max = depth;
-    while (i < markdown.length && markdown[i] !== "\n") i += 1;
+    // Longest `*`/`_` run on the line. marked's inline lexer recurses once per
+    // emphasis pair, so `"*".repeat(5000) + "x" + "*".repeat(5000)` overflows
+    // the stack — and the leading-whitespace scan above scores it 0.
+    let run = 0;
+    let longestRun = 0;
+    let previous = "";
+    while (i < markdown.length && markdown[i] !== "\n") {
+      const char = markdown[i];
+      if (char === "*" || char === "_") {
+        run = char === previous ? run + 1 : 1;
+        previous = char;
+        if (run > longestRun) longestRun = run;
+      } else {
+        run = 0;
+        previous = "";
+      }
+      i += 1;
+    }
     i += 1;
+
+    const depth = markers + (columns >> 1) + (longestRun >> 1);
+    if (depth > max) max = depth;
   }
   return max;
 }
@@ -127,7 +148,7 @@ function PlainTextMarkdown({
 }) {
   return (
     <pre
-      className={`whitespace-pre-wrap break-words font-sans ${className ?? ""}`}
+      className={cn("whitespace-pre-wrap break-words font-sans", className)}
       data-testid="markdown-plain-text"
     >
       {content}
@@ -167,9 +188,17 @@ function MarkdownBlocks({
   content: string;
   className?: string;
 }) {
-  const blocks = useMemo(() => parseMarkdownIntoBlocks(content), [content]);
+  // One-way fuse per message, mirroring the boundary above. `useMemo` is keyed
+  // on the whole streaming content, so without it a payload that only the
+  // `try/catch` catches re-enters marked.lexer on every tick.
+  const failed = useRef(false);
+  const blocks = useMemo(
+    () => (failed.current ? null : parseMarkdownIntoBlocks(content)),
+    [content],
+  );
 
   if (blocks === null) {
+    failed.current = true;
     return <PlainTextMarkdown content={content} className={className} />;
   }
 

--- a/mcpjam-inspector/client/src/components/chat-v2/thread/memomized-markdown.tsx
+++ b/mcpjam-inspector/client/src/components/chat-v2/thread/memomized-markdown.tsx
@@ -7,6 +7,7 @@ import {
   type ReactNode,
 } from "react";
 import { Streamdown, defaultUrlTransform, type UrlTransform } from "streamdown";
+import { ErrorBoundary } from "@/components/ui/error-boundary";
 
 // Per-surface markdown rendering knobs for surfaces that inline content
 // authored elsewhere — e.g. the MCPJam Agent home, which streams docs from
@@ -68,12 +69,70 @@ function buildUrlTransform(base: string | null): UrlTransform | undefined {
   };
 }
 
-function parseMarkdownIntoBlocks(markdown: string): string[] {
-  const tokens = marked.lexer(markdown);
-  if (tokens.length === 0) {
-    return [markdown];
+// INSPECTOR-CLIENT-253. Both marked (below) and Streamdown's remark pipeline
+// recurse once per level of block nesting, so `- x\n  ` + 2000 `>` — about 2KB,
+// and reachable verbatim from any MCP tool result — exhausts the JS stack.
+// Well under the ~1500-level cliff measured against marked 16.4.2.
+const MAX_MARKDOWN_NESTING = 200;
+// Backstop for inputs that are merely enormous rather than deep.
+const MAX_MARKDOWN_CHARS = 512_000;
+
+// Cheap O(n) upper bound on nesting: `>` markers are one level each, leading
+// whitespace is over-counted at 4 columns per level. Over-counting only costs
+// a plain-text render, so it errs on the safe side.
+function blockNestingDepth(markdown: string): number {
+  let max = 0;
+  let i = 0;
+  while (i < markdown.length) {
+    let columns = 0;
+    let markers = 0;
+    while (i < markdown.length) {
+      const char = markdown[i];
+      if (char === " ") columns += 1;
+      else if (char === "\t") columns += 4;
+      else if (char === ">") markers += 1;
+      else break;
+      i += 1;
+    }
+    const depth = markers + (columns >> 2);
+    if (depth > max) max = depth;
+    while (i < markdown.length && markdown[i] !== "\n") i += 1;
+    i += 1;
   }
-  return tokens.map((token) => token.raw);
+  return max;
+}
+
+// `null` means "too deep or too big to parse safely — render it as plain text".
+function parseMarkdownIntoBlocks(markdown: string): string[] | null {
+  if (markdown.length > MAX_MARKDOWN_CHARS) return null;
+  if (blockNestingDepth(markdown) > MAX_MARKDOWN_NESTING) return null;
+  try {
+    const tokens = marked.lexer(markdown);
+    if (tokens.length === 0) {
+      return [markdown];
+    }
+    return tokens.map((token) => token.raw);
+  } catch {
+    // Belt and braces for anything the depth scan under-counts.
+    return null;
+  }
+}
+
+function PlainTextMarkdown({
+  content,
+  className,
+}: {
+  content: string;
+  className?: string;
+}) {
+  return (
+    <pre
+      className={`whitespace-pre-wrap break-words font-sans ${className ?? ""}`}
+      data-testid="markdown-plain-text"
+    >
+      {content}
+    </pre>
+  );
 }
 
 const MemoizedMarkdownBlock = memo(
@@ -101,16 +160,38 @@ const MemoizedMarkdownBlock = memo(
 
 MemoizedMarkdownBlock.displayName = "MemoizedMarkdownBlock";
 
-export const MemoizedMarkdown = memo(
-  ({ content, className }: { content: string; className?: string }) => {
-    const blocks = useMemo(() => parseMarkdownIntoBlocks(content), [content]);
+function MarkdownBlocks({
+  content,
+  className,
+}: {
+  content: string;
+  className?: string;
+}) {
+  const blocks = useMemo(() => parseMarkdownIntoBlocks(content), [content]);
 
-    return blocks.map((block, index) => (
-      <div className={className} key={`markdown-block_${index}`}>
-        <MemoizedMarkdownBlock content={block} />
-      </div>
-    ));
-  },
+  if (blocks === null) {
+    return <PlainTextMarkdown content={content} className={className} />;
+  }
+
+  return blocks.map((block, index) => (
+    <div className={className} key={`markdown-block_${index}`}>
+      <MemoizedMarkdownBlock content={block} />
+    </div>
+  ));
+}
+
+export const MemoizedMarkdown = memo(
+  ({ content, className }: { content: string; className?: string }) => (
+    // The fuse: a throw here used to unmount the whole route through the
+    // router's errorElement, taking the conversation with it. Once tripped it
+    // stays on plain text for this message, which still shows every character.
+    <ErrorBoundary
+      name="markdown-render"
+      fallback={<PlainTextMarkdown content={content} className={className} />}
+    >
+      <MarkdownBlocks content={content} className={className} />
+    </ErrorBoundary>
+  ),
   (prevProps, nextProps) => {
     if (prevProps.content !== nextProps.content) return false;
     if (prevProps.className !== nextProps.className) return false;

--- a/mcpjam-inspector/client/src/lib/__tests__/sentry.test.ts
+++ b/mcpjam-inspector/client/src/lib/__tests__/sentry.test.ts
@@ -2,13 +2,17 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 const init = vi.fn();
 const replayIntegration = vi.fn(() => ({ name: "Replay" }));
-const browserTracingIntegration = vi.fn(() => ({ name: "BrowserTracing" }));
+const reactRouterV7BrowserTracingIntegration = vi.fn(() => ({
+  name: "BrowserTracing",
+}));
+const wrapCreateBrowserRouterV7 = vi.fn((createRouter) => createRouter);
 const getClient = vi.fn();
 
 vi.mock("@sentry/react", () => ({
   init,
   replayIntegration,
-  browserTracingIntegration,
+  reactRouterV7BrowserTracingIntegration,
+  wrapCreateBrowserRouterV7,
   getClient,
 }));
 
@@ -28,7 +32,8 @@ describe("client sentry init", () => {
     vi.stubGlobal("__APP_VERSION__", "2.34.0-test");
     init.mockClear();
     replayIntegration.mockClear();
-    browserTracingIntegration.mockClear();
+    reactRouterV7BrowserTracingIntegration.mockClear();
+    wrapCreateBrowserRouterV7.mockClear();
     getClient.mockReset();
   });
 
@@ -82,7 +87,7 @@ describe("client sentry init", () => {
     // The integration must not even LOAD — zero rates alone would still ship
     // the recorder and open its buffers.
     expect(replayIntegration).not.toHaveBeenCalled();
-    expect(browserTracingIntegration).toHaveBeenCalled();
+    expect(reactRouterV7BrowserTracingIntegration).toHaveBeenCalled();
     expect(config.integrations).toHaveLength(1);
   });
 
@@ -117,6 +122,32 @@ describe("client sentry init", () => {
     expect(replayIntegration).not.toHaveBeenCalled();
     expect(config.replaysSessionSampleRate).toBe(0);
     expect(config.integrations).toHaveLength(1);
+  });
+
+  it("instruments react-router so transactions name the route in view", async () => {
+    // INSPECTOR-CLIENT-253 was reported against `/servers` but crashed on
+    // `/playground`: plain browserTracingIntegration names the transaction
+    // once, at pageload, and never again on a client-side navigation.
+    const { initSentry } = await import("../sentry");
+
+    initSentry();
+    const options = reactRouterV7BrowserTracingIntegration.mock.calls[0][0];
+
+    expect(typeof options.useEffect).toBe("function");
+    expect(typeof options.useLocation).toBe("function");
+    expect(typeof options.useNavigationType).toBe("function");
+    expect(typeof options.createRoutesFromChildren).toBe("function");
+    expect(typeof options.matchRoutes).toBe("function");
+  });
+
+  it("builds the app router through Sentry's router wrapper", async () => {
+    // The hooks above only report navigations the SDK can see; a data router
+    // has to be created through the wrapper for its routes to be matched.
+    const { createBrowserRouter } = await import("react-router");
+    const { createSentryBrowserRouter } = await import("../sentry");
+
+    expect(wrapCreateBrowserRouterV7).toHaveBeenCalledWith(createBrowserRouter);
+    expect(typeof createSentryBrowserRouter).toBe("function");
   });
 });
 

--- a/mcpjam-inspector/client/src/lib/__tests__/sentry.test.ts
+++ b/mcpjam-inspector/client/src/lib/__tests__/sentry.test.ts
@@ -5,7 +5,10 @@ const replayIntegration = vi.fn(() => ({ name: "Replay" }));
 const reactRouterV7BrowserTracingIntegration = vi.fn(() => ({
   name: "BrowserTracing",
 }));
-const wrapCreateBrowserRouterV7 = vi.fn((createRouter) => createRouter);
+// Returns a stub rather than the passthrough `(fn) => fn`: the wrapped factory
+// gets invoked below, and the real createBrowserRouter would build a router.
+const wrappedRouterFactory = vi.fn(() => ({ routes: [] }));
+const wrapCreateBrowserRouterV7 = vi.fn(() => wrappedRouterFactory);
 const getClient = vi.fn();
 
 vi.mock("@sentry/react", () => ({
@@ -34,6 +37,7 @@ describe("client sentry init", () => {
     replayIntegration.mockClear();
     reactRouterV7BrowserTracingIntegration.mockClear();
     wrapCreateBrowserRouterV7.mockClear();
+    wrappedRouterFactory.mockClear();
     getClient.mockReset();
   });
 
@@ -140,14 +144,27 @@ describe("client sentry init", () => {
     expect(typeof options.matchRoutes).toBe("function");
   });
 
-  it("builds the app router through Sentry's router wrapper", async () => {
-    // The hooks above only report navigations the SDK can see; a data router
-    // has to be created through the wrapper for its routes to be matched.
+  it("does not wrap the router at module scope", async () => {
+    // Module scope runs before initSentry(), and wrapCreateBrowserRouterV7
+    // returns createBrowserRouter UNWRAPPED when the integration's setup() has
+    // not run yet — reactrouterv6-compat-utils.js:33. It only warns behind
+    // DEBUG_BUILD, so a premature wrap fails silently in production.
+    await import("../sentry");
+
+    expect(wrapCreateBrowserRouterV7).not.toHaveBeenCalled();
+  });
+
+  it("wraps the router only after the tracing integration is registered", async () => {
     const { createBrowserRouter } = await import("react-router");
-    const { createSentryBrowserRouter } = await import("../sentry");
+    const { initSentry, createSentryBrowserRouter } = await import("../sentry");
+
+    initSentry();
+    createSentryBrowserRouter([]);
 
     expect(wrapCreateBrowserRouterV7).toHaveBeenCalledWith(createBrowserRouter);
-    expect(typeof createSentryBrowserRouter).toBe("function");
+    expect(init.mock.invocationCallOrder[0]).toBeLessThan(
+      wrapCreateBrowserRouterV7.mock.invocationCallOrder[0],
+    );
   });
 });
 

--- a/mcpjam-inspector/client/src/lib/sentry.ts
+++ b/mcpjam-inspector/client/src/lib/sentry.ts
@@ -1,4 +1,12 @@
 import * as Sentry from "@sentry/react";
+import { useEffect } from "react";
+import {
+  createBrowserRouter,
+  createRoutesFromChildren,
+  matchRoutes,
+  useLocation,
+  useNavigationType,
+} from "react-router";
 import { buildClientSentryConfig } from "../../../shared/sentry-config";
 import { HOSTED_MODE } from "./config";
 import {
@@ -6,6 +14,16 @@ import {
   isErrorCaptureSurface,
   shouldRecordSession,
 } from "./PosthogUtils";
+
+/**
+ * `createBrowserRouter`, instrumented — build the app router with this.
+ *
+ * Plain `browserTracingIntegration` names a transaction once, at pageload, and
+ * never again on a client-side navigation. That is why INSPECTOR-CLIENT-253
+ * was filed against `/servers` while actually crashing on `/playground`.
+ */
+export const createSentryBrowserRouter =
+  Sentry.wrapCreateBrowserRouterV7(createBrowserRouter);
 
 /**
  * Resolve the config the browser bundle inits with.
@@ -46,7 +64,15 @@ export function initSentry() {
       // `replay.stop()` FLUSHES the buffered segment — which is the
       // token-bearing page itself. Such a session simply has no replay.
       ...(shouldRecordSession() ? [Sentry.replayIntegration()] : []),
-      Sentry.browserTracingIntegration(),
+      // Paired with `createSentryBrowserRouter` above: the hooks report the
+      // navigation, the wrapper supplies the route it resolved to.
+      Sentry.reactRouterV7BrowserTracingIntegration({
+        useEffect,
+        useLocation,
+        useNavigationType,
+        createRoutesFromChildren,
+        matchRoutes,
+      }),
     ],
   });
 }

--- a/mcpjam-inspector/client/src/lib/sentry.ts
+++ b/mcpjam-inspector/client/src/lib/sentry.ts
@@ -15,15 +15,28 @@ import {
   shouldRecordSession,
 } from "./PosthogUtils";
 
+let wrappedCreateBrowserRouter: typeof createBrowserRouter | null = null;
+
 /**
  * `createBrowserRouter`, instrumented — build the app router with this.
  *
- * Plain `browserTracingIntegration` names a transaction once, at pageload, and
- * never again on a client-side navigation. That is why INSPECTOR-CLIENT-253
- * was filed against `/servers` while actually crashing on `/playground`.
+ * Wrapped on FIRST CALL, never at module scope. `wrapCreateBrowserRouterV7`
+ * hands back `createBrowserRouter` unwrapped when the tracing integration's
+ * `setup()` has not run yet, and says so only behind `DEBUG_BUILD` — silence in
+ * production. Module scope always loses that race: `router.tsx` imports this
+ * file, so it evaluates before `main.tsx` reaches `initSentry()`.
+ *
+ * A no-op wrap is worse than none: the v7 integration builds its inner
+ * browser-tracing with `instrumentNavigation: false` and re-implements
+ * navigation spans through this wrapper, so an inert wrapper emits nothing.
  */
-export const createSentryBrowserRouter =
-  Sentry.wrapCreateBrowserRouterV7(createBrowserRouter);
+export function createSentryBrowserRouter(
+  ...args: Parameters<typeof createBrowserRouter>
+) {
+  wrappedCreateBrowserRouter ??=
+    Sentry.wrapCreateBrowserRouterV7(createBrowserRouter);
+  return wrappedCreateBrowserRouter(...args);
+}
 
 /**
  * Resolve the config the browser bundle inits with.

--- a/mcpjam-inspector/client/src/router.tsx
+++ b/mcpjam-inspector/client/src/router.tsx
@@ -50,6 +50,7 @@ import {
   routePaths,
 } from "./lib/app-navigation";
 import { APP_ROUTES } from "./lib/app-routes";
+import { createSentryBrowserRouter } from "./lib/sentry";
 
 export { getAppRouter };
 
@@ -283,7 +284,9 @@ function buildRouteChildren() {
 export function createAppRouter(): AppRouter {
   const existing = getAppRouter();
   if (existing) return existing;
-  const router = createBrowserRouter([
+  // Sentry-wrapped: an unwrapped data router leaves every transaction named
+  // after the pageload URL. See `createSentryBrowserRouter`.
+  const router = createSentryBrowserRouter([
     ...(import.meta.env.DEV
       ? [
           {


### PR DESCRIPTION
## The crash

`marked` and Streamdown's remark pipeline each recurse once per level of markdown nesting, and nothing bounded the input. Two payloads reproduce it against the repo's marked 16.4.2:

```
- x\n  + 2000 `>`                          2 KB    RangeError, 24ms   (block nesting)
5000 `*` + "x" + 5000 `*`                 10 KB    RangeError, 210ms  (inline emphasis)
```

Any MCP tool result reaches this renderer verbatim, so the payload can come from outside. With no error boundary anywhere in `chat-v2`, the throw escaped to the router's `errorElement` and unmounted the whole `/playground` route, taking the conversation with it.

The `RegExp.exec` frame at the bottom of the Sentry stack is a red herring — `hrRegex` holds up under 50k chars in 1 ms. It is just the call that tipped an already-exhausted stack over.

## The guard

`parseMarkdownIntoBlocks` returns `string[] | null`. An O(n) scan bounds three nesting axes — `>` markers, indentation at two columns per level, and `*`/`_` runs at two delimiters per level — behind a 512 KB size cap and a `try/catch`. Anything that trips renders as plain text rather than markdown, because handing the payload to Streamdown would only move the crash downstream.

Cap is 200 against a measured ~1500-level cliff. Across 152 real markdown files in this repo the deepest scores 21, and the longest emphasis run is 3 characters.

Behind that, `MemoizedMarkdown` wraps the render in an `ErrorBoundary`, and a ref latch stops a failed parse re-entering the lexer on every streaming tick. Both fuses are scoped to the document that tripped them: a prefix check separates "same message still streaming" from "new document", and the latter remounts. Without that, `SkillFileViewer` — which renders with no key — left every file after a bad one stuck on plain text.

## The observability half

Two commits, and the first one was wrong: `wrapCreateBrowserRouterV7` at module scope always runs before `initSentry()`, and the SDK returns `createBrowserRouter` **unwrapped** when the tracing integration's `setup()` has not run, warning only behind `DEBUG_BUILD`. Worse than inert — the v7 integration disables `instrumentNavigation` and routes navigation spans through that wrapper, so nothing was emitted at all.

Wrapping lazily on first call fixes it. Verified in a browser against the running app with Sentry ingest intercepted:

```
eager wrap: pageload /servers source=url,   no navigation transaction
lazy wrap:  pageload /servers source=route, navigation /playground source=route
```

`/hosts/:hostId` reports as the pattern, not the raw id, so a deep-linked host stays one transaction group.

## Not in this PR

`marked` is also quadratic in the list tokenizer's continuation-line loop. One list item with N continuation lines: 5k → 354 ms, 10k → 1.4 s, 20k (140 KB) → 5.2 s of blocked main thread. Different bug — no recursion, no exception, just a frozen tab — and a size cap does not separate it from legitimate content (512 KB of realistic markdown lexes in 132 ms).

Also untouched: two copies of `marked` in the bundle (16.4.2 for the app, 17.x via Streamdown), the `useMemo` re-lexing the full message on every streaming tick, and two load-dependent flakes seen in separate full-suite runs (`OAuthDebugCallback` leaks a `setTimeout` past teardown; `ScenarioChatPage` misses a button). Neither flake touches any file here.

## Test plan

- Full client suite green: 909 files, 9870 tests. `typecheck:client` clean.
- Every guard is mutation-checked — removing it turns its test red. That is how the first router test was caught passing against broken production behaviour.
- Browser A/B above is the only evidence that the Sentry half works; unit tests can only pin the wiring and the ordering.

Fixes INSPECTOR-CLIENT-253

🤖 Generated with [Claude Code](https://claude.com/claude-code)
