### PR TITLE
changesets: release Inspector, CLI, and SDK

### DIFF
--- a/.changeset/releases-2026-08-25.md
+++ b/.changeset/releases-2026-08-25.md
@@ -1,0 +1,7 @@
+---
+"@mcpjam/inspector": minor
+"@mcpjam/cli": minor
+"@mcpjam/sdk": minor
+---
+
+Release the latest Inspector, CLI, and SDK updates.


### PR DESCRIPTION
- Adds one changeset that bumps `@mcpjam/inspector`, `@mcpjam/cli`, and `@mcpjam/sdk` a minor version each.
- No code changes — this just tells the release job to cut new versions of those three packages.

🤖 Generated with [Claude Code](https://claude.com/claude-code)