### PR TITLE
fix(connect): clarify used handoff links

### DIFF
--- a/.changeset/clear-used-connection-link.md
+++ b/.changeset/clear-used-connection-link.md
@@ -1,0 +1,5 @@
+---
+"@mcpjam/inspector": patch
+---
+
+Explain when a one-time server connection link has already been used.

--- a/mcpjam-inspector/client/src/components/server-connections/ServerConnectionHandoff.tsx
+++ b/mcpjam-inspector/client/src/components/server-connections/ServerConnectionHandoff.tsx
@@ -114,6 +114,15 @@ class HandoffCallError extends Error {
   }
 }
 
+function isUsedLinkError(error: unknown): boolean {
+  return (
+    error instanceof HandoffCallError &&
+    typeof error.details === "object" &&
+    error.details !== null &&
+    (error.details as { reason?: unknown }).reason === "REQUEST_NOT_FOUND"
+  );
+}
+
 async function call<T>(
   path: string,
   body?: unknown,
@@ -353,11 +362,7 @@ export function ServerConnectionHandoff() {
             : null;
         if (claimRefusal) setRefusal(claimRefusal);
         else {
-          setUsedLink(
-            route?.kind === "claim" &&
-              cause instanceof HandoffCallError &&
-              cause.status === 404,
-          );
+          setUsedLink(route?.kind === "claim" && isUsedLinkError(cause));
           setError(cause instanceof Error ? cause.message : String(cause));
         }
         return;

--- a/mcpjam-inspector/client/src/components/server-connections/ServerConnectionHandoff.tsx
+++ b/mcpjam-inspector/client/src/components/server-connections/ServerConnectionHandoff.tsx
@@ -104,7 +104,11 @@ async function bestEffortAccessToken(
  * lives in `details`, not in the prose.
  */
 class HandoffCallError extends Error {
-  constructor(message: string, readonly details?: unknown) {
+  constructor(
+    message: string,
+    readonly status: number,
+    readonly details?: unknown,
+  ) {
     super(message);
     this.name = "HandoffCallError";
   }
@@ -136,6 +140,7 @@ async function call<T>(
   if (!response.ok) {
     throw new HandoffCallError(
       payload?.message ?? "Something went wrong. Please try again.",
+      response.status,
       payload?.details,
     );
   }
@@ -266,6 +271,7 @@ export function ServerConnectionHandoff() {
   } = useAuth();
   const [state, setState] = useState<HandoffState | null>(null);
   const [error, setError] = useState<string | null>(null);
+  const [usedLink, setUsedLink] = useState(false);
   const [refusal, setRefusal] = useState<ClaimRefusalDetails | null>(null);
   const [busy, setBusy] = useState(false);
   const claimed = useRef(false);
@@ -346,7 +352,14 @@ export function ServerConnectionHandoff() {
             ? readClaimRefusal(cause.details)
             : null;
         if (claimRefusal) setRefusal(claimRefusal);
-        else setError(cause instanceof Error ? cause.message : String(cause));
+        else {
+          setUsedLink(
+            route?.kind === "claim" &&
+              cause instanceof HandoffCallError &&
+              cause.status === 404,
+          );
+          setError(cause instanceof Error ? cause.message : String(cause));
+        }
         return;
       }
       await refresh();
@@ -485,8 +498,16 @@ export function ServerConnectionHandoff() {
   if (error && !state) {
     return (
       <Shell>
-        <h1 className="text-lg font-semibold">This link cannot be used</h1>
-        <p className="text-sm text-muted-foreground">{error}</p>
+        <h1 className="text-lg font-semibold">
+          {usedLink
+            ? "This link has already been used"
+            : "This link cannot be used"}
+        </h1>
+        <p className="text-sm text-muted-foreground">
+          {usedLink
+            ? "Connection links work only once. Create a new link from the CLI to connect again."
+            : error}
+        </p>
       </Shell>
     );
   }

--- a/mcpjam-inspector/client/src/components/server-connections/__tests__/ServerConnectionHandoff.test.tsx
+++ b/mcpjam-inspector/client/src/components/server-connections/__tests__/ServerConnectionHandoff.test.tsx
@@ -148,7 +148,7 @@ describe("the claim", () => {
     expect(calls.some((call) => call.path === "/claim")).toBe(false);
   });
 
-  it("says the link is unusable rather than showing an empty page", async () => {
+  it("explains that a spent one-time link must be recreated", async () => {
     vi.stubGlobal(
       "fetch",
       vi.fn(
@@ -163,7 +163,12 @@ describe("the claim", () => {
     render(<ServerConnectionHandoff />);
 
     expect(
-      await screen.findByText("That link has expired."),
+      await screen.findByText("This link has already been used"),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText(
+        "Connection links work only once. Create a new link from the CLI to connect again.",
+      ),
     ).toBeInTheDocument();
   });
 });

--- a/mcpjam-inspector/client/src/components/server-connections/__tests__/ServerConnectionHandoff.test.tsx
+++ b/mcpjam-inspector/client/src/components/server-connections/__tests__/ServerConnectionHandoff.test.tsx
@@ -153,9 +153,13 @@ describe("the claim", () => {
       "fetch",
       vi.fn(
         async () =>
-          new Response(JSON.stringify({ message: "That link has expired." }), {
-            status: 404,
-          }),
+          new Response(
+            JSON.stringify({
+              message: "Connection request not found",
+              details: { reason: "REQUEST_NOT_FOUND" },
+            }),
+            { status: 404 },
+          ),
       ),
     );
     goTo("/connect/server/dead-token");
@@ -169,6 +173,32 @@ describe("the claim", () => {
       screen.getByText(
         "Connection links work only once. Create a new link from the CLI to connect again.",
       ),
+    ).toBeInTheDocument();
+  });
+
+  it("keeps the accurate message for an expired link", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(
+        async () =>
+          new Response(
+            JSON.stringify({
+              message: "That authorization link has expired.",
+              details: { reason: "REQUEST_EXPIRED" },
+            }),
+            { status: 404 },
+          ),
+      ),
+    );
+    goTo("/connect/server/expired-token");
+
+    render(<ServerConnectionHandoff />);
+
+    expect(
+      await screen.findByText("This link cannot be used"),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText("That authorization link has expired."),
     ).toBeInTheDocument();
   });
 });

--- a/mcpjam-inspector/server/routes/web/__tests__/server-connections.test.ts
+++ b/mcpjam-inspector/server/routes/web/__tests__/server-connections.test.ts
@@ -278,6 +278,24 @@ describe("claim", () => {
     expect(res.headers.get("set-cookie")).toBeNull();
   });
 
+  it.each([
+    ["REQUEST_NOT_FOUND", 404, "Connection request not found"],
+    ["REQUEST_EXPIRED", 410, "That authorization link has expired."],
+  ])(
+    "passes the backend's gone reason through to the page",
+    async (code, status, message) => {
+      backendCalls.claimHandoff.mockRejectedValue(
+        new ServerConnectionBackendError(message, status, code)
+      );
+
+      const res = await post("/claim", { handoffToken: "handoff-1" });
+      const body = (await res.json()) as { details?: { reason?: string } };
+
+      expect(res.status).toBe(404);
+      expect(body.details?.reason).toBe(code);
+    }
+  );
+
   it("passes the refusal reason and masked owner through to the page", async () => {
     // The page renders a different call to action per reason, so the reason has
     // to survive the hop. It travels in `details` rather than as the envelope

--- a/mcpjam-inspector/server/routes/web/server-connections.ts
+++ b/mcpjam-inspector/server/routes/web/server-connections.ts
@@ -140,7 +140,12 @@ function translate(error: unknown): WebRouteError {
   if (error instanceof WebRouteError) return error;
   if (error instanceof ServerConnectionBackendError) {
     if (error.isGone) {
-      return new WebRouteError(404, ErrorCode.NOT_FOUND, error.message);
+      return new WebRouteError(
+        404,
+        ErrorCode.NOT_FOUND,
+        error.message,
+        error.code ? { reason: error.code } : undefined
+      );
     }
     // NO 401 ARM, DELIBERATELY. A continuation token the backend does not
     // recognize — expired, or consumed by a cancel — comes back 404


### PR DESCRIPTION
## Summary
- explain that spent connection links only work once
- tell users to create a new link from the CLI
- preserve the existing message for unrelated errors

## Tests
- npm test -- --run client/src/components/server-connections/__tests__/ServerConnectionHandoff.test.tsx
- npm run typecheck:client

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Clarifies the error message for spent one-time server connection links so users know the link only works once and how to connect again.

- Distinguishes a used-link 404 response from an expired-link 410; used links get a dedicated message while expired links keep the accurate server message.
- Shows "This link has already been used" with instructions to create a new link from the CLI.
- Adds a changeset for `@mcpjam/inspector`.

<sup>Written for commit 1d72e0a3713e60bbe89e475c90824cb26a1aef94. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/MCPJam/inspector/pull/4393?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

