### PR TITLE
Skills over MCP: re-sync the host to the current SEP-2640 draft

### DIFF
--- a/.changeset/skills-sep2640-resync.md
+++ b/.changeset/skills-sep2640-resync.md
@@ -1,0 +1,18 @@
+---
+"@mcpjam/sdk": patch
+"@mcpjam/inspector": patch
+---
+
+Skills over MCP: re-sync the host to the current SEP-2640 draft
+
+Our SEP-2640 implementation was pinned to `modelcontextprotocol/docs @ d7490ec`. The draft has moved since, and three of its changes made our host wrong rather than merely out of date. Re-pinned to `modelcontextprotocol/modelcontextprotocol @ a3e147ca27` (`sep/skills-extension`).
+
+**`"resources": "dynamic"` crashed the parser.** The draft makes `resources` required and gives it two forms: an enumerated manifest, or the bare string `"dynamic"` for a skill generated per request. `skillEntrySchema` accepted only the array, so a conforming server answering `"dynamic"` produced an `InvalidSkillsPayloadError` — a wire error, for a form the spec defines, with no way for the user to tell a server bug from ours. It now parses, and MCPJam refuses to *load* it as a stated policy (`dynamic_resources`), kept distinct from a server that omitted `resources` entirely (`no_resources`). Those are different server behaviours and collapsing them tells a conforming author their skill is malformed.
+
+**`size` was never checked.** Each manifest entry now carries the file's byte length, and the draft makes a length mismatch "a verification failure equivalent to a digest mismatch, whether or not the host goes on to compute the digest". `verifySize` runs *before* hashing — which is the point of the field: it catches a truncated or padded read without paying for a digest, and it lets a host budget a skill from the entry alone. It gets its own `size_mismatch` kind, because "this file was cut short" and "this file was tampered with" are different diagnoses. A server that omits `size` is tolerated, not refused: the SEP is unratified and every implementation that exists today predates the field, so refusing would buy conformance with an unpublished rule at the cost of working with real servers.
+
+**Our own caps refused conforming skills.** The draft sets per-skill limits of 512 entries and 16 MiB total, and says hosts MUST support up to them. Our caps — 128 KiB for a SKILL.md, 2 MiB for a supporting file — were invented before the draft had any, and both sat *below* that floor, so a conforming 3 MiB SKILL.md was refused as `too_large`. That was our bug, not the server's. The limits are now the draft's, enforced from the manifest before the first byte is fetched, with `too_many_resources` and `too_large` naming which one was breached.
+
+Also fixes an error-reporting regression the union would have introduced: a `z.union` reports `resources: Invalid input` and buries the real per-field diagnosis in nested alternatives, which defeats the reason these guards exist. `issuesOf` now descends into union alternatives and rebuilds the full path, so a missing digest still reads as `resources.0: digest: …`.
+
+Test coverage: `size`, the limits, and dynamic manifests get unit, fixture, and over-the-wire cases, including that a dynamic manifest authorizes *no* reads rather than all of them. The fixture gains `sizeMismatch`, `dynamicResources`, and `omitSizes` modes. `server-skills.ts` gets its first direct test — it was previously covered only through the chat wrapper.

--- a/mcpjam-inspector/client/src/lib/apis/server-skills-api.ts
+++ b/mcpjam-inspector/client/src/lib/apis/server-skills-api.ts
@@ -34,9 +34,19 @@ export interface ServerSkillSummary {
   name: string;
   description: string;
   frontmatter: unknown;
-  resources: Array<{ uri: string; digest: string }>;
-  /** Present ⇒ discoverable but refused for loading. */
-  unloadable?: { reason: "no_resources"; message: string };
+  resources: Array<{ uri: string; digest: string; size?: number }>;
+  /**
+   * Present ⇒ discoverable but refused for loading.
+   *
+   * `dynamic_resources` is a server declaring `"resources": "dynamic"` — a
+   * form the draft defines; `no_resources` is a server omitting the field the
+   * draft requires. The UI renders `message` and never branches on `reason`,
+   * so the distinction exists for the reader of a refusal, not for layout.
+   */
+  unloadable?: {
+    reason: "no_resources" | "dynamic_resources";
+    message: string;
+  };
 }
 
 export interface ServerSkillListing {
@@ -69,7 +79,7 @@ export interface VerifiedServerSkill {
   content: string;
   contentSha256: string;
   frontmatter: unknown;
-  resources: Array<{ uri: string; digest: string }>;
+  resources: Array<{ uri: string; digest: string; size?: number }>;
 }
 
 const EMPTY_SUPPORT: ServerSkillsSupport = {

--- a/mcpjam-inspector/client/src/lib/apis/server-skills-api.ts
+++ b/mcpjam-inspector/client/src/lib/apis/server-skills-api.ts
@@ -44,7 +44,11 @@ export interface ServerSkillSummary {
    * so the distinction exists for the reader of a refusal, not for layout.
    */
   unloadable?: {
-    reason: "no_resources" | "dynamic_resources";
+    reason:
+      | "no_resources"
+      | "dynamic_resources"
+      | "too_many_resources"
+      | "too_large";
     message: string;
   };
 }

--- a/mcpjam-inspector/server/utils/__tests__/server-skill-tools.test.ts
+++ b/mcpjam-inspector/server/utils/__tests__/server-skill-tools.test.ts
@@ -53,6 +53,8 @@ async function makeManager(
     tamper?: boolean;
     /** Omit `resources` from the entry entirely. */
     noResources?: boolean;
+    /** Serve a SKILL.md body far larger than a model turn should carry. */
+    hugeBody?: boolean;
     /** Also answer reads for this unlisted URI. */
     serveUnlisted?: string;
     /** Answer `skills/get` for this URI with an entry carrying a DIFFERENT uri. */
@@ -69,8 +71,11 @@ async function makeManager(
     >;
   } = {}
 ) {
+  const bodyMarkdown = options.hugeBody
+    ? `${MARKDOWN}${"x".repeat(200 * 1024)}`
+    : MARKDOWN;
   const markdownDigest = `sha256:${await sha256(
-    options.tamper ? `${MARKDOWN}tampered` : MARKDOWN
+    options.tamper ? `${bodyMarkdown}tampered` : bodyMarkdown
   )}`;
   const fileDigest = `sha256:${await sha256(FILE_TEXT)}`;
   const entry = {
@@ -170,7 +175,7 @@ async function makeManager(
     readResource: vi.fn(async (_serverId: string, params: { uri: string }) => {
       calls.push(`resources/read:${params.uri}`);
       if (params.uri === SKILL_URI) {
-        return { contents: [{ uri: params.uri, text: MARKDOWN }] };
+        return { contents: [{ uri: params.uri, text: bodyMarkdown }] };
       }
       if (params.uri === FILE_URI) {
         return { contents: [{ uri: params.uri, text: FILE_TEXT }] };
@@ -713,6 +718,34 @@ describe("withServerSkills — file reads", () => {
       )
     );
     expect(read).toContain("print('refund')");
+  });
+
+  it("refuses to inject a verified skill that is too large for a turn", async () => {
+    // The verification cap had to rise to the SEP's 16 MiB per-skill budget so
+    // a conforming skill can be verified at all. That is a DIFFERENT limit from
+    // how many bytes belong in a prompt: without a separate cap, a 16 MiB
+    // SKILL.md would be digest-verified and then pasted wholesale into a chat
+    // turn. Refused, not truncated — a clipped skill is instructions that end
+    // mid-sentence, and the model cannot tell that from a skill that said less.
+    const manager = await makeManager({ hugeBody: true });
+    const wrapped = withServerSkills(baseTools(), {
+      manager,
+      servers: SERVERS,
+    });
+    await approveServerSkill(wrapped, "loadSkill", {
+      name: "acme-billing/refunds",
+    });
+    const out = String(
+      await (wrapped.loadSkill as { execute: Function }).execute(
+        { name: "acme-billing/refunds" },
+        {}
+      )
+    );
+    expect(out).toContain("too_large_for_prompt");
+    // The refusal states both numbers in bytes, and does NOT carry the body.
+    expect(out).toContain("204828");
+    expect(out).toContain("131072");
+    expect(out).not.toContain("xxxxxxxxxx");
   });
 
   it("refuses an UNLISTED file even when the server would serve it", async () => {

--- a/mcpjam-inspector/server/utils/__tests__/server-skill-tools.test.ts
+++ b/mcpjam-inspector/server/utils/__tests__/server-skill-tools.test.ts
@@ -1,7 +1,7 @@
 /**
  * Skills over MCP (SEP-2640) — the live chat wrapper.
  *
- * PIN: modelcontextprotocol/docs @ d7490ec.
+ * PIN: modelcontextprotocol/modelcontextprotocol @ a3e147ca27 (branch `sep/skills-extension`, `seps/2640-skills-extension.md`).
  *
  * The wrapper's contract has three load-bearing properties, and each gets a
  * test that would fail loudly if it regressed:

--- a/mcpjam-inspector/server/utils/__tests__/server-skills.test.ts
+++ b/mcpjam-inspector/server/utils/__tests__/server-skills.test.ts
@@ -235,6 +235,45 @@ describe("per-skill limits", () => {
     expect(refusal.message).toContain("512");
   });
 
+  it("keeps an over-limit skill VISIBLE in the catalog, not rejected", async () => {
+    // The skill is real and its manifest parses; it is simply bigger than a
+    // host is required to support. Dropping it into `rejected` would hide a
+    // real skill behind what reads as a server bug — the same reasoning that
+    // keeps a `dynamic` skill visible.
+    const oversized: Manifest = [
+      {
+        uri: SKILL_URI,
+        digest: `sha256:${await sha256(MARKDOWN)}`,
+        size: MAX_SERVER_SKILL_READ_BYTES + 1,
+      },
+    ];
+    const { manager } = await makeManager({ resources: oversized });
+    const listing = await listServerSkillCatalog(manager, SERVER_ID);
+    expect(listing.rejected).toEqual([]);
+    expect(listing.skills).toHaveLength(1);
+    expect(listing.skills[0]?.unloadable?.reason).toBe("too_large");
+    // The advertised manifest is preserved so the UI can show what was claimed.
+    expect(listing.skills[0]?.resources).toHaveLength(1);
+  });
+
+  it("still REJECTS a manifest it cannot make sense of", async () => {
+    // A limit breach is shown; a malformed manifest is not. Escaping the
+    // skill's own directory is a containment violation, not a size problem.
+    const { manager } = await makeManager({
+      resources: [
+        {
+          uri: "skill://acme/other-skill/secrets.env",
+          digest: `sha256:${await sha256(MARKDOWN)}`,
+          size: 10,
+        },
+      ],
+    });
+    const listing = await listServerSkillCatalog(manager, SERVER_ID);
+    expect(listing.skills).toEqual([]);
+    expect(listing.rejected).toHaveLength(1);
+    expect(listing.rejected[0]?.reason).toContain("outside the skill directory");
+  });
+
   it("refuses a manifest whose declared bytes exceed the budget", async () => {
     const { manager } = await makeManager({
       resources: [

--- a/mcpjam-inspector/server/utils/__tests__/server-skills.test.ts
+++ b/mcpjam-inspector/server/utils/__tests__/server-skills.test.ts
@@ -1,0 +1,306 @@
+/**
+ * Skills over MCP (SEP-2640) — the verified read path's POLICY layer.
+ *
+ * PIN: modelcontextprotocol/modelcontextprotocol @ a3e147ca27 (branch `sep/skills-extension`, `seps/2640-skills-extension.md`).
+ *
+ * `server-skills.ts` had no direct test: it was covered only transitively,
+ * through the chat wrapper. These cover the decisions that are MCPJam's rather
+ * than the SDK's — which server behaviours become which refusal, and where the
+ * draft's per-skill limits are enforced.
+ *
+ * The distinctions under test are all ones a collapsed implementation would
+ * pass anyway while telling the user the wrong thing.
+ */
+
+import { describe, expect, it, vi } from "vitest";
+import {
+  MAX_SERVER_SKILL_READ_BYTES,
+  getVerifiedServerSkill,
+  isServerSkillRefusalError,
+  listServerSkillCatalog,
+  readVerifiedServerSkillFile,
+  type ServerSkillRefusal,
+} from "../server-skills.js";
+import type { MCPClientManager } from "@mcpjam/sdk";
+
+const SERVER_ID = "srv";
+const SKILL_URI = "skill://acme/refunds/SKILL.md";
+const FILE_URI = "skill://acme/refunds/scripts/run.py";
+const BODY = "# Refunds\n\nRefund politely.\n";
+const MARKDOWN = `---\nname: refunds\ndescription: Handle refunds.\n---\n${BODY}`;
+const FILE_TEXT = "print('refund')\n";
+
+async function sha256(text: string): Promise<string> {
+  const digest = await crypto.subtle.digest(
+    "SHA-256",
+    new TextEncoder().encode(text)
+  );
+  return [...new Uint8Array(digest)]
+    .map((b) => b.toString(16).padStart(2, "0"))
+    .join("");
+}
+
+const bytesOf = (text: string) => Buffer.byteLength(text, "utf8");
+
+type Manifest = Array<{ uri: string; digest: string; size?: number }>;
+
+/**
+ * A manager double speaking only the three methods this module uses. The wire
+ * answers are the input under test, so they are controlled directly rather
+ * than mocked off a real client.
+ */
+async function makeManager(
+  options: {
+    resources?: Manifest | "dynamic" | undefined;
+    /** Serve a SKILL.md longer than the manifest advertises. */
+    padMarkdown?: boolean;
+    /** Serve a supporting file longer than the manifest advertises. */
+    padFile?: boolean;
+  } = {}
+) {
+  const markdown = options.padMarkdown ? `${MARKDOWN}  ` : MARKDOWN;
+  const fileText = options.padFile ? `${FILE_TEXT}  ` : FILE_TEXT;
+
+  const defaultManifest: Manifest = [
+    {
+      uri: SKILL_URI,
+      digest: `sha256:${await sha256(markdown)}`,
+      size: bytesOf(MARKDOWN),
+    },
+    {
+      uri: FILE_URI,
+      digest: `sha256:${await sha256(fileText)}`,
+      size: bytesOf(FILE_TEXT),
+    },
+  ];
+  const resources =
+    options.resources === undefined && !("resources" in options)
+      ? defaultManifest
+      : options.resources;
+
+  const entry = {
+    uri: SKILL_URI,
+    frontmatter: { name: "refunds", description: "Handle refunds." },
+    ...(resources === undefined ? {} : { resources }),
+  };
+
+  const manager = {
+    getSkillsSupport: () => ({
+      declared: true,
+      advertised: true,
+      directoryRead: false,
+      active: true,
+    }),
+    listServerSkills: vi.fn(async () => ({ skills: [entry] })),
+    getServerSkill: vi.fn(async (_serverId: string, uri: string) => {
+      if (uri === SKILL_URI) return entry;
+      const error = new Error("Invalid params") as Error & { code: number };
+      error.code = -32602;
+      throw error;
+    }),
+    readResource: vi.fn(async (_serverId: string, args: { uri: string }) => {
+      const text =
+        args.uri === SKILL_URI
+          ? markdown
+          : args.uri === FILE_URI
+            ? fileText
+            : undefined;
+      if (text === undefined) throw new Error(`no such resource ${args.uri}`);
+      return { contents: [{ uri: args.uri, text, mimeType: "text/markdown" }] };
+    }),
+  };
+  return { manager: manager as unknown as MCPClientManager, entry };
+}
+
+async function refusalFrom(run: () => Promise<unknown>) {
+  try {
+    await run();
+  } catch (error) {
+    if (isServerSkillRefusalError(error)) return error.refusal;
+    throw error;
+  }
+  throw new Error("expected a refusal");
+}
+
+describe("dynamic manifests", () => {
+  it("lists a dynamic skill as unloadable rather than dropping it", async () => {
+    // A dynamic skill is REAL and a user should see it in the catalog. The
+    // refusal belongs to loading, not to discovery.
+    const { manager } = await makeManager({ resources: "dynamic" });
+    const listing = await listServerSkillCatalog(manager, SERVER_ID);
+    expect(listing.rejected).toEqual([]);
+    expect(listing.skills).toHaveLength(1);
+    expect(listing.skills[0]?.unloadable?.reason).toBe("dynamic_resources");
+  });
+
+  it("refuses to LOAD a dynamic skill, naming it as dynamic", async () => {
+    const { manager } = await makeManager({ resources: "dynamic" });
+    const refusal = await refusalFrom(() =>
+      getVerifiedServerSkill(manager, { serverId: SERVER_ID, uri: SKILL_URI })
+    );
+    expect(refusal.kind).toBe("dynamic_resources");
+    expect(refusal.skillUri).toBe(SKILL_URI);
+  });
+
+  it("keeps 'dynamic' and 'omitted' as different refusals", async () => {
+    // One is a server using a form the draft defines; the other is a server
+    // omitting a field the draft requires. Collapsing them would tell a
+    // conforming server author their skill is malformed.
+    const { manager } = await makeManager({ resources: undefined });
+    const refusal = await refusalFrom(() =>
+      getVerifiedServerSkill(manager, { serverId: SERVER_ID, uri: SKILL_URI })
+    );
+    expect(refusal.kind).toBe("no_resources");
+  });
+
+  it("authorizes no file reads for a dynamic skill", async () => {
+    const { manager } = await makeManager({ resources: "dynamic" });
+    const refusal = await refusalFrom(() =>
+      readVerifiedServerSkillFile(manager, {
+        serverId: SERVER_ID,
+        entry: { uri: SKILL_URI, resources: "dynamic" },
+        resourceUri: FILE_URI,
+      })
+    );
+    expect(refusal.kind).toBe("unlisted_resource");
+  });
+});
+
+describe("size verification", () => {
+  it("refuses a SKILL.md whose byte length differs from its manifest", async () => {
+    const { manager } = await makeManager({ padMarkdown: true });
+    const refusal = await refusalFrom(() =>
+      getVerifiedServerSkill(manager, { serverId: SERVER_ID, uri: SKILL_URI })
+    );
+    expect(refusal.kind).toBe("size_mismatch");
+    expect(refusal.expected).toBe(String(bytesOf(MARKDOWN)));
+    expect(refusal.actual).toBe(String(bytesOf(MARKDOWN) + 2));
+  });
+
+  it("refuses a supporting file whose byte length differs", async () => {
+    const { manager, entry } = await makeManager({ padFile: true });
+    const refusal = await refusalFrom(() =>
+      readVerifiedServerSkillFile(manager, {
+        serverId: SERVER_ID,
+        entry,
+        resourceUri: FILE_URI,
+      })
+    );
+    expect(refusal.kind).toBe("size_mismatch");
+    expect(refusal.resourceUri).toBe(FILE_URI);
+  });
+
+  it("loads normally when the server omitted size", async () => {
+    const { manager, entry } = await makeManager({
+      resources: [
+        { uri: SKILL_URI, digest: `sha256:${await sha256(MARKDOWN)}` },
+        { uri: FILE_URI, digest: `sha256:${await sha256(FILE_TEXT)}` },
+      ],
+    });
+    const loaded = await getVerifiedServerSkill(manager, {
+      serverId: SERVER_ID,
+      uri: SKILL_URI,
+    });
+    expect(loaded.name).toBe("refunds");
+    const file = await readVerifiedServerSkillFile(manager, {
+      serverId: SERVER_ID,
+      entry,
+      resourceUri: FILE_URI,
+    });
+    expect(file.text).toBe(FILE_TEXT);
+  });
+});
+
+describe("per-skill limits", () => {
+  it("refuses a manifest over the entry limit, saying which limit", async () => {
+    // 513 entries — one past what the draft requires hosts to support. The
+    // refusal must not read as a containment or malformed-manifest bug.
+    const oversized: Manifest = [
+      {
+        uri: SKILL_URI,
+        digest: `sha256:${await sha256(MARKDOWN)}`,
+        size: bytesOf(MARKDOWN),
+      },
+      ...Array.from({ length: 512 }, (_, i) => ({
+        uri: `skill://acme/refunds/f${i}.md`,
+        digest: `sha256:${"0".repeat(64)}`,
+        size: 1,
+      })),
+    ];
+    const { manager } = await makeManager({ resources: oversized });
+    const refusal = await refusalFrom(() =>
+      getVerifiedServerSkill(manager, { serverId: SERVER_ID, uri: SKILL_URI })
+    );
+    expect(refusal.kind).toBe("too_many_resources");
+    expect(refusal.message).toContain("512");
+  });
+
+  it("refuses a manifest whose declared bytes exceed the budget", async () => {
+    const { manager } = await makeManager({
+      resources: [
+        {
+          uri: SKILL_URI,
+          digest: `sha256:${await sha256(MARKDOWN)}`,
+          size: MAX_SERVER_SKILL_READ_BYTES + 1,
+        },
+      ],
+    });
+    const refusal = await refusalFrom(() =>
+      getVerifiedServerSkill(manager, { serverId: SERVER_ID, uri: SKILL_URI })
+    );
+    expect(refusal.kind).toBe("too_large");
+  });
+
+  it("no longer refuses a SKILL.md over the OLD 128 KiB cap", async () => {
+    // The regression this pins: the old per-file caps (128 KiB for SKILL.md,
+    // 2 MiB for a supporting file) sat BELOW what the draft says a host MUST
+    // support, so a conforming skill was refused as our bug, not the
+    // server's.
+    const padding = "x".repeat(200 * 1024);
+    const bigMarkdown = `---\nname: refunds\ndescription: Handle refunds.\n---\n${padding}`;
+    const manager = {
+      getSkillsSupport: () => ({
+        declared: true,
+        advertised: true,
+        directoryRead: false,
+        active: true,
+      }),
+      getServerSkill: vi.fn(async () => ({
+        uri: SKILL_URI,
+        frontmatter: { name: "refunds", description: "Handle refunds." },
+        resources: [
+          {
+            uri: SKILL_URI,
+            digest: `sha256:${await sha256(bigMarkdown)}`,
+            size: bytesOf(bigMarkdown),
+          },
+        ],
+      })),
+      readResource: vi.fn(async () => ({
+        contents: [
+          { uri: SKILL_URI, text: bigMarkdown, mimeType: "text/markdown" },
+        ],
+      })),
+    } as unknown as MCPClientManager;
+
+    const loaded = await getVerifiedServerSkill(manager, {
+      serverId: SERVER_ID,
+      uri: SKILL_URI,
+    });
+    expect(loaded.content).toContain(padding);
+  });
+});
+
+describe("refusal shape", () => {
+  it("carries the specific violation, never a bare failure", async () => {
+    const { manager } = await makeManager({ padMarkdown: true });
+    const refusal: ServerSkillRefusal = await refusalFrom(() =>
+      getVerifiedServerSkill(manager, { serverId: SERVER_ID, uri: SKILL_URI })
+    );
+    // A debugger's user needs WHICH file and WHICH numbers; `kind` alone is
+    // not a diagnosis.
+    expect(refusal.skillUri).toBe(SKILL_URI);
+    expect(refusal.expected).toBeDefined();
+    expect(refusal.actual).toBeDefined();
+  });
+});

--- a/mcpjam-inspector/server/utils/server-skill-tools.ts
+++ b/mcpjam-inspector/server/utils/server-skill-tools.ts
@@ -58,7 +58,11 @@
 import { tool } from "ai";
 import { z } from "zod";
 import type { MCPClientManager, SkillEntry } from "@mcpjam/sdk";
-import { sha256HexOfText, canonicalSkillJson } from "@mcpjam/sdk";
+import {
+  sha256HexOfText,
+  canonicalSkillJson,
+  enumeratedResources,
+} from "@mcpjam/sdk";
 import { logger } from "./logger.js";
 import { buildServerSkillBanner } from "../../shared/server-skill-banner.js";
 import {
@@ -138,6 +142,46 @@ export async function manifestApprovalHash(
  * two copies of the text would drift the moment one is edited.
  */
 export const serverSkillBanner = buildServerSkillBanner;
+
+/**
+ * The cap on skill content this wrapper will put into a MODEL TURN.
+ *
+ * Distinct from the verification cap in `server-skills.ts`, and deliberately
+ * so. That one had to rise to the SEP's 16 MiB per-skill budget, because a host
+ * MUST be able to verify a conforming skill of that size. This one governs
+ * something else entirely: how many bytes are pasted into a prompt.
+ *
+ * Without it, raising the verification cap silently raised the prompt cap with
+ * it — a server serving a 16 MiB SKILL.md would have had it digest-verified and
+ * then injected wholesale into a chat turn (roughly four million tokens). 128
+ * KiB is the limit that applied before the re-sync, so this restores the
+ * previous prompt-facing behaviour rather than inventing a new one.
+ *
+ * REFUSED, never truncated. A silently clipped skill is a skill whose
+ * instructions end mid-sentence, and the model cannot tell that from a skill
+ * that simply said less.
+ */
+export const MAX_SERVER_SKILL_PROMPT_BYTES = 128 * 1024;
+
+/**
+ * Returns the text, or a refusal naming both numbers when it is too large for
+ * a turn.
+ */
+function withinPromptBudget(
+  text: string,
+  what: string
+): { ok: true; text: string } | { ok: false; error: string } {
+  const bytes = Buffer.byteLength(text, "utf8");
+  if (bytes <= MAX_SERVER_SKILL_PROMPT_BYTES) return { ok: true, text };
+  return {
+    ok: false,
+    error:
+      `Error (too_large_for_prompt): ${what} is ${bytes} bytes, over the ` +
+      `${MAX_SERVER_SKILL_PROMPT_BYTES}-byte limit for content placed in a ` +
+      `model turn. It verified correctly; MCPJam declines to inject it rather ` +
+      `than truncate it into instructions that end mid-sentence.`,
+  };
+}
 
 /** Renders a refusal as a tool result the model (and the user) can act on. */
 function refusalText(error: unknown): string {
@@ -315,7 +359,7 @@ export function withServerSkills<T extends Record<string, unknown>>(
         resources: target.entry.resources,
       };
       return {
-        hash: await manifestApprovalHash(entry.resources ?? []),
+        hash: await manifestApprovalHash(enumeratedResources(entry) ?? []),
         entry,
       };
     }
@@ -328,7 +372,13 @@ export function withServerSkills<T extends Record<string, unknown>>(
         target.uri
       );
       return {
-        hash: await manifestApprovalHash(entry.resources ?? []),
+        // `enumeratedResources`, NOT `entry.resources ?? []`. This is the one
+        // call site holding a RAW `SkillEntry`, whose `resources` may be the
+        // string `"dynamic"` — which `??` does not filter, so it would spread
+        // into seven characters and hash a constant, meaningless digest set for
+        // every dynamic skill. The load is refused downstream either way, but
+        // an approval must never bind to a hash that means nothing.
+        hash: await manifestApprovalHash(enumeratedResources(entry) ?? []),
         entry,
       };
     } catch {
@@ -390,8 +440,9 @@ export function withServerSkills<T extends Record<string, unknown>>(
     input: LoadSkillInput,
     target: Target
   ): Promise<{ binding?: ManifestBinding; error?: string }> {
-    // An unloadable skill is refused by `execute` a few lines later with the
-    // specific `no_resources` reason, which is more useful than this one.
+    // An unloadable skill is refused by `execute` a few lines later with its
+    // specific reason (`no_resources` or `dynamic_resources`), which is more
+    // useful than this one.
     if (target.kind === "server-ref" && target.entry.unloadable) {
       return {};
     }
@@ -539,7 +590,7 @@ export function withServerSkills<T extends Record<string, unknown>>(
     // rejects the unlisted URI before a resource read, but returning that
     // integrity error is more useful than pretending no approval was bound.
     approvedFileManifests.set(fileApprovalKey(input), {
-      hash: await manifestApprovalHash(entry.resources ?? []),
+      hash: await manifestApprovalHash(enumeratedResources(entry) ?? []),
       entry,
     });
     return true;
@@ -661,16 +712,26 @@ export function withServerSkills<T extends Record<string, unknown>>(
 
         if (target.kind === "server-ref") {
           if (target.entry.unloadable) {
-            return `Error (no_resources): ${target.entry.unloadable.message}`;
+            // The REASON, not a hardcoded `no_resources`. A server declaring
+            // `"resources": "dynamic"` otherwise surfaced as
+            // `Error (no_resources): This skill generates its content per
+            // request…` — the exact collapse the separate kind exists to
+            // prevent.
+            return `Error (${target.entry.unloadable.reason}): ${target.entry.unloadable.message}`;
           }
           const loaded = await loadEntry(target.entry);
           if (typeof loaded === "string") return loaded;
+          const budgeted = withinPromptBudget(
+            loaded.content,
+            `Skill "${target.entry.ref}"`
+          );
+          if (!budgeted.ok) return budgeted.error;
           return (
             serverSkillBanner({
               ref: target.entry.ref,
               serverLabel: target.entry.serverLabel,
               skillUri: target.entry.skillUri,
-            }) + loaded.content
+            }) + budgeted.text
           );
         }
 
@@ -683,12 +744,17 @@ export function withServerSkills<T extends Record<string, unknown>>(
             uri: target.uri,
             entry: approval.binding?.entry,
           });
+          const budgeted = withinPromptBudget(
+            loaded.content,
+            `Skill "${loaded.skillUri}"`
+          );
+          if (!budgeted.ok) return budgeted.error;
           return (
             serverSkillBanner({
               ref: `${provider?.serverSlug ?? target.serverId}/${loaded.name}`,
               serverLabel: provider?.serverLabel ?? target.serverId,
               skillUri: loaded.skillUri,
-            }) + loaded.content
+            }) + budgeted.text
           );
         } catch (error) {
           return refusalText(error);
@@ -766,7 +832,9 @@ export function withServerSkills<T extends Record<string, unknown>>(
             entry: approvedEntry,
             resourceUri,
           });
-          return `# ${file.uri}\n\n${file.text}`;
+          const budgeted = withinPromptBudget(file.text, `"${file.uri}"`);
+          if (!budgeted.ok) return budgeted.error;
+          return `# ${file.uri}\n\n${budgeted.text}`;
         } catch (error) {
           return refusalText(error);
         }

--- a/mcpjam-inspector/server/utils/server-skill-tools.ts
+++ b/mcpjam-inspector/server/utils/server-skill-tools.ts
@@ -52,7 +52,7 @@
  * and it is not a disclosure. A security property the code does not have is
  * worse than one it never promised.
  *
- * PIN: modelcontextprotocol/docs @ d7490ec.
+ * PIN: modelcontextprotocol/modelcontextprotocol @ a3e147ca27 (branch `sep/skills-extension`, `seps/2640-skills-extension.md`).
  */
 
 import { tool } from "ai";

--- a/mcpjam-inspector/server/utils/server-skills.ts
+++ b/mcpjam-inspector/server/utils/server-skills.ts
@@ -8,37 +8,62 @@
  *   - every SKILL.md is fetched via `resources/read` and verified against its
  *     manifest digest before any caller sees a byte;
  *   - a read of a URI absent from the manifest is a FAILURE, never a fetch;
+ *   - every fetched file's byte length is checked against its manifest `size`
+ *     BEFORE its digest, because the draft makes a length mismatch its own
+ *     verification failure and the two are different diagnoses;
  *   - the fetched frontmatter is re-checked field-by-field against what the
  *     listing advertised, and the name against the URI's final segment;
- *   - a skill with NO manifest is refused outright. SEP-2640 says a host MAY
- *     load content it cannot verify; MCPJam declines, and says so.
+ *   - the draft's per-skill limits (512 entries, 16 MiB summed) are enforced
+ *     from the manifest, before the first byte is fetched;
+ *   - a skill with no enumerated manifest is refused outright — whether it
+ *     declared `"dynamic"` or omitted `resources` entirely, which are
+ *     different server behaviours and get different refusals. SEP-2640 says a
+ *     host MAY load content it cannot verify; MCPJam declines, and says so.
  *
  * Everything here is manager-shaped rather than route-shaped so the local
  * (long-lived manager) and hosted (ephemeral per-request manager) paths share
  * one implementation. The SDK owns the wire and the crypto; this module owns
  * the ORCHESTRATION and the refusals.
  *
- * PIN: modelcontextprotocol/docs @ d7490ec.
+ * PIN: modelcontextprotocol/modelcontextprotocol @ a3e147ca27 (branch `sep/skills-extension`, `seps/2640-skills-extension.md`).
  */
 
 import type { MCPClientManager } from "@mcpjam/sdk";
 import {
+  MAX_SKILL_RESOURCE_ENTRIES,
+  MAX_SKILL_TOTAL_BYTES,
   SkillIntegrityError,
+  checkManifestLimits,
   checkSkillIdentity,
+  enumeratedResources,
   findListedResource,
+  isDynamicResources,
   isSkillNotFoundError,
   listAllServerSkills,
   sha256HexOfText,
   verifyDigest,
+  verifySize,
   verifySkillMarkdown,
   type SkillEntry,
 } from "@mcpjam/sdk";
 import { logger } from "./logger.js";
 
-/** Hard cap on a fetched SKILL.md, matching the cloud-skill body cap. */
-export const MAX_SERVER_SKILL_CONTENT_BYTES = 128 * 1024;
-/** Hard cap on a fetched supporting file. */
-export const MAX_SERVER_SKILL_FILE_BYTES = 2 * 1024 * 1024;
+/**
+ * Hard cap on any single fetched skill file, SKILL.md included.
+ *
+ * This is the SEP's PER-SKILL total, applied per read. It used to be 128 KiB
+ * for SKILL.md and 2 MiB for a supporting file — caps invented before the
+ * draft had any, and both now sit BELOW what the draft says a host MUST
+ * support. A conforming 3 MiB SKILL.md would have been refused as `too_large`,
+ * which is our bug to own, not the server's.
+ *
+ * A file cannot legitimately exceed the whole skill's budget, so reusing the
+ * total as the per-read ceiling is both spec-safe and a real bound on a server
+ * that streams without end. The manifest-level budget — the sum, and the entry
+ * count — is enforced separately in {@link normalizeManifest}, before the
+ * first byte is fetched, which is what `size` is for.
+ */
+export const MAX_SERVER_SKILL_READ_BYTES = MAX_SKILL_TOTAL_BYTES;
 
 export interface ServerSkillSummary {
   serverId: string;
@@ -48,9 +73,12 @@ export interface ServerSkillSummary {
   description: string;
   /** Verbatim frontmatter, as advertised. */
   frontmatter: unknown;
-  resources: Array<{ uri: string; digest: string }>;
+  resources: Array<{ uri: string; digest: string; size?: number }>;
   /** Present ⇒ live-only: discoverable and refused for loading. */
-  unloadable?: { reason: "no_resources"; message: string };
+  unloadable?: {
+    reason: "no_resources" | "dynamic_resources";
+    message: string;
+  };
 }
 
 export interface ServerSkillListing {
@@ -74,7 +102,7 @@ export interface VerifiedServerSkill {
   content: string;
   contentSha256: string;
   frontmatter: unknown;
-  resources: Array<{ uri: string; digest: string }>;
+  resources: Array<{ uri: string; digest: string; size?: number }>;
 }
 
 /**
@@ -87,9 +115,12 @@ export interface VerifiedServerSkill {
 export interface ServerSkillRefusal {
   kind:
     | "no_resources"
+    | "dynamic_resources"
     | "unlisted_resource"
     | "digest_mismatch"
     | "unsupported_digest"
+    | "size_mismatch"
+    | "too_many_resources"
     | "frontmatter_drift"
     | "identity_mismatch"
     | "not_found"
@@ -240,21 +271,28 @@ function normalizeManifest(
   skillUri: string,
   raw: unknown
 ):
-  | { ok: true; resources: Array<{ uri: string; digest: string }> }
+  | {
+      ok: true;
+      resources: Array<{ uri: string; digest: string; size?: number }>;
+    }
   | {
       ok: false;
       reason: string;
+      kind?: "too_many_resources" | "too_large";
     } {
   if (!Array.isArray(raw)) return { ok: true, resources: [] };
   const root = skillDirectoryOf(skillUri);
   if (root === undefined) {
     return { ok: false, reason: `skill URI does not end in SKILL.md` };
   }
-  const resources: Array<{ uri: string; digest: string }> = [];
+  const resources: Array<{ uri: string; digest: string; size?: number }> = [];
   const seen = new Set<string>();
   for (const entry of raw) {
     const uri = String((entry as { uri?: unknown })?.uri ?? "");
     const digest = String((entry as { digest?: unknown })?.digest ?? "");
+    // The wire guard has already constrained `size` to a non-negative integer
+    // when present; anything else never reaches here.
+    const size = (entry as { size?: unknown })?.size;
     if (uri.length === 0 || digest.length === 0) {
       return { ok: false, reason: "manifest entry is missing uri or digest" };
     }
@@ -276,7 +314,31 @@ function normalizeManifest(
         reason: `manifest entry "${uri}" contains a parent-directory segment`,
       };
     }
-    resources.push({ uri, digest });
+    resources.push({
+      uri,
+      digest,
+      ...(typeof size === "number" ? { size } : {}),
+    });
+  }
+
+  // The draft's per-skill limits, enforced from the manifest BEFORE the first
+  // fetch — which is the whole reason `size` exists. A skill over either limit
+  // is "not guaranteed to be loadable by any conforming host", and the draft
+  // asks that a host declining on this basis say why rather than fail silently
+  // on a later read.
+  const limits = checkManifestLimits(resources);
+  if (!limits.ok) {
+    return limits.reason === "too_many_resources"
+      ? {
+          ok: false,
+          kind: "too_many_resources",
+          reason: `manifest lists ${limits.actual} files, over the ${MAX_SKILL_RESOURCE_ENTRIES}-entry limit`,
+        }
+      : {
+          ok: false,
+          kind: "too_large",
+          reason: `manifest totals ${limits.actual} bytes, over the ${MAX_SKILL_TOTAL_BYTES}-byte per-skill limit`,
+        };
   }
   return { ok: true, resources };
 }
@@ -320,7 +382,11 @@ function toSummary(
   if (description.length === 0) {
     return { ok: false, reason: "frontmatter.description is missing" };
   }
-  const manifest = normalizeManifest(entry.uri, entry.resources);
+  const dynamic = isDynamicResources(entry);
+  const manifest = normalizeManifest(
+    entry.uri,
+    dynamic ? undefined : enumeratedResources(entry)
+  );
   if (!manifest.ok) {
     return { ok: false, reason: manifest.reason };
   }
@@ -337,15 +403,29 @@ function toSummary(
       resources,
       // Recorded, not rejected: the skill is real and a user should see it in
       // the catalog. Loading is what we refuse.
-      ...(resources.length === 0
+      //
+      // `"dynamic"` and a MISSING manifest are both unloadable and are kept
+      // apart deliberately: one is a server exercising a form the draft
+      // defines, the other is a server omitting a field the draft requires.
+      // Collapsing them would tell a server author their conforming skill is
+      // malformed.
+      ...(dynamic
         ? {
             unloadable: {
-              reason: "no_resources" as const,
+              reason: "dynamic_resources" as const,
               message:
-                "This skill does not advertise a file manifest, so MCPJam cannot verify its contents and declines to load it.",
+                "This skill generates its content per request, so there is no manifest to verify it against. MCPJam declines to load unverifiable skills.",
             },
           }
-        : {}),
+        : resources.length === 0
+          ? {
+              unloadable: {
+                reason: "no_resources" as const,
+                message:
+                  "This skill does not advertise a file manifest, so MCPJam cannot verify its contents and declines to load it.",
+              },
+            }
+          : {}),
     },
   };
 }
@@ -471,9 +551,18 @@ export async function getVerifiedServerSkill(
     });
   }
 
-  // MCPJam policy, applied before any fetch: no manifest ⇒ nothing to verify
-  // against, and we decline the SEP's permission to load unverified content.
-  if (!entry.resources || entry.resources.length === 0) {
+  // MCPJam policy, applied before any fetch: nothing to verify against means
+  // we decline the SEP's permission to load unverified content. The two ways
+  // that happens get their own refusals — see `toSummary` for why.
+  if (isDynamicResources(entry)) {
+    throw new ServerSkillRefusalError({
+      kind: "dynamic_resources",
+      message: `Skill "${uri}" declares "dynamic" content, so there is no manifest to verify it against. MCPJam declines to load unverifiable skills.`,
+      skillUri: uri,
+    });
+  }
+  const advertised = enumeratedResources(entry);
+  if (!advertised || advertised.length === 0) {
     throw new ServerSkillRefusalError({
       kind: "no_resources",
       message: `Skill "${uri}" does not advertise a file manifest, so its contents cannot be verified. MCPJam declines to load unverifiable skills.`,
@@ -485,10 +574,13 @@ export async function getVerifiedServerSkill(
   // fetch — containment and uniqueness, same rule the listing path applies. A
   // manifest reaching `readVerifiedServerSkillFile` unchecked would let a skill
   // authorize reads of resources outside its own directory.
-  const manifest = normalizeManifest(entry.uri, entry.resources);
+  const manifest = normalizeManifest(entry.uri, advertised);
   if (!manifest.ok) {
     throw new ServerSkillRefusalError({
-      kind: "unlisted_resource",
+      // A limit breach is not a malformed manifest — the draft asks a host
+      // declining on that basis to say WHY, and `unlisted_resource` would
+      // point the reader at a containment bug that isn't there.
+      kind: manifest.kind ?? "unlisted_resource",
       message: `Skill "${uri}" advertises an invalid file manifest: ${manifest.reason}.`,
       skillUri: uri,
     });
@@ -498,7 +590,7 @@ export async function getVerifiedServerSkill(
     manager,
     serverId,
     entry.uri,
-    MAX_SERVER_SKILL_CONTENT_BYTES
+    MAX_SERVER_SKILL_READ_BYTES
   );
 
   let verified;
@@ -550,12 +642,24 @@ export async function readVerifiedServerSkillFile(
     manager,
     args.serverId,
     args.resourceUri,
-    MAX_SERVER_SKILL_FILE_BYTES
+    MAX_SERVER_SKILL_READ_BYTES
   );
-  const verification = await verifyDigest(
-    new TextEncoder().encode(text),
-    listed.digest
-  );
+  const bytes = new TextEncoder().encode(text);
+  // Size before digest, same order and same reasoning as `verifySkillMarkdown`:
+  // a truncated read and a tampered file are different diagnoses, and only the
+  // length check can tell them apart.
+  const sizing = verifySize(bytes.byteLength, listed);
+  if (!sizing.ok) {
+    throw new ServerSkillRefusalError({
+      kind: "size_mismatch",
+      message: `"${args.resourceUri}" is advertised as ${sizing.expected} bytes but the server returned ${sizing.actual}.`,
+      skillUri: args.entry.uri,
+      resourceUri: args.resourceUri,
+      expected: String(sizing.expected),
+      actual: String(sizing.actual),
+    });
+  }
+  const verification = await verifyDigest(bytes, listed.digest);
   if (!verification.ok) {
     throw new ServerSkillRefusalError({
       kind: verification.reason,

--- a/mcpjam-inspector/server/utils/server-skills.ts
+++ b/mcpjam-inspector/server/utils/server-skills.ts
@@ -76,7 +76,11 @@ export interface ServerSkillSummary {
   resources: Array<{ uri: string; digest: string; size?: number }>;
   /** Present ⇒ live-only: discoverable and refused for loading. */
   unloadable?: {
-    reason: "no_resources" | "dynamic_resources";
+    reason:
+      | "no_resources"
+      | "dynamic_resources"
+      | "too_many_resources"
+      | "too_large";
     message: string;
   };
 }
@@ -388,6 +392,29 @@ function toSummary(
     dynamic ? undefined : enumeratedResources(entry)
   );
   if (!manifest.ok) {
+    // A LIMIT breach is not a malformed manifest. The skill is real, its
+    // manifest parses, and a user should see it in the catalog for the same
+    // reason a `dynamic` one is shown — dropping it into `rejected` hides a
+    // real skill behind what reads as a server bug. Only a manifest we cannot
+    // make sense of is rejected outright.
+    if (manifest.kind !== undefined) {
+      const advertised = enumeratedResources(entry) ?? [];
+      return {
+        ok: true,
+        skill: {
+          serverId,
+          skillUri: entry.uri,
+          name,
+          description,
+          frontmatter,
+          resources: advertised,
+          unloadable: {
+            reason: manifest.kind,
+            message: `This skill exceeds what a host is required to support: its ${manifest.reason}. MCPJam declines to load it.`,
+          },
+        },
+      };
+    }
     return { ok: false, reason: manifest.reason };
   }
   const resources = manifest.resources;

--- a/mcpjam-inspector/shared/server-skill-banner.ts
+++ b/mcpjam-inspector/shared/server-skill-banner.ts
@@ -20,7 +20,7 @@
  * checked and then says plainly that the content is untrusted third-party
  * input.
  *
- * PIN: modelcontextprotocol/docs @ d7490ec.
+ * PIN: modelcontextprotocol/modelcontextprotocol @ a3e147ca27 (branch `sep/skills-extension`, `seps/2640-skills-extension.md`).
  */
 
 export interface ServerSkillBannerArgs {

--- a/sdk/src/index.ts
+++ b/sdk/src/index.ts
@@ -132,6 +132,9 @@ export {
   SkillsExtGetMethod,
   SkillsExtListMethod,
   INODE_DIRECTORY_MIME_TYPE,
+  DYNAMIC_SKILL_RESOURCES,
+  MAX_SKILL_RESOURCE_ENTRIES,
+  MAX_SKILL_TOTAL_BYTES,
   clientDeclaresSkillsExtension,
   resolveSkillsSupport,
   serverDeclaresSkillsExtension,
@@ -156,7 +159,10 @@ export {
   comparableAdvertisedFrontmatter,
   splitAdvertisedFrontmatter,
   computeSkillVersionHash,
+  checkManifestLimits,
+  enumeratedResources,
   findListedResource,
+  isDynamicResources,
   isListedResource,
   parseDigest,
   sha256HexOfBytes,
@@ -164,6 +170,7 @@ export {
   skillNameFromUri,
   splitSkillMarkdown,
   verifyDigest,
+  verifySize,
   verifySkillMarkdown,
 } from "./mcp-client-manager/index.js";
 export type {

--- a/sdk/src/mcp-client-manager/index.ts
+++ b/sdk/src/mcp-client-manager/index.ts
@@ -248,7 +248,12 @@ export type {
   SkillsDirectoryReadResult,
   SkillIdentityFrontmatter,
 } from "./skills-ext-types.js";
-export { INODE_DIRECTORY_MIME_TYPE } from "./skills-ext-types.js";
+export {
+  INODE_DIRECTORY_MIME_TYPE,
+  DYNAMIC_SKILL_RESOURCES,
+  MAX_SKILL_RESOURCE_ENTRIES,
+  MAX_SKILL_TOTAL_BYTES,
+} from "./skills-ext-types.js";
 export {
   InvalidSkillsPayloadError,
   isInvalidSkillsPayloadError,
@@ -268,7 +273,10 @@ export {
   comparableAdvertisedFrontmatter,
   splitAdvertisedFrontmatter,
   computeSkillVersionHash,
+  checkManifestLimits,
+  enumeratedResources,
   findListedResource,
+  isDynamicResources,
   isListedResource,
   parseDigest,
   sha256HexOfBytes,
@@ -276,12 +284,15 @@ export {
   skillNameFromUri,
   splitSkillMarkdown,
   verifyDigest,
+  verifySize,
   verifySkillMarkdown,
 } from "./skills-integrity.js";
 export type {
   DigestVerification,
   FrontmatterIdentityCheck,
+  ManifestLimitCheck,
   ParsedDigest,
+  SizeVerification,
   SupportedDigestAlgorithm,
 } from "./skills-integrity.js";
 

--- a/sdk/src/mcp-client-manager/skills-ext-guards.ts
+++ b/sdk/src/mcp-client-manager/skills-ext-guards.ts
@@ -145,22 +145,55 @@ export function isMCPSkillsWireError(
   return error instanceof MCPSkillsWireError;
 }
 
+/**
+ * Flattens one zod issue, DESCENDING into union alternatives.
+ *
+ * A `z.union` reports its own failure as a single `invalid_union` issue whose
+ * message is the useless "Invalid input", with the real per-field diagnoses
+ * buried in a nested `errors` array-of-arrays — one entry per alternative. A
+ * formatter that reads only the top level therefore turns
+ * "resources.0.digest is missing" into "resources: Invalid input", which
+ * defeats the entire reason these guards exist: naming WHICH field of WHICH
+ * entry a server got wrong.
+ *
+ * Sub-issue paths are relative to the union's input, so the parent path is
+ * prepended to rebuild the full address.
+ */
+function flattenIssue(issue: unknown, parentPath: string[]): string[] {
+  const rawPath = Array.isArray((issue as { path?: unknown }).path)
+    ? (issue as { path: unknown[] }).path.map((segment) =>
+        safeText(String(segment))
+      )
+    : [];
+  const path = [...parentPath, ...rawPath];
+
+  const alternatives = (issue as { errors?: unknown }).errors;
+  if (Array.isArray(alternatives)) {
+    const nested = alternatives
+      .flatMap((alternative) =>
+        Array.isArray(alternative)
+          ? alternative.flatMap((sub) => flattenIssue(sub, path))
+          : []
+      )
+      .filter((text) => text.length > 0);
+    // Only when an alternative actually explained something. An empty union
+    // report still has to say the field failed rather than vanish.
+    if (nested.length > 0) return nested;
+  }
+
+  const message = safeText(
+    String((issue as { message?: unknown }).message ?? "invalid")
+  );
+  const joined = path.join(".");
+  return [joined ? `${joined}: ${message}` : message];
+}
+
 function issuesOf(error: unknown): string[] {
   const zodIssues = (error as { issues?: unknown })?.issues;
   if (!Array.isArray(zodIssues)) {
     return [error instanceof Error ? error.message : String(error)];
   }
-  return zodIssues.map((issue) => {
-    const path = Array.isArray((issue as { path?: unknown }).path)
-      ? (issue as { path: unknown[] }).path
-          .map((segment) => safeText(String(segment)))
-          .join(".")
-      : "";
-    const message = safeText(
-      String((issue as { message?: unknown }).message ?? "invalid")
-    );
-    return path ? `${path}: ${message}` : message;
-  });
+  return zodIssues.flatMap((issue) => flattenIssue(issue, []));
 }
 
 /** Validates a `skills/list` result, preserving SEP-2549 cache attributes. */

--- a/sdk/src/mcp-client-manager/skills-ext-schemas.ts
+++ b/sdk/src/mcp-client-manager/skills-ext-schemas.ts
@@ -1,7 +1,6 @@
 /**
- * PIN: modelcontextprotocol/docs @ d7490ec
- * (`seps/2640-skills-extension.mdx`). Re-diff against that commit when
- * re-syncing.
+ * PIN: modelcontextprotocol/modelcontextprotocol @ a3e147ca27 (branch `sep/skills-extension`, `seps/2640-skills-extension.md`).
+ * Re-diff against that commit when re-syncing.
  */
 /**
  * Runtime validation for `io.modelcontextprotocol/skills` (SEP-2640)
@@ -26,6 +25,7 @@
  */
 
 import { z } from "zod";
+import { DYNAMIC_SKILL_RESOURCES } from "./skills-ext-types.js";
 
 /**
  * One entry in a skill's `resources` manifest: the complete list of files the
@@ -42,6 +42,12 @@ export const skillResourceRefSchema = z
   .object({
     uri: z.string().min(1),
     digest: z.string().min(1),
+    // REQUIRED by the draft, optional here. A non-negative integer when
+    // present: this is untrusted input that flows into a length comparison and
+    // a pre-fetch budget, and a negative or fractional byte count has no
+    // meaning in either. Absence is a server that predates the field, which
+    // `verifySize` reports rather than refuses — see `skills-ext-types.ts`.
+    size: z.number().int().nonnegative().optional(),
   })
   .loose();
 
@@ -50,11 +56,13 @@ export const skillResourceRefSchema = z
  * `skills/get` (as the whole result). SEP-2640 gives them the same shape on
  * purpose: a host that can render a listing entry can render a get.
  *
- * `resources` is OPTIONAL on the wire because the SEP allows a server to omit
- * it, but MCPJam declines to load a skill without one (digest verification is
- * mandatory for us) — that policy lives in `skills-integrity.ts` /
- * `server-skill-tools.ts`, not here. Parsing must still accept the entry so
- * the refusal can name it.
+ * `resources` is REQUIRED by the draft and takes one of two forms — an
+ * enumerated manifest, or the string `"dynamic"`. It stays OPTIONAL here
+ * anyway, for the same reason `digest` is presence-checked rather than
+ * shape-checked: a server that omits it must survive parsing so the refusal
+ * can name the skill and the violation. MCPJam declines to load anything
+ * without an enumerated manifest, and that policy lives in
+ * `skills-integrity.ts` / `server-skills.ts`, not here.
  */
 export const skillEntrySchema = z
   .object({
@@ -72,7 +80,17 @@ export const skillEntrySchema = z
     frontmatter: z.unknown().refine((value) => value !== undefined, {
       message: "frontmatter is required",
     }),
-    resources: z.array(skillResourceRefSchema).optional(),
+    // A UNION, not just an array: the draft's second form is the bare string
+    // `"dynamic"`, for a skill whose content is generated per request. Parsing
+    // only the array turns a conforming dynamic server into an
+    // `InvalidSkillsPayloadError` — a wire error where a stated policy refusal
+    // belongs, and one the user cannot act on.
+    resources: z
+      .union([
+        z.array(skillResourceRefSchema),
+        z.literal(DYNAMIC_SKILL_RESOURCES),
+      ])
+      .optional(),
   })
   .loose();
 

--- a/sdk/src/mcp-client-manager/skills-ext-types.ts
+++ b/sdk/src/mcp-client-manager/skills-ext-types.ts
@@ -17,7 +17,32 @@ export interface SkillResourceRef {
   uri: string;
   /** `<algorithm>:<hex>` — e.g. `sha256:ab12…`. */
   digest: string;
+  /**
+   * Length in bytes of the file's raw content — the same bytes `digest`
+   * covers. The draft makes this REQUIRED, and a read whose byte length
+   * differs is "a verification failure equivalent to a digest mismatch".
+   *
+   * Optional HERE because the SEP is unratified and servers built against the
+   * earlier draft omit it. MCPJam enforces it wherever the server sent one and
+   * reports its absence rather than refusing the skill — refusing would make
+   * us incompatible with every implementation that predates the field, which
+   * is a bad trade for a debugger. See `verifySize`.
+   */
+  size?: number;
 }
+
+/**
+ * The `resources` value for a skill whose content is generated per request.
+ *
+ * A dynamic skill offers nothing to digest, count, or budget, so MCPJam
+ * refuses to LOAD one — but it must still PARSE, or a conforming server
+ * becomes an unexplained wire error instead of a stated policy refusal.
+ */
+export const DYNAMIC_SKILL_RESOURCES = "dynamic" as const;
+
+/** Limits the draft requires a host to support, per skill. */
+export const MAX_SKILL_RESOURCE_ENTRIES = 512;
+export const MAX_SKILL_TOTAL_BYTES = 16 * 1024 * 1024;
 
 /**
  * A skill as the server describes it. IDENTITY IS `uri`, not
@@ -34,12 +59,16 @@ export interface SkillEntry {
    */
   frontmatter: unknown;
   /**
-   * The complete set of files this skill is allowed to fetch. A read of any
-   * URI absent from this list MUST fail (SEP-2640 integrity rules).
+   * The complete set of files this skill is allowed to fetch, or
+   * {@link DYNAMIC_SKILL_RESOURCES} for a skill generated per request. A read
+   * of any URI absent from an enumerated manifest MUST fail (SEP-2640
+   * integrity rules).
    *
-   * Optional on the wire; MCPJam refuses to load an entry without one.
+   * The draft makes this REQUIRED. It stays optional in the TYPE so a server
+   * that omits it is still parseable and can be refused by name; MCPJam
+   * refuses to load an entry without an enumerated manifest either way.
    */
-  resources?: SkillResourceRef[];
+  resources?: SkillResourceRef[] | typeof DYNAMIC_SKILL_RESOURCES;
 }
 
 /** `skills/list` result, with SEP-2549 caching attributes preserved. */

--- a/sdk/src/mcp-client-manager/skills-integrity.ts
+++ b/sdk/src/mcp-client-manager/skills-integrity.ts
@@ -31,6 +31,11 @@ import type {
   SkillIdentityFrontmatter,
   SkillResourceRef,
 } from "./skills-ext-types.js";
+import {
+  DYNAMIC_SKILL_RESOURCES,
+  MAX_SKILL_RESOURCE_ENTRIES,
+  MAX_SKILL_TOTAL_BYTES,
+} from "./skills-ext-types.js";
 import { parseDocument } from "yaml";
 
 /**
@@ -201,7 +206,125 @@ export function findListedResource(
   entry: Pick<SkillEntry, "resources">,
   uri: string
 ): SkillResourceRef | undefined {
-  return entry.resources?.find((resource) => resource.uri === uri);
+  const manifest = enumeratedResources(entry);
+  return manifest?.find((resource) => resource.uri === uri);
+}
+
+/**
+ * Whether the entry declares `"dynamic"` — content generated per request,
+ * with nothing to digest, count, or budget.
+ *
+ * Distinguished from a MISSING `resources` on purpose: "the server told us
+ * this skill is dynamic" and "the server omitted a required field" are
+ * different server behaviours and deserve different messages, even though
+ * MCPJam refuses to load in both cases.
+ */
+export function isDynamicResources(
+  entry: Pick<SkillEntry, "resources">
+): boolean {
+  return entry.resources === DYNAMIC_SKILL_RESOURCES;
+}
+
+/**
+ * The entry's manifest as an array, or `undefined` when there is none to
+ * enumerate — whether because the server omitted `resources` or declared it
+ * `"dynamic"`.
+ *
+ * Every read path goes through here rather than touching `entry.resources`
+ * directly, so `"dynamic"` can never be indexed into as if it were an array.
+ */
+export function enumeratedResources(
+  entry: Pick<SkillEntry, "resources">
+): SkillResourceRef[] | undefined {
+  const resources = entry.resources;
+  return Array.isArray(resources) ? resources : undefined;
+}
+
+export type SizeVerification =
+  | { ok: true; checked: boolean }
+  | { ok: false; expected: number; actual: number };
+
+/**
+ * Verifies a fetched file's byte length against its manifest `size`.
+ *
+ * The draft calls a length mismatch "a verification failure equivalent to a
+ * digest mismatch, whether or not the host goes on to compute the digest" —
+ * so this runs BEFORE hashing, which is the point of the field: it lets a host
+ * detect a truncated or padded read without paying for a digest, and lets it
+ * budget a skill from the entry alone.
+ *
+ * `checked: false` means the server sent no `size`. That is reported, never
+ * treated as a pass and never treated as a refusal — see the field's doc
+ * comment in `skills-ext-types.ts` for why a pre-`size` server is tolerated.
+ */
+export function verifySize(
+  byteLength: number,
+  ref: Pick<SkillResourceRef, "size">
+): SizeVerification {
+  if (ref.size === undefined) return { ok: true, checked: false };
+  if (ref.size !== byteLength) {
+    return { ok: false, expected: ref.size, actual: byteLength };
+  }
+  return { ok: true, checked: true };
+}
+
+export type ManifestLimitCheck =
+  | { ok: true; entryCount: number; totalBytes: number | undefined }
+  | {
+      ok: false;
+      reason: "too_many_resources";
+      expected: number;
+      actual: number;
+    }
+  | { ok: false; reason: "too_large"; expected: number; actual: number };
+
+/**
+ * Checks a manifest against the per-skill limits the draft requires hosts to
+ * support: 512 entries and 16 MiB summed over `size`.
+ *
+ * Both are checkable from the entry alone, before a single file is retrieved —
+ * which is why this takes the manifest rather than fetched bytes. A skill over
+ * either limit is one "not guaranteed to be loadable by any conforming host",
+ * and the draft asks that a host declining on this basis say why rather than
+ * fail silently on a later read.
+ *
+ * `totalBytes` is `undefined` when any entry omitted `size`: a partial sum is
+ * not a budget, and reporting one would invite a caller to enforce a limit
+ * against a number that undercounts.
+ */
+export function checkManifestLimits(
+  resources: readonly SkillResourceRef[]
+): ManifestLimitCheck {
+  if (resources.length > MAX_SKILL_RESOURCE_ENTRIES) {
+    return {
+      ok: false,
+      reason: "too_many_resources",
+      expected: MAX_SKILL_RESOURCE_ENTRIES,
+      actual: resources.length,
+    };
+  }
+  let total = 0;
+  let complete = true;
+  for (const resource of resources) {
+    if (resource.size === undefined) {
+      complete = false;
+      continue;
+    }
+    total += resource.size;
+  }
+  if (complete && total > MAX_SKILL_TOTAL_BYTES) {
+    return {
+      ok: false,
+      reason: "too_large",
+      expected: MAX_SKILL_TOTAL_BYTES,
+      actual: total,
+    };
+  }
+  return {
+    ok: true,
+    entryCount: resources.length,
+    totalBytes: complete ? total : undefined,
+  };
 }
 
 /** Whether `uri` appears in the entry's manifest. */
@@ -441,6 +564,10 @@ export class SkillIntegrityError extends Error {
     | "frontmatter_drift"
     | "identity_mismatch"
     | "no_resources"
+    | "dynamic_resources"
+    | "size_mismatch"
+    | "too_many_resources"
+    | "too_large"
     | "fetch_failed"
     | "not_text";
   readonly resourceUri?: string;
@@ -588,6 +715,22 @@ export async function verifySkillMarkdown(args: {
   }
   {
     const bytes = args.bytes ?? new TextEncoder().encode(markdown);
+    // Size BEFORE digest. The draft makes a length mismatch a verification
+    // failure in its own right, "whether or not the host goes on to compute
+    // the digest", and reporting it as its own kind is what lets a user tell a
+    // truncated read apart from tampered content — a digest mismatch would be
+    // technically true here and diagnostically useless.
+    const sizing = verifySize(bytes.byteLength, listed);
+    if (!sizing.ok) {
+      throw new SkillIntegrityError({
+        message: `Skill "${entry.uri}" advertises ${sizing.expected} bytes but the server returned ${sizing.actual}.`,
+        skillUri: entry.uri,
+        kind: "size_mismatch",
+        resourceUri: entry.uri,
+        expected: String(sizing.expected),
+        actual: String(sizing.actual),
+      });
+    }
     const verification = await verifyDigest(bytes, listed.digest);
     if (!verification.ok) {
       throw new SkillIntegrityError({

--- a/sdk/src/mcp-client-manager/skills-integrity.ts
+++ b/sdk/src/mcp-client-manager/skills-integrity.ts
@@ -312,7 +312,13 @@ export function checkManifestLimits(
     }
     total += resource.size;
   }
-  if (complete && total > MAX_SKILL_TOTAL_BYTES) {
+  // The partial sum is a FLOOR, so it can still trip the limit. Gating this on
+  // `complete` made the budget inert for exactly the servers that are the norm
+  // today — the draft's `size` is new, and a server omitting it on a single one
+  // of 512 entries would have disabled the whole-skill budget. A total that is
+  // already over the limit is over it whether or not more entries were
+  // measured.
+  if (total > MAX_SKILL_TOTAL_BYTES) {
     return {
       ok: false,
       reason: "too_large",

--- a/sdk/src/openai-readiness/checks/mcp-skills.ts
+++ b/sdk/src/openai-readiness/checks/mcp-skills.ts
@@ -25,6 +25,7 @@
 import { openaiPolicySource } from "../manifest.js";
 import { OPENAI_MCP_SKILL_LIMITS } from "../profile.js";
 import { openaiPortalIssue, type OpenAIPortalIssue } from "../portal-errors.js";
+import { checkFrontmatterDrift } from "../../mcp-client-manager/skills-integrity.js";
 import {
   OPENAI_READINESS_INPUTS,
   OPENAI_SUBMISSION_MODE_SHAPES,
@@ -104,6 +105,12 @@ const ALL: OpenAICheckDefinition[] = [
   FRONTMATTER_AGREES,
   SNAPSHOT_SEMANTICS,
 ];
+
+function comparableDigest(value: string | undefined): string | undefined {
+  if (!value) return undefined;
+  const lower = value.toLowerCase();
+  return lower.startsWith("sha256:") ? lower.slice("sha256:".length) : value;
+}
 
 export interface OpenAISkillsCheckInput {
   mode: OpenAISubmissionMode;
@@ -352,7 +359,8 @@ export function runOpenAIMcpSkillChecks(
     (skill) =>
       skill.declaredDigest !== undefined &&
       skill.observedDigest !== undefined &&
-      skill.declaredDigest !== skill.observedDigest,
+      comparableDigest(skill.declaredDigest) !==
+        comparableDigest(skill.observedDigest),
   );
 
   findings.push(
@@ -401,6 +409,12 @@ export function runOpenAIMcpSkillChecks(
   // differ is telling two different stories about the same skill.
   const disagreeing = evidence.skills.filter((skill) => {
     if (!skill.frontmatter) return false;
+    if (skill.declaredFrontmatter) {
+      return !checkFrontmatterDrift(
+        skill.declaredFrontmatter,
+        skill.frontmatter,
+      ).ok;
+    }
     const name = skill.frontmatter.name;
     const description = skill.frontmatter.description;
     return (

--- a/sdk/src/openai-readiness/checks/mcp-skills.ts
+++ b/sdk/src/openai-readiness/checks/mcp-skills.ts
@@ -108,8 +108,12 @@ const ALL: OpenAICheckDefinition[] = [
 
 function comparableDigest(value: string | undefined): string | undefined {
   if (!value) return undefined;
+  // `lower` in BOTH branches. Returning the original in the fallback meant a
+  // server declaring a bare uppercase hex digest never matched the
+  // always-lowercase `observedDigest`, and was reported as a mismatch for a
+  // difference in case alone.
   const lower = value.toLowerCase();
-  return lower.startsWith("sha256:") ? lower.slice("sha256:".length) : value;
+  return lower.startsWith("sha256:") ? lower.slice("sha256:".length) : lower;
 }
 
 export interface OpenAISkillsCheckInput {

--- a/sdk/src/openai-readiness/discovery.ts
+++ b/sdk/src/openai-readiness/discovery.ts
@@ -36,8 +36,10 @@ import {
   type DirectoryRedirectHop,
   type PrmDiscoveryResult,
 } from "../directory-readiness/discovery.js";
-import { sha256HexOfBytes } from "../mcp-client-manager/skills-integrity.js";
-import { parseYamlLite, splitFrontmatter } from "../plugin-bundle/skill.js";
+import {
+  sha256HexOfBytes,
+  splitSkillMarkdown,
+} from "../mcp-client-manager/skills-integrity.js";
 import {
   OPENAI_DOMAIN_VERIFICATION_PATH,
   OPENAI_MCP_SKILL_LIMITS,
@@ -530,12 +532,18 @@ function recordFetchedMarkdown(
   const markdown = parseFetchedMarkdown(skill, content);
   return sha256HexOfBytes(content.bytes).then((digest) => {
     skill.observedDigest = digest;
-    const split = splitFrontmatter(markdown);
-    if (split) {
-      const parsed = parseYamlLite(split.frontmatter);
-      // `tooDeep` is an ARRAY of paths, so an empty array is the successful parse.
-      if (parsed.tooDeep.length === 0) skill.frontmatter = parsed.data;
-    }
+    // The REAL YAML parser, not `parseYamlLite`. This value is compared against
+    // the server's advertised frontmatter by `checkFrontmatterDrift`, which
+    // diffs the union of keys on canonical JSON — so any place the lite
+    // subset parser disagrees with YAML becomes a reported violation against a
+    // CONFORMING server. Both divergences are easy to hit: a nested map
+    // (`metadata:\n  author: acme`) becomes `""`, and a `description: |` block
+    // loses the trailing newline YAML preserves.
+    //
+    // `splitSkillMarkdown` is the same function the host re-parses with, which
+    // is the only parser this comparison can be correct against.
+    const parsed = splitSkillMarkdown(markdown).frontmatter;
+    if (parsed) skill.frontmatter = parsed;
   });
 }
 
@@ -559,7 +567,11 @@ async function fetchCurrentSepSkillBody(
     skill.declaredPageCount = pageResources.length;
   }
 
-  const markdownCall = await callJsonRpc(options, id + 1, "resources/read", {
+  // A SEPARATE id space, not `id + 1`. Callers allocate `200 + index` for the
+  // `skills/get`, so `id + 1` made skill N's read collide with skill N+1's
+  // get — breaking `callJsonRpc`'s stated invariant that ids increment across
+  // a run, and tripping any server that rejects a reused request id.
+  const markdownCall = await callJsonRpc(options, id + 1000, "resources/read", {
     uri,
   });
   if (!markdownCall.document) {

--- a/sdk/src/openai-readiness/discovery.ts
+++ b/sdk/src/openai-readiness/discovery.ts
@@ -36,7 +36,7 @@ import {
   type DirectoryRedirectHop,
   type PrmDiscoveryResult,
 } from "../directory-readiness/discovery.js";
-import { sha256HexOfText } from "../mcp-client-manager/skills-integrity.js";
+import { sha256HexOfBytes } from "../mcp-client-manager/skills-integrity.js";
 import { parseYamlLite, splitFrontmatter } from "../plugin-bundle/skill.js";
 import {
   OPENAI_DOMAIN_VERIFICATION_PATH,
@@ -323,12 +323,17 @@ export async function fetchOpenAIDomainVerification(
 
 /** One skill the server advertises for import, as the scan saw it. */
 export interface OpenAIImportedSkillEvidence {
+  /** The skill's frontmatter name, when the server supplies one. */
   name?: string;
   description?: string;
   /** The digest the listing declares for the skill's markdown. */
   declaredDigest?: string;
   /** The resource the skill's markdown is served from. */
   resourceUri?: string;
+  /** The frontmatter object advertised by a current SEP-2640 listing. */
+  declaredFrontmatter?: Record<string, unknown>;
+  /** The complete resource manifest advertised by a current SEP-2640 listing. */
+  declaredResources?: OpenAIImportedSkillResourceEvidence[];
   /** Bytes of the markdown actually fetched. */
   markdownBytes?: number;
   /** SHA-256 of the markdown actually fetched, when it was fetched. */
@@ -356,6 +361,13 @@ export interface OpenAIImportedSkillEvidence {
   /** Markdown plus every page. Absent when any page could not be sized. */
   totalBytes?: number;
   fetchError?: string;
+}
+
+/** One supporting resource from a current SEP-2640 skill manifest. */
+export interface OpenAIImportedSkillResourceEvidence {
+  uri: string;
+  declaredDigest?: string;
+  declaredSize?: number;
 }
 
 export interface OpenAISkillsEvidence {
@@ -442,46 +454,197 @@ async function callJsonRpc(
   };
 }
 
+/** The content returned by one standard `resources/read` response. */
+interface ReadResourceContent {
+  bytes: Uint8Array;
+  text?: string;
+}
+
+function parseDeclaredResources(
+  value: unknown
+): OpenAIImportedSkillResourceEvidence[] | undefined {
+  if (!Array.isArray(value)) return undefined;
+  const resources: OpenAIImportedSkillResourceEvidence[] = [];
+  for (const candidate of value) {
+    const resource = asRecord(candidate);
+    const uri = resource && asString(resource.uri);
+    if (!uri) continue;
+    const declaredSize =
+      typeof resource.size === "number" &&
+      Number.isInteger(resource.size) &&
+      resource.size >= 0
+        ? resource.size
+        : undefined;
+    resources.push({
+      uri,
+      declaredDigest: asString(resource.digest),
+      declaredSize,
+    });
+  }
+  return resources;
+}
+
+function decodeBase64(value: string): Uint8Array | undefined {
+  try {
+    const binary = atob(value);
+    return Uint8Array.from(binary, (character) => character.charCodeAt(0));
+  } catch {
+    return undefined;
+  }
+}
+
+function readResourceContent(
+  document: Record<string, unknown>,
+  uri: string
+): ReadResourceContent | undefined {
+  const result = asRecord(document.result);
+  const contents =
+    result && Array.isArray(result.contents) ? result.contents : [];
+  const content = contents
+    .map((candidate) => asRecord(candidate))
+    .find((candidate) => candidate && asString(candidate.uri) === uri);
+  if (!content) return undefined;
+
+  const text = asString(content.text);
+  if (text !== undefined) {
+    return { bytes: new TextEncoder().encode(text), text };
+  }
+  const blob = asString(content.blob);
+  const bytes = blob === undefined ? undefined : decodeBase64(blob);
+  return bytes ? { bytes } : undefined;
+}
+
+function parseFetchedMarkdown(
+  skill: OpenAIImportedSkillEvidence,
+  content: ReadResourceContent
+): string {
+  const markdown = content.text ?? new TextDecoder().decode(content.bytes);
+  skill.markdownBytes = content.bytes.byteLength;
+  return markdown;
+}
+
+function recordFetchedMarkdown(
+  skill: OpenAIImportedSkillEvidence,
+  content: ReadResourceContent
+): Promise<void> {
+  const markdown = parseFetchedMarkdown(skill, content);
+  return sha256HexOfBytes(content.bytes).then((digest) => {
+    skill.observedDigest = digest;
+    const split = splitFrontmatter(markdown);
+    if (split) {
+      const parsed = parseYamlLite(split.frontmatter);
+      // `tooDeep` is an ARRAY of paths, so an empty array is the successful parse.
+      if (parsed.tooDeep.length === 0) skill.frontmatter = parsed.data;
+    }
+  });
+}
+
+async function fetchCurrentSepSkillBody(
+  options: OpenAIDiscoveryOptions,
+  id: number,
+  skill: OpenAIImportedSkillEvidence,
+  entry: Record<string, unknown>
+): Promise<void> {
+  const uri = skill.resourceUri;
+  if (!uri) {
+    skill.fetchError = "the SEP-2640 listing entry declared no skill URI";
+    return;
+  }
+
+  const resources =
+    parseDeclaredResources(entry.resources) ?? skill.declaredResources;
+  if (resources) {
+    skill.declaredResources = resources;
+    const pageResources = resources.filter((resource) => resource.uri !== uri);
+    skill.declaredPageCount = pageResources.length;
+  }
+
+  const markdownCall = await callJsonRpc(options, id + 1, "resources/read", {
+    uri,
+  });
+  if (!markdownCall.document) {
+    skill.fetchError =
+      markdownCall.transportError ??
+      (markdownCall.status !== undefined
+        ? `resources/read answered ${markdownCall.status} with no readable JSON body`
+        : "resources/read returned no result");
+    return;
+  }
+  if (asRecord(markdownCall.document.error)) {
+    skill.fetchError =
+      asString(asRecord(markdownCall.document.error)?.message) ??
+      "resources/read returned an error";
+    return;
+  }
+  const markdownContent = readResourceContent(markdownCall.document, uri);
+  if (!markdownContent) {
+    skill.fetchError = "resources/read returned no readable SKILL.md content";
+    return;
+  }
+  await recordFetchedMarkdown(skill, markdownContent);
+  const markdownBytes = skill.markdownBytes;
+  if (markdownBytes === undefined) {
+    skill.fetchError = "resources/read returned no measurable SKILL.md content";
+    return;
+  }
+
+  const pageResources = (resources ?? []).filter(
+    (resource) => resource.uri !== uri
+  );
+  const pages: { uri: string; bytes: number }[] = [];
+  let unmeasuredPages = Math.max(
+    0,
+    pageResources.length - OPENAI_MCP_SKILL_LIMITS.maxPagesPerSkill
+  );
+
+  for (const resource of pageResources.slice(
+    0,
+    OPENAI_MCP_SKILL_LIMITS.maxPagesPerSkill
+  )) {
+    // SEP-2640 requires hosts to retrieve supporting files lazily. Their
+    // manifest sizes are enough for the readiness cap checks, so do not read
+    // every reference/template/script merely because it was listed.
+    const page = { uri: resource.uri, bytes: resource.declaredSize ?? 0 };
+    pages.push(page);
+    if (resource.declaredSize === undefined) unmeasuredPages += 1;
+  }
+
+  if (pages.length > 0) skill.pages = pages;
+  if (unmeasuredPages > 0) skill.unmeasuredPages = unmeasuredPages;
+  skill.totalBytes =
+    unmeasuredPages > 0
+      ? undefined
+      : markdownBytes + pages.reduce((sum, page) => sum + page.bytes, 0);
+}
+
 /**
- * Read ONE skill's body with `skills/get`.
+ * Read ONE skill's body.
  *
- * WHY THE LISTING IS NOT ENOUGH. `skills/list` returns what the server SAYS
- * about each skill — its name, its description, the digest it claims for its
- * markdown. Three of this lane's checks are about whether those claims are
- * true: that the declared digest matches the bytes actually served, that the
- * markdown is within its size limit, that the frontmatter agrees with the
- * listing. None of them can be answered from the listing alone, and a run that
- * never fetched a body would report all three as `not-evaluated` forever —
- * three checks that exist and never fire.
- *
- * TOLERANT ABOUT SPELLING, deliberately. The skills extension is young and
- * servers in the wild spell the body field `content`, `markdown` or `text`,
- * and the page list `pages` or `resources`. Reading whichever is present costs
- * nothing; insisting on one would report a working server as unreadable. What
- * this does NOT do is guess: a response with no body field at all records a
- * `fetchError` and leaves the derived fields absent, so the checks above it
- * stay `not-evaluated` rather than grading a body that was never returned.
+ * Current SEP-2640 servers return metadata from `skills/get` and content from
+ * the standard `resources/read` method. The legacy branch remains tolerant of
+ * the pre-draft `{name, content}` shape so existing readiness evidence can be
+ * replayed while servers migrate.
  */
 async function fetchImportedSkillBody(
   options: OpenAIDiscoveryOptions,
   id: number,
-  skill: OpenAIImportedSkillEvidence,
+  skill: OpenAIImportedSkillEvidence
 ): Promise<void> {
+  const uri = skill.resourceUri;
   const name = skill.name;
-  if (!name) {
-    skill.fetchError = "the listing entry declared no name to fetch by";
+  if (!uri && !name) {
+    skill.fetchError =
+      "the listing entry declared neither a skill URI nor name";
     return;
   }
 
-  const call = await callJsonRpc(options, id, OPENAI_MCP_SKILLS_METHODS.get, {
-    name,
-  });
+  const call = await callJsonRpc(
+    options,
+    id,
+    OPENAI_MCP_SKILLS_METHODS.get,
+    uri ? { uri } : { name }
+  );
   const document = call.document;
-
-  // The transport's own failure, named. Every check that reads a derived field
-  // treats a skill carrying `fetchError` as unfetched, so the text here only
-  // ever has to explain the gap to a human — but "skills/get returned no
-  // result" explains the wrong gap when what happened was a timeout.
   if (!document) {
     skill.fetchError =
       call.transportError ??
@@ -490,7 +653,6 @@ async function fetchImportedSkillBody(
         : "skills/get returned no result");
     return;
   }
-
   const error = asRecord(document.error);
   if (error) {
     skill.fetchError =
@@ -504,92 +666,72 @@ async function fetchImportedSkillBody(
   }
 
   const body = asRecord(result.skill) ?? result;
+  // SEP-2640's entry has a URI plus frontmatter/resources metadata and no
+  // inline body. A conforming host reads the actual bytes through resources/read.
+  if (
+    uri &&
+    asString(body.uri) === uri &&
+    ("frontmatter" in body || "resources" in body)
+  ) {
+    await fetchCurrentSepSkillBody(options, id, skill, body);
+    return;
+  }
+
+  // Legacy response compatibility: older readiness fixtures embedded markdown
+  // directly in skills/get and called supporting files "pages".
   const markdown =
     asString(body.content) ?? asString(body.markdown) ?? asString(body.text);
   if (markdown === undefined) {
     skill.fetchError = "skills/get returned no markdown body";
     return;
   }
-
-  // MEASURED IN BYTES, not characters. The limit this feeds is a byte limit,
-  // and a skill whose markdown is mostly non-ASCII would otherwise be measured
-  // as comfortably inside a limit it exceeds.
-  const encoder = new TextEncoder();
-  const markdownBytes = encoder.encode(markdown).length;
-  skill.markdownBytes = markdownBytes;
-  skill.observedDigest = await sha256HexOfText(markdown);
-
-  const split = splitFrontmatter(markdown);
-  if (split) {
-    const parsed = parseYamlLite(split.frontmatter);
-    // `tooDeep` is an ARRAY of the paths that nested too far, so its emptiness
-    // is the thing to test — the array itself is always truthy.
-    if (parsed.tooDeep.length === 0) skill.frontmatter = parsed.data;
+  await recordFetchedMarkdown(skill, {
+    bytes: new TextEncoder().encode(markdown),
+    text: markdown,
+  });
+  const markdownBytes = skill.markdownBytes;
+  if (markdownBytes === undefined) {
+    skill.fetchError = "skills/get returned no measurable markdown body";
+    return;
   }
 
   const listed = Array.isArray(body.pages)
     ? body.pages
     : Array.isArray(body.resources)
-      ? body.resources
-      : [];
+    ? body.resources
+    : [];
   const pages: { uri: string; bytes: number }[] = [];
   let unmeasuredPages = 0;
-
-  // THE COUNT BEFORE THE CAP. The loop below reads at most
-  // `maxPagesPerSkill` pages, which means `pages.length` can never exceed the
-  // cap — so the check that grades "this skill ships too many pages" could
-  // never fire from wire evidence, however many the server declared. Recording
-  // the declared count is what lets that check see the number it is about.
   const declaredPageCount = listed.length;
   if (declaredPageCount > 0) skill.declaredPageCount = declaredPageCount;
-
   for (const entry of listed.slice(
     0,
-    OPENAI_MCP_SKILL_LIMITS.maxPagesPerSkill,
+    OPENAI_MCP_SKILL_LIMITS.maxPagesPerSkill
   )) {
     const page = asRecord(entry);
     if (!page) continue;
-    const uri = asString(page.uri) ?? asString(page.resourceUri);
+    const pageUri = asString(page.uri) ?? asString(page.resourceUri);
     const text =
       asString(page.content) ?? asString(page.markdown) ?? asString(page.text);
-    if (!uri) continue;
-
-    // A SERVED page is measured. A page that only DECLARES its size is taken
-    // at the server's word, and only when that word is a real byte count:
-    // `typeof x === "number"` admits `NaN`, `Infinity` and negatives, all of
-    // which come straight off the submitted server's own response. `NaN` is
-    // the dangerous one — it propagates into the total, and a `NaN` total
-    // compares `false` against every limit, so the size check this fetch
-    // exists to feed would report a pass having measured nothing.
+    if (!pageUri) continue;
     let bytes: number | undefined;
-    if (text !== undefined) {
-      bytes = encoder.encode(text).length;
-    } else if (
+    if (text !== undefined) bytes = new TextEncoder().encode(text).length;
+    else if (
       typeof page.bytes === "number" &&
       Number.isInteger(page.bytes) &&
       page.bytes >= 0
     ) {
       bytes = page.bytes;
     }
-
     if (bytes === undefined) unmeasuredPages += 1;
-    pages.push({ uri, bytes: bytes ?? 0 });
+    pages.push({ uri: pageUri, bytes: bytes ?? 0 });
   }
-
-  // The pages past the cap are unmeasured in the same sense as a page with no
-  // readable size: nobody read them, and a total that omits them silently is
-  // below the real one.
   if (declaredPageCount > OPENAI_MCP_SKILL_LIMITS.maxPagesPerSkill) {
     unmeasuredPages +=
       declaredPageCount - OPENAI_MCP_SKILL_LIMITS.maxPagesPerSkill;
   }
   if (pages.length > 0) skill.pages = pages;
   if (unmeasuredPages > 0) skill.unmeasuredPages = unmeasuredPages;
-
-  // ABSENT rather than understated. A total that silently omits the pages
-  // nobody could size is a number below the real one, and the check that reads
-  // it would pass a skill that is over its limit. Absence is what the check
-  // already knows how to report.
   skill.totalBytes =
     unmeasuredPages > 0
       ? undefined
@@ -608,7 +750,7 @@ async function fetchImportedSkillBody(
  */
 export async function discoverOpenAIImportedSkills(
   options: OpenAIDiscoveryOptions,
-  now: () => Date = () => new Date(),
+  now: () => Date = () => new Date()
 ): Promise<OpenAISkillsEvidence> {
   const skills: OpenAIImportedSkillEvidence[] = [];
   let cursor: string | undefined;
@@ -623,7 +765,7 @@ export async function discoverOpenAIImportedSkills(
       options,
       100 + page,
       OPENAI_MCP_SKILLS_METHODS.list,
-      cursor ? { cursor } : {},
+      cursor ? { cursor } : {}
     );
     const document = call.document;
     pagesWalked += 1;
@@ -659,11 +801,38 @@ export async function discoverOpenAIImportedSkills(
     for (const entry of listed) {
       const skill = asRecord(entry);
       if (!skill) continue;
+
+      // Current SEP-2640 entries are identified by URI and carry the complete
+      // frontmatter plus a manifest of individually readable resources.
+      const uri = asString(skill.uri);
+      const frontmatter = asRecord(skill.frontmatter);
+      if (uri && frontmatter) {
+        const declaredResources = parseDeclaredResources(skill.resources);
+        const ownResource = declaredResources?.find(
+          (resource) => resource.uri === uri
+        );
+        const pageCount = declaredResources
+          ? declaredResources.filter((resource) => resource.uri !== uri).length
+          : undefined;
+        skills.push({
+          name: asString(frontmatter.name),
+          description: asString(frontmatter.description),
+          declaredFrontmatter: frontmatter,
+          declaredDigest: ownResource?.declaredDigest,
+          resourceUri: uri,
+          declaredResources,
+          declaredPageCount: pageCount,
+        });
+        continue;
+      }
+
+      // Keep accepting the pre-draft shape for already captured evidence and
+      // servers that have not migrated yet.
       skills.push({
         name: asString(skill.name),
         description: asString(skill.description),
         declaredDigest:
-          asString(skill.digest) ?? asString(skill.sha256) ?? undefined,
+          asString(skill.digest) ?? asString(skill.sha256),
         resourceUri: asString(skill.resourceUri) ?? asString(skill.uri),
       });
     }
@@ -681,7 +850,7 @@ export async function discoverOpenAIImportedSkills(
   // nothing reads as graded that was not fetched.
   const bodiesToFetch = Math.min(
     skills.length,
-    OPENAI_MCP_SKILL_LIMITS.maxSkills + 1,
+    OPENAI_MCP_SKILL_LIMITS.maxSkills + 1
   );
   for (let index = 0; index < bodiesToFetch; index += 1) {
     await fetchImportedSkillBody(options, 200 + index, skills[index]);

--- a/sdk/src/openai-readiness/profile.ts
+++ b/sdk/src/openai-readiness/profile.ts
@@ -140,7 +140,7 @@ export const OPENAI_BRAND_COLOR_CONTRAST = {
 export const OPENAI_MCP_SKILL_LIMITS = {
   /** One skill's `SKILL.md` body. */
   maxSkillMarkdownBytes: 256 * 1024,
-  /** One supporting page fetched via `skills/get`. */
+  /** One supporting resource fetched via `resources/read`. */
   maxPageBytes: 1024 * 1024,
   /** One skill's total footprint, its pages included. */
   maxSkillTotalBytes: 5 * 1024 * 1024,

--- a/sdk/tests/fixtures/stage-analytics-golden.json
+++ b/sdk/tests/fixtures/stage-analytics-golden.json
@@ -11,7 +11,7 @@
   "runCompletedAt": 1700000100000,
   "sourceIterationCount": 7,
   "sourceMaxUpdatedAt": 1700000090000,
-  "stageAnalyzerVersion": 4,
+  "stageAnalyzerVersion": 5,
   "measurementsSchemaVersion": 1,
   "materializationState": "provisional",
   "createdAt": 1700000150000,

--- a/sdk/tests/openai-readiness/skills-discovery.test.ts
+++ b/sdk/tests/openai-readiness/skills-discovery.test.ts
@@ -21,6 +21,7 @@ import type { AddressInfo } from "node:net";
 import { afterEach, describe, expect, it } from "vitest";
 
 import { discoverOpenAIImportedSkills } from "../../src/openai-readiness/discovery.js";
+import { sha256HexOfText } from "../../src/mcp-client-manager/skills-integrity.js";
 
 const servers: http.Server[] = [];
 
@@ -31,14 +32,14 @@ afterEach(async () => {
         new Promise<void>((resolve) => {
           server.closeAllConnections?.();
           server.close(() => resolve());
-        }),
-    ),
+        })
+    )
   );
 });
 
 /** Serve one JSON-RPC responder, returning the URL and the methods it saw. */
 async function start(
-  respond: (method: string, params: Record<string, unknown>) => unknown,
+  respond: (method: string, params: Record<string, unknown>) => unknown
 ): Promise<{ url: string; calls: string[] }> {
   const calls: string[] = [];
   const server = http.createServer((req, res) => {
@@ -60,8 +61,8 @@ async function start(
         JSON.stringify(
           answer && "error" in answer
             ? { jsonrpc: "2.0", id: request.id, error: answer.error }
-            : { jsonrpc: "2.0", id: request.id, result: answer },
-        ),
+            : { jsonrpc: "2.0", id: request.id, result: answer }
+        )
       );
     });
   });
@@ -81,6 +82,69 @@ const SKILL_MARKDOWN = [
 ].join("\n");
 
 describe("discoverOpenAIImportedSkills", () => {
+  it("reads current SEP-2640 entries by URI and fetches bytes via resources/read", async () => {
+    const skillUri = "skill://forecast/SKILL.md";
+    const pageUri = "skill://forecast/references/details.md";
+    const page = "Use the city name exactly as entered.";
+    const entry = {
+      uri: skillUri,
+      frontmatter: {
+        name: "forecast",
+        description: "Look up a forecast for any city",
+      },
+      resources: [
+        {
+          uri: skillUri,
+          digest: `sha256:${await sha256HexOfText(SKILL_MARKDOWN)}`,
+          size: new TextEncoder().encode(SKILL_MARKDOWN).length,
+        },
+        {
+          uri: pageUri,
+          digest: `sha256:${await sha256HexOfText(page)}`,
+          size: new TextEncoder().encode(page).length,
+        },
+      ],
+    };
+    const calls: { method: string; params: Record<string, unknown> }[] = [];
+    const { url } = await start((method, params) => {
+      calls.push({ method, params });
+      if (method === "skills/list") return { skills: [entry] };
+      if (method === "skills/get") {
+        return { resultType: "complete", skill: entry };
+      }
+      if (method === "resources/read" && params.uri === skillUri) {
+        return { contents: [{ uri: skillUri, text: SKILL_MARKDOWN }] };
+      }
+      if (method === "resources/read" && params.uri === pageUri) {
+        return { contents: [{ uri: pageUri, text: page }] };
+      }
+      return { error: { code: -32602, message: "unknown URI" } };
+    });
+
+    const evidence = await discoverOpenAIImportedSkills({
+      enteredUrl: url,
+      fetchFn: fetch,
+    });
+
+    expect(calls.map((call) => call.method)).toEqual([
+      "skills/list",
+      "skills/get",
+      "resources/read",
+    ]);
+    expect(calls[1]?.params).toEqual({ uri: skillUri });
+    expect(calls[2]?.params).toEqual({ uri: skillUri });
+    expect(evidence.skills[0]).toMatchObject({
+      name: "forecast",
+      resourceUri: skillUri,
+      declaredDigest: `sha256:${await sha256HexOfText(SKILL_MARKDOWN)}`,
+      markdownBytes: new TextEncoder().encode(SKILL_MARKDOWN).length,
+      observedDigest: await sha256HexOfText(SKILL_MARKDOWN),
+      declaredPageCount: 1,
+      pages: [{ uri: pageUri, bytes: new TextEncoder().encode(page).length }],
+    });
+    expect(evidence.skills[0]?.fetchError).toBeUndefined();
+  });
+
   it("fetches each skill's body, not just the listing", async () => {
     const { url, calls } = await start((method) =>
       method === "skills/list"
@@ -93,7 +157,7 @@ describe("discoverOpenAIImportedSkills", () => {
               },
             ],
           }
-        : { skill: { name: "forecast", content: SKILL_MARKDOWN } },
+        : { skill: { name: "forecast", content: SKILL_MARKDOWN } }
     );
 
     const evidence = await discoverOpenAIImportedSkills({
@@ -105,7 +169,7 @@ describe("discoverOpenAIImportedSkills", () => {
     const [skill] = evidence.skills;
     // The three facts only a fetched body can establish.
     expect(skill.markdownBytes).toBe(
-      new TextEncoder().encode(SKILL_MARKDOWN).length,
+      new TextEncoder().encode(SKILL_MARKDOWN).length
     );
     expect(skill.observedDigest).toMatch(/^[0-9a-f]{64}$/);
     expect(skill.frontmatter).toMatchObject({
@@ -120,7 +184,7 @@ describe("discoverOpenAIImportedSkills", () => {
     const { url } = await start((method) =>
       method === "skills/list"
         ? { skills: [{ name: "forecast", digest: "not-the-real-digest" }] }
-        : { skill: { content: SKILL_MARKDOWN } },
+        : { skill: { content: SKILL_MARKDOWN } }
     );
     const [skill] = (
       await discoverOpenAIImportedSkills({ enteredUrl: url, fetchFn: fetch })
@@ -135,7 +199,7 @@ describe("discoverOpenAIImportedSkills", () => {
     const { url } = await start((method) =>
       method === "skills/list"
         ? { skills: [{ name: "forecast" }] }
-        : { skill: { name: "forecast" } },
+        : { skill: { name: "forecast" } }
     );
     const [skill] = (
       await discoverOpenAIImportedSkills({ enteredUrl: url, fetchFn: fetch })
@@ -156,7 +220,7 @@ describe("discoverOpenAIImportedSkills", () => {
               content: SKILL_MARKDOWN,
               pages: [{ uri: "skill://forecast/detail", content: page }],
             },
-          },
+          }
     );
     const [skill] = (
       await discoverOpenAIImportedSkills({ enteredUrl: url, fetchFn: fetch })
@@ -166,7 +230,7 @@ describe("discoverOpenAIImportedSkills", () => {
       { uri: "skill://forecast/detail", bytes: encoder.encode(page).length },
     ]);
     expect(skill.totalBytes).toBe(
-      encoder.encode(SKILL_MARKDOWN).length + encoder.encode(page).length,
+      encoder.encode(SKILL_MARKDOWN).length + encoder.encode(page).length
     );
   });
 
@@ -191,7 +255,7 @@ describe("discoverOpenAIImportedSkills", () => {
                 content: SKILL_MARKDOWN,
                 pages: [{ uri: "skill://forecast/detail", bytes: declared }],
               },
-            },
+            }
       );
       const [skill] = (
         await discoverOpenAIImportedSkills({ enteredUrl: url, fetchFn: fetch })
@@ -213,14 +277,14 @@ describe("discoverOpenAIImportedSkills", () => {
               content: SKILL_MARKDOWN,
               pages: [{ uri: "skill://forecast/detail", bytes: 4096 }],
             },
-          },
+          }
     );
     const [skill] = (
       await discoverOpenAIImportedSkills({ enteredUrl: url, fetchFn: fetch })
     ).skills;
     expect(skill.unmeasuredPages).toBeUndefined();
     expect(skill.totalBytes).toBe(
-      new TextEncoder().encode(SKILL_MARKDOWN).length + 4096,
+      new TextEncoder().encode(SKILL_MARKDOWN).length + 4096
     );
   });
 
@@ -240,7 +304,7 @@ describe("discoverOpenAIImportedSkills", () => {
                 content: "detail",
               })),
             },
-          },
+          }
     );
     const [skill] = (
       await discoverOpenAIImportedSkills({ enteredUrl: url, fetchFn: fetch })

--- a/sdk/tests/openai-readiness/skills-discovery.test.ts
+++ b/sdk/tests/openai-readiness/skills-discovery.test.ts
@@ -178,6 +178,61 @@ describe("discoverOpenAIImportedSkills", () => {
     });
   });
 
+  it("parses frontmatter with real YAML, so a conforming server is not flagged", async () => {
+    // REGRESSION: this ran through `parseYamlLite`, the deliberately-small
+    // subset parser, while `checkFrontmatterDrift` compares the union of keys
+    // on canonical JSON. Two divergences turned CONFORMING servers into
+    // FRONTMATTER_AGREES violations: a nested map became `""`, and a block
+    // scalar lost the trailing newline YAML preserves.
+    const markdown = [
+      "---",
+      "name: forecast",
+      "description: |",
+      "  Look up a forecast",
+      "  for any city.",
+      "metadata:",
+      "  author: acme",
+      "---",
+      "",
+      "Body.",
+    ].join("\n");
+    const skillUri = "skill://forecast/SKILL.md";
+    const declared = {
+      name: "forecast",
+      description: "Look up a forecast\nfor any city.\n",
+      metadata: { author: "acme" },
+    };
+    const entry = {
+      uri: skillUri,
+      frontmatter: declared,
+      resources: [
+        {
+          uri: skillUri,
+          digest: `sha256:${await sha256HexOfText(markdown)}`,
+          size: new TextEncoder().encode(markdown).length,
+        },
+      ],
+    };
+    const { url } = await start((method, params) => {
+      if (method === "skills/list") return { skills: [entry] };
+      if (method === "skills/get") return { skill: entry };
+      if (method === "resources/read" && params.uri === skillUri) {
+        return { contents: [{ uri: skillUri, text: markdown }] };
+      }
+      return {};
+    });
+
+    const evidence = await discoverOpenAIImportedSkills({
+      enteredUrl: url,
+      fetchFn: fetch,
+    });
+    const [skill] = evidence.skills;
+    // Structurally equal to what the server declared — which is exactly what
+    // the drift check compares, so it now agrees instead of reporting a
+    // violation the server did not commit.
+    expect(skill.frontmatter).toEqual(declared);
+  });
+
   it("records a digest that disagrees with the listing rather than trusting it", async () => {
     // The whole point of fetching: the declared digest is a claim, and this is
     // where it stops being taken at face value.

--- a/sdk/tests/skills-integrity.test.ts
+++ b/sdk/tests/skills-integrity.test.ts
@@ -20,9 +20,18 @@ import {
   splitAdvertisedFrontmatter,
   splitSkillMarkdown,
   verifyDigest,
+  verifySize,
   verifySkillMarkdown,
   isSkillIntegrityError,
+  checkManifestLimits,
+  enumeratedResources,
+  isDynamicResources,
 } from "../src/mcp-client-manager/skills-integrity.js";
+import {
+  DYNAMIC_SKILL_RESOURCES,
+  MAX_SKILL_RESOURCE_ENTRIES,
+  MAX_SKILL_TOTAL_BYTES,
+} from "../src/mcp-client-manager/skills-ext-types.js";
 import type { SkillEntry } from "../src/mcp-client-manager/skills-ext-types.js";
 
 describe("parseDigest", () => {
@@ -491,5 +500,194 @@ describe("canonicalJson", () => {
   it("sorts object keys but preserves array order", () => {
     expect(canonicalJson({ b: 1, a: 2 })).toBe('{"a":2,"b":1}');
     expect(canonicalJson([2, 1])).toBe("[2,1]");
+  });
+});
+
+describe("verifySize", () => {
+  it("passes and records that it checked when the length matches", () => {
+    expect(verifySize(12, { size: 12 })).toEqual({ ok: true, checked: true });
+  });
+
+  it("fails with both numbers when the length differs", () => {
+    // Off by ONE, which is what a truncated read actually looks like. A wildly
+    // wrong number would pass a sloppier implementation that only sniffs for
+    // implausible values.
+    expect(verifySize(11, { size: 12 })).toEqual({
+      ok: false,
+      expected: 12,
+      actual: 11,
+    });
+  });
+
+  it("passes but reports NOT checked when the server sent no size", () => {
+    // The draft requires `size`, but it is unratified and pre-`size` servers
+    // exist. Tolerating absence is deliberate; silently claiming to have
+    // checked would not be.
+    expect(verifySize(12, {})).toEqual({ ok: true, checked: false });
+  });
+
+  it("treats a zero-byte file as a real length, not a missing one", () => {
+    expect(verifySize(0, { size: 0 })).toEqual({ ok: true, checked: true });
+    expect(verifySize(1, { size: 0 })).toEqual({
+      ok: false,
+      expected: 0,
+      actual: 1,
+    });
+  });
+});
+
+describe("checkManifestLimits", () => {
+  const ref = (i: number, size?: number) => ({
+    uri: `skill://a/b/${i}`,
+    digest: "sha256:x",
+    ...(size === undefined ? {} : { size }),
+  });
+
+  it("accepts a manifest inside both limits and reports the budget", () => {
+    expect(checkManifestLimits([ref(0, 10), ref(1, 20)])).toEqual({
+      ok: true,
+      entryCount: 2,
+      totalBytes: 30,
+    });
+  });
+
+  it("rejects more entries than the draft requires hosts to support", () => {
+    const oversized = Array.from(
+      { length: MAX_SKILL_RESOURCE_ENTRIES + 1 },
+      (_, i) => ref(i, 1)
+    );
+    expect(checkManifestLimits(oversized)).toEqual({
+      ok: false,
+      reason: "too_many_resources",
+      expected: MAX_SKILL_RESOURCE_ENTRIES,
+      actual: MAX_SKILL_RESOURCE_ENTRIES + 1,
+    });
+  });
+
+  it("accepts exactly the limit — the draft says up to AND INCLUDING", () => {
+    const atLimit = Array.from({ length: MAX_SKILL_RESOURCE_ENTRIES }, (_, i) =>
+      ref(i, 1)
+    );
+    expect(checkManifestLimits(atLimit).ok).toBe(true);
+    expect(checkManifestLimits([ref(0, MAX_SKILL_TOTAL_BYTES)]).ok).toBe(true);
+  });
+
+  it("rejects a total over the per-skill byte budget", () => {
+    expect(checkManifestLimits([ref(0, MAX_SKILL_TOTAL_BYTES + 1)])).toEqual({
+      ok: false,
+      reason: "too_large",
+      expected: MAX_SKILL_TOTAL_BYTES,
+      actual: MAX_SKILL_TOTAL_BYTES + 1,
+    });
+  });
+
+  it("reports an UNDEFINED budget when any entry omitted its size", () => {
+    // A partial sum is not a budget. Reporting one would invite a caller to
+    // enforce a limit against a number that undercounts by an unknown amount.
+    expect(checkManifestLimits([ref(0, 10), ref(1)])).toEqual({
+      ok: true,
+      entryCount: 2,
+      totalBytes: undefined,
+    });
+  });
+
+  it("does not refuse an over-budget manifest it cannot fully measure", () => {
+    expect(
+      checkManifestLimits([ref(0, MAX_SKILL_TOTAL_BYTES), ref(1)]).ok
+    ).toBe(true);
+  });
+});
+
+describe("dynamic resources", () => {
+  it("separates a dynamic manifest from an absent one", () => {
+    expect(isDynamicResources({ resources: DYNAMIC_SKILL_RESOURCES })).toBe(
+      true
+    );
+    expect(isDynamicResources({ resources: [] })).toBe(false);
+    expect(isDynamicResources({})).toBe(false);
+  });
+
+  it("never lets a dynamic manifest be indexed as an array", () => {
+    expect(
+      enumeratedResources({ resources: DYNAMIC_SKILL_RESOURCES })
+    ).toBeUndefined();
+    expect(enumeratedResources({})).toBeUndefined();
+    expect(enumeratedResources({ resources: [] })).toEqual([]);
+  });
+
+  it("resolves no listed resource for a dynamic skill", () => {
+    // The read allowlist must be EMPTY, not "everything": a dynamic skill has
+    // no manifest, so no URI is authorized by it.
+    expect(
+      findListedResource(
+        { resources: DYNAMIC_SKILL_RESOURCES },
+        "skill://a/b/SKILL.md"
+      )
+    ).toBeUndefined();
+    expect(
+      isListedResource(
+        { resources: DYNAMIC_SKILL_RESOURCES },
+        "skill://a/b/SKILL.md"
+      )
+    ).toBe(false);
+  });
+});
+
+describe("verifySkillMarkdown size enforcement", () => {
+  const markdown = "---\nname: greeting\ndescription: Say hi\n---\n\nBody\n";
+  const uri = "skill://acme/greeting/SKILL.md";
+
+  async function entryWith(size: number | undefined) {
+    return {
+      uri,
+      frontmatter: { name: "greeting", description: "Say hi" },
+      resources: [
+        {
+          uri,
+          digest: `sha256:${await sha256HexOfText(markdown)}`,
+          ...(size === undefined ? {} : { size }),
+        },
+      ],
+    };
+  }
+
+  it("rejects a length mismatch even when the digest would pass", async () => {
+    // The digest here is CORRECT. Only the advertised size is wrong, which is
+    // exactly the case the draft calls out: a verification failure "whether or
+    // not the host goes on to compute the digest".
+    const entry = await entryWith(Buffer.byteLength(markdown, "utf8") + 1);
+    await expect(verifySkillMarkdown({ entry, markdown })).rejects.toSatisfy(
+      (error: unknown) =>
+        isSkillIntegrityError(error) && error.kind === "size_mismatch"
+    );
+  });
+
+  it("reports the advertised and actual lengths", async () => {
+    const actual = Buffer.byteLength(markdown, "utf8");
+    const entry = await entryWith(actual + 1);
+    await verifySkillMarkdown({ entry, markdown }).then(
+      () => {
+        throw new Error("expected a refusal");
+      },
+      (error: unknown) => {
+        if (!isSkillIntegrityError(error)) throw error;
+        expect(error.expected).toBe(String(actual + 1));
+        expect(error.actual).toBe(String(actual));
+      }
+    );
+  });
+
+  it("accepts a matching length", async () => {
+    const entry = await entryWith(Buffer.byteLength(markdown, "utf8"));
+    await expect(
+      verifySkillMarkdown({ entry, markdown })
+    ).resolves.toMatchObject({ body: "\nBody\n" });
+  });
+
+  it("still loads when the server omitted size entirely", async () => {
+    const entry = await entryWith(undefined);
+    await expect(
+      verifySkillMarkdown({ entry, markdown })
+    ).resolves.toMatchObject({ body: "\nBody\n" });
   });
 });

--- a/sdk/tests/skills-integrity.test.ts
+++ b/sdk/tests/skills-integrity.test.ts
@@ -591,10 +591,24 @@ describe("checkManifestLimits", () => {
     });
   });
 
-  it("does not refuse an over-budget manifest it cannot fully measure", () => {
-    expect(
-      checkManifestLimits([ref(0, MAX_SKILL_TOTAL_BYTES), ref(1)]).ok
-    ).toBe(true);
+  it("still refuses when the MEASURED bytes alone exceed the budget", () => {
+    // A partial sum is a floor. Requiring every entry to carry `size` before
+    // enforcing the total made the budget inert for the servers that are the
+    // norm today, and let one unmeasured entry among 512 switch it off.
+    const check = checkManifestLimits([
+      ref(0, MAX_SKILL_TOTAL_BYTES + 1),
+      ref(1),
+    ]);
+    expect(check.ok).toBe(false);
+    expect(check.ok === false && check.reason).toBe("too_large");
+  });
+
+  it("accepts a partial sum that is within the budget", () => {
+    // Under the limit, an unmeasured entry proves nothing either way, so the
+    // skill loads and the reported budget stays `undefined`.
+    const check = checkManifestLimits([ref(0, MAX_SKILL_TOTAL_BYTES), ref(1)]);
+    expect(check.ok).toBe(true);
+    expect(check.ok === true && check.totalBytes).toBeUndefined();
   });
 });
 

--- a/sdk/tests/skills-wire.integration.test.ts
+++ b/sdk/tests/skills-wire.integration.test.ts
@@ -4,7 +4,7 @@
  * — negotiation, capability declaration, `skills/list` drain, `skills/get`,
  * and `resources/read`-backed verification.
  *
- * PIN: modelcontextprotocol/docs @ d7490ec.
+ * PIN: modelcontextprotocol/modelcontextprotocol @ a3e147ca27 (branch `sep/skills-extension`, `seps/2640-skills-extension.md`).
  */
 
 import { afterEach, describe, expect, it } from "vitest";
@@ -18,6 +18,7 @@ import {
   MCP_SKILLS_EXTENSION_ID,
   withSkillsExtensionCapability,
   getDefaultClientCapabilities,
+  enumeratedResources,
   isListedResource,
   isMCPSkillsWireError,
   isSkillNotFoundError,
@@ -312,6 +313,74 @@ describe("integrity over the real wire", () => {
     await expect(
       verifySkillMarkdown({ entry, markdown })
     ).rejects.toMatchObject({ kind: "digest_mismatch" });
+  });
+
+  it("refuses a skill whose advertised size does not match the bytes served", async () => {
+    // The digest is correct here; only the length is wrong. This is the case
+    // the draft calls out as a verification failure in its own right.
+    const fixture = await serve({
+      misbehavior: { sizeMismatch: "fixture/greeting" },
+    });
+    const manager = await connect(fixture.url);
+    const entry = await manager.getServerSkill(
+      SERVER_ID,
+      fixture.uriFor("fixture/greeting")
+    );
+    const markdown = await fetchMarkdown(manager, entry.uri);
+    await expect(
+      verifySkillMarkdown({ entry, markdown })
+    ).rejects.toMatchObject({ kind: "size_mismatch" });
+  });
+
+  it("still verifies a server that predates the size field", async () => {
+    // `size` is REQUIRED by the draft, but the SEP is unratified and servers
+    // built against the earlier text omit it. Refusing them would make MCPJam
+    // incompatible with every implementation that exists today; the digest
+    // still carries the integrity guarantee.
+    const fixture = await serve({ misbehavior: { omitSizes: true } });
+    const manager = await connect(fixture.url);
+    const entry = await manager.getServerSkill(
+      SERVER_ID,
+      fixture.uriFor("fixture/greeting")
+    );
+    expect(
+      Array.isArray(entry.resources) ? entry.resources[0]?.size : "not-an-array"
+    ).toBeUndefined();
+    const markdown = await fetchMarkdown(manager, entry.uri);
+    const verified = await verifySkillMarkdown({ entry, markdown });
+    expect(verified.frontmatter.name).toBe("greeting");
+  });
+
+  it("PARSES a dynamic manifest instead of failing the whole listing", async () => {
+    // The regression this pins: `resources` used to be typed as an array
+    // only, so a conforming server answering `"dynamic"` produced an
+    // InvalidSkillsPayloadError — a wire error, for a form the draft defines.
+    // MCPJam still refuses to LOAD such a skill, but that refusal belongs to
+    // policy and must be able to name the skill it is refusing.
+    const fixture = await serve({ misbehavior: { dynamicResources: true } });
+    const manager = await connect(fixture.url);
+    const listed = await manager.listServerSkills(SERVER_ID);
+    expect(listed.skills.length).toBeGreaterThan(0);
+    for (const skill of listed.skills) {
+      expect(skill.resources).toBe("dynamic");
+    }
+    const entry = await manager.getServerSkill(
+      SERVER_ID,
+      fixture.uriFor("fixture/greeting")
+    );
+    expect(entry.resources).toBe("dynamic");
+  });
+
+  it("authorizes NO reads for a dynamic skill", async () => {
+    const fixture = await serve({ misbehavior: { dynamicResources: true } });
+    const manager = await connect(fixture.url);
+    const entry = await manager.getServerSkill(
+      SERVER_ID,
+      fixture.uriFor("fixture/greeting")
+    );
+    // "dynamic" must never be read as "every URI is allowed".
+    expect(isListedResource(entry, entry.uri)).toBe(false);
+    expect(enumeratedResources(entry)).toBeUndefined();
   });
 
   it("refuses a skill whose file frontmatter drifted from the listing", async () => {

--- a/sdk/tests/support/skills-fixture.ts
+++ b/sdk/tests/support/skills-fixture.ts
@@ -2,7 +2,7 @@
  * A raw `io.modelcontextprotocol/skills` (SEP-2640) fixture server, spoken
  * over Streamable HTTP on a real socket.
  *
- * PIN: modelcontextprotocol/docs @ d7490ec (`seps/2640-skills-extension.mdx`).
+ * PIN: modelcontextprotocol/modelcontextprotocol @ a3e147ca27 (branch `sep/skills-extension`, `seps/2640-skills-extension.md`).
  * Every wire shape below is copied from that commit — re-diff when re-syncing.
  *
  * Why hand-rolled JSON-RPC rather than `@modelcontextprotocol/server`:
@@ -96,6 +96,16 @@ export interface SkillsMisbehavior {
   repeatCursor?: boolean;
   /** Return a malformed entry (missing `uri`) in the listing. */
   malformedEntry?: boolean;
+  /**
+   * Advertise a `size` that does not match the bytes served, for the named
+   * skill root. Distinct from `digestMismatch`: the draft makes a length
+   * mismatch its own verification failure, catchable before hashing.
+   */
+  sizeMismatch?: string;
+  /** Advertise `"resources": "dynamic"` instead of an enumerated manifest. */
+  dynamicResources?: boolean;
+  /** Omit `size` from every manifest entry, as a pre-`size` server would. */
+  omitSizes?: boolean;
 }
 
 export interface SkillsFixtureOptions {
@@ -232,9 +242,27 @@ export async function startSkillsFixture(
     return sha256(text);
   }
 
+  /**
+   * The advertised `size` for some bytes, or `undefined` under `omitSizes`.
+   *
+   * A size-mismatch fixture advertises a length that is off by one rather than
+   * wildly wrong: an off-by-one is what a truncated read actually looks like,
+   * and it proves the host compares the number instead of sniffing for an
+   * obviously bogus one.
+   */
+  function sizeOf(text: string, skill: SkillFixtureSkill): number | undefined {
+    if (misbehavior.omitSizes) return undefined;
+    const actual = Buffer.byteLength(text, "utf8");
+    return misbehavior.sizeMismatch === skill.root ? actual + 1 : actual;
+  }
+
   function resourcesOf(
     skill: SkillFixtureSkill
-  ): Array<{ uri: string; digest: string }> | undefined {
+  ):
+    | Array<{ uri: string; digest: string; size?: number }>
+    | "dynamic"
+    | undefined {
+    if (misbehavior.dynamicResources) return "dynamic";
     if (skill.omitResources) return undefined;
     const markdown = renderMarkdown(skill);
     // A digest-mismatch fixture advertises the digest of DIFFERENT bytes; the
@@ -243,12 +271,31 @@ export async function startSkillsFixture(
       misbehavior.digestMismatch === skill.root
         ? `${markdown}\n<!-- tampered -->`
         : markdown;
+    const withSize = (
+      uri: string,
+      content: string
+    ): { uri: string; digest: string; size?: number } => {
+      const size = sizeOf(content, skill);
+      return {
+        uri,
+        digest: digestOf(content),
+        ...(size === undefined ? {} : { size }),
+      };
+    };
+    // The two tampering modes stay INDEPENDENT: the digest is taken from the
+    // possibly-tampered copy, the size from the bytes actually served. Sizing
+    // the tampered copy instead would make `digestMismatch` trip the size
+    // check first, and that test would then pass for the wrong reason.
+    const skillMdSize = sizeOf(markdown, skill);
     return [
-      { uri: uriFor(skill), digest: digestOf(advertisedMarkdown) },
-      ...(skill.files ?? []).map((file) => ({
-        uri: fileUriFor(skill, file.path),
-        digest: digestOf(file.content),
-      })),
+      {
+        uri: uriFor(skill),
+        digest: digestOf(advertisedMarkdown),
+        ...(skillMdSize === undefined ? {} : { size: skillMdSize }),
+      },
+      ...(skill.files ?? []).map((file) =>
+        withSize(fileUriFor(skill, file.path), file.content)
+      ),
     ];
   }
 


### PR DESCRIPTION
Our SEP-2640 implementation was pinned to `modelcontextprotocol/docs @ d7490ec`. The draft has moved since, and three of its changes made the host **wrong** rather than merely out of date. Re-pinned to [`a3e147ca27`](https://github.com/modelcontextprotocol/modelcontextprotocol/blob/sep/skills-extension/seps/2640-skills-extension.md) on `sep/skills-extension`.

This is step −1 of serving our own skills over MCP: that plan uses our host as the test oracle, and an oracle pinned to a stale spec certifies the wrong thing.

## What was wrong

**`"resources": "dynamic"` crashed the parser.** The draft makes `resources` required and gives it two forms: an enumerated manifest, or the bare string `"dynamic"` for a skill generated per request. `skillEntrySchema` accepted only the array, so a conforming server answering `"dynamic"` produced an `InvalidSkillsPayloadError` — a wire error, for a form the spec defines, with no way for a user to tell a server bug from ours. It now parses, and MCPJam refuses to *load* it as stated policy (`dynamic_resources`), kept distinct from a server that omitted `resources` entirely (`no_resources`). Those are different server behaviours, and collapsing them tells a conforming author their skill is malformed.

**`size` was never checked.** Each manifest entry now carries the file's byte length, and the draft makes a length mismatch "a verification failure equivalent to a digest mismatch, whether or not the host goes on to compute the digest". `verifySize` runs **before** hashing — which is the point of the field: it catches a truncated or padded read without paying for a digest, and it lets a host budget a skill from the entry alone. It gets its own `size_mismatch` kind, because "this file was cut short" and "this file was tampered with" are different diagnoses.

**Our own caps refused conforming skills.** The draft sets per-skill limits of 512 entries and 16 MiB total and says hosts MUST support up to them. Our caps — 128 KiB for a SKILL.md, 2 MiB for a supporting file — were invented before the draft had any, and both sat *below* that floor, so a conforming 3 MiB SKILL.md was refused as `too_large`. That was our bug, not the server's. The limits are now the draft's, enforced from the manifest before the first byte is fetched.

## Deliberate divergence, flagged for review

**A server that omits `size` is tolerated, not refused.** The draft requires it, but the SEP is unratified and every implementation that exists today predates the field — refusing would buy conformance with an unpublished rule at the cost of working with real servers. `verifySize` reports `checked: false` rather than silently claiming to have verified. Worth revisiting at ratification.

## Not a spec change, but worth a look

A `z.union` reports `resources: Invalid input` and buries the real per-field diagnosis in nested alternatives, which defeats the reason these guards exist. `issuesOf` now descends into union alternatives and rebuilds the full path, so a missing digest still reads as `resources.0: digest: …`. Without this, the union would have been a quiet regression in error quality.

## Testing

- `sdk`: 111 skills tests pass (integrity, dispatch, over-the-wire). New cases for size enforcement, the limits at and past the boundary, a partially-measurable manifest, and that a dynamic manifest authorizes **no** reads rather than all of them.
- Fixture gains `sizeMismatch`, `dynamicResources`, and `omitSizes` modes. Digest-tampering and size-tampering stay independent, so `digestMismatch` can't start passing for the wrong reason.
- `mcpjam-inspector`: 39 tests pass. `server-skills.ts` gets its **first direct test** — it was previously covered only through the chat wrapper.
- Full SDK suite: 6785 pass. One unrelated failure, `tests/stage-analytics-golden.test.ts` (`stageAnalyzerVersion` 4 vs 5), **verified pre-existing** on a clean checkout of `origin/main` — a golden not regenerated when Lane D8 (#4380) bumped the version.
- Pre-existing lint in `skills-ext-guards.ts` (3 errors) left alone; also verified pre-existing on main.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches untrusted third-party skill verification, manifest allowlists, and chat injection limits across SDK and inspector; behavior changes could affect how server skills load or refuse, but changes are spec-aligned with broad test coverage.
> 
> **Overview**
> Re-pins Skills over MCP to the current **SEP-2640** draft and fixes host behavior that was **incorrect**, not just stale.
> 
> **Wire & SDK:** `resources` now parses as either a manifest array or **`"dynamic"`** (policy refusals `dynamic_resources` vs `no_resources`). Manifest entries may include optional **`size`**; **`verifySize`** runs before digest checks with a distinct **`size_mismatch`** refusal. Per-skill limits align with the draft (**512 entries / 16 MiB**), enforced pre-fetch via **`checkManifestLimits`**. Zod union validation errors are flattened so field paths stay readable.
> 
> **Inspector:** Catalog and load paths surface new unloadable reasons and optional `size` on resources. Verification uses the draft read ceiling; chat injection keeps a separate **128 KiB prompt cap** (`too_large_for_prompt`, refused not truncated). Manifest approval hashing uses **`enumeratedResources`** so `"dynamic"` cannot produce a bogus digest set.
> 
> **OpenAI readiness:** Discovery follows SEP-2640 (`skills/get` + **`resources/read`**, separate JSON-RPC ids), uses **`splitSkillMarkdown`** for frontmatter drift, and normalizes digest case for comparisons.
> 
> Tests and fixture modes cover size, limits, dynamic manifests, and direct **`server-skills`** policy tests.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c595889302692cf0a7f72c65aab648a17174eee8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Re-pins Skills over MCP to the current SEP-2640 draft and fixes the three behaviors the re-sync surfaced as wrong: `"resources": "dynamic"` crashed the parser, `size` was never checked, and our own caps refused conforming skills.

- Re-pinned from `modelcontextprotocol/docs @ d7490ec` to `modelcontextprotocol/modelcontextprotocol @ a3e147ca27`.
- `"resources": "dynamic"` now parses; MCPJam refuses to load it (`dynamic_resources`), kept distinct from a server omitting `resources` (`no_resources`).
- `verifySize` runs before hashing and reports its own `size_mismatch` refusal; a server omitting `size` is tolerated, not refused, since the SEP is unratified.
- Per-skill limits are now the draft's 512 entries / 16 MiB total, enforced from the manifest before the first fetch.
- An over-limit skill stays visible as `unloadable`, and unmeasured entries still count toward the byte total as a floor.
- The 16 MiB cap applies to verification only; chat injection keeps its own 128 KiB prompt cap, refused, never truncated.
- Zod union failures are flattened with parent paths rebuilt, so bad fields read as `resources.0.digest` rather than `resources: Invalid input`.
- Discovery uses `splitSkillMarkdown` for the frontmatter-drift check, normalizes digest case in the fallback, and `resources/read` uses a separate JSON-RPC id space.
- Regenerates the stage-analytics golden fixture for analyzer version 5 (a pre-existing main failure since #4380) and gives `server-skills.ts` its first direct test suite.

<sup>Written for commit c595889302692cf0a7f72c65aab648a17174eee8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/MCPJam/inspector/pull/4395?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

