### PR TITLE
Add a skill for driving MCPJam's hosted eval tools

### DIFF
--- a/docs/cli/overview.mdx
+++ b/docs/cli/overview.mdx
@@ -20,6 +20,12 @@ To convert existing promptfoo, pytest, Jest, or CSV tests, use the [MCP eval imp
 npx skills add mcpjam/inspector --skill mcpjam-eval-import
 ```
 
+To drive MCPJam's hosted eval tools — launch a run, poll it to a verdict, and triage a failure down to the step — use the [run MCPJam evals skill](https://github.com/MCPJam/inspector/tree/main/skills/run-mcpjam-evals). This one is about running suites that already exist, not writing them.
+
+```bash
+npx skills add mcpjam/inspector --skill run-mcpjam-evals
+```
+
 Once installed, your agent will know how and when to invoke `mcpjam` commands automatically.
 
 ## Install

--- a/skills/run-mcpjam-evals/SKILL.md
+++ b/skills/run-mcpjam-evals/SKILL.md
@@ -1,0 +1,69 @@
+---
+name: run-mcpjam-evals
+description: Drive MCPJam's hosted eval tools end to end — check what a run will cost and disclose, launch it, poll it to a verdict, and triage a failure down to the step that failed. Use when connected to MCPJam's MCP server and asked to run, re-run, investigate, or compare eval results, rather than to author eval files locally.
+---
+
+# run-mcpjam-evals
+
+You have MCPJam's hosted eval tools. This is the order to call them in, and the two places calling them wrong costs real money.
+
+**This skill is about running evals that already exist.** To *write* eval files, use `create-mcp-eval` (SDK tests) or `mcpjam-eval-import` (convert an existing corpus). To author suites through these tools instead, see `references/authoring.md`.
+
+## Reference map
+
+| You are about to… | Read |
+|---|---|
+| Work out why a run did not pass | `references/triage.md` |
+| Create a suite or add cases through the tools | `references/authoring.md` |
+
+## The loop
+
+```
+list_eval_suites → get_eval_run_disclosure → run_eval_suite → get_eval_run (poll)
+                                                                    ↓
+                                          list_eval_run_iterations → get_eval_run_steps
+                                                                    ↓
+                                                            compare_eval_run
+```
+
+**1. Orient.** `list_eval_suites` returns suites with latest-run summaries and pass-rate trends. With no `project` it uses the most recently updated accessible one — fine for a quick look, but pass `project` explicitly the moment you are about to change or spend anything, or you may act on a project the user did not mean.
+
+**2. Disclose before you spend.** `get_eval_run_disclosure` answers what a run does *before* it happens: which models it calls and where they route, which judges can fire, and what is captured or retained. Call it when a user has not run this suite before, when the suite has changed, or whenever they ask what a run will do. It is read-only and free.
+
+**3. Launch.** `run_eval_suite` is **asynchronous** — it returns a `runId` immediately and the work continues server-side.
+
+**4. Poll.** `get_eval_run` with `project` and `runId` until `status` is terminal: `completed`, `failed`, or `cancelled`. Anything else means still running; wait and ask again. Do not re-launch because a result is not ready.
+
+**5. Read the verdict.** On anything other than a pass, **start at `get_eval_run`'s `decisionSummary`** — it carries the verdict and `verdictSource`, which tells you what actually decided the outcome. Do not jump straight to iterations; you will read a lot of rows without knowing what you are looking for. `references/triage.md` is the decision tree from here.
+
+**6. Compare, when there is a baseline.** `compare_eval_run` with `baseRunId` (or `baseCommitSha`) classifies each case as `regressed`, `fixed`, `new_case`, `removed_case`, `changed`, `unchanged_passed`, or `unchanged_failed`. This is the tool that answers "did my change break anything", which a single run's pass rate cannot.
+
+## Money
+
+Two tools spend the organization's model budget. Both are marked `COSTS MONEY` in their descriptions, and neither is reversible once started.
+
+- **`run_eval_suite`** — every iteration of every case is a model call.
+- **`request_eval_run_judge`** — LLM-as-judge grading over a finished run.
+
+Rules:
+
+- **Confirm before the first spend in a conversation.** Say which suite, how many cases, and — if the user set `repetitions` or `iterations` — what that multiplies out to. "Run the evals?" is not a confirmation if the user has not been told it bills.
+- **Never call either in a loop, or to poll.** Polling is `get_eval_run`, which is free.
+- **Pass `idempotencyKey` when a launch might be retried.** A transport error is not proof the run did not start; retrying without the key can bill the same run twice.
+- **A failed run has already been paid for.** Re-running to "see if it passes this time" spends again and is rarely the right next step — triage first.
+
+## Polling without being a nuisance
+
+`get_eval_run` is free, but it is not free of latency, and a tight loop reads as a hung agent.
+
+- Wait between polls, and lengthen the wait as the run goes on. A suite with many cases takes minutes, not seconds.
+- Say what you are waiting for the first time; do not narrate every poll.
+- `list_eval_run_iterations` is **paginated** — pass the returned `nextCursor` back as `cursor` until it is absent. A first page is not the whole run, and treating it as one will make you report a pass rate that is not the run's.
+- To stop a run: `cancel_eval_run` with `project` and `runId`. It terminates in-flight work, so confirm first.
+
+## Getting the arguments right
+
+- **`project` is the first argument of every one of these tools.** Resolve it once, explicitly, and reuse it. A `runId` from one project is meaningless in another.
+- **`runId` comes from `run_eval_suite`'s result**, and from `list_eval_suites`' latest-run summaries for runs you did not start.
+- **`iterationId` comes from `list_eval_run_iterations`.** `get_eval_run_steps` needs both `runId` and `iterationId`; there is no way to guess one.
+- Read the tool description before passing an option this skill does not mention. `run_eval_suite` takes many (`environments`, `hosts`, `compose`, `matchOptions`, `minPassRate`, …) and each changes what the run means.

--- a/skills/run-mcpjam-evals/references/authoring.md
+++ b/skills/run-mcpjam-evals/references/authoring.md
@@ -1,0 +1,52 @@
+# Authoring suites and cases through the tools
+
+For writing eval files in a repo, use `create-mcp-eval` (`@mcpjam/sdk` tests) or `mcpjam-eval-import` (converting an existing corpus). This is the other path: creating and editing suites that live in an MCPJam project, through the hosted tools.
+
+## Creating a suite
+
+`create_eval_suite` takes `project`, `name`, `description`, `servers`, `model`, `provider`, and one or more `cases`. A suite is runnable the moment it exists, so decide two things before you call it:
+
+- **Which servers it runs against.** `servers` are the project's HTTP servers. If the suite should instead run against a pinned environment — resolved host config, closed server set, pinned plugin versions — attach one afterwards with `set_eval_suite_environments`, and note that it **replaces** whatever the suite had rather than adding to it.
+- **Which model is the default.** Cases can override with their own `models`, but the suite default is what most of them will use.
+
+## The shape of a case
+
+Every case is an ordered `steps` array, and the step kind is what distinguishes them:
+
+- **`prompt`** — a model turn. This is where non-determinism enters.
+- **`toolCall`** — a deterministic tool call, no model involved.
+- **`assert`** — the expectations, e.g. `toolCalledWith`, `widgetRendered`.
+
+Alongside `steps`, a case carries `expectedOutput`, `iterations`, `isNegative`, `scenario`, `models`, `matchOptions`, and `checks`.
+
+Two things worth getting right the first time:
+
+- **`iterations` multiplies cost.** Every iteration is a fresh model call. It is the right tool for measuring a flaky tool-selection case, and the wrong one for a deterministic `toolCall`-only case, which will produce the same answer N times at N times the price.
+- **`isNegative` inverts the meaning of success.** A negative case passes when the model does *not* call tools. Every suite should have at least one; without it a suite cannot distinguish "chose correctly" from "always calls something".
+
+## Adding cases
+
+- `create_eval_case` — one case.
+- `create_eval_cases` — the bulk form, and the right one for converting a repo's test files or importing a suite. One call instead of a round trip per case.
+
+`create_eval_cases` takes `duplicatePolicy` and `overrideReason`. Decide the policy deliberately: re-importing a corpus with the wrong one either silently doubles the suite or silently discards edits made since the last import.
+
+## Editing
+
+`update_eval_case` changes only the fields you pass — **except `steps`, which replaces the sequence wholesale.** There is no partial step edit. To change one step, read the case with `list_eval_cases`, modify the array, and send it back whole; sending only the changed step deletes the rest.
+
+## Generating cases
+
+`generate_eval_cases` AI-generates cases from the suite's server tools and persists them. It **spends the organization's credits**, and it connects the servers to discover their tools, so it is not a dry run in any sense.
+
+- Confirm before calling it, the same as `run_eval_suite`.
+- Pass `idempotencyKey` if the call might be retried — a transport error is not proof nothing was generated.
+- `caseMix`, `caseModels`, and `varyUserStyles` shape the output. Generated cases are a starting point to review, not a suite to run and report on unread.
+
+## Scheduling
+
+`set_eval_suite_schedule` turns on automatic runs and sets `intervalMinutes`. Every scheduled run bills like a manual one — an aggressive interval on a large suite is a standing charge, so say the multiplication out loud before enabling it. Disabling preserves the stored interval and environment pin, so it is reversible.
+
+## Before running what you just built
+
+`get_eval_suite` returns the suite's fully resolved settings — execution config, hosts, match options, checks, and the resolved LLM-as-judge block (enabled, model, autoRun, threshold). Resolved is the point: it shows what a run will actually use after defaults and environment pins are applied, which is not always what was passed in.

--- a/skills/run-mcpjam-evals/references/triage.md
+++ b/skills/run-mcpjam-evals/references/triage.md
@@ -1,0 +1,67 @@
+# Triaging a run that did not pass
+
+The order matters. Each step narrows what you are looking at by roughly an order of magnitude, and skipping one means reading the next level's rows without knowing which of them matter.
+
+## 1. `get_eval_run` — what decided this?
+
+Start here, always. The `decisionSummary` carries the verdict and **`verdictSource`**: what actually produced it. That single field redirects the whole investigation, because the causes are unrelated to each other:
+
+| `verdictSource` says | You are looking at | Go to |
+|---|---|---|
+| a pass-rate threshold | cases that failed on their assertions | §2 |
+| an LLM judge | grading, not assertions | §4 |
+| a gate or waiver | policy, not test results | §5 |
+| an error / infrastructure failure | the run never really executed | §6 |
+
+Reporting "the evals failed" without naming the source is the most common way to send someone debugging the wrong layer.
+
+## 2. `list_eval_run_iterations` — which cases, and how consistently?
+
+One row per iteration: pass/fail, expected vs actual tool calls, token usage, latency.
+
+**Paginated.** Pass `nextCursor` back as `cursor` until it comes back absent. A pass rate computed from page one is not the run's pass rate.
+
+What to look for, in order:
+
+- **A case that fails every iteration** is deterministic — a real disagreement between the case and the server. Go to §3.
+- **A case that fails some iterations** is non-determinism, and the case may be at fault rather than the server: an ambiguous prompt that lets the model pick either of two reasonable tools will fail intermittently forever. Prefer reporting the rate over declaring a bug.
+- **Expected vs actual tool calls** is usually the whole answer for a tool-selection eval. If the actual call is a *reasonable* response to the prompt, the case's expectation is the thing to question.
+- **Latency or token outliers** alongside failures often mean the model ran out of steps rather than chose wrong.
+
+## 3. `get_eval_run_steps` — which step, and what evidence?
+
+Needs `runId` **and** an `iterationId` from §2. Returns one row per authored step, in order, each with a status (`ok` / `fail` / `skipped` / `pending`), a reason, and evidence — screenshot and video URLs, widget tool calls.
+
+- **The first `fail` is the one to read.** Everything after it is downstream, and a cascade of failures usually has one cause.
+- **`skipped` after a `fail`** confirms the cascade; it is not additional information.
+- **`pending` on a terminal run** means the run ended before that step — look for a timeout or a cancellation, not a wrong answer.
+- Follow the evidence URLs before theorising. A screenshot settles in one look what a reason string can only describe.
+
+## 4. When a judge decided it
+
+`request_eval_run_judge` scores each case's final answer against its expected output. If the verdict came from grading:
+
+- The tool calls may all be correct and the run still fail — the disagreement is about the *answer*, not the behaviour.
+- Check the judge `threshold` and `model` before concluding the implementation is wrong. A threshold set for one model is not automatically right for another.
+- Re-running the judge **spends budget again**. Do it because a setting was wrong, not to see whether the score moves.
+
+## 5. When a gate or waiver decided it
+
+`get_eval_gate_waiver` explains a run whose verdict came from policy rather than results. A waived or gated run can show passing cases and still not pass, and vice versa. Say so explicitly — this is the case people most often misread as a broken test.
+
+## 6. When the run never really executed
+
+Infrastructure failures look like test failures in a summary and are nothing like them. Signals: every case failing identically, zero token usage, steps stuck `pending`, a `failed` status with no per-case detail.
+
+`get_eval_run` takes `diagnosticsCursor` and `diagnosticsLimit` for exactly this — page through the diagnostics rather than inferring from case results. Do not report a server bug on the strength of a run that never called a model.
+
+## 7. Was it a regression?
+
+`compare_eval_run` against `baseRunId` (or `baseCommitSha`) is what separates "this is broken" from "this was always broken":
+
+- **`regressed`** — the only status that means your change did it.
+- **`unchanged_failed`** — failing before and after. Real, but not new, and not what the person asking about their change wants triaged first.
+- **`new_case`** — a case that did not exist in the baseline. It cannot be a regression, whatever its result.
+- **`changed`** — the case itself was edited, so the two results are not comparable. Say so rather than counting it either way.
+
+Per-scorer pass-rate and mean deltas come back too; a small mean drop across many cases is a different problem from one case flipping, and they call for different responses.


### PR DESCRIPTION
**New bottom of the skills stack** — #4395 now bases on this.

## The gap

MCPJam's three existing eval skills (`create-mcp-eval`, `explore-to-sdk-evals`, `mcpjam-eval-import`) all teach the same thing: how to **write** eval files, with the SDK or the CLI. None covers **running** one.

An agent connected to MCPJam's MCP server has ~22 eval tools and no guidance on the order to call them in — which is exactly where the expensive mistakes are. `run_eval_suite` and `request_eval_run_judge` both bill the organization's model budget, and neither is reversible once started.

## What the skill says

Orient with `list_eval_suites` → disclose before spending with `get_eval_run_disclosure` → launch → poll `get_eval_run` to a terminal status → triage → `compare_eval_run`.

Three things it conveys that a tool description alone cannot, because each is about the **relationship** between tools:

- **Polling is free, launching is not.** `run_eval_suite` returns immediately and continues server-side, so the failure mode is an agent re-launching because a result isn't ready. The skill names the terminal statuses, explains that `idempotencyKey` is what makes a retry safe, and points out that a failed run has already been paid for — so re-running "to see if it passes" is rarely the next step.
- **Triage has an order.** `get_eval_run`'s `verdictSource` says whether a pass-rate threshold, an LLM judge, a policy gate, or an infrastructure failure decided the outcome. Those are four unrelated causes that send you to different places, and skipping it means reading iteration rows without knowing which ones matter. `references/triage.md` is that decision tree.
- **Pagination changes the answer.** `list_eval_run_iterations` is paginated, so a pass rate computed from page one is not the run's.

`references/authoring.md` covers creating suites and cases through the tools, including the two contracts that silently destroy work: `steps` replaces a case's sequence wholesale, and `set_eval_suite_environments` **replaces** the suite's environments rather than adding to them.

## Verification

Every tool name (19) and parameter name (32) in the skill was checked against `ALL_OPERATIONS` rather than written from memory — a skill full of plausible-but-wrong tool names is worse than no skill. It also passes `checkSkillIdentity` against its `skill://mcpjam/run-mcpjam-evals/SKILL.md` URI, which is the gate the generator in #4397 enforces at build time.

## Scope

This PR only adds the skill and its docs entry — installable today via `npx skills add mcpjam/inspector --skill run-mcpjam-evals`. Wiring it into the hosted server's served catalog is one line in `WORKER_SKILL_ROOTS`, and lives in #4397 where that catalog is defined.

Note it is **not** added to the CLI's catalog (#4398): it describes the hosted platform tools, which `mcpjam mcp` does not expose.

⚠️ This is the stack base, so it does get real CI. The three above it don't until their bases retarget to `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation and agent guidance only; no application runtime or API behavior changes in this diff.
> 
> **Overview**
> Adds a new **`run-mcpjam-evals`** agent skill that documents how to use MCPJam’s **hosted** eval MCP tools to run existing suites (disclose → launch → poll → triage → compare), separate from the skills that **author** eval files locally.
> 
> The main **`SKILL.md`** defines the tool call order, billing guardrails for `run_eval_suite` and `request_eval_run_judge`, polling and pagination rules, and when to use `idempotencyKey`. **`references/triage.md`** walks agents through `verdictSource` and step-level failure investigation; **`references/authoring.md`** covers optional suite/case creation via hosted tools, including destructive-update footguns (`steps` wholesale replace, `set_eval_suite_environments` replaces environments).
> 
> **`docs/cli/overview.mdx`** gains install instructions: `npx skills add mcpjam/inspector --skill run-mcpjam-evals`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 80eebdeca75d35ec60ac073a8a333beceba063c2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds the `run-mcpjam-evals` skill so agents connected to MCPJam's MCP server know the order to call its hosted eval tools. The three existing eval skills only cover writing eval files, never running them, which is where the expensive mistakes happen: `run_eval_suite` and `request_eval_run_judge` both bill the organization's model budget and are not reversible once started.

**Key guidance in the skill**
- Teaches the call order: list suites, get a cost disclosure before spending, launch, poll `get_eval_run` to a terminal status, triage, then `compare_eval_run`.
- Makes the cost boundaries explicit: polling is free, a failed run is already paid for, and `idempotencyKey` is what makes a retry safe.
- Triage routes by `verdictSource` — threshold, LLM judge, policy gate, or infra failure each send the investigation to a different place, and `references/triage.md` is that decision tree.
- `list_eval_run_iterations` is paginated, so a pass rate computed from page one is not the run's.
- `references/authoring.md` covers creating suites and cases through the tools, including two contracts that silently destroy work: `steps` replaces a case's sequence wholesale, and `set_eval_suite_environments` replaces a suite's environments rather than adding to them.

**Scope**
- Adds the skill and a docs entry; installable via `npx skills add mcpjam/inspector --skill run-mcpjam-evals`.
- Not added to the CLI's catalog since the skill describes hosted platform tools that `mcpjam mcp` does not expose.
- Every tool and parameter name in the skill was verified against `ALL_OPERATIONS` rather than written from memory.

<sup>Written for commit 80eebdeca75d35ec60ac073a8a333beceba063c2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/MCPJam/inspector/pull/4400?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

