### PR TITLE
agent surfaces: let a client config round-trip, and stop the CLI lying about a live turn

### DIFF
--- a/cli/src/commands/sessions.ts
+++ b/cli/src/commands/sessions.ts
@@ -283,7 +283,11 @@ export function registerSessionsCommands(program: Command): void {
         { min: 0, max: 16 }
       ),
       temperature: parseFloatOption(options.temperature),
-    })
+    }),
+    // A Playground turn runs a model, and often tools with it. The 30s program
+    // default expired mid-turn while the turn kept running and spending, which
+    // reads to the caller as "it failed" when it had not.
+    { defaultTimeoutMs: 300_000 }
   );
 
   bindOperation(

--- a/cli/src/lib/platform-command.ts
+++ b/cli/src/lib/platform-command.ts
@@ -185,7 +185,10 @@ export async function runPlatformOperation<TOutput>(
   const timeoutHandle = setTimeout(() => {
     controller.abort(
       new PlatformApiError(
-        `Request timed out after ${timeoutMs}ms`,
+        `Request timed out after ${timeoutMs}ms. Raise it with --timeout <ms>. ` +
+          "The server may still be working: a command that spends credits keeps " +
+          "running after the client gives up, so retry with the SAME " +
+          "--idempotency-key to replay that turn rather than start another.",
         "TIMEOUT",
         {
           status: 0,
@@ -304,6 +307,18 @@ export type BindOperationExtras<TOutput> = {
    * `writeResult`, so JSON output stays machine-shaped.
    */
   formatHuman?: (result: TOutput) => string;
+  /**
+   * The `--timeout` default for THIS command, when the caller passed none.
+   *
+   * The 30s program default is sized for an MCP probe. A command that BLOCKS
+   * on a model turn — `sessions send` — routinely runs longer than that, and
+   * the client giving up does NOT stop the turn: it keeps running, keeps
+   * spending, and the caller sees only a timeout. Raising the default per
+   * command keeps the probe commands snappy without making the blocking ones
+   * lie about what happened. `eval run` needs none of this: it returns once
+   * the run has STARTED, and the run is then polled.
+   */
+  defaultTimeoutMs?: number;
 };
 
 /**
@@ -355,7 +370,7 @@ export function bindOperation<
     const invoked = invocation[invocation.length - 1] as Command;
     const options = invocation[invocation.length - 2] as TOptions;
     const positionals = invocation.slice(0, -2) as (string | undefined)[];
-    const globalOptions = getGlobalOptions(invoked);
+    const globalOptions = getGlobalOptions(invoked, bindExtras.defaultTimeoutMs);
     const merged = platformOptionsOf<TOptions & { project?: string }>(invoked);
     const underCloud = hasCloudAncestor(invoked);
     // Gating ambient resolution on the parent being named `cloud` alone

--- a/cli/src/lib/server-config.ts
+++ b/cli/src/lib/server-config.ts
@@ -156,14 +156,22 @@ export function conformanceConfigFromOptions(options: {
   };
 }
 
-export function getGlobalOptions(command: Command): GlobalOptions {
+export function getGlobalOptions(
+  command: Command,
+  defaultTimeoutMs = 30_000,
+): GlobalOptions {
   const options = command.optsWithGlobals() as Partial<GlobalOptions>;
   return {
     format: resolveOutputFormat(
       options.format as string | undefined,
       process.stdout.isTTY,
     ),
-    timeout: options.timeout ?? 30_000,
+    // `defaultTimeoutMs` applies ONLY when `--timeout` was not passed, so an
+    // explicit flag always wins. Commands that drive a model turn override it:
+    // 30s is right for an MCP probe and far too short for an agent that
+    // installs packages, and the turn keeps running server-side after the
+    // client gives up.
+    timeout: options.timeout ?? defaultTimeoutMs,
     rpc: options.rpc ?? false,
     quiet: options.quiet ?? false,
     telemetry: options.telemetry ?? true,

--- a/cli/tests/server-config.test.ts
+++ b/cli/tests/server-config.test.ts
@@ -6,6 +6,7 @@ import test from "node:test";
 import { Command } from "commander";
 import {
   addSharedServerOptions,
+  getGlobalOptions,
   parseNonNegativeInteger,
   parseJsonRecord,
   parseRetryPolicy,
@@ -570,4 +571,30 @@ test("resolveAliasedStringOption rejects missing and conflicting aliases", () =>
       error instanceof CliError &&
       error.message.includes("Specify only one of --tool-name or --name"),
   );
+});
+
+// ── The `--timeout` default ────────────────────────────────────────────────
+//
+// The 30s program default is sized for an MCP probe. Commands that drive a
+// model turn pass their own, larger default; an explicit `--timeout` must
+// still win over both, or a caller could not shorten a long-running command.
+
+function timeoutCommand(argv: string[]): Command {
+  const command = new Command("send").exitOverride();
+  command.option("--timeout <ms>", "Request timeout in milliseconds", Number);
+  command.parse(argv, { from: "user" });
+  return command;
+}
+
+test("getGlobalOptions uses the 30s program default when none is given", () => {
+  assert.equal(getGlobalOptions(timeoutCommand([])).timeout, 30_000);
+});
+
+test("getGlobalOptions honours a per-command default when --timeout is absent", () => {
+  assert.equal(getGlobalOptions(timeoutCommand([]), 300_000).timeout, 300_000);
+});
+
+test("an explicit --timeout still beats the per-command default", () => {
+  const command = timeoutCommand(["--timeout", "5000"]);
+  assert.equal(getGlobalOptions(command, 300_000).timeout, 5_000);
 });

--- a/mcpjam-inspector/server/routes/v1/__tests__/clients.test.ts
+++ b/mcpjam-inspector/server/routes/v1/__tests__/clients.test.ts
@@ -757,6 +757,74 @@ describe("v1 client routes", () => {
     });
   });
 
+  describe("the read/write round-trip", () => {
+    // The `get` → edit one field → `update` loop is what every CLI and agent
+    // caller does. It used to fail: the GET projection carries the config row's
+    // `id` and `schemaVersion`, the backend's input validator is a strict
+    // `v.object` that accepts neither, and its argument-validation error is
+    // deliberately not forwarded — so the caller got a bare 500 naming no field
+    // for a body this same API had just emitted.
+    it("strips the read-only projection keys on PATCH", async () => {
+      convexMutationMock.mockResolvedValue({ hostId: "h1" });
+      mockQuery({ "hosts:getHost": DETAIL_ROW });
+      const res = await request("PATCH", "/api/v1/projects/p1/clients/h1", {
+        body: {
+          expectedConfigId: "hc1",
+          config: {
+            id: "hc1",
+            schemaVersion: 2,
+            modelId: "openai/gpt-5",
+            systemPrompt: "edited",
+          },
+        },
+      });
+      expect(res.status).toBe(200);
+      expect(convexMutationMock).toHaveBeenCalledWith(
+        "hosts:updateHost",
+        expect.objectContaining({
+          input: { modelId: "openai/gpt-5", systemPrompt: "edited" },
+        })
+      );
+    });
+
+    it("strips them on create too", async () => {
+      convexMutationMock.mockResolvedValue({ hostId: "h1" });
+      mockQuery({ "hosts:getHost": DETAIL_ROW });
+      const res = await request("POST", "/api/v1/projects/p1/clients", {
+        body: {
+          name: "Alpha",
+          config: { id: "hc1", schemaVersion: 2, modelId: "gpt-4o-mini" },
+        },
+      });
+      expect(res.status).toBe(201);
+      expect(convexMutationMock).toHaveBeenCalledWith("hosts:createHost", {
+        projectId: "p1",
+        name: "Alpha",
+        input: { modelId: "gpt-4o-mini" },
+      });
+    });
+
+    // Only the two derived keys are dropped. Anything else the caller invents
+    // still reaches the backend validator and still fails closed there.
+    it("leaves an unrecognized key alone", async () => {
+      convexMutationMock.mockResolvedValue({ hostId: "h1" });
+      mockQuery({ "hosts:getHost": DETAIL_ROW });
+      const res = await request("PATCH", "/api/v1/projects/p1/clients/h1", {
+        body: {
+          expectedConfigId: "hc1",
+          config: { modelId: "openai/gpt-5", typodField: 1 },
+        },
+      });
+      expect(res.status).toBe(200);
+      expect(convexMutationMock).toHaveBeenCalledWith(
+        "hosts:updateHost",
+        expect.objectContaining({
+          input: { modelId: "openai/gpt-5", typodField: 1 },
+        })
+      );
+    });
+  });
+
   describe("POST servers", () => {
     it("forwards the config token to updateHostServers", async () => {
       convexMutationMock.mockResolvedValue({ hostId: "h1" });

--- a/mcpjam-inspector/server/routes/v1/clients.ts
+++ b/mcpjam-inspector/server/routes/v1/clients.ts
@@ -441,7 +441,26 @@ function hostConfigPinsAModel(config: Record<string, unknown>): boolean {
 }
 
 /**
- * Return `config` with `modelId` TRIMMED.
+ * The keys a config READ adds that a config WRITE cannot accept.
+ *
+ * `GET /clients/:id` projects the stored row, which carries the config's own
+ * row id and its schema version. Neither is in `hostConfigInputV2Validator`,
+ * and that validator is a strict `v.object`, so handing a freshly-read config
+ * straight back — the obvious `get`, edit one field, `update` loop, and what
+ * every CLI/agent caller actually does — was rejected. Convex's
+ * argument-validation error is deliberately not forwarded (it echoes the
+ * arguments), so the caller got only "Client write rejected by the platform"
+ * with no field named: a 500 for a body the API had just emitted.
+ *
+ * Stripped rather than named in a 400, because these are OUR derived fields,
+ * not the caller's mistake. A genuinely unknown key still fails closed and
+ * still logs, which is the behaviour the write translator documents.
+ */
+const READ_ONLY_CONFIG_KEYS = ["id", "schemaVersion"] as const;
+
+/**
+ * Return `config` ready for the Convex write: `modelId` TRIMMED, and the
+ * read-only projection keys dropped so `get` output round-trips into `update`.
  *
  * The rest of the config is passed through opaquely, but the model cannot be:
  * it is stored verbatim and compared verbatim downstream, so a padded
@@ -450,12 +469,15 @@ function hostConfigPinsAModel(config: Record<string, unknown>): boolean {
  * `normalizeModelId`, which is the other write boundary this value reaches.
  * Only ever a trim; the id itself is never rewritten.
  */
-function withTrimmedModelId(
+function normalizeConfigForWrite(
   config: Record<string, unknown>
 ): Record<string, unknown> {
-  return typeof config.modelId === "string"
-    ? { ...config, modelId: config.modelId.trim() }
-    : config;
+  const normalized: Record<string, unknown> = { ...config };
+  for (const key of READ_ONLY_CONFIG_KEYS) delete normalized[key];
+  if (typeof normalized.modelId === "string") {
+    normalized.modelId = normalized.modelId.trim();
+  }
+  return normalized;
 }
 
 const createClientSchema = z
@@ -747,7 +769,7 @@ async function createHandler(c: Context, surface: Surface) {
   // to one of the two ways of reaching it. A template is authored data too, and
   // one carrying a padded `modelId` would otherwise persist an id that no
   // downstream verbatim comparison recognizes.
-  const input = withTrimmedModelId(
+  const input = normalizeConfigForWrite(
     body.template
       ? await resolveHostTemplateInput(body.template, body.theme)
       : body.config!
@@ -838,7 +860,7 @@ async function updateClientHandler(c: Context) {
           hostId: clientId,
           projectId,
           ...(body.name === undefined ? {} : { name: body.name }),
-          input: withTrimmedModelId(body.config),
+          input: normalizeConfigForWrite(body.config),
           ...tokens,
         } as any
       );
@@ -880,7 +902,7 @@ async function updateHostAliasHandler(c: Context) {
       await readHostDetail(token, projectId, hostId),
       body.config
     );
-    updateArgs.input = withTrimmedModelId(body.config);
+    updateArgs.input = normalizeConfigForWrite(body.config);
   }
   const convexClient = createConvexClient(token);
   try {


### PR DESCRIPTION
Found while driving the CLI through the environment → Playground → eval loop against prod. Both bugs make a working request look broken, and both cost real debugging time before I understood them.

## 1. A client config could not be read and written back

`GET /projects/:p/clients/:id` projects the stored row, so its `config` carries the config row's own `id` and `schemaVersion`. Neither is in the backend's `hostConfigInputV2Validator`, and that validator is a strict `v.object`.

So the obvious loop — `get`, edit one field, `update`, which is exactly what every CLI and agent caller does — was **rejected**. And the failure surfaced as:

```
{"error":{"code":"INTERNAL_ERROR","message":"Client write rejected by the platform"}}
```

No field named. That's because `translateConvexWriteError` deliberately does not forward Convex's argument-validation text (it echoes the arguments back, which would leak internals) — a decision I agree with and did **not** change. The net effect was a `500` on a body this same API had just emitted, with nothing actionable in it. I burned several attempts assuming my config was wrong before reading the validator.

**Fix:** drop the two derived keys at `normalizeConfigForWrite`, the one chokepoint all three write paths (`create`, canonical `PATCH`, legacy alias `PATCH`) already pass through.

Stripped rather than named in a 400 because these are *our* projection fields, not the caller's mistake. A genuinely unknown key still fails closed and still logs — the behaviour the write translator documents — and there's a test pinning that so this doesn't quietly become "swallow anything".

Also renamed `withTrimmedModelId` → `normalizeConfigForWrite`, since it now does two things.

## 2. `sessions send` timed out at 30s while the turn kept running

The 30s program default is sized for an MCP probe, not a model turn with tools. And the client giving up does **not** stop the turn — it keeps running and keeps spending. The caller saw only:

```
Request timed out after 30000ms
```

Nothing about raising `--timeout`, and nothing warning that retrying with a *fresh* `--idempotency-key` would bill a second turn. The idempotency key exists precisely to make that retry safe, and the error that most invites a retry never mentioned it.

**Fix:** `bindOperation` takes an optional per-command `defaultTimeoutMs` (an explicit `--timeout` still wins in both directions), `sessions send` sets 300s, and the timeout message now says what to change and that the turn may still be in flight.

`eval run` deliberately gets none of this — it returns once the run has *started* and is polled after, so 30s is correct there.

## Verification

- Both fixes were reverted to confirm their tests fail: 2 fail for the round-trip, 3 for the timeout default.
- 82 inspector route tests pass (`clients`, `client-write-freeze`).
- 1153 CLI tests pass, up from 1150.
- `cli` typechecks clean. The inspector's pre-existing typecheck noise in a bare worktree is untouched, and no error mentions the changed file.

## Not in this PR

Three related things I found but deliberately did not fix here:

- **Custom sandbox image builds are inert on prod.** `COMPUTERS_ENV_BUILDER` is unset, so builds fall to the stub builder and report `status: ready` having built nothing (`provider: "stub"`, log `"stub builder: image ready"`). The kill switch is deliberate; a green `ready` on an image that was never built is not. Backend repo, needs its own PR.
- **The v1 turn route silently ignores `builtInToolIds` and `computer`.** A host config can carry `bash` plus a computer, the write succeeds, and `chat-session-turn.ts` never reads either — so a Playground shell is browser-only and the CLI/MCP surfaces quietly advertise MCP tools alone. Wiring it vs. refusing the config is a product decision, not a bug fix.
- **A server that fails `tools/list` 502s the whole turn.** Reproduced with a server that initializes fine but times out on discovery. The 502 I captured had a generic body, which points at an edge proxy rather than the app's own fail-closed path in `computeExcludedToolNames` — so I'm not touching a security-sensitive tool-policy path on an unconfirmed root cause.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit 20d328ba97932fbbecef5dc6dec3e8e3ae5dc3c8. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes two bugs that made working CLI requests look broken: client configs now round-trip through read and write, and `sessions send` no longer times out mid-turn while the turn keeps running and spending.

- A config read includes `id` and `schemaVersion`, which the strict write validator rejected; those keys are now stripped at the single write chokepoint, so `get` → edit → `update` works again.
- Unknown config keys still fail closed and log, with tests pinning that behavior.
- `sessions send` now defaults to a 300s timeout instead of 30s; an explicit `--timeout` still wins.
- The timeout message now suggests raising `--timeout` and retrying with the same `--idempotency-key`, since the turn may still be in flight.
- `eval run` keeps the 30s default because it returns once the run has started.

<sup>Written for commit 20d328ba97932fbbecef5dc6dec3e8e3ae5dc3c8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/MCPJam/inspector/pull/4401?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

