### PR TITLE
cli: make the per-command --timeout default actually apply

### DIFF
--- a/cli/src/lib/server-config.ts
+++ b/cli/src/lib/server-config.ts
@@ -156,6 +156,17 @@ export function conformanceConfigFromOptions(options: {
   };
 }
 
+/**
+ * Did the CALLER choose `--timeout`, as opposed to commander defaulting it?
+ *
+ * `getOptionValueSourceWithGlobals` walks parent commands, which matters
+ * because `--timeout` is declared once on the program and read from a leaf.
+ */
+function timeoutWasSupplied(command: Command): boolean {
+  const source = command.getOptionValueSourceWithGlobals?.("timeout");
+  return source !== undefined && source !== "default";
+}
+
 export function getGlobalOptions(
   command: Command,
   defaultTimeoutMs = 30_000,
@@ -166,12 +177,21 @@ export function getGlobalOptions(
       options.format as string | undefined,
       process.stdout.isTTY,
     ),
-    // `defaultTimeoutMs` applies ONLY when `--timeout` was not passed, so an
-    // explicit flag always wins. Commands that drive a model turn override it:
-    // 30s is right for an MCP probe and far too short for an agent that
-    // installs packages, and the turn keeps running server-side after the
-    // client gives up.
-    timeout: options.timeout ?? defaultTimeoutMs,
+    // `defaultTimeoutMs` applies ONLY when the caller did not supply
+    // `--timeout`, so an explicit flag always wins. Commands that drive a model
+    // turn override it: 30s is right for an MCP probe and far too short for an
+    // agent that installs packages, and the turn keeps running server-side
+    // after the client gives up.
+    //
+    // Keyed off the option's SOURCE, not its value. The program registers
+    // `--timeout` with a commander default of 30_000, so the value is never
+    // `undefined` and an `options.timeout ?? …` fallback is dead code that
+    // silently pins every command to 30s. `"default"` means commander filled
+    // it in; anything else (`"cli"`, `"env"`, `"config"`) means the caller
+    // chose it and must win.
+    timeout: timeoutWasSupplied(command)
+      ? (options.timeout ?? defaultTimeoutMs)
+      : defaultTimeoutMs,
     rpc: options.rpc ?? false,
     quiet: options.quiet ?? false,
     telemetry: options.telemetry ?? true,

--- a/cli/tests/server-config.test.ts
+++ b/cli/tests/server-config.test.ts
@@ -586,6 +586,29 @@ function timeoutCommand(argv: string[]): Command {
   return command;
 }
 
+/**
+ * The REAL shape: `--timeout` lives on the program, carries a commander
+ * default of 30_000, and is read from a subcommand.
+ *
+ * The first version of this fix passed the simple test above and did nothing
+ * in production, because with a commander default the option value is never
+ * `undefined` — so a `?? perCommandDefault` fallback is unreachable. Anything
+ * asserting the per-command default MUST go through this builder.
+ */
+function programWithTimeout(argv: string[]): Command {
+  const program = new Command("mcpjam").exitOverride();
+  program.option(
+    "--timeout <ms>",
+    "Request timeout in milliseconds",
+    Number,
+    30_000,
+  );
+  const leaf = program.command("send").exitOverride();
+  leaf.action(() => {});
+  program.parse(argv, { from: "user" });
+  return leaf;
+}
+
 test("getGlobalOptions uses the 30s program default when none is given", () => {
   assert.equal(getGlobalOptions(timeoutCommand([])).timeout, 30_000);
 });
@@ -597,4 +620,19 @@ test("getGlobalOptions honours a per-command default when --timeout is absent", 
 test("an explicit --timeout still beats the per-command default", () => {
   const command = timeoutCommand(["--timeout", "5000"]);
   assert.equal(getGlobalOptions(command, 300_000).timeout, 5_000);
+});
+
+test("the per-command default beats the program's own commander default", () => {
+  const leaf = programWithTimeout(["send"]);
+  assert.equal(getGlobalOptions(leaf, 300_000).timeout, 300_000);
+});
+
+test("the program default still applies when a command asks for none", () => {
+  const leaf = programWithTimeout(["send"]);
+  assert.equal(getGlobalOptions(leaf).timeout, 30_000);
+});
+
+test("an explicit --timeout beats both defaults, from a subcommand", () => {
+  const leaf = programWithTimeout(["--timeout", "5000", "send"]);
+  assert.equal(getGlobalOptions(leaf, 300_000).timeout, 5_000);
 });


### PR DESCRIPTION
Follow-up to #4401. **The `defaultTimeoutMs` that PR added never applied.** I caught it by building the CLI locally and running the actual failing command against prod, which is something #4401's unit tests could not have told me.

## What was wrong

The program registers `--timeout <ms>` with a **commander default of 30_000**:

```ts
.option("--timeout <ms>", "Request timeout in milliseconds",
        (value: string) => parsePositiveInteger(value, "Timeout"), 30_000)
```

So `optsWithGlobals().timeout` is never `undefined`, and `options.timeout ?? defaultTimeoutMs` is unreachable. Every command stayed pinned to 30s — including the `sessions send` the change existed for.

The tests passed because they built a bare `Command` with no commander default. They tested the helper in isolation and modelled a program that doesn't exist.

## The fix

Key off the option's **source**, not its value. `getOptionValueSourceWithGlobals` (commander 14, and it walks parents, which matters since `--timeout` is declared on the program and read from a leaf) reports `"default"` when commander filled the value in, and `"cli"` / `"env"` / `"config"` when the caller chose it. The per-command default applies only in the first case, so an explicit `--timeout` still wins in both directions.

## Test change that matters

`programWithTimeout` reproduces the real shape — option on the program, **with a commander default**, read from a subcommand — and every per-command-default assertion now goes through it. It carries a comment naming this trap so the next person doesn't re-introduce it. The original bare-`Command` builder is kept for the explicit-flag cases.

## Verified end to end against prod

Locally built CLI, one prompt that genuinely takes ~90s:

| invocation | result |
|---|---|
| `--timeout 30000` (old default, forced) | TIMEOUT at **30.9s** |
| no flag, **before** this fix | TIMEOUT at **31.0s** ← still broken |
| no flag, **after** this fix | **completed in 1:29**, 6873 output tokens |
| `--timeout 1500` | TIMEOUT at 1500ms (override intact) |

1156 CLI tests pass; `cli` typechecks clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the per-command `--timeout` default so it actually applies; previously the commander default of 30s always won, so commands like `sessions send` stayed pinned to 30s. The fix keys off the option's source (`cli`/`env`/`config` vs. `default`) instead of its value, so an explicit `--timeout` still overrides.

**Bug Fixes**
- The per-command default now applies when the caller didn't supply `--timeout`, matching the intent from #4401.
- Tests now reproduce the real program shape (option on the program with a commander default, read from a subcommand) to prevent regression.

<sup>Written for commit e4847bb636401a62d940cec5c7b59215dddd56ef. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/MCPJam/inspector/pull/4405?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes timeout behavior for commands that pass a custom `defaultTimeoutMs` (e.g. sessions send); explicit `--timeout` behavior is preserved but long-running commands may wait longer than before when no flag is passed.
> 
> **Overview**
> **Fixes per-command request timeouts that never applied** because the program registers `--timeout` with a Commander default of 30s, so `options.timeout ?? defaultTimeoutMs` always saw 30_000 and ignored larger command defaults (e.g. long model turns).
> 
> `getGlobalOptions` now uses **`getOptionValueSourceWithGlobals("timeout")`** via a new `timeoutWasSupplied` helper: when the source is Commander’s `"default"`, the command’s `defaultTimeoutMs` wins; when the user set the flag (`"cli"`, etc.), that value still wins over both defaults.
> 
> Tests add **`programWithTimeout`**, mirroring the real layout (global option with default, read from a subcommand), so per-command default behavior is asserted against production-shaped parsing—not a bare leaf `Command` without a Commander default.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e4847bb636401a62d940cec5c7b59215dddd56ef. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->