### PR TITLE
v1 turn: bound tools/list, so a hung server fails as our 502 and not the proxy's

### DIFF
--- a/mcpjam-inspector/server/routes/v1/__tests__/chat-sessions.test.ts
+++ b/mcpjam-inspector/server/routes/v1/__tests__/chat-sessions.test.ts
@@ -563,6 +563,28 @@ describe("computeExcludedToolNames", () => {
       ),
     ).rejects.toThrow(/tool policy cannot be applied/);
   });
+
+  it("fails CLOSED, and in bounded time, when tools/list never answers", async () => {
+    // The failure this exists for: a server that answers `initialize` and then
+    // hangs on `tools/list`. Connecting was already bounded; listing was not,
+    // so the turn sat on a promise that never settled until the edge proxy
+    // killed the request and returned a 502 with no body — no code, no
+    // message, nothing naming the server. Now it is this route's own 502.
+    vi.useFakeTimers();
+    try {
+      const hangs = { getTools: () => new Promise(() => {}) } as never;
+      const pending = computeExcludedToolNames(hangs, ["srv"], {
+        toolMode: "read_only",
+      });
+      const assertion = expect(pending).rejects.toThrow(
+        /did not answer tools\/list/,
+      );
+      await vi.advanceTimersByTimeAsync(30_000);
+      await assertion;
+    } finally {
+      vi.useRealTimers();
+    }
+  });
 });
 
 // ── Target narrowing ────────────────────────────────────────────────────────

--- a/mcpjam-inspector/server/routes/v1/chat-session-turn.ts
+++ b/mcpjam-inspector/server/routes/v1/chat-session-turn.ts
@@ -96,6 +96,23 @@ const TURN_WALL_CLOCK_MS = 90_000;
 const MAX_CONCURRENT_TURNS_PER_ORG = 4;
 /** Connect budget for the target's MCP servers, inside the turn wall clock. */
 const CONNECT_TIMEOUT_MS = 30_000;
+/**
+ * Enumeration budget, the peer of {@link CONNECT_TIMEOUT_MS}.
+ *
+ * Connecting was bounded; listing was not. A server that answers `initialize`
+ * and then never answers `tools/list` is not hypothetical — it is how a
+ * half-healthy server usually presents — and it left the turn hanging on an
+ * unbounded promise. `TURN_WALL_CLOCK_MS` could not save it: that abort signal
+ * is never handed to `getTools`, so nothing in-process observed the stall. The
+ * request eventually died at the edge proxy instead, which returns a 502 with
+ * NO body, so the SDK could only report `Request to … failed (502)` — no code,
+ * no message, nothing naming the server that hung.
+ *
+ * With a budget the same stall becomes this route's own 502, carrying
+ * `SERVER_UNREACHABLE` and a message that says what timed out. Sized to match
+ * the connect budget, so connect + list still sit well inside the wall clock.
+ */
+const LIST_TOOLS_TIMEOUT_MS = 30_000;
 
 // ── Request contract ────────────────────────────────────────────────────────
 
@@ -380,6 +397,40 @@ async function resolveTarget(
  * model's plan, and still produces a turn that reads as a refusal rather than
  * a capability boundary.
  */
+/**
+ * `manager.getTools`, but it cannot hang forever.
+ *
+ * Rejects rather than degrading to "no tools": the caller turns any failure
+ * into a 502, and that fail-closed choice is deliberate — a target we cannot
+ * enumerate is a target we cannot apply `read_only` to, and answering with an
+ * empty exclusion list would advertise everything.
+ */
+async function listToolsWithinBudget(
+  manager: MCPClientManager,
+  serverIds: string[],
+): Promise<unknown> {
+  let timer: ReturnType<typeof setTimeout> | undefined;
+  try {
+    return await Promise.race([
+      manager.getTools(serverIds),
+      new Promise<never>((_resolve, reject) => {
+        timer = setTimeout(() => {
+          reject(
+            new Error(
+              `the server did not answer tools/list within ${LIST_TOOLS_TIMEOUT_MS}ms`,
+            ),
+          );
+        }, LIST_TOOLS_TIMEOUT_MS);
+      }),
+    ]);
+  } finally {
+    // The loser of the race is abandoned, not cancelled — leaving the timer
+    // live would hold the event loop open for the rest of the budget on every
+    // healthy turn.
+    if (timer !== undefined) clearTimeout(timer);
+  }
+}
+
 async function computeExcludedToolNames(
   manager: MCPClientManager,
   serverIds: string[],
@@ -392,7 +443,7 @@ async function computeExcludedToolNames(
 ): Promise<{ excluded: string[]; advertised: number }> {
   let tools: Array<{ name?: string; annotations?: { readOnlyHint?: unknown } }>;
   try {
-    tools = (await manager.getTools(serverIds)) as typeof tools;
+    tools = (await listToolsWithinBudget(manager, serverIds)) as typeof tools;
   } catch (error) {
     // A target we cannot enumerate is a target we cannot apply a tool policy
     // to. Failing OPEN here would advertise every tool on a `read_only` turn,


### PR DESCRIPTION
v1 turn: bound tools/list, so a hung server fails as our 502 and not the proxy's

Connecting to the target's MCP servers was bounded (`CONNECT_TIMEOUT_MS`).
Listing their tools was not: `computeExcludedToolNames` awaited
`manager.getTools(serverIds)` with no budget and no abort wiring, so a server
that answers `initialize` and then never answers `tools/list` left the turn on a
promise that never settled.

`TURN_WALL_CLOCK_MS` did not save it. That signal is never handed to `getTools`,
so nothing in-process observed the stall; the request died at the edge proxy
instead. An edge 502 carries NO body, and the v1 error envelope is top-level
`{code, message}` — so with nothing to read, the SDK could only report
`Request to /chat-sessions/messages failed (502)`. No code, no message, nothing
naming the server that hung. Reproduced against prod with a real registry
server that initializes but times out on discovery: every send against it 502'd,
including a `--max-tool-calls 0` "reply PONG" that advertises no tools at all.

`listToolsWithinBudget` races the listing against `LIST_TOOLS_TIMEOUT_MS`
(30s, the peer of the connect budget — connect + list still sit well inside the
90s wall clock) and clears the timer in a `finally`, so a healthy turn does not
hold the event loop open for the rest of the budget.

The fail-closed policy is UNCHANGED and deliberately so: a timeout rejects, the
existing catch turns it into 502 `SERVER_UNREACHABLE`, and the message now names
what timed out. Degrading to "no tools" was rejected — an empty exclusion list
advertises everything, which is the exact outcome `read_only` exists to prevent.

The new test drives fake timers through the budget and asserts the rejection;
it fails without the fix.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit fb909e0678f9797ba8d58584f0f60498e322362b. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Bounds MCP tool listing in the v1 turn endpoint so a server that hangs on `tools/list` fails as our own 502 instead of the edge proxy's. Previously `computeExcludedToolNames` awaited `manager.getTools(serverIds)` with no budget, so a hung server left the turn on a promise that never settled; the request died at the proxy with a bodyless 502, leaving the SDK with no code or message. The listing now races against a 30s timeout, and a timeout rejects — the existing catch turns it into 502 `SERVER_UNREACHABLE` with a message naming what timed out. Fail-closed behavior is unchanged: a server we cannot enumerate is a server we cannot apply `read_only` to, so the route still refuses rather than advertising everything.

**Bug Fixes**
- The timer is cleared in a `finally`, so a healthy turn does not hold the event loop open for the rest of the budget.
- Added a fake-timer test that drives through the budget and asserts the rejection; it fails without the fix.

<sup>Written for commit fb909e0678f9797ba8d58584f0f60498e322362b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/MCPJam/inspector/pull/4406?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

