### PR TITLE
Skills: unbreak harness eval runs, and make skill IDs obtainable

### DIFF
--- a/.changeset/skills-harness-unbreak-and-reads.md
+++ b/.changeset/skills-harness-unbreak-and-reads.md
@@ -1,0 +1,13 @@
+---
+"@mcpjam/inspector": patch
+"@mcpjam/sdk": patch
+"@mcpjam/cli": patch
+---
+
+Unbreak harness eval runs that carry skills, and make skill IDs obtainable without the web app.
+
+A harness eval run whose environment or suite pinned any skill failed at setup with `tokensUsed: 0` — its pins reached `prepareChatV2`, which refuses them because a harness already receives skills as SKILL.md on the box. Both iteration paths now route that decision through one seam, and the refusal's message says what to pass instead. Turn-end skill adoption is no longer allowed out of a pinned turn, where it could write an agent-authored skill back into the pool the next A/B arm resolves against.
+
+A `skills-enabled` gate refusal now surfaces as a 403 carrying the backend's message instead of an opaque `Server Error` 500.
+
+Adds a read-only Cloud Skills surface — `GET /v1/projects/:projectId/skills` and `/skills/:skillId`, the matching SDK operations, and `mcpjam cloud skills list|get` — so the skill IDs that `--compose-skill` and an environment's `skillSelection` demand can be discovered from the CLI and MCP catalog. Authoring stays an app flow.

--- a/cli/src/commands/cloud.ts
+++ b/cli/src/commands/cloud.ts
@@ -6,6 +6,7 @@ import { registerEnvironmentsCommands } from "./environments.js";
 import { registerEvalCommands } from "./eval.js";
 import { registerClientsCommands } from "./clients.js";
 import { registerImagesCommands } from "./images.js";
+import { registerSkillsCommands } from "./skills.js";
 import { registerJourneysCommands } from "./journeys.js";
 import { registerOrganizationsCommands } from "./organizations.js";
 import { registerProjectsCommands } from "./projects.js";
@@ -44,6 +45,7 @@ export function registerCloudCommands(program: Command): Command {
   registerClientsCommands(cloud);
   registerEnvironmentsCommands(cloud);
   registerImagesCommands(cloud);
+  registerSkillsCommands(cloud);
 
   cloud.commandsGroup("Swarms and user testing:");
   const journeys = registerJourneysCommands(cloud);

--- a/cli/src/commands/skills.ts
+++ b/cli/src/commands/skills.ts
@@ -1,0 +1,86 @@
+/**
+ * `mcpjam cloud skills` — READ-ONLY Cloud Skills commands.
+ *
+ * These exist to close a loop the CLI could not close on its own: three
+ * separate flags here take a skill ID (`eval run --compose-skill`,
+ * `eval cases run --compose-skill`, `environments ensure-adhoc --skill`) and
+ * until now nothing in the CLI could tell you what those IDs were. The only
+ * way to learn one was to open the web app.
+ *
+ * Authoring stays out of the CLI deliberately, matching `cloud plugins`:
+ * creating a skill is a project-admin app flow behind a beta gate, and the
+ * public API exposes no skill write.
+ */
+import type { Command } from "commander";
+import {
+  getProjectSkillOperation,
+  listProjectSkillsOperation,
+} from "@mcpjam/sdk/platform";
+import { writeResult } from "../lib/output.js";
+import {
+  platformOptionsOf,
+  runPlatformOperation as runPlatformCommand,
+  type PlatformOptions,
+} from "../lib/platform-command.js";
+import { resolveCloudProjectArgs } from "../lib/cloud-scope.js";
+import { getGlobalOptions } from "../lib/server-config.js";
+
+export function registerSkillsCommands(program: Command): void {
+  const skills = program
+    .command("skills")
+    .description(
+      "List and read the Cloud Skills in your hosted MCPJam projects (read-only; authoring lives in the app)"
+    );
+
+  skills
+    .command("list")
+    .description(
+      "List the skills visible to you in a project, with the IDs that --compose-skill and --skill take"
+    )
+    .option(
+      "--project <id-or-name>",
+      "Project name or ID (defaults to the most recently updated project)"
+    )
+    .action(
+      async (options: PlatformOptions & { project?: string }, command) => {
+        const globalOptions = getGlobalOptions(command);
+        const result = await runPlatformCommand(
+          platformOptionsOf(command),
+          globalOptions.timeout,
+          ({ client, signal }) =>
+            listProjectSkillsOperation.execute(
+              { project: resolveCloudProjectArgs(options).project },
+              { client, signal }
+            )
+        );
+        writeResult(result, globalOptions.format);
+      }
+    );
+
+  skills
+    .command("get")
+    .description("Show one skill, including its SKILL.md body")
+    .requiredOption("--skill <id>", "Skill ID, from `cloud skills list`")
+    .option("--project <id-or-name>", "Project name or ID")
+    .action(
+      async (
+        options: PlatformOptions & { project?: string; skill: string },
+        command
+      ) => {
+        const globalOptions = getGlobalOptions(command);
+        const result = await runPlatformCommand(
+          platformOptionsOf(command),
+          globalOptions.timeout,
+          ({ client, signal }) =>
+            getProjectSkillOperation.execute(
+              {
+                project: resolveCloudProjectArgs(options).project,
+                skillId: options.skill,
+              },
+              { client, signal }
+            )
+        );
+        writeResult(result, globalOptions.format);
+      }
+    );
+}

--- a/cli/src/lib/op-bindings.ts
+++ b/cli/src/lib/op-bindings.ts
@@ -217,6 +217,8 @@ export const CLI_BINDINGS: Readonly<Record<string, CliBinding>> = {
     excluded:
       "No `plugins` command group yet — the read surface shipped for the MCP catalog and API first. Bind both plugin reads together when the CLI grows one.",
   },
+  list_project_skills: { command: "cloud skills list" },
+  get_project_skill: { command: "cloud skills get" },
   list_sandbox_images: { command: "cloud images list" },
   get_sandbox_image: { command: "cloud images get" },
   create_sandbox_image: { command: "cloud images create" },

--- a/cli/tests/cloud-flag-conventions.test.ts
+++ b/cli/tests/cloud-flag-conventions.test.ts
@@ -31,6 +31,7 @@ const CLOUD_COMMAND_FILES = [
   "registry.ts",
   "scenarios.ts",
   "sessions.ts",
+  "skills.ts",
   "swarms.ts",
   "tunnel.ts",
   "user-testing.ts",

--- a/docs/reference/openapi.json
+++ b/docs/reference/openapi.json
@@ -34,6 +34,10 @@
       "description": "Agent Plugins imported into a project — read-only inventory and version detail."
     },
     {
+      "name": "Skills",
+      "description": "Cloud Skills: authored SKILL.md files stored in a project. Read-only here. Environments pin skills by id (`skillSelection.skillIds`) and eval runs pin them with `--compose-skill`, so this surface exists to give an unattended caller those ids; authoring is an app flow behind a beta gate."
+    },
+    {
       "name": "Sandbox images",
       "description": "Custom Computer images: a digest-pinned Dockerfile built into an immutable image your project's computers boot from."
     },
@@ -4930,6 +4934,93 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/PluginVersion"
+                }
+              }
+            }
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "403": {
+            "$ref": "#/components/responses/Forbidden"
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound"
+          },
+          "429": {
+            "$ref": "#/components/responses/RateLimited"
+          },
+          "500": {
+            "$ref": "#/components/responses/InternalError"
+          },
+          "502": {
+            "$ref": "#/components/responses/ServerUnreachable"
+          }
+        }
+      }
+    },
+    "/projects/{projectId}/skills": {
+      "get": {
+        "operationId": "listProjectSkills",
+        "tags": ["Skills"],
+        "summary": "List a project's skills",
+        "description": "The Cloud Skills visible to the caller in this project: the project-shared ones plus the caller's own drafts. Each row reports `pinnability`, which is what decides whether its id is usable in an environment's `skillSelection`.",
+        "parameters": [{ "$ref": "#/components/parameters/projectId" }],
+        "responses": {
+          "200": {
+            "description": "The project's skills.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/SkillPage"
+                }
+              }
+            }
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "403": {
+            "$ref": "#/components/responses/Forbidden"
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound"
+          },
+          "429": {
+            "$ref": "#/components/responses/RateLimited"
+          },
+          "500": {
+            "$ref": "#/components/responses/InternalError"
+          },
+          "502": {
+            "$ref": "#/components/responses/ServerUnreachable"
+          }
+        }
+      }
+    },
+    "/projects/{projectId}/skills/{skillId}": {
+      "get": {
+        "operationId": "getProjectSkill",
+        "tags": ["Skills"],
+        "summary": "Get a skill",
+        "description": "One skill, including its SKILL.md body. The body is mutable and an edit overwrites the previous one in place, so `aggregateHash` is the only handle on which content this read returned.",
+        "parameters": [
+          { "$ref": "#/components/parameters/projectId" },
+          {
+            "name": "skillId",
+            "in": "path",
+            "required": true,
+            "schema": { "type": "string" },
+            "description": "Skill ID."
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "The skill.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/SkillDetail"
                 }
               }
             }
@@ -16595,6 +16686,98 @@
           },
           "readyAt": {
             "type": "number"
+          }
+        }
+      },
+      "Skill": {
+        "type": "object",
+        "required": [
+          "id",
+          "projectId",
+          "name",
+          "description",
+          "sharing",
+          "isOwner",
+          "aggregateHash",
+          "createdAt",
+          "updatedAt"
+        ],
+        "properties": {
+          "id": {
+            "type": "string"
+          },
+          "projectId": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string",
+            "description": "Load-bearing identity: the on-box directory name and the `loadSkill` argument. Immutable — renames are rejected."
+          },
+          "description": {
+            "type": "string"
+          },
+          "sharing": {
+            "type": "string",
+            "enum": ["user", "project"],
+            "description": "`project` skills are shared with the organization and are the only ones an environment may pin. `user` skills are the caller's own drafts."
+          },
+          "isOwner": {
+            "type": "boolean"
+          },
+          "aggregateHash": {
+            "type": "string",
+            "description": "Drift key over the body and any supporting files. A skill body is mutable and an edit overwrites it in place, so this is the only handle on WHICH content a given pin resolved to."
+          },
+          "provenance": {
+            "type": "string",
+            "description": "How the row came to exist (`authored`, `computer-adopted`, …). Absent on older records; treat an unknown value as `authored`."
+          },
+          "pinnability": {
+            "type": "object",
+            "description": "Whether this skill may be pinned into an environment. ABSENT means unknown (an older backend), which is not the same as eligible.",
+            "required": ["ok"],
+            "properties": {
+              "ok": {
+                "type": "boolean"
+              },
+              "reason": {
+                "type": "string",
+                "description": "Why not, when `ok` is false — e.g. the skill is personal, carries supporting files, or carries extra frontmatter."
+              }
+            }
+          },
+          "createdAt": {
+            "type": "number"
+          },
+          "updatedAt": {
+            "type": "number"
+          }
+        }
+      },
+      "SkillDetail": {
+        "allOf": [
+          { "$ref": "#/components/schemas/Skill" },
+          {
+            "type": "object",
+            "required": ["content"],
+            "properties": {
+              "content": {
+                "type": "string",
+                "description": "The SKILL.md body, with frontmatter stripped."
+              }
+            }
+          }
+        ]
+      },
+      "SkillPage": {
+        "type": "object",
+        "required": ["items"],
+        "properties": {
+          "items": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Skill"
+            }
           }
         }
       },

--- a/mcp/README.md
+++ b/mcp/README.md
@@ -92,6 +92,8 @@ so results respect the caller's project access.
 | `get_sandbox_image` | Show one sandbox image's blueprint, sharing, and latest build status. | — |
 | `list_project_plugins` | List the live Agent Plugins installed in a project: name, display name, enabled state, and active version id. | — |
 | `get_plugin_version` | Show one imported plugin version: status, component counts, and per-component summaries (servers with placement and auth timing, skills with their namespaced refs). | — |
+| `list_project_skills` | List the Cloud Skills visible to you in a project, with the IDs that environments and eval runs pin. Each row reports whether it is eligible to be pinned, and why not if it isn't. | — |
+| `get_project_skill` | Show one Cloud Skill including its SKILL.md body. | — |
 | `list_scenarios` | List the scenarios published from an MCPJam project: name, access mode, attached servers, and share link. | ✅ |
 | `get_scenario` | Get one scenario's read-only settings: model, system prompt, temperature, tool-approval policy, and resolved servers. | ✅ |
 | `list_chat_sessions` | List chat sessions visible to the caller, most recent activity first. | — |

--- a/mcp/src/tools/platformTools.ts
+++ b/mcp/src/tools/platformTools.ts
@@ -69,6 +69,8 @@ import {
   getImageOperation,
   listEnvironmentsOperation,
   listProjectPluginsOperation,
+  listProjectSkillsOperation,
+  getProjectSkillOperation,
   listProjectsOperation,
   listProjectServersOperation,
   listServerPromptsOperation,
@@ -273,6 +275,13 @@ export const PLATFORM_CATALOG_OPERATIONS: ReadonlyArray<
   // there is no excluded write operation to list because the SDK ships none.
   listProjectPluginsOperation,
   getPluginVersionOperation,
+  // Cloud Skills: the READ half only, same policy as plugins — authoring is an
+  // app flow behind a beta gate and the SDK ships no skill write. These are
+  // here because skill IDs are load-bearing on this very catalog
+  // (set_eval_suite_environments, run_eval_suite's composed stacks), and an
+  // agent that cannot list them cannot use the tools that demand them.
+  listProjectSkillsOperation,
+  getProjectSkillOperation,
   listScenariosOperation,
   getScenarioOperation,
   listChatSessionsOperation,

--- a/mcp/tests/platformTools.test.ts
+++ b/mcp/tests/platformTools.test.ts
@@ -179,6 +179,8 @@ const PLAIN_TOOLS = [
   // Agent Plugins reads: agent-oriented payloads, no widget view.
   "list_project_plugins",
   "get_plugin_version",
+  "list_project_skills",
+  "get_project_skill",
   "get_eval_iteration_trace",
   "compare_eval_run",
   // The gate-waiver read: an agent-oriented payload, no widget view.
@@ -434,6 +436,8 @@ describe("platform tool registration", () => {
       "get_sandbox_image",
       "list_project_plugins",
       "get_plugin_version",
+      "list_project_skills",
+      "get_project_skill",
       "list_scenarios",
       "get_scenario",
       "list_chat_sessions",

--- a/mcpjam-inspector/server/routes/v1/__tests__/sdk-coverage.test.ts
+++ b/mcpjam-inspector/server/routes/v1/__tests__/sdk-coverage.test.ts
@@ -152,6 +152,10 @@ const ROUTE_TO_SDK: Readonly<Record<string, string>> = {
   "get /projects/{projectId}/plugins": "listProjectPlugins",
   "get /plugin-versions/{pluginVersionId}": "getPluginVersion",
 
+  // Cloud Skills (read-only)
+  "get /projects/{projectId}/skills": "listProjectSkills",
+  "get /projects/{projectId}/skills/{skillId}": "getProjectSkill",
+
   // Sandbox images
   "get /projects/{projectId}/images": "listImages",
   "post /projects/{projectId}/images": "createImage",

--- a/mcpjam-inspector/server/routes/v1/agent-op-registry.ts
+++ b/mcpjam-inspector/server/routes/v1/agent-op-registry.ts
@@ -2354,6 +2354,14 @@ export const EXCLUDED_FROM_AGENT: Readonly<Record<string, string>> = {
   get_plugin_version:
     "Plugin version detail is a setup/administration read, not a turn concern yet; exposed on the MCP catalog and public API.",
 
+  // Cloud Skills. Same shape and same decision as plugins: read-only
+  // inventory, shipped for the MCP catalog and the CLI, not registered on the
+  // in-turn agent brief until skill questions become a turn concern.
+  list_project_skills:
+    "Skill inventory is a setup/administration read, not a turn concern yet; exposed on the MCP catalog and public API.",
+  get_project_skill:
+    "Skill detail (including the SKILL.md body) is a setup/administration read, not a turn concern yet; exposed on the MCP catalog and public API.",
+
   // Sandbox images and computers: minutes-long builds and billable compute.
   list_sandbox_images:
     "Image lifecycle is an operator surface, exposed via the CLI.",

--- a/mcpjam-inspector/server/routes/v1/index.ts
+++ b/mcpjam-inspector/server/routes/v1/index.ts
@@ -28,6 +28,7 @@ import clients from "./clients.js";
 import harness from "./harness.js";
 import environments from "./environments.js";
 import plugins from "./plugins.js";
+import skills from "./skills.js";
 import journeys from "./journeys.js";
 import personas from "./personas.js";
 import swarms from "./swarms.js";
@@ -125,6 +126,12 @@ v1.route("/", environments);
 // (no GUEST_ALLOWED_V1_RULES entry): the Convex reads are member-gated
 // anyway, and there is no share-link flow that needs plugin inventory.
 v1.route("/", plugins);
+// Cloud Skills — READ-ONLY (list + detail). Authoring stays on `/api/web` and
+// stays behind the backend's `skills-enabled` gate; these reads are ungated,
+// matching the backend where reads and deletes are never gated. Guest-DENIED
+// by default (no GUEST_ALLOWED_V1_RULES entry): the Convex reads are
+// member-gated, and a share-link visitor has no business enumerating skills.
+v1.route("/", skills);
 // Journeys + journey runs — the public API for Swarms. Flag-gated beta
 // (`sandboxes-enabled`, enforced server-side on writes), so these are absent
 // from the OpenAPI spec and from the MCP/agent/workspace catalogs until GA.

--- a/mcpjam-inspector/server/routes/v1/skills.ts
+++ b/mcpjam-inspector/server/routes/v1/skills.ts
@@ -1,0 +1,163 @@
+/**
+ * Public v1 Cloud Skills surface — READ-ONLY.
+ *
+ * A project skill is an authored SKILL.md stored in Convex (not on any
+ * Computer), pinned into environments by `skillSelection.skillIds` and into
+ * eval runs by `--compose-skill`. Both of those take skill IDs — and until
+ * this route existed there was NO way to obtain an ID from an unattended
+ * caller: authoring lives on `/api/web/skills/*` (browser/session surface) and
+ * the CLI is a thin client over `/api/v1`. So the CLI demanded an identifier
+ * it gave you no way to discover, and the answer was "open the web app".
+ *
+ * Reads only, deliberately, for the same reason as `plugins.ts`: authoring is
+ * a project-admin app flow, and this surface feeds unattended callers (CLI,
+ * the platform MCP worker) where no skill write belongs. It is also why this
+ * route is not gated on `skills-enabled` — the backend gates AUTHORING
+ * (`convex/projectSkills.ts` → `requireSkillsFeature`); reads and deletes stay
+ * ungated, and a flagged-off org listing zero skills is a correct answer.
+ *
+ * Thin proxies over the Convex `projectSkills:*` member-gated reads, called
+ * with the request's Convex bearer. Both scope on the path's `projectId` and
+ * let Convex enforce membership, like the environments and plugins routes.
+ */
+import { Hono } from "hono";
+import { ConvexHttpClient } from "convex/browser";
+import { ErrorCode, WebRouteError } from "../web/errors.js";
+import { getConvexBearerForRequest } from "../../utils/v1-convex-token.js";
+import { v1PageJson, v1Resource } from "./envelope.js";
+import { translateConvexReadError } from "./convex-read-errors.js";
+
+const skills = new Hono();
+
+// ── Convex row shapes (hand-mirrored from convex/projectSkills.ts) ───────────
+//
+// Mirrored by hand rather than imported: the backend is a separate repo, so a
+// field added there is invisible here until someone widens these types. Keep
+// every added field OPTIONAL so an older inspector against a newer backend
+// deserializes rather than throws.
+
+type SkillListRow = {
+  skillId: string;
+  projectId: string;
+  name: string;
+  description: string;
+  sharing: "user" | "project";
+  isOwner: boolean;
+  aggregateHash: string;
+  provenance?: string;
+  pinnability?: { ok: true } | { ok: false; reason: string };
+  createdAt: number;
+  updatedAt: number;
+};
+
+type SkillDetailRow = SkillListRow & { content: string };
+
+/**
+ * `pinnability` is the field that makes this listing actionable rather than
+ * merely informative: an id that cannot be pinned is not a usable answer to
+ * "what can I pass to --compose-skill". Absent on older backends, so it is
+ * forwarded only when present rather than defaulted — inventing `{ok:true}`
+ * would turn an unknown into a promise we cannot keep.
+ */
+function toSkillDto(row: SkillListRow) {
+  return {
+    id: row.skillId,
+    projectId: row.projectId,
+    name: row.name,
+    description: row.description,
+    sharing: row.sharing,
+    isOwner: row.isOwner,
+    aggregateHash: row.aggregateHash,
+    ...(row.provenance !== undefined ? { provenance: row.provenance } : {}),
+    ...(row.pinnability !== undefined
+      ? { pinnability: row.pinnability }
+      : {}),
+    createdAt: row.createdAt,
+    updatedAt: row.updatedAt,
+  };
+}
+
+function toSkillDetailDto(row: SkillDetailRow) {
+  return { ...toSkillDto(row), content: row.content };
+}
+
+function createConvexClient(convexAuthToken: string): ConvexHttpClient {
+  const convexUrl = process.env.CONVEX_URL;
+  if (!convexUrl) {
+    throw new WebRouteError(
+      500,
+      ErrorCode.INTERNAL_ERROR,
+      "Server missing CONVEX_URL configuration"
+    );
+  }
+  const client = new ConvexHttpClient(convexUrl);
+  client.setAuth(convexAuthToken);
+  return client;
+}
+
+/**
+ * `projectSkills:*` reads throw structured `ConvexError` data: `NOT_FOUND` for
+ * a missing id, `FORBIDDEN` for a non-member. Both collapse to 404 — telling a
+ * non-member that a skill id exists would be a free existence oracle, the same
+ * reasoning as `translatePluginReadError`.
+ */
+function translateSkillReadError(error: unknown): WebRouteError {
+  const data = (error as { data?: unknown } | null)?.data;
+  const code =
+    data && typeof data === "object" && !Array.isArray(data)
+      ? (data as { code?: unknown }).code
+      : undefined;
+  if (code === "NOT_FOUND" || code === "FORBIDDEN") {
+    return new WebRouteError(404, ErrorCode.NOT_FOUND, "Skill not found");
+  }
+  return translateConvexReadError(error, {
+    scope: "v1/skills",
+    notFoundMessage: "Skill or project not found, or you do not have access.",
+  });
+}
+
+// ── Routes ───────────────────────────────────────────────────────────────────
+
+// GET /v1/projects/:projectId/skills — every skill VISIBLE to the caller in
+// this project: the project-shared ones plus the caller's own personal drafts.
+// Only `sharing: "project"` rows are pinnable into an environment, which is
+// what `pinnability` reports per row.
+skills.get("/projects/:projectId/skills", async (c) => {
+  const projectId = c.req.param("projectId");
+  const readClient = createConvexClient(await getConvexBearerForRequest(c));
+  let rows: SkillListRow[] | null | undefined;
+  try {
+    rows = (await readClient.query(
+      "projectSkills:listSkills" as any,
+      { projectId } as any
+    )) as SkillListRow[] | null | undefined;
+  } catch (error) {
+    throw translateSkillReadError(error);
+  }
+  return v1PageJson(c, (rows ?? []).map(toSkillDto));
+});
+
+// GET /v1/projects/:projectId/skills/:skillId — one skill, including its
+// SKILL.md body. The body is here because the caller most likely to want it is
+// diffing two arms of a skill A/B, and making that a second round-trip through
+// a different surface is the gap this route exists to close.
+skills.get("/projects/:projectId/skills/:skillId", async (c) => {
+  const projectId = c.req.param("projectId");
+  const skillId = c.req.param("skillId");
+  const readClient = createConvexClient(await getConvexBearerForRequest(c));
+  let row: SkillDetailRow | null | undefined;
+  try {
+    row = (await readClient.query(
+      "projectSkills:getSkill" as any,
+      { projectId, skillId } as any
+    )) as SkillDetailRow | null | undefined;
+  } catch (error) {
+    throw translateSkillReadError(error);
+  }
+  if (!row) {
+    throw new WebRouteError(404, ErrorCode.NOT_FOUND, "Skill not found");
+  }
+  return v1Resource(c, toSkillDetailDto(row));
+});
+
+export default skills;

--- a/mcpjam-inspector/server/services/evals-runner.ts
+++ b/mcpjam-inspector/server/services/evals-runner.ts
@@ -360,6 +360,34 @@ export function runFrozenSkillOptions(run: {
 }
 
 /**
+ * Which skills source an ITERATION hands `prepareChatV2` — the second half of
+ * the two-channel decision `runFrozenSkillOptions` bundles.
+ *
+ * Eval runs never use local-FS skills (decision 10), so the answer is always
+ * explicit. The part that is not obvious: a HARNESS iteration takes
+ * `{ kind: "none" }` EVEN WHEN THE RUN HAS PINS. Its pins are already travelling
+ * on the other channel (`pinnedHarnessSkills` → SKILL.md on the box), and
+ * `prepareChatV2` THROWS on harness+pinned because delivering both would hand
+ * the model the same skill twice by two mechanisms — an in-memory `loadSkill`
+ * tool AND an on-box copy.
+ *
+ * This is a seam guard, in the same spirit as `runFrozenSkillOptions` and for a
+ * bug of the same family. #4146 wired a run's pins into `pinnedSkillSource`
+ * without teaching the two iteration paths that a harness must not receive
+ * them, so every harness run whose environment carried a skill died at
+ * `prepareChatV2` with `tokensUsed: 0` — while runs with no skills stayed green,
+ * which is why it shipped. Both call sites now ask this one function, so the
+ * two paths cannot drift apart again.
+ */
+export function resolveIterationSkillsSource(args: {
+  harness?: string | undefined;
+  pinnedSkillSource?: EvalPinnedSkillSource;
+}): EvalPinnedSkillSource | { kind: "none" } {
+  if (args.harness) return { kind: "none" };
+  return args.pinnedSkillSource ?? { kind: "none" };
+}
+
+/**
  * The match options the `toolCalls:match` score definition hashes over.
  *
  * RESOLVED, not authored. The matcher applies `MATCH_OPTIONS_DEFAULTS` to
@@ -2997,8 +3025,6 @@ const runLocalIteration = async ({
   emit?: StreamEmit;
 }): Promise<EvalIterationOutcome> => {
   const resolvedTest = resolveEvalTestCase(test);
-  // Eval runs NEVER use local-FS skills (decision 10): always explicit.
-  const skillsSource = pinnedSkillSource ?? ({ kind: "none" } as const);
   const toolPolicyGate = toolPolicy
     ? createToolPolicyGate({
         policy: toolPolicy,
@@ -3094,6 +3120,10 @@ const runLocalIteration = async ({
           : undefined,
     },
     precedence: "override-wins",
+  });
+  const skillsSource = resolveIterationSkillsSource({
+    harness: resolvedExecution.harness,
+    pinnedSkillSource,
   });
   const system = withHostContextSystemPrompt(
     resolvedExecution.systemPrompt,
@@ -4080,8 +4110,6 @@ const runHostedIterationWithBrowser = async (
   browser: BrowserSessionContext
 ): Promise<EvalIterationOutcome> => {
   const resolvedTest = resolveEvalTestCase(test);
-  // Eval runs NEVER use local-FS skills (decision 10): always explicit.
-  const skillsSource = pinnedSkillSource ?? ({ kind: "none" } as const);
   const toolPolicyGate = toolPolicy
     ? createToolPolicyGate({
         policy: toolPolicy,
@@ -4164,6 +4192,10 @@ const runHostedIterationWithBrowser = async (
           : undefined,
     },
     precedence: "override-wins",
+  });
+  const skillsSource = resolveIterationSkillsSource({
+    harness: resolvedExecution.harness,
+    pinnedSkillSource,
   });
   const systemPrompt = withHostContextSystemPrompt(
     resolvedExecution.systemPrompt,

--- a/mcpjam-inspector/server/services/evals/__tests__/resolve-iteration-skills-source.test.ts
+++ b/mcpjam-inspector/server/services/evals/__tests__/resolve-iteration-skills-source.test.ts
@@ -1,0 +1,80 @@
+import { describe, expect, it } from "vitest";
+import { resolveIterationSkillsSource } from "../../evals-runner";
+
+/**
+ * The second seam of the two-channel skill decision (the first is
+ * `runFrozenSkillOptions`), and a regression test for a bug that SHIPPED.
+ *
+ * #4146 wired a run's pinned skills into `pinnedSkillSource` for every eval
+ * iteration, but neither iteration path learned that a harness must not receive
+ * them — a harness gets its pins as SKILL.md on the box instead, and
+ * `prepareChatV2` throws when handed both. The result: every harness eval run
+ * whose environment carried at least one skill failed at setup with
+ * `tokensUsed: 0`, while runs with no skills stayed green. That asymmetry is
+ * why it went unnoticed, and it is what the third case below pins.
+ */
+describe("resolveIterationSkillsSource", () => {
+  const pinned = {
+    kind: "pinned" as const,
+    skills: [{ name: "s", description: "d", content: "c", contentHash: "h" }],
+  };
+
+  it("forwards the run's pins on the EMULATED path", () => {
+    expect(
+      resolveIterationSkillsSource({
+        harness: undefined,
+        pinnedSkillSource: pinned,
+      })
+    ).toEqual(pinned);
+  });
+
+  it("is 'none' when an emulated run pinned nothing (never local-FS skills)", () => {
+    expect(
+      resolveIterationSkillsSource({
+        harness: undefined,
+        pinnedSkillSource: undefined,
+      })
+    ).toEqual({ kind: "none" });
+  });
+
+  it("REGRESSION: a harness run with pins gets 'none', not the pins", () => {
+    // The pins are not dropped — they travel on `pinnedHarnessSkills` and are
+    // materialized on the box. Handing them here as well is what threw.
+    expect(
+      resolveIterationSkillsSource({
+        harness: "claude-code",
+        pinnedSkillSource: pinned,
+      })
+    ).toEqual({ kind: "none" });
+  });
+
+  it("is 'none' for a harness run with no pins (unchanged behaviour)", () => {
+    expect(
+      resolveIterationSkillsSource({
+        harness: "claude-code",
+        pinnedSkillSource: undefined,
+      })
+    ).toEqual({ kind: "none" });
+  });
+
+  it("gates on the harness being SET, not on which harness it is", () => {
+    for (const harness of ["claude-code", "codex"]) {
+      expect(
+        resolveIterationSkillsSource({ harness, pinnedSkillSource: pinned })
+      ).toEqual({ kind: "none" });
+    }
+  });
+
+  it("treats a `pinned-effective` source the same way", () => {
+    // `pinned-effective` is chosen when a run needs the effective skill surface
+    // (plugin pins, server-skill pins, or pins with supporting files). It is
+    // still a pinned source, so it must not reach a harness turn either.
+    const effective = { kind: "pinned-effective" as const, capabilities: {} };
+    expect(
+      resolveIterationSkillsSource({
+        harness: "claude-code",
+        pinnedSkillSource: effective as never,
+      })
+    ).toEqual({ kind: "none" });
+  });
+});

--- a/mcpjam-inspector/server/utils/__tests__/chat-v2-orchestration.test.ts
+++ b/mcpjam-inspector/server/utils/__tests__/chat-v2-orchestration.test.ts
@@ -1475,6 +1475,11 @@ describe("prepareChatV2 — pinned skills × harness (Project Environments guard
     expect(result.allTools).not.toHaveProperty("loadSkill");
   });
 
+  // The throw is a CALLER contract (the two delivery channels are disjoint), not
+  // a claim that a harness cannot take pinned skills — it can, and does, as
+  // SKILL.md on the box. Callers route pins to `pinnedHarnessSkills` and pass
+  // `{ kind: "none" }` here; `resolveIterationSkillsSource` is the eval side of
+  // that, and `sessionSimulation/runner.ts` the swarm side.
   it("THROWS on harness + skillsSource pinned (harness pinned skills must ride the harness path, never this branch)", async () => {
     const manager = mockManager({});
     await expect(
@@ -1491,7 +1496,7 @@ describe("prepareChatV2 — pinned skills × harness (Project Environments guard
           ],
         },
       })
-    ).rejects.toThrow(/Pinned skills are not supported on harness/);
+    ).rejects.toThrow(/receive pinned skills on box via `pinnedHarnessSkills`/);
   });
 
   it("accepts harness + skillsSource none (a deliberately skill-less env target)", async () => {

--- a/mcpjam-inspector/server/utils/__tests__/cloud-skills.test.ts
+++ b/mcpjam-inspector/server/utils/__tests__/cloud-skills.test.ts
@@ -130,6 +130,32 @@ describe("cloud-skills (Convex-sourced)", () => {
     ).rejects.toMatchObject({ status: 400 });
   });
 
+  it("maps a FEATURE_UNAVAILABLE ConvexError code → 403 with the real message", async () => {
+    // The backend gates skill AUTHORING behind the `skills-enabled` flag
+    // (`convex/projectSkills.ts` → requireSkillsFeature). Before this code was
+    // in CODE_STATUS it fell through to the message-regex fallback, which does
+    // not match "… is not currently available for your organization" — so a
+    // flagged-off user got an opaque `Server Error` 500 and no way to learn
+    // that a feature flag, not their payload, was the problem.
+    //
+    // 403 matches routes/v1/convex-errors.ts, which chose FORBIDDEN over
+    // FEATURE_NOT_SUPPORTED because the latter maps to 422 (malformed request)
+    // and this request is well-formed.
+    const convexErr = Object.assign(new Error("[CONVEX] redacted"), {
+      data: {
+        code: "FEATURE_UNAVAILABLE",
+        message: "Skills is not currently available for your organization.",
+      },
+    });
+    vi.mocked(convexCreateSkill).mockRejectedValue(convexErr);
+    await expect(
+      createCloudSkill(ctx, { name: "x", description: "d", content: "c" }),
+    ).rejects.toMatchObject({
+      status: 403,
+      message: "Skills is not currently available for your organization.",
+    });
+  });
+
   it("wraps unknown errors as CloudSkillsError 500", async () => {
     vi.mocked(convexCreateSkill).mockRejectedValue(new Error("kaboom"));
     await expect(

--- a/mcpjam-inspector/server/utils/chat-v2-orchestration.ts
+++ b/mcpjam-inspector/server/utils/chat-v2-orchestration.ts
@@ -1077,12 +1077,23 @@ export async function prepareChatV2(
   const skillsArePinned =
     skillsSource?.kind === "pinned" ||
     skillsSource?.kind === "pinned-effective";
-  // Decision 11: harness eval turns live-fetch skills, so a pinned set would
-  // falsify the snapshot claim. Harness is stripped from suite configs already;
-  // this throw is belt-and-suspenders at the single point both paths funnel through.
+  // The two skill-delivery channels are deliberately DISJOINT, and this is the
+  // single point both funnel through. A harness turn materializes SKILL.md on
+  // the box from `pinnedHarnessSkills` (see `utils/harness/skill-delivery.ts`);
+  // an emulated turn gets in-memory `loadSkill` tools from `skillsSource`.
+  // Delivering both would hand the model the same skill twice, by two mechanisms.
+  //
+  // So this is a CALLER contract, not a statement about what a harness can do:
+  // harness callers pass `{ kind: "none" }` here and put their pins on
+  // `pinnedHarnessSkills`. (Historical note: this once read "harness runs
+  // live-fetch skills" — that stopped being true when on-box pinned delivery
+  // landed, and the stale wording cost real debugging time. `run-harness-turn`
+  // does not call `fetchRuntimeSkills` at all in pinned mode.)
   if (harness && skillsArePinned) {
     throw new Error(
-      "Pinned skills are not supported on harness runs (they live-fetch skills)."
+      "Harness turns receive pinned skills on box via `pinnedHarnessSkills`, " +
+        "not via `skillsSource`. Pass `skillsSource: { kind: 'none' }` for a " +
+        "harness turn — the two delivery channels are deliberately disjoint."
     );
   }
   const modelContextTokens =

--- a/mcpjam-inspector/server/utils/computers/cloud-skills.ts
+++ b/mcpjam-inspector/server/utils/computers/cloud-skills.ts
@@ -69,6 +69,17 @@ const CODE_STATUS: Record<string, number> = {
   FORBIDDEN: 403,
   NOT_FOUND: 404,
   CONFLICT: 409,
+  // The backend's beta gate (`convex/lib/featureGates.ts`) refuses every skill
+  // AUTHORING write — create/update/adopt/upload/attach/promote — when the
+  // `skills-enabled` flag is off; reads and deletes stay ungated. Without this
+  // entry the code fell through to the regex fallback below, which does not
+  // match "… is not currently available for your organization", so a clean
+  // actionable refusal rendered as an opaque 500 `Server Error`.
+  //
+  // 403 to match `routes/v1/convex-errors.ts`, which documents why FORBIDDEN
+  // and not FEATURE_NOT_SUPPORTED: the latter maps to 422 (malformed request),
+  // and this is a well-formed request the server declines to authorize.
+  FEATURE_UNAVAILABLE: 403,
 };
 
 /** Read a `ConvexError`'s structured `{ code, message }` payload, if present. */

--- a/mcpjam-inspector/server/utils/harness/__tests__/should-adopt-sandbox-skills.test.ts
+++ b/mcpjam-inspector/server/utils/harness/__tests__/should-adopt-sandbox-skills.test.ts
@@ -1,0 +1,79 @@
+import { describe, expect, it } from "vitest";
+import { shouldAdoptSandboxSkills } from "../adopt-sandbox-skills";
+
+/**
+ * Turn-end adoption is a WRITE back into the live project pool, so the question
+ * "may this turn adopt?" is a correctness question, not a convenience one.
+ *
+ * The case that matters most is `skillsArePinned`. Before it was checked, a
+ * pinned harness eval run could sync a skill its agent authored on box up into
+ * the project — mutating the pool the NEXT arm of a skill A/B resolves against.
+ * Two runs meant to differ only in their pinned skills would then differ in the
+ * pool too, and nothing would say so.
+ */
+const base = {
+  runSucceeded: true,
+  aborted: false,
+  pausedForApproval: false,
+  supportsSkills: true,
+  runtimeSkillsKnown: true,
+  skillsArePinned: false,
+  hasExecutionScope: false,
+  hasCredentials: true,
+  hasFileSession: true,
+  adoptionDisabled: false,
+};
+
+describe("shouldAdoptSandboxSkills", () => {
+  it("adopts on a clean, unpinned, in-scope turn", () => {
+    expect(shouldAdoptSandboxSkills(base)).toBe(true);
+  });
+
+  it("REGRESSION: never adopts out of a PINNED turn", () => {
+    expect(
+      shouldAdoptSandboxSkills({ ...base, skillsArePinned: true })
+    ).toBe(false);
+  });
+
+  it("does not adopt when the turn did not cleanly succeed", () => {
+    expect(shouldAdoptSandboxSkills({ ...base, runSucceeded: false })).toBe(
+      false
+    );
+    expect(shouldAdoptSandboxSkills({ ...base, aborted: true })).toBe(false);
+    expect(
+      shouldAdoptSandboxSkills({ ...base, pausedForApproval: true })
+    ).toBe(false);
+  });
+
+  it("does not adopt when the live skills set is UNKNOWN", () => {
+    // A failed fetch is not "no skills" — adopting against an unknown set could
+    // re-adopt something already managed.
+    expect(shouldAdoptSandboxSkills({ ...base, runtimeSkillsKnown: false })).toBe(
+      false
+    );
+  });
+
+  it("does not adopt inside a guest/swarm execution scope", () => {
+    expect(shouldAdoptSandboxSkills({ ...base, hasExecutionScope: true })).toBe(
+      false
+    );
+  });
+
+  it("does not adopt without credentials, a file session, or a skills-capable adapter", () => {
+    expect(shouldAdoptSandboxSkills({ ...base, hasCredentials: false })).toBe(
+      false
+    );
+    expect(shouldAdoptSandboxSkills({ ...base, hasFileSession: false })).toBe(
+      false
+    );
+    expect(shouldAdoptSandboxSkills({ ...base, supportsSkills: false })).toBe(
+      false
+    );
+  });
+
+  it("honours the operator kill switch", () => {
+    expect(shouldAdoptSandboxSkills({ ...base, adoptionDisabled: true })).toBe(
+      false
+    );
+  });
+});

--- a/mcpjam-inspector/server/utils/harness/adopt-sandbox-skills.ts
+++ b/mcpjam-inspector/server/utils/harness/adopt-sandbox-skills.ts
@@ -171,6 +171,50 @@ function parseAdoptCandidate(
 }
 
 /**
+ * Whether a finished turn may sync on-box skills up into the project pool.
+ *
+ * Extracted from the call site so the conditions are testable and named,
+ * because one of them is subtle and was WRONG: adoption must never run out of a
+ * PINNED turn. A pinned set is a frozen snapshot of the project pool, and
+ * adoption is a write back INTO that pool. So an eval arm whose agent happened
+ * to author a skill on box would mutate what the next arm resolves against —
+ * silently changing the thing under comparison between two runs that are
+ * supposed to differ only in their pinned skills. That is a real falsification
+ * of the snapshot claim, and `executionScope` does not cover it: eval runs set
+ * no execution scope at all.
+ *
+ * `HARNESS_SKILL_ADOPTION_DISABLED=1` remains the operator-side kill switch.
+ */
+export function shouldAdoptSandboxSkills(args: {
+  runSucceeded: boolean;
+  aborted: boolean;
+  pausedForApproval: boolean;
+  supportsSkills: boolean;
+  /** `null` ⇒ the live skills fetch failed; adopting on top of an unknown set
+   *  could re-adopt something we simply failed to see as already-managed. */
+  runtimeSkillsKnown: boolean;
+  skillsArePinned: boolean;
+  /** Guest / swarm scopes never adopt (v1). */
+  hasExecutionScope: boolean;
+  hasCredentials: boolean;
+  hasFileSession: boolean;
+  adoptionDisabled: boolean;
+}): boolean {
+  return (
+    args.runSucceeded &&
+    !args.aborted &&
+    !args.pausedForApproval &&
+    args.supportsSkills &&
+    args.runtimeSkillsKnown &&
+    !args.skillsArePinned &&
+    !args.hasExecutionScope &&
+    args.hasCredentials &&
+    args.hasFileSession &&
+    !args.adoptionDisabled
+  );
+}
+
+/**
  * Scan the runtime's skills root for unmanaged skill dirs and adopt them into
  * Convex. `managedNames` are the names already delivered as cloud skills this
  * turn — those dirs are the adapter's own output, so they're skipped. Returns the

--- a/mcpjam-inspector/server/utils/harness/run-harness-turn.ts
+++ b/mcpjam-inspector/server/utils/harness/run-harness-turn.ts
@@ -113,7 +113,10 @@ import {
   reconcileSkillDirs,
   appendManagedSkills,
 } from "./reconcile-skill-dirs.js";
-import { adoptSandboxSkills } from "./adopt-sandbox-skills.js";
+import {
+  adoptSandboxSkills,
+  shouldAdoptSandboxSkills,
+} from "./adopt-sandbox-skills.js";
 import {
   claimHarnessSessionState,
   commitHarnessSessionState,
@@ -2603,17 +2606,26 @@ export async function runHarnessTurn(
           // fail-soft. NOTE: a fresh adoption adds a new skillId to the runtime set
           // NEXT turn, so the runtime fingerprint intentionally forks then (the
           // adapter (re)writes on the fresh start) — expected, not a bug.
+          //
+          // See `shouldAdoptSandboxSkills` for why each condition is there —
+          // in particular why a PINNED turn must never adopt.
           if (
-            runSucceeded &&
-            !aborted &&
-            !pausedForApproval &&
-            harnessAdapter.supportsSkills &&
-            runtimeSkills !== null &&
-            !executionScope &&
+            shouldAdoptSandboxSkills({
+              runSucceeded,
+              aborted,
+              pausedForApproval,
+              supportsSkills: harnessAdapter.supportsSkills,
+              runtimeSkillsKnown: runtimeSkills !== null,
+              skillsArePinned,
+              hasExecutionScope: Boolean(executionScope),
+              hasCredentials: Boolean(authHeader && projectId),
+              hasFileSession: Boolean(sandboxFileSession),
+              adoptionDisabled:
+                process.env.HARNESS_SKILL_ADOPTION_DISABLED === "1",
+            }) &&
             authHeader &&
             projectId &&
-            sandboxFileSession &&
-            process.env.HARNESS_SKILL_ADOPTION_DISABLED !== "1"
+            sandboxFileSession
           ) {
             const fileSession = sandboxFileSession;
             const { adopted } = await adoptSandboxSkills({

--- a/sdk/src/platform/__tests__/operation-permalink-coverage.test.ts
+++ b/sdk/src/platform/__tests__/operation-permalink-coverage.test.ts
@@ -53,6 +53,9 @@ const ROUTE_DEBT_ALLOWLIST: Readonly<Record<string, string>> = {
   get_swarm: "swarms/definitions/:swarmId",
   create_swarm: "swarms/definitions/:swarmId",
   update_swarm: "swarms/definitions/:swarmId",
+  // Cloud Skills: the /skills surface selects a skill as component state.
+  list_project_skills: "skills/:skillId",
+  get_project_skill: "skills/:skillId",
   get_persona: "swarms/personas/:personaId",
   create_persona: "swarms/personas/:personaId",
   update_persona: "swarms/personas/:personaId",

--- a/sdk/src/platform/client.ts
+++ b/sdk/src/platform/client.ts
@@ -87,6 +87,8 @@ import type {
   PlatformOrganization,
   PlatformPage,
   PlatformPlugin,
+  PlatformProjectSkill,
+  PlatformProjectSkillDetail,
   PlatformPluginVersion,
   PlatformProject,
   PlatformServerConnection,
@@ -1342,6 +1344,37 @@ export class PlatformApiClient {
         params.projectId,
       )}/environments/${encodeURIComponent(params.environmentId)}/restore`,
       { body: { expectedRevision: params.expectedRevision } },
+      options,
+    );
+  }
+
+  // ── Cloud Skills ─────────────────────────────────────────────────────
+  //
+  // Read-only: the skills visible to the caller in a project, and one skill's
+  // detail including its SKILL.md body. Authoring stays on the app surface.
+
+  listProjectSkills(
+    params: { projectId: string },
+    options?: RequestOptions,
+  ): Promise<PlatformPage<PlatformProjectSkill>> {
+    return this.request(
+      "GET",
+      `/projects/${encodeURIComponent(params.projectId)}/skills`,
+      {},
+      options,
+    );
+  }
+
+  getProjectSkill(
+    params: { projectId: string; skillId: string },
+    options?: RequestOptions,
+  ): Promise<PlatformProjectSkillDetail> {
+    return this.request(
+      "GET",
+      `/projects/${encodeURIComponent(
+        params.projectId,
+      )}/skills/${encodeURIComponent(params.skillId)}`,
+      {},
       options,
     );
   }

--- a/sdk/src/platform/index.ts
+++ b/sdk/src/platform/index.ts
@@ -456,6 +456,8 @@ export {
   restoreEnvironmentOperation,
   listProjectPluginsOperation,
   getPluginVersionOperation,
+  listProjectSkillsOperation,
+  getProjectSkillOperation,
   listProjectsOperation,
   listProjectServersOperation,
   listServerPromptsOperation,

--- a/sdk/src/platform/operations.ts
+++ b/sdk/src/platform/operations.ts
@@ -138,6 +138,8 @@ import type {
   PlatformMe,
   PlatformModel,
   PlatformPlugin,
+  PlatformProjectSkill,
+  PlatformProjectSkillDetail,
   PlatformPluginVersion,
   PlatformProject,
   PlatformProjectServer,
@@ -9076,6 +9078,109 @@ export const restoreEnvironmentOperation: PlatformOperation<
   },
 };
 
+// ── Cloud Skills ─────────────────────────────────────────────────────────────
+//
+// Read-only, for the same reason as plugins: authoring is a project-admin app
+// flow. These exist because skill IDs are load-bearing on this very surface —
+// `set_eval_suite_environments`, an environment's `skillSelection`, and the
+// CLI's `--compose-skill` all demand one — and before this there was no
+// programmatic way to obtain one. The answer was "open the web app", which is
+// not an answer an unattended caller can act on.
+
+const listProjectSkillsInput = z.object({
+  project: z
+    .string()
+    .trim()
+    .min(1)
+    .optional()
+    .describe(PROJECT_SELECTOR_DESCRIPTION),
+});
+export type ListProjectSkillsInput = z.infer<typeof listProjectSkillsInput>;
+
+export type ListProjectSkillsResult = {
+  project: SelectedProjectInfo;
+  items: PlatformProjectSkill[];
+  otherProjects: ProjectInfo[];
+};
+
+export const listProjectSkillsOperation: PlatformOperation<
+  ListProjectSkillsInput,
+  ListProjectSkillsResult
+> = {
+  name: "list_project_skills",
+  title: "List MCPJam project skills",
+  description:
+    "List the Cloud Skills visible to you in an MCPJam project — the project-shared ones plus your own personal drafts. Use this to obtain the skill IDs that environments pin via skillSelection and that eval runs pin via --compose-skill. Only `sharing: \"project\"` skills can be pinned; each row's `pinnability` says whether that skill is eligible and, if not, why.",
+  readOnly: true,
+  permalink: noPermalink(
+    "route-not-addressable",
+    "The app's /skills surface selects a skill as component state, so there is no skills/:skillId route to open one of these rows at."
+  ),
+  inputSchema: listProjectSkillsInput,
+  async execute(input, { client, signal, onScopeResolved }) {
+    const { project, sortedProjects } = await resolveProjectOrThrow(
+      { client, signal, onScopeResolved },
+      input.project
+    );
+    const page = await client.listProjectSkills(
+      { projectId: project.id },
+      { signal }
+    );
+    return {
+      project: toSelectedProjectInfo(project),
+      items: page.items,
+      otherProjects: toOtherProjects(sortedProjects, project.id),
+    };
+  },
+};
+
+const getProjectSkillInput = z.object({
+  project: z
+    .string()
+    .trim()
+    .min(1)
+    .optional()
+    .describe(PROJECT_SELECTOR_DESCRIPTION),
+  skillId: z
+    .string()
+    .trim()
+    .min(1)
+    .describe("Skill ID, from list_project_skills."),
+});
+export type GetProjectSkillInput = z.infer<typeof getProjectSkillInput>;
+
+export type GetProjectSkillResult = {
+  project: SelectedProjectInfo;
+  skill: PlatformProjectSkillDetail;
+};
+
+export const getProjectSkillOperation: PlatformOperation<
+  GetProjectSkillInput,
+  GetProjectSkillResult
+> = {
+  name: "get_project_skill",
+  title: "Get an MCPJam project skill",
+  description:
+    "Read one Cloud Skill, including its SKILL.md body. Useful for confirming which body a skill currently holds before pinning it into a run — the body is mutable and an edit overwrites the previous one in place, so `aggregateHash` is the only handle on which version you are looking at.",
+  readOnly: true,
+  permalink: noPermalink(
+    "route-not-addressable",
+    "The app's /skills surface selects a skill as component state, so there is no skills/:skillId route to open this row at."
+  ),
+  inputSchema: getProjectSkillInput,
+  async execute(input, { client, signal, onScopeResolved }) {
+    const { project } = await resolveProjectOrThrow(
+      { client, signal, onScopeResolved },
+      input.project
+    );
+    const skill = await client.getProjectSkill(
+      { projectId: project.id, skillId: input.skillId },
+      { signal }
+    );
+    return { project: toSelectedProjectInfo(project), skill };
+  },
+};
+
 // ── Agent Plugins ────────────────────────────────────────────────────────────
 //
 // Read-only. Import, activate, enable/disable and uninstall stay in the app —
@@ -13090,6 +13195,8 @@ export const ALL_OPERATIONS: readonly AnyPlatformOperation[] = [
   restoreEnvironmentOperation,
   listProjectPluginsOperation,
   getPluginVersionOperation,
+  listProjectSkillsOperation,
+  getProjectSkillOperation,
   listImagesOperation,
   getImageOperation,
   createImageOperation,

--- a/sdk/src/platform/types.ts
+++ b/sdk/src/platform/types.ts
@@ -2118,6 +2118,48 @@ export interface PlatformEnvironmentResolved {
   sandboxImageId?: string;
 }
 
+// ── Cloud Skills ─────────────────────────────────────────────────────────────
+//
+// An authored SKILL.md stored in Convex. Environments pin them by id
+// (`skillSelection.skillIds`) and eval runs pin them with `--compose-skill`,
+// so the id is the load-bearing value — and this READ-ONLY surface is the only
+// programmatic way to obtain one. Authoring stays on the app's `/api/web`
+// surface behind the `skills-enabled` beta gate.
+
+/** Why a skill cannot be pinned into an environment's `skillSelection`. */
+export type PlatformSkillPinnability =
+  | { ok: true }
+  | { ok: false; reason: string };
+
+/** One skill visible to the caller: project-shared, or their own draft. */
+export interface PlatformProjectSkill {
+  id: string;
+  projectId: string;
+  /** Load-bearing identity: the on-box dir name and `loadSkill(name)` arg. */
+  name: string;
+  description: string;
+  /** `project` = shared with the org (the only kind an environment may pin). */
+  sharing: "user" | "project";
+  isOwner: boolean;
+  /** Drift key folding in the body and any supporting files. */
+  aggregateHash: string;
+  provenance?: string;
+  /**
+   * Whether this skill may be pinned. Absent on older backends — treat absent
+   * as UNKNOWN, never as `{ok:true}`: a skill with supporting files or extra
+   * frontmatter is rejected at save time, and guessing would just move the
+   * failure later.
+   */
+  pinnability?: PlatformSkillPinnability;
+  createdAt: number;
+  updatedAt: number;
+}
+
+/** One skill with its SKILL.md body (frontmatter stripped). */
+export interface PlatformProjectSkillDetail extends PlatformProjectSkill {
+  content: string;
+}
+
 // ── Agent Plugins ────────────────────────────────────────────────────────────
 //
 // A plugin bundle (agent-plugins.org format) imported into a project. Each

--- a/sdk/tests/platform/operations.test.ts
+++ b/sdk/tests/platform/operations.test.ts
@@ -2025,6 +2025,8 @@ describe("operation catalog consistency", () => {
     get_project_environment_capabilities: {},
     list_project_plugins: {},
     get_plugin_version: { pluginVersionId: "pv" },
+    list_project_skills: {},
+    get_project_skill: { skillId: "sk" },
     get_project_environment: { environment: "e" },
     resolve_project_environment: { environment: "e" },
     create_project_environment: { name: "e", hostId: "h" },


### PR DESCRIPTION
## The bug

**Harness eval runs have been failing on `main` since 2026-08-20 for any run that carries skills.** Not a limitation — a regression.

#4146 wired a run's pinned skills into `pinnedSkillSource` for every eval iteration, but neither iteration path learned that a harness must not receive them. A harness gets its pins as SKILL.md on the box via `pinnedHarnessSkills`; `prepareChatV2` throws when handed both. Four unconditional hops later, `harness` and `skillsSource` arrive together and the iteration dies at setup:

```
error: "Pinned skills are not supported on harness runs (they live-fetch skills)."
status: setup_failed   tokensUsed: 0
```

Runs with **no** skills attached stayed green, which is why it shipped unnoticed.

Reproduced against production before writing any code: two harness runs against `mcp.excalidraw.com`, both `setup_failed` with `tokensUsed: 0`, `executionEngine: harness:claude-code`.

## The fix

The throw is **correct and stays**. The two delivery channels are deliberately disjoint — delivering both would hand the model the same skill twice, once as an in-memory `loadSkill` tool and once as an on-box copy. What was wrong was:

1. **The callers.** `resolveIterationSkillsSource` is now the one place both iteration paths ask, so they cannot drift apart again. Same shape and same reason as the neighbouring `runFrozenSkillOptions`, whose own docstring describes this exact family of seam bug.
2. **The message.** It claimed "harness runs live-fetch skills". That stopped being true when on-box pinned delivery landed in #3405/#3446 — `run-harness-turn` does not call `fetchRuntimeSkills` at all in pinned mode. The stale wording is what sent me into the backend repo to answer a one-line question. It now tells the caller what to pass instead.

The undocumented "Decision 11" the old comment cited appears nowhere in either repo; the test guarding the throw states the real intent (channel disjointness), and that intent is preserved.

## Also fixed

**Adoption could corrupt an A/B mid-experiment.** Turn-end skill adoption wasn't gated on the turn being pinned. Eval runs set no `executionScope`, so nothing stopped a pinned harness run from syncing an agent-authored on-box skill back into the live project pool — mutating what the *next* arm resolves against, between two runs meant to differ only in their pinned skills. `shouldAdoptSandboxSkills` now names every condition and is tested directly.

**A feature-gate refusal rendered as an opaque 500.** The backend throws a perfectly good `ConvexError({code: "FEATURE_UNAVAILABLE"})` when `skills-enabled` is off, but `CODE_STATUS` in `cloud-skills.ts` didn't map that code, so it fell through to a message-regex fallback that doesn't match "… is not currently available for your organization". Users saw `[Request ID: …] Server Error` instead of the reason. Now a 403 carrying the backend's real message — matching what `routes/v1/convex-errors.ts` already documents and does.

**Skill IDs were unobtainable from any unattended surface.** Three CLI flags demand one — `eval run --compose-skill`, `eval cases run --compose-skill`, `environments ensure-adhoc --skill` — and the only way to learn one was to open the web app, because authoring lives on `/api/web` while the CLI is a thin client over `/api/v1`. This adds the read half:

- `GET /v1/projects/:projectId/skills` and `/skills/:skillId`
- `listProjectSkills` / `getProjectSkill` on the SDK client, plus the two operations
- `mcpjam cloud skills list|get`

Read-only, same policy as `cloud plugins`: authoring is a project-admin app flow behind a beta gate and the SDK ships no skill write. Each row reports `pinnability`, since an id that can't be pinned isn't a usable answer to "what do I pass to `--compose-skill`".

## Registration

Every surface partition that demands it, because each has a drift guard and each one caught me:

| surface | entry |
|---|---|
| MCP catalog + README table | listed (read-only, like plugins) |
| agent-op registry | excluded, with a reason |
| CLI op-bindings | bound to the new commands |
| SDK permalink allowlist | `route-not-addressable` — no `/skills/:id` page exists |
| v1 ↔ SDK coverage map | mapped |
| `openapi.json` | documented (tag, 3 schemas, 2 paths) |

The spec is documented rather than baselined, per that file's own doctrine: "an entry without a reason is a backlog item wearing a decision's clothes."

## Verification

| suite | result |
|---|---|
| evals + harness | 1016 passed |
| v1 routes (incl. openapi drift, sdk coverage) | 1321 passed |
| SDK platform | 282 passed |
| MCP package | 56 passed |
| CLI | 1153 passed |
| server typecheck | identical to baseline — 267 pre-existing, **0 new** |

`mcpjam cloud skills list` resolves the project and reaches the endpoint; it 404s until the server route deploys, which is expected and the only thing not verified end-to-end.

## Not in this PR

The structural gap behind all of this — **authored skills have no immutable version identity**, so you can't A/B v1 vs v2 of the same skill — is a schema change in `mcpjam-backend` and gets its own PR. Design notes are in `mcpjam-docs/skills-version-identity.md`.

Also deferred, both backend-repo: environment clone + `EnvironmentOverrides.skillIds` (building the second arm is currently a 20-item checkbox rebuild), and a skill row in `buildEvalRunDiff` (nothing today tells you two runs differed in skills).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes eval harness skill routing and adoption gates on production eval paths; the new read APIs are low-risk, but incorrect routing could still break harness runs or A/B integrity.
> 
> **Overview**
> Fixes a **harness eval regression** where runs with pinned skills failed at setup (`tokensUsed: 0`) because pinned skills were passed to `prepareChatV2` while harness delivery already materializes them on-box. Both eval iteration paths now use **`resolveIterationSkillsSource`**, which forces `skillsSource: { kind: "none" }` whenever a harness is active; the `prepareChatV2` error text now points callers at **`pinnedHarnessSkills`** instead of stale “live-fetch” wording.
> 
> **Harness turn-end skill adoption** is blocked when the turn used pinned skills (`shouldAdoptSandboxSkills`), so agent-authored on-box skills cannot be synced back into the project pool and skew skill A/B comparisons.
> 
> Adds a **read-only Cloud Skills** path end-to-end: `GET /v1/projects/:projectId/skills` (+ detail), SDK `listProjectSkills` / `getProjectSkill`, **`mcpjam cloud skills list|get`**, and matching MCP catalog tools—with `pinnability` on list rows for `--compose-skill` / environment pins. Skill authoring stays app-only.
> 
> Maps backend **`FEATURE_UNAVAILABLE`** (`skills-enabled` gate) to **403** with the real message instead of an opaque 500.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d99dda987000ec0d5540b203de9d2761a516eaf0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes harness eval runs failing at setup whenever they carry skills, and adds a read-only Cloud Skills API so skill IDs are obtainable from the CLI, SDK, and MCP catalog without opening the web app.

**Bug Fixes**
- Harness eval iterations died at setup with `tokensUsed: 0` when pinned skills reached `prepareChatV2`; both iteration paths now resolve the skills source through one seam that keeps pins off the harness path.
- `prepareChatV2`'s refusal message now tells callers what to pass instead of the stale "harness runs live-fetch skills" claim.
- Turn-end adoption no longer runs out of pinned harness turns, which could write an agent-authored skill back into the project pool mid-A/B and change what the next arm resolves against.
- Feature-gate refusals now surface as a 403 with the backend's message rather than an opaque `Server Error` 500.

**New Features**
- Adds `GET /v1/projects/:projectId/skills` and `/skills/:skillId`, SDK `listProjectSkills` / `getProjectSkill`, and `mcpjam cloud skills list|get`.
- Skill rows report `pinnability` so callers know which IDs are usable with `--compose-skill` and environment `skillSelection`.
- Skills are read-only on the public surface; authoring stays in the web app behind the beta gate.

<sup>Written for commit d99dda987000ec0d5540b203de9d2761a516eaf0. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/MCPJam/inspector/pull/4409?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

