### PR TITLE
Unbreak main: put the Cloud Skills reads on one side of the workspace partition

### DIFF
--- a/mcpjam-inspector/server/utils/built-in-tools/mcpjam.ts
+++ b/mcpjam-inspector/server/utils/built-in-tools/mcpjam.ts
@@ -429,6 +429,16 @@ export const EXCLUDED_FROM_WORKSPACE: Readonly<Record<string, string>> = {
   export_server: "Emits a full server config including its auth shape.",
   show_servers:
     "The widget-bearing variant for MCP Apps hosts, not in-app chat.",
+
+  // Cloud Skills, the read half. Advertised on the agent catalog
+  // (`mcp/src/tools/platformTools.ts`) because an agent driving eval runs
+  // cannot pin a skill it cannot name. In-app chat is the surface where that
+  // argument does NOT hold: the person is already looking at /skills, which
+  // lists the same rows with the pinnability and the body beside them.
+  list_project_skills:
+    "Skill IDs are load-bearing on the agent catalog, not in in-app chat: the /skills surface lists the same rows with each one's pinnability inline, which is the half of the answer an id alone leaves out. Available on REST/CLI/MCP.",
+  get_project_skill:
+    "Paired with the list above; /skills renders the SKILL.md body next to the aggregateHash that says which version it is, and the body is mutable so that pairing is the point.",
 };
 
 const OPERATIONS_BY_ID = new Map(


### PR DESCRIPTION
`main` is red, and has been since #4409. Every open PR inherits the failure.

## The failure

`Inspector Tests 3/4`, in `mcpjam-inspector/server/utils/__tests__/mcpjam-built-in-tools.test.ts:249` — "covers every operation exactly once":

```
AssertionError: expected [ 'get_project_skill', …(1) ] to deeply equal []
+ [ "get_project_skill", "list_project_skills" ]
```

| main commit | Tests |
|---|---|
| `2e4acc6` (#4407) | ✅ success |
| `fbe5a24` (#4409) Skills: unbreak harness eval runs… | ❌ failure |
| `79e5cff` (#4412) — current `main` | ❌ failure |

## Cause

#4409 added `listProjectSkillsOperation` and `getProjectSkillOperation` to the SDK's `ALL_OPERATIONS`, and to `PLATFORM_CATALOG_OPERATIONS` in `mcp/src/tools/platformTools.ts` (lines 72–73, 283–284). It did not add them to either `WORKSPACE_OPERATIONS` or `EXCLUDED_FROM_WORKSPACE` in `server/utils/built-in-tools/mcpjam.ts`, which until this PR contained zero occurrences of "skill".

The ratchet requires every SDK operation to sit on exactly one side of that partition, so a new operation cannot appear in — or be quietly withheld from — the chat toolset without a deliberate edit. It did its job; the edit just never happened.

## Why excluded rather than advertised

Both repairs clear the ratchet, so this is a judgment call and worth stating plainly.

The agent catalog's own comment explains why *it* carries them: skill IDs are load-bearing on that catalog (`set_eval_suite_environments`, `run_eval_suite`'s composed stacks), and "an agent that cannot list them cannot use the tools that demand them."

In-app chat is the surface where that argument does not hold. The person is already looking at `/skills`, which lists the same rows with each one's `pinnability` inline and renders the `SKILL.md` body next to the `aggregateHash` that identifies which version it is — and the body is mutable, so that pairing is the point. An id handed back in chat is the half of the answer that leaves all of it out. This matches the many existing `"Available on REST/CLI/MCP"` entries in the exclusion list.

Advertising them instead would also trip the pin two tests up — "the operation names the backend catalog rows must mirror" — which reaches into `mcpjam-backend`. That is a wider change than unbreaking `main` warrants, and it remains available as a follow-up if chat exposure is what was intended: this PR is a two-entry edit to reverse.

Both operations stay available on REST, the CLI and MCP. Nothing is removed.

## Testing

Ran the exact shard CI was failing:

```
npx cross-env NODE_OPTIONS=--max-old-space-size=6144 vitest run --shard=3/4
Test Files  365 passed | 3 skipped (368)
      Tests  4838 passed | 7 skipped (4845)
```

`mcpjam-built-in-tools.test.ts` on its own: 21 passed. Prettier clean.

Found while driving MCPJam/inspector#4414 to green; that PR is unrelated to skills and stays scoped to its own fixes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015NJXFGMbHuWFa23PXQRz83

---
_Generated by [Claude Code](https://claude.ai/code/session_015NJXFGMbHuWFa23PXQRz83)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Policy-only classification in the workspace built-in tools map to satisfy tests; no auth, data, or API removal.
> 
> **Overview**
> Fixes the **`mcpjam-built-in-tools`** partition failure on `main` by explicitly placing **`list_project_skills`** and **`get_project_skill`** in **`EXCLUDED_FROM_WORKSPACE`** instead of leaving them uncovered after #4409 added them to the SDK catalog.
> 
> The new entries document why in-app chat should not expose these reads: **`/skills`** already shows skill rows with pinnability and renders **`SKILL.md`** next to **`aggregateHash`**, while the agent catalog still needs skill IDs for eval pinning. **REST, CLI, and MCP** behavior is unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b3b82d93ac89099e178f953d8544c672ae961fce. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the red main branch by classifying `list_project_skills` and `get_project_skill` as excluded from the workspace partition, so the exposure ratchet passes again.

- Both operations are now in `EXCLUDED_FROM_WORKSPACE`, not advertised in in-app chat.
- They remain available on REST, CLI, and MCP.

<sup>Written for commit b3b82d93ac89099e178f953d8544c672ae961fce. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/MCPJam/inspector/pull/4416?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

