### PR TITLE
harness: let the Claude Code bootstrap install its CLI on modern pnpm

### DIFF
--- a/.changeset/harness-pnpm-allow-builds.md
+++ b/.changeset/harness-pnpm-allow-builds.md
@@ -1,0 +1,14 @@
+---
+"@mcpjam/inspector": patch
+---
+
+Let the Claude Code harness bootstrap install its CLI on modern pnpm.
+
+`@anthropic-ai/claude-code` ships a `postinstall` that fetches its
+platform-native binary. pnpm 10 stopped running dependency build scripts by
+default, and the computer template installs pnpm unpinned — so on a pnpm that
+treats the skipped script as an error (`ERR_PNPM_IGNORED_BUILDS`) the
+bootstrap's `pnpm install` aborts, taking the adapter's own `install.cjs`
+rescue step down with it, and the harness dies before its first turn.
+
+The bootstrap now writes an `.npmrc` beside the adapter's bundled manifest.

--- a/mcpjam-inspector/server/utils/harness/__tests__/registry.test.ts
+++ b/mcpjam-inspector/server/utils/harness/__tests__/registry.test.ts
@@ -243,6 +243,48 @@ const toUserMessage = (text) => ({
     );
   });
 
+  it("writes an .npmrc that lets the bootstrap's pnpm run build scripts", async () => {
+    const harness = patchClaudeCodeHarnessBootstrap(
+      createClaudeCode({
+        model: "haiku",
+        auth: {
+          gateway: {
+            apiKey: "test",
+            baseUrl: "https://ai-gateway.vercel.sh/v1",
+          },
+        },
+      }) as any
+    );
+
+    const bootstrap = await harness.getBootstrap?.();
+    const npmrc = bootstrap?.files.find((file) =>
+      file.path.endsWith("/.npmrc")
+    );
+
+    // Without this, pnpm skips `@anthropic-ai/claude-code`'s postinstall. On a
+    // pnpm that treats the skip as an error the install step aborts the whole
+    // recipe, so the adapter's own `install.cjs` rescue never runs and the CLI
+    // never exists — the bootstrap dies before a single turn.
+    expect(npmrc?.path).toBe(`${bootstrap?.bootstrapDir}/.npmrc`);
+    expect(npmrc?.content).toContain("dangerously-allow-all-builds=true");
+
+    // It has to sit BESIDE the adapter's manifest, not inside it: the install
+    // runs `--frozen-lockfile`, so amending `package.json` to carry
+    // `onlyBuiltDependencies` would fail the lockfile check. Both halves of
+    // that reasoning are pinned here so a future edit cannot quietly break one.
+    const manifest = bootstrap?.files.find((file) =>
+      file.path.endsWith("/package.json")
+    );
+    if (manifest) {
+      expect(JSON.parse(manifest.content).pnpm).toBeUndefined();
+    }
+    expect(
+      bootstrap?.commands.some((command) =>
+        command.command.includes("--frozen-lockfile")
+      )
+    ).toBe(true);
+  });
+
   it("Claude Code attributes mcp__ tool names", () => {
     const keyToServerId = { weather: "srv_123" };
     expect(

--- a/mcpjam-inspector/server/utils/harness/registry.ts
+++ b/mcpjam-inspector/server/utils/harness/registry.ts
@@ -465,6 +465,36 @@ function patchClaudeCodeBridgeContent(content: string): string {
   return patched;
 }
 
+/**
+ * The `.npmrc` written beside the adapter's bundled manifest, so its
+ * `pnpm install` is allowed to run dependency build scripts.
+ *
+ * WHY THIS EXISTS. `@anthropic-ai/claude-code` ships a `postinstall`
+ * (`node install.cjs`) that fetches its platform-native binary; without it the
+ * CLI starts and immediately reports `claude native binary not installed`.
+ * pnpm 10 stopped running dependency build scripts by default, and the
+ * computer template installs pnpm UNPINNED (`npm install -g pnpm`), so the
+ * behaviour of a rebuilt image changes with whatever pnpm is current.
+ *
+ * The adapter's own recipe already anticipates the skip: after `pnpm install`
+ * it re-runs `install.cjs` by hand. That rescue only fires when the install
+ * step EXITS ZERO. Where the skip is a hard error rather than a warning —
+ * `ERR_PNPM_IGNORED_BUILDS`, which is what a strict or newer pnpm produces —
+ * the install step aborts the whole recipe and the rescue never runs. That is
+ * the failure this file prevents, and it is why a warning-only pnpm looks fine.
+ *
+ * WHY A FILE AND NOT THE MANIFEST. `onlyBuiltDependencies` would be narrower,
+ * but pnpm reads it only from `package.json` / `pnpm-workspace.yaml` — never
+ * from `.npmrc` — and the manifest here is a bundled asset of
+ * `@ai-sdk/harness-claude-code`, not ours to amend. Editing it would also
+ * invalidate the `--frozen-lockfile` the adapter installs with. A sibling
+ * `.npmrc` changes neither, and `--dir` makes pnpm read it.
+ *
+ * The permissiveness is bounded by where it lands: one directory inside a
+ * disposable sandbox that already runs an agent with full shell access.
+ */
+const CLAUDE_CODE_BOOTSTRAP_NPMRC = "dangerously-allow-all-builds=true\n";
+
 export function patchClaudeCodeHarnessBootstrap(
   harness: HarnessAgentAdapter
 ): HarnessAgentAdapter {
@@ -482,11 +512,20 @@ export function patchClaudeCodeHarnessBootstrap(
       const bootstrap = await originalGetBootstrap(...args);
       cachedPatchedBootstrap = {
         ...bootstrap,
-        files: bootstrap.files.map((file) =>
-          file.path.endsWith("/bridge.mjs")
-            ? { ...file, content: patchClaudeCodeBridgeContent(file.content) }
-            : file
-        ),
+        // Appended rather than merged over an existing entry: the adapter
+        // ships no `.npmrc` today, and if a future version starts shipping one
+        // we want the duplicate to surface instead of silently winning.
+        files: [
+          ...bootstrap.files.map((file) =>
+            file.path.endsWith("/bridge.mjs")
+              ? { ...file, content: patchClaudeCodeBridgeContent(file.content) }
+              : file
+          ),
+          {
+            path: `${bootstrap.bootstrapDir}/.npmrc`,
+            content: CLAUDE_CODE_BOOTSTRAP_NPMRC,
+          },
+        ],
       };
       return cachedPatchedBootstrap;
     },


### PR DESCRIPTION
## The failure

Reported from a hosted eval sandbox, during Claude Code harness bootstrap:

```
pnpm --dir /tmp/harness/claude-code install --frozen-lockfile --store-dir /tmp/harness/claude-code/.pnpm-store
→ ERR_PNPM_IGNORED_BUILDS  Ignored build scripts: @anthropic-ai/claude-code
```

`@anthropic-ai/claude-code` ships a `postinstall` (`node install.cjs`) that fetches its platform-native binary. pnpm 10 stopped running dependency build scripts by default.

## Why it aborts the whole bootstrap

The adapter's recipe is three steps, and **step 3 already anticipates the skip**:

```
1. mkdir -p ${BOOTSTRAP_DIR}
2. pnpm --dir ${BOOTSTRAP_DIR} install --frozen-lockfile --store-dir ...
3. cd ${BOOTSTRAP_DIR} && ... node node_modules/@anthropic-ai/claude-code/install.cjs ... && ./node_modules/.bin/claude --version
```

That rescue only fires when step 2 **exits zero**. Where the skip is a warning, step 2 passes and step 3 quietly repairs it. Where it is a hard error, step 2 aborts the recipe and the rescue never runs.

That asymmetry is why this looks environment-dependent: harness evals pass on prod today only because template `ciq83q75k6orlaznpxo7` was built at `90d7d715` (16 Jun), when pnpm was still 9.x.

## The latent version of this bug

`templates/computer/e2b.Dockerfile:36` is `RUN npm install -g pnpm` — **unpinned**. npm's current pnpm is 11.x. A template rebuild is already on the board (`docs/computer-template-rebuild`), and performing it would break harness evals in production for every user with this exact error. This PR defuses that independently of the rebuild.

Pinning pnpm in the Dockerfile is still worth doing as hygiene — an unpinned global install means the image changes meaning over time, which is how this arrived — but it is not the fix and needs a rebuild to take effect.

## The fix

One file, written where we already patch the adapter's bootstrap files:

```ts
{ path: `${bootstrap.bootstrapDir}/.npmrc`, content: "dangerously-allow-all-builds=true\n" }
```

**Why not `onlyBuiltDependencies`**, which would be narrower — three reasons, each verified rather than assumed:

1. pnpm reads it only from `package.json` / `pnpm-workspace.yaml`, **never from `.npmrc`**. I tried that spelling first; it still fails.
2. The manifest is a bundled asset of `@ai-sdk/harness-claude-code`, not ours to amend. Latest `1.0.94` (we ship `1.0.0-canary.9`) still carries no `onlyBuiltDependencies`, so upgrading does not fix it either.
3. Amending it would fail the `--frozen-lockfile` the adapter installs with.

A sibling `.npmrc` changes neither the manifest nor the lockfile, and `--dir` makes pnpm read it. Bootstrap `files` are written before any command runs, so it is in place for step 2.

The permissiveness is bounded by where it lands: one directory inside a disposable sandbox already running an agent with full shell access.

## Verification

Replayed the adapter's exact invocation from a different cwd, against a real `@anthropic-ai/claude-code` install:

```
BEFORE   ERR_PNPM_IGNORED_BUILDS  Ignored build scripts: @anthropic-ai/claude-code
AFTER    Done in 2s using pnpm v10.18.1  →  2.1.146 (Claude Code)
```

Also confirmed the non-strict path's failure mode, which is quieter and worse — install exits 0 and the CLI fails at runtime with Claude Code's own message: `claude native binary not installed. Either postinstall did not run (--ignore-scripts, some pnpm configs)…`

`server/utils/harness/`: **347 tests passing**, including a new one asserting the `.npmrc` lands at `${bootstrapDir}/.npmrc`, that the manifest is left without a `pnpm` field, and that the install still uses `--frozen-lockfile` — so a future edit cannot quietly break the reasoning above.

One pre-existing failure in that directory, `plugin-delivery.test.ts`, is a missing generated bundle (`PluginShim.bundled.js`) in a fresh worktree. Confirmed identical with this change stashed.

## Note on recipe identity

`HarnessV1Bootstrap` is hashed into an identity used for snapshot-based sandbox reuse. Adding a file changes that hash, which correctly invalidates snapshots built without the `.npmrc` — intended, and the reason this reaches boxes that were already warm.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01B2roGnZkf28Ry5GSo26BWB

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit 7f8f519080ebd6e0c6022409aa2caa64a345b2a4. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stops the Claude Code harness bootstrap from failing on modern pnpm by writing an `.npmrc` with `dangerously-allow-all-builds=true` beside the adapter's bundled manifest. Without it, pnpm 10 skips `@anthropic-ai/claude-code`'s `postinstall`, and on a strict pnpm the install step aborts with `ERR_PNPM_IGNORED_BUILDS`, so the adapter's hand-run `install.cjs` rescue never fires. This makes the bootstrap succeed regardless of pnpm's strictness, but it does change the bootstrap's identity hash, which invalidates pre-built sandbox snapshots so they rebuild with the new file.

<sup>Written for commit 7f8f519080ebd6e0c6022409aa2caa64a345b2a4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/MCPJam/inspector/pull/4418?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

