### PR TITLE
The agent turn advertises Skills over MCP

### DIFF
--- a/.changeset/hosted-turn-advertises-skills.md
+++ b/.changeset/hosted-turn-advertises-skills.md
@@ -1,0 +1,15 @@
+---
+"@mcpjam/inspector": patch
+---
+
+The agent turn advertises Skills over MCP, so a server that serves skills is visible to it
+
+MCPJam serves Agent Skills over SEP-2640 and verifies them on the way in — but its own hosted agent surface (`send_chat_message` / the `/v1` chat turn) could never see one. Driving the playground against a skills-serving server returned `advertisedToolCount: 0`, and the model answered that it had no tool-calling interface at all: `withServerSkills` filters to extension-active connections, the hosted connection advertised nothing, so no `listSkills` / `loadSkill` was ever merged. A server that serves skills was indistinguishable from one that does not.
+
+`withSkillsExtensionCapability` had exactly one call site — the LOCAL connect path.
+
+The declaration is opt-in rather than blanket, because most hosted connections **emulate a third-party host** and the debugger's whole promise is that the wire shows what that host would send; advertising skills on an emulated Cursor persona would be a lie about Cursor. The agent turn emulates no persona, pins no host config, and ships the fulfiller (`prepareChatV2` merges `withServerSkills`, which loads only through the verified read path in `server-skills.ts`), so advertise = enforce is satisfied there and nowhere else changes.
+
+It is set on the manager's **defaults**, not on per-server `clientCapabilities`. The latter takes `MCPClientManager`'s exact-set branch and is advertised verbatim: since the default set declares `io.modelcontextprotocol/ui`, routing the extension through it would have silently stopped the agent turn advertising MCP Apps and lost widget rendering. It would also have overridden any host config that pinned its own capability set. Defaults merge; a pinned exact set still wins.
+
+Tested with that concrete regression pinned — the capability object alone carries skills and not `ui`, and the merged result carries both.

--- a/mcpjam-inspector/server/routes/v1/__tests__/chat-sessions.test.ts
+++ b/mcpjam-inspector/server/routes/v1/__tests__/chat-sessions.test.ts
@@ -1,4 +1,10 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  withSkillsExtensionCapability,
+  clientDeclaresSkillsExtension,
+  mergeClientCapabilities,
+  getDefaultClientCapabilities,
+} from "@mcpjam/sdk";
 import { Hono } from "hono";
 
 /**
@@ -662,6 +668,64 @@ describe("allowedServerIds narrowing", () => {
       undefined,
     );
     expect(result.names).toBeUndefined();
+  });
+});
+
+// ── Skills extension declaration ────────────────────────────────────────────
+
+describe("skills capability on the agent turn", () => {
+  it("declares the extension in a form the SDK's own gate recognises", () => {
+    // The bug this pins: a hosted turn that advertises nothing leaves the
+    // extension inactive, so `withServerSkills` merges no tools and the model
+    // is handed no `listSkills` / `loadSkill` at all — a server that serves
+    // skills is then indistinguishable from one that does not.
+    //
+    // Asserted through `clientDeclaresSkillsExtension`, the same predicate the
+    // dispatch gate uses, rather than against a hand-written object: a
+    // declaration the gate does not accept is not a declaration. `true` or a
+    // misspelled id would satisfy a shape check and fail this.
+    expect(clientDeclaresSkillsExtension(withSkillsExtensionCapability({}))).toBe(
+      true,
+    );
+  });
+
+  it("MERGES with the SDK defaults instead of replacing them", () => {
+    // The regression this exists to prevent, named concretely. Passing the
+    // extension as a per-server `clientCapabilities` takes
+    // `MCPClientManager`'s exact-set branch, which advertises the object
+    // VERBATIM — and the default set declares `io.modelcontextprotocol/ui`,
+    // so the agent turn would silently stop advertising MCP Apps and lose
+    // widget rendering. The fix sets it on the manager's DEFAULTS, which
+    // merge.
+    const UI = "io.modelcontextprotocol/ui";
+    const SKILLS = "io.modelcontextprotocol/skills";
+
+    const alone = withSkillsExtensionCapability({}) as {
+      extensions?: Record<string, unknown>;
+    };
+    // The counterfactual is what gives the merge its point: alone, this
+    // object carries skills and nothing else.
+    expect(alone.extensions).toHaveProperty(SKILLS);
+    expect(alone.extensions).not.toHaveProperty(UI);
+
+    // `mergeClientCapabilities(getDefaultClientCapabilities(), …)` is exactly
+    // what the manager constructor does with `defaultCapabilities`, so this
+    // asserts the real composition rather than an approximation.
+    const merged = mergeClientCapabilities(
+      getDefaultClientCapabilities(),
+      withSkillsExtensionCapability({}),
+    ) as { extensions?: Record<string, unknown> };
+    expect(merged.extensions).toHaveProperty(SKILLS);
+    expect(merged.extensions).toHaveProperty(UI);
+    expect(clientDeclaresSkillsExtension(merged)).toBe(true);
+  });
+
+  it("leaves a connection that declares nothing inactive", () => {
+    // The other half of advertise = enforce: absence stays absent, so an
+    // emulated third-party host does not start claiming skills support it
+    // was never configured for.
+    expect(clientDeclaresSkillsExtension({})).toBe(false);
+    expect(clientDeclaresSkillsExtension(undefined)).toBe(false);
   });
 });
 

--- a/mcpjam-inspector/server/routes/v1/chat-session-turn.ts
+++ b/mcpjam-inspector/server/routes/v1/chat-session-turn.ts
@@ -904,7 +904,17 @@ async function handleTurn(c: Context): Promise<Response> {
         ...(selectedServerNames ? { serverNames: selectedServerNames } : {}),
       },
       connectionSchema,
-      { timeoutMs: CONNECT_TIMEOUT_MS },
+      {
+        timeoutMs: CONNECT_TIMEOUT_MS,
+        // This surface emulates no host persona — it is MCPJam's own agent —
+        // and it ships the fulfiller, since `prepareChatV2` merges
+        // `withServerSkills`, which loads only through the verified read path
+        // in `server-skills.ts`. Without the declaration the extension can
+        // never be active: the model is handed no `listSkills` / `loadSkill`
+        // at all, so a server that serves skills is indistinguishable from one
+        // that does not.
+        advertiseSkillsExtension: true,
+      },
     );
     manager = connection.manager;
 

--- a/mcpjam-inspector/server/routes/web/auth.ts
+++ b/mcpjam-inspector/server/routes/web/auth.ts
@@ -4,6 +4,7 @@ import {
   MCPClientManager,
   isKnownProtocolVersion,
   isStatelessProtocolVersion,
+  withSkillsExtensionCapability,
   type McpProtocolVersion,
 } from "@mcpjam/sdk";
 import type {
@@ -1035,6 +1036,25 @@ export async function createAuthorizedManager(
   clientCapabilities?: Record<string, unknown>,
   options?: {
     accessScope?: "project_member" | "chat_v2";
+    /**
+     * Declare `io.modelcontextprotocol/skills` on this manager's DEFAULTS.
+     *
+     * Opt-in, and deliberately not the norm. Most hosted connections EMULATE a
+     * third-party host, and the debugger's promise is that the wire shows what
+     * that host would send — advertising skills on an emulated Cursor persona
+     * would be a lie about Cursor. Surfaces that emulate no persona (MCPJam's
+     * own agent turn) pass this, because they ship the fulfiller: the verified
+     * read path in `server-skills.ts`, merged into the toolset by
+     * `withServerSkills`.
+     *
+     * Set on DEFAULTS rather than per-server `clientCapabilities` on purpose.
+     * The latter is advertised VERBATIM (see `MCPClientManager`'s exact-set
+     * branch), so putting the extension there would replace a connection's
+     * whole declaration — silently dropping elicitation — and would also
+     * override a host config that pinned its own set. Defaults merge, and a
+     * pinned exact set still wins.
+     */
+    advertiseSkillsExtension?: boolean;
     scenarioId?: string;
     accessVersion?: number;
     rpcLogger?: RpcLogger;
@@ -1815,6 +1835,9 @@ export async function createAuthorizedManager(
     rpcLogger: options?.rpcLogger,
     httpLogger: options?.httpLogger,
     retryPolicy: INSPECTOR_MCP_RETRY_POLICY,
+    ...(options?.advertiseSkillsExtension
+      ? { defaultCapabilities: withSkillsExtensionCapability({}) }
+      : {}),
     // Auto-negotiation outcome telemetry (always-on negotiation).
     negotiationOutcomeLogger: negotiationTelemetryLogger("hosted-direct"),
     ...(options?.elicitationTimeoutExtensionMs !== undefined
@@ -2109,6 +2132,8 @@ export async function createManualHostedConnection<S extends z.ZodTypeAny>(
     mrtrInputCollectorForServer?: (
       serverId: string
     ) => MrtrInputCollector | undefined;
+    /** See `createAuthorizedManager`'s option of the same name. */
+    advertiseSkillsExtension?: boolean;
   }
 ): Promise<{
   manager: InstanceType<typeof MCPClientManager>;
@@ -2199,6 +2224,9 @@ export async function createManualHostedConnection<S extends z.ZodTypeAny>(
       accessScope,
       scenarioId,
       accessVersion,
+      ...(options?.advertiseSkillsExtension
+        ? { advertiseSkillsExtension: true }
+        : {}),
       rpcLogger: options?.rpcLogger,
       httpLogger: options?.httpLogger,
       serverNames,


### PR DESCRIPTION
Found by driving the playground against a skills-serving server after #4397/#4398 shipped.

## The bug

MCPJam serves Agent Skills over SEP-2640 and verifies them on the way in — but its **own** hosted agent surface could never see one.

```
send_chat_message → allowedTools: ["get_me", "listSkills"]
  advertisedToolCount: 1     ← get_me matched
  excludedToolCount:  142    ← listSkills did NOT
```

The model said so itself: *"I don't have a tool-calling interface available."* It had been handed zero tools.

`withServerSkills` filters to extension-active connections. The hosted connection advertised nothing, so nothing merged, and **a server that serves skills was indistinguishable from one that does not.**

```
$ grep -rn 'withSkillsExtensionCapability' mcpjam-inspector/server
local-server-resolver.ts:659    ← one call site. The LOCAL path.
```

## Why opt-in rather than blanket

Most hosted connections **emulate a third-party host**, and the debugger's whole promise is that the wire shows what that host would send. Advertising skills on an emulated Cursor persona would be a lie about Cursor — which is exactly why the local path's comment says the declaration should come from a host config.

The agent turn is the exception: it emulates no persona, pins no host config, and ships the fulfiller — `prepareChatV2` merges `withServerSkills`, which loads only through the verified read path in `server-skills.ts`. So advertise = enforce is satisfied there, and nowhere else changes.

## Why on defaults, not per-server capabilities

**I wrote this the wrong way first.** Passing the extension as per-server `clientCapabilities` takes `MCPClientManager`'s exact-set branch, which advertises the object **verbatim**. The default set declares `io.modelcontextprotocol/ui` — so that version would have silently stopped the agent turn advertising MCP Apps and **lost widget rendering**. It would also have overridden any host config that pinned its own set.

Setting it on the manager's `defaultCapabilities` merges instead; a pinned exact set still wins.

That regression is now a test rather than a comment: the capability object alone carries `skills` and not `ui`; the merged result carries both.

## Testing

`chat-sessions.test.ts` 51 pass, server skills suites 93 pass total, typecheck clean for the touched files.

**Not yet verified end-to-end** — the agent turn runs on the hosted backend, so this needs a deploy before the playground can be retried. That retry is the real acceptance test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes MCP initialize capability advertisement for one hosted surface; incorrect merging could affect tool/MCP Apps exposure, but scope is limited to opt-in agent turns with explicit regression tests.
> 
> **Overview**
> The hosted **agent Playground** turn (`POST /v1/chat-sessions/messages`) could connect to skills-serving MCP servers but never activated the Skills extension on initialize, so `withServerSkills` did not merge **`listSkills` / `loadSkill`** and the model saw no skills tools.
> 
> This PR adds an **opt-in** `advertiseSkillsExtension` flag on `createAuthorizedManager` / `createManualHostedConnection`. When set, it applies `withSkillsExtensionCapability` to the manager’s **`defaultCapabilities`** (merged with SDK defaults), not per-server `clientCapabilities` — avoiding a regression where a verbatim capability set would drop **`io.modelcontextprotocol/ui`** and break MCP Apps. Only the agent turn enables it; emulated third-party host connections stay unchanged.
> 
> Tests pin the SDK’s `clientDeclaresSkillsExtension` gate, merged defaults (skills **and** UI), and that empty capabilities remain inactive.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4aa28f0ef4cf587379b1c5a5ecc08b59346ede73. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the hosted agent turn so it advertises Skills over MCP — previously it advertised nothing, so a server serving skills was indistinguishable from one that did not and the model was handed zero tools.

- The declaration is opt-in; hosted connections that emulate a third-party host keep advertising only what that host would send.
- The agent turn emulates no persona and ships the fulfiller, so advertise equals enforce there.
- It's set on the manager's defaults, which merge; per-server capability sets are advertised verbatim and would silently drop the `ui` extension, losing widget rendering.
- Adds tests pinning that the merged defaults keep `ui` alongside skills.

<sup>Written for commit 4aa28f0ef4cf587379b1c5a5ecc08b59346ede73. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/MCPJam/inspector/pull/4419?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

