### PR TITLE
chore: add release changeset for inspector, CLI, and SDK

### DIFF
--- a/.changeset/probe-listchanged-structuredcontent.md
+++ b/.changeset/probe-listchanged-structuredcontent.md
@@ -1,0 +1,8 @@
+---
+"@mcpjam/inspector": patch
+"@mcpjam/cli": patch
+"@mcpjam/sdk": patch
+---
+
+Improve MCP profile probing and host compatibility support for tool-list changes,
+structured tool results, and MCP Apps.


### PR DESCRIPTION
Adds one patch changeset covering the MCP profile and host compatibility updates for @mcpjam/inspector, @mcpjam/cli, and @mcpjam/sdk.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a patch changeset for `@mcpjam/inspector`, `@mcpjam/cli`, and `@mcpjam/sdk` covering MCP profile probing and host compatibility updates.

<sup>Written for commit 742b758050b99c24e99aacd2ad1f5db970955eec. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/MCPJam/inspector/pull/4420?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

