### PR TITLE
Stop the backend preview jobs checking out a backend branch in this repo

### DIFF
--- a/.github/workflows/pr-preview.yml
+++ b/.github/workflows/pr-preview.yml
@@ -399,10 +399,19 @@ jobs:
       DEFAULT_BACKEND_CONVEX_HTTP_URL: ${{ vars.PREVIEW_BACKEND_CONVEX_HTTP_URL || vars.STAGING_CONVEX_HTTP_URL }}
       STAGING_APP_URL: ${{ vars.STAGING_APP_URL || 'https://staging.mcpjam.com' }}
     steps:
+      # `client_payload.branch` is the *backend* PR's head ref, and for
+      # `backend_pr_preview_requested` it is the only ref the dispatch sends
+      # (mcpjam-backend/.github/workflows/backend-pr-inspector-preview.yml).
+      # Handing it to actions/checkout asked *this* repo for a branch that
+      # only exists in mcpjam-backend, so the fetch hard-failed and the
+      # `|| 'main'` fallback was never reached -- this job failed on every
+      # run from the day it was added. A backend-only PR wants the inspector
+      # at its default branch anyway; the co-developed inspector-PR case
+      # arrives as `backend_preview_ready` carrying a real inspector ref.
       - name: Checkout default branch
         uses: actions/checkout@v4
         with:
-          ref: ${{ github.event.client_payload.inspector_sha || github.event.client_payload.inspector_git_ref || github.event.client_payload.branch || 'main' }}
+          ref: ${{ github.event.client_payload.inspector_sha || github.event.client_payload.inspector_git_ref || 'main' }}
 
       - name: Resolve deployed commit metadata
         id: preview_commit
@@ -797,10 +806,15 @@ jobs:
       PREVIEW_BACKEND_CONFIGURED: ${{ vars.PREVIEW_BACKEND_VITE_CONVEX_URL != '' }}
       STAGING_APP_URL: ${{ vars.STAGING_APP_URL || 'https://staging.mcpjam.com' }}
     steps:
+      # Never fall back to `client_payload.branch` here either: it names a
+      # branch in mcpjam-backend, not in this repo. See the same checkout in
+      # `upsert-backend-pr-preview` above. `backend_preview_ready` and
+      # `backend_preview_failed` normally carry `inspector_git_ref`, so this
+      # only bites when that resolves empty -- but then it bites the same way.
       - name: Checkout code
         uses: actions/checkout@v4
         with:
-          ref: ${{ github.event.client_payload.inspector_sha || github.event.client_payload.inspector_git_ref || github.event.client_payload.branch || 'main' }}
+          ref: ${{ github.event.client_payload.inspector_sha || github.event.client_payload.inspector_git_ref || 'main' }}
 
       - name: Resolve deployed commit metadata
         id: preview_commit


### PR DESCRIPTION
## What was red

`upsert-backend-pr-preview` has failed **26 of 26 runs** since it was added — zero successes, ever.

It surfaces as a red check on whatever commit most recently landed on `main` (most recently `dda771b`, #4419), because `repository_dispatch` runs carry no branch context and GitHub attributes their check runs to the default branch's head SHA. The commits it lands on have nothing to do with it.

## Root cause

The checkout used this ref chain:

```
inspector_sha || inspector_git_ref || client_payload.branch || 'main'
```

The dispatch that triggers this job (`mcpjam-backend/.github/workflows/backend-pr-inspector-preview.yml`) sends only `branch`, `backend_pr_number`, and `backend_repo` — **never** an inspector ref. So it always fell through to `client_payload.branch`, which is the *backend* PR's head ref, and asked `MCPJam/inspector` for a branch that only exists in `mcpjam-backend`:

```
fetch ... +refs/heads/claude/mcp-benchmarks-v2-b0tw4b-be1*
The process '/usr/bin/git' failed with exit code 1
```

`actions/checkout` hard-fails on a missing ref rather than falling through, so the trailing `|| 'main'` was dead code.

## The change

Drop `client_payload.branch` from both dispatch checkout chains.

A backend-only PR wants the inspector at its default branch — which is what the step is already named for. The co-developed inspector-PR case arrives as `backend_preview_ready`, which *does* carry a real `inspector_git_ref`, so that path is unchanged.

`sync-backend-preview` (line ~803) had the identical fallback and is fixed alongside it. There it was latent rather than firing, since its dispatch does send `inspector_git_ref`.

## Verification

- YAML parses; both refs resolve to `inspector_sha || inspector_git_ref || 'main'`; all 5 jobs intact.
- No changeset or prettier gate covers workflow files.
- **Caveat:** this job only runs on a live backend dispatch, so merging is the real test. The change is a straight deletion of a provably-wrong fallback, but it cannot be exercised from a PR.

## Out of scope — needs a settings change, not code

`sync-backend-preview` separately fails on `backend_preview_failed` with `Resource not accessible by personal access token`: `INSPECTOR_PREVIEW_CALLBACK_TOKEN` lacks permission to post the preview comment. That will keep the backend preview loop broken after this merges, and needs a token-scope fix in repo settings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit b9511f9137cfbca15b62633136bb79c80f807c08. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the backend preview jobs failing on every run by removing a checkout fallback that pointed at a branch that doesn't exist in this repo. Both `upsert-backend-pr-preview` and `sync-backend-preview` now resolve their checkout to `inspector_sha || inspector_git_ref || 'main'`.

- The old `client_payload.branch` fallback was the backend PR's head ref; `actions/checkout` hard-failed when this repo didn't have it, so the trailing `|| 'main'` never ran.
- Backend-only PRs want the inspector's default branch anyway; the co-developed inspector-PR case still arrives with a real `inspector_git_ref`.
- This change can only be exercised by a live backend dispatch, so the merge is the real test.
- `sync-backend-preview` will keep failing on `backend_preview_failed` because the callback token lacks permission to post the preview comment — that needs a token-scope fix in repo settings, not code.

<sup>Written for commit b9511f9137cfbca15b62633136bb79c80f807c08. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/MCPJam/inspector/pull/4424?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

