### PR TITLE
fix(sessions): a session permalink outruns the rollout flag

### DIFF
--- a/.changeset/session-permalink-outruns-rollout-flag.md
+++ b/.changeset/session-permalink-outruns-rollout-flag.md
@@ -1,0 +1,11 @@
+---
+"@mcpjam/inspector": patch
+---
+
+A session permalink opens the session instead of bouncing to Connect
+
+`https://app.mcpjam.com/sessions?session=<id>&project=<id>` — the link every `/v1/sessions` item carries, and the only URL that opens one conversation — landed a viewer on `/p/<projectId>/servers` with the session id dropped and nothing to say why.
+
+Neither the permalink builder nor the legacy `?project=` normalizer was at fault: the normalizer rewrote the URL correctly to `/p/<projectId>/sessions?session=<id>`, and `SessionsRoute` then threw it away, because the viewer's account resolved `unified-sessions-enabled` to `false`. The route guard bounced the whole visit to Connect.
+
+That flag is a ROLLOUT control over who DISCOVERS the feed — the sidebar item, a bare `/sessions` visit — not an authorization boundary. Row-level visibility is entirely server-side (`canViewSessionInProject`), so honouring a link somebody was handed exposes nothing the flag was protecting, and the route's dark-ship `ErrorBoundary` already covers a deployment whose `sessionsFeed:*` queries are not live yet. The guard now skips the redirect when the URL names a session, and is otherwise unchanged: `/sessions` with no id still bounces for a flagged-out viewer, and the pre-hydration `undefined` window still redirects nobody.

--- a/mcpjam-inspector/client/src/App.tsx
+++ b/mcpjam-inspector/client/src/App.tsx
@@ -299,6 +299,7 @@ import {
   scopeNavigationTarget,
   type OrganizationRouteSection,
   useCurrentLocationParts,
+  useCurrentSearchParam,
   useActiveTab,
   useAppNavigate,
   useCurrentOrgRoute,
@@ -1815,10 +1816,28 @@ export function SessionsRoute() {
   const { convexProjectId } = useAppRouteContext();
   const unifiedSessionsEnabled = useUnifiedSessionsEnabledState();
 
+  /**
+   * A permalink names ONE exact session, and this feed is the only screen that
+   * opens one: every `/v1/sessions` item carries `/sessions?session=<id>` as
+   * its link, which the backend mints as the universal target for sessions
+   * whose surface-native page does not exist (an eval Quick Run, a session
+   * whose parent run was deleted). Nothing else in the app can render it.
+   *
+   * So the ROLLOUT flag must not swallow that link. It gates who DISCOVERS the
+   * feed — the sidebar item, an unaddressed `/sessions` visit — not who may
+   * read a session they were handed the id of, and bouncing a permalink to
+   * Connect drops the id on the floor and lands the recipient on a screen they
+   * never asked for, with nothing to say what happened. Row-level visibility
+   * is entirely server-side (`canViewSessionInProject`), so honouring the link
+   * exposes nothing the flag was protecting, and the dark-ship ErrorBoundary
+   * below still covers a deployment whose feed queries are not live yet.
+   */
+  const permalinkSessionId = useCurrentSearchParam("session");
+
   // Only redirect on an explicit `false`. While PostHog hydrates the flag is
   // `undefined`; bouncing then would strand a flagged-in user who cold-loads
   // /sessions directly. (Same tradeoff as SwarmsRoute.)
-  if (unifiedSessionsEnabled === false) {
+  if (unifiedSessionsEnabled === false && !permalinkSessionId) {
     return <ScopedNavigate to={routePaths.servers} replace />;
   }
   if (unifiedSessionsEnabled === undefined) {

--- a/mcpjam-inspector/client/src/__tests__/SessionsRoute.permalink.test.tsx
+++ b/mcpjam-inspector/client/src/__tests__/SessionsRoute.permalink.test.tsx
@@ -1,0 +1,155 @@
+import { render, screen } from "@testing-library/react";
+import { MemoryRouter } from "react-router";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { AppRouteReactContext } from "../lib/app-route-context";
+import { routePaths, useCurrentSearchParam } from "../lib/app-navigation";
+
+/**
+ * The rollout flag must not eat a session permalink.
+ *
+ * Every `/v1/sessions` item carries `/sessions?session=<id>&project=<id>` as
+ * its link, and this feed is the ONLY screen that can open one. A viewer
+ * outside the `unified-sessions-enabled` cohort followed such a link and
+ * landed on `/p/<projectId>/servers`: the normalizer had done its job
+ * (`?project=` → path, `?session=` preserved) and then the route guard bounced
+ * the whole thing, dropping the id with no message. The flag gates DISCOVERY —
+ * the sidebar item, a bare `/sessions` visit — not a link somebody was handed.
+ *
+ * Shape mirrors `EvaluateRoute.flag-hydration.test.tsx`.
+ */
+
+// Controls the tri-state PostHog flag the route guard reads.
+let flagState: boolean | undefined = undefined;
+
+// Convex-shaped ([a-z0-9]{16,64}): `parseProjectPath` rejects anything else,
+// so a placeholder like "project-1" would make the scoped-redirect assertion
+// pass for the wrong reason.
+const PROJECT_ID = "v977phvmg9dtt6exdykq890rjs8awe54";
+const SESSION_ID = "qh75b50ftsbdat1mmsgjvtep8n8d9ysj";
+
+vi.mock("../hooks/useUnifiedSessionsEnabled", () => ({
+  UNIFIED_SESSIONS_FEATURE_FLAG: "unified-sessions-enabled",
+  useUnifiedSessionsEnabledState: () => flagState,
+  useUnifiedSessionsEnabled: () => flagState === true,
+}));
+
+vi.mock("react-router", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("react-router")>();
+  return {
+    ...actual,
+    // Sentinel so a redirect is observable without a real router.
+    Navigate: ({ to }: { to: string }) => (
+      <div data-testid="navigate" data-to={to} />
+    ),
+  };
+});
+
+// The panel itself subscribes to Convex. Stub it, but read the selection out
+// of the URL exactly as the real one does (`useCurrentSearchParam("session")`,
+// see `SessionsPanel`), so these assertions cover the id actually arriving.
+vi.mock("../components/sessions/SessionsPanel", () => ({
+  SessionsPanel: ({ projectId }: { projectId: string }) => (
+    <div
+      data-testid="sessions-panel"
+      data-project-id={projectId}
+      data-selected-session={useCurrentSearchParam("session") ?? ""}
+    />
+  ),
+}));
+
+// App.tsx's import graph pulls in the CodeMirror JSON editor; stub it (and the
+// CodeMirror packages it imports) so the route module loads under jsdom.
+vi.mock("../components/ui/json-editor/codemirror-json-editor", () => ({
+  CodemirrorJsonEditor: () => null,
+}));
+vi.mock("@codemirror/lang-json", () => ({ json: () => ({}) }));
+vi.mock("@codemirror/view", () => ({
+  EditorView: class {},
+  lineNumbers: () => ({}),
+  highlightActiveLine: () => ({}),
+  highlightSpecialChars: () => ({}),
+  keymap: () => ({}),
+}));
+vi.mock("@codemirror/state", () => ({ EditorState: { create: vi.fn() } }));
+vi.mock("@codemirror/commands", () => ({
+  defaultKeymap: [],
+  history: () => ({}),
+  historyKeymap: [],
+}));
+vi.mock("@codemirror/language", () => ({
+  bracketMatching: () => ({}),
+  foldGutter: () => ({}),
+  indentOnInput: () => ({}),
+  syntaxHighlighting: () => ({}),
+  defaultHighlightStyle: {},
+}));
+vi.mock("@codemirror/lint", () => ({
+  linter: () => ({}),
+  lintGutter: () => ({}),
+}));
+
+import { SessionsRoute } from "../App";
+
+afterEach(() => {
+  flagState = undefined;
+  vi.clearAllMocks();
+});
+
+/**
+ * The redirect goes through `ScopedNavigate`, which reads the current location
+ * to carry the project into a project-owned target — so it needs a router
+ * context. The route also reads `?session=` from that same location.
+ */
+function renderRoute(initialPath: string) {
+  return render(
+    <MemoryRouter initialEntries={[initialPath]}>
+      <AppRouteReactContext.Provider value={{ convexProjectId: PROJECT_ID }}>
+        <SessionsRoute />
+      </AppRouteReactContext.Provider>
+    </MemoryRouter>
+  );
+}
+
+describe("SessionsRoute — a session permalink outruns the rollout flag", () => {
+  it("opens the permalinked session even when the flag is off", () => {
+    flagState = false;
+    renderRoute(`/p/${PROJECT_ID}/sessions?session=${SESSION_ID}`);
+
+    expect(screen.queryByTestId("navigate")).not.toBeInTheDocument();
+    const panel = screen.getByTestId("sessions-panel");
+    expect(panel).toHaveAttribute("data-project-id", PROJECT_ID);
+    expect(panel).toHaveAttribute("data-selected-session", SESSION_ID);
+  });
+
+  it("still bounces a bare /sessions visit when the flag is off", () => {
+    // The gate itself is unchanged: without an id there is nothing the link
+    // was pointing at, so a flagged-out viewer has no business on the feed.
+    flagState = false;
+    renderRoute(`/p/${PROJECT_ID}/sessions`);
+
+    expect(screen.getByTestId("navigate")).toHaveAttribute(
+      "data-to",
+      `/p/${PROJECT_ID}${routePaths.servers}`
+    );
+    expect(screen.queryByTestId("sessions-panel")).not.toBeInTheDocument();
+  });
+
+  it("opens the permalinked session for a flagged-in viewer", () => {
+    flagState = true;
+    renderRoute(`/p/${PROJECT_ID}/sessions?session=${SESSION_ID}`);
+
+    expect(screen.queryByTestId("navigate")).not.toBeInTheDocument();
+    expect(screen.getByTestId("sessions-panel")).toHaveAttribute(
+      "data-selected-session",
+      SESSION_ID
+    );
+  });
+
+  it("does not redirect while the flag is still loading (undefined)", () => {
+    flagState = undefined;
+    renderRoute(`/p/${PROJECT_ID}/sessions`);
+
+    expect(screen.queryByTestId("navigate")).not.toBeInTheDocument();
+    expect(screen.queryByTestId("sessions-panel")).not.toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## The bug

`https://app.mcpjam.com/sessions?session=<sessionId>&project=<projectId>` — the permalink every `/v1/sessions` item carries, and the only URL in the app that opens one conversation — rewrote itself to `https://app.mcpjam.com/p/<projectId>/servers`. The session id was dropped and the recipient landed on Connect with nothing to say what happened.

Reproduced against session `qh75b50ftsbdat1mmsgjvtep8n8d9ysj` in project `v977phvmg9dtt6exdykq890rjs8awe54`, signed in as the account that owns it.

## Root cause

**Neither the permalink builder nor the route normalizer.** Both were verified correct and are unchanged:

- `sdk/src/platform/permalinks.ts` mints the documented legacy shape (`chat_session` → `segments: ["sessions"]`, `idParam: "session"`, plus `?project=`), which the client is designed to accept.
- `LegacyProjectRouteNormalizer` + `canonicalizeLegacyProjectTarget` rewrite it correctly to `/p/<projectId>/sessions?session=<sessionId>`: only the `project` field is dropped, `session` survives byte-for-byte. Covered by existing tests.
- `SessionsPanel` reads `?session=` and selects that row. Also already tested.

The URL arrives at `SessionsRoute` intact, and `SessionsRoute` throws it away. Its `unified-sessions-enabled` guard renders `<ScopedNavigate to={routePaths.servers} replace />` on an explicit `false` — and `ScopedNavigate` carries the project prefix into the target, which is exactly how `/p/<projectId>/sessions?session=…` becomes `/p/<projectId>/servers`. Nothing else on that path produces that URL.

The reporting account is outside the flag's cohort (it targets `email icontains @mcpjam.com`). Confirmed in PostHog: for that account, `$feature_flag_called` for `unified-sessions-enabled` has responded `false` — most recently at the time of the repro.

## The fix

`unified-sessions-enabled` is a **rollout** control over who DISCOVERS the feed — the sidebar item, a bare `/sessions` visit — not an authorization boundary:

- row-level visibility is entirely server-side (`canViewSessionInProject`), so honouring a link somebody was handed exposes nothing the flag was protecting;
- the flag's stated purpose (the `sessionsFeed:*` queries may not be deployed yet) is already independently covered by the route's dark-ship `ErrorBoundary`, which degrades to copy instead of white-screening.

So the guard now skips the redirect when the URL names a session (`?session=`). One condition, in one route:

```diff
-  if (unifiedSessionsEnabled === false) {
+  const permalinkSessionId = useCurrentSearchParam("session");
+  if (unifiedSessionsEnabled === false && !permalinkSessionId) {
     return <ScopedNavigate to={routePaths.servers} replace />;
   }
```

Everything else is unchanged: a bare `/sessions` visit still bounces for a flagged-out viewer, the sidebar item is still hidden, the Atlas still does not advertise the surface, and the pre-hydration `undefined` window still redirects nobody. No routing refactor.

## Verified

- New regression test `client/src/__tests__/SessionsRoute.permalink.test.tsx` (4 cases), styled after the existing `EvaluateRoute.flag-hydration.test.tsx`. Its mocked panel reads the selection through the real `useCurrentSearchParam("session")`, so it asserts the id actually reaching the panel — not just that a redirect was skipped.
- **Confirmed it fails before the fix**: with the `App.tsx` change reverted, the permalink case fails with `found <div data-testid="navigate" data-to="/p/v977phvmg9dtt6exdykq890rjs8awe54/servers" />` — literally the URL from the report. The other three pass before and after.
- `npx vitest run client/src/__tests__/ client/src/components/routing/__tests__/ client/src/lib/__tests__/project-route.test.ts client/src/lib/__tests__/app-navigation.test.ts client/src/lib/__tests__/permalink-signin-return.test.ts client/src/components/sessions/__tests__/` → 18 files, 242 tests, all passing.
- `npm run typecheck:client` → clean.
- Prettier: `App.tsx` was already non-conforming at `origin/main` (checked against `HEAD`), so no formatting regression; the new test file follows the trailing-comma style of the sibling route tests it mirrors.

## Not verified

- No browser run against prod — the fix was verified at the component-route layer, and the end-to-end claim rests on the pre-fix reproduction above plus the existing normalizer and `SessionsPanel` tests covering the two neighbouring layers.
- Flipping `unified-sessions-enabled` on for the affected account would also make the link work; that is a rollout decision and is deliberately left alone. This change makes the link work regardless of the cohort, which is what a permalink has to do.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single conditional change in one route guard with server-side session visibility unchanged; regression tests cover redirect vs open behavior.
> 
> **Overview**
> **Session permalinks no longer redirect to Connect** when `unified-sessions-enabled` is `false`. URLs like `/sessions?session=<id>` (and the normalized `/p/<project>/sessions?session=<id>`) were reaching `SessionsRoute` correctly, but the rollout guard always sent flagged-out users to `/p/<project>/servers` and dropped the session id.
> 
> `SessionsRoute` now reads **`?session=`** with `useCurrentSearchParam` and **skips the redirect when a session id is present**. Bare `/sessions` visits still bounce to Connect for flagged-out users; flag hydration (`undefined`) behavior is unchanged.
> 
> Adds **`SessionsRoute.permalink.test.tsx`** (four cases: permalink with flag off/on, bare route with flag off, loading state) plus a patch **changeset** for `@mcpjam/inspector`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e14016a6df6e98cac734eff01d431a2727780898. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes session permalinks bouncing to Connect. `/sessions?session=<id>&project=<id>`—the link every `/v1/sessions` item carries—rewrote itself to `/p/<projectId>/servers` for viewers outside the `unified-sessions-enabled` rollout cohort, dropping the session id; the route guard now skips the redirect when the URL names a session and opens the panel.

**Bug Fix**
- The flag gates discovery (sidebar item, bare `/sessions` visit), not read access; row-level visibility stays server-side in `canViewSessionInProject`.
- A bare `/sessions` visit still redirects for a flagged-out viewer, and the pre-hydration `undefined` state still redirects nobody.
- Adds a four-case regression test and a patch changeset for `@mcpjam/inspector`.

<sup>Written for commit e14016a6df6e98cac734eff01d431a2727780898. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/MCPJam/inspector/pull/4427?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

