### PR TITLE
fix(agent-turn): namespace server skills by server name, not raw id

### DIFF
--- a/mcpjam-inspector/server/routes/v1/__tests__/chat-sessions.test.ts
+++ b/mcpjam-inspector/server/routes/v1/__tests__/chat-sessions.test.ts
@@ -671,6 +671,51 @@ describe("allowedServerIds narrowing", () => {
   });
 });
 
+// ── Server-skill namespacing ────────────────────────────────────────────────
+
+describe("serverLabels on the agent turn", () => {
+  const { narrowTarget, serverLabelsFor } = __testing;
+
+  it("namespaces skill refs by the user-assigned name, not the raw id", () => {
+    // The bug this pins: the hosted turn called `prepareChatV2` without
+    // `serverLabels`, so every SEP-2640 ref fell back to the server id and the
+    // model (and the user) saw `p176vpy587jn4v51vd9bm5g3rx8d8yry/run-evals`
+    // instead of `mcpjam-staging-skills/run-evals` — in the `listSkills`
+    // catalog AND in the origin banner on loaded skill content.
+    const { selected } = narrowTarget(
+      {
+        serverIds: ["p176vpy587jn4v51vd9bm5g3rx8d8yry"],
+        serverNames: ["mcpjam-staging-skills"],
+      },
+      undefined,
+    );
+    expect(serverLabelsFor(selected)).toEqual({
+      p176vpy587jn4v51vd9bm5g3rx8d8yry: "mcpjam-staging-skills",
+    });
+  });
+
+  it("keys by id, so a missing name only costs that one server its label", () => {
+    // Keyed rather than positional precisely BECAUSE `narrowTarget().names` is
+    // all-or-nothing: reusing that array would let one unnamed server strip
+    // the labels off every named one. An entry with no name is simply absent
+    // here and falls back to the id in `prepareChatV2` — never to a neighbor's
+    // name, which would be confidently wrong.
+    const { selected, names } = narrowTarget(
+      { serverIds: ["a", "b", "c"], serverNames: ["Alpha"] },
+      undefined,
+    );
+    expect(names).toBeUndefined();
+    expect(serverLabelsFor(selected)).toEqual({ a: "Alpha" });
+  });
+
+  it("returns undefined when nothing is labelled", () => {
+    // So the call site can keep to spread-only-when-present and leave the
+    // option off entirely rather than passing an empty map.
+    const { selected } = narrowTarget({ serverIds: ["a", "b"] }, undefined);
+    expect(serverLabelsFor(selected)).toBeUndefined();
+  });
+});
+
 // ── Skills extension declaration ────────────────────────────────────────────
 
 describe("skills capability on the agent turn", () => {

--- a/mcpjam-inspector/server/routes/v1/chat-session-turn.ts
+++ b/mcpjam-inspector/server/routes/v1/chat-session-turn.ts
@@ -540,6 +540,34 @@ function narrowTarget(
   return { selected, ...(names ? { names } : {}) };
 }
 
+/**
+ * serverId → user-assigned name, for namespacing SEP-2640 server-skill refs.
+ *
+ * Keyed by id rather than positional like `narrowTarget`'s `names`, so a
+ * half-populated name array cannot misalign anything: an entry with no name is
+ * simply absent, and `prepareChatV2` falls back to the server id for it. That
+ * fallback is safe but ugly — the id is host-assigned, which is the property
+ * that matters (a server must never get to choose the namespace its own skills
+ * are addressed under, so `serverInfo.name` is never a candidate) — it just
+ * reads as `p176vpy…/run-evals` instead of `mcpjam-staging-skills/run-evals`
+ * in the `listSkills` catalog and in the origin banner on loaded skill content,
+ * both of which the model and the user see.
+ *
+ * Returns `undefined` when nothing is labelled, so the call site can keep to
+ * the spread-only-when-present convention the rest of the options use.
+ */
+function serverLabelsFor(
+  selected: ReadonlyArray<{ id: string; name?: string }>,
+): Record<string, string> | undefined {
+  const labels: Record<string, string> = {};
+  for (const entry of selected) {
+    if (typeof entry.name === "string" && entry.name.length > 0) {
+      labels[entry.id] = entry.name;
+    }
+  }
+  return Object.keys(labels).length > 0 ? labels : undefined;
+}
+
 /** The two equivalent ways a caller says "run this turn with no tools". */
 function wantsNoTools(body: {
   maxToolCalls?: number;
@@ -888,6 +916,10 @@ async function handleTurn(c: Context): Promise<Response> {
       );
     }
     const selectedServerIds = selected.map((entry) => entry.id);
+    // Built from the PAIRS, not from `selectedServerNames`: that array is
+    // all-or-nothing on purpose, so one unnamed server would strip the labels
+    // off every named one and send the whole turn back to raw ids.
+    const serverLabels = serverLabelsFor(selected);
 
     const modelDefinition = await resolveHostModelDefinition({
       modelId: pins.modelId,
@@ -942,6 +974,10 @@ async function handleTurn(c: Context): Promise<Response> {
     const prepared = await prepareChatV2({
       mcpClientManager: manager,
       selectedServers: selectedServerIds,
+      // Without this every server-skill ref is namespaced by the raw server
+      // id, in the `listSkills` catalog the model reads AND in the origin
+      // banner prepended to loaded skill content.
+      ...(serverLabels ? { serverLabels } : {}),
       modelDefinition,
       ...(pins.systemPrompt ? { systemPrompt: pins.systemPrompt } : {}),
       ...(pins.temperature !== undefined
@@ -1290,6 +1326,7 @@ export const __testing = {
   assertUnambiguousModelId,
   capToolCalls,
   narrowTarget,
+  serverLabelsFor,
   shouldReleaseLease,
   wantsNoTools,
   computeExcludedToolNames,


### PR DESCRIPTION
## The bug

In the hosted agent turn (`send_chat_message` / `POST /v1/chat-sessions/:id/turns`), MCP-server-provided skills were addressed by the **raw server id**:

```
p176vpy587jn4v51vd9bm5g3rx8d8yry/run-mcpjam-evals
```

when they should read:

```
mcpjam-staging-skills/run-mcpjam-evals
```

The ref is user-visible in two places, both of which the model also reads: the `listSkills` catalog, and the origin banner prepended to loaded skill content.

## Root cause

`server/utils/chat-v2-orchestration.ts` namespaces every SEP-2640 server-skill ref with:

```ts
serverLabel: serverLabels?.[serverId] ?? serverId,
```

`prepareChatV2` accepts an optional `serverLabels?: Record<string, string>`. The hosted agent turn in `server/routes/v1/chat-session-turn.ts` called `prepareChatV2({...})` **without** it, so every ref fell through to the fallback.

The fallback itself is not a security problem and should stay: the server id is host-assigned, and that is the property that matters here — a server must never get to choose the namespace its own skills are addressed under, which is why `serverInfo.name` is never a candidate. It just reads badly.

The names were already in hand at the call site: `narrowTarget()` returns id/name **pairs** and the route already destructures `selected`.

## The change

- New `serverLabelsFor(selected)` next to `narrowTarget`, building the `id → name` map and returning `undefined` when nothing is labelled, so the call site keeps to the spread-only-when-present convention the surrounding options use.
- Built from the **pairs**, deliberately not from `narrowTarget().names`. That array is all-or-nothing by design (it is dropped entirely rather than half-aligned, because the connection layer pairs ids and names positionally), so reusing it would let a single unnamed server strip the labels off every named one and send the whole turn back to raw ids. Keying by id has no alignment hazard: an entry with no name is simply absent and falls back to its id — never to a neighbour's name.
- A comment at the fallback explaining why it is safe but ugly.

Scope is that route plus tests. `server-skill-tools.ts` and the approval logic are untouched (separate change in flight).

## Verified

- `npx vitest run --project server chat-sessions` — **54 passed**, including three new cases: the name is used for the namespace; a missing name costs only that server its label while the existing "names dropped rather than half-aligned" behaviour is unchanged; and an all-unlabelled selection yields `undefined` rather than an empty map.
- `npx tsc --noEmit -p mcpjam-inspector/server/tsconfig.json` — **240 errors before and 240 after**, all pre-existing and unrelated (stale local `@mcpjam/sdk` exports, `computer-use-tool.ts`, `local-server-resolver.ts`, etc.). Baselined by restoring both touched files from `origin/main`, re-running, and diffing: the only diagnostic in either file is the same pre-existing `TS2345` in `chat-sessions.test.ts`, at line 720 before and 765 after — shifted purely by the added lines.

## Not verified

Not exercised against a live server end-to-end; the fix is asserted at the unit level on the map that feeds `prepareChatV2`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized fix to skill ref display/namespacing on the hosted agent turn; no auth, billing, or tool-policy changes.
> 
> **Overview**
> Hosted agent turns (`POST /v1/chat-sessions/messages`) now pass **user-assigned server names** into `prepareChatV2` as `serverLabels`, so SEP-2640 server-skill references show as `mcpjam-staging-skills/run-evals` instead of raw ids like `p176vpy…/run-evals` in **`listSkills`** and skill content origin banners (model- and user-visible).
> 
> A new **`serverLabelsFor(selected)`** builds an id→name map from the same id/name **pairs** as `narrowTarget`, not from the all-or-nothing `names` array—so one unnamed server only loses its own label and never misaligns neighbors. When nothing is labelled, it returns **`undefined`** so the route keeps spread-only-when-present options.
> 
> Unit tests pin the map behavior and export `serverLabelsFor` on `__testing`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7bd00b35febf0ded1dda3564613cc123f96ba542. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the hosted agent turn so MCP server skills are namespaced by the server's user-assigned name instead of the raw server id, which the model and user see in the skill catalog and origin banner.

**Bug Fixes**
- Adds `serverLabelsFor` to build an id→name map from the already-selected server pairs, and passes it into `prepareChatV2` when non-empty.
- Keys labels by server id rather than positionally, so a missing name only costs that server its label and never misaligns others.
- Adds three unit tests covering the namespace, the missing-name fallback, and the empty-map case.

<sup>Written for commit 7bd00b35febf0ded1dda3564613cc123f96ba542. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/MCPJam/inspector/pull/4428?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

