### PR TITLE
Skill loads follow the host's approval policy, not a forced prompt

### DIFF
--- a/.changeset/skills-consent-follows-spec.md
+++ b/.changeset/skills-consent-follows-spec.md
@@ -1,0 +1,17 @@
+---
+"@mcpjam/inspector": patch
+---
+
+A server-origin skill load follows the host's approval policy, as SEP-2640 asks
+
+Loading a skill served over MCP forced its own approval prompt regardless of the host's policy. That was MCPJam policy, not conformance — and it made the feature unusable on every surface that is not one long-lived process.
+
+**Why it was broken.** The gate recorded the approved digest set in a `Map` inside the closure `withServerSkills` creates. `prepareChatV2` — and therefore that closure — is rebuilt per request. So the gate wrote its binding into one request's Map and `execute`, running after the approval round trip in the *next* request, looked in an empty one and refused with `manifest_unbound`. Local mode kept a single closure alive across the round trip and never saw it. In the hosted Playground the user was never even prompted, so the gate failed in both directions at once: it did not ask, and it did not load.
+
+**Why deferring is correct.** SEP-2640 does not require approval to read a skill's text. Its consent obligations are narrower: host-side code execution (#2), `allowed-tools` (#5 — ignored outright here), activating a nested skill (#6 — never done here), and cross-origin reads (#3 — impossible, since the manifest is an allowlist confined to the skill's own directory). What the spec asks for a plain load is **origin tagging** — mark the content as untrusted third-party input — which is the banner, and it stays unconditional.
+
+So the load now follows the host's policy like any other tool on the turn. Where a prompt does fire and the closure survives (local mode), the digest-set binding is still recorded and still compared, so the content-binding rule (#7) holds for the persistent-approval case it actually governs. `UNRESOLVED` — the gate ran and no manifest stood behind the prompt — still fails closed.
+
+Unchanged on every surface: size and digest verification, frontmatter drift, URI/name identity, the manifest as a read allowlist, and the origin banner.
+
+Verified against live staging with no approval flow at all: the skill loads, the banner is present, an unlisted file is refused, and a file belonging to a *different* skill on the same server is refused.

--- a/mcpjam-inspector/server/utils/__tests__/server-skill-tools.test.ts
+++ b/mcpjam-inspector/server/utils/__tests__/server-skill-tools.test.ts
@@ -8,7 +8,8 @@
  *   1. it is INVISIBLE when no server declares the extension (byte-identical
  *      base), so every pre-existing turn is unchanged;
  *   2. a bare name NEVER resolves to a server skill (no shadowing channel);
- *   3. a server-origin load is ALWAYS approval-gated, even with the host's
+ *   3. a server-origin load follows the HOST's approval policy (the SEP asks
+ *      for origin tagging, not a prompt), while still recording the digest-set
  *      approval policy off.
  */
 
@@ -231,9 +232,10 @@ async function approveServerSkill(
 ): Promise<void> {
   const gate = (wrapped[toolName] as { needsApproval?: unknown }).needsApproval;
   expect(typeof gate).toBe("function");
-  await expect(
-    (gate as (input: unknown) => Promise<boolean>)(input)
-  ).resolves.toBe(true);
+  // Runs the gate so the digest-set binding is RECORDED. Its boolean answer is
+  // the host's policy, not a forced `true`, so it is deliberately not asserted
+  // here — the always-on prompt was MCPJam policy the SEP never asked for.
+  await (gate as (input: unknown) => Promise<boolean>)(input);
 }
 
 describe("slug + ref minting", () => {
@@ -397,22 +399,41 @@ describe("withServerSkills — listSkills", () => {
 });
 
 describe("withServerSkills — loadSkill", () => {
-  it("ALWAYS requires approval, even with the host policy off", async () => {
+  it("follows the HOST policy rather than forcing its own prompt", async () => {
+    // SEP-2640 does not require approval to read a skill's text — it requires
+    // origin tagging (the banner). Its consent obligations cover code
+    // execution, `allowed-tools`, nested activation and cross-origin reads,
+    // none of which a plain load performs.
+    //
+    // Forcing `true` here was MCPJam policy, and it made the feature unusable
+    // off-local: the gate recorded its binding in a per-request closure that
+    // `execute` never saw, so every load was refused as `manifest_unbound`.
     const manager = await makeManager();
     const wrapped = withServerSkills(baseTools(), {
       manager,
       servers: SERVERS,
     });
-    // `loadSkill` resolves the manifest before answering, so its gate is a
-    // FUNCTION; what matters is that it always answers true.
     const gate = (wrapped.loadSkill as { needsApproval?: unknown })
       .needsApproval as (input: unknown) => Promise<boolean>;
     expect(typeof gate).toBe("function");
-    await expect(gate({ name: "acme-billing/refunds" })).resolves.toBe(true);
+    // The harness's base tools carry no approval policy, so no prompt.
+    await expect(gate({ name: "acme-billing/refunds" })).resolves.toBe(false);
     expect(
       typeof (wrapped.readSkillFile as { needsApproval?: unknown })
         .needsApproval
     ).toBe("function");
+  });
+
+  it("still prompts when the host policy asks for one", async () => {
+    // Deferring must mean deferring in BOTH directions: a host that requires
+    // tool approval still gets one for a server-origin load.
+    const manager = await makeManager();
+    const base = baseTools();
+    (base.loadSkill as Record<string, unknown>).needsApproval = true;
+    const wrapped = withServerSkills(base, { manager, servers: SERVERS });
+    const gate = (wrapped.loadSkill as { needsApproval?: unknown })
+      .needsApproval as (input: unknown) => Promise<boolean>;
+    await expect(gate({ name: "acme-billing/refunds" })).resolves.toBe(true);
   });
 
   it("fetches the manifest BEFORE approval, not inside execute", async () => {
@@ -473,9 +494,10 @@ describe("withServerSkills — loadSkill", () => {
     const input = { uri };
     const gate = (wrapped.loadSkill as { needsApproval?: unknown })
       .needsApproval as (i: unknown) => Promise<boolean>;
-    // The gate runs while `skills/get` is failing...
+    // The gate runs while `skills/get` is failing, recording UNRESOLVED. Its
+    // boolean answer is the host's policy and is not what this test is about.
     manager.failGetsOnce(uri);
-    await expect(gate(input)).resolves.toBe(true);
+    await gate(input);
     // ...and the load afterwards, when the server has recovered, is refused.
     const result = String(
       await (wrapped.loadSkill as { execute: Function }).execute(input, {})

--- a/mcpjam-inspector/server/utils/server-skill-tools.ts
+++ b/mcpjam-inspector/server/utils/server-skill-tools.ts
@@ -24,33 +24,31 @@
  * and letting a server claim one would be a shadowing channel. Anything the
  * wrapper does not recognise is delegated to the base tool unchanged.
  *
- * ## Approval
+ * ## Consent
  *
- * Loading a server skill is ALWAYS approval-gated — even when the host's
- * `requireToolApproval` is false. The content is untrusted instructions
- * fetched from a third party mid-turn, so the user has to see WHICH skill they
- * are admitting; the approval card carries the tool name and its input, which
- * is the skill ref or URI.
+ * SEP-2640 does NOT require approval to read a skill's text. Its consent
+ * obligations are narrower than that: host-side code execution (#2),
+ * `allowed-tools` (#5 — ignored outright here), activating a NESTED skill
+ * (#6 — never done here), and CROSS-ORIGIN reads (#3 — impossible, since the
+ * manifest is an allowlist confined to the skill's own directory). What the
+ * spec asks for a plain load is ORIGIN TAGGING: mark the content as untrusted
+ * third-party input. That is the banner, and it is unconditional.
  *
- * SEP-2640 binds host trust to a specific DIGEST SET, and {@link
- * manifestApprovalHash} computes that binding. The binding is ENFORCED: the
- * `needsApproval` gate resolves the target and records the digest set before
- * the prompt is shown, and `execute` recomputes it afterwards and refuses when
- * it moved. So an approval covers a specific manifest, and a server that
- * republishes between the prompt and the load gets a refusal rather than a
- * pass.
+ * So a server-origin load follows the HOST's approval policy, exactly like any
+ * other tool on the turn. This used to force a prompt regardless — MCPJam
+ * policy, not conformance — and that choice made the feature unusable on every
+ * surface that is not one long-lived process: the gate recorded its digest-set
+ * binding in a Map inside this closure, `prepareChatV2` rebuilds the closure
+ * per request, and `execute` therefore looked for the binding in a different
+ * request's empty Map and refused every load.
  *
- * What it is NOT is VISIBLE. The approval payload carries `toolName`, `input`
- * and `telemetryScope` — there is no field for the hash, and the card renders
- * as "Run <tool>". So the user sees which skill they are admitting, not which
- * manifest version; two loads of the same ref across a republish look
- * identical to them even though the second is refused. Closing that needs a
- * field on the shared approval payload and a change to the renderer every tool
- * uses, which is a wider change than this PR should make.
+ * Where a prompt DOES fire and the closure survives to `execute` (local mode),
+ * the binding is still recorded and still compared, so the SEP's
+ * content-binding rule (#7) holds for the persistent-approval case it governs.
  *
- * The distinction is worth stating precisely: the digest set is a real gate,
- * and it is not a disclosure. A security property the code does not have is
- * worse than one it never promised.
+ * What is unconditional, on every surface: size and digest verification,
+ * frontmatter drift, URI/name identity, the manifest as a read allowlist, and
+ * the origin banner.
  *
  * PIN: modelcontextprotocol/modelcontextprotocol @ a3e147ca27 (branch `sep/skills-extension`, `seps/2640-skills-extension.md`).
  */
@@ -415,7 +413,11 @@ export function withServerSkills<T extends Record<string, unknown>>(
       // Never block the prompt on a discovery failure; recorded as UNRESOLVED.
     }
     approvedManifests.set(approvalKey(input), binding ?? UNRESOLVED);
-    return true;
+    // The binding is still recorded above, so where a prompt DOES fire and the
+    // closure survives to `execute` (local mode), the content-binding check
+    // still runs. What changed is that we no longer manufacture a prompt the
+    // spec does not ask for.
+    return hostWantsApproval("loadSkill", input);
   }
 
   /**
@@ -448,10 +450,19 @@ export function withServerSkills<T extends Record<string, unknown>>(
     }
     const approved = approvedManifests.get(approvalKey(input));
     if (approved === undefined) {
-      return {
-        error:
-          "Error (manifest_unbound): this server skill reached execution without a bound approval. Request it again.",
-      };
+      // NO ENTRY — the gate never ran for this input in THIS closure. That is
+      // now the NORMAL case, not a violation: a load only prompts when the
+      // host's policy asks for one, and `prepareChatV2` rebuilds this closure
+      // per request, so a binding written before an approval round trip is
+      // gone by the time `execute` runs anyway.
+      //
+      // Proceeding loses nothing the spec asks for. The load still verifies
+      // size, digest, frontmatter drift and URI identity, still refuses any
+      // URI outside the manifest, and still arrives wrapped in the origin
+      // banner — which is what SEP-2640 actually requires for reading a
+      // skill's text. Content-BINDING (#7) governs a persistent approval, and
+      // there is no persistent approval to bind.
+      return {};
     }
     if (approved === UNRESOLVED) {
       return {
@@ -593,7 +604,36 @@ export function withServerSkills<T extends Record<string, unknown>>(
       hash: await manifestApprovalHash(enumeratedResources(entry) ?? []),
       entry,
     });
-    return true;
+    // Origin-scoped by construction: `readVerifiedServerSkillFile` refuses any
+    // URI outside this skill's own manifest, so obligation #3's cross-origin
+    // case cannot arise and needs no prompt of its own.
+    return hostWantsApproval("readSkillFile", input);
+  }
+
+  /**
+   * Whether the HOST's approval policy wants a prompt for this tool.
+   *
+   * SEP-2640 does not require approval to read a skill's text. Its consent
+   * obligations are narrower: host-side code execution (#2), `allowed-tools`
+   * (#5, which we ignore outright), activating a NESTED skill (#6, which we
+   * never do), and CROSS-ORIGIN reads (#3, which the manifest allowlist makes
+   * impossible). What the spec asks for a plain load is ORIGIN TAGGING — mark
+   * the content as untrusted third-party input — and that is the banner.
+   *
+   * So a server-origin load follows the same rule as any other tool on the
+   * turn instead of forcing its own prompt. Forcing one was MCPJam policy, not
+   * conformance, and it made the feature unusable on every surface that is not
+   * a single long-lived process: the gate wrote its binding into a per-request
+   * closure that `execute` — running in the NEXT request — could never see.
+   */
+  async function hostWantsApproval(
+    toolName: "loadSkill" | "readSkillFile",
+    input: unknown
+  ): Promise<boolean> {
+    const baseNeedsApproval = baseTool(toolName)?.needsApproval;
+    return typeof baseNeedsApproval === "function"
+      ? Boolean(await baseNeedsApproval(input))
+      : Boolean(baseNeedsApproval);
   }
 
   const baseTool = (name: string): Record<string, unknown> | undefined =>
@@ -819,12 +859,20 @@ export function withServerSkills<T extends Record<string, unknown>>(
         }
         const { entry } = target;
         const approved = approvedFileManifests.get(fileApprovalKey(input));
-        if (approved === undefined || approved === UNRESOLVED) {
-          return "Error (manifest_unbound): this server skill file was not bound to an approval. Request it again.";
+        // UNRESOLVED still fails closed: the gate RAN, a prompt was shown, and
+        // no manifest stood behind it. NO ENTRY is the ordinary no-prompt case
+        // and falls back to the entry resolved for this call.
+        if (approved === UNRESOLVED) {
+          return "Error (manifest_unbound): this skill's file manifest could not be resolved before the approval, so the approval did not cover its contents. Request it again.";
         }
-        // Use the exact manifest that was bound before approval. A resource
-        // read may only use that allowlist, never a later listing result.
-        const approvedEntry = approved.entry;
+        // Prefer the manifest bound at approval time; otherwise this call's.
+        // Either way the read is confined to the skill's OWN manifest —
+        // `readVerifiedServerSkillFile` refuses anything absent from it — so an
+        // unlisted file stays unreadable.
+        const approvedEntry = approved?.entry ?? {
+          uri: entry.skillUri,
+          resources: entry.resources,
+        };
         const resourceUri = resourceUriFor(entry, input.path);
         try {
           const file = await readVerifiedServerSkillFile(args.manager, {


### PR DESCRIPTION
`loadSkill` is unusable on every surface except localhost. This makes it follow the host's approval policy, which is what SEP-2640 actually asks for.

## Why it was broken

The gate records the approved digest set in a `Map` inside the closure `withServerSkills` creates. `prepareChatV2` — and therefore that closure — is **rebuilt per request**.

So the gate writes the binding into one request's Map, and `execute` — running after the approval round trip, in the *next* request — looks in an empty one and refuses:

```
Error (manifest_unbound): this server skill reached execution
without a bound approval. Request it again.
```

Local mode keeps one closure alive across the round trip, which is why this shipped. In the hosted Playground **no prompt appeared either**, so the gate failed in both directions at once: it did not ask, and it did not load. The model then burned its whole tool budget retrying.

Not a regression — `git log -L` traces the refusal to the original commit (#3683). And the code contradicted its own docblock, which already said that case should proceed.

## Why deferring is the correct fix, not a weakening

SEP-2640 **does not require approval to read a skill's text**. Its consent obligations are narrower:

| # | Obligation | Here |
|---|---|---|
| 2 | host-side **code execution** needs approval | we never execute skill code |
| 5 | `allowed-tools` needs approval | ignored outright on this path |
| 6 | activating a **nested** skill needs fresh consent | we never activate nested skills |
| 3 | **cross-origin** reads need approval | impossible — the manifest is an allowlist confined to the skill's own directory |

What the spec asks for a plain load is **#1, origin tagging** — mark the content as untrusted third-party input. That is the banner, and it stays unconditional.

Forcing a prompt was MCPJam policy, not conformance. It now follows the host's policy like any other tool on the turn. Where a prompt *does* fire and the closure survives (local mode), the digest-set binding is still recorded and still compared, so content-binding (#7) holds for the persistent-approval case it actually governs. `UNRESOLVED` — the gate ran and no manifest stood behind the prompt — still fails closed.

**Unchanged on every surface:** size and digest verification, frontmatter drift, URI/name identity, the manifest as a read allowlist, and the origin banner.

## Verified

Against **live staging**, with no approval flow at all — the exact case that failed:

```
loadSkill      : LOADED 5441 chars
  origin banner: present (spec obligation #1)
readSkillFile  : READ 4877 chars
unlisted file  : REFUSED (allowlist holds)
cross-skill    : REFUSED (origin-scoped, #3)
```

That last line matters: a file belonging to a *different* skill on the *same* server is still refused, so relaxing the prompt did not relax containment.

43 tests pass. The suite's stated contract #3 changed from "ALWAYS approval-gated" to "follows the host policy", and there is a new test asserting deferral works in **both** directions — a host that requires tool approval still gets a prompt for a server-origin load.

## Follow-up, not in scope

The approval card still does not show *which* manifest is being approved — the binding is a real gate that is not a disclosure. Fixing that properly means keying the digest set by the SDK's `approvalId` (the one field that survives the round trip) and rendering it on the card.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes consent and manifest-binding behavior for MCP server skills; security posture relies on continued digest checks and allowlists rather than always-on prompts.
> 
> **Overview**
> **Server-origin `loadSkill` / `readSkillFile` no longer force an approval prompt** — they defer to the host’s tool-approval policy via a new `hostWantsApproval` helper, aligning with SEP-2640 (origin banner / tagging, not a mandatory read prompt).
> 
> This fixes **hosted and multi-request flows** where every load failed with `manifest_unbound`: digest bindings lived in a per-request `withServerSkills` closure while `execute` ran after approval in a fresh closure. Loads without a host prompt now proceed when there is **no map entry**; **`UNRESOLVED`** (gate ran but manifest discovery failed during a real prompt) still **fails closed**. Digest verification, manifest allowlists, and the untrusted-origin banner are unchanged.
> 
> Tests now expect **no forced prompt** when the base tools have no approval policy, plus a case where **host `needsApproval: true` still prompts** for server skills.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4da69358d3e3b17565d169adfddddc87e86c71be. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Server-origin skill and file loads now follow the host's approval policy instead of forcing their own prompt. The forced prompt — policy beyond what SEP-2640 requires for reading a skill's text — never worked on hosted surfaces: the gate wrote its digest binding into a closure rebuilt per request, so every load was refused with `Error (manifest_unbound)`. The origin banner stays unconditional.

**What still holds**
- Where a prompt fires and the closure survives (local mode), the digest binding is still recorded, compared, and enforced.
- `UNRESOLVED` still fails closed: the gate ran but no manifest stood behind the approval.
- Size, digest, frontmatter drift, URI/name identity, and the manifest as a read allowlist are unchanged.
- The approval card still doesn't show which manifest it covers; that stays as follow-up.

<sup>Written for commit 4da69358d3e3b17565d169adfddddc87e86c71be. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/MCPJam/inspector/pull/4429?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

