### PR TITLE
harness: fix the Claude Code bootstrap on pnpm 11, and stop depending on one setting

### DIFF
--- a/.changeset/harness-pnpm-allow-builds-pnpm11.md
+++ b/.changeset/harness-pnpm-allow-builds-pnpm11.md
@@ -1,0 +1,12 @@
+---
+"@mcpjam/inspector": patch
+---
+
+Fix the Claude Code harness bootstrap on pnpm 11.
+
+The previous fix wrote only `.npmrc`, verified against pnpm 10 — but pnpm 11
+reads none of its settings from `.npmrc`, so every harness bootstrap failed
+with `ERR_PNPM_IGNORED_BUILDS` once the changed recipe hash stopped snapshots
+from hiding it. Both spellings are now written, plus a second layer that keeps
+a skipped build non-fatal so the adapter's own `install.cjs` step can repair
+the install if the allow-list setting is ever renamed again.

--- a/mcpjam-inspector/server/utils/harness/__tests__/registry.test.ts
+++ b/mcpjam-inspector/server/utils/harness/__tests__/registry.test.ts
@@ -260,13 +260,37 @@ const toUserMessage = (text) => ({
     const npmrc = bootstrap?.files.find((file) =>
       file.path.endsWith("/.npmrc")
     );
+    const workspace = bootstrap?.files.find((file) =>
+      file.path.endsWith("/pnpm-workspace.yaml")
+    );
 
     // Without this, pnpm skips `@anthropic-ai/claude-code`'s postinstall. On a
     // pnpm that treats the skip as an error the install step aborts the whole
     // recipe, so the adapter's own `install.cjs` rescue never runs and the CLI
     // never exists — the bootstrap dies before a single turn.
+    //
+    // BOTH files are required and neither is redundant: pnpm 10 reads these
+    // settings only from `.npmrc`, pnpm 11 only from `pnpm-workspace.yaml`,
+    // and the template installs pnpm unpinned so either major can be present.
+    // Shipping just one is exactly how this broke the first time.
     expect(npmrc?.path).toBe(`${bootstrap?.bootstrapDir}/.npmrc`);
     expect(npmrc?.content).toContain("dangerously-allow-all-builds=true");
+    expect(workspace?.path).toBe(
+      `${bootstrap?.bootstrapDir}/pnpm-workspace.yaml`
+    );
+    expect(workspace?.content).toContain("dangerouslyAllowAllBuilds: true");
+
+    // The second, load-bearing layer: even if the allow-list setting is
+    // renamed again, a skipped build must stay a WARNING so the adapter's
+    // `install.cjs` step can repair the install. Verified end to end against
+    // pnpm 11 with the allow-list setting deliberately absent.
+    expect(npmrc?.content).toContain("strict-dep-builds=false");
+    expect(workspace?.content).toContain("strictDepBuilds: false");
+    expect(
+      bootstrap?.commands.some((command) =>
+        command.command.includes("install.cjs")
+      )
+    ).toBe(true);
 
     // It has to sit BESIDE the adapter's manifest, not inside it: the install
     // runs `--frozen-lockfile`, so amending `package.json` to carry

--- a/mcpjam-inspector/server/utils/harness/registry.ts
+++ b/mcpjam-inspector/server/utils/harness/registry.ts
@@ -466,34 +466,49 @@ function patchClaudeCodeBridgeContent(content: string): string {
 }
 
 /**
- * The `.npmrc` written beside the adapter's bundled manifest, so its
- * `pnpm install` is allowed to run dependency build scripts.
+ * Config written beside the adapter's bundled manifest so its `pnpm install`
+ * can install a working Claude Code CLI.
  *
  * WHY THIS EXISTS. `@anthropic-ai/claude-code` ships a `postinstall`
  * (`node install.cjs`) that fetches its platform-native binary; without it the
  * CLI starts and immediately reports `claude native binary not installed`.
  * pnpm 10 stopped running dependency build scripts by default, and the
- * computer template installs pnpm UNPINNED (`npm install -g pnpm`), so the
- * behaviour of a rebuilt image changes with whatever pnpm is current.
+ * computer template installs pnpm UNPINNED (`npm install -g pnpm`), so a
+ * rebuilt image changes behaviour with whatever pnpm is current.
  *
- * The adapter's own recipe already anticipates the skip: after `pnpm install`
- * it re-runs `install.cjs` by hand. That rescue only fires when the install
- * step EXITS ZERO. Where the skip is a hard error rather than a warning —
- * `ERR_PNPM_IGNORED_BUILDS`, which is what a strict or newer pnpm produces —
- * the install step aborts the whole recipe and the rescue never runs. That is
- * the failure this file prevents, and it is why a warning-only pnpm looks fine.
+ * TWO INDEPENDENT LAYERS, because the first one is a moving target:
  *
- * WHY A FILE AND NOT THE MANIFEST. `onlyBuiltDependencies` would be narrower,
- * but pnpm reads it only from `package.json` / `pnpm-workspace.yaml` — never
- * from `.npmrc` — and the manifest here is a bundled asset of
- * `@ai-sdk/harness-claude-code`, not ours to amend. Editing it would also
- * invalidate the `--frozen-lockfile` the adapter installs with. A sibling
- * `.npmrc` changes neither, and `--dir` makes pnpm read it.
+ *   1. ALLOW the build to run, so the postinstall happens normally.
+ *   2. Failing that, do not let a SKIPPED build be FATAL. The adapter's own
+ *      recipe re-runs `install.cjs` by hand after the install — but that
+ *      rescue only fires when the install step exits zero. Turning
+ *      `ERR_PNPM_IGNORED_BUILDS` back into a warning is what lets the
+ *      adapter repair itself.
+ *
+ * Layer 2 is the durable one. It survives a rename of the allow-list setting,
+ * which has already happened once: the first version of this patch shipped
+ * only `.npmrc`, verified against pnpm 10 — and pnpm 11 reads none of its
+ * settings from `.npmrc`, so it broke every harness bootstrap the moment the
+ * recipe hash changed and snapshots stopped hiding it. Both spellings are
+ * written for that reason, and BOTH FILES ARE REQUIRED: `.npmrc` is the only
+ * one pnpm 10 reads, `pnpm-workspace.yaml` the only one pnpm 11 reads.
+ * Verified against pnpm 10.34.5 and 11.24.0.
+ *
+ * WHY NOT THE MANIFEST. `onlyBuiltDependencies` would be narrower, but the
+ * manifest is a bundled asset of `@ai-sdk/harness-claude-code`, not ours to
+ * amend, and editing it would invalidate the `--frozen-lockfile` the adapter
+ * installs with. It also does not work here: pnpm 11 ignored it under `--dir`
+ * in testing, while the settings below took effect.
  *
  * The permissiveness is bounded by where it lands: one directory inside a
  * disposable sandbox that already runs an agent with full shell access.
  */
-const CLAUDE_CODE_BOOTSTRAP_NPMRC = "dangerously-allow-all-builds=true\n";
+const CLAUDE_CODE_BOOTSTRAP_NPMRC =
+  "dangerously-allow-all-builds=true\nstrict-dep-builds=false\n";
+
+/** pnpm 11's home for the same two settings; see {@link CLAUDE_CODE_BOOTSTRAP_NPMRC}. */
+const CLAUDE_CODE_BOOTSTRAP_PNPM_WORKSPACE =
+  "dangerouslyAllowAllBuilds: true\nstrictDepBuilds: false\n";
 
 export function patchClaudeCodeHarnessBootstrap(
   harness: HarnessAgentAdapter
@@ -513,8 +528,8 @@ export function patchClaudeCodeHarnessBootstrap(
       cachedPatchedBootstrap = {
         ...bootstrap,
         // Appended rather than merged over an existing entry: the adapter
-        // ships no `.npmrc` today, and if a future version starts shipping one
-        // we want the duplicate to surface instead of silently winning.
+        // ships neither file today, and if a future version starts shipping
+        // one we want the duplicate to surface instead of silently winning.
         files: [
           ...bootstrap.files.map((file) =>
             file.path.endsWith("/bridge.mjs")
@@ -524,6 +539,10 @@ export function patchClaudeCodeHarnessBootstrap(
           {
             path: `${bootstrap.bootstrapDir}/.npmrc`,
             content: CLAUDE_CODE_BOOTSTRAP_NPMRC,
+          },
+          {
+            path: `${bootstrap.bootstrapDir}/pnpm-workspace.yaml`,
+            content: CLAUDE_CODE_BOOTSTRAP_PNPM_WORKSPACE,
           },
         ],
       };


### PR DESCRIPTION
Follows #4418, which was wrong in a way that broke prod. Detail below, because the failure mode is the interesting part.

## What broke

```
Bootstrap command failed for harness 'claude-code' (exit 1):
pnpm --dir /tmp/harness/claude-code install --frozen-lockfile --store-dir ...
Error: ERR_PNPM_IGNORED_BUILDS
  × installing dependencies
  ╰─▶ Ignored build scripts: @anthropic-ai/claude-code@2.1.146
```

Every `harness:claude-code` iteration, 0 tokens, ~15s.

## Two mistakes, one of which is the real lesson

**1. `.npmrc` was verified against the wrong pnpm.** #4418 was tested on pnpm 10.18.1, where `dangerously-allow-all-builds` in `.npmrc` works. **pnpm 11 reads none of its settings from `.npmrc`.** Measured:

| | pnpm 10 | pnpm 11 |
|---|---|---|
| `.npmrc: dangerously-allow-all-builds` | ✅ | ❌ |
| `pnpm-workspace.yaml: onlyBuiltDependencies` | — | ❌ ignored under `--dir` |
| `pnpm-workspace.yaml: dangerouslyAllowAllBuilds` | — | ✅ |
| both files | ✅ | ✅ |

The template installs pnpm **unpinned** (`templates/computer/e2b.Dockerfile:36`), so either major can be present. Both files are required; neither is redundant.

**2. The bootstrap was already broken — a snapshot was hiding it.** `HarnessV1Bootstrap` is hashed into the identity used for snapshot reuse. Adding a file changed that hash, invalidated the snapshots, and forced the first genuine bootstrap in months. Prod harness runs had been passing on a snapshot whose bootstrap succeeded long ago under an older pnpm.

So #4418 did not break the bootstrap. It stopped the cache from concealing that it was broken — the latent failure that PR's own description warned about, triggered from the inside.

## The fix: two independent layers

**Layer 1 — allow the build**, in both places pnpm looks:

```
.npmrc                dangerously-allow-all-builds=true
pnpm-workspace.yaml   dangerouslyAllowAllBuilds: true
```

**Layer 2 — keep a skipped build non-fatal**:

```
.npmrc                strict-dep-builds=false
pnpm-workspace.yaml   strictDepBuilds: false
```

Layer 2 is the durable one. The adapter's recipe already re-runs `install.cjs` by hand after the install, but that rescue only fires when the install **exits zero**. Turning `ERR_PNPM_IGNORED_BUILDS` back into a warning is what lets the adapter repair itself — which means a future rename of the allow-list setting degrades to "still works" instead of "prod down."

Verified deliberately: with the allow-list setting **absent** on pnpm 11, the install warns, exits 0, and `install.cjs` produces a working CLI.

## Verification

The adapter's exact invocation, from a different cwd, against a real `@anthropic-ai/claude-code` install:

```
final content · pnpm 10.34.5  →  Done in 2.3s  →  2.1.146 (Claude Code)
final content · pnpm 11.24.0  →  Done in 1.7s  →  2.1.146 (Claude Code)
```

No unknown-key warnings on either major. `server/utils/harness/__tests__/registry.test.ts`: 28 passing, with the test extended to pin **both** files, **both** layers, and the presence of the `install.cjs` rescue that layer 2 depends on — so a future edit cannot drop half the mechanism the way this one did.

## Follow-up worth doing separately

Pin pnpm in `templates/computer/e2b.Dockerfile`. An unpinned `npm install -g pnpm` means the image's behaviour changes with whatever pnpm ships that week, which is the root of both this bug and its first bad fix. This PR makes the bootstrap survive that either way.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01B2roGnZkf28Ry5GSo26BWB

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are limited to sandbox bootstrap file generation and tests; no auth or persistence paths, with behavior pinned in CI.
> 
> **Overview**
> Fixes **Claude Code harness bootstrap** failing on **pnpm 11** with `ERR_PNPM_IGNORED_BUILDS` when `@anthropic-ai/claude-code`’s postinstall is skipped—after a prior fix that only wrote **`.npmrc`** (pnpm 10) stopped being masked by snapshot reuse.
> 
> `patchClaudeCodeHarnessBootstrap` now drops **both** **`.npmrc`** and **`pnpm-workspace.yaml`** beside the adapter manifest with **two layers**: allow dependency build scripts (`dangerously-allow-all-builds` / `dangerouslyAllowAllBuilds`) and keep skipped builds **non-fatal** (`strict-dep-builds=false` / `strictDepBuilds: false`) so `pnpm install` can exit 0 and the adapter’s **`install.cjs`** rescue still runs if allow-list settings change again.
> 
> Registry tests are extended to require both files, both setting pairs, and the bootstrap command that runs `install.cjs`, without putting `pnpm` config in `package.json` (frozen lockfile).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a0c674d2481173ee6699b70ca3afa704e36270dc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the Claude Code harness bootstrap so installs work on pnpm 11, and stops relying on a single allow-list setting that pnpm 11 ignores.

- Writes the build permissions to both `.npmrc` and `pnpm-workspace.yaml` since pnpm 10 and 11 each read only one of them, and the template installs pnpm unpinned.
- Adds `strict-dep-builds` so a skipped build is a warning, letting the adapter's own `install.cjs` step repair the install if the allow-list setting ever changes again.

<sup>Written for commit a0c674d2481173ee6699b70ca3afa704e36270dc. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/MCPJam/inspector/pull/4430?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

