### PR TITLE
Versioned Skills: surface skill revisions in run comparisons and the environment picker

### DIFF
--- a/docs/reference/openapi.json
+++ b/docs/reference/openapi.json
@@ -13946,6 +13946,84 @@
           "summary"
         ]
       },
+      "EvalRunCompareSkillsSide": {
+        "type": "object",
+        "properties": {
+          "excluded": {
+            "type": "boolean",
+            "description": "This run deliberately ran with skills disabled — distinct from a run that simply pinned none."
+          },
+          "count": {
+            "type": "integer",
+            "description": "How many skills this run pinned."
+          }
+        },
+        "required": ["excluded", "count"]
+      },
+      "EvalRunCompareSkillSide": {
+        "type": "object",
+        "description": "One skill's identity on one side of the comparison.",
+        "properties": {
+          "contentHash": {
+            "type": "string"
+          },
+          "aggregateHash": {
+            "type": "string",
+            "description": "Complete-artifact hash; present only when supporting files diverge it from `contentHash`."
+          },
+          "versionNumber": {
+            "type": "integer",
+            "description": "Authored-skill revision, when the run recorded one."
+          },
+          "serverSkillVersionNumber": {
+            "type": "integer",
+            "description": "MCP-captured revision, when the run recorded one."
+          }
+        },
+        "required": ["contentHash"]
+      },
+      "EvalRunCompareSkillChange": {
+        "type": "object",
+        "properties": {
+          "key": {
+            "type": "string",
+            "description": "Stable match key; opaque, safe for list keys and dedupe."
+          },
+          "name": {
+            "type": "string"
+          },
+          "modelRef": {
+            "type": "string",
+            "description": "Namespaced runtime address for a plugin-channel skill."
+          },
+          "channels": {
+            "type": "array",
+            "items": {
+              "type": "string",
+              "enum": ["host", "environment", "plugin", "mcp-server"]
+            }
+          },
+          "kind": {
+            "type": "string",
+            "enum": ["added", "removed", "changed"]
+          },
+          "renamedFrom": {
+            "type": "string",
+            "description": "Present when the skill was renamed between the runs; it is still matched as ONE skill by its logical id."
+          },
+          "base": {
+            "$ref": "#/components/schemas/EvalRunCompareSkillSide"
+          },
+          "compare": {
+            "$ref": "#/components/schemas/EvalRunCompareSkillSide"
+          },
+          "versionDelta": {
+            "type": "string",
+            "description": "Human-readable revision move (`v3 → v4`), present only when BOTH sides recorded a number. A change with no delta is a real content change whose revisions are unknown, not a smaller change."
+          }
+        },
+        "required": ["key", "name", "channels", "kind"]
+      },
       "EvalRunCompare": {
         "type": "object",
         "properties": {
@@ -14031,6 +14109,30 @@
               }
             },
             "required": ["wallDurationMs", "totalTokens", "estimatedCostUsd"]
+          },
+          "skills": {
+            "type": "object",
+            "nullable": true,
+            "description": "Which skills changed between the two runs — the configuration attribution that usually explains the case-level differences. `null` when NEITHER run recorded pinned skills (an empty section would instead claim no skills were involved). Absent when the deployment predates skill attribution, so clients must tolerate all three states.",
+            "properties": {
+              "base": {
+                "$ref": "#/components/schemas/EvalRunCompareSkillsSide"
+              },
+              "compare": {
+                "$ref": "#/components/schemas/EvalRunCompareSkillsSide"
+              },
+              "changes": {
+                "type": "array",
+                "description": "Added, removed and changed skills only, changed first. Unchanged skills are counted, not listed.",
+                "items": {
+                  "$ref": "#/components/schemas/EvalRunCompareSkillChange"
+                }
+              },
+              "unchangedCount": {
+                "type": "integer"
+              }
+            },
+            "required": ["base", "compare", "changes", "unchangedCount"]
           },
           "scoreContract": {
             "type": "object",

--- a/docs/reference/openapi.json
+++ b/docs/reference/openapi.json
@@ -16314,7 +16314,24 @@
             "items": {
               "type": "string"
             },
-            "description": "Project-shared skill IDs. Skills carrying supporting files or extra frontmatter, and plugin-component skills, cannot be pinned."
+            "description": "Project-shared skill IDs. Plugin-component skills cannot be selected — they reach a run by pinning their plugin version."
+          },
+          "versionPins": {
+            "type": "array",
+            "minItems": 1,
+            "items": {
+              "type": "object",
+              "required": ["skillId", "versionId"],
+              "properties": {
+                "skillId": {
+                  "type": "string"
+                },
+                "versionId": {
+                  "type": "string"
+                }
+              }
+            },
+            "description": "Optional exact-version overlay: at most one entry per selected skill, each naming a version of that same skill. A selected skill with no entry runs \"Latest\" — its current revision, resolved when the run starts. Pin a version to hold this environment at a known revision, e.g. to compare two revisions of one skill side by side."
           }
         }
       },

--- a/mcpjam-inspector/client/src/components/environment-composer/environment-stack.ts
+++ b/mcpjam-inspector/client/src/components/environment-composer/environment-stack.ts
@@ -98,7 +98,7 @@ export function emptyComposerState(): EnvironmentComposerState {
  * defaults" instead of throwing while rendering the strip.
  */
 export function modelChoiceCount(
-  selection: ModelSelection | undefined
+  selection: ModelSelection | undefined,
 ): number {
   const resolved = selection ?? emptyModelSelection();
   return (
@@ -108,7 +108,7 @@ export function modelChoiceCount(
 
 /** Inherit first, then explicit ids in list order. Host-major mint uses this. */
 export function expandModelChoices(
-  selection: ModelSelection | undefined
+  selection: ModelSelection | undefined,
 ): Array<{
   modelId: string | undefined;
 }> {
@@ -125,7 +125,7 @@ export function expandModelChoices(
 
 export function sameModelSelection(
   a: ModelSelection,
-  b: ModelSelection
+  b: ModelSelection,
 ): boolean {
   if (a.includeClientDefaults !== b.includeClientDefaults) return false;
   if (a.explicitModelIds.length !== b.explicitModelIds.length) return false;
@@ -152,13 +152,13 @@ export function defaultComposerState(args: {
   environmentsEnabled: boolean;
 }): EnvironmentComposerState | null {
   const liveNamed = args.environments.filter(
-    (env) => !env.archivedAt && isNamedEnvironment(env)
+    (env) => !env.archivedAt && isNamedEnvironment(env),
   );
   if (args.environmentsEnabled && liveNamed.length > 0) {
     const preferred =
       (args.preferredEnvironmentId
         ? liveNamed.find(
-            (env) => env.environmentId === args.preferredEnvironmentId
+            (env) => env.environmentId === args.preferredEnvironmentId,
           )
         : undefined) ?? liveNamed[0];
     return composerStateFromEnvironments([preferred]);
@@ -181,7 +181,7 @@ export function defaultComposerState(args: {
 
 /** The slots of a saved environment, as a loose stack the user can now edit. */
 export function stackFromEnvironment(
-  env: ProjectEnvironmentView
+  env: ProjectEnvironmentView,
 ): EnvironmentStack {
   return {
     hostIds: env.hostId ? [env.hostId] : [],
@@ -215,7 +215,7 @@ export type EnabledStackSlots = {
 function enabledSlotsEqual(
   a: ProjectEnvironmentView,
   b: ProjectEnvironmentView,
-  enabled: EnabledStackSlots
+  enabled: EnabledStackSlots,
 ): boolean {
   return (
     (a.serverAttachmentId ?? null) === (b.serverAttachmentId ?? null) &&
@@ -238,7 +238,7 @@ function enabledSlotsEqual(
  * blocked.
  */
 export function environmentsCarryPluginPins(
-  environments: ProjectEnvironmentView[]
+  environments: ProjectEnvironmentView[],
 ): boolean {
   return environments.some((env) => (env.pluginVersionIds?.length ?? 0) > 0);
 }
@@ -251,7 +251,7 @@ export function environmentsCarryPluginPins(
  * shed the override (D2).
  */
 export function environmentsCarryModels(
-  environments: readonly ProjectEnvironmentView[]
+  environments: readonly ProjectEnvironmentView[],
 ): boolean {
   return environments.some((env) => Boolean(env.modelId));
 }
@@ -261,7 +261,7 @@ function modelChoiceKey(env: ProjectEnvironmentView): string {
 }
 
 function modelChoiceSetsAgree(
-  environments: readonly ProjectEnvironmentView[]
+  environments: readonly ProjectEnvironmentView[],
 ): boolean {
   const byHost = new Map<string, Set<string>>();
   for (const env of environments) {
@@ -274,13 +274,13 @@ function modelChoiceSetsAgree(
   const first = [...byHost.values()][0]!;
   const firstKey = [...first].sort().join("\0");
   return [...byHost.values()].every(
-    (set) => [...set].sort().join("\0") === firstKey
+    (set) => [...set].sort().join("\0") === firstKey,
   );
 }
 
 function reconstructModelSelection(
   environments: readonly ProjectEnvironmentView[],
-  slots?: EnabledStackSlots
+  slots?: EnabledStackSlots,
 ): ModelSelection {
   if (slots?.modelsEnabled !== true) {
     return emptyModelSelection();
@@ -323,18 +323,20 @@ function reconstructModelSelection(
  */
 export function environmentsExceedOneStack(
   environments: ProjectEnvironmentView[],
-  enabled: EnabledStackSlots
+  enabled: EnabledStackSlots,
 ): boolean {
   if (environments.length < 2) return false;
 
   if (enabled.modelsEnabled === true) {
     if (
-      environments.some((env) => !enabledSlotsEqual(env, environments[0], enabled))
+      environments.some(
+        (env) => !enabledSlotsEqual(env, environments[0], enabled),
+      )
     ) {
       return true;
     }
     const cells = environments.map(
-      (env) => `${env.hostId}::${modelChoiceKey(env)}`
+      (env) => `${env.hostId}::${modelChoiceKey(env)}`,
     );
     if (new Set(cells).size !== cells.length) return true;
     return !modelChoiceSetsAgree(environments);
@@ -343,7 +345,7 @@ export function environmentsExceedOneStack(
   const hosts = new Set(environments.map((e) => e.hostId));
   if (hosts.size !== environments.length) return true;
   return environments.some(
-    (env) => !enabledSlotsEqual(env, environments[0], enabled)
+    (env) => !enabledSlotsEqual(env, environments[0], enabled),
   );
 }
 
@@ -370,7 +372,7 @@ export function environmentsExceedOneStack(
  */
 export function composerStateFromEnvironments(
   environments: ProjectEnvironmentView[],
-  slots?: EnabledStackSlots
+  slots?: EnabledStackSlots,
 ): EnvironmentComposerState {
   const hostIds: string[] = [];
   for (const env of environments) {
@@ -379,7 +381,7 @@ export function composerStateFromEnvironments(
   const first = environments[0];
   const sharedSlot = <T>(
     pick: (env: ProjectEnvironmentView) => T | null,
-    equal: (a: T | null, b: T | null) => boolean
+    equal: (a: T | null, b: T | null) => boolean,
   ): T | null =>
     first && environments.every((env) => equal(pick(env), pick(first)))
       ? pick(first)
@@ -393,15 +395,15 @@ export function composerStateFromEnvironments(
       hostIds,
       serverAttachmentId: sharedSlot(
         (env) => env.serverAttachmentId ?? null,
-        (a, b) => a === b
+        (a, b) => a === b,
       ),
       skillSelection: sharedSlot(
         (env) => env.skillSelection ?? null,
-        sameSkillSelection
+        sameSkillSelection,
       ),
       computerEnvironmentId: sharedSlot(
         (env) => env.computerEnvironmentId ?? null,
-        (a, b) => a === b
+        (a, b) => a === b,
       ),
       modelSelection: reconstructModelSelection(environments, slots),
     },
@@ -446,13 +448,32 @@ export function composerTargetCount(state: EnvironmentComposerState): number {
 
 export function sameSkillSelection(
   a: ProjectEnvironmentSkillSelection | null | undefined,
-  b: ProjectEnvironmentSkillSelection | null | undefined
+  b: ProjectEnvironmentSkillSelection | null | undefined,
 ): boolean {
   const left = a ?? null;
   const right = b ?? null;
   if (left === null || right === null) return left === right;
   if (left.skillIds.length !== right.skillIds.length) return false;
-  return left.skillIds.every((id, i) => id === right.skillIds[i]);
+  if (!left.skillIds.every((id, i) => id === right.skillIds[i])) return false;
+  return sameVersionPins(left.versionPins, right.versionPins);
+}
+
+/**
+ * Version pins compared as a SET keyed by skill: which revision each skill is
+ * held at is what matters, not the order they were written in. Absent and empty
+ * are the same thing (nothing pinned) — the backend stores absent, but a picker
+ * mid-edit can easily produce `[]`, and treating those as different would mark
+ * an untouched form dirty.
+ */
+function sameVersionPins(
+  a: ProjectEnvironmentSkillSelection["versionPins"],
+  b: ProjectEnvironmentSkillSelection["versionPins"],
+): boolean {
+  const left = a ?? [];
+  const right = b ?? [];
+  if (left.length !== right.length) return false;
+  const bySkill = new Map(right.map((pin) => [pin.skillId, pin.versionId]));
+  return left.every((pin) => bySkill.get(pin.skillId) === pin.versionId);
 }
 
 export function stackFieldsEqual(
@@ -463,7 +484,7 @@ export function stackFieldsEqual(
   b: Pick<
     EnvironmentStack,
     "serverAttachmentId" | "skillSelection" | "computerEnvironmentId"
-  >
+  >,
 ): boolean {
   return (
     (a.serverAttachmentId ?? null) === (b.serverAttachmentId ?? null) &&
@@ -484,7 +505,7 @@ export function stackFieldsEqual(
  */
 export function sameOptionalModel(
   left: string | undefined,
-  right: string | undefined
+  right: string | undefined,
 ): boolean {
   return (left ?? null) === (right ?? null);
 }
@@ -493,11 +514,13 @@ export function sameOptionalModel(
 export function targetProductCapReason(
   hostCount: number,
   choiceCount: number,
-  max: number
+  max: number,
 ): string {
   const clients = `${hostCount} client${hostCount === 1 ? "" : "s"}`;
   const models = `${choiceCount} model choice${choiceCount === 1 ? "" : "s"}`;
-  return `${clients} × ${models} = ${hostCount * choiceCount} targets; limit ${max}`;
+  return `${clients} × ${models} = ${
+    hostCount * choiceCount
+  } targets; limit ${max}`;
 }
 
 export type TargetBudgetContext = {

--- a/mcpjam-inspector/client/src/components/evals/__tests__/run-diff-view.test.tsx
+++ b/mcpjam-inspector/client/src/components/evals/__tests__/run-diff-view.test.tsx
@@ -36,17 +36,47 @@ function makeDiff(): EvalRunDiff {
       summary: { total: 1, passed: 0, failed: 1, passRate: 0 },
     },
     metrics: {
-      startOffsetMs: { base: -2_000, compare: 0, delta: 2_000, percentDelta: -100 },
-      wallDurationMs: { base: 1_000, compare: 2_000, delta: 1_000, percentDelta: 100 },
+      startOffsetMs: {
+        base: -2_000,
+        compare: 0,
+        delta: 2_000,
+        percentDelta: -100,
+      },
+      wallDurationMs: {
+        base: 1_000,
+        compare: 2_000,
+        delta: 1_000,
+        percentDelta: 100,
+      },
       totalTokens: { base: 10, compare: 12, delta: 2, percentDelta: 20 },
       inputTokens: { base: 4, compare: 5, delta: 1, percentDelta: 25 },
       outputTokens: { base: 6, compare: 7, delta: 1, percentDelta: 16.666 },
-      cachedInputTokens: { base: null, compare: null, delta: null, percentDelta: null },
-      reasoningTokens: { base: null, compare: null, delta: null, percentDelta: null },
-      estimatedCostUsd: { base: 0.001, compare: 0.002, delta: 0.001, percentDelta: 100 },
+      cachedInputTokens: {
+        base: null,
+        compare: null,
+        delta: null,
+        percentDelta: null,
+      },
+      reasoningTokens: {
+        base: null,
+        compare: null,
+        delta: null,
+        percentDelta: null,
+      },
+      estimatedCostUsd: {
+        base: 0.001,
+        compare: 0.002,
+        delta: 0.001,
+        percentDelta: 100,
+      },
     },
     scores: {
-      passRatePercent: { base: 100, compare: 0, delta: -100, percentDelta: -100 },
+      passRatePercent: {
+        base: 100,
+        compare: 0,
+        delta: -100,
+        percentDelta: -100,
+      },
       total: { base: 1, compare: 1, delta: 0, percentDelta: 0 },
       passed: { base: 1, compare: 0, delta: -1, percentDelta: -100 },
       failed: { base: 0, compare: 1, delta: 1, percentDelta: null },
@@ -99,13 +129,33 @@ function makeDiff(): EvalRunDiff {
           },
         },
         metrics: {
-          durationMs: { base: 1_000, compare: 2_000, delta: 1_000, percentDelta: 100 },
+          durationMs: {
+            base: 1_000,
+            compare: 2_000,
+            delta: 1_000,
+            percentDelta: 100,
+          },
           totalTokens: { base: 10, compare: 12, delta: 2, percentDelta: 20 },
           inputTokens: { base: 4, compare: 5, delta: 1, percentDelta: 25 },
           outputTokens: { base: 6, compare: 7, delta: 1, percentDelta: 16.666 },
-          cachedInputTokens: { base: null, compare: null, delta: null, percentDelta: null },
-          reasoningTokens: { base: null, compare: null, delta: null, percentDelta: null },
-          estimatedCostUsd: { base: 0.001, compare: 0.002, delta: 0.001, percentDelta: 100 },
+          cachedInputTokens: {
+            base: null,
+            compare: null,
+            delta: null,
+            percentDelta: null,
+          },
+          reasoningTokens: {
+            base: null,
+            compare: null,
+            delta: null,
+            percentDelta: null,
+          },
+          estimatedCostUsd: {
+            base: 0.001,
+            compare: 0.002,
+            delta: 0.001,
+            percentDelta: 100,
+          },
         },
       },
     ],
@@ -157,5 +207,111 @@ describe("RunDiffView", () => {
       "compare-run-456",
       "iter-compare",
     );
+  });
+});
+
+describe("RunDiffView — skill changes", () => {
+  beforeEach(() => {
+    mocks.getRunDiff.mockReset();
+  });
+
+  function renderWithSkills(skills: EvalRunDiff["skills"]) {
+    mocks.getRunDiff.mockResolvedValue({ ...makeDiff(), skills });
+    render(
+      <RunDiffView
+        baseRunId="base-run-123"
+        compareRunId="compare-run-456"
+        onOpenIteration={vi.fn()}
+      />,
+    );
+  }
+
+  it("names the edited skill and its version move", async () => {
+    // The whole point: the regression below now has a candidate explanation.
+    renderWithSkills({
+      base: { excluded: false, count: 1 },
+      compare: { excluded: false, count: 1 },
+      changes: [
+        {
+          key: "skill:refunds",
+          name: "refunds",
+          channels: ["environment"],
+          kind: "changed",
+          base: { contentHash: "aaaaaaa1", versionNumber: 3 },
+          compare: { contentHash: "bbbbbbb2", versionNumber: 4 },
+          versionDelta: "v3 → v4",
+        },
+      ],
+      unchangedCount: 2,
+    });
+
+    expect(await screen.findByText("Skill changes")).toBeInTheDocument();
+    expect(screen.getByText("refunds")).toBeInTheDocument();
+    expect(screen.getByText("v3 → v4")).toBeInTheDocument();
+    expect(screen.getByText("Changed")).toBeInTheDocument();
+    expect(screen.getByText("2 unchanged")).toBeInTheDocument();
+  });
+
+  it("falls back to hashes when a run predates versioning", async () => {
+    // A real change whose revisions are unknown must still read as a change,
+    // not as "nothing moved".
+    renderWithSkills({
+      base: { excluded: false, count: 1 },
+      compare: { excluded: false, count: 1 },
+      changes: [
+        {
+          key: "skill:refunds",
+          name: "refunds",
+          channels: ["environment"],
+          kind: "changed",
+          base: { contentHash: "abc1234def" },
+          compare: { contentHash: "999888777x" },
+        },
+      ],
+      unchangedCount: 0,
+    });
+
+    expect(await screen.findByText("abc1234 → 9998887")).toBeInTheDocument();
+  });
+
+  it("renders nothing when no skills changed", async () => {
+    // An empty card on every comparison is noise; silence is the right answer.
+    renderWithSkills({
+      base: { excluded: false, count: 3 },
+      compare: { excluded: false, count: 3 },
+      changes: [],
+      unchangedCount: 3,
+    });
+
+    await screen.findByText("Cases");
+    expect(screen.queryByText("Skill changes")).not.toBeInTheDocument();
+  });
+
+  it("renders nothing for runs that predate skill pinning entirely", async () => {
+    renderWithSkills(null);
+    await screen.findByText("Cases");
+    expect(screen.queryByText("Skill changes")).not.toBeInTheDocument();
+  });
+
+  it("calls out an arm that deliberately ran without skills", async () => {
+    renderWithSkills({
+      base: { excluded: false, count: 1 },
+      compare: { excluded: true, count: 0 },
+      changes: [
+        {
+          key: "skill:refunds",
+          name: "refunds",
+          channels: ["environment"],
+          kind: "removed",
+          base: { contentHash: "aaaaaaa1", versionNumber: 3 },
+        },
+      ],
+      unchangedCount: 0,
+    });
+
+    expect(
+      await screen.findByText("The compared run ran with skills disabled."),
+    ).toBeInTheDocument();
+    expect(screen.getByText("Removed")).toBeInTheDocument();
   });
 });

--- a/mcpjam-inspector/client/src/components/evals/__tests__/run-diff-view.test.tsx
+++ b/mcpjam-inspector/client/src/components/evals/__tests__/run-diff-view.test.tsx
@@ -274,6 +274,32 @@ describe("RunDiffView — skill changes", () => {
     expect(await screen.findByText("abc1234 → 9998887")).toBeInTheDocument();
   });
 
+  it("shows an added skill's recorded revision rather than its hash", async () => {
+    // An added or removed skill has only one side, so it never carries a
+    // versionDelta — but it usually knows its revision, and `v2` says more to a
+    // reader than seven characters of hash.
+    renderWithSkills({
+      base: { excluded: false, count: 0 },
+      compare: { excluded: false, count: 1 },
+      changes: [
+        {
+          key: "serverSkill:lookup",
+          name: "lookup",
+          channels: ["mcp-server"],
+          kind: "added",
+          compare: {
+            contentHash: "server_skill_lookup_hash",
+            serverSkillVersionNumber: 2,
+          },
+        },
+      ],
+      unchangedCount: 0,
+    });
+
+    expect(await screen.findByText("v2")).toBeInTheDocument();
+    expect(screen.queryByText(/server_/)).not.toBeInTheDocument();
+  });
+
   it("renders nothing when no skills changed", async () => {
     // An empty card on every comparison is noise; silence is the right answer.
     renderWithSkills({

--- a/mcpjam-inspector/client/src/components/evals/__tests__/run-plugin-snapshot.test.tsx
+++ b/mcpjam-inspector/client/src/components/evals/__tests__/run-plugin-snapshot.test.tsx
@@ -1,0 +1,46 @@
+/**
+ * The run's pinned-plugin row, and the "skills excluded" badge that rides on it.
+ *
+ * The badge marks the without-skills arm of a comparison — and that arm very
+ * often pins no plugins at all, which is exactly the case an early return on an
+ * empty plugin list used to swallow. These tests pin the reachability down so
+ * the two conditions can't be collapsed back into one.
+ */
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import { RunPluginSnapshot } from "../run-plugin-snapshot";
+
+describe("RunPluginSnapshot", () => {
+  it("says nothing when there are no plugins and nothing else to report", () => {
+    // Absence is semantic: an empty "Plugins" row would read like a failure to
+    // load one.
+    const { container } = render(<RunPluginSnapshot pluginVersions={[]} />);
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it("shows the skills-excluded badge even with no pinned plugins", () => {
+    render(<RunPluginSnapshot pluginVersions={[]} skillsExcluded />);
+    expect(screen.getByText("skills excluded")).toBeInTheDocument();
+    // Nothing to label — the row carries only the badge.
+    expect(screen.queryByText("Plugins")).not.toBeInTheDocument();
+  });
+
+  it("labels pinned plugins, and carries the badge alongside them", () => {
+    render(
+      <RunPluginSnapshot
+        pluginVersions={[
+          {
+            pluginId: "plug-1",
+            pluginVersionId: "ver-1",
+            name: "billing",
+            bundleHash: "abcdef1234567890",
+          },
+        ]}
+        skillsExcluded
+      />,
+    );
+    expect(screen.getByText("Plugins")).toBeInTheDocument();
+    expect(screen.getByText("billing")).toBeInTheDocument();
+    expect(screen.getByText("skills excluded")).toBeInTheDocument();
+  });
+});

--- a/mcpjam-inspector/client/src/components/evals/cross-host/__tests__/use-cross-host-data.test.ts
+++ b/mcpjam-inspector/client/src/components/evals/cross-host/__tests__/use-cross-host-data.test.ts
@@ -1,5 +1,10 @@
 import { describe, it, expect } from "vitest";
-import type { EvalCase, EvalIteration, EvalSuite, EvalSuiteRun } from "../../types";
+import type {
+  EvalCase,
+  EvalIteration,
+  EvalSuite,
+  EvalSuiteRun,
+} from "../../types";
 
 // Exercise the data-shaping logic directly by calling the hook's memoized
 // computation via a thin helper that skips the React useMemo wrapper.
@@ -112,10 +117,7 @@ function makeSuite(
 // Import the hook's computation inline by re-implementing the shape logic here.
 // The real test target is `use-cross-host-data.ts`; this mirrors the logic to
 // avoid requiring a React test renderer for pure data-shaping.
-import {
-  buildCellTrendSeries,
-  useCrossHostData,
-} from "../use-cross-host-data";
+import { buildCellTrendSeries, useCrossHostData } from "../use-cross-host-data";
 import { renderHook } from "@testing-library/react";
 
 describe("useCrossHostData", () => {
@@ -134,9 +136,7 @@ describe("useCrossHostData", () => {
       { namedHostId: "h1", hostName: "Claude" },
       { namedHostId: "h2", hostName: "Cursor" },
     ]);
-    const { result } = renderHook(() =>
-      useCrossHostData(suite, [], [], []),
-    );
+    const { result } = renderHook(() => useCrossHostData(suite, [], [], []));
     expect(result.current.hasHostAttachments).toBe(true);
     expect(result.current.hasAnyData).toBe(false);
     expect(result.current.hostColumns).toHaveLength(2);
@@ -260,7 +260,9 @@ describe("useCrossHostData", () => {
         isHistorical: false,
       },
     ]);
-    expect(result.current.matrix.get("c1")?.get("h_env::client-default")?.passCount).toBe(1);
+    expect(
+      result.current.matrix.get("c1")?.get("h_env::client-default")?.passCount,
+    ).toBe(1);
   });
 
   it("collapses two environments resolving to the same host into one column", () => {
@@ -288,7 +290,9 @@ describe("useCrossHostData", () => {
     expect(result.current.hostColumns).toHaveLength(1);
     expect(result.current.hostColumns[0].hostId).toBe("h_env");
     // Latest run wins the cell, exactly as it does for host-backed reruns.
-    expect(result.current.matrix.get("c1")?.get("h_env::client-default")?.failCount).toBe(1);
+    expect(
+      result.current.matrix.get("c1")?.get("h_env::client-default")?.failCount,
+    ).toBe(1);
   });
 
   it("keeps a host historical when only legacy runs reached it", () => {
@@ -388,7 +392,7 @@ describe("useCrossHostData", () => {
       useCrossHostData(suite, cases, [run1, run2], [iter1, iter2]),
     );
     expect(
-      result.current.matrix.get("c1")?.get("h1::client-default")?.trendSeries
+      result.current.matrix.get("c1")?.get("h1::client-default")?.trendSeries,
     ).toBeUndefined();
   });
 
@@ -525,7 +529,13 @@ describe("useCrossHostData", () => {
   it("splits one host into two columns for default + override", () => {
     const suite = makeSuite();
     const cases = [makeCase("c1")];
-    const inherit = makeEnvironmentRun("rInherit", "h1", "env-inherit", 1, 1000);
+    const inherit = makeEnvironmentRun(
+      "rInherit",
+      "h1",
+      "env-inherit",
+      1,
+      1000,
+    );
     const override = {
       ...makeEnvironmentRun("rOverride", "h1", "env-override", 1, 2000),
       modelSource: "override" as const,
@@ -561,13 +571,15 @@ describe("useCrossHostData", () => {
       "h1::client-default",
       "h1::google/gemini-2.5-flash",
     ]);
-    expect(result.current.hostColumns.every((c) => c.hostId === "h1")).toBe(true);
+    expect(result.current.hostColumns.every((c) => c.hostId === "h1")).toBe(
+      true,
+    );
     expect(
-      result.current.matrix.get("c1")?.get("h1::client-default")?.passCount
+      result.current.matrix.get("c1")?.get("h1::client-default")?.passCount,
     ).toBe(1);
     expect(
       result.current.matrix.get("c1")?.get("h1::google/gemini-2.5-flash")
-        ?.failCount
+        ?.failCount,
     ).toBe(1);
   });
 
@@ -597,7 +609,7 @@ describe("useCrossHostData", () => {
     expect(result.current.hostColumns[0].columnKey).toBe("h1::client-default");
     // Latest run (env inherit) wins the cell.
     expect(
-      result.current.matrix.get("c1")?.get("h1::client-default")?.failCount
+      result.current.matrix.get("c1")?.get("h1::client-default")?.failCount,
     ).toBe(1);
   });
 
@@ -645,6 +657,61 @@ describe("useCrossHostData", () => {
     expect(result.current.hostColumns[0].splitLabel).not.toBe(
       result.current.hostColumns[1].splitLabel,
     );
+  });
+
+  it("splits the matrix by exact skill revision, not just by skill ids", () => {
+    // Two environments selecting the SAME skill at two revisions is the
+    // side-by-side comparison version pins exist for. Fingerprinting on ids
+    // alone would report them as one slot and average both revisions' runs
+    // into a single cell — silently erasing the difference under test.
+    const suite = makeSuite();
+    const cases = [makeCase("c1")];
+    const runA = makeEnvironmentRun("rA", "h1", "envA", 1, 1000);
+    const runB = makeEnvironmentRun("rB", "h1", "envB", 1, 2000);
+    const iters = [
+      makeIteration("iA", {
+        suiteRunId: "rA",
+        testCaseId: "c1",
+        result: "passed",
+      }),
+      makeIteration("iB", {
+        suiteRunId: "rB",
+        testCaseId: "c1",
+        result: "failed",
+      }),
+    ];
+    const { result } = renderHook(() =>
+      useCrossHostData(suite, cases, [runA, runB], iters, {
+        hostNamesById: new Map([["h1", "Claude"]]),
+        environments: [
+          {
+            environmentId: "envA",
+            hostId: "h1",
+            skillSelection: {
+              skillIds: ["skill-refunds"],
+              versionPins: [{ skillId: "skill-refunds", versionId: "ver-1" }],
+            },
+          },
+          {
+            environmentId: "envB",
+            hostId: "h1",
+            // Same skill, Latest — the other arm of the comparison.
+            skillSelection: { skillIds: ["skill-refunds"] },
+          },
+        ],
+      }),
+    );
+    expect(result.current.hostColumns).toHaveLength(2);
+    expect(result.current.hostColumns.map((c) => c.columnKey)).toEqual([
+      "h1::client-default::envA",
+      "h1::client-default::envB",
+    ]);
+    // A skill COUNT would read "1 skill" on both columns and tell nobody
+    // anything; the pinned arm has to name what makes it different.
+    expect(result.current.hostColumns[0].splitLabel).not.toBe(
+      result.current.hostColumns[1].splitLabel,
+    );
+    expect(result.current.hostColumns[0].splitLabel).toMatch(/pinned/);
   });
 
   it("annotates a split by the slot that actually differs, not the sandbox pin", () => {
@@ -719,11 +786,11 @@ describe("useCrossHostData", () => {
     const keys = result.current.hostColumns.map((c) => c.columnKey);
     expect(keys).toContain("h1::client-default");
     expect(
-      result.current.matrix.get("c1")?.get("h1::client-default")?.passCount
+      result.current.matrix.get("c1")?.get("h1::client-default")?.passCount,
     ).toBe(1);
     expect(
       result.current.matrix.get("c1")?.get("h1::google/gemini-2.5-flash")
-        ?.passCount ?? 0
+        ?.passCount ?? 0,
     ).toBe(0);
   });
 
@@ -755,10 +822,10 @@ describe("useCrossHostData", () => {
     );
     expect(
       result.current.matrix.get("c1")?.get("h1::google/gemini-2.5-flash")
-        ?.failCount
+        ?.failCount,
     ).toBe(1);
     expect(
-      result.current.matrix.get("c1")?.get("h1::openai/gpt-4o")?.failCount ?? 0
+      result.current.matrix.get("c1")?.get("h1::openai/gpt-4o")?.failCount ?? 0,
     ).toBe(0);
   });
 
@@ -856,7 +923,7 @@ describe("useCrossHostData", () => {
       "h1::client-default",
     ]);
     expect(
-      result.current.matrix.get("c1")?.get("h1::client-default")?.passCount
+      result.current.matrix.get("c1")?.get("h1::client-default")?.passCount,
     ).toBe(1);
   });
 });

--- a/mcpjam-inspector/client/src/components/evals/cross-host/__tests__/use-cross-host-data.test.ts
+++ b/mcpjam-inspector/client/src/components/evals/cross-host/__tests__/use-cross-host-data.test.ts
@@ -714,6 +714,59 @@ describe("useCrossHostData", () => {
     expect(result.current.hostColumns[0].splitLabel).toMatch(/pinned/);
   });
 
+  it("names the revision in the label, since a pin COUNT is equally blind", () => {
+    // Two environments each pinning ONE skill to a different revision: a count
+    // would read "pinned 1 version" on both columns, reproducing exactly the
+    // ambiguity the label exists to remove.
+    const suite = makeSuite();
+    const cases = [makeCase("c1")];
+    const runA = makeEnvironmentRun("rA", "h1", "envA", 1, 1000);
+    const runB = makeEnvironmentRun("rB", "h1", "envB", 1, 2000);
+    const iters = [
+      makeIteration("iA", {
+        suiteRunId: "rA",
+        testCaseId: "c1",
+        result: "passed",
+      }),
+      makeIteration("iB", {
+        suiteRunId: "rB",
+        testCaseId: "c1",
+        result: "failed",
+      }),
+    ];
+    const { result } = renderHook(() =>
+      useCrossHostData(suite, cases, [runA, runB], iters, {
+        hostNamesById: new Map([["h1", "Claude"]]),
+        environments: [
+          {
+            environmentId: "envA",
+            hostId: "h1",
+            skillSelection: {
+              skillIds: ["skill-refunds"],
+              versionPins: [
+                { skillId: "skill-refunds", versionId: "version-aaaa" },
+              ],
+            },
+          },
+          {
+            environmentId: "envB",
+            hostId: "h1",
+            skillSelection: {
+              skillIds: ["skill-refunds"],
+              versionPins: [
+                { skillId: "skill-refunds", versionId: "version-bbbb" },
+              ],
+            },
+          },
+        ],
+      }),
+    );
+    expect(result.current.hostColumns).toHaveLength(2);
+    const labels = result.current.hostColumns.map((c) => c.splitLabel);
+    expect(labels[0]).not.toBe(labels[1]);
+    expect(labels).toEqual(["pinned aaaa", "pinned bbbb"]);
+  });
+
   it("annotates a split by the slot that actually differs, not the sandbox pin", () => {
     const suite = makeSuite();
     const cases = [makeCase("c1")];

--- a/mcpjam-inspector/client/src/components/evals/cross-host/use-cross-host-data.ts
+++ b/mcpjam-inspector/client/src/components/evals/cross-host/use-cross-host-data.ts
@@ -371,14 +371,19 @@ function splitLabelFor(
         ? `servers-${env.serverAttachmentId.slice(-4)}`
         : "no servers";
     case "skills": {
-      // When the split is BY revision, a skill count is the one thing that
-      // cannot tell the columns apart — every column would read "1 skill".
-      // Name the pinned revisions instead.
+      // A COUNT cannot tell these columns apart. That is true of a skill count
+      // when the split is by revision — every column reads "1 skill" — and just
+      // as true of a pin COUNT, since two environments each pinning one skill
+      // to a different revision both read "pinned 1 version". Name the
+      // revisions themselves, by the same id-suffix convention the servers and
+      // sandbox arms use. Sorted so the label is stable across pin order.
       const pins = env.skillSelection?.versionPins ?? [];
       if (pins.length > 0) {
-        return `pinned ${
-          pins.length === 1 ? "1 version" : `${pins.length} versions`
-        }`;
+        const revisions = pins
+          .map((pin) => pin.versionId.slice(-4))
+          .sort()
+          .join(",");
+        return `pinned ${revisions}`;
       }
       const count = env.skillSelection?.skillIds.length ?? 0;
       return count === 0

--- a/mcpjam-inspector/client/src/components/evals/cross-host/use-cross-host-data.ts
+++ b/mcpjam-inspector/client/src/components/evals/cross-host/use-cross-host-data.ts
@@ -2,7 +2,12 @@ import { useMemo } from "react";
 import { compactModelIdTail } from "@/lib/environment-label";
 import { formatRunId, runEnvironmentRef } from "../helpers";
 import { computeIterationResult } from "../pass-criteria";
-import type { EvalCase, EvalIteration, EvalSuite, EvalSuiteRun } from "../types";
+import type {
+  EvalCase,
+  EvalIteration,
+  EvalSuite,
+  EvalSuiteRun,
+} from "../types";
 
 export const CLIENT_DEFAULT_MODEL_KEY = "client-default";
 
@@ -11,7 +16,15 @@ export type CrossHostEnvironment = {
   hostId: string;
   modelId?: string;
   serverAttachmentId?: string | null;
-  skillSelection?: { skillIds: string[] } | null;
+  skillSelection?: {
+    skillIds: string[];
+    /**
+     * Exact-version pins. Carried because two environments can differ ONLY in
+     * which revision they hold a skill at — that is the side-by-side comparison
+     * the feature exists for, and it must not collapse into one cell.
+     */
+    versionPins?: { skillId: string; versionId: string }[];
+  } | null;
   computerEnvironmentId?: string | null;
   pluginVersionIds?: string[];
 };
@@ -243,8 +256,7 @@ export function buildCellTrendSeries(
       latencyP95Ms: percentile(latencySamples, 95),
       tokens:
         totalCount > 0 && totalTokens > 0 ? totalTokens / totalCount : null,
-      toolCalls:
-        totalCount > 0 ? totalToolCalls / totalCount : null,
+      toolCalls: totalCount > 0 ? totalToolCalls / totalCount : null,
     };
   });
 }
@@ -290,7 +302,7 @@ function buildCellData(iterations: EvalIteration[]): CellData {
 }
 
 function slotFingerprint(env: CrossHostEnvironment): string {
-  const skills = [...(env.skillSelection?.skillIds ?? [])].sort().join(",");
+  const skills = skillSlotKey(env);
   const plugins = [...(env.pluginVersionIds ?? [])].sort().join(",");
   return [
     env.serverAttachmentId ?? "",
@@ -310,7 +322,7 @@ function differingSlot(envs: CrossHostEnvironment[]): DifferingSlot | null {
     envs.some((env) => read(env) !== read(first));
 
   if (differsOn((env) => env.serverAttachmentId ?? "")) return "servers";
-  if (differsOn((env) => sortedIds(env.skillSelection?.skillIds))) {
+  if (differsOn(skillSlotKey)) {
     return "skills";
   }
   if (differsOn((env) => env.computerEnvironmentId ?? "")) return "sandbox";
@@ -320,6 +332,24 @@ function differingSlot(envs: CrossHostEnvironment[]): DifferingSlot | null {
 
 function sortedIds(ids: readonly string[] | undefined): string {
   return [...(ids ?? [])].sort().join(",");
+}
+
+/**
+ * The skill slot's identity: WHICH skills, and at which revision each is held.
+ *
+ * The revision half is load-bearing. Two environments selecting the same skill
+ * ids at different pinned revisions are two different executions — comparing
+ * them is the whole point — so a key built from ids alone would report them as
+ * one slot, merge their runs into a single cell, and average away the very
+ * difference under test.
+ */
+function skillSlotKey(env: CrossHostEnvironment): string {
+  const ids = sortedIds(env.skillSelection?.skillIds);
+  const pins = [...(env.skillSelection?.versionPins ?? [])]
+    .map((pin) => `${pin.skillId}@${pin.versionId}`)
+    .sort()
+    .join(",");
+  return pins ? `${ids}#${pins}` : ids;
 }
 
 /**
@@ -333,7 +363,7 @@ function sortedIds(ids: readonly string[] | undefined): string {
  */
 function splitLabelFor(
   env: CrossHostEnvironment,
-  slot: DifferingSlot | null
+  slot: DifferingSlot | null,
 ): string | null {
   switch (slot) {
     case "servers":
@@ -341,8 +371,19 @@ function splitLabelFor(
         ? `servers-${env.serverAttachmentId.slice(-4)}`
         : "no servers";
     case "skills": {
+      // When the split is BY revision, a skill count is the one thing that
+      // cannot tell the columns apart — every column would read "1 skill".
+      // Name the pinned revisions instead.
+      const pins = env.skillSelection?.versionPins ?? [];
+      if (pins.length > 0) {
+        return `pinned ${
+          pins.length === 1 ? "1 version" : `${pins.length} versions`
+        }`;
+      }
       const count = env.skillSelection?.skillIds.length ?? 0;
-      return count === 0 ? "no skills" : `${count} skill${count === 1 ? "" : "s"}`;
+      return count === 0
+        ? "no skills"
+        : `${count} skill${count === 1 ? "" : "s"}`;
     }
     case "sandbox":
       return env.computerEnvironmentId
@@ -350,7 +391,9 @@ function splitLabelFor(
         : "no sandbox";
     case "plugins": {
       const count = env.pluginVersionIds?.length ?? 0;
-      return count === 0 ? "no plugins" : `${count} plugin${count === 1 ? "" : "s"}`;
+      return count === 0
+        ? "no plugins"
+        : `${count} plugin${count === 1 ? "" : "s"}`;
     }
     default:
       return null;
@@ -359,7 +402,7 @@ function splitLabelFor(
 
 export function modelKeyForRun(
   run: EvalSuiteRun,
-  envById: Map<string, CrossHostEnvironment>
+  envById: Map<string, CrossHostEnvironment>,
 ): string {
   // Persisted attribution is the run's frozen column. A later edit to the
   // named environment must not move historical runs into a new model cell
@@ -395,7 +438,7 @@ export function useCrossHostData(
     const attachments = suite.hostAttachments ?? [];
     const hasHostAttachments = attachments.length > 0;
     const envById = new Map(
-      (environments ?? []).map((env) => [env.environmentId, env])
+      (environments ?? []).map((env) => [env.environmentId, env]),
     );
 
     const activeRunIds = new Set(runs.map((r) => r._id));
@@ -414,7 +457,7 @@ export function useCrossHostData(
     const touch = (
       hostId: string,
       modelKey: string,
-      opts: { envId?: string; historical: boolean }
+      opts: { envId?: string; historical: boolean },
     ) => {
       const key = groupKey(hostId, modelKey);
       const existing = pending.get(key);
@@ -441,8 +484,7 @@ export function useCrossHostData(
       if (!run.namedHostId) continue;
       const modelKey = modelKeyForRun(run, envById);
       const ref = runEnvironmentRef(run);
-      const historical =
-        !attachedHostIds.has(run.namedHostId) && ref === null;
+      const historical = !attachedHostIds.has(run.namedHostId) && ref === null;
       touch(run.namedHostId, modelKey, {
         envId: ref?.environmentId,
         historical,
@@ -482,7 +524,7 @@ export function useCrossHostData(
       if (!run.namedHostId) continue;
       if (runEnvironmentRef(run)) continue;
       groupsNeedingResidual.add(
-        groupKey(run.namedHostId, modelKeyForRun(run, envById))
+        groupKey(run.namedHostId, modelKeyForRun(run, envById)),
       );
     }
 
@@ -506,7 +548,9 @@ export function useCrossHostData(
             splitLabel: splitLabelFor(env, slot),
           });
         }
-        if (!groupsNeedingResidual.has(groupKey(group.hostId, group.modelKey))) {
+        if (
+          !groupsNeedingResidual.has(groupKey(group.hostId, group.modelKey))
+        ) {
           continue;
         }
       }
@@ -532,11 +576,11 @@ export function useCrossHostData(
           col.modelKey === modelKey &&
           col.splitLabel &&
           ref &&
-          col.columnKey?.endsWith(`::${ref.environmentId}`)
+          col.columnKey?.endsWith(`::${ref.environmentId}`),
       );
       runHostMap.set(
         run._id,
-        splitCol?.columnKey ?? groupKey(run.namedHostId, modelKey)
+        splitCol?.columnKey ?? groupKey(run.namedHostId, modelKey),
       );
     }
 
@@ -585,7 +629,8 @@ export function useCrossHostData(
       if (!hostId) continue;
       const caseId = iter.testCaseId ?? `__no_case_${iter._id}`;
 
-      if (winningRunByCell.get(caseId)?.get(hostId) !== iter.suiteRunId) continue;
+      if (winningRunByCell.get(caseId)?.get(hostId) !== iter.suiteRunId)
+        continue;
 
       let byHost = rawMatrix.get(caseId);
       if (!byHost) {

--- a/mcpjam-inspector/client/src/components/evals/run-diff-view.tsx
+++ b/mcpjam-inspector/client/src/components/evals/run-diff-view.tsx
@@ -389,13 +389,19 @@ function SkillChangesSection({ skills }: { skills: EvalRunDiff["skills"] }) {
 }
 
 function SkillChangeRow({ change }: { change: EvalRunSkillChange }) {
-  // `versionDelta` is absent when a side predates versioning; fall back to the
-  // short hashes so a real change is never rendered as if nothing moved.
+  // Prefer the revision a run actually recorded, on either identity system.
+  // An ADDED or REMOVED skill never has a `versionDelta` — there is only one
+  // side — but it usually does know its revision, and `v2` says more to a
+  // reader than seven characters of hash. The hash is the fallback for a run
+  // that predates versioning, so a real change is never rendered as if nothing
+  // moved.
+  const sideDetail = (side: EvalRunSkillSide | undefined): string =>
+    revisionLabel(side) || shortHash(side);
   const detail =
     change.versionDelta ??
     (change.kind === "changed"
-      ? `${shortHash(change.base)} → ${shortHash(change.compare)}`
-      : shortHash(change.base ?? change.compare));
+      ? `${sideDetail(change.base)} → ${sideDetail(change.compare)}`
+      : sideDetail(change.base ?? change.compare));
 
   return (
     <div className="flex flex-wrap items-center gap-x-3 gap-y-1.5 px-4 py-2.5">
@@ -430,6 +436,12 @@ function SkillChangeRow({ change }: { change: EvalRunSkillChange }) {
       ))}
     </div>
   );
+}
+
+/** `v4` from whichever identity system recorded it, or "" when neither did. */
+function revisionLabel(side: EvalRunSkillSide | undefined): string {
+  const version = side?.versionNumber ?? side?.serverSkillVersionNumber;
+  return version === undefined ? "" : `v${version}`;
 }
 
 /** First 7 chars of whichever hash identifies the COMPLETE artifact. */

--- a/mcpjam-inspector/client/src/components/evals/run-diff-view.tsx
+++ b/mcpjam-inspector/client/src/components/evals/run-diff-view.tsx
@@ -9,6 +9,8 @@ import type {
   EvalRunDiffCaseStatus,
   EvalRunDiffSide,
   EvalRunNumericDiff,
+  EvalRunSkillChange,
+  EvalRunSkillSide,
 } from "./types";
 
 type RunDiffViewProps = {
@@ -42,7 +44,7 @@ export function RunDiffView({
   onOpenIteration,
 }: RunDiffViewProps) {
   const getRunDiff = useAction(
-    "testSuites:getTestSuiteRunDiff" as any
+    "testSuites:getTestSuiteRunDiff" as any,
   ) as unknown as (args: {
     baseRunId: string;
     compareRunId: string;
@@ -146,7 +148,7 @@ function RunDiffLoaded({
 }) {
   const changedCount = useMemo(
     () => diff.cases.filter((row) => row.status !== "unchanged_passed").length,
-    [diff.cases]
+    [diff.cases],
   );
 
   const metricLabel =
@@ -155,38 +157,80 @@ function RunDiffLoaded({
       : "Accuracy";
 
   const summaryMetrics = useMemo(
-    () =>
-      [
-        { label: metricLabel, diff: diff.scores.passRatePercent, format: "percent" as const, higherIsBetter: true },
-        { label: "Passed", diff: diff.scores.passed, format: "number" as const, higherIsBetter: true },
-        { label: "Failed", diff: diff.scores.failed, format: "number" as const },
-        { label: "Total", diff: diff.scores.total, format: "number" as const, neutral: true },
-      ],
-    [diff.scores, metricLabel]
+    () => [
+      {
+        label: metricLabel,
+        diff: diff.scores.passRatePercent,
+        format: "percent" as const,
+        higherIsBetter: true,
+      },
+      {
+        label: "Passed",
+        diff: diff.scores.passed,
+        format: "number" as const,
+        higherIsBetter: true,
+      },
+      { label: "Failed", diff: diff.scores.failed, format: "number" as const },
+      {
+        label: "Total",
+        diff: diff.scores.total,
+        format: "number" as const,
+        neutral: true,
+      },
+    ],
+    [diff.scores, metricLabel],
   );
 
   const performanceMetrics = useMemo(
     () =>
       (
         [
-          { label: "Duration", diff: diff.metrics.wallDurationMs, format: "duration" as const },
-          { label: "Tokens", diff: diff.metrics.totalTokens, format: "number" as const },
-          { label: "Input tokens", diff: diff.metrics.inputTokens, format: "number" as const },
-          { label: "Output tokens", diff: diff.metrics.outputTokens, format: "number" as const },
-          { label: "Cached tokens", diff: diff.metrics.cachedInputTokens, format: "number" as const },
-          { label: "Reasoning tokens", diff: diff.metrics.reasoningTokens, format: "number" as const },
-          { label: "Cost", diff: diff.metrics.estimatedCostUsd, format: "cost" as const },
+          {
+            label: "Duration",
+            diff: diff.metrics.wallDurationMs,
+            format: "duration" as const,
+          },
+          {
+            label: "Tokens",
+            diff: diff.metrics.totalTokens,
+            format: "number" as const,
+          },
+          {
+            label: "Input tokens",
+            diff: diff.metrics.inputTokens,
+            format: "number" as const,
+          },
+          {
+            label: "Output tokens",
+            diff: diff.metrics.outputTokens,
+            format: "number" as const,
+          },
+          {
+            label: "Cached tokens",
+            diff: diff.metrics.cachedInputTokens,
+            format: "number" as const,
+          },
+          {
+            label: "Reasoning tokens",
+            diff: diff.metrics.reasoningTokens,
+            format: "number" as const,
+          },
+          {
+            label: "Cost",
+            diff: diff.metrics.estimatedCostUsd,
+            format: "cost" as const,
+          },
         ] satisfies Array<{
           label: string;
           diff: EvalRunNumericDiff;
           format: DiffMetricFormat;
         }>
       ).filter((metric) => metricHasData(metric.diff)),
-    [diff.metrics]
+    [diff.metrics],
   );
 
   const changedPerformanceMetrics = performanceMetrics.filter((metric) =>
-    metricChanged(metric.diff)
+    metricChanged(metric.diff),
   );
 
   return (
@@ -203,7 +247,9 @@ function RunDiffLoaded({
               {" · "}
               {changedCount === 0
                 ? "No case changes"
-                : `${changedCount} changed case${changedCount === 1 ? "" : "s"}`}
+                : `${changedCount} changed case${
+                    changedCount === 1 ? "" : "s"
+                  }`}
               {" · "}
               {diff.cases.length} total
             </p>
@@ -223,7 +269,9 @@ function RunDiffLoaded({
       ) : (
         <div className="flex flex-wrap items-center justify-between gap-2">
           <p className="text-sm text-muted-foreground">
-            <span className="font-medium text-foreground">{diff.suite.name}</span>
+            <span className="font-medium text-foreground">
+              {diff.suite.name}
+            </span>
             {" · "}
             {changedCount === 0
               ? "No case changes"
@@ -232,7 +280,8 @@ function RunDiffLoaded({
             {diff.cases.length} case{diff.cases.length === 1 ? "" : "s"}
           </p>
           <p className="text-xs text-muted-foreground">
-            {formatTime(diff.baseRun.createdAt)} → {formatTime(diff.compareRun.createdAt)}
+            {formatTime(diff.baseRun.createdAt)} →{" "}
+            {formatTime(diff.compareRun.createdAt)}
           </p>
         </div>
       )}
@@ -264,6 +313,8 @@ function RunDiffLoaded({
         ) : null}
       </section>
 
+      <SkillChangesSection skills={diff.skills} />
+
       <section className="min-h-0 rounded-lg border border-border/60 bg-card">
         <div className="flex items-center justify-between border-b border-border/40 px-4 py-2.5">
           <h3 className="text-sm font-medium">Cases</h3>
@@ -291,6 +342,123 @@ function RunDiffLoaded({
       </section>
     </div>
   );
+}
+
+/**
+ * WHICH SKILLS CHANGED between the two runs — placed above Cases because it
+ * usually explains them. "You edited `refunds` and three cases regressed" is
+ * the question people open a comparison to answer, and before this the diff
+ * showed only the second half of it.
+ *
+ * Renders nothing when there is nothing to say: a `null` section (neither run
+ * recorded skills — an older run, from before skills were pinned) and a section
+ * whose only content is unchanged skills both stay quiet, rather than adding an
+ * empty card to every comparison.
+ */
+function SkillChangesSection({ skills }: { skills: EvalRunDiff["skills"] }) {
+  if (!skills) return null;
+  const excludedArm = skills.base.excluded || skills.compare.excluded;
+  if (skills.changes.length === 0 && !excludedArm) return null;
+
+  return (
+    <section className="rounded-lg border border-border/60 bg-card">
+      <div className="flex items-center justify-between border-b border-border/40 px-4 py-2.5">
+        <h3 className="text-sm font-medium">Skill changes</h3>
+        {skills.unchangedCount > 0 ? (
+          <span className="text-xs text-muted-foreground tabular-nums">
+            {skills.unchangedCount} unchanged
+          </span>
+        ) : null}
+      </div>
+      {excludedArm ? (
+        <div className="border-b border-border/40 px-4 py-2 text-xs text-muted-foreground">
+          {skills.base.excluded && skills.compare.excluded
+            ? "Both runs ran with skills disabled."
+            : skills.base.excluded
+            ? "The base run ran with skills disabled."
+            : "The compared run ran with skills disabled."}
+        </div>
+      ) : null}
+      <div className="divide-y divide-border/40">
+        {skills.changes.map((change) => (
+          <SkillChangeRow key={change.key} change={change} />
+        ))}
+      </div>
+    </section>
+  );
+}
+
+function SkillChangeRow({ change }: { change: EvalRunSkillChange }) {
+  // `versionDelta` is absent when a side predates versioning; fall back to the
+  // short hashes so a real change is never rendered as if nothing moved.
+  const detail =
+    change.versionDelta ??
+    (change.kind === "changed"
+      ? `${shortHash(change.base)} → ${shortHash(change.compare)}`
+      : shortHash(change.base ?? change.compare));
+
+  return (
+    <div className="flex flex-wrap items-center gap-x-3 gap-y-1.5 px-4 py-2.5">
+      <span className="text-sm font-medium">
+        {change.modelRef ?? change.name}
+      </span>
+      <span
+        className={cn(
+          "rounded px-1.5 py-0.5 text-[11px] font-medium",
+          skillChangeBadgeClass(change.kind),
+        )}
+      >
+        {skillChangeLabel(change.kind)}
+      </span>
+      {detail ? (
+        <span className="text-xs text-muted-foreground tabular-nums">
+          {detail}
+        </span>
+      ) : null}
+      {change.renamedFrom ? (
+        <span className="text-xs text-muted-foreground">
+          renamed from {change.renamedFrom}
+        </span>
+      ) : null}
+      {change.channels.map((channel) => (
+        <span
+          key={channel}
+          className="rounded bg-muted px-1.5 py-0.5 text-[11px] text-muted-foreground"
+        >
+          {channel}
+        </span>
+      ))}
+    </div>
+  );
+}
+
+/** First 7 chars of whichever hash identifies the COMPLETE artifact. */
+function shortHash(side: EvalRunSkillSide | undefined): string {
+  if (!side) return "";
+  return (side.aggregateHash ?? side.contentHash).slice(0, 7);
+}
+
+function skillChangeLabel(kind: EvalRunSkillChange["kind"]): string {
+  switch (kind) {
+    case "added":
+      return "Added";
+    case "removed":
+      return "Removed";
+    case "changed":
+      return "Changed";
+  }
+}
+
+function skillChangeBadgeClass(kind: EvalRunSkillChange["kind"]): string {
+  switch (kind) {
+    // A changed skill is the likeliest explanation for a regression below, so
+    // it carries the same weight as a changed case.
+    case "changed":
+      return "bg-warning/50 text-foreground";
+    case "added":
+    case "removed":
+      return "bg-muted text-muted-foreground";
+  }
 }
 
 function SummaryMetric({
@@ -365,7 +533,9 @@ function CaseRow({
                 Config changed
               </span>
             ) : null}
-            <h4 className="min-w-0 truncate text-sm font-medium">{row.title}</h4>
+            <h4 className="min-w-0 truncate text-sm font-medium">
+              {row.title}
+            </h4>
           </div>
           {!isCompact ? (
             <p className="mt-0.5 font-mono text-[11px] text-muted-foreground">
@@ -373,13 +543,21 @@ function CaseRow({
             </p>
           ) : null}
         </div>
-        {(durationChanged || tokensChanged) ? (
+        {durationChanged || tokensChanged ? (
           <div className="flex flex-wrap items-center gap-2 text-xs text-muted-foreground">
             {durationChanged ? (
-              <CaseMetricDelta label="Duration" diff={row.metrics.durationMs} format="duration" />
+              <CaseMetricDelta
+                label="Duration"
+                diff={row.metrics.durationMs}
+                format="duration"
+              />
             ) : null}
             {tokensChanged ? (
-              <CaseMetricDelta label="Tokens" diff={row.metrics.totalTokens} format="number" />
+              <CaseMetricDelta
+                label="Tokens"
+                diff={row.metrics.totalTokens}
+                format="number"
+              />
             ) : null}
           </div>
         ) : isCompact ? (
@@ -419,7 +597,12 @@ function CaseMetricDelta({
   return (
     <span className="tabular-nums">
       {label}{" "}
-      <DeltaPill diff={diff} format={format} higherIsBetter={false} neutral={false} />
+      <DeltaPill
+        diff={diff}
+        format={format}
+        higherIsBetter={false}
+        neutral={false}
+      />
     </span>
   );
 }
@@ -463,7 +646,7 @@ function DeltaPill({
     <span
       className={cn(
         "rounded px-1.5 py-0.5 text-[11px] font-semibold tabular-nums",
-        toneClass
+        toneClass,
       )}
     >
       {formatSignedMetric(diff.delta, format)}
@@ -521,7 +704,7 @@ function StatusBadge({ status }: { status: EvalRunDiffCaseStatus }) {
     <span
       className={cn(
         "rounded px-1.5 py-0.5 text-[10px] font-semibold uppercase tracking-wide",
-        statusBadgeClass(status)
+        statusBadgeClass(status),
       )}
     >
       {statusLabel(status)}
@@ -585,7 +768,7 @@ function metricChanged(diff: EvalRunNumericDiff): boolean {
 
 function formatMetricValue(
   value: number | null,
-  format: DiffMetricFormat
+  format: DiffMetricFormat,
 ): string {
   if (value === null || Number.isNaN(value)) {
     return "-";

--- a/mcpjam-inspector/client/src/components/evals/run-plugin-snapshot.tsx
+++ b/mcpjam-inspector/client/src/components/evals/run-plugin-snapshot.tsx
@@ -37,11 +37,18 @@ export function RunPluginSnapshot({
   const versions = pluginVersions ?? [];
   // Absence is semantic: a run with no pinned plugins should say nothing, not
   // render an empty "Plugins" row that reads like a failure to load one.
-  if (versions.length === 0) return null;
+  //
+  // `skillsExcluded` is NOT covered by that: it is a fact about the run, not
+  // about plugins, and the common "without skills" arm pins no plugins at all —
+  // so returning early on an empty plugin list used to hide the badge in
+  // exactly the case it exists for.
+  if (versions.length === 0 && !skillsExcluded) return null;
 
   return (
     <div className="mb-4 flex flex-wrap items-center gap-2">
-      <span className={runDetailMetaLabelClass}>Plugins</span>
+      {versions.length > 0 ? (
+        <span className={runDetailMetaLabelClass}>Plugins</span>
+      ) : null}
       {versions.map((version) => (
         <span
           key={version.pluginVersionId}

--- a/mcpjam-inspector/client/src/components/evals/types.ts
+++ b/mcpjam-inspector/client/src/components/evals/types.ts
@@ -383,7 +383,6 @@ export type EvalCase = {
   _creationTime?: number; // Convex auto field
 };
 
-
 export type EvalIteration = {
   _id: string;
   testCaseId?: string;
@@ -976,6 +975,54 @@ export type EvalRunDiffSide = {
   };
 };
 
+/** Delivery channel a pinned skill reached the run through. */
+export type EvalRunSkillChannel =
+  | "host"
+  | "environment"
+  | "plugin"
+  | "mcp-server";
+
+/** One skill's identity + content fingerprint on one side of a comparison. */
+export type EvalRunSkillSide = {
+  contentHash: string;
+  /** Complete-artifact hash; present only when supporting files diverge it. */
+  aggregateHash?: string;
+  /** Authored-skill revision, when the run recorded one. */
+  versionNumber?: number;
+  /** MCP-captured revision, when the run recorded one. */
+  serverSkillVersionNumber?: number;
+};
+
+export type EvalRunSkillChange = {
+  key: string;
+  name: string;
+  modelRef?: string;
+  channels: EvalRunSkillChannel[];
+  kind: "added" | "removed" | "changed";
+  /** The skill was renamed between the runs; ids still matched it as one skill. */
+  renamedFrom?: string;
+  base?: EvalRunSkillSide;
+  compare?: EvalRunSkillSide;
+  /** `v3 → v4`, present only when BOTH sides recorded a revision number. */
+  versionDelta?: string;
+};
+
+/**
+ * Which skills changed between two runs — the configuration attribution that
+ * usually explains the case-level regressions next to it.
+ *
+ * `null` (not an empty section) when neither run recorded pinned skills:
+ * rendering "no skills changed" for two legacy runs would be a claim nobody
+ * verified.
+ */
+export type EvalRunSkillDiff = {
+  base: { excluded: boolean; count: number };
+  compare: { excluded: boolean; count: number };
+  /** Added / removed / changed only, changed first. Unchanged are counted. */
+  changes: EvalRunSkillChange[];
+  unchangedCount: number;
+};
+
 export type EvalRunDiff = {
   suite: {
     id: string;
@@ -1018,6 +1065,8 @@ export type EvalRunDiff = {
     passed: EvalRunNumericDiff;
     failed: EvalRunNumericDiff;
   };
+  /** See {@link EvalRunSkillDiff}. Absent on responses from an older backend. */
+  skills?: EvalRunSkillDiff | null;
   cases: Array<{
     caseKey: string;
     title: string;

--- a/mcpjam-inspector/client/src/components/project-environments/EnvironmentSummaryLine.tsx
+++ b/mcpjam-inspector/client/src/components/project-environments/EnvironmentSummaryLine.tsx
@@ -37,7 +37,8 @@ export function EnvironmentSummaryLine({
   // rows. Every caller of THIS component passes a real context, so the fallback
   // is for type honesty rather than a case we expect to hit.
   const hostName = ctx.hostName?.(environment.hostId) ?? "Unknown client";
-  const { skillPins, pluginPins } = environmentPinCounts(environment);
+  const { skillPins, pluginPins, skillVersionPins } =
+    environmentPinCounts(environment);
   const imageLabel = environmentImageLabel(environment, ctx);
 
   return (
@@ -48,6 +49,10 @@ export function EnvironmentSummaryLine({
         {describeServerScope(environment)}
         {" · "}
         {skillPins} skill pin{skillPins === 1 ? "" : "s"}
+        {/* Exact-version pins are called out because they change what a future
+            edit does: a skill on Latest follows the edit, a pinned one does
+            not. */}
+        {skillVersionPins > 0 ? ` (${skillVersionPins} at a version)` : ""}
         {" · "}
         {pluginPins} plugin pin{pluginPins === 1 ? "" : "s"}
         {/* Image chip only when pinned AND the computers flag is on — absence is

--- a/mcpjam-inspector/client/src/components/project-environments/ProjectEnvironmentEditor.tsx
+++ b/mcpjam-inspector/client/src/components/project-environments/ProjectEnvironmentEditor.tsx
@@ -19,6 +19,11 @@ import {
   type ProjectEnvironmentView,
 } from "@/hooks/useProjectEnvironments";
 import { ProjectEnvironmentSkillsPicker } from "./ProjectEnvironmentSkillsPicker";
+// Re-exported from the composer's shared helper rather than kept as a second
+// copy: a dirty-check that missed version pins would silently discard a "hold
+// this skill at v1" edit, and two implementations means one of them eventually
+// does.
+import { sameSkillSelection } from "@/components/environment-composer/environment-stack";
 
 type EnvironmentDraft = {
   name: string;
@@ -42,17 +47,6 @@ function draftFromEnvironment(env: ProjectEnvironmentView): EnvironmentDraft {
     skillSelection: env.skillSelection ?? null,
     computerEnvironmentId: env.computerEnvironmentId ?? null,
   };
-}
-
-function sameSkillSelection(
-  a: ProjectEnvironmentSkillSelection | null,
-  b: ProjectEnvironmentSkillSelection | null
-): boolean {
-  if (a === null || b === null) return a === b;
-  return (
-    a.skillIds.length === b.skillIds.length &&
-    a.skillIds.every((id, i) => id === b.skillIds[i])
-  );
 }
 
 /**
@@ -119,11 +113,11 @@ export function ProjectEnvironmentEditor({
           skillSelection: null,
           computerEnvironmentId: null,
           ...initialDraft,
-        }
+        },
   );
   // Captured at draft init/reset — the ONLY revision update may send.
   const [baseRevision, setBaseRevision] = useState<number | null>(
-    environment?.revision ?? null
+    environment?.revision ?? null,
   );
   const [saving, setSaving] = useState(false);
   // Set on a rejected stale write; cleared only by an explicit reload.
@@ -145,7 +139,7 @@ export function ProjectEnvironmentEditor({
       (skillsEnabled &&
         !sameSkillSelection(
           draft.skillSelection,
-          environment.skillSelection ?? null
+          environment.skillSelection ?? null,
         )) ||
       (computersEnabled &&
         draft.computerEnvironmentId !==
@@ -189,7 +183,7 @@ export function ProjectEnvironmentEditor({
             serverAttachmentId: null,
             skillSelection: null,
             computerEnvironmentId: null,
-          }
+          },
     );
     setBaseRevision(environment?.revision ?? null);
     setConflicted(false);
@@ -263,7 +257,7 @@ export function ProjectEnvironmentEditor({
         ...(skillsEnabled &&
         !sameSkillSelection(
           draft.skillSelection,
-          environment.skillSelection ?? null
+          environment.skillSelection ?? null,
         )
           ? { skillSelection: draft.skillSelection }
           : {}),
@@ -283,7 +277,7 @@ export function ProjectEnvironmentEditor({
         // review the refreshed values explicitly.
         setConflicted(true);
         toast.error(
-          "This environment was changed by someone else — review the refreshed values before saving again."
+          "This environment was changed by someone else — review the refreshed values before saving again.",
         );
       } else {
         toast.error(
@@ -291,8 +285,8 @@ export function ProjectEnvironmentEditor({
             err,
             environment
               ? "Could not save the environment."
-              : "Could not create the environment."
-          )
+              : "Could not create the environment.",
+          ),
         );
       }
     } finally {
@@ -408,7 +402,10 @@ export function ProjectEnvironmentEditor({
 
       {computersEnabled ? (
         <div className="space-y-1.5">
-          <Label htmlFor="project-environment-sandbox-image" className="text-xs">
+          <Label
+            htmlFor="project-environment-sandbox-image"
+            className="text-xs"
+          >
             Sandbox image
           </Label>
           <div className="flex items-center gap-2">
@@ -436,7 +433,7 @@ export function ProjectEnvironmentEditor({
               <EnvironmentBuildBadge
                 build={
                   (sandboxImages ?? []).find(
-                    (img) => img.environmentId === draft.computerEnvironmentId
+                    (img) => img.environmentId === draft.computerEnvironmentId,
                   )?.currentBuild ?? null
                 }
               />
@@ -446,8 +443,8 @@ export function ProjectEnvironmentEditor({
             Applies to cloud runs in this environment: evals, swarms, and
             user-testing sessions each boot a fresh, isolated sandbox from this
             image. Cloud runs only — sandbox images never apply to the machine
-            running this inspector. A not-built image fails at launch — build
-            it first under Computer → Images.
+            running this inspector. A not-built image fails at launch — build it
+            first under Computer → Images.
           </p>
         </div>
       ) : null}

--- a/mcpjam-inspector/client/src/components/project-environments/ProjectEnvironmentSkillsPicker.tsx
+++ b/mcpjam-inspector/client/src/components/project-environments/ProjectEnvironmentSkillsPicker.tsx
@@ -8,7 +8,11 @@ import {
   TooltipTrigger,
 } from "@mcpjam/design-system/tooltip";
 import { cn } from "@/lib/utils";
-import { listSkills } from "@/lib/apis/mcp-skills-api";
+import {
+  listSkills,
+  listSkillVersions,
+  type CloudSkillVersionSummary,
+} from "@/lib/apis/mcp-skills-api";
 import type { SkillListItem } from "@/shared/skill-types";
 import type { ProjectEnvironmentSkillSelection } from "@/hooks/useProjectEnvironments";
 
@@ -24,8 +28,17 @@ export const MAX_ENVIRONMENT_SKILLS = 20;
  * frontmatter) render disabled with the backend-aligned reason, so users
  * never pick a skill only to discover the restriction at save time.
  *
- * Emits `{ mode: 'explicit', skillIds }` or `null` — never an empty array
- * (the backend rejects `[]`; clearing means `null`).
+ * Each selected skill also gets a VERSION control, defaulting to "Latest" —
+ * the skill's current revision, resolved when the run starts, which is what an
+ * environment has always done. Choosing an exact revision writes a
+ * `versionPins` entry, which is how two environments run two revisions of one
+ * skill side by side. History is fetched only when a control is opened: a
+ * picker listing 20 skills should not fetch 20 histories nobody looked at.
+ *
+ * Emits `{ mode: 'explicit', skillIds, versionPins? }` or `null` — never an
+ * empty array (the backend rejects `[]`; clearing means `null`), and
+ * `versionPins` is omitted rather than `[]` when nothing is pinned, so an
+ * unpinned environment serializes exactly as it did before pins existed.
  */
 export function ProjectEnvironmentSkillsPicker({
   projectId,
@@ -53,7 +66,7 @@ export function ProjectEnvironmentSkillsPicker({
       } catch (err) {
         if (!active) return;
         setLoadError(
-          err instanceof Error ? err.message : "Failed to load skills"
+          err instanceof Error ? err.message : "Failed to load skills",
         );
       }
     })();
@@ -63,6 +76,11 @@ export function ProjectEnvironmentSkillsPicker({
   }, [projectId]);
 
   const selectedIds = useMemo(() => new Set(value?.skillIds ?? []), [value]);
+  const pinnedVersionBySkillId = useMemo(
+    () =>
+      new Map((value?.versionPins ?? []).map((p) => [p.skillId, p.versionId])),
+    [value],
+  );
   const atCap = selectedIds.size >= MAX_ENVIRONMENT_SKILLS;
   // Pinned ids the shared-skills list doesn't return: the skill was unshared,
   // deleted, or moved out of the project. Without a row they are invisible AND
@@ -74,10 +92,30 @@ export function ProjectEnvironmentSkillsPicker({
       skills === null
         ? []
         : Array.from(selectedIds).filter(
-            (id) => !skills.some((s) => s.skillId === id)
+            (id) => !skills.some((s) => s.skillId === id),
           ),
-    [skills, selectedIds]
+    [skills, selectedIds],
   );
+
+  /** Emit a selection, dropping pins for skills that are no longer selected. */
+  const emit = (nextIds: Set<string>, nextPins: Map<string, string>): void => {
+    // Never emit an empty explicit selection — clearing means null.
+    if (nextIds.size === 0) {
+      onChange(null);
+      return;
+    }
+    const pins = Array.from(nextPins.entries())
+      // A pin for an unselected skill is rejected by the backend, and would be
+      // a silent passenger even if it weren't.
+      .filter(([skillId]) => nextIds.has(skillId))
+      .map(([skillId, versionId]) => ({ skillId, versionId }));
+    onChange({
+      mode: "explicit",
+      skillIds: Array.from(nextIds),
+      // Absent, not `[]`, when nothing is pinned.
+      ...(pins.length > 0 ? { versionPins: pins } : {}),
+    });
+  };
 
   const toggle = (skillId: string, checked: boolean) => {
     const next = new Set(selectedIds);
@@ -87,10 +125,15 @@ export function ProjectEnvironmentSkillsPicker({
     } else {
       next.delete(skillId);
     }
-    // Never emit an empty explicit selection — clearing means null.
-    onChange(
-      next.size === 0 ? null : { mode: "explicit", skillIds: Array.from(next) }
-    );
+    emit(next, pinnedVersionBySkillId);
+  };
+
+  /** Pin one skill to an exact revision, or `null` to go back to Latest. */
+  const setVersionPin = (skillId: string, versionId: string | null) => {
+    const nextPins = new Map(pinnedVersionBySkillId);
+    if (versionId === null) nextPins.delete(skillId);
+    else nextPins.set(skillId, versionId);
+    emit(selectedIds, nextPins);
   };
 
   if (loadError) {
@@ -143,7 +186,7 @@ export function ProjectEnvironmentSkillsPicker({
               className={cn(
                 "flex cursor-pointer items-center gap-2 rounded-md px-2 py-1.5 text-sm hover:bg-accent/30",
                 rowDisabled &&
-                  "cursor-not-allowed opacity-60 hover:bg-transparent"
+                  "cursor-not-allowed opacity-60 hover:bg-transparent",
               )}
             >
               <Checkbox
@@ -161,6 +204,16 @@ export function ProjectEnvironmentSkillsPicker({
                   </span>
                 ) : null}
               </span>
+              {checked ? (
+                <SkillVersionControl
+                  projectId={projectId}
+                  skillId={skillId}
+                  currentVersionNumber={skill.currentVersionNumber}
+                  pinnedVersionId={pinnedVersionBySkillId.get(skillId) ?? null}
+                  disabled={disabled}
+                  onChange={(versionId) => setVersionPin(skillId, versionId)}
+                />
+              ) : null}
             </Label>
           );
           if (!ineligible) return row;
@@ -185,7 +238,7 @@ export function ProjectEnvironmentSkillsPicker({
             key={skillId}
             className={cn(
               "flex cursor-pointer items-center gap-2 rounded-md px-2 py-1.5 text-sm hover:bg-accent/30",
-              disabled && "cursor-not-allowed opacity-60 hover:bg-transparent"
+              disabled && "cursor-not-allowed opacity-60 hover:bg-transparent",
             )}
           >
             {/* Unresolvable pin: uncheck to remove only — never re-selectable.
@@ -214,8 +267,104 @@ export function ProjectEnvironmentSkillsPicker({
       </div>
       <p className="text-[11px] text-muted-foreground">
         {selectedIds.size}/{MAX_ENVIRONMENT_SKILLS} skills selected
+        {pinnedVersionBySkillId.size > 0
+          ? ` (${pinnedVersionBySkillId.size} pinned to a version)`
+          : ""}
         {atCap ? " — cap reached" : ""}. Shared skills only.
       </p>
     </div>
+  );
+}
+
+/**
+ * "Latest" vs an exact revision, for ONE selected skill.
+ *
+ * History loads on first open, not on mount: a picker showing 20 skills would
+ * otherwise fire 20 requests for lists nobody looked at. Until then the control
+ * shows what it already knows from the list row — the current version number.
+ *
+ * Latest is the default and stays the default. Pinning is the deliberate act
+ * (hold this environment at a known revision so a comparison means something),
+ * so it is never selected on the user's behalf.
+ */
+function SkillVersionControl({
+  projectId,
+  skillId,
+  currentVersionNumber,
+  pinnedVersionId,
+  disabled,
+  onChange,
+}: {
+  projectId: string;
+  skillId: string;
+  currentVersionNumber?: number;
+  pinnedVersionId: string | null;
+  disabled: boolean;
+  onChange: (versionId: string | null) => void;
+}) {
+  const [versions, setVersions] = useState<CloudSkillVersionSummary[] | null>(
+    null,
+  );
+  const [loading, setLoading] = useState(false);
+
+  const loadVersions = async () => {
+    if (versions !== null || loading) return;
+    setLoading(true);
+    try {
+      setVersions(await listSkillVersions(projectId, skillId));
+    } catch {
+      // A failed history load must not block the selection itself: fall back
+      // to an empty list, which renders as "Latest only".
+      setVersions([]);
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  // What the trigger says before history arrives: the pinned number when we
+  // know it, else Latest (with its number when the list row carried one).
+  const pinned = versions?.find((v) => v.versionId === pinnedVersionId);
+  const label = pinnedVersionId
+    ? pinned
+      ? `v${pinned.versionNumber}`
+      : "Pinned"
+    : currentVersionNumber !== undefined
+    ? `Latest (v${currentVersionNumber})`
+    : "Latest";
+
+  return (
+    <select
+      // eslint-disable-next-line jsx-a11y/no-onchange
+      className={cn(
+        "ml-auto shrink-0 rounded border border-border/60 bg-background px-1.5 py-0.5 text-[11px]",
+        pinnedVersionId && "border-warning/60",
+      )}
+      aria-label={`Version for ${skillId}`}
+      disabled={disabled}
+      value={pinnedVersionId ?? ""}
+      onMouseDown={(e) => {
+        // Opening the control is what triggers the fetch; stop the click from
+        // reaching the row Label, which would toggle the checkbox.
+        e.stopPropagation();
+        void loadVersions();
+      }}
+      onClick={(e) => e.stopPropagation()}
+      onFocus={() => void loadVersions()}
+      onChange={(e) => onChange(e.target.value === "" ? null : e.target.value)}
+    >
+      <option value="">{label === "Pinned" ? "Latest" : label}</option>
+      {loading ? <option disabled>Loading…</option> : null}
+      {(versions ?? []).map((version) => (
+        <option key={version.versionId} value={version.versionId}>
+          v{version.versionNumber}
+          {version.isCurrent ? " (current)" : ""}
+        </option>
+      ))}
+      {/* A pin whose history hasn't loaded still needs a selectable option, or
+          the control would silently reset it to Latest on first render. */}
+      {pinnedVersionId && !pinned ? (
+        <option value={pinnedVersionId}>Pinned version</option>
+      ) : null}
+    </select>
   );
 }

--- a/mcpjam-inspector/client/src/components/project-environments/ProjectEnvironmentSkillsPicker.tsx
+++ b/mcpjam-inspector/client/src/components/project-environments/ProjectEnvironmentSkillsPicker.tsx
@@ -210,7 +210,11 @@ export function ProjectEnvironmentSkillsPicker({
                   skillId={skillId}
                   currentVersionNumber={skill.currentVersionNumber}
                   pinnedVersionId={pinnedVersionBySkillId.get(skillId) ?? null}
-                  disabled={disabled}
+                  // An ineligible skill's selection is rejected at save, so
+                  // choosing a revision for it leads nowhere. The row's
+                  // checkbox stays enabled (see `rowDisabled`) precisely so the
+                  // user can repair the selection by removing it.
+                  disabled={disabled || ineligible}
                   onChange={(versionId) => setVersionPin(skillId, versionId)}
                 />
               ) : null}

--- a/mcpjam-inspector/client/src/components/project-environments/__tests__/skills-picker-version-pins.test.tsx
+++ b/mcpjam-inspector/client/src/components/project-environments/__tests__/skills-picker-version-pins.test.tsx
@@ -160,6 +160,78 @@ describe("ProjectEnvironmentSkillsPicker — version pins", () => {
     });
   });
 
+  it("stays usable when the history request fails", async () => {
+    // A failed history load must not block the selection itself — the skill is
+    // still selected, it just can't offer revisions to choose from.
+    mockListSkillVersions.mockRejectedValue(new Error("network"));
+    render(
+      <ProjectEnvironmentSkillsPicker
+        projectId="proj-1"
+        value={{ mode: "explicit", skillIds: ["skill-refunds"] }}
+        onChange={vi.fn()}
+      />,
+    );
+
+    const control = await screen.findByLabelText("Version for skill-refunds");
+    fireEvent.focus(control);
+    await waitFor(() => expect(mockListSkillVersions).toHaveBeenCalled());
+    expect(control).toHaveValue("");
+    expect(screen.getByText("Latest (v4)")).toBeInTheDocument();
+  });
+
+  it("renders the empty state when the project has no shared skills", async () => {
+    mockListSkills.mockResolvedValue([]);
+    render(
+      <ProjectEnvironmentSkillsPicker
+        projectId="proj-1"
+        value={null}
+        onChange={vi.fn()}
+      />,
+    );
+    expect(
+      await screen.findByText(/No shared skills in this project yet/i),
+    ).toBeInTheDocument();
+  });
+
+  it("accepts a null selection without crashing", async () => {
+    render(
+      <ProjectEnvironmentSkillsPicker
+        projectId="proj-1"
+        value={null}
+        onChange={vi.fn()}
+      />,
+    );
+    // Nothing is checked, so no version control exists to show.
+    expect(await screen.findByLabelText("refunds")).not.toBeChecked();
+    expect(
+      screen.queryByLabelText("Version for skill-refunds"),
+    ).not.toBeInTheDocument();
+  });
+
+  it("disables the version control for an ineligible selected skill", async () => {
+    // Its selection is rejected at save, so choosing a revision leads nowhere —
+    // but the checkbox stays live so the user can remove it and repair the
+    // selection.
+    mockListSkills.mockResolvedValue([
+      {
+        ...REFUNDS,
+        pinnability: { ok: false, reason: "not_shared" },
+      },
+    ]);
+    render(
+      <ProjectEnvironmentSkillsPicker
+        projectId="proj-1"
+        value={{ mode: "explicit", skillIds: ["skill-refunds"] }}
+        onChange={vi.fn()}
+      />,
+    );
+
+    expect(
+      await screen.findByLabelText("Version for skill-refunds"),
+    ).toBeDisabled();
+    expect(screen.getByLabelText("refunds")).not.toBeDisabled();
+  });
+
   it("keeps a pin selectable before its history has loaded", async () => {
     // Otherwise the control would render an unknown value, fall back to
     // Latest, and silently discard the pin on the next save.

--- a/mcpjam-inspector/client/src/components/project-environments/__tests__/skills-picker-version-pins.test.tsx
+++ b/mcpjam-inspector/client/src/components/project-environments/__tests__/skills-picker-version-pins.test.tsx
@@ -1,0 +1,181 @@
+/**
+ * The version control in the environment skills picker.
+ *
+ * The behaviours worth pinning here are the ones a careless refactor breaks
+ * silently: Latest stays the default (an environment must not drift onto a
+ * frozen revision by accident), pins ride alongside `skillIds` in the emitted
+ * selection, deselecting a skill takes its pin with it, and history is fetched
+ * only when someone actually opens a control.
+ */
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const { mockListSkills, mockListSkillVersions } = vi.hoisted(() => ({
+  mockListSkills: vi.fn(),
+  mockListSkillVersions: vi.fn(),
+}));
+
+vi.mock("@/lib/apis/mcp-skills-api", () => ({
+  listSkills: (...args: unknown[]) => mockListSkills(...args),
+  listSkillVersions: (...args: unknown[]) => mockListSkillVersions(...args),
+}));
+
+import { ProjectEnvironmentSkillsPicker } from "../ProjectEnvironmentSkillsPicker";
+
+const REFUNDS = {
+  name: "refunds",
+  description: "Handle refunds",
+  path: "Shared",
+  skillId: "skill-refunds",
+  sharing: "project" as const,
+  isOwner: false,
+  origin: "cloud" as const,
+  currentVersionId: "ver-4",
+  currentVersionNumber: 4,
+};
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockListSkills.mockResolvedValue([REFUNDS]);
+  mockListSkillVersions.mockResolvedValue([
+    {
+      versionId: "ver-4",
+      versionNumber: 4,
+      versionHash: "h4",
+      contentHash: "h4",
+      name: "refunds",
+      description: "Handle refunds",
+      fileCount: 0,
+      isCurrent: true,
+      createdByUserId: "u1",
+      createdAt: 4,
+    },
+    {
+      versionId: "ver-1",
+      versionNumber: 1,
+      versionHash: "h1",
+      contentHash: "h1",
+      name: "refunds",
+      description: "Handle refunds",
+      fileCount: 0,
+      isCurrent: false,
+      createdByUserId: "u1",
+      createdAt: 1,
+    },
+  ]);
+});
+
+describe("ProjectEnvironmentSkillsPicker — version pins", () => {
+  it("shows Latest by default and does not fetch history until opened", async () => {
+    render(
+      <ProjectEnvironmentSkillsPicker
+        projectId="proj-1"
+        value={{ mode: "explicit", skillIds: ["skill-refunds"] }}
+        onChange={vi.fn()}
+      />,
+    );
+
+    const control = await screen.findByLabelText("Version for skill-refunds");
+    expect(control).toHaveValue("");
+    expect(screen.getByText("Latest (v4)")).toBeInTheDocument();
+    // A picker of 20 skills must not fire 20 history requests nobody asked for.
+    expect(mockListSkillVersions).not.toHaveBeenCalled();
+
+    fireEvent.focus(control);
+    await waitFor(() => expect(mockListSkillVersions).toHaveBeenCalledTimes(1));
+  });
+
+  it("emits a versionPins entry when an exact revision is chosen", async () => {
+    const onChange = vi.fn();
+    render(
+      <ProjectEnvironmentSkillsPicker
+        projectId="proj-1"
+        value={{ mode: "explicit", skillIds: ["skill-refunds"] }}
+        onChange={onChange}
+      />,
+    );
+
+    const control = await screen.findByLabelText("Version for skill-refunds");
+    fireEvent.focus(control);
+    await waitFor(() => expect(mockListSkillVersions).toHaveBeenCalled());
+    await screen.findByText("v1");
+
+    fireEvent.change(control, { target: { value: "ver-1" } });
+    expect(onChange).toHaveBeenCalledWith({
+      mode: "explicit",
+      skillIds: ["skill-refunds"],
+      versionPins: [{ skillId: "skill-refunds", versionId: "ver-1" }],
+    });
+  });
+
+  it("omits versionPins entirely when going back to Latest", async () => {
+    // Absent, not `[]` — an unpinned environment must serialize (and
+    // fingerprint) exactly as one written before pins existed.
+    const onChange = vi.fn();
+    render(
+      <ProjectEnvironmentSkillsPicker
+        projectId="proj-1"
+        value={{
+          mode: "explicit",
+          skillIds: ["skill-refunds"],
+          versionPins: [{ skillId: "skill-refunds", versionId: "ver-1" }],
+        }}
+        onChange={onChange}
+      />,
+    );
+
+    const control = await screen.findByLabelText("Version for skill-refunds");
+    fireEvent.change(control, { target: { value: "" } });
+    expect(onChange).toHaveBeenCalledWith({
+      mode: "explicit",
+      skillIds: ["skill-refunds"],
+    });
+  });
+
+  it("drops a skill's pin when the skill is deselected", async () => {
+    // A pin for an unselected skill is rejected by the backend, and would be an
+    // invisible passenger on every save even if it weren't.
+    const onChange = vi.fn();
+    mockListSkills.mockResolvedValue([
+      REFUNDS,
+      { ...REFUNDS, name: "tone", skillId: "skill-tone" },
+    ]);
+    render(
+      <ProjectEnvironmentSkillsPicker
+        projectId="proj-1"
+        value={{
+          mode: "explicit",
+          skillIds: ["skill-refunds", "skill-tone"],
+          versionPins: [{ skillId: "skill-refunds", versionId: "ver-1" }],
+        }}
+        onChange={onChange}
+      />,
+    );
+
+    const refundsCheckbox = await screen.findByLabelText("refunds");
+    fireEvent.click(refundsCheckbox);
+    expect(onChange).toHaveBeenCalledWith({
+      mode: "explicit",
+      skillIds: ["skill-tone"],
+    });
+  });
+
+  it("keeps a pin selectable before its history has loaded", async () => {
+    // Otherwise the control would render an unknown value, fall back to
+    // Latest, and silently discard the pin on the next save.
+    render(
+      <ProjectEnvironmentSkillsPicker
+        projectId="proj-1"
+        value={{
+          mode: "explicit",
+          skillIds: ["skill-refunds"],
+          versionPins: [{ skillId: "skill-refunds", versionId: "ver-1" }],
+        }}
+        onChange={vi.fn()}
+      />,
+    );
+
+    const control = await screen.findByLabelText("Version for skill-refunds");
+    expect(control).toHaveValue("ver-1");
+  });
+});

--- a/mcpjam-inspector/client/src/components/swarms/__tests__/environment-selection-key.test.ts
+++ b/mcpjam-inspector/client/src/components/swarms/__tests__/environment-selection-key.test.ts
@@ -1,0 +1,150 @@
+/**
+ * The create flow's environment-selection key.
+ *
+ * This key decides whether previously resolved environments and already-created
+ * journeys can be reused. Getting it wrong is SILENT: the flow still runs, it
+ * just runs the wrong thing — which is why the invariant is tested directly.
+ */
+import { describe, expect, it } from "vitest";
+import { buildEnvironmentSelectionKey } from "../new-swarm-flow-draft";
+
+const BASE = {
+  composeMode: false,
+  environmentIds: [] as string[],
+  hostIds: ["host-1"],
+  serverAttachmentId: null,
+  computerEnvironmentId: null,
+  customized: false,
+};
+
+describe("buildEnvironmentSelectionKey", () => {
+  it("changes when a selected skill is pinned to a different revision", () => {
+    // The regression this exists for: `skillIds` is identical on both sides, so
+    // a key built from ids alone would compare equal and the flow would reuse
+    // journeys created against the OLD revision.
+    const latest = buildEnvironmentSelectionKey({
+      ...BASE,
+      skillSelection: { skillIds: ["skill-refunds"] },
+    });
+    const pinned = buildEnvironmentSelectionKey({
+      ...BASE,
+      skillSelection: {
+        skillIds: ["skill-refunds"],
+        versionPins: [{ skillId: "skill-refunds", versionId: "ver-1" }],
+      },
+    });
+    expect(pinned).not.toBe(latest);
+  });
+
+  it("changes when a pin moves from one revision to another", () => {
+    const v1 = buildEnvironmentSelectionKey({
+      ...BASE,
+      skillSelection: {
+        skillIds: ["skill-refunds"],
+        versionPins: [{ skillId: "skill-refunds", versionId: "ver-1" }],
+      },
+    });
+    const v2 = buildEnvironmentSelectionKey({
+      ...BASE,
+      skillSelection: {
+        skillIds: ["skill-refunds"],
+        versionPins: [{ skillId: "skill-refunds", versionId: "ver-2" }],
+      },
+    });
+    expect(v2).not.toBe(v1);
+  });
+
+  it("is stable across pin ORDER — which revision each skill runs is the identity", () => {
+    const a = buildEnvironmentSelectionKey({
+      ...BASE,
+      skillSelection: {
+        skillIds: ["skill-a", "skill-b"],
+        versionPins: [
+          { skillId: "skill-a", versionId: "ver-1" },
+          { skillId: "skill-b", versionId: "ver-9" },
+        ],
+      },
+    });
+    const b = buildEnvironmentSelectionKey({
+      ...BASE,
+      skillSelection: {
+        skillIds: ["skill-a", "skill-b"],
+        versionPins: [
+          { skillId: "skill-b", versionId: "ver-9" },
+          { skillId: "skill-a", versionId: "ver-1" },
+        ],
+      },
+    });
+    expect(a).toBe(b);
+  });
+
+  it("treats no pins and an empty pin list as the same selection", () => {
+    // A picker mid-edit can produce `[]`; the backend stores absent. Neither
+    // pins anything, so neither should invalidate the cache.
+    const absent = buildEnvironmentSelectionKey({
+      ...BASE,
+      skillSelection: { skillIds: ["skill-refunds"] },
+    });
+    const empty = buildEnvironmentSelectionKey({
+      ...BASE,
+      skillSelection: { skillIds: ["skill-refunds"], versionPins: [] },
+    });
+    expect(empty).toBe(absent);
+  });
+
+  it("still distinguishes everything it distinguished before", () => {
+    const base = buildEnvironmentSelectionKey({
+      ...BASE,
+      skillSelection: null,
+    });
+    expect(
+      buildEnvironmentSelectionKey({
+        ...BASE,
+        skillSelection: null,
+        composeMode: true,
+      }),
+    ).not.toBe(base);
+    expect(
+      buildEnvironmentSelectionKey({
+        ...BASE,
+        skillSelection: null,
+        hostIds: ["host-2"],
+      }),
+    ).not.toBe(base);
+    expect(
+      buildEnvironmentSelectionKey({
+        ...BASE,
+        skillSelection: null,
+        serverAttachmentId: "att-1",
+      }),
+    ).not.toBe(base);
+    expect(
+      buildEnvironmentSelectionKey({
+        ...BASE,
+        skillSelection: null,
+        computerEnvironmentId: "img-1",
+      }),
+    ).not.toBe(base);
+    expect(
+      buildEnvironmentSelectionKey({
+        ...BASE,
+        skillSelection: null,
+        customized: true,
+      }),
+    ).not.toBe(base);
+    // Host ids are a SET; their order must not invalidate the cache.
+    expect(
+      buildEnvironmentSelectionKey({
+        ...BASE,
+        skillSelection: null,
+        hostIds: ["host-1", "host-2"],
+      }),
+    ).toBe(
+      buildEnvironmentSelectionKey({
+        ...BASE,
+        skillSelection: null,
+        hostIds: ["host-2", "host-1"],
+      }),
+    );
+  });
+});

--- a/mcpjam-inspector/client/src/components/swarms/new-swarm-create-flow.tsx
+++ b/mcpjam-inspector/client/src/components/swarms/new-swarm-create-flow.tsx
@@ -60,6 +60,7 @@ import {
   type SwarmLaunchedRun,
 } from "@/components/swarms/new-swarm-running-step";
 import {
+  buildEnvironmentSelectionKey,
   clearNewSwarmFlowDraft,
   readNewSwarmFlowDraft,
   saveNewSwarmFlowDraft,
@@ -250,7 +251,7 @@ function EnvironmentGroundingHint({
 }) {
   const inventory = useQuery(
     SWARM_QUERIES.getEnvironmentToolInventory as any,
-    { projectId, environmentId } as any
+    { projectId, environmentId } as any,
   ) as
     | {
         environmentName: string;
@@ -292,7 +293,7 @@ function EnvironmentGroundingHint({
 async function runWithConcurrency<T>(
   items: T[],
   limit: number,
-  worker: (item: T) => Promise<void | "stop">
+  worker: (item: T) => Promise<void | "stop">,
 ): Promise<void> {
   let cursor = 0;
   let stopped = false;
@@ -308,7 +309,7 @@ async function runWithConcurrency<T>(
           return;
         }
       }
-    }
+    },
   );
   await Promise.all(runners);
 }
@@ -320,7 +321,7 @@ async function runWithConcurrency<T>(
  */
 function sameEnvironmentSelection(
   stored: readonly string[] | null,
-  selection: readonly string[]
+  selection: readonly string[],
 ): boolean {
   const current = stored ?? [];
   if (current.length !== selection.length) return false;
@@ -362,7 +363,7 @@ export function NewSwarmCreateFlow({
   onCreatePersona: (draft: CreatePersonaDraft) => Promise<string>;
   onCreateJourney: (
     personaRefId: string,
-    draft: CreateJourneyDraft
+    draft: CreateJourneyDraft,
   ) => Promise<string>;
   /** Apply this swarm's promises to a REUSED journey before launch: the
    * Describe env selection (when its stored fan-out differs) and the merged
@@ -377,7 +378,7 @@ export function NewSwarmCreateFlow({
       judgeConfig?: GoalJudgeConfig;
       /** Confirm edits a reused goal's text in place (BB-122). */
       goal?: string;
-    }
+    },
   ) => Promise<void>;
   launchJourney: (
     journeyId: string,
@@ -389,7 +390,7 @@ export function NewSwarmCreateFlow({
      * environment id) was therefore invisible to this interface, one rename
      * away from being silently dropped.
      */
-    opts?: { swarmRunGroupId?: string; environmentIds?: string[] }
+    opts?: { swarmRunGroupId?: string; environmentIds?: string[] },
   ) => Promise<
     { status: "launched"; runId?: string } | { status: "already_launching" }
   >;
@@ -420,7 +421,7 @@ export function NewSwarmCreateFlow({
    */
   onSaveExistingPersona: (
     personaRefId: string,
-    patch: { name?: string; role?: string; notes?: string }
+    patch: { name?: string; role?: string; notes?: string },
   ) => Promise<void>;
   /**
    * Save the project's clustering settings. Optional: absent hides the row, so
@@ -435,8 +436,7 @@ export function NewSwarmCreateFlow({
   const resolveComposerTargets = useComposerResolver(projectId);
   const { isAuthenticated } = useConvexAuth();
   const isUserReady = useDbUserReady();
-  const hostsQueryEnabled =
-    isAuthenticated && shouldQueryProjectId(projectId);
+  const hostsQueryEnabled = isAuthenticated && shouldQueryProjectId(projectId);
   const attachmentsQueryEnabled =
     isAuthenticated && isUserReady && shouldQueryProjectId(projectId);
   const { hosts, isLoading: hostsLoading } = useHostList({
@@ -459,7 +459,7 @@ export function NewSwarmCreateFlow({
    */
   const [restoredDraft] = useState(() => readNewSwarmFlowDraft(projectId));
   const [step, setStep] = useState<"describe" | "confirm" | "running">(
-    restoredDraft?.step ?? "describe"
+    restoredDraft?.step ?? "describe",
   );
   const [draft, setDraft] = useState(restoredDraft?.description ?? "");
   /**
@@ -469,7 +469,7 @@ export function NewSwarmCreateFlow({
   const [swarmName, setSwarmName] = useState(
     // `||`, not `??`: a draft written before this field existed carries an
     // empty string, which should still fall back to the suggestion.
-    () => restoredDraft?.name || suggestSwarmName(new Date())
+    () => restoredDraft?.name || suggestSwarmName(new Date()),
   );
   /**
    * Whether the user has typed in the name field.
@@ -482,10 +482,10 @@ export function NewSwarmCreateFlow({
    * was cleared. So the fact is recorded, and travels with the draft.
    */
   const [nameEdited, setNameEdited] = useState(
-    restoredDraft?.nameEdited === true
+    restoredDraft?.nameEdited === true,
   );
   const [targetState, setTargetState] = useState<EnvironmentComposerState>(
-    () => restoredDraft?.targetState ?? emptyComposerState()
+    () => restoredDraft?.targetState ?? emptyComposerState(),
   );
   /** One-shot auto-seed — never overwrite after the user clears or edits. */
   const targetSeededRef = useRef(false);
@@ -510,7 +510,7 @@ export function NewSwarmCreateFlow({
   // make every create flow subscribe to a function that does not exist.
   const insightsTuning = useQuery(
     SWARM_QUERIES.getSwarmInsightsTuning as any,
-    onSetInsightsTuning ? ({ projectId } as any) : "skip"
+    onSetInsightsTuning ? ({ projectId } as any) : "skip",
   ) as { tuning: ClusterTuning; source: string } | null | undefined;
 
   const handleSaveInsightsTuning = useCallback(
@@ -525,24 +525,24 @@ export function NewSwarmCreateFlow({
           toast.error(
             error instanceof Error
               ? error.message
-              : "Could not save insight grouping."
+              : "Could not save insight grouping.",
           );
         })
         .finally(() => setSavingInsightsTuning(false));
     },
-    [onSetInsightsTuning]
+    [onSetInsightsTuning],
   );
   const [pushIntensity, setPushIntensity] = useState<SwarmPushIntensity>(
-    restoredDraft?.pushIntensity ?? DEFAULT_SWARM_INTENSITY
+    restoredDraft?.pushIntensity ?? DEFAULT_SWARM_INTENSITY,
   );
   const [reusedIds, setReusedIds] = useState<string[]>(
-    restoredDraft?.reusedIds ?? []
+    restoredDraft?.reusedIds ?? [],
   );
   const [proposed, setProposed] = useState<ProposedPersona[]>(
-    restoredDraft?.proposed ?? []
+    restoredDraft?.proposed ?? [],
   );
   const [launchedRuns, setLaunchedRuns] = useState<SwarmLaunchedRun[]>(
-    restoredDraft?.launchedRuns ?? []
+    restoredDraft?.launchedRuns ?? [],
   );
   const [generating, setGenerating] = useState(false);
   /** When the in-flight generation started — drives the progress line. */
@@ -555,7 +555,7 @@ export function NewSwarmCreateFlow({
   const [errorMessage, setErrorMessage] = useState<string | null>(
     restoredDraft?.generatingSince != null
       ? "Persona generation was interrupted when this view reloaded. Nothing was saved — press Continue to generate again."
-      : null
+      : null,
   );
   // Sync latch: `generating`/`launching` are state, so two fast clicks in one
   // tick would both see the old value and fire twice.
@@ -563,20 +563,20 @@ export function NewSwarmCreateFlow({
   // Labels for Overview session grouping — set at launch, handed to onDone
   // when the user leaves Running (Cancel / Stop / Look now).
   const launchedRunLabelsRef = useRef<Map<string, string>>(
-    new Map(restoredDraft?.runLabels ?? [])
+    new Map(restoredDraft?.runLabels ?? []),
   );
   // Rows a previous attempt already created. A launch failure leaves the user
   // on Confirm with a Retry, and without this the retry would create every
   // persona and journey a SECOND time — the rows are already real, only the
   // launch needs redoing.
   const persistedTargetsRef = useRef<LaunchTarget[] | null>(
-    restoredDraft?.launch.targets ?? null
+    restoredDraft?.launch.targets ?? null,
   );
   // Environments baked into those persisted journeys. If the user goes Back
   // and changes the env selection, retrying must NOT relaunch the old
   // single-client journeys while the matrix shows the new multi-client set.
   const persistedEnvironmentKeyRef = useRef<string | null>(
-    restoredDraft?.launch.environmentKey ?? null
+    restoredDraft?.launch.environmentKey ?? null,
   );
   /**
    * The wave id for THIS swarm, minted once and reused across a retry.
@@ -589,7 +589,7 @@ export function NewSwarmCreateFlow({
    * Overview.
    */
   const persistedRunGroupIdRef = useRef<string | null>(
-    restoredDraft?.launch.runGroupId ?? null
+    restoredDraft?.launch.runGroupId ?? null,
   );
   /**
    * Stable prefix for this authoring session's idempotency keys.
@@ -604,7 +604,7 @@ export function NewSwarmCreateFlow({
   const flowIdRef = useRef<string | null>(restoredDraft?.launch.flowId ?? null);
   /** The swarm row this launch created, so a retry doesn't create a second. */
   const persistedSwarmIdRef = useRef<string | null>(
-    restoredDraft?.launch.swarmId ?? null
+    restoredDraft?.launch.swarmId ?? null,
   );
 
   const envList = useMemo(() => environments ?? [], [environments]);
@@ -620,11 +620,7 @@ export function NewSwarmCreateFlow({
     if (attachmentsQueryEnabled && attachmentsLoading) return;
     // Auth settled but DB user not ready yet — attachments are still skipped.
     // Seeding now would permanently miss the default server group.
-    if (
-      isAuthenticated &&
-      shouldQueryProjectId(projectId) &&
-      !isUserReady
-    ) {
+    if (isAuthenticated && shouldQueryProjectId(projectId) && !isUserReady) {
       return;
     }
     // Any non-empty stack or customized flag means the user already touched
@@ -705,18 +701,16 @@ export function NewSwarmCreateFlow({
    */
   const environmentSelectionKey = useMemo(
     () =>
-      [
-        composeMode ? "compose" : "castles",
-        ...[...targetState.environmentIds].sort(),
-        ...[...targetState.stack.hostIds].sort(),
-        targetState.stack.serverAttachmentId ?? "",
-        targetState.stack.computerEnvironmentId ?? "",
-        `skills:${(targetState.stack.skillSelection?.skillIds ?? []).join(
-          ","
-        )}`,
-        targetState.customized ? "custom" : "seeded",
-      ].join("|"),
-    [composeMode, targetState]
+      buildEnvironmentSelectionKey({
+        composeMode,
+        environmentIds: targetState.environmentIds,
+        hostIds: targetState.stack.hostIds,
+        serverAttachmentId: targetState.stack.serverAttachmentId,
+        computerEnvironmentId: targetState.stack.computerEnvironmentId,
+        skillSelection: targetState.stack.skillSelection,
+        customized: targetState.customized,
+      }),
+    [composeMode, targetState],
   );
 
   // A restored draft already carries the resolution for the selection key it
@@ -750,7 +744,7 @@ export function NewSwarmCreateFlow({
   const preset = SWARM_INTENSITY_PRESETS[pushIntensity];
   const reusedPersonas = useMemo(
     () => personaList.filter((persona) => reusedIds.includes(persona._id)),
-    [personaList, reusedIds]
+    [personaList, reusedIds],
   );
 
   const hasGenerateTargets =
@@ -844,7 +838,7 @@ export function NewSwarmCreateFlow({
       skillsEnabled,
       swarmName,
       targetState.stack,
-    ]
+    ],
   );
 
   /**
@@ -909,7 +903,7 @@ export function NewSwarmCreateFlow({
       });
       const payload = buildEnvJourneyPayload(
         composed.environmentIds,
-        composed.environments
+        composed.environments,
       );
       resolved = payload
         ? {
@@ -935,7 +929,7 @@ export function NewSwarmCreateFlow({
     setResolvedEnvironments(resolved.environments);
     if (resolved.materialized?.createdIds.length) {
       const created = resolved.environments.filter((env) =>
-        resolved.materialized!.createdIds.includes(env.environmentId)
+        resolved.materialized!.createdIds.includes(env.environmentId),
       );
       setCreatedEnvOverlay((prev) => {
         const byId = new Map(prev.map((e) => [e.environmentId, e]));
@@ -974,7 +968,7 @@ export function NewSwarmCreateFlow({
         throw new Error(
           composeMode
             ? "Could not create environments from the selected clients."
-            : "Pick an environment to generate against."
+            : "Pick an environment to generate against.",
         );
       }
       const result = await generateSwarmPersonaBatch({
@@ -996,7 +990,7 @@ export function NewSwarmCreateFlow({
       });
       if (result.personas.length === 0) {
         throw new Error(
-          "Generation returned no personas. Try again, or make sure the environment's servers have been connected so their tools are inspected."
+          "Generation returned no personas. Try again, or make sure the environment's servers have been connected so their tools are inspected.",
         );
       }
       // A fresh slate is a fresh set of rows to create — drop any memory of
@@ -1034,7 +1028,7 @@ export function NewSwarmCreateFlow({
                 }
               : {}),
           })),
-        }))
+        })),
       );
       track("swarm_create_generate_completed", {
         location: "swarms",
@@ -1049,7 +1043,7 @@ export function NewSwarmCreateFlow({
           err instanceof ComposerResolveError ||
           err instanceof SwarmGenerateError
           ? err.message
-          : errorMessageOf(err, "Failed to generate personas.")
+          : errorMessageOf(err, "Failed to generate personas."),
       );
     } finally {
       inFlightRef.current = false;
@@ -1096,7 +1090,7 @@ export function NewSwarmCreateFlow({
       // otherwise fail partway through, leaving some personas created.
       if (personaList.length + proposed.length > MAX_PERSONAS_PER_PROJECT) {
         setErrorMessage(
-          `This project is at its limit of ${MAX_PERSONAS_PER_PROJECT} personas. Delete some before creating ${proposed.length} more.`
+          `This project is at its limit of ${MAX_PERSONAS_PER_PROJECT} personas. Delete some before creating ${proposed.length} more.`,
         );
         return;
       }
@@ -1123,15 +1117,15 @@ export function NewSwarmCreateFlow({
               ? err.message
               : errorMessageOf(
                   err,
-                  "Could not resolve environments for launch."
-                )
+                  "Could not resolve environments for launch.",
+                ),
           );
           return;
         }
       }
       if (!envPayload && proposed.length > 0) {
         setErrorMessage(
-          "The selected environments can't be resolved to hosts. Go back and pick an environment or clients with a compatible host."
+          "The selected environments can't be resolved to hosts. Go back and pick an environment or clients with a compatible host.",
         );
         return;
       }
@@ -1210,7 +1204,7 @@ export function NewSwarmCreateFlow({
             // journeys are simply created without a container.
             firstError ??= errorMessageOf(
               err,
-              "The swarm record could not be created."
+              "The swarm record could not be created.",
             );
           }
         }
@@ -1236,7 +1230,7 @@ export function NewSwarmCreateFlow({
             payload.reusedGrading.map((row) => [
               row.journeyId,
               row.existingRubric,
-            ])
+            ]),
           );
 
           for (const target of payload.reusedTargets) {
@@ -1271,7 +1265,7 @@ export function NewSwarmCreateFlow({
               } catch (err) {
                 firstError ??= errorMessageOf(
                   err,
-                  "A reused goal could not be updated for this swarm."
+                  "A reused goal could not be updated for this swarm.",
                 );
                 // Only grading can fail here now, and grading is advisory: the
                 // run is still the one the user asked for, so it goes ahead
@@ -1285,7 +1279,7 @@ export function NewSwarmCreateFlow({
 
           for (const persona of proposed) {
             const journeys = persona.journeys.filter((journey) =>
-              journey.goal.trim()
+              journey.goal.trim(),
             );
             // Draft rows with blank goals are authoring placeholders — skip
             // the whole persona rather than create an empty shell.
@@ -1307,7 +1301,7 @@ export function NewSwarmCreateFlow({
             } catch (err) {
               firstError ??= errorMessageOf(
                 err,
-                "A persona could not be created."
+                "A persona could not be created.",
               );
               continue;
             }
@@ -1359,7 +1353,7 @@ export function NewSwarmCreateFlow({
               } catch (err) {
                 firstError ??= errorMessageOf(
                   err,
-                  "A goal could not be created."
+                  "A goal could not be created.",
                 );
               }
             }
@@ -1393,7 +1387,7 @@ export function NewSwarmCreateFlow({
                 target.environmentIds !== undefined &&
                 !sameEnvironmentSelection(
                   target.environmentIds,
-                  envPayload.environmentIds
+                  envPayload.environmentIds,
                 )
                   ? { environmentIds: envPayload.environmentIds }
                   : {}),
@@ -1437,11 +1431,11 @@ export function NewSwarmCreateFlow({
               }
               firstError ??= errorMessageOf(
                 err,
-                "A run could not be launched."
+                "A run could not be launched.",
               );
             }
             return undefined;
-          }
+          },
         );
       } catch (err) {
         firstError ??= errorMessageOf(err, "The swarm could not be launched.");
@@ -1473,13 +1467,13 @@ export function NewSwarmCreateFlow({
                 } created — retrying only launches ${
                   created === 1 ? "it" : "them"
                 }.`
-              : "")
+              : ""),
         );
         return;
       }
       if (launched === targets.length) {
         toast.success(
-          `Launched ${launched} ${launched === 1 ? "run" : "runs"}`
+          `Launched ${launched} ${launched === 1 ? "run" : "runs"}`,
         );
       } else if (billingBlocked) {
         // ONE billing message for the whole wave. The count matters here in a
@@ -1489,7 +1483,7 @@ export function NewSwarmCreateFlow({
         toast.warning(
           `Launched ${launched} of ${targets.length} runs — ${
             billingError ?? "the organization's credit limit was reached."
-          }`
+          }`,
         );
       } else {
         toast.warning(`Launched ${launched} of ${targets.length} runs`);
@@ -1513,7 +1507,7 @@ export function NewSwarmCreateFlow({
       pushIntensity,
       resolveTargets,
       targetState.environmentIds.length,
-    ]
+    ],
   );
 
   /**
@@ -1608,7 +1602,7 @@ export function NewSwarmCreateFlow({
         runLabels: launchedRunLabelsRef.current,
       });
     },
-    [onOpenSession]
+    [onOpenSession],
   );
 
   const activeStepIndex = step === "describe" ? 0 : step === "confirm" ? 1 : 2;
@@ -1625,7 +1619,7 @@ export function NewSwarmCreateFlow({
         setStep("describe");
       }
     },
-    [activeStepIndex, generating, launching, materializing, step]
+    [activeStepIndex, generating, launching, materializing, step],
   );
 
   /**
@@ -1639,7 +1633,7 @@ export function NewSwarmCreateFlow({
       if (step === "running") return false;
       return index < activeStepIndex;
     },
-    [activeStepIndex, generating, launching, materializing, step]
+    [activeStepIndex, generating, launching, materializing, step],
   );
 
   /**
@@ -1673,7 +1667,7 @@ export function NewSwarmCreateFlow({
   const runningFallbackColumns = useMemo(() => {
     return environmentIds.flatMap((environmentId) => {
       const env = envListForPayload.find(
-        (entry) => entry.environmentId === environmentId
+        (entry) => entry.environmentId === environmentId,
       );
       if (!env) return [];
       return [
@@ -1689,7 +1683,7 @@ export function NewSwarmCreateFlow({
     () =>
       environmentIds.map((environmentId) => {
         const env = envListForPayload.find(
-          (entry) => entry.environmentId === environmentId
+          (entry) => entry.environmentId === environmentId,
         );
         // `slice(0, 8)` stays for a row that isn't in the list AT ALL — a
         // different failure from a row that merely has no name, which
@@ -1698,7 +1692,7 @@ export function NewSwarmCreateFlow({
           ? environmentLabel(env, { hostName: hostNameById })
           : environmentId.slice(0, 8);
       }),
-    [envListForPayload, environmentIds, hostNameById]
+    [envListForPayload, environmentIds, hostNameById],
   );
 
   const groundingEnvironmentId =
@@ -1743,7 +1737,7 @@ export function NewSwarmCreateFlow({
           "min-h-0 flex-1 bg-background",
           step === "confirm" || step === "running"
             ? "overflow-hidden"
-            : "overflow-y-auto"
+            : "overflow-y-auto",
         )}
       >
         {step === "running" ? (
@@ -1782,7 +1776,7 @@ export function NewSwarmCreateFlow({
             availablePersonas={personaList}
             onAddReused={(personaId) =>
               setReusedIds((ids) =>
-                ids.includes(personaId) ? ids : [...ids, personaId]
+                ids.includes(personaId) ? ids : [...ids, personaId],
               )
             }
             onSaveReusedPersona={onSaveExistingPersona}
@@ -1897,7 +1891,7 @@ export function NewSwarmCreateFlow({
                         className="shrink-0 rounded-sm text-muted-foreground transition-colors hover:text-foreground"
                         onClick={() =>
                           setReusedIds((ids) =>
-                            ids.filter((id) => id !== persona._id)
+                            ids.filter((id) => id !== persona._id),
                           )
                         }
                       >
@@ -1926,7 +1920,7 @@ export function NewSwarmCreateFlow({
                       setReusedIds((ids) =>
                         ids.includes(personaId)
                           ? ids.filter((id) => id !== personaId)
-                          : [...ids, personaId]
+                          : [...ids, personaId],
                       ),
                   }}
                 />
@@ -1959,7 +1953,7 @@ export function NewSwarmCreateFlow({
                         "rounded-lg px-3 py-2.5 text-left transition-colors",
                         selected
                           ? "bg-background shadow-sm ring-1 ring-border/60"
-                          : "hover:bg-background/60"
+                          : "hover:bg-background/60",
                       )}
                     >
                       <span className="block text-sm font-semibold text-foreground">
@@ -2035,7 +2029,7 @@ export function NewSwarmCreateFlow({
                   // shouldn't read like incidental helper text.
                   className={cn(
                     "mr-auto text-sm leading-relaxed",
-                    canContinue ? "text-muted-foreground" : "text-foreground"
+                    canContinue ? "text-muted-foreground" : "text-foreground",
                   )}
                 >
                   {continueHint}

--- a/mcpjam-inspector/client/src/components/swarms/new-swarm-flow-draft.ts
+++ b/mcpjam-inspector/client/src/components/swarms/new-swarm-flow-draft.ts
@@ -44,6 +44,54 @@ const DRAFT_MAX_AGE_MS = 4 * 60 * 60 * 1000;
 
 export type NewSwarmFlowStep = "describe" | "confirm" | "running";
 
+/**
+ * The identity of an environment SELECTION, for cache invalidation.
+ *
+ * The create flow resolves environments and creates journeys against them, then
+ * caches both. That cache is keyed on this string, so anything that changes
+ * WHICH EXECUTION the user asked for must change the key — otherwise a confirm
+ * after the edit relaunches rows built for the previous setup.
+ *
+ * Extracted from the flow component because getting it wrong is silent: the
+ * flow still works, it just runs the wrong thing. A pure function can be tested
+ * against that.
+ *
+ * Ids that the resolver treats as a SET are sorted; `skillIds` is not, because
+ * the resolver iterates them in order into `composeSkillChannels`.
+ */
+export function buildEnvironmentSelectionKey(input: {
+  composeMode: boolean;
+  environmentIds: readonly string[];
+  hostIds: readonly string[];
+  serverAttachmentId?: string | null;
+  computerEnvironmentId?: string | null;
+  skillSelection?: {
+    skillIds: string[];
+    versionPins?: { skillId: string; versionId: string }[];
+  } | null;
+  customized: boolean;
+}): string {
+  return [
+    input.composeMode ? "compose" : "castles",
+    ...[...input.environmentIds].sort(),
+    ...[...input.hostIds].sort(),
+    input.serverAttachmentId ?? "",
+    input.computerEnvironmentId ?? "",
+    `skills:${(input.skillSelection?.skillIds ?? []).join(",")}`,
+    // EXACT-VERSION PINS. Pinning a selected skill to a different revision
+    // changes nothing about `skillIds`, so without this the key would compare
+    // equal and the flow would reuse journeys created against the OLD revision
+    // — running the revision the user just pinned away from, which is the exact
+    // mistake pinning exists to prevent. Sorted by skill: which revision each
+    // skill is held at is the identity, not the order the picker wrote them in.
+    `skillVersions:${[...(input.skillSelection?.versionPins ?? [])]
+      .map((pin) => `${pin.skillId}@${pin.versionId}`)
+      .sort()
+      .join(",")}`,
+    input.customized ? "custom" : "seeded",
+  ].join("|");
+}
+
 /** Ids a retry must reuse so the backend replays rows instead of doubling them. */
 export type NewSwarmLaunchIdentity = {
   flowId: string | null;
@@ -114,7 +162,7 @@ function isLabelEntries(value: unknown): value is [string, string][] {
         Array.isArray(entry) &&
         entry.length === 2 &&
         typeof entry[0] === "string" &&
-        typeof entry[1] === "string"
+        typeof entry[1] === "string",
     )
   );
 }
@@ -141,8 +189,8 @@ function isProposedPersonaArray(value: unknown): value is ProposedPersona[] {
           (journey) =>
             isRecord(journey) &&
             typeof journey.key === "string" &&
-            typeof journey.goal === "string"
-        )
+            typeof journey.goal === "string",
+        ),
     )
   );
 }
@@ -156,7 +204,7 @@ function isLaunchedRunArray(value: unknown): value is SwarmLaunchedRun[] {
         typeof entry.runId === "string" &&
         typeof entry.journeyId === "string" &&
         typeof entry.personaId === "string" &&
-        typeof entry.label === "string"
+        typeof entry.label === "string",
     )
   );
 }
@@ -169,7 +217,7 @@ function isLaunchTargetArray(value: unknown): value is LaunchTarget[] {
         isRecord(entry) &&
         typeof entry.journeyId === "string" &&
         typeof entry.label === "string" &&
-        typeof entry.personaId === "string"
+        typeof entry.personaId === "string",
     )
   );
 }
@@ -191,9 +239,10 @@ function isComposerState(value: unknown): value is EnvironmentComposerState {
  * keeps every reader working on a complete stack.
  */
 function withModelSelection(
-  state: EnvironmentComposerState
+  state: EnvironmentComposerState,
 ): EnvironmentComposerState {
-  const selection = (state.stack as { modelSelection?: unknown }).modelSelection;
+  const selection = (state.stack as { modelSelection?: unknown })
+    .modelSelection;
   if (
     isRecord(selection) &&
     typeof selection.includeClientDefaults === "boolean" &&
@@ -211,7 +260,7 @@ function isEnvironmentArray(value: unknown): value is ProjectEnvironmentView[] {
   return (
     Array.isArray(value) &&
     value.every(
-      (entry) => isRecord(entry) && typeof entry.environmentId === "string"
+      (entry) => isRecord(entry) && typeof entry.environmentId === "string",
     )
   );
 }
@@ -233,7 +282,10 @@ function parseDraft(value: unknown): NewSwarmFlowDraft | null {
   if (!isRecord(value)) return null;
   const step = value.step;
   const intensity = value.pushIntensity;
-  if (typeof step !== "string" || !FLOW_STEPS.includes(step as NewSwarmFlowStep)) {
+  if (
+    typeof step !== "string" ||
+    !FLOW_STEPS.includes(step as NewSwarmFlowStep)
+  ) {
     return null;
   }
   if (
@@ -269,7 +321,10 @@ function parseDraft(value: unknown): NewSwarmFlowDraft | null {
   if (!isProposedPersonaArray(value.proposed)) return null;
   if (!isLaunchedRunArray(value.launchedRuns)) return null;
   if (!isLabelEntries(value.runLabels)) return null;
-  if (value.generatingSince !== null && typeof value.generatingSince !== "number") {
+  if (
+    value.generatingSince !== null &&
+    typeof value.generatingSince !== "number"
+  ) {
     return null;
   }
   if (!isLaunchIdentity(value.launch)) return null;
@@ -295,7 +350,7 @@ function parseDraft(value: unknown): NewSwarmFlowDraft | null {
 
 export function saveNewSwarmFlowDraft(
   projectId: string,
-  draft: NewSwarmFlowDraft
+  draft: NewSwarmFlowDraft,
 ): void {
   const key = projectId.trim();
   if (!key) return;
@@ -320,7 +375,7 @@ export function saveNewSwarmFlowDraft(
  * after ITS remount.
  */
 export function readNewSwarmFlowDraft(
-  projectId: string | null | undefined
+  projectId: string | null | undefined,
 ): NewSwarmFlowDraft | null {
   const key = projectId?.trim();
   if (!key) return null;

--- a/mcpjam-inspector/client/src/hooks/useProjectEnvironments.ts
+++ b/mcpjam-inspector/client/src/hooks/useProjectEnvironments.ts
@@ -23,9 +23,26 @@ import {
  * the types below are hand-mirrored (no codegen).
  */
 
+/** One skill held at an EXACT revision, rather than tracking Latest. */
+export type ProjectEnvironmentSkillVersionPin = {
+  skillId: string;
+  versionId: string;
+};
+
 export type ProjectEnvironmentSkillSelection = {
   mode: "explicit";
   skillIds: string[];
+  /**
+   * Exact-version overlay on top of `skillIds`. At most one entry per selected
+   * skill; a selected skill with NO entry runs "Latest" — its current revision,
+   * resolved when the run starts, which is what every environment did before
+   * pins existed and what omitting this field still means.
+   *
+   * Absent rather than `[]` when nothing is pinned, matching how the backend
+   * stores it: an unpinned environment must serialize (and fingerprint)
+   * identically to one written before this feature.
+   */
+  versionPins?: ProjectEnvironmentSkillVersionPin[];
 };
 
 /**
@@ -126,7 +143,7 @@ export interface ProjectEnvironmentView {
  */
 export function useProjectEnvironments(
   projectId: string | null,
-  options?: { includeArchived?: boolean; includeAdhoc?: boolean }
+  options?: { includeArchived?: boolean; includeAdhoc?: boolean },
 ): ProjectEnvironmentView[] | undefined {
   const { isAuthenticated } = useConvexAuth();
   const isUserReady = useDbUserReady();
@@ -145,7 +162,7 @@ export function useProjectEnvironments(
           ...(options?.includeArchived ? { includeArchived: true } : {}),
           ...(includeAdhoc ? { origin: "all" } : {}),
         } as any)
-      : "skip"
+      : "skip",
   ) as ProjectEnvironmentView[] | undefined;
   return useMemo(() => {
     if (rows === undefined) return undefined;
@@ -163,7 +180,7 @@ export function useProjectEnvironments(
  */
 export function useProjectEnvironment(
   projectId: string | null,
-  environmentId: string | null
+  environmentId: string | null,
 ): ProjectEnvironmentView | null | undefined {
   // Same gate as the list hook: without the auth/db-ready checks the query can
   // fire before the backend identity exists and fail rather than skip.
@@ -185,7 +202,7 @@ export function useProjectEnvironment(
           projectId: normalizedProjectId,
           environmentId: normalizedEnvironmentId,
         } as any)
-      : "skip"
+      : "skip",
   ) as ProjectEnvironmentView | null | undefined;
 }
 
@@ -238,7 +255,7 @@ export function useEnsureAdhocEnvironment(): (args: {
   modelId?: string;
 }) => Promise<{ environment: ProjectEnvironmentView; created?: boolean }> {
   return useMutation(
-    "projectEnvironments:ensureAdhocEnvironment" as any
+    "projectEnvironments:ensureAdhocEnvironment" as any,
   ) as never;
 }
 
@@ -268,7 +285,7 @@ export function useEnsureAdhocEnvironments(): (args: {
   Array<{ environment: ProjectEnvironmentView; created?: boolean }>
 > {
   return useMutation(
-    "projectEnvironments:ensureAdhocEnvironments" as any
+    "projectEnvironments:ensureAdhocEnvironments" as any,
   ) as never;
 }
 

--- a/mcpjam-inspector/client/src/lib/apis/mcp-skills-api.ts
+++ b/mcpjam-inspector/client/src/lib/apis/mcp-skills-api.ts
@@ -29,7 +29,7 @@ export type SkillsSource =
 export type SkillSharing = "user" | "project";
 
 function isCloud(
-  source?: SkillsSource
+  source?: SkillsSource,
 ): source is { kind: "cloud"; projectId: string } {
   return source?.kind === "cloud";
 }
@@ -48,6 +48,9 @@ interface CloudSkillWire {
    * below can carry it; absent on older backends.
    */
   pinnability?: SkillPinnability;
+  /** Which revision "Latest" resolves to; absent on older backends. */
+  currentVersionId?: string;
+  currentVersionNumber?: number;
   content?: string;
 }
 
@@ -67,6 +70,10 @@ function cloudToListItem(s: CloudSkillWire): SkillListItem {
     origin: "cloud",
     provenance: normalizeProvenance(s.provenance),
     ...(s.pinnability ? { pinnability: s.pinnability } : {}),
+    ...(s.currentVersionId ? { currentVersionId: s.currentVersionId } : {}),
+    ...(s.currentVersionNumber !== undefined
+      ? { currentVersionNumber: s.currentVersionNumber }
+      : {}),
   };
 }
 
@@ -110,7 +117,7 @@ async function sha256Hex(buf: ArrayBuffer): Promise<string> {
 
 async function resolveCloudSkillId(
   projectId: string,
-  name: string
+  name: string,
 ): Promise<string> {
   const body = await webPost<
     { projectId: string },
@@ -126,7 +133,7 @@ export interface ListSkillsResponse {
 }
 
 export async function listSkills(
-  source?: SkillsSource
+  source?: SkillsSource,
 ): Promise<SkillListItem[]> {
   if (isCloud(source)) {
     const body = await webPost<
@@ -163,7 +170,7 @@ export async function listSkills(
 
 export async function getSkill(
   name: string,
-  source?: SkillsSource
+  source?: SkillsSource,
 ): Promise<Skill> {
   if (isCloud(source)) {
     const body = await webPost<
@@ -199,11 +206,24 @@ export async function uploadSkill(
      * description/body. Ignored by the local-FS path.
      */
     skillMd?: string;
+    /**
+     * FOLDER IMPORT (cloud only): create the skill as a hidden draft whose
+     * supporting files are still uploading. The bulk `/files/attach` that
+     * follows commits it and mints its single v1 — so an interrupted import
+     * leaves nothing visible, instead of a skill whose scripts/ never arrived.
+     */
+    importPending?: boolean;
   },
   source?: SkillsSource,
-  sharing: SkillSharing = "user"
+  sharing: SkillSharing = "user",
+  /**
+   * Cloud only: receives the created row's id. A folder import NEEDS this —
+   * its draft is hidden until the file attach commits it, so it cannot be
+   * looked up by name the way `resolveCloudSkillId` would.
+   */
+  onCloudSkillId?: (skillId: string) => void,
 ): Promise<Skill> {
-  const { skillMd, ...fields } = data;
+  const { skillMd, importPending, ...fields } = data;
   if (isCloud(source)) {
     const body = await webPost<
       {
@@ -213,6 +233,7 @@ export async function uploadSkill(
         content: string;
         sharing: SkillSharing;
         skillMd?: string;
+        importPending?: boolean;
       },
       { skill: CloudSkillWire }
     >("/api/web/skills/create", {
@@ -220,7 +241,9 @@ export async function uploadSkill(
       ...fields,
       sharing,
       ...(skillMd !== undefined ? { skillMd } : {}),
+      ...(importPending ? { importPending: true } : {}),
     });
+    onCloudSkillId?.(body.skill.skillId);
     return cloudToSkill(body.skill);
   }
 
@@ -242,13 +265,13 @@ export async function uploadSkillFolder(
   files: File[],
   skillName: string,
   source?: SkillsSource,
-  sharing: SkillSharing = "user"
+  sharing: SkillSharing = "user",
 ): Promise<Skill> {
   if (isCloud(source)) {
     const skillMdFile = files.find(
       (f) =>
         f.name === "SKILL.md" ||
-        ((f as any).webkitRelativePath || "").endsWith("/SKILL.md")
+        ((f as any).webkitRelativePath || "").endsWith("/SKILL.md"),
     );
     if (!skillMdFile) throw new Error("No SKILL.md found in the folder");
     // 1. Create the skill from SKILL.md. A 409 here is a genuine name
@@ -261,10 +284,25 @@ export async function uploadSkillFolder(
     const rawSkillMd = await skillMdFile.text();
     const { description, body } = parseSkillMd(rawSkillMd);
     const supporting = files.filter((f) => f !== skillMdFile);
+    let createdCloudSkillId: string | null = null;
     const skill = await uploadSkill(
-      { name: skillName, description, content: body, skillMd: rawSkillMd },
+      {
+        name: skillName,
+        description,
+        content: body,
+        skillMd: rawSkillMd,
+        // Only when files actually follow: a SKILL.md-only folder is complete
+        // the moment it is created, and marking it pending would leave it
+        // hidden with no attach coming to commit it.
+        ...(supporting.length > 0 && isCloud(source)
+          ? { importPending: true }
+          : {}),
+      },
       source,
-      sharing
+      sharing,
+      (id) => {
+        createdCloudSkillId = id;
+      },
     );
 
     // 2. Upload supporting files DIRECTLY to Convex (bypasses inspector body
@@ -274,13 +312,19 @@ export async function uploadSkillFolder(
     if (supporting.length === 0) return skill;
 
     const failedPaths: string[] = [];
-    let skillId: string | null = null;
-    try {
-      skillId = await resolveCloudSkillId(source.projectId, skillName);
-    } catch {
-      // Can't even address the created skill's file APIs — treat every
-      // supporting file as failed so the rollback below runs.
-      failedPaths.push(...supporting.map(skillRelativePath));
+    // The create response's id, NOT a lookup by name: an import draft is hidden
+    // from every listing until its attach commits it, so re-resolving by name
+    // would fail on exactly the path that needs it. The lookup stays as a
+    // fallback for a create that returned no id (an older server).
+    let skillId: string | null = createdCloudSkillId;
+    if (!skillId) {
+      try {
+        skillId = await resolveCloudSkillId(source.projectId, skillName);
+      } catch {
+        // Can't even address the created skill's file APIs — treat every
+        // supporting file as failed so the rollback below runs.
+        failedPaths.push(...supporting.map(skillRelativePath));
+      }
     }
     if (skillId) {
       const attachInputs: {
@@ -342,7 +386,21 @@ export async function uploadSkillFolder(
       // half-created skill is left behind.
       let rollbackFailed = false;
       try {
-        await deleteSkill(skillName, source);
+        // By ID when we have one: the draft this rollback exists to clean up is
+        // hidden from listings, so deleting it by NAME would fail and leave the
+        // very orphan the rollback is for. (Deleting a draft hard-deletes it —
+        // it was never a real skill.)
+        if (skillId) {
+          await webPost<
+            { projectId: string; skillId: string },
+            { success: boolean }
+          >("/api/web/skills/delete", {
+            projectId: source.projectId,
+            skillId,
+          });
+        } else {
+          await deleteSkill(skillName, source);
+        }
       } catch {
         rollbackFailed = true;
       }
@@ -352,12 +410,12 @@ export async function uploadSkillFolder(
           `Upload failed — ${failedPaths.length} supporting file(s) failed ` +
             `(${failing}), and removing the partially created skill also ` +
             `failed. Delete skill '${skillName}' manually, then fix the ` +
-            `failing files and retry.`
+            `failing files and retry.`,
         );
       }
       throw new Error(
         `Upload failed — nothing was saved. Fix the failing files ` +
-          `(${failing}) and retry.`
+          `(${failing}) and retry.`,
       );
     }
     return skill;
@@ -382,7 +440,7 @@ export async function uploadSkillFolder(
   } catch {}
   if (!res.ok) {
     throw new Error(
-      body?.error || body?.message || `Upload skill failed (${res.status})`
+      body?.error || body?.message || `Upload skill failed (${res.status})`,
     );
   }
   return body.skill as Skill;
@@ -398,7 +456,7 @@ export async function uploadSkillFolder(
 export async function updateSkill(
   skillId: string,
   data: { description?: string; content?: string },
-  source?: SkillsSource
+  source?: SkillsSource,
 ): Promise<Skill> {
   if (!isCloud(source)) {
     throw new Error("Editing is only supported for cloud skills.");
@@ -419,15 +477,81 @@ export async function updateSkill(
   return cloudToSkill(body.skill);
 }
 
+/** One revision in a cloud skill's history (newest first from the backend). */
+export interface CloudSkillVersionSummary {
+  versionId: string;
+  versionNumber: number;
+  versionHash: string;
+  contentHash: string;
+  name: string;
+  description: string;
+  fileCount: number;
+  /** The revision this skill's "Latest" resolves to right now. */
+  isCurrent: boolean;
+  /** Set when this revision was minted by restoring an older one. */
+  restoredFromVersionNumber?: number;
+  createdByUserId: string;
+  createdAt: number;
+}
+
+/**
+ * A cloud skill's revisions, newest first. Cloud-only: local filesystem skills
+ * have no version history (git is their history).
+ */
+export async function listSkillVersions(
+  projectId: string,
+  skillId: string,
+): Promise<CloudSkillVersionSummary[]> {
+  const body = await webPost<
+    { projectId: string; skillId: string },
+    { versions: CloudSkillVersionSummary[] }
+  >("/api/web/skills/versions/list", { projectId, skillId });
+  return body?.versions ?? [];
+}
+
+export interface CloudSkillVersionDetail extends CloudSkillVersionSummary {
+  content: string;
+  files: { path: string; size: number; contentHash: string }[];
+}
+
+/** One revision in full — body plus the file manifest it froze. */
+export async function getSkillVersion(args: {
+  projectId: string;
+  skillId: string;
+  versionId: string;
+}): Promise<CloudSkillVersionDetail> {
+  const body = await webPost<typeof args, { version: CloudSkillVersionDetail }>(
+    "/api/web/skills/versions/get",
+    args,
+  );
+  return body.version;
+}
+
+/**
+ * Bring an older revision's bytes back as the live skill. A revert, not a
+ * rewind: the backend mints the restored content as the NEXT revision, so
+ * environments tracking Latest pick it up while exact-pinned ones do not.
+ */
+export async function restoreSkillVersion(args: {
+  projectId: string;
+  skillId: string;
+  versionId: string;
+}): Promise<void> {
+  await webPost<typeof args, { success: boolean }>(
+    "/api/web/skills/versions/restore",
+    args,
+  );
+}
+
 export async function deleteSkill(
   name: string,
-  source?: SkillsSource
+  source?: SkillsSource,
 ): Promise<void> {
   if (isCloud(source)) {
     const skillId = await resolveCloudSkillId(source.projectId, name);
     await webPost<{ projectId: string; skillId: string }, { success: boolean }>(
       "/api/web/skills/delete",
-      { projectId: source.projectId, skillId }
+      { projectId: source.projectId, skillId },
     );
     return;
   }
@@ -448,12 +572,12 @@ export async function deleteSkill(
 /** Cloud only: promote a personal skill to project-shared (admin). */
 export async function promoteSkill(
   name: string,
-  projectId: string
+  projectId: string,
 ): Promise<void> {
   const skillId = await resolveCloudSkillId(projectId, name);
   await webPost<{ projectId: string; skillId: string }, { success: boolean }>(
     "/api/web/skills/promote",
-    { projectId, skillId }
+    { projectId, skillId },
   );
 }
 
@@ -517,7 +641,7 @@ export function buildSkillFileTree(files: CloudSkillFileWire[]): SkillFile[] {
 
 export async function listSkillFiles(
   name: string,
-  source?: SkillsSource
+  source?: SkillsSource,
 ): Promise<SkillFile[]> {
   if (isCloud(source)) {
     const skillId = await resolveCloudSkillId(source.projectId, name);
@@ -546,7 +670,7 @@ export async function listSkillFiles(
 export async function readSkillFile(
   name: string,
   filePath: string,
-  source?: SkillsSource
+  source?: SkillsSource,
 ): Promise<SkillFileContent> {
   if (isCloud(source)) {
     // SKILL.md is the skill body (not a stored file); everything else is a

--- a/mcpjam-inspector/client/src/lib/environment-label.ts
+++ b/mcpjam-inspector/client/src/lib/environment-label.ts
@@ -94,7 +94,7 @@ export function trimOrUndefined(value: string | undefined): string | undefined {
  * nameless without an origin still reads as ad-hoc rather than rendering blank.
  */
 export function environmentOrigin(
-  environment: EnvironmentLabelRow
+  environment: EnvironmentLabelRow,
 ): ProjectEnvironmentOrigin {
   if (environment.origin === "named" || environment.origin === "adhoc") {
     return environment.origin;
@@ -121,7 +121,7 @@ export function isAdhocEnvironment(environment: EnvironmentLabelRow): boolean {
  */
 export function environmentLabel(
   environment: EnvironmentLabelRow,
-  ctx: EnvironmentLabelContext = {}
+  ctx: EnvironmentLabelContext = {},
 ): string {
   const name = trimOrUndefined(environment.name);
   if (name) return name;
@@ -163,10 +163,19 @@ export function describeServerScope(environment: EnvironmentLabelRow): string {
 export function environmentPinCounts(environment: EnvironmentLabelRow): {
   skillPins: number;
   pluginPins: number;
+  /**
+   * How many of `skillPins` are held at an EXACT revision rather than tracking
+   * Latest (Versioned Skills). Reported separately because the difference is
+   * the whole point of a pin: an environment at "3 skills, 1 at an exact
+   * version" behaves differently on the next edit than one tracking Latest
+   * throughout, and a single count hides that.
+   */
+  skillVersionPins: number;
 } {
   return {
     skillPins: environment.skillSelection?.skillIds.length ?? 0,
     pluginPins: environment.pluginVersionIds?.length ?? 0,
+    skillVersionPins: environment.skillSelection?.versionPins?.length ?? 0,
   };
 }
 
@@ -180,7 +189,7 @@ export function environmentPinCounts(environment: EnvironmentLabelRow): {
  */
 export function environmentImageLabel(
   environment: EnvironmentLabelRow,
-  ctx: EnvironmentLabelContext
+  ctx: EnvironmentLabelContext,
 ): string | undefined {
   if (!ctx.computersEnabled) return undefined;
   const imageId = environment.computerEnvironmentId;
@@ -206,7 +215,7 @@ export function environmentImageLabel(
  */
 export function environmentDetailLine(
   environment: EnvironmentLabelRow,
-  ctx: EnvironmentLabelContext
+  ctx: EnvironmentLabelContext,
 ): string {
   const { skillPins, pluginPins } = environmentPinCounts(environment);
   const parts = [
@@ -228,7 +237,7 @@ export function environmentDetailLine(
  * row on one client derives the same label.
  */
 export function disambiguateLabels<T extends { label: string }>(
-  items: readonly T[]
+  items: readonly T[],
 ): T[] {
   const counts = new Map<string, number>();
   for (const item of items) {

--- a/mcpjam-inspector/server/routes/v1/__fixtures__/eval-run-compare-parity.json
+++ b/mcpjam-inspector/server/routes/v1/__fixtures__/eval-run-compare-parity.json
@@ -11,7 +11,8 @@
       "a run-level evaluation config change (cfg_hash_base -> cfg_hash_compare)",
       "a per-case config that did NOT change while the run-level one did (ck_stable)",
       "not_applicable excluded from a pass-rate denominator (tone on ck_stable)",
-      "_storage blob ids present in the internal diff and dropped by the public DTO"
+      "_storage blob ids present in the internal diff and dropped by the public DTO",
+      "an authored skill edited across the runs (refunds v3 -> v4), an MCP-served skill added, and one unchanged"
     ]
   },
   "suite": {
@@ -49,7 +50,33 @@
         ],
         "environment": {
           "servers": []
-        }
+        },
+        "pinnedSkills": [
+          {
+            "skillId": "kd7abc000000000000000001projectSkills",
+            "name": "refunds",
+            "description": "Handle refund requests",
+            "contentHash": "skill_refunds_v3_hash",
+            "projectSkillVersionId": "kv7abc000000000000000003projectSkillVersions",
+            "projectSkillVersionNumber": 3,
+            "sharing": "project",
+            "channels": [
+              "environment"
+            ]
+          },
+          {
+            "skillId": "kd7abc000000000000000002projectSkills",
+            "name": "tone",
+            "description": "House tone",
+            "contentHash": "skill_tone_v1_hash",
+            "projectSkillVersionId": "kv7abc000000000000000010projectSkillVersions",
+            "projectSkillVersionNumber": 1,
+            "sharing": "project",
+            "channels": [
+              "environment"
+            ]
+          }
+        ]
       },
       "_id": "run_parity_base",
       "runNumber": 1,
@@ -278,7 +305,44 @@
         ],
         "environment": {
           "servers": []
-        }
+        },
+        "pinnedSkills": [
+          {
+            "skillId": "kd7abc000000000000000001projectSkills",
+            "name": "refunds",
+            "description": "Handle refund requests",
+            "contentHash": "skill_refunds_v4_hash",
+            "projectSkillVersionId": "kv7abc000000000000000004projectSkillVersions",
+            "projectSkillVersionNumber": 4,
+            "sharing": "project",
+            "channels": [
+              "environment"
+            ]
+          },
+          {
+            "skillId": "kd7abc000000000000000002projectSkills",
+            "name": "tone",
+            "description": "House tone",
+            "contentHash": "skill_tone_v1_hash",
+            "projectSkillVersionId": "kv7abc000000000000000010projectSkillVersions",
+            "projectSkillVersionNumber": 1,
+            "sharing": "project",
+            "channels": [
+              "environment"
+            ]
+          },
+          {
+            "serverSkillId": "ks7abc000000000000000005serverSkills",
+            "name": "lookup",
+            "description": "Order lookup served over MCP",
+            "contentHash": "server_skill_lookup_hash",
+            "serverSkillVersionNumber": 2,
+            "sharing": "project",
+            "channels": [
+              "mcp-server"
+            ]
+          }
+        ]
       },
       "_id": "run_parity_compare",
       "runNumber": 2,
@@ -662,6 +726,48 @@
           }
         }
       ]
+    },
+    "skills": {
+      "base": {
+        "excluded": false,
+        "count": 2
+      },
+      "compare": {
+        "excluded": false,
+        "count": 3
+      },
+      "changes": [
+        {
+          "key": "skill:kd7abc000000000000000001projectSkills",
+          "name": "refunds",
+          "channels": [
+            "environment"
+          ],
+          "kind": "changed",
+          "base": {
+            "contentHash": "skill_refunds_v3_hash",
+            "versionNumber": 3
+          },
+          "compare": {
+            "contentHash": "skill_refunds_v4_hash",
+            "versionNumber": 4
+          },
+          "versionDelta": "v3 → v4"
+        },
+        {
+          "key": "serverSkill:ks7abc000000000000000005serverSkills",
+          "name": "lookup",
+          "channels": [
+            "mcp-server"
+          ],
+          "kind": "added",
+          "compare": {
+            "contentHash": "server_skill_lookup_hash",
+            "serverSkillVersionNumber": 2
+          }
+        }
+      ],
+      "unchangedCount": 1
     },
     "cases": [
       {

--- a/mcpjam-inspector/server/routes/v1/__tests__/environments.test.ts
+++ b/mcpjam-inspector/server/routes/v1/__tests__/environments.test.ts
@@ -66,7 +66,7 @@ function makeApp(): Hono {
 function request(
   method: string,
   path: string,
-  opts: { body?: unknown; token?: string | null } = {}
+  opts: { body?: unknown; token?: string | null } = {},
 ): Promise<Response> {
   const { body, token = "tok" } = opts;
   const headers: Record<string, string> = {
@@ -78,7 +78,7 @@ function request(
       method,
       headers,
       ...(body !== undefined ? { body: JSON.stringify(body) } : {}),
-    })
+    }),
   );
 }
 
@@ -123,7 +123,7 @@ const RESOLVED_ROW = {
 /** Dispatch the mocked Convex query by function name. */
 function mockQuery(map: Record<string, unknown>) {
   convexQueryMock.mockImplementation(async (fn: string) =>
-    fn in map ? map[fn] : null
+    fn in map ? map[fn] : null,
   );
 }
 
@@ -134,7 +134,7 @@ function mockQuery(map: Record<string, unknown>) {
 function convexError(
   code: string,
   message: string,
-  details?: Record<string, string>
+  details?: Record<string, string>,
 ): Error {
   const error = new Error(`Uncaught ConvexError: ${message}`);
   (error as unknown as { data: unknown }).data = {
@@ -173,7 +173,7 @@ describe("v1 project environment routes", () => {
       });
       expect(res.status).toBe(401);
       expect(((await res.json()) as { code?: string }).code).toBe(
-        "UNAUTHORIZED"
+        "UNAUTHORIZED",
       );
     });
 
@@ -197,7 +197,7 @@ describe("v1 project environment routes", () => {
       const res = await request(
         "POST",
         "/api/v1/projects/p1/environments/env1/archive",
-        { token: "guest-jwt", body: { expectedRevision: 3 } }
+        { token: "guest-jwt", body: { expectedRevision: 3 } },
       );
       expect(res.status).toBe(401);
       expect(convexMutationMock).not.toHaveBeenCalled();
@@ -226,17 +226,17 @@ describe("v1 project environment routes", () => {
       await request("GET", "/api/v1/projects/p1/environments");
       expect(convexQueryMock).toHaveBeenCalledWith(
         "projectEnvironments:listEnvironments",
-        { projectId: "p1", includeArchived: false }
+        { projectId: "p1", includeArchived: false },
       );
 
       convexQueryMock.mockClear();
       await request(
         "GET",
-        "/api/v1/projects/p1/environments?includeArchived=true"
+        "/api/v1/projects/p1/environments?includeArchived=true",
       );
       expect(convexQueryMock).toHaveBeenCalledWith(
         "projectEnvironments:listEnvironments",
-        { projectId: "p1", includeArchived: true }
+        { projectId: "p1", includeArchived: true },
       );
     });
 
@@ -244,7 +244,7 @@ describe("v1 project environment routes", () => {
       mockQuery({ "projectEnvironments:listEnvironments": [ARCHIVED_ROW] });
       const res = await request(
         "GET",
-        "/api/v1/projects/p1/environments?includeArchived=true"
+        "/api/v1/projects/p1/environments?includeArchived=true",
       );
       const body = (await res.json()) as { items: Record<string, unknown>[] };
       expect(body.items[0]).toMatchObject({ archived: true, archivedAt: 99 });
@@ -263,7 +263,7 @@ describe("v1 project environment routes", () => {
       // Project scope is enforced inside Convex — the route must pass projectId.
       expect(convexQueryMock).toHaveBeenCalledWith(
         "projectEnvironments:getEnvironment",
-        { projectId: "p1", environmentId: "env1" }
+        { projectId: "p1", environmentId: "env1" },
       );
     });
 
@@ -276,7 +276,7 @@ describe("v1 project environment routes", () => {
 
     it("maps a structured NOT_FOUND ConvexError to 404", async () => {
       convexQueryMock.mockRejectedValue(
-        convexError("NOT_FOUND", "Environment not found")
+        convexError("NOT_FOUND", "Environment not found"),
       );
       const res = await request("GET", "/api/v1/projects/p1/environments/env1");
       expect(res.status).toBe(404);
@@ -303,7 +303,7 @@ describe("v1 project environment routes", () => {
       });
       expect(res.status).toBe(400);
       expect(((await res.json()) as { code?: string }).code).toBe(
-        "VALIDATION_ERROR"
+        "VALIDATION_ERROR",
       );
       expect(convexMutationMock).not.toHaveBeenCalled();
     });
@@ -316,12 +316,38 @@ describe("v1 project environment routes", () => {
       expect(convexMutationMock).not.toHaveBeenCalled();
     });
 
+    it("accepts and forwards exact authored-skill version pins", async () => {
+      convexMutationMock.mockResolvedValue(ENV_ROW);
+      const res = await request("POST", "/api/v1/projects/p1/environments", {
+        body: {
+          name: "Skill v1",
+          hostId: "h1",
+          skillSelection: {
+            mode: "explicit",
+            skillIds: ["sk1"],
+            versionPins: [{ skillId: "sk1", versionId: "sk1-v1" }],
+          },
+        },
+      });
+      expect(res.status).toBe(201);
+      expect(mutationArgs("projectEnvironments:createEnvironment")).toEqual({
+        projectId: "p1",
+        name: "Skill v1",
+        hostId: "h1",
+        skillSelection: {
+          mode: "explicit",
+          skillIds: ["sk1"],
+          versionPins: [{ skillId: "sk1", versionId: "sk1-v1" }],
+        },
+      });
+    });
+
     it("surfaces the admin gate as 403, not a misleading 404", async () => {
       convexMutationMock.mockRejectedValue(
         convexError(
           "FORBIDDEN",
-          "Managing environments requires project admin (shared execution config)."
-        )
+          "Managing environments requires project admin (shared execution config).",
+        ),
       );
       const res = await request("POST", "/api/v1/projects/p1/environments", {
         body: { name: "Staging", hostId: "h1" },
@@ -332,7 +358,7 @@ describe("v1 project environment routes", () => {
 
     it("hides non-membership as 404 so project existence never leaks", async () => {
       convexMutationMock.mockRejectedValue(
-        convexError("FORBIDDEN", "Not authorized for this project")
+        convexError("FORBIDDEN", "Not authorized for this project"),
       );
       const res = await request("POST", "/api/v1/projects/p1/environments", {
         body: { name: "Staging", hostId: "h1" },
@@ -347,7 +373,7 @@ describe("v1 project environment routes", () => {
       const res = await request(
         "PATCH",
         "/api/v1/projects/p1/environments/env1",
-        { body: { name: "Renamed" } }
+        { body: { name: "Renamed" } },
       );
       expect(res.status).toBe(400);
       expect(convexMutationMock).not.toHaveBeenCalled();
@@ -357,7 +383,7 @@ describe("v1 project environment routes", () => {
       const res = await request(
         "PATCH",
         "/api/v1/projects/p1/environments/env1",
-        { body: { expectedRevision: 3 } }
+        { body: { expectedRevision: 3 } },
       );
       expect(res.status).toBe(400);
       expect(convexMutationMock).not.toHaveBeenCalled();
@@ -374,7 +400,7 @@ describe("v1 project environment routes", () => {
             serverAttachmentId: null,
             name: "Renamed",
           },
-        }
+        },
       );
       expect(res.status).toBe(200);
       const args = mutationArgs("projectEnvironments:updateEnvironment");
@@ -405,17 +431,46 @@ describe("v1 project environment routes", () => {
       expect(args.pluginVersionIds).toBeNull();
     });
 
+    it("accepts and forwards exact authored-skill version pins", async () => {
+      convexMutationMock.mockResolvedValue(ENV_ROW);
+      const res = await request(
+        "PATCH",
+        "/api/v1/projects/p1/environments/env1",
+        {
+          body: {
+            expectedRevision: 3,
+            skillSelection: {
+              mode: "explicit",
+              skillIds: ["sk1"],
+              versionPins: [{ skillId: "sk1", versionId: "sk1-v2" }],
+            },
+          },
+        },
+      );
+      expect(res.status).toBe(200);
+      expect(mutationArgs("projectEnvironments:updateEnvironment")).toEqual({
+        projectId: "p1",
+        environmentId: "env1",
+        expectedRevision: 3,
+        skillSelection: {
+          mode: "explicit",
+          skillIds: ["sk1"],
+          versionPins: [{ skillId: "sk1", versionId: "sk1-v2" }],
+        },
+      });
+    });
+
     it("maps a stale revision to 409 CONFLICT with the backend's message", async () => {
       convexMutationMock.mockRejectedValue(
         convexError(
           "CONFLICT",
-          "Environment changed since you loaded it (expected revision 3, current 5). Reload and retry."
-        )
+          "Environment changed since you loaded it (expected revision 3, current 5). Reload and retry.",
+        ),
       );
       const res = await request(
         "PATCH",
         "/api/v1/projects/p1/environments/env1",
-        { body: { expectedRevision: 3, name: "Renamed" } }
+        { body: { expectedRevision: 3, name: "Renamed" } },
       );
       expect(res.status).toBe(409);
       const body = (await res.json()) as { code?: string; message?: string };
@@ -427,8 +482,8 @@ describe("v1 project environment routes", () => {
       convexMutationMock.mockRejectedValue(
         convexError(
           "VALIDATION",
-          'Skill "notes" has supporting files, which can\'t be pinned into runs yet.'
-        )
+          'Skill "notes" has supporting files, which can\'t be pinned into runs yet.',
+        ),
       );
       const res = await request(
         "PATCH",
@@ -438,11 +493,11 @@ describe("v1 project environment routes", () => {
             expectedRevision: 3,
             skillSelection: { mode: "explicit", skillIds: ["sk1"] },
           },
-        }
+        },
       );
       expect(res.status).toBe(400);
       expect(((await res.json()) as { message?: string }).message).toMatch(
-        /supporting files/
+        /supporting files/,
       );
     });
   });
@@ -482,7 +537,7 @@ describe("v1 project environment routes", () => {
         modelId: "openai/gpt-5",
       });
       expect(((await res.json()) as { modelId?: string }).modelId).toBe(
-        "openai/gpt-5"
+        "openai/gpt-5",
       );
     });
 
@@ -513,7 +568,7 @@ describe("v1 project environment routes", () => {
         body: { expectedRevision: 3, name: "Renamed" },
       });
       expect(
-        "modelId" in mutationArgs("projectEnvironments:updateEnvironment")
+        "modelId" in mutationArgs("projectEnvironments:updateEnvironment"),
       ).toBe(false);
     });
 
@@ -528,7 +583,7 @@ describe("v1 project environment routes", () => {
       });
       const res = await request(
         "GET",
-        "/api/v1/projects/p1/environments/env1/resolve"
+        "/api/v1/projects/p1/environments/env1/resolve",
       );
       expect(await res.json()).toMatchObject({
         modelId: "openai/gpt-5",
@@ -547,7 +602,7 @@ describe("v1 project environment routes", () => {
       });
       const res = await request(
         "GET",
-        "/api/v1/projects/p1/environments/env1/resolve"
+        "/api/v1/projects/p1/environments/env1/resolve",
       );
       const body = (await res.json()) as {
         modelId?: string;
@@ -567,12 +622,12 @@ describe("v1 project environment routes", () => {
         convexError(
           "ENV_MODEL_REQUIRED",
           'Environment "Staging" has no model to run.',
-          { environmentId: "env1", hostId: "h1", hostConfigId: "hc1" }
-        )
+          { environmentId: "env1", hostId: "h1", hostConfigId: "hc1" },
+        ),
       );
       const res = await request(
         "GET",
-        "/api/v1/projects/p1/environments/env1/resolve"
+        "/api/v1/projects/p1/environments/env1/resolve",
       );
       expect(res.status).toBe(409);
       const body = (await res.json()) as {
@@ -598,7 +653,7 @@ describe("v1 project environment routes", () => {
       });
       const res = await request(
         "GET",
-        "/api/v1/projects/p1/environments/capabilities"
+        "/api/v1/projects/p1/environments/capabilities",
       );
       expect(res.status).toBe(200);
       expect(await res.json()).toMatchObject({
@@ -612,12 +667,12 @@ describe("v1 project environment routes", () => {
       // a 500 here would break clients that are perfectly able to fall back.
       convexQueryMock.mockRejectedValue(
         new Error(
-          "Could not find public function for 'projectEnvironments:getCapabilities'"
-        )
+          "Could not find public function for 'projectEnvironments:getCapabilities'",
+        ),
       );
       const res = await request(
         "GET",
-        "/api/v1/projects/p1/environments/capabilities"
+        "/api/v1/projects/p1/environments/capabilities",
       );
       expect(res.status).toBe(200);
       expect(await res.json()).toMatchObject({
@@ -631,15 +686,15 @@ describe("v1 project environment routes", () => {
       // into a cheerful 200 tells the caller "upgrade your platform" when the
       // real problem is that they cannot read this project.
       convexQueryMock.mockRejectedValue(
-        convexError("FORBIDDEN", "Not authorized for this project")
+        convexError("FORBIDDEN", "Not authorized for this project"),
       );
       const res = await request(
         "GET",
-        "/api/v1/projects/p1/environments/capabilities"
+        "/api/v1/projects/p1/environments/capabilities",
       );
       expect(res.status).not.toBe(200);
       expect(((await res.json()) as { code?: string }).code).not.toBe(
-        "VALIDATION_ERROR"
+        "VALIDATION_ERROR",
       );
     });
 
@@ -647,7 +702,7 @@ describe("v1 project environment routes", () => {
       convexQueryMock.mockRejectedValue(new Error("fetch failed: ECONNRESET"));
       const res = await request(
         "GET",
-        "/api/v1/projects/p1/environments/capabilities"
+        "/api/v1/projects/p1/environments/capabilities",
       );
       expect(res.status).not.toBe(200);
     });
@@ -661,12 +716,12 @@ describe("v1 project environment routes", () => {
       });
       const res = await request(
         "GET",
-        "/api/v1/projects/p1/environments/capabilities"
+        "/api/v1/projects/p1/environments/capabilities",
       );
       expect(res.status).toBe(200);
       expect(convexQueryMock).toHaveBeenCalledWith(
         "projectEnvironments:getCapabilities",
-        { projectId: "p1" }
+        { projectId: "p1" },
       );
     });
   });
@@ -677,7 +732,7 @@ describe("v1 project environment routes", () => {
       const res = await request(
         "POST",
         "/api/v1/projects/p1/environments/env1/archive",
-        { body: { expectedRevision: 3 } }
+        { body: { expectedRevision: 3 } },
       );
       expect(res.status).toBe(200);
       expect((await res.json()) as Record<string, unknown>).toMatchObject({
@@ -695,7 +750,7 @@ describe("v1 project environment routes", () => {
       const res = await request(
         "POST",
         "/api/v1/projects/p1/environments/env1/restore",
-        { body: { expectedRevision: 4 } }
+        { body: { expectedRevision: 4 } },
       );
       expect(res.status).toBe(200);
       expect(mutationArgs("projectEnvironments:restoreEnvironment")).toEqual({
@@ -709,7 +764,7 @@ describe("v1 project environment routes", () => {
       const res = await request(
         "POST",
         "/api/v1/projects/p1/environments/env1/archive",
-        { body: {} }
+        { body: {} },
       );
       expect(res.status).toBe(400);
       expect(convexMutationMock).not.toHaveBeenCalled();
@@ -719,7 +774,7 @@ describe("v1 project environment routes", () => {
       const res = await request(
         "POST",
         "/api/v1/projects/p1/environments/env1/archive",
-        { body: { expectedRevision: 3, force: true } }
+        { body: { expectedRevision: 3, force: true } },
       );
       expect(res.status).toBe(400);
       expect(convexMutationMock).not.toHaveBeenCalled();
@@ -727,12 +782,12 @@ describe("v1 project environment routes", () => {
 
     it("maps already-archived to 409, not 400", async () => {
       convexMutationMock.mockRejectedValue(
-        convexError("CONFLICT", "Environment is already archived.")
+        convexError("CONFLICT", "Environment is already archived."),
       );
       const res = await request(
         "POST",
         "/api/v1/projects/p1/environments/env1/archive",
-        { body: { expectedRevision: 3 } }
+        { body: { expectedRevision: 3 } },
       );
       expect(res.status).toBe(409);
     });
@@ -745,7 +800,7 @@ describe("v1 project environment routes", () => {
       });
       const res = await request(
         "GET",
-        "/api/v1/projects/p1/environments/env1/resolve"
+        "/api/v1/projects/p1/environments/env1/resolve",
       );
       expect(res.status).toBe(200);
       const body = (await res.json()) as Record<string, any>;
@@ -759,17 +814,17 @@ describe("v1 project environment routes", () => {
       expect(body.pluginVersions).toHaveLength(1);
       expect(convexQueryMock).toHaveBeenCalledWith(
         "projectEnvironments:resolveEnvironmentForLaunch",
-        { projectId: "p1", environmentId: "env1" }
+        { projectId: "p1", environmentId: "env1" },
       );
     });
 
     it("maps ENV_NOT_FOUND to 404", async () => {
       convexQueryMock.mockRejectedValue(
-        convexError("ENV_NOT_FOUND", "Environment not found")
+        convexError("ENV_NOT_FOUND", "Environment not found"),
       );
       const res = await request(
         "GET",
-        "/api/v1/projects/p1/environments/env1/resolve"
+        "/api/v1/projects/p1/environments/env1/resolve",
       );
       expect(res.status).toBe(404);
     });
@@ -779,12 +834,12 @@ describe("v1 project environment routes", () => {
         convexError(
           "ENV_PLUGIN_UNAVAILABLE",
           'Plugin "linear" is disabled; enable it before running.',
-          { reason: "disabled" }
-        )
+          { reason: "disabled" },
+        ),
       );
       const res = await request(
         "GET",
-        "/api/v1/projects/p1/environments/env1/resolve"
+        "/api/v1/projects/p1/environments/env1/resolve",
       );
       expect(res.status).toBe(409);
       const body = (await res.json()) as {
@@ -798,11 +853,11 @@ describe("v1 project environment routes", () => {
 
     it("maps an empty resolved server set to 409", async () => {
       convexQueryMock.mockRejectedValue(
-        convexError("ENV_NO_SERVERS", "Environment resolves to no servers.")
+        convexError("ENV_NO_SERVERS", "Environment resolves to no servers."),
       );
       const res = await request(
         "GET",
-        "/api/v1/projects/p1/environments/env1/resolve"
+        "/api/v1/projects/p1/environments/env1/resolve",
       );
       expect(res.status).toBe(409);
     });
@@ -842,7 +897,7 @@ describe("v1 project environment routes", () => {
       });
       expect(
         mutationArgs("projectEnvironments:updateEnvironment")
-          .computerEnvironmentId
+          .computerEnvironmentId,
       ).toBeNull();
 
       convexMutationMock.mockClear();
@@ -852,7 +907,7 @@ describe("v1 project environment routes", () => {
       });
       expect(
         mutationArgs("projectEnvironments:updateEnvironment")
-          .computerEnvironmentId
+          .computerEnvironmentId,
       ).toBe("img2");
 
       convexMutationMock.mockClear();
@@ -870,7 +925,7 @@ describe("v1 project environment routes", () => {
       const res = await request(
         "PATCH",
         "/api/v1/projects/p1/environments/env1",
-        { body: { expectedRevision: 3, sandboxImageId: "img1" } }
+        { body: { expectedRevision: 3, sandboxImageId: "img1" } },
       );
       expect(res.status).toBe(200);
     });
@@ -883,7 +938,7 @@ describe("v1 project environment routes", () => {
           "/api/v1/projects/p1/environments",
           {
             body: { name: "Staging", hostId: "h1", sandboxImageId: value },
-          }
+          },
         );
         expect(created.status).toBe(400);
         expect(convexMutationMock).not.toHaveBeenCalled();
@@ -891,7 +946,7 @@ describe("v1 project environment routes", () => {
         const patched = await request(
           "PATCH",
           "/api/v1/projects/p1/environments/env1",
-          { body: { expectedRevision: 3, sandboxImageId: value } }
+          { body: { expectedRevision: 3, sandboxImageId: value } },
         );
         expect(patched.status).toBe(400);
         expect(convexMutationMock).not.toHaveBeenCalled();
@@ -907,7 +962,7 @@ describe("v1 project environment routes", () => {
       });
       const res = await request(
         "GET",
-        "/api/v1/projects/p1/environments/env1/resolve"
+        "/api/v1/projects/p1/environments/env1/resolve",
       );
       expect(res.status).toBe(200);
       const dto = (await res.json()) as Record<string, unknown>;
@@ -941,7 +996,7 @@ describe("v1 project environment routes", () => {
             sandboxImageId: "img1",
             modelId: "anthropic/claude-haiku-4.5",
           },
-        }
+        },
       );
 
       expect(res.status).toBe(200);
@@ -954,7 +1009,7 @@ describe("v1 project environment routes", () => {
           // The public name is renamed at the boundary; the internal one must
           // not leak and the public one must not be forwarded.
           computerEnvironmentId: "img1",
-        }
+        },
       );
       const body = (await res.json()) as any;
       // EXPLICIT, so a reader can tell "unnamed by construction" from "the
@@ -974,7 +1029,7 @@ describe("v1 project environment routes", () => {
       const res = await request(
         "POST",
         "/api/v1/projects/p1/environments/ensure-adhoc",
-        { body: { hostId: "h1" } }
+        { body: { hostId: "h1" } },
       );
       expect(res.status).toBe(200);
       expect(((await res.json()) as any).created).toBe(false);
@@ -982,12 +1037,12 @@ describe("v1 project environment routes", () => {
 
     it("translates a deployment without ad-hoc environments into an instruction", async () => {
       convexMutationMock.mockRejectedValue(
-        new Error("Could not find public function for 'projectEnvironments'")
+        new Error("Could not find public function for 'projectEnvironments'"),
       );
       const res = await request(
         "POST",
         "/api/v1/projects/p1/environments/ensure-adhoc",
-        { body: { hostId: "h1" } }
+        { body: { hostId: "h1" } },
       );
       expect(res.status).toBe(400);
       const body = (await res.json()) as any;
@@ -999,7 +1054,7 @@ describe("v1 project environment routes", () => {
       const res = await request(
         "POST",
         "/api/v1/projects/p1/environments/ensure-adhoc",
-        { body: { hostId: "h1", computerEnvironmentId: "img1" } }
+        { body: { hostId: "h1", computerEnvironmentId: "img1" } },
       );
       expect(res.status).toBe(400);
       expect(convexMutationMock).not.toHaveBeenCalled();
@@ -1017,7 +1072,7 @@ describe("v1 project environment routes", () => {
       const res = await request(
         "POST",
         "/api/v1/projects/p1/environments/env-adhoc/name",
-        { body: { expectedRevision: 1, name: "Promoted" } }
+        { body: { expectedRevision: 1, name: "Promoted" } },
       );
       expect(res.status).toBe(200);
       expect(convexMutationMock).toHaveBeenCalledWith(
@@ -1027,7 +1082,7 @@ describe("v1 project environment routes", () => {
           environmentId: "env-adhoc",
           expectedRevision: 1,
           name: "Promoted",
-        }
+        },
       );
       const body = (await res.json()) as any;
       expect(body.id).toBe("env-adhoc");
@@ -1038,7 +1093,7 @@ describe("v1 project environment routes", () => {
       const res = await request(
         "POST",
         "/api/v1/projects/p1/environments/env-adhoc/name",
-        { body: { name: "Promoted" } }
+        { body: { name: "Promoted" } },
       );
       expect(res.status).toBe(400);
       expect(convexMutationMock).not.toHaveBeenCalled();
@@ -1048,13 +1103,13 @@ describe("v1 project environment routes", () => {
       convexMutationMock.mockRejectedValue(
         convexError(
           "CONFLICT",
-          "This environment already has a name. Rename it from the Environments list."
-        )
+          "This environment already has a name. Rename it from the Environments list.",
+        ),
       );
       const res = await request(
         "POST",
         "/api/v1/projects/p1/environments/env1/name",
-        { body: { expectedRevision: 3, name: "Nope" } }
+        { body: { expectedRevision: 3, name: "Nope" } },
       );
       expect(res.status).toBe(409);
     });

--- a/mcpjam-inspector/server/routes/v1/__tests__/eval-compare-dto.test.ts
+++ b/mcpjam-inspector/server/routes/v1/__tests__/eval-compare-dto.test.ts
@@ -31,7 +31,7 @@ import {
  * one change.
  */
 const EVAL_RUN_COMPARE_PARITY_SHA256 =
-  "362a9a1e4133883e11cd8a0ec6aba9c3c7215730a1ec30c5b179f32a9390db53";
+  "5823c2420be670bcffaa3b0bdb4e98046393b2929dce903b7aa74fcc5bbf9e02";
 
 const FIXTURE_PATH = join(
   dirname(fileURLToPath(import.meta.url)),
@@ -86,6 +86,35 @@ describe("toRunCompareDto — leak gate", () => {
     expect(serialized).not.toContain("kg9042pxwq7mn3jrl6svbt85dz1storage");
     // Nothing that even looks like a storage handle.
     expect(serialized).not.toMatch(/storage/i);
+  });
+
+  it("projects the skills section, including the version move", () => {
+    // The attribution half of a comparison: the fixture's `refunds` was edited
+    // between the two runs, an MCP-served skill was added, and one was
+    // untouched. A public caller needs all three to explain a regression.
+    const skills = dto().skills as Record<string, any>;
+    expect(skills.unchangedCount).toBe(1);
+    expect(skills.base).toEqual({ excluded: false, count: 2 });
+
+    const changed = skills.changes.find((c: any) => c.kind === "changed");
+    expect(changed.name).toBe("refunds");
+    expect(changed.versionDelta).toBe("v3 → v4");
+    expect(changed.base.versionNumber).toBe(3);
+    expect(changed.compare.versionNumber).toBe(4);
+
+    const added = skills.changes.find((c: any) => c.kind === "added");
+    expect(added.name).toBe("lookup");
+    expect(added.channels).toEqual(["mcp-server"]);
+  });
+
+  it("passes a null skills section through instead of flattening it", () => {
+    // null means "neither run recorded skills". An empty `{changes: []}` would
+    // claim no skills were involved, which is a different statement.
+    const dtoWithout = toRunCompareDto(
+      { ...fixture.expectedDiff, skills: null },
+      BASELINE,
+    );
+    expect(dtoWithout.skills).toBeNull();
   });
 
   it("keeps iterationIds, which are already public", () => {
@@ -231,10 +260,12 @@ describe("toRunCompareDto — projection", () => {
     // The diff was handed two runs; only the action knows which policy chose
     // one of them, so `baseline` is passed in rather than read off the diff.
     expect(
-      (toRunCompareDto(fixture.expectedDiff, {
-        policy: "run",
-        baseRunId: "run_explicit",
-      }) as Record<string, any>).baseline,
+      (
+        toRunCompareDto(fixture.expectedDiff, {
+          policy: "run",
+          baseRunId: "run_explicit",
+        }) as Record<string, any>
+      ).baseline,
     ).toEqual({ policy: "run", baseRunId: "run_explicit" });
   });
 

--- a/mcpjam-inspector/server/routes/v1/environments.ts
+++ b/mcpjam-inspector/server/routes/v1/environments.ts
@@ -50,7 +50,12 @@ import { readJsonObjectBody } from "./adapter.js";
 const environments = new Hono();
 
 // ── Convex row shapes (hand-mirrored from convex/projectEnvironments.ts) ─────
-type SkillSelection = { mode: "explicit"; skillIds: string[] };
+type SkillSelection = {
+  mode: "explicit";
+  skillIds: string[];
+  /** Optional exact authored-skill revisions; absent means Latest at launch. */
+  versionPins?: Array<{ skillId: string; versionId: string }>;
+};
 
 /**
  * A row this API is willing to emit.
@@ -216,7 +221,7 @@ function createConvexClient(convexAuthToken: string): ConvexHttpClient {
     throw new WebRouteError(
       500,
       ErrorCode.INTERNAL_ERROR,
-      "Server missing CONVEX_URL configuration"
+      "Server missing CONVEX_URL configuration",
     );
   }
   const client = new ConvexHttpClient(convexUrl);
@@ -243,7 +248,7 @@ type ConvexErrorData = {
  */
 function isMissingConvexFunctionError(error: unknown): boolean {
   const message = String(
-    (error as { message?: unknown } | null)?.message ?? error ?? ""
+    (error as { message?: unknown } | null)?.message ?? error ?? "",
   ).toLowerCase();
   return (
     message.includes("could not find public function") ||
@@ -293,7 +298,7 @@ function translateResolveError(error: unknown): WebRouteError {
       return new WebRouteError(
         404,
         ErrorCode.NOT_FOUND,
-        "Environment not found"
+        "Environment not found",
       );
     }
     const reason = RESOLVE_REASON_BY_CODE[code];
@@ -318,7 +323,7 @@ function translateResolveError(error: unknown): WebRouteError {
  */
 function translateConvexError(
   error: unknown,
-  fallbackMessage = "Environment write rejected by the platform"
+  fallbackMessage = "Environment write rejected by the platform",
 ): WebRouteError {
   return translateConvexWriteError(error, {
     resource: "Environment",
@@ -337,7 +342,7 @@ function translateConvexError(
 async function readEnvironment(
   convexAuthToken: string,
   projectId: string,
-  environmentId: string
+  environmentId: string,
 ): Promise<EnvironmentRow> {
   const readClient = createConvexClient(convexAuthToken);
   let row: EnvironmentRow | null;
@@ -346,7 +351,7 @@ async function readEnvironment(
     // `projectId`: an id from another of the caller's projects throws NOT_FOUND.
     row = (await readClient.query(
       "projectEnvironments:getEnvironment" as any,
-      { projectId, environmentId } as any
+      { projectId, environmentId } as any,
     )) as EnvironmentRow | null;
   } catch (error) {
     throw translateConvexError(error);
@@ -365,11 +370,21 @@ async function readEnvironment(
 /**
  * Mirrors the backend envelope exactly. `skillIds` is `.min(1)` because the
  * backend rejects an empty explicit selection — "no skills" is expressed by
- * clearing the field (`null`), not by an empty list.
+ * clearing the field (`null`), not by an empty list. `versionPins` is an
+ * optional overlay: selected skills without a pin track Latest at launch.
  */
 const skillSelectionSchema = z.strictObject({
   mode: z.literal("explicit"),
   skillIds: z.array(z.string().trim().min(1)).min(1),
+  versionPins: z
+    .array(
+      z.strictObject({
+        skillId: z.string().trim().min(1),
+        versionId: z.string().trim().min(1),
+      }),
+    )
+    .min(1)
+    .optional(),
 });
 
 const pluginVersionIdsSchema = z.array(z.string().trim().min(1)).min(1);
@@ -424,7 +439,7 @@ const updateEnvironmentSchema = z
     {
       message:
         "Provide at least one of `name`, `description`, `hostId`, `serverAttachmentId`, `modelId`, `skillSelection`, `pluginVersionIds`, or `sandboxImageId` to update.",
-    }
+    },
   );
 
 /**
@@ -492,7 +507,7 @@ environments.get(
       capabilities =
         ((await readClient.query(
           "projectEnvironments:getCapabilities" as any,
-          { projectId } as any
+          { projectId } as any,
         )) as typeof capabilities | null) ?? {};
     } catch (error) {
       // ONLY deploy skew is swallowed. An older backend does not export this
@@ -507,7 +522,7 @@ environments.get(
       if (!isMissingConvexFunctionError(error)) {
         throw translateConvexError(
           error,
-          "Environment capabilities could not be read"
+          "Environment capabilities could not be read",
         );
       }
       capabilities = {};
@@ -518,7 +533,7 @@ environments.get(
       ephemeralEnvironmentLaunch:
         capabilities.ephemeralEnvironmentLaunch === true,
     });
-  }
+  },
 );
 
 // GET /v1/projects/:projectId/environments — list a project's environments.
@@ -541,14 +556,14 @@ environments.get("/projects/:projectId/environments", async (c) => {
   try {
     rows = (await readClient.query(
       "projectEnvironments:listEnvironments" as any,
-      { projectId, includeArchived } as any
+      { projectId, includeArchived } as any,
     )) as EnvironmentRow[] | null | undefined;
   } catch (error) {
     throw translateConvexError(error);
   }
   return v1PageJson(
     c,
-    (rows ?? []).filter(isNamedEnvironmentRow).map(toEnvironmentDto)
+    (rows ?? []).filter(isNamedEnvironmentRow).map(toEnvironmentDto),
   );
 });
 
@@ -564,9 +579,9 @@ environments.get(
       c,
       isNamedEnvironmentRow(row)
         ? toEnvironmentDto(row)
-        : toAdhocEnvironmentDto(row)
+        : toAdhocEnvironmentDto(row),
     );
-  }
+  },
 );
 
 // GET /v1/projects/:projectId/environments/:environmentId/resolve
@@ -584,7 +599,7 @@ environments.get(
     try {
       resolved = (await readClient.query(
         "projectEnvironments:resolveEnvironmentForLaunch" as any,
-        { projectId, environmentId } as any
+        { projectId, environmentId } as any,
       )) as ResolvedEnvironmentRow | null;
     } catch (error) {
       throw translateResolveError(error);
@@ -593,11 +608,11 @@ environments.get(
       throw new WebRouteError(
         404,
         ErrorCode.NOT_FOUND,
-        "Environment not found"
+        "Environment not found",
       );
     }
     return v1Resource(c, toResolvedDto(resolved));
-  }
+  },
 );
 
 // POST /v1/projects/:projectId/environments — create. Requires project admin.
@@ -605,7 +620,7 @@ environments.post("/projects/:projectId/environments", async (c) => {
   const projectId = c.req.param("projectId");
   const body = parseWithSchema(
     createEnvironmentSchema,
-    await readJsonObjectBody(c)
+    await readJsonObjectBody(c),
   );
   const token = await getConvexBearerForRequest(c);
   const convexClient = createConvexClient(token);
@@ -623,7 +638,7 @@ environments.post("/projects/:projectId/environments", async (c) => {
         ...(sandboxImageId !== undefined
           ? { computerEnvironmentId: sandboxImageId }
           : {}),
-      } as any
+      } as any,
     )) as EnvironmentRow;
   } catch (error) {
     throw translateConvexError(error);
@@ -656,11 +671,9 @@ environments.post(
     const projectId = c.req.param("projectId");
     const body = parseWithSchema(
       ensureAdhocEnvironmentSchema,
-      await readJsonObjectBody(c)
+      await readJsonObjectBody(c),
     );
-    const convexClient = createConvexClient(
-      await getConvexBearerForRequest(c)
-    );
+    const convexClient = createConvexClient(await getConvexBearerForRequest(c));
 
     // Same boundary rename as create: the public `sandboxImageId` is the
     // internal `computerEnvironmentId`, and the spread must not forward the
@@ -676,7 +689,7 @@ environments.post(
           ...(sandboxImageId !== undefined
             ? { computerEnvironmentId: sandboxImageId }
             : {}),
-        } as any
+        } as any,
       )) as { environment: EnvironmentRow; created: boolean };
     } catch (error) {
       // DEPLOY SKEW, translated rather than surfaced as a 500: a backend that
@@ -687,7 +700,7 @@ environments.post(
           400,
           ErrorCode.VALIDATION_ERROR,
           "This deployment predates ad-hoc environments — create a named environment instead (POST /environments).",
-          { reason: "ADHOC_UNAVAILABLE" }
+          { reason: "ADHOC_UNAVAILABLE" },
         );
       }
       throw translateConvexError(error);
@@ -700,7 +713,7 @@ environments.post(
       environment: toAdhocEnvironmentDto(result.environment),
       created: result.created === true,
     });
-  }
+  },
 );
 
 // POST /v1/projects/:projectId/environments/:environmentId/name
@@ -724,11 +737,9 @@ environments.post(
     const environmentId = c.req.param("environmentId");
     const body = parseWithSchema(
       nameEnvironmentSchema,
-      await readJsonObjectBody(c)
+      await readJsonObjectBody(c),
     );
-    const convexClient = createConvexClient(
-      await getConvexBearerForRequest(c)
-    );
+    const convexClient = createConvexClient(await getConvexBearerForRequest(c));
     let named: EnvironmentRow;
     try {
       named = (await convexClient.mutation(
@@ -741,7 +752,7 @@ environments.post(
           ...(body.description !== undefined
             ? { description: body.description }
             : {}),
-        } as any
+        } as any,
       )) as EnvironmentRow;
     } catch (error) {
       if (isMissingConvexFunctionError(error)) {
@@ -749,7 +760,7 @@ environments.post(
           400,
           ErrorCode.VALIDATION_ERROR,
           "This deployment predates ad-hoc environments, so there is nothing to promote.",
-          { reason: "ADHOC_UNAVAILABLE" }
+          { reason: "ADHOC_UNAVAILABLE" },
         );
       }
       // An already-named row comes back as the backend's CONFLICT, which is
@@ -759,7 +770,7 @@ environments.post(
       throw translateConvexError(error);
     }
     return v1Resource(c, toEnvironmentDto(named));
-  }
+  },
 );
 
 // PATCH /v1/projects/:projectId/environments/:environmentId
@@ -772,7 +783,7 @@ environments.patch(
     const environmentId = c.req.param("environmentId");
     const body = parseWithSchema(
       updateEnvironmentSchema,
-      await readJsonObjectBody(c)
+      await readJsonObjectBody(c),
     );
     const token = await getConvexBearerForRequest(c);
 
@@ -807,13 +818,13 @@ environments.patch(
     try {
       updated = (await convexClient.mutation(
         "projectEnvironments:updateEnvironment" as any,
-        updateArgs as any
+        updateArgs as any,
       )) as EnvironmentRow;
     } catch (error) {
       throw translateConvexError(error);
     }
     return v1Resource(c, toEnvironmentDto(updated));
-  }
+  },
 );
 
 // POST /v1/projects/:projectId/environments/:environmentId/archive
@@ -826,7 +837,7 @@ environments.post(
     const environmentId = c.req.param("environmentId");
     const body = parseWithSchema(
       revisionBodySchema,
-      await readJsonObjectBody(c)
+      await readJsonObjectBody(c),
     );
     const convexClient = createConvexClient(await getConvexBearerForRequest(c));
     let archived: EnvironmentRow;
@@ -837,13 +848,13 @@ environments.post(
           projectId,
           environmentId,
           expectedRevision: body.expectedRevision,
-        } as any
+        } as any,
       )) as EnvironmentRow;
     } catch (error) {
       throw translateConvexError(error);
     }
     return v1Resource(c, toEnvironmentDto(archived));
-  }
+  },
 );
 
 // POST /v1/projects/:projectId/environments/:environmentId/restore
@@ -857,7 +868,7 @@ environments.post(
     const environmentId = c.req.param("environmentId");
     const body = parseWithSchema(
       revisionBodySchema,
-      await readJsonObjectBody(c)
+      await readJsonObjectBody(c),
     );
     const convexClient = createConvexClient(await getConvexBearerForRequest(c));
     let restored: EnvironmentRow;
@@ -868,13 +879,13 @@ environments.post(
           projectId,
           environmentId,
           expectedRevision: body.expectedRevision,
-        } as any
+        } as any,
       )) as EnvironmentRow;
     } catch (error) {
       throw translateConvexError(error);
     }
     return v1Resource(c, toEnvironmentDto(restored));
-  }
+  },
 );
 
 export default environments;

--- a/mcpjam-inspector/server/routes/v1/eval-compare-projection.ts
+++ b/mcpjam-inspector/server/routes/v1/eval-compare-projection.ts
@@ -143,12 +143,12 @@ const CASE_OUTCOMES = new Set(["passed", "failed", "absent"]);
 function caseSide(value: unknown): Rec {
   const side = isRecord(value) ? value : {};
   const iterationIds = Array.isArray(side.iterationIds)
-    ? side.iterationIds.filter(
-        (id): id is string => typeof id === "string",
-      )
+    ? side.iterationIds.filter((id): id is string => typeof id === "string")
     : [];
   return {
-    outcome: CASE_OUTCOMES.has(str(side.outcome)) ? str(side.outcome) : "absent",
+    outcome: CASE_OUTCOMES.has(str(side.outcome))
+      ? str(side.outcome)
+      : "absent",
     iterationIds,
     representativeIterationId: strOrNull(side.representativeIterationId),
     error: strOrNull(side.error),
@@ -197,6 +197,79 @@ function runSide(value: unknown): Rec {
     ...(run.modelSource === "client_default" || run.modelSource === "override"
       ? { modelSource: run.modelSource }
       : {}),
+  };
+}
+
+const SKILL_CHANGE_KINDS = new Set(["added", "removed", "changed"]);
+const SKILL_CHANNELS = new Set(["host", "environment", "plugin", "mcp-server"]);
+
+/**
+ * One side's fingerprint of a skill: hashes plus, when the run recorded one,
+ * the revision number. Whitelisted field by field like everything else here —
+ * the pinned-skill metadata is a wide internal shape and only these four are
+ * public.
+ */
+function skillSide(value: unknown): Rec | null {
+  if (!isRecord(value)) return null;
+  return {
+    contentHash: str(value.contentHash),
+    ...(typeof value.aggregateHash === "string"
+      ? { aggregateHash: value.aggregateHash }
+      : {}),
+    ...(typeof value.versionNumber === "number"
+      ? { versionNumber: value.versionNumber }
+      : {}),
+    ...(typeof value.serverSkillVersionNumber === "number"
+      ? { serverSkillVersionNumber: value.serverSkillVersionNumber }
+      : {}),
+  };
+}
+
+/**
+ * Which skills changed between the two runs — the configuration attribution
+ * that explains a case-level regression.
+ *
+ * `null` passes through as `null` rather than becoming an empty section: the
+ * backend uses it to mean "neither run recorded skills", and flattening that
+ * into `{changes: []}` would tell a public caller no skills were involved.
+ *
+ * The internal shape carries no `_storage` ids (skill bodies and files live in
+ * the pin stores, joined by hash elsewhere), so nothing here needs dropping —
+ * but it is still a whitelist, for the same reason the rest of the file is.
+ */
+function skills(value: unknown): Rec | null {
+  if (!isRecord(value)) return null;
+  const base = isRecord(value.base) ? value.base : {};
+  const compare = isRecord(value.compare) ? value.compare : {};
+  const changes = Array.isArray(value.changes) ? value.changes : [];
+  return {
+    base: { excluded: boolOf(base.excluded), count: countOf(base.count) },
+    compare: {
+      excluded: boolOf(compare.excluded),
+      count: countOf(compare.count),
+    },
+    changes: changes.filter(isRecord).map((row) => {
+      const baseSide = skillSide(row.base);
+      const compareSide = skillSide(row.compare);
+      return {
+        key: str(row.key),
+        name: str(row.name),
+        ...(typeof row.modelRef === "string" ? { modelRef: row.modelRef } : {}),
+        channels: (Array.isArray(row.channels) ? row.channels : [])
+          .filter((c): c is string => typeof c === "string")
+          .filter((c) => SKILL_CHANNELS.has(c)),
+        kind: SKILL_CHANGE_KINDS.has(str(row.kind)) ? str(row.kind) : "changed",
+        ...(typeof row.renamedFrom === "string"
+          ? { renamedFrom: row.renamedFrom }
+          : {}),
+        ...(baseSide ? { base: baseSide } : {}),
+        ...(compareSide ? { compare: compareSide } : {}),
+        ...(typeof row.versionDelta === "string"
+          ? { versionDelta: row.versionDelta }
+          : {}),
+      };
+    }),
+    unchangedCount: countOf(value.unchangedCount),
   };
 }
 
@@ -259,6 +332,7 @@ export function toRunCompareDto(
       estimatedCostUsd: numericDiff(metrics.estimatedCostUsd),
     },
     scoreContract: scoreContract(source.scoreContract),
+    skills: skills(source.skills),
     cases: cases.filter(isRecord).map((row) => ({
       caseKey: str(row.caseKey),
       title: str(row.title),

--- a/mcpjam-inspector/server/routes/web/__tests__/skills.test.ts
+++ b/mcpjam-inspector/server/routes/web/__tests__/skills.test.ts
@@ -348,12 +348,35 @@ describe("POST /api/web/skills/versions/*", () => {
     expect((await res.json()).skill.content).toBe("restored");
   });
 
-  it("rejects a request with no versionId", async () => {
-    const res = await post("/api/web/skills/versions/get", {
-      projectId: "proj_1",
-      skillId: "s1",
-    });
-    expect(res.status).toBe(400);
+  it("rejects a missing, null or empty versionId without calling upstream", async () => {
+    // An empty string is the one that matters in practice: a picker or URL
+    // param can produce it, and `z.string().min(1)` is what stops it reaching
+    // Convex as a lookup for a version nobody named.
+    for (const [route, mock] of [
+      ["get", getCloudSkillVersion],
+      ["restore", restoreCloudSkillVersion],
+    ] as const) {
+      for (const versionId of [undefined, null, ""]) {
+        const res = await post(`/api/web/skills/versions/${route}`, {
+          projectId: "proj_1",
+          skillId: "s1",
+          ...(versionId === undefined ? {} : { versionId }),
+        });
+        expect(res.status).toBe(400);
+        expect(vi.mocked(mock)).not.toHaveBeenCalled();
+      }
+    }
+  });
+
+  it("rejects a missing, null or empty skillId without calling upstream", async () => {
+    for (const skillId of [undefined, null, ""]) {
+      const res = await post("/api/web/skills/versions/list", {
+        projectId: "proj_1",
+        ...(skillId === undefined ? {} : { skillId }),
+      });
+      expect(res.status).toBe(400);
+      expect(vi.mocked(listCloudSkillVersions)).not.toHaveBeenCalled();
+    }
   });
 
   it("maps an upstream failure to its status", async () => {

--- a/mcpjam-inspector/server/routes/web/__tests__/skills.test.ts
+++ b/mcpjam-inspector/server/routes/web/__tests__/skills.test.ts
@@ -26,6 +26,9 @@ vi.mock("../../../utils/computers/cloud-skills", () => {
     updateCloudSkill: vi.fn(),
     deleteCloudSkill: vi.fn(),
     promoteCloudSkill: vi.fn(),
+    listCloudSkillVersions: vi.fn(),
+    getCloudSkillVersion: vi.fn(),
+    restoreCloudSkillVersion: vi.fn(),
   };
 });
 
@@ -36,6 +39,9 @@ import {
   createCloudSkill,
   deleteCloudSkill,
   promoteCloudSkill,
+  listCloudSkillVersions,
+  getCloudSkillVersion,
+  restoreCloudSkillVersion,
 } from "../../../utils/computers/cloud-skills";
 
 function createApp() {
@@ -80,7 +86,10 @@ describe("POST /api/web/skills/list", () => {
     const body = await res.json();
     expect(body.skills[0].name).toBe("pdf");
     expect(vi.mocked(listCloudSkills)).toHaveBeenCalledWith(
-      expect.objectContaining({ authHeader: "convex-jwt", projectId: "proj_1" }),
+      expect.objectContaining({
+        authHeader: "convex-jwt",
+        projectId: "proj_1",
+      }),
     );
   });
 
@@ -265,5 +274,139 @@ describe("POST /api/web/skills/delete + /promote", () => {
     });
     expect(res.status).toBe(200);
     expect((await res.json()).skill.sharing).toBe("project");
+  });
+});
+
+describe("POST /api/web/skills/versions/*", () => {
+  const VERSION = {
+    versionId: "v1",
+    versionNumber: 1,
+    versionHash: "h1",
+    contentHash: "c1",
+    name: "pdf",
+    description: "d",
+    fileCount: 0,
+    isCurrent: true,
+    createdByUserId: "u1",
+    createdAt: 1,
+  };
+
+  it("lists a skill's revisions", async () => {
+    vi.mocked(listCloudSkillVersions).mockResolvedValue([VERSION]);
+    const res = await post("/api/web/skills/versions/list", {
+      projectId: "proj_1",
+      skillId: "s1",
+    });
+    expect(res.status).toBe(200);
+    expect((await res.json()).versions[0].versionNumber).toBe(1);
+    expect(vi.mocked(listCloudSkillVersions)).toHaveBeenCalledWith(
+      expect.objectContaining({ projectId: "proj_1" }),
+      "s1",
+    );
+  });
+
+  it("returns one revision in full", async () => {
+    vi.mocked(getCloudSkillVersion).mockResolvedValue({
+      ...VERSION,
+      content: "body",
+      files: [{ path: "scripts/run.py", size: 10, contentHash: "f1" }],
+    });
+    const res = await post("/api/web/skills/versions/get", {
+      projectId: "proj_1",
+      skillId: "s1",
+      versionId: "v1",
+    });
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.version.content).toBe("body");
+    expect(body.version.files).toHaveLength(1);
+    expect(vi.mocked(getCloudSkillVersion)).toHaveBeenCalledWith(
+      expect.objectContaining({ projectId: "proj_1" }),
+      { skillId: "s1", versionId: "v1" },
+    );
+  });
+
+  it("restores a revision", async () => {
+    vi.mocked(restoreCloudSkillVersion).mockResolvedValue({
+      skillId: "s1",
+      projectId: "proj_1",
+      name: "pdf",
+      description: "d",
+      sharing: "project",
+      isOwner: false,
+      content: "restored",
+      aggregateHash: "h",
+      createdAt: 1,
+      updatedAt: 2,
+    });
+    const res = await post("/api/web/skills/versions/restore", {
+      projectId: "proj_1",
+      skillId: "s1",
+      versionId: "v1",
+    });
+    expect(res.status).toBe(200);
+    expect((await res.json()).skill.content).toBe("restored");
+  });
+
+  it("rejects a request with no versionId", async () => {
+    const res = await post("/api/web/skills/versions/get", {
+      projectId: "proj_1",
+      skillId: "s1",
+    });
+    expect(res.status).toBe(400);
+  });
+
+  it("maps an upstream failure to its status", async () => {
+    vi.mocked(listCloudSkillVersions).mockRejectedValue(
+      new CloudSkillsError("Skill not found", 404),
+    );
+    const res = await post("/api/web/skills/versions/list", {
+      projectId: "proj_1",
+      skillId: "gone",
+    });
+    expect(res.status).toBe(404);
+  });
+});
+
+describe("POST /api/web/skills/create — folder-import draft", () => {
+  const CREATED = {
+    skillId: "s2",
+    projectId: "proj_1",
+    name: "greeter",
+    description: "hi",
+    sharing: "user" as const,
+    isOwner: true,
+    content: "c",
+    aggregateHash: "h",
+    createdAt: 1,
+    updatedAt: 1,
+  };
+
+  it("forwards importPending so the attach commits the single v1", async () => {
+    vi.mocked(createCloudSkill).mockResolvedValue(CREATED);
+    const res = await post("/api/web/skills/create", {
+      projectId: "proj_1",
+      name: "greeter",
+      description: "hi",
+      content: "c",
+      importPending: true,
+    });
+    expect(res.status).toBe(200);
+    expect(vi.mocked(createCloudSkill)).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({ importPending: true }),
+    );
+  });
+
+  it("omits it entirely for an ordinary create, preserving legacy behavior", async () => {
+    vi.mocked(createCloudSkill).mockResolvedValue(CREATED);
+    await post("/api/web/skills/create", {
+      projectId: "proj_1",
+      name: "greeter",
+      description: "hi",
+      content: "c",
+    });
+    const [, data] = vi.mocked(createCloudSkill).mock.calls[0]!;
+    expect(data).not.toHaveProperty("importPending");
   });
 });

--- a/mcpjam-inspector/server/routes/web/skills.ts
+++ b/mcpjam-inspector/server/routes/web/skills.ts
@@ -34,6 +34,9 @@ import {
   attachCloudSkillFiles,
   removeCloudSkillFile,
   readCloudSkillFile,
+  listCloudSkillVersions,
+  getCloudSkillVersion,
+  restoreCloudSkillVersion,
   MAX_SKILL_CONTENT_BYTES,
   type CloudSkillsContext,
 } from "../../utils/computers/cloud-skills.js";
@@ -78,7 +81,10 @@ async function run<T>(fn: () => Promise<T>): Promise<T> {
   }
 }
 
-async function ctxFrom(c: Context, projectId: string): Promise<CloudSkillsContext> {
+async function ctxFrom(
+  c: Context,
+  projectId: string,
+): Promise<CloudSkillsContext> {
   // Exchange the request bearer for a Convex-usable bearer (handles WorkOS
   // API-key → delegated-JWT; a session JWT passes through).
   const bearer = await getConvexBearerForRequest(c);
@@ -156,6 +162,53 @@ skills.post("/get-by-name", async (c) =>
   }),
 );
 
+// ── Version history ──────────────────────────────────────────────────────────
+//
+// Reads are visibility-gated exactly like the skill itself; restore is
+// manage-gated, because it rewrites the live artifact.
+
+skills.post("/versions/list", async (c) =>
+  handleRoute(c, async () => {
+    const body = parseWithSchema(skillIdSchema, await readJsonBody(c));
+    const versions = await run(async () =>
+      listCloudSkillVersions(await ctxFrom(c, body.projectId), body.skillId),
+    );
+    return { versions };
+  }),
+);
+
+skills.post("/versions/get", async (c) =>
+  handleRoute(c, async () => {
+    const body = parseWithSchema(
+      skillIdSchema.extend({ versionId: z.string().min(1) }),
+      await readJsonBody(c),
+    );
+    const version = await run(async () =>
+      getCloudSkillVersion(await ctxFrom(c, body.projectId), {
+        skillId: body.skillId,
+        versionId: body.versionId,
+      }),
+    );
+    return { version };
+  }),
+);
+
+skills.post("/versions/restore", async (c) =>
+  handleRoute(c, async () => {
+    const body = parseWithSchema(
+      skillIdSchema.extend({ versionId: z.string().min(1) }),
+      await readJsonBody(c),
+    );
+    const skill = await run(async () =>
+      restoreCloudSkillVersion(await ctxFrom(c, body.projectId), {
+        skillId: body.skillId,
+        versionId: body.versionId,
+      }),
+    );
+    return { success: true, skill };
+  }),
+);
+
 skills.post("/create", async (c) =>
   handleRoute(c, async () => {
     const body = parseWithSchema(
@@ -169,6 +222,11 @@ skills.post("/create", async (c) =>
         // client's naive frontmatter parse drops preserved fields like
         // `allowed-tools`). Absent ⇒ legacy behavior, unchanged.
         skillMd: skillMdSchema.optional(),
+        // FOLDER IMPORT: create the skill as a hidden draft whose files are
+        // still uploading. The bulk `/files/attach` that follows commits it and
+        // mints its one v1, so an interrupted import cannot leave a visible
+        // skill missing its scripts. Set only by the folder-upload flow.
+        importPending: z.boolean().optional(),
       }),
       await readJsonBody(c),
     );
@@ -222,6 +280,7 @@ skills.post("/create", async (c) =>
         content,
         ...(body.sharing ? { sharing: body.sharing } : {}),
         ...(extraFrontmatter ? { extraFrontmatter } : {}),
+        ...(body.importPending ? { importPending: true } : {}),
       }),
     );
     return { success: true, skill };

--- a/mcpjam-inspector/server/utils/computers/cloud-skills.ts
+++ b/mcpjam-inspector/server/utils/computers/cloud-skills.ts
@@ -25,14 +25,19 @@ import {
   convexGetSkill,
   convexGetSkillByName,
   convexGetSkillFileUrl,
+  convexGetSkillVersion,
   convexListSkillFiles,
+  convexListSkillVersions,
   convexListSkills,
   convexPromoteSkill,
   convexRemoveSkillFile,
+  convexRestoreSkillVersion,
   convexUpdateSkill,
   type CloudSkillDetail,
   type CloudSkillFileMeta,
   type CloudSkillListItem,
+  type CloudSkillVersionDetail,
+  type CloudSkillVersionSummary,
   type SkillExtraFrontmatterInput,
   type SkillSharing,
 } from "./convex-skills-client.js";
@@ -73,7 +78,7 @@ const CODE_STATUS: Record<string, number> = {
 
 /** Read a `ConvexError`'s structured `{ code, message }` payload, if present. */
 function convexErrorData(
-  err: unknown
+  err: unknown,
 ): { code?: string; message?: string } | null {
   const data = (err as { data?: unknown })?.data;
   if (data && typeof data === "object") return data as { code?: string };
@@ -95,7 +100,7 @@ function mapConvexError(err: unknown): CloudSkillsError {
   if (data?.code && CODE_STATUS[data.code] !== undefined) {
     return new CloudSkillsError(
       data.message ?? "Skill request failed",
-      CODE_STATUS[data.code]
+      CODE_STATUS[data.code],
     );
   }
 
@@ -104,7 +109,7 @@ function mapConvexError(err: unknown): CloudSkillsError {
   let status = 500;
   if (
     /not authorized|requires project admin|owned by another|only the owner|requires project member/.test(
-      lower
+      lower,
     )
   ) {
     status = 403;
@@ -112,7 +117,7 @@ function mapConvexError(err: unknown): CloudSkillsError {
     status = 404;
   } else if (
     /already exists|already shared|already a personal|pick a different name|already have a skill/.test(
-      lower
+      lower,
     )
   ) {
     status = 409;
@@ -131,21 +136,21 @@ async function run<T>(fn: () => Promise<T>): Promise<T> {
 }
 
 export function listCloudSkills(
-  ctx: CloudSkillsContext
+  ctx: CloudSkillsContext,
 ): Promise<CloudSkillListItem[]> {
   return run(() => convexListSkills(ctx.authHeader, ctx.projectId));
 }
 
 export function getCloudSkill(
   ctx: CloudSkillsContext,
-  skillId: string
+  skillId: string,
 ): Promise<CloudSkillDetail> {
   return run(() => convexGetSkill(ctx.authHeader, ctx.projectId, skillId));
 }
 
 export function getCloudSkillByName(
   ctx: CloudSkillsContext,
-  name: string
+  name: string,
 ): Promise<CloudSkillDetail | null> {
   return run(() => convexGetSkillByName(ctx.authHeader, ctx.projectId, name));
 }
@@ -159,10 +164,52 @@ export function createCloudSkill(
     sharing?: SkillSharing;
     /** Preserved spec frontmatter (backend re-validates + size-caps). */
     extraFrontmatter?: SkillExtraFrontmatterInput;
-  }
+    /** Folder import: create a hidden draft; the file attach commits its v1. */
+    importPending?: boolean;
+  },
 ): Promise<CloudSkillDetail> {
   return run(() =>
-    convexCreateSkill(ctx.authHeader, { projectId: ctx.projectId, ...data })
+    convexCreateSkill(ctx.authHeader, { projectId: ctx.projectId, ...data }),
+  );
+}
+
+/** A skill's revisions, newest first. */
+export function listCloudSkillVersions(
+  ctx: CloudSkillsContext,
+  skillId: string,
+): Promise<CloudSkillVersionSummary[]> {
+  return run(() =>
+    convexListSkillVersions(ctx.authHeader, ctx.projectId, skillId),
+  );
+}
+
+/** One revision in full: body, frontmatter, and the file manifest it froze. */
+export function getCloudSkillVersion(
+  ctx: CloudSkillsContext,
+  data: { skillId: string; versionId: string },
+): Promise<CloudSkillVersionDetail> {
+  return run(() =>
+    convexGetSkillVersion(ctx.authHeader, {
+      projectId: ctx.projectId,
+      ...data,
+    }),
+  );
+}
+
+/**
+ * Bring an older revision's bytes back as the live skill. A revert, not a
+ * rewind: the backend mints the restored content as the NEXT revision, so
+ * environments tracking Latest pick it up and exact-pinned ones do not.
+ */
+export function restoreCloudSkillVersion(
+  ctx: CloudSkillsContext,
+  data: { skillId: string; versionId: string },
+): Promise<CloudSkillDetail> {
+  return run(() =>
+    convexRestoreSkillVersion(ctx.authHeader, {
+      projectId: ctx.projectId,
+      ...data,
+    }),
   );
 }
 
@@ -173,23 +220,23 @@ export function updateCloudSkill(
     skillId: string;
     description?: string;
     content?: string;
-  }
+  },
 ): Promise<CloudSkillDetail> {
   return run(() =>
-    convexUpdateSkill(ctx.authHeader, { projectId: ctx.projectId, ...data })
+    convexUpdateSkill(ctx.authHeader, { projectId: ctx.projectId, ...data }),
   );
 }
 
 export function deleteCloudSkill(
   ctx: CloudSkillsContext,
-  skillId: string
+  skillId: string,
 ): Promise<{ deleted: true }> {
   return run(() => convexDeleteSkill(ctx.authHeader, ctx.projectId, skillId));
 }
 
 export function promoteCloudSkill(
   ctx: CloudSkillsContext,
-  skillId: string
+  skillId: string,
 ): Promise<CloudSkillDetail> {
   return run(() => convexPromoteSkill(ctx.authHeader, ctx.projectId, skillId));
 }
@@ -200,39 +247,39 @@ export type { CloudSkillFileMeta };
 
 export function generateCloudSkillFileUploadUrl(
   ctx: CloudSkillsContext,
-  skillId: string
+  skillId: string,
 ): Promise<{ uploadUrl: string }> {
   return run(() =>
-    convexGenerateSkillFileUploadUrl(ctx.authHeader, ctx.projectId, skillId)
+    convexGenerateSkillFileUploadUrl(ctx.authHeader, ctx.projectId, skillId),
   );
 }
 
 export function attachCloudSkillFiles(
   ctx: CloudSkillsContext,
   skillId: string,
-  files: { path: string; storageId: string; contentHash: string }[]
+  files: { path: string; storageId: string; contentHash: string }[],
 ): Promise<{ files: CloudSkillFileMeta[] }> {
   return run(() =>
-    convexAttachSkillFiles(ctx.authHeader, ctx.projectId, skillId, files)
+    convexAttachSkillFiles(ctx.authHeader, ctx.projectId, skillId, files),
   );
 }
 
 export function removeCloudSkillFile(
   ctx: CloudSkillsContext,
   skillId: string,
-  path: string
+  path: string,
 ): Promise<{ removed: boolean }> {
   return run(() =>
-    convexRemoveSkillFile(ctx.authHeader, ctx.projectId, skillId, path)
+    convexRemoveSkillFile(ctx.authHeader, ctx.projectId, skillId, path),
   );
 }
 
 export function listCloudSkillFiles(
   ctx: CloudSkillsContext,
-  skillId: string
+  skillId: string,
 ): Promise<CloudSkillFileMeta[]> {
   return run(() =>
-    convexListSkillFiles(ctx.authHeader, ctx.projectId, skillId)
+    convexListSkillFiles(ctx.authHeader, ctx.projectId, skillId),
   );
 }
 
@@ -245,14 +292,14 @@ export function listCloudSkillFiles(
 export function readCloudSkillFile(
   ctx: CloudSkillsContext,
   skillId: string,
-  path: string
+  path: string,
 ): Promise<SkillFileContent> {
   return run(async () => {
     const { url, size } = await convexGetSkillFileUrl(
       ctx.authHeader,
       ctx.projectId,
       skillId,
-      path
+      path,
     );
     if (!url) throw new CloudSkillsError("Skill file not found", 404);
     // Guard on the server-verified size BEFORE fetching so a large blob can't
@@ -261,7 +308,7 @@ export function readCloudSkillFile(
     if (size > SKILL_FILE_MAX_READ_BYTES) {
       throw new CloudSkillsError(
         `Skill file too large to read (${size} bytes).`,
-        413
+        413,
       );
     }
     // Combine the caller's disconnect signal with an explicit timeout so a slow
@@ -274,7 +321,7 @@ export function readCloudSkillFile(
     if (!res.ok) {
       throw new CloudSkillsError(
         `Failed to read skill file (${res.status})`,
-        502
+        502,
       );
     }
     const bytes = new Uint8Array(await res.arrayBuffer());

--- a/mcpjam-inspector/server/utils/computers/convex-skills-client.ts
+++ b/mcpjam-inspector/server/utils/computers/convex-skills-client.ts
@@ -23,7 +23,9 @@ export type SkillSharing = "user" | "project";
  * known {@link SkillProvenance}. Absent / unknown ⇒ 'authored' — the legacy
  * default, matching the backend `rowProvenance` read-normalizer.
  */
-export function normalizeProvenance(value: string | undefined): SkillProvenance {
+export function normalizeProvenance(
+  value: string | undefined,
+): SkillProvenance {
   return value === "computer-adopted" ? "computer-adopted" : "authored";
 }
 
@@ -46,8 +48,38 @@ export interface CloudSkillListItem {
    * backends (wire-tolerant).
    */
   pinnability?: { ok: true } | { ok: false; reason: string };
+  /**
+   * Which revision "Latest" currently resolves to, for a `v3` badge and as the
+   * default in a version picker. Absent on a skill that predates versioning and
+   * has not been backfilled — consumers render nothing rather than guessing v1.
+   */
+  currentVersionId?: string;
+  currentVersionNumber?: number;
   createdAt: number;
   updatedAt: number;
+}
+
+/** One revision in a skill's history (newest-first from `listSkillVersions`). */
+export interface CloudSkillVersionSummary {
+  versionId: string;
+  versionNumber: number;
+  versionHash: string;
+  contentHash: string;
+  name: string;
+  description: string;
+  fileCount: number;
+  /** The revision the skill's "Latest" resolves to right now. */
+  isCurrent: boolean;
+  /** Set when this revision was minted by restoring an older one. */
+  restoredFromVersionNumber?: number;
+  createdByUserId: string;
+  createdAt: number;
+}
+
+export interface CloudSkillVersionDetail extends CloudSkillVersionSummary {
+  content: string;
+  extraFrontmatter?: SkillExtraFrontmatterInput;
+  files: { path: string; size: number; contentHash: string }[];
 }
 
 export interface CloudSkillDetail extends CloudSkillListItem {
@@ -145,6 +177,9 @@ const FN = {
   fileUrl: "projectSkills:getSkillFileUrl",
   filesForRuntime: "projectSkills:listSkillFilesForRuntime",
   filesForRuntimeExecution: "projectSkills:listSkillFilesForRuntimeExecution",
+  listVersions: "projectSkills:listSkillVersions",
+  getVersion: "projectSkills:getSkillVersion",
+  restoreVersion: "projectSkills:restoreSkillVersion",
 } as const;
 
 function stripBearer(token: string): string {
@@ -228,9 +263,41 @@ export async function convexCreateSkill(
     sharing?: SkillSharing;
     /** Preserved spec frontmatter (backend re-validates + size-caps). */
     extraFrontmatter?: SkillExtraFrontmatterInput;
+    /**
+     * FOLDER IMPORT: create the skill as a hidden draft that mints no version.
+     * The bulk `attachSkillFiles` carrying its files commits it and mints v1, so
+     * a crash between the two leaves an invisible draft rather than a visible
+     * skill whose scripts never arrived. Only the folder-upload flow sets it.
+     */
+    importPending?: boolean;
   },
 ): Promise<CloudSkillDetail> {
   return await makeClient(bearer).mutation(FN.create as any, args);
+}
+
+export async function convexListSkillVersions(
+  bearer: string,
+  projectId: string,
+  skillId: string,
+): Promise<CloudSkillVersionSummary[]> {
+  return await makeClient(bearer).query(FN.listVersions as any, {
+    projectId,
+    skillId,
+  });
+}
+
+export async function convexGetSkillVersion(
+  bearer: string,
+  args: { projectId: string; skillId: string; versionId: string },
+): Promise<CloudSkillVersionDetail> {
+  return await makeClient(bearer).query(FN.getVersion as any, args);
+}
+
+export async function convexRestoreSkillVersion(
+  bearer: string,
+  args: { projectId: string; skillId: string; versionId: string },
+): Promise<CloudSkillDetail> {
+  return await makeClient(bearer).mutation(FN.restoreVersion as any, args);
 }
 
 export async function convexUpdateSkill(

--- a/mcpjam-inspector/shared/skill-types.ts
+++ b/mcpjam-inspector/shared/skill-types.ts
@@ -151,6 +151,15 @@ export interface SkillListItem {
    * pickers treat absent as eligible and rely on the save-time backend gate.
    */
   pinnability?: SkillPinnability;
+  /**
+   * Cloud skills only — which revision this skill's "Latest" currently resolves
+   * to (Versioned Skills), for a `v3` badge and as the default in a version
+   * picker. Absent on a skill that predates versioning and has not been
+   * backfilled, and on older backends: consumers render nothing rather than
+   * guessing "v1".
+   */
+  currentVersionId?: string;
+  currentVersionNumber?: number;
 }
 
 /**

--- a/sdk/src/platform/operations.ts
+++ b/sdk/src/platform/operations.ts
@@ -8547,6 +8547,33 @@ const skillSelectionInput = z
         "Optional exact-version overlay: at most one entry per selected skill, each naming a version of that same skill. A selected skill with no entry runs 'Latest' — its current revision, resolved when the run starts. Pin a version to hold this environment at a known revision, e.g. to compare two revisions of one skill side by side."
       ),
   })
+  // The pins are only meaningful RELATIVE to the selection they ride on, so the
+  // relation is checked here rather than left to the API: a duplicate pin makes
+  // "which revision does this skill run?" ambiguous, and a pin for an
+  // unselected skill silently does nothing. Both are rejected server-side too —
+  // catching them in the SDK turns a round-trip error into an immediate one.
+  .superRefine((selection, ctx) => {
+    const pins = selection.versionPins ?? [];
+    const selected = new Set(selection.skillIds);
+    const seen = new Set<string>();
+    for (const pin of pins) {
+      if (seen.has(pin.skillId)) {
+        ctx.addIssue({
+          code: z.ZodIssueCode.custom,
+          path: ["versionPins"],
+          message: `Skill ${pin.skillId} has more than one version pin; pin at most one version per skill.`,
+        });
+      }
+      seen.add(pin.skillId);
+      if (!selected.has(pin.skillId)) {
+        ctx.addIssue({
+          code: z.ZodIssueCode.custom,
+          path: ["versionPins"],
+          message: `Version pin references skill ${pin.skillId}, which is not in skillIds.`,
+        });
+      }
+    }
+  })
   .describe(
     "Explicit pinned skill selection. Cannot be empty — omit the field entirely, or pass null when updating, to mean 'no pinned skills'."
   );

--- a/sdk/src/platform/operations.ts
+++ b/sdk/src/platform/operations.ts
@@ -8532,7 +8532,19 @@ const skillSelectionInput = z
       .array(z.string().trim().min(1))
       .min(1)
       .describe(
-        "Project-shared skill IDs to pin. Skills with supporting files or extra frontmatter, and plugin-component skills, cannot be pinned."
+        "Project-shared skill IDs to select. Plugin-component skills cannot be selected — they reach a run by pinning their plugin version."
+      ),
+    versionPins: z
+      .array(
+        z.object({
+          skillId: z.string().trim().min(1),
+          versionId: z.string().trim().min(1),
+        })
+      )
+      .min(1)
+      .optional()
+      .describe(
+        "Optional exact-version overlay: at most one entry per selected skill, each naming a version of that same skill. A selected skill with no entry runs 'Latest' — its current revision, resolved when the run starts. Pin a version to hold this environment at a known revision, e.g. to compare two revisions of one skill side by side."
       ),
   })
   .describe(

--- a/sdk/src/platform/types.ts
+++ b/sdk/src/platform/types.ts
@@ -1755,11 +1755,15 @@ export interface PlatformRunCompare {
    * Which skills changed between the two runs — the configuration attribution
    * that usually explains the case-level differences beside it.
    *
-   * `null` when NEITHER run recorded pinned skills: two runs that predate skill
-   * pinning have nothing to say here, and an empty section would claim no
-   * skills were involved.
+   * Three states, and they mean different things:
+   *   - a section — these skills changed (or none did, with a count);
+   *   - `null` — NEITHER run recorded pinned skills, so there is nothing to
+   *     say; an empty section would claim no skills were involved;
+   *   - ABSENT — the deployment answering predates skill attribution entirely.
+   *     Optional for that reason: a client cannot assume every backend it talks
+   *     to has this, and a required field would make old responses unusable.
    */
-  skills: PlatformRunCompareSkills | null;
+  skills?: PlatformRunCompareSkills | null;
   cases: PlatformRunCompareCase[];
 }
 

--- a/sdk/src/platform/types.ts
+++ b/sdk/src/platform/types.ts
@@ -1751,7 +1751,62 @@ export interface PlatformRunCompare {
     estimatedCostUsd: PlatformNumericDiff;
   };
   scoreContract: PlatformScoreContractDiff;
+  /**
+   * Which skills changed between the two runs — the configuration attribution
+   * that usually explains the case-level differences beside it.
+   *
+   * `null` when NEITHER run recorded pinned skills: two runs that predate skill
+   * pinning have nothing to say here, and an empty section would claim no
+   * skills were involved.
+   */
+  skills: PlatformRunCompareSkills | null;
   cases: PlatformRunCompareCase[];
+}
+
+/** Delivery channel a pinned skill reached a run through. */
+export type PlatformRunCompareSkillChannel =
+  | "host"
+  | "environment"
+  | "plugin"
+  | "mcp-server";
+
+/** One skill's identity + content fingerprint on one side of a comparison. */
+export interface PlatformRunCompareSkillSide {
+  contentHash: string;
+  /** Complete-artifact hash; present only when supporting files diverge it. */
+  aggregateHash?: string;
+  /** Authored-skill revision, when the run recorded one. */
+  versionNumber?: number;
+  /** MCP-captured revision, when the run recorded one. */
+  serverSkillVersionNumber?: number;
+}
+
+export interface PlatformRunCompareSkillChange {
+  /** Stable match key; opaque, safe for list keys and dedupe. */
+  key: string;
+  name: string;
+  /** Namespaced runtime address for a plugin-channel skill. */
+  modelRef?: string;
+  channels: PlatformRunCompareSkillChannel[];
+  kind: "added" | "removed" | "changed";
+  /** Renamed between the runs — matched as ONE skill by its logical id. */
+  renamedFrom?: string;
+  base?: PlatformRunCompareSkillSide;
+  compare?: PlatformRunCompareSkillSide;
+  /**
+   * `v3 → v4`, present only when BOTH sides recorded a revision number. A
+   * change with no delta is a real content change whose revisions are unknown
+   * (one side predates versioning) — not a smaller change.
+   */
+  versionDelta?: string;
+}
+
+export interface PlatformRunCompareSkills {
+  base: { excluded: boolean; count: number };
+  compare: { excluded: boolean; count: number };
+  /** Added / removed / changed only, changed first. Unchanged are counted. */
+  changes: PlatformRunCompareSkillChange[];
+  unchangedCount: number;
 }
 
 export interface PlatformEvalSuiteDeleted {
@@ -1885,6 +1940,21 @@ export interface PlatformHostDeleted {
 export interface PlatformEnvironmentSkillSelection {
   mode: "explicit";
   skillIds: string[];
+  /**
+   * EXACT-version overlay. At most one entry per selected skill; a selected
+   * skill with no entry resolves "Latest" — its current revision, read when the
+   * run starts, which is what every environment did before pins existed and
+   * what omitting this field still means.
+   *
+   * Pin a version to hold an environment at a known revision — the way two
+   * environments run two revisions of one skill side by side for a comparison.
+   */
+  versionPins?: PlatformEnvironmentSkillVersionPin[];
+}
+
+export interface PlatformEnvironmentSkillVersionPin {
+  skillId: string;
+  versionId: string;
 }
 
 export interface PlatformEnvironment {

--- a/sdk/tests/platform/operations-environment-skill-pins.test.ts
+++ b/sdk/tests/platform/operations-environment-skill-pins.test.ts
@@ -1,0 +1,68 @@
+/**
+ * Version-pin validation on the environment operations' input schema.
+ *
+ * The pins are only meaningful RELATIVE to the selection they ride on, and both
+ * ways of getting that relation wrong are silent rather than loud: a duplicate
+ * pin makes "which revision does this skill run?" ambiguous, and a pin naming an
+ * unselected skill simply does nothing. The API rejects both; catching them here
+ * turns a round-trip error into an immediate one.
+ */
+import { describe, expect, it } from "vitest";
+import { createEnvironmentOperation } from "../../src/platform/index.js";
+
+const BASE = {
+  name: "Baseline",
+  hostId: "host-1",
+};
+
+function parse(skillSelection: unknown) {
+  return createEnvironmentOperation.inputSchema.safeParse({
+    ...BASE,
+    skillSelection,
+  });
+}
+
+describe("environment skillSelection version pins", () => {
+  it("accepts a selection with no pins — every skill runs Latest", () => {
+    expect(parse({ mode: "explicit", skillIds: ["skill-a"] }).success).toBe(
+      true
+    );
+  });
+
+  it("accepts one pin per selected skill", () => {
+    const result = parse({
+      mode: "explicit",
+      skillIds: ["skill-a", "skill-b"],
+      versionPins: [
+        { skillId: "skill-a", versionId: "ver-1" },
+        { skillId: "skill-b", versionId: "ver-7" },
+      ],
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it("rejects two pins for the same skill", () => {
+    const result = parse({
+      mode: "explicit",
+      skillIds: ["skill-a"],
+      versionPins: [
+        { skillId: "skill-a", versionId: "ver-1" },
+        { skillId: "skill-a", versionId: "ver-2" },
+      ],
+    });
+    expect(result.success).toBe(false);
+    expect(JSON.stringify(result.error?.issues)).toMatch(
+      /more than one version pin/
+    );
+  });
+
+  it("rejects a pin for a skill the environment does not select", () => {
+    const result = parse({
+      mode: "explicit",
+      skillIds: ["skill-a"],
+      versionPins: [{ skillId: "skill-b", versionId: "ver-1" }],
+    });
+    expect(result.success).toBe(false);
+    expect(JSON.stringify(result.error?.issues)).toMatch(/not in skillIds/);
+  });
+});


### PR DESCRIPTION
Companion PR: MCPJam/mcpjam-backend#1168 — **these must ship together.** They share a byte-identical parity fixture and its pinned SHA, so each repo's parity test fails until the other lands.

## Why

You edit a skill, rerun your evals, and three cases regress. The comparison showed you the regressed cases and said nothing about the configuration that produced them — so a skill edit read as an unexplained regression, which is the exact question people open a comparison to answer.

The backend PR records which revision of each skill a run used and lets an environment pin one. This PR is the half users touch.

## What changed

**Run comparison — a "Skill changes" section**, above Cases because it usually explains them:

```
refunds   v3 → v4   Changed   environment
lookup    v2        Added     mcp-server
```

- Prefers the revision a run recorded, on either identity system; short hashes are the fallback for a run that predates versioning, so a real change is never rendered as if nothing moved.
- Renders nothing when no skills changed, and nothing when *neither* run recorded skills — an empty card on every comparison is noise, and for two legacy runs "no skills changed" is a claim nobody checked.
- Calls out an arm that deliberately ran without skills.

**Environment picker — a per-skill version control**, defaulting to Latest and writing `versionPins`. One shared component feeds four surfaces (environment editor, skills pill, the composer used by evals and User Testing, and swarms), so all four get it at once. History loads when a control is opened, not on mount — a picker showing twenty skills should not fetch twenty histories nobody looked at. Deselecting a skill takes its pin with it, and `versionPins` is omitted rather than emptied when nothing is pinned, so an unpinned environment still serializes — and fingerprints — exactly as before.

Both dirty-checks now compare pins. The editor's private copy of `sameSkillSelection` was deleted in favour of the shared helper: a check that missed pins would silently discard a "hold this at v1" edit, and two implementations means one of them eventually does.

**Two latent bugs, surfaced by the atomic-import draft.** Folder import now creates a hidden draft that the file attach commits. That exposed the fact that the client resolved the new skill's id by **name**, and its failure path deleted by **name** — both of which fail against a hidden row, leaving exactly the orphan the rollback exists to prevent. Both now use the id the create call returns, with the name lookup kept as the fallback for an older server.

**Also fixed:** the "skills excluded" badge was unreachable in the common case, because the component early-returned when a run pinned no plugins — which is precisely what the without-skills arm of a comparison looks like.

**Plumbing:** skills projected through the v1 DTO whitelist (field by field, like everything else there — `null` passes through as `null` rather than flattening to an empty section); `versionPins` on the client hook, SDK types and Zod input; OpenAPI documents both; `SkillListItem` carries the current revision for the `vN` default; REST + Convex client wrappers for version list/get/restore.

## Review fixes (`b302356`)

Review found **two places where a version pin was silently ignored** while the UI went on looking like it worked. Both are fixed with regression tests that fail without the fix:

- **Swarm cache identity.** `environmentSelectionKey` was built from `skillIds` alone — and pinning a skill to another revision changes no id. The key compared equal, the reset effects never fired, and confirming after the edit relaunched journeys created for the *old* revision: the swarm ran the revision the user had just pinned away from. The key now folds in the pins, sorted by skill. It moved into `new-swarm-flow-draft.ts` (which already owned the concept) as `buildEnvironmentSelectionKey`, so the invariant is testable rather than buried in a 2,000-line component.
- **Cross-host matrix.** `slotFingerprint` ignored pins, so two environments identical but for the pinned revision produced equal fingerprints, never split into columns, and had both revisions' iterations averaged into one cell — erasing the difference under test. Its split label now names the pinned revisions; a skill *count* is the one thing that cannot tell those columns apart, since every column would read "1 skill".

Plus: an added/removed skill now shows its recorded revision instead of a hash; the version control is disabled for a skill whose selection the backend would reject (checkbox stays live so the selection can be repaired); and the SDK schema rejects duplicate pins and pins naming unselected skills.

**One deliberate divergence from review:** `skills` was asked to be a *required* property. It's optional. Required is what broke CI here (it failed the `@mcpjam/cli` typecheck across every fixture), and it's wrong on the merits — a client can be talking to a deployment that predates skill attribution, and absent / `null` / populated are three different statements. Reasoning is on the thread.

## Testing

Full inspector suite green: **18,752 passed, 0 failed** (1,468 files). SDK suite green: 6,793 passed. Typechecks clean across `@mcpjam/sdk`, `@mcpjam/cli`, and `@mcpjam/inspector`.

New tests cover: the version move and its hash fallback, an added MCP skill showing `v2`, silence when nothing changed and when both runs are legacy, the excluded-arm note, the skills-excluded badge with no plugins pinned (the case that made it unreachable), Latest as default, history fetched only on open, history-failure and empty states, pins dropped with their skill, `versionPins` omitted rather than emptied, a pin staying selectable before its history loads, the version control disabled for an ineligible skill, the swarm key invariants, cross-host cell splitting by revision, SDK pin validation, and the version routes.

Both cross-repo ratchets pass: the parity fixture is byte-identical to the backend's with the same SHA, and OpenAPI ↔ SDK type parity is green.

*(An earlier revision of this description noted two failing tests — `ScenarioChatPage` and `mcp-apps-renderer`. They were parallel-interference flakes in files this diff doesn't touch; they pass in isolation and did not recur on the latest full run.)*

## Follow-up

The Skills-screen version history UI (timeline, body/file diffs, restore button) is deliberately not here. The backend APIs exist, are tested, and are already wired through this PR's REST layer, so it's a self-contained UI slice.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes eval comparison UX and environment/skill selection plumbing where incorrect cache keys or matrix fingerprinting could silently run or display the wrong skill revision; no auth or payment paths touched.
> 
> **Overview**
> **Surfaces skill configuration in eval run comparisons and lets project environments pin exact skill revisions** — the pieces users need to connect a regression to a skill edit or to compare two revisions side by side.
> 
> **Run comparison** adds a **Skill changes** block above Cases when the API returns skill attribution: added/removed/changed skills with revision moves (`v3 → v4`), hash fallbacks for legacy runs, silence when nothing changed or neither run recorded skills, and a note when one arm ran with skills disabled. **Run plugin snapshot** no longer hides the **skills excluded** badge when there are no pinned plugins.
> 
> **Project environment skills picker** gains a per-selected-skill version control (Latest vs exact revision via optional `versionPins`), lazy-loaded history, and shared **`sameSkillSelection`** (including pins) for composer dirty-checks and the environment editor. **Environment summary** can call out how many skills are pinned to a version. **OpenAPI** documents `versionPins` and the eval compare `skills` payload.
> 
> **Swarm create flow** keys cached resolved environments/journeys with **`buildEnvironmentSelectionKey`**, which now includes version pins so changing only the pinned revision invalidates reuse instead of relaunching against the old revision.
> 
> **Cross-host eval matrix** treats skill slots as ids **plus** pinned revisions (`skillSlotKey` / split labels like `pinned aaaa`), so two environments that differ only by revision split into separate columns instead of merging runs in one cell.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8d5e098d14d22bc8e202dd845d9be383d1ff6f62. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->