### PR TITLE
server doctor: don't blame the server when we're the reason skills went uninspected

### DIFF
--- a/.changeset/doctor-skills-attribution.md
+++ b/.changeset/doctor-skills-attribution.md
@@ -1,0 +1,13 @@
+---
+"@mcpjam/sdk": patch
+---
+
+`server doctor` no longer blames the server when MCPJam is the reason skills went uninspected
+
+The skills check reports `skipped` when Skills over MCP is not active on a connection, which is right — most servers serve no skills and calling that a failure would make the doctor cry wolf on almost every run. But `active` is the AND of two independent declarations, and the check read only that boolean, so one message covered both sides: "the server must declare the extension and the client must advertise it."
+
+That sentence is true and useless in the case that matters. `runServerDoctor` advertises the extension itself, so the only way to reach "server declared, client did not" is a caller who pinned an exact client-capability set — `--host cursor` and friends. That caller is asking "what would this host see", and the honest answer is that the host is the reason there is nothing to see. A server author running the doctor behind a host pin, against a server whose skills serving works perfectly, previously read "not active on this connection" as their own bug.
+
+The two cases now say which side withheld the declaration, and the whole-run status stays `skipped` in both: a host pin is a legitimate way to run the doctor, not a defect in the server being examined. This also settles an internal disagreement — the CLI's `skills` verbs already refuse this exact case by name, so the doctor was contradicting them on the same connection.
+
+The ok line also names its own sampling cap. The check verifies at most five skills, so a 200-skill server used to be summarized as "200 skills discovered. 5 verified against their manifests", which reads as "only 5 of them check out" — a much worse claim about the server than the true one. It now reads "5 of 200 sampled and verified" when the cap bit, and is unchanged when the whole catalog was verified.

--- a/sdk/src/server-doctor.ts
+++ b/sdk/src/server-doctor.ts
@@ -239,11 +239,47 @@ export async function collectConnectedServerDoctorState(
 const DOCTOR_SKILL_VERIFY_SAMPLE = 5;
 
 /**
+ * Why `skills/*` was not attempted, attributed to whoever actually withheld the
+ * declaration.
+ *
+ * `active` is the AND of two independent declarations, so one message covering
+ * both sides reports OUR omission as a fact about the server. That matters more
+ * here than it looks: `runServerDoctor` now advertises the extension itself, so
+ * the only way to reach `declared && !advertised` is a caller that pinned an
+ * exact client-capability set — `--host cursor` and friends. That caller is
+ * asking "what would this host see", and the honest answer is that the host, not
+ * the server, is the reason there is nothing to see. The CLI's `skills` verbs
+ * already refuse that case by name (`applySkillsExtensionCapability`); a doctor
+ * that blamed the server would contradict them on the same connection.
+ *
+ * Status stays `skipped` in every branch. A host pin is a legitimate way to run
+ * the doctor, not a defect in the server being examined.
+ */
+function inactiveSkillsDetail(
+  support: { declared?: boolean; advertised?: boolean } | undefined
+): string {
+  if (support?.declared && !support.advertised) {
+    return (
+      "This server DOES declare Skills over MCP, but the client capabilities " +
+      "pinned for this run did not advertise the extension, so no `skills/*` " +
+      "call was made. Drop the host/capability pin to inspect them."
+    );
+  }
+  if (support && !support.declared) {
+    return "The server does not declare the Skills over MCP extension (`io.modelcontextprotocol/skills`).";
+  }
+  // `getSkillsSupport` threw — we know nothing about either side, so the
+  // original both-sides wording is the only honest one left.
+  return "Skills over MCP is not active on this connection (the server must declare the extension and the client must advertise it).";
+}
+
+/**
  * Skills over MCP (SEP-2640), verified rather than counted.
  *
  * Three outcomes, deliberately distinct:
  *   - extension inactive -> `skipped`, because most servers serve no skills and
- *     that is not a fault;
+ *     that is not a fault. Which SIDE withheld it is named — see
+ *     {@link inactiveSkillsDetail};
  *   - listing works and the sample verifies -> `ok`;
  *   - a skill fails verification -> `error` naming the refusal KIND, since
  *     `digest_mismatch` and `frontmatter_drift` send a server author to
@@ -257,19 +293,16 @@ async function collectSkills(
   manager: MCPClientManager,
   serverId: string
 ): Promise<DoctorSkillsCollectionResult> {
-  let support: { active?: boolean } | undefined;
+  let support:
+    | { active?: boolean; declared?: boolean; advertised?: boolean }
+    | undefined;
   try {
     support = manager.getSkillsSupport(serverId);
   } catch {
     support = undefined;
   }
   if (!support?.active) {
-    return {
-      skills: [],
-      check: skippedCheck(
-        "Skills over MCP is not active on this connection (the server must declare the extension and the client must advertise it)."
-      ),
-    };
+    return { skills: [], check: skippedCheck(inactiveSkillsDetail(support)) };
   }
 
   try {
@@ -295,10 +328,18 @@ async function collectSkills(
     }
 
     const unloadable = listing.skills.filter((skill) => skill.unloadable).length;
+    const loadable = listing.skills.length - unloadable;
     const parts = [describeCount(listing.skills.length, "skill")];
     if (sample.length > 0) {
+      // Name the cap when it bit. "200 skills discovered. 5 verified" reads as
+      // "only 5 of them could be verified", which is a much worse claim than
+      // the true one — that the doctor deliberately stopped at 5.
+      const scope =
+        loadable > sample.length
+          ? `${sample.length} of ${loadable} sampled and verified`
+          : `${sample.length} verified`;
       parts.push(
-        `${sample.length} verified against ${sample.length === 1 ? "its manifest" : "their manifests"}.`
+        `${scope} against ${sample.length === 1 ? "its manifest" : "their manifests"}.`
       );
     }
     if (unloadable > 0) {

--- a/sdk/tests/server-doctor.test.ts
+++ b/sdk/tests/server-doctor.test.ts
@@ -148,6 +148,81 @@ describe("the skills check", () => {
     });
   }
 
+  const markdownFor = (name: string) =>
+    `---\nname: ${name}\ndescription: Skill ${name}.\n---\n# ${name}\n`;
+
+  /** A server serving `count` distinct, individually verifiable skills. */
+  async function manySkillsManager(count: number) {
+    const entries = await Promise.all(
+      Array.from({ length: count }, async (_unused, index) => {
+        const name = `skill-${index + 1}`;
+        const uri = `skill://demo/${name}/SKILL.md`;
+        const markdown = markdownFor(name);
+        return {
+          uri,
+          frontmatter: { name, description: `Skill ${name}.` },
+          resources: [
+            {
+              uri,
+              digest: `sha256:${await sha256(markdown)}`,
+              size: new TextEncoder().encode(markdown).byteLength,
+            },
+          ],
+        };
+      })
+    );
+    const byUri = new Map(entries.map((entry) => [entry.uri, entry]));
+    return createMockManager({
+      getSkillsSupport: jest.fn().mockReturnValue({
+        declared: true,
+        advertised: true,
+        directoryRead: false,
+        active: true,
+      }),
+      listServerSkills: jest.fn().mockResolvedValue({ skills: entries }),
+      getServerSkill: jest
+        .fn()
+        .mockImplementation(async (_serverId: string, uri: string) =>
+          byUri.get(uri)
+        ),
+      readResource: jest
+        .fn()
+        .mockImplementation(
+          async (_serverId: string, params: { uri: string }) => ({
+            contents: [
+              {
+                uri: params.uri,
+                text: markdownFor(params.uri.split("/").at(-2) as string),
+                mimeType: "text/markdown",
+              },
+            ],
+          })
+        ),
+    });
+  }
+
+  it("says how much of the catalog it actually sampled", async () => {
+    // The cap is deliberate, so it has to be visible. "8 skills discovered. 5
+    // verified" reads as "only 5 of them check out" — a far worse claim about
+    // the server than the true one, which is that the doctor stopped at 5.
+    const manager = await manySkillsManager(8);
+
+    const result = await collectConnectedServerDoctorState(manager, "srv");
+
+    expect(result.checks.skills.status).toBe("ok");
+    expect(result.checks.skills.detail).toContain("5 of 8 sampled and verified");
+    expect(result.skills).toHaveLength(8);
+  });
+
+  it("does not claim a sample when it verified the whole catalog", async () => {
+    const manager = await manySkillsManager(2);
+
+    const result = await collectConnectedServerDoctorState(manager, "srv");
+
+    expect(result.checks.skills.detail).toContain("2 verified");
+    expect(result.checks.skills.detail).not.toContain("sampled");
+  });
+
   it("skips when the extension was never negotiated", async () => {
     // Most servers serve no skills. Reporting that as a failure would make the
     // doctor cry wolf on almost every run.
@@ -163,7 +238,31 @@ describe("the skills check", () => {
     const result = await collectConnectedServerDoctorState(manager, "srv");
 
     expect(result.checks.skills.status).toBe("skipped");
+    expect(result.checks.skills.detail).toContain("does not declare");
     expect(result.skills).toEqual([]);
+  });
+
+  it("blames the capability pin, not the server, when we were the ones who did not ask", async () => {
+    // `active` is the AND of two declarations, so a single message for both
+    // sides reports our own omission as a fact about the server. A server
+    // author running the doctor behind `--host cursor` against a server that
+    // serves skills perfectly well must not read "not active" as their bug.
+    const manager = createMockManager({
+      getSkillsSupport: jest.fn().mockReturnValue({
+        declared: true,
+        advertised: false,
+        directoryRead: false,
+        active: false,
+      }),
+    });
+
+    const result = await collectConnectedServerDoctorState(manager, "srv");
+
+    expect(result.checks.skills.status).toBe("skipped");
+    expect(result.checks.skills.detail).toContain("DOES declare");
+    expect(result.checks.skills.detail).toContain("pinned for this run");
+    // The failure this guards against is the detail reading as a server defect.
+    expect(result.checks.skills.detail).not.toContain("does not declare");
   });
 
   it("verifies the skills it lists, rather than counting them", async () => {


### PR DESCRIPTION
Follow-up to #4433, review finding.

## The problem

`collectSkills` reads only `support.active` and emits one message for two different situations:

> Skills over MCP is not active on this connection (the server must declare the extension and the client must advertise it).

`active` is the AND of two independent declarations, so that one sentence reports **our** omission as a fact about the server.

The case that matters is not hypothetical. `runServerDoctor` advertises the extension itself now, so the only way to reach `declared && !advertised` is a caller who pinned an exact client-capability set — `--host cursor` and friends. That caller is asking *"what would this host see"*, and the honest answer is that the host, not the server, is why there is nothing to see. A server author running the doctor behind a host pin, against a server whose skills serving works fine, reads "not active on this connection" as their own bug.

It was also an internal contradiction: the CLI's `skills` verbs already refuse this exact case by name (`applySkillsExtensionCapability`, added in #4433), so the doctor disagreed with them on the same connection.

## The fix

`SkillsSupport` already carries `declared` and `advertised` separately, so this is a message split, not new plumbing:

| state | detail |
|---|---|
| `declared && !advertised` | names the capability pin as the cause, and says the server *does* serve skills |
| `!declared` | the server does not declare the extension |
| `getSkillsSupport` threw | the original both-sides wording — the only branch that still deserves it |

**Status stays `skipped` in every branch.** A host pin is a legitimate way to run the doctor, not a defect in the server being examined, and a wording fix should not start failing runs.

## Also: the sampling cap now names itself

The check verifies at most 5 skills. A 200-skill server was summarized as "200 skills discovered. 5 verified against their manifests", which reads as *only 5 of them check out* — a much worse claim about the server than the true one. It now reads "5 of 200 sampled and verified" when the cap bit, and is unchanged when the whole catalog was verified.

## Verification

Four new cases in `sdk/tests/server-doctor.test.ts`, each of which fails against `main`:

- the pin case names the pin and does **not** read as a server defect
- the undeclared case says the server does not declare
- an 8-skill catalog reports "5 of 8 sampled and verified"
- a 2-skill catalog says "2 verified" and never says "sampled"

`sdk/tests/server-doctor.test.ts` 13/13 green; full SDK suite 6,825 passing; `npm run typecheck -w @mcpjam/sdk` clean.

**Pre-existing, unrelated:** `sdk/tests/browser-entry-guard.test.ts` fails on a clean checkout of `main` in the same worktree (browser entry import graph reaching `xml-crypto`/`@xmldom/xpath`). Verified by stashing this change and re-running. Not touched here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> User-facing doctor copy and test coverage only; no change to skills RPC behavior or overall doctor status semantics.
> 
> **Overview**
> **`server doctor` skills check** no longer uses one generic “not active” line when Skills over MCP was skipped. It now uses `inactiveSkillsDetail` to say whether the **server** omitted the extension, the **client capability pin** (e.g. `--host cursor`) blocked advertising, or both sides are unknown after `getSkillsSupport` fails. Status stays **`skipped`** in all of those cases.
> 
> When verification hits the five-skill cap, the **ok** detail now says **`N of M sampled and verified`** instead of wording that sounds like only N skills passed; full-catalog runs still say **`N verified`** without “sampled”.
> 
> Tests cover the pin case, undeclared server, sampling cap, and full-catalog wording; changeset bumps **`@mcpjam/sdk`** patch.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 95d922442bf3fff5886cf00b87468b1e2e9df201. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the `server doctor` skills check so it names the side that withheld its Skills over MCP declaration, instead of reporting MCPJam's own capability-pin omission as a server defect.

**Details**
- `declared && !advertised` (a pinned host/capability set) now names the pin and says the server does serve skills.
- `!declared` now says the server does not declare the extension; the original both-sides wording survives only when `getSkillsSupport` threw.
- Status stays `skipped` in every branch.
- The sampling message now reads "5 of 200 sampled and verified" when the cap bites, and stays "N verified" when the whole catalog was checked.

<sup>Written for commit 95d922442bf3fff5886cf00b87468b1e2e9df201. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/MCPJam/inspector/pull/4436?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

