### PR TITLE
Skills rows carry their origin, and re-list when the handshake changes

### DIFF
--- a/.changeset/skills-rows-carry-their-origin.md
+++ b/.changeset/skills-rows-carry-their-origin.md
@@ -1,0 +1,13 @@
+---
+"@mcpjam/inspector": patch
+---
+
+Server-served skills re-list when the connection re-negotiates, and each row names the server it came from
+
+**The listing could answer for a handshake that had already changed.** `support.active` is `client advertised ∧ server declared`, and the client half comes from the hosted api-context, which hydrates from a Convex query. A listing issued on mount could go out before the host config landed — advertising the SDK defaults, which deliberately omit `io.modelcontextprotocol/skills` — and come back `active: false` for a reason that stopped being true a moment later. Nothing re-ran it, because the refetch key was the connected-server set, and a capability change is not a connection change to that key. The symptom was a row that appeared while loading and vanished when the answer arrived, with no way back: the only refresh button lived inside the row it had just hidden.
+
+The section now folds the api-context revision into that key, the same `useSyncExternalStore` subscription `useAggregatedTools` uses, for the same reason — a catalog is a fact about a *negotiated connection*, not about a server id.
+
+**Provenance moved onto the row.** The "From MCP servers" heading and the per-server group headers are gone; each skill row carries a server icon and its origin server's label instead. A skill's provenance is the reason its content is untrusted third-party input, and that stays true wherever the row is read — a heading only says it while you are underneath it. Refusals, rejected entries, duplicate URIs and the load-by-URI input keep their per-server wording inline.
+
+With the group headers went their refresh buttons, so the tab's single refresh control now re-reads both halves — and it stays visible when `skills-enabled` hides the project store, since the server skills are exactly what is on screen in that case.

--- a/mcpjam-inspector/client/src/components/SkillsTab.tsx
+++ b/mcpjam-inspector/client/src/components/SkillsTab.tsx
@@ -134,6 +134,15 @@ export function SkillsTab({
   const [isDeleting, setIsDeleting] = useState(false);
 
   // File browsing state - now stores files per skill
+  /**
+   * Bumped by the header's refresh control.
+   *
+   * The server-skills rows have no refresh of their own — they sit in the list
+   * without a group header to hang one on — so the tab's single control has to
+   * reach both halves. It is a counter rather than a callback because the
+   * section owns its own per-connection fetch state.
+   */
+  const [refreshToken, setRefreshToken] = useState(0);
   const [skillFiles, setSkillFiles] = useState<Record<string, SkillFile[]>>({});
   const [loadingFiles, setLoadingFiles] = useState<Record<string, boolean>>({});
   const [selectedFilePath, setSelectedFilePath] = useState<string>("SKILL.md");
@@ -491,47 +500,54 @@ export function SkillsTab({
                   </Badge>
                 )}
               </div>
-              {/* Upload, refresh and the Local/Cloud toggle all act on the
-                  project store, so they go with it. `ServerSkillsSection`
-                  carries its own per-origin refresh. */}
-              {!cloudStoreHidden && (
-                <div className="flex items-center gap-1">
-                  {showSourceToggle && (
-                    <ViewModeSelector
-                      value={source}
-                      ariaLabel="Skills source"
-                      indicatorId="skills-source"
-                      onChange={(next) => setSource(next)}
-                      options={[
-                        { value: "local", label: "Local" },
-                        { value: "cloud", label: "Cloud" },
-                      ]}
-                      className="mr-1"
-                    />
-                  )}
-                  <Button
-                    onClick={() => setIsUploadDialogOpen(true)}
-                    variant="ghost"
-                    size="sm"
-                    title="Upload skill"
-                    disabled={cloudUnavailable}
-                  >
-                    <Plus className="h-3 w-3 cursor-pointer" />
-                  </Button>
-                  <Button
-                    onClick={() => fetchSkills()}
-                    variant="ghost"
-                    size="sm"
-                    disabled={fetchingSkills}
-                  >
-                    <RefreshCw
-                      className={`h-3 w-3 ${
-                        fetchingSkills ? "animate-spin" : ""
-                      } cursor-pointer`}
-                    />
-                  </Button>
-                </div>
-              )}
+              {/* Upload and the Local/Cloud toggle act on the project store,
+                  so they go with it. Refresh does NOT: it re-reads the server
+                  skills too, and those are exactly what is on screen when the
+                  project store is hidden. */}
+              <div className="flex items-center gap-1">
+                {!cloudStoreHidden && (
+                  <>
+                    {showSourceToggle && (
+                      <ViewModeSelector
+                        value={source}
+                        ariaLabel="Skills source"
+                        indicatorId="skills-source"
+                        onChange={(next) => setSource(next)}
+                        options={[
+                          { value: "local", label: "Local" },
+                          { value: "cloud", label: "Cloud" },
+                        ]}
+                        className="mr-1"
+                      />
+                    )}
+                    <Button
+                      onClick={() => setIsUploadDialogOpen(true)}
+                      variant="ghost"
+                      size="sm"
+                      title="Upload skill"
+                      disabled={cloudUnavailable}
+                    >
+                      <Plus className="h-3 w-3 cursor-pointer" />
+                    </Button>
+                  </>
+                )}
+                <Button
+                  onClick={() => {
+                    void fetchSkills();
+                    setRefreshToken((n) => n + 1);
+                  }}
+                  variant="ghost"
+                  size="sm"
+                  title="Refresh skills"
+                  disabled={fetchingSkills}
+                >
+                  <RefreshCw
+                    className={`h-3 w-3 ${
+                      fetchingSkills ? "animate-spin" : ""
+                    } cursor-pointer`}
+                  />
+                </Button>
+              </div>
             </div>
 
             {/* Unified Tree */}
@@ -575,12 +591,16 @@ export function SkillsTab({
                       onExpandSkill={handleExpandSkill}
                     />
                   )}
-                  {/* Skills over MCP (SEP-2640). Rendered outside the tree:
+                  {/* Skills over MCP (SEP-2640). Rendered outside the tree —
                       these are identified by URI rather than by name and carry
-                      a verification state the tree has no vocabulary for. */}
+                      a verification state the tree has no vocabulary for — but
+                      NOT under a heading of their own: each row carries its
+                      origin server instead, so provenance travels with the
+                      skill rather than with the reader's scroll position. */}
                   <ServerSkillsSection
                     servers={mcpServers ?? []}
                     {...(projectId ? { projectId } : {})}
+                    refreshToken={refreshToken}
                     onOpenSkill={handleOpenServerSkill}
                   />
                 </div>

--- a/mcpjam-inspector/client/src/components/skills/ServerSkillsSection.tsx
+++ b/mcpjam-inspector/client/src/components/skills/ServerSkillsSection.tsx
@@ -12,18 +12,26 @@
  * check renders its specific violation instead of appearing to load.
  */
 
-import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import {
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+  useSyncExternalStore,
+} from "react";
 import { Badge } from "@mcpjam/design-system/badge";
 import { Button } from "@mcpjam/design-system/button";
 import {
   AlertTriangle,
-  ChevronDown,
-  ChevronRight,
   Link2,
-  RefreshCw,
   Server,
   ShieldCheck,
 } from "lucide-react";
+import {
+  getApiContextRevision,
+  subscribeApiContext,
+} from "@/lib/apis/web/context";
 import {
   getServerSkill,
   listServerSkills,
@@ -44,6 +52,14 @@ export interface ServerSkillsSectionServer {
 interface Props {
   servers: ServerSkillsSectionServer[];
   projectId?: string;
+  /**
+   * Bumped by the tab's refresh control to re-list every server.
+   *
+   * There is no per-server refresh button any more — the rows carry their
+   * origin instead of sitting under a header that could hold one — so this is
+   * the only manual re-read, and it has to reach here.
+   */
+  refreshToken?: number;
   /** Renders a loaded skill in the right-hand viewer. */
   onOpenSkill?: (skill: VerifiedServerSkill, serverLabel: string) => void;
 }
@@ -57,10 +73,29 @@ type ServerState =
 export function ServerSkillsSection({
   servers,
   projectId,
+  refreshToken,
   onOpenSkill,
 }: Props) {
+  /**
+   * The hosted request context, as a version.
+   *
+   * `buildServerRequest` reads `clientCapabilities` from this context, and
+   * whether THIS host declares `io.modelcontextprotocol/skills` is half of the
+   * mutual declaration that decides `support.active`. The context hydrates
+   * from a Convex query, so a listing issued on mount can go out before the
+   * host config lands — advertising the SDK defaults, which deliberately omit
+   * the skills extension. The answer then says `active: false` for a reason
+   * that stopped being true a moment later, and nothing re-ran it.
+   *
+   * Same subscription `useAggregatedTools` uses, for the same reason: a
+   * catalog is a fact about a NEGOTIATED CONNECTION, not about a server id.
+   */
+  const apiContextRevision = useSyncExternalStore(
+    subscribeApiContext,
+    getApiContextRevision,
+    getApiContextRevision
+  );
   const [byServer, setByServer] = useState<Record<string, ServerState>>({});
-  const [collapsed, setCollapsed] = useState<Record<string, boolean>>({});
   const [uriInput, setUriInput] = useState<Record<string, string>>({});
   const [refusal, setRefusal] = useState<
     Record<string, ServerSkillRefusal | undefined>
@@ -133,7 +168,13 @@ export function ServerSkillsSection({
    * connection's catalog — the catalog is a live fact about a connection, not
    * about a server id.
    */
-  const connectedSignature = connected.map((s) => s.serverId).join("|");
+  const connectedSignature = [
+    connected.map((s) => s.serverId).join("|"),
+    // A capability change re-negotiates the connection, so its previous answer
+    // is about a handshake that no longer describes us.
+    `rev:${apiContextRevision}`,
+    `refresh:${refreshToken ?? 0}`,
+  ].join("#");
   const seenSignature = useRef<string>("");
 
   useEffect(() => {
@@ -214,183 +255,132 @@ export function ServerSkillsSection({
   if (connected.length === 0) return null;
 
   return (
-    <div className="mt-4 border-t border-border pt-3">
-      <div className="px-2 pb-2 flex items-center gap-2">
-        <Server className="h-3 w-3 text-muted-foreground" />
-        <span className="text-[11px] font-semibold uppercase tracking-wide text-muted-foreground">
-          From MCP servers
-        </span>
-      </div>
-
+    <>
       {connected.map((server) => {
         const state = byServer[server.serverId] ?? { status: "idle" };
-        const isCollapsed = collapsed[server.serverId] === true;
         const listing = state.status === "ready" ? state.listing : undefined;
 
-        // A server that never declared the extension is not shown as an empty
-        // catalog — that would read as "this server has no skills", which is a
-        // different fact from "no skills conversation happened here".
+        // A server that never declared the extension contributes nothing —
+        // not an empty group. "This host and server never had a skills
+        // conversation" is a different fact from "this server has no skills",
+        // and a heading over nothing asserts the second.
         if (listing && !listing.support.active) {
           return null;
         }
 
         return (
-          <div key={server.serverId} className="mb-2">
-            <div className="flex items-center gap-1 px-2 py-1">
-              <button
-                type="button"
-                className="flex items-center gap-1 min-w-0 flex-1 text-left"
-                onClick={() =>
-                  setCollapsed((prev) => ({
-                    ...prev,
-                    [server.serverId]: !isCollapsed,
-                  }))
+          <div key={server.serverId}>
+            {state.status === "error" && (
+              <p className="text-[11px] text-destructive py-1 px-2">
+                {server.label}: {state.message}
+              </p>
+            )}
+
+            {listing?.skills.map((skill) => (
+              <SkillRow
+                key={skill.skillUri}
+                skill={skill}
+                origin={server.label}
+                onOpen={() =>
+                  void openSkill(server.serverId, server.label, skill.skillUri)
                 }
-              >
-                {isCollapsed ? (
-                  <ChevronRight className="h-3 w-3 flex-shrink-0" />
-                ) : (
-                  <ChevronDown className="h-3 w-3 flex-shrink-0" />
-                )}
-                <span className="text-xs font-medium truncate">
-                  {server.label}
+              />
+            ))}
+
+            {listing && listing.skills.length === 0 && (
+              <p className="text-[11px] text-muted-foreground py-1 px-2">
+                {server.label} declares the skills extension but listed none. A
+                listing may be partial — try loading a skill by URI.
+              </p>
+            )}
+
+            {/* A duplicated URI is a server bug, surfaced rather than silently
+                resolved by picking a winner. */}
+            {listing && listing.duplicateUris.length > 0 && (
+              <div className="flex items-start gap-1 py-1 px-2 text-[11px] text-amber-600 dark:text-amber-400">
+                <AlertTriangle className="h-3 w-3 mt-0.5 flex-shrink-0" />
+                <span>
+                  {server.label} listed these more than once, so both copies
+                  were rejected: {listing.duplicateUris.join(", ")}
                 </span>
-                {listing && (
-                  <Badge
-                    variant="secondary"
-                    className="text-[10px] flex-shrink-0"
-                  >
-                    {listing.skills.length}
-                  </Badge>
-                )}
-              </button>
-              <Button
-                variant="ghost"
-                size="sm"
-                title="Refresh this server's skills"
-                onClick={() => void load(server.serverId)}
-                disabled={state.status === "loading"}
-              >
-                <RefreshCw
-                  className={`h-3 w-3 ${
-                    state.status === "loading" ? "animate-spin" : ""
-                  }`}
-                />
-              </Button>
-            </div>
-
-            {!isCollapsed && (
-              <div className="pl-5 pr-2">
-                {state.status === "error" && (
-                  <p className="text-[11px] text-destructive py-1">
-                    {state.message}
-                  </p>
-                )}
-
-                {listing?.skills.map((skill) => (
-                  <SkillRow
-                    key={skill.skillUri}
-                    skill={skill}
-                    onOpen={() =>
-                      void openSkill(
-                        server.serverId,
-                        server.label,
-                        skill.skillUri
-                      )
-                    }
-                  />
-                ))}
-
-                {listing && listing.skills.length === 0 && (
-                  <p className="text-[11px] text-muted-foreground py-1">
-                    This server declares the skills extension but listed none. A
-                    listing may be partial — try loading a skill by URI.
-                  </p>
-                )}
-
-                {/* A duplicated URI is a server bug, surfaced rather than
-                    silently resolved by picking a winner. */}
-                {listing && listing.duplicateUris.length > 0 && (
-                  <div className="flex items-start gap-1 py-1 text-[11px] text-amber-600 dark:text-amber-400">
-                    <AlertTriangle className="h-3 w-3 mt-0.5 flex-shrink-0" />
-                    <span>
-                      Listed more than once, so both copies were rejected:{" "}
-                      {listing.duplicateUris.join(", ")}
-                    </span>
-                  </div>
-                )}
-
-                {listing?.rejected.map((entry) => (
-                  <div
-                    key={`${entry.skillUri}:${entry.reason}`}
-                    className="flex items-start gap-1 py-1 text-[11px] text-amber-600 dark:text-amber-400"
-                  >
-                    <AlertTriangle className="h-3 w-3 mt-0.5 flex-shrink-0" />
-                    <span>
-                      {entry.skillUri || "(entry with no URI)"}: {entry.reason}
-                    </span>
-                  </div>
-                ))}
-
-                {/* Load by URI. This is not a convenience: `skills/get` answers
-                    for skills a listing never mentioned, and a URI can arrive
-                    from a server's instructions or from another skill. */}
-                <div className="flex items-center gap-1 py-1">
-                  <Link2 className="h-3 w-3 text-muted-foreground flex-shrink-0" />
-                  <input
-                    value={uriInput[server.serverId] ?? ""}
-                    aria-label={`Load a skill from ${server.label} by URI`}
-                    onKeyDown={(event) => {
-                      if (event.key !== "Enter") return;
-                      const uri = (uriInput[server.serverId] ?? "").trim();
-                      if (!uri) return;
-                      void openSkill(server.serverId, server.label, uri);
-                    }}
-                    onChange={(event) =>
-                      setUriInput((prev) => ({
-                        ...prev,
-                        [server.serverId]: event.target.value,
-                      }))
-                    }
-                    placeholder="Load by URI (skill://…)"
-                    className="flex-1 min-w-0 bg-transparent text-[11px] outline-none border-b border-transparent focus:border-border py-0.5"
-                  />
-                  <Button
-                    variant="ghost"
-                    size="sm"
-                    disabled={
-                      !(uriInput[server.serverId] ?? "").trim() ||
-                      opening[server.serverId] === true
-                    }
-                    onClick={() =>
-                      void openSkill(
-                        server.serverId,
-                        server.label,
-                        (uriInput[server.serverId] ?? "").trim()
-                      )
-                    }
-                  >
-                    Load
-                  </Button>
-                </div>
-
-                {refusal[server.serverId] && (
-                  <RefusalNotice refusal={refusal[server.serverId]!} />
-                )}
               </div>
+            )}
+
+            {listing?.rejected.map((entry) => (
+              <div
+                key={`${entry.skillUri}:${entry.reason}`}
+                className="flex items-start gap-1 py-1 px-2 text-[11px] text-amber-600 dark:text-amber-400"
+              >
+                <AlertTriangle className="h-3 w-3 mt-0.5 flex-shrink-0" />
+                <span>
+                  {entry.skillUri || "(entry with no URI)"}: {entry.reason}
+                </span>
+              </div>
+            ))}
+
+            {/* Load by URI. Not a convenience: `skills/get` answers for skills
+                a listing never mentioned, and a URI can arrive from a server's
+                instructions or from another skill. Kept per server because the
+                URI is only meaningful against the origin that serves it. */}
+            {listing && (
+              <div className="flex items-center gap-1 py-1 px-2">
+                <Link2 className="h-3 w-3 text-muted-foreground flex-shrink-0" />
+                <input
+                  value={uriInput[server.serverId] ?? ""}
+                  aria-label={`Load a skill from ${server.label} by URI`}
+                  onKeyDown={(event) => {
+                    if (event.key !== "Enter") return;
+                    const uri = (uriInput[server.serverId] ?? "").trim();
+                    if (!uri) return;
+                    void openSkill(server.serverId, server.label, uri);
+                  }}
+                  onChange={(event) =>
+                    setUriInput((prev) => ({
+                      ...prev,
+                      [server.serverId]: event.target.value,
+                    }))
+                  }
+                  placeholder={`Load from ${server.label} by URI (skill://…)`}
+                  className="flex-1 min-w-0 bg-transparent text-[11px] outline-none border-b border-transparent focus:border-border py-0.5"
+                />
+                <Button
+                  variant="ghost"
+                  size="sm"
+                  disabled={
+                    !(uriInput[server.serverId] ?? "").trim() ||
+                    opening[server.serverId] === true
+                  }
+                  onClick={() =>
+                    void openSkill(
+                      server.serverId,
+                      server.label,
+                      (uriInput[server.serverId] ?? "").trim()
+                    )
+                  }
+                >
+                  Load
+                </Button>
+              </div>
+            )}
+
+            {refusal[server.serverId] && (
+              <RefusalNotice refusal={refusal[server.serverId]!} />
             )}
           </div>
         );
       })}
-    </div>
+    </>
   );
 }
 
 function SkillRow({
   skill,
+  origin,
   onOpen,
 }: {
   skill: ServerSkillSummary;
+  /** The user-assigned label of the server serving this skill. */
+  origin: string;
   onOpen: () => void;
 }) {
   return (
@@ -402,9 +392,24 @@ function SkillRow({
       className="w-full text-left py-1 group disabled:cursor-not-allowed disabled:opacity-60"
     >
       <div className="flex items-center gap-1.5 min-w-0">
+        {/* Origin, on the row rather than in a heading above a group. A
+            skill's provenance travels with the skill: it is the reason its
+            content is untrusted third-party input, and it stays true wherever
+            the row is read. A heading only says it while you are under it. */}
+        <Server
+          className="h-3 w-3 flex-shrink-0 text-muted-foreground"
+          aria-hidden
+        />
         <span className="text-xs truncate group-hover:underline">
           {skill.name}
         </span>
+        <Badge
+          variant="secondary"
+          className="text-[10px] flex-shrink-0 font-normal"
+          title={`Served over MCP by ${origin}`}
+        >
+          {origin}
+        </Badge>
         {skill.unloadable ? (
           <Badge
             variant="outline"

--- a/mcpjam-inspector/client/src/components/skills/__tests__/ServerSkillsSection.test.tsx
+++ b/mcpjam-inspector/client/src/components/skills/__tests__/ServerSkillsSection.test.tsx
@@ -1,0 +1,129 @@
+/**
+ * Two properties this section has to hold, both learned the hard way.
+ *
+ * 1. A catalog is a fact about a NEGOTIATED CONNECTION. `support.active` is
+ *    `client advertised ∧ server declared`, and the client half comes from the
+ *    hosted api-context, which hydrates asynchronously. A listing issued
+ *    before it lands advertises the SDK defaults — which deliberately omit the
+ *    skills extension — and answers `active: false` for a reason that stopped
+ *    being true a moment later. Nothing used to re-run it, and the row it hid
+ *    was where the only refresh button lived.
+ *
+ * 2. Provenance rides the ROW. There is no "From MCP servers" heading any
+ *    more, so each row states the server it came from.
+ */
+import { render, screen, waitFor } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const { listServerSkills, apiContext } = vi.hoisted(() => ({
+  listServerSkills: vi.fn(),
+  apiContext: { revision: 0, listeners: new Set<() => void>() },
+}));
+
+vi.mock("@/lib/apis/server-skills-api", () => ({
+  listServerSkills: (...args: unknown[]) => listServerSkills(...args),
+  getServerSkill: vi.fn(),
+}));
+
+vi.mock("@/lib/apis/web/context", () => ({
+  getApiContextRevision: () => apiContext.revision,
+  subscribeApiContext: (listener: () => void) => {
+    apiContext.listeners.add(listener);
+    return () => apiContext.listeners.delete(listener);
+  },
+}));
+
+import { ServerSkillsSection } from "../ServerSkillsSection";
+
+const SERVERS = [{ serverId: "s1", label: "staging", connected: true }];
+
+function listing(active: boolean, names: string[] = []) {
+  return {
+    support: {
+      declared: true,
+      advertised: active,
+      directoryRead: false,
+      active,
+    },
+    serverId: "s1",
+    skills: names.map((name) => ({
+      serverId: "s1",
+      skillUri: `skill://mcpjam/${name}/SKILL.md`,
+      name,
+      description: `${name} description`,
+      frontmatter: {},
+      resources: [{ uri: `skill://mcpjam/${name}/SKILL.md`, digest: "d" }],
+    })),
+    duplicateUris: [],
+    rejected: [],
+  };
+}
+
+/** Mirrors what the real context does when the host config lands. */
+function bumpApiContext() {
+  apiContext.revision += 1;
+  for (const listener of apiContext.listeners) listener();
+}
+
+beforeEach(() => {
+  apiContext.revision = 0;
+  apiContext.listeners.clear();
+  listServerSkills.mockReset();
+});
+
+afterEach(() => vi.clearAllMocks());
+
+describe("ServerSkillsSection", () => {
+  it("re-lists when the advertised capabilities change", async () => {
+    // First answer: the host had not yet declared the extension.
+    listServerSkills.mockResolvedValueOnce(listing(false));
+    render(<ServerSkillsSection servers={SERVERS} projectId="p1" />);
+
+    await waitFor(() => expect(listServerSkills).toHaveBeenCalledTimes(1));
+    // Nothing is shown, correctly: this connection never had the conversation.
+    expect(screen.queryByText("run-evals")).not.toBeInTheDocument();
+
+    // The host config lands and the context re-negotiates.
+    listServerSkills.mockResolvedValueOnce(listing(true, ["run-evals"]));
+    bumpApiContext();
+
+    await waitFor(() => expect(listServerSkills).toHaveBeenCalledTimes(2));
+    expect(await screen.findByText("run-evals")).toBeInTheDocument();
+  });
+
+  it("re-lists when the tab's refresh control fires", async () => {
+    listServerSkills.mockResolvedValue(listing(true, ["run-evals"]));
+    const { rerender } = render(
+      <ServerSkillsSection servers={SERVERS} projectId="p1" refreshToken={0} />
+    );
+    await waitFor(() => expect(listServerSkills).toHaveBeenCalledTimes(1));
+
+    rerender(
+      <ServerSkillsSection servers={SERVERS} projectId="p1" refreshToken={1} />
+    );
+    await waitFor(() => expect(listServerSkills).toHaveBeenCalledTimes(2));
+  });
+
+  it("marks each row with the server it came from, under no heading", async () => {
+    listServerSkills.mockResolvedValue(listing(true, ["run-evals"]));
+    render(<ServerSkillsSection servers={SERVERS} projectId="p1" />);
+
+    expect(await screen.findByText("run-evals")).toBeInTheDocument();
+    // The origin is on the row itself, so it stays true wherever the row is
+    // read — a heading only says it while you are underneath it.
+    expect(screen.getByText("staging")).toBeInTheDocument();
+    expect(screen.queryByText(/from mcp servers/i)).not.toBeInTheDocument();
+  });
+
+  it("renders nothing at all when no connected server declares it", async () => {
+    listServerSkills.mockResolvedValue(listing(false));
+    const { container } = render(
+      <ServerSkillsSection servers={SERVERS} projectId="p1" />
+    );
+    await waitFor(() => expect(listServerSkills).toHaveBeenCalled());
+    // "This host and server never had a skills conversation" is a different
+    // fact from "this server has no skills"; a heading over nothing asserts
+    // the second.
+    await waitFor(() => expect(container.textContent).toBe(""));
+  });
+});


### PR DESCRIPTION
Follow-up to #4435. Two changes, one of which is the reason the section was blank on staging even after that merged.

## The listing could answer for a handshake that had already changed

`support.active` is `client advertised ∧ server declared`. The client half comes from `apiContext.clientCapabilities`, which hydrates from a Convex query — so a listing issued on mount can go out **before the host config lands**, advertising `getDefaultClientCapabilities()`, which deliberately omits `io.modelcontextprotocol/skills` (SEP-2133 makes extension support opt-in and the bare SDK ships no fulfiller).

The answer then says `active: false` for a reason that stopped being true a moment later. Nothing re-ran it: the refetch key was the connected-server set, and a capability change is not a connection change to that key.

The observable symptom, which is what finally identified it — **a row appears while the listing is loading, then vanishes when it arrives**. In `idle`/`loading` there is no `listing`, so the hide branch can't fire; the moment the answer lands, `if (listing && !listing.support.active) return null` removes it. And the only refresh button lived *inside* the row it had just hidden, so there was no way back.

Fixed by folding the api-context revision into the refetch key, through the same `useSyncExternalStore(subscribeApiContext, getApiContextRevision)` subscription `useAggregatedTools` already uses — for the same reason. A catalog is a fact about a **negotiated connection**, not about a server id, which is exactly why reconnects are already in that key.

## Provenance moved onto the row

The `FROM MCP SERVERS` heading and the per-server group headers are gone. Each skill row carries a server icon and its origin server's label instead.

A skill's provenance is the reason its content is untrusted third-party input, and that stays true wherever the row is read — a heading only says it while you are underneath it. Refusals, rejected entries, duplicate URIs and the load-by-URI input keep their per-server wording inline, so nothing that named a server stopped naming it.

With the group headers went their refresh buttons, so the tab's single refresh control now re-reads both halves. It also moves **outside** the `skills-enabled` gate #4432 added: when that flag hides the project store, the server skills are exactly what is on screen, and hiding their only refresh with the upload button was wrong.

A connection where the extension is not mutually declared still renders nothing at all — deliberately. "This host and server never had a skills conversation" is a different fact from "this server has no skills", and a heading over nothing asserts the second.

## Tests

`ServerSkillsSection.test.tsx` (new, 4 cases): re-lists when the advertised capabilities change; re-lists on the refresh token; each row names its origin and no heading survives; an undeclared connection renders empty. **Verified to fail without the fix** — the two refetch cases go red when the revision and token are dropped from the key.

Full client suite: 611 files, 6,646 passed, 23 skipped, 0 failed.


🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Inspector client-only changes to skills listing timing and layout; verified-path loading behavior is unchanged.
> 
> **Overview**
> Fixes server-served skills **vanishing after load** when the first listing used pre-hydration client capabilities (SDK defaults without `io.modelcontextprotocol/skills`), then answered `support.active: false` with no refetch. **`ServerSkillsSection`** now includes **api-context revision** in its refetch signature via `useSyncExternalStore`, matching **`useAggregatedTools`**, so listings rerun when negotiated capabilities change.
> 
> **UI/provenance:** Removes the "From MCP servers" section heading, per-server collapsible groups, and per-server refresh controls. Each server skill row shows a **server icon** and **origin label** badge; errors, empty lists, duplicates, and load-by-URI copy still name the server inline.
> 
> **Skills tab refresh:** A shared **`refreshToken`** bumps on header refresh so one control reloads **project skills and all server catalogs**; refresh stays visible when `skills-enabled` hides the project store (server skills are the only list). Adds **`ServerSkillsSection.test.tsx`** for capability-driven re-list, refresh token, row provenance, and inactive-extension empty render.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f9de3675f1895d6f3b1d11e83a8684eee31f00bc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the server-skill listing answering for an outdated handshake, and moves each skill's provenance onto its own row.

- The refetch key now includes the api-context revision and a tab-level refresh token, so a hosted config change or a manual refresh re-lists every server.
- Each skill row now shows its origin server's icon and label; the "From MCP servers" and per-server group headers are gone.
- The tab's single refresh control now re-reads both the project store and server skills, and stays visible when the project store is hidden.
- Adds four tests: capability-change re-listing, refresh-token re-listing, row-level provenance without headings, and an empty undeclared-connection case.

<sup>Written for commit f9de3675f1895d6f3b1d11e83a8684eee31f00bc. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/MCPJam/inspector/pull/4440?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

