### PR TITLE
Fix/mcpjam elicitation default

### DIFF
--- a/mcpjam-inspector/client/src/components/hosts/redesigned/focus/__tests__/UpdateHostToLatestButton.test.tsx
+++ b/mcpjam-inspector/client/src/components/hosts/redesigned/focus/__tests__/UpdateHostToLatestButton.test.tsx
@@ -310,6 +310,10 @@ describe("UpdateHostToLatestButton", () => {
     );
 
     expect(draftRef.current).toEqual(catalogDraftFor("mcpjam"));
+    expect(draftRef.current.clientCapabilities.elicitation).toEqual({
+      form: {},
+      url: {},
+    });
   });
 
   it("stays enabled when only the display name needs updating", async () => {

--- a/sdk/src/host-compat/catalog.generated.ts
+++ b/sdk/src/host-compat/catalog.generated.ts
@@ -64,6 +64,10 @@ export const BUNDLED_HOST_COMPAT_CATALOG = {
         requestTimeout: 10000,
       },
       clientCapabilities: {
+        elicitation: {
+          form: {},
+          url: {},
+        },
         extensions: {
           "io.modelcontextprotocol/ui": {
             mimeTypes: ["text/html;profile=mcp-app"],

--- a/sdk/src/host-config/templates/seed-host-template.ts
+++ b/sdk/src/host-config/templates/seed-host-template.ts
@@ -414,6 +414,11 @@ export const HOST_TEMPLATES: readonly HostTemplate[] = [
       // MCP UI extension intact.
       base.clientCapabilities = {
         ...base.clientCapabilities,
+        // MCPJam has both local and hosted bridges for form and URL
+        // elicitation. URL mode is narrowed or rejected on legacy protocol
+        // connections, so this only declares modes the active bridge can
+        // safely handle.
+        elicitation: { form: {}, url: {} },
         extensions: {
           ...(base.clientCapabilities.extensions as Record<string, unknown>),
           [XAA_MCP_EXTENSION]: {},

--- a/sdk/tests/__snapshots__/host-config-seed-host-template.test.ts.snap
+++ b/sdk/tests/__snapshots__/host-config-seed-host-template.test.ts.snap
@@ -2682,6 +2682,10 @@ exports[`seedHostTemplate > seed output matches the committed golden snapshot 1`
     "builtInToolIds": [],
     "chatUiOverride": undefined,
     "clientCapabilities": {
+      "elicitation": {
+        "form": {},
+        "url": {},
+      },
       "extensions": {
         "io.modelcontextprotocol/enterprise-managed-authorization": {},
         "io.modelcontextprotocol/ui": {
@@ -2868,6 +2872,10 @@ exports[`seedHostTemplate > seed output matches the committed golden snapshot 1`
     "builtInToolIds": [],
     "chatUiOverride": undefined,
     "clientCapabilities": {
+      "elicitation": {
+        "form": {},
+        "url": {},
+      },
       "extensions": {
         "io.modelcontextprotocol/enterprise-managed-authorization": {},
         "io.modelcontextprotocol/ui": {


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Advertises elicitation support for MCPJam so hosts can offer form and URL elicitation alongside the MCP UI extension.

- MCPJam's host template and bundled catalog now declare `elicitation: { form: {}, url: {} }`; URL mode is only advertised where the active bridge can safely handle it.
- The update-to-latest draft for MCPJam preserves the elicitation capability.

<sup>Written for commit 81ec68e70aec4e4db7902bfb333c09f7f291ac38. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/MCPJam/inspector/pull/4443?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

