### PR TITLE
Pin composed eval servers with --compose-server

### DIFF
--- a/.changeset/compose-runs-must-name-their-servers.md
+++ b/.changeset/compose-runs-must-name-their-servers.md
@@ -1,0 +1,21 @@
+---
+"@mcpjam/cli": minor
+"@mcpjam/sdk": minor
+---
+
+A composed eval run now has to say which servers it is testing
+
+`--compose-host chatgpt` recorded only the CLIENT. The server half was resolved at run
+time from that host's current list, so pointing the shared ChatGPT host at a different
+server silently repointed every eval composed against it — a suite written for Vercel
+would connect to Sentry, run its cases there, and report a real score for a server it
+was never meant to test. Nothing errored, because nothing was wrong as far as the run
+could tell.
+
+Composed runs now require `--compose-server <name>` (or `--compose-server-group <id>`).
+Following the host's live list is still available as `--compose-host-servers`, which is
+the same behaviour as before — the difference is that it is now something you ask for
+rather than what you get by saying nothing.
+
+Existing scripts that pass `--compose-host` alone will fail with a message naming both
+flags. Saved environments, journeys and user-testing scenarios are unaffected.

--- a/cli/src/commands/eval.ts
+++ b/cli/src/commands/eval.ts
@@ -228,6 +228,7 @@ function composeField(options: {
   composeHost?: string;
   composeComputer?: string;
   composeModel?: string | string[];
+  composeServer?: string[];
   composeServerGroup?: string;
   composeSkill?: string[];
   withClientDefault?: boolean;
@@ -236,6 +237,8 @@ function composeField(options: {
   compose?: {
     host: string;
     serverGroup?: string;
+    server?: string;
+    servers?: string[];
     models?: string[];
     includeClientDefault?: boolean;
     saveTargets?: boolean;
@@ -251,6 +254,7 @@ function composeField(options: {
   const refinements =
     options.composeComputer !== undefined ||
     models !== undefined ||
+    (options.composeServer?.length ?? 0) > 0 ||
     options.composeServerGroup !== undefined ||
     (options.composeSkill?.length ?? 0) > 0 ||
     options.withClientDefault === true ||
@@ -263,12 +267,23 @@ function composeField(options: {
     }
     return {};
   }
+  // Both fill the same slot: --compose-server RESOLVES to a group. Rejected
+  // here as well as in the op so the CLI names the two flags the user typed.
+  if (
+    options.composeServerGroup !== undefined &&
+    options.composeServer?.length
+  ) {
+    throw usageError(
+      "--compose-server and --compose-server-group both pin the run's servers. Use --compose-server with server names, or --compose-server-group with an existing group ID."
+    );
+  }
   return {
     compose: {
       host: options.composeHost,
       ...(options.composeServerGroup !== undefined
         ? { serverGroup: options.composeServerGroup }
         : {}),
+      ...selectorField("server", "servers", options.composeServer),
       ...(models !== undefined ? { models } : {}),
       ...(options.withClientDefault === true
         ? { includeClientDefault: true }
@@ -2932,6 +2947,10 @@ export function registerEvalCommands(program: Command): void {
         "Attach the composed environments to the suite (append, capped at 10). Default is ephemeral."
       )
       .option(
+        "--compose-server <id-or-name...>",
+        "Server(s) to pin on the composed stack. Snapshots them into a server group, so the run keeps testing these servers even if the host's own server list changes later. Mutually exclusive with --compose-server-group."
+      )
+      .option(
         "--compose-server-group <id>",
         "Standalone server group to pin on the composed stack"
       )
@@ -2956,6 +2975,7 @@ export function registerEvalCommands(program: Command): void {
         composeModel?: string[];
         withClientDefault?: boolean;
         saveTargets?: boolean;
+        composeServer?: string[];
         composeServerGroup?: string;
         composeSkill?: string[];
         project?: string;
@@ -4612,6 +4632,10 @@ export function registerEvalCommands(program: Command): void {
         "One model to run this case on. A matrix of models is suite-level (`eval run`) only."
       )
       .option(
+        "--compose-server <id-or-name...>",
+        "Server(s) to pin on the composed stack. Snapshots them into a server group, so the run keeps testing these servers even if the host's own server list changes later. Mutually exclusive with --compose-server-group."
+      )
+      .option(
         "--compose-server-group <id>",
         "Standalone server group to pin on the composed stack"
       )
@@ -4624,6 +4648,7 @@ export function registerEvalCommands(program: Command): void {
         composeHost?: string;
         composeComputer?: string;
         composeModel?: string;
+        composeServer?: string[];
         composeServerGroup?: string;
         composeSkill?: string[];
         project?: string;

--- a/cli/src/commands/eval.ts
+++ b/cli/src/commands/eval.ts
@@ -230,6 +230,7 @@ function composeField(options: {
   composeModel?: string | string[];
   composeServer?: string[];
   composeServerGroup?: string;
+  composeHostServers?: boolean;
   composeSkill?: string[];
   withClientDefault?: boolean;
   saveTargets?: boolean;
@@ -239,6 +240,7 @@ function composeField(options: {
     serverGroup?: string;
     server?: string;
     servers?: string[];
+    hostServers?: boolean;
     models?: string[];
     includeClientDefault?: boolean;
     saveTargets?: boolean;
@@ -256,6 +258,7 @@ function composeField(options: {
     models !== undefined ||
     (options.composeServer?.length ?? 0) > 0 ||
     options.composeServerGroup !== undefined ||
+    options.composeHostServers === true ||
     (options.composeSkill?.length ?? 0) > 0 ||
     options.withClientDefault === true ||
     options.saveTargets === true;
@@ -277,12 +280,29 @@ function composeField(options: {
       "--compose-server and --compose-server-group both pin the run's servers. Use --compose-server with server names, or --compose-server-group with an existing group ID."
     );
   }
+  const pinsServers =
+    options.composeServerGroup !== undefined ||
+    (options.composeServer?.length ?? 0) > 0;
+  if (options.composeHostServers === true && pinsServers) {
+    throw usageError(
+      "--compose-host-servers runs against the host's current list, so it cannot be combined with --compose-server / --compose-server-group, which pin one."
+    );
+  }
+  // The server is what the suite is testing, so a composed run has to name it.
+  // Left implicit, the run reads the host's list at execution time and a later
+  // edit to that shared host silently repoints the eval.
+  if (!pinsServers && options.composeHostServers !== true) {
+    throw usageError(
+      "--compose-host needs to know which servers to test: add --compose-server <name>. To deliberately use whatever servers the host points at right now — which changes when the host is edited — pass --compose-host-servers."
+    );
+  }
   return {
     compose: {
       host: options.composeHost,
       ...(options.composeServerGroup !== undefined
         ? { serverGroup: options.composeServerGroup }
         : {}),
+      ...(options.composeHostServers === true ? { hostServers: true } : {}),
       ...selectorField("server", "servers", options.composeServer),
       ...(models !== undefined ? { models } : {}),
       ...(options.withClientDefault === true
@@ -2955,6 +2975,10 @@ export function registerEvalCommands(program: Command): void {
         "Standalone server group to pin on the composed stack"
       )
       .option(
+        "--compose-host-servers",
+        "Run against whatever servers the host points at right now, instead of pinning a set. Editing that host later changes what a rerun tests."
+      )
+      .option(
         "--compose-skill <id...>",
         "Project-shared skill IDs to pin on the composed stack"
       )
@@ -2977,6 +3001,7 @@ export function registerEvalCommands(program: Command): void {
         saveTargets?: boolean;
         composeServer?: string[];
         composeServerGroup?: string;
+        composeHostServers?: boolean;
         composeSkill?: string[];
         project?: string;
         suite?: string;
@@ -4640,6 +4665,10 @@ export function registerEvalCommands(program: Command): void {
         "Standalone server group to pin on the composed stack"
       )
       .option(
+        "--compose-host-servers",
+        "Run against whatever servers the host points at right now, instead of pinning a set. Editing that host later changes what a rerun tests."
+      )
+      .option(
         "--compose-skill <id...>",
         "Project-shared skill IDs to pin on the composed stack"
       ).action(
@@ -4650,6 +4679,7 @@ export function registerEvalCommands(program: Command): void {
         composeModel?: string;
         composeServer?: string[];
         composeServerGroup?: string;
+        composeHostServers?: boolean;
         composeSkill?: string[];
         project?: string;
         suite: string;

--- a/cli/tests/eval.test.ts
+++ b/cli/tests/eval.test.ts
@@ -5341,6 +5341,7 @@ test("eval run --compose-* mints ephemerally and does not attach", async () => {
             "suite-1",
             "--compose-host",
             "Claude Code",
+            "--compose-host-servers",
             "--compose-computer",
             "default",
             "--compose-model",
@@ -5390,6 +5391,7 @@ test("eval run --compose-model variadic launches one group without attaching", a
             "suite-1",
             "--compose-host",
             "Claude Code",
+            "--compose-host-servers",
             "--compose-model",
             "anthropic/claude-haiku-4.5",
             "google/gemini-2.5-flash"
@@ -5438,6 +5440,7 @@ test("eval run --save-targets attaches the composed cell", async () => {
             "suite-1",
             "--compose-host",
             "Claude Code",
+            "--compose-host-servers",
             "--save-targets"
           ),
           "--format",
@@ -5483,6 +5486,37 @@ test("eval run rejects a --compose-* refinement with no --compose-host", async (
     assert.notEqual(run.result.exitCode, 0);
     assert.match(run.stderr, /--compose-\* flags need --compose-host/);
     assert.equal(fixture.composeBodies.length, 0);
+  } finally {
+    await fixture.close();
+  }
+});
+
+test("eval run refuses a composed run that names no servers", async () => {
+  // The server is what the suite tests. Left unsaid, the run reads the host's
+  // CURRENT list, so editing that shared host repoints every eval composed
+  // against it — silently, with a real score to show for it.
+  const fixture = await startEvalFixture();
+  try {
+    const run = await captureProcessOutput(() =>
+      main(
+        evalArgv(
+          fixture.baseUrl,
+          "run",
+          "--project",
+          "proj-alpha",
+          "--suite",
+          "suite-1",
+          "--compose-host",
+          "Claude Code"
+        ),
+        { telemetry: telemetryDisabled }
+      )
+    );
+    assert.notEqual(run.result.exitCode, 0);
+    assert.match(run.stderr, /--compose-server/);
+    assert.match(run.stderr, /--compose-host-servers/);
+    assert.equal(fixture.composeBodies.length, 0);
+    assert.equal(fixture.runBodies.length, 0);
   } finally {
     await fixture.close();
   }

--- a/docs/reference/openapi.json
+++ b/docs/reference/openapi.json
@@ -2818,6 +2818,110 @@
         }
       }
     },
+    "/projects/{projectId}/server-groups": {
+      "get": {
+        "operationId": "listServerGroups",
+        "tags": [
+          "Environments"
+        ],
+        "summary": "List a project's server groups",
+        "description": "A server group is an immutable snapshot of a set of saved servers. Pinning one on an environment is what keeps a run off its host's live server list, so a composed run keeps testing the servers it was composed against even after the shared host is edited.",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/projectId"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "The project's server groups.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ServerGroupPage"
+                }
+              }
+            }
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "403": {
+            "$ref": "#/components/responses/Forbidden"
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound"
+          },
+          "429": {
+            "$ref": "#/components/responses/RateLimited"
+          },
+          "500": {
+            "$ref": "#/components/responses/InternalError"
+          }
+        }
+      },
+      "post": {
+        "operationId": "createServerGroup",
+        "tags": [
+          "Environments"
+        ],
+        "summary": "Snapshot servers into a server group",
+        "description": "Creates a server group holding exactly the given servers and responds `201` with its detail. Groups are create-only — there is no update route, because an editable group would reintroduce the drift that pinning exists to prevent. Names are unique per project, so a clash responds `409`. Servers must belong to this project and must not be plugin-managed.",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/projectId"
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/ServerGroupCreateRequest"
+              },
+              "example": {
+                "name": "Vercel",
+                "serverIds": [
+                  "p1750000000000000000000000000"
+                ]
+              }
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "description": "The server group was created.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ServerGroup"
+                }
+              }
+            }
+          },
+          "400": {
+            "$ref": "#/components/responses/ValidationError"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "403": {
+            "$ref": "#/components/responses/Forbidden"
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound"
+          },
+          "409": {
+            "$ref": "#/components/responses/Conflict"
+          },
+          "429": {
+            "$ref": "#/components/responses/RateLimited"
+          },
+          "500": {
+            "$ref": "#/components/responses/InternalError"
+          }
+        }
+      }
+    },
     "/projects/{projectId}/eval-suites/{suiteId}/environments": {
       "post": {
         "operationId": "attachEvalSuiteEnvironment",
@@ -15144,6 +15248,96 @@
             "type": "array",
             "items": {
               "$ref": "#/components/schemas/ProjectServer"
+            }
+          }
+        }
+      },
+      "ServerGroup": {
+        "type": "object",
+        "description": "An immutable snapshot of a set of saved servers. Pin one on an environment so a run uses exactly these servers instead of following its host's live server list.",
+        "required": [
+          "id",
+          "name",
+          "serverIds",
+          "serverNames"
+        ],
+        "properties": {
+          "id": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          },
+          "description": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "serverIds": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "description": "The snapshotted server ids. Authoritative."
+          },
+          "serverNames": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "description": "Display names resolved at read time; a deleted server is labelled rather than dropped."
+          },
+          "createdAt": {
+            "type": [
+              "number",
+              "null"
+            ],
+            "description": "Epoch milliseconds."
+          },
+          "updatedAt": {
+            "type": [
+              "number",
+              "null"
+            ]
+          }
+        }
+      },
+      "ServerGroupPage": {
+        "type": "object",
+        "required": [
+          "items"
+        ],
+        "properties": {
+          "items": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/ServerGroup"
+            }
+          }
+        }
+      },
+      "ServerGroupCreateRequest": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+          "name",
+          "serverIds"
+        ],
+        "properties": {
+          "name": {
+            "type": "string",
+            "minLength": 1,
+            "description": "Unique among the project's live server groups."
+          },
+          "description": {
+            "type": "string"
+          },
+          "serverIds": {
+            "type": "array",
+            "minItems": 1,
+            "items": {
+              "type": "string"
             }
           }
         }

--- a/mcpjam-inspector/server/routes/v1/__tests__/agent-op-registry.test.ts
+++ b/mcpjam-inspector/server/routes/v1/__tests__/agent-op-registry.test.ts
@@ -583,6 +583,103 @@ describe("agent op registry", () => {
     });
   });
 
+  it("freezes compose server names to server ids, and folds the singular in", async () => {
+    // Frozen to SERVER ids, not to a group id: the group is minted at execute
+    // time and is content-determined by these ids, so freezing them closes the
+    // pointer without doing a write inside what must stay a read.
+    const client = {
+      listHosts: async () => ({
+        items: [{ id: "host_a", name: "Claude Code" }],
+      }),
+      listImages: async () => ({ items: [] }),
+      listProjectServers: async () => ({
+        items: [
+          { id: "srv_vercel", name: "Vercel" },
+          { id: "srv_sentry", name: "Sentry" },
+        ],
+      }),
+    } as unknown as Parameters<
+      ReturnType<typeof proposalMetaFor>["normalizeArgs"]
+    >[1]["client"];
+
+    expect(
+      await proposalMetaFor(runEvalSuiteOperation.name).normalizeArgs(
+        { suite: "smoke", compose: { host: "Claude Code", server: "Vercel" } },
+        { projectId: "p1", client }
+      )
+    ).toEqual({
+      suite: "smoke",
+      compose: {
+        host: "host_a",
+        hostLabel: "Claude Code",
+        servers: ["srv_vercel"],
+      },
+    });
+  });
+
+  it("leaves compose servers as written when the platform cannot resolve them", async () => {
+    // Freezing is a narrowing, and a platform that cannot answer must not cost
+    // the caller the proposal — execute still resolves the selector.
+    const client = {
+      listHosts: async () => ({
+        items: [{ id: "host_a", name: "Claude Code" }],
+      }),
+      listImages: async () => ({ items: [] }),
+      listProjectServers: async () => {
+        throw new Error("platform unavailable");
+      },
+    } as unknown as Parameters<
+      ReturnType<typeof proposalMetaFor>["normalizeArgs"]
+    >[1]["client"];
+
+    expect(
+      await proposalMetaFor(runEvalSuiteOperation.name).normalizeArgs(
+        { suite: "smoke", compose: { host: "Claude Code", server: "Vercel" } },
+        { projectId: "p1", client }
+      )
+    ).toEqual({
+      suite: "smoke",
+      compose: {
+        host: "host_a",
+        hostLabel: "Claude Code",
+        server: "Vercel",
+      },
+    });
+  });
+
+  it("freezes no server when only SOME of the list resolves", async () => {
+    // All-or-nothing: a half-frozen list would pair resolved ids with a name
+    // still free to repoint, which is worse than freezing none.
+    const client = {
+      listHosts: async () => ({
+        items: [{ id: "host_a", name: "Claude Code" }],
+      }),
+      listImages: async () => ({ items: [] }),
+      listProjectServers: async () => ({
+        items: [{ id: "srv_vercel", name: "Vercel" }],
+      }),
+    } as unknown as Parameters<
+      ReturnType<typeof proposalMetaFor>["normalizeArgs"]
+    >[1]["client"];
+
+    expect(
+      await proposalMetaFor(runEvalSuiteOperation.name).normalizeArgs(
+        {
+          suite: "smoke",
+          compose: { host: "Claude Code", servers: ["Vercel", "Ghost"] },
+        },
+        { projectId: "p1", client }
+      )
+    ).toEqual({
+      suite: "smoke",
+      compose: {
+        host: "host_a",
+        hostLabel: "Claude Code",
+        servers: ["Vercel", "Ghost"],
+      },
+    });
+  });
+
   it("freezes a case run's compose the same way the suite run's is frozen", async () => {
     // run_eval_case takes the full compose input — including `saveTargets`,
     // which ATTACHES the minted cell to the suite. Without normalization its

--- a/mcpjam-inspector/server/routes/v1/__tests__/sdk-coverage.test.ts
+++ b/mcpjam-inspector/server/routes/v1/__tests__/sdk-coverage.test.ts
@@ -82,6 +82,8 @@ const ROUTE_TO_SDK: Readonly<Record<string, string>> = {
   // Project servers
   "get /projects/{projectId}/servers": "listProjectServers",
   "post /projects/{projectId}/servers": "createProjectServer",
+  "get /projects/{projectId}/server-groups": "listServerGroups",
+  "post /projects/{projectId}/server-groups": "createServerGroup",
   "get /projects/{projectId}/servers/{serverId}": "getProjectServer",
   "patch /projects/{projectId}/servers/{serverId}": "updateProjectServer",
   "delete /projects/{projectId}/servers/{serverId}": "deleteProjectServer",

--- a/mcpjam-inspector/server/routes/v1/__tests__/server-groups.test.ts
+++ b/mcpjam-inspector/server/routes/v1/__tests__/server-groups.test.ts
@@ -1,0 +1,275 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { Hono } from "hono";
+
+// Covers the v1 SERVER GROUP surface (server/routes/v1/server-groups.ts): auth
+// + guest gating, the public DTO mapping (no Convex `_id` leak, no
+// `serverAttachment` vocabulary), the args forwarded to Convex, and the error
+// contract — a duplicate name is a 409, not a 400 or a 500.
+//
+// Convex is mocked at the `convex/browser` boundary, so these prove the
+// gateway's behavior and the ARGS it forwards, NOT that the backend accepts
+// them. The backend's own validation (same-project servers, plugin-managed
+// refusal, name uniqueness) is covered by
+// mcpjam-backend/tests/convex/serverAttachments.test.ts.
+
+const {
+  validateGuestTokenMock,
+  validateApiKeyMock,
+  resolveUserByExternalIdMock,
+  lookupWorkosKeyBindingMock,
+  convexQueryMock,
+  convexMutationMock,
+} = vi.hoisted(() => ({
+  validateGuestTokenMock: vi.fn(),
+  validateApiKeyMock: vi.fn(),
+  resolveUserByExternalIdMock: vi.fn(),
+  lookupWorkosKeyBindingMock: vi.fn(),
+  convexQueryMock: vi.fn(),
+  convexMutationMock: vi.fn(),
+}));
+
+vi.mock("../../../services/guest-token.js", () => ({
+  validateGuestTokenDetailedAsync: validateGuestTokenMock,
+}));
+
+vi.mock("../../../services/workos-client.js", () => ({
+  getWorkOSClient: () => ({
+    apiKeys: { createValidation: validateApiKeyMock },
+  }),
+}));
+vi.mock("../../../services/identity.js", () => ({
+  resolveUserByExternalId: resolveUserByExternalIdMock,
+}));
+vi.mock("../../../services/workos-key-bindings.js", () => ({
+  lookupWorkosKeyBinding: lookupWorkosKeyBindingMock,
+}));
+
+vi.mock("convex/browser", () => ({
+  ConvexHttpClient: vi.fn().mockImplementation(() => ({
+    setAuth: vi.fn(),
+    query: convexQueryMock,
+    mutation: convexMutationMock,
+  })),
+}));
+
+import v1Routes from "../index.js";
+import { logger } from "../../../utils/logger.js";
+
+function makeApp(): Hono {
+  const app = new Hono();
+  app.route("/api/v1", v1Routes);
+  return app;
+}
+
+function request(
+  method: string,
+  path: string,
+  opts: { body?: unknown; token?: string | null } = {}
+): Promise<Response> {
+  const { body, token = "tok" } = opts;
+  const headers: Record<string, string> = {
+    "Content-Type": "application/json",
+  };
+  if (token) headers.Authorization = `Bearer ${token}`;
+  return Promise.resolve(
+    makeApp().request(path, {
+      method,
+      headers,
+      ...(body !== undefined ? { body: JSON.stringify(body) } : {}),
+    })
+  );
+}
+
+const GROUP_ROW = {
+  _id: "att1",
+  name: "Vercel",
+  description: "the vercel server",
+  serverIds: ["srv1", "srv2"],
+  resolvedServerNames: ["Vercel", "Sentry"],
+  createdAt: 1,
+  updatedAt: 2,
+};
+
+function mockQuery(map: Record<string, unknown>) {
+  convexQueryMock.mockImplementation(async (fn: string) =>
+    fn in map ? map[fn] : null
+  );
+}
+
+/** A structured Convex refusal, the way the backend raises one. */
+function convexError(code: string, message: string) {
+  return Object.assign(new Error(`Uncaught ConvexError: ${message}`), {
+    data: { code, message },
+  });
+}
+
+describe("v1 server-group routes", () => {
+  const originalEnv = {
+    CONVEX_URL: process.env.CONVEX_URL,
+    CONVEX_HTTP_URL: process.env.CONVEX_HTTP_URL,
+  };
+  let warnSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    process.env.CONVEX_URL = "https://convex.example.com";
+    process.env.CONVEX_HTTP_URL = "https://convex-http.example.com";
+    validateGuestTokenMock.mockResolvedValue({ valid: false });
+    warnSpy = vi.spyOn(logger, "warn").mockImplementation(() => undefined);
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    for (const [key, value] of Object.entries(originalEnv)) {
+      if (value) process.env[key] = value;
+      else delete process.env[key];
+    }
+    warnSpy.mockRestore();
+  });
+
+  describe("auth", () => {
+    it("rejects a request with no bearer token (401)", async () => {
+      const res = await request("GET", "/api/v1/projects/p1/server-groups", {
+        token: null,
+      });
+      expect(res.status).toBe(401);
+      expect(((await res.json()) as { code?: string }).code).toBe(
+        "UNAUTHORIZED"
+      );
+    });
+
+    it("denies guest callers — server groups are not on the allowlist", async () => {
+      validateGuestTokenMock.mockResolvedValue({
+        valid: true,
+        guestId: "guest_1",
+      });
+      const res = await request("GET", "/api/v1/projects/p1/server-groups", {
+        token: "guest-jwt",
+      });
+      expect(res.status).toBe(401);
+      expect(((await res.json()) as { code?: string }).code).toBe(
+        "UNAUTHORIZED"
+      );
+      expect(convexQueryMock).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("GET /projects/:projectId/server-groups", () => {
+    it("maps rows to the public DTO and scopes the read to the path project", async () => {
+      mockQuery({ "serverAttachments:listServerAttachments": [GROUP_ROW] });
+      const res = await request("GET", "/api/v1/projects/p1/server-groups");
+      expect(res.status).toBe(200);
+      expect(await res.json()).toEqual({
+        items: [
+          {
+            id: "att1",
+            name: "Vercel",
+            description: "the vercel server",
+            serverIds: ["srv1", "srv2"],
+            serverNames: ["Vercel", "Sentry"],
+            createdAt: 1,
+            updatedAt: 2,
+          },
+        ],
+      });
+      expect(convexQueryMock).toHaveBeenCalledWith(
+        "serverAttachments:listServerAttachments",
+        { projectId: "p1" }
+      );
+    });
+
+    it("answers an empty page when the project has no groups", async () => {
+      mockQuery({ "serverAttachments:listServerAttachments": null });
+      const res = await request("GET", "/api/v1/projects/p1/server-groups");
+      expect(res.status).toBe(200);
+      expect(await res.json()).toEqual({ items: [] });
+    });
+  });
+
+  describe("POST /projects/:projectId/server-groups", () => {
+    it("creates a group and answers 201 with its detail", async () => {
+      convexMutationMock.mockResolvedValue(GROUP_ROW);
+      const res = await request("POST", "/api/v1/projects/p1/server-groups", {
+        body: { name: "Vercel", serverIds: ["srv1", "srv2"] },
+      });
+      expect(res.status).toBe(201);
+      expect((await res.json()) as { id?: string }).toMatchObject({
+        id: "att1",
+        name: "Vercel",
+      });
+      expect(convexMutationMock).toHaveBeenCalledWith(
+        "serverAttachments:createServerAttachment",
+        { projectId: "p1", name: "Vercel", serverIds: ["srv1", "srv2"] }
+      );
+    });
+
+    it("takes projectId from the PATH, never the body", async () => {
+      const res = await request("POST", "/api/v1/projects/p1/server-groups", {
+        body: {
+          name: "Vercel",
+          serverIds: ["srv1"],
+          projectId: "someone-elses-project",
+        },
+      });
+      expect(res.status).toBe(400);
+      expect(convexMutationMock).not.toHaveBeenCalled();
+    });
+
+    it("rejects an empty server list", async () => {
+      const res = await request("POST", "/api/v1/projects/p1/server-groups", {
+        body: { name: "Vercel", serverIds: [] },
+      });
+      expect(res.status).toBe(400);
+      expect(convexMutationMock).not.toHaveBeenCalled();
+    });
+
+    it("rejects a missing name", async () => {
+      const res = await request("POST", "/api/v1/projects/p1/server-groups", {
+        body: { serverIds: ["srv1"] },
+      });
+      expect(res.status).toBe(400);
+    });
+
+    it("answers 409 for a duplicate name, not 400 or 500", async () => {
+      // The SDK's create-then-reuse path keys off this status: a 409 means
+      // "re-list and adopt the winner", anything else aborts the compose.
+      convexMutationMock.mockRejectedValue(
+        convexError(
+          "CONFLICT",
+          'a server attachment named "Vercel" already exists in this project'
+        )
+      );
+      const res = await request("POST", "/api/v1/projects/p1/server-groups", {
+        body: { name: "Vercel", serverIds: ["srv1"] },
+      });
+      expect(res.status).toBe(409);
+      expect(((await res.json()) as { code?: string }).code).toBe("CONFLICT");
+    });
+
+    it("answers 409 for a legacy deployment's prose conflict too", async () => {
+      convexMutationMock.mockRejectedValue(
+        new Error('a server attachment named "Vercel" already exists')
+      );
+      const res = await request("POST", "/api/v1/projects/p1/server-groups", {
+        body: { name: "Vercel", serverIds: ["srv1"] },
+      });
+      expect(res.status).toBe(409);
+    });
+
+    it("surfaces a plugin-managed server refusal as a 400", async () => {
+      convexMutationMock.mockRejectedValue(
+        convexError(
+          "VALIDATION",
+          "Plugin-managed servers cannot be added to a server group."
+        )
+      );
+      const res = await request("POST", "/api/v1/projects/p1/server-groups", {
+        body: { name: "Vercel", serverIds: ["srv1"] },
+      });
+      expect(res.status).toBe(400);
+      expect(((await res.json()) as { message?: string }).message).toContain(
+        "Plugin-managed"
+      );
+    });
+  });
+});

--- a/mcpjam-inspector/server/routes/v1/agent-op-registry.ts
+++ b/mcpjam-inspector/server/routes/v1/agent-op-registry.ts
@@ -563,8 +563,12 @@ async function freezeEvalRunTargets(
  * "name or ID" and resolved by name at execute time, so an image renamed or
  * replaced between the proposal and the click repoints which sandbox the
  * approved run boots — the pointer problem this function exists to close, one
- * slot over. `serverGroup`, `skills.skillIds` and `pluginVersionIds` are
- * ID-only by contract and so are not pointers to freeze.
+ * slot over. `server`/`servers` are pointers for the same reason and frozen
+ * the same way: to SERVER ids, not to a group id. The group is minted at
+ * execute time and is content-determined by those ids, so freezing the ids
+ * closes the pointer without doing a write inside what must stay a read.
+ * `serverGroup`, `skills.skillIds` and `pluginVersionIds` are ID-only by
+ * contract and so are not pointers to freeze.
  *
  * `includeClientDefault` and `saveTargets` stay as written — they are
  * closed choices, not pointers. Compose itself is kept: dropping it would
@@ -614,6 +618,36 @@ async function freezeComposeRunTarget(
             computerSelector.toLocaleLowerCase(),
         );
       if (match) nextCompose.computer = match.id;
+    } catch {
+      // Same posture as the host lookup: a platform that cannot answer must
+      // not cost the caller the proposal. Execute still resolves the selector.
+    }
+  }
+
+  const serverSelectors = [
+    ...new Set([
+      ...readStringList(compose, "servers"),
+      ...(named(compose, "server") ? [named(compose, "server")!] : []),
+    ]),
+  ];
+  if (serverSelectors.length > 0) {
+    try {
+      const page = await client.listProjectServers({ projectId });
+      // All-or-nothing: a partially frozen list would pair resolved ids with
+      // a name still free to repoint, which is worse than freezing none —
+      // execute resolves the whole list under one set of rules either way.
+      const matches = serverSelectors.map(
+        (selector) =>
+          page.items.find((server) => server.id === selector) ??
+          page.items.find(
+            (server) =>
+              server.name.toLocaleLowerCase() === selector.toLocaleLowerCase(),
+          ),
+      );
+      if (matches.every((match) => match !== undefined)) {
+        nextCompose.servers = matches.map((match) => match!.id);
+        delete nextCompose.server;
+      }
     } catch {
       // Same posture as the host lookup: a platform that cannot answer must
       // not cost the caller the proposal. Execute still resolves the selector.

--- a/mcpjam-inspector/server/routes/v1/index.ts
+++ b/mcpjam-inspector/server/routes/v1/index.ts
@@ -18,6 +18,7 @@ import { passthroughRateLimitMiddleware } from "../../middleware/passthrough-rat
 // ask the same question without importing this router (a cycle).
 import { isGuestAllowedV1Request } from "./guest-allowed-paths.js";
 import servers from "./servers.js";
+import serverGroups from "./server-groups.js";
 import serverConnections from "./server-connections.js";
 import tools from "./tools.js";
 import prompts from "./prompts.js";
@@ -109,6 +110,10 @@ v1.use("*", async (c, next) => {
 
 // Each sub-router declares full resource paths; mount them all at the root.
 v1.route("/", servers);
+// Server groups (immutable standalone server snapshots). Guest-DENIED: the
+// Convex reads are membership-gated and creating one is a member write, so
+// there is no share-link flow that needs them.
+v1.route("/", serverGroups);
 v1.route("/", serverConnections);
 v1.route("/", tools);
 v1.route("/", prompts);

--- a/mcpjam-inspector/server/routes/v1/server-groups.ts
+++ b/mcpjam-inspector/server/routes/v1/server-groups.ts
@@ -1,0 +1,131 @@
+/**
+ * Public v1 server-group surface: list and create a project's standalone
+ * server groups.
+ *
+ * A server group is an immutable SNAPSHOT of a set of saved servers — the
+ * backend's `serverAttachment` rows with `scope: 'standalone'`. Pinning one on
+ * an environment is what stops a run from following its host's live server
+ * list, so a composed eval keeps testing the servers it was composed against
+ * even after somebody edits the shared host.
+ *
+ * "Server group" is the user-facing vocabulary (it matches the `serverGroup`
+ * compose field and the web `ServerGroupPicker`); `serverAttachment` is the
+ * backend's internal name and stays out of the public contract.
+ *
+ * These are thin proxies over the same Convex `serverAttachments:*` functions
+ * the hosted UI calls, with the request's Convex bearer — Convex enforces
+ * project membership (guest to list, member to create) and rejects servers
+ * from another project, soft-deleted servers, and plugin-managed ones. There
+ * is no update route because standalone rows are create-only by design: an
+ * editable group would reintroduce exactly the drift the pin exists to close.
+ */
+import { Hono } from "hono";
+import { z } from "zod";
+import { ConvexHttpClient } from "convex/browser";
+import { parseWithSchema, ErrorCode, WebRouteError } from "../web/errors.js";
+import { getConvexBearerForRequest } from "../../utils/v1-convex-token.js";
+import { v1PageJson, v1Resource } from "./envelope.js";
+import { translateConvexWriteError } from "./convex-errors.js";
+import { readJsonObjectBody } from "./adapter.js";
+
+const serverGroups = new Hono();
+
+// ── Convex row shape (mirrors serverAttachments:listServerAttachments) ──────
+type ServerGroupRow = {
+  _id: string;
+  name?: string;
+  description?: string;
+  serverIds?: string[];
+  resolvedServerNames?: string[];
+  createdAt?: number;
+  updatedAt?: number;
+};
+
+const createServerGroupSchema = z.strictObject({
+  name: z.string().trim().min(1),
+  description: z.string().optional(),
+  serverIds: z.array(z.string().trim().min(1)).min(1),
+});
+
+function createConvexClient(convexAuthToken: string): ConvexHttpClient {
+  const convexUrl = process.env.CONVEX_URL;
+  if (!convexUrl) {
+    throw new WebRouteError(
+      500,
+      ErrorCode.INTERNAL_ERROR,
+      "Server missing CONVEX_URL configuration"
+    );
+  }
+  const client = new ConvexHttpClient(convexUrl);
+  client.setAuth(convexAuthToken);
+  return client;
+}
+
+function translateServerGroupError(error: unknown): WebRouteError {
+  return translateConvexWriteError(error, {
+    resource: "Server group",
+    conflictMessage:
+      "A server group with that name already exists in this project.",
+    fallbackMessage: "Server group write rejected",
+  });
+}
+
+function toServerGroupDto(row: ServerGroupRow) {
+  return {
+    id: String(row._id),
+    name: row.name ?? "",
+    description: row.description ?? null,
+    serverIds: (row.serverIds ?? []).map(String),
+    // Hydrated by the backend through the live-edge resolver, so a renamed
+    // server reads under its current name and a deleted one is labelled
+    // rather than dropped — the id list stays authoritative either way.
+    serverNames: row.resolvedServerNames ?? [],
+    createdAt: row.createdAt ?? null,
+    updatedAt: row.updatedAt ?? null,
+  };
+}
+
+// GET /v1/projects/:projectId/server-groups — list live standalone groups.
+serverGroups.get("/projects/:projectId/server-groups", async (c) => {
+  const projectId = c.req.param("projectId");
+  const readClient = createConvexClient(await getConvexBearerForRequest(c));
+  let rows: ServerGroupRow[] | null | undefined;
+  try {
+    rows = (await readClient.query(
+      "serverAttachments:listServerAttachments" as any,
+      { projectId } as any
+    )) as ServerGroupRow[] | null | undefined;
+  } catch (error) {
+    throw translateServerGroupError(error);
+  }
+  return v1PageJson(c, (rows ?? []).map(toServerGroupDto));
+});
+
+// POST /v1/projects/:projectId/server-groups — snapshot a set of servers.
+serverGroups.post("/projects/:projectId/server-groups", async (c) => {
+  const projectId = c.req.param("projectId");
+  const body = parseWithSchema(
+    createServerGroupSchema,
+    await readJsonObjectBody(c)
+  );
+  const convexClient = createConvexClient(await getConvexBearerForRequest(c));
+  let created: ServerGroupRow;
+  try {
+    created = (await convexClient.mutation(
+      "serverAttachments:createServerAttachment" as any,
+      {
+        projectId,
+        name: body.name,
+        ...(body.description !== undefined
+          ? { description: body.description }
+          : {}),
+        serverIds: body.serverIds,
+      } as any
+    )) as ServerGroupRow;
+  } catch (error) {
+    throw translateServerGroupError(error);
+  }
+  return v1Resource(c, toServerGroupDto(created), 201);
+});
+
+export default serverGroups;

--- a/sdk/src/platform/client.ts
+++ b/sdk/src/platform/client.ts
@@ -95,6 +95,7 @@ import type {
   PlatformServerConnection,
   PlatformServerConnectionCreateBody,
   PlatformProjectServer,
+  PlatformServerGroup,
   PlatformSessionsPage,
   PlatformTunnelClosed,
   PlatformTunnelGrant,
@@ -514,6 +515,33 @@ export class PlatformApiClient {
       "GET",
       `/projects/${encodeURIComponent(params.projectId)}/servers`,
       {},
+      options,
+    );
+  }
+
+  listServerGroups(
+    params: { projectId: string },
+    options?: RequestOptions,
+  ): Promise<PlatformPage<PlatformServerGroup>> {
+    return this.request(
+      "GET",
+      `/projects/${encodeURIComponent(params.projectId)}/server-groups`,
+      {},
+      options,
+    );
+  }
+
+  createServerGroup(
+    params: {
+      projectId: string;
+      body: { name: string; description?: string; serverIds: string[] };
+    },
+    options?: RequestOptions,
+  ): Promise<PlatformServerGroup> {
+    return this.request(
+      "POST",
+      `/projects/${encodeURIComponent(params.projectId)}/server-groups`,
+      { body: params.body },
       options,
     );
   }

--- a/sdk/src/platform/index.ts
+++ b/sdk/src/platform/index.ts
@@ -255,6 +255,7 @@ export type {
   PlatformPluginVersion,
   PlatformProject,
   PlatformProjectServer,
+  PlatformServerGroup,
   PlatformCatalogOauthProbe,
   PlatformCatalogServer,
   PlatformCatalogSourceStatus,

--- a/sdk/src/platform/operations.ts
+++ b/sdk/src/platform/operations.ts
@@ -2945,6 +2945,7 @@ async function composeRunEnvironment(
     serverGroup?: string;
     server?: string;
     servers?: string[];
+    hostServers?: boolean;
     model?: string;
     models?: string[];
     includeClientDefault?: boolean;
@@ -2964,6 +2965,16 @@ async function composeRunEnvironment(
     stack,
     signal
   );
+  // The server is the thing under test, so a composed RUN has to say which one.
+  // Without a pin the run reads the host's list at execution time, and editing
+  // that shared host silently repoints every eval composed against it — the
+  // failure this guard exists to stop. Following the host stays available, but
+  // only as something the caller asked for out loud.
+  if (pinned.serverGroup === undefined && stack.hostServers !== true) {
+    throw operationInputError(
+      "A composed eval run must say which servers to test: pass `server`/`servers` (or `serverGroup`). To deliberately run against the host's current list — which changes when the host is edited — pass `hostServers: true`."
+    );
+  }
   const choices = expandComposeModelChoices(pinned);
   const cells: ComposedCell[] = [];
   for (const choice of choices) {
@@ -3374,7 +3385,13 @@ const composeRunTargetInput = z
       .min(1)
       .optional()
       .describe(
-        "Standalone server group to pin (by ID). Omit to use the host's own servers."
+        "Standalone server group to pin (by ID). One of `server`/`servers`/`serverGroup` is required unless `hostServers` opts into the host's live list."
+      ),
+    hostServers: z
+      .boolean()
+      .optional()
+      .describe(
+        "Run against the host's CURRENT server list instead of pinning one. The list is read at run time, so editing the host later changes what a rerun tests — opt in only when following the host is the point."
       ),
     server: z
       .string()

--- a/sdk/src/platform/operations.ts
+++ b/sdk/src/platform/operations.ts
@@ -2965,12 +2965,28 @@ async function composeRunEnvironment(
     stack,
     signal
   );
+  // Truthiness, not `!== undefined`, because that is what actually reaches the
+  // wire: `resolveComposeStack` drops a blank `serverGroup`, so a `""` checked
+  // for presence alone would clear this guard and then compose the exact
+  // unpinned environment it exists to refuse.
+  const pinnedGroup = pinned.serverGroup?.trim();
+  // Asking to follow the host AND to pin is a contradiction, and resolving it
+  // silently would drop one of the two things the caller said. The CLI rejects
+  // the pair too; repeated here because `execute` is reachable without it.
+  if (
+    stack.hostServers === true &&
+    (pinnedGroup || stack.server !== undefined || stack.servers !== undefined)
+  ) {
+    throw operationInputError(
+      "`hostServers` runs against the host's current list, so it cannot be combined with `server`/`servers`/`serverGroup`, which pin one."
+    );
+  }
   // The server is the thing under test, so a composed RUN has to say which one.
   // Without a pin the run reads the host's list at execution time, and editing
   // that shared host silently repoints every eval composed against it — the
   // failure this guard exists to stop. Following the host stays available, but
   // only as something the caller asked for out loud.
-  if (pinned.serverGroup === undefined && stack.hostServers !== true) {
+  if (!pinnedGroup && stack.hostServers !== true) {
     throw operationInputError(
       "A composed eval run must say which servers to test: pass `server`/`servers` (or `serverGroup`). To deliberately run against the host's current list — which changes when the host is edited — pass `hostServers: true`."
     );

--- a/sdk/src/platform/operations.ts
+++ b/sdk/src/platform/operations.ts
@@ -450,6 +450,15 @@ export interface PlatformOperation<TInput, TOutput> {
 const PROJECT_SELECTOR_DESCRIPTION =
   "Project name or ID. Defaults to the most recently updated accessible project.";
 
+/**
+ * Up here, not beside the compose resolvers it belongs to, for the same
+ * temporal-dead-zone reason `composeRunTargetInput` is declared above the run
+ * inputs: both compose schemas read this at module-init time, and the earlier
+ * of the two sits thousands of lines above those resolvers.
+ */
+const SERVERS_SELECTOR_DESCRIPTION =
+  "Server(s) (name or ID) the stack must run against. Resolves to a pinned standalone server group holding exactly these servers, so the stack keeps testing them even if the host's own server list is edited later. Mutually exclusive with `serverGroup`.";
+
 const listProjectsInput = z.object({
   organizationId: z
     .string()
@@ -2934,6 +2943,8 @@ async function composeRunEnvironment(
   stack: {
     host: string;
     serverGroup?: string;
+    server?: string;
+    servers?: string[];
     model?: string;
     models?: string[];
     includeClientDefault?: boolean;
@@ -2945,13 +2956,21 @@ async function composeRunEnvironment(
   signal: AbortSignal | undefined,
   options: { attach: boolean } = { attach: true }
 ): Promise<ComposedRunEnvironment> {
-  const choices = expandComposeModelChoices(stack);
+  // Once, before the fan-out: every model cell shares one server group, and
+  // resolving inside the loop would re-list (and race to create) per cell.
+  const pinned = await materializeComposeServers(
+    client,
+    project,
+    stack,
+    signal
+  );
+  const choices = expandComposeModelChoices(pinned);
   const cells: ComposedCell[] = [];
   for (const choice of choices) {
     const body = await resolveComposeStack(
       client,
       project,
-      { ...stack, model: choice.modelId },
+      { ...pinned, model: choice.modelId },
       signal
     );
     const ensured = await client.ensureAdhocEnvironment(
@@ -3357,6 +3376,17 @@ const composeRunTargetInput = z
       .describe(
         "Standalone server group to pin (by ID). Omit to use the host's own servers."
       ),
+    server: z
+      .string()
+      .trim()
+      .min(1)
+      .optional()
+      .describe("Singular alias for `servers`."),
+    servers: z
+      .array(z.string().trim().min(1))
+      .min(1)
+      .optional()
+      .describe(SERVERS_SELECTOR_DESCRIPTION),
     model: z
       .string()
       .trim()
@@ -3403,6 +3433,7 @@ const composeRunTargetInput = z
       .optional()
       .describe("Plugin VERSION IDs to pin for the composed stack."),
   })
+  .superRefine(refineComposeServerSelectors)
   .describe(
     "Compose an execution stack to run instead of naming a saved environment. Default is EPHEMERAL: cells are minted and launched without attaching them to the suite (`saveTargets: true` opts into append). Deduplicated by content, so composing the same stack twice reuses one environment. Mutually exclusive with environment/environments/host/hosts/servers/allAttached."
   );
@@ -8895,6 +8926,17 @@ const composeStackFields = {
     .describe(
       "Standalone server group to pin (by ID). Omit to use the host's own servers."
     ),
+  server: z
+    .string()
+    .trim()
+    .min(1)
+    .optional()
+    .describe("Singular alias for `servers`."),
+  servers: z
+    .array(z.string().trim().min(1))
+    .min(1)
+    .optional()
+    .describe(SERVERS_SELECTOR_DESCRIPTION),
   model: z
     .string()
     .trim()
@@ -8923,7 +8965,7 @@ const ensureAdhocEnvironmentInput = z.object({
     .optional()
     .describe(PROJECT_SELECTOR_DESCRIPTION),
   ...composeStackFields,
-});
+}).superRefine(refineComposeServerSelectors);
 export type EnsureAdhocEnvironmentInput = z.infer<
   typeof ensureAdhocEnvironmentInput
 >;
@@ -8934,6 +8976,183 @@ export type EnsureAdhocEnvironmentResult = {
   /** False when this stack had already been composed — see the op description. */
   created: boolean;
 };
+
+/** How many `name (n)` variants to try before giving up on a colliding name. */
+const SERVER_GROUP_NAME_ATTEMPTS = 5;
+
+/**
+ * `server`/`servers` are two spellings of one axis, and `serverGroup` is the
+ * already-resolved form of the same thing — so at most one may be set. Shared
+ * by both compose schemas (a function declaration, so it is in scope for the
+ * run-target schema declared far above `composeStackFields`).
+ */
+function refineComposeServerSelectors(
+  value: { server?: string; servers?: string[]; serverGroup?: string },
+  ctx: z.RefinementCtx,
+): void {
+  if (value.server !== undefined && value.servers !== undefined) {
+    ctx.addIssue({
+      code: "custom",
+      path: ["servers"],
+      message: "Provide either `server` or `servers`, not both.",
+    });
+  }
+  if (
+    value.serverGroup !== undefined &&
+    (value.server !== undefined || value.servers !== undefined)
+  ) {
+    ctx.addIssue({
+      code: "custom",
+      path: ["serverGroup"],
+      message:
+        "Provide either `serverGroup` (an existing group ID) or `server`/`servers` (which resolve to one), not both.",
+    });
+  }
+}
+
+/** Order-independent set equality over two id lists. */
+function sameServerSet(a: string[], b: string[]): boolean {
+  if (a.length !== b.length) return false;
+  const left = new Set(a);
+  return left.size === new Set(b).size && b.every((id) => left.has(id));
+}
+
+/**
+ * A stable, human-readable name for a group minted from server selectors.
+ *
+ * Sorted so the name does not depend on the order the selectors were typed —
+ * `--compose-server A B` and `--compose-server B A` describe one group and
+ * should not mint two.
+ */
+function composeServerGroupName(servers: PlatformProjectServer[]): string {
+  return [...servers]
+    .map((server) => server.name)
+    .sort((a, b) => a.localeCompare(b))
+    .join(" + ");
+}
+
+/**
+ * Resolve server selectors to a pinned server group, creating one if no
+ * existing group already holds exactly that set.
+ *
+ * Reuse is matched on CONTENT, not name, because the environment fingerprint
+ * keys on the group's ID: two same-content groups mint two ad-hoc
+ * environments, and a group a live environment pins cannot be deleted. So
+ * minting one per run would accumulate undeletable near-duplicates and defeat
+ * the content-addressing that makes re-composing a stack free.
+ *
+ * A name collision means someone already has a DIFFERENT group under the name
+ * we derived. We re-list before suffixing because the likeliest cause is a
+ * concurrent identical compose that won the race — reusing its group is the
+ * whole point. Only when the name is genuinely taken by other content do we
+ * suffix.
+ */
+async function resolveComposeServerGroup(
+  client: PlatformApiClient,
+  project: PlatformProject,
+  selectors: string[],
+  signal: AbortSignal | undefined,
+): Promise<string> {
+  // Reuses the run-server resolver: same name-or-id rules, same up-front
+  // refusal of stdio/URL-less servers the hosted runner could never connect.
+  const servers = await resolveRunServers(client, project, selectors, signal);
+  const wanted = servers.map((server) => server.id);
+
+  const findMatch = async () => {
+    let page;
+    try {
+      page = await client.listServerGroups(
+        { projectId: project.id },
+        { signal }
+      );
+    } catch (error) {
+      // A deployment that predates the server-group routes answers 404 for the
+      // ROUTE, which would otherwise surface as a bare "not found" naming
+      // nothing the caller can act on. `--compose-server-group` still works
+      // there, so say so rather than leaving them to guess.
+      if (error instanceof PlatformApiError && error.status === 404) {
+        throw resolutionError(
+          "This deployment does not support --compose-server yet. Create a server group in the app and pass it with --compose-server-group <id>.",
+        );
+      }
+      throw error;
+    }
+    return page.items.find((group) => sameServerSet(group.serverIds, wanted));
+  };
+
+  const existing = await findMatch();
+  if (existing) return existing.id;
+
+  const baseName = composeServerGroupName(servers);
+  for (let attempt = 1; attempt <= SERVER_GROUP_NAME_ATTEMPTS; attempt += 1) {
+    const name = attempt === 1 ? baseName : `${baseName} (${attempt})`;
+    try {
+      const created = await client.createServerGroup(
+        {
+          projectId: project.id,
+          body: { name, serverIds: wanted },
+        },
+        { signal },
+      );
+      return created.id;
+    } catch (error) {
+      if (!(error instanceof PlatformApiError) || error.status !== 409) {
+        throw error;
+      }
+      const raced = await findMatch();
+      if (raced) return raced.id;
+    }
+  }
+
+  throw resolutionError(
+    `Could not create a server group named "${baseName}": that name and ${
+      SERVER_GROUP_NAME_ATTEMPTS - 1
+    } numbered variants are already taken by groups holding different servers. Rename one, or pass an existing group with --compose-server-group.`,
+  );
+}
+
+/**
+ * Rewrite a stack's `server`/`servers` selectors into the `serverGroup` the
+ * rest of the pipeline already understands.
+ *
+ * Deliberately separate from `resolveComposeStack`, which run composition
+ * calls once PER MODEL CELL: doing the list-and-maybe-create in there would
+ * repeat it per cell and let a fan-out race itself into a name conflict.
+ * Callers run this once, up front.
+ */
+async function materializeComposeServers<
+  T extends { serverGroup?: string; server?: string; servers?: string[] },
+>(
+  client: PlatformApiClient,
+  project: PlatformProject,
+  stack: T,
+  signal: AbortSignal | undefined,
+): Promise<T> {
+  // Both refinement rules are repeated below, not just the group one: the
+  // schemas only run for callers that PARSE their input, and a direct
+  // `execute()` caller passing both would otherwise have one selector
+  // silently dropped and spend a run against the wrong servers.
+  if (stack.server !== undefined && stack.servers !== undefined) {
+    throw operationInputError(
+      "Provide either `server` or `servers`, not both."
+    );
+  }
+  const selectors = stack.servers ?? (stack.server ? [stack.server] : []);
+  if (selectors.length === 0) return stack;
+  if (stack.serverGroup !== undefined) {
+    throw operationInputError(
+      "Provide either `serverGroup` (an existing group ID) or `server`/`servers` (which resolve to one), not both.",
+    );
+  }
+  const serverGroup = await resolveComposeServerGroup(
+    client,
+    project,
+    selectors,
+    signal
+  );
+  const { server: _server, servers: _servers, ...rest } = stack;
+  return { ...rest, serverGroup } as T;
+}
 
 /**
  * Resolve a composed stack's selectors to the ids the platform stores.
@@ -8991,7 +9210,13 @@ export const ensureAdhocEnvironmentOperation: PlatformOperation<
       { client, signal, onScopeResolved },
       input.project
     );
-    const body = await resolveComposeStack(client, project, input, signal);
+    const stack = await materializeComposeServers(
+      client,
+      project,
+      input,
+      signal
+    );
+    const body = await resolveComposeStack(client, project, stack, signal);
     const ensured = await client.ensureAdhocEnvironment(
       { projectId: project.id, body },
       { signal }

--- a/sdk/src/platform/types.ts
+++ b/sdk/src/platform/types.ts
@@ -220,6 +220,22 @@ export interface PlatformProjectServer {
   updatedAt: number | null;
 }
 
+/**
+ * An immutable snapshot of a set of saved servers (the backend's standalone
+ * `serverAttachment`). Pinning one on an environment is what keeps a run off
+ * its host's live server list.
+ */
+export interface PlatformServerGroup {
+  id: string;
+  name: string;
+  description: string | null;
+  serverIds: string[];
+  /** Display names hydrated by the backend; ids stay authoritative. */
+  serverNames: string[];
+  createdAt: number | null;
+  updatedAt: number | null;
+}
+
 export interface PlatformEvalRunSummary {
   id: string | null;
   status: string | null;

--- a/sdk/tests/platform/operations-compose.test.ts
+++ b/sdk/tests/platform/operations-compose.test.ts
@@ -599,6 +599,43 @@ describe("compose server selectors", () => {
     expect(bodyOf(fetchMock, /ensure-adhoc$/)).toBeUndefined();
   });
 
+  it("refuses a composed run that names no servers", async () => {
+    // The whole defect in one case: without a pin the run reads the host's
+    // list at execution time, so editing that shared host repoints the eval.
+    const { client, fetchMock } = makeClient();
+    const error = await runEvalSuiteOperation
+      .execute({ suite: "Smoke", compose: { host: "Claude Code" } }, { client })
+      .catch((caught: unknown) => caught);
+    expect(String((error as Error).message)).toContain("must say which servers");
+    expect(bodyOf(fetchMock, /ensure-adhoc$/)).toBeUndefined();
+    expect(bodyOf(fetchMock, /eval-runs$/)).toBeUndefined();
+  });
+
+  it("follows the host's live list only when asked out loud", async () => {
+    const { client, fetchMock } = makeClient();
+    await runEvalSuiteOperation.execute(
+      { suite: "Smoke", compose: { host: "Claude Code", hostServers: true } },
+      { client },
+    );
+    // Opting in composes as before — no group is pinned, so the runner resolves
+    // servers from the host.
+    expect(bodyOf(fetchMock, /ensure-adhoc$/)).toEqual({
+      hostId: "host-claude",
+    });
+  });
+
+  it("refuses a single case run that names no servers", async () => {
+    const { client, fetchMock } = makeClient();
+    const error = await runEvalCaseOperation
+      .execute(
+        { suite: "Smoke", case: "case-1", compose: { host: "Claude Code" } },
+        { client },
+      )
+      .catch((caught: unknown) => caught);
+    expect(String((error as Error).message)).toContain("must say which servers");
+    expect(bodyOf(fetchMock, /ensure-adhoc$/)).toBeUndefined();
+  });
+
   it("pins the same way for a single case run", async () => {
     const { client, fetchMock } = makeClient();
     await runEvalCaseOperation.execute(
@@ -654,7 +691,7 @@ describe("run_eval_suite compose", () => {
     const result = await runEvalSuiteOperation.execute(
       {
         suite: "Smoke",
-        compose: { host: "Claude Code", computer: "default" },
+        compose: { host: "Claude Code", hostServers: true, computer: "default" },
       },
       { client },
     );
@@ -680,7 +717,7 @@ describe("run_eval_suite compose", () => {
     const result = await runEvalSuiteOperation.execute(
       {
         suite: "Smoke",
-        compose: { host: "Claude Code", saveTargets: true },
+        compose: { host: "Claude Code", hostServers: true, saveTargets: true },
       },
       { client },
     );
@@ -701,7 +738,7 @@ describe("run_eval_suite compose", () => {
     const { client, fetchMock } = makeClient({ launchFails: true });
     const error = await runEvalSuiteOperation
       .execute(
-        { suite: "Smoke", compose: { host: "Claude Code" } },
+        { suite: "Smoke", compose: { host: "Claude Code", hostServers: true } },
         { client },
       )
       .catch((caught: unknown) => caught);
@@ -728,6 +765,7 @@ describe("run_eval_suite compose", () => {
         suite: "Smoke",
         compose: {
           host: "Claude Code",
+          hostServers: true,
           models: [
             "anthropic/claude-haiku-4.5",
             "google/gemini-2.5-flash",
@@ -820,7 +858,7 @@ describe("run_eval_suite compose", () => {
     // break every composed run against an older deployment.
     const { client, fetchMock } = makeClient({ modelOverrides: false });
     await runEvalSuiteOperation.execute(
-      { suite: "Smoke", compose: { host: "Claude Code" } },
+      { suite: "Smoke", compose: { host: "Claude Code", hostServers: true } },
       { client },
     );
     expect(bodyOf(fetchMock, /ensure-adhoc$/)).toBeDefined();
@@ -829,7 +867,7 @@ describe("run_eval_suite compose", () => {
   it("falls back to attach for a single cell on an old backend", async () => {
     const { client, fetchMock } = makeClient({ ephemeralLaunch: false });
     await runEvalSuiteOperation.execute(
-      { suite: "Smoke", compose: { host: "Claude Code" } },
+      { suite: "Smoke", compose: { host: "Claude Code", hostServers: true } },
       { client },
     );
     expect(
@@ -852,7 +890,7 @@ describe("run_eval_suite compose", () => {
       .execute(
         {
           suite: "Smoke",
-          compose: { host: "Claude Code" },
+          compose: { host: "Claude Code", hostServers: true },
           cases: ["no such case"],
         },
         { client },
@@ -872,10 +910,10 @@ describe("run_eval_suite compose", () => {
     // not use the result.
     const { client, fetchMock } = makeClient();
     for (const input of [
-      { suite: "Smoke", compose: { host: "Claude Code" }, environment: "e" },
-      { suite: "Smoke", compose: { host: "Claude Code" }, host: "ChatGPT" },
-      { suite: "Smoke", compose: { host: "Claude Code" }, servers: ["s"] },
-      { suite: "Smoke", compose: { host: "Claude Code" }, allAttached: true },
+      { suite: "Smoke", compose: { host: "Claude Code", hostServers: true }, environment: "e" },
+      { suite: "Smoke", compose: { host: "Claude Code", hostServers: true }, host: "ChatGPT" },
+      { suite: "Smoke", compose: { host: "Claude Code", hostServers: true }, servers: ["s"] },
+      { suite: "Smoke", compose: { host: "Claude Code", hostServers: true }, allAttached: true },
     ]) {
       const error = await runEvalSuiteOperation
         .execute(input, { client })
@@ -894,7 +932,7 @@ describe("run_eval_case compose", () => {
       {
         suite: "Smoke",
         case: "echo works",
-        compose: { host: "Claude Code", model: "anthropic/claude-haiku-4.5" },
+        compose: { host: "Claude Code", hostServers: true, model: "anthropic/claude-haiku-4.5" },
       },
       { client },
     );

--- a/sdk/tests/platform/operations-compose.test.ts
+++ b/sdk/tests/platform/operations-compose.test.ts
@@ -52,6 +52,39 @@ const IMAGES = [
   { id: "img-heavy", name: "heavy", projectId: PROJECT.id },
 ];
 
+const SERVERS = [
+  {
+    id: "srv-vercel",
+    name: "Vercel",
+    projectId: PROJECT.id,
+    enabled: true,
+    transportType: "http",
+    url: "https://vercel.test/mcp",
+    useOAuth: false,
+    hasClientSecret: false,
+  },
+  {
+    id: "srv-sentry",
+    name: "Sentry",
+    projectId: PROJECT.id,
+    enabled: true,
+    transportType: "http",
+    url: "https://sentry.test/mcp",
+    useOAuth: false,
+    hasClientSecret: false,
+  },
+  {
+    id: "srv-local",
+    name: "Local",
+    projectId: PROJECT.id,
+    enabled: true,
+    transportType: "stdio",
+    url: null,
+    useOAuth: false,
+    hasClientSecret: false,
+  },
+];
+
 const ADHOC_ENVIRONMENT = {
   id: "env-adhoc-1",
   projectId: PROJECT.id,
@@ -81,15 +114,89 @@ interface Fixture {
   modelOverrides?: boolean;
   /** Suite already has these attached environment ids (union-cap tests). */
   attachedEnvironmentIds?: string[];
+  /** Server groups the project already holds. */
+  serverGroups?: Array<{ id: string; name: string; serverIds: string[] }>;
+  /** Deployment that predates the server-group routes (404s the route). */
+  serverGroupsUnavailable?: boolean;
+  /**
+   * Names whose FIRST create attempt answers 409, modelling a name already
+   * taken by a group holding different servers.
+   */
+  takenGroupNames?: string[];
+  /**
+   * A concurrent compose that wins the create race: the conflicting POST is
+   * answered 409 AND this group appears in the next list.
+   */
+  raceGroupOnConflict?: { id: string; name: string; serverIds: string[] };
 }
 
 function makeClient(fixture: Fixture = {}) {
+  // Mutable so a create is visible to the list that follows it — the
+  // conflict-then-relist path depends on that ordering.
+  const serverGroups = [...(fixture.serverGroups ?? [])];
+  let createdGroupCount = 0;
   const fetchMock = vi.fn(async (target: unknown, init?: RequestInit) => {
     const path = new URL(String(target)).pathname;
     const method = init?.method ?? "GET";
     if (path === "/api/v1/projects") return Response.json({ items: [PROJECT] });
     if (/\/hosts$/.test(path)) return Response.json({ items: HOSTS });
     if (/\/images$/.test(path)) return Response.json({ items: IMAGES });
+    if (/\/servers$/.test(path) && method === "GET") {
+      return Response.json({ items: SERVERS });
+    }
+    if (/\/server-groups$/.test(path) && fixture.serverGroupsUnavailable) {
+      return Response.json(
+        { code: "NOT_FOUND", message: "Not Found" },
+        { status: 404 },
+      );
+    }
+    if (/\/server-groups$/.test(path) && method === "GET") {
+      return Response.json({
+        items: serverGroups.map((group) => ({
+          ...group,
+          description: null,
+          serverNames: [],
+          createdAt: 1,
+          updatedAt: 1,
+        })),
+      });
+    }
+    if (/\/server-groups$/.test(path) && method === "POST") {
+      const body = JSON.parse(String(init?.body)) as {
+        name: string;
+        serverIds: string[];
+      };
+      if (fixture.takenGroupNames?.includes(body.name)) {
+        if (fixture.raceGroupOnConflict) {
+          serverGroups.push(fixture.raceGroupOnConflict);
+        }
+        return Response.json(
+          {
+            code: "CONFLICT",
+            message:
+              "A server group with that name already exists in this project.",
+          },
+          { status: 409 },
+        );
+      }
+      createdGroupCount += 1;
+      const group = {
+        id: `grp-created-${createdGroupCount}`,
+        name: body.name,
+        serverIds: body.serverIds,
+      };
+      serverGroups.push(group);
+      return Response.json(
+        {
+          ...group,
+          description: null,
+          serverNames: [],
+          createdAt: 1,
+          updatedAt: 1,
+        },
+        { status: 201 },
+      );
+    }
     if (/\/eval-suites$/.test(path) && method === "GET") {
       return Response.json({ items: [SUITE] });
     }
@@ -272,6 +379,240 @@ describe("ensure_adhoc_environment", () => {
     expect((error as PlatformApiError).message).toContain(
       "predates ad-hoc environments",
     );
+  });
+});
+
+/**
+ * `server`/`servers` on a composed stack.
+ *
+ * The bug they close: without a pinned group, a composed environment follows
+ * its HOST's live server list, so editing a shared host silently repoints
+ * every eval composed against it. These selectors snapshot the servers into a
+ * group instead, and the environment pins that group.
+ *
+ * Reuse is by CONTENT, not name, because the environment fingerprint keys on
+ * the group id — minting a fresh group per run would mint a fresh environment
+ * per run and leave undeletable near-duplicates behind.
+ */
+describe("compose server selectors", () => {
+  function groupBodies(fetchMock: ReturnType<typeof vi.fn>) {
+    return fetchMock.mock.calls
+      .filter(
+        ([target, init]) =>
+          /\/server-groups$/.test(new URL(String(target)).pathname) &&
+          (init as RequestInit | undefined)?.method === "POST",
+      )
+      .map(([, init]) => JSON.parse(String((init as RequestInit).body)));
+  }
+
+  it("resolves server names, snapshots a group, and pins it on the stack", async () => {
+    const { client, fetchMock } = makeClient();
+    await ensureAdhocEnvironmentOperation.execute(
+      { host: "Claude Code", server: "Vercel" },
+      { client },
+    );
+    expect(groupBodies(fetchMock)).toEqual([
+      { name: "Vercel", serverIds: ["srv-vercel"] },
+    ]);
+    expect(bodyOf(fetchMock, /ensure-adhoc$/)).toEqual({
+      hostId: "host-claude",
+      serverAttachmentId: "grp-created-1",
+    });
+  });
+
+  it("reuses a group holding the same servers, whatever its name or order", async () => {
+    const { client, fetchMock } = makeClient({
+      serverGroups: [
+        {
+          id: "grp-existing",
+          name: "hand made",
+          serverIds: ["srv-sentry", "srv-vercel"],
+        },
+      ],
+    });
+    await ensureAdhocEnvironmentOperation.execute(
+      { host: "Claude Code", servers: ["Vercel", "Sentry"] },
+      { client },
+    );
+    expect(groupBodies(fetchMock)).toEqual([]);
+    expect(bodyOf(fetchMock, /ensure-adhoc$/)).toEqual({
+      hostId: "host-claude",
+      serverAttachmentId: "grp-existing",
+    });
+  });
+
+  it("names a group independently of the order the servers were typed", async () => {
+    const { client, fetchMock } = makeClient();
+    await ensureAdhocEnvironmentOperation.execute(
+      { host: "Claude Code", servers: ["Vercel", "Sentry"] },
+      { client },
+    );
+    expect(groupBodies(fetchMock)).toEqual([
+      { name: "Sentry + Vercel", serverIds: ["srv-vercel", "srv-sentry"] },
+    ]);
+  });
+
+  it("resolves the group ONCE across a model matrix, not per cell", async () => {
+    // Resolving inside the fan-out would re-list per cell and let the run race
+    // itself into a name conflict against its own earlier create.
+    const { client, fetchMock } = makeClient();
+    await runEvalSuiteOperation.execute(
+      {
+        suite: "Smoke",
+        compose: {
+          host: "Claude Code",
+          server: "Vercel",
+          models: ["anthropic/claude-sonnet-4-5", "openai/gpt-5.6"],
+        },
+      },
+      { client },
+    );
+    expect(groupBodies(fetchMock)).toHaveLength(1);
+    const ensureCalls = fetchMock.mock.calls.filter(([target]) =>
+      /ensure-adhoc$/.test(new URL(String(target)).pathname),
+    );
+    expect(ensureCalls).toHaveLength(2);
+    for (const [, init] of ensureCalls) {
+      expect(
+        JSON.parse(String((init as RequestInit).body)).serverAttachmentId,
+      ).toBe("grp-created-1");
+    }
+  });
+
+  it("reuses the winner when a concurrent compose takes the name first", async () => {
+    const { client, fetchMock } = makeClient({
+      takenGroupNames: ["Vercel"],
+      raceGroupOnConflict: {
+        id: "grp-raced",
+        name: "Vercel",
+        serverIds: ["srv-vercel"],
+      },
+    });
+    await ensureAdhocEnvironmentOperation.execute(
+      { host: "Claude Code", server: "Vercel" },
+      { client },
+    );
+    // The conflict is not an error: the other writer created exactly the group
+    // this run wanted, so it is adopted rather than suffixed around.
+    expect(groupBodies(fetchMock)).toEqual([
+      { name: "Vercel", serverIds: ["srv-vercel"] },
+    ]);
+    expect(bodyOf(fetchMock, /ensure-adhoc$/)).toEqual({
+      hostId: "host-claude",
+      serverAttachmentId: "grp-raced",
+    });
+  });
+
+  it("suffixes when the name is taken by a group holding OTHER servers", async () => {
+    const { client, fetchMock } = makeClient({
+      takenGroupNames: ["Vercel"],
+      serverGroups: [
+        { id: "grp-stale", name: "Vercel", serverIds: ["srv-sentry"] },
+      ],
+    });
+    await ensureAdhocEnvironmentOperation.execute(
+      { host: "Claude Code", server: "Vercel" },
+      { client },
+    );
+    expect(groupBodies(fetchMock)).toEqual([
+      { name: "Vercel", serverIds: ["srv-vercel"] },
+      { name: "Vercel (2)", serverIds: ["srv-vercel"] },
+    ]);
+    expect(bodyOf(fetchMock, /ensure-adhoc$/)).toEqual({
+      hostId: "host-claude",
+      serverAttachmentId: "grp-created-1",
+    });
+  });
+
+  it("names the escape hatch on a deployment without the routes", async () => {
+    // The routes ship with the inspector server, so a platform that has not
+    // taken that deploy 404s the ROUTE. A bare "not found" would name nothing
+    // the caller can act on, and --compose-server-group still works there.
+    const { client } = makeClient({ serverGroupsUnavailable: true });
+    const error = await ensureAdhocEnvironmentOperation
+      .execute({ host: "Claude Code", server: "Vercel" }, { client })
+      .catch((caught: unknown) => caught);
+    expect((error as PlatformApiError).message).toContain(
+      "--compose-server-group",
+    );
+  });
+
+  it("refuses a stdio server before writing anything", async () => {
+    const { client, fetchMock } = makeClient();
+    const error = await ensureAdhocEnvironmentOperation
+      .execute({ host: "Claude Code", server: "Local" }, { client })
+      .catch((caught: unknown) => caught);
+    expect((error as PlatformApiError).message).toContain(
+      "stdio servers are not supported",
+    );
+    expect(groupBodies(fetchMock)).toEqual([]);
+  });
+
+  it("refuses an unknown server name", async () => {
+    const { client } = makeClient();
+    const error = await ensureAdhocEnvironmentOperation
+      .execute({ host: "Claude Code", server: "Nope" }, { client })
+      .catch((caught: unknown) => caught);
+    expect((error as PlatformApiError).message).toContain("was not found");
+  });
+
+  it("rejects `servers` together with an explicit `serverGroup`", async () => {
+    // Both fill one slot. Guarded twice on purpose: the schema catches callers
+    // that parse their input, and `execute` catches the rest — without the
+    // second the resolved group would silently overwrite the explicit one.
+    const parsed = ensureAdhocEnvironmentOperation.inputSchema.safeParse({
+      host: "Claude Code",
+      server: "Vercel",
+      serverGroup: "grp-x",
+    });
+    expect(parsed.success).toBe(false);
+
+    const { client, fetchMock } = makeClient();
+    const error = await ensureAdhocEnvironmentOperation
+      .execute(
+        { host: "Claude Code", server: "Vercel", serverGroup: "grp-x" },
+        { client },
+      )
+      .catch((caught: unknown) => caught);
+    expect(String((error as Error).message)).toContain("not both");
+    expect(bodyOf(fetchMock, /ensure-adhoc$/)).toBeUndefined();
+  });
+
+  it("rejects the singular and plural spellings together", async () => {
+    const parsed = ensureAdhocEnvironmentOperation.inputSchema.safeParse({
+      host: "Claude Code",
+      server: "Vercel",
+      servers: ["Sentry"],
+    });
+    expect(parsed.success).toBe(false);
+
+    // The schema only runs for callers that parse. A direct `execute()` would
+    // otherwise drop `server`, silently spending the run on `servers`.
+    const { client, fetchMock } = makeClient();
+    const error = await ensureAdhocEnvironmentOperation
+      .execute(
+        { host: "Claude Code", server: "Vercel", servers: ["Sentry"] },
+        { client },
+      )
+      .catch((caught: unknown) => caught);
+    expect(String((error as Error).message)).toContain("not both");
+    expect(bodyOf(fetchMock, /ensure-adhoc$/)).toBeUndefined();
+  });
+
+  it("pins the same way for a single case run", async () => {
+    const { client, fetchMock } = makeClient();
+    await runEvalCaseOperation.execute(
+      {
+        suite: "Smoke",
+        case: "case-1",
+        compose: { host: "Claude Code", server: "Vercel" },
+      },
+      { client },
+    );
+    expect(bodyOf(fetchMock, /ensure-adhoc$/)).toEqual({
+      hostId: "host-claude",
+      serverAttachmentId: "grp-created-1",
+    });
   });
 });
 

--- a/sdk/tests/platform/operations-compose.test.ts
+++ b/sdk/tests/platform/operations-compose.test.ts
@@ -636,6 +636,40 @@ describe("compose server selectors", () => {
     expect(bodyOf(fetchMock, /ensure-adhoc$/)).toBeUndefined();
   });
 
+  it("does not accept a blank group as a pin", async () => {
+    // `resolveComposeStack` drops a blank id, so accepting `""` here would wave
+    // through the unpinned run this guard exists to refuse — presence is not
+    // the same question as "will a group actually be sent".
+    const { client, fetchMock } = makeClient();
+    const error = await runEvalSuiteOperation
+      .execute(
+        { suite: "Smoke", compose: { host: "Claude Code", serverGroup: "  " } },
+        { client },
+      )
+      .catch((caught: unknown) => caught);
+    expect(String((error as Error).message)).toContain("must say which servers");
+    expect(bodyOf(fetchMock, /ensure-adhoc$/)).toBeUndefined();
+  });
+
+  it("refuses following the host and pinning at once", async () => {
+    const { client, fetchMock } = makeClient();
+    const error = await runEvalSuiteOperation
+      .execute(
+        {
+          suite: "Smoke",
+          compose: {
+            host: "Claude Code",
+            server: "Vercel",
+            hostServers: true,
+          },
+        },
+        { client },
+      )
+      .catch((caught: unknown) => caught);
+    expect(String((error as Error).message)).toContain("cannot be combined");
+    expect(bodyOf(fetchMock, /ensure-adhoc$/)).toBeUndefined();
+  });
+
   it("pins the same way for a single case run", async () => {
     const { client, fetchMock } = makeClient();
     await runEvalCaseOperation.execute(


### PR DESCRIPTION
A composed eval with no pinned server group follows its HOST's live server list, so editing a shared host silently repoints every eval composed against it — a Vercel suite ran against Sentry after the ChatGPT host was swapped.

--compose-server <id-or-name...> resolves servers by name, snapshots them into a standalone server group, and pins that group on the ad-hoc environment. The host is never mutated.

Groups are reused by CONTENT rather than name: environments are content- addressed by group id, and a group a live environment pins cannot be deleted, so minting one per run would accumulate undeletable duplicates. Resolution runs once per run, not per model cell, so a matrix shares one group instead of racing itself into a name conflict.

No backend changes — the new /v1 server-group routes proxy the existing Convex serverAttachments functions, and ensureAdhocEnvironment already took a serverAttachmentId.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Composed eval runs must now name the servers they test: `--compose-server <id-or-name...>` (or `--compose-server-group <id>`) snapshots the named servers into a standalone pinned group, and `--compose-host-servers` restores the old behavior of following the host's live list. A run that only passed `--compose-host` previously resolved servers from that host's list at run time — so editing a shared host silently repointed every eval composed against it — and now fails with a message naming both flags. Passing `--compose-host-servers` alongside any pin is rejected, and a blank `serverGroup` no longer slips past the guard since it would have been dropped before hitting the wire anyway.

Adds `/v1/projects/{projectId}/server-groups` list/create routes and matching SDK methods that proxy the existing Convex `serverAttachments` functions; no backend changes.

**New Features**
- Groups are matched and reused by their server-id set, not by name, so a concurrent identical compose adopts one group instead of minting duplicates that can't be deleted once a live environment pins them.
- A name conflict triggers a re-list; the concurrent winner is adopted when its content matches, otherwise the name gets a ` (2)` suffix up to five attempts.
- Server resolution runs once per run, not per model cell, so a matrix shares one group instead of racing itself.
- `--compose-server` is mutually exclusive with `--compose-server-group`, and the singular `server` and plural `servers` spellings can't be combined.
- Proposal normalization freezes `server`/`servers` selectors to server IDs (all-or-nothing); if the platform can't resolve them, they're left as written.
- Platforms without the new routes fail with a message pointing to `--compose-server-group`.

<sup>Written for commit c592f5078a702c3772c4610349f30a7f20f6275e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/MCPJam/inspector/pull/4444?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

