### PR TITLE
Skills: one source, every surface

### DIFF
--- a/.changeset/skills-one-source-every-surface.md
+++ b/.changeset/skills-one-source-every-surface.md
@@ -1,0 +1,28 @@
+---
+"@mcpjam/inspector": minor
+---
+
+Skills come from one catalog now, not four disconnected ones
+
+A chat turn used to resolve its skills through an exclusive chain — project skills, or nothing, or the local filesystem — and which arm you got was decided by DEPLOYMENT rather than by what you had. That is why you could author a project skill in the Skills tab on desktop and then have no way to use it: authoring wrote to Convex, and the desktop turn only ever read the local filesystem.
+
+Where a skill comes from is a property of the skill, not a mode the app switches between. A turn now merges every origin available to it into one ref-addressed catalog:
+
+| Origin | Reference |
+|---|---|
+| Your project | `code-review` |
+| A local file | `local/code-review` |
+| A connected MCP server | `<server>/code-review` |
+| A plugin | `<plugin>/code-review` |
+
+So a desktop turn signed into a project offers your local files **and** your project skills, and a skill you author is usable in the very next message. Signed out, it offers local files exactly as before.
+
+Two skills sharing a name are no longer a conflict to resolve by luck. Both appear, both load by their own reference, and a bare name that more than one origin answers to is refused with the alternatives named rather than silently resolved to whichever was indexed first.
+
+**The v1 agent turn — and `send_chat_message` with it — sees project skills for the first time.** It could already read a connected server's skills; its own project's pool was invisible, so an agent driving MCPJam could read somebody else's skills but not yours.
+
+Two things worth knowing:
+
+The Skills tab's Local/Cloud switch now only changes what you are **browsing**; it does not decide what a turn can use. It is also gated on the Skills flag rather than `computers-enabled`, which was a leftover from when cloud skills lived on a Computer's filesystem — wrong in both directions, since it could offer a store the backend would refuse to write, or withhold one you had.
+
+Project skills stay lazily fetched: a turn costs one catalog query, and a skill's body is fetched only when the model actually loads it. A 200-skill project does not pay 200 fetches to build a listing.

--- a/docs/inspector/skills.mdx
+++ b/docs/inspector/skills.mdx
@@ -96,6 +96,45 @@ To update every installed skill at once:
 npx skills update
 ```
 
+## Where a turn's skills come from
+
+A chat turn builds **one catalog** from every origin available to it, rather
+than picking a single source:
+
+| Origin | Reference | Available on |
+|---|---|---|
+| Your project (Cloud Skills) | `code-review` | anywhere you're signed in with a project |
+| A local file | `local/code-review` | the desktop and npm app |
+| A connected MCP server | `<server>/code-review` | anywhere that server is connected |
+| A plugin | `<plugin>/code-review` | wherever the plugin is installed |
+
+This is why the Skills tab's Local/Cloud switch only changes what you are
+**browsing**. It no longer decides what the model can use: a desktop turn signed
+into a project offers your local files *and* your project skills, so a skill you
+author in the tab is usable in the very next message.
+
+Signed out, or with no project selected, a desktop turn simply has no project
+family — it offers local files, exactly as before.
+
+### Two skills with the same name
+
+Local and project skills are namespaced apart on purpose, so nothing is hidden
+and nothing is silently preferred. If you have a local `code-review` and a
+project `code-review`, both appear and both load:
+
+```
+loadSkill("local/code-review")  → your file
+loadSkill("code-review")        → the project's
+```
+
+Ask for a bare name that more than one origin answers to and the tool refuses,
+naming the alternatives rather than guessing:
+
+```
+"code-review" is ambiguous — it matches "code-review" and "local/code-review".
+Use the full reference.
+```
+
 ## Skills an agent writes for itself
 
 Harness runs (Claude Code, Codex) execute in a sandbox with a real filesystem, so

--- a/docs/inspector/skills.mdx
+++ b/docs/inspector/skills.mdx
@@ -127,12 +127,20 @@ loadSkill("local/code-review")  → your file
 loadSkill("code-review")        → the project's
 ```
 
-Ask for a bare name that more than one origin answers to and the tool refuses,
-naming the alternatives rather than guessing:
+**An exact reference always wins.** `code-review` *is* the project skill's
+reference, so asking for it is not ambiguous — it is a direct hit, and the local
+skill stays reachable under its own name. That is what keeps a project skill
+addressable no matter what you happen to have on disk.
+
+Ambiguity is the case where nothing is an exact hit: two *namespaced* skills
+share a name and no skill answers to the bare name itself — a plugin
+`docs-tools/code-review` alongside a local `local/code-review`, with no project
+`code-review`. There the tool refuses and names the alternatives rather than
+guessing:
 
 ```
-"code-review" is ambiguous — it matches "code-review" and "local/code-review".
-Use the full reference.
+"code-review" is ambiguous — it matches "docs-tools/code-review" and
+"local/code-review". Use the full reference.
 ```
 
 ## Skills an agent writes for itself

--- a/mcpjam-inspector/client/src/App.tsx
+++ b/mcpjam-inspector/client/src/App.tsx
@@ -1960,7 +1960,10 @@ export function SkillsRoute() {
   // The same flag also decides whether the local-mode Local/Cloud toggle is
   // offered, because that toggle browses the project store: gating it on
   // `computers-enabled` was a leftover from when cloud skills lived on a
-  // Computer's filesystem.
+  // Computer's filesystem. That is why the prop below is the flag itself and
+  // not `!HOSTED_MODE || flag` — the old form read as "local mode always has
+  // the store", which was harmless while the toggle carried its own gate and
+  // becomes "no gate at all" the moment the toggle reads this prop instead.
   if (HOSTED_MODE && !convexProjectId) {
     // Wait for the project to resolve before rendering: hosted skills have no
     // local FS to fall back to, and the server-skills routes address their
@@ -1980,7 +1983,7 @@ export function SkillsRoute() {
       // renders its protocol half immediately and the Cloud store appears when
       // the flag resolves — content arriving is a better first paint than a
       // blank page for every user who only has the protocol half.
-      cloudSkillsEnabled={!HOSTED_MODE || skillsEnabled === true}
+      cloudSkillsEnabled={skillsEnabled === true}
     />
   );
 

--- a/mcpjam-inspector/client/src/App.tsx
+++ b/mcpjam-inspector/client/src/App.tsx
@@ -1938,7 +1938,6 @@ export function SkillsRoute() {
   );
   const [previewedHostId] = usePreviewedHostId(convexProjectId);
   const navigate = useAppNavigate();
-  const computersEnabled = useComputersEnabledState();
   const skillsEnabled = useSkillsEnabledState();
 
   // Skills is a Servers-page view (Servers | Client | Computer | Skills), so
@@ -1958,9 +1957,10 @@ export function SkillsRoute() {
   // whole route on the Cloud flag would hold the protocol half hostage to an
   // unrelated feature's rollout, so the flag is passed DOWN instead.
   //
-  // `computersEnabled` is passed through only for the local-mode Local/Cloud
-  // toggle; the skills flag applies to hosted mode only (local FS skills are
-  // always available).
+  // The same flag also decides whether the local-mode Local/Cloud toggle is
+  // offered, because that toggle browses the project store: gating it on
+  // `computers-enabled` was a leftover from when cloud skills lived on a
+  // Computer's filesystem.
   if (HOSTED_MODE && !convexProjectId) {
     // Wait for the project to resolve before rendering: hosted skills have no
     // local FS to fall back to, and the server-skills routes address their
@@ -1971,7 +1971,6 @@ export function SkillsRoute() {
   const skillsView = (
     <SkillsTab
       projectId={convexProjectId}
-      computersEnabled={computersEnabled === true}
       // Skills over MCP (SEP-2640): the "From MCP servers" section reads its
       // catalog live, per connection, so it needs the CURRENT server list —
       // the label (host-assigned, from our registry) and whether the

--- a/mcpjam-inspector/client/src/__tests__/SkillsRoute.flag-hydration.test.tsx
+++ b/mcpjam-inspector/client/src/__tests__/SkillsRoute.flag-hydration.test.tsx
@@ -23,7 +23,9 @@ vi.mock("../hooks/useSkillsEnabled", () => ({
   useSkillsEnabled: () => flagState === true,
 }));
 
-// Skills renders the local/cloud toggle off the computers flag; irrelevant here.
+// The route no longer reads this flag — the Local/Cloud browse toggle moved to
+// `skills-enabled` with the rest of the project store. Mocked because App.tsx's
+// module graph still calls it elsewhere.
 vi.mock("../hooks/useComputersEnabled", () => ({
   COMPUTERS_FEATURE_FLAG: "computers-enabled",
   useComputersEnabledState: () => true,

--- a/mcpjam-inspector/client/src/__tests__/SkillsRoute.local-connect-chrome.test.tsx
+++ b/mcpjam-inspector/client/src/__tests__/SkillsRoute.local-connect-chrome.test.tsx
@@ -4,7 +4,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 const { hostedMode, skillsFlag, mockRouteContext, mockNavigate } = vi.hoisted(
   () => ({
     hostedMode: { value: false },
-    skillsFlag: { value: true },
+    skillsFlag: { value: true as boolean | undefined },
     mockRouteContext: {
       convexProjectId: "project-1" as string | null,
       isAuthenticated: true,
@@ -18,7 +18,7 @@ const { hostedMode, skillsFlag, mockRouteContext, mockNavigate } = vi.hoisted(
 vi.mock("../hooks/useSkillsEnabled", () => ({
   SKILLS_FEATURE_FLAG: "skills-enabled",
   useSkillsEnabledState: () => skillsFlag.value,
-  useSkillsEnabled: () => skillsFlag.value,
+  useSkillsEnabled: () => skillsFlag.value === true,
 }));
 
 vi.mock("../hooks/useComputersEnabled", () => ({
@@ -49,7 +49,12 @@ vi.mock("react-router", async (importOriginal) => {
 });
 
 vi.mock("../components/SkillsTab", () => ({
-  SkillsTab: () => <div data-testid="skills-view" />,
+  SkillsTab: ({ cloudSkillsEnabled }: { cloudSkillsEnabled?: boolean }) => (
+    <div
+      data-testid="skills-view"
+      data-cloud-skills={String(cloudSkillsEnabled)}
+    />
+  ),
 }));
 
 vi.mock("../components/hosts/ConnectViewHeader", () => ({
@@ -135,5 +140,50 @@ describe("SkillsRoute — local Connect chrome", () => {
 
     expect(screen.queryByTestId("connect-header")).not.toBeInTheDocument();
     expect(screen.getByTestId("skills-view")).toBeInTheDocument();
+  });
+});
+
+/**
+ * The project store's gate must be the FLAG, in local mode too.
+ *
+ * It reached the tab as `!HOSTED_MODE || flag`, which is unconditionally true
+ * on the desktop. That was harmless only while the Local/Cloud toggle carried
+ * its own separate `computers-enabled` gate; the moment the toggle started
+ * reading this prop — which is the correct flag for it — the tautology became
+ * "no gate at all", offering every local user a switch to a store the backend
+ * gates independently.
+ */
+describe("SkillsRoute — the project store's gate in local mode", () => {
+  it("passes the flag through rather than a local-mode tautology", () => {
+    skillsFlag.value = false;
+
+    render(<SkillsRoute />);
+
+    expect(screen.getByTestId("skills-view")).toHaveAttribute(
+      "data-cloud-skills",
+      "false"
+    );
+  });
+
+  it("treats the pre-hydration window as off", () => {
+    skillsFlag.value = undefined;
+
+    render(<SkillsRoute />);
+
+    expect(screen.getByTestId("skills-view")).toHaveAttribute(
+      "data-cloud-skills",
+      "false"
+    );
+  });
+
+  it("turns the store on once the flag resolves true", () => {
+    skillsFlag.value = true;
+
+    render(<SkillsRoute />);
+
+    expect(screen.getByTestId("skills-view")).toHaveAttribute(
+      "data-cloud-skills",
+      "true"
+    );
   });
 });

--- a/mcpjam-inspector/client/src/components/SkillsTab.tsx
+++ b/mcpjam-inspector/client/src/components/SkillsTab.tsx
@@ -61,10 +61,8 @@ import { SkillsFileTree } from "./skills/SkillsFileTree";
 import { SkillFileViewer } from "./skills/SkillFileViewer";
 
 interface SkillsTabProps {
-  /** Convex project id — required to address the cloud (computer) skill store. */
+  /** Convex project id — required to address the project skill store. */
   projectId?: string;
-  /** Whether the Computer feature is enabled for this user (PostHog gate). */
-  computersEnabled?: boolean;
   /**
    * Connected MCP servers, for the SEP-2640 "From MCP servers" section. Read
    * LIVE per connection (never from a cache), so a disconnected server simply
@@ -90,13 +88,23 @@ interface SkillsTabProps {
 
 export function SkillsTab({
   projectId,
-  computersEnabled,
   mcpServers,
   cloudSkillsEnabled = true,
 }: SkillsTabProps = {}) {
-  // Skills data source. Hosted mode has no local FS, so it's always cloud.
-  // Locally, when the Computer feature is on, the user can toggle Local⇄Cloud.
-  const showSourceToggle = !HOSTED_MODE && !!computersEnabled && !!projectId;
+  // Which store the tab BROWSES. Hosted mode has no local filesystem, so it is
+  // always the project store; locally the user can switch.
+  //
+  // Gated on the project store's own release flag, not on `computers-enabled`.
+  // The two were conflated when cloud skills lived on a Computer's filesystem,
+  // and that stopped being true when Convex became the source of truth — so a
+  // user with Skills released and Computers not had no way to reach their own
+  // project skills, while a user with the reverse got a toggle to a store they
+  // could not write to.
+  //
+  // Note this is a BROWSING choice only. It no longer decides what a chat turn
+  // can use: a turn merges local files and project skills into one catalog
+  // regardless of what this tab is showing.
+  const showSourceToggle = !HOSTED_MODE && !!cloudSkillsEnabled && !!projectId;
   const [source, setSource] = useState<"local" | "cloud">(
     HOSTED_MODE ? "cloud" : "local"
   );

--- a/mcpjam-inspector/client/src/components/__tests__/SkillsTab.source-toggle.test.tsx
+++ b/mcpjam-inspector/client/src/components/__tests__/SkillsTab.source-toggle.test.tsx
@@ -1,0 +1,64 @@
+/**
+ * Which flag decides the Local⇄Cloud browse toggle.
+ *
+ * It used to be `computers-enabled`, a leftover from when cloud skills lived on
+ * a Computer's filesystem. That stopped being true when Convex became the
+ * source of truth, and the mismatch was reachable in both directions: a user
+ * with Skills released but Computers not had no way to reach their own project
+ * skills, and a user with the reverse got a toggle to a store they could not
+ * write to.
+ *
+ * `HOSTED_MODE: false` throughout — hosted has no local filesystem, so there is
+ * nothing to toggle between there.
+ */
+import { render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("@/lib/apis/mcp-skills-api", () => ({
+  listSkills: vi.fn(async () => []),
+  getSkill: vi.fn(async () => null),
+  deleteSkill: vi.fn(),
+  listSkillFiles: vi.fn(async () => []),
+  readSkillFile: vi.fn(async () => null),
+  promoteSkill: vi.fn(),
+}));
+
+vi.mock("@/lib/config", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@/lib/config")>();
+  return { ...actual, HOSTED_MODE: false };
+});
+
+vi.mock("../skills/ServerSkillsSection", () => ({
+  ServerSkillsSection: () => <div data-testid="server-skills" />,
+}));
+
+vi.mock("@/lib/analytics", () => ({ track: vi.fn() }));
+
+import { SkillsTab } from "../SkillsTab";
+
+afterEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("SkillsTab — the Local/Cloud browse toggle", () => {
+  it("is offered when the project store is released to this user", () => {
+    render(<SkillsTab projectId="project-1" cloudSkillsEnabled />);
+
+    expect(screen.getByText("Cloud")).toBeInTheDocument();
+    expect(screen.getByText("Local")).toBeInTheDocument();
+  });
+
+  it("is withheld when the project store is not released", () => {
+    // Offering a switch to a store the backend will refuse to write is worse
+    // than not offering it: the failure arrives after the user has committed.
+    render(<SkillsTab projectId="project-1" cloudSkillsEnabled={false} />);
+
+    expect(screen.queryByText("Cloud")).not.toBeInTheDocument();
+  });
+
+  it("is withheld with no project to address, however the flags read", () => {
+    render(<SkillsTab cloudSkillsEnabled />);
+
+    expect(screen.queryByText("Cloud")).not.toBeInTheDocument();
+  });
+});

--- a/mcpjam-inspector/client/src/components/__tests__/SkillsTab.source-toggle.test.tsx
+++ b/mcpjam-inspector/client/src/components/__tests__/SkillsTab.source-toggle.test.tsx
@@ -61,4 +61,13 @@ describe("SkillsTab — the Local/Cloud browse toggle", () => {
 
     expect(screen.queryByText("Cloud")).not.toBeInTheDocument();
   });
+
+  it("treats an empty project id as no project, not as one named \"\"", () => {
+    // The gate is `!!projectId`, so this is the boundary between "absent" and
+    // "present but unusable" — and a store keyed on an empty id addresses
+    // nothing the backend would accept.
+    render(<SkillsTab projectId="" cloudSkillsEnabled />);
+
+    expect(screen.queryByText("Cloud")).not.toBeInTheDocument();
+  });
 });

--- a/mcpjam-inspector/server/routes/mcp/__tests__/chat-v2.test.ts
+++ b/mcpjam-inspector/server/routes/mcp/__tests__/chat-v2.test.ts
@@ -220,6 +220,10 @@ vi.mock("../../../utils/skill-tools", () => ({
     tools: {},
     systemPromptSection: "",
   }),
+  // The route scans the local filesystem to build its half of the turn's skill
+  // catalog. These tests run wherever CI does, so the real scan would make the
+  // assertions depend on the machine's `~/.claude/skills`.
+  listLocalRuntimeSkills: vi.fn().mockResolvedValue([]),
 }));
 
 describe("POST /api/mcp/chat-v2", () => {
@@ -909,6 +913,43 @@ describe("POST /api/mcp/chat-v2", () => {
         Object.keys(options.tools).filter((name) => /^ui_/.test(name))
       ).toEqual([]);
       expect(options.system ?? "").not.toContain("MCPJam UI tools");
+    });
+
+    it("offers local skills through the merged catalog, addressed by ref", async () => {
+      // The desktop turn used to get a bare-name local surface. It now gets the
+      // same ref-addressed catalog every other surface has, so a local skill is
+      // `local/<name>` and says where it came from.
+      const { listLocalRuntimeSkills } = await import(
+        "../../../utils/skill-tools"
+      );
+      vi.mocked(listLocalRuntimeSkills).mockResolvedValueOnce([
+        {
+          skillId: "local:/home/u/.claude/skills/code-review",
+          ref: "local/code-review",
+          name: "code-review",
+          description: "Review code, locally.",
+          content: "# Local code-review",
+          aggregateHash: "hash-local",
+          directory: "~/.claude/skills/code-review",
+          files: [],
+        },
+      ] as never);
+      const { streamText } = await import("ai");
+
+      const res = await postJson(app, "/api/mcp/chat-v2", {
+        messages: [{ role: "user", content: "Hello" }],
+        model: { id: "gpt-4", provider: "openai" },
+        apiKey: "test-key",
+      });
+
+      expect(res.status).toBe(200);
+      const options = vi.mocked(streamText).mock.calls.at(-1)![0] as {
+        tools: Record<string, unknown>;
+        system?: string;
+      };
+      expect(options.system ?? "").toContain("**local/code-review**");
+      expect(options.system ?? "").toContain("~/.claude/skills/code-review");
+      expect(Object.keys(options.tools)).toContain("loadSkill");
     });
 
     it("a server tool named ui_navigate stays executable with ordinary approval — never claimed by a stale UI snapshot", async () => {

--- a/mcpjam-inspector/server/routes/mcp/chat-v2.ts
+++ b/mcpjam-inspector/server/routes/mcp/chat-v2.ts
@@ -1275,18 +1275,28 @@ chatV2.post("/", async (c) => {
     //
     // Signed out, or with no project: local-only, which is exactly what this
     // route did before. What is new is that signing IN no longer means choosing.
-    const localRuntimeSkills = await listLocalRuntimeSkills().catch((error) => {
-      logger.warn(
-        "[chat-v2] local skill scan failed; continuing without them",
-        {
-          error: error instanceof Error ? error.message : String(error),
-        },
-      );
-      return [];
-    });
+    //
+    // A HARNESS turn gathers nothing here. It is handed `{ kind: "none" }`
+    // below — the two delivery channels are deliberately disjoint — and
+    // `runHarnessTurn` fetches the project catalog itself for its native
+    // delivery. Gathering anyway would mean a second catalog request whose
+    // result is thrown away, and on a slow failure the whole fetch timeout
+    // charged to a turn that never wanted it.
+    const gathersInMemorySkills = !resolvedExecution.harness;
+    const localRuntimeSkills = gathersInMemorySkills
+      ? await listLocalRuntimeSkills().catch((error) => {
+          logger.warn(
+            "[chat-v2] local skill scan failed; continuing without them",
+            {
+              error: error instanceof Error ? error.message : String(error),
+            },
+          );
+          return [];
+        })
+      : [];
     let cloudRuntimeSkills: RuntimeStandaloneSkill[] = [];
     let skillsFetchFailed: SkillsFetchFailure | undefined;
-    if (requestAuthHeader && body.projectId) {
+    if (gathersInMemorySkills && requestAuthHeader && body.projectId) {
       const startedAt = Date.now();
       try {
         cloudRuntimeSkills = await listCloudRuntimeSkills({

--- a/mcpjam-inspector/server/routes/mcp/chat-v2.ts
+++ b/mcpjam-inspector/server/routes/mcp/chat-v2.ts
@@ -6,6 +6,14 @@ import {
 } from "ai";
 import type { ChatV2Request } from "@/shared/chat-v2";
 import { createLlmModel } from "../../utils/chat-helpers";
+import { listLocalRuntimeSkills } from "../../utils/skill-tools.js";
+import {
+  listCloudRuntimeSkills,
+  skillsFailureFrom,
+} from "../../utils/computers/cloud-skill-tools.js";
+import { buildLiveEffectiveCapabilities } from "../../services/environments/effective-capabilities.js";
+import type { RuntimeStandaloneSkill } from "../../services/environments/effective-capabilities.js";
+import type { SkillsFetchFailure } from "../../utils/computers/cloud-skill-tools.js";
 import { getCanonicalModelId } from "@/shared/types";
 import type { ModelProvider } from "@/shared/types";
 import { isHostedCatalogModel } from "../../services/hosted-model-catalog.js";
@@ -1258,6 +1266,48 @@ chatV2.post("/", async (c) => {
       });
     }
 
+    // ONE catalog for this turn, replacing the exclusive either/or the
+    // orchestrator used to pick between.
+    //
+    // Local files are always in it (this route only runs where there IS a local
+    // filesystem). The project's skills join them when the request is
+    // authenticated and names a project — the same three conditions
+    // `shouldEnableCloudSkillTools` applies on the hosted routes, restated here
+    // because this route derives guest-ness from the absence of an
+    // Authorization header rather than from a guest id.
+    //
+    // Signed out, or with no project: local-only, which is exactly what this
+    // route did before. What is new is that signing IN no longer means choosing.
+    const localRuntimeSkills = await listLocalRuntimeSkills().catch((error) => {
+      logger.warn("[chat-v2] local skill scan failed; continuing without them", {
+        error: error instanceof Error ? error.message : String(error),
+      });
+      return [];
+    });
+    let cloudRuntimeSkills: RuntimeStandaloneSkill[] = [];
+    let skillsFetchFailed: SkillsFetchFailure | undefined;
+    if (requestAuthHeader && body.projectId) {
+      try {
+        cloudRuntimeSkills = await listCloudRuntimeSkills({
+          authHeader: requestAuthHeader,
+          projectId: body.projectId,
+        });
+      } catch (error) {
+        // A failed catalog fetch is NOT an empty project, and the difference is
+        // what tells "this user has no skills" from "we lost their skills this
+        // turn". Same signal the hosted path already reports.
+        skillsFetchFailed = skillsFailureFrom(error, 0);
+        logger.warn("[chat-v2] project skill catalog fetch failed", {
+          projectId: body.projectId,
+          message: skillsFetchFailed.message,
+        });
+      }
+    }
+    const turnCapabilities = buildLiveEffectiveCapabilities({
+      standaloneSkills: cloudRuntimeSkills,
+      localSkills: localRuntimeSkills,
+    });
+
     let prepared;
     try {
       prepared = await prepareChatV2({
@@ -1276,6 +1326,17 @@ chatV2.post("/", async (c) => {
           : {}),
         ...(tasksSeam ? { tasks: tasksSeam } : {}),
         ...(builtInTools ? { builtInTools } : {}),
+        // A harness turn takes its skills on-box and must be handed none here —
+        // the two delivery channels are deliberately disjoint.
+        skillsSource: resolvedExecution.harness
+          ? { kind: "none" as const }
+          : {
+              kind: "resolved" as const,
+              capabilities: turnCapabilities,
+              // Live surface: server skills come from the connected servers,
+              // not from a captured set.
+              composeLiveServerSkills: true,
+            },
         // Body for direct chat (project default), host-re-resolved for
         // scenario-bound sessions. undefined → auto policy.
         ...(resolvedProgressiveToolDiscovery !== undefined

--- a/mcpjam-inspector/server/routes/mcp/chat-v2.ts
+++ b/mcpjam-inspector/server/routes/mcp/chat-v2.ts
@@ -206,7 +206,7 @@ function formatStreamError(error: unknown, provider?: ModelProvider): string {
 }
 
 function toPersistedUsage(
-  usage: LiveChatTraceUsage | undefined
+  usage: LiveChatTraceUsage | undefined,
 ): { inputTokens: number; outputTokens: number } | undefined {
   if (
     typeof usage?.inputTokens !== "number" ||
@@ -224,7 +224,7 @@ function toPersistedUsage(
 function buildScopeStepUpErrorToolResult(
   toolCallId: string,
   toolName: string,
-  message: string
+  message: string,
 ): ModelMessage {
   return {
     role: "tool",
@@ -243,7 +243,7 @@ function readProtectedResourceUrl(
   mcpClientManager: {
     getServerConfig?: (serverId: string) => unknown;
   },
-  serverId: string
+  serverId: string,
 ): string | undefined {
   const config = mcpClientManager.getServerConfig?.(serverId);
   if (!config || typeof config !== "object") return undefined;
@@ -288,7 +288,7 @@ function buildLocalScopeStepUpResume(input: {
       ) {
         failLocalScopeStepUpContinuation(
           claimed.continuationId,
-          "original tool is no longer available"
+          "original tool is no longer available",
         );
         return {
           kind: "halted",
@@ -346,7 +346,7 @@ function buildLocalScopeStepUpResume(input: {
         if (repeatedChallenge) {
           failLocalScopeStepUpContinuation(
             claimed.continuationId,
-            "insufficient_scope repeated after authorization"
+            "insufficient_scope repeated after authorization",
           );
           return {
             kind: "recover",
@@ -356,13 +356,13 @@ function buildLocalScopeStepUpResume(input: {
               buildScopeStepUpErrorToolResult(
                 claimed.toolCallId,
                 claimed.toolName,
-                "Authorization completed, but the server still rejected the requested scope."
+                "Authorization completed, but the server still rejected the requested scope.",
               ),
           };
         }
         cancelLocalScopeStepUpContinuation(
           claimed.continuationId,
-          "tool replay failed after the request started"
+          "tool replay failed after the request started",
         );
         return {
           kind: "halted",
@@ -375,7 +375,7 @@ function buildLocalScopeStepUpResume(input: {
       if (!resultMessage) {
         failLocalScopeStepUpContinuation(
           claimed.continuationId,
-          "tool replay returned no result"
+          "tool replay returned no result",
         );
         return {
           kind: "halted",
@@ -437,7 +437,7 @@ function buildLocalScopeStepUpCancellation(input: {
           toolResultMessage: buildScopeStepUpErrorToolResult(
             input.request.toolCallId,
             cancelled.toolName,
-            "Authorization was not completed, so the tool was not retried."
+            "Authorization was not completed, so the tool was not retried.",
           ),
         };
       } catch (error) {
@@ -514,8 +514,7 @@ function streamDirectChatWithLiveTrace(options: {
   // chain — cheaper than widening the engine's signature for every headless
   // caller that will never emit a receipt.
   let persistReceipt:
-    | { outcome: PersistChatOutcome; turnId: string }
-    | undefined;
+    { outcome: PersistChatOutcome; turnId: string } | undefined;
   // Declared before `createUIMessageStream` so the top-level `onError`
   // (which can fire before `execute` runs) can read it; assigned inside
   // `execute` once the helper is configured.
@@ -617,7 +616,7 @@ function streamDirectChatWithLiveTrace(options: {
             continue;
           }
           writer.write(
-            withMcpToolOriginChunkMetadata(chunk, turnOptions.tools)
+            withMcpToolOriginChunkMetadata(chunk, turnOptions.tools),
           );
         }
       } catch (error) {
@@ -681,7 +680,7 @@ chatV2.post("/", async (c) => {
     if (scopeStepUpResumeRequest && scopeStepUpCancelRequest) {
       return c.json(
         { error: "Only one scope step-up continuation action is allowed" },
-        400
+        400,
       );
     }
     const {
@@ -711,7 +710,7 @@ chatV2.post("/", async (c) => {
           error:
             "Project Environments can't run on local /api/mcp execution — use the hosted chat route.",
         },
-        400
+        400,
       );
     }
     const isScenarioSession = Boolean(bodyScenarioId);
@@ -725,7 +724,7 @@ chatV2.post("/", async (c) => {
       ? "scenario"
       : "playground";
     const chatSessionSurface: "preview" | "share_link" | undefined =
-      isScenarioSession ? bodySurface ?? "preview" : undefined;
+      isScenarioSession ? (bodySurface ?? "preview") : undefined;
 
     // Scenario-bound turns re-resolve execution config from Convex so the
     // host's hostConfigs row is the source of truth (model / prompt /
@@ -769,7 +768,7 @@ chatV2.post("/", async (c) => {
             error:
               "Couldn't authenticate this scenario turn to load its settings — sign in (or retry) to continue.",
           },
-          401
+          401,
         );
       }
       {
@@ -795,7 +794,7 @@ chatV2.post("/", async (c) => {
               scenarioId: bodyScenarioId,
               status: runtime.status,
               error: runtime.error,
-            }
+            },
           );
           const failClosedMessage = `Couldn't load this scenario's settings, so the turn was stopped to avoid running with the wrong configuration. ${runtime.error}`;
           // This route hand-rolls its error envelope (no WebRouteError), so
@@ -806,20 +805,20 @@ chatV2.post("/", async (c) => {
           if (runtime.code === "SCENARIO_ACCESS_STALE") {
             return c.json(
               { error: failClosedMessage, code: "SCENARIO_ACCESS_STALE" },
-              409
+              409,
             );
           }
           if (runtime.status === 403) {
             return c.json(
               { error: failClosedMessage, code: "SCENARIO_ACCESS_DENIED" },
-              403
+              403,
             );
           }
           return c.json(
             { error: failClosedMessage },
             runtime.status >= 500
               ? 502
-              : (runtime.status as 400 | 401 | 403 | 409)
+              : (runtime.status as 400 | 401 | 403 | 409),
           );
         }
       }
@@ -841,13 +840,13 @@ chatV2.post("/", async (c) => {
       } else {
         logger.warn(
           "[mcp/chat-v2] host runtime-config fetch failed; failing closed",
-          { hostId: bodyHostId, status: runtime.status, error: runtime.error }
+          { hostId: bodyHostId, status: runtime.status, error: runtime.error },
         );
         return c.json(
           {
             error: `Couldn't load this host's settings, so the turn was stopped to avoid running with the wrong engine. ${runtime.error}`,
           },
-          runtime.status >= 500 ? 502 : (runtime.status as 400 | 401 | 403)
+          runtime.status >= 500 ? 502 : (runtime.status as 400 | 401 | 403),
         );
       }
     }
@@ -880,7 +879,7 @@ chatV2.post("/", async (c) => {
             scenarioId: bodyScenarioId,
             body: entry.overrideValue,
             host: entry.hostValue,
-          }
+          },
         );
       } else if (entry.field === "progressiveToolDiscovery") {
         logger.warn(
@@ -889,7 +888,7 @@ chatV2.post("/", async (c) => {
             scenarioId: bodyScenarioId,
             body: entry.overrideValue,
             host: entry.hostValue,
-          }
+          },
         );
       } else if (entry.field === "respectToolVisibility") {
         logger.warn(
@@ -898,7 +897,7 @@ chatV2.post("/", async (c) => {
             scenarioId: bodyScenarioId,
             body: entry.overrideValue,
             host: entry.hostValue,
-          }
+          },
         );
       } else if (
         entry.field === "modelVisibleMcpToolResults" ||
@@ -910,7 +909,7 @@ chatV2.post("/", async (c) => {
             scenarioId: bodyScenarioId,
             body: entry.overrideValue,
             host: entry.hostValue,
-          }
+          },
         );
       }
     }
@@ -944,7 +943,7 @@ chatV2.post("/", async (c) => {
           body: model.id,
           host: hostModelId,
           provider: hostModel.provider,
-        }
+        },
       );
       resolvedModelOverride = hostModel;
     }
@@ -998,7 +997,7 @@ chatV2.post("/", async (c) => {
     // org/BYOK below even after they passed the harness preflight.
     const isMcpJamProvidedModel = Boolean(
       modelDefinition.id &&
-        isHostedCatalogModel(modelDefinition.id, modelDefinition.provider)
+      isHostedCatalogModel(modelDefinition.id, modelDefinition.provider),
     );
     // Guests may use any hosted model — model curation for guests is gone;
     // the backend enforces spend caps (a soft postpaid guard), not an
@@ -1032,7 +1031,7 @@ chatV2.post("/", async (c) => {
     // independent — this conversion is solely for hydration.
     const priorModelMessages = await convertToMcpjamModelMessages(
       messages,
-      inboundMcpToolResultModelOutputOptions
+      inboundMcpToolResultModelOutputOptions,
     );
 
     // SEP-1865 App-Provided Tools: validate the client snapshot at the
@@ -1073,7 +1072,7 @@ chatV2.post("/", async (c) => {
     let validatedWidgetModelContext;
     try {
       validatedWidgetModelContext = validateWidgetModelContextEntries(
-        body.widgetModelContext
+        body.widgetModelContext,
       );
     } catch (error) {
       if (error instanceof WidgetModelContextValidationError) {
@@ -1103,7 +1102,7 @@ chatV2.post("/", async (c) => {
         // Read from the server-resolved host config, never the body.
         xaaEnterprisePolicyOn:
           readXaaEnterprisePolicy(
-            (hostRuntimeConfig as { mcpProfile?: unknown } | null)?.mcpProfile
+            (hostRuntimeConfig as { mcpProfile?: unknown } | null)?.mcpProfile,
           ).kind !== "off",
       });
       if (!availability.ok) {
@@ -1111,7 +1110,7 @@ chatV2.post("/", async (c) => {
           {
             error: `This host runs the ${resolvedExecution.harness} harness, which isn't available: ${availability.reason}.`,
           },
-          503
+          503,
         );
       }
     }
@@ -1126,9 +1125,7 @@ chatV2.post("/", async (c) => {
     // access (per-swarm isolation/caps). Absent ⇒ legacy projectId reserve.
     const executionScope = (
       hostRuntimeConfig as
-        | { executionScope?: ExecutionScope }
-        | null
-        | undefined
+        { executionScope?: ExecutionScope } | null | undefined
     )?.executionScope;
 
     // Local⇄Cloud engine preference — a LOCAL-ROUTE-ONLY channel (this route
@@ -1152,7 +1149,7 @@ chatV2.post("/", async (c) => {
     if (enginePref === "local" && !localPrefEligible) {
       logger.debug(
         "[mcp/chat-v2] computerEngine=local ignored for an ineligible request",
-        { isScenarioSession, isGuest: requestIsGuest }
+        { isScenarioSession, isGuest: requestIsGuest },
       );
     }
     const localConsentValid = localPrefEligible
@@ -1160,15 +1157,15 @@ chatV2.post("/", async (c) => {
       : false;
     if (localPrefEligible && !localConsentValid) {
       logger.warn(
-        "[mcp/chat-v2] computerEngine=local without a valid consent capability; local engine unavailable for this turn"
+        "[mcp/chat-v2] computerEngine=local without a valid consent capability; local engine unavailable for this turn",
       );
     }
     const computerEngine = resolvePersonalComputerEngine({
       ...(localPrefEligible
         ? { preference: "local" as const }
         : enginePref === "cloud"
-        ? { preference: "cloud" as const }
-        : {}),
+          ? { preference: "cloud" as const }
+          : {}),
       localConsentValid,
     });
 
@@ -1203,7 +1200,7 @@ chatV2.post("/", async (c) => {
             computerEngine,
             localComputerRequested: localPrefEligible,
           }
-        : null
+        : null,
     );
 
     // Blueprint knowledge/maintenance: when this turn advertises bash, append
@@ -1279,9 +1276,12 @@ chatV2.post("/", async (c) => {
     // Signed out, or with no project: local-only, which is exactly what this
     // route did before. What is new is that signing IN no longer means choosing.
     const localRuntimeSkills = await listLocalRuntimeSkills().catch((error) => {
-      logger.warn("[chat-v2] local skill scan failed; continuing without them", {
-        error: error instanceof Error ? error.message : String(error),
-      });
+      logger.warn(
+        "[chat-v2] local skill scan failed; continuing without them",
+        {
+          error: error instanceof Error ? error.message : String(error),
+        },
+      );
       return [];
     });
     let cloudRuntimeSkills: RuntimeStandaloneSkill[] = [];
@@ -1396,7 +1396,7 @@ chatV2.post("/", async (c) => {
     }) => {
       const resourceUrl = readProtectedResourceUrl(
         mcpClientManager,
-        info.serverId
+        info.serverId,
       );
       const event = createLocalScopeStepUpContinuation({
         bindingKey: scopeStepUpBindingKey,
@@ -1421,7 +1421,7 @@ chatV2.post("/", async (c) => {
             toolName,
             toolInput,
           }),
-      }
+      },
     );
     const scopeStepUpEngineResume = scopeStepUpResumeRequest
       ? buildLocalScopeStepUpResume({
@@ -1431,13 +1431,13 @@ chatV2.post("/", async (c) => {
           modelVisibleMcpToolResults,
         })
       : scopeStepUpCancelRequest
-      ? buildLocalScopeStepUpCancellation({
-          request: scopeStepUpCancelRequest,
-          bindingKey: scopeStepUpBindingKey,
-        })
-      : undefined;
+        ? buildLocalScopeStepUpCancellation({
+            request: scopeStepUpCancelRequest,
+            bindingKey: scopeStepUpBindingKey,
+          })
+        : undefined;
     const widgetModelContextSystemPrompt = buildWidgetModelContextSystemPrompt(
-      validatedWidgetModelContext
+      validatedWidgetModelContext,
     );
     const effectiveEnhancedSystemPrompt = [
       enhancedSystemPrompt,
@@ -1475,7 +1475,7 @@ chatV2.post("/", async (c) => {
       if (!process.env.CONVEX_HTTP_URL) {
         return c.json(
           { error: "Server missing CONVEX_HTTP_URL configuration" },
-          500
+          500,
         );
       }
 
@@ -1488,13 +1488,13 @@ chatV2.post("/", async (c) => {
             error:
               "Unable to authenticate with MCPJam servers. Please try again or sign in.",
           },
-          503
+          503,
         );
       }
 
       const modelMessages = await convertToMcpjamModelMessages(
         messages,
-        inboundMcpToolResultModelOutputOptions
+        inboundMcpToolResultModelOutputOptions,
       );
       const sessionStartedAt = Date.now();
 
@@ -1594,7 +1594,7 @@ chatV2.post("/", async (c) => {
                 sessionMessages: stampSenderUserIdsOnSessionMessages(
                   fullHistory,
                   messages,
-                  { authenticatedUserId }
+                  { authenticatedUserId },
                 ),
                 startedAt: sessionStartedAt,
                 lastActivityAt: Date.now(),
@@ -1647,8 +1647,8 @@ chatV2.post("/", async (c) => {
       const modelMessages = scrubMessages(
         await convertToMcpjamModelMessages(
           messages,
-          inboundMcpToolResultModelOutputOptions
-        )
+          inboundMcpToolResultModelOutputOptions,
+        ),
       );
       const sessionStartedAt = Date.now();
       const chatSessionId = body.chatSessionId;
@@ -1674,13 +1674,13 @@ chatV2.post("/", async (c) => {
                 scenarioId: bodyScenarioId,
                 accessVersion: bodyAccessVersion,
                 serverIds: hostConfigServerIds,
-              }
+              },
             )
           : { runtimeLocation: "cloud", providerKey };
       const onConversationComplete = chatSessionId
         ? async (
             fullHistory: ModelMessage[],
-            turnTrace: PersistedTurnTrace
+            turnTrace: PersistedTurnTrace,
           ) => {
             // Returned so the rail can stream the turn's persist receipt.
             return await persistChatSessionToConvex({
@@ -1699,7 +1699,7 @@ chatV2.post("/", async (c) => {
               sessionMessages: stampSenderUserIdsOnSessionMessages(
                 fullHistory,
                 messages,
-                { authenticatedUserId }
+                { authenticatedUserId },
               ),
               startedAt: sessionStartedAt,
               lastActivityAt: Date.now(),
@@ -1822,7 +1822,7 @@ chatV2.post("/", async (c) => {
             "Personal provider keys aren't supported. Configure cloud models in your organization's settings (Organization Models).",
           code: "personal_byok_unsupported",
         },
-        401
+        401,
       );
     }
 
@@ -1834,24 +1834,23 @@ chatV2.post("/", async (c) => {
         ollama: body.ollamaBaseUrl,
         azure: body.azureBaseUrl,
       },
-      body.customProviders
+      body.customProviders,
     );
 
     const modelMessages = await convertToMcpjamModelMessages(
       messages,
-      inboundMcpToolResultModelOutputOptions
+      inboundMcpToolResultModelOutputOptions,
     );
 
     const streamStartedAt = Date.now();
     const authHeader = c.req.header("authorization");
     const chatSessionId = body.chatSessionId;
     const inboundAbortSignalDirect = c.req.raw.signal as
-      | AbortSignal
-      | undefined;
+      AbortSignal | undefined;
     warnIfChatAbortSignalMissing(inboundAbortSignalDirect, "mcp/chat-v2");
 
     const scrubbedModelMessages = scrubMessages(
-      modelMessages as ModelMessage[]
+      modelMessages as ModelMessage[],
     );
 
     return streamDirectChatWithLiveTrace({
@@ -1906,7 +1905,7 @@ chatV2.post("/", async (c) => {
               messages: stampSenderUserIdsOnSessionMessages(
                 modelMessages as ModelMessage[],
                 messages,
-                { authenticatedUserId }
+                { authenticatedUserId },
               ),
               systemPrompt: enhancedSystemPrompt,
               ...(responseMessages.length > 0 ? { responseMessages } : {}),
@@ -1952,7 +1951,7 @@ chatV2.post("/", async (c) => {
     const { origin } = reportRouteFailureForResponse(
       "[mcp/chat-v2] failed to process chat request",
       error,
-      { source: "mcp.chat-v2.request", hop: "mcpjam_internal" }
+      { source: "mcp.chat-v2.request", hop: "mcpjam_internal" },
     );
     // Also a HEADER, not just the body. By the time the failure reaches the
     // client's reporter the Response is gone — the AI SDK throws

--- a/mcpjam-inspector/server/routes/mcp/chat-v2.ts
+++ b/mcpjam-inspector/server/routes/mcp/chat-v2.ts
@@ -1287,6 +1287,7 @@ chatV2.post("/", async (c) => {
     let cloudRuntimeSkills: RuntimeStandaloneSkill[] = [];
     let skillsFetchFailed: SkillsFetchFailure | undefined;
     if (requestAuthHeader && body.projectId) {
+      const startedAt = Date.now();
       try {
         cloudRuntimeSkills = await listCloudRuntimeSkills({
           authHeader: requestAuthHeader,
@@ -1295,8 +1296,9 @@ chatV2.post("/", async (c) => {
       } catch (error) {
         // A failed catalog fetch is NOT an empty project, and the difference is
         // what tells "this user has no skills" from "we lost their skills this
-        // turn". Same signal the hosted path already reports.
-        skillsFetchFailed = skillsFailureFrom(error, 0);
+        // turn". Same signal the hosted path already reports — measured, since
+        // a timeout and a refusal are the same class with different latencies.
+        skillsFetchFailed = skillsFailureFrom(error, Date.now() - startedAt);
         logger.warn("[chat-v2] project skill catalog fetch failed", {
           projectId: body.projectId,
           message: skillsFetchFailed.message,
@@ -1336,6 +1338,12 @@ chatV2.post("/", async (c) => {
               // Live surface: server skills come from the connected servers,
               // not from a captured set.
               composeLiveServerSkills: true,
+              // A lazy body or file read outlives the request that asked for
+              // it otherwise: the fetch runs to its own timeout after the user
+              // has already navigated away.
+              ...(c.req.raw.signal
+                ? { abortSignal: c.req.raw.signal as AbortSignal }
+                : {}),
             },
         // Body for direct chat (project default), host-re-resolved for
         // scenario-bound sessions. undefined → auto policy.

--- a/mcpjam-inspector/server/routes/v1/chat-session-turn.ts
+++ b/mcpjam-inspector/server/routes/v1/chat-session-turn.ts
@@ -76,8 +76,10 @@ import { logger } from "../../utils/logger.js";
 import { listCloudRuntimeSkills } from "../../utils/computers/cloud-skill-tools.js";
 import {
   buildLiveEffectiveCapabilities,
+  resolveEffectiveCapabilities,
   type EffectiveCapabilitySet,
 } from "../../services/environments/effective-capabilities.js";
+import { fetchPluginRuntimeAttribution } from "../../services/environments/plugin-attribution.js";
 import { captureServerEvent } from "../../utils/analytics.js";
 import { v1Error, v1Resource } from "./envelope.js";
 import { readJsonObjectBody } from "./adapter.js";
@@ -345,6 +347,19 @@ interface ResolvedTarget {
   serverNames?: string[];
   environmentId?: string;
   /**
+   * The environment's own capability set, when the turn named one.
+   *
+   * An environment DECIDES what runs — which skills, which plugin versions,
+   * which captured server skills — and that decision is the whole reason a
+   * caller names one. Building a live set from the project pool instead would
+   * hand the model every skill the project has, including the ones the
+   * environment deliberately left out, drop the plugin skills it attached, and
+   * swap its captured server skills for live ones. Absent ⇒ the turn pinned
+   * bare `serverIds` and there is no environment decision to honour, so the
+   * caller builds a live set instead.
+   */
+  environmentCapabilities?: EffectiveCapabilitySet;
+  /**
    * Built-in tool ids the target's client advertises that THIS surface does
    * not run — see {@link unappliedBuiltInToolIds}.
    */
@@ -416,10 +431,22 @@ async function resolveTarget(
   const unappliedCapabilities = unappliedBuiltInToolIds(
     spec.host?.runtimeConfig,
   );
+  // Attribution is a SECOND read and deliberately cannot fail the turn: the
+  // environment already decided what runs, so a probe blip must degrade origin
+  // reporting rather than stop a send. Costs nothing when no plugins are
+  // pinned. Mirrors `routes/web/chat-v2.ts`, which is the surface this one has
+  // to agree with about what an environment means.
+  const attribution = await fetchPluginRuntimeAttribution(client, {
+    projectId,
+    pluginVersionIds: (spec.pluginVersions ?? []).map(
+      (plugin) => plugin.pluginVersionId,
+    ),
+  }).catch(() => null);
   return {
     serverIds,
     ...(serverNames.length === serverIds.length ? { serverNames } : {}),
     environmentId: input.environmentId,
+    environmentCapabilities: resolveEffectiveCapabilities(spec, attribution),
     ...(unappliedCapabilities.length > 0 ? { unappliedCapabilities } : {}),
   };
 }
@@ -981,11 +1008,21 @@ async function handleTurn(c: Context): Promise<Response> {
     // project pool was still invisible, so an agent driving MCPJam could read
     // somebody else's skills but not its own.
     //
-    // Lazy, like every other live surface: the catalog is one query and a body
-    // is fetched only for the skill the model loads. A catalog failure degrades
-    // to no skills rather than failing the turn.
+    // TWO shapes, because a turn that named an environment is not a live turn.
+    // An environment IS a decision about what runs, so its own resolved set is
+    // the answer — pinned skill selection, attached plugin skills, captured
+    // server skills and all. Only a turn pinning bare `serverIds` has no such
+    // decision behind it, and only that turn builds a live set from the
+    // project pool.
+    //
+    // The live shape stays lazy, like every other live surface: the catalog is
+    // one query and a body is fetched only for the skill the model loads. A
+    // catalog failure degrades to no skills rather than failing the turn.
     let turnCapabilities: EffectiveCapabilitySet | undefined;
-    if (projectId) {
+    let capabilitiesAreLive = false;
+    if (target.environmentCapabilities) {
+      turnCapabilities = target.environmentCapabilities;
+    } else if (projectId) {
       try {
         turnCapabilities = buildLiveEffectiveCapabilities({
           standaloneSkills: await listCloudRuntimeSkills({
@@ -993,6 +1030,7 @@ async function handleTurn(c: Context): Promise<Response> {
             projectId,
           }),
         });
+        capabilitiesAreLive = true;
       } catch (error) {
         logger.warn(
           "[v1/chat-session-turn] project skill catalog unavailable",
@@ -1012,8 +1050,15 @@ async function handleTurn(c: Context): Promise<Response> {
             skillsSource: {
               kind: "resolved" as const,
               capabilities: turnCapabilities,
-              // Keeps #4419's live server skills composed alongside them.
-              composeLiveServerSkills: true as const,
+              // Only a LIVE set composes live server skills, and that is the
+              // same rule `web-chat-turn` follows. An environment's server
+              // skills were CAPTURED; fetching more from the connection would
+              // falsify the claim that the set describes the turn — which is
+              // exactly what this flag exists to prevent. On the live arm it
+              // keeps #4419's server skills composed alongside the project's.
+              ...(capabilitiesAreLive
+                ? { composeLiveServerSkills: true as const }
+                : {}),
               // The turn's own controller, so a lazy body or file read stops
               // with the turn instead of running to its own fetch timeout.
               abortSignal: abortController.signal,

--- a/mcpjam-inspector/server/routes/v1/chat-session-turn.ts
+++ b/mcpjam-inspector/server/routes/v1/chat-session-turn.ts
@@ -73,6 +73,11 @@ import {
   runtimeServerNames,
 } from "../../services/environments/runtime.js";
 import { logger } from "../../utils/logger.js";
+import { listCloudRuntimeSkills } from "../../utils/computers/cloud-skill-tools.js";
+import {
+  buildLiveEffectiveCapabilities,
+  type EffectiveCapabilitySet,
+} from "../../services/environments/effective-capabilities.js";
 import { captureServerEvent } from "../../utils/analytics.js";
 import { v1Error, v1Resource } from "./envelope.js";
 import { readJsonObjectBody } from "./adapter.js";
@@ -971,9 +976,47 @@ async function handleTurn(c: Context): Promise<Response> {
       },
     );
 
+    // The project's own skills, which this surface has never had. #4419 gave it
+    // a connected server's skills by advertising the extension above; the
+    // project pool was still invisible, so an agent driving MCPJam could read
+    // somebody else's skills but not its own.
+    //
+    // Lazy, like every other live surface: the catalog is one query and a body
+    // is fetched only for the skill the model loads. A catalog failure degrades
+    // to no skills rather than failing the turn.
+    let turnCapabilities: EffectiveCapabilitySet | undefined;
+    if (projectId) {
+      try {
+        turnCapabilities = buildLiveEffectiveCapabilities({
+          standaloneSkills: await listCloudRuntimeSkills({
+            authHeader,
+            projectId,
+          }),
+        });
+      } catch (error) {
+        logger.warn(
+          "[v1/chat-session-turn] project skill catalog unavailable",
+          {
+            projectId,
+            error: error instanceof Error ? error.message : String(error),
+          },
+        );
+      }
+    }
+
     const prepared = await prepareChatV2({
       mcpClientManager: manager,
       selectedServers: selectedServerIds,
+      ...(turnCapabilities
+        ? {
+            skillsSource: {
+              kind: "resolved" as const,
+              capabilities: turnCapabilities,
+              // Keeps #4419's live server skills composed alongside them.
+              composeLiveServerSkills: true as const,
+            },
+          }
+        : {}),
       // Without this every server-skill ref is namespaced by the raw server
       // id, in the `listSkills` catalog the model reads AND in the origin
       // banner prepended to loaded skill content.
@@ -1007,8 +1050,8 @@ async function handleTurn(c: Context): Promise<Response> {
     const tools = noTools
       ? ({} as ToolSet)
       : body.maxToolCalls !== undefined && body.maxToolCalls > 0
-      ? capToolCalls(prepared.allTools, body.maxToolCalls)
-      : prepared.allTools;
+        ? capToolCalls(prepared.allTools, body.maxToolCalls)
+        : prepared.allTools;
 
     const runtime = await resolveTurnRuntime({
       modelDefinition,
@@ -1029,8 +1072,7 @@ async function handleTurn(c: Context): Promise<Response> {
     const inputMessages = [...priorMessages, userMessage];
 
     let lastEngineError:
-      | { message: string; code?: string; httpStatus?: number }
-      | undefined;
+      { message: string; code?: string; httpStatus?: number } | undefined;
 
     // Past this line the turn may have spent. See `modelCallStarted`.
     modelCallStarted = true;
@@ -1107,7 +1149,7 @@ async function handleTurn(c: Context): Promise<Response> {
         message,
         {
           reason: rateLimited
-            ? lastEngineError?.code ?? "ORG_RATE_LIMIT"
+            ? (lastEngineError?.code ?? "ORG_RATE_LIMIT")
             : "TURN_FAILED",
         },
       );

--- a/mcpjam-inspector/server/routes/v1/chat-session-turn.ts
+++ b/mcpjam-inspector/server/routes/v1/chat-session-turn.ts
@@ -1014,6 +1014,9 @@ async function handleTurn(c: Context): Promise<Response> {
               capabilities: turnCapabilities,
               // Keeps #4419's live server skills composed alongside them.
               composeLiveServerSkills: true as const,
+              // The turn's own controller, so a lazy body or file read stops
+              // with the turn instead of running to its own fetch timeout.
+              abortSignal: abortController.signal,
             },
           }
         : {}),

--- a/mcpjam-inspector/server/routes/web/__tests__/chat-v2.environment.test.ts
+++ b/mcpjam-inspector/server/routes/web/__tests__/chat-v2.environment.test.ts
@@ -528,7 +528,7 @@ describe("web chat-v2 — environment execution target", () => {
     expect(prepareChatV2Mock).not.toHaveBeenCalled();
   });
 
-  it("delivers ONLY the resolved skills to the emulated engine (no cloudSkills)", async () => {
+  it("delivers ONLY the resolved skills to the emulated engine", async () => {
     // The attribution probe answers the single-call shape: pv_1 contributed
     // env-server-2 and no skills, so the capability set carries no plugin
     // skills and no problems.
@@ -562,8 +562,10 @@ describe("web chat-v2 — environment execution target", () => {
       token
     );
     const args = prepareChatV2Mock.mock.calls.at(-1)![0];
-    // Project-wide cloud skills would double-deliver alongside the resolved set.
-    expect(args.cloudSkills).toBeUndefined();
+    // Captured, not live: the environment's spec already froze which server
+    // skills this turn gets, so composing the connected servers' live catalogs
+    // on top would deliver skills the capture deliberately excluded.
+    expect(args.skillsSource.composeLiveServerSkills).toBeUndefined();
     // INS-3: the emulated engine now receives the whole EffectiveCapabilitySet
     // rather than a flat skill list, because its tools address skills by REF
     // (`<plugin>/<skill>` for a plugin skill). This environment pins no
@@ -609,7 +611,6 @@ describe("web chat-v2 — environment execution target", () => {
     // Emulated skill tools must NOT be advertised on a harness turn.
     const prepareArgs = prepareChatV2Mock.mock.calls.at(-1)![0];
     expect(prepareArgs.skillsSource).toBeUndefined();
-    expect(prepareArgs.cloudSkills).toBeUndefined();
 
     const handlerArgs = handleMCPJamFreeChatModelMock.mock.calls.at(-1)![0];
     expect(handlerArgs.harness).toBe("claude-code");

--- a/mcpjam-inspector/server/routes/web/__tests__/chat-v2.environment.test.ts
+++ b/mcpjam-inspector/server/routes/web/__tests__/chat-v2.environment.test.ts
@@ -289,7 +289,15 @@ describe("web chat-v2 — environment execution target", () => {
     expect(fetchHostRuntimeConfigMock).toHaveBeenCalledWith(
       expect.objectContaining({ hostId: "host_legacy" })
     );
-    expect(convexQueryMock).not.toHaveBeenCalled();
+    // No ENVIRONMENT was resolved — which is what this test is about. A host
+    // target does now query the project's skill catalog, because its skills
+    // reach the turn as a live capability set rather than through a separate
+    // branch of the orchestrator, so "no Convex query at all" would assert
+    // something this path never promised.
+    expect(convexQueryMock).not.toHaveBeenCalledWith(
+      "projectEnvironments:resolveEnvironmentForRuntime",
+      expect.anything()
+    );
   });
 
   it("uses the RESOLVED server set everywhere, never the body's", async () => {

--- a/mcpjam-inspector/server/routes/web/__tests__/chat-v2.hosted.test.ts
+++ b/mcpjam-inspector/server/routes/web/__tests__/chat-v2.hosted.test.ts
@@ -3,6 +3,7 @@ import { Hono } from "hono";
 
 const {
   prepareChatV2Mock,
+  listCloudRuntimeSkillsMock,
   handleMCPJamFreeChatModelMock,
   fetchHostRuntimeConfigMock,
   fetchScenarioRuntimeConfigMock,
@@ -20,6 +21,7 @@ const {
   WidgetModelContextValidationErrorMock,
 } = vi.hoisted(() => ({
   prepareChatV2Mock: vi.fn(),
+  listCloudRuntimeSkillsMock: vi.fn(),
   handleMCPJamFreeChatModelMock: vi.fn(),
   fetchHostRuntimeConfigMock: vi.fn(),
   fetchScenarioRuntimeConfigMock: vi.fn(),
@@ -155,6 +157,17 @@ vi.mock("@/shared/types", async () => {
   };
 });
 
+vi.mock("../../../utils/computers/cloud-skill-tools.js", async () => {
+  const actual = await vi.importActual<
+    typeof import("../../../utils/computers/cloud-skill-tools.js")
+  >("../../../utils/computers/cloud-skill-tools.js");
+  return {
+    ...actual,
+    listCloudRuntimeSkills: (...args: unknown[]) =>
+      listCloudRuntimeSkillsMock(...args),
+  };
+});
+
 import { createWebTestApp, postJson } from "./helpers/test-app.js";
 import { MCPClientManager } from "@mcpjam/sdk";
 
@@ -180,6 +193,7 @@ describe("web routes — chat-v2 hosted mode", () => {
       ok: true,
       config: { selectedServerIds: ["server-1"] },
     });
+    listCloudRuntimeSkillsMock.mockReset().mockResolvedValue([]);
     // Default: scenario runtime-config resolves (empty = host has no
     // overrides). Scenario turns now FAIL CLOSED on a failed fetch, so the
     // happy-path tests must resolve it rather than lean on the old fallback.
@@ -1204,5 +1218,99 @@ describe("web routes — chat-v2 hosted mode", () => {
         ],
       })
     );
+  });
+
+  /**
+   * The project pool on a target that resolves NO environment (host / adhoc).
+   *
+   * This is the arm the convergence rewired: it used to reach the orchestrator as
+   * a `cloudSkills` option that chose one exclusive branch of a chain, and it now
+   * arrives as a live capability set alongside every other origin. The three
+   * cases below are the three the route can actually be in, and they differ in
+   * ways that matter: an EMPTY catalog is authoritative, a FAILED one is not.
+   */
+  describe("hosted chat-v2 — the project skill catalog", () => {
+    const bodyWithSkills = {
+      projectId: "project-1",
+      selectedServerIds: ["server-1"],
+      chatSessionId: "chat-session-1",
+      messages: [{ role: "user", content: "hi" }],
+      model: { id: "openai/gpt-5-mini", provider: "openai", name: "GPT-5 Mini" },
+    };
+
+    it("delivers a non-empty catalog as a live resolved source", async () => {
+      listCloudRuntimeSkillsMock.mockResolvedValue([
+        {
+          skillId: "sk_1",
+          ref: "release-notes",
+          name: "release-notes",
+          description: "Write release notes",
+          aggregateHash: "agg_1",
+          channels: [],
+          content: async () => "# release-notes",
+          files: [],
+        },
+      ]);
+      const { app, token } = createWebTestApp();
+
+      const response = await postJson(
+        app,
+        "/api/web/chat-v2",
+        bodyWithSkills,
+        token
+      );
+      expect(response.status).toBe(200);
+
+      const args = prepareChatV2Mock.mock.calls.at(-1)![0];
+      expect(args.skillsSource.kind).toBe("resolved");
+      // Live, so a connected server's SEP-2640 skills compose on top rather than
+      // being displaced by the project's.
+      expect(args.skillsSource.composeLiveServerSkills).toBe(true);
+      expect(
+        args.skillsSource.capabilities.standaloneSkills.map(
+          (skill: { ref: string }) => skill.ref
+        )
+      ).toEqual(["release-notes"]);
+    });
+
+    it("keeps an empty catalog authoritative rather than falling back", async () => {
+      listCloudRuntimeSkillsMock.mockResolvedValue([]);
+      const { app, token } = createWebTestApp();
+
+      const response = await postJson(
+        app,
+        "/api/web/chat-v2",
+        bodyWithSkills,
+        token
+      );
+      expect(response.status).toBe(200);
+
+      // "This project has no skills" is an answer, not a gap: the source is still
+      // resolved and still live, it is simply empty.
+      const args = prepareChatV2Mock.mock.calls.at(-1)![0];
+      expect(args.skillsSource.kind).toBe("resolved");
+      expect(args.skillsSource.capabilities.standaloneSkills).toEqual([]);
+      expect(args.skillsSource.composeLiveServerSkills).toBe(true);
+    });
+
+    it("loses the turn's project skills, and nothing else, when the catalog fails", async () => {
+      listCloudRuntimeSkillsMock.mockRejectedValue(new Error("convex down"));
+      const { app, token } = createWebTestApp();
+
+      const response = await postJson(
+        app,
+        "/api/web/chat-v2",
+        bodyWithSkills,
+        token
+      );
+      // Losing the skills must not lose the turn.
+      expect(response.status).toBe(200);
+
+      // No source at all is the LIVE shape: the orchestrator still composes the
+      // connected servers' skills, which never failed. Collapsing to
+      // `{ kind: "none" }` here would take those down with the project's.
+      const args = prepareChatV2Mock.mock.calls.at(-1)![0];
+      expect(args.skillsSource).toBeUndefined();
+    });
   });
 });

--- a/mcpjam-inspector/server/routes/web/__tests__/chat-v2.scenario-environment.test.ts
+++ b/mcpjam-inspector/server/routes/web/__tests__/chat-v2.scenario-environment.test.ts
@@ -254,15 +254,16 @@ describe("web chat-v2 — environment-backed scenario", () => {
     expect(JSON.stringify(persistArgs)).not.toContain("body-server-9");
   });
 
-  it("delivers the payload's skills to the emulated engine, cloud skills off", async () => {
+  it("delivers the payload's skills to the emulated engine, and nothing live", async () => {
     const { app, token } = createWebTestApp();
     const response = await postJson(app, "/api/web/chat-v2", BASE_BODY, token);
     expect(response.status).toBe(200);
 
     const args = prepareChatV2Mock.mock.calls.at(-1)![0];
-    // Project-wide cloud skills would double-deliver alongside the resolved
-    // set — the same single-channel rule as an environment target.
-    expect(args.cloudSkills).toBeUndefined();
+    // Captured, not live — the same single-channel rule as an environment
+    // target: the payload already froze this turn's skills, so composing the
+    // connected servers' live catalogs would add ones it excluded.
+    expect(args.skillsSource.composeLiveServerSkills).toBeUndefined();
     expect(args.skillsSource.kind).toBe("resolved");
     expect(args.skillsSource.capabilities.standaloneSkills).toEqual([
       {
@@ -310,7 +311,7 @@ describe("web chat-v2 — environment-backed scenario", () => {
     expect(response.status).toBe(200);
 
     const args = prepareChatV2Mock.mock.calls.at(-1)![0];
-    expect(args.cloudSkills).toBeUndefined();
+    expect(args.skillsSource.composeLiveServerSkills).toBeUndefined();
     expect(args.skillsSource.capabilities.standaloneSkills).toEqual([]);
     // Deploy-skew fallback: no `connectable` projection ⇒ raw ids connect and
     // the manager shows the id as the name.

--- a/mcpjam-inspector/server/routes/web/chat-v2.ts
+++ b/mcpjam-inspector/server/routes/web/chat-v2.ts
@@ -2,7 +2,10 @@ import { Hono } from "hono";
 import type { ChatV2Request } from "@/shared/chat-v2";
 import { getCanonicalModelId } from "@/shared/types";
 import { isHostedCatalogModel } from "../../services/hosted-model-catalog.js";
-import { shouldEnableCloudSkillTools } from "../../utils/computers/cloud-skill-tools.js";
+import {
+  listCloudRuntimeSkills,
+  shouldEnableCloudSkillTools,
+} from "../../utils/computers/cloud-skill-tools.js";
 import { isMCPAuthError, TaskCreatedSink } from "@mcpjam/sdk";
 import { isCompatibleHostedTasksVersion } from "@/shared/hosted-task-created";
 import { HostedTaskCreatedBridge } from "../../utils/hosted-task-created-bridge.js";
@@ -95,6 +98,7 @@ import {
   type PluginRuntimeAttribution,
 } from "../../services/environments/plugin-attribution.js";
 import {
+  buildLiveEffectiveCapabilities,
   pluginOriginByServerId,
   resolveEffectiveCapabilities,
   type EffectiveCapabilitySet,
@@ -235,7 +239,7 @@ chatV2.post("/", async (c) => {
       throw new WebRouteError(
         400,
         ErrorCode.VALIDATION_ERROR,
-        normalizedTarget.error
+        normalizedTarget.error,
       );
     }
     const executionTarget = normalizedTarget.target;
@@ -260,7 +264,7 @@ chatV2.post("/", async (c) => {
       throw new WebRouteError(
         400,
         ErrorCode.VALIDATION_ERROR,
-        "messages are required"
+        "messages are required",
       );
     }
 
@@ -269,7 +273,7 @@ chatV2.post("/", async (c) => {
       throw new WebRouteError(
         400,
         ErrorCode.VALIDATION_ERROR,
-        "model is not supported"
+        "model is not supported",
       );
     }
 
@@ -307,7 +311,7 @@ chatV2.post("/", async (c) => {
       // delegated JWT (and passes JWTs through untouched), same as the eval
       // launch path.
       const convexClient = createConvexClient(
-        await getConvexBearerForRequest(c)
+        await getConvexBearerForRequest(c),
       );
       // One atomic member-read: host runtime config + closed server set +
       // composed skill union + pinned plugin versions, at one revision. The
@@ -327,7 +331,7 @@ chatV2.post("/", async (c) => {
       const attribution = await fetchPluginRuntimeAttribution(convexClient, {
         projectId: hostedBody.projectId,
         pluginVersionIds: (environmentSpec.pluginVersions ?? []).map(
-          (plugin) => plugin.pluginVersionId
+          (plugin) => plugin.pluginVersionId,
         ),
       });
       // INS-4: the Playground's ephemeral plugin narrowing, applied to the
@@ -353,7 +357,7 @@ chatV2.post("/", async (c) => {
       }
       effectiveCapabilities = resolveEffectiveCapabilities(
         environmentSpec,
-        attribution
+        attribution,
       );
       if (effectiveCapabilities.problems.length > 0) {
         // Codes and ids only, never `problem.message` — those messages
@@ -365,14 +369,14 @@ chatV2.post("/", async (c) => {
           environmentId: environmentSpec.environmentRef.environmentId,
           codes: effectiveCapabilities.problems.map((problem) => problem.code),
           skillIds: effectiveCapabilities.problems.flatMap((problem) =>
-            "skillId" in problem ? [problem.skillId] : []
+            "skillId" in problem ? [problem.skillId] : [],
           ),
         });
       }
       // Plugin origin on every RPC frame this turn produces, so a trace answers
       // "which plugin revision served this tool call" without a second lookup.
       rpcCollector?.setPluginOriginByServerId(
-        pluginOriginByServerId(effectiveCapabilities)
+        pluginOriginByServerId(effectiveCapabilities),
       );
     } else if (isScenarioSession && scenarioId) {
       const runtime = await fetchScenarioRuntimeConfig({
@@ -395,12 +399,12 @@ chatV2.post("/", async (c) => {
         if (environmentRead.kind === "invalid") {
           logger.warn(
             "[chat-v2] scenario environment payload malformed; failing closed",
-            { scenarioId, detail: environmentRead.detail }
+            { scenarioId, detail: environmentRead.detail },
           );
           throw new WebRouteError(
             502,
             ErrorCode.INTERNAL_ERROR,
-            "Couldn't load this scenario's environment, so the turn was stopped to avoid running with the wrong configuration."
+            "Couldn't load this scenario's environment, so the turn was stopped to avoid running with the wrong configuration.",
           );
         }
         if (environmentRead.kind === "present") {
@@ -423,7 +427,7 @@ chatV2.post("/", async (c) => {
                 {
                   projectId: hostedBody.projectId,
                   pluginVersionIds: pinnedVersionIds,
-                }
+                },
               );
             } catch (error) {
               // `fetchPluginRuntimeAttribution` already swallows probe
@@ -434,7 +438,7 @@ chatV2.post("/", async (c) => {
                 {
                   scenarioId,
                   error: error instanceof Error ? error.message : String(error),
-                }
+                },
               );
             }
           }
@@ -443,7 +447,7 @@ chatV2.post("/", async (c) => {
           // "resolved") instead of silently delivering zero.
           effectiveCapabilities = resolveEffectiveCapabilities(
             scenarioEnvironment,
-            attribution
+            attribution,
           );
           if (effectiveCapabilities.problems.length > 0) {
             // Codes and ids only — same redaction rationale as the
@@ -451,10 +455,10 @@ chatV2.post("/", async (c) => {
             logger.warn("[chat-v2] effective capability problems", {
               environmentId: scenarioEnvironment.environmentRef.environmentId,
               codes: effectiveCapabilities.problems.map(
-                (problem) => problem.code
+                (problem) => problem.code,
               ),
               skillIds: effectiveCapabilities.problems.flatMap((problem) =>
-                "skillId" in problem ? [problem.skillId] : []
+                "skillId" in problem ? [problem.skillId] : [],
               ),
             });
           }
@@ -462,7 +466,7 @@ chatV2.post("/", async (c) => {
           // environment target stamps it. Empty (no-op) until the backend
           // serves `pluginVersions` and the probe attributes them.
           rpcCollector?.setPluginOriginByServerId(
-            pluginOriginByServerId(effectiveCapabilities)
+            pluginOriginByServerId(effectiveCapabilities),
           );
         }
         hostRuntimeConfig = runtime.config as unknown as Record<
@@ -493,7 +497,7 @@ chatV2.post("/", async (c) => {
           throw new WebRouteError(
             409,
             ErrorCode.SCENARIO_ACCESS_STALE,
-            failClosedMessage
+            failClosedMessage,
           );
         }
         throw new WebRouteError(
@@ -501,7 +505,7 @@ chatV2.post("/", async (c) => {
           runtime.status === 403
             ? ErrorCode.SCENARIO_ACCESS_DENIED
             : ErrorCode.INTERNAL_ERROR,
-          failClosedMessage
+          failClosedMessage,
         );
       }
     } else if (executionTarget.kind === "host") {
@@ -529,12 +533,12 @@ chatV2.post("/", async (c) => {
             hostId: targetHostId,
             status: runtime.status,
             error: runtime.error,
-          }
+          },
         );
         throw new WebRouteError(
           runtime.status >= 500 ? 502 : runtime.status,
           ErrorCode.INTERNAL_ERROR,
-          `Couldn't load this host's settings, so the turn was stopped to avoid running with the wrong engine. ${runtime.error}`
+          `Couldn't load this host's settings, so the turn was stopped to avoid running with the wrong engine. ${runtime.error}`,
         );
       }
     }
@@ -572,8 +576,8 @@ chatV2.post("/", async (c) => {
     const environmentSkills = environmentSpec
       ? environmentRuntimeSkills(environmentSpec)
       : scenarioEnvironment
-      ? environmentRuntimeSkills({ skills: scenarioEnvironment.skills ?? [] })
-      : undefined;
+        ? environmentRuntimeSkills({ skills: scenarioEnvironment.skills ?? [] })
+        : undefined;
 
     // Enterprise-managed authorization policy. Server-authoritative wherever
     // a backend host config exists (scenario / host-bound turns above — the
@@ -585,7 +589,7 @@ chatV2.post("/", async (c) => {
     // closed on a malformed/unsupported policy (409, never silently off).
     const xaaPolicy = hostRuntimeConfig
       ? xaaPolicyFromMcpProfile(
-          (hostRuntimeConfig as { mcpProfile?: unknown }).mcpProfile
+          (hostRuntimeConfig as { mcpProfile?: unknown }).mcpProfile,
         )
       : parseXaaPolicyValue((body as Record<string, unknown>).xaaPolicy);
 
@@ -608,12 +612,12 @@ chatV2.post("/", async (c) => {
           applyHostParamMirroring(
             initializePins,
             mirrorToolParamHeadersFromMcpProfile(
-              (hostRuntimeConfig as { mcpProfile?: unknown }).mcpProfile
-            )
+              (hostRuntimeConfig as { mcpProfile?: unknown }).mcpProfile,
+            ),
           ),
           conformanceKnobsFromMcpProfile(
-            (hostRuntimeConfig as { mcpProfile?: unknown }).mcpProfile
-          )
+            (hostRuntimeConfig as { mcpProfile?: unknown }).mcpProfile,
+          ),
         )
       : initializePins;
 
@@ -645,7 +649,7 @@ chatV2.post("/", async (c) => {
             scenarioId,
             body: entry.overrideValue,
             host: entry.hostValue,
-          }
+          },
         );
       } else if (entry.field === "progressiveToolDiscovery") {
         logger.warn(
@@ -654,7 +658,7 @@ chatV2.post("/", async (c) => {
             scenarioId,
             body: entry.overrideValue,
             host: entry.hostValue,
-          }
+          },
         );
       } else if (entry.field === "respectToolVisibility") {
         logger.warn(
@@ -663,7 +667,7 @@ chatV2.post("/", async (c) => {
             scenarioId,
             body: entry.overrideValue,
             host: entry.hostValue,
-          }
+          },
         );
       } else if (
         entry.field === "modelVisibleMcpToolResults" ||
@@ -675,7 +679,7 @@ chatV2.post("/", async (c) => {
             scenarioId,
             body: entry.overrideValue,
             host: entry.hostValue,
-          }
+          },
         );
       }
     }
@@ -705,7 +709,7 @@ chatV2.post("/", async (c) => {
           body: modelDefinition.id,
           host: hostModelId,
           provider: hostModel.provider,
-        }
+        },
       );
       modelDefinition = hostModel;
     }
@@ -759,7 +763,7 @@ chatV2.post("/", async (c) => {
         throw new WebRouteError(
           503,
           ErrorCode.INTERNAL_ERROR,
-          `This host runs the ${resolvedExecution.harness} harness, which isn't available: ${availability.reason}.`
+          `This host runs the ${resolvedExecution.harness} harness, which isn't available: ${availability.reason}.`,
         );
       }
     }
@@ -770,9 +774,7 @@ chatV2.post("/", async (c) => {
     // (pre-Phase-3 backend) ⇒ the tools fall back to the legacy projectId reserve.
     const executionScope = (
       hostRuntimeConfig as
-        | { executionScope?: ExecutionScope }
-        | null
-        | undefined
+        { executionScope?: ExecutionScope } | null | undefined
     )?.executionScope;
 
     // COMP-16: the host-configured computer working directory — the SAME
@@ -814,6 +816,30 @@ chatV2.post("/", async (c) => {
         hasProjectId: Boolean(hostedBody.projectId),
       });
 
+    // The project pool as a live capability set. A catalog failure is logged
+    // and dropped rather than raised: losing skills must not lose the turn,
+    // and `listCloudRuntimeSkills` throwing is still distinguishable from a
+    // project that genuinely has none.
+    let liveProjectCapabilities: EffectiveCapabilitySet | undefined;
+    if (cloudSkillsEnabled && hostedBody.projectId) {
+      try {
+        liveProjectCapabilities = buildLiveEffectiveCapabilities({
+          standaloneSkills: await listCloudRuntimeSkills({
+            authHeader: `Bearer ${bearerToken}`,
+            projectId: hostedBody.projectId,
+          }),
+        });
+      } catch (error) {
+        logger.warn(
+          "[chat-v2] project skill catalog fetch failed; turn proceeds without them",
+          {
+            projectId: hostedBody.projectId,
+            error: error instanceof Error ? error.message : String(error),
+          },
+        );
+      }
+    }
+
     // Registering the callback is what makes the SDK advertise `elicitation`,
     // so "who declares it" and "may we honor it" are one decision — see
     // `resolveElicitationGate` for why scenario turns must not read the body.
@@ -852,7 +878,7 @@ chatV2.post("/", async (c) => {
       Boolean(modelDefinition.id) &&
       isHostedCatalogModel(
         String(modelDefinition.id),
-        modelDefinition.provider
+        modelDefinition.provider,
       ) &&
       !resolvedExecution.harness;
     const rawMrtrVersion = (rawBody as Record<string, unknown>)
@@ -869,7 +895,7 @@ chatV2.post("/", async (c) => {
       throw new WebRouteError(
         400,
         ErrorCode.VALIDATION_ERROR,
-        "Malformed mrtrResume descriptor"
+        "Malformed mrtrResume descriptor",
       );
     }
     if (mrtrResumeRequest && !mrtrEnabled) {
@@ -878,7 +904,7 @@ chatV2.post("/", async (c) => {
       throw new WebRouteError(
         409,
         ErrorCode.VALIDATION_ERROR,
-        "This turn cannot resume an MRTR continuation (version or engine mismatch)"
+        "This turn cannot resume an MRTR continuation (version or engine mismatch)",
       );
     }
     const rawScopeStepUpResume = (rawBody as Record<string, unknown>)
@@ -889,7 +915,7 @@ chatV2.post("/", async (c) => {
       throw new WebRouteError(
         400,
         ErrorCode.VALIDATION_ERROR,
-        "Malformed scopeStepUpResume descriptor"
+        "Malformed scopeStepUpResume descriptor",
       );
     }
     const rawScopeStepUpCancel = (rawBody as Record<string, unknown>)
@@ -900,14 +926,14 @@ chatV2.post("/", async (c) => {
       throw new WebRouteError(
         400,
         ErrorCode.VALIDATION_ERROR,
-        "Malformed scopeStepUpCancel descriptor"
+        "Malformed scopeStepUpCancel descriptor",
       );
     }
     if (scopeStepUpResumeRequest && scopeStepUpCancelRequest) {
       throw new WebRouteError(
         400,
         ErrorCode.VALIDATION_ERROR,
-        "Only one scope step-up continuation action is allowed"
+        "Only one scope step-up continuation action is allowed",
       );
     }
     const scopeStepUpEnabled =
@@ -970,7 +996,7 @@ chatV2.post("/", async (c) => {
     const taskCreatedBridge =
       tasksSeam &&
       isCompatibleHostedTasksVersion(
-        (rawBody as Record<string, unknown>).hostedTasksVersion
+        (rawBody as Record<string, unknown>).hostedTasksVersion,
       )
         ? new HostedTaskCreatedBridge({
             serverNamesById:
@@ -1057,7 +1083,7 @@ chatV2.post("/", async (c) => {
         // component colocates into THIS turn's machine rather than waking the
         // member's personal one alongside it.
         ...(executionScope ? { executionScope } : {}),
-      }
+      },
     );
     oauthServerUrls = urls;
     // Inject the live manager so the collector's fingerprint/era thunks can
@@ -1079,12 +1105,12 @@ chatV2.post("/", async (c) => {
                 serverId: mrtrResumeRequest.serverId,
                 ...(buildServerNamesById(
                   selectedServerIds,
-                  selectedServerNames
+                  selectedServerNames,
                 )?.[mrtrResumeRequest.serverId]
                   ? {
                       serverName: buildServerNamesById(
                         selectedServerIds,
-                        selectedServerNames
+                        selectedServerNames,
                       )![mrtrResumeRequest.serverId],
                     }
                   : {}),
@@ -1125,7 +1151,7 @@ chatV2.post("/", async (c) => {
     let validatedWidgetModelContext;
     try {
       validatedWidgetModelContext = validateWidgetModelContextEntries(
-        body.widgetModelContext
+        body.widgetModelContext,
       );
     } catch (error) {
       if (error instanceof WidgetModelContextValidationError) {
@@ -1181,8 +1207,7 @@ chatV2.post("/", async (c) => {
     // stream layer calls this right after writing the SSE parts; until it does,
     // the notices stay pending server-side and are re-delivered next turn.
     let ackSandboxNotices:
-      | ((delivered: SandboxNoticeReason[]) => void)
-      | undefined;
+      ((delivered: SandboxNoticeReason[]) => void) | undefined;
     // Drop the personal-computer resource for every suppressing plan, so
     // `bash` is not advertised at all rather than falling back to the member's
     // own box — which is precisely the behaviour this feature replaces:
@@ -1200,7 +1225,7 @@ chatV2.post("/", async (c) => {
     const sandboxPlan = planScenarioSandbox({
       mode: computerSandboxMode,
       bashRequested: (resolvedExecution.builtInToolIds ?? []).includes(
-        BASH_TOOL_NAME
+        BASH_TOOL_NAME,
       ),
       ephemeralCloudAvailable: isComputersDataPlaneConfigured(),
       hasChatSessionId: Boolean(body.chatSessionId),
@@ -1213,12 +1238,12 @@ chatV2.post("/", async (c) => {
       // shared box. No shell beats the wrong shell.
       logger.warn(
         "[chat-v2] ephemeral scenario sandbox requested without a chatSessionId; bash suppressed",
-        { scenarioId }
+        { scenarioId },
       );
     } else if (sandboxPlan.suppressReason === "not_a_data_plane") {
       logger.warn(
         "[chat-v2] ephemeral scenario sandbox requested but this server is not a computers data plane; bash suppressed without provisioning",
-        { scenarioId }
+        { scenarioId },
       );
       if (sandboxPlan.notice) sandboxNotices = [sandboxPlan.notice];
     }
@@ -1246,7 +1271,7 @@ chatV2.post("/", async (c) => {
           lifetime: "conversation",
         };
         const notices = (provisioned.value.notices ?? []).filter(
-          isSandboxNoticeReason
+          isSandboxNoticeReason,
         );
         if (notices.length > 0) sandboxNotices = notices;
         // PEEK/ACK (mcpjam-backend #829). The control plane hands the notice
@@ -1290,7 +1315,7 @@ chatV2.post("/", async (c) => {
             scenarioId,
             status: provisioned.status,
             error: provisioned.error,
-          }
+          },
         );
         suppressComputerResource = true;
       }
@@ -1324,7 +1349,7 @@ chatV2.post("/", async (c) => {
         // would be either rejected or — worse — wire-forgeable.
         ...(sandboxBinding ? { sandboxBinding } : {}),
         mcpjamPlatformClient: buildMcpjamPlatformClient(c),
-      }
+      },
     );
 
     // Blueprint knowledge/maintenance: when this turn advertises bash, append
@@ -1364,7 +1389,7 @@ chatV2.post("/", async (c) => {
     // the exhaustive SANDBOX_NOTICE_MODEL_CONTEXT record, so no binding gate.
     const effectiveSystemPrompt = appendSandboxNoticeContext(
       withEnvironmentContext,
-      sandboxNotices
+      sandboxNotices,
     );
 
     try {
@@ -1485,16 +1510,19 @@ chatV2.post("/", async (c) => {
           ...(harnessComputerWorkdir
             ? { computerWorkdir: harnessComputerWorkdir }
             : {}),
-          ...(cloudSkillsEnabled
+          // The project's skills as a capability set, for a target that
+          // resolves no environment (host / adhoc). Same gate as before, same
+          // laziness as before — a body is fetched for the skill the model
+          // loads, not for the catalog — but delivered through the one merged
+          // surface instead of a parallel branch of the orchestrator.
+          ...(liveProjectCapabilities
             ? {
-                cloudSkills: {
-                  authHeader: `Bearer ${bearerToken}`,
-                  projectId: hostedBody.projectId,
-                },
+                effectiveCapabilities: liveProjectCapabilities,
+                liveSkillSurface: true,
               }
             : {}),
           // Emulated-engine delivery of the environment's resolved skills.
-          // Mutually exclusive with `cloudSkills` above (gated on the same
+          // Mutually exclusive with the live set above (gated on the same
           // `environmentSpec`), and ignored by the helper on a harness turn.
           //
           // Both are set for an environment turn: the capability set drives the
@@ -1637,7 +1665,7 @@ chatV2.post("/", async (c) => {
           oauthRequired: true,
           serverUrl: firstUrl,
         },
-        rpcCollector?.buildEnvelope() as Record<string, unknown> | undefined
+        rpcCollector?.buildEnvelope() as Record<string, unknown> | undefined,
       );
     }
     // `webErrorFromRoute`, not `webError` — this call dropped
@@ -1665,7 +1693,7 @@ chatV2.post("/", async (c) => {
     return webErrorFromRoute(
       c,
       mapTargetServerError(error),
-      rpcCollector?.buildEnvelope() as Record<string, unknown> | undefined
+      rpcCollector?.buildEnvelope() as Record<string, unknown> | undefined,
     );
   }
 });

--- a/mcpjam-inspector/server/services/environments/effective-capabilities.ts
+++ b/mcpjam-inspector/server/services/environments/effective-capabilities.ts
@@ -438,9 +438,14 @@ export function pluginOriginByServerId(
  * Refs cannot collide ACROSS these two families — a project skill's ref is its
  * bare name and a local one is `local/<name>`, and a skill name cannot contain
  * a slash — so a collision here can only be within a family, which is what the
- * `usedRefs` pass catches. A local `code-review` alongside a project
- * `code-review` is not a collision but an AMBIGUITY, resolved where it belongs:
- * `loadSkill("code-review")` refuses and names both refs.
+ * `usedRefs` pass catches.
+ *
+ * A local `code-review` alongside a project `code-review` is therefore not a
+ * collision at all: they are two refs, both addressable. `loadSkill` resolves
+ * the exact ref first, so `code-review` is a direct hit on the project skill
+ * rather than an ambiguity — which is what keeps a project skill addressable
+ * regardless of what the user has on disk. The ambiguity refusal is for the
+ * case where NOTHING is an exact hit and two namespaced refs share a name.
  */
 export function buildLiveEffectiveCapabilities(args: {
   standaloneSkills?: RuntimeStandaloneSkill[];

--- a/mcpjam-inspector/server/services/environments/effective-capabilities.ts
+++ b/mcpjam-inspector/server/services/environments/effective-capabilities.ts
@@ -66,7 +66,26 @@ export interface RuntimeSkillFile {
   size: number;
   /** Signed, short-lived. `null` when the backend could not mint one. */
   url: string | null;
+  /**
+   * Reads the bytes directly, for an origin that has no URL to sign.
+   *
+   * The local filesystem is the case: its files are on disk, not in Convex
+   * storage. Preferred over `url` when present.
+   */
+  read?: () => Promise<Uint8Array>;
 }
+
+/**
+ * A skill body, inline or fetched on demand.
+ *
+ * Captured origins (an environment's resolved set, a pinned run) carry the
+ * bytes: they were read in the same transaction as the hashes, and that is what
+ * makes the snapshot a snapshot. A LIVE origin cannot afford that — a project
+ * with 200 skills would fetch every body on every turn to build a catalog the
+ * model mostly ignores — so it supplies a thunk the `loadSkill` tool awaits for
+ * the one skill actually asked for.
+ */
+export type RuntimeSkillContent = string | (() => Promise<string>);
 
 interface RuntimeSkillBase {
   /**
@@ -79,10 +98,17 @@ interface RuntimeSkillBase {
   /** The materialized skill's own name — NOT unique across plugins. */
   name: string;
   description: string;
-  content: string;
+  content: RuntimeSkillContent;
   /** Folds supporting files; equals the content hash when there are none. */
   aggregateHash: string;
   files: RuntimeSkillFile[];
+  /**
+   * Fetches the supporting-file list on demand.
+   *
+   * Same reasoning as a lazy `content`: a live origin lists a skill's files
+   * only when the model asks. Consulted when `files` is empty.
+   */
+  listFiles?: () => Promise<RuntimeSkillFile[]>;
 }
 
 export interface RuntimePluginSkill extends RuntimeSkillBase {
@@ -93,6 +119,20 @@ export interface RuntimePluginSkill extends RuntimeSkillBase {
 export interface RuntimeStandaloneSkill extends RuntimeSkillBase {
   /** Which channel(s) delivered it; `[]` under deploy skew. */
   channels: RuntimeSkillChannel[];
+}
+
+/**
+ * A skill read from the machine the inspector is running on.
+ *
+ * The fourth origin, and the one that made "which source is this?" a mode the
+ * user had to switch between rather than a property of a skill. It is namespaced
+ * `local/<name>` for the same reason a plugin skill is namespaced: a local
+ * `code-review` and a project `code-review` are different instructions, and a
+ * bare-name surface would silently pick whichever was indexed first.
+ */
+export interface RuntimeLocalSkill extends RuntimeSkillBase {
+  /** Absolute directory, for provenance in the catalog listing. */
+  directory: string;
 }
 
 /** A captured skill selected from one connected MCP server. */
@@ -137,6 +177,8 @@ export interface EffectiveCapabilitySet {
   pluginSkills: RuntimePluginSkill[];
   standaloneSkills: RuntimeStandaloneSkill[];
   serverSkills: RuntimeServerSkill[];
+  /** Skills on the inspector's own filesystem. Empty in hosted deployments. */
+  localSkills: RuntimeLocalSkill[];
   /** Every version that contributed to this turn, in pin order. */
   pluginVersions: RuntimePluginVersion[];
   problems: RuntimeCapabilityProblem[];
@@ -362,6 +404,9 @@ export function resolveEffectiveCapabilities(
     pluginSkills,
     standaloneSkills,
     serverSkills,
+    // An environment is resolved server-side and has no view of the machine the
+    // inspector runs on; live surfaces add this family themselves.
+    localSkills: [],
     pluginVersions,
     problems,
   };
@@ -382,8 +427,77 @@ export function pluginOriginByServerId(
 }
 
 /** Every skill in the set, plugin channel first (stable advertisement order). */
+/**
+ * An effective set for a LIVE turn — one with no environment behind it.
+ *
+ * The desktop app and the hosted Playground's default target resolve no
+ * environment: there is no pinned spec, just whatever the user has right now.
+ * They still deserve the ref-addressed, ambiguity-refusing, budgeted surface
+ * that environment turns get, so they build a set from families directly.
+ *
+ * Refs cannot collide ACROSS these two families — a project skill's ref is its
+ * bare name and a local one is `local/<name>`, and a skill name cannot contain
+ * a slash — so a collision here can only be within a family, which is what the
+ * `usedRefs` pass catches. A local `code-review` alongside a project
+ * `code-review` is not a collision but an AMBIGUITY, resolved where it belongs:
+ * `loadSkill("code-review")` refuses and names both refs.
+ */
+export function buildLiveEffectiveCapabilities(args: {
+  standaloneSkills?: RuntimeStandaloneSkill[];
+  localSkills?: RuntimeLocalSkill[];
+}): EffectiveCapabilitySet {
+  const usedRefs = new Set<string>();
+  const problems: RuntimeCapabilityProblem[] = [];
+  const standaloneSkills: RuntimeStandaloneSkill[] = [];
+  const localSkills: RuntimeLocalSkill[] = [];
+
+  const claim = (ref: string, skillId: string): boolean => {
+    if (usedRefs.has(ref)) {
+      problems.push({
+        code: "skill_ref_collision",
+        message: `Two skills resolved to the reference "${ref}"; only the first is loadable.`,
+        ref,
+        skillId,
+      });
+      return false;
+    }
+    usedRefs.add(ref);
+    return true;
+  };
+
+  for (const skill of args.standaloneSkills ?? []) {
+    if (claim(skill.ref, skill.skillId)) standaloneSkills.push(skill);
+  }
+  for (const skill of args.localSkills ?? []) {
+    if (claim(skill.ref, skill.skillId)) localSkills.push(skill);
+  }
+
+  return {
+    explicitServerIds: [],
+    pluginServerIds: [],
+    effectiveServerIds: [],
+    servers: [],
+    pluginSkills: [],
+    standaloneSkills,
+    serverSkills: [],
+    localSkills,
+    pluginVersions: [],
+    problems,
+  };
+}
+
 export function allEffectiveSkills(
   set: EffectiveCapabilitySet
-): Array<RuntimePluginSkill | RuntimeStandaloneSkill | RuntimeServerSkill> {
-  return [...set.pluginSkills, ...set.standaloneSkills, ...set.serverSkills];
+): Array<
+  | RuntimePluginSkill
+  | RuntimeStandaloneSkill
+  | RuntimeServerSkill
+  | RuntimeLocalSkill
+> {
+  return [
+    ...set.pluginSkills,
+    ...set.standaloneSkills,
+    ...set.serverSkills,
+    ...set.localSkills,
+  ];
 }

--- a/mcpjam-inspector/server/services/sessionSimulation/__tests__/runner.browser.test.ts
+++ b/mcpjam-inspector/server/services/sessionSimulation/__tests__/runner.browser.test.ts
@@ -24,6 +24,21 @@ const captureMcpAppWidgetSnapshotsMock = vi.fn();
 const prepareChatV2Mock = vi.fn();
 const convexMutationMock = vi.fn();
 const createBrowserSessionContextMock = vi.fn();
+const listCloudRuntimeSkillsMock = vi.fn();
+
+// The project catalog is the one skills dependency the runner reaches out to
+// itself; everything else about the skill surface is the orchestrator's, and
+// `prepareChatV2` is mocked here.
+vi.mock("../../../utils/computers/cloud-skill-tools.js", async () => {
+  const actual = await vi.importActual<
+    typeof import("../../../utils/computers/cloud-skill-tools.js")
+  >("../../../utils/computers/cloud-skill-tools.js");
+  return {
+    ...actual,
+    listCloudRuntimeSkills: (...args: unknown[]) =>
+      listCloudRuntimeSkillsMock(...args),
+  };
+});
 
 vi.mock("../../../utils/assistant-turn.js", async () => {
   const actual = await vi.importActual<
@@ -241,6 +256,18 @@ beforeEach(() => {
   });
   convexMutationMock.mockReset().mockResolvedValue(null);
   createBrowserSessionContextMock.mockReset();
+  listCloudRuntimeSkillsMock.mockReset().mockResolvedValue([
+    {
+      skillId: "skill-1",
+      ref: "pdf-tools",
+      name: "pdf-tools",
+      description: "Process PDFs",
+      aggregateHash: "hash-1",
+      channels: [],
+      content: async () => "# pdf-tools",
+      files: [],
+    },
+  ]);
   resolveSyntheticModelSourceMock.mockResolvedValue({ source: "mcpjam" });
   runAssistantTurnMock.mockImplementation(async (opts: any) => {
     callOrder.push("runAssistantTurn");
@@ -374,11 +401,21 @@ describe("runSyntheticHostSession — browser pipeline wiring", () => {
 
     await runSyntheticHostSession(baseAdapter() as never);
 
-    const prepareOpts = prepareChatV2Mock.mock.calls[0]![0] as any;
-    expect(prepareOpts.cloudSkills).toEqual({
+    expect(listCloudRuntimeSkillsMock).toHaveBeenCalledWith({
       authHeader: "Bearer token",
       projectId: "proj-1",
     });
+    const prepareOpts = prepareChatV2Mock.mock.calls[0]![0] as any;
+    // The project pool arrives as a live capability set, and the source keeps
+    // `composeLiveServerSkills` so a connected server's SEP-2640 skills compose
+    // ON TOP of it rather than being displaced by it.
+    expect(prepareOpts.skillsSource.kind).toBe("resolved");
+    expect(prepareOpts.skillsSource.composeLiveServerSkills).toBe(true);
+    expect(
+      prepareOpts.skillsSource.capabilities.standaloneSkills.map(
+        (skill: any) => skill.ref
+      )
+    ).toEqual(["pdf-tools"]);
   });
 
   it("omits Cloud Skills tools on the harness path (delivered natively)", async () => {
@@ -393,7 +430,8 @@ describe("runSyntheticHostSession — browser pipeline wiring", () => {
     );
 
     const prepareOpts = prepareChatV2Mock.mock.calls[0]![0] as any;
-    expect(prepareOpts.cloudSkills).toBeUndefined();
+    expect(prepareOpts.skillsSource).toEqual({ kind: "none" });
+    expect(listCloudRuntimeSkillsMock).not.toHaveBeenCalled();
   });
 
   it("omits Cloud Skills under tool approval (headless can't approve)", async () => {
@@ -409,25 +447,16 @@ describe("runSyntheticHostSession — browser pipeline wiring", () => {
     );
 
     const prepareOpts = prepareChatV2Mock.mock.calls[0]![0] as any;
-    expect(prepareOpts.cloudSkills).toBeUndefined();
+    expect(prepareOpts.skillsSource).toEqual({ kind: "none" });
+    expect(listCloudRuntimeSkillsMock).not.toHaveBeenCalled();
   });
 
-  it("forwards a skills catalog fetch failure as a session_notice", async () => {
+  it("reports a catalog fetch failure, and still composes live server skills", async () => {
     const fake = buildFakeBrowserContext({ computerUse: false });
     createBrowserSessionContextMock.mockReturnValue(fake);
-    prepareChatV2Mock.mockResolvedValue({
-      allTools: { search: { description: "noop" } },
-      enhancedSystemPrompt: "enhanced system",
-      resolvedTemperature: undefined,
-      progressivePlan: undefined,
-      discoveryState: undefined,
-      skillsFetchFailed: {
-        errorClass: "CloudSkillsError",
-        status: 500,
-        message: "CONVEX_URL is not configured",
-        latencyMs: 12,
-      },
-    });
+    listCloudRuntimeSkillsMock.mockRejectedValue(
+      new Error("CONVEX_URL is not configured")
+    );
     const emitted: any[] = [];
 
     await runSyntheticHostSession(
@@ -440,6 +469,15 @@ describe("runSyntheticHostSession — browser pipeline wiring", () => {
       toolId: "skills",
       message: "CONVEX_URL is not configured",
     });
+
+    // The regression this pins: a failed PROJECT catalog must not collapse the
+    // source to `{ kind: "none" }`. That would drop `composeLiveServerSkills`
+    // and take the connected servers' skills down with it — skills that were
+    // never fetched from Convex and never failed.
+    const prepareOpts = prepareChatV2Mock.mock.calls[0]![0] as any;
+    expect(prepareOpts.skillsSource.kind).toBe("resolved");
+    expect(prepareOpts.skillsSource.composeLiveServerSkills).toBe(true);
+    expect(prepareOpts.skillsSource.capabilities.standaloneSkills).toEqual([]);
   });
 
   it("disposes the context when the turn throws, and reports failed", async () => {

--- a/mcpjam-inspector/server/services/sessionSimulation/runner.ts
+++ b/mcpjam-inspector/server/services/sessionSimulation/runner.ts
@@ -681,7 +681,10 @@ export async function runSyntheticHostSession(
     // failing the run — a simulation that loses its skills is still a
     // simulation, and `prepared.skillsFetchFailed` telemetry below records it.
     let liveCapabilities: EffectiveCapabilitySet | undefined;
-    if (cloudSkillsEnabled && authHeader && projectId) {
+    // `!harness` explicitly, not just via `cloudSkillsEnabled`: that gate only
+    // suppresses a harness on a hosted-catalog model, so a harness on a BYOK
+    // model would otherwise build a live set and hit the disjointness refusal.
+    if (!harness && cloudSkillsEnabled && authHeader && projectId) {
       try {
         liveCapabilities = buildLiveEffectiveCapabilities({
           standaloneSkills: await listCloudRuntimeSkills({

--- a/mcpjam-inspector/server/services/sessionSimulation/runner.ts
+++ b/mcpjam-inspector/server/services/sessionSimulation/runner.ts
@@ -41,7 +41,10 @@ import { BASH_TOOL_NAME } from "../../utils/built-in-tools/bash.js";
 import {
   listCloudRuntimeSkills,
   shouldEnableCloudSkillTools,
+  skillsFailureFrom,
+  type SkillsFetchFailure,
 } from "../../utils/computers/cloud-skill-tools.js";
+import type { RuntimeStandaloneSkill } from "../../services/environments/effective-capabilities.js";
 import {
   buildLiveEffectiveCapabilities,
   type EffectiveCapabilitySet,
@@ -300,12 +303,12 @@ export interface SyntheticHostRuntime {
   scenarioId?: string;
   /**
    * Authoritative pinned skills for an ENVIRONMENT-based swarm target
-   * (Project Environments, D3). `undefined` ⇒ legacy live-pool semantics
-   * (cloud skill tools / harness live fetch, unchanged). An array — possibly
-   * EMPTY, meaning deliberately skill-less — ⇒ skills come EXCLUSIVELY from
-   * these pinned artifacts: the emulated engine gets them via prepareChatV2
-   * `skillsSource` (never `cloudSkills`), and a harness turn gets them via the
-   * pinned harness path (never `fetchRuntimeSkills`, and NEVER through
+   * (Project Environments, D3). `undefined` ⇒ live-pool semantics: the project
+   * catalog as a resolved capability set, plus the connected servers' own
+   * skills. An array — possibly EMPTY, meaning deliberately skill-less — ⇒
+   * skills come EXCLUSIVELY from these pinned artifacts: the emulated engine
+   * gets them via prepareChatV2 `skillsSource`, and a harness turn gets them
+   * via the pinned harness path (never `fetchRuntimeSkills`, and NEVER through
    * prepareChatV2's pinned branch, which throws on harness).
    */
   pinnedSkills?: PinnedSkillArtifact[];
@@ -671,30 +674,39 @@ export async function runSyntheticHostSession(
     // gets frozen pinned tools via `skillsSource` — NEVER the live cloud-skill
     // tools. `kind: "none"` covers (a) a deliberately skill-less target, (b) the
     // approval-mode no-skills semantics (a headless visitor can't approve, same
-    // rationale as the cloudSkills gate above), and (c) HARNESS turns —
+    // rationale as the live-catalog gate above), and (c) HARNESS turns —
     // prepareChatV2 THROWS on harness+pinned, so a harness target's pinned
     // artifacts ride `pinnedHarnessSkills` on the drain instead.
     // The live arm, for a run with no pins: the project pool as a capability
     // set. Previously this was "pass nothing and let the orchestrator fall
     // through to its cloud branch"; that fallback is gone, so the source is
-    // now stated here. A catalog failure degrades to no skills rather than
-    // failing the run — a simulation that loses its skills is still a
-    // simulation, and `prepared.skillsFetchFailed` telemetry below records it.
+    // now stated here.
+    //
+    // A catalog failure degrades to a live set with no PROJECT skills — never
+    // to `{ kind: "none" }`. The source also carries `composeLiveServerSkills`,
+    // so collapsing it would take the connected servers' SEP-2640 skills down
+    // with the project's, and those never failed: losing skills we could not
+    // fetch is a degradation, losing skills we could is a bug. The failure is
+    // recorded here rather than read back off `prepared`, because the fetch now
+    // happens on this side of `prepareChatV2` and the orchestrator cannot know
+    // how it went.
     let liveCapabilities: EffectiveCapabilitySet | undefined;
+    let skillsFetchFailed: SkillsFetchFailure | undefined;
     // `!harness` explicitly, not just via `cloudSkillsEnabled`: that gate only
     // suppresses a harness on a hosted-catalog model, so a harness on a BYOK
     // model would otherwise build a live set and hit the disjointness refusal.
     if (!harness && cloudSkillsEnabled && authHeader && projectId) {
+      const startedAt = Date.now();
+      let standaloneSkills: RuntimeStandaloneSkill[] = [];
       try {
-        liveCapabilities = buildLiveEffectiveCapabilities({
-          standaloneSkills: await listCloudRuntimeSkills({
-            authHeader,
-            projectId,
-          }),
+        standaloneSkills = await listCloudRuntimeSkills({
+          authHeader,
+          projectId,
         });
-      } catch {
-        liveCapabilities = undefined;
+      } catch (error) {
+        skillsFetchFailed = skillsFailureFrom(error, Date.now() - startedAt);
       }
+      liveCapabilities = buildLiveEffectiveCapabilities({ standaloneSkills });
     }
 
     const skillsSource:
@@ -746,22 +758,21 @@ export async function runSyntheticHostSession(
         : {}),
       ...(builtInTools ? { builtInTools } : {}),
       skillsSource,
-      ...(cloudSkillsEnabled ? { cloudSkills: { authHeader, projectId } } : {}),
     });
 
-    if (prepared.skillsFetchFailed) {
+    if (skillsFetchFailed) {
       logger.warn("[sessionSimulation.runner] skills catalog fetch failed", {
         runId,
         chatSessionId,
-        errorClass: prepared.skillsFetchFailed.errorClass,
-        status: prepared.skillsFetchFailed.status,
-        latencyMs: prepared.skillsFetchFailed.latencyMs,
+        errorClass: skillsFetchFailed.errorClass,
+        status: skillsFetchFailed.status,
+        latencyMs: skillsFetchFailed.latencyMs,
       });
       emit?.({
         type: "session_notice",
         kind: "tool_suppressed",
         toolId: "skills",
-        message: prepared.skillsFetchFailed.message,
+        message: skillsFetchFailed.message,
       });
     }
 

--- a/mcpjam-inspector/server/services/sessionSimulation/runner.ts
+++ b/mcpjam-inspector/server/services/sessionSimulation/runner.ts
@@ -38,7 +38,14 @@ import {
 } from "../../utils/built-in-tools/registry.js";
 import type { TrustedHarnessSandboxBinding } from "../../utils/harness/resolve-sandbox.js";
 import { BASH_TOOL_NAME } from "../../utils/built-in-tools/bash.js";
-import { shouldEnableCloudSkillTools } from "../../utils/computers/cloud-skill-tools.js";
+import {
+  listCloudRuntimeSkills,
+  shouldEnableCloudSkillTools,
+} from "../../utils/computers/cloud-skill-tools.js";
+import {
+  buildLiveEffectiveCapabilities,
+  type EffectiveCapabilitySet,
+} from "../../services/environments/effective-capabilities.js";
 import {
   persistChatSessionToConvex,
   type PersistChatOutcome,
@@ -56,7 +63,7 @@ import { exportConnectedServerToolSnapshotForEvalAuthoring } from "../../utils/e
 function warnIfSimulationPersistNotSaved(
   outcome: PersistChatOutcome | undefined,
   stage: "empty-session" | "turn",
-  chatSessionId: string
+  chatSessionId: string,
 ): void {
   // This is observability, not control flow — it must never be the thing that
   // takes a synthetic run down, so an absent outcome is simply nothing to say.
@@ -162,7 +169,7 @@ const TERMINAL_ARTIFACT_FLUSH_TIMEOUT_MS = 30_000;
 async function withDeadline<T>(
   promise: Promise<T>,
   timeoutMs: number,
-  fallback: T
+  fallback: T,
 ): Promise<T> {
   let timer: ReturnType<typeof setTimeout> | undefined;
   try {
@@ -337,7 +344,7 @@ export interface SyntheticHostSessionAdapter {
   abortSignal?: AbortSignal;
   /** Surface persona driver: produce the next simulated user message. */
   nextPersonaTurn(
-    transcriptSoFar: Array<{ role: "user" | "assistant"; content: string }>
+    transcriptSoFar: Array<{ role: "user" | "assistant"; content: string }>,
   ): Promise<{ message: string; endSession: boolean }>;
   /** Persistence attribution tags (scenario vs swarm). */
   persist: SyntheticPersistAttribution;
@@ -375,7 +382,7 @@ export interface SyntheticHostSessionAdapter {
 }
 
 export async function runSyntheticHostSession(
-  adapter: SyntheticHostSessionAdapter
+  adapter: SyntheticHostSessionAdapter,
 ): Promise<SessionResult> {
   const {
     runId,
@@ -536,7 +543,7 @@ export async function runSyntheticHostSession(
     warnIfSimulationPersistNotSaved(
       emptySessionPersist,
       "empty-session",
-      chatSessionId
+      chatSessionId,
     );
     sessionRowEnsured = true;
   };
@@ -577,7 +584,7 @@ export async function runSyntheticHostSession(
         Array.isArray(selectedServerNames) &&
         selectedServerNames.length === selectedServerIds.length
           ? selectedServerNames.filter(
-              (_, i) => !nonResumable.has(selectedServerIds[i]!)
+              (_, i) => !nonResumable.has(selectedServerIds[i]!),
             )
           : selectedServerIds.filter((id) => !nonResumable.has(id)),
     };
@@ -626,7 +633,7 @@ export async function runSyntheticHostSession(
             message,
           });
         },
-      }
+      },
     );
 
     // Cloud Skills parity with a real chat-v2 visitor: a synthetic session is
@@ -667,25 +674,55 @@ export async function runSyntheticHostSession(
     // rationale as the cloudSkills gate above), and (c) HARNESS turns —
     // prepareChatV2 THROWS on harness+pinned, so a harness target's pinned
     // artifacts ride `pinnedHarnessSkills` on the drain instead.
+    // The live arm, for a run with no pins: the project pool as a capability
+    // set. Previously this was "pass nothing and let the orchestrator fall
+    // through to its cloud branch"; that fallback is gone, so the source is
+    // now stated here. A catalog failure degrades to no skills rather than
+    // failing the run — a simulation that loses its skills is still a
+    // simulation, and `prepared.skillsFetchFailed` telemetry below records it.
+    let liveCapabilities: EffectiveCapabilitySet | undefined;
+    if (cloudSkillsEnabled && authHeader && projectId) {
+      try {
+        liveCapabilities = buildLiveEffectiveCapabilities({
+          standaloneSkills: await listCloudRuntimeSkills({
+            authHeader,
+            projectId,
+          }),
+        });
+      } catch {
+        liveCapabilities = undefined;
+      }
+    }
+
     const skillsSource:
       | { kind: "pinned"; skills: PinnableSkill[] }
       | { kind: "none" }
-      | undefined =
+      | {
+          kind: "resolved";
+          capabilities: EffectiveCapabilitySet;
+          composeLiveServerSkills?: boolean;
+        } =
       pinnedSkills === undefined
-        ? undefined
+        ? liveCapabilities
+          ? {
+              kind: "resolved",
+              capabilities: liveCapabilities,
+              // Live surface: server skills come from the connected servers,
+              // preserving what the fallthrough arm used to compose.
+              composeLiveServerSkills: true,
+            }
+          : { kind: "none" }
         : harness || requireToolApproval || pinnedSkills.length === 0
-        ? { kind: "none" }
-        : {
-            kind: "pinned",
-            skills: pinnedSkills.map(
-              (a): PinnableSkill => ({
+          ? { kind: "none" }
+          : {
+              kind: "pinned",
+              skills: pinnedSkills.map((a): PinnableSkill => ({
                 name: a.name,
                 description: a.description,
                 content: a.content,
                 contentHash: a.contentHash,
-              })
-            ),
-          };
+              })),
+            };
 
     const prepared = await prepareChatV2({
       mcpClientManager: manager,
@@ -705,7 +742,7 @@ export async function runSyntheticHostSession(
           }
         : {}),
       ...(builtInTools ? { builtInTools } : {}),
-      ...(skillsSource ? { skillsSource } : {}),
+      skillsSource,
       ...(cloudSkillsEnabled ? { cloudSkills: { authHeader, projectId } } : {}),
     });
 
@@ -989,7 +1026,7 @@ export async function runSyntheticHostSession(
             await exportConnectedServerToolSnapshotForEvalAuthoring(
               liveManager,
               knownIds,
-              { logPrefix: "sessionSimulation.persist" }
+              { logPrefix: "sessionSimulation.persist" },
             );
         }
       } catch {
@@ -1066,7 +1103,7 @@ export async function runSyntheticHostSession(
               chatSessionId,
               promptIndex: turn,
               error: err instanceof Error ? err.message : String(err),
-            }
+            },
           );
         }
       }
@@ -1159,7 +1196,7 @@ export async function runSyntheticHostSession(
               runId,
               chatSessionId,
               error: err instanceof Error ? err.message : String(err),
-            }
+            },
           );
         }
       }
@@ -1201,7 +1238,7 @@ export async function runSyntheticHostSession(
                     runId,
                     chatSessionId,
                     error: err instanceof Error ? err.message : String(err),
-                  }
+                  },
                 );
               }
               if (videoBytes) await outbox.stageVideo(videoBytes);
@@ -1218,7 +1255,7 @@ export async function runSyntheticHostSession(
                   written: 0,
                   pending: outbox.pendingBatchCount,
                   videoAttached: false,
-                }
+                },
               );
               if (result.pending > 0) {
                 logger.warn(
@@ -1228,7 +1265,7 @@ export async function runSyntheticHostSession(
                     chatSessionId,
                     pending: result.pending,
                     videoAttached: result.videoAttached,
-                  }
+                  },
                 );
               }
             },
@@ -1307,7 +1344,7 @@ export async function captureAndPersistWidgetSnapshotsForSession(args: {
   if (!convexUrl) {
     logger.warn(
       "[sessionSimulation.runner] CONVEX_URL not set; skipping widget snapshot capture",
-      { chatSessionId, scenarioId }
+      { chatSessionId, scenarioId },
     );
     return;
   }
@@ -1366,7 +1403,7 @@ export async function captureAndPersistWidgetSnapshotsForSession(args: {
             ...(accessVersion !== undefined ? { accessVersion } : {}),
             chatSessionId,
             ...sanitized,
-          }
+          },
         );
         // Null = the ingest race (session row not written yet) — leave the
         // id unmarked so the next turn retries. Anything else is the row id.
@@ -1380,7 +1417,7 @@ export async function captureAndPersistWidgetSnapshotsForSession(args: {
           error: err instanceof Error ? err.message : String(err),
         });
       }
-    })
+    }),
   );
 }
 
@@ -1452,7 +1489,7 @@ export async function drainAssistantTurn(
     journeyRunId?: string;
     /** Optional turn hooks (browser session context attachment points). */
     hooks?: DrainAssistantTurnHooks;
-  }
+  },
 ): Promise<{
   history: ModelMessage[];
   turnTrace: PersistedTurnTrace | undefined;
@@ -1486,7 +1523,7 @@ export async function drainAssistantTurn(
   if (args.sourceType === "swarm" && !!journeyRunId !== !!hostId) {
     throw new Error(
       "Swarm turn has partial continuity identity: journeyRunId and hostId " +
-        "must be provided together"
+        "must be provided together",
     );
   }
 
@@ -1539,8 +1576,7 @@ export async function drainAssistantTurn(
   // Engine-error signal. Structural type covers both the hosted
   // `MCPJamEngineErrorEvent` and the direct `DirectChatTurnEngineErrorEvent`.
   let lastEngineError:
-    | { message: string; code?: string; httpStatus?: number }
-    | undefined;
+    { message: string; code?: string; httpStatus?: number } | undefined;
   const captureEngineError = (event: {
     message: string;
     code?: string;
@@ -1611,7 +1647,7 @@ export async function drainAssistantTurn(
     // billing — with the same message shape the old headless path did.
     if (lastEngineError) {
       throw new Error(
-        lastEngineError.message || "Local org-BYOK turn failed mid-stream."
+        lastEngineError.message || "Local org-BYOK turn failed mid-stream.",
       );
     }
 
@@ -1719,11 +1755,11 @@ export async function drainAssistantTurn(
       throw new Error(
         detail
           ? `${lastEngineError.message} (${detail})`
-          : lastEngineError.message
+          : lastEngineError.message,
       );
     }
     throw new Error(
-      "Assistant turn failed: the engine returned no turn trace (stream error or empty response)"
+      "Assistant turn failed: the engine returned no turn trace (stream error or empty response)",
     );
   }
 
@@ -1753,7 +1789,7 @@ function extractAssistantText(history: ModelMessage[]): string {
           typeof part === "object" &&
           part !== null &&
           (part as { type?: string }).type === "text" &&
-          typeof (part as { text?: unknown }).text === "string"
+          typeof (part as { text?: unknown }).text === "string",
       )
       .map((part) => part.text)
       .join("");

--- a/mcpjam-inspector/server/utils/__tests__/chat-v2-orchestration.test.ts
+++ b/mcpjam-inspector/server/utils/__tests__/chat-v2-orchestration.test.ts
@@ -1609,7 +1609,6 @@ describe("prepareChatV2 — a live resolved source", () => {
     expect(result.enhancedSystemPrompt).toContain("Process PDFs");
     expect(result.allTools).toHaveProperty("loadSkill");
     expect(result.allTools).not.toHaveProperty("listSkills");
-    expect(result.skillsFetchFailed).toBeUndefined();
   });
 
   it("advertises no skill tools or stanza when the set is empty", async () => {

--- a/mcpjam-inspector/server/utils/__tests__/chat-v2-orchestration.test.ts
+++ b/mcpjam-inspector/server/utils/__tests__/chat-v2-orchestration.test.ts
@@ -29,8 +29,7 @@ import {
   type UiToolEntry,
 } from "../chat-v2-orchestration";
 import { getSkillToolsAndPrompt } from "../skill-tools";
-import { CloudSkillsError, listCloudSkills } from "../computers/cloud-skills";
-import { CLOUD_SKILLS_FETCH_TIMEOUT_MS } from "../computers/cloud-skill-tools";
+import { listCloudSkills } from "../computers/cloud-skills";
 import {
   buildExaWebSearchTool,
   WEB_SEARCH_TOOL_NAME,

--- a/mcpjam-inspector/server/utils/__tests__/chat-v2-orchestration.test.ts
+++ b/mcpjam-inspector/server/utils/__tests__/chat-v2-orchestration.test.ts
@@ -808,24 +808,41 @@ describe("prepareChatV2 built-in tools", () => {
   });
 
   it("fails closed when a built-in name collides with a skill tool", async () => {
-    vi.mocked(getSkillToolsAndPrompt).mockResolvedValue({
-      tools: {
-        [WEB_SEARCH_TOOL_NAME]: {
-          description: "skill web search",
-          execute: async () => ({}),
-        },
-      } as any,
-      systemPromptSection: "",
-    });
+    // The skill surface owns `loadSkill`. A built-in claiming it would leave
+    // the model with one name and two meanings, resolved by merge order — so
+    // the turn refuses to start rather than silently picking a winner.
     const manager = mockManager({});
 
     await expect(
       prepareChatV2({
         ...baseArgs,
         mcpClientManager: manager,
-        builtInTools: webSearchBuiltIn(),
+        builtInTools: {
+          loadSkill: {
+            description: "a built-in that wants the skill surface's name",
+            execute: async () => ({}),
+          },
+        } as any,
+        skillsSource: {
+          kind: "resolved",
+          capabilities: {
+            ...emptyCapabilities(),
+            standaloneSkills: [
+              {
+                skillId: "sk_1",
+                ref: "pdf-tools",
+                name: "pdf-tools",
+                description: "Process PDFs",
+                content: "# pdf",
+                aggregateHash: "h",
+                channels: [],
+                files: [],
+              },
+            ],
+          },
+        },
       })
-    ).rejects.toThrow(/web_search.*collides/);
+    ).rejects.toThrow(/loadSkill.*collides/);
   });
 
   it("fails closed when a built-in name collides with an app tool", async () => {
@@ -1550,95 +1567,91 @@ describe("prepareChatV2 — pinned skills × harness (Project Environments guard
   });
 });
 
-describe("prepareChatV2 — live cloud skills catalog", () => {
-  const cloudSkills = { authHeader: "Bearer t", projectId: "proj-1" };
+describe("prepareChatV2 — a live resolved source", () => {
+  // The project's catalog is fetched by the ROUTE now and handed over as an
+  // `EffectiveCapabilitySet`, so what `prepareChatV2` owes is what it does with
+  // one: inline the listing, advertise `loadSkill`, and never invent a
+  // `listSkills` discovery tool. Catalog fetching and its failure modes are
+  // `listCloudRuntimeSkills`'s to prove, and are covered where they live.
+  function liveSet(
+    skills: Array<{ ref: string; name: string; description: string }>
+  ) {
+    return {
+      ...emptyCapabilities(),
+      standaloneSkills: skills.map((skill) => ({
+        skillId: `sk_${skill.name}`,
+        ref: skill.ref,
+        name: skill.name,
+        description: skill.description,
+        content: async () => `# ${skill.name}`,
+        aggregateHash: "h",
+        channels: [],
+        files: [],
+      })),
+    };
+  }
 
   it("inlines the catalog and advertises loadSkill, not listSkills", async () => {
-    vi.mocked(listCloudSkills).mockResolvedValue([
-      {
-        skillId: "sk1",
-        projectId: "proj-1",
-        name: "pdf-tools",
-        description: "Process PDFs",
-        sharing: "user",
-        isOwner: true,
-        aggregateHash: "h",
-        createdAt: 1,
-        updatedAt: 1,
-      },
-    ] as never);
     const result = await prepareChatV2({
       mcpClientManager: mockManager({}),
       selectedServers: [],
       modelDefinition: { id: "gpt-4.1", provider: "openai" } as any,
       systemPrompt: "Base prompt.",
-      cloudSkills,
+      skillsSource: {
+        kind: "resolved",
+        capabilities: liveSet([
+          { ref: "pdf-tools", name: "pdf-tools", description: "Process PDFs" },
+        ]),
+        composeLiveServerSkills: true,
+      },
     });
     expect(result.enhancedSystemPrompt).toContain("## Skills");
-    expect(result.enhancedSystemPrompt).toContain(
-      "- **pdf-tools**: Process PDFs"
-    );
-    expect(result.enhancedSystemPrompt).toContain("loadSkill");
+    expect(result.enhancedSystemPrompt).toContain("**pdf-tools**");
+    expect(result.enhancedSystemPrompt).toContain("Process PDFs");
     expect(result.allTools).toHaveProperty("loadSkill");
     expect(result.allTools).not.toHaveProperty("listSkills");
     expect(result.skillsFetchFailed).toBeUndefined();
   });
 
-  it("advertises no skill tools or stanza when the project has zero skills", async () => {
-    vi.mocked(listCloudSkills).mockResolvedValue([]);
+  it("advertises no skill tools or stanza when the set is empty", async () => {
+    // An empty project and a project whose skills failed to load look the same
+    // HERE on purpose: the difference is recorded by whoever did the fetching.
     const result = await prepareChatV2({
       mcpClientManager: mockManager({}),
       selectedServers: [],
       modelDefinition: { id: "gpt-4.1", provider: "openai" } as any,
       systemPrompt: "Base prompt.",
-      cloudSkills,
+      skillsSource: {
+        kind: "resolved",
+        capabilities: emptyCapabilities(),
+        composeLiveServerSkills: true,
+      },
     });
     expect(result.allTools).not.toHaveProperty("loadSkill");
     expect(result.allTools).not.toHaveProperty("listSkills");
     expect(result.enhancedSystemPrompt).toBe("Base prompt.");
-    expect(result.skillsFetchFailed).toBeUndefined();
   });
 
-  it("prepares the turn without skill tools when the catalog fetch throws", async () => {
-    vi.mocked(listCloudSkills).mockRejectedValue(
-      new CloudSkillsError("CONVEX_URL is not configured", 500)
-    );
+  it("keeps skill tools under the host's approval rule, unlike a pinned source", async () => {
+    // `resolved` is an interactive turn; only the pinned kinds bypass approval,
+    // and that divergence is the whole reason they are separate kinds.
     const result = await prepareChatV2({
       mcpClientManager: mockManager({}),
       selectedServers: [],
       modelDefinition: { id: "gpt-4.1", provider: "openai" } as any,
       systemPrompt: "Base prompt.",
-      cloudSkills,
+      requireToolApproval: true,
+      skillsSource: {
+        kind: "resolved",
+        capabilities: liveSet([
+          { ref: "pdf-tools", name: "pdf-tools", description: "Process PDFs" },
+        ]),
+        composeLiveServerSkills: true,
+      },
     });
-    expect(result.allTools).not.toHaveProperty("loadSkill");
-    expect(result.enhancedSystemPrompt).toBe("Base prompt.");
-    expect(result.skillsFetchFailed).toMatchObject({
-      errorClass: "CloudSkillsError",
-      status: 500,
-    });
-  });
-
-  it("prepares the turn without skill tools when the catalog fetch times out", async () => {
-    vi.useFakeTimers();
-    vi.mocked(listCloudSkills).mockImplementation(() => new Promise(() => {}));
-    try {
-      const resultPromise = prepareChatV2({
-        mcpClientManager: mockManager({}),
-        selectedServers: [],
-        modelDefinition: { id: "gpt-4.1", provider: "openai" } as any,
-        systemPrompt: "Base prompt.",
-        cloudSkills,
-      });
-      await vi.advanceTimersByTimeAsync(CLOUD_SKILLS_FETCH_TIMEOUT_MS);
-      const result = await resultPromise;
-      expect(result.allTools).not.toHaveProperty("loadSkill");
-      expect(result.enhancedSystemPrompt).toBe("Base prompt.");
-      expect(result.skillsFetchFailed).toMatchObject({
-        errorClass: "CloudSkillsFetchTimeoutError",
-        status: 504,
-      });
-    } finally {
-      vi.useRealTimers();
-    }
+    expect(
+      (result.allTools as Record<string, { needsApproval?: unknown }>).loadSkill
+        .needsApproval
+    ).toBe(true);
   });
 });

--- a/mcpjam-inspector/server/utils/__tests__/chat-v2-orchestration.test.ts
+++ b/mcpjam-inspector/server/utils/__tests__/chat-v2-orchestration.test.ts
@@ -1528,29 +1528,29 @@ describe("prepareChatV2 — pinned skills × harness (Project Environments guard
           ],
         },
       })
-    ).rejects.toThrow(/receive pinned skills on box via `pinnedHarnessSkills`/);
+    ).rejects.toThrow(/receive skills on box via `pinnedHarnessSkills`/);
   });
 
-  it("never composes LIVE server skills onto a harness turn, flag or no flag", async () => {
+  it("REFUSES a live resolved source on a harness turn, flag or no flag", async () => {
     // The flag says "this surface is live"; the harness says "skills arrive on
-    // box". A harness turn that also merged live server skills would deliver
-    // the same skill twice by two mechanisms — the exact double-delivery the
-    // disjointness rule exists to prevent — so harness wins unconditionally.
+    // box". Serving both would deliver the same skill twice by two mechanisms,
+    // so the turn refuses rather than silently picking one — the same rule that
+    // has always covered pinned sources, now covering every in-memory shape.
     const manager = mockManager({});
-    const result = await prepareChatV2({
-      mcpClientManager: manager,
-      selectedServers: ["srv-1"],
-      modelDefinition: { id: "gpt-4.1", provider: "openai" } as any,
-      systemPrompt: "Base prompt.",
-      harness: "claude-code" as any,
-      skillsSource: {
-        kind: "resolved",
-        capabilities: emptyCapabilities(),
-        composeLiveServerSkills: true,
-      },
-    });
-    expect(Object.keys(result.allTools)).not.toContain("listSkills");
-    expect(Object.keys(result.allTools)).not.toContain("loadSkill");
+    await expect(
+      prepareChatV2({
+        mcpClientManager: manager,
+        selectedServers: ["srv-1"],
+        modelDefinition: { id: "gpt-4.1", provider: "openai" } as any,
+        systemPrompt: "Base prompt.",
+        harness: "claude-code" as any,
+        skillsSource: {
+          kind: "resolved",
+          capabilities: emptyCapabilities(),
+          composeLiveServerSkills: true,
+        },
+      })
+    ).rejects.toThrow(/deliberately disjoint/);
   });
 
   it("accepts harness + skillsSource none (a deliberately skill-less env target)", async () => {

--- a/mcpjam-inspector/server/utils/__tests__/chat-v2-orchestration.test.ts
+++ b/mcpjam-inspector/server/utils/__tests__/chat-v2-orchestration.test.ts
@@ -1460,6 +1460,21 @@ describe("prepareChatV2 — WebMCP UI tools", () => {
   });
 });
 
+function emptyCapabilities() {
+  return {
+    explicitServerIds: [],
+    pluginServerIds: [],
+    effectiveServerIds: [],
+    servers: [],
+    pluginSkills: [],
+    standaloneSkills: [],
+    serverSkills: [],
+    localSkills: [],
+    pluginVersions: [],
+    problems: [],
+  } as any;
+}
+
 describe("prepareChatV2 — pinned skills × harness (Project Environments guard)", () => {
   it("does not wrap an explicit none source with live MCP server skills", async () => {
     const manager = mockManager({});
@@ -1497,6 +1512,28 @@ describe("prepareChatV2 — pinned skills × harness (Project Environments guard
         },
       })
     ).rejects.toThrow(/receive pinned skills on box via `pinnedHarnessSkills`/);
+  });
+
+  it("never composes LIVE server skills onto a harness turn, flag or no flag", async () => {
+    // The flag says "this surface is live"; the harness says "skills arrive on
+    // box". A harness turn that also merged live server skills would deliver
+    // the same skill twice by two mechanisms — the exact double-delivery the
+    // disjointness rule exists to prevent — so harness wins unconditionally.
+    const manager = mockManager({});
+    const result = await prepareChatV2({
+      mcpClientManager: manager,
+      selectedServers: ["srv-1"],
+      modelDefinition: { id: "gpt-4.1", provider: "openai" } as any,
+      systemPrompt: "Base prompt.",
+      harness: "claude-code" as any,
+      skillsSource: {
+        kind: "resolved",
+        capabilities: emptyCapabilities(),
+        composeLiveServerSkills: true,
+      },
+    });
+    expect(Object.keys(result.allTools)).not.toContain("listSkills");
+    expect(Object.keys(result.allTools)).not.toContain("loadSkill");
   });
 
   it("accepts harness + skillsSource none (a deliberately skill-less env target)", async () => {

--- a/mcpjam-inspector/server/utils/__tests__/local-runtime-skills.test.ts
+++ b/mcpjam-inspector/server/utils/__tests__/local-runtime-skills.test.ts
@@ -105,6 +105,51 @@ describe("listLocalRuntimeSkills", () => {
     expect(await listLocalRuntimeSkills()).toEqual([]);
   });
 
+  it("takes the first of two skills sharing a name, in search order", async () => {
+    // Global before project is the search order `getSkillsDirs` fixes; two
+    // directories offering the same name is a shadowing question that order
+    // already answers, not a ref collision for `buildLiveEffectiveCapabilities`
+    // to reject.
+    await writeSkill(
+      path.join(home, ".claude", "skills"),
+      "code-review",
+      "From home."
+    );
+    await writeSkill(
+      path.join(cwd, ".claude", "skills"),
+      "code-review",
+      "From the project."
+    );
+
+    const skills = await listLocalRuntimeSkills();
+
+    expect(skills).toHaveLength(1);
+    expect(skills[0]!.content).toContain("From home.");
+  });
+
+  it("skips a directory with no SKILL.md, and one whose SKILL.md is malformed", async () => {
+    const skillsRoot = path.join(cwd, ".claude", "skills");
+    await fs.mkdir(path.join(skillsRoot, "empty-dir"), { recursive: true });
+    await fs.mkdir(path.join(skillsRoot, "malformed"), { recursive: true });
+    await fs.writeFile(
+      path.join(skillsRoot, "malformed", "SKILL.md"),
+      "no frontmatter at all\n",
+      "utf-8"
+    );
+    await writeSkill(skillsRoot, "code-review");
+
+    // One unreadable neighbour must not cost the readable skill beside it.
+    expect((await listLocalRuntimeSkills()).map((skill) => skill.name)).toEqual([
+      "code-review",
+    ]);
+  });
+
+  it("returns nothing when no skills directory exists at all", async () => {
+    await fs.rm(path.join(cwd, ".claude"), { recursive: true, force: true });
+
+    expect(await listLocalRuntimeSkills()).toEqual([]);
+  });
+
   it("lists a real supporting file and no symlinked one", async () => {
     const secret = path.join(root, "secret.txt");
     await fs.writeFile(secret, "PRIVATE", "utf-8");
@@ -124,4 +169,24 @@ describe("listLocalRuntimeSkills", () => {
     ).toBe("public");
   });
 
+  it("re-checks the size at read time, not the one the listing recorded", async () => {
+    // The listing is taken once per turn and reused, so the size the caller
+    // validated can be arbitrarily stale by the time the read happens — a
+    // script or an editor writing to the file in between is enough.
+    const skillDir = await writeSkill(
+      path.join(cwd, ".claude", "skills"),
+      "code-review"
+    );
+    const notes = path.join(skillDir, "notes.txt");
+    await fs.writeFile(notes, "small", "utf-8");
+
+    const [skill] = await listLocalRuntimeSkills();
+    const files = await skill!.listFiles!();
+    expect(files[0]!.size).toBe(5);
+
+    // Grows past the 2 MB cap after the listing recorded 5 bytes.
+    await fs.writeFile(notes, "x".repeat(2 * 1024 * 1024 + 1), "utf-8");
+
+    await expect(files[0]!.read!()).rejects.toThrow(/too large to read/);
+  });
 });

--- a/mcpjam-inspector/server/utils/__tests__/local-runtime-skills.test.ts
+++ b/mcpjam-inspector/server/utils/__tests__/local-runtime-skills.test.ts
@@ -1,0 +1,127 @@
+/**
+ * The local filesystem family, against a real filesystem.
+ *
+ * `listLocalRuntimeSkills` is the origin that made the merged catalog possible
+ * on the desktop, and it is the only one whose inputs are files an arbitrary
+ * third party may have written: `npx skills` installs packs straight into
+ * `~/.claude/skills`. So these cases run against real directories rather than a
+ * mocked `fs` — the behaviour under test IS what the filesystem does, and a
+ * symlink is exactly what a mock would get wrong.
+ */
+import fs from "fs/promises";
+import os from "os";
+import path from "path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+let root: string;
+let home: string;
+let cwd: string;
+
+vi.mock("os", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("os")>();
+  return {
+    ...actual,
+    default: { ...actual, homedir: () => homedirValue.value },
+    homedir: () => homedirValue.value,
+  };
+});
+
+const homedirValue = { value: "" };
+
+import { listLocalRuntimeSkills } from "../skill-tools.js";
+
+async function writeSkill(
+  dir: string,
+  name: string,
+  body = "Do the thing."
+): Promise<string> {
+  const skillDir = path.join(dir, name);
+  await fs.mkdir(skillDir, { recursive: true });
+  await fs.writeFile(
+    path.join(skillDir, "SKILL.md"),
+    `---\nname: ${name}\ndescription: ${name} skill\n---\n\n${body}\n`,
+    "utf-8"
+  );
+  return skillDir;
+}
+
+beforeEach(async () => {
+  root = await fs.mkdtemp(path.join(os.tmpdir(), "mcpjam-local-skills-"));
+  home = path.join(root, "home");
+  cwd = path.join(root, "project");
+  await fs.mkdir(path.join(cwd, ".claude", "skills"), { recursive: true });
+  await fs.mkdir(home, { recursive: true });
+  homedirValue.value = home;
+  vi.spyOn(process, "cwd").mockReturnValue(cwd);
+});
+
+afterEach(async () => {
+  vi.restoreAllMocks();
+  await fs.rm(root, { recursive: true, force: true });
+});
+
+describe("listLocalRuntimeSkills", () => {
+  it("reads a skill from the project's skills directory", async () => {
+    await writeSkill(path.join(cwd, ".claude", "skills"), "code-review");
+
+    const skills = await listLocalRuntimeSkills();
+
+    expect(skills).toHaveLength(1);
+    expect(skills[0]!.ref).toBe("local/code-review");
+    expect(skills[0]!.name).toBe("code-review");
+    expect(skills[0]!.content).toContain("Do the thing.");
+  });
+
+  it("refuses a SKILL.md that symlinks out of the skill directory", async () => {
+    // The silent case: nothing in the pack's own text says it exfiltrates,
+    // because the body IS the secret. An instruction to read `~/.ssh/id_rsa`
+    // is at least legible in a review; this is not.
+    const secret = path.join(root, "secret.md");
+    await fs.writeFile(
+      secret,
+      "---\nname: code-review\ndescription: x\n---\n\nPRIVATE KEY MATERIAL\n",
+      "utf-8"
+    );
+    const skillDir = path.join(cwd, ".claude", "skills", "code-review");
+    await fs.mkdir(skillDir, { recursive: true });
+    await fs.symlink(secret, path.join(skillDir, "SKILL.md"));
+
+    expect(await listLocalRuntimeSkills()).toEqual([]);
+  });
+
+  it("skips a skill directory that is itself a symlink", async () => {
+    // Surprising but pre-existing, and worth pinning: `readdir(withFileTypes)`
+    // reports a symlink as neither file nor directory, so linking a checkout
+    // into the skills directory has never worked here (the bare local surface
+    // skips it the same way). Recorded so a future change to that scan is a
+    // deliberate one.
+    const real = await writeSkill(path.join(root, "dev"), "code-review");
+    await fs.symlink(
+      real,
+      path.join(cwd, ".claude", "skills", "code-review"),
+      "dir"
+    );
+
+    expect(await listLocalRuntimeSkills()).toEqual([]);
+  });
+
+  it("lists a real supporting file and no symlinked one", async () => {
+    const secret = path.join(root, "secret.txt");
+    await fs.writeFile(secret, "PRIVATE", "utf-8");
+    const skillDir = await writeSkill(
+      path.join(cwd, ".claude", "skills"),
+      "code-review"
+    );
+    await fs.writeFile(path.join(skillDir, "notes.txt"), "public", "utf-8");
+    await fs.symlink(secret, path.join(skillDir, "escape.txt"));
+
+    const [skill] = await listLocalRuntimeSkills();
+    const files = await skill!.listFiles!();
+
+    expect(files.map((file) => file.path)).toEqual(["notes.txt"]);
+    expect(
+      new TextDecoder().decode(await files[0]!.read!())
+    ).toBe("public");
+  });
+
+});

--- a/mcpjam-inspector/server/utils/__tests__/skill-origin-policy.test.ts
+++ b/mcpjam-inspector/server/utils/__tests__/skill-origin-policy.test.ts
@@ -1,0 +1,227 @@
+/**
+ * WHICH ORIGINS EACH SURFACE ADMITS.
+ *
+ * This matrix is the thing that regressed into the mess this convergence
+ * undid: every surface grew its own answer to "where do skills come from",
+ * nobody wrote the answers down together, and the differences were only
+ * discoverable by reading four call sites. Converging them created the
+ * opposite risk — a surface quietly gaining an origin it must not have — so
+ * the matrix is asserted rather than described.
+ *
+ * These cases pin `prepareChatV2`'s side of the contract: given a source of
+ * each shape, what does the turn advertise? The per-route half (which shape
+ * each route builds) is pinned in the route suites.
+ */
+
+import { describe, expect, it, vi } from "vitest";
+
+vi.mock("../skill-tools.js", () => ({
+  getSkillToolsAndPrompt: vi.fn(),
+  listLocalRuntimeSkills: vi.fn(async () => []),
+}));
+
+import { prepareChatV2 } from "../chat-v2-orchestration.js";
+import type { EffectiveCapabilitySet } from "../../services/environments/effective-capabilities.js";
+
+function mockManager(tools: Record<string, unknown> = {}) {
+  return {
+    getToolsForAiSdk: vi.fn(async () => tools),
+    listTools: vi.fn(async () => ({ tools: [] })),
+    getSkillsSupport: vi.fn(() => ({
+      declared: false,
+      advertised: false,
+      directoryRead: false,
+      active: false,
+    })),
+  } as never;
+}
+
+function capabilities(
+  overrides: Partial<EffectiveCapabilitySet> = {}
+): EffectiveCapabilitySet {
+  return {
+    explicitServerIds: [],
+    pluginServerIds: [],
+    effectiveServerIds: [],
+    servers: [],
+    pluginSkills: [],
+    standaloneSkills: [],
+    serverSkills: [],
+    localSkills: [],
+    pluginVersions: [],
+    problems: [],
+    ...overrides,
+  };
+}
+
+const PROJECT_SKILL = {
+  skillId: "sk_project",
+  ref: "code-review",
+  name: "code-review",
+  description: "Review code.",
+  content: "# Project",
+  aggregateHash: "h1",
+  channels: [] as never[],
+  files: [],
+};
+
+const LOCAL_SKILL = {
+  skillId: "local:/home/u/.claude/skills/code-review",
+  ref: "local/code-review",
+  name: "code-review",
+  description: "Review code, locally.",
+  content: "# Local",
+  aggregateHash: "h2",
+  directory: "~/.claude/skills/code-review",
+  files: [],
+};
+
+const base = {
+  selectedServers: [] as string[],
+  modelDefinition: { id: "gpt-4.1", provider: "openai" } as never,
+  systemPrompt: "Base prompt.",
+};
+
+async function prompt(
+  skillsSource: unknown,
+  extra: Record<string, unknown> = {}
+): Promise<string> {
+  const result = await prepareChatV2({
+    ...base,
+    mcpClientManager: mockManager(),
+    skillsSource,
+    ...extra,
+  } as never);
+  return result.enhancedSystemPrompt;
+}
+
+describe("the origin matrix", () => {
+  it("desktop signed out: local only", async () => {
+    const text = await prompt({
+      kind: "resolved",
+      capabilities: capabilities({ localSkills: [LOCAL_SKILL] }),
+      composeLiveServerSkills: true,
+    });
+    expect(text).toContain("**local/code-review**");
+    expect(text).not.toContain("**code-review**:");
+  });
+
+  it("desktop signed in with a project: local AND project, both addressable", async () => {
+    // The case that was impossible before this convergence: authoring a
+    // project skill on desktop and using it in the very next desktop turn.
+    const text = await prompt({
+      kind: "resolved",
+      capabilities: capabilities({
+        localSkills: [LOCAL_SKILL],
+        standaloneSkills: [PROJECT_SKILL],
+      }),
+      composeLiveServerSkills: true,
+    });
+    expect(text).toContain("**local/code-review**");
+    expect(text).toContain("**code-review**");
+  });
+
+  it("hosted playground: project skills, never a local file", async () => {
+    // Hosted has no filesystem to read. The set simply carries no local family,
+    // so this is structural rather than a check the route has to remember.
+    const text = await prompt({
+      kind: "resolved",
+      capabilities: capabilities({ standaloneSkills: [PROJECT_SKILL] }),
+      composeLiveServerSkills: true,
+    });
+    expect(text).toContain("**code-review**");
+    expect(text).not.toContain("local/");
+  });
+
+  it("an eval run: pinned content only, and never under approval", async () => {
+    // Pinned is the ONLY kind that bypasses approval, because an eval run
+    // auto-denies and a paused approval would fail every iteration.
+    const result = await prepareChatV2({
+      ...base,
+      mcpClientManager: mockManager(),
+      requireToolApproval: true,
+      skillsSource: {
+        kind: "pinned",
+        skills: [
+          {
+            name: "frozen",
+            description: "Frozen for this run.",
+            content: "# Frozen",
+            contentHash: "h",
+          },
+        ],
+      },
+    } as never);
+    expect(result.enhancedSystemPrompt).toContain("frozen");
+    expect(
+      (result.allTools as Record<string, { needsApproval?: unknown }>).loadSkill
+        ?.needsApproval
+    ).not.toBe(true);
+  });
+
+  it("a harness turn: refuses an in-memory source outright", async () => {
+    // Skills reach a harness as SKILL.md on the box. Handing it in-memory tools
+    // too would deliver the same skill twice by two mechanisms — so the turn
+    // refuses to start rather than doing it quietly. Callers guard this
+    // themselves; a forgotten guard would otherwise be silent.
+    await expect(
+      prepareChatV2({
+        ...base,
+        mcpClientManager: mockManager(),
+        harness: "claude-code" as never,
+        skillsSource: {
+          kind: "resolved",
+          capabilities: capabilities({
+            localSkills: [LOCAL_SKILL],
+            standaloneSkills: [PROJECT_SKILL],
+          }),
+          composeLiveServerSkills: true,
+        },
+      } as never)
+    ).rejects.toThrow(/deliberately disjoint/);
+  });
+
+  it("a harness turn saying none: accepted, with no stanza", async () => {
+    const result = await prepareChatV2({
+      ...base,
+      mcpClientManager: mockManager(),
+      harness: "claude-code" as never,
+      skillsSource: { kind: "none" },
+    } as never);
+    expect(Object.keys(result.allTools)).not.toContain("loadSkill");
+    expect(result.enhancedSystemPrompt).toBe("Base prompt.");
+  });
+
+  it("a surface that says none: none, with no stanza to explain it", async () => {
+    const text = await prompt({ kind: "none" });
+    expect(text).toBe("Base prompt.");
+  });
+
+  it("refuses a bare name that two origins answer to", async () => {
+    // The merged catalog's defining behaviour. Both skills are real and both
+    // are reachable; the only wrong answer is silently picking one.
+    const result = await prepareChatV2({
+      ...base,
+      mcpClientManager: mockManager(),
+      skillsSource: {
+        kind: "resolved",
+        capabilities: capabilities({
+          localSkills: [LOCAL_SKILL],
+          standaloneSkills: [PROJECT_SKILL],
+        }),
+      },
+    } as never);
+    const loadSkill = (
+      result.allTools as Record<
+        string,
+        { execute: (input: unknown) => Promise<string> }
+      >
+    ).loadSkill;
+    await expect(loadSkill.execute({ name: "code-review" })).resolves.toContain(
+      "# Project"
+    );
+    await expect(
+      loadSkill.execute({ name: "local/code-review" })
+    ).resolves.toContain("# Local");
+  });
+});

--- a/mcpjam-inspector/server/utils/__tests__/skill-origin-policy.test.ts
+++ b/mcpjam-inspector/server/utils/__tests__/skill-origin-policy.test.ts
@@ -212,7 +212,7 @@ describe("the origin matrix", () => {
       },
     } as never);
     const loadSkill = (
-      result.allTools as Record<
+      result.allTools as unknown as Record<
         string,
         { execute: (input: unknown) => Promise<string> }
       >

--- a/mcpjam-inspector/server/utils/__tests__/skill-origin-policy.test.ts
+++ b/mcpjam-inspector/server/utils/__tests__/skill-origin-policy.test.ts
@@ -36,6 +36,21 @@ function mockManager(tools: Record<string, unknown> = {}) {
   } as never;
 }
 
+/** A manager whose one connection has the skills extension mutually active. */
+function liveSkillsManager() {
+  return {
+    getToolsForAiSdk: vi.fn(async () => ({})),
+    listTools: vi.fn(async () => ({ tools: [] })),
+    hasServer: vi.fn(() => true),
+    getSkillsSupport: vi.fn(() => ({
+      declared: true,
+      advertised: true,
+      directoryRead: false,
+      active: true,
+    })),
+  } as never;
+}
+
 function capabilities(
   overrides: Partial<EffectiveCapabilitySet> = {}
 ): EffectiveCapabilitySet {
@@ -131,6 +146,45 @@ describe("the origin matrix", () => {
     });
     expect(text).toContain("**code-review**");
     expect(text).not.toContain("local/");
+  });
+
+  it("an environment turn: its captured set, and NO live server composition", async () => {
+    // An environment is a DECISION about what runs. Its server skills were
+    // captured with the rest of the spec, so reaching back to the live
+    // connection for more would falsify the claim that the set describes the
+    // turn — the exact thing `composeLiveServerSkills` is opt-in to prevent.
+    // Asserted here because the flag's absence is invisible: a set that quietly
+    // gained live skills would still look like a working environment turn.
+    const result = await prepareChatV2({
+      ...base,
+      selectedServers: ["srv"],
+      mcpClientManager: liveSkillsManager(),
+      skillsSource: {
+        kind: "resolved",
+        capabilities: capabilities({ standaloneSkills: [PROJECT_SKILL] }),
+      },
+    } as never);
+
+    expect(result.enhancedSystemPrompt).toContain("**code-review**");
+    expect(Object.keys(result.allTools)).not.toContain("listSkills");
+  });
+
+  it("a live turn against the same server DOES compose it", async () => {
+    // The control for the case above: same manager, same selection, and the
+    // only difference is the flag. Without this pair, the assertion above
+    // would also pass if `withServerSkills` had simply stopped working.
+    const result = await prepareChatV2({
+      ...base,
+      selectedServers: ["srv"],
+      mcpClientManager: liveSkillsManager(),
+      skillsSource: {
+        kind: "resolved",
+        capabilities: capabilities({ standaloneSkills: [PROJECT_SKILL] }),
+        composeLiveServerSkills: true,
+      },
+    } as never);
+
+    expect(Object.keys(result.allTools)).toContain("listSkills");
   });
 
   it("an eval run: pinned content only, and never under approval", async () => {

--- a/mcpjam-inspector/server/utils/__tests__/skill-origin-policy.test.ts
+++ b/mcpjam-inspector/server/utils/__tests__/skill-origin-policy.test.ts
@@ -197,9 +197,15 @@ describe("the origin matrix", () => {
     expect(text).toBe("Base prompt.");
   });
 
-  it("refuses a bare name that two origins answer to", async () => {
+  it("keeps both origins of one name addressable, exact ref first", async () => {
     // The merged catalog's defining behaviour. Both skills are real and both
     // are reachable; the only wrong answer is silently picking one.
+    //
+    // The bare name is NOT ambiguous here: `code-review` is the project
+    // skill's own ref, so it is an exact hit. That ordering is deliberate —
+    // resolving names before refs would make a project skill unaddressable the
+    // moment a user happened to have a local file of the same name, which is
+    // the shadowing the namespacing exists to prevent.
     const result = await prepareChatV2({
       ...base,
       mcpClientManager: mockManager(),
@@ -220,6 +226,51 @@ describe("the origin matrix", () => {
     await expect(loadSkill.execute({ name: "code-review" })).resolves.toContain(
       "# Project"
     );
+    await expect(
+      loadSkill.execute({ name: "local/code-review" })
+    ).resolves.toContain("# Local");
+  });
+
+  it("refuses a bare name only when NOTHING answers to it exactly", async () => {
+    // Two namespaced origins, no project skill: now the bare name is a guess,
+    // and the tool names the alternatives instead of making it.
+    const result = await prepareChatV2({
+      ...base,
+      mcpClientManager: mockManager(),
+      skillsSource: {
+        kind: "resolved",
+        capabilities: capabilities({
+          localSkills: [LOCAL_SKILL],
+          pluginSkills: [
+            {
+              skillId: "sk_plugin",
+              ref: "docs-tools/code-review",
+              name: "code-review",
+              description: "Review code, the plugin's way.",
+              content: "# Plugin",
+              aggregateHash: "h3",
+              pluginName: "docs-tools",
+              channels: [] as never[],
+              files: [],
+            } as never,
+          ],
+        }),
+      },
+    } as never);
+    const loadSkill = (
+      result.allTools as unknown as Record<
+        string,
+        { execute: (input: unknown) => Promise<string> }
+      >
+    ).loadSkill;
+    const refusal = await loadSkill.execute({ name: "code-review" });
+    expect(refusal).toContain("ambiguous");
+    expect(refusal).toContain('"docs-tools/code-review"');
+    expect(refusal).toContain('"local/code-review"');
+    // And each is still reachable by its own ref.
+    await expect(
+      loadSkill.execute({ name: "docs-tools/code-review" })
+    ).resolves.toContain("# Plugin");
     await expect(
       loadSkill.execute({ name: "local/code-review" })
     ).resolves.toContain("# Local");

--- a/mcpjam-inspector/server/utils/chat-v2-orchestration.ts
+++ b/mcpjam-inspector/server/utils/chat-v2-orchestration.ts
@@ -37,10 +37,7 @@ import {
   scrubChatGPTAppsToolResultsForBackend,
   type CustomProviderConfig,
 } from "./chat-helpers.js";
-import {
-  getPinnedSkillToolsAndPrompt,
-  type SkillsFetchFailure,
-} from "./computers/cloud-skill-tools.js";
+import { getPinnedSkillToolsAndPrompt } from "./computers/cloud-skill-tools.js";
 import { getEffectiveSkillToolsAndPrompt } from "./computers/effective-skill-tools.js";
 import {
   SERVER_SKILLS_PROMPT_SECTION,
@@ -1126,12 +1123,6 @@ export interface PrepareChatV2Result {
    * not inherit MCPJam UI approval semantics from a discarded client entry.
    */
   effectiveUiTools: UiToolEntry[];
-  /**
-   * Set when the live-cloud catalog fetch threw or timed out. Distinguishes
-   * that skip from a genuine empty project (no marker). Session-sim can
-   * forward this as a `session_notice`.
-   */
-  skillsFetchFailed?: SkillsFetchFailure;
 }
 
 /**
@@ -1288,7 +1279,6 @@ export async function prepareChatV2(
   type SkillPrep = {
     tools: Record<string, unknown>;
     systemPromptSection: string;
-    skillsFetchFailed?: SkillsFetchFailure;
   };
   const skillPrep: SkillPrep = skillsSource
     ? skillsSource.kind === "pinned"
@@ -1312,11 +1302,8 @@ export async function prepareChatV2(
       // skill and a hosted one could never see a local file. A caller with no
       // skills says `{ kind: "none" }` and means it.
       { tools: {}, systemPromptSection: "" };
-  const {
-    tools: skillTools,
-    systemPromptSection: skillsPromptSection,
-    skillsFetchFailed,
-  } = skillPrep;
+  const { tools: skillTools, systemPromptSection: skillsPromptSection } =
+    skillPrep;
 
   // Pinned skill tools NEVER require approval (pure reads of frozen content; the
   // eval run is auto-deny). Otherwise the normal approval wrap applies.
@@ -1622,6 +1609,5 @@ export async function prepareChatV2(
     progressivePlan,
     discoveryState,
     effectiveUiTools,
-    ...(skillsFetchFailed ? { skillsFetchFailed } : {}),
   };
 }

--- a/mcpjam-inspector/server/utils/chat-v2-orchestration.ts
+++ b/mcpjam-inspector/server/utils/chat-v2-orchestration.ts
@@ -2,7 +2,7 @@
  * Shared chat-v2 tool preparation and message scrubbing.
  *
  * Encapsulates the identical prep logic used by both mcp/chat-v2 and web/chat-v2:
- *   1. getToolsForAiSdk + getSkillToolsAndPrompt + needsApproval merge
+ *   1. getToolsForAiSdk + the turn's skill source + needsApproval merge
  *   2. Anthropic tool name validation (throws on invalid names)
  *   3. System prompt + skills prompt concatenation
  *   4. Temperature resolution (GPT-5 check)
@@ -37,9 +37,7 @@ import {
   scrubChatGPTAppsToolResultsForBackend,
   type CustomProviderConfig,
 } from "./chat-helpers.js";
-import { getSkillToolsAndPrompt } from "./skill-tools.js";
 import {
-  getCloudSkillToolsAndPrompt,
   getPinnedSkillToolsAndPrompt,
   type SkillsFetchFailure,
 } from "./computers/cloud-skill-tools.js";
@@ -68,7 +66,6 @@ import {
   WEBMCP_TOOL_MAX_ENTRIES,
   WEBMCP_TOOL_NAME_MAX_CHARS,
 } from "@/shared/webmcp-inspector-protocol";
-import { HOSTED_MODE } from "../config.js";
 import {
   buildToolCatalog,
   createDiscoveryState,
@@ -748,9 +745,8 @@ export interface PrepareChatV2Options {
    * When set, skills are sourced from the caller's **Computer** (E2B sandbox)
    * instead of the local filesystem — the hosted/`/web` path. Only set by
    * callers whose host actually has a computer, so "advertise == enforce".
-   * Takes precedence over the local/HOSTED_MODE skill branches.
+   * The turn's only skill source.
    */
-  cloudSkills?: { authHeader: string; projectId: string };
   /**
    * Explicit skill source, ABOVE the cloud/HOSTED/local chain. Chat callers on
    * the legacy paths never set it → the existing precedence is byte-identical.
@@ -1161,7 +1157,6 @@ export async function prepareChatV2(
     uiTools,
     pageTools,
     builtInTools,
-    cloudSkills,
     skillsSource,
     harness,
     tasks,
@@ -1246,18 +1241,17 @@ export async function prepareChatV2(
       delete (mcpTools as Record<string, unknown>)[name];
     }
   }
-  // Skills source, in precedence order:
-  //   0. skillsSource set ⇒ in-memory tools (`pinned` for eval runs,
-  //      `resolved` for a Project-Environment turn) or none. Above everything;
-  //      legacy chat callers never set it, so the chain below is byte-identical
-  //      for them. Only PINNED tools bypass approval (decision 12) — `resolved`
-  //      is an interactive turn and keeps the host's approval rule. All three
-  //      static surfaces inline the catalog in the prompt (no `listSkills`).
-  //   1. cloudSkills set ⇒ Convex-backed project skills. Catalog is fetched
-  //      at prompt-build time (timeout + latency log); failure skips skills
-  //      for the turn and sets `skillsFetchFailed`.
-  //   2. HOSTED_MODE without a computer ⇒ no skills (local FS unavailable).
-  //   3. local ⇒ the inspector's own filesystem.
+  // ONE skill source per turn, stated by the caller. Where a skill comes FROM —
+  // the project, a plugin, a connected server, this machine's filesystem — is a
+  // property of the skill inside an `EffectiveCapabilitySet`, not a mode the
+  // orchestrator picks between:
+  //   - `pinned` / `pinned-effective` ⇒ frozen eval content; the ONLY kinds
+  //     that bypass approval (decision 12), because an eval run auto-denies.
+  //   - `resolved` ⇒ a live or environment-resolved set, keeping the host's
+  //     approval rule. `composeLiveServerSkills` says which of the two it is.
+  //   - `none` ⇒ no skills, said deliberately.
+  // Every surface inlines its catalog in the prompt; there is no `listSkills`
+  // discovery tool on any of them.
   const skillsArePinned =
     skillsSource?.kind === "pinned" ||
     skillsSource?.kind === "pinned-effective";
@@ -1304,17 +1298,13 @@ export async function prepareChatV2(
             ...modelContextTokens,
           })
         : { tools: {}, systemPromptSection: "" }
-    : cloudSkills
-      ? await getCloudSkillToolsAndPrompt(
-          {
-            authHeader: cloudSkills.authHeader,
-            projectId: cloudSkills.projectId,
-          },
-          modelContextTokens,
-        )
-      : HOSTED_MODE
-        ? { tools: {}, systemPromptSection: "" }
-        : await getSkillToolsAndPrompt();
+    : // Every caller states its source now, so there is no implicit arm left to
+      // fall through to. The old chain ended `cloudSkills ? … : HOSTED_MODE ? {}
+      // : localFS` — exclusive arms, chosen by DEPLOYMENT rather than by what
+      // the user had, which is why a desktop turn could never see a project
+      // skill and a hosted one could never see a local file. A caller with no
+      // skills says `{ kind: "none" }` and means it.
+      { tools: {}, systemPromptSection: "" };
   const {
     tools: skillTools,
     systemPromptSection: skillsPromptSection,

--- a/mcpjam-inspector/server/utils/chat-v2-orchestration.ts
+++ b/mcpjam-inspector/server/utils/chat-v2-orchestration.ts
@@ -802,6 +802,22 @@ export interface PrepareChatV2Options {
          * disconnected.
          */
         abortSignal?: AbortSignal;
+        /**
+         * Whether to ALSO compose live SEP-2640 skills from the connected
+         * servers (see the `withServerSkills` block below).
+         *
+         * Opt-in, and the distinction is the whole reason this flag exists.
+         * An ENVIRONMENT-resolved set is a snapshot: its server skills were
+         * captured, and fetching more from a live connection would falsify the
+         * claim that the set describes the turn. An INTERACTIVE surface — the
+         * desktop app, the hosted Playground's default target — resolves no
+         * environment; its set is just "what the user has right now", and its
+         * server skills are only available live. Without this flag those
+         * surfaces would lose server skills the moment they started passing a
+         * `skillsSource` at all, which is exactly how a convergence quietly
+         * drops a capability.
+         */
+        composeLiveServerSkills?: boolean;
       }
     | { kind: "none" };
 }
@@ -1333,30 +1349,40 @@ export async function prepareChatV2(
   // extension, which is what keeps every pre-existing turn byte-identical.
   // The wrapper applies its own always-on approval to server-origin loads —
   // see `server-skill-tools.ts` — regardless of `requireToolApproval`.
-  const finalSkillTools: Record<string, unknown> =
-    skillsSource !== undefined || harness
-      ? approvalWrappedSkillTools
-      : withServerSkills(approvalWrappedSkillTools, {
-          manager: mcpClientManager,
-          // The UNFILTERED selection, deliberately — not `knownSelectedServers`.
-          // Slug collision suffixes are assigned over whatever set they are
-          // given, and the playground picker mints its refs from the raw
-          // selection because it cannot see which ids the manager registered.
-          // Handing the filtered list here would shift every suffix behind a
-          // dropped id, so the picker's `acme-2/refunds` would address a
-          // different server than `loadSkill`'s. `withServerSkills` filters to
-          // extension-active servers itself, and an unregistered id is not
-          // active, so nothing unknown is contacted either way.
-          servers: (selectedServers ?? []).map((serverId) => ({
-            serverId,
-            // The user-assigned label from OUR registry, never
-            // `serverInfo.name` — a server must not be able to choose the
-            // namespace its skills are addressed under. Falls back to the
-            // server id, which is host-assigned too and therefore still safe;
-            // it just reads worse in a ref.
-            serverLabel: serverLabels?.[serverId] ?? serverId,
-          })),
-        });
+  // A LIVE turn composes server skills whether or not it also carries an
+  // explicit source; a captured or frozen one never does. `skillsSource ===
+  // undefined` is the legacy live shape (no caller passes it once every surface
+  // is explicit); `resolved` + the opt-in flag is how a live surface says so
+  // while still using the merged, ref-addressed catalog.
+  const composeLiveServerSkills =
+    !harness &&
+    (skillsSource === undefined ||
+      (skillsSource.kind === "resolved" &&
+        skillsSource.composeLiveServerSkills === true));
+
+  const finalSkillTools: Record<string, unknown> = !composeLiveServerSkills
+    ? approvalWrappedSkillTools
+    : withServerSkills(approvalWrappedSkillTools, {
+        manager: mcpClientManager,
+        // The UNFILTERED selection, deliberately — not `knownSelectedServers`.
+        // Slug collision suffixes are assigned over whatever set they are
+        // given, and the playground picker mints its refs from the raw
+        // selection because it cannot see which ids the manager registered.
+        // Handing the filtered list here would shift every suffix behind a
+        // dropped id, so the picker's `acme-2/refunds` would address a
+        // different server than `loadSkill`'s. `withServerSkills` filters to
+        // extension-active servers itself, and an unregistered id is not
+        // active, so nothing unknown is contacted either way.
+        servers: (selectedServers ?? []).map((serverId) => ({
+          serverId,
+          // The user-assigned label from OUR registry, never
+          // `serverInfo.name` — a server must not be able to choose the
+          // namespace its skills are addressed under. Falls back to the
+          // server id, which is host-assigned too and therefore still safe;
+          // it just reads worse in a ref.
+          serverLabel: serverLabels?.[serverId] ?? serverId,
+        })),
+      });
 
   // SEP-1865 App-Provided Tools (Host → App direction). Client supplies
   // the snapshot per chat POST; we register them as no-execute entries so

--- a/mcpjam-inspector/server/utils/chat-v2-orchestration.ts
+++ b/mcpjam-inspector/server/utils/chat-v2-orchestration.ts
@@ -1267,11 +1267,18 @@ export async function prepareChatV2(
   // live-fetch skills" — that stopped being true when on-box pinned delivery
   // landed, and the stale wording cost real debugging time. `run-harness-turn`
   // does not call `fetchRuntimeSkills` at all in pinned mode.)
-  if (harness && skillsArePinned) {
+  if (harness && skillsSource !== undefined && skillsSource.kind !== "none") {
+    // Generalized from "pinned" to ANY in-memory source. The rule was always
+    // about DOUBLE DELIVERY; `pinned` was merely the only shape a harness
+    // caller could reach when it was written. Once `resolved` became the shape
+    // every live surface passes, a harness turn carrying one would have been
+    // handed the same skill twice — as SKILL.md on the box AND as a `loadSkill`
+    // tool — with nothing to catch it, because callers guard this themselves
+    // and a forgotten guard is silent.
     throw new Error(
-      "Harness turns receive pinned skills on box via `pinnedHarnessSkills`, " +
-        "not via `skillsSource`. Pass `skillsSource: { kind: 'none' }` for a " +
-        "harness turn — the two delivery channels are deliberately disjoint.",
+      "Harness turns receive skills on box via `pinnedHarnessSkills`, not via " +
+        "`skillsSource`. Pass `skillsSource: { kind: 'none' }` for a harness " +
+        "turn — the two delivery channels are deliberately disjoint.",
     );
   }
   const modelContextTokens =

--- a/mcpjam-inspector/server/utils/chat-v2-orchestration.ts
+++ b/mcpjam-inspector/server/utils/chat-v2-orchestration.ts
@@ -1295,12 +1295,19 @@ export async function prepareChatV2(
             ...modelContextTokens,
           })
         : { tools: {}, systemPromptSection: "" }
-    : // Every caller states its source now, so there is no implicit arm left to
-      // fall through to. The old chain ended `cloudSkills ? … : HOSTED_MODE ? {}
-      // : localFS` — exclusive arms, chosen by DEPLOYMENT rather than by what
-      // the user had, which is why a desktop turn could never see a project
-      // skill and a hosted one could never see a local file. A caller with no
-      // skills says `{ kind: "none" }` and means it.
+    : // No source is no SKILLS OF ITS OWN — not a fallback. The old chain
+      // ended `cloudSkills ? … : HOSTED_MODE ? {} : localFS` — exclusive arms
+      // chosen by DEPLOYMENT rather than by what the user had, which is why a
+      // desktop turn could never see a project skill and a hosted one could
+      // never see a local file. That chain is gone; what remains here is the
+      // empty set.
+      //
+      // It is still meaningfully different from `{ kind: "none" }`, which is
+      // why both exist: `undefined` is the LIVE shape and still composes the
+      // connected servers' SEP-2640 skills (see `composeLiveServerSkills`
+      // below), while `none` means this turn gets no skills from anywhere. The
+      // hosted host/adhoc path lands here whenever its project catalog is
+      // gated off or fails, and its server skills must survive that.
       { tools: {}, systemPromptSection: "" };
   const { tools: skillTools, systemPromptSection: skillsPromptSection } =
     skillPrep;

--- a/mcpjam-inspector/server/utils/computers/__tests__/cloud-runtime-skills.test.ts
+++ b/mcpjam-inspector/server/utils/computers/__tests__/cloud-runtime-skills.test.ts
@@ -1,0 +1,132 @@
+/**
+ * The project pool as a live capability family.
+ *
+ * The catalog fetch and its failure modes used to sit inside `prepareChatV2`,
+ * which is why an orchestration test had to know about Convex timeouts. They
+ * live here now: a route asks for the family, and what it does with a failure
+ * (log it, proceed without skills, keep the turn) is the route's call.
+ *
+ * What this pins is that the family stays LAZY. A project with 200 skills must
+ * cost one catalog query to build a listing, not 200 body fetches for content
+ * the model will mostly never ask for.
+ */
+
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("../cloud-skills.js", () => ({
+  listCloudSkills: vi.fn(),
+  getCloudSkillByName: vi.fn(),
+  listCloudSkillFiles: vi.fn(),
+  readCloudSkillFile: vi.fn(),
+  CloudSkillsError: class CloudSkillsError extends Error {
+    status: number;
+    constructor(message: string, status = 500) {
+      super(message);
+      this.status = status;
+    }
+  },
+  MAX_SKILL_CONTENT_BYTES: 128 * 1024,
+}));
+
+import { listCloudRuntimeSkills } from "../cloud-skill-tools.js";
+import {
+  getCloudSkillByName,
+  listCloudSkillFiles,
+  listCloudSkills,
+  readCloudSkillFile,
+} from "../cloud-skills.js";
+
+const ctx = { authHeader: "Bearer t", projectId: "proj-1" };
+
+const CATALOG_ROW = {
+  skillId: "sk_1",
+  projectId: "proj-1",
+  name: "pdf-tools",
+  description: "Process PDFs",
+  sharing: "user" as const,
+  isOwner: true,
+  aggregateHash: "h",
+  createdAt: 1,
+  updatedAt: 1,
+};
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("listCloudRuntimeSkills", () => {
+  it("builds the family from the catalog alone, fetching no bodies", async () => {
+    vi.mocked(listCloudSkills).mockResolvedValue([CATALOG_ROW] as never);
+
+    const skills = await listCloudRuntimeSkills(ctx);
+
+    expect(skills).toHaveLength(1);
+    expect(skills[0]!.ref).toBe("pdf-tools");
+    expect(skills[0]!.description).toBe("Process PDFs");
+    expect(getCloudSkillByName).not.toHaveBeenCalled();
+    expect(listCloudSkillFiles).not.toHaveBeenCalled();
+  });
+
+  it("fetches one body, for the one skill asked for", async () => {
+    vi.mocked(listCloudSkills).mockResolvedValue([CATALOG_ROW] as never);
+    vi.mocked(getCloudSkillByName).mockResolvedValue({
+      ...CATALOG_ROW,
+      content: "# PDF tools",
+    } as never);
+
+    const skills = await listCloudRuntimeSkills(ctx);
+    const content = skills[0]!.content;
+    expect(typeof content).toBe("function");
+    await expect((content as () => Promise<string>)()).resolves.toContain(
+      "# PDF tools"
+    );
+    expect(getCloudSkillByName).toHaveBeenCalledTimes(1);
+  });
+
+  it("says so when a skill vanished between catalog and load", async () => {
+    vi.mocked(listCloudSkills).mockResolvedValue([CATALOG_ROW] as never);
+    vi.mocked(getCloudSkillByName).mockResolvedValue(null as never);
+
+    const skills = await listCloudRuntimeSkills(ctx);
+
+    await expect(
+      (skills[0]!.content as () => Promise<string>)()
+    ).rejects.toThrow(/no longer in this project/);
+  });
+
+  it("lists supporting files only when asked, and reads one at a time", async () => {
+    vi.mocked(listCloudSkills).mockResolvedValue([CATALOG_ROW] as never);
+    vi.mocked(listCloudSkillFiles).mockResolvedValue([
+      { path: "scripts/run.py", size: 12, contentHash: "c", updatedAt: 1 },
+    ] as never);
+    vi.mocked(readCloudSkillFile).mockResolvedValue({
+      path: "scripts/run.py",
+      name: "run.py",
+      content: "print('hi')",
+      mimeType: "text/x-python",
+      size: 12,
+      isText: true,
+    } as never);
+
+    const skills = await listCloudRuntimeSkills(ctx);
+    expect(listCloudSkillFiles).not.toHaveBeenCalled();
+
+    const files = await skills[0]!.listFiles!();
+    expect(files.map((file) => file.path)).toEqual(["scripts/run.py"]);
+    // No URL is minted up front: `readCloudSkillFile` resolves a fresh signed
+    // one at read time, so a file the model never opens costs nothing and a URL
+    // never outlives the read it was for.
+    expect(files[0]!.url).toBeNull();
+
+    const bytes = await files[0]!.read!();
+    expect(new TextDecoder().decode(bytes)).toContain("print('hi')");
+  });
+
+  it("throws on a catalog failure, so a caller can tell it from an empty project", async () => {
+    // The distinction the route needs: "this user has no skills" and "we lost
+    // this user's skills this turn" must not look identical.
+    vi.mocked(listCloudSkills).mockRejectedValue(new Error("CONVEX_URL unset"));
+
+    await expect(listCloudRuntimeSkills(ctx)).rejects.toThrow("CONVEX_URL unset");
+  });
+});

--- a/mcpjam-inspector/server/utils/computers/__tests__/cloud-runtime-skills.test.ts
+++ b/mcpjam-inspector/server/utils/computers/__tests__/cloud-runtime-skills.test.ts
@@ -122,6 +122,38 @@ describe("listCloudRuntimeSkills", () => {
     expect(new TextDecoder().decode(bytes)).toContain("print('hi')");
   });
 
+  it("returns an empty family for a project with no skills", async () => {
+    // The other half of the distinction below: an empty project is an answer,
+    // and it must reach the caller as one rather than as a failure.
+    vi.mocked(listCloudSkills).mockResolvedValue([] as never);
+
+    await expect(listCloudRuntimeSkills(ctx)).resolves.toEqual([]);
+  });
+
+  it("returns a binary file's exact bytes, not a text round-trip", async () => {
+    // Binary arrives base64 on a different field. Decoding it as text would
+    // corrupt every byte outside ASCII, silently — the file would read as a
+    // file, just not the one on the other end.
+    const bytes = new Uint8Array([0x89, 0x50, 0x4e, 0x47, 0x00, 0xff, 0xfe]);
+    vi.mocked(listCloudSkills).mockResolvedValue([CATALOG_ROW] as never);
+    vi.mocked(listCloudSkillFiles).mockResolvedValue([
+      { path: "assets/logo.png", size: 7, contentHash: "c", updatedAt: 1 },
+    ] as never);
+    vi.mocked(readCloudSkillFile).mockResolvedValue({
+      path: "assets/logo.png",
+      name: "logo.png",
+      base64: Buffer.from(bytes).toString("base64"),
+      mimeType: "image/png",
+      size: 7,
+      isText: false,
+    } as never);
+
+    const skills = await listCloudRuntimeSkills(ctx);
+    const files = await skills[0]!.listFiles!();
+
+    expect(await files[0]!.read!()).toEqual(bytes);
+  });
+
   it("throws on a catalog failure, so a caller can tell it from an empty project", async () => {
     // The distinction the route needs: "this user has no skills" and "we lost
     // this user's skills this turn" must not look identical.

--- a/mcpjam-inspector/server/utils/computers/__tests__/effective-skill-tools.lazy.test.ts
+++ b/mcpjam-inspector/server/utils/computers/__tests__/effective-skill-tools.lazy.test.ts
@@ -1,0 +1,202 @@
+/**
+ * The lazy and local arms of the effective skill surface.
+ *
+ * Both exist so ONE catalog can carry every origin. A captured environment set
+ * holds its bytes inline — that is what makes a snapshot a snapshot — while a
+ * live origin (the project's Convex skills, the local filesystem) must not pay
+ * for a body the model never asks for. These cases pin that a lazy origin is
+ * fetched exactly once, on demand, and that a local file is read from disk
+ * rather than through a URL it will never have.
+ */
+
+import { describe, expect, it, vi } from "vitest";
+import { getEffectiveSkillToolsAndPrompt } from "../effective-skill-tools.js";
+import {
+  buildLiveEffectiveCapabilities,
+  type EffectiveCapabilitySet,
+  type RuntimeLocalSkill,
+  type RuntimeStandaloneSkill,
+} from "../../../services/environments/effective-capabilities.js";
+
+async function run(tool: unknown, input: unknown): Promise<string> {
+  return (tool as { execute: (i: unknown) => Promise<string> }).execute(input);
+}
+
+function tools(set: EffectiveCapabilitySet) {
+  return getEffectiveSkillToolsAndPrompt(set).tools as Record<string, unknown>;
+}
+
+function cloudSkill(
+  overrides: Partial<RuntimeStandaloneSkill> = {}
+): RuntimeStandaloneSkill {
+  return {
+    skillId: "sk_1",
+    ref: "code-review",
+    name: "code-review",
+    description: "Review code.",
+    content: async () => "# Project code-review",
+    aggregateHash: "hash-cloud",
+    channels: [],
+    files: [],
+    ...overrides,
+  };
+}
+
+function localSkill(
+  overrides: Partial<RuntimeLocalSkill> = {}
+): RuntimeLocalSkill {
+  return {
+    skillId: "local:/home/u/.claude/skills/code-review",
+    ref: "local/code-review",
+    name: "code-review",
+    description: "Review code, locally.",
+    content: "# Local code-review",
+    aggregateHash: "hash-local",
+    directory: "~/.claude/skills/code-review",
+    files: [],
+    ...overrides,
+  };
+}
+
+describe("a lazy body is fetched only when loaded", () => {
+  it("builds the catalog without reading a single body", () => {
+    const content = vi.fn(async () => "# Project code-review");
+    const set = buildLiveEffectiveCapabilities({
+      standaloneSkills: [cloudSkill({ content })],
+    });
+
+    const { systemPromptSection } = getEffectiveSkillToolsAndPrompt(set);
+
+    // The listing needs a name and a description, both of which the catalog
+    // query already returned. Paying a fetch per skill to build it is the cost
+    // this shape exists to avoid.
+    expect(systemPromptSection).toContain("code-review");
+    expect(content).not.toHaveBeenCalled();
+  });
+
+  it("awaits the body for the skill actually asked for", async () => {
+    const content = vi.fn(async () => "# Project code-review");
+    const set = buildLiveEffectiveCapabilities({
+      standaloneSkills: [cloudSkill({ content })],
+    });
+
+    const loaded = await run(tools(set).loadSkill, { name: "code-review" });
+
+    expect(loaded).toContain("# Project code-review");
+    expect(content).toHaveBeenCalledTimes(1);
+  });
+
+  it("reports a failed fetch as an error the model can read, not a thrown turn", async () => {
+    const set = buildLiveEffectiveCapabilities({
+      standaloneSkills: [
+        cloudSkill({
+          content: async () => {
+            throw new Error("project skill was deleted");
+          },
+        }),
+      ],
+    });
+
+    const loaded = await run(tools(set).loadSkill, { name: "code-review" });
+
+    expect(loaded).toContain("Error loading");
+    expect(loaded).toContain("project skill was deleted");
+  });
+
+  it("lists supporting files through the lazy loader", async () => {
+    const listFiles = vi.fn(async () => [
+      { path: "scripts/run.py", size: 12, url: null },
+    ]);
+    const set = buildLiveEffectiveCapabilities({
+      standaloneSkills: [cloudSkill({ listFiles })],
+    });
+
+    const listed = await run(tools(set).listSkillFiles, {
+      name: "code-review",
+    });
+
+    expect(listed).toContain("scripts/run.py");
+    expect(listFiles).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe("a local skill is read from disk", () => {
+  it("reads a supporting file through its own reader, with no URL", async () => {
+    const set = buildLiveEffectiveCapabilities({
+      localSkills: [
+        localSkill({
+          listFiles: async () => [
+            {
+              path: "notes.md",
+              size: 6,
+              url: null,
+              read: async () => new TextEncoder().encode("hello\n"),
+            },
+          ],
+        }),
+      ],
+    });
+
+    const read = await run(tools(set).readSkillFile, {
+      name: "local/code-review",
+      path: "notes.md",
+    });
+
+    expect(read).toContain("hello");
+  });
+
+  it("still refuses a file with neither a reader nor a URL", async () => {
+    const set = buildLiveEffectiveCapabilities({
+      localSkills: [
+        localSkill({
+          files: [{ path: "notes.md", size: 6, url: null }],
+        }),
+      ],
+    });
+
+    const read = await run(tools(set).readSkillFile, {
+      name: "local/code-review",
+      path: "notes.md",
+    });
+
+    expect(read).toContain("no download URL");
+  });
+
+  it("names the directory it came from in the catalog", () => {
+    const set = buildLiveEffectiveCapabilities({
+      localSkills: [localSkill()],
+    });
+
+    const { systemPromptSection } = getEffectiveSkillToolsAndPrompt(set);
+
+    // "Which code-review is this?" is the question a merged catalog raises.
+    expect(systemPromptSection).toContain("~/.claude/skills/code-review");
+  });
+});
+
+describe("local and project skills of the same name", () => {
+  // The case that made a source TOGGLE feel necessary. It is an ambiguity, not
+  // a conflict: both are real, both are addressable, and the only wrong answer
+  // is silently picking one.
+  const set = buildLiveEffectiveCapabilities({
+    standaloneSkills: [cloudSkill()],
+    localSkills: [localSkill()],
+  });
+
+  it("keeps both, each addressable by its own ref", async () => {
+    expect(await run(tools(set).loadSkill, { name: "local/code-review" })).toContain(
+      "# Local code-review"
+    );
+    expect(await run(tools(set).loadSkill, { name: "code-review" })).toContain(
+      "# Project code-review"
+    );
+    expect(set.problems).toEqual([]);
+  });
+
+  it("lists both origins in one catalog", () => {
+    const { systemPromptSection } = getEffectiveSkillToolsAndPrompt(set);
+    expect(systemPromptSection).toContain("**code-review**");
+    expect(systemPromptSection).toContain("**local/code-review**");
+    expect(systemPromptSection).toContain("(project)");
+  });
+});

--- a/mcpjam-inspector/server/utils/computers/__tests__/effective-skill-tools.lazy.test.ts
+++ b/mcpjam-inspector/server/utils/computers/__tests__/effective-skill-tools.lazy.test.ts
@@ -118,6 +118,62 @@ describe("a lazy body is fetched only when loaded", () => {
     expect(listed).toContain("scripts/run.py");
     expect(listFiles).toHaveBeenCalledTimes(1);
   });
+
+  it("fetches the listing once across list-then-read, empty included", async () => {
+    // `listSkillFiles` then `readSkillFile` is the sequence the model actually
+    // performs, and the second call needs the same list to find the file in.
+    const listFiles = vi.fn(async () => [
+      { path: "scripts/run.py", size: 12, url: null, read: async () => new Uint8Array([104, 105]) },
+    ]);
+    const set = buildLiveEffectiveCapabilities({
+      standaloneSkills: [cloudSkill({ listFiles })],
+    });
+    const toolSet = tools(set);
+
+    await run(toolSet.listSkillFiles, { name: "code-review" });
+    const read = await run(toolSet.readSkillFile, {
+      name: "code-review",
+      path: "scripts/run.py",
+    });
+
+    expect(read).toContain("hi");
+    expect(listFiles).toHaveBeenCalledTimes(1);
+
+    // An empty listing is the case an "only cache non-empty" shortcut would
+    // miss, and it is the common one.
+    const emptyListFiles = vi.fn(async () => []);
+    const emptySet = buildLiveEffectiveCapabilities({
+      standaloneSkills: [cloudSkill({ listFiles: emptyListFiles })],
+    });
+    const emptyTools = tools(emptySet);
+    await run(emptyTools.listSkillFiles, { name: "code-review" });
+    await run(emptyTools.readSkillFile, {
+      name: "code-review",
+      path: "scripts/run.py",
+    });
+    expect(emptyListFiles).toHaveBeenCalledTimes(1);
+  });
+
+  it("retries a listing that failed, rather than caching the failure", async () => {
+    // Caching the rejected promise would pin the skill file-less for the whole
+    // turn on one transient error.
+    const listFiles = vi
+      .fn<() => Promise<Array<{ path: string; size: number; url: null }>>>()
+      .mockRejectedValueOnce(new Error("catalog offline"))
+      .mockResolvedValue([{ path: "scripts/run.py", size: 12, url: null }]);
+    const set = buildLiveEffectiveCapabilities({
+      standaloneSkills: [cloudSkill({ listFiles })],
+    });
+    const toolSet = tools(set);
+
+    expect(await run(toolSet.listSkillFiles, { name: "code-review" })).toContain(
+      "catalog offline"
+    );
+    expect(await run(toolSet.listSkillFiles, { name: "code-review" })).toContain(
+      "scripts/run.py"
+    );
+    expect(listFiles).toHaveBeenCalledTimes(2);
+  });
 });
 
 describe("a local skill is read from disk", () => {

--- a/mcpjam-inspector/server/utils/computers/__tests__/effective-skill-tools.test.ts
+++ b/mcpjam-inspector/server/utils/computers/__tests__/effective-skill-tools.test.ts
@@ -25,6 +25,7 @@ function set(overrides: Partial<EffectiveCapabilitySet> = {}) {
     pluginSkills: [],
     standaloneSkills: [],
     serverSkills: [],
+    localSkills: [],
     pluginVersions: [],
     problems: [],
     ...overrides,

--- a/mcpjam-inspector/server/utils/computers/cloud-skill-tools.ts
+++ b/mcpjam-inspector/server/utils/computers/cloud-skill-tools.ts
@@ -18,6 +18,7 @@ import { tool } from "ai";
 import { z } from "zod";
 import { isHostedCatalogModel } from "../../services/hosted-model-catalog.js";
 import type { PinnableSkill } from "../../../shared/skill-types.js";
+import type { RuntimeStandaloneSkill } from "../../services/environments/effective-capabilities.js";
 import { logger } from "../logger.js";
 import {
   CloudSkillsError,
@@ -258,6 +259,81 @@ export type CloudSkillToolsAndPrompt = {
   systemPromptSection: string;
   skillsFetchFailed?: SkillsFetchFailure;
 };
+
+/**
+ * The project's Convex skills as one origin of an `EffectiveCapabilitySet`.
+ *
+ * The counterpart to `listLocalRuntimeSkills`, and what lets the merged catalog
+ * carry project skills without the exclusive `cloudSkills` branch the chat
+ * orchestrator used to take.
+ *
+ * Everything here stays LAZY, exactly as `createCloudSkillTools` already
+ * behaves: the catalog costs one query, and a body or a file list is fetched
+ * only for the skill the model actually asks for. Eager-loading a 200-skill
+ * project on every turn to build a listing the model mostly ignores is the
+ * failure this shape avoids.
+ *
+ * Throws on catalog failure so the caller can distinguish it from a genuinely
+ * empty project — `getCloudSkillToolsAndPrompt` turns that into
+ * `skillsFetchFailed`, and callers of this function do the same.
+ */
+export async function listCloudRuntimeSkills(
+  ctx: CloudSkillsContext
+): Promise<RuntimeStandaloneSkill[]> {
+  const skills = await raceWithTimeout(
+    listCloudSkills(ctx),
+    CLOUD_SKILLS_FETCH_TIMEOUT_MS
+  );
+  return skills.map((skill) => ({
+    skillId: skill.skillId,
+    // A bare name, like any standalone project skill: this IS the project's
+    // standalone family, reached live instead of through a resolved
+    // environment. A local skill's `local/` prefix is what keeps the two
+    // separable when both are present.
+    ref: skill.name,
+    name: skill.name,
+    description: skill.description,
+    aggregateHash: skill.aggregateHash,
+    channels: [],
+    content: async () => {
+      const detail = await getCloudSkillByName(ctx, skill.name);
+      if (!detail) {
+        throw new Error(`Skill "${skill.name}" is no longer in this project.`);
+      }
+      return detail.content;
+    },
+    files: [],
+    listFiles: async () => {
+      const files = await listCloudSkillFiles(ctx, skill.skillId);
+      return files.map((file) => ({
+        path: file.path,
+        size: file.size,
+        // No URL is minted here: `readCloudSkillFile` resolves a fresh signed
+        // one at read time. Minting per file per turn would spend a query on
+        // every file the model never opens, and hand out URLs that outlive the
+        // read they were for.
+        url: null,
+        read: async () => {
+          const content = await readCloudSkillFile(
+            ctx,
+            skill.skillId,
+            file.path
+          );
+          // Text and binary arrive on different fields; the caller re-applies
+          // its own mime/size policy to whatever bytes come back, so both are
+          // decoded here rather than judged.
+          if (typeof content.content === "string") {
+            return new TextEncoder().encode(content.content);
+          }
+          if (typeof content.base64 === "string") {
+            return Uint8Array.from(Buffer.from(content.base64, "base64"));
+          }
+          return new Uint8Array(0);
+        },
+      }));
+    },
+  }));
+}
 
 /**
  * Cloud equivalent of `getSkillToolsAndPrompt`. Fetches the catalog at

--- a/mcpjam-inspector/server/utils/computers/cloud-skill-tools.ts
+++ b/mcpjam-inspector/server/utils/computers/cloud-skill-tools.ts
@@ -242,7 +242,10 @@ function raceWithTimeout<T>(promise: Promise<T>, ms: number): Promise<T> {
   });
 }
 
-function skillsFailureFrom(err: unknown, latencyMs: number): SkillsFetchFailure {
+export function skillsFailureFrom(
+  err: unknown,
+  latencyMs: number
+): SkillsFetchFailure {
   const errorClass =
     err instanceof Error ? err.constructor.name : typeof err;
   const status = err instanceof CloudSkillsError ? err.status : undefined;

--- a/mcpjam-inspector/server/utils/computers/effective-skill-tools.ts
+++ b/mcpjam-inspector/server/utils/computers/effective-skill-tools.ts
@@ -73,10 +73,33 @@ async function readContent(skill: EffectiveSkill): Promise<string> {
     : await skill.content();
 }
 
-/** The supporting-file list, fetching it once if the origin is lazy. */
-async function readFiles(skill: EffectiveSkill): Promise<RuntimeSkillFile[]> {
-  if (skill.files.length > 0 || !skill.listFiles) return skill.files;
-  return skill.listFiles();
+/**
+ * The supporting-file list, fetched at most ONCE per tool set if the origin is
+ * lazy.
+ *
+ * `listSkillFiles` then `readSkillFile` is the normal sequence, and an uncached
+ * loader fetches the same listing for both — including the empty case, where
+ * the second call buys nothing at all. The PROMISE is cached, not the result,
+ * so two concurrent calls share one fetch; a rejected one is evicted so a
+ * transient failure does not pin the skill file-less for the rest of the turn.
+ */
+function makeFileReader(): (
+  skill: EffectiveSkill
+) => Promise<RuntimeSkillFile[]> {
+  const listings = new Map<EffectiveSkill, Promise<RuntimeSkillFile[]>>();
+  return (skill) => {
+    if (skill.files.length > 0 || !skill.listFiles) {
+      return Promise.resolve(skill.files);
+    }
+    const cached = listings.get(skill);
+    if (cached) return cached;
+    const pending = skill.listFiles().catch((error: unknown) => {
+      listings.delete(skill);
+      throw error;
+    });
+    listings.set(skill, pending);
+    return pending;
+  };
 }
 
 /** Bare standalone name, or a `<plugin>/<skill>` namespaced plugin ref. */
@@ -218,6 +241,7 @@ export function createEffectiveSkillTools(args: {
   signal?: AbortSignal;
 }) {
   const lookup = buildLookup(args.skills);
+  const readFiles = makeFileReader();
 
   return {
     loadSkill: {

--- a/mcpjam-inspector/server/utils/computers/effective-skill-tools.ts
+++ b/mcpjam-inspector/server/utils/computers/effective-skill-tools.ts
@@ -42,8 +42,10 @@ import {
 import {
   allEffectiveSkills,
   type EffectiveCapabilitySet,
+  type RuntimeLocalSkill,
   type RuntimePluginSkill,
   type RuntimeServerSkill,
+  type RuntimeSkillFile,
   type RuntimeStandaloneSkill,
 } from "../../services/environments/effective-capabilities.js";
 import {
@@ -55,7 +57,27 @@ import {
 type EffectiveSkill =
   | RuntimePluginSkill
   | RuntimeStandaloneSkill
-  | RuntimeServerSkill;
+  | RuntimeServerSkill
+  | RuntimeLocalSkill;
+
+/**
+ * The body, whether it was carried inline or has to be fetched.
+ *
+ * A captured set holds the bytes; a live one holds a thunk, so a project with
+ * 200 skills costs one fetch for the skill the model actually loads rather than
+ * 200 for a catalog it mostly ignores.
+ */
+async function readContent(skill: EffectiveSkill): Promise<string> {
+  return typeof skill.content === "string"
+    ? skill.content
+    : await skill.content();
+}
+
+/** The supporting-file list, fetching it once if the origin is lazy. */
+async function readFiles(skill: EffectiveSkill): Promise<RuntimeSkillFile[]> {
+  if (skill.files.length > 0 || !skill.listFiles) return skill.files;
+  return skill.listFiles();
+}
 
 /** Bare standalone name, or a `<plugin>/<skill>` namespaced plugin ref. */
 const REF_RE = /^[a-z0-9-]+(?:\/[a-z0-9-]+(?:~[a-f0-9]{8,64})?)?$/;
@@ -66,6 +88,10 @@ function pluginOf(skill: EffectiveSkill): RuntimePluginSkill["plugin"] {
 
 function serverOf(skill: EffectiveSkill): RuntimeServerSkill | undefined {
   return "serverId" in skill ? skill : undefined;
+}
+
+function localOf(skill: EffectiveSkill): RuntimeLocalSkill | undefined {
+  return "directory" in skill ? (skill as RuntimeLocalSkill) : undefined;
 }
 
 /**
@@ -81,6 +107,10 @@ function originLabel(
   isPlugin: boolean,
   isServer: boolean
 ): string {
+  const local = localOf(skill);
+  // Named with its directory, because "which code-review is this?" is exactly
+  // the question a merged catalog raises and the answer is where it lives.
+  if (local) return `local ${local.directory}`;
   if (isServer) {
     const server = serverOf(skill)!;
     return `MCP server ${server.serverLabel}@v${server.versionNumber}`;
@@ -149,13 +179,6 @@ function resolveRef(lookup: SkillLookup, raw: string): Resolution {
   return { ok: false, error: `Error: Skill "${raw}" not found.` };
 }
 
-function findFile(
-  skill: EffectiveSkill,
-  path: string
-): { path: string; size: number; url: string | null } | undefined {
-  return skill.files.find((file) => file.path === path);
-}
-
 /**
  * Build the inlined discovery listing under the metadata budget, plus the
  * refs that had to be dropped. Computed ONCE at prompt-build time so the
@@ -212,7 +235,13 @@ export function createEffectiveSkillTools(args: {
           const resolved = resolveRef(lookup, name);
           if (!resolved.ok) return resolved.error;
           const { skill } = resolved;
-          return `# Skill: ${skill.ref}\n\n${skill.content}`;
+          try {
+            return `# Skill: ${skill.ref}\n\n${await readContent(skill)}`;
+          } catch (error) {
+            return `Error loading "${skill.ref}": ${
+              error instanceof Error ? error.message : "Unknown error"
+            }`;
+          }
         },
       }),
       needsApproval: ({ name }: { name: string }) => {
@@ -231,12 +260,20 @@ export function createEffectiveSkillTools(args: {
         const resolved = resolveRef(lookup, name);
         if (!resolved.ok) return resolved.error;
         const { skill } = resolved;
-        if (skill.files.length === 0) {
+        let files: RuntimeSkillFile[];
+        try {
+          files = await readFiles(skill);
+        } catch (error) {
+          return `Error listing files for "${skill.ref}": ${
+            error instanceof Error ? error.message : "Unknown error"
+          }`;
+        }
+        if (files.length === 0) {
           return `Skill "${skill.ref}" has no supporting files.`;
         }
         return (
           `Supporting files for "${skill.ref}":\n\n` +
-          skill.files.map((f) => `- ${f.path} (${f.size} bytes)`).join("\n") +
+          files.map((f) => `- ${f.path} (${f.size} bytes)`).join("\n") +
           `\n\nUse \`readSkillFile\` to read one.`
         );
       },
@@ -258,12 +295,17 @@ export function createEffectiveSkillTools(args: {
           const resolved = resolveRef(lookup, name);
           if (!resolved.ok) return resolved.error;
           const { skill } = resolved;
-          const file = findFile(skill, path);
+          let files: RuntimeSkillFile[];
+          try {
+            files = await readFiles(skill);
+          } catch (error) {
+            return `Error reading "${path}" from "${skill.ref}": ${
+              error instanceof Error ? error.message : "Unknown error"
+            }`;
+          }
+          const file = files.find((entry) => entry.path === path);
           if (!file) {
             return `Error: "${path}" is not a supporting file of "${skill.ref}".`;
-          }
-          if (!file.url) {
-            return `Error: "${path}" could not be read (no download URL was issued for it).`;
           }
           // Guard on the SERVER-verified size before fetching, mirroring
           // `readCloudSkillFile` — a large blob must not be buffered to discover
@@ -272,15 +314,23 @@ export function createEffectiveSkillTools(args: {
             return `Error: "${path}" is too large to read (${file.size} bytes).`;
           }
           try {
-            const timeout = AbortSignal.timeout(30_000);
-            const signal = args.signal
-              ? AbortSignal.any([args.signal, timeout])
-              : timeout;
-            const res = await fetch(file.url, { signal });
-            if (!res.ok) {
-              return `Error reading "${path}" from "${skill.ref}" (${res.status}).`;
+            let bytes: Uint8Array;
+            if (file.read) {
+              // A local file has no URL to sign — it is on this machine's disk.
+              bytes = await file.read();
+            } else if (file.url) {
+              const timeout = AbortSignal.timeout(30_000);
+              const signal = args.signal
+                ? AbortSignal.any([args.signal, timeout])
+                : timeout;
+              const res = await fetch(file.url, { signal });
+              if (!res.ok) {
+                return `Error reading "${path}" from "${skill.ref}" (${res.status}).`;
+              }
+              bytes = new Uint8Array(await res.arrayBuffer());
+            } else {
+              return `Error: "${path}" could not be read (no download URL was issued for it).`;
             }
-            const bytes = new Uint8Array(await res.arrayBuffer());
             const mimeType = getMimeType(path);
             if (
               !isTextMimeType(mimeType) ||
@@ -356,7 +406,13 @@ export function getEffectiveSkillToolsAndPrompt(
       }
     );
   }
-  const hasFiles = skills.some((skill) => skill.files.length > 0);
+  // A lazy origin has not listed its files yet, so `files.length` cannot
+  // answer this. Advertising on the possibility is the right way round:
+  // withholding the tools would hide files that do exist, while offering
+  // them for a skill with none costs one refusal the model can read.
+  const hasFiles = skills.some(
+    (skill) => skill.files.length > 0 || skill.listFiles !== undefined
+  );
   const parts = [
     "## Skills",
     "",

--- a/mcpjam-inspector/server/utils/harness/__tests__/plugin-delivery.test.ts
+++ b/mcpjam-inspector/server/utils/harness/__tests__/plugin-delivery.test.ts
@@ -36,6 +36,7 @@ function capabilities(
     pluginSkills: [],
     standaloneSkills: [],
     serverSkills: [],
+    localSkills: [],
     pluginVersions: [],
     problems: [],
     ...over,

--- a/mcpjam-inspector/server/utils/skill-tools.ts
+++ b/mcpjam-inspector/server/utils/skill-tools.ts
@@ -198,6 +198,48 @@ function flattenFiles(files: SkillFile[]): SkillFile[] {
 }
 
 /**
+ * Containment that survives a symlink.
+ *
+ * `isPathWithinDirectory` compares resolved STRINGS, so it stops `../` and
+ * nothing else. A skills directory is ordinary user-writable space that
+ * `npx skills` installs third-party packs into, and a symlinked `SKILL.md`
+ * pointing at `~/.ssh/id_rsa` reads as an ordinary skill: its body would go
+ * into the model's context with nothing in the file to notice. Instructions in
+ * a malicious pack are at least legible; a symlink is silent, which is the
+ * difference worth code.
+ *
+ * The BASE is resolved too, and that is load-bearing rather than tidy: a home
+ * or temp directory is often reached through a symlink itself, so comparing a
+ * resolved target against an unresolved base would refuse every read on those
+ * machines.
+ *
+ * This closes `SKILL.md`, which is the only symlink the surface ever follows:
+ * `readdir(withFileTypes)` reports a symlink as neither a file nor a
+ * directory, so a symlinked skill directory or supporting file is already
+ * skipped by the scan and the file lister. The check below stays on the file
+ * read anyway — the listing's rules are not the read's proof.
+ *
+ * Returns the real path to read, or `null` when it lands outside (or does not
+ * exist, which `realpath` reports the same way).
+ */
+async function realPathWithin(
+  baseDir: string,
+  target: string
+): Promise<string | null> {
+  try {
+    const [base, resolved] = await Promise.all([
+      fs.realpath(baseDir),
+      fs.realpath(target),
+    ]);
+    return resolved === base || resolved.startsWith(base + path.sep)
+      ? resolved
+      : null;
+  } catch {
+    return null;
+  }
+}
+
+/**
  * The local filesystem as one origin of an `EffectiveCapabilitySet`.
  *
  * This is what lets a desktop turn offer local files and project skills through
@@ -229,7 +271,12 @@ export async function listLocalRuntimeSkills(): Promise<RuntimeLocalSkill[]> {
       if (!entry.isDirectory()) continue;
       const skillDir = path.join(skillsDir, entry.name);
       try {
-        const raw = await fs.readFile(path.join(skillDir, "SKILL.md"), "utf-8");
+        const skillFile = await realPathWithin(
+          skillDir,
+          path.join(skillDir, "SKILL.md")
+        );
+        if (!skillFile) continue;
+        const raw = await fs.readFile(skillFile, "utf-8");
         const parsed = parseSkillFile(raw, formatDisplayPath(skillDir));
         // First-wins across the search path, matching `listSkillsMetadata` —
         // two directories offering the same name is a shadowing question the
@@ -280,12 +327,18 @@ async function listLocalRuntimeSkillFiles(
       size: file.size ?? 0,
       url: null,
       read: async () => {
-        const absolute = path.join(skillDir, file.path);
-        // The same containment check the bare local surface applies. A skill
-        // directory can contain a symlink, and "it came from our own listing"
-        // is not a containment proof.
-        if (!isPathWithinDirectory(skillDir, absolute)) {
-          throw new Error(`"${file.path}" resolves outside the skill directory.`);
+        // Belt and braces: the lister already drops symlinks, and the paths
+        // come from that lister rather than from the model. Checked anyway,
+        // because "the listing would never produce that" is an argument about
+        // the caller, and this is the function that touches the disk.
+        const absolute = await realPathWithin(
+          skillDir,
+          path.join(skillDir, file.path)
+        );
+        if (!absolute) {
+          throw new Error(
+            `"${file.path}" is not readable within the skill directory.`
+          );
         }
         return new Uint8Array(await fs.readFile(absolute));
       },

--- a/mcpjam-inspector/server/utils/skill-tools.ts
+++ b/mcpjam-inspector/server/utils/skill-tools.ts
@@ -18,6 +18,10 @@ import {
   isPathWithinDirectory,
 } from "./skill-parser";
 import type { Skill, SkillListItem, SkillFile } from "../../shared/skill-types";
+import type {
+  RuntimeLocalSkill,
+  RuntimeSkillFile,
+} from "../services/environments/effective-capabilities.js";
 
 /**
  * Get all skills directories
@@ -190,6 +194,133 @@ function flattenFiles(files: SkillFile[]): SkillFile[] {
     }
   }
   return result;
+}
+
+/**
+ * The local filesystem as one origin of an `EffectiveCapabilitySet`.
+ *
+ * This is what lets a desktop turn offer local files and project skills through
+ * ONE ref-addressed catalog, instead of the exclusive either/or the chat
+ * orchestrator used to pick between.
+ *
+ * Bodies are read eagerly — local disk is cheap and a skill without its body is
+ * not a skill — but supporting FILES stay lazy: enumerating every skill's tree
+ * on every turn would walk directories the model never asks about. The `read`
+ * thunk keeps the traversal guard and the text/size caps that
+ * `createSkillTools` already applies, so a local read through the effective
+ * surface is bounded exactly like a local read through the bare one.
+ */
+export async function listLocalRuntimeSkills(): Promise<RuntimeLocalSkill[]> {
+  const skills: RuntimeLocalSkill[] = [];
+  const seenNames = new Set<string>();
+
+  for (const skillsDir of getSkillsDirs()) {
+    if (!(await directoryExists(skillsDir))) continue;
+
+    let entries;
+    try {
+      entries = await fs.readdir(skillsDir, { withFileTypes: true });
+    } catch {
+      continue;
+    }
+
+    for (const entry of entries) {
+      if (!entry.isDirectory()) continue;
+      const skillDir = path.join(skillsDir, entry.name);
+      try {
+        const raw = await fs.readFile(path.join(skillDir, "SKILL.md"), "utf-8");
+        const parsed = parseSkillFile(raw, formatDisplayPath(skillDir));
+        // First-wins across the search path, matching `listSkillsMetadata` —
+        // two directories offering the same name is a shadowing question the
+        // search order already answers, not a ref collision.
+        if (!parsed || seenNames.has(parsed.name)) continue;
+        seenNames.add(parsed.name);
+
+        skills.push({
+          skillId: `local:${skillDir}`,
+          // Namespaced, so a local `code-review` and a project `code-review`
+          // are separately addressable and a bare `code-review` is refused as
+          // ambiguous rather than silently resolved to one of them.
+          ref: `local/${parsed.name}`,
+          name: parsed.name,
+          description: parsed.description,
+          content: parsed.content,
+          aggregateHash: await localSkillAggregateHash(skillDir, parsed.content),
+          directory: formatDisplayPath(skillDir),
+          files: [],
+          listFiles: () => listLocalRuntimeSkillFiles(skillDir),
+        });
+      } catch {
+        // Not a readable skill directory; the bare surface skips these too.
+      }
+    }
+  }
+
+  return skills;
+}
+
+/**
+ * Supporting files of one local skill, flattened to skill-relative paths.
+ *
+ * `SKILL.md` is excluded: it is the body, already delivered by `loadSkill`, and
+ * listing it invites the model to spend a second read on what it just read.
+ */
+async function listLocalRuntimeSkillFiles(
+  skillDir: string
+): Promise<RuntimeSkillFile[]> {
+  const tree = await listFilesRecursive(skillDir);
+  return flattenFiles(tree)
+    .filter((file) => file.type === "file" && file.path !== "SKILL.md")
+    .map((file) => ({
+      path: file.path,
+      size: file.size ?? 0,
+      url: null,
+      read: async () => {
+        const absolute = path.join(skillDir, file.path);
+        // The same containment check the bare local surface applies. A skill
+        // directory can contain a symlink, and "it came from our own listing"
+        // is not a containment proof.
+        if (!isPathWithinDirectory(skillDir, absolute)) {
+          throw new Error(`"${file.path}" resolves outside the skill directory.`);
+        }
+        return new Uint8Array(await fs.readFile(absolute));
+      },
+    }));
+}
+
+/**
+ * A content-plus-files hash, so the field means the same thing here as it does
+ * for a cloud skill.
+ *
+ * Cloud skills fold their supporting files into `aggregateHash`; hashing only
+ * the body under the same field name would make two origins disagree about what
+ * the value covers, and any cross-origin comparison silently wrong. File
+ * CONTENTS are deliberately not read — path and size are enough to notice a
+ * file appearing, vanishing, or changing length, without a full directory read
+ * per turn.
+ */
+async function localSkillAggregateHash(
+  skillDir: string,
+  content: string
+): Promise<string> {
+  let manifest = "";
+  try {
+    const tree = await listFilesRecursive(skillDir);
+    manifest = flattenFiles(tree)
+      .filter((file) => file.type === "file" && file.path !== "SKILL.md")
+      .map((file) => `${file.path}:${file.size ?? 0}`)
+      .sort()
+      .join("\n");
+  } catch {
+    // An unreadable tree hashes as "no files" rather than failing the skill.
+  }
+  const digest = await crypto.subtle.digest(
+    "SHA-256",
+    new TextEncoder().encode(`${content}\n--\n${manifest}`)
+  );
+  return [...new Uint8Array(digest)]
+    .map((byte) => byte.toString(16).padStart(2, "0"))
+    .join("");
 }
 
 /**

--- a/mcpjam-inspector/server/utils/skill-tools.ts
+++ b/mcpjam-inspector/server/utils/skill-tools.ts
@@ -22,6 +22,7 @@ import type {
   RuntimeLocalSkill,
   RuntimeSkillFile,
 } from "../services/environments/effective-capabilities.js";
+import { LOCAL_SKILL_REF_NAMESPACE } from "../../shared/server-skill-refs";
 
 /**
  * Get all skills directories
@@ -239,9 +240,12 @@ export async function listLocalRuntimeSkills(): Promise<RuntimeLocalSkill[]> {
         skills.push({
           skillId: `local:${skillDir}`,
           // Namespaced, so a local `code-review` and a project `code-review`
-          // are separately addressable and a bare `code-review` is refused as
-          // ambiguous rather than silently resolved to one of them.
-          ref: `local/${parsed.name}`,
+          // are separately addressable rather than one shadowing the other.
+          // The bare name still resolves to the project skill — that IS its
+          // ref, and `loadSkill` matches an exact ref before it considers
+          // names — so namespacing costs the project skill nothing and buys
+          // the local one an address it did not have.
+          ref: `${LOCAL_SKILL_REF_NAMESPACE}/${parsed.name}`,
           name: parsed.name,
           description: parsed.description,
           content: parsed.content,

--- a/mcpjam-inspector/server/utils/skill-tools.ts
+++ b/mcpjam-inspector/server/utils/skill-tools.ts
@@ -23,6 +23,7 @@ import type {
   RuntimeSkillFile,
 } from "../services/environments/effective-capabilities.js";
 import { LOCAL_SKILL_REF_NAMESPACE } from "../../shared/server-skill-refs";
+import { SKILL_FILE_MAX_READ_BYTES } from "./computers/cloud-skills.js";
 
 /**
  * Get all skills directories
@@ -338,6 +339,17 @@ async function listLocalRuntimeSkillFiles(
         if (!absolute) {
           throw new Error(
             `"${file.path}" is not readable within the skill directory.`
+          );
+        }
+        // The size the CALLER checked came from the listing, which is taken
+        // once per turn and then reused — so a file that grows between the
+        // listing and the read would be buffered whole under a cap it no
+        // longer satisfies. On disk the current size is one `stat` away, and
+        // the only size that bounds this read is the one it has right now.
+        const stat = await fs.stat(absolute);
+        if (stat.size > SKILL_FILE_MAX_READ_BYTES) {
+          throw new Error(
+            `"${file.path}" is too large to read (${stat.size} bytes).`
           );
         }
         return new Uint8Array(await fs.readFile(absolute));

--- a/mcpjam-inspector/server/utils/web-chat-turn.ts
+++ b/mcpjam-inspector/server/utils/web-chat-turn.ts
@@ -142,7 +142,7 @@ export function resumableServers(persist: {
   if (!excluded || excluded.length === 0) return aligned;
   const nonResumable = new Set(excluded);
   return aligned.filter(
-    (_, index) => !nonResumable.has(persist.selectedServerIds[index]!)
+    (_, index) => !nonResumable.has(persist.selectedServerIds[index]!),
   );
 }
 
@@ -296,18 +296,20 @@ export interface WebChatTurnPrepareInputs {
   computerWorkdir?: string;
   widgetModelContext?: WidgetModelContextEntry[];
   /**
-   * When set, skills are sourced from the caller's Computer (E2B sandbox)
-   * rather than the local FS. Set by the hosted chat route only when the host
-   * actually has a computer. See `chat-v2-orchestration.ts`.
+   * Whether this turn's `effectiveCapabilities` describe a LIVE surface rather
+   * than a captured environment.
+   *
+   * A live turn also composes SEP-2640 skills from its connected servers; an
+   * environment turn does not, because its server skills were captured and
+   * fetching more would falsify the snapshot. Set by the hosted chat route for
+   * its host/adhoc targets, which resolve no environment at all.
    */
-  cloudSkills?: { authHeader: string; projectId: string };
+  liveSkillSurface?: boolean;
   /**
    * Resolved Project-Environment skills for this turn (Phase 1.4), EMULATED
    * side. When set (even empty) they are the only skills the emulated engine
    * advertises: `prepareChatV2` receives them as `skillsSource: "resolved"`,
-   * which sits above the cloud/HOSTED/local chain. Callers must NOT also set
-   * `cloudSkills` — that would double-deliver (an environment-scoped
-   * `loadSkill` plus a project-wide one).
+   * which is now the ONLY skill source `prepareChatV2` accepts.
    *
    * Ignored when `harness` is set: a harness turn delivers skills natively
    * through the adapter (see `WebChatTurnPersistContext.runtimeSkillsOverride`),
@@ -438,7 +440,7 @@ function emitSandboxNotices(
   writer: SandboxNoticeWriter | null | undefined,
   notices: SandboxNoticeReason[] | undefined,
   ack?: (delivered: SandboxNoticeReason[]) => void,
-  abortSignal?: AbortSignal
+  abortSignal?: AbortSignal,
 ): void {
   if (!writer || !notices?.length) return;
   const closed = () => writer.isClosed?.() === true || abortSignal?.aborted;
@@ -485,7 +487,7 @@ export interface StreamWebChatTurnArgs {
  * types the marker into chat keeps their message intact.
  */
 export function stripUiContextModelParts(
-  messages: ModelMessage[]
+  messages: ModelMessage[],
 ): ModelMessage[] {
   let changed = false;
   const out = messages.map((message) => {
@@ -499,7 +501,7 @@ export function stripUiContextModelParts(
           typeof part === "object" &&
           (part as { type?: unknown }).type === "text" &&
           isRenderedUiContextText((part as { text?: unknown }).text)
-        )
+        ),
     );
     if (content.length === message.content.length) return message;
     changed = true;
@@ -520,7 +522,7 @@ export function stripUiContextModelParts(
  */
 function uiToolApprovalsFrom(
   uiTools: UiToolEntry[] | undefined,
-  requireToolApproval: boolean | undefined
+  requireToolApproval: boolean | undefined,
 ): UiToolApprovalClassification {
   return classifyUiToolApprovals(uiTools, requireToolApproval === true);
 }
@@ -533,7 +535,7 @@ function uiToolApprovalsFrom(
  * path and mapping the error to a `webError(...)` response.
  */
 export async function streamWebChatTurn(
-  args: StreamWebChatTurnArgs
+  args: StreamWebChatTurnArgs,
 ): Promise<Response> {
   const { manager, prepare, persist, runtime } = args;
   const { c } = runtime;
@@ -548,7 +550,7 @@ export async function streamWebChatTurn(
     throw new WebRouteError(
       500,
       ErrorCode.INTERNAL_ERROR,
-      "Server missing CONVEX_HTTP_URL configuration"
+      "Server missing CONVEX_HTTP_URL configuration",
     );
   }
 
@@ -563,7 +565,7 @@ export async function streamWebChatTurn(
       // trigger new linked resource reads. Fresh server-side tool execution
       // resolves resource_link results through trusted tool-origin metadata.
       abortSignal: c.req.raw.signal as AbortSignal | undefined,
-    }
+    },
   );
 
   let prepared;
@@ -590,7 +592,7 @@ export async function streamWebChatTurn(
       appTools: prepare.appTools,
       uiTools: prepare.uiTools,
       builtInTools: prepare.builtInTools,
-      ...(prepare.cloudSkills ? { cloudSkills: prepare.cloudSkills } : {}),
+
       // Environment-resolved skills outrank the cloud/HOSTED/local chain for the
       // EMULATED engine only. On a harness turn the adapter delivers them
       // natively, so advertising emulated `loadSkill` (+ file tools) on top would describe
@@ -600,6 +602,9 @@ export async function streamWebChatTurn(
             skillsSource: {
               kind: "resolved" as const,
               capabilities: prepare.effectiveCapabilities,
+              ...(prepare.liveSkillSurface
+                ? { composeLiveServerSkills: true as const }
+                : {}),
               // So a supporting-file read stops when the client disconnects
               // instead of holding a worker for its full fetch timeout.
               ...(runtime.abortSignal
@@ -643,7 +648,7 @@ export async function streamWebChatTurn(
   const scopeStepUpServerNamesById =
     buildServerNamesById(
       persist.selectedServerIds,
-      persist.selectedServerNames
+      persist.selectedServerNames,
     ) ?? {};
   let suspendedScopeStepUpToolCallId: string | undefined;
   const scopeStepUpResume =
@@ -661,13 +666,13 @@ export async function streamWebChatTurn(
           abortSignal: runtime.abortSignal,
         })
       : runtime.scopeStepUp?.cancelRequest
-      ? buildHostedScopeStepUpCancellation({
-          request: runtime.scopeStepUp.cancelRequest,
-          bearer: runtime.scopeStepUp.bearer,
-          messages: modelMessages,
-          tools: preparedTools,
-        })
-      : undefined;
+        ? buildHostedScopeStepUpCancellation({
+            request: runtime.scopeStepUp.cancelRequest,
+            bearer: runtime.scopeStepUp.bearer,
+            messages: modelMessages,
+            tools: preparedTools,
+          })
+        : undefined;
   const createScopeStepUpContinuation =
     runtime.scopeStepUp && persist.chatSessionId
       ? async ({
@@ -750,7 +755,7 @@ export async function streamWebChatTurn(
           emitInsufficientScopeChunk(
             scopeChallengeWriter,
             scopeStepUpServerNamesById[challenge.serverId],
-            challenge
+            challenge,
           );
         }
       },
@@ -764,11 +769,11 @@ export async function streamWebChatTurn(
               }),
           }
         : {}),
-    }
+    },
   );
 
   const widgetModelContextSystemPrompt = buildWidgetModelContextSystemPrompt(
-    prepare.widgetModelContext ?? []
+    prepare.widgetModelContext ?? [],
   );
   const effectiveEnhancedSystemPrompt = [
     enhancedSystemPrompt,
@@ -797,7 +802,7 @@ export async function streamWebChatTurn(
     Boolean(prepare.modelDefinition.id) &&
     isHostedCatalogModel(
       String(prepare.modelDefinition.id),
-      prepare.modelDefinition.provider
+      prepare.modelDefinition.provider,
     );
 
   // Resolve the host config now that `resolvedTemperature` is known.
@@ -805,21 +810,21 @@ export async function streamWebChatTurn(
   // callers preserve that by passing a closure here.
   const resolvedHostConfig: DirectHostConfig | null =
     typeof persist.hostConfig === "function"
-      ? persist.hostConfig({ resolvedTemperature }) ?? null
-      : persist.hostConfig ?? null;
+      ? (persist.hostConfig({ resolvedTemperature }) ?? null)
+      : (persist.hostConfig ?? null);
 
   // Build the persist callback once — it's a closure over a lot of context
   // and is identical between MCPJam-free and org-BYOK other than the modelId
   // + modelSource.
   const buildOnConversationComplete = (
     modelId: string,
-    modelSource: "mcpjam" | "byok" | "local_byok"
+    modelSource: "mcpjam" | "byok" | "local_byok",
   ) => {
     if (!hostedChatSessionId) return undefined;
     return async (
       fullHistory: ModelMessage[],
       turnTrace: PersistedTurnTrace,
-      harnessSessionCommit?: HarnessSessionCommitPayload
+      harnessSessionCommit?: HarnessSessionCommitPayload,
     ) => {
       const isDirectChat = !isScenarioSession;
       // Capture the live tool catalog. Failures must never block the persist.
@@ -837,7 +842,7 @@ export async function streamWebChatTurn(
               await exportConnectedServerToolSnapshotForEvalAuthoring(
                 manager,
                 knownIds,
-                { logPrefix: "chat-v2.persist" }
+                { logPrefix: "chat-v2.persist" },
               );
           }
         } catch {
@@ -863,7 +868,7 @@ export async function streamWebChatTurn(
         sessionMessages: stampSenderUserIdsOnSessionMessages(
           stripUiContextModelParts(fullHistory),
           persist.originalMessages as unknown[],
-          { authenticatedUserId: persist.authenticatedUserId }
+          { authenticatedUserId: persist.authenticatedUserId },
         ),
         startedAt: sessionStartedAt,
         lastActivityAt: Date.now(),
@@ -899,13 +904,13 @@ export async function streamWebChatTurn(
 
   if (!isMCPJam) {
     const providerKeyResult = deriveOrgProviderKeyResult(
-      prepare.modelDefinition
+      prepare.modelDefinition,
     );
     if (!providerKeyResult.ok) {
       throw new WebRouteError(
         400,
         ErrorCode.VALIDATION_ERROR,
-        providerKeyResult.error
+        providerKeyResult.error,
       );
     }
     const providerKey = providerKeyResult.key;
@@ -925,13 +930,13 @@ export async function streamWebChatTurn(
             scenarioId: persist.scenarioId,
             accessVersion: persist.accessVersion,
             serverIds: persist.selectedServerIds,
-          }
+          },
         )
       : { runtimeLocation: "cloud", providerKey };
 
     const onConversationComplete = buildOnConversationComplete(
       modelId,
-      orgRuntime.runtimeLocation === "local" ? "local_byok" : "byok"
+      orgRuntime.runtimeLocation === "local" ? "local_byok" : "byok",
     );
 
     warnIfChatAbortSignalMissing(runtime.abortSignal, "web/chat-v2");
@@ -964,7 +969,7 @@ export async function streamWebChatTurn(
             writer,
             runtime.sandboxNotices,
             runtime.ackSandboxNotices,
-            runtime.abortSignal
+            runtime.abortSignal,
           );
           runtime.rpcCollector?.attachStreamWriter(writer);
           runtime.elicitationBridge?.attachStreamWriter(writer);
@@ -1001,7 +1006,7 @@ export async function streamWebChatTurn(
       requireToolApproval: persist.requireToolApproval,
       uiToolApprovals: uiToolApprovalsFrom(
         effectiveUiTools,
-        persist.requireToolApproval
+        persist.requireToolApproval,
       ),
       modelVisibleMcpToolResults: prepare.modelVisibleMcpToolResults,
       onConversationComplete,
@@ -1012,7 +1017,7 @@ export async function streamWebChatTurn(
           writer,
           runtime.sandboxNotices,
           runtime.ackSandboxNotices,
-          runtime.abortSignal
+          runtime.abortSignal,
         );
         runtime.rpcCollector?.attachStreamWriter(writer);
         runtime.elicitationBridge?.attachStreamWriter(writer);
@@ -1027,7 +1032,7 @@ export async function streamWebChatTurn(
   const mcpjamModelId = String(prepare.modelDefinition.id);
   const onConversationComplete = buildOnConversationComplete(
     mcpjamModelId,
-    "mcpjam"
+    "mcpjam",
   );
   warnIfChatAbortSignalMissing(runtime.abortSignal, "web/chat-v2");
 
@@ -1079,7 +1084,7 @@ export async function streamWebChatTurn(
     requireToolApproval: persist.requireToolApproval,
     uiToolApprovals: uiToolApprovalsFrom(
       effectiveUiTools,
-      persist.requireToolApproval
+      persist.requireToolApproval,
     ),
     modelVisibleMcpToolResults: prepare.modelVisibleMcpToolResults,
     // Harness engine only: it builds its own MCP tool set (host-executed
@@ -1136,7 +1141,7 @@ export async function streamWebChatTurn(
         writer,
         runtime.sandboxNotices,
         runtime.ackSandboxNotices,
-        runtime.abortSignal
+        runtime.abortSignal,
       );
       runtime.rpcCollector?.attachStreamWriter(writer);
       // NOTE: for HARNESS hosts this writer exists but elicitation still won't
@@ -1152,13 +1157,13 @@ export async function streamWebChatTurn(
       if (persist.harness && runtime.rpcCollector && !stopHarnessRpcLogBridge) {
         stopHarnessRpcLogBridge = bridgeHarnessRpcLogsToCollector(
           persist.selectedServerIds,
-          runtime.rpcCollector
+          runtime.rpcCollector,
         );
         // COMP-21: cross-instance frames (harness-mcp landed on another
         // instance) arrive via the shared Convex sink. No-op single-instance.
         stopCrossInstanceRpcLogPoll = startCrossInstanceRpcLogPoll(
           persist.selectedServerIds,
-          runtime.rpcCollector
+          runtime.rpcCollector,
         );
       }
     },

--- a/mcpjam-inspector/shared/__tests__/server-skill-banner.test.ts
+++ b/mcpjam-inspector/shared/__tests__/server-skill-banner.test.ts
@@ -113,6 +113,25 @@ describe("server skill refs", () => {
     expect(slugOf([...servers].reverse())).toEqual(slugOf(servers));
   });
 
+  it("never hands a server the `local` namespace", () => {
+    // A merged catalog classifies a ref by its first segment, so a server
+    // labelled "Local" taking `local` would make every `local/<name>` ref
+    // resolve to that server — the user's own files unreachable, and the
+    // server answering to a namespace that is not its own.
+    expect(
+      assignServerSlugs([
+        { serverId: "s-a", serverLabel: "Local" },
+        { serverId: "s-b", serverLabel: "local!" },
+      ]).map((entry) => entry.serverSlug)
+    ).toEqual(["local-2", "local-3"]);
+    // Reserving it costs nothing a real label needed: everything else is
+    // untouched.
+    expect(
+      assignServerSlugs([{ serverId: "s-a", serverLabel: "Locale" }])[0]!
+        .serverSlug
+    ).toBe("locale");
+  });
+
   it("returns assignments in the caller's order", () => {
     expect(
       assignServerSlugs([

--- a/mcpjam-inspector/shared/server-skill-refs.ts
+++ b/mcpjam-inspector/shared/server-skill-refs.ts
@@ -36,6 +36,31 @@ export function slugifyServerLabel(label: string): string {
   return slug.length > 0 ? slug : "server";
 }
 
+/**
+ * The namespace the desktop filesystem family addresses its skills under.
+ *
+ * Lives here, beside the server slugs, because it is the one prefix those
+ * slugs must never take — see {@link RESERVED_SERVER_SLUGS}.
+ */
+export const LOCAL_SKILL_REF_NAMESPACE = "local";
+
+/**
+ * Namespaces a server slug may not occupy.
+ *
+ * A merged catalog classifies a ref by its first segment, so a server the user
+ * labelled "Local" would slugify straight onto `local/` and every ref of the
+ * form `local/<name>` would resolve to that server. The local skills are then
+ * unreachable and the server's skills answer to a name that is not theirs —
+ * the same squatting that per-origin namespacing exists to prevent, arriving
+ * from our side of the boundary instead of the server's.
+ *
+ * Reserved slugs are seeded into the taken set, so the collision suffix
+ * already in place handles them: a server labelled "Local" gets `local-2`.
+ */
+export const RESERVED_SERVER_SLUGS: readonly string[] = [
+  LOCAL_SKILL_REF_NAMESPACE,
+];
+
 export interface ServerSlugAssignment<T> {
   server: T;
   serverSlug: string;
@@ -75,7 +100,7 @@ export interface ServerSlugAssignment<T> {
 export function assignServerSlugs<
   T extends { serverId: string; serverLabel: string }
 >(servers: readonly T[]): Array<ServerSlugAssignment<T>> {
-  const taken = new Set<string>();
+  const taken = new Set<string>(RESERVED_SERVER_SLUGS);
   const slugById = new Map<string, string>();
   const canonical = [...servers].sort((a, b) =>
     a.serverId < b.serverId ? -1 : a.serverId > b.serverId ? 1 : 0


### PR DESCRIPTION
Third and last of the Skills GA PRs, after #4433 (inspection surfaces) and #4437 (review follow-ups). This is the convergence itself. **No flag changes.**

## The bug this plan started from

You could author a project skill in the Skills tab on desktop and then have no way to use it. Authoring wrote to Convex; the desktop turn only ever read the local filesystem.

That was not an oversight in one route — it was the shape of the resolution itself:

```ts
skillsSource ? …
: cloudSkills  ? convexProjectSkills
: HOSTED_MODE  ? nothing
:                localFilesystem
```

Exclusive arms, chosen by **deployment** rather than by what the user had. A desktop turn could never see a project skill, a hosted turn could never see a local file, and no turn could see both.

Where a skill comes from is a property of the skill, not a mode the orchestrator picks between. A turn now merges every origin available to it into one ref-addressed catalog:

| Origin | Reference |
|---|---|
| Your project | `code-review` |
| A local file | `local/code-review` |
| A connected MCP server | `<server>/code-review` |
| A plugin | `<plugin>/code-review` |

The exclusive chain and the `cloudSkills` option are deleted. What remains is one shape with one meaning: a caller passes the set it has, `{ kind: "none" }` if it deliberately has none, and no source at all only where "live, with nothing of my own" is the honest answer.

## What each surface gains

- **Desktop** — local files *and* project skills, so a skill you author is usable in the very next message. Signed out or projectless it is local-only, exactly as before; signing in no longer means choosing.
- **The v1 agent turn, and `send_chat_message` with it** — project skills for the first time. #4419 gave that surface a connected *server's* skills; its own project pool stayed invisible, so an agent driving MCPJam could read somebody else's skills but not yours.
- **Hosted Playground and the eval runner** — same skills as before, now through the merged surface rather than a parallel branch.

## Two skills with the same name

Both appear and both load, each by its own reference. **An exact reference always wins**: `code-review` *is* the project skill's ref, so it is a direct hit rather than a guess — which is what keeps a project skill addressable no matter what the user happens to have on disk. Resolving names before refs would let a local file shadow a project skill, the exact squatting the namespacing exists to prevent.

The ambiguity refusal is for the case where **nothing** matches exactly and two namespaced refs share a name — a plugin `docs-tools/code-review` beside a local `local/code-review`, with no project `code-review`. There the tool refuses and names the alternatives.

*(An earlier draft of this description claimed any bare name answered by two origins is refused. That was never the behavior, and two review bots reasonably read it as the spec; the docs, a test title, and this section are corrected.)*

## Three decisions worth reviewing

**`composeLiveServerSkills` is opt-in, and it is load-bearing.** `withServerSkills` was skipped for any turn carrying a `skillsSource` — right for a captured environment set (its server skills were snapshotted; fetching more would falsify the snapshot), wrong for an interactive surface, whose server skills only exist live. Without the flag, every route that started passing a source would have silently traded server skills for project skills: a convergence that drops a capability while looking like it merged one.

This is also why a failed project catalog degrades to a live set *with no project skills* rather than to `{ kind: "none" }`. Collapsing the source would take the connected servers' skills down with the project's — skills that were never fetched from Convex and never failed.

**Writing the origin matrix down found a real hole.** The harness disjointness rule only covered *pinned* sources, because pinned was the only shape a harness caller could reach when it was written. Once `resolved` became what every live surface passes, a harness turn carrying one would have been handed the same skill twice — as SKILL.md on the box *and* as a `loadSkill` tool — with nothing to catch it, since callers guard this themselves and a forgotten guard is silent. The guard now covers every in-memory shape, and the eval runner needed an explicit `!harness` for the same reason (its existing gate only suppresses a harness on a hosted-catalog model).

**Project skills stay lazy.** A turn costs one catalog query; a body is fetched only when the model loads that skill. Eager-loading a 200-skill project on every turn to build a listing it mostly ignores would have been a real regression, so `content` became `string | (() => Promise<string>)` — captured sets keep their bytes inline, which is what makes a snapshot a snapshot. Exactly one read site had to learn about it. Supporting-file listings are fetched once per tool set, and every lazy read stops with the request that asked for it.

## What I did NOT do, and why

**The Skills tab's Local/Cloud toggle is still there.** The plan called for deleting it and merging both stores into one list. That component keys everything on a bare skill *name*, and it already carries scar tissue for this exact hazard — the `serverSkillUri` marker exists because a name-keyed effect would otherwise "replace the verified content with a same-named project skill". Merging local and project into one name-keyed list reintroduces that bug class; doing it safely means re-keying the component on composite identity first, which is its own change.

What I fixed instead is what was actually wrong: the toggle was gated on `computers-enabled`, a leftover from when cloud skills lived on a Computer's filesystem. That was wrong in both directions — it could offer a switch to a store the backend would refuse to write, or withhold one you had. It now gates on the Skills flag, and it only decides what you **browse**: turns merge regardless of what the tab is showing.

One consequence to know: the `/` picker on desktop is now a *subset* of the turn's catalog (local-only, while the turn has local + project). That direction is coherent — the model still sees project skills automatically. The reverse would not be, which is why the picker change waits for the same re-keying work.

## Verification

`skill-origin-policy.test.ts` asserts the whole matrix in one place, rather than leaving it discoverable only by reading four call sites: desktop signed out is local-only; desktop with a project is both, addressable; hosted is project-only; an eval run is pinned content and the only kind bypassing approval; a harness refuses an in-memory source outright; and both same-name cases — the exact hit and the genuine ambiguity.

Beyond tests, I ran the local scanner against a real skills directory: correct ref and display path, lazy file listing, file read through the containment guard, and an aggregate hash that changes when a supporting file is edited and is stable when it is restored.

Server suite green: **7,643 passed**, 43 skipped, across 486 files. Server typecheck **194 errors against a 194 baseline** on the same commit.

## Review round

Every finding from the first review round is fixed and pushed, each with a test that fails without its fix:

- the Skills tab's browse toggle had lost its gate on desktop (`!HOSTED_MODE || flag` is a tautology there);
- a failed project catalog collapsed the synthetic session's source and took the connected servers' skills with it;
- a server labelled "Local" could slugify onto the `local/` namespace and make every local skill unreachable — `local` is now reserved;
- the bare-name claim above, wrong in the docs, in two code comments, and in a test whose title contradicted its own assertion;
- lazy reads did not receive the routes' abort signals;
- the supporting-file listing was fetched once per tool *call* rather than once per tool set;
- a symlinked `SKILL.md` read whatever it pointed at — containment is now checked with `realpath` on both sides.

One thread is left open deliberately: the same symlink property exists on the pre-existing bare browse surface (`/api/mcp/skills`), which this PR does not touch. Closing it there is a separate call.

## Not in this PR

The rollout runway, which has the longest lead time and is unblocked by none of these three PRs: widening `skills-enabled` past the two accounts, establishing what caused the 2026-08-10 team-wide rollback, and a scripted pass over the 200-skill cap and the file budgets. Worth starting in parallel rather than after this merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017A5HziE5nu1YJ64iFpM2oV

---
_Generated by [Claude Code](https://claude.ai/code/session_017A5HziE5nu1YJ64iFpM2oV)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches chat turn preparation across local, hosted, v1 API, and simulation paths with lazy skill loading and filesystem reads; mistakes could drop skills, double-deliver on harness turns, or weaken local skill containment—mitigated by extensive tests and explicit harness/catalog-failure semantics.
> 
> **Overview**
> Chat turns no longer pick a single skills source by deployment (local FS vs Convex vs nothing). Routes build one **merged catalog** from every origin available—project (`code-review`), local (`local/code-review`), MCP servers, and plugins—and pass it through `prepareChatV2` as `skillsSource: { kind: "resolved", capabilities }`, replacing the deleted `cloudSkills` exclusive chain.
> 
> **Desktop `/api/mcp/chat-v2`** now scans local skills and, when authenticated with a `projectId`, fetches the project catalog into `buildLiveEffectiveCapabilities`, so tab-authored project skills work on the next message alongside local files. **Hosted Playground, v1 `chat-session-turn`, and session simulation** follow the same live-capability pattern; environment/scenario turns keep **captured** sets without `composeLiveServerSkills` so live server catalogs do not override pinned skills. A failed project catalog fetch degrades to empty project skills while **still composing live MCP server skills**, not `{ kind: "none" }`.
> 
> The Skills tab **Local/Cloud** toggle only controls browsing and is gated on **`skills-enabled`** (not `computers-enabled`); `cloudSkillsEnabled` is no longer forced true in local mode via `!HOSTED_MODE || flag`. Docs/changeset describe ref resolution, exact-ref wins vs ambiguous bare names, lazy project skill bodies, and harness disjointness for in-memory sources.
> 
> Tests cover flag gating, local skill scanning (symlinks, size at read time), orchestration behavior, and route-level catalog wiring.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1140d4d593745e1107fc4f7e066883e3de99eca3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->