### PR TITLE
Hosted skills routes connect before asking whether the extension is active

### DIFF
--- a/.changeset/skills-connect-before-support.md
+++ b/.changeset/skills-connect-before-support.md
@@ -1,0 +1,22 @@
+---
+"@mcpjam/inspector": patch
+"@mcpjam/sdk": patch
+---
+
+Hosted skills routes connect before asking whether the extension is active
+
+Every hosted `/server-skills` request answered "this connection does not speak skills" — for every server, including ones that plainly do — and the Skills tab showed nothing.
+
+`getSkillsSupport` is a synchronous read of what a LIVE connection negotiated. A hosted manager is ephemeral: nothing has connected when the handler starts, so the read answered `active: false` before the extension had any chance to be declared. The route then returned its empty listing and the wrapper's `finally` tore the manager down — aborting the negotiation that was still in flight. The telemetry is unambiguous once you look for it:
+
+```
+[event] mcp.connection.negotiated { serverId: 'mn7…', configuredMode: 'auto',
+  outcome: 'failed', failureClass: 'AbortError' }
+--> POST /api/web/server-skills/list 200 516ms
+```
+
+A `200` with no skills, an aborted connection, and a server that answers `skills/list` perfectly when asked directly. Every other route to that same server negotiated `connected` in the same log, because they all reach the wire through methods that `await ensureConnected` first — `listTools`, `readResource`, and the rest. Skills had no such method, so the route read the answer before there was one.
+
+`MCPClientManager.ensureSkillsSupport()` is that method: it awaits the connection, then answers `getSkillsSupport`. The shared route core (`/api/web/server-skills` and its `/api/v1` mirror) now uses it in all three handlers.
+
+Local mode was never affected and is unchanged — its manager is long-lived and already connected by the time anything asks, which is exactly why this survived local testing.

--- a/mcpjam-inspector/server/utils/__tests__/server-skill-route-core.test.ts
+++ b/mcpjam-inspector/server/utils/__tests__/server-skill-route-core.test.ts
@@ -55,12 +55,28 @@ async function makeManager(
       },
     ],
   };
+  /**
+   * Models the real manager's connection lifecycle, which is the whole point
+   * on a hosted request: `getSkillsSupport` reads what a LIVE connection
+   * negotiated, so before anything connects it answers `active: false` for
+   * every server — regardless of what the server actually declares. A core
+   * that reads it synchronously therefore reports "inactive" on every hosted
+   * call. Only `ensureSkillsSupport` awaits the connection first.
+   */
+  let connected = false;
+  const support = () => ({
+    declared: connected && options.active !== false,
+    advertised: connected && options.active !== false,
+    directoryRead: false,
+    active: connected && options.active !== false,
+  });
   return {
-    getSkillsSupport: () => ({
-      declared: options.active !== false,
-      advertised: options.active !== false,
-      directoryRead: false,
-      active: options.active !== false,
+    connectCount: 0,
+    getSkillsSupport: () => support(),
+    ensureSkillsSupport: vi.fn(async function (this: any) {
+      connected = true;
+      this.connectCount += 1;
+      return support();
     }),
     listServerSkills: vi.fn(async () => ({ skills: [entry] })),
     getServerSkill: vi.fn(async () => entry),
@@ -75,6 +91,45 @@ async function makeManager(
     })),
   } as unknown as MCPClientManager;
 }
+
+describe("support is read from a connection, not before one", () => {
+  // The regression: a hosted manager is EPHEMERAL, so nothing has connected
+  // when the handler starts. Reading `getSkillsSupport` synchronously answered
+  // "inactive" on every hosted request and returned an empty listing, while
+  // the route's teardown aborted the negotiation still in flight — a 200 with
+  // no skills and an `AbortError`, against a reachable server.
+  it("connects before answering, so a declared extension is seen", async () => {
+    const manager = (await makeManager()) as any;
+    // The synchronous read is false right now, and stays false unless the core
+    // awaits the connection.
+    expect(manager.getSkillsSupport().active).toBe(false);
+
+    const result = await listServerSkillsCore(manager, { serverId: SERVER_ID });
+
+    expect(manager.ensureSkillsSupport).toHaveBeenCalledWith(SERVER_ID);
+    expect(result.support.active).toBe(true);
+    expect(result.skills).toHaveLength(1);
+  });
+
+  it("does the same on get and read-file", async () => {
+    const getManager = (await makeManager()) as any;
+    const got = await getServerSkillCore(getManager, {
+      serverId: SERVER_ID,
+      uri: SKILL_URI,
+    });
+    expect(getManager.ensureSkillsSupport).toHaveBeenCalledWith(SERVER_ID);
+    expect(got.skill).toBeDefined();
+
+    const readManager = (await makeManager()) as any;
+    const read = await readServerSkillFileCore(readManager, {
+      serverId: SERVER_ID,
+      skillUri: SKILL_URI,
+      resourceUri: FILE_URI,
+    });
+    expect(readManager.ensureSkillsSupport).toHaveBeenCalledWith(SERVER_ID);
+    expect(read.file).toBeDefined();
+  });
+});
 
 describe("an inactive extension is a state, not a failure", () => {
   // The client renders a response with no refusal as a generic `fetch_failed`,

--- a/mcpjam-inspector/server/utils/server-skill-route-core.ts
+++ b/mcpjam-inspector/server/utils/server-skill-route-core.ts
@@ -12,6 +12,15 @@
  * `/read-file` would eventually disagree about whether an inactive extension is
  * a 200 with a refusal or a 500, and the client renders a missing refusal as a
  * generic `fetch_failed`: a network story for what is a capability state.
+ *
+ * Support is read with `ensureSkillsSupport`, NEVER the synchronous
+ * `getSkillsSupport`. A hosted manager is ephemeral: nothing has connected when
+ * the handler starts, so the synchronous read answers from a live connection
+ * that does not exist yet and reports the extension inactive on every request.
+ * The route then returns an empty listing and its own teardown aborts the
+ * negotiation still in flight — a 200 with no skills and an `AbortError` in the
+ * connection telemetry, against a server that is perfectly reachable. Local
+ * mode hid it, because there the manager is long-lived and already connected.
  */
 
 import type { MCPClientManager } from "@mcpjam/sdk";
@@ -36,7 +45,7 @@ export async function listServerSkillsCore(
   manager: Manager,
   body: { serverId: string }
 ) {
-  const support = manager.getSkillsSupport(body.serverId);
+  const support = await manager.ensureSkillsSupport(body.serverId);
   if (!support.active) {
     return {
       support,
@@ -55,7 +64,7 @@ export async function getServerSkillCore(
   manager: Manager,
   body: { serverId: string; uri: string }
 ) {
-  const support = manager.getSkillsSupport(body.serverId);
+  const support = await manager.ensureSkillsSupport(body.serverId);
   if (!support.active) return { support, refusal: EXTENSION_INACTIVE_REFUSAL };
   try {
     return {
@@ -76,7 +85,7 @@ export async function readServerSkillFileCore(
   manager: Manager,
   body: { serverId: string; skillUri: string; resourceUri: string }
 ) {
-  const support = manager.getSkillsSupport(body.serverId);
+  const support = await manager.ensureSkillsSupport(body.serverId);
   if (!support.active) return { support, refusal: EXTENSION_INACTIVE_REFUSAL };
   try {
     // The entry is re-fetched rather than taken from the caller: the manifest

--- a/sdk/src/mcp-client-manager/MCPClientManager.ts
+++ b/sdk/src/mcp-client-manager/MCPClientManager.ts
@@ -2065,6 +2065,31 @@ export class MCPClientManager {
   }
 
   /**
+   * {@link getSkillsSupport}, after ensuring the connection exists.
+   *
+   * `getSkillsSupport` reads what a LIVE connection negotiated, synchronously.
+   * On a manager whose connection has not been established yet it therefore
+   * answers `active: false` for every server — not because the extension is
+   * absent, but because there is nothing to read. That is the right answer to
+   * the question it was asked and the wrong answer to the question a caller
+   * usually means.
+   *
+   * It matters on EPHEMERAL managers, which is every hosted request: a route
+   * that reads support as its first act reads it before anything has
+   * connected, concludes the extension is inactive, and returns an empty
+   * listing — then tears the manager down, aborting the negotiation that was
+   * still in flight. The symptom is a 200 with no skills and an `AbortError`
+   * in the connection telemetry, on a server that is perfectly reachable.
+   *
+   * Every other capability question reaches the wire through a method that
+   * awaits `ensureConnected` first. This is that method for skills.
+   */
+  async ensureSkillsSupport(serverId: string): Promise<SkillsSupport> {
+    await this.ensureConnected(serverId);
+    return this.getSkillsSupport(serverId);
+  }
+
+  /**
    * Advertise = enforce. A `skills/*` request is refused BEFORE it reaches the
    * wire whenever the extension is not mutually declared.
    *


### PR DESCRIPTION
The Skills tab was empty on staging because **every hosted `/server-skills` request answered "this connection does not speak skills"** — for every server, including ones that plainly do.

## The evidence

Staging logs, one request:

```
[event] mcp.connection.negotiated { serverId: 'mn7akmwtxwn8811a0ggqb6x52s8d9t50',
  transport: 'http', configuredMode: 'auto',
  outcome: 'failed', failureClass: 'AbortError' }
--> POST /api/web/server-skills/list 200 516ms
```

A `200` with no skills, an aborted negotiation, and a worker that answers `skills/list` perfectly when asked directly (verified by curl and by running the real `MCPClientManager` + `listServerSkillCatalog` against it — `active: true`, 4 skills, on both `2025-06-18` and `2026-07-28`).

And in the same log, every *other* route to that same server: `outcome: 'connected'`.

## The cause

`getSkillsSupport` is a **synchronous** read of what a LIVE connection negotiated. A hosted manager is ephemeral — nothing has connected when the handler starts — so it answered `active: false` before the extension had any chance to be declared. The route then returned its empty listing and `runEphemeralConnection`'s `finally { disconnectAllServers() }` tore the manager down, aborting the negotiation still in flight.

Every other capability question reaches the wire through a method that `await`s `ensureConnected` first — `listTools`, `readResource`, `getPrompt`. Skills had no such method, so the route read the answer before there was one to read.

That is also why this survived every local test: local mode's manager is long-lived and already connected by the time anything asks.

## The fix

`MCPClientManager.ensureSkillsSupport()` — awaits the connection, then answers `getSkillsSupport`. The shared route core uses it in all three handlers, so `/api/web/server-skills` and its `/api/v1` mirror are both fixed.

The local `routes/mcp/server-skills.ts` reads are deliberately left synchronous: that manager is long-lived, and forcing a connect from its status probe would change what "inactive" means on a surface that works today.

## Tests

`server-skill-route-core.test.ts` — the fake manager now models the connection lifecycle: `getSkillsSupport` reports inactive until something connects, and only `ensureSkillsSupport` connects. Two new cases assert the core connects before answering, on list and on get/read-file. **Verified to fail without the fix** — 5 of 7 go red when the core is reverted to the synchronous read.

Unrelated failures in that run: `servers-doctor-egress.test.ts` (DNS-dependent) and a batch of collection errors from a missing temp dir. Neither touches skills.

## Note

`withServerSkills` in the chat path gates on the same synchronous `serverSkillsActive`. It happens to be safe today because tool aggregation connects first, but it is the same latent hazard and worth a look separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes connection ordering for hosted skills API paths; behavior is localized to those routes and SDK adds a new public method without altering existing synchronous reads.
> 
> **Overview**
> Fixes the **hosted Skills tab showing empty catalogs** even when servers declare the skills extension.
> 
> Hosted `/server-skills` handlers used synchronous `getSkillsSupport` on an **ephemeral** `MCPClientManager` that had not finished connecting yet, so every request looked like `active: false`, returned HTTP 200 with no skills, and teardown aborted negotiation (`AbortError` in telemetry). Other MCP routes already `await ensureConnected` first; skills did not.
> 
> **`MCPClientManager.ensureSkillsSupport(serverId)`** awaits `ensureConnected`, then returns `getSkillsSupport`. Shared route core (`listServerSkillsCore`, `getServerSkillCore`, `readServerSkillFileCore`) now uses it for both `/api/web/server-skills` and `/api/v1` mirrors. **Local** inspector routes stay on synchronous `getSkillsSupport` (long-lived manager).
> 
> Tests model pre-connect `active: false` and assert the core calls `ensureSkillsSupport` before listing, getting, or reading skill files. Patch bumps for `@mcpjam/inspector` and `@mcpjam/sdk`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 95384f6feb88f3d44eff1e985e5411bd0a383e5f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes hosted skills routes answering "does not speak skills" for every server, so the Skills tab no longer shows an empty listing. The routes read connection support synchronously, but a hosted manager has not connected when the handler starts, so they got `active: false` and then tore the manager down, aborting the negotiation still in flight. Routes now await the connection before reading support.

- Adds `MCPClientManager.ensureSkillsSupport()`, which connects before answering `getSkillsSupport`, and uses it in all three handlers of the shared route core covering `/api/web/server-skills` and the `/api/v1` mirror.
- Tests model the connection lifecycle and fail against the old synchronous read.
- Local mode stays synchronous: its manager is long-lived and already connected, and forcing a connect would change what "inactive" means.
- `withServerSkills` in the chat path gates on the same synchronous read and is a latent hazard; it is safe today only because tool aggregation connects first.

<sup>Written for commit 95384f6feb88f3d44eff1e985e5411bd0a383e5f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/MCPJam/inspector/pull/4446?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

