### PR TITLE
Remove the non-prod lockdown gate; move staging access to the edge

### DIFF
--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -69,7 +69,11 @@ jobs:
       # browser-parsed frame-ancestors directive, which DOES support `*`.
       # `ALLOWED_ORIGINS` (origin-validation middleware) supports the
       # wildcard via `matchesAllowedOrigin`, gated on
-      # `MCPJAM_NONPROD_LOCKDOWN=true` — staging satisfies that.
+      # `MCPJAM_ALLOW_WILDCARD_ORIGINS=true`, which is set below. That opt-in
+      # is set HERE rather than by hand on the service: it used to be implied
+      # by `MCPJAM_NONPROD_LOCKDOWN`, which was never actually set on the
+      # staging service, so `getAllowedOrigins()` silently stripped the
+      # wildcard on every boot and preview→staging calls were rejected.
       #
       # The two vars use different wildcard shapes intentionally:
       #   - ALLOWED_ORIGINS uses the tight mid-host pattern so only PR
@@ -95,6 +99,7 @@ jobs:
             -s "$RAILWAY_INSPECTOR_SERVICE" \
             ALLOWED_ORIGINS="$STAGING_APP_URL,https://mcp-inspector-pr-*.up.railway.app" \
             WEB_ALLOWED_ORIGINS="$STAGING_APP_URL,https://*.up.railway.app" \
+            MCPJAM_ALLOW_WILDCARD_ORIGINS=true \
             MCPJAM_INSPECTOR_PUBLIC_URL="$STAGING_APP_URL"
 
       # Capture the most recent deployment id before we trigger a new one so

--- a/.github/workflows/pr-preview.yml
+++ b/.github/workflows/pr-preview.yml
@@ -78,7 +78,6 @@ jobs:
       # it is provisioned; fall back to duplicating staging — secrets and
       # all — until then.
       RAILWAY_PREVIEW_SOURCE_ENVIRONMENT: ${{ vars.RAILWAY_PREVIEW_TEMPLATE_ENVIRONMENT || vars.RAILWAY_STAGING_ENVIRONMENT }}
-      MCPJAM_EMPLOYEE_EMAIL_DOMAINS: ${{ vars.MCPJAM_EMPLOYEE_EMAIL_DOMAINS }}
       STAGING_WORKOS_CLIENT_ID: ${{ vars.STAGING_WORKOS_CLIENT_ID }}
       STAGING_WORKOS_API_HOSTNAME: ${{ vars.STAGING_WORKOS_API_HOSTNAME || 'api.workos.com' }}
       # Default Convex backend for previews when no per-PR backend preview
@@ -166,11 +165,8 @@ jobs:
           .github/scripts/railway-retry.sh .github/scripts/railway-set-vars.sh \
             -e "${{ steps.meta.outputs.environment }}" \
             -s "$RAILWAY_INSPECTOR_SERVICE" \
-            MCPJAM_NONPROD_LOCKDOWN=true \
-            MCPJAM_EMPLOYEE_EMAIL_DOMAINS="$MCPJAM_EMPLOYEE_EMAIL_DOMAINS" \
+            MCPJAM_ALLOW_WILDCARD_ORIGINS=true \
             MCPJAM_ALLOWED_HOSTS="staging.mcpjam.com,*.up.railway.app" \
-            VITE_MCPJAM_NONPROD_LOCKDOWN=true \
-            VITE_MCPJAM_EMPLOYEE_EMAIL_DOMAINS="$MCPJAM_EMPLOYEE_EMAIL_DOMAINS" \
             VITE_MCPJAM_HOSTED_MODE=true \
             VITE_WORKOS_CLIENT_ID="$STAGING_WORKOS_CLIENT_ID" \
             VITE_WORKOS_API_HOSTNAME="$STAGING_WORKOS_API_HOSTNAME" \
@@ -387,7 +383,6 @@ jobs:
       # it is provisioned; fall back to duplicating staging — secrets and
       # all — until then.
       RAILWAY_PREVIEW_SOURCE_ENVIRONMENT: ${{ vars.RAILWAY_PREVIEW_TEMPLATE_ENVIRONMENT || vars.RAILWAY_STAGING_ENVIRONMENT }}
-      MCPJAM_EMPLOYEE_EMAIL_DOMAINS: ${{ vars.MCPJAM_EMPLOYEE_EMAIL_DOMAINS }}
       STAGING_WORKOS_CLIENT_ID: ${{ vars.STAGING_WORKOS_CLIENT_ID }}
       STAGING_WORKOS_API_HOSTNAME: ${{ vars.STAGING_WORKOS_API_HOSTNAME || 'api.workos.com' }}
       # Default Convex backend for previews when no per-PR backend preview
@@ -454,11 +449,8 @@ jobs:
           .github/scripts/railway-retry.sh .github/scripts/railway-set-vars.sh \
             -e "${{ steps.meta.outputs.environment }}" \
             -s "$RAILWAY_INSPECTOR_SERVICE" \
-            MCPJAM_NONPROD_LOCKDOWN=true \
-            MCPJAM_EMPLOYEE_EMAIL_DOMAINS="$MCPJAM_EMPLOYEE_EMAIL_DOMAINS" \
+            MCPJAM_ALLOW_WILDCARD_ORIGINS=true \
             MCPJAM_ALLOWED_HOSTS="staging.mcpjam.com,*.up.railway.app" \
-            VITE_MCPJAM_NONPROD_LOCKDOWN=true \
-            VITE_MCPJAM_EMPLOYEE_EMAIL_DOMAINS="$MCPJAM_EMPLOYEE_EMAIL_DOMAINS" \
             VITE_MCPJAM_HOSTED_MODE=true \
             VITE_WORKOS_CLIENT_ID="$STAGING_WORKOS_CLIENT_ID" \
             VITE_WORKOS_API_HOSTNAME="$STAGING_WORKOS_API_HOSTNAME" \
@@ -796,7 +788,6 @@ jobs:
       RAILWAY_API_TOKEN: ${{ secrets.RAILWAY_API_TOKEN }}
       RAILWAY_PROJECT_ID: ${{ vars.RAILWAY_PROJECT_ID }}
       RAILWAY_INSPECTOR_SERVICE: ${{ vars.RAILWAY_INSPECTOR_SERVICE }}
-      MCPJAM_EMPLOYEE_EMAIL_DOMAINS: ${{ vars.MCPJAM_EMPLOYEE_EMAIL_DOMAINS }}
       STAGING_WORKOS_CLIENT_ID: ${{ vars.STAGING_WORKOS_CLIENT_ID }}
       STAGING_WORKOS_API_HOSTNAME: ${{ vars.STAGING_WORKOS_API_HOSTNAME || 'api.workos.com' }}
       # See upsert-preview: shared preview deployment when provisioned,
@@ -856,11 +847,8 @@ jobs:
           .github/scripts/railway-retry.sh .github/scripts/railway-set-vars.sh \
             -e "${{ github.event.client_payload.inspector_environment }}" \
             -s "$RAILWAY_INSPECTOR_SERVICE" \
-            MCPJAM_NONPROD_LOCKDOWN=true \
-            MCPJAM_EMPLOYEE_EMAIL_DOMAINS="$MCPJAM_EMPLOYEE_EMAIL_DOMAINS" \
+            MCPJAM_ALLOW_WILDCARD_ORIGINS=true \
             MCPJAM_ALLOWED_HOSTS="staging.mcpjam.com,*.up.railway.app" \
-            VITE_MCPJAM_NONPROD_LOCKDOWN=true \
-            VITE_MCPJAM_EMPLOYEE_EMAIL_DOMAINS="$MCPJAM_EMPLOYEE_EMAIL_DOMAINS" \
             VITE_MCPJAM_HOSTED_MODE=true \
             VITE_WORKOS_CLIENT_ID="$STAGING_WORKOS_CLIENT_ID" \
             VITE_WORKOS_API_HOSTNAME="$STAGING_WORKOS_API_HOSTNAME" \

--- a/mcpjam-inspector/client/src/App.tsx
+++ b/mcpjam-inspector/client/src/App.tsx
@@ -1,5 +1,4 @@
 import { useConvexAuth, useQuery } from "convex/react";
-import { permalinkSignInOptions } from "@/lib/permalink-signin-return";
 import {
   useCallback,
   useContext,
@@ -154,7 +153,6 @@ import {
   ScenarioChatPage,
   getScenarioPathTokenFromLocation,
 } from "./components/hosted/ScenarioChatPage";
-import { isEmbeddedPreview } from "./lib/embedded-preview";
 import { useApiContext } from "./hooks/hosted/use-hosted-api-context";
 import { useHostedClientCapabilities } from "./hooks/hosted/use-hosted-client-capabilities";
 import { useLocalStateMigration } from "./hooks/use-local-state-migration";
@@ -165,7 +163,7 @@ import {
   resolveScopeStepUpServer,
 } from "./lib/scope-step-up";
 import { markPendingChatScopeStepUpCancelled } from "./lib/scope-step-up-pending";
-import { HOSTED_MODE, NON_PROD_LOCKDOWN } from "./lib/config";
+import { HOSTED_MODE } from "./lib/config";
 import {
   createInspectorCommandClientError,
   registerInspectorCommandHandler,
@@ -227,7 +225,6 @@ import {
   clearScenarioSignInReturnPath,
   readScenarioSession,
   readScenarioSignInReturnPath,
-  writeScenarioSignInReturnPath,
 } from "./lib/scenario-session";
 import {
   clearCliSignInReturnPath,
@@ -2460,7 +2457,6 @@ export default function App() {
   const {
     getAccessToken,
     signIn,
-    signOut,
     user: workOsUser,
     isLoading: isWorkOsLoading,
   } = useAuth();
@@ -3082,26 +3078,17 @@ export default function App() {
   )?.name;
   const hostedShellGateState = resolveHostedShellGateState({
     hostedMode: HOSTED_MODE,
-    nonProdLockdown: NON_PROD_LOCKDOWN,
-    // Read on every render, like `scenarioPathToken` above: framing is a fact
-    // about this document, fixed for its lifetime, so there is nothing to
-    // memoize and nothing that can change under us.
-    embeddedPreview: isScenarioChatRoute && isEmbeddedPreview(),
     isConvexAuthLoading: isAuthLoading,
     isConvexAuthenticated: isAuthenticated,
     isWorkOsLoading,
     hasWorkOsUser: !!workOsUser,
-    workOsUserEmail: workOsUser?.email ?? null,
   });
   const baseHostedShellGateState = hostedShellGateState;
   const pendingDashboardOAuthServer = pendingDashboardOAuth
     ? projectServers[pendingDashboardOAuth.serverName]
     : null;
   const shouldShowPendingDashboardOAuthGate =
-    !!pendingDashboardOAuth &&
-    !pendingDashboardOAuthServer &&
-    baseHostedShellGateState !== "logged-out" &&
-    baseHostedShellGateState !== "restricted";
+    !!pendingDashboardOAuth && !pendingDashboardOAuthServer;
   const effectiveHostedShellGateState = shouldShowPendingDashboardOAuthGate
     ? "project-loading"
     : baseHostedShellGateState;
@@ -5067,36 +5054,6 @@ export default function App() {
                     ? pendingDashboardOAuthMessage
                     : undefined
                 }
-                onSignIn={() => {
-                  if (scenarioPathToken) {
-                    // The scenario gate owns its own return path; leaving the
-                    // permalink nonce out keeps exactly one mechanism live on
-                    // that route rather than two racing to redirect.
-                    writeScenarioSignInReturnPath(window.location.pathname);
-                    signIn();
-                    return;
-                  }
-                  // THE primary signed-out path for a permalink. This gate
-                  // intercepts a hosted cold load before any screen renders,
-                  // so a bare `signIn()` here loses the resource path and its
-                  // `?project=` scope no matter what the header button does —
-                  // the visitor authenticates and lands on the app shell.
-                  //
-                  // The generic path is stored alongside the scenario one, not
-                  // instead of it: the scenario flow keeps its precedence on
-                  // `/callback`, and this only fills in for everything else.
-                  captureAppSignInReturnPath();
-                  signIn(permalinkSignInOptions());
-                }}
-                onSignOut={() => {
-                  void (async () => {
-                    try {
-                      await disconnectRuntimeServersForAuthExit();
-                    } finally {
-                      await signOut();
-                    }
-                  })();
-                }}
               >
                 {isScenarioChatRoute ? (
                   <ScenarioChatPage

--- a/mcpjam-inspector/client/src/__tests__/App.hosted-oauth.test.tsx
+++ b/mcpjam-inspector/client/src/__tests__/App.hosted-oauth.test.tsx
@@ -283,7 +283,6 @@ vi.mock("../hooks/usePostHogOrgContext", () => ({
 
 vi.mock("../lib/config", () => ({
   HOSTED_MODE: true,
-  NON_PROD_LOCKDOWN: false,
 }));
 
 vi.mock("../lib/theme-utils", () => ({

--- a/mcpjam-inspector/client/src/components/hosted/HostedShellGate.tsx
+++ b/mcpjam-inspector/client/src/components/hosted/HostedShellGate.tsx
@@ -1,19 +1,11 @@
 import type { ReactNode } from "react";
-import { AlertTriangle, Loader2 } from "lucide-react";
-import { Button } from "@mcpjam/design-system/button";
+import { Loader2 } from "lucide-react";
 
-export type HostedShellGateState =
-  | "ready"
-  | "auth-loading"
-  | "project-loading"
-  | "logged-out"
-  | "restricted";
+export type HostedShellGateState = "ready" | "auth-loading" | "project-loading";
 
 interface HostedShellGateProps {
   state: HostedShellGateState;
   loadingMessage?: string;
-  onSignIn?: () => void;
-  onSignOut?: () => void;
   children: ReactNode;
 }
 
@@ -21,20 +13,12 @@ function getGateCopy(state: HostedShellGateState): string {
   if (state === "auth-loading") {
     return "Checking authentication...";
   }
-  if (state === "project-loading") {
-    return "Preparing project...";
-  }
-  if (state === "restricted") {
-    return "This environment is limited to MCPJam employees.";
-  }
-  return "Sign in to MCPJam to continue";
+  return "Preparing project...";
 }
 
 export function HostedShellGate({
   state,
   loadingMessage,
-  onSignIn,
-  onSignOut,
   children,
 }: HostedShellGateProps) {
   const isBlocked = state !== "ready" && state !== "auth-loading";
@@ -61,39 +45,8 @@ export function HostedShellGate({
           className="absolute inset-0 z-50 flex items-center justify-center bg-background/70 backdrop-blur-sm px-4"
         >
           <div className="flex max-w-md flex-col items-center rounded-lg border border-border bg-card/90 p-6 text-center shadow-sm">
-            {state === "logged-out" ? (
-              <img
-                src="/mcp_jam.svg"
-                alt="MCPJam"
-                className="mb-4 h-12 w-auto"
-              />
-            ) : state === "restricted" ? (
-              <AlertTriangle className="mb-4 h-5 w-5 text-amber-600" />
-            ) : (
-              <Loader2 className="mb-4 h-5 w-5 animate-spin text-muted-foreground" />
-            )}
+            <Loader2 className="mb-4 h-5 w-5 animate-spin text-muted-foreground" />
             <p className="text-sm text-foreground">{copy}</p>
-            {state === "logged-out" && (
-              <Button
-                type="button"
-                size="sm"
-                className="mt-4"
-                onClick={() => onSignIn?.()}
-              >
-                Sign in
-              </Button>
-            )}
-            {state === "restricted" && onSignOut ? (
-              <Button
-                type="button"
-                size="sm"
-                variant="outline"
-                className="mt-4"
-                onClick={() => onSignOut()}
-              >
-                Use another account
-              </Button>
-            ) : null}
           </div>
         </div>
       )}

--- a/mcpjam-inspector/client/src/components/hosted/__tests__/HostedShellGate.test.tsx
+++ b/mcpjam-inspector/client/src/components/hosted/__tests__/HostedShellGate.test.tsx
@@ -1,5 +1,5 @@
-import { describe, expect, it, vi } from "vitest";
-import { fireEvent, render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import { render, screen } from "@testing-library/react";
 import { HostedShellGate } from "../HostedShellGate";
 
 describe("HostedShellGate", () => {
@@ -56,36 +56,16 @@ describe("HostedShellGate", () => {
     ).toBeInTheDocument();
   });
 
-  it("shows sign in call-to-action when logged out", () => {
-    const onSignIn = vi.fn();
-
+  it("blocks input while the project-loading overlay is up", () => {
     render(
-      <HostedShellGate state="logged-out" onSignIn={onSignIn}>
+      <HostedShellGate state="project-loading">
         <div>App Content</div>
       </HostedShellGate>,
     );
 
-    expect(
-      screen.getByText("Sign in to MCPJam to continue"),
-    ).toBeInTheDocument();
-    expect(screen.getByRole("img", { name: "MCPJam" })).toBeInTheDocument();
-    fireEvent.click(screen.getByRole("button", { name: "Sign in" }));
-    expect(onSignIn).toHaveBeenCalledTimes(1);
-  });
-
-  it("shows employee-only gate copy when restricted", () => {
-    const onSignOut = vi.fn();
-
-    render(
-      <HostedShellGate state="restricted" onSignOut={onSignOut}>
-        <div>App Content</div>
-      </HostedShellGate>,
+    expect(screen.getByTestId("hosted-shell-gate-overlay")).toBeInTheDocument();
+    expect(screen.getByTestId("hosted-shell-gate-content")).toHaveAttribute(
+      "inert",
     );
-
-    expect(
-      screen.getByText("This environment is limited to MCPJam employees."),
-    ).toBeInTheDocument();
-    fireEvent.click(screen.getByRole("button", { name: "Use another account" }));
-    expect(onSignOut).toHaveBeenCalledTimes(1);
   });
 });

--- a/mcpjam-inspector/client/src/components/hosted/__tests__/hosted-shell-gate-state.test.ts
+++ b/mcpjam-inspector/client/src/components/hosted/__tests__/hosted-shell-gate-state.test.ts
@@ -6,12 +6,10 @@ describe("resolveHostedShellGateState", () => {
     expect(
       resolveHostedShellGateState({
         hostedMode: false,
-        nonProdLockdown: false,
         isConvexAuthLoading: false,
         isConvexAuthenticated: false,
         isWorkOsLoading: false,
         hasWorkOsUser: false,
-        workOsUserEmail: null,
       }),
     ).toBe("ready");
   });
@@ -20,12 +18,10 @@ describe("resolveHostedShellGateState", () => {
     expect(
       resolveHostedShellGateState({
         hostedMode: true,
-        nonProdLockdown: false,
         isConvexAuthLoading: false,
         isConvexAuthenticated: false,
         isWorkOsLoading: true,
         hasWorkOsUser: false,
-        workOsUserEmail: null,
       }),
     ).toBe("auth-loading");
   });
@@ -34,12 +30,10 @@ describe("resolveHostedShellGateState", () => {
     expect(
       resolveHostedShellGateState({
         hostedMode: true,
-        nonProdLockdown: false,
         isConvexAuthLoading: false,
         isConvexAuthenticated: false,
         isWorkOsLoading: false,
         hasWorkOsUser: true,
-        workOsUserEmail: "employee@mcpjam.com",
       }),
     ).toBe("auth-loading");
   });
@@ -48,12 +42,10 @@ describe("resolveHostedShellGateState", () => {
     expect(
       resolveHostedShellGateState({
         hostedMode: true,
-        nonProdLockdown: false,
         isConvexAuthLoading: false,
         isConvexAuthenticated: false,
         isWorkOsLoading: false,
         hasWorkOsUser: false,
-        workOsUserEmail: null,
       }),
     ).toBe("ready");
   });
@@ -62,79 +54,11 @@ describe("resolveHostedShellGateState", () => {
     expect(
       resolveHostedShellGateState({
         hostedMode: true,
-        nonProdLockdown: false,
         isConvexAuthLoading: false,
         isConvexAuthenticated: true,
         isWorkOsLoading: false,
         hasWorkOsUser: true,
-        workOsUserEmail: "employee@mcpjam.com",
       }),
     ).toBe("ready");
-  });
-
-  it("requires sign-in when lockdown is enabled", () => {
-    expect(
-      resolveHostedShellGateState({
-        hostedMode: true,
-        nonProdLockdown: true,
-        isConvexAuthLoading: false,
-        isConvexAuthenticated: false,
-        isWorkOsLoading: false,
-        hasWorkOsUser: false,
-        workOsUserEmail: null,
-      }),
-    ).toBe("logged-out");
-  });
-
-  /**
-   * SUTB-6. The Preview embed mounts the whole app shell, so under lockdown
-   * the author's own frame rendered this gate's "Sign in to MCPJam to
-   * continue" wall over the scenario they had just created — a wall whose
-   * button cannot complete inside a frame (`/oauth/callback` is outside the
-   * `main.tsx` self-embed exemption). The frame is the author's, in a
-   * dashboard that already cleared the gate; it is never the place to gate.
-   */
-  it("never walls the author's Preview embed under lockdown", () => {
-    expect(
-      resolveHostedShellGateState({
-        hostedMode: true,
-        nonProdLockdown: true,
-        embeddedPreview: true,
-        isConvexAuthLoading: false,
-        isConvexAuthenticated: false,
-        isWorkOsLoading: false,
-        hasWorkOsUser: false,
-        workOsUserEmail: null,
-      }),
-    ).toBe("ready");
-  });
-
-  it("does not apply the employee-domain restriction inside the Preview embed", () => {
-    expect(
-      resolveHostedShellGateState({
-        hostedMode: true,
-        nonProdLockdown: true,
-        embeddedPreview: true,
-        isConvexAuthLoading: false,
-        isConvexAuthenticated: true,
-        isWorkOsLoading: false,
-        hasWorkOsUser: true,
-        workOsUserEmail: "contractor@example.com",
-      }),
-    ).toBe("ready");
-  });
-
-  it("blocks authenticated users outside employee domains", () => {
-    expect(
-      resolveHostedShellGateState({
-        hostedMode: true,
-        nonProdLockdown: true,
-        isConvexAuthLoading: false,
-        isConvexAuthenticated: true,
-        isWorkOsLoading: false,
-        hasWorkOsUser: true,
-        workOsUserEmail: "contractor@example.com",
-      }),
-    ).toBe("restricted");
   });
 });

--- a/mcpjam-inspector/client/src/components/hosted/hosted-shell-gate-state.ts
+++ b/mcpjam-inspector/client/src/components/hosted/hosted-shell-gate-state.ts
@@ -1,39 +1,19 @@
 import type { HostedShellGateState } from "./HostedShellGate";
-import { isAllowedEmployeeEmail } from "@/lib/config";
 
 interface ResolveHostedShellGateStateOptions {
   hostedMode: boolean;
-  nonProdLockdown: boolean;
-  /**
-   * The app is mounted as the Scenarios/User Testing Preview embed
-   * (`isEmbeddedPreview()`), i.e. the author's own same-origin frame inside a
-   * dashboard that already cleared this gate.
-   *
-   * The lockdown gate is skipped there, and skipping it is the only correct
-   * outcome: the gate's Sign in button navigates the FRAME to WorkOS and
-   * returns to `/oauth/callback`, a path the `main.tsx` self-embed exemption
-   * deliberately does not cover, so the frame lands on `IframeRouterError`.
-   * A gate the author cannot pass is a wall, not a gate — the preview renders
-   * as the signed-in author, or the runtime reports why it can't; it never
-   * asks them to sign in. The dashboard around it stays gated as before.
-   */
-  embeddedPreview?: boolean;
   isConvexAuthLoading: boolean;
   isConvexAuthenticated: boolean;
   isWorkOsLoading: boolean;
   hasWorkOsUser: boolean;
-  workOsUserEmail?: string | null;
 }
 
 export function resolveHostedShellGateState({
   hostedMode,
-  nonProdLockdown,
-  embeddedPreview = false,
   isConvexAuthLoading,
   isConvexAuthenticated,
   isWorkOsLoading,
   hasWorkOsUser,
-  workOsUserEmail,
 }: ResolveHostedShellGateStateOptions): HostedShellGateState {
   if (!hostedMode) {
     return "ready";
@@ -45,20 +25,6 @@ export function resolveHostedShellGateState({
     (hasWorkOsUser && !isConvexAuthenticated);
   if (isAuthSettling) {
     return "auth-loading";
-  }
-
-  if (nonProdLockdown && !embeddedPreview) {
-    if (!hasWorkOsUser || !isConvexAuthenticated) {
-      return "logged-out";
-    }
-
-    if (!isAllowedEmployeeEmail(workOsUserEmail)) {
-      return "restricted";
-    }
-  }
-
-  if (!hasWorkOsUser && !isConvexAuthenticated) {
-    return "ready";
   }
 
   return "ready";

--- a/mcpjam-inspector/client/src/hooks/__tests__/use-chat-session.local-engine.test.tsx
+++ b/mcpjam-inspector/client/src/hooks/__tests__/use-chat-session.local-engine.test.tsx
@@ -73,7 +73,6 @@ vi.mock("@/state/oauth-orchestrator", () => ({
 }));
 vi.mock("@/lib/config", () => ({
   HOSTED_MODE: false,
-  NON_PROD_LOCKDOWN: false,
 }));
 vi.mock("@/components/chat-v2/shared/model-helpers", () => ({
   buildAvailableModels: vi.fn(() => [byokModel]),

--- a/mcpjam-inspector/client/src/lib/config.ts
+++ b/mcpjam-inspector/client/src/lib/config.ts
@@ -51,32 +51,6 @@ export const SANDBOX_ORIGIN: string | null = (() => {
   }
 })();
 
-export const NON_PROD_LOCKDOWN =
-  import.meta.env.VITE_MCPJAM_NONPROD_LOCKDOWN === "true";
-
-export const EMPLOYEE_EMAIL_DOMAINS = (
-  import.meta.env.VITE_MCPJAM_EMPLOYEE_EMAIL_DOMAINS ?? ""
-)
-  .split(",")
-  .map((domain) => domain.trim().toLowerCase())
-  .filter((domain) => domain.length > 0);
-
-export function isAllowedEmployeeEmail(
-  email: string | null | undefined,
-): boolean {
-  if (!email || EMPLOYEE_EMAIL_DOMAINS.length === 0) {
-    return false;
-  }
-
-  const normalizedEmail = email.trim().toLowerCase();
-  const atIndex = normalizedEmail.lastIndexOf("@");
-  if (atIndex === -1) {
-    return false;
-  }
-
-  return EMPLOYEE_EMAIL_DOMAINS.includes(normalizedEmail.slice(atIndex + 1));
-}
-
 /**
  * The Discord application the agent bot runs as, used to build the "add to
  * server" URL on the Integrations page.

--- a/mcpjam-inspector/client/src/lib/guest-session.ts
+++ b/mcpjam-inspector/client/src/lib/guest-session.ts
@@ -12,7 +12,6 @@
  * transient failures do not strand old guests on a new identity.
  */
 
-import { NON_PROD_LOCKDOWN } from "@/lib/config";
 
 declare global {
   interface Window {
@@ -195,13 +194,6 @@ async function requestGuestSession(
   mode: GuestSessionMode,
   legacyToken: string | null,
 ): Promise<GuestSession | null> {
-  // Non-prod lockdown disables guest sessions server-side (returns 403). Skip
-  // the network call entirely so the console isn't flooded with errors and
-  // callers settle quickly into the unauthenticated state.
-  if (NON_PROD_LOCKDOWN) {
-    return null;
-  }
-
   const body: Record<string, unknown> = { mode };
   if (legacyToken) body.legacyToken = legacyToken;
 

--- a/mcpjam-inspector/client/src/lib/unified-convex-auth.ts
+++ b/mcpjam-inspector/client/src/lib/unified-convex-auth.ts
@@ -1,6 +1,5 @@
 import { useEffect, useMemo, useState } from "react";
 import { useAuth as useWorkOSAuth } from "@workos-inc/authkit-react";
-import { NON_PROD_LOCKDOWN } from "@/lib/config";
 import {
   forceRefreshGuestSession,
   getCachedGuestSession,
@@ -63,14 +62,6 @@ export function useUnifiedConvexAuth() {
       setGuestLoading(false);
       return;
     }
-    // Non-prod lockdown blocks guest sessions: the gate will show "logged-out"
-    // and any retry would just spam 403s. Settle as unauthenticated immediately.
-    if (NON_PROD_LOCKDOWN) {
-      setGuestToken(null);
-      setGuestLoading(false);
-      return;
-    }
-
     let cancelled = false;
     // Only flip to loading if we have no cached token; if we do, the async
     // call will resolve immediately and setting true→false would cause the

--- a/mcpjam-inspector/client/src/vite-env.d.ts
+++ b/mcpjam-inspector/client/src/vite-env.d.ts
@@ -5,8 +5,6 @@ interface ImportMetaEnv {
   readonly VITE_DOCKER?: string;
   readonly VITE_RUNTIME?: string;
   readonly VITE_MCPJAM_HOSTED_MODE?: string;
-  readonly VITE_MCPJAM_NONPROD_LOCKDOWN?: string;
-  readonly VITE_MCPJAM_EMPLOYEE_EMAIL_DOMAINS?: string;
   readonly VITE_MCPJAM_SANDBOX_ORIGIN?: string;
   readonly VITE_ENVIRONMENT?: string;
   // more env variables...

--- a/mcpjam-inspector/e2e/caniuse-table-fills-viewport.spec.ts
+++ b/mcpjam-inspector/e2e/caniuse-table-fills-viewport.spec.ts
@@ -64,18 +64,15 @@ test("caniuse compare table fills the viewport and keeps its header pinned", asy
     ).toBe(true);
   }).toPass({ timeout: 30_000 });
 
-  // Everything below drives real pointer input, which a signed-out hosted
-  // deployment will not accept. `HostedShellGate` (App.tsx) wraps the whole
-  // app, and under `MCPJAM_NONPROD_LOCKDOWN` — which staging runs with — a
-  // signed-out visitor gets an overlay plus `inert` + `pointer-events-none`
-  // on the content. `scroller.hover()` then never resolves: Playwright's
-  // actionability check keeps landing on the gate's Sign in button and
-  // retries until the enclosing `toPass` gives up, which surfaces as a bare
-  // "Timeout exceeded while waiting on the predicate" with no assertion
-  // behind it. The geometry above is unaffected (the gate changes input, not
-  // layout) and still measures the real deployed table, so only this half is
-  // skipped. The un-gated local build in the `Tests` workflow runs it in
-  // full. Same reasoning as nux.spec.ts's hosted-auth skip.
+  // Everything below drives real pointer input, which `HostedShellGate`
+  // (App.tsx) blocks whenever it is showing an overlay: the content gets
+  // `inert` + `pointer-events-none`, so `scroller.hover()` never resolves and
+  // the enclosing `toPass` dies with a bare "Timeout exceeded while waiting on
+  // the predicate" and no assertion behind it. The signed-out lockdown gate
+  // that used to make this permanent on staging is gone; what remains is the
+  // transient project-loading overlay on a slow cold load. The geometry above
+  // is unaffected (the gate changes input, not layout) and still measures the
+  // real deployed table, so only this half is skipped when we catch one.
   //
   // Only paid against a deployed target; a local build is never hosted.
   const gated =
@@ -89,7 +86,7 @@ test("caniuse compare table fills the viewport and keeps its header pinned", asy
       ));
   test.skip(
     gated,
-    "signed-out hosted lockdown makes the page inert; pointer-driven scrolling can't be exercised there"
+    "a hosted shell overlay makes the page inert; pointer-driven scrolling can't be exercised there"
   );
 
   // The header row stays at a fixed spot in the viewport across a real,

--- a/mcpjam-inspector/server/app.ts
+++ b/mcpjam-inspector/server/app.ts
@@ -543,14 +543,13 @@ export async function createHonoApp() {
 
         // Guest bootstrap blob: mint a guest bearer server-side and inject it
         // so a cold guest boots with a token already in hand. Gated on
-        // production + hosted + not locked-down + a host allowlist that
-        // includes the hosted app host(s) (mayServeGuestBootstrap), mirroring
-        // the session-token discipline. Wrapped in its own try/catch so a
-        // mint failure never 500s the document.
+        // production + hosted + a host allowlist that includes the hosted app
+        // host(s) (mayServeGuestBootstrap), mirroring the session-token
+        // discipline. Wrapped in its own try/catch so a mint failure never
+        // 500s the document.
         if (
           process.env.NODE_ENV === "production" &&
           HOSTED_MODE &&
-          process.env.MCPJAM_NONPROD_LOCKDOWN !== "true" &&
           mayServeGuestBootstrap({
             host,
             forwardedHost,

--- a/mcpjam-inspector/server/config.ts
+++ b/mcpjam-inspector/server/config.ts
@@ -43,8 +43,6 @@ export const LOCAL_COMPUTER_ENABLED =
 export const WEBMCP_INSPECTOR_ENABLED =
   !HOSTED_MODE && process.env.MCPJAM_WEBMCP_INSPECTOR_ENABLED !== "false";
 
-export const NON_PROD_LOCKDOWN = process.env.MCPJAM_NONPROD_LOCKDOWN === "true";
-
 /**
  * Feed model-visible widget→host tool calls (recorded by Interact steps) to the
  * eval model as a per-turn system-prompt addendum, so the model reasons over a
@@ -56,30 +54,6 @@ export const NON_PROD_LOCKDOWN = process.env.MCPJAM_NONPROD_LOCKDOWN === "true";
  */
 export const EVAL_WIDGET_MODEL_CONTEXT =
   process.env.MCPJAM_EVAL_WIDGET_MODEL_CONTEXT === "true";
-
-export const EMPLOYEE_EMAIL_DOMAINS = (
-  process.env.MCPJAM_EMPLOYEE_EMAIL_DOMAINS ?? ""
-)
-  .split(",")
-  .map((domain) => domain.trim().toLowerCase())
-  .filter((domain) => domain.length > 0);
-
-export function isAllowedEmployeeEmail(
-  email: string | null | undefined
-): boolean {
-  if (!email || EMPLOYEE_EMAIL_DOMAINS.length === 0) {
-    return false;
-  }
-
-  const normalizedEmail = email.trim().toLowerCase();
-  const atIndex = normalizedEmail.lastIndexOf("@");
-  if (atIndex === -1) {
-    return false;
-  }
-
-  const emailDomain = normalizedEmail.slice(atIndex + 1);
-  return EMPLOYEE_EMAIL_DOMAINS.includes(emailDomain);
-}
 
 // Exact origins allowed for hosted web routes and CORS
 export const WEB_ALLOWED_ORIGINS = (process.env.WEB_ALLOWED_ORIGINS ?? "")

--- a/mcpjam-inspector/server/index.ts
+++ b/mcpjam-inspector/server/index.ts
@@ -765,8 +765,8 @@ if (process.env.NODE_ENV === "production") {
 
       // Guest bootstrap blob: mint a guest bearer server-side and inject it so
       // a cold guest boots with a token already in hand (no render-blocking
-      // POST /api/web/guest-session). Gated on production + hosted + not
-      // locked-down + a host allowlist that includes the hosted app host(s)
+      // POST /api/web/guest-session). Gated on production + hosted + a host
+      // allowlist that includes the hosted app host(s)
       // (mayServeGuestBootstrap), mirroring the session-token discipline.
       //
       // Wrapped in its OWN try/catch so a mint failure never 500s the
@@ -775,7 +775,6 @@ if (process.env.NODE_ENV === "production") {
       if (
         process.env.NODE_ENV === "production" &&
         HOSTED_MODE &&
-        process.env.MCPJAM_NONPROD_LOCKDOWN !== "true" &&
         mayServeGuestBootstrap({
           host,
           forwardedHost,

--- a/mcpjam-inspector/server/middleware/__tests__/origin-validation.test.ts
+++ b/mcpjam-inspector/server/middleware/__tests__/origin-validation.test.ts
@@ -30,13 +30,13 @@ function createTestApp(): Hono {
 describe("originValidationMiddleware", () => {
   let app: Hono;
   const originalAllowedOrigins = process.env.ALLOWED_ORIGINS;
-  const originalNonprodLockdown = process.env.MCPJAM_NONPROD_LOCKDOWN;
+  const originalAllowWildcardOrigins = process.env.MCPJAM_ALLOW_WILDCARD_ORIGINS;
 
   beforeEach(() => {
     app = createTestApp();
     // Clear any custom allowed origins
     delete process.env.ALLOWED_ORIGINS;
-    delete process.env.MCPJAM_NONPROD_LOCKDOWN;
+    delete process.env.MCPJAM_ALLOW_WILDCARD_ORIGINS;
   });
 
   afterEach(() => {
@@ -46,10 +46,10 @@ describe("originValidationMiddleware", () => {
     } else {
       delete process.env.ALLOWED_ORIGINS;
     }
-    if (originalNonprodLockdown) {
-      process.env.MCPJAM_NONPROD_LOCKDOWN = originalNonprodLockdown;
+    if (originalAllowWildcardOrigins) {
+      process.env.MCPJAM_ALLOW_WILDCARD_ORIGINS = originalAllowWildcardOrigins;
     } else {
-      delete process.env.MCPJAM_NONPROD_LOCKDOWN;
+      delete process.env.MCPJAM_ALLOW_WILDCARD_ORIGINS;
     }
   });
 
@@ -240,7 +240,7 @@ describe("originValidationMiddleware", () => {
     it("supports wildcard origins like https://*.up.railway.app", async () => {
       process.env.ALLOWED_ORIGINS =
         "https://*.up.railway.app,https://staging.mcpjam.com";
-      process.env.MCPJAM_NONPROD_LOCKDOWN = "true";
+      process.env.MCPJAM_ALLOW_WILDCARD_ORIGINS = "true";
 
       app = createTestApp();
 
@@ -258,7 +258,7 @@ describe("originValidationMiddleware", () => {
       // origin validation.
       process.env.ALLOWED_ORIGINS =
         "https://staging.mcpjam.com,https://mcp-inspector-pr-*.up.railway.app";
-      process.env.MCPJAM_NONPROD_LOCKDOWN = "true";
+      process.env.MCPJAM_ALLOW_WILDCARD_ORIGINS = "true";
 
       app = createTestApp();
 
@@ -285,7 +285,7 @@ describe("originValidationMiddleware", () => {
 
     it("blocks origins that don't match wildcard pattern", async () => {
       process.env.ALLOWED_ORIGINS = "https://*.up.railway.app";
-      process.env.MCPJAM_NONPROD_LOCKDOWN = "true";
+      process.env.MCPJAM_ALLOW_WILDCARD_ORIGINS = "true";
 
       app = createTestApp();
 
@@ -297,7 +297,7 @@ describe("originValidationMiddleware", () => {
 
     it("rejects wildcard origin when scheme mismatches (http vs https)", async () => {
       process.env.ALLOWED_ORIGINS = "https://*.up.railway.app";
-      process.env.MCPJAM_NONPROD_LOCKDOWN = "true";
+      process.env.MCPJAM_ALLOW_WILDCARD_ORIGINS = "true";
 
       app = createTestApp();
 
@@ -310,7 +310,7 @@ describe("originValidationMiddleware", () => {
     it("strips wildcard origins outside non-prod lockdown", async () => {
       process.env.ALLOWED_ORIGINS =
         "https://*.up.railway.app,https://staging.mcpjam.com";
-      // MCPJAM_NONPROD_LOCKDOWN is not set — simulates production
+      // MCPJAM_ALLOW_WILDCARD_ORIGINS is not set — simulates production
 
       app = createTestApp();
 

--- a/mcpjam-inspector/server/middleware/bearer-auth.ts
+++ b/mcpjam-inspector/server/middleware/bearer-auth.ts
@@ -310,15 +310,6 @@ export async function bearerAuthMiddleware(
   try {
     const result = await validateGuestTokenDetailedAsync(token);
     if (result.valid && result.guestId) {
-      if (process.env.MCPJAM_NONPROD_LOCKDOWN === "true") {
-        return c.json(
-          {
-            code: ErrorCode.FORBIDDEN,
-            message: "Guest access is disabled in this environment.",
-          },
-          403
-        );
-      }
       c.set("guestId", result.guestId);
       c.set("authMethod", "guest");
       return next();

--- a/mcpjam-inspector/server/middleware/origin-validation.ts
+++ b/mcpjam-inspector/server/middleware/origin-validation.ts
@@ -21,14 +21,16 @@ function getAllowedOrigins(): string[] {
   if (process.env.ALLOWED_ORIGINS) {
     const origins = process.env.ALLOWED_ORIGINS.split(",").map((o) => o.trim());
 
-    // Wildcard origins (e.g. https://*.up.railway.app) are only safe behind
-    // non-prod lockdown.  Reject them in production to prevent accidental
-    // misconfiguration from weakening origin checks.
-    if (process.env.MCPJAM_NONPROD_LOCKDOWN !== "true") {
+    // Wildcard origins (e.g. https://*.up.railway.app) are only safe in
+    // non-production environments that deliberately opt in via
+    // MCPJAM_ALLOW_WILDCARD_ORIGINS (staging and PR previews, which need to
+    // accept each other's ephemeral Railway hostnames). Reject them anywhere
+    // else so a misconfiguration cannot weaken origin checks in production.
+    if (process.env.MCPJAM_ALLOW_WILDCARD_ORIGINS !== "true") {
       const wildcards = origins.filter((o) => o.includes("*"));
       if (wildcards.length > 0) {
         appLogger.warn(
-          `[Security] Wildcard ALLOWED_ORIGINS rejected outside non-prod lockdown: ${wildcards.join(", ")}`,
+          `[Security] Wildcard ALLOWED_ORIGINS rejected without MCPJAM_ALLOW_WILDCARD_ORIGINS=true: ${wildcards.join(", ")}`,
         );
         return origins.filter((o) => !o.includes("*"));
       }

--- a/mcpjam-inspector/server/routes/web/__tests__/guest-session-diagnosability.test.ts
+++ b/mcpjam-inspector/server/routes/web/__tests__/guest-session-diagnosability.test.ts
@@ -31,7 +31,6 @@ describe("guest-session 5xx diagnosability", () => {
       "test-guest-session-secret";
     delete process.env.MCPJAM_GUEST_SESSION_URL;
     delete process.env.VITE_MCPJAM_HOSTED_MODE;
-    delete process.env.MCPJAM_NONPROD_LOCKDOWN;
     // The upstream is down: this is the shape that produced the 07-22 rows.
     global.fetch = vi
       .fn()

--- a/mcpjam-inspector/server/routes/web/__tests__/guest-session-document.test.ts
+++ b/mcpjam-inspector/server/routes/web/__tests__/guest-session-document.test.ts
@@ -57,7 +57,6 @@ async function buildDocumentApp() {
 
     if (
       process.env.NODE_ENV === "production" &&
-      process.env.MCPJAM_NONPROD_LOCKDOWN !== "true" &&
       mayServeGuestBootstrap({
         host,
         forwardedHost,
@@ -103,22 +102,18 @@ function get(
 
 describe("guest-session document bootstrap", () => {
   const originalNodeEnv = process.env.NODE_ENV;
-  const originalLockdown = process.env.MCPJAM_NONPROD_LOCKDOWN;
   const originalHosted = process.env.VITE_MCPJAM_HOSTED_MODE;
 
   beforeEach(() => {
     vi.resetModules();
     vi.clearAllMocks();
     process.env.NODE_ENV = "production";
-    delete process.env.MCPJAM_NONPROD_LOCKDOWN;
     // Force the Convex source branch (shouldFetchGuestSessionFromConvex()).
     process.env.VITE_MCPJAM_HOSTED_MODE = "true";
   });
 
   afterEach(() => {
     process.env.NODE_ENV = originalNodeEnv;
-    if (originalLockdown === undefined) delete process.env.MCPJAM_NONPROD_LOCKDOWN;
-    else process.env.MCPJAM_NONPROD_LOCKDOWN = originalLockdown;
     if (originalHosted === undefined) delete process.env.VITE_MCPJAM_HOSTED_MODE;
     else process.env.VITE_MCPJAM_HOSTED_MODE = originalHosted;
   });
@@ -189,23 +184,6 @@ describe("guest-session document bootstrap", () => {
     });
     const body = await res.text();
 
-    expect(body).not.toContain("__MCP_GUEST_BOOTSTRAP__");
-    expect(mockFetchConvexGuestSession).not.toHaveBeenCalled();
-  });
-
-  it("injects nothing under lockdown (no-op)", async () => {
-    process.env.MCPJAM_NONPROD_LOCKDOWN = "true";
-    mockFetchConvexGuestSession.mockResolvedValue({
-      kind: "session",
-      session: { guestId: "g", token: "t", expiresAt: Date.now() + 60_000 },
-      setCookies: [],
-    });
-
-    const app = await buildDocumentApp();
-    const res = await get(app);
-    const body = await res.text();
-
-    expect(res.status).toBe(200);
     expect(body).not.toContain("__MCP_GUEST_BOOTSTRAP__");
     expect(mockFetchConvexGuestSession).not.toHaveBeenCalled();
   });

--- a/mcpjam-inspector/server/routes/web/__tests__/guest-session.test.ts
+++ b/mcpjam-inspector/server/routes/web/__tests__/guest-session.test.ts
@@ -7,7 +7,6 @@ const ORIGINAL_CONVEX_HTTP_URL = process.env.CONVEX_HTTP_URL;
 const ORIGINAL_REMOTE_URL = process.env.MCPJAM_GUEST_SESSION_URL;
 const ORIGINAL_SHARED_SECRET = process.env.MCPJAM_GUEST_SESSION_SHARED_SECRET;
 const ORIGINAL_HOSTED_MODE = process.env.VITE_MCPJAM_HOSTED_MODE;
-const ORIGINAL_NON_PROD_LOCKDOWN = process.env.MCPJAM_NONPROD_LOCKDOWN;
 const ORIGINAL_FETCH = global.fetch;
 
 const SAMPLE_COOKIE =
@@ -30,7 +29,6 @@ describe("POST /guest-session", () => {
     process.env.CONVEX_HTTP_URL = "https://test-deployment.convex.site";
     delete process.env.MCPJAM_GUEST_SESSION_URL;
     delete process.env.VITE_MCPJAM_HOSTED_MODE;
-    delete process.env.MCPJAM_NONPROD_LOCKDOWN;
     process.env.MCPJAM_GUEST_SESSION_SHARED_SECRET =
       "test-guest-session-secret";
     global.fetch = vi.fn().mockImplementation(async () => {
@@ -69,11 +67,6 @@ describe("POST /guest-session", () => {
       delete process.env.VITE_MCPJAM_HOSTED_MODE;
     } else {
       process.env.VITE_MCPJAM_HOSTED_MODE = ORIGINAL_HOSTED_MODE;
-    }
-    if (ORIGINAL_NON_PROD_LOCKDOWN === undefined) {
-      delete process.env.MCPJAM_NONPROD_LOCKDOWN;
-    } else {
-      process.env.MCPJAM_NONPROD_LOCKDOWN = ORIGINAL_NON_PROD_LOCKDOWN;
     }
     if (ORIGINAL_SHARED_SECRET === undefined) {
       delete process.env.MCPJAM_GUEST_SESSION_SHARED_SECRET;
@@ -336,17 +329,6 @@ describe("POST /guest-session", () => {
     expect(setCookie).toContain(
       "mcpjam_guest_session=; HttpOnly; SameSite=Lax; Path=/; Max-Age=0",
     );
-  });
-
-  it("returns 403 when non-prod lockdown is enabled", async () => {
-    process.env.MCPJAM_NONPROD_LOCKDOWN = "true";
-
-    const res = await app.request("/guest-session", { method: "POST" });
-
-    expect(res.status).toBe(403);
-    await expect(res.json()).resolves.toMatchObject({
-      code: "FORBIDDEN",
-    });
   });
 
   describe("HTTP method handling", () => {

--- a/mcpjam-inspector/server/routes/web/__tests__/guest-token.test.ts
+++ b/mcpjam-inspector/server/routes/web/__tests__/guest-token.test.ts
@@ -44,14 +44,12 @@ function mint(
 
 describe("POST /api/web/guest-token", () => {
   const originalServiceToken = process.env.INSPECTOR_SERVICE_TOKEN;
-  const originalLockdown = process.env.MCPJAM_NONPROD_LOCKDOWN;
   const originalNodeEnv = process.env.NODE_ENV;
   const originalAllowLocalDev = process.env.ALLOW_LOCAL_DEV_SERVICE_TOKEN;
 
   beforeEach(() => {
     vi.clearAllMocks();
     process.env.INSPECTOR_SERVICE_TOKEN = SERVICE_TOKEN;
-    delete process.env.MCPJAM_NONPROD_LOCKDOWN;
     delete process.env.ALLOW_LOCAL_DEV_SERVICE_TOKEN;
     fetchConvexGuestSessionMock.mockResolvedValue({
       kind: "session",
@@ -65,11 +63,6 @@ describe("POST /api/web/guest-token", () => {
       delete process.env.INSPECTOR_SERVICE_TOKEN;
     } else {
       process.env.INSPECTOR_SERVICE_TOKEN = originalServiceToken;
-    }
-    if (originalLockdown === undefined) {
-      delete process.env.MCPJAM_NONPROD_LOCKDOWN;
-    } else {
-      process.env.MCPJAM_NONPROD_LOCKDOWN = originalLockdown;
     }
     if (originalNodeEnv === undefined) {
       delete process.env.NODE_ENV;
@@ -95,16 +88,6 @@ describe("POST /api/web/guest-token", () => {
       "x-mcpjam-client-ip": "1.1.1.2",
     });
     expect(res.status).toBe(401);
-    expect(fetchConvexGuestSessionMock).not.toHaveBeenCalled();
-  });
-
-  it("returns 403 when guest access is locked down", async () => {
-    process.env.MCPJAM_NONPROD_LOCKDOWN = "true";
-    const res = await mint(makeApp(), {
-      "x-inspector-service-token": SERVICE_TOKEN,
-      "x-mcpjam-client-ip": "1.1.1.3",
-    });
-    expect(res.status).toBe(403);
     expect(fetchConvexGuestSessionMock).not.toHaveBeenCalled();
   });
 

--- a/mcpjam-inspector/server/routes/web/guest-session.ts
+++ b/mcpjam-inspector/server/routes/web/guest-session.ts
@@ -61,16 +61,6 @@ function parseRequestBody(raw: unknown): GuestSessionRequestBody {
  * Rate limited to 10 requests per minute per IP.
  */
 guestSession.post("/", async (c) => {
-  if (process.env.MCPJAM_NONPROD_LOCKDOWN === "true") {
-    return c.json(
-      {
-        code: ErrorCode.FORBIDDEN,
-        message: "Guest access is disabled in this environment.",
-      },
-      403
-    );
-  }
-
   const ip = getClientIp(c);
   if (!ip && process.env.NODE_ENV === "production") {
     return c.json(
@@ -185,16 +175,6 @@ function buildExpiredGuestSessionCookie(): string {
 }
 
 guestSession.post("/revoke", async (c) => {
-  if (process.env.MCPJAM_NONPROD_LOCKDOWN === "true") {
-    return c.json(
-      {
-        code: ErrorCode.FORBIDDEN,
-        message: "Guest access is disabled in this environment.",
-      },
-      403
-    );
-  }
-
   const context: GuestSessionFetchContext = {
     cookie: extractGuestSessionCookie(c.req.header("cookie")),
     userAgent: c.req.header("user-agent") ?? null,
@@ -249,16 +229,6 @@ guestSession.post("/revoke", async (c) => {
  * route so a stolen secret cannot be used to flood the upstream.
  */
 guestSession.post("/promotion-proof", async (c) => {
-  if (process.env.MCPJAM_NONPROD_LOCKDOWN === "true") {
-    return c.json(
-      {
-        code: ErrorCode.FORBIDDEN,
-        message: "Guest access is disabled in this environment.",
-      },
-      403
-    );
-  }
-
   const ip = getClientIp(c);
   if (!ip && process.env.NODE_ENV === "production") {
     return c.json(

--- a/mcpjam-inspector/server/routes/web/guest-token.ts
+++ b/mcpjam-inspector/server/routes/web/guest-token.ts
@@ -127,15 +127,6 @@ guestToken.post("/", async (c) => {
     return webError(c, 401, ErrorCode.UNAUTHORIZED, "Invalid service token");
   }
 
-  if (process.env.MCPJAM_NONPROD_LOCKDOWN === "true") {
-    return webError(
-      c,
-      403,
-      ErrorCode.FORBIDDEN,
-      "Guest access is disabled in this environment."
-    );
-  }
-
   const ip = c.req.header("x-mcpjam-client-ip")?.trim() || "unknown";
   if (!allowMint(ip)) {
     return webError(


### PR DESCRIPTION
## What

Deletes the `MCPJAM_NONPROD_LOCKDOWN` gate from the inspector, client and server.

## Why

The staging "employee-only" gate was **client-side only**. `MCPJAM_NONPROD_LOCKDOWN` was never set on the staging Railway service — only its `VITE_` twin — so the blur overlay was the entire control:

```
$ curl -s -X POST https://staging.mcpjam.com/api/web/guest-session -d '{}'
{"guestId":"a676ab5a-...","token":"eyJhbGciOiJSUzI1NiIs..."}   # HTTP 200
```

That endpoint 403s whenever the server-side flag is on, so the 200 proves it is off. A gate that stops the UI and not the API is worse than no gate, because it reads as protection in code review and in the browser.

Access control for staging moves to **Cloudflare Access** in front of the Railway service, where it applies to every request rather than the ones the SPA happens to render. Staging already holds no production data — separate Convex deployment and a separate WorkOS tenant — which is the control that was actually doing the work.

## Removed

- `HostedShellGate`'s `logged-out` and `restricted` states, their sign-in / sign-out affordances, and the `nonProdLockdown` / `embeddedPreview` / `workOsUserEmail` inputs to `resolveHostedShellGateState`. What remains is the loading overlay the pending-OAuth flow uses.
- The six server branches that 403'd guest access or withheld the guest bootstrap blob under the flag (`guest-session.ts` ×3, `guest-token.ts`, `bearer-auth.ts`, and the document gate in `app.ts` + `index.ts`).
- `EMPLOYEE_EMAIL_DOMAINS` / `isAllowedEmployeeEmail` on both sides. The gate was their only reader in this repo; the backend's copy is separate and untouched.
- The lockdown and employee-domain writes in `pr-preview.yml` (three blocks).

## Kept, on its own flag — and a bug fix

`origin-validation.ts` keeps its wildcard guard, but wildcard `ALLOWED_ORIGINS` entries are now authorized by `MCPJAM_ALLOW_WILDCARD_ORIGINS` instead of by lockdown.

This fixes a live bug. `deploy-staging.yml` writes `ALLOWED_ORIGINS=...,https://mcp-inspector-pr-*.up.railway.app`, and its comment claims "staging satisfies `MCPJAM_NONPROD_LOCKDOWN=true`". Staging does not — so `getAllowedOrigins()` has been silently stripping that wildcard on every boot and rejecting preview→staging cross-origin calls. The workflow now sets the new flag explicitly.

## Follow-ups (not in this PR)

1. Delete `VITE_MCPJAM_NONPROD_LOCKDOWN` and the employee-domain vars from the Railway staging service (preview envs duplicate from staging).
2. Cloudflare Access app for `staging.mcpjam.com`: Allow `@mcpjam.com`, plus a Service Auth policy for a service token.
3. Wire `CF-Access-Client-Id` / `CF-Access-Client-Secret` into `post-deploy-smoke.yml`'s curls and Playwright's `extraHTTPHeaders` **before** enabling the policy — Access would otherwise 302 every smoke check.
4. `X-Robots-Tag: noindex, nofollow` transform rule on the staging hostname; there is nothing today.

## Test

- `npm test` — 1490 files / 18,952 tests passed, 4 files skipped, exit 0.
- `npm run typecheck:client` — clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Removes in-app staging access controls and re-enables guest APIs on non-prod; staging protection is expected to move to edge (Cloudflare Access), which is not in this diff.
> 
> **Overview**
> Removes the **`MCPJAM_NONPROD_LOCKDOWN`** / employee-email gate from the inspector SPA and server. **`HostedShellGate`** no longer shows sign-in or “employees only” overlays—only auth-settling and project-loading spinners remain—and guest session minting, bootstrap injection, and bearer auth no longer 403 when that flag was set.
> 
> **Origin validation** now honors wildcard `ALLOWED_ORIGINS` only when **`MCPJAM_ALLOW_WILDCARD_ORIGINS=true`**, replacing the old tie to lockdown. **`deploy-staging.yml`** and **`pr-preview.yml`** set that flag explicitly so PR previews can call staging APIs (previously the wildcard was stripped on every staging boot because lockdown was never set server-side).
> 
> CI drops lockdown and employee-domain Railway vars; client/server **`EMPLOYEE_EMAIL_DOMAINS`** helpers and related tests are deleted. E2E comments are updated to reflect that staging is no longer permanently blocked when signed out.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0d4c5f4d268958b999b894e3b476ef30f64023f8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removes the `MCPJAM_NONPROD_LOCKDOWN` gate from the client and server. The gate only blurred the staging UI — the API still served guest sessions — so it read as protection without providing any. Staging access now moves to Cloudflare Access at the edge.

Wildcard origin support moves to `MCPJAM_ALLOW_WILDCARD_ORIGINS`, and setting it in `deploy-staging.yml` fixes a live bug: the preview wildcard was stripped on every boot because the old flag was never actually set, so preview→staging calls were rejected.

**Migration**
- Configure Cloudflare Access for staging with `@mcpjam.com` employees and a service token before enabling the policy.
- Wire `CF-Access-Client-Id` and `CF-Access-Client-Secret` into smoke test curls and Playwright headers, or smoke checks will 302.
- Delete the `VITE_` lockdown and employee-domain vars from the staging Railway service.

<sup>Written for commit 0d4c5f4d268958b999b894e3b476ef30f64023f8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/MCPJam/inspector/pull/4449?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

