### PR TITLE
Carry a Cloudflare Access service token through the staging smoke lane

### DIFF
--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -137,3 +137,6 @@ jobs:
   smoke:
     needs: deploy
     uses: ./.github/workflows/post-deploy-smoke.yml
+    secrets:
+      CF_ACCESS_CLIENT_ID: ${{ secrets.CF_ACCESS_CLIENT_ID }}
+      CF_ACCESS_CLIENT_SECRET: ${{ secrets.CF_ACCESS_CLIENT_SECRET }}

--- a/.github/workflows/post-deploy-smoke.yml
+++ b/.github/workflows/post-deploy-smoke.yml
@@ -26,6 +26,16 @@ on:
         required: false
         default: true
         type: boolean
+    secrets:
+      # Cloudflare Access service token. staging.mcpjam.com sits behind an
+      # Access policy, so every request below has to present one or Access
+      # answers with its own 302 to the login page and the smoke reads as a
+      # deploy failure. Optional: targets that are not behind Access (prod)
+      # simply omit them, and the steps skip the headers.
+      CF_ACCESS_CLIENT_ID:
+        required: false
+      CF_ACCESS_CLIENT_SECRET:
+        required: false
   workflow_dispatch:
     inputs:
       base_url:
@@ -65,22 +75,44 @@ jobs:
           fi
           echo "base_url=$BASE_URL" >> "$GITHUB_OUTPUT"
 
+      # `CF_ARGS` is built as an array and expanded unquoted-per-element so an
+      # absent token yields NO header flags at all, rather than two empty
+      # headers that Access would reject as malformed.
       - name: Check public health endpoints
         env:
           BASE_URL: ${{ steps.target.outputs.base_url }}
+          CF_ACCESS_CLIENT_ID: ${{ secrets.CF_ACCESS_CLIENT_ID }}
+          CF_ACCESS_CLIENT_SECRET: ${{ secrets.CF_ACCESS_CLIENT_SECRET }}
         shell: bash
         run: |
-          curl --fail --silent --show-error "$BASE_URL/health" >/tmp/health.json
-          curl --fail --silent --show-error "$BASE_URL/api/mcp/health" >/tmp/mcp-health.json
-          curl --fail --silent --show-error "$BASE_URL/api/apps/health" >/tmp/apps-health.json
+          CF_ARGS=()
+          if [ -n "$CF_ACCESS_CLIENT_ID" ] && [ -n "$CF_ACCESS_CLIENT_SECRET" ]; then
+            CF_ARGS=(-H "CF-Access-Client-Id: $CF_ACCESS_CLIENT_ID" \
+                     -H "CF-Access-Client-Secret: $CF_ACCESS_CLIENT_SECRET")
+          fi
+          curl --fail --silent --show-error "${CF_ARGS[@]}" "$BASE_URL/health" >/tmp/health.json
+          curl --fail --silent --show-error "${CF_ARGS[@]}" "$BASE_URL/api/mcp/health" >/tmp/mcp-health.json
+          curl --fail --silent --show-error "${CF_ARGS[@]}" "$BASE_URL/api/apps/health" >/tmp/apps-health.json
 
+      # "Unauthenticated" here means unauthenticated TO THE APP. The Access
+      # token still has to be present, otherwise Access answers first and the
+      # 302 gets read as the app's own denial — the assertion would pass while
+      # testing nothing.
       - name: Check unauthenticated web route is denied
         env:
           BASE_URL: ${{ steps.target.outputs.base_url }}
+          CF_ACCESS_CLIENT_ID: ${{ secrets.CF_ACCESS_CLIENT_ID }}
+          CF_ACCESS_CLIENT_SECRET: ${{ secrets.CF_ACCESS_CLIENT_SECRET }}
         shell: bash
         run: |
+          CF_ARGS=()
+          if [ -n "$CF_ACCESS_CLIENT_ID" ] && [ -n "$CF_ACCESS_CLIENT_SECRET" ]; then
+            CF_ARGS=(-H "CF-Access-Client-Id: $CF_ACCESS_CLIENT_ID" \
+                     -H "CF-Access-Client-Secret: $CF_ACCESS_CLIENT_SECRET")
+          fi
           STATUS="$(curl --silent --output /tmp/web-auth.json --write-out '%{http_code}' \
             -X POST \
+            "${CF_ARGS[@]}" \
             -H 'Content-Type: application/json' \
             "$BASE_URL/api/web/tools/list" \
             -d '{"workspaceId":"smoke","serverId":"smoke"}')"
@@ -142,6 +174,8 @@ jobs:
         # smoke job's output because step outputs are job-local.
         env:
           PLAYWRIGHT_BASE_URL: ${{ needs.smoke.outputs.base_url }}
+          CF_ACCESS_CLIENT_ID: ${{ secrets.CF_ACCESS_CLIENT_ID }}
+          CF_ACCESS_CLIENT_SECRET: ${{ secrets.CF_ACCESS_CLIENT_SECRET }}
         run: npm run test:e2e -w @mcpjam/inspector
 
       - name: Upload Playwright report

--- a/mcpjam-inspector/playwright.config.ts
+++ b/mcpjam-inspector/playwright.config.ts
@@ -7,6 +7,20 @@ import { fileURLToPath } from "node:url";
 const deployedBaseUrl = process.env.PLAYWRIGHT_BASE_URL;
 const baseURL = deployedBaseUrl ?? "http://localhost:6274";
 
+// staging.mcpjam.com sits behind Cloudflare Access. Without a service token
+// every navigation lands on the Access login page instead of the app, and the
+// failures read as product bugs. Only sent when both halves are present, so a
+// local run against localhost is unaffected.
+const cfAccessClientId = process.env.CF_ACCESS_CLIENT_ID;
+const cfAccessClientSecret = process.env.CF_ACCESS_CLIENT_SECRET;
+const cfAccessHeaders =
+  cfAccessClientId && cfAccessClientSecret
+    ? {
+        "CF-Access-Client-Id": cfAccessClientId,
+        "CF-Access-Client-Secret": cfAccessClientSecret,
+      }
+    : undefined;
+
 // Resolve to the inspector package root (this config's directory) so the booted
 // webServer runs the workspace's `npm run start` regardless of the invoking cwd.
 const packageRoot = fileURLToPath(new URL(".", import.meta.url));
@@ -21,6 +35,7 @@ export default defineConfig({
   reporter: [["list"], ["html", { open: "never" }]],
   use: {
     baseURL,
+    ...(cfAccessHeaders ? { extraHTTPHeaders: cfAccessHeaders } : {}),
     trace: "retain-on-failure",
     screenshot: "only-on-failure",
     video: "retain-on-failure",


### PR DESCRIPTION
## Why

`staging.mcpjam.com` is moving behind Cloudflare Access (companion to #4449, which deletes the fake client-side gate). Access answers before the origin does, so without a service token every post-deploy check gets a 302 to the login page: the health curls fail, and the Playwright job drives the Access login screen while reporting the failures as product bugs.

## What

- `post-deploy-smoke.yml` declares `CF_ACCESS_CLIENT_ID` / `CF_ACCESS_CLIENT_SECRET` as **optional** `workflow_call` secrets and sends them as `CF-Access-Client-Id` / `CF-Access-Client-Secret` on the three health curls, the unauthenticated-route check, and the Playwright job.
- `deploy-staging.yml` passes both through explicitly (not `secrets: inherit` — only these two are needed).
- `playwright.config.ts` sets `extraHTTPHeaders` when both are in the environment.

The secrets already exist on the repo; the service token is `github-actions-staging-smoke` in the MCPJam Zero Trust org, valid one year.

## Safe to land before Access is turned on

Every path is conditional on both halves being present. Absent, the curls build an empty `CF_ARGS` array and send **no** header flags (rather than two empty headers Access would reject), and Playwright omits `extraHTTPHeaders`. `deploy-webapp.yml`'s production target is not behind Access and is deliberately left passing nothing.

## One subtlety worth reviewing

The "unauthenticated web route is denied" check now carries the token too. "Unauthenticated" there means unauthenticated **to the app**, not to Access — without the token, Access's 302 would be read as the app's own denial and the assertion would pass while testing nothing.

## Test

Not exercised end-to-end yet: it cannot be until the Access policy exists. Until then the conditionals are inert and the lane behaves exactly as it does today, which the next staging deploy will confirm.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are limited to optional CI smoke/Playwright headers; no production app or auth logic is modified, and behavior is unchanged when secrets are absent.
> 
> **Overview**
> Post-deploy smoke against **staging** can authenticate through **Cloudflare Access** so health curls and Playwright hit the app instead of the Access login redirect.
> 
> **`post-deploy-smoke.yml`** adds optional `workflow_call` secrets `CF_ACCESS_CLIENT_ID` / `CF_ACCESS_CLIENT_SECRET`. When both are set, curl steps attach `CF-Access-Client-Id` and `CF-Access-Client-Secret` via a conditional `CF_ARGS` array (no empty headers if secrets are missing). The same headers are used for the “unauthenticated web route” check so the test still asserts **app** 401/403, not an Access 302. The Playwright job receives the secrets as env vars.
> 
> **`deploy-staging.yml`** forwards only those two repo secrets into the reusable smoke workflow. Production’s **`deploy-webapp.yml`** caller is unchanged and omits them.
> 
> **`playwright.config.ts`** sets `extraHTTPHeaders` with the Access token pair when both env vars are present, so remote staging runs work without affecting local localhost runs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a2f6505ee9f3ece7400a5321badb67f90b2bde65. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Carries a Cloudflare Access service token through the staging smoke lane. `staging.mcpjam.com` is moving behind Access, which answers before the origin does, so without the token every post-deploy check hits the login 302: the health curls fail and Playwright drives the login screen while reporting product bugs.

**Notes**
- The token is optional everywhere; when absent, no Access headers are sent, so the lane is unchanged until the policy exists and the production target (not behind Access) is untouched.
- The unauthenticated-route check deliberately carries the token: "unauthenticated" means unauthenticated to the app, and Access's own 302 would otherwise pass the denial assertion while testing nothing.

<sup>Written for commit a2f6505ee9f3ece7400a5321badb67f90b2bde65. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/MCPJam/inspector/pull/4450?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

