### PR TITLE
Keep synthetic loadSkill tool-call ids inside the provider's charset

### DIFF
--- a/.changeset/skill-toolcall-id-charset.md
+++ b/.changeset/skill-toolcall-id-charset.md
@@ -1,0 +1,13 @@
+---
+"@mcpjam/inspector": patch
+---
+
+Directly loading a server-served skill no longer breaks the rest of the conversation
+
+Attaching a skill from the picker injects a synthetic `loadSkill` tool call into the transcript, and that call's id is replayed to the provider on every later turn. The id was built as `skill-load-${skill.name}-${generateId()}`.
+
+A server-served skill (SEP-2640) is addressed by a namespaced `<server>/<skill>` ref, so the id carried a `/`. Anthropic validates `tool_use.id` against `^[a-zA-Z0-9_-]+$` and rejects the whole request otherwise — so the next message failed with `messages.5.content.1.tool_use.id: String should match pattern '^[a-zA-Z0-9_-]+$'` and the conversation could not be continued at all. The load itself had already succeeded; it was the turn after it that died.
+
+Cloud and local skills are plain slugs, which is why the id survived unsanitized until server skills put a separator in the name.
+
+The name is in the id for debuggability only — `generateId()` supplies the uniqueness — so the offending characters are replaced rather than dropped, keeping the id readable. Sanitizing happens at the one place ids are minted, not by narrowing refs upstream: the ref's shape is the namespacing contract the picker and `loadSkill` both compute, and bending it to one provider's id rules would make two unrelated concerns share a format.

--- a/mcpjam-inspector/client/src/components/chat-v2/shared/__tests__/chat-helpers-skill-tool-ids.test.ts
+++ b/mcpjam-inspector/client/src/components/chat-v2/shared/__tests__/chat-helpers-skill-tool-ids.test.ts
@@ -1,0 +1,75 @@
+/**
+ * A directly-loaded skill is injected into the transcript as a synthetic
+ * `loadSkill` tool call, and that call's id goes to the provider verbatim on
+ * every subsequent turn.
+ *
+ * Anthropic validates `tool_use.id` against `^[a-zA-Z0-9_-]+$` and rejects the
+ * whole request otherwise — so an id built from a name containing anything
+ * else does not degrade, it makes the conversation uncontinuable:
+ * `messages.5.content.1.tool_use.id: String should match pattern`. A
+ * server-served skill (SEP-2640) is addressed by a namespaced `<server>/<skill>`
+ * ref, so it carries exactly such a character.
+ */
+import { describe, expect, it } from "vitest";
+import { buildSkillToolMessages } from "../chat-helpers";
+
+/** The pattern the provider enforces. */
+const PROVIDER_TOOL_USE_ID = /^[a-zA-Z0-9_-]+$/;
+
+function toolCallIds(messages: ReturnType<typeof buildSkillToolMessages>) {
+  return messages.flatMap((message) =>
+    message.parts
+      .filter(
+        (part): part is Extract<typeof part, { toolCallId: string }> =>
+          "toolCallId" in part && typeof part.toolCallId === "string"
+      )
+      .map((part) => part.toolCallId)
+  );
+}
+
+describe("synthetic loadSkill tool-call ids", () => {
+  it("stays inside the provider's charset for a namespaced server skill", () => {
+    const messages = buildSkillToolMessages([
+      {
+        name: "staging/run-mcpjam-evals",
+        content: "# Run evals\n",
+      } as never,
+    ]);
+
+    const ids = toolCallIds(messages);
+    expect(ids.length).toBeGreaterThan(0);
+    for (const id of ids) expect(id).toMatch(PROVIDER_TOOL_USE_ID);
+  });
+
+  it("keeps the name legible rather than dropping it", () => {
+    const [message] = buildSkillToolMessages([
+      { name: "staging/run-mcpjam-evals", content: "x" } as never,
+    ]);
+    const [id] = toolCallIds([message!]);
+    // The name is in the id for debuggability; only the offending character
+    // is replaced.
+    expect(id).toContain("staging_run-mcpjam-evals");
+  });
+
+  it("leaves an already-valid cloud skill name untouched", () => {
+    const [message] = buildSkillToolMessages([
+      { name: "run-mcpjam-evals", content: "x" } as never,
+    ]);
+    const [id] = toolCallIds([message!]);
+    expect(id).toContain("skill-load-run-mcpjam-evals-");
+    expect(id).toMatch(PROVIDER_TOOL_USE_ID);
+  });
+
+  it("covers supporting-file calls too", () => {
+    const messages = buildSkillToolMessages([
+      {
+        name: "staging/run-mcpjam-evals",
+        content: "x",
+        selectedFiles: [{ path: "references/triage.md", content: "y" }],
+      } as never,
+    ]);
+    const ids = toolCallIds(messages);
+    expect(ids.length).toBeGreaterThan(1);
+    for (const id of ids) expect(id).toMatch(PROVIDER_TOOL_USE_ID);
+  });
+});

--- a/mcpjam-inspector/client/src/components/chat-v2/shared/chat-helpers.ts
+++ b/mcpjam-inspector/client/src/components/chat-v2/shared/chat-helpers.ts
@@ -750,6 +750,29 @@ export function buildMcpPromptMessages(
 }
 
 /**
+ * A skill name, reduced to the character set a provider accepts inside a
+ * `tool_use.id`.
+ *
+ * Anthropic validates those ids against `^[a-zA-Z0-9_-]+$` and rejects the
+ * whole request otherwise. A SERVER-SERVED skill (SEP-2640) is addressed by a
+ * namespaced ref — `<server>/<skill>` — so its `/` made every follow-up turn
+ * fail with `messages.N.content.M.tool_use.id: String should match pattern`,
+ * and the transcript could not be continued at all. Cloud and local skills are
+ * plain slugs, which is why the id survived unsanitized until server skills
+ * introduced a separator into the name.
+ *
+ * The name is in the id for debuggability only — `generateId()` supplies the
+ * uniqueness — so replacing rather than dropping the offending characters
+ * keeps the id readable while making it valid. Sanitized at the ONE place ids
+ * are minted rather than by narrowing refs upstream: the ref's shape is the
+ * namespacing contract the picker and `loadSkill` both compute, and bending it
+ * to a provider's id rules would make two unrelated concerns share a format.
+ */
+function toolCallIdSegment(name: string): string {
+  return name.replace(/[^a-zA-Z0-9_-]+/g, "_");
+}
+
+/**
  * Builds UIMessages that simulate the LLM calling loadSkill tool.
  * Creates assistant messages with tool invocations instead of user messages.
  */
@@ -761,7 +784,9 @@ export function buildSkillToolMessages(
   for (const skill of skillResults) {
     if (!skill.content) continue;
 
-    const toolCallId = `skill-load-${skill.name}-${generateId()}`;
+    const toolCallId = `skill-load-${toolCallIdSegment(
+      skill.name
+    )}-${generateId()}`;
 
     // Format output to match server-side loadSkill response.
     //


### PR DESCRIPTION
Attaching a server-served skill from the picker made the **next** message fail:

```
An error occurred: messages.5.content.1.tool_use.id:
  String should match pattern '^[a-zA-Z0-9_-]+$'
```

The load itself had already succeeded. It was the turn after it that could not be sent — and no amount of retrying helps, because the bad id is now in the transcript.

## Cause

Attaching a skill injects a synthetic `loadSkill` tool call, and that call's id is replayed to the provider on every later turn. `chat-helpers.ts` built it as:

```js
const toolCallId = `skill-load-${skill.name}-${generateId()}`;
```

A server-served skill (SEP-2640) is addressed by a namespaced `<server>/<skill>` ref, so the id carried a `/`. Anthropic validates `tool_use.id` against `^[a-zA-Z0-9_-]+$` and rejects the whole request otherwise.

Cloud and local skills are plain slugs — that is why the id survived unsanitized until server skills put a separator in the name.

## Fix

Sanitize the name into the id's allowed charset at the one place ids are minted. The name is there for debuggability only (`generateId()` supplies uniqueness), so the offending characters are replaced rather than dropped and the id stays readable: `skill-load-staging_run-mcpjam-evals-<id>`.

Deliberately **not** fixed by narrowing the ref upstream: the ref's shape is the namespacing contract the picker and `loadSkill` both compute, and bending it to one provider's id rules would make two unrelated concerns share a format.

Only `toolCallId` is affected. The neighbouring `id:` fields on the same messages are ours, not provider-validated, and are left alone.

## Tests

`chat-helpers-skill-tool-ids.test.ts` (new, 4 cases): a namespaced server skill produces ids matching the provider pattern; the name stays legible rather than being dropped; an already-valid cloud-skill name is untouched; supporting-file calls are covered too. **Verified to fail without the fix** — 3 of 4 go red on revert.

Sibling suites: `client/src/components/chat-v2/shared/__tests__` — 10 files, 97 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized change to synthetic transcript tool-call id formatting with targeted tests; no auth, persistence, or skill ref contract changes.
> 
> **Overview**
> **Fixes conversations breaking on the turn after attaching a server-served skill** (`<server>/<skill>`). The picker injects a synthetic `loadSkill` tool call whose `toolCallId` is replayed to Anthropic on every later message; ids were built as `skill-load-${skill.name}-${generateId()}`, so the `/` in the ref violated `^[a-zA-Z0-9_-]+$` and the provider rejected the whole request.
> 
> `buildSkillToolMessages` now runs the skill name through `toolCallIdSegment`, replacing disallowed characters with `_` while keeping the slug readable (e.g. `staging_run-mcpjam-evals`). Skill refs and message `id` fields are unchanged—only provider-facing `toolCallId` values are sanitized at mint time.
> 
> Adds `chat-helpers-skill-tool-ids.test.ts` (namespaced server skill, legibility, plain cloud slug, supporting-file tool parts) and a patch changeset for `@mcpjam/inspector`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c846453e08623e7cbb6dc2c0aa8d3b3bef3028b6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes attaching a server-served skill from the picker making the next message fail: the synthetic `loadSkill` tool-call id carried a `/` from the namespaced `<server>/<skill>` ref, and the provider rejects ids outside `^[a-zA-Z0-9_-]+$`, killing the whole request. The id's name segment is now sanitized at the single place ids are minted, replacing offending characters with `_` instead of dropping them.

- Only `toolCallId` is sanitized; neighboring `id:` fields on the same messages are not provider-validated and are left alone.
- The namespaced ref shape is kept intact upstream since it's the contract the picker and `loadSkill` both share.
- New tests cover namespaced server skills, untouched cloud-skill names, legible sanitization, and supporting-file calls; they fail if the fix is reverted.

<sup>Written for commit c846453e08623e7cbb6dc2c0aa8d3b3bef3028b6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/MCPJam/inspector/pull/4451?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

