### PR TITLE
Versioned Skills: compose stops dropping version pins, and turns record what they ran with

### DIFF
--- a/docs/reference/openapi.json
+++ b/docs/reference/openapi.json
@@ -18257,6 +18257,10 @@
           "ephemeralEnvironmentLaunch": {
             "type": "boolean",
             "description": "`startTestSuiteRun` / the v1 group route accept `ephemeralEnvironment` — a project-scoped env may launch without suite membership. Absent or false on older backends."
+          },
+          "skillVersionPins": {
+            "type": "boolean",
+            "description": "`skillSelection.versionPins` and `serverSkillSelection.versionPins` are accepted, and a pinned revision survives into run snapshots. Absent or false on older backends, which reject the unknown field outright — probe this before offering a version picker."
           }
         }
       },

--- a/mcpjam-inspector/server/routes/v1/__tests__/environments.test.ts
+++ b/mcpjam-inspector/server/routes/v1/__tests__/environments.test.ts
@@ -649,6 +649,7 @@ describe("v1 project environment routes", () => {
         "projectEnvironments:getCapabilities": {
           modelOverrides: true,
           modelMatrix: true,
+          skillVersionPins: true,
         },
       });
       const res = await request(
@@ -659,7 +660,27 @@ describe("v1 project environment routes", () => {
       expect(await res.json()).toMatchObject({
         modelOverrides: true,
         modelMatrix: true,
+        skillVersionPins: true,
       });
+    });
+
+    it("reports skillVersionPins false when the backend predates version pins", async () => {
+      // A backend that HAS getCapabilities but not this flag is the ordinary
+      // skew case: every flag is normalized with `=== true`, so an absent one
+      // reads false rather than undefined and a client that probes it gets a
+      // usable answer instead of a falsy-but-unknown.
+      mockQuery({
+        "projectEnvironments:getCapabilities": {
+          modelOverrides: true,
+          modelMatrix: true,
+        },
+      });
+      const res = await request(
+        "GET",
+        "/api/v1/projects/p1/environments/capabilities",
+      );
+      expect(res.status).toBe(200);
+      expect(await res.json()).toMatchObject({ skillVersionPins: false });
     });
 
     it("answers false — not an error — when the deployment is too OLD", async () => {

--- a/mcpjam-inspector/server/routes/v1/environments.ts
+++ b/mcpjam-inspector/server/routes/v1/environments.ts
@@ -502,6 +502,7 @@ environments.get(
       modelOverrides?: boolean;
       modelMatrix?: boolean;
       ephemeralEnvironmentLaunch?: boolean;
+      skillVersionPins?: boolean;
     } = {};
     try {
       capabilities =
@@ -532,6 +533,7 @@ environments.get(
       modelMatrix: capabilities.modelMatrix === true,
       ephemeralEnvironmentLaunch:
         capabilities.ephemeralEnvironmentLaunch === true,
+      skillVersionPins: capabilities.skillVersionPins === true,
     });
   },
 );

--- a/mcpjam-inspector/server/routes/web/__tests__/chat-v2.environment.test.ts
+++ b/mcpjam-inspector/server/routes/web/__tests__/chat-v2.environment.test.ts
@@ -823,3 +823,162 @@ describe("web chat-v2 — plugin capability attribution", () => {
     ]);
   });
 });
+
+describe("web chat-v2 — turn provenance (P1)", () => {
+  const originalFetch = global.fetch;
+  const originalConvexHttpUrl = process.env.CONVEX_HTTP_URL;
+  const originalConvexUrl = process.env.CONVEX_URL;
+
+  const PROVENANCE = {
+    skillId: "sk_env",
+    projectSkillVersionId: "psv_1",
+    projectSkillVersionNumber: 3,
+    versionPinned: true,
+    name: "release-notes",
+    description: "Write release notes",
+    contentHash: "h_env",
+    sharing: "project",
+    channels: ["environment"],
+  };
+  const SPEC_WITH_PROVENANCE = {
+    ...ENV_SPEC,
+    skills: [{ ...ENV_SPEC.skills[0], provenance: PROVENANCE }],
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    process.env.CONVEX_HTTP_URL = "https://example.convex.site";
+    process.env.CONVEX_URL = "https://example.convex.cloud";
+    prepareChatV2Mock.mockResolvedValue({
+      allTools: {},
+      enhancedSystemPrompt: "system",
+      resolvedTemperature: 0.7,
+    });
+    fetchHostRuntimeConfigMock.mockResolvedValue({ ok: true, config: {} });
+    fetchScenarioRuntimeConfigMock.mockResolvedValue({ ok: true, config: {} });
+    handleMCPJamFreeChatModelMock.mockImplementation(async (options: any) => {
+      await options.onConversationComplete?.(
+        [{ role: "user", content: "hi" }],
+        {
+          turnId: "t",
+          promptIndex: 0,
+          startedAt: 1,
+          endedAt: 2,
+          spans: [],
+          modelId: "test-model",
+        }
+      );
+      options.onStreamComplete?.();
+      return new Response("ok", { status: 200 });
+    });
+    global.fetch = vi.fn(async (input, init) => {
+      if (String(input).endsWith("/web/authorize-batch")) {
+        const payload = JSON.parse(String(init?.body ?? "{}"));
+        const serverIds: string[] = Array.isArray(payload?.serverIds)
+          ? payload.serverIds
+          : [];
+        return new Response(
+          JSON.stringify({
+            results: Object.fromEntries(
+              serverIds.map((serverId) => [
+                serverId,
+                {
+                  ok: true,
+                  role: "member",
+                  accessLevel: "shared_chat",
+                  permissions: { chatOnly: false },
+                  internalLogContext: {
+                    authType: "signedIn",
+                    userId: "u-alice",
+                    projectId: payload.projectId ?? null,
+                  },
+                  serverConfig: {
+                    transportType: "http",
+                    url: `https://${serverId}.example.com/mcp`,
+                    headers: {},
+                    useOAuth: false,
+                  },
+                },
+              ])
+            ),
+          }),
+          { status: 200, headers: { "Content-Type": "application/json" } }
+        );
+      }
+      throw new Error(`Unexpected fetch: ${String(input)}`);
+    }) as unknown as typeof fetch;
+  });
+
+  afterEach(() => {
+    global.fetch = originalFetch;
+    process.env.CONVEX_HTTP_URL = originalConvexHttpUrl;
+    process.env.CONVEX_URL = originalConvexUrl;
+  });
+
+  async function runEnvironmentTurn() {
+    const { app, token } = createWebTestApp();
+    const response = await postJson(
+      app,
+      "/api/web/chat-v2",
+      {
+        ...BASE_BODY,
+        executionTarget: { kind: "environment", environmentId: "env_1" },
+      },
+      token
+    );
+    expect(response.status).toBe(200);
+    return persistChatSessionToConvexMock.mock.calls.at(-1)![0];
+  }
+
+  it("records the environment and its skill rows on the turn trace", async () => {
+    convexQueryMock.mockResolvedValue(SPEC_WITH_PROVENANCE);
+    const persistArgs = await runEnvironmentTurn();
+    expect(persistArgs.turnTrace.environmentAtTurn).toEqual({
+      environmentId: "env_1",
+      name: "Staging",
+      revision: 7,
+    });
+    expect(persistArgs.turnTrace.skillsAtTurn).toEqual([PROVENANCE]);
+    // The rest of the trace is untouched — provenance is merged onto it, not
+    // substituted for it.
+    expect(persistArgs.turnTrace.turnId).toBe("t");
+    expect(persistArgs.turnTrace.spans).toEqual([]);
+  });
+
+  it("never carries skill CONTENT into the record", async () => {
+    convexQueryMock.mockResolvedValue(SPEC_WITH_PROVENANCE);
+    const persistArgs = await runEnvironmentTurn();
+    expect(JSON.stringify(persistArgs.turnTrace)).not.toContain(
+      "env skill body"
+    );
+  });
+
+  it("records an empty skill list rather than going silent, on an older backend", async () => {
+    // Deploy skew: the backend resolves skills but attaches no provenance
+    // rows. The turn still records WHICH environment ran — the part this side
+    // can prove — and claims nothing about skills it cannot describe.
+    convexQueryMock.mockResolvedValue(ENV_SPEC);
+    const persistArgs = await runEnvironmentTurn();
+    expect(persistArgs.turnTrace.environmentAtTurn).toEqual({
+      environmentId: "env_1",
+      name: "Staging",
+      revision: 7,
+    });
+    expect(persistArgs.turnTrace.skillsAtTurn).toEqual([]);
+  });
+
+  it("a direct turn with no environment records nothing", async () => {
+    convexQueryMock.mockResolvedValue(ENV_SPEC);
+    const { app, token } = createWebTestApp();
+    const response = await postJson(
+      app,
+      "/api/web/chat-v2",
+      { ...BASE_BODY, hostId: "host_legacy" },
+      token
+    );
+    expect(response.status).toBe(200);
+    const persistArgs = persistChatSessionToConvexMock.mock.calls.at(-1)![0];
+    expect(persistArgs.turnTrace.environmentAtTurn).toBeUndefined();
+    expect(persistArgs.turnTrace.skillsAtTurn).toBeUndefined();
+  });
+});

--- a/mcpjam-inspector/server/routes/web/__tests__/chat-v2.environment.test.ts
+++ b/mcpjam-inspector/server/routes/web/__tests__/chat-v2.environment.test.ts
@@ -1035,6 +1035,15 @@ describe("web chat-v2 — turn provenance (P1)", () => {
     });
 
     const persistArgs = await runEnvironmentTurn();
+
+    // Assert DELIVERY as well as the record — the invariant is that the two
+    // agree, and checking only the record would pass even if the capture had
+    // reached `runtimeSkillsOverride` (which would make the record wrong in
+    // the other direction).
+    const handlerArgs = handleMCPJamFreeChatModelMock.mock.calls.at(-1)![0];
+    expect(handlerArgs.runtimeSkillsOverride).toEqual([
+      expect.objectContaining({ skillId: "sk_env", name: "release-notes" }),
+    ]);
     // The authored skill IS delivered by the harness, so it is recorded.
     expect(persistArgs.turnTrace.skillsAtTurn).toEqual([PROVENANCE]);
     // The environment binding is still true and still recorded.

--- a/mcpjam-inspector/server/routes/web/__tests__/chat-v2.environment.test.ts
+++ b/mcpjam-inspector/server/routes/web/__tests__/chat-v2.environment.test.ts
@@ -911,8 +911,13 @@ describe("web chat-v2 — turn provenance (P1)", () => {
 
   afterEach(() => {
     global.fetch = originalFetch;
-    process.env.CONVEX_HTTP_URL = originalConvexHttpUrl;
-    process.env.CONVEX_URL = originalConvexUrl;
+    // Delete rather than assign when the var was absent: assigning `undefined`
+    // stores the literal string "undefined", which leaks into later suites as
+    // a truthy Convex URL. The two describe blocks above already do this.
+    if (originalConvexHttpUrl === undefined) delete process.env.CONVEX_HTTP_URL;
+    else process.env.CONVEX_HTTP_URL = originalConvexHttpUrl;
+    if (originalConvexUrl === undefined) delete process.env.CONVEX_URL;
+    else process.env.CONVEX_URL = originalConvexUrl;
   });
 
   async function runEnvironmentTurn() {
@@ -943,6 +948,52 @@ describe("web chat-v2 — turn provenance (P1)", () => {
     // substituted for it.
     expect(persistArgs.turnTrace.turnId).toBe("t");
     expect(persistArgs.turnTrace.spans).toEqual([]);
+  });
+
+  it("records a delivered CAPTURED server skill alongside the authored ones", async () => {
+    // End-to-end wiring for the helper's serverSkills branch: a captured
+    // MCP-server skill reaches the model through the same capability set as an
+    // authored one, so it must appear in the record of what ran.
+    const CAPTURE_PROVENANCE = {
+      serverSkillId: "ss_1",
+      serverSkillVersionId: "ssv_1",
+      serverSkillVersionNumber: 2,
+      name: "refunds",
+      modelRef: "acme/refunds",
+      contentHash: "h_capture",
+      sharing: "project",
+      channels: ["mcp-server"],
+    };
+    convexQueryMock.mockResolvedValue({
+      ...SPEC_WITH_PROVENANCE,
+      serverSkills: [
+        {
+          serverSkillId: "ss_1",
+          versionId: "ssv_1",
+          serverId: "env-server-1",
+          serverSlug: "acme",
+          serverLabel: "Acme",
+          ref: "acme/refunds",
+          skillUri: "skill://acme/refunds/SKILL.md",
+          name: "refunds",
+          description: "Handle refunds",
+          content: "captured body",
+          contentSha256: "raw-digest",
+          contentHash: "h_capture",
+          versionHash: "vh_1",
+          versionNumber: 2,
+          capturedAt: 1,
+          provenance: CAPTURE_PROVENANCE,
+          files: [],
+        },
+      ],
+    });
+
+    const persistArgs = await runEnvironmentTurn();
+    expect(persistArgs.turnTrace.skillsAtTurn).toEqual([
+      PROVENANCE,
+      CAPTURE_PROVENANCE,
+    ]);
   });
 
   it("never carries skill CONTENT into the record", async () => {

--- a/mcpjam-inspector/server/routes/web/__tests__/chat-v2.environment.test.ts
+++ b/mcpjam-inspector/server/routes/web/__tests__/chat-v2.environment.test.ts
@@ -996,6 +996,55 @@ describe("web chat-v2 — turn provenance (P1)", () => {
     ]);
   });
 
+  it("does NOT record a capture on a HARNESS turn, which cannot deliver it", async () => {
+    // The reviewer's finding, at the route level: a harness adapter receives
+    // only the flat `runtimeSkillsOverride` (authored + plugin). A capture's
+    // address is `<serverSlug>/<name>` and `isValidSkillName` rejects `/`, so
+    // the adapter skips it. Recording it would make the trace claim a skill the
+    // model never received.
+    convexQueryMock.mockResolvedValue({
+      ...SPEC_WITH_PROVENANCE,
+      host: {
+        ...SPEC_WITH_PROVENANCE.host,
+        runtimeConfig: {
+          ...SPEC_WITH_PROVENANCE.host.runtimeConfig,
+          harness: "claude-code",
+        },
+      },
+      serverSkills: [
+        {
+          serverSkillId: "ss_1",
+          versionId: "ssv_1",
+          serverId: "env-server-1",
+          serverSlug: "acme",
+          serverLabel: "Acme",
+          ref: "acme/refunds",
+          skillUri: "skill://acme/refunds/SKILL.md",
+          name: "refunds",
+          description: "Handle refunds",
+          content: "captured body",
+          contentSha256: "raw-digest",
+          contentHash: "h_capture",
+          versionHash: "vh_1",
+          versionNumber: 2,
+          capturedAt: 1,
+          provenance: { name: "refunds", contentHash: "h_capture" },
+          files: [],
+        },
+      ],
+    });
+
+    const persistArgs = await runEnvironmentTurn();
+    // The authored skill IS delivered by the harness, so it is recorded.
+    expect(persistArgs.turnTrace.skillsAtTurn).toEqual([PROVENANCE]);
+    // The environment binding is still true and still recorded.
+    expect(persistArgs.turnTrace.environmentAtTurn).toEqual({
+      environmentId: "env_1",
+      name: "Staging",
+      revision: 7,
+    });
+  });
+
   it("never carries skill CONTENT into the record", async () => {
     convexQueryMock.mockResolvedValue(SPEC_WITH_PROVENANCE);
     const persistArgs = await runEnvironmentTurn();

--- a/mcpjam-inspector/server/routes/web/__tests__/chat-v2.scenario-environment.test.ts
+++ b/mcpjam-inspector/server/routes/web/__tests__/chat-v2.scenario-environment.test.ts
@@ -228,6 +228,92 @@ describe("web chat-v2 — environment-backed scenario", () => {
     else process.env.CONVEX_URL = originalConvexUrl;
   });
 
+  it("records turn provenance — the isDirectChat gate must NOT swallow it", async () => {
+    // THE BYPASS THIS PINS. `resumeConfig` and friends are merged only for a
+    // direct chat, because they are the restorable-resume surface. Provenance
+    // is not: a scenario turn runs through an environment too, and gating it
+    // the same way would leave User Testing — the most environment-driven
+    // surface there is — with no record of what it ran.
+    const PROVENANCE = {
+      skillId: "sk_env",
+      projectSkillVersionNumber: 3,
+      versionPinned: true,
+      name: "release-notes",
+      contentHash: "h_env",
+      sharing: "project",
+      channels: ["environment"],
+    };
+    fetchScenarioRuntimeConfigMock.mockResolvedValue({
+      ok: true,
+      config: {
+        ...SCENARIO_CONFIG,
+        environment: {
+          ...ENVIRONMENT_PAYLOAD,
+          skills: [
+            { ...ENVIRONMENT_PAYLOAD.skills[0], provenance: PROVENANCE },
+          ],
+        },
+      },
+    });
+
+    const { app, token } = createWebTestApp();
+    const response = await postJson(app, "/api/web/chat-v2", BASE_BODY, token);
+    expect(response.status).toBe(200);
+
+    const persistArgs = persistChatSessionToConvexMock.mock.calls.at(-1)![0];
+    // A scenario turn: no resumeConfig (the gate is still doing its job)…
+    expect(persistArgs.resumeConfig).toBeUndefined();
+    // …and provenance regardless.
+    expect(persistArgs.turnTrace.environmentAtTurn).toEqual({
+      environmentId: "env_1",
+      name: "Staging",
+      revision: 7,
+    });
+    expect(persistArgs.turnTrace.skillsAtTurn).toEqual([PROVENANCE]);
+  });
+
+  it("drops a malformed provenance entry without failing the turn", async () => {
+    // Tolerant pass-through: losing a provenance LABEL must never cost a turn.
+    fetchScenarioRuntimeConfigMock.mockResolvedValue({
+      ok: true,
+      config: {
+        ...SCENARIO_CONFIG,
+        environment: {
+          ...ENVIRONMENT_PAYLOAD,
+          skills: [
+            { ...ENVIRONMENT_PAYLOAD.skills[0], provenance: "not an object" },
+          ],
+        },
+      },
+    });
+
+    const { app, token } = createWebTestApp();
+    const response = await postJson(app, "/api/web/chat-v2", BASE_BODY, token);
+    expect(response.status).toBe(200);
+
+    const persistArgs = persistChatSessionToConvexMock.mock.calls.at(-1)![0];
+    expect(persistArgs.turnTrace.skillsAtTurn).toEqual([]);
+    expect(persistArgs.turnTrace.environmentAtTurn).toBeDefined();
+    // Delivery is unaffected — the skill still reaches the engine.
+    const args = prepareChatV2Mock.mock.calls.at(-1)![0];
+    expect(args.skillsSource.capabilities.standaloneSkills).toHaveLength(1);
+  });
+
+  it("a HOST-backed scenario records nothing — there is no environment", async () => {
+    fetchScenarioRuntimeConfigMock.mockResolvedValue({
+      ok: true,
+      config: SCENARIO_CONFIG,
+    });
+
+    const { app, token } = createWebTestApp();
+    const response = await postJson(app, "/api/web/chat-v2", BASE_BODY, token);
+    expect(response.status).toBe(200);
+
+    const persistArgs = persistChatSessionToConvexMock.mock.calls.at(-1)![0];
+    expect(persistArgs.turnTrace.environmentAtTurn).toBeUndefined();
+    expect(persistArgs.turnTrace.skillsAtTurn).toBeUndefined();
+  });
+
   it("runs on the payload's server set everywhere, never the body's", async () => {
     const { app, token } = createWebTestApp();
     const response = await postJson(app, "/api/web/chat-v2", BASE_BODY, token);

--- a/mcpjam-inspector/server/routes/web/chat-v2.ts
+++ b/mcpjam-inspector/server/routes/web/chat-v2.ts
@@ -89,6 +89,7 @@ import {
   runtimeServersAreOverridden,
   runtimeSkills as environmentRuntimeSkills,
   turnSkillProvenance,
+  type EnvironmentSkillDelivery,
   type ResolvedEnvironmentRuntime,
 } from "../../services/environments/runtime.js";
 import {
@@ -576,24 +577,6 @@ chatV2.post("/", async (c) => {
       ? environmentRuntimeSkills({ skills: scenarioEnvironment.skills ?? [] })
       : undefined;
 
-    // What this turn will RECORD about the configuration it ran with. Computed
-    // from the POST-narrowing spec (plugin overrides filtered `environmentSpec`
-    // above), so it reflects what actually ran rather than what the environment
-    // would resolve on its own.
-    //
-    // Purely a recording concern: it feeds `persist`, never the engines, so
-    // skill delivery is byte-identical whether or not the backend supplied
-    // provenance rows. A turn with no environment records nothing — there is
-    // nothing to record.
-    const turnProvenance = environmentSpec
-      ? turnSkillProvenance(environmentSpec)
-      : scenarioEnvironment
-      ? turnSkillProvenance({
-          environmentRef: scenarioEnvironment.environmentRef,
-          skills: scenarioEnvironment.skills ?? [],
-        })
-      : undefined;
-
     // Enterprise-managed authorization policy. Server-authoritative wherever
     // a backend host config exists (scenario / host-bound turns above — the
     // same fail-closed fetch that owns harness/computer): a tampered body
@@ -656,6 +639,39 @@ chatV2.post("/", async (c) => {
       // precedence can't leak them from the body).
       precedence: isScenarioSession ? "host-wins" : "override-wins",
     });
+    // What this turn will RECORD about the configuration it ran with. Computed
+    // from the POST-narrowing spec (plugin overrides filtered `environmentSpec`
+    // above), so it reflects what actually ran rather than what the environment
+    // would resolve on its own.
+    //
+    // Sits AFTER `resolvedExecution` because the record has to follow DELIVERY,
+    // and delivery depends on the resolved engine: the emulated engine mints a
+    // tool for every channel including captured MCP-server skills, the harness
+    // adapter receives only `runtimeSkills(spec)` (captures are not addressable
+    // there — their `<serverSlug>/<name>` ref fails `isValidSkillName`), and a
+    // skills-incapable harness delivers nothing at all. Recording the resolved
+    // set instead would make the trace claim a skill the model never saw.
+    //
+    // Still purely a recording concern: it feeds `persist`, never the engines,
+    // so what reaches the model is byte-identical either way. A turn with no
+    // environment records nothing — there is nothing to record.
+    const skillDeliveryMode: EnvironmentSkillDelivery = !resolvedExecution.harness
+      ? "emulated"
+      : harnessSupportsSkills(resolvedExecution.harness)
+      ? "harness"
+      : "unsupported";
+    const turnProvenance = environmentSpec
+      ? turnSkillProvenance(environmentSpec, { delivery: skillDeliveryMode })
+      : scenarioEnvironment
+      ? turnSkillProvenance(
+          {
+            environmentRef: scenarioEnvironment.environmentRef,
+            skills: scenarioEnvironment.skills ?? [],
+          },
+          { delivery: skillDeliveryMode }
+        )
+      : undefined;
+
     for (const entry of resolvedExecution.drift) {
       if (entry.field === "requireToolApproval") {
         logger.warn(

--- a/mcpjam-inspector/server/routes/web/chat-v2.ts
+++ b/mcpjam-inspector/server/routes/web/chat-v2.ts
@@ -88,6 +88,7 @@ import {
   runtimeServerNames,
   runtimeServersAreOverridden,
   runtimeSkills as environmentRuntimeSkills,
+  turnSkillProvenance,
   type ResolvedEnvironmentRuntime,
 } from "../../services/environments/runtime.js";
 import {
@@ -573,6 +574,24 @@ chatV2.post("/", async (c) => {
       ? environmentRuntimeSkills(environmentSpec)
       : scenarioEnvironment
       ? environmentRuntimeSkills({ skills: scenarioEnvironment.skills ?? [] })
+      : undefined;
+
+    // What this turn will RECORD about the configuration it ran with. Computed
+    // from the POST-narrowing spec (plugin overrides filtered `environmentSpec`
+    // above), so it reflects what actually ran rather than what the environment
+    // would resolve on its own.
+    //
+    // Purely a recording concern: it feeds `persist`, never the engines, so
+    // skill delivery is byte-identical whether or not the backend supplied
+    // provenance rows. A turn with no environment records nothing — there is
+    // nothing to record.
+    const turnProvenance = environmentSpec
+      ? turnSkillProvenance(environmentSpec)
+      : scenarioEnvironment
+      ? turnSkillProvenance({
+          environmentRef: scenarioEnvironment.environmentRef,
+          skills: scenarioEnvironment.skills ?? [],
+        })
       : undefined;
 
     // Enterprise-managed authorization policy. Server-authoritative wherever
@@ -1526,6 +1545,7 @@ chatV2.post("/", async (c) => {
           ...(environmentSkills !== undefined
             ? { runtimeSkillsOverride: environmentSkills }
             : {}),
+          ...(turnProvenance ? { turnProvenance } : {}),
           // INS-7: the same resolution, unflattened, for Computer delivery —
           // supporting files (the flat list drops them, and the project-wide
           // file query cannot return a plugin skill's) and the pinned plugin

--- a/mcpjam-inspector/server/services/environments/__tests__/runtime.test.ts
+++ b/mcpjam-inspector/server/services/environments/__tests__/runtime.test.ts
@@ -7,6 +7,7 @@ import {
   runtimeServersAreOverridden,
   runtimeSkills,
   toEnvironmentPreview,
+  turnSkillProvenance,
   translateEnvironmentRuntimeError,
   type ResolvedEnvironmentRuntime,
 } from "../runtime";
@@ -385,5 +386,97 @@ describe("toEnvironmentPreview", () => {
     );
     expect(emulated.capabilities.skillDelivery).toBe("emulated");
     expect(emulated.capabilities.hasComputer).toBe(false);
+  });
+});
+
+describe("turnSkillProvenance", () => {
+  // What a turn RECORDS about the configuration it ran with. Separate from
+  // `runtimeSkills`, which is what reaches the model — a recording change that
+  // also changed delivery would be impossible to review.
+
+  const PROVENANCED: ResolvedEnvironmentRuntime = {
+    ...SPEC,
+    skills: [
+      {
+        ...SPEC.skills![0],
+        provenance: {
+          skillId: "sk_1",
+          projectSkillVersionNumber: 3,
+          versionPinned: true,
+          name: "pdf-processing",
+          contentHash: "h1",
+          sharing: "project",
+          channels: ["host", "environment"],
+        },
+      },
+      {
+        ...SPEC.skills![1],
+        provenance: {
+          name: "release-notes",
+          modelRef: "notes/release-notes",
+          contentHash: "h2",
+          sharing: "project",
+          channels: ["plugin"],
+        },
+      },
+    ],
+  };
+
+  it("echoes the backend's rows verbatim, with the environment binding", () => {
+    expect(turnSkillProvenance(PROVENANCED)).toEqual({
+      environmentAtTurn: {
+        environmentId: "env_1",
+        name: "Staging",
+        revision: 7,
+      },
+      skillsAtTurn: [
+        PROVENANCED.skills![0].provenance,
+        PROVENANCED.skills![1].provenance,
+      ],
+    });
+  });
+
+  it("never carries skill CONTENT — provenance is metadata", () => {
+    const out = turnSkillProvenance(PROVENANCED)!;
+    expect(JSON.stringify(out)).not.toContain("SECRET INSTRUCTIONS");
+  });
+
+  it("returns undefined without an environment — nothing to record", () => {
+    expect(turnSkillProvenance(undefined)).toBeUndefined();
+    expect(turnSkillProvenance(null)).toBeUndefined();
+    expect(
+      turnSkillProvenance({
+        environmentRef: undefined as never,
+        skills: PROVENANCED.skills,
+      })
+    ).toBeUndefined();
+  });
+
+  it("returns an EMPTY array for an environment that resolves no skills", () => {
+    // "Ran with none" is a real answer and a different one from "unknown".
+    expect(
+      turnSkillProvenance({ environmentRef: SPEC.environmentRef, skills: [] })
+    ).toEqual({
+      environmentAtTurn: SPEC.environmentRef,
+      skillsAtTurn: [],
+    });
+  });
+
+  it("skips entries the backend did not attach provenance to", () => {
+    // Deploy skew: an older backend omits the field. Recording only what this
+    // side can prove beats assembling a partial row from the other fields —
+    // `modelRef` and `versionPinned` appear nowhere else in this DTO, which is
+    // exactly how provenance goes quietly missing.
+    const mixed = turnSkillProvenance({
+      environmentRef: SPEC.environmentRef,
+      skills: [SPEC.skills![0], PROVENANCED.skills![1]],
+    })!;
+    expect(mixed.skillsAtTurn).toEqual([PROVENANCED.skills![1].provenance]);
+  });
+
+  it("skills delivery is untouched by any of this", () => {
+    // The invariant that makes the change reviewable: same flat list with and
+    // without provenance rows.
+    expect(runtimeSkills(PROVENANCED)).toEqual(runtimeSkills(SPEC));
   });
 });

--- a/mcpjam-inspector/server/services/environments/__tests__/runtime.test.ts
+++ b/mcpjam-inspector/server/services/environments/__tests__/runtime.test.ts
@@ -423,7 +423,7 @@ describe("turnSkillProvenance", () => {
   };
 
   it("echoes the backend's rows verbatim, with the environment binding", () => {
-    expect(turnSkillProvenance(PROVENANCED)).toEqual({
+    expect(turnSkillProvenance(PROVENANCED, { delivery: "emulated" })).toEqual({
       environmentAtTurn: {
         environmentId: "env_1",
         name: "Staging",
@@ -437,18 +437,22 @@ describe("turnSkillProvenance", () => {
   });
 
   it("never carries skill CONTENT — provenance is metadata", () => {
-    const out = turnSkillProvenance(PROVENANCED)!;
+    const out = turnSkillProvenance(PROVENANCED, { delivery: "emulated" })!;
     expect(JSON.stringify(out)).not.toContain("SECRET INSTRUCTIONS");
   });
 
   it("returns undefined without an environment — nothing to record", () => {
-    expect(turnSkillProvenance(undefined)).toBeUndefined();
-    expect(turnSkillProvenance(null)).toBeUndefined();
     expect(
-      turnSkillProvenance({
-        environmentRef: undefined as never,
-        skills: PROVENANCED.skills,
-      })
+      turnSkillProvenance(undefined, { delivery: "emulated" })
+    ).toBeUndefined();
+    expect(
+      turnSkillProvenance(null, { delivery: "emulated" })
+    ).toBeUndefined();
+    expect(
+      turnSkillProvenance(
+        { environmentRef: undefined as never, skills: PROVENANCED.skills },
+        { delivery: "emulated" }
+      )
     ).toBeUndefined();
   });
 
@@ -458,18 +462,39 @@ describe("turnSkillProvenance", () => {
     // reads as a real environment called nothing instead of as absent
     // provenance.
     expect(
-      turnSkillProvenance({
-        environmentRef: { ...SPEC.environmentRef, name: "" },
-        skills: PROVENANCED.skills,
-      })
+      turnSkillProvenance(
+        {
+          environmentRef: { ...SPEC.environmentRef, name: "" },
+          skills: PROVENANCED.skills,
+        },
+        { delivery: "emulated" }
+      )
     ).toBeUndefined();
   });
 
-  it("records CAPTURED server skills too — they are delivered like any other", () => {
-    // `resolveEffectiveCapabilities` puts `serverSkills` into the capability
-    // set and `allEffectiveSkills` hands them to the model, so omitting them
-    // would leave a turn claiming to list what it ran while silently dropping
-    // every captured MCP-server skill that ran.
+  const CAPTURE = {
+    serverSkillId: "ss_1",
+    versionId: "ssv_1",
+    serverId: "srv_1",
+    serverSlug: "acme",
+    serverLabel: "Acme",
+    ref: "acme/refunds",
+    skillUri: "skill://acme/refunds/SKILL.md",
+    name: "refunds",
+    description: "Handle refunds",
+    content: "CAPTURED SECRET",
+    contentSha256: "raw-digest",
+    versionHash: "vh_1",
+    versionNumber: 2,
+    capturedAt: 1,
+    files: [],
+  };
+
+  it("records CAPTURED server skills on an EMULATED turn, which delivers them", () => {
+    // `getEffectiveSkillToolsAndPrompt` mints a tool per entry of
+    // `allEffectiveSkills`, captures included and addressed by their `ref`.
+    // They really do reach the model here, so omitting them would leave a turn
+    // claiming to list what it ran while dropping every capture that ran.
     const serverProvenance = {
       serverSkillId: "ss_1",
       serverSkillVersionId: "ssv_1",
@@ -480,30 +505,14 @@ describe("turnSkillProvenance", () => {
       sharing: "project",
       channels: ["mcp-server"],
     };
-    const out = turnSkillProvenance({
-      environmentRef: SPEC.environmentRef,
-      skills: PROVENANCED.skills,
-      serverSkills: [
-        {
-          serverSkillId: "ss_1",
-          versionId: "ssv_1",
-          serverId: "srv_1",
-          serverSlug: "acme",
-          serverLabel: "Acme",
-          ref: "acme/refunds",
-          skillUri: "skill://acme/refunds/SKILL.md",
-          name: "refunds",
-          description: "Handle refunds",
-          content: "CAPTURED SECRET",
-          contentSha256: "raw-digest",
-          versionHash: "vh_1",
-          versionNumber: 2,
-          capturedAt: 1,
-          provenance: serverProvenance,
-          files: [],
-        },
-      ],
-    })!;
+    const out = turnSkillProvenance(
+      {
+        environmentRef: SPEC.environmentRef,
+        skills: PROVENANCED.skills,
+        serverSkills: [{ ...CAPTURE, provenance: serverProvenance }],
+      },
+      { delivery: "emulated" }
+    )!;
 
     // Authored entries first, captures appended — the order the backend's own
     // run snapshots pin them in.
@@ -515,37 +524,69 @@ describe("turnSkillProvenance", () => {
     expect(JSON.stringify(out)).not.toContain("CAPTURED SECRET");
   });
 
+  it("does NOT record captures on a HARNESS turn, which cannot deliver them", () => {
+    // THE LIE THIS PREVENTS. A harness adapter receives only
+    // `runtimeSkills(spec)` — `spec.skills` alone. A capture's runtime address
+    // is `<serverSlug>/<name>`, and `isValidSkillName` rejects a name with a
+    // `/`, so the adapter would skip every one as `invalid-skill-name`.
+    // Recording it anyway would make the trace assert a skill the model never
+    // received, which is the one thing a provenance record must not do.
+    const out = turnSkillProvenance(
+      {
+        environmentRef: SPEC.environmentRef,
+        skills: PROVENANCED.skills,
+        serverSkills: [
+          { ...CAPTURE, provenance: { name: "refunds", contentHash: "h_c" } },
+        ],
+      },
+      { delivery: "harness" }
+    )!;
+
+    expect(out.skillsAtTurn).toEqual([
+      PROVENANCED.skills![0].provenance,
+      PROVENANCED.skills![1].provenance,
+    ]);
+    // The environment binding is still recorded — that part IS true.
+    expect(out.environmentAtTurn).toEqual(SPEC.environmentRef);
+  });
+
+  it("records NOTHING when the harness has no skill channel at all", () => {
+    // Codex today: the skills resolved and nothing delivered them. An empty
+    // list is the honest answer — the same lie one level up from captures.
+    const out = turnSkillProvenance(
+      {
+        environmentRef: SPEC.environmentRef,
+        skills: PROVENANCED.skills,
+        serverSkills: [
+          { ...CAPTURE, provenance: { name: "refunds", contentHash: "h_c" } },
+        ],
+      },
+      { delivery: "unsupported" }
+    )!;
+
+    expect(out.skillsAtTurn).toEqual([]);
+    expect(out.environmentAtTurn).toEqual(SPEC.environmentRef);
+  });
+
   it("skips a captured skill the backend attached no provenance to", () => {
-    const out = turnSkillProvenance({
-      environmentRef: SPEC.environmentRef,
-      skills: [],
-      serverSkills: [
-        {
-          serverSkillId: "ss_1",
-          versionId: "ssv_1",
-          serverId: "srv_1",
-          serverSlug: "acme",
-          serverLabel: "Acme",
-          ref: "acme/refunds",
-          skillUri: "skill://acme/refunds/SKILL.md",
-          name: "refunds",
-          description: "Handle refunds",
-          content: "body",
-          contentSha256: "raw-digest",
-          versionHash: "vh_1",
-          versionNumber: 2,
-          capturedAt: 1,
-          files: [],
-        },
-      ],
-    })!;
+    const out = turnSkillProvenance(
+      {
+        environmentRef: SPEC.environmentRef,
+        skills: [],
+        serverSkills: [CAPTURE],
+      },
+      { delivery: "emulated" }
+    )!;
     expect(out.skillsAtTurn).toEqual([]);
   });
 
   it("returns an EMPTY array for an environment that resolves no skills", () => {
     // "Ran with none" is a real answer and a different one from "unknown".
     expect(
-      turnSkillProvenance({ environmentRef: SPEC.environmentRef, skills: [] })
+      turnSkillProvenance(
+        { environmentRef: SPEC.environmentRef, skills: [] },
+        { delivery: "emulated" }
+      )
     ).toEqual({
       environmentAtTurn: SPEC.environmentRef,
       skillsAtTurn: [],
@@ -557,10 +598,13 @@ describe("turnSkillProvenance", () => {
     // side can prove beats assembling a partial row from the other fields —
     // `modelRef` and `versionPinned` appear nowhere else in this DTO, which is
     // exactly how provenance goes quietly missing.
-    const mixed = turnSkillProvenance({
-      environmentRef: SPEC.environmentRef,
-      skills: [SPEC.skills![0], PROVENANCED.skills![1]],
-    })!;
+    const mixed = turnSkillProvenance(
+      {
+        environmentRef: SPEC.environmentRef,
+        skills: [SPEC.skills![0], PROVENANCED.skills![1]],
+      },
+      { delivery: "emulated" }
+    )!;
     expect(mixed.skillsAtTurn).toEqual([PROVENANCED.skills![1].provenance]);
   });
 

--- a/mcpjam-inspector/server/services/environments/__tests__/runtime.test.ts
+++ b/mcpjam-inspector/server/services/environments/__tests__/runtime.test.ts
@@ -452,6 +452,96 @@ describe("turnSkillProvenance", () => {
     ).toBeUndefined();
   });
 
+  it("rejects an EMPTY environment name rather than recording a blank one", () => {
+    // `readScenarioEnvironment` normalizes a missing `environmentRef.name` to
+    // `""`. Recording that would export `mcpjam.environment.name: ""`, which
+    // reads as a real environment called nothing instead of as absent
+    // provenance.
+    expect(
+      turnSkillProvenance({
+        environmentRef: { ...SPEC.environmentRef, name: "" },
+        skills: PROVENANCED.skills,
+      })
+    ).toBeUndefined();
+  });
+
+  it("records CAPTURED server skills too — they are delivered like any other", () => {
+    // `resolveEffectiveCapabilities` puts `serverSkills` into the capability
+    // set and `allEffectiveSkills` hands them to the model, so omitting them
+    // would leave a turn claiming to list what it ran while silently dropping
+    // every captured MCP-server skill that ran.
+    const serverProvenance = {
+      serverSkillId: "ss_1",
+      serverSkillVersionId: "ssv_1",
+      serverSkillVersionNumber: 2,
+      name: "refunds",
+      modelRef: "acme/refunds",
+      contentHash: "h_capture",
+      sharing: "project",
+      channels: ["mcp-server"],
+    };
+    const out = turnSkillProvenance({
+      environmentRef: SPEC.environmentRef,
+      skills: PROVENANCED.skills,
+      serverSkills: [
+        {
+          serverSkillId: "ss_1",
+          versionId: "ssv_1",
+          serverId: "srv_1",
+          serverSlug: "acme",
+          serverLabel: "Acme",
+          ref: "acme/refunds",
+          skillUri: "skill://acme/refunds/SKILL.md",
+          name: "refunds",
+          description: "Handle refunds",
+          content: "CAPTURED SECRET",
+          contentSha256: "raw-digest",
+          versionHash: "vh_1",
+          versionNumber: 2,
+          capturedAt: 1,
+          provenance: serverProvenance,
+          files: [],
+        },
+      ],
+    })!;
+
+    // Authored entries first, captures appended — the order the backend's own
+    // run snapshots pin them in.
+    expect(out.skillsAtTurn).toEqual([
+      PROVENANCED.skills![0].provenance,
+      PROVENANCED.skills![1].provenance,
+      serverProvenance,
+    ]);
+    expect(JSON.stringify(out)).not.toContain("CAPTURED SECRET");
+  });
+
+  it("skips a captured skill the backend attached no provenance to", () => {
+    const out = turnSkillProvenance({
+      environmentRef: SPEC.environmentRef,
+      skills: [],
+      serverSkills: [
+        {
+          serverSkillId: "ss_1",
+          versionId: "ssv_1",
+          serverId: "srv_1",
+          serverSlug: "acme",
+          serverLabel: "Acme",
+          ref: "acme/refunds",
+          skillUri: "skill://acme/refunds/SKILL.md",
+          name: "refunds",
+          description: "Handle refunds",
+          content: "body",
+          contentSha256: "raw-digest",
+          versionHash: "vh_1",
+          versionNumber: 2,
+          capturedAt: 1,
+          files: [],
+        },
+      ],
+    })!;
+    expect(out.skillsAtTurn).toEqual([]);
+  });
+
   it("returns an EMPTY array for an environment that resolves no skills", () => {
     // "Ran with none" is a real answer and a different one from "unknown".
     expect(

--- a/mcpjam-inspector/server/services/environments/runtime.ts
+++ b/mcpjam-inspector/server/services/environments/runtime.ts
@@ -445,7 +445,10 @@ export function runtimeSkills(
  */
 export function turnSkillProvenance(
   spec:
-    | Pick<ResolvedEnvironmentRuntime, "environmentRef" | "skills">
+    | Pick<
+        ResolvedEnvironmentRuntime,
+        "environmentRef" | "skills" | "serverSkills"
+      >
     | null
     | undefined
 ): TurnSkillProvenance | undefined {
@@ -454,24 +457,38 @@ export function turnSkillProvenance(
     !ref ||
     typeof ref.environmentId !== "string" ||
     typeof ref.name !== "string" ||
+    // An EMPTY name is rejected, not tolerated. `readScenarioEnvironment`
+    // normalizes a missing `environmentRef.name` to `""`, and recording that
+    // would put a blank `mcpjam.environment.name` into an exported trace —
+    // which reads as a real environment called nothing, rather than as absent
+    // provenance. Costs nothing in practice: a payload old enough to omit the
+    // name is old enough that its skills carry no `provenance` rows either, so
+    // `skillsAtTurn` would have been empty anyway.
+    ref.name.length === 0 ||
     typeof ref.revision !== "number"
   ) {
     return undefined;
   }
+  const isProvenanceRow = (
+    provenance: unknown
+  ): provenance is Record<string, unknown> =>
+    !!provenance && typeof provenance === "object" && !Array.isArray(provenance);
   return {
     environmentAtTurn: {
       environmentId: ref.environmentId,
       name: ref.name,
       revision: ref.revision,
     },
-    skillsAtTurn: (spec?.skills ?? [])
-      .map((skill) => skill.provenance)
-      .filter(
-        (provenance): provenance is Record<string, unknown> =>
-          !!provenance &&
-          typeof provenance === "object" &&
-          !Array.isArray(provenance)
-      ),
+    // BOTH delivered channels. `resolveEffectiveCapabilities` puts
+    // `spec.serverSkills` into the capability set and `allEffectiveSkills`
+    // hands them to the model exactly like authored ones — so recording only
+    // `spec.skills` would leave a turn claiming to list what it ran while
+    // omitting every captured MCP-server skill that ran. Appended after, which
+    // is the order the backend's own run snapshots pin them in.
+    skillsAtTurn: [
+      ...(spec?.skills ?? []).map((skill) => skill.provenance),
+      ...(spec?.serverSkills ?? []).map((skill) => skill.provenance),
+    ].filter(isProvenanceRow),
   };
 }
 

--- a/mcpjam-inspector/server/services/environments/runtime.ts
+++ b/mcpjam-inspector/server/services/environments/runtime.ts
@@ -437,11 +437,32 @@ export function runtimeSkills(
  * record reflects what actually ran rather than what the environment would
  * resolve on its own.
  *
+ * DELIVERY DECIDES WHAT IS RECORDED. `skillsAtTurn` asserts "this turn ran with
+ * exactly these", so it must describe what the model RECEIVED, not what the
+ * environment resolved — the two differ per channel, and recording the resolved
+ * set would make the trace claim a skill the model never saw:
+ *
+ *   - `emulated` — every channel is delivered. `getEffectiveSkillToolsAndPrompt`
+ *     mints a tool per entry of `allEffectiveSkills`, captures included and
+ *     addressed by their namespaced `ref`. Record everything.
+ *   - `harness` — only `runtimeSkills(spec)` reaches the adapter, and that is
+ *     `spec.skills` alone. Captured MCP-server skills are NOT delivered: their
+ *     runtime address is `<serverSlug>/<name>`, and `isValidSkillName` rejects
+ *     a name containing `/`, so an adapter would skip every one as
+ *     `invalid-skill-name`. Record authored + plugin only.
+ *   - `unsupported` — the resolved harness has no skill channel at all (Codex
+ *     today). Nothing is delivered, so record an empty list.
+ *
+ * Wiring captures into the harness channel is a DELIVERY change blocked on that
+ * addressing question — see the P2 skill-delivery work. Until it lands, the
+ * honest record is the narrower one.
+ *
  * `undefined` when there is no environment — a plain Playground chat has
- * nothing to record. An empty `skillsAtTurn` when the environment resolved
- * none, because "ran with none" is a real answer. Entries whose `provenance`
- * the backend did not supply are skipped: on an older deployment that yields
- * an empty array, which is honest about what this side can prove.
+ * nothing to record. An empty `skillsAtTurn` when nothing was delivered,
+ * because "ran with none" is a real answer and a different one from "unknown".
+ * Entries whose `provenance` the backend did not supply are skipped: on an
+ * older deployment that yields an empty array, which is honest about what this
+ * side can prove.
  */
 export function turnSkillProvenance(
   spec:
@@ -450,7 +471,8 @@ export function turnSkillProvenance(
         "environmentRef" | "skills" | "serverSkills"
       >
     | null
-    | undefined
+    | undefined,
+  options: { delivery: EnvironmentSkillDelivery }
 ): TurnSkillProvenance | undefined {
   const ref = spec?.environmentRef;
   if (
@@ -479,16 +501,18 @@ export function turnSkillProvenance(
       name: ref.name,
       revision: ref.revision,
     },
-    // BOTH delivered channels. `resolveEffectiveCapabilities` puts
-    // `spec.serverSkills` into the capability set and `allEffectiveSkills`
-    // hands them to the model exactly like authored ones — so recording only
-    // `spec.skills` would leave a turn claiming to list what it ran while
-    // omitting every captured MCP-server skill that ran. Appended after, which
-    // is the order the backend's own run snapshots pin them in.
-    skillsAtTurn: [
-      ...(spec?.skills ?? []).map((skill) => skill.provenance),
-      ...(spec?.serverSkills ?? []).map((skill) => skill.provenance),
-    ].filter(isProvenanceRow),
+    // Exactly the channels this delivery mode hands to the model — see the
+    // header. Captures are appended after authored entries, the order the
+    // backend's own run snapshots pin them in.
+    skillsAtTurn:
+      options.delivery === "unsupported"
+        ? []
+        : [
+            ...(spec?.skills ?? []).map((skill) => skill.provenance),
+            ...(options.delivery === "emulated"
+              ? (spec?.serverSkills ?? []).map((skill) => skill.provenance)
+              : []),
+          ].filter(isProvenanceRow),
   };
 }
 

--- a/mcpjam-inspector/server/services/environments/runtime.ts
+++ b/mcpjam-inspector/server/services/environments/runtime.ts
@@ -51,9 +51,42 @@ export interface ResolvedEnvironmentSkill {
   extraFrontmatter?: unknown;
   /** Optional for deploy skew — an older backend may omit channel provenance. */
   channels?: RuntimeSkillChannel[];
+  /**
+   * The backend's ready-made provenance row for this entry — the shape of
+   * `pinnedSkillMetaValidator` (mcpjam-backend
+   * convex/lib/projectEnvironmentValidators.ts), built there by the one shared
+   * writer.
+   *
+   * OPAQUE on purpose. Re-declaring its fields here would make this the FOURTH
+   * hand mirror of a shape whose three existing mirrors all drifted — and the
+   * only thing this side does with it is echo it back onto the turn trace.
+   * Typing it as a record is what keeps that honest: nothing here can read a
+   * field, so nothing here can start depending on one.
+   *
+   * Optional for deploy skew: an older backend omits it, and a turn then
+   * records no provenance rather than a partial one.
+   */
+  provenance?: Record<string, unknown>;
   /** Optional for deploy skew; absent is read as "no supporting files". */
   files?: Array<{ path: string; size: number; url: string | null }>;
 }
+
+/**
+ * Per-turn configuration provenance, in the shape the chat-ingestion turn
+ * trace carries it (`turnTrace.skillsAtTurn` / `.environmentAtTurn`).
+ *
+ * `skillsAtTurn` being an EMPTY array is meaningful — "this turn ran with no
+ * skills" — and is a different fact from the whole object being undefined,
+ * which means there was no environment to record.
+ */
+export type TurnSkillProvenance = {
+  environmentAtTurn: {
+    environmentId: string;
+    name: string;
+    revision: number;
+  };
+  skillsAtTurn: Array<Record<string, unknown>>;
+};
 
 /**
  * The inspector-side mirror of the backend's `ResolvedEnvironmentRuntimeSpec`.
@@ -107,6 +140,8 @@ export interface ResolvedEnvironmentRuntime {
     versionHash: string;
     versionNumber: number;
     capturedAt: number;
+    /** Same opaque provenance row as {@link ResolvedEnvironmentSkill}. */
+    provenance?: Record<string, unknown>;
     files: Array<{ path: string; size: number; url: string | null }>;
   }>;
   pluginVersions?: Array<{
@@ -388,6 +423,56 @@ export function runtimeSkills(
       ? { extraFrontmatter: skill.extraFrontmatter as never }
       : {}),
   }));
+}
+
+/**
+ * What this turn should RECORD about the configuration it ran with.
+ *
+ * Deliberately NOT part of `runtimeSkills` and not in the effective-capability
+ * set: skill DELIVERY stays byte-identical, and provenance is a separate
+ * outbound field on the turn trace. A recording change that also changed what
+ * reaches the model would be impossible to review.
+ *
+ * Call this AFTER any narrowing (plugin overrides filter `spec.skills`), so the
+ * record reflects what actually ran rather than what the environment would
+ * resolve on its own.
+ *
+ * `undefined` when there is no environment — a plain Playground chat has
+ * nothing to record. An empty `skillsAtTurn` when the environment resolved
+ * none, because "ran with none" is a real answer. Entries whose `provenance`
+ * the backend did not supply are skipped: on an older deployment that yields
+ * an empty array, which is honest about what this side can prove.
+ */
+export function turnSkillProvenance(
+  spec:
+    | Pick<ResolvedEnvironmentRuntime, "environmentRef" | "skills">
+    | null
+    | undefined
+): TurnSkillProvenance | undefined {
+  const ref = spec?.environmentRef;
+  if (
+    !ref ||
+    typeof ref.environmentId !== "string" ||
+    typeof ref.name !== "string" ||
+    typeof ref.revision !== "number"
+  ) {
+    return undefined;
+  }
+  return {
+    environmentAtTurn: {
+      environmentId: ref.environmentId,
+      name: ref.name,
+      revision: ref.revision,
+    },
+    skillsAtTurn: (spec?.skills ?? [])
+      .map((skill) => skill.provenance)
+      .filter(
+        (provenance): provenance is Record<string, unknown> =>
+          !!provenance &&
+          typeof provenance === "object" &&
+          !Array.isArray(provenance)
+      ),
+  };
 }
 
 // ── Browser preview projection ──────────────────────────────────────────────

--- a/mcpjam-inspector/server/utils/__tests__/chat-ingestion.test.ts
+++ b/mcpjam-inspector/server/utils/__tests__/chat-ingestion.test.ts
@@ -802,6 +802,63 @@ describe("chat-ingestion", () => {
     expect(body.turnTrace.turnId).toBe("turn-abc");
   });
 
+  it("carries the turn's skill/environment provenance on the wire", async () => {
+    // The provenance rides INSIDE `turnTrace`, which `buildIngestBody`
+    // serializes whole — so this reaches the backend with no edit to the body
+    // builder's field spread. If someone "fixes" that by adding the fields
+    // there too, this test still passes and the duplication is dead weight;
+    // what it guards is that the fields arrive at all.
+    global.fetch = vi.fn().mockResolvedValue(
+      new Response(JSON.stringify({ ok: true, version: 2 }), {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      })
+    ) as typeof fetch;
+
+    const turnTrace = {
+      turnId: "turn-prov",
+      promptIndex: 0,
+      startedAt: 1,
+      endedAt: 2,
+      spans: [],
+      modelId: "openai/gpt-oss-120b",
+      skillsAtTurn: [
+        {
+          skillId: "sk_1",
+          projectSkillVersionNumber: 3,
+          versionPinned: true,
+          name: "refunds",
+          contentHash: "h1",
+          sharing: "project",
+          channels: ["environment"],
+        },
+      ],
+      environmentAtTurn: {
+        environmentId: "env_1",
+        name: "Pinned arm",
+        revision: 4,
+      },
+    };
+
+    await persistChatSessionToConvex({
+      chatSessionId: "prov-session",
+      modelId: "openai/gpt-oss-120b",
+      modelSource: "mcpjam",
+      authHeader: "Bearer bearer-token",
+      origin: "playground",
+      startedAt: 1,
+      turnTrace,
+    });
+
+    const calls = (global.fetch as unknown as ReturnType<typeof vi.fn>).mock
+      .calls;
+    const body = JSON.parse(calls[0][1].body as string);
+    expect(body.turnTrace.skillsAtTurn).toEqual(turnTrace.skillsAtTurn);
+    expect(body.turnTrace.environmentAtTurn).toEqual(
+      turnTrace.environmentAtTurn
+    );
+  });
+
   it("omits turnId for a traceless payload so the legacy path is unchanged", async () => {
     // Its own fetch mock: reading `mock.calls[0]` off an inherited one makes the
     // assertion depend on suite order rather than on this request.

--- a/mcpjam-inspector/server/utils/chat-ingestion.ts
+++ b/mcpjam-inspector/server/utils/chat-ingestion.ts
@@ -240,6 +240,26 @@ export interface PersistedTurnTrace {
   usage?: LiveChatTraceUsage;
   finishReason?: string;
   modelId: string;
+  /**
+   * Which skills and which environment this turn ran with, echoed from the
+   * backend's per-entry `provenance` rows (see
+   * `services/environments/runtime.ts` `turnSkillProvenance`).
+   *
+   * Carried INSIDE the turn trace, not beside it, for two reasons. The binding
+   * is per-TURN — a session live-follows Latest, so an edit changes what the
+   * NEXT turn runs. And `buildIngestBody` serializes `turnTrace` whole, so
+   * these fields reach the wire with NO change to the body builder: do not
+   * "fix" that by adding them to its spread.
+   *
+   * Ids are opaque strings here. The backend normalizes and tenancy-checks
+   * every one and strips what fails, so this side never needs to.
+   */
+  skillsAtTurn?: Array<Record<string, unknown>>;
+  environmentAtTurn?: {
+    environmentId: string;
+    name: string;
+    revision: number;
+  };
 }
 
 // Mirrors mcpjam-backend `chatOriginValidator`. Required at every writer

--- a/mcpjam-inspector/server/utils/scenario-runtime-config.ts
+++ b/mcpjam-inspector/server/utils/scenario-runtime-config.ts
@@ -63,6 +63,18 @@ export type ScenarioEnvironmentRuntime = {
     aggregateHash: string;
     extraFrontmatter?: unknown;
     channels?: RuntimeSkillChannel[];
+    /**
+     * The backend's ready-made provenance row for this entry — opaque here for
+     * the reason spelled out on `ResolvedEnvironmentSkill.provenance`: this
+     * side only echoes it onto the turn trace, and a typed mirror would be the
+     * fourth copy of a shape whose three existing copies all drifted.
+     *
+     * Passed through TOLERANTLY: any object survives, and a non-object drops.
+     * Deliberately NOT routed through the `SKILL_CHANNELS` filter the sibling
+     * fields use — that filter exists to keep unknown channels out of delivery
+     * decisions, and this field reaches no delivery decision.
+     */
+    provenance?: Record<string, unknown>;
     files?: Array<{ path: string; size: number; url: string | null }>;
   }>;
   /**
@@ -462,6 +474,9 @@ export function readScenarioEnvironment(
               ? { extraFrontmatter: entry.extraFrontmatter }
               : {}),
             ...(channels ? { channels } : {}),
+            ...(isRecord(entry.provenance)
+              ? { provenance: entry.provenance }
+              : {}),
             ...(files ? { files } : {}),
           },
         ];

--- a/mcpjam-inspector/server/utils/web-chat-turn.ts
+++ b/mcpjam-inspector/server/utils/web-chat-turn.ts
@@ -77,6 +77,7 @@ import {
 import type { HarnessSessionCommitPayload } from "./harness/harness-session-state.js";
 import { type RuntimeSkill } from "./harness/runtime-skills.js";
 import type { EffectiveCapabilitySet } from "../services/environments/effective-capabilities.js";
+import type { TurnSkillProvenance } from "../services/environments/runtime.js";
 import { exportConnectedServerToolSnapshotForEvalAuthoring } from "./export-helpers.js";
 import { ErrorCode, WebRouteError } from "./../routes/web/errors.js";
 import { readUrlElicitations } from "@/shared/http-tool-calls";
@@ -254,6 +255,16 @@ export interface WebChatTurnPersistContext {
    * resumed sandbox with stale plugin material ineligible.
    */
   effectiveCapabilities?: EffectiveCapabilitySet;
+  /**
+   * What this turn should RECORD about the configuration it ran with —
+   * `{environmentAtTurn, skillsAtTurn}` from `turnSkillProvenance`, computed
+   * from the POST-narrowing spec so it reflects what actually ran.
+   *
+   * Separate from `runtimeSkillsOverride` and `effectiveCapabilities` on
+   * purpose: those decide what reaches the model, this only decides what gets
+   * written down. Delivery is byte-identical whether this is present or not.
+   */
+  turnProvenance?: TurnSkillProvenance;
 }
 
 /**
@@ -885,7 +896,14 @@ export async function streamWebChatTurn(
               ...(resolvedHostConfig ? { hostConfig: resolvedHostConfig } : {}),
             }
           : {}),
-        turnTrace,
+        // Merged OUTSIDE the `isDirectChat` gate above: a scenario turn runs
+        // through an environment too, and skipping it there would leave User
+        // Testing's most environment-driven surface with no record of what it
+        // ran. Distinct from `resumeConfig`, which is gated because it is the
+        // restorable-resume surface; this is provenance and restores nothing.
+        turnTrace: persist.turnProvenance
+          ? { ...turnTrace, ...persist.turnProvenance }
+          : turnTrace,
         ...(persist.expectedVersion !== undefined
           ? { expectedVersion: persist.expectedVersion }
           : {}),

--- a/sdk/src/platform/operations.ts
+++ b/sdk/src/platform/operations.ts
@@ -92,6 +92,7 @@ import type {
   PlatformEvalRunGroupCreated,
   PlatformAdhocEnvironment,
   PlatformAdhocEnvironmentBody,
+  PlatformEnvironmentSkillSelection,
   PlatformComputerAttached,
   PlatformComputerReset,
   PlatformEnvironment,
@@ -2943,7 +2944,7 @@ async function composeRunEnvironment(
     includeClientDefault?: boolean;
     saveTargets?: boolean;
     computer?: string;
-    skills?: { mode: "explicit"; skillIds: string[] };
+    skills?: PlatformEnvironmentSkillSelection;
     pluginVersionIds?: string[];
   },
   signal: AbortSignal | undefined,
@@ -3334,6 +3335,73 @@ export const listEvalSuiteRunsOperation: PlatformOperation<
  * until someone hits it.
  */
 /**
+ * The ONE skill-selection schema. Every surface that accepts a pinned skill
+ * selection — `create_project_environment`, `update_project_environment`,
+ * `ensure_adhoc_environment`, and the run ops' `compose` field — parses
+ * through this, so a selection means the same thing wherever it is written.
+ *
+ * `compose` used to declare its own narrower twin, which parsed `mode` and
+ * `skillIds` and dropped `versionPins` on the floor: composing a pinned stack
+ * silently ran Latest, which is precisely the arm the caller pinned away from.
+ *
+ * Declared HERE, above the run inputs, for the same temporal-dead-zone reason
+ * `composeRunTargetInput` is — the environment ops that also use it are far
+ * below.
+ */
+const skillSelectionInput = z
+  .object({
+    mode: z.literal("explicit"),
+    skillIds: z
+      .array(z.string().trim().min(1))
+      .min(1)
+      .describe(
+        "Project-shared skill IDs to select. Plugin-component skills cannot be selected — they reach a run by pinning their plugin version."
+      ),
+    versionPins: z
+      .array(
+        z.object({
+          skillId: z.string().trim().min(1),
+          versionId: z.string().trim().min(1),
+        })
+      )
+      .min(1)
+      .optional()
+      .describe(
+        "Optional exact-version overlay: at most one entry per selected skill, each naming a version of that same skill. A selected skill with no entry runs 'Latest' — its current revision, resolved when the run starts. Pin a version to hold this environment at a known revision, e.g. to compare two revisions of one skill side by side."
+      ),
+  })
+  // The pins are only meaningful RELATIVE to the selection they ride on, so the
+  // relation is checked here rather than left to the API: a duplicate pin makes
+  // "which revision does this skill run?" ambiguous, and a pin for an
+  // unselected skill silently does nothing. Both are rejected server-side too —
+  // catching them in the SDK turns a round-trip error into an immediate one.
+  .superRefine((selection, ctx) => {
+    const pins = selection.versionPins ?? [];
+    const selected = new Set(selection.skillIds);
+    const seen = new Set<string>();
+    for (const pin of pins) {
+      if (seen.has(pin.skillId)) {
+        ctx.addIssue({
+          code: z.ZodIssueCode.custom,
+          path: ["versionPins"],
+          message: `Skill ${pin.skillId} has more than one version pin; pin at most one version per skill.`,
+        });
+      }
+      seen.add(pin.skillId);
+      if (!selected.has(pin.skillId)) {
+        ctx.addIssue({
+          code: z.ZodIssueCode.custom,
+          path: ["versionPins"],
+          message: `Version pin references skill ${pin.skillId}, which is not in skillIds.`,
+        });
+      }
+    }
+  })
+  .describe(
+    "Explicit pinned skill selection. Cannot be empty — omit the field entirely, or pass null when updating, to mean 'no pinned skills'."
+  );
+
+/**
  * A COMPOSED run target: assemble a stack instead of naming a saved
  * environment. Declared here, above the run inputs, for the same
  * temporal-dead-zone reason `publicMatchOptionsSchema` is.
@@ -3394,13 +3462,11 @@ const composeRunTargetInput = z
       .describe(
         "Sandbox image (name or ID) to pin, so the run boots a fresh computer from it. Must be project-shared."
       ),
-    skills: z
-      .object({
-        mode: z.literal("explicit"),
-        skillIds: z.array(z.string().trim().min(1)).min(1),
-      })
+    skills: skillSelectionInput
       .optional()
-      .describe("Explicit pinned skill selection for the composed stack."),
+      .describe(
+        "Explicit pinned skill selection for the composed stack, `versionPins` included — the same schema every other skill-selection surface uses."
+      ),
     pluginVersionIds: z
       .array(z.string().trim().min(1))
       .min(1)
@@ -8728,59 +8794,6 @@ export const resolveEnvironmentOperation: PlatformOperation<
   },
 };
 
-const skillSelectionInput = z
-  .object({
-    mode: z.literal("explicit"),
-    skillIds: z
-      .array(z.string().trim().min(1))
-      .min(1)
-      .describe(
-        "Project-shared skill IDs to select. Plugin-component skills cannot be selected — they reach a run by pinning their plugin version."
-      ),
-    versionPins: z
-      .array(
-        z.object({
-          skillId: z.string().trim().min(1),
-          versionId: z.string().trim().min(1),
-        })
-      )
-      .min(1)
-      .optional()
-      .describe(
-        "Optional exact-version overlay: at most one entry per selected skill, each naming a version of that same skill. A selected skill with no entry runs 'Latest' — its current revision, resolved when the run starts. Pin a version to hold this environment at a known revision, e.g. to compare two revisions of one skill side by side."
-      ),
-  })
-  // The pins are only meaningful RELATIVE to the selection they ride on, so the
-  // relation is checked here rather than left to the API: a duplicate pin makes
-  // "which revision does this skill run?" ambiguous, and a pin for an
-  // unselected skill silently does nothing. Both are rejected server-side too —
-  // catching them in the SDK turns a round-trip error into an immediate one.
-  .superRefine((selection, ctx) => {
-    const pins = selection.versionPins ?? [];
-    const selected = new Set(selection.skillIds);
-    const seen = new Set<string>();
-    for (const pin of pins) {
-      if (seen.has(pin.skillId)) {
-        ctx.addIssue({
-          code: z.ZodIssueCode.custom,
-          path: ["versionPins"],
-          message: `Skill ${pin.skillId} has more than one version pin; pin at most one version per skill.`,
-        });
-      }
-      seen.add(pin.skillId);
-      if (!selected.has(pin.skillId)) {
-        ctx.addIssue({
-          code: z.ZodIssueCode.custom,
-          path: ["versionPins"],
-          message: `Version pin references skill ${pin.skillId}, which is not in skillIds.`,
-        });
-      }
-    }
-  })
-  .describe(
-    "Explicit pinned skill selection. Cannot be empty — omit the field entirely, or pass null when updating, to mean 'no pinned skills'."
-  );
-
 const pluginVersionIdsInput = z
   .array(z.string().trim().min(1))
   .min(1)
@@ -8972,7 +8985,7 @@ async function resolveComposeStack(
     serverGroup?: string;
     model?: string;
     computer?: string;
-    skills?: { mode: "explicit"; skillIds: string[] };
+    skills?: PlatformEnvironmentSkillSelection;
     pluginVersionIds?: string[];
   },
   signal: AbortSignal | undefined

--- a/sdk/src/platform/types.ts
+++ b/sdk/src/platform/types.ts
@@ -2139,6 +2139,14 @@ export interface PlatformEnvironmentCapabilities {
    * env may launch without suite membership. Absent/false on older backends.
    */
   ephemeralEnvironmentLaunch?: boolean;
+  /**
+   * `skillSelection.versionPins` / `serverSkillSelection.versionPins` are
+   * accepted, and a pinned revision survives into run snapshots. Absent/false
+   * on older backends, which reject the unknown field outright — so probe this
+   * before offering a version picker. Optional, so an older backend's response
+   * still parses.
+   */
+  skillVersionPins?: boolean;
 }
 
 /** Body for the archive/restore sub-actions — the precondition only. */

--- a/sdk/tests/platform/operations-compose.test.ts
+++ b/sdk/tests/platform/operations-compose.test.ts
@@ -628,3 +628,79 @@ describe("expandComposeModelChoices", () => {
     ]);
   });
 });
+
+describe("compose skill selection", () => {
+  it("carries versionPins through to the ensure-adhoc body", async () => {
+    // The regression: `compose` declared its own narrower `skills` schema that
+    // parsed `mode` + `skillIds` and dropped `versionPins` on the floor, so
+    // composing a pinned stack silently ran Latest — the exact arm the caller
+    // pinned away from, invisibly, in a comparison meant to tell two revisions
+    // apart. Both surfaces parse through one schema now.
+    const { client, fetchMock } = makeClient();
+    // Through the SCHEMA, the way every real caller arrives (MCP tool call,
+    // CLI flag parse). `execute` on a hand-built object would sail past the
+    // very stripping this covers.
+    const input = runEvalSuiteOperation.inputSchema.parse({
+      suite: "Smoke",
+      compose: {
+        host: "Claude Code",
+        skills: {
+          mode: "explicit",
+          skillIds: ["skill-a", "skill-b"],
+          versionPins: [{ skillId: "skill-a", versionId: "ver-a1" }],
+        },
+      },
+    });
+    await runEvalSuiteOperation.execute(input, { client });
+
+    expect(bodyOf(fetchMock, /ensure-adhoc$/)).toEqual({
+      hostId: "host-claude",
+      skillSelection: {
+        mode: "explicit",
+        skillIds: ["skill-a", "skill-b"],
+        versionPins: [{ skillId: "skill-a", versionId: "ver-a1" }],
+      },
+    });
+  });
+
+  it("rejects a duplicate pin and a pin for an unselected skill, before any write", () => {
+    // Sharing the schema means sharing its refinements: `compose` inherits the
+    // relational checks it never had, so these fail immediately instead of
+    // after a round trip.
+    const duplicate = runEvalSuiteOperation.inputSchema.safeParse({
+      suite: "Smoke",
+      compose: {
+        host: "Claude Code",
+        skills: {
+          mode: "explicit",
+          skillIds: ["skill-a"],
+          versionPins: [
+            { skillId: "skill-a", versionId: "ver-a1" },
+            { skillId: "skill-a", versionId: "ver-a2" },
+          ],
+        },
+      },
+    });
+    expect(duplicate.success).toBe(false);
+    expect(JSON.stringify(duplicate.error?.issues)).toContain(
+      "more than one version pin",
+    );
+
+    const unselected = runEvalCaseOperation.inputSchema.safeParse({
+      suite: "Smoke",
+      case: "c1",
+      compose: {
+        host: "Claude Code",
+        skills: {
+          mode: "explicit",
+          skillIds: ["skill-a"],
+          versionPins: [{ skillId: "skill-b", versionId: "ver-b1" }],
+        },
+      },
+    });
+    expect(unselected.success).toBe(false);
+    expect(JSON.stringify(unselected.error?.issues)).toContain(
+      "which is not in skillIds",
+    );
+  });
+});


### PR DESCRIPTION
Follow-up to #4431. Two commits: the P0 fix first, then the P1 echo plumbing.

## Commit 1 — P0: `compose` silently stripped `versionPins`

`run_eval_suite` / `run_eval_case`'s `compose.skills` declared its own narrower Zod object — `mode` and `skillIds` only. Zod strips unknown keys, so **composing a stack with `versionPins` parsed clean and ran Latest: the exact arm the caller pinned away from, invisibly, in a comparison meant to tell two revisions apart.**

Compose now parses through `skillSelectionInput`, the schema every other skill-selection surface already used, hoisted above the run inputs the way `composeRunTargetInput` itself is (temporal dead zone — the environment ops that also use it sit far below). It inherits the relational refinements for free: a duplicate pin, or a pin for an unselected skill, is now rejected client-side instead of after a round trip. The two compose stack types carry `PlatformEnvironmentSkillSelection` rather than a third hand-written twin, so pins reach `ensureAdhocEnvironment`, whose body type already accepted them.

Both regression tests go **through the schema**, the way a real caller arrives (MCP tool call, CLI flag parse) — `execute` on a hand-built object sails straight past the stripping this is about. Both fail on `main`.

Also adds the `skillVersionPins` capability so a client can probe whether a deployment accepts pins before offering a version picker: v1 capabilities route (normalized with `=== true`, so an older backend reads `false` rather than `undefined`), OpenAPI schema, and the SDK capabilities type as an additive optional.

No spec change was needed for compose itself — it is SDK-side composition and the REST target already documents `versionPins`. `openapi-types-parity` and `sdk-coverage` stay green.

## Commit 2 — P1: turns echo the configuration they ran with

The backend now hands down a ready-made provenance row per resolved skill entry (MCPJam/mcpjam-backend#1175). This echoes it onto the outgoing turn trace.

- **Echoed opaquely**, as `Record<string, unknown>`. A typed mirror would be the fourth copy of a shape whose three existing copies all drifted, and nothing here reads a field — typing it as a record is what keeps that true.
- `turnSkillProvenance(spec)` builds `{environmentAtTurn, skillsAtTurn}` from the **post-narrowing** spec, so plugin overrides are reflected. It is deliberately **not** part of `runtimeSkills` or the effective-capability set: skill delivery stays byte-identical, and a recording change that also changed what reaches the model would be impossible to review. There is a test asserting exactly that.
- Entries without a `provenance` row are skipped. On an older backend that yields an empty list — honest about what this side can prove, where assembling a row from the DTO's other fields would quietly omit `modelRef` and `versionPinned`.
- **The merge sits OUTSIDE the `isDirectChat` gate.** `resumeConfig` is gated because it is the restorable-resume surface; provenance restores nothing, and gating it the same way would leave User Testing — the most environment-driven surface there is — with no record of what it ran. There is a scenario-turn test that fails if someone moves it inside.
- **`buildIngestBody` needs no edit** and gets none: it serializes `turnTrace` whole, and the fields ride inside it. That is by design, not an oversight — please don't "fix" it by adding them to the body builder's field spread.
- Scenario runtime configs pass the row through tolerantly (any object survives, a non-object drops), **not** through the `SKILL_CHANNELS` filter its siblings use — that filter keeps unknown channels out of delivery decisions, and this field reaches none.
- Ids stay opaque strings here; the backend normalizes and tenancy-checks every one and strips what fails.

## Verification

- `npx vitest run server/` — **7,642 passed**, 43 skipped
- `npm run test -w @mcpjam/sdk` — **6,841 passed**, 8 skipped
- workspace `npm run typecheck` and `npm run test:checks` green; `server/tsconfig.json` error count unchanged from `main` (188 pre-existing)
- 9 of the new tests fail on `main` with only the source files reverted

## Known gaps (accepted)

- `routes/v1/chat-session-turn.ts` delivers no environment skills yet (P2), so v1 API sessions legitimately record none.
- `routes/mcp/chat-v2.ts` (local) and `routes/web/mcpjam-agent.ts` are untouched.
- Harness turns that fall back to the project-wide skill pool record nothing.

Companion PR: MCPJam/mcpjam-backend#1175 — that one carries a **production crash fix** (pinning a skill version and starting an eval run currently throws at run start) and is worth landing first. Deploy interleaving is otherwise safe in either order: an older backend drops these fields at its allowlist, and an older Inspector simply sends none.

Out of scope, per plan: P2 (Playground skills UI + version picker, v1 turn-route skill delivery, `list_skill_versions`, CLI `versions`/`name@vN`, `serverSkillSelection` product surface, Skills-screen history, detail-view provenance display) and P3.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Q4DPJguFhCqfv919mnnknq)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes eval compose inputs and chat persistence/trace shape; delivery is intentionally unchanged but provenance logic must stay aligned with harness vs emulated skill channels to avoid misleading traces.
> 
> **Overview**
> **Fixes `compose` silently dropping skill `versionPins`** so a pinned eval stack no longer parses clean and runs Latest. `run_eval_suite` / `run_eval_case` now share the same `skillSelectionInput` schema as environment create/update, including client-side refinements for duplicate or unselected pins. Adds **`skillVersionPins`** on v1 environment capabilities (normalized to boolean), OpenAPI, and SDK types so clients can probe before showing a version picker.
> 
> **Records what each web chat turn ran with** without changing skill delivery: new `turnSkillProvenance` builds `environmentAtTurn` and `skillsAtTurn` from backend opaque provenance rows after execution is resolved — emulated turns include captured MCP-server skills; harness turns record only authored/plugin skills; unsupported harness channels get an empty list. Provenance merges into `turnTrace` **outside** the `isDirectChat` gate so environment-backed scenario turns are covered; direct/host turns omit it. Scenario runtime config passes `provenance` through tolerantly.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cd60f41e66b1cd83f885a7e559271f3c5effca8d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes `compose` silently stripping skill `versionPins`, so a pinned run no longer silently runs Latest, and records what skills and environment each chat turn actually ran with. Companion `mcpjam-backend` PR #1175 carries a production crash fix for pinned eval runs and is worth landing first; deploy interleaving is safe either way.

**Bug Fixes**
- `runEvalSuite`/`runEvalCase` now parse `compose.skills` through the shared `skillSelectionInput` schema, so `versionPins` survive and duplicate or unselected pins fail client-side.
- Adds the `skillVersionPins` capability so a client can probe whether a deployment accepts pins before offering a version picker.

**New Features**
- Turns now record `environmentAtTurn` and `skillsAtTurn` on the turn trace, echoed opaquely from backend rows so skill delivery stays byte-identical; the record follows what was actually delivered, so captured MCP-server skills appear only on emulated turns, never harness ones.
- Provenance is merged outside the `isDirectChat` gate so environment-backed scenario turns record what they ran; entries without provenance rows and blank environment names are skipped on older backends.
- Tests assert both the model handler's delivery input and the persisted record on a harness turn, pinning the invariant that the two agree.
- Known gaps: v1 API sessions and harness turns that fall back to the project-wide skill pool record no provenance.

<sup>Written for commit cd60f41e66b1cd83f885a7e559271f3c5effca8d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/MCPJam/inspector/pull/4452?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

