### PR TITLE
Skills tab: an honest count, and rows that say only what distinguishes them

### DIFF
--- a/.changeset/skills-rows-say-only-what-distinguishes-them.md
+++ b/.changeset/skills-rows-say-only-what-distinguishes-them.md
@@ -1,0 +1,13 @@
+---
+"@mcpjam/inspector": patch
+---
+
+Skills tab: the header count tells the truth, and a row only says what makes it different
+
+**"Skills 0" over a list of skills.** The header badge counted the project store alone. That was unambiguous while server-served skills sat under a heading of their own, and became a plain falsehood the moment both halves became one flat list — a signed-out user with a connected server saw `0` above a panel of visible rows. A badge next to a list is read as the length of that list, so it now counts both halves. The two really are different namespaces (a name here, a URI there); that distinction lives on the rows, which name their origin server, not in a number nobody reads that way.
+
+**A green shield with a bare number on every row.** The number was the file count of the skill's advertised manifest, and the shield meant the skill was digest-verified — which every listed skill is, because verification is mandatory rather than something a skill can win. So the badge distinguished nothing and the number had no reading. Both moved into the row's tooltip, next to the skill URI. What stays on the row is the amber `unverifiable — declined` badge: the one row that behaves differently is the one worth marking.
+
+**A block of dead space above the rows.** The project store's "No skills available / Upload your first skill" call to action rendered on the project store's own count, so it appeared — a centred hundred-odd pixels of it — between the header and server rows that were right there. Both placeholders now speak for the whole list: they render only when the whole list is empty, and below the rows rather than above them. The server section reports whether a listing is still outstanding, so an unanswered fetch no longer reads as an empty store and then flashes away when the rows land.
+
+**The per-server "load by URI" input is gone.** `skills/get` still answers for a URI a listing never mentioned — that capability has not moved, and the tab still uses it to open a row — but a text box under every server was a debugging tool priced as permanent furniture in a panel whose job is to show what a server serves. It is available on `mcpjam skills get` and on the `/v1/…/skills/get` REST endpoint.

--- a/mcpjam-inspector/client/src/components/SkillsTab.tsx
+++ b/mcpjam-inspector/client/src/components/SkillsTab.tsx
@@ -151,6 +151,23 @@ export function SkillsTab({
    * section owns its own per-connection fetch state.
    */
   const [refreshToken, setRefreshToken] = useState(0);
+  /**
+   * What the server-skills half of the list currently holds.
+   *
+   * The tab makes two claims about the list as a whole — the header count, and
+   * the "no skills yet" call to action — and since the group headers went away
+   * both halves are one flat list. Reported up rather than re-derived here: the
+   * section owns the per-connection fetch, and only it knows which servers
+   * declared the extension at all.
+   */
+  const [serverSkills, setServerSkills] = useState<{
+    count: number;
+    pending: boolean;
+  }>({ count: 0, pending: false });
+  const handleServerSkillsChange = useCallback(
+    (state: { count: number; pending: boolean }) => setServerSkills(state),
+    []
+  );
   const [skillFiles, setSkillFiles] = useState<Record<string, SkillFile[]>>({});
   const [loadingFiles, setLoadingFiles] = useState<Record<string, boolean>>({});
   const [selectedFilePath, setSelectedFilePath] = useState<string>("SKILL.md");
@@ -485,6 +502,13 @@ export function SkillsTab({
     setRawMode(false);
   };
 
+  // Both halves, because the placeholders below speak for the whole list.
+  // `listIsSettling` covers a listing that has not answered yet — offering
+  // "upload your first skill" in that window would be a claim about a store we
+  // are still reading, and it would flash away the moment the rows land.
+  const listIsEmpty = skills.length === 0 && serverSkills.count === 0;
+  const listIsSettling = fetchingSkills || serverSkills.pending;
+
   return (
     <div className="h-full flex flex-col">
       <ResizablePanelGroup direction="horizontal" className="flex-1">
@@ -498,15 +522,17 @@ export function SkillsTab({
                 <h2 className="text-xs font-semibold text-foreground">
                   Skills
                 </h2>
-                {/* Counts the PROJECT store only. Server skills are counted
-                    per origin inside their own section, because one number
-                    spanning both would imply a single namespace they do not
-                    share — a name here, a URI there. */}
-                {!cloudStoreHidden && (
-                  <Badge variant="secondary" className="text-xs font-mono">
-                    {skills.length}
-                  </Badge>
-                )}
+                {/* Counts BOTH halves, because it counts what is on the screen.
+                    It used to count the project store alone, which was
+                    unambiguous while server skills sat under a heading of their
+                    own and became a plain falsehood when they joined the same
+                    flat list — "Skills 0" over a panel of visible rows. The two
+                    halves really are different namespaces (a name here, a URI
+                    there), but a badge next to a list is read as the length of
+                    that list, not as the size of a namespace. */}
+                <Badge variant="secondary" className="text-xs font-mono">
+                  {skills.length + serverSkills.count}
+                </Badge>
               </div>
               {/* Upload and the Local/Cloud toggle act on the project store,
                   so they go with it. Refresh does NOT: it re-reads the server
@@ -562,31 +588,7 @@ export function SkillsTab({
             <div className="flex-1 overflow-hidden">
               <ScrollArea className="h-full">
                 <div className="p-2">
-                  {cloudStoreHidden ? null : fetchingSkills ? (
-                    <div className="flex flex-col items-center justify-center py-16 text-center">
-                      <div className="w-8 h-8 bg-muted rounded-full flex items-center justify-center mb-3">
-                        <RefreshCw className="h-4 w-4 text-muted-foreground animate-spin cursor-pointer" />
-                      </div>
-                      <p className="text-xs text-muted-foreground font-semibold mb-1">
-                        Loading skills...
-                      </p>
-                    </div>
-                  ) : skills.length === 0 ? (
-                    <div className="text-center py-8">
-                      <p className="text-sm text-muted-foreground mb-4">
-                        No skills available
-                      </p>
-                      <Button
-                        variant="outline"
-                        size="sm"
-                        onClick={() => setIsUploadDialogOpen(true)}
-                        disabled={cloudUnavailable}
-                      >
-                        <Plus className="h-3 w-3 mr-2" />
-                        Upload your first skill
-                      </Button>
-                    </div>
-                  ) : (
+                  {!cloudStoreHidden && skills.length > 0 && (
                     <SkillsFileTree
                       skills={skills}
                       skillFiles={skillFiles}
@@ -610,7 +612,42 @@ export function SkillsTab({
                     {...(projectId ? { projectId } : {})}
                     refreshToken={refreshToken}
                     onOpenSkill={handleOpenServerSkill}
+                    onListingChange={handleServerSkillsChange}
                   />
+                  {/* Placeholders for the WHOLE list, so they render only when
+                      the whole list is empty — and BELOW the rows, so nothing
+                      can sit above them. The project store's own empty state
+                      used to render on its own count: a signed-out user with a
+                      server serving skills got a hundred-odd pixels of centered
+                      "upload your first skill" wedged between the header and
+                      rows that were right there. */}
+                  {listIsEmpty &&
+                    !cloudStoreHidden &&
+                    (listIsSettling ? (
+                      <div className="flex flex-col items-center justify-center py-16 text-center">
+                        <div className="w-8 h-8 bg-muted rounded-full flex items-center justify-center mb-3">
+                          <RefreshCw className="h-4 w-4 text-muted-foreground animate-spin cursor-pointer" />
+                        </div>
+                        <p className="text-xs text-muted-foreground font-semibold mb-1">
+                          Loading skills...
+                        </p>
+                      </div>
+                    ) : (
+                      <div className="text-center py-8">
+                        <p className="text-sm text-muted-foreground mb-4">
+                          No skills available
+                        </p>
+                        <Button
+                          variant="outline"
+                          size="sm"
+                          onClick={() => setIsUploadDialogOpen(true)}
+                          disabled={cloudUnavailable}
+                        >
+                          <Plus className="h-3 w-3 mr-2" />
+                          Upload your first skill
+                        </Button>
+                      </div>
+                    ))}
                 </div>
               </ScrollArea>
             </div>

--- a/mcpjam-inspector/client/src/components/__tests__/SkillsTab.list-summary.test.tsx
+++ b/mcpjam-inspector/client/src/components/__tests__/SkillsTab.list-summary.test.tsx
@@ -1,0 +1,108 @@
+/**
+ * The header count and the "no skills yet" call to action describe the LIST.
+ *
+ * They used to describe the project store alone, which was unambiguous while
+ * server skills sat under a heading of their own. Once the headings went and
+ * both halves became one flat list, each claim became visibly wrong in the same
+ * screenshot: a badge reading "Skills 0" above server rows, and a centred
+ * upload prompt reserving a block of vertical space between the header and
+ * those same rows.
+ */
+import { useEffect } from "react";
+import { render, screen, waitFor } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const { listSkills, serverListing } = vi.hoisted(() => ({
+  listSkills: vi.fn(async () => [] as Array<{ name: string }>),
+  serverListing: { count: 0, pending: false },
+}));
+
+vi.mock("@/lib/apis/mcp-skills-api", () => ({
+  listSkills,
+  getSkill: vi.fn(async () => null),
+  deleteSkill: vi.fn(),
+  listSkillFiles: vi.fn(async () => []),
+  readSkillFile: vi.fn(async () => null),
+  promoteSkill: vi.fn(),
+}));
+
+vi.mock("@/lib/config", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@/lib/config")>();
+  return { ...actual, HOSTED_MODE: true };
+});
+
+// Stands in for the real per-connection fetch: it answers with whatever this
+// test's `serverListing` says, on the same channel the real section uses.
+vi.mock("../skills/ServerSkillsSection", () => ({
+  ServerSkillsSection: ({
+    onListingChange,
+  }: {
+    onListingChange?: (state: { count: number; pending: boolean }) => void;
+  }) => {
+    useEffect(() => {
+      onListingChange?.(serverListing);
+    }, [onListingChange]);
+    return <div data-testid="server-skills" />;
+  },
+}));
+
+vi.mock("@/lib/analytics", () => ({ track: vi.fn() }));
+
+import { SkillsTab } from "../SkillsTab";
+
+beforeEach(() => {
+  listSkills.mockClear();
+  listSkills.mockResolvedValue([]);
+  serverListing.count = 0;
+  serverListing.pending = false;
+});
+
+afterEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("SkillsTab — what the header and the placeholder claim", () => {
+  it("counts both halves of the list", async () => {
+    listSkills.mockResolvedValue([{ name: "refunds" }]);
+    serverListing.count = 2;
+
+    render(<SkillsTab projectId="project-1" cloudSkillsEnabled />);
+
+    // Not "1": the badge sits next to a list, and is read as its length.
+    expect(await screen.findByText("3")).toBeInTheDocument();
+  });
+
+  it("does not reserve space for an upload prompt above server rows", async () => {
+    serverListing.count = 2;
+
+    render(<SkillsTab projectId="project-1" cloudSkillsEnabled />);
+
+    await waitFor(() => expect(listSkills).toHaveBeenCalled());
+    expect(screen.queryByText("No skills available")).not.toBeInTheDocument();
+    expect(
+      screen.queryByRole("button", { name: /upload your first skill/i })
+    ).not.toBeInTheDocument();
+    expect(await screen.findByText("2")).toBeInTheDocument();
+  });
+
+  it("still offers the upload prompt when the whole list is empty", async () => {
+    render(<SkillsTab projectId="project-1" cloudSkillsEnabled />);
+
+    expect(
+      await screen.findByRole("button", { name: /upload your first skill/i })
+    ).toBeInTheDocument();
+  });
+
+  it("withholds the upload prompt while a server listing is outstanding", async () => {
+    serverListing.pending = true;
+
+    render(<SkillsTab projectId="project-1" cloudSkillsEnabled />);
+
+    await waitFor(() => expect(listSkills).toHaveBeenCalled());
+    // An unanswered listing is not an empty one — offering to upload here would
+    // flash away the moment the rows land.
+    expect(
+      screen.queryByRole("button", { name: /upload your first skill/i })
+    ).not.toBeInTheDocument();
+  });
+});

--- a/mcpjam-inspector/client/src/components/skills/ServerSkillsSection.tsx
+++ b/mcpjam-inspector/client/src/components/skills/ServerSkillsSection.tsx
@@ -5,8 +5,10 @@
  * because these are not the same kind of thing as the skills that tree shows:
  * they are identified by URI rather than by name, they are owned by a server
  * rather than by the project, and their contents carry a verification state
- * that has no analogue for a local or Convex skill. Grouping them under their
- * origin server — with that state visible — is the whole point.
+ * that has no analogue for a local or Convex skill. Each row names the server
+ * it came from, and shows its verification state only where that state is
+ * exceptional: every skill listed here is digest-verified, so a badge saying so
+ * on every row would distinguish nothing.
  *
  * Every read goes through the verified path, so a skill that fails a mandatory
  * check renders its specific violation instead of appearing to load.
@@ -21,13 +23,7 @@ import {
   useSyncExternalStore,
 } from "react";
 import { Badge } from "@mcpjam/design-system/badge";
-import { Button } from "@mcpjam/design-system/button";
-import {
-  AlertTriangle,
-  Link2,
-  Server,
-  ShieldCheck,
-} from "lucide-react";
+import { AlertTriangle, Server } from "lucide-react";
 import {
   getApiContextRevision,
   subscribeApiContext,
@@ -62,6 +58,20 @@ interface Props {
   refreshToken?: number;
   /** Renders a loaded skill in the right-hand viewer. */
   onOpenSkill?: (skill: VerifiedServerSkill, serverLabel: string) => void;
+  /**
+   * How many rows this section is showing, and whether any connected server is
+   * still answering.
+   *
+   * The tab owns two things that describe the WHOLE list — the header count and
+   * the "no skills yet" call to action — and half the list lives in here. While
+   * server skills sat under their own heading the tab could ignore them; flat
+   * rows made both claims wrong at once, the count reading `0` above a screenful
+   * of rows and the call to action reserving a block of vertical space above
+   * them. `pending` keeps the tab from flashing that call to action during the
+   * per-connection fetch, which is a listing that has not answered yet rather
+   * than an empty one.
+   */
+  onListingChange?: (state: { count: number; pending: boolean }) => void;
 }
 
 type ServerState =
@@ -75,6 +85,7 @@ export function ServerSkillsSection({
   projectId,
   refreshToken,
   onOpenSkill,
+  onListingChange,
 }: Props) {
   /**
    * The hosted request context, as a version.
@@ -96,11 +107,9 @@ export function ServerSkillsSection({
     getApiContextRevision
   );
   const [byServer, setByServer] = useState<Record<string, ServerState>>({});
-  const [uriInput, setUriInput] = useState<Record<string, string>>({});
   const [refusal, setRefusal] = useState<
     Record<string, ServerSkillRefusal | undefined>
   >({});
-  const [opening, setOpening] = useState<Record<string, boolean>>({});
   /**
    * Server ids with a listing request in flight.
    *
@@ -206,11 +215,11 @@ export function ServerSkillsSection({
   /**
    * Synchronous in-flight lock, per server.
    *
-   * `opening` is React state, so it does not update until the next render —
-   * the Load button reads it and disables itself, but the URI input's Enter
-   * handler can fire several times before that render lands, dispatching
-   * duplicate concurrent loads. A ref is set before the first `await`, so it
-   * closes the window for BOTH entry points rather than one.
+   * A row is a button with nothing to disable it mid-flight, and `skills/get`
+   * re-reads and re-verifies every file in the manifest — so an impatient
+   * double-click would dispatch that work twice and race two writes into the
+   * viewer. A ref is set before the first `await`, so the second click is
+   * refused on the click that made it rather than a render later.
    */
   const openInFlight = useRef<Set<string>>(new Set());
 
@@ -219,7 +228,6 @@ export function ServerSkillsSection({
       if (openInFlight.current.has(serverId)) return;
       openInFlight.current.add(serverId);
       setRefusal((prev) => ({ ...prev, [serverId]: undefined }));
-      setOpening((prev) => ({ ...prev, [serverId]: true }));
       try {
         const result = await getServerSkill({
           serverId,
@@ -246,11 +254,48 @@ export function ServerSkillsSection({
         }));
       } finally {
         openInFlight.current.delete(serverId);
-        setOpening((prev) => ({ ...prev, [serverId]: false }));
       }
     },
     [onOpenSkill, projectId]
   );
+
+  /**
+   * What the tab needs to describe the list: rows shown, and whether any
+   * answer is still outstanding.
+   *
+   * A server that never declared the extension contributes neither — its
+   * absence from the count is the same judgement the render makes below, kept
+   * in one expression so the number and the rows cannot disagree.
+   */
+  const rendered = useMemo(() => {
+    let count = 0;
+    let pending = false;
+    for (const server of connected) {
+      const state = byServer[server.serverId] ?? { status: "idle" as const };
+      if (state.status === "idle" || state.status === "loading") {
+        pending = true;
+      } else if (state.status === "ready" && state.listing.support.active) {
+        count += state.listing.skills.length;
+      }
+    }
+    return { count, pending };
+  }, [connected, byServer]);
+
+  /**
+   * Reported by VALUE, not on every render.
+   *
+   * The parent hands this section a fresh `servers` array each render and takes
+   * a state update in return, so calling the callback whenever the memo
+   * re-derives the same numbers would be a render loop between the two
+   * components.
+   */
+  const lastReported = useRef<string>("");
+  useEffect(() => {
+    const signature = `${rendered.count}:${rendered.pending}`;
+    if (lastReported.current === signature) return;
+    lastReported.current = signature;
+    onListingChange?.(rendered);
+  }, [rendered, onListingChange]);
 
   if (connected.length === 0) return null;
 
@@ -318,50 +363,12 @@ export function ServerSkillsSection({
               </div>
             ))}
 
-            {/* Load by URI. Not a convenience: `skills/get` answers for skills
-                a listing never mentioned, and a URI can arrive from a server's
-                instructions or from another skill. Kept per server because the
-                URI is only meaningful against the origin that serves it. */}
-            {listing && (
-              <div className="flex items-center gap-1 py-1 px-2">
-                <Link2 className="h-3 w-3 text-muted-foreground flex-shrink-0" />
-                <input
-                  value={uriInput[server.serverId] ?? ""}
-                  aria-label={`Load a skill from ${server.label} by URI`}
-                  onKeyDown={(event) => {
-                    if (event.key !== "Enter") return;
-                    const uri = (uriInput[server.serverId] ?? "").trim();
-                    if (!uri) return;
-                    void openSkill(server.serverId, server.label, uri);
-                  }}
-                  onChange={(event) =>
-                    setUriInput((prev) => ({
-                      ...prev,
-                      [server.serverId]: event.target.value,
-                    }))
-                  }
-                  placeholder={`Load from ${server.label} by URI (skill://…)`}
-                  className="flex-1 min-w-0 bg-transparent text-[11px] outline-none border-b border-transparent focus:border-border py-0.5"
-                />
-                <Button
-                  variant="ghost"
-                  size="sm"
-                  disabled={
-                    !(uriInput[server.serverId] ?? "").trim() ||
-                    opening[server.serverId] === true
-                  }
-                  onClick={() =>
-                    void openSkill(
-                      server.serverId,
-                      server.label,
-                      (uriInput[server.serverId] ?? "").trim()
-                    )
-                  }
-                >
-                  Load
-                </Button>
-              </div>
-            )}
+            {/* No load-by-URI field here. `skills/get` still answers for a URI
+                the listing never mentioned — that is a real capability, and it
+                is why the tab keeps `openSkill` — but a text box under every
+                server is a debugging tool priced as permanent furniture in a
+                panel whose job is to show what a server serves. It lives on
+                `mcpjam skills get` and the REST endpoint instead. */}
 
             {refusal[server.serverId] && (
               <RefusalNotice refusal={refusal[server.serverId]!} />
@@ -388,7 +395,10 @@ function SkillRow({
       type="button"
       onClick={skill.unloadable ? undefined : onOpen}
       disabled={Boolean(skill.unloadable)}
-      title={skill.unloadable?.message ?? skill.skillUri}
+      title={
+        skill.unloadable?.message ??
+        `${skill.skillUri} · ${skill.resources.length} file(s) in the advertised manifest`
+      }
       className="w-full text-left py-1 group disabled:cursor-not-allowed disabled:opacity-60"
     >
       <div className="flex items-center gap-1.5 min-w-0">
@@ -410,21 +420,18 @@ function SkillRow({
         >
           {origin}
         </Badge>
-        {skill.unloadable ? (
+        {/* Only the EXCEPTION gets a badge. Every row that is loadable is
+            digest-verified — verification is mandatory, not a feature a skill
+            can win — so a badge saying so on every row distinguishes nothing,
+            and the manifest file count it used to carry was a number with no
+            reading. Both moved into the row's tooltip; what stays on the row is
+            the one row that behaves differently. */}
+        {skill.unloadable && (
           <Badge
             variant="outline"
             className="text-[10px] flex-shrink-0 border-amber-500/40 bg-amber-500/10 text-amber-600 dark:text-amber-400"
           >
             unverifiable — declined
-          </Badge>
-        ) : (
-          <Badge
-            variant="outline"
-            className="text-[10px] flex-shrink-0 gap-1 border-emerald-500/40 bg-emerald-500/10 text-emerald-600 dark:text-emerald-400"
-            title={`${skill.resources.length} file(s) in the advertised manifest`}
-          >
-            <ShieldCheck className="h-3 w-3" />
-            {skill.resources.length}
           </Badge>
         )}
       </div>

--- a/mcpjam-inspector/client/src/components/skills/__tests__/ServerSkillsSection.test.tsx
+++ b/mcpjam-inspector/client/src/components/skills/__tests__/ServerSkillsSection.test.tsx
@@ -11,6 +11,10 @@
  *
  * 2. Provenance rides the ROW. There is no "From MCP servers" heading any
  *    more, so each row states the server it came from.
+ *
+ * 3. The row states what DISTINGUISHES it. Verification is mandatory, so a
+ *    badge on every verified row said nothing; the manifest file count it
+ *    carried said less. Both belong in the tooltip.
  */
 import { render, screen, waitFor } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
@@ -37,7 +41,7 @@ import { ServerSkillsSection } from "../ServerSkillsSection";
 
 const SERVERS = [{ serverId: "s1", label: "staging", connected: true }];
 
-function listing(active: boolean, names: string[] = []) {
+function listing(active: boolean, names: string[] = [], files = 1) {
   return {
     support: {
       declared: true,
@@ -52,7 +56,10 @@ function listing(active: boolean, names: string[] = []) {
       name,
       description: `${name} description`,
       frontmatter: {},
-      resources: [{ uri: `skill://mcpjam/${name}/SKILL.md`, digest: "d" }],
+      resources: Array.from({ length: files }, (_, index) => ({
+        uri: `skill://mcpjam/${name}/file-${index}.md`,
+        digest: "d",
+      })),
     })),
     duplicateUris: [],
     rejected: [],
@@ -113,6 +120,82 @@ describe("ServerSkillsSection", () => {
     // read — a heading only says it while you are underneath it.
     expect(screen.getByText("staging")).toBeInTheDocument();
     expect(screen.queryByText(/from mcp servers/i)).not.toBeInTheDocument();
+  });
+
+  it("keeps the manifest file count out of the row and in its tooltip", async () => {
+    listServerSkills.mockResolvedValue(listing(true, ["run-evals"], 3));
+    render(<ServerSkillsSection servers={SERVERS} projectId="p1" />);
+
+    const row = await screen.findByRole("button", { name: /run-evals/ });
+    // A bare "3" next to a shield rendered on every row and read as nothing.
+    expect(row.textContent).not.toMatch(/\b3\b/);
+    expect(row.getAttribute("title")).toBe(
+      "skill://mcpjam/run-evals/SKILL.md \u00b7 3 file(s) in the advertised manifest"
+    );
+  });
+
+  it("still marks the exception — a skill it declines to verify", async () => {
+    const answer = listing(true, ["run-evals"]);
+    answer.skills[0] = {
+      ...answer.skills[0],
+      unloadable: { reason: "no_resources", message: "no manifest" },
+    } as (typeof answer.skills)[number];
+    listServerSkills.mockResolvedValue(answer);
+    render(<ServerSkillsSection servers={SERVERS} projectId="p1" />);
+
+    expect(await screen.findByText(/unverifiable/)).toBeInTheDocument();
+  });
+
+  it("offers no load-by-URI field — that capability lives on the CLI", async () => {
+    listServerSkills.mockResolvedValue(listing(true, ["run-evals"]));
+    render(<ServerSkillsSection servers={SERVERS} projectId="p1" />);
+
+    expect(await screen.findByText("run-evals")).toBeInTheDocument();
+    expect(screen.queryByPlaceholderText(/skill:\/\//)).not.toBeInTheDocument();
+    expect(
+      screen.queryByRole("button", { name: /^load$/i })
+    ).not.toBeInTheDocument();
+  });
+
+  it("reports its row count so the tab can describe the whole list", async () => {
+    listServerSkills.mockResolvedValue(listing(true, ["run-evals", "triage"]));
+    const onListingChange = vi.fn();
+    render(
+      <ServerSkillsSection
+        servers={SERVERS}
+        projectId="p1"
+        onListingChange={onListingChange}
+      />
+    );
+
+    // Pending first: an unanswered listing is not an empty one, and the tab
+    // would otherwise offer "upload your first skill" over rows about to land.
+    expect(onListingChange).toHaveBeenCalledWith({ count: 0, pending: true });
+    await waitFor(() =>
+      expect(onListingChange).toHaveBeenLastCalledWith({
+        count: 2,
+        pending: false,
+      })
+    );
+  });
+
+  it("counts nothing for a server that never declared the extension", async () => {
+    listServerSkills.mockResolvedValue(listing(false, ["run-evals"]));
+    const onListingChange = vi.fn();
+    render(
+      <ServerSkillsSection
+        servers={SERVERS}
+        projectId="p1"
+        onListingChange={onListingChange}
+      />
+    );
+
+    await waitFor(() =>
+      expect(onListingChange).toHaveBeenLastCalledWith({
+        count: 0,
+        pending: false,
+      })
+    );
   });
 
   it("renders nothing at all when no connected server declares it", async () => {


### PR DESCRIPTION
Three things in the Skills tab that read badly once PRs #4432/#4435/#4440/#4446 flattened server skills into plain rows, plus the header count that went wrong with them.

### 1. The green shield badge is gone from the row

Rows showed a shield icon and a bare number (`3`, `8`, `1`). The number was the file count of the skill's advertised manifest; the shield meant the skill was digest-verified. **Every** listed skill is digest-verified — verification is mandatory, not something a skill can win — so the badge rendered identically on every row and distinguished nothing, and the number had no reading without an explanation the row had no room for.

Both moved into the row's existing `title` tooltip, alongside the skill URI:

```
skill://mcpjam/run-evals/SKILL.md · 3 file(s) in the advertised manifest
```

The amber `unverifiable — declined` badge stays. It marks the exceptional row, which is the row worth marking.

### 2. The dead vertical space above the rows

**Cause:** the project store's own empty state — the centred `No skills available` / `Upload your first skill` block, `py-8` plus a paragraph plus a button, roughly 100px — rendered on `skills.length === 0` alone. Server rows are appended *after* it in the same `<div className="p-2">`, so with the project store empty and a connected server serving skills, that block sat wedged between the header and rows that were plainly right there. (Verified by rendering the tab in jsdom for the local-mode signed-out configuration rather than reading the JSX: `cloudStoreHidden` is false whenever `HOSTED_MODE` is false, so the flag does not suppress it, and the `skills.length === 0` branch is what emits the block.) The `Loading skills…` branch (`py-16`) has the same shape and the same problem during a refresh.

**Fix:** both placeholders now speak for the *whole* list. `ServerSkillsSection` reports `{ count, pending }` up to the tab; the tab renders a placeholder only when `skills.length + count === 0`, and renders it *below* the rows so nothing can ever sit above them. `pending` matters: an unanswered per-connection listing is not an empty one, so without it the CTA would flash for the duration of the fetch and then vanish.

### 3. The "Load from … by URI (skill://…)" input is removed

A text input plus a Load button under every server's rows. The capability itself has not moved — `skills/get` still answers for a URI a listing never mentioned, and the tab still uses `openSkill` to open a row — but it is reachable as `mcpjam skills get` on the CLI and via the `/v1/…/skills/get` REST endpoint added in #4433. Nothing is lost; a debugging affordance stops being permanent furniture in a panel whose job is to show what a server serves.

Removed with it: the `uriInput` and `opening` state, and the `Link2` / `Button` imports. `openInFlight` is kept — a row is a button with nothing to disable it mid-flight, and `skills/get` re-reads and re-verifies every file in the manifest, so a double-click still needs the synchronous lock. Its docblock is rewritten, since the Load button it used to describe is gone.

### Also: the header badge is honest now

It read `Skills 0` above visible server-skill rows. **It now counts both halves** rather than hiding when the project store is empty. The reasoning: the two halves are genuinely different namespaces — a name here, a URI there — which is exactly why the old comment kept them apart, but a badge sitting next to a list is read as *the length of that list*, not as the size of a namespace. Hiding it would have left the honest-but-mute option; counting both makes it say something true. The namespace distinction is carried where it belongs, on the rows, each of which names its origin server.

### Tests

`ServerSkillsSection.test.tsx`:
- the manifest file count is in the row's `title`, not in its text (`row.textContent` must not contain the bare count)
- the `unverifiable — declined` badge still renders for an unloadable skill
- no load-by-URI placeholder and no `Load` button
- `onListingChange` reports `{ count: 0, pending: true }` first, then the settled count
- a server that never declared the extension contributes `0`, not `pending`

`SkillsTab.list-summary.test.tsx` (new): the badge counts both halves (1 project + 2 server = `3`); no `No skills available` block or upload CTA while server rows are present; the CTA still appears when the whole list is empty; the CTA is withheld while a server listing is outstanding.

Each of these was confirmed to fail against the un-patched components: reverting `SkillsTab.tsx` and `ServerSkillsSection.tsx` while keeping the tests gives **7 failed / 6 passed** — the six survivors being the pre-existing suite plus the `unverifiable` badge assertion, which is a preservation test rather than a regression guard.

```
npx vitest run client/src/components/skills \
  client/src/components/__tests__/SkillsTab.cloud-gate.test.tsx \
  client/src/components/__tests__/SkillsTab.list-summary.test.tsx \
  client/src/components/__tests__/SkillsTab.source-toggle.test.tsx \
  client/src/__tests__/SkillsRoute.flag-hydration.test.tsx \
  client/src/__tests__/SkillsRoute.local-connect-chrome.test.tsx
→ Test Files 6 passed (6) · Tests 31 passed (31)
```

`tsc --noEmit -p client/tsconfig.typecheck.json` is clean. No `prettier --write` was run; formatting was matched by hand.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Inspector Skills tab UI and list-state wiring only; no auth, API, or data-model changes beyond reporting counts to the parent.
> 
> **Overview**
> After server skills joined the project tree as one flat list, the Skills tab **header badge** now sums project-store and MCP-server rows (it no longer showed `0` above visible server skills). **`ServerSkillsSection`** reports `{ count, pending }` upward so loading and empty states describe the **whole** list: placeholders render only when both halves are empty, sit **below** the rows, and the upload CTA is suppressed while a server listing is still in flight.
> 
> **Server skill rows** drop the green shield and manifest file count from the row chrome; that detail moves into the row **tooltip**, and only **`unverifiable — declined`** stays visible for unloadable skills. The per-server **load-by-URI** field and Load button are removed from the panel (opening listed rows and `skills/get` via CLI/REST are unchanged). Tests cover the combined count, placeholder behavior, tooltip vs badge, listing callbacks, and the removed URI UI.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0702841afdfb735208a72eab3bd9ebb521544f1d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the Skills tab's header count, rows, and empty-state placeholders so they describe the flat list of project and server skills: the badge counts both halves, and placeholders render only when the whole list is empty.

- The green shield badge and manifest file count moved into the row's tooltip — every listed skill is digest-verified, so the badge distinguished nothing. The amber `unverifiable — declined` badge stays.
- `ServerSkillsSection` reports `{ count, pending }` up to the tab, so a pending server listing doesn't read as an empty store and flash the upload CTA.
- The per-server load-by-URI input is removed; `skills/get` for an unlisted URI remains reachable via `mcpjam skills get` and the `/v1/…/skills/get` REST endpoint.

<sup>Written for commit 0702841afdfb735208a72eab3bd9ebb521544f1d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/MCPJam/inspector/pull/4453?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

