### PR TITLE
Evals D5b + D5c: serve per-run stage analytics, and show where the chain stopped

### DIFF
--- a/.changeset/evals-d5b-d5c-inspector.md
+++ b/.changeset/evals-d5b-d5c-inspector.md
@@ -1,0 +1,6 @@
+---
+"@mcpjam/inspector": patch
+---
+
+Add the eval-suite stage-analytics route and the /evaluate stage-analytics
+panel, rendering backend-materialized per-run stage analytics.

--- a/.changeset/evals-d5b-sdk.md
+++ b/.changeset/evals-d5b-sdk.md
@@ -1,0 +1,7 @@
+---
+"@mcpjam/sdk": patch
+---
+
+Add listEvalSuiteStageAnalytics to the Platform client. Requires the deployed
+backend stage-analytics query (backend D5a); a missing backend surfaces as a
+service error, never an empty result.

--- a/docs/reference/openapi.json
+++ b/docs/reference/openapi.json
@@ -2395,6 +2395,9 @@
               }
             }
           },
+          "400": {
+            "$ref": "#/components/responses/ValidationError"
+          },
           "401": {
             "$ref": "#/components/responses/Unauthorized"
           },
@@ -2406,6 +2409,9 @@
           },
           "429": {
             "$ref": "#/components/responses/RateLimited"
+          },
+          "502": {
+            "$ref": "#/components/responses/ServerUnreachable"
           },
           "500": {
             "$ref": "#/components/responses/InternalError"

--- a/docs/reference/openapi.json
+++ b/docs/reference/openapi.json
@@ -2410,11 +2410,11 @@
           "429": {
             "$ref": "#/components/responses/RateLimited"
           },
-          "502": {
-            "$ref": "#/components/responses/ServerUnreachable"
-          },
           "500": {
             "$ref": "#/components/responses/InternalError"
+          },
+          "502": {
+            "$ref": "#/components/responses/ServerUnreachable"
           }
         }
       }

--- a/docs/reference/openapi.json
+++ b/docs/reference/openapi.json
@@ -2319,6 +2319,100 @@
         }
       }
     },
+    "/projects/{projectId}/eval-suites/{suiteId}/stage-analytics": {
+      "get": {
+        "operationId": "listEvalSuiteStageAnalytics",
+        "tags": ["Eval runs"],
+        "summary": "List a suite's per-run stage analytics",
+        "description": "One materialized stage-analytics document per RUN, newest completion first: where trials fell out of the six-stage user-value chain (connection, discovery, selection, tool call, response, user value), overall and sliced marginally by intent, model and host.\n\nEach item is one run's COMPLETE document and stands alone. There is deliberately no cross-run aggregate — two funnels averaged together describe no run — so compare runs by rendering them side by side, never by summing these documents.\n\nCounts are returned; RATES are not. A zero denominator is `notMeasured`, never `0`, and every excluded observation is counted under a named class so a denominator can never shrink silently.\n\nNOT backfilled: a run that completed before this shipped has no document at all, and that absence means UNMEASURED — it is never a funnel of zeros.",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/projectId"
+          },
+          {
+            "$ref": "#/components/parameters/suiteId"
+          },
+          {
+            "name": "from",
+            "in": "query",
+            "required": false,
+            "description": "Inclusive lower bound on the run's completion stamp, in epoch MILLISECONDS (not ISO). Runs that never completed carry no stamp and are excluded by any `from` bound. Must be less than or equal to `to`, or the request is a VALIDATION_ERROR.",
+            "schema": {
+              "type": "integer",
+              "minimum": 0
+            }
+          },
+          {
+            "name": "to",
+            "in": "query",
+            "required": false,
+            "description": "Inclusive upper bound on the run's completion stamp, in epoch MILLISECONDS (not ISO).",
+            "schema": {
+              "type": "integer",
+              "minimum": 0
+            }
+          },
+          {
+            "name": "runGroupId",
+            "in": "query",
+            "required": false,
+            "description": "Narrow to one comparison group (a matrix leg, a schedule).",
+            "schema": {
+              "type": "string",
+              "minLength": 1
+            }
+          },
+          {
+            "name": "cursor",
+            "in": "query",
+            "required": false,
+            "description": "Opaque cursor from a previous page's `nextCursor`.",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "limit",
+            "in": "query",
+            "required": false,
+            "description": "Maximum documents to return, 1–100. Defaults to 25 — these documents are large.",
+            "schema": {
+              "type": "integer",
+              "minimum": 1,
+              "maximum": 100,
+              "default": 25
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "One page of per-run stage-analytics documents, newest run completion first. An empty `items` means this suite has no materialized documents in the requested window — which is not the same as a run whose stages all measured zero.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/EvalStageAnalyticsPage"
+                }
+              }
+            }
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "403": {
+            "$ref": "#/components/responses/Forbidden"
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound"
+          },
+          "429": {
+            "$ref": "#/components/responses/RateLimited"
+          },
+          "500": {
+            "$ref": "#/components/responses/InternalError"
+          }
+        }
+      }
+    },
     "/projects/{projectId}/eval-suites/{suiteId}/schedule": {
       "patch": {
         "operationId": "updateEvalSuiteSchedule",
@@ -14908,6 +15002,482 @@
             "items": {
               "$ref": "#/components/schemas/ResolvedScoreDefinition"
             }
+          }
+        }
+      },
+      "EvalStageExclusions": {
+        "type": "object",
+        "description": "How many observations each class removed from ONE denominator. A class that excluded nothing is OMITTED rather than written as 0 — absent and 0 mean the same thing here.",
+        "properties": {
+          "lifecycle": {
+            "type": "integer",
+            "minimum": 0,
+            "description": "The trial never produced a comparable observation: not terminal, skipped, cancelled, timed out, setup-failed, execution failed, or the evaluator itself errored."
+          },
+          "integrity": {
+            "type": "integer",
+            "minimum": 0,
+            "description": "A chain or measurement was missing, unverified or rejected at the write boundary. Never coerced into a passing observation."
+          },
+          "version": {
+            "type": "integer",
+            "minimum": 0,
+            "description": "Produced by an analyzer or schema version this reader does not understand. Also never coerced."
+          },
+          "notApplicable": {
+            "type": "integer",
+            "minimum": 0,
+            "description": "The stage does not apply to this case at all."
+          },
+          "reachUnknown": {
+            "type": "integer",
+            "minimum": 0,
+            "description": "Nothing was captured, so reach could not be decided. Deliberately excluded from the reach denominator."
+          },
+          "notMeasured": {
+            "type": "integer",
+            "minimum": 0,
+            "description": "The stage was reached but nothing decided it."
+          }
+        }
+      },
+      "EvalStageCoverageDetail": {
+        "type": "object",
+        "description": "The FINE-GRAINED reason a trial was excluded. Run-level only — the coarse six-class tally repeats on every stage of every slice, but 'we could not read the chain' and 'the chain was there and was refused' are different operator actions and are carried once, here.",
+        "properties": {
+          "notTerminal": { "type": "integer", "minimum": 0 },
+          "skipped": { "type": "integer", "minimum": 0 },
+          "cancelled": { "type": "integer", "minimum": 0 },
+          "setupFailed": { "type": "integer", "minimum": 0 },
+          "timedOut": { "type": "integer", "minimum": 0 },
+          "executionFailed": { "type": "integer", "minimum": 0 },
+          "evaluatorError": { "type": "integer", "minimum": 0 },
+          "chainMissing": { "type": "integer", "minimum": 0 },
+          "chainUnverified": { "type": "integer", "minimum": 0 },
+          "chainVersionAhead": { "type": "integer", "minimum": 0 },
+          "measurementsMissing": { "type": "integer", "minimum": 0 },
+          "measurementsInvalid": { "type": "integer", "minimum": 0 },
+          "measurementsVersionAhead": { "type": "integer", "minimum": 0 },
+          "analyzerMismatch": {
+            "type": "integer",
+            "minimum": 0,
+            "description": "The chain's analyzer version and its own measurements' disagree — a payload whose two halves came from different analyzers. Always a bug, never a deploy window."
+          }
+        }
+      },
+      "EvalStageLatencyAggregate": {
+        "type": "object",
+        "description": "Sums, not means. `totalMs` + `sampleCount` is strictly more information than a mean and is MERGEABLE. There is no p99 and no confidence interval on purpose. An aggregate with no samples is OMITTED, never zeroed.",
+        "required": [
+          "unit",
+          "basis",
+          "sampleCount",
+          "totalMs",
+          "minMs",
+          "maxMs"
+        ],
+        "properties": {
+          "unit": {
+            "type": "string",
+            "enum": ["ms"]
+          },
+          "basis": {
+            "type": "string",
+            "enum": ["evidence_span_union"],
+            "description": "How the span was measured. Always display the basis beside the number."
+          },
+          "sampleCount": {
+            "type": "integer",
+            "minimum": 1,
+            "description": "At least one. Never exceeds the tally's `reached`."
+          },
+          "totalMs": { "type": "number", "minimum": 0 },
+          "minMs": { "type": "number", "minimum": 0 },
+          "maxMs": { "type": "number", "minimum": 0 }
+        }
+      },
+      "EvalSetupLatencyAggregate": {
+        "type": "object",
+        "description": "The same aggregate shape over a setup phase's wall clock. Sampled once per ATTEMPT, never once per copied iteration.",
+        "required": [
+          "unit",
+          "basis",
+          "sampleCount",
+          "totalMs",
+          "minMs",
+          "maxMs"
+        ],
+        "properties": {
+          "unit": {
+            "type": "string",
+            "enum": ["ms"]
+          },
+          "basis": {
+            "type": "string",
+            "enum": ["setup_phase_wall"]
+          },
+          "sampleCount": { "type": "integer", "minimum": 1 },
+          "totalMs": { "type": "number", "minimum": 0 },
+          "minMs": { "type": "number", "minimum": 0 },
+          "maxMs": { "type": "number", "minimum": 0 }
+        }
+      },
+      "EvalStageTally": {
+        "type": "object",
+        "description": "One stage's counts within one slice. Every field is a COUNT of trials, and the arithmetic is enforced: `passed + failed = measured`, `measured + notMeasured = reached`, `reached + notReached + reachUnknown = applicable`.",
+        "required": [
+          "stage",
+          "applicable",
+          "reached",
+          "notReached",
+          "reachUnknown",
+          "measured",
+          "passed",
+          "failed",
+          "notMeasured",
+          "notApplicable",
+          "excluded",
+          "reasons"
+        ],
+        "properties": {
+          "stage": {
+            "type": "string",
+            "enum": [
+              "connection",
+              "discovery",
+              "selection",
+              "call",
+              "response",
+              "userValue"
+            ]
+          },
+          "applicable": {
+            "type": "integer",
+            "minimum": 0,
+            "description": "Trials for which this stage applies at all (included minus notApplicable)."
+          },
+          "reached": { "type": "integer", "minimum": 0 },
+          "notReached": { "type": "integer", "minimum": 0 },
+          "reachUnknown": {
+            "type": "integer",
+            "minimum": 0,
+            "description": "Reached-ness could not be decided. Excluded from the reach denominator: a trial we captured nothing for is not evidence of a drop-off."
+          },
+          "measured": {
+            "type": "integer",
+            "minimum": 0,
+            "description": "Reached AND decided — `passed + failed`."
+          },
+          "passed": { "type": "integer", "minimum": 0 },
+          "failed": { "type": "integer", "minimum": 0 },
+          "notMeasured": {
+            "type": "integer",
+            "minimum": 0,
+            "description": "Reached but nothing decided it."
+          },
+          "notApplicable": { "type": "integer", "minimum": 0 },
+          "excluded": {
+            "$ref": "#/components/schemas/EvalStageExclusions"
+          },
+          "reasons": {
+            "type": "array",
+            "description": "Why stages landed where they did, by reason code. A CLOSED vocabulary — render what arrives, never widen it.",
+            "items": {
+              "type": "object",
+              "required": ["reason", "count"],
+              "properties": {
+                "reason": { "type": "string" },
+                "count": { "type": "integer", "minimum": 1 }
+              }
+            }
+          },
+          "latency": {
+            "$ref": "#/components/schemas/EvalStageLatencyAggregate"
+          }
+        }
+      },
+      "EvalStageAnalyticsSlice": {
+        "description": "Which population a slice describes. MARGINAL only — there is deliberately no intent x model x host cross-product, because a funnel computed over two trials is not a comparison.",
+        "oneOf": [
+          {
+            "type": "object",
+            "required": ["dimension"],
+            "properties": {
+              "dimension": { "type": "string", "enum": ["overall"] }
+            }
+          },
+          {
+            "type": "object",
+            "required": ["dimension", "intent"],
+            "properties": {
+              "dimension": { "type": "string", "enum": ["intent"] },
+              "intent": {
+                "type": ["string", "null"],
+                "minLength": 1,
+                "description": "`null` is the UNLABELLED slice and is a real slice, not an omission. Never display the raw null — untagged cases are often the majority, and dropping them would make the intent funnel describe a subset while looking like the whole."
+              }
+            }
+          },
+          {
+            "type": "object",
+            "required": ["dimension", "provider", "model"],
+            "properties": {
+              "dimension": { "type": "string", "enum": ["model"] },
+              "provider": { "type": "string", "minLength": 1 },
+              "model": { "type": "string", "minLength": 1 }
+            }
+          },
+          {
+            "type": "object",
+            "required": ["dimension", "hostKey"],
+            "properties": {
+              "dimension": { "type": "string", "enum": ["host"] },
+              "hostKey": {
+                "type": "string",
+                "minLength": 1,
+                "description": "Stable across renames. The join key, not the display name."
+              },
+              "hostName": { "type": "string", "minLength": 1 },
+              "executionEngine": {
+                "type": "string",
+                "minLength": 1,
+                "description": "`emulated` or `harness:<id>`. ABSENT means not recorded — not emulated."
+              }
+            }
+          }
+        ]
+      },
+      "EvalStageAnalyticsSliceRow": {
+        "type": "object",
+        "required": [
+          "slice",
+          "includedTrials",
+          "excludedTrials",
+          "failureCategories",
+          "stages"
+        ],
+        "properties": {
+          "slice": {
+            "$ref": "#/components/schemas/EvalStageAnalyticsSlice"
+          },
+          "includedTrials": {
+            "type": "integer",
+            "minimum": 0,
+            "description": "Trials that contributed observations to this slice."
+          },
+          "excludedTrials": {
+            "$ref": "#/components/schemas/EvalStageExclusions"
+          },
+          "failureCategories": {
+            "type": "array",
+            "description": "Failure categories over TRIALS in this slice — one bucket per trial, not per stage. A CLOSED vocabulary.",
+            "items": {
+              "type": "object",
+              "required": ["category", "count"],
+              "properties": {
+                "category": { "type": "string" },
+                "count": { "type": "integer", "minimum": 1 }
+              }
+            }
+          },
+          "stages": {
+            "type": "array",
+            "description": "Exactly six tallies in canonical stage order. Position is meaning — never re-sort them.",
+            "minItems": 6,
+            "maxItems": 6,
+            "items": {
+              "$ref": "#/components/schemas/EvalStageTally"
+            }
+          }
+        }
+      },
+      "EvalSetupTally": {
+        "type": "object",
+        "description": "One setup phase's facts for this run. RUN-LEVEL, not per-slice: an attempt happens once per run+phase and is copied onto every iteration, so attempts are counted once here while `impactedTrials` — which genuinely varies per trial — is counted distinctly and MAY exceed the attempt count.",
+        "required": [
+          "phase",
+          "uniqueAttempts",
+          "failedAttempts",
+          "serverAttributedFailures",
+          "impactedTrials"
+        ],
+        "properties": {
+          "phase": {
+            "type": "string",
+            "enum": ["connection", "discovery"]
+          },
+          "uniqueAttempts": { "type": "integer", "minimum": 0 },
+          "failedAttempts": { "type": "integer", "minimum": 0 },
+          "serverAttributedFailures": {
+            "type": "integer",
+            "minimum": 0,
+            "description": "Failures attributable to the SERVER under a deliberately narrow rule: the signal said `theirs` AND our own egress was positively verified. Anything less is unknown and is not attributed."
+          },
+          "impactedTrials": {
+            "type": "integer",
+            "minimum": 0,
+            "description": "DISTINCT trials this phase's failed attempts blocked. May exceed `uniqueAttempts` — that is the point of counting it separately."
+          },
+          "latency": {
+            "$ref": "#/components/schemas/EvalSetupLatencyAggregate"
+          }
+        }
+      },
+      "EvalStageAnalytics": {
+        "type": "object",
+        "description": "One RUN's materialized stage funnel. Counts are stored; rates are DERIVED by the SDK contract's helpers, so a zero denominator stays `notMeasured` and never renders as `0%`. There is no top-level overall, latency or reasons object: the overall funnel is the `overall` slice (always present, always first), latency lives inside each stage tally and each setup row, and reasons live inside each stage tally.",
+        "required": [
+          "schemaVersion",
+          "measurementUnit",
+          "runId",
+          "suiteId",
+          "sourceIterationCount",
+          "stageAnalyzerVersion",
+          "measurementsSchemaVersion",
+          "materializationState",
+          "createdAt",
+          "updatedAt",
+          "includedTrials",
+          "excludedTrials",
+          "totalTrials",
+          "excludedTrialDetail",
+          "slices",
+          "setup"
+        ],
+        "properties": {
+          "schemaVersion": {
+            "type": "integer",
+            "enum": [1]
+          },
+          "measurementUnit": {
+            "type": "string",
+            "enum": ["trial"],
+            "description": "The literal `trial`, carried rather than assumed. An eval iteration, a user-testing session and a swarm traversal share this stage vocabulary and are NOT the same unit; a consumer merging two documents must check this first."
+          },
+          "runId": { "type": "string", "minLength": 1 },
+          "suiteId": { "type": "string", "minLength": 1 },
+          "runGroupId": {
+            "type": "string",
+            "minLength": 1,
+            "description": "Present when the run is grouped for comparison (a matrix, a schedule)."
+          },
+          "configRevision": {
+            "type": "string",
+            "minLength": 1,
+            "description": "The run's authored-configuration revision. One of three identities a parity claim requires; ABSENCE BLOCKS parity rather than being assumed compatible."
+          },
+          "caseSetFingerprint": {
+            "type": "string",
+            "minLength": 1,
+            "description": "A digest over the comparable case set this run actually measured. Absence blocks parity, same rule."
+          },
+          "organizationId": { "type": "string", "minLength": 1 },
+          "workspaceId": { "type": "string", "minLength": 1 },
+          "projectId": { "type": "string", "minLength": 1 },
+          "runCompletedAt": {
+            "type": "integer",
+            "minimum": 0,
+            "description": "When the run reached a terminal status, in epoch milliseconds. The field `from`/`to` filter on."
+          },
+          "sourceIterationCount": {
+            "type": "integer",
+            "minimum": 0,
+            "description": "How many iterations this materialization actually read."
+          },
+          "sourceMaxUpdatedAt": {
+            "type": "integer",
+            "minimum": 0,
+            "description": "The newest update stamp among those iterations — the staleness handle for a rebuild."
+          },
+          "stageAnalyzerVersion": {
+            "type": "integer",
+            "minimum": 1,
+            "description": "The analyzer the source chains were ACTUALLY derived at, not the version the reader understands. When included trials disagree this is the newest present."
+          },
+          "sourceStageAnalyzerVersions": {
+            "type": "array",
+            "minItems": 2,
+            "items": { "type": "integer", "minimum": 1 },
+            "description": "Every DISTINCT analyzer version among included trials, ascending. Present ONLY when more than one contributed — a uniform document omits it. A mixed document is not comparable to anything."
+          },
+          "measurementsSchemaVersion": { "type": "integer", "minimum": 1 },
+          "sourceMeasurementsSchemaVersions": {
+            "type": "array",
+            "minItems": 2,
+            "items": { "type": "integer", "minimum": 1 },
+            "description": "Every distinct measurement schema version among included trials. Same rule as the analyzer versions."
+          },
+          "materializationState": {
+            "type": "string",
+            "enum": ["provisional", "final"],
+            "description": "`provisional` while a judge fanout is still pending — the counts may still move under the reader — and `final` once every applicable fanout has completed. There is no `stale`."
+          },
+          "createdAt": { "type": "integer", "minimum": 0 },
+          "updatedAt": { "type": "integer", "minimum": 0 },
+          "includedTrials": {
+            "type": "integer",
+            "minimum": 0,
+            "description": "Trials that contributed observations. Equals the overall slice's own count, and never exceeds `totalTrials`."
+          },
+          "excludedTrials": {
+            "$ref": "#/components/schemas/EvalStageExclusions"
+          },
+          "totalTrials": {
+            "type": "integer",
+            "minimum": 0,
+            "description": "Every trial the materializer saw, included or not."
+          },
+          "excludedTrialDetail": {
+            "$ref": "#/components/schemas/EvalStageCoverageDetail"
+          },
+          "slices": {
+            "type": "array",
+            "maxItems": 101,
+            "description": "Marginal slices in canonical order. Exactly one `overall` slice, always present and always first.",
+            "items": {
+              "$ref": "#/components/schemas/EvalStageAnalyticsSliceRow"
+            }
+          },
+          "setup": {
+            "type": "array",
+            "maxItems": 2,
+            "description": "Run-level setup facts, one row per phase that carried a signal. Never two rows for one phase.",
+            "items": {
+              "$ref": "#/components/schemas/EvalSetupTally"
+            }
+          },
+          "sliceTruncation": {
+            "type": "array",
+            "maxItems": 3,
+            "description": "Which dimensions hit a cap, and by how much. Present ONLY when a cap bit — a truncated slice array with no such record would read as 'these are all the models'.",
+            "items": {
+              "type": "object",
+              "required": ["dimension", "distinctValues", "retained"],
+              "properties": {
+                "dimension": {
+                  "type": "string",
+                  "enum": ["intent", "model", "host"]
+                },
+                "distinctValues": { "type": "integer", "minimum": 1 },
+                "retained": { "type": "integer", "minimum": 0 }
+              }
+            }
+          }
+        }
+      },
+      "EvalStageAnalyticsPage": {
+        "type": "object",
+        "required": ["items"],
+        "properties": {
+          "items": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/EvalStageAnalytics"
+            }
+          },
+          "nextCursor": {
+            "type": "string",
+            "description": "Opaque cursor for the next page. Omitted on the last page."
           }
         }
       },

--- a/mcpjam-inspector/client/src/components/evaluate/__tests__/stage-analytics-model.test.ts
+++ b/mcpjam-inspector/client/src/components/evaluate/__tests__/stage-analytics-model.test.ts
@@ -1,0 +1,297 @@
+/**
+ * The presentation model's honest-state rules.
+ *
+ * Every assertion here is about a number NOT being invented: a zero denominator
+ * rendering as words rather than `0%`, a genuine measured zero still rendering
+ * as `0%`, an absent latency aggregate staying absent rather than becoming
+ * `0 ms`, and the unlabelled intent slice surviving as a real population.
+ */
+import { describe, expect, it } from "vitest";
+import {
+  GOLDEN_STAGE_ANALYTICS,
+  stageAnalyticsVariation,
+} from "@/test/stage-analytics-fixtures";
+import {
+  NOT_MEASURED_LABEL,
+  describeExclusions,
+  deriveStageAnalyticsPanelState,
+  formatLatency,
+  overallSlice,
+  sliceTitle,
+  slicesOfDimension,
+  toRunHeaderView,
+  toSetupView,
+  toStageRowView,
+} from "../stage-analytics-model";
+import type { EvalStageTally } from "@mcpjam/sdk/contract";
+
+function tally(overrides: Partial<EvalStageTally> = {}): EvalStageTally {
+  return {
+    stage: "selection",
+    applicable: 0,
+    reached: 0,
+    notReached: 0,
+    reachUnknown: 0,
+    measured: 0,
+    passed: 0,
+    failed: 0,
+    notMeasured: 0,
+    notApplicable: 0,
+    excluded: {},
+    reasons: [],
+    ...overrides,
+  } as EvalStageTally;
+}
+
+describe("panel state derivation", () => {
+  const base = {
+    rows: [],
+    error: null,
+    runCount: 0,
+    runsLoading: false,
+  } as const;
+
+  it("treats a service failure as unsupported, not as empty", () => {
+    const state = deriveStageAnalyticsPanelState({
+      ...base,
+      status: "error",
+      error: { message: "upstream is down", kind: "requestFailed" },
+    });
+    expect(state.kind).toBe("unsupported");
+  });
+
+  it("treats a missing route as unsupported", () => {
+    const state = deriveStageAnalyticsPanelState({
+      ...base,
+      status: "error",
+      error: { message: "not served here", kind: "routeUnavailable" },
+    });
+    expect(state.kind).toBe("unsupported");
+  });
+
+  it("treats a contract failure as an error, not as unsupported", () => {
+    // A payload that did not validate is a BUG REPORT, not a deployment gap.
+    const state = deriveStageAnalyticsPanelState({
+      ...base,
+      status: "error",
+      error: { message: "did not match the contract", kind: "invalidContract" },
+    });
+    expect(state.kind).toBe("error");
+  });
+
+  it("renders a vanished suite as an error, never as empty analytics", () => {
+    const state = deriveStageAnalyticsPanelState({
+      ...base,
+      status: "error",
+      error: { message: "Eval suite not found", kind: "notFound" },
+    });
+    expect(state.kind).toBe("error");
+  });
+
+  it("distinguishes pre-analytics runs from a suite with no runs", () => {
+    const legacy = deriveStageAnalyticsPanelState({
+      ...base,
+      status: "ready",
+      runCount: 12,
+    });
+    expect(legacy).toEqual({ kind: "unmeasuredLegacy", runCount: 12 });
+
+    const empty = deriveStageAnalyticsPanelState({ ...base, status: "ready" });
+    expect(empty).toEqual({ kind: "empty" });
+  });
+
+  it("holds the loading frame while the run list is still arriving", () => {
+    // Guessing here would flash "no runs yet" at a suite that has hundreds.
+    const state = deriveStageAnalyticsPanelState({
+      ...base,
+      status: "ready",
+      runsLoading: true,
+    });
+    expect(state.kind).toBe("loading");
+  });
+
+  it("is ready when documents arrived", () => {
+    const state = deriveStageAnalyticsPanelState({
+      ...base,
+      status: "ready",
+      rows: [GOLDEN_STAGE_ANALYTICS],
+    });
+    expect(state.kind).toBe("ready");
+  });
+});
+
+describe("rate formatting", () => {
+  it("renders words, not a zero, when there is nothing to divide", () => {
+    const view = toStageRowView(tally());
+    expect(view.pass.percent).toBeNull();
+    expect(view.pass.arithmetic).toBeNull();
+    // No bar either — a zero-width bar still reads as a measured zero.
+    expect(view.pass.fraction).toBeNull();
+    expect(NOT_MEASURED_LABEL).toBe("not measured");
+  });
+
+  it("renders a GENUINE measured zero as 0%", () => {
+    // 0 of 5 eligible is a real finding and must not be hidden behind words.
+    const view = toStageRowView(
+      tally({ applicable: 5, reached: 5, measured: 5, passed: 0, failed: 5 }),
+    );
+    expect(view.pass.percent).toBe("0%");
+    expect(view.pass.arithmetic).toBe("0/5");
+    expect(view.pass.fraction).toBe(0);
+  });
+
+  it("keeps the arithmetic beside every rate", () => {
+    const view = toStageRowView(
+      tally({
+        applicable: 5,
+        reached: 4,
+        notReached: 1,
+        measured: 4,
+        passed: 3,
+        failed: 1,
+      }),
+    );
+    expect(view.pass.percent).toBe("75%");
+    expect(view.pass.arithmetic).toBe("3/4");
+    expect(view.coverage.arithmetic).toBe("4/4");
+    expect(view.reach.arithmetic).toBe("4/5");
+  });
+
+  it("excludes reachUnknown from the reach denominator", () => {
+    // A trial we captured nothing for is not evidence of a drop-off; counting
+    // it would make broken instrumentation look like a broken server.
+    const view = toStageRowView(
+      tally({
+        applicable: 5,
+        reached: 3,
+        notReached: 1,
+        reachUnknown: 1,
+        measured: 3,
+        passed: 3,
+      }),
+    );
+    expect(view.reach.arithmetic).toBe("3/4");
+    expect(view.reach.exclusions.join(" ")).toContain("reach is undecidable");
+  });
+});
+
+describe("exclusion naming", () => {
+  it("names each class and omits the ones that excluded nothing", () => {
+    expect(describeExclusions({ lifecycle: 2, integrity: 1 })).toEqual([
+      "2 never produced a comparable observation",
+      "1 evidence missing or unverified",
+    ]);
+    expect(describeExclusions({})).toEqual([]);
+    // Zero is omitted by the contract; an explicit 0 means the same as absent.
+    expect(describeExclusions({ lifecycle: 0 })).toEqual([]);
+  });
+});
+
+describe("latency", () => {
+  it("is absent, not zero, when there are no samples", () => {
+    expect(formatLatency(undefined)).toBeNull();
+  });
+
+  it("always carries the unit and the basis", () => {
+    expect(
+      formatLatency({
+        unit: "ms",
+        basis: "evidence_span_union",
+        sampleCount: 4,
+        totalMs: 400,
+      }),
+    ).toBe("100 ms · evidence span union");
+    expect(
+      formatLatency({
+        unit: "ms",
+        basis: "setup_phase_wall",
+        sampleCount: 2,
+        totalMs: 500,
+      }),
+    ).toBe("250 ms · setup wall clock");
+  });
+});
+
+describe("slices", () => {
+  it("names the unlabelled intent slice rather than dropping it", () => {
+    expect(sliceTitle({ dimension: "intent", intent: null })).toBe("Unlabeled");
+    expect(sliceTitle({ dimension: "intent", intent: "search" })).toBe(
+      "search",
+    );
+  });
+
+  it("keeps every intent slice from the golden document, including the null one", () => {
+    const intents = slicesOfDimension(GOLDEN_STAGE_ANALYTICS, "intent");
+    expect(intents.map((slice) => slice.title)).toContain("Unlabeled");
+    expect(intents.map((slice) => slice.title)).toContain("search");
+  });
+
+  it("carries the provider beside a model, and never invents an engine", () => {
+    const models = slicesOfDimension(GOLDEN_STAGE_ANALYTICS, "model");
+    expect(models[0]?.subtitle).toBeTruthy();
+    expect(sliceTitle({ dimension: "host", hostKey: "host_x" })).toBe("host_x");
+  });
+
+  it("finds exactly one overall slice and keeps the six stages in order", () => {
+    const overall = overallSlice(GOLDEN_STAGE_ANALYTICS);
+    expect(overall).not.toBeNull();
+    expect(overall!.stages.map((stage) => stage.stage)).toEqual([
+      "connection",
+      "discovery",
+      "selection",
+      "call",
+      "response",
+      "userValue",
+    ]);
+  });
+});
+
+describe("run header", () => {
+  it("flags a provisional document", () => {
+    const header = toRunHeaderView(GOLDEN_STAGE_ANALYTICS);
+    expect(header.provisional).toBe(true);
+    expect(header.materializationLabel).toContain("may change");
+  });
+
+  it("names the population on the trial count", () => {
+    const header = toRunHeaderView(GOLDEN_STAGE_ANALYTICS);
+    // Never "cases" — the unit is a trial and the count says so.
+    expect(header.populationLabel).toContain("trials in this run");
+    expect(header.populationLabel).not.toContain("case");
+  });
+
+  it("discloses mixed analyzer versions", () => {
+    const header = toRunHeaderView(
+      stageAnalyticsVariation({ sourceStageAnalyzerVersions: [1, 2] }),
+    );
+    expect(header.disclosures.join(" ")).toContain("Mixed stage analyzer");
+  });
+
+  it("discloses truncation rather than presenting a partial set as complete", () => {
+    const header = toRunHeaderView(
+      stageAnalyticsVariation({
+        sliceTruncation: [
+          { dimension: "model", distinctValues: 40, retained: 25 },
+        ],
+      }),
+    );
+    expect(header.disclosures.join(" ")).toContain("not the complete set");
+  });
+
+  it("reports a final document as final", () => {
+    const header = toRunHeaderView(
+      stageAnalyticsVariation({ materializationState: "final" }),
+    );
+    expect(header.provisional).toBe(false);
+  });
+});
+
+describe("setup", () => {
+  it("keeps impacted trials separate from attempts", () => {
+    const setup = GOLDEN_STAGE_ANALYTICS.setup.map(toSetupView);
+    expect(setup[0]?.label).toBe("Connection");
+    // The asymmetry is the point: one attempt can block many trials.
+    expect(typeof setup[0]?.impactedTrials).toBe("number");
+    expect(typeof setup[0]?.uniqueAttempts).toBe("number");
+  });
+});

--- a/mcpjam-inspector/client/src/components/evaluate/__tests__/stage-analytics-panel.test.tsx
+++ b/mcpjam-inspector/client/src/components/evaluate/__tests__/stage-analytics-panel.test.tsx
@@ -1,0 +1,227 @@
+/**
+ * The stage-analytics panel's rendered states.
+ *
+ * Populated fixtures come from the SDK's GOLDEN corpus, never a local copy, so
+ * a change to what a stage funnel means shows up here as a failing render. The
+ * states the golden document does not itself carry — truncation, mixed
+ * versions, a `final` row — are built as schema-validated variations of it.
+ *
+ * The assertions are mostly about states being TOLD APART: a service failure
+ * must not look like an empty result, and pre-analytics runs must not look
+ * like a funnel of zeros.
+ */
+import { describe, expect, it, vi, beforeEach } from "vitest";
+import { render, screen, waitFor, within } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { StageAnalyticsPanel } from "../stage-analytics-panel";
+import {
+  GOLDEN_STAGE_ANALYTICS,
+  stageAnalyticsVariation,
+} from "@/test/stage-analytics-fixtures";
+
+const { fetchMock } = vi.hoisted(() => ({ fetchMock: vi.fn() }));
+vi.mock("@/lib/apis/eval-stage-analytics-api", async () => {
+  const actual = await vi.importActual<
+    typeof import("@/lib/apis/eval-stage-analytics-api")
+  >("@/lib/apis/eval-stage-analytics-api");
+  return { ...actual, fetchEvalSuiteStageAnalytics: fetchMock };
+});
+
+const SUITE_ID = GOLDEN_STAGE_ANALYTICS.suiteId;
+
+function renderPanel(
+  props: Partial<React.ComponentProps<typeof StageAnalyticsPanel>> = {},
+) {
+  return render(
+    <StageAnalyticsPanel
+      projectId="p1"
+      suiteId={SUITE_ID}
+      runCount={0}
+      runsLoading={false}
+      {...props}
+    />,
+  );
+}
+
+beforeEach(() => {
+  fetchMock.mockReset();
+});
+
+describe("StageAnalyticsPanel", () => {
+  it("renders the populated document from the golden corpus", async () => {
+    fetchMock.mockResolvedValue({ rows: [GOLDEN_STAGE_ANALYTICS] });
+    renderPanel();
+
+    await screen.findByTestId("stage-analytics-document");
+
+    // The overall funnel, and the marginal slices beside it.
+    expect(screen.getByText(/where the chain stopped/i)).toBeTruthy();
+    expect(screen.getByText("By intent")).toBeTruthy();
+    expect(screen.getByText("By model")).toBeTruthy();
+    expect(screen.getByText("By host")).toBeTruthy();
+    // The unlabelled intent slice is a real population, rendered as a word.
+    expect(screen.getByText("Unlabeled")).toBeTruthy();
+    // Six stages in the overall slice, position preserved.
+    const slices = screen.getAllByTestId("stage-slice");
+    expect(within(slices[0]!).getAllByTestId("stage-row")).toHaveLength(6);
+  });
+
+  it("badges a provisional document", async () => {
+    fetchMock.mockResolvedValue({ rows: [GOLDEN_STAGE_ANALYTICS] });
+    renderPanel();
+
+    const badge = await screen.findByTestId("stage-analytics-provisional");
+    expect(badge.textContent).toMatch(/may change/i);
+  });
+
+  it("shows no provisional badge on a final document", async () => {
+    fetchMock.mockResolvedValue({
+      rows: [stageAnalyticsVariation({ materializationState: "final" })],
+    });
+    renderPanel();
+
+    await screen.findByTestId("stage-analytics-document");
+    expect(screen.queryByTestId("stage-analytics-provisional")).toBeNull();
+  });
+
+  it("names the population on the trial count, never calling trials cases", async () => {
+    fetchMock.mockResolvedValue({ rows: [GOLDEN_STAGE_ANALYTICS] });
+    renderPanel();
+
+    const doc = await screen.findByTestId("stage-analytics-document");
+    expect(doc.textContent).toMatch(/trials in this run/i);
+  });
+
+  it("renders a service failure distinctly from an empty result", async () => {
+    fetchMock.mockRejectedValue(new Error("upstream down"));
+    renderPanel({ runCount: 5 });
+
+    const state = await screen.findByTestId("stage-analytics-unsupported");
+    expect(state.textContent).toMatch(/not measured here/i);
+    // NOT the empty state, and NOT a chart.
+    expect(screen.queryByTestId("stage-analytics-empty")).toBeNull();
+    expect(screen.queryByTestId("stage-analytics-document")).toBeNull();
+  });
+
+  it("renders pre-analytics runs as unmeasured, not as a zero", async () => {
+    fetchMock.mockResolvedValue({ rows: [] });
+    renderPanel({ runCount: 12 });
+
+    const state = await screen.findByTestId(
+      "stage-analytics-unmeasured-legacy",
+    );
+    expect(state.textContent).toMatch(/predate stage analytics/i);
+    expect(state.textContent).not.toMatch(/0%/);
+  });
+
+  it("renders a suite with no runs as validly empty", async () => {
+    fetchMock.mockResolvedValue({ rows: [] });
+    renderPanel({ runCount: 0 });
+
+    const state = await screen.findByTestId("stage-analytics-empty");
+    expect(state.textContent).toMatch(/no completed runs yet/i);
+  });
+
+  it("shows a loading state before the first page lands", async () => {
+    fetchMock.mockImplementation(() => new Promise(() => {}));
+    renderPanel();
+    expect(await screen.findByTestId("stage-analytics-loading")).toBeTruthy();
+  });
+
+  it("discloses truncation rather than presenting a partial set as complete", async () => {
+    fetchMock.mockResolvedValue({
+      rows: [
+        stageAnalyticsVariation({
+          sliceTruncation: [
+            { dimension: "model", distinctValues: 40, retained: 25 },
+          ],
+        }),
+      ],
+    });
+    renderPanel();
+
+    const disclosures = await screen.findByTestId(
+      "stage-analytics-disclosures",
+    );
+    expect(disclosures.textContent).toMatch(/not the complete set/i);
+  });
+
+  it("discloses mixed analyzer versions", async () => {
+    fetchMock.mockResolvedValue({
+      rows: [stageAnalyticsVariation({ sourceStageAnalyzerVersions: [1, 2] })],
+    });
+    renderPanel();
+
+    const disclosures = await screen.findByTestId(
+      "stage-analytics-disclosures",
+    );
+    expect(disclosures.textContent).toMatch(/mixed stage analyzer/i);
+  });
+
+  it("renders setup with its unit and basis", async () => {
+    fetchMock.mockResolvedValue({ rows: [GOLDEN_STAGE_ANALYTICS] });
+    renderPanel();
+
+    const setup = await screen.findByTestId("stage-analytics-setup");
+    expect(setup.textContent).toMatch(/Connection/);
+    // Impacted trials are counted separately from attempts.
+    expect(setup.textContent).toMatch(/blocking \d+ trials in this run/i);
+  });
+
+  it("renders words, not a percentage, for a stage with nothing to divide", async () => {
+    // Every stage tally zeroed: applicable 0 everywhere, so every rate is
+    // notMeasured and NOT a 0%.
+    const emptyStages = structuredClone(GOLDEN_STAGE_ANALYTICS);
+    for (const slice of emptyStages.slices) {
+      slice.includedTrials = 0;
+      slice.failureCategories = [];
+      for (const stage of slice.stages) {
+        Object.assign(stage, {
+          applicable: 0,
+          reached: 0,
+          notReached: 0,
+          reachUnknown: 0,
+          measured: 0,
+          passed: 0,
+          failed: 0,
+          notMeasured: 0,
+          notApplicable: 0,
+          reasons: [],
+        });
+        delete (stage as { latency?: unknown }).latency;
+      }
+    }
+    emptyStages.includedTrials = 0;
+    fetchMock.mockResolvedValue({
+      rows: [stageAnalyticsVariation(emptyStages)],
+    });
+    renderPanel();
+
+    const doc = await screen.findByTestId("stage-analytics-document");
+    expect(within(doc).getAllByText("not measured").length).toBeGreaterThan(0);
+    expect(doc.textContent).not.toMatch(/\b0%/);
+  });
+
+  it("lists runs and loads more without dropping the current view", async () => {
+    const second = stageAnalyticsVariation({
+      runId: "run_second",
+      runCompletedAt: 1600000000000,
+    });
+    fetchMock
+      .mockResolvedValueOnce({
+        rows: [GOLDEN_STAGE_ANALYTICS],
+        nextCursor: "c2",
+      })
+      .mockResolvedValueOnce({ rows: [second] });
+
+    renderPanel();
+    const button = await screen.findByTestId("stage-analytics-load-more");
+    await userEvent.click(button);
+
+    await waitFor(() =>
+      expect(screen.getByTestId("stage-analytics-run-list")).toBeTruthy(),
+    );
+    // Still showing the newest run's document, with the older one selectable.
+    expect(screen.getByTestId("stage-analytics-document")).toBeTruthy();
+  });
+});

--- a/mcpjam-inspector/client/src/components/evaluate/__tests__/suite-detail-overview.test.tsx
+++ b/mcpjam-inspector/client/src/components/evaluate/__tests__/suite-detail-overview.test.tsx
@@ -7,6 +7,22 @@ vi.mock("@/hooks/useProjectEnvironmentsEnabled", () => ({
   useProjectEnvironmentsEnabled: () => false,
 }));
 
+// The stage-analytics panel owns its own REST read. Stubbed at the api
+// boundary rather than by replacing the component, so this file still proves
+// the real section mounts with the props the page hands it.
+const { stageAnalyticsFetchMock } = vi.hoisted(() => ({
+  stageAnalyticsFetchMock: vi.fn(),
+}));
+vi.mock("@/lib/apis/eval-stage-analytics-api", async () => {
+  const actual = await vi.importActual<
+    typeof import("@/lib/apis/eval-stage-analytics-api")
+  >("@/lib/apis/eval-stage-analytics-api");
+  return {
+    ...actual,
+    fetchEvalSuiteStageAnalytics: stageAnalyticsFetchMock,
+  };
+});
+
 function makeSuite(overrides: Partial<EvalSuite> = {}): EvalSuite {
   return {
     _id: "suite-1",
@@ -533,5 +549,67 @@ describe("SuiteDetailOverview", () => {
       screen.queryByText("No runs match these filters."),
     ).toBeNull();
     expect(screen.getByTestId("suite-run-row-run-1")).toBeTruthy();
+  });
+
+  describe("stage analytics section", () => {
+    function renderWithRuns(runs: EvalSuiteRun[], runsLoading = false) {
+      return renderWithProviders(
+        <SuiteDetailOverview
+          suite={makeSuite()}
+          cases={[makeCase({ _id: "case-1" })]}
+          runs={runs}
+          runsLoading={runsLoading}
+          allIterations={[]}
+          hostNamesById={hostNamesById}
+          onRerun={vi.fn()}
+          onEditSuite={vi.fn()}
+          onEditCases={vi.fn()}
+          onRunClick={vi.fn()}
+          onTestCaseClick={vi.fn()}
+          projectId="p1"
+        />,
+      );
+    }
+
+    it("mounts the section on the Evaluate suite page", async () => {
+      stageAnalyticsFetchMock.mockResolvedValue({ rows: [] });
+      renderWithRuns([makeRun({ _id: "run-1" })]);
+
+      expect(
+        await screen.findByTestId("suite-detail-stage-analytics"),
+      ).toBeTruthy();
+      // Fed the suite and project the page already holds — never resolved in
+      // the browser, which is how a suite gets read against the wrong project.
+      expect(stageAnalyticsFetchMock).toHaveBeenCalledWith(
+        expect.objectContaining({ projectId: "p1", suiteId: "suite-1" }),
+        expect.any(AbortSignal),
+      );
+    });
+
+    it("distinguishes a suite with runs from one without", async () => {
+      stageAnalyticsFetchMock.mockResolvedValue({ rows: [] });
+      const { unmount } = renderWithRuns([makeRun({ _id: "run-1" })]);
+      expect(
+        await screen.findByTestId("stage-analytics-unmeasured-legacy"),
+      ).toBeTruthy();
+      unmount();
+
+      stageAnalyticsFetchMock.mockResolvedValue({ rows: [] });
+      renderWithRuns([]);
+      expect(await screen.findByTestId("stage-analytics-empty")).toBeTruthy();
+    });
+
+    it("keeps the sibling sections alive when the panel read fails", async () => {
+      // A panel failure is a panel failure. The run history beside it is a
+      // different query and must not be taken down with it.
+      stageAnalyticsFetchMock.mockRejectedValue(new Error("upstream down"));
+      renderWithRuns([makeRun({ _id: "run-1" })]);
+
+      expect(
+        await screen.findByTestId("stage-analytics-unsupported"),
+      ).toBeTruthy();
+      expect(screen.getByTestId("suite-detail-run-history")).toBeTruthy();
+      expect(screen.getByTestId("suite-detail-test-cases")).toBeTruthy();
+    });
   });
 });

--- a/mcpjam-inspector/client/src/components/evaluate/__tests__/suite-detail-overview.test.tsx
+++ b/mcpjam-inspector/client/src/components/evaluate/__tests__/suite-detail-overview.test.tsx
@@ -599,6 +599,34 @@ describe("SuiteDetailOverview", () => {
       expect(await screen.findByTestId("stage-analytics-empty")).toBeTruthy();
     });
 
+    it("omits the panel entirely when there is no project id", async () => {
+      // `projectId` is nullable on this page and the read is project-scoped, so
+      // without one there is no request to make. Rendering the panel anyway
+      // would leave it on a spinner for a fetch that never starts.
+      stageAnalyticsFetchMock.mockResolvedValue({ rows: [] });
+      renderWithProviders(
+        <SuiteDetailOverview
+          suite={makeSuite()}
+          cases={[makeCase({ _id: "case-1" })]}
+          runs={[makeRun({ _id: "run-1" })]}
+          runsLoading={false}
+          allIterations={[]}
+          hostNamesById={hostNamesById}
+          onRerun={vi.fn()}
+          onEditSuite={vi.fn()}
+          onEditCases={vi.fn()}
+          onRunClick={vi.fn()}
+          onTestCaseClick={vi.fn()}
+        />,
+      );
+
+      expect(screen.queryByTestId("suite-detail-stage-analytics")).toBeNull();
+      expect(screen.queryByTestId("stage-analytics-loading")).toBeNull();
+      expect(stageAnalyticsFetchMock).not.toHaveBeenCalled();
+      // The rest of the page is unaffected.
+      expect(screen.getByTestId("suite-detail-run-history")).toBeTruthy();
+    });
+
     it("keeps the sibling sections alive when the panel read fails", async () => {
       // A panel failure is a panel failure. The run history beside it is a
       // different query and must not be taken down with it.

--- a/mcpjam-inspector/client/src/components/evaluate/stage-analytics-model.ts
+++ b/mcpjam-inspector/client/src/components/evaluate/stage-analytics-model.ts
@@ -1,0 +1,378 @@
+/**
+ * The presentation model for the stage-analytics panel (D5c).
+ *
+ * PURE — no React, no fetching, no clock. Everything the panel renders is
+ * derived here so the honest-state rules are unit-testable without a DOM, the
+ * same split `suite-detail-model.ts` uses.
+ *
+ * ── The one rule this module exists to hold ──────────────────────────────────
+ *
+ * Every rate comes from the contract's own helpers (`measuredPassRate`,
+ * `measurementCoverageRate`, `reachRate`, `latencyMeanMs`). There is no
+ * division anywhere in this file, and there must never be one: the helpers are
+ * what make `0/0` a `notMeasured` state rather than a `0%`, and a hand-rolled
+ * `passed / measured` here would reintroduce exactly the number this whole
+ * contract was built to make unrepresentable.
+ *
+ * A GENUINE measured zero is different and IS shown: `0/5` eligible renders
+ * `0%`, because that is a real finding. Only a zero DENOMINATOR renders words.
+ */
+import {
+  UNLABELED_INTENT_LABEL,
+  USER_VALUE_STAGE_LABELS,
+  latencyMeanMs,
+  measuredPassRate,
+  measurementCoverageRate,
+  reachRate,
+  type EvalSetupTally,
+  type EvalStageAnalyticsSliceRow,
+  type EvalStageAnalyticsV1,
+  type EvalStageExclusions,
+  type EvalStageRate,
+  type EvalStageTally,
+} from "@mcpjam/sdk/contract";
+import type { StageAnalyticsFailureKind } from "@/lib/apis/eval-stage-analytics-api";
+
+// ── panel state ──────────────────────────────────────────────────────────────
+/**
+ * What the panel is showing, as five mutually exclusive facts.
+ *
+ * `unsupported` and `unmeasuredLegacy` are deliberately NOT `empty`. "The
+ * backend could not answer", "these runs finished before we measured this" and
+ * "this suite has no runs" are three different things to know, and the one
+ * thing none of them may look like is a funnel of zeros.
+ */
+export type StageAnalyticsPanelState =
+  /** The read did not complete, or this deployment does not serve the route. */
+  | { kind: "unsupported"; message: string }
+  /** The route answered badly, or answered about something else. */
+  | { kind: "error"; message: string }
+  /** No runs at all yet — there is nothing to have measured. */
+  | { kind: "empty" }
+  /** The suite HAS runs, and none of them carries a document. Not a zero. */
+  | { kind: "unmeasuredLegacy"; runCount: number }
+  | { kind: "loading" }
+  | { kind: "ready"; rows: EvalStageAnalyticsV1[] };
+
+export function deriveStageAnalyticsPanelState(input: {
+  status: "idle" | "loading" | "ready" | "error";
+  rows: EvalStageAnalyticsV1[];
+  error: { message: string; kind: StageAnalyticsFailureKind } | null;
+  /** Whether the suite has runs at all — the legacy/empty distinction. */
+  runCount: number;
+  runsLoading: boolean;
+}): StageAnalyticsPanelState {
+  if (input.status === "error" && input.error) {
+    // A service failure and a contract failure are both visible states, and
+    // neither is an empty chart. They are split because only one of them is
+    // actionable by the reader: "try again later" versus "this is a bug".
+    if (
+      input.error.kind === "routeUnavailable" ||
+      input.error.kind === "requestFailed"
+    ) {
+      return { kind: "unsupported", message: input.error.message };
+    }
+    return { kind: "error", message: input.error.message };
+  }
+  if (input.status === "idle" || input.status === "loading") {
+    return { kind: "loading" };
+  }
+  if (input.rows.length > 0) return { kind: "ready", rows: input.rows };
+  // Zero rows is ambiguous on its own, and the run list is what disambiguates
+  // it. Hold the loading frame rather than guessing while runs are still
+  // arriving — guessing here would flash "no runs yet" at a suite that has
+  // hundreds.
+  if (input.runsLoading) return { kind: "loading" };
+  if (input.runCount > 0) {
+    return { kind: "unmeasuredLegacy", runCount: input.runCount };
+  }
+  return { kind: "empty" };
+}
+
+// ── rate formatting ──────────────────────────────────────────────────────────
+/** The words a zero denominator renders as. Never a percentage. */
+export const NOT_MEASURED_LABEL = "not measured";
+
+export interface StageRateView {
+  label: string;
+  /** `72%`, or `null` when there is nothing to divide. */
+  percent: string | null;
+  /** `4/5` — the arithmetic, which always travels with the rate. */
+  arithmetic: string | null;
+  /** `0..1`, for a bar width. `null` means DRAW NO BAR. */
+  fraction: number | null;
+  /** Named exclusions, already in words. Empty when nothing was excluded. */
+  exclusions: string[];
+}
+
+function formatRate(label: string, rate: EvalStageRate): StageRateView {
+  if (rate.state === "notMeasured") {
+    return {
+      label,
+      percent: null,
+      arithmetic: null,
+      fraction: null,
+      exclusions: describeExclusions(rate.exclusions),
+    };
+  }
+  return {
+    label,
+    // Rounded for display only; the arithmetic beside it is the exact claim.
+    // A genuine measured zero formats as "0%" — that is a finding, not the
+    // zero-denominator case the words exist for.
+    percent: `${Math.round(rate.value * 100)}%`,
+    arithmetic: `${rate.numerator}/${rate.denominator}`,
+    fraction: rate.value,
+    exclusions: describeExclusions(rate.exclusions),
+  };
+}
+
+/** The six exclusion classes, in words a reader can act on. */
+export const EXCLUSION_CLASS_LABELS: Record<keyof EvalStageExclusions, string> =
+  {
+    lifecycle: "never produced a comparable observation",
+    integrity: "evidence missing or unverified",
+    version: "produced by a version this reader does not understand",
+    notApplicable: "does not apply to this case",
+    reachUnknown: "nothing captured, so reach is undecidable",
+    notMeasured: "reached, but nothing decided it",
+  };
+
+export function describeExclusions(exclusions: EvalStageExclusions): string[] {
+  const out: string[] = [];
+  for (const [key, label] of Object.entries(EXCLUSION_CLASS_LABELS) as [
+    keyof EvalStageExclusions,
+    string,
+  ][]) {
+    const count = exclusions[key];
+    // Zero is OMITTED by the contract, so an undefined and a 0 mean the same
+    // thing and neither is worth a line.
+    if (count !== undefined && count > 0) out.push(`${count} ${label}`);
+  }
+  return out;
+}
+
+// ── per-stage rows ───────────────────────────────────────────────────────────
+export interface StageRowView {
+  stage: EvalStageTally["stage"];
+  label: string;
+  /** Of the trials whose reach we could decide, how many got here. */
+  reach: StageRateView;
+  /** Of the trials that reached, how many we actually decided. */
+  coverage: StageRateView;
+  /** Of what we decided, how much passed. */
+  pass: StageRateView;
+  applicable: number;
+  notApplicable: number;
+  reachUnknown: number;
+  /** `123 ms · evidence span union`, or `null` when there are no samples. */
+  latency: string | null;
+  reasons: { reason: string; count: number }[];
+}
+
+export function toStageRowView(tally: EvalStageTally): StageRowView {
+  return {
+    stage: tally.stage,
+    label: USER_VALUE_STAGE_LABELS[tally.stage],
+    // The three rates, in the order they qualify one another: a 100% pass rate
+    // over 5% coverage is not a green server, it is an uninstrumented one.
+    reach: formatRate("Reach", reachRate(tally)),
+    coverage: formatRate(
+      "Measurement coverage",
+      measurementCoverageRate(tally),
+    ),
+    pass: formatRate("Measured pass", measuredPassRate(tally)),
+    applicable: tally.applicable,
+    notApplicable: tally.notApplicable,
+    reachUnknown: tally.reachUnknown,
+    latency: formatLatency(tally.latency),
+    reasons: tally.reasons.map((entry) => ({ ...entry })),
+  };
+}
+
+/** The two bases, in words. Always shown — a duration without its basis is a claim. */
+export const LATENCY_BASIS_LABELS: Record<string, string> = {
+  evidence_span_union: "evidence span union",
+  setup_phase_wall: "setup wall clock",
+};
+
+export function formatLatency(
+  aggregate:
+    | { unit: string; basis: string; sampleCount: number; totalMs: number }
+    | undefined,
+): string | null {
+  const mean = latencyMeanMs(aggregate);
+  // `null`, not `0`: a mean of no samples is not a fast server.
+  if (mean === null || aggregate === undefined) return null;
+  const basis = LATENCY_BASIS_LABELS[aggregate.basis] ?? aggregate.basis;
+  return `${Math.round(mean)} ${aggregate.unit} · ${basis}`;
+}
+
+// ── slices ───────────────────────────────────────────────────────────────────
+export interface SliceView {
+  key: string;
+  /** What this slice is, in words. `null` intent becomes "Unlabeled". */
+  title: string;
+  /** A second line when the dimension carries one (provider, engine). */
+  subtitle: string | null;
+  includedTrials: number;
+  exclusions: string[];
+  failureCategories: { category: string; count: number }[];
+  stages: StageRowView[];
+}
+
+export function sliceTitle(slice: EvalStageAnalyticsSliceRow["slice"]): string {
+  switch (slice.dimension) {
+    case "overall":
+      return "Overall";
+    case "intent":
+      // `null` is the UNLABELLED slice and is a real population, not an
+      // omission — never render the raw null, and never drop the row.
+      return slice.intent ?? UNLABELED_INTENT_LABEL;
+    case "model":
+      return slice.model;
+    case "host":
+      return slice.hostName ?? slice.hostKey;
+  }
+}
+
+function sliceSubtitle(
+  slice: EvalStageAnalyticsSliceRow["slice"],
+): string | null {
+  switch (slice.dimension) {
+    case "model":
+      // Two providers serve models by the same name, so the provider is part
+      // of the identity rather than decoration.
+      return slice.provider;
+    case "host":
+      // ABSENT means not recorded — never say "emulated" for a missing engine.
+      return slice.executionEngine ?? null;
+    default:
+      return null;
+  }
+}
+
+export function toSliceView(
+  row: EvalStageAnalyticsSliceRow,
+  index: number,
+): SliceView {
+  return {
+    key: `${row.slice.dimension}:${index}`,
+    title: sliceTitle(row.slice),
+    subtitle: sliceSubtitle(row.slice),
+    includedTrials: row.includedTrials,
+    exclusions: describeExclusions(row.excludedTrials),
+    failureCategories: row.failureCategories.map((entry) => ({ ...entry })),
+    // Position is meaning — the six tallies are a funnel and are never sorted.
+    stages: row.stages.map(toStageRowView),
+  };
+}
+
+/** The overall slice, which the contract guarantees is present exactly once. */
+export function overallSlice(
+  row: EvalStageAnalyticsV1,
+): EvalStageAnalyticsSliceRow | null {
+  return (
+    row.slices.find((slice) => slice.slice.dimension === "overall") ?? null
+  );
+}
+
+export function slicesOfDimension(
+  row: EvalStageAnalyticsV1,
+  dimension: "intent" | "model" | "host",
+): SliceView[] {
+  return row.slices
+    .map((slice, index) => ({ slice, index }))
+    .filter((entry) => entry.slice.slice.dimension === dimension)
+    .map((entry) => toSliceView(entry.slice, entry.index));
+}
+
+// ── setup ────────────────────────────────────────────────────────────────────
+export interface SetupView {
+  phase: EvalSetupTally["phase"];
+  label: string;
+  uniqueAttempts: number;
+  failedAttempts: number;
+  serverAttributedFailures: number;
+  impactedTrials: number;
+  latency: string | null;
+}
+
+export const SETUP_PHASE_LABELS: Record<EvalSetupTally["phase"], string> = {
+  connection: "Connection",
+  discovery: "Discovery",
+};
+
+export function toSetupView(tally: EvalSetupTally): SetupView {
+  return {
+    phase: tally.phase,
+    label: SETUP_PHASE_LABELS[tally.phase],
+    uniqueAttempts: tally.uniqueAttempts,
+    failedAttempts: tally.failedAttempts,
+    serverAttributedFailures: tally.serverAttributedFailures,
+    // May exceed the attempt count — one failed attempt can block many trials,
+    // and that asymmetry is the reason this is counted separately.
+    impactedTrials: tally.impactedTrials,
+    latency: formatLatency(tally.latency),
+  };
+}
+
+// ── run-level disclosures ────────────────────────────────────────────────────
+export interface RunHeaderView {
+  runId: string;
+  /** `provisional` numbers may still move under the reader. Always said. */
+  provisional: boolean;
+  materializationLabel: string;
+  includedTrials: number;
+  totalTrials: number;
+  /** "Trials in this run" — every count names its population. */
+  populationLabel: string;
+  completedAt: number | null;
+  disclosures: string[];
+}
+
+export function toRunHeaderView(row: EvalStageAnalyticsV1): RunHeaderView {
+  const provisional = row.materializationState === "provisional";
+  const disclosures: string[] = [];
+
+  if (row.sourceStageAnalyzerVersions !== undefined) {
+    // A mixed-version row is not comparable to anything, including another
+    // mixed one. Disclosed rather than silently averaged.
+    disclosures.push(
+      `Mixed stage analyzer versions (${row.sourceStageAnalyzerVersions.join(
+        ", ",
+      )}): stages mean subtly different things across a version bump.`,
+    );
+  }
+  if (row.sourceMeasurementsSchemaVersions !== undefined) {
+    disclosures.push(
+      `Mixed measurement schema versions (${row.sourceMeasurementsSchemaVersions.join(
+        ", ",
+      )}).`,
+    );
+  }
+  for (const truncation of row.sliceTruncation ?? []) {
+    // A truncated slice array that looked complete would read as "these are
+    // all the models" — the false comparison the cap record exists to prevent.
+    disclosures.push(
+      `Showing ${truncation.retained} of ${truncation.distinctValues} ${truncation.dimension} values — this is not the complete set.`,
+    );
+  }
+  const excluded = describeExclusions(row.excludedTrials);
+  if (excluded.length > 0) {
+    disclosures.push(`Excluded: ${excluded.join("; ")}.`);
+  }
+
+  return {
+    runId: row.runId,
+    provisional,
+    materializationLabel: provisional
+      ? "provisional — a judge pass is still landing, so these numbers may change"
+      : "final",
+    includedTrials: row.includedTrials,
+    totalTrials: row.totalTrials,
+    populationLabel: `${row.includedTrials} of ${row.totalTrials} trials in this run`,
+    completedAt: row.runCompletedAt ?? null,
+    disclosures,
+  };
+}

--- a/mcpjam-inspector/client/src/components/evaluate/stage-analytics-panel.tsx
+++ b/mcpjam-inspector/client/src/components/evaluate/stage-analytics-panel.tsx
@@ -1,0 +1,453 @@
+/**
+ * The stage-analytics panel on the Evaluate (New) suite page (D5c).
+ *
+ * WHERE the chain stopped — not why, and never a root cause. Each run's
+ * document says where trials fell out of the six-stage chain and whether that
+ * differs by intent, model or host; it explains measured behavior and never
+ * replaces the run's verdict, which stays the verdict policy's to decide.
+ *
+ * ── Why this is not the shared `StageFunnel` ─────────────────────────────────
+ *
+ * `components/shared/user-value-chain/StageFunnel.tsx` renders an OLDER
+ * projection: a precomputed `passRate`, no reach/measured distinction, and a
+ * derivation-lifecycle exclusion vocabulary (`absent`/`deriving`/`stale`/
+ * `failed`) that is deliberately incompatible with `EvalStageExclusions`.
+ * Forcing this document through it would discard exactly the three-rate
+ * structure D5c exists to show. So this renders `EvalStageTally` directly —
+ * while copying that component's honest-state conventions, which are the part
+ * worth sharing: words instead of a bar when nothing was measured, named
+ * exclusions, and a population named on every count.
+ *
+ * ── Run-scoped, never aggregated ─────────────────────────────────────────────
+ *
+ * Each row is ONE run's complete document, and there is no cross-run merge in
+ * the SDK on purpose. So this lists the runs and renders the SELECTED one.
+ * Paging browses further back; it never accumulates into a combined funnel.
+ */
+import { useMemo, useState } from "react";
+import { Loader2 } from "lucide-react";
+import { Button } from "@mcpjam/design-system/button";
+import { cn } from "@/lib/utils";
+import type { EvalStageAnalyticsV1 } from "@mcpjam/sdk/contract";
+import {
+  evalSurfaceCardClass,
+  evalSurfaceHeaderClass,
+} from "../evals/eval-surface-chrome";
+import { useEvalSuiteStageAnalytics } from "@/hooks/use-eval-suite-stage-analytics";
+import {
+  NOT_MEASURED_LABEL,
+  deriveStageAnalyticsPanelState,
+  overallSlice,
+  slicesOfDimension,
+  toRunHeaderView,
+  toSetupView,
+  toSliceView,
+  type SliceView,
+  type StageRateView,
+  type StageRowView,
+} from "./stage-analytics-model";
+
+function formatCompletedAt(epochMs: number | null): string {
+  if (epochMs === null) return "no completion stamp";
+  return new Date(epochMs).toLocaleString();
+}
+
+/** One rate, with its arithmetic and its exclusions. Words when unmeasured. */
+function RateCell({ rate }: { rate: StageRateView }) {
+  return (
+    <div className="flex flex-col gap-0.5">
+      <span className="text-[11px] text-muted-foreground">{rate.label}</span>
+      {rate.percent === null ? (
+        // The words, not a zero. A zero DENOMINATOR is not a measurement.
+        <span className="text-[11px] text-muted-foreground italic">
+          {NOT_MEASURED_LABEL}
+        </span>
+      ) : (
+        <span className="text-[11px] text-muted-foreground">
+          <span className="font-medium text-foreground">{rate.percent}</span>{" "}
+          {/* The counts travel with the rate, always. */}
+          <span aria-label={`${rate.arithmetic} eligible`}>
+            ({rate.arithmetic})
+          </span>
+        </span>
+      )}
+      <div
+        className="mt-0.5 h-1 w-full overflow-hidden rounded-full bg-muted"
+        role="presentation"
+      >
+        {rate.fraction === null ? null : (
+          <div
+            className="h-full rounded-full bg-emerald-500"
+            style={{ width: `${rate.fraction * 100}%` }}
+          />
+        )}
+      </div>
+      {rate.exclusions.length > 0 ? (
+        <p className="text-[10px] text-muted-foreground/80">
+          Excluded: {rate.exclusions.join("; ")}
+        </p>
+      ) : null}
+    </div>
+  );
+}
+
+function StageRow({ stage }: { stage: StageRowView }) {
+  return (
+    <li className="py-2" data-stage={stage.stage} data-testid="stage-row">
+      <div className="flex items-baseline justify-between gap-2">
+        <span className="text-xs font-medium text-foreground">
+          {stage.label}
+        </span>
+        {stage.latency ? (
+          // Unit AND basis: a duration without its basis is a claim, not a
+          // measurement.
+          <span className="text-[10px] text-muted-foreground">
+            {stage.latency}
+          </span>
+        ) : null}
+      </div>
+      <div className="mt-1 grid gap-3 sm:grid-cols-3">
+        <RateCell rate={stage.reach} />
+        <RateCell rate={stage.coverage} />
+        <RateCell rate={stage.pass} />
+      </div>
+      {stage.reachUnknown > 0 || stage.notApplicable > 0 ? (
+        <p className="mt-1 text-[10px] text-muted-foreground/80">
+          {/* Three different facts, kept as three sentences. None is a failure. */}
+          {stage.reachUnknown} captured nothing (reach undecidable),{" "}
+          {stage.notApplicable} not applicable to the case. Neither is counted
+          as a drop-off.
+        </p>
+      ) : null}
+      {stage.reasons.length > 0 ? (
+        <p className="mt-1 text-[10px] text-muted-foreground/80">
+          {stage.reasons
+            .map((entry) => `${entry.reason} (${entry.count})`)
+            .join(", ")}
+        </p>
+      ) : null}
+    </li>
+  );
+}
+
+function SliceBlock({ slice }: { slice: SliceView }) {
+  return (
+    <div
+      className="rounded-md border border-border/60 p-3"
+      data-testid="stage-slice"
+    >
+      <div className="flex items-baseline justify-between gap-2">
+        <div className="flex flex-col">
+          <span className="text-xs font-medium text-foreground">
+            {slice.title}
+          </span>
+          {slice.subtitle ? (
+            <span className="text-[10px] text-muted-foreground">
+              {slice.subtitle}
+            </span>
+          ) : null}
+        </div>
+        {/* Every count names its population. */}
+        <span className="text-[10px] text-muted-foreground">
+          {slice.includedTrials} trials in this slice
+        </span>
+      </div>
+      {slice.exclusions.length > 0 ? (
+        <p className="mt-1 text-[10px] text-muted-foreground/80">
+          Excluded: {slice.exclusions.join("; ")}
+        </p>
+      ) : null}
+      {slice.failureCategories.length > 0 ? (
+        <p className="mt-1 text-[10px] text-muted-foreground/80">
+          {slice.failureCategories
+            .map((entry) => `${entry.category} (${entry.count})`)
+            .join(", ")}
+        </p>
+      ) : null}
+      <ul className="mt-1 divide-y divide-border/50">
+        {slice.stages.map((stage) => (
+          <StageRow key={stage.stage} stage={stage} />
+        ))}
+      </ul>
+    </div>
+  );
+}
+
+function SliceGroup({ title, slices }: { title: string; slices: SliceView[] }) {
+  if (slices.length === 0) return null;
+  return (
+    <section className="mt-3">
+      <h4 className="text-[11px] font-medium uppercase tracking-wide text-muted-foreground">
+        {title}
+      </h4>
+      <div className="mt-1.5 grid gap-2">
+        {slices.map((slice) => (
+          <SliceBlock key={slice.key} slice={slice} />
+        ))}
+      </div>
+    </section>
+  );
+}
+
+function RunDocument({ row }: { row: EvalStageAnalyticsV1 }) {
+  const header = toRunHeaderView(row);
+  const overall = overallSlice(row);
+  const intents = slicesOfDimension(row, "intent");
+  const models = slicesOfDimension(row, "model");
+  const hosts = slicesOfDimension(row, "host");
+  const setup = row.setup.map(toSetupView);
+
+  return (
+    <div data-testid="stage-analytics-document">
+      <div className="flex flex-wrap items-baseline gap-2">
+        <span className="text-xs font-medium text-foreground">
+          {formatCompletedAt(header.completedAt)}
+        </span>
+        {header.provisional ? (
+          <span
+            className="rounded-full bg-amber-500/15 px-2 py-0.5 text-[10px] text-amber-700 dark:text-amber-400"
+            data-testid="stage-analytics-provisional"
+          >
+            {header.materializationLabel}
+          </span>
+        ) : null}
+        <span className="text-[10px] text-muted-foreground">
+          {header.populationLabel}
+        </span>
+      </div>
+
+      {header.disclosures.length > 0 ? (
+        <ul
+          className="mt-1.5 space-y-0.5"
+          data-testid="stage-analytics-disclosures"
+        >
+          {header.disclosures.map((line) => (
+            <li key={line} className="text-[10px] text-muted-foreground/80">
+              {line}
+            </li>
+          ))}
+        </ul>
+      ) : null}
+
+      {overall ? (
+        <section className="mt-3">
+          <h4 className="text-[11px] font-medium uppercase tracking-wide text-muted-foreground">
+            Overall — where the chain stopped
+          </h4>
+          <div className="mt-1.5">
+            <SliceBlock slice={toSliceView(overall, 0)} />
+          </div>
+        </section>
+      ) : null}
+
+      <SliceGroup title="By intent" slices={intents} />
+      <SliceGroup title="By model" slices={models} />
+      <SliceGroup title="By host" slices={hosts} />
+
+      {setup.length > 0 ? (
+        <section className="mt-3" data-testid="stage-analytics-setup">
+          <h4 className="text-[11px] font-medium uppercase tracking-wide text-muted-foreground">
+            Setup
+          </h4>
+          <div className="mt-1.5 grid gap-2">
+            {setup.map((phase) => (
+              <div
+                key={phase.phase}
+                className="rounded-md border border-border/60 p-3"
+              >
+                <div className="flex items-baseline justify-between gap-2">
+                  <span className="text-xs font-medium text-foreground">
+                    {phase.label}
+                  </span>
+                  {phase.latency ? (
+                    <span className="text-[10px] text-muted-foreground">
+                      {phase.latency}
+                    </span>
+                  ) : null}
+                </div>
+                <p className="mt-1 text-[10px] text-muted-foreground">
+                  {/* Attempts are counted once per run; impacted trials are
+                      counted distinctly and MAY exceed them. */}
+                  {phase.uniqueAttempts} attempts, {phase.failedAttempts} failed
+                  ({phase.serverAttributedFailures} attributed to the server),
+                  blocking {phase.impactedTrials} trials in this run
+                </p>
+              </div>
+            ))}
+          </div>
+        </section>
+      ) : null}
+    </div>
+  );
+}
+
+export function StageAnalyticsPanel({
+  projectId,
+  suiteId,
+  runCount,
+  runsLoading,
+}: {
+  projectId: string | null | undefined;
+  suiteId: string | null | undefined;
+  /** How many runs this suite has — the legacy/empty distinction. */
+  runCount: number;
+  runsLoading: boolean;
+}) {
+  const {
+    status,
+    rows,
+    error,
+    canLoadMore,
+    isLoadingMore,
+    pageError,
+    loadMore,
+    retryFailedPage,
+  } = useEvalSuiteStageAnalytics({ projectId, suiteId });
+
+  const [selectedRunId, setSelectedRunId] = useState<string | null>(null);
+
+  const panelState = useMemo(
+    () =>
+      deriveStageAnalyticsPanelState({
+        status,
+        rows,
+        error,
+        runCount,
+        runsLoading,
+      }),
+    [status, rows, error, runCount, runsLoading],
+  );
+
+  // Default to the newest run, and fall back to it whenever the selected run
+  // leaves the list (a filter change, a fresh walk).
+  const selected =
+    rows.find((row) => row.runId === selectedRunId) ?? rows[0] ?? null;
+
+  return (
+    <section
+      className={cn(evalSurfaceCardClass, "overflow-hidden")}
+      data-testid="suite-detail-stage-analytics"
+    >
+      <div className={cn(evalSurfaceHeaderClass, "px-4 py-3")}>
+        <h3 className="text-sm font-medium text-foreground">Stage analytics</h3>
+        <p className="mt-0.5 text-[11px] text-muted-foreground">
+          Where trials stopped in the user-value chain, per run. Explains
+          measured behavior; it does not decide the run&apos;s verdict.
+        </p>
+      </div>
+
+      <div className="px-4 py-3">
+        {panelState.kind === "loading" ? (
+          <p
+            className="flex items-center gap-2 text-xs text-muted-foreground"
+            data-testid="stage-analytics-loading"
+          >
+            <Loader2 className="h-3 w-3 animate-spin" />
+            Loading stage analytics…
+          </p>
+        ) : null}
+
+        {panelState.kind === "unsupported" ? (
+          // A SERVICE state, visibly distinct from "there is nothing here".
+          // An empty chart would read as "measured, and it was all zero".
+          <p
+            className="text-xs text-muted-foreground"
+            data-testid="stage-analytics-unsupported"
+          >
+            Stage analytics could not be loaded, so this run&apos;s chain is not
+            measured here. {panelState.message}
+          </p>
+        ) : null}
+
+        {panelState.kind === "error" ? (
+          <p
+            className="text-xs text-muted-foreground"
+            data-testid="stage-analytics-error"
+          >
+            {panelState.message}
+          </p>
+        ) : null}
+
+        {panelState.kind === "empty" ? (
+          <p
+            className="text-xs text-muted-foreground"
+            data-testid="stage-analytics-empty"
+          >
+            No completed runs yet.
+          </p>
+        ) : null}
+
+        {panelState.kind === "unmeasuredLegacy" ? (
+          // NOT a zero and NOT empty: these runs finished before the chain was
+          // measured, and there is no honest way to reconstruct it after the
+          // fact.
+          <p
+            className="text-xs text-muted-foreground"
+            data-testid="stage-analytics-unmeasured-legacy"
+          >
+            These {panelState.runCount} runs predate stage analytics, so their
+            chain was never measured. Runs from here on will be.
+          </p>
+        ) : null}
+
+        {panelState.kind === "ready" && selected ? (
+          <>
+            {rows.length > 1 ? (
+              <div
+                className="mb-3 flex flex-wrap gap-1.5"
+                data-testid="stage-analytics-run-list"
+              >
+                {rows.map((row) => (
+                  <button
+                    key={row.runId}
+                    type="button"
+                    onClick={() => setSelectedRunId(row.runId)}
+                    className={cn(
+                      "rounded-md border px-2 py-1 text-[10px]",
+                      row.runId === selected.runId
+                        ? "border-foreground/40 bg-muted text-foreground"
+                        : "border-border/60 text-muted-foreground",
+                    )}
+                  >
+                    {formatCompletedAt(row.runCompletedAt ?? null)}
+                    {row.materializationState === "provisional"
+                      ? " · provisional"
+                      : ""}
+                  </button>
+                ))}
+              </div>
+            ) : null}
+
+            <RunDocument row={selected} />
+
+            {pageError ? (
+              // A later page failing never clears the pages already read.
+              <div className="mt-3 flex items-center gap-2">
+                <span className="text-[11px] text-muted-foreground">
+                  Could not load more runs. {pageError.message}
+                </span>
+                <Button size="sm" variant="ghost" onClick={retryFailedPage}>
+                  Retry
+                </Button>
+              </div>
+            ) : null}
+
+            {canLoadMore ? (
+              <div className="mt-3">
+                <Button
+                  size="sm"
+                  variant="ghost"
+                  onClick={loadMore}
+                  disabled={isLoadingMore}
+                  data-testid="stage-analytics-load-more"
+                >
+                  {isLoadingMore ? "Loading…" : "Load more runs"}
+                </Button>
+              </div>
+            ) : null}
+          </>
+        ) : null}
+      </div>
+    </section>
+  );
+}

--- a/mcpjam-inspector/client/src/components/evaluate/suite-detail-overview.tsx
+++ b/mcpjam-inspector/client/src/components/evaluate/suite-detail-overview.tsx
@@ -525,13 +525,20 @@ export function SuiteDetailOverview({
 
       {/* Where the chain stopped, per run — the measured half of a run, beside
           its history. Evaluate-only by construction: this file is the Evaluate
-          (New) suite page, so /evals cannot pick it up. */}
-      <StageAnalyticsPanel
-        projectId={projectId}
-        suiteId={suite._id}
-        runCount={runs.length}
-        runsLoading={runsLoading}
-      />
+          (New) suite page, so /evals cannot pick it up.
+
+          Gated on `projectId` because it is genuinely nullable here and the
+          read is project-scoped: without one there is no request to make, and
+          rendering the panel anyway would leave it spinning on a fetch that
+          never starts. Same gate the traces export uses above. */}
+      {projectId ? (
+        <StageAnalyticsPanel
+          projectId={projectId}
+          suiteId={suite._id}
+          runCount={runs.length}
+          runsLoading={runsLoading}
+        />
+      ) : null}
 
       {showEmptyCasesHero ? (
         <SuiteEmptyCasesHero

--- a/mcpjam-inspector/client/src/components/evaluate/suite-detail-overview.tsx
+++ b/mcpjam-inspector/client/src/components/evaluate/suite-detail-overview.tsx
@@ -42,6 +42,7 @@ import {
   type SuiteRunHistoryFilters,
   type SuiteRunHistoryRow,
 } from "./suite-detail-model";
+import { StageAnalyticsPanel } from "./stage-analytics-panel";
 import type { EvalCase, EvalIteration, EvalSuite, EvalSuiteRun } from "../evals/types";
 import {
   RunDecisionVerdictBadge,
@@ -521,6 +522,16 @@ export function SuiteDetailOverview({
         </div>
       </section>
       ) : null}
+
+      {/* Where the chain stopped, per run — the measured half of a run, beside
+          its history. Evaluate-only by construction: this file is the Evaluate
+          (New) suite page, so /evals cannot pick it up. */}
+      <StageAnalyticsPanel
+        projectId={projectId}
+        suiteId={suite._id}
+        runCount={runs.length}
+        runsLoading={runsLoading}
+      />
 
       {showEmptyCasesHero ? (
         <SuiteEmptyCasesHero

--- a/mcpjam-inspector/client/src/hooks/__tests__/use-eval-suite-stage-analytics.test.tsx
+++ b/mcpjam-inspector/client/src/hooks/__tests__/use-eval-suite-stage-analytics.test.tsx
@@ -1,0 +1,216 @@
+/**
+ * The stage-analytics fetch hook.
+ *
+ * The four things worth pinning are all about NOT painting the wrong answer:
+ * an out-of-order response must never overwrite a newer one, unmounting must
+ * abort rather than write into a dead component, switching suites must reset
+ * the walk rather than inherit cursors that describe different runs, and a
+ * later page failing must never destroy the pages already on screen.
+ */
+import { describe, expect, it, vi, beforeEach, afterEach } from "vitest";
+import { act, render, waitFor } from "@testing-library/react";
+import { useEvalSuiteStageAnalytics } from "../use-eval-suite-stage-analytics";
+import {
+  GOLDEN_STAGE_ANALYTICS,
+  stageAnalyticsVariation,
+} from "@/test/stage-analytics-fixtures";
+import type { EvalSuiteStageAnalyticsState } from "../use-eval-suite-stage-analytics";
+
+const { fetchMock } = vi.hoisted(() => ({ fetchMock: vi.fn() }));
+vi.mock("@/lib/apis/eval-stage-analytics-api", async () => {
+  const actual = await vi.importActual<
+    typeof import("@/lib/apis/eval-stage-analytics-api")
+  >("@/lib/apis/eval-stage-analytics-api");
+  return { ...actual, fetchEvalSuiteStageAnalytics: fetchMock };
+});
+
+const SUITE_ID = GOLDEN_STAGE_ANALYTICS.suiteId;
+
+function Harness({
+  projectId = "p1",
+  suiteId = SUITE_ID,
+  onState,
+}: {
+  projectId?: string | null;
+  suiteId?: string | null;
+  onState: (state: EvalSuiteStageAnalyticsState) => void;
+}) {
+  onState(useEvalSuiteStageAnalytics({ projectId, suiteId }));
+  return null;
+}
+
+function renderHook(props: Partial<Parameters<typeof Harness>[0]> = {}) {
+  const states: EvalSuiteStageAnalyticsState[] = [];
+  const utils = render(
+    <Harness {...props} onState={(state) => states.push(state)} />,
+  );
+  return {
+    ...utils,
+    states,
+    latest: () => states[states.length - 1]!,
+  };
+}
+
+beforeEach(() => {
+  fetchMock.mockReset();
+});
+
+afterEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("useEvalSuiteStageAnalytics", () => {
+  it("loads the first page and reports ready", async () => {
+    fetchMock.mockResolvedValue({ rows: [GOLDEN_STAGE_ANALYTICS] });
+
+    const { latest } = renderHook();
+    await waitFor(() => expect(latest().status).toBe("ready"));
+
+    expect(latest().rows).toHaveLength(1);
+    expect(latest().canLoadMore).toBe(false);
+    expect(fetchMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        projectId: "p1",
+        suiteId: SUITE_ID,
+        limit: 25,
+      }),
+      expect.any(AbortSignal),
+    );
+  });
+
+  it("reports a failure as an error state, never as an empty ready", async () => {
+    fetchMock.mockRejectedValue(new Error("upstream down"));
+
+    const { latest } = renderHook();
+    await waitFor(() => expect(latest().status).toBe("error"));
+
+    // Empty AND error is the state the panel must be able to tell from
+    // empty AND ready — one is "no data", the other is "we could not ask".
+    expect(latest().rows).toEqual([]);
+    expect(latest().error?.kind).toBe("requestFailed");
+  });
+
+  it("aborts the in-flight read on unmount", async () => {
+    let capturedSignal: AbortSignal | undefined;
+    fetchMock.mockImplementation(
+      (_params: unknown, signal?: AbortSignal) =>
+        new Promise(() => {
+          capturedSignal = signal;
+        }),
+    );
+
+    const { unmount } = renderHook();
+    await waitFor(() => expect(capturedSignal).toBeDefined());
+    expect(capturedSignal!.aborted).toBe(false);
+
+    unmount();
+    expect(capturedSignal!.aborted).toBe(true);
+  });
+
+  it("resets the walk when the suite changes", async () => {
+    fetchMock.mockResolvedValue({ rows: [GOLDEN_STAGE_ANALYTICS] });
+
+    const states: EvalSuiteStageAnalyticsState[] = [];
+    const { rerender } = render(
+      <Harness suiteId={SUITE_ID} onState={(s) => states.push(s)} />,
+    );
+    await waitFor(() =>
+      expect(states[states.length - 1]!.status).toBe("ready"),
+    );
+
+    const other = stageAnalyticsVariation({
+      suiteId: "suite_other",
+      runId: "run_other",
+    });
+    fetchMock.mockResolvedValue({ rows: [other] });
+    rerender(<Harness suiteId="suite_other" onState={(s) => states.push(s)} />);
+
+    await waitFor(() =>
+      expect(states[states.length - 1]!.rows[0]?.runId).toBe("run_other"),
+    );
+    // The previous suite's documents are gone, not merged in beneath the new
+    // ones — they describe a different set of runs entirely.
+    expect(states[states.length - 1]!.rows).toHaveLength(1);
+  });
+
+  it("accumulates later pages and dedupes by runId", async () => {
+    const second = stageAnalyticsVariation({ runId: "run_second" });
+    fetchMock
+      .mockResolvedValueOnce({
+        rows: [GOLDEN_STAGE_ANALYTICS],
+        nextCursor: "c2",
+      })
+      .mockResolvedValueOnce({
+        // The first run repeats — a cursor boundary that shifted under a
+        // concurrent write must not make one run appear twice.
+        rows: [GOLDEN_STAGE_ANALYTICS, second],
+      });
+
+    const { latest } = renderHook();
+    await waitFor(() => expect(latest().canLoadMore).toBe(true));
+
+    act(() => latest().loadMore());
+    await waitFor(() => expect(latest().rows).toHaveLength(2));
+
+    expect(latest().rows.map((row) => row.runId)).toEqual([
+      GOLDEN_STAGE_ANALYTICS.runId,
+      "run_second",
+    ]);
+    expect(latest().canLoadMore).toBe(false);
+  });
+
+  it("keeps earlier pages when a later page fails, and retries just that page", async () => {
+    const second = stageAnalyticsVariation({ runId: "run_second" });
+    fetchMock
+      .mockResolvedValueOnce({
+        rows: [GOLDEN_STAGE_ANALYTICS],
+        nextCursor: "c2",
+      })
+      .mockRejectedValueOnce(new Error("page two exploded"))
+      .mockResolvedValueOnce({ rows: [second] });
+
+    const { latest } = renderHook();
+    await waitFor(() => expect(latest().canLoadMore).toBe(true));
+
+    act(() => latest().loadMore());
+    await waitFor(() => expect(latest().pageError).not.toBeNull());
+
+    // NON-DESTRUCTIVE: page one is still on screen.
+    expect(latest().rows).toHaveLength(1);
+    expect(latest().status).toBe("ready");
+
+    act(() => latest().retryFailedPage());
+    await waitFor(() => expect(latest().rows).toHaveLength(2));
+    expect(latest().pageError).toBeNull();
+  });
+
+  it("does not replay a cursor it has already walked", async () => {
+    fetchMock
+      .mockResolvedValueOnce({
+        rows: [GOLDEN_STAGE_ANALYTICS],
+        nextCursor: "c2",
+      })
+      // The backend hands back the SAME cursor — a walk that replayed it would
+      // append the same runs forever.
+      .mockResolvedValueOnce({
+        rows: [stageAnalyticsVariation({ runId: "run_second" })],
+        nextCursor: "c2",
+      });
+
+    const { latest } = renderHook();
+    await waitFor(() => expect(latest().canLoadMore).toBe(true));
+
+    act(() => latest().loadMore());
+    await waitFor(() => expect(latest().rows).toHaveLength(2));
+
+    const callsBefore = fetchMock.mock.calls.length;
+    act(() => latest().loadMore());
+    expect(fetchMock.mock.calls.length).toBe(callsBefore);
+  });
+
+  it("stays idle without a project or suite", async () => {
+    const { latest } = renderHook({ suiteId: null });
+    await waitFor(() => expect(latest().status).toBe("idle"));
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+});

--- a/mcpjam-inspector/client/src/hooks/use-eval-suite-stage-analytics.ts
+++ b/mcpjam-inspector/client/src/hooks/use-eval-suite-stage-analytics.ts
@@ -1,0 +1,239 @@
+/**
+ * Fetch hook for a suite's materialized stage analytics (D5c).
+ *
+ * The no-store variant, on purpose. `use-eval-run-decision-summary.ts` pages
+ * through an LRU store because dozens of run rows each ask for their own
+ * summary and the dedupe is what keeps that from being dozens of requests. This
+ * surface is ONE panel on one suite page; a store would be machinery with no
+ * second caller, so this follows `use-run-disclosure.ts` instead — status
+ * state, a monotonic request id so an out-of-order response can never paint
+ * over a newer one, and an `AbortController` per effect.
+ *
+ * Paging follows `useEvalRunDecisionDetail`'s cursor-array shape: each cursor
+ * is its own request, a later page failing never destroys the pages already
+ * read, and a cursor already walked is never replayed. What it does NOT do is
+ * merge the pages into a single funnel — each row is one run's complete
+ * document and there is no honest cross-run aggregate to compute, so pages
+ * accumulate as a LIST of runs and the panel renders one of them.
+ */
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import type { EvalStageAnalyticsV1 } from "@mcpjam/sdk/contract";
+import {
+  fetchEvalSuiteStageAnalytics,
+  isEvalStageAnalyticsError,
+  type StageAnalyticsFailureKind,
+} from "@/lib/apis/eval-stage-analytics-api";
+
+export type StageAnalyticsStatus = "idle" | "loading" | "ready" | "error";
+
+export interface StageAnalyticsErrorInfo {
+  message: string;
+  /**
+   * Which of the four failures this is. Carried rather than flattened to a
+   * message because the panel renders them differently: `routeUnavailable` and
+   * `requestFailed` are SERVICE states ("we could not measure this"), while
+   * `invalidContract` is a bug report and `notFound` is a fact about the suite.
+   * None of them is an empty chart.
+   */
+  kind: StageAnalyticsFailureKind;
+  status?: number;
+}
+
+export interface EvalSuiteStageAnalyticsState {
+  status: StageAnalyticsStatus;
+  /** Accumulated documents, newest run completion first, deduped by `runId`. */
+  rows: EvalStageAnalyticsV1[];
+  error: StageAnalyticsErrorInfo | null;
+  canLoadMore: boolean;
+  isLoadingMore: boolean;
+  /** A LATER page's failure. Never clears the pages already read. */
+  pageError: StageAnalyticsErrorInfo | null;
+  loadMore: () => void;
+  retryFailedPage: () => void;
+}
+
+/** Default page size — mirrors the route's own default. */
+export const STAGE_ANALYTICS_PAGE_LIMIT = 25;
+
+function toErrorInfo(error: unknown): StageAnalyticsErrorInfo {
+  if (isEvalStageAnalyticsError(error)) {
+    return {
+      message: error.message,
+      kind: error.kind,
+      ...(error.status !== undefined ? { status: error.status } : {}),
+    };
+  }
+  return {
+    message: error instanceof Error ? error.message : String(error),
+    kind: "requestFailed",
+  };
+}
+
+export function useEvalSuiteStageAnalytics({
+  projectId,
+  suiteId,
+  enabled = true,
+  limit = STAGE_ANALYTICS_PAGE_LIMIT,
+}: {
+  projectId: string | null | undefined;
+  suiteId: string | null | undefined;
+  enabled?: boolean;
+  limit?: number;
+}): EvalSuiteStageAnalyticsState {
+  const active = Boolean(enabled && projectId && suiteId);
+
+  const [rows, setRows] = useState<EvalStageAnalyticsV1[]>([]);
+  const [status, setStatus] = useState<StageAnalyticsStatus>("idle");
+  const [error, setError] = useState<StageAnalyticsErrorInfo | null>(null);
+  const [nextCursor, setNextCursor] = useState<string | undefined>(undefined);
+  const [pendingCursor, setPendingCursor] = useState<string | undefined>(
+    undefined,
+  );
+  const [pageError, setPageError] = useState<StageAnalyticsErrorInfo | null>(
+    null,
+  );
+  const [isLoadingMore, setIsLoadingMore] = useState(false);
+
+  // Every cursor already walked. A cursor is never replayed: a backend that
+  // returns the same cursor twice would otherwise loop forever, appending the
+  // same runs on each pass.
+  const walkedRef = useRef<Set<string>>(new Set());
+  // Monotonic request id. Only the newest in-flight request may write state.
+  const requestIdRef = useRef(0);
+
+  // A new suite (or project) is a new walk. Without this the second suite would
+  // inherit the first's cursors and rows, which describe different runs.
+  const identity = `${projectId ?? ""}::${suiteId ?? ""}::${limit}`;
+  const previousIdentity = useRef(identity);
+  if (previousIdentity.current !== identity) {
+    previousIdentity.current = identity;
+    walkedRef.current = new Set();
+    requestIdRef.current += 1;
+    if (rows.length > 0) setRows([]);
+    if (nextCursor !== undefined) setNextCursor(undefined);
+    if (pendingCursor !== undefined) setPendingCursor(undefined);
+    if (pageError !== null) setPageError(null);
+    if (error !== null) setError(null);
+    if (isLoadingMore) setIsLoadingMore(false);
+    if (status !== "idle") setStatus("idle");
+  }
+
+  // ── the first page ─────────────────────────────────────────────────────────
+  useEffect(() => {
+    if (!active) {
+      requestIdRef.current += 1;
+      setStatus("idle");
+      setRows([]);
+      setError(null);
+      setNextCursor(undefined);
+      return;
+    }
+
+    requestIdRef.current += 1;
+    const requestId = requestIdRef.current;
+    const controller = new AbortController();
+    setStatus("loading");
+    setError(null);
+
+    void (async () => {
+      try {
+        const page = await fetchEvalSuiteStageAnalytics(
+          {
+            projectId: projectId as string,
+            suiteId: suiteId as string,
+            limit,
+          },
+          controller.signal,
+        );
+        if (requestId !== requestIdRef.current) return;
+        walkedRef.current = new Set();
+        setRows(page.rows);
+        setNextCursor(page.nextCursor);
+        setStatus("ready");
+      } catch (err) {
+        // An abort is the caller's own teardown, not a failure to report.
+        if (controller.signal.aborted) return;
+        if (requestId !== requestIdRef.current) return;
+        setRows([]);
+        setNextCursor(undefined);
+        setError(toErrorInfo(err));
+        setStatus("error");
+      }
+    })();
+
+    return () => controller.abort();
+  }, [active, projectId, suiteId, limit]);
+
+  // ── later pages ────────────────────────────────────────────────────────────
+  useEffect(() => {
+    if (!active || pendingCursor === undefined) return;
+
+    const controller = new AbortController();
+    setIsLoadingMore(true);
+    setPageError(null);
+
+    void (async () => {
+      try {
+        const page = await fetchEvalSuiteStageAnalytics(
+          {
+            projectId: projectId as string,
+            suiteId: suiteId as string,
+            limit,
+            cursor: pendingCursor,
+          },
+          controller.signal,
+        );
+        if (controller.signal.aborted) return;
+        walkedRef.current.add(pendingCursor);
+        // Deduped by `runId`: one run has exactly one document, and a cursor
+        // boundary that shifted under a concurrent write must not make one run
+        // appear twice in the list.
+        setRows((current) => {
+          const seen = new Set(current.map((row) => row.runId));
+          return [
+            ...current,
+            ...page.rows.filter((row) => !seen.has(row.runId)),
+          ];
+        });
+        setNextCursor(page.nextCursor);
+        setIsLoadingMore(false);
+        setPendingCursor(undefined);
+      } catch (err) {
+        if (controller.signal.aborted) return;
+        // NON-DESTRUCTIVE: the pages already read stay on screen, and the
+        // cursor stays un-walked so a retry can ask for the same page again.
+        setPageError(toErrorInfo(err));
+        setIsLoadingMore(false);
+        setPendingCursor(undefined);
+      }
+    })();
+
+    return () => controller.abort();
+  }, [active, projectId, suiteId, limit, pendingCursor]);
+
+  const loadMore = useCallback(() => {
+    if (!nextCursor || walkedRef.current.has(nextCursor)) return;
+    setPendingCursor(nextCursor);
+  }, [nextCursor]);
+
+  const retryFailedPage = useCallback(() => {
+    if (!nextCursor || !pageError) return;
+    setPendingCursor(nextCursor);
+  }, [nextCursor, pageError]);
+
+  const canLoadMore = useMemo(
+    () => Boolean(nextCursor) && !isLoadingMore,
+    [nextCursor, isLoadingMore],
+  );
+
+  return {
+    status,
+    rows,
+    error,
+    canLoadMore,
+    isLoadingMore,
+    pageError,
+    loadMore,
+    retryFailedPage,
+  };
+}

--- a/mcpjam-inspector/client/src/lib/apis/__tests__/eval-stage-analytics-api.test.ts
+++ b/mcpjam-inspector/client/src/lib/apis/__tests__/eval-stage-analytics-api.test.ts
@@ -1,0 +1,228 @@
+/**
+ * The browser adapter for a suite's stage analytics.
+ *
+ * What these pin:
+ *
+ *   - **Auth has ONE owner.** If the adapter lets `PlatformApiClient` set its
+ *     own `Authorization`, `authFetch` treats the caller as owning the bearer
+ *     and skips BOTH its header and its 401 refresh-and-retry.
+ *   - **The filters reach the wire.** A dropped cursor silently re-reads page
+ *     one forever; a dropped window reads a different population than the
+ *     caller asked about.
+ *   - **An abort stays an abort**, not an error painted on a surface the user
+ *     just navigated away from.
+ *   - **The four failure kinds stay four.** Only `invalidContract` is a bug
+ *     report, and none of them is an empty page.
+ *   - **The payload is VALIDATED, not trusted** — with the REFINED schema, and
+ *     bound to the suite that was actually asked about.
+ */
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const { authFetchMock } = vi.hoisted(() => ({ authFetchMock: vi.fn() }));
+vi.mock("@/lib/session-token", () => ({ authFetch: authFetchMock }));
+
+import {
+  EvalStageAnalyticsError,
+  fetchEvalSuiteStageAnalytics,
+  isEvalStageAnalyticsError,
+} from "../eval-stage-analytics-api";
+import {
+  GOLDEN_STAGE_ANALYTICS,
+  stageAnalyticsVariation,
+} from "@/test/stage-analytics-fixtures";
+
+const SUITE_ID = GOLDEN_STAGE_ANALYTICS.suiteId;
+
+function jsonResponse(body: unknown, status = 200): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { "content-type": "application/json" },
+  });
+}
+
+function lastRequest(): { url: URL; init: RequestInit } {
+  const [target, init] = authFetchMock.mock.calls.at(-1)!;
+  return {
+    url: new URL(String(target), "https://app.example.com"),
+    init: (init ?? {}) as RequestInit,
+  };
+}
+
+beforeEach(() => {
+  authFetchMock.mockReset();
+});
+
+describe("fetchEvalSuiteStageAnalytics", () => {
+  it("reads a page and returns the validated documents", async () => {
+    authFetchMock.mockResolvedValue(
+      jsonResponse({ items: [GOLDEN_STAGE_ANALYTICS], nextCursor: "c2" }),
+    );
+
+    const page = await fetchEvalSuiteStageAnalytics({
+      projectId: "p1",
+      suiteId: SUITE_ID,
+    });
+
+    expect(page.rows).toHaveLength(1);
+    expect(page.rows[0]!.runId).toBe(GOLDEN_STAGE_ANALYTICS.runId);
+    expect(page.nextCursor).toBe("c2");
+  });
+
+  it("omits nextCursor on the last page", async () => {
+    authFetchMock.mockResolvedValue(jsonResponse({ items: [] }));
+    const page = await fetchEvalSuiteStageAnalytics({
+      projectId: "p1",
+      suiteId: SUITE_ID,
+    });
+    // Completeness is the ABSENCE of a cursor, not a boolean beside it.
+    expect(page.nextCursor).toBeUndefined();
+    expect(page.rows).toEqual([]);
+  });
+
+  it("leaves the bearer to authFetch", async () => {
+    authFetchMock.mockResolvedValue(jsonResponse({ items: [] }));
+    await fetchEvalSuiteStageAnalytics({ projectId: "p1", suiteId: SUITE_ID });
+
+    const headers = new Headers(lastRequest().init.headers);
+    expect(headers.has("authorization")).toBe(false);
+  });
+
+  it("puts every filter on the wire", async () => {
+    authFetchMock.mockResolvedValue(jsonResponse({ items: [] }));
+    await fetchEvalSuiteStageAnalytics({
+      projectId: "p1",
+      suiteId: SUITE_ID,
+      from: 1700000000000,
+      to: 1700000100000,
+      runGroupId: "grp_1",
+      cursor: "c1",
+      limit: 10,
+    });
+
+    const { url } = lastRequest();
+    expect(url.pathname).toContain("/eval-suites/");
+    expect(url.pathname).toContain("/stage-analytics");
+    expect(url.searchParams.get("from")).toBe("1700000000000");
+    expect(url.searchParams.get("to")).toBe("1700000100000");
+    expect(url.searchParams.get("runGroupId")).toBe("grp_1");
+    expect(url.searchParams.get("cursor")).toBe("c1");
+    expect(url.searchParams.get("limit")).toBe("10");
+  });
+
+  it("forwards the caller's abort signal and rethrows the abort untouched", async () => {
+    const controller = new AbortController();
+    authFetchMock.mockImplementation(
+      (_input: unknown, init?: RequestInit) =>
+        new Promise((_resolve, reject) => {
+          const fail = () => reject(new DOMException("aborted", "AbortError"));
+          if (init?.signal?.aborted) {
+            fail();
+            return;
+          }
+          init?.signal?.addEventListener("abort", fail);
+        }),
+    );
+
+    const pending = fetchEvalSuiteStageAnalytics(
+      { projectId: "p1", suiteId: SUITE_ID },
+      controller.signal,
+    ).catch((error: unknown) => error);
+    controller.abort();
+
+    const error = await pending;
+    // Not dressed up as an API failure — the caller cancelled this.
+    expect(isEvalStageAnalyticsError(error)).toBe(false);
+    expect((error as DOMException).name).toBe("AbortError");
+  });
+
+  describe("the four failure kinds stay four", () => {
+    it("maps a 404 to notFound", async () => {
+      authFetchMock.mockResolvedValue(
+        jsonResponse(
+          { code: "NOT_FOUND", message: "Eval suite not found" },
+          404,
+        ),
+      );
+      const error = await fetchEvalSuiteStageAnalytics({
+        projectId: "p1",
+        suiteId: SUITE_ID,
+      }).catch((caught: unknown) => caught);
+
+      expect(error).toBeInstanceOf(EvalStageAnalyticsError);
+      expect((error as EvalStageAnalyticsError).kind).toBe("notFound");
+    });
+
+    it("maps a 501 to routeUnavailable", async () => {
+      authFetchMock.mockResolvedValue(
+        jsonResponse({ code: "NOT_IMPLEMENTED", message: "nope" }, 501),
+      );
+      const error = await fetchEvalSuiteStageAnalytics({
+        projectId: "p1",
+        suiteId: SUITE_ID,
+      }).catch((caught: unknown) => caught);
+
+      expect((error as EvalStageAnalyticsError).kind).toBe("routeUnavailable");
+    });
+
+    it("maps a 502 to requestFailed — a service state, never an empty page", async () => {
+      authFetchMock.mockResolvedValue(
+        jsonResponse(
+          {
+            code: "SERVER_UNREACHABLE",
+            message: "Stage analytics payload failed validation",
+          },
+          502,
+        ),
+      );
+      const error = await fetchEvalSuiteStageAnalytics({
+        projectId: "p1",
+        suiteId: SUITE_ID,
+      }).catch((caught: unknown) => caught);
+
+      expect((error as EvalStageAnalyticsError).kind).toBe("requestFailed");
+    });
+
+    it("maps a malformed document to invalidContract", async () => {
+      const broken = structuredClone(GOLDEN_STAGE_ANALYTICS) as any;
+      broken.slices[0].stages[0].passed = 99;
+      authFetchMock.mockResolvedValue(jsonResponse({ items: [broken] }));
+
+      const error = await fetchEvalSuiteStageAnalytics({
+        projectId: "p1",
+        suiteId: SUITE_ID,
+      }).catch((caught: unknown) => caught);
+
+      expect((error as EvalStageAnalyticsError).kind).toBe("invalidContract");
+    });
+
+    it("maps a non-envelope response to invalidContract", async () => {
+      authFetchMock.mockResolvedValue(jsonResponse({ rows: [] }));
+      const error = await fetchEvalSuiteStageAnalytics({
+        projectId: "p1",
+        suiteId: SUITE_ID,
+      }).catch((caught: unknown) => caught);
+
+      expect((error as EvalStageAnalyticsError).kind).toBe("invalidContract");
+    });
+  });
+
+  it("refuses a document for a different suite", async () => {
+    // Shape is not identity: a perfectly valid document for ANOTHER suite would
+    // otherwise render under this suite's heading as its funnel.
+    authFetchMock.mockResolvedValue(
+      jsonResponse({
+        items: [stageAnalyticsVariation({ suiteId: "some-other-suite" })],
+      }),
+    );
+
+    const error = await fetchEvalSuiteStageAnalytics({
+      projectId: "p1",
+      suiteId: SUITE_ID,
+    }).catch((caught: unknown) => caught);
+
+    expect((error as EvalStageAnalyticsError).kind).toBe("invalidContract");
+    expect((error as EvalStageAnalyticsError).message).toContain(
+      "different suite",
+    );
+  });
+});

--- a/mcpjam-inspector/client/src/lib/apis/eval-stage-analytics-api.ts
+++ b/mcpjam-inspector/client/src/lib/apis/eval-stage-analytics-api.ts
@@ -1,0 +1,230 @@
+/**
+ * The browser read for a suite's materialized stage analytics (D5c).
+ *
+ * Same shape and the same reasons as `eval-run-decision-summary-api.ts`:
+ * `PlatformApiClient` already speaks this endpoint with typed parameters and
+ * URL encoding, so this wraps it rather than hand-rolling a second `fetch`, and
+ * the transport strips the client's own `Authorization` header so `authFetch`
+ * stays the ONE owner of the bearer (and keeps its 401 refresh-and-retry).
+ *
+ * ── What this module refuses to do ───────────────────────────────────────────
+ *
+ * It does not compute analytics. There is no client-side fallback that walks
+ * iterations, scans traces, or reconstructs a denominator from a trial array:
+ * a second derivation in the browser is a second reading of the run, and it
+ * would produce numbers that disagree with the API's for reasons no one could
+ * explain. If the backend cannot answer, this says so and the panel renders a
+ * SERVICE state — never an empty chart, which reads as "measured, and it was
+ * all zero".
+ *
+ * It also does not merge pages into one funnel. Each item is one run's complete
+ * document and the SDK has no cross-run merge on purpose; summing them here
+ * would be inventing a number the contract deliberately refuses to store.
+ *
+ * ── The four ways this can fail, kept apart ──────────────────────────────────
+ *
+ * `notFound`, `routeUnavailable`, `invalidContract` and `requestFailed` are
+ * four different facts, and collapsing them into "couldn't load" loses the only
+ * one a reader can act on. `invalidContract` in particular — the route answered
+ * and the answer did not validate — is a bug report, not a network blip.
+ */
+import { PlatformApiClient, isPlatformApiError } from "@mcpjam/sdk/platform";
+import {
+  evalStageAnalyticsSchema,
+  type EvalStageAnalyticsV1,
+} from "@mcpjam/sdk/contract";
+import { authFetch } from "@/lib/session-token";
+
+/** Why a stage-analytics read did not produce documents. */
+export type StageAnalyticsFailureKind =
+  /** The route answered 404: this project has no such suite (or cannot see it). */
+  | "notFound"
+  /** The deployment does not serve the stage-analytics contract at all. */
+  | "routeUnavailable"
+  /** The route answered and the payload did not validate against the contract. */
+  | "invalidContract"
+  /** Network, timeout, auth, 5xx — the read did not complete. */
+  | "requestFailed";
+
+export class EvalStageAnalyticsError extends Error {
+  readonly kind: StageAnalyticsFailureKind;
+  readonly status?: number;
+
+  constructor(
+    kind: StageAnalyticsFailureKind,
+    message: string,
+    options?: { status?: number; cause?: unknown },
+  ) {
+    super(
+      message,
+      options?.cause !== undefined ? { cause: options.cause } : {},
+    );
+    this.name = "EvalStageAnalyticsError";
+    this.kind = kind;
+    this.status = options?.status;
+  }
+}
+
+export function isEvalStageAnalyticsError(
+  error: unknown,
+): error is EvalStageAnalyticsError {
+  return error instanceof EvalStageAnalyticsError;
+}
+
+/** One page of per-run documents, newest run completion first. */
+export interface EvalStageAnalyticsPage {
+  rows: EvalStageAnalyticsV1[];
+  /** Absent means this was the last page — completeness is this field's absence. */
+  nextCursor?: string;
+}
+
+const stageAnalyticsFetch: typeof fetch = (input, init) => {
+  const headers = new Headers(init?.headers);
+  headers.delete("authorization");
+  return authFetch(input as Parameters<typeof authFetch>[0], {
+    ...init,
+    headers,
+  });
+};
+
+function client(): PlatformApiClient {
+  return new PlatformApiClient({
+    baseUrl: "/api/v1",
+    // Empty on purpose — `stageAnalyticsFetch` strips it and `authFetch`
+    // supplies the real one, so the bearer has exactly one owner.
+    getAuth: () => "",
+    fetch: stageAnalyticsFetch,
+  });
+}
+
+/**
+ * A deployment that predates the stage-analytics route, as opposed to a suite
+ * that is not there.
+ *
+ * `FEATURE_NOT_SUPPORTED` and `501` are the two ways an API says "this build
+ * does not serve that"; `405` is the same answer from a router that knows the
+ * path shape but not this method. Everything else at 404 is the route's own
+ * "Eval suite not found", which is a fact about the suite.
+ */
+function isRouteUnavailable(status: number, code: string): boolean {
+  return (
+    code === "FEATURE_NOT_SUPPORTED" ||
+    code === "NOT_IMPLEMENTED" ||
+    status === 501 ||
+    status === 405
+  );
+}
+
+export async function fetchEvalSuiteStageAnalytics(
+  params: {
+    projectId: string;
+    suiteId: string;
+    /** Inclusive epoch ms over `runCompletedAt`. */
+    from?: number;
+    to?: number;
+    runGroupId?: string;
+    cursor?: string;
+    limit?: number;
+  },
+  signal?: AbortSignal,
+): Promise<EvalStageAnalyticsPage> {
+  let raw: unknown;
+  try {
+    raw = await client().listEvalSuiteStageAnalytics(
+      {
+        projectId: params.projectId,
+        suiteId: params.suiteId,
+        ...(params.from !== undefined ? { from: params.from } : {}),
+        ...(params.to !== undefined ? { to: params.to } : {}),
+        ...(params.runGroupId ? { runGroupId: params.runGroupId } : {}),
+        ...(params.cursor ? { cursor: params.cursor } : {}),
+        ...(params.limit !== undefined ? { limit: params.limit } : {}),
+      },
+      { signal },
+    );
+  } catch (error) {
+    // A caller's abort is the caller's, not a failure of the read. Rethrow it
+    // untouched so the controller can tell "we cancelled this" from "the API
+    // said no".
+    if (signal?.aborted) throw error;
+    if (isPlatformApiError(error)) {
+      if (isRouteUnavailable(error.status, error.code)) {
+        throw new EvalStageAnalyticsError(
+          "routeUnavailable",
+          "This deployment does not serve eval stage analytics.",
+          { status: error.status, cause: error },
+        );
+      }
+      if (error.status === 404) {
+        throw new EvalStageAnalyticsError("notFound", error.message, {
+          status: error.status,
+          cause: error,
+        });
+      }
+      throw new EvalStageAnalyticsError("requestFailed", error.message, {
+        status: error.status,
+        cause: error,
+      });
+    }
+    throw new EvalStageAnalyticsError(
+      "requestFailed",
+      error instanceof Error ? error.message : String(error),
+      { cause: error },
+    );
+  }
+
+  const envelope = raw as { items?: unknown; nextCursor?: unknown } | null;
+  if (
+    !envelope ||
+    typeof envelope !== "object" ||
+    !Array.isArray(envelope.items)
+  ) {
+    throw new EvalStageAnalyticsError(
+      "invalidContract",
+      "The stage analytics response was not a page envelope.",
+    );
+  }
+  if (
+    envelope.nextCursor !== undefined &&
+    typeof envelope.nextCursor !== "string"
+  ) {
+    throw new EvalStageAnalyticsError(
+      "invalidContract",
+      "The stage analytics page cursor was not a string.",
+    );
+  }
+
+  const rows: EvalStageAnalyticsV1[] = [];
+  for (const item of envelope.items) {
+    // Parsed HERE rather than trusted from the wire, with the REFINED schema —
+    // the structural one would admit a document with two `overall` slices or an
+    // overall slice that disagrees with the row's own trial count, and those
+    // are exactly the invariants every number below rests on.
+    const parsed = evalStageAnalyticsSchema.safeParse(item);
+    if (!parsed.success) {
+      throw new EvalStageAnalyticsError(
+        "invalidContract",
+        "A stage analytics document did not match the published contract.",
+        { cause: parsed.error },
+      );
+    }
+    // Shape is not identity. `suiteId` is only `string().min(1)` to the schema,
+    // so a valid document for a DIFFERENT suite parses perfectly — and would
+    // then render under this suite's heading as its funnel. Nothing upstream
+    // binds the answer to the question; this does.
+    if (parsed.data.suiteId !== params.suiteId) {
+      throw new EvalStageAnalyticsError(
+        "invalidContract",
+        "A stage analytics document is for a different suite than the one requested.",
+      );
+    }
+    rows.push(parsed.data as EvalStageAnalyticsV1);
+  }
+
+  return {
+    rows,
+    ...(typeof envelope.nextCursor === "string"
+      ? { nextCursor: envelope.nextCursor }
+      : {}),
+  };
+}

--- a/mcpjam-inspector/client/src/test/stage-analytics-fixtures.ts
+++ b/mcpjam-inspector/client/src/test/stage-analytics-fixtures.ts
@@ -1,0 +1,59 @@
+/**
+ * The SDK's golden stage-analytics document, read directly.
+ *
+ * NOT COPIED, for the same reason `eval-decision-summary-fixtures.ts` is not:
+ * `sdk/tests/fixtures/stage-analytics-golden.json` is the shared corpus, and a
+ * UI that asserts against its own copy silently stops being part of that claim
+ * the first time the contract changes. A change to what a stage funnel MEANS
+ * has to show up here as a failing render.
+ *
+ * The variations below are built FROM the golden document and each is
+ * re-validated with the refined schema, so a fixture can never drift into
+ * asserting a shape the contract would reject.
+ */
+import { evalStageAnalyticsSchema } from "@mcpjam/sdk/contract";
+import type { EvalStageAnalyticsV1 } from "@mcpjam/sdk/contract";
+import { existsSync, readFileSync } from "node:fs";
+import { dirname, resolve } from "node:path";
+
+const CORPUS_RELATIVE_PATH = "sdk/tests/fixtures/stage-analytics-golden.json";
+
+/** Walk up to the workspace root — see the decision-summary reader for why. */
+function locateCorpus(): string {
+  let directory = process.cwd();
+  for (let depth = 0; depth < 8; depth += 1) {
+    const candidate = resolve(directory, CORPUS_RELATIVE_PATH);
+    if (existsSync(candidate)) return candidate;
+    const parent = dirname(directory);
+    if (parent === directory) break;
+    directory = parent;
+  }
+  throw new Error(
+    `Could not find ${CORPUS_RELATIVE_PATH} above ${process.cwd()}. The UI ` +
+      `asserts against the SDK's corpus directly and must not fall back to a copy.`,
+  );
+}
+
+/** The golden document, validated on load with the REFINED schema. */
+export const GOLDEN_STAGE_ANALYTICS: EvalStageAnalyticsV1 =
+  evalStageAnalyticsSchema.parse(
+    JSON.parse(readFileSync(locateCorpus(), "utf8")),
+  ) as EvalStageAnalyticsV1;
+
+/**
+ * A variation of the golden document, re-validated.
+ *
+ * The validation is the point: the golden document carries no truncation, no
+ * mixed versions and no `discovery` setup row, so those states must be BUILT —
+ * and a hand-built document that no longer satisfies the contract would make
+ * every assertion drawn from it meaningless.
+ */
+export function stageAnalyticsVariation(
+  overrides: Partial<EvalStageAnalyticsV1>,
+): EvalStageAnalyticsV1 {
+  const draft = {
+    ...structuredClone(GOLDEN_STAGE_ANALYTICS),
+    ...overrides,
+  };
+  return evalStageAnalyticsSchema.parse(draft) as EvalStageAnalyticsV1;
+}

--- a/mcpjam-inspector/server/routes/v1/__tests__/eval-stage-analytics-route.test.ts
+++ b/mcpjam-inspector/server/routes/v1/__tests__/eval-stage-analytics-route.test.ts
@@ -247,6 +247,27 @@ describe("GET …/eval-suites/:suiteId/stage-analytics", () => {
       );
     });
 
+    it("treats blank query values as absent, not as a bound of zero", async () => {
+      // `?from=` must not become `from: 0`. Any `from` bound excludes runs that
+      // never recorded a completion stamp, so a coerced blank would silently
+      // narrow the reported population while the request looked unfiltered.
+      stub({});
+      const res = await request(`${PATH}?from=&to=&runGroupId=&cursor=&limit=`);
+      expect(res.status).toBe(200);
+      expect(analyticsArgs()).toEqual({
+        projectId: PROJECT_ID,
+        suiteId: SUITE_ID,
+        paginationOpts: { numItems: 25, cursor: null },
+      });
+    });
+
+    it("keeps a genuine zero lower bound", async () => {
+      // The blank is dropped; an explicit `0` is a real bound and is forwarded.
+      stub({});
+      await request(`${PATH}?from=0`);
+      expect(analyticsArgs()).toMatchObject({ from: 0 });
+    });
+
     it("maps the backend's own INVALID_ARGUMENT throw to a 400", async () => {
       // Unreachable while the edge schema holds. Mapped anyway so the contract
       // cannot drift into answering a caller error with a 500.

--- a/mcpjam-inspector/server/routes/v1/__tests__/eval-stage-analytics-route.test.ts
+++ b/mcpjam-inspector/server/routes/v1/__tests__/eval-stage-analytics-route.test.ts
@@ -1,0 +1,327 @@
+/**
+ * `GET …/eval-suites/:suiteId/stage-analytics` — the read boundary, end to end.
+ *
+ * The claim under test is not "the route returns a body". It is that this route
+ * is the only place a stage-analytics document crosses into the public API, and
+ * that it refuses to launder anything on the way: a suite from another project
+ * reads as NOT_FOUND, a payload that fails the CONTRACT is a service error
+ * rather than a 200 with the bad row quietly dropped, and an inverted window is
+ * a caller error rather than a silently empty page.
+ *
+ * So the Convex mock is stubbed BY FUNCTION NAME rather than by call order —
+ * the route makes two reads and their order is an implementation detail — and
+ * the populated fixtures are the SDK's shared golden document rather than a
+ * local hand-copy, so a contract change breaks this test instead of drifting
+ * past it.
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { dirname, resolve } from "node:path";
+import { Hono } from "hono";
+import { evalStageAnalyticsSchema } from "@mcpjam/sdk/contract";
+import type { EvalStageAnalyticsV1 } from "@mcpjam/sdk/contract";
+
+const { validateGuestTokenMock, convexQueryMock } = vi.hoisted(() => ({
+  validateGuestTokenMock: vi.fn(),
+  convexQueryMock: vi.fn(),
+}));
+
+vi.mock("../../../services/guest-token.js", () => ({
+  validateGuestTokenDetailedAsync: validateGuestTokenMock,
+}));
+
+vi.mock("convex/browser", () => ({
+  ConvexHttpClient: vi.fn().mockImplementation(() => ({
+    setAuth: vi.fn(),
+    query: convexQueryMock,
+    mutation: vi.fn(),
+    action: vi.fn(),
+  })),
+}));
+
+import v1Routes from "../index.js";
+
+const here = dirname(fileURLToPath(import.meta.url));
+
+/**
+ * The SHARED golden document, validated on load.
+ *
+ * Validated here rather than trusted because this file builds variations of it:
+ * if the corpus itself ever stopped satisfying the refined schema, every
+ * assertion below would be measuring a fixture bug rather than the route.
+ */
+const GOLDEN: EvalStageAnalyticsV1 = evalStageAnalyticsSchema.parse(
+  JSON.parse(
+    readFileSync(
+      resolve(
+        here,
+        "../../../../../sdk/tests/fixtures/stage-analytics-golden.json",
+      ),
+      "utf8",
+    ),
+  ),
+) as EvalStageAnalyticsV1;
+
+const PROJECT_ID = "proj_1";
+const SUITE_ID = "suite_1";
+const BEARER = "caller-bearer-token";
+
+/** The golden document re-homed onto this test's project/suite ids. */
+function row(
+  overrides: Partial<EvalStageAnalyticsV1> = {},
+): EvalStageAnalyticsV1 {
+  return {
+    ...GOLDEN,
+    suiteId: SUITE_ID,
+    projectId: PROJECT_ID,
+    ...overrides,
+  } as EvalStageAnalyticsV1;
+}
+
+function makeApp(): Hono {
+  const app = new Hono();
+  app.route("/api/v1", v1Routes);
+  return app;
+}
+
+function request(path: string): Promise<Response> {
+  return makeApp().request(`/api/v1${path}`, {
+    method: "GET",
+    headers: { Authorization: `Bearer ${BEARER}` },
+  });
+}
+
+/** Stub BY NAME: the route's two reads are not order-guaranteed. */
+function stub(options: {
+  suite?: unknown;
+  suiteError?: unknown;
+  page?: { page: unknown[]; isDone: boolean; continueCursor: string };
+  pageError?: unknown;
+}): void {
+  const suite =
+    options.suite === undefined ? { projectId: PROJECT_ID } : options.suite;
+  convexQueryMock.mockImplementation((name: string) => {
+    if (name === "testSuites:getTestSuite") {
+      if (options.suiteError) return Promise.reject(options.suiteError);
+      return Promise.resolve(suite);
+    }
+    if (name === "testSuites:listEvalStageAnalytics") {
+      if (options.pageError) return Promise.reject(options.pageError);
+      return Promise.resolve(
+        options.page ?? { page: [], isDone: true, continueCursor: "" },
+      );
+    }
+    return Promise.resolve(null);
+  });
+}
+
+/** The args the route passed to the analytics query. */
+function analyticsArgs(): Record<string, unknown> {
+  const call = convexQueryMock.mock.calls.find(
+    ([name]) => name === "testSuites:listEvalStageAnalytics",
+  );
+  return (call?.[1] ?? {}) as Record<string, unknown>;
+}
+
+const PATH = `/projects/${PROJECT_ID}/eval-suites/${SUITE_ID}/stage-analytics`;
+
+beforeEach(() => {
+  vi.stubEnv("CONVEX_URL", "https://example.convex.cloud");
+  validateGuestTokenMock.mockResolvedValue({ valid: false });
+});
+
+afterEach(() => {
+  vi.unstubAllEnvs();
+  vi.clearAllMocks();
+});
+
+describe("GET …/eval-suites/:suiteId/stage-analytics", () => {
+  it("returns the documents and pages with the v1 envelope", async () => {
+    stub({
+      page: { page: [row()], isDone: false, continueCursor: "cursor_2" },
+    });
+    const res = await request(PATH);
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as {
+      items: EvalStageAnalyticsV1[];
+      nextCursor?: string;
+    };
+    expect(body.items).toHaveLength(1);
+    expect(body.items[0]).toEqual(row());
+    expect(body.nextCursor).toBe("cursor_2");
+    // The Convex-internal `isDone`/`continueCursor`/`page` names never reach
+    // the wire — completeness is `nextCursor`'s ABSENCE.
+    expect(Object.keys(body).sort()).toEqual(["items", "nextCursor"]);
+  });
+
+  it("defaults to 25 items and a null first cursor", async () => {
+    stub({});
+    await request(PATH);
+    expect(analyticsArgs()).toEqual({
+      projectId: PROJECT_ID,
+      suiteId: SUITE_ID,
+      // `null`, not `undefined`: Convex pagination requires an explicit first
+      // cursor, and an `undefined` would be dropped from the args entirely.
+      paginationOpts: { numItems: 25, cursor: null },
+    });
+  });
+
+  it("forwards every optional filter, and omits the ones not supplied", async () => {
+    stub({});
+    await request(
+      `${PATH}?from=1700000000000&to=1700000100000&runGroupId=grp_1&cursor=c1&limit=10`,
+    );
+    expect(analyticsArgs()).toEqual({
+      projectId: PROJECT_ID,
+      suiteId: SUITE_ID,
+      // Numbers, not the raw query strings: `from`/`to` are epoch ms and the
+      // backend indexes on them numerically.
+      from: 1700000000000,
+      to: 1700000100000,
+      runGroupId: "grp_1",
+      paginationOpts: { numItems: 10, cursor: "c1" },
+    });
+  });
+
+  it("omits nextCursor entirely on the last page", async () => {
+    stub({ page: { page: [row()], isDone: true, continueCursor: "" } });
+    const res = await request(PATH);
+    const body = (await res.json()) as Record<string, unknown>;
+    expect(res.status).toBe(200);
+    expect("nextCursor" in body).toBe(false);
+  });
+
+  it("answers an empty page as a valid 200, not an error", async () => {
+    // The backend's tenant-safe deny path returns a well-formed EMPTY page
+    // rather than throwing. That serializes here as a plain empty 200: a real
+    // "no documents" answer, which the UI must be free to tell apart from a
+    // service failure.
+    stub({ page: { page: [], isDone: true, continueCursor: "" } });
+    const res = await request(PATH);
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({ items: [] });
+  });
+
+  it("refuses a suite belonging to another project as NOT_FOUND", async () => {
+    stub({ suite: { projectId: "some-other-project" } });
+    const res = await request(PATH);
+    expect(res.status).toBe(404);
+    // The analytics query is never reached: the project cross-check is what
+    // stops a valid suite id from another project reading across the scope the
+    // path declares.
+    expect(analyticsArgs()).toEqual({});
+  });
+
+  it("maps a Convex visibility failure to NOT_FOUND", async () => {
+    stub({ suiteError: new Error("Not a member of this organization") });
+    const res = await request(PATH);
+    expect(res.status).toBe(404);
+  });
+
+  describe("window validation", () => {
+    it("rejects an inverted window at the edge", async () => {
+      stub({});
+      const res = await request(`${PATH}?from=200&to=100`);
+      expect(res.status).toBe(400);
+      expect(((await res.json()) as { code?: string }).code).toBe(
+        "VALIDATION_ERROR",
+      );
+      expect(analyticsArgs()).toEqual({});
+    });
+
+    it.each([
+      ["non-numeric from", "?from=abc"],
+      ["negative from", "?from=-1"],
+      ["fractional to", "?to=1.5"],
+      ["limit above the maximum", "?limit=101"],
+      ["limit below the minimum", "?limit=0"],
+      ["non-numeric limit", "?limit=many"],
+    ])("rejects %s with a 400", async (_label, query) => {
+      stub({});
+      const res = await request(`${PATH}${query}`);
+      expect(res.status).toBe(400);
+      expect(((await res.json()) as { code?: string }).code).toBe(
+        "VALIDATION_ERROR",
+      );
+    });
+
+    it("maps the backend's own INVALID_ARGUMENT throw to a 400", async () => {
+      // Unreachable while the edge schema holds. Mapped anyway so the contract
+      // cannot drift into answering a caller error with a 500.
+      const convexError = Object.assign(new Error("inverted window"), {
+        data: {
+          code: "INVALID_ARGUMENT",
+          message:
+            "from must be less than or equal to to (inclusive epoch ms over runCompletedAt).",
+        },
+      });
+      stub({ pageError: convexError });
+      const res = await request(PATH);
+      expect(res.status).toBe(400);
+      expect(((await res.json()) as { code?: string }).code).toBe(
+        "VALIDATION_ERROR",
+      );
+    });
+  });
+
+  describe("contract enforcement at the boundary", () => {
+    it("answers a schema-invalid row with a 502, not a 200", async () => {
+      // `measured` that is not `passed + failed` — an arithmetic break the
+      // STRUCTURAL schema would let through and the refined one catches.
+      const broken = JSON.parse(JSON.stringify(row())) as any;
+      broken.slices[0].stages[0].passed = 99;
+      stub({ page: { page: [broken], isDone: true, continueCursor: "" } });
+      const res = await request(PATH);
+      expect(res.status).toBe(502);
+      const body = (await res.json()) as { code?: string };
+      expect(body.code).toBe("SERVER_UNREACHABLE");
+      // The response names the failure without echoing the payload: these
+      // documents carry intent labels and host names.
+      expect(JSON.stringify(body)).not.toContain("host_a");
+    });
+
+    it("rejects a row that breaks a REFINED invariant the structure allows", async () => {
+      // Two `overall` slices: structurally a valid array of slice rows, and a
+      // document no reader can trust — "the overall funnel" would be ambiguous.
+      const broken = JSON.parse(JSON.stringify(row())) as any;
+      broken.slices.push(JSON.parse(JSON.stringify(broken.slices[0])));
+      stub({ page: { page: [broken], isDone: true, continueCursor: "" } });
+      const res = await request(PATH);
+      expect(res.status).toBe(502);
+    });
+
+    it("fails the whole page rather than dropping the bad row from it", async () => {
+      // A silently shortened page is a denominator that changed without saying
+      // so — the one failure mode this contract exists to prevent.
+      const broken = JSON.parse(JSON.stringify(row())) as any;
+      broken.includedTrials = broken.totalTrials + 1;
+      stub({
+        page: { page: [row(), broken], isDone: true, continueCursor: "" },
+      });
+      const res = await request(PATH);
+      expect(res.status).toBe(502);
+    });
+  });
+
+  it("propagates a non-visibility Convex failure as a non-200", async () => {
+    stub({ pageError: new Error("ECONNRESET") });
+    const res = await request(PATH);
+    expect(res.status).toBeGreaterThanOrEqual(500);
+  });
+
+  it("is NOT guest-allowed", async () => {
+    // Omission from the guest allowlist is what denies guests, and an omission
+    // is invisible in a diff. Pinned so re-adding it has to be deliberate.
+    const { isGuestAllowedV1Request } = await import(
+      "../guest-allowed-paths.js"
+    );
+    expect(
+      isGuestAllowedV1Request(
+        "GET",
+        `/api/v1/projects/${PROJECT_ID}/eval-suites/${SUITE_ID}/stage-analytics`,
+      ),
+    ).toBe(false);
+  });
+});

--- a/mcpjam-inspector/server/routes/v1/__tests__/sdk-coverage.test.ts
+++ b/mcpjam-inspector/server/routes/v1/__tests__/sdk-coverage.test.ts
@@ -186,6 +186,8 @@ const ROUTE_TO_SDK: Readonly<Record<string, string>> = {
   "patch /projects/{projectId}/eval-suites/{suiteId}/schedule":
     "setEvalSuiteSchedule",
   "get /projects/{projectId}/eval-suites/{suiteId}/runs": "listEvalSuiteRuns",
+  "get /projects/{projectId}/eval-suites/{suiteId}/stage-analytics":
+    "listEvalSuiteStageAnalytics",
   "get /projects/{projectId}/eval-suites/{suiteId}/cases": "listEvalCases",
   "post /projects/{projectId}/eval-suites/{suiteId}/cases": "createEvalCase",
   "post /projects/{projectId}/eval-suites/{suiteId}/cases/batch":

--- a/mcpjam-inspector/server/routes/v1/evals.ts
+++ b/mcpjam-inspector/server/routes/v1/evals.ts
@@ -4718,17 +4718,30 @@ evals.get(
   async (c) => {
     const projectId = c.req.param("projectId");
     const suiteId = c.req.param("suiteId");
+    // An EMPTY query value means "not supplied", not "supplied as empty".
+    // Without this, `?from=` coerces to `0` — a real lower bound, which
+    // excludes every run that never recorded a completion stamp — so a request
+    // that looks unfiltered would quietly narrow the population it reports on.
+    // That is the one failure this whole contract is built against, so the
+    // blank is dropped here rather than being given a meaning.
+    const optionalQuery = (name: string): string | undefined => {
+      const raw = c.req.query(name);
+      if (raw === undefined) return undefined;
+      return raw.trim() === "" ? undefined : raw;
+    };
     const query = parseWithSchema(stageAnalyticsQuerySchema, {
-      ...(c.req.query("from") !== undefined ? { from: c.req.query("from") } : {}),
-      ...(c.req.query("to") !== undefined ? { to: c.req.query("to") } : {}),
-      ...(c.req.query("runGroupId") !== undefined
-        ? { runGroupId: c.req.query("runGroupId") }
+      ...(optionalQuery("from") !== undefined
+        ? { from: optionalQuery("from") }
         : {}),
-      ...(c.req.query("cursor") !== undefined
-        ? { cursor: c.req.query("cursor") }
+      ...(optionalQuery("to") !== undefined ? { to: optionalQuery("to") } : {}),
+      ...(optionalQuery("runGroupId") !== undefined
+        ? { runGroupId: optionalQuery("runGroupId") }
         : {}),
-      ...(c.req.query("limit") !== undefined
-        ? { limit: c.req.query("limit") }
+      ...(optionalQuery("cursor") !== undefined
+        ? { cursor: optionalQuery("cursor") }
+        : {}),
+      ...(optionalQuery("limit") !== undefined
+        ? { limit: optionalQuery("limit") }
         : {}),
     });
     const limit = query.limit ?? 25;

--- a/mcpjam-inspector/server/routes/v1/evals.ts
+++ b/mcpjam-inspector/server/routes/v1/evals.ts
@@ -51,10 +51,12 @@ import {
 import {
   caseIntentSchema,
   caseIntentUpdateSchema,
+  evalStageAnalyticsSchema,
   evalSuiteFileCaseImportSchema,
   IMPORT_MAPPING_STATUSES,
   opaqueIdSchema,
 } from "@mcpjam/sdk/contract";
+import type { EvalStageAnalyticsV1 } from "@mcpjam/sdk/contract";
 import { checkEvalHarnessStaticAdmission } from "../../services/evals/harness-admission.js";
 import { loadSuiteHostConfig } from "../../services/evals/compat-runtime.js";
 import {
@@ -4659,6 +4661,173 @@ evals.get("/projects/:projectId/eval-suites/:suiteId/runs", async (c) => {
   }
   return v1PageJson(c, (runs ?? []).map(toRunDto));
 });
+
+// GET /v1/projects/:projectId/eval-suites/:suiteId/stage-analytics
+//     ?from=&to=&runGroupId=&cursor=&limit=
+//
+// One materialized `EvalStageAnalyticsV1` document per RUN, newest completion
+// first — where trials fell out of the user-value chain, and whether that
+// differs by intent, by model, or by host.
+//
+// Each item is one run's COMPLETE document, and that is the whole read model:
+// there is no cross-run merge here and none in the SDK, because averaging two
+// funnels is not a funnel. A caller compares by rendering runs side by side
+// under the contract's own parity rules, never by summing these rows.
+//
+// `from`/`to` are INCLUSIVE epoch milliseconds over the run's completion
+// stamp, matching the Convex boundary exactly rather than inventing an ISO
+// dialect this API has no other precedent for. Runs that never completed carry
+// no stamp, sort last, and are excluded by any `from` bound.
+//
+// NOT backfilled: a run that terminalized before the materializer shipped has
+// no row at all, and that absence is the honest "unmeasured" answer. It is
+// never reported as a funnel of zeros.
+const stageAnalyticsQuerySchema = z
+  .object({
+    // Coerced because query strings are strings; `.int()` after coercion is
+    // what rejects `1.5` and `abc` (which coerce to NaN) rather than letting
+    // Convex see a non-integer millisecond.
+    from: z.coerce.number().int().min(0).optional(),
+    to: z.coerce.number().int().min(0).optional(),
+    runGroupId: z.string().trim().min(1).optional(),
+    cursor: z.string().min(1).optional(),
+    limit: z.coerce.number().int().min(1).max(100).optional(),
+  })
+  .superRefine((query, ctx) => {
+    // Rejected HERE as well as in Convex. The backend throws on an inverted
+    // window rather than fail-softing to an empty page — an empty page would
+    // read as "this suite has no analytics" and send the reader looking in the
+    // wrong place — and a 400 at the edge names the bad parameter instead of
+    // surfacing a backend error string.
+    if (
+      query.from !== undefined &&
+      query.to !== undefined &&
+      query.from > query.to
+    ) {
+      ctx.addIssue({
+        code: "custom",
+        path: ["from"],
+        message:
+          "from must be less than or equal to to (inclusive epoch ms over runCompletedAt)",
+      });
+    }
+  });
+
+evals.get(
+  "/projects/:projectId/eval-suites/:suiteId/stage-analytics",
+  async (c) => {
+    const projectId = c.req.param("projectId");
+    const suiteId = c.req.param("suiteId");
+    const query = parseWithSchema(stageAnalyticsQuerySchema, {
+      ...(c.req.query("from") !== undefined ? { from: c.req.query("from") } : {}),
+      ...(c.req.query("to") !== undefined ? { to: c.req.query("to") } : {}),
+      ...(c.req.query("runGroupId") !== undefined
+        ? { runGroupId: c.req.query("runGroupId") }
+        : {}),
+      ...(c.req.query("cursor") !== undefined
+        ? { cursor: c.req.query("cursor") }
+        : {}),
+      ...(c.req.query("limit") !== undefined
+        ? { limit: c.req.query("limit") }
+        : {}),
+    });
+    const limit = query.limit ?? 25;
+    // `null`, never `undefined`: Convex pagination requires an explicit null
+    // first cursor, and `undefined` would be dropped from the args object.
+    const cursor = query.cursor ?? null;
+    const convex = createConvexReadClient(await getConvexBearerForRequest(c));
+
+    let page: {
+      page: unknown[];
+      isDone: boolean;
+      continueCursor: string;
+    };
+    try {
+      // The suite is read and project-matched FIRST so a valid suite id from
+      // another of the caller's projects reads as NOT_FOUND here, rather than
+      // relying on the backend's tenant-safe empty page — which is defense in
+      // depth, not the answer: an empty page is indistinguishable from "this
+      // suite has no analytics yet".
+      const suite = await convex.query("testSuites:getTestSuite" as any, {
+        suiteId,
+      });
+      requireProjectMatch(suite, projectId, "Eval suite");
+      page = await convex.query("testSuites:listEvalStageAnalytics" as any, {
+        projectId,
+        suiteId,
+        // Omitted rather than sent as `undefined`: the Convex validators are
+        // `v.optional`, and an explicit `undefined` is not the same as absent.
+        ...(query.from !== undefined ? { from: query.from } : {}),
+        ...(query.to !== undefined ? { to: query.to } : {}),
+        ...(query.runGroupId !== undefined
+          ? { runGroupId: query.runGroupId }
+          : {}),
+        paginationOpts: { numItems: limit, cursor },
+      });
+    } catch (error) {
+      if (isConvexNotVisibleError(error)) {
+        throw new WebRouteError(
+          404,
+          ErrorCode.NOT_FOUND,
+          "Eval suite not found",
+        );
+      }
+      // The backend's own inverted-window guard. Unreachable while the schema
+      // above holds, and mapped anyway so the contract cannot drift into
+      // answering a caller error with a 500.
+      const data = (error as { data?: unknown } | null)?.data;
+      if (
+        data &&
+        typeof data === "object" &&
+        !Array.isArray(data) &&
+        (data as { code?: unknown }).code === "INVALID_ARGUMENT"
+      ) {
+        const message = (data as { message?: unknown }).message;
+        throw new WebRouteError(
+          400,
+          ErrorCode.VALIDATION_ERROR,
+          typeof message === "string"
+            ? message
+            : "Invalid stage analytics window",
+        );
+      }
+      throw error;
+    }
+
+    // Validated at the boundary with the REFINED schema — the structural one
+    // would miss exactly the invariants a reader relies on (one overall slice,
+    // the overall slice agreeing with the row's own trial count). A payload
+    // that fails is an upstream fault: it is answered as a service error, never
+    // as a 200 with the bad row quietly dropped, because a silently shortened
+    // page is a denominator that changed without saying so.
+    const rows: EvalStageAnalyticsV1[] = [];
+    for (const row of page.page ?? []) {
+      const parsed = evalStageAnalyticsSchema.safeParse(row);
+      if (!parsed.success) {
+        logger.warn("[v1 evals] stage analytics row failed contract validation", {
+          projectId,
+          suiteId,
+          // The ISSUE, never the row: the payload can carry intent labels and
+          // host names, and a validation log is not the place for them.
+          issue: parsed.error.issues[0]?.message ?? "unknown",
+          path: parsed.error.issues[0]?.path?.join(".") ?? "",
+        });
+        throw new WebRouteError(
+          502,
+          ErrorCode.SERVER_UNREACHABLE,
+          "Stage analytics payload failed validation",
+        );
+      }
+      rows.push(parsed.data as EvalStageAnalyticsV1);
+    }
+
+    return v1PageJson(
+      c,
+      rows,
+      page.isDone ? undefined : page.continueCursor,
+    );
+  },
+);
 
 // ── Eval suite/case editing routes ───────────────────────────────────
 

--- a/sdk/src/platform/client.ts
+++ b/sdk/src/platform/client.ts
@@ -1842,12 +1842,12 @@ export class PlatformApiClient {
       cursor?: string;
       limit?: number;
     },
-    options?: RequestOptions,
+    options?: RequestOptions
   ): Promise<PlatformPage<PlatformEvalStageAnalytics>> {
     return this.request(
       "GET",
       `/projects/${encodeURIComponent(
-        params.projectId,
+        params.projectId
       )}/eval-suites/${encodeURIComponent(params.suiteId)}/stage-analytics`,
       {
         query: {
@@ -1858,7 +1858,7 @@ export class PlatformApiClient {
           limit: params.limit,
         },
       },
-      options,
+      options
     );
   }
 

--- a/sdk/src/platform/client.ts
+++ b/sdk/src/platform/client.ts
@@ -12,6 +12,7 @@ import type {
   PlatformEvalIteration,
   PlatformEvalRun,
   PlatformEvalRunDecisionSummary,
+  PlatformEvalStageAnalytics,
   PlatformGateWaiverRead,
   PlatformGateWaiverWriteResult,
   PlatformEvalRunInsightsRequested,
@@ -1806,6 +1807,57 @@ export class PlatformApiClient {
         params.projectId,
       )}/eval-runs/${encodeURIComponent(params.runId)}/decision-summary`,
       { query: { cursor: params.cursor, limit: params.limit } },
+      options,
+    );
+  }
+
+  /**
+   * One page of a suite's materialized stage analytics, newest run-completion
+   * first — one complete `EvalStageAnalyticsV1` document per RUN.
+   *
+   * Each item stands alone: the overall funnel plus the intent, model and host
+   * MARGINAL slices for that one run. There is deliberately no cross-run merge
+   * here or anywhere in the SDK — two funnels averaged together describe no run
+   * — so a caller that wants a comparison renders runs side by side under
+   * `stageAnalyticsParityBlockers`, never by summing these documents.
+   *
+   * `from`/`to` are INCLUSIVE epoch MILLISECONDS over the run's completion
+   * stamp (not ISO strings), matching the storage boundary exactly; `from`
+   * greater than `to` is a `400`. Runs that never completed carry no stamp and
+   * are excluded by any `from` bound. `runGroupId` narrows to one comparison
+   * group. `limit` is 1..100 and defaults to 25 — these documents are large.
+   *
+   * NEWER than most deployments, and NOT backfilled: an API that predates it
+   * answers `404`, and a run that finished before the materializer shipped has
+   * no row at all. Both mean UNMEASURED and neither is a zeroed funnel — there
+   * is no client-side reconstruction to fall back to, by design.
+   */
+  listEvalSuiteStageAnalytics(
+    params: {
+      projectId: string;
+      suiteId: string;
+      from?: number;
+      to?: number;
+      runGroupId?: string;
+      cursor?: string;
+      limit?: number;
+    },
+    options?: RequestOptions,
+  ): Promise<PlatformPage<PlatformEvalStageAnalytics>> {
+    return this.request(
+      "GET",
+      `/projects/${encodeURIComponent(
+        params.projectId,
+      )}/eval-suites/${encodeURIComponent(params.suiteId)}/stage-analytics`,
+      {
+        query: {
+          from: params.from,
+          to: params.to,
+          runGroupId: params.runGroupId,
+          cursor: params.cursor,
+          limit: params.limit,
+        },
+      },
       options,
     );
   }

--- a/sdk/src/platform/index.ts
+++ b/sdk/src/platform/index.ts
@@ -124,6 +124,7 @@ export type {
   PlatformReadinessSubmissionMode,
   PlatformEvalRun,
   PlatformEvalRunDecisionSummary,
+  PlatformEvalStageAnalytics,
   PlatformGateWaiver,
   PlatformGateWaiverRead,
   PlatformGateWaiverWriteResult,

--- a/sdk/src/platform/types.ts
+++ b/sdk/src/platform/types.ts
@@ -15,6 +15,7 @@ import type {
 } from "../contract/types.js";
 import type {
   EvalRunDecisionSummary,
+  EvalStageAnalyticsV1,
   EvalSuiteFileCaseImport,
   EvalVerdictDecision,
   FailureCategory,
@@ -34,6 +35,23 @@ import type {
  * recreate exactly the drift this lane removed.
  */
 export type PlatformEvalRunDecisionSummary = EvalRunDecisionSummary;
+
+/**
+ * One item of
+ * `GET /projects/{p}/eval-suites/{suiteId}/stage-analytics` — one RUN's
+ * complete materialized stage-analytics document.
+ *
+ * An ALIAS, for the same reason the decision summary is one: the shape is owned
+ * by `@mcpjam/sdk/contract` (`evalStageAnalyticsSchema`), and re-declaring it
+ * here would produce two hand-mirrored descriptions of one contract that drift
+ * the first time a field is added.
+ *
+ * Rates are NOT on this object. It carries counts, and every rate is derived by
+ * the contract's own helpers (`measuredPassRate`, `measurementCoverageRate`,
+ * `reachRate`, `latencyMeanMs`) so a zero denominator stays `notMeasured`
+ * instead of becoming a `0%` nobody can act on.
+ */
+export type PlatformEvalStageAnalytics = EvalStageAnalyticsV1;
 
 /** Collection envelope: `nextCursor` is omitted on the last page. */
 export type PlatformPage<TItem> = {

--- a/sdk/tests/platform/client-eval-stage-analytics.test.ts
+++ b/sdk/tests/platform/client-eval-stage-analytics.test.ts
@@ -1,0 +1,194 @@
+/**
+ * `PlatformApiClient.listEvalSuiteStageAnalytics` — the wire it actually makes.
+ *
+ * The platform client is a TOLERANT reader by design: it does not validate
+ * response bodies, so what is worth pinning here is everything it DOES own —
+ * the path it builds, which query parameters it serializes and which it drops,
+ * and that the shared timeout/abort/error plumbing reaches this method too.
+ * Contract validation belongs at the two ends (the route before the boundary,
+ * the client-side wrapper after it) and is asserted there.
+ */
+
+import { describe, expect, it, vi } from "vitest";
+import {
+  PlatformApiClient,
+  PlatformApiError,
+} from "../../src/platform/index.js";
+
+type FetchMock = ReturnType<typeof vi.fn>;
+
+function jsonResponse(body: unknown, status = 200): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { "content-type": "application/json" },
+  });
+}
+
+function makeClient(
+  fetchMock: FetchMock,
+  options: Partial<ConstructorParameters<typeof PlatformApiClient>[0]> = {}
+): PlatformApiClient {
+  return new PlatformApiClient({
+    baseUrl: "https://api.example.com/api/v1",
+    getAuth: () => "sk_test_token",
+    fetch: fetchMock as unknown as typeof fetch,
+    ...options,
+  });
+}
+
+function urlOf(fetchMock: FetchMock): URL {
+  return new URL(String(fetchMock.mock.calls[0]![0]));
+}
+
+describe("listEvalSuiteStageAnalytics", () => {
+  it("builds the suite-scoped path with encoded ids", async () => {
+    const fetchMock = vi.fn(async () => jsonResponse({ items: [] }));
+    await makeClient(fetchMock).listEvalSuiteStageAnalytics({
+      projectId: "proj/1",
+      suiteId: "suite 1",
+    });
+
+    const url = urlOf(fetchMock);
+    expect(url.pathname).toBe(
+      "/api/v1/projects/proj%2F1/eval-suites/suite%201/stage-analytics"
+    );
+    expect(fetchMock.mock.calls[0]![1]?.method).toBe("GET");
+  });
+
+  it("serializes every filter, with epoch ms as plain integers", async () => {
+    const fetchMock = vi.fn(async () => jsonResponse({ items: [] }));
+    await makeClient(fetchMock).listEvalSuiteStageAnalytics({
+      projectId: "p1",
+      suiteId: "s1",
+      from: 1700000000000,
+      to: 1700000100000,
+      runGroupId: "grp_1",
+      cursor: "c1",
+      limit: 25,
+    });
+
+    const params = urlOf(fetchMock).searchParams;
+    // Epoch MILLISECONDS, not an ISO string and not exponential notation —
+    // the backend indexes on this numerically.
+    expect(params.get("from")).toBe("1700000000000");
+    expect(params.get("to")).toBe("1700000100000");
+    expect(params.get("runGroupId")).toBe("grp_1");
+    expect(params.get("cursor")).toBe("c1");
+    expect(params.get("limit")).toBe("25");
+  });
+
+  it("drops the parameters the caller did not supply", async () => {
+    const fetchMock = vi.fn(async () => jsonResponse({ items: [] }));
+    await makeClient(fetchMock).listEvalSuiteStageAnalytics({
+      projectId: "p1",
+      suiteId: "s1",
+      limit: 10,
+    });
+
+    const params = urlOf(fetchMock).searchParams;
+    // Absent, not empty: `?from=` would reach the route as a string that fails
+    // coercion, turning an unfiltered read into a 400.
+    expect(params.has("from")).toBe(false);
+    expect(params.has("to")).toBe(false);
+    expect(params.has("runGroupId")).toBe(false);
+    expect(params.has("cursor")).toBe(false);
+    expect(params.get("limit")).toBe("10");
+  });
+
+  it("returns the page envelope through unchanged", async () => {
+    const page = { items: [{ runId: "run_1" }], nextCursor: "c2" };
+    const fetchMock = vi.fn(async () => jsonResponse(page));
+    const result = await makeClient(fetchMock).listEvalSuiteStageAnalytics({
+      projectId: "p1",
+      suiteId: "s1",
+    });
+    expect(result).toEqual(page);
+  });
+
+  it("forwards a caller AbortSignal", async () => {
+    const fetchMock = vi.fn(
+      (_url: unknown, init?: RequestInit) =>
+        new Promise<Response>((_resolve, reject) => {
+          const fail = () =>
+            reject(new DOMException("caller aborted", "AbortError"));
+          // The abort can land BEFORE fetch is reached — the client awaits its
+          // auth resolution first — so an already-aborted signal has to be
+          // handled, not just listened for.
+          if (init?.signal?.aborted) {
+            fail();
+            return;
+          }
+          init?.signal?.addEventListener("abort", fail);
+        })
+    );
+    const controller = new AbortController();
+
+    const pending = makeClient(fetchMock, { timeoutMs: 60_000 })
+      .listEvalSuiteStageAnalytics(
+        { projectId: "p1", suiteId: "s1" },
+        { signal: controller.signal }
+      )
+      .catch((caught: unknown) => caught);
+    controller.abort();
+
+    const error = await pending;
+    // A caller's own abort stays an AbortError — it is not the client's
+    // deadline and must not be relabelled as one.
+    expect((error as { name?: string }).name).toBe("AbortError");
+  });
+
+  it("synthesizes TIMEOUT when the client deadline expires", async () => {
+    const fetchMock = vi.fn(
+      (_url: unknown, init?: RequestInit) =>
+        new Promise<Response>((_resolve, reject) => {
+          init?.signal?.addEventListener("abort", () =>
+            reject(new DOMException("aborted", "AbortError"))
+          );
+        })
+    );
+
+    const error = await makeClient(fetchMock, { timeoutMs: 10 })
+      .listEvalSuiteStageAnalytics({ projectId: "p1", suiteId: "s1" })
+      .catch((caught: unknown) => caught);
+
+    expect(error).toBeInstanceOf(PlatformApiError);
+    expect((error as PlatformApiError).code).toBe("TIMEOUT");
+  });
+
+  it("maps a v1 error body onto the typed error", async () => {
+    const fetchMock = vi.fn(async () =>
+      jsonResponse({ code: "NOT_FOUND", message: "Eval suite not found" }, 404)
+    );
+
+    const error = await makeClient(fetchMock)
+      .listEvalSuiteStageAnalytics({ projectId: "p1", suiteId: "s1" })
+      .catch((caught: unknown) => caught);
+
+    expect(error).toBeInstanceOf(PlatformApiError);
+    expect((error as PlatformApiError).status).toBe(404);
+    expect((error as PlatformApiError).code).toBe("NOT_FOUND");
+  });
+
+  it("surfaces the 502 a failed contract validation produces", async () => {
+    // The route answers a malformed upstream payload with a service error
+    // rather than a 200. A caller must be able to tell that apart from an
+    // empty page — it is the difference between "nothing measured" and
+    // "something is broken".
+    const fetchMock = vi.fn(async () =>
+      jsonResponse(
+        {
+          code: "SERVER_UNREACHABLE",
+          message: "Stage analytics payload failed validation",
+        },
+        502
+      )
+    );
+
+    const error = await makeClient(fetchMock)
+      .listEvalSuiteStageAnalytics({ projectId: "p1", suiteId: "s1" })
+      .catch((caught: unknown) => caught);
+
+    expect((error as PlatformApiError).status).toBe(502);
+    expect((error as PlatformApiError).code).toBe("SERVER_UNREACHABLE");
+  });
+});


### PR DESCRIPTION
## What this completes

- **D5b** — `GET /v1/projects/:projectId/eval-suites/:suiteId/stage-analytics`
  + `PlatformApiClient.listEvalSuiteStageAnalytics` (+ the `sdk-coverage` map entry and the OpenAPI operation/schemas).
- **D5c** — the stage-analytics panel on the **Evaluate (New)** suite page (`/evaluate`).

Lane D is code complete when this merges; rollout stays gated (below).

## Backend dependency

- Consumes merged [mcpjam-backend#1169](https://github.com/MCPJam/mcpjam-backend/pull/1169) (`testSuites:listEvalStageAnalytics`), staging-deployed — "Deploy Staging" [run 33120965439](https://github.com/MCPJam/mcpjam-backend/actions/runs/33120965439), `head_sha` `3844ecd4a7c4e02c080e3af0d0e0f33abd36453e` (the D5a merge commit), conclusion `success`. Producer side: [inspector#4441](https://github.com/MCPJam/inspector/pull/4441).
- The backend query and its wire projection were re-read at this branch's tip and match the contract this PR implements, field for field.
- **Deployment-evidence state: verified-present via the staging workflow run.** The stronger check — `npx convex function-spec` against the deployment — needs a deploy key this environment does not have, so it was not run.
- No schema migration, no backfill. A missing capability is an explicit service state; there is no client-side fallback.

## Semantics

- **Run-scoped.** Each item is one run's complete `EvalStageAnalyticsV1` document. There is no cross-run merge in the SDK on purpose, and none is invented here — averaging two funnels describes no run. Paging browses further back; it never accumulates into a combined funnel.
- **Rates only via the contract helpers** (`measuredPassRate`, `measurementCoverageRate`, `reachRate`, `stageRate`, `latencyMeanMs`). There is no division anywhere in this diff. A zero denominator renders as the words "not measured"; a genuine measured `0/5` still renders as `0%`.
- Overall / intent (including the `null` → **Unlabeled** slice) / model / host marginal slices; setup with attempts, server-attributed failures and impacted trials counted separately; latency always carrying unit **and** basis (`ms · evidence span union` / `ms · setup wall clock`).
- **Honest states, kept apart:** provisional (a judge pass may still move the numbers), unsupported/service, old-run-unmeasured (no row exists — never a zeroed funnel), valid-empty, and per-stage zero-eligible.
- Mixed analyzer/measurement versions and slice truncation are **disclosed**, never quietly averaged or presented as a complete set.
- `from`/`to` are **inclusive epoch milliseconds** over `runCompletedAt` (route + SDK only; no date UI in this PR). A blank value (`?from=`) is treated as absent rather than coerced to `0`, which would silently exclude every run without a completion stamp.
- Public page shape is `{ items, nextCursor? }` per the v1 envelope — completeness is `nextCursor`'s absence.
- Validation happens at the two ends: the route validates every Convex row with the **refined** `evalStageAnalyticsSchema` before it crosses the public boundary (failure ⇒ 502, never a 200 and never a silently dropped row), and the client wrapper re-parses and identity-checks `suiteId`.
- The panel is gated on `projectId`, which is nullable on this page: the read is project-scoped, so without one there is nothing to request.
- Stage analytics explains measured behavior. It does not touch the run verdict — `EvalVerdictDecision` remains the authority.

## Scope

`/evals` is untouched, structurally rather than by convention: the mount point (`components/evaluate/suite-detail-overview.tsx`) is a file only the Evaluate (New) page uses. The shared `components/shared/user-value-chain/**` components are not modified — they consume an older projection (precomputed `passRate`, no reach/measured distinction, an incompatible exclusion vocabulary), so pushing this document through them would discard exactly what D5c exists to show. Their honest-state conventions are copied instead.

No new feature flag: `/evaluate` is already wholly guarded by the fail-closed `evaluate-enabled` PostHog flag.

## Deliberate deferrals

- No `PlatformOperation` / CLI / agent-registry / MCP-catalog surfaces — client method only. `list_eval_suite_stage_analytics` as an operation is follow-up work.
- No `openapi-types-parity` `PAIRS` entry (the schema is documented; pairing would force a hand-mirrored `types.ts` interface in place of the contract alias). Follow-up.
- No run-group side-by-side comparison UI, and no date-range UI.

## Verification

CI is green on `832fa89`: **Build and Test**, **Tests** (Run Tests + E2E Smoke + all 4 inspector shards), **PR Preview**, and both Snyk scans.

Run locally from the repo root after `npm ci --legacy-peer-deps`:

| Command | Result |
| --- | --- |
| `npm run typecheck` | pass |
| `npm run typecheck:client -w @mcpjam/inspector` | pass |
| `npm run build:inspector` | pass |
| `npm run test:checks` (incl. `check:platform-runtime-safety`) | pass |
| `npm run test -w @mcpjam/sdk` | **311 files, 6847 passed, 0 failed** |
| `npm run test -w @mcpjam/inspector` (full suite, unsharded) | **1522 files passed / 5 skipped; 19460 passed / 73 skipped; 0 failed** |
| `npm run test:packaging -w @mcpjam/sdk` / `-w @mcpjam/vitest` | pass |
| `npx eslint src/platform/client.ts` (in `sdk/`) | 478 errors — identical to `origin/main`; this PR adds none |
| `git diff --check` | clean |

Scope note: the full-suite run above was executed on the `cce77f4` tree. The only later commit (`832fa89`) reorders two keys in `openapi.json`; the sole suite that reads that file, `openapi-drift`, was re-run against it and passes. CI then ran everything on `832fa89` itself.

Focused suites added by this PR (all green in the full run above):

- `server/routes/v1/__tests__/eval-stage-analytics-route.test.ts` — 22 tests
- `server/routes/v1/__tests__/sdk-coverage.test.ts` + `openapi-drift.test.ts` — 10 tests (the two ratchets)
- `sdk/tests/platform/client-eval-stage-analytics.test.ts` — 8 tests
- `client/src/lib/apis/__tests__/eval-stage-analytics-api.test.ts` — 11 tests
- `client/src/hooks/__tests__/use-eval-suite-stage-analytics.test.tsx` — 8 tests
- `client/src/components/evaluate/__tests__/stage-analytics-model.test.ts` — 24 tests
- `client/src/components/evaluate/__tests__/stage-analytics-panel.test.tsx` — 13 tests
- `client/src/components/evaluate/__tests__/suite-detail-overview.test.tsx` — 16 tests (4 new)

Populated fixtures come from the shared SDK corpus (`sdk/tests/fixtures/stage-analytics-golden.json`), never a local copy; the states it does not carry (truncation, mixed versions, `final`) are built as variations and re-validated with the refined schema.

The published `EvalStageAnalytics` schema was checked field-by-field against `evalStageAnalyticsStructuralSchema`: its `required` list and property set match the contract exactly, in both directions. (The drift test does not verify this, so it was checked separately.)

Note for anyone running the client tests locally: `@mcpjam/sdk/platform` is not source-aliased in vitest (only `/contract` is), so `npm run build -w @mcpjam/sdk` must run first. This is pre-existing and affects the existing sibling suites identically.

### One local-only flake, for the record

While verifying locally, `npm run verify -w @mcpjam/discord-app` failed on three `discord-app/tests/journey-watcher.test.js` cases with `Promise resolution is still pending but the event loop has already resolved`. The same three fail at clean `origin/main` in a separate worktree, and this branch touches no file under `discord-app/`.

**CI does not see it:** the `Run Tests` job runs the same `test:ci:rest` (discord lane included) and passed on `832fa89`. So this is an artifact of the local sandbox's event-loop timing under parallel load, not a repo-level failure. Recorded only so the local-verification numbers above are reproducible; nothing here was skipped, quarantined, or masked.

## Rollout

- Rides the existing fail-closed `evaluate-enabled` flag; no new flag, and no flag plumbing changed.
- Operator gates before enablement: `convex function-spec` verification against the target deployment with a real deploy key, then smoke — populated overall; intent including Unlabeled; model/host slices; provisional → final after judge fanout settles; pagination without dupes or drops; tenant-denied requests safe; pre-D5a runs show unmeasured; zero-eligible shows words not rates; backend down/timeout shows a service state rather than an empty chart. Then internal cohort → gradual enablement.