### PR TITLE
Keep Playwright out of the Electron main bundle (fixes the red macOS release build)

### DIFF
--- a/mcpjam-inspector/vite.main.config.ts
+++ b/mcpjam-inspector/vite.main.config.ts
@@ -53,6 +53,20 @@ export default defineConfig({
         // off by design. Real Electron terminal support (extraResource +
         // custom resolution) is a scoped follow-up.
         "node-pty",
+        // Same story for Playwright, reached via `await import("playwright")`
+        // / `await import("playwright-core")` in browser-rendering-setup, the
+        // MCP App browser harness, and the WebMCP provider. Those literal
+        // dynamic imports make Rollup pull all of playwright-core into this
+        // bundle, and since 1.62 its inlined chokidar has a bare
+        // `require("fsevents")` that the commonjs plugin resolves to a native
+        // `.node` binary — which Rollup then tries to parse as JS and dies on
+        // ("Unexpected character"), breaking every macOS release build. Keep
+        // it external: as with node-pty the packaged app has no node_modules,
+        // so the import rejects and the browser-backed paths degrade off,
+        // exactly as they already did (a rolled-up playwright-core could never
+        // have found its wasm/registry assets at runtime anyway).
+        "playwright",
+        "playwright-core",
         ...builtinModules,
         ...builtinModules.map((m) => `node:${m}`),
       ],


### PR DESCRIPTION
## The failure

Every macOS release build dies in `electron-forge make`, at the Vite main-process bundle step — e.g. [run 33161606135](https://github.com/MCPJam/inspector/actions/runs/33161606135/job/98817496494):

```
[commonjs--resolver] node_modules/fsevents/fsevents.node (1:0): Unexpected character '\xff'
  (Note that you need plugins to import files that are not JavaScript)
file: .../node_modules/fsevents/fsevents.node:1:0 (.../node_modules/playwright-core/index.js)
```

Rollup is trying to parse a compiled native binary as JavaScript. The signing step itself is fine — it's the bundle inside it.

## Why

`src/main.ts` dynamically imports the whole server, and the server reaches Playwright through three literal dynamic imports:

- `server/utils/browser-rendering-setup.ts:53`
- `server/utils/mcp-app-browser-harness.ts:694`
- `server/services/webmcp-inspector/playwright-provider.ts:487`

`vite.main.config.ts` sets `inlineDynamicImports: false` (deliberately — see the comment there) and externalizes only `node-pty` + builtins, so Rollup follows those specifiers and bundles all of `playwright-core` as a chunk.

That was survivable until #4422 pinned `playwright` `^1.59.1` → `1.62.1`:

| `grep -rl fsevents node_modules/playwright-core/lib` | 1.59.1 | 1.62.1 |
| --- | --- | --- |
| | *(no hits)* | `lib/utilsBundle.js`, `lib/serverRegistry.js` |

1.62.1 inlines a chokidar carrying a bare `require("fsevents")`, which `@rollup/plugin-commonjs` resolves to the `.node` binary. Only `build-mac` is red because fsevents is a darwin-only optional dep.

## The fix

Externalize `playwright` / `playwright-core` next to `node-pty`, with a comment recording why.

**Behavioral note, stated rather than buried:** as with `node-pty`, the packaged app ships no `node_modules` (forge's vite plugin packs only `.vite`), so `await import("playwright")` now rejects and the browser-backed paths (MCP App browser harness, WebMCP provider, Chromium auto-install probe) degrade off in the desktop build. That is not a regression — a rolled-up `playwright-core` could never have located its wasm/registry assets at runtime either. `isChromiumInstalled()` already try/catches to `false`; the harness surfaces the missing browser and the eval falls back to the HTML snapshot path. Real Chromium support in the Electron app is an `extraResource` follow-up.

Nothing changes for the hosted/server build — `server/tsup.config.ts` already externalizes both packages.

## Verification

At `origin/main`, with the generated bundles present, running just the main-process build:

- **without this change:** fails with the fsevents parse error above (exit 1)
- **with this change:** `✓ built in 8.81s`, and Playwright's weight leaves the bundle

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015f98cNVeWQRzceokZtYzGE

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit 220f56d11a352088a578c37d46315bd199516bae. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Externalizes `playwright` and `playwright-core` in the Electron main bundle so macOS release builds stop failing when Rollup tries to parse Playwright's inlined `fsevents` native binary as JavaScript. The browser-backed paths (MCP App harness, WebMCP provider, Chromium probe) now degrade off as they already did in the packaged app, since it ships no runtime Playwright assets.

<sup>Written for commit 220f56d11a352088a578c37d46315bd199516bae. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/MCPJam/inspector/pull/4457?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

