### PR TITLE
fix: increase payload limits and improve truncation handling for RPC logs

### DIFF
--- a/mcpjam-inspector/client/src/stores/__tests__/traffic-log-store.rpc-stream.test.ts
+++ b/mcpjam-inspector/client/src/stores/__tests__/traffic-log-store.rpc-stream.test.ts
@@ -148,7 +148,7 @@ describe("traffic-log-store rpc stream (local mode)", () => {
         jsonrpc: "2.0",
         id: 14,
         method: "tools/call",
-        params: { data: "A".repeat(400_000) },
+        params: { data: "A".repeat(2_000_000) },
       },
     });
     unsubscribe();
@@ -162,9 +162,15 @@ describe("traffic-log-store rpc stream (local mode)", () => {
       jsonrpc: "2.0",
       id: 14,
       method: "tools/call",
-      params: { _truncated: true },
+      params: {
+        data: {
+          _truncated: true,
+          bytes: 2_000_000,
+          head: "A".repeat(8 * 1024),
+        },
+      },
       _truncated: true,
-      limitBytes: 256 * 1024,
+      limitBytes: 1024 * 1024,
     });
   });
 

--- a/mcpjam-inspector/client/src/stores/__tests__/traffic-log-store.rpc-stream.test.ts
+++ b/mcpjam-inspector/client/src/stores/__tests__/traffic-log-store.rpc-stream.test.ts
@@ -174,6 +174,70 @@ describe("traffic-log-store rpc stream (local mode)", () => {
     });
   });
 
+  // `MAX_ITEMS` bounds the row COUNT, and a count is not a memory bound: a
+  // thousand rows just under the per-row cap is a gigabyte in the renderer, and
+  // raising the per-row cap raises that ceiling with it. The total budget is
+  // what actually holds, so the oldest rows go once it is spent.
+  it("evicts the oldest rows once the total retention budget is spent", async () => {
+    const { subscribeToRpcStream, useTrafficLogStore } = await loadStore();
+    useTrafficLogStore.getState().clear();
+
+    const unsubscribe = subscribeToRpcStream();
+    const source = FakeEventSource.last!;
+    // Sixteen rows of ~900 KB: each one under the per-row cap and so retained
+    // whole, all sixteen far under MAX_ITEMS, together over the 8 MB budget.
+    for (let i = 0; i < 16; i++) {
+      source.emit({
+        ...rpcFrame(`rpc:bulk:${i}`, i),
+        message: {
+          jsonrpc: "2.0",
+          id: i,
+          method: "tools/call",
+          params: { data: "A".repeat(900_000) },
+        },
+      });
+    }
+    unsubscribe();
+
+    const items = useTrafficLogStore.getState().mcpServerItems;
+    // Every row is intact, so nothing but the budget can have dropped these.
+    expect(items.length).toBeLessThan(16);
+    expect(items.length).toBeGreaterThan(1);
+    expect(isTruncatedRpcPayload(items[0].payload)).toBe(false);
+    // Newest first, and the newest is what a reader is actually looking at.
+    expect(items[0].id).toBe("rpc:bulk:15");
+    const retained = items.reduce(
+      (sum, item) => sum + JSON.stringify(item.payload).length,
+      0,
+    );
+    // The budget, plus the one newest row that is never evicted for it.
+    expect(retained).toBeLessThanOrEqual(8 * 1024 * 1024 + 1024 * 1024);
+  });
+
+  // Hosted rows reach the store from a producer that does not cap them here, so
+  // one can exceed the whole budget by itself. Evicting it would leave the panel
+  // empty, which tells a reader less than a single oversized row does.
+  it("keeps the newest row even when it alone is over the budget", async () => {
+    const { useTrafficLogStore } = await loadStore();
+    useTrafficLogStore.getState().clear();
+
+    const add = (id: string, payload: unknown) =>
+      useTrafficLogStore.getState().addMcpServerLog({
+        id,
+        serverId: "srv-1",
+        direction: "RECEIVE",
+        method: "tools/call",
+        timestamp: "2026-08-02T00:00:00.000Z",
+        payload,
+      });
+    add("small", { jsonrpc: "2.0", id: 1 });
+    add("huge", { jsonrpc: "2.0", id: 2, result: "A".repeat(9_000_000) });
+
+    const items = useTrafficLogStore.getState().mcpServerItems;
+    expect(items).toHaveLength(1);
+    expect(items[0].id).toBe("huge");
+  });
+
   it("keeps the full payload of a frame under the cap", async () => {
     const { subscribeToRpcStream, useTrafficLogStore } = await loadStore();
     useTrafficLogStore.getState().clear();

--- a/mcpjam-inspector/client/src/stores/__tests__/traffic-log-store.rpc-stream.test.ts
+++ b/mcpjam-inspector/client/src/stores/__tests__/traffic-log-store.rpc-stream.test.ts
@@ -207,7 +207,8 @@ describe("traffic-log-store rpc stream (local mode)", () => {
     // Newest first, and the newest is what a reader is actually looking at.
     expect(items[0].id).toBe("rpc:bulk:15");
     const retained = items.reduce(
-      (sum, item) => sum + JSON.stringify(item.payload).length,
+      (sum, item) =>
+        sum + new TextEncoder().encode(JSON.stringify(item.payload)).length,
       0,
     );
     // The budget, plus the one newest row that is never evicted for it.

--- a/mcpjam-inspector/client/src/stores/traffic-log-store.ts
+++ b/mcpjam-inspector/client/src/stores/traffic-log-store.ts
@@ -105,8 +105,12 @@ const MAX_ITEMS = 1000;
  * holds, so nothing has to be serialized to measure it. That text carries the
  * event envelope as well as the payload, making the cap slightly conservative.
  * Hosted-mode rows arrive from a different producer and are bounded there.
+ *
+ * MIRRORING IS THE POINT: raising the server cap alone changes nothing that
+ * reaches the panel, because whatever survives the bus is cut again here. The
+ * two constants have to move together, in both directions.
  */
-const MAX_PAYLOAD_CHARS = 256 * 1024;
+const MAX_PAYLOAD_CHARS = 1024 * 1024;
 
 export const useTrafficLogStore = create<TrafficLogState>((set) => ({
   items: [],

--- a/mcpjam-inspector/client/src/stores/traffic-log-store.ts
+++ b/mcpjam-inspector/client/src/stores/traffic-log-store.ts
@@ -27,7 +27,11 @@ import type {
 // for internal use and re-exported below so existing import sites are unchanged.
 import { extractMethod } from "@mcpjam/sdk/widget-runtime";
 import type { HttpExchangeLogEvent } from "@mcpjam/sdk/browser";
-import { truncateRpcPayload } from "@/shared/rpc-log-truncation";
+import {
+  measureString,
+  probeSerializedSize,
+  truncateRpcPayload,
+} from "@/shared/rpc-log-truncation";
 
 /**
  * The path of an exchange URL — the row label. The query string is dropped on
@@ -101,16 +105,61 @@ const MAX_ITEMS = 1000;
  * /playground, both dying in mark-compact, both `deployment: self_hosted`).
  *
  * Scoped to this ingest path rather than to `addMcpServerLog`, because only
- * here is the size free: the SSE frame arrives as TEXT the browser already
- * holds, so nothing has to be serialized to measure it. That text carries the
- * event envelope as well as the payload, making the cap slightly conservative.
- * Hosted-mode rows arrive from a different producer and are bounded there.
+ * here is the size cheap: the SSE frame arrives as TEXT the browser already
+ * holds, so nothing has to be serialized to measure it — `measureString` walks
+ * that text instead, and stops at the cap. That text carries the event envelope
+ * as well as the payload, making the cap slightly conservative. Hosted-mode rows
+ * arrive from a different producer and are bounded there.
  *
  * MIRRORING IS THE POINT: raising the server cap alone changes nothing that
  * reaches the panel, because whatever survives the bus is cut again here. The
  * two constants have to move together, in both directions.
  */
-const MAX_PAYLOAD_CHARS = 1024 * 1024;
+const MAX_PAYLOAD_BYTES = 1024 * 1024;
+
+/**
+ * Total retained payload budget across every row — the browser twin of
+ * `MAX_BUFFERED_BYTES_PER_SERVER` in `server/services/rpc-log-bus.ts`, and the
+ * cap that actually bounds this store.
+ *
+ * `MAX_ITEMS` and `MAX_PAYLOAD_BYTES` do not compose into a memory bound. A
+ * thousand rows each just under the per-row cap is a gigabyte, and every raise
+ * of the per-row cap raises that ceiling with it — the per-row number buys
+ * legible rows, not a bounded heap. The renderer has already died of exactly
+ * this shape (INSPECTOR-ELECTRON-VJ on /tools, -VT on /playground, both in
+ * mark-compact), so the row count is not what is holding it up. This is.
+ */
+const MAX_RETAINED_PAYLOAD_BYTES = 8 * 1024 * 1024;
+
+/**
+ * What each retained row was charged against {@link MAX_RETAINED_PAYLOAD_BYTES}.
+ *
+ * Keyed on the row OBJECT rather than on its id: rows are replaced wholesale by
+ * an upsert and dropped without ceremony by eviction, and a WeakMap needs no
+ * bookkeeping for either — the entry goes when the row does. Charging once at
+ * insert is what keeps eviction from re-measuring a thousand payloads per frame.
+ */
+const retainedPayloadBytes = new WeakMap<McpServerRpcItem, number>();
+
+/**
+ * Trim to both caps, oldest first. `items` is newest-first, so everything from
+ * the cut onwards is the oldest history.
+ *
+ * The newest row is kept even when it alone is over the budget: a list that
+ * evicts itself empty shows a reader nothing at all, which is strictly worse
+ * than one oversized row. Same rule, and the same reason, as the bus.
+ */
+function withinRetentionBudget(items: McpServerRpcItem[]): McpServerRpcItem[] {
+  const capped = items.length > MAX_ITEMS ? items.slice(0, MAX_ITEMS) : items;
+  let bytes = 0;
+  for (let i = 0; i < capped.length; i++) {
+    bytes += retainedPayloadBytes.get(capped[i]) ?? 0;
+    if (bytes > MAX_RETAINED_PAYLOAD_BYTES && i > 0) {
+      return capped.slice(0, i);
+    }
+  }
+  return capped;
+}
 
 export const useTrafficLogStore = create<TrafficLogState>((set) => ({
   items: [],
@@ -140,14 +189,18 @@ export const useTrafficLogStore = create<TrafficLogState>((set) => ({
     // `pluginOrigin` and the streamed copy did not), the later one silently
     // overwrites the earlier with no signal. Enrich at CAPTURE, or give the
     // enriched event its own id.
+    retainedPayloadBytes.set(
+      newItem,
+      probeSerializedSize(newItem.payload, MAX_RETAINED_PAYLOAD_BYTES).bytes,
+    );
     set((state) => ({
-      mcpServerItems: state.mcpServerItems.some(
-        (existing) => existing.id === newItem.id,
-      )
-        ? state.mcpServerItems.map((existing) =>
-            existing.id === newItem.id ? newItem : existing,
-          )
-        : [newItem, ...state.mcpServerItems].slice(0, MAX_ITEMS),
+      mcpServerItems: withinRetentionBudget(
+        state.mcpServerItems.some((existing) => existing.id === newItem.id)
+          ? state.mcpServerItems.map((existing) =>
+              existing.id === newItem.id ? newItem : existing,
+            )
+          : [newItem, ...state.mcpServerItems],
+      ),
     }));
   },
   clear: () => set({ items: [], mcpServerItems: [] }),
@@ -374,8 +427,8 @@ export function subscribeToRpcStream(): () => void {
           method: extractMethod(message),
           timestamp: timestamp ?? new Date().toISOString(),
           payload:
-            evt.data.length > MAX_PAYLOAD_CHARS
-              ? truncateRpcPayload(message, MAX_PAYLOAD_CHARS)
+            measureString(evt.data, MAX_PAYLOAD_BYTES).utf8 > MAX_PAYLOAD_BYTES
+              ? truncateRpcPayload(message, MAX_PAYLOAD_BYTES)
               : message,
         });
       } catch {

--- a/mcpjam-inspector/server/services/__tests__/rpc-log-bus.test.ts
+++ b/mcpjam-inspector/server/services/__tests__/rpc-log-bus.test.ts
@@ -155,7 +155,7 @@ describe("rpcLogBus", () => {
     const seen: RpcLogEvent[] = [];
     const stop = rpcLogBus.subscribe([serverId], (e) => seen.push(e));
     try {
-      rpcLogBus.publish(bulkyEvent(serverId, 1, 600_000));
+      rpcLogBus.publish(bulkyEvent(serverId, 1, 2_000_000));
     } finally {
       stop();
     }
@@ -181,7 +181,7 @@ describe("rpcLogBus", () => {
         jsonrpc: "2.0",
         id: 42,
         method: "tools/call",
-        params: { data: "A".repeat(600_000) },
+        params: { data: "A".repeat(2_000_000) },
       },
     });
 
@@ -191,24 +191,37 @@ describe("rpcLogBus", () => {
       id: 42,
       method: "tools/call",
       // The key survives even though the body did not — `extractMethod` labels
-      // a response by the PRESENCE of `result`/`error`.
-      params: { _truncated: true },
+      // a response by the PRESENCE of `result`/`error`. Its SHAPE survives too
+      // now, down to the field that was too big and how big it was.
+      params: {
+        data: {
+          _truncated: true,
+          bytes: 2_000_000,
+          head: "A".repeat(8 * 1024),
+        },
+      },
       _truncated: true,
-      limitBytes: 256 * 1024,
+      limitBytes: 1024 * 1024,
     });
   });
 
   it("keeps a truncated response labelled as a response", () => {
     const serverId = `response-label-${crypto.randomUUID()}`;
-    rpcLogBus.publish(bulkyEvent(serverId, 9, 600_000));
+    rpcLogBus.publish(bulkyEvent(serverId, 9, 2_000_000));
 
     const [buffered] = rpcLogBus.getBuffer([serverId], -1);
     expect(messageOf(buffered)).toEqual({
       jsonrpc: "2.0",
       id: 9,
-      result: { _truncated: true },
+      result: {
+        data: {
+          _truncated: true,
+          bytes: 2_000_000,
+          head: "A".repeat(8 * 1024),
+        },
+      },
       _truncated: true,
-      limitBytes: 256 * 1024,
+      limitBytes: 1024 * 1024,
     });
   });
 
@@ -227,7 +240,7 @@ describe("rpcLogBus", () => {
   it("falls back to a bare marker when the preserved envelope is itself oversized", () => {
     const serverId = `wide-frame-${crypto.randomUUID()}`;
     const wide: Record<string, unknown> = { jsonrpc: "2.0", id: 1 };
-    for (let i = 0; i < 5_000; i++) {
+    for (let i = 0; i < 20_000; i++) {
       wide[`field_${i}`] = "y".repeat(200);
     }
 
@@ -239,10 +252,10 @@ describe("rpcLogBus", () => {
     });
 
     const [buffered] = rpcLogBus.getBuffer([serverId], -1);
-    // Not the 5,000 preserved scalars — the whole point of the cap.
+    // Not the 20,000 preserved scalars — the whole point of the cap.
     expect(messageOf(buffered)).toEqual({
       _truncated: true,
-      limitBytes: 256 * 1024,
+      limitBytes: 1024 * 1024,
     });
   });
 
@@ -295,7 +308,7 @@ describe("rpcLogBus", () => {
     const serverId = `stats-truncated-${crypto.randomUUID()}`;
     const before = rpcLogBus.stats();
 
-    rpcLogBus.publish(bulkyEvent(serverId, 1, 600_000));
+    rpcLogBus.publish(bulkyEvent(serverId, 1, 2_000_000));
 
     expect(rpcLogBus.stats().truncatedFrames).toBe(before.truncatedFrames + 1);
   });

--- a/mcpjam-inspector/server/services/rpc-log-bus.ts
+++ b/mcpjam-inspector/server/services/rpc-log-bus.ts
@@ -96,15 +96,27 @@ const MAX_BUFFERED_EVENTS_PER_SERVER = 500;
  * worth gigabytes. INSPECTOR-ELECTRON-W3 died with 2.24 GB live in a 2.27 GB
  * old space after a full mark-compact.
  *
- * 256 KB leaves ordinary frames — including most tool results anyone actually
- * reads in the Logs panel — completely intact, and turns the ones nobody can
- * read anyway into a marker.
+ * 1 MB leaves ordinary frames — including most tool results anyone actually
+ * reads in the Logs panel — completely intact, and truncates the ones nobody
+ * can read anyway to a head plus their true size.
+ *
+ * This bounds what the LOGS PANEL retains, never what a tool may return. A
+ * response over this size is still delivered and rendered in full; only its
+ * Logs row is shortened. Reading the number as a response limit gets the
+ * direction of the constraint backwards.
+ *
+ * Nor does the exact value bound this process — `MAX_BUFFERED_BYTES_PER_SERVER`
+ * below is the ceiling that actually holds, and eviction enforces it whatever a
+ * single frame weighs. The crash above was unbounded RETENTION, not one large
+ * frame. What this value buys is that frames someone opens in the panel are
+ * usually there whole; what keeps a dropped one legible is `truncateRpcPayload`
+ * leaving a head and a byte count rather than a bare marker.
  */
-const MAX_MESSAGE_BYTES = 256 * 1024;
+const MAX_MESSAGE_BYTES = 1024 * 1024;
 
 /**
  * Per-server TOTAL retention cap, and the one that really bounds the process:
- * the per-frame cap alone still permits 500 x 256 KB per server, times every
+ * the per-frame cap alone still permits 500 frames per server, times every
  * server id ever seen.
  */
 const MAX_BUFFERED_BYTES_PER_SERVER = 8 * 1024 * 1024;

--- a/mcpjam-inspector/server/utils/harness/__tests__/harness-rpc-log-sink.test.ts
+++ b/mcpjam-inspector/server/utils/harness/__tests__/harness-rpc-log-sink.test.ts
@@ -106,9 +106,15 @@ describe("enqueue + batched flush", () => {
       // stops at the cap rather than serializing the frame to measure it.
       limitBytes: 16 * 1024,
     });
-    // The KEY survives with a nested marker, the 20 KB value does not: a frame
-    // whose field names were dropped too is one nobody can identify afterwards.
-    expect(body.entries[0].message.big).toEqual({ _truncated: true });
+    // The KEY survives, and so does the head of its value and the size it
+    // really was. A frame that dropped its field names cannot be identified
+    // afterwards; one that dropped the size cannot be compared against what the
+    // server actually sent.
+    expect(body.entries[0].message.big).toEqual({
+      _truncated: true,
+      bytes: 20_000,
+      head: "x".repeat(8 * 1024),
+    });
   });
 
   // A cycle used to be caught by the `JSON.stringify` that sized the frame. The

--- a/mcpjam-inspector/shared/__tests__/rpc-log-truncation.test.ts
+++ b/mcpjam-inspector/shared/__tests__/rpc-log-truncation.test.ts
@@ -2,9 +2,15 @@ import { describe, expect, it } from "vitest";
 import {
   describeTruncatedRpcPayload,
   isTruncatedRpcPayload,
+  measureString,
   probeSerializedSize,
   truncateRpcPayload,
 } from "../rpc-log-truncation";
+
+/** What the value really costs on the wire, measured the way a consumer does. */
+function serializedBytes(value: unknown): number {
+  return new TextEncoder().encode(JSON.stringify(value)).length;
+}
 
 /**
  * An object with `count` enumerable getters that record every read. The probe
@@ -28,6 +34,35 @@ function countingWideObject(count: number): {
   }
   return { value, touched: () => touched };
 }
+
+// Every budget in this module is charged in serialized bytes. `value.length`
+// used to stand in for that and counts UTF-16 code units, which is a different
+// number for everything but ASCII.
+describe("measureString", () => {
+  it("counts exactly what JSON.stringify would write", () => {
+    // `.length` reads these as 3, 1, 1, 2 and 1 respectively.
+    expect(measureString("\u65e5\u672c\u8a9e", Infinity)).toEqual({
+      utf8: 9,
+      json: 11,
+    });
+    expect(measureString("\u0001", Infinity)).toEqual({ utf8: 1, json: 8 });
+    expect(measureString('"', Infinity)).toEqual({ utf8: 1, json: 4 });
+    // An astral code point is one character over two UTF-16 units...
+    expect(measureString("\u{1F600}", Infinity)).toEqual({ utf8: 4, json: 6 });
+    // ...and half of one encodes as the replacement character but serializes
+    // as a six-character escape.
+    expect(measureString("\ud800", Infinity)).toEqual({ utf8: 3, json: 8 });
+  });
+
+  it("leaves both counts over the budget when it stops early", () => {
+    // The early exit is on `utf8`, the smaller of the two, so a caller
+    // comparing EITHER count against the same budget still gets "over".
+    const measured = measureString("\u65e5".repeat(100_000), 1024);
+
+    expect(measured.utf8).toBeGreaterThan(1024);
+    expect(measured.json).toBeGreaterThan(1024);
+  });
+});
 
 describe("probeSerializedSize", () => {
   it("stops walking a very wide object at the budget instead of enqueuing every key", () => {
@@ -57,6 +92,24 @@ describe("probeSerializedSize", () => {
 
     expect(result.exceeded).toBe(false);
     expect(result.bytes).toBeGreaterThan(0);
+  });
+
+  // Regression: `.length` read this frame as ~100 KB and let it through a
+  // 256 KB cap that JSON.stringify blows by 44 KB.
+  it("sizes a CJK payload by its serialized bytes, not its UTF-16 length", () => {
+    const frame = { a: "\u65e5".repeat(100_000) };
+    expect(serializedBytes(frame)).toBeGreaterThan(256 * 1024);
+
+    expect(probeSerializedSize(frame, 256 * 1024).exceeded).toBe(true);
+  });
+
+  // Control characters are the worse direction: JSON writes six characters for
+  // each one, so `.length` undercounted this frame by 6x.
+  it("counts a control character as the escape JSON writes for it", () => {
+    const frame = { a: "\u0001".repeat(100_000) };
+    expect(serializedBytes(frame)).toBeGreaterThan(256 * 1024);
+
+    expect(probeSerializedSize(frame, 256 * 1024).exceeded).toBe(true);
   });
 });
 
@@ -163,6 +216,62 @@ describe("truncateRpcPayload", () => {
     }
   });
 
+  // The ceiling is a PROMISE, not an approximation: `harness-rpc-log-sink`
+  // sizes a Convex document against it. Measured in UTF-16 units a 16 KB limit
+  // came back with 24 KB of CJK on the wire, and the document limit is the next
+  // ceiling up.
+  it("holds its limit in real bytes for a frame that is not ASCII", () => {
+    for (const limit of [512, 16 * 1024, 1024 * 1024]) {
+      const truncated = truncateRpcPayload(
+        {
+          jsonrpc: "2.0",
+          id: 12,
+          result: {
+            text: "\u65e5".repeat(500_000),
+            control: "\u0001".repeat(50_000),
+          },
+        },
+        limit,
+      );
+
+      expect(serializedBytes(truncated)).toBeLessThanOrEqual(limit);
+    }
+  });
+
+  // Regression: the marker was spread over the preserved envelope, which only
+  // overwrites the keys the marker HAS — and it carries neither `head` nor
+  // `reason` on a frame-level truncation. A frame supplying its own read back
+  // as the marker's account of what it dropped.
+  it("never lets a frame's own field supply the marker's truncation metadata", () => {
+    const truncated = truncateRpcPayload(
+      {
+        jsonrpc: "2.0",
+        id: 13,
+        head: "ok",
+        bytes: 7,
+        reason: "not a truncation",
+        result: { data: "x".repeat(5_000_000) },
+      },
+      1024,
+    );
+
+    expect(truncated.head).toBeUndefined();
+    expect(truncated.bytes).toBeUndefined();
+    expect(truncated.reason).toBeUndefined();
+    expect(truncated.limitBytes).toBe(1024);
+    // The notice used to read "Payload not recorded: not a truncation." — the
+    // frame describing itself.
+    expect(describeTruncatedRpcPayload(truncated)).toBe(
+      "Payload not recorded \u2014 over the 1 KB log limit.",
+    );
+    // Everything that is not the marker's to own is still there.
+    expect(truncated.jsonrpc).toBe("2.0");
+    expect(truncated.id).toBe(13);
+    expect(truncated.result).toEqual({
+      data: { _truncated: true, bytes: 5_000_000 },
+    });
+  });
+
   it("terminates on a cyclic frame instead of recursing forever", () => {
     const cyclic: Record<string, unknown> = { jsonrpc: "2.0", id: 11 };
     cyclic.self = cyclic;
@@ -227,6 +336,23 @@ describe("the truncation notice the Logs panel renders", () => {
     ).toBe(
       "Payload truncated — over the 1.0 MB log limit. It was 2.0 MB. " +
         "Showing the first 8 KB.",
+    );
+  });
+
+  it("reports the head in the same unit as the size beside it", () => {
+    // 4096 CJK characters are 12 KB on the wire. Reported as `head.length` the
+    // sentence read "the first 4 KB" next to a size in bytes, and the two
+    // numbers invited exactly the ratio nobody should compute from them.
+    expect(
+      describeTruncatedRpcPayload({
+        _truncated: true,
+        limitBytes: 1024 * 1024,
+        bytes: 3 * 1024 * 1024,
+        head: "\u65e5".repeat(4 * 1024),
+      }),
+    ).toBe(
+      "Payload truncated \u2014 over the 1.0 MB log limit. It was 3.0 MB. " +
+        "Showing the first 12 KB.",
     );
   });
 

--- a/mcpjam-inspector/shared/__tests__/rpc-log-truncation.test.ts
+++ b/mcpjam-inspector/shared/__tests__/rpc-log-truncation.test.ts
@@ -76,13 +76,15 @@ describe("truncateRpcPayload", () => {
     expect(truncated).toEqual({
       jsonrpc: "2.0",
       id: null,
-      error: { _truncated: true },
+      // The walk descends, so the error CODE survives too — the single most
+      // useful field on a frame whose body could not be kept.
+      error: { code: -32700, message: { _truncated: true, bytes: 400 } },
       _truncated: true,
       limitBytes: 256,
     });
   });
 
-  it("preserves short scalars and replaces long values with a nested marker", () => {
+  it("descends into a dropped field instead of collapsing it, and names the size", () => {
     const truncated = truncateRpcPayload(
       {
         jsonrpc: "2.0",
@@ -94,15 +96,81 @@ describe("truncateRpcPayload", () => {
       1024,
     );
 
+    // `params` used to become a bare `{_truncated: true}`, which told a reader
+    // nothing about what had been there. Its shape now survives, and the string
+    // that could not fit reports its own length.
     expect(truncated).toEqual({
       jsonrpc: "2.0",
       id: 7,
       method: "tools/call",
       streaming: false,
-      params: { _truncated: true },
+      params: { data: { _truncated: true, bytes: 5000 } },
       _truncated: true,
       limitBytes: 1024,
     });
+  });
+
+  it("keeps a head of an oversized string when the budget has room for one", () => {
+    const truncated = truncateRpcPayload(
+      { jsonrpc: "2.0", id: 8, result: { content: [{ type: "text", text: "y".repeat(1_048_576) }] } },
+      1024 * 1024,
+    );
+
+    const text = (truncated as any).result.content[0].text;
+    expect(text.bytes).toBe(1_048_576);
+    expect(text.head).toHaveLength(8 * 1024);
+    expect(text.head).toBe("y".repeat(8 * 1024));
+    // Sibling scalars inside the same content block are untouched — the reader
+    // can still tell WHAT kind of block lost its body.
+    expect((truncated as any).result.content[0].type).toBe("text");
+  });
+
+  it("keeps a frame's `_meta` — 150 bytes that the depth-one collapse always threw away", () => {
+    const truncated = truncateRpcPayload(
+      {
+        jsonrpc: "2.0",
+        id: 9,
+        result: {
+          content: [{ type: "text", text: "z".repeat(2_000_000) }],
+          _meta: { tool: "big_text", actualBytes: 2_000_000, fnv: "4db183ec" },
+        },
+      },
+      1024 * 1024,
+    );
+
+    expect((truncated as any).result._meta).toEqual({
+      tool: "big_text",
+      actualBytes: 2_000_000,
+      fnv: "4db183ec",
+    });
+  });
+
+  it("never returns more than the limit, whatever the frame looks like", () => {
+    for (const limit of [512, 16 * 1024, 1024 * 1024]) {
+      const truncated = truncateRpcPayload(
+        {
+          jsonrpc: "2.0",
+          id: 10,
+          result: {
+            a: "x".repeat(5_000_000),
+            b: "y".repeat(5_000_000),
+            c: Array.from({ length: 200 }, () => "z".repeat(50_000)),
+          },
+        },
+        limit,
+      );
+      expect(probeSerializedSize(truncated, limit).exceeded).toBe(false);
+    }
+  });
+
+  it("terminates on a cyclic frame instead of recursing forever", () => {
+    const cyclic: Record<string, unknown> = { jsonrpc: "2.0", id: 11 };
+    cyclic.self = cyclic;
+
+    const truncated = truncateRpcPayload(cyclic, 1024 * 1024);
+
+    expect(truncated._truncated).toBe(true);
+    expect(truncated.id).toBe(11);
   });
 
   it("returns a bare marker for a frame too wide for the envelope to fit", () => {
@@ -141,6 +209,24 @@ describe("the truncation notice the Logs panel renders", () => {
     // No limit and no size still reads as a sentence, not as "undefined".
     expect(describeTruncatedRpcPayload({ _truncated: true })).toBe(
       "Payload not recorded — over the log size limit.",
+    );
+  });
+
+  it("says TRUNCATED, not 'not recorded', once a head survived", () => {
+    // The two words carry different information. A reader looking at the first
+    // 8 KB has to know the rest exists somewhere, and needs a size to compare
+    // against what the server actually sent; a reader looking at nothing needs
+    // to know the row never had a body at all.
+    expect(
+      describeTruncatedRpcPayload({
+        _truncated: true,
+        limitBytes: 1024 * 1024,
+        bytes: 2 * 1024 * 1024,
+        head: "x".repeat(8 * 1024),
+      }),
+    ).toBe(
+      "Payload truncated — over the 1.0 MB log limit. It was 2.0 MB. " +
+        "Showing the first 8 KB.",
     );
   });
 

--- a/mcpjam-inspector/shared/__tests__/rpc-log-truncation.test.ts
+++ b/mcpjam-inspector/shared/__tests__/rpc-log-truncation.test.ts
@@ -52,6 +52,11 @@ describe("measureString", () => {
     // ...and half of one encodes as the replacement character but serializes
     // as a six-character escape.
     expect(measureString("\ud800", Infinity)).toEqual({ utf8: 3, json: 8 });
+    // `\b \t \n \f \r` are the control characters with a two-character escape;
+    // every other one costs six, like the `\u0001` above.
+    expect(measureString("\n", Infinity)).toEqual({ utf8: 1, json: 4 });
+    // The smallest string there is: nothing but the two quotes.
+    expect(measureString("", Infinity)).toEqual({ utf8: 0, json: 2 });
   });
 
   it("leaves both counts over the budget when it stops early", () => {

--- a/mcpjam-inspector/shared/rpc-log-truncation.ts
+++ b/mcpjam-inspector/shared/rpc-log-truncation.ts
@@ -18,7 +18,7 @@
  */
 export type TruncatedRpcPayload = {
   _truncated: true;
-  /** Exact serialized size, when the producer already had it in hand. */
+  /** Exact size in UTF-8 bytes, when the producer measured it. */
   bytes?: number;
   /** The ceiling that was crossed, when the exact size was never measured. */
   limitBytes?: number;
@@ -58,6 +58,116 @@ const STRING_HEAD_CHARS = 8 * 1024;
 const STRING_MARKER_OVERHEAD = 64;
 
 /**
+ * The names the marker owns.
+ *
+ * {@link truncateRpcPayload} merges what it preserved off the source frame with
+ * the marker, and these have to come from the marker alone:
+ * {@link describeTruncatedRpcPayload} reads them as the marker's account of what
+ * it dropped. A frame carrying a root-level `head` renders as "Showing the first
+ * 2 B" of a payload nothing ever sliced; one carrying `reason` renders the
+ * frame's own string as the reason nothing was recorded.
+ *
+ * None of them is a JSON-RPC field, so a frame losing one off its envelope costs
+ * a reader nothing that a truthful notice does not repay. Spreading the marker
+ * last is not enough on its own — it only overwrites the keys the marker
+ * happens to carry, and `head`, `bytes` and `reason` are exactly the ones it
+ * usually does not.
+ */
+const MARKER_FIELDS = new Set([
+  "_truncated",
+  "bytes",
+  "limitBytes",
+  "reason",
+  "head",
+]);
+
+/**
+ * The two sizes this module measures a string by, counted in one pass.
+ *
+ * `utf8` is the string's own encoded length — what a marker's `bytes` reports,
+ * and what an already-serialized frame is measured by. `json` is what the same
+ * string costs INSIDE serialized JSON: those bytes with JSON's escapes applied
+ * and the surrounding quotes counted. Every budget here is charged `json`.
+ *
+ * `value.length` used to stand in for both and is neither. It counts UTF-16
+ * code units, so `"日本語"` measured 3 where JSON writes 9, and a control
+ * character measured 1 where JSON writes the six of `\u0001`. Undercounting was
+ * documented as the tolerable direction — a cap that lets a big value through —
+ * but no caller uses it that way: `harness-rpc-log-sink` sizes a Convex
+ * document against it, and {@link truncateRpcPayload} promises every caller a
+ * result under `limitBytes`. A 16 KB limit returning 24 KB of CJK is not a
+ * conservative cap, it is a broken one.
+ *
+ * Both counters stop once `utf8` passes `budget`. `json` is never smaller than
+ * `utf8`, so at that point BOTH are over it and a caller comparing either
+ * against the same budget still gets the right answer — while the scan costs at
+ * most the budget rather than the string. Pass `Infinity` when the exact size is
+ * the point.
+ */
+export function measureString(
+  value: string,
+  budget: number,
+): { utf8: number; json: number } {
+  let utf8 = 0;
+  let escapes = 0;
+  for (let i = 0; i < value.length; i++) {
+    if (utf8 > budget) break;
+    const code = value.charCodeAt(i);
+    if (code < 0x80) {
+      utf8 += 1;
+      if (code === 0x22 || code === 0x5c) {
+        escapes += 1; // \" and \\
+      } else if (code < 0x20) {
+        // \b \t \n \f \r have two-character escapes; every other control
+        // character is written as \u00xx.
+        escapes +=
+          code === 8 || code === 9 || code === 10 || code === 12 || code === 13
+            ? 1
+            : 5;
+      }
+      continue;
+    }
+    if (code < 0x800) {
+      utf8 += 2;
+      continue;
+    }
+    if (code >= 0xd800 && code <= 0xdbff) {
+      const low = value.charCodeAt(i + 1);
+      // NaN past the end of the string, so an unpaired trailing high surrogate
+      // falls through to the branch below rather than reading off the end.
+      if (low >= 0xdc00 && low <= 0xdfff) {
+        utf8 += 4;
+        i++;
+        continue;
+      }
+    }
+    if (code >= 0xd800 && code <= 0xdfff) {
+      // An unpaired surrogate encodes as the three-byte replacement character,
+      // but `JSON.stringify` writes it as the six of `\udXXX`.
+      utf8 += 3;
+      escapes += 3;
+      continue;
+    }
+    utf8 += 3;
+  }
+  return { utf8, json: utf8 + escapes + 2 };
+}
+
+/**
+ * The first {@link STRING_HEAD_CHARS} characters of a string, never splitting a
+ * surrogate pair — half of one is not text, it is a `�` in the panel.
+ */
+function headOf(value: string): string {
+  const last = value.charCodeAt(STRING_HEAD_CHARS - 1);
+  return value.slice(
+    0,
+    last >= 0xd800 && last <= 0xdbff
+      ? STRING_HEAD_CHARS - 1
+      : STRING_HEAD_CHARS,
+  );
+}
+
+/**
  * Depth ceiling for the shrink walk. Deep enough for any JSON-RPC frame
  * (`result.content[n].text` is four), shallow enough that a cyclic or
  * adversarially nested value terminates without a stack guard.
@@ -82,9 +192,10 @@ const MAX_PROBE_NODES = 50_000;
  * `Zone::Expand` in the browser process). The walk stops at `budget`, so its
  * cost is bounded by the cap rather than by the value.
  *
- * Counts UTF-16 code units, not UTF-8 bytes, so a CJK payload is undercounted
- * by up to 3x. That is the tolerable direction for a retention cap: it can let
- * an oversized value through, never truncate one that would have fit.
+ * Strings are measured by {@link measureString}, so what is counted is what
+ * `JSON.stringify` would actually write — UTF-8, escapes included. Everything
+ * else is approximated by a flat constant, which is why this is a ceiling
+ * rather than an exact size.
  *
  * Cycles terminate at the node ceiling rather than throwing, so a caller can
  * treat `exceeded` as "do not keep this" without a separate cycle check.
@@ -103,7 +214,7 @@ export function probeSerializedSize(
 
     const node = stack.pop();
     if (typeof node === "string") {
-      bytes += node.length + 2; // surrounding quotes
+      bytes += measureString(node, budget - bytes).json;
       continue;
     }
     if (node === null || typeof node !== "object") {
@@ -128,7 +239,7 @@ export function probeSerializedSize(
     bytes += 2; // braces
     for (const key in node) {
       if (!Object.hasOwn(node, key)) continue;
-      bytes += key.length + 4; // quotes, colon, separator
+      bytes += measureString(key, budget - bytes).json + 2; // colon, separator
       if (bytes > budget) return { bytes, exceeded: true };
       stack.push((node as Record<string, unknown>)[key]);
     }
@@ -211,23 +322,30 @@ export function truncateRpcPayload(
     if (++nodes > MAX_PROBE_NODES) return dropped();
 
     if (typeof value === "string") {
+      const measured = measureString(value, limitBytes - spent);
       if (
         value.length <= MAX_PRESERVED_STRING_CHARS &&
-        spent + value.length + 2 <= limitBytes
+        spent + measured.json <= limitBytes
       ) {
-        spent += value.length + 2;
+        spent += measured.json;
         return value;
       }
-      if (spent + STRING_HEAD_CHARS + STRING_MARKER_OVERHEAD <= limitBytes) {
-        spent += STRING_HEAD_CHARS + STRING_MARKER_OVERHEAD;
-        return {
-          _truncated: true,
-          bytes: value.length,
-          head: value.slice(0, STRING_HEAD_CHARS),
-        };
+      // Past the fits-whole check the marker reports the size either way, and
+      // `measured` stopped at the budget rather than at the end of the string.
+      const bytes = measureString(value, Number.POSITIVE_INFINITY).utf8;
+      const head = headOf(value);
+      // A head equal to the string is not a head. The two constants are equal
+      // today so this only fires on a surrogate pair straddling the cut, but
+      // the honesty of the marker should not rest on their staying equal.
+      if (head.length < value.length) {
+        const headBytes = measureString(head, Number.POSITIVE_INFINITY).json;
+        if (spent + headBytes + STRING_MARKER_OVERHEAD <= limitBytes) {
+          spent += headBytes + STRING_MARKER_OVERHEAD;
+          return { _truncated: true, bytes, head };
+        }
       }
       spent += STRING_MARKER_OVERHEAD;
-      return dropped(value.length);
+      return dropped(bytes);
     }
 
     if (value === null || typeof value !== "object") {
@@ -257,7 +375,7 @@ export function truncateRpcPayload(
     const out: Record<string, unknown> = {};
     for (const key in value as Record<string, unknown>) {
       if (!Object.hasOwn(value, key)) continue;
-      spent += key.length + 4;
+      spent += measureString(key, limitBytes - spent).json + 2;
       if (spent > limitBytes) {
         path.delete(value);
         return dropped();
@@ -269,11 +387,20 @@ export function truncateRpcPayload(
   };
 
   const shrunk = shrink(payload, 0);
-  const preserved =
-    isTruncatedRpcPayload(shrunk) || typeof shrunk !== "object" || shrunk === null
-      ? {}
-      : (shrunk as Record<string, unknown>);
-  // Marker last: it must win over any same-named field on the frame.
+  const preserved: Record<string, unknown> = {};
+  if (
+    !isTruncatedRpcPayload(shrunk) &&
+    typeof shrunk === "object" &&
+    shrunk !== null
+  ) {
+    for (const [key, field] of Object.entries(shrunk)) {
+      // Dropped, not overwritten: the marker does not carry `head`, `bytes` or
+      // `reason` on every frame, so spreading it last leaves whichever of them
+      // the FRAME supplied standing — and the notice then describes the frame's
+      // own field as the marker's account of what was dropped. See MARKER_FIELDS.
+      if (!MARKER_FIELDS.has(key)) preserved[key] = field;
+    }
+  }
   const truncated = { ...preserved, ...marker };
 
   // The loop above bails on the envelope's own size, but the marker fields it
@@ -331,8 +458,11 @@ export function describeTruncatedRpcPayload(
   if (typeof payload.head === "string") {
     // No claim about where the rest is: this module describes frames of every
     // kind, and only SOME of them have a tool-result card holding the original.
+    // Measured, not `head.length`: the sentence next to it reports `bytes` in
+    // UTF-8, and two numbers in different units invite exactly the comparison
+    // that makes a reader think a third of the payload survived.
     return `Payload truncated — ${limit}.${size} Showing the first ${formatBytes(
-      payload.head.length,
+      measureString(payload.head, Number.POSITIVE_INFINITY).utf8,
     )}.`;
   }
   return `Payload not recorded — ${limit}.${size}`;

--- a/mcpjam-inspector/shared/rpc-log-truncation.ts
+++ b/mcpjam-inspector/shared/rpc-log-truncation.ts
@@ -24,16 +24,45 @@ export type TruncatedRpcPayload = {
   limitBytes?: number;
   /** Why the payload could not be serialized at all (e.g. a cycle). */
   reason?: string;
+  /**
+   * The first {@link STRING_HEAD_CHARS} characters of a dropped string, when
+   * the budget had room for them. Present only on the marker that replaced a
+   * single oversized string, never on a frame-level marker — a frame is an
+   * object, and objects are shrunk field by field rather than sliced.
+   */
+  head?: string;
   /** Short scalars preserved off the original frame — see
    *  {@link truncateRpcPayload}. */
   [key: string]: unknown;
 };
 
 /**
- * A preserved string this long is a label, not a payload. Anything longer is
- * the thing being dropped.
+ * A string this long is kept whole. It was 256 — a threshold that made sense
+ * when the marker was all a reader got either way, and made none once the
+ * marker started carrying a head: below 8 KB the head WOULD BE the whole
+ * string, so wrapping it in a "truncated" marker would claim a loss that never
+ * happened.
  */
-const MAX_PRESERVED_STRING_CHARS = 256;
+const MAX_PRESERVED_STRING_CHARS = 8 * 1024;
+
+/**
+ * How much of an oversized string the marker carries. Kept only when the
+ * remaining budget has room for all of it: a partial head sized by whatever was
+ * left would make the amount you see depend on where in the frame the string
+ * happened to sit, which is not a property anyone can reason about while
+ * debugging.
+ */
+const STRING_HEAD_CHARS = 8 * 1024;
+
+/** Room for `_truncated`, `bytes`, and the braces around them. */
+const STRING_MARKER_OVERHEAD = 64;
+
+/**
+ * Depth ceiling for the shrink walk. Deep enough for any JSON-RPC frame
+ * (`result.content[n].text` is four), shallow enough that a cyclic or
+ * adversarially nested value terminates without a stack guard.
+ */
+const MAX_SHRINK_DEPTH = 8;
 
 /**
  * Node ceiling for {@link probeSerializedSize}. A value with this many nodes is
@@ -122,9 +151,33 @@ export function probeSerializedSize(
  * or `error`; drop the key and every truncated response reads as "unknown"
  * instead of "result".
  *
- * So: short own scalars are copied, and every other own field keeps its key
- * with a nested marker for its value. No knowledge of which frame shape
- * (request, response, notification) this was handed is needed.
+ * So: short own scalars are copied, and every other own field keeps its key.
+ * No knowledge of which frame shape (request, response, notification) this was
+ * handed is needed.
+ *
+ * What that field's VALUE becomes is where the cost of the old shape showed.
+ * Every non-scalar used to collapse to `{_truncated: true}` at depth one,
+ * unconditionally, so a megabyte of text and an empty object produced identical
+ * rows: `result` vanished whole, and `result._meta` went with it despite being
+ * ~150 bytes that would always have fit. Nothing in the row said how much had
+ * been dropped, which is the one fact a reader needs to tell a capped log entry
+ * apart from a genuinely empty response.
+ *
+ * The walk now descends instead, spending a budget as it goes:
+ *   - a scalar, or a string that still fits, is copied;
+ *   - a longer string becomes `{_truncated, bytes, head}` — its true length and
+ *     its first {@link STRING_HEAD_CHARS} characters when they fit, `bytes`
+ *     alone when they do not. The length is kept even when the head cannot be:
+ *     knowing a value was 2 MB is most of what makes the row readable;
+ *   - an object or array is rebuilt field by field until the budget runs out.
+ *
+ * Two properties from the original are load-bearing and preserved. The walk
+ * ABANDONS a partial container the moment the budget is gone rather than
+ * filling in the rest — a pathologically wide frame must never be materialized
+ * only to be rejected. And the result is re-probed at the end: every caller
+ * sizes its own storage on the guarantee that this returns something under
+ * `limitBytes` (`harness-rpc-log-sink` guards a Convex document limit with it),
+ * so the ceiling holds for every input shape, not just well-formed frames.
  */
 export function truncateRpcPayload(
   payload: unknown,
@@ -139,25 +192,87 @@ export function truncateRpcPayload(
     return marker;
   }
 
-  const preserved: Record<string, unknown> = {};
-  let preservedBytes = 0;
-  for (const key in payload) {
-    if (!Object.hasOwn(payload, key)) continue;
-    const value = (payload as Record<string, unknown>)[key];
-    const isShortScalar =
-      value === null ||
-      typeof value === "number" ||
-      typeof value === "boolean" ||
-      (typeof value === "string" && value.length <= MAX_PRESERVED_STRING_CHARS);
-    // The nested marker carries no `limitBytes`; the top level states it once.
-    preserved[key] = isShortScalar ? value : { _truncated: true };
-    // Stop building the envelope the moment it can no longer fit, rather than
-    // materializing one entry per key and rejecting the result afterwards: a
-    // pathologically wide frame would allocate the whole thing first.
-    preservedBytes +=
-      key.length + 4 + probeSerializedSize(preserved[key], limitBytes).bytes;
-    if (preservedBytes > limitBytes) return marker;
-  }
+  let spent = 0;
+  let nodes = 0;
+  /**
+   * The containers currently on the path from the root, so a self-reference
+   * becomes one marker instead of {@link MAX_SHRINK_DEPTH} levels of nesting.
+   * Entries are removed on the way back out: a value referenced twice as
+   * SIBLINGS is not a cycle, and dropping the second copy would hide a field
+   * that was perfectly renderable.
+   */
+  const path = new Set<object>();
+
+  /** The nested marker carries no `limitBytes`; the top level states it once. */
+  const dropped = (bytes?: number): TruncatedRpcPayload =>
+    bytes === undefined ? { _truncated: true } : { _truncated: true, bytes };
+
+  const shrink = (value: unknown, depth: number): unknown => {
+    if (++nodes > MAX_PROBE_NODES) return dropped();
+
+    if (typeof value === "string") {
+      if (
+        value.length <= MAX_PRESERVED_STRING_CHARS &&
+        spent + value.length + 2 <= limitBytes
+      ) {
+        spent += value.length + 2;
+        return value;
+      }
+      if (spent + STRING_HEAD_CHARS + STRING_MARKER_OVERHEAD <= limitBytes) {
+        spent += STRING_HEAD_CHARS + STRING_MARKER_OVERHEAD;
+        return {
+          _truncated: true,
+          bytes: value.length,
+          head: value.slice(0, STRING_HEAD_CHARS),
+        };
+      }
+      spent += STRING_MARKER_OVERHEAD;
+      return dropped(value.length);
+    }
+
+    if (value === null || typeof value !== "object") {
+      spent += 5;
+      return value;
+    }
+
+    if (depth >= MAX_SHRINK_DEPTH || path.has(value)) return dropped();
+    path.add(value);
+
+    if (Array.isArray(value)) {
+      spent += 2;
+      const out: unknown[] = [];
+      for (const item of value) {
+        spent += 1;
+        if (spent > limitBytes) {
+          path.delete(value);
+          return dropped();
+        }
+        out.push(shrink(item, depth + 1));
+      }
+      path.delete(value);
+      return out;
+    }
+
+    spent += 2;
+    const out: Record<string, unknown> = {};
+    for (const key in value as Record<string, unknown>) {
+      if (!Object.hasOwn(value, key)) continue;
+      spent += key.length + 4;
+      if (spent > limitBytes) {
+        path.delete(value);
+        return dropped();
+      }
+      out[key] = shrink((value as Record<string, unknown>)[key], depth + 1);
+    }
+    path.delete(value);
+    return out;
+  };
+
+  const shrunk = shrink(payload, 0);
+  const preserved =
+    isTruncatedRpcPayload(shrunk) || typeof shrunk !== "object" || shrunk === null
+      ? {}
+      : (shrunk as Record<string, unknown>);
   // Marker last: it must win over any same-named field on the frame.
   const truncated = { ...preserved, ...marker };
 
@@ -189,8 +304,15 @@ function formatBytes(bytes: number): string {
 }
 
 /**
- * One line explaining why a row has no body. Reads the same whichever producer
- * dropped it, and says what the reader lost rather than that something failed.
+ * One line explaining why a row has no body — or, now, a partial one. Reads the
+ * same whichever producer dropped it, and says what the reader lost rather than
+ * that something failed.
+ *
+ * "Not recorded" and "truncated" are deliberately different words. A reader who
+ * sees the first 8 KB of a value needs to know the rest exists somewhere; a
+ * reader who sees nothing needs to know the row never carried a body at all.
+ * One line for both states cannot say which of the two happened, and the
+ * difference is what tells a shortened row apart from an empty response.
  */
 export function describeTruncatedRpcPayload(
   payload: TruncatedRpcPayload,
@@ -206,5 +328,12 @@ export function describeTruncatedRpcPayload(
     typeof payload.bytes === "number"
       ? ` It was ${formatBytes(payload.bytes)}.`
       : "";
+  if (typeof payload.head === "string") {
+    // No claim about where the rest is: this module describes frames of every
+    // kind, and only SOME of them have a tool-result card holding the original.
+    return `Payload truncated — ${limit}.${size} Showing the first ${formatBytes(
+      payload.head.length,
+    )}.`;
+  }
   return `Payload not recorded — ${limit}.${size}`;
 }


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Fixes BB-96 by raising the RPC log per-frame cap from 256 KB to 1 MB and reworking truncation so oversized payloads keep a readable head, their true size, and short fields like error codes and `_meta` instead of collapsing to a bare marker. Response delivery is unaffected — only the Logs row is shortened; the tool-result card still renders the full response.

**Bug Fixes**

- Server and client caps both move to 1 MB and must stay in sync.
- Truncation descends into dropped fields, keeping the first 8 KB of an oversized string and its byte count.
- Sizes are now serialized UTF-8 bytes, not UTF-16 `length`, so CJK and control characters are no longer undercounted; the walk terminates on cycles and always stays under the limit.
- The notice says "truncated" when a head survives, "not recorded" only when nothing did, and never lets a frame's own fields supply the marker's metadata.
- The client store now evicts oldest rows past a total 8 MB, mirroring the server bus.

<sup>Written for commit c6be6567cb25091c1f3f243b32e9780930b1a6d7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/MCPJam/inspector/pull/4458?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

