### PR TITLE
fix(webmcp): thread page-tool approval into chat-v2's hosted engines

### DIFF
--- a/mcpjam-inspector/server/routes/mcp/chat-v2.ts
+++ b/mcpjam-inspector/server/routes/mcp/chat-v2.ts
@@ -125,6 +125,7 @@ import {
   markLocalScopeStepUpWireStarted,
 } from "../../utils/scope-step-up-continuation.js";
 import { executeToolCallsFromMessages } from "@/shared/http-tool-calls";
+import { classifyPageToolApprovals } from "@/shared/client-fulfilled-tools";
 import type {
   MrtrChatResumeResolution,
   MrtrEngineResume,
@@ -1389,6 +1390,18 @@ chatV2.post("/", async (c) => {
       progressivePlan,
       discoveryState,
     } = prepared;
+    // The hosted engines (MCPJam-free and hosted-org) classify tool approval by
+    // NAME and never read a tool's own `needsApproval`, so page tools reach them
+    // approval-less unless we hand over their classification here. Page tools
+    // always gate; an empty set (no page tools, incl. every hosted-mode turn
+    // where WEBMCP_INSPECTOR_ENABLED is off) leaves all other tools on the
+    // existing `requireToolApproval` path unchanged. Without this the turn
+    // strands — the client defers the call awaiting an approval pill the server
+    // never sends. `uiTools` are ignored on this route (see above), so the page
+    // classification is the whole of this turn's `uiToolApprovals`.
+    const pageToolApprovals = classifyPageToolApprovals(
+      validatedPageTools.map((entry) => entry.alias),
+    );
     const authenticatedUserId = c.var.requestLogContext?.userId ?? null;
     const scopeStepUpBindingKey = JSON.stringify([
       authenticatedUserId ?? "local-anonymous",
@@ -1536,6 +1549,7 @@ chatV2.post("/", async (c) => {
         mcpClientManager,
         selectedServers,
         requireToolApproval,
+        uiToolApprovals: pageToolApprovals,
         modelVisibleMcpToolResults,
         // Harness engine only: it builds its own MCP tool set (host-executed
         // delivery) rather than consuming `allTools`, so the host's
@@ -1803,6 +1817,7 @@ chatV2.post("/", async (c) => {
         selectedServers,
         serverIds: hostConfigServerIds,
         requireToolApproval,
+        uiToolApprovals: pageToolApprovals,
         modelVisibleMcpToolResults,
         scopeStepUpResume: scopeStepUpEngineResume,
         abortSignal: inboundAbortSignalOrg,

--- a/mcpjam-inspector/server/utils/__tests__/mcpjam-stream-handler.test.ts
+++ b/mcpjam-inspector/server/utils/__tests__/mcpjam-stream-handler.test.ts
@@ -3,7 +3,10 @@ import {
   executeToolCallsFromMessages,
   hasUnresolvedToolCalls,
 } from "@/shared/http-tool-calls";
-import { classifyUiToolApprovals } from "@/shared/client-fulfilled-tools";
+import {
+  classifyPageToolApprovals,
+  classifyUiToolApprovals,
+} from "@/shared/client-fulfilled-tools";
 import { handleMCPJamFreeChatModel } from "../mcpjam-stream-handler";
 import { serializeToolsForConvex } from "../mcpjam-tool-helpers";
 import { createHostedRpcLogCollector } from "../../routes/web/hosted-rpc-logs.js";
@@ -1948,6 +1951,80 @@ describe("mcpjam-stream-handler", () => {
       for (const call of calls) {
         expect((call[1] as any)?.filterToolName).toBeUndefined();
       }
+    });
+
+    it("emits an approval request for a page_* tool with the flag OFF (via classifyPageToolApprovals)", async () => {
+      // Page tools always gate. With their classification threaded in, the
+      // hosted gate emits a pill even though requireToolApproval is off (the
+      // default on the WebMCP Inspector surface).
+      global.fetch = vi.fn().mockResolvedValue(
+        createSseResponse([
+          {
+            type: "tool-input-available",
+            toolCallId: "call-page-1",
+            toolName: "page_ab12cd34",
+            input: { text: "hi" },
+          },
+          { type: "finish", finishReason: "stop" },
+        ])
+      );
+
+      await handleMCPJamFreeChatModel({
+        messages: [{ role: "user", content: "use the page tool" }] as any,
+        modelId: "gpt-4.1-mini",
+        systemPrompt: "You are helpful",
+        tools: { page_ab12cd34: {} } as any,
+        mcpClientManager: {
+          getAllToolsMetadata: vi.fn().mockReturnValue({}),
+        } as any,
+        requireToolApproval: false,
+        uiToolApprovals: classifyPageToolApprovals(["page_ab12cd34"]),
+      });
+
+      await lastExecution;
+
+      const approvalRequests = writtenChunks.filter(
+        (chunk: any) => chunk.type === "tool-approval-request"
+      );
+      expect(approvalRequests).toHaveLength(1);
+      expect(approvalRequests[0]).toMatchObject({ toolCallId: "call-page-1" });
+    });
+
+    it("STRANDS a page_* call when no classification is threaded (the bug this fix closes)", async () => {
+      // Regression guard for the pre-fix chat-v2 behavior: with no
+      // uiToolApprovals and the flag off, the hosted gate emitted no pill while
+      // the client had already deferred the call awaiting one — a turn that
+      // waits forever. This asserts the broken shape so a revert fails here.
+      global.fetch = vi.fn().mockResolvedValue(
+        createSseResponse([
+          {
+            type: "tool-input-available",
+            toolCallId: "call-page-strand",
+            toolName: "page_ab12cd34",
+            input: { text: "hi" },
+          },
+          { type: "finish", finishReason: "stop" },
+        ])
+      );
+
+      await handleMCPJamFreeChatModel({
+        messages: [{ role: "user", content: "use the page tool" }] as any,
+        modelId: "gpt-4.1-mini",
+        systemPrompt: "You are helpful",
+        tools: { page_ab12cd34: {} } as any,
+        mcpClientManager: {
+          getAllToolsMetadata: vi.fn().mockReturnValue({}),
+        } as any,
+        requireToolApproval: false,
+        // uiToolApprovals deliberately omitted — the pre-fix chat-v2 shape.
+      });
+
+      await lastExecution;
+
+      const approvalRequests = writtenChunks.filter(
+        (chunk: any) => chunk.type === "tool-approval-request"
+      );
+      expect(approvalRequests).toHaveLength(0);
     });
 
     it("a resume turn with a client tool-result + dangling approval-request proceeds to the model", async () => {

--- a/mcpjam-inspector/shared/__tests__/client-fulfilled-tools.test.ts
+++ b/mcpjam-inspector/shared/__tests__/client-fulfilled-tools.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "vitest";
 import {
+  classifyPageToolApprovals,
   classifyUiToolApprovals,
   isAppToolAlias,
   isClientFulfilledToolName,
@@ -240,6 +241,34 @@ describe("client-fulfilled tool names", () => {
       expect([...classifyUiToolApprovals(legacy, true).requiredNames]).toEqual([
         "ui_navigate",
       ]);
+    });
+  });
+
+  describe("classifyPageToolApprovals", () => {
+    it("puts every page alias in requiredNames, regardless of the approval flag", () => {
+      // Page tools always gate (pageToolCallNeedsApproval), so unlike UI tools
+      // the requireToolApproval flag never moves them to freeNames. This is the
+      // property the hosted engines rely on to emit an approval request instead
+      // of stranding the deferred call.
+      const aliases = ["page_ab12cd34", "page_ef56gh78"];
+      const { requiredNames, freeNames } = classifyPageToolApprovals(aliases);
+      expect([...requiredNames].sort()).toEqual([...aliases].sort());
+      expect(freeNames.size).toBe(0);
+    });
+
+    it("returns empty sets for no page tools, leaving other tools on the flag", () => {
+      for (const input of [undefined, []]) {
+        const { requiredNames, freeNames } = classifyPageToolApprovals(input);
+        expect(requiredNames.size).toBe(0);
+        expect(freeNames.size).toBe(0);
+      }
+    });
+
+    it("marks a page alias as requiring approval the way the hosted gate reads it", () => {
+      // Mirrors toolCallNeedsApproval in mcpjam-stream-handler:
+      //   if (uiToolApprovals?.requiredNames.has(name)) return true;
+      const { requiredNames } = classifyPageToolApprovals(["page_deadbeef"]);
+      expect(requiredNames.has("page_deadbeef")).toBe(true);
     });
   });
 });

--- a/mcpjam-inspector/shared/client-fulfilled-tools.ts
+++ b/mcpjam-inspector/shared/client-fulfilled-tools.ts
@@ -211,3 +211,31 @@ export function classifyUiToolApprovals(
   }
   return { requiredNames, freeNames };
 }
+
+/**
+ * Per-turn approval classification for a turn's WebMCP `page_*` tools.
+ *
+ * Page tools are client-fulfilled (the browser runs them) and ALWAYS gate — see
+ * `pageToolCallNeedsApproval`. The hosted engines classify by name via
+ * `toolCallNeedsApproval` and never read a tool's own `needsApproval`, so a turn
+ * that advertises page tools MUST hand them this classification. Without it,
+ * every page alias falls through to the `requireToolApproval` default (off by
+ * default), the server emits no approval request, and the turn strands: the
+ * client has already deferred the call awaiting an approval pill that never
+ * comes. (The BYOK `streamText` path is unaffected — it honors the per-tool
+ * `needsApproval` that `buildPageTools` bakes in.)
+ *
+ * Page aliases are collision-free by construction, so the advertised names are
+ * exactly the turn's validated aliases. Routing through `pageToolCallNeedsApproval`
+ * keeps this the single source of truth rather than hard-coding "always gate".
+ */
+export function classifyPageToolApprovals(
+  aliases: readonly string[] | undefined,
+): UiToolApprovalClassification {
+  const requiredNames = new Set<string>();
+  const freeNames = new Set<string>();
+  for (const alias of aliases ?? []) {
+    (pageToolCallNeedsApproval() ? requiredNames : freeNames).add(alias);
+  }
+  return { requiredNames, freeNames };
+}


### PR DESCRIPTION
The hosted engines (MCPJam-free and hosted-org) classify tool approval by NAME via `toolCallNeedsApproval` and never read a tool's own `needsApproval`. chat-v2 advertised `page_*` tools but passed no `uiToolApprovals`, so every page call fell through to the `requireToolApproval` default (off) — the server emitted no approval request while the client had already deferred the call awaiting a pill, stranding the turn forever. This bit the live WebMCP Inspector surface with a hosted MCPJam model.

- shared/client-fulfilled-tools.ts: `classifyPageToolApprovals` — the single source that routes page aliases through `pageToolCallNeedsApproval` (always gate). Aliases are collision-free, so advertised names = validated aliases.
- chat-v2.ts: build it from the validated page tools and thread it into both hosted-engine calls. Empty when there are no page tools (every hosted-mode turn, where WEBMCP_INSPECTOR_ENABLED is off), leaving all other tools on the existing `requireToolApproval` path unchanged. The BYOK streamText path was already correct (it honors the per-tool `needsApproval` buildPageTools bakes in).

Tests: unit coverage for the classifier, plus stream-handler cases proving a page tool gates with the flag OFF when the classification is threaded, and a regression guard asserting the pre-fix shape (no classification) strands.


Claude-Session: https://claude.ai/code/session_01RY7NKoBrR8WCc6sA5rYThK

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches hosted chat tool-approval gating for WebMCP page tools; behavior is narrow (only advertised `page_*` aliases) but fixes a user-visible hang on a live surface.
> 
> **Overview**
> Fixes **stuck WebMCP Inspector turns** when a hosted MCPJam model calls a `page_*` tool: the client defers execution for approval, but the server never sent an approval pill.
> 
> Adds **`classifyPageToolApprovals`** so every validated page alias lands in `uiToolApprovals.requiredNames` (page tools always gate via `pageToolCallNeedsApproval`, independent of `requireToolApproval`). **`chat-v2`** builds that from validated page tools and passes **`uiToolApprovals: pageToolApprovals`** into **`handleMCPJamFreeChatModel`** and **`handleHostedOrgChatModel`**. Turns with no page tools get empty sets, so other tools still follow the existing flag. Direct BYOK **`streamText`** is unchanged.
> 
> Tests cover the classifier and hosted-stream behavior (approval with flag off when classification is present; regression that omitting it emits no approval).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f480d57316d21ac16042188cb02d5e4abcf7754a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes page-tool approval in chat-v2's hosted engines so page calls no longer strand the turn. The hosted engines classify tool approval by name and never read a tool's own `needsApproval`, so `page_*` tools fell through to the off-by-default approval check: the server emitted no approval request while the client waited for a pill that never came. Now the approval classification is threaded into both hosted-engine calls, and page tools always require approval regardless of the `requireToolApproval` flag.

**Bug Fixes**
- Adds `classifyPageToolApprovals` as the single approval source for page aliases; aliases are collision-free, so advertised names are exactly the validated set.
- Threads it into the MCPJam-free and hosted-org engine calls; empty when there are no page tools, leaving all other tools on the existing path unchanged.
- Leaves the BYOK `streamText` path untouched — it already honors the per-tool `needsApproval` that `buildPageTools` bakes in.
- Tests cover the classifier and a regression guard asserting the pre-fix shape strands the turn.

<sup>Written for commit f480d57316d21ac16042188cb02d5e4abcf7754a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/MCPJam/inspector/pull/4466?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

