### PR TITLE
feat(browserd): W1(a) — canonical protocol + at-most-once command queue

### DIFF
--- a/mcpjam-inspector/server/services/browserd/daemon/__tests__/command-queue.test.ts
+++ b/mcpjam-inspector/server/services/browserd/daemon/__tests__/command-queue.test.ts
@@ -1,0 +1,163 @@
+import { describe, expect, it } from "vitest";
+import { CommandQueue, type CommandExecutor } from "../command-queue";
+import type { BrowserCommand, BrowserCommandResult } from "../../protocol";
+
+const tick = () => new Promise((r) => setTimeout(r, 0));
+
+/**
+ * A controllable fake executor. The queue invokes the executor one microtask
+ * after `submit` (it chains onto the per-tab FIFO), so `release` waits until the
+ * call for a given commandId has actually arrived before resolving it — no
+ * hand-tuned tick counting in each test.
+ */
+function controllableExecutor() {
+  const calls: BrowserCommand[] = [];
+  const resolvers = new Map<string, (r: BrowserCommandResult) => void>();
+  const executor: CommandExecutor = (command) => {
+    calls.push(command);
+    return new Promise<BrowserCommandResult>((resolve) => {
+      resolvers.set(command.commandId, resolve);
+    });
+  };
+  async function release(commandId: string, result: BrowserCommandResult) {
+    for (let i = 0; i < 100 && !resolvers.has(commandId); i++) await tick();
+    const resolve = resolvers.get(commandId);
+    if (!resolve) throw new Error(`executor never called for ${commandId}`);
+    resolve(result);
+  }
+  return { executor, calls, release };
+}
+
+function cmd(
+  commandId: string,
+  overrides: Partial<BrowserCommand> = {},
+): BrowserCommand {
+  return {
+    commandId,
+    source: "chat",
+    action: { kind: "observe", mode: "url" },
+    ...overrides,
+  };
+}
+
+describe("browserd CommandQueue", () => {
+  it("executes an unseen commandId once and returns its result (rule 1)", async () => {
+    const { executor, calls, release } = controllableExecutor();
+    const q = new CommandQueue(executor, "boot-a");
+    const p = q.submit(cmd("c1"));
+    await release("c1", { ok: true, output: "https://x.test" });
+    expect(await p).toEqual({
+      status: "ok",
+      result: { ok: true, output: "https://x.test" },
+      bootId: "boot-a",
+    });
+    expect(calls).toHaveLength(1);
+  });
+
+  it("attaches a duplicate WHILE running to the one execution (rule 2)", async () => {
+    const { executor, calls, release } = controllableExecutor();
+    const q = new CommandQueue(executor, "boot-a");
+    const first = q.submit(cmd("c1"));
+    await tick(); // let the executor be invoked for c1
+    const dup = q.submit(cmd("c1")); // same id, still in flight
+    expect(calls).toHaveLength(1); // NOT executed twice
+    await release("c1", { ok: true, output: 42 });
+    const [a, b] = await Promise.all([first, dup]);
+    expect(a).toEqual(b);
+    expect(calls).toHaveLength(1);
+  });
+
+  it("returns the recorded result for a duplicate AFTER settle (rule 3)", async () => {
+    const { executor, calls, release } = controllableExecutor();
+    const q = new CommandQueue(executor, "boot-a");
+    const first = q.submit(cmd("c1"));
+    await release("c1", { ok: true, output: "done" });
+    await first;
+    const dup = await q.submit(cmd("c1"));
+    expect(dup).toMatchObject({ status: "ok", result: { output: "done" } });
+    expect(calls).toHaveLength(1); // never re-executed
+  });
+
+  it("serializes commands on the same tab (FIFO) but runs different tabs concurrently", async () => {
+    const { executor, calls, release } = controllableExecutor();
+    const q = new CommandQueue(executor, "boot-a");
+    q.submit(cmd("t1a", { tabId: "tab-1" }));
+    q.submit(cmd("t1b", { tabId: "tab-1" }));
+    q.submit(cmd("t2a", { tabId: "tab-2" }));
+    await tick();
+    // tab-1's second command must NOT start until the first settles; tab-2 runs
+    // immediately. So only t1a and t2a are in flight.
+    expect(calls.map((c) => c.commandId).sort()).toEqual(["t1a", "t2a"]);
+    await release("t1a", { ok: true });
+    await tick();
+    expect(calls.map((c) => c.commandId)).toContain("t1b"); // now t1b runs
+  });
+
+  it("rejects with `busy` at the per-queue depth cap (rule 1)", async () => {
+    const { executor } = controllableExecutor();
+    const q = new CommandQueue(executor, "boot-a", { perQueueDepthCap: 2 });
+    q.submit(cmd("a", { tabId: "tab-1" }));
+    q.submit(cmd("b", { tabId: "tab-1" }));
+    const third = await q.submit(cmd("c", { tabId: "tab-1" }));
+    expect(third).toEqual({ status: "busy", bootId: "boot-a" });
+  });
+
+  it("evicts the oldest settled result by LRU and reports a later duplicate as `expired` (rule 4)", async () => {
+    const { executor, release } = controllableExecutor();
+    const q = new CommandQueue(executor, "boot-a", { maxRetained: 1 });
+    const first = q.submit(cmd("c1"));
+    await release("c1", { ok: true, output: 1 });
+    await first;
+    const second = q.submit(cmd("c2"));
+    await release("c2", { ok: true, output: 2 }); // settling c2 evicts c1 (cap 1)
+    await second;
+    expect(q.retainedCount).toBe(1);
+    const dupOld = await q.submit(cmd("c1"));
+    expect(dupOld).toEqual({ status: "expired", bootId: "boot-a" });
+  });
+
+  it("expires a settled result after its TTL and never re-executes it (rule 4, TTL arm)", async () => {
+    const { executor, calls, release } = controllableExecutor();
+    let clock = 1_000;
+    const q = new CommandQueue(executor, "boot-a", {
+      retainTtlMs: 100,
+      now: () => clock,
+    });
+    const first = q.submit(cmd("c1"));
+    await release("c1", { ok: true, output: "x" });
+    await first;
+    clock += 101; // age the result past its TTL
+    const dup = await q.submit(cmd("c1"));
+    expect(dup).toEqual({ status: "expired", bootId: "boot-a" });
+    expect(calls).toHaveLength(1); // unknowable outcome — must NOT re-run
+  });
+
+  it("normalizes an executor that throws into a recorded {ok:false} result", async () => {
+    const executor: CommandExecutor = async () => {
+      throw new Error("cdp exploded");
+    };
+    const q = new CommandQueue(executor, "boot-a");
+    const outcome = await q.submit(cmd("c1"));
+    expect(outcome).toMatchObject({
+      status: "ok",
+      result: { ok: false, error: "cdp exploded" },
+    });
+    // A duplicate gets the same recorded failure, not a re-throw or re-run.
+    const dup = await q.submit(cmd("c1"));
+    expect(dup).toMatchObject({ result: { ok: false, error: "cdp exploded" } });
+  });
+
+  it("does not let one command's failure stall the rest of its tab's FIFO", async () => {
+    const results: BrowserCommandResult[] = [
+      { ok: false, error: "boom" },
+      { ok: true, output: "recovered" },
+    ];
+    let i = 0;
+    const executor: CommandExecutor = async () => results[i++];
+    const q = new CommandQueue(executor, "boot-a");
+    const a = await q.submit(cmd("a", { tabId: "tab-1" }));
+    const b = await q.submit(cmd("b", { tabId: "tab-1" }));
+    expect(a).toMatchObject({ result: { ok: false } });
+    expect(b).toMatchObject({ result: { ok: true, output: "recovered" } });
+  });
+});

--- a/mcpjam-inspector/server/services/browserd/daemon/__tests__/command-queue.test.ts
+++ b/mcpjam-inspector/server/services/browserd/daemon/__tests__/command-queue.test.ts
@@ -192,6 +192,13 @@ describe("browserd CommandQueue", () => {
     expect(
       () => new CommandQueue(executor, "b", { retainTtlMs: Infinity }),
     ).toThrow(RangeError);
+    expect(
+      () =>
+        new CommandQueue(executor, "b", {
+          maxRetained: 10,
+          maxCommandsPerBoot: 5, // must be >= maxRetained
+        }),
+    ).toThrow(RangeError);
   });
 
   it("evicts least-recently-USED, not merely oldest-settled (rule 3 recency)", async () => {
@@ -214,17 +221,52 @@ describe("browserd CommandQueue", () => {
     });
   });
 
-  it("bounds the tombstone set so a long-lived daemon cannot leak memory", async () => {
-    const { executor, release } = controllableExecutor();
+  it("keeps a tombstone for the whole boot so an evicted id is never re-run (P1)", async () => {
+    // The bug a count-bounded tombstone set would reintroduce: after enough
+    // distinct commands the oldest tombstone is dropped, and a delayed retry of
+    // that id re-runs a non-idempotent action. Tombstones must outlive the
+    // result cache for the full boot.
+    const { executor, calls, release } = controllableExecutor();
     const q = new CommandQueue(executor, "boot-a", { maxRetained: 2 });
-    for (let i = 0; i < 50; i++) {
+    for (let i = 0; i < 40; i++) {
       const id = `c${i}`;
       const p = q.submit(cmd(id));
       await release(id, { ok: true, output: i });
       await p;
     }
-    expect(q.retainedCount).toBeLessThanOrEqual(2);
-    expect(q.tombstoneCount).toBeLessThanOrEqual(2); // bounded by maxRetained
+    const callsBefore = calls.length;
+    // c0's RESULT was evicted long ago, but its tombstone remains.
+    expect(await q.submit(cmd("c0"))).toEqual({
+      status: "expired",
+      bootId: "boot-a",
+    });
+    expect(calls.length).toBe(callsBefore); // NOT re-executed
+    expect(q.tombstoneCount).toBeGreaterThan(2); // tombstones outlive the cache
+  });
+
+  it("refuses a NEW command at the per-boot ceiling rather than forgetting a tombstone", async () => {
+    const { executor, release } = controllableExecutor();
+    const q = new CommandQueue(executor, "boot-a", {
+      maxRetained: 2,
+      maxCommandsPerBoot: 3,
+    });
+    for (const id of ["a", "b", "c"]) {
+      const p = q.submit(cmd(id));
+      await release(id, { ok: true });
+      await p;
+    }
+    // 'a' was evicted from the 2-slot result cache but is tombstoned, so the
+    // boot ledger now tracks 3 ids (b, c live + a tombstoned) = the ceiling.
+    expect(await q.submit(cmd("d"))).toEqual({
+      status: "at_capacity",
+      bootId: "boot-a",
+    });
+    // A duplicate of an already-tracked id still resolves — capacity only gates
+    // genuinely new commands.
+    expect(await q.submit(cmd("a"))).toEqual({
+      status: "expired",
+      bootId: "boot-a",
+    });
   });
 
   it("does not let one command's failure stall the rest of its tab's FIFO", async () => {

--- a/mcpjam-inspector/server/services/browserd/daemon/__tests__/command-queue.test.ts
+++ b/mcpjam-inspector/server/services/browserd/daemon/__tests__/command-queue.test.ts
@@ -12,20 +12,29 @@ const tick = () => new Promise((r) => setTimeout(r, 0));
  */
 function controllableExecutor() {
   const calls: BrowserCommand[] = [];
-  const resolvers = new Map<string, (r: BrowserCommandResult) => void>();
+  const pending = new Map<
+    string,
+    { resolve: (r: BrowserCommandResult) => void; reject: (e: unknown) => void }
+  >();
   const executor: CommandExecutor = (command) => {
     calls.push(command);
-    return new Promise<BrowserCommandResult>((resolve) => {
-      resolvers.set(command.commandId, resolve);
+    return new Promise<BrowserCommandResult>((resolve, reject) => {
+      pending.set(command.commandId, { resolve, reject });
     });
   };
-  async function release(commandId: string, result: BrowserCommandResult) {
-    for (let i = 0; i < 100 && !resolvers.has(commandId); i++) await tick();
-    const resolve = resolvers.get(commandId);
-    if (!resolve) throw new Error(`executor never called for ${commandId}`);
-    resolve(result);
+  async function waitForCall(commandId: string) {
+    for (let i = 0; i < 100 && !pending.has(commandId); i++) await tick();
+    const p = pending.get(commandId);
+    if (!p) throw new Error(`executor never called for ${commandId}`);
+    return p;
   }
-  return { executor, calls, release };
+  async function release(commandId: string, result: BrowserCommandResult) {
+    (await waitForCall(commandId)).resolve(result);
+  }
+  async function throwFor(commandId: string, error: unknown) {
+    (await waitForCall(commandId)).reject(error);
+  }
+  return { executor, calls, release, throwFor };
 }
 
 function cmd(
@@ -145,6 +154,77 @@ describe("browserd CommandQueue", () => {
     // A duplicate gets the same recorded failure, not a re-throw or re-run.
     const dup = await q.submit(cmd("c1"));
     expect(dup).toMatchObject({ result: { ok: false, error: "cdp exploded" } });
+  });
+
+  it("gives a duplicate the SAME normalized result when the executor throws (rule 2, P1 regression)", async () => {
+    // The bug this guards: a duplicate attached while running used to await the
+    // raw rejected promise and reject, while the original caller caught the same
+    // failure and got a normalized {ok:false} outcome — two callers, two answers.
+    const { executor, calls, throwFor } = controllableExecutor();
+    const q = new CommandQueue(executor, "boot-a");
+    const first = q.submit(cmd("c1"));
+    await tick(); // executor invoked for c1
+    const dup = q.submit(cmd("c1")); // attached while running
+    await throwFor("c1", new Error("cdp exploded"));
+    const [a, b] = await Promise.all([first, dup]); // neither rejects
+    expect(a).toMatchObject({
+      status: "ok",
+      result: { ok: false, error: "cdp exploded" },
+    });
+    expect(b).toEqual(a);
+    expect(calls).toHaveLength(1);
+  });
+
+  it("rejects nonsensical constructor limits instead of looping forever", () => {
+    const { executor } = controllableExecutor();
+    expect(() => new CommandQueue(executor, "b", { maxRetained: -1 })).toThrow(
+      RangeError,
+    );
+    expect(() => new CommandQueue(executor, "b", { maxRetained: 1.5 })).toThrow(
+      RangeError,
+    );
+    expect(
+      () => new CommandQueue(executor, "b", { perQueueDepthCap: 0 }),
+    ).toThrow(RangeError);
+    expect(() => new CommandQueue(executor, "b", { retainTtlMs: -1 })).toThrow(
+      RangeError,
+    );
+    expect(
+      () => new CommandQueue(executor, "b", { retainTtlMs: Infinity }),
+    ).toThrow(RangeError);
+  });
+
+  it("evicts least-recently-USED, not merely oldest-settled (rule 3 recency)", async () => {
+    const { executor, release } = controllableExecutor();
+    const q = new CommandQueue(executor, "boot-a", { maxRetained: 2 });
+    for (const id of ["c1", "c2"]) {
+      const p = q.submit(cmd(id));
+      await release(id, { ok: true, output: id });
+      await p;
+    }
+    // Touch c1 so c2 is now the least-recently-used of the two.
+    expect(await q.submit(cmd("c1"))).toMatchObject({ status: "ok" });
+    const third = q.submit(cmd("c3"));
+    await release("c3", { ok: true, output: "c3" });
+    await third; // settling c3 must evict c2 (LRU), NOT c1 (FIFO would evict c1)
+    expect(await q.submit(cmd("c1"))).toMatchObject({ status: "ok" });
+    expect(await q.submit(cmd("c2"))).toEqual({
+      status: "expired",
+      bootId: "boot-a",
+    });
+  });
+
+  it("bounds the tombstone set so a long-lived daemon cannot leak memory", async () => {
+    const { executor, release } = controllableExecutor();
+    const q = new CommandQueue(executor, "boot-a", { maxRetained: 2 });
+    for (let i = 0; i < 50; i++) {
+      const id = `c${i}`;
+      const p = q.submit(cmd(id));
+      await release(id, { ok: true, output: i });
+      await p;
+    }
+    expect(q.retainedCount).toBeLessThanOrEqual(2);
+    expect(q.tombstoneCount).toBeLessThanOrEqual(2); // bounded by maxRetained
   });
 
   it("does not let one command's failure stall the rest of its tab's FIFO", async () => {

--- a/mcpjam-inspector/server/services/browserd/daemon/command-queue.ts
+++ b/mcpjam-inspector/server/services/browserd/daemon/command-queue.ts
@@ -9,9 +9,10 @@
  *      (one queue per tab serializes manual + chat + inspector + eval traffic;
  *      whole-session commands share one queue). At the depth cap → `busy` (429).
  *   2. Duplicate WHILE running → attach to the in-flight promise. One execution,
- *      both callers get the same result.
+ *      both callers get the same NORMALIZED result — even if the executor throws.
  *   3. Duplicate AFTER settle → return the recorded result (no re-execution).
- *      Results are retained LRU `maxRetained` / TTL `retainTtlMs`.
+ *      Results are retained LRU `maxRetained` / TTL `retainTtlMs`; a cache hit
+ *      refreshes recency, so eviction is genuinely least-recently-USED.
  *   4. Duplicate after the result was EVICTED → `expired` (409). Never re-run:
  *      the caller must treat the original outcome as unknown.
  *
@@ -43,8 +44,14 @@ function queueKeyFor(command: BrowserCommand): string {
   return command.tabId ?? "@session";
 }
 
+function normalizeError(err: unknown): BrowserCommandResult {
+  return { ok: false, error: err instanceof Error ? err.message : String(err) };
+}
+
 interface RunningEntry {
   state: "running";
+  /** Never rejects: an executor throw is normalized to `{ok:false}` here, so a
+   * duplicate awaiting this promise gets the same result as the first caller. */
   promise: Promise<BrowserCommandResult>;
 }
 interface SettledEntry {
@@ -64,14 +71,17 @@ export class CommandQueue {
 
   /** commandId → its running promise or settled result. */
   private readonly commands = new Map<string, CommandEntry>();
-  /** Insertion-ordered commandIds of SETTLED entries, for LRU eviction. */
+  /** Insertion/access-ordered commandIds of SETTLED entries, for LRU eviction. */
   private readonly settledOrder: string[] = [];
+  /** commandIds whose settled result was evicted (LRU/TTL): duplicates → expired.
+   * Bounded (see `tombstone`) so a long-lived daemon cannot leak memory. */
+  private readonly evicted = new Set<string>();
+  /** Insertion-ordered tombstones, for bounding `evicted`. */
+  private readonly evictedOrder: string[] = [];
   /** queueKey → tail of that FIFO, so the next command chains after it. */
   private readonly tails = new Map<string, Promise<unknown>>();
   /** queueKey → count of in-flight + queued commands, for the depth cap. */
   private readonly depth = new Map<string, number>();
-  /** commandIds whose settled result was evicted (LRU/TTL): duplicates → expired. */
-  private readonly evicted = new Set<string>();
 
   constructor(
     executor: CommandExecutor,
@@ -87,21 +97,32 @@ export class CommandQueue {
     this.perQueueDepthCap =
       options.perQueueDepthCap ?? DEFAULT_COMMAND_QUEUE_OPTIONS.perQueueDepthCap;
     this.now = options.now ?? Date.now;
+
+    // Reject nonsensical limits up front: e.g. `maxRetained: -1` would make
+    // `settle` loop forever (`0 > -1`), blocking the daemon event loop.
+    if (!Number.isInteger(this.maxRetained) || this.maxRetained < 0) {
+      throw new RangeError(`maxRetained must be an integer >= 0, got ${this.maxRetained}`);
+    }
+    if (!Number.isInteger(this.perQueueDepthCap) || this.perQueueDepthCap < 1) {
+      throw new RangeError(`perQueueDepthCap must be an integer >= 1, got ${this.perQueueDepthCap}`);
+    }
+    if (!Number.isFinite(this.retainTtlMs) || this.retainTtlMs < 0) {
+      throw new RangeError(`retainTtlMs must be a finite number >= 0, got ${this.retainTtlMs}`);
+    }
   }
 
   async submit(command: BrowserCommand): Promise<BrowserCommandOutcome> {
     const existing = this.lookup(command.commandId);
     if (existing) {
-      // Rules 2 & 3: de-duplicate to the one execution.
-      if (existing.state === "running") {
-        return { status: "ok", result: await existing.promise, bootId: this.bootId };
-      }
-      return { status: "ok", result: existing.result, bootId: this.bootId };
+      // Rules 2 & 3: de-duplicate to the one execution. The running promise is
+      // pre-normalized, so awaiting it here can never reject.
+      const result =
+        existing.state === "running" ? await existing.promise : existing.result;
+      return { status: "ok", result, bootId: this.bootId };
     }
 
-    // Rule 4: a commandId we retained the result for and then evicted is NOT
-    // safe to re-run. lookup() only removes EXPIRED (TTL) settled entries;
-    // eviction by LRU records a tombstone so a later duplicate is caught here.
+    // Rule 4: a commandId we retained a result for and then evicted is NOT safe
+    // to re-run — its outcome is unknowable.
     if (this.evicted.has(command.commandId)) {
       return { status: "expired", bootId: this.bootId };
     }
@@ -117,22 +138,22 @@ export class CommandQueue {
     // commands on the same tab run in order while different tabs run concurrently.
     this.depth.set(key, (this.depth.get(key) ?? 0) + 1);
     const prior = this.tails.get(key) ?? Promise.resolve();
-    const run = prior
+    const raw = prior
       .catch(() => undefined) // a prior command's failure must not stall the tab
       .then(() => this.executor(command));
-    this.tails.set(key, run);
-    this.commands.set(command.commandId, { state: "running", promise: run });
+    this.tails.set(key, raw);
+    // The shared promise both the first caller and any duplicate await. It
+    // resolves to a normalized result and NEVER rejects, so an executor throw
+    // yields the same `{ok:false}` outcome for everyone (rule 2).
+    const normalized = raw.then((r) => r, normalizeError);
+    this.commands.set(command.commandId, { state: "running", promise: normalized });
 
     let result: BrowserCommandResult;
     try {
-      result = await run;
-    } catch (err) {
-      // The executor threw rather than returning {ok:false}; normalize so the
-      // recorded outcome is a value, and a duplicate gets the same answer.
-      result = { ok: false, error: err instanceof Error ? err.message : String(err) };
+      result = await normalized;
     } finally {
       this.depth.set(key, (this.depth.get(key) ?? 1) - 1);
-      if (this.tails.get(key) === run) this.tails.delete(key);
+      if (this.tails.get(key) === raw) this.tails.delete(key);
     }
 
     this.settle(command.commandId, result);
@@ -144,6 +165,11 @@ export class CommandQueue {
     return this.settledOrder.length;
   }
 
+  /** Current tombstone count. Exposed for tests; bounded by `maxRetained`. */
+  get tombstoneCount(): number {
+    return this.evicted.size;
+  }
+
   private lookup(commandId: string): CommandEntry | undefined {
     const entry = this.commands.get(commandId);
     if (!entry) return undefined;
@@ -152,9 +178,12 @@ export class CommandQueue {
       // Rule 4 (TTL arm): the result aged out. Drop it and tombstone the id so a
       // duplicate is reported `expired`, never re-executed.
       this.dropSettled(commandId);
-      this.evicted.add(commandId);
+      this.tombstone(commandId);
       return undefined;
     }
+    // Rule 3: a cache hit refreshes recency so eviction is truly least-recently
+    // USED, not merely oldest-settled.
+    this.touchRecency(commandId);
     return entry;
   }
 
@@ -166,10 +195,18 @@ export class CommandQueue {
     });
     this.settledOrder.push(commandId);
     while (this.settledOrder.length > this.maxRetained) {
-      // Rule 4 (LRU arm): evict the oldest settled result and tombstone it.
+      // Rule 4 (LRU arm): evict the least-recently-used settled result.
       const evictedId = this.settledOrder.shift()!;
       this.commands.delete(evictedId);
-      this.evicted.add(evictedId);
+      this.tombstone(evictedId);
+    }
+  }
+
+  private touchRecency(commandId: string): void {
+    const idx = this.settledOrder.indexOf(commandId);
+    if (idx !== -1) {
+      this.settledOrder.splice(idx, 1);
+      this.settledOrder.push(commandId);
     }
   }
 
@@ -177,5 +214,22 @@ export class CommandQueue {
     this.commands.delete(commandId);
     const idx = this.settledOrder.indexOf(commandId);
     if (idx !== -1) this.settledOrder.splice(idx, 1);
+  }
+
+  /**
+   * Record a tombstone, keeping the set bounded by `maxRetained`. Unbounded
+   * tombstones would leak memory in a long-lived daemon. The tradeoff of the
+   * bound: once the OLDEST tombstone is dropped, a replay of that ancient
+   * commandId would be treated as unseen and re-run — acceptable because a
+   * realistic retry arrives within seconds (far inside the retained window), and
+   * cross-boot replays are already caught by the bootId check at the HTTP layer.
+   */
+  private tombstone(commandId: string): void {
+    if (this.evicted.has(commandId)) return;
+    this.evicted.add(commandId);
+    this.evictedOrder.push(commandId);
+    while (this.evictedOrder.length > this.maxRetained) {
+      this.evicted.delete(this.evictedOrder.shift()!);
+    }
   }
 }

--- a/mcpjam-inspector/server/services/browserd/daemon/command-queue.ts
+++ b/mcpjam-inspector/server/services/browserd/daemon/command-queue.ts
@@ -1,0 +1,181 @@
+/**
+ * The daemon's real at-most-once command queue.
+ *
+ * `computerCommands` in Convex is only a post-hoc, best-effort log (see
+ * `run-command.ts`), so the actual at-most-once guarantee has to live HERE, in
+ * the process that drives the browser. The rules, from the plan:
+ *
+ *   1. Unseen commandId  → claim it, execute on the command's per-queue FIFO
+ *      (one queue per tab serializes manual + chat + inspector + eval traffic;
+ *      whole-session commands share one queue). At the depth cap → `busy` (429).
+ *   2. Duplicate WHILE running → attach to the in-flight promise. One execution,
+ *      both callers get the same result.
+ *   3. Duplicate AFTER settle → return the recorded result (no re-execution).
+ *      Results are retained LRU `maxRetained` / TTL `retainTtlMs`.
+ *   4. Duplicate after the result was EVICTED → `expired` (409). Never re-run:
+ *      the caller must treat the original outcome as unknown.
+ *
+ * bootId staleness (a commandId replayed against a *different* daemon boot) is
+ * handled one layer up, at the HTTP boundary, before a command reaches this
+ * queue — a fresh boot has a fresh queue with no memory of the old id, so the
+ * daemon compares the caller's expected bootId to its own and rejects a mismatch
+ * as `command_unknown_boot`. This queue is per-boot by construction.
+ */
+import {
+  BrowserCommand,
+  BrowserCommandOutcome,
+  BrowserCommandResult,
+  CommandQueueOptions,
+  DEFAULT_COMMAND_QUEUE_OPTIONS,
+} from "../protocol";
+
+/**
+ * Executes one command against the real browser. The queue owns ordering and
+ * de-duplication; the executor owns the Chromium/CDP work. Injected so the queue
+ * is testable with a fake driver, the way `run-command.ts` injects `BashRunner`.
+ */
+export type CommandExecutor = (
+  command: BrowserCommand,
+) => Promise<BrowserCommandResult>;
+
+/** Which FIFO a command belongs to: its tab, or the session if tab-less. */
+function queueKeyFor(command: BrowserCommand): string {
+  return command.tabId ?? "@session";
+}
+
+interface RunningEntry {
+  state: "running";
+  promise: Promise<BrowserCommandResult>;
+}
+interface SettledEntry {
+  state: "settled";
+  result: BrowserCommandResult;
+  settledAt: number;
+}
+type CommandEntry = RunningEntry | SettledEntry;
+
+export class CommandQueue {
+  private readonly executor: CommandExecutor;
+  private readonly bootId: string;
+  private readonly maxRetained: number;
+  private readonly retainTtlMs: number;
+  private readonly perQueueDepthCap: number;
+  private readonly now: () => number;
+
+  /** commandId → its running promise or settled result. */
+  private readonly commands = new Map<string, CommandEntry>();
+  /** Insertion-ordered commandIds of SETTLED entries, for LRU eviction. */
+  private readonly settledOrder: string[] = [];
+  /** queueKey → tail of that FIFO, so the next command chains after it. */
+  private readonly tails = new Map<string, Promise<unknown>>();
+  /** queueKey → count of in-flight + queued commands, for the depth cap. */
+  private readonly depth = new Map<string, number>();
+  /** commandIds whose settled result was evicted (LRU/TTL): duplicates → expired. */
+  private readonly evicted = new Set<string>();
+
+  constructor(
+    executor: CommandExecutor,
+    bootId: string,
+    options: CommandQueueOptions = {},
+  ) {
+    this.executor = executor;
+    this.bootId = bootId;
+    this.maxRetained =
+      options.maxRetained ?? DEFAULT_COMMAND_QUEUE_OPTIONS.maxRetained;
+    this.retainTtlMs =
+      options.retainTtlMs ?? DEFAULT_COMMAND_QUEUE_OPTIONS.retainTtlMs;
+    this.perQueueDepthCap =
+      options.perQueueDepthCap ?? DEFAULT_COMMAND_QUEUE_OPTIONS.perQueueDepthCap;
+    this.now = options.now ?? Date.now;
+  }
+
+  async submit(command: BrowserCommand): Promise<BrowserCommandOutcome> {
+    const existing = this.lookup(command.commandId);
+    if (existing) {
+      // Rules 2 & 3: de-duplicate to the one execution.
+      if (existing.state === "running") {
+        return { status: "ok", result: await existing.promise, bootId: this.bootId };
+      }
+      return { status: "ok", result: existing.result, bootId: this.bootId };
+    }
+
+    // Rule 4: a commandId we retained the result for and then evicted is NOT
+    // safe to re-run. lookup() only removes EXPIRED (TTL) settled entries;
+    // eviction by LRU records a tombstone so a later duplicate is caught here.
+    if (this.evicted.has(command.commandId)) {
+      return { status: "expired", bootId: this.bootId };
+    }
+
+    const key = queueKeyFor(command);
+    if ((this.depth.get(key) ?? 0) >= this.perQueueDepthCap) {
+      // Rule 1: per-tab queue is saturated. Reject without touching the map, so
+      // the same commandId can be retried once the queue drains.
+      return { status: "busy", bootId: this.bootId };
+    }
+
+    // Rule 1: claim the id, then chain execution onto the per-queue FIFO so
+    // commands on the same tab run in order while different tabs run concurrently.
+    this.depth.set(key, (this.depth.get(key) ?? 0) + 1);
+    const prior = this.tails.get(key) ?? Promise.resolve();
+    const run = prior
+      .catch(() => undefined) // a prior command's failure must not stall the tab
+      .then(() => this.executor(command));
+    this.tails.set(key, run);
+    this.commands.set(command.commandId, { state: "running", promise: run });
+
+    let result: BrowserCommandResult;
+    try {
+      result = await run;
+    } catch (err) {
+      // The executor threw rather than returning {ok:false}; normalize so the
+      // recorded outcome is a value, and a duplicate gets the same answer.
+      result = { ok: false, error: err instanceof Error ? err.message : String(err) };
+    } finally {
+      this.depth.set(key, (this.depth.get(key) ?? 1) - 1);
+      if (this.tails.get(key) === run) this.tails.delete(key);
+    }
+
+    this.settle(command.commandId, result);
+    return { status: "ok", result, bootId: this.bootId };
+  }
+
+  /** Current retained-result count. Exposed for tests. */
+  get retainedCount(): number {
+    return this.settledOrder.length;
+  }
+
+  private lookup(commandId: string): CommandEntry | undefined {
+    const entry = this.commands.get(commandId);
+    if (!entry) return undefined;
+    if (entry.state === "running") return entry;
+    if (this.now() - entry.settledAt > this.retainTtlMs) {
+      // Rule 4 (TTL arm): the result aged out. Drop it and tombstone the id so a
+      // duplicate is reported `expired`, never re-executed.
+      this.dropSettled(commandId);
+      this.evicted.add(commandId);
+      return undefined;
+    }
+    return entry;
+  }
+
+  private settle(commandId: string, result: BrowserCommandResult): void {
+    this.commands.set(commandId, {
+      state: "settled",
+      result,
+      settledAt: this.now(),
+    });
+    this.settledOrder.push(commandId);
+    while (this.settledOrder.length > this.maxRetained) {
+      // Rule 4 (LRU arm): evict the oldest settled result and tombstone it.
+      const evictedId = this.settledOrder.shift()!;
+      this.commands.delete(evictedId);
+      this.evicted.add(evictedId);
+    }
+  }
+
+  private dropSettled(commandId: string): void {
+    this.commands.delete(commandId);
+    const idx = this.settledOrder.indexOf(commandId);
+    if (idx !== -1) this.settledOrder.splice(idx, 1);
+  }
+}

--- a/mcpjam-inspector/server/services/browserd/daemon/command-queue.ts
+++ b/mcpjam-inspector/server/services/browserd/daemon/command-queue.ts
@@ -67,6 +67,7 @@ export class CommandQueue {
   private readonly maxRetained: number;
   private readonly retainTtlMs: number;
   private readonly perQueueDepthCap: number;
+  private readonly maxCommandsPerBoot: number;
   private readonly now: () => number;
 
   /** commandId → its running promise or settled result. */
@@ -74,10 +75,10 @@ export class CommandQueue {
   /** Insertion/access-ordered commandIds of SETTLED entries, for LRU eviction. */
   private readonly settledOrder: string[] = [];
   /** commandIds whose settled result was evicted (LRU/TTL): duplicates → expired.
-   * Bounded (see `tombstone`) so a long-lived daemon cannot leak memory. */
+   * Kept for the FULL boot — forgetting one would let a delayed retry re-run a
+   * non-idempotent action. Growth is bounded by refusing new commands at
+   * `maxCommandsPerBoot`, not by dropping tombstones. */
   private readonly evicted = new Set<string>();
-  /** Insertion-ordered tombstones, for bounding `evicted`. */
-  private readonly evictedOrder: string[] = [];
   /** queueKey → tail of that FIFO, so the next command chains after it. */
   private readonly tails = new Map<string, Promise<unknown>>();
   /** queueKey → count of in-flight + queued commands, for the depth cap. */
@@ -96,6 +97,9 @@ export class CommandQueue {
       options.retainTtlMs ?? DEFAULT_COMMAND_QUEUE_OPTIONS.retainTtlMs;
     this.perQueueDepthCap =
       options.perQueueDepthCap ?? DEFAULT_COMMAND_QUEUE_OPTIONS.perQueueDepthCap;
+    this.maxCommandsPerBoot =
+      options.maxCommandsPerBoot ??
+      DEFAULT_COMMAND_QUEUE_OPTIONS.maxCommandsPerBoot;
     this.now = options.now ?? Date.now;
 
     // Reject nonsensical limits up front: e.g. `maxRetained: -1` would make
@@ -108,6 +112,16 @@ export class CommandQueue {
     }
     if (!Number.isFinite(this.retainTtlMs) || this.retainTtlMs < 0) {
       throw new RangeError(`retainTtlMs must be a finite number >= 0, got ${this.retainTtlMs}`);
+    }
+    // The per-boot ceiling must admit at least the result cache, or a full cache
+    // would wedge the daemon at capacity with no room for tombstones.
+    if (
+      !Number.isInteger(this.maxCommandsPerBoot) ||
+      this.maxCommandsPerBoot < this.maxRetained
+    ) {
+      throw new RangeError(
+        `maxCommandsPerBoot must be an integer >= maxRetained (${this.maxRetained}), got ${this.maxCommandsPerBoot}`,
+      );
     }
   }
 
@@ -125,6 +139,14 @@ export class CommandQueue {
     // to re-run — its outcome is unknowable.
     if (this.evicted.has(command.commandId)) {
       return { status: "expired", bootId: this.bootId };
+    }
+
+    // A genuinely NEW command adds one more id we must remember for the whole
+    // boot (as a returnable result, then as a tombstone). At the ceiling we
+    // refuse rather than forget a tombstone: forgetting one would let a delayed
+    // retry re-run a non-idempotent action. The daemon should rotate.
+    if (this.distinctTrackedCount >= this.maxCommandsPerBoot) {
+      return { status: "at_capacity", bootId: this.bootId };
     }
 
     const key = queueKeyFor(command);
@@ -165,9 +187,19 @@ export class CommandQueue {
     return this.settledOrder.length;
   }
 
-  /** Current tombstone count. Exposed for tests; bounded by `maxRetained`. */
+  /** Current tombstone count. Exposed for tests. */
   get tombstoneCount(): number {
     return this.evicted.size;
+  }
+
+  /**
+   * Distinct commandIds this boot is obligated to remember: live results/running
+   * entries plus tombstones. Every distinct command contributes exactly one
+   * (a settled result becomes a tombstone on eviction — one leaves `commands`,
+   * one enters `evicted`), so this is monotonic and the memory ceiling.
+   */
+  private get distinctTrackedCount(): number {
+    return this.commands.size + this.evicted.size;
   }
 
   private lookup(commandId: string): CommandEntry | undefined {
@@ -217,19 +249,12 @@ export class CommandQueue {
   }
 
   /**
-   * Record a tombstone, keeping the set bounded by `maxRetained`. Unbounded
-   * tombstones would leak memory in a long-lived daemon. The tradeoff of the
-   * bound: once the OLDEST tombstone is dropped, a replay of that ancient
-   * commandId would be treated as unseen and re-run — acceptable because a
-   * realistic retry arrives within seconds (far inside the retained window), and
-   * cross-boot replays are already caught by the bootId check at the HTTP layer.
+   * Tombstone a commandId for the rest of the boot. Deliberately never dropped:
+   * a delayed retry of any evicted id must return `expired`, never re-run. Total
+   * tombstones are bounded because `submit` refuses NEW commands once
+   * `distinctTrackedCount` reaches `maxCommandsPerBoot`.
    */
   private tombstone(commandId: string): void {
-    if (this.evicted.has(commandId)) return;
     this.evicted.add(commandId);
-    this.evictedOrder.push(commandId);
-    while (this.evictedOrder.length > this.maxRetained) {
-      this.evicted.delete(this.evictedOrder.shift()!);
-    }
   }
 }

--- a/mcpjam-inspector/server/services/browserd/protocol.ts
+++ b/mcpjam-inspector/server/services/browserd/protocol.ts
@@ -1,0 +1,122 @@
+/**
+ * The canonical `mcpjam-browserd` wire protocol.
+ *
+ * browserd is the sandbox-local daemon that drives Chromium for the Hosted
+ * Browser + WebMCP Runtime. This file is the ONE source of truth for its API;
+ * the W5 hosted conversion re-derives the V1 WebMCP Inspector protocol from it
+ * rather than the other way round (see the `webmcp-hosted-runtime` skill). It is
+ * intentionally transport-agnostic and free of Playwright/E2B imports so it can
+ * be bundled into the daemon and imported by the inspector server alike.
+ *
+ * The command envelope mirrors V1's `POST /sessions/:id/command`
+ * (`shared/webmcp-inspector-protocol.ts`) so the W5 mapping is thin, while
+ * widening the action set to what the six `browser_*` model tools need.
+ */
+
+/**
+ * A random id minted once per browserd process start and echoed on every
+ * response. The inspector stores the last-seen value; a command replayed against
+ * a DIFFERENT bootId is rejected (`command_unknown_boot`) rather than silently
+ * re-run, because the first execution's outcome across a restart is unknowable —
+ * re-executing would be a lie. See the command-queue idempotency rules.
+ */
+export type BootId = string;
+
+/** Where a command originated. All sources share one per-tab queue and timeline. */
+export type BrowserCommandSource = "manual" | "chat" | "inspector" | "eval";
+
+/** A selector target for a `browser_act` verb. */
+export type BrowserActTarget =
+  | { coordinates: [number, number] }
+  | { selector: string }
+  | { a11yRef: string };
+
+export type BrowserAction =
+  | { kind: "navigate"; url: string; newTab?: boolean }
+  | { kind: "back" }
+  | { kind: "reload" }
+  | {
+      kind: "act";
+      verb:
+        | "click"
+        | "type"
+        | "press"
+        | "scroll"
+        | "hover"
+        | "drag"
+        | "select"
+        | "close_tab"
+        | "activate_tab";
+      target?: BrowserActTarget;
+      value?: string;
+    }
+  | {
+      kind: "observe";
+      mode:
+        | "screenshot"
+        | "dom"
+        | "a11y"
+        | "console"
+        | "url"
+        | "webmcp_tools";
+    }
+  | { kind: "webmcp_invoke"; toolKey: string; input: unknown }
+  | { kind: "webmcp_cancel"; invocationId: string };
+
+/**
+ * One command envelope. `commandId` is the idempotency key: the daemon executes
+ * a given `commandId` AT MOST ONCE per boot, no matter how many times it is
+ * submitted (retries, replica races). `tabId` selects the per-tab FIFO queue;
+ * omit it for whole-session commands, which share a session-level queue.
+ */
+export interface BrowserCommand {
+  commandId: string;
+  tabId?: string;
+  source: BrowserCommandSource;
+  action: BrowserAction;
+}
+
+/** The daemon's result for one executed command. Opaque to the queue. */
+export interface BrowserCommandResult {
+  ok: boolean;
+  /** Present on success; shape depends on the action. */
+  output?: unknown;
+  /** Present when `ok` is false. */
+  error?: string;
+}
+
+/**
+ * The outcome the queue hands back to the HTTP layer, which maps it to a status
+ * code. Distinct from `BrowserCommandResult`: a command can be rejected
+ * (busy/expired) without ever executing.
+ */
+export type BrowserCommandOutcome =
+  /** Executed (or de-duplicated to a prior execution). Carries the result. */
+  | { status: "ok"; result: BrowserCommandResult; bootId: BootId }
+  /** Per-tab queue is at its depth cap; the caller should retry later. → 429 */
+  | { status: "busy"; bootId: BootId }
+  /**
+   * The command settled earlier but its result has since been evicted (LRU/TTL),
+   * so it can be neither returned nor safely re-run. → 409 `command_expired`
+   */
+  | { status: "expired"; bootId: BootId };
+
+/** The idempotency/eviction knobs, all overridable for tests. */
+export interface CommandQueueOptions {
+  /** Max settled results retained for de-duplication (LRU). */
+  maxRetained?: number;
+  /** How long a settled result stays returnable, in ms. */
+  retainTtlMs?: number;
+  /** Max in-flight + queued commands per tab before `busy`. */
+  perQueueDepthCap?: number;
+  /** Injectable clock for deterministic TTL tests. */
+  now?: () => number;
+}
+
+export const DEFAULT_COMMAND_QUEUE_OPTIONS: Required<
+  Omit<CommandQueueOptions, "now">
+> = {
+  maxRetained: 512,
+  retainTtlMs: 15 * 60 * 1000,
+  perQueueDepthCap: 8,
+};

--- a/mcpjam-inspector/server/services/browserd/protocol.ts
+++ b/mcpjam-inspector/server/services/browserd/protocol.ts
@@ -99,7 +99,16 @@ export type BrowserCommandOutcome =
    * The command settled earlier but its result has since been evicted (LRU/TTL),
    * so it can be neither returned nor safely re-run. → 409 `command_expired`
    */
-  | { status: "expired"; bootId: BootId };
+  | { status: "expired"; bootId: BootId }
+  /**
+   * The daemon has tracked its per-boot ceiling of distinct commandIds and
+   * cannot admit a NEW one without either forgetting a tombstone (which would
+   * permit a re-execution) or leaking memory. The caller should rotate the
+   * daemon — a fresh boot resets the ledger, and its new bootId makes any stale
+   * commandId `command_unknown_boot`. Duplicates of already-seen ids still
+   * resolve. → 503 `daemon_at_capacity`
+   */
+  | { status: "at_capacity"; bootId: BootId };
 
 /** The idempotency/eviction knobs, all overridable for tests. */
 export interface CommandQueueOptions {
@@ -109,6 +118,15 @@ export interface CommandQueueOptions {
   retainTtlMs?: number;
   /** Max in-flight + queued commands per tab before `busy`. */
   perQueueDepthCap?: number;
+  /**
+   * Ceiling on DISTINCT commandIds tracked per boot (returnable results + their
+   * boot-long tombstones). Tombstones are never silently forgotten — doing so
+   * would let a delayed retry re-run a non-idempotent action — so instead a NEW
+   * command past this ceiling is refused (`at_capacity`) and the daemon should
+   * rotate. Sized well above any realistic per-session command count; it is a
+   * memory ceiling, not a target. Must be >= `maxRetained`.
+   */
+  maxCommandsPerBoot?: number;
   /** Injectable clock for deterministic TTL tests. */
   now?: () => number;
 }
@@ -119,4 +137,5 @@ export const DEFAULT_COMMAND_QUEUE_OPTIONS: Required<
   maxRetained: 512,
   retainTtlMs: 15 * 60 * 1000,
   perQueueDepthCap: 8,
+  maxCommandsPerBoot: 50_000,
 };


### PR DESCRIPTION
First feature code for the **Hosted Browser + WebMCP Runtime** (W1), built eval-first. `mcpjam-browserd` is the sandbox-local daemon that will drive Chromium on an E2B desktop; this PR lands its **wire protocol** and the piece everything else sits on — the **real at-most-once command queue**. No live E2B / Chromium dependency, fully unit-tested.

## Why the queue lives in the daemon

`computerCommands` in Convex is only a **post-hoc, best-effort log** (see `run-command.ts`), so the actual at-most-once guarantee has to live in the process that drives the browser. The queue implements the four idempotency rules from the plan:

1. **Unseen** commandId → execute once on its per-tab FIFO.
2. **Duplicate while running** → attach to the in-flight promise (one execution, both callers get the result).
3. **Duplicate after settle** → return the recorded result (LRU 512 / 15-min TTL retention).
4. **Duplicate after the result was evicted** → `expired`, and **never re-run** — the original outcome is unknowable across eviction/restart, so a silent re-execution would be a lie.

Per-tab FIFO serializes manual/chat/inspector/eval traffic; a depth cap returns `busy`. The executor is **injected** so the queue is testable with a fake driver (the `run-command.ts` `BashRunner` pattern); Playwright/CDP fills that seam in the next PR.

## What's here

- `server/services/browserd/protocol.ts` — `BootId`, the command envelope (mirrors V1's `POST /sessions/:id/command` so the W5 mapping is thin, widened for the six `browser_*` tools), result/outcome types, queue defaults.
- `server/services/browserd/daemon/command-queue.ts` — the queue.
- `daemon/__tests__/command-queue.test.ts` — **9 cases**, all green: every rule, FIFO vs cross-tab concurrency, LRU + TTL eviction, executor-throw normalization, and failure-does-not-stall-the-tab.

## Scope boundary

bootId **staleness** (`command_unknown_boot`, a commandId replayed against a *different* daemon boot) is enforced one layer up at the HTTP boundary in **PR (b)** — a fresh boot has a fresh queue, so the daemon compares the caller's expected bootId to its own and rejects a mismatch. This queue is per-boot by construction.

## W1 slicing (this is PR a of e)

(a) protocol + queue ← **this** · (b) daemon HTTP server + Chromium driver · (c) bundler + boot recipe · (d) backend `templates/desktop/` + provision + `computer-browser` token · (e) internal debug route wiring it end to end.

Recovery posture reflects the M0 spike (health-check, not always-kill-on-wake): a surviving daemon keeps a stable bootId across a pause, so this queue's idempotency survives snapshots. Tracked by the `webmcp-hosted-runtime` skill (W1 row).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> New correctness-critical idempotency layer for browser commands; behavior is well-tested but mistakes could allow double-execution or block legitimate retries once wired to live traffic.
> 
> **Overview**
> Introduces **`mcpjam-browserd`** foundation: a transport-agnostic **`protocol.ts`** (command envelope aligned with V1 WebMCP inspector, expanded **`browser_*` actions**, **`bootId`**, and queue outcomes like **`busy`**, **`expired`**, **`at_capacity`**) and a daemon **`CommandQueue`** that enforces **at-most-once execution per `commandId` per boot**.
> 
> The queue **deduplicates** in-flight and settled retries, **serializes per-tab** traffic while allowing **cross-tab concurrency**, caps queue depth, **retains results** with LRU + TTL, and **tombstones evicted ids** so late duplicates return **`expired`** instead of re-running browser actions. Executor failures are **normalized** to shared `{ok:false}` results, and invalid queue limits throw at construction. **14 unit tests** cover the idempotency rules, eviction, capacity, and FIFO behavior; **HTTP / Chromium wiring** and **`command_unknown_boot`** are explicitly out of scope here.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9ab349d7f1e885fdeb24eca46a21c8ac7ff0cb85. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds the browser daemon's wire protocol and a real at-most-once command queue, the foundation for the hosted browser runtime (`mcpjam-browserd`). This enforces per-command ID idempotency the existing Convex log cannot provide.

- Unseen command IDs run once; in-flight duplicates share one execution, settled results return from memory, and evicted results return `expired` and never re-run.
- Per-tab FIFO serializes commands with a depth cap returning `busy`; executor throws normalize to a shared `{ok:false}` result for all callers.
- Evicted IDs stay tombstoned for the whole boot; instead of dropping tombstones, the queue refuses new commands past a per-boot ceiling (`maxCommandsPerBoot`, default 50k) with `at_capacity`.
- Constructor limits are validated, cache hits refresh recency for true LRU eviction, and 14 tests cover dedup, concurrency, eviction, capacity, and failure recovery.
- `bootId` staleness checking is deferred to the HTTP boundary in a later PR.

<sup>Written for commit 9ab349d7f1e885fdeb24eca46a21c8ac7ff0cb85. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/MCPJam/inspector/pull/4467?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

