### PR TITLE
feat(browserd): daemon control plane — HTTP handler, auth, bootId, staleness guard (W1 PR b)

### DIFF
--- a/mcpjam-inspector/server/services/browserd/daemon/__tests__/browser-driver.test.ts
+++ b/mcpjam-inspector/server/services/browserd/daemon/__tests__/browser-driver.test.ts
@@ -1,0 +1,99 @@
+import { describe, expect, it, vi } from "vitest";
+import {
+  guardStaleness,
+  stateTokensMatch,
+  type BrowserDriver,
+} from "../browser-driver";
+import type {
+  BrowserCommand,
+  BrowserCommandResult,
+  ObservationStateToken,
+} from "../../protocol";
+
+function token(over: Partial<ObservationStateToken> = {}): ObservationStateToken {
+  return { tabId: "tab-1", navCounter: 1, urlHash: "u1", domHash: "d1", ...over };
+}
+
+/** A driver whose execute result and current token are set per test. */
+function fakeDriver(over: Partial<BrowserDriver> = {}): BrowserDriver {
+  return {
+    execute: vi.fn(
+      async (): Promise<BrowserCommandResult> => ({ ok: true, output: "ran" }),
+    ),
+    currentStateToken: vi.fn(async () => token()),
+    health: vi.fn(async () => ({ ok: true })),
+    close: vi.fn(async () => {}),
+    ...over,
+  };
+}
+
+function actCmd(
+  expectedState?: ObservationStateToken,
+  over: Partial<BrowserCommand> = {},
+): BrowserCommand {
+  return {
+    commandId: "c1",
+    tabId: "tab-1",
+    source: "chat",
+    action: { kind: "act", verb: "click", expectedState },
+    ...over,
+  };
+}
+
+describe("stateTokensMatch", () => {
+  it("is true only when every field matches", () => {
+    expect(stateTokensMatch(token(), token())).toBe(true);
+    expect(stateTokensMatch(token(), token({ navCounter: 2 }))).toBe(false);
+    expect(stateTokensMatch(token(), token({ domHash: "d2" }))).toBe(false);
+    expect(stateTokensMatch(token(), token({ urlHash: "u2" }))).toBe(false);
+    expect(stateTokensMatch(token(), token({ tabId: "tab-2" }))).toBe(false);
+  });
+});
+
+describe("guardStaleness", () => {
+  it("executes an act whose expectedState still matches the live tab", async () => {
+    const driver = fakeDriver({ currentStateToken: vi.fn(async () => token()) });
+    const result = await guardStaleness(driver)(actCmd(token()));
+    expect(result).toEqual({ ok: true, output: "ran" });
+    expect(driver.execute).toHaveBeenCalledOnce();
+  });
+
+  it("REFUSES an act whose expectedState is stale, returning the fresh token (L3)", async () => {
+    const fresh = token({ navCounter: 9, domHash: "moved" });
+    const driver = fakeDriver({ currentStateToken: vi.fn(async () => fresh) });
+    const result = await guardStaleness(driver)(actCmd(token()));
+    expect(result).toEqual({
+      ok: false,
+      staleObservation: true,
+      error: "stale_observation",
+      stateToken: fresh,
+    });
+    expect(driver.execute).not.toHaveBeenCalled(); // the click NEVER lands
+  });
+
+  it("executes an act with NO expectedState (opt-out) without reading state", async () => {
+    const driver = fakeDriver();
+    await guardStaleness(driver)(actCmd(undefined));
+    expect(driver.currentStateToken).not.toHaveBeenCalled();
+    expect(driver.execute).toHaveBeenCalledOnce();
+  });
+
+  it("passes a non-act command straight through even if a token is present", async () => {
+    const driver = fakeDriver();
+    const navigate: BrowserCommand = {
+      commandId: "c2",
+      source: "chat",
+      action: { kind: "navigate", url: "https://x.test" },
+    };
+    await guardStaleness(driver)(navigate);
+    expect(driver.currentStateToken).not.toHaveBeenCalled();
+    expect(driver.execute).toHaveBeenCalledOnce();
+  });
+
+  it("executes when the tab is unknown (no current token to compare against)", async () => {
+    const driver = fakeDriver({ currentStateToken: vi.fn(async () => undefined) });
+    const result = await guardStaleness(driver)(actCmd(token()));
+    expect(result).toMatchObject({ ok: true });
+    expect(driver.execute).toHaveBeenCalledOnce();
+  });
+});

--- a/mcpjam-inspector/server/services/browserd/daemon/__tests__/request-handler.test.ts
+++ b/mcpjam-inspector/server/services/browserd/daemon/__tests__/request-handler.test.ts
@@ -1,0 +1,207 @@
+import { describe, expect, it, vi } from "vitest";
+import {
+  BrowserdRequestHandler,
+  type DaemonRequest,
+} from "../request-handler";
+import type { BrowserCommand, BrowserCommandOutcome } from "../../protocol";
+
+const TOKEN = "s3cr3t-per-boot-token";
+const BOOT = "boot-abc";
+
+function makeHandler(over: {
+  outcome?: BrowserCommandOutcome;
+  submit?: (c: BrowserCommand) => Promise<BrowserCommandOutcome>;
+  health?: () => Promise<{ ok: boolean; detail?: string }>;
+} = {}) {
+  const submit =
+    over.submit ??
+    vi.fn(async () => over.outcome ?? { status: "ok", result: { ok: true }, bootId: BOOT });
+  const health = over.health ?? (async () => ({ ok: true as const }));
+  const handler = new BrowserdRequestHandler({
+    queue: { submit },
+    driver: { health },
+    bootId: BOOT,
+    token: TOKEN,
+  });
+  return { handler, submit };
+}
+
+function req(over: Partial<DaemonRequest> = {}): DaemonRequest {
+  return {
+    method: "POST",
+    path: "/v1/commands",
+    origin: undefined,
+    authorization: `Bearer ${TOKEN}`,
+    body: JSON.stringify({
+      command: { commandId: "c1", source: "chat", action: { kind: "reload" } },
+    }),
+    ...over,
+  };
+}
+
+describe("BrowserdRequestHandler — health", () => {
+  it("answers /healthz unauthenticated with no secrets", async () => {
+    const { handler } = makeHandler();
+    const res = await handler.handle({
+      method: "GET",
+      path: "/healthz",
+      origin: undefined,
+      authorization: undefined,
+      body: "",
+    });
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual({ ok: true });
+    // never leaks the token or the bootId
+    expect(JSON.stringify(res.body)).not.toContain(TOKEN);
+    expect(JSON.stringify(res.body)).not.toContain(BOOT);
+  });
+
+  it("reports a dead browser as 503 so the supervisor relaunches", async () => {
+    const { handler } = makeHandler({
+      health: async () => ({ ok: false, detail: "chromium exited" }),
+    });
+    const res = await handler.handle({
+      method: "GET",
+      path: "/healthz",
+      origin: undefined,
+      authorization: undefined,
+      body: "",
+    });
+    expect(res.status).toBe(503);
+    expect(res.body).toMatchObject({ ok: false, detail: "chromium exited" });
+  });
+
+  it("405s a non-GET /healthz", async () => {
+    const { handler } = makeHandler();
+    const res = await handler.handle(req({ method: "POST", path: "/healthz" }));
+    expect(res.status).toBe(405);
+  });
+});
+
+describe("BrowserdRequestHandler — auth & routing", () => {
+  it("401s a request with no bearer", async () => {
+    const { handler, submit } = makeHandler();
+    const res = await handler.handle(req({ authorization: undefined }));
+    expect(res.status).toBe(401);
+    expect(submit).not.toHaveBeenCalled();
+  });
+
+  it("401s a request with the wrong bearer", async () => {
+    const { handler } = makeHandler();
+    const res = await handler.handle(req({ authorization: "Bearer nope" }));
+    expect(res.status).toBe(401);
+  });
+
+  it("403s any request that carries an Origin (rebinding defence)", async () => {
+    const { handler, submit } = makeHandler();
+    const res = await handler.handle(req({ origin: "https://evil.test" }));
+    expect(res.status).toBe(403);
+    expect(submit).not.toHaveBeenCalled();
+  });
+
+  it("404s an unknown authenticated path", async () => {
+    const { handler } = makeHandler();
+    const res = await handler.handle(req({ path: "/v1/nope" }));
+    expect(res.status).toBe(404);
+  });
+
+  it("405s a non-POST /v1/commands", async () => {
+    const { handler } = makeHandler();
+    const res = await handler.handle(req({ method: "GET" }));
+    expect(res.status).toBe(405);
+    expect(res.headers).toMatchObject({ allow: "POST" });
+  });
+});
+
+describe("BrowserdRequestHandler — command body", () => {
+  it("400s malformed JSON", async () => {
+    const { handler, submit } = makeHandler();
+    const res = await handler.handle(req({ body: "{not json" }));
+    expect(res.status).toBe(400);
+    expect(res.body).toMatchObject({ error: "invalid_json" });
+    expect(submit).not.toHaveBeenCalled();
+  });
+
+  it("400s a body with no valid command envelope", async () => {
+    const { handler, submit } = makeHandler();
+    const res = await handler.handle(
+      req({ body: JSON.stringify({ command: { commandId: "" } }) }),
+    );
+    expect(res.status).toBe(400);
+    expect(res.body).toMatchObject({ error: "invalid_command" });
+    expect(submit).not.toHaveBeenCalled();
+  });
+
+  it("executes a valid command and echoes the bootId", async () => {
+    const { handler, submit } = makeHandler();
+    const res = await handler.handle(req());
+    expect(res.status).toBe(200);
+    expect(res.body).toMatchObject({ status: "ok", bootId: BOOT });
+    expect(submit).toHaveBeenCalledOnce();
+  });
+});
+
+describe("BrowserdRequestHandler — bootId staleness", () => {
+  it("rejects a command whose expectedBootId is a DIFFERENT boot, without queuing it", async () => {
+    const { handler, submit } = makeHandler();
+    const res = await handler.handle(
+      req({
+        body: JSON.stringify({
+          command: { commandId: "c1", source: "chat", action: { kind: "reload" } },
+          expectedBootId: "boot-OLD",
+        }),
+      }),
+    );
+    expect(res.status).toBe(409);
+    expect(res.body).toMatchObject({ error: "command_unknown_boot", bootId: BOOT });
+    expect(submit).not.toHaveBeenCalled(); // never re-run across a restart
+  });
+
+  it("accepts a command whose expectedBootId matches the current boot", async () => {
+    const { handler, submit } = makeHandler();
+    const res = await handler.handle(
+      req({
+        body: JSON.stringify({
+          command: { commandId: "c1", source: "chat", action: { kind: "reload" } },
+          expectedBootId: BOOT,
+        }),
+      }),
+    );
+    expect(res.status).toBe(200);
+    expect(submit).toHaveBeenCalledOnce();
+  });
+});
+
+describe("BrowserdRequestHandler — outcome mapping", () => {
+  const cases: Array<[BrowserCommandOutcome, number, unknown]> = [
+    [{ status: "busy", bootId: BOOT }, 429, { status: "busy", bootId: BOOT }],
+    [{ status: "expired", bootId: BOOT }, 409, { error: "command_expired" }],
+    [{ status: "at_capacity", bootId: BOOT }, 503, { error: "daemon_at_capacity" }],
+  ];
+  for (const [outcome, status, body] of cases) {
+    it(`maps ${outcome.status} → ${status}`, async () => {
+      const { handler } = makeHandler({ outcome });
+      const res = await handler.handle(req());
+      expect(res.status).toBe(status);
+      expect(res.body).toMatchObject(body as object);
+    });
+  }
+
+  it("maps a stale-observation result (L3) to 409 with the fresh state", async () => {
+    const fresh = { tabId: "tab-1", navCounter: 9, urlHash: "u9", domHash: "d9" };
+    const { handler } = makeHandler({
+      outcome: {
+        status: "ok",
+        result: { ok: false, staleObservation: true, stateToken: fresh },
+        bootId: BOOT,
+      },
+    });
+    const res = await handler.handle(req());
+    expect(res.status).toBe(409);
+    expect(res.body).toMatchObject({
+      error: "stale_observation",
+      result: { staleObservation: true, stateToken: fresh },
+      bootId: BOOT,
+    });
+  });
+});

--- a/mcpjam-inspector/server/services/browserd/daemon/__tests__/server.test.ts
+++ b/mcpjam-inspector/server/services/browserd/daemon/__tests__/server.test.ts
@@ -1,0 +1,101 @@
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import type { AddressInfo } from "node:net";
+import type { Server } from "node:http";
+import { buildBrowserdStack } from "../server";
+import type { BrowserDriver } from "../browser-driver";
+import type { BrowserCommandResult } from "../../protocol";
+
+const TOKEN = "integration-token";
+
+function stubDriver(): BrowserDriver {
+  return {
+    execute: async (): Promise<BrowserCommandResult> => ({
+      ok: true,
+      output: "navigated",
+      settled: true,
+    }),
+    currentStateToken: async () => undefined,
+    health: async () => ({ ok: true }),
+    close: async () => {},
+  };
+}
+
+describe("browserd server adapter (over a real socket)", () => {
+  let server: Server;
+  let bootId: string;
+  let base: string;
+
+  beforeEach(async () => {
+    const stack = buildBrowserdStack(stubDriver(), {
+      token: TOKEN,
+      bodyLimitBytes: 256,
+    });
+    server = stack.server;
+    bootId = stack.bootId;
+    await new Promise<void>((resolve) => server.listen(0, "127.0.0.1", resolve));
+    const { port } = server.address() as AddressInfo;
+    base = `http://127.0.0.1:${port}`;
+  });
+
+  afterEach(async () => {
+    await new Promise<void>((resolve) => server.close(() => resolve()));
+  });
+
+  it("serves /healthz unauthenticated", async () => {
+    const res = await fetch(`${base}/healthz`);
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({ ok: true });
+  });
+
+  it("401s a command with no bearer", async () => {
+    const res = await fetch(`${base}/v1/commands`, {
+      method: "POST",
+      body: JSON.stringify({
+        command: { commandId: "c1", source: "chat", action: { kind: "reload" } },
+      }),
+    });
+    expect(res.status).toBe(401);
+  });
+
+  it("round-trips a valid command and echoes the minted bootId", async () => {
+    const res = await fetch(`${base}/v1/commands`, {
+      method: "POST",
+      headers: { authorization: `Bearer ${TOKEN}` },
+      body: JSON.stringify({
+        command: {
+          commandId: "c1",
+          source: "chat",
+          action: { kind: "navigate", url: "https://x.test" },
+        },
+      }),
+    });
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({
+      status: "ok",
+      result: { ok: true, output: "navigated", settled: true },
+      bootId,
+    });
+  });
+
+  it("rejects a replay against a different bootId as command_unknown_boot", async () => {
+    const res = await fetch(`${base}/v1/commands`, {
+      method: "POST",
+      headers: { authorization: `Bearer ${TOKEN}` },
+      body: JSON.stringify({
+        command: { commandId: "c1", source: "chat", action: { kind: "reload" } },
+        expectedBootId: "some-old-boot",
+      }),
+    });
+    expect(res.status).toBe(409);
+    expect(await res.json()).toMatchObject({ error: "command_unknown_boot" });
+  });
+
+  it("413s a body over the size limit", async () => {
+    const res = await fetch(`${base}/v1/commands`, {
+      method: "POST",
+      headers: { authorization: `Bearer ${TOKEN}` },
+      body: "x".repeat(512),
+    });
+    expect(res.status).toBe(413);
+  });
+});

--- a/mcpjam-inspector/server/services/browserd/daemon/auth.ts
+++ b/mcpjam-inspector/server/services/browserd/daemon/auth.ts
@@ -1,0 +1,38 @@
+/**
+ * Per-request bearer authentication for browserd.
+ *
+ * EVERY `getHost(port)` E2B exposes is a public HTTPS endpoint (M0 finding), so
+ * the daemon cannot rely on network isolation: it self-authenticates every
+ * request against a per-boot token passed in `envs`. This mirrors the plugin
+ * shim's posture (`shim/mcpjam-plugin-shim.mjs`); the helpers are re-expressed
+ * in TypeScript here so the daemon control plane can import and test them.
+ */
+import { createHmac, randomBytes, timingSafeEqual } from "node:crypto";
+
+/** The bearer credential a request presents, or "" when it presents none. */
+export function presentedBearer(headerValue: string | undefined): string {
+  if (typeof headerValue !== "string") return "";
+  const separator = headerValue.indexOf(" ");
+  if (separator === -1) return "";
+  if (headerValue.slice(0, separator).toLowerCase() !== "bearer") return "";
+  return headerValue.slice(separator + 1).trim();
+}
+
+/**
+ * Per-process key so the digests below cannot be precomputed by an attacker who
+ * knows the algorithm.
+ */
+const AUTH_DIGEST_KEY = randomBytes(32);
+
+/**
+ * Constant-time string comparison that is also constant-time in LENGTH.
+ *
+ * `timingSafeEqual` throws on unequal lengths, and the obvious length guard
+ * returns early, leaking the token's length through response timing. Hashing
+ * both sides to a fixed 32 bytes makes every comparison do identical work.
+ */
+export function constantTimeEquals(a: string, b: string): boolean {
+  const digestA = createHmac("sha256", AUTH_DIGEST_KEY).update(a, "utf8").digest();
+  const digestB = createHmac("sha256", AUTH_DIGEST_KEY).update(b, "utf8").digest();
+  return timingSafeEqual(digestA, digestB);
+}

--- a/mcpjam-inspector/server/services/browserd/daemon/browser-driver.ts
+++ b/mcpjam-inspector/server/services/browserd/daemon/browser-driver.ts
@@ -1,0 +1,89 @@
+/**
+ * The seam between the daemon's control plane (queue + HTTP) and the real
+ * browser. The control plane owns ordering, de-duplication, auth, and boot
+ * identity; the driver owns the Chromium/CDP work. Keeping it an interface lets
+ * every layer above be unit-tested with a fake driver — the way PR (a)'s queue
+ * injects a `CommandExecutor` — while the real Playwright/CDP driver (with its
+ * launch flags, settle logic, and profile-lock handling) lands with the boot
+ * recipe in PR (c), where it can actually drive a browser.
+ */
+import {
+  BrowserCommand,
+  BrowserCommandResult,
+  ObservationStateToken,
+} from "../protocol";
+import type { CommandExecutor } from "./command-queue";
+
+export interface DriverHealth {
+  ok: boolean;
+  /** Free-text reason when `ok` is false (e.g. "chromium exited"). */
+  detail?: string;
+}
+
+export interface BrowserDriver {
+  /**
+   * Execute one command against the real browser and return its result. This is
+   * exactly the `CommandExecutor` the queue drives; the queue owns idempotency,
+   * so the driver may assume it is asked to run a given commandId at most once.
+   */
+  execute(command: BrowserCommand): Promise<BrowserCommandResult>;
+  /**
+   * The current rendered-state token for a tab (L3), or undefined if the tab is
+   * unknown. Read WITHOUT mutating the page, so the staleness guard can compare
+   * it against an act's `expectedState` before deciding whether to execute.
+   */
+  currentStateToken(
+    tabId: string | undefined,
+  ): Promise<ObservationStateToken | undefined>;
+  /** Liveness of the underlying browser process, for `GET /healthz`. */
+  health(): Promise<DriverHealth>;
+  /** Tear the browser down. Called on daemon shutdown. */
+  close(): Promise<void>;
+}
+
+/** Structural equality of two state tokens (L3). */
+export function stateTokensMatch(
+  a: ObservationStateToken,
+  b: ObservationStateToken,
+): boolean {
+  return (
+    a.tabId === b.tabId &&
+    a.navCounter === b.navCounter &&
+    a.urlHash === b.urlHash &&
+    a.domHash === b.domHash
+  );
+}
+
+/**
+ * Wrap a driver's `execute` with the L3 staleness check, producing the
+ * `CommandExecutor` the queue runs. For an `act` that carries an
+ * `expectedState`, the guard reads the tab's CURRENT token first; if the page
+ * has navigated or mutated structurally since the observation the act was
+ * decided from, it REFUSES the act (returns `staleObservation`) instead of
+ * clicking the wrong place, and hands back the fresh token so the caller
+ * re-observes. Everything else — acts without an expected token, and every
+ * non-act command — passes straight through.
+ *
+ * The check lives here, above the driver, so it is pure and testable with a
+ * fake driver: the real driver never has to special-case staleness.
+ */
+export function guardStaleness(driver: BrowserDriver): CommandExecutor {
+  return async (command: BrowserCommand): Promise<BrowserCommandResult> => {
+    const { action } = command;
+    if (action.kind !== "act" || action.expectedState === undefined) {
+      return driver.execute(command);
+    }
+    const current = await driver.currentStateToken(command.tabId);
+    if (current !== undefined && !stateTokensMatch(current, action.expectedState)) {
+      // The page moved under the model. Do NOT act; return the fresh state so
+      // it can re-decide from what is actually on screen now.
+      return {
+        ok: false,
+        staleObservation: true,
+        error: "stale_observation",
+        stateToken: current,
+      };
+    }
+    return driver.execute(command);
+  };
+}

--- a/mcpjam-inspector/server/services/browserd/daemon/request-handler.ts
+++ b/mcpjam-inspector/server/services/browserd/daemon/request-handler.ts
@@ -1,0 +1,197 @@
+/**
+ * browserd's HTTP control plane — the pure request handler.
+ *
+ * It wraps PR (a)'s command queue with the wire concerns the daemon boundary
+ * owns, and NOTHING else:
+ *
+ *   - per-request bearer auth (every endpoint is public over `getHost`);
+ *   - `bootId` identity: the daemon mints one per process start and echoes it on
+ *     every response, and REJECTS a command whose caller expected a different
+ *     boot (`command_unknown_boot`) rather than re-running it — the first
+ *     execution's fate across a restart is unknowable, so replaying would lie;
+ *   - mapping the queue's `BrowserCommandOutcome` to an HTTP status;
+ *   - surfacing the L3 stale-observation refusal as `409 stale_observation`.
+ *
+ * It is transport-agnostic: it takes a parsed `DaemonRequest` and returns a
+ * `DaemonResponse`, so it is unit-testable without a socket. The thin Node-http
+ * adapter that reads the body and writes the response lives in `server.ts`.
+ */
+import type {
+  BrowserCommand,
+  BrowserCommandOutcome,
+} from "../protocol";
+import type { CommandQueue } from "./command-queue";
+import type { BrowserDriver } from "./browser-driver";
+import { constantTimeEquals, presentedBearer } from "./auth";
+
+/** A parsed inbound request; the adapter fills this from a Node req. */
+export interface DaemonRequest {
+  method: string;
+  path: string;
+  /** The `origin` header value, if any. Any value fails the rebinding check. */
+  origin: string | undefined;
+  /** The raw `authorization` header value, if any. */
+  authorization: string | undefined;
+  /** The raw request body (already size-limited by the adapter). */
+  body: string;
+}
+
+/** What the handler wants written back. `body` undefined → empty response. */
+export interface DaemonResponse {
+  status: number;
+  body?: unknown;
+  headers?: Record<string, string>;
+}
+
+/** The shape of a `POST /v1/commands` body. */
+interface CommandRequestBody {
+  command: BrowserCommand;
+  /**
+   * The bootId the caller believes it is talking to. Absent on first contact
+   * (the caller learns the current bootId from the response); present on a retry
+   * so a replay against a fresh boot is rejected rather than re-executed.
+   */
+  expectedBootId?: string;
+}
+
+export interface BrowserdHandlerDeps {
+  queue: Pick<CommandQueue, "submit">;
+  driver: Pick<BrowserDriver, "health">;
+  /** Minted once per daemon process start; echoed on every response. */
+  bootId: string;
+  /** The shared secret every non-`/healthz` request must present. */
+  token: string;
+}
+
+export class BrowserdRequestHandler {
+  private readonly queue: Pick<CommandQueue, "submit">;
+  private readonly driver: Pick<BrowserDriver, "health">;
+  private readonly bootId: string;
+  private readonly token: string;
+
+  constructor(deps: BrowserdHandlerDeps) {
+    this.queue = deps.queue;
+    this.driver = deps.driver;
+    this.bootId = deps.bootId;
+    this.token = deps.token;
+  }
+
+  async handle(req: DaemonRequest): Promise<DaemonResponse> {
+    // `/healthz` is unauthenticated liveness and carries NO secrets — not the
+    // token, not the bootId. The supervisor polls it to decide kill/relaunch on
+    // wake (M0 recovery posture), so browser-down is a 503, not a thrown error.
+    if (req.path === "/healthz") {
+      if (req.method !== "GET" && req.method !== "HEAD") {
+        return { status: 405, headers: { allow: "GET, HEAD" } };
+      }
+      const health = await this.driver.health();
+      return health.ok
+        ? { status: 200, body: { ok: true } }
+        : { status: 503, body: { ok: false, detail: health.detail } };
+    }
+
+    // Everything else is authenticated. No `WWW-Authenticate` (browserd is not
+    // an OAuth resource server) and no body — a 401 says nothing about why.
+    if (!constantTimeEquals(presentedBearer(req.authorization), this.token)) {
+      return { status: 401 };
+    }
+
+    // DNS-rebinding defence: every legitimate caller is server-side and sends no
+    // Origin, so any Origin at all is rejected.
+    if (req.origin !== undefined) {
+      return { status: 403, body: { error: "cross_origin_forbidden" } };
+    }
+
+    if (req.path === "/v1/commands") {
+      if (req.method !== "POST") {
+        return { status: 405, headers: { allow: "POST" } };
+      }
+      return this.handleCommand(req);
+    }
+
+    return { status: 404 };
+  }
+
+  private async handleCommand(req: DaemonRequest): Promise<DaemonResponse> {
+    let parsed: CommandRequestBody;
+    try {
+      parsed = JSON.parse(req.body) as CommandRequestBody;
+    } catch {
+      return { status: 400, body: { error: "invalid_json", bootId: this.bootId } };
+    }
+    if (!isValidCommand(parsed?.command)) {
+      return {
+        status: 400,
+        body: { error: "invalid_command", bootId: this.bootId },
+      };
+    }
+
+    // bootId staleness: a command the caller expected a DIFFERENT boot to run is
+    // rejected before it reaches the queue. Never re-execute across a restart.
+    if (
+      parsed.expectedBootId !== undefined &&
+      parsed.expectedBootId !== this.bootId
+    ) {
+      return {
+        status: 409,
+        body: { error: "command_unknown_boot", bootId: this.bootId },
+      };
+    }
+
+    const outcome = await this.queue.submit(parsed.command);
+    return this.mapOutcome(outcome);
+  }
+
+  /** Map a queue outcome to an HTTP response. */
+  private mapOutcome(outcome: BrowserCommandOutcome): DaemonResponse {
+    switch (outcome.status) {
+      case "ok":
+        // An `act` refused for a stale observation (L3) rides back as an OK
+        // outcome carrying a `staleObservation` result; surface it as a 409 with
+        // the fresh state so the caller re-decides.
+        if (outcome.result.staleObservation) {
+          return {
+            status: 409,
+            body: {
+              error: "stale_observation",
+              result: outcome.result,
+              bootId: outcome.bootId,
+            },
+          };
+        }
+        return {
+          status: 200,
+          body: { status: "ok", result: outcome.result, bootId: outcome.bootId },
+        };
+      case "busy":
+        return {
+          status: 429,
+          body: { status: "busy", bootId: outcome.bootId },
+        };
+      case "expired":
+        return {
+          status: 409,
+          body: { error: "command_expired", bootId: outcome.bootId },
+        };
+      case "at_capacity":
+        return {
+          status: 503,
+          body: { error: "daemon_at_capacity", bootId: outcome.bootId },
+        };
+    }
+  }
+}
+
+/** Minimal structural validation — the queue trusts the envelope's shape. */
+function isValidCommand(value: unknown): value is BrowserCommand {
+  if (typeof value !== "object" || value === null) return false;
+  const candidate = value as Partial<BrowserCommand>;
+  return (
+    typeof candidate.commandId === "string" &&
+    candidate.commandId.length > 0 &&
+    typeof candidate.source === "string" &&
+    typeof candidate.action === "object" &&
+    candidate.action !== null &&
+    (candidate.tabId === undefined || typeof candidate.tabId === "string")
+  );
+}

--- a/mcpjam-inspector/server/services/browserd/daemon/server.ts
+++ b/mcpjam-inspector/server/services/browserd/daemon/server.ts
@@ -1,0 +1,149 @@
+/**
+ * The thin Node-http adapter for browserd's control plane.
+ *
+ * All routing, auth, and outcome logic lives in `BrowserdRequestHandler` (pure,
+ * unit-tested). This file does only what a socket forces: parse the request,
+ * enforce a body-size limit, call the handler, and write the JSON response. It
+ * also assembles the full daemon stack from a `BrowserDriver` — mint the
+ * per-boot id, build the command queue with the staleness-guarded executor, and
+ * hand both to the handler — and emits the stdout ready-line the boot recipe
+ * (PR c) waits on.
+ */
+import { createServer, type Server } from "node:http";
+import { randomUUID } from "node:crypto";
+import { CommandQueue } from "./command-queue";
+import { BrowserdRequestHandler, type DaemonResponse } from "./request-handler";
+import { guardStaleness, type BrowserDriver } from "./browser-driver";
+
+/** Requests bigger than this are refused with 413 before they reach the queue. */
+const DEFAULT_BODY_LIMIT_BYTES = 1024 * 1024;
+
+class BodyTooLargeError extends Error {}
+
+function readRequestBody(
+  req: import("node:http").IncomingMessage,
+  limitBytes: number,
+): Promise<string> {
+  return new Promise((resolve, reject) => {
+    const chunks: Buffer[] = [];
+    let size = 0;
+    let refused = false;
+    req.on("data", (chunk: Buffer) => {
+      if (refused) return;
+      size += chunk.length;
+      if (size > limitBytes) {
+        refused = true;
+        // Pause rather than destroy: destroying the socket would deny the caller
+        // the 413 it is owed. Pausing stops accumulation while the response stays
+        // writable; the caller closes the socket once the refusal has flushed.
+        req.pause();
+        reject(new BodyTooLargeError());
+        return;
+      }
+      chunks.push(chunk);
+    });
+    req.on("end", () => resolve(Buffer.concat(chunks).toString("utf8")));
+    req.on("error", reject);
+  });
+}
+
+function writeResponse(
+  res: import("node:http").ServerResponse,
+  response: DaemonResponse,
+): void {
+  if (response.body === undefined) {
+    res.writeHead(response.status, {
+      "content-length": "0",
+      ...response.headers,
+    });
+    res.end();
+    return;
+  }
+  const payload = JSON.stringify(response.body);
+  res.writeHead(response.status, {
+    "content-type": "application/json",
+    "content-length": Buffer.byteLength(payload),
+    ...response.headers,
+  });
+  res.end(payload);
+}
+
+export interface DaemonServerOptions {
+  bodyLimitBytes?: number;
+}
+
+/** Bind a request handler to a Node http server. Does not call `listen`. */
+export function createDaemonServer(
+  handler: BrowserdRequestHandler,
+  options: DaemonServerOptions = {},
+): Server {
+  const bodyLimit = options.bodyLimitBytes ?? DEFAULT_BODY_LIMIT_BYTES;
+  return createServer((req, res) => {
+    void (async () => {
+      let path: string;
+      try {
+        path = new URL(req.url ?? "/", "http://browserd.invalid").pathname;
+      } catch {
+        writeResponse(res, { status: 404 });
+        return;
+      }
+      let body = "";
+      if (req.method === "POST" || req.method === "PUT") {
+        try {
+          body = await readRequestBody(req, bodyLimit);
+        } catch (error) {
+          writeResponse(res, {
+            status: error instanceof BodyTooLargeError ? 413 : 400,
+          });
+          return;
+        }
+      }
+      const response = await handler.handle({
+        method: req.method ?? "GET",
+        path,
+        origin: headerValue(req.headers.origin),
+        authorization: headerValue(req.headers.authorization),
+        body,
+      });
+      writeResponse(res, response);
+    })().catch(() => {
+      if (!res.headersSent) writeResponse(res, { status: 500 });
+      else res.end();
+    });
+  });
+}
+
+function headerValue(value: string | string[] | undefined): string | undefined {
+  return Array.isArray(value) ? value[0] : value;
+}
+
+export interface BrowserdStack {
+  server: Server;
+  handler: BrowserdRequestHandler;
+  queue: CommandQueue;
+  bootId: string;
+}
+
+/**
+ * Assemble the whole daemon around a driver: one bootId shared by the queue and
+ * the handler, the queue driven by the staleness-guarded executor, and the http
+ * server bound to the handler. The caller (`PR c` entrypoint) then `listen`s and
+ * prints the ready-line.
+ */
+export function buildBrowserdStack(
+  driver: BrowserDriver,
+  config: { token: string; bootId?: string } & DaemonServerOptions,
+): BrowserdStack {
+  const bootId = config.bootId ?? randomUUID();
+  const queue = new CommandQueue(guardStaleness(driver), bootId);
+  const handler = new BrowserdRequestHandler({
+    queue,
+    driver,
+    bootId,
+    token: config.token,
+  });
+  const server = createDaemonServer(handler, {
+    bodyLimitBytes: config.bodyLimitBytes,
+  });
+  return { server, handler, queue, bootId };
+}

--- a/mcpjam-inspector/server/services/browserd/protocol.ts
+++ b/mcpjam-inspector/server/services/browserd/protocol.ts
@@ -31,6 +31,23 @@ export type BrowserActTarget =
   | { selector: string }
   | { a11yRef: string };
 
+/**
+ * A cheap fingerprint of a tab's rendered state, minted with every observation
+ * (L3). `browser_act` may carry the token it was DECIDED from; the daemon
+ * rejects the act (`stale_observation`) if the page has navigated or mutated
+ * structurally since — the actual production failure mode is not duplicate
+ * command delivery (the command queue already handles that) but STALE targeting:
+ * a click computed from a screenshot that a late-loading banner has shifted.
+ * `navCounter` bumps on every commit; `urlHash`/`domHash` are cheap digests of
+ * the location and a structural view of the DOM.
+ */
+export interface ObservationStateToken {
+  tabId: string;
+  navCounter: number;
+  urlHash: string;
+  domHash: string;
+}
+
 export type BrowserAction =
   | { kind: "navigate"; url: string; newTab?: boolean }
   | { kind: "back" }
@@ -49,6 +66,13 @@ export type BrowserAction =
         | "activate_tab";
       target?: BrowserActTarget;
       value?: string;
+      /**
+       * The observation token this act was decided from (L3). When present, the
+       * daemon refuses the act if the tab's current state token no longer matches
+       * — the page moved under the model — and returns a fresh observation so it
+       * can re-decide. Optional: a caller that opts out accepts stale targeting.
+       */
+      expectedState?: ObservationStateToken;
     }
   | {
       kind: "observe";
@@ -83,6 +107,26 @@ export interface BrowserCommandResult {
   output?: unknown;
   /** Present when `ok` is false. */
   error?: string;
+  /**
+   * The fresh state token for the acted-on / observed tab (L3). Every capture
+   * carries one so the next `act` can be pinned to it.
+   */
+  stateToken?: ObservationStateToken;
+  /**
+   * False while the page is still loading at capture time (L2). browserd settles
+   * (nav commit → brief network-quiet → rAF) before capturing, so this is
+   * normally true; when a page genuinely will not settle, the daemon returns the
+   * frame with `settled: false` rather than exposing a `wait` verb, and the
+   * caller re-observes only when told the state is unsettled.
+   */
+  settled?: boolean;
+  /**
+   * Set when an `act` was REFUSED because its `expectedState` no longer matched
+   * the live tab (L3). The action did NOT run; `output`/`stateToken` carry the
+   * fresh observation so the caller can re-decide. The HTTP layer maps a result
+   * with this flag to `409 stale_observation`.
+   */
+  staleObservation?: boolean;
 }
 
 /**


### PR DESCRIPTION
**W1 PR (b)** of the Hosted Browser + WebMCP Runtime. Builds directly on **#4467** (the command queue, PR a), now merged to `main`.

## What this is
The daemon's HTTP control plane: the wire concerns the browserd boundary owns, wrapped around PR (a)'s queue. Built as **pure, fully-tested logic behind a thin Node-http adapter**, with **no E2B/Chromium/Playwright dependency** — the discipline that kept PR (a) clean. The real Playwright/CDP driver folds into **PR (c)**, where it can drive a browser.

> Scope note: the W1 brief lumped "HTTP server + Chromium supervisor" into one PR. I split them so every PR stays unit-testable without live E2B; the driver lands with the boot recipe that runs it.

## Contents (8 files, +924)
- **`protocol.ts`** — `ObservationStateToken` (**L3**) + `expectedState` on `act`; `settled` (**L2**), `stateToken`, `staleObservation` on `BrowserCommandResult`.
- **`daemon/browser-driver.ts`** — the `BrowserDriver` seam + `guardStaleness`: the **L3** stale-targeting check as a pure executor wrapper. An `act` whose `expectedState` no longer matches the live tab is **refused** (fresh token returned), never clicked stale — complementary to, not a substitute for, the queue's at-most-once.
- **`daemon/auth.ts`** — constant-time (incl. length) bearer check. Every `getHost(port)` is public (M0 finding), so browserd self-authenticates every request.
- **`daemon/request-handler.ts`** — unauthenticated `/healthz` (503 on a dead browser for the supervisor's kill/relaunch decision; carries no secrets), bearer + `Origin` gate, `bootId` minting/echo + `command_unknown_boot` rejection, and the outcome->status map (busy 429; expired/stale 409; at_capacity 503).
- **`daemon/server.ts`** — thin adapter (body-limit -> 413) + `buildBrowserdStack` wiring one `bootId` across queue and handler; stdout ready-line for the boot recipe.

## Tests
28 new (staleness guard, handler routing/auth/mapping, socket-level round-trip incl. `command_unknown_boot` and 413). **42 green total (with PR a's 14), tsc clean across the repo.**

## Deliberately deferred
- Real Chromium/CDP `BrowserDriver` + L4 flags / L5 determinism pins / L8 SingletonLock -> **PR (c)** boot recipe.
- bash/browser same-uid co-tenancy position -> boot recipe / debug-route PRs (this PR's per-request token auth is the browserd half).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Introduces a publicly reachable control plane with bearer auth and boot/replay semantics; mistakes in auth or bootId handling could allow unauthorized commands or unsafe replays after restart.
> 
> **Overview**
> Adds **browserd’s daemon HTTP control plane** on top of the existing command queue: a testable handler plus a thin Node `http` adapter, wired through **`buildBrowserdStack`** with a stub-injectable **`BrowserDriver`** (real Playwright/CDP deferred).
> 
> **Protocol** gains **L3 observation pinning**: `ObservationStateToken`, optional `expectedState` on `act`, and result fields `stateToken`, `settled`, and `staleObservation`. **`guardStaleness`** wraps the driver executor so mismatched `expectedState` refuses the act and returns a fresh token instead of executing.
> 
> **Wire behavior**: unauthenticated **`GET /healthz`** (503 when the driver reports unhealthy); **`POST /v1/commands`** behind constant-time bearer auth, **`Origin`** rejection, per-process **`bootId`** echo and **`expectedBootId`** mismatch → `command_unknown_boot`; queue outcomes mapped to HTTP (including **409** for stale observation and unknown boot); body size → **413**.
> 
> **28 new tests** cover staleness, handler routing/auth/mapping, and socket-level round-trips.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 13c231cb4a78742405d41e02495b2b20bae502ef. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds the browserd daemon's HTTP control plane: an authenticated `POST /v1/commands` route over the command queue, with per-boot identity and a staleness guard. An `act` whose `expectedState` no longer matches the live tab is now refused with `409 stale_observation` and a fresh observation token instead of clicking the wrong place.

**New Features**
- Every non-`/healthz` request requires a constant-time bearer check; any `Origin` header is rejected.
- The daemon mints a `bootId` per process start, echoes it on every response, and rejects commands pinned to a different boot with `command_unknown_boot`.
- Unauthenticated `/healthz` returns 503 when the browser process is dead so the supervisor can relaunch it.
- Queue outcomes map to `429 busy`, `409 expired`, `503 at_capacity`, and oversized bodies to `413`.
- All routing and auth logic is socket-free and unit-tested behind a thin Node-http adapter; the real Playwright/CDP driver lands in a follow-up.

<sup>Written for commit 13c231cb4a78742405d41e02495b2b20bae502ef. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/MCPJam/inspector/pull/4470?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

