### PR TITLE
Record the system prompt the hosted turn actually sent

### DIFF
--- a/.changeset/hosted-turn-records-what-it-sent.md
+++ b/.changeset/hosted-turn-records-what-it-sent.md
@@ -1,0 +1,11 @@
+---
+"@mcpjam/inspector": patch
+---
+
+The hosted chat turn records the system prompt it actually sent
+
+`persistChatSessionToConvex` has two prompt fields, and they answer different questions: top-level `systemPrompt` is EVIDENCE of what the model was given, and `resumeConfig.systemPrompt` is what a RESUMED turn replays. The local route (`routes/mcp/chat-v2.ts`) and the agent-turn route both fill the first with the enhanced prompt. The hosted Playground route filled only the second — so the record of a hosted turn carried the bare host prompt and none of what the turn added: the server-skill catalog, widget model context, the environment block.
+
+That matters most for the thing skills over MCP just shipped. "Did the model even know that skill existed?" is the first question anyone asks when an agent ignores a skill, and it is answered by the catalog being in the prompt or not. A record that cannot show the catalog cannot answer it.
+
+The two fields stay separate, deliberately. Turn-injected content is true of the turn that happened and not of the next one — replaying "your sandbox was reset" long after the fact, or a skills catalog for servers no longer connected, is exactly the confabulation the raw resume prompt exists to prevent. Both fields already existed on the ingest contract; only the hosted writer was leaving one empty.

--- a/mcpjam-inspector/server/utils/__tests__/chat-ingestion.test.ts
+++ b/mcpjam-inspector/server/utils/__tests__/chat-ingestion.test.ts
@@ -110,6 +110,33 @@ describe("chat-ingestion", () => {
     expect(body.surface).toBe("share_link");
   });
 
+  it("keeps the sent prompt and the resume prompt as separate fields", async () => {
+    // Two different questions, and merging them breaks one of the two:
+    // `systemPrompt` is EVIDENCE of what the model was given (turn-injected
+    // sections included), `resumeConfig.systemPrompt` is what a resumed turn
+    // replays. Replaying turn-injected content — a skills catalog for servers
+    // that may no longer be connected, or a "your sandbox was reset" notice —
+    // is the confabulation the raw resume prompt exists to prevent.
+    await persistChatSessionToConvex({
+      chatSessionId: "session-2",
+      modelId: "openai/gpt-oss-120b",
+      modelSource: "mcpjam",
+      authHeader: "Bearer bearer-token",
+      sourceType: "direct",
+      origin: "playground",
+      systemPrompt: "HOST PROMPT\n\n## Skills from MCP servers\n\n- **acme/refunds**",
+      resumeConfig: { systemPrompt: "HOST PROMPT" },
+      startedAt: 1,
+      lastActivityAt: 2,
+    });
+
+    const request = (global.fetch as any).mock.calls[0]?.[1];
+    const body = JSON.parse((request?.body as string) ?? "{}");
+
+    expect(body.systemPrompt).toContain("## Skills from MCP servers");
+    expect(body.resumeConfig.systemPrompt).toBe("HOST PROMPT");
+  });
+
   it("serializes rewind lineage for an edited branch", async () => {
     await persistChatSessionToConvex({
       chatSessionId: "branch-session",

--- a/mcpjam-inspector/server/utils/chat-ingestion.ts
+++ b/mcpjam-inspector/server/utils/chat-ingestion.ts
@@ -272,6 +272,19 @@ interface PersistChatSessionOptions {
   visitorDisplayName?: string;
   sessionMessages?: unknown[];
   messages?: unknown[];
+  /**
+   * The system prompt as SENT — turn-injected sections included.
+   *
+   * Evidence, not configuration. It is what the Raw view and
+   * `get_chat_session` show, so it has to be the string the model actually
+   * received: the host prompt plus whatever the turn added (the server-skill
+   * catalog, widget model context, the environment block, sandbox notices).
+   *
+   * NOT the same field as `resumeConfig.systemPrompt`, which is the RAW host
+   * prompt a resumed turn replays. Turn-injected content is true of the turn
+   * that happened and not of the next one, so the two must not be merged —
+   * see the comment at the hosted persist call.
+   */
   systemPrompt?: string;
   responseMessages?: unknown[];
   assistantText?: string;

--- a/mcpjam-inspector/server/utils/web-chat-turn.ts
+++ b/mcpjam-inspector/server/utils/web-chat-turn.ts
@@ -865,6 +865,23 @@ export async function streamWebChatTurn(
           : {}),
         scenarioId: persist.scenarioId,
         authHeader: runtime.authHeader,
+        // WHAT WAS SENT, for the Raw view and `get_chat_session` — distinct
+        // from `resumeConfig.systemPrompt` below, which is what a RESUMED turn
+        // replays.
+        //
+        // Those are different questions and the hosted path only ever answered
+        // the second, so Raw showed the bare host prompt while the model had
+        // been given more: the skills catalog, widget model context, the
+        // environment block. A debugger that cannot show what the model was
+        // told cannot answer "did it even know that skill existed?" — which is
+        // the first question anyone asks when an agent ignores a skill.
+        //
+        // Resume must NOT read this one. Turn-injected content is true of the
+        // turn that happened, not of the next one: replaying "your sandbox was
+        // reset" long after the fact is the confabulation `resumeConfig`'s raw
+        // prompt exists to prevent. Hence two fields, both already on the
+        // ingest contract — the local route has always filled this one.
+        systemPrompt: effectiveEnhancedSystemPrompt,
         sessionMessages: stampSenderUserIdsOnSessionMessages(
           stripUiContextModelParts(fullHistory),
           persist.originalMessages as unknown[],


### PR DESCRIPTION
The Raw view showed `"system": "You are a helpful assistant with access to MCP tools."` on a turn whose model had actually been given much more — including the server-skill catalog.

## What's wrong

`persistChatSessionToConvex` carries two prompt fields for two different questions:

| Field | Question |
|---|---|
| top-level `systemPrompt` | **evidence** — what was the model given? |
| `resumeConfig.systemPrompt` | **config** — what does a resumed turn replay? |

`routes/mcp/chat-v2.ts` (local) and `routes/v1/chat-session-turn.ts` (agent turn) fill the first with `enhancedSystemPrompt`. **`web-chat-turn.ts` (hosted Playground) filled only the second**, so a hosted turn's record carried the bare host prompt and nothing the turn injected: the server-skill catalog, widget model context, the environment block.

That matters most for what skills over MCP just shipped. *"Did the model even know that skill existed?"* is the first question anyone asks when an agent ignores a skill, and it is answered entirely by whether the catalog was in the prompt. A record that cannot show the catalog cannot answer it.

## Why not just merge them

Because `resumeConfig` must keep the raw prompt, and the existing comment says why:

> *TURN-INJECTED, never persisted: `persist.systemPrompt` keeps the raw host prompt, so a resumed turn does not replay a stale "your sandbox was reset" long after the fact.*

That reasoning is right. A resumed turn replaying a skills catalog for servers no longer connected is the same failure. So: two fields, both already on the ingest contract, one of them simply left empty by one writer.

## Scope, honestly

This fixes what the hosted turn **records**. I have **not** confirmed it is what produced the screenshot, and I want that on the record rather than implied:

- The live Raw view is built by `buildResolvedModelRequestPayload` from a **trace event**, not from the persisted row — and that path already carries the enhanced prompt (I have a session payload showing the full catalog under `system`).
- `PersistedTurnTrace` has no `requestPayloads` field, so the live request payload is **not persisted at all**. A reloaded Raw view is therefore reconstructed from something else, and I did not finish tracing which field feeds it.

So this is a verified inconsistency worth closing on its own terms — local and agent-turn record what they sent, hosted did not — and it is a prerequisite for a reloaded Raw view ever being accurate. Whether the reader also needs work is an open question I would rather state than paper over. If persisting request payloads per turn is the real answer, that is a bigger change and a separate PR.

## Tests

`chat-ingestion.test.ts` — a case pinning that the two fields stay distinct through the ingest body: the sent prompt keeps its catalog section, the resume prompt stays the bare host prompt. 45 pass in that file.

Pre-existing and untouched: two type errors in `web-chat-turn-dispatch.test.ts`, present on a clean `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Narrow persistence fix: fills an existing optional ingest field with the same enhanced prompt already used at inference time; resume behavior unchanged.
> 
> **Overview**
> **Hosted Playground** turns now persist **what the model actually received** in top-level `systemPrompt` when calling `persistChatSessionToConvex`, matching local (`chat-v2`) and agent-turn writers.
> 
> Previously the hosted path only set `resumeConfig.systemPrompt` to the **raw host prompt**, so stored sessions omitted turn-injected content (MCP **skills catalog**, widget model context, environment block). Raw / `get_chat_session` evidence could not answer whether a skill was in the prompt. **`resumeConfig.systemPrompt` stays the bare host prompt** for safe resume replay—turn-specific injections are not copied into resume config.
> 
> Adds ingest contract docs on `systemPrompt` vs `resumeConfig.systemPrompt` and a test that both fields pass through the ingest body unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3d771fbd7d21551be6cc4bd7a734427555acf0d4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes hosted Playground turns recording only the bare host prompt, so the Raw view now shows the full system prompt the model actually received (including the server-skill catalog). The persisted `systemPrompt` field is now set to the effective prompt, matching the local and agent-turn routes; `resumeConfig.systemPrompt` is unchanged, so resumed turns still replay the raw prompt.

Adds a test pinning that the sent prompt and resume prompt stay separate fields.

<sup>Written for commit 3d771fbd7d21551be6cc4bd7a734427555acf0d4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/MCPJam/inspector/pull/4471?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

