### PR TITLE
feat(browserd): Chromium driver foundations — launch args, state token, profile lock, settle (W1 PR c1)

### DIFF
--- a/mcpjam-inspector/server/services/browserd/daemon/__tests__/launch-args.test.ts
+++ b/mcpjam-inspector/server/services/browserd/daemon/__tests__/launch-args.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, it } from "vitest";
+import {
+  BROWSERD_CONTEXT_OPTIONS,
+  BROWSERD_HARDENING_ARGS,
+  BROWSERD_OBSERVATION_VIEWPORT,
+  buildBrowserdLaunchArgs,
+} from "../launch-args";
+import { WEBMCP_LAUNCH_ARGS } from "../../../webmcp-inspector/launch-args";
+
+describe("buildBrowserdLaunchArgs", () => {
+  it("puts the shared WebMCP feature flag first, then the hardening set", () => {
+    const args = buildBrowserdLaunchArgs();
+    expect(args[0]).toBe(WEBMCP_LAUNCH_ARGS[0]);
+    expect(args).toEqual([...WEBMCP_LAUNCH_ARGS, ...BROWSERD_HARDENING_ARGS]);
+  });
+
+  it("carries the load-bearing hardening flags (L4)", () => {
+    const args = buildBrowserdLaunchArgs();
+    // crash-avoidance, bot-detection, and screenshot determinism specifically
+    expect(args).toContain("--disable-dev-shm-usage");
+    expect(args).toContain("--disable-blink-features=AutomationControlled");
+    expect(args).toContain("--force-color-profile=srgb");
+    expect(args).toContain("--disable-features=PaintHolding");
+  });
+
+  it("appends extra args (e.g. --window-size from the boot recipe) last", () => {
+    const args = buildBrowserdLaunchArgs(["--window-size=1600,1200"]);
+    expect(args.at(-1)).toBe("--window-size=1600,1200");
+  });
+
+  it("does not enable every experimental platform feature (would perturb pages)", () => {
+    expect(buildBrowserdLaunchArgs()).not.toContain(
+      "--enable-experimental-web-platform-features",
+    );
+  });
+});
+
+describe("determinism pins (L5)", () => {
+  it("pins the canonical model-facing viewport", () => {
+    expect(BROWSERD_OBSERVATION_VIEWPORT).toEqual({ width: 1024, height: 768 });
+    expect(BROWSERD_CONTEXT_OPTIONS.viewport).toBe(BROWSERD_OBSERVATION_VIEWPORT);
+  });
+
+  it("pins scale, locale, timezone, and motion so captures are reproducible", () => {
+    expect(BROWSERD_CONTEXT_OPTIONS.deviceScaleFactor).toBe(1);
+    expect(BROWSERD_CONTEXT_OPTIONS.locale).toBe("en-US");
+    expect(BROWSERD_CONTEXT_OPTIONS.timezoneId).toBe("UTC");
+    expect(BROWSERD_CONTEXT_OPTIONS.reducedMotion).toBe("reduce");
+  });
+
+  it("presents a real desktop UA (pairs with the AutomationControlled flag)", () => {
+    expect(BROWSERD_CONTEXT_OPTIONS.userAgent).toMatch(/Chrome\/\d+/);
+    expect(BROWSERD_CONTEXT_OPTIONS.userAgent).not.toMatch(/Headless/i);
+  });
+});

--- a/mcpjam-inspector/server/services/browserd/daemon/__tests__/profile-lock.test.ts
+++ b/mcpjam-inspector/server/services/browserd/daemon/__tests__/profile-lock.test.ts
@@ -1,0 +1,45 @@
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { mkdtemp, rm, writeFile, readdir, mkdir } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { clearStaleSingletonLock } from "../profile-lock";
+
+describe("clearStaleSingletonLock (L8)", () => {
+  let dir: string;
+  beforeEach(async () => {
+    dir = await mkdtemp(join(tmpdir(), "browserd-profile-"));
+  });
+  afterEach(async () => {
+    await rm(dir, { recursive: true, force: true });
+  });
+
+  it("removes the singleton files an ungraceful kill left behind", async () => {
+    for (const f of ["SingletonLock", "SingletonSocket", "SingletonCookie"]) {
+      await writeFile(join(dir, f), "stale");
+    }
+    await writeFile(join(dir, "Cookies"), "keep me"); // a real profile file
+    const result = await clearStaleSingletonLock(dir);
+    expect(result.removed.sort()).toEqual([
+      "SingletonCookie",
+      "SingletonLock",
+      "SingletonSocket",
+    ]);
+    expect(result.failed).toEqual([]);
+    // only the singleton files went; real profile data is untouched
+    expect(await readdir(dir)).toEqual(["Cookies"]);
+  });
+
+  it("is a no-op on a clean profile (nothing to clear is success)", async () => {
+    const result = await clearStaleSingletonLock(dir);
+    expect(result).toEqual({ removed: [], failed: [] });
+  });
+
+  it("reports (does not throw) a singleton it cannot remove", async () => {
+    // A directory named SingletonLock cannot be unlink()ed → surfaces in failed.
+    await mkdir(join(dir, "SingletonLock"));
+    const result = await clearStaleSingletonLock(dir);
+    expect(result.removed).toEqual([]);
+    expect(result.failed).toHaveLength(1);
+    expect(result.failed[0].name).toBe("SingletonLock");
+  });
+});

--- a/mcpjam-inspector/server/services/browserd/daemon/__tests__/settle.test.ts
+++ b/mcpjam-inspector/server/services/browserd/daemon/__tests__/settle.test.ts
@@ -1,0 +1,60 @@
+import { describe, expect, it, vi } from "vitest";
+import { settlePage, type SettleSteps } from "../settle";
+
+const resolved = async () => {};
+
+/** A step that never resolves on its own; it rejects when its signal aborts. */
+function hangsUntilAborted(signal: AbortSignal): Promise<void> {
+  return new Promise((_resolve, reject) => {
+    signal.addEventListener("abort", () => reject(new Error("aborted")), {
+      once: true,
+    });
+  });
+}
+
+describe("settlePage (L2)", () => {
+  it("reports settled:true when the sequence completes within budget", async () => {
+    const steps: SettleSteps = {
+      waitForCommit: resolved,
+      waitForNetworkQuiet: resolved,
+      waitForAnimationFrame: resolved,
+    };
+    expect(await settlePage(steps, { maxWaitMs: 1000 })).toEqual({ settled: true });
+  });
+
+  it("runs the steps in order: commit → network-quiet → animation frame", async () => {
+    const order: string[] = [];
+    const steps: SettleSteps = {
+      waitForCommit: async () => void order.push("commit"),
+      waitForNetworkQuiet: async () => void order.push("network"),
+      waitForAnimationFrame: async () => void order.push("raf"),
+    };
+    await settlePage(steps, { maxWaitMs: 1000 });
+    expect(order).toEqual(["commit", "network", "raf"]);
+  });
+
+  it("returns settled:false (never throws) when the page won't settle in time", async () => {
+    const waitForNetworkQuiet = vi.fn(hangsUntilAborted);
+    const steps: SettleSteps = {
+      waitForCommit: resolved,
+      waitForNetworkQuiet,
+      waitForAnimationFrame: resolved,
+    };
+    expect(await settlePage(steps, { maxWaitMs: 10 })).toEqual({ settled: false });
+    // the hung step was actually aborted, not left dangling
+    expect(waitForNetworkQuiet.mock.calls[0][0].aborted).toBe(true);
+  });
+
+  it("propagates a real failure (a crash is not mere slowness)", async () => {
+    const steps: SettleSteps = {
+      waitForCommit: async () => {
+        throw new Error("target crashed");
+      },
+      waitForNetworkQuiet: resolved,
+      waitForAnimationFrame: resolved,
+    };
+    await expect(settlePage(steps, { maxWaitMs: 1000 })).rejects.toThrow(
+      "target crashed",
+    );
+  });
+});

--- a/mcpjam-inspector/server/services/browserd/daemon/__tests__/state-token.test.ts
+++ b/mcpjam-inspector/server/services/browserd/daemon/__tests__/state-token.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it } from "vitest";
+import { computeStateToken, shortHash } from "../state-token";
+
+const base = { tabId: "tab-1", navCounter: 3, url: "https://x.test/a", domSignal: "<a><b>" };
+
+describe("computeStateToken (L3)", () => {
+  it("is stable for identical inputs", () => {
+    expect(computeStateToken(base)).toEqual(computeStateToken({ ...base }));
+  });
+
+  it("passes tabId and navCounter through verbatim", () => {
+    const t = computeStateToken(base);
+    expect(t.tabId).toBe("tab-1");
+    expect(t.navCounter).toBe(3);
+  });
+
+  it("changes urlHash when the URL changes (navigation)", () => {
+    const a = computeStateToken(base);
+    const b = computeStateToken({ ...base, url: "https://x.test/b" });
+    expect(b.urlHash).not.toBe(a.urlHash);
+    expect(b.domHash).toBe(a.domHash); // DOM signal unchanged
+  });
+
+  it("changes domHash when the structure changes (a banner shifted the DOM)", () => {
+    const a = computeStateToken(base);
+    const b = computeStateToken({ ...base, domSignal: "<a><banner><b>" });
+    expect(b.domHash).not.toBe(a.domHash);
+    expect(b.urlHash).toBe(a.urlHash); // same URL
+  });
+
+  it("distinguishes back/forward to the same URL via navCounter", () => {
+    const a = computeStateToken(base);
+    const b = computeStateToken({ ...base, navCounter: 5 });
+    expect(b.navCounter).not.toBe(a.navCounter);
+    expect(b.urlHash).toBe(a.urlHash);
+  });
+});
+
+describe("shortHash", () => {
+  it("is deterministic and compact", () => {
+    expect(shortHash("hello")).toBe(shortHash("hello"));
+    expect(shortHash("hello")).toHaveLength(16);
+    expect(shortHash("hello")).not.toBe(shortHash("world"));
+  });
+});

--- a/mcpjam-inspector/server/services/browserd/daemon/launch-args.ts
+++ b/mcpjam-inspector/server/services/browserd/daemon/launch-args.ts
@@ -1,0 +1,100 @@
+/**
+ * The Chromium switches and context pins browserd launches with in the hosted
+ * desktop sandbox — and WHY each earns its place.
+ *
+ * This extends the local WebMCP Inspector's `launch-args.ts` philosophy ("the
+ * probe that proved each one necessary") to the hosted context, which differs in
+ * three ways the local inspector never faces: the browser runs headed under Xfce
+ * inside E2B (small `/dev/shm`, GPU-less, frequently-occluded window), it opens
+ * arbitrary PUBLIC sites (bot-detection, cookie walls), and its screenshots feed
+ * an eval double-run bar that demands determinism.
+ *
+ * PROVENANCE HONESTY: the WebMCP feature flag and `--disable-dev-shm-usage` are
+ * carried over from the local inspector, where they were probed against the
+ * pinned Chromium (151.0.7922.34 / Playwright 1.62.1). The remaining hardening
+ * (L4) and determinism pins (L5) come from a year of production browser-driving
+ * shared by an operator (tracker: `webmcp-hosted-runtime`, learnings L4/L5) and
+ * are documented by PURPOSE here; each is live-verified by the driver's
+ * spike-gated integration test in PR (c2), NOT asserted as probed yet.
+ */
+import { WEBMCP_LAUNCH_ARGS } from "../../webmcp-inspector/launch-args";
+
+/**
+ * L4 — hardening flags that turn "the sandbox is flaky" and "the site blocks the
+ * agent" into solved problems. Grouped by what each defends against.
+ */
+export const BROWSERD_HARDENING_ARGS: readonly string[] = [
+  // Crash-avoidance in a container with a small /dev/shm. Its ABSENCE is exactly
+  // what reads as "E2B is flaky" under load. (Local inspector carries this too.)
+  "--disable-dev-shm-usage",
+
+  // Bot-detection is a top-3 practical failure on public HTTPS — browserd's
+  // hosted target. Drop the automation signal; a real UA is set on the context.
+  "--disable-blink-features=AutomationControlled",
+
+  // Determinism for the eval double-run bar: identical color across hosts.
+  "--force-color-profile=srgb",
+
+  // Otherwise a navigation can hold the OLD frame and we screenshot a page that
+  // no longer exists — poison for both the agent and the eval.
+  "--disable-features=PaintHolding",
+
+  // The panel/stream is frequently occluded and the driven tab is often not
+  // foreground; without these, timers throttle and the agent sees a frozen app.
+  "--disable-background-timer-throttling",
+  "--disable-renderer-backgrounding",
+  "--disable-backgrounding-occluded-windows",
+  "--disable-back-forward-cache",
+
+  // Every one of these otherwise becomes a modal the agent cannot reason about.
+  "--disable-popup-blocking",
+  "--disable-prompt-on-repost",
+  "--disable-hang-monitor",
+  "--noerrdialogs",
+
+  // Force desktop hover / fine-pointer semantics. Without it, sites that gate
+  // menus on `@media (hover: hover)` behave as touch devices and hover-triggered
+  // navigation is unreachable by synthetic input.
+  "--blink-settings=primaryHoverType=2,availableHoverTypes=2,primaryPointerType=4,availablePointerTypes=4",
+
+  // Software GL that still RUNS WebGL content instead of failing it (no GPU in
+  // the sandbox).
+  "--disable-gpu",
+  "--use-angle=swiftshader-webgl",
+];
+
+/**
+ * L5 — the canonical model-facing coordinate space. Every screenshot handed to
+ * the model is at this resolution and every coordinate it emits is in this
+ * space, mapped by the driver — so the model never does scaling math and a
+ * viewport change cannot silently corrupt targeting.
+ */
+export const BROWSERD_OBSERVATION_VIEWPORT = { width: 1024, height: 768 } as const;
+
+/**
+ * L5 — Playwright context options that make "fresh context per iteration" give
+ * DETERMINISM, not just isolation. Pinned so a screenshot on one host matches
+ * another: same device scale, locale, timezone, and no motion. A real desktop
+ * UA pairs with `--disable-blink-features=AutomationControlled` above.
+ */
+export const BROWSERD_CONTEXT_OPTIONS = {
+  viewport: BROWSERD_OBSERVATION_VIEWPORT,
+  deviceScaleFactor: 1,
+  locale: "en-US",
+  timezoneId: "UTC",
+  reducedMotion: "reduce",
+  colorScheme: "light",
+  userAgent:
+    "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) " +
+    "Chrome/151.0.0.0 Safari/537.36 MCPJam-Browser/1.0",
+} as const;
+
+/**
+ * Build browserd's full launch-arg list: the WebMCP feature flag (shared with
+ * the local inspector, single source), the L4 hardening set, and any extra args
+ * (e.g. `--window-size` matched to the X screen geometry, supplied by the boot
+ * recipe once it knows the display). Order is stable for test assertions.
+ */
+export function buildBrowserdLaunchArgs(extra: readonly string[] = []): string[] {
+  return [...WEBMCP_LAUNCH_ARGS, ...BROWSERD_HARDENING_ARGS, ...extra];
+}

--- a/mcpjam-inspector/server/services/browserd/daemon/profile-lock.ts
+++ b/mcpjam-inspector/server/services/browserd/daemon/profile-lock.ts
@@ -1,0 +1,65 @@
+/**
+ * L8 — clearing a stale Chromium profile lock before relaunch.
+ *
+ * A persistent `--user-data-dir` is a SINGLETON: exactly one Chromium may own it
+ * at a time, guarded by `SingletonLock` (a symlink) plus `SingletonSocket` /
+ * `SingletonCookie`. On a clean exit Chromium removes them; on an UNGRACEFUL
+ * kill they remain, and the next launch either fails or silently forwards the
+ * URL to a process that is already dead.
+ *
+ * browserd's recovery posture makes this the common case, not the edge case:
+ * the M0 finding is to kill/relaunch on a failed `/healthz` after wake, so every
+ * wake that fails health leaves an ungraceful exit behind. The supervisor must
+ * therefore clear the lock before each relaunch. Best-effort by design: a
+ * missing file is success (nothing to clear), and a lock we cannot remove is
+ * surfaced, not thrown — the caller decides whether to proceed.
+ */
+import { unlink } from "node:fs/promises";
+import { join } from "node:path";
+
+/** The singleton artifacts Chromium leaves in a user-data dir. */
+const SINGLETON_FILES = [
+  "SingletonLock",
+  "SingletonSocket",
+  "SingletonCookie",
+] as const;
+
+export interface ClearedLock {
+  /** Names actually removed (were present). */
+  removed: string[];
+  /** Names that were present but could not be removed, with the error text. */
+  failed: Array<{ name: string; error: string }>;
+}
+
+/**
+ * Remove any stale Chromium singleton files from `userDataDir`. Safe to call
+ * when the directory is clean (removes nothing) and when Chromium is NOT running
+ * (there is no live owner to disturb — the caller guarantees that by only
+ * clearing before a relaunch). ENOENT is treated as already-clear.
+ */
+export async function clearStaleSingletonLock(
+  userDataDir: string,
+): Promise<ClearedLock> {
+  const result: ClearedLock = { removed: [], failed: [] };
+  for (const name of SINGLETON_FILES) {
+    try {
+      await unlink(join(userDataDir, name));
+      result.removed.push(name);
+    } catch (err) {
+      if (isNotFound(err)) continue; // already clear — the common, healthy case
+      result.failed.push({
+        name,
+        error: err instanceof Error ? err.message : String(err),
+      });
+    }
+  }
+  return result;
+}
+
+function isNotFound(err: unknown): boolean {
+  return (
+    typeof err === "object" &&
+    err !== null &&
+    (err as NodeJS.ErrnoException).code === "ENOENT"
+  );
+}

--- a/mcpjam-inspector/server/services/browserd/daemon/settle.ts
+++ b/mcpjam-inspector/server/services/browserd/daemon/settle.ts
@@ -1,0 +1,64 @@
+/**
+ * L2 — settling a page before capture, instead of exposing a `wait` verb.
+ *
+ * Models reflexively insert click → sleep(5s) → screenshot, and every sleep is a
+ * wasted turn and a wrong guess about duration. browserd removes the need: after
+ * a navigation or an act, it settles the page HERE — nav commit → a brief
+ * network-quiet window → one animation frame — and only then captures. When a
+ * page genuinely will not settle within the budget, the driver returns the frame
+ * anyway with `settled: false` (see `BrowserCommandResult`), and the model
+ * re-observes only when told the state is unsettled — it never asks browserd to
+ * wait.
+ *
+ * This module is the pure POLICY: the sequence and the timeout budget. The three
+ * waits are injected so the driver wires them to Playwright (`waitForLoadState`,
+ * a network-idle watcher, an `evaluate` of `requestAnimationFrame`) while the
+ * decision logic stays unit-testable without a browser.
+ */
+
+export interface SettleSteps {
+  /** Resolves when the navigation has committed. */
+  waitForCommit(signal: AbortSignal): Promise<void>;
+  /** Resolves after a short window with no in-flight requests. */
+  waitForNetworkQuiet(signal: AbortSignal): Promise<void>;
+  /** Resolves after one rendered frame, so layout reflects the settled DOM. */
+  waitForAnimationFrame(signal: AbortSignal): Promise<void>;
+}
+
+export interface SettleOptions {
+  /** Total budget for the whole sequence; past it, return `settled: false`. */
+  maxWaitMs: number;
+}
+
+export const DEFAULT_SETTLE_OPTIONS: SettleOptions = { maxWaitMs: 10_000 };
+
+/**
+ * Run the settle sequence, bounded by `maxWaitMs`. Returns `{ settled: true }`
+ * when the page came to rest within budget, `{ settled: false }` when it did not
+ * (the caller captures and returns the frame regardless — never a wait verb). A
+ * step that fails for a reason OTHER than the timeout propagates: that is a real
+ * fault (e.g. the page crashed), not mere slowness, and must not masquerade as
+ * an unsettled frame.
+ */
+export async function settlePage(
+  steps: SettleSteps,
+  options: SettleOptions = DEFAULT_SETTLE_OPTIONS,
+): Promise<{ settled: boolean }> {
+  const controller = new AbortController();
+  let timedOut = false;
+  const timer = setTimeout(() => {
+    timedOut = true;
+    controller.abort();
+  }, options.maxWaitMs);
+  try {
+    await steps.waitForCommit(controller.signal);
+    await steps.waitForNetworkQuiet(controller.signal);
+    await steps.waitForAnimationFrame(controller.signal);
+    return { settled: true };
+  } catch (err) {
+    if (timedOut) return { settled: false };
+    throw err;
+  } finally {
+    clearTimeout(timer);
+  }
+}

--- a/mcpjam-inspector/server/services/browserd/daemon/state-token.ts
+++ b/mcpjam-inspector/server/services/browserd/daemon/state-token.ts
@@ -1,0 +1,45 @@
+/**
+ * L3 — computing a tab's observation state token.
+ *
+ * Every capture the driver returns carries one of these (see `protocol.ts`); a
+ * later `act` may pin itself to the token it was decided from, and the daemon
+ * refuses the act if the token no longer matches — the production failure mode
+ * is not duplicate delivery (the command queue handles that) but STALE
+ * targeting: a click computed from a screenshot that a late-loading banner has
+ * shifted. The token must therefore change whenever the page navigates OR
+ * mutates structurally, and be stable otherwise.
+ *
+ * This module is the pure computation only: the driver supplies the raw facts
+ * (the tab's nav counter, its URL, and a structural signal of the DOM) and this
+ * turns them into a token. Keeping it pure makes both the hashing and the
+ * change-detection semantics unit-testable without a browser.
+ */
+import { createHash } from "node:crypto";
+import type { ObservationStateToken } from "../protocol";
+
+/** A short, stable digest. Change-detection only — not a security boundary. */
+export function shortHash(value: string): string {
+  return createHash("sha1").update(value, "utf8").digest("hex").slice(0, 16);
+}
+
+export interface StateTokenInputs {
+  tabId: string;
+  /** Bumps on every navigation commit, so back/forward to the same URL differ. */
+  navCounter: number;
+  url: string;
+  /**
+   * A structural signal of the current DOM — e.g. a serialization of the tag
+   * skeleton or the a11y tree. The driver decides its exact shape; this module
+   * only needs it to change when the structure the model targeted changes.
+   */
+  domSignal: string;
+}
+
+export function computeStateToken(inputs: StateTokenInputs): ObservationStateToken {
+  return {
+    tabId: inputs.tabId,
+    navCounter: inputs.navCounter,
+    urlHash: shortHash(inputs.url),
+    domHash: shortHash(inputs.domSignal),
+  };
+}


### PR DESCRIPTION
**W1 PR (c1)** of the Hosted Browser + WebMCP Runtime. Follows #4467 (queue) and #4470 (control plane), both merged.

The pure, unit-tested mechanics the real Chromium/CDP driver sits on — split out ahead of the driver itself so they get **normal-CI review** while the live-browser code (PR c2) takes the spike-gated path. This mirrors how the local `webmcp-inspector` separates its helpers from its Playwright provider.

## Contents (8 files, all pure + tested)
- **`daemon/launch-args.ts` (L4/L5)** — browserd's Chromium switches + context pins, extending the local inspector's *"the probe that earned each flag"* doctrine to the hosted sandbox: crash-avoidance (`--disable-dev-shm-usage`), bot-detection (`--disable-blink-features=AutomationControlled` + real UA), screenshot determinism (`srgb`, pinned scale/locale/timezone/reduced-motion), occlusion throttle-disables, modal-killers, desktop hover/pointer, software WebGL, and a canonical **1024×768 model-facing coordinate space**. Reuses the inspector's single `--enable-features=WebMCP` flag.
  - *Provenance honesty:* carried-over flags were probed on the pinned Chromium (151.0.7922.34); the new ones (from a year of production browser-driving) are documented **by purpose** and live-verified in **c2**, not asserted as probed yet.
- **`daemon/state-token.ts` (L3)** — `computeStateToken`: a cheap url + DOM-structure digest that changes on navigation or structural mutation — the basis for `stale_observation`.
- **`daemon/profile-lock.ts` (L8)** — `clearStaleSingletonLock`: removes the `SingletonLock`/`Socket`/`Cookie` an ungraceful kill leaves, so relaunch-on-wake doesn't hand off to a dead instance (best-effort; missing = success; unremovable = reported, not thrown).
- **`daemon/settle.ts` (L2)** — `settlePage`: the settle **policy** (commit → network-quiet → rAF, bounded), returning `settled: false` rather than exposing a `wait` verb; the real waits are injected so the decision is testable without a browser.

## Tests
20 new (launch-args ordering + the load-bearing flags/pins; state-token change-detection; profile-lock incl. the unremovable case; settle order/timeout/real-failure). **62 green total, tsc clean across the repo.**

## Next
**PR (c2):** the `ChromiumDriver` wrapping the inspector's `WebMcpBrowserProvider`, wiring these four helpers, W1 action subset (navigate/back/reload/observe), + entrypoint + esbuild bundler + a spike-gated live integration test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Additive library code and tests only; no runtime wiring in this PR, so production behavior is unchanged until the driver integrates these modules.
> 
> **Overview**
> Introduces **pure, testable building blocks** under `browserd/daemon` for the upcoming hosted Chromium driver (wired in a follow-up PR), mirroring how the local WebMCP inspector splits helpers from Playwright.
> 
> **Launch configuration** extends the inspector’s `WEBMCP_LAUNCH_ARGS` with `buildBrowserdLaunchArgs`, a documented L4 hardening switch set (sandbox stability, bot-detection, occlusion/throttling, modals, desktop pointer/hover, software WebGL), plus L5 pins: **1024×768** observation viewport and fixed Playwright context options (locale, timezone, reduced motion, desktop UA).
> 
> **Observation safety** adds `computeStateToken` / `shortHash` so captures carry url/DOM-structure digests and acts can detect **stale targeting** after navigation or DOM shifts (with `navCounter` for same-URL history).
> 
> **Recovery** adds `clearStaleSingletonLock` to best-effort remove Chromium `Singleton*` files after ungraceful kills before relaunch, without touching real profile data.
> 
> **Pre-capture behavior** adds `settlePage`: commit → network-quiet → animation frame within a timeout, returning `settled: false` on budget expiry (no `wait` verb) while still propagating real crashes.
> 
> Twenty new Vitest cases cover ordering, determinism pins, token change semantics, lock cleanup edge cases, and settle ordering/timeout/abort behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8bc1e3a9d9d5a1109698b95861ce45011711b477. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds the four pure, unit-tested modules that underpin the hosted browser's Chromium driver: launch args, a page state token, stale profile-lock cleanup, and a settle policy. They're split out from the live-browser driver (c2) so this foundation gets normal CI review; 20 new tests bring the suite to 62 green with tsc clean.

**Changes**

- `launch-args.ts` defines browserd's Chromium switches and context pins — crash avoidance, bot detection, deterministic capture (srgb, pinned scale/locale/timezone/motion), occlusion throttle-disables, modal suppressors, desktop hover/pointer, software WebGL, and a canonical 1024×768 model-facing viewport.
- `state-token.ts` computes a URL + DOM-structure digest that changes on navigation or structural mutation, the basis for stale-observation detection.
- `profile-lock.ts` clears stale `SingletonLock`/`SingletonSocket`/`SingletonCookie` files an ungraceful kill leaves, best-effort: missing is success, unremovable is reported not thrown.
- `settle.ts` runs commit → network-quiet → animation frame under a bounded budget, returning `settled: false` on timeout rather than exposing a wait verb; waits are injected for browser-free testing.

Launch flags carried over from the local inspector were probed against the pinned Chromium (151.0.7922.34); the new hardening flags are documented by purpose here and verified live in the c2 driver.

<sup>Written for commit 8bc1e3a9d9d5a1109698b95861ce45011711b477. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/MCPJam/inspector/pull/4472?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

