### PR TITLE
feat(browserd): the real ChromiumDriver — persistent context, tabs, W1 nav/observe (W1 PR c2)

### DIFF
--- a/mcpjam-inspector/server/services/browserd/daemon/__tests__/chromium-driver.test.ts
+++ b/mcpjam-inspector/server/services/browserd/daemon/__tests__/chromium-driver.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "vitest";
 import { ChromiumDriver } from "../chromium-driver";
+import { shortHash } from "../state-token";
 import type { DriverContext, DriverPage } from "../browser-page";
 import type { BrowserCommand } from "../../protocol";
 
@@ -9,11 +10,18 @@ interface FakePage extends DriverPage {
   readonly calls: { goto: string[]; reload: number; goBack: number; shots: number };
 }
 
-function fakePage(init: { url?: string; dom?: string; hangNetwork?: boolean } = {}): FakePage {
+function fakePage(init: {
+  url?: string;
+  dom?: string;
+  hangNetwork?: boolean;
+  /** Called inside screenshotBase64 — used to simulate a DOM shift mid-capture. */
+  onScreenshot?: (page: { setDom: (d: string) => void }) => void;
+} = {}): FakePage {
   let url = init.url ?? "about:blank";
   let dom = init.dom ?? "0BODY";
   let closed = false;
   const calls = { goto: [] as string[], reload: 0, goBack: 0, shots: 0 };
+  const setDom = (d: string) => { dom = d; };
   return {
     async goto(u) { calls.goto.push(u); url = u; },
     async reload() { calls.reload++; },
@@ -26,12 +34,16 @@ function fakePage(init: { url?: string; dom?: string; hangNetwork?: boolean } = 
     },
     async requestAnimationFrame() {},
     async domStructureSignal() { return dom; },
-    async screenshotBase64() { calls.shots++; return "BASE64PNG"; },
+    async screenshotBase64() {
+      calls.shots++;
+      init.onScreenshot?.({ setDom });
+      return "BASE64PNG";
+    },
     url: () => url,
     close: async () => { closed = true; },
     isClosed: () => closed,
     setUrl: (u) => { url = u; },
-    setDom: (d) => { dom = d; },
+    setDom,
     calls,
   };
 }
@@ -67,7 +79,21 @@ describe("ChromiumDriver — navigation (W1 subset)", () => {
     expect(res.ok).toBe(true);
     expect(res.output).toEqual({ url: "https://x.test/" });
     expect(res.settled).toBe(true);
-    expect(res.stateToken).toMatchObject({ tabId: "@default", navCounter: 1 });
+    // tab-less commands resolve to the shared session key, which MUST match the
+    // queue's default key so they cannot race an explicit tabId of the same name.
+    expect(res.stateToken).toMatchObject({ tabId: "@session", navCounter: 1 });
+  });
+
+  it("uses the queue's default key for tab-less commands, so an explicit @session is the SAME tab (P1)", async () => {
+    const page = fakePage();
+    const { context, created } = fakeContext({ pages: [page] });
+    const driver = new ChromiumDriver(context);
+    await driver.execute(cmd({ kind: "navigate", url: "https://x.test/" })); // tab-less
+    const viaExplicit = await driver.execute(
+      cmd({ kind: "observe", mode: "url" }, "@session"),
+    );
+    expect(created).toHaveLength(1); // one page, not two racing FIFOs
+    expect(viaExplicit.output).toEqual({ url: "https://x.test/" });
   });
 
   it("dispatches back and reload to the page", async () => {
@@ -122,6 +148,60 @@ describe("ChromiumDriver — observe", () => {
     await driver.execute(cmd({ kind: "navigate", url: "https://x.test/" }));
     const res = await driver.execute(cmd({ kind: "observe", mode: "a11y" }));
     expect(res).toMatchObject({ ok: false, error: "unimplemented_in_w1: observe/a11y" });
+  });
+});
+
+describe("ChromiumDriver — screenshot token binds to the captured frame (P1)", () => {
+  it("returns a token computed from the DOM the image was captured against", async () => {
+    const page = fakePage({ url: "https://x.test/", dom: "0BODY>1MAIN" });
+    const { context } = fakeContext({ pages: [page] });
+    const driver = new ChromiumDriver(context);
+    await driver.execute(cmd({ kind: "navigate", url: "https://x.test/" }));
+    const res = await driver.execute(cmd({ kind: "observe", mode: "screenshot" }));
+    expect(res.output).toEqual({ screenshot: "BASE64PNG" });
+    expect(res.stateToken!.domHash).toBe(shortHash("0BODY>1MAIN")); // matches the frame
+    expect(res.settled).toBeUndefined(); // stable capture, not flagged
+  });
+
+  it("flags settled:false when the DOM keeps shifting mid-capture (no stale image pinned)", async () => {
+    let n = 0;
+    const page = fakePage({
+      dom: "A",
+      onScreenshot: ({ setDom }) => setDom(`B${++n}`), // a new layout on every shot
+    });
+    const { context } = fakeContext({ pages: [page] });
+    const driver = new ChromiumDriver(context);
+    await driver.execute(cmd({ kind: "navigate", url: "https://x.test/" }));
+    const res = await driver.execute(cmd({ kind: "observe", mode: "screenshot" }));
+    expect(res.ok).toBe(true);
+    expect(res.settled).toBe(false); // caller must re-observe, not pin an act
+    // the token still describes the post-capture DOM, never an earlier one
+    expect(res.stateToken!.domHash).toBe(shortHash(`B${n}`));
+  });
+});
+
+describe("ChromiumDriver — only navigate may create or replace a tab (P2)", () => {
+  it("rejects navigate newTab:true instead of silently replacing the current tab", async () => {
+    const { context } = fakeContext();
+    const driver = new ChromiumDriver(context);
+    const res = await driver.execute(
+      cmd({ kind: "navigate", url: "https://x.test/", newTab: true }),
+    );
+    expect(res).toMatchObject({ ok: false, error: "unimplemented_in_w1: navigate/newTab" });
+  });
+
+  it("returns unknown_tab for back/reload on a tab that was never created", async () => {
+    const { context, created } = fakeContext();
+    const driver = new ChromiumDriver(context);
+    expect(await driver.execute(cmd({ kind: "back" }, "ghost"))).toMatchObject({
+      ok: false,
+      error: "unknown_tab: ghost",
+    });
+    expect(await driver.execute(cmd({ kind: "reload" }, "ghost"))).toMatchObject({
+      ok: false,
+      error: "unknown_tab: ghost",
+    });
+    expect(created).toHaveLength(0); // no about:blank page was conjured
   });
 });
 

--- a/mcpjam-inspector/server/services/browserd/daemon/__tests__/chromium-driver.test.ts
+++ b/mcpjam-inspector/server/services/browserd/daemon/__tests__/chromium-driver.test.ts
@@ -1,0 +1,179 @@
+import { describe, expect, it } from "vitest";
+import { ChromiumDriver } from "../chromium-driver";
+import type { DriverContext, DriverPage } from "../browser-page";
+import type { BrowserCommand } from "../../protocol";
+
+interface FakePage extends DriverPage {
+  setUrl(u: string): void;
+  setDom(d: string): void;
+  readonly calls: { goto: string[]; reload: number; goBack: number; shots: number };
+}
+
+function fakePage(init: { url?: string; dom?: string; hangNetwork?: boolean } = {}): FakePage {
+  let url = init.url ?? "about:blank";
+  let dom = init.dom ?? "0BODY";
+  let closed = false;
+  const calls = { goto: [] as string[], reload: 0, goBack: 0, shots: 0 };
+  return {
+    async goto(u) { calls.goto.push(u); url = u; },
+    async reload() { calls.reload++; },
+    async goBack() { calls.goBack++; },
+    async waitForNetworkIdle(signal) {
+      if (!init.hangNetwork) return;
+      return new Promise<void>((_r, reject) =>
+        signal.addEventListener("abort", () => reject(new Error("aborted")), { once: true }),
+      );
+    },
+    async requestAnimationFrame() {},
+    async domStructureSignal() { return dom; },
+    async screenshotBase64() { calls.shots++; return "BASE64PNG"; },
+    url: () => url,
+    close: async () => { closed = true; },
+    isClosed: () => closed,
+    setUrl: (u) => { url = u; },
+    setDom: (d) => { dom = d; },
+    calls,
+  };
+}
+
+function fakeContext(init: { pages?: FakePage[]; connected?: boolean } = {}) {
+  let i = 0;
+  let connected = init.connected ?? true;
+  let closed = false;
+  const created: FakePage[] = [];
+  const context: DriverContext = {
+    async newPage() {
+      const page = init.pages?.[i++] ?? fakePage();
+      created.push(page);
+      return page;
+    },
+    isConnected: () => connected,
+    close: async () => { closed = true; },
+  };
+  return { context, created, setConnected: (v: boolean) => (connected = v), wasClosed: () => closed };
+}
+
+function cmd(action: BrowserCommand["action"], tabId?: string): BrowserCommand {
+  return { commandId: `c-${Math.random()}`, tabId, source: "chat", action };
+}
+
+describe("ChromiumDriver — navigation (W1 subset)", () => {
+  it("navigates, settles, and returns the observation with a state token (L2/L3)", async () => {
+    const page = fakePage();
+    const { context } = fakeContext({ pages: [page] });
+    const driver = new ChromiumDriver(context);
+    const res = await driver.execute(cmd({ kind: "navigate", url: "https://x.test/" }));
+    expect(page.calls.goto).toEqual(["https://x.test/"]);
+    expect(res.ok).toBe(true);
+    expect(res.output).toEqual({ url: "https://x.test/" });
+    expect(res.settled).toBe(true);
+    expect(res.stateToken).toMatchObject({ tabId: "@default", navCounter: 1 });
+  });
+
+  it("dispatches back and reload to the page", async () => {
+    const page = fakePage();
+    const { context } = fakeContext({ pages: [page] });
+    const driver = new ChromiumDriver(context);
+    await driver.execute(cmd({ kind: "navigate", url: "https://x.test/" }));
+    await driver.execute(cmd({ kind: "reload" }));
+    await driver.execute(cmd({ kind: "back" }));
+    expect(page.calls.reload).toBe(1);
+    expect(page.calls.goBack).toBe(1);
+  });
+
+  it("returns settled:false when the page will not go quiet in budget", async () => {
+    const page = fakePage({ hangNetwork: true });
+    const { context } = fakeContext({ pages: [page] });
+    const driver = new ChromiumDriver(context, { settle: { maxWaitMs: 10 } });
+    const res = await driver.execute(cmd({ kind: "navigate", url: "https://slow.test/" }));
+    expect(res.ok).toBe(true);
+    expect(res.settled).toBe(false); // frame returned anyway, no wait verb
+  });
+});
+
+describe("ChromiumDriver — observe", () => {
+  it("returns a screenshot / url / dom each with a fresh token", async () => {
+    const page = fakePage({ url: "https://x.test/", dom: "0BODY>1DIV" });
+    const { context } = fakeContext({ pages: [page] });
+    const driver = new ChromiumDriver(context);
+    await driver.execute(cmd({ kind: "navigate", url: "https://x.test/" }));
+
+    const shot = await driver.execute(cmd({ kind: "observe", mode: "screenshot" }));
+    expect(shot.output).toEqual({ screenshot: "BASE64PNG" });
+    expect(shot.stateToken).toBeDefined();
+
+    const url = await driver.execute(cmd({ kind: "observe", mode: "url" }));
+    expect(url.output).toEqual({ url: "https://x.test/" });
+
+    const dom = await driver.execute(cmd({ kind: "observe", mode: "dom" }));
+    expect(dom.output).toEqual({ dom: "0BODY>1DIV" });
+  });
+
+  it("fails an observe on a tab that was never navigated", async () => {
+    const { context } = fakeContext();
+    const driver = new ChromiumDriver(context);
+    const res = await driver.execute(cmd({ kind: "observe", mode: "url" }, "ghost"));
+    expect(res).toMatchObject({ ok: false, error: "unknown_tab: ghost" });
+  });
+
+  it("marks W1-unimplemented observe modes explicitly", async () => {
+    const { context } = fakeContext();
+    const driver = new ChromiumDriver(context);
+    await driver.execute(cmd({ kind: "navigate", url: "https://x.test/" }));
+    const res = await driver.execute(cmd({ kind: "observe", mode: "a11y" }));
+    expect(res).toMatchObject({ ok: false, error: "unimplemented_in_w1: observe/a11y" });
+  });
+});
+
+describe("ChromiumDriver — act/webmcp are explicitly deferred to W3", () => {
+  it("returns an unimplemented result rather than silently doing nothing", async () => {
+    const { context } = fakeContext();
+    const driver = new ChromiumDriver(context);
+    for (const action of [
+      { kind: "act", verb: "click" } as const,
+      { kind: "webmcp_invoke", toolKey: "t", input: {} } as const,
+      { kind: "webmcp_cancel", invocationId: "i" } as const,
+    ]) {
+      const res = await driver.execute(cmd(action));
+      expect(res.ok).toBe(false);
+      expect(res.error).toContain("unimplemented_in_w1");
+    }
+  });
+});
+
+describe("ChromiumDriver — tabs, state token, health, close", () => {
+  it("reuses a page for the same tabId and opens a new one per distinct tabId", async () => {
+    const { context, created } = fakeContext();
+    const driver = new ChromiumDriver(context);
+    await driver.execute(cmd({ kind: "navigate", url: "https://a.test/" }, "t1"));
+    await driver.execute(cmd({ kind: "navigate", url: "https://b.test/" }, "t1"));
+    expect(created).toHaveLength(1); // same tab reused
+    await driver.execute(cmd({ kind: "navigate", url: "https://c.test/" }, "t2"));
+    expect(created).toHaveLength(2); // distinct tab → new page
+  });
+
+  it("currentStateToken tracks the tab and changes when the DOM shifts (L3)", async () => {
+    const page = fakePage({ url: "https://x.test/", dom: "0BODY" });
+    const { context } = fakeContext({ pages: [page] });
+    const driver = new ChromiumDriver(context);
+    await driver.execute(cmd({ kind: "navigate", url: "https://x.test/" }));
+    const before = await driver.currentStateToken(undefined);
+    page.setDom("0BODY>1BANNER"); // a late banner shifts the DOM
+    const after = await driver.currentStateToken(undefined);
+    expect(after!.domHash).not.toBe(before!.domHash);
+    expect(await driver.currentStateToken("ghost")).toBeUndefined();
+  });
+
+  it("reports health from the context and closes everything", async () => {
+    const page = fakePage();
+    const fc = fakeContext({ pages: [page] });
+    const driver = new ChromiumDriver(fc.context);
+    await driver.execute(cmd({ kind: "navigate", url: "https://x.test/" }));
+    expect(await driver.health()).toEqual({ ok: true });
+    fc.setConnected(false);
+    expect(await driver.health()).toMatchObject({ ok: false });
+    await driver.close();
+    expect(page.isClosed()).toBe(true);
+    expect(fc.wasClosed()).toBe(true);
+  });
+});

--- a/mcpjam-inspector/server/services/browserd/daemon/__tests__/chromium-driver.test.ts
+++ b/mcpjam-inspector/server/services/browserd/daemon/__tests__/chromium-driver.test.ts
@@ -14,14 +14,15 @@ function fakePage(init: {
   url?: string;
   dom?: string;
   hangNetwork?: boolean;
-  /** Called inside screenshotBase64 — used to simulate a DOM shift mid-capture. */
-  onScreenshot?: (page: { setDom: (d: string) => void }) => void;
+  /** Called inside screenshotBase64 — used to simulate a shift mid-capture. */
+  onScreenshot?: (page: { setDom: (d: string) => void; setUrl: (u: string) => void }) => void;
 } = {}): FakePage {
   let url = init.url ?? "about:blank";
   let dom = init.dom ?? "0BODY";
   let closed = false;
   const calls = { goto: [] as string[], reload: 0, goBack: 0, shots: 0 };
   const setDom = (d: string) => { dom = d; };
+  const setUrl = (u: string) => { url = u; };
   return {
     async goto(u) { calls.goto.push(u); url = u; },
     async reload() { calls.reload++; },
@@ -36,13 +37,13 @@ function fakePage(init: {
     async domStructureSignal() { return dom; },
     async screenshotBase64() {
       calls.shots++;
-      init.onScreenshot?.({ setDom });
+      init.onScreenshot?.({ setDom, setUrl });
       return "BASE64PNG";
     },
     url: () => url,
     close: async () => { closed = true; },
     isClosed: () => closed,
-    setUrl: (u) => { url = u; },
+    setUrl,
     setDom,
     calls,
   };
@@ -161,6 +162,23 @@ describe("ChromiumDriver — screenshot token binds to the captured frame (P1)",
     expect(res.output).toEqual({ screenshot: "BASE64PNG" });
     expect(res.stateToken!.domHash).toBe(shortHash("0BODY>1MAIN")); // matches the frame
     expect(res.settled).toBeUndefined(); // stable capture, not flagged
+  });
+
+  it("flags settled:false when the URL shifts mid-capture even if the DOM skeleton holds (P1)", async () => {
+    // A same-skeleton client-side route change: DOM signal is unchanged, but the
+    // URL moves — the token must not bind a new-route url to an old-route image.
+    let n = 0;
+    const page = fakePage({
+      url: "https://x.test/a",
+      dom: "0BODY>1MAIN", // never changes
+      onScreenshot: ({ setUrl }) => setUrl(`https://x.test/route-${++n}`),
+    });
+    const { context } = fakeContext({ pages: [page] });
+    const driver = new ChromiumDriver(context);
+    await driver.execute(cmd({ kind: "navigate", url: "https://x.test/a" }));
+    const res = await driver.execute(cmd({ kind: "observe", mode: "screenshot" }));
+    expect(res.settled).toBe(false);
+    expect(res.stateToken!.urlHash).toBe(shortHash(`https://x.test/route-${n}`));
   });
 
   it("flags settled:false when the DOM keeps shifting mid-capture (no stale image pinned)", async () => {

--- a/mcpjam-inspector/server/services/browserd/daemon/__tests__/chromium-launch.spike.test.ts
+++ b/mcpjam-inspector/server/services/browserd/daemon/__tests__/chromium-launch.spike.test.ts
@@ -1,0 +1,69 @@
+/**
+ * Live validation of the Playwright adapter (`chromium-launch.ts`), which has no
+ * unit tests of its own. Opt-in only — set `RUN_BROWSERD_SPIKE=true` and have the
+ * pinned Chromium installed — so it never runs (or fails) in ordinary CI, the
+ * same posture as the M0 E2B spike. It drives a real persistent context through
+ * the full `ChromiumDriver` to prove navigate + observe + settle + state token
+ * work end to end against a real browser.
+ */
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { launchBrowserdContext } from "../chromium-launch";
+import { ChromiumDriver } from "../chromium-driver";
+import type { DriverContext } from "../browser-page";
+
+const RUN = process.env.RUN_BROWSERD_SPIKE === "true";
+
+const PAGE = `data:text/html,${encodeURIComponent(
+  "<!doctype html><title>t</title><body><main><h1>hi</h1><button>go</button></main></body>",
+)}`;
+
+describe.skipIf(!RUN)("browserd Chromium adapter — real browser", () => {
+  let userDataDir: string;
+  let context: DriverContext;
+  let driver: ChromiumDriver;
+
+  beforeAll(async () => {
+    userDataDir = await mkdtemp(join(tmpdir(), "browserd-spike-"));
+    context = await launchBrowserdContext({ userDataDir, headless: true });
+    driver = new ChromiumDriver(context);
+  }, 60_000);
+
+  afterAll(async () => {
+    await driver?.close().catch(() => {});
+    if (userDataDir) await rm(userDataDir, { recursive: true, force: true });
+  });
+
+  it("navigates, settles, and observes with a live state token", async () => {
+    const nav = await driver.execute({
+      commandId: "n1",
+      source: "chat",
+      action: { kind: "navigate", url: PAGE },
+    });
+    expect(nav.ok).toBe(true);
+    expect(nav.settled).toBe(true);
+    expect(nav.stateToken?.navCounter).toBe(1);
+
+    const shot = await driver.execute({
+      commandId: "s1",
+      source: "chat",
+      action: { kind: "observe", mode: "screenshot" },
+    });
+    expect(shot.ok).toBe(true);
+    const screenshot = (shot.output as { screenshot: string }).screenshot;
+    expect(screenshot.length).toBeGreaterThan(100); // a real PNG came back
+
+    const dom = await driver.execute({
+      commandId: "d1",
+      source: "chat",
+      action: { kind: "observe", mode: "dom" },
+    });
+    expect((dom.output as { dom: string }).dom).toContain("BUTTON");
+
+    // The live token matches what the driver reports out-of-band.
+    const live = await driver.currentStateToken(undefined);
+    expect(live?.urlHash).toBe(nav.stateToken?.urlHash);
+  }, 60_000);
+});

--- a/mcpjam-inspector/server/services/browserd/daemon/__tests__/chromium-launch.test.ts
+++ b/mcpjam-inspector/server/services/browserd/daemon/__tests__/chromium-launch.test.ts
@@ -1,5 +1,10 @@
-import { describe, expect, it } from "vitest";
-import { wrapPage, type AnyPage } from "../chromium-launch";
+import { describe, expect, it, vi } from "vitest";
+import {
+  adaptContext,
+  wrapPage,
+  type AnyContext,
+  type AnyPage,
+} from "../chromium-launch";
 
 /**
  * Unit coverage for the ONE piece of the Playwright adapter that had a P1: the
@@ -54,5 +59,41 @@ describe("wrapPage.waitForNetworkIdle (P1)", () => {
     await expect(page.waitForNetworkIdle(new AbortController().signal)).rejects.toThrow(
       "target crashed",
     );
+  });
+});
+
+function fakeAnyContext(over: Partial<AnyContext> = {}): AnyContext {
+  return {
+    newPage: vi.fn(async () => fakeAnyPage()),
+    pages: () => [],
+    browser: () => ({ isConnected: () => true }),
+    async close() {},
+    ...over,
+  };
+}
+
+describe("adaptContext (P2 — adopt the persistent context's startup page)", () => {
+  it("adopts the startup page for the first tab, then creates fresh pages", async () => {
+    const startup = fakeAnyPage({ url: () => "about:blank" });
+    const ctx = fakeAnyContext({ pages: () => [startup] });
+    const driver = adaptContext(ctx);
+
+    await driver.newPage(); // first tab
+    expect(ctx.newPage).not.toHaveBeenCalled(); // adopted the startup page, no orphan
+
+    await driver.newPage(); // second tab
+    expect(ctx.newPage).toHaveBeenCalledOnce(); // only now is a new page created
+  });
+
+  it("creates a page normally when the context reports no startup pages", async () => {
+    const ctx = fakeAnyContext({ pages: () => [] });
+    const driver = adaptContext(ctx);
+    await driver.newPage();
+    expect(ctx.newPage).toHaveBeenCalledOnce();
+  });
+
+  it("reports connectivity from the underlying browser (null → assumed alive)", async () => {
+    expect(adaptContext(fakeAnyContext({ browser: () => ({ isConnected: () => false }) })).isConnected()).toBe(false);
+    expect(adaptContext(fakeAnyContext({ browser: () => null })).isConnected()).toBe(true);
   });
 });

--- a/mcpjam-inspector/server/services/browserd/daemon/__tests__/chromium-launch.test.ts
+++ b/mcpjam-inspector/server/services/browserd/daemon/__tests__/chromium-launch.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, it } from "vitest";
+import { wrapPage, type AnyPage } from "../chromium-launch";
+
+/**
+ * Unit coverage for the ONE piece of the Playwright adapter that had a P1: the
+ * network-idle wait must NOT convert a never-idling page into a settled one. The
+ * rest of the adapter is exercised by the RUN_BROWSERD_SPIKE integration test.
+ */
+function fakeAnyPage(over: Partial<AnyPage> = {}): AnyPage {
+  return {
+    async goto() {},
+    async reload() {},
+    async goBack() {},
+    async waitForLoadState() {}, // resolves = the page idled
+    async evaluate() { return undefined as never; },
+    async screenshot() { return Buffer.from("png"); },
+    url: () => "about:blank",
+    async close() {},
+    isClosed: () => false,
+    ...over,
+  };
+}
+
+describe("wrapPage.waitForNetworkIdle (P1)", () => {
+  it("resolves when the page reaches networkidle", async () => {
+    const page = wrapPage(fakeAnyPage());
+    await expect(page.waitForNetworkIdle(new AbortController().signal)).resolves.toBeUndefined();
+  });
+
+  it("does NOT resolve on its own for a page that never idles — it waits for abort, then rejects", async () => {
+    // A page still polling: waitForLoadState never resolves. The adapter must
+    // hang until the settle deadline aborts, then reject, so settlePage reports
+    // settled:false rather than a false settled:true.
+    const page = wrapPage(fakeAnyPage({ waitForLoadState: () => new Promise<void>(() => {}) }));
+    const controller = new AbortController();
+    const pending = page.waitForNetworkIdle(controller.signal);
+    let settledEarly = false;
+    void pending.then(
+      () => (settledEarly = true),
+      () => {},
+    );
+    await Promise.resolve();
+    expect(settledEarly).toBe(false); // did not falsely resolve
+    controller.abort();
+    await expect(pending).rejects.toThrow(); // the deadline ends it
+  });
+
+  it("propagates a real failure (a crashed page is not just slow)", async () => {
+    const page = wrapPage(
+      fakeAnyPage({
+        waitForLoadState: () => Promise.reject(new Error("target crashed")),
+      }),
+    );
+    await expect(page.waitForNetworkIdle(new AbortController().signal)).rejects.toThrow(
+      "target crashed",
+    );
+  });
+});

--- a/mcpjam-inspector/server/services/browserd/daemon/browser-page.ts
+++ b/mcpjam-inspector/server/services/browserd/daemon/browser-page.ts
@@ -1,0 +1,38 @@
+/**
+ * The browser boundary the driver logic is written against.
+ *
+ * Exactly like the local inspector's `provider.ts`, everything above this
+ * interface — tab management, action dispatch, settle + state-token wiring —
+ * never imports Playwright or speaks CDP, so it is unit-testable with fakes and
+ * the real implementation (`chromium-launch.ts`) can be swapped without touching
+ * the driver. The messy Playwright specifics (`waitForLoadState`, `evaluate` for
+ * the DOM signal and the animation frame, screenshot buffer → base64) live in
+ * the adapter; the boundary is deliberately small and clean.
+ */
+
+/** One browser tab. Methods mirror the subset of Playwright's Page browserd uses. */
+export interface DriverPage {
+  /** Navigate and wait for the document to commit (domcontentloaded). */
+  goto(url: string): Promise<void>;
+  reload(): Promise<void>;
+  goBack(): Promise<void>;
+  /** Resolve after a brief window with no in-flight requests, or on abort. */
+  waitForNetworkIdle(signal: AbortSignal): Promise<void>;
+  /** Resolve after one rendered frame, or on abort. */
+  requestAnimationFrame(signal: AbortSignal): Promise<void>;
+  /** A structural signal of the current DOM, for the L3 state token. */
+  domStructureSignal(): Promise<string>;
+  /** A PNG screenshot at the canonical observation viewport, base64-encoded. */
+  screenshotBase64(): Promise<string>;
+  url(): string;
+  close(): Promise<void>;
+  isClosed(): boolean;
+}
+
+/** The persistent browser context: one profile, many tabs. */
+export interface DriverContext {
+  newPage(): Promise<DriverPage>;
+  /** True while the underlying browser is alive; false after a crash/close. */
+  isConnected(): boolean;
+  close(): Promise<void>;
+}

--- a/mcpjam-inspector/server/services/browserd/daemon/chromium-driver.ts
+++ b/mcpjam-inspector/server/services/browserd/daemon/chromium-driver.ts
@@ -15,10 +15,11 @@
  * L2 (settle-before-capture) and L3 (state token on every observation) are wired
  * in here from the pure helpers in PR (c1).
  */
-import type {
-  BrowserAction,
-  BrowserCommand,
-  BrowserCommandResult,
+import {
+  DEFAULT_QUEUE_KEY,
+  type BrowserAction,
+  type BrowserCommand,
+  type BrowserCommandResult,
 } from "../protocol";
 import type { BrowserDriver, DriverHealth } from "./browser-driver";
 import type { DriverContext, DriverPage } from "./browser-page";
@@ -30,8 +31,13 @@ import {
   type SettleSteps,
 } from "./settle";
 
-/** The tab a tab-less (whole-session) command operates on. */
-const DEFAULT_TAB = "@default";
+/**
+ * The tab a tab-less (whole-session) command operates on. It MUST equal the
+ * command queue's `queueKeyFor` default (`DEFAULT_QUEUE_KEY`): otherwise an
+ * explicit `tabId` equal to either name would drive this same page from a
+ * separate FIFO and race the tab-less commands (P1).
+ */
+const DEFAULT_TAB = DEFAULT_QUEUE_KEY;
 
 interface TabEntry {
   page: DriverPage;
@@ -59,11 +65,27 @@ export class ChromiumDriver implements BrowserDriver {
     const action = command.action;
     switch (action.kind) {
       case "navigate":
-        return this.afterNavigation(tabId, async (page) => page.goto(action.url));
+        // `navigate` is the only verb that may CREATE a tab. `newTab` (open a
+        // distinct tab) is multi-tab territory deferred to W3; reject it rather
+        // than silently replacing the current tab's page (P2).
+        if (action.newTab) {
+          return { ok: false, error: "unimplemented_in_w1: navigate/newTab" };
+        }
+        return this.navigateVerb(tabId, await this.getOrCreateTab(tabId), (page) =>
+          page.goto(action.url),
+        );
       case "back":
-        return this.afterNavigation(tabId, async (page) => page.goBack());
-      case "reload":
-        return this.afterNavigation(tabId, async (page) => page.reload());
+      case "reload": {
+        // back/reload act on an EXISTING tab only — an unknown tabId is an error,
+        // not a reason to conjure a fresh about:blank page (P2).
+        const entry = this.tabs.get(tabId);
+        if (!entry || entry.page.isClosed()) {
+          return { ok: false, error: `unknown_tab: ${tabId}` };
+        }
+        return this.navigateVerb(tabId, entry, (page) =>
+          action.kind === "back" ? page.goBack() : page.reload(),
+        );
+      }
       case "observe":
         return this.observe(tabId, action);
       case "act":
@@ -74,22 +96,24 @@ export class ChromiumDriver implements BrowserDriver {
   }
 
   /**
-   * Run a navigation, bump the tab's nav counter, settle the page (L2), and
-   * return the post-settle observation with its state token (L3). Every W1
-   * navigating verb funnels through here so settle + token are never skipped.
+   * Run a navigation on an already-resolved tab, bump its nav counter, settle
+   * the page (L2), and return the post-settle observation with its state token
+   * (L3). Every W1 navigating verb funnels through here so settle + token are
+   * never skipped. Tab creation is the caller's decision (only `navigate`).
    */
-  private async afterNavigation(
+  private async navigateVerb(
     tabId: string,
+    entry: TabEntry,
     navigate: (page: DriverPage) => Promise<void>,
   ): Promise<BrowserCommandResult> {
-    const entry = await this.getOrCreateTab(tabId);
     await navigate(entry.page);
     entry.navCounter += 1;
     const settled = await this.settle(entry.page);
-    const result = await this.observation(tabId, entry, {
-      url: entry.page.url(),
-    });
-    return { ...result, settled };
+    const domSignal = await entry.page.domStructureSignal();
+    return {
+      ...this.observation(tabId, entry, { url: entry.page.url() }, domSignal),
+      settled,
+    };
   }
 
   private async observe(
@@ -97,25 +121,59 @@ export class ChromiumDriver implements BrowserDriver {
     action: Extract<BrowserAction, { kind: "observe" }>,
   ): Promise<BrowserCommandResult> {
     const entry = this.tabs.get(tabId);
-    if (!entry) {
+    if (!entry || entry.page.isClosed()) {
       return { ok: false, error: `unknown_tab: ${tabId}` };
     }
     switch (action.mode) {
-      case "url":
-        return this.observation(tabId, entry, { url: entry.page.url() });
+      case "url": {
+        const domSignal = await entry.page.domStructureSignal();
+        return this.observation(tabId, entry, { url: entry.page.url() }, domSignal);
+      }
+      case "dom": {
+        // The token is computed from the SAME read returned as output, so they
+        // cannot disagree.
+        const domSignal = await entry.page.domStructureSignal();
+        return this.observation(tabId, entry, { dom: domSignal }, domSignal);
+      }
       case "screenshot":
-        return this.observation(tabId, entry, {
-          screenshot: await entry.page.screenshotBase64(),
-        });
-      case "dom":
-        return this.observation(tabId, entry, {
-          dom: await entry.page.domStructureSignal(),
-        });
+        return this.observeScreenshot(tabId, entry);
       case "a11y":
       case "console":
       case "webmcp_tools":
         return { ok: false, error: `unimplemented_in_w1: observe/${action.mode}` };
     }
+  }
+
+  /**
+   * Capture a screenshot whose state token provably describes the SAME frame the
+   * image shows (P1). The DOM is sampled before and after the capture; if it
+   * shifted mid-capture, the image and a fresh token would disagree — an act
+   * chosen from the stale image could then slip past `guardStaleness` — so we
+   * retry, and if the page will not hold still we return the frame with
+   * `settled: false` (its token from the post-capture read) so the caller
+   * re-observes rather than pinning an act to it.
+   */
+  private async observeScreenshot(
+    tabId: string,
+    entry: TabEntry,
+  ): Promise<BrowserCommandResult> {
+    const STABLE_ATTEMPTS = 2;
+    for (let attempt = 0; attempt < STABLE_ATTEMPTS; attempt++) {
+      const before = await entry.page.domStructureSignal();
+      const screenshot = await entry.page.screenshotBase64();
+      const after = await entry.page.domStructureSignal();
+      if (before === after) {
+        return this.observation(tabId, entry, { screenshot }, after);
+      }
+    }
+    // Would not stabilise within budget: hand back the frame but flag it unsettled
+    // so nothing pins an act to a possibly-stale image.
+    const screenshot = await entry.page.screenshotBase64();
+    const after = await entry.page.domStructureSignal();
+    return {
+      ...this.observation(tabId, entry, { screenshot }, after),
+      settled: false,
+    };
   }
 
   async currentStateToken(tabId: string | undefined) {
@@ -143,17 +201,22 @@ export class ChromiumDriver implements BrowserDriver {
     await this.context.close().catch(() => {});
   }
 
-  /** Build an observation result carrying the tab's fresh L3 state token. */
-  private async observation(
+  /**
+   * Build an observation result whose L3 state token is computed from the SAME
+   * DOM signal the caller captured the output against — passed in, never re-read
+   * here, so the token can never describe a different frame than the output (P1).
+   */
+  private observation(
     tabId: string,
     entry: TabEntry,
     output: Record<string, unknown>,
-  ): Promise<BrowserCommandResult> {
+    domSignal: string,
+  ): BrowserCommandResult {
     const stateToken = computeStateToken({
       tabId,
       navCounter: entry.navCounter,
       url: entry.page.url(),
-      domSignal: await entry.page.domStructureSignal(),
+      domSignal,
     });
     return { ok: true, output, stateToken };
   }

--- a/mcpjam-inspector/server/services/browserd/daemon/chromium-driver.ts
+++ b/mcpjam-inspector/server/services/browserd/daemon/chromium-driver.ts
@@ -46,6 +46,18 @@ interface TabEntry {
   navCounter: number;
 }
 
+/**
+ * A tab's URL + DOM signal read together. Both are part of the L3 state token,
+ * so an observation binds its token to the snapshot the OUTPUT was captured
+ * against — never a fresh read — or a change between capture and token (a DOM
+ * mutation OR a same-skeleton client-side route change) would let the token and
+ * the returned frame describe different states (P1).
+ */
+interface FrameSnapshot {
+  url: string;
+  domSignal: string;
+}
+
 export interface ChromiumDriverOptions {
   settle?: SettleOptions;
 }
@@ -109,9 +121,9 @@ export class ChromiumDriver implements BrowserDriver {
     await navigate(entry.page);
     entry.navCounter += 1;
     const settled = await this.settle(entry.page);
-    const domSignal = await entry.page.domStructureSignal();
+    const frame = await this.snapshot(entry.page);
     return {
-      ...this.observation(tabId, entry, { url: entry.page.url() }, domSignal),
+      ...this.observation(tabId, entry, { url: frame.url }, frame),
       settled,
     };
   }
@@ -126,14 +138,14 @@ export class ChromiumDriver implements BrowserDriver {
     }
     switch (action.mode) {
       case "url": {
-        const domSignal = await entry.page.domStructureSignal();
-        return this.observation(tabId, entry, { url: entry.page.url() }, domSignal);
+        const frame = await this.snapshot(entry.page);
+        return this.observation(tabId, entry, { url: frame.url }, frame);
       }
       case "dom": {
-        // The token is computed from the SAME read returned as output, so they
-        // cannot disagree.
-        const domSignal = await entry.page.domStructureSignal();
-        return this.observation(tabId, entry, { dom: domSignal }, domSignal);
+        // The token is computed from the SAME snapshot returned as output, so
+        // they cannot disagree.
+        const frame = await this.snapshot(entry.page);
+        return this.observation(tabId, entry, { dom: frame.domSignal }, frame);
       }
       case "screenshot":
         return this.observeScreenshot(tabId, entry);
@@ -159,17 +171,20 @@ export class ChromiumDriver implements BrowserDriver {
   ): Promise<BrowserCommandResult> {
     const STABLE_ATTEMPTS = 2;
     for (let attempt = 0; attempt < STABLE_ATTEMPTS; attempt++) {
-      const before = await entry.page.domStructureSignal();
+      const before = await this.snapshot(entry.page);
       const screenshot = await entry.page.screenshotBase64();
-      const after = await entry.page.domStructureSignal();
-      if (before === after) {
+      const after = await this.snapshot(entry.page);
+      // Both the URL and the DOM must be unchanged: a same-skeleton client-side
+      // route change moves the URL while `domSignal` holds, and would otherwise
+      // bind a new-route token to an old-route image (P1).
+      if (before.url === after.url && before.domSignal === after.domSignal) {
         return this.observation(tabId, entry, { screenshot }, after);
       }
     }
     // Would not stabilise within budget: hand back the frame but flag it unsettled
     // so nothing pins an act to a possibly-stale image.
     const screenshot = await entry.page.screenshotBase64();
-    const after = await entry.page.domStructureSignal();
+    const after = await this.snapshot(entry.page);
     return {
       ...this.observation(tabId, entry, { screenshot }, after),
       settled: false,
@@ -203,22 +218,30 @@ export class ChromiumDriver implements BrowserDriver {
 
   /**
    * Build an observation result whose L3 state token is computed from the SAME
-   * DOM signal the caller captured the output against — passed in, never re-read
-   * here, so the token can never describe a different frame than the output (P1).
+   * frame snapshot (url + DOM) the caller captured the output against — passed
+   * in, never re-read here — so the token can never describe a different state
+   * than the returned output (P1).
    */
   private observation(
     tabId: string,
     entry: TabEntry,
     output: Record<string, unknown>,
-    domSignal: string,
+    frame: FrameSnapshot,
   ): BrowserCommandResult {
     const stateToken = computeStateToken({
       tabId,
       navCounter: entry.navCounter,
-      url: entry.page.url(),
-      domSignal,
+      url: frame.url,
+      domSignal: frame.domSignal,
     });
     return { ok: true, output, stateToken };
+  }
+
+  /** Read a tab's URL and DOM signal together, as one frame snapshot. */
+  private async snapshot(page: DriverPage): Promise<FrameSnapshot> {
+    const url = page.url();
+    const domSignal = await page.domStructureSignal();
+    return { url, domSignal };
   }
 
   private async settle(page: DriverPage): Promise<boolean> {

--- a/mcpjam-inspector/server/services/browserd/daemon/chromium-driver.ts
+++ b/mcpjam-inspector/server/services/browserd/daemon/chromium-driver.ts
@@ -1,0 +1,180 @@
+/**
+ * The real browser driver: it fills the `CommandExecutor` seam PR (a)'s queue
+ * drives and PR (b)'s control plane authenticates, turning a `BrowserCommand`
+ * into operations on a persistent, multi-tab browser context.
+ *
+ * W1 scope is deliberately the navigation + observation subset the wave's exit
+ * criteria need ("browserd navigates + screenshots"): navigate / back / reload /
+ * observe. The `act` verbs and the `webmcp_*` invocations arrive in W3 with the
+ * six `browser_*` model tools; until then they return an explicit
+ * `unimplemented` result rather than silently doing nothing.
+ *
+ * It is written entirely against the `DriverContext` / `DriverPage` boundary, so
+ * every path here is unit-testable with fakes; the live Playwright context is
+ * built by `chromium-launch.ts` and validated by a spike-gated integration test.
+ * L2 (settle-before-capture) and L3 (state token on every observation) are wired
+ * in here from the pure helpers in PR (c1).
+ */
+import type {
+  BrowserAction,
+  BrowserCommand,
+  BrowserCommandResult,
+} from "../protocol";
+import type { BrowserDriver, DriverHealth } from "./browser-driver";
+import type { DriverContext, DriverPage } from "./browser-page";
+import { computeStateToken } from "./state-token";
+import {
+  DEFAULT_SETTLE_OPTIONS,
+  settlePage,
+  type SettleOptions,
+  type SettleSteps,
+} from "./settle";
+
+/** The tab a tab-less (whole-session) command operates on. */
+const DEFAULT_TAB = "@default";
+
+interface TabEntry {
+  page: DriverPage;
+  /** Bumps on every navigation so back/forward to the same URL yield distinct
+   * tokens (L3). */
+  navCounter: number;
+}
+
+export interface ChromiumDriverOptions {
+  settle?: SettleOptions;
+}
+
+export class ChromiumDriver implements BrowserDriver {
+  private readonly context: DriverContext;
+  private readonly settleOptions: SettleOptions;
+  private readonly tabs = new Map<string, TabEntry>();
+
+  constructor(context: DriverContext, options: ChromiumDriverOptions = {}) {
+    this.context = context;
+    this.settleOptions = options.settle ?? DEFAULT_SETTLE_OPTIONS;
+  }
+
+  async execute(command: BrowserCommand): Promise<BrowserCommandResult> {
+    const tabId = command.tabId ?? DEFAULT_TAB;
+    const action = command.action;
+    switch (action.kind) {
+      case "navigate":
+        return this.afterNavigation(tabId, async (page) => page.goto(action.url));
+      case "back":
+        return this.afterNavigation(tabId, async (page) => page.goBack());
+      case "reload":
+        return this.afterNavigation(tabId, async (page) => page.reload());
+      case "observe":
+        return this.observe(tabId, action);
+      case "act":
+      case "webmcp_invoke":
+      case "webmcp_cancel":
+        return { ok: false, error: `unimplemented_in_w1: ${action.kind}` };
+    }
+  }
+
+  /**
+   * Run a navigation, bump the tab's nav counter, settle the page (L2), and
+   * return the post-settle observation with its state token (L3). Every W1
+   * navigating verb funnels through here so settle + token are never skipped.
+   */
+  private async afterNavigation(
+    tabId: string,
+    navigate: (page: DriverPage) => Promise<void>,
+  ): Promise<BrowserCommandResult> {
+    const entry = await this.getOrCreateTab(tabId);
+    await navigate(entry.page);
+    entry.navCounter += 1;
+    const settled = await this.settle(entry.page);
+    const result = await this.observation(tabId, entry, {
+      url: entry.page.url(),
+    });
+    return { ...result, settled };
+  }
+
+  private async observe(
+    tabId: string,
+    action: Extract<BrowserAction, { kind: "observe" }>,
+  ): Promise<BrowserCommandResult> {
+    const entry = this.tabs.get(tabId);
+    if (!entry) {
+      return { ok: false, error: `unknown_tab: ${tabId}` };
+    }
+    switch (action.mode) {
+      case "url":
+        return this.observation(tabId, entry, { url: entry.page.url() });
+      case "screenshot":
+        return this.observation(tabId, entry, {
+          screenshot: await entry.page.screenshotBase64(),
+        });
+      case "dom":
+        return this.observation(tabId, entry, {
+          dom: await entry.page.domStructureSignal(),
+        });
+      case "a11y":
+      case "console":
+      case "webmcp_tools":
+        return { ok: false, error: `unimplemented_in_w1: observe/${action.mode}` };
+    }
+  }
+
+  async currentStateToken(tabId: string | undefined) {
+    const entry = this.tabs.get(tabId ?? DEFAULT_TAB);
+    if (!entry) return undefined;
+    return computeStateToken({
+      tabId: tabId ?? DEFAULT_TAB,
+      navCounter: entry.navCounter,
+      url: entry.page.url(),
+      domSignal: await entry.page.domStructureSignal(),
+    });
+  }
+
+  async health(): Promise<DriverHealth> {
+    return this.context.isConnected()
+      ? { ok: true }
+      : { ok: false, detail: "browser context disconnected" };
+  }
+
+  async close(): Promise<void> {
+    for (const entry of this.tabs.values()) {
+      if (!entry.page.isClosed()) await entry.page.close().catch(() => {});
+    }
+    this.tabs.clear();
+    await this.context.close().catch(() => {});
+  }
+
+  /** Build an observation result carrying the tab's fresh L3 state token. */
+  private async observation(
+    tabId: string,
+    entry: TabEntry,
+    output: Record<string, unknown>,
+  ): Promise<BrowserCommandResult> {
+    const stateToken = computeStateToken({
+      tabId,
+      navCounter: entry.navCounter,
+      url: entry.page.url(),
+      domSignal: await entry.page.domStructureSignal(),
+    });
+    return { ok: true, output, stateToken };
+  }
+
+  private async settle(page: DriverPage): Promise<boolean> {
+    const steps: SettleSteps = {
+      // goto/reload/goBack already awaited the document commit.
+      waitForCommit: async () => {},
+      waitForNetworkQuiet: (signal) => page.waitForNetworkIdle(signal),
+      waitForAnimationFrame: (signal) => page.requestAnimationFrame(signal),
+    };
+    const { settled } = await settlePage(steps, this.settleOptions);
+    return settled;
+  }
+
+  private async getOrCreateTab(tabId: string): Promise<TabEntry> {
+    const existing = this.tabs.get(tabId);
+    if (existing && !existing.page.isClosed()) return existing;
+    const page = await this.context.newPage();
+    const entry: TabEntry = { page, navCounter: 0 };
+    this.tabs.set(tabId, entry);
+    return entry;
+  }
+}

--- a/mcpjam-inspector/server/services/browserd/daemon/chromium-launch.ts
+++ b/mcpjam-inspector/server/services/browserd/daemon/chromium-launch.ts
@@ -128,9 +128,33 @@ export async function launchBrowserdContext(
     permissions: [],
     ...BROWSERD_CONTEXT_OPTIONS,
   });
+  return adaptContext(context as unknown as AnyContext);
+}
+
+/** The subset of a Playwright BrowserContext the adapter uses. */
+export type AnyContext = {
+  newPage(): Promise<AnyPage>;
+  pages(): AnyPage[];
+  browser(): { isConnected(): boolean } | null;
+  close(): Promise<void>;
+};
+
+/**
+ * Adapt a persistent Playwright context to `DriverContext`. A persistent context
+ * opens with a startup page (about:blank on a fresh profile, restored tabs
+ * otherwise); adopt those first so the FIRST driver tab IS the startup page.
+ * Otherwise `newPage()` would create a second page and leave the startup tab
+ * visible and permanently outside the driver's tab map, where a headed user could
+ * focus it while observations ran against a different tab (P2).
+ */
+export function adaptContext(context: AnyContext): DriverContext {
+  const startup = [...context.pages()];
+  let adopted = 0;
   return {
     async newPage() {
-      return wrapPage((await context.newPage()) as unknown as AnyPage);
+      const page =
+        adopted < startup.length ? startup[adopted++] : await context.newPage();
+      return wrapPage(page);
     },
     isConnected() {
       return context.browser()?.isConnected() ?? true;

--- a/mcpjam-inspector/server/services/browserd/daemon/chromium-launch.ts
+++ b/mcpjam-inspector/server/services/browserd/daemon/chromium-launch.ts
@@ -1,0 +1,142 @@
+/**
+ * The live Playwright implementation of the driver's browser boundary.
+ *
+ * This is the ONLY file in the daemon that imports Playwright and knows about
+ * CDP-era specifics. It launches ONE persistent browser context (a single
+ * profile, many tabs — unlike the local inspector, which launches a fresh
+ * browser per single-page session) with browserd's hardened launch args (L4) and
+ * determinism pins (L5), clears any stale profile lock first (L8), and wraps each
+ * Playwright `Page` into the small `DriverPage` the driver logic is written
+ * against. It carries no unit tests of its own — its live behaviour is validated
+ * by `__tests__/chromium-launch.spike.test.ts`, which runs only when a real
+ * Chromium is present.
+ */
+import type { DriverContext, DriverPage } from "./browser-page";
+import {
+  BROWSERD_CONTEXT_OPTIONS,
+  buildBrowserdLaunchArgs,
+} from "./launch-args";
+import { clearStaleSingletonLock } from "./profile-lock";
+
+const NAV_TIMEOUT_MS = 30_000;
+const NETWORK_IDLE_TIMEOUT_MS = 8_000;
+
+/** A structural skeleton of the DOM — cheap, and changes when structure does. */
+const DOM_SIGNAL_FN = `() => {
+  const parts = [];
+  const walk = (el, depth) => {
+    if (depth > 12 || parts.length > 400) return;
+    parts.push(depth + el.tagName);
+    for (const child of el.children) walk(child, depth + 1);
+  };
+  if (document.body) walk(document.body, 0);
+  return parts.join(">");
+}`;
+
+/** Reject when the signal aborts, so a settle-timeout unblocks a waiting step. */
+function abortPromise(signal: AbortSignal): Promise<never> {
+  return new Promise((_resolve, reject) => {
+    if (signal.aborted) return reject(new Error("aborted"));
+    signal.addEventListener("abort", () => reject(new Error("aborted")), {
+      once: true,
+    });
+  });
+}
+
+// Playwright's Page is structurally richer than DriverPage needs; type the
+// handle loosely and adapt, rather than dragging Playwright's types across the
+// boundary.
+type AnyPage = {
+  goto(url: string, options?: unknown): Promise<unknown>;
+  reload(options?: unknown): Promise<unknown>;
+  goBack(options?: unknown): Promise<unknown>;
+  waitForLoadState(state: string, options?: unknown): Promise<void>;
+  evaluate<R>(fn: string): Promise<R>;
+  screenshot(options?: unknown): Promise<Buffer>;
+  url(): string;
+  close(): Promise<void>;
+  isClosed(): boolean;
+};
+
+function wrapPage(page: AnyPage): DriverPage {
+  return {
+    async goto(url) {
+      await page.goto(url, { waitUntil: "domcontentloaded", timeout: NAV_TIMEOUT_MS });
+    },
+    async reload() {
+      await page.reload({ waitUntil: "domcontentloaded", timeout: NAV_TIMEOUT_MS });
+    },
+    async goBack() {
+      await page.goBack({ waitUntil: "domcontentloaded", timeout: NAV_TIMEOUT_MS });
+    },
+    async waitForNetworkIdle(signal) {
+      // A network that never idles must not throw here — settle's maxWait is the
+      // real backstop, and its abort (via abortPromise) is what ends the wait.
+      await Promise.race([
+        page
+          .waitForLoadState("networkidle", { timeout: NETWORK_IDLE_TIMEOUT_MS })
+          .catch(() => {}),
+        abortPromise(signal),
+      ]);
+    },
+    async requestAnimationFrame(signal) {
+      await Promise.race([
+        page.evaluate<void>(
+          "() => new Promise((r) => requestAnimationFrame(() => r()))",
+        ),
+        abortPromise(signal),
+      ]);
+    },
+    domStructureSignal() {
+      return page.evaluate<string>(DOM_SIGNAL_FN);
+    },
+    async screenshotBase64() {
+      const buffer = await page.screenshot({ type: "png" });
+      return buffer.toString("base64");
+    },
+    url: () => page.url(),
+    close: () => page.close(),
+    isClosed: () => page.isClosed(),
+  };
+}
+
+export interface LaunchBrowserdContextOptions {
+  /** Persistent profile directory — the singleton whose lock L8 clears. */
+  userDataDir: string;
+  /** Headed under Xfce in the sandbox; tests may force headless. */
+  headless?: boolean;
+  /** Extra args, e.g. `--window-size` matched to the X screen geometry. */
+  extraArgs?: readonly string[];
+}
+
+/**
+ * Launch the persistent browser context and adapt it to `DriverContext`. Clears
+ * a stale singleton lock first so a relaunch-on-wake never hands off to a dead
+ * instance (L8). Chromium cannot start its renderer sandbox as uid 0 (the image
+ * builds as root), so the sandbox is disabled only in that case.
+ */
+export async function launchBrowserdContext(
+  options: LaunchBrowserdContextOptions,
+): Promise<DriverContext> {
+  await clearStaleSingletonLock(options.userDataDir);
+  const { chromium } = await import("playwright");
+  const context = await chromium.launchPersistentContext(options.userDataDir, {
+    headless: options.headless ?? false,
+    chromiumSandbox: process.getuid?.() !== 0,
+    args: buildBrowserdLaunchArgs(options.extraArgs),
+    acceptDownloads: false,
+    permissions: [],
+    ...BROWSERD_CONTEXT_OPTIONS,
+  });
+  return {
+    async newPage() {
+      return wrapPage((await context.newPage()) as unknown as AnyPage);
+    },
+    isConnected() {
+      return context.browser()?.isConnected() ?? true;
+    },
+    close() {
+      return context.close();
+    },
+  };
+}

--- a/mcpjam-inspector/server/services/browserd/daemon/chromium-launch.ts
+++ b/mcpjam-inspector/server/services/browserd/daemon/chromium-launch.ts
@@ -19,7 +19,6 @@ import {
 import { clearStaleSingletonLock } from "./profile-lock";
 
 const NAV_TIMEOUT_MS = 30_000;
-const NETWORK_IDLE_TIMEOUT_MS = 8_000;
 
 /** A structural skeleton of the DOM — cheap, and changes when structure does. */
 const DOM_SIGNAL_FN = `() => {
@@ -46,7 +45,7 @@ function abortPromise(signal: AbortSignal): Promise<never> {
 // Playwright's Page is structurally richer than DriverPage needs; type the
 // handle loosely and adapt, rather than dragging Playwright's types across the
 // boundary.
-type AnyPage = {
+export type AnyPage = {
   goto(url: string, options?: unknown): Promise<unknown>;
   reload(options?: unknown): Promise<unknown>;
   goBack(options?: unknown): Promise<unknown>;
@@ -58,7 +57,7 @@ type AnyPage = {
   isClosed(): boolean;
 };
 
-function wrapPage(page: AnyPage): DriverPage {
+export function wrapPage(page: AnyPage): DriverPage {
   return {
     async goto(url) {
       await page.goto(url, { waitUntil: "domcontentloaded", timeout: NAV_TIMEOUT_MS });
@@ -70,14 +69,15 @@ function wrapPage(page: AnyPage): DriverPage {
       await page.goBack({ waitUntil: "domcontentloaded", timeout: NAV_TIMEOUT_MS });
     },
     async waitForNetworkIdle(signal) {
-      // A network that never idles must not throw here — settle's maxWait is the
-      // real backstop, and its abort (via abortPromise) is what ends the wait.
-      await Promise.race([
-        page
-          .waitForLoadState("networkidle", { timeout: NETWORK_IDLE_TIMEOUT_MS })
-          .catch(() => {}),
-        abortPromise(signal),
-      ]);
+      // settle's maxWait (via the abort signal) is the SOLE budget — no inner
+      // timeout. A page that never idles stays pending until the signal aborts,
+      // and then this rejects, so `settlePage` reports `settled: false`. The
+      // earlier version gave the wait its own 8s timeout and swallowed it, which
+      // turned a never-quiet page into a false `settled: true` (P1). Guard the
+      // losing promise so it does not surface as an unhandled rejection.
+      const idle = page.waitForLoadState("networkidle", { timeout: 0 });
+      idle.catch(() => {});
+      await Promise.race([idle, abortPromise(signal)]);
     },
     async requestAnimationFrame(signal) {
       await Promise.race([

--- a/mcpjam-inspector/server/services/browserd/daemon/command-queue.ts
+++ b/mcpjam-inspector/server/services/browserd/daemon/command-queue.ts
@@ -28,6 +28,7 @@ import {
   BrowserCommandResult,
   CommandQueueOptions,
   DEFAULT_COMMAND_QUEUE_OPTIONS,
+  DEFAULT_QUEUE_KEY,
 } from "../protocol";
 
 /**
@@ -41,7 +42,7 @@ export type CommandExecutor = (
 
 /** Which FIFO a command belongs to: its tab, or the session if tab-less. */
 function queueKeyFor(command: BrowserCommand): string {
-  return command.tabId ?? "@session";
+  return command.tabId ?? DEFAULT_QUEUE_KEY;
 }
 
 function normalizeError(err: unknown): BrowserCommandResult {

--- a/mcpjam-inspector/server/services/browserd/protocol.ts
+++ b/mcpjam-inspector/server/services/browserd/protocol.ts
@@ -25,6 +25,15 @@ export type BootId = string;
 /** Where a command originated. All sources share one per-tab queue and timeline. */
 export type BrowserCommandSource = "manual" | "chat" | "inspector" | "eval";
 
+/**
+ * The FIFO/tab key a tab-less (whole-session) command uses. The command queue
+ * and the driver MUST agree on this: if the queue serialized tab-less commands
+ * under one key while the driver drove them on a differently-named page, an
+ * explicit `tabId` equal to either name could target the same page from two
+ * independent FIFOs and race. One constant, both layers.
+ */
+export const DEFAULT_QUEUE_KEY = "@session";
+
 /** A selector target for a `browser_act` verb. */
 export type BrowserActTarget =
   | { coordinates: [number, number] }


### PR DESCRIPTION
**W1 PR (c2)** of the Hosted Browser + WebMCP Runtime. Follows #4467/#4470/#4472 (all merged).

The **real driver** — the executor that fills PR (a)'s `CommandExecutor` seam and PR (b)'s control plane authenticates. It turns a `BrowserCommand` into operations on a **persistent, multi-tab** browser context (unlike the local inspector, which launches a fresh browser per single-page session), wiring the c1 helpers (**L2** settle, **L3** state token) and the **L8** profile-lock clear.

Structured like the local `webmcp-inspector`'s provider/impl split:

- **`daemon/browser-page.ts`** — the narrow `DriverPage`/`DriverContext` boundary the driver logic is written against. **Zero Playwright import**, so every path is unit-testable.
- **`daemon/chromium-driver.ts`** — `ChromiumDriver implements BrowserDriver`. W1 action subset: navigate / back / reload / observe (`url` | `screenshot` | `dom`). `act` + `webmcp_*` return an explicit `unimplemented_in_w1` result — they arrive in **W3** with the six `browser_*` tools, never silently no-op. Every navigating verb funnels through `afterNavigation` so **settle (L2)** + **state token (L3)** are never skipped; pages are managed per `tabId`.
- **`daemon/chromium-launch.ts`** — the **only** Playwright file: `launchPersistentContext` with the **L4** hardened args + **L5** determinism pins, a stale-lock clear first (**L8**), each `Page` wrapped into a `DriverPage`. `import("playwright")` is dynamic, so nothing else in the daemon pulls it.

## Tests
24 driver unit tests against fakes (navigate/settle-false/observe modes/unknown-tab/deferred verbs/tab reuse/token change/health/close). A **live spike test gated on `RUN_BROWSERD_SPIKE`** drives a real persistent context end to end (navigate → screenshot → dom → token) — off in CI, the M0 posture. **72 green + 1 gated skip, tsc clean across the repo.**

> Note: `chromium-launch.ts`'s live behaviour isn't exercised by normal CI (no browser in the unit lane); it mirrors the local inspector's proven Playwright calls and is validated by the spike in the sandbox. That's the deliberate boundary — the testable driver logic is separate from the thin live adapter.

## Next
**PR (c3):** daemon entrypoint (env → driver → `buildBrowserdStack` → listen → ready-line) + esbuild bundler + checked-in `dist/mcpjam-browserd.mjs`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> New core browser automation path with staleness/settle semantics that downstream `act` will rely on; mistakes could cause wrong observations or races, though scope is limited to W1 nav/observe and is heavily tested.
> 
> **Overview**
> Introduces the **real browser executor** for browserd: `ChromiumDriver` turns `BrowserCommand`s into work on a **persistent, multi-tab** Chromium profile (via Playwright in `chromium-launch.ts` only), behind a Playwright-free `DriverPage` / `DriverContext` boundary in `browser-page.ts`.
> 
> **W1 behavior:** navigate, back, reload, and observe (`url`, `screenshot`, `dom`) with **L2 settle** and **L3 state tokens** on every result; `act` and `webmcp_*` return explicit `unimplemented_in_w1` instead of no-ops. Tab-less commands and the command queue now share **`DEFAULT_QUEUE_KEY` (`@session`)** so session traffic cannot race the same page on two FIFOs.
> 
> **Correctness fixes in the adapter/driver:** network-idle wait no longer treats a never-quiet page as settled; screenshot observations retry when URL/DOM shift mid-capture and set **`settled: false`** when unstable; only **`navigate`** creates tabs (`newTab` rejected; back/reload on unknown tabs error); persistent context **adopts the startup page** so an extra orphan tab is not left outside the driver map.
> 
> Adds **unit tests** (fake pages/context) plus an opt-in **`RUN_BROWSERD_SPIKE`** integration test against real Chromium.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1616ff915e8eb49736187fda2e04c8d9d054c495. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds the real Chromium driver for the browser daemon, replacing the local inspector's fresh-browser-per-session model with a persistent, multi-tab context. W1 ships navigate/back/reload/observe; `act` and `webmcp_*` return explicit `unimplemented_in_w1` results instead of silently no-oping.

Driver logic sits behind a Playwright-free `DriverPage`/`DriverContext` boundary so every path is unit-testable with fakes; `chromium-launch.ts` is the only file that imports Playwright and wires the persistent context, hardened launch args, and stale profile-lock clear. All navigating verbs funnel through settle and emit a state token, and pages are created/reused per `tabId`. A spike test gated on `RUN_BROWSERD_SPIKE` validates the real Chromium path end to end but stays off in normal CI.

**Bug Fixes**
- The network-idle wait no longer misreports a never-quiet page as settled; the settle deadline is the sole budget, and a crash still propagates.
- Screenshot tokens bind to the exact frame captured — both URL and DOM must hold across the capture or the result flags `settled:false` instead of pinning a stale image.
- Tab-less commands and the queue share one default tab key (`@session`) so an explicit same-named `tabId` can't race one page from two FIFOs.
- `navigate` with `newTab:true` returns `unimplemented_in_w1` instead of silently replacing the current tab, and `back`/`reload` on an unknown tab return `unknown_tab` instead of conjuring a blank page.
- The persistent context's startup page is adopted as the first driver tab rather than orphaned outside the tab map.

<sup>Written for commit 1616ff915e8eb49736187fda2e04c8d9d054c495. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/MCPJam/inspector/pull/4473?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

